### PR TITLE
fix(backfill): cancel stale Inngest functions before restarting backfill

### DIFF
--- a/api/src/sync-cdc/backfill.ts
+++ b/api/src/sync-cdc/backfill.ts
@@ -1092,6 +1092,27 @@ export class CdcBackfillService {
     const skipped = 0;
     let errors = 0;
 
+    // Cancel all stale Inngest functions first so the concurrency slots
+    // (limit: 1 per flowId) are freed before we try to start new ones.
+    for (const flow of staleFlows) {
+      const fId = String(flow._id);
+      try {
+        await inngest.send({
+          name: "flow.cancel",
+          data: { flowId: fId },
+        });
+      } catch (err) {
+        log.warn("Failed to send Inngest cancel during startup recovery", {
+          flowId: fId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    // Give Inngest a moment to process the cancellations and release
+    // the concurrency slots before we start new executions.
+    await new Promise(r => setTimeout(r, 2000));
+
     for (const flow of staleFlows) {
       const wId = String(flow.workspaceId);
       const fId = String(flow._id);
@@ -1118,8 +1139,6 @@ export class CdcBackfillService {
           });
         }
 
-        // Server restarts are expected (deploys, scaling). Reset the failure
-        // counter so they don't trip the circuit breaker and strand backfills.
         await Flow.findByIdAndUpdate(fId, {
           $set: { "backfillState.consecutiveFailures": 0 },
         });


### PR DESCRIPTION
## Summary

- Send `flow.cancel` to Inngest for all stale flows during startup recovery **before** attempting to restart them
- Wait 2s for Inngest to process cancellations and release concurrency slots

## Problem

After a server restart, the startup recovery correctly:
1. Abandoned DB executions (marked as "abandoned")
2. Set backfillState to "running"
3. Sent a new `flow.execute` event to Inngest

But the **old Inngest function was still alive** on Inngest's side (functions survive server restarts until they timeout). Since `flow.execute` has `concurrency: { limit: 1, key: "event.data.flowId" }`, the new event got **queued behind the old one** and never started.

Result: backfillState showed "Running" but no actual execution existed — a phantom running state.

## Fix

Cancel the old Inngest functions first (`flow.cancel` event matched by `cancelOn`), freeing the concurrency slot so the new `flow.execute` can actually run.

## Test plan

- [ ] Deploy and verify backfills that were stuck in "Running" with no execution now auto-recover
- [ ] Simulate server restart mid-backfill: new execution should appear within ~5s of startup

Made with [Cursor](https://cursor.com)