### PR TITLE
docs: fix AI models section, document SSH tunneling and Stripe billing

### DIFF
--- a/docs/src/content/docs/ai-agent.md
+++ b/docs/src/content/docs/ai-agent.md
@@ -98,11 +98,30 @@ The agent handles edit-mode locking, so concurrent users cannot conflict.
 
 ## AI Models
 
-Mako supports multiple providers. Configure API keys in `.env` and users select their preferred model in the UI:
+Mako routes all AI requests through the **Vercel AI Gateway**, which provides access to 180+ models across Anthropic, OpenAI, Google, DeepSeek, and others. Only `AI_GATEWAY_API_KEY` is required — no individual provider API keys needed.
 
-- **Anthropic** — Claude Sonnet 4, Claude Opus 4 (with extended thinking)
-- **OpenAI** — GPT-4o, GPT-5.2, GPT-5.2 Codex
-- **Google** — Gemini 2.5 Pro, Gemini 2.5 Flash
+Models are discovered dynamically at runtime by merging the Gateway model catalog with [arena.ai](https://arena.ai) code leaderboard ELO scores. The catalog refreshes hourly.
+
+### Free vs Pro Models
+
+When billing is enabled, models are split into two tiers:
+
+| Tier | Criteria | Examples |
+|------|----------|---------|
+| **Free** | Blended cost ≤ $3 / 1M tokens | GPT-4o Mini, Gemini 2.5 Flash, DeepSeek Chat |
+| **Pro** | All other models | Claude Sonnet 4, GPT-4o, Gemini 2.5 Pro |
+
+The top 3 free-tier models are auto-selected by ELO ranking. Free users are gated to free-tier models. Pro users can access all models.
+
+When billing is disabled (self-hosted default), all models are available to all users.
+
+### Thinking / Reasoning Models
+
+Models tagged with `reasoning` in the Gateway catalog automatically enable extended thinking. Budget tokens are set to 10,000 by default.
+
+### Model Selection
+
+Users pick their preferred model in the chat UI. The model is persisted per-user in workspace settings. If a user's saved model becomes unavailable (e.g. billing downgrade), Mako falls back to the best available model for their plan.
 
 ## Safety
 

--- a/docs/src/content/docs/api-reference.md
+++ b/docs/src/content/docs/api-reference.md
@@ -157,3 +157,36 @@ The response is a **Server-Sent Events (SSE)** stream:
 | Method | Endpoint       | Description                        |
 | ------ | -------------- | ---------------------------------- |
 | `POST` | `/api/inngest` | Inngest webhook handler (internal) |
+
+## Billing
+
+Subscription management endpoints. All require workspace membership. When `BILLING_ENABLED` is `false` (self-hosted default), all endpoints return `{ "billingEnabled": false }`.
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/api/workspaces/:wid/billing/status` | Get plan, usage quota, and subscription status |
+| `POST` | `/api/workspaces/:wid/billing/checkout` | Create a Stripe Checkout session (returns `{ url }`) |
+| `POST` | `/api/workspaces/:wid/billing/portal` | Create a Stripe Customer Portal session (returns `{ url }`) |
+
+### Billing Status Response
+
+```json
+{
+  "billingEnabled": true,
+  "plan": "free",
+  "subscriptionStatus": null,
+  "usageQuotaUsd": 5,
+  "hardLimitUsd": 5,
+  "currentUsageUsd": 1.23,
+  "modelTier": "free",
+  "maxDatabases": 3,
+  "maxMembers": 3
+}
+```
+
+### Error Codes
+
+| Status | Description |
+|--------|-------------|
+| 403 | Not a workspace owner or admin |
+| 409 | Active subscription already exists (on checkout) |

--- a/docs/src/content/docs/databases/connect-databases.md
+++ b/docs/src/content/docs/databases/connect-databases.md
@@ -57,6 +57,22 @@ Standard connection string format:
 mysql://user:password@host:3306/database
 ```
 
+#### SSH Tunnel
+
+If your MySQL server is not directly accessible (e.g. it's behind a bastion host or inside a private VPC), Mako supports SSH tunneling. Enable it in the connection settings and provide:
+
+| Field | Description |
+|-------|-------------|
+| **SSH Host** | Hostname or IP of the SSH bastion/jumphost |
+| **SSH Port** | Port for SSH (default: 22) |
+| **SSH Username** | Username to authenticate with on the bastion |
+| **Auth Method** | `Password` or `Private Key` |
+| **Password / Private Key** | Credentials for SSH authentication. Private keys can be RSA/Ed25519. Optional passphrase supported. |
+| **Remote Host** | The MySQL host as seen *from* the bastion (often `127.0.0.1` or a private hostname) |
+| **Remote Port** | MySQL port on the remote side (default: 3306) |
+
+Mako opens the tunnel, forwards traffic through a local ephemeral port, and reuses the tunnel for subsequent queries (idle tunnels expire after 5 minutes).
+
 ### MongoDB
 
 When connecting via MongoDB Atlas, the connection string format differs from what Atlas shows:

--- a/docs/src/content/docs/deployment.md
+++ b/docs/src/content/docs/deployment.md
@@ -69,6 +69,11 @@ Set these in Cloud Run's environment configuration (or via `cloud-run-env.yaml`)
 | `GOOGLE_CLIENT_ID` + `SECRET`  | Optional    | Google OAuth                             |
 | `GH_CLIENT_ID` + `SECRET`      | Optional    | GitHub OAuth                             |
 | `SENDGRID_API_KEY`             | Optional    | Email invitations                        |
+| `BILLING_ENABLED`              | Optional    | Set `true` to enable Stripe billing (default: `false`) |
+| `STRIPE_SECRET_KEY`            | Optional    | Stripe secret key (required if billing enabled) |
+| `STRIPE_WEBHOOK_SECRET`        | Optional    | Stripe webhook signing secret |
+| `STRIPE_PRO_PRICE_ID`          | Optional    | Stripe Price ID for the Pro monthly subscription |
+| `STRIPE_METER_EVENT_NAME`      | Optional    | Stripe meter event name for usage reporting (default: `llm_usage_usd`) |
 
 ### Dashboard Artifact Storage
 
@@ -164,6 +169,35 @@ artifacts, delete stale artifacts, and generate signed read URLs.
 - Preview environments should use a unique prefix such as
   `dashboard-artifacts/pr-123` so all previews can safely share the same
   bucket.
+
+## Billing (Optional)
+
+Mako includes an optional Stripe-based subscription billing system. It is **disabled by default** — self-hosted and open-source deployments have unlimited access to all models and features.
+
+To enable billing for a hosted/SaaS deployment, set `BILLING_ENABLED=true` and configure the Stripe env vars above.
+
+### Plans
+
+| Plan | Free Quota | Hard Limit | Model Access | Max Databases | Max Members |
+|------|-----------|------------|-------------|--------------|------------|
+| **Free** | $5 / month | $5 | Free-tier models only (≤$3/M) | 3 | 3 |
+| **Pro** | $80 / month | None (overage billed) | All models | 50 | 25 |
+
+### Billing API Endpoints
+
+All endpoints are mounted at `/api/workspaces/:workspaceId/billing`:
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/api/workspaces/:wid/billing/status` | Get current plan, usage, and subscription status |
+| `POST` | `/api/workspaces/:wid/billing/checkout` | Create a Stripe Checkout session (upgrade to Pro) |
+| `POST` | `/api/workspaces/:wid/billing/portal` | Create a Stripe Customer Portal session (manage subscription) |
+
+Stripe webhooks are handled at `/api/stripe-webhook` with signature verification.
+
+### Promotion Codes
+
+Stripe promotion codes/coupons can be applied at checkout. The Stripe Checkout UI includes a promo code input field.
 
 ## Cloudflare Workers
 


### PR DESCRIPTION
## Summary

Fixes documentation drift from 3 recent feature deployments that shipped without docs updates.

### Changes

**`ai-agent.md` (P0 fix — factually wrong)**
- The AI Models section listed hardcoded providers/models (Claude Sonnet 4, GPT-5.2, Gemini 2.5 Pro, etc.) that no longer apply
- Mako now uses the Vercel AI Gateway dynamic catalog (180+ models, ELO-ranked via arena.ai)
- Added: free vs pro model tier explanation, thinking/reasoning model detection, model fallback behavior
- Closes drift from: `feat: dynamic model discovery via AI Gateway + arena.ai leaderboard`

**`databases/connect-databases.md` (P1 — missing feature)**
- Added SSH tunnel section under MySQL with full field reference (host, port, username, auth method, private key, passphrase, remote host/port)
- Documents idle tunnel behavior (5-min expiry) and connection reuse
- Closes drift from: `feat: add SSH tunnel support for MySQL connections`

**`deployment.md` (P1 — missing feature)**
- Added Stripe/billing env vars to the environment variable table
- Added full Billing section: free/pro plan limits, billing API endpoints, promo code support, self-hosted default (BILLING_ENABLED=false)
- Closes drift from: `feat: implement subscription billing system with Stripe`, `feat: allow promotion codes on Stripe Checkout`

**`api-reference.md` (P1 — missing feature)**
- Added Billing section documenting the 3 billing endpoints (GET status, POST checkout, POST portal)
- Includes status response schema and billing-disabled behavior for self-hosted deployments

### Files changed
- `docs/src/content/docs/ai-agent.md`
- `docs/src/content/docs/databases/connect-databases.md`
- `docs/src/content/docs/deployment.md`
- `docs/src/content/docs/api-reference.md`