### PR TITLE
fix(backfill): rescue orphaned staging data before dropping on resume

### DIFF
--- a/api/src/inngest/functions/sync-entity.ts
+++ b/api/src/inngest/functions/sync-entity.ts
@@ -290,11 +290,22 @@ export const syncBackfillEntityFunction = inngest.createFunction(
 
       await step.run(`prepare-staging-${safeEntityStepId}`, async () => {
         await touchHeartbeat(executionId);
-        logExec(
-          "info",
-          `Preparing staging table for ${entity} (dropping if exists)`,
-          { entity },
-        );
+
+        // Rescue orphaned staging data from a previously crashed invocation
+        // before dropping the staging table.
+        try {
+          const rescued = await performStagingMerge(bulkSyncOptions as any);
+          if (rescued.written > 0) {
+            logExec(
+              "info",
+              `Rescued ${rescued.written} orphaned staging rows into live table before fresh start`,
+              { entity, rescued: rescued.written },
+            );
+          }
+        } catch {
+          // Staging table may not exist — that's fine
+        }
+
         await performPrepareStaging(bulkSyncOptions as any);
       });
       stepsUsed++;


### PR DESCRIPTION
## Summary

- Before the `prepare-staging` step drops the BQ staging table, it now attempts to merge any existing staging rows into the live table first
- This rescues data from previously crashed invocations that flushed to staging but were killed before merging to live
- If the staging table doesn't exist (normal case), the rescue merge silently no-ops

**Context:** This is the safety-net companion to #307 (atomic flush+merge). Even with atomic flushes, there's a tiny window where a crash between `loadStagingFromParquet` and `mergeFromStaging` within a single step could orphan data. This rescue merge catches that edge case.

## Test plan

- [ ] Deploy to PR preview and trigger a CDC backfill
- [ ] Verify the rescue merge runs on first invocation (should no-op with no pre-existing staging table)
- [ ] Simulate a crash after a flush but before merge (e.g. kill the process), then restart — verify the rescued rows appear in the live table
- [ ] Verify normal backfill completion is unaffected


Made with [Cursor](https://cursor.com)