### PR TITLE
feat(app,api): console tabs, URL sync, theme, and AI tool states

### DIFF
--- a/api/src/utils/message-sanitizer.ts
+++ b/api/src/utils/message-sanitizer.ts
@@ -10,12 +10,13 @@ import type { UIMessage } from "ai";
  *
  *   "tool_use ids were found without tool_result blocks immediately after"
  *
- * This function filters out incomplete tool parts before sending to the model.
- * Tool parts are considered complete only if their state is:
- * - "output-available" (successful completion)
- * - "error" (failed with error result)
+ * AI SDK `convertToModelMessages` (v6) emits a tool-result only for tool UI states
+ * `output-available`, `output-error`, and `output-denied`. A legacy `state: "error"`
+ * (used by older client normalization) still produces a tool-call but no tool-result,
+ * which triggers the Anthropic error above. We map `error` → `output-error` first.
  *
- * All other states indicate incomplete tool calls that should be removed.
+ * This function filters out incomplete tool parts before sending to the model.
+ * Complete tool states: output-available, output-error, output-denied.
  */
 export function sanitizeMessagesForModel(messages: UIMessage[]): UIMessage[] {
   return messages.map(msg => {
@@ -35,7 +36,41 @@ export function sanitizeMessagesForModel(messages: UIMessage[]): UIMessage[] {
       };
     }
 
-    const sanitizedParts = msg.parts.filter(part => {
+    const partsNormalized = msg.parts.map(part => {
+      const partType = part.type;
+      if (
+        typeof partType !== "string" ||
+        (!partType.startsWith("tool-") && partType !== "dynamic-tool")
+      ) {
+        return part;
+      }
+
+      const p = part as Record<string, unknown>;
+      if (p.state === "error") {
+        const output = p.output as Record<string, unknown> | null | undefined;
+        const errorText =
+          typeof p.errorText === "string"
+            ? p.errorText
+            : output != null &&
+                typeof output === "object" &&
+                typeof output.error === "string"
+              ? output.error
+              : output != null &&
+                  typeof output === "object" &&
+                  output.error != null
+                ? String(output.error)
+                : "Tool failed";
+        return {
+          ...part,
+          state: "output-error",
+          output: undefined,
+          errorText,
+        } as typeof part;
+      }
+      return part;
+    });
+
+    const sanitizedParts = partsNormalized.filter(part => {
       const partType = part.type;
 
       // Keep all non-tool parts (text, reasoning, etc.)
@@ -51,9 +86,12 @@ export function sanitizeMessagesForModel(messages: UIMessage[]): UIMessage[] {
         | string
         | undefined;
 
-      // Complete states: output-available (success) or error (failed but has result)
-      // Incomplete states: input-streaming, input-available, output-streaming, undefined
-      return state === "output-available" || state === "error";
+      // Match AI SDK UIToolInvocation terminal states (see convert-to-model-messages.ts)
+      return (
+        state === "output-available" ||
+        state === "output-error" ||
+        state === "output-denied"
+      );
     });
 
     // If all parts were filtered out, return a minimal message to preserve structure
@@ -63,11 +101,6 @@ export function sanitizeMessagesForModel(messages: UIMessage[]): UIMessage[] {
         ...msg,
         parts: [{ type: "text" as const, text: "[Response interrupted]" }],
       };
-    }
-
-    // If nothing changed, return original to preserve object identity
-    if (sanitizedParts.length === msg.parts.length) {
-      return msg;
     }
 
     return { ...msg, parts: sanitizedParts };

--- a/app/package.json
+++ b/app/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@ai-sdk/react": "3.0.0-beta.169",
     "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@duckdb/duckdb-wasm": "1.33.1-dev20.0",

--- a/app/src/components/AuthWrapper.tsx
+++ b/app/src/components/AuthWrapper.tsx
@@ -1,7 +1,6 @@
 import { AuthProvider } from "../contexts/auth-context";
 import { WorkspaceProvider } from "../contexts/workspace-context";
 import { OnboardingProvider } from "../contexts/onboarding-context";
-import { ThemeProvider } from "../contexts/ThemeContext";
 import { ProtectedRoute } from "./ProtectedRoute";
 
 interface AuthWrapperProps {
@@ -11,17 +10,18 @@ interface AuthWrapperProps {
 /**
  * Wrapper component that provides authentication and workspace context
  * Also wraps children in protected route
+ *
+ * Theme is provided once in main.tsx — do not nest another ThemeProvider here
+ * or theme toggles will only update part of the tree until a full reload.
  */
 export function AuthWrapper({ children }: AuthWrapperProps) {
   return (
-    <ThemeProvider>
-      <AuthProvider>
-        <OnboardingProvider>
-          <WorkspaceProvider>
-            <ProtectedRoute>{children}</ProtectedRoute>
-          </WorkspaceProvider>
-        </OnboardingProvider>
-      </AuthProvider>
-    </ThemeProvider>
+    <AuthProvider>
+      <OnboardingProvider>
+        <WorkspaceProvider>
+          <ProtectedRoute>{children}</ProtectedRoute>
+        </WorkspaceProvider>
+      </OnboardingProvider>
+    </AuthProvider>
   );
 }

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -100,14 +100,16 @@ const CodeBlock = React.memo(
     children,
     isGenerating,
     scrollable,
+    paletteMode,
   }: {
     language: string;
     children: string;
     isGenerating: boolean;
     scrollable?: boolean;
+    /** Included so memo re-renders when the app theme toggles */
+    paletteMode: "light" | "dark";
   }) => {
-    const muiTheme = useMuiTheme();
-    const effectiveMode = muiTheme.palette.mode;
+    const effectiveMode = paletteMode;
     const syntaxTheme = effectiveMode === "dark" ? tomorrow : prism;
     const [isExpanded, setIsExpanded] = React.useState(false);
     const [isCopied, setIsCopied] = React.useState(false);
@@ -287,9 +289,11 @@ const ReasoningDisplay = React.memo(
   ({
     reasoningText,
     isStreaming,
+    paletteMode: _paletteMode,
   }: {
     reasoningText: string;
     isStreaming: boolean;
+    paletteMode: "light" | "dark";
   }) => {
     const [userToggled, setUserToggled] = React.useState(false);
     const [userOpen, setUserOpen] = React.useState(false);
@@ -438,15 +442,14 @@ const streamingIndicatorDotSx = {
 } as const;
 
 // StreamingIndicator - Shows pulsing dot while content is being streamed
-const StreamingIndicator = React.memo(() => {
+// (not memoized) so it picks up theme updates when the parent palette changes
+function StreamingIndicator() {
   return (
     <Box component="span" sx={streamingIndicatorContainerSx}>
       <Box sx={streamingIndicatorDotSx} />
     </Box>
   );
-});
-
-StreamingIndicator.displayName = "StreamingIndicator";
+}
 
 // ── Memoized message row ─────────────────────────────────────────
 // Prevents completed messages from re-rendering on every streaming chunk.
@@ -522,6 +525,7 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
   isLastMessage,
   isStreaming,
   onToolClick,
+  paletteMode,
 }: ChatMessageRowProps) {
   if (message.role === "user") {
     const fileParts = (message.parts || []).filter(
@@ -608,20 +612,33 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
               partType === "dynamic-tool"
                 ? (part.toolName as string)
                 : partType.split("-").slice(1).join("-");
+            const rawState = part.state as string;
+            const cardState: ToolPartState =
+              rawState === "output-error"
+                ? "error"
+                : (part.state as ToolPartState);
+            const cardOutput =
+              rawState === "output-error"
+                ? {
+                    success: false,
+                    error:
+                      (part.errorText as string | undefined) ?? "Tool failed",
+                  }
+                : part.output;
             return (
               <StreamingToolCard
                 key={partIndex}
                 toolName={toolName}
-                state={part.state as ToolPartState}
+                state={cardState}
                 input={part.input}
-                output={part.output}
+                output={cardOutput}
                 onDetailClick={() =>
                   onToolClick({
                     toolCallId: (part.toolCallId as string) || "",
                     toolName: toolName || "",
                     state: part.state as ToolInvocationInfo["state"],
                     input: part.input,
-                    output: part.output,
+                    output: cardOutput,
                   })
                 }
               />
@@ -638,6 +655,7 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
                 key={`reasoning-${partIndex}`}
                 reasoningText={group.text}
                 isStreaming={isGroupStreaming}
+                paletteMode={paletteMode}
               />
             );
           }
@@ -675,6 +693,7 @@ interface ChatInputAreaProps {
   isLoading: boolean;
   disabled: boolean;
   focusKey: string | number;
+  paletteMode: "light" | "dark";
 }
 
 function readFileAsDataUrl(file: File): Promise<string> {
@@ -687,7 +706,14 @@ function readFileAsDataUrl(file: File): Promise<string> {
 }
 
 const ChatInputArea = React.memo(
-  ({ onSubmit, onStop, isLoading, disabled, focusKey }: ChatInputAreaProps) => {
+  ({
+    onSubmit,
+    onStop,
+    isLoading,
+    disabled,
+    focusKey,
+    paletteMode: _paletteMode,
+  }: ChatInputAreaProps) => {
     const [input, setInput] = useState("");
     const [images, setImages] = useState<ImageAttachment[]>([]);
     const [isPreparingSubmission, setIsPreparingSubmission] = useState(false);
@@ -1077,6 +1103,7 @@ const Chat: React.FC<ChatProps> = ({
   onChartSpecChangeRef,
   resultsContextRef,
 }) => {
+  const paletteMode = useMuiTheme().palette.mode;
   const { currentWorkspace } = useWorkspace();
   const selectedModelId = useSettingsStore(s => s.selectedModelId);
   const activeTabId = useConsoleStore(state => state.activeTabId);
@@ -1736,25 +1763,52 @@ const Chat: React.FC<ChatProps> = ({
                       };
                     }
                     // Tool parts: ensure state is set for UI rendering
+                    // AI SDK v6 uses output-error (not "error") so convertToModelMessages
+                    // emits a matching tool-result for Anthropic.
                     if (
                       p.type?.startsWith("tool-") ||
                       p.type === "dynamic-tool"
                     ) {
                       const toolState = p.state as string | undefined;
+                      const interruptedText =
+                        "Interrupted — stream disconnected before tool completed";
+                      if (toolState === "error") {
+                        const output = p.output as
+                          | { error?: unknown }
+                          | null
+                          | undefined;
+                        const errorText =
+                          typeof p.errorText === "string"
+                            ? p.errorText
+                            : typeof output?.error === "string"
+                              ? output.error
+                              : output?.error != null
+                                ? String(output.error)
+                                : "Tool failed";
+                        return {
+                          ...p,
+                          state: "output-error",
+                          input: p.input ?? {},
+                          output: undefined,
+                          errorText,
+                        };
+                      }
                       const isComplete =
                         toolState === "output-available" ||
-                        toolState === "error";
+                        toolState === "output-error" ||
+                        toolState === "output-denied";
+                      if (isComplete) {
+                        return {
+                          ...p,
+                          input: p.input ?? {},
+                        };
+                      }
                       return {
                         ...p,
-                        state: isComplete ? toolState : "error",
+                        state: "output-error",
                         input: p.input ?? {},
-                        output: isComplete
-                          ? (p.output ?? null)
-                          : (p.output ?? {
-                              success: false,
-                              error:
-                                "Interrupted — stream disconnected before tool completed",
-                            }),
+                        output: undefined,
+                        errorText: interruptedText,
                       };
                     }
                     // Unknown part type - pass through as-is
@@ -1986,12 +2040,22 @@ const Chat: React.FC<ChatProps> = ({
   return (
     <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
       {/* Header with history and new chat */}
-      <Box sx={{ px: 1, py: 0.5, borderBottom: 1, borderColor: "divider" }}>
+      <Box
+        sx={{
+          px: 1,
+          py: 0.25,
+          minHeight: 37,
+          borderBottom: 1,
+          borderColor: "divider",
+        }}
+      >
         <Box
           sx={{
             display: "flex",
             justifyContent: "space-between",
             alignItems: "center",
+            height: "100%",
+            minHeight: 32,
           }}
         >
           <Box
@@ -2253,6 +2317,7 @@ const Chat: React.FC<ChatProps> = ({
                 isLastMessage={msgIdx === messages.length - 1}
                 isStreaming={status === "streaming"}
                 onToolClick={handleToolClick}
+                paletteMode={paletteMode}
               />
             ))}
           </List>
@@ -2320,6 +2385,7 @@ const Chat: React.FC<ChatProps> = ({
         isLoading={isLoading}
         disabled={!currentWorkspace}
         focusKey={`${chatId}-${messages.length}`}
+        paletteMode={paletteMode}
       />
 
       {/* Tool Debug Dialog */}
@@ -2337,7 +2403,12 @@ const Chat: React.FC<ChatProps> = ({
             <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
               Input
             </Typography>
-            <CodeBlock language="json" isGenerating={false} scrollable>
+            <CodeBlock
+              language="json"
+              isGenerating={false}
+              scrollable
+              paletteMode={paletteMode}
+            >
               {selectedTool && selectedTool.input !== undefined
                 ? typeof selectedTool.input === "string"
                   ? selectedTool.input
@@ -2349,7 +2420,12 @@ const Chat: React.FC<ChatProps> = ({
             <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
               Output
             </Typography>
-            <CodeBlock language="json" isGenerating={false} scrollable>
+            <CodeBlock
+              language="json"
+              isGenerating={false}
+              scrollable
+              paletteMode={paletteMode}
+            >
               {selectedTool && selectedTool.output !== undefined
                 ? typeof selectedTool.output === "string"
                   ? selectedTool.output

--- a/app/src/components/ConnectorExplorer.tsx
+++ b/app/src/components/ConnectorExplorer.tsx
@@ -150,12 +150,22 @@ function ConnectorExplorer() {
   return (
     <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
       {/* Header */}
-      <Box sx={{ px: 1, py: 0.5, borderBottom: 1, borderColor: "divider" }}>
+      <Box
+        sx={{
+          px: 1,
+          py: 0.25,
+          minHeight: 37,
+          borderBottom: 1,
+          borderColor: "divider",
+        }}
+      >
         <Box
           sx={{
             display: "flex",
             justifyContent: "space-between",
             alignItems: "center",
+            height: "100%",
+            minHeight: 32,
           }}
         >
           <Typography

--- a/app/src/components/Console.tsx
+++ b/app/src/components/Console.tsx
@@ -12,6 +12,7 @@ import {
   Button,
   Select,
   MenuItem,
+  Menu,
   FormControl,
   Tooltip,
   IconButton,
@@ -19,6 +20,8 @@ import {
   Badge,
   Alert,
   Chip,
+  ListItemIcon,
+  ListItemText,
 } from "@mui/material";
 import { PlayArrow as PlayIcon } from "@mui/icons-material";
 import {
@@ -30,6 +33,9 @@ import {
   History as HistoryIcon,
   Info as InfoOutlineIcon,
   Square as StopIcon,
+  ChevronDown as ChevronDownIcon,
+  Copy as CopyIcon,
+  FolderInput as MoveIcon,
 } from "lucide-react";
 import Editor, { DiffEditor } from "@monaco-editor/react";
 import { useTheme } from "../contexts/ThemeContext";
@@ -72,6 +78,10 @@ interface ConsoleProps {
   ) => void;
   onCancel?: () => void;
   onSave?: (content: string, currentPath?: string) => Promise<boolean>;
+  /** Save the current buffer as a NEW console at a chosen path (original untouched). */
+  onSaveAsCopy?: (content: string) => void;
+  /** Move/rename the current console to a new path. */
+  onRenameMove?: (content: string, currentPath?: string) => void;
   isExecuting: boolean;
   isCancelling?: boolean;
   isSaving?: boolean;
@@ -115,6 +125,8 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
     onExecute,
     onCancel,
     onSave,
+    onSaveAsCopy,
+    onRenameMove,
     isExecuting,
     isCancelling,
     isSaving,
@@ -148,6 +160,11 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
   // State for info modal
   const [infoModalOpen, setInfoModalOpen] = useState(false);
   const [monacoInstance, setMonacoInstance] = useState<any>(null);
+  // Save split-button menu anchor
+  const [saveMenuAnchor, setSaveMenuAnchor] = useState<null | HTMLElement>(
+    null,
+  );
+  const saveMenuOpen = Boolean(saveMenuAnchor);
 
   // Compute dirty state by comparing current state hash vs saved state hash
   const hasUnsavedChanges = useMemo(() => {
@@ -224,6 +241,8 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
   // Keep refs of the latest callbacks and props to avoid stale closures in Monaco commands
   const onExecuteRef = useRef(onExecute);
   const onSaveRef = useRef(onSave);
+  const onSaveAsCopyRef = useRef(onSaveAsCopy);
+  const onRenameMoveRef = useRef(onRenameMove);
   const connectionIdRef = useRef(connectionId);
   const databaseIdRef = useRef(databaseId);
 
@@ -235,6 +254,14 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
   useEffect(() => {
     onSaveRef.current = onSave;
   }, [onSave]);
+
+  useEffect(() => {
+    onSaveAsCopyRef.current = onSaveAsCopy;
+  }, [onSaveAsCopy]);
+
+  useEffect(() => {
+    onRenameMoveRef.current = onRenameMove;
+  }, [onRenameMove]);
 
   useEffect(() => {
     connectionIdRef.current = connectionId;
@@ -449,6 +476,20 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
     }
   }, [getFullEditorContent]);
 
+  const handleSaveAsCopy = useCallback(() => {
+    if (onSaveAsCopyRef.current) {
+      const content = getFullEditorContent();
+      onSaveAsCopyRef.current(content);
+    }
+  }, [getFullEditorContent]);
+
+  const handleRenameMove = useCallback(() => {
+    if (onRenameMoveRef.current) {
+      const content = getFullEditorContent();
+      onRenameMoveRef.current(content, filePathRef.current);
+    }
+  }, [getFullEditorContent]);
+
   // Calculate editor language
   const editorLanguage = useMemo(() => {
     if (filePath?.endsWith(".sql")) return "sql";
@@ -544,6 +585,19 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
         });
       }
 
+      // CMD/CTRL + Shift + S → Save as Copy (fallback to first-time save when
+      // onSaveAsCopy isn't available).
+      editor.addCommand(
+        monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KeyS,
+        () => {
+          if (onSaveAsCopyRef.current) {
+            handleSaveAsCopy();
+          } else if (onSaveRef.current) {
+            handleSave();
+          }
+        },
+      );
+
       // Auto-focus the editor when it mounts
       editor.focus();
 
@@ -593,6 +647,7 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
       setEditor,
       handleExecute,
       handleSave,
+      handleSaveAsCopy,
       onSave,
       saveUserEdit,
       consoleId,
@@ -930,26 +985,102 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
           )}
 
           {onSave && !isReadOnly && (
-            <Tooltip
-              title={
-                !hasUnsavedChanges
-                  ? "No changes to save"
-                  : filePathRef.current
-                    ? "Save (⌘/Ctrl+S)"
-                    : "Save As... (⌘/Ctrl+S)"
-              }
+            <Box
+              sx={{
+                ml: 1,
+                display: "inline-flex",
+                alignItems: "center",
+              }}
             >
-              <IconButton
-                size="small"
-                onClick={handleSave}
-                disabled={isSaving || isExecuting || !hasUnsavedChanges}
-                sx={{
-                  ml: 1,
-                }}
+              <Tooltip
+                title={
+                  !hasUnsavedChanges
+                    ? "No changes to save"
+                    : filePathRef.current
+                      ? "Save (⌘/Ctrl+S)"
+                      : "Save (first save) (⌘/Ctrl+S)"
+                }
               >
-                <SaveIcon strokeWidth={2} size={22} />
-              </IconButton>
-            </Tooltip>
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={handleSave}
+                    disabled={isSaving || isExecuting || !hasUnsavedChanges}
+                    sx={{
+                      borderTopRightRadius: 0,
+                      borderBottomRightRadius: 0,
+                      pr: 0.5,
+                    }}
+                  >
+                    <SaveIcon strokeWidth={2} size={22} />
+                  </IconButton>
+                </span>
+              </Tooltip>
+              <Tooltip title="More save options">
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={e => setSaveMenuAnchor(e.currentTarget)}
+                    disabled={isSaving || isExecuting}
+                    sx={{
+                      borderTopLeftRadius: 0,
+                      borderBottomLeftRadius: 0,
+                      pl: 0,
+                      pr: 0.5,
+                    }}
+                    aria-haspopup="menu"
+                    aria-expanded={saveMenuOpen ? "true" : undefined}
+                  >
+                    <ChevronDownIcon strokeWidth={2} size={14} />
+                  </IconButton>
+                </span>
+              </Tooltip>
+              <Menu
+                anchorEl={saveMenuAnchor}
+                open={saveMenuOpen}
+                onClose={() => setSaveMenuAnchor(null)}
+                anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+                transformOrigin={{ vertical: "top", horizontal: "left" }}
+              >
+                <MenuItem
+                  disabled={isSaving || isExecuting || !onSaveAsCopy}
+                  onClick={() => {
+                    setSaveMenuAnchor(null);
+                    handleSaveAsCopy();
+                  }}
+                >
+                  <ListItemIcon>
+                    <CopyIcon size={16} strokeWidth={2} />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary="Save a Copy..."
+                    secondary="⌘/Ctrl+Shift+S"
+                  />
+                </MenuItem>
+                <MenuItem
+                  disabled={
+                    isSaving ||
+                    isExecuting ||
+                    !onRenameMove ||
+                    !filePathRef.current
+                  }
+                  onClick={() => {
+                    setSaveMenuAnchor(null);
+                    handleRenameMove();
+                  }}
+                >
+                  <ListItemIcon>
+                    <MoveIcon size={16} strokeWidth={2} />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary="Rename / Move..."
+                    secondary={
+                      !filePathRef.current ? "Save the file first" : undefined
+                    }
+                  />
+                </MenuItem>
+              </Menu>
+            </Box>
           )}
 
           {enableVersionControl && (

--- a/app/src/components/ConsoleExplorer.tsx
+++ b/app/src/components/ConsoleExplorer.tsx
@@ -466,12 +466,22 @@ function ConsoleExplorer(
 
   return (
     <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
-      <Box sx={{ px: 1, py: 0.5, borderBottom: 1, borderColor: "divider" }}>
+      <Box
+        sx={{
+          px: 1,
+          py: 0.25,
+          minHeight: 37,
+          borderBottom: 1,
+          borderColor: "divider",
+        }}
+      >
         <Box
           sx={{
             display: "flex",
             justifyContent: "space-between",
             alignItems: "center",
+            height: "100%",
+            minHeight: 32,
           }}
         >
           <Box

--- a/app/src/components/DashboardsExplorer.tsx
+++ b/app/src/components/DashboardsExplorer.tsx
@@ -295,12 +295,22 @@ export function DashboardsExplorer() {
   return (
     <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
       {/* Header */}
-      <Box sx={{ px: 1, py: 0.5, borderBottom: 1, borderColor: "divider" }}>
+      <Box
+        sx={{
+          px: 1,
+          py: 0.25,
+          minHeight: 37,
+          borderBottom: 1,
+          borderColor: "divider",
+        }}
+      >
         <Box
           sx={{
             display: "flex",
             justifyContent: "space-between",
             alignItems: "center",
+            height: "100%",
+            minHeight: 32,
           }}
         >
           <Typography

--- a/app/src/components/DatabaseExplorer.tsx
+++ b/app/src/components/DatabaseExplorer.tsx
@@ -537,12 +537,22 @@ function DatabaseExplorer({
 
   return (
     <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
-      <Box sx={{ px: 1, py: 0.5, borderBottom: 1, borderColor: "divider" }}>
+      <Box
+        sx={{
+          px: 1,
+          py: 0.25,
+          minHeight: 37,
+          borderBottom: 1,
+          borderColor: "divider",
+        }}
+      >
         <Box
           sx={{
             display: "flex",
             justifyContent: "space-between",
             alignItems: "center",
+            height: "100%",
+            minHeight: 32,
           }}
         >
           <Box

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -1,4 +1,24 @@
-import React, { useRef, useEffect, useState, useCallback } from "react";
+import React, {
+  useRef,
+  useEffect,
+  useMemo,
+  useState,
+  useCallback,
+} from "react";
+import {
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  horizontalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { restrictToHorizontalAxis } from "@dnd-kit/modifiers";
 import {
   Box,
   Tabs,
@@ -23,6 +43,7 @@ import {
   Webhook as WebhookIcon,
   CirclePause as PauseIcon,
   ChartPie as DashboardIcon,
+  ChevronRight as BreadcrumbChevronIcon,
 } from "lucide-react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { loader } from "@monaco-editor/react";
@@ -38,7 +59,8 @@ import ConflictResolutionDialog, {
   ConflictData,
 } from "./ConflictResolutionDialog";
 import FileExplorerDialog from "./FileExplorerDialog";
-import { useConsoleStore } from "../store/consoleStore";
+import { useConsoleStore, selectConsoleTabs } from "../store/consoleStore";
+import { useShallow } from "zustand/react/shallow";
 import { useDashboardStore } from "../store/dashboardStore";
 import { useUIStore } from "../store/uiStore";
 import { useSchemaStore } from "../store/schemaStore";
@@ -47,6 +69,7 @@ import { ConsoleModification } from "../hooks/useMonacoConsole";
 import { useSqlAutocomplete } from "../hooks/useSqlAutocomplete";
 import { trackEvent } from "../lib/analytics";
 import { getApiBasePath } from "../lib/api-base-path";
+import { generateObjectId } from "../utils/objectId";
 import {
   computeConsoleStateHash,
   computeDashboardStateHash,
@@ -157,6 +180,76 @@ function LockConflictDialog() {
   );
 }
 
+/**
+ * MUI <Tabs> clones its direct children to inject props (selected, onChange,
+ * textColor, indicator, ...). This wrapper accepts all Tab props (plus MUI's
+ * clone-injected extras), wires up dnd-kit's useSortable for drag-to-reorder,
+ * and forwards everything to an underlying <Tab>.
+ *
+ * UX:
+ * - Dragged tab stays in place (only dimmed); no translation or layout shift.
+ * - A thin vertical bar (drop indicator) is rendered on the leading or
+ *   trailing edge of the tab currently under the pointer, showing where the
+ *   dragged tab will land on drop.
+ *
+ * Implementation notes:
+ * - We intentionally do NOT spread dnd-kit's `attributes` onto the Tab — they
+ *   include role="button"/tabIndex which would clobber MUI Tab's own
+ *   role="tab"/tabIndex logic and break tab selection + cause a feedback
+ *   loop with MUI Tabs' indicator ResizeObserver.
+ * - We use inline `style` (not `sx`) for the drag opacity so emotion doesn't
+ *   churn className hashes on every pointer move during a drag.
+ */
+function SortableConsoleTab(props: React.ComponentProps<typeof Tab>) {
+  const id = props.value as string;
+  const { listeners, setNodeRef, isDragging, isOver, activeIndex, overIndex } =
+    useSortable({ id });
+
+  // Show a drop indicator on the hovered tab, but not on the dragged tab
+  // itself and not when dropping would be a no-op (same index).
+  const showIndicator =
+    isOver && !isDragging && activeIndex !== -1 && activeIndex !== overIndex;
+  // Leading edge when moving the tab to the left, trailing edge when moving
+  // it to the right.
+  const indicatorSide: "left" | "right" =
+    activeIndex > overIndex ? "left" : "right";
+
+  const dragStyle: React.CSSProperties = {
+    opacity: isDragging ? 0.4 : 1,
+    touchAction: "none",
+  };
+
+  const indicatorSx = showIndicator
+    ? {
+        "&::after": {
+          content: '""',
+          position: "absolute",
+          top: 0,
+          bottom: 0,
+          [indicatorSide]: -3,
+          width: "6px",
+          backgroundColor: "divider",
+          pointerEvents: "none",
+          zIndex: 2,
+        },
+      }
+    : undefined;
+
+  const mergedSx = indicatorSx
+    ? ([props.sx, indicatorSx] as React.ComponentProps<typeof Tab>["sx"])
+    : props.sx;
+
+  return (
+    <Tab
+      {...props}
+      {...listeners}
+      ref={setNodeRef as unknown as React.Ref<HTMLDivElement>}
+      sx={mergedSx}
+      style={{ ...(props.style || {}), ...dragStyle }}
+    />
+  );
+}
+
 function Editor({
   dbFlowFormRef,
   onChartSpecChangeRef,
@@ -225,6 +318,20 @@ function Editor({
   const [saveDialogOpen, setSaveDialogOpen] = useState(false);
   const [saveDialogTabId, setSaveDialogTabId] = useState<string | null>(null);
   const [saveDialogContent, setSaveDialogContent] = useState("");
+  // Which flow opened the dialog:
+  //   "new"           — first-time save of a draft tab (POST with the tab's own id)
+  //   "save-as-copy"  — create a brand-new console record (POST with a fresh id),
+  //                     leaving the current tab untouched.
+  //   "rename-move"   — relocate an already-saved console (PUT via saveConsole)
+  //                     to a new path; current tab updates to the new path.
+  const [saveDialogMode, setSaveDialogMode] = useState<
+    "new" | "save-as-copy" | "rename-move"
+  >("new");
+  // Id that will be sent to the API. Same as saveDialogTabId for "new" and
+  // "rename-move"; a freshly-generated id for "save-as-copy".
+  const [saveDialogTargetId, setSaveDialogTargetId] = useState<string | null>(
+    null,
+  );
 
   // Conflict resolution state
   const [conflictDialogOpen, setConflictDialogOpen] = useState(false);
@@ -269,7 +376,11 @@ function Editor({
   const saveConsole = useConsoleStore(state => state.saveConsole);
   const deleteConsole = useConsoleStore(state => state.deleteConsole);
   const openTab = useConsoleStore(state => state.openTab);
-  const consoleTabs = Object.values(tabs);
+  const reorderTabs = useConsoleStore(state => state.reorderTabs);
+  // useShallow prevents infinite re-renders: selectConsoleTabs returns a new
+  // array on every call; without shallow comparison useSyncExternalStore would
+  // detect a change every render and trigger a re-render loop.
+  const consoleTabs = useConsoleStore(useShallow(selectConsoleTabs));
   const activeConsoleId = activeTabId;
 
   const setChartSpecForTab = useCallback(
@@ -567,6 +678,26 @@ function Editor({
   const handleTabChange = (_: React.SyntheticEvent, newValue: string) => {
     setActiveTab(newValue);
   };
+
+  // Drag-to-reorder tabs
+  const dndSensors = useSensors(
+    useSensor(PointerSensor, {
+      // Keep click-to-select working: only start a drag after 4px of movement.
+      activationConstraint: { distance: 4 },
+    }),
+  );
+  const sortableTabIds = useMemo(
+    () => consoleTabs.map(t => t.id),
+    [consoleTabs],
+  );
+  const handleTabDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      reorderTabs(String(active.id), String(over.id));
+    },
+    [reorderTabs],
+  );
 
   const cleanupTab = (tabId: string) => {
     closeTab(tabId);
@@ -882,7 +1013,9 @@ function Editor({
       const savePath = currentPath;
       if (!savePath) {
         // Open the folder navigator save dialog instead of prompt()
+        setSaveDialogMode("new");
         setSaveDialogTabId(tabId);
+        setSaveDialogTargetId(tabId);
         setSaveDialogContent(contentToSave);
         setSaveDialogOpen(true);
         setIsSaving(false);
@@ -1091,15 +1224,81 @@ function Editor({
 
     // Build the path: if folderId is provided the API will handle folder association via the path or directly
     const savePath = name.endsWith(".js") ? name.slice(0, -3) : name;
+    const targetId = saveDialogTargetId ?? saveDialogTabId;
+    const mode = saveDialogMode;
 
     setIsSaving(true);
     try {
-      const currentTab = tabs[saveDialogTabId];
-      const connectionId = currentTab?.connectionId;
-      const databaseId = currentTab?.databaseId;
-      const databaseName = currentTab?.databaseName;
+      // Source tab (for connection/chart/view-mode). Even in "save-as-copy",
+      // the new record inherits these from the source tab.
+      const sourceTab = tabs[saveDialogTabId];
+      const connectionId = sourceTab?.connectionId;
+      const databaseId = sourceTab?.databaseId;
+      const databaseName = sourceTab?.databaseName;
 
-      // Use POST to create with explicit folderId
+      if (mode === "rename-move") {
+        // PUT /consoles/:id — updates the existing console's path.
+        const result = await saveConsole(
+          currentWorkspace.id,
+          targetId,
+          saveDialogContent,
+          savePath,
+          connectionId,
+          databaseName,
+          databaseId,
+          tabChartSpecs[saveDialogTabId] ?? undefined,
+          tabViewModes[saveDialogTabId],
+        );
+
+        if (result.error === "conflict" && result.conflict) {
+          setPendingSaveData({
+            tabId: targetId,
+            content: saveDialogContent,
+            path: savePath,
+            connectionId,
+            databaseId,
+            databaseName,
+          });
+          setConflictData(result.conflict);
+          setConflictDialogOpen(true);
+          setIsSaving(false);
+          return;
+        }
+
+        if (result.success) {
+          updateFilePath(targetId, savePath);
+          updateTitle(targetId, savePath);
+          updateDirty(targetId, true);
+
+          const newHash = computeConsoleStateHash(
+            saveDialogContent,
+            connectionId,
+            databaseId,
+            databaseName,
+          );
+          updateSavedState(targetId, true, newHash);
+
+          trackEvent("console_renamed", {
+            console_id: targetId,
+            new_path: savePath,
+          });
+
+          setSnackbarMessage(`Renamed to '${savePath}.js'`);
+          setSnackbarOpen(true);
+
+          const { useConsoleTreeStore } = await import(
+            "../store/consoleTreeStore"
+          );
+          useConsoleTreeStore.getState().refresh(currentWorkspace.id);
+        } else {
+          setErrorMessage(JSON.stringify(result.error, null, 2));
+          setErrorModalOpen(true);
+        }
+
+        return;
+      }
+
+      // Both "new" and "save-as-copy" use POST to create a new record.
       const response = await fetch(
         `/api/workspaces/${currentWorkspace.id}/consoles`,
         {
@@ -1107,7 +1306,7 @@ function Editor({
           headers: { "Content-Type": "application/json" },
           credentials: "include",
           body: JSON.stringify({
-            id: saveDialogTabId,
+            id: targetId,
             path: savePath,
             content: saveDialogContent,
             connectionId,
@@ -1124,7 +1323,7 @@ function Editor({
 
       if (response.status === 409 && result.error === "conflict") {
         setPendingSaveData({
-          tabId: saveDialogTabId,
+          tabId: targetId,
           content: saveDialogContent,
           path: savePath,
           connectionId,
@@ -1138,26 +1337,38 @@ function Editor({
       }
 
       if (result.success) {
-        const tabId = saveDialogTabId;
-        updateFilePath(tabId, savePath);
-        updateTitle(tabId, savePath);
-        updateDirty(tabId, true);
+        if (mode === "save-as-copy") {
+          // Do NOT mutate the source tab. Just refresh the tree so the copy
+          // shows up. Optionally we could also open the new console as a tab,
+          // but keep the UX conservative: user stays focused on their work.
+          trackEvent("console_saved_as_copy", {
+            source_console_id: saveDialogTabId,
+            new_console_id: targetId,
+          });
+          setSnackbarMessage(`Saved a copy as '${savePath}.js'`);
+          setSnackbarOpen(true);
+        } else {
+          // "new" — first-time save of a draft; update the originating tab.
+          updateFilePath(targetId, savePath);
+          updateTitle(targetId, savePath);
+          updateDirty(targetId, true);
 
-        const newHash = computeConsoleStateHash(
-          saveDialogContent,
-          connectionId,
-          databaseId,
-          databaseName,
-        );
-        updateSavedState(tabId, true, newHash);
+          const newHash = computeConsoleStateHash(
+            saveDialogContent,
+            connectionId,
+            databaseId,
+            databaseName,
+          );
+          updateSavedState(targetId, true, newHash);
 
-        trackEvent("console_saved", {
-          console_id: tabId,
-          is_new: true,
-        });
+          trackEvent("console_saved", {
+            console_id: targetId,
+            is_new: true,
+          });
 
-        setSnackbarMessage(`Console saved as '${savePath}'`);
-        setSnackbarOpen(true);
+          setSnackbarMessage(`Console saved as '${savePath}'`);
+          setSnackbarOpen(true);
+        }
 
         const { useConsoleTreeStore } = await import(
           "../store/consoleTreeStore"
@@ -1173,8 +1384,53 @@ function Editor({
     } finally {
       setIsSaving(false);
       setSaveDialogTabId(null);
+      setSaveDialogTargetId(null);
+      setSaveDialogMode("new");
       setSaveDialogContent("");
     }
+  };
+
+  // "Save a Copy..." — POST a brand-new console record with a fresh id; the
+  // currently open tab keeps pointing at the original file.
+  const handleSaveAsCopy = (tabId: string, contentToSave: string) => {
+    if (!currentWorkspace) {
+      setErrorMessage("No workspace selected");
+      setErrorModalOpen(true);
+      return;
+    }
+    const newId = generateObjectId();
+    setSaveDialogMode("save-as-copy");
+    setSaveDialogTabId(tabId);
+    setSaveDialogTargetId(newId);
+    setSaveDialogContent(contentToSave);
+    setSaveDialogOpen(true);
+  };
+
+  // "Rename / Move..." — relocate the existing console (same id) to a new path.
+  const handleRenameMove = (
+    tabId: string,
+    contentToSave: string,
+    currentPath?: string,
+  ) => {
+    if (!currentWorkspace) {
+      setErrorMessage("No workspace selected");
+      setErrorModalOpen(true);
+      return;
+    }
+    if (!currentPath) {
+      // Nothing to rename yet — fall back to first-time save flow.
+      setSaveDialogMode("new");
+      setSaveDialogTabId(tabId);
+      setSaveDialogTargetId(tabId);
+      setSaveDialogContent(contentToSave);
+      setSaveDialogOpen(true);
+      return;
+    }
+    setSaveDialogMode("rename-move");
+    setSaveDialogTabId(tabId);
+    setSaveDialogTargetId(tabId);
+    setSaveDialogContent(contentToSave);
+    setSaveDialogOpen(true);
   };
 
   const handleConflictSaveAsNew = () => {
@@ -1182,8 +1438,10 @@ function Editor({
     setConflictData(null);
 
     if (pendingSaveData) {
-      // Open save dialog with a suggested copy name
+      // Re-open the dialog to let the user pick a new name.
+      setSaveDialogMode("new");
       setSaveDialogTabId(pendingSaveData.tabId);
+      setSaveDialogTargetId(pendingSaveData.tabId);
       setSaveDialogContent(pendingSaveData.content);
       setSaveDialogOpen(true);
     }
@@ -1222,94 +1480,182 @@ function Editor({
             sx={{
               display: "flex",
               alignItems: "center",
+              minHeight: 36,
               borderBottom: 1,
               borderColor: "divider",
             }}
           >
-            <Tabs
-              value={activeConsoleId}
-              onChange={handleTabChange}
-              variant="scrollable"
-              scrollButtons="auto"
+            <DndContext
+              sensors={dndSensors}
+              collisionDetection={closestCenter}
+              modifiers={[restrictToHorizontalAxis]}
+              onDragEnd={handleTabDragEnd}
             >
-              {consoleTabs.map(tab => (
-                <Tab
-                  key={tab.id}
-                  value={tab.id}
-                  label={
-                    <Box
+              <SortableContext
+                items={sortableTabIds}
+                strategy={horizontalListSortingStrategy}
+              >
+                <Tabs
+                  value={activeConsoleId}
+                  onChange={handleTabChange}
+                  variant="scrollable"
+                  scrollButtons="auto"
+                  sx={{
+                    minHeight: 36,
+                    "& .MuiTabs-indicator": { height: 2 },
+                  }}
+                >
+                  {consoleTabs.map(tab => (
+                    <SortableConsoleTab
+                      key={tab.id}
+                      value={tab.id}
                       sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 0.75,
-                        minWidth: 0,
-                        maxWidth: "100%",
+                        minHeight: 36,
+                        py: 0.25,
+                        px: 1.25,
+                        textTransform: "none",
                       }}
-                    >
-                      {tab.icon ? (
+                      label={
                         <Box
-                          component="img"
-                          src={tab.icon}
-                          alt="tab icon"
-                          sx={{ width: 20, height: 20 }}
-                        />
-                      ) : tab.kind === "settings" ? (
-                        <SettingsIcon size={20} strokeWidth={1.5} />
-                      ) : tab.kind === "connectors" ? (
-                        <DataSourceIcon size={20} strokeWidth={1.5} />
-                      ) : tab.kind === "flow-editor" ? (
-                        tab.metadata?.flowType === "webhook" ? (
-                          <WebhookIcon size={20} strokeWidth={1.5} />
-                        ) : tab.metadata?.enabled === false ? (
-                          <PauseIcon size={20} strokeWidth={1.5} />
-                        ) : (
-                          <ScheduleIcon size={20} strokeWidth={1.5} />
-                        )
-                      ) : tab.kind === "dashboard" ? (
-                        <DashboardIcon size={20} strokeWidth={1.5} />
-                      ) : (
-                        <ConsoleIcon size={20} strokeWidth={1.5} />
-                      )}
-                      <span
-                        style={{
-                          fontStyle: tab.isDirty ? "normal" : "italic",
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          whiteSpace: "nowrap",
-                          display: "inline-block",
-                          maxWidth: "150px",
-                        }}
-                        onDoubleClick={e => {
-                          e.stopPropagation();
-                          updateDirty(tab.id, true);
-                        }}
-                      >
-                        {tab.title}
-                      </span>
-                      <IconButton
-                        component="span"
-                        size="small"
-                        onClick={e => {
-                          e.stopPropagation();
-                          closeConsole(tab.id);
-                        }}
-                      >
-                        <CloseIcon fontSize="small" />
-                      </IconButton>
-                    </Box>
-                  }
-                />
-              ))}
-            </Tabs>
+                          sx={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 0.5,
+                            minWidth: 0,
+                            maxWidth: "100%",
+                          }}
+                        >
+                          {tab.icon ? (
+                            <Box
+                              component="img"
+                              src={tab.icon}
+                              alt="tab icon"
+                              sx={{ width: 18, height: 18 }}
+                            />
+                          ) : tab.kind === "settings" ? (
+                            <SettingsIcon size={18} strokeWidth={1.5} />
+                          ) : tab.kind === "connectors" ? (
+                            <DataSourceIcon size={18} strokeWidth={1.5} />
+                          ) : tab.kind === "flow-editor" ? (
+                            tab.metadata?.flowType === "webhook" ? (
+                              <WebhookIcon size={18} strokeWidth={1.5} />
+                            ) : tab.metadata?.enabled === false ? (
+                              <PauseIcon size={18} strokeWidth={1.5} />
+                            ) : (
+                              <ScheduleIcon size={18} strokeWidth={1.5} />
+                            )
+                          ) : tab.kind === "dashboard" ? (
+                            <DashboardIcon size={18} strokeWidth={1.5} />
+                          ) : (
+                            <ConsoleIcon size={18} strokeWidth={1.5} />
+                          )}
+                          <span
+                            style={{
+                              fontStyle: tab.isDirty ? "normal" : "italic",
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                              whiteSpace: "nowrap",
+                              display: "inline-block",
+                              maxWidth: "150px",
+                            }}
+                            onDoubleClick={e => {
+                              e.stopPropagation();
+                              updateDirty(tab.id, true);
+                            }}
+                            title={tab.title}
+                          >
+                            {tab.title?.split("/").filter(Boolean).pop() ||
+                              tab.title}
+                          </span>
+                          <IconButton
+                            component="span"
+                            size="small"
+                            onClick={e => {
+                              e.stopPropagation();
+                              closeConsole(tab.id);
+                            }}
+                            onPointerDown={e => {
+                              // Prevent the Tab's drag listener from starting
+                              // a drag when the user clicks the close button.
+                              e.stopPropagation();
+                            }}
+                            sx={{ p: 0.25, ml: 0.25 }}
+                          >
+                            <CloseIcon fontSize="inherit" />
+                          </IconButton>
+                        </Box>
+                      }
+                    />
+                  ))}
+                </Tabs>
+              </SortableContext>
+            </DndContext>
             <IconButton
               onClick={handleAddTab}
               size="small"
-              sx={{ ml: 1, mr: 1 }}
+              sx={{ ml: 0.5, mr: 0.5, p: 0.5 }}
               title="Add new console tab"
             >
-              <AddIcon />
+              <AddIcon fontSize="small" />
             </IconButton>
           </Box>
+
+          {/* Breadcrumb path (Cursor-style) — only when the active tab has a filePath */}
+          {(() => {
+            const activeTab = activeConsoleId ? tabs[activeConsoleId] : null;
+            const filePath = activeTab?.filePath;
+            if (!filePath) return null;
+            const segments = filePath.split("/").filter(Boolean);
+            if (segments.length === 0) return null;
+            return (
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  minHeight: 22,
+                  px: 1.5,
+                  py: 0.25,
+                  backgroundColor: "background.paper",
+                  color: "text.secondary",
+                  fontSize: "0.75rem",
+                  overflow: "hidden",
+                  whiteSpace: "nowrap",
+                  gap: 0.25,
+                }}
+              >
+                {segments.map((segment, index) => (
+                  <Box
+                    key={`${index}-${segment}`}
+                    component="span"
+                    sx={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: 0.25,
+                      minWidth: 0,
+                    }}
+                  >
+                    {index > 0 && (
+                      <BreadcrumbChevronIcon
+                        size={12}
+                        strokeWidth={2}
+                        style={{ flexShrink: 0, opacity: 0.6 }}
+                      />
+                    )}
+                    <Box
+                      component="span"
+                      sx={{
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {segment}
+                    </Box>
+                  </Box>
+                ))}
+              </Box>
+            );
+          })()}
 
           {/* Unified tab rendering: every tab stays mounted, visibility toggled with CSS */}
           <Box sx={{ flexGrow: 1, overflow: "hidden" }}>
@@ -1391,6 +1737,12 @@ function Editor({
                         onCancel={() => handleConsoleCancel(tab.id)}
                         onSave={(content, currentPath) =>
                           handleConsoleSave(tab.id, content, currentPath)
+                        }
+                        onSaveAsCopy={content =>
+                          handleSaveAsCopy(tab.id, content)
+                        }
+                        onRenameMove={(content, currentPath) =>
+                          handleRenameMove(tab.id, content, currentPath)
                         }
                         isExecuting={executingTabs[tab.id] || false}
                         isCancelling={cancellingTabs[tab.id] || false}
@@ -1548,11 +1900,25 @@ function Editor({
         onClose={() => {
           setSaveDialogOpen(false);
           setSaveDialogTabId(null);
+          setSaveDialogTargetId(null);
+          setSaveDialogMode("new");
           setSaveDialogContent("");
         }}
         mode="save"
         onSave={handleSaveDialogConfirm}
-        defaultName={saveDialogTabId ? tabs[saveDialogTabId]?.title || "" : ""}
+        defaultName={(() => {
+          if (!saveDialogTabId) return "";
+          const tab = tabs[saveDialogTabId];
+          if (!tab) return "";
+          if (saveDialogMode === "save-as-copy") {
+            const base = tab.filePath || tab.title || "";
+            return base ? `${base} (copy)` : "";
+          }
+          if (saveDialogMode === "rename-move") {
+            return tab.filePath || tab.title || "";
+          }
+          return tab.title || "";
+        })()}
         isSaving={isSaving}
       />
 

--- a/app/src/components/FlowsExplorer.tsx
+++ b/app/src/components/FlowsExplorer.tsx
@@ -205,12 +205,22 @@ export function FlowsExplorer() {
   return (
     <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
       {/* Header */}
-      <Box sx={{ px: 1, py: 0.5, borderBottom: 1, borderColor: "divider" }}>
+      <Box
+        sx={{
+          px: 1,
+          py: 0.25,
+          minHeight: 37,
+          borderBottom: 1,
+          borderColor: "divider",
+        }}
+      >
         <Box
           sx={{
             display: "flex",
             justifyContent: "space-between",
             alignItems: "center",
+            height: "100%",
+            minHeight: 32,
           }}
         >
           <Typography

--- a/app/src/components/UrlSync.tsx
+++ b/app/src/components/UrlSync.tsx
@@ -21,16 +21,40 @@ import { useAuth } from "../contexts/auth-context";
 export function UrlSync() {
   const { currentWorkspace } = useWorkspace();
   const { user } = useAuth();
-  // We need access to store methods but we don't want to trigger re-renders of this component
-  // when the store changes, so we'll use the hooks but rely on the useEffect dependencies
-  // to control when updates happen.
-  const activeTabId = useConsoleStore(state => state.activeTabId);
-  const tabs = useConsoleStore(state => state.tabs);
   const loadConsole = useConsoleStore(state => state.loadConsole);
   const openTab = useConsoleStore(state => state.openTab);
   const setActiveTab = useConsoleStore(state => state.setActiveTab);
-  const consoleTabs = Object.values(tabs);
-  const activeConsoleId = activeTabId;
+
+  // Derive the URL path for the currently active tab as a primitive string.
+  // Returning a primitive means zustand's default Object.is comparison skips
+  // re-renders on unrelated state changes (e.g. keystrokes updating tab
+  // content), so this component only re-renders when the URL actually needs
+  // to change.
+  const activeTabPath = useConsoleStore(state => {
+    const id = state.activeTabId;
+    if (!id) return null;
+    const tab = state.tabs[id];
+    if (!tab) return null;
+    switch (tab.kind) {
+      case undefined:
+      case "console":
+        return `/c/${id}`;
+      case "connectors":
+        return typeof tab.content === "string" && tab.content
+          ? `/cx/${tab.content}`
+          : null;
+      case "flow-editor":
+        return tab.metadata?.flowId ? `/f/${tab.metadata.flowId}` : null;
+      case "dashboard":
+        return tab.metadata?.dashboardId
+          ? `/d/${tab.metadata.dashboardId}`
+          : null;
+      case "settings":
+        return "/settings";
+      default:
+        return null;
+    }
+  });
 
   const activeView = useUIStore(state => state.leftPane);
   const setLeftPane = useUIStore(state => state.setLeftPane);
@@ -73,7 +97,7 @@ export function UrlSync() {
       setLeftPane("connectors");
 
       // Check if we already have a tab for this connector
-      const existingTab = consoleTabs.find(
+      const existingTab = Object.values(useConsoleStore.getState().tabs).find(
         t => t.kind === "connectors" && t.content === connectorId,
       );
 
@@ -95,7 +119,7 @@ export function UrlSync() {
       setLeftPane("flows");
 
       // Check for existing tab
-      const existingTab = consoleTabs.find(
+      const existingTab = Object.values(useConsoleStore.getState().tabs).find(
         t => t.kind === "flow-editor" && t.metadata?.flowId === flowId,
       );
 
@@ -115,7 +139,7 @@ export function UrlSync() {
       const dashboardId = dashboardMatch[1];
       setLeftPane("dashboards");
 
-      const existingTab = consoleTabs.find(
+      const existingTab = Object.values(useConsoleStore.getState().tabs).find(
         t => t.kind === "dashboard" && t.metadata?.dashboardId === dashboardId,
       );
 
@@ -162,62 +186,31 @@ export function UrlSync() {
   }, [currentWorkspace, user]); // Only run when workspace is ready and user is authenticated
 
   // --- Synchronization: Update URL when state changes ---
+  //
+  // The URL follows the active tab (the document open in the editor), not the
+  // left-pane view. That way switching between tabs — or opening the app with
+  // a persisted active tab while the left pane is on a different view — still
+  // produces a shareable /c/:id (or /d/:id, /f/:id, /cx/:id) URL.
+  //
+  // `activeTabPath` is a primitive string derived inside the zustand selector,
+  // so this effect only fires when the URL it would produce actually changes
+  // (not on every keystroke in the editor).
   useEffect(() => {
     // Don't sync until after hydration or if user is not authenticated
     if (!isHydrated.current || !user) return;
 
-    let newPath = "/";
+    let newPath = activeTabPath ?? "/";
 
-    // Determine path based on active view and active tab
-    if (activeView === "settings") {
+    // View-only fallback: if no active tab owns the URL but the user is on
+    // the settings view, still reflect that so /settings is shareable.
+    if (newPath === "/" && activeView === "settings") {
       newPath = "/settings";
-    } else if (activeView === "consoles") {
-      if (activeConsoleId) {
-        const tab = consoleTabs.find(t => t.id === activeConsoleId);
-        // Ensure we only link to actual consoles in the console view
-        if (tab && (tab.kind === "console" || !tab.kind)) {
-          newPath = `/c/${activeConsoleId}`;
-        }
-      }
-    } else if (activeView === "connectors") {
-      // If a specific connector tab is focused
-      if (activeConsoleId) {
-        const tab = consoleTabs.find(t => t.id === activeConsoleId);
-        if (tab && tab.kind === "connectors" && tab.content) {
-          // content holds the sourceId for connectors
-          newPath = `/cx/${tab.content}`;
-        }
-      }
-    } else if (activeView === "flows") {
-      if (activeConsoleId) {
-        const tab = consoleTabs.find(t => t.id === activeConsoleId);
-        if (tab && tab.kind === "flow-editor" && tab.metadata?.flowId) {
-          newPath = `/f/${tab.metadata.flowId}`;
-        }
-      }
-    } else if (activeView === "dashboards") {
-      if (activeConsoleId) {
-        const tab = consoleTabs.find(t => t.id === activeConsoleId);
-        if (tab && tab.kind === "dashboard" && tab.metadata?.dashboardId) {
-          newPath = `/d/${tab.metadata.dashboardId}`;
-        }
-      }
     }
 
-    // Fallback: if the consoles view is active but no console-specific path was set,
-    // still reflect the active console in the URL so the link is shareable/bookmarkable.
-    if (newPath === "/" && activeView === "consoles" && activeConsoleId) {
-      const tab = consoleTabs.find(t => t.id === activeConsoleId);
-      if (tab && (tab.kind === "console" || !tab.kind)) {
-        newPath = `/c/${activeConsoleId}`;
-      }
-    }
-
-    // Only update if changed to avoid noise (though replaceState is cheap)
     if (window.location.pathname !== newPath) {
       window.history.replaceState(null, "", newPath);
     }
-  }, [activeView, activeConsoleId, consoleTabs, user]); // Re-run when relevant state changes
+  }, [activeTabPath, activeView, user]);
 
   return null; // This component renders nothing
 }

--- a/app/src/components/__tests__/Chat.perf.test.ts
+++ b/app/src/components/__tests__/Chat.perf.test.ts
@@ -28,6 +28,7 @@ function makeProps(
     isLastMessage: false,
     isStreaming: false,
     onToolClick: () => {},
+    paletteMode: "light",
     ...overrides,
   };
 }
@@ -80,6 +81,12 @@ describe("chatMessageRowArePropsEqual", () => {
   it("returns false when isStreaming changes", () => {
     const prev = makeProps({ isStreaming: false });
     const next = makeProps({ isStreaming: true });
+    expect(chatMessageRowArePropsEqual(prev, next)).toBe(false);
+  });
+
+  it("returns false when paletteMode changes (theme toggle)", () => {
+    const prev = makeProps({ paletteMode: "light" });
+    const next = makeProps({ paletteMode: "dark" });
     expect(chatMessageRowArePropsEqual(prev, next)).toBe(false);
   });
 

--- a/app/src/components/chat-message-comparator.ts
+++ b/app/src/components/chat-message-comparator.ts
@@ -14,6 +14,8 @@ export interface ChatMessageRowProps {
   isLastMessage: boolean;
   isStreaming: boolean;
   onToolClick: (tool: any) => void;
+  /** Bust memo when MUI palette mode changes so row styles stay in sync */
+  paletteMode: "light" | "dark";
 }
 
 /**
@@ -30,6 +32,7 @@ export function chatMessageRowArePropsEqual(
   prev: ChatMessageRowProps,
   next: ChatMessageRowProps,
 ): boolean {
+  if (prev.paletteMode !== next.paletteMode) return false;
   if (prev.isLastMessage !== next.isLastMessage) return false;
   if (prev.isStreaming !== next.isStreaming) return false;
   if (prev.message === next.message) return true;

--- a/app/src/contexts/ThemeContext.tsx
+++ b/app/src/contexts/ThemeContext.tsx
@@ -3,6 +3,7 @@ import React, {
   useContext,
   useState,
   useEffect,
+  useLayoutEffect,
   ReactNode,
 } from "react";
 import {
@@ -84,8 +85,10 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
   const effectiveMode: "light" | "dark" =
     mode === "system" ? systemTheme : mode;
 
-  // Sync the 'dark' class on <html> for Tailwind/Streamdown CSS variables
-  useEffect(() => {
+  // Sync the 'dark' class on <html> for Tailwind/Streamdown CSS variables.
+  // useLayoutEffect keeps this aligned with MUI palette before paint (avoids
+  // a frame where Streamdown/Tailwind still use light tokens after a toggle).
+  useLayoutEffect(() => {
     if (effectiveMode === "dark") {
       document.documentElement.classList.add("dark");
     } else {

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -22,6 +22,8 @@ type MarketingEvent =
 type ProductEvent =
   | "query_executed"
   | "console_saved"
+  | "console_saved_as_copy"
+  | "console_renamed"
   | "flow_created"
   | "ai_chat_message_sent"
   | "api_key_created"

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -16,6 +16,8 @@ import type {
 
 interface ConsoleState {
   tabs: Record<string, ConsoleTab>;
+  /** Order in which tabs are displayed in the tab bar. Source of truth for the UI. */
+  tabOrder: string[];
   activeTabId: string | null;
   loading: Record<string, boolean>;
   error: Record<string, string | null>;
@@ -32,6 +34,8 @@ interface ConsoleActions {
   closeTab: (id: string) => void;
   setActiveTab: (id: string | null) => void;
   clearAllConsoles: () => void;
+  /** Reorder the tab bar by moving `fromId` to the position of `toId`. */
+  reorderTabs: (fromId: string, toId: string) => void;
 
   // Tab updates
   updateContent: (id: string, content: string) => void;
@@ -113,6 +117,7 @@ type ConsoleStore = ConsoleState & ConsoleActions;
 
 const initialState: ConsoleState = {
   tabs: {},
+  tabOrder: [],
   activeTabId: null,
   loading: {},
   error: {},
@@ -172,7 +177,9 @@ export const useConsoleStore = create<ConsoleStore>()(
         set(state => {
           if (pristineTabId && pristineTabId !== id) {
             delete state.tabs[pristineTabId];
+            state.tabOrder = state.tabOrder.filter(t => t !== pristineTabId);
           }
+          const isExisting = !!state.tabs[id];
           state.tabs[id] = {
             ...tab,
             id,
@@ -182,6 +189,9 @@ export const useConsoleStore = create<ConsoleStore>()(
             kind: tab.kind || "console",
             isDirty: tab.isDirty ?? false,
           };
+          if (!isExisting && !state.tabOrder.includes(id)) {
+            state.tabOrder.push(id);
+          }
           state.activeTabId = id;
         });
 
@@ -199,8 +209,19 @@ export const useConsoleStore = create<ConsoleStore>()(
 
         set(state => {
           delete state.tabs[id];
+          const prevIndex = state.tabOrder.indexOf(id);
+          state.tabOrder = state.tabOrder.filter(t => t !== id);
           if (state.activeTabId === id) {
-            state.activeTabId = Object.keys(state.tabs)[0] || null;
+            if (state.tabOrder.length === 0) {
+              state.activeTabId = null;
+            } else {
+              // Prefer the tab that took this one's slot, else the previous one.
+              const nextIndex = Math.min(
+                Math.max(prevIndex, 0),
+                state.tabOrder.length - 1,
+              );
+              state.activeTabId = state.tabOrder[nextIndex] ?? null;
+            }
           }
         });
       },
@@ -212,6 +233,17 @@ export const useConsoleStore = create<ConsoleStore>()(
 
       clearAllConsoles: () => {
         Object.keys(get().tabs).forEach(tabId => get().closeTab(tabId));
+      },
+
+      reorderTabs: (fromId, toId) => {
+        if (fromId === toId) return;
+        set(state => {
+          const fromIndex = state.tabOrder.indexOf(fromId);
+          const toIndex = state.tabOrder.indexOf(toId);
+          if (fromIndex < 0 || toIndex < 0) return;
+          const [moved] = state.tabOrder.splice(fromIndex, 1);
+          state.tabOrder.splice(toIndex, 0, moved);
+        });
       },
 
       // Tab updates
@@ -571,6 +603,7 @@ export const useConsoleStore = create<ConsoleStore>()(
       name: "console-store",
       partialize: state => ({
         tabs: state.tabs,
+        tabOrder: state.tabOrder,
         activeTabId: state.activeTabId,
       }),
       storage: {
@@ -579,6 +612,19 @@ export const useConsoleStore = create<ConsoleStore>()(
           if (str) {
             const data = JSON.parse(str);
             if (data.state?.tabs) {
+              // Rebuild or reconcile tabOrder with the current tabs map so
+              // upgrading users don't end up with an empty tab strip.
+              const tabIds = Object.keys(data.state.tabs);
+              const persistedOrder: string[] = Array.isArray(
+                data.state.tabOrder,
+              )
+                ? data.state.tabOrder.filter((id: string) =>
+                    Object.prototype.hasOwnProperty.call(data.state.tabs, id),
+                  )
+                : [];
+              const missing = tabIds.filter(id => !persistedOrder.includes(id));
+              data.state.tabOrder = [...persistedOrder, ...missing];
+
               Object.values(data.state.tabs).forEach((tab: any) => {
                 if (
                   tab.databaseId === undefined &&
@@ -633,8 +679,22 @@ export const useConsoleStore = create<ConsoleStore>()(
 );
 
 // Selectors
-export const selectConsoleTabs = (state: ConsoleStore): ConsoleTab[] =>
-  Object.values(state.tabs);
+export const selectConsoleTabs = (state: ConsoleStore): ConsoleTab[] => {
+  // Return tabs in tabOrder, falling back to insertion order for any orphans.
+  const ordered: ConsoleTab[] = [];
+  const seen = new Set<string>();
+  for (const id of state.tabOrder) {
+    const tab = state.tabs[id];
+    if (tab) {
+      ordered.push(tab);
+      seen.add(id);
+    }
+  }
+  for (const [id, tab] of Object.entries(state.tabs)) {
+    if (!seen.has(id)) ordered.push(tab);
+  }
+  return ordered;
+};
 export const selectActiveConsoleId = (state: ConsoleStore) => state.activeTabId;
 export const selectConsoleById =
   (id: string) =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,6 +274,9 @@ importers:
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/modifiers':
+        specifier: ^9.0.0
+        version: 9.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@dnd-kit/sortable':
         specifier: ^10.0.0
         version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
@@ -976,6 +979,12 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
+
+  '@dnd-kit/modifiers@9.0.0':
+    resolution: {integrity: sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
 
   '@dnd-kit/sortable@10.0.0':
     resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
@@ -1704,183 +1713,155 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -2177,28 +2158,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@14.2.33':
     resolution: {integrity: sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@14.2.33':
     resolution: {integrity: sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@14.2.33':
     resolution: {integrity: sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@14.2.33':
     resolution: {integrity: sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==}
@@ -2874,67 +2851,56 @@ packages:
     resolution: {integrity: sha512-wC53ZNDgt0pqx5xCAgNunkTzFE8GTgdZ9EwYGVcg+jEjJdZGtq9xPjDnFgfFozQI/Xm1mh+D9YlYtl+ueswNEg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.41.1':
     resolution: {integrity: sha512-jwKCca1gbZkZLhLRtsrka5N8sFAaxrGz/7wRJ8Wwvq3jug7toO21vWlViihG85ei7uJTpzbXZRcORotE+xyrLA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.41.1':
     resolution: {integrity: sha512-g0UBcNknsmmNQ8V2d/zD2P7WWfJKU0F1nu0k5pW4rvdb+BIqMm8ToluW/eeRmxCared5dD76lS04uL4UaNgpNA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.41.1':
     resolution: {integrity: sha512-XZpeGB5TKEZWzIrj7sXr+BEaSgo/ma/kCgrZgL0oo5qdB1JlTzIYQKel/RmhT6vMAvOdM2teYlAaOGJpJ9lahg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.41.1':
     resolution: {integrity: sha512-bkCfDJ4qzWfFRCNt5RVV4DOw6KEgFTUZi2r2RuYhGWC8WhCA8lCAJhDeAmrM/fdiAH54m0mA0Vk2FGRPyzI+tw==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.41.1':
     resolution: {integrity: sha512-3mr3Xm+gvMX+/8EKogIZSIEF0WUu0HL9di+YWlJpO8CQBnoLAEL/roTCxuLncEdgcfJcvA4UMOf+2dnjl4Ut1A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.41.1':
     resolution: {integrity: sha512-3rwCIh6MQ1LGrvKJitQjZFuQnT2wxfU+ivhNBzmxXTXPllewOF7JR1s2vMX/tWtUYFgphygxjqMl76q4aMotGw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.41.1':
     resolution: {integrity: sha512-LdIUOb3gvfmpkgFZuccNa2uYiqtgZAz3PTzjuM5bH3nvuy9ty6RGc/Q0+HDFrHrizJGVpjnTZ1yS5TNNjFlklw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.41.1':
     resolution: {integrity: sha512-oIE6M8WC9ma6xYqjvPhzZYk6NbobIURvP/lEbh7FWplcMO6gn7MM2yHKA1eC/GvYwzNKK/1LYgqzdkZ8YFxR8g==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.41.1':
     resolution: {integrity: sha512-cWBOvayNvA+SyeQMp79BHPK8ws6sHSsYnK5zDcsC3Hsxr1dgTABKjMnMslPq1DvZIp6uO7kIWhiGwaTdR4Og9A==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.41.1':
     resolution: {integrity: sha512-y5CbN44M+pUCdGDlZFzGGBSKCA4A/J2ZH4edTYSSxFg7ce1Xt3GtydbVKWLlzL+INfFIZAEg1ZV6hh9+QQf9YQ==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.41.1':
     resolution: {integrity: sha512-lZkCxIrjlJlMt1dLO/FbpZbzt6J/A8p4DnqzSa4PWqPEUUUnzXLeki/iyPLfV0BmHItlYgHUqJe+3KiyydmiNQ==}
@@ -3245,28 +3211,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -6532,56 +6494,48 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.31.0:
     resolution: {integrity: sha512-EpAQTq6TXL+200bDNMzhbFpqAJsto01R//xuE8yAWN0l4wmJhmS1r/FxoudIUM9PxHMPEiWeLw+1thdF5ZPg7Q==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.31.0:
     resolution: {integrity: sha512-6tuU37nXStA3kxNnjC49z1tPFEoviC9ZLyB34O3X1/VTLXdZX2vmPZ+45XesagvlgoeJQ9r9XVSovUZny41AQA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.31.0:
     resolution: {integrity: sha512-enNePbgDKmJybVz90/8dAGTOulvpn0IwxamHHnIj32gmdbuSPJ9mk+Nob4UmiqLMAdHlH+0c+lpsZkv4TSxi3w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-musl@1.31.0:
     resolution: {integrity: sha512-EM4jGT+V+PdFkcrIB5m5yiSzfV7z43k0pOtUmODhFSbuay5JvbVChK1uoaMmwPTKGWatwSRbiu90BUzU262B9g==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -10729,6 +10683,13 @@ snapshots:
       '@dnd-kit/utilities': 3.2.2(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+      tslib: 2.8.1
+
+  '@dnd-kit/modifiers@9.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/utilities': 3.2.2(react@18.3.1)
+      react: 18.3.1
       tslib: 2.8.1
 
   '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':


### PR DESCRIPTION
## Summary

This PR bundles frontend console/editor improvements with API-side chat message sanitization aligned to AI SDK v6 tool part states.

### AI / API
- **Message sanitizer**: Map legacy `state: "error"` tool parts to `output-error` with `errorText`, and treat `output-available`, `output-error`, and `output-denied` as complete so `convertToModelMessages` always emits matching tool results for Anthropic (avoids "tool_use ids without tool_result" errors).

### App — theme and chat
- **AuthWrapper**: Remove nested `ThemeProvider` (theme now comes from `main.tsx`) so toggling theme updates the whole tree without a full reload.
- **Chat**: Pass `paletteMode` into memoized subtrees (e.g. code blocks, message rows); normalize tool UI `output-error` for cards and interrupted streams; small header layout tweaks.

### App — editor and URL
- **Editor**: Drag-to-reorder console tabs via dnd-kit (`restrictToHorizontalAxis`), with drop indicators and activation distance so click-to-select still works.
- **consoleStore**: Ordered tab list selector (`selectConsoleTabs`), `reorderTabs`, and save flows extended (save-as-copy with new id, rename-move).
- **UrlSync**: Derive `activeTabPath` as a primitive in a Zustand selector so the URL tracks the **active document tab** and the sync effect does not run on every editor keystroke; settings view fallback preserved.

### Other
- Explorer components and **Console** updated in line with console/tab behavior; **analytics** / **ThemeContext** / perf test / lockfile adjusted as needed.

## Test plan
- [ ] Toggle light/dark theme: chat code blocks and UI update immediately without reload.
- [ ] Open chat with tool calls: completed, errored, and interrupted tools render and re-send without Anthropic errors.
- [ ] Drag console tabs horizontally; order persists as expected.
- [ ] Switch tabs (console, connector, flow, dashboard): URL updates to `/c/`, `/cx/`, `/f/`, `/d/` as appropriate; typing in editor does not spam `history.replaceState`.
- [ ] Save-as-copy and rename/move console flows behave correctly.

Made with [Cursor](https://cursor.com)