### PR TITLE
docs: align documentation with recent CDC, Dashboard Agent, and Close CRM changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Mako - The AI-native SQL Client**
 
-Mako is a production-ready, multi-tenant AI-powered SQL client built with a PNPM workspace monorepo structure. It combines multi-database query execution (MongoDB, PostgreSQL, BigQuery, ClickHouse, etc.), AI-powered query generation with multi-provider LLM support (OpenAI, Anthropic, Google), team collaboration features, and optional data source connectors (Stripe, Close CRM, GraphQL APIs, PostHog, REST APIs) with event-driven synchronization via Inngest.
+Mako is a production-ready, multi-tenant AI-powered SQL client built with a PNPM workspace monorepo structure. It combines multi-database query execution (MongoDB, PostgreSQL, BigQuery, ClickHouse, etc.), AI-powered query generation with multi-provider LLM support (OpenAI, Anthropic, Google), team collaboration features, and optional data source connectors (Stripe, Close CRM, GraphQL APIs, PostHog, REST APIs) with event-driven synchronization (batch and CDC/streaming) via Inngest.
 
 **Architecture:** Five main packages:
 

--- a/docs/src/content/docs/ai-agent.md
+++ b/docs/src/content/docs/ai-agent.md
@@ -91,6 +91,7 @@ Key capabilities:
 - **Widgets** — charts (Vega-Lite), KPI cards, and data tables that query the local data
 - **Cross-filtering** — clicking a bar or slice in one chart filters all other charts automatically
 - **Global filters** — dashboard-level date range pickers, dropdowns, and search fields
+- **Debugging & Guardrails** — enforces cross-filter diagnosis and source-query edit safety, verifying causes before modifying charts or retrying broken SQL edits.
 - **Multi-dashboard** — multiple dashboards can be open simultaneously, each with its own isolated DuckDB instance
 
 The agent handles edit-mode locking, so concurrent users cannot conflict.

--- a/docs/src/content/docs/connectors.md
+++ b/docs/src/content/docs/connectors.md
@@ -14,7 +14,7 @@ Connectors pull data from external services and sync it into your connected data
 | Connector     | Source          | Entities                                                                         |
 | ------------- | --------------- | -------------------------------------------------------------------------------- |
 | **Stripe**    | Stripe API      | Customers, Subscriptions, Charges, Invoices, Products, Plans                     |
-| **Close CRM** | Close API       | Leads, Opportunities, Activities (10+ sub-types), Contacts, Users, Custom Fields |
+| **Close CRM** | Close API       | Leads, Opportunities, Activities (10+ sub-types), Contacts, Users, Custom Fields. *Webhooks are automatically scoped to synced entities only.* |
 | **PostHog**   | PostHog HogQL   | Dynamic — each configured HogQL query becomes an entity                          |
 | **GraphQL**   | Any GraphQL API | Dynamic — each configured query becomes an entity                                |
 | **BigQuery**  | Google BigQuery | Dynamic — each configured query becomes an entity                                |

--- a/docs/src/content/docs/data-sync.md
+++ b/docs/src/content/docs/data-sync.md
@@ -23,6 +23,14 @@ Each flow run:
 4. Saves the new cursor position
 5. Repeats until no more records
 
+## Change Data Capture (CDC) & Streaming
+
+In addition to scheduled batch syncing, Mako supports experimental Change Data Capture (CDC) for near real-time updates.
+
+- **Streaming Sync** — continuous event consumption via webhooks or log streams
+- **Backfills** — historical data backfills run robustly within 1Gi Cloud Run memory limits, safely handling bulk flushes by cycling DuckDB instances
+- **BigQuery Staging** — streams events into region-aligned BigQuery staging tables (safely preserved during recovery)
+
 ## Job Queue
 
 Flows run on [Inngest](https://www.inngest.com/), a job queue that handles:


### PR DESCRIPTION
## Description
This PR addresses doc drift from recent commits:
- Documented CDC streaming syncs, backfills, and BigQuery staging in `data-sync.md` and `CLAUDE.md`
- Added debugging and safety guardrail information to the Dashboard Agent section in `ai-agent.md`
- Clarified that Close CRM webhook registrations are scoped to synced entities in `connectors.md`

## Related Commits
- fix(cdc) stabilization and BigQuery staging (#284, #283, #280, etc.)
- fix: tighten dashboard agent debugging guardrails (cd545bd3)
- feat(close): scope webhook registration (#277)