### PR TITLE
Mongodb query cancellation issue

### DIFF
--- a/api/src/services/database-connection.service.ts
+++ b/api/src/services/database-connection.service.ts
@@ -853,7 +853,8 @@ export class DatabaseConnectionService {
               const runningMs = op.secs_running * 1000;
               const opApproxStart = Date.now() - runningMs;
               // Check if the operation started within a reasonable window of our query
-              if (opApproxStart >= queryStartTime - 2000) {
+              // Use a symmetric tolerance window to avoid matching unrelated newer ops.
+              if (Math.abs(opApproxStart - queryStartTime) < 2000) {
                 return true;
               }
             }


### PR DESCRIPTION
Implement query cancellation for MongoDB queries to prevent them from running on the server after client-side cancellation.

Previously, MongoDB queries would continue to execute on the server even after a client-side cancellation request, leading to wasted resources and incorrect status. This PR introduces a mechanism to track running MongoDB queries using `AbortController` and attempts to terminate server-side operations using MongoDB's `killOp` admin command.

---
<a href="https://cursor.com/background-agent?bcId=bc-cd63ecce-804b-4dd0-953f-e7e6fa02bf87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cd63ecce-804b-4dd0-953f-e7e6fa02bf87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds MongoDB query cancellation with tracked executions, AbortController propagation, and optional server-side killOp; integrates with unified cancelQuery flow.
> 
> - **Database service (`api/src/services/database-connection.service.ts`)**:
>   - **MongoDB cancellation**:
>     - Track running queries via `runningMongoQueries` (stores `client`, `AbortController`, `startTime`).
>     - New `cancelMongoDBQuery(executionId)` aborts client-side work and attempts server-side termination via `admin.currentOp` + `killOp`.
>     - Integrated into `cancelQuery(...)` auto-detection alongside BigQuery/PostgreSQL.
>   - **Execution tracking & cleanup**:
>     - `executeMongoDBQuery(...)` now registers queries by `executionId`, passes `AbortSignal` to JS executor, returns "Query cancelled" on abort, and cleans up tracking in `finally`.
>   - **JS query execution**:
>     - `executeMongoDBJavaScriptQuery(...)` accepts `signal` and races promises/cursor `toArray()` via `raceWithAbort` to honor cancellations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b3f0fd861aaf6d74e7598f0c909705f61ba89b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->