### PR TITLE
feat: Add static IP setup and VPC configuration for outbound database…

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -370,6 +370,9 @@ jobs:
             --min-instances=0 \
             --max-instances=2 \
             --allow-unauthenticated \
+            --network=mako-vpc \
+            --subnet=mako-subnet \
+            --vpc-egress=all-traffic \
             --set-env-vars BASE_URL=${BASE_URL} \
             --set-env-vars BCRYPT_ROUNDS=${BCRYPT_ROUNDS} \
             --set-env-vars CLIENT_URL=${CLIENT_URL} \
@@ -663,6 +666,9 @@ jobs:
             --region ${GCP_REGION} \
             --timeout=600 \
             --min-instances=1 \
+            --network=mako-vpc \
+            --subnet=mako-subnet \
+            --vpc-egress=all-traffic \
             --set-env-vars BASE_URL=${BASE_URL} \
             --set-env-vars BCRYPT_ROUNDS=${BCRYPT_ROUNDS} \
             --set-env-vars CLIENT_URL=${CLIENT_URL} \

--- a/README.md
+++ b/README.md
@@ -97,6 +97,16 @@ Mako uses a modern, scalable architecture designed for flexibility and performan
 - **Database**: MongoDB (Metadata & Data Warehouse)
 - **Sync Engine**: Custom incremental sync with atomic collection swaps
 
+## 🌐 IP Whitelisting
+
+If your database requires IP whitelisting, add the following static IP to your allowlist:
+
+```
+34.79.190.46
+```
+
+This IP is used by Mako's cloud service for all outbound database connections.
+
 ## 💻 Development Commands
 
 | Command              | Description                                 |

--- a/deploy.sh
+++ b/deploy.sh
@@ -69,6 +69,49 @@ echo "API startup verification succeeded."
 #   --repository-format=docker \
 #   --location=$REGION
 
+# -------------------------------------------------------------
+# Static Outbound IP Setup (ONE-TIME - already executed)
+# This enables IP whitelisting for external database connections.
+# Static IP: 34.79.190.46
+# -------------------------------------------------------------
+#
+# # 1. Reserve static IP
+# gcloud compute addresses create mako-static-ip \
+#     --region=$REGION \
+#     --project=$PROJECT_ID
+#
+# # 2. Create VPC
+# gcloud compute networks create mako-vpc \
+#     --subnet-mode=custom \
+#     --project=$PROJECT_ID
+#
+# # 3. Create subnet
+# gcloud compute networks subnets create mako-subnet \
+#     --network=mako-vpc \
+#     --region=$REGION \
+#     --range=10.0.0.0/24 \
+#     --project=$PROJECT_ID
+#
+# # 4. Create Cloud Router
+# gcloud compute routers create mako-router \
+#     --network=mako-vpc \
+#     --region=$REGION \
+#     --project=$PROJECT_ID
+#
+# # 5. Create Cloud NAT with static IP
+# gcloud compute routers nats create mako-nat \
+#     --router=mako-router \
+#     --region=$REGION \
+#     --nat-external-ip-pool=mako-static-ip \
+#     --nat-all-subnet-ip-ranges \
+#     --project=$PROJECT_ID
+#
+# # 6. Get the static IP to share with users
+# gcloud compute addresses describe mako-static-ip \
+#     --region=$REGION \
+#     --format="get(address)"
+# -------------------------------------------------------------
+
 # Rebuild and redeploy (explicitly build for linux/amd64 platform)
 echo "Building Docker image..."
 
@@ -119,7 +162,10 @@ gcloud run deploy mako \
   --region $REGION \
   --env-vars-file env.yaml \
   --min-instances=1 \
-  --timeout=600
+  --timeout=600 \
+  --network=mako-vpc \
+  --subnet=mako-subnet \
+  --vpc-egress=all-traffic
 
 # -------------------------------------------------------------
 # Run database migrations

--- a/docs/src/content/docs/databases/connect-databases.md
+++ b/docs/src/content/docs/databases/connect-databases.md
@@ -3,6 +3,16 @@ title: Connect Databases
 description: Learn how to connect your external databases to Mako.
 ---
 
+## IP Whitelisting
+
+If your database requires IP whitelisting, add the following IP address to your allowlist:
+
+```
+34.79.190.46
+```
+
+This is the static outbound IP used by Mako's cloud service for all database connections.
+
 ## MongoDB Atlas
 
 In MongoDB Atlas, when you click "connect" to your data source in your account, the website gives you a string that looks like this:
@@ -14,3 +24,10 @@ In Mako, you actually need to paste this URL:
 `mongodb+srv://<db_username>:<db_password>@<cluster_name>.<server_name>.mongodb.net/<cluster_name>`
 
 (notice the query param vs the segment)
+
+### IP Whitelisting in Atlas
+
+1. Go to **Network Access** in your MongoDB Atlas project
+2. Click **Add IP Address**
+3. Enter `34.79.190.46`
+4. Click **Confirm**


### PR DESCRIPTION
… connections

- Introduced a one-time static IP setup for IP whitelisting, including steps to reserve a static IP, create a VPC, subnet, Cloud Router, and Cloud NAT.
- Updated deployment scripts and workflows to utilize the new VPC and subnet for outbound traffic.
- Documented the static IP address for database connection whitelisting in README and connection documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces VPC networking for Cloud Run to ensure a static outbound IP for database connections.
> 
> - Updates Cloud Run deploys in `.github/workflows/deploy-app.yml` and `deploy.sh` to use `--network=mako-vpc`, `--subnet=mako-subnet`, and `--vpc-egress=all-traffic`
> - Adds one-time infra setup (commented) in `deploy.sh` for static IP + VPC/NAT (address, VPC, subnet, router, NAT)
> - Documents static IP `34.79.190.46` and whitelisting steps in `README.md` and `docs/databases/connect-databases.md` (including MongoDB Atlas instructions)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0aea1471a0d8abf2f6c776c356d881d7a2d5bf08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->