### PR TITLE
fix(cdc): stabilize 1Gi backfill runs and surface event status counts

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -452,6 +452,7 @@ jobs:
             --region ${GCP_REGION} \
             --timeout=3600 \
             --memory=1Gi \
+            --concurrency=4 \
             --min-instances=0 \
             --max-instances=2 \
             --allow-unauthenticated \
@@ -482,6 +483,10 @@ jobs:
             --set-env-vars ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY} \
             --set-env-vars GOOGLE_GENERATIVE_AI_API_KEY=${GOOGLE_GENERATIVE_AI_API_KEY} \
             --set-env-vars OPENAI_API_KEY=${OPENAI_API_KEY} \
+            --set-env-vars SYNC_BULK_FLUSH_BATCH_SIZE=30000 \
+            --set-env-vars SYNC_BULK_MONGO_TO_PARQUET_CHUNK=200 \
+            --set-env-vars SYNC_PARQUET_DUCKDB_MEMORY_LIMIT_MB=256 \
+            --set-env-vars SYNC_PARQUET_DUCKDB_THREADS=1 \
             --set-env-vars RATE_LIMIT_MAX_REQUESTS=${RATE_LIMIT_MAX_REQUESTS} \
             --set-env-vars RATE_LIMIT_WINDOW_MS=${RATE_LIMIT_WINDOW_MS} \
             --set-env-vars SENDGRID_API_KEY=${SENDGRID_API_KEY} \
@@ -789,6 +794,7 @@ jobs:
             --region ${GCP_REGION} \
             --timeout=3600 \
             --memory=1Gi \
+            --concurrency=4 \
             --min-instances=1 \
             --network=mako-vpc \
             --subnet=mako-subnet \
@@ -812,6 +818,10 @@ jobs:
             --set-env-vars ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY} \
             --set-env-vars GOOGLE_GENERATIVE_AI_API_KEY=${GOOGLE_GENERATIVE_AI_API_KEY} \
             --set-env-vars OPENAI_API_KEY=${OPENAI_API_KEY} \
+            --set-env-vars SYNC_BULK_FLUSH_BATCH_SIZE=30000 \
+            --set-env-vars SYNC_BULK_MONGO_TO_PARQUET_CHUNK=200 \
+            --set-env-vars SYNC_PARQUET_DUCKDB_MEMORY_LIMIT_MB=256 \
+            --set-env-vars SYNC_PARQUET_DUCKDB_THREADS=1 \
             --set-env-vars RATE_LIMIT_MAX_REQUESTS=${RATE_LIMIT_MAX_REQUESTS} \
             --set-env-vars RATE_LIMIT_WINDOW_MS=${RATE_LIMIT_WINDOW_MS} \
             --set-env-vars SENDGRID_API_KEY=${SENDGRID_API_KEY} \

--- a/api/src/sync/sync-orchestrator.ts
+++ b/api/src/sync/sync-orchestrator.ts
@@ -956,10 +956,25 @@ async function performSyncChunkSql(
  * to the OS promptly). The streaming pipeline micro-chunks rows via
  * MONGO_TO_PARQUET_CHUNK so peak JS heap stays bounded regardless of this value.
  */
-const FLUSH_BATCH_SIZE = 60_000;
+function resolvePositiveIntEnv(
+  value: string | undefined,
+  fallback: number,
+): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+const FLUSH_BATCH_SIZE = resolvePositiveIntEnv(
+  process.env.SYNC_BULK_FLUSH_BATCH_SIZE,
+  30_000,
+);
 
 /** Rows passed per DuckDB insertBatch from Mongo (parquet builder micro-chunks SQL). */
