### PR TITLE
feat: Implement retry logic for database connections

### DIFF
--- a/api/src/services/database-connection.service.ts
+++ b/api/src/services/database-connection.service.ts
@@ -197,16 +197,21 @@ async function withRetry<T>(
 
       // Wait before retrying
       await new Promise<void>((resolve, reject) => {
-        const timeoutId = setTimeout(resolve, delayMs);
+        const abortHandler = () => {
+          clearTimeout(timeoutId);
+          reject(new Error("Operation cancelled"));
+        };
+
+        const timeoutId = setTimeout(() => {
+          // Clean up abort listener when timeout completes normally
+          if (signal) {
+            signal.removeEventListener("abort", abortHandler);
+          }
+          resolve();
+        }, delayMs);
+
         if (signal) {
-          signal.addEventListener(
-            "abort",
-            () => {
-              clearTimeout(timeoutId);
-              reject(new Error("Operation cancelled"));
-            },
-            { once: true },
-          );
+          signal.addEventListener("abort", abortHandler, { once: true });
         }
       });
     }
@@ -2735,9 +2740,15 @@ export class DatabaseConnectionService {
       const client = await withRetry(
         async () => {
           const newClient = createClient(config);
-          // Verify connection is working before returning
-          await newClient.ping();
-          return newClient;
+          try {
+            // Verify connection is working before returning
+            await newClient.ping();
+            return newClient;
+          } catch (error) {
+            // Close the client if ping fails to prevent resource leaks
+            await newClient.close().catch(() => {});
+            throw error;
+          }
         },
         {
           maxRetries: this.clickHouseMaxRetries,


### PR DESCRIPTION
- Added retry utility with exponential backoff for handling transient connection failures in PostgreSQL and ClickHouse.
- Introduced RetryOptions interface and default error patterns for retryable and non-retryable errors.
- Enhanced connection methods to utilize retry logic, improving resilience against temporary outages.
- Updated PostgreSQL and ClickHouse client configurations to include timeout settings for better connection management.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves resilience of database connectivity and query cancellation.
> 
> - Adds `withRetry` utility with exponential backoff plus retryable/non-retryable error pattern matching
> - Refactors PostgreSQL to use `buildPostgreSQLClientConfig` with `connectionTimeoutMillis`, `query_timeout`, `statement_timeout`; applies retries in `testPostgreSQLConnection`, `createPostgreSQLConnection`, and temporary connections in `executePostgreSQLQuery`; uses same config in `cancelPostgresQuery`
> - Enhances ClickHouse config via `buildClickHouseClientConfig` (adds `request_timeout` and `keep_alive`); applies retries for client creation/ping in `testClickHouseConnection` and connection establishment in `executeClickHouseQuery` (query execution itself not retried); introduces per-query `query_id` and cleans up abort listeners
> - Introduces constants for retry/timeout tuning (`clickHouseRequestTimeout`, `clickHouseMaxRetries`, `postgresConnectionTimeoutMs`, etc.) and fixes minor cleanup (`client` null check)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b44a7ccf5b2da36b4ebeb69900a960af3cd0eae8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->