### PR TITLE
feat: introduce workspace skills system

### DIFF
--- a/api/src/agent-lib/entity-extraction.ts
+++ b/api/src/agent-lib/entity-extraction.ts
@@ -1,0 +1,212 @@
+/**
+ * Entity extraction for the skills system.
+ *
+ * Used on both sides of retrieval:
+ *   - Write path: when a skill is authored, extract entities from
+ *     `loadWhen + body` and union with author-declared entities.
+ *   - Read path: on each turn, extract entities from the user query +
+ *     short recent context, intersect with skill.entities arrays to
+ *     find candidate skills (before semantic re-ranking).
+ *
+ * Deterministic by design. Keeps tokens that look like identifiers or
+ * domain nouns: snake_case / dotted identifiers (e.g. `public.leads`,
+ * `customer_email`), camelCase runs, and alphanumeric words >= 3 chars.
+ * Lowercases everything and filters common English stopwords.
+ *
+ * LLM-based extraction is a future upgrade; keeping this path cheap and
+ * synchronous lets us run it every turn without latency or cost.
+ */
+
+const STOPWORDS = new Set([
+  "the",
+  "and",
+  "for",
+  "are",
+  "but",
+  "not",
+  "you",
+  "all",
+  "any",
+  "can",
+  "had",
+  "her",
+  "was",
+  "one",
+  "our",
+  "out",
+  "day",
+  "get",
+  "has",
+  "him",
+  "his",
+  "how",
+  "man",
+  "new",
+  "now",
+  "old",
+  "see",
+  "two",
+  "way",
+  "who",
+  "its",
+  "that",
+  "this",
+  "with",
+  "from",
+  "they",
+  "will",
+  "would",
+  "there",
+  "been",
+  "have",
+  "were",
+  "said",
+  "each",
+  "which",
+  "their",
+  "some",
+  "when",
+  "what",
+  "where",
+  "about",
+  "just",
+  "into",
+  "over",
+  "than",
+  "then",
+  "them",
+  "these",
+  "those",
+  "your",
+  "yours",
+  "mine",
+  "ours",
+  "why",
+  "yes",
+  "use",
+  "using",
+  "used",
+  "make",
+  "made",
+  "want",
+  "does",
+  "doing",
+  "done",
+  "very",
+  "also",
+  "only",
+  "much",
+  "many",
+  "most",
+  "such",
+  "should",
+  "could",
+  "may",
+  "might",
+  "must",
+  "shall",
+  "able",
+  "need",
+  "want",
+  "like",
+  "more",
+  "less",
+  "few",
+  "still",
+  "between",
+  "because",
+  "before",
+  "after",
+  "while",
+  "both",
+  "either",
+  "neither",
+  "since",
+  "until",
+]);
+
+// Drop purely numeric tokens — they're rarely useful as entities
+// (dates, row counts, etc.) and would create noise on overlap.
+function isPurelyNumeric(token: string): boolean {
+  return /^\d+$/.test(token);
+}
+
+function splitCamelCase(token: string): string[] {
+  // Split camelCase and PascalCase into pieces but keep the original too.
+  const pieces = token
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .split(" ")
+    .filter(Boolean);
+  if (pieces.length > 1) return [token, ...pieces];
+  return [token];
+}
+
+/**
+ * Extract a set of normalized entity tokens from arbitrary text.
+ *
+ * - Splits on non-identifier characters but preserves `.` and `_` as
+ *   part of identifiers (so `public.leads` and `customer_email` stay
+ *   intact, while also contributing split pieces `public`, `leads`).
+ * - Lowercases, dedupes, drops stopwords and tokens < 3 chars.
+ */
+export function extractEntities(text: string): string[] {
+  if (!text) return [];
+
+  const seen = new Set<string>();
+  const out: string[] = [];
+
+  // Phase 1: grab compound identifiers like `public.leads` or `a.b.c`.
+  const compound = text.match(
+    /[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+/g,
+  );
+  if (compound) {
+    for (const c of compound) {
+      const norm = c.toLowerCase();
+      if (!seen.has(norm)) {
+        seen.add(norm);
+        out.push(norm);
+      }
+      for (const piece of c.split(".")) {
+        const p = piece.toLowerCase();
+        if (p.length >= 3 && !STOPWORDS.has(p) && !seen.has(p)) {
+          seen.add(p);
+          out.push(p);
+        }
+      }
+    }
+  }
+
+  // Phase 2: tokenize everything else on non-identifier boundaries.
+  const tokens = text.split(/[^A-Za-z0-9_]+/).filter(Boolean);
+  for (const raw of tokens) {
+    for (const piece of splitCamelCase(raw)) {
+      const p = piece.toLowerCase();
+      if (p.length < 3) continue;
+      if (STOPWORDS.has(p)) continue;
+      if (isPurelyNumeric(p)) continue;
+      if (seen.has(p)) continue;
+      seen.add(p);
+      out.push(p);
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Overlap count between two entity sets (unordered).
+ * Used to rank candidate skills against the current user query.
+ */
+export function entityOverlap(
+  a: readonly string[],
+  b: readonly string[],
+): number {
+  if (a.length === 0 || b.length === 0) return 0;
+  const setB = new Set(b);
+  let count = 0;
+  for (const t of a) {
+    if (setB.has(t)) count += 1;
+  }
+  return count;
+}

--- a/api/src/agent-lib/tools/skill-tools.ts
+++ b/api/src/agent-lib/tools/skill-tools.ts
@@ -1,0 +1,150 @@
+/**
+ * Skill tools — agent-side CRUD + search for the skills system (issue #365).
+ *
+ * Four tools:
+ *   - save_skill     upsert a named playbook (auto-extracts entities)
+ *   - delete_skill   retract a skill by name
+ *   - load_skill     explicit load; appears in trace, forces commitment
+ *   - search_skills  fallback when the injected index misses
+ *
+ * The main retrieval happens *before* the agent runs — the system prompt
+ * is pre-populated with the skill index and top-k auto-loaded bodies. These
+ * tools exist so the agent can (a) write what it learns, (b) correct itself
+ * by deleting wrong skills, (c) pull a specific skill mid-turn, and (d) run
+ * a direct search if the index hint didn't fire.
+ */
+
+import { z } from "zod";
+import {
+  deleteSkill,
+  loadSkill,
+  saveSkill,
+  searchSkills,
+} from "../../services/skills.service";
+
+const saveSkillSchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .max(80)
+    .regex(/^[a-z0-9_]+$/, "name must be lowercase snake_case")
+    .describe(
+      "Unique skill name. Lowercase snake_case. Stable identifier — reuse the same name to overwrite an existing skill (the previous body is preserved for one undo step).",
+    ),
+  loadWhen: z
+    .string()
+    .min(1)
+    .max(500)
+    .describe(
+      "Short (1-2 sentence) description of when to load this skill. This is the primary retrieval signal; write it as a trigger, e.g. 'building a sales report or answering \"who are the best salespeople\"'.",
+    ),
+  body: z
+    .string()
+    .min(1)
+    .max(20000)
+    .describe(
+      "The full playbook content. Mix schema facts, gotchas, query patterns, IDs — whatever the agent will need next time the trigger fires. Prefer compact bullet points over prose.",
+    ),
+  entities: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Optional author-declared triggers (table names, columns, business concepts, country names, etc.) — unioned with extractor output to improve retrieval. Include synonyms (e.g. 'revenue' if the body talks about 'MRR').",
+    ),
+});
+
+const deleteSkillSchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .describe("Skill name to delete. Deletion is permanent."),
+});
+
+const loadSkillSchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .describe(
+      "Skill name to explicitly load. Use this when you see a skill in the index whose loadWhen matches what you're about to do but it wasn't auto-loaded.",
+    ),
+});
+
+const searchSkillsSchema = z.object({
+  query: z
+    .string()
+    .min(1)
+    .describe(
+      "Free-text query. Use this as a fallback when the injected skills index doesn't show an obvious match.",
+    ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(20)
+    .optional()
+    .describe("Max results (default 5)."),
+});
+
+type SaveInput = z.infer<typeof saveSkillSchema>;
+type DeleteInput = z.infer<typeof deleteSkillSchema>;
+type LoadInput = z.infer<typeof loadSkillSchema>;
+type SearchInput = z.infer<typeof searchSkillsSchema>;
+
+export function createSkillTools(workspaceId: string, userId?: string) {
+  const authorId = userId && userId.length > 0 ? userId : "agent";
+
+  return {
+    save_skill: {
+      description: [
+        "Save or overwrite a workspace-scoped skill — a named playbook that",
+        "will be auto-injected into future sessions when its `loadWhen`",
+        "trigger matches the user query. Use this whenever the user teaches",
+        "you something durable about this workspace (a schema fact, a gotcha,",
+        "a query pattern, a definition). Skills survive across sessions.",
+        "",
+        "Choose `name` as a stable snake_case identifier (e.g.",
+        "`mrr_walkthrough_fr`, `sms_funnel_conversion`). Write `loadWhen` as",
+        "a trigger phrase — what query or task should cause this to load.",
+        "Keep `body` compact and structured.",
+      ].join("\n"),
+      inputSchema: saveSkillSchema,
+      execute: async (input: SaveInput) => {
+        return saveSkill(workspaceId, input, authorId);
+      },
+    },
+    delete_skill: {
+      description:
+        "Delete a workspace skill by name. Use this to retract a skill that turned out to be wrong — without deletion, bad skills poison every future query. Deletion is permanent.",
+      inputSchema: deleteSkillSchema,
+      execute: async ({ name }: DeleteInput) => {
+        return deleteSkill(workspaceId, name);
+      },
+    },
+    load_skill: {
+      description:
+        "Explicitly load a skill by name from the index. Use this when you spot a skill in the injected index whose `loadWhen` matches what you're about to do, but it wasn't auto-loaded. Bumps the skill's useCount so retrieval can reinforce it later.",
+      inputSchema: loadSkillSchema,
+      execute: async ({ name }: LoadInput) => {
+        return loadSkill(workspaceId, name);
+      },
+    },
+    search_skills: {
+      description:
+        "Search workspace skills by free-text query. Fallback for when the injected skills index doesn't surface something you know should exist. Returns ranked full bodies.",
+      inputSchema: searchSkillsSchema,
+      execute: async ({ query, limit }: SearchInput) => {
+        const hits = await searchSkills(workspaceId, query, limit ?? 5);
+        return {
+          success: true,
+          results: hits.map(h => ({
+            name: h.name,
+            loadWhen: h.loadWhen,
+            body: h.body,
+            score: Math.round(h.score * 100) / 100,
+            entityOverlap: h.entityOverlap,
+          })),
+        };
+      },
+    },
+  };
+}

--- a/api/src/agents/console/index.ts
+++ b/api/src/agents/console/index.ts
@@ -14,6 +14,7 @@ import type {
 import { UNIVERSAL_PROMPT_V2 } from "../../agent-lib/prompts/universal";
 import { createUniversalTools } from "../../agent-lib/tools/universal-tools";
 import { createSelfDirectiveTools } from "../../agent-lib/tools/self-directive-tool";
+import { createSkillTools } from "../../agent-lib/tools/skill-tools";
 import { createConsoleSearchTools } from "../../agent-lib/tools/console-search-tools";
 import { createVersionHistoryTools } from "../../agent-lib/tools/version-history-tools";
 import type { ConsoleDataV2 } from "../../agent-lib/types";
@@ -161,6 +162,7 @@ export const consoleAgentFactory: AgentFactory = (
     workspaceCustomPrompt = "",
     selfDirective = "",
     consoleHints = "",
+    skillsBlock = "",
     activeConsoleResults,
   } = context;
 
@@ -208,6 +210,7 @@ export const consoleAgentFactory: AgentFactory = (
     context.toolExecutionContext,
   );
   const selfDirectiveTools = createSelfDirectiveTools(workspaceId);
+  const skillTools = createSkillTools(workspaceId, context.userId);
   const consoleSearchTools = createConsoleSearchTools(
     workspaceId,
     context.toolExecutionContext,
@@ -225,12 +228,14 @@ export const consoleAgentFactory: AgentFactory = (
       },
       {
         role: "system" as const,
-        content: selfDirectiveContext + consoleHints + runtimeContext,
+        content:
+          selfDirectiveContext + skillsBlock + consoleHints + runtimeContext,
       },
     ],
     tools: {
       ...tools,
       ...selfDirectiveTools,
+      ...skillTools,
       ...consoleSearchTools,
       ...versionHistoryTools,
     } as Record<string, any>,

--- a/api/src/agents/types.ts
+++ b/api/src/agents/types.ts
@@ -99,6 +99,13 @@ export interface AgentContext {
   selfDirective?: string;
   /** Auto-discovered relevant consoles (injected via embedding search) */
   consoleHints?: string;
+  /**
+   * Pre-rendered skills block: the workspace-scoped skills index + any
+   * auto-loaded skill bodies for this turn. Populated by `agent.routes.ts`
+   * via `retrieveRelevantSkills` + `renderSkillsPromptBlock`. Empty string
+   * if the workspace has no skills.
+   */
+  skillsBlock?: string;
   /** Active console's query results and chart state */
   activeConsoleResults?: {
     viewMode: "table" | "json" | "chart";

--- a/api/src/agents/unified/index.ts
+++ b/api/src/agents/unified/index.ts
@@ -2,6 +2,7 @@ import type { AgentConfig, AgentContext, AgentMeta } from "../types";
 import { createUniversalTools } from "../../agent-lib/tools/universal-tools";
 import { clientDashboardTools } from "../../agent-lib/tools/dashboard-tools-client";
 import { createSelfDirectiveTools } from "../../agent-lib/tools/self-directive-tool";
+import { createSkillTools } from "../../agent-lib/tools/skill-tools";
 import { createConsoleSearchTools } from "../../agent-lib/tools/console-search-tools";
 import { createDashboardSearchTools } from "../../agent-lib/tools/dashboard-search-tools";
 import { createFlowTools } from "../flow";
@@ -28,6 +29,7 @@ export function unifiedAgentFactory(context: AgentContext): AgentConfig {
   );
   const flowTools = createFlowTools(workspaceId, context.toolExecutionContext);
   const selfDirectiveTools = createSelfDirectiveTools(workspaceId);
+  const skillTools = createSkillTools(workspaceId, userId);
   const consoleSearchTools = createConsoleSearchTools(
     workspaceId,
     context.toolExecutionContext,
@@ -65,6 +67,7 @@ export function unifiedAgentFactory(context: AgentContext): AgentConfig {
       ...clientDashboardTools,
       ...flowUniqueTools,
       ...selfDirectiveTools,
+      ...skillTools,
       ...consoleSearchTools,
       ...dashboardSearchTools,
       ...versionHistoryTools,

--- a/api/src/agents/unified/prompt.ts
+++ b/api/src/agents/unified/prompt.ts
@@ -397,6 +397,12 @@ export function buildCurrentScreenContext(context: AgentContext): string {
     sections.push(context.selfDirective.trim());
   }
 
+  if (context.skillsBlock?.trim()) {
+    // skillsBlock is pre-rendered with its own header/separator by
+    // renderSkillsPromptBlock — don't double-wrap it here.
+    sections.push(context.skillsBlock);
+  }
+
   if (context.consoleHints?.trim()) {
     sections.push("");
     sections.push("### Relevant Saved Consoles");

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -2988,3 +2988,84 @@ export const Dashboard = mongoose.model<IDashboard>(
   "Dashboard",
   DashboardSchema,
 );
+
+/**
+ * Skill — workspace-scoped knowledge + procedure primitive.
+ *
+ * See GitHub issue #365. A skill is a named, conditional playbook with:
+ *   - loadWhen: short trigger description (what query/task it applies to)
+ *   - body:     schema facts + procedural hints (SQL shapes, gotchas, etc.)
+ *   - entities: tokens used for retrieval (authored + extracted)
+ *
+ * Retrieval combines entity overlap with semantic similarity on `loadWhen`.
+ * The full index (name + loadWhen) is injected into the agent's system prompt
+ * every turn; bodies are injected only for top-k matches above a threshold
+ * or when the agent explicitly calls `load_skill`.
+ */
+export type SkillScopeType = "workspace" | "user" | "connection";
+
+export interface ISkill extends Document {
+  _id: Types.ObjectId;
+  workspaceId: Types.ObjectId;
+  name: string;
+  loadWhen: string;
+  body: string;
+  entities: string[];
+  /** Embedding over `loadWhen` only. Bodies are too long to embed usefully. */
+  loadWhenEmbedding?: number[];
+  embeddingModel?: string;
+  /** Reserved for future scoping. MVP: all skills are scope_type="workspace". */
+  scopeType: SkillScopeType;
+  scopeRefId?: Types.ObjectId | string;
+  /** "agent" for model-authored skills, otherwise a user id. */
+  createdBy: string;
+  /** Soft-disable without deletion — lets admins A/B whether a skill helps. */
+  suppressed: boolean;
+  useCount: number;
+  lastUsedAt?: Date;
+  /** Single-slot undo for wrong overwrites. */
+  previousBody?: string;
+  previousUpdatedAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const SkillSchema = new Schema<ISkill>(
+  {
+    workspaceId: {
+      type: Schema.Types.ObjectId,
+      ref: "Workspace",
+      required: true,
+    },
+    name: { type: String, required: true, trim: true },
+    loadWhen: { type: String, required: true, trim: true, maxlength: 500 },
+    body: { type: String, required: true, maxlength: 20000 },
+    entities: { type: [String], default: [] },
+    loadWhenEmbedding: { type: [Number], select: false },
+    embeddingModel: { type: String },
+    scopeType: {
+      type: String,
+      enum: ["workspace", "user", "connection"],
+      default: "workspace",
+      required: true,
+    },
+    scopeRefId: { type: Schema.Types.Mixed },
+    createdBy: { type: String, required: true },
+    suppressed: { type: Boolean, default: false },
+    useCount: { type: Number, default: 0 },
+    lastUsedAt: { type: Date },
+    previousBody: { type: String },
+    previousUpdatedAt: { type: Date },
+  },
+  { collection: "skills", timestamps: true },
+);
+
+SkillSchema.index({ workspaceId: 1, name: 1 }, { unique: true });
+SkillSchema.index({ workspaceId: 1, suppressed: 1 });
+SkillSchema.index({ workspaceId: 1, entities: 1 });
+SkillSchema.index(
+  { name: "text", loadWhen: "text", body: "text" },
+  { name: "skill_text_search" },
+);
+
+export const Skill = mongoose.model<ISkill>("Skill", SkillSchema);

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -11,6 +11,7 @@ import { executeRoutes } from "./routes/execute";
 import { databaseRoutes } from "./routes/database";
 import { dataSourceRoutes } from "./routes/sources";
 import { customPromptRoutes } from "./routes/custom-prompt";
+import { skillsRoutes } from "./routes/skills";
 import { chatsRoutes } from "./routes/chats";
 import { agentRoutes } from "./routes/agent.routes";
 import { adminRoutes } from "./routes/admin.routes";
@@ -114,6 +115,7 @@ app.route("/api/workspaces/:workspaceId/execute", workspaceExecuteRoutes);
 app.route("/api/workspaces/:workspaceId/consoles", consoleRoutes);
 app.route("/api/workspaces/:workspaceId/chats", chatsRoutes);
 app.route("/api/workspaces/:workspaceId/custom-prompt", customPromptRoutes);
+app.route("/api/workspaces/:workspaceId/skills", skillsRoutes);
 // Connectors routes
 app.route("/api/workspaces/:workspaceId/connectors", dataSourceRoutes);
 app.route("/api/workspaces/:workspaceId/flows", flowRoutes);

--- a/api/src/migrations/2026-04-23-134116_create_skills_collection.ts
+++ b/api/src/migrations/2026-04-23-134116_create_skills_collection.ts
@@ -1,0 +1,119 @@
+import { Db } from "mongodb";
+import { loggers } from "../logging";
+
+const log = loggers.migration();
+
+export const description =
+  "Create skills collection with compound/text/vector indexes (see issue #365)";
+
+function hasIndexOnKeys(
+  indexes: { key: Record<string, number | string> }[],
+  keyPattern: Record<string, number | string>,
+): boolean {
+  const target = JSON.stringify(keyPattern);
+  return indexes.some(idx => JSON.stringify(idx.key) === target);
+}
+
+export async function up(db: Db): Promise<void> {
+  const existing = await db.listCollections({ name: "skills" }).toArray();
+  if (existing.length === 0) {
+    await db.createCollection("skills");
+    log.info("Created 'skills' collection");
+  } else {
+    log.info("'skills' collection already exists");
+  }
+
+  const col = db.collection("skills");
+  const indexes = await col.indexes();
+
+  if (!hasIndexOnKeys(indexes, { workspaceId: 1, name: 1 })) {
+    await col.createIndex(
+      { workspaceId: 1, name: 1 },
+      { unique: true, name: "skills_workspace_name_unique" },
+    );
+    log.info("Created unique index on { workspaceId, name }");
+  }
+
+  if (!hasIndexOnKeys(indexes, { workspaceId: 1, suppressed: 1 })) {
+    await col.createIndex(
+      { workspaceId: 1, suppressed: 1 },
+      { name: "skills_workspace_suppressed" },
+    );
+    log.info("Created index on { workspaceId, suppressed }");
+  }
+
+  if (!hasIndexOnKeys(indexes, { workspaceId: 1, entities: 1 })) {
+    await col.createIndex(
+      { workspaceId: 1, entities: 1 },
+      { name: "skills_workspace_entities" },
+    );
+    log.info("Created index on { workspaceId, entities }");
+  }
+
+  // Text index across name + loadWhen + body for keyword fallback.
+  // Best-effort: never fail the migration if a text index already exists.
+  try {
+    const hasTextIndex = indexes.some(
+      (idx: { textIndexVersion?: number }) =>
+        idx.textIndexVersion !== undefined,
+    );
+    if (hasTextIndex) {
+      log.info("Text index already exists on skills, skipping creation");
+    } else {
+      await col.createIndex(
+        { name: "text", loadWhen: "text", body: "text" },
+        { name: "skill_text_search" },
+      );
+      log.info("Created text index on { name, loadWhen, body }");
+    }
+  } catch (err: unknown) {
+    const e = err as { code?: number; codeName?: string; message?: string };
+    if (e?.code === 85 || e?.codeName === "IndexOptionsConflict") {
+      log.info(
+        "Text index already exists (possibly under a different name), skipping",
+      );
+    } else {
+      log.info(
+        "Text index creation failed — keyword search may be unavailable. " +
+          `Reason: ${(e?.message ?? String(err)).substring(0, 200)}`,
+      );
+    }
+  }
+
+  // Atlas Vector Search index on loadWhenEmbedding (cosine, 1536 dims for
+  // OpenAI text-embedding-3-small). Best-effort — runtime detects availability
+  // via probe in embedding.service and falls back to entity-overlap + text.
+  try {
+    await (
+      col as unknown as {
+        createSearchIndex: (spec: unknown) => Promise<unknown>;
+      }
+    ).createSearchIndex({
+      name: "skill_embeddings",
+      type: "vectorSearch",
+      definition: {
+        fields: [
+          {
+            path: "loadWhenEmbedding",
+            type: "vector",
+            numDimensions: 1536,
+            similarity: "cosine",
+          },
+          { path: "workspaceId", type: "filter" },
+          { path: "suppressed", type: "filter" },
+        ],
+      },
+    });
+    log.info('Created Atlas Vector Search index "skill_embeddings" on skills');
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("already exists") || msg.includes("duplicate")) {
+      log.info('Atlas Vector Search index "skill_embeddings" already exists');
+    } else {
+      log.info(
+        "Atlas Vector Search index creation skipped — search will use " +
+          `entity-overlap + text fallback. Reason: ${msg.substring(0, 200)}`,
+      );
+    }
+  }
+}

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -45,6 +45,10 @@ import {
   isVectorSearchAvailable,
 } from "../services/embedding.service";
 import { searchConsoles } from "../agent-lib/tools/console-search-tools";
+import {
+  retrieveRelevantSkills,
+  renderSkillsPromptBlock,
+} from "../services/skills.service";
 import { sanitizeMessagesForModel } from "../utils/message-sanitizer";
 import { loggers, enrichContextWithWorkspace } from "../logging";
 import { checkBillingLimits } from "../billing/usage-limit.middleware";
@@ -494,6 +498,14 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
     isAborted: () => requestSignal.aborted,
   };
 
+  // Extract last user text once — used by both console hints and skills retrieval.
+  const lastUserMsg = [...messages].reverse().find(m => m.role === "user");
+  const lastUserText =
+    lastUserMsg?.parts
+      ?.filter((p): p is { type: "text"; text: string } => p.type === "text")
+      .map(p => p.text)
+      .join("") ?? "";
+
   // Auto-discover relevant consoles via embedding search (parallel with other setup)
   let consoleHints = "";
   if (
@@ -502,18 +514,8 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
     messages.length > 0
   ) {
     try {
-      const lastUserMsg = [...messages].reverse().find(m => m.role === "user");
-      const userText = lastUserMsg?.parts
-        ?.filter((p): p is { type: "text"; text: string } => p.type === "text")
-        .map(p => p.text)
-        .join("");
-
-      if (
-        userText &&
-        userText.length >= 5 &&
-        (await isVectorSearchAvailable())
-      ) {
-        const hints = await searchConsoles(userText, workspaceId, 3);
+      if (lastUserText.length >= 5 && (await isVectorSearchAvailable())) {
+        const hints = await searchConsoles(lastUserText, workspaceId, 3);
         if (hints.length > 0) {
           consoleHints =
             "\n\n---\n\n### Relevant Saved Consoles (auto-discovered)\n" +
@@ -528,6 +530,19 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
       }
     } catch (err) {
       logger.debug("Console hint injection skipped", { error: err });
+    }
+  }
+
+  // Skills retrieval — runs for console + unified agents (parity with
+  // self-directive). Index is always included when any skills exist;
+  // bodies are only pulled in when score clears threshold.
+  let skillsBlock = "";
+  if (resolvedAgentId === "console" || resolvedAgentId === "unified") {
+    try {
+      const retrieval = await retrieveRelevantSkills(workspaceId, lastUserText);
+      skillsBlock = renderSkillsPromptBlock(retrieval);
+    } catch (err) {
+      logger.debug("Skills block injection skipped", { error: err });
     }
   }
 
@@ -562,6 +577,7 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
     workspaceCustomPrompt,
     selfDirective,
     consoleHints,
+    skillsBlock,
     activeConsoleResults,
     activeDashboardContext: dashboardContext.activeDashboardContext,
     toolExecutionContext,

--- a/api/src/routes/skills.ts
+++ b/api/src/routes/skills.ts
@@ -1,0 +1,258 @@
+/**
+ * Skills admin routes (issue #365).
+ *
+ * Mounted at `/api/workspaces/:workspaceId/skills`. All routes require
+ * authentication via unifiedAuthMiddleware and workspace access via the
+ * same pattern as custom-prompt.ts.
+ *
+ * Agent-side skill CRUD lives in agent-lib/tools/skill-tools.ts — these
+ * routes are for the workspace admin UI: list, get, update, delete, and
+ * toggle-suppress.
+ */
+
+import { Hono } from "hono";
+import { Types } from "mongoose";
+import { loggers, enrichContextWithWorkspace } from "../logging";
+import { unifiedAuthMiddleware } from "../auth/unified-auth.middleware";
+import { workspaceService } from "../services/workspace.service";
+import { AuthenticatedContext } from "../middleware/workspace.middleware";
+import {
+  deleteSkillById,
+  getSkillForAdmin,
+  listSkillsForAdmin,
+  saveSkill,
+  toggleSkillSuppressed,
+} from "../services/skills.service";
+
+const logger = loggers.api("skills");
+
+export const skillsRoutes = new Hono();
+
+skillsRoutes.use("*", unifiedAuthMiddleware);
+
+// Workspace access check — mirrors custom-prompt.ts
+skillsRoutes.use("*", async (c: AuthenticatedContext, next) => {
+  const workspaceId = c.req.param("workspaceId");
+  if (!workspaceId) {
+    await next();
+    return;
+  }
+  const user = c.get("user");
+  const workspace = c.get("workspace");
+
+  if (workspace) {
+    if (workspace._id.toString() !== workspaceId) {
+      return c.json(
+        {
+          success: false,
+          error: "API key not authorized for this workspace",
+        },
+        403,
+      );
+    }
+  } else if (user) {
+    const hasAccess = await workspaceService.hasAccess(workspaceId, user.id);
+    if (!hasAccess) {
+      return c.json(
+        { success: false, error: "Access denied to workspace" },
+        403,
+      );
+    }
+  } else {
+    return c.json({ success: false, error: "Unauthorized" }, 401);
+  }
+
+  enrichContextWithWorkspace(workspaceId);
+  await next();
+});
+
+// GET /api/workspaces/:workspaceId/skills — list all skills in the workspace
+skillsRoutes.get("/", async c => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    if (!workspaceId || !Types.ObjectId.isValid(workspaceId)) {
+      return c.json(
+        { success: false, error: "Valid workspace ID is required" },
+        400,
+      );
+    }
+    const skills = await listSkillsForAdmin(workspaceId);
+    return c.json({ success: true, skills });
+  } catch (error) {
+    logger.error("Error listing skills", { error });
+    return c.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Failed to list skills",
+      },
+      500,
+    );
+  }
+});
+
+// GET /api/workspaces/:workspaceId/skills/:id — full skill body
+skillsRoutes.get("/:id", async c => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const id = c.req.param("id");
+    if (!workspaceId || !Types.ObjectId.isValid(workspaceId)) {
+      return c.json(
+        { success: false, error: "Valid workspace ID is required" },
+        400,
+      );
+    }
+    const skill = await getSkillForAdmin(workspaceId, id);
+    if (!skill) {
+      return c.json({ success: false, error: "Skill not found" }, 404);
+    }
+    return c.json({
+      success: true,
+      skill: {
+        id: skill._id.toString(),
+        name: skill.name,
+        loadWhen: skill.loadWhen,
+        body: skill.body,
+        entities: skill.entities ?? [],
+        suppressed: !!skill.suppressed,
+        useCount: skill.useCount ?? 0,
+        lastUsedAt: skill.lastUsedAt ?? null,
+        createdBy: skill.createdBy,
+        createdAt: skill.createdAt,
+        updatedAt: skill.updatedAt,
+        previousBody: skill.previousBody ?? null,
+        previousUpdatedAt: skill.previousUpdatedAt ?? null,
+      },
+    });
+  } catch (error) {
+    logger.error("Error getting skill", { error });
+    return c.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Failed to get skill",
+      },
+      500,
+    );
+  }
+});
+
+// PUT /api/workspaces/:workspaceId/skills/:id — edit loadWhen/body/entities
+skillsRoutes.put("/:id", async c => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const id = c.req.param("id");
+    if (!workspaceId || !Types.ObjectId.isValid(workspaceId)) {
+      return c.json(
+        { success: false, error: "Valid workspace ID is required" },
+        400,
+      );
+    }
+    const existing = await getSkillForAdmin(workspaceId, id);
+    if (!existing) {
+      return c.json({ success: false, error: "Skill not found" }, 404);
+    }
+    const body = (await c.req.json()) as {
+      loadWhen?: unknown;
+      body?: unknown;
+      entities?: unknown;
+    };
+    const user = (c as AuthenticatedContext).get("user");
+    const actorId = user?.id ?? existing.createdBy;
+
+    const nextLoadWhen =
+      typeof body.loadWhen === "string" ? body.loadWhen : existing.loadWhen;
+    const nextBody = typeof body.body === "string" ? body.body : existing.body;
+    const nextEntities = Array.isArray(body.entities)
+      ? body.entities.filter((e): e is string => typeof e === "string")
+      : undefined;
+
+    const result = await saveSkill(
+      workspaceId,
+      {
+        name: existing.name,
+        loadWhen: nextLoadWhen,
+        body: nextBody,
+        entities: nextEntities,
+      },
+      actorId,
+    );
+    if (!result.success) {
+      return c.json({ success: false, error: result.error }, 400);
+    }
+    return c.json({ success: true, skill: result.skill });
+  } catch (error) {
+    logger.error("Error updating skill", { error });
+    return c.json(
+      {
+        success: false,
+        error:
+          error instanceof Error ? error.message : "Failed to update skill",
+      },
+      500,
+    );
+  }
+});
+
+// POST /api/workspaces/:workspaceId/skills/:id/suppress — toggle suppressed
+skillsRoutes.post("/:id/suppress", async c => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const id = c.req.param("id");
+    if (!workspaceId || !Types.ObjectId.isValid(workspaceId)) {
+      return c.json(
+        { success: false, error: "Valid workspace ID is required" },
+        400,
+      );
+    }
+    const body = (await c.req.json().catch(() => ({}))) as {
+      suppressed?: unknown;
+    };
+    const suppressed =
+      typeof body.suppressed === "boolean" ? body.suppressed : true;
+    const ok = await toggleSkillSuppressed(workspaceId, id, suppressed);
+    if (!ok) {
+      return c.json({ success: false, error: "Skill not found" }, 404);
+    }
+    return c.json({ success: true, suppressed });
+  } catch (error) {
+    logger.error("Error toggling skill suppressed", { error });
+    return c.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to update suppressed flag",
+      },
+      500,
+    );
+  }
+});
+
+// DELETE /api/workspaces/:workspaceId/skills/:id — permanent delete
+skillsRoutes.delete("/:id", async c => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const id = c.req.param("id");
+    if (!workspaceId || !Types.ObjectId.isValid(workspaceId)) {
+      return c.json(
+        { success: false, error: "Valid workspace ID is required" },
+        400,
+      );
+    }
+    const ok = await deleteSkillById(workspaceId, id);
+    if (!ok) {
+      return c.json({ success: false, error: "Skill not found" }, 404);
+    }
+    return c.json({ success: true });
+  } catch (error) {
+    logger.error("Error deleting skill", { error });
+    return c.json(
+      {
+        success: false,
+        error:
+          error instanceof Error ? error.message : "Failed to delete skill",
+      },
+      500,
+    );
+  }
+});

