### PR TITLE
feat: generate AI version comments for console version history

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -32,6 +32,7 @@
     "commander": "^14.0.0",
     "cors": "^2.8.5",
     "cron-parser": "^5.3.0",
+    "diff": "^9.0.0",
     "dotenv": "^16.5.0",
     "express-rate-limit": "^7.5.0",
     "google-auth-library": "^10.4.0",
@@ -57,6 +58,7 @@
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
     "@types/cors": "^2.8.19",
+    "@types/diff": "^8.0.0",
     "@types/inquirer": "^8.2.11",
     "@types/js-yaml": "^4.0.9",
     "@types/mssql": "^9.1.7",

--- a/api/src/database/schema.ts
+++ b/api/src/database/schema.ts
@@ -307,7 +307,8 @@ export interface ILlmUsage extends Document {
     | "chat"
     | "title_generation"
     | "description_generation"
-    | "embedding";
+    | "embedding"
+    | "version_comment";
   modelId: string;
   inputTokens: number;
   outputTokens: number;
@@ -347,7 +348,13 @@ const LlmUsageSchema = new Schema<ILlmUsage>(
     invocationType: {
       type: String,
       required: true,
-      enum: ["chat", "title_generation", "description_generation", "embedding"],
+      enum: [
+        "chat",
+        "title_generation",
+        "description_generation",
+        "embedding",
+        "version_comment",
+      ],
     },
     modelId: { type: String, required: true },
     inputTokens: { type: Number, required: true, default: 0 },

--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -1546,7 +1546,7 @@ consoleRoutes.post("/:id/version-comment", async (c: Context) => {
       }
     }
 
-    const comment = await generateVersionComment(
+    const result = await generateVersionComment(
       {
         previousContent,
         newContent,
@@ -1557,7 +1557,11 @@ consoleRoutes.post("/:id/version-comment", async (c: Context) => {
       { workspaceId, userId: user.id },
     );
 
-    return c.json({ success: true, comment });
+    return c.json({
+      success: true,
+      comment: result.comment,
+      diff: result.diff,
+    });
   } catch (error) {
     logger.error("Error generating version comment", { error });
     return c.json(

--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -9,6 +9,7 @@ import {
   SavedConsole,
   ConsoleFolder,
   IDatabaseConnection,
+  EntityVersion,
   type ISavedConsole,
 } from "../database/workspace-schema";
 import { User } from "../database/schema";
@@ -1501,6 +1502,7 @@ consoleRoutes.patch("/folders/:id/move", async (c: Context) => {
 consoleRoutes.post("/:id/version-comment", async (c: Context) => {
   try {
     const workspaceId = c.req.param("workspaceId");
+    const consoleId = c.req.param("id");
     const user = c.get("user");
 
     if (!user || !(await workspaceService.hasAccess(workspaceId, user.id))) {
@@ -1511,46 +1513,46 @@ consoleRoutes.post("/:id/version-comment", async (c: Context) => {
     }
 
     const body = await c.req.json();
+    const { newContent, source, aiPrompt } = body;
 
-    const { previousContent, newContent, language, source, aiPrompt, title } =
-      body;
-
-    if (typeof previousContent !== "string" || typeof newContent !== "string") {
+    if (typeof newContent !== "string") {
       return c.json(
-        {
-          success: false,
-          error: "previousContent and newContent must be strings",
-        },
+        { success: false, error: "newContent must be a string" },
         400,
       );
     }
 
-    if (typeof language !== "string") {
-      return c.json({ success: false, error: "language is required" }, 400);
-    }
-
-    if (source !== "user" && source !== "ai") {
-      return c.json(
-        { success: false, error: "source must be 'user' or 'ai'" },
-        400,
-      );
-    }
-
-    if (previousContent.length > 50_000 || newContent.length > 50_000) {
+    if (newContent.length > 50_000) {
       return c.json(
         { success: false, error: "Content too large for comment generation" },
         400,
       );
     }
 
+    let previousContent = "";
+    if (Types.ObjectId.isValid(consoleId)) {
+      const latestSnapshot = await EntityVersion.findOne(
+        {
+          entityId: new Types.ObjectId(consoleId),
+          entityType: "console",
+        },
+        { "snapshot.code": 1 },
+      )
+        .sort({ version: -1 })
+        .lean();
+
+      if (latestSnapshot?.snapshot?.code) {
+        previousContent = latestSnapshot.snapshot.code as string;
+      }
+    }
+
     const comment = await generateVersionComment(
       {
         previousContent,
         newContent,
-        language,
-        source,
+        language: "sql",
+        source: source === "ai" ? "ai" : "user",
         aiPrompt: typeof aiPrompt === "string" ? aiPrompt : undefined,
-        title: typeof title === "string" ? title : undefined,
       },
       { workspaceId, userId: user.id },
     );

--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -1530,20 +1530,33 @@ consoleRoutes.post("/:id/version-comment", async (c: Context) => {
     }
 
     let previousContent = "";
+    let versionFound = false;
     if (Types.ObjectId.isValid(consoleId)) {
       const latestSnapshot = await EntityVersion.findOne(
         {
           entityId: new Types.ObjectId(consoleId),
           entityType: "console",
         },
-        { "snapshot.code": 1 },
+        { snapshot: 1, version: 1 },
       )
         .sort({ version: -1 })
         .lean();
 
       if (latestSnapshot?.snapshot?.code) {
         previousContent = latestSnapshot.snapshot.code as string;
+        versionFound = true;
       }
+
+      logger.debug("Version comment baseline lookup", {
+        consoleId,
+        versionFound,
+        latestVersion: latestSnapshot?.version ?? null,
+        snapshotKeys: latestSnapshot?.snapshot
+          ? Object.keys(latestSnapshot.snapshot)
+          : null,
+        previousContentLength: previousContent.length,
+        newContentLength: newContent.length,
+      });
     }
 
     const result = await generateVersionComment(
@@ -1561,6 +1574,12 @@ consoleRoutes.post("/:id/version-comment", async (c: Context) => {
       success: true,
       comment: result.comment,
       diff: result.diff,
+      debug: {
+        consoleId,
+        versionFound,
+        previousContentLength: previousContent.length,
+        newContentLength: newContent.length,
+      },
     });
   } catch (error) {
     logger.error("Error generating version comment", { error });

--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -26,6 +26,7 @@ import {
   isDescriptionGenAvailable,
   generateDescriptionAndEmbedding,
 } from "../services/console-description.service";
+import { generateVersionComment } from "../services/version-comment.service";
 import {
   applySqlRowLimit,
   checkPreviewQuerySafety,
@@ -1491,6 +1492,74 @@ consoleRoutes.patch("/folders/:id/move", async (c: Context) => {
             ? error.message
             : "Unknown error moving folder",
       },
+      500,
+    );
+  }
+});
+
+// POST /api/workspaces/:workspaceId/consoles/:id/version-comment - Generate AI version comment
+consoleRoutes.post("/:id/version-comment", async (c: Context) => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const user = c.get("user");
+
+    if (!user || !(await workspaceService.hasAccess(workspaceId, user.id))) {
+      return c.json(
+        { success: false, error: "Access denied to workspace" },
+        403,
+      );
+    }
+
+    const body = await c.req.json();
+
+    const { previousContent, newContent, language, source, aiPrompt, title } =
+      body;
+
+    if (typeof previousContent !== "string" || typeof newContent !== "string") {
+      return c.json(
+        {
+          success: false,
+          error: "previousContent and newContent must be strings",
+        },
+        400,
+      );
+    }
+
+    if (typeof language !== "string") {
+      return c.json({ success: false, error: "language is required" }, 400);
+    }
+
+    if (source !== "user" && source !== "ai") {
+      return c.json(
+        { success: false, error: "source must be 'user' or 'ai'" },
+        400,
+      );
+    }
+
+    if (previousContent.length > 50_000 || newContent.length > 50_000) {
+      return c.json(
+        { success: false, error: "Content too large for comment generation" },
+        400,
+      );
+    }
+
+    const comment = await generateVersionComment(
+      {
+        previousContent,
+        newContent,
+        language,
+        source,
+        aiPrompt: typeof aiPrompt === "string" ? aiPrompt : undefined,
+        title: typeof title === "string" ? title : undefined,
+      },
+      { workspaceId, userId: user.id },
+    );
+
+    return c.json({ success: true, comment });
+  } catch (error) {
+    logger.error("Error generating version comment", { error });
+    return c.json(
+      { success: false, error: "Failed to generate version comment" },
       500,
     );
   }

--- a/api/src/services/llm-usage.service.ts
+++ b/api/src/services/llm-usage.service.ts
@@ -20,7 +20,8 @@ export interface TrackUsageParams {
     | "chat"
     | "title_generation"
     | "description_generation"
-    | "embedding";
+    | "embedding"
+    | "version_comment";
   modelId: string;
   inputTokens: number;
   outputTokens: number;

--- a/api/src/services/version-comment.service.ts
+++ b/api/src/services/version-comment.service.ts
@@ -1,0 +1,167 @@
+import { generateText } from "ai";
+import { getModel, buildProviderOptions } from "../agent-lib/ai-gateway";
+import { getUtilityModelId } from "../agent-lib/ai-models";
+import { getUtilityModelIds } from "./model-catalog.service";
+import type { GatewayLanguageModelOptions } from "@ai-sdk/gateway";
+import { trackUsage } from "./llm-usage.service";
+import { loggers } from "../logging";
+import { extractTokenCounts } from "../utils/safe-num";
+
+const logger = loggers.app();
+
+const VERSION_COMMENT_SYSTEM_PROMPT = `You write short commit-message style summaries of changes to a database query.
+
+Rules:
+- 1 sentence, under 120 chars, imperative mood ("Add filter on status")
+- Focus on WHAT changed semantically, not line numbers
+- If source is "ai" and an aiPrompt is provided, reflect the user's intent
+- No quotes, no trailing period
+- Return only the summary, nothing else`;
+
+export interface VersionCommentContext {
+  previousContent: string;
+  newContent: string;
+  language: string;
+  source: "user" | "ai";
+  title?: string;
+  aiPrompt?: string;
+}
+
+export interface VersionCommentTrackingContext {
+  workspaceId: string;
+  userId: string;
+}
+
+function computeSimpleLineDiff(a: string, b: string): string {
+  const aLines = a.split("\n");
+  const bLines = b.split("\n");
+  const result: string[] = [];
+
+  const maxLen = Math.max(aLines.length, bLines.length);
+  for (let i = 0; i < maxLen; i++) {
+    const aLine = i < aLines.length ? aLines[i] : undefined;
+    const bLine = i < bLines.length ? bLines[i] : undefined;
+
+    if (aLine === bLine) continue;
+    if (aLine !== undefined && (bLine === undefined || aLine !== bLine)) {
+      result.push(`- ${aLine}`);
+    }
+    if (bLine !== undefined && (aLine === undefined || aLine !== bLine)) {
+      result.push(`+ ${bLine}`);
+    }
+  }
+
+  return result.join("\n");
+}
+
+function isWhitespaceOnly(diff: string): boolean {
+  return diff.split("\n").every(line => {
+    if (!line.startsWith("+ ") && !line.startsWith("- ")) return true;
+    const content = line.slice(2);
+    return content.trim() === "";
+  });
+}
+
+export async function generateVersionComment(
+  context: VersionCommentContext,
+  trackingCtx?: VersionCommentTrackingContext,
+): Promise<string | null> {
+  if (context.previousContent === context.newContent) return null;
+  if (context.previousContent.trim() === context.newContent.trim()) return null;
+
+  const diff = computeSimpleLineDiff(
+    context.previousContent.substring(0, 3000),
+    context.newContent.substring(0, 3000),
+  );
+
+  if (!diff || isWhitespaceOnly(diff)) return null;
+
+  const truncatedDiff = diff.substring(0, 2000);
+
+  const parts: string[] = [];
+
+  if (context.title) {
+    parts.push(`Console: ${context.title}`);
+  }
+
+  parts.push(`Language: ${context.language}`);
+  parts.push(`Change source: ${context.source}`);
+
+  if (context.source === "ai" && context.aiPrompt) {
+    parts.push(`User's AI prompt: ${context.aiPrompt.substring(0, 500)}`);
+  }
+
+  parts.push("");
+  parts.push("Diff:");
+  parts.push(truncatedDiff);
+
+  parts.push("");
+  parts.push("New query:");
+  parts.push(context.newContent.substring(0, 2000));
+
+  const prompt = parts.join("\n");
+
+  try {
+    const utilityModel = await getUtilityModelId();
+    if (!utilityModel) return null;
+
+    const failoverModels = await getUtilityModelIds(3);
+
+    const baseOpts = trackingCtx
+      ? buildProviderOptions({
+          userId: trackingCtx.userId,
+          workspaceId: trackingCtx.workspaceId,
+          invocationType: "version_comment",
+        })
+      : {};
+    const gatewayBase = (baseOpts.gateway ?? {}) as Record<string, unknown>;
+
+    const { text, usage, response } = await generateText({
+      model: getModel(utilityModel),
+      system: VERSION_COMMENT_SYSTEM_PROMPT,
+      prompt,
+      providerOptions: {
+        gateway: {
+          ...gatewayBase,
+          models: [
+            utilityModel,
+            ...failoverModels.filter(id => id !== utilityModel),
+          ],
+        } satisfies GatewayLanguageModelOptions,
+      },
+    });
+
+    const actualModelId = (response as Record<string, unknown>)?.modelId as
+      | string
+      | undefined;
+    const modelId = actualModelId || utilityModel;
+
+    if (trackingCtx) {
+      const { inputTokens, outputTokens } = extractTokenCounts(
+        usage as Record<string, unknown>,
+      );
+      void trackUsage({
+        workspaceId: trackingCtx.workspaceId,
+        userId: trackingCtx.userId,
+        invocationType: "version_comment",
+        modelId,
+        inputTokens,
+        outputTokens,
+        totalTokens: inputTokens + outputTokens,
+      }).catch(err =>
+        logger.warn("Failed to track version comment usage", { error: err }),
+      );
+    }
+
+    let comment = text.trim();
+    comment = comment.replace(/^["']|["']$/g, "");
+    comment = comment.replace(/\.+$/, "");
+    comment = comment.substring(0, 120);
+
+    if (comment.length < 3) return null;
+    return comment;
+  } catch (err) {
+    logger.error("Version comment generation failed", { error: err });
+    return null;
+  }
+}

--- a/api/src/services/version-comment.service.ts
+++ b/api/src/services/version-comment.service.ts
@@ -9,14 +9,24 @@ import { extractTokenCounts } from "../utils/safe-num";
 
 const logger = loggers.app();
 
-const VERSION_COMMENT_SYSTEM_PROMPT = `You write short commit-message style summaries of changes to a database query.
+const VERSION_COMMENT_SYSTEM_PROMPT = `You are to act as an author of a version comment for a saved database query (SQL, MongoDB, etc).
+Your mission is to create a clean and comprehensive commit message that explains WHAT changed and WHY.
+I'll send you a diff of the query changes, and you convert it into a commit message.
 
 Rules:
-- 1 sentence, under 120 chars, imperative mood ("Add filter on status")
-- Focus on WHAT changed semantically, not line numbers
-- If source is "ai" and an aiPrompt is provided, reflect the user's intent
-- No quotes, no trailing period
-- Return only the summary, nothing else`;
+- Use present tense, imperative mood (e.g. "Add filter", "Refactor subquery", "Fix join condition")
+- Be specific: mention table names, column names, filters, joins, aggregations — not line numbers
+- Maximum 72 characters
+- Do NOT wrap the message in quotes or backticks
+- Do NOT add a trailing period
+- Do NOT add any prefix like "feat:" or "fix:"
+- Do NOT add explanations or descriptions beyond the single commit line
+- Your entire response will be used directly as the version comment
+- Respond with ONLY the commit message text, nothing else
+
+Example:
+Given a diff that changes \`WHERE status = 'active'\` to \`WHERE status = 'active' AND created_at > '2024-01-01'\`, you respond:
+Add created_at filter to restrict to records after 2024-01-01`;
 
 export interface VersionCommentContext {
   previousContent: string;
@@ -76,28 +86,20 @@ export async function generateVersionComment(
 
   if (!diff || isWhitespaceOnly(diff)) return null;
 
-  const truncatedDiff = diff.substring(0, 2000);
+  const truncatedDiff = diff.substring(0, 3000);
 
   const parts: string[] = [];
 
-  if (context.title) {
-    parts.push(`Console: ${context.title}`);
-  }
-
-  parts.push(`Language: ${context.language}`);
-  parts.push(`Change source: ${context.source}`);
-
   if (context.source === "ai" && context.aiPrompt) {
-    parts.push(`User's AI prompt: ${context.aiPrompt.substring(0, 500)}`);
+    parts.push(
+      `The user asked the AI assistant to: ${context.aiPrompt.substring(0, 500)}`,
+    );
+    parts.push("");
   }
 
-  parts.push("");
-  parts.push("Diff:");
+  parts.push(`\`\`\`diff`);
   parts.push(truncatedDiff);
-
-  parts.push("");
-  parts.push("New query:");
-  parts.push(context.newContent.substring(0, 2000));
+  parts.push(`\`\`\``);
 
   const prompt = parts.join("\n");
 
@@ -156,7 +158,7 @@ export async function generateVersionComment(
     let comment = text.trim();
     comment = comment.replace(/^["']|["']$/g, "");
     comment = comment.replace(/\.+$/, "");
-    comment = comment.substring(0, 120);
+    comment = comment.substring(0, 72);
 
     if (comment.length < 3) return null;
     return comment;

--- a/api/src/services/version-comment.service.ts
+++ b/api/src/services/version-comment.service.ts
@@ -6,6 +6,7 @@ import type { GatewayLanguageModelOptions } from "@ai-sdk/gateway";
 import { trackUsage } from "./llm-usage.service";
 import { loggers } from "../logging";
 import { extractTokenCounts } from "../utils/safe-num";
+import { createTwoFilesPatch } from "diff";
 
 const logger = loggers.app();
 
@@ -42,34 +43,27 @@ export interface VersionCommentTrackingContext {
   userId: string;
 }
 
-function computeSimpleLineDiff(a: string, b: string): string {
-  const aLines = a.split("\n");
-  const bLines = b.split("\n");
-  const result: string[] = [];
-
-  const maxLen = Math.max(aLines.length, bLines.length);
-  for (let i = 0; i < maxLen; i++) {
-    const aLine = i < aLines.length ? aLines[i] : undefined;
-    const bLine = i < bLines.length ? bLines[i] : undefined;
-
-    if (aLine === bLine) continue;
-    if (aLine !== undefined && (bLine === undefined || aLine !== bLine)) {
-      result.push(`- ${aLine}`);
-    }
-    if (bLine !== undefined && (aLine === undefined || aLine !== bLine)) {
-      result.push(`+ ${bLine}`);
-    }
-  }
-
-  return result.join("\n");
+function computeUnifiedDiff(a: string, b: string): string {
+  const patch = createTwoFilesPatch("previous", "current", a, b, "", "", {
+    context: 3,
+  });
+  const lines = patch.split("\n");
+  const headerEnd = lines.findIndex(l => l.startsWith("@@"));
+  if (headerEnd === -1) return "";
+  return lines.slice(headerEnd).join("\n");
 }
 
-function isWhitespaceOnly(diff: string): boolean {
-  return diff.split("\n").every(line => {
-    if (!line.startsWith("+ ") && !line.startsWith("- ")) return true;
-    const content = line.slice(2);
-    return content.trim() === "";
-  });
+function hasRealChanges(unifiedDiff: string): boolean {
+  return unifiedDiff
+    .split("\n")
+    .some(
+      l =>
+        (l.startsWith("+") || l.startsWith("-")) &&
+        !l.startsWith("+++") &&
+        !l.startsWith("---") &&
+        !l.startsWith("@@") &&
+        l.slice(1).trim() !== "",
+    );
 }
 
 export function computeDiff(
@@ -79,13 +73,9 @@ export function computeDiff(
   if (previousContent === newContent) return null;
   if (previousContent.trim() === newContent.trim()) return null;
 
-  const diff = computeSimpleLineDiff(
-    previousContent.substring(0, 3000),
-    newContent.substring(0, 3000),
-  );
-
-  if (!diff || isWhitespaceOnly(diff)) return null;
-  return diff.substring(0, 3000);
+  const diff = computeUnifiedDiff(previousContent, newContent);
+  if (!diff || !hasRealChanges(diff)) return null;
+  return diff.substring(0, 4000);
 }
 
 export interface VersionCommentResult {
@@ -109,9 +99,7 @@ export async function generateVersionComment(
     parts.push("");
   }
 
-  parts.push(`\`\`\`diff`);
   parts.push(diff);
-  parts.push(`\`\`\``);
 
   const prompt = parts.join("\n");
 

--- a/api/src/services/version-comment.service.ts
+++ b/api/src/services/version-comment.service.ts
@@ -72,21 +72,33 @@ function isWhitespaceOnly(diff: string): boolean {
   });
 }
 
-export async function generateVersionComment(
-  context: VersionCommentContext,
-  trackingCtx?: VersionCommentTrackingContext,
-): Promise<string | null> {
-  if (context.previousContent === context.newContent) return null;
-  if (context.previousContent.trim() === context.newContent.trim()) return null;
+export function computeDiff(
+  previousContent: string,
+  newContent: string,
+): string | null {
+  if (previousContent === newContent) return null;
+  if (previousContent.trim() === newContent.trim()) return null;
 
   const diff = computeSimpleLineDiff(
-    context.previousContent.substring(0, 3000),
-    context.newContent.substring(0, 3000),
+    previousContent.substring(0, 3000),
+    newContent.substring(0, 3000),
   );
 
   if (!diff || isWhitespaceOnly(diff)) return null;
+  return diff.substring(0, 3000);
+}
 
-  const truncatedDiff = diff.substring(0, 3000);
+export interface VersionCommentResult {
+  comment: string | null;
+  diff: string | null;
+}
+
+export async function generateVersionComment(
+  context: VersionCommentContext,
+  trackingCtx?: VersionCommentTrackingContext,
+): Promise<VersionCommentResult> {
+  const diff = computeDiff(context.previousContent, context.newContent);
+  if (!diff) return { comment: null, diff: null };
 
   const parts: string[] = [];
 
@@ -98,14 +110,14 @@ export async function generateVersionComment(
   }
 
   parts.push(`\`\`\`diff`);
-  parts.push(truncatedDiff);
+  parts.push(diff);
   parts.push(`\`\`\``);
 
   const prompt = parts.join("\n");
 
   try {
     const utilityModel = await getUtilityModelId();
-    if (!utilityModel) return null;
+    if (!utilityModel) return { comment: null, diff };
 
     const failoverModels = await getUtilityModelIds(3);
 
@@ -160,10 +172,10 @@ export async function generateVersionComment(
     comment = comment.replace(/\.+$/, "");
     comment = comment.substring(0, 72);
 
-    if (comment.length < 3) return null;
-    return comment;
+    if (comment.length < 3) return { comment: null, diff };
+    return { comment, diff };
   } catch (err) {
     logger.error("Version comment generation failed", { error: err });
-    return null;
+    return { comment: null, diff };
   }
 }

--- a/app/src/components/Console.tsx
+++ b/app/src/components/Console.tsx
@@ -233,6 +233,8 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
   } = useMonacoConsole({
     consoleId,
     onContentChange: enableVersionControl ? onContentChange : undefined,
+    workspaceId: currentWorkspace?.id,
+    title,
   });
 
   // Track if we've saved the initial version

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -341,6 +341,7 @@ function Editor({
     undefined,
   );
   const [suggestedCommentLoading, setSuggestedCommentLoading] = useState(false);
+  const [saveCommentDiff, setSaveCommentDiff] = useState<string | null>(null);
   const saveCommentAbortRef = useRef<AbortController | null>(null);
   const [pendingCommentSave, setPendingCommentSave] = useState<{
     tabId: string;
@@ -1140,9 +1141,10 @@ function Editor({
         tabId,
         { newContent: contentToSave, source: "user" },
         controller.signal,
-      ).then(comment => {
+      ).then(result => {
         if (!controller.signal.aborted) {
-          setSuggestedComment(comment ?? undefined);
+          setSuggestedComment(result.comment ?? undefined);
+          setSaveCommentDiff(result.diff);
           setSuggestedCommentLoading(false);
         }
       });
@@ -1163,6 +1165,7 @@ function Editor({
     setCommentDialogOpen(false);
     saveCommentAbortRef.current?.abort();
     setSuggestedCommentLoading(false);
+    setSaveCommentDiff(null);
     const pending = pendingCommentSave;
     setPendingCommentSave(null);
     if (!pending) return;
@@ -1179,6 +1182,7 @@ function Editor({
     setCommentDialogOpen(false);
     saveCommentAbortRef.current?.abort();
     setSuggestedCommentLoading(false);
+    setSaveCommentDiff(null);
     const pending = pendingCommentSave;
     setPendingCommentSave(null);
     pending?.resolve(false);
@@ -2027,6 +2031,7 @@ function Editor({
         title="Save Console"
         defaultComment={suggestedComment}
         loading={suggestedCommentLoading}
+        diff={saveCommentDiff}
       />
 
       {/* Version history panel */}

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -340,6 +340,8 @@ function Editor({
   const [suggestedComment, setSuggestedComment] = useState<string | undefined>(
     undefined,
   );
+  const [suggestedCommentLoading, setSuggestedCommentLoading] = useState(false);
+  const saveCommentAbortRef = useRef<AbortController | null>(null);
   const [pendingCommentSave, setPendingCommentSave] = useState<{
     tabId: string;
     content: string;
@@ -396,6 +398,9 @@ function Editor({
   );
   const setActiveTab = useConsoleStore(state => state.setActiveTab);
   const getVersionManager = useConsoleStore(state => state.getVersionManager);
+  const generateSaveComment = useConsoleStore(
+    state => state.generateSaveComment,
+  );
   const executeQuery = useConsoleStore(state => state.executeQuery);
   const cancelQuery = useConsoleStore(state => state.cancelQuery);
   const saveConsole = useConsoleStore(state => state.saveConsole);
@@ -1121,9 +1126,36 @@ function Editor({
 
     const vm = getVersionManager(tabId);
     const aiComments = vm?.getRecentAiComments() ?? [];
-    setSuggestedComment(
-      aiComments.length > 0 ? aiComments.join("; ") : undefined,
-    );
+    const existingComment =
+      aiComments.length > 0 ? aiComments.join("; ") : undefined;
+    setSuggestedComment(existingComment);
+
+    if (!existingComment && currentWorkspace?.id) {
+      const previousContent = vm?.getFirstContent() ?? "";
+      if (previousContent !== contentToSave) {
+        saveCommentAbortRef.current?.abort();
+        const controller = new AbortController();
+        saveCommentAbortRef.current = controller;
+        setSuggestedCommentLoading(true);
+        generateSaveComment(
+          currentWorkspace.id,
+          tabId,
+          {
+            previousContent,
+            newContent: contentToSave,
+            language: "sql",
+            source: "user",
+            title: tabs[tabId]?.title,
+          },
+          controller.signal,
+        ).then(comment => {
+          if (!controller.signal.aborted) {
+            setSuggestedComment(comment ?? undefined);
+            setSuggestedCommentLoading(false);
+          }
+        });
+      }
+    }
 
     return new Promise<boolean>(resolve => {
       setPendingCommentSave({
@@ -1138,6 +1170,8 @@ function Editor({
 
   const handleCommentSaveConfirm = async (comment: string) => {
     setCommentDialogOpen(false);
+    saveCommentAbortRef.current?.abort();
+    setSuggestedCommentLoading(false);
     const pending = pendingCommentSave;
     setPendingCommentSave(null);
     if (!pending) return;
@@ -1152,6 +1186,8 @@ function Editor({
 
   const handleCommentSaveCancel = () => {
     setCommentDialogOpen(false);
+    saveCommentAbortRef.current?.abort();
+    setSuggestedCommentLoading(false);
     const pending = pendingCommentSave;
     setPendingCommentSave(null);
     pending?.resolve(false);
@@ -1999,6 +2035,7 @@ function Editor({
         onCancel={handleCommentSaveCancel}
         title="Save Console"
         defaultComment={suggestedComment}
+        loading={suggestedCommentLoading}
       />
 
       {/* Version history panel */}

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -337,6 +337,9 @@ function Editor({
 
   // Save comment dialog state (version commit message)
   const [commentDialogOpen, setCommentDialogOpen] = useState(false);
+  const [suggestedComment, setSuggestedComment] = useState<string | undefined>(
+    undefined,
+  );
   const [pendingCommentSave, setPendingCommentSave] = useState<{
     tabId: string;
     content: string;
@@ -392,6 +395,7 @@ function Editor({
     state => state.updateResultsViewMode,
   );
   const setActiveTab = useConsoleStore(state => state.setActiveTab);
+  const getVersionManager = useConsoleStore(state => state.getVersionManager);
   const executeQuery = useConsoleStore(state => state.executeQuery);
   const cancelQuery = useConsoleStore(state => state.cancelQuery);
   const saveConsole = useConsoleStore(state => state.saveConsole);
@@ -1114,6 +1118,12 @@ function Editor({
       setSaveDialogOpen(true);
       return false;
     }
+
+    const vm = getVersionManager(tabId);
+    const aiComments = vm?.getRecentAiComments() ?? [];
+    setSuggestedComment(
+      aiComments.length > 0 ? aiComments.join("; ") : undefined,
+    );
 
     return new Promise<boolean>(resolve => {
       setPendingCommentSave({
@@ -1988,6 +1998,7 @@ function Editor({
         onSave={handleCommentSaveConfirm}
         onCancel={handleCommentSaveCancel}
         title="Save Console"
+        defaultComment={suggestedComment}
       />
 
       {/* Version history panel */}

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -398,6 +398,9 @@ function Editor({
   );
   const setActiveTab = useConsoleStore(state => state.setActiveTab);
   const getVersionManager = useConsoleStore(state => state.getVersionManager);
+  const getLastSavedContent = useConsoleStore(
+    state => state.getLastSavedContent,
+  );
   const generateSaveComment = useConsoleStore(
     state => state.generateSaveComment,
   );
@@ -1131,7 +1134,7 @@ function Editor({
     setSuggestedComment(existingComment);
 
     if (!existingComment && currentWorkspace?.id) {
-      const previousContent = vm?.getFirstContent() ?? "";
+      const previousContent = getLastSavedContent(tabId) ?? "";
       if (previousContent !== contentToSave) {
         saveCommentAbortRef.current?.abort();
         const controller = new AbortController();

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -398,9 +398,6 @@ function Editor({
   );
   const setActiveTab = useConsoleStore(state => state.setActiveTab);
   const getVersionManager = useConsoleStore(state => state.getVersionManager);
-  const getLastSavedContent = useConsoleStore(
-    state => state.getLastSavedContent,
-  );
   const generateSaveComment = useConsoleStore(
     state => state.generateSaveComment,
   );
@@ -1134,30 +1131,21 @@ function Editor({
     setSuggestedComment(existingComment);
 
     if (!existingComment && currentWorkspace?.id) {
-      const previousContent = getLastSavedContent(tabId) ?? "";
-      if (previousContent !== contentToSave) {
-        saveCommentAbortRef.current?.abort();
-        const controller = new AbortController();
-        saveCommentAbortRef.current = controller;
-        setSuggestedCommentLoading(true);
-        generateSaveComment(
-          currentWorkspace.id,
-          tabId,
-          {
-            previousContent,
-            newContent: contentToSave,
-            language: "sql",
-            source: "user",
-            title: tabs[tabId]?.title,
-          },
-          controller.signal,
-        ).then(comment => {
-          if (!controller.signal.aborted) {
-            setSuggestedComment(comment ?? undefined);
-            setSuggestedCommentLoading(false);
-          }
-        });
-      }
+      saveCommentAbortRef.current?.abort();
+      const controller = new AbortController();
+      saveCommentAbortRef.current = controller;
+      setSuggestedCommentLoading(true);
+      generateSaveComment(
+        currentWorkspace.id,
+        tabId,
+        { newContent: contentToSave, source: "user" },
+        controller.signal,
+      ).then(comment => {
+        if (!controller.signal.aborted) {
+          setSuggestedComment(comment ?? undefined);
+          setSuggestedCommentLoading(false);
+        }
+      });
     }
 
     return new Promise<boolean>(resolve => {

--- a/app/src/components/SaveCommentDialog.tsx
+++ b/app/src/components/SaveCommentDialog.tsx
@@ -143,14 +143,19 @@ export function SaveCommentDialog({
                   lineHeight: 1.4,
                   "& .diff-add": { color: "success.main" },
                   "& .diff-del": { color: "error.main" },
+                  "& .diff-hunk": { color: "info.main", opacity: 0.7 },
                 }}
               >
                 {diff.split("\n").map((line, i) => {
-                  const cls = line.startsWith("+ ")
-                    ? "diff-add"
-                    : line.startsWith("- ")
-                      ? "diff-del"
-                      : undefined;
+                  const isHunk = line.startsWith("@@");
+                  const cls =
+                    line.startsWith("+") && !line.startsWith("+++")
+                      ? "diff-add"
+                      : line.startsWith("-") && !line.startsWith("---")
+                        ? "diff-del"
+                        : isHunk
+                          ? "diff-hunk"
+                          : undefined;
                   return (
                     <Box
                       component="span"

--- a/app/src/components/SaveCommentDialog.tsx
+++ b/app/src/components/SaveCommentDialog.tsx
@@ -14,6 +14,7 @@ interface SaveCommentDialogProps {
   onCancel: () => void;
   title?: string;
   defaultComment?: string;
+  loading?: boolean;
 }
 
 export function SaveCommentDialog({
@@ -22,12 +23,23 @@ export function SaveCommentDialog({
   onCancel,
   title = "Save",
   defaultComment,
+  loading,
 }: SaveCommentDialogProps) {
   const [comment, setComment] = useState("");
+  const [userEdited, setUserEdited] = useState(false);
 
   useEffect(() => {
-    if (open) setComment(defaultComment ?? "");
-  }, [open, defaultComment]);
+    if (open) {
+      setComment(defaultComment ?? "");
+      setUserEdited(false);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (defaultComment && !userEdited) {
+      setComment(defaultComment);
+    }
+  }, [defaultComment, userEdited]);
 
   const handleSave = useCallback(() => {
     onSave(comment);
@@ -53,9 +65,16 @@ export function SaveCommentDialog({
           multiline
           minRows={2}
           maxRows={4}
-          placeholder="Describe your changes (optional)"
+          placeholder={
+            loading
+              ? "Generating comment..."
+              : "Describe your changes (optional)"
+          }
           value={comment}
-          onChange={e => setComment(e.target.value)}
+          onChange={e => {
+            setComment(e.target.value);
+            setUserEdited(true);
+          }}
           onKeyDown={handleKeyDown}
           variant="outlined"
           size="small"

--- a/app/src/components/SaveCommentDialog.tsx
+++ b/app/src/components/SaveCommentDialog.tsx
@@ -13,6 +13,7 @@ interface SaveCommentDialogProps {
   onSave: (comment: string) => void;
   onCancel: () => void;
   title?: string;
+  defaultComment?: string;
 }
 
 export function SaveCommentDialog({
@@ -20,12 +21,13 @@ export function SaveCommentDialog({
   onSave,
   onCancel,
   title = "Save",
+  defaultComment,
 }: SaveCommentDialogProps) {
   const [comment, setComment] = useState("");
 
   useEffect(() => {
-    if (open) setComment("");
-  }, [open]);
+    if (open) setComment(defaultComment ?? "");
+  }, [open, defaultComment]);
 
   const handleSave = useCallback(() => {
     onSave(comment);

--- a/app/src/components/SaveCommentDialog.tsx
+++ b/app/src/components/SaveCommentDialog.tsx
@@ -6,7 +6,11 @@ import {
   DialogActions,
   TextField,
   Button,
+  Box,
+  LinearProgress,
+  Typography,
 } from "@mui/material";
+import { Sparkles } from "lucide-react";
 
 interface SaveCommentDialogProps {
   open: boolean;
@@ -65,11 +69,7 @@ export function SaveCommentDialog({
           multiline
           minRows={2}
           maxRows={4}
-          placeholder={
-            loading
-              ? "Generating comment..."
-              : "Describe your changes (optional)"
-          }
+          placeholder="Describe your changes (optional)"
           value={comment}
           onChange={e => {
             setComment(e.target.value);
@@ -80,6 +80,29 @@ export function SaveCommentDialog({
           size="small"
           sx={{ mt: 1 }}
         />
+        {loading && (
+          <Box sx={{ mt: 1.5 }}>
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 0.75,
+                mb: 0.5,
+              }}
+            >
+              <Sparkles size={14} />
+              <Typography variant="caption" color="text.secondary">
+                Generating comment with AI...
+              </Typography>
+            </Box>
+            <LinearProgress
+              sx={{
+                borderRadius: 1,
+                height: 3,
+              }}
+            />
+          </Box>
+        )}
       </DialogContent>
       <DialogActions>
         <Button onClick={onCancel} size="small">

--- a/app/src/components/SaveCommentDialog.tsx
+++ b/app/src/components/SaveCommentDialog.tsx
@@ -9,8 +9,10 @@ import {
   Box,
   LinearProgress,
   Typography,
+  Collapse,
+  IconButton,
 } from "@mui/material";
-import { Sparkles } from "lucide-react";
+import { Sparkles, ChevronDown, ChevronRight } from "lucide-react";
 
 interface SaveCommentDialogProps {
   open: boolean;
@@ -19,6 +21,7 @@ interface SaveCommentDialogProps {
   title?: string;
   defaultComment?: string;
   loading?: boolean;
+  diff?: string | null;
 }
 
 export function SaveCommentDialog({
@@ -28,14 +31,17 @@ export function SaveCommentDialog({
   title = "Save",
   defaultComment,
   loading,
+  diff,
 }: SaveCommentDialogProps) {
   const [comment, setComment] = useState("");
   const [userEdited, setUserEdited] = useState(false);
+  const [diffExpanded, setDiffExpanded] = useState(false);
 
   useEffect(() => {
     if (open) {
       setComment(defaultComment ?? "");
       setUserEdited(false);
+      setDiffExpanded(false);
     }
   }, [open]);
 
@@ -95,12 +101,70 @@ export function SaveCommentDialog({
                 Generating comment with AI...
               </Typography>
             </Box>
-            <LinearProgress
+            <LinearProgress sx={{ borderRadius: 1, height: 3 }} />
+          </Box>
+        )}
+        {diff && (
+          <Box sx={{ mt: 1.5 }}>
+            <Box
               sx={{
-                borderRadius: 1,
-                height: 3,
+                display: "flex",
+                alignItems: "center",
+                cursor: "pointer",
+                userSelect: "none",
               }}
-            />
+              onClick={() => setDiffExpanded(v => !v)}
+            >
+              <IconButton size="small" sx={{ p: 0, mr: 0.5 }}>
+                {diffExpanded ? (
+                  <ChevronDown size={14} />
+                ) : (
+                  <ChevronRight size={14} />
+                )}
+              </IconButton>
+              <Typography variant="caption" color="text.secondary">
+                Changes since last save
+              </Typography>
+            </Box>
+            <Collapse in={diffExpanded}>
+              <Box
+                component="pre"
+                sx={{
+                  mt: 0.5,
+                  p: 1,
+                  borderRadius: 1,
+                  bgcolor: "action.hover",
+                  fontSize: "0.7rem",
+                  fontFamily: "monospace",
+                  overflow: "auto",
+                  maxHeight: 200,
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-word",
+                  lineHeight: 1.4,
+                  "& .diff-add": { color: "success.main" },
+                  "& .diff-del": { color: "error.main" },
+                }}
+              >
+                {diff.split("\n").map((line, i) => {
+                  const cls = line.startsWith("+ ")
+                    ? "diff-add"
+                    : line.startsWith("- ")
+                      ? "diff-del"
+                      : undefined;
+                  return (
+                    <Box
+                      component="span"
+                      key={i}
+                      className={cls}
+                      sx={{ display: "block" }}
+                    >
+                      {line}
+                      {"\n"}
+                    </Box>
+                  );
+                })}
+              </Box>
+            </Collapse>
           </Box>
         )}
       </DialogContent>

--- a/app/src/hooks/useMonacoConsole.ts
+++ b/app/src/hooks/useMonacoConsole.ts
@@ -45,7 +45,6 @@ export const useMonacoConsole = (options: UseMonacoConsoleOptions) => {
   const [canUndo, setCanUndo] = useState(false);
   const [canRedo, setCanRedo] = useState(false);
 
-  // Get version manager and comment generator from store
   const { getVersionManager, generateVersionComment } = useConsoleStore();
 
   // Get the version manager for this console

--- a/app/src/hooks/useMonacoConsole.ts
+++ b/app/src/hooks/useMonacoConsole.ts
@@ -26,17 +26,27 @@ interface UseMonacoConsoleOptions {
   consoleId: string;
   onContentChange?: (content: string) => void;
   onVersionChange?: (canUndo: boolean, canRedo: boolean) => void;
+  workspaceId?: string;
+  language?: string;
+  title?: string;
 }
 
 export const useMonacoConsole = (options: UseMonacoConsoleOptions) => {
-  const { consoleId, onContentChange, onVersionChange } = options;
+  const {
+    consoleId,
+    onContentChange,
+    onVersionChange,
+    workspaceId,
+    language,
+    title,
+  } = options;
   const editorRef = useRef<any>(null);
   const isApplyingModificationRef = useRef(false);
   const [canUndo, setCanUndo] = useState(false);
   const [canRedo, setCanRedo] = useState(false);
 
-  // Get version manager from store
-  const { getVersionManager } = useConsoleStore();
+  // Get version manager and comment generator from store
+  const { getVersionManager, generateVersionComment } = useConsoleStore();
 
   // Get the version manager for this console
   const getVersionManagerForConsole = useCallback(() => {
@@ -58,6 +68,30 @@ export const useMonacoConsole = (options: UseMonacoConsoleOptions) => {
       onVersionChange(newCanUndo, newCanRedo);
     }
   }, [getVersionManagerForConsole, onVersionChange]);
+
+  const requestVersionComment = useCallback(
+    (
+      versionId: string,
+      previousContent: string,
+      newContent: string,
+      source: "user" | "ai",
+      aiPrompt?: string,
+    ) => {
+      if (!workspaceId) return;
+      if (previousContent === newContent) return;
+      if (previousContent.trim() === newContent.trim()) return;
+
+      generateVersionComment(workspaceId, consoleId, versionId, {
+        previousContent,
+        newContent,
+        language: language || "sql",
+        source,
+        aiPrompt,
+        title,
+      });
+    },
+    [workspaceId, consoleId, language, title, generateVersionComment],
+  );
 
   // Set the editor reference
   const setEditor = useCallback((editor: any) => {
@@ -193,11 +227,13 @@ export const useMonacoConsole = (options: UseMonacoConsoleOptions) => {
 
         // Save the new state after modification
         const newContent = model.getValue();
-        versionManager.saveVersion(
+        const aiVersionId = versionManager.saveVersion(
           newContent,
           "ai",
           `AI ${modification.action}`,
         );
+
+        requestVersionComment(aiVersionId, currentContent, newContent, "ai");
 
         // Flash the editor to indicate change
         flashEditor(editor);
@@ -216,7 +252,12 @@ export const useMonacoConsole = (options: UseMonacoConsoleOptions) => {
       // Focus the editor
       editor.focus();
     },
-    [getVersionManagerForConsole, onContentChange, updateVersionState],
+    [
+      getVersionManagerForConsole,
+      onContentChange,
+      updateVersionState,
+      requestVersionComment,
+    ],
   );
 
   // Undo functionality
@@ -311,11 +352,25 @@ export const useMonacoConsole = (options: UseMonacoConsoleOptions) => {
         const versionManager = getVersionManagerForConsole();
         if (!versionManager) return;
 
-        versionManager.saveVersion(content, "user", description);
+        const versionId = versionManager.saveVersion(
+          content,
+          "user",
+          description,
+        );
         updateVersionState();
+
+        if (
+          description !== "Initial content" &&
+          description !== "Before AI modification"
+        ) {
+          const previousContent = versionManager.getPreviousContent(versionId);
+          if (previousContent !== null) {
+            requestVersionComment(versionId, previousContent, content, "user");
+          }
+        }
       }
     },
-    [getVersionManagerForConsole, updateVersionState],
+    [getVersionManagerForConsole, updateVersionState, requestVersionComment],
   );
 
   // Clear version history

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -62,6 +62,7 @@ interface ConsoleActions {
 
   // Versioning
   getVersionManager: (consoleId: string) => ConsoleVersionManager | null;
+  getLastSavedContent: (consoleId: string) => string | null;
 
   // API operations
   loadConsole: (workspaceId: string, consoleId: string) => Promise<void>;
@@ -152,10 +153,9 @@ const initialState: ConsoleState = {
 
 // Store version managers for each console tab
 const versionManagers = new Map<string, ConsoleVersionManager>();
+const lastSavedContent = new Map<string, string>();
 
-// Abort controllers for in-flight version comment generation (per console ID)
 const versionCommentControllers = new Map<string, AbortController>();
-// Debounce timers for version comment generation (per console ID)
 const versionCommentTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 // Debounce timers for draft console saves (per console ID)
@@ -363,6 +363,7 @@ export const useConsoleStore = create<ConsoleStore>()(
 
       // Versioning
       getVersionManager: consoleId => versionManagers.get(consoleId) || null,
+      getLastSavedContent: consoleId => lastSavedContent.get(consoleId) ?? null,
 
       // API operations
       loadConsole: async (workspaceId, consoleId) => {
@@ -386,6 +387,7 @@ export const useConsoleStore = create<ConsoleStore>()(
           if (res.success) {
             const content = res.content || "";
             const filePath = res.path || res.name;
+            lastSavedContent.set(res.id, content);
 
             get().openTab({
               id: res.id,
@@ -429,6 +431,7 @@ export const useConsoleStore = create<ConsoleStore>()(
           if (res.success) {
             const content = res.content || "";
             const filePath = res.path || res.name;
+            lastSavedContent.set(res.id, content);
 
             get().openTab({
               id: res.id,
@@ -460,6 +463,7 @@ export const useConsoleStore = create<ConsoleStore>()(
 
           if (res.success) {
             const filePath = res.path || res.name;
+            lastSavedContent.set(consoleId, res.content || "");
             set(state => {
               const tab = state.tabs[consoleId];
               if (tab) {
@@ -543,9 +547,11 @@ export const useConsoleStore = create<ConsoleStore>()(
             return { success: false, error: res.error || "Save failed" };
           }
 
-          return res.success
-            ? { success: true, path: cleanPath }
-            : { success: false, error: res.error || "Save failed" };
+          if (res.success) {
+            lastSavedContent.set(tabId, content);
+            return { success: true, path: cleanPath };
+          }
+          return { success: false, error: res.error || "Save failed" };
         } catch (e) {
           return {
             success: false,

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -363,7 +363,16 @@ export const useConsoleStore = create<ConsoleStore>()(
 
       // Versioning
       getVersionManager: consoleId => versionManagers.get(consoleId) || null,
-      getLastSavedContent: consoleId => lastSavedContent.get(consoleId) ?? null,
+      getLastSavedContent: consoleId => {
+        const cached = lastSavedContent.get(consoleId);
+        if (cached !== undefined) return cached;
+        const tab = get().tabs[consoleId];
+        if (tab?.isSaved && tab.content) {
+          lastSavedContent.set(consoleId, tab.content);
+          return tab.content;
+        }
+        return null;
+      },
 
       // API operations
       loadConsole: async (workspaceId, consoleId) => {

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -62,7 +62,6 @@ interface ConsoleActions {
 
   // Versioning
   getVersionManager: (consoleId: string) => ConsoleVersionManager | null;
-  getLastSavedContent: (consoleId: string) => string | null;
 
   // API operations
   loadConsole: (workspaceId: string, consoleId: string) => Promise<void>;
@@ -131,11 +130,8 @@ interface ConsoleActions {
     workspaceId: string,
     consoleId: string,
     payload: {
-      previousContent: string;
       newContent: string;
-      language: string;
       source: "user" | "ai";
-      title?: string;
     },
     signal?: AbortSignal,
   ) => Promise<string | null>;
@@ -153,8 +149,6 @@ const initialState: ConsoleState = {
 
 // Store version managers for each console tab
 const versionManagers = new Map<string, ConsoleVersionManager>();
-const lastSavedContent = new Map<string, string>();
-
 const versionCommentControllers = new Map<string, AbortController>();
 const versionCommentTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
@@ -363,16 +357,6 @@ export const useConsoleStore = create<ConsoleStore>()(
 
       // Versioning
       getVersionManager: consoleId => versionManagers.get(consoleId) || null,
-      getLastSavedContent: consoleId => {
-        const cached = lastSavedContent.get(consoleId);
-        if (cached !== undefined) return cached;
-        const tab = get().tabs[consoleId];
-        if (tab?.isSaved && tab.content) {
-          lastSavedContent.set(consoleId, tab.content);
-          return tab.content;
-        }
-        return null;
-      },
 
       // API operations
       loadConsole: async (workspaceId, consoleId) => {
@@ -396,7 +380,6 @@ export const useConsoleStore = create<ConsoleStore>()(
           if (res.success) {
             const content = res.content || "";
             const filePath = res.path || res.name;
-            lastSavedContent.set(res.id, content);
 
             get().openTab({
               id: res.id,
@@ -440,7 +423,6 @@ export const useConsoleStore = create<ConsoleStore>()(
           if (res.success) {
             const content = res.content || "";
             const filePath = res.path || res.name;
-            lastSavedContent.set(res.id, content);
 
             get().openTab({
               id: res.id,
@@ -472,7 +454,6 @@ export const useConsoleStore = create<ConsoleStore>()(
 
           if (res.success) {
             const filePath = res.path || res.name;
-            lastSavedContent.set(consoleId, res.content || "");
             set(state => {
               const tab = state.tabs[consoleId];
               if (tab) {
@@ -557,7 +538,6 @@ export const useConsoleStore = create<ConsoleStore>()(
           }
 
           if (res.success) {
-            lastSavedContent.set(tabId, content);
             return { success: true, path: cleanPath };
           }
           return { success: false, error: res.error || "Save failed" };

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -126,6 +126,18 @@ interface ConsoleActions {
       title?: string;
     },
   ) => void;
+  generateSaveComment: (
+    workspaceId: string,
+    consoleId: string,
+    payload: {
+      previousContent: string;
+      newContent: string;
+      language: string;
+      source: "user" | "ai";
+      title?: string;
+    },
+    signal?: AbortSignal,
+  ) => Promise<string | null>;
 }
 
 type ConsoleStore = ConsoleState & ConsoleActions;
@@ -655,6 +667,22 @@ export const useConsoleStore = create<ConsoleStore>()(
         } else {
           const timer = setTimeout(() => void fire(), DEBOUNCE_MS);
           versionCommentTimers.set(consoleId, timer);
+        }
+      },
+
+      generateSaveComment: async (workspaceId, consoleId, payload, signal) => {
+        try {
+          const res = await apiClient.post<{
+            success: boolean;
+            comment: string | null;
+          }>(
+            `/workspaces/${workspaceId}/consoles/${consoleId}/version-comment`,
+            payload,
+            { signal },
+          );
+          return res.success ? (res.comment ?? null) : null;
+        } catch {
+          return null;
         }
       },
 

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -113,6 +113,19 @@ interface ConsoleActions {
     databaseId?: string,
     databaseName?: string,
   ) => void;
+  generateVersionComment: (
+    workspaceId: string,
+    consoleId: string,
+    versionId: string,
+    payload: {
+      previousContent: string;
+      newContent: string;
+      language: string;
+      source: "user" | "ai";
+      aiPrompt?: string;
+      title?: string;
+    },
+  ) => void;
 }
 
 type ConsoleStore = ConsoleState & ConsoleActions;
@@ -127,6 +140,11 @@ const initialState: ConsoleState = {
 
 // Store version managers for each console tab
 const versionManagers = new Map<string, ConsoleVersionManager>();
+
+// Abort controllers for in-flight version comment generation (per console ID)
+const versionCommentControllers = new Map<string, AbortController>();
+// Debounce timers for version comment generation (per console ID)
+const versionCommentTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 // Debounce timers for draft console saves (per console ID)
 const draftSaveTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -580,6 +598,63 @@ export const useConsoleStore = create<ConsoleStore>()(
             success: false,
             error: e instanceof Error ? e.message : "Cancel failed",
           };
+        }
+      },
+
+      generateVersionComment: (workspaceId, consoleId, versionId, payload) => {
+        const DEBOUNCE_MS = 800;
+
+        const existingTimer = versionCommentTimers.get(consoleId);
+        if (existingTimer) {
+          clearTimeout(existingTimer);
+        }
+
+        const vm = versionManagers.get(consoleId);
+        if (vm) {
+          vm.updateVersion(versionId, { aiCommentStatus: "pending" });
+        }
+
+        const fire = async () => {
+          versionCommentTimers.delete(consoleId);
+
+          const prev = versionCommentControllers.get(consoleId);
+          if (prev) prev.abort();
+
+          const controller = new AbortController();
+          versionCommentControllers.set(consoleId, controller);
+
+          try {
+            const res = await apiClient.post<{
+              success: boolean;
+              comment: string | null;
+            }>(
+              `/workspaces/${workspaceId}/consoles/${consoleId}/version-comment`,
+              payload,
+              { signal: controller.signal },
+            );
+
+            if (res.success && res.comment && vm) {
+              vm.updateVersion(versionId, {
+                aiComment: res.comment,
+                aiCommentStatus: "done",
+              });
+            } else if (vm) {
+              vm.updateVersion(versionId, { aiCommentStatus: "failed" });
+            }
+          } catch (_e) {
+            if (vm) {
+              vm.updateVersion(versionId, { aiCommentStatus: "failed" });
+            }
+          } finally {
+            versionCommentControllers.delete(consoleId);
+          }
+        };
+
+        if (payload.source === "ai") {
+          void fire();
+        } else {
+          const timer = setTimeout(() => void fire(), DEBOUNCE_MS);
+          versionCommentTimers.set(consoleId, timer);
         }
       },
 

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -134,7 +134,7 @@ interface ConsoleActions {
       source: "user" | "ai";
     },
     signal?: AbortSignal,
-  ) => Promise<string | null>;
+  ) => Promise<{ comment: string | null; diff: string | null }>;
 }
 
 type ConsoleStore = ConsoleState & ConsoleActions;
@@ -670,14 +670,17 @@ export const useConsoleStore = create<ConsoleStore>()(
           const res = await apiClient.post<{
             success: boolean;
             comment: string | null;
+            diff: string | null;
           }>(
             `/workspaces/${workspaceId}/consoles/${consoleId}/version-comment`,
             payload,
             { signal },
           );
-          return res.success ? (res.comment ?? null) : null;
+          return res.success
+            ? { comment: res.comment ?? null, diff: res.diff ?? null }
+            : { comment: null, diff: null };
         } catch {
-          return null;
+          return { comment: null, diff: null };
         }
       },
 

--- a/app/src/utils/ConsoleVersionManager.ts
+++ b/app/src/utils/ConsoleVersionManager.ts
@@ -79,6 +79,17 @@ export class ConsoleVersionManager {
     return this.versions[index - 1].content;
   }
 
+  getRecentAiComments(): string[] {
+    const comments: string[] = [];
+    for (let i = this.versions.length - 1; i >= 0; i--) {
+      const v = this.versions[i];
+      if (v.aiComment && v.aiCommentStatus === "done") {
+        comments.unshift(v.aiComment);
+      }
+    }
+    return comments;
+  }
+
   undo(): string | null {
     if (!this.canUndo()) return null;
 

--- a/app/src/utils/ConsoleVersionManager.ts
+++ b/app/src/utils/ConsoleVersionManager.ts
@@ -5,6 +5,8 @@ export interface ConsoleVersion {
   source: "user" | "ai";
   description?: string;
   aiPrompt?: string;
+  aiComment?: string;
+  aiCommentStatus?: "pending" | "done" | "failed";
 }
 
 export interface VersionHistory {
@@ -13,6 +15,8 @@ export interface VersionHistory {
   timestamp: Date;
   source: "user" | "ai";
   description?: string;
+  aiComment?: string;
+  aiCommentStatus?: "pending" | "done" | "failed";
   isCurrent: boolean;
 }
 
@@ -34,7 +38,7 @@ export class ConsoleVersionManager {
     source: "user" | "ai",
     description?: string,
     aiPrompt?: string,
-  ): void {
+  ): string {
     // Remove any versions after the current index (for redo functionality)
     if (this.currentIndex < this.versions.length - 1) {
       this.versions = this.versions.slice(0, this.currentIndex + 1);
@@ -58,6 +62,21 @@ export class ConsoleVersionManager {
 
     this.currentIndex = this.versions.length - 1;
     this.persistToStorage();
+    return newVersion.id;
+  }
+
+  updateVersion(id: string, patch: Partial<ConsoleVersion>): boolean {
+    const version = this.versions.find(v => v.id === id);
+    if (!version) return false;
+    Object.assign(version, patch);
+    this.persistToStorage();
+    return true;
+  }
+
+  getPreviousContent(id: string): string | null {
+    const index = this.versions.findIndex(v => v.id === id);
+    if (index <= 0) return null;
+    return this.versions[index - 1].content;
   }
 
   undo(): string | null {

--- a/app/src/utils/ConsoleVersionManager.ts
+++ b/app/src/utils/ConsoleVersionManager.ts
@@ -90,6 +90,10 @@ export class ConsoleVersionManager {
     return comments;
   }
 
+  getFirstContent(): string | null {
+    return this.versions.length > 0 ? this.versions[0].content : null;
+  }
+
   undo(): string | null {
     if (!this.canUndo()) return null;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       cron-parser:
         specifier: ^5.3.0
         version: 5.3.0
+      diff:
+        specifier: ^9.0.0
+        version: 9.0.0
       dotenv:
         specifier: ^16.5.0
         version: 16.5.0
@@ -226,6 +229,9 @@ importers:
       '@types/cors':
         specifier: ^2.8.19
         version: 2.8.19
+      '@types/diff':
+        specifier: ^8.0.0
+        version: 8.0.0
       '@types/inquirer':
         specifier: ^8.2.11
         version: 8.2.11
@@ -1713,155 +1719,183 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -2158,24 +2192,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@14.2.33':
     resolution: {integrity: sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@14.2.33':
     resolution: {integrity: sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@14.2.33':
     resolution: {integrity: sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@14.2.33':
     resolution: {integrity: sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==}
@@ -2851,56 +2889,67 @@ packages:
     resolution: {integrity: sha512-wC53ZNDgt0pqx5xCAgNunkTzFE8GTgdZ9EwYGVcg+jEjJdZGtq9xPjDnFgfFozQI/Xm1mh+D9YlYtl+ueswNEg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.41.1':
     resolution: {integrity: sha512-jwKCca1gbZkZLhLRtsrka5N8sFAaxrGz/7wRJ8Wwvq3jug7toO21vWlViihG85ei7uJTpzbXZRcORotE+xyrLA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.41.1':
     resolution: {integrity: sha512-g0UBcNknsmmNQ8V2d/zD2P7WWfJKU0F1nu0k5pW4rvdb+BIqMm8ToluW/eeRmxCared5dD76lS04uL4UaNgpNA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.41.1':
     resolution: {integrity: sha512-XZpeGB5TKEZWzIrj7sXr+BEaSgo/ma/kCgrZgL0oo5qdB1JlTzIYQKel/RmhT6vMAvOdM2teYlAaOGJpJ9lahg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.41.1':
     resolution: {integrity: sha512-bkCfDJ4qzWfFRCNt5RVV4DOw6KEgFTUZi2r2RuYhGWC8WhCA8lCAJhDeAmrM/fdiAH54m0mA0Vk2FGRPyzI+tw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.41.1':
     resolution: {integrity: sha512-3mr3Xm+gvMX+/8EKogIZSIEF0WUu0HL9di+YWlJpO8CQBnoLAEL/roTCxuLncEdgcfJcvA4UMOf+2dnjl4Ut1A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.41.1':
     resolution: {integrity: sha512-3rwCIh6MQ1LGrvKJitQjZFuQnT2wxfU+ivhNBzmxXTXPllewOF7JR1s2vMX/tWtUYFgphygxjqMl76q4aMotGw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.41.1':
     resolution: {integrity: sha512-LdIUOb3gvfmpkgFZuccNa2uYiqtgZAz3PTzjuM5bH3nvuy9ty6RGc/Q0+HDFrHrizJGVpjnTZ1yS5TNNjFlklw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.41.1':
     resolution: {integrity: sha512-oIE6M8WC9ma6xYqjvPhzZYk6NbobIURvP/lEbh7FWplcMO6gn7MM2yHKA1eC/GvYwzNKK/1LYgqzdkZ8YFxR8g==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.41.1':
     resolution: {integrity: sha512-cWBOvayNvA+SyeQMp79BHPK8ws6sHSsYnK5zDcsC3Hsxr1dgTABKjMnMslPq1DvZIp6uO7kIWhiGwaTdR4Og9A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.41.1':
     resolution: {integrity: sha512-y5CbN44M+pUCdGDlZFzGGBSKCA4A/J2ZH4edTYSSxFg7ce1Xt3GtydbVKWLlzL+INfFIZAEg1ZV6hh9+QQf9YQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.41.1':
     resolution: {integrity: sha512-lZkCxIrjlJlMt1dLO/FbpZbzt6J/A8p4DnqzSa4PWqPEUUUnzXLeki/iyPLfV0BmHItlYgHUqJe+3KiyydmiNQ==}
@@ -3211,24 +3260,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -3420,6 +3473,10 @@ packages:
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/diff@8.0.0':
+    resolution: {integrity: sha512-o7jqJM04gfaYrdCecCVMbZhNdG6T1MHg/oQoRFdERLV+4d+V7FijhiEAbFu0Usww84Yijk9yH58U4Jk4HbtzZw==}
+    deprecated: This is a stub types definition. diff provides its own type definitions, so you do not need this installed.
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -4943,6 +5000,10 @@ packages:
 
   diff@5.2.0:
     resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
+    engines: {node: '>=0.3.1'}
+
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
@@ -6494,48 +6555,56 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.31.0:
     resolution: {integrity: sha512-EpAQTq6TXL+200bDNMzhbFpqAJsto01R//xuE8yAWN0l4wmJhmS1r/FxoudIUM9PxHMPEiWeLw+1thdF5ZPg7Q==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.31.0:
     resolution: {integrity: sha512-6tuU37nXStA3kxNnjC49z1tPFEoviC9ZLyB34O3X1/VTLXdZX2vmPZ+45XesagvlgoeJQ9r9XVSovUZny41AQA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.31.0:
     resolution: {integrity: sha512-enNePbgDKmJybVz90/8dAGTOulvpn0IwxamHHnIj32gmdbuSPJ9mk+Nob4UmiqLMAdHlH+0c+lpsZkv4TSxi3w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-musl@1.31.0:
     resolution: {integrity: sha512-EM4jGT+V+PdFkcrIB5m5yiSzfV7z43k0pOtUmODhFSbuay5JvbVChK1uoaMmwPTKGWatwSRbiu90BUzU262B9g==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -13339,6 +13408,10 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
+  '@types/diff@8.0.0':
+    dependencies:
+      diff: 9.0.0
+
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.7
@@ -15172,6 +15245,8 @@ snapshots:
   diff@4.0.2: {}
 
   diff@5.2.0: {}
+
+  diff@9.0.0: {}
 
   dir-glob@3.0.1:
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When saving a console (Cmd+S), an AI-generated commit-message-style comment is suggested in the Save dialog, describing what changed since the last saved version. The server fetches the previous version's code from the `EntityVersion` snapshot collection (the only reliable source of truth for "last explicitly saved" content) and diffs it against the new content.

## Changes

### Backend

- **`api/src/services/version-comment.service.ts`** (new) — Computes a line diff, sends it to the AI Gateway utility model with a prompt modeled after aicommits/opencommit best practices (imperative mood, max 72 chars, present tense, few-shot example). Tracks usage under `invocationType: "version_comment"`.
- **`api/src/routes/consoles.ts`** — `POST /:id/version-comment` route now **fetches the latest `EntityVersion` snapshot's `code` field** from MongoDB as the diff baseline. Client only sends `newContent`. For consoles with no prior versions (first save), `previousContent` is empty string so the AI describes the full query.
- **`api/src/database/schema.ts`** + **`api/src/services/llm-usage.service.ts`** — Added `"version_comment"` to the `invocationType` enum.

### Frontend

- **`app/src/utils/ConsoleVersionManager.ts`** — Extended with `aiComment`/`aiCommentStatus` fields, `updateVersion()`, `getPreviousContent()`, `getRecentAiComments()`, `getFirstContent()`. `saveVersion()` returns version ID.
- **`app/src/store/consoleStore.ts`** — `generateVersionComment()` for background async comments (debounced). `generateSaveComment()` for on-demand awaitable calls at save time. Removed all client-side `lastSavedContent` tracking (server handles it).
- **`app/src/hooks/useMonacoConsole.ts`** — Wires background comment generation into `saveUserEdit` and `applyModification`.
- **`app/src/components/Console.tsx`** — Passes `workspaceId` and `title` to the hook.
- **`app/src/components/SaveCommentDialog.tsx`** — `defaultComment` + `loading` props. Shows sparkles icon + progress bar while generating. Won't overwrite user-typed text.
- **`app/src/components/Editor.tsx`** — Fires `generateSaveComment()` when Save dialog opens. Simplified payload (just `newContent` + `source`).

## Key Design Decision: Server-Side Diff Baseline

The previous version's code is fetched **server-side** from the `EntityVersion` collection because:
- `SavedConsole.code` is unreliable — auto-save overwrites it continuously
- Client-side tracking (`lastSavedContent` Map) breaks for tabs hydrated from localStorage (pre-versioning consoles)
- The version snapshot is the **only** record of what code was at each explicit Cmd+S save

For first-time saves (no prior versions), `previousContent` is empty and the AI describes the full query.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5347ab6-85d3-45c3-8c38-7ec720e7084c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5347ab6-85d3-45c3-8c38-7ec720e7084c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

