### PR TITLE
feat: add SSH tunnel support for MySQL connections

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -52,6 +52,7 @@
     "pg": "^8.16.0",
     "sqlite": "^5.1.1",
     "sqlite3": "^5.1.7",
+    "ssh2": "^1.17.0",
     "stripe": "^14.25.0",
     "uuid": "^9.0.0",
     "zod": "^4.2.1"
@@ -64,6 +65,7 @@
     "@types/mssql": "^9.1.7",
     "@types/node": "^24.0.0",
     "@types/pg": "^8.15.4",
+    "@types/ssh2": "^1.15.5",
     "@types/uuid": "^9.0.0",
     "@typescript-eslint/eslint-plugin": "^8.34.0",
     "@typescript-eslint/parser": "^8.34.0",

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -226,7 +226,10 @@ export interface IDatabaseConnection extends Document {
       host?: string;
       port?: number;
       username?: string;
+      authMethod?: "password" | "privateKey";
+      password?: string;
       privateKey?: string;
+      passphrase?: string;
     };
   };
   isDemo?: boolean; // True if this is a demo database connection

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -41,6 +41,7 @@ import { webhookRoutes } from "./routes/webhooks";
 import { getFunctions, inngest, logInngestStatus } from "./inngest";
 import mongoose from "mongoose";
 import { databaseConnectionService } from "./services/database-connection.service";
+import { sshTunnelManager } from "./services/ssh-tunnel.service";
 import { loggers, loggingMiddleware } from "./logging";
 import { warmPricingCache } from "./services/gateway-pricing.service";
 import { isGatewayMode } from "./agent-lib/ai-models";
@@ -304,6 +305,10 @@ async function gracefulShutdown(
 
   let exitCode = forcedExitCode ?? 0;
   try {
+    // Close SSH tunnels
+    logger.info("Closing SSH tunnels");
+    await sshTunnelManager.closeAll();
+
     // Close unified MongoDB connection pool
     logger.info("Closing MongoDB connection pool");
     await databaseConnectionService.closeAllConnections();

--- a/api/src/logging/index.ts
+++ b/api/src/logging/index.ts
@@ -151,6 +151,12 @@ async function doInitialize(): Promise<void> {
         lowestLevel: minLevel,
         sinks: [sinkName],
       },
+      // SSH tunnel operations
+      {
+        category: ["ssh-tunnel"],
+        lowestLevel: minLevel,
+        sinks: [sinkName],
+      },
     ],
   });
 

--- a/api/src/routes/database-schemas.ts
+++ b/api/src/routes/database-schemas.ts
@@ -26,6 +26,14 @@ interface FieldSchema {
   placeholder?: string;
   rows?: number;
   options?: Array<{ label: string; value: any }>;
+  /** Dot-path for nested fields (e.g. "sshTunnel.host" → stored as connection.sshTunnel.host) */
+  path?: string;
+  /** If true, rendered in a collapsible advanced section */
+  advanced?: boolean;
+  /** Group label for advanced sections (e.g. "SSH Tunnel") */
+  group?: string;
+  /** Show this field only when another field matches a value */
+  visibleWhen?: { field: string; equals: unknown };
 }
 
 interface DatabaseSchemaResponse {
@@ -386,6 +394,97 @@ const DATABASE_SCHEMAS: Record<string, DatabaseSchemaResponse> = {
         required: false,
       },
       { name: "ssl", label: "Use SSL/TLS", type: "boolean", default: false },
+      // SSH Tunnel (advanced)
+      {
+        name: "sshTunnel.enabled",
+        path: "sshTunnel.enabled",
+        label: "Connect via SSH Tunnel",
+        type: "boolean",
+        default: false,
+        advanced: true,
+        group: "SSH Tunnel",
+        helperText: "Route the MySQL connection through an SSH bastion host",
+      },
+      {
+        name: "sshTunnel.host",
+        path: "sshTunnel.host",
+        label: "SSH Host",
+        type: "string",
+        required: false,
+        placeholder: "bastion.example.com",
+        advanced: true,
+        group: "SSH Tunnel",
+        visibleWhen: { field: "sshTunnel.enabled", equals: true },
+      },
+      {
+        name: "sshTunnel.port",
+        path: "sshTunnel.port",
+        label: "SSH Port",
+        type: "number",
+        required: false,
+        default: 22,
+        advanced: true,
+        group: "SSH Tunnel",
+        visibleWhen: { field: "sshTunnel.enabled", equals: true },
+      },
+      {
+        name: "sshTunnel.username",
+        path: "sshTunnel.username",
+        label: "SSH Username",
+        type: "string",
+        required: false,
+        advanced: true,
+        group: "SSH Tunnel",
+        visibleWhen: { field: "sshTunnel.enabled", equals: true },
+      },
+      {
+        name: "sshTunnel.authMethod",
+        path: "sshTunnel.authMethod",
+        label: "SSH Auth Method",
+        type: "select",
+        default: "password",
+        options: [
+          { label: "Password", value: "password" },
+          { label: "Private Key", value: "privateKey" },
+        ],
+        advanced: true,
+        group: "SSH Tunnel",
+        visibleWhen: { field: "sshTunnel.enabled", equals: true },
+      },
+      {
+        name: "sshTunnel.password",
+        path: "sshTunnel.password",
+        label: "SSH Password",
+        type: "password",
+        required: false,
+        advanced: true,
+        group: "SSH Tunnel",
+        visibleWhen: { field: "sshTunnel.authMethod", equals: "password" },
+      },
+      {
+        name: "sshTunnel.privateKey",
+        path: "sshTunnel.privateKey",
+        label: "SSH Private Key",
+        type: "textarea",
+        required: false,
+        rows: 4,
+        placeholder: "-----BEGIN OPENSSH PRIVATE KEY-----\n...",
+        helperText: "Paste your private key contents (PEM or OpenSSH format)",
+        advanced: true,
+        group: "SSH Tunnel",
+        visibleWhen: { field: "sshTunnel.authMethod", equals: "privateKey" },
+      },
+      {
+        name: "sshTunnel.passphrase",
+        path: "sshTunnel.passphrase",
+        label: "Key Passphrase",
+        type: "password",
+        required: false,
+        helperText: "Leave empty if the key is not passphrase-protected",
+        advanced: true,
+        group: "SSH Tunnel",
+        visibleWhen: { field: "sshTunnel.authMethod", equals: "privateKey" },
+      },
     ],
   },
   sqlite: {

--- a/api/src/routes/workspace-databases.ts
+++ b/api/src/routes/workspace-databases.ts
@@ -525,23 +525,6 @@ workspaceDatabaseRoutes.post(
         updatedAt: new Date(),
       });
 
