### PR TITLE
feat(close): scope webhook registration to synced entities only

### DIFF
--- a/api/src/connectors/base/BaseConnector.ts
+++ b/api/src/connectors/base/BaseConnector.ts
@@ -79,6 +79,7 @@ export interface ProvisionWebhookOptions {
   endpointUrl: string;
   verifySsl?: boolean;
   events?: string[];
+  enabledEntities?: string[];
 }
 
 export interface ProvisionWebhookResult {

--- a/api/src/connectors/close/connector.ts
+++ b/api/src/connectors/close/connector.ts
@@ -1990,11 +1990,13 @@ export class CloseConnector extends BaseConnector {
           .map(event => event.trim())
           .filter((event): event is string => event.length > 0)
       : [];
-    const normalized = normalizeEventSelectors(
+
+    const effectiveEvents =
       requestedEvents.length > 0
         ? requestedEvents
-        : this.getSupportedWebhookEvents(),
-    );
+        : this.getWebhookEventsForEntities(options.enabledEntities ?? []);
+
+    const normalized = normalizeEventSelectors(effectiveEvents);
     if (requestedEvents.length > 0 && normalized.unsupported.length > 0) {
       logger.warn("Ignoring unsupported Close webhook events", {
         unsupportedEvents: normalized.unsupported,
@@ -2039,6 +2041,23 @@ export class CloseConnector extends BaseConnector {
           existing.subscription_id ||
           existing.webhook_id;
         if (existingId) {
+          try {
+            await api.put(`/webhook/${existingId}/`, {
+              events: normalized.selectors,
+            });
+            logger.info(
+              "Updated Close webhook events for existing subscription",
+              {
+                webhookId: existingId,
+                eventCount: normalized.selectors.length,
+              },
+            );
+          } catch (updateError) {
+            logger.warn("Could not update events on existing Close webhook", {
+              webhookId: existingId,
+              error: updateError,
+            });
+          }
           return {
             providerWebhookId: String(existingId),
             endpointUrl: options.endpointUrl,
@@ -2259,6 +2278,69 @@ export class CloseConnector extends BaseConnector {
     return CLOSE_SUPPORTED_WEBHOOK_SELECTORS.map(
       selector => `${selector.object_type}.${selector.action}`,
     );
+  }
+
+  /**
+   * Return only the webhook event strings relevant to the given entities.
+   * Falls back to all supported events when the entity list is empty
+   * (i.e. no explicit selection — sync everything).
+   */
+  getWebhookEventsForEntities(entities: string[]): string[] {
+    if (entities.length === 0) return this.getSupportedWebhookEvents();
+
+    const entitySet = new Set(entities.map(e => e.toLowerCase()));
+
+    const activitySubTypeToObjectType: Record<string, string> = {
+      call: "activity.call",
+      email: "activity.email",
+      emailthread: "activity.email_thread",
+      sms: "activity.sms",
+      note: "activity.note",
+      meeting: "activity.meeting",
+      leadstatuschange: "activity.lead_status_change",
+      opportunitystatuschange: "activity.opportunity_status_change",
+      taskcompleted: "activity.task_completed",
+      customactivity: "activity.custom_activity",
+    };
+
+    const entityToObjectTypes: Record<string, string[]> = {
+      leads: ["lead"],
+      contacts: ["contact"],
+      opportunities: ["opportunity"],
+      custom_fields: [
+        "custom_fields.lead",
+        "custom_fields.contact",
+        "custom_fields.opportunity",
+        "custom_fields.activity",
+        "custom_fields.custom_object",
+        "custom_fields.shared",
+      ],
+      custom_activity_types: ["custom_activity_type"],
+      custom_object_types: ["custom_object_type"],
+      custom_objects: ["custom_object"],
+      lead_statuses: ["status.lead"],
+      opportunity_statuses: ["status.opportunity"],
+    };
+
+    const relevantObjectTypes = new Set<string>();
+
+    for (const entity of entitySet) {
+      if (entity.startsWith("activities:")) {
+        const subType = entity.slice("activities:".length).toLowerCase();
+        const objType = activitySubTypeToObjectType[subType];
+        if (objType) relevantObjectTypes.add(objType);
+        continue;
+      }
+
+      const mapped = entityToObjectTypes[entity];
+      if (mapped) {
+        for (const ot of mapped) relevantObjectTypes.add(ot);
+      }
+    }
+
+    return CLOSE_SUPPORTED_WEBHOOK_SELECTORS.filter(selector =>
+      relevantObjectTypes.has(selector.object_type),
+    ).map(selector => `${selector.object_type}.${selector.action}`);
   }
 
   /**

--- a/api/src/routes/flows.ts
+++ b/api/src/routes/flows.ts
@@ -2049,10 +2049,13 @@ flowRoutes.post("/:flowId/webhook/provision", async c => {
           .filter(Boolean)
       : undefined;
 
+    const { entities: enabledEntities } = resolveConfiguredEntities(flow);
+
     const created = await connector.createWebhookSubscription({
       endpointUrl: endpoint,
       verifySsl: body.verifySsl !== false,
       events: requestedEvents,
+      enabledEntities,
     });
 
     if (!flow.webhookConfig) {


### PR DESCRIPTION
## Summary

- Close webhook provisioning now only registers event selectors for entities the flow actually has enabled, instead of blindly registering all ~70 supported events
- When re-provisioning an existing webhook (same URL found), the connector now PUT-updates its event list so entity selection changes take effect without deleting/recreating the subscription
- Added `enabledEntities` to `ProvisionWebhookOptions` interface so connectors can receive the flow's entity configuration during provisioning

## Changes

| File | What |
|------|------|
| `api/src/connectors/base/BaseConnector.ts` | Added optional `enabledEntities` to `ProvisionWebhookOptions` |
| `api/src/connectors/close/connector.ts` | New `getWebhookEventsForEntities()` method that maps Mako entities → Close webhook selectors; `createWebhookSubscription` uses it for filtering and PUT-updates existing webhooks |
| `api/src/routes/flows.ts` | Provision route resolves flow entities via `resolveConfiguredEntities()` and passes them to the connector |

## Behavior

- **New webhook**: Only registers selectors for entities the flow has enabled
- **Re-provision (existing webhook)**: Updates the existing webhook's events to match current entity selection
- **No explicit entity selection**: Falls back to all events (preserves current behavior)
- **Explicit `events` in request body**: Still takes precedence (existing override mechanism preserved)

## Test plan

- [ ] Provision a Close webhook flow with a subset of entities enabled → verify Close API receives only relevant selectors
- [ ] Re-provision the same flow after changing entity selection → verify the existing webhook's events are updated via PUT
- [ ] Provision a flow with no explicit entity selection → verify all events are registered (backward compat)
- [ ] Verify webhook events for unsynced entities are no longer received from Close


Made with [Cursor](https://cursor.com)