### PR TITLE
feat: inline CDC materialize trigger + reduce throttle to 10s

### DIFF
--- a/api/src/inngest/functions/sync-entity.ts
+++ b/api/src/inngest/functions/sync-entity.ts
@@ -532,7 +532,9 @@ export const syncBackfillEntityFunction = inngest.createFunction(
                 { entity, flushIndex, tempCount },
               );
               await performPrepareStaging(bulkSyncOptions as any);
-              await performBulkFlush(bulkSyncOptions as any);
+              await performBulkFlush(bulkSyncOptions as any, () =>
+                touchHeartbeat(executionId),
+              );
               await performStagingMerge(bulkSyncOptions as any);
               await performStagingCleanup(bulkSyncOptions as any);
             },
@@ -580,7 +582,9 @@ export const syncBackfillEntityFunction = inngest.createFunction(
             { entity, tempCount: finalRowsInTemp },
           );
           await performPrepareStaging(bulkSyncOptions as any);
-          await performBulkFlush(bulkSyncOptions as any);
+          await performBulkFlush(bulkSyncOptions as any, () =>
+            touchHeartbeat(executionId),
+          );
         });
 
         await step.run(`merge-final-${safeEntityStepId}`, async () => {

--- a/api/src/inngest/functions/webhook-flow.ts
+++ b/api/src/inngest/functions/webhook-flow.ts
@@ -35,7 +35,7 @@ const WEBHOOK_CDC_INGEST_PROCESS_CONCURRENCY = Math.max(
 );
 
 const CDC_MATERIALIZE_THROTTLE_PERIOD = (process.env
-  .CDC_MATERIALIZE_THROTTLE_PERIOD || "30s") as `${number}s`;
+  .CDC_MATERIALIZE_THROTTLE_PERIOD || "10s") as `${number}s`;
 
 async function runWebhookEventProcess({
   event,
@@ -933,8 +933,24 @@ export const webhookEventProcessCdcFunction = inngest.createFunction(
         count: cdcEvents.length,
         dropped: droppedIds.length,
         total: webhookEvents.length,
+        workspaceId: String(flow.workspaceId),
+        entities: [...new Set(cdcEvents.map(e => e.entity))],
       };
     });
+
+    const { entities: ingestedEntities, workspaceId } = result as {
+      entities?: string[];
+      workspaceId?: string;
+    };
+    if (ingestedEntities && ingestedEntities.length > 0 && workspaceId) {
+      await step.sendEvent(
+        "trigger-materialize",
+        ingestedEntities.map(entity => ({
+          name: "cdc/materialize" as const,
+          data: { workspaceId, flowId, entity, force: false },
+        })),
+      );
+    }
 
     return { success: true, ...result };
   },

--- a/api/src/services/sync-executor.service.ts
+++ b/api/src/services/sync-executor.service.ts
@@ -33,8 +33,9 @@ export async function performSyncChunk(
 
 export async function performBulkFlush(
   options: SyncChunkOptions,
+  onBatchFlushed?: () => Promise<void>,
 ): Promise<{ flushed: number }> {
-  return performBulkFlushOrchestrated(options);
+  return performBulkFlushOrchestrated(options, onBatchFlushed);
 }
 
 export async function performPrepareStaging(

--- a/api/src/sync-cdc/ingest.ts
+++ b/api/src/sync-cdc/ingest.ts
@@ -9,10 +9,10 @@ class CdcIngestService {
   /**
    * Append normalized CDC events to the event store and update ingest state.
    *
-   * Materialization is NOT triggered inline — the cdcMaterializeSchedulerFunction
-   * cron picks up stale entities every ~30 s by comparing lastIngestSeq vs
-   * lastMaterializedSeq in CdcEntityState. The `enqueue` parameter is retained
-   * for backward compatibility but is a no-op.
+   * The caller (webhookEventProcessCdcFunction) is responsible for triggering
+   * materialization by emitting cdc/materialize events after this call.
+   * The cdcMaterializeSchedulerFunction cron acts as a safety net for any
+   * entities missed by the inline trigger.
    */
   async appendNormalizedEvents(params: {
     workspaceId: string;

--- a/api/src/sync/sync-orchestrator.ts
+++ b/api/src/sync/sync-orchestrator.ts
@@ -1012,6 +1012,7 @@ async function flushBulkBuffer(
   flowId: string,
   logger?: SyncLogger,
   schemaFields?: FieldMeta[],
+  onBatchFlushed?: () => Promise<void>,
 ): Promise<{ flushed: number }> {
   const initialCount = await tempCollection.countDocuments();
   if (initialCount === 0) return { flushed: 0 };
@@ -1207,6 +1208,8 @@ async function flushBulkBuffer(
       global.gc();
     }
 
+    await onBatchFlushed?.();
+
     consecutiveSuccesses++;
     if (
       consecutiveSuccesses >= CONSECUTIVE_OK_TO_GROW &&
@@ -1291,6 +1294,7 @@ async function resolveAdapterContext(options: SyncChunkOptions) {
 
 export async function performBulkFlush(
   options: SyncChunkOptions,
+  onBatchFlushed?: () => Promise<void>,
 ): Promise<{ flushed: number }> {
   if (!options.tableDestination?.connectionId || !options.flowId) {
     return { flushed: 0 };
@@ -1333,6 +1337,7 @@ export async function performBulkFlush(
     options.flowId!,
     options.logger,
     schemaFields,
+    onBatchFlushed,
   );
 }
 


### PR DESCRIPTION
## Summary

- Triggers `cdc/materialize` events directly from `webhookEventProcessCdcFunction` after successful CDC ingest, eliminating the ~60s wait for the scheduler cron to detect stale entities
- Reduces the default `CDC_MATERIALIZE_THROTTLE_PERIOD` from 30s to 10s (still configurable via env var)
- Cuts worst-case webhook-to-BigQuery latency from ~2 minutes to ~15 seconds
- The `cdcMaterializeSchedulerFunction` cron remains as a safety net for any missed triggers

## Test plan

- [ ] Verify CDC webhook events are materialized to BigQuery within ~15s of receipt
- [ ] Confirm the scheduler still picks up stale entities as a fallback
- [ ] Monitor Inngest queue depth — should be significantly lower since inline triggers are coalesced by Inngest's throttle
- [ ] Verify no duplicate materialization runs (concurrency limit of 1 per flowId:entity protects this)


Made with [Cursor](https://cursor.com)