### PR TITLE
docs: document workspace skills system (#365)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -32,6 +32,7 @@ export default defineConfig({
             { label: "Dashboards", slug: "dashboards" },
             { label: "Query Runner", slug: "query-runner" },
             { label: "Self-Directive", slug: "self-directive" },
+            { label: "Skills", slug: "skills" },
           ],
         },
         {

--- a/docs/src/content/docs/ai-agent.md
+++ b/docs/src/content/docs/ai-agent.md
@@ -70,6 +70,20 @@ Mako learns your database over time. When it discovers that your `created_at` co
 
 This persists across all conversations. The more you use Mako, the less explaining you need to do.
 
+
+## Targeted Playbooks (Skills)
+
+Beyond the always-on self-directive, Mako supports **skills** — named, workspace-scoped playbooks that load only when their trigger fires. Good for per-country queries, multi-step procedures, or rare schema gotchas that shouldn't clutter the always-on memory.
+
+| Tool            | What It Does                                                |
+| --------------- | ----------------------------------------------------------- |
+| `save_skill`    | Create or overwrite a named playbook                        |
+| `delete_skill`  | Retract a skill that turned out to be wrong                 |
+| `load_skill`    | Explicitly load a skill mid-turn when the index hints at it |
+| `search_skills` | Free-text fallback when the auto-injected index misses      |
+
+Every turn, Mako injects a compact index of every skill plus the top-3 auto-retrieved bodies (entity overlap 0.6 + semantic similarity 0.4). See [Skills](/skills/) for the full model, admin UI, and REST API.
+
 ## Multi-Agent Architecture
 
 Different contexts activate different specialized agents:

--- a/docs/src/content/docs/api-reference.md
+++ b/docs/src/content/docs/api-reference.md
@@ -149,6 +149,40 @@ The response is a **Server-Sent Events (SSE)** stream:
 | `DELETE` | `/api/workspaces/:wid/chats/:id` | Delete a chat      |
 
 
+## Skills
+
+Workspace skills — named playbooks the agent can author and load on demand. See [Skills](/skills/) for the conceptual model.
+
+| Method   | Endpoint                                            | Description                                   |
+| -------- | --------------------------------------------------- | --------------------------------------------- |
+| `GET`    | `/api/workspaces/:wid/skills`                       | List every skill in the workspace             |
+| `GET`    | `/api/workspaces/:wid/skills/:id`                   | Get a single skill with full body             |
+| `PUT`    | `/api/workspaces/:wid/skills/:id`                   | Edit `loadWhen`, `body`, or `entities`        |
+| `POST`   | `/api/workspaces/:wid/skills/:id/suppress`          | Toggle the `suppressed` flag                  |
+| `DELETE` | `/api/workspaces/:wid/skills/:id`                   | Permanently delete a skill                    |
+
+All endpoints require authentication and workspace access. Agent-side CRUD is available through the `save_skill`, `delete_skill`, `load_skill`, and `search_skills` tools — see [AI Agent](/ai-agent/#targeted-playbooks-skills).
+
+### Skill Response Shape
+
+```json
+{
+  "success": true,
+  "skill": {
+    "id": "6620...",
+    "name": "mrr_walkthrough_fr",
+    "loadWhen": "Building a sales report or answering questions about MRR in France",
+    "body": "...",
+    "entities": ["mrr", "france", "subscriptions"],
+    "suppressed": false,
+    "useCount": 12,
+    "createdBy": "6612...",
+    "createdAt": "2026-04-23T12:36:00.000Z",
+    "updatedAt": "2026-04-23T12:36:00.000Z"
+  }
+}
+```
+
 ## Dashboards
 
 | Method   | Endpoint                                                         | Description                          |

--- a/docs/src/content/docs/self-directive.md
+++ b/docs/src/content/docs/self-directive.md
@@ -41,3 +41,8 @@ Typical self-directive content:
 4. Next conversation, agent reads self-directive → already knows the quirk → skips re-discovery
 
 This means the agent gets faster and more accurate over time for recurring work in the same workspace.
+
+## Related: Skills
+
+The self-directive is always loaded. For playbooks that should only fire under specific conditions, use [Skills](/skills/) — named, workspace-scoped procedures that Mako retrieves on demand based on a trigger phrase and entity/semantic match.
+

--- a/docs/src/content/docs/skills.md
+++ b/docs/src/content/docs/skills.md
@@ -1,0 +1,86 @@
+---
+title: Skills
+description: Workspace-scoped playbooks the agent can author and load on demand.
+---
+
+Skills are named, workspace-scoped playbooks the agent writes for itself. Each skill has a short trigger (`loadWhen`), a body of schema facts or procedures, and a set of entities used for retrieval. When a user sends a message, Mako automatically surfaces the most relevant skills into the agent's context.
+
+They complement the [Self-Directive](/self-directive/): the self-directive is a single always-on document, while skills are targeted playbooks that load only when their trigger matches. Use skills for things that should fire only under specific conditions -- a per-country sales query, a multi-step reconciliation procedure, a rare schema gotcha.
+
+## How Retrieval Works
+
+Every agent turn does the following before the LLM call:
+
+1. **Index injection** -- the compact list of every non-suppressed skill in the workspace (name + `loadWhen`) is always injected into the system prompt. The agent can see everything that exists, even if nothing matches strongly.
+2. **Scoring** -- the user's message is embedded and compared against every skill's `loadWhen` embedding. A weighted score is computed:
+   - Entity overlap (0.6) -- tokens extracted from the message vs the skill's entities
+   - Semantic similarity (0.4) -- cosine similarity on the `loadWhen` embedding
+3. **Auto-injection** -- the top 3 skills with a composite score ≥ 0.25 have their full bodies injected into the system prompt.
+4. **Explicit load** -- if the agent sees a skill in the index that wasn't auto-loaded but looks relevant, it can call `load_skill` to pull it mid-turn.
+
+Skills survive across sessions and are shared across all members of the workspace.
+
+## Agent Tools
+
+| Tool            | What It Does                                                                                  |
+| --------------- | --------------------------------------------------------------------------------------------- |
+| `save_skill`    | Upsert a skill by name. Reusing the same name overwrites the body (one undo step is retained) |
+| `delete_skill`  | Retract a skill permanently. Use when a skill turned out to be wrong                          |
+| `load_skill`    | Explicitly load a skill from the index mid-turn. Bumps `useCount` for retrieval reinforcement |
+| `search_skills` | Free-text search over all skills in the workspace. Fallback when the index doesn't surface it |
+
+`save_skill` accepts:
+
+- `name` (required) -- lowercase `snake_case`, max 80 chars, unique within the workspace
+- `loadWhen` (required) -- 1-2 sentence trigger phrase, max 500 chars
+- `body` (required) -- the playbook content, max 20,000 chars
+- `entities` (optional) -- author-declared triggers (table names, concepts, country codes). Unioned with the automatic extractor's output
+
+## What Good Skills Look Like
+
+A skill should have a sharp trigger and a compact body. Bad skills have vague triggers and dump generic prose.
+
+**Good trigger:** `Building a sales report, computing MRR, or answering "who are the best salespeople"`
+
+**Bad trigger:** `Answering questions about revenue`
+
+**Good body:** Mixes schema facts, gotchas, and example patterns, all tied to specific tables and columns.
+
+**Bad body:** Paragraphs of narrative without concrete identifiers.
+
+## Admin UI
+
+Settings → Skills lists every skill in the workspace. For each skill you can:
+
+- **Edit** -- rewrite the `loadWhen`, body, or entities. Takes effect on the next agent turn
+- **Suppress** -- disable the skill without deleting it. Suppressed skills stay in the database but are excluded from the index and retrieval
+- **Delete** -- permanently remove the skill
+
+The hard cap is 200 skills per workspace, which keeps the injected index bounded.
+
+## REST API
+
+All endpoints are mounted under `/api/workspaces/:workspaceId/skills` and require authentication plus workspace access.
+
+| Method   | Endpoint                  | Description                             |
+| -------- | ------------------------- | --------------------------------------- |
+| `GET`    | `/`                       | List all skills in the workspace        |
+| `GET`    | `/:id`                    | Get a single skill with full body       |
+| `PUT`    | `/:id`                    | Edit `loadWhen`, `body`, or `entities`  |
+| `POST`   | `/:id/suppress`           | Toggle the `suppressed` flag            |
+| `DELETE` | `/:id`                    | Permanently delete a skill              |
+
+See [API Reference](/api-reference/#skills) for the full response schema.
+
+## Relationship to the Self-Directive
+
+Both are workspace-scoped persistent memory, but they serve different purposes:
+
+| Aspect        | Self-Directive                                 | Skills                                                |
+| ------------- | ---------------------------------------------- | ----------------------------------------------------- |
+| Structure     | One text document, up to 10,000 chars          | Many named playbooks, up to 20,000 chars each         |
+| Loading       | Always in context                              | Retrieved on demand based on trigger + similarity     |
+| Scope         | Broad workspace-wide rules                     | Targeted, condition-specific playbooks                |
+| Use when      | Something always applies                       | Something applies only in a specific situation        |
+
+In practice: put a naming convention in the self-directive, put the full `monthly_recurring_revenue` computation procedure in a skill.


### PR DESCRIPTION
## Gap

PR #365 shipped a new workspace-scoped **skills system** — 4 new agent tools, 5 admin REST endpoints, new Settings → Skills UI, new \`skills\` MongoDB collection, new retrieval pipeline — with zero user-facing docs. This closes that gap.

## Changes

- **New page** \`docs/src/content/docs/skills.md\` — covers the retrieval model (entity overlap 0.6 + semantic similarity 0.4, top-3 auto-inject at threshold 0.25), the four agent tools, what good skills look like, the admin UI, REST endpoints, and how skills relate to the self-directive.
- **\`ai-agent.md\`** — added a *Targeted Playbooks (Skills)* section between the self-directive and multi-agent architecture blocks, with the tool table and a cross-link.
- **\`api-reference.md\`** — added a \`## Skills\` section with all five endpoints and the response shape (verified against \`api/src/routes/skills.ts\` and \`api/src/database/workspace-schema.ts\`).
- **\`self-directive.md\`** — added a \`## Related: Skills\` note explaining when to use which primitive.
- **\`astro.config.mjs\`** — sidebar entry for Skills under Core Features, after Self-Directive.

## Verification

- Endpoints verified against \`api/src/routes/skills.ts\` (GET /, GET /:id, PUT /:id, POST /:id/suppress, DELETE /:id).
- Response shape verified against \`ISkill\` in \`api/src/database/workspace-schema.ts\`.
- Agent tool list + descriptions cross-checked against \`api/src/agent-lib/tools/skill-tools.ts\`.
- Retrieval weights (ENTITY=0.6, SEMANTIC=0.4, threshold=0.25, AUTO_INJECT_LIMIT=3, MAX_SKILLS_PER_WORKSPACE=200) pulled from \`api/src/services/skills.service.ts\`.

## Scope

Docs-only. 5 files, +140/-0. No behavioral changes.