### PR TITLE
fix: add pipeline observability to diagnose backfill row loss

### DIFF
--- a/api/src/inngest/functions/sync-entity.ts
+++ b/api/src/inngest/functions/sync-entity.ts
@@ -551,10 +551,15 @@ export const syncBackfillEntityFunction = inngest.createFunction(
       }
     }
 
+    const totalFetched = state?.totalProcessed ?? totalWrittenForEntity;
     logger.info("Completed chunked sync for entity", {
       flowId,
       entity,
       totalChunks: chunkIndex,
+      totalFetched,
+      totalWrittenForEntity,
+      fetchWriteDelta: totalFetched - totalWrittenForEntity,
+      useBulkPath,
     });
 
     // ── Flush remaining + merge for bulk path ─────────────────────────
@@ -592,13 +597,20 @@ export const syncBackfillEntityFunction = inngest.createFunction(
           logExec("info", `Merging ${entity} staging table to live`, {
             entity,
           });
-          await performStagingMerge(bulkSyncOptions as any);
+          const mergeResult = await performStagingMerge(bulkSyncOptions as any);
           await performStagingCleanup(bulkSyncOptions as any);
           logExec(
             "info",
-            `✅ ${entity} bulk backfill complete (buffer → Parquet → staging → live)`,
-            { entity },
+            `✅ ${entity} bulk backfill complete (buffer → Parquet → staging → live, ${mergeResult.written} rows merged)`,
+            { entity, mergedRows: mergeResult.written },
           );
+          logger.info("Final merge result", {
+            flowId,
+            entity,
+            mergedRows: mergeResult.written,
+            totalFetched,
+            totalWrittenToTemp: totalWrittenForEntity,
+          });
         });
       }
 

--- a/api/src/inngest/functions/sync-entity.ts
+++ b/api/src/inngest/functions/sync-entity.ts
@@ -532,7 +532,9 @@ export const syncBackfillEntityFunction = inngest.createFunction(
                 { entity, flushIndex, tempCount },
               );
               await performPrepareStaging(bulkSyncOptions as any);
-              await performBulkFlush(bulkSyncOptions as any);
+              await performBulkFlush(bulkSyncOptions as any, () =>
+                touchHeartbeat(executionId),
+              );
               await performStagingMerge(bulkSyncOptions as any);
               await performStagingCleanup(bulkSyncOptions as any);
             },
@@ -580,7 +582,9 @@ export const syncBackfillEntityFunction = inngest.createFunction(
             { entity, tempCount: finalRowsInTemp },
           );
           await performPrepareStaging(bulkSyncOptions as any);
