### PR TITLE
fix: trigger CDC materialization inline to reduce lag below 5 minutes

### DIFF
--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -781,6 +781,9 @@ export interface ICdcEntityState extends Document {
   lastEnqueuedAt?: Date;
   mergeIntervalSeconds: number;
   backfillCursor?: Record<string, unknown>;
+  consecutiveFailures: number;
+  lastFailedAt?: Date;
+  lastFailureError?: string;
 }
 
 export type IBigQueryChangeEvent = ICdcChangeEvent;
@@ -2055,6 +2058,9 @@ const CdcEntityStateSchema = new Schema<ICdcEntityState>(
     lastEnqueuedAt: Date,
     mergeIntervalSeconds: { type: Number, default: 300 },
     backfillCursor: Schema.Types.Mixed,
+    consecutiveFailures: { type: Number, default: 0 },
+    lastFailedAt: Date,
+    lastFailureError: String,
   },
   {
     collection: "cdc_entity_state",

--- a/api/src/inngest/functions/webhook-flow.ts
+++ b/api/src/inngest/functions/webhook-flow.ts
@@ -1129,6 +1129,17 @@ const CDC_MATERIALIZE_MAX_EVENTS_BACKFILL = Math.max(
   100,
 );
 
+const CDC_CIRCUIT_BREAKER_BASE_BACKOFF_S = 60;
+const CDC_CIRCUIT_BREAKER_MAX_BACKOFF_S = 30 * 60;
+
+function circuitBreakerBackoffMs(consecutiveFailures: number): number {
+  const seconds = Math.min(
+    CDC_CIRCUIT_BREAKER_BASE_BACKOFF_S * 2 ** (consecutiveFailures - 1),
+    CDC_CIRCUIT_BREAKER_MAX_BACKOFF_S,
+  );
+  return seconds * 1000;
+}
+
 async function runCdcMaterialization(params: {
   eventData: unknown;
   step: any;
@@ -1141,6 +1152,58 @@ async function runCdcMaterialization(params: {
     entity: string;
     force?: boolean;
   };
+
+  const circuitCheck = (await params.step.run(
+    "check-circuit-breaker",
+    async () => {
+      const entityState = await CdcEntityState.findOne({
+        flowId: new Types.ObjectId(flowId),
+        entity,
+      })
+        .select("consecutiveFailures lastFailedAt lastFailureError")
+        .lean();
+
+      const failures = entityState?.consecutiveFailures || 0;
+      if (failures === 0) return { open: false, failures: 0 };
+
+      const lastFailedAt = entityState?.lastFailedAt
+        ? new Date(entityState.lastFailedAt).getTime()
+        : 0;
+      const backoffMs = circuitBreakerBackoffMs(failures);
+      const elapsed = Date.now() - lastFailedAt;
+
+      if (elapsed < backoffMs) {
+        return {
+          open: true,
+          failures,
+          backoffMs,
+          elapsedMs: elapsed,
+          retryAfterMs: backoffMs - elapsed,
+          lastError: entityState?.lastFailureError,
+        };
+      }
+
+      return { open: false, failures, halfOpen: true };
+    },
+  )) as any;
+
+  if (circuitCheck.open && !force) {
+    params.logger.info("CDC materialization skipped (circuit breaker open)", {
+      flowId,
+      entity,
+      consecutiveFailures: circuitCheck.failures,
+      backoffMs: circuitCheck.backoffMs,
+      retryAfterMs: circuitCheck.retryAfterMs,
+      lastError: circuitCheck.lastError,
+    });
+    return {
+      success: true,
+      skipped: true,
+      reason: "circuit_breaker_open",
+      consecutiveFailures: circuitCheck.failures,
+      retryAfterMs: circuitCheck.retryAfterMs,
+    };
+  }
 
   const materializeStartedAt = Date.now();
   const result = (await params.step.run("materialize-cdc-entity", async () => {
@@ -1242,16 +1305,27 @@ export const cdcMaterializeSchedulerFunction = inngest.createFunction(
           { lastMaterializedAt: { $lt: staleThreshold } },
         ],
       })
-        .select("workspaceId flowId entity")
+        .select("workspaceId flowId entity consecutiveFailures lastFailedAt")
         .lean();
 
       if (candidates.length === 0) {
         return [];
       }
 
+      const now = Date.now();
+      const eligible = candidates.filter(c => {
+        const failures = (c as any).consecutiveFailures || 0;
+        if (failures === 0) return true;
+        const lastFailed = (c as any).lastFailedAt
+          ? new Date((c as any).lastFailedAt).getTime()
+          : 0;
+        return now - lastFailed >= circuitBreakerBackoffMs(failures);
+      });
+
       const flowIds = Array.from(
-        new Set(candidates.map(c => c.flowId.toString())),
+        new Set(eligible.map(c => c.flowId.toString())),
       );
+      if (flowIds.length === 0) return [];
       const existingFlows = await Flow.find({ _id: { $in: flowIds } })
         .select("_id")
         .lean();
@@ -1259,7 +1333,7 @@ export const cdcMaterializeSchedulerFunction = inngest.createFunction(
         existingFlows.map(f => f._id.toString()),
       );
 
-      return candidates.filter(c => existingFlowIdSet.has(c.flowId.toString()));
+      return eligible.filter(c => existingFlowIdSet.has(c.flowId.toString()));
     });
 
     const entities = staleEntities as Array<{

--- a/api/src/inngest/functions/webhook-flow.ts
+++ b/api/src/inngest/functions/webhook-flow.ts
@@ -35,7 +35,7 @@ const WEBHOOK_CDC_INGEST_PROCESS_CONCURRENCY = Math.max(
 );
 
 const CDC_MATERIALIZE_THROTTLE_PERIOD = (process.env
-  .CDC_MATERIALIZE_THROTTLE_PERIOD || "10s") as `${number}s`;
+  .CDC_MATERIALIZE_THROTTLE_PERIOD || "5s") as `${number}s`;
 
 async function runWebhookEventProcess({
   event,
@@ -938,10 +938,31 @@ export const webhookEventProcessCdcFunction = inngest.createFunction(
       };
     });
 
-    // Materialization is NOT triggered inline — the scheduler cron picks up
-    // stale entities every 2 min by comparing lastIngestSeq vs
-    // lastMaterializedSeq.  Emitting here would duplicate the scheduler's
-    // work and flood the Inngest queue with redundant cdc/materialize events.
+    const typedResult = result as {
+      processed: boolean;
+      count: number;
+      workspaceId?: string;
+      entities?: string[];
+    } | null;
+
+    if (
+      typedResult?.processed &&
+      typedResult.count > 0 &&
+      typedResult.entities?.length
+    ) {
+      await step.sendEvent(
+        "trigger-inline-materialize",
+        typedResult.entities.map(entity => ({
+          name: "cdc/materialize" as const,
+          data: {
+            workspaceId: typedResult.workspaceId!,
+            flowId,
+            entity,
+            force: false,
+          },
+        })),
+      );
+    }
 
     return { success: true, ...result };
   },
@@ -1195,24 +1216,24 @@ export const cdcMaterializeFunction = inngest.createFunction(
 );
 
 /**
- * Periodic scheduler that finds entities with un-materialized CDC events
+ * Safety-net scheduler that finds entities with un-materialized CDC events
  * and emits one cdc/materialize per stale (flowId, entity) pair.
  *
- * This decouples materialization timing from ingest volume: instead of
- * N webhooks producing N materialize triggers (of which N-1 are redundant),
- * the scheduler fires at most one per entity every 30 s.
+ * Primary materialization is triggered inline after CDC ingest. This
+ * scheduler catches any entities missed by the inline trigger or delayed
+ * by transient failures. Fires every minute with a 20 s staleness window.
  */
 export const cdcMaterializeSchedulerFunction = inngest.createFunction(
   {
     id: "cdc-materialize-scheduler",
     name: "CDC Materialize Scheduler",
   },
-  { cron: "*/2 * * * *" },
+  { cron: "*/1 * * * *" },
   async ({ step, logger }) => {
     const staleEntities = await step.run("find-stale-entities", async () => {
-      // Skip entities materialized within the last 45 s — they already have
+      // Skip entities materialized within the last 20 s — they already have
       // a queued or throttled run and re-emitting is pure waste.
-      const staleThreshold = new Date(Date.now() - 45_000);
+      const staleThreshold = new Date(Date.now() - 20_000);
 
       const candidates = await CdcEntityState.find({
         $expr: { $gt: ["$lastIngestSeq", "$lastMaterializedSeq"] },

--- a/api/src/sync-cdc/consumer.ts
+++ b/api/src/sync-cdc/consumer.ts
@@ -228,6 +228,18 @@ export class CdcConsumerService {
         rowsAppliedDelta: apply.applied,
       });
 
+      if (state?.consecutiveFailures) {
+        await CdcEntityState.updateOne(
+          {
+            flowId: new Types.ObjectId(params.flowId),
+            entity: params.entity,
+          },
+          {
+            $set: { consecutiveFailures: 0, lastFailureError: null },
+          },
+        );
+      }
+
       return {
         processed: pending.length,
         applied: apply.applied,
@@ -248,6 +260,19 @@ export class CdcConsumerService {
         {
           code: "MATERIALIZATION_FAILED",
           message: errorMessage,
+        },
+      );
+      await CdcEntityState.updateOne(
+        {
+          flowId: new Types.ObjectId(params.flowId),
+          entity: params.entity,
+        },
+        {
+          $inc: { consecutiveFailures: 1 },
+          $set: {
+            lastFailedAt: new Date(),
+            lastFailureError: errorMessage.slice(0, 500),
+          },
         },
       );
       await cdcSyncStateService.applyStreamTransition({

--- a/api/src/sync-cdc/ingest.ts
+++ b/api/src/sync-cdc/ingest.ts
@@ -9,10 +9,10 @@ class CdcIngestService {
   /**
    * Append normalized CDC events to the event store and update ingest state.
    *
-   * The caller (webhookEventProcessCdcFunction) is responsible for triggering
-   * materialization by emitting cdc/materialize events after this call.
-   * The cdcMaterializeSchedulerFunction cron acts as a safety net for any
-   * entities missed by the inline trigger.
+   * The caller (webhookEventProcessCdcFunction) triggers materialization
+   * inline by emitting cdc/materialize events immediately after this call.
+   * The cdcMaterializeSchedulerFunction cron (every 1 min) acts as a safety
+   * net for any entities missed by the inline trigger.
    */
   async appendNormalizedEvents(params: {
     workspaceId: string;


### PR DESCRIPTION
## Summary

- **Trigger materialization inline** after CDC ingest instead of relying solely on the 2-minute cron scheduler. The `webhookEventProcessCdcFunction` now emits `cdc/materialize` events immediately for each affected entity after ingesting events.
- **Reduce throttle period** from 10s to 5s — the existing per-(flow, entity) throttle on `cdcMaterializeFunction` handles deduplication, so inline triggers won't flood the queue.
- **Tighten scheduler as safety net** — cron interval reduced from 2min to 1min, stale threshold from 45s to 20s, so missed entities are caught faster.
- **Circuit breaker for broken flows** — when a CDC entity hits repeated materialization failures (e.g. BigQuery quota exceeded), it backs off exponentially (1min → 2min → 4min → ... → 30min max) instead of retrying every ~70s indefinitely. This prevents one broken flow from starving all other flows of Inngest concurrency and BigQuery API capacity. `force=true` bypasses the circuit breaker for manual recovery.

## Context

The `fr_close → bigquery_write` pipeline was hitting BigQuery per-table quota errors and retrying every ~70s, consuming all available materialization capacity. This caused cascading lag across all flows — Italy (`it_close`) had 4h+ lag with zero errors, purely because France was hogging all the resources.

## Expected impact

| Scenario | Before | After |
|---|---|---|
| Normal webhook flow | ~2 min (cron) + 10s (throttle) | ~5-10 seconds |
| Missed inline trigger | ~2 min + 45s staleness | ~1 min + 20s staleness |
| Quota error on one flow | Retries every ~70s, blocks ALL flows | Backs off 1min→30min, other flows unaffected |

## Circuit breaker backoff schedule

| Consecutive failures | Backoff |
|---|---|
| 1 | 1 min |
| 2 | 2 min |
| 3 | 4 min |
| 4 | 8 min |
| 5 | 16 min |
| 6+ | 30 min (max) |

Resets to 0 on first successful materialization. The scheduler also filters out circuit-breaker-open entities so they don't waste scheduler slots.

## Test plan

- [ ] Verify CDC webhook events trigger materialization within seconds (check Inngest dashboard for `cdc/materialize` events emitted from `trigger-inline-materialize` step)
- [ ] Confirm no duplicate materialization runs (throttle deduplicates)
- [ ] Verify circuit breaker activates after repeated failures — check logs for "circuit breaker open" messages
- [ ] Verify healthy flows continue materializing while a broken flow is in backoff
- [ ] Verify `force=true` bypasses the circuit breaker (manual "Retry failed" button in UI)
- [ ] Verify circuit breaker resets after a successful materialization