### PR TITLE
fix(backfill): stop auto-restarting on startup, let cron recover

### DIFF
--- a/api/src/inngest/functions/flow.ts
+++ b/api/src/inngest/functions/flow.ts
@@ -2387,7 +2387,7 @@ export const cleanupAbandonedFlowsFunction = inngest.createFunction(
     id: "cleanup-abandoned-flows",
     name: "Cleanup Abandoned Flows",
   },
-  { cron: "*/15 * * * *" }, // Run every 15 minutes
+  { cron: "*/5 * * * *" },
   async ({ step, logger }) => {
     const result = await step.run("cleanup-abandoned-flows", async () => {
       const db = Flow.db;
@@ -2585,15 +2585,70 @@ export const cleanupAbandonedFlowsFunction = inngest.createFunction(
         });
       }
 
+      // 3. Recover interrupted CDC backfills left in "error" state by
+      //    startup recovery (server restart). These have a runId (checkpoint)
+      //    and low consecutiveFailures since startup resets the counter.
+      let cdcRecoveredCount = 0;
+      const interruptedCdcFlows = await Flow.find({
+        syncEngine: "cdc",
+        "backfillState.status": "error",
+        "backfillState.runId": { $exists: true, $ne: null },
+        $or: [
+          { "backfillState.consecutiveFailures": { $exists: false } },
+          {
+            "backfillState.consecutiveFailures": {
+              $lt: MAX_CONSECUTIVE_FAILURES,
+            },
+          },
+        ],
+      }).lean();
+
+      for (const cdcFlow of interruptedCdcFlows) {
+        const wId = String(cdcFlow.workspaceId);
+        const fId = String(cdcFlow._id);
+        const failures = cdcFlow.backfillState?.consecutiveFailures ?? 0;
+
+        const hasRunningExec = await executionsCollection.findOne({
+          flowId: cdcFlow._id,
+          status: "running",
+        });
+        if (hasRunningExec) continue;
+
+        try {
+          const restartResult = await cdcBackfillService.startBackfill(
+            wId,
+            fId,
+            {
+              reuseExistingRunId: true,
+              reason: `Auto-resumed interrupted backfill (attempt ${failures + 1}/${MAX_CONSECUTIVE_FAILURES})`,
+            },
+          );
+          logger.info("Auto-restarted interrupted CDC backfill", {
+            flowId: fId,
+            consecutiveFailures: failures,
+            runId: restartResult.runId,
+            reusedRunId: restartResult.reusedRunId,
+          });
+          cdcRecoveredCount++;
+        } catch (cdcErr) {
+          logger.error("Failed to restart interrupted CDC backfill", {
+            flowId: fId,
+            error: cdcErr instanceof Error ? cdcErr.message : String(cdcErr),
+          });
+        }
+      }
+
       logger.info("Cleanup abandoned flows completed", {
         abandonedExecutions: abandonedCount,
         staleLocks: staleLockCount,
+        cdcRecovered: cdcRecoveredCount,
         timestamp: now.toISOString(),
       });
 
       return {
         abandonedExecutions: abandonedCount,
         staleLocks: staleLockCount,
+        cdcRecovered: cdcRecoveredCount,
         timestamp: now,
       };
     });

--- a/api/src/routes/flows.ts
+++ b/api/src/routes/flows.ts
@@ -1892,6 +1892,105 @@ flowRoutes.post("/:flowId/sync-cdc/recover", async c => {
   }
 });
 
