### PR TITLE
Dev

### DIFF
--- a/api/src/agent/mongodb/tools.ts
+++ b/api/src/agent/mongodb/tools.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore – provided at runtime
 import { tool } from "@openai/agents";
+import { Document } from "mongodb";
 import { Types } from "mongoose";
 import { DatabaseConnection } from "../../database/workspace-schema";
 import { databaseConnectionService } from "../../services/database-connection.service";
@@ -107,6 +108,142 @@ const inferBsonType = (value: any): string => {
   return typeof value;
 };
 
+// Truncation constants for preventing context overflow
+const MAX_STRING_LENGTH = 200;
+const MAX_ARRAY_ITEMS = 5;
+const MAX_OBJECT_KEYS = 10;
+const MAX_NESTED_DEPTH = 3;
+const MAX_SAMPLE_DOCS_RETURNED = 5;
+const MAX_TOTAL_OUTPUT_SIZE = 50000; // ~50KB cap for the entire output
+
+/**
+ * Truncate a single value to prevent context overflow while preserving structure
+ */
+const truncateValue = (value: any, depth: number = 0): any => {
+  if (depth > MAX_NESTED_DEPTH) {
+    return "[nested too deep]";
+  }
+
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  // Handle BSON types
+  if (value?._bsontype === "ObjectId") {
+    return value.toString();
+  }
+  if (value?._bsontype === "Decimal128") {
+    return value.toString();
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  // Handle strings
+  if (typeof value === "string") {
+    if (value.length > MAX_STRING_LENGTH) {
+      return (
+        value.substring(0, MAX_STRING_LENGTH) +
+        `... [truncated, ${value.length} chars total]`
+      );
+    }
+    return value;
+  }
+
+  // Handle arrays
+  if (Array.isArray(value)) {
+    const truncatedArray = value
+      .slice(0, MAX_ARRAY_ITEMS)
+      .map(item => truncateValue(item, depth + 1));
+    if (value.length > MAX_ARRAY_ITEMS) {
+      truncatedArray.push(`[... ${value.length - MAX_ARRAY_ITEMS} more items]`);
+    }
+    return truncatedArray;
+  }
+
+  // Handle objects
+  if (typeof value === "object") {
+    const keys = Object.keys(value);
+    const truncatedObj: Record<string, any> = {};
+    const keysToInclude = keys.slice(0, MAX_OBJECT_KEYS);
+
+    for (const key of keysToInclude) {
+      truncatedObj[key] = truncateValue(value[key], depth + 1);
+    }
+
+    if (keys.length > MAX_OBJECT_KEYS) {
+      truncatedObj["_truncated"] =
+        `${keys.length - MAX_OBJECT_KEYS} more keys omitted`;
+    }
+
+    return truncatedObj;
+  }
+
+  // Primitives pass through
+  return value;
+};
+
+/**
+ * Truncate an entire document for safe inclusion in agent context
+ */
+const truncateDocument = (doc: any): any => {
+  return truncateValue(doc, 0);
+};
+
+/**
+ * Truncate query results to prevent context overflow
+ */
+const truncateQueryResults = (results: any): any => {
+  if (!results) return results;
+
+  // If results is an array, truncate each item and limit count
+  if (Array.isArray(results)) {
+    const maxResults = 100;
+    const truncated = results
+      .slice(0, maxResults)
+      .map(doc => truncateDocument(doc));
+    if (results.length > maxResults) {
+      return {
+        data: truncated,
+        _truncated: true,
+        _message: `Showing ${maxResults} of ${results.length} results. Use LIMIT in your query for specific counts.`,
+      };
+    }
+    return truncated;
+  }
+
+  // If results is an object with data array (common pattern)
+  if (results.data && Array.isArray(results.data)) {
+    const truncatedData = truncateQueryResults(results.data);
+
+    // If truncateQueryResults returned an object with metadata (due to >100 items),
+    // flatten it to avoid nested { data: { data: [...], _truncated: ... } }
+    if (
+      truncatedData &&
+      typeof truncatedData === "object" &&
+      !Array.isArray(truncatedData) &&
+      truncatedData.data
+    ) {
+      return {
+        ...results,
+        ...truncatedData, // Spreads data, _truncated, and _message at top level
+      };
+    }
+
+    return {
+      ...results,
+      data: truncatedData,
+    };
+  }
+
+  // Single document
+  if (typeof results === "object") {
+    return truncateDocument(results);
+  }
+
+  return results;
+};
+
 const inspectCollection = async (
   connectionId: string,
   collectionName: string,
@@ -152,11 +289,32 @@ const inspectCollection = async (
     field,
     types: Array.from(types),
   }));