-          await performBulkFlush(bulkSyncOptions as any);
+          await performBulkFlush(bulkSyncOptions as any, () =>
+            touchHeartbeat(executionId),
+          );
         });
 
         await step.run(`merge-final-${safeEntityStepId}`, async () => {

--- a/api/src/services/sync-executor.service.ts
+++ b/api/src/services/sync-executor.service.ts
@@ -33,8 +33,9 @@ export async function performSyncChunk(
 
 export async function performBulkFlush(
   options: SyncChunkOptions,
+  onBatchFlushed?: () => Promise<void>,
 ): Promise<{ flushed: number }> {
-  return performBulkFlushOrchestrated(options);
+  return performBulkFlushOrchestrated(options, onBatchFlushed);
 }
 
 export async function performPrepareStaging(

--- a/api/src/sync-cdc/adapters/bigquery.ts
+++ b/api/src/sync-cdc/adapters/bigquery.ts
@@ -578,6 +578,32 @@ export class BigQueryDestinationAdapter implements CdcDestinationAdapter {
 
     const [deleteStmt, insertStmt] = buildMergeStatements(allColumns);
 
+    let stagingRowCount = 0;
+    try {
+      const countResult = await databaseConnectionService.executeQuery(
+        destination,
+        `SELECT COUNT(*) AS cnt FROM ${fullStaging}`,
+        { location: datasetLocation },
+      );
+      if (
+        countResult.success &&
+        Array.isArray(countResult.data) &&
+        countResult.data[0]
+      ) {
+        stagingRowCount = Number((countResult.data[0] as any).cnt || 0);
+      }
+    } catch {
+      log.warn("Could not count staging rows before merge", { stagingTable });
+    }
+
+    log.info("Starting staging-to-live merge", {
+      liveTable,
+      stagingTable,
+      dataset,
+      stagingRowCount,
+      columnCount: allColumns.length,
+    });
+
     await retryOnQuota(
       async () => {
         const deleteResult = await databaseConnectionService.executeQuery(
@@ -622,14 +648,34 @@ export class BigQueryDestinationAdapter implements CdcDestinationAdapter {
       { label: `mergeStagingToLive:INSERT(${liveTable})` },
     );
 
+    let liveRowCount = 0;
+    try {
+      const liveCountResult = await databaseConnectionService.executeQuery(
+        destination,
+        `SELECT COUNT(*) AS cnt FROM ${fullLive}`,
+        { location: datasetLocation },
+      );
+      if (
+        liveCountResult.success &&
+        Array.isArray(liveCountResult.data) &&
+        liveCountResult.data[0]
+      ) {
+        liveRowCount = Number((liveCountResult.data[0] as any).cnt || 0);
+      }
+    } catch {
+      log.warn("Could not count live rows after merge", { liveTable });
+    }
+
     log.info("Merged staging to live table via DELETE+INSERT", {
       liveTable,
       stagingTable,
       dataset,
+      stagingRowCount,
+      liveRowCount,
       skippedLiveAdds,
     });
 
-    return { written: 0 };
+    return { written: stagingRowCount };
   }
 
   async cleanupStaging(

--- a/api/src/sync-cdc/ingest.ts
+++ b/api/src/sync-cdc/ingest.ts
@@ -60,6 +60,12 @@ class CdcIngestService {
       deduped: result.deduped,
       attempted: result.attempted,
       entities: result.entities.map(entity => entity.entity),
+      entityBreakdown: result.entities.map(entity => ({
+        entity: entity.entity,
+        source: entity.source,
+        lastIngestSeq: entity.lastIngestSeq,
+        runId: entity.runId,
+      })),
     });
 
     return result;

--- a/api/src/sync/sync-orchestrator.ts
+++ b/api/src/sync/sync-orchestrator.ts
@@ -929,10 +929,23 @@ async function performSyncChunkSql(
       await writer.finalize();
     }
 
+    const fetchWriteDelta = fetchState.totalProcessed - runningRowsWritten;
     logger?.log(
       "info",
       `✅ ${entity} SQL sync completed (${runningRowsWritten} written, ${fetchState.totalProcessed} fetched)`,
     );
+    if (fetchWriteDelta !== 0) {
+      logger?.log(
+        "warn",
+        `⚠️ ${entity} fetch/write mismatch: ${fetchState.totalProcessed} fetched but ${runningRowsWritten} written (delta: ${fetchWriteDelta})`,
+        {
+          entity,
+          totalFetched: fetchState.totalProcessed,
+          totalWritten: runningRowsWritten,
+          delta: fetchWriteDelta,
+        },
+      );
+    }
   } else {
     logger?.log(
       "info",
@@ -1150,10 +1163,11 @@ async function flushBulkBuffer(
     );
 
     if (parquet.rowCount === 0) {
+      const actualRemaining = await tempCollection.countDocuments();
       logger?.log(
         "warn",
-        `${entity} flush: empty parquet (possible race), stopping flush loop`,
-        { entity, batch: batchNum },
+        `${entity} flush: empty parquet (possible race), stopping flush loop (${actualRemaining} rows still in temp, ${totalFlushed} flushed so far)`,
+        { entity, batch: batchNum, actualRemaining, totalFlushed },
       );
       break;
     }
@@ -1257,11 +1271,25 @@ async function flushBulkBuffer(
     {
       entity,
       totalFlushed,
+      initialCount,
       batches: batchNum,
       finalBatchSize: currentBatchSize,
       memory: syncMemorySnapshot(),
     },
   );
+
+  if (totalFlushed !== initialCount) {
+    logger?.log(
+      "warn",
+      `⚠️ ${entity} flush mismatch: ${initialCount} rows in temp but only ${totalFlushed} flushed to staging (${initialCount - totalFlushed} lost)`,
+      {
+        entity,
+        initialCount,
+        totalFlushed,
+        delta: initialCount - totalFlushed,
+      },
+    );
+  }
 
   return { flushed: totalFlushed };
 }

--- a/api/src/sync/sync-orchestrator.ts
+++ b/api/src/sync/sync-orchestrator.ts
@@ -1012,6 +1012,7 @@ async function flushBulkBuffer(
   flowId: string,
   logger?: SyncLogger,
   schemaFields?: FieldMeta[],
+  onBatchFlushed?: () => Promise<void>,
 ): Promise<{ flushed: number }> {
   const initialCount = await tempCollection.countDocuments();
   if (initialCount === 0) return { flushed: 0 };
@@ -1207,6 +1208,8 @@ async function flushBulkBuffer(
       global.gc();
     }
 
+    await onBatchFlushed?.();
+
     consecutiveSuccesses++;
     if (
       consecutiveSuccesses >= CONSECUTIVE_OK_TO_GROW &&
@@ -1291,6 +1294,7 @@ async function resolveAdapterContext(options: SyncChunkOptions) {
 
 export async function performBulkFlush(
   options: SyncChunkOptions,
+  onBatchFlushed?: () => Promise<void>,
 ): Promise<{ flushed: number }> {
   if (!options.tableDestination?.connectionId || !options.flowId) {
     return { flushed: 0 };
@@ -1333,6 +1337,7 @@ export async function performBulkFlush(
     options.flowId!,
     options.logger,
     schemaFields,
+    onBatchFlushed,
   );
 }
 


### PR DESCRIPTION
## Summary

- Adds logging at every stage of the backfill pipeline (fetch → temp → parquet → staging → live) to diagnose where rows are lost
- After a meetings backfill showed 151k fetched but only ~127k in BigQuery, there was no way to tell where the ~24k rows disappeared
- BigQuery `mergeFromStaging` now returns actual merged row count instead of always returning 0

## Changes

- **sync-orchestrator.ts**: Warn on fetch/write mismatch at sync completion; warn on temp/flushed mismatch after bulk flush; add remaining count to empty-parquet diagnostic
- **bigquery.ts**: Count staging rows before merge and live rows after merge; return actual `stagingRowCount` from `mergeFromStaging`
- **sync-entity.ts**: Log end-to-end totals (fetched/temp/merged) at entity completion; log merge result with row counts
- **ingest.ts**: Add per-entity breakdown (source, lastIngestSeq, runId) to CDC ingest logs

## Test plan

- [ ] Deploy and run a backfill — verify new logs appear at each pipeline stage
- [ ] Confirm fetch/write mismatch warning fires when counts differ
- [ ] Verify `mergeFromStaging` returns non-zero row count after BQ merge
- [ ] Check that no existing log formats are broken


Made with [Cursor](https://cursor.com)