### PR TITLE
feat: immutable versioning for saved consoles and dashboards

### DIFF
--- a/api/src/agent-lib/tools/version-history-tools.ts
+++ b/api/src/agent-lib/tools/version-history-tools.ts
@@ -4,7 +4,7 @@ import {
   getVersion,
 } from "../../services/entity-version.service";
 
-export const createVersionHistoryTools = (_workspaceId: string) => ({
+export const createVersionHistoryTools = (workspaceId: string) => ({
   browse_version_history: {
     description:
       "Browse the version history of a saved console or dashboard. " +
@@ -35,6 +35,7 @@ export const createVersionHistoryTools = (_workspaceId: string) => ({
       try {
         const result = await listVersions(entityId, entityType, {
           limit: limit || 10,
+          workspaceId,
         });
         return {
           success: true as const,
@@ -85,7 +86,7 @@ export const createVersionHistoryTools = (_workspaceId: string) => ({
       version: number;
     }) => {
       try {
-        const v = await getVersion(entityId, entityType, version);
+        const v = await getVersion(entityId, entityType, version, workspaceId);
         if (!v) {
           return {
             success: false as const,

--- a/api/src/agent-lib/tools/version-history-tools.ts
+++ b/api/src/agent-lib/tools/version-history-tools.ts
@@ -1,0 +1,117 @@
+import { z } from "zod";
+import {
+  listVersions,
+  getVersion,
+} from "../../services/entity-version.service";
+
+export const createVersionHistoryTools = (_workspaceId: string) => ({
+  browse_version_history: {
+    description:
+      "Browse the version history of a saved console or dashboard. " +
+      "Returns a list of past versions with who saved them, when, and their commit comment. " +
+      "Use after search_consoles or search_dashboards to inspect change history, " +
+      "understand who changed what, or help the user decide which version to restore. " +
+      "Pass the entityId from a search result.",
+    inputSchema: z.object({
+      entityType: z
+        .enum(["console", "dashboard"])
+        .describe("Whether this is a console or dashboard"),
+      entityId: z.string().describe("The ID of the console or dashboard"),
+      limit: z
+        .number()
+        .optional()
+        .default(10)
+        .describe("Max versions to return (default 10)"),
+    }),
+    execute: async ({
+      entityType,
+      entityId,
+      limit,
+    }: {
+      entityType: "console" | "dashboard";
+      entityId: string;
+      limit?: number;
+    }) => {
+      try {
+        const result = await listVersions(entityId, entityType, {
+          limit: limit || 10,
+        });
+        return {
+          success: true as const,
+          entityType,
+          entityId,
+          total: result.total,
+          versions: result.versions.map(v => ({
+            version: v.version,
+            savedBy: v.savedByName,
+            comment: v.comment || "(no comment)",
+            restoredFrom: v.restoredFrom ?? null,
+            createdAt: v.createdAt,
+          })),
+          message: `Found ${result.total} version(s) for this ${entityType}`,
+        };
+      } catch (error) {
+        return {
+          success: false as const,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Failed to browse version history",
+        };
+      }
+    },
+  },
+
+  get_version_snapshot: {
+    description:
+      "Get the full snapshot of a specific version of a console or dashboard. " +
+      "Use this to show the user what a past version looked like, or to compare " +
+      "with the current state. For consoles, the snapshot includes the code; " +
+      "for dashboards, it includes widgets, data sources, and layout.",
+    inputSchema: z.object({
+      entityType: z
+        .enum(["console", "dashboard"])
+        .describe("Whether this is a console or dashboard"),
+      entityId: z.string().describe("The ID of the console or dashboard"),
+      version: z.number().describe("The version number to retrieve"),
+    }),
+    execute: async ({
+      entityType,
+      entityId,
+      version,
+    }: {
+      entityType: "console" | "dashboard";
+      entityId: string;
+      version: number;
+    }) => {
+      try {
+        const v = await getVersion(entityId, entityType, version);
+        if (!v) {
+          return {
+            success: false as const,
+            error: `Version ${version} not found`,
+          };
+        }
+        return {
+          success: true as const,
+          entityType,
+          entityId,
+          version: v.version,
+          savedBy: v.savedByName,
+          comment: v.comment || "(no comment)",
+          restoredFrom: v.restoredFrom ?? null,
+          createdAt: v.createdAt,
+          snapshot: v.snapshot,
+        };
+      } catch (error) {
+        return {
+          success: false as const,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Failed to get version snapshot",
+        };
+      }
+    },
+  },
+});

--- a/api/src/agents/console/index.ts
+++ b/api/src/agents/console/index.ts
@@ -15,6 +15,7 @@ import { UNIVERSAL_PROMPT_V2 } from "../../agent-lib/prompts/universal";
 import { createUniversalTools } from "../../agent-lib/tools/universal-tools";
 import { createSelfDirectiveTools } from "../../agent-lib/tools/self-directive-tool";
 import { createConsoleSearchTools } from "../../agent-lib/tools/console-search-tools";
+import { createVersionHistoryTools } from "../../agent-lib/tools/version-history-tools";
 import type { ConsoleDataV2 } from "../../agent-lib/types";
 
 /**
@@ -211,6 +212,7 @@ export const consoleAgentFactory: AgentFactory = (
     workspaceId,
     context.toolExecutionContext,
   );
+  const versionHistoryTools = createVersionHistoryTools(workspaceId);
 
   return {
     systemPrompt: [
@@ -230,6 +232,7 @@ export const consoleAgentFactory: AgentFactory = (
       ...tools,
       ...selfDirectiveTools,
       ...consoleSearchTools,
+      ...versionHistoryTools,
     } as Record<string, any>,
   };
 };

--- a/api/src/agents/dashboard/index.ts
+++ b/api/src/agents/dashboard/index.ts
@@ -15,6 +15,7 @@ import { clientDashboardTools } from "../../agent-lib/tools/dashboard-tools-clie
 import { createSelfDirectiveTools } from "../../agent-lib/tools/self-directive-tool";
 import { createConsoleSearchTools } from "../../agent-lib/tools/console-search-tools";
 import { createDashboardSearchTools } from "../../agent-lib/tools/dashboard-search-tools";
+import { createVersionHistoryTools } from "../../agent-lib/tools/version-history-tools";
 
 /**
  * Dashboard agent metadata for UI and routing
@@ -44,6 +45,7 @@ export function dashboardAgentFactory(context: AgentContext): AgentConfig {
     workspaceId,
     context.toolExecutionContext,
   );
+  const versionHistoryTools = createVersionHistoryTools(workspaceId);
 
   const runtimeContext = buildDashboardRuntimeContext(context);
 
@@ -66,6 +68,7 @@ export function dashboardAgentFactory(context: AgentContext): AgentConfig {
       ...selfDirectiveTools,
       ...consoleSearchTools,
       ...dashboardSearchTools,
+      ...versionHistoryTools,
     } as Record<string, unknown>,
   };
 }

--- a/api/src/agents/types.ts
+++ b/api/src/agents/types.ts
@@ -46,8 +46,21 @@ export interface AgentMeta {
 export interface AgentContext {
   /** Current workspace ID */
   workspaceId: string;
-  /** What the user is currently looking at */
+  /** What the user is currently looking at (the active editor tab's kind) */
   activeView?: "console" | "dashboard" | "flow-editor" | "empty";
+  /**
+   * Which left-pane explorer is currently open and visible, or `null` if the
+   * left pane is collapsed. Use this when guiding the user to a specific
+   * explorer panel (e.g. "open the Databases panel on the left"), instead of
+   * assuming a panel is always visible.
+   */
+  activeExplorer?:
+    | "databases"
+    | "consoles"
+    | "connectors"
+    | "flows"
+    | "dashboards"
+    | null;
   /** Current user ID (if session auth) */
   userId?: string;
   /** Open console tabs (for console agent) */

--- a/api/src/agents/unified/index.ts
+++ b/api/src/agents/unified/index.ts
@@ -5,6 +5,7 @@ import { createSelfDirectiveTools } from "../../agent-lib/tools/self-directive-t
 import { createConsoleSearchTools } from "../../agent-lib/tools/console-search-tools";
 import { createDashboardSearchTools } from "../../agent-lib/tools/dashboard-search-tools";
 import { createFlowTools } from "../flow";
+import { createVersionHistoryTools } from "../../agent-lib/tools/version-history-tools";
 import { UNIFIED_SYSTEM_PROMPT, buildCurrentScreenContext } from "./prompt";
 
 export const unifiedAgentMeta: AgentMeta = {
@@ -35,6 +36,7 @@ export function unifiedAgentFactory(context: AgentContext): AgentConfig {
     workspaceId,
     context.toolExecutionContext,
   );
+  const versionHistoryTools = createVersionHistoryTools(workspaceId);
 
   const {
     list_connections: _flowListConnections,
@@ -65,6 +67,7 @@ export function unifiedAgentFactory(context: AgentContext): AgentConfig {
       ...selfDirectiveTools,
       ...consoleSearchTools,
       ...dashboardSearchTools,
+      ...versionHistoryTools,
     } as Record<string, unknown>,
   };
 }

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -395,6 +395,7 @@ export interface ISavedConsole extends Document {
   isSaved: boolean; // true = explicitly saved, false/undefined = draft
   access: ConsoleAccessLevel;
   owner_id: string;
+  version: number;
   is_deleted?: boolean;
   deletedAt?: Date;
   createdAt: Date;
@@ -1381,6 +1382,10 @@ const SavedConsoleSchema = new Schema<ISavedConsole>(
     executionCount: {
       type: Number,
       default: 0,
+    },
+    version: {
+      type: Number,
+      default: 1,
     },
     is_deleted: {
       type: Boolean,
@@ -2867,6 +2872,88 @@ export const Connector = mongoose.model<IConnector>(
   "Connector",
   ConnectorSchema,
 );
+/**
+ * EntityVersion — immutable append-only version snapshots for consoles and dashboards.
+ * Every explicit save creates a new version record; history is never rewritten.
+ */
+export type VersionableEntityType = "console" | "dashboard";
+
+export interface IEntityVersion extends Document {
+  _id: Types.ObjectId;
+  workspaceId: Types.ObjectId;
+  entityType: VersionableEntityType;
+  entityId: Types.ObjectId;
+  version: number;
+  snapshot: Record<string, unknown>;
+  savedBy: string;
+  savedByName: string;
+  comment: string;
+  restoredFrom?: number;
+  createdAt: Date;
+}
+
+const EntityVersionSchema = new Schema<IEntityVersion>(
+  {
+    workspaceId: {
+      type: Schema.Types.ObjectId,
+      ref: "Workspace",
+      required: true,
+    },
+    entityType: {
+      type: String,
+      enum: ["console", "dashboard"],
+      required: true,
+    },
+    entityId: {
+      type: Schema.Types.ObjectId,
+      required: true,
+    },
+    version: {
+      type: Number,
+      required: true,
+    },
+    snapshot: {
+      type: Schema.Types.Mixed,
+      required: true,
+    },
+    savedBy: {
+      type: String,
+      required: true,
+    },
+    savedByName: {
+      type: String,
+      required: true,
+    },
+    comment: {
+      type: String,
+      default: "",
+    },
+    restoredFrom: {
+      type: Number,
+    },
+  },
+  {
+    collection: "entity_versions",
+    timestamps: { createdAt: true, updatedAt: false },
+  },
+);
+
+EntityVersionSchema.index({ entityId: 1, version: -1 });
+EntityVersionSchema.index(
+  { entityId: 1, entityType: 1, version: 1 },
+  { unique: true },
+);
+EntityVersionSchema.index({
+  workspaceId: 1,
+  entityType: 1,
+  createdAt: -1,
+});
+
+export const EntityVersion = mongoose.model<IEntityVersion>(
+  "EntityVersion",
+  EntityVersionSchema,
+);
+
 export const ConsoleFolder = mongoose.model<IConsoleFolder>(
   "ConsoleFolder",
   ConsoleFolderSchema,

--- a/api/src/migrations/2026-04-05-075746_add_entity_versions_collection.ts
+++ b/api/src/migrations/2026-04-05-075746_add_entity_versions_collection.ts
@@ -1,0 +1,154 @@
+import { Db } from "mongodb";
+
+export const description =
+  "Create entity_versions collection with indexes and seed v1 for existing saved consoles and dashboards";
+
+export async function up(db: Db): Promise<void> {
+  const col = db.collection("entity_versions");
+
+  const indexes = await col.listIndexes().toArray();
+  const hasKeys = (kp: Record<string, number>) =>
+    indexes.some(i => JSON.stringify(i.key) === JSON.stringify(kp));
+
+  if (!hasKeys({ entityId: 1, version: -1 })) {
+    await col.createIndex({ entityId: 1, version: -1 });
+  }
+  if (!hasKeys({ entityId: 1, entityType: 1, version: 1 })) {
+    await col.createIndex(
+      { entityId: 1, entityType: 1, version: 1 },
+      { unique: true },
+    );
+  }
+  if (!hasKeys({ workspaceId: 1, entityType: 1, createdAt: -1 })) {
+    await col.createIndex({ workspaceId: 1, entityType: 1, createdAt: -1 });
+  }
+
+  // Set version: 1 on all saved consoles that don't have it yet
+  await db
+    .collection("savedconsoles")
+    .updateMany(
+      { isSaved: true, version: { $exists: false } },
+      { $set: { version: 1 } },
+    );
+
+  // Seed v1 for existing saved consoles without a version record
+  const savedConsoles = await db
+    .collection("savedconsoles")
+    .find({ isSaved: true })
+    .project({
+      _id: 1,
+      workspaceId: 1,
+      name: 1,
+      description: 1,
+      code: 1,
+      language: 1,
+      connectionId: 1,
+      databaseName: 1,
+      databaseId: 1,
+      chartSpec: 1,
+      resultsViewMode: 1,
+      mongoOptions: 1,
+      folderId: 1,
+      access: 1,
+      createdBy: 1,
+      createdAt: 1,
+    })
+    .toArray();
+
+  for (const c of savedConsoles) {
+    const exists = await col.findOne({
+      entityId: c._id,
+      entityType: "console",
+      version: 1,
+    });
+    if (exists) continue;
+
+    // Look up display name
+    const user = await db
+      .collection("users")
+      .findOne({ _id: c.createdBy }, { projection: { name: 1, email: 1 } });
+    const displayName = user?.name || user?.email || String(c.createdBy);
+
+    await col.insertOne({
+      workspaceId: c.workspaceId,
+      entityType: "console",
+      entityId: c._id,
+      version: 1,
+      snapshot: {
+        name: c.name,
+        description: c.description,
+        code: c.code,
+        language: c.language,
+        connectionId: c.connectionId?.toString(),
+        databaseName: c.databaseName,
+        databaseId: c.databaseId,
+        chartSpec: c.chartSpec,
+        resultsViewMode: c.resultsViewMode,
+        mongoOptions: c.mongoOptions,
+        folderId: c.folderId?.toString(),
+        access: c.access ?? "private",
+      },
+      savedBy: String(c.createdBy),
+      savedByName: displayName,
+      comment: "Initial version (migrated)",
+      createdAt: c.createdAt ?? new Date(),
+    });
+  }
+
+  // Seed v1 for existing dashboards without a version record
+  const dashboards = await db
+    .collection("dashboards")
+    .find({})
+    .project({
+      _id: 1,
+      workspaceId: 1,
+      title: 1,
+      description: 1,
+      dataSources: 1,
+      widgets: 1,
+      relationships: 1,
+      globalFilters: 1,
+      crossFilter: 1,
+      layout: 1,
+      materializationSchedule: 1,
+      createdBy: 1,
+      createdAt: 1,
+    })
+    .toArray();
+
+  for (const d of dashboards) {
+    const exists = await col.findOne({
+      entityId: d._id,
+      entityType: "dashboard",
+      version: 1,
+    });
+    if (exists) continue;
+
+    const user = await db
+      .collection("users")
+      .findOne({ _id: d.createdBy }, { projection: { name: 1, email: 1 } });
+    const displayName = user?.name || user?.email || String(d.createdBy);
+
+    await col.insertOne({
+      workspaceId: d.workspaceId,
+      entityType: "dashboard",
+      entityId: d._id,
+      version: 1,
+      snapshot: {
+        title: d.title,
+        description: d.description,
+        dataSources: d.dataSources,
+        widgets: d.widgets,
+        relationships: d.relationships,
+        globalFilters: d.globalFilters,
+        crossFilter: d.crossFilter,
+        layout: d.layout,
+        materializationSchedule: d.materializationSchedule,
+      },
+      savedBy: String(d.createdBy),
+      savedByName: displayName,
+      comment: "Initial version (migrated)",
+      createdAt: d.createdAt ?? new Date(),
+    });
+  }
+}

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -222,6 +222,7 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
     // Agent mode selection (new)
     agentId,
     activeView,
+    activeExplorer,
     tabKind,
     flowType,
     flowFormState,
@@ -238,6 +239,13 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
     activeConsoleResults?: ActiveConsoleResults;
     agentId?: string;
     activeView?: "console" | "dashboard" | "flow-editor" | "empty";
+    activeExplorer?:
+      | "databases"
+      | "consoles"
+      | "connectors"
+      | "flows"
+      | "dashboards"
+      | null;
     tabKind?: string;
     flowType?: string;
     flowFormState?: Record<string, unknown>;
@@ -523,6 +531,7 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
   const agentContext: AgentContext = {
     workspaceId,
     activeView,
+    activeExplorer,
     userId: actorId,
     consoles: enrichedConsoles,
     consoleId,

--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -2264,7 +2264,8 @@ consoleRoutes.post("/:id/versions/:version/restore", async (c: Context) => {
 
     const snap = oldVersion.snapshot as Record<string, any>;
 
-    // Apply the snapshot to the console document
+    // Apply the snapshot to the console document. Includes every field
+    // captured in buildConsoleSnapshot so restore is a true revert.
     const restoreFields: Record<string, any> = {
       code: snap.code,
       name: snap.name,
@@ -2278,6 +2279,8 @@ consoleRoutes.post("/:id/versions/:version/restore", async (c: Context) => {
         : undefined,
       databaseName: snap.databaseName,
       databaseId: snap.databaseId,
+      folderId: snap.folderId ? new Types.ObjectId(snap.folderId) : null,
+      access: snap.access,
     };
 
     const restored = await SavedConsole.findOneAndUpdate(

--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -865,23 +865,23 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
       },
     );
 
-    // Create version record and increment version counter
-    const updatedForVersion = await SavedConsole.findByIdAndUpdate(
-      savedConsole._id,
-      { $inc: { version: 1 } },
-      { new: true },
-    ).lean();
-    if (updatedForVersion) {
+    // Create version 1 for this new console
+    const freshDocPath = await SavedConsole.findById(savedConsole._id).lean();
+    if (freshDocPath) {
       const displayNamePath = await getUserDisplayName(user.id);
       await createVersion({
         entityType: "console",
         entityId: savedConsole._id,
         workspaceId: new Types.ObjectId(workspaceId),
-        snapshot: buildConsoleSnapshot(updatedForVersion as ISavedConsole),
+        snapshot: buildConsoleSnapshot(freshDocPath as ISavedConsole),
         savedBy: user.id,
         savedByName: displayNamePath,
         comment: body.comment ?? "",
       });
+      await SavedConsole.updateOne(
+        { _id: savedConsole._id },
+        { $set: { version: 1 } },
+      );
     }
 
     // Fire-and-forget: regenerate description + embedding when content changes

--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -9,6 +9,7 @@ import {
   SavedConsole,
   ConsoleFolder,
   IDatabaseConnection,
+  type ISavedConsole,
 } from "../database/workspace-schema";
 import { User } from "../database/schema";
 import { workspaceService } from "../services/workspace.service";
@@ -30,6 +31,11 @@ import {
   checkPreviewQuerySafety,
 } from "../services/query-pagination.service";
 import { createStreamingExportResponse } from "../utils/query-export-stream";
+import {
+  createVersion,
+  listVersions,
+  getVersion,
+} from "../services/entity-version.service";
 
 /**
  * Map console language to query language for tracking
@@ -43,6 +49,28 @@ function mapConsoleLanguageToQueryLanguage(
 }
 
 const logger = loggers.api("consoles");
+
+function buildConsoleSnapshot(doc: ISavedConsole): Record<string, unknown> {
+  return {
+    name: doc.name,
+    description: doc.description,
+    code: doc.code,
+    language: doc.language,
+    connectionId: doc.connectionId?.toString(),
+    databaseName: doc.databaseName,
+    databaseId: doc.databaseId,
+    chartSpec: doc.chartSpec,
+    resultsViewMode: doc.resultsViewMode,
+    mongoOptions: doc.mongoOptions,
+    folderId: doc.folderId?.toString(),
+    access: doc.access,
+  };
+}
+
+async function getUserDisplayName(userId: string): Promise<string> {
+  const u = await User.findById(userId, { email: 1 }).lean();
+  return u?.email || userId;
+}
 
 function sanitizeDownloadFilename(value: string): string {
   return value.replace(/[^a-zA-Z0-9._-]+/g, "_");
@@ -407,6 +435,25 @@ consoleRoutes.post("/", async (c: Context) => {
       });
     }
 
+    // Create version 1 for this new console
+    const freshDoc = await SavedConsole.findById(savedConsole._id).lean();
+    if (freshDoc) {
+      const displayName = await getUserDisplayName(user.id);
+      await createVersion({
+        entityType: "console",
+        entityId: savedConsole._id,
+        workspaceId: new Types.ObjectId(workspaceId),
+        snapshot: buildConsoleSnapshot(freshDoc as ISavedConsole),
+        savedBy: user.id,
+        savedByName: displayName,
+        comment: body.comment ?? "",
+      });
+      await SavedConsole.updateOne(
+        { _id: savedConsole._id },
+        { $set: { version: 1 } },
+      );
+    }
+
     // Fire-and-forget: generate description + embedding for searchability
     if (isDescriptionGenAvailable() && content.trim()) {
       void (async () => {
@@ -569,6 +616,8 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
           );
         }
 
+        const displayName = await getUserDisplayName(user.id);
+
         // Update with path information (use upsert in case console hasn't been auto-saved yet)
         const setFields: Record<string, any> = {
           code: body.content,
@@ -594,6 +643,7 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
           },
           {
             $set: setFields,
+            $inc: { version: 1 },
             $setOnInsert: {
               createdBy: user.id,
               owner_id: user.id,
@@ -606,6 +656,17 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
           },
           { upsert: true, new: true },
         );
+
+        // Create version record for the new state
+        await createVersion({
+          entityType: "console",
+          entityId: result._id,
+          workspaceId: new Types.ObjectId(workspaceId),
+          snapshot: buildConsoleSnapshot(result as ISavedConsole),
+          savedBy: user.id,
+          savedByName: displayName,
+          comment: body.comment ?? "",
+        });
 
         return c.json({
           success: true,
@@ -665,10 +726,23 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
           },
           {
             $set: setFields,
+            $inc: { version: 1 },
             $setOnInsert: setOnInsertFields,
           },
           { upsert: true, new: true },
         );
+
+        // Create version record for the new state
+        const displayNameExplicit = await getUserDisplayName(user.id);
+        await createVersion({
+          entityType: "console",
+          entityId: result._id,
+          workspaceId: new Types.ObjectId(workspaceId),
+          snapshot: buildConsoleSnapshot(result as ISavedConsole),
+          savedBy: user.id,
+          savedByName: displayNameExplicit,
+          comment: body.comment ?? "",
+        });
 
         // Fire-and-forget: generate description + embedding on explicit save
         if (isDescriptionGenAvailable() && body.content?.trim()) {
@@ -790,6 +864,25 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
         isPrivate: body.isPrivate,
       },
     );
+
+    // Create version record and increment version counter
+    const updatedForVersion = await SavedConsole.findByIdAndUpdate(
+      savedConsole._id,
+      { $inc: { version: 1 } },
+      { new: true },
+    ).lean();
+    if (updatedForVersion) {
+      const displayNamePath = await getUserDisplayName(user.id);
+      await createVersion({
+        entityType: "console",
+        entityId: savedConsole._id,
+        workspaceId: new Types.ObjectId(workspaceId),
+        snapshot: buildConsoleSnapshot(updatedForVersion as ISavedConsole),
+        savedBy: user.id,
+        savedByName: displayNamePath,
+        comment: body.comment ?? "",
+      });
+    }
 
     // Fire-and-forget: regenerate description + embedding when content changes
     if (isDescriptionGenAvailable() && body.content.trim()) {
@@ -2032,5 +2125,200 @@ consoleRoutes.get("/:id/details", async (c: Context) => {
       },
       500,
     );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Version history routes
+// ---------------------------------------------------------------------------
+
+// GET /api/workspaces/:workspaceId/consoles/:id/versions
+consoleRoutes.get("/:id/versions", async (c: Context) => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const consoleId = c.req.param("id");
+    const user = c.get("user");
+
+    if (!user || !(await workspaceService.hasAccess(workspaceId, user.id))) {
+      return c.json(
+        { success: false, error: "Access denied to workspace" },
+        403,
+      );
+    }
+
+    if (!Types.ObjectId.isValid(consoleId)) {
+      return c.json({ success: false, error: "Invalid console ID" }, 400);
+    }
+
+    const consoleDoc = await SavedConsole.findOne({
+      _id: new Types.ObjectId(consoleId),
+      workspaceId: new Types.ObjectId(workspaceId),
+    });
+    if (!consoleDoc) {
+      return c.json({ success: false, error: "Console not found" }, 404);
+    }
+
+    const limit = Math.min(
+      parseInt(c.req.query("limit") ?? "50", 10) || 50,
+      100,
+    );
+    const offset = parseInt(c.req.query("offset") ?? "0", 10) || 0;
+
+    const result = await listVersions(
+      new Types.ObjectId(consoleId),
+      "console",
+      { limit, offset },
+    );
+
+    return c.json({ success: true, ...result });
+  } catch (error) {
+    logger.error("Error listing console versions", { error });
+    return c.json({ success: false, error: "Failed to list versions" }, 500);
+  }
+});
+
+// GET /api/workspaces/:workspaceId/consoles/:id/versions/:version
+consoleRoutes.get("/:id/versions/:version", async (c: Context) => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const consoleId = c.req.param("id");
+    const versionNum = parseInt(c.req.param("version"), 10);
+    const user = c.get("user");
+
+    if (!user || !(await workspaceService.hasAccess(workspaceId, user.id))) {
+      return c.json(
+        { success: false, error: "Access denied to workspace" },
+        403,
+      );
+    }
+
+    if (!Types.ObjectId.isValid(consoleId) || isNaN(versionNum)) {
+      return c.json(
+        { success: false, error: "Invalid console ID or version" },
+        400,
+      );
+    }
+
+    const consoleDoc = await SavedConsole.findOne({
+      _id: new Types.ObjectId(consoleId),
+      workspaceId: new Types.ObjectId(workspaceId),
+    });
+    if (!consoleDoc) {
+      return c.json({ success: false, error: "Console not found" }, 404);
+    }
+
+    const version = await getVersion(consoleId, "console", versionNum);
+    if (!version) {
+      return c.json({ success: false, error: "Version not found" }, 404);
+    }
+
+    return c.json({ success: true, version });
+  } catch (error) {
+    logger.error("Error getting console version", { error });
+    return c.json({ success: false, error: "Failed to get version" }, 500);
+  }
+});
+
+// POST /api/workspaces/:workspaceId/consoles/:id/versions/:version/restore
+consoleRoutes.post("/:id/versions/:version/restore", async (c: Context) => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const consoleId = c.req.param("id");
+    const versionNum = parseInt(c.req.param("version"), 10);
+    const body = await c.req.json().catch(() => ({}));
+    const user = c.get("user");
+
+    if (!user || !(await workspaceService.hasAccess(workspaceId, user.id))) {
+      return c.json(
+        { success: false, error: "Access denied to workspace" },
+        403,
+      );
+    }
+
+    if (!Types.ObjectId.isValid(consoleId) || isNaN(versionNum)) {
+      return c.json(
+        { success: false, error: "Invalid console ID or version" },
+        400,
+      );
+    }
+
+    const consoleDoc = await SavedConsole.findOne({
+      _id: new Types.ObjectId(consoleId),
+      workspaceId: new Types.ObjectId(workspaceId),
+    });
+    if (!consoleDoc) {
+      return c.json({ success: false, error: "Console not found" }, 404);
+    }
+
+    const member = await workspaceService.getMember(workspaceId, user.id);
+    const isAdmin = member?.role === "owner" || member?.role === "admin";
+    if (!ConsoleManager.canWrite(consoleDoc, user.id, isAdmin)) {
+      return c.json(
+        { success: false, error: "You do not have write access" },
+        403,
+      );
+    }
+
+    const oldVersion = await getVersion(consoleId, "console", versionNum);
+    if (!oldVersion) {
+      return c.json({ success: false, error: "Version not found" }, 404);
+    }
+
+    const snap = oldVersion.snapshot as Record<string, any>;
+
+    // Apply the snapshot to the console document
+    const restoreFields: Record<string, any> = {
+      code: snap.code,
+      name: snap.name,
+      language: snap.language,
+      description: snap.description,
+      chartSpec: snap.chartSpec,
+      resultsViewMode: snap.resultsViewMode,
+      mongoOptions: snap.mongoOptions,
+      connectionId: snap.connectionId
+        ? new Types.ObjectId(snap.connectionId)
+        : undefined,
+      databaseName: snap.databaseName,
+      databaseId: snap.databaseId,
+    };
+
+    const restored = await SavedConsole.findOneAndUpdate(
+      {
+        _id: new Types.ObjectId(consoleId),
+        workspaceId: new Types.ObjectId(workspaceId),
+      },
+      { $set: restoreFields, $inc: { version: 1 } },
+      { new: true },
+    ).lean();
+
+    if (!restored) {
+      return c.json({ success: false, error: "Restore failed" }, 500);
+    }
+
+    const displayName = await getUserDisplayName(user.id);
+    const comment = body.comment ?? `Restored from version ${versionNum}`;
+    await createVersion({
+      entityType: "console",
+      entityId: new Types.ObjectId(consoleId),
+      workspaceId: new Types.ObjectId(workspaceId),
+      snapshot: buildConsoleSnapshot(restored as ISavedConsole),
+      savedBy: user.id,
+      savedByName: displayName,
+      comment,
+      restoredFrom: versionNum,
+    });
+
+    return c.json({
+      success: true,
+      message: `Restored to version ${versionNum}`,
+      console: {
+        id: restored._id.toString(),
+        name: restored.name,
+        version: restored.version,
+      },
+    });
+  } catch (error) {
+    logger.error("Error restoring console version", { error });
+    return c.json({ success: false, error: "Failed to restore version" }, 500);
   }
 });

--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -35,6 +35,7 @@ import {
   createVersion,
   listVersions,
   getVersion,
+  getUserDisplayName,
 } from "../services/entity-version.service";
 
 /**
@@ -65,11 +66,6 @@ function buildConsoleSnapshot(doc: ISavedConsole): Record<string, unknown> {
     folderId: doc.folderId?.toString(),
     access: doc.access,
   };
-}
-
-async function getUserDisplayName(userId: string): Promise<string> {
-  const u = await User.findById(userId, { email: 1 }).lean();
-  return u?.email || userId;
 }
 
 function sanitizeDownloadFilename(value: string): string {

--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -648,6 +648,7 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
               access: "private" as const,
               executionCount: 0,
               createdAt: now,
+              version: 0,
             },
           },
           { upsert: true, new: true },
@@ -709,6 +710,7 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
           access: "private" as const,
           executionCount: 0,
           createdAt: now,
+          version: 0,
         };
         // Only add name to $setOnInsert if not already in $set (avoid MongoDB conflict)
         if (!setFields.name) {

--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -648,7 +648,6 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
               access: "private" as const,
               executionCount: 0,
               createdAt: now,
-              version: 0,
             },
           },
           { upsert: true, new: true },
@@ -710,7 +709,6 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
           access: "private" as const,
           executionCount: 0,
           createdAt: now,
-          version: 0,
         };
         // Only add name to $setOnInsert if not already in $set (avoid MongoDB conflict)
         if (!setFields.name) {

--- a/api/src/routes/dashboards.ts
+++ b/api/src/routes/dashboards.ts
@@ -3,7 +3,9 @@ import {
   Dashboard,
   DashboardFolder,
   DatabaseConnection,
+  type IDashboard,
 } from "../database/workspace-schema";
+import { User } from "../database/schema";
 import { Types } from "mongoose";
 import { nanoid } from "nanoid";
 import { loggers, enrichContextWithWorkspace } from "../logging";
@@ -25,12 +27,38 @@ import {
 } from "../services/dashboard-materialization-schedule.service";
 import { queueDashboardArtifactRefresh } from "../services/dashboard-refresh-runner.service";
 import { DashboardManager } from "../utils/dashboard-manager";
+import {
+  createVersion,
+  listVersions,
+  getVersion,
+} from "../services/entity-version.service";
 
 const logger = loggers.api("dashboards");
 
 const app = new Hono();
 
 const DASHBOARD_QUERY_LANGUAGES = new Set(["sql", "javascript", "mongodb"]);
+
+function buildDashboardSnapshot(
+  doc: IDashboard | Record<string, any>,
+): Record<string, unknown> {
+  return {
+    title: doc.title,
+    description: doc.description,
+    dataSources: doc.dataSources,
+    widgets: doc.widgets,
+    relationships: doc.relationships,
+    globalFilters: doc.globalFilters,
+    crossFilter: doc.crossFilter,
+    layout: doc.layout,
+    materializationSchedule: doc.materializationSchedule,
+  };
+}
+
+async function getDashboardUserDisplayName(userId: string): Promise<string> {
+  const u = await User.findById(userId, { email: 1 }).lean();
+  return u?.email || userId;
+}
 
 async function normalizeDashboardDataSources(
   workspaceId: string,
@@ -396,6 +424,19 @@ app.post("/", async (c: AuthenticatedContext) => {
     });
 
     await dashboard.save();
+
+    // Create version 1 for the new dashboard
+    const displayName = await getDashboardUserDisplayName(userId);
+    await createVersion({
+      entityType: "dashboard",
+      entityId: dashboard._id,
+      workspaceId: new Types.ObjectId(workspaceId),
+      snapshot: buildDashboardSnapshot(dashboard.toObject()),
+      savedBy: userId,
+      savedByName: displayName,
+      comment: body.comment ?? "",
+    });
+
     if (
       (dashboard.dataSources || []).length > 0 &&
       isDashboardMaterializationEnabled(dashboard.materializationSchedule)
@@ -626,6 +667,18 @@ app.put("/:id", async (c: AuthenticatedContext) => {
       return c.json({ success: false, error: "Dashboard not found" }, 404);
     }
 
+    // Create version record for the new state
+    const putDisplayName = await getDashboardUserDisplayName(userId);
+    await createVersion({
+      entityType: "dashboard",
+      entityId: updated._id,
+      workspaceId: new Types.ObjectId(workspaceId),
+      snapshot: buildDashboardSnapshot(updated.toObject()),
+      savedBy: userId,
+      savedByName: putDisplayName,
+      comment: body.comment ?? "",
+    });
+
     if (
       didDashboardArtifactInputsChange(
         previousDataSources as any[],
@@ -822,6 +875,18 @@ app.patch("/:id", async (c: AuthenticatedContext) => {
       }
       return c.json({ success: false, error: "Dashboard not found" }, 404);
     }
+
+    // Create version record for the new state
+    const patchDisplayName = await getDashboardUserDisplayName(userId);
+    await createVersion({
+      entityType: "dashboard",
+      entityId: dashboard._id,
+      workspaceId: new Types.ObjectId(workspaceId),
+      snapshot: buildDashboardSnapshot(dashboard.toObject()),
+      savedBy: userId,
+      savedByName: patchDisplayName,
+      comment: body.comment ?? "",
+    });
 
     if (
       didDashboardArtifactInputsChange(
@@ -1502,6 +1567,191 @@ app.patch("/:id/move", async (c: AuthenticatedContext) => {
       },
       500,
     );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Version history routes
+// ---------------------------------------------------------------------------
+
+// GET /api/workspaces/:workspaceId/dashboards/:id/versions
+app.get("/:id/versions", async (c: AuthenticatedContext) => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const id = c.req.param("id");
+    const userId = c.get("user")?.id;
+
+    if (!userId) {
+      return c.json({ success: false, error: "Unauthorized" }, 401);
+    }
+
+    if (!Types.ObjectId.isValid(id)) {
+      return c.json({ success: false, error: "Invalid dashboard ID" }, 400);
+    }
+
+    const dashboard = await Dashboard.findOne({
+      _id: new Types.ObjectId(id),
+      workspaceId: new Types.ObjectId(workspaceId),
+    });
+    if (!dashboard) {
+      return c.json({ success: false, error: "Dashboard not found" }, 404);
+    }
+    if (!DashboardManager.canRead(dashboard, userId)) {
+      return c.json({ success: false, error: "Access denied" }, 403);
+    }
+
+    const limit = Math.min(
+      parseInt(c.req.query("limit") ?? "50", 10) || 50,
+      100,
+    );
+    const offset = parseInt(c.req.query("offset") ?? "0", 10) || 0;
+
+    const result = await listVersions(new Types.ObjectId(id), "dashboard", {
+      limit,
+      offset,
+    });
+
+    return c.json({ success: true, ...result });
+  } catch (error) {
+    logger.error("Error listing dashboard versions", { error });
+    return c.json({ success: false, error: "Failed to list versions" }, 500);
+  }
+});
+
+// GET /api/workspaces/:workspaceId/dashboards/:id/versions/:version
+app.get("/:id/versions/:version", async (c: AuthenticatedContext) => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const id = c.req.param("id");
+    const versionNum = parseInt(c.req.param("version"), 10);
+    const userId = c.get("user")?.id;
+
+    if (!userId) {
+      return c.json({ success: false, error: "Unauthorized" }, 401);
+    }
+
+    if (!Types.ObjectId.isValid(id) || isNaN(versionNum)) {
+      return c.json(
+        { success: false, error: "Invalid dashboard ID or version" },
+        400,
+      );
+    }
+
+    const dashboard = await Dashboard.findOne({
+      _id: new Types.ObjectId(id),
+      workspaceId: new Types.ObjectId(workspaceId),
+    });
+    if (!dashboard) {
+      return c.json({ success: false, error: "Dashboard not found" }, 404);
+    }
+    if (!DashboardManager.canRead(dashboard, userId)) {
+      return c.json({ success: false, error: "Access denied" }, 403);
+    }
+
+    const version = await getVersion(id, "dashboard", versionNum);
+    if (!version) {
+      return c.json({ success: false, error: "Version not found" }, 404);
+    }
+
+    return c.json({ success: true, version });
+  } catch (error) {
+    logger.error("Error getting dashboard version", { error });
+    return c.json({ success: false, error: "Failed to get version" }, 500);
+  }
+});
+
+// POST /api/workspaces/:workspaceId/dashboards/:id/versions/:version/restore
+app.post("/:id/versions/:version/restore", async (c: AuthenticatedContext) => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const id = c.req.param("id");
+    const versionNum = parseInt(c.req.param("version"), 10);
+    const body = await c.req.json().catch(() => ({}));
+    const userId = c.get("user")?.id;
+
+    if (!userId) {
+      return c.json({ success: false, error: "Unauthorized" }, 401);
+    }
+
+    if (!Types.ObjectId.isValid(id) || isNaN(versionNum)) {
+      return c.json(
+        { success: false, error: "Invalid dashboard ID or version" },
+        400,
+      );
+    }
+
+    const dashboard = await Dashboard.findOne({
+      _id: new Types.ObjectId(id),
+      workspaceId: new Types.ObjectId(workspaceId),
+    });
+    if (!dashboard) {
+      return c.json({ success: false, error: "Dashboard not found" }, 404);
+    }
+
+    const memberRole = c.get("memberRole");
+    const isAdmin = memberRole === "owner" || memberRole === "admin";
+    if (!DashboardManager.canWrite(dashboard, userId, isAdmin)) {
+      return c.json(
+        { success: false, error: "You do not have write access" },
+        403,
+      );
+    }
+
+    const oldVersion = await getVersion(id, "dashboard", versionNum);
+    if (!oldVersion) {
+      return c.json({ success: false, error: "Version not found" }, 404);
+    }
+
+    const snap = oldVersion.snapshot as Record<string, any>;
+
+    const restoreFields: Record<string, any> = {
+      title: snap.title,
+      description: snap.description,
+      dataSources: snap.dataSources,
+      widgets: snap.widgets,
+      relationships: snap.relationships,
+      globalFilters: snap.globalFilters,
+      crossFilter: snap.crossFilter,
+      layout: snap.layout,
+      materializationSchedule: snap.materializationSchedule,
+    };
+
+    const restored = await Dashboard.findOneAndUpdate(
+      {
+        _id: new Types.ObjectId(id),
+        workspaceId: new Types.ObjectId(workspaceId),
+      },
+      { $set: restoreFields, $inc: { version: 1 } },
+      { new: true },
+    );
+
+    if (!restored) {
+      return c.json({ success: false, error: "Restore failed" }, 500);
+    }
+
+    const displayName = await getDashboardUserDisplayName(userId);
+    const comment = body.comment ?? `Restored from version ${versionNum}`;
+    await createVersion({
+      entityType: "dashboard",
+      entityId: new Types.ObjectId(id),
+      workspaceId: new Types.ObjectId(workspaceId),
+      snapshot: buildDashboardSnapshot(restored.toObject()),
+      savedBy: userId,
+      savedByName: displayName,
+      comment,
+      restoredFrom: versionNum,
+    });
+
+    return c.json({
+      success: true,
+      message: `Restored to version ${versionNum}`,
+      data: sanitizeDashboardResponse(
+        await hydrateDashboardArtifactUrls(restored.toObject() as any),
+      ),
+    });
+  } catch (error) {
+    logger.error("Error restoring dashboard version", { error });
+    return c.json({ success: false, error: "Failed to restore version" }, 500);
   }
 });
 

--- a/api/src/routes/dashboards.ts
+++ b/api/src/routes/dashboards.ts
@@ -871,17 +871,18 @@ app.patch("/:id", async (c: AuthenticatedContext) => {
       return c.json({ success: false, error: "Dashboard not found" }, 404);
     }
 
-    // Create version record for the new state
-    const patchDisplayName = await getUserDisplayName(userId);
-    await createVersion({
-      entityType: "dashboard",
-      entityId: dashboard._id,
-      workspaceId: new Types.ObjectId(workspaceId),
-      snapshot: buildDashboardSnapshot(dashboard.toObject()),
-      savedBy: userId,
-      savedByName: patchDisplayName,
-      comment: body.comment ?? "",
-    });
+    if (typeof body.comment === "string") {
+      const patchDisplayName = await getUserDisplayName(userId);
+      await createVersion({
+        entityType: "dashboard",
+        entityId: dashboard._id,
+        workspaceId: new Types.ObjectId(workspaceId),
+        snapshot: buildDashboardSnapshot(dashboard.toObject()),
+        savedBy: userId,
+        savedByName: patchDisplayName,
+        comment: body.comment,
+      });
+    }
 
     if (
       didDashboardArtifactInputsChange(

--- a/api/src/routes/dashboards.ts
+++ b/api/src/routes/dashboards.ts
@@ -5,7 +5,6 @@ import {
   DatabaseConnection,
   type IDashboard,
 } from "../database/workspace-schema";
-import { User } from "../database/schema";
 import { Types } from "mongoose";
 import { nanoid } from "nanoid";
 import { loggers, enrichContextWithWorkspace } from "../logging";
@@ -31,6 +30,7 @@ import {
   createVersion,
   listVersions,
   getVersion,
+  getUserDisplayName,
 } from "../services/entity-version.service";
 
 const logger = loggers.api("dashboards");
@@ -53,11 +53,6 @@ function buildDashboardSnapshot(
     layout: doc.layout,
     materializationSchedule: doc.materializationSchedule,
   };
-}
-
-async function getDashboardUserDisplayName(userId: string): Promise<string> {
-  const u = await User.findById(userId, { email: 1 }).lean();
-  return u?.email || userId;
 }
 
 async function normalizeDashboardDataSources(
@@ -426,7 +421,7 @@ app.post("/", async (c: AuthenticatedContext) => {
     await dashboard.save();
 
     // Create version 1 for the new dashboard
-    const displayName = await getDashboardUserDisplayName(userId);
+    const displayName = await getUserDisplayName(userId);
     await createVersion({
       entityType: "dashboard",
       entityId: dashboard._id,
@@ -668,7 +663,7 @@ app.put("/:id", async (c: AuthenticatedContext) => {
     }
 
     // Create version record for the new state
-    const putDisplayName = await getDashboardUserDisplayName(userId);
+    const putDisplayName = await getUserDisplayName(userId);
     await createVersion({
       entityType: "dashboard",
       entityId: updated._id,
@@ -877,7 +872,7 @@ app.patch("/:id", async (c: AuthenticatedContext) => {
     }
 
     // Create version record for the new state
-    const patchDisplayName = await getDashboardUserDisplayName(userId);
+    const patchDisplayName = await getUserDisplayName(userId);
     await createVersion({
       entityType: "dashboard",
       entityId: dashboard._id,
@@ -1729,7 +1724,7 @@ app.post("/:id/versions/:version/restore", async (c: AuthenticatedContext) => {
       return c.json({ success: false, error: "Restore failed" }, 500);
     }
 
-    const displayName = await getDashboardUserDisplayName(userId);
+    const displayName = await getUserDisplayName(userId);
     const comment = body.comment ?? `Restored from version ${versionNum}`;
     await createVersion({
       entityType: "dashboard",

--- a/api/src/services/entity-version.service.ts
+++ b/api/src/services/entity-version.service.ts
@@ -1,0 +1,114 @@
+import { Types } from "mongoose";
+import {
+  EntityVersion,
+  type IEntityVersion,
+  type VersionableEntityType,
+} from "../database/workspace-schema";
+import { loggers } from "../logging";
+
+const logger = loggers.api("entity-versions");
+
+export interface CreateVersionParams {
+  entityType: VersionableEntityType;
+  entityId: Types.ObjectId;
+  workspaceId: Types.ObjectId;
+  snapshot: Record<string, unknown>;
+  savedBy: string;
+  savedByName: string;
+  comment: string;
+  restoredFrom?: number;
+}
+
+export interface VersionListItem {
+  version: number;
+  savedBy: string;
+  savedByName: string;
+  comment: string;
+  restoredFrom?: number;
+  createdAt: Date;
+}
+
+export async function getLatestVersionNumber(
+  entityId: Types.ObjectId,
+  entityType: VersionableEntityType,
+): Promise<number> {
+  const latest = await EntityVersion.findOne(
+    { entityId, entityType },
+    { version: 1 },
+  )
+    .sort({ version: -1 })
+    .lean();
+  return latest?.version ?? 0;
+}
+
+export async function createVersion(
+  params: CreateVersionParams,
+): Promise<IEntityVersion> {
+  const nextVersion =
+    (await getLatestVersionNumber(params.entityId, params.entityType)) + 1;
+
+  const doc = await EntityVersion.create({
+    workspaceId: params.workspaceId,
+    entityType: params.entityType,
+    entityId: params.entityId,
+    version: nextVersion,
+    snapshot: params.snapshot,
+    savedBy: params.savedBy,
+    savedByName: params.savedByName,
+    comment: params.comment,
+    restoredFrom: params.restoredFrom,
+  });
+
+  logger.debug("Version created", {
+    entityType: params.entityType,
+    entityId: params.entityId.toString(),
+    version: nextVersion,
+  });
+
+  return doc;
+}
+
+export async function listVersions(
+  entityId: Types.ObjectId | string,
+  entityType: VersionableEntityType,
+  opts: { limit?: number; offset?: number } = {},
+): Promise<{ versions: VersionListItem[]; total: number }> {
+  const eid =
+    typeof entityId === "string" ? new Types.ObjectId(entityId) : entityId;
+  const limit = Math.min(opts.limit ?? 50, 100);
+  const offset = opts.offset ?? 0;
+
+  const filter = { entityId: eid, entityType };
+
+  const [versions, total] = await Promise.all([
+    EntityVersion.find(filter, {
+      version: 1,
+      savedBy: 1,
+      savedByName: 1,
+      comment: 1,
+      restoredFrom: 1,
+      createdAt: 1,
+    })
+      .sort({ version: -1 })
+      .skip(offset)
+      .limit(limit)
+      .lean<VersionListItem[]>(),
+    EntityVersion.countDocuments(filter),
+  ]);
+
+  return { versions, total };
+}
+
+export async function getVersion(
+  entityId: Types.ObjectId | string,
+  entityType: VersionableEntityType,
+  version: number,
+): Promise<IEntityVersion | null> {
+  const eid =
+    typeof entityId === "string" ? new Types.ObjectId(entityId) : entityId;
+  return EntityVersion.findOne({
+    entityId: eid,
+    entityType,
+    version,
+  }).lean();
+}

--- a/api/src/services/entity-version.service.ts
+++ b/api/src/services/entity-version.service.ts
@@ -154,6 +154,6 @@ export async function getVersion(
 }
 
 export async function getUserDisplayName(userId: string): Promise<string> {
-  const u = await User.findById(userId, { name: 1, email: 1 }).lean();
-  return u?.name || u?.email || userId;
+  const u = await User.findById(userId, { email: 1 }).lean();
+  return u?.email || userId;
 }

--- a/api/src/services/entity-version.service.ts
+++ b/api/src/services/entity-version.service.ts
@@ -4,6 +4,7 @@ import {
   type IEntityVersion,
   type VersionableEntityType,
 } from "../database/workspace-schema";
+import { User } from "../database/schema";
 import { loggers } from "../logging";
 
 const logger = loggers.api("entity-versions");
@@ -92,14 +93,24 @@ export async function createVersion(
 export async function listVersions(
   entityId: Types.ObjectId | string,
   entityType: VersionableEntityType,
-  opts: { limit?: number; offset?: number } = {},
+  opts: {
+    limit?: number;
+    offset?: number;
+    workspaceId?: Types.ObjectId | string;
+  } = {},
 ): Promise<{ versions: VersionListItem[]; total: number }> {
   const eid =
     typeof entityId === "string" ? new Types.ObjectId(entityId) : entityId;
   const limit = Math.min(opts.limit ?? 50, 100);
   const offset = opts.offset ?? 0;
 
-  const filter = { entityId: eid, entityType };
+  const filter: Record<string, unknown> = { entityId: eid, entityType };
+  if (opts.workspaceId) {
+    filter.workspaceId =
+      typeof opts.workspaceId === "string"
+        ? new Types.ObjectId(opts.workspaceId)
+        : opts.workspaceId;
+  }
 
   const [versions, total] = await Promise.all([
     EntityVersion.find(filter, {
@@ -124,12 +135,25 @@ export async function getVersion(
   entityId: Types.ObjectId | string,
   entityType: VersionableEntityType,
   version: number,
+  workspaceId?: Types.ObjectId | string,
 ): Promise<IEntityVersion | null> {
   const eid =
     typeof entityId === "string" ? new Types.ObjectId(entityId) : entityId;
-  return EntityVersion.findOne({
+  const filter: Record<string, unknown> = {
     entityId: eid,
     entityType,
     version,
-  }).lean();
+  };
+  if (workspaceId) {
+    filter.workspaceId =
+      typeof workspaceId === "string"
+        ? new Types.ObjectId(workspaceId)
+        : workspaceId;
+  }
+  return EntityVersion.findOne(filter).lean();
+}
+
+export async function getUserDisplayName(userId: string): Promise<string> {
+  const u = await User.findById(userId, { email: 1 }).lean();
+  return u?.email || userId;
 }

--- a/api/src/services/entity-version.service.ts
+++ b/api/src/services/entity-version.service.ts
@@ -154,6 +154,6 @@ export async function getVersion(
 }
 
 export async function getUserDisplayName(userId: string): Promise<string> {
-  const u = await User.findById(userId, { email: 1 }).lean();
-  return u?.email || userId;
+  const u = await User.findById(userId, { name: 1, email: 1 }).lean();
+  return u?.name || u?.email || userId;
 }

--- a/api/src/services/entity-version.service.ts
+++ b/api/src/services/entity-version.service.ts
@@ -41,31 +41,52 @@ export async function getLatestVersionNumber(
   return latest?.version ?? 0;
 }
 
+const MAX_VERSION_RETRIES = 3;
+
 export async function createVersion(
   params: CreateVersionParams,
 ): Promise<IEntityVersion> {
-  const nextVersion =
-    (await getLatestVersionNumber(params.entityId, params.entityType)) + 1;
+  for (let attempt = 0; attempt < MAX_VERSION_RETRIES; attempt++) {
+    const nextVersion =
+      (await getLatestVersionNumber(params.entityId, params.entityType)) + 1;
 
-  const doc = await EntityVersion.create({
-    workspaceId: params.workspaceId,
-    entityType: params.entityType,
-    entityId: params.entityId,
-    version: nextVersion,
-    snapshot: params.snapshot,
-    savedBy: params.savedBy,
-    savedByName: params.savedByName,
-    comment: params.comment,
-    restoredFrom: params.restoredFrom,
-  });
+    try {
+      const doc = await EntityVersion.create({
+        workspaceId: params.workspaceId,
+        entityType: params.entityType,
+        entityId: params.entityId,
+        version: nextVersion,
+        snapshot: params.snapshot,
+        savedBy: params.savedBy,
+        savedByName: params.savedByName,
+        comment: params.comment,
+        restoredFrom: params.restoredFrom,
+      });
 
-  logger.debug("Version created", {
-    entityType: params.entityType,
-    entityId: params.entityId.toString(),
-    version: nextVersion,
-  });
+      logger.debug("Version created", {
+        entityType: params.entityType,
+        entityId: params.entityId.toString(),
+        version: nextVersion,
+      });
 
-  return doc;
+      return doc;
+    } catch (err: unknown) {
+      const isDuplicateKey =
+        err instanceof Error &&
+        "code" in err &&
+        (err as { code: number }).code === 11000;
+      if (isDuplicateKey && attempt < MAX_VERSION_RETRIES - 1) {
+        logger.warn("Version conflict, retrying", {
+          entityId: params.entityId.toString(),
+          attempt: attempt + 1,
+        });
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  throw new Error("Failed to create version after retries");
 }
 
 export async function listVersions(

--- a/app/src/agent-runtime/request-context.test.ts
+++ b/app/src/agent-runtime/request-context.test.ts
@@ -76,6 +76,7 @@ describe("buildChatRequestBody", () => {
         databaseName: "analytics",
       } as any,
       activeView: "console",
+      activeExplorer: "consoles",
       activeConsoleId: "console_1",
       activeConsoleResults: {
         viewMode: "table",
@@ -123,6 +124,7 @@ describe("buildChatRequestBody", () => {
         metadata: { dashboardId: baseDashboard._id },
       } as any,
       activeView: "dashboard",
+      activeExplorer: "dashboards",
       workspaceConnections: [
         { id: "conn_1", type: "postgresql", sqlDialect: "postgresql" },
       ] as any,

--- a/app/src/agent-runtime/request-context.ts
+++ b/app/src/agent-runtime/request-context.ts
@@ -1,5 +1,6 @@
 import type { ConsoleTab } from "../store/lib/types";
 import type { Connection } from "../store/schemaStore";
+import type { ActiveExplorer } from "../store/uiStore";
 import { getDashboardStateSnapshot } from "../dashboard-runtime/commands";
 import { useDashboardStore } from "../store/dashboardStore";
 
@@ -30,6 +31,7 @@ interface BuildChatRequestBodyOptions {
   activeTabId?: string | null;
   activeTab?: ConsoleTab;
   activeView: ChatActiveView;
+  activeExplorer: ActiveExplorer;
   activeConsoleId?: string | null;
   activeConsoleResults?: ActiveConsoleResultsContext;
   flowFormState?: Record<string, unknown>;
@@ -179,6 +181,7 @@ export function buildChatRequestBody({
   activeTabId,
   activeTab,
   activeView,
+  activeExplorer,
   activeConsoleId,
   activeConsoleResults,
   flowFormState,
@@ -196,6 +199,7 @@ export function buildChatRequestBody({
     activeConsoleResults,
     agentId: "unified",
     activeView,
+    activeExplorer,
     tabKind: activeTab?.kind,
     flowType: activeTab?.metadata?.flowType,
     flowFormState,

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -64,6 +64,7 @@ import { executeDashboardAgentTool } from "../dashboard-runtime/agent-tools";
 import type { ConsoleTab } from "../store/lib/types";
 import { useSettingsStore } from "../store/settingsStore";
 import { useSchemaStore } from "../store/schemaStore";
+import { selectActiveExplorer, useUIStore } from "../store/uiStore";
 import { ModelSelector } from "./ModelSelector";
 import { generateObjectId } from "../utils/objectId";
 import { ConsoleModificationPayload } from "../hooks/useMonacoConsole";
@@ -1276,6 +1277,7 @@ const Chat: React.FC<ChatProps> = ({
                 activeTabId: store.activeTabId,
                 activeTab,
                 activeView: computedActiveView,
+                activeExplorer: selectActiveExplorer(useUIStore.getState()),
                 activeConsoleId: activeConsoleIdRef.current,
                 activeConsoleResults,
                 flowFormState,

--- a/app/src/components/Console.tsx
+++ b/app/src/components/Console.tsx
@@ -17,7 +17,6 @@ import {
   Tooltip,
   IconButton,
   Divider,
-  Badge,
   Alert,
   Chip,
   ListItemIcon,
@@ -99,6 +98,12 @@ interface ConsoleProps {
   ) => void;
   filePath?: string;
   onHistoryClick?: () => void;
+  /**
+   * When false, the history button is rendered but disabled (e.g. for
+   * unsaved drafts that have no versions yet). Defaults to true so existing
+   * callers that already gate via `onHistoryClick` keep working.
+   */
+  historyAvailable?: boolean;
   enableVersionControl?: boolean;
 }
 
@@ -140,6 +145,7 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
     onDatabaseNameChange,
     filePath,
     onHistoryClick,
+    historyAvailable = true,
     enableVersionControl = false,
   } = props;
 
@@ -222,7 +228,6 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
     redo,
     canUndo,
     canRedo,
-    getHistory,
     saveUserEdit,
     isApplyingModification,
   } = useMonacoConsole({
@@ -1134,20 +1139,22 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
               </Tooltip>
 
               {onHistoryClick && (
-                <Tooltip title="Version History">
-                  <IconButton
-                    size="small"
-                    onClick={onHistoryClick}
-                    disabled={isDiffMode}
-                  >
-                    <Badge
-                      badgeContent={getHistory().length}
-                      color="primary"
-                      max={99}
+                <Tooltip
+                  title={
+                    historyAvailable
+                      ? "Version History"
+                      : "Save this console to start tracking version history"
+                  }
+                >
+                  <span>
+                    <IconButton
+                      size="small"
+                      onClick={onHistoryClick}
+                      disabled={isDiffMode || !historyAvailable}
                     >
                       <HistoryIcon strokeWidth={2} size={22} />
-                    </Badge>
-                  </IconButton>
+                    </IconButton>
+                  </span>
                 </Tooltip>
               )}
             </>

--- a/app/src/components/ConsoleTree.tsx
+++ b/app/src/components/ConsoleTree.tsx
@@ -1,18 +1,18 @@
 import {
   forwardRef,
   useCallback,
+  useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
 } from "react";
-import {
-  Eye as EyeIcon,
-  Globe as GlobeIcon,
-  SquareTerminal as ConsoleIcon,
-} from "lucide-react";
+import { Eye as EyeIcon, SquareTerminal as ConsoleIcon } from "lucide-react";
 import { Box, Tooltip } from "@mui/material";
 import { useExplorerStore } from "../store/explorerStore";
 import { useConsoleStore } from "../store/consoleStore";
+import { useSchemaStore } from "../store/schemaStore";
+import { useDatabaseCatalogStore } from "../store/databaseCatalogStore";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useAuth } from "../contexts/auth-context";
 import {
@@ -97,6 +97,37 @@ function ConsoleTreeInner(
 ) {
   const { currentWorkspace, members } = useWorkspace();
   const { user } = useAuth();
+
+  // Pull the workspace's connections and the catalog of database types so we
+  // can render a database-specific icon per console (mysql / postgres /
+  // bigquery…) instead of a generic terminal glyph.
+  const connectionsMap = useSchemaStore(state => state.connections);
+  const connections = useMemo(
+    () => (currentWorkspace ? connectionsMap[currentWorkspace.id] || [] : []),
+    [currentWorkspace, connectionsMap],
+  );
+
+  const dbTypes = useDatabaseCatalogStore(state => state.types);
+  const fetchDbTypes = useDatabaseCatalogStore(state => state.fetchTypes);
+
+  useEffect(() => {
+    // `fetchTypes` is deduped + persisted internally, so this is cheap when
+    // another component has already loaded the catalog.
+    void fetchDbTypes();
+  }, [fetchDbTypes]);
+
+  const typeIconUrlByConnectionId = useMemo(() => {
+    const iconByType = new Map<string, string>();
+    for (const t of dbTypes ?? []) {
+      if (t.iconUrl) iconByType.set(t.type, t.iconUrl);
+    }
+    const byConnection = new Map<string, string>();
+    for (const conn of connections) {
+      const url = iconByType.get(conn.type);
+      if (url) byConnection.set(conn.id, url);
+    }
+    return byConnection;
+  }, [connections, dbTypes]);
 
   const myConsolesMap = useConsoleTreeStore(state => state.myConsoles);
   const sharedWithWorkspaceMap = useConsoleTreeStore(
@@ -191,9 +222,34 @@ function ConsoleTreeInner(
 
   const getItemIcon = useCallback(
     (node: ConsoleEntry) => {
+      const iconUrl = node.connectionId
+        ? typeIconUrlByConnectionId.get(node.connectionId)
+        : undefined;
+
       return (
         <Box sx={{ display: "flex", alignItems: "center", gap: 0.25 }}>
-          <ConsoleIcon size={16} strokeWidth={1.5} />
+          {iconUrl ? (
+            <Box
+              component="img"
+              src={iconUrl}
+              alt=""
+              sx={{
+                width: 16,
+                height: 16,
+                display: "block",
+                flexShrink: 0,
+                // Images render via the page — avoid dragging the asset when
+                // the row is part of a DnD gesture.
+                pointerEvents: "none",
+                userSelect: "none",
+              }}
+              draggable={false}
+            />
+          ) : (
+            // Fallback when a console has no connection yet, or the catalog
+            // hasn't loaded / doesn't know this type.
+            <ConsoleIcon size={16} strokeWidth={1.5} />
+          )}
           {!node.isDirectory &&
             !isOwner(node) &&
             (node.access || "private") === "workspace" && (
@@ -208,7 +264,7 @@ function ConsoleTreeInner(
         </Box>
       );
     },
-    [isOwner],
+    [isOwner, typeIconUrlByConnectionId],
   );
 
   const handleLocationChange = useCallback(
@@ -298,7 +354,6 @@ function ConsoleTreeInner(
     {
       key: "my",
       label: "My Consoles",
-      icon: <ConsoleIcon size={18} strokeWidth={1.5} />,
       nodes: myConsoles as ResourceTreeNode[],
       droppableId: enableDragDrop ? "__section_my" : undefined,
       defaultAccess: "private" as const,
@@ -306,7 +361,6 @@ function ConsoleTreeInner(
     {
       key: "workspace",
       label: "Workspace",
-      icon: <GlobeIcon size={18} strokeWidth={1.5} />,
       nodes: sharedWithWorkspace as ResourceTreeNode[],
       droppableId: enableDragDrop ? "__section_workspace" : undefined,
       defaultAccess: "workspace" as const,
@@ -334,6 +388,7 @@ function ConsoleTreeInner(
       searchQuery={searchQuery}
       getItemIcon={node => getItemIcon(node as ConsoleEntry)}
       showFiles={showFiles}
+      hideFolderIcon
       enableDragDrop={enableDragDrop}
       enableRename={enableRename}
       enableDuplicate={enableDuplicate}

--- a/app/src/components/DashboardCanvas.tsx
+++ b/app/src/components/DashboardCanvas.tsx
@@ -29,6 +29,7 @@ import {
   Code2,
   Pencil,
   Eye,
+  History,
 } from "lucide-react";
 import {
   useDashboardStore,
@@ -53,6 +54,8 @@ import DataSourcePanel from "./dashboard/DataSourcePanel";
 import AddWidgetDialog from "./dashboard/AddWidgetDialog";
 import DashboardSettingsDialog from "./dashboard/DashboardSettingsDialog";
 import WidgetInspector from "./dashboard/WidgetInspector";
+import { SaveCommentDialog } from "./SaveCommentDialog";
+import { VersionHistoryPanel } from "./VersionHistoryPanel";
 
 type ViewMode = "canvas" | "code";
 
@@ -132,6 +135,8 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
   const [inspectedWidget, setInspectedWidget] =
     useState<DashboardWidget | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const [commentDialogOpen, setCommentDialogOpen] = useState(false);
+  const [versionHistoryOpen, setVersionHistoryOpen] = useState(false);
 
   const queryGeneration = runtimeSession?.queryGeneration ?? 0;
 
@@ -425,29 +430,7 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
                   disabled={
                     !hasUnsavedChanges || (viewMode === "code" && hasCodeError)
                   }
-                  onClick={async () => {
-                    if (!workspaceId || !dashboardId) return;
-                    try {
-                      const result = await saveDashboardAction(
-                        workspaceId,
-                        dashboardId,
-                      );
-                      if (!result.ok) {
-                        if (result.error) setSaveError(result.error);
-                        return;
-                      }
-                      void materializeDashboardInBackgroundCommand({
-                        workspaceId,
-                        dashboardId,
-                      }).catch(() => undefined);
-                    } catch (err) {
-                      setSaveError(
-                        err instanceof Error
-                          ? err.message
-                          : "Failed to save dashboard",
-                      );
-                    }
-                  }}
+                  onClick={() => setCommentDialogOpen(true)}
                 >
                   <Save size={16} />
                 </IconButton>
@@ -458,15 +441,33 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
                 <Settings size={16} />
               </IconButton>
             </Tooltip>
+            <Tooltip title="Version History">
+              <IconButton
+                size="small"
+                onClick={() => setVersionHistoryOpen(true)}
+              >
+                <History size={16} />
+              </IconButton>
+            </Tooltip>
           </>
         )}
 
         {!isEditMode && (
-          <Tooltip title="Dashboard settings">
-            <IconButton size="small" onClick={() => setSettingsOpen(true)}>
-              <Settings size={16} />
-            </IconButton>
-          </Tooltip>
+          <>
+            <Tooltip title="Dashboard settings">
+              <IconButton size="small" onClick={() => setSettingsOpen(true)}>
+                <Settings size={16} />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Version History">
+              <IconButton
+                size="small"
+                onClick={() => setVersionHistoryOpen(true)}
+              >
+                <History size={16} />
+              </IconButton>
+            </Tooltip>
+          </>
         )}
 
         <Tooltip title="Toggle dashboard event log">
@@ -602,6 +603,51 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
           </Button>
         </DialogActions>
       </Dialog>
+
+      {dashboardId && (
+        <VersionHistoryPanel
+          open={versionHistoryOpen}
+          onClose={() => setVersionHistoryOpen(false)}
+          entityType="dashboard"
+          entityId={dashboardId}
+          onRestore={() => {
+            if (workspaceId && dashboardId) {
+              useDashboardStore
+                .getState()
+                .reloadDashboard(workspaceId, dashboardId);
+            }
+          }}
+        />
+      )}
+
+      <SaveCommentDialog
+        open={commentDialogOpen}
+        onCancel={() => setCommentDialogOpen(false)}
+        onSave={async comment => {
+          setCommentDialogOpen(false);
+          if (!workspaceId || !dashboardId) return;
+          try {
+            const result = await saveDashboardAction(
+              workspaceId,
+              dashboardId,
+              comment,
+            );
+            if (!result.ok) {
+              if (result.error) setSaveError(result.error);
+              return;
+            }
+            void materializeDashboardInBackgroundCommand({
+              workspaceId,
+              dashboardId,
+            }).catch(() => undefined);
+          } catch (err) {
+            setSaveError(
+              err instanceof Error ? err.message : "Failed to save dashboard",
+            );
+          }
+        }}
+        title="Save Dashboard"
+      />
 
       <Snackbar
         open={!!saveError}

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -397,6 +397,7 @@ function Editor({
   const openTab = useConsoleStore(state => state.openTab);
   const reorderTabs = useConsoleStore(state => state.reorderTabs);
   const loadConsole = useConsoleStore(state => state.loadConsole);
+  const reloadConsole = useConsoleStore(state => state.reloadConsole);
   // useShallow prevents infinite re-renders: selectConsoleTabs returns a new
   // array on every call; without shallow comparison useSyncExternalStore would
   // detect a change every render and trigger a re-render loop.
@@ -1993,7 +1994,7 @@ function Editor({
           entityId={versionHistoryTabId}
           onRestore={() => {
             if (currentWorkspace && versionHistoryTabId) {
-              loadConsole(currentWorkspace.id, versionHistoryTabId);
+              reloadConsole(currentWorkspace.id, versionHistoryTabId);
             }
           }}
         />

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -59,6 +59,8 @@ import ConflictResolutionDialog, {
   ConflictData,
 } from "./ConflictResolutionDialog";
 import FileExplorerDialog from "./FileExplorerDialog";
+import { SaveCommentDialog } from "./SaveCommentDialog";
+import { VersionHistoryPanel } from "./VersionHistoryPanel";
 import { useConsoleStore, selectConsoleTabs } from "../store/consoleStore";
 import { useShallow } from "zustand/react/shallow";
 import { useDashboardStore } from "../store/dashboardStore";
@@ -333,6 +335,23 @@ function Editor({
     null,
   );
 
+  // Save comment dialog state (version commit message)
+  const [commentDialogOpen, setCommentDialogOpen] = useState(false);
+  const [pendingCommentSave, setPendingCommentSave] = useState<{
+    tabId: string;
+    content: string;
+    path: string;
+  } | null>(null);
+
+  // Version history panel state
+  const [versionHistoryOpen, setVersionHistoryOpen] = useState(false);
+  const [versionHistoryTabId, setVersionHistoryTabId] = useState<string | null>(
+    null,
+  );
+  const [versionHistoryEntityType, setVersionHistoryEntityType] = useState<
+    "console" | "dashboard"
+  >("console");
+
   // Conflict resolution state
   const [conflictDialogOpen, setConflictDialogOpen] = useState(false);
   const [conflictData, setConflictData] = useState<ConflictData | null>(null);
@@ -377,6 +396,7 @@ function Editor({
   const deleteConsole = useConsoleStore(state => state.deleteConsole);
   const openTab = useConsoleStore(state => state.openTab);
   const reorderTabs = useConsoleStore(state => state.reorderTabs);
+  const loadConsole = useConsoleStore(state => state.loadConsole);
   // useShallow prevents infinite re-renders: selectConsoleTabs returns a new
   // array on every call; without shallow comparison useSyncExternalStore would
   // detect a change every render and trigger a re-render loop.
@@ -993,36 +1013,17 @@ function Editor({
     await cancelQuery(currentWorkspace.id, executionId);
   };
 
-  const handleConsoleSave = async (
+  const executeConsoleSave = async (
     tabId: string,
     contentToSave: string,
-    currentPath?: string,
+    savePath: string,
+    comment: string,
   ): Promise<boolean> => {
-    if (!currentWorkspace) {
-      setErrorMessage("No workspace selected");
-      setErrorModalOpen(true);
-      return false;
-    }
-
+    if (!currentWorkspace) return false;
     setIsSaving(true);
     let success = false;
     try {
-      // Get the current tab info (needed for default filename and connection info)
       const currentTab = tabs[tabId];
-
-      const savePath = currentPath;
-      if (!savePath) {
-        // Open the folder navigator save dialog instead of prompt()
-        setSaveDialogMode("new");
-        setSaveDialogTabId(tabId);
-        setSaveDialogTargetId(tabId);
-        setSaveDialogContent(contentToSave);
-        setSaveDialogOpen(true);
-        setIsSaving(false);
-        return false;
-      }
-
-      // Get the current connection and database info for the tab
       const connectionId = currentTab?.connectionId;
       const databaseId = currentTab?.databaseId;
       const databaseName = currentTab?.databaseName;
@@ -1037,6 +1038,7 @@ function Editor({
         databaseId,
         tabChartSpecs[tabId] ?? undefined,
         tabViewModes[tabId],
+        comment,
       );
 
       // Handle conflict - show resolution dialog
@@ -1072,24 +1074,11 @@ function Editor({
 
         trackEvent("console_saved", {
           console_id: tabId,
-          is_new: !currentPath,
         });
 
-        setSnackbarMessage(
-          `Console saved ${!currentPath ? "as" : "to"} '${savePath}.js'`,
-        );
+        setSnackbarMessage(`Console saved to '${savePath}.js'`);
         setSnackbarOpen(true);
         success = true;
-
-        // Add the console to the tree
-        if (!currentPath) {
-          const { useConsoleTreeStore } = await import(
-            "../store/consoleTreeStore"
-          );
-          useConsoleTreeStore
-            .getState()
-            .addConsole(currentWorkspace.id, savePath ?? "", tabId);
-        }
       } else {
         setErrorMessage(JSON.stringify(result.error, null, 2));
         setErrorModalOpen(true);
@@ -1101,6 +1090,50 @@ function Editor({
       setIsSaving(false);
     }
     return success;
+  };
+
+  const handleConsoleSave = async (
+    tabId: string,
+    contentToSave: string,
+    currentPath?: string,
+  ): Promise<boolean> => {
+    if (!currentWorkspace) {
+      setErrorMessage("No workspace selected");
+      setErrorModalOpen(true);
+      return false;
+    }
+
+    if (!currentPath) {
+      setSaveDialogMode("new");
+      setSaveDialogTabId(tabId);
+      setSaveDialogTargetId(tabId);
+      setSaveDialogContent(contentToSave);
+      setSaveDialogOpen(true);
+      return false;
+    }
+
+    // Show comment dialog before saving
+    setPendingCommentSave({ tabId, content: contentToSave, path: currentPath });
+    setCommentDialogOpen(true);
+    return false;
+  };
+
+  const handleCommentSaveConfirm = async (comment: string) => {
+    setCommentDialogOpen(false);
+    const pending = pendingCommentSave;
+    setPendingCommentSave(null);
+    if (!pending) return;
+    await executeConsoleSave(
+      pending.tabId,
+      pending.content,
+      pending.path,
+      comment,
+    );
+  };
+
+  const handleCommentSaveCancel = () => {
+    setCommentDialogOpen(false);
+    setPendingCommentSave(null);
   };
 
   // Conflict resolution handlers
@@ -1315,6 +1348,7 @@ function Editor({
             folderId: folderId || undefined,
             chartSpec: tabChartSpecs[saveDialogTabId] ?? null,
             resultsViewMode: tabViewModes[saveDialogTabId],
+            comment: "",
           }),
         },
       );
@@ -1778,6 +1812,15 @@ function Editor({
                         }
                         filePath={tab.filePath}
                         enableVersionControl={true}
+                        onHistoryClick={
+                          tab.isSaved
+                            ? () => {
+                                setVersionHistoryTabId(tab.id);
+                                setVersionHistoryEntityType("console");
+                                setVersionHistoryOpen(true);
+                              }
+                            : undefined
+                        }
                       />
                     </Panel>
 
@@ -1929,6 +1972,32 @@ function Editor({
         })()}
         isSaving={isSaving}
       />
+
+      {/* Save comment dialog (version commit message) */}
+      <SaveCommentDialog
+        open={commentDialogOpen}
+        onSave={handleCommentSaveConfirm}
+        onCancel={handleCommentSaveCancel}
+        title="Save Console"
+      />
+
+      {/* Version history panel */}
+      {versionHistoryTabId && (
+        <VersionHistoryPanel
+          open={versionHistoryOpen}
+          onClose={() => {
+            setVersionHistoryOpen(false);
+            setVersionHistoryTabId(null);
+          }}
+          entityType={versionHistoryEntityType}
+          entityId={versionHistoryTabId}
+          onRestore={() => {
+            if (currentWorkspace && versionHistoryTabId) {
+              loadConsole(currentWorkspace.id, versionHistoryTabId);
+            }
+          }}
+        />
+      )}
 
       {/* Success Snackbar */}
       <Snackbar

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -341,6 +341,7 @@ function Editor({
     tabId: string;
     content: string;
     path: string;
+    resolve: (success: boolean) => void;
   } | null>(null);
 
   // Version history panel state
@@ -367,6 +368,7 @@ function Editor({
     connectionId?: string;
     databaseId?: string;
     databaseName?: string;
+    comment?: string;
   } | null>(null);
 
   // Refs for query cancellation (per-tab to support parallel queries)
@@ -396,7 +398,6 @@ function Editor({
   const deleteConsole = useConsoleStore(state => state.deleteConsole);
   const openTab = useConsoleStore(state => state.openTab);
   const reorderTabs = useConsoleStore(state => state.reorderTabs);
-  const loadConsole = useConsoleStore(state => state.loadConsole);
   const reloadConsole = useConsoleStore(state => state.reloadConsole);
   // useShallow prevents infinite re-renders: selectConsoleTabs returns a new
   // array on every call; without shallow comparison useSyncExternalStore would
@@ -1051,6 +1052,7 @@ function Editor({
           connectionId,
           databaseId,
           databaseName,
+          comment,
         });
         setConflictData(result.conflict);
         setConflictDialogOpen(true);
@@ -1113,10 +1115,15 @@ function Editor({
       return false;
     }
 
-    // Show comment dialog before saving
-    setPendingCommentSave({ tabId, content: contentToSave, path: currentPath });
-    setCommentDialogOpen(true);
-    return false;
+    return new Promise<boolean>(resolve => {
+      setPendingCommentSave({
+        tabId,
+        content: contentToSave,
+        path: currentPath,
+        resolve,
+      });
+      setCommentDialogOpen(true);
+    });
   };
 
   const handleCommentSaveConfirm = async (comment: string) => {
@@ -1124,17 +1131,20 @@ function Editor({
     const pending = pendingCommentSave;
     setPendingCommentSave(null);
     if (!pending) return;
-    await executeConsoleSave(
+    const success = await executeConsoleSave(
       pending.tabId,
       pending.content,
       pending.path,
       comment,
     );
+    pending.resolve(success);
   };
 
   const handleCommentSaveCancel = () => {
     setCommentDialogOpen(false);
+    const pending = pendingCommentSave;
     setPendingCommentSave(null);
+    pending?.resolve(false);
   };
 
   // Conflict resolution handlers
@@ -1199,6 +1209,7 @@ function Editor({
         pendingSaveData.databaseId,
         tabChartSpecs[pendingSaveData.tabId] ?? undefined,
         tabViewModes[pendingSaveData.tabId],
+        pendingSaveData.comment,
       );
 
       if (result.success) {

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -1824,15 +1824,12 @@ function Editor({
                         }
                         filePath={tab.filePath}
                         enableVersionControl={true}
-                        onHistoryClick={
-                          tab.isSaved
-                            ? () => {
-                                setVersionHistoryTabId(tab.id);
-                                setVersionHistoryEntityType("console");
-                                setVersionHistoryOpen(true);
-                              }
-                            : undefined
-                        }
+                        onHistoryClick={() => {
+                          setVersionHistoryTabId(tab.id);
+                          setVersionHistoryEntityType("console");
+                          setVersionHistoryOpen(true);
+                        }}
+                        historyAvailable={tab.isSaved}
                       />
                     </Panel>
 

--- a/app/src/components/ResourceTree.tsx
+++ b/app/src/components/ResourceTree.tsx
@@ -10,7 +10,6 @@ import React, {
 } from "react";
 import {
   Box,
-  Chip,
   Divider,
   List,
   ListItemButton,
@@ -45,12 +44,24 @@ import {
   type DragOverEvent,
   type DragStartEvent,
 } from "@dnd-kit/core";
-import { countItems, filterTree } from "../store/lib/tree-helpers";
+import { filterTree } from "../store/lib/tree-helpers";
 import {
+  DraggableFolderScope,
   DraggableTreeItem,
   DroppableFolderContent,
-  DroppableSectionHeader,
+  SectionScope,
 } from "./resource-tree/dnd";
+
+// Pixel height of a single tree row. Used to stack sticky folder/section
+// headers so each ancestor pins one row below its parent as the user scrolls.
+// Keep this in sync with the `minHeight` / vertical padding set in
+// `buildRowSx` and on section headers.
+const ROW_HEIGHT = 24;
+
+// Width of the leading chevron / icon column. Used for both the folder
+// chevron and (when `hideFolderIcon` is on) the file icon so they line up
+// vertically across sibling rows.
+const ICON_COL_WIDTH = 20;
 import {
   findNodeInSections,
   getFolderDropTargetId,
@@ -71,7 +82,7 @@ export interface ResourceTreeNode {
 export interface ResourceTreeSection {
   key: string;
   label: string;
-  icon: ReactNode;
+  icon?: ReactNode;
   nodes: ResourceTreeNode[];
   droppableId?: string;
   defaultAccess?: "private" | "workspace";
@@ -94,6 +105,12 @@ export interface ResourceTreeProps {
 
   getItemIcon?: (node: ResourceTreeNode) => ReactNode;
   showFiles?: boolean;
+  /**
+   * When true, folder rows render only a chevron + name (no folder icon), and
+   * file rows drop the hidden chevron placeholder so their icon sits in the
+   * chevron column. Produces a Cursor-style compact tree.
+   */
+  hideFolderIcon?: boolean;
 
   enableDragDrop?: boolean;
   enableRename?: boolean;
@@ -155,6 +172,7 @@ function ResourceTreeInner(
     searchQuery = "",
     getItemIcon,
     showFiles = true,
+    hideFolderIcon = false,
     enableDragDrop = true,
     enableRename = true,
     enableDuplicate = false,
@@ -775,29 +793,27 @@ function ResourceTreeInner(
   const buildRowSx = ({
     depth,
     isDropTarget,
-    isFocused,
     isSelected,
   }: {
     depth: number;
     isDropTarget?: boolean;
-    isFocused?: boolean;
     isSelected?: boolean;
   }) => ({
     pl: 0.5 + depth * 1.5,
     minWidth: 0,
-    py: 0.25,
-    minHeight: 28,
+    py: 0,
+    minHeight: ROW_HEIGHT,
     bgcolor: isDropTarget
       ? "action.hover"
       : isSelected
         ? "action.selected"
         : undefined,
-    outline: isDropTarget ? "2px dashed" : isFocused ? "1px solid" : undefined,
-    outlineColor: isDropTarget
-      ? "primary.main"
-      : isFocused
-        ? "divider"
-        : undefined,
+    outline: isDropTarget ? "2px dashed" : undefined,
+    outlineColor: isDropTarget ? "primary.main" : undefined,
+    // Draw the drop-target outline inside the row's own box so it isn't
+    // clipped by adjacent opaque rows or sticky ancestors (CSS outlines
+    // don't reserve layout space, so they get painted over otherwise).
+    outlineOffset: isDropTarget ? "-2px" : undefined,
     borderRadius: 0,
   });
 
@@ -813,7 +829,6 @@ function ResourceTreeInner(
 
       const canManage = resolveCanManage(node);
       const isExpanded = node.isDirectory && isNodeExpanded(node);
-      const isFocused = focusedNodeId === node.id;
       const isSelectedLocation =
         mode === "picker" && currentSelectedLocation === node.id;
       const isActive = mode === "sidebar" && activeItemId === node.id;
@@ -843,14 +858,41 @@ function ResourceTreeInner(
                 startInlineRename(node);
               }
             }}
-            sx={buildRowSx({
-              depth,
-              isDropTarget,
-              isFocused,
-              isSelected: isSelectedLocation,
-            })}
+            sx={{
+              ...buildRowSx({
+                depth,
+                isDropTarget,
+                isSelected: isSelectedLocation,
+              }),
+              position: "sticky",
+              // Stack ancestor headers: depth=1 sits just below the section
+              // header (which is sticky at top: 0), depth=2 one row below
+              // that, and so on.
+              top: depth * ROW_HEIGHT,
+              // Deeper folders get a lower z-index so outer ancestors always
+              // paint on top when sticky rows collide during scroll.
+              zIndex: 20 - depth,
+              // Non-transparent fill so content scrolling underneath doesn't
+              // bleed through while stuck. Uses `background.default` to match
+              // the ambient sidebar canvas (sidebar has no explicit bg, so it
+              // inherits the default theme background) — this makes the row
+              // visually invisible against the surrounding tree at rest.
+              // Selected / drop-target states from buildRowSx still win.
+              backgroundColor:
+                isDropTarget || isSelectedLocation
+                  ? undefined
+                  : "background.default",
+            }}
           >
-            <ListItemIcon sx={{ minWidth: 22, mr: 0 }}>
+            <ListItemIcon
+              sx={{
+                minWidth: ICON_COL_WIDTH,
+                mr: 0,
+                // MUI's ListItemIcon defaults to `action.active` which looks
+                // dimmed; the chevron should match the folder name's color.
+                color: "text.primary",
+              }}
+            >
               <Box
                 component="span"
                 onClick={event => {
@@ -872,13 +914,15 @@ function ResourceTreeInner(
                 )}
               </Box>
             </ListItemIcon>
-            <ListItemIcon sx={{ minWidth: 22 }}>
-              {isExpanded ? (
-                <FolderOpen size={16} strokeWidth={1.5} />
-              ) : (
-                <Folder size={16} strokeWidth={1.5} />
-              )}
-            </ListItemIcon>
+            {!hideFolderIcon && (
+              <ListItemIcon sx={{ minWidth: ICON_COL_WIDTH }}>
+                {isExpanded ? (
+                  <FolderOpen size={16} strokeWidth={1.5} />
+                ) : (
+                  <Folder size={16} strokeWidth={1.5} />
+                )}
+              </ListItemIcon>
+            )}
             <MuiListItemText
               primary={
                 isRenaming ? renderInlineRenameInput(node.id) : node.name
@@ -896,62 +940,62 @@ function ResourceTreeInner(
           </ListItemButton>
         );
 
-        const wrappedFolderRow = enableDragDrop ? (
-          <DraggableTreeItem
-            key={`drag-folder-${node.id}`}
+        const childrenContent = isExpanded
+          ? (() => {
+              const childItems = renderTree(
+                node.children ?? [],
+                depth + 1,
+                sectionKey,
+              );
+              const childList = (
+                <List component="div" disablePadding dense>
+                  {childItems.length === 0 ? (
+                    <Typography
+                      variant="caption"
+                      color="text.disabled"
+                      sx={{
+                        pl: 0.5 + (depth + 1) * 1.5 + 2.75,
+                        py: 0.5,
+                        display: "block",
+                      }}
+                    >
+                      Empty
+                    </Typography>
+                  ) : (
+                    childItems
+                  )}
+                </List>
+              );
+
+              return enableDragDrop ? (
+                <DroppableFolderContent folderId={node.id}>
+                  {childList}
+                </DroppableFolderContent>
+              ) : (
+                childList
+              );
+            })()
+          : null;
+
+        // Wrap (header + children) in a single block so the sticky header has
+        // a containing block that spans the entire folder scope.
+        const folderScope = enableDragDrop ? (
+          <DraggableFolderScope
+            key={`folder-scope-${node.id}`}
             id={node.id}
-            isFolder
             disabled={!canManage}
+            header={folderRow}
           >
-            {folderRow}
-          </DraggableTreeItem>
+            {childrenContent}
+          </DraggableFolderScope>
         ) : (
-          folderRow
+          <Box key={`folder-scope-${node.id}`}>
+            {folderRow}
+            {childrenContent}
+          </Box>
         );
 
-        items.push(wrappedFolderRow);
-
-        if (isExpanded) {
-          const childItems = renderTree(
-            node.children ?? [],
-            depth + 1,
-            sectionKey,
-          );
-          const childList = (
-            <List component="div" disablePadding dense>
-              {childItems.length === 0 ? (
-                <Typography
-                  variant="caption"
-                  color="text.disabled"
-                  sx={{
-                    pl: 0.5 + (depth + 1) * 1.5 + 2.75,
-                    py: 0.5,
-                    display: "block",
-                  }}
-                >
-                  Empty
-                </Typography>
-              ) : (
-                childItems
-              )}
-            </List>
-          );
-
-          items.push(
-            enableDragDrop ? (
-              <DroppableFolderContent
-                key={`folder-drop-${node.id}`}
-                folderId={node.id}
-              >
-                {childList}
-              </DroppableFolderContent>
-            ) : (
-              <React.Fragment key={`folder-children-${node.id}`}>
-                {childList}
-              </React.Fragment>
-            ),
-          );
-        }
+        items.push(folderScope);
 
         continue;
       }
@@ -978,12 +1022,15 @@ function ResourceTreeInner(
           }}
           sx={buildRowSx({
             depth,
-            isFocused,
             isSelected: isActive,
           })}
         >
-          <ListItemIcon sx={{ minWidth: 22, visibility: "hidden", mr: 0 }} />
-          <ListItemIcon sx={{ minWidth: 22 }}>
+          {!hideFolderIcon && (
+            <ListItemIcon
+              sx={{ minWidth: ICON_COL_WIDTH, visibility: "hidden", mr: 0 }}
+            />
+          )}
+          <ListItemIcon sx={{ minWidth: ICON_COL_WIDTH }}>
             {getItemIcon ? getItemIcon(node) : null}
           </ListItemIcon>
           <MuiListItemText
@@ -1040,9 +1087,10 @@ function ResourceTreeInner(
         }}
         onContextMenu={event => handleSectionContextMenu(event, section.key)}
         sx={{
-          py: 0.25,
+          py: 0,
           pl: 0.5,
           minWidth: 0,
+          minHeight: ROW_HEIGHT,
           bgcolor: isDropTarget
             ? "action.hover"
             : headerSelected
@@ -1050,14 +1098,25 @@ function ResourceTreeInner(
               : undefined,
           outline: isDropTarget ? "2px dashed" : undefined,
           outlineColor: isDropTarget ? "primary.main" : undefined,
+          outlineOffset: isDropTarget ? "-2px" : undefined,
           borderRadius: 0,
           "& .MuiListItemText-root": {
             minWidth: 0,
             flex: "1 1 auto",
           },
+          // Pin the section label at the top of the scroll container as the
+          // user scrolls through the section's tree. Folder headers inside
+          // stack below this (see ROW_HEIGHT * depth in renderTree).
+          position: "sticky",
+          top: 0,
+          zIndex: 30,
+          backgroundColor:
+            isDropTarget || headerSelected ? undefined : "background.default",
         }}
       >
-        <ListItemIcon sx={{ minWidth: 22 }}>
+        <ListItemIcon
+          sx={{ minWidth: ICON_COL_WIDTH, mr: 0, color: "text.primary" }}
+        >
           <Box
             component="span"
             onClick={event => {
@@ -1082,7 +1141,11 @@ function ResourceTreeInner(
             )}
           </Box>
         </ListItemIcon>
-        <ListItemIcon sx={{ minWidth: 22 }}>{section.icon}</ListItemIcon>
+        {section.icon ? (
+          <ListItemIcon sx={{ minWidth: ICON_COL_WIDTH }}>
+            {section.icon}
+          </ListItemIcon>
+        ) : null}
         <MuiListItemText
           primary={section.label}
           primaryTypographyProps={{
@@ -1095,37 +1158,18 @@ function ResourceTreeInner(
             },
           }}
         />
-        <Chip
-          label={countItems(section.nodes)}
-          size="small"
-          sx={{ height: 18, fontSize: "0.7rem", flexShrink: 0, maxWidth: 56 }}
-        />
       </ListItemButton>
     );
 
-    if (enableDragDrop && section.droppableId) {
-      return (
-        <DroppableSectionHeader
-          key={`section-${section.key}`}
-          id={section.droppableId}
-        >
-          {header}
-        </DroppableSectionHeader>
-      );
-    }
-
-    return (
-      <React.Fragment key={`section-${section.key}`}>{header}</React.Fragment>
-    );
+    return header;
   };
 
   const treeContent = (
-    <List component="nav" dense>
-      {filteredSections.map(section => (
-        <React.Fragment key={section.key}>
-          {renderSectionHeader(section)}
-          {sectionExpanded[section.key] !== false &&
-            (section.nodes.length > 0 ? (
+    <List component="nav" dense disablePadding>
+      {filteredSections.map(section => {
+        const sectionBody =
+          sectionExpanded[section.key] !== false ? (
+            section.nodes.length > 0 ? (
               renderTree(section.nodes, 1, section.key)
             ) : (
               <Typography
@@ -1140,9 +1184,31 @@ function ResourceTreeInner(
               >
                 Nothing here yet
               </Typography>
-            ))}
-        </React.Fragment>
-      ))}
+            )
+          ) : null;
+
+        // Wrap the section header + its body in a single block so the sticky
+        // section header has a containing block spanning the whole section.
+        // When a droppableId is provided, the scope also acts as the section-
+        // level drop target (replaces the old DroppableSectionHeader wrapper
+        // around just the header).
+        return (
+          <SectionScope
+            key={`section-${section.key}`}
+            droppableId={
+              enableDragDrop && section.droppableId
+                ? section.droppableId
+                : undefined
+            }
+          >
+            {renderSectionHeader(section)}
+            {sectionBody}
+          </SectionScope>
+        );
+      })}
+      {/* Trailing spacer so the last row doesn't feel flush to the bottom
+          of the scroll container and hint there's more content below. */}
+      <Box sx={{ height: 24 }} aria-hidden />
     </List>
   );
 

--- a/app/src/components/SaveCommentDialog.tsx
+++ b/app/src/components/SaveCommentDialog.tsx
@@ -1,0 +1,73 @@
+import { useState, useCallback, useEffect } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Button,
+} from "@mui/material";
+
+interface SaveCommentDialogProps {
+  open: boolean;
+  onSave: (comment: string) => void;
+  onCancel: () => void;
+  title?: string;
+}
+
+export function SaveCommentDialog({
+  open,
+  onSave,
+  onCancel,
+  title = "Save",
+}: SaveCommentDialogProps) {
+  const [comment, setComment] = useState("");
+
+  useEffect(() => {
+    if (open) setComment("");
+  }, [open]);
+
+  const handleSave = useCallback(() => {
+    onSave(comment);
+  }, [comment, onSave]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        handleSave();
+      }
+    },
+    [handleSave],
+  );
+
+  return (
+    <Dialog open={open} onClose={onCancel} maxWidth="sm" fullWidth>
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent>
+        <TextField
+          autoFocus
+          fullWidth
+          multiline
+          minRows={2}
+          maxRows={4}
+          placeholder="Describe your changes (optional)"
+          value={comment}
+          onChange={e => setComment(e.target.value)}
+          onKeyDown={handleKeyDown}
+          variant="outlined"
+          size="small"
+          sx={{ mt: 1 }}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onCancel} size="small">
+          Cancel
+        </Button>
+        <Button onClick={handleSave} variant="contained" size="small">
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -19,7 +19,7 @@ import {
   CircleUserRound as UserIcon,
   MessageCircleMore as ChatIcon,
 } from "lucide-react";
-import { useUIStore } from "../store/uiStore";
+import { selectActiveExplorer, useUIStore } from "../store/uiStore";
 import { selectTabByKind, useConsoleStore } from "../store/consoleStore";
 import { useAuth } from "../contexts/auth-context";
 import { startTransition, useState } from "react";
@@ -77,7 +77,12 @@ const bottomNavigationItems: {
 }[] = [{ view: "settings", icon: SettingsIcon, label: "Settings" }];
 
 function Sidebar() {
-  const activeView = useUIStore(state => state.leftPane);
+  // `activeExplorer` is the explorer that's actually visible on the left
+  // (null when the pane is collapsed). Use this — not `leftPane`, which is
+  // the last-selected view retained across collapse — to decide which icon
+  // is highlighted, so collapsing the pane clears the highlight.
+  const activeExplorer = useUIStore(selectActiveExplorer);
+  const leftPane = useUIStore(state => state.leftPane);
   const leftPaneOpen = useUIStore(state => state.leftPaneOpen);
   const rightPaneOpen = useUIStore(state => state.rightPaneOpen);
   const setLeftPane = useUIStore(state => state.setLeftPane);
@@ -211,7 +216,7 @@ function Sidebar() {
         >
           {topNavigationItems.map(item => {
             const Icon = item.icon;
-            const isActive = activeView === item.view;
+            const isActive = activeExplorer === item.view;
 
             return (
               <Tooltip key={item.view} title={item.label} placement="right">
@@ -268,7 +273,10 @@ function Sidebar() {
           {/* Settings */}
           {bottomNavigationItems.map(item => {
             const Icon = item.icon;
-            const isActive = activeView === item.view;
+            // Settings opens as an editor tab, not a left-pane explorer, so
+            // it tracks `leftPane` (set to "settings" from the /settings URL)
+            // rather than `activeExplorer`.
+            const isActive = leftPane === item.view;
 
             return (
               <Tooltip key={item.view} title={item.label} placement="right">

--- a/app/src/components/VersionHistoryPanel.tsx
+++ b/app/src/components/VersionHistoryPanel.tsx
@@ -1,0 +1,338 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  Drawer,
+  Box,
+  Typography,
+  List,
+  ListItemButton,
+  ListItemText,
+  Chip,
+  IconButton,
+  Tooltip,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Divider,
+} from "@mui/material";
+import { X, RotateCcw } from "lucide-react";
+import {
+  useVersionStore,
+  type VersionListItem,
+  type VersionDetail,
+} from "../store/versionStore";
+import { useWorkspace } from "../contexts/workspace-context";
+
+interface VersionHistoryPanelProps {
+  open: boolean;
+  onClose: () => void;
+  entityType: "console" | "dashboard";
+  entityId: string;
+  currentCode?: string;
+  onRestore?: () => void;
+}
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - d.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHrs = Math.floor(diffMin / 60);
+  if (diffHrs < 24) return `${diffHrs}h ago`;
+  const diffDays = Math.floor(diffHrs / 24);
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return d.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: d.getFullYear() !== now.getFullYear() ? "numeric" : undefined,
+  });
+}
+
+export function VersionHistoryPanel({
+  open,
+  onClose,
+  entityType,
+  entityId,
+  onRestore,
+}: VersionHistoryPanelProps) {
+  const { currentWorkspace } = useWorkspace();
+  const workspaceId = currentWorkspace?.id;
+
+  const versions = useVersionStore(s => s.versions[entityId]);
+  const total = useVersionStore(s => s.totals[entityId] ?? 0);
+  const loading = useVersionStore(s => s.loading[entityId] ?? false);
+  const fetchHistory = useVersionStore(s => s.fetchVersionHistory);
+  const fetchVersion = useVersionStore(s => s.fetchVersion);
+  const restoreVersion = useVersionStore(s => s.restoreVersion);
+
+  const [selectedVersion, setSelectedVersion] = useState<VersionDetail | null>(
+    null,
+  );
+  const [loadingDetail, setLoadingDetail] = useState(false);
+  const [restoreDialogOpen, setRestoreDialogOpen] = useState(false);
+  const [restoreTarget, setRestoreTarget] = useState<VersionListItem | null>(
+    null,
+  );
+  const [restoreComment, setRestoreComment] = useState("");
+  const [restoring, setRestoring] = useState(false);
+
+  useEffect(() => {
+    if (open && workspaceId && entityId) {
+      fetchHistory(workspaceId, entityType, entityId);
+    }
+  }, [open, workspaceId, entityType, entityId, fetchHistory]);
+
+  const handleVersionClick = useCallback(
+    async (item: VersionListItem) => {
+      if (!workspaceId) return;
+      setLoadingDetail(true);
+      const detail = await fetchVersion(
+        workspaceId,
+        entityType,
+        entityId,
+        item.version,
+      );
+      setSelectedVersion(detail ?? null);
+      setLoadingDetail(false);
+    },
+    [workspaceId, entityType, entityId, fetchVersion],
+  );
+
+  const handleRestoreClick = (item: VersionListItem) => {
+    setRestoreTarget(item);
+    setRestoreComment(`Restored from version ${item.version}`);
+    setRestoreDialogOpen(true);
+  };
+
+  const handleRestoreConfirm = async () => {
+    if (!workspaceId || !restoreTarget) return;
+    setRestoring(true);
+    const result = await restoreVersion(
+      workspaceId,
+      entityType,
+      entityId,
+      restoreTarget.version,
+      restoreComment,
+    );
+    setRestoring(false);
+    setRestoreDialogOpen(false);
+    setRestoreTarget(null);
+    if (result.success) {
+      setSelectedVersion(null);
+      onRestore?.();
+    }
+  };
+
+  return (
+    <>
+      <Drawer
+        anchor="right"
+        open={open}
+        onClose={onClose}
+        PaperProps={{ sx: { width: 380, maxWidth: "90vw" } }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            px: 2,
+            py: 1.5,
+            borderBottom: 1,
+            borderColor: "divider",
+          }}
+        >
+          <Typography variant="subtitle1" fontWeight={600}>
+            Version History
+          </Typography>
+          <IconButton size="small" onClick={onClose}>
+            <X size={18} />
+          </IconButton>
+        </Box>
+
+        {loading && !versions?.length ? (
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "center",
+              py: 6,
+            }}
+          >
+            <CircularProgress size={24} />
+          </Box>
+        ) : !versions?.length ? (
+          <Box sx={{ px: 2, py: 4, textAlign: "center" }}>
+            <Typography variant="body2" color="text.secondary">
+              No version history yet. Versions are created each time you save.
+            </Typography>
+          </Box>
+        ) : (
+          <List dense disablePadding sx={{ overflow: "auto", flex: 1 }}>
+            {versions.map(v => (
+              <ListItemButton
+                key={v.version}
+                selected={selectedVersion?.version === v.version}
+                onClick={() => handleVersionClick(v)}
+                sx={{ alignItems: "flex-start", px: 2, py: 1 }}
+              >
+                <ListItemText
+                  primary={
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 0.75,
+                      }}
+                    >
+                      <Typography variant="body2" fontWeight={600}>
+                        v{v.version}
+                      </Typography>
+                      {v.restoredFrom && (
+                        <Chip
+                          label={`from v${v.restoredFrom}`}
+                          size="small"
+                          variant="outlined"
+                          sx={{ height: 18, fontSize: "0.7rem" }}
+                        />
+                      )}
+                      <Box sx={{ flex: 1 }} />
+                      <Tooltip title="Restore this version">
+                        <IconButton
+                          size="small"
+                          onClick={e => {
+                            e.stopPropagation();
+                            handleRestoreClick(v);
+                          }}
+                          sx={{ opacity: 0.6, "&:hover": { opacity: 1 } }}
+                        >
+                          <RotateCcw size={14} />
+                        </IconButton>
+                      </Tooltip>
+                    </Box>
+                  }
+                  secondary={
+                    <>
+                      <Typography
+                        component="span"
+                        variant="caption"
+                        color="text.secondary"
+                      >
+                        {v.savedByName} &middot; {formatDate(v.createdAt)}
+                      </Typography>
+                      {v.comment && (
+                        <Typography
+                          variant="caption"
+                          display="block"
+                          sx={{
+                            mt: 0.25,
+                            color: "text.primary",
+                            fontStyle: "italic",
+                          }}
+                        >
+                          {v.comment}
+                        </Typography>
+                      )}
+                    </>
+                  }
+                />
+              </ListItemButton>
+            ))}
+            {versions.length < total && (
+              <Box sx={{ textAlign: "center", py: 1.5 }}>
+                <Button
+                  size="small"
+                  onClick={() =>
+                    workspaceId &&
+                    fetchHistory(workspaceId, entityType, entityId, {
+                      limit: 50,
+                      offset: versions.length,
+                    })
+                  }
+                >
+                  Load more
+                </Button>
+              </Box>
+            )}
+          </List>
+        )}
+
+        {selectedVersion && (
+          <>
+            <Divider />
+            <Box sx={{ px: 2, py: 1.5 }}>
+              <Typography variant="caption" fontWeight={600}>
+                Version {selectedVersion.version} snapshot
+              </Typography>
+              {loadingDetail ? (
+                <CircularProgress size={16} sx={{ ml: 1 }} />
+              ) : (
+                <Box
+                  component="pre"
+                  sx={{
+                    mt: 1,
+                    p: 1.5,
+                    borderRadius: 1,
+                    bgcolor: "action.hover",
+                    fontSize: "0.75rem",
+                    fontFamily: "monospace",
+                    overflow: "auto",
+                    maxHeight: 260,
+                    whiteSpace: "pre-wrap",
+                    wordBreak: "break-word",
+                  }}
+                >
+                  {entityType === "console"
+                    ? ((selectedVersion.snapshot.code as string) ?? "")
+                    : JSON.stringify(selectedVersion.snapshot, null, 2)}
+                </Box>
+              )}
+            </Box>
+          </>
+        )}
+      </Drawer>
+
+      <Dialog
+        open={restoreDialogOpen}
+        onClose={() => !restoring && setRestoreDialogOpen(false)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>Restore Version {restoreTarget?.version}?</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            This will create a new version with the content from v
+            {restoreTarget?.version}. The current state is not lost.
+          </Typography>
+          <TextField
+            fullWidth
+            size="small"
+            label="Comment"
+            value={restoreComment}
+            onChange={e => setRestoreComment(e.target.value)}
+            placeholder="Describe the restore reason"
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => setRestoreDialogOpen(false)}
+            disabled={restoring}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleRestoreConfirm}
+            variant="contained"
+            disabled={restoring}
+          >
+            {restoring ? "Restoring..." : "Restore"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/app/src/components/resource-tree/dnd.tsx
+++ b/app/src/components/resource-tree/dnd.tsx
@@ -20,6 +20,76 @@ export function DroppableSectionHeader({
   return <div ref={setNodeRef}>{children}</div>;
 }
 
+interface SectionScopeProps {
+  droppableId?: string;
+  children: ReactNode;
+}
+
+/**
+ * Wraps a section header + its tree contents in a single block-level element.
+ * This gives sticky section headers a containing block that spans the entire
+ * section, so they stay pinned while the section is in view. When a
+ * `droppableId` is provided, the outer element also acts as the section-level
+ * drop target (replacing a separate `DroppableSectionHeader`).
+ */
+export function SectionScope({ droppableId, children }: SectionScopeProps) {
+  const { setNodeRef } = useDroppable({
+    id: droppableId ?? "__section_scope_noop",
+    disabled: !droppableId,
+  });
+  return <div ref={droppableId ? setNodeRef : undefined}>{children}</div>;
+}
+
+interface DraggableFolderScopeProps {
+  id: string;
+  disabled?: boolean;
+  header: ReactElement;
+  children?: ReactNode;
+}
+
+/**
+ * Wraps a folder's header + its expanded children in a single block-level
+ * element. The outer element is both the drag source and the folder drop
+ * target, but drag listeners only attach to the header so pointer events on
+ * child rows don't initiate a folder drag. The wrapping element also gives
+ * the sticky folder header a containing block that spans the entire folder,
+ * so it stays pinned while scrolling through its descendants.
+ */
+export function DraggableFolderScope({
+  id,
+  disabled,
+  header,
+  children,
+}: DraggableFolderScopeProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef: setDragRef,
+    isDragging,
+  } = useDraggable({ id, disabled });
+  const { setNodeRef: setDropRef } = useDroppable({ id });
+
+  const setRef = (element: HTMLElement | null) => {
+    setDragRef(element);
+    setDropRef(element);
+  };
+
+  const headerElement = isValidElement(header)
+    ? cloneElement(header, {
+        ...attributes,
+        ...listeners,
+        ...(header.props as HTMLAttributes<HTMLElement>),
+      })
+    : header;
+
+  return (
+    <div ref={setRef} style={{ opacity: isDragging ? 0.4 : 1 }}>
+      {headerElement}
+      {children}
+    </div>
+  );
+}
+
 interface DroppableFolderContentProps {
   folderId: string;
   children: ReactNode;

--- a/app/src/contexts/workspace-context.tsx
+++ b/app/src/contexts/workspace-context.tsx
@@ -46,7 +46,7 @@ interface WorkspaceContextState {
     data: Partial<CreateWorkspaceData>,
   ) => Promise<void>;
   deleteWorkspace: (id: string) => Promise<void>;
-  switchWorkspace: (id: string) => Promise<void>;
+  switchWorkspace: (id: string, workspaceOverride?: Workspace) => Promise<void>;
 
   // Member management
   loadMembers: () => Promise<void>;
@@ -220,8 +220,11 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
         setError(null);
         const workspace = await workspaceClient.createWorkspace(data);
         setWorkspaces(prev => [...prev, workspace]);
-        // Automatically switch to new workspace
-        await switchWorkspace(workspace.id);
+        // Automatically switch to the new workspace. We do NOT delegate to
+        // `switchWorkspace` here because its closure captures a stale
+        // `workspaces` list (without the workspace we just created), which
+        // would make the workspace lookup fail and skip the state reset.
+        await switchWorkspace(workspace.id, workspace);
         return workspace;
       } catch (err: any) {
         setError(err.message || "Failed to create workspace");
@@ -304,36 +307,35 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
   );
 
   const switchWorkspace = useCallback(
-    async (id: string) => {
+    async (id: string, workspaceOverride?: Workspace) => {
       try {
         setError(null);
         await workspaceClient.switchWorkspace(id);
-        const workspace = workspaces.find(ws => ws.id === id);
+
+        const workspace =
+          workspaceOverride ?? workspaces.find(ws => ws.id === id);
         if (workspace) {
           setCurrentWorkspace(workspace);
-
-          // Clear local storage to reset app state for new workspace
-          // But preserve the activeWorkspaceId by setting it AFTER clear
-          localStorage.clear();
-          localStorage.setItem("activeWorkspaceId", id);
-          setCurrentWorkspaceId(id);
-
-          // Also reset in-memory store state to prevent leaks if reload is delayed
-          useUIStore.getState().reset();
-          useExplorerStore.getState().reset();
-          useChatStore.getState().reset();
-          useConsoleStore.getState().clearAllConsoles();
-          useFlowStore.getState().reset();
-
-          // Reload the page to refresh all data with new workspace context
-          window.location.reload();
-        } else {
-          // Workspace not in current list - this can happen during invite acceptance
-          // Just set the ID and let the reload fetch the workspace
-          localStorage.setItem("activeWorkspaceId", id);
-          setCurrentWorkspaceId(id);
-          window.location.reload();
         }
+
+        // Clear local storage to reset app state for the new workspace.
+        // This is critical: persisted stores (console-store, flow-store-v2,
+        // explorer-store, chat-store, ui-store, …) must not leak tabs/state
+        // from the previous workspace into the new one. Preserve the
+        // activeWorkspaceId by setting it AFTER clear.
+        localStorage.clear();
+        localStorage.setItem("activeWorkspaceId", id);
+        setCurrentWorkspaceId(id);
+
+        // Also reset in-memory store state to prevent leaks if reload is delayed
+        useUIStore.getState().reset();
+        useExplorerStore.getState().reset();
+        useChatStore.getState().reset();
+        useConsoleStore.getState().clearAllConsoles();
+        useFlowStore.getState().reset();
+
+        // Reload the page to refresh all data with new workspace context
+        window.location.reload();
       } catch (err: any) {
         setError(err.message || "Failed to switch workspace");
         throw err;

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -80,6 +80,7 @@ interface ConsoleActions {
     databaseId?: string,
     chartSpec?: Record<string, unknown>,
     resultsViewMode?: string,
+    comment?: string,
   ) => Promise<ConsoleSaveResponse>;
   deleteConsole: (
     workspaceId: string,
@@ -442,6 +443,7 @@ export const useConsoleStore = create<ConsoleStore>()(
         databaseId,
         chartSpec,
         resultsViewMode,
+        comment,
       ) => {
         try {
           const cleanPath = path.endsWith(".js") ? path.slice(0, -3) : path;
@@ -460,6 +462,7 @@ export const useConsoleStore = create<ConsoleStore>()(
                 isSaved: true,
                 chartSpec: chartSpec ?? null,
                 resultsViewMode,
+                comment: comment ?? "",
               }),
             },
           );

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -65,6 +65,7 @@ interface ConsoleActions {
 
   // API operations
   loadConsole: (workspaceId: string, consoleId: string) => Promise<void>;
+  reloadConsole: (workspaceId: string, consoleId: string) => Promise<void>;
   fetchConsoleContent: (
     workspaceId: string,
     consoleId: string,
@@ -385,6 +386,37 @@ export const useConsoleStore = create<ConsoleStore>()(
           set(state => {
             delete state.loading[consoleId];
           });
+        }
+      },
+
+      reloadConsole: async (workspaceId, consoleId) => {
+        try {
+          const res = await apiClient.get<ConsoleContentResponse>(
+            `/workspaces/${workspaceId}/consoles/content`,
+            { id: consoleId },
+          );
+
+          if (res.success) {
+            const content = res.content || "";
+            const filePath = res.path || res.name;
+
+            get().openTab({
+              id: res.id,
+              title: res.name || res.path || "Console",
+              content,
+              isSaved: res.isSaved ?? !!filePath,
+              connectionId: res.connectionId,
+              databaseId: res.databaseId,
+              databaseName: res.databaseName,
+              filePath,
+              kind: "console",
+              chartSpec: res.chartSpec,
+              resultsViewMode: res.resultsViewMode,
+            });
+            get().setActiveTab(res.id);
+          }
+        } catch {
+          // silent
         }
       },
 

--- a/app/src/store/dashboardStore.ts
+++ b/app/src/store/dashboardStore.ts
@@ -177,6 +177,7 @@ interface DashboardStoreState {
   saveDashboard: (
     workspaceId: string,
     dashboardId: string,
+    comment?: string,
   ) => Promise<{ ok: boolean; error?: string }>;
   resolveConflict: (
     resolution: "discard" | "overwrite",
@@ -502,7 +503,11 @@ export const useDashboardStore = create<DashboardStoreState>()(
         void disposeDashboardRuntime(dashboardId);
       },
 
-      saveDashboard: async (workspaceId: string, dashboardId: string) => {
+      saveDashboard: async (
+        workspaceId: string,
+        dashboardId: string,
+        comment?: string,
+      ) => {
         const dashboard = get().openDashboards[dashboardId];
         if (!dashboard) return { ok: false, error: "Dashboard not loaded" };
         try {
@@ -511,6 +516,7 @@ export const useDashboardStore = create<DashboardStoreState>()(
           const payload = {
             ...editableDefinition,
             version: dashboard.version,
+            comment: comment ?? "",
           };
           const response = await apiClient.patch<{
             success: boolean;

--- a/app/src/store/uiStore.ts
+++ b/app/src/store/uiStore.ts
@@ -191,3 +191,35 @@ export const selectCurrentWorkspaceId = (state: UIStore) =>
   state.currentWorkspaceId;
 export const selectActiveEditorContent = (state: UIStore) =>
   state.activeEditorContent;
+
+/**
+ * The "active explorer" — the explorer panel currently visible on the left,
+ * or `null` when no explorer is open (pane collapsed). Unlike `leftPane`,
+ * which is the last-selected view and is retained across collapse/expand
+ * so it can be restored, `activeExplorer` reflects what is *actually* on
+ * screen. Consumers (sidebar highlight, AI context, etc.) should prefer
+ * this over `leftPane` when they want to know what the user is looking at.
+ *
+ * `"settings"` is excluded because it opens as an editor tab, not a left
+ * explorer panel.
+ */
+export type ActiveExplorer =
+  | "databases"
+  | "consoles"
+  | "connectors"
+  | "flows"
+  | "dashboards"
+  | null;
+
+const EXPLORER_VIEWS: ReadonlySet<LeftPaneView> = new Set([
+  "databases",
+  "consoles",
+  "connectors",
+  "flows",
+  "dashboards",
+]);
+
+export const selectActiveExplorer = (state: UIStore): ActiveExplorer =>
+  state.leftPaneOpen && EXPLORER_VIEWS.has(state.leftPane)
+    ? (state.leftPane as Exclude<ActiveExplorer, null>)
+    : null;

--- a/app/src/store/versionStore.ts
+++ b/app/src/store/versionStore.ts
@@ -76,7 +76,10 @@ export const useVersionStore = create<VersionStoreState>((set, get) => ({
       set(state => {
         const existing = opts?.offset ? (state.versions[key] ?? []) : [];
         return {
-          versions: { ...state.versions, [key]: [...existing, ...data.versions] },
+          versions: {
+            ...state.versions,
+            [key]: [...existing, ...data.versions],
+          },
           totals: { ...state.totals, [key]: data.total },
           loading: { ...state.loading, [key]: false },
         };

--- a/app/src/store/versionStore.ts
+++ b/app/src/store/versionStore.ts
@@ -50,7 +50,7 @@ function buildBasePath(
   entityId: string,
 ) {
   const collection = entityType === "console" ? "consoles" : "dashboards";
-  return `/api/workspaces/${workspaceId}/${collection}/${entityId}/versions`;
+  return `/workspaces/${workspaceId}/${collection}/${entityId}/versions`;
 }
 
 export const useVersionStore = create<VersionStoreState>((set, get) => ({
@@ -73,11 +73,14 @@ export const useVersionStore = create<VersionStoreState>((set, get) => ({
         total: number;
       }>(buildBasePath(workspaceId, entityType, entityId), params);
 
-      set(state => ({
-        versions: { ...state.versions, [key]: data.versions },
-        totals: { ...state.totals, [key]: data.total },
-        loading: { ...state.loading, [key]: false },
-      }));
+      set(state => {
+        const existing = opts?.offset ? (state.versions[key] ?? []) : [];
+        return {
+          versions: { ...state.versions, [key]: [...existing, ...data.versions] },
+          totals: { ...state.totals, [key]: data.total },
+          loading: { ...state.loading, [key]: false },
+        };
+      });
     } catch {
       set(state => ({ loading: { ...state.loading, [key]: false } }));
     }

--- a/app/src/store/versionStore.ts
+++ b/app/src/store/versionStore.ts
@@ -1,0 +1,128 @@
+import { create } from "zustand";
+import { apiClient } from "../lib/api-client";
+
+export interface VersionListItem {
+  version: number;
+  savedBy: string;
+  savedByName: string;
+  comment: string;
+  restoredFrom?: number | null;
+  createdAt: string;
+}
+
+export interface VersionDetail extends VersionListItem {
+  snapshot: Record<string, unknown>;
+}
+
+interface VersionStoreState {
+  versions: Record<string, VersionListItem[]>;
+  totals: Record<string, number>;
+  loading: Record<string, boolean>;
+
+  fetchVersionHistory: (
+    workspaceId: string,
+    entityType: "console" | "dashboard",
+    entityId: string,
+    opts?: { limit?: number; offset?: number },
+  ) => Promise<void>;
+
+  fetchVersion: (
+    workspaceId: string,
+    entityType: "console" | "dashboard",
+    entityId: string,
+    version: number,
+  ) => Promise<VersionDetail | null>;
+
+  restoreVersion: (
+    workspaceId: string,
+    entityType: "console" | "dashboard",
+    entityId: string,
+    version: number,
+    comment?: string,
+  ) => Promise<{ success: boolean; error?: string }>;
+
+  clearHistory: (entityId: string) => void;
+}
+
+function buildBasePath(
+  workspaceId: string,
+  entityType: "console" | "dashboard",
+  entityId: string,
+) {
+  const collection = entityType === "console" ? "consoles" : "dashboards";
+  return `/api/workspaces/${workspaceId}/${collection}/${entityId}/versions`;
+}
+
+export const useVersionStore = create<VersionStoreState>((set, get) => ({
+  versions: {},
+  totals: {},
+  loading: {},
+
+  fetchVersionHistory: async (workspaceId, entityType, entityId, opts) => {
+    const key = entityId;
+    set(state => ({ loading: { ...state.loading, [key]: true } }));
+
+    try {
+      const params: Record<string, string> = {};
+      if (opts?.limit) params.limit = String(opts.limit);
+      if (opts?.offset) params.offset = String(opts.offset);
+
+      const data = await apiClient.get<{
+        success: boolean;
+        versions: VersionListItem[];
+        total: number;
+      }>(buildBasePath(workspaceId, entityType, entityId), params);
+
+      set(state => ({
+        versions: { ...state.versions, [key]: data.versions },
+        totals: { ...state.totals, [key]: data.total },
+        loading: { ...state.loading, [key]: false },
+      }));
+    } catch {
+      set(state => ({ loading: { ...state.loading, [key]: false } }));
+    }
+  },
+
+  fetchVersion: async (workspaceId, entityType, entityId, version) => {
+    try {
+      const data = await apiClient.get<{
+        success: boolean;
+        version: VersionDetail;
+      }>(`${buildBasePath(workspaceId, entityType, entityId)}/${version}`);
+      return data.version;
+    } catch {
+      return null;
+    }
+  },
+
+  restoreVersion: async (
+    workspaceId,
+    entityType,
+    entityId,
+    version,
+    comment,
+  ) => {
+    try {
+      await apiClient.post(
+        `${buildBasePath(workspaceId, entityType, entityId)}/${version}/restore`,
+        { comment: comment ?? "" },
+      );
+      // Refresh the version list
+      await get().fetchVersionHistory(workspaceId, entityType, entityId);
+      return { success: true };
+    } catch (err) {
+      return {
+        success: false,
+        error: err instanceof Error ? err.message : "Restore failed",
+      };
+    }
+  },
+
+  clearHistory: entityId => {
+    set(state => {
+      const { [entityId]: _v, ...versions } = state.versions;
+      const { [entityId]: _t, ...totals } = state.totals;
+      return { versions, totals };
+    });
+  },
+}));


### PR DESCRIPTION
## Summary

- **Immutable version history** for saved consoles and dashboards — every explicit save creates a new snapshot in a dedicated `entity_versions` collection; data is never overwritten.
- **Save comment dialog** (like Git commit messages) shown on every save for both consoles and dashboards, with version history panel showing who saved each version, when, and their comment.
- **Restore any version** — restoring creates a new version (append-only, like `git revert`), keeping the full audit trail intact.
- **AI agent tools** — `browse_version_history` and `get_version_snapshot` registered in console, dashboard, and unified agents so the AI can inspect past versions.
- **Migration** seeds version 1 for all existing saved consoles and dashboards.

## Changes

### Backend
| File | What |
|------|------|
| `api/src/database/workspace-schema.ts` | New `IEntityVersion` interface, `EntityVersionSchema`, `EntityVersion` model with indexes. Added `version` field to `ISavedConsole`. |
| `api/src/services/entity-version.service.ts` | **New** — `createVersion`, `listVersions`, `getVersion`, `getLatestVersionNumber` |
| `api/src/routes/consoles.ts` | Version records on POST/PUT, new `GET /:id/versions`, `GET /:id/versions/:version`, `POST /:id/versions/:version/restore` |
| `api/src/routes/dashboards.ts` | Version records on POST/PUT/PATCH, same version endpoints |
| `api/src/agent-lib/tools/version-history-tools.ts` | **New** — `browse_version_history` + `get_version_snapshot` tools |
| `api/src/agents/{console,dashboard,unified}/index.ts` | Register version history tools |
| `api/src/migrations/2026-04-05-*` | **New** — creates collection, indexes, seeds v1 for existing entities |

### Frontend
| File | What |
|------|------|
| `app/src/components/SaveCommentDialog.tsx` | **New** — MUI dialog for save comments (Ctrl+Enter shortcut) |
| `app/src/components/VersionHistoryPanel.tsx` | **New** — drawer with version list, snapshot preview, restore with confirmation |
| `app/src/components/Editor.tsx` | Intercepts console saves to show comment dialog; wires history button |
| `app/src/components/DashboardCanvas.tsx` | Comment dialog on save; history button in toolbar |
| `app/src/store/versionStore.ts` | **New** — Zustand store for fetch/restore version operations |
| `app/src/store/consoleStore.ts` | Pass `comment` through save flow |
| `app/src/store/dashboardStore.ts` | Pass `comment` through save flow |

## Test plan

- [ ] Save a console → verify comment dialog appears → confirm version 1 created in DB
- [ ] Save the same console again with a different comment → verify version 2 created (version 1 untouched)
- [ ] Open version history panel on a console → verify list shows both versions with author and comment
- [ ] Click a version → verify snapshot preview shows the code at that point
- [ ] Restore version 1 → verify a new version 3 is created with "Restored from v1" indicator
- [ ] Repeat the above for dashboards (create, update, history, restore)
- [ ] Run migration on a database with existing consoles/dashboards → verify v1 seeded for each
- [ ] Ask the AI agent to "show version history for console X" → verify it returns version list
- [ ] Ask the AI agent to "show me version 1 of console X" → verify it returns the snapshot


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new persistence paths (new `entity_versions` collection, save/restore flows, migration) that affect how consoles/dashboards are stored and recovered; mistakes could impact data integrity or restore behavior. No auth model changes, but new endpoints and writes increase operational risk.
> 
> **Overview**
> Introduces *append-only, immutable versioning* for saved consoles and dashboards by writing full snapshots into a new `entity_versions` collection (with indexes) on each explicit save, and seeding v1 snapshots for existing entities via migration.
> 
> Adds API support to list versions, fetch a specific version snapshot, and restore an older version (restore applies the snapshot, increments the entity `version`, and appends a new version record with `restoredFrom`).
> 
> Updates the UI to require an optional save comment on save and to expose a Version History drawer with snapshot preview and one-click restore; wires through a new `versionStore` plus console/dashboard store updates. Also registers new agent tools (`browse_version_history`, `get_version_snapshot`) across console, dashboard, and unified agents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75d7ec3b5620d428f0c43339c03ec2c5217d4311. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->