-      // Test connection before saving using RAW (unencrypted) connection from body
-      const testResult = await databaseConnectionService.testConnection({
-        _id: database._id,
-        type: body.type,
-        connection: body.connection || {},
-      } as any);
-
-      if (!testResult.success) {
-        return c.json(
-          {
-            success: false,
-            error: `Connection test failed: ${testResult.error}`,
-          },
-          400,
-        );
-      }
-
       await database.save();
 
       return c.json(
@@ -606,24 +589,6 @@ workspaceDatabaseRoutes.put(
           (database.toObject({ getters: true }) as any).connection || {};
         const candidate = { ...previous, ...body.connection };
 
-        // Test new connection using RAW candidate (unencrypted)
-        const testResult = await databaseConnectionService.testConnection({
-          _id: database._id,
-          type: database.type,
-          connection: candidate,
-        } as any);
-
-        if (!testResult.success) {
-          return c.json(
-            {
-              success: false,
-              error: `Connection test failed: ${testResult.error}`,
-            },
-            400,
-          );
-        }
-
-        // Only assign after successful test (setter will encrypt)
         database.connection = candidate as any;
       }
 

--- a/api/src/services/database-connection.service.ts
+++ b/api/src/services/database-connection.service.ts
@@ -17,6 +17,7 @@ import {
 } from "../databases/drivers/postgresql/pg-type-utils";
 import { Connector } from "@google-cloud/cloud-sql-connector";
 import { loggers } from "../logging";
+import { sshTunnelManager, type SshTunnelConfig } from "./ssh-tunnel.service";
 import { databaseRegistry } from "../databases/registry";
 import {
   type PreviewPageInfo,
@@ -3555,9 +3556,83 @@ export class DatabaseConnectionService {
   }
 
   // MySQL specific methods
+
+  /**
+   * Build an SshTunnelConfig from the saved connection, or null when SSH is disabled.
+   * Throws on invalid/incomplete configuration so callers get a clear error.
+   */
+  private buildSshTunnelConfig(
+    database: IDatabaseConnection,
+    tunnelKey: string,
+  ): SshTunnelConfig | null {
+    const tunnel = database.connection.sshTunnel;
+    if (!tunnel?.enabled) return null;
+
+    if (!tunnel.host) {
+      throw new Error("SSH tunnel host is required");
+    }
+    if (!tunnel.username) {
+      throw new Error("SSH tunnel username is required");
+    }
+    const authMethod = tunnel.authMethod || "password";
+    if (authMethod === "password" && !tunnel.password) {
+      throw new Error(
+        "SSH tunnel password is required when using password auth",
+      );
+    }
+    if (authMethod === "privateKey" && !tunnel.privateKey) {
+      throw new Error("SSH private key is required when using key auth");
+    }
+
+    // Strip port suffix from host fields if the user accidentally entered host:port
+    const parseHost = (
+      raw: string,
+    ): { host: string; port: number | undefined } => {
+      // Bracketed IPv6: [::1]:3306
+      const bracketMatch = raw.match(/^\[([^\]]+)\](?::(\d+))?$/);
+      if (bracketMatch) {
+        return {
+          host: bracketMatch[1],
+          port: bracketMatch[2] ? Number(bracketMatch[2]) : undefined,
+        };
+      }
+      // Non-bracketed host:port — use lastIndexOf so IPv4 like 127.0.0.1:22 works
+      const lastColon = raw.lastIndexOf(":");
+      if (lastColon > 0) {
+        const maybePart = raw.slice(lastColon + 1);
+        if (/^\d+$/.test(maybePart)) {
+          return { host: raw.slice(0, lastColon), port: Number(maybePart) };
+        }
+      }
+      return { host: raw, port: undefined };
+    };
+
+    const rawRemote = parseHost(database.connection.host || "127.0.0.1");
+    const remoteHost = rawRemote.host;
+    const remotePort = database.connection.port || rawRemote.port || 3306;
+
+    const rawSsh = parseHost(tunnel.host);
+    const sshHost = rawSsh.host;
+    const sshPort = tunnel.port ?? rawSsh.port ?? 22;
+
+    return {
+      key: tunnelKey,
+      sshHost,
+      sshPort,
+      sshUsername: tunnel.username,
+      authMethod,
+      sshPassword: tunnel.password,
+      privateKey: tunnel.privateKey,
+      passphrase: tunnel.passphrase,
+      remoteHost,
+      remotePort,
+    };
+  }
+
   private buildMySQLConfig(
     database: IDatabaseConnection,
     targetDatabase?: string,
+    tunnelEndpoint?: { host: string; port: number },
   ) {
     const conn = database.connection;
     const baseConfig = {
@@ -3587,8 +3662,10 @@ export class DatabaseConnectionService {
           sslMode === "prefer";
 
         return {
-          host: url.hostname || undefined,
-          port: url.port ? Number.parseInt(url.port, 10) : 3306,
+          host: tunnelEndpoint?.host ?? (url.hostname || undefined),
+          port:
+            tunnelEndpoint?.port ??
+            (url.port ? Number.parseInt(url.port, 10) : 3306),
           database: url.pathname.slice(1)
             ? decodeURIComponent(url.pathname.slice(1))
             : undefined,
@@ -3602,9 +3679,20 @@ export class DatabaseConnectionService {
       }
     }
 
+    let host = conn.host;
+    let port = conn.port || 3306;
+    if (host && host.includes(":")) {
+      const idx = host.lastIndexOf(":");
+      const maybePart = host.slice(idx + 1);
+      if (/^\d+$/.test(maybePart)) {
+        port = conn.port || Number(maybePart);
+        host = host.slice(0, idx);
+      }
+    }
+
     return {
-      host: conn.host,
-      port: conn.port || 3306,
+      host: tunnelEndpoint?.host ?? host,
+      port: tunnelEndpoint?.port ?? port,
       database: targetDatabase || conn.database,
       user: conn.username,
       password: conn.password,
@@ -3626,7 +3714,16 @@ export class DatabaseConnectionService {
       return existing.pool;
     }
 
-    const config = this.buildMySQLConfig(database, targetDatabase);
+    const tunnelCfg = this.buildSshTunnelConfig(database, key);
+    const tunnelEndpoint = tunnelCfg
+      ? await sshTunnelManager.openTunnel(tunnelCfg)
+      : undefined;
+
+    const config = this.buildMySQLConfig(
+      database,
+      targetDatabase,
+      tunnelEndpoint,
+    );
     const pool = mysql.createPool({
       ...config,
       waitForConnections: true,
@@ -3653,6 +3750,7 @@ export class DatabaseConnectionService {
             error: endErr,
           });
         });
+        sshTunnelManager.closeTunnel(key).catch(() => {});
       });
     });
 
