### PR TITLE
feat: adaptive DuckDB backfill batching to prevent OOM on large text entities

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -485,7 +485,7 @@ jobs:
             --set-env-vars OPENAI_API_KEY=${OPENAI_API_KEY} \
             --set-env-vars SYNC_BULK_FLUSH_BATCH_SIZE=10000 \
             --set-env-vars SYNC_BULK_MONGO_TO_PARQUET_CHUNK=200 \
-            --set-env-vars SYNC_PARQUET_DUCKDB_MEMORY_LIMIT_MB=128 \
+            --set-env-vars SYNC_PARQUET_DUCKDB_MEMORY_LIMIT_MB=512 \
             --set-env-vars SYNC_PARQUET_DUCKDB_THREADS=1 \
             --set-env-vars RATE_LIMIT_MAX_REQUESTS=${RATE_LIMIT_MAX_REQUESTS} \
             --set-env-vars RATE_LIMIT_WINDOW_MS=${RATE_LIMIT_WINDOW_MS} \
@@ -823,7 +823,7 @@ jobs:
             --set-env-vars WEBHOOK_CDC_PROCESS_CONCURRENCY=10 \
             --set-env-vars SYNC_BULK_FLUSH_BATCH_SIZE=10000 \
             --set-env-vars SYNC_BULK_MONGO_TO_PARQUET_CHUNK=200 \
-            --set-env-vars SYNC_PARQUET_DUCKDB_MEMORY_LIMIT_MB=128 \
+            --set-env-vars SYNC_PARQUET_DUCKDB_MEMORY_LIMIT_MB=512 \
             --set-env-vars SYNC_PARQUET_DUCKDB_THREADS=1 \
             --set-env-vars RATE_LIMIT_MAX_REQUESTS=${RATE_LIMIT_MAX_REQUESTS} \
             --set-env-vars RATE_LIMIT_WINDOW_MS=${RATE_LIMIT_WINDOW_MS} \

