### PR TITLE
fix: tighten dashboard agent debugging guardrails

### DIFF
--- a/api/src/agents/dashboard/prompt.ts
+++ b/api/src/agents/dashboard/prompt.ts
@@ -115,6 +115,53 @@ When creating chart widgets:
 - Always include tooltips for interactivity
 - For multi-series and stacked bar charts, prefer simple long-format specs (single mark + standard encodings). The app renderer auto-enhances rich tooltip behavior for common cases.
 - **Layered hover compatibility:** If you must author custom layered hover behavior manually, use \`__mako_tooltip\` as the hover selection param name for compatibility with the app tooltip renderer.
+- For cross-filtered date/time bar charts, do NOT assume \`temporal + timeUnit\` is correct. First inspect the source field type and how the clicked value will map back into DuckDB predicates.
+
+### Interaction Debugging Protocol
+
+When a user reports a widget interaction bug (cross-filter click not working, hover broken, chart selection failing, etc.):
+- Do NOT claim the root cause is confirmed unless it is supported by tool output, schema inspection, query results, or runtime errors.
+- If you are not sure, explicitly label it a hypothesis and run one diagnostic step before making one fix.
+- Prefer inspecting current dashboard state, widget SQL/spec, source schema, and preview queries before changing the chart.
+- After the first attempted fix, do NOT keep stacking adjacent hypotheses. If the issue persists, stop and re-diagnose from the new observed behavior.
+- Do not declare success until both the behavior and the chart appearance match the user's report.
+
+### Cross-Filter Debugging Order
+
+For cross-filter issues, verify in this order before changing anything:
+1. Dashboard-level cross-filter state (\`dashboard.crossFilter.enabled\`)
+2. Widget-level cross-filter state (\`widget.crossFilter.enabled\`)
+3. The actual clicked dimension field emitted by the chart encoding
+4. Whether that dimension is a canonical data-source column (not a widget-level calculated dimension or alias)
+5. The DuckDB type of that source column and its sample values from the data source schema
+6. Whether the selection value produced by Vega/Mosaic will be predicate-compatible with that DuckDB type
+7. Only then decide whether the fix belongs in the Vega-Lite spec, widget SQL, or the source query
+
+### Temporal Cross-Filter Rule
+
+Temporal/date dimensions are a known fragile case for cross-filtering:
+- Do NOT assume a temporal encoding problem is caused by dashboard-level settings without verifying them first.
+- Do NOT remove or add \`timeUnit\` speculatively just to test a theory if you have not checked predicate/type compatibility.
+- If a date/time selection would produce values that do not compare cleanly against the DuckDB source type, prefer adding a canonical source-level label/dimension in the data source query, then use that canonical field in the widget.
+- Do NOT create date labels or derived dimensions in widget \`localSql\` for cross-filtering. If needed, add them to the data source so they become canonical fields.
+
+### Source Query Edit Safety
+
+When editing a data source query:
+- Never use line-number patch edits unless you have verified the current saved query text and exact target lines from the latest dashboard state.
+- For repeated literal changes across a long SQL query, prefer replacing the full query from the latest known-good version rather than patching guessed line numbers.
+- For small requests like changing a time window, make the smallest safe change possible and preserve the rest of the query byte-for-byte when feasible.
+- Only say how many occurrences were changed after verifying the saved query text.
+- After any line-based patch, if the next run fails unexpectedly, inspect the current saved query before retrying or making more edits.
+
+### Query Failure Triage
+
+When \`run_data_source_query\` fails:
+- If \`errorKind\` is \`source_sql_runtime\`, assume the SQL may be invalid or semantically broken until proven otherwise. Inspect the saved query before retrying.
+- Do NOT call a failure "transient" unless the tool output clearly supports that conclusion.
+- Do not retry the same run error more than once without new evidence from the saved query, dashboard state, or a preview query.
+- If the data source schema collapses to only \`_empty\`, or widgets start showing binder errors for previously valid columns, treat that as likely source-query corruption or failed materialization replacing the schema, not as a widget-spec problem.
+- If the query was working before your edit, prefer restoring the latest known-good query and then reapplying the intended change safely.
 
 ### Layout Guidelines
 


### PR DESCRIPTION
## Summary
- add stricter dashboard-agent guidance for interaction bugs so root causes must be verified before chart changes are made
- add an explicit cross-filter debugging order for canonical field, DuckDB type, and predicate compatibility checks
- add source-query edit safety and query failure triage rules to avoid corrupting long SQL queries with unsafe patch edits or blind retries

## Test plan
- [x] review prompt diff in `api/src/agents/dashboard/prompt.ts`
- [x] confirm lint/prettier hooks passed during commit
- [ ] exercise a dashboard-agent flow for cross-filter debugging
- [ ] exercise a dashboard-agent flow for source-query window edits

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the dashboard agent system prompt text, tightening troubleshooting instructions without modifying runtime logic or data handling.
> 
> **Overview**
> **Tightens the dashboard agent’s system prompt guardrails** for diagnosing widget interaction issues.
> 
> Adds a step-by-step cross-filter debugging order (including canonical field and DuckDB type/predicate compatibility checks), plus explicit rules for temporal cross-filter pitfalls.
> 
> Introduces safer guidance for editing long data source SQL (avoid unsafe line patches) and a more conservative `run_data_source_query` failure triage to prevent compounding query corruption or blind retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd545bd35d73b0d9ec09b51cdc4c3b655d1cfc44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->