### PR TITLE
chore(website): add Prettier formatting for TypeScript files in websi…

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,9 @@
     "api/**/*.ts": [
       "eslint --fix",
       "prettier --write"
+    ],
+    "website/**/*.{ts,tsx}": [
+      "prettier --write"
     ]
   },
   "devDependencies": {

--- a/website/app/lp/page.tsx
+++ b/website/app/lp/page.tsx
@@ -103,11 +103,6 @@ export default function LandingPagesIndex() {
               href={`/lp/${design.slug}`}
               className="group p-6 rounded-2xl border border-zinc-800 bg-zinc-900/50 hover:bg-zinc-900 hover:border-zinc-700 transition-all relative"
             >
-              {design.isCurrent && (
-                <span className="absolute top-4 right-4 px-2 py-0.5 rounded-full bg-emerald-500/20 text-emerald-400 text-xs border border-emerald-500/30">
-                  Current
-                </span>
-              )}
               <div className="flex items-start justify-between mb-4">
                 <div>
                   <span className="text-xs font-mono text-zinc-500 uppercase">


### PR DESCRIPTION
…te directory

- Configured Prettier to format TypeScript and TSX files in the website directory for consistent code style.
- Removed unused "Current" label from landing page design for cleaner UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - Enables Prettier on `website/**/*.{ts,tsx}` via `lint-staged` in `package.json`
> - Removes the unused `Current` badge from `website/app/lp/page.tsx` design cards for a cleaner UI
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 163ffe81126076ae0aac6effcb703d1004f8e03b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->