### PR TITLE
feat: Enhance PostgreSQL connection management with pooling

### DIFF
--- a/api/src/services/database-connection.service.ts
+++ b/api/src/services/database-connection.service.ts
@@ -2303,7 +2303,10 @@ export class DatabaseConnectionService {
     database: IDatabaseConnection,
     targetDatabase?: string,
   ): Promise<PgPool> {
-    const dbName = targetDatabase || database.connection.database || "default";
+    // Use empty string when no database specified to avoid collision with a database literally named "default".
+    // Empty string is not a valid PostgreSQL database name (must start with letter or underscore),
+    // so there's no risk of collision with an actual database name.
+    const dbName = targetDatabase || database.connection.database || "";
     const key = `${database._id.toString()}:${dbName}`;
 
     const existing = this.postgresPools.get(key);
@@ -2335,8 +2338,13 @@ export class DatabaseConnectionService {
     // Handle pool errors to prevent crashes and clean up stale pools
     pool.on("error", err => {
       logger.error("PostgreSQL pool error", { key, error: err.message });
-      // Close the pool and remove it so it gets recreated on next use
-      this.postgresPools.delete(key);
+      // Only remove from map if this is still the active pool for this key.
+      // If this pool was already replaced (e.g., by cleanup + new request),
+      // unconditionally deleting would orphan the new pool and leak connections.
+      const entry = this.postgresPools.get(key);
+      if (entry?.pool === pool) {
+        this.postgresPools.delete(key);
+      }
       pool.end().catch(endErr => {
         logger.error("Error closing PostgreSQL pool after error", {
           key,


### PR DESCRIPTION
- Implemented dedicated connection pooling for PostgreSQL to optimize resource usage and improve performance.
- Added methods for creating, closing, and managing PostgreSQL connection pools.
- Updated existing database connection logic to utilize the new pooling mechanism, ensuring efficient handling of concurrent connections.
- Enhanced error handling for PostgreSQL pools to prevent crashes and manage stale connections effectively.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces dedicated PostgreSQL `PgPool` management with lazy init, per-db pooling, and periodic idle cleanup.
> 
> - Adds `postgresPools` with `getPostgresPool`, `closePostgresPool`, `closeAllPostgresPools`, and `cleanupIdlePostgresPools`; integrates into constructor cleanup loop and `closeConnection`/`closeAllConnections`
> - Refactors PostgreSQL execution to use pool clients with retry on `pool.connect`; tracks PIDs for cancellation and ensures client release
> - Updates `cancelPostgresQuery` to use a dedicated non-pooled client to avoid deadlocks; renames `buildPostgreSQLClientConfig` → `buildPostgreSQLConfig`
> - Optimizes default MongoDB options for serverless and improves idle-close logic with race-condition rechecks
> - Minor logging/formatting adjustments across methods
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4dbd62591351984c8e066a708da20e06e64d9a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->