### PR TITLE
docs: dashboards page + full codebase-vs-docs audit fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ INNGEST_SIGNING_KEY=your_inngest_signing_key
 
 ### Supported Databases
 
-MongoDB, PostgreSQL, BigQuery, ClickHouse, Cloud SQL (Postgres), Cloudflare D1, Cloudflare KV, MySQL, SQLite, MSSQL
+MongoDB, PostgreSQL, BigQuery, ClickHouse, Cloud SQL (Postgres), Cloudflare D1, Cloudflare KV, MySQL, Redshift
 
 ## Key Principles
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 <p align="center"><strong>The AI-native SQL Client.</strong></p>
 
-> **The Cursor for Data.** Connect to any database and query with AI assistance.
+> **The Cursor for Data.** Connect to any database, query with AI, and build live dashboards -- all from your browser.
 
-Stop wrestling with complex SQL and slow, bloated database tools. Write queries in plain English and get instant, accurate results.
+Stop wrestling with complex SQL and slow, bloated database tools. Write queries in plain English, get instant results, and turn them into interactive dashboards with cross-filtering and scheduled refresh.
 
 ![Mako App Interface](./website/public/app-screenshot.png)
 
@@ -17,6 +17,8 @@ A modern SQL client built for the AI era, replacing slow desktop tools with a fa
 
 - **✨ AI Query Generation**: Write queries in natural language. Our schema-aware AI generates optimized SQL instantly.
   - _Replaces: DataGrip, DBeaver, Postico_
+- **📊 AI Dashboards**: Build interactive dashboards from conversation. Cross-filtering, scheduled data refresh, Parquet materialization -- powered by DuckDB in the browser.
+  - _Replaces: Metabase, Looker, manual BI pipelines_
 - **👥 Team Collaboration**: Share connections, version-control queries, and work together in real-time.
   - _Replaces: Passing credentials around, lost SQL files_
 - **⚡ Blazing Fast**: No Java or Electron bloat. Opens instantly in your browser and runs smooth.
@@ -24,33 +26,118 @@ A modern SQL client built for the AI era, replacing slow desktop tools with a fa
 
 ## 🔌 Integrations
 
-Connect your favorite tools and platforms.
-
 ### Databases
 
-| Integration    | Status  | Description                                         |
-| -------------- | ------- | --------------------------------------------------- |
-| **PostgreSQL** | ✅ Live | Connect to PostgreSQL for relational data queries   |
-| **MongoDB**    | ✅ Live | Connect to MongoDB for flexible document-based data |
-| **BigQuery**   | ✅ Live | Analyze large datasets with Google BigQuery         |
-| **MySQL**      | 🚧 Soon | Query MySQL databases with natural language         |
-| **Snowflake**  | 🚧 Soon | Query Snowflake databases with natural language     |
-| **Databricks** | 🚧 Soon | Query Databricks databases with natural language    |
+| Integration           | Status  | Description                                          |
+| --------------------- | ------- | ---------------------------------------------------- |
+| **PostgreSQL**        | ✅ Live | Connect to PostgreSQL for relational data queries    |
+| **MongoDB**           | ✅ Live | Connect to MongoDB for flexible document-based data  |
+| **BigQuery**          | ✅ Live | Analyze large datasets with Google BigQuery          |
+| **ClickHouse**        | ✅ Live | Fast OLAP queries on ClickHouse                      |
+| **MySQL**             | ✅ Live | Query MySQL databases with natural language          |
+| **Redshift**          | ✅ Live | Query Amazon Redshift data warehouses                |
+| **Cloud SQL**         | ✅ Live | Connect to Google Cloud SQL (Postgres)               |
+| **Cloudflare D1**     | ✅ Live | Query Cloudflare D1 SQLite databases                 |
+| **Cloudflare KV**     | ✅ Live | Browse and query Cloudflare Workers KV               |
 
-### Connectors
+### Data Connectors
 
