### PR TITLE
fix(chat): restore incremental streaming and stable tool cards

### DIFF
--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -593,9 +593,12 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
 
   const reasoningGroups = computeReasoningGroups(parts);
 
+  const lastPartIndex = parts.length - 1;
   const lastPart = parts.at(-1);
   const isLastPartReasoning =
     isLastMessage && isStreamingNow && lastPart?.type === "reasoning";
+  const isLastPartText =
+    isLastMessage && isStreamingNow && lastPart?.type === "text";
 
   let lastGroupStart = -1;
   for (const [start] of reasoningGroups) {
@@ -626,16 +629,24 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
                       (part.errorText as string | undefined) ?? "Tool failed",
                   }
                 : part.output;
+            const toolCallId = (part.toolCallId as string) || "";
+            // Key by toolCallId when available so reordering/insertion in the
+            // parts array doesn't remount completed tool cards. Falls back to
+            // a type+index tag for the (rare) case where toolCallId is missing.
+            const key = toolCallId
+              ? `tool-${toolCallId}`
+              : `tool-idx-${partIndex}`;
             return (
               <StreamingToolCard
-                key={partIndex}
+                key={key}
+                toolCallId={toolCallId}
                 toolName={toolName}
                 state={cardState}
                 input={part.input}
                 output={cardOutput}
                 onDetailClick={() =>
                   onToolClick({
-                    toolCallId: (part.toolCallId as string) || "",
+                    toolCallId,
                     toolName: toolName || "",
                     state: part.state as ToolInvocationInfo["state"],
                     input: part.input,
@@ -662,8 +673,17 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
           }
 
           if (partType === "text" && (part as { text?: string }).text) {
+            // Only the trailing text block of the actively streaming
+            // message is still growing — flag it so Streamdown knows to
+            // treat its last markdown block as incomplete. All earlier
+            // text blocks are static and can skip animation entirely.
+            const isTrailingStreamingText =
+              isLastPartText && partIndex === lastPartIndex;
             return (
-              <StreamingMarkdown key={partIndex}>
+              <StreamingMarkdown
+                key={`text-${partIndex}`}
+                isStreaming={isTrailingStreamingText}
+              >
                 {(part as { text: string }).text}
               </StreamingMarkdown>
             );

--- a/app/src/components/StreamingMarkdown.tsx
+++ b/app/src/components/StreamingMarkdown.tsx
@@ -1,8 +1,17 @@
 /**
- * StreamingMarkdown - Optimized markdown rendering for AI streaming
+ * StreamingMarkdown — thin wrapper around Streamdown.
  *
- * Uses Vercel's streamdown package with Tailwind CSS for styling.
- * https://streamdown.ai/docs/getting-started
+ * Streamdown's default `mode="streaming"` already:
+ *   • splits content into independent memoized blocks, so only the last
+ *     (still-growing) block re-renders on each chunk;
+ *   • runs `remend` internally to close unbalanced markdown mid-stream
+ *     (`parseIncompleteMarkdown: true` is its default).
+ *
+ * We only forward the streaming hint via `isAnimating` so Streamdown knows
+ * the trailing block is still being filled in. Everything else is owned by
+ * Streamdown.
+ *
+ * See https://streamdown.ai/docs
  */
 import React from "react";
 import { Streamdown, type CodeHighlighterPlugin } from "streamdown";
@@ -10,16 +19,22 @@ import { code } from "@streamdown/code";
 
 interface StreamingMarkdownProps {
   children: string;
+  /**
+   * True when this markdown belongs to a part that is still being streamed
+   * (e.g. the trailing text block of the active assistant message). Forwarded
+   * to Streamdown's `isAnimating` so it treats the last block as incomplete.
+   */
+  isStreaming?: boolean;
 }
 
 export const StreamingMarkdown: React.FC<StreamingMarkdownProps> = React.memo(
-  ({ children }) => {
+  ({ children, isStreaming = false }) => {
     return (
       <Streamdown
-        // streamdown and @streamdown/code currently expose mismatched shiki typings.
         plugins={{ code: code as unknown as CodeHighlighterPlugin }}
         shikiTheme={["github-light", "github-dark"]}
         controls={false}
+        isAnimating={isStreaming}
       >
         {children}
       </Streamdown>

--- a/app/src/components/StreamingToolCard.tsx
+++ b/app/src/components/StreamingToolCard.tsx
@@ -56,6 +56,14 @@ interface StreamingToolCardProps {
   input?: unknown;
   output?: unknown;
   onDetailClick?: () => void;
+  /**
+   * Optional — used as a defensive check in the memo comparator so that
+   * React re-renders if the underlying tool call identity actually changed.
+   * In practice parents also use this as the React key, so unmount/remount
+   * handles identity changes, but comparing here keeps memoization safe if
+   * the key strategy ever regresses.
+   */
+  toolCallId?: string;
 }
 
 const ICON_SIZE = 13;
@@ -211,6 +219,32 @@ const pulseKf = keyframes`
 `;
 
 // ── Component ────────────────────────────────────────────────
+
+// Terminal states: once the tool call reaches one of these, `input` and
+// `output` are immutable. useChat's `experimental_throttle` still hands us
+// fresh cloned `input` / `output` object references on every tick while the
+// active assistant message streams below, but the contents never change —
+// so a reference-equality memo comparator (like we had before) would
+// needlessly re-render every already-completed card ~20×/sec and make them
+// feel unresponsive (scroll jitters, expand toggle lags). Checking state is
+// enough to bail out here because the parent also uses `toolCallId` as the
+// React key, so a truly different tool call would remount and reset memo.
+const TERMINAL_TOOL_STATES = new Set<ToolPartState>([
+  "output-available",
+  "error",
+]);
+
+function toolInputSignature(input: unknown): string {
+  // Only called while the tool is still active (non-terminal state), so the
+  // payload is small (just the fields being streamed into). JSON.stringify
+  // is plenty fast here and gives us stable value equality across clones.
+  try {
+    return JSON.stringify(input ?? null);
+  } catch {
+    // Circular / non-serializable → conservatively force a re-render.
+    return `__unserializable_${Math.random()}`;
+  }
+}
 
 export const StreamingToolCard = React.memo(
   function StreamingToolCard({
@@ -500,9 +534,29 @@ export const StreamingToolCard = React.memo(
       </Box>
     );
   },
-  (prev, next) =>
-    prev.toolName === next.toolName &&
-    prev.state === next.state &&
-    prev.input === next.input &&
-    prev.output === next.output,
+  (prev, next) => {
+    // Defensive: if the logical tool call changed, always re-render. In the
+    // normal case the parent keys by toolCallId so this branch is dead, but
+    // it protects us if the key strategy ever regresses.
+    if (prev.toolCallId !== next.toolCallId) return false;
+    if (prev.toolName !== next.toolName) return false;
+    if (prev.state !== next.state) return false;
+
+    // Terminal states are immutable. Even if useChat handed us new cloned
+    // references for `input` / `output` this tick, the contents are the
+    // same — skip the render.
+    if (TERMINAL_TOOL_STATES.has(next.state)) return true;
+
+    // Non-terminal (input-streaming / input-available / output-streaming):
+    // reference-equality first for the fast path, then fall back to value
+    // equality so growing streamed input fields still trigger re-renders.
+    if (prev.input === next.input && prev.output === next.output) return true;
+    if (toolInputSignature(prev.input) !== toolInputSignature(next.input)) {
+      return false;
+    }
+    if (toolInputSignature(prev.output) !== toolInputSignature(next.output)) {
+      return false;
+    }
+    return true;
+  },
 );

--- a/app/src/components/__tests__/Chat.perf.test.ts
+++ b/app/src/components/__tests__/Chat.perf.test.ts
@@ -3,7 +3,7 @@
  *
  * These tests verify the memoization contracts that keep the Chat panel
  * responsive during AI streaming. If any of these fail, the Chat component
- * will re-render excessively and the UI will become unresponsive.
+ * will re-render excessively AND/OR fail to re-render at all during streaming.
  *
  * See: .cursor/rules/75-chat-performance.mdc
  */
@@ -37,7 +37,6 @@ function makeProps(
 
 describe("React.memo wrappers", () => {
   it("StreamingMarkdown is wrapped in React.memo", () => {
-    // React.memo sets $$typeof to Symbol.for('react.memo')
     expect((StreamingMarkdown as any).$$typeof).toBe(Symbol.for("react.memo"));
   });
 
@@ -47,14 +46,31 @@ describe("React.memo wrappers", () => {
 });
 
 // ── ChatMessageRow comparator ───────────────────────────────
+//
+// Contract: reference equality on `message` (NOT deep content comparison).
+//
+// Why: the AI SDK's first chunk uses `pushMessage`, which stores the RAW
+// mutable message reference in `messages[last]`. Later chunks call
+// `replaceMessage` (structuredClone). React.memo's stored "prev" gets
+// seeded with the RAW reference on the first render, and that reference
+// keeps being mutated in place (`part.text += delta`). A content-based
+// comparator would then see prev and next as identical (both reflect the
+// latest state) and permanently skip rendering until `isStreaming` flips.
+//
+// Reference equality sidesteps the mutation problem: every `replaceMessage`
+// produces a new reference, so the comparator correctly returns false.
+// `experimental_throttle: 50` in useChat batches these updates to ~20/sec.
 
 describe("chatMessageRowArePropsEqual", () => {
-  it("returns true for identical props (reference equal message)", () => {
+  it("returns true when all references are identical", () => {
     const props = makeProps();
     expect(chatMessageRowArePropsEqual(props, props)).toBe(true);
   });
 
-  it("returns true when message parts haven't changed (same content, different reference)", () => {
+  it("returns false when the message reference changes (streaming tick)", () => {
+    // This is THE streaming re-render trigger. On every chunk, useChat
+    // produces a new message reference via structuredClone; without this
+    // re-render, streamed text would never appear until completion.
     const prev = makeProps({
       message: {
         id: "msg-1",
@@ -66,10 +82,10 @@ describe("chatMessageRowArePropsEqual", () => {
       message: {
         id: "msg-1",
         role: "assistant",
-        parts: [{ type: "text", text: "Hello" }],
+        parts: [{ type: "text", text: "Hello" }], // same content, new ref
       },
     });
-    expect(chatMessageRowArePropsEqual(prev, next)).toBe(true);
+    expect(chatMessageRowArePropsEqual(prev, next)).toBe(false);
   });
 
   it("returns false when isLastMessage changes", () => {
@@ -90,237 +106,168 @@ describe("chatMessageRowArePropsEqual", () => {
     expect(chatMessageRowArePropsEqual(prev, next)).toBe(false);
   });
 
-  it("returns false when text length changes (streaming token arrives)", () => {
-    const prev = makeProps({
-      message: {
-        id: "msg-1",
-        role: "assistant",
-        parts: [{ type: "text", text: "Hel" }],
-      },
-    });
-    const next = makeProps({
-      message: {
-        id: "msg-1",
-        role: "assistant",
-        parts: [{ type: "text", text: "Hello" }],
-      },
-    });
-    expect(chatMessageRowArePropsEqual(prev, next)).toBe(false);
-  });
-
-  it("returns false when part count changes (new part added)", () => {
-    const prev = makeProps({
-      message: {
-        id: "msg-1",
-        role: "assistant",
-        parts: [{ type: "text", text: "Hello" }],
-      },
-    });
-    const next = makeProps({
-      message: {
-        id: "msg-1",
-        role: "assistant",
-        parts: [
-          { type: "text", text: "Hello" },
-          { type: "tool-run_console", state: "input-streaming" },
-        ],
-      },
-    });
-    expect(chatMessageRowArePropsEqual(prev, next)).toBe(false);
-  });
-
-  it("returns false when a tool part is input-streaming", () => {
-    const prev = makeProps({
-      message: {
-        id: "msg-1",
-        role: "assistant",
-        parts: [{ type: "tool-run_console", state: "input-streaming" }],
-      },
-    });
-    const next = makeProps({
-      message: {
-        id: "msg-1",
-        role: "assistant",
-        parts: [{ type: "tool-run_console", state: "input-streaming" }],
-      },
-    });
-    expect(chatMessageRowArePropsEqual(prev, next)).toBe(false);
-  });
-
-  it("returns false when a tool part is output-streaming", () => {
-    const prev = makeProps({
-      message: {
-        id: "msg-1",
-        role: "assistant",
-        parts: [{ type: "tool-run_console", state: "output-streaming" }],
-      },
-    });
-    const next = makeProps({
-      message: {
-        id: "msg-1",
-        role: "assistant",
-        parts: [{ type: "tool-run_console", state: "output-streaming" }],
-      },
-    });
-    expect(chatMessageRowArePropsEqual(prev, next)).toBe(false);
-  });
-
-  it("returns true when a tool part state is output-available (settled)", () => {
-    const prev = makeProps({
-      message: {
-        id: "msg-1",
-        role: "assistant",
-        parts: [
-          {
-            type: "tool-run_console",
-            state: "output-available",
-            input: { query: "SELECT 1" },
-            output: { success: true },
-          },
-        ],
-      },
-    });
-    const next = makeProps({
-      message: {
-        id: "msg-1",
-        role: "assistant",
-        parts: [
-          {
-            type: "tool-run_console",
-            state: "output-available",
-            input: { query: "SELECT 1" },
-            output: { success: true },
-          },
-        ],
-      },
-    });
-    expect(chatMessageRowArePropsEqual(prev, next)).toBe(true);
-  });
-
-  it("returns false when tool part state transitions", () => {
-    const prev = makeProps({
-      message: {
-        id: "msg-1",
-        role: "assistant",
-        parts: [{ type: "tool-run_console", state: "input-available" }],
-      },
-    });
-    const next = makeProps({
-      message: {
-        id: "msg-1",
-        role: "assistant",
-        parts: [{ type: "tool-run_console", state: "output-available" }],
-      },
-    });
-    expect(chatMessageRowArePropsEqual(prev, next)).toBe(false);
-  });
-
-  it("returns true when reasoning text length is unchanged", () => {
-    const prev = makeProps({
-      message: {
-        id: "msg-1",
-        role: "assistant",
-        parts: [{ type: "reasoning", text: "Let me think..." }],
-      },
-    });
-    const next = makeProps({
-      message: {
-        id: "msg-1",
-        role: "assistant",
-        parts: [{ type: "reasoning", text: "Let me think..." }],
-      },
-    });
-    expect(chatMessageRowArePropsEqual(prev, next)).toBe(true);
-  });
-
-  it("returns false when reasoning text grows (streaming)", () => {
-    const prev = makeProps({
-      message: {
-        id: "msg-1",
-        role: "assistant",
-        parts: [{ type: "reasoning", text: "Let me" }],
-      },
-    });
-    const next = makeProps({
-      message: {
-        id: "msg-1",
-        role: "assistant",
-        parts: [{ type: "reasoning", text: "Let me think about this..." }],
-      },
-    });
-    expect(chatMessageRowArePropsEqual(prev, next)).toBe(false);
-  });
-
-  it("skips re-render for completed messages when another message streams", () => {
-    // This is the key regression scenario: a completed user message should NOT
-    // re-render when the assistant message below it is streaming.
-    const prev = makeProps({
-      message: {
-        id: "user-1",
-        role: "user",
-        parts: [{ type: "text", text: "What tables exist?" }],
-      },
-      isLastMessage: false,
-      isStreaming: true,
-    });
-    const next = makeProps({
-      message: {
-        id: "user-1",
-        role: "user",
-        parts: [{ type: "text", text: "What tables exist?" }],
-      },
-      isLastMessage: false,
-      isStreaming: true,
-    });
-    expect(chatMessageRowArePropsEqual(prev, next)).toBe(true);
-  });
-
-  it("returns true when onToolClick reference changes (not compared)", () => {
+  it("returns false when onToolClick reference changes", () => {
     const prev = makeProps({ onToolClick: () => {} });
     const next = makeProps({ onToolClick: () => {} });
+    expect(chatMessageRowArePropsEqual(prev, next)).toBe(false);
+  });
+
+  it("skips re-render when a completed user message keeps its ref across streaming ticks", () => {
+    // The AI SDK's replaceMessage only clones messages[last]; earlier
+    // messages retain their references across ticks. So completed messages
+    // (e.g. the user prompt) correctly skip re-rendering while the assistant
+    // streams below them.
+    //
+    // Chat.tsx uses `useCallback` to keep `onToolClick` stable across renders,
+    // which is what makes this skip safe — all other prop references match too.
+    const sharedUserMessage = {
+      id: "user-1",
+      role: "user",
+      parts: [{ type: "text", text: "What tables exist?" }],
+    };
+    const stableOnToolClick = () => {};
+    const prev = makeProps({
+      message: sharedUserMessage,
+      onToolClick: stableOnToolClick,
+      isLastMessage: false,
+      isStreaming: true,
+    });
+    const next = makeProps({
+      message: sharedUserMessage,
+      onToolClick: stableOnToolClick,
+      isLastMessage: false,
+      isStreaming: true,
+    });
     expect(chatMessageRowArePropsEqual(prev, next)).toBe(true);
   });
 
-  it("returns false when text content changes but length stays the same", () => {
-    const prev = makeProps({
-      message: {
-        id: "msg-1",
-        role: "assistant",
-        parts: [{ type: "text", text: "AAAA" }],
-      },
-    });
-    const next = makeProps({
-      message: {
-        id: "msg-1",
-        role: "assistant",
-        parts: [{ type: "text", text: "BBBB" }],
-      },
-    });
-    expect(chatMessageRowArePropsEqual(prev, next)).toBe(false);
-  });
+  it("REGRESSION: returns false even when mutated-in-place content appears equal", () => {
+    // Simulates the AI SDK bug surface: the raw message object is mutated
+    // in-place between chunks (text grows), and the "clone" of that raw
+    // message is compared against it. A content-based comparator would
+    // incorrectly see them as identical because both reflect the latest
+    // mutated state. Reference inequality must trigger re-render regardless.
+    const rawMessage = {
+      id: "msg-1",
+      role: "assistant",
+      parts: [{ type: "text", text: "Hel" }],
+    };
 
-  it("returns false when reasoning content changes but length stays the same", () => {
-    const prev = makeProps({
-      message: {
-        id: "msg-1",
-        role: "assistant",
-        parts: [{ type: "reasoning", text: "Plan A" }],
-      },
-    });
-    const next = makeProps({
-      message: {
-        id: "msg-1",
-        role: "assistant",
-        parts: [{ type: "reasoning", text: "Plan B" }],
-      },
-    });
-    expect(chatMessageRowArePropsEqual(prev, next)).toBe(false);
+    const prevProps = makeProps({ message: rawMessage });
+
+    // First render happened with rawMessage. Now AI SDK mutates it in place:
+    rawMessage.parts[0].text = "Hello world, streaming in progress...";
+
+    // Next render uses a clone of the now-mutated state:
+    const cloneMessage = {
+      id: rawMessage.id,
+      role: rawMessage.role,
+      parts: rawMessage.parts.map(p => ({ ...p })),
+    };
+    const nextProps = makeProps({ message: cloneMessage });
+
+    // Content is identical. Reference is different. Must re-render.
+    expect(chatMessageRowArePropsEqual(prevProps, nextProps)).toBe(false);
   });
 });
 
 // ── Structural regression guards ─────────────────────────────
 // These tests read the Chat.tsx source and verify critical patterns
 // are present, catching regressions that slip past runtime tests.
+
+// ── StreamingToolCard comparator ────────────────────────────
+//
+// Contract: value-based comparison so completed (terminal-state) tool
+// cards skip re-render when useChat's `replaceMessage` hands us fresh
+// `structuredClone`d `input` / `output` references every tick while text
+// streams below them. A previous reference-equality comparator caused
+// completed tool cards to feel unresponsive (~20 re-renders/sec during a
+// streaming text reply).
+
+describe("StreamingToolCard memo comparator", () => {
+  // React.memo stores the custom comparator on `.compare`.
+  const compare = (StreamingToolCard as any).compare as (
+    prev: Record<string, unknown>,
+    next: Record<string, unknown>,
+  ) => boolean;
+
+  function baseProps(over: Record<string, unknown> = {}) {
+    return {
+      toolCallId: "tool-1",
+      toolName: "run_console",
+      state: "output-available",
+      input: { query: "SELECT 1" },
+      output: { success: true, rowCount: 1 },
+      onDetailClick: () => {},
+      ...over,
+    };
+  }
+
+  it("exposes a custom comparator (React.memo with areEqual)", () => {
+    expect(typeof compare).toBe("function");
+  });
+
+  it("skips re-render when a completed tool card's input/output refs churn", () => {
+    // useChat clones the message every tick → input / output get new refs
+    // even though their contents are immutable for terminal states.
+    const prev = baseProps();
+    const next = baseProps({
+      input: { query: "SELECT 1" }, // same content, new ref
+      output: { success: true, rowCount: 1 }, // same content, new ref
+    });
+    expect(compare(prev, next)).toBe(true);
+  });
+
+  it("re-renders when an active input-streaming tool's streamed field grows", () => {
+    const prev = baseProps({
+      state: "input-streaming",
+      input: { query: "SELECT" },
+      output: undefined,
+    });
+    const next = baseProps({
+      state: "input-streaming",
+      input: { query: "SELECT 1" },
+      output: undefined,
+    });
+    expect(compare(prev, next)).toBe(false);
+  });
+
+  it("re-renders when state transitions (e.g. input-streaming → output-available)", () => {
+    const prev = baseProps({
+      state: "input-streaming",
+      input: { query: "SELECT 1" },
+      output: undefined,
+    });
+    const next = baseProps({
+      state: "output-available",
+      input: { query: "SELECT 1" },
+      output: { success: true, rowCount: 1 },
+    });
+    expect(compare(prev, next)).toBe(false);
+  });
+
+  it("re-renders when toolCallId changes (defensive — keys normally catch this)", () => {
+    const prev = baseProps({ toolCallId: "tool-1" });
+    const next = baseProps({ toolCallId: "tool-2" });
+    expect(compare(prev, next)).toBe(false);
+  });
+
+  it("skips re-render when input and output references are identical", () => {
+    const sharedInput = { query: "SELECT 1" };
+    const sharedOutput = { success: true, rowCount: 1 };
+    const prev = baseProps({
+      state: "input-available",
+      input: sharedInput,
+      output: sharedOutput,
+    });
+    const next = baseProps({
+      state: "input-available",
+      input: sharedInput,
+      output: sharedOutput,
+    });
+    expect(compare(prev, next)).toBe(true);
+  });
+});
 
 describe("Chat.tsx structural guards", () => {
   const chatSource = fs.readFileSync(
@@ -329,6 +276,8 @@ describe("Chat.tsx structural guards", () => {
   );
 
   it("useChat has experimental_throttle configured", () => {
+    // Without a throttle, reference-equality re-renders would fire on every
+    // SSE chunk (~30/s) and make the UI unresponsive.
     expect(chatSource).toMatch(/experimental_throttle\s*:\s*\d+/);
   });
 
@@ -337,7 +286,6 @@ describe("Chat.tsx structural guards", () => {
   });
 
   it("does NOT have a DIY useEffect([messages]) auto-scroll", () => {
-    // The old pattern: useEffect depending on messages that calls scrollIntoView
     const diyScrollPattern =
       /useEffect\(\s*\(\)\s*=>\s*\{[^}]*scrollIntoView[^}]*\}\s*,\s*\[messages\]\)/s;
     expect(chatSource).not.toMatch(diyScrollPattern);
@@ -349,5 +297,36 @@ describe("Chat.tsx structural guards", () => {
 
   it("does NOT have rafIdRef (old DIY scroll coalescing)", () => {
     expect(chatSource).not.toContain("rafIdRef");
+  });
+
+  it("keys tool parts by toolCallId so completed cards don't remount", () => {
+    // Remounting a finished tool card on every parts-array mutation drops
+    // its internal expand/scroll state and causes a flicker. Keying by
+    // toolCallId keeps identity stable across reorders/inserts.
+    expect(chatSource).toMatch(/key=\{\s*key\s*\}/);
+    expect(chatSource).toMatch(/`tool-\$\{toolCallId\}`/);
+  });
+});
+
+describe("StreamingMarkdown structural guards", () => {
+  const sdSource = fs.readFileSync(
+    path.resolve(__dirname, "../StreamingMarkdown.tsx"),
+    "utf-8",
+  );
+
+  it('does NOT force mode="static" on Streamdown', () => {
+    // Streamdown's default mode is "streaming", which already splits content
+    // into memoized blocks so only the last (growing) block re-renders per
+    // chunk. Forcing static duplicates that work and defeats per-block memo.
+    expect(sdSource).not.toMatch(/mode\s*=\s*["']static["']/);
+  });
+
+  it("does NOT import remend directly (Streamdown handles it internally)", () => {
+    expect(sdSource).not.toMatch(/from\s+["']remend["']/);
+  });
+
+  it("forwards isAnimating to Streamdown", () => {
+    // Lets Streamdown treat the trailing block as incomplete while streaming.
+    expect(sdSource).toMatch(/isAnimating=\{isStreaming\}/);
   });
 });

--- a/app/src/components/chat-message-comparator.ts
+++ b/app/src/components/chat-message-comparator.ts
@@ -21,12 +21,27 @@ export interface ChatMessageRowProps {
 /**
  * Determines whether a ChatMessageRow can skip re-rendering.
  *
- * Returns `true` (skip render) only when:
- * - `isLastMessage` and `isStreaming` are unchanged, AND
- * - the message reference is identical, OR every part matches by
- *   type, state, and — for text/reasoning parts — exact string content.
+ * Returns `true` (skip render) only when every prop reference is identical.
  *
- * Streaming parts (`input-streaming`, `output-streaming`) always re-render.
+ * ⚠️  Why reference equality and NOT deep content comparison:
+ *
+ * The AI SDK's first streaming chunk uses `pushMessage`, which stores the
+ * RAW mutable message reference in `messages[last]`. Later chunks call
+ * `replaceMessage`, which does `structuredClone(message)` — producing a
+ * fresh clone each time. But React.memo's "prev props" are seeded on the
+ * FIRST render (with the RAW reference). Subsequent deltas keep mutating
+ * that raw object in place (`part.text += chunk.delta`).
+ *
+ * A content-based comparator would see `prev.message` (RAW, mutated to
+ * the current state) and `next.message` (latest clone, also current state)
+ * as equal and permanently skip rendering — so text only "appears" when
+ * isStreaming flips to false at the end.
+ * See `node_modules/@ai-sdk/react/dist/index.mjs` — `ReactChatState.pushMessage`.
+ *
+ * Reference equality sidesteps this entirely: `structuredClone` produces a
+ * new reference on every chunk, so the comparator correctly schedules a
+ * re-render. We rely on `experimental_throttle` in `useChat` to batch these
+ * into ~20 renders/sec, keeping scroll and hover responsive.
  */
 export function chatMessageRowArePropsEqual(
   prev: ChatMessageRowProps,
@@ -35,26 +50,6 @@ export function chatMessageRowArePropsEqual(
   if (prev.paletteMode !== next.paletteMode) return false;
   if (prev.isLastMessage !== next.isLastMessage) return false;
   if (prev.isStreaming !== next.isStreaming) return false;
-  if (prev.message === next.message) return true;
-
-  const prevParts = prev.message.parts || [];
-  const nextParts = next.message.parts || [];
-  if (prevParts.length !== nextParts.length) return false;
-
-  for (let i = 0; i < nextParts.length; i++) {
-    const pp = prevParts[i];
-    const np = nextParts[i];
-    if (pp.type !== np.type) return false;
-    if (pp.state !== np.state) return false;
-    if (np.state === "input-streaming" || np.state === "output-streaming") {
-      return false;
-    }
-    if (pp.type === "text" || pp.type === "reasoning") {
-      if ((pp as { text?: string }).text !== (np as { text?: string }).text) {
-        return false;
-      }
-    }
-  }
-
-  return true;
+  if (prev.onToolClick !== next.onToolClick) return false;
+  return prev.message === next.message;
 }


### PR DESCRIPTION
## Summary

Two streaming bugs were making the chat panel miserable to use:

1. **Text arrived all at once at the end.** `chatMessageRowArePropsEqual` compared messages by content, but `useChat` mutates the raw message object in place between chunks and later hands React.memo a `structuredClone` of that mutated state — so content comparison saw prev and next as equal and permanently skipped re-renders until `isStreaming` flipped to `false`. Switched to reference equality; `structuredClone` produces a fresh reference every tick, so re-renders fire, batched by `experimental_throttle: 50`.

2. **Completed tool cards became unresponsive while text streamed below them.** `StreamingToolCard`'s memo compared `input`/`output` by reference, but `useChat`'s clone gives every part in the active assistant message a new object identity every ~50ms — so finished tool cards re-rendered ~20×/sec, making clicks/hovers/expand toggles feel laggy. Made the comparator value-aware: terminal states (`output-available`, `error`) short-circuit to equal because their content is immutable, and non-terminal states fall back to a JSON signature so streamed input fields still trigger re-renders as they grow.

Also:

- Restored Streamdown's native `mode=\"streaming\"` in `StreamingMarkdown` (the prior `mode=\"static\"` + manual `remend` workaround was duplicating Streamdown's own logic and defeating its per-block memoization).
- Forwarded `isAnimating` only for the trailing text part of the actively streaming message, so earlier completed text blocks don't animate on re-render.
- Keyed tool parts by `toolCallId` instead of `partIndex` so reorders/insertions don't remount completed cards and drop their expand/scroll state.

## Key memoization boundaries after this change

| Layer | Comparator | Why |
|---|---|---|
| `ChatMessageRow` | reference equality on `message` | Clone identity drives re-renders; anything content-based deadlocks on the mutate-then-clone pattern |
| `StreamingToolCard` | value-aware: terminal short-circuit + JSON signature | Immutable once terminal; otherwise compares growth of streamed input |
| `StreamingMarkdown` | shallow compare on string primitive | Streamdown owns block-level memo and `remend` internally |
| `ReasoningDisplay` | shallow compare on primitives | Already correct — reasoning text / flags are primitives |

## Test plan

- [x] `pnpm --filter app exec vitest run src/components/__tests__/Chat.perf.test.ts` — 25/25 passing (added 6 new comparator tests + 4 structural guards for `StreamingMarkdown` / tool key strategy)
- [x] `pnpm --filter app exec tsc --noEmit` — clean
- [ ] Manually verify in the browser: streaming text appears incrementally (not all-at-once)
- [ ] Manually verify in the browser: completed tool cards above the streaming text remain clickable / expandable / hover-responsive while streaming
- [ ] Manually verify long AI responses with multiple tool calls scroll smoothly
- [ ] Manually verify reasoning blocks still auto-collapse after streaming ends

Made with [Cursor](https://cursor.com)