### PR TITLE
fix(model-catalog): tolerate non-string pricing fields from AI Gateway

### DIFF
--- a/api/src/services/model-catalog.service.ts
+++ b/api/src/services/model-catalog.service.ts
@@ -39,6 +39,18 @@ export interface CatalogModel {
 // Zod validation schemas — gate what gets persisted to DB
 // ---------------------------------------------------------------------------
 
+// Pricing: we only care about `input` and `output` (per-token strings).
+// The upstream gateway has started returning additional non-string fields for
+// some models (e.g. `input_tiers`/`output_tiers` as arrays, `video_duration_pricing`
+// as a list/object). Accept any extra keys via passthrough so validation doesn't
+// reject the whole snapshot over fields we don't use.
+const GatewayPricingSchema = z
+  .object({
+    input: z.string().optional(),
+    output: z.string().optional(),
+  })
+  .passthrough();
+
 const GatewayModelRawSchema = z.object({
   id: z.string(),
   name: z.string().optional(),
@@ -47,7 +59,7 @@ const GatewayModelRawSchema = z.object({
   type: z.string().optional(),
   context_window: z.number().optional(),
   tags: z.array(z.string()).optional(),
-  pricing: z.record(z.string(), z.string()).optional(),
+  pricing: GatewayPricingSchema.optional(),
 });
 
 const GatewayResponseSchema = z.object({


### PR DESCRIPTION
## Summary

Vercel's AI Gateway now returns pricing objects with array/object fields (`input_tiers`, `output_tiers`, `video_duration_pricing`, etc.) on many models — e.g. `alibaba/qwen3-*`, `anthropic/claude-sonnet-4`/`4.5`, `bytedance/seed-*`. The previous Zod schema was `z.record(z.string(), z.string())`, which rejects those entries, so **every** gateway refresh has been failing validation for weeks with:

```
Gateway response failed Zod validation, skipping upsert
reason: "data.6.pricing.input_tiers: Invalid input: expected string, received array; ..."
```

Because the snapshot never got persisted, `ensureCatalog()` kept falling back to:

```ts
cachedFreeTierIds = new Set(FALLBACK_FREE);
// = ["openai/gpt-4o-mini", "google/gemini-2.5-flash", "deepseek/deepseek-chat"]
```

…which meant every other model — including Claude 3.5 Haiku (blended $2.40/M, well under the $3/M free-tier cap) — got classified as `pro` and free-plan users saw **"Model requires a pro plan. Current plan: free"** on basically everything.

## Fix

Switch `pricing` validation to an explicit object schema with `.passthrough()`. We only consume `input` and `output` (both strings) in `refreshGatewaySnapshot`, so any additional non-string keys from upstream are tolerated without failing validation for the whole model list.

```ts
const GatewayPricingSchema = z
  .object({
    input: z.string().optional(),
    output: z.string().optional(),
  })
  .passthrough();
```

## Rollout

- Merge → on next API restart, `warmCatalog()` will refetch and persist the gateway/pricing snapshots.
- Alternatively the hourly Inngest cron (`Refresh AI model catalog snapshots`) will pick it up without a restart.
- Once the `modelcatalogsnapshots.gateway` + `.pricing` docs are populated, `isFreeTierModel()` computes the free set from real blended pricing and `FALLBACK_FREE` stops being hit.

## Test plan

- [ ] Restart API locally (or trigger the Inngest `Refresh AI model catalog snapshots` function) and confirm logs show `Persisted gateway + pricing snapshots` (not `Gateway response failed Zod validation`).
- [ ] On a free-plan workspace, send a chat with Claude 3.5 Haiku selected → expect a successful response, not a 403 `model_not_available`.
- [ ] `GET /api/agent/gateway-models` returns the full catalog with pricing metadata intact.
- [ ] Spot-check a tiered-pricing model (e.g. `anthropic/claude-sonnet-4.5`) appears in the catalog with a usable `blendedCostPerM`.

Made with [Cursor](https://cursor.com)