### PR TITLE
fix: redesign CDC materialization to single-source scheduling with singleton execution

### DIFF
--- a/api/src/inngest/functions/webhook-flow.ts
+++ b/api/src/inngest/functions/webhook-flow.ts
@@ -935,32 +935,6 @@ export const webhookEventProcessCdcFunction = inngest.createFunction(
       };
     });
 
-    const typedResult = result as {
-      processed: boolean;
-      count: number;
-      workspaceId?: string;
-      entities?: string[];
-    } | null;
-
-    if (
-      typedResult?.processed &&
-      typedResult.count > 0 &&
-      typedResult.entities?.length
-    ) {
-      await step.sendEvent(
-        "trigger-inline-materialize",
-        typedResult.entities.map(entity => ({
-          name: "cdc/materialize" as const,
-          data: {
-            workspaceId: typedResult.workspaceId!,
-            flowId,
-            entity,
-            force: false,
-          },
-        })),
-      );
-    }
-
     return { success: true, ...result };
   },
 );
@@ -1274,6 +1248,7 @@ export const cdcMaterializeFunction = inngest.createFunction(
   {
     id: "cdc-materialize",
     name: "CDC Materialize",
+    retries: 0,
     singleton: {
       key: "event.data.flowId + ':' + event.data.entity",
       mode: "skip",
@@ -1289,13 +1264,74 @@ export const cdcMaterializeFunction = inngest.createFunction(
   },
 );
 
+async function findStaleEntities(): Promise<
+  Array<{
+    workspaceId: { toString(): string };
+    flowId: { toString(): string };
+    entity: string;
+  }>
+> {
+  const staleThreshold = new Date(Date.now() - 20_000);
+
+  const candidates = await CdcEntityState.find({
+    $expr: { $gt: ["$lastIngestSeq", "$lastMaterializedSeq"] },
+    $or: [
+      { lastMaterializedAt: { $exists: false } },
+      { lastMaterializedAt: { $lt: staleThreshold } },
+    ],
+  })
+    .select("workspaceId flowId entity consecutiveFailures lastFailedAt")
+    .lean();
+
+  if (candidates.length === 0) {
+    return [];
+  }
+
+  const now = Date.now();
+  const eligible = candidates.filter(c => {
+    const failures = (c as any).consecutiveFailures || 0;
+    if (failures === 0) return true;
+    const lastFailed = (c as any).lastFailedAt
+      ? new Date((c as any).lastFailedAt).getTime()
+      : 0;
+    return now - lastFailed >= circuitBreakerBackoffMs(failures);
+  });
+
+  const flowIds = Array.from(new Set(eligible.map(c => c.flowId.toString())));
+  if (flowIds.length === 0) return [];
+  const existingFlows = await Flow.find({ _id: { $in: flowIds } })
+    .select("_id")
+    .lean();
+  const existingFlowIdSet = new Set(existingFlows.map(f => f._id.toString()));
+
+  return eligible.filter(c => existingFlowIdSet.has(c.flowId.toString()));
+}
+
+function buildMaterializeEvents(
+  entities: Array<{
+    workspaceId: { toString(): string };
+    flowId: { toString(): string };
+    entity: string;
+  }>,
+) {
+  return entities.map(e => ({
+    name: "cdc/materialize" as const,
+    data: {
+      workspaceId: String(e.workspaceId),
+      flowId: String(e.flowId),
+      entity: e.entity,
+      force: false,
+    },
+  }));
+}
+
 /**
- * Safety-net scheduler that finds entities with un-materialized CDC events
- * and emits one cdc/materialize per stale (flowId, entity) pair.
+ * Sole trigger for CDC materialization. Runs every minute with two passes
+ * (30s apart) to keep worst-case latency under 60s.
  *
- * Primary materialization is triggered inline after CDC ingest. This
- * scheduler catches any entities missed by the inline trigger or delayed
- * by transient failures. Fires every minute with a 20 s staleness window.
+ * Webhook ingest writes to the event store; this scheduler detects stale
+ * entities (lastIngestSeq > lastMaterializedSeq) and emits cdc/materialize
+ * events. The singleton on cdc-materialize deduplicates concurrent triggers.
  */
 export const cdcMaterializeSchedulerFunction = inngest.createFunction(
   {
@@ -1304,76 +1340,52 @@ export const cdcMaterializeSchedulerFunction = inngest.createFunction(
   },
   { cron: "*/1 * * * *" },
   async ({ step, logger }) => {
-    const staleEntities = await step.run("find-stale-entities", async () => {
-      // Skip entities materialized within the last 20 s — they already have
-      // a queued or throttled run and re-emitting is pure waste.
-      const staleThreshold = new Date(Date.now() - 20_000);
+    let totalTriggered = 0;
 
-      const candidates = await CdcEntityState.find({
-        $expr: { $gt: ["$lastIngestSeq", "$lastMaterializedSeq"] },
-        $or: [
-          { lastMaterializedAt: { $exists: false } },
-          { lastMaterializedAt: { $lt: staleThreshold } },
-        ],
-      })
-        .select("workspaceId flowId entity consecutiveFailures lastFailedAt")
-        .lean();
-
-      if (candidates.length === 0) {
-        return [];
-      }
-
-      const now = Date.now();
-      const eligible = candidates.filter(c => {
-        const failures = (c as any).consecutiveFailures || 0;
-        if (failures === 0) return true;
-        const lastFailed = (c as any).lastFailedAt
-          ? new Date((c as any).lastFailedAt).getTime()
-          : 0;
-        return now - lastFailed >= circuitBreakerBackoffMs(failures);
-      });
-
-      const flowIds = Array.from(
-        new Set(eligible.map(c => c.flowId.toString())),
-      );
-      if (flowIds.length === 0) return [];
-      const existingFlows = await Flow.find({ _id: { $in: flowIds } })
-        .select("_id")
-        .lean();
-      const existingFlowIdSet = new Set(
-        existingFlows.map(f => f._id.toString()),
-      );
-
-      return eligible.filter(c => existingFlowIdSet.has(c.flowId.toString()));
-    });
-
-    const entities = staleEntities as Array<{
+    const pass1 = (await step.run(
+      "find-stale-entities-1",
+      findStaleEntities,
+    )) as Array<{
       workspaceId: { toString(): string };
       flowId: { toString(): string };
       entity: string;
     }>;
 
-    if (!entities || entities.length === 0) {
-      return { triggered: 0 };
+    if (pass1.length > 0) {
+      await step.sendEvent(
+        "trigger-materializations-1",
+        buildMaterializeEvents(pass1),
+      );
+      totalTriggered += pass1.length;
     }
 
-    await step.sendEvent(
-      "trigger-stale-materializations",
-      entities.map(e => ({
-        name: "cdc/materialize" as const,
-        data: {
-          workspaceId: String(e.workspaceId),
-          flowId: String(e.flowId),
-          entity: e.entity,
-          force: false,
-        },
-      })),
-    );
+    await step.sleep("second-pass-delay", "30s");
 
-    logger.info("CDC materialize scheduler triggered", {
-      triggered: entities.length,
-    });
+    const pass2 = (await step.run(
+      "find-stale-entities-2",
+      findStaleEntities,
+    )) as Array<{
+      workspaceId: { toString(): string };
+      flowId: { toString(): string };
+      entity: string;
+    }>;
 
-    return { triggered: entities.length };
+    if (pass2.length > 0) {
+      await step.sendEvent(
+        "trigger-materializations-2",
+        buildMaterializeEvents(pass2),
+      );
+      totalTriggered += pass2.length;
+    }
+
+    if (totalTriggered > 0) {
+      logger.info("CDC materialize scheduler completed", {
+        pass1: pass1.length,
+        pass2: pass2.length,
+        totalTriggered,
+      });
+    }
+
+    return { triggered: totalTriggered };
   },
 );

--- a/api/src/sync-cdc/adapters/bigquery.ts
+++ b/api/src/sync-cdc/adapters/bigquery.ts
@@ -802,7 +802,7 @@ export class BigQueryDestinationAdapter implements CdcDestinationAdapter {
           .table(stagingTable)
           .load(parquetPath, {
             sourceFormat: "PARQUET",
-            writeDisposition: "WRITE_APPEND",
+            writeDisposition: "WRITE_TRUNCATE",
             schemaUpdateOptions: ["ALLOW_FIELD_ADDITION"],
           });
 


### PR DESCRIPTION
## Summary

- Replace the competing-producers architecture (inline triggers + scheduler + self-continuation all emitting `cdc/materialize` events) with a **single-source scheduler** pattern
- Scheduler is now the **sole trigger** for materialization — runs two passes per minute (30s apart) for <60s worst-case latency
- Replace `concurrency:1` + `throttle:5s` with **`singleton: { mode: "skip" }`** — only one run per `(flowId, entity)` at a time, duplicates silently dropped
- Replace self-continuation (`step.sendEvent`) with an **internal drain loop** (up to 20 iterations x 15k events = 300k per run)
- Set `retries: 0` — circuit breaker + scheduler handle failure recovery instead of Inngest retry storms
- Change BigQuery staging table write from `WRITE_APPEND` to `WRITE_TRUNCATE` to fix a latent race condition causing "Table not found" errors

**Root cause:** Three uncoordinated event sources flooding a single-consumer Inngest queue caused 16h+ pending runs. No flow control primitive could deduplicate intent across producers — the fix is to have only one producer.

## Test plan

- [ ] Verify `cdc-materialize` registers with singleton config in Inngest dev server
- [ ] Send webhook events to a CDC flow and confirm materialization starts within ~30-60s (scheduler-driven)
- [ ] Confirm duplicate `cdc/materialize` events are skipped when a run is active
- [ ] Simulate a large backlog (>15k events) and verify the drain loop processes multiple iterations
- [ ] Verify circuit breaker prevents retry storms on persistent errors (e.g. missing BigQuery table)
- [ ] Confirm no "staging table not found" errors with WRITE_TRUNCATE

Made with [Cursor](https://cursor.com)