### PR TITLE
fix(build): hoist MAX_CONSECUTIVE_FAILURES to outer scope

### DIFF
--- a/api/src/inngest/functions/flow.ts
+++ b/api/src/inngest/functions/flow.ts
@@ -2397,6 +2397,7 @@ export const cleanupAbandonedFlowsFunction = inngest.createFunction(
       const executionsCollection = db.collection("flow_executions");
       const locksCollection = db.collection("flow_execution_locks");
 
+      const MAX_CONSECUTIVE_FAILURES = 10;
       let abandonedCount = 0;
       let staleLockCount = 0;
 
@@ -2496,8 +2497,6 @@ export const cleanupAbandonedFlowsFunction = inngest.createFunction(
                 { "backfillState.status": "error" },
               ],
             }).lean();
-
-            const MAX_CONSECUTIVE_FAILURES = 10;
 
             for (const cdcFlow of stuckCdcFlows) {
               const wId = String(cdcFlow.workspaceId);


### PR DESCRIPTION
## Summary

- Move `MAX_CONSECUTIVE_FAILURES` constant declaration from inside the loop to the outer `step.run` scope where it's first needed, fixing the TS2304 "Cannot find name" build error.

## Test plan

- [x] TypeScript compilation passes

Made with [Cursor](https://cursor.com)