### PR TITLE
fix: keep heartbeat alive during bulk flush to prevent false abandonment

### DIFF
--- a/api/src/inngest/functions/sync-entity.ts
+++ b/api/src/inngest/functions/sync-entity.ts
@@ -532,7 +532,9 @@ export const syncBackfillEntityFunction = inngest.createFunction(
                 { entity, flushIndex, tempCount },
               );
               await performPrepareStaging(bulkSyncOptions as any);
-              await performBulkFlush(bulkSyncOptions as any);
+              await performBulkFlush(bulkSyncOptions as any, () =>
+                touchHeartbeat(executionId),
+              );
               await performStagingMerge(bulkSyncOptions as any);
               await performStagingCleanup(bulkSyncOptions as any);
             },
@@ -580,7 +582,9 @@ export const syncBackfillEntityFunction = inngest.createFunction(
             { entity, tempCount: finalRowsInTemp },
           );
           await performPrepareStaging(bulkSyncOptions as any);
-          await performBulkFlush(bulkSyncOptions as any);
+          await performBulkFlush(bulkSyncOptions as any, () =>
+            touchHeartbeat(executionId),
+          );
         });
 
         await step.run(`merge-final-${safeEntityStepId}`, async () => {

--- a/api/src/services/sync-executor.service.ts
+++ b/api/src/services/sync-executor.service.ts
@@ -33,8 +33,9 @@ export async function performSyncChunk(
 
 export async function performBulkFlush(
   options: SyncChunkOptions,
+  onBatchFlushed?: () => Promise<void>,
 ): Promise<{ flushed: number }> {
-  return performBulkFlushOrchestrated(options);
+  return performBulkFlushOrchestrated(options, onBatchFlushed);
 }
 
 export async function performPrepareStaging(

--- a/api/src/sync/sync-orchestrator.ts
+++ b/api/src/sync/sync-orchestrator.ts
@@ -1012,6 +1012,7 @@ async function flushBulkBuffer(
   flowId: string,
   logger?: SyncLogger,
   schemaFields?: FieldMeta[],
+  onBatchFlushed?: () => Promise<void>,
 ): Promise<{ flushed: number }> {
   const initialCount = await tempCollection.countDocuments();
   if (initialCount === 0) return { flushed: 0 };
@@ -1207,6 +1208,8 @@ async function flushBulkBuffer(
       global.gc();
     }
 
+    await onBatchFlushed?.();
+
     consecutiveSuccesses++;
     if (
       consecutiveSuccesses >= CONSECUTIVE_OK_TO_GROW &&
@@ -1291,6 +1294,7 @@ async function resolveAdapterContext(options: SyncChunkOptions) {
 
 export async function performBulkFlush(
   options: SyncChunkOptions,
+  onBatchFlushed?: () => Promise<void>,
 ): Promise<{ flushed: number }> {
   if (!options.tableDestination?.connectionId || !options.flowId) {
     return { flushed: 0 };
@@ -1333,6 +1337,7 @@ export async function performBulkFlush(
     options.flowId!,
     options.logger,
     schemaFields,
+    onBatchFlushed,
   );
 }
 


### PR DESCRIPTION
## Summary

- The `cleanup-abandoned-flows` cron (runs every 5min) marks flow executions as "abandoned" if `lastHeartbeat` is older than 10 minutes
- `performBulkFlush` for large entities like `activities:Meeting` (12K+ rows) can run for 10+ minutes in a single Inngest step, but `touchHeartbeat` was only called once at the start of the step
- The cron was falsely marking these still-running flushes as abandoned, showing the error: "Flow execution abandoned due to worker crash or timeout"

**Fix:** Passes an `onBatchFlushed` callback through `performBulkFlush` → `flushBulkBuffer` that touches the heartbeat after every successful batch, keeping it fresh throughout the entire flush.

## Test plan

- [ ] Trigger a meeting activities backfill and confirm no false "abandoned" errors
- [ ] Verify heartbeat stays fresh in `flow_executions` collection during long flush steps


Made with [Cursor](https://cursor.com)