### PR TITLE
fix: BigQuery schema evolution — auto-correct type drift in live tables

### DIFF
--- a/api/src/routes/flows.ts
+++ b/api/src/routes/flows.ts
@@ -31,6 +31,8 @@ import { resolveConfiguredEntities } from "../sync-cdc/entity-selection";
 import { syncConnectorRegistry } from "../sync/connector-registry";
 import { databaseDataSourceManager } from "../sync/database-data-source-manager";
 import { BIGQUERY_WORKING_DATASET } from "../utils/bigquery-working-dataset";
+import { databaseConnectionService } from "../services/database-connection.service";
+import { mapLogicalTypeToBigQuery } from "../sync-cdc/adapters/bigquery";
 
 const logger = loggers.inngest("flow");
 
@@ -2630,6 +2632,189 @@ flowRoutes.get("/:flowId/sync-cdc/status", async c => {
           reason: t.reason,
         })),
       },
+    });
+  } catch (error) {
+    return c.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      },
+      400,
+    );
+  }
+});
+
+// GET /api/workspaces/:workspaceId/flows/:flowId/sync-cdc/schema-health
+// Compare live destination column types against the connector schema to surface drift.
+flowRoutes.get("/:flowId/sync-cdc/schema-health", async c => {
+  try {
+    const workspaceId = c.req.param("workspaceId") as string;
+    const flowId = c.req.param("flowId") as string;
+    const entityFilter = c.req.query("entity");
+
+    const flow = await Flow.findOne({
+      _id: new Types.ObjectId(flowId),
+      workspaceId: new Types.ObjectId(workspaceId),
+    }).lean();
+    if (!flow) {
+      return c.json({ success: false, error: "Flow not found" }, 404);
+    }
+    if (flow.syncEngine !== "cdc") {
+      return c.json(
+        { success: false, error: "Schema health requires syncEngine=cdc" },
+        400,
+      );
+    }
+    if (
+      !flow.tableDestination?.connectionId ||
+      !flow.tableDestination?.schema
+    ) {
+      return c.json(
+        {
+          success: false,
+          error: "Flow has no destination table configuration",
+        },
+        400,
+      );
+    }
+
+    const destination = await DatabaseConnection.findById(
+      flow.tableDestination.connectionId,
+    );
+    if (!destination) {
+      return c.json(
+        { success: false, error: "Destination connection not found" },
+        404,
+      );
+    }
+
+    if (destination.type !== "bigquery") {
+      return c.json(
+        {
+          success: false,
+          error:
+            "Schema health is currently only supported for BigQuery destinations",
+        },
+        400,
+      );
+    }
+
+    const { entities: configuredEntities } = resolveConfiguredEntities(
+      flow as any,
+    );
+    const targetEntities = entityFilter
+      ? configuredEntities.filter(e => e === entityFilter)
+      : configuredEntities;
+
+    if (targetEntities.length === 0) {
+      return c.json({
+        success: true,
+        data: { entities: [], hasDrift: false },
+      });
+    }
+
+    const connectorSchema: Map<
+      string,
+      Record<string, { type: string }>
+    > = new Map();
+    if (flow.dataSourceId) {
+      try {
+        const ds = await databaseDataSourceManager.getDataSource(
+          String(flow.dataSourceId),
+        );
+        if (ds) {
+          const connector = await syncConnectorRegistry.getConnector(ds);
+          if (connector?.resolveSchema) {
+            for (const entity of targetEntities) {
+              try {
+                const schema = await connector.resolveSchema(entity);
+                if (schema?.fields) {
+                  connectorSchema.set(entity, schema.fields as any);
+                }
+              } catch {
+                // skip entities where schema resolution fails
+              }
+            }
+          }
+        }
+      } catch {
+        // connector resolution failed — return empty schema health
+      }
+    }
+
+    const schema = flow.tableDestination.schema;
+    const conn = (destination as any).connection || {};
+    const connLocation: string | undefined = conn.location;
+    const results: Array<{
+      entity: string;
+      columns: Array<{
+        column: string;
+        liveType: string;
+        expectedType: string;
+        status: "match" | "drift";
+      }>;
+      hasDrift: boolean;
+    }> = [];
+    let globalHasDrift = false;
+
+    for (const entity of targetEntities) {
+      const fields = connectorSchema.get(entity);
+      if (!fields) {
+        results.push({ entity, columns: [], hasDrift: false });
+        continue;
+      }
+
+      const liveTable = cdcLiveTableName(
+        flow.tableDestination.tableName,
+        entity,
+        flowId,
+      );
+
+      const infoQuery = `SELECT column_name, data_type FROM \`${schema}\`.INFORMATION_SCHEMA.COLUMNS WHERE table_name = '${liveTable.replace(/'/g, "''")}'`;
+
+      const infoResult = await databaseConnectionService.executeQuery(
+        destination,
+        infoQuery,
+        { location: connLocation },
+      );
+
+      if (!infoResult.success || !Array.isArray(infoResult.data)) {
+        results.push({ entity, columns: [], hasDrift: false });
+        continue;
+      }
+
+      const liveTypes = new Map<string, string>();
+      for (const row of infoResult.data as any[]) {
+        liveTypes.set(row.column_name, row.data_type);
+      }
+
+      const columns: Array<{
+        column: string;
+        liveType: string;
+        expectedType: string;
+        status: "match" | "drift";
+      }> = [];
+      let entityHasDrift = false;
+
+      for (const [col, fieldDef] of Object.entries(fields)) {
+        const liveType = liveTypes.get(col);
+        if (!liveType) continue;
+        const expectedType = mapLogicalTypeToBigQuery((fieldDef as any).type);
+        const status =
+          liveType.toUpperCase() === expectedType.toUpperCase()
+            ? ("match" as const)
+            : ("drift" as const);
+        if (status === "drift") entityHasDrift = true;
+        columns.push({ column: col, liveType, expectedType, status });
+      }
+
+      if (entityHasDrift) globalHasDrift = true;
+      results.push({ entity, columns, hasDrift: entityHasDrift });
+    }
+
+    return c.json({
+      success: true,
+      data: { entities: results, hasDrift: globalHasDrift },
     });
   } catch (error) {
     return c.json(

--- a/api/src/sync-cdc/adapters/bigquery.ts
+++ b/api/src/sync-cdc/adapters/bigquery.ts
@@ -64,7 +64,9 @@ async function retryOnQuota<T>(
 // INSERT SELECT casts VARCHAR staging → typed live columns.
 // ---------------------------------------------------------------------------
 
-function mapLogicalTypeToBigQuery(logicalType: ConnectorLogicalType): string {
+export function mapLogicalTypeToBigQuery(
+  logicalType: ConnectorLogicalType,
+): string {
   switch (logicalType) {
     case "string":
       return "STRING";
@@ -96,24 +98,10 @@ function resolveTargetBqType(
   entitySchema: ConnectorEntitySchema | undefined,
   liveType: string | undefined,
 ): string {
-  // When the live table already existed, its types win so INSERT ... SELECT
-  // matches BigQuery (e.g. legacy STRING vs schema TIMESTAMP — avoids cast errors).
-  // When the table was just CREATE/ALTER'd from our schema, liveType comes from
-  // INFORMATION_SCHEMA after create (see mergeStagingToLive refresh) and matches schema.
+  // After evolveSchemaIfNeeded(), liveType already reflects the corrected type.
   if (liveType) return liveType;
   const schemaField = entitySchema?.fields[column];
-  if (schemaField) {
-    const schemaType = mapLogicalTypeToBigQuery(schemaField.type);
-    if (liveType && liveType.toUpperCase() !== schemaType.toUpperCase()) {
-      log.warn(
-        "Live table column type differs from connector schema; using live type to avoid INSERT failure. " +
-          "Recreate the destination table to adopt the correct schema type.",
-        { column, schemaType, liveType },
-      );
-      return liveType;
-    }
-    return schemaType;
-  }
+  if (schemaField) return mapLogicalTypeToBigQuery(schemaField.type);
   if (SYSTEM_COLUMN_TYPES[column]) return SYSTEM_COLUMN_TYPES[column];
   return "STRING";
 }
@@ -131,6 +119,7 @@ function buildCastExpression(colRef: string, targetType: string): string {
     case "FLOAT64":
       return `SAFE_CAST(${colRef} AS FLOAT64)`;
     case "STRING":
+      return `SAFE_CAST(${colRef} AS STRING)`;
     default:
       return colRef;
   }
@@ -457,9 +446,6 @@ export class BigQueryDestinationAdapter implements CdcDestinationAdapter {
         Array.from(stagingCols),
         entitySchema,
       );
-      // Re-read live columns from BigQuery so types match the created table (connector
-      // schema). Do not infer types only in JS — reset-entity + fresh CREATE must use
-      // TIMESTAMP etc. as actually defined in BQ, same as ongoing merges use live types.
       const refreshResult = await databaseConnectionService.executeQuery(
         destination,
         infoSchemaQuery,
@@ -485,6 +471,17 @@ export class BigQueryDestinationAdapter implements CdcDestinationAdapter {
         columnCount: liveCols.size,
       });
     }
+
+    // --- Schema evolution: correct drifted column types before merge ---
+    await this.evolveSchemaIfNeeded({
+      fullLive,
+      liveTable,
+      liveCols,
+      liveTypes,
+      entitySchema,
+      destination,
+      datasetLocation,
+    });
 
     const missingInLive = [...stagingCols].filter(c => !liveCols.has(c));
     const skippedLiveAdds: string[] = [];
@@ -703,6 +700,167 @@ export class BigQueryDestinationAdapter implements CdcDestinationAdapter {
       options?.stagingSuffix,
     );
     await this.dropStagingTable(stagingTable).catch(() => undefined);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Schema evolution — correct drifted live-table column types before merge.
+  //
+  // Follows Airbyte's BigqueryDirectLoadNativeTableOperations pattern:
+  //   1. ADD a temp column with the correct type
+  //   2. UPDATE to SAFE_CAST existing data into the temp column
+  //   3. Atomically RENAME the old column to a backup and the temp to the real name
+  //   4. DROP the backup column
+  //
+  // If any step fails for a column, that column is skipped and the merge
+  // proceeds using the existing (drifted) live type for that column only.
+  // ---------------------------------------------------------------------------
+
+  private async evolveSchemaIfNeeded(params: {
+    fullLive: string;
+    liveTable: string;
+    liveCols: Set<string>;
+    liveTypes: Map<string, string>;
+    entitySchema: ConnectorEntitySchema | undefined;
+    destination: IDatabaseConnection;
+    datasetLocation: string | undefined;
+  }): Promise<void> {
+    const {
+      fullLive,
+      liveTable,
+      liveCols,
+      liveTypes,
+      entitySchema,
+      destination,
+      datasetLocation,
+    } = params;
+    if (!entitySchema) return;
+
+    const drifted: Array<{
+      column: string;
+      actualType: string;
+      expectedType: string;
+    }> = [];
+
+    for (const col of liveCols) {
+      const schemaField = entitySchema.fields[col];
+      if (!schemaField) continue;
+      const expectedType = mapLogicalTypeToBigQuery(schemaField.type);
+      const actualType = liveTypes.get(col);
+      if (!actualType) continue;
+      if (actualType.toUpperCase() === expectedType.toUpperCase()) continue;
+      drifted.push({ column: col, actualType, expectedType });
+    }
+
+    if (drifted.length === 0) return;
+
+    log.info("Schema drift detected, attempting live-table evolution", {
+      liveTable,
+      drifted: drifted.map(
+        d => `${d.column}: ${d.actualType} -> ${d.expectedType}`,
+      ),
+    });
+
+    const evolved: string[] = [];
+    const skipped: string[] = [];
+
+    for (const { column, actualType, expectedType } of drifted) {
+      const tmpCol = `${column}_mako_tmp`;
+      const bakCol = `${column}_mako_bak`;
+
+      try {
+        await retryOnQuota(
+          async () => {
+            const r = await databaseConnectionService.executeQuery(
+              destination,
+              `ALTER TABLE ${fullLive} ADD COLUMN IF NOT EXISTS ${escId(tmpCol)} ${expectedType}`,
+              { location: datasetLocation },
+            );
+            if (!r.success) throw new Error(r.error || "ADD COLUMN failed");
+          },
+          { label: `evolveSchema:ADD(${column})` },
+        );
+
+        await retryOnQuota(
+          async () => {
+            const castExpr = buildCastExpression(escId(column), expectedType);
+            const r = await databaseConnectionService.executeQuery(
+              destination,
+              `UPDATE ${fullLive} SET ${escId(tmpCol)} = ${castExpr} WHERE 1=1`,
+              { location: datasetLocation },
+            );
+            if (!r.success) throw new Error(r.error || "UPDATE cast failed");
+          },
+          { label: `evolveSchema:UPDATE(${column})` },
+        );
+
+        await retryOnQuota(
+          async () => {
+            const r = await databaseConnectionService.executeQuery(
+              destination,
+              `ALTER TABLE ${fullLive} RENAME COLUMN ${escId(column)} TO ${escId(bakCol)}, RENAME COLUMN ${escId(tmpCol)} TO ${escId(column)}`,
+              { location: datasetLocation },
+            );
+            if (!r.success) throw new Error(r.error || "RENAME COLUMN failed");
+          },
+          { label: `evolveSchema:RENAME(${column})` },
+        );
+
+        await retryOnQuota(
+          async () => {
+            const r = await databaseConnectionService.executeQuery(
+              destination,
+              `ALTER TABLE ${fullLive} DROP COLUMN IF EXISTS ${escId(bakCol)}`,
+              { location: datasetLocation },
+            );
+            if (!r.success) throw new Error(r.error || "DROP COLUMN failed");
+          },
+          { label: `evolveSchema:DROP(${column})` },
+        );
+
+        liveTypes.set(column, expectedType);
+        evolved.push(column);
+        log.info("Schema evolution applied", {
+          liveTable,
+          column,
+          from: actualType,
+          to: expectedType,
+        });
+      } catch (err) {
+        skipped.push(column);
+        log.warn(
+          "Schema evolution failed for column; merge will use existing live type",
+          {
+            liveTable,
+            column,
+            from: actualType,
+            to: expectedType,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        );
+
+        // Best-effort cleanup of leftover temp/backup columns
+        for (const leftover of [tmpCol, bakCol]) {
+          try {
+            await databaseConnectionService.executeQuery(
+              destination,
+              `ALTER TABLE ${fullLive} DROP COLUMN IF EXISTS ${escId(leftover)}`,
+              { location: datasetLocation },
+            );
+          } catch {
+            // ignore cleanup failures
+          }
+        }
+      }
+    }
+
+    if (evolved.length > 0 || skipped.length > 0) {
+      log.info("Schema evolution summary", {
+        liveTable,
+        evolved,
+        skipped,
+        total: drifted.length,
+      });
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/app/src/components/BackfillPanel.tsx
+++ b/app/src/components/BackfillPanel.tsx
@@ -38,6 +38,7 @@ import {
   ExpandMore as ExpandMoreIcon,
   ExpandLess as ExpandLessIcon,
   Replay as RetryIcon,
+  WarningAmber as WarningAmberIcon,
 } from "@mui/icons-material";
 import { useFlowStore } from "../store/flowStore";
 
@@ -263,6 +264,7 @@ export function BackfillPanel({
     fetchFlowHistory,
     fetchWebhookEvents,
     fetchEntitySchema,
+    fetchEntitySchemaHealth,
     startCdcStream,
     pauseCdcStream,
     pauseCdcFlow,
@@ -321,6 +323,13 @@ export function BackfillPanel({
     },
     [expandedEntity, entitySchemaCache, fetchEntitySchema, workspaceId, flowId],
   );
+
+  const [entityDrift, setEntityDrift] = useState<
+    Record<
+      string,
+      Array<{ column: string; liveType: string; expectedType: string }>
+    >
+  >({});
 
   const [cdc, setCdc] = useState<any | null>(null);
   const [busy, setBusy] = useState(false);
@@ -520,6 +529,26 @@ export function BackfillPanel({
       if (cdcPollRef.current) clearInterval(cdcPollRef.current);
     };
   }, [pollCdc, isActive]);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchEntitySchemaHealth(workspaceId, flowId).then(result => {
+      if (cancelled || !result) return;
+      const driftMap: Record<
+        string,
+        Array<{ column: string; liveType: string; expectedType: string }>
+      > = {};
+      for (const ent of result.entities) {
+        if (ent.hasDrift) {
+          driftMap[ent.entity] = ent.columns.filter(c => c.status === "drift");
+        }
+      }
+      setEntityDrift(driftMap);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [fetchEntitySchemaHealth, workspaceId, flowId]);
 
   useEffect(() => {
     if (!isActive) return;
@@ -1300,6 +1329,27 @@ export function BackfillPanel({
                                   />
                                 )}
                                 {entityLabel(e.entity)}
+                                {entityDrift[e.entity]?.length > 0 && (
+                                  <Tooltip
+                                    title={
+                                      entityDrift[e.entity]
+                                        .map(
+                                          d =>
+                                            `${d.column}: ${d.liveType} → ${d.expectedType}`,
+                                        )
+                                        .join("\n") +
+                                      "\nWill be auto-corrected on next sync."
+                                    }
+                                  >
+                                    <WarningAmberIcon
+                                      sx={{
+                                        fontSize: 15,
+                                        color: "warning.main",
+                                        ml: 0.5,
+                                      }}
+                                    />
+                                  </Tooltip>
+                                )}
                               </Box>
                             </TableCell>
                             <TableCell>

--- a/app/src/store/flowStore.ts
+++ b/app/src/store/flowStore.ts
@@ -510,6 +510,23 @@ interface FlowStore extends FlowStoreState {
       { type: string; nullable?: boolean; required?: boolean }
     >;
   } | null>;
+  fetchEntitySchemaHealth: (
+    workspaceId: string,
+    flowId: string,
+    entity?: string,
+  ) => Promise<{
+    entities: Array<{
+      entity: string;
+      columns: Array<{
+        column: string;
+        liveType: string;
+        expectedType: string;
+        status: "match" | "drift";
+      }>;
+      hasDrift: boolean;
+    }>;
+    hasDrift: boolean;
+  } | null>;
   fetchFlowHistory: (
     workspaceId: string,
     flowId: string,
@@ -1261,6 +1278,33 @@ export const useFlowStore = create<FlowStore>()(
             };
           }>(
             `/workspaces/${workspaceId}/flows/${flowId}/schema?entity=${encodeURIComponent(entity)}`,
+          );
+          return response.success ? response.data : null;
+        } catch {
+          return null;
+        }
+      },
+
+      fetchEntitySchemaHealth: async (workspaceId, flowId, entity) => {
+        try {
+          const query = entity ? `?entity=${encodeURIComponent(entity)}` : "";
+          const response = await apiClient.get<{
+            success: boolean;
+            data: {
+              entities: Array<{
+                entity: string;
+                columns: Array<{
+                  column: string;
+                  liveType: string;
+                  expectedType: string;
+                  status: "match" | "drift";
+                }>;
+                hasDrift: boolean;
+              }>;
+              hasDrift: boolean;
+            };
+          }>(
+            `/workspaces/${workspaceId}/flows/${flowId}/sync-cdc/schema-health${query}`,
           );
           return response.success ? response.data : null;
         } catch {


### PR DESCRIPTION
## Summary

- **Root cause**: CDC backfills crash when the live BigQuery table has drifted column types (e.g. `STRING` instead of `TIMESTAMP` from legacy table creation). The staging table uses correct types from the connector schema, but the merge INSERT fails because BigQuery won't implicitly cast `TIMESTAMP → STRING`.
- **Fix**: Adds `evolveSchemaIfNeeded()` to the BigQuery adapter — an Airbyte-inspired schema evolution step that runs before each merge. It detects type drift by comparing the connector schema against `INFORMATION_SCHEMA.COLUMNS`, then performs a safe 4-step column swap per drifted column (ADD temp with correct type → UPDATE with `SAFE_CAST` → RENAME swap → DROP backup). Failures are caught per-column with cleanup; the merge proceeds with the existing type as fallback.
- **Safety net**: The existing `SAFE_CAST` in `buildCastExpression` (including the `STRING` case added earlier) is kept as a defensive fallback.
- **Observability**: Adds a `GET /sync-cdc/schema-health` API endpoint, a `fetchEntitySchemaHealth` store method, and a `WarningAmberIcon` drift indicator per entity in `BackfillPanel` with tooltip details.
- **Cleanup**: Removes dead unreachable code in `resolveTargetBqType`.

## Test plan

- [ ] Run a CDC backfill against a BigQuery table with a known type-drifted column (e.g. `note_date_updated` as `STRING` when schema expects `TIMESTAMP`) — verify the column is auto-evolved and the merge succeeds
- [ ] Verify that a table with no drift passes through `evolveSchemaIfNeeded` as a no-op (check logs for "Schema drift detected" absence)
- [ ] Verify that if evolution fails for one column (e.g. permission issue), the merge still proceeds using the fallback live type and logs a clear warning
- [ ] Hit `GET /flows/:flowId/sync-cdc/schema-health?entity=activities:Note` and verify the response correctly reports `match` / `drift` per column
- [ ] Verify the `BackfillPanel` shows a warning icon next to entities with drifted columns, with a tooltip listing the mismatches
- [ ] Confirm no regressions on normal (non-drifted) BigQuery CDC flows


Made with [Cursor](https://cursor.com)