### PR TITLE
refactor: consolidate ConsoleTree into ResourceTree

### DIFF
--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -744,11 +744,20 @@ const ChatInputArea = React.memo(
           <Box
             sx={{
               display: "flex",
-              justifyContent: "space-between",
               alignItems: "center",
+              gap: 0.5,
+              minWidth: 0,
             }}
           >
-            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 0.5,
+                flex: "1 1 auto",
+                minWidth: 0,
+              }}
+            >
               <ModelSelector />
             </Box>
 
@@ -766,6 +775,7 @@ const ChatInputArea = React.memo(
                   "&:hover": {
                     backgroundColor: "action.selected",
                   },
+                  flexShrink: 0,
                 }}
               >
                 <Box
@@ -804,6 +814,7 @@ const ChatInputArea = React.memo(
                     backgroundColor: "action.disabledBackground",
                     color: "text.disabled",
                   },
+                  flexShrink: 0,
                 }}
               >
                 <ArrowUp size={18} />

--- a/app/src/components/ConsoleExplorer.tsx
+++ b/app/src/components/ConsoleExplorer.tsx
@@ -41,6 +41,7 @@ import {
   type ConsoleSearchResult,
 } from "../store/consoleTreeStore";
 import { useConsoleContentStore } from "../store/consoleContentStore";
+import { filterTree } from "../store/lib/tree-helpers";
 import FileExplorerDialog from "./FileExplorerDialog";
 import ConsoleInfoModal from "./ConsoleInfoModal";
 import FolderInfoModal from "./FolderInfoModal";
@@ -122,22 +123,6 @@ function ConsoleExplorer(
       }
     }
     return ids;
-  };
-
-  const filterTree = (nodes: ConsoleEntry[], query: string): ConsoleEntry[] => {
-    const lower = query.toLowerCase();
-    const result: ConsoleEntry[] = [];
-    for (const node of nodes) {
-      if (node.isDirectory && node.children) {
-        const filteredChildren = filterTree(node.children, query);
-        if (filteredChildren.length > 0) {
-          result.push({ ...node, children: filteredChildren });
-        }
-      } else if (node.name.toLowerCase().includes(lower)) {
-        result.push(node);
-      }
-    }
-    return result;
   };
 
   const filteredMyConsoles =

--- a/app/src/components/ConsoleTree.tsx
+++ b/app/src/components/ConsoleTree.tsx
@@ -1,85 +1,43 @@
 import {
-  useState,
-  useRef,
-  useEffect,
+  forwardRef,
   useCallback,
   useImperativeHandle,
-  forwardRef,
-  type ReactNode,
+  useRef,
+  useState,
 } from "react";
 import {
-  Box,
-  List,
-  ListItemButton,
-  ListItemIcon,
-  ListItemText,
-  Typography,
-  Menu,
-  MenuItem,
-  Tooltip,
-  Chip,
-  Divider,
-} from "@mui/material";
-import {
-  SquareTerminal as ConsoleIcon,
-  FolderClosed as FolderIcon,
-  FolderOpen as FolderOpenIcon,
-  ChevronRight as ChevronRightIcon,
-  ChevronDown as ChevronDownIcon,
   Eye as EyeIcon,
   Globe as GlobeIcon,
-  Pencil as EditIcon,
-  Trash2 as DeleteIcon,
-  Copy as DuplicateIcon,
-  Info as InfoIcon,
-  FolderPlus as CreateFolderIcon,
-  FolderInput as MoveIcon,
+  SquareTerminal as ConsoleIcon,
 } from "lucide-react";
-import {
-  DndContext,
-  closestCenter,
-  DragOverlay,
-  useSensor,
-  useSensors,
-  PointerSensor,
-  useDraggable,
-  useDroppable,
-  type DragStartEvent,
-  type DragEndEvent,
-  type DragOverEvent,
-} from "@dnd-kit/core";
+import { Box, Tooltip } from "@mui/material";
 import { useExplorerStore } from "../store/explorerStore";
 import { useConsoleStore } from "../store/consoleStore";
 import { useWorkspace } from "../contexts/workspace-context";
+import { useAuth } from "../contexts/auth-context";
 import {
   useConsoleTreeStore,
   type ConsoleEntry,
 } from "../store/consoleTreeStore";
