### PR TITLE
docs: PostgreSQL SQL how-to guides batch 2026-04-16 (Batch 5 complete)

### DIFF
--- a/content/guides/postgresql/array-operations.mdx
+++ b/content/guides/postgresql/array-operations.mdx
@@ -1,0 +1,179 @@
+---
+title: "PostgreSQL Arrays: Operators, Functions, and Practical Patterns"
+description: "Learn how to work with PostgreSQL array types -- creation, operators, functions like unnest and array_agg, indexing with GIN, and common patterns for storing and querying arrays."
+database: "postgresql"
+category: "sql-how-to"
+tags: ["postgresql", "sql", "arrays", "data-engineering"]
+date: "2026-04-16"
+---
+
+# PostgreSQL Arrays: Operators, Functions, and Practical Patterns
+
+PostgreSQL has a native array type that lets you store multiple values in a single column. Every data type has a corresponding array type: `INT[]`, `TEXT[]`, `UUID[]`, and so on. This is genuinely useful for tags, categories, feature flags, and multi-valued attributes -- but arrays are a tradeoff. They trade normalization flexibility for query simplicity.
+
+## Creating Array Columns
+
+```sql
+CREATE TABLE articles (
+  id SERIAL PRIMARY KEY,
+  title TEXT NOT NULL,
+  tags TEXT[],
+  scores INT[]
+);
+
+INSERT INTO articles (title, tags, scores)
+VALUES
+  ('PostgreSQL Arrays', ARRAY['postgresql', 'sql', 'backend'], ARRAY[95, 82, 88]),
+  ('Python Basics', ARRAY['python', 'beginner'], ARRAY[70, 75]);
+```
+
+You can also use the literal syntax:
+
+```sql
+INSERT INTO articles (title, tags)
+VALUES ('Redis Guide', '{redis, caching, nosql}');
+```
+
+## Accessing Elements
+
+Arrays in PostgreSQL are 1-indexed (unlike most programming languages):
+
+```sql
+SELECT title, tags[1] AS first_tag FROM articles;
+-- Returns the first element of the tags array
+
+SELECT tags[2:3] FROM articles;
+-- Slice: elements 2 through 3
+```
+
+## Key Operators
+
+| Operator | Meaning | Example |
+|---|---|---|
+| `@>` | Contains | `tags @> ARRAY['sql']` |
+| `<@` | Is contained by | `ARRAY['sql'] <@ tags` |
+| `&&` | Overlaps (any element in common) | `tags && ARRAY['sql', 'nosql']` |
+| `=` | Equal arrays | `tags = ARRAY['a', 'b']` |
+| `\|\|` | Concatenate | `tags \|\| ARRAY['new']` |
+
+```sql
+-- Articles tagged with both 'postgresql' AND 'sql'
+SELECT title FROM articles WHERE tags @> ARRAY['postgresql', 'sql'];
+
+-- Articles tagged with either 'python' OR 'redis'
+SELECT title FROM articles WHERE tags && ARRAY['python', 'redis'];
+
+-- Check if a single value is in the array
+SELECT title FROM articles WHERE 'postgresql' = ANY(tags);
+```
+
+## Essential Functions
+
+### `unnest()` -- Expand Array to Rows
+
+```sql
+SELECT title, unnest(tags) AS tag FROM articles;
+-- Returns one row per tag per article
+```
+
+This is the primary way to JOIN arrays to other tables or aggregate across array values.
+
+### `array_agg()` -- Aggregate Rows to Array
+
+The inverse of `unnest`:
+
+```sql
+SELECT department_id, array_agg(employee_name ORDER BY employee_name) AS team
+FROM employees
+GROUP BY department_id;
+```
+
+### `array_length()` and `cardinality()`
+
+```sql
+SELECT title, array_length(tags, 1) AS tag_count FROM articles;
+-- array_length requires dimension argument (1 for 1D arrays)
+
+SELECT title, cardinality(tags) AS tag_count FROM articles;
+-- cardinality() is simpler; returns 0 for empty, NULL for null
+```
+
+### `array_append()`, `array_prepend()`, `array_remove()`
+
+```sql
+-- Add a tag
+UPDATE articles SET tags = array_append(tags, 'featured') WHERE id = 1;
+
+-- Remove a tag
+UPDATE articles SET tags = array_remove(tags, 'beginner') WHERE id = 2;
+
+-- Prepend
+UPDATE articles SET tags = array_prepend('breaking', tags) WHERE id = 1;
+```
+
+### `array_position()` and `array_positions()`
+
+```sql
+-- Find index of first occurrence
+SELECT array_position(ARRAY['a', 'b', 'c', 'b'], 'b'); -- returns 2
+
+-- Find all occurrences
+SELECT array_positions(ARRAY['a', 'b', 'c', 'b'], 'b'); -- returns {2,4}
+```
+
+### `array_to_string()` and `string_to_array()`
+
+```sql
+SELECT array_to_string(ARRAY['a', 'b', 'c'], ', '); -- 'a, b, c'
+SELECT string_to_array('a,b,c', ',');               -- {a,b,c}
+```
+
+## Indexing with GIN
+
+For containment and overlap queries (`@>`, `<@`, `&&`), GIN indexes are the right choice:
+
+```sql
+CREATE INDEX idx_articles_tags ON articles USING GIN (tags);
+```
+
+After creating this index, `tags @> ARRAY['postgresql']` and `tags && ARRAY['sql', 'nosql']` will use it efficiently.
+
+For `= ANY(tags)` queries, GIN indexes may not be used -- verify with `EXPLAIN`. A standard B-tree index is also ineffective on array columns for containment queries.
+
+## Real-World Pattern: Tag Counts
+
+```sql
+-- How many articles per tag?
+SELECT tag, COUNT(*) AS article_count
+FROM articles, unnest(tags) AS tag
+GROUP BY tag
+ORDER BY article_count DESC;
+```
+
+This is the standard pattern: join the table to its own unnested array, then aggregate.
+
+## Arrays vs Normalized Tables
+
+Arrays are appropriate when:
+- The list of values is small and bounded
+- You never need to join the array values to another table by foreign key
+- Order within the list matters
+- You want to avoid a join table for simple multi-value attributes (e.g. tags, flags)
+
+Prefer a separate table when:
+- Array elements have their own attributes (id, created_at, metadata)
+- You need foreign key constraints
+- The list is large or unbounded
+- You frequently query "all articles for a given tag" (normalized table + index is faster at scale)
+
+## Common Mistakes
+
+**Forgetting 1-based indexing:** `tags[0]` always returns `NULL`. `tags[1]` is the first element.
+
+**Using `= ANY()` expecting GIN:** `= ANY(tags)` does not use GIN indexes efficiently in most cases. Use `@>` containment for indexed lookups.
+
+**NULL inside arrays:** `array_remove(tags, NULL)` does not work as expected -- `NULL` elements require `array_remove(tags, NULL::text)` with explicit type, and even then PostgreSQL comparisons with NULL are tricky. Consider `NOT NULL` constraints on array columns where appropriate.
+
+---
+
+Mako connects to PostgreSQL with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/postgresql/explain-analyze.mdx
+++ b/content/guides/postgresql/explain-analyze.mdx
@@ -1,0 +1,170 @@
+---
+title: "PostgreSQL EXPLAIN ANALYZE: Reading Query Plans"
+description: "Learn how to use EXPLAIN and EXPLAIN ANALYZE in PostgreSQL to understand query execution, identify bottlenecks, and optimize slow queries -- including how to read nodes, costs, and buffer statistics."
+database: "postgresql"
+category: "sql-how-to"
+tags: ["postgresql", "sql", "performance", "query-optimization", "data-engineering"]
+date: "2026-04-16"
+---
+
+# PostgreSQL EXPLAIN ANALYZE: Reading Query Plans
+
+`EXPLAIN` shows PostgreSQL's execution plan for a query -- the sequence of operations the planner chose. `EXPLAIN ANALYZE` actually executes the query and shows real timing alongside estimates. Understanding the difference between estimated and actual costs is the core of PostgreSQL query tuning.
+
+## Basic Usage
+
+```sql
+-- Estimated plan only (does not execute)
+EXPLAIN SELECT * FROM orders WHERE customer_id = 42;
+
+-- Executes the query and shows real timing
+EXPLAIN ANALYZE SELECT * FROM orders WHERE customer_id = 42;
+
+-- Full output with buffers, WAL, and format options
+EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT) SELECT * FROM orders WHERE customer_id = 42;
+```
+
+Always use `BUFFERS` when analyzing performance -- it shows whether data came from cache or disk.
+
+## Reading a Query Plan
+
+A query plan is a tree of nodes, each representing one operation. Indentation indicates nesting (child nodes feed into parent nodes).
+
+```
+Seq Scan on orders  (cost=0.00..4523.00 rows=150 width=72) (actual time=0.042..12.381 rows=143 loops=1)
+  Filter: (customer_id = 42)
+  Rows Removed by Filter: 89857
+```
+
+### Cost Fields
+
+`(cost=startup_cost..total_cost rows=estimated_rows width=row_bytes_estimate)`
+
+- **startup_cost** -- Cost to return the first row (sort nodes have high startup cost)
+- **total_cost** -- Cost to return all rows
+- **rows** -- Planner's estimated row count
+- **width** -- Average byte width per row
+
+These are arbitrary planner units, not milliseconds. They're useful for comparing nodes, not as wall-clock predictors.
+
+### Actual Fields
+
+`(actual time=startup_ms..total_ms rows=actual_rows loops=N)`
+
+- **time** -- Milliseconds to start and complete this node per loop
+- **rows** -- Actual rows returned
+- **loops** -- How many times this node ran (e.g. in a nested loop join, inner node loops once per outer row)
+
+**Multiply `time` by `loops` to get total time for that node.**
+
+## Common Node Types
+
+| Node | Meaning |
+|---|---|
+| `Seq Scan` | Full table scan, reading every row |
+| `Index Scan` | Reads index, then fetches rows from heap |
+| `Index Only Scan` | Reads index only (no heap access), requires covering index |
+| `Bitmap Heap Scan` | Collects row pointers via bitmap, then fetches in bulk |
+| `Hash Join` | Builds hash table on inner relation, probes with outer |
+| `Merge Join` | Joins two sorted streams; efficient on large sorted inputs |
+| `Nested Loop` | For each outer row, scan inner relation; efficient with indexes |
+| `Sort` | Sort rows (check whether it spills to disk) |
+| `Hash` | Build a hash table (memory usage shown) |
+| `Aggregate` | Grouping / aggregation |
+| `Limit` | Stop after N rows |
+
+## Reading Buffer Statistics
+
+```
+Buffers: shared hit=440 read=83 dirtied=0 written=0
+```
+
+- **shared hit** -- Pages served from PostgreSQL's shared_buffers (in-memory cache)
+- **shared read** -- Pages read from OS/disk cache or disk
+- **dirtied** -- Pages modified by this query
+- **written** -- Pages written to disk (evicted from cache during this query)
+
+High `read` values relative to `hit` suggest the working set doesn't fit in `shared_buffers`, or the data is cold.
+
+## Diagnosing Common Problems
+
+### Rows Estimate Way Off
+
+```
+Seq Scan on events  (cost=0.00..8200.00 rows=100 width=64)
+                    (actual time=0.030..45.210 rows=98547 loops=1)
+```
+
+The planner estimated 100 rows but got 98,547. This leads to bad plan choices (wrong join strategy, wrong index). Fix: run `ANALYZE events;` to update statistics, or increase `default_statistics_target` for the column.
+
+### Sequential Scan When Index Exists
+
+If the planner chooses a Seq Scan on a large table with an index on the filter column:
+1. The table might be small enough that Seq Scan is cheaper
+2. The filter selectivity is low (e.g. `WHERE status = 'active'` where 90% of rows are active)
+3. Statistics are stale -- run `ANALYZE`
+4. The index is unused because the column is cast or wrapped in a function: `WHERE UPPER(email) = 'X'` -- create a functional index instead
+
+### Sort Spilling to Disk
+
+```
+Sort  (cost=15234.50..15484.50 rows=100000 width=36)
+      (actual time=892.030..1012.450 rows=100000 loops=1)
+  Sort Key: created_at DESC
+  Sort Method: external merge  Disk: 8192kB
+```
+
+`external merge Disk` means the sort spilled to disk. Increase `work_mem` for the session:
+
+```sql
+SET work_mem = '256MB';
+EXPLAIN ANALYZE SELECT ... ORDER BY created_at DESC;
+```
+
+Don't set this globally without understanding memory implications across concurrent connections.
+
+### Nested Loop on Large Tables
+
+Nested loops work well when the inner relation is small or accessed via index. But a Nested Loop where the inner side does a Seq Scan on a large table is slow:
+
+```
+Nested Loop  (actual time=0.030..45230.210 rows=10000 loops=1)
+  -> Seq Scan on large_orders
+  -> Index Scan on customers
+```
+
+The planner chose this because statistics were off. After `ANALYZE`, it may switch to a Hash Join.
+
+## Practical Workflow
+
+```sql
+-- 1. Start with BUFFERS to see cache behavior
+EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM orders WHERE customer_id = 42;
+
+-- 2. Identify the most expensive node (highest actual time × loops)
+
+-- 3. Check if estimates are off (rows estimate vs actual)
+
+-- 4. If estimates are off, update stats:
+ANALYZE orders;
+
+-- 5. If a Seq Scan is suspicious, check if an index exists:
+SELECT indexname, indexdef FROM pg_indexes WHERE tablename = 'orders';
+
+-- 6. If index exists but unused, try:
+SET enable_seqscan = OFF;
+EXPLAIN SELECT * FROM orders WHERE customer_id = 42;
+-- This forces index use -- if still slow, the index isn't selective enough
+```
+
+## Using pgExplain and Explain.dalibo.com
+
+For complex plans, paste the output of `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)` into [explain.dalibo.com](https://explain.dalibo.com) or [pganalyze.com/explain](https://pganalyze.com/explain) for a visual tree with cost annotations.
+
+```sql
+EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) SELECT ...;
+```
+
+---
+
+Mako connects to PostgreSQL with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/postgresql/generated-columns.mdx
+++ b/content/guides/postgresql/generated-columns.mdx
@@ -1,0 +1,178 @@
+---
+title: "PostgreSQL Generated Columns: STORED and VIRTUAL"
+description: "Learn how to use generated columns in PostgreSQL -- automatically computed values derived from other columns -- including STORED vs VIRTUAL modes (PostgreSQL 18+), use cases, and limitations."
+database: "postgresql"
+category: "sql-how-to"
+tags: ["postgresql", "sql", "generated-columns", "schema", "data-engineering"]
+date: "2026-04-16"
+---
+
+# PostgreSQL Generated Columns: STORED and VIRTUAL
+
+A generated column is a column whose value is automatically computed from an expression involving other columns in the same row. You never insert or update a generated column directly -- PostgreSQL maintains it automatically.
+
+Generated columns were introduced in PostgreSQL 12 (STORED only). PostgreSQL 18 adds VIRTUAL generated columns, which compute the value on read rather than storing it on disk.
+
+## STORED Generated Columns
+
+A STORED column computes its value when a row is inserted or updated and writes the result to disk. Storage space is consumed, but reads are fast -- the computed value is already there.
+
+```sql
+CREATE TABLE products (
+  id SERIAL PRIMARY KEY,
+  price_cents INT NOT NULL,
+  tax_rate NUMERIC(4,3) NOT NULL DEFAULT 0.08,
+  price_with_tax NUMERIC GENERATED ALWAYS AS (price_cents * (1 + tax_rate) / 100.0) STORED
+);
+
+INSERT INTO products (price_cents, tax_rate) VALUES (1000, 0.08);
+-- price_with_tax is automatically 10.80
+
+SELECT price_with_tax FROM products WHERE id = 1; -- 10.80
+```
+
+The `GENERATED ALWAYS AS (...) STORED` syntax is the key part. Attempting to insert or update the generated column raises an error.
+
+## VIRTUAL Generated Columns (PostgreSQL 18+)
+
+A VIRTUAL column computes its value at query time -- nothing is written to disk. This saves storage at the cost of computation on every read.
+
+PostgreSQL 18 makes VIRTUAL the default:
+
+```sql
+-- PostgreSQL 18+
+CREATE TABLE products (
+  id SERIAL PRIMARY KEY,
+  price_cents INT NOT NULL,
+  price_dollars NUMERIC GENERATED ALWAYS AS (price_cents / 100.0) VIRTUAL
+  -- or just: price_dollars NUMERIC GENERATED ALWAYS AS (price_cents / 100.0)
+);
+```
+
+Before PostgreSQL 18, only STORED is available. The STORED keyword is required explicitly in versions 12-17.
+
+## Practical Use Cases
+
+### Full Name from First + Last
+
+```sql
+CREATE TABLE contacts (
+  id SERIAL PRIMARY KEY,
+  first_name TEXT NOT NULL,
+  last_name TEXT NOT NULL,
+  full_name TEXT GENERATED ALWAYS AS (first_name || ' ' || last_name) STORED
+);
+```
+
+This is especially useful when you want to index the full name for search:
+
+```sql
+CREATE INDEX ON contacts (full_name);
+-- Or for case-insensitive search:
+CREATE INDEX ON contacts (lower(full_name));
+```
+
+### Normalized Search Column
+
+```sql
+CREATE TABLE articles (
+  id SERIAL PRIMARY KEY,
+  title TEXT NOT NULL,
+  title_normalized TEXT GENERATED ALWAYS AS (lower(trim(title))) STORED
+);
+
+CREATE INDEX ON articles (title_normalized);
+-- Now case-insensitive lookups are index-friendly
+SELECT * FROM articles WHERE title_normalized = lower(trim('My Article'));
+```
+
+### Price Calculations
+
+```sql
+CREATE TABLE order_items (
+  id SERIAL PRIMARY KEY,
+  quantity INT NOT NULL,
+  unit_price NUMERIC(10,2) NOT NULL,
+  total NUMERIC(10,2) GENERATED ALWAYS AS (quantity * unit_price) STORED
+);
+```
+
+### Geometry / Spatial Helpers
+
+```sql
+CREATE TABLE locations (
+  id SERIAL PRIMARY KEY,
+  lat DOUBLE PRECISION,
+  lng DOUBLE PRECISION,
+  geom GEOMETRY(POINT, 4326) GENERATED ALWAYS AS (ST_SetSRID(ST_MakePoint(lng, lat), 4326)) STORED
+);
+
+CREATE INDEX ON locations USING GIST (geom);
+```
+
+Insert with just lat/lng and the geometry column is populated automatically.
+
+## Constraints and Limitations
+
+- Generated columns **cannot reference other generated columns** in their expression.
+- The expression must be **immutable** -- it cannot call non-deterministic functions like `NOW()`, `RANDOM()`, or `CURRENT_TIMESTAMP`. This means you can't auto-generate timestamps from generated columns (use `DEFAULT` with `NOW()` for that instead).
+- Generated columns cannot have `DEFAULT` values or be part of `ON CONFLICT DO UPDATE SET generated_col = ...`.
+- STORED generated columns **consume disk space** like regular columns.
+- You **cannot partition** a table by a generated column.
+- Foreign keys cannot reference generated columns in PostgreSQL 17 and earlier (this may change in future versions).
+
+## Altering Generated Columns
+
+To change the expression, drop and re-add the column:
+
+```sql
+-- Cannot use ALTER COLUMN to change the expression directly
+ALTER TABLE products DROP COLUMN price_with_tax;
+ALTER TABLE products ADD COLUMN price_with_tax NUMERIC
+  GENERATED ALWAYS AS (price_cents * (1 + tax_rate) / 100.0) STORED;
+```
+
+This rewrites the table for STORED columns. On large tables, consider `pg_repack` or an online schema change approach.
+
+## Generated Columns vs Triggers
+
+Before generated columns existed, the pattern was:
+
+```sql
+CREATE FUNCTION update_full_name() RETURNS TRIGGER AS $$
+BEGIN
+  NEW.full_name := NEW.first_name || ' ' || NEW.last_name;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER set_full_name
+BEFORE INSERT OR UPDATE ON contacts
+FOR EACH ROW EXECUTE FUNCTION update_full_name();
+```
+
+Generated columns are strictly better for this use case -- they're declarative, always consistent, can be indexed directly, and don't require trigger maintenance. Use triggers when you need logic that spans multiple tables or has side effects.
+
+## Inspecting Generated Columns
+
+```sql
+SELECT
+  column_name,
+  data_type,
+  generation_expression,
+  is_generated
+FROM information_schema.columns
+WHERE table_name = 'products'
+  AND is_generated = 'ALWAYS';
+```
+
+Or with `psql`:
+
+```sql
+\d products
+-- Generated columns show "(generated always as (expression) stored)" in the schema description
+```
+
+---
+
+Mako connects to PostgreSQL with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/postgresql/lateral-joins.mdx
+++ b/content/guides/postgresql/lateral-joins.mdx
@@ -1,0 +1,161 @@
+---
+title: "PostgreSQL LATERAL Joins: When and How to Use Them"
+description: "Understand PostgreSQL LATERAL joins -- what they are, how they differ from regular subqueries, and practical patterns like top-N per group, calling functions row-by-row, and flattening arrays."
+database: "postgresql"
+category: "sql-how-to"
+tags: ["postgresql", "sql", "lateral", "joins", "data-engineering"]
+date: "2026-04-16"
+---
+
+# PostgreSQL LATERAL Joins: When and How to Use Them
+
+A `LATERAL` subquery in PostgreSQL can reference columns from tables that appear earlier in the `FROM` clause. This is the key difference from a regular subquery, which is evaluated in isolation. `LATERAL` turns a subquery into something that runs once per row of the outer query, with access to that outer row's values.
+
+## The Core Idea
+
+Without `LATERAL`, a subquery in `FROM` is a black box:
+
+```sql
+-- Regular subquery: cannot reference outer_table
+SELECT o.id, stats.max_price
+FROM orders o,
+     (SELECT MAX(price) FROM order_items WHERE order_id = o.id) AS stats(max_price);
+-- ERROR: reference to o.id is not valid here
+```
+
+With `LATERAL`, the subquery sees the outer row:
+
+```sql
+SELECT o.id, stats.max_price
+FROM orders o,
+LATERAL (SELECT MAX(price) FROM order_items WHERE order_id = o.id) AS stats(max_price);
+-- Works: the subquery runs once per order row
+```
+
+## Top-N Per Group
+
+This is the most common use case: get the N most recent or highest-ranked rows per group.
+
+```sql
+-- Last 3 orders per customer
+SELECT c.id, c.name, recent.order_id, recent.amount, recent.created_at
+FROM customers c
+JOIN LATERAL (
+  SELECT order_id, amount, created_at
+  FROM orders
+  WHERE customer_id = c.id
+  ORDER BY created_at DESC
+  LIMIT 3
+) AS recent ON TRUE;
+```
+
+Without `LATERAL`, this requires a window function + filter or a correlated subquery that can only return one column. `LATERAL` returns multiple columns and multiple rows cleanly.
+
+`ON TRUE` is used with `JOIN LATERAL` when you want to keep all outer rows regardless of whether the subquery returns any rows (though `JOIN` will still exclude customers with no orders -- use `LEFT JOIN LATERAL ... ON TRUE` to keep them).
+
+```sql
+-- Include customers with no orders (recent.* will be NULL)
+SELECT c.id, c.name, recent.order_id, recent.amount
+FROM customers c
+LEFT JOIN LATERAL (
+  SELECT order_id, amount
+  FROM orders
+  WHERE customer_id = c.id
+  ORDER BY amount DESC
+  LIMIT 1
+) AS recent ON TRUE;
+```
+
+## Historical / Point-in-Time Lookups
+
+When a related table has versioned records, `LATERAL` makes it easy to get the version valid at a specific time:
+
+```sql
+-- Get each statement's address as it was at statement time
+SELECT s.id, s.statement_date, s.balance, a.address
+FROM statements s
+JOIN LATERAL (
+  SELECT address
+  FROM addresses
+  WHERE customer_id = s.customer_id
+    AND effective_on <= s.statement_date
+  ORDER BY effective_on DESC
+  LIMIT 1
+) AS a ON TRUE;
+```
+
+## Calling Set-Returning Functions
+
+`LATERAL` is implied (and required) when calling a set-returning function in `FROM`:
+
+```sql
+-- unnest is a set-returning function; LATERAL is implicit
+SELECT id, tag
+FROM articles, unnest(tags) AS tag;
+
+-- Explicit LATERAL (equivalent):
+SELECT id, tag
+FROM articles
+CROSS JOIN LATERAL unnest(tags) AS tag;
+```
+
+For functions that return multiple columns (`json_to_recordset`, `jsonb_array_elements`, custom functions):
+
+```sql
+SELECT id, elem->>'name' AS item_name, (elem->>'qty')::int AS qty
+FROM orders,
+LATERAL jsonb_array_elements(line_items) AS elem;
+```
+
+## Multiple Columns from a Correlated Subquery
+
+A regular correlated subquery in `SELECT` can only return one column. `LATERAL` returns a full row:
+
+```sql
+-- Correlated subquery: limited to one column
+SELECT
+  d.name,
+  (SELECT MAX(salary) FROM employees WHERE department_id = d.id) AS max_salary,
+  (SELECT MIN(salary) FROM employees WHERE department_id = d.id) AS min_salary
+  -- Two separate correlated subqueries = two scans
+FROM departments d;
+
+-- LATERAL: one scan, multiple columns
+SELECT d.name, stats.max_salary, stats.min_salary, stats.headcount
+FROM departments d
+JOIN LATERAL (
+  SELECT MAX(salary) AS max_salary, MIN(salary) AS min_salary, COUNT(*) AS headcount
+  FROM employees WHERE department_id = d.id
+) AS stats ON TRUE;
+```
+
+## LATERAL vs CTE vs Correlated Subquery
+
+All three can express similar logic. The practical differences:
+
+- **Correlated subquery in SELECT** -- one column only, re-evaluated per row
+- **LATERAL in FROM** -- multiple columns, multiple rows, re-evaluated per outer row
+- **CTE** -- evaluates once, not correlated to outer rows (except when inlined by the optimizer)
+- **Window function** -- usually the right tool for ranking/top-N if you don't need other columns from the ranked subquery
+
+For top-N per group, `LATERAL` with `LIMIT` is typically faster than a window function approach because it can use an index to fetch the top N directly rather than scanning all rows in the group.
+
+## Performance
+
+`LATERAL` subqueries execute once per outer row, so they benefit strongly from indexes on the join columns. For the customer-orders example, an index on `orders(customer_id, created_at DESC)` makes each lateral execution near-instant.
+
+```sql
+CREATE INDEX ON orders (customer_id, created_at DESC);
+```
+
+Check the plan with `EXPLAIN ANALYZE` -- each lateral execution should show an `Index Scan` or `Index Only Scan`, not a `Seq Scan`.
+
+## Common Mistakes
+
+**Forgetting `ON TRUE` with `JOIN LATERAL`:** When the lateral subquery can return zero rows, `JOIN LATERAL` will exclude the outer row. Use `LEFT JOIN LATERAL ... ON TRUE` if you want to keep outer rows with null lateral results.
+
+**Using LATERAL where a window function is cleaner:** For simple ranking (`ROW_NUMBER() OVER (PARTITION BY department ORDER BY salary DESC)`), window functions are more readable and often equivalent in performance. `LATERAL` shines when you need to pass multiple values from the subquery or use complex `ORDER BY` with `LIMIT`.
+
+---
+
+Mako connects to PostgreSQL with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/postgresql/partitioning.mdx
+++ b/content/guides/postgresql/partitioning.mdx
@@ -1,0 +1,202 @@
+---
+title: "PostgreSQL Table Partitioning: Range, List, and Hash"
+description: "Learn how to use declarative table partitioning in PostgreSQL -- range, list, and hash strategies -- with examples, partition pruning, indexing, and maintenance patterns for large tables."
+database: "postgresql"
+category: "sql-how-to"
+tags: ["postgresql", "sql", "partitioning", "performance", "data-engineering"]
+date: "2026-04-16"
+---
+
+# PostgreSQL Table Partitioning: Range, List, and Hash
+
+Table partitioning splits a single logical table into multiple physical storage units (partitions). PostgreSQL's query planner can then skip partitions that can't match the query's filters -- a technique called partition pruning. For tables with hundreds of millions of rows, partitioning can reduce query time from minutes to seconds and make operations like bulk deletes nearly instant.
+
+PostgreSQL introduced declarative partitioning in version 10. Before that, inheritance-based partitioning was the only option -- avoid it for new tables.
+
+## When Partitioning Helps
+
+Partitioning is most effective when:
+- Tables are very large (100M+ rows, or 10+ GB) and queries consistently filter on the partition key
+- You need to delete old data regularly (e.g. drop partitions for expired time ranges)
+- You want to distribute data across tablespaces (e.g. hot data on SSD, cold data on HDD)
+
+Partitioning adds overhead for small tables and queries that don't filter on the partition key. A well-indexed regular table often outperforms a poorly partitioned one.
+
+## Range Partitioning
+
+Range partitioning assigns rows based on value ranges. This is the most common strategy for time-series data.
+
+```sql
+CREATE TABLE events (
+  id BIGSERIAL,
+  event_type TEXT NOT NULL,
+  payload JSONB,
+  created_at TIMESTAMPTZ NOT NULL
+) PARTITION BY RANGE (created_at);
+
+-- Create monthly partitions
+CREATE TABLE events_2025_01 PARTITION OF events
+  FOR VALUES FROM ('2025-01-01') TO ('2025-02-01');
+
+CREATE TABLE events_2025_02 PARTITION OF events
+  FOR VALUES FROM ('2025-02-01') TO ('2025-03-01');
+
+-- Default partition catches anything outside defined ranges
+CREATE TABLE events_default PARTITION OF events DEFAULT;
+```
+
+Ranges are inclusive at the lower bound and exclusive at the upper bound.
+
+### Dropping Old Partitions
+
+```sql
+-- Drop a year's worth of data in milliseconds
+DROP TABLE events_2023_01;
+DROP TABLE events_2023_02;
+-- ...
+```
+
+This is far faster than `DELETE FROM events WHERE created_at < '2024-01-01'`, which would scan rows and generate dead tuples.
+
+## List Partitioning
+
+List partitioning assigns rows based on specific values. Useful for regional or categorical splits.
+
+```sql
+CREATE TABLE orders (
+  id BIGSERIAL,
+  region TEXT NOT NULL,
+  amount NUMERIC,
+  created_at TIMESTAMPTZ NOT NULL
+) PARTITION BY LIST (region);
+
+CREATE TABLE orders_us     PARTITION OF orders FOR VALUES IN ('us', 'ca', 'mx');
+CREATE TABLE orders_eu     PARTITION OF orders FOR VALUES IN ('de', 'fr', 'gb', 'es', 'it');
+CREATE TABLE orders_apac   PARTITION OF orders FOR VALUES IN ('jp', 'au', 'sg', 'in');
+CREATE TABLE orders_other  PARTITION OF orders DEFAULT;
+```
+
+## Hash Partitioning
+
+Hash partitioning distributes rows evenly across a fixed number of partitions using a hash of the partition key. Use this when you need to distribute load evenly and don't have a natural range or list key.
+
+```sql
+CREATE TABLE user_events (
+  id BIGSERIAL,
+  user_id BIGINT NOT NULL,
+  event_type TEXT,
+  created_at TIMESTAMPTZ NOT NULL
+) PARTITION BY HASH (user_id);
+
+CREATE TABLE user_events_0 PARTITION OF user_events
+  FOR VALUES WITH (MODULUS 4, REMAINDER 0);
+CREATE TABLE user_events_1 PARTITION OF user_events
+  FOR VALUES WITH (MODULUS 4, REMAINDER 1);
+CREATE TABLE user_events_2 PARTITION OF user_events
+  FOR VALUES WITH (MODULUS 4, REMAINDER 2);
+CREATE TABLE user_events_3 PARTITION OF user_events
+  FOR VALUES WITH (MODULUS 4, REMAINDER 3);
+```
+
+Hash partitioning doesn't support partition pruning on range queries -- it's only useful when you query by exact key value (e.g. `WHERE user_id = 12345`).
+
+## Partition Pruning
+
+Partition pruning is the planner's ability to skip irrelevant partitions. It works when the filter uses the partition key with a comparison that the planner can statically resolve.
+
+```sql
+-- Pruning works: planner knows to only scan events_2025_01
+SELECT * FROM events WHERE created_at BETWEEN '2025-01-15' AND '2025-01-20';
+
+-- No pruning: the function result isn't known at plan time in some cases
+SELECT * FROM events WHERE date_trunc('month', created_at) = '2025-01-01';
+-- Use this instead:
+SELECT * FROM events WHERE created_at >= '2025-01-01' AND created_at < '2025-02-01';
+```
+
+Check pruning with `EXPLAIN`:
+
+```sql
+EXPLAIN SELECT * FROM events WHERE created_at BETWEEN '2025-01-15' AND '2025-01-20';
+-- Should show only events_2025_01 in the plan, not all partitions
+```
+
+## Indexes on Partitioned Tables
+
+In PostgreSQL 11+, you can create indexes on the parent table and they automatically propagate to all partitions:
+
+```sql
+CREATE INDEX ON events (created_at);
+-- Creates an index on each partition automatically
+```
+
+For unique constraints and primary keys, the partition key must be part of the constraint:
+
+```sql
+-- This works in PG 11+
+ALTER TABLE events ADD PRIMARY KEY (id, created_at);
+```
+
+## Sub-Partitioning
+
+Partitions can themselves be partitioned:
+
+```sql
+CREATE TABLE events_2025_01 PARTITION OF events
+  FOR VALUES FROM ('2025-01-01') TO ('2025-02-01')
+  PARTITION BY HASH (event_type);
+
+CREATE TABLE events_2025_01_h0 PARTITION OF events_2025_01
+  FOR VALUES WITH (MODULUS 4, REMAINDER 0);
+-- ...
+```
+
+Sub-partitioning adds complexity. Be sure you actually need it before adding a second level.
+
+## Automating Partition Maintenance
+
+Creating monthly partitions manually doesn't scale. `pg_partman` is the standard extension for automated partition management (as of April 2026):
+
+```sql
+CREATE EXTENSION pg_partman;
+
+SELECT partman.create_parent(
+  p_parent_table => 'public.events',
+  p_control => 'created_at',
+  p_type => 'range',
+  p_interval => '1 month',
+  p_premake => 3  -- create 3 future partitions in advance
+);
+```
+
+`pg_partman` includes a background worker that creates future partitions and optionally retains or drops old ones.
+
+## Migrating an Existing Table
+
+You can't convert an existing table to a partitioned table in place. The standard approach:
+
+```sql
+-- 1. Create the new partitioned table
+CREATE TABLE events_new (...) PARTITION BY RANGE (created_at);
+-- 2. Create partitions
+-- 3. Copy data in batches
+INSERT INTO events_new SELECT * FROM events WHERE created_at < '2025-01-01';
+-- 4. Rename tables
+ALTER TABLE events RENAME TO events_old;
+ALTER TABLE events_new RENAME TO events;
+-- 5. Verify, then drop events_old
+```
+
+For zero-downtime migrations on live tables, use logical replication or the `pg_repack` approach.
+
+## Common Mistakes
+
+**Querying without the partition key:** A query with no filter on the partition key scans all partitions. Partitioning won't help -- it may actually hurt due to planning overhead.
+
+**Wrong index strategy:** Unique indexes on partitioned tables must include the partition key. `CREATE UNIQUE INDEX ON events (id)` fails unless `id` is the partition key or part of it.
+
+**Forgetting the default partition:** Inserts with values outside all defined ranges fail with an error if there's no default partition. Add one unless you want strict enforcement.
+
+---
+
+Mako connects to PostgreSQL with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/postgresql/recursive-queries.mdx
+++ b/content/guides/postgresql/recursive-queries.mdx
@@ -1,0 +1,230 @@
+---
+title: "PostgreSQL Recursive Queries: WITH RECURSIVE for Hierarchical Data"
+description: "Learn how to use PostgreSQL's WITH RECURSIVE to query hierarchical and graph-structured data -- org charts, categories, file trees, and bill-of-materials -- with practical examples and performance tips."
+database: "postgresql"
+category: "sql-how-to"
+tags: ["postgresql", "sql", "recursive", "cte", "hierarchical-data", "data-engineering"]
+date: "2026-04-16"
+---
+
+# PostgreSQL Recursive Queries: WITH RECURSIVE for Hierarchical Data
+
+Hierarchical data -- parent-child relationships, org charts, category trees, file systems -- is common but awkward to query with plain SQL. `WITH RECURSIVE` solves this by letting a CTE reference itself, allowing you to traverse a tree or graph structure entirely in SQL.
+
+## How WITH RECURSIVE Works
+
+A recursive CTE has two parts separated by `UNION ALL`:
+
+1. **Anchor query** -- the base case. Runs once to produce the starting set.
+2. **Recursive query** -- references the CTE name, joins against it, and produces the next level. Runs repeatedly until no new rows are produced.
+
+```sql
+WITH RECURSIVE cte_name AS (
+  -- Anchor: starting rows
+  SELECT ...
+
+  UNION ALL
+
+  -- Recursive: join CTE against the table to get next level
+  SELECT ... FROM table JOIN cte_name ON ...
+)
+SELECT * FROM cte_name;
+```
+
+PostgreSQL internally maintains a "working table" (current level) and an "intermediate table" (accumulated results). On each iteration, it joins the table against the working table to produce the next working table. It stops when the working table is empty.
+
+## Example: Organizational Hierarchy
+
+```sql
+CREATE TABLE employees (
+  id INT PRIMARY KEY,
+  name TEXT NOT NULL,
+  manager_id INT REFERENCES employees(id)
+);
+
+INSERT INTO employees VALUES
+  (1, 'Alice', NULL),   -- CEO
+  (2, 'Bob', 1),        -- CTO
+  (3, 'Carol', 1),      -- CFO
+  (4, 'Dave', 2),       -- Engineer
+  (5, 'Eve', 2),        -- Engineer
+  (6, 'Frank', 3);      -- Accountant
+```
+
+### Get All Reports Under a Manager
+
+```sql
+WITH RECURSIVE org AS (
+  -- Anchor: start with the target manager
+  SELECT id, name, manager_id, 0 AS depth
+  FROM employees
+  WHERE id = 2  -- Bob (CTO)
+
+  UNION ALL
+
+  -- Recursive: find direct reports of each level
+  SELECT e.id, e.name, e.manager_id, org.depth + 1
+  FROM employees e
+  JOIN org ON e.manager_id = org.id
+)
+SELECT depth, repeat('  ', depth) || name AS org_chart, id
+FROM org
+ORDER BY depth, name;
+```
+
+Result:
+```
+depth | org_chart       | id
+------+-----------------+----
+    0 | Bob             |  2
+    1 |   Dave          |  4
+    1 |   Eve           |  5
+```
+
+### Get the Full Path to Root
+
+```sql
+WITH RECURSIVE path AS (
+  -- Anchor: start with a leaf node
+  SELECT id, name, manager_id, name::TEXT AS path
+  FROM employees
+  WHERE id = 4  -- Dave
+
+  UNION ALL
+
+  -- Recursive: walk up to parent
+  SELECT e.id, e.name, e.manager_id, e.name || ' > ' || path.path
+  FROM employees e
+  JOIN path ON e.id = path.manager_id
+)
+SELECT path
+FROM path
+WHERE manager_id IS NULL;  -- Stop at root (CEO)
+```
+
+Result: `Alice > Bob > Dave`
+
+## Example: Category Tree
+
+```sql
+CREATE TABLE categories (
+  id INT PRIMARY KEY,
+  name TEXT,
+  parent_id INT REFERENCES categories(id)
+);
+
+-- Get all descendants of category 5
+WITH RECURSIVE subtree AS (
+  SELECT id, name, parent_id, 0 AS level
+  FROM categories
+  WHERE id = 5
+
+  UNION ALL
+
+  SELECT c.id, c.name, c.parent_id, subtree.level + 1
+  FROM categories c
+  JOIN subtree ON c.parent_id = subtree.id
+)
+SELECT level, name FROM subtree ORDER BY level;
+```
+
+## Example: Bill of Materials
+
+A classic use case: a product is made of components, which are themselves made of other components.
+
+```sql
+CREATE TABLE components (
+  parent_id INT,
+  child_id INT,
+  quantity INT
+);
+
+-- Total quantity of part #15 needed to build product #1
+WITH RECURSIVE bom AS (
+  SELECT child_id, quantity, quantity AS total
+  FROM components
+  WHERE parent_id = 1  -- top-level product
+
+  UNION ALL
+
+  SELECT c.child_id, c.quantity, bom.total * c.quantity
+  FROM components c
+  JOIN bom ON c.parent_id = bom.child_id
+)
+SELECT child_id, SUM(total) AS total_qty
+FROM bom
+WHERE child_id = 15
+GROUP BY child_id;
+```
+
+## Controlling Depth and Preventing Cycles
+
+### Depth Limit
+
+Add a depth counter and stop at a maximum:
+
+```sql
+WITH RECURSIVE org AS (
+  SELECT id, name, manager_id, 0 AS depth
+  FROM employees WHERE id = 1
+
+  UNION ALL
+
+  SELECT e.id, e.name, e.manager_id, org.depth + 1
+  FROM employees e
+  JOIN org ON e.manager_id = org.id
+  WHERE org.depth < 10  -- stop after 10 levels
+)
+SELECT * FROM org;
+```
+
+### Cycle Detection
+
+For graph data (not strict trees), rows can appear multiple times. Track the visited path:
+
+```sql
+WITH RECURSIVE graph_walk AS (
+  SELECT id, ARRAY[id] AS visited
+  FROM nodes WHERE id = 1
+
+  UNION ALL
+
+  SELECT n.id, graph_walk.visited || n.id
+  FROM edges e
+  JOIN nodes n ON e.to_id = n.id
+  JOIN graph_walk ON e.from_id = graph_walk.id
+  WHERE NOT n.id = ANY(graph_walk.visited)  -- skip already-visited nodes
+)
+SELECT id FROM graph_walk;
+```
+
+PostgreSQL 14+ has `SEARCH` and `CYCLE` clauses that handle this more cleanly:
+
+```sql
+WITH RECURSIVE graph_walk AS (
+  SELECT id FROM nodes WHERE id = 1
+  UNION ALL
+  SELECT n.id FROM edges e JOIN nodes n ON e.to_id = n.id
+  JOIN graph_walk ON e.from_id = graph_walk.id
+)
+CYCLE id SET is_cycle USING path;
+```
+
+## Performance Tips
+
+- **Index the join column:** `CREATE INDEX ON employees (manager_id)`. The recursive join fires once per level, and each iteration does a lookup by the parent ID.
+- **Limit rows early:** Filter in the anchor query, not just at the end. Fewer starting rows means fewer recursive iterations.
+- **Avoid `UNION` (without ALL):** `UNION` deduplicates at every iteration, which is expensive. Use `UNION ALL` and handle duplicates in the outer query if needed.
+- **Monitor with EXPLAIN:** Recursive queries show an additional `WorkTable Scan` node. Check its actual row count -- unexpectedly high numbers indicate a cycle or missing depth limit.
+
+## Common Mistakes
+
+**Missing the termination condition:** If the recursive step always produces rows, the query runs forever. PostgreSQL doesn't have a built-in row limit for recursive queries by default -- set `statement_timeout` on long-running environments.
+
+**Using UNION instead of UNION ALL:** Deduplication inside the recursion makes cycle detection impossible and slows down large traversals significantly.
+
+**Traversing from root when you need descendants:** The anchor is the starting set. To get all descendants of node X, anchor on X and recursively join `parent_id = current.id`. To get ancestors, anchor on X and recursively join `id = current.parent_id`.
+
+---
+
+Mako connects to PostgreSQL with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/postgresql/subqueries.mdx
+++ b/content/guides/postgresql/subqueries.mdx
@@ -1,0 +1,174 @@
+---
+title: "PostgreSQL Subqueries: A Practical Guide"
+description: "Learn how to use subqueries in PostgreSQL -- scalar, row, table, correlated, EXISTS, and ANY/ALL -- with real examples and performance guidance."
+database: "postgresql"
+category: "sql-how-to"
+tags: ["postgresql", "sql", "subqueries", "data-engineering"]
+date: "2026-04-16"
+---
+
+# PostgreSQL Subqueries: A Practical Guide
+
+A subquery is a query nested inside another query. PostgreSQL evaluates the inner query first and uses its result in the outer query. Subqueries appear in `SELECT`, `FROM`, `WHERE`, and `HAVING` clauses, and each placement has different semantics and performance characteristics.
+
+## Types of Subqueries
+
+### Scalar Subqueries
+
+A scalar subquery returns exactly one row and one column. It can appear anywhere a single value is expected.
+
+```sql
+SELECT
+  product_name,
+  price,
+  price - (SELECT AVG(price) FROM products) AS diff_from_avg
+FROM products;
+```
+
+If the subquery returns more than one row, PostgreSQL raises an error at runtime.
+
+### Row Subqueries
+
+A row subquery returns a single row with multiple columns. Compare it using a row constructor:
+
+```sql
+SELECT * FROM employees
+WHERE (department_id, salary) = (SELECT department_id, MAX(salary) FROM employees GROUP BY department_id LIMIT 1);
+```
+
+### Table Subqueries (Derived Tables)
+
+A subquery in the `FROM` clause acts like a temporary table:
+
+```sql
+SELECT dept, avg_salary
+FROM (
+  SELECT department_id AS dept, AVG(salary) AS avg_salary
+  FROM employees
+  GROUP BY department_id
+) AS dept_stats
+WHERE avg_salary > 80000;
+```
+
+The alias (`dept_stats`) is required. Derived tables are also called inline views.
+
+### Correlated Subqueries
+
+A correlated subquery references a column from the outer query. PostgreSQL re-evaluates it for every row in the outer query.
+
+```sql
+-- Films with above-average length for their rating
+SELECT title, rating, length
+FROM film f
+WHERE length > (
+  SELECT AVG(length)
+  FROM film
+  WHERE rating = f.rating
+);
+```
+
+The reference to `f.rating` is what makes it correlated. Performance scales with the number of rows in the outer query -- index the columns used in the join condition.
+
+## EXISTS and NOT EXISTS
+
+`EXISTS` tests whether a subquery returns any rows. It short-circuits as soon as one row is found, making it efficient for existence checks.
+
+```sql
+-- Customers who have placed at least one order
+SELECT customer_id, name
+FROM customers c
+WHERE EXISTS (
+  SELECT 1 FROM orders o
+  WHERE o.customer_id = c.customer_id
+);
+
+-- Customers with no orders
+SELECT customer_id, name
+FROM customers c
+WHERE NOT EXISTS (
+  SELECT 1 FROM orders o
+  WHERE o.customer_id = c.customer_id
+);
+```
+
+`SELECT 1` inside an `EXISTS` is conventional -- the actual columns returned don't matter.
+
+### EXISTS vs IN
+
+Both can express the same logic, but with differences:
+
+```sql
+-- IN version
+SELECT * FROM customers
+WHERE customer_id IN (SELECT customer_id FROM orders);
+
+-- EXISTS version
+SELECT * FROM customers c
+WHERE EXISTS (SELECT 1 FROM orders o WHERE o.customer_id = c.customer_id);
+```
+
+`IN` materializes the subquery result set first. If the subquery returns many rows or if the values list contains `NULL`, `IN` can behave unexpectedly -- `NULL IN (1, 2, NULL)` evaluates to `NULL`, not `FALSE`. `EXISTS` avoids NULL pitfalls and is generally faster on large datasets because it stops at the first match.
+
+## ANY and ALL
+
+`ANY` (equivalent to `SOME`) returns true if the condition holds for at least one value in the subquery. `ALL` requires the condition to hold for every value.
+
+```sql
+-- Products cheaper than any product in the 'Gadgets' category
+SELECT product_name, price
+FROM products
+WHERE price < ANY (
+  SELECT price FROM products WHERE category = 'Gadgets'
+);
+
+-- Products cheaper than all products in the 'Gadgets' category
+SELECT product_name, price
+FROM products
+WHERE price < ALL (
+  SELECT price FROM products WHERE category = 'Gadgets'
+);
+```
+
+`= ANY(...)` is functionally identical to `IN (...)`.
+
+## Subqueries in HAVING
+
+Filter aggregate results using a subquery in `HAVING`:
+
+```sql
+SELECT department_id, AVG(salary) AS avg_sal
+FROM employees
+GROUP BY department_id
+HAVING AVG(salary) > (SELECT AVG(salary) FROM employees);
+```
+
+## Performance Considerations
+
+- **Correlated subqueries** execute once per outer row. For large tables, convert them to JOINs or CTEs when possible.
+- **EXISTS** is almost always faster than `IN` with large subquery result sets -- it short-circuits.
+- **Derived tables** (subqueries in `FROM`) are often equivalent to CTEs in performance since PostgreSQL 12 inlines both by default.
+- Add indexes on the columns used in correlated conditions (`WHERE o.customer_id = c.customer_id` benefits from an index on `orders.customer_id`).
+
+## Common Mistakes
+
+**Returning multiple rows from a scalar context:**
+```sql
+-- Breaks if multiple rows match
+SELECT * FROM orders WHERE amount = (SELECT MAX(amount) FROM orders WHERE status = 'pending');
+-- Safer:
+SELECT * FROM orders WHERE amount = (SELECT MAX(amount) FROM orders WHERE status = 'pending') LIMIT 1;
+```
+
+**NULL handling with IN:**
+```sql
+-- Returns no rows if subquery result contains any NULL
+SELECT * FROM products WHERE id NOT IN (SELECT product_id FROM discontinued);
+-- Use NOT EXISTS instead:
+SELECT * FROM products p WHERE NOT EXISTS (
+  SELECT 1 FROM discontinued d WHERE d.product_id = p.id
+);
+```
+
+---
+
+Mako connects to PostgreSQL with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/postgresql/transactions-explained.mdx
+++ b/content/guides/postgresql/transactions-explained.mdx
@@ -1,0 +1,192 @@
+---
+title: "PostgreSQL Transactions: ACID, COMMIT, ROLLBACK, and Savepoints"
+description: "Understand how transactions work in PostgreSQL -- BEGIN, COMMIT, ROLLBACK, isolation levels, and savepoints -- with practical examples for reliable data operations."
+database: "postgresql"
+category: "sql-how-to"
+tags: ["postgresql", "sql", "transactions", "acid", "data-engineering"]
+date: "2026-04-16"
+---
+
+# PostgreSQL Transactions: ACID, COMMIT, ROLLBACK, and Savepoints
+
+A transaction groups multiple SQL operations into a single unit. Either all operations succeed and commit, or none of them do. PostgreSQL's transaction model is one of the most reliable in any relational database -- every write is transactional by default.
+
+## ACID Properties
+
+PostgreSQL guarantees ACID compliance:
+
+- **Atomicity** -- A transaction is all-or-nothing. If any operation fails, all prior operations in the transaction are rolled back automatically.
+- **Consistency** -- The database moves from one valid state to another. Constraints, triggers, and rules are checked at commit time.
+- **Isolation** -- Concurrent transactions don't see each other's uncommitted changes (with configurable levels).
+- **Durability** -- Once committed, the data survives crashes (via Write-Ahead Logging).
+
+## Basic Transaction Syntax
+
+```sql
+BEGIN;
+
+UPDATE accounts SET balance = balance - 500 WHERE account_id = 1;
+UPDATE accounts SET balance = balance + 500 WHERE account_id = 2;
+
+COMMIT;
+```
+
+If any statement fails between `BEGIN` and `COMMIT`, PostgreSQL aborts the transaction:
+
+```sql
+BEGIN;
+
+UPDATE accounts SET balance = balance - 500 WHERE account_id = 1;
+-- If this raises an error (e.g. constraint violation), the transaction is aborted
+UPDATE accounts SET balance = balance + 500 WHERE account_id = 999; -- account doesn't exist
+
+COMMIT; -- This is a no-op; transaction was already aborted
+```
+
+After an error, you must issue `ROLLBACK` before starting a new transaction. Any SQL executed in an aborted transaction state returns `ERROR: current transaction is aborted`.
+
+### ROLLBACK
+
+```sql
+BEGIN;
+
+DELETE FROM audit_log WHERE created_at < '2020-01-01';
+
+-- Changed your mind
+ROLLBACK;
+-- No rows were deleted
+```
+
+### Implicit Transactions
+
+Every statement in PostgreSQL that is not inside an explicit `BEGIN` block runs in its own implicit transaction. A single `INSERT` with no `BEGIN` is atomic by itself.
+
+## Savepoints
+
+Savepoints let you create partial rollback points within a transaction without aborting the whole thing.
+
+```sql
+BEGIN;
+
+INSERT INTO orders (customer_id, product_id, amount)
+VALUES (42, 101, 99.99);
+
+SAVEPOINT before_discount;
+
+-- Apply a discount update
+UPDATE orders SET amount = 89.99 WHERE customer_id = 42 AND product_id = 101;
+
+-- Something went wrong with the discount logic, undo just that step
+ROLLBACK TO SAVEPOINT before_discount;
+
+-- The original insert is still in effect; only the UPDATE was rolled back
+COMMIT;
+```
+
+Release a savepoint when you no longer need it (frees resources):
+
+```sql
+RELEASE SAVEPOINT before_discount;
+```
+
+## Isolation Levels
+
+PostgreSQL supports four isolation levels. The default is `READ COMMITTED`.
+
+| Level | Dirty Read | Non-Repeatable Read | Phantom Read |
+|---|---|---|---|
+| READ UNCOMMITTED | Impossible* | Possible | Possible |
+| READ COMMITTED (default) | Impossible | Possible | Possible |
+| REPEATABLE READ | Impossible | Impossible | Impossible* |
+| SERIALIZABLE | Impossible | Impossible | Impossible |
+
+*PostgreSQL never allows dirty reads, even at READ UNCOMMITTED. Its REPEATABLE READ also prevents phantom reads in practice.
+
+Set isolation level for a transaction:
+
+```sql
+BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+
+SELECT balance FROM accounts WHERE account_id = 1;
+-- Another transaction cannot modify account_id = 1 until this commits or rolls back
+UPDATE accounts SET balance = balance - 100 WHERE account_id = 1;
+
+COMMIT;
+```
+
+### When to Use Higher Isolation
+
+- **REPEATABLE READ** -- Financial calculations where you read a value and write back a derived value. Prevents another transaction from changing the value between your read and write.
+- **SERIALIZABLE** -- Full serial safety. Use for complex multi-step workflows where concurrent transactions touching the same rows could produce incorrect results. Comes with performance overhead and the possibility of serialization failures that require retry.
+
+## Transaction Status in psql
+
+```sql
+-- Check current transaction status
+SELECT txid_current();
+
+-- Check if currently in a transaction
+SELECT current_setting('transaction_isolation');
+```
+
+## Common Patterns
+
+### Error Handling (in PL/pgSQL)
+
+```sql
+DO $$
+BEGIN
+  BEGIN
+    UPDATE accounts SET balance = balance - 500 WHERE account_id = 1;
+    UPDATE accounts SET balance = balance + 500 WHERE account_id = 2;
+  EXCEPTION
+    WHEN OTHERS THEN
+      RAISE NOTICE 'Transfer failed: %', SQLERRM;
+      ROLLBACK;
+      RETURN;
+  END;
+  COMMIT;
+END $$;
+```
+
+### Long-running Operations with Savepoints
+
+When processing large batches, use savepoints to checkpoint progress and recover from individual failures without losing all completed work:
+
+```sql
+BEGIN;
+
+DO $$
+DECLARE
+  r RECORD;
+  batch_size INT := 1000;
+  processed INT := 0;
+BEGIN
+  FOR r IN SELECT id FROM large_table ORDER BY id LOOP
+    -- Process each row
+    UPDATE large_table SET processed = TRUE WHERE id = r.id;
+
+    processed := processed + 1;
+
+    IF processed % batch_size = 0 THEN
+      -- Checkpoint every 1000 rows
+      RELEASE SAVEPOINT checkpoint;
+      SAVEPOINT checkpoint;
+    END IF;
+  END LOOP;
+END $$;
+
+COMMIT;
+```
+
+## Common Mistakes
+
+**Forgetting to ROLLBACK after an error:** In psql or application code, after an error mid-transaction, you must explicitly `ROLLBACK` before the connection can accept new transactions.
+
+**Long-held transactions:** A transaction that stays open holds locks and prevents VACUUM from cleaning up dead rows. Keep transactions as short as possible. Avoid user interaction (e.g. waiting for input) inside a transaction.
+
+**Assuming autocommit in drivers:** Most PostgreSQL drivers (psycopg2, pg, etc.) operate in autocommit mode by default, meaning each statement is its own transaction. To use explicit transactions, you typically call `connection.autocommit = False` or use a context manager.
+
+---
+
+Mako connects to PostgreSQL with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/postgresql/upsert-on-conflict.mdx
+++ b/content/guides/postgresql/upsert-on-conflict.mdx
@@ -1,0 +1,161 @@
+---
+title: "PostgreSQL UPSERT: INSERT ON CONFLICT Explained"
+description: "Learn how to use PostgreSQL's INSERT ON CONFLICT to upsert data -- insert new rows or update existing ones atomically, with examples covering DO NOTHING, DO UPDATE, and partial indexes."
+database: "postgresql"
+category: "sql-how-to"
+tags: ["postgresql", "sql", "upsert", "insert", "data-engineering"]
+date: "2026-04-16"
+---
+
+# PostgreSQL UPSERT: INSERT ON CONFLICT Explained
+
+UPSERT -- insert or update -- is a common operation in data pipelines: you want to insert a new row if it doesn't exist, or update it if it does. PostgreSQL handles this with `INSERT ... ON CONFLICT`, introduced in PostgreSQL 9.5. It's atomic, which means no race conditions between the check and the write.
+
+## Basic Syntax
+
+```sql
+INSERT INTO table_name (column1, column2, ...)
+VALUES (value1, value2, ...)
+ON CONFLICT (conflict_target)
+DO UPDATE SET column1 = excluded.column1, ...;
+```
+
+The `conflict_target` specifies which unique constraint or index to check. The special `EXCLUDED` table refers to the row that was proposed for insertion.
+
+## DO NOTHING
+
+If you just want to silently skip conflicts without any update:
+
+```sql
+INSERT INTO products (sku, name, price)
+VALUES ('ABC-123', 'Widget', 9.99)
+ON CONFLICT (sku) DO NOTHING;
+```
+
+No error is raised and no changes are made if a row with `sku = 'ABC-123'` already exists.
+
+## DO UPDATE (Standard Upsert)
+
+Update the existing row when a conflict occurs:
+
+```sql
+INSERT INTO products (sku, name, price, updated_at)
+VALUES ('ABC-123', 'Widget Pro', 12.99, NOW())
+ON CONFLICT (sku)
+DO UPDATE SET
+  name = EXCLUDED.name,
+  price = EXCLUDED.price,
+  updated_at = EXCLUDED.updated_at;
+```
+
+`EXCLUDED.name` refers to the value that was proposed in the `INSERT` -- in this case, `'Widget Pro'`.
+
+## Updating Only Some Columns
+
+You don't have to update everything. Keep fields like `created_at` immutable:
+
+```sql
+INSERT INTO users (email, name, created_at)
+VALUES ('alice@example.com', 'Alice', NOW())
+ON CONFLICT (email)
+DO UPDATE SET
+  name = EXCLUDED.name;
+  -- created_at is left unchanged
+```
+
+## Conditional Updates with WHERE
+
+Add a `WHERE` clause to the `DO UPDATE` to make the update conditional:
+
+```sql
+INSERT INTO products (sku, name, price)
+VALUES ('ABC-123', 'Widget Pro', 12.99)
+ON CONFLICT (sku)
+DO UPDATE SET
+  price = EXCLUDED.price
+WHERE products.price <> EXCLUDED.price;
+-- Only updates if the price actually changed
+```
+
+This avoids unnecessary write amplification, which matters for heavily indexed tables.
+
+## Conflict on Multiple Columns
+
+When your unique constraint spans multiple columns, list all of them in the conflict target:
+
+```sql
+-- Table has UNIQUE(user_id, product_id)
+INSERT INTO favorites (user_id, product_id, added_at)
+VALUES (42, 101, NOW())
+ON CONFLICT (user_id, product_id)
+DO UPDATE SET added_at = EXCLUDED.added_at;
+```
+
+## Using ON CONFLICT ON CONSTRAINT
+
+If the constraint has a name, you can reference it directly:
+
+```sql
+INSERT INTO products (sku, name, price)
+VALUES ('ABC-123', 'Widget', 9.99)
+ON CONFLICT ON CONSTRAINT products_sku_key
+DO NOTHING;
+```
+
+## Bulk Upsert
+
+`INSERT ... ON CONFLICT` works with multi-row inserts:
+
+```sql
+INSERT INTO products (sku, name, price)
+VALUES
+  ('A-001', 'Gadget Alpha', 19.99),
+  ('A-002', 'Gadget Beta', 24.99),
+  ('A-003', 'Gadget Gamma', 29.99)
+ON CONFLICT (sku)
+DO UPDATE SET
+  name = EXCLUDED.name,
+  price = EXCLUDED.price;
+```
+
+This is the preferred pattern for data sync pipelines -- stage your data in one round trip.
+
+## Partial Index Conflicts
+
+If your unique constraint is on a partial index, the conflict target must match the index:
+
+```sql
+-- Unique index: only active products have unique SKUs
+CREATE UNIQUE INDEX products_sku_active ON products (sku) WHERE active = TRUE;
+
+INSERT INTO products (sku, name, price, active)
+VALUES ('ABC-123', 'Widget', 9.99, TRUE)
+ON CONFLICT (sku) WHERE active = TRUE
+DO UPDATE SET price = EXCLUDED.price;
+```
+
+## Returning Updated Rows
+
+Chain `RETURNING` to get back the affected rows:
+
+```sql
+INSERT INTO products (sku, name, price)
+VALUES ('ABC-123', 'Widget', 9.99)
+ON CONFLICT (sku)
+DO UPDATE SET price = EXCLUDED.price
+RETURNING id, sku, price, (xmax = 0) AS was_inserted;
+```
+
+`xmax = 0` is a PostgreSQL trick: a transaction ID of 0 means the row was newly inserted; non-zero means it was updated.
+
+## Common Mistakes
+
+**No unique constraint on the conflict column:** `ON CONFLICT (sku)` requires a unique index or constraint on `sku`. Without one, PostgreSQL raises an error.
+
+**Referencing the wrong table in DO UPDATE:** `SET price = products.price` sets the column to its own current value (a no-op). Use `EXCLUDED.price` to reference the proposed new value.
+
+**Race conditions with DO NOTHING:** `DO NOTHING` is safe against duplicate key errors but does not guarantee the most recent value wins. If two concurrent sessions upsert the same row, one will succeed and one will silently skip. Use `DO UPDATE` if you need last-write-wins semantics.
+
+---
+
+Mako connects to PostgreSQL with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/postgresql/views-guide.mdx
+++ b/content/guides/postgresql/views-guide.mdx
@@ -1,0 +1,203 @@
+---
+title: "PostgreSQL Views and Materialized Views: A Complete Guide"
+description: "Learn how to create and use regular views and materialized views in PostgreSQL, when to use each, and how to manage refresh strategies."
+database: "postgresql"
+category: "sql-how-to"
+tags: ["postgresql", "sql", "views", "materialized-views", "data-engineering"]
+date: "2026-04-16"
+---
+
+# PostgreSQL Views and Materialized Views: A Complete Guide
+
+PostgreSQL has two types of views: regular views, which are saved queries that execute at runtime, and materialized views, which store the query results physically and must be refreshed. Each solves a different problem.
+
+## Regular Views
+
+A view is a named query stored in the database. It behaves like a table in `SELECT` statements but contains no data itself -- every query against a view re-executes the underlying SQL.
+
+### Creating a View
+
+```sql
+CREATE VIEW active_customers AS
+SELECT
+  customer_id,
+  name,
+  email,
+  created_at
+FROM customers
+WHERE status = 'active';
+```
+
+Query it like a table:
+
+```sql
+SELECT * FROM active_customers WHERE created_at > '2025-01-01';
+```
+
+### Updating a View
+
+```sql
+CREATE OR REPLACE VIEW active_customers AS
+SELECT
+  customer_id,
+  name,
+  email,
+  created_at,
+  country
+FROM customers
+WHERE status = 'active';
+```
+
+`CREATE OR REPLACE` preserves existing permissions. You can only add columns or change the query body -- you cannot remove columns or change data types with this syntax. For structural changes, drop and recreate.
+
+### Dropping a View
+
+```sql
+DROP VIEW active_customers;
+-- Or, to avoid error if it doesn't exist:
+DROP VIEW IF EXISTS active_customers;
+-- To also drop dependent objects:
+DROP VIEW active_customers CASCADE;
+```
+
+### Updatable Views
+
+Simple views -- those based on a single table with no aggregation, DISTINCT, LIMIT, UNION, or window functions -- are automatically updatable in PostgreSQL. This means you can `INSERT`, `UPDATE`, and `DELETE` through them:
+
+```sql
+UPDATE active_customers SET email = 'new@example.com' WHERE customer_id = 42;
+```
+
+For complex views, use `INSTEAD OF` triggers to handle DML operations.
+
+## Materialized Views
+
+A materialized view stores the query result on disk. Queries against it read cached data, not the source tables. You must explicitly refresh it to pick up new data.
+
+### Creating a Materialized View
+
+```sql
+CREATE MATERIALIZED VIEW monthly_revenue AS
+SELECT
+  date_trunc('month', created_at) AS month,
+  SUM(amount) AS revenue,
+  COUNT(*) AS order_count
+FROM orders
+GROUP BY 1;
+```
+
+### Querying a Materialized View
+
+```sql
+SELECT * FROM monthly_revenue ORDER BY month DESC LIMIT 12;
+```
+
+The query hits the materialized cache, not the underlying `orders` table.
+
+### Refreshing
+
+```sql
+-- Locks the view for reads during refresh (data unavailable during update)
+REFRESH MATERIALIZED VIEW monthly_revenue;
+
+-- Non-blocking: old data remains readable while refresh runs
+-- Requires a UNIQUE index on the view
+REFRESH MATERIALIZED VIEW CONCURRENTLY monthly_revenue;
+```
+
+For `CONCURRENTLY` to work, you need at least one unique index on the view:
+
+```sql
+CREATE UNIQUE INDEX ON monthly_revenue (month);
+```
+
+### Dropping a Materialized View
+
+```sql
+DROP MATERIALIZED VIEW monthly_revenue;
+```
+
+## Regular Views vs Materialized Views
+
+| Characteristic | Regular View | Materialized View |
+|---|---|---|
+| Data freshness | Always current | As of last refresh |
+| Query speed | Depends on base tables | Fast (cached) |
+| Storage | None | Yes (disk space) |
+| Write-through | Possible (simple views) | No |
+| Maintenance | None | Requires REFRESH |
+| Use case | Simplification, security | Heavy aggregations, reporting |
+
+## Common Patterns
+
+### Automatic Refresh with pg_cron
+
+If you have `pg_cron` installed:
+
+```sql
+SELECT cron.schedule('refresh-monthly-revenue', '0 3 * * *',
+  'REFRESH MATERIALIZED VIEW CONCURRENTLY monthly_revenue');
+```
+
+### Conditional Refresh
+
+Track when source data last changed and only refresh if needed:
+
+```sql
+DO $$
+DECLARE
+  last_refresh TIMESTAMP;
+  latest_order TIMESTAMP;
+BEGIN
+  SELECT MAX(created_at) INTO latest_order FROM orders;
+  SELECT last_value INTO last_refresh FROM pg_matviews WHERE matviewname = 'monthly_revenue';
+
+  IF latest_order > last_refresh THEN
+    REFRESH MATERIALIZED VIEW CONCURRENTLY monthly_revenue;
+  END IF;
+END $$;
+```
+
+### Views for Security
+
+Views can expose a subset of columns, hiding sensitive fields:
+
+```sql
+CREATE VIEW public_users AS
+SELECT user_id, username, created_at
+FROM users;
+-- Hides: email, password_hash, last_login_ip
+```
+
+Grant access to the view without exposing the underlying table:
+
+```sql
+GRANT SELECT ON public_users TO reporting_role;
+```
+
+## Inspecting Views
+
+```sql
+-- List all regular views
+SELECT viewname, definition FROM pg_views WHERE schemaname = 'public';
+
+-- List all materialized views and last refresh
+SELECT matviewname, ispopulated FROM pg_matviews WHERE schemaname = 'public';
+
+-- Check when a materialized view was last refreshed
+SELECT schemaname, matviewname, last_value
+FROM pg_matviews
+WHERE matviewname = 'monthly_revenue';
+```
+
+## Common Mistakes
+
+**Forgetting `CONCURRENTLY` on busy tables:** A regular `REFRESH` locks the view for readers. If your reporting dashboard queries the view, it will block until refresh completes. Always use `CONCURRENTLY` in production with a unique index.
+
+**Stale data in CI/testing:** Materialized views don't auto-update. If your tests insert data and immediately query a materialized view, they'll see stale data unless you refresh.
+
+**Cascading drops:** `DROP TABLE orders` will fail if `monthly_revenue` depends on it. Use `CASCADE` with care -- it will drop the dependent view too.
+
+---
+
+Mako connects to PostgreSQL with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).


