### PR TITLE
feat: DB-backed model catalog cache with Zod-validated upstream snapshots

### DIFF
--- a/api/src/database/schema.ts
+++ b/api/src/database/schema.ts
@@ -374,6 +374,35 @@ export const LlmUsage =
   (mongoose.models.LlmUsage as mongoose.Model<ILlmUsage>) ||
   mongoose.model<ILlmUsage>("LlmUsage", LlmUsageSchema);
 
+// ---------------------------------------------------------------------------
+// Model Catalog Snapshot — raw upstream API responses persisted per source
+// ---------------------------------------------------------------------------
+
+export interface IModelCatalogSnapshot extends Document {
+  _id: "gateway" | "arena" | "pricing";
+  data: any[];
+  fetchedAt: Date;
+  itemCount: number;
+}
+
+const ModelCatalogSnapshotSchema = new Schema(
+  {
+    _id: { type: String, enum: ["gateway", "arena", "pricing"] },
+    data: { type: Schema.Types.Mixed, default: [] },
+    fetchedAt: { type: Date, required: true },
+    itemCount: { type: Number, required: true, default: 0 },
+  },
+  { timestamps: false },
+);
+
+export const ModelCatalogSnapshot =
+  (mongoose.models
+    .ModelCatalogSnapshot as mongoose.Model<IModelCatalogSnapshot>) ||
+  mongoose.model<IModelCatalogSnapshot>(
+    "ModelCatalogSnapshot",
+    ModelCatalogSnapshotSchema,
+  );
+
 /**
  * Database connection helper
  */

--- a/api/src/inngest/functions/model-catalog-refresh.ts
+++ b/api/src/inngest/functions/model-catalog-refresh.ts
@@ -1,0 +1,34 @@
+/**
+ * Model Catalog Refresh — Inngest Cron
+ *
+ * Runs every hour at :15 past. Each upstream source (gateway, arena) is
+ * fetched in an independent Inngest step so one failing doesn't block the
+ * other. Zod validation inside each refresh function prevents bad data
+ * from overwriting last-known-good DB snapshots.
+ */
+
+import { inngest } from "../client";
+import {
+  refreshGatewaySnapshot,
+  refreshArenaSnapshot,
+} from "../../services/model-catalog.service";
+
+export const modelCatalogRefreshFunction = inngest.createFunction(
+  {
+    id: "system/model-catalog-refresh",
+    name: "Refresh AI model catalog snapshots",
+    retries: 2,
+  },
+  { cron: "15 * * * *" },
+  async ({ step }) => {
+    const gw = await step.run("fetch-gateway", async () => {
+      return refreshGatewaySnapshot();
+    });
+
+    const arena = await step.run("fetch-arena", async () => {
+      return refreshArenaSnapshot();
+    });
+
+    return { gateway: gw, arena };
+  },
+);

--- a/api/src/inngest/index.ts
+++ b/api/src/inngest/index.ts
@@ -20,6 +20,7 @@ import {
 } from "./functions/dashboard-refresh";
 import { syncBackfillEntityFunction } from "./functions/sync-entity";
 import { usageReportingFunction } from "./functions/usage-reporting";
