### PR TITLE
docs(inngest): document webhook flow & CDC concurrency env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,10 @@ INNGEST_SIGNING_KEY=your-inngest-signing-key
 # WEBHOOK_SQL_PROCESS_CONCURRENCY=5
 # Max in-flight CDC materializations globally (caps BigQuery slot pressure, default 8)
 # CDC_MATERIALIZE_CONCURRENCY=8
+# Max in-flight CDC materializations per flow (prevents one flow from starving others, default 3)
+# CDC_MATERIALIZE_CONCURRENCY_PER_FLOW=3
+# Max wait for a single BigQuery MERGE job in CDC materialization, in ms (default 900000 = 15min)
+# BIGQUERY_MERGE_MAX_WAIT_MS=900000
 
 # Vercel AI Gateway (REQUIRED for all AI features)
 # Generate a key at: Vercel Dashboard > AI Gateway settings

--- a/INNGEST_DEV_CONFIG.md
+++ b/INNGEST_DEV_CONFIG.md
@@ -131,10 +131,13 @@ conservative values.
 |---|---|---|---|
 | `WEBHOOK_SQL_PROCESS_CONCURRENCY` | `5` | Non-CDC webhook SQL processors | Max in-flight `webhookSqlProcess` runs per flow. Higher values speed up catch-up after a backlog; lower values reduce pressure on the destination warehouse. |
 | `CDC_MATERIALIZE_CONCURRENCY` | `8` | `cdcMaterializeFunction` (global) | Max CDC materializations running in parallel across all flows/entities. Each run fires ~6-10 BigQuery jobs (INFORMATION_SCHEMA, ALTERs, COUNTs, MERGE, DROP, Parquet load), so the global cap exists to prevent slot saturation in the `europe-west6` 100-slot reservation. The per-`(flowId, entity)` singleton is preserved independently. |
+| `CDC_MATERIALIZE_CONCURRENCY_PER_FLOW` | `3` | `cdcMaterializeFunction` (per flow) | Max CDC materializations running in parallel **within a single flow**. Prevents one large flow (e.g. a full Close backfill) from monopolizing all global materialize slots while smaller flows queue. Stacks with the global `CDC_MATERIALIZE_CONCURRENCY` cap. |
+| `BIGQUERY_MERGE_MAX_WAIT_MS` | `900000` (15min) | `cdcMaterializeFunction` BigQuery MERGE job wait | Max wall time Mako waits for a single MERGE job before giving up and failing the step. Lowered from the previous 50min default so stuck MERGEs surface faster; raise only if you see spurious timeouts on legitimately slow large-partition merges. |
 
 Raise `CDC_MATERIALIZE_CONCURRENCY` only if you have headroom in the BigQuery
 slot reservation -- it is the first knob to lower if interactive or hasura-crm
-queries start queueing during CDC catch-up.
+queries start queueing during CDC catch-up. If a single flow is starving others,
+lower `CDC_MATERIALIZE_CONCURRENCY_PER_FLOW` instead of the global cap.
 
 ## Environment summary
 

--- a/INNGEST_DEV_CONFIG.md
+++ b/INNGEST_DEV_CONFIG.md
@@ -119,6 +119,23 @@ This means entities with unusually large payloads (long meeting notes, embedded
 documents) will self-heal without operator intervention, while normal entities
 continue at full batch throughput.
 
+## Webhook flow concurrency caps
+
+The webhook-driven ingestion pipeline exposes two Inngest function-level
+concurrency caps to protect shared infrastructure (most importantly the
+BigQuery slot reservation) from being starved when the scheduler fans out many
+entities at once. Both are tuned via environment variables and default to
+conservative values.
+
+| Variable | Default | Applies to | Description |
+|---|---|---|---|
+| `WEBHOOK_SQL_PROCESS_CONCURRENCY` | `5` | Non-CDC webhook SQL processors | Max in-flight `webhookSqlProcess` runs per flow. Higher values speed up catch-up after a backlog; lower values reduce pressure on the destination warehouse. |
+| `CDC_MATERIALIZE_CONCURRENCY` | `8` | `cdcMaterializeFunction` (global) | Max CDC materializations running in parallel across all flows/entities. Each run fires ~6-10 BigQuery jobs (INFORMATION_SCHEMA, ALTERs, COUNTs, MERGE, DROP, Parquet load), so the global cap exists to prevent slot saturation in the `europe-west6` 100-slot reservation. The per-`(flowId, entity)` singleton is preserved independently. |
+
+Raise `CDC_MATERIALIZE_CONCURRENCY` only if you have headroom in the BigQuery
+slot reservation -- it is the first knob to lower if interactive or hasura-crm
+queries start queueing during CDC catch-up.
+
 ## Environment summary
 
 | Environment    | Artifact Store | Artifact Prefix                         | Inngest Routing           | Schedulers             |


### PR DESCRIPTION
Docs-only. Consolidates all webhook-flow / CDC concurrency knobs into one place.

**Round 1** (follow-up to #359, which introduced `CDC_MATERIALIZE_CONCURRENCY` and uncovered that `WEBHOOK_SQL_PROCESS_CONCURRENCY` from #313 was undocumented):
- `WEBHOOK_SQL_PROCESS_CONCURRENCY` (default 5)
- `CDC_MATERIALIZE_CONCURRENCY` (default 8, global)

**Round 2** (follow-up to #360, which added two more vars that landed only in `.env.example` or nowhere at all):
- `CDC_MATERIALIZE_CONCURRENCY_PER_FLOW` (default 3) — new
- `BIGQUERY_MERGE_MAX_WAIT_MS` (default 900000 / 15min, lowered from 50min) — new

All four now live in the same table in `INNGEST_DEV_CONFIG.md` with scope (per-flow vs global), defaults, and a short tuning note so on-call knows which knob to touch first when interactive BigQuery queries start queueing. `.env.example` also updated for discoverability.

No code changes.