### PR TITLE
feat: add Gemma 4 26B to AI model list

### DIFF
--- a/api/src/agent-lib/ai-models.ts
+++ b/api/src/agent-lib/ai-models.ts
@@ -104,6 +104,13 @@ export const ALL_MODELS: AIModel[] = [
     name: "Gemini 2.5 Flash",
     description: "Fast and efficient for quick tasks",
   },
+  {
+    id: "google/gemma-4-26b-a4b-it",
+    provider: "google",
+    name: "Gemma 4 26B",
+    description:
+      "Open model, fast inference with MoE architecture (3.8B active params)",
+  },
 ];
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds Google Gemma 4 26B (`google/gemma-4-26b-a4b-it`) to the AI model list, making it available in the chat model selector.
- The Vercel AI Gateway already supports this model natively — no provider or gateway changes needed.

## Test plan

- [ ] Verify the model appears in the chat model selector under the Google group
- [ ] Send a chat message using Gemma 4 26B and confirm a streamed response

Made with [Cursor](https://cursor.com)