### PR TITLE
fix: add 7-day TTL on WebhookEvent, remove cleanup cron, reduce scheduler to 5min

### DIFF
--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -1955,6 +1955,10 @@ WebhookEventSchema.index({ flowId: 1, eventId: 1 }, { unique: true });
 WebhookEventSchema.index({ flowId: 1, status: 1, receivedAt: 1 });
 WebhookEventSchema.index({ flowId: 1, applyStatus: 1, receivedAt: 1 });
 WebhookEventSchema.index({ workspaceId: 1, receivedAt: -1 });
+WebhookEventSchema.index(
+  { receivedAt: 1 },
+  { expireAfterSeconds: 7 * 24 * 60 * 60 },
+);
 
 /**
  * CdcChangeEvent Schema

--- a/api/src/inngest/functions/webhook-flow.ts
+++ b/api/src/inngest/functions/webhook-flow.ts
@@ -603,35 +603,10 @@ export const webhookEventProcessCdcFunction = inngest.createFunction(
 );
 
 /**
- * Cleanup old webhook events (simplified version)
+ * webhookCleanupFunction — REMOVED.
+ * Superseded by a TTL index on webhookevents.receivedAt (7 days).
+ * MongoDB's background thread handles expiration automatically.
  */
-export const webhookCleanupFunction = inngest.createFunction(
-  {
-    id: "webhook-cleanup",
-    name: "Cleanup Old Webhook Events",
-  },
-  { cron: "0 2 * * *" }, // Run daily at 2 AM
-  async ({ step, logger }) => {
-    const result = await step.run("cleanup-old-events", async () => {
-      const thirtyDaysAgo = new Date();
-      thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
-
-      // Delete completed events older than 30 days
-      const deleteResult = await WebhookEvent.deleteMany({
-        status: "completed",
-        processedAt: { $lt: thirtyDaysAgo },
-      });
-
-      logger.info("Cleaned up old webhook events", {
-        deleted: deleteResult.deletedCount,
-      });
-
-      return { deleted: deleteResult.deletedCount };
-    });
-
-    return result;
-  },
-);
 
 /**
  * Retry failed / stuck webhook events.
@@ -1312,7 +1287,7 @@ export const cdcMaterializeSchedulerFunction = inngest.createFunction(
     name: "CDC Ingest + Materialize Scheduler",
     concurrency: { limit: 1 },
   },
-  { cron: "*/2 * * * *" },
+  { cron: "*/5 * * * *" },
   async ({ step, logger }) => {
     const ingestResult = (await step.run("ingest-pending-webhooks", () =>
       ingestPendingWebhookEvents(logger),

--- a/api/src/inngest/index.ts
+++ b/api/src/inngest/index.ts
@@ -9,7 +9,6 @@ import {
 import {
   webhookEventProcessFunction,
   webhookEventProcessCdcFunction,
-  webhookCleanupFunction,
   webhookRetryFunction,
   cdcMaterializeFunction,
   cdcMaterializeSchedulerFunction,
@@ -35,7 +34,6 @@ const baseFunctions = [
 const allWebhookFunctions = [
   webhookEventProcessFunction,
   webhookEventProcessCdcFunction,
-  webhookCleanupFunction,
   webhookRetryFunction,
   cdcMaterializeFunction,
   cdcMaterializeSchedulerFunction,
@@ -104,7 +102,6 @@ export {
   syncBackfillEntityFunction,
   webhookEventProcessFunction,
   webhookEventProcessCdcFunction,
-  webhookCleanupFunction,
   webhookRetryFunction,
   cdcMaterializeFunction,
   cdcMaterializeSchedulerFunction,

--- a/api/src/migrations/2026-04-15-210000_add_webhook_event_ttl_index.ts
+++ b/api/src/migrations/2026-04-15-210000_add_webhook_event_ttl_index.ts
@@ -1,0 +1,29 @@
+import { Db } from "mongodb";
+import { loggers } from "../logging";
+
+const log = loggers.migration();
+
+export const description =
+  "Add TTL index on webhookevents.receivedAt to auto-expire documents after 7 days";
+
+export async function up(db: Db): Promise<void> {
+  const collection = db.collection("webhookevents");
+
+  const indexes = await collection.indexes();
+  const hasIndex = indexes.some(
+    idx => JSON.stringify(idx.key) === JSON.stringify({ receivedAt: 1 }),
+  );
+
+  if (!hasIndex) {
+    await collection.createIndex(
+      { receivedAt: 1 },
+      {
+        expireAfterSeconds: 7 * 24 * 60 * 60,
+        name: "webhookevents_receivedAt_ttl_7d",
+      },
+    );
+    log.info("Created TTL index on webhookevents.receivedAt (7 days)");
+  } else {
+    log.info("TTL index on webhookevents.receivedAt already exists");
+  }
+}


### PR DESCRIPTION
## Summary

- **TTL index on `webhookevents.receivedAt`** (7 days) — MongoDB auto-expires documents, replacing the `webhookCleanupFunction` which only deleted `completed` events after 30 days and missed other terminal states
- **Remove `webhookCleanupFunction`** — now redundant with the TTL index
- **Reduce CDC scheduler cron from `*/2` to `*/5`** — cuts Inngest invocations from 720/day to 288/day; most off-hours runs are no-ops

## Impact

| Metric | Before | After |
|---|---|---|
| WebhookEvent retention | 30 days (completed only) | 7 days (all statuses) |
| Cleanup mechanism | Inngest cron (daily 2AM) | MongoDB TTL index (automatic) |
| CDC scheduler frequency | Every 2 min (720/day) | Every 5 min (288/day) |
| Inngest functions registered | 15 | 14 |

## Test plan

- [ ] Migration creates the TTL index on `webhookevents.receivedAt`
- [ ] Verify MongoDB background thread starts expiring old documents
- [ ] CDC scheduler still triggers materializations within 5 minutes
- [ ] No regressions in webhook event processing or retry paths

Made with [Cursor](https://cursor.com)