### PR TITLE
fix(cdc): keep backfill stable on 1Gi Cloud Run

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -452,6 +452,7 @@ jobs:
             --region ${GCP_REGION} \
             --timeout=3600 \
             --memory=1Gi \
+            --concurrency=4 \
             --min-instances=0 \
             --max-instances=2 \
             --allow-unauthenticated \
@@ -482,6 +483,10 @@ jobs:
             --set-env-vars ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY} \
             --set-env-vars GOOGLE_GENERATIVE_AI_API_KEY=${GOOGLE_GENERATIVE_AI_API_KEY} \
             --set-env-vars OPENAI_API_KEY=${OPENAI_API_KEY} \
+            --set-env-vars SYNC_BULK_FLUSH_BATCH_SIZE=30000 \
+            --set-env-vars SYNC_BULK_MONGO_TO_PARQUET_CHUNK=200 \
+            --set-env-vars SYNC_PARQUET_DUCKDB_MEMORY_LIMIT_MB=256 \
+            --set-env-vars SYNC_PARQUET_DUCKDB_THREADS=1 \
             --set-env-vars RATE_LIMIT_MAX_REQUESTS=${RATE_LIMIT_MAX_REQUESTS} \
             --set-env-vars RATE_LIMIT_WINDOW_MS=${RATE_LIMIT_WINDOW_MS} \
             --set-env-vars SENDGRID_API_KEY=${SENDGRID_API_KEY} \
@@ -789,6 +794,7 @@ jobs:
             --region ${GCP_REGION} \
             --timeout=3600 \
             --memory=1Gi \
+            --concurrency=4 \
             --min-instances=1 \
             --network=mako-vpc \
             --subnet=mako-subnet \
@@ -812,6 +818,10 @@ jobs:
             --set-env-vars ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY} \
             --set-env-vars GOOGLE_GENERATIVE_AI_API_KEY=${GOOGLE_GENERATIVE_AI_API_KEY} \
             --set-env-vars OPENAI_API_KEY=${OPENAI_API_KEY} \
+            --set-env-vars SYNC_BULK_FLUSH_BATCH_SIZE=30000 \
+            --set-env-vars SYNC_BULK_MONGO_TO_PARQUET_CHUNK=200 \
+            --set-env-vars SYNC_PARQUET_DUCKDB_MEMORY_LIMIT_MB=256 \
+            --set-env-vars SYNC_PARQUET_DUCKDB_THREADS=1 \
             --set-env-vars RATE_LIMIT_MAX_REQUESTS=${RATE_LIMIT_MAX_REQUESTS} \
             --set-env-vars RATE_LIMIT_WINDOW_MS=${RATE_LIMIT_WINDOW_MS} \
             --set-env-vars SENDGRID_API_KEY=${SENDGRID_API_KEY} \

--- a/api/src/sync/sync-orchestrator.ts
+++ b/api/src/sync/sync-orchestrator.ts
@@ -956,10 +956,25 @@ async function performSyncChunkSql(
  * to the OS promptly). The streaming pipeline micro-chunks rows via
  * MONGO_TO_PARQUET_CHUNK so peak JS heap stays bounded regardless of this value.
  */
-const FLUSH_BATCH_SIZE = 60_000;
+function resolvePositiveIntEnv(
+  value: string | undefined,
+  fallback: number,
+): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+const FLUSH_BATCH_SIZE = resolvePositiveIntEnv(
+  process.env.SYNC_BULK_FLUSH_BATCH_SIZE,
+  30_000,
+);
 
 /** Rows passed per DuckDB insertBatch from Mongo (parquet builder micro-chunks SQL). */
-const MONGO_TO_PARQUET_CHUNK = 400;
+const MONGO_TO_PARQUET_CHUNK = resolvePositiveIntEnv(
+  process.env.SYNC_BULK_MONGO_TO_PARQUET_CHUNK,
+  200,
+);
 
 function syncMemorySnapshot(): {
   heapUsedMb: number;

--- a/api/src/utils/streaming-parquet-builder.ts
+++ b/api/src/utils/streaming-parquet-builder.ts
@@ -8,6 +8,17 @@ const logger = loggers.api("streaming-parquet-builder");
 
 /** Max rows per INSERT VALUES clause to cap peak JS heap (SQL string materialization). */
 const INSERT_MICRO_BATCH_ROWS = 120;
+const DEFAULT_DUCKDB_MEMORY_LIMIT_MB = 256;
+const DEFAULT_DUCKDB_THREADS = 1;
+
+function parsePositiveInt(
+  rawValue: string | undefined,
+  fallback: number,
+): number {
+  if (!rawValue) return fallback;
+  const parsed = Number.parseInt(rawValue, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -197,12 +208,26 @@ export async function buildParquetFromBatches(
 
   const instance = await DuckDBInstance.create(dbPath);
   const connection = await instance.connect();
+  const duckDbMemoryLimitMb = parsePositiveInt(
+    process.env.SYNC_PARQUET_DUCKDB_MEMORY_LIMIT_MB,
+    DEFAULT_DUCKDB_MEMORY_LIMIT_MB,
+  );
+  const duckDbThreads = parsePositiveInt(
+    process.env.SYNC_PARQUET_DUCKDB_THREADS,
+    DEFAULT_DUCKDB_THREADS,
+  );
   let totalRows = 0;
   let tableCreated = false;
   let columns: string[] = [];
   let columnTypeMap = new Map<string, DuckDBColumnType>();
 
   try {
+    await connection.run(`PRAGMA threads=${duckDbThreads}`);
+    await connection.run(`PRAGMA memory_limit='${duckDbMemoryLimitMb}MB'`);
+    await connection.run(
+      `PRAGMA temp_directory='${os.tmpdir().replace(/'/g, "''")}'`,
+    );
+
     const insertBatch = async (rows: Record<string, unknown>[]) => {
       if (rows.length === 0) return;
 
@@ -292,6 +317,8 @@ export async function buildParquetFromBatches(
       rowCount: totalRows,
       byteSize: stat.size,
       parquetPath,
+      duckDbMemoryLimitMb,
+      duckDbThreads,
     });
 
     return {


### PR DESCRIPTION
## Summary
- Reduce peak backfill memory usage by lowering bulk flush and Mongo-to-Parquet chunk defaults, while keeping them tunable via environment variables.
- Cap DuckDB parquet builder memory/threads (`PRAGMA memory_limit`, `PRAGMA threads`) so parquet conversion cannot consume most of a 1Gi instance.
- Lower Cloud Run per-instance concurrency and set sync memory tuning env vars in deploy workflow for preview and production deploys.

## Test plan
- [x] Run lints on changed files (`ReadLints` showed no errors).
- [ ] Deploy branch to preview and start a CDC backfill with high-volume entities.
- [ ] Confirm no `Memory limit of 1024 MiB exceeded` entries in Cloud Run system logs during backfill.
- [ ] Verify Inngest backfill reaches completion without `SERVER_RESTART` transitions.

Made with [Cursor](https://cursor.com)