### PR TITLE
fix(agent): drop empty assistant messages that crash the chat

### DIFF
--- a/api/src/services/agent-thread.service.ts
+++ b/api/src/services/agent-thread.service.ts
@@ -636,10 +636,29 @@ export const saveChat = async (
   usage?: ChatUsageData,
 ): Promise<typeof Chat.prototype | null> => {
   const now = new Date();
-  const storedMessages = messages.map(convertUIMessageToStoredFormat);
+
+  // Drop assistant messages that arrived with no parts. This happens when a
+  // stream is aborted before any delta is emitted: `toUIMessageStreamResponse`
+  // has already minted an assistant message id, so `onFinish` hands us a
+  // zero-parts message. Persisting it would poison the chat — on the next
+  // turn `convertToModelMessages` would reject the history with
+  // "Invalid prompt: The messages do not match the ModelMessage[] schema."
+  const persistableMessages = messages.filter(
+    m => m.role !== "assistant" || (m.parts && m.parts.length > 0),
+  );
+  if (persistableMessages.length !== messages.length) {
+    logger.warn("Dropping empty assistant messages before persistence", {
+      chatId,
+      dropped: messages.length - persistableMessages.length,
+    });
+  }
+
+  const storedMessages = persistableMessages.map(
+    convertUIMessageToStoredFormat,
+  );
 
   // Count assistant messages to determine the message index for usage history
-  const assistantMessageCount = messages.filter(
+  const assistantMessageCount = persistableMessages.filter(
     m => m.role === "assistant",
   ).length;
 

--- a/api/src/utils/message-sanitizer.ts
+++ b/api/src/utils/message-sanitizer.ts
@@ -24,9 +24,15 @@ export function sanitizeMessagesForModel(messages: UIMessage[]): UIMessage[] {
       return msg;
     }
 
-    // If no parts, nothing to sanitize
+    // Empty assistant messages (e.g. from interrupted streams persisted with
+    // no content) must not be forwarded to `convertToModelMessages`, which
+    // throws "The messages do not match the ModelMessage[] schema." Replace
+    // with the same placeholder we use for tool-only messages below.
     if (!msg.parts || msg.parts.length === 0) {
-      return msg;
+      return {
+        ...msg,
+        parts: [{ type: "text" as const, text: "[Response interrupted]" }],
+      };
     }
 
     const sanitizedParts = msg.parts.filter(part => {


### PR DESCRIPTION
## Summary

Fixes the chat crash `Invalid prompt: The messages do not match the ModelMessage[] schema.`

### Root cause
`toUIMessageStreamResponse` mints a new assistant message id up-front via `generateMessageId`. If the stream is aborted before any reasoning/text delta is emitted (user clicks Stop fast, connection drops, early error), `onFinish` still fires and hands `saveChat` an assistant message with `parts: []`. That gets persisted to Mongo. On the next turn, loading the chat and calling `convertToModelMessages` on the history rejects the empty assistant message and the whole chat breaks.

### Fix (defense in depth)
- **Write path** (`agent-thread.service.ts`): filter assistant messages with empty `parts` out of `saveChat` so they never reach the DB. Partial assistant turns (reasoning + truncated text) still have at least one part and are preserved. Also corrects `assistantMessageCount` to use the filtered list for `usage.history.messageIndex`.
- **Read path** (`message-sanitizer.ts`): for histories already poisoned by prior deployments, substitute `[Response interrupted]` in place of empty assistant parts before `convertToModelMessages`, mirroring the existing fallback used when tool-part sanitization drains a message to zero.

### Self-healing
Because `originalMessages` flows from the client into `onFinish.allMessages`, the very next successful turn on a polluted chat will save without the empty bubbles and Mongo is clean. No backfill migration needed.

## Test plan
- [ ] Open the chat that was crashing, send a new message — should no longer throw the schema error and the three empty assistant rows should be dropped from Mongo on the next `saveChat`.
- [ ] Start a new chat, click Stop immediately after hitting send (before any reasoning chunk) — confirm no empty assistant row is persisted and the follow-up turn succeeds.
- [ ] Start a chat, let it stream a few tokens, then Stop — confirm the partial assistant message (with reasoning/text parts) is still persisted and displayed.
- [ ] Confirm `usage.history.messageIndex` still aligns with the saved assistant message index when an empty row was dropped.


Made with [Cursor](https://cursor.com)