### PR TITLE
feat: Add isDirty property to console modifications for better state …

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -23,7 +23,7 @@ import { AuthWrapper } from "./components/AuthWrapper";
 import { AcceptInvite } from "./components/AcceptInvite";
 import { WorkspaceProvider } from "./contexts/workspace-context";
 import { OnboardingProvider } from "./contexts/onboarding-context";
-import { ConsoleModification } from "./hooks/useMonacoConsole";
+import { ConsoleModificationPayload } from "./hooks/useMonacoConsole";
 import { generateObjectId } from "./utils/objectId";
 import { LoginPage } from "./components/LoginPage";
 import { RegisterPage } from "./components/RegisterPage";
@@ -68,14 +68,7 @@ function MainApp() {
 
   // Handle console modification from AI
   const handleConsoleModification = async (
-    modification: ConsoleModification & {
-      consoleId?: string;
-      title?: string;
-      connectionId?: string;
-      databaseId?: string;
-      databaseName?: string;
-      isDirty?: boolean;
-    },
+    modification: ConsoleModificationPayload,
   ) => {
     // handleConsoleModification called
 

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -54,7 +54,10 @@ import { useSettingsStore } from "../store/settingsStore";
 import { useSchemaStore } from "../store/schemaStore";
 import { ModelSelector } from "./ModelSelector";
 import { generateObjectId } from "../utils/objectId";
-import { ConsoleModification } from "../hooks/useMonacoConsole";
+import {
+  ConsoleModification,
+  ConsoleModificationPayload,
+} from "../hooks/useMonacoConsole";
 import { applyModification } from "../utils/consoleModification";
 import { trackEvent } from "../lib/analytics";
 
@@ -399,16 +402,6 @@ const StreamingIndicator = React.memo(() => {
 });
 
 StreamingIndicator.displayName = "StreamingIndicator";
-
-// Extended ConsoleModification with fields for console creation
-type ConsoleModificationPayload = ConsoleModification & {
-  consoleId?: string;
-  title?: string;
-  connectionId?: string;
-  databaseId?: string;
-  databaseName?: string;
-  isDirty?: boolean;
-};
 
 interface ChatProps {
   onConsoleModification?: (modification: ConsoleModificationPayload) => void;

--- a/app/src/hooks/useMonacoConsole.ts
+++ b/app/src/hooks/useMonacoConsole.ts
@@ -12,6 +12,16 @@ export interface ConsoleModification {
   endLine?: number;
 }
 
+// Extended ConsoleModification with fields for console creation/modification handlers
+export type ConsoleModificationPayload = ConsoleModification & {
+  consoleId?: string;
+  title?: string;
+  connectionId?: string;
+  databaseId?: string;
+  databaseName?: string;
+  isDirty?: boolean;
+};
+
 interface UseMonacoConsoleOptions {
   consoleId: string;
   onContentChange?: (content: string) => void;


### PR DESCRIPTION
…management

- Introduced isDirty property in ConsoleModificationPayload to track the dirty state of consoles.
- Updated MainApp and Chat components to set isDirty appropriately, ensuring agent-created consoles are marked as dirty by default.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces dirty-state tracking for AI-created consoles and consolidates console modification typing.
> 
> - Exports `ConsoleModificationPayload` from `useMonacoConsole` with optional `consoleId`, `title`, connection/db fields, and new `isDirty` flag
> - Updates `App.tsx` and `Chat.tsx` to use `ConsoleModificationPayload`; removes the duplicate local type in `Chat`
> - Marks newly created consoles via AI as dirty by default: `Chat` passes `isDirty: true` in `create_console`; `App` sets `isDirty: modification.isDirty ?? true` when opening tabs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3113ae7c40dd58780954dbc9c1de84c269dae57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->