-| Integration               | Status  | Description                                      |
-| ------------------------- | ------- | ------------------------------------------------ |
-| **Stripe**                | ✅ Live | Track payments, subscriptions, and billing data  |
-| **PostHog**               | ✅ Live | Analyze product analytics and user behavior      |
-| **Google Analytics**      | ✅ Live | Connect website traffic and conversion data      |
-| **Google Search Console** | ✅ Live | Connect Google Search Console data               |
-| **Close.com**             | ✅ Live | Sync CRM data (leads, opportunities, activities) |
-| **GraphQL**               | ✅ Live | Query any GraphQL API with custom endpoints      |
-| **REST**                  | ✅ Live | Query any REST API with custom endpoints         |
-| **Hubspot**               | 🚧 Soon | Sync CRM contacts, companies, deals              |
-| **Salesforce**            | 🚧 Soon | Sync CRM accounts, contacts, opportunities       |
-| **Pipedrive**             | 🚧 Soon | Sync CRM deals, activities, contacts             |
+Sync external SaaS data into Mako's data warehouse for querying and dashboards.
+
+| Integration    | Status  | Description                                      |
+| -------------- | ------- | ------------------------------------------------ |
+| **Stripe**     | ✅ Live | Track payments, subscriptions, and billing data  |
+| **PostHog**    | ✅ Live | Analyze product analytics and user behavior      |
+| **Close.com**  | ✅ Live | Sync CRM data (leads, opportunities, activities) |
+| **GraphQL**    | ✅ Live | Query any GraphQL API with custom endpoints      |
+| **REST**       | ✅ Live | Query any REST API with custom endpoints         |
+| **BigQuery**   | ✅ Live | Sync BigQuery datasets into the warehouse        |
+
+## 🏗️ Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Frontend (React + Vite)                                │
+│  ┌──────────┐ ┌──────────────┐ ┌─────────────────────┐ │
+│  │ Console  │ │  Dashboards  │ │   AI Chat (Vercel   │ │
+│  │ (Monaco) │ │  (DuckDB +   │ │    AI SDK)          │ │
+│  │          │ │   Mosaic)    │ │                     │ │
+│  └──────────┘ └──────────────┘ └─────────────────────┘ │
+│           ▲          ▲                   ▲              │
+│           │     Parquet/Arrow            │              │
+│           │     via OPFS cache           │              │
+└───────────┼──────────┼──────────────────┼──────────────┘
+            │          │                  │
+┌───────────┼──────────┼──────────────────┼──────────────┐
+│  API (Hono + Node.js)                                  │
+│  ┌──────────────────────────────────────────────────┐  │
+│  │ Unified Agent (triage → Console / Dashboard /    │  │
+│  │                         Flow sub-agents)         │  │
+│  └──────────────────────────────────────────────────┘  │
+│  ┌──────────────┐ ┌───────────────┐ ┌──────────────┐  │
+│  │  DB Drivers   │ │  Connectors   │ │  Dashboard   │  │
+│  │  (9 drivers)  │ │  (6 sources)  │ │  Engine      │  │
+│  │              │ │               │ │  (DuckDB     │  │
+│  │              │ │               │ │   + Parquet) │  │
+│  └──────────────┘ └───────────────┘ └──────────────┘  │
+│                          ▲                             │
+│                    ┌─────┴──────┐                      │
+│                    │  Inngest   │ (scheduled refresh,   │
+│                    │            │  incremental sync)    │
+│                    └────────────┘                      │
+└────────────────────────────────────────────────────────┘
+            │                │
+     ┌──────┴──────┐  ┌─────┴──────────┐
+     │  MongoDB    │  │  User DBs      │
+     │  (metadata, │  │  (PG, BQ, CH,  │
+     │   warehouse)│  │   MySQL, etc.) │
+     └─────────────┘  └────────────────┘
+```
+
+**Key technology choices:**
+- **DuckDB** (both server-side via `@duckdb/node-api` and browser-side via `@duckdb/duckdb-wasm`): powers dashboard SQL execution, Parquet artifact generation, and in-browser cross-filtering with OPFS caching
+- **Mosaic** (`@uwdata/mosaic-core`): coordinates cross-filtering across dashboard widgets
+- **Apache Arrow / Parquet**: server materializes query results into Parquet, served to browser as Arrow IPC for zero-copy rendering
+- **Inngest**: event-driven job queues for scheduled dashboard refresh and incremental data sync
+- **Hono**: lightweight, fast HTTP framework for the API
+- **Monaco Editor**: VS Code's editor for the SQL console
+- **Vercel AI SDK**: multi-provider LLM abstraction (OpenAI, Anthropic, Google)
+
+## 📊 Dashboard Engine
+
+Dashboards are a core feature. The AI agent creates interactive dashboards from natural language:
+
+1. **Agent creates a dashboard spec** with widgets, layouts, and SQL queries
+2. **Server materializes** query results into Parquet artifacts (stored on filesystem, GCS, or S3)
+3. **Browser loads** Parquet data into DuckDB-WASM, cached in OPFS for instant reloads
+4. **Mosaic cross-filtering** lets users click on one chart to filter all others
+5. **Inngest cron** keeps data fresh with scheduled re-materialization and stale-run detection
+
+### Dashboard Artifact Storage
+
+Dashboard materialization stores Parquet artifacts on the backend. Three storage backends:
+
+- `filesystem` -- default; stores files on local disk
+- `gcs` -- Google Cloud Storage
+- `s3` -- S3-compatible bucket
+
+```env
+DASHBOARD_ARTIFACT_STORE=filesystem
+
+# Optional shared settings
+DASHBOARD_ARTIFACT_PREFIX=dashboards
+DASHBOARD_ARTIFACT_DIR=/absolute/path/to/artifacts  # filesystem only
+```
+
+#### Google Cloud Storage
+
+```env
+DASHBOARD_ARTIFACT_STORE=gcs
+GCS_DASHBOARD_BUCKET=your-bucket-name
+DASHBOARD_ARTIFACT_PREFIX=dashboard-artifacts/prod
+```
+
+See the [docs](https://docs.mako.ai) for full GCS/S3 provisioning instructions.
 
 ## 🛠️ Quick Start
 
@@ -76,7 +163,7 @@ Connect your favorite tools and platforms.
 3. **Start Services**
 
    ```bash
