### PR TITLE
fix(cdc): stabilize backfill ownership on Cloud Run startup

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -796,6 +796,7 @@ jobs:
             --memory=1Gi \
             --concurrency=4 \
             --min-instances=1 \
+            --max-instances=1 \
             --network=mako-vpc \
             --subnet=mako-subnet \
             --vpc-egress=all-traffic \

--- a/api/src/sync-cdc/backfill.ts
+++ b/api/src/sync-cdc/backfill.ts
@@ -1095,15 +1095,37 @@ export class CdcBackfillService {
       const runId = flow.backfillState?.runId || "unknown";
       const failures = flow.backfillState?.consecutiveFailures ?? 0;
 
-      // On startup, force-abandon ALL running executions for this flow.
-      // The previous process is gone, so any "running" execution is orphaned
-      // regardless of heartbeat recency (e.g. crash < 10 min ago).
-      await abandonStaleExecutions(wId, fId, { force: true });
+      // Do NOT force-abandon executions on every startup:
+      // in Cloud Run autoscaling/multi-instance environments, a new instance can
+      // start while another healthy instance is still processing the backfill.
+      // Only abandon executions that are actually stale by heartbeat timeout.
+      const abandonedCount = await abandonStaleExecutions(wId, fId);
+
+      const stillRunning = await FlowExecution.exists({
+        workspaceId: new Types.ObjectId(wId),
+        flowId: new Types.ObjectId(fId),
+        status: "running",
+      });
+
+      if (abandonedCount === 0 && stillRunning) {
+        log.info(
+          `Startup recovery: "${flowLabel}" — skipping (active execution heartbeat is healthy)`,
+          { flowId: fId, runId, consecutiveFailures: failures },
+        );
+        skipped++;
+        continue;
+      }
 
       try {
         log.info(
           `Startup recovery: "${flowLabel}" — transitioning to error (was stuck in running)`,
-          { flowId: fId, runId, consecutiveFailures: failures },
+          {
+            flowId: fId,
+            runId,
+            consecutiveFailures: failures,
+            abandonedCount,
+            stillRunning: Boolean(stillRunning),
+          },
         );
 
         await cdcSyncStateService.applyBackfillTransition({


### PR DESCRIPTION
## Summary
- Set production Cloud Run deploy to a single instance (`--max-instances=1`) to avoid cross-instance execution ownership races during active backfills.
- Update CDC startup recovery to stop force-abandoning all `running` executions on startup.
- Only recover/abandon executions that are actually stale by heartbeat timeout, and skip recovery when a healthy running execution is still present.

## Test plan
- [x] Applied runtime hotfix in prod (`mako-00196-jz2`) with `max-instances=1`.
- [x] Confirmed no lint errors in touched files.
- [ ] Start/restart a backfill while service autoscaling events occur and verify no new `Execution abandoned on server startup — previous process no longer running` for healthy runs.
- [ ] Verify flow progresses beyond `Flow execution started: full sync` without being force-abandoned by startup recovery.

Made with [Cursor](https://cursor.com)