### PR TITLE
feat: Implement token usage tracking for chat interactions

### DIFF
--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -323,6 +323,29 @@ export interface IMessagePart {
 }
 
 /**
+ * Usage history entry for tracking token consumption per turn
+ * Useful for metered billing and cost analysis
+ */
+export interface IUsageHistoryEntry {
+  messageIndex: number; // Index of the assistant message this usage corresponds to
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  model?: string; // Model used for this turn (for cost calculation)
+  timestamp: Date;
+}
+
+/**
+ * Chat usage tracking for token consumption
+ */
+export interface IChatUsage {
+  promptTokens: number; // Total prompt tokens across all turns
+  completionTokens: number; // Total completion tokens across all turns
+  totalTokens: number; // Total tokens (prompt + completion)
+  history?: IUsageHistoryEntry[]; // Per-turn usage for detailed analytics
+}
+
+/**
  * Chat model interface
  */
 export interface IChat extends Document {
@@ -352,6 +375,7 @@ export interface IChat extends Document {
   titleGenerated: boolean;
   systemPrompt?: string; // System prompt used for this conversation
   workspacePrompt?: string; // Workspace custom prompt appended to system prompt
+  usage?: IChatUsage; // Token usage tracking for billing
   createdAt: Date;
   updatedAt: Date;
 }
@@ -1021,6 +1045,48 @@ const ChatSchema = new Schema<IChat>(
     workspacePrompt: {
       type: String,
       required: false,
+    },
+    usage: {
+      promptTokens: {
+        type: Number,
+        default: 0,
+      },
+      completionTokens: {
+        type: Number,
+        default: 0,
+      },
+      totalTokens: {
+        type: Number,
+        default: 0,
+      },
+      history: [
+        {
+          messageIndex: {
+            type: Number,
+            required: true,
+          },
+          promptTokens: {
+            type: Number,
+            required: true,
+          },
+          completionTokens: {
+            type: Number,
+            required: true,
+          },
+          totalTokens: {
+            type: Number,
+            required: true,
+          },
+          model: {
+            type: String,
+            required: false,
+          },
+          timestamp: {
+            type: Date,
+            default: Date.now,
+          },
+        },
+      ],
     },
   },
   {

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -347,16 +347,50 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
     // (e.g., Claude claude-3-7-sonnet-20250219, DeepSeek deepseek-r1)
     sendReasoning: true,
     onFinish: async ({ messages: allMessages }) => {
-      console.log("[Agent] Stream finished, saving chat:", {
-        chatId,
-        messageCount: allMessages.length,
-      });
+      // Get usage from the streamText result (not from toUIMessageStreamResponse callback)
+      // result.usage is a promise that resolves when the stream completes
+      let modelUsage: Record<string, unknown> | undefined;
+      try {
+        const usage = await result.usage;
+        modelUsage = usage as unknown as Record<string, unknown>;
+      } catch (err) {
+        console.warn("[Agent] Failed to get usage from model:", err);
+      }
+
+      // Safely extract usage values
+      // Handle different provider naming conventions:
+      // - OpenAI/standard: promptTokens, completionTokens
+      // - Anthropic: may use input_tokens, output_tokens or similar
+      const getNumber = (val: unknown): number => {
+        if (typeof val === "number" && !isNaN(val)) return val;
+        return 0;
+      };
+
+      const promptTokens =
+        getNumber(modelUsage?.promptTokens) ||
+        getNumber(modelUsage?.input_tokens) ||
+        getNumber(modelUsage?.inputTokens) ||
+        0;
+      const completionTokens =
+        getNumber(modelUsage?.completionTokens) ||
+        getNumber(modelUsage?.output_tokens) ||
+        getNumber(modelUsage?.outputTokens) ||
+        0;
+      const totalTokens =
+        getNumber(modelUsage?.totalTokens) ||
+        getNumber(modelUsage?.total_tokens) ||
+        promptTokens + completionTokens;
 
       try {
         // Save all messages in one atomic operation (AI SDK best practice)
         // Title was already generated in parallel at the start for new chats
         // Note: Draft consoles are saved client-side when modified (debounced)
-        await saveChat(chatId, workspaceId, userId.toString(), allMessages);
+        await saveChat(chatId, workspaceId, userId.toString(), allMessages, {
+          promptTokens,
+          completionTokens,
+          totalTokens,
+          model: modelId,
+        });
       } catch (error) {
         console.error("[Agent] Error saving chat:", error);
       }

--- a/api/src/services/agent-thread.service.ts
+++ b/api/src/services/agent-thread.service.ts
@@ -600,37 +600,80 @@ function convertUIMessageToStoredFormat(msg: UIMessage): {
 }
 
 /**
+ * Usage data for token tracking (for metered billing)
+ */
+export interface ChatUsageData {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  model?: string;
+}
+
+/**
  * Save chat using AI SDK best practice: single atomic save at the end.
  * Uses upsert to create or update the chat document.
  *
  * chatId must be a valid 24-character MongoDB ObjectId hex string.
  * The frontend generates this using generateObjectId() utility.
+ *
+ * @param usage - Optional usage data from AI SDK for token tracking
  */
 export const saveChat = async (
   chatId: string,
   workspaceId: string,
   userId: string,
   messages: UIMessage[],
+  usage?: ChatUsageData,
 ): Promise<typeof Chat.prototype | null> => {
   const now = new Date();
   const storedMessages = messages.map(convertUIMessageToStoredFormat);
 
+  // Count assistant messages to determine the message index for usage history
+  const assistantMessageCount = messages.filter(
+    m => m.role === "assistant",
+  ).length;
+
+  // Build the update operation
+  const updateOp: Record<string, unknown> = {
+    $set: {
+      messages: storedMessages,
+      updatedAt: now,
+    },
+    $setOnInsert: {
+      workspaceId: new ObjectId(workspaceId),
+      createdBy: userId,
+      title: "New Chat",
+      titleGenerated: false,
+      threadId: uuidv4(),
+      createdAt: now,
+    },
+  };
+
+  // If usage data is provided, update cumulative totals and append to history
+  if (usage && usage.totalTokens > 0) {
+    // Use $inc for cumulative totals to handle concurrent updates correctly
+    (updateOp as Record<string, Record<string, unknown>>).$inc = {
+      "usage.promptTokens": usage.promptTokens,
+      "usage.completionTokens": usage.completionTokens,
+      "usage.totalTokens": usage.totalTokens,
+    };
+
+    // Append to usage history for per-turn tracking
+    (updateOp as Record<string, Record<string, unknown>>).$push = {
+      "usage.history": {
+        messageIndex: assistantMessageCount - 1, // 0-indexed
+        promptTokens: usage.promptTokens,
+        completionTokens: usage.completionTokens,
+        totalTokens: usage.totalTokens,
+        model: usage.model,
+        timestamp: now,
+      },
+    };
+  }
+
   const result = await Chat.findOneAndUpdate(
     { _id: new ObjectId(chatId) },
-    {
-      $set: {
-        messages: storedMessages,
-        updatedAt: now,
-      },
-      $setOnInsert: {
-        workspaceId: new ObjectId(workspaceId),
-        createdBy: userId,
-        title: "New Chat",
-        titleGenerated: false,
-        threadId: uuidv4(),
-        createdAt: now,
-      },
-    },
+    updateOp,
     { upsert: true, new: true },
   );
 

--- a/docs/vercel-ai-sdk-comparison.md
+++ b/docs/vercel-ai-sdk-comparison.md
@@ -11,13 +11,13 @@ This document provides a comparison between Mako's AI implementation and Vercel'
 | Category | Following Best Practice | Gap/Missing |
 |----------|------------------------|-------------|
 | Core Streaming | 8 | 4 |
-| Data Model | 7 | 4 |
-| Frontend/React | 6 | 8 |
+| Data Model | 8 | 3 |
+| Frontend/React | 7 | 7 |
 | Tools & Agents | 7 | 5 |
 | Providers & Models | 5 | 4 |
 | Error Handling | 3 | 5 |
 | Advanced Patterns | 2 | 9 |
-| **Total** | **38** | **39** |
+| **Total** | **40** | **37** |
 
 ---
 
@@ -54,7 +54,7 @@ This document provides a comparison between Mako's AI implementation and Vercel'
 | Data Model | Message versioning | Track message edits/regenerations | ❌ Missing | No version tracking for edited messages |
 | Data Model | Conversation branching | Support for conversation branches/forks | ❌ Missing | Linear conversation only |
 | Data Model | Attachment storage | Store file attachments with messages | ❌ Missing | No attachment support in schema |
-| Data Model | Usage/token tracking | Store token counts per message | ❌ Missing | Not tracking usage metrics |
+| Data Model | Usage/token tracking | Store token counts per message | ✅ Implemented | Tracking promptTokens, completionTokens, totalTokens with per-turn history |
 
 ### Frontend/React Patterns
 
@@ -66,7 +66,7 @@ This document provides a comparison between Mako's AI implementation and Vercel'
 | Frontend | `onToolCall` callback | Handle client-side tools | ✅ Implemented | 5 client tools: read/modify/create console, list, set_connection |
 | Frontend | `stop()` function | Cancel streaming | ✅ Implemented | Stop button with proper cleanup |
 | Frontend | Message parts rendering | Render different part types | ✅ Implemented | Handling text, tool, reasoning parts |
-| Frontend | `streamdown` package | Optimized markdown streaming | ❌ Missing | Using react-markdown without streaming optimization |
+| Frontend | `streamdown` package | Optimized markdown streaming | ✅ Implemented | Using `streamdown` with `@streamdown/code` in `StreamingMarkdown.tsx` |
 | Frontend | `useCompletion` hook | Simple completion without chat history | ❌ Not needed | N/A - chat-focused use case |
 | Frontend | `useObject` hook | Stream structured objects to UI | ❌ Missing | Not using for schema-validated UI updates |
 | Frontend | `experimental_useAssistant` | OpenAI Assistants API integration | ❌ Missing | Not using OpenAI Assistants |
@@ -141,15 +141,11 @@ This document provides a comparison between Mako's AI implementation and Vercel'
 
 ### High Priority (Significant UX/DX Impact)
 
-1. **`streamdown` package** - Significantly improves markdown rendering during streaming. Current react-markdown flickers/jumps during updates.
+1. **Stream resumption** - Critical for reliability. Users lose context when connection drops.
 
-2. **Reasoning parts display** - You have basic collapsible display, but could use Vercel's recommended progressive disclosure pattern with streaming support.
+2. **Multimodal input** - Image input support is increasingly expected. AI SDK has native support.
 
-3. **Stream resumption** - Critical for reliability. Users lose context when connection drops.
-
-4. **Multimodal input** - Image input support is increasingly expected. AI SDK has native support.
-
-5. **Usage tracking** - Important for cost management and debugging. AI SDK provides usage data in callbacks.
+3. **Reasoning parts display** - You have basic collapsible display, but could use Vercel's recommended progressive disclosure pattern with streaming support.
 
 ### Medium Priority (Better DX/Maintainability)
 
@@ -195,9 +191,7 @@ This document provides a comparison between Mako's AI implementation and Vercel'
 
 2. **Message format** - Now storing native UIMessage parts format with legacy fallback for old chats.
 
-3. **Streaming library** - Switching to streamdown would require updating Chat.tsx markdown rendering.
-
-4. **Provider setup** - Current switch-based approach works but registry would be more extensible.
+3. **Provider setup** - Current switch-based approach works but registry would be more extensible.
 
 ---
 
@@ -220,6 +214,7 @@ This document provides a comparison between Mako's AI implementation and Vercel'
 | `api/src/services/agent-thread.service.ts` | Chat persistence with saveChat (native parts storage) |
 | `api/src/services/title-generator.ts` | AI title generation |
 | `app/src/components/Chat.tsx` | Frontend chat UI with useChat |
+| `app/src/components/StreamingMarkdown.tsx` | Optimized markdown streaming with streamdown |
 | `api/src/database/workspace-schema.ts` | MongoDB schema including Chat model with IMessagePart |
 
 ---


### PR DESCRIPTION
- Added IUsageHistoryEntry and IChatUsage interfaces to track token consumption per chat turn.
- Updated the saveChat function to include usage data, allowing for cumulative token tracking and per-turn history.
- Enhanced agent routes to extract and save token usage from model responses, improving billing and cost analysis capabilities.
- Updated documentation to reflect the implementation of usage tracking metrics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces end-to-end token usage tracking for chat streams, with cumulative totals and per-turn history for billing/analytics.
> 
> - Adds `IUsageHistoryEntry`/`IChatUsage` and persists `usage` in `Chat` schema (`promptTokens`, `completionTokens`, `totalTokens`, `history[]`) in `workspace-schema.ts`
> - Enhances `saveChat()` to accept `usage`, `$inc` cumulative totals, and `$push` per-turn history (with `messageIndex`, `model`, `timestamp`) in `agent-thread.service.ts`
> - Extracts usage from `result.usage` in `agent.routes.ts` (handles provider variants like `input_tokens`/`output_tokens`) and passes it to `saveChat()`
> - Updates `docs/vercel-ai-sdk-comparison.md` to reflect implemented usage tracking and frontend markdown streaming status
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5e774c11cf48adcca5a8baf8511238fdf7d3907. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->