### PR TITLE
fix(agent): resolve Anthropic thinking mode at catalog build time

### DIFF
--- a/api/src/agent-lib/ai-models.ts
+++ b/api/src/agent-lib/ai-models.ts
@@ -13,6 +13,7 @@ import {
   getUtilityChatModelId,
   type CatalogModel,
 } from "../services/model-catalog.service";
+import type { AnthropicThinkingMode } from "./anthropic-thinking";
 
 export type AIProvider = string;
 
@@ -25,6 +26,7 @@ export interface AIModel {
   description?: string;
   tier?: ModelTier;
   supportsThinking?: boolean;
+  thinkingMode?: AnthropicThinkingMode;
   thinkingBudgetTokens?: number;
 }
 
@@ -36,6 +38,7 @@ function catalogToAIModel(cm: CatalogModel): AIModel {
     description: cm.description,
     tier: cm.tier,
     supportsThinking: cm.supportsThinking,
+    thinkingMode: cm.thinkingMode,
     thinkingBudgetTokens: cm.thinkingBudgetTokens,
   };
 }

--- a/api/src/agent-lib/anthropic-thinking.test.ts
+++ b/api/src/agent-lib/anthropic-thinking.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import {
+  buildAnthropicThinkingConfig,
+  resolveAnthropicThinkingMode,
+} from "./anthropic-thinking";
+
+function t(label: string, fn: () => void) {
+  fn();
+  process.stdout.write(`ok  ${label}\n`);
+}
+
+// --- Explicit allowlist ---------------------------------------------------
+// These IDs are catalogued directly from Vercel's docs and must always
+// resolve to the documented mode regardless of the version-regex fallback.
+// https://vercel.com/docs/ai-gateway/capabilities/reasoning/anthropic
+
+t("opus-4.7 (explicit) → adaptive", () => {
+  assert.equal(
+    resolveAnthropicThinkingMode("anthropic/claude-opus-4.7", true),
+    "adaptive",
+  );
+});
+t("opus-4.6 (explicit) → adaptive", () => {
+  assert.equal(
+    resolveAnthropicThinkingMode("anthropic/claude-opus-4.6", true),
+    "adaptive",
+  );
+});
+t("sonnet-4.6 (explicit) → adaptive", () => {
+  assert.equal(
+    resolveAnthropicThinkingMode("anthropic/claude-sonnet-4.6", true),
+    "adaptive",
+  );
+});
+t("opus-4.5 (explicit) → manual", () => {
+  assert.equal(
+    resolveAnthropicThinkingMode("anthropic/claude-opus-4.5", true),
+    "manual",
+  );
+});
+t("sonnet-4.5 (explicit) → manual", () => {
+  assert.equal(
+    resolveAnthropicThinkingMode("anthropic/claude-sonnet-4.5", true),
+    "manual",
+  );
+});
+t("haiku-4.5 (explicit) → manual", () => {
+  assert.equal(
+    resolveAnthropicThinkingMode("anthropic/claude-haiku-4.5", true),
+    "manual",
+  );
+});
+
+// --- Fallback: uncatalogued Claude IDs -----------------------------------
+// The version regex covers IDs we haven't pinned explicitly yet (e.g. future
+// releases or alternate delimiter styles in seed migrations).
+
+t("dash-notation opus-4-7 → adaptive", () => {
+  assert.equal(
+    resolveAnthropicThinkingMode("anthropic/claude-opus-4-7", true),
+    "adaptive",
+  );
+});
+t("reverse-order claude-4.7-opus → adaptive", () => {
+  assert.equal(
+    resolveAnthropicThinkingMode("claude-4.7-opus", true),
+    "adaptive",
+  );
+});
+t("future opus-5.0 → adaptive", () => {
+  assert.equal(
+    resolveAnthropicThinkingMode("anthropic/claude-opus-5.0", true),
+    "adaptive",
+  );
+});
+t("mythos preview → adaptive", () => {
+  assert.equal(
+    resolveAnthropicThinkingMode("anthropic/claude-mythos-preview", true),
+    "adaptive",
+  );
+});
+t("uncatalogued sonnet-4.0 → manual", () => {
+  assert.equal(
+    resolveAnthropicThinkingMode("anthropic/claude-sonnet-4.0", true),
+    "manual",
+  );
+});
+t("uncatalogued opus-3.5 → manual", () => {
+  assert.equal(
+    resolveAnthropicThinkingMode("anthropic/claude-opus-3.5", true),
+    "manual",
+  );
+});
+
+// --- Non-thinking / non-Anthropic ---------------------------------------
+
+t("supportsThinking=false → none", () => {
+  assert.equal(
+    resolveAnthropicThinkingMode("anthropic/claude-opus-4.7", false),
+    "none",
+  );
+});
+t("openai/gpt-5.4 → manual (not used, short-circuits upstream)", () => {
+  assert.equal(resolveAnthropicThinkingMode("openai/gpt-5.4", true), "manual");
+});
+
+// --- Payload shape -------------------------------------------------------
+
+t("buildAnthropicThinkingConfig adaptive payload", () => {
+  assert.deepEqual(buildAnthropicThinkingConfig("adaptive", 10000), {
+    type: "adaptive",
+    display: "summarized",
+  });
+});
+t("buildAnthropicThinkingConfig manual payload carries budgetTokens", () => {
+  assert.deepEqual(buildAnthropicThinkingConfig("manual", 12345), {
+    type: "enabled",
+    budgetTokens: 12345,
+  });
+});
+t("buildAnthropicThinkingConfig none returns null", () => {
+  assert.equal(buildAnthropicThinkingConfig("none", 10000), null);
+});

