### PR TITLE
fix: exclude high-volume collections from preview DB restore

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,7 +29,7 @@ jobs:
       issues: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Mirror fork branch to origin (workaround for claude-code-action fork bug)
@@ -74,7 +74,7 @@ jobs:
       issues: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Mirror fork branch to origin (workaround for claude-code-action fork bug)

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -23,7 +23,7 @@ jobs:
       GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_DEV_SERVICE_ACCOUNT }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # On pull_request: closed, default checkout may be the merge commit or default branch.
           # Pin to the PR head SHA so git diff sees the PR's actual changes.
@@ -31,12 +31,12 @@ jobs:
           fetch-depth: 0
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ env.GCP_SERVICE_ACCOUNT }}
 
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ env.GCP_PROJECT_ID }}
 
@@ -112,7 +112,7 @@ jobs:
           mongosh "$STAGING_DATABASE_URL" --eval "db.getSiblingDB('${DB_NAME}').dropDatabase()" || echo "Database not found or already deleted"
 
       - name: Comment on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prNumber = context.payload.pull_request.number;

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -61,7 +61,7 @@ jobs:
           echo "Fetched PR #${{ inputs.pr_number }} head ref: ${PR_REF}, SHA: ${PR_SHA}"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ steps.pr-info.outputs.pr_ref || github.ref }}
@@ -193,17 +193,17 @@ jobs:
           echo "SERVICE_NAME=mako-pr-${PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.detect-changes.outputs.pr_ref || github.ref }}
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: pnpm
@@ -228,12 +228,12 @@ jobs:
           VITE_GTM_ID: ${{ env.VITE_GTM_ID }}
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ env.GCP_SERVICE_ACCOUNT }}
 
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ env.GCP_PROJECT_ID }}
 
@@ -608,7 +608,7 @@ jobs:
 
       - name: Comment on PR with deployment URL
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
@@ -677,7 +677,7 @@ jobs:
     needs: detect-changes
     steps:
       - name: Comment on PR about skipped deployment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
@@ -766,18 +766,18 @@ jobs:
       DASHBOARD_ARTIFACT_PREFIX: dashboard-artifacts/prod
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Always checkout master for production deploys to prevent accidental deployments from other branches
           ref: master
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: pnpm
@@ -802,12 +802,12 @@ jobs:
           VITE_GTM_ID: ${{ env.VITE_GTM_ID }}
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ env.GCP_SERVICE_ACCOUNT }}
 
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ env.GCP_PROJECT_ID }}
 

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -398,7 +398,13 @@ jobs:
           # to stay within Atlas storage quota limits
           EXCLUDE_COLLECTIONS=(
             "flow_executions"
-            "webhook_events"
+            "webhookevents"
+            "cdc_change_events"
+            "cdc_state_transitions"
+            "query_executions"
+            "materialization_runs"
+            "chats"
+            "llmusages"
           )
           EXCLUDE_ARGS=""
           for col in "${EXCLUDE_COLLECTIONS[@]}"; do
@@ -416,6 +422,58 @@ jobs:
           fi
 
           echo "✅ Production database successfully copied to ephemeral database: ${EPHEMERAL_DB_NAME}"