### PR DESCRIPTION
## Batch 5: PostgreSQL SQL How-tos -- Complete

This PR completes Batch 5 (all 20 PostgreSQL how-to guides).

### Articles added (10)

- `subqueries` -- scalar, correlated, EXISTS/NOT EXISTS, IN vs EXISTS, ANY/ALL, NULL pitfalls
- `views-guide` -- regular views vs materialized views, REFRESH CONCURRENTLY, security patterns
- `transactions-explained` -- ACID, BEGIN/COMMIT/ROLLBACK, savepoints, isolation levels
- `array-operations` -- array type, operators (@>, &&), unnest, array_agg, GIN indexing
- `upsert-on-conflict` -- INSERT ON CONFLICT DO NOTHING/UPDATE, EXCLUDED table, conditional updates
- `explain-analyze` -- reading plan nodes, cost fields, buffer stats, diagnosing seq scans and sort spills
- `partitioning` -- range/list/hash declarative partitioning, partition pruning, pg_partman
- `recursive-queries` -- WITH RECURSIVE, org charts, bill-of-materials, cycle detection, CYCLE clause (PG14+)
- `lateral-joins` -- LATERAL vs correlated subquery, top-N per group, point-in-time lookups
- `generated-columns` -- STORED (PG12+) and VIRTUAL (PG18+) generated columns, use cases, limitations

### Previous batch
PR #334 (merged) covered: window-functions, cte, json-queries, indexes-explained, joins-guide, pivot-table, full-text-search, date-functions, string-functions, aggregate-functions.

### Next
Batch 6: MySQL SQL how-to guides (mirror of Batch 5).