### PR TITLE
infra: increase production Cloud Run memory to 2Gi

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -793,7 +793,7 @@ jobs:
             --image ${{ steps.image.outputs.sha_tag }} \
             --region ${GCP_REGION} \
             --timeout=3600 \
-            --memory=1Gi \
+            --memory=2Gi \
             --concurrency=4 \
             --min-instances=1 \
             --max-instances=15 \


### PR DESCRIPTION
## Summary
- Increases production Cloud Run memory from 1Gi to 2Gi to reduce OOM pressure during CDC backfills and heavy sync workloads.
- Preview environments remain at 1Gi.

## Test plan
- [ ] Verify production deploy succeeds with `--memory=2Gi`
- [ ] Monitor memory usage after deploy to confirm headroom improvement

Made with [Cursor](https://cursor.com)