### PR TITLE
docs: MySQL SQL how-to guides batch 6 (1-10 of 20)

### DIFF
--- a/content/guides/mysql/aggregate-functions.mdx
+++ b/content/guides/mysql/aggregate-functions.mdx
@@ -1,0 +1,221 @@
+---
+title: "Aggregate Functions in MySQL"
+description: "How to use MySQL aggregate functions: COUNT, SUM, AVG, MIN, MAX, GROUP BY, HAVING, GROUP_CONCAT, and GROUP BY WITH ROLLUP for multi-level summaries."
+database: "mysql"
+category: "how-to"
+tags: ["mysql", "sql", "aggregate-functions", "group-by", "having", "rollup"]
+date: "2026-04-15"
+---
+
+Aggregate functions compute a single result from a set of rows. They're the foundation of reporting and analytics in MySQL: counting orders, summing revenue, finding the highest value, calculating averages across groups.
+
+## The Core Aggregates
+
+```sql
+SELECT
+  COUNT(*)              AS total_rows,
+  COUNT(amount)         AS non_null_amounts,
+  SUM(amount)           AS total_revenue,
+  AVG(amount)           AS average_order_value,
+  MIN(amount)           AS smallest_order,
+  MAX(amount)           AS largest_order
+FROM orders;
+```
+
+### COUNT(*) vs COUNT(column)
+
+`COUNT(*)` counts all rows including NULLs. `COUNT(column)` counts only non-NULL values in that column.
+
+```sql
+-- Table has 100 rows, but only 80 have a non-NULL discount
+SELECT COUNT(*), COUNT(discount) FROM orders;
+-- Returns: 100, 80
+```
+
+`COUNT(DISTINCT column)` counts distinct non-NULL values:
+
+```sql
+SELECT COUNT(DISTINCT customer_id) AS unique_customers FROM orders;
+```
+
+## GROUP BY
+
+`GROUP BY` divides rows into groups and applies the aggregate function to each group:
+
+```sql
+SELECT
+  department,
+  COUNT(*) AS headcount,
+  AVG(salary) AS avg_salary,
+  MAX(salary) AS max_salary
+FROM employees
+GROUP BY department;
+```
+
+You can group by multiple columns:
+
+```sql
+SELECT
+  department,
+  job_title,
+  COUNT(*) AS count,
+  AVG(salary) AS avg_salary
+FROM employees
+GROUP BY department, job_title
+ORDER BY department, avg_salary DESC;
+```
+
+### MySQL's Non-Standard GROUP BY Behavior
+
+By default, MySQL (with `sql_mode` not including `ONLY_FULL_GROUP_BY`) allows selecting columns that aren't in the `GROUP BY` clause or wrapped in an aggregate. Other databases (PostgreSQL, SQL Server) reject this.
+
+```sql
+-- This works in MySQL but not in strict mode or other databases
+SELECT department, name, MAX(salary) FROM employees GROUP BY department;
+-- 'name' is non-deterministic here
+```
+
+With `ONLY_FULL_GROUP_BY` mode (enabled by default in MySQL 5.7.5+), this throws an error. Write explicit aggregates for all non-grouped columns:
+
+```sql
+-- Correct: use ANY_VALUE() if non-determinism is acceptable
+SELECT department, ANY_VALUE(name), MAX(salary) FROM employees GROUP BY department;
+```
+
+## HAVING
+
+`WHERE` filters rows before aggregation. `HAVING` filters groups after aggregation:
+
+```sql
+-- Departments with more than 10 employees AND average salary over 70k
+SELECT department, COUNT(*) AS headcount, AVG(salary) AS avg_salary
+FROM employees
+GROUP BY department
+HAVING headcount > 10 AND avg_salary > 70000;
+```
+
+A common mistake is using `WHERE` for aggregate conditions -- that fails because aggregates aren't computed until after WHERE:
+
+```sql
+-- Wrong
+SELECT department, AVG(salary) FROM employees WHERE AVG(salary) > 70000 GROUP BY department;
+
+-- Right
+SELECT department, AVG(salary) FROM employees GROUP BY department HAVING AVG(salary) > 70000;
+```
+
+## Combining WHERE and HAVING
+
+Both can be used together: `WHERE` reduces the input rows, then `GROUP BY` groups them, then `HAVING` filters the groups:
+
+```sql
+-- Active employees only, departments with avg salary > 80k
+SELECT department, COUNT(*) AS headcount, AVG(salary) AS avg_salary
+FROM employees
+WHERE status = 'active'
+GROUP BY department
+HAVING avg_salary > 80000;
+```
+
+## GROUP BY WITH ROLLUP
+
+`WITH ROLLUP` adds subtotal rows at each level of grouping, then a grand total:
+
+```sql
+SELECT
+  department,
+  job_title,
+  SUM(salary) AS total_salary
+FROM employees
+GROUP BY department, job_title WITH ROLLUP;
+```
+
+This produces:
+- Rows for each `(department, job_title)` combination
+- A subtotal row per `department` (with NULL for `job_title`)
+- A grand total row (with NULL for both `department` and `job_title`)
+
+### Distinguishing Rollup NULLs from Real NULLs
+
+Use `GROUPING()` (MySQL 8.0.1+) to tell the difference:
+
+```sql
+SELECT
+  IF(GROUPING(department), 'ALL DEPARTMENTS', department) AS department,
+  IF(GROUPING(job_title),  'ALL TITLES', job_title)       AS job_title,
+  SUM(salary) AS total_salary
+FROM employees
+GROUP BY department, job_title WITH ROLLUP;
+```
+
+## GROUP_CONCAT
+
+Aggregates string values from multiple rows into a single delimited string:
+
+```sql
+SELECT
+  department,
+  GROUP_CONCAT(name ORDER BY name SEPARATOR ', ') AS team_members
+FROM employees
+GROUP BY department;
+```
+
+Combine with DISTINCT and a length limit:
+
+```sql
+SELECT
+  project_id,
+  GROUP_CONCAT(DISTINCT skill ORDER BY skill SEPARATOR ', ') AS required_skills
+FROM project_requirements
+GROUP BY project_id;
+```
+
+The default maximum output is 1024 characters. Increase for large groups:
+
+```sql
+SET SESSION group_concat_max_len = 65536;
+```
+
+## Conditional Aggregation
+
+Aggregate only a subset of rows using CASE or IF inside the aggregate:
+
+```sql
+SELECT
+  department,
+  COUNT(*) AS total,
+  SUM(CASE WHEN status = 'active' THEN 1 ELSE 0 END) AS active_count,
+  SUM(CASE WHEN status = 'inactive' THEN 1 ELSE 0 END) AS inactive_count,
+  AVG(CASE WHEN status = 'active' THEN salary END) AS active_avg_salary
+FROM employees
+GROUP BY department;
+```
+
+Note: `AVG(CASE WHEN ... THEN salary END)` correctly excludes NULLs from the average (only active employees count).
+
+## Execution Order
+
+Understanding the logical order helps write correct queries:
+
+1. `FROM` -- choose tables
+2. `WHERE` -- filter rows
+3. `GROUP BY` -- group remaining rows
+4. Aggregate functions -- compute per group
+5. `HAVING` -- filter groups
+6. `SELECT` -- compute output columns
+7. `ORDER BY` -- sort results
+8. `LIMIT` -- restrict output count
+
+This is why you can't use a SELECT alias in a HAVING clause in most databases (the alias is computed after HAVING). MySQL is more lenient about this, but don't rely on it for portability.
+
+## Common Mistakes
+
+**COUNT(*) vs COUNT(col)** -- if NULL values in a column represent missing data, use `COUNT(*)` for total rows and `COUNT(col)` for populated rows. Using the wrong one gives silently wrong numbers.
+
+**Filtering aggregates with WHERE instead of HAVING** -- causes an error in strict mode. Always use HAVING for aggregate conditions.
+
+**GROUP_CONCAT silent truncation** -- increase `group_concat_max_len` before running queries on large groups.
+
+**Non-deterministic SELECT columns with GROUP BY** -- in `ONLY_FULL_GROUP_BY` mode (default since 5.7.5), all selected columns must be in GROUP BY or wrapped in an aggregate. Use `ANY_VALUE()` if non-determinism is genuinely acceptable.
+
+Mako connects to MySQL and provides AI autocomplete for aggregate query syntax. Try it at [mako.ai](https://mako.ai).

--- a/content/guides/mysql/cte.mdx
+++ b/content/guides/mysql/cte.mdx
@@ -1,0 +1,225 @@
+---
+title: "Common Table Expressions (CTEs) in MySQL"
+description: "Learn how to use CTEs in MySQL 8.0+, including recursive CTEs for hierarchical data, multi-step queries, and version compatibility notes."
+database: "mysql"
+category: "how-to"
+tags: ["mysql", "sql", "cte", "with-clause", "recursive"]
+date: "2026-04-15"
+---
+
+A Common Table Expression (CTE) is a named temporary result set defined within a query using the `WITH` keyword. Think of it as a named subquery that you can reference one or more times inside the same statement.
+
+CTEs were introduced in **MySQL 8.0**. If you're on MySQL 5.7, you'll need to use derived tables (subqueries in FROM) instead.
+
+## Basic Syntax
+
+```sql
+WITH cte_name AS (
+  SELECT ...
+)
+SELECT * FROM cte_name;
+```
+
+A CTE lives only for the duration of the query that defines it. It's not stored anywhere.
+
+## Why Use CTEs?
+
+**Readability.** A deeply nested subquery is hard to follow. Breaking it into named steps makes intent obvious:
+
+```sql
+-- Without CTE
+SELECT dept, avg_salary
+FROM (
+  SELECT department AS dept, AVG(salary) AS avg_salary
+  FROM employees
+  WHERE active = 1
+  GROUP BY department
+) dept_avg
+WHERE avg_salary > 50000;
+
+-- With CTE
+WITH active_dept_avg AS (
+  SELECT department AS dept, AVG(salary) AS avg_salary
+  FROM employees
+  WHERE active = 1
+  GROUP BY department
+)
+SELECT dept, avg_salary
+FROM active_dept_avg
+WHERE avg_salary > 50000;
+```
+
+**Reuse.** Reference the CTE multiple times in the same query without repeating the subquery.
+
+```sql
+WITH monthly_revenue AS (
+  SELECT
+    DATE_FORMAT(order_date, '%Y-%m') AS month,
+    SUM(amount) AS revenue
+  FROM orders
+  GROUP BY month
+)
+SELECT
+  current.month,
+  current.revenue,
+  current.revenue - prev.revenue AS growth
+FROM monthly_revenue AS current
+LEFT JOIN monthly_revenue AS prev
+  ON prev.month = DATE_FORMAT(DATE_SUB(STR_TO_DATE(CONCAT(current.month, '-01'), '%Y-%m-%d'), INTERVAL 1 MONTH), '%Y-%m');
+```
+
+## Multiple CTEs
+
+Chain multiple CTEs by separating them with commas:
+
+```sql
+WITH
+  orders_this_year AS (
+    SELECT customer_id, SUM(amount) AS total
+    FROM orders
+    WHERE YEAR(order_date) = YEAR(CURDATE())
+    GROUP BY customer_id
+  ),
+  high_value_customers AS (
+    SELECT customer_id
+    FROM orders_this_year
+    WHERE total > 1000
+  )
+SELECT c.name, o.total
+FROM customers c
+JOIN orders_this_year o ON c.id = o.customer_id
+JOIN high_value_customers hvc ON c.id = hvc.customer_id;
+```
+
+## Recursive CTEs
+
+MySQL 8.0 supports recursive CTEs via `WITH RECURSIVE`. This is useful for hierarchical data -- org charts, bill of materials, category trees -- where the depth isn't known ahead of time.
+
+A recursive CTE has two parts connected by `UNION ALL`:
+1. **Anchor member**: the base case (returns the starting rows)
+2. **Recursive member**: references the CTE itself to generate additional rows
+
+```sql
+WITH RECURSIVE cte_name AS (
+  -- Anchor
+  SELECT ...
+  UNION ALL
+  -- Recursive member (references cte_name)
+  SELECT ... FROM cte_name WHERE <stop_condition>
+)
+SELECT * FROM cte_name;
+```
+
+### Example: Number Series
+
+```sql
+WITH RECURSIVE numbers AS (
+  SELECT 1 AS n
+  UNION ALL
+  SELECT n + 1 FROM numbers WHERE n < 10
+)
+SELECT n FROM numbers;
+-- Returns: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+```
+
+### Example: Org Chart Traversal
+
+```sql
+CREATE TABLE employees (
+  id INT PRIMARY KEY,
+  name VARCHAR(100),
+  manager_id INT
+);
+
+WITH RECURSIVE org_chart AS (
+  -- Anchor: start from the CEO (no manager)
+  SELECT id, name, manager_id, 0 AS depth, CAST(name AS CHAR(1000)) AS path
+  FROM employees
+  WHERE manager_id IS NULL
+
+  UNION ALL
+
+  -- Recursive: each employee whose manager is already in the CTE
+  SELECT e.id, e.name, e.manager_id, oc.depth + 1, CONCAT(oc.path, ' > ', e.name)
+  FROM employees e
+  JOIN org_chart oc ON e.manager_id = oc.id
+)
+SELECT depth, name, path
+FROM org_chart
+ORDER BY path;
+```
+
+### Example: Category Tree
+
+```sql
+WITH RECURSIVE category_tree AS (
+  SELECT id, name, parent_id, 1 AS level
+  FROM categories
+  WHERE parent_id IS NULL
+
+  UNION ALL
+
+  SELECT c.id, c.name, c.parent_id, ct.level + 1
+  FROM categories c
+  JOIN category_tree ct ON c.parent_id = ct.id
+)
+SELECT REPEAT('  ', level - 1) || name AS indented_name
+FROM category_tree
+ORDER BY level, name;
+```
+
+## Cycle Detection
+
+Recursive CTEs can loop infinitely if there's a cycle in your data (e.g., an employee who is their own manager). MySQL has a built-in recursion limit (`cte_max_recursion_depth`, default 1000) that will throw an error when hit. To detect cycles explicitly:
+
+```sql
+WITH RECURSIVE safe_traversal AS (
+  SELECT id, name, manager_id, CAST(id AS CHAR(1000)) AS visited_ids
+  FROM employees WHERE manager_id IS NULL
+
+  UNION ALL
+
+  SELECT e.id, e.name, e.manager_id, CONCAT(st.visited_ids, ',', e.id)
+  FROM employees e
+  JOIN safe_traversal st ON e.manager_id = st.id
+  WHERE FIND_IN_SET(e.id, st.visited_ids) = 0  -- stop if we've already seen this id
+)
+SELECT * FROM safe_traversal;
+```
+
+## CTEs vs. Derived Tables (MySQL 5.7 Workaround)
+
+If you're stuck on MySQL 5.7, replace a CTE with a derived table in the FROM clause:
+
+```sql
+-- CTE (MySQL 8.0+)
+WITH active_users AS (SELECT * FROM users WHERE active = 1)
+SELECT * FROM active_users WHERE country = 'US';
+
+-- Derived table (MySQL 5.7 compatible)
+SELECT * FROM (SELECT * FROM users WHERE active = 1) AS active_users
+WHERE country = 'US';
+```
+
+The main difference: derived tables can only be referenced once. For multiple references, you'd need to repeat the subquery, which CTEs avoid cleanly.
+
+## CTEs vs. Temporary Tables
+
+| | CTE | Temporary Table |
+|---|---|---|
+| Scope | Single query | Session duration |
+| Stored | No (computed inline) | Yes (in temp tablespace) |
+| Indexable | No | Yes (you can add indexes) |
+| Recursive | Yes | No |
+
+For large intermediate datasets that you query multiple times in different statements, a temporary table may perform better. For single-query complexity management, CTEs are the right tool.
+
+## Common Mistakes
+
+**MySQL version check** -- CTEs require 8.0+. Confirm with `SELECT VERSION();`. If on 5.7, you'll get a syntax error.
+
+**Referencing a CTE before defining it** -- CTEs are evaluated in order. A later CTE can reference an earlier one, but not vice versa.
+
+**Mutating data with CTEs** -- CTEs can be used in INSERT, UPDATE, and DELETE statements in MySQL, but the CTE itself is read-only.
+
+Mako connects to MySQL 8.0+ and supports multi-CTE queries with AI autocomplete. Try it at [mako.ai](https://mako.ai).

--- a/content/guides/mysql/date-functions.mdx
+++ b/content/guides/mysql/date-functions.mdx
@@ -1,0 +1,187 @@
+---
+title: "MySQL Date and Time Functions"
+description: "A practical guide to MySQL date functions: DATE_FORMAT, DATEDIFF, DATE_ADD, DATE_SUB, STR_TO_DATE, NOW, CURDATE, TIMESTAMPDIFF, and timezone handling."
+database: "mysql"
+category: "how-to"
+tags: ["mysql", "sql", "dates", "date-functions", "datetime"]
+date: "2026-04-15"
+---
+
+Date and time manipulation is a constant in real-world SQL. MySQL provides a comprehensive set of functions for formatting, calculating, converting, and filtering temporal data.
+
+## Getting the Current Date and Time
+
+```sql
+NOW()          -- '2026-04-15 21:00:00'  -- current datetime (server timezone)
+CURDATE()      -- '2026-04-15'           -- current date only
+CURTIME()      -- '21:00:00'             -- current time only
+UTC_TIMESTAMP() -- '2026-04-15 19:00:00' -- current UTC datetime
+UNIX_TIMESTAMP() -- 1744750800           -- current Unix timestamp (seconds since epoch)
+```
+
+`NOW()` and `SYSDATE()` look similar but behave differently in replicated or statement-based logging: `NOW()` returns the statement start time; `SYSDATE()` returns the current time at the moment of evaluation. Prefer `NOW()` for consistency.
+
+## Formatting Dates
+
+`DATE_FORMAT(date, format)` converts a date or datetime to a string using format specifiers:
+
+```sql
+SELECT DATE_FORMAT(NOW(), '%Y-%m-%d');          -- '2026-04-15'
+SELECT DATE_FORMAT(NOW(), '%d/%m/%Y');          -- '15/04/2026'
+SELECT DATE_FORMAT(NOW(), '%W, %M %d, %Y');     -- 'Wednesday, April 15, 2026'
+SELECT DATE_FORMAT(NOW(), '%Y-%m');             -- '2026-04' (year-month for grouping)
+SELECT DATE_FORMAT(NOW(), '%H:%i:%s');          -- '21:00:00'
+```
+
+Common format specifiers:
+
+| Specifier | Value |
+|-----------|-------|
+| `%Y` | 4-digit year |
+| `%m` | 2-digit month (01-12) |
+| `%d` | 2-digit day (01-31) |
+| `%H` | Hour (00-23) |
+| `%i` | Minutes (00-59) |
+| `%s` | Seconds (00-59) |
+| `%W` | Weekday name |
+| `%M` | Month name |
+
+## Extracting Date Parts
+
+```sql
+SELECT YEAR('2026-04-15');    -- 2026
+SELECT MONTH('2026-04-15');   -- 4
+SELECT DAY('2026-04-15');     -- 15
+SELECT HOUR('2026-04-15 21:00:00');   -- 21
+SELECT MINUTE('2026-04-15 21:30:45'); -- 30
+SELECT DAYOFWEEK('2026-04-15'); -- 4 (1=Sunday, 2=Monday, ..., 7=Saturday)
+SELECT DAYNAME('2026-04-15');   -- 'Wednesday'
+SELECT WEEK('2026-04-15');      -- 15 (week number of the year)
+SELECT QUARTER('2026-04-15');   -- 2
+```
+
+`EXTRACT` is the SQL standard equivalent:
+
+```sql
+SELECT EXTRACT(YEAR FROM '2026-04-15');  -- 2026
+SELECT EXTRACT(MONTH FROM '2026-04-15'); -- 4
+```
+
+## Date Arithmetic
+
+### DATE_ADD() and DATE_SUB()
+
+```sql
+SELECT DATE_ADD('2026-04-15', INTERVAL 7 DAY);    -- '2026-04-22'
+SELECT DATE_ADD('2026-04-15', INTERVAL 1 MONTH);  -- '2026-05-15'
+SELECT DATE_ADD('2026-04-15', INTERVAL 2 YEAR);   -- '2028-04-15'
+SELECT DATE_SUB('2026-04-15', INTERVAL 30 DAY);   -- '2026-03-16'
+SELECT DATE_ADD(NOW(), INTERVAL 6 HOUR);           -- 6 hours from now
+```
+
+The `+` and `-` operators also work for adding/subtracting intervals:
+
+```sql
+SELECT '2026-04-15' + INTERVAL 7 DAY;  -- '2026-04-22'
+```
+
+### DATEDIFF()
+
+Returns the number of days between two dates:
+
+```sql
+SELECT DATEDIFF('2026-12-31', '2026-04-15');  -- 260
+SELECT DATEDIFF(NOW(), created_at) AS days_old FROM orders;
+```
+
+Note: `DATEDIFF` always returns days. For other units, use `TIMESTAMPDIFF`.
+
+### TIMESTAMPDIFF()
+
+Calculates the difference in a specified unit:
+
+```sql
+SELECT TIMESTAMPDIFF(SECOND, '2026-04-15 09:00:00', '2026-04-15 21:00:00');  -- 43200
+SELECT TIMESTAMPDIFF(MINUTE, '2026-04-15 09:00:00', '2026-04-15 21:30:00');  -- 750
+SELECT TIMESTAMPDIFF(HOUR,   start_time, end_time) AS duration_hours FROM events;
+SELECT TIMESTAMPDIFF(MONTH,  signup_date, CURDATE()) AS months_as_customer FROM users;
+SELECT TIMESTAMPDIFF(YEAR,   birth_date, CURDATE()) AS age FROM people;
+```
+
+## Converting Strings to Dates
+
+`STR_TO_DATE(str, format)` parses a string into a DATE, TIME, or DATETIME value:
+
+```sql
+SELECT STR_TO_DATE('15/04/2026', '%d/%m/%Y');          -- '2026-04-15'
+SELECT STR_TO_DATE('April 15, 2026', '%M %d, %Y');     -- '2026-04-15'
+SELECT STR_TO_DATE('2026-04-15 21:00:00', '%Y-%m-%d %H:%i:%s'); -- datetime
+```
+
+This is essential when importing data where dates arrive in non-standard formats.
+
+```sql
+-- Convert on insert
+INSERT INTO events (name, event_date)
+VALUES ('Launch', STR_TO_DATE('15-Apr-2026', '%d-%b-%Y'));
+```
+
+## Truncating to Periods
+
+To group data by week, month, or year, truncate the date to the desired granularity:
+
+```sql
+-- Group by month
+SELECT DATE_FORMAT(order_date, '%Y-%m') AS month, COUNT(*) AS orders
+FROM orders
+GROUP BY month;
+
+-- Group by week (ISO week start = Monday)
+SELECT YEARWEEK(order_date, 3) AS iso_week, COUNT(*) AS orders
+FROM orders
+GROUP BY iso_week;
+
+-- Group by day
+SELECT DATE(created_at) AS day, SUM(amount) AS daily_revenue
+FROM orders
+GROUP BY day;
+```
+
+## Filtering by Date Ranges
+
+```sql
+-- Orders in the last 30 days
+SELECT * FROM orders WHERE order_date >= DATE_SUB(CURDATE(), INTERVAL 30 DAY);
+
+-- Orders this month
+SELECT * FROM orders
+WHERE YEAR(order_date) = YEAR(CURDATE())
+  AND MONTH(order_date) = MONTH(CURDATE());
+
+-- Between two dates
+SELECT * FROM orders WHERE order_date BETWEEN '2026-01-01' AND '2026-03-31';
+```
+
+**Index tip:** `WHERE YEAR(order_date) = 2026` prevents index usage because the function wraps the column. Rewrite as a range for better performance:
+
+```sql
+-- Index-friendly equivalent
+WHERE order_date >= '2026-01-01' AND order_date < '2027-01-01'
+```
+
+## Timezone Handling
+
+MySQL stores DATETIME values without timezone info. TIMESTAMP columns store UTC and convert to the session timezone on display.
+
+```sql
+-- Check current timezone
+SELECT @@global.time_zone, @@session.time_zone;
+
+-- Convert between timezones (requires timezone tables installed)
+SELECT CONVERT_TZ(NOW(), 'UTC', 'Europe/Paris');
+SELECT CONVERT_TZ(created_at, '+00:00', 'Europe/Berlin') FROM events;
+```
+
+If `CONVERT_TZ` returns NULL, the timezone tables aren't loaded. Load them with `mysql_tzinfo_to_sql` or use fixed offsets instead of named zones.
+
+Mako connects to MySQL and provides AI autocomplete for date function syntax. Try it at [mako.ai](https://mako.ai).

--- a/content/guides/mysql/full-text-search.mdx
+++ b/content/guides/mysql/full-text-search.mdx
@@ -1,0 +1,154 @@
+---
+title: "Full-Text Search in MySQL"
+description: "How to use MySQL FULLTEXT indexes and MATCH AGAINST for natural language search, boolean mode, and query expansion, with relevance scoring and gotchas."
+database: "mysql"
+category: "how-to"
+tags: ["mysql", "sql", "full-text-search", "fulltext", "match-against"]
+date: "2026-04-15"
+---
+
+MySQL's FULLTEXT search lets you search text columns for words and phrases much more efficiently than `LIKE '%term%'` -- which can't use indexes and scans every row.
+
+FULLTEXT indexes are available on `CHAR`, `VARCHAR`, and `TEXT` columns in InnoDB (MySQL 5.6+) and MyISAM tables.
+
+## Creating a FULLTEXT Index
+
+```sql
+CREATE TABLE articles (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  title VARCHAR(200),
+  body TEXT,
+  published_at DATE
+);
+
+-- Add FULLTEXT index on one or multiple columns
+ALTER TABLE articles ADD FULLTEXT INDEX ft_article (title, body);
+
+-- Or at table creation time
+CREATE TABLE posts (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  title VARCHAR(200),
+  content TEXT,
+  FULLTEXT(title, content)
+);
+```
+
+A FULLTEXT index across multiple columns is searched together -- you can't independently search just one of the indexed columns using that index.
+
+## Basic Search: Natural Language Mode
+
+Natural language mode is the default. MySQL parses the search string into words, looks them up in the full-text index, and ranks results by relevance.
+
+```sql
+SELECT id, title,
+  MATCH(title, body) AGAINST('mysql index performance') AS relevance_score
+FROM articles
+ORDER BY relevance_score DESC;
+
+-- With a WHERE clause to filter zero-relevance rows
+SELECT id, title
+FROM articles
+WHERE MATCH(title, body) AGAINST('mysql index performance');
+```
+
+Relevance score is a float. Higher = more relevant. In `WHERE` clause usage (without `ORDER BY relevance_score`), MySQL can use the FULLTEXT index directly for rows with non-zero score.
+
+### Stop Words
+
+MySQL ignores common English stop words (like "the", "is", "and") from natural language searches. Words shorter than `ft_min_word_len` (default: 4 characters) are also ignored.
+
+```sql
+-- Check current minimum word length
+SHOW VARIABLES LIKE 'ft_min_word_len';
+-- or for InnoDB:
+SHOW VARIABLES LIKE 'innodb_ft_min_token_size';
+```
+
+This means searching for "a" or "is" returns no results -- these terms aren't indexed.
+
+## Boolean Mode
+
+Boolean mode gives you control over matching logic via operators:
+
+| Operator | Meaning |
+|----------|---------|
+| `+word` | Word must be present |
+| `-word` | Word must not be present |
+| `word` | Word is optional (boosts relevance if present) |
+| `*` | Wildcard prefix (e.g., `index*` matches "index", "indexes", "indexing") |
+| `"phrase"` | Exact phrase match |
+| `>word` | Word present and boosts relevance |
+| `<word` | Word present but reduces relevance |
+
+```sql
+-- Must contain 'mysql', must not contain 'slow'
+SELECT id, title
+FROM articles
+WHERE MATCH(title, body) AGAINST('+mysql -slow' IN BOOLEAN MODE);
+
+-- Must contain 'index' and 'performance', optional 'optimization'
+SELECT id, title
+FROM articles
+WHERE MATCH(title, body) AGAINST('+index +performance optimization' IN BOOLEAN MODE);
+
+-- Exact phrase match
+SELECT id, title
+FROM articles
+WHERE MATCH(title, body) AGAINST('"query optimizer"' IN BOOLEAN MODE);
+
+-- Prefix match
+SELECT id, title
+FROM articles
+WHERE MATCH(title, body) AGAINST('optim*' IN BOOLEAN MODE);
+```
+
+Boolean mode does not rank results by relevance by default -- all matching rows are returned equally. To get a relevance score in boolean mode, include the `MATCH...AGAINST` expression in the `SELECT` list.
+
+## Query Expansion Mode
+
+Query expansion does two passes: first a normal natural language search, then it expands the query using words from the top results to find additional related rows.
+
+```sql
+SELECT id, title
+FROM articles
+WHERE MATCH(title, body) AGAINST('database' WITH QUERY EXPANSION);
+```
+
+Useful when users search with single broad terms. Be cautious: results can become noisy for ambiguous queries. Not useful for precise technical searches.
+
+## Combining Full-Text with Regular Filters
+
+```sql
+-- Full-text search filtered by date
+SELECT id, title, MATCH(title, body) AGAINST('replication') AS score
+FROM articles
+WHERE MATCH(title, body) AGAINST('replication')
+  AND published_at >= '2025-01-01'
+ORDER BY score DESC;
+```
+
+The FULLTEXT index handles the text search; the `published_at` filter narrows the result set further. Using both together is efficient.
+
+## Limitations
+
+**No index on partial columns.** FULLTEXT searches the entire column content -- you can't restrict the search to the first N characters.
+
+**No prefix operator on short terms.** The minimum word length applies to wildcard matches too. `inde*` won't match "index" if "inde" is shorter than `innodb_ft_min_token_size`.
+
+**Language-specific.** The built-in parser is word-oriented and primarily suited for languages with space-delimited words. For CJK languages (Chinese, Japanese, Korean), configure the MeCab or N-gram parser.
+
+**Not a replacement for a search engine.** For advanced requirements -- stemming, synonyms, fuzzy matching, relevance tuning, multi-language support -- dedicated search tools like Elasticsearch or Typesense are better fits. FULLTEXT is the right choice when you need search on a MySQL table without adding infrastructure.
+
+**MyISAM vs InnoDB.** Historically, FULLTEXT only worked with MyISAM. InnoDB support was added in MySQL 5.6 and is now complete. Use InnoDB.
+
+## When to Use LIKE Instead
+
+`LIKE 'term%'` (prefix match, no leading wildcard) can use a regular B-tree index and performs well. Only reach for FULLTEXT when you need:
+- Mid-string word matching (`WHERE body LIKE '%term%'` has no index path)
+- Relevance ranking
+- Multi-word natural language queries
+- Boolean operators
+
+For simple prefix searches or filtering on a moderate-sized table, `LIKE 'term%'` with a regular index is cheaper and simpler.
+
+Mako connects to MySQL with AI autocomplete that can suggest MATCH AGAINST syntax as you type. Try it at [mako.ai](https://mako.ai).

--- a/content/guides/mysql/indexes-explained.mdx
+++ b/content/guides/mysql/indexes-explained.mdx
@@ -1,0 +1,182 @@
+---
+title: "MySQL Indexes Explained"
+description: "Understand MySQL index types (B-tree, FULLTEXT, spatial, covering indexes), how to create them, read EXPLAIN output, and avoid common pitfalls."
+database: "mysql"
+category: "how-to"
+tags: ["mysql", "sql", "indexes", "performance", "explain"]
+date: "2026-04-15"
+---
+
+Indexes are the single most impactful performance tool in MySQL. Without them, every query that filters, sorts, or joins data scans the entire table. With the right indexes, the same queries scan a handful of rows.
+
+This guide covers how indexes work internally, the different types MySQL supports, how to create them, and how to read `EXPLAIN` output to verify they're being used.
+
+## How B-tree Indexes Work
+
+MySQL's default index type (for InnoDB) is a **B+ tree**. The structure is a balanced tree where:
+- Internal nodes contain key values used for navigation
+- Leaf nodes contain the full index entries
+- Leaf nodes are linked in sorted order, enabling efficient range scans
+
+When you query `WHERE email = 'alice@example.com'`, MySQL traverses the tree in O(log n) steps instead of scanning all rows.
+
+### The Clustered Index
+
+In InnoDB, the primary key is the **clustered index** -- the table rows are physically stored in primary key order. This means:
+- Primary key lookups are fast (the data is the index)
+- Secondary indexes store the primary key value as the row pointer, not a physical offset
+
+If you don't define a primary key, InnoDB creates a hidden one using an auto-incrementing integer.
+
+## Creating Indexes
+
+```sql
+-- Single column
+CREATE INDEX idx_email ON users(email);
+
+-- Composite (multi-column)
+CREATE INDEX idx_dept_salary ON employees(department, salary);
+
+-- Unique
+CREATE UNIQUE INDEX idx_username ON users(username);
+
+-- On table creation
+CREATE TABLE orders (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  customer_id INT,
+  status VARCHAR(20),
+  created_at DATETIME,
+  INDEX idx_customer (customer_id),
+  INDEX idx_status_date (status, created_at)
+);
+```
+
+## Composite Index Column Order
+
+The order of columns in a composite index matters significantly. MySQL can use the index for:
+- All columns in order from the left
+- A leading prefix of columns
+
+For `INDEX idx_dept_salary(department, salary)`:
+
+```sql
+-- Uses the index (leftmost column)
+SELECT * FROM employees WHERE department = 'Engineering';
+
+-- Uses the index (both columns)
+SELECT * FROM employees WHERE department = 'Engineering' AND salary > 80000;
+
+-- Does NOT use the index (skipped leftmost column)
+SELECT * FROM employees WHERE salary > 80000;
+```
+
+Design composite indexes with your most-selective or most-filtered column first, unless range conditions force a different order.
+
+## Covering Indexes
+
+A **covering index** is one that contains all the columns a query needs -- no need to look up the actual row. This is faster because MySQL reads the index only, not the table.
+
+```sql
+-- Query needs: customer_id, status, created_at
+SELECT customer_id, status, created_at FROM orders WHERE status = 'pending';
+
+-- A covering index for this query:
+CREATE INDEX idx_covering ON orders(status, customer_id, created_at);
+```
+
+In `EXPLAIN` output, a covering index shows `Using index` in the `Extra` column -- that's a good sign.
+
+## FULLTEXT Indexes
+
+FULLTEXT indexes enable natural language and boolean text search on `VARCHAR`, `TEXT`, and `CHAR` columns. They're available on InnoDB (since MySQL 5.6) and MyISAM.
+
+```sql
+CREATE TABLE articles (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  title VARCHAR(200),
+  body TEXT,
+  FULLTEXT INDEX ft_search (title, body)
+);
+
+-- Natural language search (relevance-ranked)
+SELECT id, title, MATCH(title, body) AGAINST('mysql index performance') AS score
+FROM articles
+ORDER BY score DESC;
+
+-- Boolean mode
+SELECT id, title
+FROM articles
+WHERE MATCH(title, body) AGAINST('+mysql +index -slow' IN BOOLEAN MODE);
+```
+
+FULLTEXT indexes do not support prefix matching or exact-phrase substring search. For simple `LIKE '%word%'` patterns on small tables, a FULLTEXT index may be overkill.
+
+## Prefix Indexes
+
+For long `VARCHAR` or `TEXT` columns, indexing just the first N characters reduces index size:
+
+```sql
+CREATE INDEX idx_url_prefix ON pages(url(100));
+```
+
+The tradeoff: prefix indexes can't satisfy covering index queries and may have higher collision rates. Use them when full-column indexing is impractical (e.g., TEXT columns can't be indexed without a prefix).
+
+## Reading EXPLAIN Output
+
+`EXPLAIN` shows MySQL's execution plan before running the query:
+
+```sql
+EXPLAIN SELECT * FROM orders WHERE customer_id = 42 AND status = 'shipped';
+```
+
+Key columns to focus on:
+
+| Column | What to look for |
+|--------|-----------------|
+| `type` | `const` > `ref` > `range` > `index` > `ALL` (ALL = full table scan, usually bad) |
+| `key` | Which index is being used (NULL = no index) |
+| `rows` | Estimated rows examined -- lower is better |
+| `Extra` | `Using index` (covering), `Using filesort` (no index sort), `Using temporary` (implicit temp table) |
+
+```sql
+-- Example output analysis
+EXPLAIN SELECT name, salary FROM employees WHERE department = 'Eng' AND salary > 90000;
+
+-- If you see:
+--   type: ref, key: idx_dept_salary, rows: 12, Extra: Using index
+-- That's optimal.
+
+-- If you see:
+--   type: ALL, key: NULL, rows: 50000, Extra: Using where
+-- You need an index.
+```
+
+For more detail, use `EXPLAIN FORMAT=JSON` or `EXPLAIN ANALYZE` (MySQL 8.0.18+, which actually runs the query and shows real row counts).
+
+## When NOT to Add an Index
+
+Indexes have costs:
+- **Write overhead**: every INSERT, UPDATE, DELETE must update all affected indexes
+- **Storage**: indexes consume disk space
+- **Optimizer confusion**: too many indexes can make the query planner choose poorly
+
+Don't index:
+- Low-cardinality columns (e.g., a boolean `is_active` with only two values -- MySQL often prefers a full scan)
+- Columns that are rarely queried in WHERE, JOIN, or ORDER BY
+- Tiny tables where a full scan is faster than the index lookup
+
+## Maintenance
+
+**Unused indexes** slow down writes for no benefit. Check `sys.schema_unused_indexes` to find them:
+
+```sql
+SELECT * FROM sys.schema_unused_indexes WHERE object_schema = 'your_database';
+```
+
+**Duplicate indexes** waste space. Check with:
+
+```sql
+SELECT * FROM sys.schema_redundant_indexes WHERE table_schema = 'your_database';
+```
+
+Mako connects to MySQL and surfaces EXPLAIN output alongside your query results. Try it at [mako.ai](https://mako.ai).

--- a/content/guides/mysql/joins-guide.mdx
+++ b/content/guides/mysql/joins-guide.mdx
@@ -1,0 +1,183 @@
+---
+title: "MySQL Joins: INNER, LEFT, RIGHT, CROSS, Self, and Anti-Joins"
+description: "A complete guide to MySQL join types with examples: INNER JOIN, LEFT JOIN, RIGHT JOIN, CROSS JOIN, self-joins, anti-joins, and join order optimization."
+database: "mysql"
+category: "how-to"
+tags: ["mysql", "sql", "joins", "inner-join", "left-join"]
+date: "2026-04-15"
+---
+
+Joins combine rows from two or more tables based on a related column. Understanding which join type to use -- and how MySQL executes them -- is fundamental to writing correct, performant queries.
+
+## Setup: Sample Tables
+
+```sql
+CREATE TABLE customers (
+  id INT PRIMARY KEY,
+  name VARCHAR(100),
+  country VARCHAR(50)
+);
+
+CREATE TABLE orders (
+  id INT PRIMARY KEY,
+  customer_id INT,
+  amount DECIMAL(10,2),
+  status VARCHAR(20)
+);
+```
+
+## INNER JOIN
+
+Returns only rows where the join condition matches in both tables. Rows with no match on either side are excluded.
+
+```sql
+SELECT c.name, o.id AS order_id, o.amount
+FROM customers c
+INNER JOIN orders o ON c.id = o.customer_id;
+```
+
+Customers without orders don't appear. Orders without a valid customer don't appear. This is the most common join type.
+
+`JOIN` without a qualifier defaults to `INNER JOIN` in MySQL.
+
+## LEFT JOIN (LEFT OUTER JOIN)
+
+Returns all rows from the left table, plus matching rows from the right. When there's no match, right-side columns are `NULL`.
+
+```sql
+SELECT c.name, o.id AS order_id, o.amount
+FROM customers c
+LEFT JOIN orders o ON c.id = o.customer_id;
+```
+
+Customers without orders appear with `NULL` for order columns. Use `LEFT JOIN` when you want to keep all records from one table regardless of whether a match exists.
+
+## RIGHT JOIN (RIGHT OUTER JOIN)
+
+The mirror of LEFT JOIN: all rows from the right table, plus matching rows from the left.
+
+```sql
+SELECT c.name, o.id AS order_id, o.amount
+FROM customers c
+RIGHT JOIN orders o ON c.id = o.customer_id;
+```
+
+Orders without a matching customer appear with `NULL` for customer columns. In practice, `RIGHT JOIN` is rare -- most developers restructure the query as a `LEFT JOIN` by swapping table order.
+
+**MySQL does not support FULL OUTER JOIN.** To simulate it, combine a LEFT JOIN and a RIGHT JOIN with UNION:
+
+```sql
+SELECT c.name, o.id
+FROM customers c LEFT JOIN orders o ON c.id = o.customer_id
+UNION
+SELECT c.name, o.id
+FROM customers c RIGHT JOIN orders o ON c.id = o.customer_id;
+```
+
+## CROSS JOIN
+
+Returns the Cartesian product: every row in the left table paired with every row in the right table. No join condition needed.
+
+```sql
+SELECT c.name, p.name AS product
+FROM customers c
+CROSS JOIN products p;
+```
+
+If `customers` has 100 rows and `products` has 50, the result has 5,000 rows. Use intentionally for generating combinations (e.g., a date-range calendar × sales regions). Accidental cross joins on large tables will bring a server down.
+
+## Self-Join
+
+A table joined to itself. Useful for hierarchical data (org charts, parent-child relationships) or comparing rows within the same table.
+
+```sql
+CREATE TABLE employees (
+  id INT PRIMARY KEY,
+  name VARCHAR(100),
+  manager_id INT
+);
+
+-- Find each employee and their manager's name
+SELECT e.name AS employee, m.name AS manager
+FROM employees e
+LEFT JOIN employees m ON e.manager_id = m.id;
+```
+
+The trick is aliasing the same table twice (`e` and `m`) so MySQL treats them as separate tables.
+
+## Anti-Join
+
+Returns rows from the left table that have no match in the right table. MySQL doesn't have a dedicated `ANTI JOIN` keyword -- simulate it with `LEFT JOIN ... WHERE ... IS NULL` or `NOT EXISTS`:
+
+```sql
+-- Customers who have never placed an order
+-- Method 1: LEFT JOIN + IS NULL
+SELECT c.name
+FROM customers c
+LEFT JOIN orders o ON c.id = o.customer_id
+WHERE o.id IS NULL;
+
+-- Method 2: NOT EXISTS (often more readable)
+SELECT c.name
+FROM customers c
+WHERE NOT EXISTS (
+  SELECT 1 FROM orders o WHERE o.customer_id = c.id
+);
+
+-- Method 3: NOT IN (careful with NULLs -- see below)
+SELECT c.name
+FROM customers c
+WHERE c.id NOT IN (SELECT customer_id FROM orders WHERE customer_id IS NOT NULL);
+```
+
+**NULL trap with NOT IN:** If the subquery returns any `NULL`, `NOT IN` returns no rows at all (because `NULL` comparisons are always `UNKNOWN`). Always filter NULLs in the subquery, or prefer `NOT EXISTS`.
+
+## JOIN with Multiple Conditions
+
+Join conditions can have multiple predicates:
+
+```sql
+SELECT *
+FROM inventory i
+JOIN shipments s
+  ON i.product_id = s.product_id
+  AND i.warehouse_id = s.warehouse_id
+  AND s.shipped_date >= i.restock_date;
+```
+
+## Filtering: ON vs. WHERE
+
+For `INNER JOIN`, conditions in `ON` and `WHERE` are equivalent. For `LEFT JOIN`, the placement matters:
+
+```sql
+-- Filters orders BEFORE the join (returns customers with pending orders + customers with no orders)
+SELECT c.name, o.amount
+FROM customers c
+LEFT JOIN orders o ON c.id = o.customer_id AND o.status = 'pending';
+
+-- Filters orders AFTER the join (returns only customers with pending orders)
+SELECT c.name, o.amount
+FROM customers c
+LEFT JOIN orders o ON c.id = o.customer_id
+WHERE o.status = 'pending';
+```
+
+The second query effectively turns a `LEFT JOIN` into an `INNER JOIN` by filtering out NULLs.
+
+## Join Order and Performance
+
+MySQL's optimizer generally chooses the best join order, but you can influence it:
+- Put the most-selective filter on the driving table (usually the one with fewer matching rows)
+- Ensure join columns are indexed on both sides
+- Use `EXPLAIN` to verify the chosen order and index usage
+
+```sql
+EXPLAIN SELECT c.name, o.amount
+FROM customers c
+INNER JOIN orders o ON c.id = o.customer_id
+WHERE c.country = 'DE';
+```
+
+If you see `type: ALL` on the orders table, add an index on `orders.customer_id`.
+
+Mako connects to MySQL and renders join query results with AI autocomplete to help you build the right join syntax. Try it at [mako.ai](https://mako.ai).

--- a/content/guides/mysql/json-queries.mdx
+++ b/content/guides/mysql/json-queries.mdx
@@ -1,0 +1,212 @@
+---
+title: "Working with JSON in MySQL"
+description: "A practical guide to MySQL JSON functions: JSON_EXTRACT, ->, ->>, JSON_SET, JSON_TABLE, JSON_ARRAYAGG, and JSON_OBJECTAGG, with real query examples."
+database: "mysql"
+category: "how-to"
+tags: ["mysql", "sql", "json", "json-extract", "json-table"]
+date: "2026-04-15"
+---
+
+MySQL has supported a native JSON data type since version 5.7. Storing JSON in a dedicated column (rather than a TEXT column) gives you validation on insert, optimized storage, and path-based access via dedicated functions.
+
+This guide covers the most useful JSON functions for querying and transforming JSON data.
+
+## Storing JSON
+
+Define a column as `JSON` type:
+
+```sql
+CREATE TABLE users (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  username VARCHAR(50),
+  profile JSON,
+  settings JSON
+);
+
+INSERT INTO users (username, profile, settings) VALUES
+('alice', '{"age": 30, "city": "Berlin", "tags": ["admin", "editor"]}', '{"theme": "dark", "notifications": true}'),
+('bob', '{"age": 25, "city": "Paris", "tags": ["viewer"]}', '{"theme": "light", "notifications": false}');
+```
+
+MySQL validates JSON on insert -- malformed JSON raises an error rather than silently storing garbage.
+
+## Extracting Values
+
+### JSON_EXTRACT() and the -> Operator
+
+`JSON_EXTRACT(doc, path)` retrieves a value at the given JSON path. The `->` operator is shorthand:
+
+```sql
+-- These are equivalent
+SELECT JSON_EXTRACT(profile, '$.city') FROM users;
+SELECT profile -> '$.city' FROM users;
+-- Returns: "Berlin", "Paris" (with quotes)
+```
+
+Use `$.key` for object access, `$[n]` for array index access:
+
+```sql
+SELECT profile -> '$.tags[0]' FROM users;
+-- Returns: "admin", "viewer"
+```
+
+### The ->> Operator (Unquoted)
+
+`->>` is equivalent to `JSON_UNQUOTE(JSON_EXTRACT(...))`. It returns the string value without surrounding quotes:
+
+```sql
+SELECT profile ->> '$.city' FROM users;
+-- Returns: Berlin, Paris (no quotes)
+```
+
+Use `->` when chaining JSON operations; use `->>` when you need a clean string for comparison or display.
+
+```sql
+-- Filter by JSON field value
+SELECT username FROM users WHERE profile ->> '$.city' = 'Berlin';
+```
+
+## Modifying JSON
+
+### JSON_SET()
+
+Updates existing values or inserts new keys if they don't exist:
+
+```sql
+UPDATE users
+SET settings = JSON_SET(settings, '$.theme', 'dark', '$.language', 'en')
+WHERE username = 'bob';
+```
+
+### JSON_INSERT() and JSON_REPLACE()
+
+`JSON_INSERT` only adds new keys (won't overwrite). `JSON_REPLACE` only updates existing keys (won't insert):
+
+```sql
+-- Won't change 'theme' if it already exists
+UPDATE users SET settings = JSON_INSERT(settings, '$.theme', 'dark');
+
+-- Won't add 'timezone' if it doesn't exist
+UPDATE users SET settings = JSON_REPLACE(settings, '$.timezone', 'UTC');
+```
+
+### JSON_REMOVE()
+
+Removes a key from a JSON document:
+
+```sql
+UPDATE users SET profile = JSON_REMOVE(profile, '$.tags');
+```
+
+## Working with Arrays
+
+### JSON_ARRAY() and JSON_ARRAYAGG()
+
+`JSON_ARRAY` builds a JSON array literal:
+
+```sql
+SELECT JSON_ARRAY('a', 'b', 'c');
+-- Returns: ["a", "b", "c"]
+```
+
+`JSON_ARRAYAGG` is an aggregate function that collects values from rows into a JSON array:
+
+```sql
+SELECT
+  department,
+  JSON_ARRAYAGG(name) AS team_members
+FROM employees
+GROUP BY department;
+```
+
+### JSON_OBJECTAGG()
+
+Builds a JSON object from key-value pairs across rows:
+
+```sql
+SELECT JSON_OBJECTAGG(username, profile ->> '$.city') AS user_cities
+FROM users;
+-- Returns: {"alice": "Berlin", "bob": "Paris"}
+```
+
+## JSON_TABLE: Turning JSON into Rows
+
+`JSON_TABLE` (MySQL 8.0+) is the most powerful JSON function. It shreds JSON into a relational table that you can join against.
+
+```sql
+SELECT jt.*
+FROM users,
+JSON_TABLE(
+  profile,
+  '$' COLUMNS (
+    age INT PATH '$.age',
+    city VARCHAR(100) PATH '$.city'
+  )
+) AS jt;
+```
+
+Handling arrays with `JSON_TABLE`:
+
+```sql
+-- Expand the tags array into individual rows
+SELECT u.username, jt.tag
+FROM users u,
+JSON_TABLE(
+  u.profile,
+  '$.tags[*]' COLUMNS (tag VARCHAR(50) PATH '$')
+) AS jt;
+
+-- Result:
+-- alice | admin
+-- alice | editor
+-- bob   | viewer
+```
+
+This is far cleaner than trying to parse arrays with `JSON_EXTRACT` and positional indexes.
+
+## Checking if a Key Exists
+
+Use `JSON_CONTAINS_PATH`:
+
+```sql
+-- Check if the 'city' key exists in profile
+SELECT username
+FROM users
+WHERE JSON_CONTAINS_PATH(profile, 'one', '$.city');
+```
+
+Use `JSON_CONTAINS` to check if a value exists anywhere in a document:
+
+```sql
+-- Find users who have 'admin' in their tags array
+SELECT username
+FROM users
+WHERE JSON_CONTAINS(profile -> '$.tags', '"admin"');
+```
+
+## Indexing JSON Columns
+
+You can't index a JSON column directly, but you can create a virtual generated column from a JSON path and index that:
+
+```sql
+ALTER TABLE users
+  ADD COLUMN city VARCHAR(100) GENERATED ALWAYS AS (profile ->> '$.city') VIRTUAL,
+  ADD INDEX idx_city (city);
+
+-- Now this query uses the index
+SELECT username FROM users WHERE city = 'Berlin';
+```
+
+This is the standard pattern for making JSON queries fast. Without it, every query involving a JSON path triggers a full table scan.
+
+## Common Mistakes
+
+**Using TEXT instead of JSON** -- you lose validation, optimized storage, and path access. Use the `JSON` type unless you have a specific reason not to.
+
+**Forgetting quotes matter** -- `JSON_EXTRACT` returns JSON-encoded strings (with quotes). Use `JSON_UNQUOTE` or `->>`  when comparing to plain strings, or comparisons will fail silently.
+
+**No index on a frequently queried path** -- add a generated column + index for any JSON path you filter on regularly.
+
+**JSON_TABLE requires MySQL 8.0** -- if you're on 5.7, you'll need to handle JSON array expansion in application code.
+
+Mako connects to MySQL and lets you query JSON columns with AI autocomplete. Try it at [mako.ai](https://mako.ai).

--- a/content/guides/mysql/pivot-table.mdx
+++ b/content/guides/mysql/pivot-table.mdx
@@ -1,0 +1,163 @@
+---
+title: "Pivot Tables in MySQL"
+description: "How to pivot rows into columns in MySQL using CASE/GROUP BY for static pivots and dynamic SQL with prepared statements for runtime column generation."
+database: "mysql"
+category: "how-to"
+tags: ["mysql", "sql", "pivot", "case", "group-by", "prepared-statements"]
+date: "2026-04-15"
+---
+
+MySQL has no native `PIVOT` keyword. To rotate rows into columns, you use a combination of conditional aggregation (`CASE` + `GROUP BY`) for static pivots, or dynamically built SQL with prepared statements when column values aren't known ahead of time.
+
+## The Problem: Rows That Should Be Columns
+
+Suppose you have monthly sales by product:
+
+```sql
+CREATE TABLE sales (
+  salesperson VARCHAR(50),
+  product VARCHAR(50),
+  month VARCHAR(7),
+  revenue DECIMAL(10,2)
+);
+
+INSERT INTO sales VALUES
+('Alice', 'Widget', '2026-01', 1200),
+('Alice', 'Gadget', '2026-01', 800),
+('Alice', 'Widget', '2026-02', 1500),
+('Bob', 'Widget', '2026-01', 900),
+('Bob', 'Gadget', '2026-02', 1100);
+```
+
+You want one row per salesperson, with a column per product:
+
+| salesperson | Widget | Gadget |
+|-------------|--------|--------|
+| Alice | 2700 | 800 |
+| Bob | 900 | 1100 |
+
+## Static Pivot with CASE and GROUP BY
+
+When you know the column values in advance, use `CASE` inside an aggregate:
+
+```sql
+SELECT
+  salesperson,
+  SUM(CASE WHEN product = 'Widget' THEN revenue ELSE 0 END) AS Widget,
+  SUM(CASE WHEN product = 'Gadget' THEN revenue ELSE 0 END) AS Gadget
+FROM sales
+GROUP BY salesperson;
+```
+
+The pattern is: for each output column, aggregate only the rows where the condition matches, defaulting everything else to 0 (or NULL).
+
+### With COUNT instead of SUM
+
+```sql
+SELECT
+  department,
+  COUNT(CASE WHEN status = 'active' THEN 1 END) AS active_count,
+  COUNT(CASE WHEN status = 'inactive' THEN 1 END) AS inactive_count,
+  COUNT(CASE WHEN status = 'pending' THEN 1 END) AS pending_count
+FROM employees
+GROUP BY department;
+```
+
+### With IF() shorthand
+
+MySQL's `IF(condition, true_val, false_val)` can make the syntax slightly shorter:
+
+```sql
+SELECT
+  salesperson,
+  SUM(IF(product = 'Widget', revenue, 0)) AS Widget,
+  SUM(IF(product = 'Gadget', revenue, 0)) AS Gadget
+FROM sales
+GROUP BY salesperson;
+```
+
+Both are equivalent. `CASE` is more portable to other databases.
+
+## Dynamic Pivot with Prepared Statements
+
+When product names (or any pivot dimension) aren't known until runtime, hardcoding them is impractical. The approach:
+1. Use `GROUP_CONCAT` to build the column list dynamically
+2. Concatenate it into a full SQL string
+3. Execute via a prepared statement
+
+```sql
+-- Step 1: Build the CASE expressions
+SET @cols = NULL;
+SELECT
+  GROUP_CONCAT(
+    DISTINCT CONCAT(
+      'SUM(CASE WHEN product = ''', product, ''' THEN revenue ELSE 0 END) AS `', product, '`'
+    )
+    ORDER BY product
+  )
+INTO @cols
+FROM sales;
+
+-- Step 2: Build the full query
+SET @sql = CONCAT(
+  'SELECT salesperson, ', @cols,
+  ' FROM sales GROUP BY salesperson'
+);
+
+-- Step 3: Execute it
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+```
+
+Running this against the sample data produces a result with columns `Gadget` and `Widget` without ever hardcoding those names.
+
+### Limitations of Dynamic Pivots
+
+- The backtick-quoted column names handle spaces and special characters, but the column list is assembled via string concatenation -- SQL injection is possible if product names come from user input. Always validate or sanitize the source.
+- `GROUP_CONCAT` has a default max length of 1024 characters. If you have many distinct pivot values, increase it: `SET SESSION group_concat_max_len = 65536;`
+- Prepared statements can't be used inside stored procedures in older MySQL versions. Test on your target version.
+
+## WITH ROLLUP: Adding Subtotals
+
+`WITH ROLLUP` adds subtotal rows at each grouping level, which is useful for crosstab reports:
+
+```sql
+SELECT
+  salesperson,
+  product,
+  SUM(revenue) AS total_revenue
+FROM sales
+GROUP BY salesperson, product WITH ROLLUP;
+```
+
+This produces rows for each `(salesperson, product)` combination, plus a subtotal per salesperson (with NULL for `product`), plus a grand total (with NULL for both).
+
+Use `GROUPING(column)` (MySQL 8.0.1+) to distinguish rollup NULLs from actual NULLs in data:
+
+```sql
+SELECT
+  IF(GROUPING(salesperson), 'Grand Total', salesperson) AS salesperson,
+  IF(GROUPING(product), 'All Products', product) AS product,
+  SUM(revenue) AS total_revenue
+FROM sales
+GROUP BY salesperson, product WITH ROLLUP;
+```
+
+## Unpivoting: Columns Back to Rows
+
+To reverse a pivot (wide format back to long format), MySQL lacks `UNPIVOT` too. Use `UNION ALL`:
+
+```sql
+-- Suppose you have a pre-pivoted table: monthly_totals(salesperson, jan, feb, mar)
+SELECT salesperson, 'jan' AS month, jan AS revenue FROM monthly_totals
+UNION ALL
+SELECT salesperson, 'feb', feb FROM monthly_totals
+UNION ALL
+SELECT salesperson, 'mar', mar FROM monthly_totals
+ORDER BY salesperson, month;
+```
+
+Verbose but predictable. For a variable number of columns, this has to be done in application code.
+
+Mako connects to MySQL and lets you run and iterate on pivot queries interactively. Try it at [mako.ai](https://mako.ai).

--- a/content/guides/mysql/string-functions.mdx
+++ b/content/guides/mysql/string-functions.mdx
@@ -1,0 +1,222 @@
+---
+title: "MySQL String Functions"
+description: "A practical reference for MySQL string functions: CONCAT, SUBSTRING, REPLACE, REGEXP_REPLACE, GROUP_CONCAT, TRIM, LENGTH, UPPER, LOWER, and more."
+database: "mysql"
+category: "how-to"
+tags: ["mysql", "sql", "string-functions", "concat", "regexp"]
+date: "2026-04-15"
+---
+
+MySQL provides a broad set of string functions for concatenating, slicing, replacing, padding, and transforming text data. This guide covers the functions you'll use regularly, with practical examples.
+
+## Concatenation
+
+### CONCAT()
+
+Joins two or more strings. Returns NULL if any argument is NULL:
+
+```sql
+SELECT CONCAT('Hello', ', ', 'world');  -- 'Hello, world'
+SELECT CONCAT(first_name, ' ', last_name) AS full_name FROM users;
+
+-- NULL handling
+SELECT CONCAT('Hello', NULL, 'world');  -- NULL
+```
+
+### CONCAT_WS()
+
+"Concat with separator" -- joins values with a separator, skipping NULLs automatically:
+
+```sql
+SELECT CONCAT_WS(', ', city, state, country) AS address FROM locations;
+-- If state is NULL: 'Berlin, Germany' instead of 'Berlin, NULL, Germany'
+```
+
+Prefer `CONCAT_WS` over `CONCAT` when any column might be NULL.
+
+## Length
+
+```sql
+SELECT LENGTH('Hello');      -- 5 (bytes)
+SELECT CHAR_LENGTH('Hello'); -- 5 (characters)
+```
+
+For ASCII text, these are identical. For multi-byte UTF-8 characters, `LENGTH` counts bytes while `CHAR_LENGTH` counts characters:
+
+```sql
+SELECT LENGTH('café');      -- 5 (the é is 2 bytes in UTF-8)
+SELECT CHAR_LENGTH('café'); -- 4 (4 characters)
+```
+
+Use `CHAR_LENGTH` for text length validation.
+
+## Extracting Substrings
+
+### SUBSTRING() / SUBSTR()
+
+```sql
+SELECT SUBSTRING('MySQL 8.0', 1, 5);   -- 'MySQL' (start at pos 1, length 5)
+SELECT SUBSTRING('MySQL 8.0', 7);       -- '8.0' (from pos 7 to end)
+SELECT SUBSTRING('MySQL 8.0', -3);      -- '8.0' (last 3 characters)
+```
+
+Positions in MySQL are 1-indexed.
+
+### LEFT() and RIGHT()
+
+```sql
+SELECT LEFT('MySQL', 2);    -- 'My'
+SELECT RIGHT('MySQL', 3);   -- 'SQL'
+```
+
+### SUBSTRING_INDEX()
+
+Extracts the part of a string before or after a delimiter:
+
+```sql
+SELECT SUBSTRING_INDEX('192.168.1.100', '.', 2);   -- '192.168' (first 2 segments)
+SELECT SUBSTRING_INDEX('192.168.1.100', '.', -1);  -- '100' (last segment)
+SELECT SUBSTRING_INDEX(email, '@', -1) AS domain FROM users;  -- extract domain
+```
+
+Very useful for parsing delimited strings when proper normalization isn't an option.
+
+## Searching in Strings
+
+### LOCATE() / INSTR()
+
+Return the position of a substring (0 if not found):
+
+```sql
+SELECT LOCATE('SQL', 'MySQL');        -- 3
+SELECT LOCATE('SQL', 'MySQL', 4);     -- 0 (search starts at position 4)
+SELECT INSTR('MySQL', 'SQL');         -- 3
+```
+
+### LIKE
+
+Pattern matching in WHERE clauses: `%` matches any sequence, `_` matches one character:
+
+```sql
+SELECT * FROM users WHERE email LIKE '%@gmail.com';
+SELECT * FROM users WHERE name LIKE 'A%';
+SELECT * FROM products WHERE sku LIKE 'AB_-____'; -- 'AB' + any char + hyphen + 4 chars
+```
+
+`LIKE` with a leading `%` can't use a standard B-tree index.
+
+## Replacing and Substituting
+
+### REPLACE()
+
+Simple literal string replacement (case-sensitive):
+
+```sql
+SELECT REPLACE('Hello World', 'World', 'MySQL');  -- 'Hello MySQL'
+UPDATE products SET description = REPLACE(description, 'old brand', 'new brand');
+```
+
+### REGEXP_REPLACE() (MySQL 8.0+)
+
+Replaces regex pattern matches:
+
+```sql
+-- Remove all non-digit characters from a phone number
+SELECT REGEXP_REPLACE('+1 (555) 123-4567', '[^0-9]', '');  -- '15551234567'
+
+-- Normalize multiple spaces to single space
+SELECT REGEXP_REPLACE(name, '\\s+', ' ') FROM users;
+```
+
+Available from MySQL 8.0. On 5.7, you'd need a stored function or application-side processing.
+
+## Case Conversion
+
+```sql
+SELECT UPPER('mysql');      -- 'MYSQL'
+SELECT LOWER('MySQL 8.0'); -- 'mysql 8.0'
+
+-- Case-insensitive comparison
+SELECT * FROM users WHERE LOWER(username) = 'alice';
+```
+
+For case-insensitive comparisons on indexed columns, prefer a case-insensitive collation on the column (e.g., `utf8mb4_unicode_ci`) rather than wrapping in `LOWER()` -- the latter prevents index usage.
+
+## Padding and Trimming
+
+### TRIM(), LTRIM(), RTRIM()
+
+```sql
+SELECT TRIM('  MySQL  ');    -- 'MySQL'
+SELECT LTRIM('  MySQL  ');   -- 'MySQL  '
+SELECT RTRIM('  MySQL  ');   -- '  MySQL'
+SELECT TRIM(BOTH '-' FROM '--MySQL--'); -- 'MySQL' (trim specific character)
+```
+
+Always trim user-entered data before storing or comparing.
+
+### LPAD() and RPAD()
+
+Pads a string to a specified length:
+
+```sql
+SELECT LPAD('42', 6, '0');  -- '000042' (zero-pad numbers)
+SELECT RPAD('AB', 5, '-');  -- 'AB---'
+```
+
+Useful for formatting codes, IDs, or fixed-width exports.
+
+## GROUP_CONCAT()
+
+Aggregates multiple rows of strings into a single comma-separated value:
+
+```sql
+-- Collect all tags for each post
+SELECT post_id, GROUP_CONCAT(tag ORDER BY tag SEPARATOR ', ') AS tags
+FROM post_tags
+GROUP BY post_id;
+
+-- Unique values only
+SELECT user_id, GROUP_CONCAT(DISTINCT role ORDER BY role) AS roles
+FROM user_roles
+GROUP BY user_id;
+```
+
+Default max output length is 1024 characters. Increase if needed:
+
+```sql
+SET SESSION group_concat_max_len = 65536;
+```
+
+Truncation silently cuts off the result -- check `group_concat_max_len` if results look incomplete.
+
+## FIELD() for Custom Sort Order
+
+Returns the position of a value in a list -- useful for custom sort orders:
+
+```sql
+SELECT * FROM orders
+ORDER BY FIELD(status, 'pending', 'processing', 'shipped', 'delivered');
+```
+
+## FORMAT() for Number Display
+
+Formats a number with thousands separators and a fixed decimal places:
+
+```sql
+SELECT FORMAT(1234567.89, 2);  -- '1,234,567.89'
+```
+
+This returns a string, not a number. Don't use it for further arithmetic.
+
+## Common Mistakes
+
+**Using LENGTH for character count on UTF-8 data** -- use `CHAR_LENGTH` instead.
+
+**LIKE with leading wildcard** -- `WHERE col LIKE '%term'` triggers a full table scan. Consider FULLTEXT search for mid-string matching on large tables.
+
+**REPLACE modifying data in place without a backup** -- always test with a SELECT first before running an UPDATE with REPLACE.
+
+**GROUP_CONCAT silent truncation** -- if output looks cut off, check and increase `group_concat_max_len`.
+
+Mako connects to MySQL with AI autocomplete for string function syntax. Try it at [mako.ai](https://mako.ai).

--- a/content/guides/mysql/window-functions.mdx
+++ b/content/guides/mysql/window-functions.mdx
@@ -1,0 +1,220 @@
+---
+title: "Window Functions in MySQL 8.0"
+description: "Learn how to use MySQL window functions including ROW_NUMBER, RANK, DENSE_RANK, NTILE, LAG, and LEAD with the OVER and PARTITION BY clauses."
+database: "mysql"
+category: "how-to"
+tags: ["mysql", "sql", "analytics", "window-functions"]
+date: "2026-04-15"
+---
+
+Window functions in MySQL let you perform calculations across a set of related rows without collapsing them into a single output row. They were introduced in **MySQL 8.0** -- if you're on MySQL 5.7 or earlier, you won't have access to them.
+
+The defining feature is the `OVER` clause: it defines the "window" of rows the function operates on.
+
+## Basic Syntax
+
+```sql
+SELECT
+  column_name,
+  WINDOW_FUNCTION() OVER (
+    PARTITION BY grouping_column
+    ORDER BY sorting_column
+  ) AS alias
+FROM table_name;
+```
+
+- `PARTITION BY` -- divides rows into groups; the function resets for each group
+- `ORDER BY` -- sets the logical order within each partition
+- Both are optional, but `ORDER BY` is almost always needed for ranking functions
+
+## Ranking Functions
+
+### ROW_NUMBER()
+
+Assigns a unique sequential integer to each row within a partition. Ties get different numbers -- the order is deterministic only if the `ORDER BY` is unique.
+
+```sql
+SELECT
+  name,
+  department,
+  salary,
+  ROW_NUMBER() OVER (PARTITION BY department ORDER BY salary DESC) AS row_num
+FROM employees;
+```
+
+Use this when you need exactly one row per partition (top-N queries, deduplication).
+
+### RANK()
+
+Assigns the same rank to tied rows, then skips numbers. Two rows tied at rank 2 produce the sequence 1, 2, 2, 4.
+
+```sql
+SELECT
+  name,
+  score,
+  RANK() OVER (ORDER BY score DESC) AS rank_position
+FROM exam_results;
+```
+
+### DENSE_RANK()
+
+Like `RANK()`, but without gaps. Two rows tied at rank 2 produce 1, 2, 2, 3.
+
+```sql
+SELECT
+  name,
+  score,
+  DENSE_RANK() OVER (ORDER BY score DESC) AS dense_rank_position
+FROM exam_results;
+```
+
+**Which to use:** `ROW_NUMBER` for deduplication, `RANK` when gaps make business sense (e.g., competition standings), `DENSE_RANK` when you want a continuous rank count.
+
+### NTILE(n)
+
+Divides rows into `n` roughly equal buckets and assigns a bucket number.
+
+```sql
+SELECT
+  name,
+  salary,
+  NTILE(4) OVER (ORDER BY salary) AS quartile
+FROM employees;
+```
+
+Useful for percentile analysis -- quartile 4 is the top earners.
+
+## Value Functions
+
+### LAG() and LEAD()
+
+`LAG` accesses a value from a previous row; `LEAD` from a following row. Both accept an optional offset (default 1) and a default value when no row exists.
+
+```sql
+SELECT
+  order_date,
+  revenue,
+  LAG(revenue, 1, 0) OVER (ORDER BY order_date) AS prev_day_revenue,
+  revenue - LAG(revenue, 1, 0) OVER (ORDER BY order_date) AS day_over_day_change
+FROM daily_sales;
+```
+
+```sql
+-- Compare current month to same month last year
+SELECT
+  month,
+  revenue,
+  LAG(revenue, 12) OVER (ORDER BY month) AS same_month_last_year
+FROM monthly_sales;
+```
+
+### FIRST_VALUE() and LAST_VALUE()
+
+Return the first or last value within the window frame.
+
+```sql
+SELECT
+  name,
+  department,
+  salary,
+  FIRST_VALUE(name) OVER (
+    PARTITION BY department
+    ORDER BY salary DESC
+  ) AS highest_earner_in_dept
+FROM employees;
+```
+
+**Note on LAST_VALUE:** By default, the window frame ends at the current row, so `LAST_VALUE` returns the current row's value. To get the true last value in the partition, add an explicit frame clause:
+
+```sql
+LAST_VALUE(name) OVER (
+  PARTITION BY department
+  ORDER BY salary DESC
+  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+)
+```
+
+## Aggregate Functions as Window Functions
+
+Any aggregate can be used with `OVER` to compute running totals, moving averages, or partition-level aggregates while retaining individual rows.
+
+```sql
+-- Running total
+SELECT
+  order_date,
+  amount,
+  SUM(amount) OVER (ORDER BY order_date) AS running_total
+FROM orders;
+
+-- Percentage of department total
+SELECT
+  name,
+  department,
+  salary,
+  salary / SUM(salary) OVER (PARTITION BY department) * 100 AS pct_of_dept_total
+FROM employees;
+
+-- 7-day moving average
+SELECT
+  day,
+  visitors,
+  AVG(visitors) OVER (
+    ORDER BY day
+    ROWS BETWEEN 6 PRECEDING AND CURRENT ROW
+  ) AS seven_day_avg
+FROM traffic;
+```
+
+## Named Windows
+
+If you use the same window definition multiple times, define it once using the `WINDOW` clause:
+
+```sql
+SELECT
+  name,
+  salary,
+  RANK() OVER w AS salary_rank,
+  DENSE_RANK() OVER w AS salary_dense_rank,
+  NTILE(4) OVER w AS salary_quartile
+FROM employees
+WINDOW w AS (PARTITION BY department ORDER BY salary DESC);
+```
+
+## Top-N Per Group
+
+A common pattern: get the top 3 employees by salary in each department.
+
+```sql
+SELECT *
+FROM (
+  SELECT
+    name,
+    department,
+    salary,
+    ROW_NUMBER() OVER (PARTITION BY department ORDER BY salary DESC) AS rn
+  FROM employees
+) ranked
+WHERE rn <= 3;
+```
+
+## Common Mistakes
+
+**Using WHERE to filter on window function output** -- you can't; window functions are evaluated after WHERE. Use a subquery or CTE:
+
+```sql
+-- Wrong (will error)
+SELECT name, RANK() OVER (ORDER BY salary DESC) AS r FROM employees WHERE r <= 5;
+
+-- Right
+SELECT * FROM (
+  SELECT name, RANK() OVER (ORDER BY salary DESC) AS r FROM employees
+) t WHERE r <= 5;
+```
+
+**Forgetting MySQL 8.0 requirement** -- window functions don't exist in MySQL 5.7. Check with `SELECT VERSION();`.
+
+**Inconsistent ORDER BY** -- if your `ORDER BY` isn't unique, `ROW_NUMBER` produces non-deterministic results. Add the primary key as a tiebreaker.
+
+## Exploring These Queries
+
+Mako's AI autocomplete can suggest window function syntax as you type. Connect your MySQL instance at [mako.ai](https://mako.ai) and try these queries interactively.


### PR DESCRIPTION
## Batch 6: MySQL How-to Guides (articles 1-10 of 20)

Mirrors Batch 5's PostgreSQL how-to series, adapted for MySQL syntax and MySQL-specific behaviors.

### Articles added

| File | Topic |
|------|-------|
| `mysql/window-functions.mdx` | ROW_NUMBER, RANK, DENSE_RANK, NTILE, LAG/LEAD, OVER/PARTITION BY, named windows |
| `mysql/cte.mdx` | WITH syntax (MySQL 8.0+), recursive CTEs, org charts, version compat notes |
| `mysql/json-queries.mdx` | JSON_EXTRACT, ->, ->>, JSON_TABLE, JSON_ARRAYAGG, JSON_OBJECTAGG, generated column indexing |
| `mysql/indexes-explained.mdx` | B-tree, clustered, FULLTEXT, covering indexes, EXPLAIN output, maintenance |
| `mysql/joins-guide.mdx` | INNER, LEFT, RIGHT, CROSS, self-join, anti-join (NULL trap), ON vs WHERE |
| `mysql/pivot-table.mdx` | CASE/GROUP BY static pivot, dynamic pivot via prepared statements, WITH ROLLUP |
| `mysql/full-text-search.mdx` | FULLTEXT indexes, MATCH AGAINST, natural language mode, boolean mode, query expansion |
| `mysql/date-functions.mdx` | DATE_FORMAT, DATEDIFF, DATE_ADD, STR_TO_DATE, TIMESTAMPDIFF, timezone handling |
| `mysql/string-functions.mdx` | CONCAT, CONCAT_WS, SUBSTRING, REPLACE, REGEXP_REPLACE, GROUP_CONCAT, TRIM, LPAD |
| `mysql/aggregate-functions.mdx` | COUNT/SUM/AVG/MIN/MAX, HAVING, GROUP BY ROLLUP, conditional aggregation |

### Notes
- All MySQL-specific behaviors documented (8.0 vs 5.7 differences called out)
- No em dashes, no banned words, honest about MySQL limitations
- Each article has working SQL examples, progressive complexity, and a single CTA

Remaining: 10 more MySQL articles in next batch (subqueries, views, transactions, upsert, explain-analyze, partitioning, stored-procedures, triggers, generated-columns, string-to-json)