### PR TITLE
fix: reduce CDC materialize queue flooding that starves webhook processing

### DIFF
--- a/api/src/inngest/functions/webhook-flow.ts
+++ b/api/src/inngest/functions/webhook-flow.ts
@@ -1130,46 +1130,41 @@ async function runCdcMaterialization(params: {
     force?: boolean;
   };
 
-  const isBackfilling = await params.step.run(
-    "check-backfill-state",
-    async () => {
-      const flow = await Flow.findById(flowId)
-        .select("backfillState.status")
-        .lean();
-      return flow?.backfillState?.status === "running";
-    },
-  );
-
-  const maxEvents = isBackfilling
-    ? CDC_MATERIALIZE_MAX_EVENTS_BACKFILL
-    : CDC_MATERIALIZE_MAX_EVENTS;
-
   const materializeStartedAt = Date.now();
-  const result = await params.step.run("materialize-cdc-entity", async () => {
-    return cdcConsumerService.materializeEntity({
+  const result = (await params.step.run("materialize-cdc-entity", async () => {
+    const flow = await Flow.findById(flowId)
+      .select("backfillState.status")
+      .lean();
+    const isBackfilling = flow?.backfillState?.status === "running";
+    const maxEvents = isBackfilling
+      ? CDC_MATERIALIZE_MAX_EVENTS_BACKFILL
+      : CDC_MATERIALIZE_MAX_EVENTS;
+
+    const materializeResult = await cdcConsumerService.materializeEntity({
       workspaceId,
       flowId,
       entity,
       maxEvents,
     });
-  });
+    return { ...materializeResult, isBackfilling, maxEvents };
+  })) as any;
   const materializeStepDurationMs = Date.now() - materializeStartedAt;
 
   params.logger.info("CDC materialization completed", {
     flowId,
     entity,
     force: Boolean(force),
-    isBackfilling,
-    maxEvents,
+    isBackfilling: result.isBackfilling,
+    maxEvents: result.maxEvents,
     materializeStepDurationMs,
-    processed: (result as any).processed,
-    applied: (result as any).applied,
-    latestIngestSeq: (result as any).latestIngestSeq,
-    skipped: (result as any).skipped,
-    reason: (result as any).reason,
+    processed: result.processed,
+    applied: result.applied,
+    latestIngestSeq: result.latestIngestSeq,
+    skipped: result.skipped,
+    reason: result.reason,
   });
 
-  if ((result as any).processed >= maxEvents) {
+  if (result.processed >= result.maxEvents) {
     await params.step.sendEvent("continue-materialize", {
       name: params.continuationEventName,
       data: { workspaceId, flowId, entity, force: true },
@@ -1221,11 +1216,19 @@ export const cdcMaterializeSchedulerFunction = inngest.createFunction(
     id: "cdc-materialize-scheduler",
     name: "CDC Materialize Scheduler",
   },
-  { cron: "*/1 * * * *" },
+  { cron: "*/2 * * * *" },
   async ({ step, logger }) => {
     const staleEntities = await step.run("find-stale-entities", async () => {
+      // Skip entities materialized within the last 45 s — they already have
+      // a queued or throttled run and re-emitting is pure waste.
+      const staleThreshold = new Date(Date.now() - 45_000);
+
       const candidates = await CdcEntityState.find({
         $expr: { $gt: ["$lastIngestSeq", "$lastMaterializedSeq"] },
+        $or: [
+          { lastMaterializedAt: { $exists: false } },
+          { lastMaterializedAt: { $lt: staleThreshold } },
+        ],
       })
         .select("workspaceId flowId entity")
         .lean();

--- a/api/src/inngest/functions/webhook-flow.ts
+++ b/api/src/inngest/functions/webhook-flow.ts
@@ -938,19 +938,10 @@ export const webhookEventProcessCdcFunction = inngest.createFunction(
       };
     });
 
-    const { entities: ingestedEntities, workspaceId } = result as {
-      entities?: string[];
-      workspaceId?: string;
-    };
-    if (ingestedEntities && ingestedEntities.length > 0 && workspaceId) {
-      await step.sendEvent(
-        "trigger-materialize",
-        ingestedEntities.map(entity => ({
-          name: "cdc/materialize" as const,
-          data: { workspaceId, flowId, entity, force: false },
-        })),
-      );
-    }
+    // Materialization is NOT triggered inline — the scheduler cron picks up
+    // stale entities every 2 min by comparing lastIngestSeq vs
+    // lastMaterializedSeq.  Emitting here would duplicate the scheduler's
+    // work and flood the Inngest queue with redundant cdc/materialize events.
 
     return { success: true, ...result };
   },


### PR DESCRIPTION
## Summary

- **Filter recently-materialized entities in the scheduler**: the `cdcMaterializeSchedulerFunction` now skips entities with `lastMaterializedAt` within the last 45s, preventing redundant `cdc/materialize` events for entities that already have a queued or recently-completed run
- **Reduce scheduler cron from `*/1` to `*/2` minutes**: halves baseline event emission rate
- **Remove inline `cdc/materialize` trigger from the CDC ingest function**: the scheduler is now the single source of truth for triggering materialization — the inline trigger after every webhook batch was the main source of duplicate events flooding the queue
- **Merge two Inngest steps into one**: collapses `check-backfill-state` + `materialize-cdc-entity` into a single step, cutting per-run Inngest API overhead from 3 round-trips to 2

### Problem

The Inngest `cdc-materialize` function queue was massively backed up. The scheduler was emitting ~35 events/min and the CDC ingest function added more duplicates after every webhook batch. Most runs finished with `processed: 0` (no work to do), yet each consumed Inngest execution slots and API round-trips. This starved the `webhook-event-process-cdc` function — zero executions observed over 6+ hours despite 5,000+ incoming webhooks/hour.

### Expected impact

| Metric | Before | After |
|---|---|---|
| Scheduler events/hour | ~2,100 | ~200-400 |
| Inngest API calls/hour for materialize | ~7,800 | ~600-1,200 |
| Wasted (processed=0) runs | ~1,600/hour | near zero |
| Duplicate events from ingest path | ~500/hour | 0 |
| Available capacity for webhook processing | starved | restored |

## Deploy checklist

> **Important**: After deploying, bulk-cancel queued runs to clear the existing backlog.

1. Merge and deploy this PR
2. Go to [Inngest dashboard — cdc-materialize runs](https://app.inngest.com/env/production/functions/mako-sync-cdc-materialize/runs)
3. Filter by status **Queued**
4. Bulk cancel all queued runs
5. The scheduler will re-emit only for genuinely stale entities on the next 2-minute tick

## Test plan

- [ ] Deploy and monitor the Inngest `cdc-materialize` function queue — it should drain and stay low
- [ ] Verify `CDC materialize scheduler triggered` log shows fewer entities per run
- [ ] Verify webhook events are being processed (`webhook/event.process.cdc` runs appearing)
- [ ] Verify materialization latency (time between webhook receive and `applyStatus: "applied"`) is acceptable
- [ ] Confirm backfill recovery paths still trigger materialization correctly (they use `force: true` and bypass the scheduler)