+
+          # Create empty excluded collections with their indexes so the app
+          # schema is complete even though we skipped the data transfer.
+          echo "Creating empty excluded collections with indexes..."
+          mongosh "$EPHEMERAL_DB_URL" --quiet --eval "
+            db.createCollection('flow_executions');
+            db.flow_executions.createIndex({ flowId: 1, startedAt: -1 });
+
+            db.createCollection('webhookevents');
+            db.webhookevents.createIndex({ flowId: 1, eventId: 1 }, { unique: true });
+            db.webhookevents.createIndex({ flowId: 1, status: 1, receivedAt: 1 });
+            db.webhookevents.createIndex({ flowId: 1, applyStatus: 1, receivedAt: 1 });
+            db.webhookevents.createIndex({ workspaceId: 1, receivedAt: -1 });
+
+            db.createCollection('cdc_change_events');
+            db.cdc_change_events.createIndex({ idempotencyKey: 1 }, { unique: true });
+            db.cdc_change_events.createIndex({ flowId: 1, entity: 1, ingestSeq: 1 });
+            db.cdc_change_events.createIndex({ flowId: 1, entity: 1, recordId: 1, sourceTs: 1, ingestSeq: 1 }, { unique: true });
+            db.cdc_change_events.createIndex({ flowId: 1, entity: 1, sourceTs: 1, ingestSeq: 1 });
+            db.cdc_change_events.createIndex({ flowId: 1, entity: 1, materializationStatus: 1, ingestSeq: 1 });
+            db.cdc_change_events.createIndex({ flowId: 1, entity: 1, stageStatus: 1, ingestSeq: 1 });
+            db.cdc_change_events.createIndex({ appliedAt: 1 }, { expireAfterSeconds: 604800 });
+
+            db.createCollection('cdc_state_transitions');
+            db.cdc_state_transitions.createIndex({ flowId: 1, at: -1 });
+
+            db.createCollection('query_executions');
+            db.query_executions.createIndex({ workspaceId: 1, executedAt: -1 });
+            db.query_executions.createIndex({ userId: 1, executedAt: -1 });
+            db.query_executions.createIndex({ apiKeyId: 1, executedAt: -1 }, { sparse: true });
+            db.query_executions.createIndex({ workspaceId: 1, status: 1 });
+            db.query_executions.createIndex({ executedAt: 1 }, { expireAfterSeconds: 7776000 });
+
+            db.createCollection('materialization_runs');
+            db.materialization_runs.createIndex({ dashboardId: 1, dataSourceId: 1, requestedAt: -1 });
+            db.materialization_runs.createIndex({ workspaceId: 1, requestedAt: -1 });
+            db.materialization_runs.createIndex({ status: 1, lastHeartbeat: 1 });
+            db.materialization_runs.createIndex({ requestedAt: 1 }, { expireAfterSeconds: 2592000 });
+
+            db.createCollection('chats');
+            db.chats.createIndex({ workspaceId: 1 });
+            db.chats.createIndex({ workspaceId: 1, title: 1 });
+            db.chats.createIndex({ workspaceId: 1, createdBy: 1 });
+
+            db.createCollection('llmusages');
+            db.llmusages.createIndex({ workspaceId: 1, createdAt: -1 });
+            db.llmusages.createIndex({ userId: 1, createdAt: -1 });
+            db.llmusages.createIndex({ chatId: 1 });
+            db.llmusages.createIndex({ workspaceId: 1, userId: 1, createdAt: -1 });
+
+            print('Empty collections with indexes created');
+          "
 
           # Reset stale materialization statuses inherited from production.
           # Without this, dashboards stuck in "building" state from prod remain

--- a/.github/workflows/seed-database.yml
+++ b/.github/workflows/seed-database.yml
@@ -39,15 +39,15 @@ jobs:
           echo "✅ Confirmation validated: ${{ inputs.target_database }}"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: pnpm

--- a/.github/workflows/seed-database.yml
+++ b/.github/workflows/seed-database.yml
@@ -126,9 +126,26 @@ jobs:
           echo "Dropping existing ${{ inputs.target_database }} database..."
           mongosh "$TARGET_DATABASE_URL" --eval "db.dropDatabase()" || true
 
+          # Exclude large collections that aren't needed for staging/dev testing
+          EXCLUDE_COLLECTIONS=(
+            "flow_executions"
+            "webhookevents"
+            "cdc_change_events"
+            "cdc_state_transitions"
+            "query_executions"
+            "materialization_runs"
+            "chats"
+            "llmusages"
+          )
+          EXCLUDE_ARGS=""
+          for col in "${EXCLUDE_COLLECTIONS[@]}"; do
+            EXCLUDE_ARGS="${EXCLUDE_ARGS} --excludeCollection=${col}"
+          done
+
           # Copy production to target using archive pipe
           echo "Copying production data to ${{ inputs.target_database }}..."
-          if ! mongodump --uri="$PROD_DATABASE_URL" --gzip --archive | mongorestore --uri="$TARGET_DATABASE_URL" --gzip --archive \
+          echo "Excluding collections: ${EXCLUDE_COLLECTIONS[*]}"
+          if ! mongodump --uri="$PROD_DATABASE_URL" ${EXCLUDE_ARGS} --gzip --archive | mongorestore --uri="$TARGET_DATABASE_URL" --gzip --archive \
             --nsInclude="${PROD_DB_NAME}.*" \
             --nsFrom="${PROD_DB_NAME}.*" \
             --nsTo="${TARGET_DB_NAME}.*"; then
@@ -137,6 +154,57 @@ jobs:
           fi
 
           echo "✅ Production data successfully copied to ${{ inputs.target_database }}"