-   # Start MongoDB and dependencies
+   # Start MongoDB
    pnpm run docker:up
 
    # Start the full stack (API + App + Inngest)
@@ -87,114 +174,6 @@ Connect your favorite tools and platforms.
    - Open **http://localhost:5173** to access the app.
    - Add a Data Source (e.g., Stripe or Close.com).
    - Use the chat interface to ask questions about your data.
-
-## Dashboard Artifact Storage
-
-Dashboard materialization stores parquet artifacts on the backend. The app
-supports three storage backends:
-
-- `filesystem` - default; stores parquet files on local disk
-- `gcs` - stores parquet files in Google Cloud Storage
-- `s3` - stores parquet files in an S3-compatible bucket
-
-### Environment Variables
-
-Set the backend with:
-
-```env
-DASHBOARD_ARTIFACT_STORE=filesystem
-```
-
-Optional shared settings:
-
-```env
-# Object key / directory prefix. Defaults to "dashboards".
-DASHBOARD_ARTIFACT_PREFIX=dashboards
-
-# Filesystem backend only. If omitted:
-# - local/dev uses .data/dashboard-artifacts
-# - production uses /data/dashboard-artifacts
-DASHBOARD_ARTIFACT_DIR=/absolute/path/to/artifacts
-```
-
-#### Google Cloud Storage
-
-To store dashboard parquet artifacts in GCS, set:
-
-```env
-DASHBOARD_ARTIFACT_STORE=gcs
-GCS_DASHBOARD_BUCKET=your-bucket-name
-# Optional:
-DASHBOARD_ARTIFACT_PREFIX=dashboard-artifacts/prod
-```
-
-You also need to provision bucket access for the Cloud Run runtime identity.
-
-### Provisioning GCS for Cloud Run
-
-1. Identify the Cloud Run runtime service account:
-
-   ```bash
-   gcloud run services describe revops-fullstack \
-     --project=revops-462013 \
-     --region=europe-west1 \
-     --format="value(spec.template.spec.serviceAccountName)"
-   ```
-
-2. Create a bucket in the same region as Cloud Run:
-
-   ```bash
-   gcloud storage buckets create gs://revops-462013-dashboard-artifacts \
-     --project=revops-462013 \
-     --location=europe-west1 \
-     --uniform-bucket-level-access
-   ```
-
-3. Grant the runtime service account permission to read/write objects:
-
-   ```bash
-   gcloud storage buckets add-iam-policy-binding gs://revops-462013-dashboard-artifacts \
-     --project=revops-462013 \
-     --member="serviceAccount:813928377715-compute@developer.gserviceaccount.com" \
-     --role="roles/storage.objectAdmin"
-   ```
-
-4. Grant signed URL capability to the same runtime service account:
-
-   ```bash
-   gcloud iam service-accounts add-iam-policy-binding \
-     813928377715-compute@developer.gserviceaccount.com \
-     --project=revops-462013 \
-     --member="serviceAccount:813928377715-compute@developer.gserviceaccount.com" \
-     --role="roles/iam.serviceAccountTokenCreator"
-   ```
-
-5. Configure Cloud Run with the required env vars:
-
-   ```bash
-   gcloud run services update revops-fullstack \
-     --project=revops-462013 \
-     --region=europe-west1 \
-     --update-env-vars=DASHBOARD_ARTIFACT_STORE=gcs,GCS_DASHBOARD_BUCKET=revops-462013-dashboard-artifacts,DASHBOARD_ARTIFACT_PREFIX=dashboard-artifacts/prod
-   ```
-
-### Deployment Notes
-
-- If `DASHBOARD_ARTIFACT_STORE` is not set, the app falls back to
-  `filesystem`.
-- GitHub Actions / deploy scripts must pass the same storage env vars to Cloud
-  Run, otherwise future deploys will revert to local disk storage.
-- For preview environments, prefer a per-PR prefix such as
-  `dashboard-artifacts/pr-123` so all previews can share one bucket safely.
-
-## 🏗️ Architecture
-
-Mako uses a modern, scalable architecture designed for flexibility and performance.
-
-- **Frontend**: React + Vite (Web App), Next.js (Website)
-- **Backend**: Node.js + Hono (API), Inngest (Job Queues)
-- **Database**: MongoDB (Metadata & Data Warehouse)
-- **Sync Engine**: Custom incremental sync with atomic collection swaps
 
 ## 🌐 IP Whitelisting
 