--- a/api/src/agent-lib/anthropic-thinking.ts
+++ b/api/src/agent-lib/anthropic-thinking.ts
@@ -1,0 +1,97 @@
+/**
+ * Anthropic extended-thinking capability map.
+ *
+ * The Vercel AI Gateway does not expose which thinking mode (adaptive vs
+ * manual `budget_tokens`) each Claude model supports — the `/v1/models` and
+ * `/v1/models/{id}/endpoints` responses only carry a generic `"reasoning"`
+ * tag. The adaptive/manual split is documented only here:
+ *
+ *   https://vercel.com/docs/ai-gateway/capabilities/reasoning/anthropic
+ *   https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking
+ *
+ * Consequences of picking the wrong mode:
+ *   - adaptive payload against a pre-4.6 model → 400
+ *   - manual  payload against Opus 4.7+       → 400
+ *     ("thinking.type.enabled is not supported for this model")
+ *   - manual  payload against 4.6             → accepted today but deprecated
+ *
+ * We keep the mapping in one place, keyed off documented model IDs, with a
+ * version-range fallback so future Claude releases that follow the pattern
+ * (4.8, 5.x, …) work without a code change.
+ */
+
+export type AnthropicThinkingMode = "adaptive" | "manual" | "none";
+
+// Models for which we've verified the required/recommended mode against
+// Vercel's docs. This is the authoritative source; the regex below is only
+// a fallback for models we haven't catalogued yet.
+const EXPLICIT_MODES: Record<string, AnthropicThinkingMode> = {
+  // Adaptive — Claude 4.6+ (manual deprecated on 4.6, rejected on 4.7+)
+  "anthropic/claude-opus-4.7": "adaptive",
+  "anthropic/claude-opus-4.6": "adaptive",
+  "anthropic/claude-sonnet-4.6": "adaptive",
+  // Manual — Claude 4.x and earlier
+  "anthropic/claude-opus-4.5": "manual",
+  "anthropic/claude-opus-4.1": "manual",
+  "anthropic/claude-opus-4": "manual",
+  "anthropic/claude-sonnet-4.5": "manual",
+  "anthropic/claude-sonnet-4": "manual",
+  "anthropic/claude-haiku-4.5": "manual",
+};
+
+/**
+ * Resolve the thinking mode for a given model + capability tags.
+ *
+ *   modelId:       the gateway ID, e.g. "anthropic/claude-opus-4.7"
+ *   supportsThinking: whether the gateway tagged the model with "reasoning"
+ */
+export function resolveAnthropicThinkingMode(
+  modelId: string,
+  supportsThinking: boolean,
+): AnthropicThinkingMode {
+  if (!supportsThinking) return "none";
+  const explicit = EXPLICIT_MODES[modelId];
+  if (explicit) return explicit;
+
+  const lower = modelId.toLowerCase();
+  if (lower.includes("mythos")) return "adaptive";
+  if (!lower.includes("claude")) return "manual";
+
+  // Fallback for uncatalogued Claude models. Vercel AI Gateway uses dot
+  // notation ("claude-opus-4.7"); our seed migrations use dashes
+  // ("claude-opus-4-7"); some third-party rails flip the order. Match all.
+  const patterns = [
+    /claude-(?:opus|sonnet|haiku)-(\d+)[.-](\d+)/,
+    /claude-(\d+)[.-](\d+)-(?:opus|sonnet|haiku)/,
+  ];
+  for (const re of patterns) {
+    const m = lower.match(re);
+    if (!m) continue;
+    const major = Number.parseInt(m[1], 10);
+    const minor = Number.parseInt(m[2], 10);
+    if (Number.isNaN(major) || Number.isNaN(minor)) continue;
+    if (major > 4 || (major === 4 && minor >= 6)) return "adaptive";
+    return "manual";
+  }
+  // Unknown Claude model with reasoning tag: conservative default.
+  return "manual";
+}
+
+/**
+ * Build the Anthropic `thinking` provider-option payload for the AI SDK.
+ * Returns `null` when thinking isn't supported.
+ */
+export function buildAnthropicThinkingConfig(
+  mode: AnthropicThinkingMode,
+  budgetTokens: number,
+): Record<string, unknown> | null {
+  if (mode === "adaptive") {
+    // `display: "summarized"` restores visible reasoning on Opus 4.7, which
+    // defaults to `"omitted"` (streams arrive empty → long pause before text).
+    return { type: "adaptive", display: "summarized" };
+  }
+  if (mode === "manual") {
+    return { type: "enabled", budgetTokens };
+  }
+  return null;
+}

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -13,6 +13,7 @@ import {
   type UIMessage,
 } from "ai";
 import { getModel, buildProviderOptions } from "../agent-lib/ai-gateway";
