### PR TITLE
Agent interruption mechanism

### DIFF
--- a/api/src/routes/agent.ts
+++ b/api/src/routes/agent.ts
@@ -244,7 +244,7 @@ agentRoutes.post("/stream", async (c: AuthenticatedContext) => {
           preferredConsoleId: effectiveConsoleId,
         });
 
-        let runStream: any;
+        let runStream: any = null;
 
         // Handle client disconnection
         c.req.raw.signal.addEventListener("abort", () => {

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -334,7 +334,7 @@ const MessageItem = React.memo(
               const codeString = String(children).replace(/\n$/, "");
               return !isInline ? (
                 <CodeBlock
-                  language={match![1]}
+                  language={match?.[1] || ""}
                   key={codeString}
                   isGenerating={false}
                 >
@@ -1293,7 +1293,7 @@ const Chat: React.FC<ChatProps> = ({ onConsoleModification }) => {
                         const codeString = String(children).replace(/\n$/, "");
                         return !isInline ? (
                           <CodeBlock
-                            language={match![1]}
+                            language={match?.[1] || ""}
                             key={codeString}
                             isGenerating
                           >
@@ -1309,7 +1309,6 @@ const Chat: React.FC<ChatProps> = ({ onConsoleModification }) => {
                         );
                       },
                       table({ children }) {
-                        const muiTheme = useMuiTheme();
                         return (
                           <Box sx={{ overflow: "auto", my: 1 }}>
                             <table
@@ -1326,7 +1325,6 @@ const Chat: React.FC<ChatProps> = ({ onConsoleModification }) => {
                         );
                       },
                       th({ children }) {
-                        const muiTheme = useMuiTheme();
                         return (
                           <th
                             style={{
@@ -1344,7 +1342,6 @@ const Chat: React.FC<ChatProps> = ({ onConsoleModification }) => {
                         );
                       },
                       td({ children }) {
-                        const muiTheme = useMuiTheme();
                         return (
                           <td
                             style={{


### PR DESCRIPTION
Add a 'Stop' button to interrupt a running agent, cancelling frontend, API, and OpenAI streams.

---
<a href="https://cursor.com/background-agent?bcId=bc-61df21be-faea-470d-b28b-a3cf52673e33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-61df21be-faea-470d-b28b-a3cf52673e33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Stop button that aborts in-flight chat streams and propagates the abort to the API/agent stream, preserving partial output.
> 
> - **Frontend (Chat)**:
>   - Add Stop button shown during generation to abort via `AbortController` (`stopGeneration`, `abortControllerRef`).
>   - Pass `signal` to `/api/agent/stream` request; handle `AbortError` by committing partial content/tool-calls and clearing streaming state.
>   - Safer codeblock rendering (`language={match?.[1] || ""}`) and minor session selection guard; quiet debug logs.
> - **Backend (Agent stream)**:
>   - Track `runStream`; listen to `c.req.raw.signal` abort to set `isClosed` and `runStream.abort()` safely.
>   - Pass `signal` to `runAgent`; break stream loop when closed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2e0f7a79e1ef2c167d88a240214529b0a41325f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->