### PR TITLE
Update branding from RevOps to AI-native SQL

### DIFF
--- a/.cursor/rules/00-project-structure.mdc
+++ b/.cursor/rules/00-project-structure.mdc
@@ -2,7 +2,7 @@
 alwaysApply: true
 ---
 
-# RevOps Monorepo Guide
+# Mako Monorepo Guide
 
 - API service (Node + TypeScript): entry at [api/src/index.ts](mdc:api/src/index.ts). Built output lives in [api/dist/index.js](mdc:api/dist/index.js). Default port: 8080 (env `WEB_API_PORT`).
 - Web app (Vite + React): entry at [app/src/main.tsx](mdc:app/src/main.tsx). Built output lives under [app/dist/](mdc:app/dist/index.html). Dev server: 5173 with `/api` proxied to `http://localhost:8080`.

--- a/.cursor/rules/05-condensed-context.mdc
+++ b/.cursor/rules/05-condensed-context.mdc
@@ -1,9 +1,9 @@
 ---
 alwaysApply: true
-description: Ultra-condensed context for RevOps (99% signal)
+description: Ultra-condensed context for Mako (99% signal)
 ---
 
-# RevOps Quick Context
+# Mako Quick Context
 
 - API entry: [api/src/index.ts](mdc:api/src/index.ts); default port `WEB_API_PORT=8080`.
 - App entry: [app/src/main.tsx](mdc:app/src/main.tsx); Vite dev on 5173; proxy `/api` -> `http://localhost:8080` ([app/vite.config.ts](mdc:app/vite.config.ts)).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**Mako - The AI Data Analyst for Modern RevOps**
+**Mako - The AI-native SQL Client**
 
-Mako is a production-ready, multi-tenant data analytics SaaS platform built with a PNPM workspace monorepo structure. It combines external data source integration (Stripe, Close CRM, GraphQL APIs, PostHog, REST APIs), multi-database query execution (MongoDB, PostgreSQL, BigQuery, ClickHouse, etc.), AI-powered chat assistance with multi-provider LLM support (OpenAI, Anthropic, Google), and event-driven data synchronization via Inngest.
+Mako is a production-ready, multi-tenant AI-powered SQL client built with a PNPM workspace monorepo structure. It combines multi-database query execution (MongoDB, PostgreSQL, BigQuery, ClickHouse, etc.), AI-powered query generation with multi-provider LLM support (OpenAI, Anthropic, Google), team collaboration features, and optional data source connectors (Stripe, Close CRM, GraphQL APIs, PostHog, REST APIs) with event-driven synchronization via Inngest.
 
 **Architecture:** Five main packages:
 

--- a/CONSOLE_API_DOCUMENTATION.md
+++ b/CONSOLE_API_DOCUMENTATION.md
@@ -1,6 +1,6 @@
 # Console API Documentation
 
-This document describes how to use the RevOps Console API to execute saved consoles remotely.
+This document describes how to use the Mako Console API to execute saved consoles remotely.
 
 ## API Endpoints
 
@@ -140,12 +140,12 @@ Common error codes:
 ```bash
 # List all consoles
 curl -H "Authorization: Bearer revops_YOUR_API_KEY" \
-  https://your-revops-instance.com/api/workspaces/WORKSPACE_ID/consoles/list
+  https://your-mako-instance.com/api/workspaces/WORKSPACE_ID/consoles/list
 
 # Execute a console
 curl -X POST \
   -H "Authorization: Bearer revops_YOUR_API_KEY" \
-  https://your-revops-instance.com/api/workspaces/WORKSPACE_ID/consoles/CONSOLE_ID/execute
+  https://your-mako-instance.com/api/workspaces/WORKSPACE_ID/consoles/CONSOLE_ID/execute
 ```
 
 ### JavaScript Example
