### PR TITLE
docs: document BigQuery schema evolution and sync-cdc endpoints

### DIFF
--- a/docs/src/content/docs/api-reference.md
+++ b/docs/src/content/docs/api-reference.md
@@ -63,10 +63,36 @@ See [Console](/console/) for full API documentation with examples.
 
 ## Flows
 
-| Method | Endpoint                         | Description           |
-| ------ | -------------------------------- | --------------------- |
-| `POST` | `/api/workspaces/:wid/flows`     | Create/trigger a flow |
-| `GET`  | `/api/workspaces/:wid/flows/:id` | Get flow status       |
+| Method | Endpoint                                                           | Description                                                  |
+| ------ | ------------------------------------------------------------------ | ------------------------------------------------------------ |
+| `POST` | `/api/workspaces/:wid/flows`                                       | Create/trigger a flow                                        |
+| `GET`  | `/api/workspaces/:wid/flows/:id`                                   | Get flow status                                              |
+| `GET`  | `/api/workspaces/:wid/flows/:id/sync-cdc/status`                   | Get CDC stream status                                        |
+| `GET`  | `/api/workspaces/:wid/flows/:id/sync-cdc/schema-health`            | Compare live destination column types to the connector schema (BigQuery; detects drift) |
+| `GET`  | `/api/workspaces/:wid/flows/:id/sync-cdc/destination-counts`       | Row counts per entity in the destination                     |
+
+### Schema Health Response
+
+```json
+{
+  "success": true,
+  "data": {
+    "hasDrift": true,
+    "entities": [
+      {
+        "entity": "customers",
+        "hasDrift": true,
+        "columns": [
+          { "column": "created_at", "liveType": "STRING", "expectedType": "TIMESTAMP", "status": "drift" },
+          { "column": "id",         "liveType": "STRING", "expectedType": "STRING",    "status": "match" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Accepts an optional `?entity=<name>` query parameter to scope the check to a single entity. Drift is auto-corrected on the next CDC merge — see [Schema Evolution](/data-sync/#schema-evolution-bigquery).
 
 ## Chat API (AI Agent)
 

--- a/docs/src/content/docs/data-sync.md
+++ b/docs/src/content/docs/data-sync.md
@@ -31,6 +31,22 @@ In addition to scheduled batch syncing, Mako supports experimental Change Data C
 - **Backfills** — historical data backfills run robustly within 1Gi Cloud Run memory limits, safely handling bulk flushes by cycling DuckDB instances
 - **BigQuery Staging** — streams events into region-aligned BigQuery staging tables (safely preserved during recovery)
 
+### Schema Evolution (BigQuery)
+
+When a connector's expected column types drift from the live BigQuery table (for example, a column created as `STRING` in a legacy run that should now be `TIMESTAMP`), Mako auto-corrects the drift before merging CDC events. This prevents merge failures from type mismatches.
+
+For each drifted column, Mako runs a safe four-step swap:
+
+1. `ADD COLUMN` a temporary column with the expected type
+2. `UPDATE` the temp column with `SAFE_CAST` of the existing values
+3. `RENAME` the original column to a `_bak_*` backup and the temp into its place (atomic)
+4. `DROP` the backup column
+
+Drift detection and correction is best-effort: if any step fails for a column, the merge falls back to a `SAFE_CAST` guard using the existing live type so the sync still completes.
+
+The console surfaces drift in the **Backfill Panel** with an auto-correction notice per affected entity. Under the hood this calls the `sync-cdc/schema-health` endpoint (see [API Reference](/api-reference/#flows)) which compares each live column's `data_type` from `INFORMATION_SCHEMA.COLUMNS` against the connector schema.
+
+
 ## Job Queue
 
 Flows run on [Inngest](https://www.inngest.com/), a job queue that handles:


### PR DESCRIPTION
## What

Documents changes shipped in #348.

### `data-sync.md`
New **Schema Evolution (BigQuery)** section covering:
- When drift correction fires (connector-expected type vs. live BigQuery column type)
- The four-step safe swap: `ADD COLUMN` temp → `UPDATE` with `SAFE_CAST` → atomic `RENAME` (orig → `_bak_*`, temp → orig) → `DROP` backup
- Fallback behavior (`SAFE_CAST` guard if evolution fails on a column)
- Where drift surfaces in the console (Backfill Panel per-entity warning)

### `api-reference.md`
Expanded the **Flows** table to include the CDC sub-routes that were not documented:
- `GET /sync-cdc/status`
- `GET /sync-cdc/schema-health` (new in #348) + sample JSON response
- `GET /sync-cdc/destination-counts`

## Why

PR #348 shipped a user-visible drift indicator and a public-shape API endpoint with zero docs. The behavior is non-obvious (silent auto-correction of live tables) and worth surfacing so users understand what's happening under the hood.

## Scope

Docs-only. No code or config changes.