+import { buildAnthropicThinkingConfig } from "../agent-lib/anthropic-thinking";
 import { unifiedAuthMiddleware } from "../auth/unified-auth.middleware";
 import { AuthenticatedContext } from "../middleware/workspace.middleware";
 import { workspaceService } from "../services/workspace.service";
@@ -64,40 +65,6 @@ import { createAgentExecutionId } from "../agent-lib/tools/shared/truncation";
 import { toNum, extractTokenCounts } from "../utils/safe-num";
 
 const logger = loggers.agent();
-
-/**
- * Build the Anthropic `thinking` provider option for a given model.
- *
- * Claude Opus 4.7 (and future Claude models) rejects the legacy
- * `{ type: "enabled", budget_tokens: N }` shape with a 400 error and requires
- * `{ type: "adaptive" }` — see
- * https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking.
- * For older models (Opus 4.6, Sonnet 4.6, 4.5, 3.x) we keep the manual
- * `enabled` shape so the configured `thinkingBudgetTokens` is still honored.
- */
-function buildAnthropicThinkingConfig(
-  modelId: string,
-  budgetTokens: number,
-): Record<string, unknown> {
-  if (modelRequiresAdaptiveThinking(modelId)) {
-    return { type: "adaptive", display: "summarized" };
-  }
-  return { type: "enabled", budgetTokens };
-}
-
-function modelRequiresAdaptiveThinking(modelId: string): boolean {
-  const lower = modelId.toLowerCase();
-  if (lower.includes("mythos")) return true;
-  // Match e.g. "anthropic/claude-opus-4-7", "anthropic/claude-sonnet-5-0"
-  const match = lower.match(/claude-(?:opus|sonnet|haiku)-(\d+)-(\d+)/);
-  if (!match) return false;
-  const major = Number.parseInt(match[1], 10);
-  const minor = Number.parseInt(match[2], 10);
-  if (Number.isNaN(major) || Number.isNaN(minor)) return false;
-  if (major > 4) return true;
-  if (major === 4 && minor >= 7) return true;
-  return false;
-}
 
 export const agentRoutes = new Hono();
 
@@ -635,8 +602,12 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
   const MAX_STEPS = 256;
   let stepsCompleted = 0;
 
-  const enableThinking = modelDef?.supportsThinking === true;
+  const thinkingMode = modelDef?.thinkingMode ?? "none";
   const thinkingBudget = modelDef?.thinkingBudgetTokens ?? 10000;
+  const thinkingPayload = buildAnthropicThinkingConfig(
+    thinkingMode,
+    thinkingBudget,
+  );
 
   const providerOptions = {
     ...buildProviderOptions({
@@ -645,16 +616,7 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
       agentId: resolvedAgentId,
       invocationType: "chat",
     }),
-    ...(enableThinking
-      ? {
-          anthropic: {
-            thinking: buildAnthropicThinkingConfig(
-              resolvedModelId,
-              thinkingBudget,
-            ),
-          },
-        }
-      : {}),
+    ...(thinkingPayload ? { anthropic: { thinking: thinkingPayload } } : {}),
   };
 
   const startTime = Date.now();

--- a/api/src/services/model-catalog.service.ts
+++ b/api/src/services/model-catalog.service.ts
@@ -18,6 +18,10 @@
 import { z } from "zod";
 import { loggers } from "../logging";
 import { ModelCatalogSnapshot } from "../database/schema";
+import {
+  resolveAnthropicThinkingMode,
+  type AnthropicThinkingMode,
+} from "../agent-lib/anthropic-thinking";
 
 const logger = loggers.app();
 
