### PR TITLE
fix(agent): use adaptive thinking for Claude Opus 4.7+

### DIFF
--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -65,6 +65,40 @@ import { toNum, extractTokenCounts } from "../utils/safe-num";
 
 const logger = loggers.agent();
 
+/**
+ * Build the Anthropic `thinking` provider option for a given model.
+ *
+ * Claude Opus 4.7 (and future Claude models) rejects the legacy
+ * `{ type: "enabled", budget_tokens: N }` shape with a 400 error and requires
+ * `{ type: "adaptive" }` — see
+ * https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking.
+ * For older models (Opus 4.6, Sonnet 4.6, 4.5, 3.x) we keep the manual
+ * `enabled` shape so the configured `thinkingBudgetTokens` is still honored.
+ */
+function buildAnthropicThinkingConfig(
+  modelId: string,
+  budgetTokens: number,
+): Record<string, unknown> {
+  if (modelRequiresAdaptiveThinking(modelId)) {
+    return { type: "adaptive", display: "summarized" };
+  }
+  return { type: "enabled", budgetTokens };
+}
+
+function modelRequiresAdaptiveThinking(modelId: string): boolean {
+  const lower = modelId.toLowerCase();
+  if (lower.includes("mythos")) return true;
+  // Match e.g. "anthropic/claude-opus-4-7", "anthropic/claude-sonnet-5-0"
+  const match = lower.match(/claude-(?:opus|sonnet|haiku)-(\d+)-(\d+)/);
+  if (!match) return false;
+  const major = Number.parseInt(match[1], 10);
+  const minor = Number.parseInt(match[2], 10);
+  if (Number.isNaN(major) || Number.isNaN(minor)) return false;
+  if (major > 4) return true;
+  if (major === 4 && minor >= 7) return true;
+  return false;
+}
+
 export const agentRoutes = new Hono();
 
 // Apply unified auth middleware to all routes
@@ -614,10 +648,10 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
     ...(enableThinking
       ? {
           anthropic: {
-            thinking: {
-              type: "enabled" as const,
-              budgetTokens: thinkingBudget,
-            },
+            thinking: buildAnthropicThinkingConfig(
+              resolvedModelId,
+              thinkingBudget,
+            ),
           },
         }
       : {}),


### PR DESCRIPTION
## Summary

Fixes a 400 from the Anthropic API when the workspace selects Claude Opus 4.7: `"thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.`

Opus 4.7 dropped the manual `thinking: { type: "enabled", budget_tokens: N }` shape in favor of adaptive thinking. We were unconditionally sending the legacy shape in `api/src/routes/agent.routes.ts`.

## Changes

- New helper `buildAnthropicThinkingConfig(modelId, budgetTokens)` in `api/src/routes/agent.routes.ts`.
- `modelRequiresAdaptiveThinking()` parses the version out of IDs like `anthropic/claude-opus-4-7` and returns `true` for Claude 4.7+ (plus `mythos` preview). Older models (Opus 4.6, Sonnet 4.6, 4.5, 3.x) keep the `{ type: "enabled", budgetTokens }` shape so the curated `thinkingBudgetTokens` is still honored.
- For adaptive models we send `{ type: "adaptive", display: "summarized" }`. The explicit `display: "summarized"` is important — Opus 4.7's default is `"omitted"`, which would make the reasoning stream arrive empty and appear as a long pause before text in the chat UI.

Reference: https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking

## Test plan

- [ ] Chat with a Claude Opus 4.7 model end-to-end — request succeeds and reasoning blocks stream.
- [ ] Chat with Claude Opus 4.6 / Sonnet 4.6 — still works, still sends `budgetTokens` (verify in logs / request trace).
- [ ] Chat with an older Claude 3.x or non-Anthropic model — unchanged behavior.
- [ ] `pnpm --filter api run lint` passes.

## Follow-ups (not in this PR)

- Wire an `effort` field (`low` / `medium` / `high` / `xhigh` / `max`) into `CuratedModelEntry` and forward it as `output_config: { effort }`. Useful once super-admins want per-model cost/latency tuning.
- Opus 4.7 rejects non-default `temperature` / `top_p` / `top_k`. We don't currently set any of those, so no change needed, but worth a note if we ever start exposing sampling params.

Made with [Cursor](https://cursor.com)