--- a/INNGEST_DEV_CONFIG.md
+++ b/INNGEST_DEV_CONFIG.md
@@ -91,6 +91,34 @@ DASHBOARD_ARTIFACT_PREFIX=dashboard-artifacts/local-<your-name>
 GOOGLE_APPLICATION_CREDENTIALS=/absolute/path/to/dev-service-account.json
 ```
 
+## Sync / DuckDB Parquet Tuning
+
+The backfill pipeline flushes buffered rows from a MongoDB temp collection into
+Parquet files via DuckDB, then loads them into the destination (BigQuery,
+ClickHouse, etc.). Several environment variables control memory and batch sizing:
+
+| Variable | Default | Description |
+|---|---|---|
+| `SYNC_PARQUET_DUCKDB_MEMORY_LIMIT_MB` | `512` | DuckDB per-instance memory cap. Raise if entities contain very large text (e.g. meeting notes). |
+| `SYNC_PARQUET_DUCKDB_THREADS` | `1` | DuckDB thread count. Keep at 1 to minimize peak memory. |
+| `SYNC_BULK_FLUSH_BATCH_SIZE` | `10000` | Max rows per Parquet file in the bulk flush loop. |
+| `SYNC_BULK_FLUSH_MIN_BATCH_SIZE` | `100` | Floor for adaptive batch shrinking (see below). |
+| `SYNC_BULK_MONGO_TO_PARQUET_CHUNK` | `200` | Rows per DuckDB `INSERT` micro-batch from Mongo cursor. |
+
+### Adaptive batch sizing
+
+When a Parquet build fails with a DuckDB memory error (e.g. `failed to pin block`),
+the flush loop automatically halves the batch size and retries with the same rows.
+It continues halving down to `SYNC_BULK_FLUSH_MIN_BATCH_SIZE`. If the minimum
+still fails, the error is surfaced to the Inngest step for retry/alerting.
+
+After 3 consecutive successful flushes at a reduced size, the batch size doubles
+back toward `SYNC_BULK_FLUSH_BATCH_SIZE` so throughput recovers for normal data.
+
+This means entities with unusually large payloads (long meeting notes, embedded
+documents) will self-heal without operator intervention, while normal entities
+continue at full batch throughput.
+
 ## Environment summary
 
 | Environment    | Artifact Store | Artifact Prefix                         | Inngest Routing           | Schedulers             |

--- a/api/src/sync/sync-orchestrator.ts
+++ b/api/src/sync/sync-orchestrator.ts
@@ -19,6 +19,7 @@ import {
 import { createDestinationWriter } from "../services/destination-writer.service";
 import {
   buildParquetFromBatches,
+  isDuckDBMemoryError,
   type FieldMeta,
 } from "../utils/streaming-parquet-builder";
 import { Db, Collection } from "mongodb";
@@ -970,6 +971,12 @@ const FLUSH_BATCH_SIZE = resolvePositiveIntEnv(
   10_000,
 );
 
+/** Absolute minimum rows per parquet flush — below this we surface the OOM error. */
+const MIN_FLUSH_BATCH_SIZE = resolvePositiveIntEnv(
+  process.env.SYNC_BULK_FLUSH_MIN_BATCH_SIZE,
+  100,
+);
+
 /** Rows passed per DuckDB insertBatch from Mongo (parquet builder micro-chunks SQL). */
 const MONGO_TO_PARQUET_CHUNK = resolvePositiveIntEnv(
   process.env.SYNC_BULK_MONGO_TO_PARQUET_CHUNK,
@@ -1006,65 +1013,116 @@ async function flushBulkBuffer(
   logger?: SyncLogger,
   schemaFields?: FieldMeta[],
 ): Promise<{ flushed: number }> {
-  const totalCount = await tempCollection.countDocuments();
-  if (totalCount === 0) return { flushed: 0 };
+  const initialCount = await tempCollection.countDocuments();
+  if (initialCount === 0) return { flushed: 0 };
 
-  const totalBatches = Math.ceil(totalCount / FLUSH_BATCH_SIZE);
+  let currentBatchSize = FLUSH_BATCH_SIZE;
   let totalFlushed = 0;
+  let batchNum = 0;
 
   logger?.log(
     "info",
-    `Flushing ${entity} buffer to staging (${totalCount.toLocaleString()} rows in ${totalBatches} batch${totalBatches > 1 ? "es" : ""})`,
+    `Flushing ${entity} buffer to staging (${initialCount.toLocaleString()} rows, starting batch size ${currentBatchSize.toLocaleString()})`,
     {
       entity,
-      totalCount,
-      totalBatches,
-      batchSize: FLUSH_BATCH_SIZE,
+      totalCount: initialCount,
+      batchSize: currentBatchSize,
+      minBatchSize: MIN_FLUSH_BATCH_SIZE,
       mongoStreamChunk: MONGO_TO_PARQUET_CHUNK,
       memoryBefore: syncMemorySnapshot(),
     },
   );
 
   const DELETE_CHUNK = 2000;
+  const CONSECUTIVE_OK_TO_GROW = 3;
+  let consecutiveSuccesses = 0;
 
-  for (let batchNum = 0; batchNum < totalBatches; batchNum++) {
+  let remaining = await tempCollection.countDocuments();
+  while (remaining > 0) {
+    batchNum++;
+    const effectiveBatchSize = Math.min(currentBatchSize, remaining);
+
     let docIdChunks: unknown[][] = [];
     let currentChunk: unknown[] = [];
-    const cursor = tempCollection
-      .find({}, { projection: { _bulkRunId: 0 } })
-      .sort({ _id: 1 })
-      .limit(FLUSH_BATCH_SIZE);
 
     const tParquetStart = Date.now();
 
-    const parquet = await buildParquetFromBatches({
-      filenameBase: `backfill-${entity}`,
-      fields: schemaFields,
-      streamBatches: async insertBatch => {
-        let buffer: Record<string, unknown>[] = [];
-        for await (const doc of cursor) {
-          const d = doc as Record<string, unknown>;
-          const { _id, ...rest } = d;
-          currentChunk.push(_id);
-          if (currentChunk.length >= DELETE_CHUNK) {
+    let parquet;
+    try {
+      parquet = await buildParquetFromBatches({
+        filenameBase: `backfill-${entity}`,
+        fields: schemaFields,
+        streamBatches: async insertBatch => {
+          const cursor = tempCollection
+            .find({}, { projection: { _bulkRunId: 0 } })
+            .sort({ _id: 1 })
+            .limit(effectiveBatchSize);
+
+          let buffer: Record<string, unknown>[] = [];
+          for await (const doc of cursor) {
+            const d = doc as Record<string, unknown>;
+            const { _id, ...rest } = d;
+            currentChunk.push(_id);
+            if (currentChunk.length >= DELETE_CHUNK) {
+              docIdChunks.push(currentChunk);
+              currentChunk = [];
+            }
+            buffer.push(rest);
+            if (buffer.length >= MONGO_TO_PARQUET_CHUNK) {
+              await insertBatch(buffer);
+              buffer = [];
+            }
+          }
+          if (buffer.length > 0) {
+            await insertBatch(buffer);
+          }
+          if (currentChunk.length > 0) {
             docIdChunks.push(currentChunk);
             currentChunk = [];
           }
-          buffer.push(rest);
-          if (buffer.length >= MONGO_TO_PARQUET_CHUNK) {
-            await insertBatch(buffer);
-            buffer = [];
-          }
+        },
+      });
+    } catch (err) {
+      if (isDuckDBMemoryError(err)) {
+        const shrunkSize = Math.max(
+          MIN_FLUSH_BATCH_SIZE,
+          Math.floor(currentBatchSize / 2),
+        );
+
+        if (
+          shrunkSize <= MIN_FLUSH_BATCH_SIZE &&
+          currentBatchSize <= MIN_FLUSH_BATCH_SIZE
+        ) {
+          logger?.log(
+            "error",
+            `${entity} flush: DuckDB memory error at minimum batch size (${currentBatchSize}), cannot shrink further`,
+            {
+              entity,
+              batchSize: currentBatchSize,
+              minBatchSize: MIN_FLUSH_BATCH_SIZE,
+              error: err instanceof Error ? err.message : String(err),
+            },
+          );
+          throw err;
         }
-        if (buffer.length > 0) {
-          await insertBatch(buffer);
-        }
-        if (currentChunk.length > 0) {
-          docIdChunks.push(currentChunk);
-          currentChunk = [];
-        }
-      },
-    });
+
+        logger?.log(
+          "warn",
+          `${entity} flush batch ${batchNum}: DuckDB memory error, reducing batch size from ${currentBatchSize} to ${shrunkSize} and retrying`,
+          {
+            entity,
+            previousBatchSize: currentBatchSize,
+            newBatchSize: shrunkSize,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        );
+        currentBatchSize = shrunkSize;
+        consecutiveSuccesses = 0;
+        batchNum--;
+        continue;
+      }
+      throw err;
+    }
 
     const parquetMs = Date.now() - tParquetStart;
 
@@ -1072,7 +1130,7 @@ async function flushBulkBuffer(
       logger?.log(
         "warn",
         `${entity} flush: empty parquet (possible race), stopping flush loop`,
-        { entity, batch: batchNum + 1, totalBatches },
+        { entity, batch: batchNum },
       );
       break;
     }
@@ -1098,8 +1156,8 @@ async function flushBulkBuffer(
           const backoffMs = Math.min(1000 * 2 ** (attempt - 1), 15_000);
           logger?.log(
             "warn",
-            `${entity} flush batch ${batchNum + 1}/${totalBatches} load failed (attempt ${attempt}/${LOAD_MAX_RETRIES}), retrying in ${backoffMs}ms`,
-            { entity, batch: batchNum + 1, attempt, error: String(err) },
+            `${entity} flush batch ${batchNum} load failed (attempt ${attempt}/${LOAD_MAX_RETRIES}), retrying in ${backoffMs}ms`,
+            { entity, batch: batchNum, attempt, error: String(err) },
           );
           await new Promise(r => setTimeout(r, backoffMs));
         }
@@ -1121,30 +1179,52 @@ async function flushBulkBuffer(
       global.gc();
     }
 
+    consecutiveSuccesses++;
+    if (
+      consecutiveSuccesses >= CONSECUTIVE_OK_TO_GROW &&
+      currentBatchSize < FLUSH_BATCH_SIZE
+    ) {
+      const grownSize = Math.min(currentBatchSize * 2, FLUSH_BATCH_SIZE);
+      logger?.log(
+        "info",
+        `${entity} flush: ${consecutiveSuccesses} consecutive successes, growing batch size from ${currentBatchSize} to ${grownSize}`,
+        {
+          entity,
+          previousBatchSize: currentBatchSize,
+          newBatchSize: grownSize,
+        },
+      );
+      currentBatchSize = grownSize;
+      consecutiveSuccesses = 0;
+    }
+
     logger?.log(
       "info",
-      `📦 ${entity} flush ${batchNum + 1}/${totalBatches} — ${batchRows.toLocaleString()} rows (${totalFlushed.toLocaleString()}/${totalCount.toLocaleString()}) [parquet ${parquetMs}ms, load ${loadMs}ms]`,
+      `📦 ${entity} flush batch ${batchNum} — ${batchRows.toLocaleString()} rows (${totalFlushed.toLocaleString()}/${initialCount.toLocaleString()}) [parquet ${parquetMs}ms, load ${loadMs}ms, batchSize ${effectiveBatchSize}]`,
       {
         entity,
-        batch: batchNum + 1,
-        totalBatches,
+        batch: batchNum,
         batchRows,
         totalFlushed,
-        totalCount,
+        totalCount: initialCount,
+        effectiveBatchSize,
         durationParquetMs: parquetMs,
         durationLoadStagingMs: loadMs,
         memory: syncMemorySnapshot(),
       },
     );
+
+    remaining = await tempCollection.countDocuments();
   }
 
   logger?.log(
     "info",
-    `✅ ${entity} buffer fully flushed to staging (${totalFlushed.toLocaleString()} rows)`,
+    `✅ ${entity} buffer fully flushed to staging (${totalFlushed.toLocaleString()} rows in ${batchNum} batch${batchNum !== 1 ? "es" : ""})`,
     {
       entity,
       totalFlushed,
-      batches: totalBatches,
+      batches: batchNum,
+      finalBatchSize: currentBatchSize,
       memory: syncMemorySnapshot(),
     },
   );

--- a/api/src/utils/streaming-parquet-builder.ts
+++ b/api/src/utils/streaming-parquet-builder.ts
@@ -8,7 +8,7 @@ const logger = loggers.api("streaming-parquet-builder");
 
 /** Max rows per INSERT VALUES clause to cap peak JS heap (SQL string materialization). */
 const INSERT_MICRO_BATCH_ROWS = 120;
-const DEFAULT_DUCKDB_MEMORY_LIMIT_MB = 128;
+const DEFAULT_DUCKDB_MEMORY_LIMIT_MB = 512;
 const DEFAULT_DUCKDB_THREADS = 1;
 
 function parsePositiveInt(
@@ -180,6 +180,25 @@ function escapeDuckDBValue(
 
 function escapeIdentifier(name: string): string {
   return `"${name.replace(/"/g, '""')}"`;