--- a/api/src/services/skills.service.ts
+++ b/api/src/services/skills.service.ts
@@ -1,0 +1,691 @@
+/**
+ * Skills service — per-workspace knowledge + procedure primitive (issue #365).
+ *
+ * Skills have a name, a short `loadWhen` trigger, and a body. Retrieval is a
+ * weighted combination of entity overlap (authored + extracted tokens) and
+ * semantic similarity over the `loadWhen` embedding. The full index (name +
+ * loadWhen) is always injected into the agent's system prompt; bodies are
+ * injected only for top-k matches above a threshold, or when the agent
+ * explicitly calls `load_skill`.
+ */
+
+import { Types } from "mongoose";
+import { Skill, type ISkill } from "../database/workspace-schema";
+import {
+  embedText,
+  getEmbeddingModelName,
+  isEmbeddingAvailable,
+  isVectorSearchAvailable,
+} from "./embedding.service";
+import { databaseConnectionService } from "./database-connection.service";
+import { extractEntities, entityOverlap } from "../agent-lib/entity-extraction";
+import { loggers } from "../logging";
+
+const logger = loggers.app();
+
+const MAX_NAME_LENGTH = 80;
+const MAX_LOAD_WHEN_LENGTH = 500;
+const MAX_BODY_LENGTH = 20000;
+/** Hard cap on skills per workspace. Keeps the injected index bounded. */
+const MAX_SKILLS_PER_WORKSPACE = 200;
+/** How many skill bodies to auto-inject per turn. */
+const AUTO_INJECT_LIMIT = 3;
+/**
+ * Minimum weighted score for auto-injection. Below this we still show the
+ * skill in the index, but we don't inject the body. The agent can still
+ * `load_skill` explicitly if it decides it needs it.
+ */
+const AUTO_INJECT_THRESHOLD = 0.25;
+/** Weights for the composite retrieval score. Sum should be ~1. */
+const ENTITY_WEIGHT = 0.6;
+const SEMANTIC_WEIGHT = 0.4;
+
+export interface SkillInput {
+  name: string;
+  loadWhen: string;
+  body: string;
+  /** Optional author-declared entities, unioned with the extractor's output. */
+  entities?: string[];
+}
+
+export interface SkillIndexEntry {
+  id: string;
+  name: string;
+  loadWhen: string;
+  suppressed: boolean;
+  useCount: number;
+}
+
+export interface SkillRetrievalHit {
+  id: string;
+  name: string;
+  loadWhen: string;
+  body: string;
+  score: number;
+  entityOverlap: number;
+  semanticScore: number;
+  injected: boolean;
+}
+
+export interface SkillRetrievalResult {
+  /** The compact index of every non-suppressed skill — always injected. */
+  index: SkillIndexEntry[];
+  /** Top-k hits with bodies for auto-injection (score >= threshold). */
+  injected: SkillRetrievalHit[];
+  /** Candidates that scored but didn't clear the threshold (for trace). */
+  considered: SkillRetrievalHit[];
+  /** Entities we pulled out of the query, surfaced for trace/debug. */
+  queryEntities: string[];
+}
+
+function validateInput(input: SkillInput): string | null {
+  if (!input.name || input.name.trim().length === 0) return "name is required";
+  if (input.name.length > MAX_NAME_LENGTH) {
+    return `name exceeds ${MAX_NAME_LENGTH} characters`;
+  }
+  if (!/^[a-z0-9_]+$/.test(input.name)) {
+    return "name must be lowercase snake_case (a-z, 0-9, underscore)";
+  }
+  if (!input.loadWhen || input.loadWhen.trim().length === 0) {
+    return "loadWhen is required";
+  }
+  if (input.loadWhen.length > MAX_LOAD_WHEN_LENGTH) {
+    return `loadWhen exceeds ${MAX_LOAD_WHEN_LENGTH} characters`;
+  }
+  if (!input.body || input.body.trim().length === 0) {
+    return "body is required";
+  }
+  if (input.body.length > MAX_BODY_LENGTH) {
+    return `body exceeds ${MAX_BODY_LENGTH} characters`;
+  }
+  return null;
+}
+
+function unionEntities(
+  declared: readonly string[] | undefined,
+  extracted: readonly string[],
+): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of [...(declared ?? []), ...extracted]) {
+    const norm = raw.toLowerCase().trim();
+    if (norm.length < 2) continue;
+    if (seen.has(norm)) continue;
+    seen.add(norm);
+    out.push(norm);
+  }
+  return out;
+}
+
+async function computeEmbedding(text: string): Promise<{
+  embedding: number[] | null;
+  model: string | null;
+}> {
+  if (!isEmbeddingAvailable()) return { embedding: null, model: null };
+  try {
+    const embedding = await embedText(text);
+    if (!embedding) return { embedding: null, model: null };
+    return { embedding, model: getEmbeddingModelName() };
+  } catch (err) {
+    logger.warn("Skill embedding failed, storing without vector", {
+      error: err,
+    });
+    return { embedding: null, model: null };
+  }
+}
+
+export async function saveSkill(
+  workspaceId: string,
+  input: SkillInput,
+  createdBy: string,
+): Promise<
+  | { success: true; skill: { id: string; name: string; created: boolean } }
+  | { success: false; error: string }
+> {
+  const validation = validateInput(input);
+  if (validation) return { success: false, error: validation };
+
+  const name = input.name.trim();
+  const loadWhen = input.loadWhen.trim();
+  const body = input.body.trim();
+
+  const extracted = extractEntities(`${loadWhen}\n${body}`);
+  const entities = unionEntities(input.entities, extracted);
+
+  // Compute embedding over loadWhen ONLY. Body content is too long and noisy
+  // for the embedding to represent usefully; entity overlap carries body-
+  // level matching. See issue #365 design notes.
+  const { embedding, model } = await computeEmbedding(loadWhen);
+
+  const existing = await Skill.findOne({
+    workspaceId: new Types.ObjectId(workspaceId),
+    name,
+  });
+
+  if (!existing) {
+    const totalSkills = await Skill.countDocuments({
+      workspaceId: new Types.ObjectId(workspaceId),
+    });
+    if (totalSkills >= MAX_SKILLS_PER_WORKSPACE) {
+      return {
+        success: false,
+        error: `Workspace has hit the ${MAX_SKILLS_PER_WORKSPACE} skill limit. Delete or merge skills before adding more.`,
+      };
+    }
+
+    const created = await Skill.create({
+      workspaceId: new Types.ObjectId(workspaceId),
+      name,
+      loadWhen,
+      body,
+      entities,
+      loadWhenEmbedding: embedding ?? undefined,
+      embeddingModel: model ?? undefined,
+      scopeType: "workspace",
+      createdBy,
+      suppressed: false,
+      useCount: 0,
+    });
+    return {
+      success: true,
+      skill: { id: created._id.toString(), name: created.name, created: true },
+    };
+  }
+
+  // Overwrite path — preserve single-slot undo in `previousBody`.
+  existing.previousBody = existing.body;
+  existing.previousUpdatedAt = existing.updatedAt;
+  existing.loadWhen = loadWhen;
+  existing.body = body;
+  existing.entities = entities;
+  if (embedding) {
+    existing.loadWhenEmbedding = embedding;
+    existing.embeddingModel = model ?? undefined;
+  }
+  await existing.save();
+
+  return {
+    success: true,
+    skill: { id: existing._id.toString(), name: existing.name, created: false },
+  };
+}
+
+export async function deleteSkill(
+  workspaceId: string,
+  name: string,
+): Promise<
+  { success: true; deleted: boolean } | { success: false; error: string }
+> {
+  if (!name || name.trim().length === 0) {
+    return { success: false, error: "name is required" };
+  }
+  const res = await Skill.deleteOne({
+    workspaceId: new Types.ObjectId(workspaceId),
+    name: name.trim(),
+  });
+  return { success: true, deleted: res.deletedCount > 0 };
+}
+
+export async function loadSkill(
+  workspaceId: string,
+  name: string,
+): Promise<
+  | {
+      success: true;
+      skill: {
+        id: string;
+        name: string;
+        loadWhen: string;
+        body: string;
+        suppressed: boolean;
+      };
+    }
+  | { success: false; error: string }
+> {
+  if (!name || name.trim().length === 0) {
+    return { success: false, error: "name is required" };
+  }
+  const skill = await Skill.findOneAndUpdate(
+    {
+      workspaceId: new Types.ObjectId(workspaceId),
+      name: name.trim(),
+    },
+    { $inc: { useCount: 1 }, $set: { lastUsedAt: new Date() } },
+    { new: true },
+  );
+  if (!skill) {
+    return { success: false, error: `skill "${name}" not found` };
+  }
+  return {
+    success: true,
+    skill: {
+      id: skill._id.toString(),
+      name: skill.name,
+      loadWhen: skill.loadWhen,
+      body: skill.body,
+      suppressed: skill.suppressed,
+    },
+  };
+}
+
+/**
+ * Fallback semantic search via $vectorSearch. Only used when
+ * isVectorSearchAvailable() is true AND the query produced an embedding.
+ */
+async function vectorSearchSkills(
+  queryEmbedding: number[],
+  workspaceId: string,
+  limit: number,
+): Promise<Array<{ id: string; score: number }>> {
+  const { db } = await databaseConnectionService.getMainConnection();
+  const results = await db
+    .collection("skills")
+    .aggregate([
+      {
+        $vectorSearch: {
+          index: "skill_embeddings",
+          path: "loadWhenEmbedding",
+          queryVector: queryEmbedding,
+          numCandidates: Math.max(limit * 10, 50),
+          limit: Math.max(limit * 2, 10),
+          filter: {
+            workspaceId: new Types.ObjectId(workspaceId),
+            suppressed: { $ne: true },
+          },
+        },
+      },
+      {
+        $project: {
+          _id: 1,
+          score: { $meta: "vectorSearchScore" },
+        },
+      },
+    ])
+    .toArray();
+  return results.map(r => ({
+    id: (r._id as Types.ObjectId).toString(),
+    score: (r.score as number) || 0,
+  }));
+}
+
+/**
+ * Full text search fallback when vector search is unavailable.
+ * Uses Mongo's $text index over name + loadWhen + body.
+ */
+async function textSearchSkills(
+  query: string,
+  workspaceId: string,
+  limit: number,
+): Promise<Array<{ id: string; score: number }>> {
+  try {
+    const results = await Skill.find(
+      {
+        $text: { $search: query },
+        workspaceId: new Types.ObjectId(workspaceId),
+        suppressed: { $ne: true },
+      },
+      { score: { $meta: "textScore" } },
+    )
+      .select("_id")
+      .sort({ score: { $meta: "textScore" } })
+      .limit(limit * 2)
+      .lean();
+    const items = results as Array<{ _id: Types.ObjectId; score?: number }>;
+    return items.map(r => ({ id: r._id.toString(), score: r.score ?? 0 }));
+  } catch (err) {
+    logger.debug("Skill text search failed", { error: err });
+    return [];
+  }
+}
+
+/**
+ * Explicit skill search tool — entity overlap + either vector or text.
+ * Returns ranked full skill bodies.
+ */
+export async function searchSkills(
+  workspaceId: string,
+  query: string,
+  limit = 5,
+): Promise<SkillRetrievalHit[]> {
+  if (!query || query.trim().length === 0) return [];
+
+  const queryEntities = extractEntities(query);
+  const all = await Skill.find({
+    workspaceId: new Types.ObjectId(workspaceId),
+    suppressed: { $ne: true },
+  })
+    .select("+loadWhenEmbedding")
+    .lean();
+
+  if (all.length === 0) return [];
+
+  // Semantic scoring: prefer vectorSearch when available, else textSearch.
+  let semanticScoreById = new Map<string, number>();
+  const canVector = isEmbeddingAvailable() && (await isVectorSearchAvailable());
+
+  if (canVector) {
+    const queryEmbedding = await embedText(query).catch(() => null);
+    if (queryEmbedding) {
+      const hits = await vectorSearchSkills(
+        queryEmbedding,
+        workspaceId,
+        limit,
+      ).catch(err => {
+        logger.warn("Skill vector search failed, falling back to text", {
+          error: err,
+        });
+        return [] as Array<{ id: string; score: number }>;
+      });
+      const maxScore = Math.max(...hits.map(h => h.score), 0.001);
+      semanticScoreById = new Map(
+        hits.map(h => [h.id, maxScore > 0 ? h.score / maxScore : 0]),
+      );
+    }
+  }
+
+  if (semanticScoreById.size === 0) {
+    const hits = await textSearchSkills(query, workspaceId, limit);
+    const maxScore = Math.max(...hits.map(h => h.score), 0.001);
+    semanticScoreById = new Map(
+      hits.map(h => [h.id, maxScore > 0 ? h.score / maxScore : 0]),
+    );
+  }
+
+  const ranked: SkillRetrievalHit[] = all.map(s => {
+    const id = (s._id as Types.ObjectId).toString();
+    const overlap = entityOverlap(queryEntities, s.entities ?? []);
+    const entityScore =
+      queryEntities.length > 0
+        ? Math.min(1, overlap / Math.max(3, queryEntities.length / 2))
+        : 0;
+    const semanticScore = semanticScoreById.get(id) ?? 0;
+    const score = entityScore * ENTITY_WEIGHT + semanticScore * SEMANTIC_WEIGHT;
+    return {
+      id,
+      name: s.name,
+      loadWhen: s.loadWhen,
+      body: s.body,
+      score,
+      entityOverlap: overlap,
+      semanticScore,
+      injected: false,
+    };
+  });
+
+  ranked.sort((a, b) => b.score - a.score);
+  return ranked.slice(0, limit);
+}
+
+/**
+ * Per-turn retrieval. Called from the agent route before building the
+ * system prompt. Returns:
+ *   - `index`: every non-suppressed skill (name + loadWhen only) — always shown
+ *   - `injected`: up to AUTO_INJECT_LIMIT skill bodies above threshold
+ *   - `considered`: candidates that scored but didn't clear threshold
+ *   - `queryEntities`: extracted tokens (for trace)
+ *
+ * Also increments use counters for auto-injected skills.
+ */
+export async function retrieveRelevantSkills(
+  workspaceId: string,
+  queryText: string,
+): Promise<SkillRetrievalResult> {
+  const wsObjectId = new Types.ObjectId(workspaceId);
+
+  // Always load the index of non-suppressed skills for injection.
+  const indexDocs = await Skill.find({
+    workspaceId: wsObjectId,
+    suppressed: { $ne: true },
+  })
+    .select("name loadWhen suppressed useCount entities")
+    .sort({ useCount: -1, updatedAt: -1 })
+    .lean();
+
+  const index: SkillIndexEntry[] = indexDocs.map(s => ({
+    id: (s._id as Types.ObjectId).toString(),
+    name: s.name,
+    loadWhen: s.loadWhen,
+    suppressed: !!s.suppressed,
+    useCount: s.useCount ?? 0,
+  }));
+
+  if (indexDocs.length === 0 || !queryText || queryText.trim().length === 0) {
+    return { index, injected: [], considered: [], queryEntities: [] };
+  }
+
+  const queryEntities = extractEntities(queryText);
+  const hasEntities = queryEntities.length > 0;
+
+  // Semantic score (per-doc) when available.
+  let semanticScoreById = new Map<string, number>();
+  const canVector = isEmbeddingAvailable() && (await isVectorSearchAvailable());
+  if (canVector) {
+    try {
+      const qEmbedding = await embedText(queryText);
+      if (qEmbedding) {
+        const vecHits = await vectorSearchSkills(
+          qEmbedding,
+          workspaceId,
+          AUTO_INJECT_LIMIT + 3,
+        );
+        const maxScore = Math.max(...vecHits.map(h => h.score), 0.001);
+        semanticScoreById = new Map(
+          vecHits.map(h => [h.id, maxScore > 0 ? h.score / maxScore : 0]),
+        );
+      }
+    } catch (err) {
+      logger.debug("Skill retrieval: vector path failed, ignoring", {
+        error: err,
+      });
+    }
+  }
+
+  const candidates: SkillRetrievalHit[] = indexDocs.map(s => {
+    const id = (s._id as Types.ObjectId).toString();
+    const overlap = entityOverlap(queryEntities, s.entities ?? []);
+    const entityScore = hasEntities
+      ? Math.min(1, overlap / Math.max(3, queryEntities.length / 2))
+      : 0;
+    const semanticScore = semanticScoreById.get(id) ?? 0;
+    const score = entityScore * ENTITY_WEIGHT + semanticScore * SEMANTIC_WEIGHT;
+    return {
+      id,
+      name: s.name,
+      loadWhen: s.loadWhen,
+      body: "",
+      score,
+      entityOverlap: overlap,
+      semanticScore,
+      injected: false,
+    };
+  });
+
+  candidates.sort((a, b) => b.score - a.score);
+
+  const toInjectIds = candidates
+    .filter(c => c.score >= AUTO_INJECT_THRESHOLD)
+    .slice(0, AUTO_INJECT_LIMIT)
+    .map(c => c.id);
+
+  // Fetch bodies only for the ones we'll inject.
+  const bodies: Array<{ _id: Types.ObjectId; body: string }> =
+    toInjectIds.length
+      ? ((await Skill.find({ _id: { $in: toInjectIds } })
+          .select("body")
+          .lean()) as unknown as Array<{ _id: Types.ObjectId; body: string }>)
+      : [];
+  const bodyById = new Map(
+    bodies.map(b => [b._id.toString(), b.body as string]),
+  );
+
+  const injected: SkillRetrievalHit[] = [];
+  const considered: SkillRetrievalHit[] = [];
+  for (const c of candidates) {
+    if (c.score <= 0 && !hasEntities) continue;
+    if (toInjectIds.includes(c.id)) {
+      injected.push({
+        ...c,
+        body: bodyById.get(c.id) ?? "",
+        injected: true,
+      });
+    } else if (c.score > 0) {
+      considered.push(c);
+    }
+  }
+
+  // Fire-and-forget: bump useCount + lastUsedAt for skills we injected.
+  if (injected.length > 0) {
+    void Skill.updateMany(
+      { _id: { $in: injected.map(i => new Types.ObjectId(i.id)) } },
+      { $inc: { useCount: 1 }, $set: { lastUsedAt: new Date() } },
+    ).catch(err => {
+      logger.debug("Skill useCount bump failed", { error: err });
+    });
+  }
+
+  return {
+    index,
+    injected,
+    considered: considered.slice(0, 5),
+    queryEntities,
+  };
+}
+
+/**
+ * Render the skills block for injection into the agent's system prompt.
+ * Keeps the format compact and includes a retrieval trace so behavior is
+ * observable in chat traces.
+ */
+export function renderSkillsPromptBlock(result: SkillRetrievalResult): string {
+  if (result.index.length === 0) return "";
+
+  const lines: string[] = [];
+  lines.push("\n\n---\n");
+  lines.push("### Skills (workspace-scoped knowledge)");
+  lines.push(
+    "Skills extend or refine the self-directive for specific contexts. " +
+      "If a skill conflicts with the directive, follow the directive. " +
+      "Use `load_skill` to pull in any indexed skill on demand, `save_skill` " +
+      "to record new workspace knowledge, `delete_skill` to retract, and " +
+      "`search_skills` as a fallback.",
+  );
+  lines.push("");
+  lines.push("#### Available skills (index)");
+  for (const s of result.index) {
+    lines.push(`- \`${s.name}\`: ${s.loadWhen}`);
+  }
+
+  if (result.injected.length > 0) {
+    lines.push("");
+    lines.push("#### Auto-loaded skills (relevant to current turn)");
+    for (const s of result.injected) {
+      lines.push("");
+      lines.push(`##### \`${s.name}\``);
+      lines.push(`_loadWhen:_ ${s.loadWhen}`);
+      lines.push("");
+      lines.push(s.body);
+    }
+  }
+
+  // Retrieval trace — invisible to casual chat readers but in the trace.
+  lines.push("");
+  lines.push("<!-- skills retrieval trace");
+  lines.push(
+    `query_entities: [${result.queryEntities.slice(0, 20).join(", ")}]`,
+  );
+  for (const s of result.injected) {
+    lines.push(
+      `injected   ${s.name.padEnd(30)} score=${s.score.toFixed(2)} overlap=${s.entityOverlap} sem=${s.semanticScore.toFixed(2)}`,
+    );
+  }
+  for (const s of result.considered) {
+    lines.push(
+      `considered ${s.name.padEnd(30)} score=${s.score.toFixed(2)} overlap=${s.entityOverlap} sem=${s.semanticScore.toFixed(2)}`,
+    );
+  }
+  lines.push("-->");
+  return lines.join("\n");
+}
+
+export interface AdminSkillSummary {
+  id: string;
+  name: string;
+  loadWhen: string;
+  bodyPreview: string;
+  entities: string[];
+  suppressed: boolean;
+  useCount: number;
+  lastUsedAt: Date | null;
+  createdBy: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export async function listSkillsForAdmin(
+  workspaceId: string,
+): Promise<AdminSkillSummary[]> {
+  const docs = await Skill.find({
+    workspaceId: new Types.ObjectId(workspaceId),
+  })
+    .select(
+      "name loadWhen body entities suppressed useCount lastUsedAt createdBy createdAt updatedAt",
+    )
+    .sort({ updatedAt: -1 })
+    .lean();
+
+  return docs.map(d => {
+    const body = (d.body as string) ?? "";
+    return {
+      id: (d._id as Types.ObjectId).toString(),
+      name: d.name,
+      loadWhen: d.loadWhen,
+      bodyPreview: body.slice(0, 240) + (body.length > 240 ? "…" : ""),
+      entities: (d.entities as string[]) ?? [],
+      suppressed: !!d.suppressed,
+      useCount: d.useCount ?? 0,
+      lastUsedAt: (d.lastUsedAt as Date | undefined) ?? null,
+      createdBy: d.createdBy,
+      createdAt: d.createdAt as Date,
+      updatedAt: d.updatedAt as Date,
+    };
+  });
+}
+
+export async function getSkillForAdmin(
+  workspaceId: string,
+  id: string,
+): Promise<ISkill | null> {
+  if (!Types.ObjectId.isValid(id)) return null;
+  return Skill.findOne({
+    _id: new Types.ObjectId(id),
+    workspaceId: new Types.ObjectId(workspaceId),
+  });
+}
+
+export async function toggleSkillSuppressed(
+  workspaceId: string,
+  id: string,
+  suppressed: boolean,
+): Promise<boolean> {
+  if (!Types.ObjectId.isValid(id)) return false;
+  const res = await Skill.updateOne(
+    {
+      _id: new Types.ObjectId(id),
+      workspaceId: new Types.ObjectId(workspaceId),
+    },
+    { $set: { suppressed } },
+  );
+  return res.matchedCount > 0;
+}
+
+export async function deleteSkillById(
+  workspaceId: string,
+  id: string,
+): Promise<boolean> {
+  if (!Types.ObjectId.isValid(id)) return false;
+  const res = await Skill.deleteOne({
+    _id: new Types.ObjectId(id),
+    workspaceId: new Types.ObjectId(workspaceId),
+  });
+  return res.deletedCount > 0;
+}

--- a/app/src/agent-runtime/client-tool-manifest.ts
+++ b/app/src/agent-runtime/client-tool-manifest.ts
@@ -408,6 +408,42 @@ export const AGENT_TOOL_MANIFEST = {
     getLabel: () => "Updating memory",
     icon: "brain",
   },
+  save_skill: {
+    domain: "memory",
+    execution: "server",
+    getLabel: input => {
+      const name = (input as Record<string, unknown>)?.name;
+      return name ? `Saving skill "${name}"` : "Saving skill";
+    },
+    icon: "brain",
+  },
+  delete_skill: {
+    domain: "memory",
+    execution: "server",
+    getLabel: input => {
+      const name = (input as Record<string, unknown>)?.name;
+      return name ? `Deleting skill "${name}"` : "Deleting skill";
+    },
+    icon: "trash",
+  },
+  load_skill: {
+    domain: "memory",
+    execution: "server",
+    getLabel: input => {
+      const name = (input as Record<string, unknown>)?.name;
+      return name ? `Loading skill "${name}"` : "Loading skill";
+    },
+    icon: "brain",
+  },
+  search_skills: {
+    domain: "memory",
+    execution: "server",
+    getLabel: input => {
+      const query = (input as Record<string, unknown>)?.query;
+      return query ? `Searching skills: "${query}"` : "Searching skills";
+    },
+    icon: "search",
+  },
   get_form_state: {
     domain: "flow",
     execution: "client",

--- a/app/src/components/SettingsExplorer.tsx
+++ b/app/src/components/SettingsExplorer.tsx
@@ -2,6 +2,7 @@ import { Box, Typography } from "@mui/material";
 import {
   Sparkles as ModelsIcon,
   MessageSquareText as PromptIcon,
+  BookOpen as SkillsIcon,
   Wallet as BillingIcon,
   Users as MembersIcon,
   KeySquare as ApiKeyIcon,
@@ -22,6 +23,7 @@ const SECTION_ICONS: Record<
   (props: { size?: number; strokeWidth?: number }) => JSX.Element
 > = {
   prompt: props => <PromptIcon {...props} />,
+  skills: props => <SkillsIcon {...props} />,
   models: props => <ModelsIcon {...props} />,
   billing: props => <BillingIcon {...props} />,
   members: props => <MembersIcon {...props} />,

--- a/app/src/components/SkillsSection.tsx
+++ b/app/src/components/SkillsSection.tsx
@@ -1,0 +1,469 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Stack,
+  Switch,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import {
+  Delete as DeleteIcon,
+  EditOutlined as EditIcon,
+  Refresh as RefreshIcon,
+  Save as SaveIcon,
+} from "@mui/icons-material";
+import { useWorkspace } from "../contexts/workspace-context";
+
+interface SkillSummary {
+  id: string;
+  name: string;
+  loadWhen: string;
+  bodyPreview: string;
+  entities: string[];
+  suppressed: boolean;
+  useCount: number;
+  lastUsedAt: string | null;
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface SkillDetail extends SkillSummary {
+  body: string;
+  previousBody: string | null;
+  previousUpdatedAt: string | null;
+}
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString();
+}
+
+export function SkillsSection() {
+  const { currentWorkspace } = useWorkspace();
+  const workspaceId = currentWorkspace?.id;
+
+  const [skills, setSkills] = useState<SkillSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [editing, setEditing] = useState<SkillDetail | null>(null);
+  const [editLoading, setEditLoading] = useState(false);
+  const [editLoadWhen, setEditLoadWhen] = useState("");
+  const [editBody, setEditBody] = useState("");
+  const [editEntities, setEditEntities] = useState("");
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const fetchSkills = useCallback(async () => {
+    if (!workspaceId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/workspaces/${workspaceId}/skills`);
+      const data = await res.json();
+      if (!res.ok || !data.success) {
+        throw new Error(data.error || "Failed to load skills");
+      }
+      setSkills(data.skills as SkillSummary[]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load skills");
+    } finally {
+      setLoading(false);
+    }
+  }, [workspaceId]);
+
+  useEffect(() => {
+    void fetchSkills();
+  }, [fetchSkills]);
+
+  const handleToggleSuppress = async (skill: SkillSummary) => {
+    if (!workspaceId) return;
+    const nextSuppressed = !skill.suppressed;
+    // Optimistic update
+    setSkills(prev =>
+      prev.map(s =>
+        s.id === skill.id ? { ...s, suppressed: nextSuppressed } : s,
+      ),
+    );
+    try {
+      const res = await fetch(
+        `/api/workspaces/${workspaceId}/skills/${skill.id}/suppress`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ suppressed: nextSuppressed }),
+        },
+      );
+      if (!res.ok) throw new Error("Request failed");
+    } catch {
+      // Rollback on error
+      setSkills(prev =>
+        prev.map(s =>
+          s.id === skill.id ? { ...s, suppressed: skill.suppressed } : s,
+        ),
+      );
+    }
+  };
+
+  const handleDelete = async (skill: SkillSummary) => {
+    if (!workspaceId) return;
+    if (
+      !window.confirm(
+        `Delete skill "${skill.name}"? This is permanent — the agent can still recreate it later.`,
+      )
+    ) {
+      return;
+    }
+    try {
+      const res = await fetch(
+        `/api/workspaces/${workspaceId}/skills/${skill.id}`,
+        { method: "DELETE" },
+      );
+      if (!res.ok) throw new Error("Request failed");
+      setSkills(prev => prev.filter(s => s.id !== skill.id));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete skill");
+    }
+  };
+
+  const openEditor = async (skill: SkillSummary) => {
+    if (!workspaceId) return;
+    setEditLoading(true);
+    setEditing(null);
+    setSaveError(null);
+    try {
+      const res = await fetch(
+        `/api/workspaces/${workspaceId}/skills/${skill.id}`,
+      );
+      const data = await res.json();
+      if (!res.ok || !data.success) {
+        throw new Error(data.error || "Failed to load skill");
+      }
+      const detail = data.skill as SkillDetail;
+      setEditing(detail);
+      setEditLoadWhen(detail.loadWhen);
+      setEditBody(detail.body);
+      setEditEntities(detail.entities.join(", "));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load skill");
+    } finally {
+      setEditLoading(false);
+    }
+  };
+
+  const handleSaveEdit = async () => {
+    if (!workspaceId || !editing) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const entities = editEntities
+        .split(",")
+        .map(s => s.trim())
+        .filter(Boolean);
+      const res = await fetch(
+        `/api/workspaces/${workspaceId}/skills/${editing.id}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            loadWhen: editLoadWhen,
+            body: editBody,
+            entities,
+          }),
+        },
+      );
+      const data = await res.json();
+      if (!res.ok || !data.success) {
+        throw new Error(data.error || "Failed to save skill");
+      }
+      setEditing(null);
+      await fetchSkills();
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const hasSkills = skills.length > 0;
+  const suppressedCount = useMemo(
+    () => skills.filter(s => s.suppressed).length,
+    [skills],
+  );
+
+  return (
+    <Box>
+      <Stack
+        direction="row"
+        alignItems="center"
+        justifyContent="flex-end"
+        sx={{ mb: 1 }}
+      >
+        <Tooltip title="Refresh">
+          <span>
+            <IconButton
+              size="small"
+              onClick={fetchSkills}
+              disabled={loading}
+              aria-label="refresh skills"
+            >
+              <RefreshIcon fontSize="small" />
+            </IconButton>
+          </span>
+        </Tooltip>
+      </Stack>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      {loading && !hasSkills && (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
+          <CircularProgress size={24} />
+        </Box>
+      )}
+
+      {!loading && !hasSkills && (
+        <Alert severity="info">
+          No skills yet. The agent will save skills as you teach it durable
+          facts about your workspace (schema quirks, metric definitions,
+          connector specifics).
+        </Alert>
+      )}
+
+      {hasSkills && (
+        <Stack spacing={1.5}>
+          <Typography variant="caption" color="text.secondary">
+            {skills.length} skill{skills.length === 1 ? "" : "s"}
+            {suppressedCount > 0 ? ` · ${suppressedCount} suppressed` : ""}
+          </Typography>
+          {skills.map(skill => (
+            <Box
+              key={skill.id}
+              sx={{
+                border: 1,
+                borderColor: "divider",
+                borderRadius: 1,
+                p: 1.5,
+                bgcolor: skill.suppressed ? "action.hover" : "transparent",
+                opacity: skill.suppressed ? 0.7 : 1,
+              }}
+            >
+              <Stack
+                direction="row"
+                alignItems="flex-start"
+                justifyContent="space-between"
+                spacing={1}
+              >
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Stack
+                    direction="row"
+                    alignItems="center"
+                    spacing={1}
+                    sx={{ mb: 0.5 }}
+                  >
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        fontFamily: "monospace",
+                        fontWeight: 600,
+                      }}
+                    >
+                      {skill.name}
+                    </Typography>
+                    <Chip
+                      label={`used ${skill.useCount}×`}
+                      size="small"
+                      variant="outlined"
+                    />
+                    {skill.suppressed && (
+                      <Chip
+                        label="suppressed"
+                        size="small"
+                        color="warning"
+                        variant="outlined"
+                      />
+                    )}
+                  </Stack>
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{ mb: 0.5 }}
+                  >
+                    <strong>loadWhen:</strong> {skill.loadWhen}
+                  </Typography>
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      whiteSpace: "pre-wrap",
+                      fontSize: "0.82rem",
+                      color: "text.secondary",
+                      mb: 0.5,
+                    }}
+                  >
+                    {skill.bodyPreview}
+                  </Typography>
+                  {skill.entities.length > 0 && (
+                    <Stack
+                      direction="row"
+                      spacing={0.5}
+                      sx={{ flexWrap: "wrap", gap: 0.5, mb: 0.5 }}
+                    >
+                      {skill.entities.slice(0, 12).map(e => (
+                        <Chip
+                          key={e}
+                          label={e}
+                          size="small"
+                          sx={{ height: 18, fontSize: "0.68rem" }}
+                        />
+                      ))}
+                      {skill.entities.length > 12 && (
+                        <Typography variant="caption" color="text.secondary">
+                          +{skill.entities.length - 12} more
+                        </Typography>
+                      )}
+                    </Stack>
+                  )}
+                  <Typography variant="caption" color="text.secondary">
+                    by {skill.createdBy} · updated {formatDate(skill.updatedAt)}{" "}
+                    · last used {formatDate(skill.lastUsedAt)}
+                  </Typography>
+                </Box>
+                <Stack direction="row" alignItems="center" spacing={0.5}>
+                  <Tooltip
+                    title={
+                      skill.suppressed
+                        ? "Re-enable this skill"
+                        : "Suppress — stop injecting this skill but keep it around"
+                    }
+                  >
+                    <Switch
+                      size="small"
+                      checked={!skill.suppressed}
+                      onChange={() => handleToggleSuppress(skill)}
+                    />
+                  </Tooltip>
+                  <Tooltip title="Edit">
+                    <IconButton
+                      size="small"
+                      onClick={() => openEditor(skill)}
+                      aria-label="edit skill"
+                    >
+                      <EditIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Delete permanently">
+                    <IconButton
+                      size="small"
+                      onClick={() => handleDelete(skill)}
+                      aria-label="delete skill"
+                    >
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                </Stack>
+              </Stack>
+            </Box>
+          ))}
+        </Stack>
+      )}
+
+      <Dialog
+        open={editing !== null || editLoading}
+        onClose={() => {
+          if (!saving) setEditing(null);
+        }}
+        fullWidth
+        maxWidth="md"
+      >
+        <DialogTitle>
+          {editing ? (
+            <Box>
+              <Typography variant="h6" sx={{ fontFamily: "monospace" }}>
+                {editing.name}
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                Editing will preserve the current body as a one-step undo slot.
+              </Typography>
+            </Box>
+          ) : (
+            "Loading skill…"
+          )}
+        </DialogTitle>
+        <DialogContent dividers>
+          {editLoading && (
+            <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+              <CircularProgress size={24} />
+            </Box>
+          )}
+          {editing && (
+            <Stack spacing={2}>
+              {saveError && <Alert severity="error">{saveError}</Alert>}
+              <TextField
+                label="loadWhen"
+                value={editLoadWhen}
+                onChange={e => setEditLoadWhen(e.target.value)}
+                multiline
+                minRows={2}
+                fullWidth
+                inputProps={{ maxLength: 500 }}
+                helperText="Short trigger describing when this skill should load."
+              />
+              <TextField
+                label="body"
+                value={editBody}
+                onChange={e => setEditBody(e.target.value)}
+                multiline
+                minRows={12}
+                fullWidth
+                inputProps={{ maxLength: 20000 }}
+                sx={{ fontFamily: "monospace" }}
+              />
+              <TextField
+                label="entities (comma-separated)"
+                value={editEntities}
+                onChange={e => setEditEntities(e.target.value)}
+                fullWidth
+                helperText="Extra tokens the extractor might miss (synonyms, business concepts). Unioned with auto-extracted tokens."
+              />
+              {editing.previousBody && (
+                <Alert severity="info">
+                  Previous body from {formatDate(editing.previousUpdatedAt)} is
+                  preserved as a one-step undo.
+                </Alert>
+              )}
+            </Stack>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setEditing(null)} disabled={saving}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            startIcon={<SaveIcon />}
+            onClick={handleSaveEdit}
+            disabled={saving || !editing}
+          >
+            {saving ? "Saving…" : "Save"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -1,5 +1,6 @@
 import type { SettingsSection } from "../store/lib/types";
 import SettingsPrompt from "./settings/SettingsPrompt";
+import SettingsSkills from "./settings/SettingsSkills";
 import SettingsModels from "./settings/SettingsModels";
 import SettingsBilling from "./settings/SettingsBilling";
 import SettingsMembers from "./settings/SettingsMembers";
@@ -23,6 +24,8 @@ function Settings({ section = "prompt" }: Props) {
   switch (section) {
     case "prompt":
       return <SettingsPrompt />;
+    case "skills":
+      return <SettingsSkills />;
     case "models":
       return <SettingsModels />;
     case "billing":

--- a/app/src/pages/settings/SettingsSkills.tsx
+++ b/app/src/pages/settings/SettingsSkills.tsx
@@ -1,0 +1,13 @@
+import SettingsLayout from "./SettingsLayout";
+import { SkillsSection } from "../../components/SkillsSection";
+
+export default function SettingsSkills() {
+  return (
+    <SettingsLayout
+      title="Skills"
+      description="Named, workspace-scoped playbooks the agent can author and load on demand. Each skill has a loadWhen trigger and a body of schema facts, gotchas, or query patterns. Suppress to A/B whether a skill is helping; delete to retract permanently."
+    >
+      <SkillsSection />
+    </SettingsLayout>
+  );
+}

--- a/app/src/pages/settings/sections.ts
+++ b/app/src/pages/settings/sections.ts
@@ -8,6 +8,7 @@ import type { SettingsSection } from "../../store/lib/types";
  */
 export const SECTION_LABELS: Record<SettingsSection, string> = {
   prompt: "Custom Prompt",
+  skills: "Skills",
   models: "AI Models",
   billing: "Billing",
   members: "Members",
@@ -22,6 +23,7 @@ export const SECTION_LABELS: Record<SettingsSection, string> = {
  */
 export const SECTION_ORDER: SettingsSection[] = [
   "prompt",
+  "skills",
   "models",
   "billing",
   "members",

--- a/app/src/store/lib/types.ts
+++ b/app/src/store/lib/types.ts
@@ -22,6 +22,7 @@ export type TabKind =
  */
 export type SettingsSection =
   | "prompt"
+  | "skills"
   | "models"
   | "billing"
   | "members"


### PR DESCRIPTION
Closes #365

## Summary

Adds a named, workspace-scoped **skills** primitive the agent can author and load on demand. Skills live alongside the existing self-directive (which is intentionally untouched for this MVP — we want to observe real usage before migrating any of it).

Each skill has:
- `name` — stable identifier the agent references
- `loadWhen` — short trigger describing when it applies
- `body` — schema facts, gotchas, query patterns, playbook content
- `entities` — extracted + author-declared tokens for retrieval

## Retrieval

On every turn we extract entities from the user query and rank candidate skills with a weighted score:

- **0.6 entity overlap** — deterministic tokenizer over identifiers, dotted paths (`public.leads`), camelCase, with stopword filtering
- **0.4 semantic similarity** — cosine over an OpenAI `text-embedding-3-small` embedding of `loadWhen` only (kept narrow on purpose)

Top-3 full bodies above threshold are auto-injected into the system prompt. A compact `name + loadWhen` index of every non-suppressed skill is always present, so the agent can discover skills it didn't auto-load and call `load_skill(name)` explicitly. Retrieval decisions (scores, entities, considered vs. injected) are embedded as a commented block in the prompt for observability.

## Agent tools

- `save_skill(name, load_when, body, entities?)` — upsert; preserves `previousBody` for one-step undo
- `delete_skill(name)` — permanent retraction
- `load_skill(name)` — force-load full body, bumps `useCount` / `lastUsedAt`
- `search_skills(query, limit?)` — ranked search

Wired into the `console` and `unified` agents via `AgentContext.skillsBlock`.

## Schema / storage

- New `skills` collection with unique `(workspaceId, name)`, filter indexes on `suppressed` and `entities`, text index over `name/loadWhen/body`, and a best-effort Atlas Vector Search index (`skill_embeddings`) on `loadWhenEmbedding`. Falls back to entity + text when Atlas vector search isn't available.
- Forward-looking fields included: `scopeType` (workspace/user/connection), `scopeRefId`, `embeddingModel`, `createdBy`, `suppressed`, `useCount`, `lastUsedAt`, `previousBody`, `previousUpdatedAt`.

## Admin UI

New **Settings → Skills** section backed by `/api/workspaces/:workspaceId/skills`:
- List with loadWhen, body preview, entities, usage count, last used
- Edit loadWhen / body / entities (entities re-union on save)
- Toggle `suppressed` for A/B without deleting
- Permanent delete
- Shows one-step undo hint when `previousBody` is present

## Conflict resolution

The self-directive remains the source of truth during coexistence: if a skill conflicts with the directive, the directive wins. Documented in the injected skills block.

## Test plan

- [ ] Run `pnpm run migrate` locally — collection + indexes created, idempotent on re-run
- [ ] Verify Atlas vector index creation is a no-op on local Mongo (graceful log, retrieval still works)
- [ ] Create a skill via the agent tool (`save_skill`); confirm `loadWhenEmbedding` populated when `OPENAI_API_KEY` is set, and skill still persists without one
- [ ] Confirm compact index appears in every system prompt; top matches auto-injected on relevant queries; trace comment present
- [ ] `load_skill` / `search_skills` / `delete_skill` round-trip from the agent
- [ ] Settings → Skills: list, edit, suppress, unsuppress, delete; entity re-extraction on edit; undo hint when `previousBody` exists
- [ ] Authorization: list/edit/delete denied without workspace access

Made with [Cursor](https://cursor.com)