### PR TITLE
fix(cdc): don't drop stream staging table during recovery

### DIFF
--- a/api/src/sync-cdc/backfill.ts
+++ b/api/src/sync-cdc/backfill.ts
@@ -834,19 +834,20 @@ export class CdcBackfillService {
 
       for (const entity of enabledEntities) {
         const liveTable = cdcLiveTableName(tablePrefix, entity, flowId);
-        const bulkStaging = `${liveTable}__${flowToken}__staging`;
+        // Only drop backfill staging and legacy tables. The stream staging
+        // table (`…__staging`) is ephemeral — created and dropped within
+        // writeViaParquet's try/finally. Dropping it here races with
+        // in-flight cdc-materialize jobs and causes "Table not found" errors.
         const backfillBulkStaging = `${liveTable}__${flowToken}__backfill_staging`;
         const legacyStagingTables = [
           cdcStageTableName(tablePrefix, entity, flowId),
           `${liveTable}__stage_changes`,
         ];
-        for (const table of [bulkStaging, backfillBulkStaging]) {
-          try {
-            await driver.dropTable(destination, table, { schema });
-            dropped++;
-          } catch {
-            /* may not exist */
-          }
+        try {
+          await driver.dropTable(destination, backfillBulkStaging, { schema });
+          dropped++;
+        } catch {
+          /* may not exist */
         }
         for (const table of legacyStagingTables) {
           try {


### PR DESCRIPTION
## Summary

Two fixes to prevent stream recovery from interfering with backfill and stream materialization:

### 1. Don't drop stream staging table during recovery
`cleanupOrphanStagingTables` was dropping the stream staging table (`…__staging`) during recovery. This table is ephemeral — created and dropped within `writeViaParquet`'s `try/finally` block. Dropping it during recovery races with in-flight `cdc-materialize` Inngest jobs, causing BigQuery "Table not found" errors when the MERGE step references a staging table that recovery already deleted.

**Fix:** Only drop `…__backfill_staging` and legacy staging tables — the actual orphans. The stream staging table is self-cleaning.

### 2. Skip stream activation when recovering an incomplete backfill
`recoverFlow` unconditionally activated the stream (`RECOVER` transition + `resumeStream`) even when the backfill hadn't finished yet (`runId` still set). This caused:
- Concurrent writes to the same live tables from both stream and backfill paths
- `retryFailedMaterialization` firing stream-side `cdc/materialize` events that conflict with backfill flushes
- `cleanupOrphanStagingTables` dropping `backfill_staging` tables mid-flush

**Fix:** Check for incomplete backfill (`backfillState.runId`) and branch:
- **Incomplete backfill →** restart backfill from checkpoint via `startBackfill({ reuseExistingRunId: true })`; stream activates automatically when backfill completes (via `cdc-transition-backfill-complete`)
- **No backfill →** recover the stream as before

## Test plan

- [ ] Trigger recovery while a backfill is in progress — should restart backfill from checkpoint, not activate stream
- [ ] Trigger recovery with no active backfill — should activate stream as before
- [ ] Trigger recovery while stream materialization is in-flight — should no longer produce "Table not found" errors
- [ ] Confirm backfill staging and legacy tables are still cleaned up during non-backfill recovery