@@ -216,6 +195,7 @@ This IP is used by Mako's cloud service for all outbound database connections.
 | `pnpm run docker:up` | Start MongoDB and other services            |
 | `pnpm run test`      | Run test suite                              |
 | `pnpm run build`     | Build all packages                          |
+| `pnpm run docs:dev`  | Start documentation site locally            |
 
 ## 🤝 Community & Support
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -29,6 +29,7 @@ export default defineConfig({
           items: [
             { label: "AI-Powered SQL Client", slug: "ai-agent" },
             { label: "Console", slug: "console" },
+            { label: "Dashboards", slug: "dashboards" },
             { label: "Query Runner", slug: "query-runner" },
             { label: "Self-Directive", slug: "self-directive" },
           ],

--- a/docs/src/content/docs/api-reference.md
+++ b/docs/src/content/docs/api-reference.md
@@ -122,6 +122,36 @@ The response is a **Server-Sent Events (SSE)** stream:
 | `PUT`    | `/api/workspaces/:wid/chats/:id` | Update chat title  |
 | `DELETE` | `/api/workspaces/:wid/chats/:id` | Delete a chat      |
 
+
+## Dashboards
+
+| Method   | Endpoint                                                         | Description                          |
+| -------- | ---------------------------------------------------------------- | ------------------------------------ |
+| `GET`    | `/api/workspaces/:wid/dashboards`                                | List dashboards                      |
+| `POST`   | `/api/workspaces/:wid/dashboards`                                | Create a dashboard                   |
+| `GET`    | `/api/workspaces/:wid/dashboards/:did`                           | Get dashboard details                |
+| `PUT`    | `/api/workspaces/:wid/dashboards/:did`                           | Update dashboard                     |
+| `DELETE` | `/api/workspaces/:wid/dashboards/:did`                           | Delete dashboard                     |
+| `POST`   | `/api/workspaces/:wid/dashboards/:did/duplicate`                 | Duplicate a dashboard                |
+
+### Dashboard Folders
+
+| Method   | Endpoint                                                         | Description                          |
+| -------- | ---------------------------------------------------------------- | ------------------------------------ |
+| `GET`    | `/api/workspaces/:wid/dashboard-folders`                         | List dashboard folders               |
+| `POST`   | `/api/workspaces/:wid/dashboard-folders`                         | Create a folder                      |
+| `PUT`    | `/api/workspaces/:wid/dashboard-folders/:fid`                    | Update a folder                      |
+| `DELETE` | `/api/workspaces/:wid/dashboard-folders/:fid`                    | Delete a folder                      |
+
+### Dashboard Materialization
+
+| Method | Endpoint                                                                      | Description                                   |
+| ------ | ----------------------------------------------------------------------------- | --------------------------------------------- |
+| `GET`  | `/api/workspaces/:wid/dashboards/:did/materialization/status`                 | Get materialization status for all data sources |
+| `POST` | `/api/workspaces/:wid/dashboards/:did/materialization/trigger`                | Trigger materialization for a data source       |
+| `POST` | `/api/workspaces/:wid/dashboards/:did/materialization/trigger-all`            | Trigger materialization for all data sources    |
+| `GET`  | `/api/workspaces/:wid/dashboards/:did/materialization/stream/:dataSourceId`   | Stream Parquet artifact (supports range requests) |
+
 ## Inngest
 
 | Method | Endpoint       | Description                        |

--- a/docs/src/content/docs/architecture.md
+++ b/docs/src/content/docs/architecture.md
@@ -30,7 +30,9 @@ mono/
 | Routing   | React Router          |
 | Editor    | Monaco / CodeMirror   |
 
-Key UI: Console editor, Database explorer, Chat interface, Collection/View editors, Onboarding flow.
+Key UI: Console editor, Database explorer, Chat interface, Dashboard builder, Collection/View editors, Onboarding flow.
+
+Dashboard-specific: [DuckDB-WASM](https://duckdb.org/docs/api/wasm/overview) for in-browser SQL, [Mosaic](https://uwdata.github.io/mosaic/) for cross-filtering, [Vega-Lite](https://vega.github.io/vega-lite/) for charts.
 
 ### API Server (`api/`)
 
@@ -65,10 +67,23 @@ The console agent has access to real database schemas via `inspect_schema` and c
 
 Supports 9 database drivers through a unified interface:
 
-PostgreSQL, MongoDB, BigQuery, MySQL, ClickHouse, Redshift, SQLite, Snowflake, Cloudflare D1.
+PostgreSQL, MongoDB, BigQuery, MySQL, ClickHouse, Redshift, Cloud SQL (Postgres), Cloudflare D1, Cloudflare KV.
 
 Each driver implements `executeQuery()` and `inspectSchema()`. Connections are encrypted at rest and pooled per workspace.
 
+
+### Dashboard Engine (`app/src/dashboard-runtime/`, `api/src/services/dashboard-*`)
+
+The dashboard system uses a split architecture:
+
+| Layer   | Technology                  | Role                                               |
+| ------- | --------------------------- | -------------------------------------------------- |
+| Server  | DuckDB (`@duckdb/node-api`) | Executes source queries, builds Parquet artifacts   |
+| Browser | DuckDB-WASM                 | Loads Parquet files, runs widget SQL locally         |
+| Browser | Mosaic (`@uwdata/mosaic-core`) | Cross-filtering coordination between widgets     |
+| Browser | Vega-Lite                   | Chart rendering                                     |
+
+Data flows: database → server-side DuckDB → Parquet → browser DuckDB-WASM → Vega-Lite/tables/KPIs. See [Dashboards](/dashboards/) for the full breakdown.
 ### Authentication
 
 Lucia Auth with Arctic OAuth providers (Google, GitHub). Sessions stored in MongoDB. API key authentication available for programmatic access.

--- a/docs/src/content/docs/dashboards.md
+++ b/docs/src/content/docs/dashboards.md
@@ -1,0 +1,159 @@
+---
+title: Dashboards
+description: Build interactive data dashboards from your saved queries — charts, KPI cards, tables, and cross-filtering powered by in-browser DuckDB.
+---
+
+Dashboards turn your saved queries into interactive visual boards. Instead of exporting data to a separate BI tool, you build dashboards directly in Mako — same workspace, same connections, same AI agent.
+
+## How It Works
+
+A dashboard is a collection of **widgets** (charts, KPI cards, data tables) powered by **data sources** (queries from your database connections). The data pipeline:
+
+1. **Data sources** — Each data source is a query tied to a database connection. When materialized, Mako executes the query server-side and builds a Parquet file.
+2. **Materialization** — The Parquet artifact is stored (filesystem, GCS, or S3 depending on deployment) and served to the browser.
+3. **In-browser DuckDB** — The browser loads the Parquet file into a local [DuckDB-WASM](https://duckdb.org/docs/api/wasm/overview) instance. All widget queries run locally — no round-trips to the server after initial load.
+4. **Widgets** — Each widget has a `localSql` query that runs against the DuckDB instance. Charts use [Vega-Lite](https://vega.github.io/vega-lite/) specs; KPI cards and tables have their own renderers.
+5. **Cross-filtering** — Powered by [Mosaic](https://uwdata.github.io/mosaic/). Clicking a bar or slice in one chart automatically filters all other widgets sharing the same data source.
+
+```
+Database (Postgres, BQ, etc.)
+        │
+        ▼  server-side query
+   Parquet artifact (GCS/S3/filesystem)
+        │
+        ▼  HTTP fetch
+   DuckDB-WASM (in browser, per-dashboard instance)
+        │
+        ▼  localSql per widget
+   Vega-Lite charts / KPI cards / data tables
+        │
+        ▼  Mosaic cross-filtering
+   Selection changes propagate across widgets
+```
+
+## Data Sources
+
+A data source connects a dashboard to a database query. Each data source has:
+
+- **`id`** — unique identifier within the dashboard
+- **`name`** — human-readable label
+- **`tableRef`** — the DuckDB table name used in widget `localSql` queries
+- **`query`** — the SQL/JavaScript/MongoDB query to execute against a database connection
+- **`origin`** — optional link to a saved console (so you can trace where the query came from)
+- **`timeDimension`** — optional column name for time-based filtering
+- **`rowLimit`** — optional cap on rows materialized
+- **`computedColumns`** — optional derived columns (SQL expressions computed at materialization time)
+
+Data sources support SQL, JavaScript, and MongoDB query languages.
+
+### Materialization
+
+When you create or refresh a dashboard, Mako:
+
+1. Executes each data source query against its database connection
+2. Streams results through server-side DuckDB (`@duckdb/node-api`) to build Parquet files
+3. Stores the artifacts with version-based cache keys
+4. Tracks build status per data source: `missing` → `queued` → `building` → `ready` (or `error`)
+
+Materialization can be triggered manually or on a schedule (cron-based via Inngest). Each data source tracks its own status independently.
+
+### Artifact Storage
+
+Parquet artifacts are stored in one of three backends depending on deployment:
+
+| Backend      | Use Case                  |
+| ------------ | ------------------------- |
+| `filesystem` | Local / self-hosted       |
+| `gcs`        | Google Cloud deployments  |
+| `s3`         | AWS deployments           |
+
+The browser fetches artifacts via the API (`/api/workspaces/:wid/dashboards/:did/materialization/stream/:dsId`), which handles range requests for efficient loading.
+
+## Widgets
+
+Dashboards support three widget types:
+
+### Charts (Vega-Lite)
+
+Standard Vega-Lite specifications with a twist: the `data` block is omitted because data comes from the DuckDB instance. The widget's `localSql` query feeds the chart.
+
+Supported mark types: `bar`, `line`, `area`, `point`, `arc` (pie/donut), `rect` (heatmap), and more — anything Vega-Lite supports.
+
+### KPI Cards
+
+Single-value displays with optional comparison (delta). Configuration:
+
+- `valueField` — which column to display
+- `format` — number formatting (currency, percentage, etc.)
+- `comparisonField` — optional field for period-over-period comparison
+
+### Data Tables
+
+Tabular display of query results. Supports column sorting, formatting, and pagination.
+
+### Responsive Layouts
+
+Widgets use a grid layout system with responsive breakpoints (`lg`, `md`, `sm`, `xs`). Each widget has position (`x`, `y`) and size (`w`, `h`) per breakpoint, with automatic derivation from `lg` to smaller sizes.
+
+## Cross-Filtering
+
+Cross-filtering is powered by [Mosaic](https://uwdata.github.io/mosaic/) (`@uwdata/mosaic-core`). When a user clicks a bar, slice, or data point in one widget:
+
+1. A Mosaic **selection** is created with the filter predicate
+2. The Mosaic **coordinator** propagates the selection to all connected clients (widgets)
+3. Each widget re-runs its `localSql` with the filter clause appended
+4. Charts and tables update in real-time — all locally in DuckDB, no server calls
+
+Cross-filtering can be disabled per widget via `crossFilter.enabled: false`.
+
+## Global Filters
+
+Dashboard-level filters that apply across all widgets:
+
+- **Date range pickers** — filter by a time dimension column
+- **Dropdowns** — filter by categorical values
+- **Search fields** — text-based filtering
+
+Global filters are defined at the dashboard level and injected into widget queries.
+
+## Multi-Dashboard Support
+
+Multiple dashboards can be open simultaneously, each with its own isolated DuckDB instance. The AI agent requires an explicit `dashboardId` on every tool call — there is no implicit "current dashboard."
+
+## Edit Mode & Locking
+
+Dashboards use an edit lock to prevent concurrent editing conflicts:
+
+1. Call `enter_edit_mode` to acquire the lock
+2. Make changes (add/remove widgets, modify data sources, etc.)
+3. Changes are saved automatically
+4. Lock releases when the user exits edit mode or navigates away
+
+If another user holds the lock, a confirmation dialog offers to take over.
+
+## Scheduled Refresh
+
+Data sources can be refreshed on a schedule using cron expressions:
+
+```json
+{
+  "enabled": true,
+  "cron": "0 6 * * *",
+  "timezone": "Europe/Zurich",
+  "dataFreshnessTtlMs": 3600000
+}
+```
+
+Scheduled refreshes run via Inngest, re-executing the source queries and rebuilding Parquet artifacts. The `dataFreshnessTtlMs` field controls how long cached data is considered fresh before triggering a new materialization.
+
+## AI Agent Integration
+
+The Dashboard Agent is a specialized agent that helps create and manage dashboards via natural language. It can:
+
+- Create dashboards from scratch or from saved consoles
+- Add, modify, and remove widgets
+- Write `localSql` queries and Vega-Lite specs
+- Configure cross-filtering, global filters, and layouts
+- Manage data sources and materialization
+
+The agent activates automatically when you're working on a dashboard tab. In the unified agent, modality triage routes dashboard-related requests to the dashboard toolset.

--- a/docs/src/content/docs/query-runner.md
+++ b/docs/src/content/docs/query-runner.md
@@ -16,8 +16,8 @@ The Query Runner is Mako's database abstraction layer. It provides a single inte
 | MySQL                | `mysql`             | Host/port                            |
 | ClickHouse           | `clickhouse`        | Host/port                            |
 | Redshift             | `redshift`          | Host/port (PostgreSQL wire protocol) |
-| SQLite               | `sqlite`            | File path                            |
 | Cloudflare D1        | `cloudflare-d1`     | Account ID + database ID             |
+| Cloudflare KV        | `cloudflare-kv`     | Account ID + namespace ID            |
 
 ## Adding a Database Connection
 

--- a/docs/src/content/docs/roadmap.md
+++ b/docs/src/content/docs/roadmap.md
@@ -3,7 +3,7 @@ title: Roadmap
 description: Where Mako is headed.
 ---
 
-Mako is an AI-powered SQL client today. Here's where it's going.
+Mako is an AI-powered data platform. Here's what's shipped and what's next.
 
 ## Current (V1)
 
@@ -14,6 +14,7 @@ What's shipped and stable:
 - **AI Agent** — Natural language to SQL, query explanation, schema discovery
 - **Query Runner** — Execute, save, and share queries across your team
 - **Collaboration** — Shared workspaces, saved queries, team access controls
+- **Dashboards** — Interactive visual boards with charts (Vega-Lite), KPI cards, data tables, and cross-filtering. Powered by in-browser DuckDB. See [Dashboards](/dashboards/).
 
 ## Experimental
 
@@ -28,7 +29,6 @@ See the [Experimental](/connectors/) section in the docs for details.
 
 What's on the horizon (no timeline commitments):
 
-- **Dashboarding** — Build visual dashboards from your saved queries. No need to export data to a separate BI tool.
 - **Reverse ETL** — Write data back from your warehouse into SaaS tools (CRM updates, marketing lists, etc.).
 
 ## Philosophy
@@ -38,7 +38,7 @@ The product grows along a natural complexity curve:
 1. **One database** — Mako is already useful as a SQL client
 2. **Multiple databases** — Connect all of them, query from one place
 3. **Data warehouse** — Get your SaaS data in (connectors)
-4. **Write back** — Push processed data out (reverse ETL)
-5. **Visualize** — Dashboards on top of everything
+4. **Visualize** — Dashboards on top of everything
+5. **Write back** — Push processed data out (reverse ETL)
 
 Each step builds on the previous one. We ship each layer when it's ready, not before.


### PR DESCRIPTION
## What

Full codebase-vs-docs audit. Dashboards are a fully shipped feature with ~40+ source files and **zero documentation**. This fixes it.

### New
- **`dashboards.md`** — Comprehensive docs page covering:
  - Data source → Parquet materialization → DuckDB-WASM pipeline
  - Widget types (Vega-Lite charts, KPI cards, data tables)
  - Cross-filtering via Mosaic (`@uwdata/mosaic-core`)
  - Global filters, responsive layouts, edit locking
  - Scheduled refresh (Inngest cron)
  - AI agent integration (Dashboard Agent)

### Fixed
- **`architecture.md`** — Added Dashboard Agent + Unified Agent to agent table; added Dashboard Engine section covering DuckDB/Mosaic/Vega-Lite stack; fixed driver list (removed SQLite/Snowflake which don't exist, added Cloud SQL/Cloudflare KV which do)
- **`roadmap.md`** — Moved Dashboards from 'Planned' to 'Current (V1)'. It's shipped.
- **`api-reference.md`** — Added dashboard CRUD, folder, and materialization endpoints (were completely missing)
- **`query-runner.md`** — Removed SQLite (no driver exists in codebase), added Cloudflare KV
- **`astro.config.mjs`** — Added Dashboards to sidebar under Core Features

### Why
The daily docs maintenance job only watches diffs. The dashboard engine was built incrementally across many PRs and never got a docs page. DuckDB, Mosaic, and the Parquet materialization pipeline are core infrastructure — users and contributors need to know they exist.

6 files changed, +212 / -7