### PR TITLE
fix(build): hoist MAX_CONSECUTIVE_FAILURES to outer scope

### DIFF
--- a/api/src/inngest/functions/flow.ts
+++ b/api/src/inngest/functions/flow.ts
@@ -2397,6 +2397,7 @@ export const cleanupAbandonedFlowsFunction = inngest.createFunction(
       const executionsCollection = db.collection("flow_executions");
       const locksCollection = db.collection("flow_execution_locks");
 
+      const MAX_CONSECUTIVE_FAILURES = 10;
       let abandonedCount = 0;
       let staleLockCount = 0;
 
@@ -2496,8 +2497,6 @@ export const cleanupAbandonedFlowsFunction = inngest.createFunction(
                 { "backfillState.status": "error" },
               ],
             }).lean();
-
-            const MAX_CONSECUTIVE_FAILURES = 10;
 
             for (const cdcFlow of stuckCdcFlows) {
               const wId = String(cdcFlow.workspaceId);


### PR DESCRIPTION
## Summary

- Moves `MAX_CONSECUTIVE_FAILURES` constant from inside a nested `if` block to the top of the cleanup cron function scope. The new interrupted-backfill recovery section (added in #295) references this constant but was outside the inner block, causing `TS2304: Cannot find name 'MAX_CONSECUTIVE_FAILURES'` build failure.

## Root cause

PR #295 added a new section 3 (recover interrupted CDC backfills) that uses `MAX_CONSECUTIVE_FAILURES`, but the constant was declared inside the `if (staleGateFlowIds.length > 0)` block in section 1. TypeScript correctly refused to compile.

## Test plan

- [x] `tsc --noEmit` passes locally


Made with [Cursor](https://cursor.com)