### PR TITLE
fix(backfill): always auto-resume on server restart, reset failure counter

### DIFF
--- a/api/src/inngest/functions/flow.ts
+++ b/api/src/inngest/functions/flow.ts
@@ -2497,7 +2497,7 @@ export const cleanupAbandonedFlowsFunction = inngest.createFunction(
               ],
             }).lean();
 
-            const MAX_CONSECUTIVE_FAILURES = 3;
+            const MAX_CONSECUTIVE_FAILURES = 10;
 
             for (const cdcFlow of stuckCdcFlows) {
               const wId = String(cdcFlow.workspaceId);
@@ -2505,7 +2505,6 @@ export const cleanupAbandonedFlowsFunction = inngest.createFunction(
               const failures = cdcFlow.backfillState?.consecutiveFailures ?? 0;
 
               try {
-                // Transition to error via state machine (writes audit record)
                 if (cdcFlow.backfillState?.status === "running") {
                   await syncMachineService.applyBackfillTransition({
                     workspaceId: wId,
@@ -2522,7 +2521,6 @@ export const cleanupAbandonedFlowsFunction = inngest.createFunction(
                   });
                 }
 
-                // Auto-restart if under circuit breaker threshold
                 if (failures + 1 < MAX_CONSECUTIVE_FAILURES) {
                   const restartResult = await cdcBackfillService.startBackfill(
                     wId,

--- a/api/src/sync-cdc/backfill.ts
+++ b/api/src/sync-cdc/backfill.ts
@@ -1058,11 +1058,15 @@ export class CdcBackfillService {
     skipped: number;
     errors: number;
   }> {
-    const MAX_CONSECUTIVE_FAILURES = 3;
-
     const staleFlows = await Flow.find({
       syncEngine: "cdc",
-      "backfillState.status": "running",
+      $or: [
+        { "backfillState.status": "running" },
+        {
+          "backfillState.status": "error",
+          "backfillState.runId": { $exists: true, $ne: null },
+        },
+      ],
     }).lean();
 
     if (staleFlows.length === 0) {
@@ -1085,7 +1089,7 @@ export class CdcBackfillService {
     );
 
     let recovered = 0;
-    let skipped = 0;
+    const skipped = 0;
     let errors = 0;
 
     for (const flow of staleFlows) {
@@ -1093,54 +1097,46 @@ export class CdcBackfillService {
       const fId = String(flow._id);
       const flowLabel = `${flow.type}:${fId}`;
       const runId = flow.backfillState?.runId || "unknown";
-      const failures = flow.backfillState?.consecutiveFailures ?? 0;
 
-      // On startup, force-abandon ALL running executions for this flow.
-      // The previous process is gone, so any "running" execution is orphaned
-      // regardless of heartbeat recency (e.g. crash < 10 min ago).
       await abandonStaleExecutions(wId, fId, { force: true });
 
       try {
-        log.info(
-          `Startup recovery: "${flowLabel}" — transitioning to error (was stuck in running)`,
-          { flowId: fId, runId, consecutiveFailures: failures },
-        );
-
-        await cdcSyncStateService.applyBackfillTransition({
-          workspaceId: wId,
-          flowId: fId,
-          event: {
-            type: "FAIL",
-            reason: "Backfill interrupted by server restart",
-            errorCode: "SERVER_RESTART",
-          },
-        });
-        await Flow.findByIdAndUpdate(fId, {
-          $inc: { "backfillState.consecutiveFailures": 1 },
-        });
-
-        if (failures + 1 < MAX_CONSECUTIVE_FAILURES) {
-          const result = await this.startBackfill(wId, fId, {
-            reuseExistingRunId: true,
-            reason: `Auto-resumed on startup (attempt ${failures + 1}/${MAX_CONSECUTIVE_FAILURES})`,
-          });
+        if (flow.backfillState?.status === "running") {
           log.info(
-            `Startup recovery: "${flowLabel}" — backfill restarted from checkpoint`,
-            {
-              flowId: fId,
-              newRunId: result.runId,
-              reusedRunId: result.reusedRunId,
-              consecutiveFailures: failures + 1,
+            `Startup recovery: "${flowLabel}" — transitioning to error (was stuck in running)`,
+            { flowId: fId, runId },
+          );
+
+          await cdcSyncStateService.applyBackfillTransition({
+            workspaceId: wId,
+            flowId: fId,
+            event: {
+              type: "FAIL",
+              reason: "Backfill interrupted by server restart",
+              errorCode: "SERVER_RESTART",
             },
-          );
-          recovered++;
-        } else {
-          log.warn(
-            `Startup recovery: "${flowLabel}" — too many consecutive failures (${failures + 1}/${MAX_CONSECUTIVE_FAILURES}), manual intervention required`,
-            { flowId: fId, runId, consecutiveFailures: failures + 1 },
-          );
-          skipped++;
+          });
         }
+
+        // Server restarts are expected (deploys, scaling). Reset the failure
+        // counter so they don't trip the circuit breaker and strand backfills.
+        await Flow.findByIdAndUpdate(fId, {
+          $set: { "backfillState.consecutiveFailures": 0 },
+        });
+
+        const result = await this.startBackfill(wId, fId, {
+          reuseExistingRunId: true,
+          reason: `Auto-resumed on startup after server restart`,
+        });
+        log.info(
+          `Startup recovery: "${flowLabel}" — backfill restarted from checkpoint`,
+          {
+            flowId: fId,
+            newRunId: result.runId,
+            reusedRunId: result.reusedRunId,
+          },
+        );
+        recovered++;
       } catch (err) {
         log.error(
           `Startup recovery: "${flowLabel}" — recovery failed: ${err instanceof Error ? err.message : String(err)}`,


### PR DESCRIPTION
## Summary

- Server restarts (deploys, scaling) no longer count toward the backfill circuit breaker — `consecutiveFailures` is reset to 0 on startup and backfills always auto-resume from checkpoint
- Also recover flows stuck in "error" state with a `runId` that were previously invisible to startup recovery
- Raise cleanup cron circuit breaker from 3 → 10 for genuine worker crashes

## Problem

Each server restart incremented `consecutiveFailures`. With Inngest's 3 retries per run, a single restart could add 2–4 to the counter. After a few deploys the counter exceeded `MAX_CONSECUTIVE_FAILURES=3`, permanently stranding the backfill in error state ("26 consecutive failures").

## Root Cause

`recoverStaleBackfillsOnStartup` treated restarts as backfill failures:
1. Incremented `consecutiveFailures` on every restart
2. Only recovered flows in `"running"` status — if the previous instance transitioned to `"error"` before dying, the flow was invisible
3. Gave up after 3 failures, but a single deploy cycle could burn through all 3

## Fix

- **Reset counter on startup**: Server restarts are operational events (deploys, autoscaling), not backfill bugs
- **Always auto-resume**: No circuit breaker for restarts — the backfill picks up from its last checkpoint
- **Recover "error" flows**: Also find flows in `"error"` state that still have a `runId`
- **Raise cron threshold**: Cleanup cron circuit breaker raised from 3 → 10 for genuine worker crashes

## Test plan

- [ ] Deploy to preview — any flow stuck with high `consecutiveFailures` should auto-recover on startup
- [ ] Simulate restart mid-backfill: backfill should resume from checkpoint with counter at 0
- [ ] Verify a genuine backfill error (e.g. bad connector credentials) still surfaces as an error after 10 failures

Made with [Cursor](https://cursor.com)