### PR TITLE
feat: database visibility and permissions model

### DIFF
--- a/api/src/agent-lib/tools/mongodb-tools.ts
+++ b/api/src/agent-lib/tools/mongodb-tools.ts
@@ -8,6 +8,10 @@ import { Types } from "mongoose";
 import { DatabaseConnection } from "../../database/workspace-schema";
 import { databaseConnectionService } from "../../services/database-connection.service";
 import { queryExecutionService } from "../../services/query-execution.service";
+import {
+  canUserSeeDatabase,
+  checkQueryAccess,
+} from "../../services/database-access.service";
 import type { ConsoleDataV2 } from "../types";
 import { clientConsoleTools } from "./console-tools-client";
 import {
@@ -39,7 +43,7 @@ const executeQuerySchema = z.object({
 });
 
 // Helper implementations
-async function listMongoConnectionsImpl(workspaceId: string) {
+async function listMongoConnectionsImpl(workspaceId: string, userId?: string) {
   if (!Types.ObjectId.isValid(workspaceId)) {
     throw new Error("Invalid workspace ID");
   }
@@ -48,7 +52,7 @@ async function listMongoConnectionsImpl(workspaceId: string) {
   }).sort({ name: 1 });
 
   return databases
-    .filter(db => db.type === "mongodb")
+    .filter(db => db.type === "mongodb" && canUserSeeDatabase(db, userId))
     .map(db => ({
       id: db._id.toString(),
       name: db.name,
@@ -225,6 +229,11 @@ async function executeQueryImpl(
   });
   if (!database) throw new Error("Connection not found or access denied");
 
+  const accessCheck = checkQueryAccess(database, userId, query);
+  if (!accessCheck.allowed) {
+    throw new Error(accessCheck.error);
+  }
+
   const result = await databaseConnectionService.executeQuery(
     database as Parameters<typeof databaseConnectionService.executeQuery>[0],
     query,
@@ -318,7 +327,7 @@ export const createMongoToolsV2 = (
       description:
         "List all MongoDB connections available in this workspace. Returns connection ID, name, and database name.",
       inputSchema: emptySchema,
-      execute: async () => listMongoConnectionsImpl(workspaceId),
+      execute: async () => listMongoConnectionsImpl(workspaceId, userId),
     },
 
     list_databases: {

--- a/api/src/agent-lib/tools/sql-tools.ts
+++ b/api/src/agent-lib/tools/sql-tools.ts
@@ -142,10 +142,15 @@ async function listSqlConnectionsImpl(workspaceId: string, userId?: string) {
         displayInfo = dbId || "main";
       }
 
-      const access = db.access || "shared_write";
+      const access = db.access || "shared";
+      const permissions = db.permissions || "read_write";
       const isOwner = !!userId && db.ownerId === userId;
       const accessLabel =
-        access === "shared_read" && !isOwner ? " [read-only]" : "";
+        access === "private"
+          ? " [private]"
+          : permissions === "read_only" && !isOwner
+            ? " [read-only]"
+            : "";
 
       return {
         id: db._id.toString(),
@@ -875,7 +880,7 @@ export const createSqlToolsV2 = (
 
     sql_execute_query: {
       description:
-        "Execute a SQL query and return results. LIMIT 500 is automatically added to SELECT queries if missing. Use sqlDialect from previous tool calls to write correct syntax. For shared_read connections, only SELECT/WITH/EXPLAIN (without ANALYZE) are allowed. IMPORTANT for Cloudflare D1: use the UUID from sql_list_databases 'id' field as the database parameter.",
+        "Execute a SQL query and return results. LIMIT 500 is automatically added to SELECT queries if missing. Use sqlDialect from previous tool calls to write correct syntax. IMPORTANT for Cloudflare D1: use the UUID from sql_list_databases 'id' field as the database parameter.",
       inputSchema: executeQuerySchema,
       execute: async (params: {
         connectionId: string;

--- a/api/src/agent-lib/tools/sql-tools.ts
+++ b/api/src/agent-lib/tools/sql-tools.ts
@@ -6,6 +6,10 @@
 import { z } from "zod";
 import { DatabaseConnection } from "../../database/workspace-schema";
 import { databaseConnectionService } from "../../services/database-connection.service";
+import {
+  canUserSeeDatabase,
+  checkQueryAccess,
+} from "../../services/database-access.service";
 import type { ConsoleDataV2 } from "../types";
 import { clientConsoleTools } from "./console-tools-client";
 import {
@@ -105,7 +109,7 @@ const executeQuerySchema = z.object({
 // ============================================================================
 // sql_list_connections
 // ============================================================================
-async function listSqlConnectionsImpl(workspaceId: string) {
+async function listSqlConnectionsImpl(workspaceId: string, userId?: string) {
   const workspaceObjectId = ensureValidObjectId(workspaceId, "workspaceId");
 
   const databases = await DatabaseConnection.find({
@@ -113,38 +117,46 @@ async function listSqlConnectionsImpl(workspaceId: string) {
     type: { $in: Array.from(ALL_SQL_TYPES) },
   }).sort({ name: 1 });
 
-  return databases.map(db => {
-    const connection: Record<string, unknown> =
-      (db as unknown as { connection: Record<string, unknown> }).connection ||
-      {};
-    const dialect = getDialect(db.type);
+  return databases
+    .filter(db => canUserSeeDatabase(db, userId))
+    .map(db => {
+      const connection: Record<string, unknown> =
+        (db as unknown as { connection: Record<string, unknown> }).connection ||
+        {};
+      const dialect = getDialect(db.type);
 
-    let displayInfo: string;
-    if (dialect === "postgresql" || dialect === "mysql") {
-      const host = (connection.host || connection.instanceConnectionName) as
-        | string
-        | undefined;
-      const dbName = (connection.database || connection.db) as
-        | string
-        | undefined;
-      displayInfo = `${host || "unknown-host"}/${dbName || "unknown-db"}`;
-    } else if (dialect === "bigquery") {
-      displayInfo = (connection.project_id as string) || "unknown-project";
-    } else {
-      // SQLite/D1
-      const dbId = connection.database_id as string | undefined;
-      displayInfo = dbId || "main";
-    }
+      let displayInfo: string;
+      if (dialect === "postgresql" || dialect === "mysql") {
+        const host = (connection.host || connection.instanceConnectionName) as
+          | string
+          | undefined;
+        const dbName = (connection.database || connection.db) as
+          | string
+          | undefined;
+        displayInfo = `${host || "unknown-host"}/${dbName || "unknown-db"}`;
+      } else if (dialect === "bigquery") {
+        displayInfo = (connection.project_id as string) || "unknown-project";
+      } else {
+        // SQLite/D1
+        const dbId = connection.database_id as string | undefined;
+        displayInfo = dbId || "main";
+      }
 
-    return {
-      id: db._id.toString(),
-      name: db.name,
-      type: db.type,
-      sqlDialect: dialect,
-      displayName: `${db.name} (${dialect}: ${displayInfo})`,
-      active: true,
-    };
-  });
+      const access = db.access || "shared_write";
+      const isOwner = !!userId && db.ownerId === userId;
+      const accessLabel =
+        access === "shared_read" && !isOwner ? " [read-only]" : "";
+
+      return {
+        id: db._id.toString(),
+        name: db.name,
+        type: db.type,
+        sqlDialect: dialect,
+        displayName: `${db.name} (${dialect}: ${displayInfo})${accessLabel}`,
+        access,
+        active: true,
+      };
+    });
 }
 
 // ============================================================================
@@ -768,6 +780,7 @@ async function executeQueryImpl(
   databaseName: string,
   query: string,
   workspaceId: string,
+  userId?: string,
 ) {
   if (!databaseName) {
     throw new Error("'database' is required");
@@ -777,6 +790,12 @@ async function executeQueryImpl(
   }
 
   const database = await fetchSqlDatabase(connectionId, workspaceId);
+
+  const accessCheck = checkQueryAccess(database, userId, query);
+  if (!accessCheck.allowed) {
+    throw new Error(accessCheck.error);
+  }
+
   const dialect = getDialect(database.type);
   const safeQuery = appendLimitIfMissing(query);
 
@@ -809,15 +828,16 @@ export const createSqlToolsV2 = (
   workspaceId: string,
   _consoles: ConsoleDataV2[],
   _preferredConsoleId?: string,
+  userId?: string,
 ) => {
   return {
     ...clientConsoleTools,
 
     sql_list_connections: {
       description:
-        "List all SQL database connections (PostgreSQL, MySQL, BigQuery, SQLite, Cloudflare D1) in this workspace. Returns connection ID, name, type, and sqlDialect.",
+        "List all SQL database connections (PostgreSQL, MySQL, BigQuery, SQLite, Cloudflare D1) in this workspace. Returns connection ID, name, type, sqlDialect, and access level. Connections marked [read-only] only allow SELECT/WITH/EXPLAIN queries.",
       inputSchema: emptySchema,
-      execute: async () => listSqlConnectionsImpl(workspaceId),
+      execute: async () => listSqlConnectionsImpl(workspaceId, userId),
     },
 
     sql_list_databases: {
@@ -855,7 +875,7 @@ export const createSqlToolsV2 = (
 
     sql_execute_query: {
       description:
-        "Execute a SQL query and return results. LIMIT 500 is automatically added to SELECT queries if missing. Use sqlDialect from previous tool calls to write correct syntax. IMPORTANT for Cloudflare D1: use the UUID from sql_list_databases 'id' field as the database parameter.",
+        "Execute a SQL query and return results. LIMIT 500 is automatically added to SELECT queries if missing. Use sqlDialect from previous tool calls to write correct syntax. For shared_read connections, only SELECT/WITH/EXPLAIN (without ANALYZE) are allowed. IMPORTANT for Cloudflare D1: use the UUID from sql_list_databases 'id' field as the database parameter.",
       inputSchema: executeQuerySchema,
       execute: async (params: {
         connectionId: string;
@@ -867,6 +887,7 @@ export const createSqlToolsV2 = (
           params.database,
           params.query,
           workspaceId,
+          userId,
         ),
     },
   };

--- a/api/src/agent-lib/tools/universal-tools.ts
+++ b/api/src/agent-lib/tools/universal-tools.ts
@@ -14,6 +14,7 @@ import { clientConsoleTools } from "./console-tools-client";
 import { clientChartTools } from "./chart-tools-client";
 import { createMongoToolsV2 } from "./mongodb-tools";
 import { createSqlToolsV2 } from "./sql-tools";
+import { canUserSeeDatabase } from "../../services/database-access.service";
 
 const emptySchema = z.object({});
 
@@ -31,7 +32,7 @@ const SUPPORTED_CONNECTION_TYPES = new Set([
   "cloudflare-d1",
 ]);
 
-async function listAllConnectionsImpl(workspaceId: string) {
+async function listAllConnectionsImpl(workspaceId: string, userId?: string) {
   if (!Types.ObjectId.isValid(workspaceId)) {
     throw new Error("Invalid workspace ID");
   }
@@ -41,84 +42,86 @@ async function listAllConnectionsImpl(workspaceId: string) {
     type: { $in: Array.from(SUPPORTED_CONNECTION_TYPES) },
   }).sort({ name: 1 });
 
-  return databases.map(db => {
-    const connection: Record<string, unknown> =
-      (db as unknown as { connection: Record<string, unknown> }).connection ||
-      {};
+  return databases
+    .filter(db => canUserSeeDatabase(db, userId))
+    .map(db => {
+      const connection: Record<string, unknown> =
+        (db as unknown as { connection: Record<string, unknown> }).connection ||
+        {};
 
-    if (db.type === "mongodb") {
-      const databaseName = (connection.database as string) || undefined;
-      const displayInfo = databaseName || "Unknown Database";
+      if (db.type === "mongodb") {
+        const databaseName = (connection.database as string) || undefined;
+        const displayInfo = databaseName || "Unknown Database";
+        return {
+          id: db._id.toString(),
+          name: db.name,
+          type: db.type,
+          databaseName,
+          displayName: `${db.name} (mongodb: ${displayInfo})`,
+          active: true,
+        };
+      }
+
+      if (db.type === "bigquery") {
+        const project = (connection.project_id as string) || undefined;
+        const displayInfo = project || "Unknown Project";
+        return {
+          id: db._id.toString(),
+          name: db.name,
+          type: db.type,
+          sqlDialect: "bigquery",
+          project,
+          displayName: `${db.name} (bigquery: ${displayInfo})`,
+          active: true,
+        };
+      }
+
+      if (
+        db.type === "postgresql" ||
+        db.type === "redshift" ||
+        db.type === "cloudsql-postgres"
+      ) {
+        const host = (connection.host || connection.instanceConnectionName) as
+          | string
+          | undefined;
+        const databaseName = (connection.database || connection.db) as
+          | string
+          | undefined;
+        const displayInfo = `${host || "unknown-host"}/${databaseName || "unknown-db"}`;
+        return {
+          id: db._id.toString(),
+          name: db.name,
+          type: db.type,
+          sqlDialect: "postgresql",
+          host,
+          databaseName,
+          displayName: `${db.name} (postgresql: ${displayInfo})`,
+          active: true,
+        };
+      }
+
+      if (db.type === "sqlite" || db.type === "cloudflare-d1") {
+        const databaseId = (connection.database_id as string) || "main";
+        return {
+          id: db._id.toString(),
+          name: db.name,
+          type: db.type,
+          sqlDialect: "sqlite",
+          databaseId,
+          displayName: `${db.name} (sqlite: ${databaseId})`,
+          active: true,
+        };
+      }
+
+      // Fallback for any new types
       return {
         id: db._id.toString(),
         name: db.name,
         type: db.type,
-        databaseName,
-        displayName: `${db.name} (mongodb: ${displayInfo})`,
+        displayName: `${db.name} (${db.type})`,
         active: true,
       };
-    }
-
-    if (db.type === "bigquery") {
-      const project = (connection.project_id as string) || undefined;
-      const displayInfo = project || "Unknown Project";
-      return {
-        id: db._id.toString(),
-        name: db.name,
-        type: db.type,
-        sqlDialect: "bigquery",
-        project,
-        displayName: `${db.name} (bigquery: ${displayInfo})`,
-        active: true,
-      };
-    }
-
-    if (
-      db.type === "postgresql" ||
-      db.type === "redshift" ||
-      db.type === "cloudsql-postgres"
-    ) {
-      const host = (connection.host || connection.instanceConnectionName) as
-        | string
-        | undefined;
-      const databaseName = (connection.database || connection.db) as
-        | string
-        | undefined;
-      const displayInfo = `${host || "unknown-host"}/${databaseName || "unknown-db"}`;
-      return {
-        id: db._id.toString(),
-        name: db.name,
-        type: db.type,
-        sqlDialect: "postgresql",
-        host,
-        databaseName,
-        displayName: `${db.name} (postgresql: ${displayInfo})`,
-        active: true,
-      };
-    }
-
-    if (db.type === "sqlite" || db.type === "cloudflare-d1") {
-      const databaseId = (connection.database_id as string) || "main";
-      return {
-        id: db._id.toString(),
-        name: db.name,
-        type: db.type,
-        sqlDialect: "sqlite",
-        databaseId,
-        displayName: `${db.name} (sqlite: ${databaseId})`,
-        active: true,
-      };
-    }
-
-    // Fallback for any new types
-    return {
-      id: db._id.toString(),
-      name: db.name,
-      type: db.type,
-      displayName: `${db.name} (${db.type})`,
-      active: true,
-    };
-  });
+    });
 }
 
 /**
@@ -161,7 +164,12 @@ export const createUniversalTools = (
   } = mongoTools;
 
   // Get SQL tools and extract just the database-specific ones
-  const sqlTools = createSqlToolsV2(workspaceId, consoles, preferredConsoleId);
+  const sqlTools = createSqlToolsV2(
+    workspaceId,
+    consoles,
+    preferredConsoleId,
+    userId,
+  );
   const {
     // Strip console tools
     modify_console: _sqlModify,
@@ -183,7 +191,7 @@ export const createUniversalTools = (
       description:
         "List all database connections in this workspace (MongoDB, PostgreSQL, Redshift, BigQuery, SQLite, Cloudflare D1). Use this to discover available databases before running queries.",
       inputSchema: emptySchema,
-      execute: async () => listAllConnectionsImpl(workspaceId),
+      execute: async () => listAllConnectionsImpl(workspaceId, userId),
     },
 
     // MongoDB tools (namespaced with mongo_ prefix) - server-side

--- a/api/src/agents/console/index.ts
+++ b/api/src/agents/console/index.ts
@@ -154,6 +154,7 @@ export const consoleAgentFactory: AgentFactory = (
 ): AgentConfig => {
   const {
     workspaceId,
+    userId,
     consoles = [],
     consoleId,
     databases = [],
@@ -199,7 +200,12 @@ export const consoleAgentFactory: AgentFactory = (
   );
 
   // Create tools
-  const tools = createUniversalTools(workspaceId, enrichedConsoles, consoleId);
+  const tools = createUniversalTools(
+    workspaceId,
+    enrichedConsoles,
+    consoleId,
+    userId,
+  );
   const selfDirectiveTools = createSelfDirectiveTools(workspaceId);
   const consoleSearchTools = createConsoleSearchTools(workspaceId);
 

--- a/api/src/agents/flow/index.ts
+++ b/api/src/agents/flow/index.ts
@@ -24,6 +24,10 @@ import {
   checkQuerySafety,
 } from "../../services/destination-writer.service";
 import { databaseConnectionService } from "../../services/database-connection.service";
+import {
+  canUserSeeDatabase,
+  checkQueryAccess,
+} from "../../services/database-access.service";
 
 // Import shared database discovery tools from agent-lib
 import {
@@ -163,7 +167,7 @@ const listFlowTabsSchema = z.object({});
  * Create tools for flow agent
  * Uses shared database discovery tools from agent-lib
  */
-export function createFlowTools(workspaceId: string) {
+export function createFlowTools(workspaceId: string, userId?: string) {
   return {
     // =========================================================================
     // Database Discovery Tools (from shared agent-lib module)
@@ -339,6 +343,15 @@ export function createFlowTools(workspaceId: string) {
             return { success: false, error: "Connection not found" };
           }
 
+          if (!canUserSeeDatabase(connection, userId)) {
+            return { success: false, error: "Connection not found" };
+          }
+
+          const accessCheck = checkQueryAccess(connection, userId, query);
+          if (!accessCheck.allowed) {
+            return { success: false, error: accessCheck.error };
+          }
+
           const result = await validateQueryService(
             connection,
             query,
@@ -387,6 +400,15 @@ export function createFlowTools(workspaceId: string) {
 
           if (!connection) {
             return { success: false, error: "Connection not found" };
+          }
+
+          if (!canUserSeeDatabase(connection, userId)) {
+            return { success: false, error: "Connection not found" };
+          }
+
+          const accessCheck = checkQueryAccess(connection, userId, query);
+          if (!accessCheck.allowed) {
+            return { success: false, error: accessCheck.error };
           }
 
           // Add LIMIT if missing from SELECT queries (safety measure)
@@ -575,11 +597,11 @@ function buildRuntimeContext(
 export const flowAgentFactory: AgentFactory = (
   context: AgentContext,
 ): AgentConfig => {
-  const { workspaceId, flowFormState, databases = [] } = context;
+  const { workspaceId, userId, flowFormState, databases = [] } = context;
 
   const runtimeContext = buildRuntimeContext(flowFormState, databases);
 
-  const tools = createFlowTools(workspaceId);
+  const tools = createFlowTools(workspaceId, userId);
 
   return {
     systemPrompt: [

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -183,6 +183,8 @@ export interface IWorkspaceInvite extends Document {
   acceptedAt?: Date;
 }
 
+export type DatabaseAccessLevel = "private" | "shared_read" | "shared_write";
+
 /**
  * DatabaseConnection model interface
  * Represents a saved connection to a database server (may contain multiple databases)
@@ -229,6 +231,9 @@ export interface IDatabaseConnection extends Document {
       privateKey?: string;
     };
   };
+  access: DatabaseAccessLevel;
+  ownerId: string;
+  sharedWith: Types.ObjectId[];
   isDemo?: boolean; // True if this is a demo database connection
   createdBy: string;
   createdAt: Date;
@@ -1045,6 +1050,21 @@ const DatabaseConnectionSchema = new Schema<IDatabaseConnection>(
       set: encryptObject,
       get: decryptObject,
     },
+    access: {
+      type: String,
+      enum: ["private", "shared_read", "shared_write"],
+      default: "shared_write",
+    },
+    ownerId: {
+      type: String,
+      ref: "User",
+    },
+    sharedWith: [
+      {
+        type: Schema.Types.ObjectId,
+        ref: "WorkspaceMember",
+      },
+    ],
     isDemo: {
       type: Boolean,
       default: false,
@@ -1069,6 +1089,7 @@ const DatabaseConnectionSchema = new Schema<IDatabaseConnection>(
 // Indexes
 DatabaseConnectionSchema.index({ workspaceId: 1 });
 DatabaseConnectionSchema.index({ workspaceId: 1, name: 1 });
+DatabaseConnectionSchema.index({ workspaceId: 1, access: 1, ownerId: 1 });
 
 /**
  * Connector Schema

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -183,7 +183,8 @@ export interface IWorkspaceInvite extends Document {
   acceptedAt?: Date;
 }
 
-export type DatabaseAccessLevel = "private" | "shared_read" | "shared_write";
+export type DatabaseVisibility = "private" | "shared";
+export type DatabasePermissions = "read_write" | "read_only";
 
 /**
  * DatabaseConnection model interface
@@ -231,7 +232,8 @@ export interface IDatabaseConnection extends Document {
       privateKey?: string;
     };
   };
-  access: DatabaseAccessLevel;
+  access: DatabaseVisibility;
+  permissions: DatabasePermissions;
   ownerId: string;
   sharedWith: Types.ObjectId[];
   isDemo?: boolean; // True if this is a demo database connection
@@ -1052,8 +1054,13 @@ const DatabaseConnectionSchema = new Schema<IDatabaseConnection>(
     },
     access: {
       type: String,
-      enum: ["private", "shared_read", "shared_write"],
-      default: "shared_write",
+      enum: ["private", "shared"],
+      default: "shared",
+    },
+    permissions: {
+      type: String,
+      enum: ["read_write", "read_only"],
+      default: "read_write",
     },
     ownerId: {
       type: String,

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -1062,7 +1062,7 @@ const DatabaseConnectionSchema = new Schema<IDatabaseConnection>(
     sharedWith: [
       {
         type: Schema.Types.ObjectId,
-        ref: "WorkspaceMember",
+        ref: "User",
       },
     ],
     isDemo: {

--- a/api/src/migrations/2026-03-23-300000_add_database_access_controls.ts
+++ b/api/src/migrations/2026-03-23-300000_add_database_access_controls.ts
@@ -1,0 +1,88 @@
+import { Db } from "mongodb";
+import { loggers } from "../logging";
+
+const log = loggers.migration();
+
+export const description =
+  "Add access model fields (access, ownerId, sharedWith) to database connections";
+
+export async function up(db: Db): Promise<void> {
+  const collections = await db.listCollections().toArray();
+  const collectionNames = collections.map(c => c.name);
+
+  if (!collectionNames.includes("databaseconnections")) {
+    log.info("Collection 'databaseconnections' not found, skipping migration.");
+    return;
+  }
+
+  const col = db.collection("databaseconnections");
+
+  const ownerResult = await col.updateMany({ ownerId: { $exists: false } }, [
+    { $set: { ownerId: "$createdBy" } },
+  ]);
+  log.info(
+    `Backfilled ownerId for ${ownerResult.modifiedCount} database connections`,
+  );
+
+  const accessResult = await col.updateMany(
+    { access: { $exists: false } },
+    { $set: { access: "shared_write" } },
+  );
+  log.info(
+    `Set access='shared_write' for ${accessResult.modifiedCount} connections`,
+  );
+
+  const sharedWithResult = await col.updateMany(
+    { sharedWith: { $exists: false } },
+    { $set: { sharedWith: [] } },
+  );
+  log.info(
+    `Initialized sharedWith for ${sharedWithResult.modifiedCount} connections`,
+  );
+
+  try {
+    const existingIndexes = await col.indexes();
+    const alreadyExists = existingIndexes.some(
+      idx =>
+        idx.key &&
+        idx.key.workspaceId === 1 &&
+        idx.key.access === 1 &&
+        idx.key.ownerId === 1,
+    );
+
+    if (alreadyExists) {
+      log.info(
+        "Index on { workspaceId, access, ownerId } already exists, skipping",
+      );
+    } else {
+      await col.createIndex(
+        { workspaceId: 1, access: 1, ownerId: 1 },
+        { background: true, name: "workspace_access_owner_idx" },
+      );
+      log.info("Created index: { workspaceId: 1, access: 1, ownerId: 1 }");
+    }
+  } catch (err: any) {
+    if (err?.code === 85 || err?.codeName === "IndexOptionsConflict") {
+      log.info("Index already exists under a different name, skipping");
+    } else {
+      throw err;
+    }
+  }
+}
+
+export async function down(db: Db): Promise<void> {
+  const col = db.collection("databaseconnections");
+
+  await col.updateMany(
+    {},
+    { $unset: { access: "", ownerId: "", sharedWith: "" } },
+  );
+  log.info("Removed access, ownerId, sharedWith from all connections");
+
+  try {
+    await col.dropIndex("workspace_access_owner_idx");
+    log.info("Dropped workspace_access_owner_idx index");
+  } catch {
+    log.info("Index workspace_access_owner_idx not found, skipping drop");
+  }
+}

--- a/api/src/migrations/2026-03-23-300000_add_database_access_controls.ts
+++ b/api/src/migrations/2026-03-23-300000_add_database_access_controls.ts
@@ -26,10 +26,16 @@ export async function up(db: Db): Promise<void> {
 
   const accessResult = await col.updateMany(
     { access: { $exists: false } },
-    { $set: { access: "shared_write" } },
+    { $set: { access: "shared" } },
+  );
+  log.info(`Set access='shared' for ${accessResult.modifiedCount} connections`);
+
+  const permissionsResult = await col.updateMany(
+    { permissions: { $exists: false } },
+    { $set: { permissions: "read_write" } },
   );
   log.info(
-    `Set access='shared_write' for ${accessResult.modifiedCount} connections`,
+    `Set permissions='read_write' for ${permissionsResult.modifiedCount} connections`,
   );
 
   const sharedWithResult = await col.updateMany(
@@ -75,9 +81,11 @@ export async function down(db: Db): Promise<void> {
 
   await col.updateMany(
     {},
-    { $unset: { access: "", ownerId: "", sharedWith: "" } },
+    { $unset: { access: "", permissions: "", ownerId: "", sharedWith: "" } },
   );
-  log.info("Removed access, ownerId, sharedWith from all connections");
+  log.info(
+    "Removed access, permissions, ownerId, sharedWith from all connections",
+  );
 
   try {
     await col.dropIndex("workspace_access_owner_idx");

--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -13,6 +13,7 @@ import {
 import { User } from "../database/schema";
 import { workspaceService } from "../services/workspace.service";
 import { databaseConnectionService } from "../services/database-connection.service";
+import { checkQueryAccess } from "../services/database-access.service";
 import {
   queryExecutionService,
   QueryLanguage,
@@ -1453,6 +1454,20 @@ consoleRoutes.post("/:id/execute", async (c: Context) => {
         },
         400,
       );
+    }
+
+    // Enforce database access controls
+    const dbUserId = user?.id || apiKey?.createdBy;
+    const accessCheck = checkQueryAccess(
+      database,
+      dbUserId,
+      savedConsole.code || "",
+      {
+        mongoOperation: savedConsole.mongoOptions?.operation,
+      },
+    );
+    if (!accessCheck.allowed) {
+      return c.json({ success: false, error: accessCheck.error }, 403);
     }
 
     // Pass explicit databaseId and databaseName for cluster mode (D1, etc.)

--- a/api/src/routes/flows.ts
+++ b/api/src/routes/flows.ts
@@ -652,7 +652,7 @@ flowRoutes.post("/", async (c: AuthenticatedContext) => {
           {
             success: false,
             error:
-              "You do not have write access to the destination database. Only owners of shared_write or private databases can use them as flow destinations.",
+              "You do not have write access to the destination database. Only owners of shared or private databases can use them as flow destinations.",
           },
           403,
         );
@@ -682,7 +682,7 @@ flowRoutes.post("/", async (c: AuthenticatedContext) => {
           {
             success: false,
             error:
-              "You do not have write access to the destination database. Only owners of shared_write or private databases can use them as flow destinations.",
+              "You do not have write access to the destination database. Only owners of shared or private databases can use them as flow destinations.",
           },
           403,
         );

--- a/api/src/routes/flows.ts
+++ b/api/src/routes/flows.ts
@@ -21,6 +21,10 @@ import {
   checkQuerySafety,
   dryRunDbSync,
 } from "../services/destination-writer.service";
+import {
+  canUserWriteDatabase,
+  canUserSeeDatabase,
+} from "../services/database-access.service";
 import { cdcBackfillService } from "../sync-cdc/backfill";
 import { getCdcFlowStats } from "../sync-cdc/sync-state";
 import { databaseRegistry } from "../databases/registry";
@@ -524,14 +528,15 @@ flowRoutes.get("/", async c => {
 });
 
 // POST /api/workspaces/:workspaceId/flows - Create a new flow
-flowRoutes.post("/", async c => {
+flowRoutes.post("/", async (c: AuthenticatedContext) => {
   try {
     const workspaceId = c.req.param("workspaceId");
     if (!workspaceId) {
       return c.json({ success: false, error: "Workspace ID is required" }, 400);
     }
-    // TODO: Get userId from authentication
-    const userId = "system";
+    const user = c.get("user");
+    const apiKey = c.get("apiKey");
+    const userId = user?.id || apiKey?.createdBy || "system";
     const body = await c.req.json();
 
     // Validate required fields based on flow type and source type
@@ -591,6 +596,16 @@ flowRoutes.post("/", async c => {
           404,
         );
       }
+
+      if (!canUserSeeDatabase(sourceDb, userId)) {
+        return c.json(
+          {
+            success: false,
+            error: "You do not have access to the source database",
+          },
+          403,
+        );
+      }
     } else {
       // Connector source validation (default)
       if (!body.dataSourceId) {
@@ -632,6 +647,17 @@ flowRoutes.post("/", async c => {
         );
       }
 
+      if (!canUserWriteDatabase(destDb, userId)) {
+        return c.json(
+          {
+            success: false,
+            error:
+              "You do not have write access to the destination database. Only owners of shared_write or private databases can use them as flow destinations.",
+          },
+          403,
+        );
+      }
+
       // Use the table destination connection as the destinationDatabaseId
       destinationDatabaseId = new Types.ObjectId(
         body.tableDestination.connectionId,
@@ -648,6 +674,17 @@ flowRoutes.post("/", async c => {
         return c.json(
           { success: false, error: "Destination database not found" },
           404,
+        );
+      }
+
+      if (!canUserWriteDatabase(database, userId)) {
+        return c.json(
+          {
+            success: false,
+            error:
+              "You do not have write access to the destination database. Only owners of shared_write or private databases can use them as flow destinations.",
+          },
+          403,
         );
       }
 

--- a/api/src/routes/workspace-databases.ts
+++ b/api/src/routes/workspace-databases.ts
@@ -9,7 +9,7 @@ import {
   DatabaseConnection,
   IDatabaseConnection,
   Flow,
-  DatabaseAccessLevel,
+  DatabaseVisibility,
 } from "../database/workspace-schema";
 import {
   canUserSeeDatabase,
@@ -265,7 +265,7 @@ workspaceDatabaseRoutes.post(
         isDemo: true,
         createdBy: user.id,
         ownerId: user.id,
-        access: "shared_write" as DatabaseAccessLevel,
+        access: "shared" as DatabaseVisibility,
         createdAt: new Date(),
         updatedAt: new Date(),
       });
@@ -367,6 +367,7 @@ workspaceDatabaseRoutes.get(
             hostKey,
             hostName,
             access: level,
+            permissions: db.permissions || "read_write",
             isOwner,
             canManage,
             ownerId: db.ownerId,
@@ -443,6 +444,7 @@ workspaceDatabaseRoutes.get(
           updatedAt: database.updatedAt,
           lastConnectedAt: database.lastConnectedAt,
           access: level,
+          permissions: database.permissions || "read_write",
           isOwner,
           canManage,
           ownerId: database.ownerId,
@@ -563,7 +565,7 @@ workspaceDatabaseRoutes.post(
         ownerId: user.id,
         access: (body.access && isValidAccessLevel(body.access)
           ? body.access
-          : "shared_write") as DatabaseAccessLevel,
+          : "shared") as DatabaseVisibility,
         createdAt: new Date(),
         updatedAt: new Date(),
       });
@@ -661,8 +663,7 @@ workspaceDatabaseRoutes.put(
           return c.json(
             {
               success: false,
-              error:
-                "Invalid access level. Must be: private, shared_read, or shared_write",
+              error: "Invalid access level. Must be: private or shared",
             },
             400,
           );
@@ -859,13 +860,19 @@ workspaceDatabaseRoutes.post(
           return c.json(
             {
               success: false,
-              error:
-                "Invalid access level. Must be: private, shared_read, or shared_write",
+              error: "Invalid access level. Must be: private or shared",
             },
             400,
           );
         }
         database.access = body.access;
+      }
+
+      if (
+        body.permissions &&
+        (body.permissions === "read_write" || body.permissions === "read_only")
+      ) {
+        database.permissions = body.permissions;
       }
 
       if (Array.isArray(body.sharedWith)) {
@@ -894,6 +901,7 @@ workspaceDatabaseRoutes.post(
         data: {
           id: database._id.toString(),
           access: database.access,
+          permissions: database.permissions,
           sharedWith: database.sharedWith,
         },
       });

--- a/api/src/routes/workspace-databases.ts
+++ b/api/src/routes/workspace-databases.ts
@@ -9,7 +9,14 @@ import {
   DatabaseConnection,
   IDatabaseConnection,
   Flow,
+  DatabaseAccessLevel,
 } from "../database/workspace-schema";
+import {
+  canUserSeeDatabase,
+  checkQueryAccess,
+  getEffectiveAccess,
+  isValidAccessLevel,
+} from "../services/database-access.service";
 import { databaseConnectionService } from "../services/database-connection.service";
 import {
   queryExecutionService,
@@ -257,6 +264,8 @@ workspaceDatabaseRoutes.post(
         connection: demoConfig.connection,
         isDemo: true,
         createdBy: user.id,
+        ownerId: user.id,
+        access: "shared_write" as DatabaseAccessLevel,
         createdAt: new Date(),
         updatedAt: new Date(),
       });
@@ -301,54 +310,68 @@ workspaceDatabaseRoutes.get(
   async (c: AuthenticatedContext) => {
     try {
       const workspace = c.get("workspace");
+      const user = c.get("user");
+      const memberRole = c.get("memberRole");
+      const userId = user?.id;
 
       const databases = await DatabaseConnection.find({
         workspaceId: workspace._id,
       }).sort({ createdAt: -1 });
 
-      // Transform to API response format without connection details for security
-      const transformedDatabases = databases.map((db: IDatabaseConnection) => {
-        // Create masked hostKey for grouping per database type
-        let hostKey: string;
-        let hostName: string;
-        const conn: any = db.connection || {};
-        if (db.type === "bigquery") {
-          const projectId = conn.project_id || "unknown-project";
-          hostKey = `bigquery://${projectId}`;
-          hostName = `BigQuery (${projectId})`;
-        } else if (conn.connectionString) {
-          hostKey = maskPasswordInConnectionString(conn.connectionString);
-          hostName =
-            db.type === "mongodb" ? "MongoDB Atlas" : db.type.toUpperCase();
-        } else {
-          hostKey = conn.host || "unknown";
-          hostName =
-            db.type === "mongodb"
-              ? `MongoDB (${conn.host || "localhost"})`
-              : `${db.type.toUpperCase()} (${conn.host || "localhost"})`;
-        }
+      // Filter by visibility and transform to API response format
+      const transformedDatabases = databases
+        .filter((db: IDatabaseConnection) => canUserSeeDatabase(db, userId))
+        .map((db: IDatabaseConnection) => {
+          // Create masked hostKey for grouping per database type
+          let hostKey: string;
+          let hostName: string;
+          const conn: any = db.connection || {};
+          if (db.type === "bigquery") {
+            const projectId = conn.project_id || "unknown-project";
+            hostKey = `bigquery://${projectId}`;
+            hostName = `BigQuery (${projectId})`;
+          } else if (conn.connectionString) {
+            hostKey = maskPasswordInConnectionString(conn.connectionString);
+            hostName =
+              db.type === "mongodb" ? "MongoDB Atlas" : db.type.toUpperCase();
+          } else {
+            hostKey = conn.host || "unknown";
+            hostName =
+              db.type === "mongodb"
+                ? `MongoDB (${conn.host || "localhost"})`
+                : `${db.type.toUpperCase()} (${conn.host || "localhost"})`;
+          }
 
-        // Determine if this is a cluster/server connection without a specific database
-        const isClusterMode = !conn.database;
+          // Determine if this is a cluster/server connection without a specific database
+          const isClusterMode = !conn.database;
 
-        return {
-          id: db._id.toString(),
-          connectionId: db._id.toString(), // Explicit connection ID for clarity
-          name: db.name,
-          description: "",
-          database: conn.database,
-          databaseName: conn.database, // Alias for clarity
-          type: db.type,
-          active: true,
-          lastConnectedAt: db.lastConnectedAt,
-          isClusterMode, // true when connection can access multiple databases
-          isDemo: db.isDemo || false, // true if this is a demo database
-          // Helper fields for easier access (connection object removed for security)
-          displayName: db.name || conn.database || "Unknown Database",
-          hostKey,
-          hostName,
-        };
-      });
+          const { level, isOwner, canManage } = getEffectiveAccess(
+            db,
+            userId,
+            memberRole,
+          );
+
+          return {
+            id: db._id.toString(),
+            connectionId: db._id.toString(),
+            name: db.name,
+            description: "",
+            database: conn.database,
+            databaseName: conn.database,
+            type: db.type,
+            active: true,
+            lastConnectedAt: db.lastConnectedAt,
+            isClusterMode,
+            isDemo: db.isDemo || false,
+            displayName: db.name || conn.database || "Unknown Database",
+            hostKey,
+            hostName,
+            access: level,
+            isOwner,
+            canManage,
+            ownerId: db.ownerId,
+          };
+        });
 
       return c.json({
         success: true,
@@ -376,6 +399,9 @@ workspaceDatabaseRoutes.get(
   async (c: AuthenticatedContext) => {
     try {
       const workspace = c.get("workspace");
+      const user = c.get("user");
+      const memberRole = c.get("memberRole");
+      const userId = user?.id;
       const databaseId = c.req.param("id");
 
       if (!Types.ObjectId.isValid(databaseId)) {
@@ -391,8 +417,17 @@ workspaceDatabaseRoutes.get(
         return c.json({ success: false, error: "Database not found" }, 404);
       }
 
+      if (!canUserSeeDatabase(database, userId)) {
+        return c.json({ success: false, error: "Access denied" }, 403);
+      }
+
       const conn: any = database.connection || {};
       const isClusterMode = !conn.database;
+      const { level, isOwner, canManage } = getEffectiveAccess(
+        database,
+        userId,
+        memberRole,
+      );
 
       return c.json({
         success: true,
@@ -401,12 +436,16 @@ workspaceDatabaseRoutes.get(
           connectionId: database._id.toString(),
           name: database.name,
           type: database.type,
-          connection: database.connection, // Will be decrypted by getter
+          connection: database.connection,
           databaseName: conn.database,
           isClusterMode,
           createdAt: database.createdAt,
           updatedAt: database.updatedAt,
           lastConnectedAt: database.lastConnectedAt,
+          access: level,
+          isOwner,
+          canManage,
+          ownerId: database.ownerId,
         },
       });
     } catch (error) {
@@ -521,6 +560,10 @@ workspaceDatabaseRoutes.post(
         type: body.type,
         connection: body.connection || {},
         createdBy: user.id,
+        ownerId: user.id,
+        access: (body.access && isValidAccessLevel(body.access)
+          ? body.access
+          : "shared_write") as DatabaseAccessLevel,
         createdAt: new Date(),
         updatedAt: new Date(),
       });
@@ -582,6 +625,8 @@ workspaceDatabaseRoutes.put(
   async (c: AuthenticatedContext) => {
     try {
       const workspace = c.get("workspace");
+      const user = c.get("user");
+      const memberRole = c.get("memberRole");
       const databaseId = c.req.param("id");
       const body = await c.req.json();
 
@@ -596,6 +641,33 @@ workspaceDatabaseRoutes.put(
 
       if (!database) {
         return c.json({ success: false, error: "Database not found" }, 404);
+      }
+
+      const { canManage } = getEffectiveAccess(database, user?.id, memberRole);
+      if (!canManage) {
+        return c.json(
+          {
+            success: false,
+            error:
+              "Only the database owner or workspace admin can edit this database",
+          },
+          403,
+        );
+      }
+
+      // Update access level if provided
+      if (body.access) {
+        if (!isValidAccessLevel(body.access)) {
+          return c.json(
+            {
+              success: false,
+              error:
+                "Invalid access level. Must be: private, shared_read, or shared_write",
+            },
+            400,
+          );
+        }
+        database.access = body.access;
       }
 
       // Update fields
@@ -661,14 +733,37 @@ workspaceDatabaseRoutes.delete(
   "/:id",
   unifiedAuthMiddleware,
   requireWorkspace,
-  requireWorkspaceRole(["owner", "admin"]),
+  requireWorkspaceRole(["owner", "admin", "member"]),
   async (c: AuthenticatedContext) => {
     try {
       const workspace = c.get("workspace");
+      const user = c.get("user");
+      const memberRole = c.get("memberRole");
       const databaseId = c.req.param("id");
 
       if (!Types.ObjectId.isValid(databaseId)) {
         return c.json({ success: false, error: "Invalid database ID" }, 400);
+      }
+
+      const database = await DatabaseConnection.findOne({
+        _id: new Types.ObjectId(databaseId),
+        workspaceId: workspace._id,
+      });
+
+      if (!database) {
+        return c.json({ success: false, error: "Database not found" }, 404);
+      }
+
+      const { canManage } = getEffectiveAccess(database, user?.id, memberRole);
+      if (!canManage) {
+        return c.json(
+          {
+            success: false,
+            error:
+              "Only the database owner or workspace admin can delete this database",
+          },
+          403,
+        );
       }
 
       // Check for dependent flows
@@ -713,6 +808,104 @@ workspaceDatabaseRoutes.delete(
             error instanceof Error
               ? error.message
               : "Failed to delete database",
+        },
+        500,
+      );
+    }
+  },
+);
+
+// Share / change access level for database
+workspaceDatabaseRoutes.post(
+  "/:id/share",
+  unifiedAuthMiddleware,
+  requireWorkspace,
+  requireWorkspaceRole(["owner", "admin", "member"]),
+  async (c: AuthenticatedContext) => {
+    try {
+      const workspace = c.get("workspace");
+      const user = c.get("user");
+      const memberRole = c.get("memberRole");
+      const databaseId = c.req.param("id");
+      const body = await c.req.json();
+
+      if (!Types.ObjectId.isValid(databaseId)) {
+        return c.json({ success: false, error: "Invalid database ID" }, 400);
+      }
+
+      const database = await DatabaseConnection.findOne({
+        _id: new Types.ObjectId(databaseId),
+        workspaceId: workspace._id,
+      });
+
+      if (!database) {
+        return c.json({ success: false, error: "Database not found" }, 404);
+      }
+
+      const { canManage } = getEffectiveAccess(database, user?.id, memberRole);
+      if (!canManage) {
+        return c.json(
+          {
+            success: false,
+            error:
+              "Only the database owner or workspace admin can change sharing settings",
+          },
+          403,
+        );
+      }
+
+      if (body.access) {
+        if (!isValidAccessLevel(body.access)) {
+          return c.json(
+            {
+              success: false,
+              error:
+                "Invalid access level. Must be: private, shared_read, or shared_write",
+            },
+            400,
+          );
+        }
+        database.access = body.access;
+      }
+
+      if (Array.isArray(body.sharedWith)) {
+        const validIds = body.sharedWith.every(
+          (id: string) => typeof id === "string" && Types.ObjectId.isValid(id),
+        );
+        if (!validIds) {
+          return c.json(
+            {
+              success: false,
+              error: "sharedWith must be an array of valid ObjectId strings",
+            },
+            400,
+          );
+        }
+        database.sharedWith = body.sharedWith.map(
+          (id: string) => new Types.ObjectId(id),
+        );
+      }
+
+      database.updatedAt = new Date();
+      await database.save();
+
+      return c.json({
+        success: true,
+        data: {
+          id: database._id.toString(),
+          access: database.access,
+          sharedWith: database.sharedWith,
+        },
+      });
+    } catch (error) {
+      logger.error("Error sharing database", { error });
+      return c.json(
+        {
+          success: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Failed to update sharing settings",
         },
         500,
       );
@@ -776,6 +969,8 @@ workspaceDatabaseRoutes.post(
   async (c: AuthenticatedContext) => {
     try {
       const workspace = c.get("workspace");
+      const user = c.get("user");
+      const apiKey = c.get("apiKey");
       const databaseId = c.req.param("id");
       const body = await c.req.json();
 
@@ -794,6 +989,14 @@ workspaceDatabaseRoutes.post(
 
       if (!body.query) {
         return c.json({ success: false, error: "Query is required" }, 400);
+      }
+
+      const userId = user?.id || apiKey?.createdBy;
+      const accessCheck = checkQueryAccess(database, userId, body.query, {
+        mongoOperation: body.options?.operation,
+      });
+      if (!accessCheck.allowed) {
+        return c.json({ success: false, error: accessCheck.error }, 403);
       }
 
       const result = await databaseConnectionService.executeQuery(
@@ -1132,6 +1335,27 @@ workspaceExecuteRoutes.post(
           { success: false, error: "queryDefinition.code is required" },
           400,
         );
+      }
+
+      // Enforce database access controls
+      const accessUserId = user?.id || apiKey?.createdBy;
+      const queryString =
+        typeof executableQuery === "string"
+          ? executableQuery
+          : executableQuery.query;
+      const accessCheck = checkQueryAccess(
+        database,
+        accessUserId,
+        queryString,
+        {
+          mongoOperation:
+            typeof executableQuery !== "string"
+              ? executableQuery.operation
+              : effectiveQueryDefinition?.mongoOptions?.operation,
+        },
+      );
+      if (!accessCheck.allowed) {
+        return c.json({ success: false, error: accessCheck.error }, 403);
       }
 
       // Build options for query execution

--- a/api/src/services/database-access.service.ts
+++ b/api/src/services/database-access.service.ts
@@ -63,6 +63,9 @@ const KNOWN_MONGO_OPERATIONS = [
   "deleteMany",
   "replaceOne",
   "bulkWrite",
+  "findOneAndUpdate",
+  "findOneAndDelete",
+  "findOneAndReplace",
   "drop",
   "createIndex",
   "dropIndex",
@@ -158,7 +161,7 @@ export function stripSqlCommentsAndStrings(sql: string): string {
 function extractFirstSqlKeyword(stripped: string): string | null {
   const trimmed = stripped.trim();
   if (!trimmed) return null;
-  const match = trimmed.match(/^([A-Za-z_]+)/);
+  const match = trimmed.match(/^[\s(]*([A-Za-z_]+)/);
   return match ? match[1].toUpperCase() : null;
 }
 
@@ -191,7 +194,7 @@ export function isSqlReadOnly(query: string): boolean {
     .map(s => s.trim())
     .filter(Boolean);
 
-  if (statements.length === 0) return true;
+  if (statements.length === 0) return false;
 
   return statements.every(stmt => {
     const keyword = extractFirstSqlKeyword(stmt);
@@ -253,14 +256,15 @@ export function isValidAccessLevel(
 export function checkQueryAccess(
   database: Pick<
     IDatabaseConnection,
-    "access" | "ownerId" | "sharedWith" | "type"
+    "access" | "ownerId" | "sharedWith" | "type" | "createdBy"
   >,
   userId: string | undefined,
   query: string,
   options?: { mongoOperation?: string },
 ): AccessCheckResult {
   const access = database.access || "shared_write";
-  const isOwner = !!userId && database.ownerId === userId;
+  const ownerId = database.ownerId || database.createdBy;
+  const isOwner = !!userId && ownerId === userId;
 
   // Owner always has full access
   if (isOwner) return { allowed: true };
@@ -319,20 +323,24 @@ export function checkQueryAccess(
  * Checks whether a user can write to a database (used for flow destination validation).
  */
 export function canUserWriteDatabase(
-  database: Pick<IDatabaseConnection, "access" | "ownerId">,
+  database: Pick<IDatabaseConnection, "access" | "ownerId" | "createdBy">,
   userId: string | undefined,
 ): boolean {
   const access = database.access || "shared_write";
   if (access === "shared_write") return true;
   if (!userId) return false;
-  return database.ownerId === userId;
+  const ownerId = database.ownerId || database.createdBy;
+  return ownerId === userId;
 }
 
 /**
  * Determines whether a database should appear in a user's list.
  */
 export function canUserSeeDatabase(
-  database: Pick<IDatabaseConnection, "access" | "ownerId" | "sharedWith">,
+  database: Pick<
+    IDatabaseConnection,
+    "access" | "ownerId" | "sharedWith" | "createdBy"
+  >,
   userId: string | undefined,
 ): boolean {
   const access = database.access || "shared_write";
@@ -342,7 +350,8 @@ export function canUserSeeDatabase(
 
   // private: only owner + sharedWith
   if (!userId) return false;
-  if (database.ownerId === userId) return true;
+  const ownerId = database.ownerId || database.createdBy;
+  if (ownerId === userId) return true;
   const sharedWithIds = (database.sharedWith || []).map(id => id.toString());
   return sharedWithIds.includes(userId);
 }
@@ -352,12 +361,13 @@ export function canUserSeeDatabase(
  * `canManage` is true when the user is the owner or a workspace admin/owner.
  */
 export function getEffectiveAccess(
-  database: Pick<IDatabaseConnection, "access" | "ownerId">,
+  database: Pick<IDatabaseConnection, "access" | "ownerId" | "createdBy">,
   userId: string | undefined,
   memberRole?: string,
 ): { level: DatabaseAccessLevel; isOwner: boolean; canManage: boolean } {
   const level = database.access || "shared_write";
-  const isOwner = !!userId && database.ownerId === userId;
+  const ownerId = database.ownerId || database.createdBy;
+  const isOwner = !!userId && ownerId === userId;
   const isWorkspaceAdmin = memberRole === "owner" || memberRole === "admin";
   const canManage = isOwner || isWorkspaceAdmin;
   return { level, isOwner, canManage };

--- a/api/src/services/database-access.service.ts
+++ b/api/src/services/database-access.service.ts
@@ -1,0 +1,377 @@
+import type {
+  IDatabaseConnection,
+  DatabaseAccessLevel,
+} from "../database/workspace-schema";
+
+export interface AccessCheckResult {
+  allowed: boolean;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SQL_READ_ONLY_KEYWORDS = new Set([
+  "SELECT",
+  "SHOW",
+  "DESCRIBE",
+  "DESC",
+  "PRAGMA",
+]);
+
+const SQL_WRITE_KEYWORDS = new Set([
+  "INSERT",
+  "UPDATE",
+  "DELETE",
+  "DROP",
+  "ALTER",
+  "TRUNCATE",
+  "CREATE",
+  "REPLACE",
+  "MERGE",
+  "GRANT",
+  "REVOKE",
+  "RENAME",
+]);
+
+const MONGODB_READ_ONLY_OPERATIONS = new Set([
+  "find",
+  "findOne",
+  "aggregate",
+  "count",
+  "countDocuments",
+  "estimatedDocumentCount",
+  "distinct",
+  "explain",
+]);
+
+const KNOWN_MONGO_OPERATIONS = [
+  "find",
+  "findOne",
+  "aggregate",
+  "count",
+  "countDocuments",
+  "estimatedDocumentCount",
+  "distinct",
+  "explain",
+  "insertOne",
+  "insertMany",
+  "updateOne",
+  "updateMany",
+  "deleteOne",
+  "deleteMany",
+  "replaceOne",
+  "bulkWrite",
+  "drop",
+  "createIndex",
+  "dropIndex",
+  "dropIndexes",
+  "renameCollection",
+];
+
+const MONGO_OP_PATTERN = new RegExp(
+  `\\.(${KNOWN_MONGO_OPERATIONS.join("|")})\\s*\\(`,
+  "g",
+);
+
+const VALID_ACCESS_LEVELS: DatabaseAccessLevel[] = [
+  "private",
+  "shared_read",
+  "shared_write",
+];
+
+// ---------------------------------------------------------------------------
+// SQL helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * State-machine parser that strips SQL comments and string literals so that
+ * keyword detection isn't fooled by content inside them.
+ *
+ * Handles:
+ * - Single-line comments: -- ...
+ * - Block comments: slash-star ... star-slash
+ * - Single-quoted strings: '...' (with '' escape)
+ * - Double-quoted identifiers: "..." (with "" escape)
+ */
+export function stripSqlCommentsAndStrings(sql: string): string {
+  const out: string[] = [];
+  let i = 0;
+  const len = sql.length;
+
+  while (i < len) {
+    const ch = sql[i];
+    const next = i + 1 < len ? sql[i + 1] : "";
+
+    if (ch === "-" && next === "-") {
+      // single-line comment: skip to end of line
+      i += 2;
+      while (i < len && sql[i] !== "\n") i++;
+    } else if (ch === "/" && next === "*") {
+      // block comment: skip to */
+      i += 2;
+      while (
+        i < len &&
+        !(sql[i] === "*" && i + 1 < len && sql[i + 1] === "/")
+      ) {
+        i++;
+      }
+      i += 2; // skip */
+    } else if (ch === "'") {
+      // single-quoted string: skip contents, handle '' escape
+      i++;
+      while (i < len) {
+        if (sql[i] === "'" && i + 1 < len && sql[i + 1] === "'") {
+          i += 2;
+        } else if (sql[i] === "'") {
+          i++;
+          break;
+        } else {
+          i++;
+        }
+      }
+      out.push("''"); // placeholder so positions don't shift weirdly
+    } else if (ch === '"') {
+      // double-quoted identifier: skip contents
+      i++;
+      while (i < len) {
+        if (sql[i] === '"' && i + 1 < len && sql[i + 1] === '"') {
+          i += 2;
+        } else if (sql[i] === '"') {
+          i++;
+          break;
+        } else {
+          i++;
+        }
+      }
+      out.push('""');
+    } else {
+      out.push(ch);
+      i++;
+    }
+  }
+
+  return out.join("");
+}
+
+function extractFirstSqlKeyword(stripped: string): string | null {
+  const trimmed = stripped.trim();
+  if (!trimmed) return null;
+  const match = trimmed.match(/^([A-Za-z_]+)/);
+  return match ? match[1].toUpperCase() : null;
+}
+
+/**
+ * Checks whether a stripped SQL fragment contains write keywords using
+ * word-boundary matching. Uses a negative lookahead to skip function calls
+ * like REPLACE(col, 'a', 'b').
+ */
+export function containsSqlWriteKeyword(stripped: string): boolean {
+  const upper = stripped.toUpperCase();
+  for (const kw of SQL_WRITE_KEYWORDS) {
+    const pattern = new RegExp(`\\b${kw}\\b(?!\\s*\\()`, "i");
+    if (pattern.test(upper)) return true;
+  }
+  return false;
+}
+
+/**
+ * Determines whether a SQL query string is read-only.
+ *
+ * - Splits on ';' (after stripping comments/strings)
+ * - Each statement must start with a read-only keyword
+ * - WITH (CTE) statements are scanned for embedded write keywords
+ * - EXPLAIN ANALYZE is treated as a write (PostgreSQL executes the statement)
+ */
+export function isSqlReadOnly(query: string): boolean {
+  const stripped = stripSqlCommentsAndStrings(query);
+  const statements = stripped
+    .split(";")
+    .map(s => s.trim())
+    .filter(Boolean);
+
+  if (statements.length === 0) return true;
+
+  return statements.every(stmt => {
+    const keyword = extractFirstSqlKeyword(stmt);
+    if (!keyword) return true;
+
+    // EXPLAIN ANALYZE actually executes the statement in PostgreSQL
+    if (keyword === "EXPLAIN") {
+      const rest = stmt.replace(/^\s*EXPLAIN\s+/i, "");
+      if (/^ANALYZE\b/i.test(rest.trim())) return false;
+      return true;
+    }
+
+    // WITH (CTE) can contain writable CTEs in PostgreSQL
+    if (keyword === "WITH") {
+      if (containsSqlWriteKeyword(stmt)) return false;
+      return true;
+    }
+
+    if (SQL_READ_ONLY_KEYWORDS.has(keyword)) return true;
+
+    return false;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// MongoDB helpers
+// ---------------------------------------------------------------------------
+
+export function isMongoReadOnly(operation: string): boolean {
+  return MONGODB_READ_ONLY_OPERATIONS.has(operation);
+}
+
+export function extractAllMongoOperations(query: string): string[] {
+  const ops: string[] = [];
+  let match;
+  MONGO_OP_PATTERN.lastIndex = 0;
+  while ((match = MONGO_OP_PATTERN.exec(query)) !== null) {
+    ops.push(match[1]);
+  }
+  return ops;
+}
+
+// ---------------------------------------------------------------------------
+// Access check functions
+// ---------------------------------------------------------------------------
+
+export function isValidAccessLevel(
+  value: string,
+): value is DatabaseAccessLevel {
+  return VALID_ACCESS_LEVELS.includes(value as DatabaseAccessLevel);
+}
+
+/**
+ * Checks whether a user can execute a given query against a database.
+ *
+ * Fail-closed: when userId is undefined, only shared_write databases allow
+ * queries. private and shared_read deny everything.
+ */
+export function checkQueryAccess(
+  database: Pick<
+    IDatabaseConnection,
+    "access" | "ownerId" | "sharedWith" | "type"
+  >,
+  userId: string | undefined,
+  query: string,
+  options?: { mongoOperation?: string },
+): AccessCheckResult {
+  const access = database.access || "shared_write";
+  const isOwner = !!userId && database.ownerId === userId;
+
+  // Owner always has full access
+  if (isOwner) return { allowed: true };
+
+  // shared_write: everyone can read and write
+  if (access === "shared_write") return { allowed: true };
+
+  // private: only owner + sharedWith users
+  if (access === "private") {
+    if (!userId) {
+      return { allowed: false, error: "This database is private." };
+    }
+    const sharedWithIds = (database.sharedWith || []).map(id => id.toString());
+    if (!sharedWithIds.includes(userId)) {
+      return { allowed: false, error: "This database is private." };
+    }
+    // Fall through to read-only enforcement for sharedWith users
+  }
+
+  // shared_read or private+sharedWith: enforce read-only
+  if (!userId) {
+    return {
+      allowed: false,
+      error: "Authentication required to query this database.",
+    };
+  }
+
+  const isMongoType = database.type === "mongodb";
+  let isReadOnly: boolean;
+
+  if (isMongoType) {
+    if (options?.mongoOperation) {
+      isReadOnly = isMongoReadOnly(options.mongoOperation);
+    } else {
+      const ops = extractAllMongoOperations(query);
+      isReadOnly = ops.length === 0 || ops.every(op => isMongoReadOnly(op));
+    }
+  } else {
+    isReadOnly = isSqlReadOnly(query);
+  }
+
+  if (!isReadOnly) {
+    const hint = isMongoType
+      ? "Only find, aggregate, count, distinct, and explain are allowed."
+      : "Only SELECT, WITH, SHOW, DESCRIBE, and EXPLAIN (without ANALYZE) are allowed.";
+    return {
+      allowed: false,
+      error: `This database is shared as read-only. ${hint}`,
+    };
+  }
+
+  return { allowed: true };
+}
+
+/**
+ * Checks whether a user can write to a database (used for flow destination validation).
+ */
+export function canUserWriteDatabase(
+  database: Pick<IDatabaseConnection, "access" | "ownerId">,
+  userId: string | undefined,
+): boolean {
+  const access = database.access || "shared_write";
+  if (access === "shared_write") return true;
+  if (!userId) return false;
+  return database.ownerId === userId;
+}
+
+/**
+ * Determines whether a database should appear in a user's list.
+ */
+export function canUserSeeDatabase(
+  database: Pick<IDatabaseConnection, "access" | "ownerId" | "sharedWith">,
+  userId: string | undefined,
+): boolean {
+  const access = database.access || "shared_write";
+
+  // shared_write and shared_read are visible to everyone in the workspace
+  if (access === "shared_write" || access === "shared_read") return true;
+
+  // private: only owner + sharedWith
+  if (!userId) return false;
+  if (database.ownerId === userId) return true;
+  const sharedWithIds = (database.sharedWith || []).map(id => id.toString());
+  return sharedWithIds.includes(userId);
+}
+
+/**
+ * Returns the effective access metadata for API responses.
+ * `canManage` is true when the user is the owner or a workspace admin/owner.
+ */
+export function getEffectiveAccess(
+  database: Pick<IDatabaseConnection, "access" | "ownerId">,
+  userId: string | undefined,
+  memberRole?: string,
+): { level: DatabaseAccessLevel; isOwner: boolean; canManage: boolean } {
+  const level = database.access || "shared_write";
+  const isOwner = !!userId && database.ownerId === userId;
+  const isWorkspaceAdmin = memberRole === "owner" || memberRole === "admin";
+  const canManage = isOwner || isWorkspaceAdmin;
+  return { level, isOwner, canManage };
+}
+
+export const databaseAccessService = {
+  checkQueryAccess,
+  canUserWriteDatabase,
+  canUserSeeDatabase,
+  getEffectiveAccess,
+  isSqlReadOnly,
+  isMongoReadOnly,
+  extractAllMongoOperations,
+  isValidAccessLevel,
+  stripSqlCommentsAndStrings,
+  containsSqlWriteKeyword,
+};

--- a/api/src/services/database-access.service.ts
+++ b/api/src/services/database-access.service.ts
@@ -1,6 +1,6 @@
 import type {
   IDatabaseConnection,
-  DatabaseAccessLevel,
+  DatabaseVisibility,
 } from "../database/workspace-schema";
 
 export interface AccessCheckResult {
@@ -78,11 +78,7 @@ const MONGO_OP_PATTERN = new RegExp(
   "g",
 );
 
-const VALID_ACCESS_LEVELS: DatabaseAccessLevel[] = [
-  "private",
-  "shared_read",
-  "shared_write",
-];
+const VALID_ACCESS_LEVELS: DatabaseVisibility[] = ["private", "shared"];
 
 // ---------------------------------------------------------------------------
 // SQL helpers
@@ -241,57 +237,42 @@ export function extractAllMongoOperations(query: string): string[] {
 // Access check functions
 // ---------------------------------------------------------------------------
 
-export function isValidAccessLevel(
-  value: string,
-): value is DatabaseAccessLevel {
-  return VALID_ACCESS_LEVELS.includes(value as DatabaseAccessLevel);
+export function isValidAccessLevel(value: string): value is DatabaseVisibility {
+  return VALID_ACCESS_LEVELS.includes(value as DatabaseVisibility);
 }
 
 /**
  * Checks whether a user can execute a given query against a database.
  *
- * Fail-closed: when userId is undefined, only shared_write databases allow
- * queries. private and shared_read deny everything.
+ * Fail-closed: when userId is undefined, only shared databases allow
+ * queries. private databases deny everything.
  */
 export function checkQueryAccess(
   database: Pick<
     IDatabaseConnection,
-    "access" | "ownerId" | "sharedWith" | "type" | "createdBy"
+    "access" | "permissions" | "ownerId" | "sharedWith" | "type" | "createdBy"
   >,
   userId: string | undefined,
   query: string,
   options?: { mongoOperation?: string },
 ): AccessCheckResult {
-  const access = database.access || "shared_write";
+  const access = database.access || "shared";
+  const permissions = database.permissions || "read_write";
   const ownerId = database.ownerId || database.createdBy;
   const isOwner = !!userId && ownerId === userId;
 
   // Owner always has full access
   if (isOwner) return { allowed: true };
 
-  // shared_write: everyone can read and write
-  if (access === "shared_write") return { allowed: true };
-
-  // private: only owner + sharedWith users
+  // private: only owner
   if (access === "private") {
-    if (!userId) {
-      return { allowed: false, error: "This database is private." };
-    }
-    const sharedWithIds = (database.sharedWith || []).map(id => id.toString());
-    if (!sharedWithIds.includes(userId)) {
-      return { allowed: false, error: "This database is private." };
-    }
-    // Fall through to read-only enforcement for sharedWith users
+    return { allowed: false, error: "This database is private." };
   }
 
-  // shared_read or private+sharedWith: enforce read-only
-  if (!userId) {
-    return {
-      allowed: false,
-      error: "Authentication required to query this database.",
-    };
-  }
+  // shared + read_write: everyone can read and write
+  if (permissions === "read_write") return { allowed: true };
 
+  // shared + read_only: enforce read-only for non-owners
   const isMongoType = database.type === "mongodb";
   let isReadOnly: boolean;
 
@@ -312,7 +293,7 @@ export function checkQueryAccess(
       : "Only SELECT, WITH, SHOW, DESCRIBE, and EXPLAIN (without ANALYZE) are allowed.";
     return {
       allowed: false,
-      error: `This database is shared as read-only. ${hint}`,
+      error: `This database is read-only. ${hint}`,
     };
   }
 
@@ -323,14 +304,19 @@ export function checkQueryAccess(
  * Checks whether a user can write to a database (used for flow destination validation).
  */
 export function canUserWriteDatabase(
-  database: Pick<IDatabaseConnection, "access" | "ownerId" | "createdBy">,
+  database: Pick<
+    IDatabaseConnection,
+    "access" | "permissions" | "ownerId" | "createdBy"
+  >,
   userId: string | undefined,
 ): boolean {
-  const access = database.access || "shared_write";
-  if (access === "shared_write") return true;
-  if (!userId) return false;
+  const access = database.access || "shared";
+  const permissions = database.permissions || "read_write";
   const ownerId = database.ownerId || database.createdBy;
-  return ownerId === userId;
+  const isOwner = !!userId && ownerId === userId;
+  if (isOwner) return true;
+  if (access === "private") return false;
+  return permissions === "read_write";
 }
 
 /**
@@ -343,10 +329,10 @@ export function canUserSeeDatabase(
   >,
   userId: string | undefined,
 ): boolean {
-  const access = database.access || "shared_write";
+  const access = database.access || "shared";
 
-  // shared_write and shared_read are visible to everyone in the workspace
-  if (access === "shared_write" || access === "shared_read") return true;
+  // shared databases are visible to everyone in the workspace
+  if (access === "shared") return true;
 
   // private: only owner + sharedWith
   if (!userId) return false;
@@ -364,8 +350,8 @@ export function getEffectiveAccess(
   database: Pick<IDatabaseConnection, "access" | "ownerId" | "createdBy">,
   userId: string | undefined,
   memberRole?: string,
-): { level: DatabaseAccessLevel; isOwner: boolean; canManage: boolean } {
-  const level = database.access || "shared_write";
+): { level: DatabaseVisibility; isOwner: boolean; canManage: boolean } {
+  const level = database.access || "shared";
   const ownerId = database.ownerId || database.createdBy;
   const isOwner = !!userId && ownerId === userId;
   const isWorkspaceAdmin = memberRole === "owner" || memberRole === "admin";

--- a/app/src/components/DatabaseExplorer.tsx
+++ b/app/src/components/DatabaseExplorer.tsx
@@ -836,7 +836,7 @@ function DatabaseExplorer({
                             letterSpacing: "0.05em",
                           }}
                         >
-                          Shared with me
+                          Workspace
                         </Typography>
                       </ListItem>
                       {sharedDatabases.map(renderDatabaseItem)}

--- a/app/src/components/DatabaseExplorer.tsx
+++ b/app/src/components/DatabaseExplorer.tsx
@@ -39,6 +39,8 @@ import {
   Layers as LayersIcon,
   Share2 as ShareIcon,
   Lock as LockIcon,
+  User as UserIcon,
+  Globe as GlobeIcon,
 } from "lucide-react";
 import { useDatabaseExplorerStore } from "../store";
 import { useWorkspace } from "../contexts/workspace-context";
@@ -250,6 +252,8 @@ function DatabaseExplorer({
   const [sharingDatabase, setSharingDatabase] = useState<Connection | null>(
     null,
   );
+  const [myDbsExpanded, setMyDbsExpanded] = useState(true);
+  const [workspaceDbsExpanded, setWorkspaceDbsExpanded] = useState(true);
 
   const myDatabases = useMemo(
     () => databases.filter(db => db.isOwner === true),
@@ -806,40 +810,79 @@ function DatabaseExplorer({
                 <>
                   {myDatabases.length > 0 && (
                     <>
-                      <ListItem sx={{ py: 0.25 }}>
-                        <Typography
-                          variant="caption"
-                          sx={{
-                            color: "text.secondary",
+                      <ListItemButton
+                        onClick={() => setMyDbsExpanded(!myDbsExpanded)}
+                        sx={{ py: 0.25, pl: 0.5 }}
+                      >
+                        <ListItemIcon sx={{ minWidth: 22, mr: 0 }}>
+                          {myDbsExpanded ? (
+                            <ChevronDownIcon strokeWidth={1.5} size={20} />
+                          ) : (
+                            <ChevronRightIcon strokeWidth={1.5} size={20} />
+                          )}
+                        </ListItemIcon>
+                        <ListItemIcon sx={{ minWidth: 24 }}>
+                          <UserIcon strokeWidth={1.5} size={18} />
+                        </ListItemIcon>
+                        <ListItemText
+                          primary="My Databases"
+                          primaryTypographyProps={{
+                            variant: "body2",
                             fontWeight: 600,
-                            textTransform: "uppercase",
-                            fontSize: "0.65rem",
-                            letterSpacing: "0.05em",
+                            sx: {
+                              textTransform: "uppercase",
+                              fontSize: "0.75rem",
+                              letterSpacing: "0.05em",
+                            },
                           }}
-                        >
-                          My Databases
-                        </Typography>
-                      </ListItem>
-                      {myDatabases.map(renderDatabaseItem)}
+                        />
+                        <Chip
+                          label={myDatabases.length}
+                          size="small"
+                          sx={{ height: 18, fontSize: "0.7rem" }}
+                        />
+                      </ListItemButton>
+                      {myDbsExpanded && myDatabases.map(renderDatabaseItem)}
                     </>
                   )}
                   {sharedDatabases.length > 0 && (
                     <>
-                      <ListItem sx={{ py: 0.25, mt: 0.5 }}>
-                        <Typography
-                          variant="caption"
-                          sx={{
-                            color: "text.secondary",
+                      <ListItemButton
+                        onClick={() =>
+                          setWorkspaceDbsExpanded(!workspaceDbsExpanded)
+                        }
+                        sx={{ py: 0.25, pl: 0.5 }}
+                      >
+                        <ListItemIcon sx={{ minWidth: 22, mr: 0 }}>
+                          {workspaceDbsExpanded ? (
+                            <ChevronDownIcon strokeWidth={1.5} size={20} />
+                          ) : (
+                            <ChevronRightIcon strokeWidth={1.5} size={20} />
+                          )}
+                        </ListItemIcon>
+                        <ListItemIcon sx={{ minWidth: 24 }}>
+                          <GlobeIcon strokeWidth={1.5} size={18} />
+                        </ListItemIcon>
+                        <ListItemText
+                          primary="Workspace"
+                          primaryTypographyProps={{
+                            variant: "body2",
                             fontWeight: 600,
-                            textTransform: "uppercase",
-                            fontSize: "0.65rem",
-                            letterSpacing: "0.05em",
+                            sx: {
+                              textTransform: "uppercase",
+                              fontSize: "0.75rem",
+                              letterSpacing: "0.05em",
+                            },
                           }}
-                        >
-                          Workspace
-                        </Typography>
-                      </ListItem>
-                      {sharedDatabases.map(renderDatabaseItem)}
+                        />
+                        <Chip
+                          label={sharedDatabases.length}
+                          size="small"
+                          sx={{ height: 18, fontSize: "0.7rem" }}
+                        />
+                      </ListItemButton>
+                      {workspaceDbsExpanded &&
+                        sharedDatabases.map(db => renderDatabaseItem(db))}
                     </>
                   )}
                 </>

--- a/app/src/components/DatabaseExplorer.tsx
+++ b/app/src/components/DatabaseExplorer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useMemo } from "react";
 import {
   Box,
   Typography,
@@ -13,6 +13,16 @@ import {
   Menu,
   MenuItem,
   Tooltip,
+  Chip,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  FormControl,
+  InputLabel,
+  Select,
+  type SelectChangeEvent,
 } from "@mui/material";
 import {
   ChevronRight as ChevronRightIcon,
@@ -27,11 +37,18 @@ import {
   Trash2 as DeleteIcon,
   Settings as SettingsIcon,
   Layers as LayersIcon,
+  Share2 as ShareIcon,
+  Lock as LockIcon,
 } from "lucide-react";
 import { useDatabaseExplorerStore } from "../store";
 import { useWorkspace } from "../contexts/workspace-context";
 import CreateDatabaseDialog from "./CreateDatabaseDialog";
-import { useSchemaStore, Connection, TreeNode } from "../store/schemaStore";
+import {
+  useSchemaStore,
+  Connection,
+  TreeNode,
+  DatabaseAccessLevel,
+} from "../store/schemaStore";
 import { useDatabaseCatalogStore } from "../store/databaseCatalogStore";
 import { useConsoleStore } from "../store/consoleStore";
 
@@ -68,6 +85,99 @@ const DatabaseTypeIcon = React.memo(
   },
 );
 DatabaseTypeIcon.displayName = "DatabaseTypeIcon";
+
+const AccessBadge = React.memo(
+  ({
+    access,
+    isOwner,
+  }: {
+    access?: DatabaseAccessLevel;
+    isOwner?: boolean;
+  }) => {
+    if (!access || access === "shared_write") return null;
+    if (access === "private") {
+      return (
+        <Tooltip title="Private">
+          <LockIcon
+            size={14}
+            strokeWidth={1.5}
+            style={{ opacity: 0.6, flexShrink: 0 }}
+          />
+        </Tooltip>
+      );
+    }
+    if (access === "shared_read" && !isOwner) {
+      return (
+        <Chip
+          label="read-only"
+          size="small"
+          variant="outlined"
+          sx={{ height: 18, fontSize: "0.65rem", flexShrink: 0 }}
+        />
+      );
+    }
+    return null;
+  },
+);
+AccessBadge.displayName = "AccessBadge";
+
+function ShareDatabaseDialog({
+  open,
+  database,
+  onClose,
+  workspaceId,
+}: {
+  open: boolean;
+  database: Connection | null;
+  onClose: () => void;
+  workspaceId: string;
+}) {
+  const shareDatabase = useSchemaStore(s => s.shareDatabase);
+  const [accessLevel, setAccessLevel] = useState<DatabaseAccessLevel>(
+    database?.access || "shared_write",
+  );
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (database?.access) setAccessLevel(database.access);
+  }, [database?.access]);
+
+  const handleSave = async () => {
+    if (!database) return;
+    setSaving(true);
+    await shareDatabase(workspaceId, database.id, { access: accessLevel });
+    setSaving(false);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Share Settings</DialogTitle>
+      <DialogContent>
+        <FormControl fullWidth sx={{ mt: 1 }}>
+          <InputLabel>Access Level</InputLabel>
+          <Select
+            value={accessLevel}
+            label="Access Level"
+            onChange={(e: SelectChangeEvent) =>
+              setAccessLevel(e.target.value as DatabaseAccessLevel)
+            }
+          >
+            <MenuItem value="shared_write">Shared (read &amp; write)</MenuItem>
+            <MenuItem value="shared_read">Shared (read-only)</MenuItem>
+            <MenuItem value="private">Private (only me)</MenuItem>
+          </Select>
+        </FormControl>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={handleSave} variant="contained" disabled={saving}>
+          {saving ? "Saving..." : "Save"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
 
 interface DatabaseExplorerProps {
   onCollectionSelect?: (
@@ -135,6 +245,19 @@ function DatabaseExplorer({
   const [editingDatabaseId, setEditingDatabaseId] = useState<
     string | undefined
   >(undefined);
+  const [shareDialogOpen, setShareDialogOpen] = useState(false);
+  const [sharingDatabase, setSharingDatabase] = useState<Connection | null>(
+    null,
+  );
+
+  const myDatabases = useMemo(
+    () => databases.filter(db => db.isOwner === true),
+    [databases],
+  );
+  const sharedDatabases = useMemo(
+    () => databases.filter(db => db.isOwner !== true),
+    [databases],
+  );
 
   // Initialize connections on mount
   useEffect(() => {
@@ -376,6 +499,18 @@ function DatabaseExplorer({
     }
   }, [databaseContextMenu, currentWorkspace, deleteConnection]);
 
+  const handleShareDatabase = useCallback(() => {
+    if (!databaseContextMenu) return;
+    const db = databases.find(
+      d => d.id === databaseContextMenu.item.databaseId,
+    );
+    if (db) {
+      setSharingDatabase(db);
+      setShareDialogOpen(true);
+    }
+    setDatabaseContextMenu(null);
+  }, [databaseContextMenu, databases]);
+
   const handleDropCollection = useCallback(() => {
     if (!contextMenu) return;
     const { databaseId, collectionName } = contextMenu.item;
@@ -580,80 +715,135 @@ function DatabaseExplorer({
               </Typography>
             </Box>
           ) : (
-            databases.map(database => {
-              const isDatabaseExpandedLocal = expandedDatabases.has(
-                database.id,
-              );
-              const isLoadingData = loadingData.has(database.id);
-              const dbRootNodes: TreeNode[] =
-                treeNodes[database.id]?.["root"] || [];
+            (() => {
+              const renderDatabaseItem = (database: Connection) => {
+                const isDatabaseExpandedLocal = expandedDatabases.has(
+                  database.id,
+                );
+                const isLoadingData = loadingData.has(database.id);
+                const dbRootNodes: TreeNode[] =
+                  treeNodes[database.id]?.["root"] || [];
 
-              return (
-                <React.Fragment key={database.id}>
-                  {/* Database Level */}
-                  <ListItem disablePadding>
-                    <ListItemButton
-                      onClick={() => handleDatabaseToggle(database.id)}
-                      onContextMenu={e =>
-                        handleDatabaseContextMenu(
-                          e,
-                          database.id,
-                          database.displayName,
-                        )
-                      }
-                      sx={{ py: 0.5, pl: 1 }}
-                    >
-                      <ListItemIcon sx={{ minWidth: 22 }}>
-                        {isDatabaseExpandedLocal ? (
-                          <ChevronDownIcon strokeWidth={1.5} size={20} />
-                        ) : (
-                          <ChevronRightIcon strokeWidth={1.5} size={20} />
-                        )}
-                      </ListItemIcon>
-                      <ListItemIcon sx={{ minWidth: 24 }}>
-                        <DatabaseTypeIcon
-                          type={database.type}
-                          typeToIconUrl={typeToIconUrl}
-                        />
-                      </ListItemIcon>
-                      <ListItemText
-                        primary={
-                          <Box
-                            sx={{
-                              display: "flex",
-                              alignItems: "center",
-                              gap: 1,
-                              overflow: "hidden",
-                            }}
-                          >
-                            <Typography
-                              variant="body2"
+                return (
+                  <React.Fragment key={database.id}>
+                    <ListItem disablePadding>
+                      <ListItemButton
+                        onClick={() => handleDatabaseToggle(database.id)}
+                        onContextMenu={e =>
+                          handleDatabaseContextMenu(
+                            e,
+                            database.id,
+                            database.displayName,
+                          )
+                        }
+                        sx={{ py: 0.5, pl: 1 }}
+                      >
+                        <ListItemIcon sx={{ minWidth: 22 }}>
+                          {isDatabaseExpandedLocal ? (
+                            <ChevronDownIcon strokeWidth={1.5} size={20} />
+                          ) : (
+                            <ChevronRightIcon strokeWidth={1.5} size={20} />
+                          )}
+                        </ListItemIcon>
+                        <ListItemIcon sx={{ minWidth: 24 }}>
+                          <DatabaseTypeIcon
+                            type={database.type}
+                            typeToIconUrl={typeToIconUrl}
+                          />
+                        </ListItemIcon>
+                        <ListItemText
+                          primary={
+                            <Box
                               sx={{
+                                display: "flex",
+                                alignItems: "center",
+                                gap: 0.5,
                                 overflow: "hidden",
-                                textOverflow: "ellipsis",
-                                whiteSpace: "nowrap",
                               }}
                             >
-                              {database.displayName}
-                            </Typography>
-                          </Box>
-                        }
-                      />
-                    </ListItemButton>
-                  </ListItem>
+                              <Typography
+                                variant="body2"
+                                sx={{
+                                  overflow: "hidden",
+                                  textOverflow: "ellipsis",
+                                  whiteSpace: "nowrap",
+                                }}
+                              >
+                                {database.displayName}
+                              </Typography>
+                              <AccessBadge
+                                access={database.access}
+                                isOwner={database.isOwner}
+                              />
+                            </Box>
+                          }
+                        />
+                      </ListItemButton>
+                    </ListItem>
 
-                  {isDatabaseExpandedLocal && (
-                    <List dense disablePadding>
-                      {isLoadingData
-                        ? renderCollectionSkeletonItems()
-                        : dbRootNodes.map(node =>
-                            renderNode(database.id, node, 1),
-                          )}
-                    </List>
+                    {isDatabaseExpandedLocal && (
+                      <List dense disablePadding>
+                        {isLoadingData
+                          ? renderCollectionSkeletonItems()
+                          : dbRootNodes.map(node =>
+                              renderNode(database.id, node, 1),
+                            )}
+                      </List>
+                    )}
+                  </React.Fragment>
+                );
+              };
+
+              const showSections =
+                myDatabases.length > 0 && sharedDatabases.length > 0;
+
+              if (!showSections) {
+                return databases.map(renderDatabaseItem);
+              }
+
+              return (
+                <>
+                  {myDatabases.length > 0 && (
+                    <>
+                      <ListItem sx={{ py: 0.25 }}>
+                        <Typography
+                          variant="caption"
+                          sx={{
+                            color: "text.secondary",
+                            fontWeight: 600,
+                            textTransform: "uppercase",
+                            fontSize: "0.65rem",
+                            letterSpacing: "0.05em",
+                          }}
+                        >
+                          My Databases
+                        </Typography>
+                      </ListItem>
+                      {myDatabases.map(renderDatabaseItem)}
+                    </>
                   )}
-                </React.Fragment>
+                  {sharedDatabases.length > 0 && (
+                    <>
+                      <ListItem sx={{ py: 0.25, mt: 0.5 }}>
+                        <Typography
+                          variant="caption"
+                          sx={{
+                            color: "text.secondary",
+                            fontWeight: 600,
+                            textTransform: "uppercase",
+                            fontSize: "0.65rem",
+                            letterSpacing: "0.05em",
+                          }}
+                        >
+                          Shared with me
+                        </Typography>
+                      </ListItem>
+                      {sharedDatabases.map(renderDatabaseItem)}
+                    </>
+                  )}
+                </>
               );
-            })
+            })()
           )}
         </List>
       </Box>
@@ -704,57 +894,93 @@ function DatabaseExplorer({
       </Menu>
 
       {/* Context Menu for database */}
-      <Menu
-        open={databaseContextMenu !== null}
-        onClose={() => setDatabaseContextMenu(null)}
-        anchorReference="anchorPosition"
-        anchorPosition={
-          databaseContextMenu !== null
-            ? {
-                top: databaseContextMenu.mouseY,
-                left: databaseContextMenu.mouseX,
-              }
-            : undefined
-        }
-        PaperProps={{
-          elevation: 2,
-          sx: {
-            boxShadow: "0px 2px 4px rgba(0,0,0,0.12)",
-            minWidth: 180,
-          },
-        }}
-      >
-        <MenuItem
-          onClick={handleEditDatabase}
-          sx={{
-            pl: 1,
-            pr: 1,
-            "& .MuiListItemIcon-root": {
-              minWidth: 26,
-            },
+      {(() => {
+        const contextDb = databaseContextMenu
+          ? databases.find(d => d.id === databaseContextMenu.item.databaseId)
+          : null;
+        const canManageCtx = contextDb?.canManage === true;
+
+        return (
+          <Menu
+            open={databaseContextMenu !== null}
+            onClose={() => setDatabaseContextMenu(null)}
+            anchorReference="anchorPosition"
+            anchorPosition={
+              databaseContextMenu !== null
+                ? {
+                    top: databaseContextMenu.mouseY,
+                    left: databaseContextMenu.mouseX,
+                  }
+                : undefined
+            }
+            PaperProps={{
+              elevation: 2,
+              sx: {
+                boxShadow: "0px 2px 4px rgba(0,0,0,0.12)",
+                minWidth: 180,
+              },
+            }}
+          >
+            {canManageCtx && (
+              <MenuItem
+                onClick={handleEditDatabase}
+                sx={{
+                  pl: 1,
+                  pr: 1,
+                  "& .MuiListItemIcon-root": { minWidth: 26 },
+                }}
+              >
+                <ListItemIcon>
+                  <SettingsIcon size={18} strokeWidth={1.5} />
+                </ListItemIcon>
+                Edit connection
+              </MenuItem>
+            )}
+            {canManageCtx && (
+              <MenuItem
+                onClick={handleShareDatabase}
+                sx={{
+                  pl: 1,
+                  pr: 1,
+                  "& .MuiListItemIcon-root": { minWidth: 26 },
+                }}
+              >
+                <ListItemIcon>
+                  <ShareIcon size={18} strokeWidth={1.5} />
+                </ListItemIcon>
+                Share settings
+              </MenuItem>
+            )}
+            {canManageCtx && (
+              <MenuItem
+                onClick={handleDropDatabase}
+                sx={{
+                  pl: 1,
+                  pr: 1,
+                  "& .MuiListItemIcon-root": { minWidth: 26 },
+                }}
+              >
+                <ListItemIcon>
+                  <DeleteIcon size={18} strokeWidth={1.5} />
+                </ListItemIcon>
+                Delete database
+              </MenuItem>
+            )}
+          </Menu>
+        );
+      })()}
+
+      {currentWorkspace && (
+        <ShareDatabaseDialog
+          open={shareDialogOpen}
+          database={sharingDatabase}
+          onClose={() => {
+            setShareDialogOpen(false);
+            setSharingDatabase(null);
           }}
-        >
-          <ListItemIcon>
-            <SettingsIcon size={18} strokeWidth={1.5} />
-          </ListItemIcon>
-          Edit connection
-        </MenuItem>
-        <MenuItem
-          onClick={handleDropDatabase}
-          sx={{
-            pl: 1,
-            pr: 1,
-            "& .MuiListItemIcon-root": {
-              minWidth: 26,
-            },
-          }}
-        >
-          <ListItemIcon>
-            <DeleteIcon size={18} strokeWidth={1.5} />
-          </ListItemIcon>
-          Delete database
-        </MenuItem>
-      </Menu>
+          workspaceId={currentWorkspace.id}
+        />
+      )}
     </Box>
   );
 }

--- a/app/src/components/DatabaseExplorer.tsx
+++ b/app/src/components/DatabaseExplorer.tsx
@@ -49,7 +49,8 @@ import {
   useSchemaStore,
   Connection,
   TreeNode,
-  DatabaseAccessLevel,
+  DatabaseVisibility,
+  DatabasePermissions,
 } from "../store/schemaStore";
 import { useDatabaseCatalogStore } from "../store/databaseCatalogStore";
 import { useConsoleStore } from "../store/consoleStore";
@@ -91,12 +92,13 @@ DatabaseTypeIcon.displayName = "DatabaseTypeIcon";
 const AccessBadge = React.memo(
   ({
     access,
+    permissions,
     isOwner,
   }: {
-    access?: DatabaseAccessLevel;
+    access?: DatabaseVisibility;
+    permissions?: DatabasePermissions;
     isOwner?: boolean;
   }) => {
-    if (!access || access === "shared_write") return null;
     if (access === "private") {
       return (
         <Tooltip title="Private">
@@ -108,7 +110,7 @@ const AccessBadge = React.memo(
         </Tooltip>
       );
     }
-    if (access === "shared_read" && !isOwner) {
+    if (access === "shared" && permissions === "read_only" && !isOwner) {
       return (
         <Chip
           label="read-only"
@@ -135,19 +137,26 @@ function ShareDatabaseDialog({
   workspaceId: string;
 }) {
   const shareDatabase = useSchemaStore(s => s.shareDatabase);
-  const [accessLevel, setAccessLevel] = useState<DatabaseAccessLevel>(
-    database?.access || "shared_write",
+  const [accessLevel, setAccessLevel] = useState<DatabaseVisibility>(
+    database?.access || "shared",
+  );
+  const [permissions, setPermissions] = useState<DatabasePermissions>(
+    database?.permissions || "read_write",
   );
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
-    if (database?.access) setAccessLevel(database.access);
-  }, [database?.access]);
+    setAccessLevel(database?.access || "shared");
+    setPermissions(database?.permissions || "read_write");
+  }, [database?.access, database?.permissions]);
 
   const handleSave = async () => {
     if (!database) return;
     setSaving(true);
-    await shareDatabase(workspaceId, database.id, { access: accessLevel });
+    await shareDatabase(workspaceId, database.id, {
+      access: accessLevel,
+      permissions,
+    });
     setSaving(false);
     onClose();
   };
@@ -155,21 +164,35 @@ function ShareDatabaseDialog({
   return (
     <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
       <DialogTitle>Share Settings</DialogTitle>
-      <DialogContent>
+      <DialogContent sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
         <FormControl fullWidth sx={{ mt: 1 }}>
-          <InputLabel>Access Level</InputLabel>
+          <InputLabel>Visibility</InputLabel>
           <Select
             value={accessLevel}
-            label="Access Level"
+            label="Visibility"
             onChange={(e: SelectChangeEvent) =>
-              setAccessLevel(e.target.value as DatabaseAccessLevel)
+              setAccessLevel(e.target.value as DatabaseVisibility)
             }
           >
-            <MenuItem value="shared_write">Shared (read &amp; write)</MenuItem>
-            <MenuItem value="shared_read">Shared (read-only)</MenuItem>
+            <MenuItem value="shared">Shared with workspace</MenuItem>
             <MenuItem value="private">Private (only me)</MenuItem>
           </Select>
         </FormControl>
+        {accessLevel === "shared" && (
+          <FormControl fullWidth>
+            <InputLabel>Permissions</InputLabel>
+            <Select
+              value={permissions}
+              label="Permissions"
+              onChange={(e: SelectChangeEvent) =>
+                setPermissions(e.target.value as DatabasePermissions)
+              }
+            >
+              <MenuItem value="read_write">Read & Write</MenuItem>
+              <MenuItem value="read_only">Read only</MenuItem>
+            </Select>
+          </FormControl>
+        )}
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>Cancel</Button>
@@ -256,11 +279,11 @@ function DatabaseExplorer({
   const [workspaceDbsExpanded, setWorkspaceDbsExpanded] = useState(true);
 
   const myDatabases = useMemo(
-    () => databases.filter(db => db.isOwner === true),
+    () => databases.filter(db => db.access === "private"),
     [databases],
   );
   const sharedDatabases = useMemo(
-    () => databases.filter(db => db.isOwner !== true),
+    () => databases.filter(db => db.access !== "private"),
     [databases],
   );
 
@@ -778,6 +801,7 @@ function DatabaseExplorer({
                               </Typography>
                               <AccessBadge
                                 access={database.access}
+                                permissions={database.permissions}
                                 isOwner={database.isOwner}
                               />
                             </Box>
@@ -799,92 +823,98 @@ function DatabaseExplorer({
                 );
               };
 
-              const showSections =
-                myDatabases.length > 0 && sharedDatabases.length > 0;
-
-              if (!showSections) {
-                return databases.map(renderDatabaseItem);
-              }
-
               return (
                 <>
-                  {myDatabases.length > 0 && (
-                    <>
-                      <ListItemButton
-                        onClick={() => setMyDbsExpanded(!myDbsExpanded)}
-                        sx={{ py: 0.25, pl: 0.5 }}
+                  <ListItemButton
+                    onClick={() => setMyDbsExpanded(!myDbsExpanded)}
+                    sx={{ py: 0.25, pl: 0.5 }}
+                  >
+                    <ListItemIcon sx={{ minWidth: 22, mr: 0 }}>
+                      {myDbsExpanded ? (
+                        <ChevronDownIcon strokeWidth={1.5} size={20} />
+                      ) : (
+                        <ChevronRightIcon strokeWidth={1.5} size={20} />
+                      )}
+                    </ListItemIcon>
+                    <ListItemIcon sx={{ minWidth: 24 }}>
+                      <DatabaseIcon size={18} strokeWidth={1.5} />
+                    </ListItemIcon>
+                    <ListItemText
+                      primary="My Databases"
+                      primaryTypographyProps={{
+                        variant: "body2",
+                        fontWeight: 600,
+                        sx: {
+                          textTransform: "uppercase",
+                          fontSize: "0.75rem",
+                          letterSpacing: "0.05em",
+                        },
+                      }}
+                    />
+                    <Chip
+                      label={myDatabases.length}
+                      size="small"
+                      sx={{ height: 18, fontSize: "0.7rem" }}
+                    />
+                  </ListItemButton>
+                  {myDbsExpanded &&
+                    (myDatabases.length > 0 ? (
+                      myDatabases.map(renderDatabaseItem)
+                    ) : (
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ pl: 5, py: 0.5, display: "block" }}
                       >
-                        <ListItemIcon sx={{ minWidth: 22, mr: 0 }}>
-                          {myDbsExpanded ? (
-                            <ChevronDownIcon strokeWidth={1.5} size={20} />
-                          ) : (
-                            <ChevronRightIcon strokeWidth={1.5} size={20} />
-                          )}
-                        </ListItemIcon>
-                        <ListItemIcon sx={{ minWidth: 24 }}>
-                          <UserIcon strokeWidth={1.5} size={18} />
-                        </ListItemIcon>
-                        <ListItemText
-                          primary="My Databases"
-                          primaryTypographyProps={{
-                            variant: "body2",
-                            fontWeight: 600,
-                            sx: {
-                              textTransform: "uppercase",
-                              fontSize: "0.75rem",
-                              letterSpacing: "0.05em",
-                            },
-                          }}
-                        />
-                        <Chip
-                          label={myDatabases.length}
-                          size="small"
-                          sx={{ height: 18, fontSize: "0.7rem" }}
-                        />
-                      </ListItemButton>
-                      {myDbsExpanded && myDatabases.map(renderDatabaseItem)}
-                    </>
-                  )}
-                  {sharedDatabases.length > 0 && (
-                    <>
-                      <ListItemButton
-                        onClick={() =>
-                          setWorkspaceDbsExpanded(!workspaceDbsExpanded)
-                        }
-                        sx={{ py: 0.25, pl: 0.5 }}
+                        No databases yet
+                      </Typography>
+                    ))}
+                  <ListItemButton
+                    onClick={() =>
+                      setWorkspaceDbsExpanded(!workspaceDbsExpanded)
+                    }
+                    sx={{ py: 0.25, pl: 0.5 }}
+                  >
+                    <ListItemIcon sx={{ minWidth: 22, mr: 0 }}>
+                      {workspaceDbsExpanded ? (
+                        <ChevronDownIcon strokeWidth={1.5} size={20} />
+                      ) : (
+                        <ChevronRightIcon strokeWidth={1.5} size={20} />
+                      )}
+                    </ListItemIcon>
+                    <ListItemIcon sx={{ minWidth: 24 }}>
+                      <GlobeIcon strokeWidth={1.5} size={18} />
+                    </ListItemIcon>
+                    <ListItemText
+                      primary="Workspace"
+                      primaryTypographyProps={{
+                        variant: "body2",
+                        fontWeight: 600,
+                        sx: {
+                          textTransform: "uppercase",
+                          fontSize: "0.75rem",
+                          letterSpacing: "0.05em",
+                        },
+                      }}
+                    />
+                    <Chip
+                      label={sharedDatabases.length}
+                      size="small"
+                      sx={{ height: 18, fontSize: "0.7rem" }}
+                    />
+                  </ListItemButton>
+                  {workspaceDbsExpanded &&
+                    (sharedDatabases.length > 0 ? (
+                      sharedDatabases.map(db => renderDatabaseItem(db))
+                    ) : (
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ pl: 5, py: 0.5, display: "block" }}
                       >
-                        <ListItemIcon sx={{ minWidth: 22, mr: 0 }}>
-                          {workspaceDbsExpanded ? (
-                            <ChevronDownIcon strokeWidth={1.5} size={20} />
-                          ) : (
-                            <ChevronRightIcon strokeWidth={1.5} size={20} />
-                          )}
-                        </ListItemIcon>
-                        <ListItemIcon sx={{ minWidth: 24 }}>
-                          <GlobeIcon strokeWidth={1.5} size={18} />
-                        </ListItemIcon>
-                        <ListItemText
-                          primary="Workspace"
-                          primaryTypographyProps={{
-                            variant: "body2",
-                            fontWeight: 600,
-                            sx: {
-                              textTransform: "uppercase",
-                              fontSize: "0.75rem",
-                              letterSpacing: "0.05em",
-                            },
-                          }}
-                        />
-                        <Chip
-                          label={sharedDatabases.length}
-                          size="small"
-                          sx={{ height: 18, fontSize: "0.7rem" }}
-                        />
-                      </ListItemButton>
-                      {workspaceDbsExpanded &&
-                        sharedDatabases.map(db => renderDatabaseItem(db))}
-                    </>
-                  )}
+                        No workspace databases yet
+                      </Typography>
+                    ))}
                 </>
               );
             })()

--- a/app/src/components/DatabaseExplorer.tsx
+++ b/app/src/components/DatabaseExplorer.tsx
@@ -205,9 +205,10 @@ function DatabaseExplorer({
 
   const { currentWorkspace } = useWorkspace();
 
-  const databases: Connection[] = currentWorkspace
-    ? connections[currentWorkspace.id] || []
-    : [];
+  const databases: Connection[] = useMemo(
+    () => (currentWorkspace ? connections[currentWorkspace.id] || [] : []),
+    [connections, currentWorkspace],
+  );
 
   const isLoadingConnections = currentWorkspace
     ? !!loading[`connections:${currentWorkspace.id}`]
@@ -902,7 +903,7 @@ function DatabaseExplorer({
 
         return (
           <Menu
-            open={databaseContextMenu !== null}
+            open={databaseContextMenu !== null && canManageCtx}
             onClose={() => setDatabaseContextMenu(null)}
             anchorReference="anchorPosition"
             anchorPosition={

--- a/app/src/components/DbFlowForm.tsx
+++ b/app/src/components/DbFlowForm.tsx
@@ -222,7 +222,15 @@ export const DbFlowForm = forwardRef<DbFlowFormRef, DbFlowFormProps>(
       : null;
     const connectionsMap = useSchemaStore(state => state.connections);
     const databases = useMemo(
-      () => (currentWorkspace ? connectionsMap[currentWorkspace.id] || [] : []),
+      () =>
+        (currentWorkspace
+          ? connectionsMap[currentWorkspace.id] || []
+          : []
+        ).filter(
+          db =>
+            db.isOwner ||
+            (db.access !== "private" && db.permissions !== "read_only"),
+        ),
       [currentWorkspace, connectionsMap],
     );
     const ensureConnections = useSchemaStore(state => state.ensureConnections);

--- a/app/src/components/ScheduledFlowForm.tsx
+++ b/app/src/components/ScheduledFlowForm.tsx
@@ -145,7 +145,15 @@ export function ScheduledFlowForm({
     : null;
   const connectionsMap = useSchemaStore(state => state.connections);
   const databases = useMemo(
-    () => (currentWorkspace ? connectionsMap[currentWorkspace.id] || [] : []),
+    () =>
+      (currentWorkspace
+        ? connectionsMap[currentWorkspace.id] || []
+        : []
+      ).filter(
+        db =>
+          db.isOwner ||
+          (db.access !== "private" && db.permissions !== "read_only"),
+      ),
     [currentWorkspace, connectionsMap],
   );
   const ensureConnections = useSchemaStore(state => state.ensureConnections);

--- a/app/src/components/WebhookFlowForm.tsx
+++ b/app/src/components/WebhookFlowForm.tsx
@@ -322,9 +322,13 @@ export function WebhookFlowForm({
     : null;
   const connectionsMap = useSchemaStore(state => state.connections);
   const ensureConnections = useSchemaStore(state => state.ensureConnections);
-  const databases = currentWorkspace
+  const allDatabases = currentWorkspace
     ? connectionsMap[currentWorkspace.id] || []
     : [];
+  const databases = allDatabases.filter(
+    db =>
+      db.isOwner || (db.access !== "private" && db.permissions !== "read_only"),
+  );
 
   const [connectors, setConnectors] = useState<any[]>([]);
   const [isLoadingConnectors, setIsLoadingConnectors] = useState(false);

--- a/app/src/store/schemaStore.ts
+++ b/app/src/store/schemaStore.ts
@@ -8,7 +8,8 @@ import { apiClient } from "../lib/api-client";
 // Types
 // ============================================================================
 
-export type DatabaseAccessLevel = "private" | "shared_read" | "shared_write";
+export type DatabaseVisibility = "private" | "shared";
+export type DatabasePermissions = "read_write" | "read_only";
 
 /** Database connection/server */
 export interface Connection {
@@ -26,7 +27,8 @@ export interface Connection {
   displayName: string;
   hostKey: string;
   hostName: string;
-  access?: DatabaseAccessLevel;
+  access?: DatabaseVisibility;
+  permissions?: DatabasePermissions;
   isOwner?: boolean;
   canManage?: boolean;
   ownerId?: string;
@@ -177,7 +179,11 @@ interface SchemaState {
   shareDatabase: (
     workspaceId: string,
     databaseId: string,
-    settings: { access?: DatabaseAccessLevel; sharedWith?: string[] },
+    settings: {
+      access?: DatabaseVisibility;
+      permissions?: DatabasePermissions;
+      sharedWith?: string[];
+    },
   ) => Promise<{ success: boolean; error?: string }>;
 
   // === Console Template ===

--- a/app/src/store/schemaStore.ts
+++ b/app/src/store/schemaStore.ts
@@ -8,6 +8,8 @@ import { apiClient } from "../lib/api-client";
 // Types
 // ============================================================================
 
+export type DatabaseAccessLevel = "private" | "shared_read" | "shared_write";
+
 /** Database connection/server */
 export interface Connection {
   id: string;
@@ -24,6 +26,10 @@ export interface Connection {
   displayName: string;
   hostKey: string;
   hostName: string;
+  access?: DatabaseAccessLevel;
+  isOwner?: boolean;
+  canManage?: boolean;
+  ownerId?: string;
 }
 
 /** Tree node for databases, datasets, schemas, tables, etc. */
@@ -166,6 +172,13 @@ interface SchemaState {
     payload: Record<string, unknown>,
     databaseId?: string,
   ) => Promise<{ success: boolean; data?: unknown; error?: string }>;
+
+  // === Sharing ===
+  shareDatabase: (
+    workspaceId: string,
+    databaseId: string,
+    settings: { access?: DatabaseAccessLevel; sharedWith?: string[] },
+  ) => Promise<{ success: boolean; error?: string }>;
 
   // === Console Template ===
   fetchConsoleTemplate: (
@@ -606,6 +619,31 @@ export const useSchemaStore = create<SchemaState>()(
 
           // Refresh connections list
           await get().refreshConnections(workspaceId);
+        }
+      },
+
+      shareDatabase: async (workspaceId, databaseId, settings) => {
+        try {
+          const res = await apiClient.post<{
+            success: boolean;
+            error?: string;
+          }>(
+            `/workspaces/${workspaceId}/databases/${databaseId}/share`,
+            settings,
+          );
+
+          if (res.success) {
+            await get().refreshConnections(workspaceId);
+          }
+          return { success: res.success, error: res.error };
+        } catch (error) {
+          return {
+            success: false,
+            error:
+              error instanceof Error
+                ? error.message
+                : "Failed to update sharing settings",
+          };
         }
       },
 


### PR DESCRIPTION
## Summary

Introduces database-level access controls with a two-dimensional model, addressing issue #113.

**Visibility** (`access` field) — controls where the database appears:
| Value | Section | Who can see it |
|-------|---------|---------------|
| `shared` (default) | Workspace | All workspace members |
| `private` | My Databases | Owner only |

**Permissions** (`permissions` field) — controls what non-owners can do on shared databases:
| Value | Non-owner access |
|-------|-----------------|
| `read_write` (default) | Full read + write |
| `read_only` | SELECT, find, aggregate only |

Owner always has full access regardless of permissions setting.

## Enforcement (6 layers)

1. **API routes** (`workspace-databases.ts`) — list filtering by visibility, execute gating, CRUD restricted to owner/admin, new `/share` endpoint for visibility + permissions changes
2. **Console routes** (`consoles.ts`) — `checkQueryAccess` before query execution
3. **Flow routes** (`flows.ts`) — validates write access to destination DB at flow creation; validates read access to source DB for db-to-db flows
4. **Agent tools** (`sql-tools.ts`, `mongodb-tools.ts`, `universal-tools.ts`) — filters private DBs from listings, enforces `checkQueryAccess` on execute, shows [read-only] label
5. **Frontend** (`DatabaseExplorer.tsx`) — always-visible My Databases / Workspace sections, share dialog, access badges, context menu gated on `canManage`
6. **Flow forms** (`WebhookFlowForm`, `ScheduledFlowForm`, `DbFlowForm`) — destination database dropdown only shows writable databases

System-level paths (Inngest flow execution, CDC, sync orchestrator, dashboard refresh) are exempt — authorized at flow creation time.

## New service: `database-access.service.ts`

Centralized access control logic:
- `checkQueryAccess` — fail-closed query gating (read-only enforcement uses a state-machine SQL parser, not regex)
- `canUserWriteDatabase` — used for flow destination validation
- `canUserSeeDatabase` — visibility filtering
- `getEffectiveAccess` — returns `isOwner` + `canManage` (owner OR workspace admin)
- `isSqlReadOnly` / `isMongoReadOnly` — query classification with EXPLAIN ANALYZE blocked

## Frontend details

- **Section headers**: always-visible collapsible My Databases (database icon) / Workspace (globe icon) with count chips and empty-state text
- **Share dialog**: visibility dropdown + conditional permissions toggle (only shown when shared)
- **Access badges**: lock icon for private, read-only chip for shared + read_only
- **Context menu**: edit/share/delete gated on `canManage` (owner or workspace admin)
- **Flow forms**: destination picker filtered to `isOwner || (shared && read_write)`

## Files changed (16)

| Area | Files |
|------|-------|
| Schema | `workspace-schema.ts` — `DatabaseVisibility`, `DatabasePermissions` types + fields |
| Migration | `2026-03-23-300000_add_database_access_controls.ts` — backfills ownerId, access, permissions, sharedWith |
| Service | `database-access.service.ts` (new) — centralized access control |
| API routes | `workspace-databases.ts`, `consoles.ts`, `flows.ts` |
| Agent tools | `mongodb-tools.ts`, `sql-tools.ts`, `universal-tools.ts` |
| Agents | `console/index.ts`, `flow/index.ts` |
| Frontend | `DatabaseExplorer.tsx`, `schemaStore.ts`, `DbFlowForm.tsx`, `ScheduledFlowForm.tsx`, `WebhookFlowForm.tsx` |

## Test plan

- [ ] Create a database — defaults to shared / read_write, appears in Workspace section
- [ ] Change visibility to private via share dialog — moves to My Databases, hidden from other users
- [ ] Set shared database to read_only — non-owners see read-only badge, write queries blocked with descriptive error
- [ ] Flow creation — destination dropdown only shows writable databases (owned or shared+read_write)
- [ ] Context menu — only visible for owner or workspace admin
- [ ] Empty sections show placeholder text (No databases yet / No workspace databases yet)
- [ ] Agent tools respect visibility and permissions (private DBs hidden, read-only enforced)

Closes #113