-  return {
+
+  // Truncate sample documents to prevent context overflow
+  const truncatedSamples = sampleDocuments
+    .slice(0, MAX_SAMPLE_DOCS_RETURNED)
+    .map((doc: Document) => truncateDocument(doc));
+
+  // Final safety check: ensure total output isn't too large
+  let output = {
     schema,
-    sampleDocuments: sampleDocuments.slice(0, 25),
+    sampleDocuments: truncatedSamples,
     totalSampled: sampleDocuments.length,
+    _note: `Showing ${truncatedSamples.length} truncated samples. Values longer than ${MAX_STRING_LENGTH} chars, arrays with more than ${MAX_ARRAY_ITEMS} items, and objects with more than ${MAX_OBJECT_KEYS} keys are summarized.`,
   };
+
+  const outputSize = JSON.stringify(output).length;
+  if (outputSize > MAX_TOTAL_OUTPUT_SIZE) {
+    // If still too large, reduce samples further
+    output = {
+      schema,
+      sampleDocuments: truncatedSamples.slice(0, 2),
+      totalSampled: sampleDocuments.length,
+      _note: `Output was too large (${outputSize} bytes). Reduced to 2 samples. Use execute_query for specific data retrieval.`,
+    };
+  }
+
+  return output;
 };
 
 const executeQuery = async (
@@ -185,6 +343,29 @@ const executeQuery = async (
     query,
     { databaseName },
   );
+
+  // Truncate results to prevent context overflow
+  if (result && result.success && result.data) {
+    const truncatedData = truncateQueryResults(result.data);
+
+    // Check total size and provide warning if large
+    const outputSize = JSON.stringify(truncatedData).length;
+    if (outputSize > MAX_TOTAL_OUTPUT_SIZE) {
+      return {
+        ...result,
+        data: Array.isArray(truncatedData)
+          ? truncatedData.slice(0, 50)
+          : truncatedData,
+        _warning: `Results truncated from ${outputSize} bytes. Add .limit() to your query for smaller result sets.`,
+      };
+    }
+
+    return {
+      ...result,
+      data: truncatedData,
+    };
+  }
+
   return result;
 };
 