+import { modelCatalogRefreshFunction } from "./functions/model-catalog-refresh";
 import { loggers } from "../logging";
 
 const baseFunctions = [
@@ -31,6 +32,7 @@ const baseFunctions = [
   dashboardRefreshFunction,
   cleanupAbandonedMaterializationRunsFunction,
   usageReportingFunction,
+  modelCatalogRefreshFunction,
 ];
 
 const allWebhookFunctions = [
@@ -111,4 +113,5 @@ export {
   dashboardSchedulerFunction,
   cleanupAbandonedMaterializationRunsFunction,
   usageReportingFunction,
+  modelCatalogRefreshFunction,
 };

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -74,45 +74,50 @@ agentRoutes.use("*", unifiedAuthMiddleware);
  * Falls back to the legacy `enabledModelIds` field, then to the full catalog.
  */
 agentRoutes.get("/models", async (c: AuthenticatedContext) => {
-  const workspaceId =
-    c.req.header("x-workspace-id") || c.get("session")?.activeWorkspaceId;
+  try {
+    const workspaceId =
+      c.req.header("x-workspace-id") || c.get("session")?.activeWorkspaceId;
 
-  if (workspaceId) {
-    const ws = await Workspace.findById(workspaceId)
-      .select({ "settings.enabledModels": 1, "settings.enabledModelIds": 1 })
-      .lean();
+    if (workspaceId) {
+      const ws = await Workspace.findById(workspaceId)
+        .select({ "settings.enabledModels": 1, "settings.enabledModelIds": 1 })
+        .lean();
 
-    if (ws?.settings?.enabledModels?.length) {
-      const catalogModels = await getAvailableModels();
-      const catalogMap = new Map(catalogModels.map(m => [m.id, m]));
-      const models = ws.settings.enabledModels.map(
-        (em: {
-          id: string;
-          name: string;
-          provider: string;
-          description?: string;
-        }) => {
-          const catalogModel = catalogMap.get(em.id);
-          if (catalogModel) return catalogModel;
-          return {
-            id: em.id,
-            provider: em.provider,
-            name: em.name,
-            description: em.description || "",
-          };
-        },
-      );
-      return c.json({ models });
+      if (ws?.settings?.enabledModels?.length) {
+        const catalogModels = await getAvailableModels();
+        const catalogMap = new Map(catalogModels.map(m => [m.id, m]));
+        const models = ws.settings.enabledModels.map(
+          (em: {
+            id: string;
+            name: string;
+            provider: string;
+            description?: string;
+          }) => {
+            const catalogModel = catalogMap.get(em.id);
+            if (catalogModel) return catalogModel;
+            return {
+              id: em.id,
+              provider: em.provider,
+              name: em.name,
+              description: em.description || "",
+            };
+          },
+        );
+        return c.json({ models });
+      }
+
+      if (ws?.settings?.enabledModelIds?.length) {
+        const models = await getAvailableModels(ws.settings.enabledModelIds);
+        return c.json({ models });
+      }
     }
 
-    if (ws?.settings?.enabledModelIds?.length) {
-      const models = await getAvailableModels(ws.settings.enabledModelIds);
-      return c.json({ models });
-    }
+    const models = await getAvailableModels();
+    return c.json({ models });
+  } catch (err) {
+    logger.error("Failed to load models", { error: err });
+    return c.json({ models: [] }, 200);
   }
-
-  const models = await getAvailableModels();
-  return c.json({ models });
 });
 
 /**

--- a/api/src/services/model-catalog.service.ts
+++ b/api/src/services/model-catalog.service.ts
@@ -1,20 +1,19 @@
 /**
  * Model Catalog Service
  *
- * Single source of truth for all AI model metadata. Merges the Vercel AI
- * Gateway model list with arena.ai code leaderboard ELO scores, then
- * auto-selects the best free-tier models by ranking.
+ * Single source of truth for all AI model metadata. Persists raw upstream
+ * snapshots (Vercel AI Gateway + arena.ai) in MongoDB, then merges on read.
  *
- * Refreshed hourly; stale cache is served when upstream APIs are down.
+ * Write path (Inngest cron / startup):
+ *   fetch upstream → Zod validate → upsert DB snapshot
+ *
+ * Read path (every request):
+ *   in-memory cache (5 min TTL) → MongoDB → mergeCatalog()
  */
 
-import {
-  getGatewayModels,
-  getGatewayPricingMap,
-  type GatewayModelInfo,
-  type GatewayModelPricing,
-} from "./gateway-models.service";
+import { z } from "zod";
 import { loggers } from "../logging";
+import { ModelCatalogSnapshot } from "../database/schema";
 
 const logger = loggers.app();
 
@@ -36,29 +35,49 @@ export interface CatalogModel {
   tier: "free" | "pro";
 }
 
-interface ArenaModel {
-  rank: number;
-  model: string;
-  vendor: string;
-  license: string;
-  score: number;
-  ci: number;
-  votes: number;
-}
+// ---------------------------------------------------------------------------
+// Zod validation schemas — gate what gets persisted to DB
+// ---------------------------------------------------------------------------
 
-interface ArenaResponse {
-  meta: { model_count: number };
-  models: ArenaModel[];
-}
+const GatewayModelRawSchema = z.object({
+  id: z.string(),
+  name: z.string().optional(),
+  description: z.string().optional(),
+  owned_by: z.string().optional(),
+  type: z.string().optional(),
+  context_window: z.number().optional(),
+  tags: z.array(z.string()).optional(),
+  pricing: z.record(z.string(), z.string()).optional(),
+});
+
+const GatewayResponseSchema = z.object({
+  data: z.array(GatewayModelRawSchema).min(10),
+});
+
+const ArenaModelSchema = z.object({
+  model: z.string(),
+  score: z.number(),
+  rank: z.number().optional(),
+  vendor: z.string().optional(),
+  license: z.string().optional(),
+  ci: z.number().optional(),
+  votes: z.number().optional(),
+});
+
+const ArenaResponseSchema = z.object({
+  meta: z.object({ model_count: z.number() }),
+  models: z.array(ArenaModelSchema).min(5),
+});
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
-const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+const GATEWAY_API_URL = "https://ai-gateway.vercel.sh/v1/models";
 const ARENA_API_URL =
   "https://api.wulong.dev/arena-ai-leaderboards/v1/leaderboard?name=code";
 const FREE_TIER_MAX_COST_PER_M = 3.0;
+const MEM_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
 const FALLBACK_FREE: readonly string[] = [
   "openai/gpt-4o-mini",
@@ -66,10 +85,6 @@ const FALLBACK_FREE: readonly string[] = [
   "deepseek/deepseek-chat",
 ];
 
-/**
- * Trusted providers for default model selection. When picking the default
- * model for a user who hasn't saved a preference, we prefer these providers.
- */
 const DEFAULT_PREFERRED_PROVIDERS = new Set([
   "openai",
   "anthropic",
@@ -78,49 +93,42 @@ const DEFAULT_PREFERRED_PROVIDERS = new Set([
 ]);
 
 // ---------------------------------------------------------------------------
-// In-memory cache
+// In-memory cache (thin layer over MongoDB)
 // ---------------------------------------------------------------------------
 
 let cachedCatalog: CatalogModel[] | null = null;
 let cachedFreeTierIds: Set<string> | null = null;
 let cacheTimestamp = 0;
-let refreshInFlight: Promise<void> | null = null;
 
 // ---------------------------------------------------------------------------
-// Arena fetcher
+// Snapshot types for DB docs
 // ---------------------------------------------------------------------------
 
-async function fetchArenaScores(): Promise<Map<string, number>> {
-  const map = new Map<string, number>();
-  try {
-    const res = await fetch(ARENA_API_URL, {
-      headers: { Accept: "application/json" },
-      signal: AbortSignal.timeout(8_000),
-    });
-    if (!res.ok) throw new Error(`Arena fetch failed: ${res.status}`);
-    const body = (await res.json()) as ArenaResponse;
-    for (const m of body.models) {
-      for (const key of normalizeArenaName(m.model)) {
-        map.set(key, m.score);
-      }
-    }
-    logger.info("Fetched arena scores", { modelCount: body.models.length });
-  } catch (err) {
-    logger.warn("Failed to fetch arena scores, continuing without", {
-      error: String(err),
-    });
-  }
-  return map;
+interface GatewayModelNormalized {
+  id: string;
+  name: string;
+  description: string;
+  provider: string;
+  contextWindow: number | null;
+  tags: string[];
 }
 
-/**
- * Generate multiple normalized keys for an arena model name to improve
- * fuzzy matching against gateway IDs.
- *
- * Arena names like "claude-opus-4-6", "gemini-2.5-pro",
- * "claude-haiku-4-5-20251001" need to match gateway IDs like
- * "claude-opus-4.6", "gemini-2.5-pro", "claude-3.5-haiku".
- */
+interface PricingEntry {
+  modelId: string;
+  input: number;
+  output: number;
+}
+
+interface ArenaEntry {
+  model: string;
+  score: number;
+  rank?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Arena name normalization (for fuzzy matching gateway ↔ arena IDs)
+// ---------------------------------------------------------------------------
+
 function normalizeArenaName(name: string): string[] {
   const base = name
     .replace(/\s*\(.*?\)\s*/g, "")
@@ -128,14 +136,9 @@ function normalizeArenaName(name: string): string[] {
     .toLowerCase();
 
   const keys: string[] = [];
-
-  // dots→dashes variant
   keys.push(base.replace(/\./g, "-"));
-  // dashes→dots variant (for version numbers)
   keys.push(base.replace(/(\d)-(?=\d)/g, "$1."));
-  // as-is
   keys.push(base);
-  // strip date suffixes like -20251001, -20250929
   const noDate = base.replace(/-\d{8}$/, "");
   if (noDate !== base) {
     keys.push(noDate.replace(/\./g, "-"));
@@ -145,11 +148,6 @@ function normalizeArenaName(name: string): string[] {
   return [...new Set(keys)];
 }
 
-/**
- * Hardcoded aliases for models where arena and gateway names diverge
- * completely (e.g. Anthropic renamed "3.5 Haiku" → "Haiku 4.5" on arena).
- * Maps gateway model-part (lowercase) → arena key (post-normalization).
- */
 const GATEWAY_TO_ARENA_ALIASES: Record<string, string> = {
   "claude-3.5-haiku": "claude-haiku-4-5",
   "claude-3-5-haiku": "claude-haiku-4-5",
@@ -157,25 +155,15 @@ const GATEWAY_TO_ARENA_ALIASES: Record<string, string> = {
   "claude-3-5-sonnet": "claude-sonnet-4-6",
 };
 
-/**
- * Extract "significant tokens" from a model name for fuzzy matching.
- * Returns the model family name and all version-like segments.
- */
 function modelTokens(name: string): Set<string> {
   const tokens = new Set<string>();
   const parts = name.replace(/\./g, "-").split("-");
   for (const p of parts) {
-    if (p.length > 0) {
-      tokens.add(p);
-    }
+    if (p.length > 0) tokens.add(p);
   }
   return tokens;
 }
 
-/**
- * Look up the arena score for a gateway model ID. Tries multiple
- * normalization strategies to handle naming divergence.
- */
 function lookupArenaScore(
   gatewayId: string,
   arenaScores: Map<string, number>,
@@ -184,16 +172,12 @@ function lookupArenaScore(
   const modelPart = slashIdx >= 0 ? gatewayId.slice(slashIdx + 1) : gatewayId;
   const lower = modelPart.toLowerCase();
 
-  // 1. Hardcoded alias lookup
   const alias = GATEWAY_TO_ARENA_ALIASES[lower];
   if (alias) {
     const score = arenaScores.get(alias);
-    if (score !== undefined) {
-      return score;
-    }
+    if (score !== undefined) return score;
   }
 
-  // 2. Try exact, dots→dashes, dashes→dots
   const variants = [
     lower,
     lower.replace(/\./g, "-"),
@@ -201,19 +185,13 @@ function lookupArenaScore(
   ];
   for (const v of variants) {
     const score = arenaScores.get(v);
-    if (score !== undefined) {
-      return score;
-    }
+    if (score !== undefined) return score;
   }
 
-  // 3. Prefix match
   for (const [key, score] of arenaScores) {
-    if (key.startsWith(lower) || lower.startsWith(key)) {
-      return score;
-    }
+    if (key.startsWith(lower) || lower.startsWith(key)) return score;
   }
 
-  // 4. Token-set match: if >70% of tokens overlap (handles reordering)
   const gwTokens = modelTokens(lower);
   if (gwTokens.size >= 2) {
     let bestScore: number | null = null;
@@ -222,9 +200,7 @@ function lookupArenaScore(
       const arenaTokens = modelTokens(key);
       let overlap = 0;
       for (const t of gwTokens) {
-        if (arenaTokens.has(t)) {
-          overlap++;
-        }
+        if (arenaTokens.has(t)) overlap++;
       }
       const ratio = overlap / Math.max(gwTokens.size, arenaTokens.size);
       if (ratio > 0.7 && overlap > bestOverlap) {
@@ -232,113 +208,324 @@ function lookupArenaScore(
         bestScore = score;
       }
     }
-    if (bestScore !== null) {
-      return bestScore;
-    }
+    if (bestScore !== null) return bestScore;
   }
 
   return null;
 }
 
 // ---------------------------------------------------------------------------
-// Core: build catalog
+// Snapshot refresh: Gateway (models + pricing)
 // ---------------------------------------------------------------------------
 
-async function buildCatalog(): Promise<{
-  models: CatalogModel[];
-  freeTierIds: Set<string>;
-}> {
-  const [gatewayModels, arenaScores, pricingMap] = await Promise.all([
-    getGatewayModels(),
-    fetchArenaScores(),
-    getGatewayPricingMap(),
-  ]);
+export async function refreshGatewaySnapshot(): Promise<
+  { models: number } | { skipped: true; reason: string }
+> {
+  const res = await fetch(GATEWAY_API_URL, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(10_000),
+  });
 
-  const models: CatalogModel[] = gatewayModels.map(gm =>
-    toCatalogModel(gm, arenaScores, pricingMap),
-  );
+  if (!res.ok) {
+    throw new Error(`Gateway fetch failed: ${res.status} ${res.statusText}`);
+  }
 
-  const freeTierIds = new Set<string>();
-  for (const m of models) {
-    if (
-      m.blendedCostPerM !== null &&
-      m.blendedCostPerM <= FREE_TIER_MAX_COST_PER_M
-    ) {
-      m.tier = "free";
-      freeTierIds.add(m.id);
-    } else {
-      m.tier = "pro";
+  const body = await res.json();
+  const parsed = GatewayResponseSchema.safeParse(body);
+  if (!parsed.success) {
+    const reason = parsed.error.issues
+      .map(i => `${i.path.join(".")}: ${i.message}`)
+      .join("; ");
+    logger.warn("Gateway response failed Zod validation, skipping upsert", {
+      reason,
+    });
+    return { skipped: true, reason };
+  }
+
+  const languageModels = parsed.data.data.filter(m => m.type === "language");
+  if (languageModels.length < 10) {
+    const reason = `Only ${languageModels.length} language models after type filter`;
+    logger.warn("Gateway snapshot too small, skipping upsert", { reason });
+    return { skipped: true, reason };
+  }
+
+  // Normalize gateway models
+  const gatewayDocs: GatewayModelNormalized[] = languageModels.map(raw => ({
+    id: raw.id,
+    name: raw.name || raw.id,
+    description: raw.description || "",
+    provider: raw.owned_by || raw.id.split("/")[0] || "unknown",
+    contextWindow: raw.context_window ?? null,
+    tags: raw.tags ?? [],
+  }));
+
+  // Extract pricing
+  const pricingDocs: PricingEntry[] = [];
+  for (const raw of languageModels) {
+    if (raw.pricing?.input && raw.pricing?.output) {
+      pricingDocs.push({
+        modelId: raw.id,
+        input: parseFloat(raw.pricing.input) * 1_000_000,
+        output: parseFloat(raw.pricing.output) * 1_000_000,
+      });
     }
   }
 
-  logger.info("Built model catalog", {
-    totalModels: models.length,
-    freeModels: freeTierIds.size,
+  const now = new Date();
+
+  await Promise.all([
+    ModelCatalogSnapshot.findOneAndUpdate(
+      { _id: "gateway" },
+      { data: gatewayDocs, fetchedAt: now, itemCount: gatewayDocs.length },
+      { upsert: true },
+    ),
+    ModelCatalogSnapshot.findOneAndUpdate(
+      { _id: "pricing" },
+      { data: pricingDocs, fetchedAt: now, itemCount: pricingDocs.length },
+      { upsert: true },
+    ),
+  ]);
+
+  logger.info("Persisted gateway + pricing snapshots", {
+    models: gatewayDocs.length,
+    pricedModels: pricingDocs.length,
+  });
+
+  return { models: gatewayDocs.length };
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot refresh: Arena
+// ---------------------------------------------------------------------------
+
+export async function refreshArenaSnapshot(): Promise<
+  { scores: number } | { skipped: true; reason: string }
+> {
+  const res = await fetch(ARENA_API_URL, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(8_000),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Arena fetch failed: ${res.status} ${res.statusText}`);
+  }
+
+  const body = await res.json();
+  const parsed = ArenaResponseSchema.safeParse(body);
+  if (!parsed.success) {
+    const reason = parsed.error.issues
+      .map(i => `${i.path.join(".")}: ${i.message}`)
+      .join("; ");
+    logger.warn("Arena response failed Zod validation, skipping upsert", {
+      reason,
+    });
+    return { skipped: true, reason };
+  }
+
+  const arenaDocs: ArenaEntry[] = parsed.data.models.map(m => ({
+    model: m.model,
+    score: m.score,
+    rank: m.rank,
+  }));
+
+  await ModelCatalogSnapshot.findOneAndUpdate(
+    { _id: "arena" },
+    { data: arenaDocs, fetchedAt: new Date(), itemCount: arenaDocs.length },
+    { upsert: true },
+  );
+
+  logger.info("Persisted arena snapshot", { scores: arenaDocs.length });
+  return { scores: arenaDocs.length };
+}
+
+// ---------------------------------------------------------------------------
+// Refresh all snapshots (parallel, best-effort per source)
+// ---------------------------------------------------------------------------
+
+export async function refreshAllSnapshots(): Promise<{
+  gateway: { models: number } | { skipped: true; reason: string };
+  arena: { scores: number } | { skipped: true; reason: string };
+}> {
+  const [gateway, arena] = await Promise.all([
+    refreshGatewaySnapshot().catch(err => {
+      logger.error("Gateway snapshot refresh failed", {
+        error: String(err),
+      });
+      return { skipped: true as const, reason: String(err) };
+    }),
+    refreshArenaSnapshot().catch(err => {
+      logger.warn("Arena snapshot refresh failed", { error: String(err) });
+      return { skipped: true as const, reason: String(err) };
+    }),
+  ]);
+
+  return { gateway, arena };
+}
+
+// ---------------------------------------------------------------------------
+// Pure merge: gateway + arena + pricing → CatalogModel[]
+// ---------------------------------------------------------------------------
+
+function mergeCatalog(
+  gateway: GatewayModelNormalized[],
+  arena: ArenaEntry[],
+  pricing: PricingEntry[],
+): { models: CatalogModel[]; freeTierIds: Set<string> } {
+  // Build arena score lookup
+  const arenaScores = new Map<string, number>();
+  for (const a of arena) {
+    for (const key of normalizeArenaName(a.model)) {
+      arenaScores.set(key, a.score);
+    }
+  }
+
+  // Build pricing lookup
+  const pricingMap = new Map<string, { input: number; output: number }>();
+  for (const p of pricing) {
+    pricingMap.set(p.modelId, { input: p.input, output: p.output });
+  }
+
+  const freeTierIds = new Set<string>();
+  const models: CatalogModel[] = gateway.map(gm => {
+    const supportsThinking = gm.tags.includes("reasoning");
+    const p = pricingMap.get(gm.id);
+    const blendedCostPerM = p ? (p.input + p.output) / 2 : null;
+    const arenaScore = lookupArenaScore(gm.id, arenaScores);
+
+    const isFree =
+      blendedCostPerM !== null && blendedCostPerM <= FREE_TIER_MAX_COST_PER_M;
+    if (isFree) freeTierIds.add(gm.id);
+
+    return {
+      id: gm.id,
+      provider: gm.provider,
+      name: gm.name,
+      description: gm.description,
+      contextWindow: gm.contextWindow,
+      tags: gm.tags,
+      supportsThinking,
+      thinkingBudgetTokens: supportsThinking ? 10_000 : 0,
+      blendedCostPerM,
+      arenaScore,
+      tier: isFree ? ("free" as const) : ("pro" as const),
+    };
   });
 
   return { models, freeTierIds };
 }
 
-function toCatalogModel(
-  gm: GatewayModelInfo,
-  arenaScores: Map<string, number>,
-  pricingMap: Map<string, GatewayModelPricing>,
-): CatalogModel {
-  const supportsThinking = gm.tags.includes("reasoning");
-  const pricing = pricingMap.get(gm.id);
-  const blendedCostPerM = pricing ? (pricing.input + pricing.output) / 2 : null;
+// ---------------------------------------------------------------------------
+// ensureCatalog: in-memory → MongoDB → merge
+// ---------------------------------------------------------------------------
 
-  const arenaScore = lookupArenaScore(gm.id, arenaScores);
+async function loadFromDb(): Promise<{
+  models: CatalogModel[];
+  freeTierIds: Set<string>;
+} | null> {
+  const docs = await ModelCatalogSnapshot.find({}).lean();
+  if (docs.length === 0) return null;
 
-  return {
-    id: gm.id,
-    provider: gm.provider,
-    name: gm.name,
-    description: gm.description,
-    contextWindow: gm.contextWindow,
-    tags: gm.tags,
-    supportsThinking,
-    thinkingBudgetTokens: supportsThinking ? 10_000 : 0,
-    blendedCostPerM,
-    arenaScore,
-    tier: "pro", // overwritten by selectFreeTier
-  };
+  const gatewayDoc = docs.find(d => d._id === "gateway");
+  const arenaDoc = docs.find(d => d._id === "arena");
+  const pricingDoc = docs.find(d => d._id === "pricing");
+
+  if (!gatewayDoc || !gatewayDoc.data || gatewayDoc.data.length === 0) {
+    return null;
+  }
+
+  const gateway = gatewayDoc.data as unknown as GatewayModelNormalized[];
+  const arena = (arenaDoc?.data ?? []) as unknown as ArenaEntry[];
+  const pricing = (pricingDoc?.data ?? []) as unknown as PricingEntry[];
+
+  return mergeCatalog(gateway, arena, pricing);
 }
 
-// ---------------------------------------------------------------------------
-// Cache refresh
-// ---------------------------------------------------------------------------
-
 async function ensureCatalog(): Promise<void> {
-  if (cachedCatalog && Date.now() - cacheTimestamp < CACHE_TTL_MS) return;
-
-  if (refreshInFlight) {
-    await refreshInFlight;
+  if (
+    cachedCatalog &&
+    cachedCatalog.length > 0 &&
+    Date.now() - cacheTimestamp < MEM_CACHE_TTL_MS
+  ) {
     return;
   }
 
-  refreshInFlight = buildCatalog()
-    .then(({ models, freeTierIds }) => {
-      cachedCatalog = models;
-      cachedFreeTierIds = freeTierIds;
+  try {
+    const result = await loadFromDb();
+    if (result && result.models.length > 0) {
+      cachedCatalog = result.models;
+      cachedFreeTierIds = result.freeTierIds;
       cacheTimestamp = Date.now();
-      refreshInFlight = null;
-    })
-    .catch(err => {
-      refreshInFlight = null;
-      logger.error("Failed to build model catalog", { error: String(err) });
-      if (!cachedCatalog) {
-        cachedCatalog = [];
-        cachedFreeTierIds = new Set(FALLBACK_FREE);
-        cacheTimestamp = Date.now();
-      }
-    });
+      return;
+    }
+  } catch (err) {
+    logger.warn("Failed to load catalog from DB", { error: String(err) });
+  }
 
-  await refreshInFlight;
+  // DB empty or unavailable — serve stale in-memory data if we have any
+  if (cachedCatalog && cachedCatalog.length > 0) return;
+
+  // No data anywhere
+  logger.warn(
+    "Model catalog empty — waiting for Inngest cron or startup to populate",
+  );
+  cachedCatalog = [];
+  cachedFreeTierIds = new Set(FALLBACK_FREE);
+  cacheTimestamp = 0; // don't cache the empty result for long
 }
 
 // ---------------------------------------------------------------------------
-// Public API
+// Startup warm
+// ---------------------------------------------------------------------------
+
+export async function warmCatalog(): Promise<void> {
+  cachedCatalog = null;
+  cachedFreeTierIds = null;
+  cacheTimestamp = 0;
+
+  // Try loading from DB first (fast, no external API calls)
+  try {
+    const result = await loadFromDb();
+    if (result && result.models.length > 0) {
+      cachedCatalog = result.models;
+      cachedFreeTierIds = result.freeTierIds;
+      cacheTimestamp = Date.now();
+      logger.info("Loaded model catalog from DB", {
+        models: result.models.length,
+        freeModels: result.freeTierIds.size,
+      });
+      return;
+    }
+  } catch (err) {
+    logger.warn("Failed to load catalog from DB on startup", {
+      error: String(err),
+    });
+  }
+
+  // DB empty (first deploy) — fetch from upstream and persist
+  logger.info("DB catalog empty, fetching from upstream APIs");
+  const { gateway } = await refreshAllSnapshots();
+
+  if ("models" in gateway) {
+    const result = await loadFromDb();
+    if (result && result.models.length > 0) {
+      cachedCatalog = result.models;
+      cachedFreeTierIds = result.freeTierIds;
+      cacheTimestamp = Date.now();
+      logger.info("Populated model catalog from upstream", {
+        models: result.models.length,
+      });
+      return;
+    }
+  }
+
+  // Fallback: empty catalog
+  cachedCatalog = [];
+  cachedFreeTierIds = new Set(FALLBACK_FREE);
+  cacheTimestamp = 0;
+}
+
+// ---------------------------------------------------------------------------
+// Public API (unchanged signatures — callers don't know the source switched)
 // ---------------------------------------------------------------------------
 
 export async function getCatalogModels(): Promise<CatalogModel[]> {
@@ -363,10 +550,6 @@ export async function isFreeTierModel(id: string): Promise<boolean> {
   return cachedFreeTierIds?.has(id) ?? FALLBACK_FREE.includes(id);
 }
 
-/**
- * Pick the best default model by ELO, preferring trusted providers.
- * Used when a user hasn't saved a model preference in their settings.
- */
 function pickBestByElo(
   models: CatalogModel[],
   preferProviders = true,
@@ -379,26 +562,18 @@ function pickBestByElo(
     const preferred = sorted.find(
       m => DEFAULT_PREFERRED_PROVIDERS.has(m.provider) && m.arenaScore !== null,
     );
-    if (preferred) {
-      return preferred.id;
-    }
+    if (preferred) return preferred.id;
   }
 
   return sorted[0]?.id ?? null;
 }
 
-/**
- * Default model for Pro users (best model overall by ELO from trusted providers).
- */
 export async function getDefaultChatModelId(): Promise<string> {
   await ensureCatalog();
   const all = cachedCatalog ?? [];
   return pickBestByElo(all) ?? FALLBACK_FREE[0];
 }
 
-/**
- * Default model for Free users (best free-tier model by ELO from trusted providers).
- */
 export async function getDefaultFreeChatModelId(): Promise<string> {
   await ensureCatalog();
   const freeModels = (cachedCatalog ?? []).filter(m => m.tier === "free");
@@ -425,14 +600,4 @@ export async function getUtilityModelIds(count = 3): Promise<string[]> {
     (a, b) => (a.blendedCostPerM ?? Infinity) - (b.blendedCostPerM ?? Infinity),
   );
   return candidates.slice(0, count).map(m => m.id);
-}
-
-/**
- * Warm the catalog on startup and schedule hourly refresh.
- */
-export async function warmCatalog(): Promise<void> {
-  cachedCatalog = null;
-  cachedFreeTierIds = null;
-  cacheTimestamp = 0;
-  await ensureCatalog();
 }

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -1273,6 +1273,7 @@ const Chat: React.FC<ChatProps> = ({
     sendMessage,
     status,
     error,
+    clearError,
     stop,
     setMessages,
     addToolOutput,
@@ -1557,6 +1558,36 @@ const Chat: React.FC<ChatProps> = ({
 
     onError: err => {
       console.error("[Chat] Error:", err);
+      // When the stream disconnects (e.g. 524 timeout), tool calls may be
+      // stuck in "input-available" state. The AI SDK blocks sendMessage until
+      // all tool calls are settled. Patch them to "error" so the chat remains
+      // usable.
+      setMessages(prev =>
+        prev.map(msg => {
+          if (msg.role !== "assistant") return msg;
+          const hasPending = msg.parts?.some(p => {
+            const pt = p.type as string;
+            if (!pt?.startsWith("tool-") && pt !== "dynamic-tool") return false;
+            const s = (p as Record<string, unknown>).state as string;
+            return s !== "output-available" && s !== "error";
+          });
+          if (!hasPending) return msg;
+          return {
+            ...msg,
+            parts: msg.parts.map(p => {
+              const pt = p.type as string;
+              if (!pt?.startsWith("tool-") && pt !== "dynamic-tool") return p;
+              const s = (p as Record<string, unknown>).state as string;
+              if (s === "output-available" || s === "error") return p;
+              return {
+                ...p,
+                state: "error" as const,
+                output: { success: false, error: "Stream disconnected" },
+              };
+            }) as any,
+          };
+        }),
+      );
     },
     onFinish: () => {
       if (!isExistingChatRef.current) {
@@ -1709,11 +1740,21 @@ const Chat: React.FC<ChatProps> = ({
                       p.type?.startsWith("tool-") ||
                       p.type === "dynamic-tool"
                     ) {
+                      const toolState = p.state as string | undefined;
+                      const isComplete =
+                        toolState === "output-available" ||
+                        toolState === "error";
                       return {
                         ...p,
-                        state: p.state || "output-available",
+                        state: isComplete ? toolState : "error",
                         input: p.input ?? {},
-                        output: p.output ?? null,
+                        output: isComplete
+                          ? (p.output ?? null)
+                          : (p.output ?? {
+                              success: false,
+                              error:
+                                "Interrupted — stream disconnected before tool completed",
+                            }),
                       };
                     }
                     // Unknown part type - pass through as-is
@@ -2088,7 +2129,18 @@ const Chat: React.FC<ChatProps> = ({
               // not JSON, fall through to generic
             }
             return (
-              <Alert severity="error" sx={{ fontSize: "0.875rem" }}>
+              <Alert
+                severity="error"
+                onClose={clearError}
+                sx={{
+                  fontSize: "0.875rem",
+                  maxHeight: 200,
+                  overflowY: "auto",
+                  "& .MuiAlert-message": {
+                    overflow: "auto",
+                  },
+                }}
+              >
                 {error.message}
               </Alert>
             );

--- a/app/src/store/settingsStore.ts
+++ b/app/src/store/settingsStore.ts
@@ -15,6 +15,10 @@ import type {
 } from "../lib/api-types";
 
 let modelsInFlight: Promise<void> | null = null;
+let modelsRetryCount = 0;
+const MAX_MODELS_RETRIES = 3;
+const MODELS_RETRY_DELAYS = [2_000, 5_000, 10_000];
+let modelsRetryTimer: ReturnType<typeof setTimeout> | null = null;
 let gatewayModelsInFlight: Promise<void> | null = null;
 
 interface SettingsState {
@@ -83,14 +87,35 @@ export const useSettingsStore = create<SettingsState>()(
             set({ models });
 
             if (models.length > 0) {
+              modelsRetryCount = 0;
               const current = get().selectedModelId;
               const isAvailable = models.some(model => model.id === current);
               if (!isAvailable) {
                 set({ selectedModelId: models[0].id });
               }
+            } else if (modelsRetryCount < MAX_MODELS_RETRIES) {
+              const delay = MODELS_RETRY_DELAYS[modelsRetryCount] ?? 10_000;
+              modelsRetryCount++;
+              if (modelsRetryTimer) clearTimeout(modelsRetryTimer);
+              modelsRetryTimer = setTimeout(() => {
+                modelsRetryTimer = null;
+                modelsInFlight = null;
+                get().fetchModels();
+              }, delay);
             }
           } catch (error) {
-            set({ modelsError: "Failed to load models" });
+            if (modelsRetryCount < MAX_MODELS_RETRIES) {
+              const delay = MODELS_RETRY_DELAYS[modelsRetryCount] ?? 10_000;
+              modelsRetryCount++;
+              if (modelsRetryTimer) clearTimeout(modelsRetryTimer);
+              modelsRetryTimer = setTimeout(() => {
+                modelsRetryTimer = null;
+                modelsInFlight = null;
+                get().fetchModels();
+              }, delay);
+            } else {
+              set({ modelsError: "Failed to load models" });
+            }
           } finally {
             set({ modelsLoading: false });
             modelsInFlight = null;


### PR DESCRIPTION
## Summary

- **Persist model catalog in MongoDB**: Raw responses from Vercel AI Gateway and arena.ai are Zod-validated and stored as separate documents in a `ModelCatalogSnapshot` collection (3 docs: `gateway`, `arena`, `pricing`). The `/api/agent/models` endpoint reads from the DB instead of hitting external APIs on every request.
- **Inngest hourly cron** (`model-catalog-refresh`): Refreshes each upstream source independently so one failing doesn't block the other. Zod `.min()` sanity floors prevent bad data from overwriting last-known-good snapshots.
- **Fix intermittent model loading failures**: Backend try/catch in `/models` route, faster retry on empty catalog, frontend exponential backoff retry (2s/5s/10s), and Chat.tsx fix for stuck tool calls on stream disconnect.

### Architecture

```
Write path (Inngest cron / startup):
  fetch upstream → HTTP status check → JSON parse → Zod validate → upsert DB

Read path (every request):
  5-min in-memory cache → MongoDB find({}) → mergeCatalog() → respond
```

### Failure resilience

| Scenario | Behavior |
|---|---|
| Arena permanently dead | Gateway + pricing still refresh. Users see models without ELO scores |
| Gateway returns 200 with < 10 models | Zod `.min(10)` rejects, last-known-good data preserved |
| Both APIs down for hours | DB serves last-known-good data indefinitely |
| Server cold start | Loads from DB (~5ms), no external API calls |
| First deploy (empty DB) | Startup fetches from upstream and populates DB |

## Test plan

- [ ] Deploy to preview — verify `/api/agent/models` returns models from DB
- [ ] Check Inngest dashboard for `system/model-catalog-refresh` cron registered
- [ ] Verify models load on first app open without hitting external APIs (check API logs)
- [ ] Simulate arena.ai down — confirm gateway models still load, arena scores stale
- [ ] Confirm Chat.tsx stream disconnect error handling works (no stuck tool calls)
- [ ] Verify frontend retry logic on empty models response

Made with [Cursor](https://cursor.com)