### PR TITLE
feat: Implement re-fetching of missing children for expanded database…

### DIFF
--- a/app/src/components/DatabaseExplorer.tsx
+++ b/app/src/components/DatabaseExplorer.tsx
@@ -168,6 +168,49 @@ function DatabaseExplorer({
     });
   }, [databases, currentWorkspace?.id, treeNodes, fetchDatabaseDataLocal]);
 
+  // Re-fetch children for expanded nodes that lost their data (e.g., after refresh)
+  useEffect(() => {
+    if (!currentWorkspace) return;
+
+    databases.forEach(db => {
+      if (!isDatabaseExpanded(db.id)) return;
+
+      const dbTree = treeNodes[db.id];
+      if (!dbTree) return;
+
+      const rootNodes = dbTree["root"] || [];
+
+      const checkAndFetchMissingChildren = (node: TreeNode) => {
+        const nodeKey = `${db.id}:${node.kind}:${node.id}`;
+        if (!node.hasChildren || !expandedNodes.has(nodeKey)) return;
+
+        const childKey = `${node.kind}:${node.id}`;
+        const children = dbTree[childKey];
+
+        if (!children) {
+          // Expanded node with missing children - fetch them
+          ensureTreeChildren(currentWorkspace.id, db.id, {
+            id: node.id,
+            kind: node.kind,
+            metadata: node.metadata,
+          });
+        } else {
+          // Recurse into existing children
+          children.forEach(checkAndFetchMissingChildren);
+        }
+      };
+
+      rootNodes.forEach(checkAndFetchMissingChildren);
+    });
+  }, [
+    currentWorkspace?.id,
+    databases,
+    treeNodes,
+    expandedNodes,
+    isDatabaseExpanded,
+    ensureTreeChildren,
+  ]);
+
   const handleDatabaseToggle = useCallback(
     (connectionId: string) => {
       toggleDatabase(connectionId);


### PR DESCRIPTION
… nodes

- Added a useEffect hook to re-fetch children for expanded nodes that lost their data after a refresh.
- Introduced logic to check for missing children in the database tree and fetch them as needed, enhancing the DatabaseExplorer's functionality and user experience.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves robustness of the database tree by restoring children for expanded nodes when data is missing (e.g., after refresh).
> 
> - New `useEffect` scans expanded databases and recursively re-fetches missing children via `ensureTreeChildren`
> - Operates only on expanded nodes, using `expandedNodes` and `treeNodes` to avoid unnecessary fetches
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7e848506b12fb0509989ba7ce6e728573737293. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->