### PR TITLE
Increase Cloud Run production concurrency from 4 to 10

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -794,7 +794,7 @@ jobs:
             --region ${GCP_REGION} \
             --timeout=3600 \
             --memory=2Gi \
-            --concurrency=4 \
+            --concurrency=10 \
             --min-instances=1 \
             --max-instances=15 \
             --network=mako-vpc \


### PR DESCRIPTION
## Summary
- Increases `--concurrency` from 4 to 10 in the production Cloud Run deploy step
- Fixes 429 "no available instance" errors caused by Inngest step executions and webhook bursts exceeding the 4-request-per-instance limit

Closes #290

## Test plan
- [ ] Deploy to a preview environment and verify the Cloud Run revision has `containerConcurrency: 10`
- [ ] Monitor production after merge for absence of 429 errors in Cloud Run logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)