### PR TITLE
fix: increase cdc-materialize timeout to 30m and add cancelOn support

### DIFF
--- a/api/src/inngest/functions/webhook-flow.ts
+++ b/api/src/inngest/functions/webhook-flow.ts
@@ -874,8 +874,9 @@ export const cdcMaterializeFunction = inngest.createFunction(
     name: "CDC Materialize",
     retries: 0,
     timeouts: {
-      finish: "10m",
+      finish: "30m",
     },
+    cancelOn: [{ event: "cdc/materialize.cancel", match: "data.flowId" }],
     singleton: {
       key: "event.data.flowId + ':' + event.data.entity",
       mode: "skip",


### PR DESCRIPTION
## Summary
- Increases the `cdc-materialize` Inngest function's `finish` timeout from 10m to 30m to prevent premature timeout signals
- Adds `cancelOn` event handler (`cdc/materialize.cancel` matched on `data.flowId`) so stuck runs can be cancelled programmatically

## Context
Running `cdc-materialize` functions were stuck for 10+ hours and couldn't be cancelled from the Inngest dashboard because the function had no `cancelOn` configuration.

## Test plan
- [ ] Verify function registers correctly with the new timeout and cancelOn config
- [ ] Confirm sending a `cdc/materialize.cancel` event with matching `flowId` cancels a running materialization

Made with [Cursor](https://cursor.com)