### PR TITLE
refactor: Improve SQL autocomplete by reading fresh state from store

### DIFF
--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -185,23 +185,41 @@ function Editor() {
   }, []);
 
   // Dynamic getters for unified SQL autocomplete (reads from active console)
+  // These getters read directly from the store at call time to avoid stale closures.
+  // This is critical for autocomplete to work correctly when switching consoles.
   const getWorkspaceId = useCallback(
     () => currentWorkspace?.id,
     [currentWorkspace?.id],
   );
 
+  // Use a ref to track availableDatabases so getConnectionType can access fresh values
+  const availableDatabasesRef = useRef(availableDatabases);
+  useEffect(() => {
+    availableDatabasesRef.current = availableDatabases;
+  }, [availableDatabases]);
+
   const getConnectionId = useCallback(() => {
-    const activeTab = consoleTabs.find(tab => tab.id === activeConsoleId);
+    // Read fresh state from the store at call time (not from closed-over React state)
+    const state = useAppStore.getState();
+    const tabs = state.consoles.tabs;
+    const activeTabId = state.consoles.activeTabId;
+    const activeTab = activeTabId ? tabs[activeTabId] : null;
     return activeTab?.connectionId;
-  }, [consoleTabs, activeConsoleId]);
+  }, []); // Empty deps - always reads fresh from store
 
   const getConnectionType = useCallback(() => {
-    const activeTab = consoleTabs.find(tab => tab.id === activeConsoleId);
-    const connection = availableDatabases.find(
-      db => db.id === activeTab?.connectionId,
+    // Read fresh state from the store at call time
+    const state = useAppStore.getState();
+    const tabs = state.consoles.tabs;
+    const activeTabId = state.consoles.activeTabId;
+    const activeTab = activeTabId ? tabs[activeTabId] : null;
+    const connectionId = activeTab?.connectionId;
+    // Use ref to get current availableDatabases without causing effect re-runs
+    const connection = availableDatabasesRef.current.find(
+      db => db.id === connectionId,
     );
     return connection?.type;
-  }, [consoleTabs, activeConsoleId, availableDatabases]);
+  }, []); // Empty deps - reads fresh from store and ref
 
   // Unified SQL autocomplete - single global provider for all consoles
   useSqlAutocomplete({


### PR DESCRIPTION
- Updated dynamic getters to read directly from the store at call time, ensuring accurate autocomplete functionality when switching consoles.
- Introduced a ref to track availableDatabases, allowing getConnectionType to access the latest values without causing effect re-runs.
- Simplified dependencies for getConnectionId and getConnectionType to always read fresh state, enhancing performance and reliability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves unified SQL autocomplete to always use up-to-date console and database info.
> 
> - Refactors `getConnectionId` and `getConnectionType` in `Editor.tsx` to read from `useAppStore.getState()` at call time, avoiding stale closures when switching consoles
> - Introduces `availableDatabasesRef` with an effect to keep it in sync, enabling fresh lookups for connection type without rerunning effects
> - Simplifies deps for these getters (empty arrays) and continues wiring them into `useSqlAutocomplete`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fc47a289a7a0ddd4f83afe8c188308397965c75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->