### PR TITLE
fix: add cancellable agent tool execution across chat and runtime

### DIFF
--- a/api/src/agent-lib/tools/console-search-tools.ts
+++ b/api/src/agent-lib/tools/console-search-tools.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { Types } from "mongoose";
+import type { AgentToolExecutionContext } from "../../agents/types";
 import {
   SavedConsole,
   DatabaseConnection,
@@ -12,6 +13,11 @@ import {
 } from "../../services/embedding.service";
 import { databaseConnectionService } from "../../services/database-connection.service";
 import { loggers } from "../../logging";
+import {
+  isAgentToolAbortError,
+  registerAgentExecution,
+  throwIfAborted,
+} from "./shared/truncation";
 
 const logger = loggers.agent();
 
@@ -205,9 +211,11 @@ export async function searchConsoles(
   query: string,
   workspaceId: string,
   limit: number = 5,
+  signal?: AbortSignal,
 ): Promise<ConsoleSearchResult[]> {
   let results: any[] = [];
 
+  throwIfAborted(signal);
   const canVector = isEmbeddingAvailable() && (await isVectorSearchAvailable());
 
   if (canVector) {
@@ -216,11 +224,13 @@ export async function searchConsoles(
       if (embedding) {
         const currentModel = getEmbeddingModelName();
         const vectorResults = await vectorSearch(embedding, workspaceId, limit);
+        throwIfAborted(signal);
         results = vectorResults.filter(
           (r: any) => !r.embeddingModel || r.embeddingModel === currentModel,
         );
       }
     } catch (err) {
+      if (isAgentToolAbortError(err)) throw err;
       logger.warn("Vector search failed, falling back to text search", {
         error: err,
       });
@@ -230,6 +240,7 @@ export async function searchConsoles(
   if (results.length < limit) {
     try {
       const textResults = await textSearch(query, workspaceId, limit);
+      throwIfAborted(signal);
       const existingIds = new Set(results.map(r => r.id));
       for (const tr of textResults) {
         if (!existingIds.has(tr.id)) {
@@ -237,6 +248,7 @@ export async function searchConsoles(
         }
       }
     } catch (err) {
+      if (isAgentToolAbortError(err)) throw err;
       logger.warn("Text search failed, falling back to regex", { error: err });
     }
   }
@@ -244,6 +256,7 @@ export async function searchConsoles(
   if (results.length < limit) {
     try {
       const regexResults = await regexNameSearch(query, workspaceId, limit);
+      throwIfAborted(signal);
       const existingIds = new Set(results.map(r => r.id));
       for (const rr of regexResults) {
         if (!existingIds.has(rr.id)) {
@@ -251,6 +264,7 @@ export async function searchConsoles(
         }
       }
     } catch (err) {
+      if (isAgentToolAbortError(err)) throw err;
       logger.warn("Regex name search failed", { error: err });
     }
   }
@@ -266,6 +280,7 @@ export async function searchConsoles(
   results = results.slice(0, limit);
 
   await enrichWithConnectionNames(results);
+  throwIfAborted(signal);
 
   return results.map(r => ({
     id: r.id,
@@ -279,7 +294,10 @@ export async function searchConsoles(
   }));
 }
 
-export const createConsoleSearchTools = (workspaceId: string) => ({
+export const createConsoleSearchTools = (
+  workspaceId: string,
+  toolExecutionContext?: AgentToolExecutionContext,
+) => ({
   search_consoles: {
     description:
       "Search saved consoles across the workspace by semantic meaning or keywords. Returns matching consoles ranked by relevance and recency. Use this to find past queries, discover existing work, or locate a console the user mentions. Results include id, title, description, connection info, and language.",
@@ -296,16 +314,24 @@ export const createConsoleSearchTools = (workspaceId: string) => ({
         .describe("Max results to return (default 5)"),
     }),
     execute: async ({ query, limit }: { query: string; limit?: number }) => {
+      const { signal, release } = registerAgentExecution(
+        toolExecutionContext,
+        "agent-search-consoles",
+      );
       try {
-        return await searchConsoles(query, workspaceId, limit || 5);
+        throwIfAborted(signal);
+        return await searchConsoles(query, workspaceId, limit || 5, signal);
       } catch (error) {
         return {
           success: false,
-          error:
-            error instanceof Error
+          error: isAgentToolAbortError(error)
+            ? "Console search cancelled because the chat stopped."
+            : error instanceof Error
               ? error.message
               : "Failed to search consoles",
         };
+      } finally {
+        release();
       }
     },
   },

--- a/api/src/agent-lib/tools/dashboard-search-tools.ts
+++ b/api/src/agent-lib/tools/dashboard-search-tools.ts
@@ -1,6 +1,12 @@
 import { z } from "zod";
 import { Types } from "mongoose";
+import type { AgentToolExecutionContext } from "../../agents/types";
 import { Dashboard } from "../../database/workspace-schema";
+import {
+  isAgentToolAbortError,
+  registerAgentExecution,
+  throwIfAborted,
+} from "./shared/truncation";
 
 function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -42,7 +48,10 @@ async function searchDashboardsByQuery(
   }));
 }
 
-export const createDashboardSearchTools = (workspaceId: string) => ({
+export const createDashboardSearchTools = (
+  workspaceId: string,
+  toolExecutionContext?: AgentToolExecutionContext,
+) => ({
   search_dashboards: {
     description:
       "Search saved dashboards across the workspace by title, description, or data source name. " +
@@ -59,12 +68,18 @@ export const createDashboardSearchTools = (workspaceId: string) => ({
         .describe("Max results to return (default 5)"),
     }),
     execute: async ({ query, limit }: { query: string; limit?: number }) => {
+      const { signal, release } = registerAgentExecution(
+        toolExecutionContext,
+        "agent-search-dashboards",
+      );
       try {
+        throwIfAborted(signal);
         const results = await searchDashboardsByQuery(
           query,
           workspaceId,
           limit || 5,
         );
+        throwIfAborted(signal);
         return {
           success: true as const,
           dashboards: results,
@@ -73,11 +88,14 @@ export const createDashboardSearchTools = (workspaceId: string) => ({
       } catch (error) {
         return {
           success: false as const,
-          error:
-            error instanceof Error
+          error: isAgentToolAbortError(error)
+            ? "Dashboard search cancelled because the chat stopped."
+            : error instanceof Error
               ? error.message
               : "Failed to search dashboards",
         };
+      } finally {
+        release();
       }
     },
   },

--- a/api/src/agent-lib/tools/mongodb-tools.ts
+++ b/api/src/agent-lib/tools/mongodb-tools.ts
@@ -8,6 +8,7 @@ import { Types } from "mongoose";
 import { DatabaseConnection } from "../../database/workspace-schema";
 import { databaseConnectionService } from "../../services/database-connection.service";
 import { queryExecutionService } from "../../services/query-execution.service";
+import type { AgentToolExecutionContext } from "../../agents/types";
 import type { ConsoleDataV2 } from "../types";
 import { clientConsoleTools } from "./console-tools-client";
 import {
@@ -17,6 +18,9 @@ import {
   MAX_SAMPLE_ROWS,
   MAX_TOTAL_OUTPUT_SIZE,
   AGENT_QUERY_TIMEOUT_MS,
+  registerAgentExecution,
+  throwIfAborted,
+  isAgentToolAbortError,
   withAgentTimeout,
 } from "./shared/truncation";
 
@@ -69,6 +73,7 @@ async function listMongoConnectionsImpl(workspaceId: string) {
 async function listMongoDatabasesImpl(
   connectionId: string,
   workspaceId: string,
+  toolExecutionContext?: AgentToolExecutionContext,
 ) {
   if (
     !Types.ObjectId.isValid(connectionId) ||
@@ -76,34 +81,48 @@ async function listMongoDatabasesImpl(
   ) {
     throw new Error("Invalid connection ID or workspace ID");
   }
-  const database = await DatabaseConnection.findOne({
-    _id: new Types.ObjectId(connectionId),
-    workspaceId: new Types.ObjectId(workspaceId),
-  });
-  if (!database) throw new Error("Connection not found or access denied");
-  if (database.type !== "mongodb") {
-    throw new Error("Database listing only supported for MongoDB connections");
+  const { signal, release } = registerAgentExecution(
+    toolExecutionContext,
+    "agent-mongo-list-databases",
+  );
+
+  try {
+    throwIfAborted(signal);
+    const database = await DatabaseConnection.findOne({
+      _id: new Types.ObjectId(connectionId),
+      workspaceId: new Types.ObjectId(workspaceId),
+    });
+    if (!database) throw new Error("Connection not found or access denied");
+    if (database.type !== "mongodb") {
+      throw new Error(
+        "Database listing only supported for MongoDB connections",
+      );
+    }
+
+    const connection = await databaseConnectionService.getConnection(
+      database as Parameters<typeof databaseConnectionService.getConnection>[0],
+    );
+    const adminDb = connection.db("admin");
+    const result = await adminDb.admin().listDatabases();
+    throwIfAborted(signal);
+
+    return result.databases.map(
+      (db: { name: string; sizeOnDisk?: number; empty?: boolean }) => ({
+        name: db.name,
+        sizeOnDisk: db.sizeOnDisk,
+        empty: db.empty,
+      }),
+    );
+  } finally {
+    release();
   }
-
-  const connection = await databaseConnectionService.getConnection(
-    database as Parameters<typeof databaseConnectionService.getConnection>[0],
-  );
-  const adminDb = connection.db("admin");
-  const result = await adminDb.admin().listDatabases();
-
-  return result.databases.map(
-    (db: { name: string; sizeOnDisk?: number; empty?: boolean }) => ({
-      name: db.name,
-      sizeOnDisk: db.sizeOnDisk,
-      empty: db.empty,
-    }),
-  );
 }
 
 async function listCollectionsImpl(
   connectionId: string,
   databaseName: string,
   workspaceId: string,
+  toolExecutionContext?: AgentToolExecutionContext,
 ) {
   if (
     !Types.ObjectId.isValid(connectionId) ||
@@ -114,28 +133,41 @@ async function listCollectionsImpl(
   if (!databaseName) {
     throw new Error("'databaseName' is required");
   }
-  const database = await DatabaseConnection.findOne({
-    _id: new Types.ObjectId(connectionId),
-    workspaceId: new Types.ObjectId(workspaceId),
-  });
-  if (!database) throw new Error("Connection not found or access denied");
-  if (database.type !== "mongodb") {
-    throw new Error("Collection listing only supported for MongoDB databases");
+  const { signal, release } = registerAgentExecution(
+    toolExecutionContext,
+    "agent-mongo-list-collections",
+  );
+
+  try {
+    throwIfAborted(signal);
+    const database = await DatabaseConnection.findOne({
+      _id: new Types.ObjectId(connectionId),
+      workspaceId: new Types.ObjectId(workspaceId),
+    });
+    if (!database) throw new Error("Connection not found or access denied");
+    if (database.type !== "mongodb") {
+      throw new Error(
+        "Collection listing only supported for MongoDB databases",
+      );
+    }
+    const connection = await databaseConnectionService.getConnection(
+      database as Parameters<typeof databaseConnectionService.getConnection>[0],
+    );
+    const db = connection.db(databaseName);
+    const collections = await db
+      .listCollections({ type: "collection" })
+      .toArray();
+    throwIfAborted(signal);
+    return collections.map(
+      (col: { name: string; type?: string; options?: unknown }) => ({
+        name: col.name,
+        type: col.type,
+        options: col.options,
+      }),
+    );
+  } finally {
+    release();
   }
-  const connection = await databaseConnectionService.getConnection(
-    database as Parameters<typeof databaseConnectionService.getConnection>[0],
-  );
-  const db = connection.db(databaseName);
-  const collections = await db
-    .listCollections({ type: "collection" })
-    .toArray();
-  return collections.map(
-    (col: { name: string; type?: string; options?: unknown }) => ({
-      name: col.name,
-      type: col.type,
-      options: col.options,
-    }),
-  );
 }
 
 async function inspectCollectionImpl(
@@ -143,6 +175,7 @@ async function inspectCollectionImpl(
   collectionName: string,
   databaseName: string,
   workspaceId: string,
+  toolExecutionContext?: AgentToolExecutionContext,
 ) {
   if (
     !Types.ObjectId.isValid(connectionId) ||
@@ -164,50 +197,67 @@ async function inspectCollectionImpl(
     );
   }
 
-  return withAgentTimeout(
-    `agent-inspect-mongo-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-    async _executionId => {
-      const connection = await databaseConnectionService.getConnection(
-        database as Parameters<
-          typeof databaseConnectionService.getConnection
-        >[0],
-      );
-      const db = connection.db(databaseName);
-      const collection = db.collection(collectionName);
-
-      const SAMPLE_SIZE = 100;
-      const sampleDocuments = await collection
-        .aggregate([{ $sample: { size: SAMPLE_SIZE } }])
-        .toArray();
-
-      const fieldTypeMap: Record<string, Set<string>> = {};
-      for (const doc of sampleDocuments) {
-        for (const [field, value] of Object.entries(doc)) {
-          if (!fieldTypeMap[field]) fieldTypeMap[field] = new Set<string>();
-          fieldTypeMap[field].add(inferBsonType(value));
-        }
-      }
-
-      const fields = Object.entries(fieldTypeMap).map(([name, types]) => ({
-        name,
-        types: Array.from(types),
-      }));
-
-      const { samples, _note } = truncateSamples(
-        sampleDocuments,
-        MAX_SAMPLE_ROWS,
-      );
-
-      return {
-        entityKind: "collection" as const,
-        entityName: collectionName,
-        database: databaseName,
-        fields,
-        samples,
-        _note,
-      };
-    },
+  const { executionId, signal, release } = registerAgentExecution(
+    toolExecutionContext,
+    "agent-mongo-inspect",
   );
+
+  try {
+    return await withAgentTimeout(
+      executionId,
+      async registeredExecutionId => {
+        const SAMPLE_SIZE = 100;
+        const inspectionQuery = `db.collection(${JSON.stringify(collectionName)}).aggregate([{ $sample: { size: ${SAMPLE_SIZE} } }]).toArray()`;
+        const result = await databaseConnectionService.executeQuery(
+          database as Parameters<
+            typeof databaseConnectionService.executeQuery
+          >[0],
+          inspectionQuery,
+          {
+            databaseName,
+            executionId: registeredExecutionId,
+            signal,
+          },
+        );
+
+        if (!result.success) {
+          throw new Error(result.error || "Failed to inspect collection");
+        }
+
+        const sampleDocuments = Array.isArray(result.data) ? result.data : [];
+
+        const fieldTypeMap: Record<string, Set<string>> = {};
+        for (const doc of sampleDocuments) {
+          for (const [field, value] of Object.entries(doc)) {
+            if (!fieldTypeMap[field]) fieldTypeMap[field] = new Set<string>();
+            fieldTypeMap[field].add(inferBsonType(value));
+          }
+        }
+
+        const fields = Object.entries(fieldTypeMap).map(([name, types]) => ({
+          name,
+          types: Array.from(types),
+        }));
+
+        const { samples, _note } = truncateSamples(
+          sampleDocuments,
+          MAX_SAMPLE_ROWS,
+        );
+
+        return {
+          entityKind: "collection" as const,
+          entityName: collectionName,
+          database: databaseName,
+          fields,
+          samples,
+          _note,
+        };
+      },
+      { signal },
+    );
+  } finally {
+    release();
+  }
 }
 
 async function executeQueryImpl(
@@ -216,6 +266,7 @@ async function executeQueryImpl(
   databaseName: string,
   workspaceId: string,
   userId?: string,
+  toolExecutionContext?: AgentToolExecutionContext,
 ) {
   const startTime = Date.now();
 
@@ -234,22 +285,35 @@ async function executeQueryImpl(
   });
   if (!database) throw new Error("Connection not found or access denied");
 
+  const { executionId, signal, release } = registerAgentExecution(
+    toolExecutionContext,
+    "agent-mongo-query",
+  );
+
   let result: Awaited<
     ReturnType<typeof databaseConnectionService.executeQuery>
   >;
   try {
     result = await withAgentTimeout(
-      `agent-mongo-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-      executionId =>
+      executionId,
+      registeredExecutionId =>
         databaseConnectionService.executeQuery(
           database as Parameters<
             typeof databaseConnectionService.executeQuery
           >[0],
           query,
-          { databaseName, executionId },
+          { databaseName, executionId: registeredExecutionId, signal },
         ),
+      { signal },
     );
   } catch (err: unknown) {
+    if (isAgentToolAbortError(err)) {
+      return {
+        success: false,
+        status: "cancelled",
+        message: "Query cancelled because the chat stopped.",
+      };
+    }
     if (err instanceof Error && err.message === "AGENT_QUERY_TIMEOUT") {
       // Track timeout (fire-and-forget)
       if (userId) {
@@ -273,6 +337,8 @@ async function executeQueryImpl(
       };
     }
     throw err;
+  } finally {
+    release();
   }
 
   // Track query execution (fire-and-forget)
@@ -354,6 +420,7 @@ export const createMongoToolsV2 = (
   _consoles: ConsoleDataV2[],
   _preferredConsoleId?: string,
   userId?: string,
+  toolExecutionContext?: AgentToolExecutionContext,
 ) => {
   return {
     ...clientConsoleTools,
@@ -383,12 +450,17 @@ export const createMongoToolsV2 = (
       inputSchema: connectionIdSchema,
       execute: async (params: { connectionId: string }) => {
         try {
-          return await listMongoDatabasesImpl(params.connectionId, workspaceId);
+          return await listMongoDatabasesImpl(
+            params.connectionId,
+            workspaceId,
+            toolExecutionContext,
+          );
         } catch (error) {
           return {
             success: false,
-            error:
-              error instanceof Error
+            error: isAgentToolAbortError(error)
+              ? "Database listing cancelled because the chat stopped."
+              : error instanceof Error
                 ? error.message
                 : "Failed to list databases",
           };
@@ -408,12 +480,14 @@ export const createMongoToolsV2 = (
             params.connectionId,
             params.databaseName,
             workspaceId,
+            toolExecutionContext,
           );
         } catch (error) {
           return {
             success: false,
-            error:
-              error instanceof Error
+            error: isAgentToolAbortError(error)
+              ? "Collection listing cancelled because the chat stopped."
+              : error instanceof Error
                 ? error.message
                 : "Failed to list collections",
           };
@@ -436,17 +510,20 @@ export const createMongoToolsV2 = (
             params.collectionName,
             params.databaseName,
             workspaceId,
+            toolExecutionContext,
           );
         } catch (error) {
           const isTimeout =
             error instanceof Error && error.message === "AGENT_QUERY_TIMEOUT";
           return {
             success: false,
-            error: isTimeout
-              ? `Collection inspection timed out after ${AGENT_QUERY_TIMEOUT_MS / 1000}s. The collection may be very large. Try using execute_query with a targeted query instead.`
-              : error instanceof Error
-                ? error.message
-                : "Failed to inspect collection",
+            error: isAgentToolAbortError(error)
+              ? "Collection inspection cancelled because the chat stopped."
+              : isTimeout
+                ? `Collection inspection timed out after ${AGENT_QUERY_TIMEOUT_MS / 1000}s. The collection may be very large. Try using execute_query with a targeted query instead.`
+                : error instanceof Error
+                  ? error.message
+                  : "Failed to inspect collection",
           };
         }
       },
@@ -468,12 +545,14 @@ export const createMongoToolsV2 = (
             params.databaseName,
             workspaceId,
             userId,
+            toolExecutionContext,
           );
         } catch (error) {
           return {
             success: false,
-            error:
-              error instanceof Error
+            error: isAgentToolAbortError(error)
+              ? "Query cancelled because the chat stopped."
+              : error instanceof Error
                 ? error.message
                 : "Failed to execute query",
           };

--- a/api/src/agent-lib/tools/shared/database-discovery.ts
+++ b/api/src/agent-lib/tools/shared/database-discovery.ts
@@ -7,6 +7,7 @@
 
 import { z } from "zod";
 import { DatabaseConnection } from "../../../database/workspace-schema";
+import type { AgentToolExecutionContext } from "../../../agents/types";
 import { databaseConnectionService } from "../../../services/database-connection.service";
 import { MYSQL_SYSTEM_DATABASES_SET } from "../../../databases/drivers/mysql/driver";
 import {
@@ -21,7 +22,13 @@ import {
   escapeMySqlIdentifier,
   escapeSqliteIdentifier,
 } from "./sql-dialects";
-import { MAX_SAMPLE_ROWS } from "./truncation";
+import {
+  MAX_SAMPLE_ROWS,
+  isAgentToolAbortError,
+  registerAgentExecution,
+  throwIfAborted,
+  withAgentTimeout,
+} from "./truncation";
 
 // =============================================================================
 // Zod Schemas (for tool definitions)
@@ -176,125 +183,150 @@ export interface DatabaseInfo {
 export async function listDatabasesImpl(
   connectionId: string,
   workspaceId: string,
+  toolExecutionContext?: AgentToolExecutionContext,
 ): Promise<DatabaseInfo[]> {
-  const database = await fetchDatabase(connectionId, workspaceId, {
-    sqlOnly: true,
-  });
-  const dialect = getDialect(database.type);
+  const { executionId, signal, release } = registerAgentExecution(
+    toolExecutionContext,
+    "agent-discovery-list-databases",
+  );
 
-  if (dialect === "postgresql") {
-    const result = await databaseConnectionService.executeQuery(
-      database as Parameters<typeof databaseConnectionService.executeQuery>[0],
-      `SELECT datname FROM pg_database WHERE datistemplate = false AND datallowconn = true ORDER BY datname;`,
-    );
+  try {
+    throwIfAborted(signal);
+    const database = await fetchDatabase(connectionId, workspaceId, {
+      sqlOnly: true,
+    });
+    const dialect = getDialect(database.type);
 
-    if (!result.success) {
-      throw new Error(result.error || "Failed to list databases");
-    }
-
-    return (result.data || []).map((row: { datname: string }) => ({
-      name: row.datname,
-      sqlDialect: dialect,
-    }));
-  }
-
-  if (dialect === "mysql") {
-    const result = await databaseConnectionService.executeQuery(
-      database as Parameters<typeof databaseConnectionService.executeQuery>[0],
-      "SHOW DATABASES",
-    );
-
-    if (!result.success) {
-      throw new Error(result.error || "Failed to list databases");
-    }
-
-    return (result.data || [])
-      .map(
-        (row: { Database?: string; database?: string }) =>
-          row.Database || row.database,
-      )
-      .filter(
-        (name: string | undefined): name is string =>
-          !!name && !MYSQL_SYSTEM_DATABASES_SET.has(name),
-      )
-      .map((name: string) => ({
-        name,
-        sqlDialect: dialect,
-      }));
-  }
-
-  if (dialect === "bigquery") {
-    const datasets = await databaseConnectionService.listBigQueryDatasets(
-      database as Parameters<
-        typeof databaseConnectionService.listBigQueryDatasets
-      >[0],
-    );
-    return datasets.map(ds => ({
-      name: ds,
-      sqlDialect: dialect,
-    }));
-  }
-
-  if (dialect === "clickhouse") {
-    const result = await databaseConnectionService.executeQuery(
-      database as Parameters<typeof databaseConnectionService.executeQuery>[0],
-      "SHOW DATABASES",
-    );
-
-    if (!result.success) {
-      throw new Error(result.error || "Failed to list databases");
-    }
-
-    const systemDatabases = new Set([
-      "system",
-      "information_schema",
-      "INFORMATION_SCHEMA",
-    ]);
-
-    return (result.data || [])
-      .filter((row: { name: string }) => !systemDatabases.has(row.name))
-      .map((row: { name: string }) => ({
-        name: row.name,
-        sqlDialect: dialect,
-      }));
-  }
-
-  // SQLite/D1
-  const connection: Record<string, unknown> =
-    (database as unknown as { connection: Record<string, unknown> })
-      .connection || {};
-  const databaseId = connection.database_id as string | undefined;
-
-  // For Cloudflare D1: check if it's cluster mode (no database_id configured)
-  if (database.type === "cloudflare-d1") {
-    if (databaseId) {
-      // Single database mode: return the configured database_id as both id and name
-      return [{ id: databaseId, name: databaseId, sqlDialect: dialect }];
-    }
-
-    // Cluster mode: fetch all D1 databases from Cloudflare API
-    try {
-      const d1Databases = await databaseConnectionService.listD1Databases(
+    if (dialect === "postgresql") {
+      const result = await databaseConnectionService.executeQuery(
         database as Parameters<
-          typeof databaseConnectionService.listD1Databases
+          typeof databaseConnectionService.executeQuery
+        >[0],
+        `SELECT datname FROM pg_database WHERE datistemplate = false AND datallowconn = true ORDER BY datname;`,
+        { executionId, signal },
+      );
+
+      if (!result.success) {
+        throw new Error(result.error || "Failed to list databases");
+      }
+
+      return (result.data || []).map((row: { datname: string }) => ({
+        name: row.datname,
+        sqlDialect: dialect,
+      }));
+    }
+
+    if (dialect === "mysql") {
+      const result = await databaseConnectionService.executeQuery(
+        database as Parameters<
+          typeof databaseConnectionService.executeQuery
+        >[0],
+        "SHOW DATABASES",
+        { executionId, signal },
+      );
+
+      if (!result.success) {
+        throw new Error(result.error || "Failed to list databases");
+      }
+
+      return (result.data || [])
+        .map(
+          (row: { Database?: string; database?: string }) =>
+            row.Database || row.database,
+        )
+        .filter(
+          (name: string | undefined): name is string =>
+            !!name && !MYSQL_SYSTEM_DATABASES_SET.has(name),
+        )
+        .map((name: string) => ({
+          name,
+          sqlDialect: dialect,
+        }));
+    }
+
+    if (dialect === "bigquery") {
+      const datasets = await databaseConnectionService.listBigQueryDatasets(
+        database as Parameters<
+          typeof databaseConnectionService.listBigQueryDatasets
         >[0],
       );
-      return d1Databases.map(db => ({
-        id: db.uuid, // UUID for API calls
-        name: db.name, // Human-readable name for display
+      throwIfAborted(signal);
+      return datasets.map(ds => ({
+        name: ds,
         sqlDialect: dialect,
       }));
-    } catch {
-      // Fallback to "main" if listing fails (e.g., API error, credentials issue)
-      return [{ name: "main", sqlDialect: dialect }];
     }
-  }
 
-  // Plain SQLite (not D1)
-  if (databaseId) {
-    return [{ name: databaseId, sqlDialect: dialect }];
+    if (dialect === "clickhouse") {
+      const result = await databaseConnectionService.executeQuery(
+        database as Parameters<
+          typeof databaseConnectionService.executeQuery
+        >[0],
+        "SHOW DATABASES",
+        { executionId, signal },
+      );
+
+      if (!result.success) {
+        throw new Error(result.error || "Failed to list databases");
+      }
+
+      const systemDatabases = new Set([
+        "system",
+        "information_schema",
+        "INFORMATION_SCHEMA",
+      ]);
+
+      return (result.data || [])
+        .filter((row: { name: string }) => !systemDatabases.has(row.name))
+        .map((row: { name: string }) => ({
+          name: row.name,
+          sqlDialect: dialect,
+        }));
+    }
+
+    // SQLite/D1
+    const connection: Record<string, unknown> =
+      (database as unknown as { connection: Record<string, unknown> })
+        .connection || {};
+    const databaseId = connection.database_id as string | undefined;
+
+    // For Cloudflare D1: check if it's cluster mode (no database_id configured)
+    if (database.type === "cloudflare-d1") {
+      if (databaseId) {
+        // Single database mode: return the configured database_id as both id and name
+        return [{ id: databaseId, name: databaseId, sqlDialect: dialect }];
+      }
+
+      // Cluster mode: fetch all D1 databases from Cloudflare API
+      try {
+        const d1Databases = await databaseConnectionService.listD1Databases(
+          database as Parameters<
+            typeof databaseConnectionService.listD1Databases
+          >[0],
+        );
+        throwIfAborted(signal);
+        return d1Databases.map(db => ({
+          id: db.uuid, // UUID for API calls
+          name: db.name, // Human-readable name for display
+          sqlDialect: dialect,
+        }));
+      } catch (error) {
+        if (isAgentToolAbortError(error)) {
+          throw error;
+        }
+        // Fallback to "main" if listing fails (e.g., API error, credentials issue)
+        return [{ name: "main", sqlDialect: dialect }];
+      }
+    }
+
+    // Plain SQLite (not D1)
+    if (databaseId) {
+      return [{ name: databaseId, sqlDialect: dialect }];
+    }
+    return [{ name: "main", sqlDialect: dialect }];
+  } finally {
+    release();
   }
-  return [{ name: "main", sqlDialect: dialect }];
 }
 
 // =============================================================================
@@ -315,137 +347,160 @@ export async function listTablesImpl(
   connectionId: string,
   databaseName: string,
   workspaceId: string,
+  toolExecutionContext?: AgentToolExecutionContext,
 ): Promise<TableInfo[]> {
   if (!databaseName) {
     throw new Error("'database' is required");
   }
 
-  const database = await fetchDatabase(connectionId, workspaceId, {
-    sqlOnly: true,
-  });
-  const dialect = getDialect(database.type);
+  const { executionId, signal, release } = registerAgentExecution(
+    toolExecutionContext,
+    "agent-discovery-list-tables",
+  );
 
-  if (dialect === "postgresql") {
-    const result = await databaseConnectionService.executeQuery(
-      database as Parameters<typeof databaseConnectionService.executeQuery>[0],
-      `SELECT table_schema, table_name, table_type
+  try {
+    throwIfAborted(signal);
+    const database = await fetchDatabase(connectionId, workspaceId, {
+      sqlOnly: true,
+    });
+    const dialect = getDialect(database.type);
+
+    if (dialect === "postgresql") {
+      const result = await databaseConnectionService.executeQuery(
+        database as Parameters<
+          typeof databaseConnectionService.executeQuery
+        >[0],
+        `SELECT table_schema, table_name, table_type
        FROM information_schema.tables
        WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
        ORDER BY table_schema, table_name;`,
-      { databaseName },
-    );
+        { databaseName, executionId, signal },
+      );
 
-    if (!result.success) {
-      throw new Error(result.error || "Failed to list tables");
+      if (!result.success) {
+        throw new Error(result.error || "Failed to list tables");
+      }
+
+      return (result.data || []).map(
+        (row: {
+          table_schema: string;
+          table_name: string;
+          table_type: string;
+        }) => ({
+          name:
+            row.table_schema === "public"
+              ? row.table_name
+              : `${row.table_schema}.${row.table_name}`,
+          type: (row.table_type === "VIEW" ? "view" : "table") as
+            | "table"
+            | "view",
+          schema: row.table_schema,
+          sqlDialect: dialect,
+        }),
+      );
     }
 
-    return (result.data || []).map(
-      (row: {
-        table_schema: string;
-        table_name: string;
-        table_type: string;
-      }) => ({
-        name:
-          row.table_schema === "public"
-            ? row.table_name
-            : `${row.table_schema}.${row.table_name}`,
-        type: (row.table_type === "VIEW" ? "view" : "table") as
-          | "table"
-          | "view",
-        schema: row.table_schema,
-        sqlDialect: dialect,
-      }),
-    );
-  }
-
-  if (dialect === "mysql") {
-    const safeDb = databaseName.replace(/'/g, "''");
-    const result = await databaseConnectionService.executeQuery(
-      database as Parameters<typeof databaseConnectionService.executeQuery>[0],
-      `SELECT table_name, table_type FROM information_schema.tables 
+    if (dialect === "mysql") {
+      const safeDb = databaseName.replace(/'/g, "''");
+      const result = await databaseConnectionService.executeQuery(
+        database as Parameters<
+          typeof databaseConnectionService.executeQuery
+        >[0],
+        `SELECT table_name, table_type FROM information_schema.tables 
        WHERE table_schema = '${safeDb}' ORDER BY table_name;`,
-      { databaseName },
-    );
+        { databaseName, executionId, signal },
+      );
 
-    if (!result.success) {
-      throw new Error(result.error || "Failed to list tables");
+      if (!result.success) {
+        throw new Error(result.error || "Failed to list tables");
+      }
+
+      return (result.data || []).map(
+        (row: {
+          table_name?: string;
+          TABLE_NAME?: string;
+          table_type?: string;
+          TABLE_TYPE?: string;
+        }) => ({
+          name: (row.table_name || row.TABLE_NAME) as string,
+          type: ((row.table_type || row.TABLE_TYPE) === "VIEW"
+            ? "view"
+            : "table") as "table" | "view",
+          sqlDialect: dialect,
+        }),
+      );
     }
 
-    return (result.data || []).map(
-      (row: {
-        table_name?: string;
-        TABLE_NAME?: string;
-        table_type?: string;
-        TABLE_TYPE?: string;
-      }) => ({
-        name: (row.table_name || row.TABLE_NAME) as string,
-        type: ((row.table_type || row.TABLE_TYPE) === "VIEW"
-          ? "view"
-          : "table") as "table" | "view",
+    if (dialect === "bigquery") {
+      const tables = await databaseConnectionService.listBigQueryTables(
+        database as Parameters<
+          typeof databaseConnectionService.listBigQueryTables
+        >[0],
+        databaseName,
+      );
+      throwIfAborted(signal);
+      return tables.map(t => ({
+        name: t.name,
+        type: (t.type === "VIEW" ? "view" : "table") as "table" | "view",
         sqlDialect: dialect,
-      }),
-    );
-  }
+      }));
+    }
 
-  if (dialect === "bigquery") {
-    const tables = await databaseConnectionService.listBigQueryTables(
-      database as Parameters<
-        typeof databaseConnectionService.listBigQueryTables
-      >[0],
-      databaseName,
-    );
-    return tables.map(t => ({
-      name: t.name,
-      type: (t.type === "VIEW" ? "view" : "table") as "table" | "view",
-      sqlDialect: dialect,
-    }));
-  }
-
-  if (dialect === "sqlite") {
-    // D1/SQLite: use databaseId for cluster mode
-    const result = await databaseConnectionService.executeQuery(
-      database as Parameters<typeof databaseConnectionService.executeQuery>[0],
-      `SELECT name, type FROM sqlite_master 
+    if (dialect === "sqlite") {
+      // D1/SQLite: use databaseId for cluster mode
+      const result = await databaseConnectionService.executeQuery(
+        database as Parameters<
+          typeof databaseConnectionService.executeQuery
+        >[0],
+        `SELECT name, type FROM sqlite_master 
        WHERE type IN ('table', 'view') 
        AND name NOT LIKE 'sqlite_%' 
        AND name NOT LIKE '_cf_%'
        ORDER BY type DESC, name ASC;`,
-      { databaseId: databaseName, databaseName },
-    );
+        { databaseId: databaseName, databaseName, executionId, signal },
+      );
 
-    if (!result.success) {
-      throw new Error(result.error || "Failed to list tables");
+      if (!result.success) {
+        throw new Error(result.error || "Failed to list tables");
+      }
+
+      return (result.data || []).map((row: { name: string; type: string }) => ({
+        name: row.name,
+        type: row.type as "table" | "view",
+        sqlDialect: dialect,
+      }));
     }
 
-    return (result.data || []).map((row: { name: string; type: string }) => ({
-      name: row.name,
-      type: row.type as "table" | "view",
-      sqlDialect: dialect,
-    }));
-  }
+    if (dialect === "clickhouse") {
+      const safeDb = databaseName.replace(/'/g, "''");
+      const result = await databaseConnectionService.executeQuery(
+        database as Parameters<
+          typeof databaseConnectionService.executeQuery
+        >[0],
+        `SELECT name, engine FROM system.tables WHERE database = '${safeDb}' ORDER BY name`,
+        { executionId, signal },
+      );
 
-  if (dialect === "clickhouse") {
-    const safeDb = databaseName.replace(/'/g, "''");
-    const result = await databaseConnectionService.executeQuery(
-      database as Parameters<typeof databaseConnectionService.executeQuery>[0],
-      `SELECT name, engine FROM system.tables WHERE database = '${safeDb}' ORDER BY name`,
-    );
+      if (!result.success) {
+        throw new Error(result.error || "Failed to list tables");
+      }
 
-    if (!result.success) {
-      throw new Error(result.error || "Failed to list tables");
+      return (result.data || []).map(
+        (row: { name: string; engine: string }) => ({
+          name: row.name,
+          type:
+            row.engine === "View" || row.engine === "MaterializedView"
+              ? ("view" as const)
+              : ("table" as const),
+          sqlDialect: dialect,
+        }),
+      );
     }
 
-    return (result.data || []).map((row: { name: string; engine: string }) => ({
-      name: row.name,
-      type:
-        row.engine === "View" || row.engine === "MaterializedView"
-          ? ("view" as const)
-          : ("table" as const),
-      sqlDialect: dialect,
-    }));
+    throw new Error(`Unsupported database type: ${database.type}`);
+  } finally {
+    release();
   }
-
-  throw new Error(`Unsupported database type: ${database.type}`);
 }
 
 // =============================================================================
@@ -474,6 +529,7 @@ export async function inspectTableImpl(
   databaseName: string,
   tableName: string,
   workspaceId: string,
+  toolExecutionContext?: AgentToolExecutionContext,
 ): Promise<TableInspectionResult> {
   if (!tableName) {
     throw new Error("'table' is required");
@@ -486,209 +542,266 @@ export async function inspectTableImpl(
     sqlOnly: true,
   });
   const dialect = getDialect(database.type);
-  let columns: ColumnInfo[] = [];
-  let samples: Record<string, unknown>[] = [];
+  const { executionId, signal, release } = registerAgentExecution(
+    toolExecutionContext,
+    "agent-discovery-inspect",
+  );
 
-  if (dialect === "postgresql") {
-    // Split schema.table if needed - preserve table name parts after first dot
-    let schemaName: string;
-    let tblName: string;
-    if (tableName.includes(".")) {
-      const dotIndex = tableName.indexOf(".");
-      schemaName = tableName.slice(0, dotIndex);
-      tblName = tableName.slice(dotIndex + 1);
-    } else {
-      schemaName = "public";
-      tblName = tableName;
-    }
+  try {
+    return await withAgentTimeout(
+      executionId,
+      async registeredExecutionId => {
+        let columns: ColumnInfo[] = [];
+        let samples: Record<string, unknown>[] = [];
 
-    const safeSchema = schemaName.replace(/'/g, "''");
-    const safeTable = tblName.replace(/'/g, "''");
+        if (dialect === "postgresql") {
+          let schemaName: string;
+          let tblName: string;
+          if (tableName.includes(".")) {
+            const dotIndex = tableName.indexOf(".");
+            schemaName = tableName.slice(0, dotIndex);
+            tblName = tableName.slice(dotIndex + 1);
+          } else {
+            schemaName = "public";
+            tblName = tableName;
+          }
 
-    // Get columns
-    const colResult = await databaseConnectionService.executeQuery(
-      database as Parameters<typeof databaseConnectionService.executeQuery>[0],
-      `SELECT column_name, data_type, is_nullable
-       FROM information_schema.columns
-       WHERE table_schema = '${safeSchema}' AND table_name = '${safeTable}'
-       ORDER BY ordinal_position;`,
-      { databaseName },
+          const safeSchema = schemaName.replace(/'/g, "''");
+          const safeTable = tblName.replace(/'/g, "''");
+
+          const colResult = await databaseConnectionService.executeQuery(
+            database as Parameters<
+              typeof databaseConnectionService.executeQuery
+            >[0],
+            `SELECT column_name, data_type, is_nullable
+             FROM information_schema.columns
+             WHERE table_schema = '${safeSchema}' AND table_name = '${safeTable}'
+             ORDER BY ordinal_position;`,
+            {
+              databaseName,
+              executionId: registeredExecutionId,
+              signal,
+            },
+          );
+
+          if (colResult.success && colResult.data) {
+            columns = colResult.data.map(
+              (row: {
+                column_name: string;
+                data_type: string;
+                is_nullable: string;
+              }) => ({
+                name: row.column_name,
+                type: row.data_type,
+                nullable: row.is_nullable === "YES",
+              }),
+            );
+          }
+
+          const quotedSchema = escapePostgresIdentifier(schemaName);
+          const quotedTable = escapePostgresIdentifier(tblName);
+          const sampleResult = await databaseConnectionService.executeQuery(
+            database as Parameters<
+              typeof databaseConnectionService.executeQuery
+            >[0],
+            `SELECT * FROM ${quotedSchema}.${quotedTable} LIMIT ${MAX_SAMPLE_ROWS};`,
+            {
+              databaseName,
+              executionId: registeredExecutionId,
+              signal,
+            },
+          );
+
+          if (sampleResult.success && sampleResult.data) {
+            samples = sampleResult.data.slice(0, MAX_SAMPLE_ROWS);
+          }
+        } else if (dialect === "mysql") {
+          const safeDb = databaseName.replace(/'/g, "''");
+          const safeTable = tableName.replace(/'/g, "''");
+
+          const colResult = await databaseConnectionService.executeQuery(
+            database as Parameters<
+              typeof databaseConnectionService.executeQuery
+            >[0],
+            `SELECT column_name, data_type, is_nullable
+             FROM information_schema.columns
+             WHERE table_schema = '${safeDb}' AND table_name = '${safeTable}'
+             ORDER BY ordinal_position;`,
+            {
+              databaseName,
+              executionId: registeredExecutionId,
+              signal,
+            },
+          );
+
+          if (colResult.success && colResult.data) {
+            columns = colResult.data.map(
+              (row: {
+                column_name?: string;
+                COLUMN_NAME?: string;
+                data_type?: string;
+                DATA_TYPE?: string;
+                is_nullable?: string;
+                IS_NULLABLE?: string;
+              }) => ({
+                name: (row.column_name || row.COLUMN_NAME) as string,
+                type: (row.data_type || row.DATA_TYPE) as string,
+                nullable: (row.is_nullable || row.IS_NULLABLE) === "YES",
+              }),
+            );
+          }
+
+          const quotedTable = escapeMySqlIdentifier(tableName);
+          const sampleResult = await databaseConnectionService.executeQuery(
+            database as Parameters<
+              typeof databaseConnectionService.executeQuery
+            >[0],
+            `SELECT * FROM ${quotedTable} LIMIT ${MAX_SAMPLE_ROWS};`,
+            {
+              databaseName,
+              executionId: registeredExecutionId,
+              signal,
+            },
+          );
+
+          if (sampleResult.success && sampleResult.data) {
+            samples = sampleResult.data.slice(0, MAX_SAMPLE_ROWS);
+          }
+        } else if (dialect === "bigquery") {
+          const safeDataset = databaseName.replace(/'/g, "''");
+          const safeTable = tableName.replace(/'/g, "''");
+
+          const colResult = await databaseConnectionService.executeQuery(
+            database as Parameters<
+              typeof databaseConnectionService.executeQuery
+            >[0],
+            `SELECT column_name, data_type, is_nullable
+             FROM \`${safeDataset}\`.INFORMATION_SCHEMA.COLUMNS
+             WHERE table_name = '${safeTable}'
+             ORDER BY ordinal_position;`,
+            { executionId: registeredExecutionId, signal },
+          );
+
+          if (colResult.success && colResult.data) {
+            columns = colResult.data.map(
+              (row: {
+                column_name: string;
+                data_type: string;
+                is_nullable: string;
+              }) => ({
+                name: row.column_name,
+                type: row.data_type,
+                nullable: row.is_nullable === "YES",
+              }),
+            );
+          }
+
+          const quotedDataset = escapeBigQueryIdentifier(databaseName);
+          const quotedTable = escapeBigQueryIdentifier(tableName);
+          const sampleResult = await databaseConnectionService.executeQuery(
+            database as Parameters<
+              typeof databaseConnectionService.executeQuery
+            >[0],
+            `SELECT * FROM ${quotedDataset}.${quotedTable} LIMIT ${MAX_SAMPLE_ROWS};`,
+            { executionId: registeredExecutionId, signal },
+          );
+
+          if (sampleResult.success && sampleResult.data) {
+            samples = sampleResult.data.slice(0, MAX_SAMPLE_ROWS);
+          }
+        } else if (dialect === "sqlite") {
+          const safeTable = tableName.replace(/"/g, '""');
+
+          const colResult = await databaseConnectionService.executeQuery(
+            database as Parameters<
+              typeof databaseConnectionService.executeQuery
+            >[0],
+            `PRAGMA table_info("${safeTable}");`,
+            {
+              databaseId: databaseName,
+              databaseName,
+              executionId: registeredExecutionId,
+              signal,
+            },
+          );
+
+          if (colResult.success && colResult.data) {
+            columns = colResult.data.map(
+              (row: { name: string; type: string; notnull: number }) => ({
+                name: row.name,
+                type: row.type || "TEXT",
+                nullable: row.notnull === 0,
+              }),
+            );
+          }
+
+          const quotedTable = escapeSqliteIdentifier(tableName);
+          const sampleResult = await databaseConnectionService.executeQuery(
+            database as Parameters<
+              typeof databaseConnectionService.executeQuery
+            >[0],
+            `SELECT * FROM ${quotedTable} LIMIT ${MAX_SAMPLE_ROWS};`,
+            {
+              databaseId: databaseName,
+              databaseName,
+              executionId: registeredExecutionId,
+              signal,
+            },
+          );
+
+          if (sampleResult.success && sampleResult.data) {
+            samples = sampleResult.data.slice(0, MAX_SAMPLE_ROWS);
+          }
+        } else if (dialect === "clickhouse") {
+          const safeDb = databaseName.replace(/'/g, "''");
+          const safeTable = tableName.replace(/'/g, "''");
+
+          const colResult = await databaseConnectionService.executeQuery(
+            database as Parameters<
+              typeof databaseConnectionService.executeQuery
+            >[0],
+            `SELECT name, type FROM system.columns WHERE database = '${safeDb}' AND table = '${safeTable}' ORDER BY position`,
+            { executionId: registeredExecutionId, signal },
+          );
+
+          if (colResult.success && colResult.data) {
+            columns = colResult.data.map(
+              (row: { name: string; type: string }) => ({
+                name: row.name,
+                type: row.type,
+              }),
+            );
+          }
+
+          const escapedDbName = databaseName.replace(/"/g, '""');
+          const escapedTblName = tableName.replace(/"/g, '""');
+          const sampleResult = await databaseConnectionService.executeQuery(
+            database as Parameters<
+              typeof databaseConnectionService.executeQuery
+            >[0],
+            `SELECT * FROM "${escapedDbName}"."${escapedTblName}" LIMIT ${MAX_SAMPLE_ROWS}`,
+            { executionId: registeredExecutionId, signal },
+          );
+
+          if (sampleResult.success && sampleResult.data) {
+            samples = sampleResult.data.slice(0, MAX_SAMPLE_ROWS);
+          }
+        }
+
+        throwIfAborted(signal);
+        return {
+          columns,
+          samples,
+          sqlDialect: dialect,
+          connectionName: database.name,
+          connectionType: database.type,
+        };
+      },
+      { signal },
     );
-
-    if (colResult.success && colResult.data) {
-      columns = colResult.data.map(
-        (row: {
-          column_name: string;
-          data_type: string;
-          is_nullable: string;
-        }) => ({
-          name: row.column_name,
-          type: row.data_type,
-          nullable: row.is_nullable === "YES",
-        }),
-      );
-    }
-
-    // Get samples
-    const quotedSchema = escapePostgresIdentifier(schemaName);
-    const quotedTable = escapePostgresIdentifier(tblName);
-    const sampleResult = await databaseConnectionService.executeQuery(
-      database as Parameters<typeof databaseConnectionService.executeQuery>[0],
-      `SELECT * FROM ${quotedSchema}.${quotedTable} LIMIT ${MAX_SAMPLE_ROWS};`,
-      { databaseName },
-    );
-
-    if (sampleResult.success && sampleResult.data) {
-      samples = sampleResult.data.slice(0, MAX_SAMPLE_ROWS);
-    }
-  } else if (dialect === "mysql") {
-    const safeDb = databaseName.replace(/'/g, "''");
-    const safeTable = tableName.replace(/'/g, "''");
-
-    // Get columns
-    const colResult = await databaseConnectionService.executeQuery(
-      database as Parameters<typeof databaseConnectionService.executeQuery>[0],
-      `SELECT column_name, data_type, is_nullable
-       FROM information_schema.columns
-       WHERE table_schema = '${safeDb}' AND table_name = '${safeTable}'
-       ORDER BY ordinal_position;`,
-      { databaseName },
-    );
-
-    if (colResult.success && colResult.data) {
-      columns = colResult.data.map(
-        (row: {
-          column_name?: string;
-          COLUMN_NAME?: string;
-          data_type?: string;
-          DATA_TYPE?: string;
-          is_nullable?: string;
-          IS_NULLABLE?: string;
-        }) => ({
-          name: (row.column_name || row.COLUMN_NAME) as string,
-          type: (row.data_type || row.DATA_TYPE) as string,
-          nullable: (row.is_nullable || row.IS_NULLABLE) === "YES",
-        }),
-      );
-    }
-
-    // Get samples
-    const quotedTable = escapeMySqlIdentifier(tableName);
-    const sampleResult = await databaseConnectionService.executeQuery(
-      database as Parameters<typeof databaseConnectionService.executeQuery>[0],
-      `SELECT * FROM ${quotedTable} LIMIT ${MAX_SAMPLE_ROWS};`,
-      { databaseName },
-    );
-
-    if (sampleResult.success && sampleResult.data) {
-      samples = sampleResult.data.slice(0, MAX_SAMPLE_ROWS);
-    }
-  } else if (dialect === "bigquery") {
-    const safeDataset = databaseName.replace(/'/g, "''");
-    const safeTable = tableName.replace(/'/g, "''");
-
-    // Get columns
-    const colResult = await databaseConnectionService.executeQuery(
-      database as Parameters<typeof databaseConnectionService.executeQuery>[0],
-      `SELECT column_name, data_type, is_nullable
-       FROM \`${safeDataset}\`.INFORMATION_SCHEMA.COLUMNS
-       WHERE table_name = '${safeTable}'
-       ORDER BY ordinal_position;`,
-    );
-
-    if (colResult.success && colResult.data) {
-      columns = colResult.data.map(
-        (row: {
-          column_name: string;
-          data_type: string;
-          is_nullable: string;
-        }) => ({
-          name: row.column_name,
-          type: row.data_type,
-          nullable: row.is_nullable === "YES",
-        }),
-      );
-    }
-
-    // Get samples
-    const quotedDataset = escapeBigQueryIdentifier(databaseName);
-    const quotedTable = escapeBigQueryIdentifier(tableName);
-    const sampleResult = await databaseConnectionService.executeQuery(
-      database as Parameters<typeof databaseConnectionService.executeQuery>[0],
-      `SELECT * FROM ${quotedDataset}.${quotedTable} LIMIT ${MAX_SAMPLE_ROWS};`,
-    );
-
-    if (sampleResult.success && sampleResult.data) {
-      samples = sampleResult.data.slice(0, MAX_SAMPLE_ROWS);
-    }
-  } else if (dialect === "sqlite") {
-    const safeTable = tableName.replace(/"/g, '""');
-
-    // Get columns via PRAGMA
-    const colResult = await databaseConnectionService.executeQuery(
-      database as Parameters<typeof databaseConnectionService.executeQuery>[0],
-      `PRAGMA table_info("${safeTable}");`,
-      { databaseId: databaseName, databaseName },
-    );
-
-    if (colResult.success && colResult.data) {
-      columns = colResult.data.map(
-        (row: { name: string; type: string; notnull: number }) => ({
-          name: row.name,
-          type: row.type || "TEXT",
-          nullable: row.notnull === 0,
-        }),
-      );
-    }
-
-    // Get samples
-    const quotedTable = escapeSqliteIdentifier(tableName);
-    const sampleResult = await databaseConnectionService.executeQuery(
-      database as Parameters<typeof databaseConnectionService.executeQuery>[0],
-      `SELECT * FROM ${quotedTable} LIMIT ${MAX_SAMPLE_ROWS};`,
-      { databaseId: databaseName, databaseName },
-    );
-
-    if (sampleResult.success && sampleResult.data) {
-      samples = sampleResult.data.slice(0, MAX_SAMPLE_ROWS);
-    }
-  } else if (dialect === "clickhouse") {
-    const safeDb = databaseName.replace(/'/g, "''");
-    const safeTable = tableName.replace(/'/g, "''");
-
-    // Get columns
-    const colResult = await databaseConnectionService.executeQuery(
-      database as Parameters<typeof databaseConnectionService.executeQuery>[0],
-      `SELECT name, type FROM system.columns WHERE database = '${safeDb}' AND table = '${safeTable}' ORDER BY position`,
-    );
-
-    if (colResult.success && colResult.data) {
-      columns = colResult.data.map((row: { name: string; type: string }) => ({
-        name: row.name,
-        type: row.type,
-      }));
-    }
-
-    // Get samples - escape identifiers to prevent SQL injection
-    const escapedDbName = databaseName.replace(/"/g, '""');
-    const escapedTblName = tableName.replace(/"/g, '""');
-    const sampleResult = await databaseConnectionService.executeQuery(
-      database as Parameters<typeof databaseConnectionService.executeQuery>[0],
-      `SELECT * FROM "${escapedDbName}"."${escapedTblName}" LIMIT ${MAX_SAMPLE_ROWS}`,
-    );
-
-    if (sampleResult.success && sampleResult.data) {
-      samples = sampleResult.data.slice(0, MAX_SAMPLE_ROWS);
-    }
+  } finally {
+    release();
   }
-
-  return {
-    columns,
-    samples,
-    sqlDialect: dialect,
-    connectionName: database.name,
-    connectionType: database.type,
-  };
 }
 
 // =============================================================================

--- a/api/src/agent-lib/tools/shared/truncation.ts
+++ b/api/src/agent-lib/tools/shared/truncation.ts
@@ -3,10 +3,54 @@
  * Prevents context overflow by limiting string lengths, array sizes, object depths, etc.
  */
 
+import type { AgentToolExecutionContext } from "../../../agents/types";
 import { databaseConnectionService } from "../../../services/database-connection.service";
 
 // Agent query timeout: how long server-side agent tools wait before aborting
 export const AGENT_QUERY_TIMEOUT_MS = 60_000; // 60 seconds
+export const AGENT_QUERY_TIMEOUT = "AGENT_QUERY_TIMEOUT";
+export const AGENT_QUERY_ABORTED = "AGENT_QUERY_ABORTED";
+
+export function createAgentExecutionId(prefix = "agent-query"): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw new Error(AGENT_QUERY_ABORTED);
+  }
+}
+
+export function isAgentToolAbortError(error: unknown): boolean {
+  if (error instanceof Error && error.message === AGENT_QUERY_ABORTED) {
+    return true;
+  }
+  if (error instanceof Error && error.name === "AbortError") return true;
+  return false;
+}
+
+export function isAgentToolTimeoutError(error: unknown): boolean {
+  return error instanceof Error && error.message === AGENT_QUERY_TIMEOUT;
+}
+
+export function registerAgentExecution(
+  toolExecutionContext: AgentToolExecutionContext | undefined,
+  prefix: string,
+): {
+  executionId: string;
+  signal: AbortSignal | undefined;
+  release: () => void;
+} {
+  const executionId =
+    toolExecutionContext?.createExecutionId(prefix) ??
+    createAgentExecutionId(prefix);
+  toolExecutionContext?.registerExecution(executionId);
+  return {
+    executionId,
+    signal: toolExecutionContext?.signal,
+    release: () => toolExecutionContext?.releaseExecution(executionId),
+  };
+}
 
 /**
  * Run a database operation with a timeout. On timeout, cancels the query
@@ -15,26 +59,66 @@ export const AGENT_QUERY_TIMEOUT_MS = 60_000; // 60 seconds
 export async function withAgentTimeout<T>(
   executionId: string,
   fn: (execId: string) => Promise<T>,
+  options?: {
+    signal?: AbortSignal;
+    onTimeout?: (executionId: string) => Promise<void> | void;
+    onAbort?: (executionId: string) => Promise<void> | void;
+    timeoutMs?: number;
+  },
 ): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
+  let removeAbortListener: (() => void) | undefined;
 
   const timeoutPromise = new Promise<never>((_, reject) => {
     timer = setTimeout(
-      () => reject(new Error("AGENT_QUERY_TIMEOUT")),
-      AGENT_QUERY_TIMEOUT_MS,
+      () => reject(new Error(AGENT_QUERY_TIMEOUT)),
+      options?.timeoutMs ?? AGENT_QUERY_TIMEOUT_MS,
     );
   });
 
+  const abortSignal = options?.signal;
+  const abortPromise = abortSignal
+    ? new Promise<never>((_, reject) => {
+        const handleAbort = () => reject(new Error(AGENT_QUERY_ABORTED));
+        if (abortSignal.aborted) {
+          handleAbort();
+          return;
+        }
+        abortSignal.addEventListener("abort", handleAbort, { once: true });
+        removeAbortListener = () =>
+          abortSignal.removeEventListener("abort", handleAbort);
+      })
+    : null;
+
   try {
-    const result = await Promise.race([fn(executionId), timeoutPromise]);
+    throwIfAborted(options?.signal);
+    const result = await Promise.race(
+      [fn(executionId), timeoutPromise, abortPromise].filter(
+        (candidate): candidate is Promise<T> | Promise<never> => !!candidate,
+      ),
+    );
     return result;
   } catch (err) {
-    if (err instanceof Error && err.message === "AGENT_QUERY_TIMEOUT") {
-      databaseConnectionService.cancelQuery(executionId).catch(() => {});
+    if (isAgentToolTimeoutError(err)) {
+      const cancel =
+        options?.onTimeout ??
+        (async (id: string) => {
+          await databaseConnectionService.cancelQuery(id);
+        });
+      await Promise.resolve(cancel(executionId)).catch(() => {});
+    }
+    if (isAgentToolAbortError(err)) {
+      const cancel =
+        options?.onAbort ??
+        (async (id: string) => {
+          await databaseConnectionService.cancelQuery(id);
+        });
+      await Promise.resolve(cancel(executionId)).catch(() => {});
     }
     throw err;
   } finally {
     clearTimeout(timer);
+    removeAbortListener?.();
   }
 }
 

--- a/api/src/agent-lib/tools/sql-tools.ts
+++ b/api/src/agent-lib/tools/sql-tools.ts
@@ -8,6 +8,7 @@ import { Types } from "mongoose";
 import { DatabaseConnection } from "../../database/workspace-schema";
 import { databaseConnectionService } from "../../services/database-connection.service";
 import { queryExecutionService } from "../../services/query-execution.service";
+import type { AgentToolExecutionContext } from "../../agents/types";
 import type { ConsoleDataV2 } from "../types";
 import { clientConsoleTools } from "./console-tools-client";
 import {
@@ -15,6 +16,9 @@ import {
   truncateQueryResults,
   MAX_SAMPLE_ROWS,
   AGENT_QUERY_TIMEOUT_MS,
+  registerAgentExecution,
+  throwIfAborted,
+  isAgentToolAbortError,
   withAgentTimeout,
 } from "./shared/truncation";
 import {
@@ -154,126 +158,143 @@ async function listSqlConnectionsImpl(workspaceId: string) {
 // ============================================================================
 // sql_list_databases
 // ============================================================================
-async function listDatabasesImpl(connectionId: string, workspaceId: string) {
-  const database = await fetchSqlDatabase(connectionId, workspaceId);
-  const dialect = getDialect(database.type);
+async function listDatabasesImpl(
+  connectionId: string,
+  workspaceId: string,
+  toolExecutionContext?: AgentToolExecutionContext,
+) {
+  const { executionId, signal, release } = registerAgentExecution(
+    toolExecutionContext,
+    "agent-sql-list-databases",
+  );
 
-  if (dialect === "postgresql") {
-    // List Postgres databases
-    const result = await databaseConnectionService.executeQuery(
-      database as Parameters<typeof databaseConnectionService.executeQuery>[0],
-      `SELECT datname FROM pg_database WHERE datistemplate = false AND datallowconn = true ORDER BY datname;`,
-    );
+  try {
+    throwIfAborted(signal);
+    const database = await fetchSqlDatabase(connectionId, workspaceId);
+    const dialect = getDialect(database.type);
 
-    if (!result.success) {
-      throw new Error(result.error || "Failed to list databases");
-    }
-
-    return (result.data || []).map((row: { datname: string }) => ({
-      name: row.datname,
-      sqlDialect: dialect,
-    }));
-  }
-
-  if (dialect === "mysql") {
-    const result = await databaseConnectionService.executeQuery(
-      database as Parameters<typeof databaseConnectionService.executeQuery>[0],
-      "SHOW DATABASES",
-    );
-
-    if (!result.success) {
-      throw new Error(result.error || "Failed to list databases");
-    }
-
-    return (result.data || [])
-      .map(
-        (row: { Database?: string; database?: string }) =>
-          row.Database || row.database,
-      )
-      .filter(
-        (name: string | undefined): name is string =>
-          !!name && !MYSQL_SYSTEM_DATABASES_SET.has(name),
-      )
-      .map((name: string) => ({
-        name,
-        sqlDialect: dialect,
-      }));
-  }
-
-  if (dialect === "bigquery") {
-    // List BigQuery datasets
-    const datasets = await databaseConnectionService.listBigQueryDatasets(
-      database as Parameters<
-        typeof databaseConnectionService.listBigQueryDatasets
-      >[0],
-    );
-    return datasets.map(ds => ({
-      name: ds,
-      sqlDialect: dialect,
-    }));
-  }
-
-  if (dialect === "clickhouse") {
-    // List ClickHouse databases
-    const result = await databaseConnectionService.executeQuery(
-      database as Parameters<typeof databaseConnectionService.executeQuery>[0],
-      "SHOW DATABASES",
-    );
-
-    if (!result.success) {
-      throw new Error(result.error || "Failed to list databases");
-    }
-
-    const systemDatabases = new Set([
-      "system",
-      "information_schema",
-      "INFORMATION_SCHEMA",
-    ]);
-
-    return (result.data || [])
-      .filter((row: { name: string }) => !systemDatabases.has(row.name))
-      .map((row: { name: string }) => ({
-        name: row.name,
-        sqlDialect: dialect,
-      }));
-  }
-
-  // SQLite/D1
-  const connection: Record<string, unknown> =
-    (database as unknown as { connection: Record<string, unknown> })
-      .connection || {};
-  const databaseId = connection.database_id as string | undefined;
-
-  // For Cloudflare D1: check if it's cluster mode (no database_id configured)
-  if (database.type === "cloudflare-d1") {
-    if (databaseId) {
-      // Single database mode: return the configured database_id as both id and name
-      return [{ id: databaseId, name: databaseId, sqlDialect: dialect }];
-    }
-
-    // Cluster mode: fetch all D1 databases from Cloudflare API
-    try {
-      const d1Databases = await databaseConnectionService.listD1Databases(
+    if (dialect === "postgresql") {
+      const result = await databaseConnectionService.executeQuery(
         database as Parameters<
-          typeof databaseConnectionService.listD1Databases
+          typeof databaseConnectionService.executeQuery
+        >[0],
+        `SELECT datname FROM pg_database WHERE datistemplate = false AND datallowconn = true ORDER BY datname;`,
+        { executionId, signal },
+      );
+
+      if (!result.success) {
+        throw new Error(result.error || "Failed to list databases");
+      }
+
+      return (result.data || []).map((row: { datname: string }) => ({
+        name: row.datname,
+        sqlDialect: dialect,
+      }));
+    }
+
+    if (dialect === "mysql") {
+      const result = await databaseConnectionService.executeQuery(
+        database as Parameters<
+          typeof databaseConnectionService.executeQuery
+        >[0],
+        "SHOW DATABASES",
+        { executionId, signal },
+      );
+
+      if (!result.success) {
+        throw new Error(result.error || "Failed to list databases");
+      }
+
+      return (result.data || [])
+        .map(
+          (row: { Database?: string; database?: string }) =>
+            row.Database || row.database,
+        )
+        .filter(
+          (name: string | undefined): name is string =>
+            !!name && !MYSQL_SYSTEM_DATABASES_SET.has(name),
+        )
+        .map((name: string) => ({
+          name,
+          sqlDialect: dialect,
+        }));
+    }
+
+    if (dialect === "bigquery") {
+      const datasets = await databaseConnectionService.listBigQueryDatasets(
+        database as Parameters<
+          typeof databaseConnectionService.listBigQueryDatasets
         >[0],
       );
-      return d1Databases.map(db => ({
-        id: db.uuid, // UUID for API calls
-        name: db.name, // Human-readable name for display
+      throwIfAborted(signal);
+      return datasets.map(ds => ({
+        name: ds,
         sqlDialect: dialect,
       }));
-    } catch {
-      // Fallback to "main" if listing fails (e.g., API error, credentials issue)
-      return [{ name: "main", sqlDialect: dialect }];
     }
-  }
 
-  // Plain SQLite (not D1)
-  if (databaseId) {
-    return [{ name: databaseId, sqlDialect: dialect }];
+    if (dialect === "clickhouse") {
+      const result = await databaseConnectionService.executeQuery(
+        database as Parameters<
+          typeof databaseConnectionService.executeQuery
+        >[0],
+        "SHOW DATABASES",
+        { executionId, signal },
+      );
+
+      if (!result.success) {
+        throw new Error(result.error || "Failed to list databases");
+      }
+
+      const systemDatabases = new Set([
+        "system",
+        "information_schema",
+        "INFORMATION_SCHEMA",
+      ]);
+
+      return (result.data || [])
+        .filter((row: { name: string }) => !systemDatabases.has(row.name))
+        .map((row: { name: string }) => ({
+          name: row.name,
+          sqlDialect: dialect,
+        }));
+    }
+
+    // SQLite/D1
+    const connection: Record<string, unknown> =
+      (database as unknown as { connection: Record<string, unknown> })
+        .connection || {};
+    const databaseId = connection.database_id as string | undefined;
+
+    if (database.type === "cloudflare-d1") {
+      if (databaseId) {
+        return [{ id: databaseId, name: databaseId, sqlDialect: dialect }];
+      }
+
+      try {
+        const d1Databases = await databaseConnectionService.listD1Databases(
+          database as Parameters<
+            typeof databaseConnectionService.listD1Databases
+          >[0],
+        );
+        throwIfAborted(signal);
+        return d1Databases.map(db => ({
+          id: db.uuid,
+          name: db.name,
+          sqlDialect: dialect,
+        }));
+      } catch {
+        return [{ name: "main", sqlDialect: dialect }];
+      }
+    }
+
+    if (databaseId) {
+      return [{ name: databaseId, sqlDialect: dialect }];
+    }
+    return [{ name: "main", sqlDialect: dialect }];
+  } finally {
+    release();
   }
-  return [{ name: "main", sqlDialect: dialect }];
 }
 
 // ============================================================================
@@ -283,152 +304,170 @@ async function listTablesImpl(
   connectionId: string,
   databaseName: string,
   workspaceId: string,
+  toolExecutionContext?: AgentToolExecutionContext,
 ) {
   if (!databaseName) {
     throw new Error("'database' is required");
   }
 
-  const database = await fetchSqlDatabase(connectionId, workspaceId);
-  const dialect = getDialect(database.type);
-
-  if (dialect === "postgresql") {
-    // Query all schemas, prefix table names if not 'public'
-    const result = await databaseConnectionService.executeQuery(
-      database as Parameters<typeof databaseConnectionService.executeQuery>[0],
-      `SELECT table_schema, table_name, table_type
-       FROM information_schema.tables
-       WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
-       ORDER BY table_schema, table_name;`,
-      { databaseName },
-    );
-
-    if (!result.success) {
-      throw new Error(result.error || "Failed to list tables");
-    }
-
-    return (result.data || []).map(
-      (row: {
-        table_schema: string;
-        table_name: string;
-        table_type: string;
-      }) => {
-        const name =
-          row.table_schema === "public"
-            ? row.table_name
-            : `${row.table_schema}.${row.table_name}`;
-        return {
-          name,
-          type: row.table_type === "VIEW" ? "view" : "table",
-          schema: row.table_schema,
-          sqlDialect: dialect,
-        };
-      },
-    );
-  }
-
-  if (dialect === "mysql") {
-    const safeDb = databaseName.replace(/'/g, "''");
-    const result = await databaseConnectionService.executeQuery(
-      database as Parameters<typeof databaseConnectionService.executeQuery>[0],
-      `SELECT table_name AS table_name, table_type AS table_type
-       FROM information_schema.tables
-       WHERE table_schema = '${safeDb}'
-       ORDER BY table_name;`,
-      { databaseName },
-    );
-
-    if (!result.success) {
-      throw new Error(result.error || "Failed to list tables");
-    }
-
-    return (result.data || [])
-      .map(
-        (row: {
-          table_name?: string;
-          TABLE_NAME?: string;
-          table_type?: string;
-          TABLE_TYPE?: string;
-        }) => ({
-          name: row.table_name ?? row.TABLE_NAME,
-          type: row.table_type ?? row.TABLE_TYPE,
-        }),
-      )
-      .filter(
-        (row: {
-          name?: string;
-          type?: string;
-        }): row is {
-          name: string;
-          type?: string;
-        } => !!row.name,
-      )
-      .map((row: { name: string; type?: string }) => ({
-        name: row.name,
-        type: row.type === "VIEW" ? "view" : "table",
-        sqlDialect: dialect,
-      }));
-  }
-
-  if (dialect === "bigquery") {
-    // Use the existing service method
-    const tables = await databaseConnectionService.listBigQueryTables(
-      database as Parameters<
-        typeof databaseConnectionService.listBigQueryTables
-      >[0],
-      databaseName,
-    );
-    return tables.map(t => ({
-      name: t.name,
-      type: t.type === "VIEW" ? "view" : "table",
-      sqlDialect: dialect,
-    }));
-  }
-
-  if (dialect === "clickhouse") {
-    // List ClickHouse tables in the database
-    const result = await databaseConnectionService.executeQuery(
-      database as Parameters<typeof databaseConnectionService.executeQuery>[0],
-      `SELECT name, engine 
-       FROM system.tables 
-       WHERE database = '${databaseName.replace(/'/g, "''")}'
-       ORDER BY name`,
-    );
-
-    if (!result.success) {
-      throw new Error(result.error || "Failed to list tables");
-    }
-
-    return (result.data || []).map((row: { name: string; engine: string }) => ({
-      name: row.name,
-      type:
-        row.engine === "View" || row.engine === "MaterializedView"
-          ? "view"
-          : "table",
-      sqlDialect: dialect,
-    }));
-  }
-
-  // SQLite/D1
-  const result = await databaseConnectionService.executeQuery(
-    database as Parameters<typeof databaseConnectionService.executeQuery>[0],
-    `SELECT name, type 
-     FROM sqlite_master 
-     WHERE type IN ('table', 'view') 
-     AND name NOT LIKE 'sqlite_%' 
-     AND name NOT LIKE '_cf_%'
-     ORDER BY type DESC, name ASC;`,
-    { databaseId: databaseName },
+  const { executionId, signal, release } = registerAgentExecution(
+    toolExecutionContext,
+    "agent-sql-list-tables",
   );
 
-  if (!result.success) {
-    throw new Error(result.error || "Failed to list tables");
-  }
+  try {
+    throwIfAborted(signal);
+    const database = await fetchSqlDatabase(connectionId, workspaceId);
+    const dialect = getDialect(database.type);
 
-  return (result.data || []).map((row: { name: string; type: string }) => ({
-    name: row.name,
-    type: row.type === "view" ? "view" : "table",
-    sqlDialect: dialect,
-  }));
+    if (dialect === "postgresql") {
+      const result = await databaseConnectionService.executeQuery(
+        database as Parameters<
+          typeof databaseConnectionService.executeQuery
+        >[0],
+        `SELECT table_schema, table_name, table_type
+         FROM information_schema.tables
+         WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
+         ORDER BY table_schema, table_name;`,
+        { databaseName, executionId, signal },
+      );
+
+      if (!result.success) {
+        throw new Error(result.error || "Failed to list tables");
+      }
+
+      return (result.data || []).map(
+        (row: {
+          table_schema: string;
+          table_name: string;
+          table_type: string;
+        }) => {
+          const name =
+            row.table_schema === "public"
+              ? row.table_name
+              : `${row.table_schema}.${row.table_name}`;
+          return {
+            name,
+            type: row.table_type === "VIEW" ? "view" : "table",
+            schema: row.table_schema,
+            sqlDialect: dialect,
+          };
+        },
+      );
+    }
+
+    if (dialect === "mysql") {
+      const safeDb = databaseName.replace(/'/g, "''");
+      const result = await databaseConnectionService.executeQuery(
+        database as Parameters<
+          typeof databaseConnectionService.executeQuery
+        >[0],
+        `SELECT table_name AS table_name, table_type AS table_type
+         FROM information_schema.tables
+         WHERE table_schema = '${safeDb}'
+         ORDER BY table_name;`,
+        { databaseName, executionId, signal },
+      );
+
+      if (!result.success) {
+        throw new Error(result.error || "Failed to list tables");
+      }
+
+      return (result.data || [])
+        .map(
+          (row: {
+            table_name?: string;
+            TABLE_NAME?: string;
+            table_type?: string;
+            TABLE_TYPE?: string;
+          }) => ({
+            name: row.table_name ?? row.TABLE_NAME,
+            type: row.table_type ?? row.TABLE_TYPE,
+          }),
+        )
+        .filter(
+          (row: {
+            name?: string;
+            type?: string;
+          }): row is {
+            name: string;
+            type?: string;
+          } => !!row.name,
+        )
+        .map((row: { name: string; type?: string }) => ({
+          name: row.name,
+          type: row.type === "VIEW" ? "view" : "table",
+          sqlDialect: dialect,
+        }));
+    }
+
+    if (dialect === "bigquery") {
+      const tables = await databaseConnectionService.listBigQueryTables(
+        database as Parameters<
+          typeof databaseConnectionService.listBigQueryTables
+        >[0],
+        databaseName,
+      );
+      throwIfAborted(signal);
+      return tables.map(t => ({
+        name: t.name,
+        type: t.type === "VIEW" ? "view" : "table",
+        sqlDialect: dialect,
+      }));
+    }
+
+    if (dialect === "clickhouse") {
+      const result = await databaseConnectionService.executeQuery(
+        database as Parameters<
+          typeof databaseConnectionService.executeQuery
+        >[0],
+        `SELECT name, engine 
+         FROM system.tables 
+         WHERE database = '${databaseName.replace(/'/g, "''")}'
+         ORDER BY name`,
+        { executionId, signal },
+      );
+
+      if (!result.success) {
+        throw new Error(result.error || "Failed to list tables");
+      }
+
+      return (result.data || []).map(
+        (row: { name: string; engine: string }) => ({
+          name: row.name,
+          type:
+            row.engine === "View" || row.engine === "MaterializedView"
+              ? "view"
+              : "table",
+          sqlDialect: dialect,
+        }),
+      );
+    }
+
+    // SQLite/D1
+    const result = await databaseConnectionService.executeQuery(
+      database as Parameters<typeof databaseConnectionService.executeQuery>[0],
+      `SELECT name, type 
+       FROM sqlite_master 
+       WHERE type IN ('table', 'view') 
+       AND name NOT LIKE 'sqlite_%' 
+       AND name NOT LIKE '_cf_%'
+       ORDER BY type DESC, name ASC;`,
+      { databaseId: databaseName, executionId, signal },
+    );
+
+    if (!result.success) {
+      throw new Error(result.error || "Failed to list tables");
+    }
+
+    return (result.data || []).map((row: { name: string; type: string }) => ({
+      name: row.name,
+      type: row.type === "view" ? "view" : "table",
+      sqlDialect: dialect,
+    }));
+  } finally {
+    release();
+  }
 }
 
 // ============================================================================
@@ -439,6 +478,7 @@ async function inspectTableImpl(
   databaseName: string,
   tableName: string,
   workspaceId: string,
+  toolExecutionContext?: AgentToolExecutionContext,
 ) {
   if (!databaseName) {
     throw new Error("'database' is required");
@@ -450,17 +490,28 @@ async function inspectTableImpl(
   const database = await fetchSqlDatabase(connectionId, workspaceId);
   const dialect = getDialect(database.type);
 
-  return withAgentTimeout(
-    `agent-inspect-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-    async executionId =>
-      inspectTableInner(
-        database,
-        dialect,
-        databaseName,
-        tableName,
-        executionId,
-      ),
+  const { executionId, signal, release } = registerAgentExecution(
+    toolExecutionContext,
+    "agent-sql-inspect",
   );
+
+  try {
+    return await withAgentTimeout(
+      executionId,
+      async registeredExecutionId =>
+        inspectTableInner(
+          database,
+          dialect,
+          databaseName,
+          tableName,
+          registeredExecutionId,
+          signal,
+        ),
+      { signal },
+    );
+  } finally {
+    release();
+  }
 }
 
 async function inspectTableInner(
@@ -469,6 +520,7 @@ async function inspectTableInner(
   databaseName: string,
   tableName: string,
   executionId?: string,
+  signal?: AbortSignal,
 ) {
   let columns: Array<{
     name: string;
@@ -501,7 +553,7 @@ async function inspectTableInner(
        WHERE table_schema = ${escapePostgresLiteral(schema)}
          AND table_name = ${escapePostgresLiteral(table)}
        ORDER BY ordinal_position;`,
-      { databaseName, executionId },
+      { databaseName, executionId, signal },
     );
 
     if (!columnsResult.success) {
@@ -523,7 +575,7 @@ async function inspectTableInner(
       `SELECT table_type FROM information_schema.tables
        WHERE table_schema = ${escapePostgresLiteral(schema)}
          AND table_name = ${escapePostgresLiteral(table)};`,
-      { databaseName, executionId },
+      { databaseName, executionId, signal },
     );
     if (typeResult.success && typeResult.data?.[0]?.table_type === "VIEW") {
       entityKind = "view";
@@ -534,7 +586,7 @@ async function inspectTableInner(
     const samplesResult = await databaseConnectionService.executeQuery(
       database as Parameters<typeof databaseConnectionService.executeQuery>[0],
       `SELECT * FROM ${qualifiedName} LIMIT ${MAX_SAMPLE_ROWS};`,
-      { databaseName, executionId },
+      { databaseName, executionId, signal },
     );
 
     if (samplesResult.success && samplesResult.data) {
@@ -577,7 +629,7 @@ async function inspectTableInner(
        WHERE table_name = '${safeTableForQuery}'
        ORDER BY ordinal_position
        LIMIT 1000`,
-      { executionId },
+      { executionId, signal },
     );
 
     if (!columnsResult.success) {
@@ -597,7 +649,7 @@ async function inspectTableInner(
     const samplesResult = await databaseConnectionService.executeQuery(
       database as Parameters<typeof databaseConnectionService.executeQuery>[0],
       `SELECT * FROM ${qualifiedName} LIMIT ${MAX_SAMPLE_ROWS}`,
-      { executionId },
+      { executionId, signal },
     );
 
     if (samplesResult.success && samplesResult.data) {
@@ -615,7 +667,7 @@ async function inspectTableInner(
        FROM system.columns
        WHERE database = '${safeDatabase}' AND table = '${safeTable}'
        ORDER BY position`,
-      { executionId },
+      { executionId, signal },
     );
 
     if (!columnsResult.success) {
@@ -636,7 +688,7 @@ async function inspectTableInner(
       database as Parameters<typeof databaseConnectionService.executeQuery>[0],
       `SELECT engine FROM system.tables 
        WHERE database = '${safeDatabase}' AND name = '${safeTable}'`,
-      { executionId },
+      { executionId, signal },
     );
     if (
       typeResult.success &&
@@ -650,7 +702,7 @@ async function inspectTableInner(
     const samplesResult = await databaseConnectionService.executeQuery(
       database as Parameters<typeof databaseConnectionService.executeQuery>[0],
       `SELECT * FROM "${databaseName.replace(/"/g, '""')}"."${tableName.replace(/"/g, '""')}" LIMIT ${MAX_SAMPLE_ROWS}`,
-      { executionId },
+      { executionId, signal },
     );
 
     if (samplesResult.success && samplesResult.data) {
@@ -667,7 +719,7 @@ async function inspectTableInner(
        WHERE table_schema = '${safeDb}'
          AND table_name = '${safeTable}'
        ORDER BY ordinal_position;`,
-      { databaseName, executionId },
+      { databaseName, executionId, signal },
     );
 
     if (!columnsResult.success) {
@@ -710,7 +762,7 @@ async function inspectTableInner(
        FROM information_schema.tables
        WHERE table_schema = '${safeDb}'
          AND table_name = '${safeTable}';`,
-      { databaseName, executionId },
+      { databaseName, executionId, signal },
     );
     const typeValue =
       (typeResult.success && typeResult.data?.[0]?.table_type) ||
@@ -723,7 +775,7 @@ async function inspectTableInner(
     const samplesResult = await databaseConnectionService.executeQuery(
       database as Parameters<typeof databaseConnectionService.executeQuery>[0],
       `SELECT * FROM ${qualifiedName} LIMIT ${MAX_SAMPLE_ROWS};`,
-      { databaseName, executionId },
+      { databaseName, executionId, signal },
     );
 
     if (samplesResult.success && samplesResult.data) {
@@ -735,7 +787,7 @@ async function inspectTableInner(
     const columnsResult = await databaseConnectionService.executeQuery(
       database as Parameters<typeof databaseConnectionService.executeQuery>[0],
       `PRAGMA table_info(${escapeSqliteLiteral(tableName)});`,
-      { databaseId: databaseName, executionId },
+      { databaseId: databaseName, executionId, signal },
     );
 
     if (!columnsResult.success) {
@@ -755,7 +807,7 @@ async function inspectTableInner(
     const typeResult = await databaseConnectionService.executeQuery(
       database as Parameters<typeof databaseConnectionService.executeQuery>[0],
       `SELECT type FROM sqlite_master WHERE name = ${escapeSqliteLiteral(tableName)};`,
-      { databaseId: databaseName, executionId },
+      { databaseId: databaseName, executionId, signal },
     );
     if (typeResult.success && typeResult.data?.[0]?.type === "view") {
       entityKind = "view";
@@ -765,7 +817,7 @@ async function inspectTableInner(
     const samplesResult = await databaseConnectionService.executeQuery(
       database as Parameters<typeof databaseConnectionService.executeQuery>[0],
       `SELECT * FROM ${escapeSqliteIdentifier(tableName)} LIMIT ${MAX_SAMPLE_ROWS};`,
-      { databaseId: databaseName, executionId },
+      { databaseId: databaseName, executionId, signal },
     );
 
     if (samplesResult.success && samplesResult.data) {
@@ -798,6 +850,7 @@ async function executeQueryImpl(
   query: string,
   workspaceId: string,
   userId?: string,
+  toolExecutionContext?: AgentToolExecutionContext,
 ) {
   const startTime = Date.now();
 
@@ -819,17 +872,23 @@ async function executeQueryImpl(
     options = { databaseId: databaseName };
   }
 
+  const { executionId, signal, release } = registerAgentExecution(
+    toolExecutionContext,
+    "agent-sql-query",
+  );
+
   try {
     const result = await withAgentTimeout(
-      `agent-sql-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-      executionId =>
+      executionId,
+      registeredExecutionId =>
         databaseConnectionService.executeQuery(
           database as Parameters<
             typeof databaseConnectionService.executeQuery
           >[0],
           safeQuery,
-          { ...options, executionId },
+          { ...options, executionId: registeredExecutionId, signal },
         ),
+      { signal },
     );
 
     // Track successful/error query execution (fire-and-forget)
@@ -894,6 +953,14 @@ async function executeQueryImpl(
 
     return { ...result, sqlDialect: dialect };
   } catch (err: unknown) {
+    if (isAgentToolAbortError(err)) {
+      return {
+        success: false,
+        status: "cancelled",
+        message: "Query cancelled because the chat stopped.",
+        sqlDialect: dialect,
+      };
+    }
     if (err instanceof Error && err.message === "AGENT_QUERY_TIMEOUT") {
       if (userId) {
         queryExecutionService.track({
@@ -917,6 +984,8 @@ async function executeQueryImpl(
       };
     }
     throw err;
+  } finally {
+    release();
   }
 }
 
@@ -928,6 +997,7 @@ export const createSqlToolsV2 = (
   _consoles: ConsoleDataV2[],
   _preferredConsoleId?: string,
   userId?: string,
+  toolExecutionContext?: AgentToolExecutionContext,
 ) => {
   return {
     ...clientConsoleTools,
@@ -957,12 +1027,17 @@ export const createSqlToolsV2 = (
       inputSchema: connectionIdSchema,
       execute: async (params: { connectionId: string }) => {
         try {
-          return await listDatabasesImpl(params.connectionId, workspaceId);
+          return await listDatabasesImpl(
+            params.connectionId,
+            workspaceId,
+            toolExecutionContext,
+          );
         } catch (error) {
           return {
             success: false,
-            error:
-              error instanceof Error
+            error: isAgentToolAbortError(error)
+              ? "Database listing cancelled because the chat stopped."
+              : error instanceof Error
                 ? error.message
                 : "Failed to list databases",
           };
@@ -980,12 +1055,16 @@ export const createSqlToolsV2 = (
             params.connectionId,
             params.database,
             workspaceId,
+            toolExecutionContext,
           );
         } catch (error) {
           return {
             success: false,
-            error:
-              error instanceof Error ? error.message : "Failed to list tables",
+            error: isAgentToolAbortError(error)
+              ? "Table listing cancelled because the chat stopped."
+              : error instanceof Error
+                ? error.message
+                : "Failed to list tables",
           };
         }
       },
@@ -1006,17 +1085,20 @@ export const createSqlToolsV2 = (
             params.database,
             params.table,
             workspaceId,
+            toolExecutionContext,
           );
         } catch (error) {
           const isTimeout =
             error instanceof Error && error.message === "AGENT_QUERY_TIMEOUT";
           return {
             success: false,
-            error: isTimeout
-              ? `Table inspection timed out after ${AGENT_QUERY_TIMEOUT_MS / 1000}s. The table may be very large or the database is slow. Try using execute_query with a targeted INFORMATION_SCHEMA query instead.`
-              : error instanceof Error
-                ? error.message
-                : "Failed to inspect table",
+            error: isAgentToolAbortError(error)
+              ? "Table inspection cancelled because the chat stopped."
+              : isTimeout
+                ? `Table inspection timed out after ${AGENT_QUERY_TIMEOUT_MS / 1000}s. The table may be very large or the database is slow. Try using execute_query with a targeted INFORMATION_SCHEMA query instead.`
+                : error instanceof Error
+                  ? error.message
+                  : "Failed to inspect table",
           };
         }
       },
@@ -1038,12 +1120,14 @@ export const createSqlToolsV2 = (
             params.query,
             workspaceId,
             userId,
+            toolExecutionContext,
           );
         } catch (error) {
           return {
             success: false,
-            error:
-              error instanceof Error
+            error: isAgentToolAbortError(error)
+              ? "Query cancelled because the chat stopped."
+              : error instanceof Error
                 ? error.message
                 : "Failed to execute query",
           };

--- a/api/src/agent-lib/tools/universal-tools.ts
+++ b/api/src/agent-lib/tools/universal-tools.ts
@@ -9,6 +9,7 @@
 import { z } from "zod";
 import { Types } from "mongoose";
 import { DatabaseConnection } from "../../database/workspace-schema";
+import type { AgentToolExecutionContext } from "../../agents/types";
 import type { ConsoleDataV2 } from "../types";
 import { clientConsoleTools } from "./console-tools-client";
 import { clientChartTools } from "./chart-tools-client";
@@ -139,6 +140,7 @@ export const createUniversalTools = (
   consoles: ConsoleDataV2[],
   preferredConsoleId?: string,
   userId?: string,
+  toolExecutionContext?: AgentToolExecutionContext,
 ) => {
   // Get MongoDB tools and extract just the database-specific ones
   const mongoTools = createMongoToolsV2(
@@ -146,6 +148,7 @@ export const createUniversalTools = (
     consoles,
     preferredConsoleId,
     userId,
+    toolExecutionContext,
   );
   const {
     // Strip console tools (we use client-side versions)
@@ -166,6 +169,7 @@ export const createUniversalTools = (
     consoles,
     preferredConsoleId,
     userId,
+    toolExecutionContext,
   );
   const {
     // Strip console tools

--- a/api/src/agents/console/index.ts
+++ b/api/src/agents/console/index.ts
@@ -199,9 +199,18 @@ export const consoleAgentFactory: AgentFactory = (
   );
 
   // Create tools
-  const tools = createUniversalTools(workspaceId, enrichedConsoles, consoleId);
+  const tools = createUniversalTools(
+    workspaceId,
+    enrichedConsoles,
+    consoleId,
+    context.userId,
+    context.toolExecutionContext,
+  );
   const selfDirectiveTools = createSelfDirectiveTools(workspaceId);
-  const consoleSearchTools = createConsoleSearchTools(workspaceId);
+  const consoleSearchTools = createConsoleSearchTools(
+    workspaceId,
+    context.toolExecutionContext,
+  );
 
   return {
     systemPrompt: [

--- a/api/src/agents/dashboard/index.ts
+++ b/api/src/agents/dashboard/index.ts
@@ -36,8 +36,14 @@ export function dashboardAgentFactory(context: AgentContext): AgentConfig {
   const { workspaceId } = context;
 
   const selfDirectiveTools = createSelfDirectiveTools(workspaceId);
-  const consoleSearchTools = createConsoleSearchTools(workspaceId);
-  const dashboardSearchTools = createDashboardSearchTools(workspaceId);
+  const consoleSearchTools = createConsoleSearchTools(
+    workspaceId,
+    context.toolExecutionContext,
+  );
+  const dashboardSearchTools = createDashboardSearchTools(
+    workspaceId,
+    context.toolExecutionContext,
+  );
 
   const runtimeContext = buildDashboardRuntimeContext(context);
 

--- a/api/src/agents/flow/index.ts
+++ b/api/src/agents/flow/index.ts
@@ -24,6 +24,12 @@ import {
   checkQuerySafety,
 } from "../../services/destination-writer.service";
 import { databaseConnectionService } from "../../services/database-connection.service";
+import {
+  AGENT_QUERY_TIMEOUT_MS,
+  isAgentToolAbortError,
+  registerAgentExecution,
+  withAgentTimeout,
+} from "../../agent-lib/tools/shared/truncation";
 
 // Import shared database discovery tools from agent-lib
 import {
@@ -163,7 +169,10 @@ const listFlowTabsSchema = z.object({});
  * Create tools for flow agent
  * Uses shared database discovery tools from agent-lib
  */
-export function createFlowTools(workspaceId: string) {
+export function createFlowTools(
+  workspaceId: string,
+  toolExecutionContext?: AgentContext["toolExecutionContext"],
+) {
   return {
     // =========================================================================
     // Database Discovery Tools (from shared agent-lib module)
@@ -206,7 +215,11 @@ export function createFlowTools(workspaceId: string) {
       execute: async (params: z.infer<typeof connectionIdSchema>) => {
         try {
           const { connectionId } = params;
-          const databases = await listDatabasesImpl(connectionId, workspaceId);
+          const databases = await listDatabasesImpl(
+            connectionId,
+            workspaceId,
+            toolExecutionContext,
+          );
           return {
             success: true,
             databases: databases.map(db => ({
@@ -218,8 +231,9 @@ export function createFlowTools(workspaceId: string) {
         } catch (error) {
           return {
             success: false,
-            error:
-              error instanceof Error
+            error: isAgentToolAbortError(error)
+              ? "Database listing cancelled because the chat stopped."
+              : error instanceof Error
                 ? error.message
                 : "Failed to list databases",
           };
@@ -242,6 +256,7 @@ export function createFlowTools(workspaceId: string) {
             connectionId,
             databaseName,
             workspaceId,
+            toolExecutionContext,
           );
           return {
             success: true,
@@ -254,8 +269,11 @@ export function createFlowTools(workspaceId: string) {
         } catch (error) {
           return {
             success: false,
-            error:
-              error instanceof Error ? error.message : "Failed to list tables",
+            error: isAgentToolAbortError(error)
+              ? "Table listing cancelled because the chat stopped."
+              : error instanceof Error
+                ? error.message
+                : "Failed to list tables",
           };
         }
       },
@@ -281,6 +299,7 @@ export function createFlowTools(workspaceId: string) {
             databaseName,
             tableName,
             workspaceId,
+            toolExecutionContext,
           );
           return {
             success: true,
@@ -294,8 +313,9 @@ export function createFlowTools(workspaceId: string) {
         } catch (error) {
           return {
             success: false,
-            error:
-              error instanceof Error
+            error: isAgentToolAbortError(error)
+              ? "Table inspection cancelled because the chat stopped."
+              : error instanceof Error
                 ? error.message
                 : "Failed to inspect table",
           };
@@ -339,26 +359,40 @@ export function createFlowTools(workspaceId: string) {
             return { success: false, error: "Connection not found" };
           }
 
-          const result = await validateQueryService(
-            connection,
-            query,
-            database,
+          const { executionId, signal, release } = registerAgentExecution(
+            toolExecutionContext,
+            "agent-flow-validate-query",
           );
 
-          return {
-            success: result.success,
-            columns: result.columns,
-            sampleRow: result.sampleRow,
-            connectionName: connection.name,
-            connectionType: connection.type,
-            safetyCheck: safetyResult,
-            error: result.error,
-          };
+          try {
+            const result = await withAgentTimeout(
+              executionId,
+              registeredExecutionId =>
+                validateQueryService(connection, query, database, {
+                  executionId: registeredExecutionId,
+                  signal,
+                }),
+              { signal },
+            );
+
+            return {
+              success: result.success,
+              columns: result.columns,
+              sampleRow: result.sampleRow,
+              connectionName: connection.name,
+              connectionType: connection.type,
+              safetyCheck: safetyResult,
+              error: result.error,
+            };
+          } finally {
+            release();
+          }
         } catch (error) {
           return {
             success: false,
-            error:
-              error instanceof Error
+            error: isAgentToolAbortError(error)
+              ? "Query validation cancelled because the chat stopped."
+              : error instanceof Error
                 ? error.message
                 : "Query validation failed",
           };
@@ -389,7 +423,6 @@ export function createFlowTools(workspaceId: string) {
             return { success: false, error: "Connection not found" };
           }
 
-          // Add LIMIT if missing from SELECT queries (safety measure)
           let safeQuery = query;
           const upperQuery = query.toUpperCase().trim();
           if (
@@ -399,25 +432,50 @@ export function createFlowTools(workspaceId: string) {
             safeQuery = `${query.replace(/;+$/, "")} LIMIT 500`;
           }
 
-          const result = await databaseConnectionService.executeQuery(
-            connection.toObject(),
-            safeQuery,
-            { databaseName: database },
+          const { executionId, signal, release } = registerAgentExecution(
+            toolExecutionContext,
+            "agent-flow-execute-query",
           );
 
-          return {
-            success: result.success,
-            data: result.data,
-            rowCount: Array.isArray(result.data) ? result.data.length : 0,
-            connectionName: connection.name,
-            connectionType: connection.type,
-            error: result.error,
-          };
+          try {
+            const result = await withAgentTimeout(
+              executionId,
+              registeredExecutionId =>
+                databaseConnectionService.executeQuery(
+                  connection.toObject(),
+                  safeQuery,
+                  {
+                    databaseName: database,
+                    executionId: registeredExecutionId,
+                    signal,
+                  },
+                ),
+              { signal },
+            );
+
+            return {
+              success: result.success,
+              data: result.data,
+              rowCount: Array.isArray(result.data) ? result.data.length : 0,
+              connectionName: connection.name,
+              connectionType: connection.type,
+              error: result.error,
+            };
+          } finally {
+            release();
+          }
         } catch (error) {
+          const isTimeout =
+            error instanceof Error && error.message === "AGENT_QUERY_TIMEOUT";
           return {
             success: false,
-            error:
-              error instanceof Error ? error.message : "Query execution failed",
+            error: isAgentToolAbortError(error)
+              ? "Query execution cancelled because the chat stopped."
+              : isTimeout
+                ? `Query timed out after ${AGENT_QUERY_TIMEOUT_MS / 1000}s.`
+                : error instanceof Error
+                  ? error.message
+                  : "Query execution failed",
           };
         }
       },
@@ -579,7 +637,7 @@ export const flowAgentFactory: AgentFactory = (
 
   const runtimeContext = buildRuntimeContext(flowFormState, databases);
 
-  const tools = createFlowTools(workspaceId);
+  const tools = createFlowTools(workspaceId, context.toolExecutionContext);
 
   return {
     systemPrompt: [

--- a/api/src/agents/types.ts
+++ b/api/src/agents/types.ts
@@ -9,6 +9,19 @@
 import type { SystemModelMessage } from "ai";
 import type { ConsoleDataV2 } from "../agent-lib/types";
 
+export interface AgentToolExecutionContext {
+  /** Abort signal for the active chat request */
+  signal: AbortSignal;
+  /** Create a unique execution ID for a long-running tool */
+  createExecutionId: (prefix?: string) => string;
+  /** Register an execution so the request can cancel it on abort */
+  registerExecution: (executionId: string) => void;
+  /** Release a previously registered execution */
+  releaseExecution: (executionId: string) => void;
+  /** Check whether the chat request has already been aborted */
+  isAborted: () => boolean;
+}
+
 /**
  * Metadata about an agent for UI display and routing
  */
@@ -113,6 +126,8 @@ export interface AgentContext {
     }>;
     crossFilterEnabled: boolean;
   };
+  /** Request-scoped execution registry for cancellable server tools */
+  toolExecutionContext?: AgentToolExecutionContext;
 }
 
 /**

--- a/api/src/agents/unified/index.ts
+++ b/api/src/agents/unified/index.ts
@@ -23,11 +23,18 @@ export function unifiedAgentFactory(context: AgentContext): AgentConfig {
     consoles,
     consoleId,
     userId,
+    context.toolExecutionContext,
   );
-  const flowTools = createFlowTools(workspaceId);
+  const flowTools = createFlowTools(workspaceId, context.toolExecutionContext);
   const selfDirectiveTools = createSelfDirectiveTools(workspaceId);
-  const consoleSearchTools = createConsoleSearchTools(workspaceId);
-  const dashboardSearchTools = createDashboardSearchTools(workspaceId);
+  const consoleSearchTools = createConsoleSearchTools(
+    workspaceId,
+    context.toolExecutionContext,
+  );
+  const dashboardSearchTools = createDashboardSearchTools(
+    workspaceId,
+    context.toolExecutionContext,
+  );
 
   const {
     list_connections: _flowListConnections,

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -50,6 +50,8 @@ import {
   getAllAgentMeta,
   type AgentContext,
 } from "../agents";
+import { databaseConnectionService } from "../services/database-connection.service";
+import { createAgentExecutionId } from "../agent-lib/tools/shared/truncation";
 import { toNum, extractTokenCounts } from "../utils/safe-num";
 
 const logger = loggers.agent();
@@ -333,6 +335,47 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
 
   logger.info("Using agent", { agentId: resolvedAgentId, tabKind, flowType });
 
+  const requestSignal = c.req.raw.signal;
+  const requestExecutionIds = new Set<string>();
+
+  // Cancel all currently-registered database executions.
+  // Invariant: this only runs as a batch on abort. Any execution registered
+  // *after* the abort fires is individually cancelled inside registerExecution
+  // (which checks requestSignal.aborted synchronously after adding the ID).
+  const cancelRegisteredExecutions = async (): Promise<void> => {
+    const executionIds = Array.from(requestExecutionIds);
+    await Promise.allSettled(
+      executionIds.map(executionId =>
+        databaseConnectionService.cancelQuery(executionId),
+      ),
+    );
+  };
+  requestSignal.addEventListener(
+    "abort",
+    () => {
+      void cancelRegisteredExecutions();
+    },
+    { once: true },
+  );
+
+  const toolExecutionContext: NonNullable<
+    AgentContext["toolExecutionContext"]
+  > = {
+    signal: requestSignal,
+    createExecutionId: createAgentExecutionId,
+    registerExecution: executionId => {
+      requestExecutionIds.add(executionId);
+      if (requestSignal.aborted) {
+        requestExecutionIds.delete(executionId);
+        void databaseConnectionService.cancelQuery(executionId);
+      }
+    },
+    releaseExecution: executionId => {
+      requestExecutionIds.delete(executionId);
+    },
+    isAborted: () => requestSignal.aborted,
+  };
+
   // Auto-discover relevant consoles via embedding search (parallel with other setup)
   let consoleHints = "";
   if (
@@ -390,6 +433,7 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
     consoleHints,
     activeConsoleResults,
     activeDashboardContext,
+    toolExecutionContext,
   };
 
   // Create agent configuration
@@ -453,8 +497,9 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
     messages: modelMessages,
     tools: tools as Record<string, any>,
     stopWhen: stepCountIs(MAX_STEPS),
-    providerOptions: providerOptions as any,
-    onStepFinish: ({ toolCalls }) => {
+    providerOptions: providerOptions as Record<string, unknown>,
+    abortSignal: requestSignal,
+    onStepFinish({ toolCalls }: { toolCalls?: Array<unknown> }) {
       stepsCompleted += 1;
 
       logger.debug("Step finished", {
@@ -469,7 +514,7 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
         });
       }
     },
-  });
+  } as Parameters<typeof streamText>[0]);
 
   // Return native AI SDK UI message stream response (for useChat compatibility)
   // Using AI SDK best practice: save once at the end with all messages
@@ -480,6 +525,10 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
     // (e.g., Claude claude-3-7-sonnet-20250219, DeepSeek deepseek-r1)
     sendReasoning: true,
     onFinish: async ({ messages: allMessages }) => {
+      if (requestExecutionIds.size > 0) {
+        await cancelRegisteredExecutions();
+        requestExecutionIds.clear();
+      }
       const durationMs = Date.now() - startTime;
 
       // Extract detailed per-step usage from result.steps

--- a/api/src/services/database-connection.service.ts
+++ b/api/src/services/database-connection.service.ts
@@ -2,7 +2,7 @@ import { createClient } from "@clickhouse/client";
 import { MongoClient, Db, MongoClientOptions, ClientSession } from "mongodb";
 import { Client as PgClient, Pool as PgPool } from "pg";
 import * as mysql from "mysql2/promise";
-import { ConnectionPool } from "mssql";
+import { ConnectionPool, Request as MSSQLRequest } from "mssql";
 import { IDatabaseConnection } from "../database/workspace-schema";
 import axios, { AxiosInstance } from "axios";
 import crypto from "crypto";
@@ -320,6 +320,14 @@ export class DatabaseConnectionService {
     }
   > = new Map();
 
+  // Track running MSSQL queries for cancellation
+  private runningMSSQLQueries: Map<
+    string,
+    {
+      request: MSSQLRequest;
+    }
+  > = new Map();
+
   private cleanupInterval: NodeJS.Timeout | null = null;
   private readonly userDatabaseMaxIdleTime = 15 * 60 * 1000; // 15 minutes - keep user database pools alive during active sessions
 
@@ -432,7 +440,7 @@ export class DatabaseConnectionService {
         case "mysql":
           return await this.executeMySQLQuery(database, query, options);
         case "mssql":
-          return await this.executeMSSQLQuery(database, query);
+          return await this.executeMSSQLQuery(database, query, options);
         case "bigquery":
           return await this.executeBigQueryQuery(database, query, options);
         case "clickhouse":
@@ -2174,6 +2182,27 @@ export class DatabaseConnectionService {
     }
   }
 
+  private async cancelMSSQLQuery(
+    executionId: string,
+  ): Promise<{ success: boolean; error?: string }> {
+    const running = this.runningMSSQLQueries.get(executionId);
+    if (!running) {
+      return { success: false, error: "Query not found or already completed" };
+    }
+
+    try {
+      running.request.cancel();
+      this.runningMSSQLQueries.delete(executionId);
+      return { success: true };
+    } catch (error) {
+      return {
+        success: false,
+        error:
+          error instanceof Error ? error.message : "Failed to cancel query",
+      };
+    }
+  }
+
   /**
    * Cancel a running query (auto-detects database type)
    */
@@ -2195,6 +2224,10 @@ export class DatabaseConnectionService {
     // Try ClickHouse
     if (this.runningClickHouseQueries.has(executionId)) {
       return this.cancelClickHouseQuery(executionId);
+    }
+    // Try MSSQL
+    if (this.runningMSSQLQueries.has(executionId)) {
+      return this.cancelMSSQLQuery(executionId);
     }
 
     // Delegate to drivers that support cancellation (e.g., cloudsql-postgres)
@@ -3875,10 +3908,16 @@ export class DatabaseConnectionService {
   private async executeMSSQLQuery(
     database: IDatabaseConnection,
     query: string,
+    options?: QueryExecuteOptions,
   ): Promise<QueryResult> {
     const pool = (await this.getConnection(database)) as ConnectionPool;
+    const request = pool.request();
+    const executionId = options?.executionId;
     try {
-      const result = await pool.request().query(query);
+      if (executionId) {
+        this.runningMSSQLQueries.set(executionId, { request });
+      }
+      const result = await request.query(query);
       return {
         success: true,
         data: result.recordset,
@@ -3889,6 +3928,10 @@ export class DatabaseConnectionService {
         success: false,
         error: error instanceof Error ? error.message : "MSSQL query failed",
       };
+    } finally {
+      if (executionId) {
+        this.runningMSSQLQueries.delete(executionId);
+      }
     }
   }
 

--- a/api/src/services/destination-writer.service.ts
+++ b/api/src/services/destination-writer.service.ts
@@ -978,6 +978,7 @@ export async function estimateQueryRowCount(
   connection: IDatabaseConnection,
   query: string,
   database?: string,
+  options?: { executionId?: string; signal?: AbortSignal },
 ): Promise<{ success: boolean; estimatedCount?: number; error?: string }> {
   const driver = databaseRegistry.getDriver(connection.type);
   if (!driver) {
@@ -995,6 +996,8 @@ export async function estimateQueryRowCount(
 
     const result = await driver.executeQuery(connection, countQuery, {
       databaseName: database,
+      executionId: options?.executionId,
+      signal: options?.signal,
     });
 
     if (result.success && result.data && result.data.length > 0) {
@@ -1023,6 +1026,7 @@ export async function getMaxTrackingValue(
   trackingColumn: string,
   schema?: string,
   database?: string,
+  options?: { executionId?: string; signal?: AbortSignal },
 ): Promise<{ success: boolean; maxValue?: string; error?: string }> {
   const driver = databaseRegistry.getDriver(connection.type);
   if (!driver) {
@@ -1038,6 +1042,8 @@ export async function getMaxTrackingValue(
 
     const result = await driver.executeQuery(connection, query, {
       databaseName: database,
+      executionId: options?.executionId,
+      signal: options?.signal,
     });
 
     if (result.success && result.data && result.data.length > 0) {
@@ -1067,6 +1073,7 @@ export async function validateQuery(
   connection: IDatabaseConnection,
   query: string,
   database?: string,
+  options?: { executionId?: string; signal?: AbortSignal },
 ): Promise<{
   success: boolean;
   columns?: Array<{ name: string; type: string }>;
@@ -1091,6 +1098,8 @@ export async function validateQuery(
 
     const result = await driver.executeQuery(connection, testQuery, {
       databaseName: database,
+      executionId: options?.executionId,
+      signal: options?.signal,
     });
 
     if (!result.success) {

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -253,6 +253,35 @@ interface ToolInvocationInfo {
   output?: unknown;
 }
 
+type AutoSendPredicateArgs = Parameters<
+  typeof lastAssistantMessageIsCompleteWithToolCalls
+>[0];
+
+interface ActiveClientToolCall {
+  toolCallId: string;
+  toolName: string;
+  executionId: string;
+  abortController: AbortController;
+  cancel: () => void | Promise<void>;
+  cancellationOutput: Record<string, unknown>;
+  settled: boolean;
+}
+
+const LONG_RUNNING_DASHBOARD_TOOLS = new Set([
+  "open_dashboard",
+  "create_dashboard",
+  "enter_edit_mode",
+  "add_data_source",
+  "import_console_as_data_source",
+  "create_data_source",
+  "update_data_source_query",
+  "run_data_source_query",
+  "preview_data_source",
+  "get_data_preview",
+  "add_widget",
+  "modify_widget",
+]);
+
 // ReasoningDisplay for showing reasoning/thinking parts inline.
 // - Auto-opens while streaming, auto-collapses when done.
 // - Shows elapsed thinking time ("Thought for Xs").
@@ -394,6 +423,12 @@ const shimmerAnimation = keyframes`
 const streamingIndicatorContainerSx = {
   display: "flex",
   alignItems: "center",
+  justifyContent: "center",
+  width: 14,
+  height: 14,
+  overflow: "visible",
+  lineHeight: 0,
+  flexShrink: 0,
   mt: 0.5,
 } as const;
 
@@ -941,9 +976,20 @@ const Chat: React.FC<ChatProps> = ({
   const workspaceIdRef = useRef(currentWorkspace?.id);
   const modelIdRef = useRef(selectedModelId);
   const chatIdRef = useRef(chatId);
+  const manualStopRequestedRef = useRef(false);
+  const activeClientToolCallsRef = useRef(
+    new Map<string, ActiveClientToolCall>(),
+  );
   workspaceIdRef.current = currentWorkspace?.id;
   modelIdRef.current = selectedModelId;
   chatIdRef.current = chatId;
+
+  const autoSendWhenComplete = useCallback((options: AutoSendPredicateArgs) => {
+    if (manualStopRequestedRef.current) {
+      return false;
+    }
+    return lastAssistantMessageIsCompleteWithToolCalls(options);
+  }, []);
 
   // Create transport with prepareSendMessagesRequest for dynamic body values
   // prepareSendMessagesRequest REPLACES the body (doesn't merge), so we must include all fields
@@ -1133,7 +1179,7 @@ const Chat: React.FC<ChatProps> = ({
     transport,
 
     // Automatically submit when all tool results are available
-    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+    sendAutomaticallyWhen: autoSendWhenComplete,
 
     // Handle client-side tools (console operations)
     async onToolCall({ toolCall }) {
@@ -1535,20 +1581,21 @@ const Chat: React.FC<ChatProps> = ({
             return;
           }
 
+          const { abortController } = registerActiveClientToolCall(
+            "open_console",
+            toolCall.toolCallId,
+          );
+
           try {
             const currentStore = useConsoleStore.getState();
             const existingTab = currentStore.tabs[consoleId];
             if (existingTab) {
               currentStore.setActiveTab(consoleId);
-              addToolOutput({
-                tool: "open_console",
-                toolCallId: toolCall.toolCallId,
-                output: {
-                  success: true,
-                  consoleId,
-                  title: existingTab.title,
-                  message: `Console "${existingTab.title}" is already open — switched to it.`,
-                },
+              settleActiveClientToolCall("open_console", toolCall.toolCallId, {
+                success: true,
+                consoleId,
+                title: existingTab.title,
+                message: `Console "${existingTab.title}" is already open — switched to it.`,
               });
               return;
             }
@@ -1556,15 +1603,15 @@ const Chat: React.FC<ChatProps> = ({
             const data = await currentStore.fetchConsoleContent(
               workspaceIdRef.current!,
               consoleId,
+              { signal: abortController.signal },
             );
+            if (abortController.signal.aborted) {
+              return;
+            }
             if (!data) {
-              addToolOutput({
-                tool: "open_console",
-                toolCallId: toolCall.toolCallId,
-                output: {
-                  success: false,
-                  error: `Console ${consoleId} not found or access denied.`,
-                },
+              settleActiveClientToolCall("open_console", toolCall.toolCallId, {
+                success: false,
+                error: `Console ${consoleId} not found or access denied.`,
               });
               return;
             }
@@ -1580,24 +1627,19 @@ const Chat: React.FC<ChatProps> = ({
             });
             currentStore.setActiveTab(consoleId);
 
-            addToolOutput({
-              tool: "open_console",
-              toolCallId: toolCall.toolCallId,
-              output: {
-                success: true,
-                consoleId,
-                title,
-                message: `Console "${title}" opened successfully.`,
-              },
+            settleActiveClientToolCall("open_console", toolCall.toolCallId, {
+              success: true,
+              consoleId,
+              title,
+              message: `Console "${title}" opened successfully.`,
             });
           } catch (err) {
-            addToolOutput({
-              tool: "open_console",
-              toolCallId: toolCall.toolCallId,
-              output: {
-                success: false,
-                error: `Failed to open console: ${err instanceof Error ? err.message : String(err)}`,
-              },
+            if (abortController.signal.aborted) {
+              return;
+            }
+            settleActiveClientToolCall("open_console", toolCall.toolCallId, {
+              success: false,
+              error: `Failed to open console: ${err instanceof Error ? err.message : String(err)}`,
             });
           }
           return;
@@ -1690,71 +1732,154 @@ const Chat: React.FC<ChatProps> = ({
             return;
           }
 
-          // Send the spec to the renderer and wait for render result
-          const renderResult = await new Promise<{
-            success: boolean;
-            error?: string;
-          }>(resolve => {
-            const timeout = setTimeout(() => resolve({ success: true }), 5000);
-            onChartSpecChangeRef.current!({
-              spec: parsed.data,
-              onRenderResult: result => {
-                clearTimeout(timeout);
-                resolve(result);
-              },
-            });
-          });
+          const { abortController } = registerActiveClientToolCall(
+            "modify_chart_spec",
+            toolCall.toolCallId,
+          );
 
-          if (renderResult.success) {
-            addToolOutput({
-              tool: "modify_chart_spec",
-              toolCallId: toolCall.toolCallId,
-              output: {
-                success: true,
-                message: "Chart rendered successfully in the results panel.",
-              },
+          try {
+            // Send the spec to the renderer and wait for render result
+            const renderResult = await new Promise<{
+              success: boolean;
+              error?: string;
+            }>((resolve, reject) => {
+              const timeout = setTimeout(() => {
+                abortController.signal.removeEventListener(
+                  "abort",
+                  handleAbort,
+                );
+                resolve({ success: true });
+              }, 5000);
+              const handleAbort = () => {
+                clearTimeout(timeout);
+                abortController.signal.removeEventListener(
+                  "abort",
+                  handleAbort,
+                );
+                reject(
+                  new DOMException("Chart update cancelled", "AbortError"),
+                );
+              };
+
+              if (abortController.signal.aborted) {
+                handleAbort();
+                return;
+              }
+
+              abortController.signal.addEventListener("abort", handleAbort, {
+                once: true,
+              });
+              onChartSpecChangeRef.current!({
+                spec: parsed.data,
+                onRenderResult: result => {
+                  clearTimeout(timeout);
+                  abortController.signal.removeEventListener(
+                    "abort",
+                    handleAbort,
+                  );
+                  resolve(result);
+                },
+              });
             });
-          } else {
-            addToolOutput({
-              tool: "modify_chart_spec",
-              toolCallId: toolCall.toolCallId,
-              output: {
+
+            if (renderResult.success) {
+              settleActiveClientToolCall(
+                "modify_chart_spec",
+                toolCall.toolCallId,
+                {
+                  success: true,
+                  message: "Chart rendered successfully in the results panel.",
+                },
+              );
+            } else {
+              settleActiveClientToolCall(
+                "modify_chart_spec",
+                toolCall.toolCallId,
+                {
+                  success: false,
+                  error: `Chart failed to render: ${renderResult.error}. Fix the Vega-Lite spec and try again.`,
+                },
+              );
+            }
+          } catch (chartError) {
+            if (abortController.signal.aborted) {
+              return;
+            }
+
+            settleActiveClientToolCall(
+              "modify_chart_spec",
+              toolCall.toolCallId,
+              {
                 success: false,
-                error: `Chart failed to render: ${renderResult.error}. Fix the Vega-Lite spec and try again.`,
+                error:
+                  chartError instanceof Error
+                    ? chartError.message
+                    : "Chart rendering failed unexpectedly.",
               },
-            });
+            );
           }
           return;
         }
 
         // --- Dashboard tools (client-side) ---
         try {
+          const activeDashboardTool = LONG_RUNNING_DASHBOARD_TOOLS.has(toolName)
+            ? registerActiveClientToolCall(toolName, toolCall.toolCallId)
+            : null;
+
           const dashboardToolOutput = await executeDashboardAgentTool(
             toolName,
             input,
             capturedDashboardIdRef.current,
+            activeDashboardTool
+              ? {
+                  executionId: activeDashboardTool.executionId,
+                  signal: activeDashboardTool.abortController.signal,
+                }
+              : undefined,
           );
 
           if (dashboardToolOutput !== null) {
-            addToolOutput({
-              tool: toolName,
-              toolCallId: toolCall.toolCallId,
-              output: dashboardToolOutput,
-            });
+            if (activeDashboardTool) {
+              settleActiveClientToolCall(
+                toolName,
+                toolCall.toolCallId,
+                dashboardToolOutput,
+              );
+            } else {
+              addToolOutput({
+                tool: toolName,
+                toolCallId: toolCall.toolCallId,
+                output: dashboardToolOutput,
+              });
+            }
             return;
           }
         } catch (dashboardError) {
-          addToolOutput({
-            tool: toolName,
-            toolCallId: toolCall.toolCallId,
-            output: {
+          if (LONG_RUNNING_DASHBOARD_TOOLS.has(toolName)) {
+            if (manualStopRequestedRef.current) {
+              return;
+            }
+            settleActiveClientToolCall(toolName, toolCall.toolCallId, {
               success: false,
               error:
                 dashboardError instanceof Error
                   ? dashboardError.message
                   : "Dashboard tool execution failed",
-            },
-          });
+            });
+          } else {
+            addToolOutput({
+              tool: toolName,
+              toolCallId: toolCall.toolCallId,
+              output: {
+                success: false,
+                error:
+                  dashboardError instanceof Error
+                    ? dashboardError.message
+                    : "Dashboard tool execution failed",
+              },
+            });
+          }
           return;
         }
 
@@ -1836,9 +1961,19 @@ const Chat: React.FC<ChatProps> = ({
           }
 
           const QUERY_TIMEOUT_MS = 120_000; // 2 minutes
-          const abortController = new AbortController();
+          const { abortController, executionId } = registerActiveClientToolCall(
+            "run_console",
+            toolCall.toolCallId,
+            {
+              cancel: async () => {
+                await useConsoleStore
+                  .getState()
+                  .cancelQuery(workspaceId, executionId);
+              },
+            },
+          );
           const timeoutId = setTimeout(
-            () => abortController.abort(),
+            () => abortController.abort("query-timeout"),
             QUERY_TIMEOUT_MS,
           );
 
@@ -1855,6 +1990,7 @@ const Chat: React.FC<ChatProps> = ({
               connectionId,
               content,
               {
+                executionId,
                 databaseName: targetConsole.databaseName,
                 databaseId: targetConsole.databaseId,
                 signal: abortController.signal,
@@ -1884,34 +2020,42 @@ const Chat: React.FC<ChatProps> = ({
                 }),
               );
 
-              addToolOutput({
-                tool: "run_console",
-                toolCallId: toolCall.toolCallId,
-                output: {
-                  success: true,
-                  rowCount,
-                  preview,
-                  message: `Query executed successfully. ${rowCount} row(s) returned.`,
-                },
+              settleActiveClientToolCall("run_console", toolCall.toolCallId, {
+                success: true,
+                rowCount,
+                preview,
+                message: `Query executed successfully. ${rowCount} row(s) returned.`,
               });
             } else {
+              const abortReason =
+                typeof abortController.signal.reason === "string"
+                  ? abortController.signal.reason
+                  : undefined;
               window.dispatchEvent(
                 new CustomEvent("console-execution-result", {
                   detail: { consoleId, result: null },
                 }),
               );
 
-              addToolOutput({
-                tool: "run_console",
-                toolCallId: toolCall.toolCallId,
-                output: {
-                  success: false,
-                  error: result.error || "Query execution failed.",
-                },
+              if (abortReason === "chat-stop") {
+                return;
+              }
+
+              settleActiveClientToolCall("run_console", toolCall.toolCallId, {
+                success: false,
+                error:
+                  abortReason === "query-timeout"
+                    ? `Query timed out after ${QUERY_TIMEOUT_MS / 1000}s. The query may be too complex or the database is under heavy load.`
+                    : result.error || "Query execution failed.",
               });
             }
           } catch (e: any) {
             clearTimeout(timeoutId);
+
+            const abortReason =
+              typeof abortController.signal.reason === "string"
+                ? abortController.signal.reason
+                : undefined;
 
             window.dispatchEvent(
               new CustomEvent("console-execution-result", {
@@ -1919,17 +2063,16 @@ const Chat: React.FC<ChatProps> = ({
               }),
             );
 
-            const isTimeout =
-              e?.name === "AbortError" && abortController.signal.aborted;
-            addToolOutput({
-              tool: "run_console",
-              toolCallId: toolCall.toolCallId,
-              output: {
-                success: false,
-                error: isTimeout
+            if (abortReason === "chat-stop") {
+              return;
+            }
+
+            settleActiveClientToolCall("run_console", toolCall.toolCallId, {
+              success: false,
+              error:
+                abortReason === "query-timeout"
                   ? `Query timed out after ${QUERY_TIMEOUT_MS / 1000}s. The query may be too complex or the database is under heavy load.`
                   : e?.message || "Query execution failed unexpectedly.",
-              },
             });
           }
           return;
@@ -2121,6 +2264,96 @@ const Chat: React.FC<ChatProps> = ({
     },
   });
 
+  const createCancellationOutput = useCallback(
+    (toolName: string): Record<string, unknown> => ({
+      success: false,
+      error:
+        toolName === "run_console"
+          ? "Query cancelled because the chat stopped."
+          : "Tool cancelled because the chat stopped.",
+    }),
+    [],
+  );
+
+  const registerActiveClientToolCall = useCallback(
+    (
+      toolName: string,
+      toolCallId: string,
+      options?: {
+        executionId?: string;
+        cancel?: () => void | Promise<void>;
+        cancellationOutput?: Record<string, unknown>;
+      },
+    ) => {
+      const abortController = new AbortController();
+      const executionId =
+        options?.executionId ?? `chat-tool-${generateObjectId()}`;
+
+      activeClientToolCallsRef.current.set(toolCallId, {
+        toolCallId,
+        toolName,
+        executionId,
+        abortController,
+        cancel: options?.cancel ?? (() => {}),
+        cancellationOutput:
+          options?.cancellationOutput ?? createCancellationOutput(toolName),
+        settled: false,
+      });
+
+      return { abortController, executionId };
+    },
+    [createCancellationOutput],
+  );
+
+  const settleActiveClientToolCall = useCallback(
+    (
+      toolName: string,
+      toolCallId: string,
+      output: Record<string, unknown>,
+    ): void => {
+      const activeToolCall = activeClientToolCallsRef.current.get(toolCallId);
+      if (!activeToolCall) {
+        if (!manualStopRequestedRef.current) {
+          addToolOutput({ tool: toolName, toolCallId, output });
+        }
+        return;
+      }
+
+      if (!activeToolCall.settled) {
+        activeToolCall.settled = true;
+        addToolOutput({
+          tool: activeToolCall.toolName,
+          toolCallId,
+          output,
+        });
+      }
+
+      activeClientToolCallsRef.current.delete(toolCallId);
+    },
+    [addToolOutput],
+  );
+
+  const handleStop = useCallback(() => {
+    manualStopRequestedRef.current = true;
+
+    for (const activeToolCall of activeClientToolCallsRef.current.values()) {
+      activeToolCall.abortController.abort("chat-stop");
+      void activeToolCall.cancel();
+
+      if (!activeToolCall.settled) {
+        activeToolCall.settled = true;
+        addToolOutput({
+          tool: activeToolCall.toolName,
+          toolCallId: activeToolCall.toolCallId,
+          output: activeToolCall.cancellationOutput,
+        });
+      }
+    }
+
+    activeClientToolCallsRef.current.clear();
+    stop();
+  }, [addToolOutput, stop]);
+
   const isLoading = status === "streaming" || status === "submitted";
 
   // Auto-scroll to bottom when messages change
@@ -2284,6 +2517,7 @@ const Chat: React.FC<ChatProps> = ({
 
   // Create new chat session - just generate a new ID locally (no API call needed)
   const createNewSession = () => {
+    manualStopRequestedRef.current = false;
     setChatId(generateObjectId());
     setMessages([]);
     setIsExistingChat(false);
@@ -2298,6 +2532,7 @@ const Chat: React.FC<ChatProps> = ({
   };
 
   const handleSelectSession = (id: string) => {
+    manualStopRequestedRef.current = false;
     setChatId(id);
     setMessages([]);
     setIsExistingChat(true);
@@ -2339,6 +2574,7 @@ const Chat: React.FC<ChatProps> = ({
   // Stable submit handler — uses refs to avoid stale closures and minimize deps
   const handleChatSubmit = useCallback(
     (text: string) => {
+      manualStopRequestedRef.current = false;
       capturedConsoleIdRef.current = activeConsoleIdRef.current;
       capturedDashboardIdRef.current =
         useDashboardStore.getState().activeDashboardId ?? null;
@@ -2575,6 +2811,7 @@ const Chat: React.FC<ChatProps> = ({
                 variant="outlined"
                 size="small"
                 onClick={() => {
+                  manualStopRequestedRef.current = false;
                   // Submit the suggestion immediately
                   capturedConsoleIdRef.current = activeConsoleId;
                   capturedDashboardIdRef.current =
@@ -2648,7 +2885,7 @@ const Chat: React.FC<ChatProps> = ({
       {/* Input — isolated component so keystrokes don't re-render messages */}
       <ChatInputArea
         onSubmit={handleChatSubmit}
-        onStop={stop}
+        onStop={handleStop}
         isLoading={isLoading}
         disabled={!currentWorkspace}
         focusKey={`${chatId}-${messages.length}`}

--- a/app/src/dashboard-runtime/abort-utils.ts
+++ b/app/src/dashboard-runtime/abort-utils.ts
@@ -1,0 +1,30 @@
+export function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw new DOMException("Dashboard tool cancelled", "AbortError");
+  }
+}
+
+export function abortableSleep(
+  ms: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      signal?.removeEventListener("abort", handleAbort);
+      resolve();
+    }, ms);
+
+    const handleAbort = () => {
+      clearTimeout(timeoutId);
+      signal?.removeEventListener("abort", handleAbort);
+      reject(new DOMException("Dashboard tool cancelled", "AbortError"));
+    };
+
+    if (signal?.aborted) {
+      handleAbort();
+      return;
+    }
+
+    signal?.addEventListener("abort", handleAbort, { once: true });
+  });
+}

--- a/app/src/dashboard-runtime/agent-tools.ts
+++ b/app/src/dashboard-runtime/agent-tools.ts
@@ -24,6 +24,8 @@ import {
 import { selectWidgetRuntime } from "./selectors";
 import { getAllTemplates, getTemplate } from "@mako/schemas";
 
+import { throwIfAborted, abortableSleep } from "./abort-utils";
+
 /**
  * Poll the runtime store for widget render status after adding/modifying a
  * chart widget. Returns the render error if the chart fails, or null on
@@ -32,12 +34,14 @@ import { getAllTemplates, getTemplate } from "@mako/schemas";
 async function waitForWidgetRenderResult(
   dashboardId: string,
   widgetId: string,
+  signal?: AbortSignal,
   maxWaitMs = 3000,
 ): Promise<{ renderError: string | null; renderErrorKind: string | null }> {
   const POLL_INTERVAL = 150;
   const deadline = Date.now() + maxWaitMs;
 
   while (Date.now() < deadline) {
+    throwIfAborted(signal);
     const runtime = selectWidgetRuntime(dashboardId, widgetId);
     if (runtime?.renderStatus === "error") {
       return {
@@ -48,7 +52,7 @@ async function waitForWidgetRenderResult(
     if (runtime?.renderStatus === "ready") {
       return { renderError: null, renderErrorKind: null };
     }
-    await new Promise(r => setTimeout(r, POLL_INTERVAL));
+    await abortableSleep(POLL_INTERVAL, signal);
   }
 
   return { renderError: null, renderErrorKind: null };
@@ -117,7 +121,9 @@ export async function executeDashboardAgentTool(
   toolName: string,
   input: Record<string, unknown>,
   fallbackDashboardId?: string | null,
+  options?: { executionId?: string; signal?: AbortSignal },
 ): Promise<Record<string, unknown> | null> {
+  const signal = options?.signal;
   if (
     DASHBOARD_TOOLS.has(toolName) &&
     fallbackDashboardId &&
@@ -180,7 +186,8 @@ export async function executeDashboardAgentTool(
     }
 
     try {
-      await store.openDashboard(workspaceId, dashboardId);
+      await store.openDashboard(workspaceId, dashboardId, { signal });
+      throwIfAborted(signal);
       const dashboard =
         useDashboardStore.getState().openDashboards[dashboardId];
       if (!dashboard) {
@@ -231,15 +238,18 @@ export async function executeDashboardAgentTool(
     }
 
     try {
-      const dashboard = await useDashboardStore
-        .getState()
-        .createDashboard(workspaceId, {
+      const dashboard = await useDashboardStore.getState().createDashboard(
+        workspaceId,
+        {
           title: input.title,
           description:
             typeof input.description === "string"
               ? input.description
               : undefined,
-        } as any);
+        } as any,
+        { signal },
+      );
+      throwIfAborted(signal);
 
       if (!dashboard) {
         return { success: false, error: "Failed to create dashboard" };
@@ -255,8 +265,9 @@ export async function executeDashboardAgentTool(
 
       await useDashboardStore
         .getState()
-        .enterEditMode(workspaceId, dashboard._id)
+        .enterEditMode(workspaceId, dashboard._id, { signal })
         .catch(() => {});
+      throwIfAborted(signal);
 
       const consoleStore = useConsoleStore.getState();
       const tabId = consoleStore.openTab({
@@ -309,19 +320,35 @@ export async function executeDashboardAgentTool(
       return { success: true, alreadyEditing: true };
     }
 
-    const result = await store.enterEditMode(workspaceId, dashboardId);
+    const result = await store.enterEditMode(workspaceId, dashboardId, {
+      signal,
+    });
+    throwIfAborted(signal);
     if (result.ok) {
       return { success: true };
     }
 
     const lockedBy = result.lockedBy ?? "Another user";
-    const userApproved = await new Promise<boolean>(resolve => {
+    const userApproved = await new Promise<boolean>((resolve, reject) => {
+      const handleAbort = () => {
+        useDashboardStore.getState().setLockConflictPrompt(null);
+        reject(new DOMException("Dashboard tool cancelled", "AbortError"));
+      };
+      if (signal?.aborted) {
+        handleAbort();
+        return;
+      }
+      signal?.addEventListener("abort", handleAbort, { once: true });
       useDashboardStore.getState().setLockConflictPrompt({
         dashboardId,
         lockedBy,
-        resolve,
+        resolve: force => {
+          signal?.removeEventListener("abort", handleAbort);
+          resolve(force);
+        },
       });
     });
+    throwIfAborted(signal);
 
     if (!userApproved) {
       return {
@@ -333,7 +360,8 @@ export async function executeDashboardAgentTool(
 
     const forceResult = await useDashboardStore
       .getState()
-      .enterEditMode(workspaceId, dashboardId, { force: true });
+      .enterEditMode(workspaceId, dashboardId, { force: true, signal });
+    throwIfAborted(signal);
     if (forceResult.ok) {
       return { success: true, forcedFrom: lockedBy };
     }
@@ -381,7 +409,9 @@ export async function executeDashboardAgentTool(
               ? input.timeDimension
               : undefined,
           dashboardId: ctx.dashboardId,
+          signal,
         });
+        throwIfAborted(signal);
         const snapshot = getDashboardStateSnapshot(ctx.dashboardId);
         const runtimeSource = snapshot.dataSources.find(
           ds => ds.id === dataSource.id,
@@ -452,7 +482,9 @@ export async function executeDashboardAgentTool(
               ? input.databaseName
               : undefined,
         },
+        signal,
       });
+      throwIfAborted(signal);
       const snapshot = getDashboardStateSnapshot(ctx.dashboardId);
       const runtimeSource = snapshot.dataSources.find(
         ds => ds.id === dataSource.id,
@@ -603,7 +635,9 @@ export async function executeDashboardAgentTool(
                 : existing.query.databaseName,
           },
         },
+        signal,
       });
+      throwIfAborted(signal);
 
       if (shouldRun) {
         const snapshot = getDashboardStateSnapshot(ctx.dashboardId);
@@ -672,7 +706,9 @@ export async function executeDashboardAgentTool(
         workspaceId: ctx.workspaceId,
         dashboardId: ctx.dashboardId,
         dataSourceId: input.dataSourceId,
+        signal,
       });
+      throwIfAborted(signal);
 
       const snapshot = getDashboardStateSnapshot(ctx.dashboardId);
       const runtimeSource = snapshot.dataSources.find(
@@ -796,7 +832,9 @@ export async function executeDashboardAgentTool(
         dataSourceId: input.dataSourceId,
         sql: typeof input.sql === "string" ? input.sql : undefined,
         dashboardId: ctx.dashboardId,
+        signal,
       });
+      throwIfAborted(signal);
 
       return {
         success: true,
@@ -836,7 +874,9 @@ export async function executeDashboardAgentTool(
       dashboardId: ctx.dashboardId,
       dataSourceId: input.dataSourceId as string | undefined,
       sql: String(input.localSql || ""),
+      signal,
     });
+    throwIfAborted(signal);
     if (!queryValidation.valid) {
       return {
         success: false,
@@ -876,12 +916,15 @@ export async function executeDashboardAgentTool(
         dashboardId: ctx.dashboardId,
         dataSourceId: widget.dataSourceId,
         sql: widget.localSql,
+        signal,
       });
+      throwIfAborted(signal);
 
       const renderResult =
         widget.type === "chart" && widget.vegaLiteSpec
-          ? await waitForWidgetRenderResult(ctx.dashboardId, widget.id)
+          ? await waitForWidgetRenderResult(ctx.dashboardId, widget.id, signal)
           : null;
+      throwIfAborted(signal);
 
       if (renderResult?.renderError) {
         return {
@@ -977,7 +1020,9 @@ export async function executeDashboardAgentTool(
         dashboardId: ctx.dashboardId,
         dataSourceId: targetWidget.dataSourceId,
         sql: String(changes.localSql),
+        signal,
       });
+      throwIfAborted(signal);
       if (!queryValidation.valid) {
         return {
           success: false,
@@ -1021,14 +1066,17 @@ export async function executeDashboardAgentTool(
         dashboardId: ctx.dashboardId,
         dataSourceId: widget.dataSourceId,
         sql: widget.localSql,
+        signal,
       });
+      throwIfAborted(signal);
 
       const isChartWithSpec =
         widget.type === "chart" &&
         (changes.vegaLiteSpec || widget.vegaLiteSpec);
       const renderResult = isChartWithSpec
-        ? await waitForWidgetRenderResult(ctx.dashboardId, widget.id)
+        ? await waitForWidgetRenderResult(ctx.dashboardId, widget.id, signal)
         : null;
+      throwIfAborted(signal);
 
       if (renderResult?.renderError) {
         return {

--- a/app/src/dashboard-runtime/commands.ts
+++ b/app/src/dashboard-runtime/commands.ts
@@ -26,6 +26,7 @@ import type {
   DashboardQueryDefinition,
   DashboardWidget,
 } from "./types";
+import { abortableSleep } from "./abort-utils";
 
 function resolveActiveDashboardId(): string {
   const id = useDashboardStore.getState().activeDashboardId;
@@ -56,10 +57,6 @@ function remountWidgetsForDataSource(
       );
     }
   }
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 function isDashboardInEditMode(dashboardId: string): boolean {
@@ -103,10 +100,11 @@ export function shouldAutoApplyFreshMaterialization(
 async function fetchAndSyncMaterializationStatus(
   workspaceId: string,
   dashboardId: string,
+  signal?: AbortSignal,
 ): Promise<DashboardMaterializationStatus | null> {
   const status = await useDashboardStore
     .getState()
-    .fetchDashboardMaterializationStatus(workspaceId, dashboardId);
+    .fetchDashboardMaterializationStatus(workspaceId, dashboardId, { signal });
   if (status) {
     syncRuntimeMaterializationStatus(dashboardId, status);
   }
@@ -117,11 +115,13 @@ async function waitForDashboardMaterialization(options: {
   workspaceId: string;
   dashboardId: string;
   pollMs?: number;
+  signal?: AbortSignal;
 }): Promise<DashboardMaterializationStatus | null> {
   const runtimeStore = useDashboardRuntimeStore.getState();
   const initial = await fetchAndSyncMaterializationStatus(
     options.workspaceId,
     options.dashboardId,
+    options.signal,
   );
   if (!initial) {
     return null;
@@ -135,10 +135,11 @@ async function waitForDashboardMaterialization(options: {
   );
   let current = initial;
   while (current.anyBuilding) {
-    await sleep(options.pollMs ?? 3000);
+    await abortableSleep(options.pollMs ?? 3000, options.signal);
     const nextStatus = await fetchAndSyncMaterializationStatus(
       options.workspaceId,
       options.dashboardId,
+      options.signal,
     );
     if (!nextStatus) {
       return null;
@@ -275,6 +276,7 @@ export async function createDashboardDataSource(options: {
   timeDimension?: string;
   rowLimit?: number;
   dashboardId?: string;
+  signal?: AbortSignal;
 }): Promise<DashboardDataSource> {
   const store = useDashboardStore.getState();
   const dashboard = getDashboardOrThrow(options.dashboardId);
@@ -293,6 +295,7 @@ export async function createDashboardDataSource(options: {
     dataSource,
     force: true,
     skipParquet: true,
+    signal: options.signal,
   });
 
   return dataSource;
@@ -305,10 +308,12 @@ export async function importConsoleAsDashboardDataSource(options: {
   rowLimit?: number;
   timeDimension?: string;
   dashboardId?: string;
+  signal?: AbortSignal;
 }): Promise<DashboardDataSource> {
   const response = await apiClient.get<ConsoleContentResponse>(
     `/workspaces/${options.workspaceId}/consoles/content`,
     { id: options.consoleId },
+    { signal: options.signal },
   );
 
   if (!response.success) {
@@ -347,6 +352,7 @@ export async function importConsoleAsDashboardDataSource(options: {
     dataSource,
     force: true,
     skipParquet: true,
+    signal: options.signal,
   });
 
   return dataSource;
@@ -358,6 +364,7 @@ export async function updateDashboardDataSourceQuery(options: {
   changes: Partial<DashboardDataSource>;
   rematerialize?: boolean;
   dashboardId?: string;
+  signal?: AbortSignal;
 }): Promise<void> {
   const store = useDashboardStore.getState();
   const dashboard = getDashboardOrThrow(options.dashboardId);
@@ -375,6 +382,7 @@ export async function updateDashboardDataSourceQuery(options: {
         dataSource,
         force: true,
         skipParquet: true,
+        signal: options.signal,
       });
 
       const mosaicInstance = getMosaicInstance(updatedDashboard._id);
@@ -399,6 +407,7 @@ export async function runDashboardDataSource(options: {
   workspaceId: string;
   dashboardId: string;
   dataSourceId: string;
+  signal?: AbortSignal;
 }): Promise<{ loadPath: string | null; recovered: boolean }> {
   const dashboard = getDashboardOrThrow(options.dashboardId);
   const dataSource = dashboard.dataSources.find(
@@ -416,6 +425,7 @@ export async function runDashboardDataSource(options: {
       dataSource,
       force: true,
       skipParquet: true,
+      signal: options.signal,
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
@@ -450,6 +460,7 @@ export async function runDashboardDataSource(options: {
       dataSource: freshDs,
       force: true,
       skipParquet: true,
+      signal: options.signal,
     });
 
     const otherDataSources = freshDashboard.dataSources.filter(
@@ -464,6 +475,7 @@ export async function runDashboardDataSource(options: {
             dataSource: ds,
             force: true,
             skipParquet: true,
+            signal: options.signal,
           }),
         ),
       );
@@ -696,12 +708,14 @@ export async function previewDashboardQuery(options: {
   dataSourceId: string;
   sql?: string;
   dashboardId?: string;
+  signal?: AbortSignal;
 }) {
   const dashboard = getDashboardOrThrow(options.dashboardId);
   return await previewDashboardDataSource({
     dashboard,
     dataSourceId: options.dataSourceId,
     sql: options.sql,
+    signal: options.signal,
   });
 }
 
@@ -709,12 +723,14 @@ export async function executeDashboardSql(options: {
   sql: string;
   dataSourceId?: string;
   dashboardId?: string;
+  signal?: AbortSignal;
 }) {
   const dashboard = getDashboardOrThrow(options.dashboardId);
   return await queryDashboardRuntime({
     dashboard,
     sql: options.sql,
     dataSourceId: options.dataSourceId,
+    signal: options.signal,
   });
 }
 

--- a/app/src/dashboard-runtime/gateway.ts
+++ b/app/src/dashboard-runtime/gateway.ts
@@ -24,6 +24,7 @@ import type {
   DashboardQueryResult,
   DashboardRuntimeColumn,
 } from "./types";
+import { throwIfAborted as throwIfSignalAborted } from "./abort-utils";
 
 function hashString(value: string): string {
   let hash = 0;
@@ -214,6 +215,7 @@ async function fetchDashboardExport(
   dashboardId: string,
   dataSource: DashboardDataSource,
   format: "arrow" | "ndjson" | "parquet",
+  signal?: AbortSignal,
 ): Promise<Response & { body: ReadableStream<Uint8Array> }> {
   const response = await fetch(
     `/api/workspaces/${workspaceId}/execute/export`,
@@ -224,6 +226,7 @@ async function fetchDashboardExport(
       body: JSON.stringify(
         buildDashboardExportPayload(dashboardId, dataSource, format),
       ),
+      signal,
     },
   );
 
@@ -252,6 +255,7 @@ async function loadParquetArtifactIntoTable(options: {
   session: Awaited<ReturnType<typeof ensureDashboardSession>>;
   parquetUrl: string;
   targetTableRef: string;
+  signal?: AbortSignal;
   onProgress?: (progress: {
     rowsLoaded: number;
     bytesLoaded: number;
@@ -260,6 +264,7 @@ async function loadParquetArtifactIntoTable(options: {
 }): Promise<number> {
   const response = await fetch(options.parquetUrl, {
     credentials: "include",
+    signal: options.signal,
   });
   if (!response.ok || !response.body) {
     throw new Error(response.statusText || "Failed to fetch parquet artifact");
@@ -268,6 +273,7 @@ async function loadParquetArtifactIntoTable(options: {
   const totalBytes = parseNumericHeader(response.headers, "Content-Length");
   const totalRows = parseNumericHeader(response.headers, "X-Row-Count");
   const parquetBuffer = await collectStreamBytes(response.body, bytesLoaded => {
+    throwIfSignalAborted(options.signal);
     const estimatedRows = estimateRowsFromBytes(
       bytesLoaded,
       totalBytes,
@@ -358,6 +364,7 @@ async function loadDashboardDataSourceWithFallback(options: {
   onRowsLoaded: (loaded: number) => void;
   runtimeContext?: DashboardRuntimeContext;
   skipParquet?: boolean;
+  signal?: AbortSignal;
 }): Promise<{
   rowCount: number;
   loadPath: "memory" | "arrow_stream" | "ndjson_stream";
@@ -386,6 +393,7 @@ async function loadDashboardDataSourceWithFallback(options: {
   } | null> => {
     if (!parquetUrl) return null;
     try {
+      throwIfSignalAborted(options.signal);
       updateDatasourceDiagnostics({
         runtimeStore,
         dashboardId,
@@ -407,6 +415,7 @@ async function loadDashboardDataSourceWithFallback(options: {
           session,
           parquetUrl,
           targetTableRef,
+          signal: options.signal,
           onProgress: progress => {
             const loadingMessage =
               progress.rowsLoaded > 0
@@ -475,6 +484,7 @@ async function loadDashboardDataSourceWithFallback(options: {
         dashboardId,
         dataSource,
         "arrow",
+        options.signal,
       );
       const totalBytes = parseNumericHeader(response.headers, "Content-Length");
       const totalRows = parseNumericHeader(response.headers, "X-Row-Count");
@@ -567,6 +577,7 @@ async function loadDashboardDataSourceWithFallback(options: {
       dashboardId,
       dataSource,
       "ndjson",
+      options.signal,
     );
     const totalBytes = parseNumericHeader(response.headers, "Content-Length");
     setDatasourceLoadingMessage({
@@ -829,6 +840,7 @@ export async function materializeDashboardDataSource(options: {
   force?: boolean;
   runtimeContext?: DashboardRuntimeContext;
   skipParquet?: boolean;
+  signal?: AbortSignal;
 }): Promise<void> {
   const {
     workspaceId,
@@ -837,6 +849,7 @@ export async function materializeDashboardDataSource(options: {
     force = false,
     runtimeContext = "builder",
     skipParquet = false,
+    signal,
   } = options;
   const session = await ensureDashboardSession(dashboard._id);
   const runtimeStore = useDashboardRuntimeStore.getState();
@@ -940,6 +953,7 @@ export async function materializeDashboardDataSource(options: {
   );
 
   try {
+    throwIfSignalAborted(signal);
     temporaryTableRef = buildTemporaryTableRef(dataSource.tableRef);
     setDatasourceLoadingMessage({
       runtimeStore,
@@ -962,6 +976,7 @@ export async function materializeDashboardDataSource(options: {
       },
       runtimeContext,
       skipParquet,
+      signal,
     });
 
     setDatasourceLoadingMessage({
@@ -1174,7 +1189,9 @@ export async function queryDashboardRuntime(options: {
   dashboard: Dashboard;
   sql: string;
   dataSourceId?: string;
+  signal?: AbortSignal;
 }): Promise<DashboardQueryResult> {
+  throwIfSignalAborted(options.signal);
   const session = getDashboardSession(options.dashboard._id);
   if (!session) {
     throw new Error("Dashboard runtime session is not initialized");
@@ -1185,13 +1202,16 @@ export async function queryDashboardRuntime(options: {
     options.sql,
     options.dataSourceId,
   );
-  return await queryDuckDB(session.db, resolvedSql);
+  const result = await queryDuckDB(session.db, resolvedSql);
+  throwIfSignalAborted(options.signal);
+  return result;
 }
 
 export async function previewDashboardDataSource(options: {
   dashboard: Dashboard;
   dataSourceId: string;
   sql?: string;
+  signal?: AbortSignal;
 }): Promise<DashboardQueryResult> {
   const dataSource = options.dashboard.dataSources.find(
     ds => ds.id === options.dataSourceId,
@@ -1221,5 +1241,6 @@ export async function previewDashboardDataSource(options: {
   return await queryDashboardRuntime({
     dashboard: options.dashboard,
     sql,
+    signal: options.signal,
   });
 }

--- a/app/src/dashboard-runtime/validation.test.ts
+++ b/app/src/dashboard-runtime/validation.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { validateDuckDBQuery } from "./validation";
+import { executeDashboardSql } from "./commands";
+
+vi.mock("./commands", () => ({
+  executeDashboardSql: vi.fn(),
+}));
+
+describe("validateDuckDBQuery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("forwards the abort signal to dashboard SQL execution", async () => {
+    const controller = new AbortController();
+
+    vi.mocked(executeDashboardSql).mockResolvedValue({
+      rows: [],
+      rowCount: 0,
+      fields: [{ name: "id", type: "INTEGER" }],
+    } as any);
+
+    const result = await validateDuckDBQuery({
+      dashboardId: "dashboard-1",
+      dataSourceId: "source-1",
+      sql: "select 1",
+      signal: controller.signal,
+    });
+
+    expect(result).toEqual({
+      valid: true,
+      fields: ["id"],
+      rowCount: 0,
+    });
+    expect(executeDashboardSql).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dashboardId: "dashboard-1",
+        dataSourceId: "source-1",
+        signal: controller.signal,
+      }),
+    );
+  });
+});

--- a/app/src/dashboard-runtime/validation.ts
+++ b/app/src/dashboard-runtime/validation.ts
@@ -20,6 +20,7 @@ export async function validateDuckDBQuery(options: {
   dashboardId?: string;
   sql: string;
   dataSourceId?: string;
+  signal?: AbortSignal;
 }): Promise<
   | { valid: true; fields: string[]; rowCount: number }
   | { valid: false; error: string; errorKind: DashboardErrorKind }
@@ -39,6 +40,7 @@ export async function validateDuckDBQuery(options: {
       dashboardId: options.dashboardId,
       dataSourceId: options.dataSourceId,
       sql: validationSql,
+      signal: options.signal,
     });
 
     return {

--- a/app/src/lib/api-client.ts
+++ b/app/src/lib/api-client.ts
@@ -116,8 +116,16 @@ class ApiClient {
   /**
    * GET request
    */
-  async get<T>(path: string, params?: Record<string, string>): Promise<T> {
-    return this.request<T>(path, { method: "GET", params });
+  async get<T>(
+    path: string,
+    params?: Record<string, string>,
+    options?: { signal?: AbortSignal },
+  ): Promise<T> {
+    return this.request<T>(path, {
+      method: "GET",
+      params,
+      signal: options?.signal,
+    });
   }
 
   /**
@@ -138,18 +146,26 @@ class ApiClient {
   /**
    * PUT request
    */
-  async put<T>(path: string, data?: any): Promise<T> {
+  async put<T>(
+    path: string,
+    data?: any,
+    options?: { signal?: AbortSignal },
+  ): Promise<T> {
     return this.request<T>(path, {
       method: "PUT",
       body: data ? JSON.stringify(data) : undefined,
+      signal: options?.signal,
     });
   }
 
   /**
    * DELETE request
    */
-  async delete<T>(path: string): Promise<T> {
-    return this.request<T>(path, { method: "DELETE" });
+  async delete<T>(
+    path: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<T> {
+    return this.request<T>(path, { method: "DELETE", signal: options?.signal });
   }
 
   /**

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -64,6 +64,7 @@ interface ConsoleActions {
   fetchConsoleContent: (
     workspaceId: string,
     consoleId: string,
+    options?: { signal?: AbortSignal },
   ) => Promise<ConsoleContentResponse | null>;
   saveConsole: (
     workspaceId: string,
@@ -354,11 +355,12 @@ export const useConsoleStore = create<ConsoleStore>()(
         }
       },
 
-      fetchConsoleContent: async (workspaceId, consoleId) => {
+      fetchConsoleContent: async (workspaceId, consoleId, options) => {
         try {
           const res = await apiClient.get<ConsoleContentResponse>(
             `/workspaces/${workspaceId}/consoles/content`,
             { id: consoleId },
+            { signal: options?.signal },
           );
 
           if (res.success) {
@@ -390,6 +392,9 @@ export const useConsoleStore = create<ConsoleStore>()(
 
           return res.success ? res : null;
         } catch (e) {
+          if (e instanceof Error && e.name === "AbortError") {
+            return null;
+          }
           console.error("Failed to fetch console content", e);
           return null;
         }

--- a/app/src/store/dashboardStore.ts
+++ b/app/src/store/dashboardStore.ts
@@ -151,6 +151,7 @@ interface DashboardStoreState {
   createDashboard: (
     workspaceId: string,
     data: Partial<Dashboard>,
+    options?: { signal?: AbortSignal },
   ) => Promise<Dashboard | null>;
   updateDashboard: (
     workspaceId: string,
@@ -162,8 +163,16 @@ interface DashboardStoreState {
     workspaceId: string,
     id: string,
   ) => Promise<Dashboard | null>;
-  openDashboard: (workspaceId: string, dashboardId: string) => Promise<void>;
-  reloadDashboard: (workspaceId: string, dashboardId: string) => Promise<void>;
+  openDashboard: (
+    workspaceId: string,
+    dashboardId: string,
+    options?: { signal?: AbortSignal },
+  ) => Promise<void>;
+  reloadDashboard: (
+    workspaceId: string,
+    dashboardId: string,
+    options?: { signal?: AbortSignal },
+  ) => Promise<void>;
   closeDashboard: (dashboardId: string) => void;
   saveDashboard: (
     workspaceId: string,
@@ -202,6 +211,7 @@ interface DashboardStoreState {
   fetchDashboardMaterializationStatus: (
     workspaceId: string,
     dashboardId: string,
+    options?: { signal?: AbortSignal },
   ) => Promise<DashboardMaterializationStatus | null>;
   materializeDashboard: (
     workspaceId: string,
@@ -227,10 +237,15 @@ interface DashboardStoreState {
 
   getDashboardSavedStateHash: (dashboardId: string) => string | undefined;
 
-  acquireLock: (workspaceId: string, dashboardId: string) => Promise<boolean>;
+  acquireLock: (
+    workspaceId: string,
+    dashboardId: string,
+    options?: { signal?: AbortSignal },
+  ) => Promise<boolean>;
   forceAcquireLock: (
     workspaceId: string,
     dashboardId: string,
+    options?: { signal?: AbortSignal },
   ) => Promise<boolean>;
   releaseLock: (workspaceId: string, dashboardId: string) => Promise<void>;
   heartbeatLock: (workspaceId: string, dashboardId: string) => Promise<void>;
@@ -238,7 +253,7 @@ interface DashboardStoreState {
   enterEditMode: (
     workspaceId: string,
     dashboardId: string,
-    opts?: { force?: boolean },
+    opts?: { force?: boolean; signal?: AbortSignal },
   ) => Promise<{ ok: boolean; lockedBy?: string }>;
   exitEditMode: (workspaceId: string, dashboardId: string) => Promise<void>;
   setLockConflictPrompt: (prompt: LockConflictPrompt | null) => void;
@@ -315,12 +330,15 @@ export const useDashboardStore = create<DashboardStoreState>()(
       createDashboard: async (
         workspaceId: string,
         data: Partial<Dashboard>,
+        options?: { signal?: AbortSignal },
       ) => {
         try {
           const response = await apiClient.post<{
             success: boolean;
             data: Dashboard;
-          }>(`/workspaces/${workspaceId}/dashboards`, data);
+          }>(`/workspaces/${workspaceId}/dashboards`, data, {
+            signal: options?.signal,
+          });
 
           if (response.data) {
             set(state => {
@@ -407,7 +425,11 @@ export const useDashboardStore = create<DashboardStoreState>()(
         }
       },
 
-      openDashboard: async (workspaceId: string, dashboardId: string) => {
+      openDashboard: async (
+        workspaceId: string,
+        dashboardId: string,
+        options?: { signal?: AbortSignal },
+      ) => {
         const existing = get().openDashboards[dashboardId];
         if (existing) {
           set(state => {
@@ -416,15 +438,25 @@ export const useDashboardStore = create<DashboardStoreState>()(
           return;
         }
 
-        await get().reloadDashboard(workspaceId, dashboardId);
+        await get().reloadDashboard(workspaceId, dashboardId, options);
       },
 
-      reloadDashboard: async (workspaceId: string, dashboardId: string) => {
+      reloadDashboard: async (
+        workspaceId: string,
+        dashboardId: string,
+        options?: { signal?: AbortSignal },
+      ) => {
         try {
           const response = await apiClient.get<{
             success: boolean;
             data: Dashboard;
-          }>(`/workspaces/${workspaceId}/dashboards/${dashboardId}`);
+          }>(
+            `/workspaces/${workspaceId}/dashboards/${dashboardId}`,
+            undefined,
+            {
+              signal: options?.signal,
+            },
+          );
 
           if (response.data) {
             const dashboard = response.data;
@@ -755,6 +787,7 @@ export const useDashboardStore = create<DashboardStoreState>()(
       fetchDashboardMaterializationStatus: async (
         workspaceId: string,
         dashboardId: string,
+        options?: { signal?: AbortSignal },
       ) => {
         try {
           const response = await apiClient.get<{
@@ -762,6 +795,8 @@ export const useDashboardStore = create<DashboardStoreState>()(
             data: DashboardMaterializationStatus;
           }>(
             `/workspaces/${workspaceId}/dashboards/${dashboardId}/materialization`,
+            undefined,
+            { signal: options?.signal },
           );
           if (!response.data) {
             return null;
@@ -853,12 +888,22 @@ export const useDashboardStore = create<DashboardStoreState>()(
         return get().savedStateHashes[dashboardId];
       },
 
-      acquireLock: async (workspaceId: string, dashboardId: string) => {
+      acquireLock: async (
+        workspaceId: string,
+        dashboardId: string,
+        options?: { signal?: AbortSignal },
+      ) => {
         try {
           const response = await apiClient.post<{
             success: boolean;
             data: Pick<Dashboard, "editLock">;
-          }>(`/workspaces/${workspaceId}/dashboards/${dashboardId}/lock`);
+          }>(
+            `/workspaces/${workspaceId}/dashboards/${dashboardId}/lock`,
+            undefined,
+            {
+              signal: options?.signal,
+            },
+          );
           if (response.data) {
             set(state => {
               const d = state.openDashboards[dashboardId];
@@ -877,13 +922,19 @@ export const useDashboardStore = create<DashboardStoreState>()(
         }
       },
 
-      forceAcquireLock: async (workspaceId: string, dashboardId: string) => {
+      forceAcquireLock: async (
+        workspaceId: string,
+        dashboardId: string,
+        options?: { signal?: AbortSignal },
+      ) => {
         try {
           const response = await apiClient.post<{
             success: boolean;
             data: Pick<Dashboard, "editLock">;
           }>(
             `/workspaces/${workspaceId}/dashboards/${dashboardId}/lock?force=true`,
+            undefined,
+            { signal: options?.signal },
           );
           if (response.data) {
             set(state => {
@@ -928,13 +979,15 @@ export const useDashboardStore = create<DashboardStoreState>()(
       enterEditMode: async (
         workspaceId: string,
         dashboardId: string,
-        opts?: { force?: boolean },
+        opts?: { force?: boolean; signal?: AbortSignal },
       ) => {
         if (get().editingDashboards[dashboardId]) {
           return { ok: true };
         }
         const lockFn = opts?.force ? get().forceAcquireLock : get().acquireLock;
-        const acquired = await lockFn(workspaceId, dashboardId);
+        const acquired = await lockFn(workspaceId, dashboardId, {
+          signal: opts?.signal,
+        });
         if (acquired) {
           set(state => {
             state.editingDashboards[dashboardId] = true;


### PR DESCRIPTION
## Summary
- propagate abort signals and execution registration through agent routes, shared tool helpers, SQL/Mongo tooling, and database connection services so stopped chats cancel in-flight work cleanly
- harden dashboard runtime and chat tool handling to return consistent cancellation outputs, avoid duplicate stop results, and support abortable client requests
- add focused dashboard runtime validation coverage and preserve D1 abort semantics instead of masking cancellations with fallback results

## Test plan
- [x] `pnpm test:unit src/dashboard-runtime/validation.test.ts`
- [ ] Manually verify stopping a long-running dashboard tool emits a single cancellation result in chat
- [ ] Manually verify aborting agent-driven database discovery/query flows cancels backend work cleanly


Made with [Cursor](https://cursor.com)