### PR TITLE
fix: use unique staging tables to prevent CDC materialization race

### DIFF
--- a/api/src/sync-cdc/adapters/bigquery.ts
+++ b/api/src/sync-cdc/adapters/bigquery.ts
@@ -855,6 +855,7 @@ export class BigQueryDestinationAdapter implements CdcDestinationAdapter {
     if (params.records.length === 0) return { written: 0 };
 
     const flowId = String(params.flow._id);
+    const stagingSuffix = `stg_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 
     await this.ensureDataset();
 
@@ -870,6 +871,7 @@ export class BigQueryDestinationAdapter implements CdcDestinationAdapter {
       rows: params.records.length,
       parquetBytes: parquet.byteSize,
       flowId,
+      stagingSuffix,
     });
 
     try {
@@ -877,21 +879,26 @@ export class BigQueryDestinationAdapter implements CdcDestinationAdapter {
         parquet.filePath,
         params.layout,
         flowId,
+        { stagingSuffix },
       );
       await this.mergeFromStaging(
         params.layout,
         params.flow,
         flowId,
         params.entitySchema,
+        { stagingSuffix },
       );
     } finally {
-      await this.cleanupStaging(params.layout, flowId).catch(err => {
-        log.warn("Failed to cleanup CDC staging table", {
-          flowId,
-          table: params.layout.tableName,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      });
+      await this.cleanupStaging(params.layout, flowId, { stagingSuffix }).catch(
+        err => {
+          log.warn("Failed to cleanup CDC staging table", {
+            flowId,
+            table: params.layout.tableName,
+            stagingSuffix,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        },
+      );
     }
 
     return { written: params.records.length };

--- a/api/src/sync-cdc/adapters/bigquery.ts
+++ b/api/src/sync-cdc/adapters/bigquery.ts
@@ -802,7 +802,7 @@ export class BigQueryDestinationAdapter implements CdcDestinationAdapter {
           .table(stagingTable)
           .load(parquetPath, {
             sourceFormat: "PARQUET",
-            writeDisposition: "WRITE_TRUNCATE",
+            writeDisposition: "WRITE_APPEND",
             schemaUpdateOptions: ["ALLOW_FIELD_ADDITION"],
           });
 

--- a/api/src/sync-cdc/adapters/clickhouse.ts
+++ b/api/src/sync-cdc/adapters/clickhouse.ts
@@ -527,6 +527,7 @@ export class ClickHouseDestinationAdapter implements CdcDestinationAdapter {
     entitySchema?: ConnectorEntitySchema;
   }): Promise<{ written: number }> {
     const flowId = String(params.flow._id);
+    const stagingSuffix = `stg_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
     const parquet = await buildParquetFromBatches({
       filenameBase: `cdc-${params.layout.entity}`,
       streamBatches: async insertBatch => {
@@ -539,19 +540,23 @@ export class ClickHouseDestinationAdapter implements CdcDestinationAdapter {
         parquet.filePath,
         params.layout,
         flowId,
+        { stagingSuffix },
       );
       await this.mergeFromStaging(
         params.layout,
         params.flow,
         flowId,
         params.entitySchema,
+        { stagingSuffix },
       );
     } finally {
-      await this.cleanupStaging(params.layout, flowId).catch(err => {
-        log.warn("Failed to cleanup staging after writeViaParquet", {
-          error: err instanceof Error ? err.message : String(err),
-        });
-      });
+      await this.cleanupStaging(params.layout, flowId, { stagingSuffix }).catch(
+        err => {
+          log.warn("Failed to cleanup staging after writeViaParquet", {
+            error: err instanceof Error ? err.message : String(err),
+          });
+        },
+      );
     }
 
     return { written: params.records.length };


### PR DESCRIPTION
## Summary

- Each `writeViaParquet` call now generates a unique staging table suffix (e.g. `stg_m1abc_x9y2z3`), so concurrent or overlapping CDC materialization runs never share the same staging table
- This eliminates the `Not found: Table ...staging was not found` errors where one run's `cleanupStaging` drops the table while another is still in `mergeStagingToLive`
- Applies to both BigQuery and ClickHouse adapters
- The backfill path is unaffected — it uses its own `backfill_staging` suffix

## Root cause

The staging table name was deterministic (`{table}__{flowToken}__staging`), so concurrent runs for the same flow+entity would all operate on the same table. When run A drops the staging table in its `finally` block, run B's `INSERT INTO ... FROM staging` fails with "table not found".

## Test plan

- [ ] Verify CDC materialization completes without "Table not found" errors
- [ ] Verify staging tables are cleaned up after each run (no orphaned `stg_*` tables accumulate)
- [ ] Verify backfill bulk flush still works correctly (uses separate `backfill_staging` suffix)

Made with [Cursor](https://cursor.com)