+}
+
+// ---------------------------------------------------------------------------
+// Error classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when the error looks like a DuckDB out-of-memory / memory-limit
+ * failure. Used by callers that want to retry with a smaller batch size.
+ */
+export function isDuckDBMemoryError(err: unknown): boolean {
+  const msg =
+    err instanceof Error ? err.message : typeof err === "string" ? err : "";
+  return (
+    msg.includes("failed to pin block") ||
+    msg.includes("could not allocate") ||
+    msg.includes("Out of Memory") ||
+    msg.includes("memory_limit")
+  );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Flow executions fail with `TransactionContext Error: Failed to commit: failed to pin block of size 256.0 KiB (122.0 MiB/122.0 MiB used)` when syncing entities that contain very large text fields (e.g. meetings with long notes). The DuckDB instance used to build Parquet files was capped at 128 MB, which is insufficient for rows with large VARCHAR payloads.

## Changes

### 1. Raise DuckDB memory default (128 MB -> 512 MB)

- Updated `DEFAULT_DUCKDB_MEMORY_LIMIT_MB` in `api/src/utils/streaming-parquet-builder.ts`
- Updated `SYNC_PARQUET_DUCKDB_MEMORY_LIMIT_MB` from `128` to `512` in both preview and production deploy paths in `.github/workflows/deploy-app.yml`

### 2. Adaptive flush batch sizing

Refactored `flushBulkBuffer` in `api/src/sync/sync-orchestrator.ts` to dynamically adjust batch size on DuckDB memory errors:

- On OOM, halves the batch size and retries the same rows (no data loss since rows are only deleted from the temp collection after successful staging load)
- Continues halving down to a configurable floor (`SYNC_BULK_FLUSH_MIN_BATCH_SIZE`, default 100)
- If the minimum batch size still fails, surfaces the error for Inngest retry/alerting
- After 3 consecutive successes at a reduced size, doubles back toward the configured max to restore throughput
- Converted the flush loop from a fixed `totalBatches` counter to a `while (remaining > 0)` pattern for accurate tracking

### 3. DuckDB OOM error classifier

Added `isDuckDBMemoryError()` to `streaming-parquet-builder.ts` that detects DuckDB memory-related errors by message pattern matching (`failed to pin block`, `could not allocate`, `Out of Memory`, `memory_limit`).

### 4. Documentation

Added a "Sync / DuckDB Parquet Tuning" section to `INNGEST_DEV_CONFIG.md` documenting all tuning knobs and the adaptive batching behavior.

## New environment variables

| Variable | Default | Description |
|---|---|---|
| `SYNC_BULK_FLUSH_MIN_BATCH_SIZE` | `100` | Floor for adaptive batch shrinking |

## How it works

```
Start with SYNC_BULK_FLUSH_BATCH_SIZE (10,000)
  |
  v
Build Parquet from batch
  |
  +-- Success --> load staging, delete from temp, check if more rows
  |                 |
  |                 +-- 3 consecutive successes at reduced size? --> double batch size (up to max)
  |
  +-- DuckDB OOM --> halve batch size (down to min), retry same rows
                       |
                       +-- Already at minimum? --> surface error
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e51770f5-9d5f-411b-842f-25ca68339e12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e51770f5-9d5f-411b-842f-25ca68339e12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

