### PR TITLE
Unify explorer sidebars on ExplorerShell + ResourceTree

### DIFF
--- a/.cursor/rules/85-pre-commit.mdc
+++ b/.cursor/rules/85-pre-commit.mdc
@@ -1,0 +1,32 @@
+---
+description: Pre-commit / pre-PR checklist. The pre-commit hook is weaker than CI — always run the full package lint and typecheck before opening a PR.
+alwaysApply: true
+---
+
+# Pre-commit / pre-PR checklist
+
+CI is stricter than the `husky` pre-commit hook. Always run the package's full lint **and** typecheck for every package you touched before committing or opening a PR — not just the staged-files hook.
+
+## Minimum gate per package
+
+| You edited files under... | Run before committing |
+| --- | --- |
+| `app/` | `pnpm --filter app run typecheck && pnpm --filter app run lint` |
+| `api/` | `pnpm --filter api run lint` (typecheck runs inside `api:build`) |
+| `website/` | `pnpm --filter website run lint` |
+
+For cross-package changes, `pnpm run lint:all` covers `app` + `api` + connector-agnosticism.
+
+## Why the pre-commit hook is not enough
+
+- `lint-staged` only runs on staged files, not the full package.
+- Even with `--report-unused-disable-directives` in `lint-staged`, a stale `// eslint-disable-next-line ...` comment in an **unstaged** file (or one you touched but didn't restage) will still reach CI.
+- CI's `eslint . --report-unused-disable-directives` treats unused disable directives as **errors** and fails the build. A clean pre-commit hook does not guarantee a green CI.
+
+## Common gotchas that only CI catches
+
+- **Unused `eslint-disable` directives.** When you fix a deps array or tighten a type, the surrounding `// eslint-disable-next-line` comment often becomes unused. Delete the comment in the same edit.
+- **Pre-existing warnings you introduced one more of.** CI doesn't fail on warnings, but don't rely on that — remove warnings you can fix.
+- **`@typescript-eslint/no-non-null-assertion`** from `!` on store lookups. Use an `if (!x) return;` guard or `?.` instead.
+- **`react/no-unescaped-entities`** from quotes/apostrophes inside JSX text. Use `&quot;` / `&apos;` or wrap in a string literal: `{"I'm"}`.
+- **`react-hooks/rules-of-hooks`** from calling a hook after an early `return`. Move the hook above every early return.

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -204,7 +204,7 @@ jobs:
           ref: ${{ needs.detect-changes.outputs.pr_ref || github.ref }}
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 9
 
@@ -790,7 +790,7 @@ jobs:
           ref: master
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 9
 

--- a/.github/workflows/seed-database.yml
+++ b/.github/workflows/seed-database.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 9
 

--- a/api/src/agent-lib/tools/self-directive-tool.ts
+++ b/api/src/agent-lib/tools/self-directive-tool.ts
@@ -157,54 +157,87 @@ export function createSelfDirectiveTools(workspaceId: string) {
           const current = ws.selfDirective || "";
           let newValue: string;
 
+          // Runtime-guarded narrowing for fields that Zod's superRefine
+          // already validates per-operation but TS can't track.
+          const requireField = <T>(
+            value: T | undefined,
+            field: string,
+          ): T | { success: false; error: string } => {
+            if (value === undefined) {
+              return {
+                success: false,
+                error: `'${field}' is required for '${operation}' operation`,
+              };
+            }
+            return value;
+          };
+
           switch (operation) {
-            case "set":
-              newValue = content!;
+            case "set": {
+              const c = requireField(content, "content");
+              if (typeof c !== "string") return c;
+              newValue = c;
               break;
+            }
 
-            case "append":
-              newValue = current ? current + "\n" + content! : content!;
+            case "append": {
+              const c = requireField(content, "content");
+              if (typeof c !== "string") return c;
+              newValue = current ? current + "\n" + c : c;
               break;
+            }
 
-            case "prepend":
-              newValue = current ? content! + "\n" + current : content!;
+            case "prepend": {
+              const c = requireField(content, "content");
+              if (typeof c !== "string") return c;
+              newValue = current ? c + "\n" + current : c;
               break;
+            }
 
-            case "find_and_replace":
-              if (!current.includes(find!)) {
+            case "find_and_replace": {
+              const f = requireField(find, "find");
+              if (typeof f !== "string") return f;
+              const r = requireField(replace, "replace");
+              if (typeof r !== "string") return r;
+              if (!current.includes(f)) {
                 return {
                   success: false,
-                  error: `Text not found in self-directive: "${find!.slice(0, 80)}"`,
+                  error: `Text not found in self-directive: "${f.slice(0, 80)}"`,
                 };
               }
-              newValue = literalReplace(current, find!, replace!);
+              newValue = literalReplace(current, f, r);
               break;
+            }
 
-            case "insert_after":
-              if (!current.includes(after!)) {
+            case "insert_after": {
+              const a = requireField(after, "after");
+              if (typeof a !== "string") return a;
+              const c = requireField(content, "content");
+              if (typeof c !== "string") return c;
+              if (!current.includes(a)) {
                 return {
                   success: false,
-                  error: `Anchor text not found in self-directive: "${after!.slice(0, 80)}"`,
+                  error: `Anchor text not found in self-directive: "${a.slice(0, 80)}"`,
                 };
               }
-              newValue = literalReplace(
-                current,
-                after!,
-                after! + "\n" + content!,
-              );
+              newValue = literalReplace(current, a, a + "\n" + c);
               break;
+            }
 
-            case "delete_section":
-              if (!current.includes(find!)) {
+            case "delete_section": {
+              const f = requireField(find, "find");
+              if (typeof f !== "string") return f;
+              if (!current.includes(f)) {
                 return {
                   success: false,
-                  error: `Text not found in self-directive: "${find!.slice(0, 80)}"`,
+                  error: `Text not found in self-directive: "${f.slice(0, 80)}"`,
                 };
               }
-              newValue = literalReplace(current, find!, "")
+              newValue = literalReplace(current, f, "")
                 .replace(/\n{3,}/g, "\n\n")
                 .trim();
               break;
+            }
 
             default:
               return {

--- a/api/src/connectors/close/connector.ts
+++ b/api/src/connectors/close/connector.ts
@@ -1238,8 +1238,19 @@ export class CloseConnector extends BaseConnector {
       ).toISOString();
     }
 
+    // Invariant: windowStart and windowEnd are both set by this point.
+    // Either we returned early in the oldestResp handler, or both have been
+    // assigned above. Narrow for TypeScript to avoid non-null assertions below.
+    if (windowStart === null || windowEnd === null) {
+      return {
+        totalProcessed: recordCount,
+        hasMore: false,
+        iterationsInChunk: 0,
+      };
+    }
+
     while (iterations < maxIterations) {
-      if (new Date(windowStart!).getTime() >= new Date(upperBound).getTime()) {
+      if (new Date(windowStart).getTime() >= new Date(upperBound).getTime()) {
         return {
           totalProcessed: recordCount,
           hasMore: false,
@@ -1423,11 +1434,16 @@ export class CloseConnector extends BaseConnector {
               "Close cursor limit reached, halving date window",
               { entity, recordsFetched: recordCount, windowStart, windowEnd },
             );
+            // Snapshot current window bounds: both are guaranteed non-null
+            // by the invariant guard above the loop, but TS loses track
+            // across reassignments inside the loop.
+            const currentStart: string = windowStart ?? "";
+            const currentEnd: string = windowEnd ?? "";
             const currentSpan =
-              new Date(windowEnd!).getTime() - new Date(windowStart!).getTime();
+              new Date(currentEnd).getTime() - new Date(currentStart).getTime();
             const halfSpan = Math.max(currentSpan / 2, 24 * 60 * 60 * 1000);
             windowEnd = new Date(
-              new Date(windowStart!).getTime() + halfSpan,
+              new Date(currentStart).getTime() + halfSpan,
             ).toISOString();
           }
           pageCursor = null;

--- a/api/src/databases/drivers/bigquery/driver.ts
+++ b/api/src/databases/drivers/bigquery/driver.ts
@@ -483,7 +483,8 @@ export class BigQueryDatabaseDriver implements DatabaseDriver {
         if (value === null || value === undefined) {
           columnNullable.set(key, true);
         } else {
-          columnTypes.get(key)!.add(inferBigQueryType(value));
+          const existing = columnTypes.get(key);
+          if (existing) existing.add(inferBigQueryType(value));
         }
       }
     }

--- a/api/src/databases/drivers/postgresql/driver.ts
+++ b/api/src/databases/drivers/postgresql/driver.ts
@@ -449,7 +449,8 @@ export class PostgreSQLDatabaseDriver implements DatabaseDriver {
         if (value === null || value === undefined) {
           columnNullable.set(key, true);
         } else {
-          columnTypes.get(key)!.add(inferPostgresType(value));
+          const existing = columnTypes.get(key);
+          if (existing) existing.add(inferPostgresType(value));
         }
       }
     }

--- a/api/src/inngest/functions/flow.ts
+++ b/api/src/inngest/functions/flow.ts
@@ -721,31 +721,30 @@ export const flowFunction = inngest.createFunction(
       // ============ DATABASE SOURCE EXECUTION ============
       // For database-to-database flows, use chunked execution for resumability
       if (flow.sourceType === "database") {
+        // Validate database source configuration up-front so TypeScript can
+        // narrow `flow.databaseSource` for the remainder of this branch.
+        if (!flow.databaseSource?.connectionId || !flow.databaseSource?.query) {
+          throw new Error("Database source requires connectionId and query");
+        }
+        const dbSource = flow.databaseSource;
+
         logger.info(
           "Starting database-to-database sync with chunked execution",
           {
             flowId,
             syncMode: flow.syncMode,
-            sourceConnectionId: flow.databaseSource?.connectionId?.toString(),
-            sourceDatabase: flow.databaseSource?.database,
+            sourceConnectionId: dbSource.connectionId.toString(),
+            sourceDatabase: dbSource.database,
           },
         );
 
-        // Validate database source configuration
         const _validation = await step.run("validate-db-source", async () => {
-          if (
-            !flow.databaseSource?.connectionId ||
-            !flow.databaseSource?.query
-          ) {
-            throw new Error("Database source requires connectionId and query");
-          }
-
           const sourceConnection = await DatabaseConnection.findById(
-            flow.databaseSource.connectionId,
+            dbSource.connectionId,
           );
           if (!sourceConnection) {
             throw new Error(
-              `Source database connection not found: ${flow.databaseSource.connectionId}`,
+              `Source database connection not found: ${dbSource.connectionId}`,
             );
           }
 
@@ -760,7 +759,7 @@ export const flowFunction = inngest.createFunction(
           "init-destination-writer",
           async () => {
             const sourceConnection = await DatabaseConnection.findById(
-              flow.databaseSource!.connectionId,
+              dbSource.connectionId,
             );
 
             const destinationWriter = await createDestinationWriter(
@@ -768,7 +767,7 @@ export const flowFunction = inngest.createFunction(
                 destinationDatabaseId: flow.destinationDatabaseId,
                 destinationDatabaseName: flow.destinationDatabaseName,
                 tableDestination: flow.tableDestination,
-                dataSourceId: flow.databaseSource!.connectionId,
+                dataSourceId: dbSource.connectionId,
               },
               sourceConnection?.name,
             );
@@ -809,7 +808,7 @@ export const flowFunction = inngest.createFunction(
 
               // Re-create destination writer for this chunk
               const sourceConnection = await DatabaseConnection.findById(
-                flow.databaseSource!.connectionId,
+                dbSource.connectionId,
               );
               if (!sourceConnection) {
                 throw new Error("Source connection not found");
@@ -820,7 +819,7 @@ export const flowFunction = inngest.createFunction(
                   destinationDatabaseId: flow.destinationDatabaseId,
                   destinationDatabaseName: flow.destinationDatabaseName,
                   tableDestination: flow.tableDestination,
-                  dataSourceId: flow.databaseSource!.connectionId,
+                  dataSourceId: dbSource.connectionId,
                 },
                 sourceConnection.name,
               );
@@ -833,8 +832,8 @@ export const flowFunction = inngest.createFunction(
               // Execute chunk with pagination and type coercions
               const result = await executeDbSyncChunk({
                 sourceConnection,
-                sourceQuery: flow.databaseSource!.query,
-                sourceDatabase: flow.databaseSource!.database,
+                sourceQuery: dbSource.query,
+                sourceDatabase: dbSource.database,
                 destinationWriter,
                 batchSize: flow.batchSize || 2000,
                 syncMode: flow.syncMode,
@@ -941,7 +940,7 @@ export const flowFunction = inngest.createFunction(
             });
 
             const sourceConnection = await DatabaseConnection.findById(
-              flow.databaseSource!.connectionId,
+              dbSource.connectionId,
             );
 
             const destinationWriter = await createDestinationWriter(
@@ -949,7 +948,7 @@ export const flowFunction = inngest.createFunction(
                 destinationDatabaseId: flow.destinationDatabaseId,
                 destinationDatabaseName: flow.destinationDatabaseName,
                 tableDestination: flow.tableDestination,
-                dataSourceId: flow.databaseSource!.connectionId,
+                dataSourceId: dbSource.connectionId,
               },
               sourceConnection?.name,
             );
@@ -973,6 +972,7 @@ export const flowFunction = inngest.createFunction(
           flow.incrementalConfig?.trackingColumn &&
           totalRowsProcessed > 0
         ) {
+          const trackingColumn = flow.incrementalConfig.trackingColumn;
           await step.run("update-incremental-tracking", async () => {
             logger.info("Updating incremental tracking value", { flowId });
 
@@ -986,7 +986,7 @@ export const flowFunction = inngest.createFunction(
                 const maxValueResult = await getMaxTrackingValue(
                   destConnection,
                   flow.tableDestination.tableName,
-                  flow.incrementalConfig!.trackingColumn,
+                  trackingColumn,
                   flow.tableDestination.schema,
                   flow.tableDestination.database,
                 );
@@ -998,7 +998,7 @@ export const flowFunction = inngest.createFunction(
 
                   logger.info("Incremental tracking updated", {
                     flowId,
-                    trackingColumn: flow.incrementalConfig!.trackingColumn,
+                    trackingColumn,
                     newLastValue: maxValueResult.maxValue,
                   });
                 }
@@ -1012,7 +1012,7 @@ export const flowFunction = inngest.createFunction(
 
               logger.info("Incremental tracking updated (from chunk state)", {
                 flowId,
-                trackingColumn: flow.incrementalConfig!.trackingColumn,
+                trackingColumn,
                 newLastValue: chunkState.lastTrackingValue,
               });
             }
@@ -1158,14 +1158,15 @@ export const flowFunction = inngest.createFunction(
           isCdcEnabled &&
           Boolean(cdcBackfillRunId);
         let checkpointCompletedEntities = new Set<string>();
-        if (checkpointEnabled) {
+        if (checkpointEnabled && cdcBackfillRunId) {
+          const runId = cdcBackfillRunId;
           const completedEntities = (await step.run(
             "load-cdc-backfill-completed-entities",
             async () => {
               return cdcBackfillCheckpointService.listCompletedEntities({
                 workspaceId: String(flow.workspaceId),
                 flowId: String(flow._id),
-                runId: cdcBackfillRunId!,
+                runId,
               });
             },
           )) as string[];
@@ -1877,14 +1878,19 @@ export const flowFunction = inngest.createFunction(
       // an orphaned staging table. The cleanup logic below handles the case
       // where no staging table exists (via try/catch), so it's safe to
       // always attempt cleanup for database full syncs.
-      if (flowRef?.sourceType === "database" && flowRef?.syncMode === "full") {
+      if (
+        flowRef?.sourceType === "database" &&
+        flowRef?.syncMode === "full" &&
+        flowRef.databaseSource?.connectionId
+      ) {
         const cleanupFlow = flowRef; // Capture for closure
+        const cleanupDbSource = flowRef.databaseSource;
         await step.run("cleanup-staging-on-failure", async () => {
           try {
             logger.info("Cleaning up staging table after failure", { flowId });
 
             const sourceConnection = await DatabaseConnection.findById(
-              cleanupFlow.databaseSource!.connectionId,
+              cleanupDbSource.connectionId,
             );
 
             const destinationWriter = await createDestinationWriter(
@@ -1892,7 +1898,7 @@ export const flowFunction = inngest.createFunction(
                 destinationDatabaseId: cleanupFlow.destinationDatabaseId,
                 destinationDatabaseName: cleanupFlow.destinationDatabaseName,
                 tableDestination: cleanupFlow.tableDestination,
-                dataSourceId: cleanupFlow.databaseSource!.connectionId,
+                dataSourceId: cleanupDbSource.connectionId,
               },
               sourceConnection?.name,
             );

--- a/api/src/inngest/functions/sync-entity.ts
+++ b/api/src/inngest/functions/sync-entity.ts
@@ -158,6 +158,19 @@ export const syncBackfillEntityFunction = inngest.createFunction(
     const safeEntityStepId = entity.replace(/[^a-zA-Z0-9_-]/g, "_");
     let stepsUsed = 0;
 
+    // When checkpointEnabled is true, cdcBackfillRunId is guaranteed
+    // by the caller. Narrow to a non-optional string so downstream
+    // step closures don't need non-null assertions.
+    let checkpointRunId = "";
+    if (checkpointEnabled) {
+      if (!cdcBackfillRunId) {
+        throw new Error(
+          "cdcBackfillRunId is required when checkpointEnabled is true",
+        );
+      }
+      checkpointRunId = cdcBackfillRunId;
+    }
+
     const logExec = (
       level: "debug" | "info" | "warn" | "error",
       message: string,
@@ -204,7 +217,7 @@ export const syncBackfillEntityFunction = inngest.createFunction(
           return cdcBackfillCheckpointService.loadEntityCheckpoint({
             workspaceId,
             flowId,
-            runId: cdcBackfillRunId!,
+            runId: checkpointRunId,
             entity,
           });
         },
@@ -319,15 +332,16 @@ export const syncBackfillEntityFunction = inngest.createFunction(
     while (!completed) {
       if (stepsUsed >= STEP_BUDGET) {
         if (checkpointEnabled && state) {
+          const checkpointState = state;
           await step.run(
             `save-checkpoint-before-yield-${safeEntityStepId}`,
             async () => {
               await cdcBackfillCheckpointService.saveEntityCheckpoint({
                 workspaceId,
                 flowId,
-                runId: cdcBackfillRunId!,
+                runId: checkpointRunId,
                 entity,
-                fetchState: state!,
+                fetchState: checkpointState,
               });
             },
           );
@@ -494,7 +508,7 @@ export const syncBackfillEntityFunction = inngest.createFunction(
             await cdcBackfillCheckpointService.saveEntityCheckpoint({
               workspaceId,
               flowId,
-              runId: cdcBackfillRunId!,
+              runId: checkpointRunId,
               entity,
               fetchState: chunkResult.state,
             });
@@ -640,7 +654,7 @@ export const syncBackfillEntityFunction = inngest.createFunction(
           await cdcBackfillCheckpointService.markEntityCompleted({
             workspaceId,
             flowId,
-            runId: cdcBackfillRunId!,
+            runId: checkpointRunId,
             entity,
             fetchState: state,
           });

--- a/api/src/inngest/functions/webhook-flow.ts
+++ b/api/src/inngest/functions/webhook-flow.ts
@@ -1016,8 +1016,12 @@ async function ingestPendingWebhookEvents(logger: {
   const byFlow = new Map<string, typeof pendingEvents>();
   for (const evt of pendingEvents) {
     const fid = evt.flowId.toString();
-    if (!byFlow.has(fid)) byFlow.set(fid, []);
-    byFlow.get(fid)!.push(evt);
+    const bucket = byFlow.get(fid);
+    if (bucket) {
+      bucket.push(evt);
+    } else {
+      byFlow.set(fid, [evt]);
+    }
   }
 
   let totalIngested = 0;

--- a/api/src/routes/flows.ts
+++ b/api/src/routes/flows.ts
@@ -2473,9 +2473,9 @@ flowRoutes.get("/:flowId/sync-cdc/status", async c => {
 
     const pendingCountMap = new Map(pendingByEntity.map(r => [r._id, r.count]));
     const pendingOldestTsMap = new Map(
-      pendingByEntity
-        .filter(r => r.oldestIngestTs)
-        .map(r => [r._id, new Date(r.oldestIngestTs!)] as const),
+      pendingByEntity.flatMap(r =>
+        r.oldestIngestTs ? [[r._id, new Date(r.oldestIngestTs)] as const] : [],
+      ),
     );
 
     const entities = uniqueEntities.map(entity => {

--- a/api/src/routes/usage.ts
+++ b/api/src/routes/usage.ts
@@ -77,7 +77,8 @@ function parseDateRange(
  * Query params: ?from=ISO&to=ISO
  */
 usageRoutes.get("/summary", async (c: AuthenticatedContext) => {
-  const workspaceId = c.req.param("workspaceId")!;
+  const workspaceId = c.req.param("workspaceId");
+  if (!workspaceId) return c.json({ error: "Missing workspaceId" }, 400);
   const parsed = parseDateRange(c);
   if (!parsed.ok) return c.json({ error: parsed.error }, 400);
   const dateFilter = parsed.match;
@@ -129,7 +130,8 @@ usageRoutes.get("/summary", async (c: AuthenticatedContext) => {
  * Query params: ?from=ISO&to=ISO
  */
 usageRoutes.get("/by-user", async (c: AuthenticatedContext) => {
-  const workspaceId = c.req.param("workspaceId")!;
+  const workspaceId = c.req.param("workspaceId");
+  if (!workspaceId) return c.json({ error: "Missing workspaceId" }, 400);
   const parsed = parseDateRange(c);
   if (!parsed.ok) return c.json({ error: parsed.error }, 400);
   const dateFilter = parsed.match;
@@ -183,10 +185,10 @@ usageRoutes.get("/by-user", async (c: AuthenticatedContext) => {
  * GET /by-chat/:chatId -- per-chat detail
  */
 usageRoutes.get("/by-chat/:chatId", async (c: AuthenticatedContext) => {
-  const workspaceId = c.req.param("workspaceId")!;
-  const chatId = c.req.param("chatId")!;
-
-  if (!ObjectId.isValid(chatId)) {
+  const workspaceId = c.req.param("workspaceId");
+  if (!workspaceId) return c.json({ error: "Missing workspaceId" }, 400);
+  const chatId = c.req.param("chatId");
+  if (!chatId || !ObjectId.isValid(chatId)) {
     return c.json({ error: "Invalid chatId" }, 400);
   }
 
@@ -236,7 +238,8 @@ usageRoutes.get("/by-chat/:chatId", async (c: AuthenticatedContext) => {
  * Query params: ?from=ISO&to=ISO
  */
 usageRoutes.get("/by-model", async (c: AuthenticatedContext) => {
-  const workspaceId = c.req.param("workspaceId")!;
+  const workspaceId = c.req.param("workspaceId");
+  if (!workspaceId) return c.json({ error: "Missing workspaceId" }, 400);
   const parsed = parseDateRange(c);
   if (!parsed.ok) return c.json({ error: parsed.error }, 400);
   const dateFilter = parsed.match;

--- a/api/src/services/destination-writer.service.ts
+++ b/api/src/services/destination-writer.service.ts
@@ -1115,7 +1115,7 @@ export async function validateQuery(
 
     if (result.data && result.data.length > 0) {
       sampleRow = result.data[0] as Record<string, unknown>;
-      columns = Object.keys(sampleRow!).map(name => ({
+      columns = Object.keys(sampleRow).map(name => ({
         name,
         type: "", // Empty - types should be set by AI agent or user
       }));

--- a/api/src/services/ssh-tunnel.service.ts
+++ b/api/src/services/ssh-tunnel.service.ts
@@ -94,10 +94,11 @@ class SshTunnelManager {
         reject(err);
       });
       if (config.sshPassword) {
+        const sshPassword = config.sshPassword;
         client.on(
           "keyboard-interactive",
           (_name, _instructions, _lang, prompts, finish) => {
-            finish(prompts.map(() => config.sshPassword!));
+            finish(prompts.map(() => sshPassword));
           },
         );
       }

--- a/api/src/sync/sync-orchestrator.ts
+++ b/api/src/sync/sync-orchestrator.ts
@@ -1031,6 +1031,10 @@ async function flushBulkBuffer(
   const initialCount = await tempCollection.countDocuments();
   if (initialCount === 0) return { flushed: 0 };
 
+  const loadStagingFromParquet =
+    cdcAdapter.loadStagingFromParquet?.bind(cdcAdapter);
+  if (!loadStagingFromParquet) return { flushed: 0 };
+
   let currentBatchSize = FLUSH_BATCH_SIZE;
   let totalFlushed = 0;
   let batchNum = 0;
@@ -1178,16 +1182,11 @@ async function flushBulkBuffer(
     try {
       for (let attempt = 1; attempt <= LOAD_MAX_RETRIES; attempt++) {
         try {
-          await cdcAdapter.loadStagingFromParquet!(
-            parquet.filePath,
-            cdcLayout,
-            flowId,
-            {
-              stagingSuffix: "backfill_staging",
-              skipDrop: true,
-              skipParquetCleanup: true,
-            },
-          );
+          await loadStagingFromParquet(parquet.filePath, cdcLayout, flowId, {
+            stagingSuffix: "backfill_staging",
+            skipDrop: true,
+            skipParquetCleanup: true,
+          });
           break;
         } catch (err) {
           if (attempt === LOAD_MAX_RETRIES) throw err;
@@ -1297,12 +1296,18 @@ async function flushBulkBuffer(
 
 async function resolveAdapterContext(options: SyncChunkOptions) {
   const entity = options.entity;
+  const tableDestination = options.tableDestination;
+  if (!tableDestination) {
+    throw new Error(
+      "resolveAdapterContext requires options.tableDestination to be set",
+    );
+  }
   const entityTableName = getEntityTableName(
-    options.tableDestination!.tableName,
+    tableDestination.tableName,
     entity,
   );
   const destinationConn = await DatabaseConnection.findById(
-    options.tableDestination!.connectionId,
+    tableDestination.connectionId,
   )
     .select({ type: 1 })
     .lean();
@@ -1312,8 +1317,8 @@ async function resolveAdapterContext(options: SyncChunkOptions) {
     destinationDatabaseId: options.destinationId,
     destinationDatabaseName: options.destinationDatabaseName,
     tableDestination: {
-      connectionId: String(options.tableDestination!.connectionId),
-      schema: options.tableDestination!.schema || "public",
+      connectionId: String(tableDestination.connectionId),
+      schema: tableDestination.schema || "public",
       tableName: entityTableName,
     },
   });
@@ -1328,6 +1333,7 @@ export async function performBulkFlush(
   if (!options.tableDestination?.connectionId || !options.flowId) {
     return { flushed: 0 };
   }
+  const flowId = options.flowId;
   const { entity, entityTableName, cdcAdapter } =
     await resolveAdapterContext(options);
 
@@ -1356,7 +1362,7 @@ export async function performBulkFlush(
 
   orchestratorLogger.info("performBulkFlush: flushing buffer to staging", {
     entity,
-    flowId: options.flowId,
+    flowId,
     hasSchema: !!entitySchema,
   });
   return flushBulkBuffer(
@@ -1364,7 +1370,7 @@ export async function performBulkFlush(
     cdcAdapter,
     cdcLayout,
     entity,
-    options.flowId!,
+    flowId,
     options.logger,
     schemaFields,
     onBatchFlushed,
@@ -1375,6 +1381,7 @@ export async function performPrepareStaging(
   options: SyncChunkOptions,
 ): Promise<void> {
   if (!options.tableDestination?.connectionId || !options.flowId) return;
+  const flowId = options.flowId;
   const { entity, entityTableName, cdcAdapter } =
     await resolveAdapterContext(options);
 
@@ -1387,9 +1394,9 @@ export async function performPrepareStaging(
 
   orchestratorLogger.info(
     "performPrepareStaging: dropping staging table for fresh load",
-    { entity, flowId: options.flowId },
+    { entity, flowId },
   );
-  await cdcAdapter.prepareStaging(cdcLayout, options.flowId!, {
+  await cdcAdapter.prepareStaging(cdcLayout, flowId, {
     stagingSuffix: "backfill_staging",
   });
 }
@@ -1409,6 +1416,7 @@ export async function performStagingMerge(
   if (!options.tableDestination?.connectionId || !options.flowId) {
     return { written: 0 };
   }
+  const flowId = options.flowId;
   const { entity, entityTableName, cdcAdapter } =
     await resolveAdapterContext(options);
 
@@ -1432,12 +1440,12 @@ export async function performStagingMerge(
 
   orchestratorLogger.info("performStagingMerge: merging staging to live", {
     entity,
-    flowId: options.flowId,
+    flowId,
   });
   return cdcAdapter.mergeFromStaging(
     cdcLayout,
     {
-      _id: new Types.ObjectId(options.flowId),
+      _id: new Types.ObjectId(flowId),
       deleteMode: options.deleteMode,
       dataSourceId:
         dataSource &&
@@ -1446,7 +1454,7 @@ export async function performStagingMerge(
           ? new Types.ObjectId(dataSource.id)
           : undefined,
     } as any,
-    options.flowId!,
+    flowId,
     entitySchema ?? undefined,
     { stagingSuffix: "backfill_staging" },
   );
@@ -1456,6 +1464,7 @@ export async function performStagingCleanup(
   options: SyncChunkOptions,
 ): Promise<void> {
   if (!options.tableDestination?.connectionId || !options.flowId) return;
+  const flowId = options.flowId;
   const { entity, entityTableName, cdcAdapter } =
     await resolveAdapterContext(options);
 
@@ -1467,14 +1476,14 @@ export async function performStagingCleanup(
   });
   orchestratorLogger.info(
     "performStagingCleanup: dropping staging table and temp collection",
-    { entity, flowId: options.flowId },
+    { entity, flowId },
   );
-  await cdcAdapter.cleanupStaging(cdcLayout, options.flowId!, {
+  await cdcAdapter.cleanupStaging(cdcLayout, flowId, {
     stagingSuffix: "backfill_staging",
   });
 
   const db = Flow.db;
-  const collName = `backfill_tmp_${options.flowId}_${entity.replace(/[^a-zA-Z0-9]/g, "_")}`;
+  const collName = `backfill_tmp_${flowId}_${entity.replace(/[^a-zA-Z0-9]/g, "_")}`;
   await db
     .collection(collName)
     .drop()

--- a/app/src/components/ConnectorExplorer.tsx
+++ b/app/src/components/ConnectorExplorer.tsx
@@ -3,15 +3,9 @@ import {
   Box,
   Typography,
   IconButton,
-  List,
-  ListItem,
-  ListItemButton,
-  ListItemIcon,
-  ListItemText,
   CircularProgress,
   Tooltip,
   Alert,
-  Menu,
   MenuItem,
   Dialog,
   DialogTitle,
@@ -28,6 +22,11 @@ import {
 import { useWorkspace } from "../contexts/workspace-context";
 import { useConsoleStore } from "../store/consoleStore";
 import { useDataSourceEntitiesStore } from "../store/dataSourceEntitiesStore";
+import ResourceTree, {
+  type ResourceTreeNode,
+  type ResourceTreeSection,
+} from "./ResourceTree";
+import ExplorerShell from "./ExplorerShell";
 
 interface Connector {
   _id: string;
@@ -58,23 +57,20 @@ function ConnectorExplorer() {
     ) as Connector[];
   }, [entities, currentWorkspace]);
 
+  const connectorById = useMemo(() => {
+    const map = new Map<string, Connector>();
+    for (const c of connectors) map.set(c._id, c);
+    return map;
+  }, [connectors]);
+
   const [error] = useState<string | null>(null);
 
-  // Context-menu & delete handling state
-  const [contextMenu, setContextMenu] = useState<{
-    mouseX: number;
-    mouseY: number;
-    item: Connector;
-  } | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [selectedItem, setSelectedItem] = useState<Connector | null>(null);
 
   const fetchSources = async () => {
     if (!currentWorkspace) return;
-    const list = await refresh(currentWorkspace.id);
-    if (!list.length) {
-      // Could set error based on future error handling in store
-    }
+    await refresh(currentWorkspace.id);
   };
 
   useEffect(() => {
@@ -85,7 +81,6 @@ function ConnectorExplorer() {
   }, [currentWorkspace?.id]);
 
   const openTabForSource = (source?: Connector) => {
-    // If editing an existing source, try to reuse an open tab; for a new source always open a fresh tab
     if (source) {
       const contentKey = source._id;
       const existing = consoleTabs.find(
@@ -104,10 +99,9 @@ function ConnectorExplorer() {
       });
       setActiveTab(id);
     } else {
-      // Always create a new tab for a brand-new data source form
       const id = openTab({
         title: "New Connector",
-        content: "", // will be populated after save
+        content: "",
         kind: "connectors",
       });
       setActiveTab(id);
@@ -116,25 +110,9 @@ function ConnectorExplorer() {
 
   const handleAdd = () => openTabForSource(undefined);
 
-  // ---------- Context menu helpers ----------
-  const handleContextMenu = (
-    event: React.MouseEvent<HTMLDivElement, MouseEvent>,
-    item: Connector,
-  ) => {
-    event.preventDefault();
-    setContextMenu({
-      mouseX: event.clientX + 2,
-      mouseY: event.clientY - 6,
-      item,
-    });
-  };
-
-  const handleContextMenuClose = () => setContextMenu(null);
-
   const handleDelete = (item: Connector) => {
     setSelectedItem(item);
     setDeleteDialogOpen(true);
-    handleContextMenuClose();
   };
 
   const handleDeleteConfirm = async () => {
@@ -147,123 +125,124 @@ function ConnectorExplorer() {
     setSelectedItem(null);
   };
 
-  return (
-    <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
-      {/* Header */}
-      <Box
-        sx={{
-          px: 1,
-          py: 0.25,
-          minHeight: 37,
-          borderBottom: 1,
-          borderColor: "divider",
-        }}
-      >
-        <Box
-          sx={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-            height: "100%",
-            minHeight: 32,
-          }}
-        >
-          <Typography
-            variant="h6"
-            sx={{
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-              textTransform: "uppercase",
-            }}
-          >
-            Connectors
-          </Typography>
-          <Box sx={{ display: "flex", gap: 0 }}>
-            <Tooltip title="Add Connector">
-              <IconButton size="small" onClick={handleAdd}>
-                <AddIcon size={20} strokeWidth={2} />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Refresh">
-              <IconButton size="small" onClick={fetchSources}>
-                <RefreshIcon size={20} strokeWidth={2} />
-              </IconButton>
-            </Tooltip>
-          </Box>
-        </Box>
-      </Box>
+  const sections = useMemo<ResourceTreeSection[]>(
+    () => [
+      {
+        key: "connectors",
+        label: "",
+        hideSectionHeader: true,
+        nodes: connectors.map(c => ({
+          id: c._id,
+          name: c.name,
+          path: c.name,
+          isDirectory: false,
+        })),
+      },
+    ],
+    [connectors],
+  );
 
-      {/* List */}
-      <Box sx={{ flexGrow: 1, overflow: "auto" }}>
-        {currentWorkspace && loading[currentWorkspace.id] ? (
+  const getItemIcon = (node: ResourceTreeNode) => {
+    const src = connectorById.get(node.id);
+    if (!src) return null;
+    return (
+      <Box
+        component="img"
+        src={`/api/connectors/${src.type}/icon.svg`}
+        alt={`${src.type} icon`}
+        sx={{ width: 20, height: 20 }}
+      />
+    );
+  };
+
+  const activeConnectorId = useMemo(() => {
+    if (!activeConsoleId) return null;
+    const tab = consoleTabs.find(
+      t =>
+        t.id === activeConsoleId &&
+        t.kind === "connectors" &&
+        typeof t.content === "string",
+    );
+    return tab?.content ?? null;
+  }, [consoleTabs, activeConsoleId]);
+
+  const actions = (
+    <>
+      <Tooltip title="Add Connector">
+        <IconButton size="small" onClick={handleAdd}>
+          <AddIcon size={20} strokeWidth={2} />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Refresh">
+        <IconButton size="small" onClick={fetchSources}>
+          <RefreshIcon size={20} strokeWidth={2} />
+        </IconButton>
+      </Tooltip>
+    </>
+  );
+
+  const isLoading = !!(currentWorkspace && loading[currentWorkspace.id]);
+
+  return (
+    <>
+      <ExplorerShell
+        title="Connectors"
+        actions={actions}
+        searchPlaceholder="Search connectors..."
+        error={error}
+        loading={isLoading && connectors.length === 0}
+        skeleton={
           <Box sx={{ p: 2, textAlign: "center" }}>
             <CircularProgress size={24} />
           </Box>
-        ) : error ? (
-          <Box sx={{ p: 2 }}>
-            <Alert severity="error" sx={{ mb: 2 }}>
-              {error}
-            </Alert>
-          </Box>
-        ) : connectors.length === 0 ? (
-          <Box sx={{ p: 3, textAlign: "center", color: "text.secondary" }}>
-            <Typography variant="body2">No connectors configured.</Typography>
-          </Box>
-        ) : (
-          <List dense>
-            {connectors.map(src => {
-              const isActive = !!(
-                activeConsoleId &&
-                consoleTabs.find(
-                  t =>
-                    t.id === activeConsoleId &&
-                    t.kind === "connectors" &&
-                    t.content === src._id,
-                )
-              );
-              return (
-                <ListItem key={src._id} disablePadding>
-                  <ListItemButton
-                    selected={isActive}
-                    onClick={() => openTabForSource(src)}
-                    onContextMenu={e => handleContextMenu(e, src)}
-                  >
-                    <ListItemIcon sx={{ minWidth: 32 }}>
-                      <Box
-                        component="img"
-                        src={`/api/connectors/${src.type}/icon.svg`}
-                        alt={`${src.type} icon`}
-                        sx={{ width: 24, height: 24 }}
-                      />
-                    </ListItemIcon>
-                    <ListItemText primary={src.name} />
-                  </ListItemButton>
-                </ListItem>
-              );
-            })}
-          </List>
-        )}
-      </Box>
-
-      {/* Context Menu */}
-      <Menu
-        open={contextMenu !== null}
-        onClose={handleContextMenuClose}
-        anchorReference="anchorPosition"
-        anchorPosition={
-          contextMenu !== null
-            ? { top: contextMenu.mouseY, left: contextMenu.mouseX }
-            : undefined
         }
       >
-        <MenuItem onClick={() => contextMenu && handleDelete(contextMenu.item)}>
-          <DeleteIcon size={18} strokeWidth={1.5} style={{ marginRight: 8 }} />
-          Delete
-        </MenuItem>
-      </Menu>
+        {({ searchQuery }) =>
+          connectors.length === 0 ? (
+            <Box sx={{ p: 3, textAlign: "center", color: "text.secondary" }}>
+              <Typography variant="body2">No connectors configured.</Typography>
+            </Box>
+          ) : (
+            <ResourceTree
+              sections={sections}
+              mode="sidebar"
+              searchQuery={searchQuery}
+              activeItemId={activeConnectorId || undefined}
+              getItemIcon={getItemIcon}
+              hideFolderIcon
+              isFolderExpanded={() => true}
+              onToggleFolder={() => {}}
+              onExpandFolder={() => {}}
+              getFolderExpansionKey={node => node.id}
+              onItemClick={node => {
+                const src = connectorById.get(node.id);
+                if (src) openTabForSource(src);
+              }}
+              getContextMenuItems={(node, { closeMenu }) => {
+                const src = connectorById.get(node.id);
+                if (!src) return null;
+                return [
+                  <MenuItem
+                    key="delete"
+                    onClick={() => {
+                      closeMenu();
+                      handleDelete(src);
+                    }}
+                  >
+                    <DeleteIcon
+                      size={16}
+                      strokeWidth={1.5}
+                      style={{ marginRight: 8 }}
+                    />
+                    Delete
+                  </MenuItem>,
+                ];
+              }}
+            />
+          )
+        }
+      </ExplorerShell>
 
-      {/* Delete Confirmation Dialog */}
       <Dialog
         open={deleteDialogOpen}
         onClose={() => setDeleteDialogOpen(false)}
@@ -290,7 +269,7 @@ function ConnectorExplorer() {
           </Button>
         </DialogActions>
       </Dialog>
-    </Box>
+    </>
   );
 }
 

--- a/app/src/components/ConsoleExplorer.tsx
+++ b/app/src/components/ConsoleExplorer.tsx
@@ -4,6 +4,7 @@ import {
   useImperativeHandle,
   useRef,
   useEffect,
+  useCallback,
 } from "react";
 import {
   Box,
@@ -23,14 +24,11 @@ import {
   Button,
   Tooltip,
   Alert,
-  InputBase,
 } from "@mui/material";
 import {
   SquareTerminal as ConsoleIcon,
   RotateCw as RefreshIcon,
   Plus as AddIcon,
-  Search as SearchIcon,
-  X as ClearIcon,
   FolderPlus as CreateFolderIcon,
 } from "lucide-react";
 import { useWorkspace } from "../contexts/workspace-context";
@@ -45,6 +43,7 @@ import FileExplorerDialog from "./FileExplorerDialog";
 import ConsoleInfoModal from "./ConsoleInfoModal";
 import FolderInfoModal from "./FolderInfoModal";
 import ConsoleTree from "./ConsoleTree";
+import ExplorerShell from "./ExplorerShell";
 
 interface ConsoleExplorerProps {
   onConsoleSelect: (
@@ -92,7 +91,6 @@ function ConsoleExplorer(
   const loading = currentWorkspace ? !!loadingMap[currentWorkspace.id] : false;
   const error = currentWorkspace ? _errorFor(currentWorkspace.id) : null;
 
-  // Dialogs & menus
   const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
   const [explorerDialogOpen, setExplorerDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -104,16 +102,9 @@ function ConsoleExplorer(
     null,
   );
 
-  // Undo stack
   const [undoStack, setUndoStack] = useState<
     Array<{ type: "delete"; id: string; isDirectory: boolean }>
   >([]);
-
-  // Search
-  const [localSearchQuery, setLocalSearchQuery] = useState("");
-  const [searchOpen, setSearchOpen] = useState(false);
-  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const searchInputRef = useRef<HTMLInputElement | null>(null);
 
   const collectIds = (nodes: ConsoleEntry[]): Set<string> => {
     const ids = new Set<string>();
@@ -125,33 +116,6 @@ function ConsoleExplorer(
     }
     return ids;
   };
-
-  const filteredMyConsoles =
-    localSearchQuery.length >= 2
-      ? filterTree(myConsoles, localSearchQuery)
-      : myConsoles;
-  const filteredWorkspaceConsoles =
-    localSearchQuery.length >= 2
-      ? filterTree(sharedWithWorkspace, localSearchQuery)
-      : sharedWithWorkspace;
-
-  const treeIds =
-    localSearchQuery.length >= 2
-      ? new Set([
-          ...collectIds(filteredMyConsoles),
-          ...collectIds(filteredWorkspaceConsoles),
-        ])
-      : new Set<string>();
-  const extraServerResults = searchResults.filter(r => !treeIds.has(r.id));
-
-  const noMatches =
-    localSearchQuery.length >= 2 &&
-    filteredMyConsoles.length === 0 &&
-    filteredWorkspaceConsoles.length === 0 &&
-    extraServerResults.length === 0 &&
-    !searchLoading;
-
-  // ── Handlers ──
 
   function _errorFor(wid: string) {
     const map = useConsoleTreeStore.getState().error;
@@ -169,40 +133,22 @@ function ConsoleExplorer(
     },
   }));
 
-  // Ensure initial load happens
   useEffect(() => {
-    // Tree store handles its own initial load; this is just for the ref
+    // Tree store handles its own initial load
   }, [currentWorkspace]);
 
-  const handleSearchChange = (value: string) => {
-    setLocalSearchQuery(value);
-    if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
-
-    if (value.length < 2) {
-      clearSearch();
-      return;
-    }
-
-    searchTimerRef.current = setTimeout(() => {
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      if (value.length < 2) {
+        clearSearch();
+        return;
+      }
       if (currentWorkspace) {
         searchConsoles(currentWorkspace.id, value);
       }
-    }, 400);
-  };
-
-  const handleSearchClear = () => {
-    setLocalSearchQuery("");
-    clearSearch();
-  };
-
-  const handleSearchClose = () => {
-    handleSearchClear();
-    setSearchOpen(false);
-  };
-
-  const handleSearchOpen = () => {
-    setSearchOpen(true);
-  };
+    },
+    [clearSearch, currentWorkspace, searchConsoles],
+  );
 
   const handleSearchResultClick = (result: ConsoleSearchResult) => {
     onConsoleSelect(
@@ -454,207 +400,156 @@ function ConsoleExplorer(
 
   const treeRef = useRef<import("./ConsoleTree").ConsoleTreeRef | null>(null);
 
-  const renderSkeletonItems = () => {
-    return Array.from({ length: 3 }).map((_, index) => (
-      <ListItemButton key={`skeleton-${index}`} sx={{ py: 0.25, pl: 0.5 }}>
-        <ListItemIcon sx={{ minWidth: 22, visibility: "hidden", mr: 0 }} />
-        <ListItemIcon sx={{ minWidth: 24 }}>
-          <Skeleton variant="circular" width={18} height={18} />
-        </ListItemIcon>
-        <ListItemText
-          primary={
-            <Skeleton
-              variant="text"
-              width={`${60 + Math.random() * 40}%`}
-              height={20}
-            />
-          }
-        />
-      </ListItemButton>
-    ));
-  };
-
-  return (
-    <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
-      <Box
-        sx={{
-          px: 1,
-          height: 37,
-          borderBottom: 1,
-          borderColor: "divider",
-          display: "flex",
-          alignItems: "center",
-          gap: 0.5,
-        }}
-      >
-        {searchOpen ? (
-          <InputBase
-            autoFocus
-            inputRef={searchInputRef}
-            placeholder="Search consoles..."
-            value={localSearchQuery}
-            onChange={e => handleSearchChange(e.target.value)}
-            onKeyDown={e => {
-              if (e.key === "Escape") handleSearchClose();
-            }}
-            startAdornment={
-              <SearchIcon
-                size={14}
-                style={{ marginLeft: 6, marginRight: 6, flexShrink: 0 }}
+  const renderSkeletonItems = () => (
+    <List component="nav" dense>
+      {Array.from({ length: 3 }).map((_, index) => (
+        <ListItemButton key={`skeleton-${index}`} sx={{ py: 0.25, pl: 0.5 }}>
+          <ListItemIcon sx={{ minWidth: 22, visibility: "hidden", mr: 0 }} />
+          <ListItemIcon sx={{ minWidth: 24 }}>
+            <Skeleton variant="circular" width={18} height={18} />
+          </ListItemIcon>
+          <ListItemText
+            primary={
+              <Skeleton
+                variant="text"
+                width={`${60 + Math.random() * 40}%`}
+                height={20}
               />
             }
-            sx={{
-              flex: 1,
-              minWidth: 0,
-              height: 28,
-              fontSize: "0.85rem",
-              bgcolor: "background.paper",
-              border: 1,
-              borderColor: "divider",
-              borderRadius: 1,
-              "&.Mui-focused": { borderColor: "primary.main" },
-              "& .MuiInputBase-input": {
-                p: 0,
-                height: "100%",
-                "&:focus": { outline: "none" },
-              },
-            }}
           />
-        ) : (
-          <Box
-            sx={{
-              flex: 1,
-              minWidth: 0,
-              overflow: "hidden",
-            }}
-          >
-            <Typography
-              variant="h6"
-              sx={{
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-                textTransform: "uppercase",
-              }}
-            >
-              Consoles
-            </Typography>
-          </Box>
-        )}
-        <Box sx={{ display: "flex", gap: 0, flexShrink: 0 }}>
-          {!searchOpen && (
+        </ListItemButton>
+      ))}
+    </List>
+  );
+
+  const actions = (
+    <>
+      <Tooltip title="Add new folder">
+        <IconButton onClick={handleMenuOpen} size="small">
+          <AddIcon size={20} strokeWidth={2} />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Refresh">
+        <IconButton onClick={fetchConsoleEntries} size="small">
+          <RefreshIcon size={20} strokeWidth={2} />
+        </IconButton>
+      </Tooltip>
+    </>
+  );
+
+  return (
+    <>
+      <ExplorerShell
+        title="Consoles"
+        actions={actions}
+        searchPlaceholder="Search consoles..."
+        onSearchChange={handleSearchChange}
+        error={error}
+        loading={loading}
+        skeleton={renderSkeletonItems()}
+      >
+        {({ searchQuery }) => {
+          const filteredMyConsoles =
+            searchQuery.length >= 2
+              ? filterTree(myConsoles, searchQuery)
+              : myConsoles;
+          const filteredWorkspaceConsoles =
+            searchQuery.length >= 2
+              ? filterTree(sharedWithWorkspace, searchQuery)
+              : sharedWithWorkspace;
+
+          const treeIds =
+            searchQuery.length >= 2
+              ? new Set([
+                  ...collectIds(filteredMyConsoles),
+                  ...collectIds(filteredWorkspaceConsoles),
+                ])
+              : new Set<string>();
+          const extraServerResults = searchResults.filter(
+            r => !treeIds.has(r.id),
+          );
+
+          const noMatches =
+            searchQuery.length >= 2 &&
+            filteredMyConsoles.length === 0 &&
+            filteredWorkspaceConsoles.length === 0 &&
+            extraServerResults.length === 0 &&
+            !searchLoading;
+
+          return (
             <>
-              <Tooltip title="Add new folder">
-                <IconButton onClick={handleMenuOpen} size="small">
-                  <AddIcon size={20} strokeWidth={2} />
-                </IconButton>
-              </Tooltip>
-              <Tooltip title="Refresh">
-                <IconButton onClick={fetchConsoleEntries} size="small">
-                  <RefreshIcon size={20} strokeWidth={2} />
-                </IconButton>
-              </Tooltip>
-            </>
-          )}
-          <Tooltip title={searchOpen ? "Close search" : "Search"}>
-            <IconButton
-              onClick={searchOpen ? handleSearchClose : handleSearchOpen}
-              size="small"
-            >
-              {searchOpen ? (
-                <ClearIcon size={20} strokeWidth={2} />
-              ) : (
-                <SearchIcon size={20} strokeWidth={2} />
+              <ConsoleTree
+                ref={treeRef}
+                mode="sidebar"
+                onFileOpen={handleFileOpen}
+                showFiles
+                enableDragDrop
+                enableDuplicate
+                enableInfo
+                enableDelete
+                enableRename
+                enableMove
+                onMoveRequest={handleMoveTo}
+                onInfoRequest={handleGetInfo}
+                onFolderInfoRequest={handleFolderInfo}
+                onDeleteRequest={handleDeleteRequest}
+                onSoftDelete={handleSoftDelete}
+                onDuplicate={handleDuplicate}
+                onUndo={handleUndo}
+                searchQuery={searchQuery}
+              />
+
+              {searchQuery.length >= 2 && extraServerResults.length > 0 && (
+                <Box sx={{ px: 1, pb: 1 }}>
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ px: 0.5, pb: 0.5, display: "block" }}
+                  >
+                    Also matched by description
+                  </Typography>
+                  <List dense disablePadding>
+                    {extraServerResults.map(result => (
+                      <ListItemButton
+                        key={result.id}
+                        onClick={() => handleSearchResultClick(result)}
+                        sx={{ borderRadius: 1, py: 0.25, minHeight: 36 }}
+                      >
+                        <ListItemIcon sx={{ minWidth: 28 }}>
+                          <ConsoleIcon size={16} />
+                        </ListItemIcon>
+                        <ListItemText
+                          primary={result.title}
+                          secondary={result.description || result.language}
+                          primaryTypographyProps={{
+                            variant: "body2",
+                            noWrap: true,
+                            fontSize: "0.8rem",
+                          }}
+                          secondaryTypographyProps={{
+                            variant: "caption",
+                            noWrap: true,
+                            fontSize: "0.7rem",
+                          }}
+                        />
+                      </ListItemButton>
+                    ))}
+                  </List>
+                </Box>
               )}
-            </IconButton>
-          </Tooltip>
-        </Box>
-      </Box>
-      {error && (
-        <Box sx={{ p: 2 }}>
-          <Typography color="error" variant="body2">
-            {error}
-          </Typography>
-        </Box>
-      )}
 
-      <Box sx={{ flex: 1, minHeight: 0, overflowY: "auto" }}>
-        {loading ? (
-          <List component="nav" dense>
-            {renderSkeletonItems()}
-          </List>
-        ) : (
-          <ConsoleTree
-            ref={treeRef}
-            mode="sidebar"
-            onFileOpen={handleFileOpen}
-            showFiles
-            enableDragDrop
-            enableDuplicate
-            enableInfo
-            enableDelete
-            enableRename
-            enableMove
-            onMoveRequest={handleMoveTo}
-            onInfoRequest={handleGetInfo}
-            onFolderInfoRequest={handleFolderInfo}
-            onDeleteRequest={handleDeleteRequest}
-            onSoftDelete={handleSoftDelete}
-            onDuplicate={handleDuplicate}
-            onUndo={handleUndo}
-            searchQuery={localSearchQuery}
-          />
-        )}
+              {noMatches && (
+                <Box sx={{ px: 2, py: 1 }}>
+                  <Typography variant="caption" color="text.secondary">
+                    No consoles found
+                  </Typography>
+                </Box>
+              )}
+            </>
+          );
+        }}
+      </ExplorerShell>
 
-        {localSearchQuery.length >= 2 && extraServerResults.length > 0 && (
-          <Box sx={{ px: 1, pb: 1 }}>
-            <Typography
-              variant="caption"
-              color="text.secondary"
-              sx={{ px: 0.5, pb: 0.5, display: "block" }}
-            >
-              Also matched by description
-            </Typography>
-            <List dense disablePadding>
-              {extraServerResults.map(result => (
-                <ListItemButton
-                  key={result.id}
-                  onClick={() => handleSearchResultClick(result)}
-                  sx={{ borderRadius: 1, py: 0.25, minHeight: 36 }}
-                >
-                  <ListItemIcon sx={{ minWidth: 28 }}>
-                    <ConsoleIcon size={16} />
-                  </ListItemIcon>
-                  <ListItemText
-                    primary={result.title}
-                    secondary={result.description || result.language}
-                    primaryTypographyProps={{
-                      variant: "body2",
-                      noWrap: true,
-                      fontSize: "0.8rem",
-                    }}
-                    secondaryTypographyProps={{
-                      variant: "caption",
-                      noWrap: true,
-                      fontSize: "0.7rem",
-                    }}
-                  />
-                </ListItemButton>
-              ))}
-            </List>
-          </Box>
-        )}
-
-        {noMatches && (
-          <Box sx={{ px: 2, py: 1 }}>
-            <Typography variant="caption" color="text.secondary">
-              No consoles found
-            </Typography>
-          </Box>
-        )}
-      </Box>
-
-      {/* Add Menu */}
       <Menu
         anchorEl={menuAnchor}
         open={Boolean(menuAnchor)}
@@ -678,7 +573,6 @@ function ConsoleExplorer(
         </MenuItem>
       </Menu>
 
-      {/* Delete Confirmation Dialog */}
       <Dialog
         open={deleteDialogOpen}
         onClose={() => setDeleteDialogOpen(false)}
@@ -710,7 +604,6 @@ function ConsoleExplorer(
         </DialogActions>
       </Dialog>
 
-      {/* Console Info Modal */}
       <ConsoleInfoModal
         open={infoModalOpen}
         onClose={() => setInfoModalOpen(false)}
@@ -718,14 +611,12 @@ function ConsoleExplorer(
         workspaceId={currentWorkspace?.id}
       />
 
-      {/* Folder Info Modal */}
       <FolderInfoModal
         open={folderInfoOpen}
         onClose={() => setFolderInfoOpen(false)}
         folder={folderInfoItem}
       />
 
-      {/* File Explorer Dialog for Move */}
       <FileExplorerDialog
         open={explorerDialogOpen}
         onClose={() => {
@@ -740,7 +631,7 @@ function ConsoleExplorer(
           selectedItem ? getParentFolderIdForItem(selectedItem) : null
         }
       />
-    </Box>
+    </>
   );
 }
 

--- a/app/src/components/ConsoleExplorer.tsx
+++ b/app/src/components/ConsoleExplorer.tsx
@@ -362,15 +362,16 @@ function ConsoleExplorer(
 
   const handleSoftDelete = async (item: ConsoleEntry) => {
     if (!currentWorkspace || !item.id) return;
+    const itemId = item.id;
     const success = await deleteItem(
       currentWorkspace.id,
-      item.id,
+      itemId,
       item.isDirectory,
     );
     if (success) {
       setUndoStack(prev => [
         ...prev,
-        { type: "delete", id: item.id!, isDirectory: item.isDirectory },
+        { type: "delete", id: itemId, isDirectory: item.isDirectory },
       ]);
     }
   };

--- a/app/src/components/DashboardsExplorer.tsx
+++ b/app/src/components/DashboardsExplorer.tsx
@@ -372,7 +372,7 @@ export function DashboardsExplorer() {
         </DialogTitle>
         <DialogContent>
           <DialogContentText>
-            Are you sure you want to delete "{deleteTarget?.name}"?
+            Are you sure you want to delete &quot;{deleteTarget?.name}&quot;?
             {deleteTarget?.isDirectory
               ? " All dashboards inside will be moved to the root level."
               : " This action cannot be undone."}

--- a/app/src/components/DashboardsExplorer.tsx
+++ b/app/src/components/DashboardsExplorer.tsx
@@ -6,7 +6,6 @@ import {
   Stack,
   Typography,
   Tooltip,
-  Alert,
   Dialog,
   DialogTitle,
   DialogContent,
@@ -31,6 +30,7 @@ import { focusDashboardTab } from "../dashboard-runtime/shell";
 import type { Dashboard } from "../dashboard-runtime/types";
 import { computeDashboardStateHash } from "../utils/stateHash";
 import ResourceTree, { type ResourceTreeNode } from "./ResourceTree";
+import ExplorerShell from "./ExplorerShell";
 
 const EMPTY_TREE: ResourceTreeNode[] = [];
 const NEW_DASHBOARD_TEMPLATE = {
@@ -292,86 +292,50 @@ export function DashboardsExplorer() {
     return null;
   })();
 
+  const actions = (
+    <>
+      <Tooltip title="New Dashboard">
+        <IconButton size="small" onClick={handleCreate}>
+          <AddIcon size={20} strokeWidth={2} />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Refresh">
+        <IconButton size="small" onClick={handleRefresh} disabled={loading}>
+          <RefreshIcon size={20} strokeWidth={2} />
+        </IconButton>
+      </Tooltip>
+    </>
+  );
+
+  const isInitialLoading =
+    loading && myDashboards.length === 0 && workspaceDashboards.length === 0;
+
   return (
-    <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
-      {/* Header */}
-      <Box
-        sx={{
-          px: 1,
-          py: 0.25,
-          minHeight: 37,
-          borderBottom: 1,
-          borderColor: "divider",
+    <>
+      <ExplorerShell
+        title="Dashboards"
+        actions={actions}
+        searchPlaceholder="Search dashboards..."
+        error={error}
+        onErrorClose={() => {
+          if (workspaceId) {
+            useDashboardTreeStore.setState(state => {
+              state.error[workspaceId] = null;
+            });
+          }
         }}
-      >
-        <Box
-          sx={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-            height: "100%",
-            minHeight: 32,
-          }}
-        >
-          <Typography
-            variant="h6"
-            sx={{
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-              textTransform: "uppercase",
-            }}
-          >
-            Dashboards
-          </Typography>
-          <Box sx={{ display: "flex", gap: 0 }}>
-            <Tooltip title="New Dashboard">
-              <IconButton size="small" onClick={handleCreate}>
-                <AddIcon size={20} strokeWidth={2} />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Refresh">
-              <IconButton
-                size="small"
-                onClick={handleRefresh}
-                disabled={loading}
-              >
-                <RefreshIcon size={20} strokeWidth={2} />
-              </IconButton>
-            </Tooltip>
-          </Box>
-        </Box>
-      </Box>
-
-      {/* Error Alert */}
-      {error && (
-        <Alert
-          severity="error"
-          onClose={() => {
-            if (workspaceId) {
-              useDashboardTreeStore.setState(state => {
-                state.error[workspaceId] = null;
-              });
-            }
-          }}
-          sx={{ mx: 2, mt: 2 }}
-        >
-          {error}
-        </Alert>
-      )}
-
-      {/* Tree */}
-      <Box sx={{ flexGrow: 1, overflow: "auto" }}>
-        {loading &&
-        myDashboards.length === 0 &&
-        workspaceDashboards.length === 0 ? (
+        loading={isInitialLoading}
+        skeleton={
           <Box sx={{ p: 3, textAlign: "center", color: "text.secondary" }}>
             <Typography variant="body2">Loading...</Typography>
           </Box>
-        ) : (
+        }
+      >
+        {({ searchQuery }) => (
           <ResourceTree
             sections={sectionsDef}
             mode="sidebar"
+            searchQuery={searchQuery}
             activeItemId={activeDashboardTabId}
             getItemIcon={getItemIcon}
             enableDragDrop
@@ -399,7 +363,7 @@ export function DashboardsExplorer() {
             canManageItem={canManageItem}
           />
         )}
-      </Box>
+      </ExplorerShell>
 
       {/* Delete Confirmation Dialog */}
       <Dialog open={!!deleteTarget} onClose={() => setDeleteTarget(null)}>
@@ -466,7 +430,7 @@ export function DashboardsExplorer() {
         onClose={() => setInfoTarget(null)}
         members={members}
       />
-    </Box>
+    </>
   );
 }
 

--- a/app/src/components/DatabaseExplorer.tsx
+++ b/app/src/components/DatabaseExplorer.tsx
@@ -1,22 +1,15 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useMemo } from "react";
 import {
   Box,
   Typography,
-  List,
-  ListItem,
-  ListItemButton,
-  ListItemIcon,
-  ListItemText,
   Alert,
   IconButton,
   Skeleton,
-  Menu,
   MenuItem,
+  ListItemIcon,
   Tooltip,
 } from "@mui/material";
 import {
-  ChevronRight as ChevronRightIcon,
-  ChevronDown as ChevronDownIcon,
   Database as DatabaseIcon,
   Table as CollectionIcon,
   Eye as ViewIcon,
@@ -34,8 +27,12 @@ import CreateDatabaseDialog from "./CreateDatabaseDialog";
 import { useSchemaStore, Connection, TreeNode } from "../store/schemaStore";
 import { useDatabaseCatalogStore } from "../store/databaseCatalogStore";
 import { useConsoleStore } from "../store/consoleStore";
+import ResourceTree, {
+  type ResourceTreeNode,
+  type ResourceTreeSection,
+} from "./ResourceTree";
+import ExplorerShell from "./ExplorerShell";
 
-// For backward compatibility with existing props
 export interface CollectionInfo {
   name: string;
   type: string;
@@ -64,7 +61,7 @@ const DatabaseTypeIcon = React.memo(
   }) => {
     const iconUrl = typeToIconUrl(type);
     if (iconUrl) return <IconImg src={iconUrl} alt={type} />;
-    return <DatabaseIcon size={24} strokeWidth={1.5} />;
+    return <DatabaseIcon size={20} strokeWidth={1.5} />;
   },
 );
 DatabaseTypeIcon.displayName = "DatabaseTypeIcon";
@@ -78,11 +75,25 @@ interface DatabaseExplorerProps {
   onCollectionClick?: (databaseId: string, collection: CollectionInfo) => void;
 }
 
+// Lookup info stashed alongside each ResourceTreeNode so the lazy-load /
+// context-menu callbacks can recover the original TreeNode + connection.
+type DbNodeInfo =
+  | {
+      type: "connection";
+      connectionId: string;
+      displayName: string;
+      dbType: string;
+    }
+  | {
+      type: "node";
+      connectionId: string;
+      node: TreeNode;
+    };
+
 function DatabaseExplorer({
   onCollectionSelect,
   onCollectionClick,
 }: DatabaseExplorerProps) {
-  // Use the unified schema store
   const connections = useSchemaStore(s => s.connections);
   const treeNodes = useSchemaStore(s => s.treeNodes);
   const loading = useSchemaStore(s => s.loading);
@@ -95,9 +106,10 @@ function DatabaseExplorer({
 
   const { currentWorkspace } = useWorkspace();
 
-  const databases: Connection[] = currentWorkspace
-    ? connections[currentWorkspace.id] || []
-    : [];
+  const databases: Connection[] = useMemo(
+    () => (currentWorkspace ? connections[currentWorkspace.id] || [] : []),
+    [currentWorkspace, connections],
+  );
 
   const isLoadingConnections = currentWorkspace
     ? !!loading[`connections:${currentWorkspace.id}`]
@@ -121,22 +133,14 @@ function DatabaseExplorer({
     [dbTypes],
   );
 
-  const [loadingData, setLoadingData] = useState<Set<string>>(new Set());
-
-  const {
-    expandedDatabases,
-    toggleDatabase,
-    isDatabaseExpanded,
-    expandedNodes,
-    toggleNode,
-  } = useDatabaseExplorerStore();
+  const { toggleDatabase, isDatabaseExpanded, expandedNodes, toggleNode } =
+    useDatabaseExplorerStore();
 
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [editingDatabaseId, setEditingDatabaseId] = useState<
     string | undefined
   >(undefined);
 
-  // Initialize connections on mount
   useEffect(() => {
     if (currentWorkspace) {
       ensureConnections(currentWorkspace.id);
@@ -144,87 +148,25 @@ function DatabaseExplorer({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentWorkspace?.id, ensureConnections]);
 
-  // Fetch tree roots for all databases
-  const fetchDatabaseDataLocal = useCallback(
-    async (connectionId: string) => {
-      if (!currentWorkspace) return;
-      setLoadingData(prev => new Set(prev).add(connectionId));
-      await ensureTreeRoot(currentWorkspace.id, connectionId);
-      setLoadingData(prev => {
-        const next = new Set(prev);
-        next.delete(connectionId);
-        return next;
-      });
-    },
-    [currentWorkspace, ensureTreeRoot],
-  );
-
   useEffect(() => {
     if (!currentWorkspace) return;
     databases.forEach(db => {
       const hasNodes = treeNodes[db.id] && treeNodes[db.id]["root"];
       if (!hasNodes) {
-        fetchDatabaseDataLocal(db.id);
+        ensureTreeRoot(currentWorkspace.id, db.id);
       }
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [databases, currentWorkspace?.id, treeNodes, fetchDatabaseDataLocal]);
+  }, [databases, currentWorkspace?.id, treeNodes, ensureTreeRoot]);
 
-  // Re-fetch children for expanded nodes that lost their data (e.g., after refresh)
-  useEffect(() => {
+  const handleRefresh = useCallback(async () => {
     if (!currentWorkspace) return;
+    await refreshConnections(currentWorkspace.id);
+  }, [currentWorkspace, refreshConnections]);
 
-    databases.forEach(db => {
-      if (!isDatabaseExpanded(db.id)) return;
-
-      const dbTree = treeNodes[db.id];
-      if (!dbTree) return;
-
-      const rootNodes = dbTree["root"] || [];
-
-      const checkAndFetchMissingChildren = (node: TreeNode) => {
-        const nodeKey = `${db.id}:${node.kind}:${node.id}`;
-        if (!node.hasChildren || !expandedNodes[nodeKey]) return;
-
-        const childKey = `${node.kind}:${node.id}`;
-        const children = dbTree[childKey];
-
-        if (!children) {
-          // Expanded node with missing children - fetch them
-          ensureTreeChildren(currentWorkspace.id, db.id, {
-            id: node.id,
-            kind: node.kind,
-            metadata: node.metadata,
-          });
-        } else {
-          // Recurse into existing children
-          children.forEach(checkAndFetchMissingChildren);
-        }
-      };
-
-      rootNodes.forEach(checkAndFetchMissingChildren);
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    currentWorkspace?.id,
-    databases,
-    treeNodes,
-    expandedNodes,
-    isDatabaseExpanded,
-    ensureTreeChildren,
-  ]);
-
-  const handleDatabaseToggle = useCallback(
-    (connectionId: string) => {
-      toggleDatabase(connectionId);
-      const hasNodes =
-        treeNodes[connectionId] && treeNodes[connectionId]["root"];
-      if (!isDatabaseExpanded(connectionId) && !hasNodes) {
-        fetchDatabaseDataLocal(connectionId);
-      }
-    },
-    [toggleDatabase, treeNodes, isDatabaseExpanded, fetchDatabaseDataLocal],
-  );
+  const handleDatabaseCreated = useCallback(() => {
+    handleRefresh();
+  }, [handleRefresh]);
 
   const handleCollectionClick = useCallback(
     (connectionId: string, collection: CollectionInfo) => {
@@ -234,160 +176,334 @@ function DatabaseExplorer({
     [onCollectionSelect, onCollectionClick],
   );
 
-  const handleRefresh = useCallback(async () => {
-    if (!currentWorkspace) return;
-    setLoadingData(new Set());
-    await refreshConnections(currentWorkspace.id);
-  }, [currentWorkspace, refreshConnections]);
+  // ---------- Tree adapter ----------
 
-  const handleDatabaseCreated = useCallback(() => {
-    handleRefresh();
-  }, [handleRefresh]);
+  // Build a lookup map and the section tree in one pass so callbacks can
+  // recover original TreeNode data from ResourceTreeNode.id.
+  const { sections, nodeInfoById } = useMemo(() => {
+    const info = new Map<string, DbNodeInfo>();
 
-  const renderSkeletonItems = () => {
-    return Array.from({ length: 3 }).map((_, index) => (
-      <ListItem key={`skeleton-${index}`} disablePadding>
-        <ListItemButton sx={{ py: 0.5, pl: 1 }}>
-          <ListItemIcon sx={{ minWidth: 32 }}>
-            <Skeleton variant="circular" width={20} height={20} />
-          </ListItemIcon>
-          <ListItemIcon sx={{ minWidth: 32 }}>
-            <Skeleton variant="circular" width={24} height={24} />
-          </ListItemIcon>
-          <ListItemText
-            primary={
-              <Skeleton
-                variant="text"
-                width={`${60 + Math.random() * 40}%`}
-                height={20}
-              />
-            }
-          />
-        </ListItemButton>
-      </ListItem>
-    ));
-  };
+    const makeConnectionNodeId = (dbId: string) => dbId;
+    const makeTreeNodeId = (dbId: string, node: TreeNode) =>
+      `${dbId}:${node.kind}:${node.id}`;
 
-  const renderCollectionSkeletonItems = () => {
-    return Array.from({ length: 3 }).map((_, index) => (
-      <ListItem key={`collection-skeleton-${index}`} disablePadding>
-        <ListItemButton sx={{ py: 0.25, pl: 4 }}>
-          <ListItemIcon sx={{ minWidth: 24 }}>
-            <Skeleton variant="circular" width={16} height={16} />
-          </ListItemIcon>
-          <ListItemText
-            primary={
-              <Skeleton
-                variant="text"
-                width={`${50 + Math.random() * 30}%`}
-                height={16}
-              />
-            }
-          />
-        </ListItemButton>
-      </ListItem>
-    ));
-  };
+    const buildTreeNode = (
+      connectionId: string,
+      node: TreeNode,
+    ): ResourceTreeNode => {
+      const rtId = makeTreeNodeId(connectionId, node);
+      info.set(rtId, { type: "node", connectionId, node });
 
-  const renderNodeSkeleton = (level: number) => {
-    const pl = 1 + (level + 1) * 1.5 + 2.75;
-    return Array.from({ length: 3 }).map((_, index) => (
-      <ListItem key={`node-skeleton-${index}`} disablePadding>
-        <ListItemButton sx={{ py: 0.25, pl }}>
-          <ListItemIcon sx={{ minWidth: 28 }}>
-            <Skeleton variant="circular" width={16} height={16} />
-          </ListItemIcon>
-          <ListItemText
-            primary={
-              <Skeleton
-                variant="text"
-                width={`${50 + Math.random() * 30}%`}
-                height={16}
-              />
-            }
-          />
-        </ListItemButton>
-      </ListItem>
-    ));
-  };
+      const childKey = `${node.kind}:${node.id}`;
+      const rawChildren = treeNodes[connectionId]?.[childKey];
 
-  // ---------------- Context menu for databases ----------------
-  const [contextFocusKey, setContextFocusKey] = useState<string | null>(null);
+      const isDir = node.hasChildren === true;
+      let children: ResourceTreeNode[] | undefined;
+      if (isDir) {
+        if (rawChildren === undefined) {
+          children = undefined;
+        } else {
+          children = rawChildren.map(child =>
+            buildTreeNode(connectionId, child),
+          );
+        }
+      } else {
+        children = undefined;
+      }
 
-  const [databaseContextMenu, setDatabaseContextMenu] = useState<{
-    mouseX: number;
-    mouseY: number;
-    item: { databaseId: string; databaseName: string };
-  } | null>(null);
+      return {
+        id: rtId,
+        name: node.label,
+        path: node.label,
+        isDirectory: isDir,
+        children,
+      };
+    };
 
-  // ---------------- Context menu for collections ----------------
-  const [contextMenu, setContextMenu] = useState<{
-    mouseX: number;
-    mouseY: number;
-    item: { databaseId: string; collectionName: string };
-  } | null>(null);
-
-  const handleDatabaseContextMenu = useCallback(
-    (event: React.MouseEvent, databaseId: string, databaseName: string) => {
-      event.preventDefault();
-      event.stopPropagation();
-      setDatabaseContextMenu({
-        mouseX: event.clientX + 2,
-        mouseY: event.clientY - 6,
-        item: { databaseId, databaseName },
+    const connectionNodes: ResourceTreeNode[] = databases.map(db => {
+      const rtId = makeConnectionNodeId(db.id);
+      info.set(rtId, {
+        type: "connection",
+        connectionId: db.id,
+        displayName: db.displayName,
+        dbType: db.type,
       });
-      setContextFocusKey(databaseId);
+
+      const rawRoots = treeNodes[db.id]?.["root"];
+      let children: ResourceTreeNode[] | undefined;
+      if (rawRoots === undefined) {
+        children = undefined;
+      } else {
+        children = rawRoots.map(n => buildTreeNode(db.id, n));
+      }
+
+      return {
+        id: rtId,
+        name: db.displayName,
+        path: db.displayName,
+        isDirectory: true,
+        children,
+      };
+    });
+
+    const sectionsList: ResourceTreeSection[] = [
+      {
+        key: "databases",
+        label: "",
+        hideSectionHeader: true,
+        nodes: connectionNodes,
+      },
+    ];
+
+    return { sections: sectionsList, nodeInfoById: info };
+  }, [databases, treeNodes]);
+
+  const isFolderExpanded = useCallback(
+    (key: string) => {
+      const info = nodeInfoById.get(key);
+      if (!info) return false;
+      if (info.type === "connection") {
+        return isDatabaseExpanded(info.connectionId);
+      }
+      // For non-connection nodes, expansion is tracked in expandedNodes under
+      // the `${connectionId}:${kind}:${id}` key (which is the same as the
+      // ResourceTreeNode id we've chosen).
+      return !!expandedNodes[key];
     },
-    [],
+    [nodeInfoById, isDatabaseExpanded, expandedNodes],
   );
 
-  const handleEditDatabase = useCallback(() => {
-    if (!databaseContextMenu) return;
-    const { databaseId } = databaseContextMenu.item;
-    setEditingDatabaseId(databaseId);
-    setCreateDialogOpen(true);
-    setDatabaseContextMenu(null);
-  }, [databaseContextMenu]);
-
-  const handleDropDatabase = useCallback(async () => {
-    if (!databaseContextMenu) return;
-    const { databaseId, databaseName } = databaseContextMenu.item;
-
-    if (
-      !window.confirm(
-        `Are you sure you want to delete database "${databaseName}"? This action cannot be undone.`,
-      )
-    ) {
-      setDatabaseContextMenu(null);
-      return;
-    }
-
-    try {
-      if (currentWorkspace) {
-        await deleteConnection(currentWorkspace.id, databaseId);
+  const onToggleFolder = useCallback(
+    (key: string) => {
+      const info = nodeInfoById.get(key);
+      if (!info) return;
+      if (info.type === "connection") {
+        toggleDatabase(info.connectionId);
+      } else {
+        toggleNode(key);
       }
-    } catch (err: unknown) {
-      const message =
-        err instanceof Error ? err.message : "Failed to delete database";
-      alert(message);
-    } finally {
-      setDatabaseContextMenu(null);
-    }
-  }, [databaseContextMenu, currentWorkspace, deleteConnection]);
+    },
+    [nodeInfoById, toggleDatabase, toggleNode],
+  );
 
-  const handleDropCollection = useCallback(() => {
-    if (!contextMenu) return;
-    const { databaseId, collectionName } = contextMenu.item;
-    const command = `db.getCollection("${collectionName}").drop()`;
-    const { openTab, setActiveTab } = useConsoleStore.getState();
-    const tabId = openTab({
-      title: `Drop ${collectionName}`,
-      content: command,
-      databaseId,
-    });
-    setActiveTab(tabId);
-    setContextMenu(null);
-  }, [contextMenu]);
+  const onExpandFolder = useCallback(
+    (key: string) => {
+      const info = nodeInfoById.get(key);
+      if (!info) return;
+      if (info.type === "connection") {
+        if (!isDatabaseExpanded(info.connectionId)) {
+          toggleDatabase(info.connectionId);
+        }
+      } else if (!expandedNodes[key]) {
+        toggleNode(key);
+      }
+    },
+    [
+      nodeInfoById,
+      isDatabaseExpanded,
+      toggleDatabase,
+      expandedNodes,
+      toggleNode,
+    ],
+  );
+
+  const onLoadChildren = useCallback(
+    (node: ResourceTreeNode) => {
+      if (!currentWorkspace) return;
+      const info = nodeInfoById.get(node.id);
+      if (!info) return;
+      if (info.type === "connection") {
+        ensureTreeRoot(currentWorkspace.id, info.connectionId);
+      } else {
+        ensureTreeChildren(currentWorkspace.id, info.connectionId, {
+          id: info.node.id,
+          kind: info.node.kind,
+          metadata: info.node.metadata,
+        });
+      }
+    },
+    [currentWorkspace, nodeInfoById, ensureTreeRoot, ensureTreeChildren],
+  );
+
+  const isLoadingChildren = useCallback(
+    (node: ResourceTreeNode) => {
+      const info = nodeInfoById.get(node.id);
+      if (!info) return false;
+      if (info.type === "connection") {
+        return !!loading[`tree:${info.connectionId}:root`];
+      }
+      return !!loading[
+        `tree:${info.connectionId}:${info.node.kind}:${info.node.id}`
+      ];
+    },
+    [nodeInfoById, loading],
+  );
+
+  const getItemIcon = useCallback(
+    (node: ResourceTreeNode, ctx?: { isExpanded: boolean }) => {
+      const info = nodeInfoById.get(node.id);
+      if (!info) return null;
+      const iconEl = (() => {
+        if (info.type === "connection") {
+          return (
+            <DatabaseTypeIcon
+              type={info.dbType}
+              typeToIconUrl={typeToIconUrl}
+            />
+          );
+        }
+        switch (info.node.kind) {
+          case "dataset":
+          case "group":
+          case "schema":
+            return ctx?.isExpanded ? (
+              <FolderOpenIcon size={18} strokeWidth={1.5} />
+            ) : (
+              <FolderIcon size={18} strokeWidth={1.5} />
+            );
+          case "database":
+            return <LayersIcon size={18} strokeWidth={1.5} />;
+          case "table":
+          case "collection":
+            return <CollectionIcon size={18} strokeWidth={1.5} />;
+          case "view":
+            return <ViewIcon size={18} strokeWidth={1.5} />;
+          default:
+            return null;
+        }
+      })();
+      return iconEl;
+    },
+    [nodeInfoById, typeToIconUrl],
+  );
+
+  const getContextMenuItems = useCallback(
+    (
+      node: ResourceTreeNode,
+      helpers: { closeMenu: () => void },
+    ): React.ReactNode[] | null => {
+      const info = nodeInfoById.get(node.id);
+      if (!info) return null;
+
+      if (info.type === "connection") {
+        return [
+          <MenuItem
+            key="edit-connection"
+            onClick={() => {
+              helpers.closeMenu();
+              setEditingDatabaseId(info.connectionId);
+              setCreateDialogOpen(true);
+            }}
+          >
+            <ListItemIcon sx={{ minWidth: 26 }}>
+              <SettingsIcon size={16} strokeWidth={1.5} />
+            </ListItemIcon>
+            Edit connection
+          </MenuItem>,
+          <MenuItem
+            key="delete-database"
+            onClick={async () => {
+              helpers.closeMenu();
+              if (
+                !window.confirm(
+                  `Are you sure you want to delete database "${info.displayName}"? This action cannot be undone.`,
+                )
+              ) {
+                return;
+              }
+              try {
+                if (currentWorkspace) {
+                  await deleteConnection(
+                    currentWorkspace.id,
+                    info.connectionId,
+                  );
+                }
+              } catch (err: unknown) {
+                const message =
+                  err instanceof Error
+                    ? err.message
+                    : "Failed to delete database";
+                alert(message);
+              }
+            }}
+          >
+            <ListItemIcon sx={{ minWidth: 26 }}>
+              <DeleteIcon size={16} strokeWidth={1.5} />
+            </ListItemIcon>
+            Delete database
+          </MenuItem>,
+        ];
+      }
+
+      // For node (table / collection / view / folder / etc.)
+      const { node: treeNode, connectionId } = info;
+      const isLeafCollection =
+        !treeNode.hasChildren &&
+        (treeNode.kind === "collection" || treeNode.kind === "table");
+      if (!isLeafCollection) {
+        return []; // no menu
+      }
+      return [
+        <MenuItem
+          key="drop-collection"
+          onClick={() => {
+            helpers.closeMenu();
+            const command = `db.getCollection("${treeNode.label}").drop()`;
+            const { openTab, setActiveTab } = useConsoleStore.getState();
+            const tabId = openTab({
+              title: `Drop ${treeNode.label}`,
+              content: command,
+              databaseId: connectionId,
+            });
+            setActiveTab(tabId);
+          }}
+        >
+          <ListItemIcon sx={{ minWidth: 26 }}>
+            <DeleteIcon size={16} strokeWidth={1.5} />
+          </ListItemIcon>
+          Delete collection
+        </MenuItem>,
+      ];
+    },
+    [nodeInfoById, currentWorkspace, deleteConnection],
+  );
+
+  const handleItemClick = useCallback(
+    (node: ResourceTreeNode) => {
+      const info = nodeInfoById.get(node.id);
+      if (!info) return;
+      if (info.type === "node") {
+        const { node: treeNode, connectionId } = info;
+        if (!treeNode.hasChildren) {
+          handleCollectionClick(connectionId, {
+            name: treeNode.label,
+            type: treeNode.kind,
+            options: treeNode.metadata,
+          });
+        }
+      }
+    },
+    [nodeInfoById, handleCollectionClick],
+  );
+
+  const renderSkeletonItems = () => (
+    <Box sx={{ p: 1 }}>
+      {Array.from({ length: 3 }).map((_, index) => (
+        <Box
+          key={`skeleton-${index}`}
+          sx={{ display: "flex", alignItems: "center", gap: 1, py: 0.5 }}
+        >
+          <Skeleton variant="circular" width={20} height={20} />
+          <Skeleton variant="circular" width={24} height={24} />
+          <Skeleton
+            variant="text"
+            width={`${60 + Math.random() * 40}%`}
+            height={20}
+          />
+        </Box>
+      ))}
+    </Box>
+  );
 
   if (connectionError) {
     return (
@@ -404,297 +520,55 @@ function DatabaseExplorer({
     );
   }
 
-  const renderNode = (
-    connectionId: string,
-    node: TreeNode,
-    level: number,
-  ): React.ReactNode => {
-    const nodeKey = `${connectionId}:${node.kind}:${node.id}`;
-    const isExpanded = !!expandedNodes[nodeKey];
-    const childKey = `${node.kind}:${node.id}`;
-    const children = treeNodes[connectionId]?.[childKey];
-    const isLoading = loading[`tree:${connectionId}:${childKey}`];
-
-    const getIcon = () => {
-      switch (node.kind) {
-        case "dataset":
-        case "group":
-        case "schema":
-          return isExpanded ? (
-            <FolderOpenIcon size={18} strokeWidth={1.5} />
-          ) : (
-            <FolderIcon size={18} strokeWidth={1.5} />
-          );
-        case "database":
-          return <LayersIcon size={18} strokeWidth={1.5} />;
-        case "table":
-        case "collection":
-          return <CollectionIcon size={18} strokeWidth={1.5} />;
-        case "view":
-          return <ViewIcon size={18} strokeWidth={1.5} />;
-        default:
-          return null;
-      }
-    };
-
-    return (
-      <React.Fragment key={nodeKey}>
-        <ListItem disablePadding>
-          <ListItemButton
-            onClick={() => {
-              if (node.hasChildren) {
-                toggleNode(nodeKey);
-                if (!children && !isExpanded) {
-                  if (currentWorkspace) {
-                    ensureTreeChildren(currentWorkspace.id, connectionId, {
-                      id: node.id,
-                      kind: node.kind,
-                      metadata: node.metadata,
-                    });
-                  }
-                }
-              } else {
-                handleCollectionClick(connectionId, {
-                  name: node.label,
-                  type: node.kind,
-                  options: node.metadata,
-                });
-              }
-            }}
-            onContextMenu={event => {
-              if (
-                !node.hasChildren &&
-                (node.kind === "collection" || node.kind === "table")
-              ) {
-                event.preventDefault();
-                event.stopPropagation();
-                setContextMenu({
-                  mouseX: event.clientX + 2,
-                  mouseY: event.clientY - 6,
-                  item: {
-                    databaseId: connectionId,
-                    collectionName: node.label,
-                  },
-                });
-                setContextFocusKey(nodeKey);
-              }
-            }}
-            sx={{
-              py: 0.25,
-              pl: 1 + level * 1.5,
-              outline: contextFocusKey === nodeKey ? "1px solid" : undefined,
-              outlineColor: contextFocusKey === nodeKey ? "divider" : undefined,
-            }}
-          >
-            <ListItemIcon sx={{ minWidth: 22 }}>
-              {node.hasChildren ? (
-                isExpanded ? (
-                  <ChevronDownIcon strokeWidth={1.5} size={20} />
-                ) : (
-                  <ChevronRightIcon strokeWidth={1.5} size={20} />
-                )
-              ) : null}
-            </ListItemIcon>
-            <ListItemIcon sx={{ minWidth: 24 }}>{getIcon()}</ListItemIcon>
-            <ListItemText
-              primary={
-                <Typography
-                  variant="body2"
-                  sx={{
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
-                  }}
-                >
-                  {node.label}
-                </Typography>
-              }
-            />
-          </ListItemButton>
-        </ListItem>
-        {node.hasChildren && isExpanded && (
-          <List dense disablePadding>
-            {isLoading || (!children && isExpanded) ? (
-              renderNodeSkeleton(level)
-            ) : children && children.length === 0 ? (
-              <ListItem disablePadding sx={{ pl: 4 + (level + 1) * 2 }}>
-                <ListItemText
-                  secondary={
-                    <Typography variant="caption" color="text.secondary">
-                      Empty
-                    </Typography>
-                  }
-                />
-              </ListItem>
-            ) : (
-              children?.map(child => renderNode(connectionId, child, level + 1))
-            )}
-          </List>
-        )}
-      </React.Fragment>
-    );
-  };
+  const actions = (
+    <>
+      <Tooltip title="Add new database">
+        <IconButton size="small" onClick={() => setCreateDialogOpen(true)}>
+          <AddIcon size={20} strokeWidth={2} />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Refresh">
+        <IconButton size="small" onClick={handleRefresh}>
+          <RefreshIcon size={20} strokeWidth={2} />
+        </IconButton>
+      </Tooltip>
+    </>
+  );
 
   return (
-    <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
-      <Box
-        sx={{
-          px: 1,
-          py: 0.25,
-          minHeight: 37,
-          borderBottom: 1,
-          borderColor: "divider",
-        }}
+    <>
+      <ExplorerShell
+        title="Databases"
+        actions={actions}
+        searchPlaceholder="Search databases..."
+        loading={isLoadingConnections && databases.length === 0}
+        skeleton={renderSkeletonItems()}
       >
-        <Box
-          sx={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-            height: "100%",
-            minHeight: 32,
-          }}
-        >
-          <Box
-            sx={{
-              flexGrow: 1,
-              overflow: "hidden",
-              maxWidth: "calc(100% - 80px)",
-            }}
-          >
-            <Typography
-              variant="h6"
-              sx={{
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-                textTransform: "uppercase",
-              }}
-            >
-              Databases
-            </Typography>
-          </Box>
-          <Box sx={{ display: "flex", gap: 0 }}>
-            <Tooltip title="Add new database">
-              <IconButton
-                size="small"
-                onClick={() => setCreateDialogOpen(true)}
-              >
-                <AddIcon size={20} strokeWidth={2} />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Refresh">
-              <IconButton size="small" onClick={handleRefresh}>
-                <RefreshIcon size={20} strokeWidth={2} />
-              </IconButton>
-            </Tooltip>
-          </Box>
-        </Box>
-      </Box>
-
-      <Box sx={{ flexGrow: 1, overflow: "auto" }}>
-        <List dense>
-          {isLoadingConnections ? (
-            renderSkeletonItems()
-          ) : databases.length === 0 ? (
-            <Box
-              sx={{
-                p: 3,
-                textAlign: "center",
-                color: "text.secondary",
-              }}
-            >
+        {({ searchQuery }) =>
+          databases.length === 0 ? (
+            <Box sx={{ p: 3, textAlign: "center", color: "text.secondary" }}>
               <Typography variant="body2">
                 No databases found in configuration
               </Typography>
             </Box>
           ) : (
-            databases.map(database => {
-              const isDatabaseExpandedLocal = !!expandedDatabases[database.id];
-              const isLoadingData = loadingData.has(database.id);
-              const dbRootNodes: TreeNode[] =
-                treeNodes[database.id]?.["root"] || [];
-
-              return (
-                <React.Fragment key={database.id}>
-                  {/* Database Level */}
-                  <ListItem disablePadding>
-                    <ListItemButton
-                      onClick={() => handleDatabaseToggle(database.id)}
-                      onContextMenu={e =>
-                        handleDatabaseContextMenu(
-                          e,
-                          database.id,
-                          database.displayName,
-                        )
-                      }
-                      sx={{
-                        py: 0.5,
-                        pl: 1,
-                        outline:
-                          contextFocusKey === database.id
-                            ? "1px solid"
-                            : undefined,
-                        outlineColor:
-                          contextFocusKey === database.id
-                            ? "divider"
-                            : undefined,
-                      }}
-                    >
-                      <ListItemIcon sx={{ minWidth: 22 }}>
-                        {isDatabaseExpandedLocal ? (
-                          <ChevronDownIcon strokeWidth={1.5} size={20} />
-                        ) : (
-                          <ChevronRightIcon strokeWidth={1.5} size={20} />
-                        )}
-                      </ListItemIcon>
-                      <ListItemIcon sx={{ minWidth: 24 }}>
-                        <DatabaseTypeIcon
-                          type={database.type}
-                          typeToIconUrl={typeToIconUrl}
-                        />
-                      </ListItemIcon>
-                      <ListItemText
-                        primary={
-                          <Box
-                            sx={{
-                              display: "flex",
-                              alignItems: "center",
-                              gap: 1,
-                              overflow: "hidden",
-                            }}
-                          >
-                            <Typography
-                              variant="body2"
-                              sx={{
-                                overflow: "hidden",
-                                textOverflow: "ellipsis",
-                                whiteSpace: "nowrap",
-                              }}
-                            >
-                              {database.displayName}
-                            </Typography>
-                          </Box>
-                        }
-                      />
-                    </ListItemButton>
-                  </ListItem>
-
-                  {isDatabaseExpandedLocal && (
-                    <List dense disablePadding>
-                      {isLoadingData
-                        ? renderCollectionSkeletonItems()
-                        : dbRootNodes.map(node =>
-                            renderNode(database.id, node, 1),
-                          )}
-                    </List>
-                  )}
-                </React.Fragment>
-              );
-            })
-          )}
-        </List>
-      </Box>
+            <ResourceTree
+              sections={sections}
+              mode="sidebar"
+              searchQuery={searchQuery}
+              getItemIcon={getItemIcon}
+              isFolderExpanded={isFolderExpanded}
+              onToggleFolder={onToggleFolder}
+              onExpandFolder={onExpandFolder}
+              getFolderExpansionKey={node => node.id}
+              onLoadChildren={onLoadChildren}
+              isLoadingChildren={isLoadingChildren}
+              getContextMenuItems={getContextMenuItems}
+              onItemClick={handleItemClick}
+            />
+          )
+        }
+      </ExplorerShell>
 
       <CreateDatabaseDialog
         open={createDialogOpen}
@@ -705,101 +579,7 @@ function DatabaseExplorer({
         onSuccess={handleDatabaseCreated}
         databaseId={editingDatabaseId}
       />
-
-      {/* Context Menu for collection */}
-      <Menu
-        open={contextMenu !== null}
-        onClose={() => {
-          setContextMenu(null);
-          setContextFocusKey(null);
-        }}
-        anchorReference="anchorPosition"
-        anchorPosition={
-          contextMenu !== null
-            ? { top: contextMenu.mouseY, left: contextMenu.mouseX }
-            : undefined
-        }
-        PaperProps={{
-          elevation: 2,
-          sx: {
-            boxShadow: "0px 2px 4px rgba(0,0,0,0.12)",
-            minWidth: 180,
-          },
-        }}
-      >
-        <MenuItem
-          onClick={handleDropCollection}
-          sx={{
-            pl: 1,
-            pr: 1,
-            "& .MuiListItemIcon-root": {
-              minWidth: 26,
-            },
-          }}
-        >
-          <ListItemIcon>
-            <DeleteIcon size={18} strokeWidth={1.5} />
-          </ListItemIcon>
-          Delete collection
-        </MenuItem>
-      </Menu>
-
-      {/* Context Menu for database */}
-      <Menu
-        open={databaseContextMenu !== null}
-        onClose={() => {
-          setDatabaseContextMenu(null);
-          setContextFocusKey(null);
-        }}
-        anchorReference="anchorPosition"
-        anchorPosition={
-          databaseContextMenu !== null
-            ? {
-                top: databaseContextMenu.mouseY,
-                left: databaseContextMenu.mouseX,
-              }
-            : undefined
-        }
-        PaperProps={{
-          elevation: 2,
-          sx: {
-            boxShadow: "0px 2px 4px rgba(0,0,0,0.12)",
-            minWidth: 180,
-          },
-        }}
-      >
-        <MenuItem
-          onClick={handleEditDatabase}
-          sx={{
-            pl: 1,
-            pr: 1,
-            "& .MuiListItemIcon-root": {
-              minWidth: 26,
-            },
-          }}
-        >
-          <ListItemIcon>
-            <SettingsIcon size={18} strokeWidth={1.5} />
-          </ListItemIcon>
-          Edit connection
-        </MenuItem>
-        <MenuItem
-          onClick={handleDropDatabase}
-          sx={{
-            pl: 1,
-            pr: 1,
-            "& .MuiListItemIcon-root": {
-              minWidth: 26,
-            },
-          }}
-        >
-          <ListItemIcon>
-            <DeleteIcon size={18} strokeWidth={1.5} />
-          </ListItemIcon>
-          Delete database
-        </MenuItem>
-      </Menu>
-    </Box>
+    </>
   );
 }
 

--- a/app/src/components/DbFlowForm.tsx
+++ b/app/src/components/DbFlowForm.tsx
@@ -1803,8 +1803,8 @@ export const DbFlowForm = forwardRef<DbFlowFormRef, DbFlowFormProps>(
                             Review and adjust the destination column types. The
                             AI agent can help inspect your source table and
                             suggest optimal types. You can also manually adjust
-                            any column's destination type using the dropdowns
-                            below.
+                            any column&apos;s destination type using the
+                            dropdowns below.
                           </Typography>
 
                           <SchemaMappingTable
@@ -2029,7 +2029,8 @@ export const DbFlowForm = forwardRef<DbFlowFormRef, DbFlowFormProps>(
                                             borderRadius: 4,
                                           }}
                                         >
-                                          {trackingCol} &gt; '{lastValue}'
+                                          {trackingCol} &gt; &apos;{lastValue}
+                                          &apos;
                                         </code>
                                       </Typography>
                                     </Alert>

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -470,9 +470,10 @@ function Editor({
         });
       }
       if (tab.resultsViewMode) {
+        const viewMode = tab.resultsViewMode;
         setTabViewModes(prev => {
           if (prev[tab.id]) return prev;
-          return { ...prev, [tab.id]: tab.resultsViewMode! };
+          return { ...prev, [tab.id]: viewMode };
         });
       }
     }

--- a/app/src/components/EmbeddableDashboard.tsx
+++ b/app/src/components/EmbeddableDashboard.tsx
@@ -61,6 +61,16 @@ const EmbeddableDashboard: React.FC = () => {
   const { width: gridWidth, containerRef: gridContainerRef } =
     useContainerWidth();
 
+  const queryExecutor = useMemo(
+    () =>
+      db
+        ? createDuckDBQueryExecutor(db)
+        : async () => {
+            throw new Error("Embedded DuckDB session is not ready");
+          },
+    [db],
+  );
+
   useEffect(() => {
     const token = window.location.pathname.split("/embed/")[1];
     if (!token) {
@@ -176,15 +186,6 @@ const EmbeddableDashboard: React.FC = () => {
     }
     return result;
   })();
-  const queryExecutor = useMemo(
-    () =>
-      db
-        ? createDuckDBQueryExecutor(db)
-        : async () => {
-            throw new Error("Embedded DuckDB session is not ready");
-          },
-    [db],
-  );
 
   return (
     <ThemeProvider theme={theme}>

--- a/app/src/components/ExplorerShell.tsx
+++ b/app/src/components/ExplorerShell.tsx
@@ -1,0 +1,176 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import {
+  Alert,
+  Box,
+  IconButton,
+  InputBase,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { Search as SearchIcon, X as ClearIcon } from "lucide-react";
+
+export interface ExplorerShellProps {
+  title: string;
+  actions?: ReactNode;
+  searchPlaceholder?: string;
+  /**
+   * Fired whenever the effective search query changes, debounced by
+   * `searchDebounceMs` (default 400ms). Empty string is emitted when the user
+   * clears the field or closes the search input.
+   */
+  onSearchChange?: (query: string) => void;
+  searchDebounceMs?: number;
+  error?: string | null;
+  onErrorClose?: () => void;
+  loading?: boolean;
+  skeleton?: ReactNode;
+  /**
+   * Render-prop for the body. Receives the current debounced search query so
+   * consumers can pass it directly to a tree's `searchQuery` prop (client-side
+   * filtering). Also receives the raw, un-debounced value for UI concerns
+   * like "show 'no matches' hint".
+   */
+  children: (ctx: { searchQuery: string; rawSearchQuery: string }) => ReactNode;
+}
+
+export default function ExplorerShell({
+  title,
+  actions,
+  searchPlaceholder = "Search...",
+  onSearchChange,
+  searchDebounceMs = 400,
+  error,
+  onErrorClose,
+  loading = false,
+  skeleton,
+  children,
+}: ExplorerShellProps) {
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [rawQuery, setRawQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      setDebouncedQuery(rawQuery);
+    }, searchDebounceMs);
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [rawQuery, searchDebounceMs]);
+
+  useEffect(() => {
+    onSearchChange?.(debouncedQuery);
+  }, [debouncedQuery, onSearchChange]);
+
+  const handleSearchOpen = useCallback(() => {
+    setSearchOpen(true);
+  }, []);
+
+  const handleSearchClose = useCallback(() => {
+    setRawQuery("");
+    setDebouncedQuery("");
+    setSearchOpen(false);
+  }, []);
+
+  return (
+    <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
+      <Box
+        sx={{
+          px: 1,
+          py: 0.25,
+          minHeight: 37,
+          borderBottom: 1,
+          borderColor: "divider",
+          display: "flex",
+          alignItems: "center",
+          gap: 0.5,
+        }}
+      >
+        {searchOpen ? (
+          <InputBase
+            autoFocus
+            inputRef={searchInputRef}
+            placeholder={searchPlaceholder}
+            value={rawQuery}
+            onChange={e => setRawQuery(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === "Escape") handleSearchClose();
+            }}
+            startAdornment={
+              <SearchIcon
+                size={14}
+                style={{ marginLeft: 6, marginRight: 6, flexShrink: 0 }}
+              />
+            }
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              height: 28,
+              fontSize: "0.85rem",
+              bgcolor: "background.paper",
+              border: 1,
+              borderColor: "divider",
+              borderRadius: 1,
+              "&.Mui-focused": { borderColor: "primary.main" },
+              "& .MuiInputBase-input": {
+                p: 0,
+                height: "100%",
+                "&:focus": { outline: "none" },
+              },
+            }}
+          />
+        ) : (
+          <Box sx={{ flex: 1, minWidth: 0, overflow: "hidden" }}>
+            <Typography
+              variant="h6"
+              sx={{
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                textTransform: "uppercase",
+              }}
+            >
+              {title}
+            </Typography>
+          </Box>
+        )}
+        <Box sx={{ display: "flex", gap: 0, flexShrink: 0 }}>
+          {!searchOpen && actions}
+          <Tooltip title={searchOpen ? "Close search" : "Search"}>
+            <IconButton
+              onClick={searchOpen ? handleSearchClose : handleSearchOpen}
+              size="small"
+            >
+              {searchOpen ? (
+                <ClearIcon size={20} strokeWidth={2} />
+              ) : (
+                <SearchIcon size={20} strokeWidth={2} />
+              )}
+            </IconButton>
+          </Tooltip>
+        </Box>
+      </Box>
+
+      {error && (
+        <Alert severity="error" onClose={onErrorClose} sx={{ mx: 2, mt: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      <Box sx={{ flex: 1, minHeight: 0, overflowY: "auto" }}>
+        {loading && skeleton
+          ? skeleton
+          : children({ searchQuery: debouncedQuery, rawSearchQuery: rawQuery })}
+      </Box>
+    </Box>
+  );
+}

--- a/app/src/components/FlowsExplorer.tsx
+++ b/app/src/components/FlowsExplorer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Box,
   IconButton,
@@ -9,7 +9,6 @@ import {
   ListItemText,
   Typography,
   Tooltip,
-  Alert,
   Skeleton,
   Menu,
   MenuItem,
@@ -24,6 +23,11 @@ import {
 import { useWorkspace } from "../contexts/workspace-context";
 import { useFlowStore } from "../store/flowStore";
 import { useConsoleStore } from "../store/consoleStore";
+import ResourceTree, {
+  type ResourceTreeNode,
+  type ResourceTreeSection,
+} from "./ResourceTree";
+import ExplorerShell from "./ExplorerShell";
 
 export function FlowsExplorer() {
   const { currentWorkspace } = useWorkspace();
@@ -39,7 +43,10 @@ export function FlowsExplorer() {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
 
-  const flows = currentWorkspace ? flowsMap[currentWorkspace.id] || [] : [];
+  const flows = useMemo(
+    () => (currentWorkspace ? flowsMap[currentWorkspace.id] || [] : []),
+    [currentWorkspace, flowsMap],
+  );
   const isLoading = currentWorkspace
     ? !!loadingMap[currentWorkspace.id]
     : false;
@@ -120,14 +127,11 @@ export function FlowsExplorer() {
     }
   };
 
-  // Helper to get a display title for a flow
   const getFlowTitle = (flow: any): string => {
     if (flow.sourceType === "database") {
-      // Database-to-database flow
       const destName = flow.tableDestination?.tableName || "Table";
       return `Query → ${destName}`;
     }
-    // Connector flow
     const sourceName = flow.dataSourceId?.name || "Source";
     const destName = flow.destinationDatabaseId?.name || "Destination";
     return `${sourceName} → ${destName}`;
@@ -162,247 +166,209 @@ export function FlowsExplorer() {
     return {
       label: "Pending",
       color: "warning" as const,
-      letter: "A", // Abandoned/Awaiting
+      letter: "A",
     };
   };
 
-  const renderSkeletonItems = () => {
-    return Array.from({ length: 3 }).map((_, index) => (
-      <ListItem key={`skeleton-${index}`} disablePadding>
-        <ListItemButton disabled>
-          <ListItemText
-            primary={
-              <Skeleton
-                variant="text"
-                width={`${60 + Math.random() * 40}%`}
-                height={20}
-              />
-            }
-            secondary={
-              <Box
-                component="span"
-                sx={{
-                  display: "inline-flex",
-                  gap: 0.5,
-                  alignItems: "center",
-                }}
-              >
-                <Skeleton variant="text" width={120} height={16} />
-                <Skeleton
-                  variant="rectangular"
-                  width={50}
-                  height={16}
-                  sx={{ borderRadius: 1 }}
-                />
-              </Box>
-            }
-          />
-        </ListItemButton>
-      </ListItem>
-    ));
+  const flowById = useMemo(() => {
+    const map = new Map<string, any>();
+    for (const flow of flows) {
+      map.set(flow._id, flow);
+    }
+    return map;
+  }, [flows]);
+
+  const sections = useMemo<ResourceTreeSection[]>(() => {
+    return [
+      {
+        key: "flows",
+        label: "",
+        hideSectionHeader: true,
+        nodes: flows.map(flow => ({
+          id: flow._id,
+          name: getFlowTitle(flow),
+          path: getFlowTitle(flow),
+          isDirectory: false,
+        })),
+      },
+    ];
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [flows]);
+
+  const getItemIcon = (node: ResourceTreeNode) => {
+    const flow = flowById.get(node.id);
+    if (!flow) return null;
+    if (flow.type === "webhook") {
+      return (
+        <WebhookIcon
+          size={20}
+          strokeWidth={1.5}
+          style={{
+            color:
+              flow.webhookConfig?.enabled !== false
+                ? undefined
+                : "var(--mui-palette-text-disabled)",
+          }}
+        />
+      );
+    }
+    if (flow.schedule?.enabled === true) {
+      return <ScheduleIcon size={20} strokeWidth={1.5} />;
+    }
+    return (
+      <PauseIcon
+        size={20}
+        strokeWidth={1.5}
+        style={{ color: "var(--mui-palette-text-disabled)" }}
+      />
+    );
   };
 
-  return (
-    <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
-      {/* Header */}
-      <Box
-        sx={{
-          px: 1,
-          py: 0.25,
-          minHeight: 37,
-          borderBottom: 1,
-          borderColor: "divider",
-        }}
-      >
-        <Box
-          sx={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-            height: "100%",
-            minHeight: 32,
-          }}
+  const getRightAdornment = (node: ResourceTreeNode) => {
+    const flow = flowById.get(node.id);
+    if (!flow) return null;
+    const status = getFlowStatus(flow);
+    return (
+      <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
+        <Tooltip
+          title={
+            flow.syncMode === "incremental" ? "Incremental Sync" : "Full Sync"
+          }
         >
           <Typography
-            variant="h6"
+            variant="caption"
             sx={{
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-              textTransform: "uppercase",
+              fontWeight: "bold",
+              color: "text.secondary",
+              cursor: "help",
             }}
           >
-            Flows
+            {flow.syncMode === "incremental" ? "I" : "F"}
           </Typography>
-          <Box sx={{ display: "flex", gap: 0 }}>
-            <Tooltip title="Add Flow">
-              <IconButton size="small" onClick={handleMenuOpen}>
-                <AddIcon size={20} strokeWidth={2} />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Refresh">
-              <IconButton
-                size="small"
-                onClick={handleRefresh}
-                disabled={isLoading}
-              >
-                <RefreshIcon size={20} strokeWidth={2} />
-              </IconButton>
-            </Tooltip>
-          </Box>
-        </Box>
+        </Tooltip>
+        <Tooltip title={status.label}>
+          <Typography
+            variant="caption"
+            sx={{
+              fontWeight: "bold",
+              color:
+                status.letter === "S"
+                  ? "success.main"
+                  : status.letter === "F"
+                    ? "error.main"
+                    : status.letter === "A"
+                      ? "warning.main"
+                      : "text.disabled",
+              cursor: "help",
+            }}
+          >
+            {status.letter}
+          </Typography>
+        </Tooltip>
       </Box>
+    );
+  };
 
-      {/* Error Alert */}
-      {error && (
-        <Alert
-          severity="error"
-          onClose={() =>
-            currentWorkspace?.id && clearError(currentWorkspace.id)
-          }
-          sx={{ mx: 2, mt: 2 }}
-        >
-          {error}
-        </Alert>
-      )}
+  const activeFlowTabId = useMemo(() => {
+    const tab = consoleTabs.find(
+      (t: any) =>
+        t.id === activeConsoleId &&
+        t.kind === "flow-editor" &&
+        t.metadata?.flowId,
+    );
+    return (tab as any)?.metadata?.flowId ?? null;
+  }, [consoleTabs, activeConsoleId]);
 
-      {/* Flows List */}
-      <Box sx={{ flexGrow: 1, overflow: "auto" }}>
-        {isLoading && flows.length === 0 ? (
-          <List dense>{renderSkeletonItems()}</List>
-        ) : flows.length === 0 ? (
-          <Box sx={{ p: 3, textAlign: "center", color: "text.secondary" }}>
-            <Typography variant="body2">No flows configured.</Typography>
-          </Box>
-        ) : (
-          <List dense>
-            {flows.map(flow => {
-              const status = getFlowStatus(flow);
-              const isActive = !!(
-                activeConsoleId &&
-                consoleTabs.find(
-                  (t: any) =>
-                    t.id === activeConsoleId &&
-                    t.kind === "flow-editor" &&
-                    t.metadata?.flowId === flow._id,
-                )
-              );
-              return (
-                <ListItem key={flow._id} disablePadding>
-                  <ListItemButton
-                    selected={isActive}
-                    onClick={() => handleEditFlow(flow._id)}
-                    sx={{
-                      px: 1,
-                      py: 0.2,
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "space-between",
-                    }}
-                  >
-                    <ListItemIcon sx={{ minWidth: 28 }}>
-                      {flow.type === "webhook" ? (
-                        <WebhookIcon
-                          size={20}
-                          strokeWidth={1.5}
-                          style={{
-                            fontSize: 24,
-                            color:
-                              flow.webhookConfig?.enabled !== false
-                                ? "text.primary"
-                                : "text.disabled",
-                          }}
-                        />
-                      ) : flow.schedule?.enabled === true ? (
-                        <ScheduleIcon
-                          size={20}
-                          strokeWidth={1.5}
-                          style={{
-                            fontSize: 24,
-                            color: "text.primary",
-                          }}
-                        />
-                      ) : (
-                        <PauseIcon
-                          size={20}
-                          color="currentColor"
-                          strokeWidth={1.5}
-                          style={{
-                            color: "var(--mui-palette-text-disabled)",
-                          }}
-                        />
-                      )}
-                    </ListItemIcon>
-                    <ListItemText
-                      primary={getFlowTitle(flow)}
-                      secondary={null}
-                      sx={{
-                        pr: 6,
-                        "& .MuiListItemText-primary": {
-                          whiteSpace: "nowrap",
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                        },
-                      }}
-                    />
-                    <Box
-                      sx={{
-                        position: "absolute",
-                        right: 16,
-                        top: "50%",
-                        transform: "translateY(-50%)",
-                        display: "flex",
-                        gap: 1,
-                        alignItems: "center",
-                      }}
-                    >
-                      <Tooltip
-                        title={
-                          flow.syncMode === "incremental"
-                            ? "Incremental Sync"
-                            : "Full Sync"
-                        }
-                      >
-                        <Typography
-                          variant="caption"
-                          sx={{
-                            fontWeight: "bold",
-                            color: "text.secondary",
-                            cursor: "help",
-                          }}
-                        >
-                          {flow.syncMode === "incremental" ? "I" : "F"}
-                        </Typography>
-                      </Tooltip>
-                      <Tooltip title={status.label}>
-                        <Typography
-                          variant="caption"
-                          sx={{
-                            fontWeight: "bold",
-                            color:
-                              status.letter === "S"
-                                ? "success.main"
-                                : status.letter === "F"
-                                  ? "error.main"
-                                  : status.letter === "A"
-                                    ? "warning.main"
-                                    : "text.disabled",
-                            cursor: "help",
-                          }}
-                        >
-                          {status.letter}
-                        </Typography>
-                      </Tooltip>
-                    </Box>
-                  </ListItemButton>
-                </ListItem>
-              );
-            })}
-          </List>
-        )}
-      </Box>
+  const renderSkeletonItems = () => (
+    <List dense>
+      {Array.from({ length: 3 }).map((_, index) => (
+        <ListItem key={`skeleton-${index}`} disablePadding>
+          <ListItemButton disabled>
+            <ListItemText
+              primary={
+                <Skeleton
+                  variant="text"
+                  width={`${60 + Math.random() * 40}%`}
+                  height={20}
+                />
+              }
+              secondary={
+                <Box
+                  component="span"
+                  sx={{
+                    display: "inline-flex",
+                    gap: 0.5,
+                    alignItems: "center",
+                  }}
+                >
+                  <Skeleton variant="text" width={120} height={16} />
+                  <Skeleton
+                    variant="rectangular"
+                    width={50}
+                    height={16}
+                    sx={{ borderRadius: 1 }}
+                  />
+                </Box>
+              }
+            />
+          </ListItemButton>
+        </ListItem>
+      ))}
+    </List>
+  );
 
-      {/* Add New Flow Menu */}
+  const actions = (
+    <>
+      <Tooltip title="Add Flow">
+        <IconButton size="small" onClick={handleMenuOpen}>
+          <AddIcon size={20} strokeWidth={2} />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Refresh">
+        <IconButton size="small" onClick={handleRefresh} disabled={isLoading}>
+          <RefreshIcon size={20} strokeWidth={2} />
+        </IconButton>
+      </Tooltip>
+    </>
+  );
+
+  return (
+    <>
+      <ExplorerShell
+        title="Flows"
+        actions={actions}
+        searchPlaceholder="Search flows..."
+        error={error}
+        onErrorClose={() => {
+          if (currentWorkspace?.id) clearError(currentWorkspace.id);
+        }}
+        loading={isLoading && flows.length === 0}
+        skeleton={renderSkeletonItems()}
+      >
+        {({ searchQuery }) =>
+          flows.length === 0 ? (
+            <Box sx={{ p: 3, textAlign: "center", color: "text.secondary" }}>
+              <Typography variant="body2">No flows configured.</Typography>
+            </Box>
+          ) : (
+            <ResourceTree
+              sections={sections}
+              mode="sidebar"
+              searchQuery={searchQuery}
+              activeItemId={activeFlowTabId || undefined}
+              getItemIcon={getItemIcon}
+              getRightAdornment={getRightAdornment}
+              hideFolderIcon
+              isFolderExpanded={() => true}
+              onToggleFolder={() => {}}
+              onExpandFolder={() => {}}
+              getFolderExpansionKey={node => node.id}
+              onItemClick={node => handleEditFlow(node.id)}
+            />
+          )
+        }
+      </ExplorerShell>
+
       <Menu
         anchorEl={anchorEl}
         open={open}
@@ -435,6 +401,6 @@ export function FlowsExplorer() {
           <ListItemText>Webhook Sync</ListItemText>
         </MenuItem>
       </Menu>
-    </Box>
+    </>
   );
 }

--- a/app/src/components/FlowsExplorer.tsx
+++ b/app/src/components/FlowsExplorer.tsx
@@ -192,7 +192,6 @@ export function FlowsExplorer() {
         })),
       },
     ];
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [flows]);
 
   const getItemIcon = (node: ResourceTreeNode) => {

--- a/app/src/components/ResourceTree.tsx
+++ b/app/src/components/ResourceTree.tsx
@@ -17,6 +17,7 @@ import {
   ListItemText as MuiListItemText,
   Menu,
   MenuItem,
+  Skeleton,
   Typography,
 } from "@mui/material";
 import {
@@ -86,6 +87,12 @@ export interface ResourceTreeSection {
   nodes: ResourceTreeNode[];
   droppableId?: string;
   defaultAccess?: "private" | "workspace";
+  /**
+   * When true, skip rendering the section header row entirely. Useful for
+   * explorers that have only one implicit section (e.g. Databases, Flows,
+   * Connectors) and don't want a visible group label.
+   */
+  hideSectionHeader?: boolean;
 }
 
 export interface CreatedFolderResult {
@@ -103,7 +110,37 @@ export interface ResourceTreeProps {
   activeItemId?: string | null;
   searchQuery?: string;
 
-  getItemIcon?: (node: ResourceTreeNode) => ReactNode;
+  getItemIcon?: (
+    node: ResourceTreeNode,
+    ctx?: { isExpanded: boolean },
+  ) => ReactNode;
+  /**
+   * Optional trailing adornment rendered at the right edge of a row. Used for
+   * status letters, badges, or secondary glyphs (e.g. Flows status, Consoles
+   * read-only eye).
+   */
+  getRightAdornment?: (node: ResourceTreeNode) => ReactNode;
+  /**
+   * When a folder is expanded and its `children` array is `undefined`, this
+   * fires so the caller can lazily fetch children. Not called again while
+   * children are being loaded (`isLoadingChildren` returning true).
+   */
+  onLoadChildren?: (node: ResourceTreeNode) => void;
+  /**
+   * When true for an expanded folder, the tree renders a compact skeleton row
+   * in place of its children.
+   */
+  isLoadingChildren?: (node: ResourceTreeNode) => boolean;
+  /**
+   * When provided and returns a non-null array, replaces the default
+   * rename/duplicate/delete/info/move context menu entries for that node.
+   * Items should be `<MenuItem>` elements (or `null`). Call `helpers.closeMenu`
+   * from within each MenuItem's onClick to dismiss the menu after an action.
+   */
+  getContextMenuItems?: (
+    node: ResourceTreeNode,
+    helpers: { closeMenu: () => void },
+  ) => ReactNode[] | null;
   showFiles?: boolean;
   /**
    * When true, folder rows render only a chevron + name (no folder icon), and
@@ -171,6 +208,10 @@ function ResourceTreeInner(
     activeItemId,
     searchQuery = "",
     getItemIcon,
+    getRightAdornment,
+    onLoadChildren,
+    isLoadingChildren,
+    getContextMenuItems,
     showFiles = true,
     hideFolderIcon = false,
     enableDragDrop = true,
@@ -326,6 +367,43 @@ function ResourceTreeInner(
       })),
     [sections, searchQuery],
   );
+
+  const loadChildrenRequestedRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    if (!onLoadChildren) return;
+
+    const requested = loadChildrenRequestedRef.current;
+    const visit = (nodes: ResourceTreeNode[]) => {
+      for (const node of nodes) {
+        if (!node.isDirectory) continue;
+        const expansionKey = getExpansionKey(node);
+        if (
+          isFolderExpanded(expansionKey) &&
+          node.children === undefined &&
+          !isLoadingChildren?.(node) &&
+          !requested.has(expansionKey)
+        ) {
+          requested.add(expansionKey);
+          onLoadChildren(node);
+        } else if (node.children !== undefined) {
+          // Clear the guard so subsequent collapses/re-expansions can re-trigger
+          // a fetch if the caller dropped the children again.
+          requested.delete(expansionKey);
+          visit(node.children);
+        }
+      }
+    };
+
+    for (const section of sections) {
+      visit(section.nodes);
+    }
+  }, [
+    getExpansionKey,
+    isFolderExpanded,
+    isLoadingChildren,
+    onLoadChildren,
+    sections,
+  ]);
 
   const flatNodeIds = useMemo(() => {
     const ids: string[] = [];
@@ -531,6 +609,15 @@ function ResourceTreeInner(
     (event: React.MouseEvent, item: ResourceTreeNode) => {
       event.preventDefault();
       event.stopPropagation();
+      // Peek at custom items up front: if the caller returned an empty array
+      // for this node, skip opening the menu entirely (rather than flashing an
+      // empty popover).
+      if (getContextMenuItems) {
+        const peek = getContextMenuItems(item, { closeMenu: () => {} });
+        if (Array.isArray(peek) && peek.length === 0) {
+          return;
+        }
+      }
       const readOnly = !resolveCanManage(item);
       setContextMenu({
         anchorPosition: { top: event.clientY + 2, left: event.clientX + 2 },
@@ -539,7 +626,7 @@ function ResourceTreeInner(
       });
       setFocusedNodeId(item.id);
     },
-    [resolveCanManage],
+    [getContextMenuItems, resolveCanManage],
   );
 
   const handleSectionContextMenu = useCallback(
@@ -700,6 +787,9 @@ function ResourceTreeInner(
         event.preventDefault();
         if (!isNodeExpanded(focusItem)) {
           onExpandFolder(getExpansionKey(focusItem));
+          if (focusItem.children === undefined && onLoadChildren) {
+            onLoadChildren(focusItem);
+          }
         }
         return;
       }
@@ -751,6 +841,7 @@ function ResourceTreeInner(
     onPickerFileClick,
     onToggleFolder,
     onExpandFolder,
+    onLoadChildren,
     onUndo,
     resolveCanManage,
     startInlineRename,
@@ -799,7 +890,7 @@ function ResourceTreeInner(
     isDropTarget?: boolean;
     isSelected?: boolean;
   }) => ({
-    pl: 0.5 + depth * 1.5,
+    pl: 1.5 + depth * 1.5,
     minWidth: 0,
     py: 0,
     minHeight: ROW_HEIGHT,
@@ -816,6 +907,15 @@ function ResourceTreeInner(
     outlineOffset: isDropTarget ? "-2px" : undefined,
     borderRadius: 0,
   });
+
+  const maybeLoadChildren = useCallback(
+    (node: ResourceTreeNode) => {
+      if (node.children === undefined && onLoadChildren) {
+        onLoadChildren(node);
+      }
+    },
+    [onLoadChildren],
+  );
 
   const renderTree = (
     nodes: ResourceTreeNode[],
@@ -836,6 +936,7 @@ function ResourceTreeInner(
       const isDropTarget =
         dropTargetId === node.id ||
         dropTargetId === getFolderDropTargetId(node.id);
+      const rightAdornment = getRightAdornment?.(node);
 
       if (node.isDirectory) {
         const folderRow = (
@@ -848,7 +949,9 @@ function ResourceTreeInner(
               if (mode === "picker") {
                 updateLocationSelection(node.id, sectionKey);
               } else {
+                const willExpand = !isExpanded;
                 onToggleFolder(getExpansionKey(node));
+                if (willExpand) maybeLoadChildren(node);
               }
             }}
             onContextMenu={event => handleContextMenu(event, node)}
@@ -897,7 +1000,9 @@ function ResourceTreeInner(
                 component="span"
                 onClick={event => {
                   event.stopPropagation();
+                  const willExpand = !isExpanded;
                   onToggleFolder(getExpansionKey(node));
+                  if (willExpand) maybeLoadChildren(node);
                 }}
                 sx={{
                   display: "inline-flex",
@@ -915,8 +1020,10 @@ function ResourceTreeInner(
               </Box>
             </ListItemIcon>
             {!hideFolderIcon && (
-              <ListItemIcon sx={{ minWidth: ICON_COL_WIDTH }}>
-                {isExpanded ? (
+              <ListItemIcon sx={{ minWidth: ICON_COL_WIDTH, mr: 0.75 }}>
+                {getItemIcon ? (
+                  getItemIcon(node, { isExpanded })
+                ) : isExpanded ? (
                   <FolderOpen size={16} strokeWidth={1.5} />
                 ) : (
                   <Folder size={16} strokeWidth={1.5} />
@@ -937,26 +1044,64 @@ function ResourceTreeInner(
                 },
               }}
             />
+            {rightAdornment ? (
+              <Box
+                sx={{
+                  ml: "auto",
+                  pl: 1,
+                  display: "flex",
+                  alignItems: "center",
+                  flexShrink: 0,
+                }}
+              >
+                {rightAdornment}
+              </Box>
+            ) : null}
           </ListItemButton>
         );
 
+        const childrenLoading = isExpanded
+          ? !!isLoadingChildren?.(node)
+          : false;
+        const childrenNotYetLoaded = isExpanded && node.children === undefined;
+
         const childrenContent = isExpanded
           ? (() => {
-              const childItems = renderTree(
-                node.children ?? [],
-                depth + 1,
-                sectionKey,
-              );
+              const showSkeleton = childrenLoading || childrenNotYetLoaded;
+              const childItems = showSkeleton
+                ? []
+                : renderTree(node.children ?? [], depth + 1, sectionKey);
               const childList = (
                 <List component="div" disablePadding dense>
-                  {childItems.length === 0 ? (
+                  {showSkeleton ? (
+                    Array.from({ length: 3 }).map((_, idx) => (
+                      <Box
+                        key={`child-skel-${idx}`}
+                        sx={{
+                          pl: 1.5 + (depth + 1) * 1.5 + 2.75,
+                          py: 0.5,
+                          display: "flex",
+                          alignItems: "center",
+                        }}
+                      >
+                        <Skeleton
+                          variant="text"
+                          width={`${50 + Math.random() * 30}%`}
+                          height={16}
+                        />
+                      </Box>
+                    ))
+                  ) : childItems.length === 0 ? (
                     <Typography
                       variant="caption"
                       color="text.disabled"
                       sx={{
-                        pl: 0.5 + (depth + 1) * 1.5 + 2.75,
-                        py: 0.5,
-                        display: "block",
+                        pl: 1.5 + (depth + 1) * 1.5 + 2.75,
+                        py: 0,
+                        minHeight: ROW_HEIGHT,
+                        lineHeight: `${ROW_HEIGHT}px`,
+                        display: "flex",
+                        alignItems: "center",
                       }}
                     >
                       Empty
@@ -1030,7 +1175,7 @@ function ResourceTreeInner(
               sx={{ minWidth: ICON_COL_WIDTH, visibility: "hidden", mr: 0 }}
             />
           )}
-          <ListItemIcon sx={{ minWidth: ICON_COL_WIDTH }}>
+          <ListItemIcon sx={{ minWidth: ICON_COL_WIDTH, mr: 0.75 }}>
             {getItemIcon ? getItemIcon(node) : null}
           </ListItemIcon>
           <MuiListItemText
@@ -1044,6 +1189,19 @@ function ResourceTreeInner(
               },
             }}
           />
+          {rightAdornment ? (
+            <Box
+              sx={{
+                ml: "auto",
+                pl: 1,
+                display: "flex",
+                alignItems: "center",
+                flexShrink: 0,
+              }}
+            >
+              {rightAdornment}
+            </Box>
+          ) : null}
         </ListItemButton>
       );
 
@@ -1088,7 +1246,7 @@ function ResourceTreeInner(
         onContextMenu={event => handleSectionContextMenu(event, section.key)}
         sx={{
           py: 0,
-          pl: 0.5,
+          pl: 1.5,
           minWidth: 0,
           minHeight: ROW_HEIGHT,
           bgcolor: isDropTarget
@@ -1142,7 +1300,7 @@ function ResourceTreeInner(
           </Box>
         </ListItemIcon>
         {section.icon ? (
-          <ListItemIcon sx={{ minWidth: ICON_COL_WIDTH }}>
+          <ListItemIcon sx={{ minWidth: ICON_COL_WIDTH, mr: 0.75 }}>
             {section.icon}
           </ListItemIcon>
         ) : null}
@@ -1167,25 +1325,30 @@ function ResourceTreeInner(
   const treeContent = (
     <List component="nav" dense disablePadding>
       {filteredSections.map(section => {
-        const sectionBody =
-          sectionExpanded[section.key] !== false ? (
-            section.nodes.length > 0 ? (
-              renderTree(section.nodes, 1, section.key)
-            ) : (
-              <Typography
-                sx={{
-                  pl: 3,
-                  py: 0.5,
-                  color: "text.disabled",
-                  fontSize: "0.8rem",
-                  fontStyle: "italic",
-                }}
-                variant="body2"
-              >
-                Nothing here yet
-              </Typography>
+        const sectionVisible =
+          section.hideSectionHeader || sectionExpanded[section.key] !== false;
+        const sectionBody = sectionVisible ? (
+          section.nodes.length > 0 ? (
+            renderTree(
+              section.nodes,
+              section.hideSectionHeader ? 0 : 1,
+              section.key,
             )
-          ) : null;
+          ) : (
+            <Typography
+              sx={{
+                pl: section.hideSectionHeader ? 2.5 : 4,
+                py: 0.5,
+                color: "text.disabled",
+                fontSize: "0.8rem",
+                fontStyle: "italic",
+              }}
+              variant="body2"
+            >
+              Nothing here yet
+            </Typography>
+          )
+        ) : null;
 
         // Wrap the section header + its body in a single block so the sticky
         // section header has a containing block spanning the whole section.
@@ -1201,7 +1364,7 @@ function ResourceTreeInner(
                 : undefined
             }
           >
-            {renderSectionHeader(section)}
+            {section.hideSectionHeader ? null : renderSectionHeader(section)}
             {sectionBody}
           </SectionScope>
         );
@@ -1264,6 +1427,13 @@ function ResourceTreeInner(
           (() => {
             const { item, readOnly } = contextMenu;
             const canManage = !readOnly;
+
+            const customItems = getContextMenuItems?.(item, {
+              closeMenu: () => setContextMenu(null),
+            });
+            if (customItems !== undefined && customItems !== null) {
+              return customItems;
+            }
 
             return [
               enableRename && canManage && (

--- a/app/src/components/ResultsTable.tsx
+++ b/app/src/components/ResultsTable.tsx
@@ -91,7 +91,7 @@ const ResultsTable: React.FC<ResultsTableProps> = ({
     if (executedAt) {
       setViewMode("table");
     }
-  }, [executedAt]); // Use executedAt as dependency to detect new query executions
+  }, [executedAt, setViewMode]);
 
   // Helper function to normalize any data into an array format
   const normalizeToArray = (data: any): any[] => {

--- a/app/src/components/dashboard/PresentationMode.tsx
+++ b/app/src/components/dashboard/PresentationMode.tsx
@@ -68,12 +68,6 @@ const PresentationMode: React.FC<PresentationModeProps> = ({ onExit }) => {
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [handleKeyDown]);
 
-  if (!activeDashboard) return null;
-
-  const allSourcesReady = activeDashboard.dataSources.every(
-    ds => runtimeSession?.dataSources[ds.id]?.status === "ready",
-  );
-
   const errorSummary = useMemo(() => {
     if (!activeDashboard) return null;
     const failingSources = activeDashboard.dataSources.filter(
@@ -88,6 +82,12 @@ const PresentationMode: React.FC<PresentationModeProps> = ({ onExit }) => {
         "Failed to load one or more data sources",
     };
   }, [activeDashboard, runtimeSession]);
+
+  if (!activeDashboard) return null;
+
+  const allSourcesReady = activeDashboard.dataSources.every(
+    ds => runtimeSession?.dataSources[ds.id]?.status === "ready",
+  );
 
   const allGridLayouts = (() => {
     const breakpoints = ["lg", "md", "sm", "xs"] as const;

--- a/app/src/components/widgets/CodeWidget.tsx
+++ b/app/src/components/widgets/CodeWidget.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { Box, CircularProgress, Typography } from "@mui/material";
 import { useDashboardQuery } from "../../dashboard-runtime/useDashboardQuery";
 import type { DashboardQueryExecutor } from "../../dashboard-runtime/types";
@@ -26,7 +26,7 @@ const CodeWidget: React.FC<CodeWidgetProps> = ({
     queryExecutor,
     enabled: Boolean(localSql.trim()),
   });
-  const data = result?.rows || [];
+  const data = useMemo(() => result?.rows ?? [], [result?.rows]);
 
   useEffect(() => {
     if (error) {

--- a/app/src/components/widgets/DataTableWidget.tsx
+++ b/app/src/components/widgets/DataTableWidget.tsx
@@ -39,9 +39,10 @@ const DataTableWidgetComponent: React.FC<DataTableWidgetProps> = ({
   }, [error, onError]);
 
   let visibleFields = result?.fields || [];
-  if (tableConfig?.columns && tableConfig.columns.length > 0) {
+  const configuredColumns = tableConfig?.columns;
+  if (configuredColumns && configuredColumns.length > 0) {
     visibleFields = visibleFields.filter(f =>
-      tableConfig.columns!.includes(f.name),
+      configuredColumns.includes(f.name),
     );
   }
 

--- a/app/src/store/consoleTreeStore.ts
+++ b/app/src/store/consoleTreeStore.ts
@@ -407,10 +407,10 @@ export const useConsoleTreeStore = create<TreeState>()(
           access: resolvedAccess,
         });
         if (res.success && res.data) {
-          // Replace temp ID with real ID
+          const newId = res.data.id;
           set(state => {
             const node = findInAnySectionMut(state, workspaceId, tempId);
-            if (node) node.id = res.data!.id;
+            if (node) node.id = newId;
           });
           return { id: res.data.id, name: res.data.name };
         }
@@ -503,14 +503,14 @@ export const useConsoleTreeStore = create<TreeState>()(
           data?: { id: string; name: string; folderId?: string };
         }>(`/workspaces/${workspaceId}/consoles/${consoleId}/duplicate`);
         if (res.success && res.data) {
-          // Insert copy next to original optimistically
+          const newConsole = res.data;
           set(state => {
             const original = findInAnySectionMut(state, workspaceId, consoleId);
             if (!original) return;
             const copy: ConsoleEntry = {
               ...original,
-              id: res.data!.id,
-              name: res.data!.name,
+              id: newConsole.id,
+              name: newConsole.name,
               isDirectory: false,
             };
             // Find which section/folder the original is in

--- a/package.json
+++ b/package.json
@@ -77,11 +77,11 @@
   },
   "lint-staged": {
     "app/**/*.{ts,tsx}": [
-      "eslint --fix",
+      "eslint --fix --report-unused-disable-directives",
       "prettier --write"
     ],
     "api/**/*.ts": [
-      "eslint --fix",
+      "eslint --fix --report-unused-disable-directives",
       "prettier --write"
     ],
     "website/**/*.{ts,tsx}": [


### PR DESCRIPTION
## Summary

- Extracted a shared **`ExplorerShell`** for the left-rail panels: sticky title + action slot, toggleable debounced search input, scroll container, and error/loading slots — replacing duplicated header/search chrome across every explorer.
- Extended **`ResourceTree`** with `getRightAdornment`, `getContextMenuItems`, `onLoadChildren`/`isLoadingChildren` (lazy-load + skeleton), expansion-aware `getItemIcon`, and `hideSectionHeader` so a tree can render as a flat list.
- Migrated **Consoles, Dashboards, Flows, Connectors, and Databases** onto the shared primitives. `DatabaseExplorer` is now a thin `ResourceTree` adapter over the schema store with lazy children and per-node context menus (edit / delete).
- Tightened row spacing so icons, labels, empty-state placeholders, and skeletons line up consistently across all five explorers — bumped the base `pl`, added an `mr: 0.75` gap between the icon and label in every row, and normalized the "Empty" and "Nothing here yet" fallbacks to match real-row height.

## Test plan

- [ ] Consoles: tree renders with folders/files, drag-drop, rename, duplicate, delete, info, move, undo, and search still work.
- [ ] Dashboards: both sections (my / workspace) render, move-picker dialog still opens into a `ResourceTree` with correct selection state.
- [ ] Flows: flat list renders with status letters + sync-mode letters on the right; clicking opens/focuses the flow-editor tab.
- [ ] Connectors: flat list renders with per-type icons; right-click → Delete opens the confirmation dialog.
- [ ] Databases: connections lazy-load their root children on expand; nested schema/dataset/table rows lazy-load with a skeleton; right-click on a connection shows Edit/Delete; right-click on a collection/table shows "Delete collection".
- [ ] Icon→label gaps and left gutters look consistent when switching between the five explorers.

Made with [Cursor](https://cursor.com)