+
+          # Create empty excluded collections with their indexes
+          echo "Creating empty excluded collections with indexes..."
+          mongosh "$TARGET_DATABASE_URL" --quiet --eval "
+            db.createCollection('flow_executions');
+            db.flow_executions.createIndex({ flowId: 1, startedAt: -1 });
+
+            db.createCollection('webhookevents');
+            db.webhookevents.createIndex({ flowId: 1, eventId: 1 }, { unique: true });
+            db.webhookevents.createIndex({ flowId: 1, status: 1, receivedAt: 1 });
+            db.webhookevents.createIndex({ flowId: 1, applyStatus: 1, receivedAt: 1 });
+            db.webhookevents.createIndex({ workspaceId: 1, receivedAt: -1 });
+
+            db.createCollection('cdc_change_events');
+            db.cdc_change_events.createIndex({ idempotencyKey: 1 }, { unique: true });
+            db.cdc_change_events.createIndex({ flowId: 1, entity: 1, ingestSeq: 1 });
+            db.cdc_change_events.createIndex({ flowId: 1, entity: 1, recordId: 1, sourceTs: 1, ingestSeq: 1 }, { unique: true });
+            db.cdc_change_events.createIndex({ flowId: 1, entity: 1, sourceTs: 1, ingestSeq: 1 });
+            db.cdc_change_events.createIndex({ flowId: 1, entity: 1, materializationStatus: 1, ingestSeq: 1 });
+            db.cdc_change_events.createIndex({ flowId: 1, entity: 1, stageStatus: 1, ingestSeq: 1 });
+            db.cdc_change_events.createIndex({ appliedAt: 1 }, { expireAfterSeconds: 604800 });
+
+            db.createCollection('cdc_state_transitions');
+            db.cdc_state_transitions.createIndex({ flowId: 1, at: -1 });
+
+            db.createCollection('query_executions');
+            db.query_executions.createIndex({ workspaceId: 1, executedAt: -1 });
+            db.query_executions.createIndex({ userId: 1, executedAt: -1 });
+            db.query_executions.createIndex({ apiKeyId: 1, executedAt: -1 }, { sparse: true });
+            db.query_executions.createIndex({ workspaceId: 1, status: 1 });
+            db.query_executions.createIndex({ executedAt: 1 }, { expireAfterSeconds: 7776000 });
+
+            db.createCollection('materialization_runs');
+            db.materialization_runs.createIndex({ dashboardId: 1, dataSourceId: 1, requestedAt: -1 });
+            db.materialization_runs.createIndex({ workspaceId: 1, requestedAt: -1 });
+            db.materialization_runs.createIndex({ status: 1, lastHeartbeat: 1 });
+            db.materialization_runs.createIndex({ requestedAt: 1 }, { expireAfterSeconds: 2592000 });
+
+            db.createCollection('chats');
+            db.chats.createIndex({ workspaceId: 1 });
+            db.chats.createIndex({ workspaceId: 1, title: 1 });
+            db.chats.createIndex({ workspaceId: 1, createdBy: 1 });
+
+            db.createCollection('llmusages');
+            db.llmusages.createIndex({ workspaceId: 1, createdAt: -1 });
+            db.llmusages.createIndex({ userId: 1, createdAt: -1 });
+            db.llmusages.createIndex({ chatId: 1 });
+            db.llmusages.createIndex({ workspaceId: 1, userId: 1, createdAt: -1 });
+
+            print('Empty collections with indexes created');
+          "
 
       - name: Run migrations
         env:

--- a/restore.sh
+++ b/restore.sh
@@ -8,11 +8,81 @@ TO=$DATABASE_URL
 # Extract the database name from the URI (last path segment before query string)
 TO_DB=$(echo "$TO" | sed -E 's|.*\/([^/?]+)(\?.*)?$|\1|')
 
+FROM_DB=$(echo "$FROM" | sed -E 's|.*\/([^/?]+)(\?.*)?$|\1|')
+
+# Exclude large collections that aren't needed for local development
+EXCLUDE_COLLECTIONS=(
+  "flow_executions"
+  "webhookevents"
+  "cdc_change_events"
+  "cdc_state_transitions"
+  "query_executions"
+  "materialization_runs"
+  "chats"
+  "llmusages"
+)
+EXCLUDE_ARGS=""
+for col in "${EXCLUDE_COLLECTIONS[@]}"; do
+  EXCLUDE_ARGS="${EXCLUDE_ARGS} --excludeCollection=${col}"
+done
+
 echo "Restoring from production → $TO_DB ..."
+echo "Excluding collections: ${EXCLUDE_COLLECTIONS[*]}"
 mongosh "$TO" --eval "db.dropDatabase()"
 
-mongodump --uri="$FROM" --gzip --archive | mongorestore --uri="$TO" --gzip --archive \
-  --nsInclude="production.*" \
-  --nsFrom="production.*" \
+mongodump --uri="$FROM" ${EXCLUDE_ARGS} --gzip --archive | mongorestore --uri="$TO" --gzip --archive \
+  --nsInclude="${FROM_DB}.*" \
+  --nsFrom="${FROM_DB}.*" \
   --nsTo="${TO_DB}.*"
