### PR TITLE
Update Claude model and allowed bots in workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -58,8 +58,8 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--model claude-sonnet-4-20250514"
-          allowed_bots: "dependabot[bot],renovate[bot]"
+          claude_args: "--model claude-opus-4-6"
+          allowed_bots: "*"
           prompt: |
             Review this PR for:
             1. TypeScript type safety and correctness


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> CI-only change, but broadening `allowed_bots` to `*` increases exposure to automated/comment-based triggering and could lead to unintended runs or higher usage.
> 
> **Overview**
> Updates the GitHub Actions `Claude Code` workflow to run the `anthropics/claude-code-action` with the `claude-opus-4-6` model and allows the action to respond to comments from *any* bot account (instead of only Dependabot/Renovate).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 160ddba114c7e0c27d673cd6d5395b47fb910d06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->