### PR TITLE
fix(cdc-bq): cap cdcMaterializeFunction concurrency to prevent BigQuery slot saturation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,10 @@ INNGEST_SIGNING_KEY=your-inngest-signing-key
 # INNGEST_ENV=pr-123
 # INNGEST_SERVE_ORIGIN=http://localhost:8080
 # DISABLE_SCHEDULED_SYNC=false
+# Max in-flight non-CDC webhook SQL processors per flow (default 5)
+# WEBHOOK_SQL_PROCESS_CONCURRENCY=5
+# Max in-flight CDC materializations globally (caps BigQuery slot pressure, default 8)
+# CDC_MATERIALIZE_CONCURRENCY=8
 
 # Vercel AI Gateway (REQUIRED for all AI features)
 # Generate a key at: Vercel Dashboard > AI Gateway settings

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -905,6 +905,7 @@ jobs:
             --set-env-vars OPENAI_API_KEY=${OPENAI_API_KEY} \
             --set-env-vars WEBHOOK_SQL_PROCESS_CONCURRENCY=3 \
             --set-env-vars WEBHOOK_CDC_PROCESS_CONCURRENCY=10 \
+            --set-env-vars CDC_MATERIALIZE_CONCURRENCY=8 \
             --set-env-vars SYNC_BULK_FLUSH_BATCH_SIZE=2000 \
             --set-env-vars SYNC_BULK_MONGO_TO_PARQUET_CHUNK=100 \
             --set-env-vars SYNC_PARQUET_DUCKDB_MEMORY_LIMIT_MB=512 \

--- a/api/src/inngest/functions/webhook-flow.ts
+++ b/api/src/inngest/functions/webhook-flow.ts
@@ -26,6 +26,11 @@ const WEBHOOK_SQL_PROCESS_CONCURRENCY = Math.max(
   1,
 );
 
+const CDC_MATERIALIZE_CONCURRENCY = Math.max(
+  parseInt(process.env.CDC_MATERIALIZE_CONCURRENCY || "8", 10) || 8,
+  1,
+);
+
 async function runWebhookEventProcess({
   event,
   step,
@@ -892,6 +897,17 @@ export const cdcMaterializeFunction = inngest.createFunction(
       finish: "30m",
     },
     cancelOn: [{ event: "cdc/materialize.cancel", match: "data.flowId" }],
+    concurrency: [
+      {
+        scope: "fn",
+        limit: CDC_MATERIALIZE_CONCURRENCY,
+      },
+      {
+        scope: "fn",
+        key: "event.data.flowId + ':' + event.data.entity",
+        limit: 1,
+      },
+    ],
     singleton: {
       key: "event.data.flowId + ':' + event.data.entity",
       mode: "skip",


### PR DESCRIPTION
## Summary

- Adds a function-scoped `concurrency` cap on `cdcMaterializeFunction` (default **8**, configurable via `CDC_MATERIALIZE_CONCURRENCY`) so the scheduler's fan-out can no longer saturate the BigQuery slot reservation.
- Keeps the existing per-`(flowId, entity)` singleton intact (modelled as the second entry in the `concurrency` array) so duplicate work for the same entity still can't overlap.
- Wires `CDC_MATERIALIZE_CONCURRENCY=8` into `.github/workflows/deploy-app.yml` (next to the existing `WEBHOOK_SQL_PROCESS_CONCURRENCY`) and documents it in `.env.example`.

## Why

The `mako-etl` service account (the BigQuery destination connection used by CDC) was pinning the `impressions-stats` 100-slot reservation in `europe-west6`: ~2,274 BQ jobs/hour, avg 9s, peaks up to 200s. Queue wait times for interactive + `hasura-crm` queries were hitting 35-66s.

Root cause: `cdcMaterializeFunction` had no global concurrency — only `singleton` per `(flowId, entity)`. When `cdcMaterializeSchedulerFunction` (cron `*/5`) found N stale entities it emitted N events in parallel. Each materialization fires ~6-10 BQ jobs (INFORMATION_SCHEMA, optional per-column `ALTER TABLE`, pre/post `COUNT(*)`, `MERGE`, `DROP`, Parquet `load`), so 30 stale entities = ~200+ concurrent BQ jobs fighting for 100 slots.

With a cap of 8 in-flight materializations and ~10 BQ jobs each, peak usage is ~80 concurrent BQ jobs — well under the 100-slot budget, leaving headroom for `hasura-crm` and interactive queries.

### Why `concurrency` and not `throttle`

Query duration is bimodal (9s avg, 200s max). `throttle` caps dispatch rate; `concurrency` caps in-flight work, which is what slot pressure actually measures.

## Test plan

- [ ] Deploy to production.
- [ ] Watch the Inngest `cdc-materialize` function — "In Progress" should cap at 8, "Queued" should stay bounded and drain within a `*/5` scheduler cycle.
- [ ] Watch BigQuery slot usage for `mako-etl` in `europe-west6` — should drop from pinned-at-100 to visible headroom.
- [ ] Confirm `hasura-crm` and interactive query queue wait times drop back to single-digit seconds.
- [ ] If queue grows unboundedly, bump `CDC_MATERIALIZE_CONCURRENCY` to 12. If slots still spike, drop to 6.

## Rollback

Set `CDC_MATERIALIZE_CONCURRENCY` to a very high number (e.g. 1000) in Cloud Run env to effectively disable the cap, or revert this PR.

Made with [Cursor](https://cursor.com)