+
+echo "Creating empty excluded collections with indexes..."
+mongosh "$TO" --quiet --eval "
+  db.createCollection('flow_executions');
+  db.flow_executions.createIndex({ flowId: 1, startedAt: -1 });
+
+  db.createCollection('webhookevents');
+  db.webhookevents.createIndex({ flowId: 1, eventId: 1 }, { unique: true });
+  db.webhookevents.createIndex({ flowId: 1, status: 1, receivedAt: 1 });
+  db.webhookevents.createIndex({ flowId: 1, applyStatus: 1, receivedAt: 1 });
+  db.webhookevents.createIndex({ workspaceId: 1, receivedAt: -1 });
+
+  db.createCollection('cdc_change_events');
+  db.cdc_change_events.createIndex({ idempotencyKey: 1 }, { unique: true });
+  db.cdc_change_events.createIndex({ flowId: 1, entity: 1, ingestSeq: 1 });
+  db.cdc_change_events.createIndex({ flowId: 1, entity: 1, recordId: 1, sourceTs: 1, ingestSeq: 1 }, { unique: true });
+  db.cdc_change_events.createIndex({ flowId: 1, entity: 1, sourceTs: 1, ingestSeq: 1 });
+  db.cdc_change_events.createIndex({ flowId: 1, entity: 1, materializationStatus: 1, ingestSeq: 1 });
+  db.cdc_change_events.createIndex({ flowId: 1, entity: 1, stageStatus: 1, ingestSeq: 1 });
+  db.cdc_change_events.createIndex({ appliedAt: 1 }, { expireAfterSeconds: 604800 });
+
+  db.createCollection('cdc_state_transitions');
+  db.cdc_state_transitions.createIndex({ flowId: 1, at: -1 });
+
+  db.createCollection('query_executions');
+  db.query_executions.createIndex({ workspaceId: 1, executedAt: -1 });
+  db.query_executions.createIndex({ userId: 1, executedAt: -1 });
+  db.query_executions.createIndex({ apiKeyId: 1, executedAt: -1 }, { sparse: true });
+  db.query_executions.createIndex({ workspaceId: 1, status: 1 });
+  db.query_executions.createIndex({ executedAt: 1 }, { expireAfterSeconds: 7776000 });
+
+  db.createCollection('materialization_runs');
+  db.materialization_runs.createIndex({ dashboardId: 1, dataSourceId: 1, requestedAt: -1 });
+  db.materialization_runs.createIndex({ workspaceId: 1, requestedAt: -1 });
+  db.materialization_runs.createIndex({ status: 1, lastHeartbeat: 1 });
+  db.materialization_runs.createIndex({ requestedAt: 1 }, { expireAfterSeconds: 2592000 });
+
+  db.createCollection('chats');
+  db.chats.createIndex({ workspaceId: 1 });
+  db.chats.createIndex({ workspaceId: 1, title: 1 });
+  db.chats.createIndex({ workspaceId: 1, createdBy: 1 });
+
+  db.createCollection('llmusages');
+  db.llmusages.createIndex({ workspaceId: 1, createdAt: -1 });
+  db.llmusages.createIndex({ userId: 1, createdAt: -1 });
+  db.llmusages.createIndex({ chatId: 1 });
+  db.llmusages.createIndex({ workspaceId: 1, userId: 1, createdAt: -1 });
+
+  print('Empty collections with indexes created');
+"
+
 echo "Done!"


### PR DESCRIPTION
## Summary

- Expanded `EXCLUDE_COLLECTIONS` from 2 to 8 in the ephemeral DB rebuild step: added `cdc_change_events`, `cdc_state_transitions`, `query_executions`, `materialization_runs`, `chats`, and `llmusages`
- Fixed `webhook_events` → `webhookevents` to match the actual Mongoose collection name (the old exclude was likely a no-op)
- After restore, creates all excluded collections empty with their proper indexes so the app schema is complete
- Applied the same changes to `seed-database.yml` and `restore.sh` which previously had zero excludes

## Why

The ephemeral DB rebuild was piping GBs of append-only event/log data through `mongodump | mongorestore` -- CDC change logs, webhook payloads, chat history, query audit logs, LLM usage records -- none of which are needed for PR preview testing (scheduled sync is disabled via `DISABLE_SCHEDULED_SYNC=true`). This caused 25+ minute builds and disk exhaustion failures.

## Test plan

- [ ] Manually trigger the deploy workflow for this PR with `rebuild_db: true` to validate the ephemeral DB rebuild completes fast and the preview app starts without errors
- [ ] Verify the preview app can load dashboards, run queries, and navigate without missing-collection errors

Made with [Cursor](https://cursor.com)