+// POST /api/workspaces/:workspaceId/flows/:flowId/sync-cdc/recover-stream
+flowRoutes.post("/:flowId/sync-cdc/recover-stream", async c => {
+  try {
+    const workspaceId = c.req.param("workspaceId") as string;
+    const flowId = c.req.param("flowId") as string;
+    const authorizationError = await assertOwnerOrAdmin(
+      c as AuthenticatedContext,
+      workspaceId,
+    );
+    if (authorizationError) return authorizationError;
+
+    const body = (await c.req.json().catch(() => ({}))) as {
+      retryFailedMaterialization?: boolean;
+      entity?: string;
+    };
+    const result = await cdcBackfillService.recoverStream({
+      workspaceId,
+      flowId,
+      retryFailedMaterialization: body.retryFailedMaterialization !== false,
+      entity: typeof body.entity === "string" ? body.entity : undefined,
+    });
+    return c.json({
+      success: true,
+      message: "CDC stream recovered",
+      data: result,
+    });
+  } catch (error) {
+    return c.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      },
+      400,
+    );
+  }
+});
+
+// POST /api/workspaces/:workspaceId/flows/:flowId/sync-cdc/recover-backfill
+flowRoutes.post("/:flowId/sync-cdc/recover-backfill", async c => {
+  try {
+    const workspaceId = c.req.param("workspaceId") as string;
+    const flowId = c.req.param("flowId") as string;
+    const authorizationError = await assertOwnerOrAdmin(
+      c as AuthenticatedContext,
+      workspaceId,
+    );
+    if (authorizationError) return authorizationError;
+
+    const result = await cdcBackfillService.recoverBackfill({
+      workspaceId,
+      flowId,
+    });
+    return c.json({
+      success: true,
+      message: "CDC backfill recovered",
+      data: result,
+    });
+  } catch (error) {
+    return c.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      },
+      400,
+    );
+  }
+});
+
+// POST /api/workspaces/:workspaceId/flows/:flowId/sync-cdc/reprocess-stale
+flowRoutes.post("/:flowId/sync-cdc/reprocess-stale", async c => {
+  try {
+    const workspaceId = c.req.param("workspaceId") as string;
+    const flowId = c.req.param("flowId") as string;
+    const authorizationError = await assertOwnerOrAdmin(
+      c as AuthenticatedContext,
+      workspaceId,
+    );
+    if (authorizationError) return authorizationError;
+
+    const result = await cdcBackfillService.reprocessStaleEvents({
+      workspaceId,
+      flowId,
+    });
+    return c.json({
+      success: true,
+      message: "Stale events reprocessed",
+      data: result,
+    });
+  } catch (error) {
+    return c.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      },
+      400,
+    );
+  }
+});
+
 // POST /api/workspaces/:workspaceId/flows/:flowId/sync-cdc/materialize/retry-failed
 flowRoutes.post("/:flowId/sync-cdc/materialize/retry-failed", async c => {
   try {

--- a/api/src/sync-cdc/backfill.ts
+++ b/api/src/sync-cdc/backfill.ts
@@ -408,7 +408,7 @@ export class CdcBackfillService {
     return { resetCount, entities };
   }
 
-  async recoverFlow(params: {
+  async recoverStream(params: {
     workspaceId: string;
     flowId: string;
     retryFailedMaterialization?: boolean;
@@ -422,35 +422,17 @@ export class CdcBackfillService {
       throw new Error("Flow not found");
     }
     if (flow.syncEngine !== "cdc") {
-      throw new Error("Recover requires syncEngine=cdc");
+      throw new Error("Recover stream requires syncEngine=cdc");
     }
 
     const hasIncompleteBackfill = Boolean(flow.backfillState?.runId);
-    let resumedBackfill: { runId: string; reusedRunId: boolean } | undefined;
-
     if (hasIncompleteBackfill) {
-      // Backfill didn't finish — restart it from checkpoint instead of
-      // activating the stream. The stream will be activated automatically
-      // when the backfill completes (via the cdc-transition-backfill-complete
-      // step in the flow function). Activating the stream now would cause
-      // concurrent writes to the same live tables from both paths.
-      log.info(
-        "Recover: restarting incomplete backfill (skipping stream activation)",
+      log.warn(
+        "recoverStream: skipping stream activation because backfill is incomplete",
         {
           flowId: params.flowId,
           runId: flow.backfillState?.runId,
           backfillStatus: flow.backfillState?.status,
-        },
-      );
-
-      await assertCanStartBackfill(params.workspaceId, params.flowId);
-
-      resumedBackfill = await this.startBackfill(
-        params.workspaceId,
-        params.flowId,
-        {
-          reuseExistingRunId: true,
-          reason: "Backfill restarted via recover (from checkpoint)",
         },
       );
     } else {
@@ -467,7 +449,7 @@ export class CdcBackfillService {
     }
 
     let retried = { resetCount: 0, entities: [] as string[] };
-    if (params.retryFailedMaterialization && !hasIncompleteBackfill) {
+    if (params.retryFailedMaterialization !== false && !hasIncompleteBackfill) {
       retried = await this.retryFailedMaterialization({
         workspaceId: params.workspaceId,
         flowId: params.flowId,
@@ -484,7 +466,7 @@ export class CdcBackfillService {
       this.drainPendingWebhookEvents(
         params.workspaceId,
         params.flowId,
-        "recover",
+        "recover-stream",
       ),
       this.resetFailedWebhookEvents(params.workspaceId, params.flowId),
       this.reconcileWebhookApplyStatus(params.workspaceId, params.flowId),
@@ -500,12 +482,182 @@ export class CdcBackfillService {
       drainedFailedWebhooks,
       reconciledWebhooks,
       stagingCleaned,
+    };
+  }
+
+  async recoverBackfill(params: { workspaceId: string; flowId: string }) {
+    const flow = await Flow.findOne({
+      _id: new Types.ObjectId(params.flowId),
+      workspaceId: new Types.ObjectId(params.workspaceId),
+    });
+    if (!flow) {
+      throw new Error("Flow not found");
+    }
+    if (flow.syncEngine !== "cdc") {
+      throw new Error("Recover backfill requires syncEngine=cdc");
+    }
+
+    const hasIncompleteBackfill = Boolean(flow.backfillState?.runId);
+    let resumedBackfill: { runId: string; reusedRunId: boolean } | undefined;
+
+    if (!hasIncompleteBackfill) {
+      log.warn("recoverBackfill: no incomplete backfill found", {
+        flowId: params.flowId,
+      });
+    } else {
+      log.info(
+        "recoverBackfill: restarting incomplete backfill from checkpoint",
+        {
+          flowId: params.flowId,
+          runId: flow.backfillState?.runId,
+          backfillStatus: flow.backfillState?.status,
+        },
+      );
+
+      await assertCanStartBackfill(params.workspaceId, params.flowId);
+
+      resumedBackfill = await this.startBackfill(
+        params.workspaceId,
+        params.flowId,
+        {
+          reuseExistingRunId: true,
+          reason: "Backfill restarted via recover-backfill (from checkpoint)",
+        },
+      );
+    }
+
+    const [webhookEventsDrained, drainedFailedWebhooks, reconciledWebhooks] =
+      await Promise.all([
+        this.drainPendingWebhookEvents(
+          params.workspaceId,
+          params.flowId,
+          "recover-backfill",
+        ),
+        this.resetFailedWebhookEvents(params.workspaceId, params.flowId),
+        this.reconcileWebhookApplyStatus(params.workspaceId, params.flowId),
+      ]);
+
+    return {
+      webhookEventsDrained,
+      drainedFailedWebhooks,
+      reconciledWebhooks,
       resumedBackfill: resumedBackfill
         ? {
             runId: resumedBackfill.runId,
             reusedRunId: resumedBackfill.reusedRunId,
           }
         : undefined,
+    };
+  }
+
+  async reprocessStaleEvents(params: { workspaceId: string; flowId: string }) {
+    const flow = await Flow.findOne({
+      _id: new Types.ObjectId(params.flowId),
+      workspaceId: new Types.ObjectId(params.workspaceId),
+    });
+    if (!flow) {
+      throw new Error("Flow not found");
+    }
+    if (flow.syncEngine !== "cdc") {
+      throw new Error("Reprocess stale events requires syncEngine=cdc");
+    }
+
+    const [reconciledWebhooks, drainedWebhooks, resetFailedWebhooks] =
+      await Promise.all([
+        this.reconcileWebhookApplyStatus(params.workspaceId, params.flowId),
+        this.drainPendingWebhookEvents(
+          params.workspaceId,
+          params.flowId,
+          "reprocess-stale",
+        ),
+        this.resetFailedWebhookEvents(params.workspaceId, params.flowId),
+      ]);
+
+    let materializeTriggered = 0;
+    try {
+      const byEntity = await getCdcEventStore().countEventsByEntity({
+        workspaceId: params.workspaceId,
+        flowId: params.flowId,
+        materializationStatus: "pending",
+      });
+      for (const item of byEntity) {
+        if (item.count <= 0) continue;
+        await inngest.send({
+          name: "cdc/materialize",
+          data: {
+            workspaceId: params.workspaceId,
+            flowId: params.flowId,
+            entity: item.entity,
+            force: true,
+          },
+        });
+        materializeTriggered++;
+      }
+    } catch (error) {
+      log.warn("Failed to force-drain CDC during reprocess-stale", {
+        flowId: params.flowId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    log.info("Reprocessed stale events", {
+      flowId: params.flowId,
+      reconciledWebhooks,
+      drainedWebhooks,
+      resetFailedWebhooks,
+      materializeTriggered,
+    });
+
+    return {
+      reconciledWebhooks,
+      drainedWebhooks,
+      resetFailedWebhooks,
+      materializeTriggered,
+    };
+  }
+
+  /**
+   * Backward-compatible wrapper: delegates to recoverStream or recoverBackfill
+   * based on whether an incomplete backfill exists.
+   */
+  async recoverFlow(params: {
+    workspaceId: string;
+    flowId: string;
+    retryFailedMaterialization?: boolean;
+    entity?: string;
+  }) {
+    const flow = await Flow.findOne({
+      _id: new Types.ObjectId(params.flowId),
+      workspaceId: new Types.ObjectId(params.workspaceId),
+    });
+    if (!flow) {
+      throw new Error("Flow not found");
+    }
+
+    const hasIncompleteBackfill = Boolean(flow.backfillState?.runId);
+
+    if (hasIncompleteBackfill) {
+      const result = await this.recoverBackfill({
+        workspaceId: params.workspaceId,
+        flowId: params.flowId,
+      });
+      return {
+        retriedFailedRows: 0,
+        retriedEntities: [] as string[],
+        stagingCleaned: 0,
+        ...result,
+      };
+    }
+
+    const result = await this.recoverStream({
+      workspaceId: params.workspaceId,
+      flowId: params.flowId,
+      retryFailedMaterialization: params.retryFailedMaterialization,
+      entity: params.entity,
+    });
+    return {
+      ...result,
+      resumedBackfill: undefined,
     };
   }
 

--- a/api/src/sync-cdc/backfill.ts
+++ b/api/src/sync-cdc/backfill.ts
@@ -1075,7 +1075,7 @@ export class CdcBackfillService {
     }
 
     log.info(
-      `Startup backfill check: found ${staleFlows.length} stale backfill(s) to recover`,
+      `Startup backfill check: found ${staleFlows.length} stale backfill(s) to clean up`,
       {
         flows: staleFlows.map(f => ({
           flowId: f._id.toString(),
@@ -1089,11 +1089,13 @@ export class CdcBackfillService {
     );
 
     let recovered = 0;
-    const skipped = 0;
     let errors = 0;
 
-    // Cancel all stale Inngest functions first so the concurrency slots
-    // (limit: 1 per flowId) are freed before we try to start new ones.
+    // Cancel stale Inngest functions so concurrency slots are freed.
+    // We do NOT auto-restart here — the cleanup cron (every 5 min) will
+    // detect the interrupted backfill and restart it once the deploy
+    // stabilizes. Restarting on boot causes a storm when Cloud Run does
+    // a rolling restart (each new instance abandons and re-creates).
     for (const flow of staleFlows) {
       const fId = String(flow._id);
       try {
@@ -1109,10 +1111,6 @@ export class CdcBackfillService {
       }
     }
 
-    // Give Inngest a moment to process the cancellations and release
-    // the concurrency slots before we start new executions.
-    await new Promise(r => setTimeout(r, 2000));
-
     for (const flow of staleFlows) {
       const wId = String(flow.workspaceId);
       const fId = String(flow._id);
@@ -1124,7 +1122,7 @@ export class CdcBackfillService {
       try {
         if (flow.backfillState?.status === "running") {
           log.info(
-            `Startup recovery: "${flowLabel}" — transitioning to error (was stuck in running)`,
+            `Startup recovery: "${flowLabel}" — marking interrupted (cleanup cron will restart)`,
             { flowId: fId, runId },
           );
 
@@ -1139,26 +1137,20 @@ export class CdcBackfillService {
           });
         }
 
+        // Reset failure counter — server restarts are not backfill bugs.
+        // Keep the runId so the cleanup cron can resume from checkpoint.
         await Flow.findByIdAndUpdate(fId, {
           $set: { "backfillState.consecutiveFailures": 0 },
         });
 
-        const result = await this.startBackfill(wId, fId, {
-          reuseExistingRunId: true,
-          reason: `Auto-resumed on startup after server restart`,
-        });
         log.info(
-          `Startup recovery: "${flowLabel}" — backfill restarted from checkpoint`,
-          {
-            flowId: fId,
-            newRunId: result.runId,
-            reusedRunId: result.reusedRunId,
-          },
+          `Startup recovery: "${flowLabel}" — cleaned up, awaiting cron restart`,
+          { flowId: fId, runId },
         );
         recovered++;
       } catch (err) {
         log.error(
-          `Startup recovery: "${flowLabel}" — recovery failed: ${err instanceof Error ? err.message : String(err)}`,
+          `Startup recovery: "${flowLabel}" — cleanup failed: ${err instanceof Error ? err.message : String(err)}`,
           {
             flowId: fId,
             runId,
@@ -1170,10 +1162,10 @@ export class CdcBackfillService {
     }
 
     log.info(
-      `Startup backfill recovery complete: ${recovered} recovered, ${skipped} skipped, ${errors} errors`,
+      `Startup backfill recovery complete: ${recovered} cleaned up, ${errors} errors (cron will restart)`,
     );
 
-    return { recovered, skipped, errors };
+    return { recovered, skipped: 0, errors };
   }
 }
 

--- a/app/src/components/BackfillPanel.tsx
+++ b/app/src/components/BackfillPanel.tsx
@@ -270,7 +270,9 @@ export function BackfillPanel({
     resumeCdcFlow,
     resetCdcEntityTable,
     resyncCdcFlow,
-    recoverCdcFlow,
+    recoverCdcStream,
+    recoverCdcBackfill,
+    reprocessStaleEvents,
     retryAllFailedWebhookEvents,
   } = useFlowStore();
 
@@ -348,6 +350,7 @@ export function BackfillPanel({
     dropped: 0,
   });
   const [retryingFailed, setRetryingFailed] = useState(false);
+  const [reprocessing, setReprocessing] = useState(false);
   const [entityResetOpen, setEntityResetOpen] = useState(false);
   const [entityResetEntity, setEntityResetEntity] = useState("");
   const [runs, setRuns] = useState<
@@ -632,9 +635,8 @@ export function BackfillPanel({
   const handleRecoverStream = () =>
     withBusy(
       async () => {
-        const ok = await recoverCdcFlow(workspaceId, flowId, {
+        const ok = await recoverCdcStream(workspaceId, flowId, {
           retryFailedMaterialization: true,
-          resumeBackfill: false,
         });
         if (!ok) throw new Error("Failed to recover stream");
       },
@@ -648,6 +650,17 @@ export function BackfillPanel({
       await pollCdc();
     } finally {
       setRetryingFailed(false);
+    }
+  };
+
+  const handleReprocessStale = async () => {
+    setReprocessing(true);
+    try {
+      await reprocessStaleEvents(workspaceId, flowId);
+      await pollCdc();
+      await fetchEventCounts();
+    } finally {
+      setReprocessing(false);
     }
   };
 
@@ -681,10 +694,7 @@ export function BackfillPanel({
   const handleRecoverBackfill = () =>
     withBusy(
       async () => {
-        const ok = await recoverCdcFlow(workspaceId, flowId, {
-          retryFailedMaterialization: true,
-          resumeBackfill: true,
-        });
+        const ok = await recoverCdcBackfill(workspaceId, flowId);
         if (!ok) throw new Error("Failed to recover backfill");
       },
       { backfillStatus: "running" },
@@ -2016,6 +2026,27 @@ export function BackfillPanel({
                   {retryingFailed
                     ? "Retrying..."
                     : `Retry ${(cdc as any).failedWebhookCount} failed`}
+                </Button>
+              )}
+              {eventCounts.pending > 0 && streamState !== "error" && (
+                <Button
+                  size="small"
+                  variant="outlined"
+                  color="info"
+                  startIcon={<RetryIcon sx={{ fontSize: 14 }} />}
+                  onClick={handleReprocessStale}
+                  disabled={reprocessing}
+                  sx={{
+                    textTransform: "none",
+                    fontSize: "0.72rem",
+                    ...((cdc as any)?.failedWebhookCount > 0
+                      ? {}
+                      : { ml: "auto" }),
+                  }}
+                >
+                  {reprocessing
+                    ? "Reprocessing..."
+                    : `Reprocess ${eventCounts.pending} pending`}
                 </Button>
               )}
             </Box>

--- a/app/src/store/flowStore.ts
+++ b/app/src/store/flowStore.ts
@@ -458,6 +458,19 @@ interface FlowStore extends FlowStoreState {
       entity?: string;
     },
   ) => Promise<boolean>;
+  recoverCdcStream: (
+    workspaceId: string,
+    flowId: string,
+    options?: {
+      retryFailedMaterialization?: boolean;
+      entity?: string;
+    },
+  ) => Promise<boolean>;
+  recoverCdcBackfill: (workspaceId: string, flowId: string) => Promise<boolean>;
+  reprocessStaleEvents: (
+    workspaceId: string,
+    flowId: string,
+  ) => Promise<boolean>;
   retryFailedCdcMaterialization: (
     workspaceId: string,
     flowId: string,
@@ -1087,6 +1100,73 @@ export const useFlowStore = create<FlowStore>()(
           });
           if (!response.success) {
             throw new Error(response.error || "Failed to recover CDC flow");
+          }
+          return true;
+        } catch (error) {
+          set(state => {
+            state.error[workspaceId] = normalizeError(error);
+          });
+          return false;
+        }
+      },
+
+      recoverCdcStream: async (workspaceId, flowId, options) => {
+        try {
+          const response = await apiClient.post<{
+            success: boolean;
+            error?: string;
+          }>(
+            `/workspaces/${workspaceId}/flows/${flowId}/sync-cdc/recover-stream`,
+            {
+              retryFailedMaterialization:
+                options?.retryFailedMaterialization !== false,
+              entity: options?.entity,
+            },
+          );
+          if (!response.success) {
+            throw new Error(response.error || "Failed to recover CDC stream");
+          }
+          return true;
+        } catch (error) {
+          set(state => {
+            state.error[workspaceId] = normalizeError(error);
+          });
+          return false;
+        }
+      },
+
+      recoverCdcBackfill: async (workspaceId, flowId) => {
+        try {
+          const response = await apiClient.post<{
+            success: boolean;
+            error?: string;
+          }>(
+            `/workspaces/${workspaceId}/flows/${flowId}/sync-cdc/recover-backfill`,
+          );
+          if (!response.success) {
+            throw new Error(response.error || "Failed to recover CDC backfill");
+          }
+          return true;
+        } catch (error) {
+          set(state => {
+            state.error[workspaceId] = normalizeError(error);
+          });
+          return false;
+        }
+      },
+
+      reprocessStaleEvents: async (workspaceId, flowId) => {
+        try {
+          const response = await apiClient.post<{
+            success: boolean;
+            error?: string;
+          }>(
+            `/workspaces/${workspaceId}/flows/${flowId}/sync-cdc/reprocess-stale`,
+          );
+          if (!response.success) {
+            throw new Error(
+              response.error || "Failed to reprocess stale events",
+            );
           }
           return true;
         } catch (error) {


### PR DESCRIPTION
## Summary

- **Startup recovery no longer auto-restarts backfills.** It only cleans up: cancels stale Inngest functions, abandons executions, transitions state to "error", and resets `consecutiveFailures` to 0. This prevents a storm of abandoned executions during Cloud Run rolling deploys where each new instance would cancel→create→get killed in a loop.
- **Cleanup cron now handles recovery.** Added a dedicated section in the cleanup cron that finds CDC flows stuck in "error" state with a `runId` (checkpoint) and auto-restarts them — only once the deploy has stabilized and the cron fires.
- **Cron frequency increased from 15min → 5min** so interrupted backfills recover within 5 minutes instead of 15.

## Root cause

Each Cloud Run deploy creates multiple instances in sequence. The startup recovery was calling `startBackfill()` which sends a `flow.execute` event to Inngest. But the instance would get killed before the Inngest function could complete, and the next instance would repeat the cycle — creating 9+ abandoned executions in 20 minutes (visible in the screenshot).

## Test plan

- [ ] Deploy and verify no abandoned execution storm
- [ ] Manually cancel a running backfill during server restart — confirm cron picks it up within 5 minutes
- [ ] Verify `consecutiveFailures` stays at 0 for server restart interruptions (not counted as bugs)


Made with [Cursor](https://cursor.com)