### PR TITLE
fix(backfill): cancel orphaned child functions on backfill restart

### DIFF
--- a/api/src/inngest/functions/flow.ts
+++ b/api/src/inngest/functions/flow.ts
@@ -397,6 +397,10 @@ export const flowFunction = inngest.createFunction(
       key: "event.data.flowId", // Prevent duplicate executions of the same flow
     },
     retries: 10,
+    timeouts: {
+      start: "5m",
+      finish: "6h",
+    },
     cancelOn: [
       {
         event: "flow.cancel",

--- a/api/src/inngest/functions/flow.ts
+++ b/api/src/inngest/functions/flow.ts
@@ -399,7 +399,6 @@ export const flowFunction = inngest.createFunction(
     retries: 10,
     timeouts: {
       start: "5m",
-      finish: "6h",
     },
     cancelOn: [
       {

--- a/api/src/inngest/functions/sync-entity.ts
+++ b/api/src/inngest/functions/sync-entity.ts
@@ -124,6 +124,12 @@ export const syncBackfillEntityFunction = inngest.createFunction(
       key: "event.data.flowId",
     },
     retries: 3,
+    cancelOn: [
+      {
+        event: "flow.cancel",
+        if: "async.data.flowId == event.data.flowId",
+      },
+    ],
   },
   { event: "flow/sync-backfill-entity" },
   async ({ event, step, logger }): Promise<SyncBackfillEntityResult> => {

--- a/api/src/sync-cdc/backfill.ts
+++ b/api/src/sync-cdc/backfill.ts
@@ -28,11 +28,81 @@ const STALE_HEARTBEAT_MS = 10 * 60 * 1000; // 10 minutes
 const CANCEL_WAIT_POLL_MS = 1000;
 const CANCEL_WAIT_TIMEOUT_MS = 30_000;
 
+const INNGEST_APP_ID = "mako-sync";
+const INNGEST_FLOW_FUNCTION_ID = `${INNGEST_APP_ID}-flow`;
+
+/**
+ * Cancel all running Inngest "flow" function runs for a given flowId via the
+ * bulk-cancellation REST API.  This is the only reliable way to release the
+ * per-flow concurrency lock when a function is stuck (ghost process after
+ * server restart, step timeout, etc.).
+ */
+async function cancelInngestFlowRuns(flowId: string): Promise<boolean> {
+  const signingKey = process.env.INNGEST_SIGNING_KEY;
+  if (!signingKey) {
+    log.warn(
+      "cancelInngestFlowRuns: INNGEST_SIGNING_KEY not set, skipping API cancel",
+      { flowId },
+    );
+    return false;
+  }
+
+  try {
+    const res = await fetch("https://api.inngest.com/v1/cancellations", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${signingKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        app_id: INNGEST_APP_ID,
+        function_id: INNGEST_FLOW_FUNCTION_ID,
+        started_after: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+        started_before: new Date().toISOString(),
+        if: `event.data.flowId == '${flowId}'`,
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      log.error("Inngest bulk cancel API returned non-OK", {
+        flowId,
+        status: res.status,
+        body: body.slice(0, 500),
+      });
+      return false;
+    }
+
+    const data = (await res.json().catch(() => null)) as Record<
+      string,
+      unknown
+    > | null;
+    log.info("Inngest bulk cancel API succeeded", {
+      flowId,
+      cancellationId: data?.id,
+    });
+    return true;
+  } catch (error) {
+    log.error("Inngest bulk cancel API call failed", {
+      flowId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}
+
 async function assertCanStartBackfill(
   workspaceId: string,
   flowId: string,
 ): Promise<void> {
-  await abandonStaleExecutions(workspaceId, flowId);
+  const abandonedCount = await abandonStaleExecutions(workspaceId, flowId);
+  if (abandonedCount > 0) {
+    log.warn("Abandoned stale executions before starting backfill", {
+      flowId,
+      workspaceId,
+      abandonedCount,
+    });
+  }
 
   const workspaceObjectId = new Types.ObjectId(workspaceId);
   const flowObjectId = new Types.ObjectId(flowId);
@@ -47,6 +117,13 @@ async function assertCanStartBackfill(
 
   if (!running) return;
 
+  const executionAge = running.startedAt
+    ? Date.now() - new Date(running.startedAt).getTime()
+    : undefined;
+  const heartbeatAge = running.lastHeartbeat
+    ? Date.now() - new Date(running.lastHeartbeat).getTime()
+    : undefined;
+
   // If the backfill was paused (or cancelled), an Inngest cancel is already
   // in-flight.  Wait for the worker to finish rather than rejecting — the
   // user expects reset-entity / resume to work immediately after pause.
@@ -60,25 +137,40 @@ async function assertCanStartBackfill(
     flow?.backfillState?.status === "idle";
 
   if (!isPendingCancel) {
+    log.error("Cannot start backfill — execution still running", {
+      flowId,
+      executionId: running._id?.toString(),
+      backfillStatus: flow?.backfillState?.status,
+      executionStartedAt: running.startedAt,
+      executionAgeMs: executionAge,
+      lastHeartbeat: running.lastHeartbeat,
+      heartbeatAgeMs: heartbeatAge,
+    });
     throw new Error(
-      "Cannot start backfill while an execution is still running",
+      `Cannot start backfill while an execution is still running (execution ${running._id?.toString()}, started ${executionAge ? Math.round(executionAge / 1000) + "s ago" : "unknown"}, last heartbeat ${heartbeatAge ? Math.round(heartbeatAge / 1000) + "s ago" : "never"})`,
     );
   }
 
-  // Send cancel (idempotent) and poll until the execution finishes
+  // Send cancel via event (for functions that are actively running steps)
+  // AND via REST API (to release the concurrency lock on ghost functions)
   log.info("Waiting for previous execution to finish before starting", {
     flowId,
     executionId: running._id?.toString(),
     backfillStatus: flow?.backfillState?.status,
+    executionAgeMs: executionAge,
+    heartbeatAgeMs: heartbeatAge,
   });
 
-  await inngest.send({
-    name: "flow.cancel",
-    data: {
-      flowId,
-      executionId: running._id?.toString(),
-    },
-  });
+  await Promise.all([
+    inngest.send({
+      name: "flow.cancel",
+      data: {
+        flowId,
+        executionId: running._id?.toString(),
+      },
+    }),
+    cancelInngestFlowRuns(flowId),
+  ]);
 
   const deadline = Date.now() + CANCEL_WAIT_TIMEOUT_MS;
   while (Date.now() < deadline) {
@@ -87,13 +179,45 @@ async function assertCanStartBackfill(
       _id: running._id,
       status: "running",
     });
-    if (!still) return;
+    if (!still) {
+      log.info("Previous execution finished after cancel signal", {
+        flowId,
+        executionId: running._id?.toString(),
+        waitedMs: CANCEL_WAIT_TIMEOUT_MS - (deadline - Date.now()),
+      });
+      return;
+    }
   }
 
-  log.warn("Cancel wait timed out, force-abandoning stuck execution", {
+  log.error("Cancel wait timed out — force-abandoning stuck execution", {
     flowId,
     executionId: running._id?.toString(),
+    executionStartedAt: running.startedAt,
+    executionAgeMs: executionAge,
+    heartbeatAgeMs: heartbeatAge,
+    cancelWaitTimeoutMs: CANCEL_WAIT_TIMEOUT_MS,
   });
+
+  // Write the error into the execution so it's visible in the UI
+  await FlowExecution.updateOne(
+    { _id: running._id, status: "running" },
+    {
+      $push: {
+        logs: {
+          $each: [
+            {
+              timestamp: new Date(),
+              level: "error",
+              message: `Backfill execution stuck — no heartbeat for ${heartbeatAge ? Math.round(heartbeatAge / 1000) + "s" : "unknown"}. Force-abandoning to allow restart.`,
+              metadata: { flowId, executionId: running._id?.toString() },
+            },
+          ],
+          $slice: -200,
+        },
+      },
+    },
+  );
+
   await abandonStaleExecutions(workspaceId, flowId, { force: true });
 }
 
@@ -202,7 +326,23 @@ export class CdcBackfillService {
           ? scopeFromFlow
           : [];
 
+    log.info("startBackfill: pre-check starting", {
+      flowId,
+      workspaceId,
+      currentBackfillStatus: flow.backfillState?.status,
+      currentRunId: flow.backfillState?.runId,
+      reuseExistingRunId: shouldReuseRunId,
+      entities: effectiveScope.length > 0 ? effectiveScope : "all",
+    });
+    const preCheckStart = Date.now();
     await assertCanStartBackfill(workspaceId, flowId);
+    const preCheckMs = Date.now() - preCheckStart;
+    if (preCheckMs > 5000) {
+      log.warn("startBackfill: pre-check was slow", {
+        flowId,
+        preCheckMs,
+      });
+    }
 
     const runId =
       shouldReuseRunId && flow.backfillState?.runId
@@ -245,8 +385,9 @@ export class CdcBackfillService {
       context: { hasActiveRunLock: false },
     });
 
-    await inngest.send({
-      id: createBackfillTriggerEventId(flowId, runId),
+    const triggerEventId = createBackfillTriggerEventId(flowId, runId);
+    const sendResult = await inngest.send({
+      id: triggerEventId,
       name: "flow.execute",
       data: {
         flowId,
@@ -257,6 +398,13 @@ export class CdcBackfillService {
           ? { backfillEntities: effectiveScope }
           : {}),
       },
+    });
+
+    log.info("Backfill flow.execute event sent to Inngest", {
+      flowId,
+      runId,
+      triggerEventId,
+      inngestEventIds: sendResult?.ids,
     });
 
     return { runId, reusedRunId };

--- a/api/src/sync-cdc/backfill.ts
+++ b/api/src/sync-cdc/backfill.ts
@@ -30,12 +30,13 @@ const CANCEL_WAIT_TIMEOUT_MS = 30_000;
 
 const INNGEST_APP_ID = "mako-sync";
 const INNGEST_FLOW_FUNCTION_ID = `${INNGEST_APP_ID}-flow`;
+const INNGEST_ENTITY_FUNCTION_ID = `${INNGEST_APP_ID}-sync-backfill-entity`;
 
 /**
- * Cancel all running Inngest "flow" function runs for a given flowId via the
- * bulk-cancellation REST API.  This is the only reliable way to release the
- * per-flow concurrency lock when a function is stuck (ghost process after
- * server restart, step timeout, etc.).
+ * Cancel all running Inngest function runs for a given flowId via the
+ * bulk-cancellation REST API.  Cancels both the parent "flow" function and
+ * child "sync-backfill-entity" functions so that restarted backfills don't
+ * get blocked by orphaned children holding the concurrency slot.
  */
 async function cancelInngestFlowRuns(flowId: string): Promise<boolean> {
   const signingKey = process.env.INNGEST_SIGNING_KEY;
@@ -47,48 +48,70 @@ async function cancelInngestFlowRuns(flowId: string): Promise<boolean> {
     return false;
   }
 
-  try {
-    const res = await fetch("https://api.inngest.com/v1/cancellations", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${signingKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        app_id: INNGEST_APP_ID,
-        function_id: INNGEST_FLOW_FUNCTION_ID,
-        started_after: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
-        started_before: new Date().toISOString(),
-        if: `event.data.flowId == '${flowId}'`,
-      }),
-    });
-
-    if (!res.ok) {
-      const body = await res.text().catch(() => "");
-      log.error("Inngest bulk cancel API returned non-OK", {
-        flowId,
-        status: res.status,
-        body: body.slice(0, 500),
+  const functionIds = [INNGEST_FLOW_FUNCTION_ID, INNGEST_ENTITY_FUNCTION_ID];
+  const results = await Promise.allSettled(
+    functionIds.map(async functionId => {
+      const res = await fetch("https://api.inngest.com/v1/cancellations", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${signingKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          app_id: INNGEST_APP_ID,
+          function_id: functionId,
+          started_after: new Date(
+            Date.now() - 24 * 60 * 60 * 1000,
+          ).toISOString(),
+          started_before: new Date().toISOString(),
+          if: `event.data.flowId == '${flowId}'`,
+        }),
       });
-      return false;
-    }
 
-    const data = (await res.json().catch(() => null)) as Record<
-      string,
-      unknown
-    > | null;
-    log.info("Inngest bulk cancel API succeeded", {
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        log.error("Inngest bulk cancel API returned non-OK", {
+          flowId,
+          functionId,
+          status: res.status,
+          body: body.slice(0, 500),
+        });
+        return false;
+      }
+
+      const data = (await res.json().catch(() => null)) as Record<
+        string,
+        unknown
+      > | null;
+      log.info("Inngest bulk cancel API succeeded", {
+        flowId,
+        functionId,
+        cancellationId: data?.id,
+      });
+      return true;
+    }),
+  );
+
+  const allOk = results.every(
+    r => r.status === "fulfilled" && r.value === true,
+  );
+  if (!allOk) {
+    log.warn("Some Inngest bulk cancel calls failed", {
       flowId,
-      cancellationId: data?.id,
+      results: results.map((r, i) => ({
+        functionId: functionIds[i],
+        status: r.status,
+        value: r.status === "fulfilled" ? r.value : undefined,
+        reason:
+          r.status === "rejected"
+            ? r.reason instanceof Error
+              ? r.reason.message
+              : String(r.reason)
+            : undefined,
+      })),
     });
-    return true;
-  } catch (error) {
-    log.error("Inngest bulk cancel API call failed", {
-      flowId,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return false;
   }
+  return allOk;
 }
 
 async function assertCanStartBackfill(


### PR DESCRIPTION
## Summary

- When a backfill restarts, the parent `flowFunction` gets cancelled via `flow.cancel` + bulk API, but its child `syncBackfillEntityFunction` invocations kept running — holding the per-flow concurrency slot (`limit: 1, key: flowId`) and blocking new children from starting. This caused the restarted execution to show only "1 log" in the UI while all actual progress went to the old execution document.
- Add `cancelOn` to `syncBackfillEntityFunction` so it responds to `flow.cancel` events matching the same `flowId`
- Extend `cancelInngestFlowRuns` to bulk-cancel both `mako-sync-flow` (parent) and `mako-sync-sync-backfill-entity` (children) via the Inngest REST API in parallel
- Remove the `finish: "6h"` timeout from the parent flow function to avoid killing long-running backfills

## Test plan

- [ ] Start a backfill, then restart it — verify old child functions are cancelled and new execution shows live logs
- [ ] Verify normal (non-restart) backfills still work end-to-end
- [ ] Verify `flow.cancel` from UI cancels both parent and child functions
- [ ] Check Inngest dashboard to confirm no orphaned `sync-backfill-entity` runs after restart


Made with [Cursor](https://cursor.com)