### PR TITLE
Add Claude Code GitHub Actions workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: "--model claude-sonnet-4-20250514"
-          allowed_bots: "*"
+          allowed_bots: "dependabot[bot],renovate[bot]"
 
   auto-review:
     if: |
@@ -59,7 +59,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: "--model claude-sonnet-4-20250514"
-          allowed_bots: "*"
+          allowed_bots: "dependabot[bot],renovate[bot]"
           prompt: |
             Review this PR for:
             1. TypeScript type safety and correctness


### PR DESCRIPTION
- Add claude job: responds to @claude mentions in issues, PR comments, and PR reviews
- Add auto-review job: automatically reviews non-draft PRs for TypeScript, Hono, MongoDB, AI SDK, React, and security patterns
- Uses anthropics/claude-code-action@v1 with claude-sonnet-4-20250514

Closes #100

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new CI automation with elevated `contents`/PR write permissions and access to `ANTHROPIC_API_KEY`, which could impact repo integrity if misconfigured. Functionality is isolated to a single workflow file, limiting blast radius.
> 
> **Overview**
> Adds a new `.github/workflows/claude.yml` workflow that triggers `anthropics/claude-code-action@v1` when users mention `@claude` in issues/PR comments/reviews, granting write permissions to respond and (if needed) push changes.
> 
> Also introduces an `auto-review` job that runs on non-draft PR events and posts an automated review using a predefined checklist (TypeScript, Hono, MongoDB, AI SDK, React, security), with concurrency controls and the `ANTHROPIC_API_KEY` secret.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27e85a3f55358765de09721de2a0503bf89a3678. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->