### PR TITLE
docs: MySQL SQL how-to guides batch 6 (11-20 of 20) -- COMPLETE

### DIFF
--- a/content/guides/mysql/explain-analyze.mdx
+++ b/content/guides/mysql/explain-analyze.mdx
@@ -1,0 +1,208 @@
+---
+title: "MySQL EXPLAIN and EXPLAIN ANALYZE: Reading Query Execution Plans"
+description: "How to use MySQL EXPLAIN, EXPLAIN FORMAT=JSON, and EXPLAIN ANALYZE (8.0.18+) to understand query execution plans, identify slow spots, and optimize queries."
+database: mysql
+category: sql-how-to
+tags: [mysql, explain, explain-analyze, query-optimization, execution-plan]
+date: 2026-04-16
+---
+
+# MySQL EXPLAIN and EXPLAIN ANALYZE: Reading Query Execution Plans
+
+`EXPLAIN` shows MySQL's plan for executing a query -- which tables it reads, in what order, which indexes it uses, and how many rows it estimates it will examine. It's the first tool to reach for when a query is slow.
+
+MySQL 8.0.18+ added `EXPLAIN ANALYZE`, which actually runs the query and reports real execution statistics alongside the estimates.
+
+## Basic EXPLAIN
+
+Prefix any `SELECT`, `INSERT`, `UPDATE`, `DELETE`, or `TABLE` statement with `EXPLAIN`:
+
+```sql
+EXPLAIN SELECT * FROM orders WHERE customer_id = 42 AND status = 'pending';
+```
+
+Output columns:
+
+| Column | Meaning |
+|---|---|
+| `id` | Query block identifier. Higher = executed later. |
+| `select_type` | `SIMPLE`, `PRIMARY`, `SUBQUERY`, `DERIVED`, `UNION`, etc. |
+| `table` | Which table (or derived table / union result) |
+| `partitions` | Partitions examined (NULL if table is not partitioned) |
+| `type` | Join/access type -- see below |
+| `possible_keys` | Indexes MySQL considered |
+| `key` | Index MySQL actually chose |
+| `key_len` | Bytes of the chosen index used (shorter = fewer columns used) |
+| `ref` | What was compared against the index |
+| `rows` | Estimated rows MySQL will examine |
+| `filtered` | Estimated % of rows surviving the `WHERE` filter |
+| `Extra` | Additional information |
+
+### The `type` column -- most important signal
+
+From best to worst:
+
+| Type | Meaning |
+|---|---|
+| `system` | One row in the table (constant) |
+| `const` | At most one matching row via primary key or unique index |
+| `eq_ref` | One row from the joined table per row in previous table (PK/unique join) |
+| `ref` | Multiple rows from a non-unique index |
+| `range` | Index range scan (BETWEEN, <, >, IN) |
+| `index` | Full index scan (all index entries, no data pages) |
+| `ALL` | Full table scan -- the one to avoid on large tables |
+
+Seeing `ALL` on a large table means no usable index. Add an index or rewrite the query.
+
+### The `Extra` column -- useful signals
+
+- `Using index` -- covering index (data fetched from index only, no table read)
+- `Using where` -- MySQL applies a `WHERE` filter after fetching rows
+- `Using temporary` -- MySQL created a temp table (often for `GROUP BY` or `DISTINCT`)
+- `Using filesort` -- MySQL performed a sort not served by an index
+- `Using index condition` -- Index Condition Pushdown (ICP) applied
+- `Impossible WHERE` -- the `WHERE` clause can never be true (query returns no rows)
+
+`Using temporary` and `Using filesort` together are a common sign of an expensive `GROUP BY` or `ORDER BY` that lacks a supporting index.
+
+## EXPLAIN FORMAT=JSON
+
+The tabular output omits cost details. `FORMAT=JSON` exposes the query cost model:
+
+```sql
+EXPLAIN FORMAT=JSON
+SELECT c.name, COUNT(o.id) AS order_count
+FROM customers c
+JOIN orders o ON o.customer_id = c.id
+WHERE c.country = 'DE'
+GROUP BY c.id, c.name;
+```
+
+Key fields in the JSON output:
+
+```json
+{
+  "query_block": {
+    "select_id": 1,
+    "cost_info": {
+      "query_cost": "124.50"   // total optimizer cost estimate
+    },
+    "nested_loop": [
+      {
+        "table": {
+          "table_name": "c",
+          "access_type": "ref",
+          "key": "idx_country",
+          "rows_examined_per_scan": 83,
+          "cost_info": {
+            "read_cost": "8.30",
+            "eval_cost": "8.30",
+            "prefix_cost": "16.60"
+          }
+        }
+      },
+      {
+        "table": {
+          "table_name": "o",
+          "access_type": "ref",
+          "key": "idx_customer_id",
+          "rows_examined_per_scan": 3.2,
+          "cost_info": {
+            "read_cost": "53.44",
+            "eval_cost": "26.56",
+            "prefix_cost": "124.50"
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+`query_cost` is a unit-less internal estimate (roughly proportional to I/O operations). Lower is better. When comparing query rewrites, compare `query_cost` values.
+
+`rows_examined_per_scan` combined with the access type tells you whether the optimizer's row estimate is reasonable. If it estimates 100 rows but your table has 1M rows and no index is used, the estimate is wrong and performance will be worse than predicted.
+
+## EXPLAIN ANALYZE (MySQL 8.0.18+)
+
+`EXPLAIN ANALYZE` runs the query and reports both estimates and actual measurements:
+
+```sql
+EXPLAIN ANALYZE
+SELECT c.name, COUNT(o.id) AS order_count
+FROM customers c
+JOIN orders o ON o.customer_id = c.id
+WHERE c.country = 'DE'
+GROUP BY c.id, c.name;
+```
+
+Output format (tree-style):
+
+```
+-> Group aggregate: count(o.id)  (actual time=0.234..45.2 rows=83 loops=1)
+    -> Nested loop inner join  (actual time=0.198..42.1 rows=267 loops=1)
+        -> Index lookup on c using idx_country (country='DE')
+           (actual time=0.112..0.843 rows=83 loops=1)
+        -> Index lookup on o using idx_customer_id (customer_id=c.id)
+           (actual time=0.421..0.491 rows=3.2 loops=83)
+```
+
+Each node shows: `actual time=first_row_ms..last_row_ms rows=actual_rows loops=count`
+
+- `first_row_ms` -- time to return first row
+- `last_row_ms` -- time to return all rows
+- `loops` -- how many times this node executed (important for nested loops)
+
+### Diagnosing row estimate mismatch
+
+When `rows` in `EXPLAIN` diverges significantly from actual rows in `EXPLAIN ANALYZE`, the optimizer is working with stale statistics. Fix with:
+
+```sql
+ANALYZE TABLE orders;
+ANALYZE TABLE customers;
+```
+
+### EXPLAIN ANALYZE with FORMAT=JSON (8.0.32+)
+
+```sql
+SET explain_json_format_version = 2;
+EXPLAIN ANALYZE FORMAT=JSON SELECT ...;
+```
+
+This adds `actual_rows`, `actual_loops`, and timing data to the JSON tree -- useful for parsing programmatically or comparing across environments.
+
+## Practical workflow
+
+1. **Start with basic EXPLAIN** -- check `type`, `key`, `rows`. If you see `ALL` on a table with >10k rows, add an index.
+2. **Add index and re-run** -- verify `type` improved to `ref` or `range`.
+3. **Use EXPLAIN ANALYZE** -- confirm actual rows match estimates. Large mismatches mean stale statistics.
+4. **Use FORMAT=JSON** -- compare `query_cost` between query variants when tuning.
+5. **Check `Extra`** -- `Using filesort` or `Using temporary` with high row counts often points to a missing composite index.
+
+## Common patterns
+
+**Missing index on JOIN column:**
+```sql
+-- Before: type=ALL on orders
+EXPLAIN SELECT * FROM customers c JOIN orders o ON o.customer_id = c.id;
+-- Fix:
+CREATE INDEX idx_orders_customer ON orders(customer_id);
+```
+
+**Non-sargable WHERE (can't use index):**
+```sql
+-- Bad: function on indexed column prevents index use
+WHERE YEAR(created_at) = 2025
+
+-- Good: range on the column directly
+WHERE created_at >= '2025-01-01' AND created_at < '2026-01-01'
+```
+
+**Covering index to eliminate table fetch:**
+```sql
+-- If query only needs customer_id, status, created_at:
+CREATE INDEX idx_orders_covering ON orders(customer_id, status, created_at);
+-- Extra will show: Using index (no table read needed)
+```
+
+Mako's query editor displays `EXPLAIN` output inline alongside your results, making it easy to spot access type issues before a slow query hits production. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/mysql/generated-columns.mdx
+++ b/content/guides/mysql/generated-columns.mdx
@@ -1,0 +1,177 @@
+---
+title: "MySQL Generated Columns: VIRTUAL vs STORED, Indexing, and Use Cases"
+description: "How MySQL generated columns work -- the difference between VIRTUAL and STORED, when to index them, practical use cases for computed columns, and the limitations to know."
+database: mysql
+category: sql-how-to
+tags: [mysql, generated-columns, virtual-column, stored-column, functional-index]
+date: 2026-04-16
+---
+
+# MySQL Generated Columns: VIRTUAL vs STORED, Indexing, and Use Cases
+
+A generated column's value is computed from an expression rather than stored directly. You define the expression once in the schema; MySQL derives the column value automatically on reads (VIRTUAL) or on writes (STORED).
+
+Generated columns were introduced in MySQL 5.7 and are supported in InnoDB.
+
+## Syntax
+
+```sql
+CREATE TABLE products (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  price DECIMAL(10,2) NOT NULL,
+  quantity INT NOT NULL,
+  total_value DECIMAL(12,2) GENERATED ALWAYS AS (price * quantity) VIRTUAL,
+  price_category VARCHAR(20) GENERATED ALWAYS AS (
+    CASE
+      WHEN price < 10 THEN 'budget'
+      WHEN price < 100 THEN 'mid-range'
+      ELSE 'premium'
+    END
+  ) STORED
+);
+```
+
+`GENERATED ALWAYS AS (expression)` is required syntax. `VIRTUAL` or `STORED` is optional -- `VIRTUAL` is the default if omitted.
+
+## VIRTUAL vs STORED
+
+### VIRTUAL
+
+- Value is computed at query time, on every read
+- No extra disk space used (the column is not persisted)
+- The expression is re-evaluated for every row returned
+- Can be indexed (the index stores the computed value, but the base column doesn't)
+
+### STORED
+
+- Value is computed and written to disk at insert/update time
+- Takes up disk space like a regular column
+- Reads are fast -- no computation needed
+- Can be indexed, used in foreign keys, and referenced by other generated columns
+
+### Which to choose
+
+Start with `VIRTUAL`. Use `STORED` when:
+- The expression is computationally expensive and the column is read far more often than written
+- You need to reference the column in a foreign key
+- You need to use the column in a partition expression
+- The column needs to be part of a full-text index
+
+For simple arithmetic and string manipulation, `VIRTUAL` with an index is usually the right choice.
+
+## Adding generated columns to existing tables
+
+```sql
+ALTER TABLE orders
+ADD COLUMN order_year INT GENERATED ALWAYS AS (YEAR(created_at)) VIRTUAL;
+```
+
+Adding a `VIRTUAL` generated column is nearly instant -- it's a metadata-only change. Adding a `STORED` generated column requires computing and writing the value for every existing row, which takes time proportional to table size.
+
+## Indexing generated columns
+
+The most valuable use of generated columns is creating indexes on computed values that would otherwise require a function call in `WHERE` clauses.
+
+Without a generated column, a function in `WHERE` prevents index use:
+
+```sql
+-- This can't use an index on created_at:
+SELECT * FROM orders WHERE YEAR(created_at) = 2025;
+```
+
+With a generated column + index:
+
+```sql
+ALTER TABLE orders
+ADD COLUMN order_year INT GENERATED ALWAYS AS (YEAR(created_at)) VIRTUAL,
+ADD INDEX idx_order_year (order_year);
+
+-- Now this uses the index:
+SELECT * FROM orders WHERE order_year = 2025;
+```
+
+MySQL 8.0+ also supports functional indexes directly, which are equivalent to a hidden generated column + index:
+
+```sql
+-- MySQL 8.0+ only, equivalent to the generated column approach:
+CREATE INDEX idx_order_year ON orders((YEAR(created_at)));
+
+-- Same query works:
+SELECT * FROM orders WHERE YEAR(created_at) = 2025;
+```
+
+Both approaches produce the same execution plan. Functional indexes are syntactically cleaner; explicit generated columns are more visible in the schema.
+
+## Practical use cases
+
+### JSON field extraction and indexing
+
+A common pattern when using JSON columns with frequently-queried fields:
+
+```sql
+CREATE TABLE events (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  payload JSON NOT NULL,
+  user_id INT GENERATED ALWAYS AS (payload->>'$.user_id') STORED,
+  event_type VARCHAR(50) GENERATED ALWAYS AS (payload->>'$.type') VIRTUAL,
+  INDEX idx_user_id (user_id),
+  INDEX idx_event_type (event_type)
+);
+
+-- Now these queries use indexes:
+SELECT * FROM events WHERE user_id = 42;
+SELECT * FROM events WHERE event_type = 'purchase';
+```
+
+Without generated columns, querying JSON fields requires full table scans.
+
+### Case-insensitive search on a case-sensitive column
+
+```sql
+ALTER TABLE customers
+ADD COLUMN email_lower VARCHAR(255) GENERATED ALWAYS AS (LOWER(email)) VIRTUAL,
+ADD UNIQUE INDEX idx_email_lower (email_lower);
+
+-- Case-insensitive lookup with index:
+SELECT * FROM customers WHERE email_lower = 'user@example.com';
+```
+
+### Computed totals
+
+```sql
+CREATE TABLE invoice_lines (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  unit_price DECIMAL(10,2) NOT NULL,
+  quantity INT NOT NULL,
+  tax_rate DECIMAL(5,4) NOT NULL DEFAULT 0.20,
+  line_total DECIMAL(12,2) GENERATED ALWAYS AS (unit_price * quantity) VIRTUAL,
+  line_total_with_tax DECIMAL(12,2) GENERATED ALWAYS AS
+    (unit_price * quantity * (1 + tax_rate)) STORED
+);
+```
+
+## Constraints and limitations
+
+- The expression can only reference columns in the same row (no subqueries, no references to other tables)
+- Cannot use non-deterministic functions (`NOW()`, `RAND()`, `UUID()`)
+- Cannot reference other generated columns in a `VIRTUAL` generated column expression (can reference them in `STORED`)
+- Cannot be used directly in `DEFAULT` expressions for other columns
+- `AUTO_INCREMENT` is not allowed
+- Cannot be written to directly -- `INSERT` or `UPDATE` on a generated column raises an error
+
+```sql
+-- This fails:
+UPDATE products SET total_value = 100 WHERE id = 1;
+-- ERROR 3105: The value specified for generated column 'total_value' is not allowed.
+```
+
+## Inspecting generated columns
+
+```sql
+SELECT column_name, generation_expression, extra
+FROM information_schema.columns
+WHERE table_name = 'products' AND table_schema = DATABASE()
+  AND extra LIKE '%GENERATED%';
+```
+
+Mako's query editor shows generated column values in query results just like regular columns -- useful for validating expression logic against real data. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/mysql/partitioning.mdx
+++ b/content/guides/mysql/partitioning.mdx
@@ -1,0 +1,211 @@
+---
+title: "MySQL Table Partitioning: RANGE, LIST, HASH, KEY, and Partition Pruning"
+description: "How MySQL table partitioning works -- RANGE, LIST, HASH, and KEY partition types, partition pruning, and honest limitations before you commit to partitioning."
+database: mysql
+category: sql-how-to
+tags: [mysql, partitioning, range-partition, hash-partition, partition-pruning]
+date: 2026-04-16
+---
+
+# MySQL Table Partitioning: RANGE, LIST, HASH, KEY, and Partition Pruning
+
+MySQL table partitioning splits a logical table into physical segments (partitions) based on column values. Done right, it can improve performance on very large tables by allowing MySQL to skip entire partitions. Done wrong, it adds complexity with minimal benefit.
+
+This guide covers what each partition type does, when pruning works, and the limitations that matter before you commit to partitioning a table.
+
+## Who partitioning is for
+
+Partitioning helps when:
+- You have very large tables (hundreds of millions of rows)
+- Queries consistently filter on the partition key
+- You want to drop old data quickly (drop a partition instead of DELETE)
+
+It doesn't help when:
+- Queries don't filter on the partition key
+- The table is medium-sized (<50M rows) and well-indexed
+- You have foreign keys pointing to the table
+
+## Partitioning constraint: primary key must include partition column
+
+Every `PRIMARY KEY` and `UNIQUE INDEX` must include all columns used in the partition expression. This is enforced by MySQL and cannot be bypassed.
+
+```sql
+-- This fails:
+CREATE TABLE orders (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  created_at DATE NOT NULL
+) PARTITION BY RANGE (YEAR(created_at)) (...);
+-- ERROR 1503: A PRIMARY KEY must include all columns in the table's partitioning function
+
+-- This works:
+CREATE TABLE orders (
+  id INT NOT NULL,
+  created_at DATE NOT NULL,
+  PRIMARY KEY (id, created_at)
+) PARTITION BY RANGE (YEAR(created_at)) (...);
+```
+
+This constraint has a practical consequence: auto-increment primary keys alone don't work with most partition expressions. You must either include the partition column in the PK or remove the UNIQUE constraint.
+
+## RANGE partitioning
+
+Rows are assigned to partitions based on whether the partition column falls within a range:
+
+```sql
+CREATE TABLE orders (
+  id INT NOT NULL,
+  customer_id INT NOT NULL,
+  amount DECIMAL(10,2),
+  created_at DATE NOT NULL,
+  PRIMARY KEY (id, created_at)
+)
+PARTITION BY RANGE (YEAR(created_at)) (
+  PARTITION p2022 VALUES LESS THAN (2023),
+  PARTITION p2023 VALUES LESS THAN (2024),
+  PARTITION p2024 VALUES LESS THAN (2025),
+  PARTITION p2025 VALUES LESS THAN (2026),
+  PARTITION p_future VALUES LESS THAN MAXVALUE
+);
+```
+
+`PARTITION BY RANGE COLUMNS` supports date columns directly (avoids the `YEAR()` function):
+
+```sql
+PARTITION BY RANGE COLUMNS (created_at) (
+  PARTITION p2022 VALUES LESS THAN ('2023-01-01'),
+  PARTITION p2023 VALUES LESS THAN ('2024-01-01'),
+  PARTITION p2024 VALUES LESS THAN ('2025-01-01'),
+  PARTITION pmax VALUES LESS THAN (MAXVALUE)
+);
+```
+
+### Dropping old partitions
+
+This is the killer feature of RANGE partitioning. Dropping a partition is nearly instant -- it's a metadata operation, not a row-by-row delete:
+
+```sql
+ALTER TABLE orders DROP PARTITION p2022;
+-- Instantly removes all 2022 rows
+```
+
+Compare to `DELETE FROM orders WHERE YEAR(created_at) = 2022`, which scans and deletes row-by-row and generates redo log for each row.
+
+### Adding partitions
+
+```sql
+ALTER TABLE orders REORGANIZE PARTITION p_future INTO (
+  PARTITION p2026 VALUES LESS THAN (2027),
+  PARTITION p_future VALUES LESS THAN MAXVALUE
+);
+```
+
+## LIST partitioning
+
+Assigns rows to partitions based on column values from an explicit list:
+
+```sql
+CREATE TABLE customers (
+  id INT NOT NULL,
+  region VARCHAR(20) NOT NULL,
+  name VARCHAR(100),
+  PRIMARY KEY (id, region)
+)
+PARTITION BY LIST COLUMNS (region) (
+  PARTITION p_europe VALUES IN ('DE', 'FR', 'ES', 'IT', 'NL'),
+  PARTITION p_americas VALUES IN ('US', 'CA', 'BR', 'MX'),
+  PARTITION p_apac VALUES IN ('JP', 'AU', 'SG', 'IN')
+);
+```
+
+If you try to insert a row with a value not covered by any partition, MySQL returns an error. Always add a catch-all or validate values before insert.
+
+## HASH partitioning
+
+Distributes rows evenly across N partitions using MySQL's internal hash of the partition expression:
+
+```sql
+CREATE TABLE user_activity (
+  user_id INT NOT NULL,
+  event_type VARCHAR(50),
+  created_at DATETIME,
+  PRIMARY KEY (user_id, created_at)
+)
+PARTITION BY HASH (user_id)
+PARTITIONS 8;
+```
+
+HASH partitioning is designed for even distribution. It doesn't help with partition pruning on range queries -- `WHERE created_at > '2025-01-01'` on a HASH-partitioned table must scan all partitions.
+
+It helps when:
+- You want to spread I/O across multiple disks
+- Queries filter by exact value of the hash key (`WHERE user_id = 42` can prune to one partition)
+
+`LINEAR HASH` uses a power-of-two algorithm for faster partition management (adding/removing partitions) at the cost of potentially uneven distribution.
+
+## KEY partitioning
+
+Similar to HASH, but MySQL uses its own internal hash function on the primary key (or specified columns). Requires the partitioned columns to be part of the PK:
+
+```sql
+PARTITION BY KEY()        -- uses the primary key
+PARTITIONS 4;
+
+PARTITION BY KEY(user_id)  -- explicit column
+PARTITIONS 4;
+```
+
+KEY partitioning supports string columns, which HASH doesn't (HASH requires an integer expression).
+
+## Partition pruning
+
+Partition pruning is the mechanism by which MySQL skips partitions that can't contain rows matching the `WHERE` clause. It only works when the partition column appears in the `WHERE` clause with a compatible operator.
+
+```sql
+-- RANGE partition on YEAR(created_at):
+-- This prunes -- MySQL knows to check only p2025:
+SELECT * FROM orders WHERE created_at >= '2025-01-01' AND created_at < '2026-01-01';
+
+-- This does NOT prune -- function wraps the column:
+SELECT * FROM orders WHERE YEAR(created_at) = 2025;
+-- MySQL can't determine which partition to use from the function result at parse time
+```
+
+To verify pruning, use `EXPLAIN PARTITIONS`:
+
+```sql
+EXPLAIN SELECT * FROM orders WHERE created_at >= '2025-01-01' AND created_at < '2026-01-01';
+-- partitions column shows: p2025 (only one partition scanned)
+```
+
+If `partitions` shows all partitions, pruning isn't working -- check your `WHERE` clause matches the partition expression.
+
+## Managing partitions
+
+```sql
+-- List current partitions and row counts:
+SELECT partition_name, table_rows, data_length
+FROM information_schema.partitions
+WHERE table_name = 'orders' AND table_schema = DATABASE();
+
+-- Rebuild a partition (reclaims space, removes fragmentation):
+ALTER TABLE orders REBUILD PARTITION p2024;
+
+-- Check/analyze a partition:
+ALTER TABLE orders ANALYZE PARTITION p2025;
+
+-- Exchange a partition with a regular table (useful for bulk loads):
+ALTER TABLE orders EXCHANGE PARTITION p2025 WITH TABLE orders_2025_staging;
+```
+
+## Limitations (read before you partition)
+
+- **No foreign keys.** InnoDB tables with foreign keys cannot be partitioned. If other tables reference your table's primary key, partitioning is off the table.
+- **Every PK/unique index must include partition columns.** This often forces awkward composite primary keys.
+- **Maximum 8192 partitions** per table (including subpartitions).
+- **HASH/KEY partitions don't prune on ranges.** Only equality on the hash column prunes.
+- **Full-text indexes not supported** on partitioned tables.
+- **Some functions can't be used** in partition expressions (only deterministic, pure functions).
+
+For most tables under 100M rows with good indexes, partitioning adds complexity without meaningful benefit. Benchmark with and without before committing.
+
+Mako connects to MySQL and lets you inspect partition metadata and query individual partitions for analysis. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/mysql/stored-procedures.mdx
+++ b/content/guides/mysql/stored-procedures.mdx
@@ -1,0 +1,246 @@
+---
+title: "MySQL Stored Procedures: CREATE PROCEDURE, Parameters, Cursors, and Error Handling"
+description: "How to write MySQL stored procedures -- IN/OUT/INOUT parameters, local variables, cursors for row-by-row processing, and DECLARE HANDLER for error handling."
+database: mysql
+category: sql-how-to
+tags: [mysql, stored-procedures, cursors, declare-handler, delimiter]
+date: 2026-04-16
+---
+
+# MySQL Stored Procedures: CREATE PROCEDURE, Parameters, Cursors, and Error Handling
+
+A stored procedure is a named block of SQL and procedural logic stored in the database. You call it by name, optionally passing parameters. MySQL stored procedures support variables, conditionals, loops, cursors, and error handlers.
+
+They're useful for encapsulating complex logic that would be awkward to express in a single SQL statement, batch operations that need to run on the server, and operations that need to run atomically without round-trips to the application.
+
+## Creating a basic procedure
+
+MySQL requires changing the delimiter to define a procedure, because `;` inside the procedure body would confuse the client:
+
+```sql
+DELIMITER $$
+
+CREATE PROCEDURE GetCustomerOrders(IN customer_id INT)
+BEGIN
+  SELECT id, amount, status, created_at
+  FROM orders
+  WHERE orders.customer_id = customer_id
+  ORDER BY created_at DESC;
+END$$
+
+DELIMITER ;
+```
+
+Call it:
+
+```sql
+CALL GetCustomerOrders(42);
+```
+
+## Parameter types
+
+MySQL procedures support three parameter modes:
+
+- `IN` -- input only. The caller passes a value; the procedure cannot modify the caller's variable.
+- `OUT` -- output only. The procedure sets a value; the caller reads it after the call.
+- `INOUT` -- both. The caller passes a value, the procedure can modify it, and the caller reads the result.
+
+```sql
+DELIMITER $$
+
+CREATE PROCEDURE GetOrderSummary(
+  IN p_customer_id INT,
+  OUT p_order_count INT,
+  OUT p_total_spent DECIMAL(12,2)
+)
+BEGIN
+  SELECT COUNT(*), COALESCE(SUM(amount), 0)
+  INTO p_order_count, p_total_spent
+  FROM orders
+  WHERE customer_id = p_customer_id;
+END$$
+
+DELIMITER ;
+
+-- Call with OUT parameters:
+CALL GetOrderSummary(42, @count, @total);
+SELECT @count AS order_count, @total AS total_spent;
+```
+
+## Local variables
+
+Declare variables at the top of the `BEGIN...END` block, before any other statements:
+
+```sql
+DELIMITER $$
+
+CREATE PROCEDURE UpdateLoyaltyTier()
+BEGIN
+  DECLARE v_customer_id INT;
+  DECLARE v_total_spent DECIMAL(12,2);
+  DECLARE v_tier VARCHAR(20);
+
+  -- Use SELECT INTO to assign values:
+  SELECT id, total_spent INTO v_customer_id, v_total_spent
+  FROM customers
+  WHERE id = 1;
+
+  IF v_total_spent >= 10000 THEN
+    SET v_tier = 'platinum';
+  ELSEIF v_total_spent >= 1000 THEN
+    SET v_tier = 'gold';
+  ELSE
+    SET v_tier = 'standard';
+  END IF;
+
+  UPDATE customers SET loyalty_tier = v_tier WHERE id = v_customer_id;
+END$$
+
+DELIMITER ;
+```
+
+## Loops
+
+MySQL procedures support `WHILE`, `REPEAT`, and `LOOP`:
+
+```sql
+DELIMITER $$
+
+CREATE PROCEDURE GenerateMonthlyDates(IN p_year INT)
+BEGIN
+  DECLARE v_month INT DEFAULT 1;
+
+  WHILE v_month <= 12 DO
+    INSERT INTO reporting_periods (period_date)
+    VALUES (MAKEDATE(p_year, 1) + INTERVAL (v_month - 1) MONTH)
+    ON DUPLICATE KEY UPDATE period_date = VALUES(period_date);
+    SET v_month = v_month + 1;
+  END WHILE;
+END$$
+
+DELIMITER ;
+```
+
+## Cursors
+
+A cursor lets you iterate over a result set row by row. Use cursors when set-based SQL can't express the logic you need.
+
+The cursor lifecycle: `DECLARE` - `OPEN` - `FETCH` loop - `CLOSE`.
+
+```sql
+DELIMITER $$
+
+CREATE PROCEDURE ProcessPendingOrders()
+BEGIN
+  DECLARE v_done INT DEFAULT FALSE;
+  DECLARE v_order_id INT;
+  DECLARE v_customer_id INT;
+  DECLARE v_amount DECIMAL(10,2);
+
+  -- 1. Declare the cursor
+  DECLARE order_cursor CURSOR FOR
+    SELECT id, customer_id, amount FROM orders WHERE status = 'pending';
+
+  -- 2. Declare the NOT FOUND handler (fires when FETCH runs out of rows)
+  DECLARE CONTINUE HANDLER FOR NOT FOUND SET v_done = TRUE;
+
+  -- 3. Open the cursor
+  OPEN order_cursor;
+
+  process_loop: LOOP
+    -- 4. Fetch one row
+    FETCH order_cursor INTO v_order_id, v_customer_id, v_amount;
+
+    IF v_done THEN
+      LEAVE process_loop;
+    END IF;
+
+    -- Process the row
+    UPDATE orders SET status = 'processing' WHERE id = v_order_id;
+    INSERT INTO order_log (order_id, event, logged_at)
+    VALUES (v_order_id, 'processing_started', NOW());
+
+  END LOOP;
+
+  -- 5. Close the cursor
+  CLOSE order_cursor;
+END$$
+
+DELIMITER ;
+```
+
+**Important:** `DECLARE` statements must appear in a specific order: variables first, then cursors, then handlers. Putting a `DECLARE HANDLER` before a `DECLARE CURSOR` causes a syntax error.
+
+**Multiple cursors:** You can declare multiple cursors in one procedure, but each needs its own `NOT FOUND` handler variable (or you must track which cursor triggered the handler).
+
+**Performance:** Row-by-row cursor processing is much slower than set-based SQL. A single `UPDATE` with a `WHERE` clause processes thousands of rows in the time a cursor processes a handful. Only use cursors when a set-based approach genuinely can't express the logic.
+
+## Error handling with DECLARE HANDLER
+
+`DECLARE HANDLER` defines what to do when a specific error condition occurs:
+
+```sql
+DELIMITER $$
+
+CREATE PROCEDURE SafeInsertOrder(
+  IN p_customer_id INT,
+  IN p_amount DECIMAL(10,2),
+  OUT p_success TINYINT
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    SET p_success = 0;
+    ROLLBACK;
+  END;
+
+  SET p_success = 1;
+  START TRANSACTION;
+
+  INSERT INTO orders (customer_id, amount, status, created_at)
+  VALUES (p_customer_id, p_amount, 'pending', NOW());
+
+  UPDATE customers SET order_count = order_count + 1
+  WHERE id = p_customer_id;
+
+  COMMIT;
+END$$
+
+DELIMITER ;
+```
+
+Handler types:
+- `CONTINUE HANDLER` -- handles the condition and resumes execution at the next statement
+- `EXIT HANDLER` -- handles the condition and exits the `BEGIN...END` block
+- `UNDO HANDLER` -- not supported in MySQL (syntax accepted but treated as EXIT)
+
+Common condition values:
+- `SQLEXCEPTION` -- any error
+- `SQLWARNING` -- any warning
+- `NOT FOUND` -- no rows found (usually from SELECT INTO or FETCH)
+- `SQLSTATE '23000'` -- specific error state (23000 = integrity constraint violation)
+- `1062` -- specific MySQL error code (1062 = duplicate entry)
+
+## Listing and dropping procedures
+
+```sql
+-- List procedures in current database:
+SHOW PROCEDURE STATUS WHERE Db = DATABASE();
+
+-- View procedure definition:
+SHOW CREATE PROCEDURE GetCustomerOrders;
+
+-- Drop a procedure:
+DROP PROCEDURE IF EXISTS GetCustomerOrders;
+```
+
+## Stored procedures vs application-side logic
+
+Stored procedures move logic into the database. This has tradeoffs:
+
+- **Pros:** Less network round-trips for complex operations, logic runs close to data, consistent behavior across different application stacks
+- **Cons:** Harder to version control, no standard debugging tools (compared to application code), harder to test in isolation, logic is harder to find and maintain for developers not familiar with MySQL procedural SQL
+
+Most modern applications keep business logic in application code and use stored procedures only for performance-critical batch operations or data migrations.
+
+Mako connects to MySQL and lets you call stored procedures and inspect their results directly in the query editor. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/mysql/string-to-json.mdx
+++ b/content/guides/mysql/string-to-json.mdx
@@ -1,0 +1,218 @@
+---
+title: "Converting String Data to JSON in MySQL: JSON_OBJECT, JSON_ARRAY, and Migration Patterns"
+description: "How to use MySQL's JSON_OBJECT and JSON_ARRAY functions to build JSON from relational data, convert legacy string-serialized columns to native JSON, and query the results."
+database: mysql
+category: sql-how-to
+tags: [mysql, json, json-object, json-array, data-migration, json-column]
+date: 2026-04-16
+---
+
+# Converting String Data to JSON in MySQL: JSON_OBJECT, JSON_ARRAY, and Migration Patterns
+
+MySQL 5.7 introduced a native `JSON` column type with functions for creating, reading, and modifying JSON data. Many older schemas store JSON as `VARCHAR` or `TEXT` strings. This guide covers how to build JSON from relational data using `JSON_OBJECT` and `JSON_ARRAY`, and how to migrate legacy serialized string columns to native JSON.
+
+## Building JSON from column values
+
+### JSON_OBJECT
+
+Creates a JSON object from key-value pairs:
+
+```sql
+SELECT JSON_OBJECT(
+  'id', id,
+  'name', name,
+  'email', email,
+  'country', country
+) AS customer_json
+FROM customers
+WHERE id = 42;
+```
+
+Result:
+```json
+{"id": 42, "name": "Maria Santos", "email": "maria@example.com", "country": "ES"}
+```
+
+Key observations:
+- Keys must be strings (or expressions that evaluate to strings)
+- Values can be any MySQL expression -- numbers, strings, booleans, or even nested `JSON_OBJECT` calls
+- `NULL` values are included as JSON `null`
+- Duplicate keys: the last value for a given key wins
+
+### JSON_ARRAY
+
+Creates a JSON array from a list of values:
+
+```sql
+SELECT JSON_ARRAY(1, 'two', NULL, TRUE, NOW());
+-- Result: [1, "two", null, true, "2026-04-16 09:00:00"]
+```
+
+Combining `JSON_OBJECT` and `JSON_ARRAY`:
+
+```sql
+SELECT JSON_OBJECT(
+  'customer_id', c.id,
+  'name', c.name,
+  'top_products', JSON_ARRAY(
+    (SELECT product_id FROM order_items oi JOIN orders o ON o.id = oi.order_id
+     WHERE o.customer_id = c.id ORDER BY quantity DESC LIMIT 1),
+    (SELECT product_id FROM order_items oi JOIN orders o ON o.id = oi.order_id
+     WHERE o.customer_id = c.id ORDER BY quantity DESC LIMIT 1 OFFSET 1)
+  )
+) AS summary
+FROM customers c
+WHERE c.id = 42;
+```
+
+## Aggregating rows into JSON
+
+### JSON_ARRAYAGG
+
+Aggregates multiple rows into a JSON array:
+
+```sql
+SELECT
+  c.id,
+  c.name,
+  JSON_ARRAYAGG(
+    JSON_OBJECT('order_id', o.id, 'amount', o.amount, 'status', o.status)
+  ) AS orders
+FROM customers c
+JOIN orders o ON o.customer_id = c.id
+GROUP BY c.id, c.name;
+```
+
+Result per customer:
+```json
+[
+  {"order_id": 101, "amount": 49.99, "status": "shipped"},
+  {"order_id": 102, "amount": 199.00, "status": "pending"}
+]
+```
+
+`JSON_ARRAYAGG` preserves all rows, including duplicates. For unique values only, use `JSON_ARRAYAGG(DISTINCT column)`.
+
+### JSON_OBJECTAGG
+
+Aggregates key-value pairs into a JSON object:
+
+```sql
+-- Build a JSON object mapping product_id -> total quantity sold
+SELECT JSON_OBJECTAGG(product_id, total_qty) AS sales_map
+FROM (
+  SELECT product_id, SUM(quantity) AS total_qty
+  FROM order_items
+  GROUP BY product_id
+) t;
+```
+
+Result:
+```json
+{"1": 450, "2": 230, "7": 89}
+```
+
+## Migrating legacy serialized strings to native JSON
+
+Many older MySQL schemas store serialized data as `TEXT` -- PHP's `serialize()` format, CSV-in-a-column, or manually constructed JSON strings. Migrating to a native `JSON` column enables proper indexing and querying.
+
+### Step 1: Add a new JSON column
+
+```sql
+ALTER TABLE user_settings
+ADD COLUMN preferences_json JSON AFTER preferences_text;
+```
+
+### Step 2: Migrate existing data
+
+If the existing column already contains valid JSON strings:
+
+```sql
+UPDATE user_settings
+SET preferences_json = CAST(preferences_text AS JSON)
+WHERE preferences_text IS NOT NULL
+  AND JSON_VALID(preferences_text) = 1;
+```
+
+Check for invalid JSON before migrating:
+
+```sql
+SELECT id, preferences_text
+FROM user_settings
+WHERE preferences_text IS NOT NULL
+  AND JSON_VALID(preferences_text) = 0
+LIMIT 20;
+```
+
+Fix or discard invalid rows before proceeding.
+
+### Step 3: Validate the migration
+
+```sql
+-- Count rows where the migration succeeded:
+SELECT
+  COUNT(*) AS total,
+  SUM(preferences_json IS NOT NULL) AS migrated,
+  SUM(preferences_text IS NOT NULL AND preferences_json IS NULL) AS failed
+FROM user_settings;
+```
+
+### Step 4: Update application to write JSON column
+
+Deploy application changes to write to `preferences_json`. Run both columns in parallel until confident.
+
+### Step 5: Drop the old column
+
+```sql
+ALTER TABLE user_settings DROP COLUMN preferences_text;
+```
+
+## Converting comma-separated strings to JSON arrays
+
+A common legacy pattern: tags or categories stored as comma-separated `VARCHAR` (`"mysql,performance,indexes"`).
+
+There's no built-in function to split a string into a JSON array in MySQL 5.7. In MySQL 8.0+, you can use a stored procedure or a creative `JSON_ARRAYAGG` + derived table approach:
+
+```sql
+-- MySQL 8.0+: split comma-separated string into JSON array
+-- Using a numbers table (or recursive CTE):
+WITH RECURSIVE nums AS (
+  SELECT 1 AS n
+  UNION ALL
+  SELECT n + 1 FROM nums WHERE n < 100
+)
+SELECT
+  id,
+  tags AS tags_raw,
+  JSON_ARRAYAGG(
+    TRIM(SUBSTRING_INDEX(SUBSTRING_INDEX(tags, ',', n), ',', -1))
+  ) AS tags_json
+FROM articles
+JOIN nums ON n <= 1 + LENGTH(tags) - LENGTH(REPLACE(tags, ',', ''))
+WHERE tags IS NOT NULL
+GROUP BY id, tags;
+```
+
+In practice, for large-scale migrations, it's often cleaner to do this transformation in application code (Python, Node) where string manipulation is straightforward.
+
+## Querying the resulting JSON
+
+Once data is in a native `JSON` column, use `->` and `->>` for extraction:
+
+```sql
+-- Extract a field:
+SELECT preferences_json->>'$.theme' AS theme FROM user_settings;
+
+-- Filter on a JSON field:
+SELECT * FROM user_settings WHERE preferences_json->>'$.language' = 'de';
+
+-- Generate an index on a commonly-queried field using a generated column:
+ALTER TABLE user_settings
+ADD COLUMN pref_language VARCHAR(10) GENERATED ALWAYS AS
+  (preferences_json->>'$.language') VIRTUAL,
+ADD INDEX idx_pref_language (pref_language);
+```
+
+See the [MySQL JSON queries guide](/guides/mysql/json-queries) for a full reference on JSON extraction and modification functions.
+
+Mako connects to MySQL databases and lets you query JSON columns interactively, with results displayed inline. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/mysql/subqueries.mdx
+++ b/content/guides/mysql/subqueries.mdx
@@ -1,0 +1,194 @@
+---
+title: "Subqueries in MySQL: Correlated, IN, EXISTS, and Derived Tables"
+description: "A practical guide to MySQL subqueries -- correlated vs non-correlated, IN vs EXISTS, derived tables, and when to rewrite as a JOIN for better performance."
+database: mysql
+category: sql-how-to
+tags: [mysql, subquery, correlated, exists, derived-table, performance]
+date: 2026-04-16
+---
+
+# Subqueries in MySQL: Correlated, IN, EXISTS, and Derived Tables
+
+A subquery is a `SELECT` statement nested inside another query. MySQL supports subqueries in `WHERE`, `FROM`, `SELECT`, and `HAVING` clauses. The variation that matters most for performance is whether the subquery is *correlated* or *non-correlated*.
+
+## Non-correlated vs correlated subqueries
+
+A **non-correlated** subquery executes once and returns a result that the outer query uses:
+
+```sql
+-- Returns all customers in countries that have at least one supplier
+SELECT name, country
+FROM customers
+WHERE country IN (
+  SELECT country FROM suppliers
+);
+```
+
+A **correlated** subquery references columns from the outer query, so it re-executes for every row the outer query processes:
+
+```sql
+-- Returns employees earning more than their department's average
+SELECT name, salary, department_id
+FROM employees e
+WHERE salary > (
+  SELECT AVG(salary)
+  FROM employees
+  WHERE department_id = e.department_id
+);
+```
+
+The correlated version is logically clear but can be slow on large tables -- MySQL runs the inner `SELECT` once per outer row. For a 100k-row table that's 100k subquery executions. Always `EXPLAIN` correlated queries before deploying.
+
+## IN vs EXISTS
+
+Both test for membership, but they differ in how MySQL evaluates them.
+
+### IN with a subquery
+
+```sql
+-- Orders placed by active customers
+SELECT id, amount
+FROM orders
+WHERE customer_id IN (
+  SELECT id FROM customers WHERE status = 'active'
+);
+```
+
+`IN` materializes the subquery result into a temporary set, then checks each outer row against it. Performs well when the inner result set is small. Performance degrades when the inner set is large.
+
+One important trap: `IN` returns `NULL` unpredictably when the subquery contains `NULL` values.
+
+```sql
+-- This returns no rows if the subquery contains any NULLs
+SELECT * FROM orders WHERE customer_id NOT IN (
+  SELECT customer_id FROM returns  -- contains NULLs for anonymous returns
+);
+```
+
+Use `NOT IN` only when you're certain the subquery column has no `NULL` values, or filter them explicitly:
+
+```sql
+SELECT * FROM orders WHERE customer_id NOT IN (
+  SELECT customer_id FROM returns WHERE customer_id IS NOT NULL
+);
+```
+
+### EXISTS
+
+`EXISTS` short-circuits on the first matching row -- it stops as soon as it finds a match:
+
+```sql
+SELECT id, amount
+FROM orders o
+WHERE EXISTS (
+  SELECT 1 FROM customers c
+  WHERE c.id = o.customer_id AND c.status = 'active'
+);
+```
+
+`EXISTS` is generally faster when:
+- The inner table is large (short-circuit saves work)
+- You're checking for the presence of a relationship, not retrieving values
+
+`EXISTS` handles `NULL` safely. It evaluates to true or false, never to unknown.
+
+### Anti-join with NOT EXISTS
+
+The safest way to find rows with no match:
+
+```sql
+-- Orders with no corresponding shipment
+SELECT o.id, o.amount
+FROM orders o
+WHERE NOT EXISTS (
+  SELECT 1 FROM shipments s WHERE s.order_id = o.id
+);
+```
+
+## Derived tables (subquery in FROM)
+
+A derived table is a subquery used as a table in the `FROM` clause. MySQL materializes it into a temporary table:
+
+```sql
+-- Top-spending customer per country
+SELECT country, name, total_spend
+FROM (
+  SELECT
+    c.country,
+    c.name,
+    SUM(o.amount) AS total_spend,
+    RANK() OVER (PARTITION BY c.country ORDER BY SUM(o.amount) DESC) AS rnk
+  FROM customers c
+  JOIN orders o ON o.customer_id = c.id
+  GROUP BY c.country, c.id, c.name
+) ranked
+WHERE rnk = 1;
+```
+
+Derived tables must have an alias. In MySQL 8.0+, CTEs (`WITH`) are often more readable for the same pattern.
+
+## Scalar subqueries in SELECT
+
+A subquery in the `SELECT` list must return exactly one row and one column:
+
+```sql
+SELECT
+  id,
+  name,
+  (SELECT COUNT(*) FROM orders WHERE customer_id = c.id) AS order_count
+FROM customers c;
+```
+
+This is a correlated scalar subquery -- it executes once per customer row. For more than a few thousand customers, rewrite as a `LEFT JOIN` with `GROUP BY`:
+
+```sql
+SELECT c.id, c.name, COUNT(o.id) AS order_count
+FROM customers c
+LEFT JOIN orders o ON o.customer_id = c.id
+GROUP BY c.id, c.name;
+```
+
+## When to rewrite subqueries as JOINs
+
+MySQL's optimizer can sometimes convert subqueries to joins automatically, but it doesn't always succeed. These patterns consistently benefit from manual rewriting:
+
+**Correlated EXISTS → semi-join:**
+```sql
+-- Instead of:
+SELECT * FROM customers WHERE EXISTS (SELECT 1 FROM orders WHERE customer_id = customers.id);
+-- Write:
+SELECT DISTINCT c.* FROM customers c JOIN orders o ON o.customer_id = c.id;
+```
+
+**Correlated scalar in SELECT → LEFT JOIN:**
+```sql
+-- Instead of scalar subquery per row, join once:
+SELECT c.id, c.name, COALESCE(o.order_count, 0) AS order_count
+FROM customers c
+LEFT JOIN (
+  SELECT customer_id, COUNT(*) AS order_count FROM orders GROUP BY customer_id
+) o ON o.customer_id = c.id;
+```
+
+## EXPLAIN output for subqueries
+
+`EXPLAIN` shows how MySQL handles subqueries. Key `select_type` values:
+
+| Value | Meaning |
+|---|---|
+| `SUBQUERY` | Non-correlated subquery, executes once |
+| `DEPENDENT SUBQUERY` | Correlated subquery, executes per outer row |
+| `DERIVED` | Subquery in `FROM` clause (derived table) |
+| `MATERIALIZED` | Subquery materialized into a temporary table |
+
+`DEPENDENT SUBQUERY` in `EXPLAIN` output is a warning sign. Check whether a JOIN rewrite is possible.
+
+## Common mistakes
+
+**Forgetting that `NOT IN` breaks on NULLs.** The safest approach is `NOT EXISTS` with a correlated condition.
+
+**Using a correlated subquery where a JOIN would work.** If the inner query doesn't need to reference the outer row for logic, it's not correlated -- but MySQL may still execute it per-row if the optimizer doesn't rewrite it.
+
+**Derived tables without indexes.** MySQL materializes derived tables as temporary tables with no indexes. If you then filter or join on that result, performance can suffer. In MySQL 8.0+, consider whether a CTE with an index hint helps, or restructure the query.
+
+Mako's AI autocomplete helps you explore subquery rewrites interactively -- type the correlated version and ask it to suggest a join equivalent. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/mysql/transactions.mdx
+++ b/content/guides/mysql/transactions.mdx
@@ -1,0 +1,213 @@
+---
+title: "MySQL Transactions: START TRANSACTION, SAVEPOINT, Isolation Levels, and InnoDB"
+description: "A complete guide to MySQL transactions -- ACID properties, START TRANSACTION vs autocommit, SAVEPOINT, all four isolation levels, and how InnoDB implements locking."
+database: mysql
+category: sql-how-to
+tags: [mysql, transactions, innodb, isolation-levels, savepoint, acid]
+date: 2026-04-16
+---
+
+# MySQL Transactions: START TRANSACTION, SAVEPOINT, Isolation Levels, and InnoDB
+
+A transaction groups multiple SQL statements into a single unit of work. Either all statements succeed and are committed, or all are rolled back. This is the foundation of data integrity in relational databases.
+
+MySQL transactions work with InnoDB tables. MyISAM doesn't support transactions -- if you're still using MyISAM, migrate to InnoDB.
+
+## ACID properties
+
+- **Atomicity** -- all statements in the transaction commit or all roll back. No partial writes.
+- **Consistency** -- the database moves from one valid state to another. Constraints aren't violated.
+- **Isolation** -- concurrent transactions don't see each other's incomplete work (depending on isolation level).
+- **Durability** -- committed transactions survive crashes. InnoDB writes to the redo log before acknowledging the commit.
+
+## Basic transaction syntax
+
+MySQL defaults to autocommit mode: every statement is its own transaction, committed immediately.
+
+```sql
+-- Check autocommit status
+SELECT @@autocommit;  -- 1 = on (default)
+```
+
+To group statements into a transaction:
+
+```sql
+START TRANSACTION;  -- or BEGIN;
+
+UPDATE accounts SET balance = balance - 500 WHERE id = 1;
+UPDATE accounts SET balance = balance + 500 WHERE id = 2;
+
+COMMIT;  -- makes both updates permanent
+```
+
+If something goes wrong:
+
+```sql
+START TRANSACTION;
+
+UPDATE accounts SET balance = balance - 500 WHERE id = 1;
+-- Oops, wrong target
+ROLLBACK;  -- both updates are undone
+```
+
+`BEGIN` and `START TRANSACTION` are equivalent. `START TRANSACTION` is the SQL standard; `BEGIN` is a shorthand. Both disable autocommit for the duration of the transaction.
+
+### Autocommit and DDL
+
+DDL statements (`CREATE TABLE`, `ALTER TABLE`, `DROP TABLE`) implicitly commit the current transaction in MySQL. You cannot roll back a `DROP TABLE`. This is a common surprise -- wrapping DDL in a transaction does not protect you.
+
+## SAVEPOINT
+
+Savepoints let you roll back part of a transaction without abandoning the whole thing:
+
+```sql
+START TRANSACTION;
+
+INSERT INTO orders (customer_id, amount) VALUES (42, 199.00);
+SAVEPOINT after_order;
+
+INSERT INTO order_items (order_id, product_id, qty) VALUES (LAST_INSERT_ID(), 7, 2);
+-- Error found in product_id, roll back just this insert
+ROLLBACK TO SAVEPOINT after_order;
+
+-- Retry with the correct product_id
+INSERT INTO order_items (order_id, product_id, qty) VALUES (LAST_INSERT_ID(), 9, 2);
+
+COMMIT;  -- commits the order and the corrected item
+```
+
+`RELEASE SAVEPOINT name` removes a savepoint without rolling back to it. All savepoints are released automatically on `COMMIT` or full `ROLLBACK`.
+
+## Isolation levels
+
+MySQL InnoDB supports all four SQL standard isolation levels. The default is `REPEATABLE READ`.
+
+### READ UNCOMMITTED
+
+```sql
+SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+```
+
+A transaction can read rows that another transaction has modified but not yet committed. These are called **dirty reads**. Almost never appropriate for production -- the data you read may be rolled back seconds later.
+
+### READ COMMITTED
+
+```sql
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+```
+
+Reads only committed data. If another transaction commits a change while yours is running, a subsequent read in your transaction will see the new data. This is called a **non-repeatable read**.
+
+Common choice for OLTP applications where you want fresh data and can accept slight inconsistency within a transaction.
+
+### REPEATABLE READ (default)
+
+```sql
+SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+```
+
+Within a transaction, every read of the same rows returns the same data, regardless of commits by other transactions. InnoDB achieves this with MVCC (Multi-Version Concurrency Control) -- reads are served from a snapshot taken at the start of the transaction.
+
+Prevents dirty reads and non-repeatable reads. Allows **phantom reads** (new rows inserted by other transactions can appear in range queries) in standard SQL -- but InnoDB's gap locks prevent most phantom read scenarios in practice.
+
+### SERIALIZABLE
+
+```sql
+SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+```
+
+The strictest level. All reads are treated as `SELECT ... FOR SHARE`, meaning they acquire shared locks. Transactions execute as if they were serial. Prevents all anomalies but significantly reduces concurrency.
+
+### Setting isolation level scope
+
+```sql
+-- For the next transaction only:
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+
+-- For the current session:
+SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED;
+
+-- Global default (requires SYSTEM_VARIABLES_ADMIN privilege):
+SET GLOBAL TRANSACTION ISOLATION LEVEL READ COMMITTED;
+```
+
+### Isolation level comparison
+
+| Level | Dirty read | Non-repeatable read | Phantom read |
+|---|---|---|---|
+| READ UNCOMMITTED | Yes | Yes | Yes |
+| READ COMMITTED | No | Yes | Yes |
+| REPEATABLE READ | No | No | Mostly no (InnoDB gap locks) |
+| SERIALIZABLE | No | No | No |
+
+## Locking: shared and exclusive
+
+InnoDB uses row-level locking rather than table-level locking, which is one of the main reasons to prefer it over MyISAM.
+
+```sql
+-- Acquire a shared lock (other transactions can read, not write):
+SELECT * FROM accounts WHERE id = 1 FOR SHARE;
+
+-- Acquire an exclusive lock (blocks reads and writes by others):
+SELECT * FROM accounts WHERE id = 1 FOR UPDATE;
+```
+
+`FOR UPDATE` is the right choice before modifying a row -- it prevents another transaction from acquiring a conflicting lock between your read and your write.
+
+## Detecting and handling deadlocks
+
+InnoDB automatically detects deadlocks and rolls back the transaction with the least undo. The application should catch the error and retry:
+
+```sql
+-- Error 1213: Deadlock found when trying to get lock; try restarting transaction
+```
+
+To reduce deadlock frequency:
+- Always acquire locks in the same order across transactions
+- Keep transactions short
+- Avoid user interaction in the middle of a transaction
+- Use lower isolation levels if you can afford it
+
+```sql
+-- View the last deadlock information:
+SHOW ENGINE INNODB STATUS;
+-- Look for the LATEST DETECTED DEADLOCK section
+```
+
+## Transaction patterns
+
+### Check-then-act
+
+Always use `FOR UPDATE` when checking a value you plan to act on:
+
+```sql
+START TRANSACTION;
+
+SELECT balance FROM accounts WHERE id = 1 FOR UPDATE;
+-- Check the balance in application code
+-- If sufficient, proceed:
+UPDATE accounts SET balance = balance - 100 WHERE id = 1;
+
+COMMIT;
+```
+
+Without `FOR UPDATE`, another transaction could decrease the balance between your read and your update.
+
+### Idempotent transactions
+
+For operations triggered by events (queues, webhooks), design transactions to be safe to retry:
+
+```sql
+START TRANSACTION;
+
+-- Use INSERT IGNORE or ON DUPLICATE KEY to prevent duplicates:
+INSERT IGNORE INTO processed_events (event_id, processed_at)
+VALUES ('evt_abc123', NOW());
+
+-- Only proceed if insert succeeded (1 row affected)
+UPDATE orders SET status = 'fulfilled' WHERE id = 456;
+
+COMMIT;
+```
+
+Mako's query editor runs your SQL with full transaction support -- useful for testing multi-statement transaction logic against live data. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/mysql/triggers.mdx
+++ b/content/guides/mysql/triggers.mdx
@@ -1,0 +1,198 @@
+---
+title: "MySQL Triggers: BEFORE and AFTER INSERT, UPDATE, DELETE -- Use Cases and Pitfalls"
+description: "How MySQL triggers work, how to write BEFORE and AFTER triggers for INSERT, UPDATE, and DELETE, practical use cases, and the performance and debugging pitfalls to know before using them."
+database: mysql
+category: sql-how-to
+tags: [mysql, triggers, before-insert, after-update, audit-log]
+date: 2026-04-16
+---
+
+# MySQL Triggers: BEFORE and AFTER INSERT, UPDATE, DELETE -- Use Cases and Pitfalls
+
+A trigger is a stored procedure that fires automatically when a specific DML event (`INSERT`, `UPDATE`, or `DELETE`) occurs on a table. MySQL supports triggers at the row level: the trigger body executes once per affected row, not once per statement.
+
+## Trigger timing and events
+
+Each trigger is defined on:
+- **Event:** `INSERT`, `UPDATE`, or `DELETE`
+- **Timing:** `BEFORE` (fires before the row change) or `AFTER` (fires after the row change is committed to the table)
+
+This gives six possible trigger types:
+- `BEFORE INSERT`, `AFTER INSERT`
+- `BEFORE UPDATE`, `AFTER UPDATE`
+- `BEFORE DELETE`, `AFTER DELETE`
+
+MySQL 8.0+ allows multiple triggers per event/timing combination on the same table. Use `FOLLOWS` or `PRECEDES` to control execution order.
+
+## Creating triggers
+
+```sql
+DELIMITER $$
+
+CREATE TRIGGER trg_users_before_insert
+BEFORE INSERT ON users
+FOR EACH ROW
+BEGIN
+  -- Normalize email to lowercase before inserting
+  SET NEW.email = LOWER(NEW.email);
+  -- Set created_at if not provided
+  IF NEW.created_at IS NULL THEN
+    SET NEW.created_at = NOW();
+  END IF;
+END$$
+
+DELIMITER ;
+```
+
+### NEW and OLD row references
+
+- In `INSERT` triggers: `NEW.column` contains the value being inserted
+- In `DELETE` triggers: `OLD.column` contains the value being deleted
+- In `UPDATE` triggers: `NEW.column` = new value, `OLD.column` = old value
+
+`BEFORE` triggers can modify `NEW` values (to transform data before it's written). `AFTER` triggers cannot modify `NEW` -- the row is already written.
+
+## Practical use cases
+
+### Audit logging (AFTER trigger)
+
+```sql
+CREATE TABLE orders_audit (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  order_id INT NOT NULL,
+  changed_by VARCHAR(100),
+  old_status VARCHAR(50),
+  new_status VARCHAR(50),
+  changed_at DATETIME NOT NULL
+);
+
+DELIMITER $$
+
+CREATE TRIGGER trg_orders_after_update
+AFTER UPDATE ON orders
+FOR EACH ROW
+BEGIN
+  IF OLD.status != NEW.status THEN
+    INSERT INTO orders_audit
+      (order_id, changed_by, old_status, new_status, changed_at)
+    VALUES
+      (NEW.id, USER(), OLD.status, NEW.status, NOW());
+  END IF;
+END$$
+
+DELIMITER ;
+```
+
+The `IF OLD.status != NEW.status` check prevents logging when other columns change but status didn't.
+
+### Data validation (BEFORE trigger)
+
+```sql
+DELIMITER $$
+
+CREATE TRIGGER trg_orders_before_insert
+BEFORE INSERT ON orders
+FOR EACH ROW
+BEGIN
+  IF NEW.amount <= 0 THEN
+    SIGNAL SQLSTATE '45000'
+    SET MESSAGE_TEXT = 'Order amount must be positive';
+  END IF;
+  IF NEW.customer_id IS NULL THEN
+    SIGNAL SQLSTATE '45000'
+    SET MESSAGE_TEXT = 'Order must have a customer';
+  END IF;
+END$$
+
+DELIMITER ;
+```
+
+`SIGNAL SQLSTATE '45000'` raises a user-defined error and aborts the operation. `45000` is the conventional state for application-level errors.
+
+### Cascading denormalized updates
+
+```sql
+DELIMITER $$
+
+CREATE TRIGGER trg_order_items_after_insert
+AFTER INSERT ON order_items
+FOR EACH ROW
+BEGIN
+  -- Keep a denormalized total on the orders table
+  UPDATE orders
+  SET total_items = total_items + NEW.quantity,
+      total_amount = total_amount + (NEW.quantity * NEW.unit_price)
+  WHERE id = NEW.order_id;
+END$$
+
+DELIMITER ;
+```
+
+This approach works but creates hidden dependencies. If a developer adds items via `INSERT INTO order_items ... SELECT ...`, they may not realize the trigger is updating `orders`.
+
+### Soft-delete archiving (BEFORE DELETE)
+
+```sql
+DELIMITER $$
+
+CREATE TRIGGER trg_customers_before_delete
+BEFORE DELETE ON customers
+FOR EACH ROW
+BEGIN
+  INSERT INTO customers_archive
+  SELECT *, NOW() AS archived_at FROM customers WHERE id = OLD.id;
+END$$
+
+DELIMITER ;
+```
+
+## Managing triggers
+
+```sql
+-- List triggers in the current database:
+SHOW TRIGGERS;
+SHOW TRIGGERS LIKE 'orders%';  -- filter by table name pattern
+
+-- View trigger definition:
+SHOW CREATE TRIGGER trg_orders_after_update;
+
+-- Information schema:
+SELECT trigger_name, event_manipulation, event_object_table, action_timing
+FROM information_schema.triggers
+WHERE trigger_schema = DATABASE();
+
+-- Drop a trigger:
+DROP TRIGGER IF EXISTS trg_orders_after_update;
+```
+
+## Pitfalls
+
+### Performance overhead on every write
+
+Triggers execute for every row affected by DML. A bulk `UPDATE orders SET status = 'shipped' WHERE ...` that hits 10,000 rows fires the trigger 10,000 times. Triggers with `INSERT` statements in their body (like audit log triggers) are particularly expensive at scale. Measure before deploying triggers on high-write tables.
+
+### Hidden logic is hard to debug
+
+Triggers are invisible from the application layer. When data changes unexpectedly, triggers are often the last place developers look. Document triggers in your schema docs and naming conventions (e.g., `trg_tablename_timing_event`).
+
+### No triggers on triggers
+
+MySQL doesn't allow a trigger to directly fire another trigger. If trigger A inserts a row that would fire trigger B, trigger B does fire -- this is called a cascading trigger and can lead to infinite loops or unexpected behavior. MySQL limits trigger nesting depth to prevent infinite recursion.
+
+### REPLACE INTO fires DELETE + INSERT triggers
+
+`REPLACE INTO` on an existing row fires a `BEFORE DELETE`, `AFTER DELETE`, `BEFORE INSERT`, `AFTER INSERT` sequence. If your trigger does audit logging, you'll see a delete and insert entry, not an update.
+
+### No rollback from AFTER triggers... mostly
+
+If an `AFTER` trigger fails (raises an error), MySQL rolls back the triggering DML statement. But if the trigger's own `INSERT` or `UPDATE` fails silently (e.g., because you used `INSERT IGNORE`), the original row change is committed and the trigger failure is swallowed.
+
+## Triggers vs application logic
+
+Triggers enforce rules at the database level regardless of which application or script modifies the data. That's their main argument.
+
+Their main counterargument: they add invisible complexity, make schema changes harder (a trigger referencing a column you want to rename will break), and are difficult to test in isolation. Most modern applications prefer to handle audit logging, validation, and denormalization in application code or via event streams (CDC, message queues).
+
+If you use triggers, keep them short, name them clearly, and document their existence in your schema README.
+
+Mako's query editor executes DML and shows you the resulting state -- useful for verifying trigger behavior against real data. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/mysql/upsert.mdx
+++ b/content/guides/mysql/upsert.mdx
@@ -1,0 +1,148 @@
+---
+title: "MySQL Upsert: INSERT ON DUPLICATE KEY UPDATE, REPLACE INTO, and INSERT IGNORE"
+description: "How to handle insert-or-update logic in MySQL using INSERT ON DUPLICATE KEY UPDATE, REPLACE INTO, and INSERT IGNORE -- with honest tradeoffs for each approach."
+database: mysql
+category: sql-how-to
+tags: [mysql, upsert, insert-on-duplicate-key, replace-into, insert-ignore]
+date: 2026-04-16
+---
+
+# MySQL Upsert: INSERT ON DUPLICATE KEY UPDATE, REPLACE INTO, and INSERT IGNORE
+
+MySQL doesn't have a single `UPSERT` keyword, but it provides three distinct mechanisms for "insert if not exists, update if it does." Each has different semantics, performance characteristics, and footguns.
+
+## The problem
+
+You have a row that may or may not exist. If it doesn't, insert it. If it does, update it (or do nothing). Doing this naively with a `SELECT` check followed by `INSERT` or `UPDATE` creates a race condition. MySQL's three mechanisms handle this atomically.
+
+All three rely on a **unique constraint violation** -- either a `PRIMARY KEY` or a `UNIQUE INDEX` collision -- to decide whether to insert or take the alternate action.
+
+## INSERT ON DUPLICATE KEY UPDATE
+
+The most flexible option. If the insert would cause a unique key collision, execute the `UPDATE` clause instead:
+
+```sql
+INSERT INTO page_views (page_id, view_count, last_viewed_at)
+VALUES (42, 1, NOW())
+ON DUPLICATE KEY UPDATE
+  view_count = view_count + 1,
+  last_viewed_at = NOW();
+```
+
+The `UPDATE` clause has access to `VALUES(column)` to reference the value you attempted to insert:
+
+```sql
+INSERT INTO product_prices (product_id, price, updated_at)
+VALUES (101, 29.99, NOW())
+ON DUPLICATE KEY UPDATE
+  price = VALUES(price),
+  updated_at = VALUES(updated_at);
+```
+
+Note: `VALUES()` is deprecated in MySQL 8.0.20+. The replacement uses aliases:
+
+```sql
+INSERT INTO product_prices (product_id, price, updated_at)
+VALUES (101, 29.99, NOW()) AS new_row
+ON DUPLICATE KEY UPDATE
+  price = new_row.price,
+  updated_at = new_row.updated_at;
+```
+
+### Batch upserts
+
+`ON DUPLICATE KEY UPDATE` works with multi-row inserts:
+
+```sql
+INSERT INTO inventory (product_id, warehouse_id, quantity)
+VALUES
+  (1, 'WH-A', 100),
+  (2, 'WH-A', 50),
+  (3, 'WH-A', 200)
+ON DUPLICATE KEY UPDATE
+  quantity = VALUES(quantity);
+```
+
+### AUTO_INCREMENT behavior
+
+A known side effect: when `ON DUPLICATE KEY UPDATE` fires and updates an existing row, MySQL still increments the `AUTO_INCREMENT` counter, even though no new row was created. This causes gaps in ID sequences. Not a bug, but something to be aware of in high-volume upsert scenarios.
+
+### The `affected_rows` return value
+
+- 1 = new row inserted
+- 2 = existing row updated
+- 0 = existing row found but no values changed
+
+Application code can use this to distinguish insert from update.
+
+## REPLACE INTO
+
+`REPLACE` first deletes the existing row, then inserts a new one. It looks simple:
+
+```sql
+REPLACE INTO user_preferences (user_id, theme, language)
+VALUES (7, 'dark', 'en');
+```
+
+But it has a critical consequence: **all columns not specified in the INSERT are reset to their default values or `NULL`**. This trips up developers who assume it behaves like an update.
+
+```sql
+-- Table: user_preferences(user_id PK, theme, language, created_at DEFAULT NOW())
+-- Existing row: (7, 'light', 'de', '2025-01-01')
+REPLACE INTO user_preferences (user_id, theme, language) VALUES (7, 'dark', 'en');
+-- Result: (7, 'dark', 'en', NOW())  -- created_at was reset to now
+```
+
+Because `REPLACE` deletes and re-inserts, it also fires `BEFORE DELETE` and `AFTER DELETE` triggers, followed by `BEFORE INSERT` and `AFTER INSERT` triggers. If you have foreign keys pointing to this row, the delete will fail or cascade depending on your constraint definition.
+
+**When to use `REPLACE INTO`:** When you genuinely want to replace all column values (log entries, config snapshots) and have no foreign key concerns. It's simpler to write but rarely the right choice for partial updates.
+
+**Performance note:** `REPLACE` is significantly slower than `ON DUPLICATE KEY UPDATE` on duplicate hits because it performs a delete + insert instead of an in-place update (roughly 32x slower in benchmarks with InnoDB).
+
+## INSERT IGNORE
+
+`INSERT IGNORE` silently discards rows that would cause a unique key violation:
+
+```sql
+INSERT IGNORE INTO processed_events (event_id, processed_at)
+VALUES ('evt_abc123', NOW());
+-- If event_id already exists, no error -- just skips the insert
+```
+
+This is useful for idempotent inserts where "already exists" is fine and you don't need to update anything.
+
+**The footgun:** `INSERT IGNORE` suppresses *all* errors, not just duplicate key violations. Type conversion errors, out-of-range values, and NOT NULL violations are also silently swallowed, with MySQL inserting the "closest valid value" instead. This can corrupt data silently.
+
+```sql
+-- Column 'status' is TINYINT. Inserting 999 with INSERT IGNORE stores 127.
+INSERT IGNORE INTO orders (id, status) VALUES (5, 999);
+```
+
+If you only want to suppress duplicate key errors, `ON DUPLICATE KEY UPDATE` with a no-op is safer:
+
+```sql
+INSERT INTO processed_events (event_id, processed_at)
+VALUES ('evt_abc123', NOW())
+ON DUPLICATE KEY UPDATE event_id = event_id;  -- no-op update, but errors are real
+```
+
+## Comparison
+
+| Feature | ON DUPLICATE KEY UPDATE | REPLACE INTO | INSERT IGNORE |
+|---|---|---|---|
+| On duplicate | Updates specified columns | Deletes + re-inserts | Silently skips |
+| Unspecified columns | Unchanged | Reset to default/NULL | N/A |
+| Triggers fired | INSERT + UPDATE | DELETE + INSERT | INSERT only |
+| Performance (dupe hit) | Fast (in-place update) | Slow (delete + insert) | Fast |
+| Foreign keys | Safe | Can break | Safe |
+| AUTO_INCREMENT gap | Yes | Yes | No |
+| Error handling | Real errors surface | Real errors surface | Suppresses all errors |
+
+## Choosing the right approach
+
+- Updating specific columns on conflict while preserving others: `ON DUPLICATE KEY UPDATE`
+- Tracking counters or timestamps atomically: `ON DUPLICATE KEY UPDATE`
+- Idempotent event processing where duplicates should be skipped: `INSERT IGNORE` (with caution about error suppression)
+- Complete row replacement where all columns are specified: `REPLACE INTO`
+
+Mako connects to MySQL and lets you run and test upsert logic against real data with immediate feedback. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/mysql/views.mdx
+++ b/content/guides/mysql/views.mdx
@@ -1,0 +1,213 @@
+---
+title: "Views in MySQL: CREATE VIEW, Updatable Views, and Materialized View Patterns"
+description: "How to create and manage MySQL views, when views are updatable, how WITH CHECK OPTION works, and how to simulate materialized views using tables and events."
+database: mysql
+category: sql-how-to
+tags: [mysql, views, materialized-view, with-check-option, create-view]
+date: 2026-04-16
+---
+
+# Views in MySQL: CREATE VIEW, Updatable Views, and Materialized View Patterns
+
+A view is a named query stored in the database. When you select from a view, MySQL runs the underlying query. Views don't store data (with one exception covered below) -- they're a lens over your tables.
+
+## Creating a view
+
+```sql
+CREATE VIEW active_customers AS
+SELECT id, name, email, country
+FROM customers
+WHERE status = 'active';
+```
+
+Query it like a table:
+
+```sql
+SELECT * FROM active_customers WHERE country = 'DE';
+```
+
+MySQL appends the view's `WHERE` condition to your query. The result is equivalent to:
+
+```sql
+SELECT id, name, email, country
+FROM customers
+WHERE status = 'active' AND country = 'DE';
+```
+
+## Replacing and altering views
+
+To redefine an existing view without dropping it first:
+
+```sql
+CREATE OR REPLACE VIEW active_customers AS
+SELECT id, name, email, country, created_at
+FROM customers
+WHERE status = 'active';
+```
+
+`ALTER VIEW` also works:
+
+```sql
+ALTER VIEW active_customers AS
+SELECT id, name, email, country, created_at
+FROM customers
+WHERE status = 'active';
+```
+
+## Inspecting views
+
+```sql
+-- List all views in the current database
+SHOW FULL TABLES WHERE Table_type = 'VIEW';
+
+-- See the definition of a view
+SHOW CREATE VIEW active_customers;
+
+-- View metadata
+SELECT table_name, view_definition, is_updatable
+FROM information_schema.views
+WHERE table_schema = DATABASE();
+```
+
+## Updatable views
+
+MySQL allows `INSERT`, `UPDATE`, and `DELETE` through a view if the view meets these conditions:
+
+- References exactly one base table
+- Contains no `DISTINCT`, `GROUP BY`, `HAVING`, aggregate functions, `UNION`, or subqueries in `SELECT`
+- Does not use `LIMIT` (in most cases)
+- Does not include computed columns that can't be mapped back to a base column
+
+Example of an updatable view:
+
+```sql
+CREATE VIEW german_customers AS
+SELECT id, name, email, status, country
+FROM customers
+WHERE country = 'DE';
+
+-- This UPDATE goes through to the base table:
+UPDATE german_customers SET status = 'inactive' WHERE id = 42;
+```
+
+When a view is not updatable, MySQL will tell you clearly: `ERROR 1288 (HY000): The target table ... is not updatable`.
+
+### WITH CHECK OPTION
+
+Without `WITH CHECK OPTION`, you can insert a row through a view that immediately disappears from the view:
+
+```sql
+-- Without CHECK OPTION:
+INSERT INTO german_customers (name, email, status, country)
+VALUES ('Test', 'test@test.com', 'active', 'FR');
+-- Row inserted into customers, but now invisible through german_customers
+```
+
+Add `WITH CHECK OPTION` to prevent this:
+
+```sql
+CREATE OR REPLACE VIEW german_customers AS
+SELECT id, name, email, status, country
+FROM customers
+WHERE country = 'DE'
+WITH CHECK OPTION;
+
+-- Now this fails:
+INSERT INTO german_customers (name, email, status, country)
+VALUES ('Test', 'test@test.com', 'active', 'FR');
+-- ERROR 1369 (HY000): CHECK OPTION failed 'mydb.german_customers'
+```
+
+### LOCAL vs CASCADED check option
+
+When a view is built on top of another view, `WITH LOCAL CHECK OPTION` only enforces the current view's `WHERE` clause. `WITH CASCADED CHECK OPTION` (the default) enforces all views in the chain:
+
+```sql
+CREATE VIEW eu_customers AS
+SELECT * FROM customers WHERE country IN ('DE', 'FR', 'ES');
+
+-- CASCADED: must satisfy both eu_customers and german_active WHERE clauses
+CREATE VIEW german_active AS
+SELECT * FROM eu_customers WHERE status = 'active'
+WITH CASCADED CHECK OPTION;
+```
+
+## Views and performance
+
+MySQL doesn't cache view results. Each query against a view re-runs the underlying SQL. Complex views with joins, aggregations, or subqueries can be slow -- exactly as slow as running the underlying query directly.
+
+MySQL's optimizer sometimes merges a view into the outer query (the `MERGED` algorithm), which allows index use. Other times it materializes the view as a temporary table first (`TEMPTABLE`). You can inspect this:
+
+```sql
+SELECT table_name, algorithm
+FROM information_schema.views
+WHERE table_schema = DATABASE();
+```
+
+Views using `DISTINCT`, `GROUP BY`, or `UNION` are always `TEMPTABLE` -- the optimizer can't merge them. For frequently-queried aggregations, materialized view patterns are more practical.
+
+## Materialized view patterns in MySQL
+
+MySQL has no native materialized view. The standard workaround is a summary table refreshed by an event or trigger.
+
+### Summary table + scheduled event
+
+```sql
+-- Create the summary table
+CREATE TABLE mv_customer_order_summary (
+  customer_id INT NOT NULL PRIMARY KEY,
+  order_count INT NOT NULL DEFAULT 0,
+  total_revenue DECIMAL(12,2) NOT NULL DEFAULT 0,
+  last_order_date DATE,
+  refreshed_at DATETIME
+);
+
+-- Enable the event scheduler (requires SUPER or EVENT privilege)
+SET GLOBAL event_scheduler = ON;
+
+-- Refresh every hour
+DELIMITER $$
+CREATE EVENT evt_refresh_customer_summary
+ON SCHEDULE EVERY 1 HOUR
+STARTS CURRENT_TIMESTAMP
+DO BEGIN
+  INSERT INTO mv_customer_order_summary
+    (customer_id, order_count, total_revenue, last_order_date, refreshed_at)
+  SELECT
+    customer_id,
+    COUNT(*) AS order_count,
+    SUM(amount) AS total_revenue,
+    MAX(created_at) AS last_order_date,
+    NOW()
+  FROM orders
+  GROUP BY customer_id
+  ON DUPLICATE KEY UPDATE
+    order_count = VALUES(order_count),
+    total_revenue = VALUES(total_revenue),
+    last_order_date = VALUES(last_order_date),
+    refreshed_at = VALUES(refreshed_at);
+END$$
+DELIMITER ;
+```
+
+This pattern works well for dashboards and reports that tolerate data up to an hour old. For near-real-time, you can trigger refresh via application code on write, or use an `AFTER INSERT/UPDATE` trigger (with care -- triggers on large tables add latency to every write).
+
+### Tradeoffs
+
+| Approach | Data freshness | Complexity | Write overhead |
+|---|---|---|---|
+| Regular view | Real-time | Low | None |
+| Summary table + event | Lag = event interval | Medium | Low |
+| Summary table + trigger | Near real-time | Medium-high | High |
+| External CDC (Debezium, etc.) | Near real-time | High | Very low |
+
+For most OLTP use cases, a scheduled event with a 5--15 minute interval covers 90% of reporting needs without trigger overhead.
+
+## Dropping views
+
+```sql
+DROP VIEW IF EXISTS german_customers;
+DROP VIEW IF EXISTS german_customers, active_customers;  -- drop multiple at once
+```
+
+Mako connects to MySQL databases and lets you explore views alongside base tables in the same query editor. Try it free at [mako.ai](https://mako.ai).


### PR DESCRIPTION
## MySQL Batch 6 -- Final 10 articles

Completes the MySQL SQL how-to series (batch 6, 20/20 total).

### Articles added (11-20 of 20):
- `mysql/subqueries` -- correlated vs non-correlated, IN vs EXISTS, derived tables, anti-join patterns
- `mysql/views` -- CREATE VIEW, updatable views, WITH CHECK OPTION, materialized view patterns
- `mysql/transactions` -- START TRANSACTION, SAVEPOINT, all 4 isolation levels, InnoDB locking
- `mysql/upsert` -- INSERT ON DUPLICATE KEY UPDATE, REPLACE INTO, INSERT IGNORE, honest tradeoffs
- `mysql/explain-analyze` -- EXPLAIN, EXPLAIN FORMAT=JSON, EXPLAIN ANALYZE (8.0.18+), reading cost estimates
- `mysql/partitioning` -- RANGE/LIST/HASH/KEY, partition pruning, DROP PARTITION, limitations
- `mysql/stored-procedures` -- CREATE PROCEDURE, IN/OUT/INOUT params, cursors, DECLARE HANDLER
- `mysql/triggers` -- BEFORE/AFTER INSERT/UPDATE/DELETE, audit logging, SIGNAL, pitfalls
- `mysql/generated-columns` -- VIRTUAL vs STORED, indexing generated columns, JSON extraction pattern
- `mysql/string-to-json` -- JSON_OBJECT, JSON_ARRAYAGG, migrating legacy serialized strings

### First 10 (from PR #341, merged):
window-functions, cte, json-queries, indexes-explained, joins-guide, pivot-table, full-text-search, date-functions, string-functions, aggregate-functions

Batch 6 complete. All 20 MySQL how-to guides written.