### PR TITLE
fix: reduce materialization_runs TTL from 30 days to 7 days

### DIFF
--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -2336,7 +2336,7 @@ MaterializationRunSchema.index({ workspaceId: 1, requestedAt: -1 });
 MaterializationRunSchema.index({ status: 1, lastHeartbeat: 1 });
 MaterializationRunSchema.index(
   { requestedAt: 1 },
-  { expireAfterSeconds: 2592000 },
+  { expireAfterSeconds: 7 * 24 * 60 * 60 },
 );
 
 /**

--- a/api/src/migrations/2026-04-16-000000_reduce_matrun_ttl_30d_to_7d.ts
+++ b/api/src/migrations/2026-04-16-000000_reduce_matrun_ttl_30d_to_7d.ts
@@ -1,0 +1,46 @@
+import { Db } from "mongodb";
+import { loggers } from "../logging";
+
+const log = loggers.migration();
+
+export const description =
+  "Reduce materialization_runs TTL from 30 days to 7 days on requestedAt";
+
+const COLLECTION = "materialization_runs";
+const SEVEN_DAYS = 7 * 24 * 60 * 60;
+
+export async function up(db: Db): Promise<void> {
+  const collections = (await db.listCollections().toArray()).map(c => c.name);
+  if (!collections.includes(COLLECTION)) {
+    log.info("Collection does not exist, skipping", { collection: COLLECTION });
+    return;
+  }
+
+  const col = db.collection(COLLECTION);
+  const indexes = await col.indexes();
+
+  const requestedAtTtl = indexes.find(
+    idx =>
+      JSON.stringify(idx.key) === JSON.stringify({ requestedAt: 1 }) &&
+      idx.expireAfterSeconds != null,
+  );
+
+  if (requestedAtTtl && requestedAtTtl.expireAfterSeconds === SEVEN_DAYS) {
+    log.info("TTL index already set to 7 days, skipping");
+    return;
+  }
+
+  if (requestedAtTtl && requestedAtTtl.name) {
+    await col.dropIndex(requestedAtTtl.name);
+    log.info("Dropped old TTL index", { name: requestedAtTtl.name });
+  }
+
+  await col.createIndex(
+    { requestedAt: 1 },
+    {
+      expireAfterSeconds: SEVEN_DAYS,
+      name: "matrun_requestedAt_ttl_7d",
+    },
+  );
+  log.info("Created TTL index on materialization_runs.requestedAt (7 days)");
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Applies the remaining TTL reduction from PR #343 (`fix/cdc-ttl-7d-retention`) that was not covered by PR #345.

PR #345 already handled:
- 7-day TTL on `webhook_events.receivedAt`
- Removal of `webhookCleanupFunction` cron
- Reduction of CDC scheduler frequency

This PR applies the one remaining change:
- **Reduce `materialization_runs` TTL from 30 days to 7 days** on the `requestedAt` field

## Changes

- `api/src/database/workspace-schema.ts` — update `expireAfterSeconds` from `2592000` (30d) to `7 * 24 * 60 * 60` (7d)
- New migration `2026-04-16-000000_reduce_matrun_ttl_30d_to_7d.ts` — idempotently drops old TTL index and creates 7-day replacement

## Notes

PR #343 can now be closed — all of its intended changes are covered between PR #345 (merged) and this PR.

## Test plan

- [ ] `pnpm migrate` runs cleanly
- [ ] Verify TTL index on `materialization_runs.requestedAt` has 604800s expiry
- [ ] No regressions in materialization run tracking
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf3ac605-cf48-457e-8d89-b2a9726f940e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf3ac605-cf48-457e-8d89-b2a9726f940e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