@@ -33,6 +37,7 @@ export interface CatalogModel {
   contextWindow: number | null;
   tags: string[];
   supportsThinking: boolean;
+  thinkingMode: AnthropicThinkingMode;
   thinkingBudgetTokens: number;
   blendedCostPerM: number | null;
   tier: "free" | "pro";
@@ -389,6 +394,7 @@ function mergeCatalog(
     if (!cur || cur.visible === false) continue;
 
     const supportsThinking = gm.tags.includes("reasoning");
+    const thinkingMode = resolveAnthropicThinkingMode(gm.id, supportsThinking);
     const p = pricingMap.get(gm.id);
     const blendedCostPerM = p ? (p.input + p.output) / 2 : null;
     const tier = cur.tier;
@@ -402,6 +408,7 @@ function mergeCatalog(
       contextWindow: gm.contextWindow,
       tags: gm.tags,
       supportsThinking,
+      thinkingMode,
       thinkingBudgetTokens: supportsThinking ? 10_000 : 0,
       blendedCostPerM,
       tier,


### PR DESCRIPTION
## Summary

Follow-up to #374, which still left Opus 4.7 broken in prod.

### Why #374 didn't work
The detection regex matched `claude-opus-4-7` (dashes) only, but the Vercel AI Gateway ships Anthropic IDs in **dot notation** (\`anthropic/claude-opus-4.7\`). The check never fired in the request path, so we kept sending the rejected \`thinking: { type: "enabled" }\` shape.

### Why I didn't just patch the regex
Doing capability detection inline in the request path is fragile — every new model requires touching hot code. And the AI Gateway \`/v1/models\` and \`/v1/models/{id}/endpoints\` endpoints **do not expose** the adaptive-vs-manual distinction; both only carry a generic \`"reasoning"\` tag. The documented mapping only lives in [Vercel's Anthropic reasoning docs](https://vercel.com/docs/ai-gateway/capabilities/reasoning/anthropic).

### What this PR does
1. **New `api/src/agent-lib/anthropic-thinking.ts`** — a single authoritative module with:
   - An **explicit allowlist** of the six catalogued IDs from Vercel's docs (\`claude-opus-4.7\`, \`claude-opus-4.6\`, \`claude-sonnet-4.6\` → adaptive; \`claude-opus-4.5\`, \`claude-sonnet-4.5\`, \`claude-haiku-4.5\`, \`claude-opus-4.1\`, etc. → manual).
   - A **version-regex fallback** (dot / dash / reversed delimiters) for uncatalogued Claude releases so future 4.8 / 5.x models work without a code change.
   - \`buildAnthropicThinkingConfig(mode, budgetTokens)\` that returns the right payload shape including \`display: \"summarized\"\` on adaptive (Opus 4.7's default is \`"omitted"\`, which hides the reasoning stream).
2. **Resolve mode once at catalog build time** — \`CatalogModel.thinkingMode: "adaptive" | "manual" | "none"\` is derived alongside \`supportsThinking\` in \`mergeCatalog\`.
3. **Thread it through** \`AIModel\` → \`agent.routes.ts\`, which now just reads \`modelDef.thinkingMode\`. No detection in the request path.
4. **Fix the cutoff** — adaptive is required on **4.6+** per Vercel's docs, not only 4.7+. #374 was keeping 4.6 on the deprecated manual shape.
5. **Tests** — new \`anthropic-thinking.test.ts\` with 17 cases covering the allowlist, fallback regex, delimiter variants, and payload shapes. Run with \`pnpm exec tsx src/agent-lib/anthropic-thinking.test.ts\`.

## Test plan

- [x] \`pnpm exec tsx api/src/agent-lib/anthropic-thinking.test.ts\` — 17/17 pass
- [x] \`pnpm --filter api run lint\` — clean
- [x] \`npx tsc --noEmit\` — no new errors (the two \`version-comment.service.ts\` errors pre-exist on master)
- [ ] Chat with Claude Opus 4.7 in prod — no more 400, reasoning streams visibly
- [ ] Chat with Claude Opus 4.6 — now uses adaptive (was manual on the deprecated path)
- [ ] Chat with Claude Opus 4.5 / Sonnet 4.5 — still on manual with the curated budget
- [ ] Chat with a non-Anthropic / non-reasoning model — no \`anthropic\` provider option sent

## Notes

- If Vercel ever adds a \`thinking_mode\` field (or equivalent) to the gateway models endpoint, we can drop the allowlist + regex and read it directly. Until then, the utility is the single place to update when a new Claude model ships.

Made with [Cursor](https://cursor.com)