### PR TITLE
use staging branch when deploying

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -30,7 +30,7 @@ jobs:
       BASE_URL: ${{ github.ref_name == 'master' && 'https://app.mako.ai' || 'https://dev-app.mako.ai' }}
       BCRYPT_ROUNDS: ${{ vars.BCRYPT_ROUNDS }}
       CLIENT_URL: ${{ github.ref_name == 'master' && 'https://app.mako.ai' || 'https://dev-app.mako.ai' }}
-      DATABASE_URL: ${{ github.ref_name == 'master' && secrets.PROD_DATABASE_URL || secrets.DEV_DATABASE_URL }}
+      DATABASE_URL: ${{ github.ref_name == 'master' && secrets.PROD_DATABASE_URL || secrets.STAGING_DATABASE_URL }}
       ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
       GCP_SERVICE_ACCOUNT: ${{ github.ref_name == 'master' && secrets.GCP_PROD_SERVICE_ACCOUNT || secrets.GCP_DEV_SERVICE_ACCOUNT }}
       GITHUB_CLIENT_ID: ${{ vars.GITHUB_CLIENT_ID }}
@@ -169,15 +169,15 @@ jobs:
         if: github.ref_name == 'dev'
         env:
           PROD_DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
-          DEV_DATABASE_URL: ${{ secrets.DEV_DATABASE_URL }}
+          STAGING_DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
         run: |
           echo "Dropping staging database..."
-          mongosh "$DEV_DATABASE_URL" --eval "db.dropDatabase()"
+          mongosh "$STAGING_DATABASE_URL" --eval "db.dropDatabase()"
           echo "Restoring from production..."
-          mongodump --uri="$PROD_DATABASE_URL" --gzip --archive | mongorestore --uri="$DEV_DATABASE_URL" --gzip --archive \
+          mongodump --uri="$PROD_DATABASE_URL" --gzip --archive | mongorestore --uri="$STAGING_DATABASE_URL" --gzip --archive \
             --nsInclude="production.*" \
             --nsFrom="production.*" \
-            --nsTo="dev.*"
+            --nsTo="staging.*"
 
       - name: Run database migrations
         run: pnpm run migrate


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates deploy workflow to use staging database for non-master and restores prod data into `staging.*` namespaces.
> 
> - **CI/CD (GitHub Actions)** in `.github/workflows/deploy-app.yml`:
>   - Use `secrets.STAGING_DATABASE_URL` for non-master `DATABASE_URL` (replacing `DEV_DATABASE_URL`).
>   - Update staging DB restore step on `dev` branch:
>     - Use `STAGING_DATABASE_URL` for `mongosh` and `mongorestore`.
>     - Change restore namespace mapping from `--nsTo="dev.*"` to `--nsTo="staging.*"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a22f54d096c7d7ab2ae50f62e925c57f02ec52c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->