### PR TITLE
fix: revert BigQuery staging write disposition to WRITE_APPEND

### DIFF
--- a/api/src/sync-cdc/adapters/bigquery.ts
+++ b/api/src/sync-cdc/adapters/bigquery.ts
@@ -802,7 +802,7 @@ export class BigQueryDestinationAdapter implements CdcDestinationAdapter {
           .table(stagingTable)
           .load(parquetPath, {
             sourceFormat: "PARQUET",
-            writeDisposition: "WRITE_TRUNCATE",
+            writeDisposition: "WRITE_APPEND",
             schemaUpdateOptions: ["ALLOW_FIELD_ADDITION"],
           });
 


### PR DESCRIPTION
## Summary

- Reverts `WRITE_TRUNCATE` back to `WRITE_APPEND` in `loadParquetToStaging` (BigQuery adapter)
- `WRITE_TRUNCATE` was incorrectly introduced in #338 and is incompatible with `schemaUpdateOptions: ["ALLOW_FIELD_ADDITION"]`, causing runtime errors: *"Schema update options should only be specified with WRITE_APPEND disposition"*
- The staging table race condition that motivated the change is already prevented by the `singleton` execution mode on `cdcMaterializeFunction` (merged in #338), which ensures only one materialization run per entity at a time

## Test plan

- [ ] Verify CDC materialization completes without BigQuery schema errors
- [ ] Verify backfill bulk flush (which appends multiple batches to staging) still works correctly
- [ ] Confirm no "Table not found" staging table races occur (singleton prevents this)

Made with [Cursor](https://cursor.com)