### PR TITLE
Update GitHub Actions workflow to improve MongoDB restore command

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -337,7 +337,7 @@ jobs:
 
           # Restore to the ephemeral database
           echo "Restoring to ephemeral database: ${EPHEMERAL_DB_NAME}"
-          mongorestore --uri="$STAGING_DATABASE_URL" --nsFrom="${PROD_DB_NAME}.*" --nsTo="${EPHEMERAL_DB_NAME}.*" "$DUMP_DIR/$PROD_DB_NAME" --quiet
+          mongorestore --uri="$STAGING_DATABASE_URL" --nsInclude="${PROD_DB_NAME}.*" --nsFrom="${PROD_DB_NAME}.*" --nsTo="${EPHEMERAL_DB_NAME}.*" "$DUMP_DIR/$PROD_DB_NAME" --quiet
 
           # Cleanup
           rm -rf "$DUMP_DIR"


### PR DESCRIPTION
- Modified the `mongorestore` command in the deployment workflow to use `--nsInclude` for better namespace handling during database restoration.
- This change enhances the accuracy of the restoration process, ensuring that the correct namespaces are included when restoring to the ephemeral database.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Deploy workflow MongoDB restore refinement**
> 
> - Updates `mongorestore` in `.github/workflows/deploy-app.yml` to include `--nsInclude="${PROD_DB_NAME}.*"` alongside `--nsFrom/--nsTo` when copying the production dump to the ephemeral staging DB.
> - Affects only the ephemeral DB rebuild step; no application code or other workflow steps changed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08a13b39c565f3ae58889e808361cd647eaa7afb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->