### PR TITLE
fix: reduce CDC event retention to 7 days

### DIFF
--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -1955,6 +1955,10 @@ WebhookEventSchema.index({ flowId: 1, eventId: 1 }, { unique: true });
 WebhookEventSchema.index({ flowId: 1, status: 1, receivedAt: 1 });
 WebhookEventSchema.index({ flowId: 1, applyStatus: 1, receivedAt: 1 });
 WebhookEventSchema.index({ workspaceId: 1, receivedAt: -1 });
+WebhookEventSchema.index(
+  { receivedAt: 1 },
+  { expireAfterSeconds: 7 * 24 * 60 * 60 },
+);
 
 /**
  * CdcChangeEvent Schema
@@ -2283,7 +2287,7 @@ MaterializationRunSchema.index({ workspaceId: 1, requestedAt: -1 });
 MaterializationRunSchema.index({ status: 1, lastHeartbeat: 1 });
 MaterializationRunSchema.index(
   { requestedAt: 1 },
-  { expireAfterSeconds: 2592000 },
+  { expireAfterSeconds: 7 * 24 * 60 * 60 },
 );
 
 /**

--- a/api/src/inngest/functions/webhook-flow.ts
+++ b/api/src/inngest/functions/webhook-flow.ts
@@ -940,33 +940,17 @@ export const webhookEventProcessCdcFunction = inngest.createFunction(
 );
 
 /**
- * Cleanup old webhook events (simplified version)
+ * @deprecated TTL index on receivedAt (7 days) now handles cleanup automatically.
+ * Kept as a no-op so Inngest doesn't error on the registered function ID.
  */
 export const webhookCleanupFunction = inngest.createFunction(
   {
     id: "webhook-cleanup",
-    name: "Cleanup Old Webhook Events",
+    name: "Cleanup Old Webhook Events (deprecated - TTL handles this)",
   },
-  { cron: "0 2 * * *" }, // Run daily at 2 AM
-  async ({ step, logger }) => {
-    const result = await step.run("cleanup-old-events", async () => {
-      const thirtyDaysAgo = new Date();
-      thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
-
-      // Delete completed events older than 30 days
-      const deleteResult = await WebhookEvent.deleteMany({
-        status: "completed",
-        processedAt: { $lt: thirtyDaysAgo },
-      });
-
-      logger.info("Cleaned up old webhook events", {
-        deleted: deleteResult.deletedCount,
-      });
-
-      return { deleted: deleteResult.deletedCount };
-    });
-
-    return result;
+  { cron: "0 2 * * *" },
+  async () => {
+    return { skipped: true, reason: "TTL index on receivedAt handles cleanup" };
   },
 );
 

--- a/api/src/migrations/2026-04-15-000000_webhook_event_7d_ttl_and_matrun_ttl_reduction.ts
+++ b/api/src/migrations/2026-04-15-000000_webhook_event_7d_ttl_and_matrun_ttl_reduction.ts
@@ -1,0 +1,79 @@
+import { Db } from "mongodb";
+
+export const description =
+  "Add 7-day TTL on webhook_events.receivedAt and reduce materialization_runs TTL from 30d to 7d";
+
+const WEBHOOK_EVENTS = "webhook_events";
+const MATERIALIZATION_RUNS = "materialization_runs";
+const SEVEN_DAYS = 7 * 24 * 60 * 60; // 604800
+
+type IndexInfo = {
+  name: string;
+  key?: Record<string, unknown>;
+  expireAfterSeconds?: number;
+};
+
+function isSingleFieldIndex(index: IndexInfo, field: string): boolean {
+  const key = index.key;
+  if (!key) return false;
+  const keys = Object.keys(key);
+  return keys.length === 1 && keys[0] === field;
+}
+
+export async function up(db: Db): Promise<void> {
+  const collections = (await db.listCollections().toArray()).map(c => c.name);
+
+  // --- WebhookEvent: add 7-day TTL on receivedAt ---
+  if (collections.includes(WEBHOOK_EVENTS)) {
+    const col = db.collection(WEBHOOK_EVENTS);
+    const indexes = (await col.indexes()) as IndexInfo[];
+    const receivedAtIndexes = indexes.filter(i =>
+      isSingleFieldIndex(i, "receivedAt"),
+    );
+    const hasDesiredTtl = receivedAtIndexes.some(
+      i => i.expireAfterSeconds === SEVEN_DAYS,
+    );
+
+    if (!hasDesiredTtl) {
+      for (const idx of receivedAtIndexes) {
+        if (idx.expireAfterSeconds != null) {
+          await col.dropIndex(idx.name);
+        }
+      }
+
+      await col.createIndex(
+        { receivedAt: 1 },
+        {
+          name: "webhook_events_ttl_7d",
+          expireAfterSeconds: SEVEN_DAYS,
+        },
+      );
+    }
+  }
+
+  // --- MaterializationRun: reduce TTL from 30d to 7d on requestedAt ---
+  if (collections.includes(MATERIALIZATION_RUNS)) {
+    const col = db.collection(MATERIALIZATION_RUNS);
+    const indexes = (await col.indexes()) as IndexInfo[];
+    const requestedAtTtlIndexes = indexes.filter(
+      i => isSingleFieldIndex(i, "requestedAt") && i.expireAfterSeconds != null,
+    );
+    const hasDesiredTtl = requestedAtTtlIndexes.some(
+      i => i.expireAfterSeconds === SEVEN_DAYS,
+    );
+
+    if (!hasDesiredTtl) {
+      for (const idx of requestedAtTtlIndexes) {
+        await col.dropIndex(idx.name);
+      }
+
+      await col.createIndex(
+        { requestedAt: 1 },
+        {
+          name: "matrun_ttl_7d",
+          expireAfterSeconds: SEVEN_DAYS,
+        },
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a 7-day TTL index on `webhook_events.receivedAt` — MongoDB auto-deletes all webhook events (completed, failed, pending) after 7 days, replacing the previous 30-day completed-only cron cleanup
- Reduces `materialization_runs` TTL from 30 days to 7 days to match
- Deprecates `webhookCleanupFunction` Inngest cron (kept as no-op to avoid registration errors)
- Includes migration to drop old TTL indexes and create new 7-day ones in production

## Test plan
- [ ] Verify migration runs cleanly (`pnpm migrate`)
- [ ] Confirm TTL indexes exist on `webhook_events.receivedAt` and `materialization_runs.requestedAt` with 604800s expiry
- [ ] Verify `webhookCleanupFunction` still registers but returns immediately


Made with [Cursor](https://cursor.com)