### PR TITLE
fix: backfill column shows "In progress" after backfill is done

### DIFF
--- a/app/src/components/BackfillPanel.tsx
+++ b/app/src/components/BackfillPanel.tsx
@@ -126,8 +126,8 @@ function entityBackfillChip(e: {
   label: string;
   color: "success" | "info" | "default";
 } {
-  if (e.backlogCount > 0) return { label: "In progress", color: "info" };
   if (e.backfillDone) return { label: "Done", color: "success" };
+  if (e.backlogCount > 0) return { label: "In progress", color: "info" };
   return { label: "Not started", color: "default" };
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In `BackfillPanel.tsx`, the `entityBackfillChip` function checks `backlogCount > 0` **before** `backfillDone`. When a backfill finishes ingestion but materialization is still draining pending CDC events, the Backfill column incorrectly shows an "In progress" badge instead of "Done".

## Fix

Swap the two condition checks so `backfillDone` takes priority over `backlogCount`:

```diff
- if (e.backlogCount > 0) return { label: "In progress", color: "info" };
- if (e.backfillDone) return { label: "Done", color: "success" };
+ if (e.backfillDone) return { label: "Done", color: "success" };
+ if (e.backlogCount > 0) return { label: "In progress", color: "info" };
```

The remaining materialization backlog is already visible in the **Stream** column (which shows "Syncing" when there's a backlog), so no information is lost.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21b4c91b-6fc5-4e5b-9289-b5bfb32dfa85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21b4c91b-6fc5-4e5b-9289-b5bfb32dfa85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

