### PR TITLE
fix(cdc): lower backfill flush thresholds to prevent OOM on 1Gi Cloud Run

### DIFF
--- a/api/src/inngest/functions/sync-entity.ts
+++ b/api/src/inngest/functions/sync-entity.ts
@@ -25,6 +25,16 @@ import {
  */
 const STEP_BUDGET = 900;
 
+/**
+ * Temp collection row count that triggers a flush to staging.
+ * Kept low to stay safe on 1Gi Cloud Run instances (default 10k).
+ * Override with SYNC_BACKFILL_FLUSH_THRESHOLD for higher-memory environments.
+ */
+const FLUSH_THRESHOLD = Math.max(
+  parseInt(process.env.SYNC_BACKFILL_FLUSH_THRESHOLD || "10000", 10) || 10_000,
+  1_000,
+);
+
 export interface SyncBackfillEntityPayload {
   flowId: string;
   entity: string;
@@ -489,7 +499,7 @@ export const syncBackfillEntityFunction = inngest.createFunction(
 
       if (useBulkPath && bulkSyncOptions && !completed) {
         const tempCount = await getTempCollectionCount(flowId, entity);
-        if (tempCount >= 50_000) {
+        if (tempCount >= FLUSH_THRESHOLD) {
           await step.run(
             `flush-batch-${safeEntityStepId}-${flushIndex}`,
             async () => {
@@ -547,7 +557,7 @@ export const syncBackfillEntityFunction = inngest.createFunction(
         await performStagingCleanup(bulkSyncOptions as any);
         logExec(
           "info",
-          `✅ ${entity} bulk backfill complete (buffer → Parquet → staging → live)`,
+          `${entity} bulk backfill complete (buffer -> Parquet -> staging -> live)`,
           { entity },
         );
       });

--- a/api/src/inngest/functions/webhook-flow.ts
+++ b/api/src/inngest/functions/webhook-flow.ts
@@ -1084,6 +1084,20 @@ export const webhookRetryFunction = inngest.createFunction(
   },
 );
 
+const CDC_MATERIALIZE_MAX_EVENTS = Math.max(
+  parseInt(process.env.BIGQUERY_CDC_MATERIALIZE_MAX_EVENTS || "7500", 10) ||
+    7500,
+  100,
+);
+
+const CDC_MATERIALIZE_MAX_EVENTS_BACKFILL = Math.max(
+  parseInt(
+    process.env.BIGQUERY_CDC_MATERIALIZE_MAX_EVENTS_BACKFILL || "1000",
+    10,
+  ) || 1000,
+  100,
+);
+
 async function runCdcMaterialization(params: {
   eventData: unknown;
   step: any;
@@ -1096,11 +1110,20 @@ async function runCdcMaterialization(params: {
     entity: string;
     force?: boolean;
   };
-  const maxEvents = Math.max(
-    parseInt(process.env.BIGQUERY_CDC_MATERIALIZE_MAX_EVENTS || "7500", 10) ||
-      7500,
-    100,
+
+  const isBackfilling = await params.step.run(
+    "check-backfill-state",
+    async () => {
+      const flow = await Flow.findById(flowId)
+        .select("backfillState.status")
+        .lean();
+      return flow?.backfillState?.status === "running";
+    },
   );
+
+  const maxEvents = isBackfilling
+    ? CDC_MATERIALIZE_MAX_EVENTS_BACKFILL
+    : CDC_MATERIALIZE_MAX_EVENTS;
 
   const materializeStartedAt = Date.now();
   const result = await params.step.run("materialize-cdc-entity", async () => {
@@ -1117,6 +1140,8 @@ async function runCdcMaterialization(params: {
     flowId,
     entity,
     force: Boolean(force),
+    isBackfilling,
+    maxEvents,
     materializeStepDurationMs,
     processed: (result as any).processed,
     applied: (result as any).applied,

--- a/api/src/sync/sync-orchestrator.ts
+++ b/api/src/sync/sync-orchestrator.ts
@@ -967,7 +967,7 @@ function resolvePositiveIntEnv(
 
 const FLUSH_BATCH_SIZE = resolvePositiveIntEnv(
   process.env.SYNC_BULK_FLUSH_BATCH_SIZE,
-  30_000,
+  5_000,
 );
 
 /** Rows passed per DuckDB insertBatch from Mongo (parquet builder micro-chunks SQL). */
@@ -990,12 +990,9 @@ function syncMemorySnapshot(): {
 }
 
 /**
- * Flush ALL rows from the temp collection to BQ staging in batches of
+ * Flush rows from the temp collection to BQ staging in batches of
  * FLUSH_BATCH_SIZE.  Each batch builds its own parquet file and loads it
  * independently so peak memory stays bounded.
- *
- * This runs inside a single Inngest step — the internal loop handles memory
- * via small parquet files but doesn't create additional Inngest steps.
  */
 async function flushBulkBuffer(
   tempCollection: Collection,
@@ -1009,23 +1006,23 @@ async function flushBulkBuffer(
   const totalCount = await tempCollection.countDocuments();
   if (totalCount === 0) return { flushed: 0 };
 
-  const totalBatches = Math.ceil(totalCount / FLUSH_BATCH_SIZE);
+  const effectiveBatches = Math.ceil(totalCount / FLUSH_BATCH_SIZE);
   let totalFlushed = 0;
 
   logger?.log(
     "info",
-    `Flushing ${entity} buffer to staging (${totalCount.toLocaleString()} rows in ${totalBatches} batch${totalBatches > 1 ? "es" : ""})`,
+    `Flushing ${entity} buffer to staging (${totalCount.toLocaleString()} rows, batchSize=${FLUSH_BATCH_SIZE})`,
     {
       entity,
       totalCount,
-      totalBatches,
+      effectiveBatches,
       batchSize: FLUSH_BATCH_SIZE,
       mongoStreamChunk: MONGO_TO_PARQUET_CHUNK,
       memoryBefore: syncMemorySnapshot(),
     },
   );
 
-  for (let batchNum = 0; batchNum < totalBatches; batchNum++) {
+  for (let batchNum = 0; batchNum < effectiveBatches; batchNum++) {
     const docIds: unknown[] = [];
     const cursor = tempCollection
       .find({}, { projection: { _bulkRunId: 0 } })
@@ -1061,7 +1058,7 @@ async function flushBulkBuffer(
       logger?.log(
         "warn",
         `${entity} flush: empty parquet (possible race), stopping flush loop`,
-        { entity, batch: batchNum + 1, totalBatches },
+        { entity, batch: batchNum + 1, effectiveBatches },
       );
       break;
     }
@@ -1087,7 +1084,7 @@ async function flushBulkBuffer(
           const backoffMs = Math.min(1000 * 2 ** (attempt - 1), 15_000);
           logger?.log(
             "warn",
-            `${entity} flush batch ${batchNum + 1}/${totalBatches} load failed (attempt ${attempt}/${LOAD_MAX_RETRIES}), retrying in ${backoffMs}ms`,
+            `${entity} flush batch ${batchNum + 1}/${effectiveBatches} load failed (attempt ${attempt}/${LOAD_MAX_RETRIES}), retrying in ${backoffMs}ms`,
             { entity, batch: batchNum + 1, attempt, error: String(err) },
           );
           await new Promise(r => setTimeout(r, backoffMs));
@@ -1104,11 +1101,11 @@ async function flushBulkBuffer(
 
     logger?.log(
       "info",
-      `📦 ${entity} flush ${batchNum + 1}/${totalBatches} — ${batchRows.toLocaleString()} rows (${totalFlushed.toLocaleString()}/${totalCount.toLocaleString()}) [parquet ${parquetMs}ms, load ${loadMs}ms]`,
+      `${entity} flush ${batchNum + 1}/${effectiveBatches} — ${batchRows.toLocaleString()} rows (${totalFlushed.toLocaleString()}/${totalCount.toLocaleString()}) [parquet ${parquetMs}ms, load ${loadMs}ms]`,
       {
         entity,
         batch: batchNum + 1,
-        totalBatches,
+        effectiveBatches,
         batchRows,
         totalFlushed,
         totalCount,
@@ -1121,11 +1118,10 @@ async function flushBulkBuffer(
 
   logger?.log(
     "info",
-    `✅ ${entity} buffer fully flushed to staging (${totalFlushed.toLocaleString()} rows)`,
+    `${entity} buffer fully flushed to staging (${totalFlushed.toLocaleString()} rows)`,
     {
       entity,
       totalFlushed,
-      batches: totalBatches,
       memory: syncMemorySnapshot(),
     },
   );


### PR DESCRIPTION
## Summary

- **Flush trigger threshold**: lowered from 50k to 10k rows (`SYNC_BACKFILL_FLUSH_THRESHOLD`) so the temp collection never accumulates enough rows to OOM
- **Parquet batch size**: lowered from 30k to 5k rows (`SYNC_BULK_FLUSH_BATCH_SIZE`) so each parquet build stays well within 1Gi memory
- **Materialize cap during backfill**: added backfill-aware logic that reduces CDC materialize events from 7,500 to 1,000 while a backfill is running (`BIGQUERY_CDC_MATERIALIZE_MAX_EVENTS_BACKFILL`)

All thresholds are env-configurable for higher-memory environments. No new abstractions — just smaller fixed chunk sizes that let Inngest's existing step loop and checkpointing handle continuation naturally.

## Why this works for 1M+ rows

- 10k-row flush trigger + 5k-row parquet batches → peak memory stays well under 1Gi
- 1M rows / ~5k per chunk = ~200 Inngest steps (well within the 900 step budget)
- If step budget is exhausted, existing yield + checkpoint logic resumes from where it left off

## Test plan

- [ ] Deploy to staging and run a backfill on a large entity (100k+ rows)
- [ ] Verify Cloud Run memory stays under 1Gi throughout
- [ ] Verify backfill completes successfully end-to-end
- [ ] Verify CDC materialization still works at reduced throughput during backfill
- [ ] Verify steady-state materialization returns to 7,500 events after backfill completes


Made with [Cursor](https://cursor.com)