@@ -3680,6 +3778,12 @@ export class DatabaseConnectionService {
       } catch (error) {
         logger.error("Error closing MySQL pool", { key, error });
       }
+      await sshTunnelManager.closeTunnel(key).catch(err => {
+        logger.error("Error closing SSH tunnel for MySQL pool", {
+          key,
+          error: err,
+        });
+      });
     }
   }
 
@@ -3694,6 +3798,7 @@ export class DatabaseConnectionService {
       } catch (error) {
         logger.error("Error closing MySQL pool", { key, error });
       }
+      await sshTunnelManager.closeTunnel(key).catch(() => {});
     });
     await Promise.all(promises);
   }
@@ -3723,6 +3828,7 @@ export class DatabaseConnectionService {
         } catch (error) {
           logger.error("Error closing idle MySQL pool", { key, error });
         }
+        await sshTunnelManager.closeTunnel(key).catch(() => {});
       }
     }
   }
@@ -3730,9 +3836,15 @@ export class DatabaseConnectionService {
   private async testMySQLConnection(
     database: IDatabaseConnection,
   ): Promise<{ success: boolean; error?: string }> {
+    const ephemeralKey = `test:${Date.now()}`;
     let connection: mysql.Connection | null = null;
     try {
-      const config = this.buildMySQLConfig(database);
+      const tunnelCfg = this.buildSshTunnelConfig(database, ephemeralKey);
+      const tunnelEndpoint = tunnelCfg
+        ? await sshTunnelManager.openTunnel(tunnelCfg)
+        : undefined;
+
+      const config = this.buildMySQLConfig(database, undefined, tunnelEndpoint);
       connection = await mysql.createConnection(config);
       await connection.ping();
       return { success: true };
@@ -3746,6 +3858,7 @@ export class DatabaseConnectionService {
       if (connection) {
         await connection.end();
       }
+      await sshTunnelManager.closeTunnel(ephemeralKey).catch(() => {});
     }
   }
 

--- a/api/src/services/ssh-tunnel.service.ts
+++ b/api/src/services/ssh-tunnel.service.ts
@@ -1,0 +1,224 @@
+import { Client, type ConnectConfig } from "ssh2";
+import net from "net";
+import { getLogger } from "../logging";
+
+const logger = getLogger(["ssh-tunnel"]);
+
+export interface SshTunnelConfig {
+  /** Caller-provided cache key (e.g. `${databaseId}:${dbName}`) */
+  key: string;
+  sshHost: string;
+  sshPort?: number;
+  sshUsername: string;
+  authMethod: "password" | "privateKey";
+  sshPassword?: string;
+  privateKey?: string;
+  passphrase?: string;
+  /** Remote host the tunnel forwards to (e.g. `127.0.0.1` on the bastion) */
+  remoteHost: string;
+  /** Remote port the tunnel forwards to (e.g. `3306`) */
+  remotePort: number;
+  /** Timeout in ms for the SSH handshake. Defaults to 15 000. */
+  readyTimeoutMs?: number;
+}
+
+export interface TunnelEndpoint {
+  host: string;
+  port: number;
+}
+
+interface ActiveTunnel {
+  endpoint: TunnelEndpoint;
+  client: Client;
+  server: net.Server;
+  lastUsed: number;
+}
+
+const DEFAULT_READY_TIMEOUT_MS = 15_000;
+const IDLE_EXPIRY_MS = 5 * 60 * 1000;
+const SWEEP_INTERVAL_MS = 60 * 1000;
+
+class SshTunnelManager {
+  private tunnels = new Map<string, ActiveTunnel>();
+  private sweepTimer: ReturnType<typeof setInterval> | null = null;
+
+  /**
+   * Open (or reuse) an SSH tunnel. Returns a local endpoint that forwards
+   * traffic to `remoteHost:remotePort` through the SSH bastion.
+   */
+  async openTunnel(config: SshTunnelConfig): Promise<TunnelEndpoint> {
+    const existing = this.tunnels.get(config.key);
+    if (existing) {
+      existing.lastUsed = Date.now();
+      logger.debug("Reusing SSH tunnel", {
+        key: config.key,
+        endpoint: existing.endpoint,
+      });
+      return existing.endpoint;
+    }
+
+    this.ensureSweep();
+
+    const client = new Client();
+
+    const connectConfig: ConnectConfig = {
+      host: config.sshHost,
+      port: config.sshPort ?? 22,
+      username: config.sshUsername,
+      readyTimeout: config.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS,
+    };
+
+    if (config.authMethod === "privateKey" && config.privateKey) {
+      connectConfig.privateKey = config.privateKey;
+      if (config.passphrase) connectConfig.passphrase = config.passphrase;
+    } else if (config.sshPassword) {
+      connectConfig.password = config.sshPassword;
+      connectConfig.tryKeyboard = true;
+    }
+
+    logger.info("SSH connecting", {
+      key: config.key,
+      host: connectConfig.host,
+      port: connectConfig.port,
+      username: connectConfig.username,
+      authMethod: config.authMethod,
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      client.on("ready", resolve);
+      client.on("error", err => {
+        logger.error("SSH client error", {
+          key: config.key,
+          error: err.message,
+        });
+        reject(err);
+      });
+      if (config.sshPassword) {
+        client.on(
+          "keyboard-interactive",
+          (_name, _instructions, _lang, prompts, finish) => {
+            finish(prompts.map(() => config.sshPassword!));
+          },
+        );
+      }
+      client.connect(connectConfig);
+    });
+
+    const server = net.createServer(socket => {
+      client.forwardOut(
+        socket.remoteAddress || "127.0.0.1",
+        socket.remotePort || 0,
+        config.remoteHost,
+        config.remotePort,
+        (err, stream) => {
+          if (err) {
+            logger.error("SSH forwardOut failed", {
+              key: config.key,
+              error: err.message,
+            });
+            socket.destroy();
+            return;
+          }
+          socket.pipe(stream).pipe(socket);
+        },
+      );
+    });
+
+    const localPort = await new Promise<number>((resolve, reject) => {
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address();
+        if (addr && typeof addr !== "string") {
+          resolve(addr.port);
+        } else {
+          reject(new Error("Failed to bind local tunnel port"));
+        }
+      });
+      server.on("error", reject);
+    });
+
+    const endpoint: TunnelEndpoint = { host: "127.0.0.1", port: localPort };
+    this.tunnels.set(config.key, {
+      endpoint,
+      client,
+      server,
+      lastUsed: Date.now(),
+    });
+
+    logger.info("SSH tunnel opened", {
+      key: config.key,
+      localPort,
+      remote: `${config.remoteHost}:${config.remotePort}`,
+    });
+
+    client.on("end", () => this.removeTunnel(config.key));
+    client.on("close", () => this.removeTunnel(config.key));
+
+    return endpoint;
+  }
+
+  /** Retrieve the endpoint for an existing tunnel without touching lastUsed. */
+  getTunnel(key: string): TunnelEndpoint | null {
+    return this.tunnels.get(key)?.endpoint ?? null;
+  }
+
+  /** Explicitly close a tunnel by key. */
+  async closeTunnel(key: string): Promise<void> {
+    const tunnel = this.tunnels.get(key);
+    if (!tunnel) return;
+    this.destroyTunnel(key, tunnel);
+  }
+
+  /** Close every open tunnel. Called during graceful shutdown. */
+  async closeAll(): Promise<void> {
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = null;
+    }
+    for (const [key, tunnel] of this.tunnels) {
+      this.destroyTunnel(key, tunnel);
+    }
+  }
+
+  private removeTunnel(key: string) {
+    const tunnel = this.tunnels.get(key);
+    if (!tunnel) return;
+    this.destroyTunnel(key, tunnel);
+  }
+
+  private destroyTunnel(key: string, tunnel: ActiveTunnel) {
+    this.tunnels.delete(key);
+    try {
+      tunnel.server.close();
+    } catch {
+      /* ignore */
+    }
+    try {
+      tunnel.client.end();
+    } catch {
+      /* ignore */
+    }
+    logger.info("SSH tunnel closed", { key });
+  }
+
+  private ensureSweep() {
+    if (this.sweepTimer) return;
+    this.sweepTimer = setInterval(() => this.sweep(), SWEEP_INTERVAL_MS);
+    this.sweepTimer.unref();
+  }
+
+  private sweep() {
+    const now = Date.now();
+    for (const [key, tunnel] of this.tunnels) {
+      if (now - tunnel.lastUsed > IDLE_EXPIRY_MS) {
+        logger.info("Evicting idle SSH tunnel", { key });
+        this.destroyTunnel(key, tunnel);
+      }
+    }
+    if (this.tunnels.size === 0 && this.sweepTimer) {
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = null;
+    }
+  }
+}
+
+export const sshTunnelManager = new SshTunnelManager();

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -447,18 +447,22 @@ StreamingIndicator.displayName = "StreamingIndicator";
 // ── Memoized message row ─────────────────────────────────────────
 // Prevents completed messages from re-rendering on every streaming chunk.
 
