### PR TITLE
feat: enable API key auth for Chat API endpoint

### DIFF
--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -96,10 +96,21 @@ function getModelInstance(modelId?: string): LanguageModel {
  */
 agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
   const user = c.get("user");
-  const userId = user?.id;
+  const workspace = c.get("workspace");
+  const apiKey = c.get("apiKey");
 
-  if (!userId) {
-    return c.json({ error: "User not authenticated" }, 401);
+  // Allow both session auth (user) and API key auth (workspace)
+  // Actor ID: user ID for session, API key creator for programmatic access
+  // (chats appear in creator's history when they log in)
+  const actorId =
+    user?.id ??
+    (apiKey?.createdBy
+      ? String(apiKey.createdBy)
+      : workspace
+        ? "api-key"
+        : undefined);
+  if (!actorId) {
+    return c.json({ error: "Unauthorized" }, 401);
   }
 
   let body: Record<string, unknown> = {};
@@ -163,7 +174,6 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
   }
 
   // Verify workspace access
-  const workspace = c.get("workspace");
   if (workspace) {
     // For API key auth, verify the body workspace matches the API key's workspace
     if (workspace._id.toString() !== workspaceId) {
@@ -172,9 +182,9 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
         403,
       );
     }
-  } else if (userId) {
+  } else if (user) {
     // For session auth, verify user has access to this workspace
-    const hasAccess = await workspaceService.hasAccess(workspaceId, userId);
+    const hasAccess = await workspaceService.hasAccess(workspaceId, user.id);
     if (!hasAccess) {
       return c.json({ error: "Access denied to workspace" }, 403);
     }
@@ -205,7 +215,7 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
     await Chat.create({
       _id: new ObjectId(chatId),
       workspaceId: new ObjectId(workspaceId),
-      createdBy: userId.toString(),
+      createdBy: actorId,
       title: "New Chat",
       titleGenerated: false,
       messages: [],
@@ -288,7 +298,7 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
   // Build agent context
   const agentContext: AgentContext = {
     workspaceId,
-    userId: userId.toString(),
+    userId: actorId,
     consoles: enrichedConsoles,
     consoleId,
     databases: workspaceDatabases.map(db => ({
@@ -411,7 +421,7 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
         // Save all messages in one atomic operation (AI SDK best practice)
         // Title was already generated in parallel at the start for new chats
         // Note: Draft consoles are saved client-side when modified (debounced)
-        await saveChat(chatId, workspaceId, userId.toString(), allMessages, {
+        await saveChat(chatId, workspaceId, actorId, allMessages, {
           promptTokens,
           completionTokens,
           totalTokens,

--- a/docs/src/content/docs/api-reference.md
+++ b/docs/src/content/docs/api-reference.md
@@ -33,10 +33,106 @@ The Mako API is a RESTful API built with Hono. All endpoints are prefixed with `
 
 ## Query Execution
 
-| Method | Endpoint       | Description                 |
-| :----- | :------------- | :-------------------------- |
-| `POST` | `/api/execute` | Execute a SQL/NoSQL query   |
-| `POST` | `/api/agent`   | Ask the AI agent a question |
+| Method | Endpoint       | Description               |
+| :----- | :------------- | :------------------------ |
+| `POST` | `/api/execute` | Execute a SQL/NoSQL query |
+
+## AI Agent / Chat API
+
+The Chat API enables programmatic access to Mako's AI agent. It supports both session-based and API key authentication.
+
+| Method | Endpoint           | Description                                    |
+| :----- | :----------------- | :--------------------------------------------- |
+| `POST` | `/api/agent/chat`  | Send messages and receive streaming AI response |
+| `GET`  | `/api/agent/models` | List available AI models                       |
+| `GET`  | `/api/agent/agents` | List available agent modes                     |
+
+### Authentication
+
+Use an API key in the `Authorization` header:
+
+```
+Authorization: Bearer revops_YOUR_API_KEY
+```
+
+API keys are created in Settings → API Keys. Each key is scoped to a workspace. Chats created via API key are attributed to the key's creator, so they appear in the creator's chat history.
+
+### Request Body (`POST /api/agent/chat`)
+
+| Field          | Type             | Required | Description                                                              |
+| :------------- | :--------------- | :------- | :----------------------------------------------------------------------- |
+| `messages`     | `UIMessage[]`    | Yes      | Array of messages. Each has `id`, `role`, and `parts`.                   |
+| `chatId`       | `string`         | Yes      | 24-char MongoDB ObjectId. New ID for new chats; reuse for follow-ups.    |
+| `workspaceId`  | `string`         | Yes      | 24-char MongoDB ObjectId. Must match the API key's workspace.            |
+| `modelId`      | `string`         | No       | Model ID (e.g. `gpt-5.2`, `gemini-2.5-flash`). Default: `gpt-5.2`.     |
+| `openConsoles` | `object[]`       | No       | Console context for SQL tools.                                           |
+| `consoleId`    | `string`         | No       | Active console ID.                                                       |
+| `agentId`      | `string`         | No       | Agent mode: `console` (default) or `flow`.                               |
+
+### Message Format
+
+```json
+{
+  "id": "unique-id",
+  "role": "user",
+  "parts": [{ "type": "text", "text": "Your message here" }]
+}
+```
+
+### Example Request
+
+```bash
+curl -X POST https://your-mako.com/api/agent/chat \
+  -H "Authorization: Bearer revops_YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [{
+      "id": "1",
+      "role": "user",
+      "parts": [{ "type": "text", "text": "Show top 5 customers" }]
+    }],
+    "chatId": "507f1f77bcf86cd799439011",
+    "workspaceId": "YOUR_WORKSPACE_ID",
+    "modelId": "gemini-2.5-flash"
+  }'
+```
+
+### Response Format
+
+The response is a **streaming SSE** (Server-Sent Events) stream. Key event types:
+
+| Event Type             | Description                                          |
+| :--------------------- | :--------------------------------------------------- |
+| `start`               | Stream started. Contains `messageId`.                 |
+| `text-delta`          | Incremental text chunk from the assistant.            |
+| `tool-input-available` | Tool call with full input (e.g. SQL query).          |
+| `tool-result`         | Tool execution result (e.g. query results).           |
+| `finish`              | Stream finished. Contains `finishReason`.             |
+
+### Error Codes
+
+| Status | Description                                     |
+| :----- | :---------------------------------------------- |
+| 400    | Missing or invalid `messages`, `chatId`, or `workspaceId`. |
+| 401    | Unauthorized (missing or invalid API key).      |
+| 403    | API key not authorized for the workspace.       |
+| 404    | Agent not found (invalid `agentId`).            |
+
+For full details, see [CHAT_API_REFERENCE.md](/docs/CHAT_API_REFERENCE.md).
+
+## Chat History
+
+| Method   | Endpoint                              | Description        |
+| :------- | :------------------------------------ | :----------------- |
+| `GET`    | `/api/workspaces/:wid/chats`          | List chat sessions |
+| `POST`   | `/api/workspaces/:wid/chats`          | Create a new chat  |
+| `GET`    | `/api/workspaces/:wid/chats/:id`      | Get chat details   |
+| `PUT`    | `/api/workspaces/:wid/chats/:id`      | Update chat title  |
+| `DELETE` | `/api/workspaces/:wid/chats/:id`      | Delete a chat      |
+
+## Console API
+
+For executing saved consoles programmatically, see [CONSOLE_API_DOCUMENTATION.md](/CONSOLE_API_DOCUMENTATION.md).
 
 ## Inngest
 


### PR DESCRIPTION
## Summary

Enables the Chat API (`POST /api/agent/chat`) to accept API key authentication for programmatic access.

## Problem

The chat endpoint previously required a `userId` from session auth. API key authentication only sets `workspace`, not `user`, so requests using API keys were rejected with 401 Unauthorized.

## Solution

- Allow both session auth (user) and API key auth (workspace)
- Use the **API key creator's user ID** as the actor for chat creation and persistence
- Chats created via API key now appear in the creator's chat history when they log in
- Fallback to `"api-key"` for legacy keys without `createdBy`

## Changes

- **api/src/routes/agent.routes.ts**: Resolve `actorId` from `user.id`, `apiKey.createdBy`, or `"api-key"` fallback
- **docs/src/content/docs/api-reference.md**: Add Chat API section with endpoints, auth, payload fields, response format, and error codes

## Testing

```bash
curl -X POST https://your-mako.com/api/agent/chat \
  -H "Authorization: Bearer revops_YOUR_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "messages": [{"id": "1", "role": "user", "parts": [{"type": "text", "text": "Hello"}]}],
    "chatId": "507f1f77bcf86cd799439011",
    "workspaceId": "YOUR_WORKSPACE_ID"
  }'
```

Made with [Cursor](https://cursor.com)