### PR TITLE
Pr preview domain update

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -55,12 +55,12 @@ jobs:
     needs: detect-changes
     environment:
       name: pr-${{ github.event.pull_request.number }}
-      url: https://pr-${{ github.event.pull_request.number }}.dev-app.mako.ai
+      url: https://pr-${{ github.event.pull_request.number }}.mako.ai
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}
-      BASE_URL: https://pr-${{ github.event.pull_request.number }}.dev-app.mako.ai
-      CLIENT_URL: https://pr-${{ github.event.pull_request.number }}.dev-app.mako.ai
-      VITE_API_URL: https://pr-${{ github.event.pull_request.number }}.dev-app.mako.ai/api
+      BASE_URL: https://pr-${{ github.event.pull_request.number }}.mako.ai
+      CLIENT_URL: https://pr-${{ github.event.pull_request.number }}.mako.ai
+      VITE_API_URL: https://pr-${{ github.event.pull_request.number }}.mako.ai/api
       # PR previews disable OAuth since redirect URLs can't be dynamically registered
       DISABLE_OAUTH: "true"
       # Staging secrets (from staging environment)
@@ -249,7 +249,7 @@ jobs:
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
-            const previewUrl = `https://pr-${prNumber}.dev-app.mako.ai`;
+            const previewUrl = `https://pr-${prNumber}.mako.ai`;
             const cloudRunUrl = `${{ steps.deploy.outputs.cloud_run_url }}`;
             const migrationsChanged = '${{ needs.detect-changes.outputs.migrations_changed }}' === 'true';
 

--- a/cloudflare/README.md
+++ b/cloudflare/README.md
@@ -1,6 +1,6 @@
 # Cloudflare Worker for PR Preview Routing
 
-This worker routes requests from `pr-{number}.dev-app.mako.ai` to the corresponding Cloud Run preview deployment.
+This worker routes requests from `pr-{number}.mako.ai` to the corresponding Cloud Run preview deployment.
 
 ## Setup Instructions
 
@@ -36,7 +36,7 @@ id = "your-namespace-id-here"
 Alternatively, set up Workers Routes:
 
 1. Go to Workers & Pages → your worker → Settings → Triggers
-2. Add Route: `*.dev-app.mako.ai/*` for zone `mako.ai`
+2. Add Route: `pr-*.mako.ai/*` for zone `mako.ai`
 
 ### 4. Deploy the Worker
 
@@ -51,12 +51,12 @@ pnpm run cf:deploy
 pnpm exec wrangler kv:key put --namespace-id=YOUR_NAMESPACE_ID "123" "https://your-cloud-run-url.run.app"
 
 # Test the routing
-curl https://pr-123.dev-app.mako.ai/
+curl https://pr-123.mako.ai/
 ```
 
 ## How It Works
 
-1. Request arrives at `pr-{number}.dev-app.mako.ai`
+1. Request arrives at `pr-{number}.mako.ai`
 2. Worker extracts the PR number from the subdomain
 3. Worker looks up the Cloud Run URL from KV using the PR number as key
 4. Worker proxies the request to Cloud Run, rewriting headers appropriately

--- a/cloudflare/worker.js
+++ b/cloudflare/worker.js
@@ -1,7 +1,7 @@
 /**
  * Cloudflare Worker for PR Preview Routing
  *
- * Routes requests from pr-{number}.dev-app.mako.ai to the corresponding
+ * Routes requests from pr-{number}.mako.ai to the corresponding
  * Cloud Run service URL stored in KV.
  *
  * Setup:
@@ -15,13 +15,13 @@ export default {
     const url = new URL(request.url);
     const hostname = url.hostname;
 
-    // Extract PR number from subdomain (pr-123.dev-app.mako.ai)
-    const match = hostname.match(/^pr-(\d+)\.dev-app\.mako\.ai$/);
+    // Extract PR number from subdomain (pr-123.mako.ai)
+    const match = hostname.match(/^pr-(\d+)\.mako\.ai$/);
     if (!match) {
       return new Response(
         JSON.stringify({
           error: "Invalid preview URL",
-          message: "Expected format: pr-{number}.dev-app.mako.ai",
+          message: "Expected format: pr-{number}.mako.ai",
         }),
         {
           status: 404,

--- a/cloudflare/wrangler.toml
+++ b/cloudflare/wrangler.toml
@@ -5,8 +5,8 @@ name = "mako-pr-router"
 main = "worker.js"
 compatibility_date = "2024-01-01"
 
-# Routes - routes all *.dev-app.mako.ai traffic through this worker
-routes = [{ pattern = "*.dev-app.mako.ai/*", zone_name = "mako.ai" }]
+# Routes - routes all pr-*.mako.ai traffic through this worker
+routes = [{ pattern = "pr-*.mako.ai/*", zone_name = "mako.ai" }]
 
 # KV Namespace binding
 [[kv_namespaces]]


### PR DESCRIPTION
Update PR preview domain from `dev-app.mako.ai` to `mako.ai` to correct broken links in GitHub PR comments and email URLs.

---
<a href="https://cursor.com/background-agent?bcId=bc-413ab8aa-0087-4fcf-aceb-2575aea154f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-413ab8aa-0087-4fcf-aceb-2575aea154f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches PR preview domain from pr-*.dev-app.mako.ai to pr-*.mako.ai across GitHub Actions, Cloudflare worker, and docs.
> 
> - **CI/CD (GitHub Actions)**
>   - Update preview environment `url` and env vars (`BASE_URL`, `CLIENT_URL`, `VITE_API_URL`) to `https://pr-${PR_NUMBER}.mako.ai` in `.github/workflows/deploy-app.yml`.
>   - Update PR comment preview link to `https://pr-${PR_NUMBER}.mako.ai`.
> - **Cloudflare Worker**
>   - Change hostname regex to `^pr-(\d+)\.mako\.ai$` and error message to expect `pr-{number}.mako.ai` in `cloudflare/worker.js`.
>   - Update worker routes to `pr-*.mako.ai/*` in `cloudflare/wrangler.toml`.
> - **Docs**
>   - Revise `cloudflare/README.md` to reference `pr-{number}.mako.ai`, updated route, and test URL examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edc864346638523e6ac45fc0dd52fd9cae0773c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->