@@ -158,7 +158,7 @@ const CONSOLE_ID = "your_console_id";
 // Execute a console
 async function executeConsole() {
   const response = await fetch(
-    `https://your-revops-instance.com/api/workspaces/${WORKSPACE_ID}/consoles/${CONSOLE_ID}/execute`,
+    `https://your-mako-instance.com/api/workspaces/${WORKSPACE_ID}/consoles/${CONSOLE_ID}/execute`,
     {
       method: "POST",
       headers: {
@@ -183,7 +183,7 @@ CONSOLE_ID = 'your_console_id'
 
 # Execute a console
 response = requests.post(
-    f'https://your-revops-instance.com/api/workspaces/{WORKSPACE_ID}/consoles/{CONSOLE_ID}/execute',
+    f'https://your-mako-instance.com/api/workspaces/{WORKSPACE_ID}/consoles/{CONSOLE_ID}/execute',
     headers={
         'Authorization': f'Bearer {API_KEY}'
     }

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 # Mako 🦈
 
-**The AI Data Analyst for Modern RevOps.**
+**The AI-native SQL Client.**
 
-> **The Cursor for Data.** Build your data warehouse and analyze it with AI.
+> **The Cursor for Data.** Connect to any database and query with AI assistance.
 
-Stop wrestling with SQL and broken spreadsheets. Unify your revenue stack and ask questions in plain English to get instant answers.
+Stop wrestling with complex SQL and slow, bloated database tools. Write queries in plain English and get instant, accurate results.
 
 ![Mako App Interface](./website/public/app-screenshot.png)
 
 ## 🚀 Why Mako?
 
-We replaced the complex web of data tools with a single, intelligent platform.
+A modern SQL client built for the AI era, replacing slow desktop tools with a fast, collaborative, AI-powered experience.
 
-- **🔄 Zero-Config Data Pipelines**: Connect Stripe, PostHog, and CRMs in seconds. We handle the schema, syncing, and maintenance.
-  - _Replaces: Airbyte, Fivetran, Manual Scripts_
-- **💬 Conversational Intelligence**: Your personal data analyst, available 24/7. Ask complex questions and get accurate charts instantly.
-  - _Replaces: DataGrip, Tableau, SQL_
-- **🏢 Turn Insights into Action**: Share live dashboards, build reports together, and align your team on the metrics that matter.
-  - _Replaces: Slack Screenshots, Excel, Emails_
+- **✨ AI Query Generation**: Write queries in natural language. Our schema-aware AI generates optimized SQL instantly.
+  - _Replaces: DataGrip, DBeaver, Postico_
+- **👥 Team Collaboration**: Share connections, version-control queries, and work together in real-time.
+  - _Replaces: Passing credentials around, lost SQL files_
+- **⚡ Blazing Fast**: No Java or Electron bloat. Opens instantly in your browser and runs smooth.
+  - _Replaces: Slow desktop database tools_
 
 ## 🔌 Integrations
 

--- a/api/src/inngest/client.ts
+++ b/api/src/inngest/client.ts
@@ -5,7 +5,7 @@ import { configureLogging, LogTapeInngestLogger } from "./logging";
 void configureLogging();
 
 export const inngest = new Inngest({
-  id: "revops-sync",
-  name: "RevOps Sync",
+  id: "mako-sync",
+  name: "Mako Sync",
   logger: new LogTapeInngestLogger(["inngest"]),
 });

--- a/app/index.html
+++ b/app/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="manifest" href="/manifest.json" />
     <link rel="apple-touch-icon" href="/logo192.png" />
-    <title>Mako RevOps</title>
+    <title>Mako</title>
 
     <!-- Google Tag Manager -->
     <script>

--- a/app/public/manifest.json
+++ b/app/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "short_name": "Mako",
-  "name": "Mako - Agentic RevOps Platform",
+  "name": "Mako - AI-native SQL Client",
   "icons": [
     {
       "src": "favicon.ico",

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -150,7 +150,7 @@ function Editor() {
 
   // Update the page title based on the active tab
   useEffect(() => {
-    const baseTitle = "Mako RevOps";
+    const baseTitle = "Mako";
     if (!activeConsoleId) {
       document.title = baseTitle;
       return;

--- a/website/DEPLOYMENT.md
+++ b/website/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Website Deployment Guide
 
-This guide covers deploying the RevOps marketing website to Vercel.
+This guide covers deploying the Mako marketing website to Vercel.
 
 ## Prerequisites
 
@@ -66,7 +66,7 @@ This guide covers deploying the RevOps marketing website to Vercel.
    - Set up and deploy? Yes
    - Which scope? Select your account
    - Link to existing project? No
-   - What's your project's name? revops-website
+   - What's your project's name? mako-website
    - In which directory is your code located? ./
    - Want to override settings? No
 
@@ -86,13 +86,13 @@ Update the app links in `app/page.tsx` to point to your production app:
 ```typescript
 // Replace localhost URLs with your production app URL
 const APP_URL =
-  process.env.NEXT_PUBLIC_APP_URL || "https://app.yourrevopsdomain.com";
+  process.env.NEXT_PUBLIC_APP_URL || "https://app.mako.ai";
 ```
 
 Then set in Vercel:
 
 - **Key**: `NEXT_PUBLIC_APP_URL`
-- **Value**: `https://app.yourrevopsdomain.com`
+- **Value**: `https://app.mako.ai`
 
 ## Custom Domain
 
@@ -100,14 +100,14 @@ Then set in Vercel:
 
 1. Go to your project settings in Vercel
 2. Navigate to "Domains"
-3. Add your domain (e.g., `revops.com`)
+3. Add your domain (e.g., `mako.ai`)
 4. Follow DNS configuration instructions
 
 ### DNS Configuration
 
 Add these records to your DNS provider:
 
-**For apex domain (revops.com):**
+**For apex domain (mako.ai):**
 
 ```
 Type: A

--- a/website/README.md
+++ b/website/README.md
@@ -1,6 +1,6 @@
-# RevOps Website
+# Mako Website
 
-Public-facing marketing website for the RevOps data analytics platform.
+Public-facing marketing website for the Mako AI-native SQL client.
 
 ## Tech Stack
 
@@ -43,7 +43,7 @@ website/
 
 ### Quick Deploy
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/yourusername/revops)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/mako-ai/mono)
 
 ### Manual Deploy
 
@@ -76,7 +76,7 @@ In `app/page.tsx`, update the app links from `http://localhost:5173` to your pro
 // Find and replace
 href = "http://localhost:5173";
 // with
-href = "https://app.yourrevopsdomain.com";
+href = "https://app.mako.ai";
 ```
 
 ### Branding

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -16,9 +16,9 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Mako - Agentic RevOps Platform",
+  title: "Mako - AI-native SQL Client",
   description:
-    "Connect all of your data sources, query with natural language, and get insights that drive product and growth.",
+    "The modern SQL client with AI query generation. Connect to any database, write queries in natural language, and collaborate with your team.",
 };
 
 export default function RootLayout({

--- a/website/app/lp/page.tsx
+++ b/website/app/lp/page.tsx
@@ -5,10 +5,10 @@ export default function LandingPagesIndex() {
   const designs = [
     {
       slug: "revops",
-      name: "RevOps Platform",
+      name: "Legacy RevOps",
       description:
-        "The original RevOps-focused landing page with data pipelines and revenue operations positioning.",
-      tags: ["RevOps", "Original", "Data Pipelines"],
+        "Legacy landing page with RevOps positioning (deprecated). Kept for reference only.",
+      tags: ["Legacy", "Deprecated", "RevOps"],
     },
     {
       slug: "minimal-dark",
@@ -152,7 +152,7 @@ export default function LandingPagesIndex() {
                 <li>
                   • External connector integrations (Stripe, PostHog, etc.)
                 </li>
-                <li>• &quot;RevOps platform&quot; positioning</li>
+                <li>• Legacy &quot;RevOps platform&quot; positioning</li>
                 <li>• Data sync and pipeline features</li>
               </ul>
             </div>


### PR DESCRIPTION
Rebrand Mako across the codebase from "RevOps Platform" positioning to "AI-native SQL Client" to reflect the new product direction.

Changes include:
- Update README.md with new tagline and value propositions
- Update CLAUDE.md project description
- Update app titles (index.html, manifest.json, Editor.tsx)
- Update website metadata and deployment docs
- Update Cursor rules files
- Update Console API documentation
- Update Inngest client name
- Mark legacy RevOps landing page as deprecated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Repositions product messaging and identifiers from RevOps to an AI-native SQL client.
> 
> - Updates copy and value props in `README.md` and `CLAUDE.md`
> - Renames branding in Cursor rules (`.cursor/rules/00-project-structure.mdc`, `05-condensed-context.mdc`)
> - Changes app/window titles (`app/index.html`, `app/public/manifest.json`, `app/src/components/Editor.tsx`)
> - Updates website metadata and docs (`website/app/layout.tsx`, `website/README.md`, `website/DEPLOYMENT.md`); marks legacy RevOps LP as deprecated (`website/app/lp/page.tsx`)
> - Revises Console API docs to `your-mako-instance.com` URLs and examples (`CONSOLE_API_DOCUMENTATION.md`)
> - Renames Inngest client `id`/`name` from `revops-sync`/`RevOps Sync` to `mako-sync`/`Mako Sync` (`api/src/inngest/client.ts`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27d015fc1395555236d9c137d31b37c99af887a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->