### PR TITLE
Fix fork PR handling and upgrade to Claude Opus 4.6

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,11 +32,33 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Mirror fork branch to origin (workaround for claude-code-action fork bug)
+        if: |
+          github.event_name == 'issue_comment' ||
+          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER="${{ github.event.issue.number || github.event.pull_request.number }}"
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No PR number found, skipping fork mirror"
+            exit 0
+          fi
+          PR_DATA=$(gh pr view "$PR_NUMBER" --json headRepositoryOwner,headRepository,headRefName,isCrossRepository 2>/dev/null || true)
+          IS_FORK=$(echo "$PR_DATA" | jq -r '.isCrossRepository // false')
+          BRANCH_NAME=$(echo "$PR_DATA" | jq -r '.headRefName // empty')
+          if [ "$IS_FORK" = "true" ] && [ -n "$BRANCH_NAME" ]; then
+            echo "PR #$PR_NUMBER is from a fork. Mirroring branch '$BRANCH_NAME' to origin..."
+            git fetch origin "pull/$PR_NUMBER/head:$BRANCH_NAME"
+            git push origin "$BRANCH_NAME" || echo "Branch may already exist on origin, continuing..."
+          else
+            echo "PR #$PR_NUMBER is not from a fork or couldn't determine. Skipping mirror."
+          fi
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--model claude-sonnet-4-20250514"
-          allowed_bots: "dependabot[bot],renovate[bot]"
+          claude_args: "--model claude-opus-4-6"
+          allowed_bots: "*"
 
   auto-review:
     if: |
@@ -47,7 +69,7 @@ jobs:
       group: ${{ github.workflow }}-auto-review-${{ github.event.pull_request.head.ref }}
       cancel-in-progress: true
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
       id-token: write
@@ -55,6 +77,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Mirror fork branch to origin (workaround for claude-code-action fork bug)
+        if: github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          echo "PR #$PR_NUMBER is from a fork. Mirroring branch '$BRANCH_NAME' to origin..."
+          git fetch origin "pull/$PR_NUMBER/head:$BRANCH_NAME"
+          git push origin "$BRANCH_NAME" || echo "Branch may already exist on origin, continuing..."
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -62,10 +94,10 @@ jobs:
           allowed_bots: "*"
           prompt: |
             Review this PR for:
-            1. TypeScript type safety and correctness
-            2. Hono route patterns, middleware, and error handling
-            3. MongoDB schema changes and query patterns
-            4. AI SDK usage (model routing, streaming, tool calls)
-            5. React component patterns (MUI, state management, hooks)
-            6. Security (no leaked secrets, proper auth checks, input validation)
-            7. Anything that could break the app in production
+            a. TypeScript type safety and correctness
+            b. Hono route patterns, middleware, and error handling
+            c. MongoDB schema changes and query patterns
+            d. AI SDK usage (model routing, streaming, tool calls)
+            e. React component patterns (MUI, state management, hooks)
+            f. Security (no leaked secrets, proper auth checks, input validation)
+            g. Anything that could break the app in production


### PR DESCRIPTION
- Add 'Mirror fork branch to origin' step in both claude and auto-review jobs to work around claude-code-action fork bug (anthropics/claude-code-action#730)
- Upgrade model from claude-sonnet-4-20250514 to claude-opus-4-6
- Change allowed_bots from specific list to '*' (all bots)
- Change auto-review permissions from contents: read to contents: write (needed to push mirrored fork branches)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Workflow now pushes mirrored branches to `origin` and broadens bot triggering, increasing the blast radius if the job is abused or misconfigured despite being limited to GitHub Actions context.
> 
> **Overview**
> Updates the `Claude Code` GitHub Actions workflow to **work around fork-PR limitations** by mirroring fork PR branches into the base repo before running `anthropics/claude-code-action` (added to both the ad-hoc `claude` job and the `auto-review` job).
> 
> Switches the Claude model from `claude-sonnet-4-20250514` to `claude-opus-4-6`, relaxes `allowed_bots` to `*`, and elevates `auto-review` permissions from `contents: read` to `contents: write` to allow the new mirroring step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 056fcce73302766954ec3a6b94638b6e106700fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->