--- a/api/src/routes/agent.ts
+++ b/api/src/routes/agent.ts
@@ -9,7 +9,9 @@ import { createAgent, AgentKind } from "../agent";
 import {
   getOrCreateThreadContext,
   buildAgentContext,
-  persistChatSession,
+  persistUserMessage,
+  updateChatWithResponse,
+  persistChatError,
 } from "../services/agent-thread.service";
 import {
   shouldGenerateTitle,
@@ -119,6 +121,19 @@ agentRoutes.post("/stream", async (c: AuthenticatedContext) => {
   const stream = new ReadableStream({
     async start(controller) {
       let isClosed = false;
+      let currentSessionId = sessionId; // Track session ID for updates
+
+      // Track state for error persistence (declared here so accessible in catch)
+      let assistantReply = "";
+      let currentAgent: AgentMode = "triage";
+      let errorPersisted = false; // Flag to prevent duplicate messages after error
+      const toolCalls: Array<{
+        toolName: string;
+        timestamp: Date;
+        status: "started" | "completed";
+        input?: any;
+        result?: any;
+      }> = [];
 
       const sendEvent = (data: any) => {
         if (isClosed) return;
@@ -140,6 +155,20 @@ agentRoutes.post("/stream", async (c: AuthenticatedContext) => {
               createdBy: userId.toString(),
             })
           : null;
+
+        // EARLY PERSISTENCE: Save user message immediately before running agent
+        // This ensures the message is saved even if the agent crashes
+        currentSessionId = await persistUserMessage(
+          sessionId,
+          threadContext,
+          message.trim(),
+          workspaceId,
+          userId.toString(),
+          consoleId,
+        );
+
+        // Send the session ID immediately so frontend can track it
+        sendEvent({ type: "session", sessionId: currentSessionId });
 
         // Get workspace database capabilities for smart selection
         const workspaceDatabases = await DatabaseConnection.find({
@@ -220,18 +249,11 @@ agentRoutes.post("/stream", async (c: AuthenticatedContext) => {
           maxTurns: 100, // Allow enough turns for handoffs to complete
         });
 
-        let assistantReply = "";
+        // Reset tracking variables for this run
+        assistantReply = "";
+        currentAgent = activeAgent;
         let _eventCount = 0;
         let _textDeltaCount = 0;
-        let currentAgent = activeAgent;
-        let handoffOccurred = false;
-        const toolCalls: Array<{
-          toolName: string;
-          timestamp: Date;
-          status: "started" | "completed";
-          input?: any;
-          result?: any;
-        }> = [];
 
         try {
           for await (const event of runStream as AsyncIterable<any>) {
@@ -306,7 +328,6 @@ agentRoutes.post("/stream", async (c: AuthenticatedContext) => {
 
                 // Track handoff as a tool call
                 if (item?.type === "handoff_call_item") {
-                  handoffOccurred = true;
                   const agentNameLower = (handoffAgent || "").toLowerCase();
                   const handoffToolName = agentNameLower.includes("mongodb")
                     ? "transfer_to_mongodb"
@@ -592,11 +613,25 @@ agentRoutes.post("/stream", async (c: AuthenticatedContext) => {
           // Handle stream processing errors
           console.error("Stream processing error:", streamError);
 
+          // Persist error for debugging
+          await persistChatError(
+            currentSessionId,
+            {
+              message: streamError.message || "Stream processing error",
+              code: streamError.code,
+              type: streamError.type || "stream_error",
+            },
+            toolCalls,
+            assistantReply,
+          );
+          errorPersisted = true; // Mark error as persisted to prevent duplicate messages
+
           // Don't throw, just log and continue to close gracefully
           if (streamError.message !== "terminated") {
             sendEvent({
               type: "error",
-              message: "Stream processing error",
+              message: streamError.message || "Stream processing error",
+              code: streamError.code,
             });
           }
         }
@@ -605,6 +640,22 @@ agentRoutes.post("/stream", async (c: AuthenticatedContext) => {
           await runStream.completed;
         } catch (completionError: any) {
           console.error("Stream completion error:", completionError);
+
+          // Only persist if we haven't already persisted an error
+          if (!errorPersisted) {
+            await persistChatError(
+              currentSessionId,
+              {
+                message: completionError.message || "Stream completion error",
+                code: completionError.code,
+                type: completionError.type || "completion_error",
+              },
+              toolCalls,
+              assistantReply,
+            );
+            errorPersisted = true;
+          }
+
           // Continue anyway - we may have partial results
         }
 
@@ -614,71 +665,62 @@ agentRoutes.post("/stream", async (c: AuthenticatedContext) => {
           sendEvent({ type: "text", content: assistantReply });
         }
 
-        // Important: If a handoff occurred but no text was generated, the stream should have continued
-        // with the new agent. We should only save messages when we have actual content.
-        if (assistantReply.trim() || (!handoffOccurred && message.trim())) {
-          // Update messages with the new conversation turn
-          const allMessages = [
-            ...threadContext.recentMessages,
-            { role: "user" as const, content: message.trim() },
-          ];
-
-          // Only add assistant message if there's actual content
-          if (assistantReply.trim()) {
-            allMessages.push({
-              role: "assistant" as const,
-              content: assistantReply,
-              toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
-            });
-          }
-
-          // Persist the chat session with thread management and pinning
-          const finalSessionId = await persistChatSession(
-            sessionId,
-            threadContext,
-            allMessages,
-            workspaceId,
+        // Update chat with assistant response (user message already saved via early persistence)
+        // Skip if error was already persisted to prevent duplicate assistant messages
+        // We always update since we want to save tool calls even if there's no text response
+        if (
+          !errorPersisted &&
+          (assistantReply.trim() || toolCalls.length > 0)
+        ) {
+          await updateChatWithResponse(
+            currentSessionId,
+            assistantReply,
+            toolCalls.length > 0 ? toolCalls : undefined,
             currentAgent,
-            userId.toString(),
-            consoleId, // Pin the console if provided
           );
-
-          // Send thread info
-          sendEvent({
-            type: "thread_info",
-            threadId: threadContext.threadId,
-            messageCount: allMessages.length,
-          });
-
-          sendEvent({ type: "session", sessionId: finalSessionId });
-
-          // Fire-and-forget: generate a descriptive chat title if not already set
-          void (async () => {
-            try {
-              // Only attempt if we have a valid session id and enough context
-              if (!finalSessionId) return;
-
-              if (!shouldGenerateTitle(allMessages)) return;
-
-              const title = await generateChatTitle(allMessages);
-              const trimmed = (title || "").trim();
-              if (!trimmed) return;
-
-              await Chat.findOneAndUpdate(
-                {
-                  _id: new ObjectId(finalSessionId),
-                  workspaceId: new ObjectId(workspaceId),
-                  createdBy: userId.toString(),
-                  titleGenerated: false,
-                },
-                { title: trimmed, titleGenerated: true, updatedAt: new Date() },
-                { new: true },
-              );
-            } catch (e) {
-              console.error("Title generation error:", e);
-            }
-          })();
         }
+
+        // Fetch updated message count for thread info
+        const updatedChat = await Chat.findById(currentSessionId);
+        const messageCount = updatedChat?.messages?.length || 0;
+
+        // Send thread info
+        sendEvent({
+          type: "thread_info",
+          threadId: threadContext.threadId,
+          messageCount,
+        });
+
+        // Fire-and-forget: generate a descriptive chat title if not already set
+        void (async () => {
+          try {
+            // Only attempt if we have a valid session id
+            if (!currentSessionId) return;
+
+            const chat = await Chat.findById(currentSessionId);
+            if (!chat || chat.titleGenerated) return;
+
+            const allMessages = chat.messages || [];
+            if (!shouldGenerateTitle(allMessages)) return;
+
+            const title = await generateChatTitle(allMessages);
+            const trimmed = (title || "").trim();
+            if (!trimmed) return;
+
+            await Chat.findOneAndUpdate(
+              {
+                _id: new ObjectId(currentSessionId),
+                workspaceId: new ObjectId(workspaceId),
+                createdBy: userId.toString(),
+                titleGenerated: false,
+              },
+              { title: trimmed, titleGenerated: true, updatedAt: new Date() },
+              { new: true },
+            );
+          } catch (e) {
+            console.error("Title generation error:", e);
+          }
+        })();
 
         // Close the stream
         isClosed = true;
@@ -686,9 +728,27 @@ agentRoutes.post("/stream", async (c: AuthenticatedContext) => {
         controller.close();
       } catch (err: any) {
         console.error("/api/agent/stream error", err);
+
+        // Persist error for debugging (best-effort, don't await to avoid blocking close)
+        if (currentSessionId) {
+          void persistChatError(
+            currentSessionId,
+            {
+              message: err.message || "Unexpected error",
+              code: err.code,
+              type: err.type || "unexpected_error",
+              stack:
+                process.env.NODE_ENV === "development" ? err.stack : undefined,
+            },
+            toolCalls,
+            assistantReply,
+          );
+        }
+
         sendEvent({
           type: "error",
           message: err.message || "Unexpected error",
+          code: err.code,
         });
         isClosed = true;
         controller.enqueue(encoder.encode("data: [DONE]\n\n"));

--- a/api/src/services/agent-thread.service.ts
+++ b/api/src/services/agent-thread.service.ts
@@ -134,3 +134,223 @@ export const persistChatSession = async (
   await Chat.findByIdAndUpdate(sessionId, updateData, { new: true });
   return sessionId;
 };
+
+/**
+ * Persist user message immediately to create/update chat session before agent runs.
+ * This ensures the user's message is saved even if the agent crashes.
+ */
+export const persistUserMessage = async (
+  sessionId: string | undefined,
+  threadContext: ThreadContext,
+  userMessage: string,
+  workspaceId: string,
+  userId?: string,
+  pinnedConsoleId?: string,
+): Promise<string> => {
+  const now = new Date();
+  const userMessageObj = { role: "user" as const, content: userMessage };
+
+  if (!sessionId) {
+    // Create new chat with just the user message
+    const newChat = new Chat({
+      workspaceId: new ObjectId(workspaceId),
+      threadId: threadContext.threadId,
+      title: "New Chat",
+      messages: [...threadContext.recentMessages, userMessageObj],
+      createdBy: userId || "system",
+      titleGenerated: false,
+      createdAt: now,
+      updatedAt: now,
+      pinnedConsoleId,
+    });
+    await newChat.save();
+    return newChat._id.toString();
+  }
+
+  // Update existing chat with the new user message
+  // IMPORTANT: Fetch current messages from DB to avoid truncation data loss
+  // (threadContext.recentMessages only contains last CONTEXT_WINDOW_SIZE messages)
+  const existingChat = await Chat.findById(sessionId);
+  if (!existingChat) {
+    // Chat was deleted between context load and persist - create new one
+    const newChat = new Chat({
+      workspaceId: new ObjectId(workspaceId),
+      threadId: threadContext.threadId,
+      title: "New Chat",
+      messages: [userMessageObj],
+      createdBy: userId || "system",
+      titleGenerated: false,
+      createdAt: now,
+      updatedAt: now,
+      pinnedConsoleId,
+    });
+    await newChat.save();
+    return newChat._id.toString();
+  }
+
+  const existingMessages = existingChat.messages || [];
+  const updateData: any = {
+    messages: [...existingMessages, userMessageObj],
+    updatedAt: now,
+  };
+  if (pinnedConsoleId !== undefined) {
+    updateData.pinnedConsoleId = pinnedConsoleId;
+  }
+  await Chat.findByIdAndUpdate(sessionId, updateData, { new: true });
+  return sessionId;
+};
+
+/**
+ * Update chat with assistant response and tool calls.
+ * Called after agent completes (or partially completes).
+ */
+export const updateChatWithResponse = async (
+  sessionId: string,
+  assistantContent: string,
+  toolCalls?: Array<{
+    toolName: string;
+    timestamp?: Date;
+    status?: "started" | "completed";
+    input?: any;
+    result?: any;
+  }>,
+  activeAgent?: AgentKind,
+): Promise<void> => {
+  const now = new Date();
+
+  // Fetch current messages and append assistant response
+  const chat = await Chat.findById(sessionId);
+  if (!chat) return;
+
+  const messages = [...(chat.messages || [])];
+
+  // Add assistant message if there's content OR tool calls
+  // Tool calls should be persisted even when the assistant doesn't generate text
+  const hasContent = assistantContent.trim();
+  const hasToolCalls = toolCalls && toolCalls.length > 0;
+
+  if (hasContent || hasToolCalls) {
+    messages.push({
+      role: "assistant" as const,
+      content: assistantContent,
+      toolCalls: hasToolCalls ? toolCalls : undefined,
+    });
+  }
+
+  const updateData: any = { messages, updatedAt: now };
+  if (activeAgent) {
+    updateData.activeAgent = activeAgent;
+  }
+
+  await Chat.findByIdAndUpdate(sessionId, updateData, { new: true });
+};
+
+/**
+ * Persist error information to the chat for debugging.
+ * Adds an assistant message with error details and any partial tool calls.
+ */
+export const persistChatError = async (
+  sessionId: string,
+  error: {
+    message: string;
+    code?: string;
+    type?: string;
+    stack?: string;
+  },
+  partialToolCalls?: Array<{
+    toolName: string;
+    timestamp?: Date;
+    status?: "started" | "completed";
+    input?: any;
+    result?: any;
+  }>,
+  partialResponse?: string,
+): Promise<void> => {
+  if (!sessionId) return;
+
+  const now = new Date();
+
+  try {
+    const chat = await Chat.findById(sessionId);
+    if (!chat) return;
+
+    const messages = [...(chat.messages || [])];
+
+    // Create error details for debugging
+    const errorDetails = [
+      `⚠️ **Error occurred during processing**`,
+      ``,
+      `**Error:** ${error.message}`,
+    ];
+
+    if (error.code) {
+      errorDetails.push(`**Code:** ${error.code}`);
+    }
+    if (error.type) {
+      errorDetails.push(`**Type:** ${error.type}`);
+    }
+
+    // Add partial response if any
+    if (partialResponse?.trim()) {
+      errorDetails.push(
+        ``,
+        `**Partial response before error:**`,
+        partialResponse.trim(),
+      );
+    }
+
+    // Add tool call summary if any
+    if (partialToolCalls && partialToolCalls.length > 0) {
+      errorDetails.push(``, `**Tool calls before error:**`);
+      for (const tc of partialToolCalls) {
+        const status = tc.status === "completed" ? "✓" : "⏳";
+        errorDetails.push(`- ${status} ${tc.toolName}`);
+      }
+    }
+
+    // Add timestamp
+    errorDetails.push(``, `*Occurred at: ${now.toISOString()}*`);
+
+    // Add as an assistant message with error marker
+    messages.push({
+      role: "assistant" as const,
+      content: errorDetails.join("\n"),
+      toolCalls:
+        partialToolCalls && partialToolCalls.length > 0
+          ? [
+              ...partialToolCalls,
+              {
+                toolName: "_error",
+                timestamp: now,
+                status: "completed" as const,
+                result: {
+                  error: error.message,
+                  code: error.code,
+                  type: error.type,
+                },
+              },
+            ]
+          : [
+              {
+                toolName: "_error",
+                timestamp: now,
+                status: "completed" as const,
+                result: {
+                  error: error.message,
+                  code: error.code,
+                  type: error.type,
+                },
+              },
+            ],
+    });
+
+    await Chat.findByIdAndUpdate(
+      sessionId,
+      { messages, updatedAt: now },
+      { new: true },
+    );
+  } catch (persistError) {
+    // Don't throw - this is best-effort error logging
+    console.error("Failed to persist chat error:", persistError);
+  }
+};


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Early-persist user messages and tool calls with robust error logging, and cap MongoDB inspect/query outputs via structured truncation to prevent context overflow.
> 
> - **Agent streaming/persistence**:
>   - Early-persist user messages and emit `session` immediately; replace `persistChatSession` with `persistUserMessage` + `updateChatWithResponse`.
>   - Track `toolCalls`, current agent mode, and handoffs; persist partial state and detailed errors via `persistChatError` (includes codes/types and partial output).
>   - Always send `thread_info` using DB-fetched message count; background title generation uses latest DB state; SSE errors now include `code`.
> - **MongoDB tools (`api/src/agent/mongodb/tools.ts`)**:
>   - Add structured truncation utilities with caps on strings, arrays, object keys, depth, samples, and total output size.
>   - `inspect_collection`: return truncated sample docs with `_note`, auto-reduce if oversized.
>   - `execute_query`: truncate large results and add `_warning` when output exceeds size cap.
> - **Thread service (`agent-thread.service.ts`)**:
>   - New helpers: `persistUserMessage`, `updateChatWithResponse`, `persistChatError` to manage chat updates and error persistence safely.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 372ce3119938ec33df1c6abc05173f0b90fe2981. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->