-const MONGO_TO_PARQUET_CHUNK = 400;
+const MONGO_TO_PARQUET_CHUNK = resolvePositiveIntEnv(
+  process.env.SYNC_BULK_MONGO_TO_PARQUET_CHUNK,
+  200,
+);
 
 function syncMemorySnapshot(): {
   heapUsedMb: number;

--- a/api/src/utils/streaming-parquet-builder.ts
+++ b/api/src/utils/streaming-parquet-builder.ts
@@ -8,6 +8,17 @@ const logger = loggers.api("streaming-parquet-builder");
 
 /** Max rows per INSERT VALUES clause to cap peak JS heap (SQL string materialization). */
 const INSERT_MICRO_BATCH_ROWS = 120;
+const DEFAULT_DUCKDB_MEMORY_LIMIT_MB = 256;
+const DEFAULT_DUCKDB_THREADS = 1;
+
+function parsePositiveInt(
+  rawValue: string | undefined,
+  fallback: number,
+): number {
+  if (!rawValue) return fallback;
+  const parsed = Number.parseInt(rawValue, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -197,12 +208,26 @@ export async function buildParquetFromBatches(
 
   const instance = await DuckDBInstance.create(dbPath);
   const connection = await instance.connect();
+  const duckDbMemoryLimitMb = parsePositiveInt(
+    process.env.SYNC_PARQUET_DUCKDB_MEMORY_LIMIT_MB,
+    DEFAULT_DUCKDB_MEMORY_LIMIT_MB,
+  );
+  const duckDbThreads = parsePositiveInt(
+    process.env.SYNC_PARQUET_DUCKDB_THREADS,
+    DEFAULT_DUCKDB_THREADS,
+  );
   let totalRows = 0;
   let tableCreated = false;
   let columns: string[] = [];
   let columnTypeMap = new Map<string, DuckDBColumnType>();
 
   try {
+    await connection.run(`PRAGMA threads=${duckDbThreads}`);
+    await connection.run(`PRAGMA memory_limit='${duckDbMemoryLimitMb}MB'`);
+    await connection.run(
+      `PRAGMA temp_directory='${os.tmpdir().replace(/'/g, "''")}'`,
+    );
+
     const insertBatch = async (rows: Record<string, unknown>[]) => {
       if (rows.length === 0) return;
 
@@ -292,6 +317,8 @@ export async function buildParquetFromBatches(
       rowCount: totalRows,
       byteSize: stat.size,
       parquetPath,
+      duckDbMemoryLimitMb,
+      duckDbThreads,
     });
 
     return {

--- a/app/src/components/BackfillPanel.tsx
+++ b/app/src/components/BackfillPanel.tsx
@@ -47,6 +47,8 @@ interface BackfillPanelProps {
   onEdit?: () => void;
 }
 
+type EventFilterKey = "all" | "applied" | "pending" | "failed" | "dropped";
+
 type StreamState = "idle" | "active" | "paused" | "error";
 type BackfillStatus = "idle" | "running" | "paused" | "completed" | "error";
 
@@ -336,6 +338,15 @@ export function BackfillPanel({
   const [webhookEvents, setWebhookEvents] = useState<any[]>([]);
   const [webhookEventsTotalAll, setWebhookEventsTotalAll] = useState(0);
   const [eventsFilter, setEventsFilter] = useState<string>("all");
+  const [eventCounts, setEventCounts] = useState<
+    Record<EventFilterKey, number>
+  >({
+    all: 0,
+    applied: 0,
+    pending: 0,
+    failed: 0,
+    dropped: 0,
+  });
   const [retryingFailed, setRetryingFailed] = useState(false);
   const [entityResetOpen, setEntityResetOpen] = useState(false);
   const [entityResetEntity, setEntityResetEntity] = useState("");
@@ -422,6 +433,31 @@ export function BackfillPanel({
     flowId,
   ]);
 
+  const fetchEventCounts = useCallback(async () => {
+    const [
+      allResult,
+      appliedResult,
+      pendingResult,
+      failedResult,
+      droppedResult,
+    ] = await Promise.all([
+      fetchWebhookEvents(workspaceId, flowId, 1, 0),
+      fetchWebhookEvents(workspaceId, flowId, 1, 0, { applyStatus: "applied" }),
+      fetchWebhookEvents(workspaceId, flowId, 1, 0, { applyStatus: "pending" }),
+      fetchWebhookEvents(workspaceId, flowId, 1, 0, { applyStatus: "failed" }),
+      fetchWebhookEvents(workspaceId, flowId, 1, 0, { applyStatus: "dropped" }),
+    ]);
+
+    const all = allResult?.total ?? 0;
+    const applied = appliedResult?.total ?? 0;
+    const pending = pendingResult?.total ?? 0;
+    const failed = failedResult?.total ?? 0;
+    const dropped = droppedResult?.total ?? 0;
+
+    setEventCounts({ all, applied, pending, failed, dropped });
+    setWebhookEventsTotalAll(all);
+  }, [fetchWebhookEvents, workspaceId, flowId]);
+
   const pollLogs = useCallback(async () => {
     const currentExecId = executionIdRef.current;
     if (!currentExecId) {
@@ -494,6 +530,13 @@ export function BackfillPanel({
   useEffect(() => {
     pollCdc();
   }, [tab, eventsFilter]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (tab !== 2) return;
+    fetchEventCounts();
+    const id = setInterval(fetchEventCounts, 15000);
+    return () => clearInterval(id);
+  }, [tab, fetchEventCounts]);
 
   const pollDestCounts = useCallback(async () => {
     const counts = await fetchCdcDestinationCounts(workspaceId, flowId);
@@ -1932,9 +1975,7 @@ export function BackfillPanel({
               ).map(f => (
                 <Chip
                   key={f.key}
-                  label={
-                    f.key === "all" ? `All (${webhookEventsTotalAll})` : f.label
-                  }
+                  label={`${f.label} (${eventCounts[f.key] ?? 0})`}
                   size="small"
                   variant={eventsFilter === f.key ? "filled" : "outlined"}
                   color={


### PR DESCRIPTION
## Summary
- reduce CDC backfill memory pressure for 1Gi Cloud Run by tightening buffering behavior and deployment settings
- improve warehouse streaming/parquet handling for safer chunked flushing under constrained memory
- add per-status event count badges in the CDC Backfill Events tab (`All`, `Applied`, `Pending`, `Failed`, `Dropped`) so operators can quickly assess backlog scale

## Test plan
- [x] Run lint/format hooks via pre-commit
- [x] Verify `BackfillPanel` renders event filter counts and refreshes while Events tab is open
- [ ] Run end-to-end CDC backfill in staging and confirm no OOM on 1Gi profile
- [ ] Validate webhook event counts match backend totals for each apply status filter

Made with [Cursor](https://cursor.com)