### PR TITLE
fix(backfill): atomic flush+merge to prevent data loss on crash

### DIFF
--- a/api/src/inngest/functions/sync-entity.ts
+++ b/api/src/inngest/functions/sync-entity.ts
@@ -287,17 +287,6 @@ export const syncBackfillEntityFunction = inngest.createFunction(
         ),
         logger: bulkLogger,
       };
-
-      await step.run(`prepare-staging-${safeEntityStepId}`, async () => {
-        await touchHeartbeat(executionId);
-        logExec(
-          "info",
-          `Preparing staging table for ${entity} (dropping if exists)`,
-          { entity },
-        );
-        await performPrepareStaging(bulkSyncOptions as any);
-      });
-      stepsUsed++;
     }
 
     // ── Chunk loop ───────────────────────────────────────────────────
@@ -497,15 +486,18 @@ export const syncBackfillEntityFunction = inngest.createFunction(
         const tempCount = await getTempCollectionCount(flowId, entity);
         if (tempCount >= 20_000) {
           await step.run(
-            `flush-batch-${safeEntityStepId}-${flushIndex}`,
+            `flush-merge-${safeEntityStepId}-${flushIndex}`,
             async () => {
               await touchHeartbeat(executionId);
               logExec(
                 "info",
-                `Flushing ${entity} buffer batch ${flushIndex} to staging (${tempCount} rows in temp)`,
+                `Flushing ${entity} buffer batch ${flushIndex} to live (${tempCount} rows in temp)`,
                 { entity, flushIndex, tempCount },
               );
+              await performPrepareStaging(bulkSyncOptions as any);
               await performBulkFlush(bulkSyncOptions as any);
+              await performStagingMerge(bulkSyncOptions as any);
+              await performStagingCleanup(bulkSyncOptions as any);
             },
           );
           stepsUsed++;
@@ -526,37 +518,28 @@ export const syncBackfillEntityFunction = inngest.createFunction(
       totalChunks: chunkIndex,
     });
 
-    // ── Flush + merge + cleanup for bulk path ────────────────────────
+    // ── Flush remaining + merge for bulk path ─────────────────────────
     if (useBulkPath && bulkSyncOptions) {
       const finalRowsInTemp = await getTempCollectionCount(flowId, entity);
       if (finalRowsInTemp > 0) {
-        await step.run(`flush-final-${safeEntityStepId}`, async () => {
+        await step.run(`flush-merge-final-${safeEntityStepId}`, async () => {
           await touchHeartbeat(executionId);
           logExec(
             "info",
-            `Flushing ${entity} remaining buffer to staging (${finalRowsInTemp} rows)`,
+            `Flushing ${entity} remaining buffer to live (${finalRowsInTemp} rows)`,
             { entity, tempCount: finalRowsInTemp },
           );
+          await performPrepareStaging(bulkSyncOptions as any);
           await performBulkFlush(bulkSyncOptions as any);
+          await performStagingMerge(bulkSyncOptions as any);
+          await performStagingCleanup(bulkSyncOptions as any);
+          logExec(
+            "info",
+            `✅ ${entity} bulk backfill complete (buffer → Parquet → staging → live)`,
+            { entity },
+          );
         });
       }
-
-      await step.run(`merge-staging-${safeEntityStepId}`, async () => {
-        await touchHeartbeat(executionId);
-        logExec("info", `Merging ${entity} staging table to live`, { entity });
-        await performStagingMerge(bulkSyncOptions as any);
-        logExec("info", `${entity} merged staging to live table`, { entity });
-      });
-
-      await step.run(`cleanup-staging-${safeEntityStepId}`, async () => {
-        await touchHeartbeat(executionId);
-        await performStagingCleanup(bulkSyncOptions as any);
-        logExec(
-          "info",
-          `✅ ${entity} bulk backfill complete (buffer → Parquet → staging → live)`,
-          { entity },
-        );
-      });
 
       if (executionId) {
         try {


### PR DESCRIPTION
## Summary

- Each periodic bulk flush now does an atomic **prepare → flush → merge → cleanup** cycle, landing data in the live BigQuery table immediately instead of accumulating in a staging table
- Removes the top-level `prepare-staging` step that dropped the staging table on every invocation — including checkpoint resumes — destroying data flushed by previous (crashed) invocations
- Collapses the final flush/merge/cleanup from three separate Inngest steps into one atomic step

**Root cause:** When `sync-backfill-entity` was killed by Cloud Run timeout (3600s), the staging table held flushed data that was never merged to live. The next invocation's `prepareStaging` dropped it. For `fr_close`, this caused ~700k records to be lost — only ~62k rows from the final invocation's flushes made it to the live table.

## Test plan

- [ ] Deploy to PR preview and trigger a CDC backfill for a flow with a large entity (e.g. Close `activities:Call`)
- [ ] Verify periodic flush logs now say "to live" instead of "to staging"
- [ ] Verify data appears in the live BigQuery table incrementally (not only at the end)
- [ ] Simulate a kill mid-backfill (e.g. redeploy) and verify previously flushed data survives in the live table
- [ ] Verify checkpoint resume continues from the correct position without re-processing already-merged rows


Made with [Cursor](https://cursor.com)