-const userMessageSx = { flex: 1, mt: 2 } as const;
+const userMessageSx = { flex: 1, mt: 2, minWidth: 0 } as const;
 const userMessagePaperSx = {
   p: 1,
   borderRadius: 1,
   backgroundColor: "background.paper",
   overflow: "hidden",
 } as const;
-const userMessageBoxSx = { overflow: "auto", maxWidth: "100%" } as const;
-const userMessageTextSx = {
-  whiteSpace: "pre-wrap",
-  wordBreak: "break-word",
-  overflowWrap: "break-word",
+const userMessageBoxSx = {
+  maxWidth: "100%",
+  "& .MuiListItemText-primary": {
+    whiteSpace: "pre-wrap",
+    wordBreak: "break-word",
+    overflowWrap: "break-word",
+    overflow: "visible",
+    textOverflow: "unset",
+  },
 } as const;
 const assistantMessageSx = {
   flex: 1,
@@ -534,7 +538,6 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
                 primaryTypographyProps={{
                   variant: "body2",
                   color: "text.primary",
-                  sx: userMessageTextSx,
                 }}
               />
             </Box>

--- a/app/src/components/CreateDatabaseDialog.tsx
+++ b/app/src/components/CreateDatabaseDialog.tsx
@@ -20,6 +20,10 @@ import {
   IconButton,
   InputAdornment,
 } from "@mui/material";
+import Accordion from "@mui/material/Accordion";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import Visibility from "@mui/icons-material/Visibility";
 import VisibilityOff from "@mui/icons-material/VisibilityOff";
@@ -38,6 +42,23 @@ import {
   parseMySQLConnectionString,
   buildMySQLConnectionString,
 } from "../utils/mysql-connection-string";
+
+/** Set a value at a dot-separated path inside a nested object, creating intermediate objects as needed. */
+function setNested(obj: Record<string, any>, path: string, value: any) {
+  const keys = path.split(".");
+  let curr = obj;
+  for (let i = 0; i < keys.length - 1; i++) {
+    if (!curr[keys[i]] || typeof curr[keys[i]] !== "object") curr[keys[i]] = {};
+    curr = curr[keys[i]];
+  }
+  curr[keys[keys.length - 1]] = value;
+}
+
+/** Resolve a dot-separated path on a potentially nested object. */
+function getNested(obj: Record<string, any> | undefined, path: string): any {
+  if (!obj) return undefined;
+  return path.split(".").reduce((acc: any, key) => acc?.[key], obj);
+}
 
 interface CreateDatabaseDialogProps {
   open: boolean;
@@ -316,6 +337,7 @@ const CreateDatabaseDialog: React.FC<CreateDatabaseDialogProps> = ({
     }
     setLoading(true);
     setError(null);
+    setTestResult(null);
     try {
       const res = await saveDatabase(currentWorkspace.id, values, databaseId);
 
@@ -360,9 +382,13 @@ const CreateDatabaseDialog: React.FC<CreateDatabaseDialogProps> = ({
     const defaults: Record<string, any> = {};
     if (schema?.fields) {
       schema.fields.forEach(f => {
-        if (f.default !== undefined) defaults[f.name] = f.default;
-        else if (f.type === "boolean") defaults[f.name] = false;
-        else defaults[f.name] = "";
+        const val =
+          f.default !== undefined
+            ? f.default
+            : f.type === "boolean"
+              ? false
+              : "";
+        setNested(defaults, f.name, val);
       });
     }
     reset(prev => ({ ...prev, type: newType, connection: defaults }));
@@ -503,246 +529,278 @@ const CreateDatabaseDialog: React.FC<CreateDatabaseDialogProps> = ({
                 </Box>
               ) : (
                 selectedType &&
-                schemas[selectedType]?.fields && (
-                  <>
-                    {schemas[selectedType].fields.map(field => {
-                      const fieldName = `connection.${field.name}` as const;
-                      // For password fields in edit mode, make them optional if they are empty (meaning unchanged)
-                      // BUT, the user sees the value if we pre-fill it.
-                      // If we pre-fill, the value is there, so "required" check passes.
+                schemas[selectedType]?.fields &&
+                (() => {
+                  const allFields = schemas[selectedType].fields;
+                  const primaryFields = allFields.filter(f => !f.advanced);
+                  const advancedFields = allFields.filter(f => f.advanced);
 
-                      const requiredRule = field.required
-                        ? { required: `${field.label} is required` }
-                        : {};
+                  const advancedGroups = advancedFields.reduce<
+                    Record<string, typeof advancedFields>
+                  >((acc, f) => {
+                    const g = f.group || "Advanced";
+                    (acc[g] ||= []).push(f);
+                    return acc;
+                  }, {});
 
-                      const fieldError =
-                        (errors.connection?.[
-                          field.name as keyof FormValues["connection"]
-                        ]?.message as string) || undefined;
-                      switch (field.type) {
-                        case "boolean":
-                          return (
-                            <FormControl
-                              key={field.name}
-                              fullWidth
-                              margin="normal"
-                            >
-                              <Box
-                                sx={{ display: "flex", alignItems: "center" }}
-                              >
-                                <Typography sx={{ mr: 2 }}>
-                                  {field.label}
-                                </Typography>
-                                <Controller
-                                  control={control}
-                                  name={fieldName as `connection.${string}`}
-                                  rules={requiredRule}
-                                  render={({
-                                    field: ctrlField,
-                                    fieldState,
-                                  }) => (
-                                    <input
-                                      type="checkbox"
-                                      checked={Boolean(ctrlField.value)}
-                                      onChange={e =>
-                                        ctrlField.onChange(e.target.checked)
-                                      }
-                                      aria-invalid={
-                                        fieldState.error ? "true" : "false"
-                                      }
-                                    />
-                                  )}
-                                />
-                              </Box>
-                              {fieldError ? (
-                                <Typography variant="caption" color="error">
-                                  {fieldError}
-                                </Typography>
-                              ) : (
-                                field.helperText && (
-                                  <Typography
-                                    variant="caption"
-                                    color="text.secondary"
-                                  >
-                                    {field.helperText}
-                                  </Typography>
-                                )
-                              )}
-                            </FormControl>
-                          );
-                        case "textarea":
-                          return (
-                            <TextField
-                              key={field.name}
-                              fullWidth
-                              label={field.label}
-                              margin="normal"
-                              placeholder={field.placeholder}
-                              multiline
-                              rows={field.rows || 3}
-                              {...register(
-                                fieldName as `connection.${string}`,
-                                requiredRule,
-                              )}
-                              error={Boolean(fieldError)}
-                              helperText={fieldError ?? field.helperText}
-                              autoComplete="off"
-                            />
-                          );
-                        case "password":
-                          return (
-                            <TextField
-                              key={field.name}
-                              fullWidth
-                              type={
-                                showPassword[field.name] ? "text" : "password"
-                              }
-                              label={field.label}
-                              margin="normal"
-                              placeholder={field.placeholder}
-                              {...register(
-                                fieldName as `connection.${string}`,
-                                requiredRule,
-                              )}
-                              error={Boolean(fieldError)}
-                              helperText={fieldError ?? field.helperText}
-                              autoComplete="off"
-                              slotProps={{
-                                input: {
-                                  endAdornment: (
-                                    <InputAdornment position="end">
-                                      <IconButton
-                                        aria-label={
-                                          showPassword[field.name]
-                                            ? "Hide password"
-                                            : "Show password"
-                                        }
-                                        onClick={() =>
-                                          togglePasswordVisibility(field.name)
-                                        }
-                                        edge="end"
-                                        size="small"
-                                      >
-                                        {showPassword[field.name] ? (
-                                          <VisibilityOff fontSize="small" />
-                                        ) : (
-                                          <Visibility fontSize="small" />
-                                        )}
-                                      </IconButton>
-                                    </InputAdornment>
-                                  ),
-                                },
-                                htmlInput: {
-                                  "data-1p-ignore": true,
-                                  "data-lpignore": "true",
-                                  "data-form-type": "other",
-                                },
+                  const isFieldVisible = (
+                    field: (typeof allFields)[number],
+                  ) => {
+                    if (!field.visibleWhen) return true;
+                    const val = getNested(
+                      watchedConnection,
+                      field.visibleWhen.field,
+                    );
+                    return val === field.visibleWhen.equals;
+                  };
+
+                  const renderField = (field: (typeof allFields)[number]) => {
+                    if (!isFieldVisible(field)) return null;
+
+                    const fieldName =
+                      `connection.${field.name}` as `connection.${string}`;
+                    const requiredRule = field.required
+                      ? { required: `${field.label} is required` }
+                      : {};
+                    const fieldError =
+                      (getNested(errors, fieldName)?.message as string) ||
+                      undefined;
+
+                    switch (field.type) {
+                      case "boolean":
+                        return (
+                          <FormControl
+                            key={field.name}
+                            fullWidth
+                            margin="normal"
+                          >
+                            <Box
+                              sx={{
+                                display: "flex",
+                                alignItems: "center",
                               }}
-                            />
-                          );
-                        case "number":
-                          return (
-                            <TextField
-                              key={field.name}
-                              fullWidth
-                              type="number"
-                              label={field.label}
-                              margin="normal"
-                              placeholder={field.placeholder}
-                              {...register(
-                                fieldName as `connection.${string}`,
-                                {
-                                  ...requiredRule,
-                                  valueAsNumber: true,
-                                },
-                              )}
-                              error={Boolean(fieldError)}
-                              helperText={fieldError ?? field.helperText}
-                              autoComplete="off"
-                            />
-                          );
-                        case "select":
-                          return (
-                            <FormControl
-                              key={field.name}
-                              fullWidth
-                              margin="normal"
-                              required={field.required}
-                              error={Boolean(fieldError)}
                             >
-                              <InputLabel>{field.label}</InputLabel>
+                              <Typography sx={{ mr: 2 }}>
+                                {field.label}
+                              </Typography>
                               <Controller
                                 control={control}
-                                name={fieldName as `connection.${string}`}
+                                name={fieldName}
                                 rules={requiredRule}
-                                render={({ field: ctrlField }) => (
-                                  <Select
-                                    label={field.label}
-                                    value={ctrlField.value ?? ""}
+                                render={({ field: ctrlField, fieldState }) => (
+                                  <input
+                                    type="checkbox"
+                                    checked={Boolean(ctrlField.value)}
                                     onChange={e =>
-                                      ctrlField.onChange(String(e.target.value))
+                                      ctrlField.onChange(e.target.checked)
                                     }
-                                  >
-                                    {(field.options || []).map(opt => (
-                                      <MenuItem
-                                        key={opt.value}
-                                        value={opt.value}
-                                      >
-                                        {opt.label}
-                                      </MenuItem>
-                                    ))}
-                                  </Select>
+                                    aria-invalid={
+                                      fieldState.error ? "true" : "false"
+                                    }
+                                  />
                                 )}
                               />
-                              {fieldError ? (
-                                <Typography variant="caption" color="error">
-                                  {fieldError}
+                            </Box>
+                            {fieldError ? (
+                              <Typography variant="caption" color="error">
+                                {fieldError}
+                              </Typography>
+                            ) : (
+                              field.helperText && (
+                                <Typography
+                                  variant="caption"
+                                  color="text.secondary"
+                                >
+                                  {field.helperText}
                                 </Typography>
-                              ) : (
-                                field.helperText && (
-                                  <Typography
-                                    variant="caption"
-                                    color="text.secondary"
-                                  >
-                                    {field.helperText}
-                                  </Typography>
-                                )
+                              )
+                            )}
+                          </FormControl>
+                        );
+                      case "textarea":
+                        return (
+                          <TextField
+                            key={field.name}
+                            fullWidth
+                            label={field.label}
+                            margin="normal"
+                            placeholder={field.placeholder}
+                            multiline
+                            rows={field.rows || 3}
+                            {...register(fieldName, requiredRule)}
+                            error={Boolean(fieldError)}
+                            helperText={fieldError ?? field.helperText}
+                            autoComplete="off"
+                          />
+                        );
+                      case "password":
+                        return (
+                          <TextField
+                            key={field.name}
+                            fullWidth
+                            type={
+                              showPassword[field.name] ? "text" : "password"
+                            }
+                            label={field.label}
+                            margin="normal"
+                            placeholder={field.placeholder}
+                            {...register(fieldName, requiredRule)}
+                            error={Boolean(fieldError)}
+                            helperText={fieldError ?? field.helperText}
+                            autoComplete="off"
+                            slotProps={{
+                              input: {
+                                endAdornment: (
+                                  <InputAdornment position="end">
+                                    <IconButton
+                                      aria-label={
+                                        showPassword[field.name]
+                                          ? "Hide password"
+                                          : "Show password"
+                                      }
+                                      onClick={() =>
+                                        togglePasswordVisibility(field.name)
+                                      }
+                                      edge="end"
+                                      size="small"
+                                    >
+                                      {showPassword[field.name] ? (
+                                        <VisibilityOff fontSize="small" />
+                                      ) : (
+                                        <Visibility fontSize="small" />
+                                      )}
+                                    </IconButton>
+                                  </InputAdornment>
+                                ),
+                              },
+                              htmlInput: {
+                                "data-1p-ignore": true,
+                                "data-lpignore": "true",
+                                "data-form-type": "other",
+                              },
+                            }}
+                          />
+                        );
+                      case "number":
+                        return (
+                          <TextField
+                            key={field.name}
+                            fullWidth
+                            type="number"
+                            label={field.label}
+                            margin="normal"
+                            placeholder={field.placeholder}
+                            {...register(fieldName, {
+                              ...requiredRule,
+                              valueAsNumber: true,
+                            })}
+                            error={Boolean(fieldError)}
+                            helperText={fieldError ?? field.helperText}
+                            autoComplete="off"
+                          />
+                        );
+                      case "select":
+                        return (
+                          <FormControl
+                            key={field.name}
+                            fullWidth
+                            margin="normal"
+                            required={field.required}
+                            error={Boolean(fieldError)}
+                          >
+                            <InputLabel>{field.label}</InputLabel>
+                            <Controller
+                              control={control}
+                              name={fieldName}
+                              rules={requiredRule}
+                              render={({ field: ctrlField }) => (
+                                <Select
+                                  label={field.label}
+                                  value={ctrlField.value ?? ""}
+                                  onChange={e =>
+                                    ctrlField.onChange(String(e.target.value))
+                                  }
+                                >
+                                  {(field.options || []).map(opt => (
+                                    <MenuItem key={opt.value} value={opt.value}>
+                                      {opt.label}
+                                    </MenuItem>
+                                  ))}
+                                </Select>
                               )}
-                            </FormControl>
-                          );
-                        case "string":
-                        default:
-                          return (
-                            <TextField
-                              key={field.name}
-                              fullWidth
-                              label={field.label}
-                              margin="normal"
-                              placeholder={field.placeholder}
-                              {...register(
-                                fieldName as `connection.${string}`,
-                                requiredRule,
-                              )}
-                              error={Boolean(fieldError)}
-                              helperText={fieldError ?? field.helperText}
-                              autoComplete="off"
-                              slotProps={
-                                field.name === "username"
-                                  ? {
-                                      htmlInput: {
-                                        "data-1p-ignore": true,
-                                        "data-lpignore": "true",
-                                        "data-form-type": "other",
-                                      },
-                                    }
-                                  : undefined
-                              }
                             />
-                          );
-                      }
-                    })}
-                  </>
-                )
+                            {fieldError ? (
+                              <Typography variant="caption" color="error">
+                                {fieldError}
+                              </Typography>
+                            ) : (
+                              field.helperText && (
+                                <Typography
+                                  variant="caption"
+                                  color="text.secondary"
+                                >
+                                  {field.helperText}
+                                </Typography>
+                              )
+                            )}
+                          </FormControl>
+                        );
+                      case "string":
+                      default:
+                        return (
+                          <TextField
+                            key={field.name}
+                            fullWidth
+                            label={field.label}
+                            margin="normal"
+                            placeholder={field.placeholder}
+                            {...register(fieldName, requiredRule)}
+                            error={Boolean(fieldError)}
+                            helperText={fieldError ?? field.helperText}
+                            autoComplete="off"
+                            slotProps={
+                              field.name === "username"
+                                ? {
+                                    htmlInput: {
+                                      "data-1p-ignore": true,
+                                      "data-lpignore": "true",
+                                      "data-form-type": "other",
+                                    },
+                                  }
+                                : undefined
+                            }
+                          />
+                        );
+                    }
+                  };
+
+                  return (
+                    <>
+                      {primaryFields.map(renderField)}
+                      {Object.entries(advancedGroups).map(([group, fields]) => (
+                        <Accordion
+                          key={group}
+                          disableGutters
+                          elevation={0}
+                          sx={{
+                            mt: 2,
+                            border: 1,
+                            borderColor: "divider",
+                            borderRadius: 1,
+                            "&::before": { display: "none" },
+                          }}
+                        >
+                          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                            <Typography variant="subtitle2">{group}</Typography>
+                          </AccordionSummary>
+                          <AccordionDetails sx={{ pt: 0 }}>
+                            {fields.map(renderField)}
+                          </AccordionDetails>
+                        </Accordion>
+                      ))}
+                    </>
+                  );
+                })()
               )}
             </Box>
           </DialogContent>

--- a/app/src/store/databaseCatalogStore.ts
+++ b/app/src/store/databaseCatalogStore.ts
@@ -21,6 +21,10 @@ export interface FieldSchema {
   placeholder?: string;
   rows?: number;
   options?: Array<{ label: string; value: any }>;
+  path?: string;
+  advanced?: boolean;
+  group?: string;
+  visibleWhen?: { field: string; equals: unknown };
 }
 
 export interface DatabaseSchemaResponse {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,6 +216,9 @@ importers:
       sqlite3:
         specifier: ^5.1.7
         version: 5.1.7
+      ssh2:
+        specifier: ^1.17.0
+        version: 1.17.0
       stripe:
         specifier: ^14.25.0
         version: 14.25.0
@@ -247,6 +250,9 @@ importers:
       '@types/pg':
         specifier: ^8.15.4
         version: 8.15.4
+      '@types/ssh2':
+        specifier: ^1.15.5
+        version: 1.15.5
       '@types/uuid':
         specifier: ^9.0.0
         version: 9.0.8
@@ -3620,6 +3626,9 @@ packages:
   '@types/shimmer@1.2.0':
     resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
 
+  '@types/ssh2@1.15.5':
+    resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
+
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
 
@@ -4063,6 +4072,9 @@ packages:
   as-table@1.0.55:
     resolution: {integrity: sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==}
 
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -4148,6 +4160,9 @@ packages:
 
   bcp-47@2.1.0:
     resolution: {integrity: sha512-9IIS3UPrvIa1Ej+lVDdDwO7zLehjqsaByECw0bu2RRGP73jALm6FYbzI5gWbgHLvNdkvfXB5YrSbocZdOS0c0w==}
+
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
   bcrypt@6.0.0:
     resolution: {integrity: sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==}
@@ -4249,6 +4264,10 @@ packages:
   buffers@0.1.1:
     resolution: {integrity: sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==}
     engines: {node: '>=0.2.0'}
+
+  buildcheck@0.0.7:
+    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
+    engines: {node: '>=10.0.0'}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -4622,6 +4641,10 @@ packages:
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
+
+  cpu-features@0.0.10:
+    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
+    engines: {node: '>=10.0.0'}
 
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
@@ -7231,6 +7254,9 @@ packages:
     resolution: {integrity: sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==}
     engines: {node: '>=12.0.0'}
 
+  nan@2.26.2:
+    resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
+
   nano-spawn@2.0.0:
     resolution: {integrity: sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==}
     engines: {node: '>=20.17'}
@@ -8546,6 +8572,10 @@ packages:
     resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
     engines: {node: '>= 0.6'}
 
+  ssh2@1.17.0:
+    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
+    engines: {node: '>=10.16.0'}
+
   ssri@10.0.6:
     resolution: {integrity: sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -8974,6 +9004,9 @@ packages:
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
 
   type-check@0.3.2:
     resolution: {integrity: sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==}
@@ -13552,6 +13585,10 @@ snapshots:
 
   '@types/shimmer@1.2.0': {}
 
+  '@types/ssh2@1.15.5':
+    dependencies:
+      '@types/node': 18.19.111
+
   '@types/tedious@4.0.14':
     dependencies:
       '@types/node': 20.17.50
@@ -14145,6 +14182,10 @@ snapshots:
     dependencies:
       printable-characters: 1.0.42
 
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
   assertion-error@2.0.1: {}
 
   astring@1.9.0: {}
@@ -14322,6 +14363,10 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
 
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
+
   bcrypt@6.0.0:
     dependencies:
       node-addon-api: 8.3.1
@@ -14444,6 +14489,9 @@ snapshots:
       ieee754: 1.2.1
 
   buffers@0.1.1: {}
+
+  buildcheck@0.0.7:
+    optional: true
 
   bundle-name@4.1.0:
     dependencies:
@@ -14834,6 +14882,12 @@ snapshots:
       parse-json: 5.2.0
       path-type: 4.0.0
       yaml: 1.10.2
+
+  cpu-features@0.0.10:
+    dependencies:
+      buildcheck: 0.0.7
+      nan: 2.26.2
+    optional: true
 
   crc-32@1.2.2: {}
 
@@ -18139,6 +18193,9 @@ snapshots:
     dependencies:
       lru-cache: 7.18.3
 
+  nan@2.26.2:
+    optional: true
+
   nano-spawn@2.0.0: {}
 
   nanoid@3.3.11: {}
@@ -19770,6 +19827,14 @@ snapshots:
 
   sqlstring@2.3.3: {}
 
+  ssh2@1.17.0:
+    dependencies:
+      asn1: 0.2.6
+      bcrypt-pbkdf: 1.0.2
+    optionalDependencies:
+      cpu-features: 0.0.10
+      nan: 2.26.2
+
   ssri@10.0.6:
     dependencies:
       minipass: 7.1.2
@@ -20265,6 +20330,8 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  tweetnacl@0.14.5: {}
 
   type-check@0.3.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,4 @@ packages:
   - packages/*
 ignoredBuiltDependencies:
   - bcrypt
+onlyBuiltDependencies: '["ssh2"]'


### PR DESCRIPTION
## Summary

- **New SSH tunnel service** (`ssh-tunnel.service.ts`): reusable manager that opens, caches, and idles-out SSH tunnels via `ssh2`. Supports both password and private key auth, host:port parsing, and graceful shutdown.
- **MySQL connections routed through SSH**: `database-connection.service.ts` now builds an `SshTunnelConfig` from saved connection settings and wires the local tunnel endpoint into `buildMySQLConfig`, `getMySQLPool`, `testMySQLConnection`, and all pool close/eviction paths.
- **Schema-driven UI for SSH fields**: `database-schemas.ts` gains `advanced`, `group`, `visibleWhen`, and `path` metadata; `CreateDatabaseDialog.tsx` renders them in a collapsible Accordion with conditional visibility.
- **Chat overflow fix**: tightens `minWidth` / `overflow` styles so long user messages no longer blow out the layout.
- **Removes pre-save connection test** on create/update routes so users can save a database even when the target isn't yet reachable.

## Test plan

- [ ] Create a MySQL database connection **without** SSH — verify it still connects and queries normally
- [ ] Create a MySQL database connection **with** SSH tunnel (password auth) — verify the tunnel opens, queries work, and idle eviction cleans up
- [ ] Create a MySQL database connection **with** SSH tunnel (private key auth) — verify key-based auth works
- [ ] Edit an existing SSH-tunneled connection — verify the tunnel is recycled correctly
- [ ] Test the connection test button with SSH enabled — verify it opens an ephemeral tunnel and cleans up
- [ ] Verify the SSH Tunnel accordion in the Create Database dialog shows/hides fields based on `sshTunnel.enabled` and `sshTunnel.authMethod`
- [ ] Verify long Chat messages no longer overflow horizontally
- [ ] Verify graceful shutdown closes all SSH tunnels (check logs)

Made with [Cursor](https://cursor.com)