### PR TITLE
feat: allow promotion codes on Stripe Checkout

### DIFF
--- a/api/src/billing/billing.service.ts
+++ b/api/src/billing/billing.service.ts
@@ -94,6 +94,7 @@ export async function createCheckoutSession(
         price: getStripeOveragePriceId(),
       },
     ],
+    allow_promotion_codes: true,
     success_url: successUrl,
     cancel_url: cancelUrl,
     metadata: {


### PR DESCRIPTION
## Summary
- Enables the promo code input field on the Stripe Checkout page by adding `allow_promotion_codes: true` to the checkout session config.
- This allows coupons and promotion codes (e.g. internal dev codes) to be applied at subscription time.

## Test plan
- [ ] Start a checkout flow and verify the "Add promotion code" link appears on the Stripe Checkout page
- [ ] Apply a valid promotion code and confirm the discount is reflected

Made with [Cursor](https://cursor.com)