### PR TITLE
refactor: extract agent runtime modules from Chat.tsx

### DIFF
--- a/api/src/agent-lib/prompts/universal.ts
+++ b/api/src/agent-lib/prompts/universal.ts
@@ -15,7 +15,7 @@ When working with consoles, your primary goal is to provide a working, executabl
 * **Name Your Work:** When using \`modify_console\`, always include a descriptive \`title\` (e.g. "Monthly Revenue by Region", "User Retention Cohorts"). This is especially important when the current title is generic (like "New Console"). The title is used as the default save name.
 * **Read Before Write:** ALWAYS call \`read_console\` before \`modify_console\` to get the complete, current content. The injected context may be truncated or stale if the user edited it.
 * **Use Injected Context:** The "Open Tabs" and "Available Connections" sections already list your workspace state — do NOT call \`list_connections\` or \`list_open_consoles\` unless you suspect the context is stale (e.g., after creating or closing tabs).
-* **Test Before Deliver:** Test queries with \`execute_query\` first (60s agent timeout). If timeout: the query may be valid but slow—adapt (add LIMIT, narrow date range) for testing, or write the full query to console and use \`run_console\`. After \`modify_console\`, always call \`run_console\` to show results immediately—don't make the user click Run.
+* **Test Before Deliver:** Test queries with the engine-specific execute tool first (\`sql_execute_query\` for SQL, \`mongo_execute_query\` for MongoDB). If timeout: the query may be valid but slow—adapt (add LIMIT, narrow date range) for testing, or write the full query to console and use \`run_console\`. After \`modify_console\`, always call \`run_console\` to show results immediately—don't make the user click Run.
 * **Safety:** Limit results to 500 rows/docs unless the user explicitly requests otherwise.
 * **Preserve User Work:** Never overwrite a console with valuable content unless explicitly asked. Create a new console instead.
 
@@ -40,7 +40,7 @@ When working with consoles, your primary goal is to provide a working, executabl
 
 **Step 4: Execute**
 - Discover schema if needed (only if you don't know the structure)
-- Draft query, test with execute tool, fix errors
+- Draft query, test with \`sql_execute_query\` or \`mongo_execute_query\`, fix errors
 - \`modify_console\` with the final working query
 
 **Step 5: Explain**

--- a/api/src/agent-lib/tools/dashboard-tools-client.ts
+++ b/api/src/agent-lib/tools/dashboard-tools-client.ts
@@ -141,11 +141,6 @@ const setTimeDimensionSchema = z.object({
     .describe("The datetime column to use as default time dimension"),
 });
 
-const suggestChartsSchema = z.object({
-  dashboardId: z.string().describe("Dashboard ID"),
-  dataSourceId: z.string().describe("Data source to analyze"),
-});
-
 const importConsoleAsDataSourceSchema = z.object({
   dashboardId: z
     .string()
@@ -364,13 +359,6 @@ export const clientDashboardTools = {
     description:
       "Legacy alias for preview_data_source. Runs SQL against the loaded DuckDB table.",
     inputSchema: getDataPreviewSchema,
-  },
-  suggest_charts: {
-    description:
-      "Analyze the data sources and suggest 3-5 chart configurations. " +
-      "Returns suggestions without adding them to the dashboard. " +
-      "The user can then choose which ones to add.",
-    inputSchema: suggestChartsSchema,
   },
   add_global_filter: {
     description:

--- a/api/src/agents/dashboard/prompt.ts
+++ b/api/src/agents/dashboard/prompt.ts
@@ -53,7 +53,6 @@ Before making any changes to a dashboard, you MUST call \`enter_edit_mode\` with
 * \`run_data_source_query\` — Execute a data source query and stream fresh draft data into DuckDB. Use after \`update_data_source_query\` whenever the tool response says the definition was saved only or recommends another run. Automatically recovers if DuckDB crashes. Requires \`dashboardId\`.
 * \`get_dashboard_state\` — Read the full dashboard spec and data source schemas. Requires \`dashboardId\`.
 * \`preview_data_source\` — Run a SQL query against local DuckDB data. Requires \`dashboardId\`.
-* \`suggest_charts\` — Analyze data and suggest 3-5 chart configurations. Requires \`dashboardId\`.
 
 **Console Discovery:**
 * \`search_consoles\` — Search saved consoles by name or content to find their IDs for use as data sources
@@ -352,15 +351,11 @@ layouts: { lg: { x: 0, y: 0, w: 4, h: 4 } }
  * Build runtime context string describing the current dashboard state.
  * Injected as a second system message so the LLM knows what it's working with.
  *
- * Accepts whatever the client sends — no restrictive type to maintain.
  * Renders a compact markdown overview; full details available via get_dashboard_state.
  */
 export function buildDashboardRuntimeContext(context: AgentContext): string {
-  const raw = context as unknown as Record<string, unknown>;
-  const openDashboards = raw.openDashboards as
-    | Array<{ id: string; title: string; isActive: boolean }>
-    | undefined;
-  const dc = raw.activeDashboardContext as Record<string, any> | undefined;
+  const openDashboards = context.openDashboards;
+  const dc = context.activeDashboardContext as Record<string, any> | undefined;
 
   if (!openDashboards?.length && !dc) return "";
 

--- a/api/src/agents/types.ts
+++ b/api/src/agents/types.ts
@@ -65,6 +65,12 @@ export interface AgentContext {
     connectionId?: string;
     databaseName?: string;
   }>;
+  /** Lightweight summary of open dashboards for explicit dashboard selection */
+  openDashboards?: Array<{
+    id: string;
+    title: string;
+    isActive: boolean;
+  }>;
   /** Database connections in workspace */
   databases?: Array<{
     id: string;

--- a/api/src/agents/unified/prompt.ts
+++ b/api/src/agents/unified/prompt.ts
@@ -52,9 +52,10 @@ the existing artifact. This applies equally to consoles and dashboards.
 
 ## Tool Availability
 
-All tools are always registered, but client-side tools (console editing, dashboard widgets,
-flow form fields) operate on the active UI tab. If no dashboard is open, dashboard widget
-tools will fail. Use \`create_console\` or \`create_dashboard\` to open a new tab when needed.
+All tools are always registered. Console editing and flow form tools operate on the active
+UI tab. Dashboard tools require an explicit \`dashboardId\`; use \`list_open_dashboards\`
+to get the current IDs and pass that ID on every dashboard tool call. If no dashboard is
+open, use \`create_dashboard\` or \`open_dashboard\` first.
 
 When you create or modify source queries, use the source connection type and SQL dialect.
 When you create or modify dashboard widgets, the widget \`localSql\` always runs in DuckDB.
@@ -165,10 +166,7 @@ function buildConsoleContext(context: AgentContext): string[] {
 
 function buildDashboardContext(context: AgentContext): string[] {
   const parts: string[] = [];
-  const raw = context as unknown as Record<string, unknown>;
-  const openDashboards = raw.openDashboards as
-    | Array<{ id: string; title: string; isActive: boolean }>
-    | undefined;
+  const openDashboards = context.openDashboards;
   const dashboard = context.activeDashboardContext;
 
   if (openDashboards && openDashboards.length > 0) {
@@ -375,11 +373,7 @@ export function buildCurrentScreenContext(context: AgentContext): string {
   sections.push(...buildConsoleContext(context));
   sections.push("");
 
-  const rawCtx = context as unknown as Record<string, unknown>;
-  if (
-    context.activeDashboardContext ||
-    (rawCtx.openDashboards as unknown[] | undefined)?.length
-  ) {
+  if (context.activeDashboardContext || context.openDashboards?.length) {
     sections.push(...buildDashboardContext(context));
     sections.push("");
   }

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -143,12 +143,19 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
     databaseName?: string;
   }
 
+  interface OpenDashboardContext {
+    id: string;
+    title: string;
+    isActive: boolean;
+  }
+
   const {
     messages,
     chatId,
     workspaceId,
     openConsoles,
     openTabs,
+    openDashboards,
     consoleId,
     modelId,
     activeConsoleResults,
@@ -165,6 +172,7 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
     workspaceId?: string;
     openConsoles?: OpenConsoleContext[];
     openTabs?: OpenTabContext[];
+    openDashboards?: OpenDashboardContext[];
     consoleId?: string;
     modelId?: string;
     activeConsoleResults?: ActiveConsoleResults;
@@ -413,6 +421,17 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
     }
   }
 
+  const dashboardContext =
+    activeView === "dashboard"
+      ? {
+          openDashboards,
+          activeDashboardContext,
+        }
+      : {
+          openDashboards: undefined,
+          activeDashboardContext: undefined,
+        };
+
   // Build agent context
   const agentContext: AgentContext = {
     workspaceId,
@@ -421,6 +440,7 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
     consoles: enrichedConsoles,
     consoleId,
     openTabs,
+    openDashboards: dashboardContext.openDashboards,
     databases: workspaceDatabases.map(db => ({
       id: db._id.toString(),
       name: db.name,
@@ -432,7 +452,7 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
     selfDirective,
     consoleHints,
     activeConsoleResults,
-    activeDashboardContext,
+    activeDashboardContext: dashboardContext.activeDashboardContext,
     toolExecutionContext,
   };
 

--- a/app/src/agent-runtime/client-tool-manifest.test.ts
+++ b/app/src/agent-runtime/client-tool-manifest.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { UNIVERSAL_PROMPT_V2 } from "../../../api/src/agent-lib/prompts/universal";
+import { clientChartTools } from "../../../api/src/agent-lib/tools/chart-tools-client";
+import { clientConsoleTools } from "../../../api/src/agent-lib/tools/console-tools-client";
+import { clientDashboardTools } from "../../../api/src/agent-lib/tools/dashboard-tools-client";
+import { buildCurrentScreenContext } from "../../../api/src/agents/unified/prompt";
+import {
+  AGENT_TOOL_MANIFEST,
+  type AgentToolName,
+  type AgentToolManifestEntry,
+} from "./client-tool-manifest";
+
+function manifestKeysFor(
+  predicate: (entry: AgentToolManifestEntry) => boolean,
+): string[] {
+  return (
+    Object.entries(AGENT_TOOL_MANIFEST) as Array<
+      [AgentToolName, AgentToolManifestEntry]
+    >
+  )
+    .filter(([, entry]) => predicate(entry))
+    .map(([toolName]) => toolName)
+    .sort();
+}
+
+describe("client tool manifest contracts", () => {
+  it("matches the console client tool schema keys", () => {
+    expect(
+      manifestKeysFor(toolName => {
+        return toolName.execution === "client" && toolName.domain === "console";
+      }),
+    ).toEqual(Object.keys(clientConsoleTools).sort());
+  });
+
+  it("matches the dashboard client executor schema keys", () => {
+    expect(
+      manifestKeysFor(toolName => {
+        return (
+          toolName.execution === "client" &&
+          toolName.clientExecutor === "dashboard"
+        );
+      }),
+    ).toEqual(Object.keys(clientDashboardTools).sort());
+  });
+
+  it("matches the chart client tool schema keys", () => {
+    expect(
+      manifestKeysFor(toolName => {
+        return toolName.execution === "client" && toolName.domain === "chart";
+      }),
+    ).toEqual(Object.keys(clientChartTools).sort());
+  });
+
+  it("keeps the console prompt on engine-specific execute tools", () => {
+    expect(UNIVERSAL_PROMPT_V2).toContain("sql_execute_query");
+    expect(UNIVERSAL_PROMPT_V2).toContain("mongo_execute_query");
+    expect(UNIVERSAL_PROMPT_V2).not.toContain("`execute_query`");
+  });
+
+  it("renders open dashboards from the typed context contract", () => {
+    const context = buildCurrentScreenContext({
+      workspaceId: "ws_1",
+      activeView: "dashboard",
+      openDashboards: [
+        { id: "dash_1", title: "Revenue Dashboard", isActive: true },
+      ],
+      activeDashboardContext: {
+        dashboardId: "dash_1",
+        title: "Revenue Dashboard",
+        dataSources: [],
+        widgets: [],
+        crossFilterEnabled: true,
+      },
+    } as any);
+
+    expect(context).toContain("### Open Dashboards");
+    expect(context).toContain("Revenue Dashboard");
+    expect(context).toContain("dash_1");
+  });
+});

--- a/app/src/agent-runtime/client-tool-manifest.ts
+++ b/app/src/agent-runtime/client-tool-manifest.ts
@@ -1,0 +1,537 @@
+export type ToolIconKey =
+  | "pencil"
+  | "plus"
+  | "eye"
+  | "list"
+  | "link"
+  | "external-link"
+  | "play"
+  | "database"
+  | "table"
+  | "search"
+  | "bar-chart"
+  | "download"
+  | "trash"
+  | "filter"
+  | "clock"
+  | "brain"
+  | "shield-check"
+  | "help-circle";
+
+export type AgentToolDomain =
+  | "console"
+  | "chart"
+  | "dashboard"
+  | "flow"
+  | "search"
+  | "memory"
+  | "database";
+
+export type ClientToolExecutor = "console" | "dashboard" | "flow";
+
+export interface ToolUiConfig {
+  getLabel: (input?: unknown) => string;
+  icon: ToolIconKey;
+  preview?: { field: string; language: string };
+}
+
+export interface AgentToolManifestEntry extends ToolUiConfig {
+  domain: AgentToolDomain;
+  execution: "client" | "server";
+  clientExecutor?: ClientToolExecutor;
+  longRunning?: boolean;
+}
+
+export const AGENT_TOOL_MANIFEST = {
+  modify_console: {
+    domain: "console",
+    execution: "client",
+    clientExecutor: "console",
+    getLabel: input => {
+      const action = (input as Record<string, unknown>)?.action;
+      return action === "patch" ? "Patching console" : "Editing console";
+    },
+    icon: "pencil",
+    preview: { field: "content", language: "sql" },
+  },
+  create_console: {
+    domain: "console",
+    execution: "client",
+    clientExecutor: "console",
+    getLabel: input => {
+      const title = (input as Record<string, unknown>)?.title;
+      return title ? `Creating "${title}"` : "Creating console";
+    },
+    icon: "plus",
+    preview: { field: "content", language: "sql" },
+  },
+  read_console: {
+    domain: "console",
+    execution: "client",
+    clientExecutor: "console",
+    getLabel: () => "Reading console",
+    icon: "eye",
+  },
+  list_open_consoles: {
+    domain: "console",
+    execution: "client",
+    clientExecutor: "console",
+    getLabel: () => "Listing open consoles",
+    icon: "list",
+  },
+  set_console_connection: {
+    domain: "console",
+    execution: "client",
+    clientExecutor: "console",
+    getLabel: () => "Setting connection",
+    icon: "link",
+  },
+  open_console: {
+    domain: "console",
+    execution: "client",
+    clientExecutor: "console",
+    longRunning: true,
+    getLabel: () => "Opening console",
+    icon: "external-link",
+  },
+  run_console: {
+    domain: "console",
+    execution: "client",
+    clientExecutor: "console",
+    longRunning: true,
+    getLabel: () => "Executing console query",
+    icon: "play",
+  },
+  sql_execute_query: {
+    domain: "database",
+    execution: "server",
+    getLabel: () => "Executing SQL query",
+    icon: "play",
+    preview: { field: "query", language: "sql" },
+  },
+  sql_list_connections: {
+    domain: "database",
+    execution: "server",
+    getLabel: () => "Listing SQL connections",
+    icon: "database",
+  },
+  sql_list_databases: {
+    domain: "database",
+    execution: "server",
+    getLabel: () => "Listing databases",
+    icon: "database",
+  },
+  sql_list_tables: {
+    domain: "database",
+    execution: "server",
+    getLabel: input => {
+      const db = (input as Record<string, unknown>)?.database;
+      return db ? `Listing tables in ${db}` : "Listing tables";
+    },
+    icon: "table",
+  },
+  sql_inspect_table: {
+    domain: "database",
+    execution: "server",
+    getLabel: input => {
+      const table = (input as Record<string, unknown>)?.table;
+      return table ? `Inspecting ${table}` : "Inspecting table";
+    },
+    icon: "search",
+  },
+  mongo_execute_query: {
+    domain: "database",
+    execution: "server",
+    getLabel: () => "Executing MongoDB query",
+    icon: "play",
+    preview: { field: "query", language: "javascript" },
+  },
+  mongo_list_connections: {
+    domain: "database",
+    execution: "server",
+    getLabel: () => "Listing MongoDB connections",
+    icon: "database",
+  },
+  mongo_list_databases: {
+    domain: "database",
+    execution: "server",
+    getLabel: () => "Listing databases",
+    icon: "database",
+  },
+  mongo_list_collections: {
+    domain: "database",
+    execution: "server",
+    getLabel: input => {
+      const db = (input as Record<string, unknown>)?.databaseName;
+      return db ? `Listing collections in ${db}` : "Listing collections";
+    },
+    icon: "table",
+  },
+  mongo_inspect_collection: {
+    domain: "database",
+    execution: "server",
+    getLabel: input => {
+      const coll = (input as Record<string, unknown>)?.collectionName;
+      return coll ? `Inspecting ${coll}` : "Inspecting collection";
+    },
+    icon: "search",
+  },
+  list_connections: {
+    domain: "database",
+    execution: "server",
+    getLabel: () => "Listing connections",
+    icon: "database",
+  },
+  modify_chart_spec: {
+    domain: "chart",
+    execution: "client",
+    clientExecutor: "console",
+    longRunning: true,
+    getLabel: () => "Setting chart specification",
+    icon: "bar-chart",
+    preview: { field: "vegaLiteSpec", language: "json" },
+  },
+  list_open_dashboards: {
+    domain: "dashboard",
+    execution: "client",
+    clientExecutor: "dashboard",
+    getLabel: () => "Listing open dashboards",
+    icon: "list",
+  },
+  search_dashboards: {
+    domain: "search",
+    execution: "server",
+    getLabel: input => {
+      const query = (input as Record<string, unknown>)?.query;
+      return query
+        ? `Searching dashboards: "${query}"`
+        : "Searching dashboards";
+    },
+    icon: "search",
+  },
+  open_dashboard: {
+    domain: "dashboard",
+    execution: "client",
+    clientExecutor: "dashboard",
+    longRunning: true,
+    getLabel: () => "Opening dashboard",
+    icon: "external-link",
+  },
+  create_dashboard: {
+    domain: "dashboard",
+    execution: "client",
+    clientExecutor: "dashboard",
+    longRunning: true,
+    getLabel: input => {
+      const title = (input as Record<string, unknown>)?.title;
+      return title ? `Creating dashboard "${title}"` : "Creating dashboard";
+    },
+    icon: "plus",
+  },
+  enter_edit_mode: {
+    domain: "dashboard",
+    execution: "client",
+    clientExecutor: "dashboard",
+    longRunning: true,
+    getLabel: () => "Entering edit mode",
+    icon: "pencil",
+  },
+  add_widget: {
+    domain: "dashboard",
+    execution: "client",
+    clientExecutor: "dashboard",
+    longRunning: true,
+    getLabel: input => {
+      const type = (input as Record<string, unknown>)?.type;
+      return type ? `Adding ${type} widget` : "Adding widget";
+    },
+    icon: "plus",
+    preview: { field: "localSql", language: "sql" },
+  },
+  modify_widget: {
+    domain: "dashboard",
+    execution: "client",
+    clientExecutor: "dashboard",
+    longRunning: true,
+    getLabel: () => "Modifying widget",
+    icon: "pencil",
+    preview: { field: "localSql", language: "sql" },
+  },
+  remove_widget: {
+    domain: "dashboard",
+    execution: "client",
+    clientExecutor: "dashboard",
+    getLabel: () => "Removing widget",
+    icon: "trash",
+  },
+  create_data_source: {
+    domain: "dashboard",
+    execution: "client",
+    clientExecutor: "dashboard",
+    longRunning: true,
+    getLabel: input => {
+      const name = (input as Record<string, unknown>)?.name;
+      return name ? `Creating data source "${name}"` : "Creating data source";
+    },
+    icon: "plus",
+    preview: { field: "code", language: "sql" },
+  },
+  update_data_source_query: {
+    domain: "dashboard",
+    execution: "client",
+    clientExecutor: "dashboard",
+    longRunning: true,
+    getLabel: input => {
+      const inp = input as Record<string, unknown>;
+      const action = inp?.action;
+      const run = inp?.run === true;
+      const suffix = run ? "" : " (definition only)";
+      if (action === "patch") return `Patching data source query${suffix}`;
+      if (action === "append") return `Appending to data source query${suffix}`;
+      return `Updating data source query${suffix}`;
+    },
+    icon: "pencil",
+    preview: { field: "code", language: "sql" },
+  },
+  run_data_source_query: {
+    domain: "dashboard",
+    execution: "client",
+    clientExecutor: "dashboard",
+    longRunning: true,
+    getLabel: () => "Running data source query",
+    icon: "play",
+  },
+  import_console_as_data_source: {
+    domain: "dashboard",
+    execution: "client",
+    clientExecutor: "dashboard",
+    longRunning: true,
+    getLabel: () => "Importing console as data source",
+    icon: "download",
+  },
+  add_data_source: {
+    domain: "dashboard",
+    execution: "client",
+    clientExecutor: "dashboard",
+    longRunning: true,
+    getLabel: () => "Importing data source",
+    icon: "download",
+  },
+  get_dashboard_state: {
+    domain: "dashboard",
+    execution: "client",
+    clientExecutor: "dashboard",
+    getLabel: () => "Reading dashboard state",
+    icon: "eye",
+  },
+  preview_data_source: {
+    domain: "dashboard",
+    execution: "client",
+    clientExecutor: "dashboard",
+    longRunning: true,
+    getLabel: () => "Previewing data",
+    icon: "eye",
+    preview: { field: "sql", language: "sql" },
+  },
+  get_data_preview: {
+    domain: "dashboard",
+    execution: "client",
+    clientExecutor: "dashboard",
+    longRunning: true,
+    getLabel: () => "Previewing data",
+    icon: "eye",
+    preview: { field: "sql", language: "sql" },
+  },
+  add_global_filter: {
+    domain: "dashboard",
+    execution: "client",
+    clientExecutor: "dashboard",
+    getLabel: input => {
+      const label = (input as Record<string, unknown>)?.label;
+      return label ? `Adding filter "${label}"` : "Adding filter";
+    },
+    icon: "filter",
+  },
+  remove_global_filter: {
+    domain: "dashboard",
+    execution: "client",
+    clientExecutor: "dashboard",
+    getLabel: () => "Removing filter",
+    icon: "trash",
+  },
+  link_tables: {
+    domain: "dashboard",
+    execution: "client",
+    clientExecutor: "dashboard",
+    getLabel: () => "Linking tables",
+    icon: "link",
+  },
+  set_time_dimension: {
+    domain: "dashboard",
+    execution: "client",
+    clientExecutor: "dashboard",
+    getLabel: () => "Setting time dimension",
+    icon: "clock",
+  },
+  get_chart_templates: {
+    domain: "dashboard",
+    execution: "client",
+    clientExecutor: "dashboard",
+    getLabel: () => "Listing chart templates",
+    icon: "list",
+  },
+  get_chart_template: {
+    domain: "chart",
+    execution: "client",
+    clientExecutor: "dashboard",
+    getLabel: () => "Reading chart template",
+    icon: "eye",
+  },
+  search_consoles: {
+    domain: "search",
+    execution: "server",
+    getLabel: input => {
+      const query = (input as Record<string, unknown>)?.query;
+      return query ? `Searching "${query}"` : "Searching consoles";
+    },
+    icon: "search",
+  },
+  read_self_directive: {
+    domain: "memory",
+    execution: "server",
+    getLabel: () => "Reading memory",
+    icon: "brain",
+  },
+  update_self_directive: {
+    domain: "memory",
+    execution: "server",
+    getLabel: () => "Updating memory",
+    icon: "brain",
+  },
+  get_form_state: {
+    domain: "flow",
+    execution: "client",
+    clientExecutor: "flow",
+    getLabel: () => "Reading form state",
+    icon: "eye",
+  },
+  set_form_field: {
+    domain: "flow",
+    execution: "client",
+    clientExecutor: "flow",
+    getLabel: input => {
+      const field = (input as Record<string, unknown>)?.fieldName;
+      return field ? `Setting ${field}` : "Setting form field";
+    },
+    icon: "pencil",
+  },
+  set_multiple_fields: {
+    domain: "flow",
+    execution: "client",
+    clientExecutor: "flow",
+    getLabel: input => {
+      const fields = (input as Record<string, unknown>)?.fields;
+      const count =
+        fields && typeof fields === "object" ? Object.keys(fields).length : 0;
+      return count > 0 ? `Setting ${count} fields` : "Setting form fields";
+    },
+    icon: "pencil",
+  },
+  create_flow_tab: {
+    domain: "flow",
+    execution: "client",
+    clientExecutor: "flow",
+    getLabel: () => "Creating flow tab",
+    icon: "plus",
+  },
+  list_flow_tabs: {
+    domain: "flow",
+    execution: "client",
+    clientExecutor: "flow",
+    getLabel: () => "Listing flow tabs",
+    icon: "list",
+  },
+  list_databases: {
+    domain: "flow",
+    execution: "server",
+    getLabel: () => "Listing databases",
+    icon: "database",
+  },
+  list_tables: {
+    domain: "flow",
+    execution: "server",
+    getLabel: () => "Listing tables",
+    icon: "table",
+  },
+  inspect_table: {
+    domain: "flow",
+    execution: "server",
+    getLabel: input => {
+      const table = (input as Record<string, unknown>)?.table;
+      return table ? `Inspecting ${table}` : "Inspecting table";
+    },
+    icon: "search",
+  },
+  execute_query: {
+    domain: "flow",
+    execution: "server",
+    getLabel: () => "Executing query",
+    icon: "play",
+    preview: { field: "query", language: "sql" },
+  },
+  validate_query: {
+    domain: "flow",
+    execution: "server",
+    getLabel: () => "Validating query",
+    icon: "shield-check",
+    preview: { field: "query", language: "sql" },
+  },
+  explain_template: {
+    domain: "flow",
+    execution: "server",
+    getLabel: input => {
+      const placeholder = (input as Record<string, unknown>)?.placeholder;
+      return placeholder
+        ? `Explaining {{${placeholder}}}`
+        : "Explaining template";
+    },
+    icon: "help-circle",
+  },
+} as const satisfies Record<string, AgentToolManifestEntry>;
+
+export type AgentToolName = keyof typeof AGENT_TOOL_MANIFEST;
+
+function createToolNameSet(
+  predicate: (entry: AgentToolManifestEntry) => boolean,
+): Set<AgentToolName> {
+  return new Set(
+    (
+      Object.entries(AGENT_TOOL_MANIFEST) as Array<
+        [AgentToolName, AgentToolManifestEntry]
+      >
+    )
+      .filter(([, entry]) => predicate(entry))
+      .map(([toolName]) => toolName),
+  );
+}
+
+export const DASHBOARD_EXECUTOR_TOOL_NAMES = createToolNameSet(
+  entry => entry.execution === "client" && entry.clientExecutor === "dashboard",
+);
+
+export const CONSOLE_EXECUTOR_TOOL_NAMES = createToolNameSet(
+  entry => entry.execution === "client" && entry.clientExecutor === "console",
+);
+
+export const LONG_RUNNING_DASHBOARD_TOOL_NAMES = createToolNameSet(
+  entry =>
+    entry.execution === "client" &&
+    entry.clientExecutor === "dashboard" &&
+    entry.longRunning === true,
+);
+
+export function getAgentToolManifestEntry(
+  toolName: string,
+): AgentToolManifestEntry | undefined {
+  return AGENT_TOOL_MANIFEST[toolName as AgentToolName];
+}

--- a/app/src/agent-runtime/console-agent-tools.ts
+++ b/app/src/agent-runtime/console-agent-tools.ts
@@ -1,0 +1,723 @@
+import type {
+  ConsoleModification,
+  ConsoleModificationPayload,
+} from "../hooks/useMonacoConsole";
+import type { ConsoleTab } from "../store/lib/types";
+import { useConsoleStore } from "../store/consoleStore";
+import { generateObjectId } from "../utils/objectId";
+import { applyModification } from "../utils/consoleModification";
+import {
+  CONSOLE_EXECUTOR_TOOL_NAMES,
+  type AgentToolName,
+} from "./client-tool-manifest";
+
+type ChartSpecChangePayload =
+  import("../components/Editor").ChartSpecChangePayload;
+
+interface ToolCallPayload {
+  toolName: string;
+  toolCallId: string;
+}
+
+interface ActiveToolRegistration {
+  abortController: AbortController;
+  executionId: string;
+}
+
+interface ExecuteConsoleAgentToolOptions {
+  toolCall: ToolCallPayload;
+  input: Record<string, unknown>;
+  workspaceId?: string;
+  capturedConsoleId?: string | null;
+  onConsoleModification?: (modification: ConsoleModificationPayload) => void;
+  onChartSpecChange?: (payload: ChartSpecChangePayload) => void;
+  addToolOutput: (payload: {
+    tool: string;
+    toolCallId: string;
+    output: Record<string, unknown>;
+  }) => void;
+  registerActiveClientToolCall: (
+    toolName: string,
+    toolCallId: string,
+    options?: {
+      executionId?: string;
+      cancel?: () => void | Promise<void>;
+      cancellationOutput?: Record<string, unknown>;
+    },
+  ) => ActiveToolRegistration;
+  settleActiveClientToolCall: (
+    toolName: string,
+    toolCallId: string,
+    output: Record<string, unknown>,
+  ) => void;
+}
+
+function emitToolOutput(
+  addToolOutput: ExecuteConsoleAgentToolOptions["addToolOutput"],
+  toolName: string,
+  toolCallId: string,
+  output: Record<string, unknown>,
+) {
+  addToolOutput({ tool: toolName, toolCallId, output });
+}
+
+function isConsoleOrChartClientTool(toolName: string): boolean {
+  return CONSOLE_EXECUTOR_TOOL_NAMES.has(toolName as AgentToolName);
+}
+
+export async function executeConsoleAgentTool({
+  toolCall,
+  input,
+  workspaceId,
+  capturedConsoleId,
+  onConsoleModification,
+  onChartSpecChange,
+  addToolOutput,
+  registerActiveClientToolCall,
+  settleActiveClientToolCall,
+}: ExecuteConsoleAgentToolOptions): Promise<boolean> {
+  const { toolName, toolCallId } = toolCall;
+
+  if (!isConsoleOrChartClientTool(toolName)) {
+    return false;
+  }
+
+  if (toolName === "read_console") {
+    const consoleId = input.consoleId as string | undefined;
+
+    if (!consoleId) {
+      emitToolOutput(addToolOutput, toolName, toolCallId, {
+        success: false,
+        error:
+          "consoleId is required. Use list_open_consoles first to get available console IDs.",
+      });
+      return true;
+    }
+
+    const currentStore = useConsoleStore.getState();
+    const currentTabs = Object.values(currentStore.tabs);
+    const targetConsole = currentTabs.find((consoleTab: any) => {
+      return consoleTab.id === consoleId;
+    });
+
+    if (!targetConsole) {
+      emitToolOutput(addToolOutput, toolName, toolCallId, {
+        success: false,
+        error: `Console with ID ${consoleId} not found. Use list_open_consoles to see available consoles.`,
+      });
+      return true;
+    }
+
+    const rawContent = targetConsole.content || "";
+    const lines = rawContent.split("\n");
+    const totalLines = lines.length;
+    const lineNumberWidth = String(totalLines).length;
+    const content = lines
+      .map(
+        (line: string, index: number) =>
+          `${String(index + 1).padStart(lineNumberWidth)}| ${line}`,
+      )
+      .join("\n");
+
+    emitToolOutput(addToolOutput, toolName, toolCallId, {
+      success: true,
+      consoleId: targetConsole.id,
+      title: targetConsole.title,
+      content,
+      totalLines,
+      connectionId: targetConsole.connectionId,
+      connectionType: (targetConsole.metadata as { connectionType?: string })
+        ?.connectionType,
+      databaseId: targetConsole.databaseId,
+      databaseName: targetConsole.databaseName,
+    });
+    return true;
+  }
+
+  if (toolName === "modify_console") {
+    const action = input.action as "replace" | "insert" | "append" | "patch";
+    const content = input.content as string;
+    const position = input.position as number | null;
+    const consoleId = input.consoleId as string | undefined;
+    const modifyTitle = input.title as string | undefined;
+    const startLine = input.startLine as number | undefined;
+    const endLine = input.endLine as number | undefined;
+
+    if (!consoleId) {
+      emitToolOutput(addToolOutput, toolName, toolCallId, {
+        success: false,
+        error:
+          "consoleId is required. Use list_open_consoles to get IDs of existing consoles, or create_console to create a new one.",
+      });
+      return true;
+    }
+
+    const currentStore = useConsoleStore.getState();
+    const currentTabs = Object.values(currentStore.tabs);
+    const targetConsole = currentTabs.find((consoleTab: any) => {
+      return consoleTab.id === consoleId;
+    });
+
+    if (!targetConsole) {
+      emitToolOutput(addToolOutput, toolName, toolCallId, {
+        success: false,
+        error: `Console with ID ${consoleId} not found. Use list_open_consoles to see available consoles.`,
+      });
+      return true;
+    }
+
+    if ((targetConsole as any).readOnly) {
+      emitToolOutput(addToolOutput, toolName, toolCallId, {
+        success: false,
+        error:
+          "This console is shared as read-only. Use create_console to create a copy with the desired changes instead.",
+      });
+      return true;
+    }
+
+    if (action === "insert" && (position === null || position === undefined)) {
+      emitToolOutput(addToolOutput, toolName, toolCallId, {
+        success: false,
+        error: "Position is required for insert action",
+      });
+      return true;
+    }
+
+    if (action === "patch" && (!startLine || !endLine)) {
+      emitToolOutput(addToolOutput, toolName, toolCallId, {
+        success: false,
+        error:
+          "startLine and endLine are required for patch action. Use read_console first to see line numbers.",
+      });
+      return true;
+    }
+
+    if (onConsoleModification) {
+      onConsoleModification({
+        action,
+        content,
+        position:
+          position !== null && position !== undefined
+            ? { line: position, column: 1 }
+            : undefined,
+        consoleId,
+        startLine,
+        endLine,
+      });
+    }
+
+    const currentContent = targetConsole.content || "";
+    const modification: ConsoleModification = {
+      action,
+      content,
+      position:
+        position !== null && position !== undefined
+          ? { line: position, column: 1 }
+          : undefined,
+      startLine,
+      endLine,
+    };
+    const newContent = applyModification(currentContent, modification);
+    currentStore.updateContent(consoleId, newContent);
+
+    if (modifyTitle) {
+      currentStore.updateTitle(consoleId, modifyTitle);
+    }
+
+    emitToolOutput(addToolOutput, toolName, toolCallId, {
+      success: true,
+      consoleId,
+      message: `Console ${action}${action === "patch" ? "ed" : "d"} successfully`,
+    });
+    return true;
+  }
+
+  if (toolName === "create_console") {
+    const currentStore = useConsoleStore.getState();
+    const currentTabs = Object.values(currentStore.tabs);
+    const currentActiveId = currentStore.activeTabId;
+
+    const title = input.title as string;
+    const content = input.content as string;
+    const connectionId = (input.connectionId as string | null) ?? undefined;
+    const databaseId = (input.databaseId as string | null) ?? undefined;
+    const databaseName = (input.databaseName as string | null) ?? undefined;
+
+    const baseConsole =
+      currentTabs.find(
+        (consoleTab: any) => consoleTab.id === capturedConsoleId,
+      ) ||
+      currentTabs.find(
+        (consoleTab: any) => consoleTab.id === currentActiveId,
+      ) ||
+      currentTabs[0];
+
+    const effectiveConnectionId = connectionId ?? baseConsole?.connectionId;
+    const effectiveDatabaseId = databaseId ?? baseConsole?.databaseId;
+    const effectiveDatabaseName = databaseName ?? baseConsole?.databaseName;
+    const newConsoleId = generateObjectId();
+
+    if (onConsoleModification) {
+      onConsoleModification({
+        action: "create",
+        content,
+        consoleId: newConsoleId,
+        title,
+        connectionId: effectiveConnectionId,
+        databaseId: effectiveDatabaseId,
+        databaseName: effectiveDatabaseName,
+        isDirty: true,
+      });
+    }
+
+    emitToolOutput(addToolOutput, toolName, toolCallId, {
+      success: true,
+      _eventType: "console_creation",
+      consoleId: newConsoleId,
+      title,
+      content,
+      connectionId: effectiveConnectionId,
+      databaseId: effectiveDatabaseId,
+      databaseName: effectiveDatabaseName,
+      message: `✓ New console "${title}" created successfully`,
+    });
+    return true;
+  }
+
+  if (toolName === "list_open_consoles") {
+    const currentStore = useConsoleStore.getState();
+    const currentTabs = Object.values(currentStore.tabs);
+    const currentActiveId = currentStore.activeTabId;
+
+    const consoles = currentTabs
+      .filter((tab: any) => tab?.kind === undefined || tab?.kind === "console")
+      .map((tab: any) => ({
+        id: tab.id,
+        title: tab.title || "Untitled",
+        connectionId: tab.connectionId,
+        connectionName: tab.metadata?.connectionName || tab.connectionId,
+        databaseName:
+          tab.databaseName || tab.metadata?.queryOptions?.databaseName,
+        contentPreview:
+          (tab.content || "").slice(0, 100) +
+          ((tab.content || "").length > 100 ? "..." : ""),
+        isActive: tab.id === currentActiveId,
+      }));
+
+    emitToolOutput(addToolOutput, toolName, toolCallId, {
+      success: true,
+      consoles,
+      message: `Found ${consoles.length} open console(s)`,
+    });
+    return true;
+  }
+
+  if (toolName === "set_console_connection") {
+    const consoleId = input.consoleId as string | undefined;
+    const connectionId = input.connectionId as string;
+    const databaseId = input.databaseId as string | undefined;
+    const databaseName = input.databaseName as string | undefined;
+
+    if (!consoleId) {
+      emitToolOutput(addToolOutput, toolName, toolCallId, {
+        success: false,
+        error:
+          "consoleId is required. Use list_open_consoles to get IDs of existing consoles, or create_console to create a new one.",
+      });
+      return true;
+    }
+
+    const currentStore = useConsoleStore.getState();
+    const currentTabs = Object.values(currentStore.tabs);
+    const targetConsole = currentTabs.find((consoleTab: any) => {
+      return consoleTab.id === consoleId;
+    });
+
+    if (!targetConsole) {
+      emitToolOutput(addToolOutput, toolName, toolCallId, {
+        success: false,
+        error: `Console with ID ${consoleId} not found. Use list_open_consoles to see available consoles.`,
+      });
+      return true;
+    }
+
+    currentStore.updateConnection(consoleId, connectionId);
+    if (databaseId !== undefined || databaseName !== undefined) {
+      currentStore.updateDatabase(consoleId, databaseId, databaseName);
+    }
+
+    emitToolOutput(addToolOutput, toolName, toolCallId, {
+      success: true,
+      consoleId,
+      connectionId,
+      databaseId,
+      databaseName,
+      message: `Console "${targetConsole.title}" attached to connection ${connectionId}${databaseName ? ` (database: ${databaseName})` : ""}`,
+    });
+    return true;
+  }
+
+  if (toolName === "open_console") {
+    const consoleId = input.consoleId as string | undefined;
+    if (!consoleId) {
+      emitToolOutput(addToolOutput, toolName, toolCallId, {
+        success: false,
+        error: "consoleId is required.",
+      });
+      return true;
+    }
+
+    if (!workspaceId) {
+      emitToolOutput(addToolOutput, toolName, toolCallId, {
+        success: false,
+        error: "No workspace selected.",
+      });
+      return true;
+    }
+
+    const { abortController } = registerActiveClientToolCall(
+      toolName,
+      toolCallId,
+    );
+
+    try {
+      const currentStore = useConsoleStore.getState();
+      const existingTab = currentStore.tabs[consoleId];
+      if (existingTab) {
+        currentStore.setActiveTab(consoleId);
+        settleActiveClientToolCall(toolName, toolCallId, {
+          success: true,
+          consoleId,
+          title: existingTab.title,
+          message: `Console "${existingTab.title}" is already open — switched to it.`,
+        });
+        return true;
+      }
+
+      const data = await currentStore.fetchConsoleContent(
+        workspaceId,
+        consoleId,
+        {
+          signal: abortController.signal,
+        },
+      );
+      if (abortController.signal.aborted) {
+        return true;
+      }
+
+      if (!data) {
+        settleActiveClientToolCall(toolName, toolCallId, {
+          success: false,
+          error: `Console ${consoleId} not found or access denied.`,
+        });
+        return true;
+      }
+
+      const title = data.name || data.path || "Untitled";
+      currentStore.openTab({
+        id: consoleId,
+        title,
+        content: data.content || "",
+        connectionId: data.connectionId,
+        databaseId: data.databaseId,
+        databaseName: data.databaseName,
+      });
+      currentStore.setActiveTab(consoleId);
+
+      settleActiveClientToolCall(toolName, toolCallId, {
+        success: true,
+        consoleId,
+        title,
+        message: `Console "${title}" opened successfully.`,
+      });
+    } catch (error) {
+      if (abortController.signal.aborted) {
+        return true;
+      }
+
+      settleActiveClientToolCall(toolName, toolCallId, {
+        success: false,
+        error: `Failed to open console: ${error instanceof Error ? error.message : String(error)}`,
+      });
+    }
+    return true;
+  }
+
+  if (toolName === "modify_chart_spec") {
+    const vegaLiteSpec = input.vegaLiteSpec as
+      | Record<string, unknown>
+      | undefined;
+    if (!vegaLiteSpec) {
+      emitToolOutput(addToolOutput, toolName, toolCallId, {
+        success: false,
+        error: "vegaLiteSpec is required.",
+      });
+      return true;
+    }
+
+    const { MakoChartSpec: MakoChartSpecSchema } = await import(
+      "../lib/chart-spec"
+    );
+    const parsed = MakoChartSpecSchema.safeParse(vegaLiteSpec);
+    if (!parsed.success) {
+      const issues = parsed.error.issues
+        .slice(0, 5)
+        .map((issue: any) => `${issue.path.join(".")}: ${issue.message}`)
+        .join("; ");
+      emitToolOutput(addToolOutput, toolName, toolCallId, {
+        success: false,
+        error: `Invalid Vega-Lite spec: ${issues}. Fix the spec and try again.`,
+      });
+      return true;
+    }
+
+    if (!onChartSpecChange) {
+      emitToolOutput(addToolOutput, toolName, toolCallId, {
+        success: false,
+        error: "No active console tab to display the chart in.",
+      });
+      return true;
+    }
+
+    const { abortController } = registerActiveClientToolCall(
+      toolName,
+      toolCallId,
+    );
+
+    try {
+      const renderResult = await new Promise<{
+        success: boolean;
+        error?: string;
+      }>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          abortController.signal.removeEventListener("abort", handleAbort);
+          resolve({ success: true });
+        }, 5000);
+
+        const handleAbort = () => {
+          clearTimeout(timeout);
+          abortController.signal.removeEventListener("abort", handleAbort);
+          reject(new DOMException("Chart update cancelled", "AbortError"));
+        };
+
+        if (abortController.signal.aborted) {
+          handleAbort();
+          return;
+        }
+
+        abortController.signal.addEventListener("abort", handleAbort, {
+          once: true,
+        });
+
+        onChartSpecChange({
+          spec: parsed.data,
+          onRenderResult: result => {
+            clearTimeout(timeout);
+            abortController.signal.removeEventListener("abort", handleAbort);
+            resolve(result);
+          },
+        });
+      });
+
+      if (renderResult.success) {
+        settleActiveClientToolCall(toolName, toolCallId, {
+          success: true,
+          message: "Chart rendered successfully in the results panel.",
+        });
+      } else {
+        settleActiveClientToolCall(toolName, toolCallId, {
+          success: false,
+          error: `Chart failed to render: ${renderResult.error}. Fix the Vega-Lite spec and try again.`,
+        });
+      }
+    } catch (error) {
+      if (abortController.signal.aborted) {
+        return true;
+      }
+
+      settleActiveClientToolCall(toolName, toolCallId, {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Chart rendering failed unexpectedly.",
+      });
+    }
+    return true;
+  }
+
+  if (toolName === "run_console") {
+    const consoleId = input.consoleId as string | undefined;
+
+    if (!consoleId) {
+      emitToolOutput(addToolOutput, toolName, toolCallId, {
+        success: false,
+        error:
+          "consoleId is required. Use list_open_consoles to get IDs of existing consoles.",
+      });
+      return true;
+    }
+
+    const currentStore = useConsoleStore.getState();
+    const currentTabs = Object.values(currentStore.tabs);
+    const targetConsole = currentTabs.find((consoleTab: any) => {
+      return consoleTab.id === consoleId;
+    }) as ConsoleTab | undefined;
+
+    if (!targetConsole) {
+      emitToolOutput(addToolOutput, toolName, toolCallId, {
+        success: false,
+        error: `Console with ID ${consoleId} not found. Use list_open_consoles to see available consoles.`,
+      });
+      return true;
+    }
+
+    const content = targetConsole.content;
+    const connectionId = targetConsole.connectionId;
+
+    if (!content?.trim()) {
+      emitToolOutput(addToolOutput, toolName, toolCallId, {
+        success: false,
+        error: "Console is empty. Write a query first using modify_console.",
+      });
+      return true;
+    }
+
+    if (!connectionId) {
+      emitToolOutput(addToolOutput, toolName, toolCallId, {
+        success: false,
+        error:
+          "Console has no database connection. Use set_console_connection to attach one first.",
+      });
+      return true;
+    }
+
+    if (!workspaceId) {
+      emitToolOutput(addToolOutput, toolName, toolCallId, {
+        success: false,
+        error: "No workspace selected.",
+      });
+      return true;
+    }
+
+    const QUERY_TIMEOUT_MS = 120_000;
+    const { abortController, executionId } = registerActiveClientToolCall(
+      toolName,
+      toolCallId,
+      {
+        cancel: async () => {
+          await useConsoleStore
+            .getState()
+            .cancelQuery(workspaceId, executionId);
+        },
+      },
+    );
+    const timeoutId = setTimeout(
+      () => abortController.abort("query-timeout"),
+      QUERY_TIMEOUT_MS,
+    );
+
+    window.dispatchEvent(
+      new CustomEvent("console-execution-start", {
+        detail: { consoleId },
+      }),
+    );
+
+    try {
+      const startTime = Date.now();
+      const result = await currentStore.executeQuery(
+        workspaceId,
+        connectionId,
+        content,
+        {
+          executionId,
+          databaseName: targetConsole.databaseName,
+          databaseId: targetConsole.databaseId,
+          signal: abortController.signal,
+        },
+      );
+      clearTimeout(timeoutId);
+      const executionTime = Date.now() - startTime;
+
+      if (result.success) {
+        const data = result.rows || [];
+        const rowCount = Array.isArray(data) ? data.length : 1;
+        const preview = Array.isArray(data) ? data.slice(0, 50) : data;
+
+        window.dispatchEvent(
+          new CustomEvent("console-execution-result", {
+            detail: {
+              consoleId,
+              result: {
+                results: data,
+                executedAt: new Date().toISOString(),
+                resultCount: rowCount,
+                executionTime,
+                fields: result.fields,
+                pageInfo: result.pageInfo || null,
+              },
+            },
+          }),
+        );
+
+        settleActiveClientToolCall(toolName, toolCallId, {
+          success: true,
+          rowCount,
+          preview,
+          message: `Query executed successfully. ${rowCount} row(s) returned.`,
+        });
+      } else {
+        const abortReason =
+          typeof abortController.signal.reason === "string"
+            ? abortController.signal.reason
+            : undefined;
+
+        window.dispatchEvent(
+          new CustomEvent("console-execution-result", {
+            detail: { consoleId, result: null },
+          }),
+        );
+
+        if (abortReason === "chat-stop") {
+          return true;
+        }
+
+        settleActiveClientToolCall(toolName, toolCallId, {
+          success: false,
+          error:
+            abortReason === "query-timeout"
+              ? `Query timed out after ${QUERY_TIMEOUT_MS / 1000}s. The query may be too complex or the database is under heavy load.`
+              : result.error || "Query execution failed.",
+        });
+      }
+    } catch (error: any) {
+      clearTimeout(timeoutId);
+
+      const abortReason =
+        typeof abortController.signal.reason === "string"
+          ? abortController.signal.reason
+          : undefined;
+
+      window.dispatchEvent(
+        new CustomEvent("console-execution-result", {
+          detail: { consoleId, result: null },
+        }),
+      );
+
+      if (abortReason === "chat-stop") {
+        return true;
+      }
+
+      settleActiveClientToolCall(toolName, toolCallId, {
+        success: false,
+        error:
+          abortReason === "query-timeout"
+            ? `Query timed out after ${QUERY_TIMEOUT_MS / 1000}s. The query may be too complex or the database is under heavy load.`
+            : error?.message || "Query execution failed unexpectedly.",
+      });
+    }
+    return true;
+  }
+
+  return false;
+}

--- a/app/src/agent-runtime/request-context.test.ts
+++ b/app/src/agent-runtime/request-context.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildChatRequestBody } from "./request-context";
+import { useDashboardStore } from "../store/dashboardStore";
+import { useDashboardRuntimeStore } from "../dashboard-runtime/store";
+import type { Dashboard } from "../dashboard-runtime/types";
+
+const dashboardStoreBaseline = useDashboardStore.getState();
+const runtimeStoreBaseline = useDashboardRuntimeStore.getState();
+
+const baseDashboard = {
+  _id: "dash_1",
+  workspaceId: "ws_1",
+  title: "Revenue Dashboard",
+  description: "Quarterly revenue overview",
+  dataSources: [
+    {
+      id: "ds_1",
+      name: "Revenue",
+      tableRef: "revenue",
+      query: {
+        connectionId: "conn_1",
+        language: "sql" as const,
+        code: "select * from revenue",
+      },
+      sampleRows: [{ month: "2026-01", revenue: 100 }],
+    },
+  ],
+  widgets: [],
+  relationships: [],
+  globalFilters: [],
+  crossFilter: { enabled: true, resolution: "intersect", engine: "mosaic" },
+  materializationSchedule: { enabled: false, cron: null },
+  layout: { columns: 12, rowHeight: 80 },
+  version: 1,
+  access: "private",
+  createdBy: "user_1",
+  createdAt: "2026-04-12T00:00:00.000Z",
+  updatedAt: "2026-04-12T00:00:00.000Z",
+  cache: {},
+} as unknown as Dashboard;
+
+afterEach(() => {
+  useDashboardStore.setState(dashboardStoreBaseline, true);
+  useDashboardRuntimeStore.setState(runtimeStoreBaseline, true);
+});
+
+describe("buildChatRequestBody", () => {
+  it("omits dashboard context on console turns", () => {
+    useDashboardStore.setState(state => {
+      state.openDashboards = { [baseDashboard._id]: baseDashboard };
+      state.activeDashboardId = baseDashboard._id;
+    }, false);
+
+    const requestBody = buildChatRequestBody({
+      messages: [],
+      workspaceId: "ws_1",
+      modelId: "model_1",
+      chatId: "chat_1",
+      tabs: [
+        {
+          id: "console_1",
+          title: "Revenue Query",
+          content: "select * from revenue",
+          kind: "console",
+          connectionId: "conn_1",
+          databaseName: "analytics",
+        },
+      ] as any,
+      activeTabId: "console_1",
+      activeTab: {
+        id: "console_1",
+        title: "Revenue Query",
+        content: "select * from revenue",
+        kind: "console",
+        connectionId: "conn_1",
+        databaseName: "analytics",
+      } as any,
+      activeView: "console",
+      activeConsoleId: "console_1",
+      activeConsoleResults: {
+        viewMode: "table",
+        hasResults: true,
+        rowCount: 1,
+        columns: ["month", "revenue"],
+        sampleRows: [{ month: "2026-01", revenue: 100 }],
+        chartSpec: null,
+      },
+      workspaceConnections: [{ id: "conn_1", type: "postgresql" }] as any,
+      pinnedDashboardId: baseDashboard._id,
+    });
+
+    expect(requestBody.openTabs).toHaveLength(1);
+    expect(requestBody).not.toHaveProperty("openDashboards");
+    expect(requestBody).not.toHaveProperty("activeDashboardContext");
+  });
+
+  it("includes pinned dashboard context on dashboard turns", () => {
+    useDashboardStore.setState(state => {
+      state.openDashboards = { [baseDashboard._id]: baseDashboard };
+      state.activeDashboardId = baseDashboard._id;
+    }, false);
+
+    const requestBody = buildChatRequestBody({
+      messages: [],
+      workspaceId: "ws_1",
+      modelId: "model_1",
+      chatId: "chat_1",
+      tabs: [
+        {
+          id: "dash_tab_1",
+          title: "Revenue Dashboard",
+          content: "",
+          kind: "dashboard",
+          metadata: { dashboardId: baseDashboard._id },
+        },
+      ] as any,
+      activeTabId: "dash_tab_1",
+      activeTab: {
+        id: "dash_tab_1",
+        title: "Revenue Dashboard",
+        content: "",
+        kind: "dashboard",
+        metadata: { dashboardId: baseDashboard._id },
+      } as any,
+      activeView: "dashboard",
+      workspaceConnections: [
+        { id: "conn_1", type: "postgresql", sqlDialect: "postgresql" },
+      ] as any,
+      pinnedDashboardId: baseDashboard._id,
+    });
+
+    expect(requestBody).toHaveProperty("openDashboards");
+    expect(requestBody).toHaveProperty("activeDashboardContext");
+    expect(requestBody.activeDashboardContext).toMatchObject({
+      dashboardId: baseDashboard._id,
+      title: baseDashboard.title,
+    });
+    expect(requestBody.openDashboards).toEqual([
+      { id: baseDashboard._id, title: baseDashboard.title, isActive: true },
+    ]);
+  });
+});

--- a/app/src/agent-runtime/request-context.ts
+++ b/app/src/agent-runtime/request-context.ts
@@ -1,0 +1,210 @@
+import type { ConsoleTab } from "../store/lib/types";
+import type { Connection } from "../store/schemaStore";
+import { getDashboardStateSnapshot } from "../dashboard-runtime/commands";
+import { useDashboardStore } from "../store/dashboardStore";
+
+export type ChatActiveView = "console" | "dashboard" | "flow-editor" | "empty";
+
+export interface ActiveConsoleResultsContext {
+  viewMode: "table" | "json" | "chart";
+  hasResults: boolean;
+  rowCount: number;
+  columns: string[];
+  sampleRows: Record<string, unknown>[];
+  chartSpec: Record<string, unknown> | null;
+}
+
+interface BuildDashboardRequestContextOptions {
+  activeView: ChatActiveView;
+  pinnedDashboardId?: string | null;
+  pinnedDashboardTitle?: string | null;
+  workspaceConnections: Connection[];
+}
+
+interface BuildChatRequestBodyOptions {
+  messages: unknown;
+  workspaceId?: string;
+  modelId?: string;
+  chatId?: string;
+  tabs: ConsoleTab[];
+  activeTabId?: string | null;
+  activeTab?: ConsoleTab;
+  activeView: ChatActiveView;
+  activeConsoleId?: string | null;
+  activeConsoleResults?: ActiveConsoleResultsContext;
+  flowFormState?: Record<string, unknown>;
+  workspaceConnections: Connection[];
+  pinnedDashboardId?: string | null;
+}
+
+function buildOpenConsoles(tabs: ConsoleTab[]) {
+  return tabs
+    .filter(tab => tab?.kind === undefined || tab?.kind === "console")
+    .map(tab => {
+      const content = tab.content || "";
+      const lines = content.split("\n");
+      const maxLines = 50;
+      const truncated = lines.length > maxLines;
+      const displayContent = truncated
+        ? lines.slice(0, maxLines).join("\n")
+        : content;
+
+      return {
+        id: tab.id,
+        title: tab.title,
+        connectionId: tab.connectionId,
+        databaseId: tab.databaseId,
+        databaseName: tab.databaseName,
+        content: displayContent,
+        contentTruncated: truncated,
+        lineCount: lines.length,
+      };
+    });
+}
+
+function buildOpenTabs(tabs: ConsoleTab[], activeTabId?: string | null) {
+  return tabs.map(tab => ({
+    id: tab.id,
+    kind: tab.kind || "console",
+    title: tab.title,
+    isActive: tab.id === activeTabId,
+    dashboardId:
+      tab.kind === "dashboard"
+        ? (tab.metadata?.dashboardId as string | undefined)
+        : undefined,
+    flowId:
+      tab.kind === "flow-editor"
+        ? (tab.metadata?.flowId as string | undefined)
+        : undefined,
+    connectionId:
+      tab.kind === "console" || !tab.kind ? tab.connectionId : undefined,
+    databaseName:
+      tab.kind === "console" || !tab.kind ? tab.databaseName : undefined,
+  }));
+}
+
+export function buildDashboardRequestContext({
+  activeView,
+  pinnedDashboardId,
+  pinnedDashboardTitle,
+  workspaceConnections,
+}: BuildDashboardRequestContextOptions) {
+  if (activeView !== "dashboard" || !pinnedDashboardId) {
+    return {};
+  }
+
+  try {
+    const dashboardStore = useDashboardStore.getState();
+    const connectionById = new Map(
+      workspaceConnections.map(connection => [connection.id, connection]),
+    );
+    const SAMPLE_LIMIT = 3;
+
+    const openDashboardsFromStore = Object.values(
+      dashboardStore.openDashboards,
+    ).map((dashboard: any) => ({
+      id: dashboard._id,
+      title: dashboard.title,
+      isActive: dashboard._id === pinnedDashboardId,
+    }));
+
+    const snapshot = getDashboardStateSnapshot(pinnedDashboardId);
+    const openDashboards =
+      openDashboardsFromStore.length > 0
+        ? openDashboardsFromStore
+        : [
+            {
+              id: snapshot._id,
+              title: snapshot.title,
+              isActive: true,
+            },
+          ];
+
+    return {
+      openDashboards,
+      activeDashboardContext: {
+        dashboardId: snapshot._id,
+        title: snapshot.title,
+        description: snapshot.description,
+        crossFilterEnabled: !!snapshot.crossFilter?.enabled,
+        crossFilter: snapshot.crossFilter,
+        layout: snapshot.layout,
+        materializationSchedule: snapshot.materializationSchedule,
+        dataSources: snapshot.dataSources.map((dataSource: any) => {
+          const { _id: _dataSourceId, sampleRows, ...rest } = dataSource;
+          return {
+            ...rest,
+            sampleRows: sampleRows?.slice(0, SAMPLE_LIMIT),
+            connectionType:
+              connectionById.get(dataSource.query?.connectionId)?.type ||
+              undefined,
+            sqlDialect:
+              connectionById.get(dataSource.query?.connectionId)?.type ===
+              "mongodb"
+                ? undefined
+                : (
+                    connectionById.get(dataSource.query?.connectionId) as
+                      | { sqlDialect?: string }
+                      | undefined
+                  )?.sqlDialect ||
+                  (dataSource.query?.language === "sql" ? "duckdb" : undefined),
+          };
+        }),
+        widgets: snapshot.widgets.map(
+          ({ _id: _widgetId, ...widget }: any) => widget,
+        ),
+      },
+    };
+  } catch {
+    return pinnedDashboardTitle
+      ? {
+          openDashboards: [
+            {
+              id: pinnedDashboardId,
+              title: pinnedDashboardTitle,
+              isActive: true,
+            },
+          ],
+        }
+      : {};
+  }
+}
+
+export function buildChatRequestBody({
+  messages,
+  workspaceId,
+  modelId,
+  chatId,
+  tabs,
+  activeTabId,
+  activeTab,
+  activeView,
+  activeConsoleId,
+  activeConsoleResults,
+  flowFormState,
+  workspaceConnections,
+  pinnedDashboardId,
+}: BuildChatRequestBodyOptions) {
+  return {
+    messages,
+    workspaceId,
+    modelId,
+    chatId,
+    openConsoles: buildOpenConsoles(tabs),
+    openTabs: buildOpenTabs(tabs, activeTabId),
+    consoleId: activeConsoleId,
+    activeConsoleResults,
+    agentId: "unified",
+    activeView,
+    tabKind: activeTab?.kind,
+    flowType: activeTab?.metadata?.flowType,
+    flowFormState,
+    ...buildDashboardRequestContext({
+      activeView,
+      pinnedDashboardId,
+      pinnedDashboardTitle:
+        activeTab?.kind === "dashboard" ? activeTab.title || null : null,
+      workspaceConnections,
+    }),
+  };
+}

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -56,23 +56,26 @@ import {
 } from "ai";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useConsoleStore } from "../store/consoleStore";
-import { getDashboardStateSnapshot } from "../dashboard-runtime/commands";
 import { executeDashboardAgentTool } from "../dashboard-runtime/agent-tools";
-import { useDashboardStore } from "../store/dashboardStore";
 import type { ConsoleTab } from "../store/lib/types";
 import { useSettingsStore } from "../store/settingsStore";
 import { useSchemaStore } from "../store/schemaStore";
 import { ModelSelector } from "./ModelSelector";
 import { generateObjectId } from "../utils/objectId";
-import {
-  ConsoleModification,
-  ConsoleModificationPayload,
-} from "../hooks/useMonacoConsole";
-import { applyModification } from "../utils/consoleModification";
+import { ConsoleModificationPayload } from "../hooks/useMonacoConsole";
 import { trackEvent } from "../lib/analytics";
 import { DbFlowFormRef } from "./DbFlowForm";
 import { safeStringify, toJsonSafe } from "../lib/json-safe";
 import { StreamingToolCard, type ToolPartState } from "./StreamingToolCard";
+import {
+  buildChatRequestBody,
+  type ActiveConsoleResultsContext,
+} from "../agent-runtime/request-context";
+import { executeConsoleAgentTool } from "../agent-runtime/console-agent-tools";
+import {
+  LONG_RUNNING_DASHBOARD_TOOL_NAMES,
+  type AgentToolName,
+} from "../agent-runtime/client-tool-manifest";
 
 interface ChatSessionMeta {
   _id: string;
@@ -266,21 +269,6 @@ interface ActiveClientToolCall {
   cancellationOutput: Record<string, unknown>;
   settled: boolean;
 }
-
-const LONG_RUNNING_DASHBOARD_TOOLS = new Set([
-  "open_dashboard",
-  "create_dashboard",
-  "enter_edit_mode",
-  "add_data_source",
-  "import_console_as_data_source",
-  "create_data_source",
-  "update_data_source_query",
-  "run_data_source_query",
-  "preview_data_source",
-  "get_data_preview",
-  "add_widget",
-  "modify_widget",
-]);
 
 // ReasoningDisplay for showing reasoning/thinking parts inline.
 // - Auto-opens while streaming, auto-collapses when done.
@@ -892,9 +880,10 @@ const Chat: React.FC<ChatProps> = ({
 
   // Get connections to check if only database is the demo
   const connections = useSchemaStore(s => s.connections);
-  const workspaceConnections = currentWorkspace
-    ? connections[currentWorkspace.id] || []
-    : [];
+  const workspaceConnections = useMemo(
+    () => (currentWorkspace ? connections[currentWorkspace.id] || [] : []),
+    [connections, currentWorkspace],
+  );
 
   // Show Chinook suggestions if the only database in workspace is the demo database
   const hasOnlyDemoDatabase =
@@ -950,6 +939,9 @@ const Chat: React.FC<ChatProps> = ({
   const [selectedTool, setSelectedTool] = useState<ToolInvocationInfo | null>(
     null,
   );
+  const [capturedConsoleTitle, setCapturedConsoleTitle] = useState<
+    string | null
+  >(null);
 
   // Filter to only real console tabs (used for capturedConsoleTitle)
   const realConsoleTabs = useMemo(
@@ -959,14 +951,6 @@ const Chat: React.FC<ChatProps> = ({
       ),
     [consoleTabs],
   );
-
-  // Get the captured console's title for the visual indicator
-  const capturedConsoleTitle = useMemo(() => {
-    const capturedId = capturedConsoleIdRef.current;
-    if (!capturedId) return null;
-    const tab = realConsoleTabs.find(t => t.id === capturedId);
-    return tab?.title || null;
-  }, [realConsoleTabs]);
 
   // Ref to get current activeConsoleId at request time (avoids stale closure)
   const activeConsoleIdRef = useRef(activeConsoleId);
@@ -1003,157 +987,42 @@ const Chat: React.FC<ChatProps> = ({
           const tabs = Object.values(store.tabs) as ConsoleTab[];
           const activeTab = tabs.find(t => t.id === store.activeTabId);
 
-          const openConsoles = tabs
-            .filter(t => t?.kind === undefined || t?.kind === "console")
-            .map(tab => {
-              const content = tab.content || "";
-              const lines = content.split("\n");
-              const maxLines = 50;
-              const truncated = lines.length > maxLines;
-              const displayContent = truncated
-                ? lines.slice(0, maxLines).join("\n")
-                : content;
-
-              return {
-                id: tab.id,
-                title: tab.title,
-                connectionId: tab.connectionId,
-                databaseId: tab.databaseId,
-                databaseName: tab.databaseName,
-                content: displayContent,
-                contentTruncated: truncated,
-                lineCount: lines.length,
-              };
-            });
-
-          const openTabs = tabs.map(tab => ({
-            id: tab.id,
-            kind: tab.kind || "console",
-            title: tab.title,
-            isActive: tab.id === store.activeTabId,
-            dashboardId:
-              tab.kind === "dashboard"
-                ? (tab.metadata?.dashboardId as string | undefined)
-                : undefined,
-            flowId:
-              tab.kind === "flow-editor"
-                ? (tab.metadata?.flowId as string | undefined)
-                : undefined,
-            connectionId:
-              tab.kind === "console" || !tab.kind
-                ? tab.connectionId
-                : undefined,
-            databaseName:
-              tab.kind === "console" || !tab.kind
-                ? tab.databaseName
-                : undefined,
-          }));
-
           const flowFormState = dbFlowFormRefCurrent.current?.current
             ? dbFlowFormRefCurrent.current.current.getFormState()
             : undefined;
 
           // Read results context from Editor at request time
           const resultsCtx = resultsContextRef?.current ?? null;
-          const activeConsoleResults = resultsCtx
-            ? {
-                viewMode: resultsCtx.viewMode,
-                hasResults: resultsCtx.hasResults,
-                rowCount: resultsCtx.rowCount,
-                columns: resultsCtx.columns,
-                sampleRows: resultsCtx.sampleRows,
-                chartSpec: resultsCtx.chartSpec,
-              }
-            : undefined;
-
-          const requestBody = {
-            messages,
-            workspaceId: workspaceIdRef.current,
-            modelId: modelIdRef.current,
-            chatId: chatIdRef.current,
-            openConsoles,
-            openTabs,
-            consoleId: activeConsoleIdRef.current,
-            activeConsoleResults,
-            // Unified agent selection
-            agentId: "unified",
-            activeView,
-            tabKind: activeTab?.kind,
-            flowType: activeTab?.metadata?.flowType,
-            flowFormState,
-            ...(() => {
-              try {
-                const dashboardStore = useDashboardStore.getState();
-                const connectionById = new Map(
-                  workspaceConnections.map(connection => [
-                    connection.id,
-                    connection,
-                  ]),
-                );
-                const SAMPLE_LIMIT = 3;
-
-                const pinnedDashboardId =
-                  capturedDashboardIdRef.current ??
-                  dashboardStore.activeDashboardId;
-
-                const openDashboardsList = Object.values(
-                  dashboardStore.openDashboards,
-                ).map((d: any) => ({
-                  id: d._id,
-                  title: d.title,
-                  isActive: d._id === pinnedDashboardId,
-                }));
-
-                if (openDashboardsList.length === 0) return {};
-
-                const activeId = pinnedDashboardId;
-                const snapshot = activeId
-                  ? getDashboardStateSnapshot(activeId)
-                  : null;
-
-                if (!snapshot) {
-                  return { openDashboards: openDashboardsList };
+          const activeConsoleResults: ActiveConsoleResultsContext | undefined =
+            resultsCtx
+              ? {
+                  viewMode: resultsCtx.viewMode,
+                  hasResults: resultsCtx.hasResults,
+                  rowCount: resultsCtx.rowCount,
+                  columns: resultsCtx.columns,
+                  sampleRows: resultsCtx.sampleRows,
+                  chartSpec: resultsCtx.chartSpec,
                 }
-
-                return {
-                  openDashboards: openDashboardsList,
-                  activeDashboardContext: {
-                    dashboardId: snapshot._id,
-                    title: snapshot.title,
-                    description: snapshot.description,
-                    crossFilter: snapshot.crossFilter,
-                    layout: snapshot.layout,
-                    materializationSchedule: snapshot.materializationSchedule,
-                    dataSources: snapshot.dataSources.map((ds: any) => {
-                      const { _id: _dsId, sampleRows, ...rest } = ds;
-                      return {
-                        ...rest,
-                        sampleRows: sampleRows?.slice(0, SAMPLE_LIMIT),
-                        connectionType:
-                          connectionById.get(ds.query?.connectionId)?.type ||
-                          undefined,
-                        sqlDialect:
-                          (
-                            connectionById.get(ds.query?.connectionId) as
-                              | { sqlDialect?: string }
-                              | undefined
-                          )?.sqlDialect ||
-                          (ds.query?.language === "sql" ? "duckdb" : undefined),
-                      };
-                    }),
-                    widgets: snapshot.widgets.map(
-                      ({ _id: _wId, ...w }: any) => w,
-                    ),
-                  },
-                };
-              } catch {
-                return {};
-              }
-            })(),
-          };
+              : undefined;
 
           return {
-            body: toJsonSafe(requestBody) as Record<string, unknown>,
+            body: toJsonSafe(
+              buildChatRequestBody({
+                messages,
+                workspaceId: workspaceIdRef.current,
+                modelId: modelIdRef.current,
+                chatId: chatIdRef.current,
+                tabs,
+                activeTabId: store.activeTabId,
+                activeTab,
+                activeView,
+                activeConsoleId: activeConsoleIdRef.current,
+                activeConsoleResults,
+                flowFormState,
+                workspaceConnections,
+                pinnedDashboardId: capturedDashboardIdRef.current,
+              }),
+            ) as Record<string, unknown>,
           };
         },
       }),
@@ -1192,645 +1061,36 @@ const Chat: React.FC<ChatProps> = ({
       const input = toolCall.input as Record<string, unknown>;
 
       try {
-        // Handle read_console - requires explicit consoleId
-        if (toolName === "read_console") {
-          const consoleId = input.consoleId as string | undefined;
-
-          if (!consoleId) {
-            addToolOutput({
-              tool: "read_console",
+        if (
+          await executeConsoleAgentTool({
+            toolCall: {
+              toolName,
               toolCallId: toolCall.toolCallId,
-              output: {
-                success: false,
-                error:
-                  "consoleId is required. Use list_open_consoles first to get available console IDs.",
-              },
-            });
-            return;
-          }
-
-          // Get fresh state to avoid stale closure issues
-          const currentStore = useConsoleStore.getState();
-          const currentTabs = Object.values(currentStore.tabs);
-          const targetConsole = currentTabs.find(
-            (c: any) => c.id === consoleId,
-          );
-
-          if (!targetConsole) {
-            addToolOutput({
-              tool: "read_console",
-              toolCallId: toolCall.toolCallId,
-              output: {
-                success: false,
-                error: `Console with ID ${consoleId} not found. Use list_open_consoles to see available consoles.`,
-              },
-            });
-            return;
-          }
-
-          // Add line numbers to help AI accurately specify patch ranges
-          const rawContent = targetConsole.content || "";
-          const lines = rawContent.split("\n");
-          const totalLines = lines.length;
-          const lineNumberWidth = String(totalLines).length;
-          // Format: "  1| code here" - line numbers are for reference only
-          const content = lines
-            .map(
-              (line: string, i: number) =>
-                `${String(i + 1).padStart(lineNumberWidth)}| ${line}`,
-            )
-            .join("\n");
-
-          addToolOutput({
-            tool: "read_console",
-            toolCallId: toolCall.toolCallId,
-            output: {
-              success: true,
-              consoleId: targetConsole.id,
-              title: targetConsole.title,
-              content,
-              totalLines,
-              connectionId: targetConsole.connectionId,
-              connectionType: (
-                targetConsole.metadata as { connectionType?: string }
-              )?.connectionType,
-              databaseId: targetConsole.databaseId,
-              databaseName: targetConsole.databaseName,
             },
-          });
-          return;
-        }
-
-        // Handle modify_console - requires explicit consoleId
-        if (toolName === "modify_console") {
-          const action = input.action as
-            | "replace"
-            | "insert"
-            | "append"
-            | "patch";
-          const content = input.content as string;
-          const position = input.position as number | null;
-          const consoleId = input.consoleId as string | undefined;
-          const modifyTitle = input.title as string | undefined;
-          const startLine = input.startLine as number | undefined;
-          const endLine = input.endLine as number | undefined;
-
-          if (!consoleId) {
-            addToolOutput({
-              tool: "modify_console",
-              toolCallId: toolCall.toolCallId,
-              output: {
-                success: false,
-                error:
-                  "consoleId is required. Use list_open_consoles to get IDs of existing consoles, or create_console to create a new one.",
-              },
-            });
-            return;
-          }
-
-          // Get fresh state to avoid stale closure issues
-          const currentStore = useConsoleStore.getState();
-          const currentTabs = Object.values(currentStore.tabs);
-
-          const targetConsole = currentTabs.find(
-            (c: any) => c.id === consoleId,
-          );
-          if (!targetConsole) {
-            addToolOutput({
-              tool: "modify_console",
-              toolCallId: toolCall.toolCallId,
-              output: {
-                success: false,
-                error: `Console with ID ${consoleId} not found. Use list_open_consoles to see available consoles.`,
-              },
-            });
-            return;
-          }
-
-          // Check if the console is read-only (shared/workspace without write access)
-          if ((targetConsole as any).readOnly) {
-            addToolOutput({
-              tool: "modify_console",
-              toolCallId: toolCall.toolCallId,
-              output: {
-                success: false,
-                error:
-                  "This console is shared as read-only. Use create_console to create a copy with the desired changes instead.",
-              },
-            });
-            return;
-          }
-
-          // Validate insert action has position
-          if (
-            action === "insert" &&
-            (position === null || position === undefined)
-          ) {
-            addToolOutput({
-              tool: "modify_console",
-              toolCallId: toolCall.toolCallId,
-              output: {
-                success: false,
-                error: "Position is required for insert action",
-              },
-            });
-            return;
-          }
-
-          // Validate patch action has startLine and endLine
-          if (action === "patch" && (!startLine || !endLine)) {
-            addToolOutput({
-              tool: "modify_console",
-              toolCallId: toolCall.toolCallId,
-              output: {
-                success: false,
-                error:
-                  "startLine and endLine are required for patch action. Use read_console first to see line numbers.",
-              },
-            });
-            return;
-          }
-
-          // Dispatch through the event system - this ensures Monaco editor gets updated
-          // The App.tsx handleConsoleModification callback will:
-          // 1. Dispatch a CustomEvent that Editor.tsx listens to
-          // 2. Editor.tsx calls showDiff() on the Console ref
-          // 3. Console.tsx updates Monaco editor via the diff mode
-          if (onConsoleModificationRef.current) {
-            onConsoleModificationRef.current({
-              action,
-              content,
-              // Convert line number to position format expected by ConsoleModification
-              position:
-                position !== null && position !== undefined
-                  ? { line: position, column: 1 }
-                  : undefined,
-              consoleId,
-              startLine,
-              endLine,
-            });
-          }
-
-          // Also update store for consistency using shared utility
-          const currentContent = targetConsole.content || "";
-          const modification: ConsoleModification = {
-            action,
-            content,
-            position:
-              position !== null && position !== undefined
-                ? { line: position, column: 1 }
-                : undefined,
-            startLine,
-            endLine,
-          };
-          const newContent = applyModification(currentContent, modification);
-          currentStore.updateContent(consoleId, newContent);
-
-          if (modifyTitle) {
-            currentStore.updateTitle(consoleId, modifyTitle);
-          }
-
-          addToolOutput({
-            tool: "modify_console",
-            toolCallId: toolCall.toolCallId,
-            output: {
-              success: true,
-              consoleId,
-              message: `Console ${action}${action === "patch" ? "ed" : "d"} successfully`,
-            },
-          });
-          return;
-        }
-
-        // Handle create_console - dispatch through event system
-        if (toolName === "create_console") {
-          // Get fresh state to avoid stale closure issues
-          const currentStore = useConsoleStore.getState();
-          const currentTabs = Object.values(currentStore.tabs);
-          const currentActiveId = currentStore.activeTabId;
-
-          const title = input.title as string;
-          const content = input.content as string;
-          const connectionId =
-            (input.connectionId as string | null) ?? undefined;
-          const databaseId = (input.databaseId as string | null) ?? undefined;
-          const databaseName =
-            (input.databaseName as string | null) ?? undefined;
-
-          // Use captured console ID (from message submission time) as the primary fallback
-          // This prevents the race condition where user switches consoles while agent is thinking
-          const capturedId = capturedConsoleIdRef.current;
-
-          // If connection info not provided, inherit from captured/active console
-          const baseConsole =
-            currentTabs.find((c: any) => c.id === capturedId) ||
-            currentTabs.find((c: any) => c.id === currentActiveId) ||
-            currentTabs[0];
-
-          const effectiveConnectionId =
-            connectionId ?? baseConsole?.connectionId;
-          const effectiveDatabaseId = databaseId ?? baseConsole?.databaseId;
-          const effectiveDatabaseName =
-            databaseName ?? baseConsole?.databaseName;
-
-          // Generate a new ID for the console
-          const newConsoleId = generateObjectId();
-
-          // Dispatch through the event system - App.tsx handleConsoleModification will:
-          // 1. Call openTab with the provided consoleId
-          // 2. Call setActiveTab
-          if (onConsoleModificationRef.current) {
-            onConsoleModificationRef.current({
-              action: "create",
-              content,
-              consoleId: newConsoleId,
-              title,
-              connectionId: effectiveConnectionId,
-              databaseId: effectiveDatabaseId,
-              databaseName: effectiveDatabaseName,
-              isDirty: true, // Mark as dirty so it won't be replaced by pristine tab logic
-            });
-          }
-
-          addToolOutput({
-            tool: "create_console",
-            toolCallId: toolCall.toolCallId,
-            output: {
-              success: true,
-              _eventType: "console_creation",
-              consoleId: newConsoleId,
-              title,
-              content,
-              connectionId: effectiveConnectionId,
-              databaseId: effectiveDatabaseId,
-              databaseName: effectiveDatabaseName,
-              message: `✓ New console "${title}" created successfully`,
-            },
-          });
-          return;
-        }
-
-        // Handle list_open_consoles - return all open console tabs
-        if (toolName === "list_open_consoles") {
-          // Get fresh state to avoid stale closure issues
-          const currentStore = useConsoleStore.getState();
-          const currentTabs = Object.values(currentStore.tabs);
-          const currentActiveId = currentStore.activeTabId;
-
-          const consoles = currentTabs
-            .filter(
-              (tab: any) => tab?.kind === undefined || tab?.kind === "console",
-            )
-            .map((tab: any) => ({
-              id: tab.id,
-              title: tab.title || "Untitled",
-              connectionId: tab.connectionId,
-              connectionName: tab.metadata?.connectionName || tab.connectionId,
-              databaseName:
-                tab.databaseName || tab.metadata?.queryOptions?.databaseName,
-              contentPreview:
-                (tab.content || "").slice(0, 100) +
-                ((tab.content || "").length > 100 ? "..." : ""),
-              isActive: tab.id === currentActiveId,
-            }));
-
-          addToolOutput({
-            tool: "list_open_consoles",
-            toolCallId: toolCall.toolCallId,
-            output: {
-              success: true,
-              consoles,
-              message: `Found ${consoles.length} open console(s)`,
-            },
-          });
-          return;
-        }
-
-        // Handle set_console_connection - requires explicit consoleId
-        if (toolName === "set_console_connection") {
-          const consoleId = input.consoleId as string | undefined;
-          const connectionId = input.connectionId as string;
-          const databaseId = input.databaseId as string | undefined;
-          const databaseName = input.databaseName as string | undefined;
-
-          if (!consoleId) {
-            addToolOutput({
-              tool: "set_console_connection",
-              toolCallId: toolCall.toolCallId,
-              output: {
-                success: false,
-                error:
-                  "consoleId is required. Use list_open_consoles to get IDs of existing consoles, or create_console to create a new one.",
-              },
-            });
-            return;
-          }
-
-          // Get fresh state to avoid stale closure issues
-          const currentStore = useConsoleStore.getState();
-          const currentTabs = Object.values(currentStore.tabs);
-
-          const targetConsole = currentTabs.find(
-            (c: any) => c.id === consoleId,
-          );
-          if (!targetConsole) {
-            addToolOutput({
-              tool: "set_console_connection",
-              toolCallId: toolCall.toolCallId,
-              output: {
-                success: false,
-                error: `Console with ID ${consoleId} not found. Use list_open_consoles to see available consoles.`,
-              },
-            });
-            return;
-          }
-
-          // Update the console's connection and database
-          currentStore.updateConnection(consoleId, connectionId);
-          if (databaseId !== undefined || databaseName !== undefined) {
-            currentStore.updateDatabase(consoleId, databaseId, databaseName);
-          }
-
-          addToolOutput({
-            tool: "set_console_connection",
-            toolCallId: toolCall.toolCallId,
-            output: {
-              success: true,
-              consoleId,
-              connectionId,
-              databaseId,
-              databaseName,
-              message: `Console "${targetConsole.title}" attached to connection ${connectionId}${databaseName ? ` (database: ${databaseName})` : ""}`,
-            },
-          });
-          return;
-        }
-
-        // Handle open_console - fetch and open a saved console
-        if (toolName === "open_console") {
-          const consoleId = input.consoleId as string | undefined;
-          if (!consoleId) {
-            addToolOutput({
-              tool: "open_console",
-              toolCallId: toolCall.toolCallId,
-              output: {
-                success: false,
-                error: "consoleId is required.",
-              },
-            });
-            return;
-          }
-
-          const { abortController } = registerActiveClientToolCall(
-            "open_console",
-            toolCall.toolCallId,
-          );
-
-          try {
-            const currentStore = useConsoleStore.getState();
-            const existingTab = currentStore.tabs[consoleId];
-            if (existingTab) {
-              currentStore.setActiveTab(consoleId);
-              settleActiveClientToolCall("open_console", toolCall.toolCallId, {
-                success: true,
-                consoleId,
-                title: existingTab.title,
-                message: `Console "${existingTab.title}" is already open — switched to it.`,
-              });
-              return;
-            }
-
-            const data = await currentStore.fetchConsoleContent(
-              workspaceIdRef.current!,
-              consoleId,
-              { signal: abortController.signal },
-            );
-            if (abortController.signal.aborted) {
-              return;
-            }
-            if (!data) {
-              settleActiveClientToolCall("open_console", toolCall.toolCallId, {
-                success: false,
-                error: `Console ${consoleId} not found or access denied.`,
-              });
-              return;
-            }
-
-            const title = data.name || data.path || "Untitled";
-            currentStore.openTab({
-              id: consoleId,
-              title,
-              content: data.content || "",
-              connectionId: data.connectionId,
-              databaseId: data.databaseId,
-              databaseName: data.databaseName,
-            });
-            currentStore.setActiveTab(consoleId);
-
-            settleActiveClientToolCall("open_console", toolCall.toolCallId, {
-              success: true,
-              consoleId,
-              title,
-              message: `Console "${title}" opened successfully.`,
-            });
-          } catch (err) {
-            if (abortController.signal.aborted) {
-              return;
-            }
-            settleActiveClientToolCall("open_console", toolCall.toolCallId, {
-              success: false,
-              error: `Failed to open console: ${err instanceof Error ? err.message : String(err)}`,
-            });
-          }
-          return;
-        }
-
-        // Handle get_chart_template — pure lookup, no side effects
-        if (toolName === "get_chart_template") {
-          const { getTemplate } = await import("@mako/schemas");
-          const templateId = (input as Record<string, unknown>).templateId as
-            | string
-            | undefined;
-          if (!templateId) {
-            addToolOutput({
-              tool: "get_chart_template",
-              toolCallId: toolCall.toolCallId,
-              output: {
-                success: false,
-                error: "templateId is required.",
-              },
-            });
-            return;
-          }
-          const tpl = getTemplate(templateId);
-          if (!tpl) {
-            addToolOutput({
-              tool: "get_chart_template",
-              toolCallId: toolCall.toolCallId,
-              output: {
-                success: false,
-                error: `Template "${templateId}" not found. Available IDs: multi-series-line-hover, time-series-area, grouped-bar, stacked-bar, horizontal-ranking, donut, kpi-sparkline.`,
-              },
-            });
-            return;
-          }
-          addToolOutput({
-            tool: "get_chart_template",
-            toolCallId: toolCall.toolCallId,
-            output: { success: true, template: tpl },
-          });
-          return;
-        }
-
-        // Handle modify_chart_spec - set chart visualization for current results
-        if (toolName === "modify_chart_spec") {
-          const vegaLiteSpec = input.vegaLiteSpec as
-            | Record<string, unknown>
-            | undefined;
-          if (!vegaLiteSpec) {
-            addToolOutput({
-              tool: "modify_chart_spec",
-              toolCallId: toolCall.toolCallId,
-              output: {
-                success: false,
-                error: "vegaLiteSpec is required.",
-              },
-            });
-            return;
-          }
-
-          // Validate the spec structure with Zod before sending to the renderer
-          const { MakoChartSpec: MakoChartSpecSchema } = await import(
-            "../lib/chart-spec"
-          );
-          const parsed = MakoChartSpecSchema.safeParse(vegaLiteSpec);
-          if (!parsed.success) {
-            const issues = parsed.error.issues
-              .slice(0, 5)
-              .map((i: any) => `${i.path.join(".")}: ${i.message}`)
-              .join("; ");
-            addToolOutput({
-              tool: "modify_chart_spec",
-              toolCallId: toolCall.toolCallId,
-              output: {
-                success: false,
-                error: `Invalid Vega-Lite spec: ${issues}. Fix the spec and try again.`,
-              },
-            });
-            return;
-          }
-
-          if (!onChartSpecChangeRef?.current) {
-            addToolOutput({
-              tool: "modify_chart_spec",
-              toolCallId: toolCall.toolCallId,
-              output: {
-                success: false,
-                error: "No active console tab to display the chart in.",
-              },
-            });
-            return;
-          }
-
-          const { abortController } = registerActiveClientToolCall(
-            "modify_chart_spec",
-            toolCall.toolCallId,
-          );
-
-          try {
-            // Send the spec to the renderer and wait for render result
-            const renderResult = await new Promise<{
-              success: boolean;
-              error?: string;
-            }>((resolve, reject) => {
-              const timeout = setTimeout(() => {
-                abortController.signal.removeEventListener(
-                  "abort",
-                  handleAbort,
-                );
-                resolve({ success: true });
-              }, 5000);
-              const handleAbort = () => {
-                clearTimeout(timeout);
-                abortController.signal.removeEventListener(
-                  "abort",
-                  handleAbort,
-                );
-                reject(
-                  new DOMException("Chart update cancelled", "AbortError"),
-                );
-              };
-
-              if (abortController.signal.aborted) {
-                handleAbort();
-                return;
-              }
-
-              abortController.signal.addEventListener("abort", handleAbort, {
-                once: true,
-              });
-              onChartSpecChangeRef.current!({
-                spec: parsed.data,
-                onRenderResult: result => {
-                  clearTimeout(timeout);
-                  abortController.signal.removeEventListener(
-                    "abort",
-                    handleAbort,
-                  );
-                  resolve(result);
-                },
-              });
-            });
-
-            if (renderResult.success) {
-              settleActiveClientToolCall(
-                "modify_chart_spec",
-                toolCall.toolCallId,
-                {
-                  success: true,
-                  message: "Chart rendered successfully in the results panel.",
-                },
-              );
-            } else {
-              settleActiveClientToolCall(
-                "modify_chart_spec",
-                toolCall.toolCallId,
-                {
-                  success: false,
-                  error: `Chart failed to render: ${renderResult.error}. Fix the Vega-Lite spec and try again.`,
-                },
-              );
-            }
-          } catch (chartError) {
-            if (abortController.signal.aborted) {
-              return;
-            }
-
-            settleActiveClientToolCall(
-              "modify_chart_spec",
-              toolCall.toolCallId,
-              {
-                success: false,
-                error:
-                  chartError instanceof Error
-                    ? chartError.message
-                    : "Chart rendering failed unexpectedly.",
-              },
-            );
-          }
+            input,
+            workspaceId: workspaceIdRef.current,
+            capturedConsoleId: capturedConsoleIdRef.current,
+            onConsoleModification: onConsoleModificationRef.current,
+            onChartSpecChange: onChartSpecChangeRef?.current,
+            addToolOutput,
+            registerActiveClientToolCall,
+            settleActiveClientToolCall,
+          })
+        ) {
           return;
         }
 
         // --- Dashboard tools (client-side) ---
         try {
-          const activeDashboardTool = LONG_RUNNING_DASHBOARD_TOOLS.has(toolName)
+          const activeDashboardTool = LONG_RUNNING_DASHBOARD_TOOL_NAMES.has(
+            toolName as AgentToolName,
+          )
             ? registerActiveClientToolCall(toolName, toolCall.toolCallId)
             : null;
 
           const dashboardToolOutput = await executeDashboardAgentTool(
             toolName,
             input,
-            capturedDashboardIdRef.current,
             activeDashboardTool
               ? {
                   executionId: activeDashboardTool.executionId,
@@ -1856,7 +1116,9 @@ const Chat: React.FC<ChatProps> = ({
             return;
           }
         } catch (dashboardError) {
-          if (LONG_RUNNING_DASHBOARD_TOOLS.has(toolName)) {
+          if (
+            LONG_RUNNING_DASHBOARD_TOOL_NAMES.has(toolName as AgentToolName)
+          ) {
             if (manualStopRequestedRef.current) {
               return;
             }
@@ -1878,201 +1140,6 @@ const Chat: React.FC<ChatProps> = ({
                     ? dashboardError.message
                     : "Dashboard tool execution failed",
               },
-            });
-          }
-          return;
-        }
-
-        // Handle run_console - execute the query in a console tab
-        if (toolName === "run_console") {
-          const consoleId = input.consoleId as string | undefined;
-
-          if (!consoleId) {
-            addToolOutput({
-              tool: "run_console",
-              toolCallId: toolCall.toolCallId,
-              output: {
-                success: false,
-                error:
-                  "consoleId is required. Use list_open_consoles to get IDs of existing consoles.",
-              },
-            });
-            return;
-          }
-
-          const currentStore = useConsoleStore.getState();
-          const currentTabs = Object.values(currentStore.tabs);
-          const targetConsole = currentTabs.find(
-            (c: any) => c.id === consoleId,
-          ) as ConsoleTab | undefined;
-
-          if (!targetConsole) {
-            addToolOutput({
-              tool: "run_console",
-              toolCallId: toolCall.toolCallId,
-              output: {
-                success: false,
-                error: `Console with ID ${consoleId} not found. Use list_open_consoles to see available consoles.`,
-              },
-            });
-            return;
-          }
-
-          const content = targetConsole.content;
-          const connectionId = targetConsole.connectionId;
-          const workspaceId = workspaceIdRef.current;
-
-          if (!content?.trim()) {
-            addToolOutput({
-              tool: "run_console",
-              toolCallId: toolCall.toolCallId,
-              output: {
-                success: false,
-                error:
-                  "Console is empty. Write a query first using modify_console.",
-              },
-            });
-            return;
-          }
-
-          if (!connectionId) {
-            addToolOutput({
-              tool: "run_console",
-              toolCallId: toolCall.toolCallId,
-              output: {
-                success: false,
-                error:
-                  "Console has no database connection. Use set_console_connection to attach one first.",
-              },
-            });
-            return;
-          }
-
-          if (!workspaceId) {
-            addToolOutput({
-              tool: "run_console",
-              toolCallId: toolCall.toolCallId,
-              output: {
-                success: false,
-                error: "No workspace selected.",
-              },
-            });
-            return;
-          }
-
-          const QUERY_TIMEOUT_MS = 120_000; // 2 minutes
-          const { abortController, executionId } = registerActiveClientToolCall(
-            "run_console",
-            toolCall.toolCallId,
-            {
-              cancel: async () => {
-                await useConsoleStore
-                  .getState()
-                  .cancelQuery(workspaceId, executionId);
-              },
-            },
-          );
-          const timeoutId = setTimeout(
-            () => abortController.abort("query-timeout"),
-            QUERY_TIMEOUT_MS,
-          );
-
-          window.dispatchEvent(
-            new CustomEvent("console-execution-start", {
-              detail: { consoleId },
-            }),
-          );
-
-          try {
-            const startTime = Date.now();
-            const result = await currentStore.executeQuery(
-              workspaceId,
-              connectionId,
-              content,
-              {
-                executionId,
-                databaseName: targetConsole.databaseName,
-                databaseId: targetConsole.databaseId,
-                signal: abortController.signal,
-              },
-            );
-            clearTimeout(timeoutId);
-            const executionTime = Date.now() - startTime;
-
-            if (result.success) {
-              const data = result.rows || [];
-              const rowCount = Array.isArray(data) ? data.length : 1;
-              const preview = Array.isArray(data) ? data.slice(0, 50) : data;
-
-              window.dispatchEvent(
-                new CustomEvent("console-execution-result", {
-                  detail: {
-                    consoleId,
-                    result: {
-                      results: data,
-                      executedAt: new Date().toISOString(),
-                      resultCount: rowCount,
-                      executionTime,
-                      fields: result.fields,
-                      pageInfo: result.pageInfo || null,
-                    },
-                  },
-                }),
-              );
-
-              settleActiveClientToolCall("run_console", toolCall.toolCallId, {
-                success: true,
-                rowCount,
-                preview,
-                message: `Query executed successfully. ${rowCount} row(s) returned.`,
-              });
-            } else {
-              const abortReason =
-                typeof abortController.signal.reason === "string"
-                  ? abortController.signal.reason
-                  : undefined;
-              window.dispatchEvent(
-                new CustomEvent("console-execution-result", {
-                  detail: { consoleId, result: null },
-                }),
-              );
-
-              if (abortReason === "chat-stop") {
-                return;
-              }
-
-              settleActiveClientToolCall("run_console", toolCall.toolCallId, {
-                success: false,
-                error:
-                  abortReason === "query-timeout"
-                    ? `Query timed out after ${QUERY_TIMEOUT_MS / 1000}s. The query may be too complex or the database is under heavy load.`
-                    : result.error || "Query execution failed.",
-              });
-            }
-          } catch (e: any) {
-            clearTimeout(timeoutId);
-
-            const abortReason =
-              typeof abortController.signal.reason === "string"
-                ? abortController.signal.reason
-                : undefined;
-
-            window.dispatchEvent(
-              new CustomEvent("console-execution-result", {
-                detail: { consoleId, result: null },
-              }),
-            );
-
-            if (abortReason === "chat-stop") {
-              return;
-            }
-
-            settleActiveClientToolCall("run_console", toolCall.toolCallId, {
-              success: false,
-              error:
-                abortReason === "query-timeout"
-                  ? `Query timed out after ${QUERY_TIMEOUT_MS / 1000}s. The query may be too complex or the database is under heavy load.`
-                  : e?.message || "Query execution failed unexpectedly.",
             });
           }
           return;
@@ -2577,17 +1644,24 @@ const Chat: React.FC<ChatProps> = ({
       manualStopRequestedRef.current = false;
       capturedConsoleIdRef.current = activeConsoleIdRef.current;
       capturedDashboardIdRef.current =
-        useDashboardStore.getState().activeDashboardId ?? null;
+        activeTab?.kind === "dashboard"
+          ? ((activeTab.metadata?.dashboardId as string | undefined) ?? null)
+          : null;
       const store = useConsoleStore.getState();
       const currentTabs = Object.values(store.tabs);
       const activeConsole = currentTabs.find(t => t.id === store.activeTabId);
+      setCapturedConsoleTitle(
+        activeConsole?.kind === undefined || activeConsole?.kind === "console"
+          ? activeConsole?.title || null
+          : null,
+      );
       trackEvent("ai_chat_message_sent", {
         model: modelIdRef.current,
         has_context: !!activeConsole?.content,
       });
       sendMessage({ text });
     },
-    [sendMessage],
+    [activeTab, sendMessage],
   );
 
   // Copy chat history handler
@@ -2814,8 +1888,16 @@ const Chat: React.FC<ChatProps> = ({
                   manualStopRequestedRef.current = false;
                   // Submit the suggestion immediately
                   capturedConsoleIdRef.current = activeConsoleId;
+                  const activeConsole = realConsoleTabs.find(
+                    tab => tab.id === activeConsoleId,
+                  );
+                  setCapturedConsoleTitle(activeConsole?.title || null);
                   capturedDashboardIdRef.current =
-                    useDashboardStore.getState().activeDashboardId ?? null;
+                    activeTab?.kind === "dashboard"
+                      ? ((activeTab.metadata?.dashboardId as
+                          | string
+                          | undefined) ?? null)
+                      : null;
                   trackEvent("ai_chat_message_sent", {
                     model: selectedModelId,
                     has_context: false,

--- a/app/src/components/DashboardsExplorer.tsx
+++ b/app/src/components/DashboardsExplorer.tsx
@@ -25,9 +25,32 @@ import { useConsoleStore } from "../store/consoleStore";
 import { useDashboardStore } from "../store/dashboardStore";
 import { useDashboardTreeStore } from "../store/dashboardTreeStore";
 import { useExplorerStore } from "../store/explorerStore";
+import { focusDashboardTab } from "../dashboard-runtime/shell";
+import type { Dashboard } from "../dashboard-runtime/types";
+import { computeDashboardStateHash } from "../utils/stateHash";
 import ResourceTree, { type ResourceTreeNode } from "./ResourceTree";
 
 const EMPTY_TREE: ResourceTreeNode[] = [];
+const NEW_DASHBOARD_TEMPLATE = {
+  title: "Untitled Dashboard",
+  dataSources: [],
+  widgets: [],
+  relationships: [],
+  globalFilters: [],
+  crossFilter: {
+    enabled: true,
+    resolution: "intersect",
+    engine: "mosaic",
+  },
+  materializationSchedule: {
+    enabled: true,
+    cron: "0 0 * * *",
+    timezone: "UTC",
+  },
+  layout: { columns: 12, rowHeight: 80 },
+  cache: {},
+  access: "private",
+} satisfies Partial<Dashboard>;
 
 export function DashboardsExplorer() {
   const { currentWorkspace } = useWorkspace();
@@ -55,6 +78,7 @@ export function DashboardsExplorer() {
   const renameItem = useDashboardTreeStore(s => s.renameItem);
   const deleteItem = useDashboardTreeStore(s => s.deleteItem);
   const resortItem = useDashboardTreeStore(s => s.resortItem);
+  const createDashboard = useDashboardStore(s => s.createDashboard);
   const duplicateDashboard = useDashboardStore(s => s.duplicateDashboard);
 
   const isDashboardFolderExpanded = useExplorerStore(
@@ -79,15 +103,22 @@ export function DashboardsExplorer() {
     if (workspaceId) await fetchTree(workspaceId);
   }, [workspaceId, fetchTree]);
 
-  const handleCreate = useCallback(() => {
-    const id = openTab({
-      title: "New Dashboard",
-      content: "",
-      kind: "dashboard",
-      metadata: { isNew: true },
+  const handleCreate = useCallback(async () => {
+    if (!workspaceId) return;
+
+    const created = await createDashboard(workspaceId, NEW_DASHBOARD_TEMPLATE);
+    if (!created) return;
+
+    useDashboardStore.setState(state => {
+      state.openDashboards[created._id] = created;
+      state.activeDashboardId = created._id;
+      state.historyMap[created._id] = { stack: [], index: -1 };
+      state.savedStateHashes[created._id] = computeDashboardStateHash(created);
     });
-    setActiveTab(id);
-  }, [openTab, setActiveTab]);
+
+    focusDashboardTab(created._id, created.title);
+    void fetchTree(workspaceId);
+  }, [workspaceId, createDashboard, fetchTree]);
 
   const handleItemClick = useCallback(
     (node: ResourceTreeNode) => {

--- a/app/src/components/StreamingToolCard.tsx
+++ b/app/src/components/StreamingToolCard.tsx
@@ -37,6 +37,11 @@ import {
   X,
   ExternalLink,
 } from "lucide-react";
+import {
+  getAgentToolManifestEntry,
+  type ToolIconKey,
+  type ToolUiConfig,
+} from "../agent-runtime/client-tool-manifest";
 
 export type ToolPartState =
   | "input-streaming"
@@ -53,316 +58,7 @@ interface StreamingToolCardProps {
   onDetailClick?: () => void;
 }
 
-interface ToolConfig {
-  getLabel: (input?: unknown) => string;
-  icon: React.ReactNode;
-  preview?: { field: string; language: string };
-}
-
 const ICON_SIZE = 13;
-
-const TOOL_CONFIG: Record<string, ToolConfig> = {
-  // ── Console ──────────────────────────────────────────────
-  modify_console: {
-    getLabel: input => {
-      const action = (input as Record<string, unknown>)?.action;
-      return action === "patch" ? "Patching console" : "Editing console";
-    },
-    icon: <Pencil size={ICON_SIZE} />,
-    preview: { field: "content", language: "sql" },
-  },
-  create_console: {
-    getLabel: input => {
-      const title = (input as Record<string, unknown>)?.title;
-      return title ? `Creating "${title}"` : "Creating console";
-    },
-    icon: <Plus size={ICON_SIZE} />,
-    preview: { field: "content", language: "sql" },
-  },
-  read_console: {
-    getLabel: () => "Reading console",
-    icon: <Eye size={ICON_SIZE} />,
-  },
-  list_open_consoles: {
-    getLabel: () => "Listing open consoles",
-    icon: <List size={ICON_SIZE} />,
-  },
-  set_console_connection: {
-    getLabel: () => "Setting connection",
-    icon: <Link size={ICON_SIZE} />,
-  },
-  open_console: {
-    getLabel: () => "Opening console",
-    icon: <ExternalLink size={ICON_SIZE} />,
-  },
-
-  // ── SQL ──────────────────────────────────────────────────
-  sql_execute_query: {
-    getLabel: () => "Executing SQL query",
-    icon: <Play size={ICON_SIZE} />,
-    preview: { field: "query", language: "sql" },
-  },
-  sql_list_connections: {
-    getLabel: () => "Listing SQL connections",
-    icon: <Database size={ICON_SIZE} />,
-  },
-  sql_list_databases: {
-    getLabel: () => "Listing databases",
-    icon: <Database size={ICON_SIZE} />,
-  },
-  sql_list_tables: {
-    getLabel: input => {
-      const db = (input as Record<string, unknown>)?.database;
-      return db ? `Listing tables in ${db}` : "Listing tables";
-    },
-    icon: <Table2 size={ICON_SIZE} />,
-  },
-  sql_inspect_table: {
-    getLabel: input => {
-      const table = (input as Record<string, unknown>)?.table;
-      return table ? `Inspecting ${table}` : "Inspecting table";
-    },
-    icon: <Search size={ICON_SIZE} />,
-  },
-
-  // ── MongoDB ──────────────────────────────────────────────
-  mongo_execute_query: {
-    getLabel: () => "Executing MongoDB query",
-    icon: <Play size={ICON_SIZE} />,
-    preview: { field: "query", language: "javascript" },
-  },
-  mongo_list_connections: {
-    getLabel: () => "Listing MongoDB connections",
-    icon: <Database size={ICON_SIZE} />,
-  },
-  mongo_list_databases: {
-    getLabel: () => "Listing databases",
-    icon: <Database size={ICON_SIZE} />,
-  },
-  mongo_list_collections: {
-    getLabel: input => {
-      const db = (input as Record<string, unknown>)?.databaseName;
-      return db ? `Listing collections in ${db}` : "Listing collections";
-    },
-    icon: <Table2 size={ICON_SIZE} />,
-  },
-  mongo_inspect_collection: {
-    getLabel: input => {
-      const coll = (input as Record<string, unknown>)?.collectionName;
-      return coll ? `Inspecting ${coll}` : "Inspecting collection";
-    },
-    icon: <Search size={ICON_SIZE} />,
-  },
-
-  // ── Universal discovery ──────────────────────────────────
-  list_connections: {
-    getLabel: () => "Listing connections",
-    icon: <Database size={ICON_SIZE} />,
-  },
-
-  // ── Chart ────────────────────────────────────────────────
-  modify_chart_spec: {
-    getLabel: () => "Setting chart specification",
-    icon: <BarChart3 size={ICON_SIZE} />,
-    preview: { field: "vegaLiteSpec", language: "json" },
-  },
-
-  // ── Dashboard ────────────────────────────────────────────
-  list_open_dashboards: {
-    getLabel: () => "Listing open dashboards",
-    icon: <List size={ICON_SIZE} />,
-  },
-  search_dashboards: {
-    getLabel: input => {
-      const query = (input as Record<string, unknown>)?.query;
-      return query
-        ? `Searching dashboards: "${query}"`
-        : "Searching dashboards";
-    },
-    icon: <Search size={ICON_SIZE} />,
-  },
-  open_dashboard: {
-    getLabel: () => "Opening dashboard",
-    icon: <ExternalLink size={ICON_SIZE} />,
-  },
-  create_dashboard: {
-    getLabel: input => {
-      const title = (input as Record<string, unknown>)?.title;
-      return title ? `Creating dashboard "${title}"` : "Creating dashboard";
-    },
-    icon: <Plus size={ICON_SIZE} />,
-  },
-  add_widget: {
-    getLabel: input => {
-      const type = (input as Record<string, unknown>)?.type;
-      return type ? `Adding ${type} widget` : "Adding widget";
-    },
-    icon: <Plus size={ICON_SIZE} />,
-    preview: { field: "localSql", language: "sql" },
-  },
-  modify_widget: {
-    getLabel: () => "Modifying widget",
-    icon: <Pencil size={ICON_SIZE} />,
-    preview: { field: "localSql", language: "sql" },
-  },
-  remove_widget: {
-    getLabel: () => "Removing widget",
-    icon: <Trash2 size={ICON_SIZE} />,
-  },
-  create_data_source: {
-    getLabel: input => {
-      const name = (input as Record<string, unknown>)?.name;
-      return name ? `Creating data source "${name}"` : "Creating data source";
-    },
-    icon: <Plus size={ICON_SIZE} />,
-    preview: { field: "code", language: "sql" },
-  },
-  update_data_source_query: {
-    getLabel: input => {
-      const inp = input as Record<string, unknown>;
-      const action = inp?.action;
-      const run = inp?.run === true;
-      const suffix = run ? "" : " (definition only)";
-      if (action === "patch") return `Patching data source query${suffix}`;
-      if (action === "append") return `Appending to data source query${suffix}`;
-      return `Updating data source query${suffix}`;
-    },
-    icon: <Pencil size={ICON_SIZE} />,
-    preview: { field: "code", language: "sql" },
-  },
-  run_data_source_query: {
-    getLabel: () => "Running data source query",
-    icon: <Play size={ICON_SIZE} />,
-  },
-  import_console_as_data_source: {
-    getLabel: () => "Importing console as data source",
-    icon: <Download size={ICON_SIZE} />,
-  },
-  add_data_source: {
-    getLabel: () => "Importing data source",
-    icon: <Download size={ICON_SIZE} />,
-  },
-  get_dashboard_state: {
-    getLabel: () => "Reading dashboard state",
-    icon: <Eye size={ICON_SIZE} />,
-  },
-  preview_data_source: {
-    getLabel: () => "Previewing data",
-    icon: <Eye size={ICON_SIZE} />,
-    preview: { field: "sql", language: "sql" },
-  },
-  get_data_preview: {
-    getLabel: () => "Previewing data",
-    icon: <Eye size={ICON_SIZE} />,
-    preview: { field: "sql", language: "sql" },
-  },
-  suggest_charts: {
-    getLabel: () => "Suggesting charts",
-    icon: <BarChart3 size={ICON_SIZE} />,
-  },
-  add_global_filter: {
-    getLabel: input => {
-      const label = (input as Record<string, unknown>)?.label;
-      return label ? `Adding filter "${label}"` : "Adding filter";
-    },
-    icon: <Filter size={ICON_SIZE} />,
-  },
-  remove_global_filter: {
-    getLabel: () => "Removing filter",
-    icon: <Trash2 size={ICON_SIZE} />,
-  },
-  link_tables: {
-    getLabel: () => "Linking tables",
-    icon: <Link size={ICON_SIZE} />,
-  },
-  set_time_dimension: {
-    getLabel: () => "Setting time dimension",
-    icon: <Clock size={ICON_SIZE} />,
-  },
-
-  // ── Search ───────────────────────────────────────────────
-  search_consoles: {
-    getLabel: input => {
-      const query = (input as Record<string, unknown>)?.query;
-      return query ? `Searching "${query}"` : "Searching consoles";
-    },
-    icon: <Search size={ICON_SIZE} />,
-  },
-
-  // ── Self-directive / memory ──────────────────────────────
-  read_self_directive: {
-    getLabel: () => "Reading memory",
-    icon: <Brain size={ICON_SIZE} />,
-  },
-  update_self_directive: {
-    getLabel: () => "Updating memory",
-    icon: <Brain size={ICON_SIZE} />,
-  },
-
-  // ── Flow tools ───────────────────────────────────────────
-  get_form_state: {
-    getLabel: () => "Reading form state",
-    icon: <Eye size={ICON_SIZE} />,
-  },
-  set_form_field: {
-    getLabel: input => {
-      const field = (input as Record<string, unknown>)?.fieldName;
-      return field ? `Setting ${field}` : "Setting form field";
-    },
-    icon: <Pencil size={ICON_SIZE} />,
-  },
-  set_multiple_fields: {
-    getLabel: input => {
-      const fields = (input as Record<string, unknown>)?.fields;
-      const count =
-        fields && typeof fields === "object" ? Object.keys(fields).length : 0;
-      return count > 0 ? `Setting ${count} fields` : "Setting form fields";
-    },
-    icon: <Pencil size={ICON_SIZE} />,
-  },
-  create_flow_tab: {
-    getLabel: () => "Creating flow tab",
-    icon: <Plus size={ICON_SIZE} />,
-  },
-  list_flow_tabs: {
-    getLabel: () => "Listing flow tabs",
-    icon: <List size={ICON_SIZE} />,
-  },
-
-  // ── Flow discovery ───────────────────────────────────────
-  list_databases: {
-    getLabel: () => "Listing databases",
-    icon: <Database size={ICON_SIZE} />,
-  },
-  list_tables: {
-    getLabel: () => "Listing tables",
-    icon: <Table2 size={ICON_SIZE} />,
-  },
-  inspect_table: {
-    getLabel: input => {
-      const table = (input as Record<string, unknown>)?.table;
-      return table ? `Inspecting ${table}` : "Inspecting table";
-    },
-    icon: <Search size={ICON_SIZE} />,
-  },
-  execute_query: {
-    getLabel: () => "Executing query",
-    icon: <Play size={ICON_SIZE} />,
-    preview: { field: "query", language: "sql" },
-  },
-  validate_query: {
-    getLabel: () => "Validating query",
-    icon: <ShieldCheck size={ICON_SIZE} />,
-    preview: { field: "query", language: "sql" },
-  },
-  explain_template: {
-    getLabel: input => {
-      const ph = (input as Record<string, unknown>)?.placeholder;
-      return ph ? `Explaining {{${ph}}}` : "Explaining template";
-    },
-    icon: <HelpCircle size={ICON_SIZE} />,
-  },
-};
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -370,11 +66,55 @@ function humanizeToolName(name: string): string {
   return name.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
 }
 
-function getToolConfig(toolName: string): ToolConfig {
+function renderToolIcon(iconKey: ToolIconKey): React.ReactNode {
+  switch (iconKey) {
+    case "pencil":
+      return <Pencil size={ICON_SIZE} />;
+    case "plus":
+      return <Plus size={ICON_SIZE} />;
+    case "eye":
+      return <Eye size={ICON_SIZE} />;
+    case "list":
+      return <List size={ICON_SIZE} />;
+    case "link":
+      return <Link size={ICON_SIZE} />;
+    case "external-link":
+      return <ExternalLink size={ICON_SIZE} />;
+    case "play":
+      return <Play size={ICON_SIZE} />;
+    case "database":
+      return <Database size={ICON_SIZE} />;
+    case "table":
+      return <Table2 size={ICON_SIZE} />;
+    case "search":
+      return <Search size={ICON_SIZE} />;
+    case "bar-chart":
+      return <BarChart3 size={ICON_SIZE} />;
+    case "download":
+      return <Download size={ICON_SIZE} />;
+    case "trash":
+      return <Trash2 size={ICON_SIZE} />;
+    case "filter":
+      return <Filter size={ICON_SIZE} />;
+    case "clock":
+      return <Clock size={ICON_SIZE} />;
+    case "brain":
+      return <Brain size={ICON_SIZE} />;
+    case "shield-check":
+      return <ShieldCheck size={ICON_SIZE} />;
+    case "help-circle":
+      return <HelpCircle size={ICON_SIZE} />;
+    default:
+      return <Wrench size={ICON_SIZE} />;
+  }
+}
+
+function getToolConfig(toolName: string): ToolUiConfig {
+  const config = getAgentToolManifestEntry(toolName);
   return (
-    TOOL_CONFIG[toolName] ?? {
+    config ?? {
       getLabel: () => humanizeToolName(toolName),
-      icon: <Wrench size={ICON_SIZE} />,
+      icon: "help-circle",
     }
   );
 }
@@ -636,7 +376,7 @@ export const StreamingToolCard = React.memo(
                 <ChevronRight size={14} />
               )
             ) : (
-              config.icon
+              renderToolIcon(config.icon)
             )}
           </Box>
 

--- a/app/src/dashboard-runtime/agent-tools.ts
+++ b/app/src/dashboard-runtime/agent-tools.ts
@@ -11,11 +11,14 @@ import {
   updateDashboardWidget,
 } from "./commands";
 import { useDashboardStore } from "../store/dashboardStore";
-import { useConsoleStore } from "../store/consoleStore";
-import { useUIStore } from "../store/uiStore";
 import type { DashboardDataSource, DashboardWidget } from "./types";
 import { classifyDuckDBError, classifySourceError } from "./error-kinds";
 import { computeDashboardStateHash } from "../utils/stateHash";
+import {
+  DASHBOARD_EXECUTOR_TOOL_NAMES,
+  type AgentToolName,
+} from "../agent-runtime/client-tool-manifest";
+import { focusDashboardTab, getCurrentWorkspaceId } from "./shell";
 import {
   validateCrossFilterWidgetSql,
   validateDuckDBQuery,
@@ -79,7 +82,6 @@ const READ_ONLY_TOOLS = new Set([
   "get_dashboard_state",
   "preview_data_source",
   "get_data_preview",
-  "suggest_charts",
   "get_chart_templates",
   "get_chart_template",
   "list_open_dashboards",
@@ -93,44 +95,16 @@ const EDIT_MODE_EXEMPT_TOOLS = new Set([
   "open_dashboard",
 ]);
 
-const DASHBOARD_TOOLS = new Set([
-  "list_open_dashboards",
-  "open_dashboard",
-  "create_dashboard",
-  "enter_edit_mode",
-  "add_data_source",
-  "import_console_as_data_source",
-  "create_data_source",
-  "update_data_source_query",
-  "run_data_source_query",
-  "get_chart_templates",
-  "get_chart_template",
-  "get_dashboard_state",
-  "get_data_preview",
-  "preview_data_source",
-  "add_widget",
-  "modify_widget",
-  "remove_widget",
-  "add_global_filter",
-  "remove_global_filter",
-  "link_tables",
-  "set_time_dimension",
-]);
-
 export async function executeDashboardAgentTool(
   toolName: string,
   input: Record<string, unknown>,
-  fallbackDashboardId?: string | null,
   options?: { executionId?: string; signal?: AbortSignal },
 ): Promise<Record<string, unknown> | null> {
-  const signal = options?.signal;
-  if (
-    DASHBOARD_TOOLS.has(toolName) &&
-    fallbackDashboardId &&
-    typeof input.dashboardId !== "string"
-  ) {
-    input = { ...input, dashboardId: fallbackDashboardId };
+  if (!DASHBOARD_EXECUTOR_TOOL_NAMES.has(toolName as AgentToolName)) {
+    return null;
   }
+
+  const signal = options?.signal;
   if (toolName === "list_open_dashboards") {
     const store = useDashboardStore.getState();
     const dashboards = Object.values(store.openDashboards).map((d: any) => ({
@@ -164,14 +138,7 @@ export async function executeDashboardAgentTool(
           s.activeDashboardId = dashboardId;
         });
       }
-      const consoleStore = useConsoleStore.getState();
-      const existingTab = Object.values(consoleStore.tabs).find(
-        (t: any) =>
-          t.kind === "dashboard" && t.metadata?.dashboardId === dashboardId,
-      );
-      if (existingTab) {
-        consoleStore.setActiveTab((existingTab as any).id);
-      }
+      focusDashboardTab(dashboardId, (existing as any).title);
       return {
         success: true,
         dashboardId,
@@ -180,7 +147,7 @@ export async function executeDashboardAgentTool(
       };
     }
 
-    const workspaceId = useUIStore.getState().currentWorkspaceId;
+    const workspaceId = getCurrentWorkspaceId();
     if (!workspaceId) {
       return { success: false, error: "No active workspace" };
     }
@@ -197,23 +164,7 @@ export async function executeDashboardAgentTool(
         };
       }
 
-      const consoleStore = useConsoleStore.getState();
-      const existingTab = Object.values(consoleStore.tabs).find(
-        (t: any) =>
-          t.kind === "dashboard" && t.metadata?.dashboardId === dashboardId,
-      );
-      if (!existingTab) {
-        const tabId = consoleStore.openTab({
-          title: (dashboard as any).title,
-          content: "",
-          kind: "dashboard",
-          metadata: { dashboardId },
-        });
-        consoleStore.setActiveTab(tabId);
-      } else {
-        consoleStore.setActiveTab((existingTab as any).id);
-      }
-      useUIStore.getState().setLeftPane("dashboards");
+      focusDashboardTab(dashboardId, (dashboard as any).title);
 
       return {
         success: true,
@@ -229,7 +180,7 @@ export async function executeDashboardAgentTool(
   }
 
   if (toolName === "create_dashboard") {
-    const workspaceId = useUIStore.getState().currentWorkspaceId;
+    const workspaceId = getCurrentWorkspaceId();
     if (!workspaceId || typeof workspaceId !== "string") {
       return { success: false, error: "No active workspace" };
     }
@@ -269,15 +220,7 @@ export async function executeDashboardAgentTool(
         .catch(() => {});
       throwIfAborted(signal);
 
-      const consoleStore = useConsoleStore.getState();
-      const tabId = consoleStore.openTab({
-        title: dashboard.title,
-        content: "",
-        kind: "dashboard",
-        metadata: { dashboardId: dashboard._id },
-      });
-      consoleStore.setActiveTab(tabId);
-      useUIStore.getState().setLeftPane("dashboards");
+      focusDashboardTab(dashboard._id, dashboard.title);
 
       return {
         success: true,

--- a/app/src/dashboard-runtime/commands.ts
+++ b/app/src/dashboard-runtime/commands.ts
@@ -230,23 +230,14 @@ export async function activateDashboardSession(
 }
 
 export async function closeDashboardSession(
-  dashboardId?: string,
+  dashboardId: string,
 ): Promise<void> {
-  const id = dashboardId ?? useDashboardStore.getState().activeDashboardId;
-  if (!id) return;
-  await disposeDashboardRuntime(id);
+  await disposeDashboardRuntime(dashboardId);
 }
 
-export async function getDashboardMosaicInstance(dashboardId?: string) {
-  const resolvedDashboardId =
-    dashboardId || useDashboardStore.getState().activeDashboardId;
-  if (!resolvedDashboardId) {
-    throw new Error("No active dashboard");
-  }
-
+export async function getDashboardMosaicInstance(dashboardId: string) {
   return (
-    getMosaicInstance(resolvedDashboardId) ||
-    (await ensureMosaicInstance(resolvedDashboardId))
+    getMosaicInstance(dashboardId) || (await ensureMosaicInstance(dashboardId))
   );
 }
 
@@ -653,7 +644,7 @@ export function refreshDashboardWidgetCommand(options: {
     );
 }
 
-export function getDashboardStateSnapshot(dashboardId?: string) {
+export function getDashboardStateSnapshot(dashboardId: string) {
   const dashboard = getDashboardOrThrow(dashboardId);
 
   return {

--- a/app/src/dashboard-runtime/shell.ts
+++ b/app/src/dashboard-runtime/shell.ts
@@ -1,0 +1,27 @@
+import { useConsoleStore } from "../store/consoleStore";
+import { useUIStore } from "../store/uiStore";
+
+export function getCurrentWorkspaceId(): string | null {
+  return useUIStore.getState().currentWorkspaceId ?? null;
+}
+
+export function focusDashboardTab(dashboardId: string, title: string): string {
+  const consoleStore = useConsoleStore.getState();
+  const existingTab = Object.values(consoleStore.tabs).find(
+    (tab: any) =>
+      tab.kind === "dashboard" && tab.metadata?.dashboardId === dashboardId,
+  );
+
+  const tabId =
+    existingTab?.id ??
+    consoleStore.openTab({
+      title,
+      content: "",
+      kind: "dashboard",
+      metadata: { dashboardId },
+    });
+
+  consoleStore.setActiveTab(tabId);
+  useUIStore.getState().setLeftPane("dashboards");
+  return tabId;
+}


### PR DESCRIPTION
## Summary

- **Extract ~1,500 lines** from the monolithic `Chat.tsx` and `StreamingToolCard.tsx` into dedicated, testable modules under `app/src/agent-runtime/`
- **`client-tool-manifest.ts`**: single source of truth for all agent tool metadata (domain, execution type, UI labels/icons/previews), replacing duplicated config in `StreamingToolCard` and hardcoded sets in `Chat.tsx`
- **`console-agent-tools.ts`**: extracted console & chart tool execution logic (`read_console`, `modify_console`, `create_console`, `run_console`, `modify_chart_spec`, etc.)
- **`request-context.ts`**: extracted chat request body building with `buildChatRequestBody()` and `buildDashboardRequestContext()`
- **`dashboard-runtime/shell.ts`**: thin helpers (`focusDashboardTab`, `getCurrentWorkspaceId`) eliminating duplicated tab-focusing logic across `agent-tools.ts` and `DashboardsExplorer.tsx`
- **Type-safe `openDashboards`** on `AgentContext` — removes unsafe `as unknown as Record<string, unknown>` casts in API prompt builders
- **Remove unused `suggest_charts` tool** from schema, prompt, and manifest
- **Dashboard commands require explicit `dashboardId`** — no more silent fallback to active dashboard
- **`DashboardsExplorer`** now creates dashboards via API before opening a tab (instead of opening a blank "New Dashboard" tab)
- **Contract tests** validate manifest keys match API-side tool schemas, and request context correctly omits/includes dashboard data based on active view

## Test plan

- [ ] Verify `pnpm build` passes (lint + typecheck)
- [ ] Run `pnpm vitest run` for the new test files (`client-tool-manifest.test.ts`, `request-context.test.ts`)
- [ ] Manual: open a console, send a chat message — verify console tools (read, modify, create, run) work as before
- [ ] Manual: open a dashboard, send a chat message — verify dashboard context is included and dashboard tools work
- [ ] Manual: on a console tab with a dashboard open in another tab — verify dashboard context is NOT sent
- [ ] Manual: click "New Dashboard" in the explorer — verify it creates via API and opens the tab
- [ ] Verify `suggest_charts` is no longer offered by the agent


Made with [Cursor](https://cursor.com)