-import { useAuth } from "../contexts/auth-context";
-
-// ── Types ──
+import ResourceTree, {
+  type CreatedFolderResult,
+  type ResourceTreeNode,
+  type ResourceTreeRef,
+  type ResourceTreeSection,
+} from "./ResourceTree";
 
 export interface ConsoleTreeProps {
   mode: "sidebar" | "picker";
 
   onFileOpen?: (node: ConsoleEntry) => void;
-
-  /** Picker mode: called when a file (console) is clicked */
   onFileClick?: (node: ConsoleEntry) => void;
-
-  /** Picker mode: called when the selected location changes */
   onLocationChange?: (
     folderId: string | null,
     section: "my" | "workspace",
   ) => void;
-
-  /** Picker mode: externally controlled selected folder */
   selectedLocationId?: string | null;
-
-  /** Auto-expand to this folder on mount and select it */
+  selectedSectionKey?: "my" | "workspace";
   initialFolderId?: string | null;
-
-  /** Which section the initialFolderId belongs to */
   initialSection?: "my" | "workspace";
 
   showFiles?: boolean;
@@ -91,7 +49,6 @@ export interface ConsoleTreeProps {
   enableRename?: boolean;
   enableMove?: boolean;
 
-  /** Sidebar-only callbacks */
   onMoveRequest?: (item: ConsoleEntry) => void;
   onInfoRequest?: (item: ConsoleEntry) => void;
   onFolderInfoRequest?: (item: ConsoleEntry) => void;
@@ -100,7 +57,6 @@ export interface ConsoleTreeProps {
   onDuplicate?: (item: ConsoleEntry) => void;
   onUndo?: () => void;
 
-  /** Optional external search filter */
   searchQuery?: string;
 }
 
@@ -111,8 +67,6 @@ export interface ConsoleTreeRef {
   ) => void;
 }
 
-// ── Component ──
-
 function ConsoleTreeInner(
   {
     mode,
@@ -120,6 +74,7 @@ function ConsoleTreeInner(
     onFileClick,
     onLocationChange,
     selectedLocationId,
+    selectedSectionKey,
     initialFolderId,
     initialSection,
     showFiles = true,
@@ -151,10 +106,11 @@ function ConsoleTreeInner(
   const moveFolder = useConsoleTreeStore(state => state.moveFolder);
   const renameItem = useConsoleTreeStore(state => state.renameItem);
   const deleteItem = useConsoleTreeStore(state => state.deleteItem);
+  const createFolder = useConsoleTreeStore(state => state.createFolder);
+  const resortItem = useConsoleTreeStore(state => state.resortItem);
 
   const activeTabId = useConsoleStore(state => state.activeTabId);
 
-  // Sidebar uses the shared persisted store; picker uses local state
   const storeExpandedFolders = useExplorerStore(
     state => state.console.expandedFolders,
   );
@@ -162,27 +118,35 @@ function ConsoleTreeInner(
   const storeExpandFolder = useExplorerStore(state => state.expandFolder);
 
   const [localExpandedFolders, setLocalExpandedFolders] = useState<Set<string>>(
-    () => new Set(storeExpandedFolders),
+    () => new Set(Object.keys(storeExpandedFolders)),
   );
 
-  const expandedFolders =
-    mode === "sidebar" ? storeExpandedFolders : localExpandedFolders;
+  const isFolderExpandedLocal = useCallback(
+    (key: string): boolean => {
+      if (mode === "sidebar") {
+        return !!storeExpandedFolders[key];
+      }
+      return localExpandedFolders.has(key);
+    },
+    [mode, storeExpandedFolders, localExpandedFolders],
+  );
 
   const toggleFolder = useCallback(
     (path: string) => {
       if (mode === "sidebar") {
         storeToggleFolder(path);
-      } else {
-        setLocalExpandedFolders(prev => {
-          const next = new Set(prev);
-          if (next.has(path)) {
-            next.delete(path);
-          } else {
-            next.add(path);
-          }
-          return next;
-        });
+        return;
       }
+
+      setLocalExpandedFolders(prev => {
+        const next = new Set(prev);
+        if (next.has(path)) {
+          next.delete(path);
+        } else {
+          next.add(path);
+        }
+        return next;
+      });
     },
     [mode, storeToggleFolder],
   );
@@ -191,14 +155,15 @@ function ConsoleTreeInner(
     (path: string) => {
       if (mode === "sidebar") {
         storeExpandFolder(path);
-      } else {
-        setLocalExpandedFolders(prev => {
-          if (prev.has(path)) return prev;
-          const next = new Set(prev);
-          next.add(path);
-          return next;
-        });
+        return;
       }
+
+      setLocalExpandedFolders(prev => {
+        if (prev.has(path)) return prev;
+        const next = new Set(prev);
+        next.add(path);
+        return next;
+      });
     },
     [mode, storeExpandFolder],
   );
@@ -210,1184 +175,206 @@ function ConsoleTreeInner(
     ? sharedWithWorkspaceMap[currentWorkspace.id] || []
     : [];
 
-  // Section expanded states
-  const [myConsolesExpanded, setMyConsolesExpanded] = useState(true);
-  const [sharedWithWorkspaceExpanded, setSharedWithWorkspaceExpanded] =
-    useState(true);
-
-  // Inline rename
-  const [renamingItemId, setRenamingItemId] = useState<string | null>(null);
-  const [renameValue, setRenameValue] = useState("");
-  const renameInputRef = useRef<HTMLInputElement>(null);
-
-  // DnD
-  const [draggedItem, setDraggedItem] = useState<ConsoleEntry | null>(null);
-  const [dropTargetId, setDropTargetId] = useState<string | null>(null);
-
-  // Context menus
-  const [contextMenu, setContextMenu] = useState<{
-    mouseX: number;
-    mouseY: number;
-    item: ConsoleEntry;
-    readOnly?: boolean;
-  } | null>(null);
-  const [sectionContextMenu, setSectionContextMenu] = useState<{
-    mouseX: number;
-    mouseY: number;
-    section: "my" | "workspace";
-  } | null>(null);
-
-  // Keyboard selection
-  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
-
-  // Picker mode: internal selected location (when not externally controlled)
-  const [internalSelectedLocation, setInternalSelectedLocation] = useState<
-    string | null
-  >(null);
-  const [pickerSection, setPickerSection] = useState<"my" | "workspace">("my");
-
-  const currentSelectedLocation =
-    selectedLocationId !== undefined
-      ? selectedLocationId
-      : internalSelectedLocation;
-
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-
-  // Auto-expand to initialFolderId on mount
-  const [didInitialExpand, setDidInitialExpand] = useState(false);
-
-  useEffect(() => {
-    if (didInitialExpand || !initialFolderId) return;
-
-    const findAncestorPaths = (
-      nodes: ConsoleEntry[],
-      targetId: string,
-      ancestors: string[],
-    ): string[] | null => {
-      for (const node of nodes) {
-        if (node.id === targetId) return ancestors;
-        if (node.isDirectory && node.children) {
-          const result = findAncestorPaths(node.children, targetId, [
-            ...ancestors,
-            node.path,
-          ]);
-          if (result) return result;
-        }
-      }
-      return null;
-    };
-
-    let paths = findAncestorPaths(myConsoles, initialFolderId, []);
-    let section: "my" | "workspace" = initialSection ?? "my";
-    if (!paths) {
-      paths = findAncestorPaths(sharedWithWorkspace, initialFolderId, []);
-      if (paths) section = "workspace";
-    }
-
-    if (paths) {
-      for (const p of paths) {
-        expandFolder(p);
-      }
-      // Also expand the target folder itself
-      const targetNode = findNodeById(initialFolderId) ?? null;
-      if (targetNode?.isDirectory) {
-        expandFolder(targetNode.path);
-      }
-    }
-
-    if (section === "my") {
-      setMyConsolesExpanded(true);
-    } else {
-      setSharedWithWorkspaceExpanded(true);
-    }
-
-    setInternalSelectedLocation(initialFolderId);
-    setPickerSection(section);
-    onLocationChange?.(initialFolderId, section);
-    setDidInitialExpand(true);
-
-    requestAnimationFrame(() => {
-      const el = scrollContainerRef.current?.querySelector(
-        `[data-node-id="${initialFolderId}"]`,
-      );
-      el?.scrollIntoView({ block: "center" });
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialFolderId, myConsoles, sharedWithWorkspace, didInitialExpand]);
-
-  const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: { distance: 8 },
-    }),
+  const isOwner = useCallback(
+    (item: ConsoleEntry) => item.owner_id === user?.id,
+    [user?.id],
   );
 
-  // ── Search filtering ──
-
-  const filterTree = useCallback(
-    (nodes: ConsoleEntry[], query: string): ConsoleEntry[] => {
-      const lower = query.toLowerCase();
-      const result: ConsoleEntry[] = [];
-      for (const node of nodes) {
-        if (node.isDirectory && node.children) {
-          const filteredChildren = filterTree(node.children, query);
-          if (filteredChildren.length > 0) {
-            result.push({ ...node, children: filteredChildren });
-          } else if (node.name.toLowerCase().includes(lower)) {
-            result.push(node);
-          }
-        } else if (node.name.toLowerCase().includes(lower)) {
-          result.push(node);
-        }
-      }
-      return result;
+  const canManage = useCallback(
+    (item: ConsoleEntry) => {
+      if (isOwner(item)) return true;
+      const myRole = members.find(member => member.userId === user?.id)?.role;
+      return myRole === "owner" || myRole === "admin";
     },
-    [],
+    [isOwner, members, user?.id],
   );
 
-  const filteredMyConsoles =
-    searchQuery.length >= 2 ? filterTree(myConsoles, searchQuery) : myConsoles;
-  const filteredWorkspaceConsoles =
-    searchQuery.length >= 2
-      ? filterTree(sharedWithWorkspace, searchQuery)
-      : sharedWithWorkspace;
-
-  // ── Helpers ──
-
-  const isOwner = (item: ConsoleEntry): boolean => {
-    return item.owner_id === user?.id;
-  };
-
-  const canManage = (item: ConsoleEntry): boolean => {
-    if (isOwner(item)) return true;
-    const myRole = members.find(m => m.userId === user?.id)?.role;
-    return myRole === "owner" || myRole === "admin";
-  };
-
-  const findInAnyTree = (
-    targetId: string,
-  ): { node: ConsoleEntry; section: "my" | "workspace" } | null => {
-    const search = (nodes: ConsoleEntry[]): ConsoleEntry | null => {
-      for (const node of nodes) {
-        if (node.id === targetId) return node;
-        if (node.isDirectory && node.children) {
-          const found = search(node.children);
-          if (found) return found;
-        }
-      }
-      return null;
-    };
-    const inMy = search(myConsoles);
-    if (inMy) return { node: inMy, section: "my" };
-    const inWorkspace = search(sharedWithWorkspace);
-    if (inWorkspace) return { node: inWorkspace, section: "workspace" };
-    return null;
-  };
-
-  const findNodeById = useCallback(
-    (targetId: string): ConsoleEntry | null => {
-      const search = (nodes: ConsoleEntry[]): ConsoleEntry | null => {
-        for (const node of nodes) {
-          if (node.id === targetId) return node;
-          if (node.isDirectory && node.children) {
-            const found = search(node.children);
-            if (found) return found;
-          }
-        }
-        return null;
-      };
-      return search(myConsoles) || search(sharedWithWorkspace);
-    },
-    [myConsoles, sharedWithWorkspace],
-  );
-
-  // ── Inline rename ──
-
-  const startInlineRename = (item: ConsoleEntry) => {
-    if (!item.id || !enableRename) return;
-    setRenamingItemId(item.id);
-    setRenameValue(item.name);
-    handleContextMenuClose();
-  };
-
-  const commitInlineRename = async () => {
-    if (!currentWorkspace || !renamingItemId || !renameValue.trim()) {
-      cancelInlineRename();
-      return;
-    }
-
-    const item = findNodeById(renamingItemId);
-    const trimmedName = renameValue.trim();
-
-    if (item && trimmedName !== item.name) {
-      await renameItem(
-        currentWorkspace.id,
-        renamingItemId,
-        trimmedName,
-        item.isDirectory,
+  const getItemIcon = useCallback(
+    (node: ConsoleEntry) => {
+      return (
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.25 }}>
+          <ConsoleIcon size={16} strokeWidth={1.5} />
+          {!node.isDirectory &&
+            !isOwner(node) &&
+            (node.access || "private") === "workspace" && (
+              <Tooltip title="Read-only">
+                <EyeIcon
+                  size={14}
+                  strokeWidth={1.5}
+                  style={{ opacity: 0.5, flexShrink: 0 }}
+                />
+              </Tooltip>
+            )}
+        </Box>
       );
-    } else if (item) {
-      useConsoleTreeStore
-        .getState()
-        .resortItem(currentWorkspace.id, renamingItemId);
-    }
+    },
+    [isOwner],
+  );
 
-    setRenamingItemId(null);
-    setRenameValue("");
-  };
+  const handleLocationChange = useCallback(
+    (folderId: string | null, sectionKey: string) => {
+      if (sectionKey === "my" || sectionKey === "workspace") {
+        onLocationChange?.(folderId, sectionKey);
+      }
+    },
+    [onLocationChange],
+  );
 
-  const cancelInlineRename = () => {
-    setRenamingItemId(null);
-    setRenameValue("");
-  };
-
-  useEffect(() => {
-    if (renamingItemId && renameInputRef.current) {
-      renameInputRef.current.focus();
-      renameInputRef.current.select();
-    }
-  }, [renamingItemId]);
-
-  // ── Folder creation (exposed via callback) ──
-
-  const createFolderInline = useCallback(
-    async (parentId: string | null, access?: "private" | "workspace") => {
+  const handleMoveItem = useCallback(
+    (itemId: string, targetFolderId: string | null, access?: string) => {
       if (!currentWorkspace) return;
-      const createFolder = useConsoleTreeStore.getState().createFolder;
-      const result = await createFolder(
+      void moveConsole(
+        currentWorkspace.id,
+        itemId,
+        targetFolderId,
+        (access as "private" | "workspace" | undefined) ?? undefined,
+      );
+    },
+    [currentWorkspace, moveConsole],
+  );
+
+  const handleMoveFolder = useCallback(
+    (folderId: string, parentId: string | null, access?: string) => {
+      if (!currentWorkspace) return;
+      void moveFolder(
+        currentWorkspace.id,
+        folderId,
+        parentId,
+        (access as "private" | "workspace" | undefined) ?? undefined,
+      );
+    },
+    [currentWorkspace, moveFolder],
+  );
+
+  const handleRenameItem = useCallback(
+    (id: string, name: string, isDirectory: boolean) => {
+      if (!currentWorkspace) return;
+      void renameItem(currentWorkspace.id, id, name, isDirectory);
+    },
+    [currentWorkspace, renameItem],
+  );
+
+  const handleDeleteItem = useCallback(
+    async (node: ResourceTreeNode) => {
+      if (!currentWorkspace) return;
+      const consoleNode = node as ConsoleEntry;
+
+      if (mode === "sidebar") {
+        if (consoleNode.isDirectory) {
+          onDeleteRequest?.(consoleNode);
+        } else {
+          onSoftDelete?.(consoleNode);
+        }
+        return;
+      }
+
+      if (!consoleNode.id) return;
+      await deleteItem(
+        currentWorkspace.id,
+        consoleNode.id,
+        consoleNode.isDirectory,
+      );
+    },
+    [currentWorkspace, deleteItem, mode, onDeleteRequest, onSoftDelete],
+  );
+
+  const handleCreateFolder = useCallback(
+    async (
+      parentId: string | null,
+      access?: string,
+    ): Promise<CreatedFolderResult | null> => {
+      if (!currentWorkspace) return null;
+      return createFolder(
         currentWorkspace.id,
         "New Folder",
         parentId,
-        access,
+        (access as "private" | "workspace" | undefined) ?? undefined,
       );
-      if (result) {
-        setRenamingItemId(result.id);
-        setRenameValue(result.name);
-      }
     },
-    [currentWorkspace],
+    [createFolder, currentWorkspace],
   );
+
+  const sections = [
+    {
+      key: "my",
+      label: "My Consoles",
+      icon: <ConsoleIcon size={18} strokeWidth={1.5} />,
+      nodes: myConsoles as ResourceTreeNode[],
+      droppableId: enableDragDrop ? "__section_my" : undefined,
+      defaultAccess: "private" as const,
+    },
+    {
+      key: "workspace",
+      label: "Workspace",
+      icon: <GlobeIcon size={18} strokeWidth={1.5} />,
+      nodes: sharedWithWorkspace as ResourceTreeNode[],
+      droppableId: enableDragDrop ? "__section_workspace" : undefined,
+      defaultAccess: "workspace" as const,
+    },
+  ] satisfies ResourceTreeSection[];
+
+  const resourceTreeRef = useRef<ResourceTreeRef | null>(null);
 
   useImperativeHandle(
     ref,
     () => ({
-      createFolder: createFolderInline,
+      createFolder: (parentId, access) => {
+        void resourceTreeRef.current?.createFolder(parentId, access);
+      },
     }),
-    [createFolderInline],
-  );
-
-  // ── Context menu handlers ──
-
-  const handleContextMenu = (
-    event: React.MouseEvent,
-    item: ConsoleEntry,
-    readOnly = false,
-  ) => {
-    event.preventDefault();
-    setContextMenu({
-      mouseX: event.clientX + 2,
-      mouseY: event.clientY - 6,
-      item,
-      readOnly,
-    });
-  };
-
-  const handleContextMenuClose = () => {
-    setContextMenu(null);
-  };
-
-  const handleSectionContextMenu = (
-    event: React.MouseEvent,
-    section: "my" | "workspace",
-  ) => {
-    event.preventDefault();
-    setSectionContextMenu({
-      mouseX: event.clientX + 2,
-      mouseY: event.clientY - 6,
-      section,
-    });
-  };
-
-  const handleDelete = (item: ConsoleEntry) => {
-    if (item.isDirectory) {
-      onDeleteRequest?.(item);
-    } else {
-      onSoftDelete?.(item);
-    }
-    handleContextMenuClose();
-  };
-
-  const handleDeleteInPicker = async (item: ConsoleEntry) => {
-    if (!currentWorkspace || !item.id) return;
-    handleContextMenuClose();
-    await deleteItem(currentWorkspace.id, item.id, item.isDirectory);
-  };
-
-  // ── DnD handlers ──
-
-  const handleDragStart = (event: DragStartEvent) => {
-    const result = findInAnyTree(event.active.id as string);
-    if (result) setDraggedItem(result.node);
-  };
-
-  const handleDragOver = (event: DragOverEvent) => {
-    const { over } = event;
-    setDropTargetId(over ? (over.id as string) : null);
-  };
-
-  const handleDragEnd = async (event: DragEndEvent) => {
-    const { active, over } = event;
-    setDraggedItem(null);
-    setDropTargetId(null);
-
-    if (!over || !currentWorkspace || active.id === over.id) return;
-
-    const dragId = active.id as string;
-    const dropId = over.id as string;
-    const dragResult = findInAnyTree(dragId);
-    if (!dragResult) return;
-
-    if (dropId === "__section_my" || dropId === "__section_workspace") {
-      const newAccess =
-        dropId === "__section_workspace" ? "workspace" : "private";
-      if (dragResult.node.isDirectory) {
-        await moveFolder(currentWorkspace.id, dragId, null, newAccess);
-      } else {
-        await moveConsole(currentWorkspace.id, dragId, null, newAccess);
-      }
-      return;
-    }
-
-    if (dropId.startsWith("__folder_content_")) {
-      const parentFolderId = dropId.replace("__folder_content_", "");
-      if (dragResult.node.isDirectory) {
-        await moveFolder(currentWorkspace.id, dragId, parentFolderId);
-      } else {
-        await moveConsole(currentWorkspace.id, dragId, parentFolderId);
-      }
-      return;
-    }
-
-    const dropResult = findInAnyTree(dropId);
-    if (!dropResult?.node.isDirectory) return;
-
-    if (dragResult.node.isDirectory) {
-      await moveFolder(currentWorkspace.id, dragId, dropId);
-    } else {
-      await moveConsole(currentWorkspace.id, dragId, dropId);
-    }
-  };
-
-  // ── Keyboard navigation ──
-
-  const flatNodeIds = (() => {
-    const ids: string[] = [];
-    const collect = (nodes: ConsoleEntry[], sectionExpanded: boolean) => {
-      if (!sectionExpanded) return;
-      for (const node of nodes) {
-        if (!showFiles && !node.isDirectory) continue;
-        if (node.id) ids.push(node.id);
-        if (
-          node.isDirectory &&
-          expandedFolders.has(node.path) &&
-          node.children
-        ) {
-          collect(node.children, true);
-        }
-      }
-    };
-    collect(filteredMyConsoles, myConsolesExpanded);
-    collect(filteredWorkspaceConsoles, sharedWithWorkspaceExpanded);
-    return ids;
-  })();
-
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      const tag = (e.target as HTMLElement)?.tagName;
-      if (tag === "INPUT" || tag === "TEXTAREA") return;
-
-      const focusId =
-        selectedNodeId || (mode === "sidebar" ? activeTabId : null);
-      const focusItem = focusId ? findNodeById(focusId) : null;
-      const meta = e.metaKey || e.ctrlKey;
-
-      if (e.key === "F2" && focusItem && enableRename) {
-        e.preventDefault();
-        startInlineRename(focusItem);
-        return;
-      }
-
-      if (
-        (e.key === "Delete" || e.key === "Backspace") &&
-        focusItem &&
-        !meta &&
-        enableDelete
-      ) {
-        e.preventDefault();
-        if (mode === "sidebar") {
-          handleDelete(focusItem);
-        } else {
-          handleDeleteInPicker(focusItem);
-        }
-        return;
-      }
-
-      if (
-        meta &&
-        e.key === "d" &&
-        focusItem &&
-        !focusItem.isDirectory &&
-        enableDuplicate
-      ) {
-        e.preventDefault();
-        onDuplicate?.(focusItem);
-        return;
-      }
-
-      if (
-        meta &&
-        e.key === "i" &&
-        focusItem &&
-        !focusItem.isDirectory &&
-        enableInfo
-      ) {
-        e.preventDefault();
-        onInfoRequest?.(focusItem);
-        return;
-      }
-
-      if (meta && e.key === "z" && !e.shiftKey && onUndo) {
-        e.preventDefault();
-        onUndo();
-        return;
-      }
-
-      if (e.key === "ArrowDown") {
-        e.preventDefault();
-        const idx = focusId ? flatNodeIds.indexOf(focusId) : -1;
-        const nextId = flatNodeIds[idx + 1];
-        if (nextId) setSelectedNodeId(nextId);
-        return;
-      }
-
-      if (e.key === "ArrowUp") {
-        e.preventDefault();
-        const idx = focusId ? flatNodeIds.indexOf(focusId) : flatNodeIds.length;
-        const prevId = flatNodeIds[idx - 1];
-        if (prevId) setSelectedNodeId(prevId);
-        return;
-      }
-
-      if (e.key === "ArrowRight" && focusItem?.isDirectory) {
-        e.preventDefault();
-        if (!expandedFolders.has(focusItem.path)) {
-          toggleFolder(focusItem.path);
-        }
-        return;
-      }
-
-      if (e.key === "ArrowLeft" && focusItem?.isDirectory) {
-        e.preventDefault();
-        if (expandedFolders.has(focusItem.path)) {
-          toggleFolder(focusItem.path);
-        }
-        return;
-      }
-
-      if (e.key === "Enter" && focusItem) {
-        e.preventDefault();
-        if (focusItem.isDirectory) {
-          toggleFolder(focusItem.path);
-          if (mode === "picker") {
-            handlePickerSelect(focusItem);
-          }
-        } else if (mode === "sidebar") {
-          onFileOpen?.(focusItem);
-        }
-        return;
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    selectedNodeId,
-    activeTabId,
-    myConsoles,
-    sharedWithWorkspace,
-    flatNodeIds,
-    expandedFolders,
-    mode,
-  ]);
-
-  // ── Picker selection ──
-
-  const handlePickerSelect = (node: ConsoleEntry) => {
-    if (!node.isDirectory) return;
-    const result = findInAnyTree(node.id!);
-    const section = result?.section ?? pickerSection;
-    setInternalSelectedLocation(node.id ?? null);
-    setPickerSection(section);
-    onLocationChange?.(node.id ?? null, section);
-  };
-
-  const handlePickerSectionRootSelect = (section: "my" | "workspace") => {
-    setInternalSelectedLocation(null);
-    setPickerSection(section);
-    onLocationChange?.(null, section);
-  };
-
-  // ── Access icon ──
-
-  const getAccessIcon = (node: ConsoleEntry) => {
-    if (isOwner(node)) return null;
-    const nodeAccess = node.access || "private";
-    if (nodeAccess === "workspace") {
-      return (
-        <Tooltip title="Read-only">
-          <EyeIcon
-            size={14}
-            strokeWidth={1.5}
-            style={{ opacity: 0.5, flexShrink: 0 }}
-          />
-        </Tooltip>
-      );
-    }
-    return null;
-  };
-
-  // ── Inline rename input ──
-
-  const renderInlineRenameInput = () => (
-    <input
-      ref={renameInputRef}
-      value={renameValue}
-      onChange={e => setRenameValue(e.target.value)}
-      onBlur={commitInlineRename}
-      onKeyDown={e => {
-        if (e.key === "Enter") {
-          e.preventDefault();
-          commitInlineRename();
-        }
-        if (e.key === "Escape") {
-          e.preventDefault();
-          cancelInlineRename();
-        }
-        e.stopPropagation();
-      }}
-      onClick={e => e.stopPropagation()}
-      onDoubleClick={e => e.stopPropagation()}
-      style={{
-        border: "none",
-        borderRadius: 3,
-        padding: 0,
-        margin: 0,
-        fontSize: "0.875rem",
-        lineHeight: "1.43",
-        width: "100%",
-        outline: "1px solid currentColor",
-        outlineOffset: "1px",
-        background: "transparent",
-        color: "inherit",
-        fontFamily: "inherit",
-        boxSizing: "border-box",
-      }}
-    />
-  );
-
-  // ── Tree rendering ──
-
-  const renderTree = (
-    nodes: ConsoleEntry[],
-    depth = 0,
-    readOnlyContext = false,
-  ) => {
-    return nodes.map(node => {
-      if (!showFiles && !node.isDirectory) return null;
-
-      if (node.isDirectory) {
-        const isExpanded = expandedFolders.has(node.path);
-        const nodeKey = node.id || node.path;
-        const isDragOver =
-          dropTargetId === node.id ||
-          dropTargetId === `__folder_content_${node.id}`;
-        const isRenaming = renamingItemId === node.id;
-        const isPickerSelected =
-          mode === "picker" && currentSelectedLocation === node.id;
-
-        return (
-          <div key={`dir-${nodeKey}`}>
-            <DraggableTreeItem
-              id={node.id || node.path}
-              disabled={readOnlyContext || !enableDragDrop}
-              isFolder
-            >
-              <ListItemButton
-                data-node-id={node.id}
-                onClick={() => {
-                  setSelectedNodeId(node.id || null);
-                  toggleFolder(node.path);
-                  if (mode === "picker") {
-                    handlePickerSelect(node);
-                  }
-                }}
-                onContextMenu={e => handleContextMenu(e, node, readOnlyContext)}
-                onDoubleClick={e => {
-                  if (!readOnlyContext && enableRename) {
-                    e.stopPropagation();
-                    startInlineRename(node);
-                  }
-                }}
-                selected={isPickerSelected || selectedNodeId === node.id}
-                sx={{
-                  py: 0.25,
-                  pl: 0.5 + depth * 1.5,
-                  bgcolor: isDragOver ? "action.hover" : undefined,
-                  outline: isDragOver ? "2px dashed" : undefined,
-                  outlineColor: isDragOver ? "primary.main" : undefined,
-                  borderRadius: isDragOver ? 1 : undefined,
-                }}
-              >
-                <ListItemIcon sx={{ minWidth: 22, mr: 0 }}>
-                  {isExpanded ? (
-                    <ChevronDownIcon strokeWidth={1.5} size={20} />
-                  ) : (
-                    <ChevronRightIcon strokeWidth={1.5} size={20} />
-                  )}
-                </ListItemIcon>
-                <ListItemIcon sx={{ minWidth: 24 }}>
-                  {isExpanded ? (
-                    <FolderOpenIcon strokeWidth={1.5} size={18} />
-                  ) : (
-                    <FolderIcon strokeWidth={1.5} size={18} />
-                  )}
-                </ListItemIcon>
-                {isRenaming ? (
-                  <Box sx={{ flex: 1, minWidth: 0 }}>
-                    {renderInlineRenameInput()}
-                  </Box>
-                ) : (
-                  <ListItemText
-                    primary={node.name}
-                    primaryTypographyProps={{
-                      variant: "body2",
-                      style: {
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                        whiteSpace: "nowrap",
-                      },
-                    }}
-                  />
-                )}
-              </ListItemButton>
-            </DraggableTreeItem>
-            {isExpanded && (
-              <DroppableFolderContent folderId={node.id || node.path}>
-                <List component="div" disablePadding dense>
-                  {node.children &&
-                    renderTree(node.children, depth + 1, readOnlyContext)}
-                </List>
-              </DroppableFolderContent>
-            )}
-          </div>
-        );
-      }
-
-      const nodeKey = node.id || node.path;
-      const isActive =
-        mode === "sidebar" && !!(node.id && activeTabId === node.id);
-      const isRenaming = renamingItemId === node.id;
-
-      return (
-        <DraggableTreeItem
-          key={`file-${nodeKey}`}
-          id={node.id || node.path}
-          disabled={readOnlyContext || !enableDragDrop}
-        >
-          <ListItemButton
-            onClick={() => {
-              setSelectedNodeId(node.id || null);
-              if (mode === "sidebar") {
-                onFileOpen?.(node);
-              } else if (mode === "picker") {
-                onFileClick?.(node);
-              }
-            }}
-            onContextMenu={e => handleContextMenu(e, node, readOnlyContext)}
-            onDoubleClick={e => {
-              if (!readOnlyContext && enableRename) {
-                e.stopPropagation();
-                startInlineRename(node);
-              }
-            }}
-            selected={isActive || selectedNodeId === node.id}
-            sx={{
-              py: 0.25,
-              pl: 0.5 + depth * 1.5,
-            }}
-          >
-            <ListItemIcon sx={{ minWidth: 22, visibility: "hidden", mr: 0 }} />
-            <ListItemIcon sx={{ minWidth: 24 }}>
-              <ConsoleIcon size={18} strokeWidth={1.5} />
-            </ListItemIcon>
-            {isRenaming ? (
-              <Box sx={{ flex: 1, minWidth: 0 }}>
-                {renderInlineRenameInput()}
-              </Box>
-            ) : (
-              <ListItemText
-                primary={node.name}
-                primaryTypographyProps={{
-                  variant: "body2",
-                  fontSize: "0.9rem",
-                  style: {
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
-                  },
-                }}
-              />
-            )}
-            {getAccessIcon(node)}
-          </ListItemButton>
-        </DraggableTreeItem>
-      );
-    });
-  };
-
-  // ── Section headers ──
-
-  const countItems = (nodes: ConsoleEntry[]): number => {
-    let count = 0;
-    for (const node of nodes) {
-      if (node.isDirectory && node.children) {
-        count += countItems(node.children);
-      } else if (!node.isDirectory) {
-        count += 1;
-      }
-    }
-    return count;
-  };
-
-  const renderSectionHeader = (
-    label: string,
-    icon: ReactNode,
-    isExpanded: boolean,
-    onToggle: () => void,
-    count: number,
-    onCtxMenu?: (e: React.MouseEvent) => void,
-    droppableId?: string,
-    section?: "my" | "workspace",
-  ) => {
-    const isDragOver = droppableId && dropTargetId === droppableId;
-    const isPickerSelected =
-      mode === "picker" &&
-      currentSelectedLocation === null &&
-      pickerSection === section;
-
-    const header = (
-      <ListItemButton
-        onClick={() => {
-          onToggle();
-          if (mode === "picker" && section) {
-            handlePickerSectionRootSelect(section);
-          }
-        }}
-        onContextMenu={onCtxMenu}
-        selected={isPickerSelected}
-        sx={{
-          py: 0.25,
-          pl: 0.5,
-          bgcolor: isDragOver ? "action.hover" : undefined,
-          outline: isDragOver ? "2px dashed" : undefined,
-          outlineColor: isDragOver ? "primary.main" : undefined,
-          borderRadius: isDragOver ? 1 : undefined,
-        }}
-      >
-        <ListItemIcon sx={{ minWidth: 22, mr: 0 }}>
-          {isExpanded ? (
-            <ChevronDownIcon strokeWidth={1.5} size={20} />
-          ) : (
-            <ChevronRightIcon strokeWidth={1.5} size={20} />
-          )}
-        </ListItemIcon>
-        <ListItemIcon sx={{ minWidth: 24 }}>{icon}</ListItemIcon>
-        <ListItemText
-          primary={label}
-          primaryTypographyProps={{
-            variant: "body2",
-            fontWeight: 600,
-            sx: {
-              textTransform: "uppercase",
-              fontSize: "0.75rem",
-              letterSpacing: "0.05em",
-            },
-          }}
-        />
-        {count > 0 && (
-          <Chip
-            label={count}
-            size="small"
-            sx={{ height: 18, fontSize: "0.7rem" }}
-          />
-        )}
-      </ListItemButton>
-    );
-
-    if (droppableId) {
-      return (
-        <DroppableSectionHeader id={droppableId}>
-          {header}
-        </DroppableSectionHeader>
-      );
-    }
-    return header;
-  };
-
-  const renderEmptyPlaceholder = (message: string) => (
-    <Typography
-      sx={{
-        pl: 3,
-        py: 0.5,
-        color: "text.disabled",
-        fontSize: "0.8rem",
-        fontStyle: "italic",
-      }}
-      variant="body2"
-    >
-      {message}
-    </Typography>
-  );
-
-  // ── Main render ──
-
-  const treeContent = (
-    <List component="nav" dense>
-      {renderSectionHeader(
-        "My Consoles",
-        <ConsoleIcon strokeWidth={1.5} size={18} />,
-        myConsolesExpanded,
-        () => setMyConsolesExpanded(!myConsolesExpanded),
-        countItems(filteredMyConsoles),
-        e => handleSectionContextMenu(e, "my"),
-        enableDragDrop ? "__section_my" : undefined,
-        "my",
-      )}
-      {myConsolesExpanded && (
-        <>
-          {filteredMyConsoles.length > 0
-            ? renderTree(filteredMyConsoles, 1)
-            : renderEmptyPlaceholder("No consoles yet")}
-        </>
-      )}
-
-      {renderSectionHeader(
-        "Workspace",
-        <GlobeIcon strokeWidth={1.5} size={18} />,
-        sharedWithWorkspaceExpanded,
-        () => setSharedWithWorkspaceExpanded(!sharedWithWorkspaceExpanded),
-        countItems(filteredWorkspaceConsoles),
-        e => handleSectionContextMenu(e, "workspace"),
-        enableDragDrop ? "__section_workspace" : undefined,
-        "workspace",
-      )}
-      {sharedWithWorkspaceExpanded && (
-        <>
-          {filteredWorkspaceConsoles.length > 0
-            ? renderTree(filteredWorkspaceConsoles, 1)
-            : renderEmptyPlaceholder("No workspace consoles yet")}
-        </>
-      )}
-    </List>
+    [],
   );
 
   return (
-    <Box
-      sx={{ display: "flex", flexDirection: "column", minHeight: 0, flex: 1 }}
-    >
-      <Box
-        ref={scrollContainerRef}
-        sx={{
-          flexGrow: 1,
-          overflowY: "auto",
-          "&::-webkit-scrollbar": { width: "0.4em" },
-          "&::-webkit-scrollbar-track": {
-            boxShadow: "inset 0 0 6px rgba(0,0,0,0.00)",
-          },
-          "&::-webkit-scrollbar-thumb": {
-            backgroundColor: "rgba(0,0,0,.1)",
-            outline: "1px solid slategrey",
-          },
-        }}
-      >
-        {enableDragDrop ? (
-          <DndContext
-            sensors={sensors}
-            collisionDetection={closestCenter}
-            onDragStart={handleDragStart}
-            onDragOver={handleDragOver}
-            onDragEnd={handleDragEnd}
-          >
-            {treeContent}
-            <DragOverlay>
-              {draggedItem ? (
-                <Box
-                  sx={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 1,
-                    px: 1.5,
-                    py: 0.5,
-                    bgcolor: "background.paper",
-                    border: 1,
-                    borderColor: "divider",
-                    borderRadius: 1,
-                    boxShadow: 3,
-                    opacity: 0.9,
-                  }}
-                >
-                  {draggedItem.isDirectory ? (
-                    <FolderIcon size={16} strokeWidth={1.5} />
-                  ) : (
-                    <ConsoleIcon size={16} strokeWidth={1.5} />
-                  )}
-                  <Typography variant="body2" noWrap>
-                    {draggedItem.name}
-                  </Typography>
-                </Box>
-              ) : null}
-            </DragOverlay>
-          </DndContext>
-        ) : (
-          treeContent
-        )}
-      </Box>
-
-      {/* Item context menu */}
-      <Menu
-        open={contextMenu !== null}
-        onClose={handleContextMenuClose}
-        anchorReference="anchorPosition"
-        anchorPosition={
-          contextMenu !== null
-            ? { top: contextMenu.mouseY, left: contextMenu.mouseX }
-            : undefined
-        }
-      >
-        {contextMenu && enableRename && canManage(contextMenu.item) && (
-          <MenuItem
-            onClick={() => contextMenu && startInlineRename(contextMenu.item)}
-          >
-            <EditIcon size={16} strokeWidth={1.5} style={{ marginRight: 8 }} />
-            Rename
-          </MenuItem>
-        )}
-        {contextMenu && enableDuplicate && !contextMenu.item.isDirectory && (
-          <MenuItem
-            onClick={() => {
-              if (contextMenu) {
-                onDuplicate?.(contextMenu.item);
-                handleContextMenuClose();
-              }
-            }}
-          >
-            <DuplicateIcon
-              size={16}
-              strokeWidth={1.5}
-              style={{ marginRight: 8 }}
-            />
-            Duplicate
-          </MenuItem>
-        )}
-        {contextMenu?.item.isDirectory && !contextMenu.readOnly && (
-          <MenuItem
-            onClick={() => {
-              if (contextMenu.item.id) {
-                createFolderInline(contextMenu.item.id);
-                if (!expandedFolders.has(contextMenu.item.path)) {
-                  toggleFolder(contextMenu.item.path);
-                }
-              }
-              handleContextMenuClose();
-            }}
-          >
-            <CreateFolderIcon
-              size={16}
-              strokeWidth={1.5}
-              style={{ marginRight: 8 }}
-            />
-            New Subfolder
-          </MenuItem>
-        )}
-        {contextMenu && enableMove && canManage(contextMenu.item) && (
-          <MenuItem
-            onClick={() => {
-              if (contextMenu) {
-                onMoveRequest?.(contextMenu.item);
-                handleContextMenuClose();
-              }
-            }}
-          >
-            <MoveIcon size={16} strokeWidth={1.5} style={{ marginRight: 8 }} />
-            Move to...
-          </MenuItem>
-        )}
-        {contextMenu && enableInfo && !contextMenu.item.isDirectory && (
-          <MenuItem
-            onClick={() => {
-              if (contextMenu) {
-                onInfoRequest?.(contextMenu.item);
-                handleContextMenuClose();
-              }
-            }}
-          >
-            <InfoIcon size={16} strokeWidth={1.5} style={{ marginRight: 8 }} />
-            Information
-          </MenuItem>
-        )}
-        {contextMenu && enableInfo && contextMenu.item.isDirectory && (
-          <MenuItem
-            onClick={() => {
-              if (contextMenu) {
-                onFolderInfoRequest?.(contextMenu.item);
-                handleContextMenuClose();
-              }
-            }}
-          >
-            <InfoIcon size={16} strokeWidth={1.5} style={{ marginRight: 8 }} />
-            Information
-          </MenuItem>
-        )}
-        {contextMenu && enableDelete && canManage(contextMenu.item) && (
-          <>
-            <Divider />
-            <MenuItem
-              onClick={() => {
-                if (contextMenu) {
-                  if (mode === "sidebar") {
-                    handleDelete(contextMenu.item);
-                  } else {
-                    handleDeleteInPicker(contextMenu.item);
-                  }
-                }
-              }}
-              sx={{ color: "error.main" }}
-            >
-              <DeleteIcon
-                size={16}
-                strokeWidth={1.5}
-                style={{ marginRight: 8 }}
-              />
-              Delete
-            </MenuItem>
-          </>
-        )}
-      </Menu>
-
-      {/* Section header context menu */}
-      <Menu
-        open={sectionContextMenu !== null}
-        onClose={() => setSectionContextMenu(null)}
-        anchorReference="anchorPosition"
-        anchorPosition={
-          sectionContextMenu !== null
-            ? {
-                top: sectionContextMenu.mouseY,
-                left: sectionContextMenu.mouseX,
-              }
-            : undefined
-        }
-      >
-        <MenuItem
-          onClick={() => {
-            const section = sectionContextMenu?.section;
-            setSectionContextMenu(null);
-            if (section === "workspace") {
-              createFolderInline(null, "workspace");
-            } else {
-              createFolderInline(null, "private");
-            }
-          }}
-        >
-          <CreateFolderIcon
-            size={16}
-            strokeWidth={1.5}
-            style={{ marginRight: 8 }}
-          />
-          New Folder
-        </MenuItem>
-      </Menu>
-    </Box>
+    <ResourceTree
+      ref={resourceTreeRef}
+      sections={sections}
+      mode={mode}
+      activeItemId={mode === "sidebar" ? activeTabId : null}
+      searchQuery={searchQuery}
+      getItemIcon={node => getItemIcon(node as ConsoleEntry)}
+      showFiles={showFiles}
+      enableDragDrop={enableDragDrop}
+      enableRename={enableRename}
+      enableDuplicate={enableDuplicate}
+      enableDelete={enableDelete}
+      enableMove={enableMove}
+      enableInfo={enableInfo}
+      enableNewFolder
+      onItemClick={node => onFileOpen?.(node as ConsoleEntry)}
+      onPickerFileClick={node => onFileClick?.(node as ConsoleEntry)}
+      onLocationChange={handleLocationChange}
+      selectedLocationId={selectedLocationId}
+      selectedSectionKey={selectedSectionKey}
+      initialFolderId={initialFolderId}
+      initialSectionKey={initialSection}
+      onMoveItem={handleMoveItem}
+      onMoveFolder={handleMoveFolder}
+      onRenameItem={handleRenameItem}
+      onDeleteItem={handleDeleteItem}
+      onDuplicateItem={node => onDuplicate?.(node as ConsoleEntry)}
+      onCreateFolder={handleCreateFolder}
+      onInfoRequest={node => onInfoRequest?.(node as ConsoleEntry)}
+      onFolderInfoRequest={node => onFolderInfoRequest?.(node as ConsoleEntry)}
+      onMoveRequest={node => onMoveRequest?.(node as ConsoleEntry)}
+      onResortItem={id => {
+        if (!currentWorkspace) return;
+        resortItem(currentWorkspace.id, id);
+      }}
+      onUndo={onUndo}
+      isFolderExpanded={isFolderExpandedLocal}
+      onToggleFolder={toggleFolder}
+      onExpandFolder={expandFolder}
+      getFolderExpansionKey={node => node.id}
+      canManageItem={node => canManage(node as ConsoleEntry)}
+    />
   );
 }
 
 const ConsoleTree = forwardRef<ConsoleTreeRef, ConsoleTreeProps>(
   ConsoleTreeInner,
 );
+
+ConsoleTree.displayName = "ConsoleTree";
+
 export default ConsoleTree;
-
-// ── DnD helper components ──
-
-function DroppableSectionHeader({
-  id,
-  children,
-}: {
-  id: string;
-  children: ReactNode;
-}) {
-  const { setNodeRef } = useDroppable({ id });
-  return <div ref={setNodeRef}>{children}</div>;
-}
-
-function DroppableFolderContent({
-  folderId,
-  children,
-}: {
-  folderId: string;
-  children: ReactNode;
-}) {
-  const { setNodeRef } = useDroppable({
-    id: `__folder_content_${folderId}`,
-  });
-  return <div ref={setNodeRef}>{children}</div>;
-}
-
-function DraggableTreeItem({
-  id,
-  disabled,
-  isFolder,
-  children,
-}: {
-  id: string;
-  disabled?: boolean;
-  isFolder?: boolean;
-  children: ReactNode;
-}) {
-  const {
-    attributes,
-    listeners,
-    setNodeRef: setDragRef,
-    isDragging,
-  } = useDraggable({ id, disabled });
-
-  const { setNodeRef: setDropRef } = useDroppable({
-    id,
-    disabled: !isFolder,
-  });
-
-  const setRef = (el: HTMLElement | null) => {
-    setDragRef(el);
-    if (isFolder) setDropRef(el);
-  };
-
-  return (
-    <div
-      ref={setRef}
-      style={{ opacity: isDragging ? 0.4 : 1 }}
-      {...attributes}
-      {...listeners}
-    >
-      {children}
-    </div>
-  );
-}

--- a/app/src/components/DashboardsExplorer.tsx
+++ b/app/src/components/DashboardsExplorer.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import {
   Box,
+  Chip,
   IconButton,
+  Stack,
   Typography,
   Tooltip,
   Alert,
@@ -53,7 +55,7 @@ const NEW_DASHBOARD_TEMPLATE = {
 } satisfies Partial<Dashboard>;
 
 export function DashboardsExplorer() {
-  const { currentWorkspace } = useWorkspace();
+  const { currentWorkspace, members } = useWorkspace();
   const { user } = useAuth();
   const workspaceId = currentWorkspace?.id;
   const isAdmin =
@@ -81,17 +83,24 @@ export function DashboardsExplorer() {
   const createDashboard = useDashboardStore(s => s.createDashboard);
   const duplicateDashboard = useDashboardStore(s => s.duplicateDashboard);
 
-  const isDashboardFolderExpanded = useExplorerStore(
-    s => s.isDashboardFolderExpanded,
+  const dashboardExpandedFolders = useExplorerStore(
+    s => s.dashboard.expandedFolders,
   );
   const toggleDashboardFolder = useExplorerStore(s => s.toggleDashboardFolder);
   const expandDashboardFolder = useExplorerStore(s => s.expandDashboardFolder);
+
+  const isDashboardFolderExpanded = useCallback(
+    (key: string) => !!dashboardExpandedFolders[key],
+    [dashboardExpandedFolders],
+  );
 
   const { openTab, setActiveTab, activeTabId, tabs } = useConsoleStore();
 
   const [deleteTarget, setDeleteTarget] = useState<ResourceTreeNode | null>(
     null,
   );
+  const [moveTarget, setMoveTarget] = useState<ResourceTreeNode | null>(null);
+  const [infoTarget, setInfoTarget] = useState<ResourceTreeNode | null>(null);
 
   useEffect(() => {
     if (workspaceId) {
@@ -173,14 +182,15 @@ export function DashboardsExplorer() {
     async (
       parentId: string | null,
       access?: string,
-    ): Promise<string | null> => {
+    ): Promise<{ id: string; name: string } | null> => {
       if (!workspaceId) return null;
-      return createFolder(
+      const id = await createFolder(
         workspaceId,
         "New Folder",
         parentId,
         (access as "private" | "workspace") || undefined,
       );
+      return id ? { id, name: "New Folder" } : null;
     },
     [workspaceId, createFolder],
   );
@@ -235,6 +245,14 @@ export function DashboardsExplorer() {
     },
     [isAdmin, user?.id],
   );
+
+  const handleMoveRequest = useCallback((node: ResourceTreeNode) => {
+    setMoveTarget(node);
+  }, []);
+
+  const handleInfoRequest = useCallback((node: ResourceTreeNode) => {
+    setInfoTarget(node);
+  }, []);
 
   const getItemIcon = useCallback((node: ResourceTreeNode) => {
     if (node.access === "workspace") {
@@ -359,9 +377,15 @@ export function DashboardsExplorer() {
             onDuplicateItem={handleDuplicate}
             onCreateFolder={handleCreateFolder}
             onResortItem={handleResortItem}
+            enableMove
+            enableInfo
+            onMoveRequest={handleMoveRequest}
+            onInfoRequest={handleInfoRequest}
+            onFolderInfoRequest={handleInfoRequest}
             isFolderExpanded={isDashboardFolderExpanded}
             onToggleFolder={toggleDashboardFolder}
             onExpandFolder={expandDashboardFolder}
+            getFolderExpansionKey={node => node.id}
             canManageItem={canManageItem}
           />
         )}
@@ -387,7 +411,164 @@ export function DashboardsExplorer() {
           </Button>
         </DialogActions>
       </Dialog>
+
+      {/* Move Dialog */}
+      <Dialog
+        open={!!moveTarget}
+        onClose={() => setMoveTarget(null)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>
+          Move {moveTarget?.isDirectory ? "Folder" : "Dashboard"}
+        </DialogTitle>
+        <DialogContent sx={{ p: 0, height: 320 }}>
+          <ResourceTree
+            sections={sectionsDef}
+            mode="picker"
+            showFiles={false}
+            getItemIcon={getItemIcon}
+            isFolderExpanded={isDashboardFolderExpanded}
+            onToggleFolder={toggleDashboardFolder}
+            onExpandFolder={expandDashboardFolder}
+            getFolderExpansionKey={node => node.id}
+            onLocationChange={(folderId, sectionKey) => {
+              if (!moveTarget || !workspaceId) return;
+              const access =
+                sectionKey === "workspace" ? "workspace" : "private";
+              if (moveTarget.isDirectory) {
+                moveFolder(workspaceId, moveTarget.id, folderId, access);
+              } else {
+                moveItem(workspaceId, moveTarget.id, folderId, access);
+              }
+              setMoveTarget(null);
+            }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setMoveTarget(null)}>Cancel</Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Information Dialog */}
+      <DashboardInfoDialog
+        item={infoTarget}
+        onClose={() => setInfoTarget(null)}
+        members={members}
+      />
     </Box>
+  );
+}
+
+const accessLabels: Record<string, string> = {
+  private: "Private",
+  workspace: "Shared with workspace",
+};
+
+function formatDate(value?: string): string {
+  if (!value) return "Unknown";
+  const d = new Date(value);
+  if (isNaN(d.getTime())) return "Unknown";
+  return d.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function DashboardInfoDialog({
+  item,
+  onClose,
+  members,
+}: {
+  item: ResourceTreeNode | null;
+  onClose: () => void;
+  members: { userId: string; email: string }[];
+}) {
+  const ownerEmail = item?.owner_id
+    ? members.find(m => m.userId === item.owner_id)?.email || item.owner_id
+    : "Unknown";
+
+  const dashboardEntry = item as ResourceTreeNode & {
+    createdAt?: string;
+    updatedAt?: string;
+  };
+
+  return (
+    <Dialog open={!!item} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle sx={{ pb: 1 }}>
+        {item?.isDirectory ? "Folder" : "Dashboard"} Information
+      </DialogTitle>
+      <DialogContent sx={{ pt: 1 }}>
+        <Stack spacing={2}>
+          <Box>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+              Name
+            </Typography>
+            <Typography variant="body2">{item?.name ?? "—"}</Typography>
+          </Box>
+
+          <Box>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+              Created by
+            </Typography>
+            <Typography variant="body2">{ownerEmail}</Typography>
+          </Box>
+
+          {dashboardEntry?.createdAt && (
+            <Box>
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ mb: 0.5 }}
+              >
+                Created at
+              </Typography>
+              <Typography variant="body2">
+                {formatDate(dashboardEntry.createdAt)}
+              </Typography>
+            </Box>
+          )}
+
+          {dashboardEntry?.updatedAt && (
+            <Box>
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ mb: 0.5 }}
+              >
+                Last modified
+              </Typography>
+              <Typography variant="body2">
+                {formatDate(dashboardEntry.updatedAt)}
+              </Typography>
+            </Box>
+          )}
+
+          {item?.access && (
+            <Box>
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ mb: 0.5 }}
+              >
+                Access
+              </Typography>
+              <Chip
+                label={accessLabels[item.access] || item.access}
+                size="small"
+                variant="outlined"
+              />
+            </Box>
+          )}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
   );
 }
 

--- a/app/src/components/DatabaseExplorer.tsx
+++ b/app/src/components/DatabaseExplorer.tsx
@@ -184,7 +184,7 @@ function DatabaseExplorer({
 
       const checkAndFetchMissingChildren = (node: TreeNode) => {
         const nodeKey = `${db.id}:${node.kind}:${node.id}`;
-        if (!node.hasChildren || !expandedNodes.has(nodeKey)) return;
+        if (!node.hasChildren || !expandedNodes[nodeKey]) return;
 
         const childKey = `${node.kind}:${node.id}`;
         const children = dbTree[childKey];
@@ -312,6 +312,8 @@ function DatabaseExplorer({
   };
 
   // ---------------- Context menu for databases ----------------
+  const [contextFocusKey, setContextFocusKey] = useState<string | null>(null);
+
   const [databaseContextMenu, setDatabaseContextMenu] = useState<{
     mouseX: number;
     mouseY: number;
@@ -329,17 +331,14 @@ function DatabaseExplorer({
     (event: React.MouseEvent, databaseId: string, databaseName: string) => {
       event.preventDefault();
       event.stopPropagation();
-      setDatabaseContextMenu(
-        contextMenu === null
-          ? {
-              mouseX: event.clientX + 2,
-              mouseY: event.clientY - 6,
-              item: { databaseId, databaseName },
-            }
-          : null,
-      );
+      setDatabaseContextMenu({
+        mouseX: event.clientX + 2,
+        mouseY: event.clientY - 6,
+        item: { databaseId, databaseName },
+      });
+      setContextFocusKey(databaseId);
     },
-    [contextMenu],
+    [],
   );
 
   const handleEditDatabase = useCallback(() => {
@@ -411,7 +410,7 @@ function DatabaseExplorer({
     level: number,
   ): React.ReactNode => {
     const nodeKey = `${connectionId}:${node.kind}:${node.id}`;
-    const isExpanded = expandedNodes.has(nodeKey);
+    const isExpanded = !!expandedNodes[nodeKey];
     const childKey = `${node.kind}:${node.id}`;
     const children = treeNodes[connectionId]?.[childKey];
     const isLoading = loading[`tree:${connectionId}:${childKey}`];
@@ -462,9 +461,29 @@ function DatabaseExplorer({
                 });
               }
             }}
+            onContextMenu={event => {
+              if (
+                !node.hasChildren &&
+                (node.kind === "collection" || node.kind === "table")
+              ) {
+                event.preventDefault();
+                event.stopPropagation();
+                setContextMenu({
+                  mouseX: event.clientX + 2,
+                  mouseY: event.clientY - 6,
+                  item: {
+                    databaseId: connectionId,
+                    collectionName: node.label,
+                  },
+                });
+                setContextFocusKey(nodeKey);
+              }
+            }}
             sx={{
               py: 0.25,
               pl: 1 + level * 1.5,
+              outline: contextFocusKey === nodeKey ? "1px solid" : undefined,
+              outlineColor: contextFocusKey === nodeKey ? "divider" : undefined,
             }}
           >
             <ListItemIcon sx={{ minWidth: 22 }}>
@@ -581,9 +600,7 @@ function DatabaseExplorer({
             </Box>
           ) : (
             databases.map(database => {
-              const isDatabaseExpandedLocal = expandedDatabases.has(
-                database.id,
-              );
+              const isDatabaseExpandedLocal = !!expandedDatabases[database.id];
               const isLoadingData = loadingData.has(database.id);
               const dbRootNodes: TreeNode[] =
                 treeNodes[database.id]?.["root"] || [];
@@ -601,7 +618,18 @@ function DatabaseExplorer({
                           database.displayName,
                         )
                       }
-                      sx={{ py: 0.5, pl: 1 }}
+                      sx={{
+                        py: 0.5,
+                        pl: 1,
+                        outline:
+                          contextFocusKey === database.id
+                            ? "1px solid"
+                            : undefined,
+                        outlineColor:
+                          contextFocusKey === database.id
+                            ? "divider"
+                            : undefined,
+                      }}
                     >
                       <ListItemIcon sx={{ minWidth: 22 }}>
                         {isDatabaseExpandedLocal ? (
@@ -671,7 +699,10 @@ function DatabaseExplorer({
       {/* Context Menu for collection */}
       <Menu
         open={contextMenu !== null}
-        onClose={() => setContextMenu(null)}
+        onClose={() => {
+          setContextMenu(null);
+          setContextFocusKey(null);
+        }}
         anchorReference="anchorPosition"
         anchorPosition={
           contextMenu !== null
@@ -706,7 +737,10 @@ function DatabaseExplorer({
       {/* Context Menu for database */}
       <Menu
         open={databaseContextMenu !== null}
-        onClose={() => setDatabaseContextMenu(null)}
+        onClose={() => {
+          setDatabaseContextMenu(null);
+          setContextFocusKey(null);
+        }}
         anchorReference="anchorPosition"
         anchorPosition={
           databaseContextMenu !== null

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -1238,7 +1238,13 @@ function Editor({
                   value={tab.id}
                   label={
                     <Box
-                      sx={{ display: "flex", alignItems: "center", gap: 0.75 }}
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 0.75,
+                        minWidth: 0,
+                        maxWidth: "100%",
+                      }}
                     >
                       {tab.icon ? (
                         <Box
@@ -1270,6 +1276,7 @@ function Editor({
                           overflow: "hidden",
                           textOverflow: "ellipsis",
                           whiteSpace: "nowrap",
+                          display: "inline-block",
                           maxWidth: "150px",
                         }}
                         onDoubleClick={e => {

--- a/app/src/components/FileExplorerDialog.tsx
+++ b/app/src/components/FileExplorerDialog.tsx
@@ -41,7 +41,7 @@ interface FileExplorerDialogProps {
   isDirectory?: boolean;
 
   /** new-folder mode: called with parent folderId (null = root) */
-  onNewFolder?: (parentFolderId: string | null) => void;
+  onNewFolder?: (parentFolderId: string | null, name: string) => void;
 
   /** Pre-select this folder on open (e.g. the item's current parent) */
   initialFolderId?: string | null;
@@ -159,7 +159,7 @@ export default function FileExplorerDialog({
       onMove?.(selectedFolderId, nameChanged ? newName : undefined);
     } else if (mode === "new-folder") {
       if (!folderName.trim()) return;
-      onNewFolder?.(selectedFolderId);
+      onNewFolder?.(selectedFolderId, folderName.trim());
     }
   };
 
@@ -221,7 +221,9 @@ export default function FileExplorerDialog({
       <DialogTitle
         sx={{ pb: 0, pt: 1.5, px: 2, display: "flex", alignItems: "center" }}
       >
-        <Box sx={{ flex: 1 }}>{dialogTitle}</Box>
+        <Box sx={{ flex: 1, minWidth: 0 }} className="app-truncate">
+          {dialogTitle}
+        </Box>
         <Tooltip title="New Folder">
           <IconButton size="small" onClick={handleNewFolder}>
             <CreateFolderIcon size={18} strokeWidth={1.5} />
@@ -279,7 +281,7 @@ export default function FileExplorerDialog({
             border: 1,
             borderColor: "divider",
             borderRadius: 1,
-            overflow: "hidden",
+            overflow: "auto",
             display: "flex",
             flexDirection: "column",
           }}
@@ -297,6 +299,7 @@ export default function FileExplorerDialog({
             onLocationChange={handleLocationChange}
             onFileClick={handleFileClick}
             selectedLocationId={selectedFolderId}
+            selectedSectionKey={selectedSection}
             initialFolderId={initialFolderId}
           />
         </Box>

--- a/app/src/components/ModelSelector.tsx
+++ b/app/src/components/ModelSelector.tsx
@@ -114,13 +114,23 @@ export const ModelSelector: React.FC = () => {
           fontSize: 12,
           py: 0.25,
           px: 1,
-          minWidth: "auto",
+          minWidth: 0,
+          maxWidth: "100%",
+          minHeight: 28,
+          flexShrink: 1,
+          justifyContent: "space-between",
           "&:hover": {
             backgroundColor: "action.hover",
           },
         }}
       >
-        {displayName}
+        <Box
+          component="span"
+          className="app-truncate-inline"
+          sx={{ flex: "1 1 auto", minWidth: 0 }}
+        >
+          {displayName}
+        </Box>
       </Button>
       <Menu
         anchorEl={anchorEl}
@@ -168,13 +178,16 @@ export const ModelSelector: React.FC = () => {
                 px: 2,
               }}
             >
-              <Box>
-                <Typography variant="body2">{model.name}</Typography>
+              <Box sx={{ minWidth: 0, width: "100%" }}>
+                <Typography variant="body2" noWrap>
+                  {model.name}
+                </Typography>
                 {model.description && (
                   <Typography
                     variant="caption"
                     color="text.secondary"
                     sx={{ display: "block" }}
+                    noWrap
                   >
                     {model.description}
                   </Typography>

--- a/app/src/components/ResourceTree.tsx
+++ b/app/src/components/ResourceTree.tsx
@@ -1,49 +1,61 @@
 import React, {
   type ReactNode,
-  useState,
-  useEffect,
+  forwardRef,
   useCallback,
+  useEffect,
+  useImperativeHandle,
   useMemo,
   useRef,
+  useState,
 } from "react";
 import {
   Box,
   Chip,
+  Divider,
   List,
   ListItemButton,
   ListItemIcon,
+  ListItemText as MuiListItemText,
   Menu,
   MenuItem,
-  ListItemText as MuiListItemText,
   Typography,
-  Divider,
 } from "@mui/material";
 import {
-  ChevronRight,
+  ArrowRightLeft,
   ChevronDown,
+  ChevronRight,
+  Copy,
   Folder,
   FolderOpen,
-  Pencil,
-  Copy,
-  Trash2,
   FolderPlus,
-  ArrowRightLeft,
   Info,
+  Pencil,
+  Trash2,
 } from "lucide-react";
 import {
   DndContext,
   DragOverlay,
   PointerSensor,
+  closestCenter,
+  pointerWithin,
   useSensor,
   useSensors,
-  closestCenter,
+  type CollisionDetection,
   type DragEndEvent,
-  useDraggable,
-  useDroppable,
+  type DragOverEvent,
+  type DragStartEvent,
 } from "@dnd-kit/core";
-import { filterTree, countItems } from "../store/lib/tree-helpers";
-
-// ── Public types ──
+import { countItems, filterTree } from "../store/lib/tree-helpers";
+import {
+  DraggableTreeItem,
+  DroppableFolderContent,
+  DroppableSectionHeader,
+} from "./resource-tree/dnd";
+import {
+  findNodeInSections,
+  getFolderDropTargetId,
+  resolveTreeDropTarget,
+} from "./resource-tree/utils";
 
 export interface ResourceTreeNode {
   id: string;
@@ -59,10 +71,19 @@ export interface ResourceTreeNode {
 export interface ResourceTreeSection {
   key: string;
   label: string;
-  icon: React.ReactNode;
+  icon: ReactNode;
   nodes: ResourceTreeNode[];
   droppableId?: string;
   defaultAccess?: "private" | "workspace";
+}
+
+export interface CreatedFolderResult {
+  id: string;
+  name: string;
+}
+
+export interface ResourceTreeRef {
+  createFolder: (parentId: string | null, access?: string) => Promise<void>;
 }
 
 export interface ResourceTreeProps {
@@ -71,7 +92,7 @@ export interface ResourceTreeProps {
   activeItemId?: string | null;
   searchQuery?: string;
 
-  getItemIcon?: (node: ResourceTreeNode) => React.ReactNode;
+  getItemIcon?: (node: ResourceTreeNode) => ReactNode;
   showFiles?: boolean;
 
   enableDragDrop?: boolean;
@@ -83,6 +104,13 @@ export interface ResourceTreeProps {
   enableNewFolder?: boolean;
 
   onItemClick?: (node: ResourceTreeNode) => void;
+  onPickerFileClick?: (node: ResourceTreeNode) => void;
+  onLocationChange?: (folderId: string | null, sectionKey: string) => void;
+  selectedLocationId?: string | null;
+  selectedSectionKey?: string;
+  initialFolderId?: string | null;
+  initialSectionKey?: string;
+
   onMoveItem?: (
     itemId: string,
     targetFolderId: string | null,
@@ -99,55 +127,68 @@ export interface ResourceTreeProps {
   onCreateFolder?: (
     parentId: string | null,
     access?: string,
-  ) => Promise<string | null>;
+  ) => Promise<CreatedFolderResult | null>;
   onInfoRequest?: (node: ResourceTreeNode) => void;
+  onFolderInfoRequest?: (node: ResourceTreeNode) => void;
+  onMoveRequest?: (node: ResourceTreeNode) => void;
   onResortItem?: (id: string) => void;
+  onUndo?: () => void;
 
-  isFolderExpanded: (path: string) => boolean;
-  onToggleFolder: (path: string) => void;
-  onExpandFolder: (path: string) => void;
+  isFolderExpanded: (expansionKey: string) => boolean;
+  onToggleFolder: (expansionKey: string) => void;
+  onExpandFolder: (expansionKey: string) => void;
+  getFolderExpansionKey?: (node: ResourceTreeNode) => string;
 
   canManageItem?: (node: ResourceTreeNode) => boolean;
 }
 
-// ── Component ──
+const collisionDetectionStrategy: CollisionDetection = args => {
+  const pointerCollisions = pointerWithin(args);
+  return pointerCollisions.length > 0 ? pointerCollisions : closestCenter(args);
+};
 
-export default function ResourceTree({
-  sections,
-  mode = "sidebar",
-  activeItemId,
-  searchQuery = "",
-
-  getItemIcon,
-  showFiles = true,
-
-  enableDragDrop = true,
-  enableRename = true,
-  enableDuplicate = false,
-  enableDelete = true,
-  enableMove = false,
-  enableInfo = false,
-  enableNewFolder = true,
-
-  onItemClick,
-  onMoveItem,
-  onMoveFolder,
-  onRenameItem,
-  onDeleteItem,
-  onDuplicateItem,
-  onCreateFolder,
-  onInfoRequest,
-  onResortItem,
-
-  isFolderExpanded,
-  onToggleFolder,
-  onExpandFolder,
-
-  canManageItem,
-}: ResourceTreeProps) {
-  // ── State ──
-
-  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+function ResourceTreeInner(
+  {
+    sections,
+    mode = "sidebar",
+    activeItemId,
+    searchQuery = "",
+    getItemIcon,
+    showFiles = true,
+    enableDragDrop = true,
+    enableRename = true,
+    enableDuplicate = false,
+    enableDelete = true,
+    enableMove = false,
+    enableInfo = false,
+    enableNewFolder = true,
+    onItemClick,
+    onPickerFileClick,
+    onLocationChange,
+    selectedLocationId,
+    selectedSectionKey,
+    initialFolderId,
+    initialSectionKey,
+    onMoveItem,
+    onMoveFolder,
+    onRenameItem,
+    onDeleteItem,
+    onDuplicateItem,
+    onCreateFolder,
+    onInfoRequest,
+    onFolderInfoRequest,
+    onMoveRequest,
+    onResortItem,
+    onUndo,
+    isFolderExpanded,
+    onToggleFolder,
+    onExpandFolder,
+    getFolderExpansionKey,
+    canManageItem,
+  }: ResourceTreeProps,
+  ref: React.Ref<ResourceTreeRef>,
+) {
+  const [focusedNodeId, setFocusedNodeId] = useState<string | null>(null);
   const [renamingItemId, setRenamingItemId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
   const renameInputRef = useRef<HTMLInputElement>(null);
@@ -155,9 +196,8 @@ export default function ResourceTree({
   const [contextMenu, setContextMenu] = useState<{
     anchorPosition: { top: number; left: number };
     item: ResourceTreeNode;
-    readOnly?: boolean;
+    readOnly: boolean;
   } | null>(null);
-
   const [sectionContextMenu, setSectionContextMenu] = useState<{
     anchorPosition: { top: number; left: number };
     sectionKey: string;
@@ -165,11 +205,30 @@ export default function ResourceTree({
 
   const [sectionExpanded, setSectionExpanded] = useState<
     Record<string, boolean>
-  >(() => Object.fromEntries(sections.map(s => [s.key, true])));
+  >(() => Object.fromEntries(sections.map(section => [section.key, true])));
 
   const [draggedNode, setDraggedNode] = useState<ResourceTreeNode | null>(null);
+  const [dropTargetId, setDropTargetId] = useState<string | null>(null);
+  const [pendingCreatedFolderId, setPendingCreatedFolderId] = useState<
+    string | null
+  >(null);
+  const [didInitialExpand, setDidInitialExpand] = useState(false);
 
-  // ── DnD ──
+  const [internalSelectedLocation, setInternalSelectedLocation] = useState<
+    string | null
+  >(null);
+  const [internalSelectedSectionKey, setInternalSelectedSectionKey] = useState(
+    sections[0]?.key ?? "",
+  );
+
+  const currentSelectedLocation =
+    selectedLocationId !== undefined
+      ? selectedLocationId
+      : internalSelectedLocation;
+  const currentSelectedSectionKey =
+    selectedSectionKey !== undefined
+      ? selectedSectionKey
+      : internalSelectedSectionKey;
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -177,115 +236,212 @@ export default function ResourceTree({
     }),
   );
 
-  const findNodeById = useCallback(
-    (id: string): ResourceTreeNode | null => {
-      const search = (nodes: ResourceTreeNode[]): ResourceTreeNode | null => {
-        for (const n of nodes) {
-          if (n.id === id) return n;
-          if (n.isDirectory && n.children) {
-            const found = search(n.children);
-            if (found) return found;
-          }
+  useEffect(() => {
+    setSectionExpanded(prev => {
+      const next = { ...prev };
+      for (const section of sections) {
+        if (!(section.key in next)) {
+          next[section.key] = true;
         }
-        return null;
-      };
-      for (const s of sections) {
-        const found = search(s.nodes);
-        if (found) return found;
       }
-      return null;
-    },
+      return next;
+    });
+    if (!internalSelectedSectionKey && sections[0]?.key) {
+      setInternalSelectedSectionKey(sections[0].key);
+    }
+  }, [sections, internalSelectedSectionKey]);
+
+  useEffect(() => {
+    setDidInitialExpand(false);
+  }, [initialFolderId, initialSectionKey, mode]);
+
+  const findNodeLocation = useCallback(
+    (id: string) => findNodeInSections(sections, id),
     [sections],
   );
 
-  const handleDragStart = useCallback(
-    (event: { active: { id: string | number } }) => {
-      const node = findNodeById(String(event.active.id));
-      setDraggedNode(node);
-    },
-    [findNodeById],
+  const getExpansionKey = useCallback(
+    (node: ResourceTreeNode) => getFolderExpansionKey?.(node) ?? node.id,
+    [getFolderExpansionKey],
   );
 
-  const handleDragEnd = useCallback(
-    (event: DragEndEvent) => {
-      setDraggedNode(null);
-      const { active, over } = event;
-      if (!over || !active) return;
-
-      const activeId = String(active.id);
-      const overId = String(over.id);
-      if (activeId === overId) return;
-
-      const activeNode = findNodeById(activeId);
-      if (!activeNode) return;
-
-      for (const s of sections) {
-        if (overId === s.droppableId) {
-          if (activeNode.isDirectory) {
-            onMoveFolder?.(activeId, null, s.defaultAccess);
-          } else {
-            onMoveItem?.(activeId, null, s.defaultAccess);
+  const findAncestorExpansionKeys = useCallback(
+    (
+      nodes: ResourceTreeNode[],
+      targetId: string,
+      ancestors: string[] = [],
+    ): string[] => {
+      for (const node of nodes) {
+        if (node.id === targetId) return ancestors;
+        if (node.isDirectory && node.children) {
+          const found = findAncestorExpansionKeys(node.children, targetId, [
+            ...ancestors,
+            getExpansionKey(node),
+          ]);
+          if (
+            found.length > 0 ||
+            node.children.some(child => child.id === targetId)
+          ) {
+            return found;
           }
-          return;
         }
       }
+      return [];
+    },
+    [getExpansionKey],
+  );
 
-      if (overId.startsWith("__folder_content_")) {
-        const folderId = overId.replace("__folder_content_", "");
-        if (activeNode.isDirectory) {
-          onMoveFolder?.(activeId, folderId);
-        } else {
-          onMoveItem?.(activeId, folderId);
+  const isNodeExpanded = useCallback(
+    (node: ResourceTreeNode) =>
+      searchQuery.length >= 2 ? true : isFolderExpanded(getExpansionKey(node)),
+    [getExpansionKey, isFolderExpanded, searchQuery],
+  );
+
+  const filteredSections = useMemo(
+    () =>
+      sections.map(section => ({
+        ...section,
+        nodes:
+          searchQuery.length >= 2
+            ? filterTree(section.nodes, searchQuery)
+            : section.nodes,
+      })),
+    [sections, searchQuery],
+  );
+
+  const flatNodeIds = useMemo(() => {
+    const ids: string[] = [];
+
+    const collect = (nodes: ResourceTreeNode[], sectionVisible: boolean) => {
+      if (!sectionVisible) return;
+      for (const node of nodes) {
+        if (!showFiles && !node.isDirectory) continue;
+        ids.push(node.id);
+        if (node.isDirectory && node.children && isNodeExpanded(node)) {
+          collect(node.children, true);
         }
-        return;
       }
+    };
 
-      const overNode = findNodeById(overId);
-      if (overNode?.isDirectory) {
-        if (activeNode.isDirectory) {
-          onMoveFolder?.(activeId, overId);
-        } else {
-          onMoveItem?.(activeId, overId);
-        }
-      }
+    for (const section of filteredSections) {
+      collect(section.nodes, sectionExpanded[section.key] !== false);
+    }
+
+    return ids;
+  }, [filteredSections, isNodeExpanded, sectionExpanded, showFiles]);
+
+  const resolveCanManage = useCallback(
+    (node: ResourceTreeNode) => {
+      if (canManageItem) return canManageItem(node);
+      return !node.readOnly;
     },
-    [findNodeById, onMoveItem, onMoveFolder, sections],
+    [canManageItem],
   );
 
-  // ── Inline rename ──
-
-  const startInlineRename = useCallback(
-    (item: ResourceTreeNode) => {
-      if (!item.id || !enableRename) return;
-      setRenamingItemId(item.id);
-      setRenameValue(item.name);
-      setContextMenu(null);
+  const updateLocationSelection = useCallback(
+    (folderId: string | null, sectionKey: string) => {
+      if (selectedLocationId === undefined) {
+        setInternalSelectedLocation(folderId);
+      }
+      if (selectedSectionKey === undefined) {
+        setInternalSelectedSectionKey(sectionKey);
+      }
+      onLocationChange?.(folderId, sectionKey);
     },
-    [enableRename],
+    [onLocationChange, selectedLocationId, selectedSectionKey],
   );
 
-  const commitInlineRename = useCallback(
-    (itemId: string) => {
-      const trimmed = renameValue.trim();
-      const node = findNodeById(itemId);
-      if (!node) {
-        setRenamingItemId(null);
-        return;
-      }
-      if (trimmed && trimmed !== node.name) {
-        onRenameItem?.(itemId, trimmed, node.isDirectory);
-      } else {
-        onResortItem?.(itemId);
-      }
-      setRenamingItemId(null);
-    },
-    [renameValue, findNodeById, onRenameItem, onResortItem],
-  );
+  useEffect(() => {
+    if (mode !== "picker" || didInitialExpand) return;
 
-  const cancelInlineRename = useCallback(() => {
-    setRenamingItemId(null);
-    setRenameValue("");
-  }, []);
+    const fallbackSectionKey = initialSectionKey || sections[0]?.key;
+    if (!fallbackSectionKey) return;
+
+    if (!initialFolderId) {
+      updateLocationSelection(null, fallbackSectionKey);
+      setDidInitialExpand(true);
+      return;
+    }
+
+    const location = findNodeLocation(initialFolderId);
+    if (!location) {
+      updateLocationSelection(null, fallbackSectionKey);
+      setFocusedNodeId(null);
+      setDidInitialExpand(true);
+      return;
+    }
+    const sectionKey =
+      initialSectionKey || location.sectionKey || fallbackSectionKey;
+    const sectionNodes =
+      sections.find(section => section.key === sectionKey)?.nodes ?? [];
+
+    for (const expansionKey of findAncestorExpansionKeys(
+      sectionNodes,
+      initialFolderId,
+    )) {
+      onExpandFolder(expansionKey);
+    }
+
+    setSectionExpanded(prev => ({ ...prev, [sectionKey]: true }));
+    updateLocationSelection(initialFolderId, sectionKey);
+    setFocusedNodeId(initialFolderId);
+    setDidInitialExpand(true);
+  }, [
+    didInitialExpand,
+    findAncestorExpansionKeys,
+    findNodeLocation,
+    initialFolderId,
+    initialSectionKey,
+    mode,
+    onExpandFolder,
+    sections,
+    updateLocationSelection,
+  ]);
+
+  useEffect(() => {
+    if (!pendingCreatedFolderId) return;
+    const location = findNodeLocation(pendingCreatedFolderId);
+    if (!location) return;
+
+    const sectionNodes =
+      sections.find(section => section.key === location.sectionKey)?.nodes ??
+      [];
+    for (const expansionKey of findAncestorExpansionKeys(
+      sectionNodes,
+      pendingCreatedFolderId,
+    )) {
+      onExpandFolder(expansionKey);
+    }
+
+    setSectionExpanded(prev => ({ ...prev, [location.sectionKey]: true }));
+    setFocusedNodeId(pendingCreatedFolderId);
+    setRenamingItemId(pendingCreatedFolderId);
+    setRenameValue(location.node.name);
+    if (mode === "picker" && location.node.isDirectory) {
+      updateLocationSelection(location.node.id, location.sectionKey);
+    }
+    setPendingCreatedFolderId(null);
+  }, [
+    findAncestorExpansionKeys,
+    findNodeLocation,
+    mode,
+    onExpandFolder,
+    pendingCreatedFolderId,
+    sections,
+    updateLocationSelection,
+  ]);
+
+  useEffect(() => {
+    if (!pendingCreatedFolderId) return;
+
+    const timeoutId = window.setTimeout(() => {
+      setPendingCreatedFolderId(current =>
+        current === pendingCreatedFolderId ? null : current,
+      );
+    }, 2000);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [pendingCreatedFolderId]);
 
   useEffect(() => {
     if (renamingItemId && renameInputRef.current) {
@@ -294,230 +450,427 @@ export default function ResourceTree({
     }
   }, [renamingItemId]);
 
-  // ── Context menus ──
+  const triggerCreateFolder = useCallback(
+    async (parentId: string | null, access?: string) => {
+      const created = await onCreateFolder?.(parentId, access);
+      if (created) {
+        setPendingCreatedFolderId(created.id);
+      }
+    },
+    [onCreateFolder],
+  );
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      createFolder: triggerCreateFolder,
+    }),
+    [triggerCreateFolder],
+  );
+
+  const startInlineRename = useCallback(
+    (item: ResourceTreeNode) => {
+      if (!enableRename) return;
+      setRenamingItemId(item.id);
+      setRenameValue(item.name);
+      setContextMenu(null);
+    },
+    [enableRename],
+  );
+
+  const cancelInlineRename = useCallback(() => {
+    setRenamingItemId(null);
+    setRenameValue("");
+  }, []);
+
+  const commitInlineRename = useCallback(
+    (itemId: string) => {
+      const nextName = renameValue.trim();
+      const location = findNodeLocation(itemId);
+      if (!location) {
+        cancelInlineRename();
+        return;
+      }
+
+      if (nextName && nextName !== location.node.name) {
+        onRenameItem?.(itemId, nextName, location.node.isDirectory);
+      } else {
+        onResortItem?.(itemId);
+      }
+
+      cancelInlineRename();
+    },
+    [
+      cancelInlineRename,
+      findNodeLocation,
+      onRenameItem,
+      onResortItem,
+      renameValue,
+    ],
+  );
 
   const handleContextMenu = useCallback(
-    (e: React.MouseEvent, item: ResourceTreeNode, readOnly?: boolean) => {
-      e.preventDefault();
-      e.stopPropagation();
+    (event: React.MouseEvent, item: ResourceTreeNode) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const readOnly = !resolveCanManage(item);
       setContextMenu({
-        anchorPosition: { top: e.clientY + 2, left: e.clientX + 2 },
+        anchorPosition: { top: event.clientY + 2, left: event.clientX + 2 },
         item,
         readOnly,
       });
-      setSelectedNodeId(item.id);
+      setFocusedNodeId(item.id);
     },
-    [],
+    [resolveCanManage],
   );
 
   const handleSectionContextMenu = useCallback(
-    (e: React.MouseEvent, sectionKey: string) => {
-      e.preventDefault();
-      e.stopPropagation();
+    (event: React.MouseEvent, sectionKey: string) => {
+      event.preventDefault();
+      event.stopPropagation();
       setSectionContextMenu({
-        anchorPosition: { top: e.clientY + 2, left: e.clientX + 2 },
+        anchorPosition: { top: event.clientY + 2, left: event.clientX + 2 },
         sectionKey,
       });
     },
     [],
   );
 
-  // ── Filtered trees ──
-
-  const filteredSections = useMemo(
-    () =>
-      sections.map(s => ({
-        ...s,
-        nodes:
-          searchQuery.length >= 2 ? filterTree(s.nodes, searchQuery) : s.nodes,
-      })),
-    [sections, searchQuery],
+  const handleDragStart = useCallback(
+    (event: DragStartEvent) => {
+      const location = findNodeLocation(String(event.active.id));
+      setDraggedNode(location?.node ?? null);
+    },
+    [findNodeLocation],
   );
 
-  // ── Flat node IDs for keyboard nav ──
+  const handleDragOver = useCallback((event: DragOverEvent) => {
+    setDropTargetId(event.over ? String(event.over.id) : null);
+  }, []);
 
-  const flatNodeIds = useMemo(() => {
-    const ids: string[] = [];
-    const collect = (nodes: ResourceTreeNode[], sectionVisible: boolean) => {
-      if (!sectionVisible) return;
-      for (const node of nodes) {
-        if (!showFiles && !node.isDirectory) continue;
-        if (node.id) ids.push(node.id);
-        if (node.isDirectory && node.children && isFolderExpanded(node.path)) {
-          collect(node.children, true);
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      setDraggedNode(null);
+      setDropTargetId(null);
+
+      const { active, over } = event;
+      if (!active || !over) return;
+
+      const activeId = String(active.id);
+      const overId = String(over.id);
+      if (activeId === overId) return;
+
+      const activeLocation = findNodeLocation(activeId);
+      if (!activeLocation) return;
+
+      const target = resolveTreeDropTarget(sections, overId);
+      if (!target) return;
+
+      if (target.kind === "section") {
+        if (activeLocation.node.isDirectory) {
+          onMoveFolder?.(activeId, null, target.access);
+        } else {
+          onMoveItem?.(activeId, null, target.access);
         }
+        return;
       }
-    };
-    for (const s of filteredSections) {
-      collect(s.nodes, sectionExpanded[s.key] !== false);
-    }
-    return ids;
-  }, [filteredSections, isFolderExpanded, sectionExpanded, showFiles]);
 
-  // ── Keyboard navigation ──
+      if (target.targetFolderId === activeId) return;
+      if (
+        activeLocation.node.isDirectory &&
+        findNodeInSections(
+          [
+            {
+              key: activeLocation.sectionKey,
+              nodes: activeLocation.node.children ?? [],
+            },
+          ],
+          target.targetFolderId,
+        )
+      ) {
+        return;
+      }
+
+      if (activeLocation.node.isDirectory) {
+        onMoveFolder?.(activeId, target.targetFolderId);
+      } else {
+        onMoveItem?.(activeId, target.targetFolderId);
+      }
+    },
+    [findNodeLocation, onMoveFolder, onMoveItem, sections],
+  );
 
   useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      const target = e.target as HTMLElement;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement;
       if (target.tagName === "INPUT" || target.tagName === "TEXTAREA") return;
 
-      const focusId = selectedNodeId || activeItemId;
+      const focusId =
+        focusedNodeId ||
+        (mode === "sidebar" ? activeItemId : currentSelectedLocation) ||
+        null;
+      const focusLocation = focusId ? findNodeLocation(focusId) : null;
+      const focusItem = focusLocation?.node ?? null;
+      const canManageFocused = focusItem ? resolveCanManage(focusItem) : false;
+      const meta = event.metaKey || event.ctrlKey;
 
-      if (e.key === "F2" && enableRename && focusId) {
-        const node = findNodeById(focusId);
-        if (node) {
-          e.preventDefault();
-          startInlineRename(node);
+      if (event.key === "F2" && focusItem && enableRename && canManageFocused) {
+        event.preventDefault();
+        startInlineRename(focusItem);
+        return;
+      }
+
+      if (
+        (event.key === "Delete" || event.key === "Backspace") &&
+        focusItem &&
+        enableDelete &&
+        canManageFocused &&
+        !meta
+      ) {
+        event.preventDefault();
+        onDeleteItem?.(focusItem);
+        return;
+      }
+
+      if (
+        meta &&
+        event.key.toLowerCase() === "d" &&
+        focusItem &&
+        enableDuplicate &&
+        !focusItem.isDirectory
+      ) {
+        event.preventDefault();
+        onDuplicateItem?.(focusItem);
+        return;
+      }
+
+      if (meta && event.key.toLowerCase() === "i" && focusItem && enableInfo) {
+        event.preventDefault();
+        if (focusItem.isDirectory) {
+          onFolderInfoRequest?.(focusItem);
+        } else {
+          onInfoRequest?.(focusItem);
         }
         return;
       }
 
       if (
-        (e.key === "Delete" || e.key === "Backspace") &&
-        enableDelete &&
-        !e.metaKey &&
-        focusId
+        meta &&
+        event.key.toLowerCase() === "z" &&
+        !event.shiftKey &&
+        onUndo
       ) {
-        const node = findNodeById(focusId);
-        if (node) {
-          e.preventDefault();
-          onDeleteItem?.(node);
+        event.preventDefault();
+        onUndo();
+        return;
+      }
+
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        event.preventDefault();
+        const currentIndex = focusId ? flatNodeIds.indexOf(focusId) : -1;
+        const nextIndex =
+          event.key === "ArrowDown"
+            ? Math.min(currentIndex + 1, flatNodeIds.length - 1)
+            : Math.max(currentIndex - 1, 0);
+        if (flatNodeIds[nextIndex]) {
+          setFocusedNodeId(flatNodeIds[nextIndex]);
         }
         return;
       }
 
-      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
-        e.preventDefault();
-        const currentIdx = focusId ? flatNodeIds.indexOf(focusId) : -1;
-        const nextIdx =
-          e.key === "ArrowDown"
-            ? Math.min(currentIdx + 1, flatNodeIds.length - 1)
-            : Math.max(currentIdx - 1, 0);
-        if (flatNodeIds[nextIdx]) {
-          setSelectedNodeId(flatNodeIds[nextIdx]);
+      if (event.key === "ArrowRight" && focusItem?.isDirectory) {
+        event.preventDefault();
+        if (!isNodeExpanded(focusItem)) {
+          onExpandFolder(getExpansionKey(focusItem));
         }
         return;
       }
 
-      if ((e.key === "ArrowRight" || e.key === "ArrowLeft") && focusId) {
-        const node = findNodeById(focusId);
-        if (node?.isDirectory) {
-          e.preventDefault();
-          if (e.key === "ArrowRight") {
-            onExpandFolder(node.path);
+      if (event.key === "ArrowLeft" && focusItem?.isDirectory) {
+        event.preventDefault();
+        if (isNodeExpanded(focusItem)) {
+          onToggleFolder(getExpansionKey(focusItem));
+        }
+        return;
+      }
+
+      if (event.key === "Enter" && focusItem && focusLocation) {
+        event.preventDefault();
+        if (focusItem.isDirectory) {
+          if (mode === "picker") {
+            updateLocationSelection(focusItem.id, focusLocation.sectionKey);
           } else {
-            if (isFolderExpanded(node.path)) {
-              onToggleFolder(node.path);
-            }
+            onToggleFolder(getExpansionKey(focusItem));
           }
-        }
-        return;
-      }
-
-      if (e.key === "Enter" && focusId) {
-        const node = findNodeById(focusId);
-        if (!node) return;
-        e.preventDefault();
-        if (node.isDirectory) {
-          onToggleFolder(node.path);
+        } else if (mode === "picker") {
+          onPickerFileClick?.(focusItem);
         } else {
-          onItemClick?.(node);
+          onItemClick?.(focusItem);
         }
       }
     };
 
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
   }, [
-    selectedNodeId,
     activeItemId,
-    flatNodeIds,
-    isFolderExpanded,
-    enableRename,
+    currentSelectedLocation,
     enableDelete,
-    findNodeById,
-    startInlineRename,
+    enableDuplicate,
+    enableInfo,
+    enableRename,
+    findNodeLocation,
+    flatNodeIds,
+    focusedNodeId,
+    getExpansionKey,
+    isNodeExpanded,
+    mode,
     onDeleteItem,
+    onDuplicateItem,
+    onFolderInfoRequest,
+    onInfoRequest,
     onItemClick,
+    onPickerFileClick,
     onToggleFolder,
     onExpandFolder,
+    onUndo,
+    resolveCanManage,
+    startInlineRename,
+    updateLocationSelection,
   ]);
-
-  // ── Rename input ──
 
   const renderInlineRenameInput = (nodeId: string) => (
     <input
       ref={renameInputRef}
       value={renameValue}
-      onChange={e => setRenameValue(e.target.value)}
+      onChange={event => setRenameValue(event.target.value)}
       onBlur={() => commitInlineRename(nodeId)}
-      onKeyDown={e => {
-        e.stopPropagation();
-        if (e.key === "Enter") {
-          e.preventDefault();
+      onKeyDown={event => {
+        event.stopPropagation();
+        if (event.key === "Enter") {
+          event.preventDefault();
           commitInlineRename(nodeId);
         }
-        if (e.key === "Escape") {
-          e.preventDefault();
+        if (event.key === "Escape") {
+          event.preventDefault();
           cancelInlineRename();
         }
       }}
-      onClick={e => e.stopPropagation()}
+      onClick={event => event.stopPropagation()}
       style={{
-        fontSize: "0.8125rem",
-        fontFamily: "inherit",
+        width: "100%",
         border: "1px solid",
         borderColor: "var(--mui-palette-divider, #ccc)",
         borderRadius: 4,
         padding: "1px 4px",
         outline: "none",
-        width: "100%",
         background: "transparent",
         color: "inherit",
+        fontSize: "0.8125rem",
+        fontFamily: "inherit",
       }}
     />
   );
 
-  // ── Recursive tree render ──
+  const buildRowSx = ({
+    depth,
+    isDropTarget,
+    isFocused,
+    isSelected,
+  }: {
+    depth: number;
+    isDropTarget?: boolean;
+    isFocused?: boolean;
+    isSelected?: boolean;
+  }) => ({
+    pl: 0.5 + depth * 1.5,
+    minWidth: 0,
+    py: 0.25,
+    minHeight: 28,
+    bgcolor: isDropTarget
+      ? "action.hover"
+      : isSelected
+        ? "action.selected"
+        : undefined,
+    outline: isDropTarget ? "2px dashed" : isFocused ? "1px solid" : undefined,
+    outlineColor: isDropTarget
+      ? "primary.main"
+      : isFocused
+        ? "divider"
+        : undefined,
+    borderRadius: 0,
+  });
 
   const renderTree = (
     nodes: ResourceTreeNode[],
-    depth: number = 0,
-    readOnlyContext: boolean = false,
+    depth: number,
+    sectionKey: string,
   ): ReactNode[] => {
     const items: ReactNode[] = [];
 
     for (const node of nodes) {
       if (!showFiles && !node.isDirectory) continue;
 
-      const isExpanded = node.isDirectory && isFolderExpanded(node.path);
+      const canManage = resolveCanManage(node);
+      const isExpanded = node.isDirectory && isNodeExpanded(node);
+      const isFocused = focusedNodeId === node.id;
+      const isSelectedLocation =
+        mode === "picker" && currentSelectedLocation === node.id;
       const isActive = mode === "sidebar" && activeItemId === node.id;
-      const isSelected = selectedNodeId === node.id;
       const isRenaming = renamingItemId === node.id;
+      const isDropTarget =
+        dropTargetId === node.id ||
+        dropTargetId === getFolderDropTargetId(node.id);
 
       if (node.isDirectory) {
         const folderRow = (
           <ListItemButton
             key={node.id}
             data-node-id={node.id}
-            selected={isSelected}
+            selected={isSelectedLocation}
             onClick={() => {
-              onToggleFolder(node.path);
-              setSelectedNodeId(node.id);
+              setFocusedNodeId(node.id);
+              if (mode === "picker") {
+                updateLocationSelection(node.id, sectionKey);
+              } else {
+                onToggleFolder(getExpansionKey(node));
+              }
             }}
-            onContextMenu={e => handleContextMenu(e, node, readOnlyContext)}
-            sx={{
-              pl: 0.5 + depth * 1.5,
-              py: 0.25,
-              minHeight: 28,
+            onContextMenu={event => handleContextMenu(event, node)}
+            onDoubleClick={event => {
+              if (enableRename && canManage) {
+                event.stopPropagation();
+                startInlineRename(node);
+              }
             }}
+            sx={buildRowSx({
+              depth,
+              isDropTarget,
+              isFocused,
+              isSelected: isSelectedLocation,
+            })}
           >
-            <ListItemIcon sx={{ minWidth: 22 }}>
-              {isExpanded ? (
-                <ChevronDown size={14} strokeWidth={1.5} />
-              ) : (
-                <ChevronRight size={14} strokeWidth={1.5} />
-              )}
+            <ListItemIcon sx={{ minWidth: 22, mr: 0 }}>
+              <Box
+                component="span"
+                onClick={event => {
+                  event.stopPropagation();
+                  onToggleFolder(getExpansionKey(node));
+                }}
+                sx={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  width: 18,
+                  height: 18,
+                }}
+              >
+                {isExpanded ? (
+                  <ChevronDown size={14} strokeWidth={1.5} />
+                ) : (
+                  <ChevronRight size={14} strokeWidth={1.5} />
+                )}
+              </Box>
             </ListItemIcon>
             <ListItemIcon sx={{ minWidth: 22 }}>
               {isExpanded ? (
@@ -543,12 +896,12 @@ export default function ResourceTree({
           </ListItemButton>
         );
 
-        const wrappedRow = enableDragDrop ? (
+        const wrappedFolderRow = enableDragDrop ? (
           <DraggableTreeItem
-            key={`drag-${node.id}`}
+            key={`drag-folder-${node.id}`}
             id={node.id}
             isFolder
-            disabled={readOnlyContext}
+            disabled={!canManage}
           >
             {folderRow}
           </DraggableTreeItem>
@@ -556,136 +909,196 @@ export default function ResourceTree({
           folderRow
         );
 
-        items.push(wrappedRow);
+        items.push(wrappedFolderRow);
 
-        if (isExpanded && node.children) {
-          const childContent = renderTree(
-            node.children,
+        if (isExpanded) {
+          const childItems = renderTree(
+            node.children ?? [],
             depth + 1,
-            readOnlyContext,
+            sectionKey,
+          );
+          const childList = (
+            <List component="div" disablePadding dense>
+              {childItems.length === 0 ? (
+                <Typography
+                  variant="caption"
+                  color="text.disabled"
+                  sx={{
+                    pl: 0.5 + (depth + 1) * 1.5 + 2.75,
+                    py: 0.5,
+                    display: "block",
+                  }}
+                >
+                  Empty
+                </Typography>
+              ) : (
+                childItems
+              )}
+            </List>
           );
 
-          if (enableDragDrop) {
-            items.push(
+          items.push(
+            enableDragDrop ? (
               <DroppableFolderContent
-                key={`drop-${node.id}`}
+                key={`folder-drop-${node.id}`}
                 folderId={node.id}
               >
-                {childContent}
-              </DroppableFolderContent>,
-            );
-          } else {
-            items.push(...childContent);
-          }
+                {childList}
+              </DroppableFolderContent>
+            ) : (
+              <React.Fragment key={`folder-children-${node.id}`}>
+                {childList}
+              </React.Fragment>
+            ),
+          );
         }
-      } else {
-        const icon = getItemIcon ? getItemIcon(node) : null;
-        const fileRow = (
-          <ListItemButton
-            key={node.id}
-            data-node-id={node.id}
-            selected={isActive || isSelected}
-            onClick={() => {
-              setSelectedNodeId(node.id);
-              onItemClick?.(node);
-            }}
-            onContextMenu={e =>
-              handleContextMenu(e, node, readOnlyContext || node.readOnly)
-            }
-            sx={{
-              pl: 0.5 + depth * 1.5 + (icon ? 0 : 1.5),
-              py: 0.25,
-              minHeight: 28,
-            }}
-          >
-            {icon && (
-              <ListItemIcon sx={{ minWidth: 22, visibility: "visible" }}>
-                <Box sx={{ width: 14 }} />
-              </ListItemIcon>
-            )}
-            {icon && <ListItemIcon sx={{ minWidth: 22 }}>{icon}</ListItemIcon>}
-            {!icon && (
-              <ListItemIcon sx={{ minWidth: 22, visibility: "hidden" }}>
-                <ChevronRight size={14} />
-              </ListItemIcon>
-            )}
-            <MuiListItemText
-              primary={
-                isRenaming ? renderInlineRenameInput(node.id) : node.name
-              }
-              primaryTypographyProps={{
-                variant: "body2",
-                sx: {
-                  whiteSpace: "nowrap",
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                },
-              }}
-            />
-          </ListItemButton>
-        );
 
-        items.push(
-          enableDragDrop ? (
-            <DraggableTreeItem
-              key={`drag-${node.id}`}
-              id={node.id}
-              disabled={readOnlyContext || node.readOnly}
-            >
-              {fileRow}
-            </DraggableTreeItem>
-          ) : (
-            fileRow
-          ),
-        );
+        continue;
       }
+
+      const fileRow = (
+        <ListItemButton
+          key={node.id}
+          data-node-id={node.id}
+          selected={isActive}
+          onClick={() => {
+            setFocusedNodeId(node.id);
+            if (mode === "picker") {
+              onPickerFileClick?.(node);
+            } else {
+              onItemClick?.(node);
+            }
+          }}
+          onContextMenu={event => handleContextMenu(event, node)}
+          onDoubleClick={event => {
+            if (enableRename && canManage) {
+              event.stopPropagation();
+              startInlineRename(node);
+            }
+          }}
+          sx={buildRowSx({
+            depth,
+            isFocused,
+            isSelected: isActive,
+          })}
+        >
+          <ListItemIcon sx={{ minWidth: 22, visibility: "hidden", mr: 0 }} />
+          <ListItemIcon sx={{ minWidth: 22 }}>
+            {getItemIcon ? getItemIcon(node) : null}
+          </ListItemIcon>
+          <MuiListItemText
+            primary={isRenaming ? renderInlineRenameInput(node.id) : node.name}
+            primaryTypographyProps={{
+              variant: "body2",
+              sx: {
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+              },
+            }}
+          />
+        </ListItemButton>
+      );
+
+      items.push(
+        enableDragDrop ? (
+          <DraggableTreeItem
+            key={`drag-file-${node.id}`}
+            id={node.id}
+            disabled={!canManage}
+          >
+            {fileRow}
+          </DraggableTreeItem>
+        ) : (
+          fileRow
+        ),
+      );
     }
+
     return items;
   };
 
-  // ── Section header ──
-
   const renderSectionHeader = (section: ResourceTreeSection) => {
-    const isExpanded = sectionExpanded[section.key] !== false;
-    const filtered = filteredSections.find(s => s.key === section.key);
-    const count = filtered ? countItems(filtered.nodes) : 0;
+    const headerSelected =
+      mode === "picker" &&
+      currentSelectedLocation === null &&
+      currentSelectedSectionKey === section.key;
+    const isDropTarget = section.droppableId === dropTargetId;
 
     const header = (
       <ListItemButton
-        onClick={() =>
-          setSectionExpanded(prev => ({
-            ...prev,
-            [section.key]: !isExpanded,
-          }))
-        }
-        onContextMenu={e => handleSectionContextMenu(e, section.key)}
-        sx={{ px: 1, py: 0.5, gap: 0.5, minHeight: 32 }}
+        selected={headerSelected}
+        onClick={() => {
+          if (mode === "picker") {
+            updateLocationSelection(null, section.key);
+          } else {
+            setSectionExpanded(prev => ({
+              ...prev,
+              [section.key]: !prev[section.key],
+            }));
+          }
+        }}
+        onContextMenu={event => handleSectionContextMenu(event, section.key)}
+        sx={{
+          py: 0.25,
+          pl: 0.5,
+          minWidth: 0,
+          bgcolor: isDropTarget
+            ? "action.hover"
+            : headerSelected
+              ? "action.selected"
+              : undefined,
+          outline: isDropTarget ? "2px dashed" : undefined,
+          outlineColor: isDropTarget ? "primary.main" : undefined,
+          borderRadius: 0,
+          "& .MuiListItemText-root": {
+            minWidth: 0,
+            flex: "1 1 auto",
+          },
+        }}
       >
-        {isExpanded ? (
-          <ChevronDown size={16} strokeWidth={1.5} />
-        ) : (
-          <ChevronRight size={16} strokeWidth={1.5} />
-        )}
-        <Box sx={{ display: "flex", flexShrink: 0 }}>{section.icon}</Box>
-        <Typography
-          variant="body2"
-          sx={{
-            fontWeight: 600,
-            textTransform: "uppercase",
-            fontSize: "0.7rem",
-            letterSpacing: "0.05em",
-            flex: 1,
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
+        <ListItemIcon sx={{ minWidth: 22 }}>
+          <Box
+            component="span"
+            onClick={event => {
+              event.stopPropagation();
+              setSectionExpanded(prev => ({
+                ...prev,
+                [section.key]: !prev[section.key],
+              }));
+            }}
+            sx={{
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              width: 18,
+              height: 18,
+            }}
+          >
+            {sectionExpanded[section.key] !== false ? (
+              <ChevronDown size={14} strokeWidth={1.5} />
+            ) : (
+              <ChevronRight size={14} strokeWidth={1.5} />
+            )}
+          </Box>
+        </ListItemIcon>
+        <ListItemIcon sx={{ minWidth: 22 }}>{section.icon}</ListItemIcon>
+        <MuiListItemText
+          primary={section.label}
+          primaryTypographyProps={{
+            variant: "body2",
+            sx: {
+              fontWeight: 600,
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            },
           }}
-        >
-          {section.label}
-        </Typography>
+        />
         <Chip
-          label={count}
+          label={countItems(section.nodes)}
           size="small"
-          sx={{ height: 20, fontSize: "0.7rem" }}
+          sx={{ height: 18, fontSize: "0.7rem", flexShrink: 0, maxWidth: 56 }}
         />
       </ListItemButton>
     );
@@ -700,50 +1113,50 @@ export default function ResourceTree({
         </DroppableSectionHeader>
       );
     }
+
     return (
       <React.Fragment key={`section-${section.key}`}>{header}</React.Fragment>
     );
   };
 
-  // ── Render ──
+  const treeContent = (
+    <List component="nav" dense>
+      {filteredSections.map(section => (
+        <React.Fragment key={section.key}>
+          {renderSectionHeader(section)}
+          {sectionExpanded[section.key] !== false &&
+            (section.nodes.length > 0 ? (
+              renderTree(section.nodes, 1, section.key)
+            ) : (
+              <Typography
+                sx={{
+                  pl: 3,
+                  py: 0.5,
+                  color: "text.disabled",
+                  fontSize: "0.8rem",
+                  fontStyle: "italic",
+                }}
+                variant="body2"
+              >
+                Nothing here yet
+              </Typography>
+            ))}
+        </React.Fragment>
+      ))}
+    </List>
+  );
 
-  return (
+  const content = enableDragDrop ? (
     <DndContext
       sensors={sensors}
-      collisionDetection={closestCenter}
+      collisionDetection={collisionDetectionStrategy}
       onDragStart={handleDragStart}
+      onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}
     >
-      <List dense disablePadding>
-        {filteredSections.map(section => (
-          <React.Fragment key={section.key}>
-            {renderSectionHeader(section)}
-            {sectionExpanded[section.key] !== false && (
-              <>
-                {section.nodes.length > 0 ? (
-                  renderTree(
-                    section.nodes,
-                    1,
-                    section.defaultAccess === "workspace",
-                  )
-                ) : (
-                  <Typography
-                    variant="caption"
-                    color="text.disabled"
-                    sx={{ display: "block", pl: 4, py: 0.5 }}
-                  >
-                    Empty
-                  </Typography>
-                )}
-              </>
-            )}
-          </React.Fragment>
-        ))}
-      </List>
-
-      {/* Drag overlay */}
+      {treeContent}
       <DragOverlay>
-        {draggedNode && (
+        {draggedNode ? (
           <Box
             sx={{
               display: "flex",
@@ -762,12 +1175,19 @@ export default function ResourceTree({
             ) : (
               getItemIcon?.(draggedNode) || null
             )}
-            <span>{draggedNode.name}</span>
+            <span className="app-truncate-inline">{draggedNode.name}</span>
           </Box>
-        )}
+        ) : null}
       </DragOverlay>
+    </DndContext>
+  ) : (
+    treeContent
+  );
 
-      {/* Item context menu */}
+  return (
+    <>
+      {content}
+
       <Menu
         open={!!contextMenu}
         onClose={() => setContextMenu(null)}
@@ -777,7 +1197,7 @@ export default function ResourceTree({
         {contextMenu &&
           (() => {
             const { item, readOnly } = contextMenu;
-            const canManage = canManageItem ? canManageItem(item) : !readOnly;
+            const canManage = !readOnly;
 
             return [
               enableRename && canManage && (
@@ -808,44 +1228,57 @@ export default function ResourceTree({
                   key="subfolder"
                   onClick={async () => {
                     setContextMenu(null);
-                    onExpandFolder(item.path);
-                    await onCreateFolder?.(item.id, item.access);
+                    onExpandFolder(getExpansionKey(item));
+                    await triggerCreateFolder(item.id, item.access);
                   }}
                 >
                   <FolderPlus size={14} style={{ marginRight: 8 }} />
                   New Subfolder
                 </MenuItem>
               ),
-              enableMove && canManage && (
+              enableMove && canManage && onMoveRequest && (
                 <MenuItem
                   key="move"
                   onClick={() => {
                     setContextMenu(null);
+                    onMoveRequest(item);
                   }}
                 >
                   <ArrowRightLeft size={14} style={{ marginRight: 8 }} />
                   Move to...
                 </MenuItem>
               ),
-              enableInfo && (
+              enableInfo && !item.isDirectory && onInfoRequest && (
                 <MenuItem
-                  key="info"
+                  key="info-file"
                   onClick={() => {
                     setContextMenu(null);
-                    onInfoRequest?.(item);
+                    onInfoRequest(item);
                   }}
                 >
                   <Info size={14} style={{ marginRight: 8 }} />
                   Information
                 </MenuItem>
               ),
-              enableDelete && canManage && (
+              enableInfo && item.isDirectory && onFolderInfoRequest && (
+                <MenuItem
+                  key="info-folder"
+                  onClick={() => {
+                    setContextMenu(null);
+                    onFolderInfoRequest(item);
+                  }}
+                >
+                  <Info size={14} style={{ marginRight: 8 }} />
+                  Information
+                </MenuItem>
+              ),
+              enableDelete && canManage && onDeleteItem && (
                 <React.Fragment key="delete-group">
                   <Divider />
                   <MenuItem
                     onClick={() => {
                       setContextMenu(null);
-                      onDeleteItem?.(item);
+                      onDeleteItem(item);
                     }}
                     sx={{ color: "error.main" }}
                   >
@@ -858,20 +1291,20 @@ export default function ResourceTree({
           })()}
       </Menu>
 
-      {/* Section context menu */}
       <Menu
         open={!!sectionContextMenu}
         onClose={() => setSectionContextMenu(null)}
         anchorReference="anchorPosition"
         anchorPosition={sectionContextMenu?.anchorPosition}
       >
-        {sectionContextMenu && enableNewFolder && (
+        {sectionContextMenu && enableNewFolder && onCreateFolder && (
           <MenuItem
             onClick={async () => {
-              const sk = sectionContextMenu.sectionKey;
+              const section = sections.find(
+                entry => entry.key === sectionContextMenu.sectionKey,
+              );
               setSectionContextMenu(null);
-              const section = sections.find(s => s.key === sk);
-              await onCreateFolder?.(null, section?.defaultAccess);
+              await triggerCreateFolder(null, section?.defaultAccess);
             }}
           >
             <FolderPlus size={14} style={{ marginRight: 8 }} />
@@ -879,72 +1312,14 @@ export default function ResourceTree({
           </MenuItem>
         )}
       </Menu>
-    </DndContext>
+    </>
   );
 }
 
-// ── DnD helper components ──
+const ResourceTree = forwardRef<ResourceTreeRef, ResourceTreeProps>(
+  ResourceTreeInner,
+);
 
-function DroppableSectionHeader({
-  id,
-  children,
-}: {
-  id: string;
-  children: ReactNode;
-}) {
-  const { setNodeRef } = useDroppable({ id });
-  return <div ref={setNodeRef}>{children}</div>;
-}
+ResourceTree.displayName = "ResourceTree";
 
-function DroppableFolderContent({
-  folderId,
-  children,
-}: {
-  folderId: string;
-  children: ReactNode;
-}) {
-  const { setNodeRef } = useDroppable({
-    id: `__folder_content_${folderId}`,
-  });
-  return <div ref={setNodeRef}>{children}</div>;
-}
-
-function DraggableTreeItem({
-  id,
-  disabled,
-  isFolder,
-  children,
-}: {
-  id: string;
-  disabled?: boolean;
-  isFolder?: boolean;
-  children: ReactNode;
-}) {
-  const {
-    attributes,
-    listeners,
-    setNodeRef: setDragRef,
-    isDragging,
-  } = useDraggable({ id, disabled });
-
-  const { setNodeRef: setDropRef } = useDroppable({
-    id,
-    disabled: !isFolder,
-  });
-
-  const setRef = (el: HTMLElement | null) => {
-    setDragRef(el);
-    if (isFolder) setDropRef(el);
-  };
-
-  return (
-    <div
-      ref={setRef}
-      style={{ opacity: isDragging ? 0.4 : 1 }}
-      {...attributes}
-      {...listeners}
-    >
-      {children}
-    </div>
-  );
-}
+export default ResourceTree;

--- a/app/src/components/ViewExplorer.tsx
+++ b/app/src/components/ViewExplorer.tsx
@@ -197,7 +197,7 @@ const ViewExplorer: React.FC<ViewExplorerProps> = ({
               const collections = Object.keys(groupedViews).sort();
 
               return collections.map(collection => {
-                const isExpanded = expandedCollections.has(collection);
+                const isExpanded = !!expandedCollections[collection];
                 const collectionViews = groupedViews[collection];
 
                 return (

--- a/app/src/components/WorkspaceSwitcher.tsx
+++ b/app/src/components/WorkspaceSwitcher.tsx
@@ -121,14 +121,15 @@ export function WorkspaceSwitcher() {
           minWidth: 200,
           justifyContent: "space-between",
           px: 2,
+          maxWidth: "100%",
         }}
       >
-        <Box sx={{ textAlign: "left", flex: 1 }}>
+        <Box sx={{ textAlign: "left", flex: 1, minWidth: 0 }}>
           <Typography variant="body2" noWrap>
             {currentWorkspace?.name || "Select Workspace"}
           </Typography>
           {currentWorkspace && (
-            <Typography variant="caption" color="text.secondary">
+            <Typography variant="caption" color="text.secondary" noWrap>
               {currentWorkspace.role}
             </Typography>
           )}
@@ -168,6 +169,7 @@ export function WorkspaceSwitcher() {
                     alignItems: "center",
                     gap: 1,
                     mt: 0.5,
+                    minWidth: 0,
                   }}
                 >
                   <Chip
@@ -175,7 +177,11 @@ export function WorkspaceSwitcher() {
                     size="small"
                     color={getRoleBadgeColor(workspace.role)}
                   />
-                  <Typography variant="caption" color="text.secondary">
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    className="app-truncate"
+                  >
                     {workspace.settings.billingTier}
                   </Typography>
                 </Box>

--- a/app/src/components/resource-tree/dnd.tsx
+++ b/app/src/components/resource-tree/dnd.tsx
@@ -1,0 +1,85 @@
+import {
+  cloneElement,
+  isValidElement,
+  type HTMLAttributes,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import { useDraggable, useDroppable } from "@dnd-kit/core";
+
+interface DroppableSectionHeaderProps {
+  id: string;
+  children: ReactNode;
+}
+
+export function DroppableSectionHeader({
+  id,
+  children,
+}: DroppableSectionHeaderProps) {
+  const { setNodeRef } = useDroppable({ id });
+  return <div ref={setNodeRef}>{children}</div>;
+}
+
+interface DroppableFolderContentProps {
+  folderId: string;
+  children: ReactNode;
+}
+
+export function DroppableFolderContent({
+  folderId,
+  children,
+}: DroppableFolderContentProps) {
+  const { setNodeRef } = useDroppable({
+    id: `__folder_content_${folderId}`,
+  });
+  return <div ref={setNodeRef}>{children}</div>;
+}
+
+interface DraggableTreeItemProps {
+  id: string;
+  disabled?: boolean;
+  isFolder?: boolean;
+  children: ReactElement;
+}
+
+export function DraggableTreeItem({
+  id,
+  disabled,
+  isFolder,
+  children,
+}: DraggableTreeItemProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef: setDragRef,
+    isDragging,
+  } = useDraggable({ id, disabled });
+
+  const { setNodeRef: setDropRef } = useDroppable({
+    id,
+    disabled: !isFolder,
+  });
+
+  const setRef = (element: HTMLElement | null) => {
+    setDragRef(element);
+    if (isFolder) {
+      setDropRef(element);
+    }
+  };
+
+  if (!isValidElement(children)) {
+    return <div ref={setRef}>{children}</div>;
+  }
+
+  const childProps = children.props as HTMLAttributes<HTMLElement>;
+
+  return (
+    <div ref={setRef} style={{ opacity: isDragging ? 0.4 : 1 }}>
+      {cloneElement(children, {
+        ...attributes,
+        ...listeners,
+        ...childProps,
+      })}
+    </div>
+  );
+}

--- a/app/src/components/resource-tree/utils.test.ts
+++ b/app/src/components/resource-tree/utils.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import {
+  findAncestorPaths,
+  findNodeInSections,
+  flattenVisibleNodeIds,
+  getFolderDropTargetId,
+  resolveTreeDropTarget,
+  type ResourceTreeLikeNode,
+  type ResourceTreeLikeSection,
+} from "./utils";
+
+interface TestNode extends ResourceTreeLikeNode {
+  name: string;
+  children?: TestNode[];
+}
+
+const sections: ResourceTreeLikeSection<TestNode>[] = [
+  {
+    key: "my",
+    droppableId: "__section_my",
+    defaultAccess: "private",
+    nodes: [
+      {
+        id: "folder-a",
+        name: "Folder A",
+        path: "Folder A",
+        isDirectory: true,
+        children: [
+          {
+            id: "folder-b",
+            name: "Folder B",
+            path: "Folder A/Folder B",
+            isDirectory: true,
+            children: [
+              {
+                id: "file-1",
+                name: "Console 1",
+                path: "Folder A/Folder B/Console 1",
+                isDirectory: false,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    key: "workspace",
+    droppableId: "__section_workspace",
+    defaultAccess: "workspace",
+    nodes: [
+      {
+        id: "file-2",
+        name: "Workspace Console",
+        path: "Workspace Console",
+        isDirectory: false,
+      },
+    ],
+  },
+];
+
+describe("resource-tree utils", () => {
+  it("finds a node and its section", () => {
+    expect(findNodeInSections(sections, "file-2")).toEqual({
+      node: sections[1].nodes[0],
+      sectionKey: "workspace",
+    });
+  });
+
+  it("returns ancestor folder paths for a nested node", () => {
+    expect(
+      findAncestorPaths(sections[0].nodes, "file-1", [], node => node.path),
+    ).toEqual(["Folder A", "Folder A/Folder B"]);
+  });
+
+  it("flattens only visible nodes", () => {
+    const visible = flattenVisibleNodeIds(sections, {
+      showFiles: true,
+      isFolderExpanded: path => path === "Folder A",
+      sectionExpanded: { my: true, workspace: false },
+      getExpansionKey: node => node.path,
+    });
+
+    expect(visible).toEqual(["folder-a", "folder-b"]);
+  });
+
+  it("resolves drops into sections and folders", () => {
+    expect(resolveTreeDropTarget(sections, "__section_workspace")).toEqual({
+      kind: "section",
+      targetFolderId: null,
+      sectionKey: "workspace",
+      access: "workspace",
+    });
+
+    expect(
+      resolveTreeDropTarget(sections, getFolderDropTargetId("folder-b")),
+    ).toEqual({
+      kind: "folder",
+      targetFolderId: "folder-b",
+      sectionKey: "my",
+    });
+
+    expect(resolveTreeDropTarget(sections, "folder-a")).toEqual({
+      kind: "folder",
+      targetFolderId: "folder-a",
+      sectionKey: "my",
+    });
+  });
+});

--- a/app/src/components/resource-tree/utils.ts
+++ b/app/src/components/resource-tree/utils.ts
@@ -1,0 +1,164 @@
+export interface ResourceTreeLikeNode {
+  id: string;
+  path: string;
+  isDirectory: boolean;
+  children?: ResourceTreeLikeNode[];
+}
+
+export interface ResourceTreeLikeSection<
+  TNode extends ResourceTreeLikeNode = ResourceTreeLikeNode,
+> {
+  key: string;
+  nodes: TNode[];
+  droppableId?: string;
+  defaultAccess?: string;
+}
+
+export interface ResourceTreeNodeLocation<
+  TNode extends ResourceTreeLikeNode = ResourceTreeLikeNode,
+> {
+  node: TNode;
+  sectionKey: string;
+}
+
+export type ResourceTreeDropResolution =
+  | {
+      kind: "section";
+      targetFolderId: null;
+      sectionKey: string;
+      access?: string;
+    }
+  | {
+      kind: "folder";
+      targetFolderId: string;
+      sectionKey: string;
+    }
+  | null;
+
+export const getFolderDropTargetId = (folderId: string) =>
+  `__folder_content_${folderId}`;
+
+export function findNodeById<TNode extends ResourceTreeLikeNode>(
+  nodes: TNode[],
+  id: string,
+): TNode | null {
+  for (const node of nodes) {
+    if (node.id === id) return node;
+    if (node.isDirectory && node.children) {
+      const found = findNodeById(node.children as TNode[], id);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+export function findNodeInSections<TNode extends ResourceTreeLikeNode>(
+  sections: ResourceTreeLikeSection<TNode>[],
+  id: string,
+): ResourceTreeNodeLocation<TNode> | null {
+  for (const section of sections) {
+    const node = findNodeById(section.nodes, id);
+    if (node) {
+      return { node, sectionKey: section.key };
+    }
+  }
+  return null;
+}
+
+export function findAncestorPaths<TNode extends ResourceTreeLikeNode>(
+  nodes: TNode[],
+  targetId: string,
+  ancestors: string[] = [],
+  getExpansionKey: (node: TNode) => string = node => node.id,
+): string[] {
+  for (const node of nodes) {
+    if (node.id === targetId) return ancestors;
+    if (node.isDirectory && node.children) {
+      const found = findAncestorPaths(
+        node.children as TNode[],
+        targetId,
+        [...ancestors, getExpansionKey(node)],
+        getExpansionKey,
+      );
+      if (
+        found.length > 0 ||
+        node.children.some(child => child.id === targetId)
+      ) {
+        return found;
+      }
+    }
+  }
+  return [];
+}
+
+export function flattenVisibleNodeIds<TNode extends ResourceTreeLikeNode>(
+  sections: ResourceTreeLikeSection<TNode>[],
+  options: {
+    showFiles: boolean;
+    isFolderExpanded: (expansionKey: string) => boolean;
+    sectionExpanded: Record<string, boolean>;
+    getExpansionKey?: (node: TNode) => string;
+  },
+): string[] {
+  const ids: string[] = [];
+  const getExpansionKey = options.getExpansionKey ?? ((node: TNode) => node.id);
+
+  const collect = (nodes: TNode[], sectionVisible: boolean) => {
+    if (!sectionVisible) return;
+    for (const node of nodes) {
+      if (!options.showFiles && !node.isDirectory) continue;
+      ids.push(node.id);
+      if (
+        node.isDirectory &&
+        node.children &&
+        options.isFolderExpanded(getExpansionKey(node))
+      ) {
+        collect(node.children as TNode[], true);
+      }
+    }
+  };
+
+  for (const section of sections) {
+    collect(section.nodes, options.sectionExpanded[section.key] !== false);
+  }
+
+  return ids;
+}
+
+export function resolveTreeDropTarget<TNode extends ResourceTreeLikeNode>(
+  sections: ResourceTreeLikeSection<TNode>[],
+  overId: string,
+): ResourceTreeDropResolution {
+  for (const section of sections) {
+    if (overId === section.droppableId) {
+      return {
+        kind: "section",
+        targetFolderId: null,
+        sectionKey: section.key,
+        access: section.defaultAccess,
+      };
+    }
+  }
+
+  if (overId.startsWith("__folder_content_")) {
+    const folderId = overId.replace("__folder_content_", "");
+    const location = findNodeInSections(sections, folderId);
+    if (!location) return null;
+    return {
+      kind: "folder",
+      targetFolderId: folderId,
+      sectionKey: location.sectionKey,
+    };
+  }
+
+  const location = findNodeInSections(sections, overId);
+  if (location?.node.isDirectory) {
+    return {
+      kind: "folder",
+      targetFolderId: overId,
+      sectionKey: location.sectionKey,
+    };
+  }
+
+  return null;
+}

--- a/app/src/contexts/ThemeContext.tsx
+++ b/app/src/contexts/ThemeContext.tsx
@@ -13,6 +13,13 @@ import {
 
 export type ThemeMode = "light" | "dark" | "system";
 
+const truncateTextStyles = {
+  minWidth: 0,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+} as const;
+
 interface ThemeContextType {
   mode: ThemeMode;
   setMode: (mode: ThemeMode) => void;
@@ -201,6 +208,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
             minHeight: 28,
             borderRadius: 4,
             margin: "1px 0",
+            ...truncateTextStyles,
             '&[aria-selected="true"]': {
               backgroundColor: theme.palette.action.selected,
             },
@@ -227,6 +235,11 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
         styleOverrides: {
           root: {
             textTransform: "none",
+            ...truncateTextStyles,
+            maxWidth: "100%",
+            "& .MuiButton-startIcon, & .MuiButton-endIcon": {
+              flexShrink: 0,
+            },
           },
           sizeSmall: {
             py: 1,
@@ -253,6 +266,8 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
             "& .MuiSelect-select": {
               fontSize: "0.9em",
               padding: theme.spacing(0.5, 1),
+              display: "block",
+              ...truncateTextStyles,
             },
             // Remove underline for the "standard" variant only (legacy)
             ...(ownerState.variant === "standard" && {
@@ -311,8 +326,10 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
           root: ({ theme }: any) => ({
             textTransform: "none",
             minHeight: 0,
+            maxWidth: "100%",
             padding: theme.spacing(0.5, 1),
             color: theme.palette.text.secondary,
+            ...truncateTextStyles,
             "&:hover": {
               color: theme.palette.text.primary,
             },
@@ -331,6 +348,10 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
             padding: "4px 8px",
             borderRadius: 4,
             margin: "1px 0",
+            ...truncateTextStyles,
+            "& .MuiListItemText-root": {
+              minWidth: 0,
+            },
             "&:hover": {
               backgroundColor: theme.palette.action.hover,
             },
@@ -365,6 +386,13 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
               transform: "none",
             },
           }),
+        },
+      },
+      MuiDialogTitle: {
+        styleOverrides: {
+          root: {
+            ...truncateTextStyles,
+          },
         },
       },
       MuiFormLabel: {
@@ -491,14 +519,42 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
           },
         },
       },
+      MuiAccordionSummary: {
+        styleOverrides: {
+          content: {
+            minWidth: 0,
+            overflow: "hidden",
+          },
+        },
+      },
       MuiListItemText: {
         styleOverrides: {
           root: ({ theme, ownerState }: any) => ({
+            minWidth: 0,
             ...(ownerState?.dense && {
               marginTop: theme.spacing(0.25),
               marginBottom: theme.spacing(0.25),
             }),
           }),
+          primary: {
+            display: "block",
+            ...truncateTextStyles,
+          },
+          secondary: {
+            display: "block",
+            ...truncateTextStyles,
+          },
+        },
+      },
+      MuiChip: {
+        styleOverrides: {
+          root: {
+            maxWidth: "100%",
+          },
+          label: {
+            display: "block",
+            ...truncateTextStyles,
+          },
         },
       },
       MuiToggleButtonGroup: {
@@ -523,6 +579,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
             fontSize: "2rem",
             borderRadius: 3,
             textTransform: "none",
+            ...truncateTextStyles,
           },
         },
       },

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -2,6 +2,22 @@
 /* Include streamdown styles */
 @source "../node_modules/streamdown/dist/*.js";
 
+.app-truncate {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.app-truncate-inline {
+  display: inline-block;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Register shadcn color tokens with Tailwind v4.
    `inline` inlines the hsl(var(--xxx)) expression into each utility,
    so .dark overrides on the raw HSL variables work at runtime. */

--- a/app/src/store/consoleTreeStore.ts
+++ b/app/src/store/consoleTreeStore.ts
@@ -1,6 +1,14 @@
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import { apiClient } from "../lib/api-client";
+import {
+  findById,
+  findParentArray,
+  findTargetArray,
+  insertAlphabetically,
+  insertAtTop,
+  removeById,
+} from "./lib/tree-helpers";
 
 export type ConsoleAccessLevel = "private" | "workspace";
 
@@ -24,90 +32,6 @@ export interface ConsoleEntry {
   owner_id?: string;
   createdAt?: string;
 }
-
-// ── Tree helpers (mutate in place, used inside immer) ──
-
-const findTargetArray = (
-  nodes: ConsoleEntry[],
-  remainingSegments: string[],
-): ConsoleEntry[] | null => {
-  if (remainingSegments.length === 0) return nodes;
-  const folderName = remainingSegments[0];
-  const folder = nodes.find(
-    node => node.isDirectory && node.name === folderName,
-  );
-  if (!folder) return null;
-  if (!folder.children) folder.children = [];
-  return findTargetArray(folder.children, remainingSegments.slice(1));
-};
-
-const removeById = (
-  nodes: ConsoleEntry[],
-  targetId: string,
-): ConsoleEntry | null => {
-  const index = nodes.findIndex(item => item.id === targetId);
-  if (index !== -1) return nodes.splice(index, 1)[0];
-  for (const node of nodes) {
-    if (node.isDirectory && node.children) {
-      const removed = removeById(node.children, targetId);
-      if (removed) return removed;
-    }
-  }
-  return null;
-};
-
-const insertAlphabetically = (
-  nodes: ConsoleEntry[],
-  entry: ConsoleEntry,
-): void => {
-  let insertIndex = nodes.length;
-  for (let i = 0; i < nodes.length; i++) {
-    const item = nodes[i];
-    if (entry.isDirectory && !item.isDirectory) {
-      insertIndex = i;
-      break;
-    }
-    if (entry.isDirectory === item.isDirectory) {
-      if (entry.name.toLowerCase() < item.name.toLowerCase()) {
-        insertIndex = i;
-        break;
-      }
-    }
-  }
-  nodes.splice(insertIndex, 0, entry);
-};
-
-const insertAtTop = (nodes: ConsoleEntry[], entry: ConsoleEntry): void => {
-  nodes.unshift(entry);
-};
-
-const findById = (
-  nodes: ConsoleEntry[],
-  targetId: string,
-): ConsoleEntry | null => {
-  for (const node of nodes) {
-    if (node.id === targetId) return node;
-    if (node.isDirectory && node.children) {
-      const found = findById(node.children, targetId);
-      if (found) return found;
-    }
-  }
-  return null;
-};
-
-const findParentArray = (
-  nodes: ConsoleEntry[],
-  targetId: string,
-): ConsoleEntry[] | null => {
-  if (nodes.some(n => n.id === targetId)) return nodes;
-  for (const node of nodes) {
-    if (node.isDirectory && node.children) {
-      const found = findParentArray(node.children, targetId);
-      if (found) return found;
-    }
-  }
-  return null;
-};
 
 /** Get both section arrays for a workspace */
 const allSections = (state: TreeState, wid: string): ConsoleEntry[][] => [
@@ -479,7 +403,7 @@ export const useConsoleTreeStore = create<TreeState>()(
         }>(`/workspaces/${workspaceId}/consoles/folders`, {
           name,
           parentId: parentId || undefined,
-          isPrivate: false,
+          isPrivate: resolvedAccess !== "workspace",
           access: resolvedAccess,
         });
         if (res.success && res.data) {

--- a/app/src/store/explorerStore.ts
+++ b/app/src/store/explorerStore.ts
@@ -4,38 +4,38 @@
  * Manages expanded/collapsed state for all explorer panels:
  * - Database explorer (servers, databases, collections, views, nodes)
  * - Console explorer (folders)
+ * - Dashboard explorer (folders)
  * - View explorer (collections)
  *
- * Uses Set<string> internally for O(1) lookups, serializes to arrays for persistence.
+ * Uses Record<string, true> for O(1) lookups.
+ * Previous versions used Set<string> which is unreliable inside immer drafts.
  */
 
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 
+type ExpandedMap = Record<string, true>;
+
 interface ExplorerState {
-  // Database explorer
   database: {
-    expandedServers: Set<string>;
-    expandedDatabases: Set<string>;
-    expandedCollectionGroups: Set<string>;
-    expandedViewGroups: Set<string>;
-    expandedNodes: Set<string>;
+    expandedServers: ExpandedMap;
+    expandedDatabases: ExpandedMap;
+    expandedCollectionGroups: ExpandedMap;
+    expandedViewGroups: ExpandedMap;
+    expandedNodes: ExpandedMap;
   };
 
-  // Console explorer
   console: {
-    expandedFolders: Set<string>;
+    expandedFolders: ExpandedMap;
   };
 
-  // Dashboard explorer
   dashboard: {
-    expandedFolders: Set<string>;
+    expandedFolders: ExpandedMap;
   };
 
-  // View explorer
   view: {
-    expandedCollections: Set<string>;
+    expandedCollections: ExpandedMap;
   };
 }
 
@@ -49,7 +49,6 @@ interface ExplorerActions {
   expandServer: (serverId: string) => void;
   expandDatabase: (databaseId: string) => void;
 
-  // Helper methods for database explorer
   isServerExpanded: (serverId: string) => boolean;
   isDatabaseExpanded: (databaseId: string) => boolean;
   isCollectionGroupExpanded: (databaseId: string) => boolean;
@@ -57,14 +56,14 @@ interface ExplorerActions {
   isNodeExpanded: (nodeId: string) => boolean;
 
   // Console explorer
-  toggleFolder: (folderPath: string) => void;
-  expandFolder: (folderPath: string) => void;
-  isFolderExpanded: (folderPath: string) => boolean;
+  toggleFolder: (folderKey: string) => void;
+  expandFolder: (folderKey: string) => void;
+  isFolderExpanded: (folderKey: string) => boolean;
 
   // Dashboard explorer
-  toggleDashboardFolder: (folderPath: string) => void;
-  expandDashboardFolder: (folderPath: string) => void;
-  isDashboardFolderExpanded: (folderPath: string) => boolean;
+  toggleDashboardFolder: (folderKey: string) => void;
+  expandDashboardFolder: (folderKey: string) => void;
+  isDashboardFolderExpanded: (folderKey: string) => boolean;
 
   // View explorer
   toggleCollection: (collectionName: string) => void;
@@ -79,29 +78,28 @@ type ExplorerStore = ExplorerState & ExplorerActions;
 
 const createInitialState = (): ExplorerState => ({
   database: {
-    expandedServers: new Set(),
-    expandedDatabases: new Set(),
-    expandedCollectionGroups: new Set(),
-    expandedViewGroups: new Set(),
-    expandedNodes: new Set(),
+    expandedServers: {},
+    expandedDatabases: {},
+    expandedCollectionGroups: {},
+    expandedViewGroups: {},
+    expandedNodes: {},
   },
   console: {
-    expandedFolders: new Set(),
+    expandedFolders: {},
   },
   dashboard: {
-    expandedFolders: new Set(),
+    expandedFolders: {},
   },
   view: {
-    expandedCollections: new Set(),
+    expandedCollections: {},
   },
 });
 
-// Helper to toggle a value in a Set
-const toggleInSet = (set: Set<string>, value: string): void => {
-  if (set.has(value)) {
-    set.delete(value);
+const toggleKey = (map: ExpandedMap, key: string): void => {
+  if (map[key]) {
+    delete map[key];
   } else {
-    set.add(value);
+    map[key] = true;
   }
 };
 
@@ -110,184 +108,149 @@ export const useExplorerStore = create<ExplorerStore>()(
     immer((set, get) => ({
       ...createInitialState(),
 
-      // Database explorer actions
       toggleServer: serverId =>
         set(state => {
-          toggleInSet(state.database.expandedServers, serverId);
+          toggleKey(state.database.expandedServers, serverId);
         }),
 
       toggleDatabase: databaseId =>
         set(state => {
-          toggleInSet(state.database.expandedDatabases, databaseId);
+          toggleKey(state.database.expandedDatabases, databaseId);
         }),
 
       toggleCollectionGroup: databaseId =>
         set(state => {
-          toggleInSet(state.database.expandedCollectionGroups, databaseId);
+          toggleKey(state.database.expandedCollectionGroups, databaseId);
         }),
 
       toggleViewGroup: databaseId =>
         set(state => {
-          toggleInSet(state.database.expandedViewGroups, databaseId);
+          toggleKey(state.database.expandedViewGroups, databaseId);
         }),
 
       toggleNode: nodeId =>
         set(state => {
-          toggleInSet(state.database.expandedNodes, nodeId);
+          toggleKey(state.database.expandedNodes, nodeId);
         }),
 
       expandServer: serverId =>
         set(state => {
-          state.database.expandedServers.add(serverId);
+          state.database.expandedServers[serverId] = true;
         }),
 
       expandDatabase: databaseId =>
         set(state => {
-          state.database.expandedDatabases.add(databaseId);
+          state.database.expandedDatabases[databaseId] = true;
         }),
 
-      // Database explorer helpers
-      isServerExpanded: serverId =>
-        get().database.expandedServers.has(serverId),
+      isServerExpanded: serverId => !!get().database.expandedServers[serverId],
       isDatabaseExpanded: databaseId =>
-        get().database.expandedDatabases.has(databaseId),
+        !!get().database.expandedDatabases[databaseId],
       isCollectionGroupExpanded: databaseId =>
-        get().database.expandedCollectionGroups.has(databaseId),
+        !!get().database.expandedCollectionGroups[databaseId],
       isViewGroupExpanded: databaseId =>
-        get().database.expandedViewGroups.has(databaseId),
-      isNodeExpanded: nodeId => get().database.expandedNodes.has(nodeId),
+        !!get().database.expandedViewGroups[databaseId],
+      isNodeExpanded: nodeId => !!get().database.expandedNodes[nodeId],
 
-      // Console explorer actions
-      toggleFolder: folderPath =>
+      toggleFolder: folderKey =>
         set(state => {
-          toggleInSet(state.console.expandedFolders, folderPath);
+          toggleKey(state.console.expandedFolders, folderKey);
         }),
 
-      expandFolder: folderPath =>
+      expandFolder: folderKey =>
         set(state => {
-          state.console.expandedFolders.add(folderPath);
+          state.console.expandedFolders[folderKey] = true;
         }),
 
-      isFolderExpanded: folderPath =>
-        get().console.expandedFolders.has(folderPath),
+      isFolderExpanded: folderKey => !!get().console.expandedFolders[folderKey],
 
-      // Dashboard explorer actions
-      toggleDashboardFolder: folderPath =>
+      toggleDashboardFolder: folderKey =>
         set(state => {
-          toggleInSet(state.dashboard.expandedFolders, folderPath);
+          toggleKey(state.dashboard.expandedFolders, folderKey);
         }),
 
-      expandDashboardFolder: folderPath =>
+      expandDashboardFolder: folderKey =>
         set(state => {
-          state.dashboard.expandedFolders.add(folderPath);
+          state.dashboard.expandedFolders[folderKey] = true;
         }),
 
-      isDashboardFolderExpanded: folderPath =>
-        get().dashboard.expandedFolders.has(folderPath),
+      isDashboardFolderExpanded: folderKey =>
+        !!get().dashboard.expandedFolders[folderKey],
 
-      // View explorer actions
       toggleCollection: collectionName =>
         set(state => {
-          toggleInSet(state.view.expandedCollections, collectionName);
+          toggleKey(state.view.expandedCollections, collectionName);
         }),
 
       expandCollection: collectionName =>
         set(state => {
-          state.view.expandedCollections.add(collectionName);
+          state.view.expandedCollections[collectionName] = true;
         }),
 
       isCollectionExpanded: collectionName =>
-        get().view.expandedCollections.has(collectionName),
+        !!get().view.expandedCollections[collectionName],
 
-      // Reset
       reset: () => set(createInitialState()),
     })),
     {
       name: "explorer-store",
-      // Custom serialization for Sets
       storage: {
         getItem: name => {
           const str = localStorage.getItem(name);
           if (!str) return null;
 
           const data = JSON.parse(str);
-          // Convert arrays back to Sets
-          if (data.state?.database) {
-            data.state.database.expandedServers = new Set(
-              data.state.database.expandedServers || [],
+          const s = data.state;
+
+          // Migrate legacy Set-serialized arrays to Record<string, true>
+          const migrateArray = (arr: unknown): ExpandedMap => {
+            if (Array.isArray(arr)) {
+              const map: ExpandedMap = {};
+              for (const key of arr) {
+                if (typeof key === "string") map[key] = true;
+              }
+              return map;
+            }
+            if (arr && typeof arr === "object" && !Array.isArray(arr)) {
+              return arr as ExpandedMap;
+            }
+            return {};
+          };
+
+          if (s?.database) {
+            s.database.expandedServers = migrateArray(
+              s.database.expandedServers,
             );
-            data.state.database.expandedDatabases = new Set(
-              data.state.database.expandedDatabases || [],
+            s.database.expandedDatabases = migrateArray(
+              s.database.expandedDatabases,
             );
-            data.state.database.expandedCollectionGroups = new Set(
-              data.state.database.expandedCollectionGroups || [],
+            s.database.expandedCollectionGroups = migrateArray(
+              s.database.expandedCollectionGroups,
             );
-            data.state.database.expandedViewGroups = new Set(
-              data.state.database.expandedViewGroups || [],
+            s.database.expandedViewGroups = migrateArray(
+              s.database.expandedViewGroups,
             );
-            data.state.database.expandedNodes = new Set(
-              data.state.database.expandedNodes || [],
-            );
+            s.database.expandedNodes = migrateArray(s.database.expandedNodes);
           }
-          if (data.state?.console) {
-            data.state.console.expandedFolders = new Set(
-              data.state.console.expandedFolders || [],
-            );
+          if (s?.console) {
+            s.console.expandedFolders = migrateArray(s.console.expandedFolders);
           }
-          if (data.state?.dashboard) {
-            data.state.dashboard.expandedFolders = new Set(
-              data.state.dashboard.expandedFolders || [],
+          if (s?.dashboard) {
+            s.dashboard.expandedFolders = migrateArray(
+              s.dashboard.expandedFolders,
             );
           } else {
-            data.state.dashboard = { expandedFolders: new Set() };
+            s.dashboard = { expandedFolders: {} };
           }
-          if (data.state?.view) {
-            data.state.view.expandedCollections = new Set(
-              data.state.view.expandedCollections || [],
+          if (s?.view) {
+            s.view.expandedCollections = migrateArray(
+              s.view.expandedCollections,
             );
           }
           return data;
         },
         setItem: (name, value) => {
-          // Convert Sets to arrays for JSON serialization
-          const serialized = {
-            ...value,
-            state: {
-              database: {
-                expandedServers: Array.from(
-                  value.state.database.expandedServers || [],
-                ),
-                expandedDatabases: Array.from(
-                  value.state.database.expandedDatabases || [],
-                ),
-                expandedCollectionGroups: Array.from(
-                  value.state.database.expandedCollectionGroups || [],
-                ),
-                expandedViewGroups: Array.from(
-                  value.state.database.expandedViewGroups || [],
-                ),
-                expandedNodes: Array.from(
-                  value.state.database.expandedNodes || [],
-                ),
-              },
-              console: {
-                expandedFolders: Array.from(
-                  value.state.console.expandedFolders || [],
-                ),
-              },
-              dashboard: {
-                expandedFolders: Array.from(
-                  value.state.dashboard?.expandedFolders || [],
-                ),
-              },
-              view: {
-                expandedCollections: Array.from(
-                  value.state.view.expandedCollections || [],
-                ),
-              },
-            },
-          };
-          localStorage.setItem(name, JSON.stringify(serialized));
+          localStorage.setItem(name, JSON.stringify(value));
         },
         removeItem: name => {
           localStorage.removeItem(name);
@@ -302,14 +265,12 @@ export const useDatabaseExplorerStore = () => {
   const store = useExplorerStore();
 
   return {
-    // Expose Sets directly for components expecting the old interface
     expandedServers: store.database.expandedServers,
     expandedDatabases: store.database.expandedDatabases,
     expandedCollectionGroups: store.database.expandedCollectionGroups,
     expandedViewGroups: store.database.expandedViewGroups,
     expandedNodes: store.database.expandedNodes,
 
-    // Actions
     toggleServer: store.toggleServer,
     toggleDatabase: store.toggleDatabase,
     toggleCollectionGroup: store.toggleCollectionGroup,
@@ -318,7 +279,6 @@ export const useDatabaseExplorerStore = () => {
     expandServer: store.expandServer,
     expandDatabase: store.expandDatabase,
 
-    // Helpers
     isServerExpanded: store.isServerExpanded,
     isDatabaseExpanded: store.isDatabaseExpanded,
     isCollectionGroupExpanded: store.isCollectionGroupExpanded,

--- a/app/src/store/lib/tree-helpers.test.ts
+++ b/app/src/store/lib/tree-helpers.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import {
+  countItems,
+  filterTree,
+  insertAlphabetically,
+  removeById,
+  type ManagedTreeNode,
+} from "./tree-helpers";
+
+interface TestNode extends ManagedTreeNode {
+  id: string;
+  children?: TestNode[];
+}
+
+describe("tree-helpers", () => {
+  it("keeps folders before files when inserting alphabetically", () => {
+    const nodes: TestNode[] = [
+      { id: "file-b", name: "b.sql", isDirectory: false },
+      { id: "file-c", name: "c.sql", isDirectory: false },
+    ];
+
+    insertAlphabetically(nodes, {
+      id: "folder-a",
+      name: "Archive",
+      isDirectory: true,
+      children: [],
+    });
+    insertAlphabetically(nodes, {
+      id: "file-a",
+      name: "a.sql",
+      isDirectory: false,
+    });
+
+    expect(nodes.map(node => node.name)).toEqual([
+      "Archive",
+      "a.sql",
+      "b.sql",
+      "c.sql",
+    ]);
+  });
+
+  it("filters matching folders without needing child matches", () => {
+    const nodes: TestNode[] = [
+      {
+        id: "folder-1",
+        name: "Dashboards",
+        isDirectory: true,
+        children: [{ id: "file-1", name: "Sales", isDirectory: false }],
+      },
+    ];
+
+    expect(filterTree(nodes, "dash")).toEqual([
+      {
+        id: "folder-1",
+        name: "Dashboards",
+        isDirectory: true,
+        children: [],
+      },
+    ]);
+  });
+
+  it("can require descendant matches when filtering folders", () => {
+    const nodes: TestNode[] = [
+      {
+        id: "folder-1",
+        name: "Dashboards",
+        isDirectory: true,
+        children: [{ id: "file-1", name: "Sales", isDirectory: false }],
+      },
+    ];
+
+    expect(
+      filterTree(nodes, "dash", { includeMatchingFolders: false }),
+    ).toEqual([]);
+    expect(
+      filterTree(nodes, "sale", { includeMatchingFolders: false }),
+    ).toEqual([
+      {
+        id: "folder-1",
+        name: "Dashboards",
+        isDirectory: true,
+        children: [{ id: "file-1", name: "Sales", isDirectory: false }],
+      },
+    ]);
+  });
+
+  it("removes a nested node by id", () => {
+    const nodes: TestNode[] = [
+      {
+        id: "folder-1",
+        name: "Folder",
+        isDirectory: true,
+        children: [{ id: "file-1", name: "Query", isDirectory: false }],
+      },
+    ];
+
+    const removed = removeById(nodes, "file-1");
+
+    expect(removed?.name).toBe("Query");
+    expect(nodes[0].children).toEqual([]);
+  });
+
+  it("counts only non-directory items", () => {
+    const nodes: TestNode[] = [
+      {
+        id: "folder-1",
+        name: "Folder",
+        isDirectory: true,
+        children: [
+          { id: "file-1", name: "One", isDirectory: false },
+          { id: "file-2", name: "Two", isDirectory: false },
+        ],
+      },
+      { id: "file-3", name: "Three", isDirectory: false },
+    ];
+
+    expect(countItems(nodes)).toBe(3);
+  });
+});

--- a/app/src/store/lib/tree-helpers.ts
+++ b/app/src/store/lib/tree-helpers.ts
@@ -7,14 +7,16 @@
  * Used by both consoleTreeStore and dashboardTreeStore.
  */
 
-export interface TreeNode {
+export interface ManagedTreeNode {
   id?: string;
   name: string;
   isDirectory: boolean;
-  children?: TreeNode[];
+  children?: ManagedTreeNode[];
 }
 
-export function findTargetArray<T extends TreeNode>(
+export type TreeNode = ManagedTreeNode;
+
+export function findTargetArray<T extends ManagedTreeNode>(
   nodes: T[],
   remainingSegments: string[],
 ): T[] | null {
@@ -28,7 +30,7 @@ export function findTargetArray<T extends TreeNode>(
   return findTargetArray(folder.children as T[], remainingSegments.slice(1));
 }
 
-export function removeById<T extends TreeNode>(
+export function removeById<T extends ManagedTreeNode>(
   nodes: T[],
   targetId: string,
 ): T | null {
@@ -43,7 +45,7 @@ export function removeById<T extends TreeNode>(
   return null;
 }
 
-export function insertAlphabetically<T extends TreeNode>(
+export function insertAlphabetically<T extends ManagedTreeNode>(
   nodes: T[],
   entry: T,
 ): void {
@@ -64,11 +66,14 @@ export function insertAlphabetically<T extends TreeNode>(
   nodes.splice(insertIndex, 0, entry);
 }
 
-export function insertAtTop<T extends TreeNode>(nodes: T[], entry: T): void {
+export function insertAtTop<T extends ManagedTreeNode>(
+  nodes: T[],
+  entry: T,
+): void {
   nodes.unshift(entry);
 }
 
-export function findById<T extends TreeNode>(
+export function findById<T extends ManagedTreeNode>(
   nodes: T[],
   targetId: string,
 ): T | null {
@@ -82,7 +87,7 @@ export function findById<T extends TreeNode>(
   return null;
 }
 
-export function findParentArray<T extends TreeNode>(
+export function findParentArray<T extends ManagedTreeNode>(
   nodes: T[],
   targetId: string,
 ): T[] | null {
@@ -100,17 +105,30 @@ export function findParentArray<T extends TreeNode>(
  * Client-side filter: case-insensitive match on node name.
  * Folders pass if their name matches or any descendant matches.
  */
-export function filterTree<T extends TreeNode>(nodes: T[], query: string): T[] {
+export interface FilterTreeOptions {
+  includeMatchingFolders?: boolean;
+}
+
+export function filterTree<T extends ManagedTreeNode>(
+  nodes: T[],
+  query: string,
+  options: FilterTreeOptions = {},
+): T[] {
   const lower = query.toLowerCase();
+  const includeMatchingFolders = options.includeMatchingFolders ?? true;
   const result: T[] = [];
   for (const node of nodes) {
     if (node.isDirectory && node.children) {
-      const filteredChildren = filterTree(node.children as T[], query);
+      const filteredChildren = filterTree(node.children as T[], query, options);
       if (
         filteredChildren.length > 0 ||
-        node.name.toLowerCase().includes(lower)
+        (includeMatchingFolders && node.name.toLowerCase().includes(lower))
       ) {
         result.push({ ...node, children: filteredChildren } as T);
+      }
+    } else if (node.isDirectory && includeMatchingFolders) {
+      if (node.name.toLowerCase().includes(lower)) {
+        result.push({ ...node, children: [] } as T);
       }
     } else if (node.name.toLowerCase().includes(lower)) {
       result.push(node);
@@ -120,7 +138,7 @@ export function filterTree<T extends TreeNode>(nodes: T[], query: string): T[] {
 }
 
 /** Count all non-directory items in a tree (recursive) */
-export function countItems<T extends TreeNode>(nodes: T[]): number {
+export function countItems<T extends ManagedTreeNode>(nodes: T[]): number {
   let count = 0;
   for (const node of nodes) {
     if (node.isDirectory && node.children) {


### PR DESCRIPTION
## Summary

- **ConsoleTree deduplication**: Reduces ConsoleTree from ~1400 lines to ~200 by delegating DnD, context menus, keyboard nav, inline rename, and picker mode to the shared ResourceTree component
- **explorerStore: Set → Record migration**: Replaces `Set<string>` with `Record<string, true>` to fix unreliable behavior inside immer drafts, with backward-compatible migration for persisted localStorage data
- **Extracted utilities**: Moves DnD helpers into `resource-tree/dnd.tsx` and tree search/drop-resolution logic into `resource-tree/utils.ts` with full test coverage
- **Global text overflow fixes**: Adds truncation styles to ThemeContext (MUI component overrides) and CSS utility classes (`app-truncate`, `app-truncate-inline`) to prevent text overflow in Chat, Editor, ModelSelector, WorkspaceSwitcher, and FileExplorerDialog
- **Bug fix**: Folder creation now correctly derives `isPrivate` from the access level

## Test plan

- [x] `tree-helpers.test.ts` — 5 tests passing (insert, filter, remove, count)
- [x] `resource-tree/utils.test.ts` — 4 tests passing (find, ancestors, flatten, drop resolution)
- [x] TypeScript compiles with no errors
- [x] Lint + prettier pass via pre-commit hooks
- [ ] Manual: verify console tree sidebar — expand/collapse, rename, DnD, context menus
- [ ] Manual: verify console tree picker — folder selection, initial expand, new folder
- [ ] Manual: verify dashboard explorer — move, info dialog, folder creation
- [ ] Manual: verify text truncation in narrow viewports (model selector, tabs, workspace switcher)

🤖 Generated with [Claude Code](https://claude.com/claude-code)