### PR TITLE
docs: document immutable version history (consoles + dashboards)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -30,6 +30,7 @@ export default defineConfig({
             { label: "AI-Powered SQL Client", slug: "ai-agent" },
             { label: "Console", slug: "console" },
             { label: "Dashboards", slug: "dashboards" },
+            { label: "Version History", slug: "version-history" },
             { label: "Query Runner", slug: "query-runner" },
             { label: "Self-Directive", slug: "self-directive" },
           ],

--- a/docs/src/content/docs/ai-agent.md
+++ b/docs/src/content/docs/ai-agent.md
@@ -96,6 +96,15 @@ Key capabilities:
 
 The agent handles edit-mode locking, so concurrent users cannot conflict.
 
+## Version-Aware Tools
+
+All agents have access to two shared tools for inspecting the history of saved consoles and dashboards:
+
+- `browse_version_history` — list past versions of a console or dashboard with author, timestamp, and comment.
+- `get_version_snapshot` — fetch the full snapshot of a specific version.
+
+Both are workspace-scoped. See [Version History](/version-history/).
+
 ## AI Models
 
 Mako routes all AI requests through the **Vercel AI Gateway**, which provides access to 180+ models across Anthropic, OpenAI, Google, DeepSeek, and others. Only `AI_GATEWAY_API_KEY` is required — no individual provider API keys needed.

--- a/docs/src/content/docs/api-reference.md
+++ b/docs/src/content/docs/api-reference.md
@@ -55,11 +55,14 @@ Authorization: Bearer revops_YOUR_API_KEY
 
 | Method | Endpoint                                    | Description                |
 | ------ | ------------------------------------------- | -------------------------- |
-| `GET`  | `/api/workspaces/:wid/consoles/list`        | List all consoles          |
-| `GET`  | `/api/workspaces/:wid/consoles/:id/details` | Get console details + code |
-| `POST` | `/api/workspaces/:wid/consoles/:id/execute` | Execute a saved console    |
+| `GET`  | `/api/workspaces/:wid/consoles/list`                         | List all consoles                        |
+| `GET`  | `/api/workspaces/:wid/consoles/:id/details`                  | Get console details + code               |
+| `POST` | `/api/workspaces/:wid/consoles/:id/execute`                  | Execute a saved console                  |
+| `GET`  | `/api/workspaces/:wid/consoles/:id/versions`                 | List version history (paginated)         |
+| `GET`  | `/api/workspaces/:wid/consoles/:id/versions/:version`        | Get a specific version snapshot          |
+| `POST` | `/api/workspaces/:wid/consoles/:id/versions/:version/restore` | Restore console to a past version        |
 
-See [Console](/console/) for full API documentation with examples.
+See [Console](/console/) for full API documentation with examples. Version history is covered under [Version History](/version-history/).
 
 ## Flows
 
@@ -159,6 +162,9 @@ The response is a **Server-Sent Events (SSE)** stream:
 | `PUT`    | `/api/workspaces/:wid/dashboards/:did`                           | Update dashboard                     |
 | `DELETE` | `/api/workspaces/:wid/dashboards/:did`                           | Delete dashboard                     |
 | `POST`   | `/api/workspaces/:wid/dashboards/:did/duplicate`                 | Duplicate a dashboard                |
+| `GET`    | `/api/workspaces/:wid/dashboards/:did/versions`                  | List dashboard version history       |
+| `GET`    | `/api/workspaces/:wid/dashboards/:did/versions/:version`         | Get a specific dashboard version     |
+| `POST`   | `/api/workspaces/:wid/dashboards/:did/versions/:version/restore` | Restore dashboard to a past version  |
 
 ### Dashboard Folders
 

--- a/docs/src/content/docs/console.md
+++ b/docs/src/content/docs/console.md
@@ -36,6 +36,10 @@ Open the chat panel and describe what you want. The agent will:
 
 Consoles can be organized into folders. Use the sidebar tree to drag and arrange.
 
+### Version History
+
+Every save of a console creates an immutable version record. Open the history panel from the editor to browse past versions, preview them, and restore with one click. Full details: [Version History](/version-history/).
+
 ## Console API
 
 Saved consoles can be executed programmatically. This is useful for building dashboards, automations, or integrations on top of your queries.

--- a/docs/src/content/docs/dashboards.md
+++ b/docs/src/content/docs/dashboards.md
@@ -131,6 +131,10 @@ Dashboards use an edit lock to prevent concurrent editing conflicts:
 
 If another user holds the lock, a confirmation dialog offers to take over.
 
+## Version History
+
+Every save of a dashboard creates an immutable version snapshot (widgets, data sources, layout). Authors, timestamps, and commit comments are preserved. Restoring a past version creates a new version record referencing the one it came from — the timeline is append-only. See [Version History](/version-history/) for the API and agent tools.
+
 ## Scheduled Refresh
 
 Data sources can be refreshed on a schedule using cron expressions:

--- a/docs/src/content/docs/version-history.md
+++ b/docs/src/content/docs/version-history.md
@@ -1,0 +1,127 @@
+---
+title: Version History
+description: Immutable snapshots for saved consoles and dashboards — browse, view, and restore past versions.
+---
+
+Every saved console and dashboard has a full, immutable version history. Every save creates a new version record capturing the complete state at that point in time. Versions are never rewritten or deleted.
+
+## How It Works
+
+- Each console or dashboard has a monotonically increasing `version` number on the main document.
+- Every save creates an `EntityVersion` record in MongoDB scoped to `(entityType, entityId, version)`.
+- Snapshots capture the full entity state (for consoles: code, language, chart spec, connection; for dashboards: widgets, data sources, layout).
+- Restoring a past version writes the old snapshot into the main document **and** appends a new version record (with `restoredFrom` set), so the timeline is never lost.
+
+Version numbers are unique per entity and enforced by a unique index on `(entityType, entityId, version)`. Retry logic handles the rare case of concurrent writers picking the same version number.
+
+## REST API
+
+All endpoints live under the workspace path and require workspace membership.
+
+### Consoles
+
+| Method | Endpoint                                                      | Description                              |
+| ------ | ------------------------------------------------------------- | ---------------------------------------- |
+| `GET`  | `/api/workspaces/:wid/consoles/:id/versions`                  | List versions (paginated, newest first)  |
+| `GET`  | `/api/workspaces/:wid/consoles/:id/versions/:version`         | Get a specific version snapshot          |
+| `POST` | `/api/workspaces/:wid/consoles/:id/versions/:version/restore` | Restore the console to that version      |
+
+### Dashboards
+
+| Method | Endpoint                                                        | Description                              |
+| ------ | --------------------------------------------------------------- | ---------------------------------------- |
+| `GET`  | `/api/workspaces/:wid/dashboards/:did/versions`                 | List versions (paginated, newest first)  |
+| `GET`  | `/api/workspaces/:wid/dashboards/:did/versions/:version`        | Get a specific version snapshot          |
+| `POST` | `/api/workspaces/:wid/dashboards/:did/versions/:version/restore` | Restore the dashboard to that version    |
+
+### Query Parameters (list endpoints)
+
+| Param    | Default | Max | Description                      |
+| -------- | ------- | --- | -------------------------------- |
+| `limit`  | 50      | 100 | Number of versions to return     |
+| `offset` | 0       | —   | Pagination offset                |
+
+### List Response
+
+```json
+{
+  "success": true,
+  "versions": [
+    {
+      "version": 7,
+      "savedBy": "user_abc123",
+      "savedByName": "Alice Doe",
+      "comment": "Added filter on status",
+      "restoredFrom": null,
+      "createdAt": "2026-04-22T14:10:32.000Z"
+    }
+  ],
+  "total": 7
+}
+```
+
+### Snapshot Response
+
+```json
+{
+  "success": true,
+  "version": {
+    "version": 7,
+    "savedBy": "user_abc123",
+    "savedByName": "Alice Doe",
+    "comment": "Added filter on status",
+    "restoredFrom": null,
+    "createdAt": "2026-04-22T14:10:32.000Z",
+    "snapshot": { "code": "SELECT ...", "language": "sql" }
+  }
+}
+```
+
+### Restore Response
+
+```json
+{
+  "success": true,
+  "message": "Restored to version 5",
+  "version": 8,
+  "restoredFrom": 5
+}
+```
+
+Restoring bumps the entity to a new version (`N + 1`) whose record has `restoredFrom: 5`. The restored content is written to the main document atomically alongside the version write.
+
+Optional body on restore: `{ "comment": "Reverting because X" }`. If omitted, the comment defaults to `"Restored from version N"`.
+
+## UI
+
+Open the **version history panel** from any saved console or dashboard. It shows the full list of versions with author, timestamp, and commit comment. From there you can:
+
+- Click a version to preview its snapshot
+- Restore any past version with one click
+- Optionally add a commit comment when saving via the save dialog
+
+Unsaved drafts have no version history yet; the history button is disabled until the first save.
+
+## AI Agent Tools
+
+The assistant can inspect version history through two dedicated tools. See [AI Agent](/ai-agent/) for the full tool surface.
+
+### `browse_version_history`
+
+Lists past versions of a console or dashboard. Returns authors, timestamps, and comments.
+
+**Inputs:** `entityType` (`"console"` | `"dashboard"`), `entityId`, optional `limit` (default 10).
+
+### `get_version_snapshot`
+
+Fetches the full snapshot of a specific version — including code (consoles) or widgets/data sources/layout (dashboards).
+
+**Inputs:** `entityType`, `entityId`, `version`.
+
+Both tools are workspace-scoped: the assistant can only browse entities inside the current workspace.
+
+## Notes
+
+- Version history is enabled by default for every workspace; no configuration needed.
+- The `EntityVersion` collection was introduced in migration `2026-04-05-075746_add_entity_versions_collection`.
+- Console and dashboard saves are append-only from the history's perspective — there is no hard delete, even on restore.


### PR DESCRIPTION
PR #258 shipped immutable versioning for saved consoles and dashboards — 6 new REST endpoints, 2 new agent tools, a new UI panel, and a new MongoDB collection — but landed with zero user-facing docs. This fixes that.

## What's in here

**New page:** `docs/src/content/docs/version-history.md`
- How versioning works (append-only snapshots, `EntityVersion` collection, `restoredFrom` chains)
- Full REST API reference for both consoles and dashboards (list / get / restore)
- Query params, response shapes (list / snapshot / restore)
- UI panel walkthrough
- Agent tools: `browse_version_history` and `get_version_snapshot`

**Updated pages:**
- `api-reference.md` — versions endpoints added to the Consoles and Dashboards tables
- `console.md` — Version History subsection with link to the new page
- `dashboards.md` — Version History section above Scheduled Refresh
- `ai-agent.md` — new 'Version-Aware Tools' block before AI Models
- `astro.config.mjs` — sidebar entry under Core Features

## Verification

Endpoints and tool names checked against:
- `api/src/routes/consoles.ts` (lines 2131-2330ish)
- `api/src/routes/dashboards.ts` (lines 1573-1750ish)
- `api/src/agent-lib/tools/version-history-tools.ts`
- `api/src/services/entity-version.service.ts`
- Migration `2026-04-05-075746_add_entity_versions_collection`

No behavior changes — docs only.

Made-with: Aura