### PR TITLE
feat: add console-based scheduled queries

### DIFF
--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -389,6 +389,21 @@ export interface ISavedConsole extends Document {
   isSaved: boolean; // true = explicitly saved, false/undefined = draft
   access: ConsoleAccessLevel;
   owner_id: string;
+  schedule?: {
+    cron: string;
+    timezone: string;
+  };
+  scheduledRun?: {
+    nextAt?: Date;
+    lastAt?: Date;
+    lastStatus?: "success" | "error";
+    lastError?: string;
+    lastDurationMs?: number;
+    lastRowsAffected?: number;
+    lastRowCount?: number;
+    runCount: number;
+    consecutiveFailures: number;
+  };
   version: number;
   is_deleted?: boolean;
   deletedAt?: Date;
@@ -396,6 +411,26 @@ export interface ISavedConsole extends Document {
   updatedAt: Date;
   lastExecutedAt?: Date;
   executionCount: number;
+}
+
+export interface IScheduledQueryRun extends Document {
+  _id: Types.ObjectId;
+  workspaceId: Types.ObjectId;
+  consoleId: Types.ObjectId;
+  triggeredAt: Date;
+  startedAt?: Date;
+  completedAt?: Date;
+  status: "queued" | "running" | "success" | "error";
+  triggerType: "schedule" | "manual";
+  triggeredBy?: string;
+  durationMs?: number;
+  rowsAffected?: number;
+  rowCount?: number;
+  error?: {
+    message: string;
+    code?: string;
+  };
+  inngestRunId?: string;
 }
 
 /**
@@ -845,7 +880,7 @@ export interface IQueryExecution extends Document {
   consoleId?: Types.ObjectId; // If executed from a saved console
 
   // Execution context
-  source: "console_ui" | "api" | "agent" | "flow";
+  source: "console_ui" | "api" | "agent" | "flow" | "scheduled_query";
   databaseType: string; // postgresql, mongodb, bigquery, etc.
   queryLanguage: "sql" | "mongodb" | "javascript";
 
@@ -1361,6 +1396,48 @@ const SavedConsoleSchema = new Schema<ISavedConsole>(
       type: String,
       ref: "User",
     },
+    schedule: {
+      cron: {
+        type: String,
+        trim: true,
+      },
+      timezone: {
+        type: String,
+        trim: true,
+      },
+    },
+    scheduledRun: {
+      nextAt: {
+        type: Date,
+      },
+      lastAt: {
+        type: Date,
+      },
+      lastStatus: {
+        type: String,
+        enum: ["success", "error"],
+      },
+      lastError: {
+        type: String,
+      },
+      lastDurationMs: {
+        type: Number,
+      },
+      lastRowsAffected: {
+        type: Number,
+      },
+      lastRowCount: {
+        type: Number,
+      },
+      runCount: {
+        type: Number,
+        default: 0,
+      },
+      consecutiveFailures: {
+        type: Number,
+        default: 0,
+      },
+    },
     lastExecutedAt: {
       type: Date,
     },
@@ -1391,6 +1468,10 @@ SavedConsoleSchema.index({ workspaceId: 1, createdBy: 1, isPrivate: 1 });
 SavedConsoleSchema.index({ workspaceId: 1, isSaved: 1 }); // For filtering saved vs draft consoles
 SavedConsoleSchema.index({ connectionId: 1 }, { sparse: true }); // Sparse index since connectionId is optional
 SavedConsoleSchema.index({ workspaceId: 1, access: 1, owner_id: 1 }); // Console access model queries
+SavedConsoleSchema.index(
+  { workspaceId: 1, "scheduledRun.nextAt": 1 },
+  { sparse: true },
+);
 SavedConsoleSchema.index(
   { name: "text", description: "text" },
   { name: "console_text_search" },
@@ -2199,7 +2280,7 @@ const QueryExecutionSchema = new Schema<IQueryExecution>(
     // Execution context
     source: {
       type: String,
-      enum: ["console_ui", "api", "agent", "flow"],
+      enum: ["console_ui", "api", "agent", "flow", "scheduled_query"],
       required: true,
     },
     databaseType: { type: String, required: true },
@@ -2234,6 +2315,80 @@ QueryExecutionSchema.index({ userId: 1, executedAt: -1 }); // Per-user analytics
 QueryExecutionSchema.index({ apiKeyId: 1, executedAt: -1 }, { sparse: true }); // API key usage
 QueryExecutionSchema.index({ workspaceId: 1, status: 1 }); // Error rate monitoring
 QueryExecutionSchema.index({ executedAt: 1 }, { expireAfterSeconds: 7776000 }); // TTL: 90 days
+
+const ScheduledQueryRunSchema = new Schema<IScheduledQueryRun>(
+  {
+    workspaceId: {
+      type: Schema.Types.ObjectId,
+      ref: "Workspace",
+      required: true,
+    },
+    consoleId: {
+      type: Schema.Types.ObjectId,
+      ref: "SavedConsole",
+      required: true,
+    },
+    triggeredAt: {
+      type: Date,
+      required: true,
+      default: Date.now,
+    },
+    startedAt: {
+      type: Date,
+    },
+    completedAt: {
+      type: Date,
+    },
+    status: {
+      type: String,
+      enum: ["queued", "running", "success", "error"],
+      required: true,
+    },
+    triggerType: {
+      type: String,
+      enum: ["schedule", "manual"],
+      required: true,
+    },
+    triggeredBy: {
+      type: String,
+      ref: "User",
+    },
+    durationMs: {
+      type: Number,
+    },
+    rowsAffected: {
+      type: Number,
+    },
+    rowCount: {
+      type: Number,
+    },
+    error: {
+      message: {
+        type: String,
+      },
+      code: {
+        type: String,
+      },
+    },
+    inngestRunId: {
+      type: String,
+    },
+  },
+  {
+    collection: "scheduled_query_runs",
+    timestamps: false,
+  },
+);
+
+ScheduledQueryRunSchema.index({
+  workspaceId: 1,
+  consoleId: 1,
+  triggeredAt: -1,
+});
+ScheduledQueryRunSchema.index(
+  { completedAt: 1 },
+  { sparse: true, expireAfterSeconds: 7776000 },
+);
 
 export interface IMaterializationRun extends Document {
   workspaceId: Types.ObjectId;
@@ -2975,6 +3130,10 @@ export const BigQueryCdcState = CdcEntityState;
 export const QueryExecution = mongoose.model<IQueryExecution>(
   "QueryExecution",
   QueryExecutionSchema,
+);
+export const ScheduledQueryRun = mongoose.model<IScheduledQueryRun>(
+  "ScheduledQueryRun",
+  ScheduledQueryRunSchema,
 );
 export const MaterializationRun = mongoose.model<IMaterializationRun>(
   "MaterializationRun",

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -41,6 +41,7 @@ import { billingRoutes } from "./routes/billing";
 import { stripeWebhookRoutes } from "./routes/stripe-webhook";
 import { dashboardRoutes } from "./routes/dashboards";
 import { dashboardMaterializationRoutes } from "./routes/dashboard-materialization";
+import { scheduledQueryRoutes } from "./routes/scheduled-queries";
 import { webhookRoutes } from "./routes/webhooks";
 import { getFunctions, inngest, logInngestStatus } from "./inngest";
 import mongoose from "mongoose";
@@ -119,6 +120,10 @@ app.route("/api/workspaces/:workspaceId/skills", skillsRoutes);
 // Connectors routes
 app.route("/api/workspaces/:workspaceId/connectors", dataSourceRoutes);
 app.route("/api/workspaces/:workspaceId/flows", flowRoutes);
+app.route(
+  "/api/workspaces/:workspaceId/scheduled-queries",
+  scheduledQueryRoutes,
+);
 app.route("/api/workspaces/:workspaceId/usage", usageRoutes);
 app.route("/api/workspaces/:workspaceId/billing", billingRoutes);
 app.route("/api/workspaces/:workspaceId/dashboards", dashboardRoutes);

--- a/api/src/inngest/functions/scheduled-query.ts
+++ b/api/src/inngest/functions/scheduled-query.ts
@@ -1,0 +1,316 @@
+import { Types } from "mongoose";
+import { inngest } from "../client";
+import {
+  DatabaseConnection,
+  type IDatabaseConnection,
+  type ISavedConsole,
+  SavedConsole,
+  ScheduledQueryRun,
+} from "../../database/workspace-schema";
+import { databaseConnectionService } from "../../services/database-connection.service";
+import { queryExecutionService } from "../../services/query-execution.service";
+import { loggers } from "../../logging";
+import { getNextScheduledConsoleRunAt } from "../../services/scheduled-query-schedule.service";
+
+const logger = loggers.inngest();
+
+function mapConsoleLanguageToQueryLanguage(
+  language: "sql" | "javascript" | "mongodb",
+): "sql" | "javascript" | "mongodb" {
+  if (language === "mongodb") return "mongodb";
+  if (language === "javascript") return "javascript";
+  return "sql";
+}
+
+export const scheduledQuerySchedulerFunction = inngest.createFunction(
+  {
+    id: "scheduled-query-scheduler",
+    name: "Run Scheduled Queries",
+  },
+  { cron: "*/1 * * * *" },
+  async ({ step }) => {
+    const now = new Date();
+
+    const dueConsoles = await step.run(
+      "fetch-due-scheduled-queries",
+      async () => {
+        const consoles = await SavedConsole.find({
+          "schedule.cron": { $exists: true, $ne: "" },
+          "scheduledRun.nextAt": { $lte: now },
+          isSaved: true,
+          $or: [
+            { is_deleted: { $ne: true } },
+            { is_deleted: { $exists: false } },
+          ],
+        })
+          .select("_id workspaceId schedule scheduledRun")
+          .lean();
+
+        return consoles.map(consoleDoc => ({
+          id: consoleDoc._id.toString(),
+          workspaceId: consoleDoc.workspaceId.toString(),
+          nextAt: consoleDoc.scheduledRun?.nextAt ?? null,
+          schedule: consoleDoc.schedule,
+        }));
+      },
+    );
+
+    for (const consoleDoc of dueConsoles) {
+      if (!consoleDoc.schedule?.cron || !consoleDoc.schedule?.timezone)
+        continue;
+
+      const nextAt = getNextScheduledConsoleRunAt(consoleDoc.schedule, now);
+      const updateResult = await step.run(
+        `claim-${consoleDoc.id}-${consoleDoc.nextAt?.toString() ?? "none"}`,
+        async () =>
+          SavedConsole.updateOne(
+            {
+              _id: new Types.ObjectId(consoleDoc.id),
+              "scheduledRun.nextAt": consoleDoc.nextAt,
+            },
+            {
+              $set: {
+                "scheduledRun.nextAt": nextAt,
+              },
+            },
+          ),
+      );
+
+      if (updateResult.modifiedCount === 0) {
+        continue;
+      }
+
+      await inngest.send({
+        name: "scheduled_query/execute",
+        data: {
+          workspaceId: consoleDoc.workspaceId,
+          consoleId: consoleDoc.id,
+          triggerType: "schedule",
+        },
+      });
+    }
+
+    return { checked: dueConsoles.length };
+  },
+);
+
+export const scheduledQueryExecutorFunction = inngest.createFunction(
+  {
+    id: "scheduled-query-executor",
+    name: "Execute Scheduled Query",
+    concurrency: {
+      key: "event.data.consoleId",
+      limit: 1,
+    },
+  },
+  { event: "scheduled_query/execute" },
+  async ({ event, step }) => {
+    const workspaceId = String(event.data.workspaceId);
+    const consoleId = String(event.data.consoleId);
+    const triggerType =
+      event.data.triggerType === "manual" ? "manual" : "schedule";
+    const triggeredBy =
+      typeof event.data.triggeredBy === "string"
+        ? event.data.triggeredBy
+        : undefined;
+
+    const run = await step.run("create-run", async () => {
+      const created = await ScheduledQueryRun.create({
+        workspaceId: new Types.ObjectId(workspaceId),
+        consoleId: new Types.ObjectId(consoleId),
+        triggeredAt: new Date(),
+        status: "queued",
+        triggerType,
+        triggeredBy,
+        inngestRunId: event.id,
+      });
+
+      return { id: created._id.toString() };
+    });
+
+    const startedAt = new Date();
+    let isFinalized = false;
+    await step.run("mark-running", async () => {
+      await ScheduledQueryRun.updateOne(
+        { _id: new Types.ObjectId(run.id) },
+        { $set: { status: "running", startedAt } },
+      );
+    });
+
+    try {
+      const consoleDoc = (await step.run("load-console", async () => {
+        const savedConsole = (await SavedConsole.findOne({
+          _id: new Types.ObjectId(consoleId),
+          workspaceId: new Types.ObjectId(workspaceId),
+        }).lean()) as ISavedConsole | null;
+
+        if (!savedConsole) {
+          throw new Error("Scheduled console not found");
+        }
+
+        const connection = savedConsole.connectionId
+          ? ((await DatabaseConnection.findById(
+              savedConsole.connectionId,
+            ).lean()) as IDatabaseConnection | null)
+          : null;
+
+        if (!connection) {
+          throw new Error("Scheduled console has no database connection");
+        }
+
+        return {
+          savedConsole,
+          connection,
+        };
+      })) as {
+        savedConsole: ISavedConsole;
+        connection: IDatabaseConnection;
+      };
+
+      const executionStartedAt = Date.now();
+      const result = await step.run("execute-query", async () =>
+        databaseConnectionService.executeQuery(
+          consoleDoc.connection,
+          consoleDoc.savedConsole.code,
+          {
+            databaseId: consoleDoc.savedConsole.databaseId,
+            databaseName: consoleDoc.savedConsole.databaseName,
+          },
+        ),
+      );
+
+      const completedAt = new Date();
+      const durationMs = Date.now() - executionStartedAt;
+      const rowCount =
+        result.rowCount ??
+        (Array.isArray(result.data) ? result.data.length : undefined);
+      const status = result.success ? "success" : "error";
+      const errorMessage = result.success
+        ? undefined
+        : result.error || "Unknown error";
+
+      await step.run("finalize-run", async () => {
+        await ScheduledQueryRun.updateOne(
+          { _id: new Types.ObjectId(run.id) },
+          {
+            $set: {
+              status,
+              completedAt,
+              durationMs,
+              rowCount,
+              error: errorMessage ? { message: errorMessage } : undefined,
+            },
+          },
+        );
+
+        const nextAt =
+          consoleDoc.savedConsole.schedule?.cron &&
+          consoleDoc.savedConsole.schedule?.timezone
+            ? getNextScheduledConsoleRunAt(
+                {
+                  cron: consoleDoc.savedConsole.schedule.cron,
+                  timezone: consoleDoc.savedConsole.schedule.timezone,
+                },
+                completedAt,
+              )
+            : undefined;
+
+        await SavedConsole.updateOne(
+          { _id: new Types.ObjectId(consoleId) },
+          {
+            $set: {
+              "scheduledRun.lastAt": completedAt,
+              "scheduledRun.lastStatus": status,
+              "scheduledRun.lastError": errorMessage,
+              "scheduledRun.lastDurationMs": durationMs,
+              "scheduledRun.lastRowCount": rowCount,
+              ...(nextAt ? { "scheduledRun.nextAt": nextAt } : {}),
+            },
+            $inc: {
+              "scheduledRun.runCount": 1,
+              "scheduledRun.consecutiveFailures": status === "error" ? 1 : 0,
+            },
+          },
+        );
+
+        if (status === "success") {
+          await SavedConsole.updateOne(
+            { _id: new Types.ObjectId(consoleId) },
+            { $set: { "scheduledRun.consecutiveFailures": 0 } },
+          );
+        }
+      });
+      isFinalized = true;
+
+      queryExecutionService.track({
+        userId: triggeredBy || consoleDoc.savedConsole.createdBy,
+        workspaceId: consoleDoc.savedConsole.workspaceId,
+        connectionId: consoleDoc.connection._id,
+        databaseName:
+          consoleDoc.savedConsole.databaseName ||
+          consoleDoc.connection.connection.database,
+        consoleId: consoleDoc.savedConsole._id,
+        source: "scheduled_query",
+        databaseType: consoleDoc.connection.type,
+        queryLanguage: mapConsoleLanguageToQueryLanguage(
+          consoleDoc.savedConsole.language,
+        ),
+        status: status === "error" ? "error" : "success",
+        executionTimeMs: durationMs,
+        rowCount,
+        errorType: status === "error" ? "unknown" : undefined,
+      });
+
+      if (!result.success) {
+        logger.error("Scheduled query execution failed", {
+          consoleId,
+          workspaceId,
+          error: result.error,
+        });
+        throw new Error(result.error || "Scheduled query execution failed");
+      }
+
+      return {
+        runId: run.id,
+        consoleId,
+        workspaceId,
+        rowCount,
+        durationMs,
+      };
+    } catch (error) {
+      if (isFinalized) {
+        throw error;
+      }
+      await step.run("finalize-run-error", async () => {
+        const completedAt = new Date();
+        const message =
+          error instanceof Error ? error.message : "Scheduled query failed";
+        await ScheduledQueryRun.updateOne(
+          { _id: new Types.ObjectId(run.id) },
+          {
+            $set: {
+              status: "error",
+              completedAt,
+              error: { message },
+            },
+          },
+        );
+        await SavedConsole.updateOne(
+          { _id: new Types.ObjectId(consoleId) },
+          {
+            $set: {
+              "scheduledRun.lastAt": completedAt,
+              "scheduledRun.lastStatus": "error",
+              "scheduledRun.lastError": message,
+            },
+            $inc: {
+              "scheduledRun.runCount": 1,
+              "scheduledRun.consecutiveFailures": 1,
+            },
+          },
+        );
+      });
+      throw error;
+    }
+  },
+);

--- a/api/src/inngest/functions/scheduled-query.ts
+++ b/api/src/inngest/functions/scheduled-query.ts
@@ -56,8 +56,9 @@ export const scheduledQuerySchedulerFunction = inngest.createFunction(
     );
 
     for (const consoleDoc of dueConsoles) {
-      if (!consoleDoc.schedule?.cron || !consoleDoc.schedule?.timezone)
+      if (!consoleDoc.schedule?.cron || !consoleDoc.schedule?.timezone) {
         continue;
+      }
 
       const nextAt = getNextScheduledConsoleRunAt(consoleDoc.schedule, now);
       const updateResult = await step.run(

--- a/api/src/inngest/index.ts
+++ b/api/src/inngest/index.ts
@@ -21,6 +21,10 @@ import {
 import { syncBackfillEntityFunction } from "./functions/sync-entity";
 import { usageReportingFunction } from "./functions/usage-reporting";
 import { modelCatalogRefreshFunction } from "./functions/model-catalog-refresh";
+import {
+  scheduledQueryExecutorFunction,
+  scheduledQuerySchedulerFunction,
+} from "./functions/scheduled-query";
 import { loggers } from "../logging";
 
 const baseFunctions = [
@@ -33,6 +37,7 @@ const baseFunctions = [
   cleanupAbandonedMaterializationRunsFunction,
   usageReportingFunction,
   modelCatalogRefreshFunction,
+  scheduledQueryExecutorFunction,
 ];
 
 const allWebhookFunctions = [
@@ -67,6 +72,7 @@ export function getFunctions() {
         ...webhookFunctions,
         flowSchedulerFunction,
         dashboardSchedulerFunction,
+        scheduledQuerySchedulerFunction,
       ];
 
   return _functions;
@@ -114,4 +120,6 @@ export {
   cleanupAbandonedMaterializationRunsFunction,
   usageReportingFunction,
   modelCatalogRefreshFunction,
+  scheduledQueryExecutorFunction,
+  scheduledQuerySchedulerFunction,
 };

--- a/api/src/middleware/workspace-admin.middleware.ts
+++ b/api/src/middleware/workspace-admin.middleware.ts
@@ -1,0 +1,27 @@
+import { Next } from "hono";
+import { workspaceService } from "../services/workspace.service";
+import { AuthenticatedContext } from "./workspace.middleware";
+
+export async function requireWorkspaceAdmin(
+  c: AuthenticatedContext,
+  next: Next,
+) {
+  const workspaceId = c.req.param("workspaceId");
+  const user = c.get("user");
+
+  if (!workspaceId || !user?.id) {
+    return c.json({ success: false, error: "Unauthorized" }, 401);
+  }
+
+  const member = await workspaceService.getMember(workspaceId, user.id);
+  const isAdmin = member?.role === "owner" || member?.role === "admin";
+
+  if (!isAdmin) {
+    return c.json(
+      { success: false, error: "Admin access required for scheduled queries" },
+      403,
+    );
+  }
+
+  await next();
+}

--- a/api/src/migrations/2026-04-22-120000_create_scheduled_query_runs.ts
+++ b/api/src/migrations/2026-04-22-120000_create_scheduled_query_runs.ts
@@ -1,0 +1,67 @@
+import { Db } from "mongodb";
+import { loggers } from "../logging";
+
+const log = loggers.migration();
+
+export const description =
+  "Create scheduled_query_runs collection and indexes for scheduled console execution history";
+
+function hasIndexOnKeys(
+  indexes: { key: Record<string, number> }[],
+  keyPattern: Record<string, number>,
+): boolean {
+  const target = JSON.stringify(keyPattern);
+  return indexes.some(idx => JSON.stringify(idx.key) === target);
+}
+
+export async function up(db: Db): Promise<void> {
+  const collections = await db.listCollections().toArray();
+  const collectionNames = collections.map(collection => collection.name);
+
+  if (!collectionNames.includes("scheduled_query_runs")) {
+    await db.createCollection("scheduled_query_runs");
+    log.info("Created scheduled_query_runs collection");
+  }
+
+  const scheduledRuns = db.collection("scheduled_query_runs");
+  const scheduledRunIndexes = await scheduledRuns.listIndexes().toArray();
+
+  if (
+    !hasIndexOnKeys(scheduledRunIndexes, {
+      workspaceId: 1,
+      consoleId: 1,
+      triggeredAt: -1,
+    })
+  ) {
+    await scheduledRuns.createIndex(
+      { workspaceId: 1, consoleId: 1, triggeredAt: -1 },
+      { name: "workspace_console_triggered_at_idx" },
+    );
+  }
+
+  if (!hasIndexOnKeys(scheduledRunIndexes, { completedAt: 1 })) {
+    await scheduledRuns.createIndex(
+      { completedAt: 1 },
+      { name: "completed_at_ttl_idx", expireAfterSeconds: 7776000 },
+    );
+  }
+
+  if (!collectionNames.includes("savedconsoles")) {
+    return;
+  }
+
+  const savedConsoles = db.collection("savedconsoles");
+  const savedConsoleIndexes = await savedConsoles.listIndexes().toArray();
+
+  if (
+    !hasIndexOnKeys(savedConsoleIndexes, {
+      workspaceId: 1,
+      "scheduledRun.nextAt": 1,
+    })
+  ) {
+    await savedConsoles.createIndex(
+      { workspaceId: 1, "scheduledRun.nextAt": 1 },
+      { name: "workspace_scheduled_next_at_idx", sparse: true },
+    );
+  }
+}

--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -11,6 +11,7 @@ import {
   IDatabaseConnection,
   EntityVersion,
   type ISavedConsole,
+  ScheduledQueryRun,
 } from "../database/workspace-schema";
 import { User } from "../database/schema";
 import { workspaceService } from "../services/workspace.service";
@@ -39,6 +40,12 @@ import {
   getVersion,
   getUserDisplayName,
 } from "../services/entity-version.service";
+import { inngest } from "../inngest";
+import { requireWorkspaceAdmin } from "../middleware/workspace-admin.middleware";
+import {
+  getNextScheduledConsoleRunAt,
+  validateScheduledConsoleSchedule,
+} from "../services/scheduled-query-schedule.service";
 
 /**
  * Map console language to query language for tracking
@@ -149,6 +156,9 @@ async function verifyWorkspaceAccess(
 
   return null;
 }
+
+consoleRoutes.use("/:id/schedule", requireWorkspaceAdmin);
+consoleRoutes.use("/:id/schedule/*", requireWorkspaceAdmin);
 
 // GET /api/workspaces/:workspaceId/consoles - List all consoles (tree structure) for workspace
 consoleRoutes.get("/", async (c: Context) => {
@@ -274,6 +284,8 @@ consoleRoutes.get("/content", async (c: Context) => {
       owner_id: ownerId,
       ownerDisplayName,
       readOnly,
+      schedule: fullConsole?.schedule,
+      scheduledRun: fullConsole?.scheduledRun,
     });
   } catch (error) {
     logger.error("Error fetching console content", {
@@ -286,6 +298,213 @@ consoleRoutes.get("/content", async (c: Context) => {
         error: error instanceof Error ? error.message : "Console not found",
       },
       404,
+    );
+  }
+});
+
+consoleRoutes.put("/:id/schedule", async (c: AuthenticatedContext) => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const consoleId = c.req.param("id");
+    const body = await c.req.json();
+
+    if (!Types.ObjectId.isValid(consoleId)) {
+      return c.json({ success: false, error: "Invalid console ID" }, 400);
+    }
+
+    const savedConsole = await SavedConsole.findOne({
+      _id: new Types.ObjectId(consoleId),
+      workspaceId: new Types.ObjectId(workspaceId),
+      $or: [{ is_deleted: { $ne: true } }, { is_deleted: { $exists: false } }],
+    });
+
+    if (!savedConsole) {
+      return c.json({ success: false, error: "Console not found" }, 404);
+    }
+
+    const schedule = validateScheduledConsoleSchedule({
+      cron: body?.cron,
+      timezone: body?.timezone,
+    });
+    const nextAt = getNextScheduledConsoleRunAt(schedule);
+
+    if (typeof body?.name === "string" && body.name.trim()) {
+      savedConsole.name = body.name.trim();
+    }
+
+    savedConsole.schedule = schedule;
+    savedConsole.scheduledRun = {
+      nextAt,
+      lastAt: savedConsole.scheduledRun?.lastAt,
+      lastStatus: savedConsole.scheduledRun?.lastStatus,
+      lastError: savedConsole.scheduledRun?.lastError,
+      lastDurationMs: savedConsole.scheduledRun?.lastDurationMs,
+      lastRowsAffected: savedConsole.scheduledRun?.lastRowsAffected,
+      lastRowCount: savedConsole.scheduledRun?.lastRowCount,
+      runCount: savedConsole.scheduledRun?.runCount ?? 0,
+      consecutiveFailures: savedConsole.scheduledRun?.consecutiveFailures ?? 0,
+    };
+    savedConsole.isSaved = true;
+    await savedConsole.save();
+
+    return c.json({
+      success: true,
+      schedule: savedConsole.schedule,
+      scheduledRun: savedConsole.scheduledRun,
+      console: {
+        id: savedConsole._id.toString(),
+        name: savedConsole.name,
+      },
+    });
+  } catch (error) {
+    logger.error("Error updating console schedule", { error });
+    return c.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to update console schedule",
+      },
+      500,
+    );
+  }
+});
+
+consoleRoutes.delete("/:id/schedule", async (c: AuthenticatedContext) => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const consoleId = c.req.param("id");
+
+    if (!Types.ObjectId.isValid(consoleId)) {
+      return c.json({ success: false, error: "Invalid console ID" }, 400);
+    }
+
+    const savedConsole = await SavedConsole.findOneAndUpdate(
+      {
+        _id: new Types.ObjectId(consoleId),
+        workspaceId: new Types.ObjectId(workspaceId),
+      },
+      {
+        $unset: {
+          schedule: 1,
+          "scheduledRun.nextAt": 1,
+        },
+      },
+      { new: true },
+    );
+
+    if (!savedConsole) {
+      return c.json({ success: false, error: "Console not found" }, 404);
+    }
+
+    return c.json({ success: true });
+  } catch (error) {
+    logger.error("Error removing console schedule", { error });
+    return c.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to remove console schedule",
+      },
+      500,
+    );
+  }
+});
+
+consoleRoutes.post("/:id/schedule/run", async (c: AuthenticatedContext) => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const consoleId = c.req.param("id");
+    const user = c.get("user");
+
+    if (!Types.ObjectId.isValid(consoleId)) {
+      return c.json({ success: false, error: "Invalid console ID" }, 400);
+    }
+
+    const savedConsole = await SavedConsole.findOne({
+      _id: new Types.ObjectId(consoleId),
+      workspaceId: new Types.ObjectId(workspaceId),
+    }).select("_id");
+
+    if (!savedConsole) {
+      return c.json({ success: false, error: "Console not found" }, 404);
+    }
+
+    const eventId = await inngest.send({
+      name: "scheduled_query/execute",
+      data: {
+        workspaceId,
+        consoleId,
+        triggerType: "manual",
+        triggeredBy: user?.id,
+      },
+    });
+
+    return c.json({ success: true, eventId });
+  } catch (error) {
+    logger.error("Error triggering scheduled console run", { error });
+    return c.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to trigger scheduled query run",
+      },
+      500,
+    );
+  }
+});
+
+consoleRoutes.get("/:id/schedule/runs", async (c: AuthenticatedContext) => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const consoleId = c.req.param("id");
+    const limit = Math.min(parseInt(c.req.query("limit") || "50", 10), 100);
+
+    if (!Types.ObjectId.isValid(consoleId)) {
+      return c.json({ success: false, error: "Invalid console ID" }, 400);
+    }
+
+    const runs = await ScheduledQueryRun.find({
+      workspaceId: new Types.ObjectId(workspaceId),
+      consoleId: new Types.ObjectId(consoleId),
+    })
+      .sort({ triggeredAt: -1 })
+      .limit(limit)
+      .lean();
+
+    return c.json({
+      success: true,
+      runs: runs.map(run => ({
+        id: run._id.toString(),
+        triggeredAt: run.triggeredAt,
+        startedAt: run.startedAt,
+        completedAt: run.completedAt,
+        status: run.status,
+        triggerType: run.triggerType,
+        triggeredBy: run.triggeredBy,
+        durationMs: run.durationMs,
+        rowsAffected: run.rowsAffected,
+        rowCount: run.rowCount,
+        error: run.error,
+        inngestRunId: run.inngestRunId,
+      })),
+    });
+  } catch (error) {
+    logger.error("Error listing scheduled console runs", { error });
+    return c.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to list scheduled query runs",
+      },
+      500,
     );
   }
 });

--- a/api/src/routes/scheduled-queries.ts
+++ b/api/src/routes/scheduled-queries.ts
@@ -1,0 +1,80 @@
+import { Hono } from "hono";
+import { Types } from "mongoose";
+import { unifiedAuthMiddleware } from "../auth/unified-auth.middleware";
+import { SavedConsole } from "../database/workspace-schema";
+import { loggers } from "../logging";
+import { requireWorkspaceAdmin } from "../middleware/workspace-admin.middleware";
+import { AuthenticatedContext } from "../middleware/workspace.middleware";
+import { workspaceService } from "../services/workspace.service";
+
+const logger = loggers.api("scheduled-queries");
+
+export const scheduledQueryRoutes = new Hono();
+
+scheduledQueryRoutes.use("*", unifiedAuthMiddleware);
+
+scheduledQueryRoutes.use("*", async (c: AuthenticatedContext, next) => {
+  const workspaceId = c.req.param("workspaceId");
+  const user = c.get("user");
+
+  if (!workspaceId || !Types.ObjectId.isValid(workspaceId)) {
+    return c.json(
+      { success: false, error: "Invalid workspace ID format" },
+      400,
+    );
+  }
+
+  if (!user || !(await workspaceService.hasAccess(workspaceId, user.id))) {
+    return c.json({ success: false, error: "Access denied to workspace" }, 403);
+  }
+
+  await next();
+});
+
+scheduledQueryRoutes.use("*", requireWorkspaceAdmin);
+
+scheduledQueryRoutes.get("/", async (c: AuthenticatedContext) => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+
+    const consoles = await SavedConsole.find({
+      workspaceId: new Types.ObjectId(workspaceId),
+      isSaved: true,
+      "schedule.cron": { $exists: true, $ne: "" },
+      $or: [{ is_deleted: { $ne: true } }, { is_deleted: { $exists: false } }],
+    })
+      .select(
+        "_id name schedule scheduledRun connectionId databaseName databaseId access owner_id createdBy updatedAt",
+      )
+      .sort({ name: 1 })
+      .lean();
+
+    return c.json({
+      success: true,
+      scheduledQueries: consoles.map(consoleDoc => ({
+        id: consoleDoc._id.toString(),
+        name: consoleDoc.name,
+        connectionId: consoleDoc.connectionId?.toString(),
+        databaseId: consoleDoc.databaseId,
+        databaseName: consoleDoc.databaseName,
+        schedule: consoleDoc.schedule,
+        scheduledRun: consoleDoc.scheduledRun,
+        access: consoleDoc.access,
+        owner_id: consoleDoc.owner_id || consoleDoc.createdBy,
+        updatedAt: consoleDoc.updatedAt,
+      })),
+    });
+  } catch (error) {
+    logger.error("Failed to list scheduled queries", { error });
+    return c.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to list scheduled queries",
+      },
+      500,
+    );
+  }
+});

--- a/api/src/services/query-execution.service.ts
+++ b/api/src/services/query-execution.service.ts
@@ -7,7 +7,12 @@ const logger = loggers.query();
 /**
  * Query execution source types
  */
-export type QuerySource = "console_ui" | "api" | "agent" | "flow";
+export type QuerySource =
+  | "console_ui"
+  | "api"
+  | "agent"
+  | "flow"
+  | "scheduled_query";
 
 /**
  * Query execution status types

--- a/api/src/services/scheduled-query-schedule.service.ts
+++ b/api/src/services/scheduled-query-schedule.service.ts
@@ -1,0 +1,62 @@
+import { CronExpressionParser } from "cron-parser";
+
+export interface ScheduledConsoleScheduleInput {
+  cron?: string | null;
+  timezone?: string | null;
+}
+
+export interface ScheduledConsoleSchedule {
+  cron: string;
+  timezone: string;
+}
+
+export function normalizeScheduledConsoleSchedule(
+  input?: ScheduledConsoleScheduleInput | null,
+): ScheduledConsoleSchedule {
+  return {
+    cron: input?.cron?.trim() || "0 0 * * *",
+    timezone: input?.timezone?.trim() || "UTC",
+  };
+}
+
+export function validateScheduledConsoleSchedule(
+  input?: ScheduledConsoleScheduleInput | null,
+): ScheduledConsoleSchedule {
+  const schedule = normalizeScheduledConsoleSchedule(input);
+
+  if (!schedule.cron) {
+    throw new Error("Schedule cron is required");
+  }
+
+  CronExpressionParser.parse(schedule.cron, {
+    currentDate: new Date(),
+    tz: schedule.timezone,
+  });
+
+  return schedule;
+}
+
+export function getNextScheduledConsoleRunAt(
+  schedule: ScheduledConsoleSchedule,
+  from = new Date(),
+): Date {
+  return CronExpressionParser.parse(schedule.cron, {
+    currentDate: from,
+    tz: schedule.timezone,
+  })
+    .next()
+    .toDate();
+}
+
+export function getUpcomingScheduledConsoleRuns(
+  schedule: ScheduledConsoleSchedule,
+  count: number,
+  from = new Date(),
+): Date[] {
+  const interval = CronExpressionParser.parse(schedule.cron, {
+    currentDate: from,
+    tz: schedule.timezone,
+  });
+
+  return Array.from({ length: count }, () => interval.next().toDate());
+}

--- a/app/src/components/Console.tsx
+++ b/app/src/components/Console.tsx
@@ -175,6 +175,9 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
   const savedStateHash = tab?.savedStateHash;
   const isSaved = tab?.isSaved ?? false;
   const isReadOnly = tab?.readOnly ?? false;
+  const hasSchedule = Boolean(
+    schedule?.cron?.trim() && schedule?.timezone?.trim(),
+  );
 
   // State for info modal
   const [infoModalOpen, setInfoModalOpen] = useState(false);
@@ -1014,7 +1017,7 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
                 title={
                   !isSaved
                     ? "Save this console before scheduling it"
-                    : schedule
+                    : hasSchedule
                       ? "Update scheduled query"
                       : "Create scheduled query"
                 }
@@ -1027,7 +1030,7 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
                       <Badge
                         color="success"
                         variant="dot"
-                        invisible={!schedule}
+                        invisible={!hasSchedule}
                         overlap="circular"
                       >
                         <ScheduleIcon size={16} />
@@ -1049,7 +1052,7 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
                 onClose={() => setScheduleMenuAnchor(null)}
               >
                 <MenuItem
-                  disabled={!isSaved || Boolean(schedule)}
+                  disabled={!isSaved || hasSchedule}
                   onClick={() => {
                     setScheduleMenuAnchor(null);
                     onCreateSchedule?.();
@@ -1058,7 +1061,7 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
                   Create new scheduled query
                 </MenuItem>
                 <MenuItem
-                  disabled={!isSaved || !schedule}
+                  disabled={!isSaved || !hasSchedule}
                   onClick={() => {
                     setScheduleMenuAnchor(null);
                     onUpdateSchedule?.();
@@ -1066,7 +1069,7 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
                 >
                   Update scheduled query
                 </MenuItem>
-                {schedule && onRemoveSchedule && (
+                {hasSchedule && onRemoveSchedule && (
                   <MenuItem
                     onClick={() => {
                       setScheduleMenuAnchor(null);

--- a/app/src/components/Console.tsx
+++ b/app/src/components/Console.tsx
@@ -18,6 +18,7 @@ import {
   IconButton,
   Divider,
   Alert,
+  Badge,
   Chip,
   ListItemIcon,
   ListItemText,
@@ -35,6 +36,7 @@ import {
   ChevronDown as ChevronDownIcon,
   Copy as CopyIcon,
   FolderInput as MoveIcon,
+  Clock3 as ScheduleIcon,
 } from "lucide-react";
 import Editor, { DiffEditor } from "@monaco-editor/react";
 import { useTheme } from "../contexts/ThemeContext";
@@ -105,6 +107,13 @@ interface ConsoleProps {
    */
   historyAvailable?: boolean;
   enableVersionControl?: boolean;
+  schedule?: {
+    cron: string;
+    timezone: string;
+  };
+  onCreateSchedule?: () => void;
+  onUpdateSchedule?: () => void;
+  onRemoveSchedule?: () => void;
 }
 
 export interface ConsoleRef {
@@ -147,6 +156,10 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
     onHistoryClick,
     historyAvailable = true,
     enableVersionControl = false,
+    schedule,
+    onCreateSchedule,
+    onUpdateSchedule,
+    onRemoveSchedule,
   } = props;
 
   const editorRef = useRef<any>(null);
@@ -195,6 +208,8 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
   const [modifiedContent, setModifiedContent] = useState("");
   const [pendingModification, setPendingModification] =
     useState<ConsoleModification | null>(null);
+  const [scheduleMenuAnchor, setScheduleMenuAnchor] =
+    useState<HTMLElement | null>(null);
 
   // Editor key to force remount when needed
   const [editorKey, setEditorKey] = useState(0);
@@ -291,6 +306,8 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
 
   const isLoadingDatabases =
     schemaLoading[`tree:${connectionId}:root`] || false;
+
+  const scheduleMenuOpen = Boolean(scheduleMenuAnchor);
 
   // Fetch sub-databases if needed (for cluster mode)
   useEffect(() => {
@@ -989,6 +1006,78 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
               variant="outlined"
               sx={{ ml: 1, height: 24, fontSize: "0.75rem" }}
             />
+          )}
+
+          {!isReadOnly && (onCreateSchedule || onUpdateSchedule) && (
+            <>
+              <Tooltip
+                title={
+                  !isSaved
+                    ? "Save this console before scheduling it"
+                    : schedule
+                      ? "Update scheduled query"
+                      : "Create scheduled query"
+                }
+              >
+                <span>
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    startIcon={
+                      <Badge
+                        color="success"
+                        variant="dot"
+                        invisible={!schedule}
+                        overlap="circular"
+                      >
+                        <ScheduleIcon size={16} />
+                      </Badge>
+                    }
+                    onClick={event =>
+                      setScheduleMenuAnchor(event.currentTarget)
+                    }
+                    disabled={!isSaved}
+                    sx={{ ml: 1, whiteSpace: "nowrap" }}
+                  >
+                    Schedule
+                  </Button>
+                </span>
+              </Tooltip>
+              <Menu
+                anchorEl={scheduleMenuAnchor}
+                open={scheduleMenuOpen}
+                onClose={() => setScheduleMenuAnchor(null)}
+              >
+                <MenuItem
+                  disabled={!isSaved || Boolean(schedule)}
+                  onClick={() => {
+                    setScheduleMenuAnchor(null);
+                    onCreateSchedule?.();
+                  }}
+                >
+                  Create new scheduled query
+                </MenuItem>
+                <MenuItem
+                  disabled={!isSaved || !schedule}
+                  onClick={() => {
+                    setScheduleMenuAnchor(null);
+                    onUpdateSchedule?.();
+                  }}
+                >
+                  Update scheduled query
+                </MenuItem>
+                {schedule && onRemoveSchedule && (
+                  <MenuItem
+                    onClick={() => {
+                      setScheduleMenuAnchor(null);
+                      onRemoveSchedule();
+                    }}
+                  >
+                    Remove schedule
+                  </MenuItem>
+                )}
+              </Menu>
+            </>
           )}
 
           {onSave && !isReadOnly && (

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -441,6 +441,7 @@ function Editor({
   const updateResultsViewMode = useConsoleStore(
     state => state.updateResultsViewMode,
   );
+  const updateMetadata = useConsoleStore(state => state.updateMetadata);
   const setActiveTab = useConsoleStore(state => state.setActiveTab);
   const getVersionManager = useConsoleStore(state => state.getVersionManager);
   const generateSaveComment = useConsoleStore(
@@ -463,6 +464,10 @@ function Editor({
   const consoleTabs = useConsoleStore(useShallow(selectConsoleTabs));
   const activeConsoleId = activeTabId;
   const scheduleModalTab = scheduleModalTabId ? tabs[scheduleModalTabId] : null;
+  const scheduleModalHasSchedule = Boolean(
+    scheduleModalTab?.schedule?.cron?.trim() &&
+      scheduleModalTab?.schedule?.timezone?.trim(),
+  );
 
   const setChartSpecForTab = useCallback(
     (tabId: string, spec: import("../lib/chart-spec").MakoChartSpec | null) => {
@@ -1274,6 +1279,25 @@ function Editor({
     [currentWorkspace, listScheduledRuns],
   );
 
+  useEffect(() => {
+    if (!activeTabId) return;
+
+    const activeTab = tabs[activeTabId];
+    if (!activeTab?.metadata?.openScheduledRuns) return;
+
+    setTabBottomPanel(prev =>
+      prev[activeTabId] === "runs" ? prev : { ...prev, [activeTabId]: "runs" },
+    );
+    void loadScheduledRunsForTab(activeTabId);
+
+    const nextMetadata = { ...(activeTab.metadata || {}) };
+    delete nextMetadata.openScheduledRuns;
+    updateMetadata(
+      activeTabId,
+      Object.keys(nextMetadata).length > 0 ? nextMetadata : undefined,
+    );
+  }, [activeTabId, tabs, loadScheduledRunsForTab, updateMetadata]);
+
   const handleOpenScheduleModal = useCallback(
     (tabId: string, mode: "create" | "update") => {
       setScheduleModalTabId(tabId);
@@ -2078,26 +2102,76 @@ function Editor({
                             flexDirection: "column",
                           }}
                         >
-                          <Tabs
-                            value={tabBottomPanel[tab.id] || "results"}
-                            onChange={(_event, value: "results" | "runs") => {
-                              setTabBottomPanel(prev => ({
-                                ...prev,
-                                [tab.id]: value,
-                              }));
-                              if (value === "runs") {
-                                void loadScheduledRunsForTab(tab.id);
-                              }
+                          <Box
+                            sx={{
+                              px: 1.5,
+                              borderBottom: 1,
+                              borderColor: "divider",
+                              minHeight: 36,
+                              display: "flex",
+                              alignItems: "center",
                             }}
-                            sx={{ minHeight: 40 }}
                           >
-                            <Tab value="results" label="Results" />
-                            <Tab
-                              value="runs"
-                              label={`Runs (${tab.scheduledRun?.runCount ?? 0})`}
-                              disabled={!tab.schedule}
-                            />
-                          </Tabs>
+                            <Tabs
+                              value={tabBottomPanel[tab.id] || "results"}
+                              onChange={(_event, value: "results" | "runs") => {
+                                setTabBottomPanel(prev => ({
+                                  ...prev,
+                                  [tab.id]: value,
+                                }));
+                                if (value === "runs") {
+                                  void loadScheduledRunsForTab(tab.id);
+                                }
+                              }}
+                              sx={{
+                                minHeight: 36,
+                                "& .MuiTabs-indicator": {
+                                  height: 2,
+                                },
+                              }}
+                            >
+                              <Tab
+                                value="results"
+                                label="Results"
+                                disableRipple
+                                sx={{
+                                  minHeight: 36,
+                                  py: 0.25,
+                                  px: 1.25,
+                                  minWidth: 0,
+                                  textTransform: "none",
+                                  fontSize: "0.875rem",
+                                  fontWeight: 600,
+                                  color: "text.secondary",
+                                  "&.Mui-selected": {
+                                    color: "text.primary",
+                                  },
+                                }}
+                              />
+                              <Tab
+                                value="runs"
+                                label={`Runs (${tab.scheduledRun?.runCount ?? 0})`}
+                                disabled={!tab.schedule}
+                                disableRipple
+                                sx={{
+                                  minHeight: 36,
+                                  py: 0.25,
+                                  px: 1.25,
+                                  minWidth: 0,
+                                  textTransform: "none",
+                                  fontSize: "0.875rem",
+                                  fontWeight: 600,
+                                  color: "text.secondary",
+                                  "&.Mui-selected": {
+                                    color: "text.primary",
+                                  },
+                                  "&.Mui-disabled": {
+                                    opacity: 0.5,
+                                  },
+                                }}
+                              />
+                            </Tabs>
+                          </Box>
                           <Box sx={{ flexGrow: 1, minHeight: 0 }}>
                             {(tabBottomPanel[tab.id] || "results") ===
                             "runs" ? (
@@ -2306,12 +2380,12 @@ function Editor({
           onClose={() => setScheduleModalTabId(null)}
           onSave={handleSaveSchedule}
           onRemove={
-            scheduleModalMode === "update" && scheduleModalTab.schedule
+            scheduleModalMode === "update" && scheduleModalHasSchedule
               ? async () => handleRemoveSchedule(scheduleModalTab.id)
               : undefined
           }
           onRunNow={
-            scheduleModalMode === "update" && scheduleModalTab.schedule
+            scheduleModalMode === "update" && scheduleModalHasSchedule
               ? async () => handleRunScheduledNow(scheduleModalTab.id)
               : undefined
           }

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -54,6 +54,8 @@ import ConnectorTab from "./ConnectorTab";
 import { WorkspaceMembers } from "./WorkspaceMembers";
 import { FlowEditor } from "./FlowEditor";
 import DashboardCanvas from "./DashboardCanvas";
+import ScheduleConsoleModal from "./ScheduleConsoleModal";
+import ScheduledRunsPanel from "./ScheduledRunsPanel";
 import type { DbFlowFormRef } from "./DbFlowForm";
 import ConflictResolutionDialog, {
   ConflictData,
@@ -77,6 +79,7 @@ import {
   computeConsoleStateHash,
   computeDashboardStateHash,
 } from "../utils/stateHash";
+import type { ScheduledQueryRunItem } from "../lib/api-types";
 
 interface QueryPageInfo {
   pageSize: number;
@@ -381,6 +384,24 @@ function Editor({
   const [versionHistoryEntityType, setVersionHistoryEntityType] = useState<
     "console" | "dashboard"
   >("console");
+  const [scheduleModalTabId, setScheduleModalTabId] = useState<string | null>(
+    null,
+  );
+  const [scheduleModalMode, setScheduleModalMode] = useState<
+    "create" | "update"
+  >("create");
+  const [tabBottomPanel, setTabBottomPanel] = useState<
+    Record<string, "results" | "runs">
+  >({});
+  const [tabScheduledRuns, setTabScheduledRuns] = useState<
+    Record<string, ScheduledQueryRunItem[]>
+  >({});
+  const [tabScheduledRunsLoading, setTabScheduledRunsLoading] = useState<
+    Record<string, boolean>
+  >({});
+  const [tabScheduledRunsError, setTabScheduledRunsError] = useState<
+    Record<string, string | null>
+  >({});
 
   // Conflict resolution state
   const [conflictDialogOpen, setConflictDialogOpen] = useState(false);
@@ -429,6 +450,10 @@ function Editor({
   const cancelQuery = useConsoleStore(state => state.cancelQuery);
   const saveConsole = useConsoleStore(state => state.saveConsole);
   const deleteConsole = useConsoleStore(state => state.deleteConsole);
+  const setSchedule = useConsoleStore(state => state.setSchedule);
+  const removeSchedule = useConsoleStore(state => state.removeSchedule);
+  const runScheduledNow = useConsoleStore(state => state.runScheduledNow);
+  const listScheduledRuns = useConsoleStore(state => state.listScheduledRuns);
   const openTab = useConsoleStore(state => state.openTab);
   const reorderTabs = useConsoleStore(state => state.reorderTabs);
   const reloadConsole = useConsoleStore(state => state.reloadConsole);
@@ -437,6 +462,7 @@ function Editor({
   // detect a change every render and trigger a re-render loop.
   const consoleTabs = useConsoleStore(useShallow(selectConsoleTabs));
   const activeConsoleId = activeTabId;
+  const scheduleModalTab = scheduleModalTabId ? tabs[scheduleModalTabId] : null;
 
   const setChartSpecForTab = useCallback(
     (tabId: string, spec: import("../lib/chart-spec").MakoChartSpec | null) => {
@@ -1109,6 +1135,27 @@ function Editor({
         setSnackbarMessage(`Console saved to '${savePath}.js'`);
         setSnackbarOpen(true);
         success = true;
+
+        // Add the console to the tree
+        if (!currentTab?.filePath) {
+          const { useConsoleTreeStore } = await import(
+            "../store/consoleTreeStore"
+          );
+          useConsoleTreeStore
+            .getState()
+            .addConsole(currentWorkspace.id, savePath ?? "", tabId);
+        }
+
+        if (currentTab?.metadata?.openScheduleOnSave) {
+          useConsoleStore.setState(state => {
+            const tab = state.tabs[tabId];
+            if (tab?.metadata) {
+              delete tab.metadata.openScheduleOnSave;
+            }
+          });
+          setScheduleModalTabId(tabId);
+          setScheduleModalMode("create");
+        }
       } else {
         setErrorMessage(JSON.stringify(result.error, null, 2));
         setErrorModalOpen(true);
@@ -1204,6 +1251,87 @@ function Editor({
     setPendingCommentSave(null);
     pending?.resolve(false);
   };
+
+  const loadScheduledRunsForTab = useCallback(
+    async (tabId: string) => {
+      if (!currentWorkspace) return;
+
+      setTabScheduledRunsLoading(prev => ({ ...prev, [tabId]: true }));
+      setTabScheduledRunsError(prev => ({ ...prev, [tabId]: null }));
+
+      const response = await listScheduledRuns(currentWorkspace.id, tabId, 50);
+      if (response.success) {
+        setTabScheduledRuns(prev => ({ ...prev, [tabId]: response.runs }));
+      } else {
+        setTabScheduledRunsError(prev => ({
+          ...prev,
+          [tabId]: response.error || "Failed to load scheduled runs",
+        }));
+      }
+
+      setTabScheduledRunsLoading(prev => ({ ...prev, [tabId]: false }));
+    },
+    [currentWorkspace, listScheduledRuns],
+  );
+
+  const handleOpenScheduleModal = useCallback(
+    (tabId: string, mode: "create" | "update") => {
+      setScheduleModalTabId(tabId);
+      setScheduleModalMode(mode);
+    },
+    [],
+  );
+
+  const handleSaveSchedule = useCallback(
+    async (input: { name: string; cron: string; timezone: string }) => {
+      if (!currentWorkspace || !scheduleModalTabId) {
+        throw new Error("No workspace selected");
+      }
+
+      const response = await setSchedule(
+        currentWorkspace.id,
+        scheduleModalTabId,
+        input,
+      );
+      if (!response.success) {
+        throw new Error(response.error || "Failed to save schedule");
+      }
+
+      if (tabBottomPanel[scheduleModalTabId] === "runs") {
+        await loadScheduledRunsForTab(scheduleModalTabId);
+      }
+    },
+    [
+      currentWorkspace,
+      scheduleModalTabId,
+      setSchedule,
+      tabBottomPanel,
+      loadScheduledRunsForTab,
+    ],
+  );
+
+  const handleRemoveSchedule = useCallback(
+    async (tabId: string) => {
+      if (!currentWorkspace) return;
+      const response = await removeSchedule(currentWorkspace.id, tabId);
+      if (!response.success) {
+        throw new Error(response.error || "Failed to remove schedule");
+      }
+    },
+    [currentWorkspace, removeSchedule],
+  );
+
+  const handleRunScheduledNow = useCallback(
+    async (tabId: string) => {
+      if (!currentWorkspace) return;
+      const response = await runScheduledNow(currentWorkspace.id, tabId);
+      if (!response.success) {
+        throw new Error(response.error || "Failed to run scheduled query");
+      }
+      await loadScheduledRunsForTab(tabId);
+    },
+    [currentWorkspace, runScheduledNow, loadScheduledRunsForTab],
+  );
 
   // Conflict resolution handlers
   const handleConflictOverwrite = async () => {
@@ -1926,6 +2054,16 @@ function Editor({
                           setVersionHistoryOpen(true);
                         }}
                         historyAvailable={tab.isSaved}
+                        schedule={tab.schedule}
+                        onCreateSchedule={() =>
+                          handleOpenScheduleModal(tab.id, "create")
+                        }
+                        onUpdateSchedule={() =>
+                          handleOpenScheduleModal(tab.id, "update")
+                        }
+                        onRemoveSchedule={() => {
+                          void handleRemoveSchedule(tab.id);
+                        }}
                       />
                     </Panel>
 
@@ -1933,38 +2071,85 @@ function Editor({
 
                     <Panel defaultSize={40} minSize={1}>
                       <Box sx={{ height: "100%", overflow: "hidden" }}>
-                        <ResultsTable
-                          results={tabResults[tab.id] || null}
-                          chartSpec={tabChartSpecs[tab.id] ?? null}
-                          onChartSpecChange={spec =>
-                            setChartSpecForTab(tab.id, spec)
-                          }
-                          viewMode={tabViewModes[tab.id] ?? "table"}
-                          onViewModeChange={mode =>
-                            setViewModeForTab(tab.id, mode)
-                          }
-                          onChartRenderError={error => {
-                            const cb = pendingRenderCallbackRef.current[tab.id];
-                            if (cb) {
-                              cb({ success: false, error });
-                              delete pendingRenderCallbackRef.current[tab.id];
-                            }
+                        <Box
+                          sx={{
+                            height: "100%",
+                            display: "flex",
+                            flexDirection: "column",
                           }}
-                          onChartRenderSuccess={() => {
-                            const cb = pendingRenderCallbackRef.current[tab.id];
-                            if (cb) {
-                              cb({ success: true });
-                              delete pendingRenderCallbackRef.current[tab.id];
-                            }
-                          }}
-                          onPreviousPage={() =>
-                            handlePreviousResultsPage(tab.id)
-                          }
-                          onNextPage={() => handleNextResultsPage(tab.id)}
-                          onDownload={format =>
-                            handleDownloadResults(tab.id, format)
-                          }
-                        />
+                        >
+                          <Tabs
+                            value={tabBottomPanel[tab.id] || "results"}
+                            onChange={(_event, value: "results" | "runs") => {
+                              setTabBottomPanel(prev => ({
+                                ...prev,
+                                [tab.id]: value,
+                              }));
+                              if (value === "runs") {
+                                void loadScheduledRunsForTab(tab.id);
+                              }
+                            }}
+                            sx={{ minHeight: 40 }}
+                          >
+                            <Tab value="results" label="Results" />
+                            <Tab
+                              value="runs"
+                              label={`Runs (${tab.scheduledRun?.runCount ?? 0})`}
+                              disabled={!tab.schedule}
+                            />
+                          </Tabs>
+                          <Box sx={{ flexGrow: 1, minHeight: 0 }}>
+                            {(tabBottomPanel[tab.id] || "results") ===
+                            "runs" ? (
+                              <ScheduledRunsPanel
+                                loading={
+                                  tabScheduledRunsLoading[tab.id] || false
+                                }
+                                error={tabScheduledRunsError[tab.id]}
+                                runs={tabScheduledRuns[tab.id] || []}
+                              />
+                            ) : (
+                              <ResultsTable
+                                results={tabResults[tab.id] || null}
+                                chartSpec={tabChartSpecs[tab.id] ?? null}
+                                onChartSpecChange={spec =>
+                                  setChartSpecForTab(tab.id, spec)
+                                }
+                                viewMode={tabViewModes[tab.id] ?? "table"}
+                                onViewModeChange={mode =>
+                                  setViewModeForTab(tab.id, mode)
+                                }
+                                onChartRenderError={error => {
+                                  const cb =
+                                    pendingRenderCallbackRef.current[tab.id];
+                                  if (cb) {
+                                    cb({ success: false, error });
+                                    delete pendingRenderCallbackRef.current[
+                                      tab.id
+                                    ];
+                                  }
+                                }}
+                                onChartRenderSuccess={() => {
+                                  const cb =
+                                    pendingRenderCallbackRef.current[tab.id];
+                                  if (cb) {
+                                    cb({ success: true });
+                                    delete pendingRenderCallbackRef.current[
+                                      tab.id
+                                    ];
+                                  }
+                                }}
+                                onPreviousPage={() =>
+                                  handlePreviousResultsPage(tab.id)
+                                }
+                                onNextPage={() => handleNextResultsPage(tab.id)}
+                                onDownload={format =>
+                                  handleDownloadResults(tab.id, format)
+                                }
+                              />
+                            )}
+                          </Box>
+                        </Box>
                       </Box>
                     </Panel>
                   </PanelGroup>
@@ -2104,6 +2289,32 @@ function Editor({
               reloadConsole(currentWorkspace.id, versionHistoryTabId);
             }
           }}
+        />
+      )}
+
+      {scheduleModalTab && (
+        <ScheduleConsoleModal
+          open={Boolean(scheduleModalTab)}
+          mode={scheduleModalMode}
+          initialName={scheduleModalTab.title}
+          initialSchedule={scheduleModalTab.schedule}
+          connectionLabel={
+            availableDatabases.find(
+              connection => connection.id === scheduleModalTab.connectionId,
+            )?.displayName || scheduleModalTab.databaseName
+          }
+          onClose={() => setScheduleModalTabId(null)}
+          onSave={handleSaveSchedule}
+          onRemove={
+            scheduleModalMode === "update" && scheduleModalTab.schedule
+              ? async () => handleRemoveSchedule(scheduleModalTab.id)
+              : undefined
+          }
+          onRunNow={
+            scheduleModalMode === "update" && scheduleModalTab.schedule
+              ? async () => handleRunScheduledNow(scheduleModalTab.id)
+              : undefined
+          }
         />
       )}
 

--- a/app/src/components/FlowsExplorer.tsx
+++ b/app/src/components/FlowsExplorer.tsx
@@ -275,7 +275,9 @@ export function FlowsExplorer() {
     if (!workspaceId) return;
 
     if (flowNode.itemType === "scheduled-query" && flowNode.consoleId) {
-      await loadConsole(workspaceId, flowNode.consoleId);
+      await loadConsole(workspaceId, flowNode.consoleId, {
+        openScheduledRuns: true,
+      });
       return;
     }
 

--- a/app/src/components/FlowsExplorer.tsx
+++ b/app/src/components/FlowsExplorer.tsx
@@ -1,33 +1,57 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
+  Alert,
   Box,
   IconButton,
-  List,
-  ListItem,
-  ListItemButton,
-  ListItemIcon,
-  ListItemText,
-  Typography,
-  Tooltip,
-  Skeleton,
   Menu,
   MenuItem,
+  Tooltip,
+  Typography,
 } from "@mui/material";
 import {
+  Activity as CdcIcon,
+  Clock3 as ScheduleIcon,
+  Database as DatabaseIcon,
   Plus as AddIcon,
-  CirclePause as PauseIcon,
-  Clock as ScheduleIcon,
   RotateCw as RefreshIcon,
+  SquareTerminal as ConsoleIcon,
   Webhook as WebhookIcon,
 } from "lucide-react";
+import { apiClient } from "../lib/api-client";
+import type {
+  ScheduledQueryListItem,
+  ScheduledQueryListResponse,
+} from "../lib/api-types";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useFlowStore } from "../store/flowStore";
 import { useConsoleStore } from "../store/consoleStore";
-import ResourceTree, {
-  type ResourceTreeNode,
-  type ResourceTreeSection,
-} from "./ResourceTree";
-import ExplorerShell from "./ExplorerShell";
+import ResourceTree, { type ResourceTreeNode } from "./ResourceTree";
+
+interface FlowTreeNode extends ResourceTreeNode {
+  itemType: "flow" | "scheduled-query";
+  flowId?: string;
+  consoleId?: string;
+  flowKind?: "connector" | "webhook" | "db-sync" | "cdc";
+}
+
+const noopIsExpanded = () => false;
+const noopToggle = () => undefined;
+
+const getFlowTitle = (flow: any): string => {
+  if (flow.sourceType === "database") {
+    return `Query -> ${flow.tableDestination?.tableName || "Table"}`;
+  }
+  const sourceName = flow.dataSourceId?.name || "Source";
+  const destName = flow.destinationDatabaseId?.name || "Destination";
+  return `${sourceName} -> ${destName}`;
+};
+
+const classifyFlow = (flow: any): FlowTreeNode["flowKind"] => {
+  if (flow.syncEngine === "cdc") return "cdc";
+  if (flow.type === "webhook") return "webhook";
+  if (flow.sourceType === "database") return "db-sync";
+  return "connector";
+};
 
 export function FlowsExplorer() {
   const { currentWorkspace } = useWorkspace();
@@ -40,52 +64,75 @@ export function FlowsExplorer() {
     selectFlow,
     clearError,
   } = useFlowStore();
+  const { tabs, activeTabId, openTab, setActiveTab, loadConsole } =
+    useConsoleStore();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const open = Boolean(anchorEl);
+  const [scheduledQueries, setScheduledQueries] = useState<
+    ScheduledQueryListItem[]
+  >([]);
+  const [scheduledLoading, setScheduledLoading] = useState(false);
+  const [scheduledError, setScheduledError] = useState<string | null>(null);
 
+  const workspaceId = currentWorkspace?.id;
   const flows = useMemo(
-    () => (currentWorkspace ? flowsMap[currentWorkspace.id] || [] : []),
-    [currentWorkspace, flowsMap],
+    () => (workspaceId ? flowsMap[workspaceId] || [] : []),
+    [workspaceId, flowsMap],
   );
-  const isLoading = currentWorkspace
-    ? !!loadingMap[currentWorkspace.id]
-    : false;
-  const error = currentWorkspace ? errorMap[currentWorkspace.id] || null : null;
+  const isLoading = workspaceId ? !!loadingMap[workspaceId] : false;
+  const error = workspaceId ? errorMap[workspaceId] || null : null;
 
-  const { tabs, activeTabId, openTab, setActiveTab } = useConsoleStore();
-  const consoleTabs = Object.values(tabs);
-  const activeConsoleId = activeTabId;
+  const fetchScheduledQueries = useCallback(async () => {
+    if (!workspaceId) return;
+    setScheduledLoading(true);
+    setScheduledError(null);
+
+    try {
+      const response = await apiClient.get<ScheduledQueryListResponse>(
+        `/workspaces/${workspaceId}/scheduled-queries`,
+      );
+      setScheduledQueries(response.scheduledQueries || []);
+    } catch (err) {
+      setScheduledError(
+        err instanceof Error ? err.message : "Failed to load scheduled queries",
+      );
+    } finally {
+      setScheduledLoading(false);
+    }
+  }, [workspaceId]);
 
   useEffect(() => {
-    if (currentWorkspace) {
-      init(currentWorkspace.id);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentWorkspace?.id, init]);
+    if (!workspaceId) return;
+    void init(workspaceId);
+    void fetchScheduledQueries();
+  }, [workspaceId, init, fetchScheduledQueries]);
 
   const handleRefresh = async () => {
-    if (currentWorkspace?.id) {
-      await refresh(currentWorkspace.id);
-    }
-  };
-
-  const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleMenuClose = () => {
-    setAnchorEl(null);
+    if (!workspaceId) return;
+    await refresh(workspaceId);
+    await fetchScheduledQueries();
   };
 
   const handleCreateNew = (
-    flowType: "scheduled" | "webhook" | "db-scheduled",
+    flowType: "scheduled" | "webhook" | "db-scheduled" | "scheduled-query",
   ) => {
+    if (flowType === "scheduled-query") {
+      const id = openTab({
+        title: "New Scheduled Query",
+        content: "",
+        metadata: { openScheduleOnSave: true },
+      });
+      setActiveTab(id);
+      setAnchorEl(null);
+      return;
+    }
+
     const title =
       flowType === "scheduled"
         ? "New Scheduled Flow"
         : flowType === "webhook"
           ? "New Webhook Flow"
           : "New Database Sync";
+
     const id = openTab({
       title,
       content: "",
@@ -93,313 +140,264 @@ export function FlowsExplorer() {
       metadata: { isNew: true, flowType },
     });
     setActiveTab(id);
-    handleMenuClose();
+    setAnchorEl(null);
   };
 
-  const handleEditFlow = (flowId: string) => {
+  const handleFlowClick = (flowId: string) => {
     selectFlow(flowId);
-    const flow = flows.find(f => f._id === flowId);
-    if (flow) {
-      const existingTab = Object.values(useConsoleStore.getState().tabs).find(
-        (tab: any) => tab.metadata?.flowId === flowId,
-      );
+    const flow = flows.find(item => item._id === flowId);
+    if (!flow) return;
 
-      if (existingTab) {
-        setActiveTab(existingTab.id);
-      } else {
-        const id = openTab({
-          title: getFlowTitle(flow),
-          content: "",
-          kind: "flow-editor",
-          metadata: {
-            flowId,
-            isNew: false,
-            flowType:
-              flow.sourceType === "database" ? "db-scheduled" : flow.type,
-            enabled:
-              flow.type === "webhook"
-                ? flow.webhookConfig?.enabled
-                : flow.schedule?.enabled,
-          },
-        });
-        setActiveTab(id);
-      }
+    const existingTab = Object.values(useConsoleStore.getState().tabs).find(
+      (tab: any) => tab.metadata?.flowId === flowId,
+    );
+
+    if (existingTab) {
+      setActiveTab(existingTab.id);
+      return;
     }
+
+    const id = openTab({
+      title: getFlowTitle(flow),
+      content: "",
+      kind: "flow-editor",
+      metadata: {
+        flowId,
+        isNew: false,
+        flowType: flow.sourceType === "database" ? "db-scheduled" : flow.type,
+        enabled:
+          flow.type === "webhook"
+            ? flow.webhookConfig?.enabled
+            : flow.schedule?.enabled,
+      },
+    });
+    setActiveTab(id);
   };
 
-  const getFlowTitle = (flow: any): string => {
-    if (flow.sourceType === "database") {
-      const destName = flow.tableDestination?.tableName || "Table";
-      return `Query → ${destName}`;
-    }
-    const sourceName = flow.dataSourceId?.name || "Source";
-    const destName = flow.destinationDatabaseId?.name || "Destination";
-    return `${sourceName} → ${destName}`;
-  };
+  const sections = useMemo(() => {
+    const connectorNodes: FlowTreeNode[] = [];
+    const webhookNodes: FlowTreeNode[] = [];
+    const dbSyncNodes: FlowTreeNode[] = [];
+    const cdcNodes: FlowTreeNode[] = [];
 
-  const getFlowStatus = (flow: any) => {
-    const isEnabled =
-      flow.type === "webhook"
-        ? flow.webhookConfig?.enabled !== false
-        : flow.schedule?.enabled === true;
-    if (!isEnabled) {
-      return {
-        label: "Disabled",
-        color: "default" as const,
-        letter: "D",
-      };
-    }
-    if (flow.lastError) {
-      return {
-        label: "Failed",
-        color: "error" as const,
-        letter: "F",
-      };
-    }
-    if (flow.lastSuccessAt) {
-      return {
-        label: "Success",
-        color: "success" as const,
-        letter: "S",
-      };
-    }
-    return {
-      label: "Pending",
-      color: "warning" as const,
-      letter: "A",
-    };
-  };
-
-  const flowById = useMemo(() => {
-    const map = new Map<string, any>();
     for (const flow of flows) {
-      map.set(flow._id, flow);
-    }
-    return map;
-  }, [flows]);
+      const node: FlowTreeNode = {
+        id: flow._id,
+        name: getFlowTitle(flow),
+        path: flow._id,
+        isDirectory: false,
+        itemType: "flow",
+        flowId: flow._id,
+        flowKind: classifyFlow(flow),
+      };
 
-  const sections = useMemo<ResourceTreeSection[]>(() => {
+      if (node.flowKind === "cdc") cdcNodes.push(node);
+      else if (node.flowKind === "webhook") webhookNodes.push(node);
+      else if (node.flowKind === "db-sync") dbSyncNodes.push(node);
+      else connectorNodes.push(node);
+    }
+
+    const scheduledNodes: FlowTreeNode[] = scheduledQueries.map(query => ({
+      id: query.id,
+      name: query.name,
+      path: query.id,
+      isDirectory: false,
+      itemType: "scheduled-query",
+      consoleId: query.id,
+    }));
+
     return [
       {
-        key: "flows",
-        label: "",
-        hideSectionHeader: true,
-        nodes: flows.map(flow => ({
-          id: flow._id,
-          name: getFlowTitle(flow),
-          path: getFlowTitle(flow),
-          isDirectory: false,
-        })),
+        key: "connector-sync",
+        label: "Connector Sync",
+        icon: <ScheduleIcon size={16} strokeWidth={1.5} />,
+        nodes: connectorNodes,
       },
-    ];
-  }, [flows]);
+      {
+        key: "webhook",
+        label: "Webhook",
+        icon: <WebhookIcon size={16} strokeWidth={1.5} />,
+        nodes: webhookNodes,
+      },
+      {
+        key: "db-sync",
+        label: "DB Sync",
+        icon: <DatabaseIcon size={16} strokeWidth={1.5} />,
+        nodes: dbSyncNodes,
+      },
+      {
+        key: "cdc",
+        label: "CDC",
+        icon: <CdcIcon size={16} strokeWidth={1.5} />,
+        nodes: cdcNodes,
+      },
+      {
+        key: "scheduled-query",
+        label: "Scheduled Query",
+        icon: <ConsoleIcon size={16} strokeWidth={1.5} />,
+        nodes: scheduledNodes,
+      },
+    ].filter(section => section.nodes.length > 0);
+  }, [flows, scheduledQueries]);
 
-  const getItemIcon = (node: ResourceTreeNode) => {
-    const flow = flowById.get(node.id);
-    if (!flow) return null;
-    if (flow.type === "webhook") {
-      return (
-        <WebhookIcon
-          size={20}
-          strokeWidth={1.5}
-          style={{
-            color:
-              flow.webhookConfig?.enabled !== false
-                ? undefined
-                : "var(--mui-palette-text-disabled)",
-          }}
-        />
-      );
+  const activeItemId = useMemo(() => {
+    if (!activeTabId) return null;
+    const activeTab = tabs[activeTabId];
+    if (!activeTab) return null;
+    if (activeTab.kind === "flow-editor" && activeTab.metadata?.flowId) {
+      return activeTab.metadata.flowId as string;
     }
-    if (flow.schedule?.enabled === true) {
-      return <ScheduleIcon size={20} strokeWidth={1.5} />;
+    if (activeTab.kind === "console" && activeTab.schedule) {
+      return activeTab.id;
     }
-    return (
-      <PauseIcon
-        size={20}
-        strokeWidth={1.5}
-        style={{ color: "var(--mui-palette-text-disabled)" }}
-      />
-    );
+    return null;
+  }, [activeTabId, tabs]);
+
+  const getItemIcon = useCallback((node: ResourceTreeNode) => {
+    const flowNode = node as FlowTreeNode;
+    if (flowNode.itemType === "scheduled-query") {
+      return <ConsoleIcon size={16} strokeWidth={1.5} />;
+    }
+    switch (flowNode.flowKind) {
+      case "webhook":
+        return <WebhookIcon size={16} strokeWidth={1.5} />;
+      case "db-sync":
+        return <DatabaseIcon size={16} strokeWidth={1.5} />;
+      case "cdc":
+        return <CdcIcon size={16} strokeWidth={1.5} />;
+      default:
+        return <ScheduleIcon size={16} strokeWidth={1.5} />;
+    }
+  }, []);
+
+  const handleItemClick = async (node: ResourceTreeNode) => {
+    const flowNode = node as FlowTreeNode;
+    if (!workspaceId) return;
+
+    if (flowNode.itemType === "scheduled-query" && flowNode.consoleId) {
+      await loadConsole(workspaceId, flowNode.consoleId);
+      return;
+    }
+
+    if (flowNode.flowId) {
+      handleFlowClick(flowNode.flowId);
+    }
   };
 
-  const getRightAdornment = (node: ResourceTreeNode) => {
-    const flow = flowById.get(node.id);
-    if (!flow) return null;
-    const status = getFlowStatus(flow);
-    return (
-      <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
-        <Tooltip
-          title={
-            flow.syncMode === "incremental" ? "Incremental Sync" : "Full Sync"
-          }
-        >
-          <Typography
-            variant="caption"
-            sx={{
-              fontWeight: "bold",
-              color: "text.secondary",
-              cursor: "help",
-            }}
-          >
-            {flow.syncMode === "incremental" ? "I" : "F"}
-          </Typography>
-        </Tooltip>
-        <Tooltip title={status.label}>
-          <Typography
-            variant="caption"
-            sx={{
-              fontWeight: "bold",
-              color:
-                status.letter === "S"
-                  ? "success.main"
-                  : status.letter === "F"
-                    ? "error.main"
-                    : status.letter === "A"
-                      ? "warning.main"
-                      : "text.disabled",
-              cursor: "help",
-            }}
-          >
-            {status.letter}
-          </Typography>
-        </Tooltip>
-      </Box>
-    );
-  };
-
-  const activeFlowTabId = useMemo(() => {
-    const tab = consoleTabs.find(
-      (t: any) =>
-        t.id === activeConsoleId &&
-        t.kind === "flow-editor" &&
-        t.metadata?.flowId,
-    );
-    return (tab as any)?.metadata?.flowId ?? null;
-  }, [consoleTabs, activeConsoleId]);
-
-  const renderSkeletonItems = () => (
-    <List dense>
-      {Array.from({ length: 3 }).map((_, index) => (
-        <ListItem key={`skeleton-${index}`} disablePadding>
-          <ListItemButton disabled>
-            <ListItemText
-              primary={
-                <Skeleton
-                  variant="text"
-                  width={`${60 + Math.random() * 40}%`}
-                  height={20}
-                />
-              }
-              secondary={
-                <Box
-                  component="span"
-                  sx={{
-                    display: "inline-flex",
-                    gap: 0.5,
-                    alignItems: "center",
-                  }}
-                >
-                  <Skeleton variant="text" width={120} height={16} />
-                  <Skeleton
-                    variant="rectangular"
-                    width={50}
-                    height={16}
-                    sx={{ borderRadius: 1 }}
-                  />
-                </Box>
-              }
-            />
-          </ListItemButton>
-        </ListItem>
-      ))}
-    </List>
-  );
-
-  const actions = (
-    <>
-      <Tooltip title="Add Flow">
-        <IconButton size="small" onClick={handleMenuOpen}>
-          <AddIcon size={20} strokeWidth={2} />
-        </IconButton>
-      </Tooltip>
-      <Tooltip title="Refresh">
-        <IconButton size="small" onClick={handleRefresh} disabled={isLoading}>
-          <RefreshIcon size={20} strokeWidth={2} />
-        </IconButton>
-      </Tooltip>
-    </>
-  );
+  const combinedError = error || scheduledError;
+  const isBusy = isLoading || scheduledLoading;
 
   return (
-    <>
-      <ExplorerShell
-        title="Flows"
-        actions={actions}
-        searchPlaceholder="Search flows..."
-        error={error}
-        onErrorClose={() => {
-          if (currentWorkspace?.id) clearError(currentWorkspace.id);
-        }}
-        loading={isLoading && flows.length === 0}
-        skeleton={renderSkeletonItems()}
-      >
-        {({ searchQuery }) =>
-          flows.length === 0 ? (
-            <Box sx={{ p: 3, textAlign: "center", color: "text.secondary" }}>
-              <Typography variant="body2">No flows configured.</Typography>
-            </Box>
-          ) : (
-            <ResourceTree
-              sections={sections}
-              mode="sidebar"
-              searchQuery={searchQuery}
-              activeItemId={activeFlowTabId || undefined}
-              getItemIcon={getItemIcon}
-              getRightAdornment={getRightAdornment}
-              hideFolderIcon
-              isFolderExpanded={() => true}
-              onToggleFolder={() => {}}
-              onExpandFolder={() => {}}
-              getFolderExpansionKey={node => node.id}
-              onItemClick={node => handleEditFlow(node.id)}
-            />
-          )
-        }
-      </ExplorerShell>
+    <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
+      <Box sx={{ px: 1, py: 0.5, borderBottom: 1, borderColor: "divider" }}>
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
+          <Typography
+            variant="h6"
+            sx={{
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              textTransform: "uppercase",
+            }}
+          >
+            Flows
+          </Typography>
+          <Box sx={{ display: "flex", gap: 0 }}>
+            <Tooltip title="Add Flow">
+              <IconButton
+                size="small"
+                onClick={event => setAnchorEl(event.currentTarget)}
+              >
+                <AddIcon size={20} strokeWidth={2} />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Refresh">
+              <IconButton
+                size="small"
+                onClick={handleRefresh}
+                disabled={isBusy}
+              >
+                <RefreshIcon size={20} strokeWidth={2} />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        </Box>
+      </Box>
+
+      {combinedError && (
+        <Alert
+          severity="error"
+          onClose={() => {
+            if (workspaceId) {
+              clearError(workspaceId);
+            }
+            setScheduledError(null);
+          }}
+          sx={{ mx: 2, mt: 2 }}
+        >
+          {combinedError}
+        </Alert>
+      )}
+
+      <Box sx={{ flexGrow: 1, overflow: "auto" }}>
+        {isBusy && sections.length === 0 ? (
+          <Box sx={{ p: 3, textAlign: "center", color: "text.secondary" }}>
+            <Typography variant="body2">Loading...</Typography>
+          </Box>
+        ) : sections.length === 0 ? (
+          <Box sx={{ p: 3, textAlign: "center", color: "text.secondary" }}>
+            <Typography variant="body2">No flows configured.</Typography>
+          </Box>
+        ) : (
+          <ResourceTree
+            sections={sections}
+            mode="sidebar"
+            activeItemId={activeItemId}
+            getItemIcon={getItemIcon}
+            enableDragDrop={false}
+            enableRename={false}
+            enableDelete={false}
+            enableMove={false}
+            enableInfo={false}
+            enableNewFolder={false}
+            onItemClick={node => {
+              void handleItemClick(node);
+            }}
+            isFolderExpanded={noopIsExpanded}
+            onToggleFolder={noopToggle}
+            onExpandFolder={noopToggle}
+            getFolderExpansionKey={node => node.id}
+            canManageItem={() => false}
+          />
+        )}
+      </Box>
 
       <Menu
         anchorEl={anchorEl}
-        open={open}
-        onClose={handleMenuClose}
-        anchorOrigin={{
-          vertical: "bottom",
-          horizontal: "right",
-        }}
-        transformOrigin={{
-          vertical: "top",
-          horizontal: "right",
-        }}
+        open={Boolean(anchorEl)}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+        transformOrigin={{ vertical: "top", horizontal: "right" }}
       >
         <MenuItem onClick={() => handleCreateNew("db-scheduled")}>
-          <ListItemIcon>
-            <ScheduleIcon fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>Database Sync</ListItemText>
+          Database Sync
         </MenuItem>
         <MenuItem onClick={() => handleCreateNew("scheduled")}>
-          <ListItemIcon>
-            <ScheduleIcon fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>Connector Sync</ListItemText>
+          Connector Sync
         </MenuItem>
         <MenuItem onClick={() => handleCreateNew("webhook")}>
-          <ListItemIcon>
-            <WebhookIcon fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>Webhook Sync</ListItemText>
+          Webhook Sync
+        </MenuItem>
+        <MenuItem onClick={() => handleCreateNew("scheduled-query")}>
+          Scheduled Query
         </MenuItem>
       </Menu>
-    </>
+    </Box>
   );
 }

--- a/app/src/components/ScheduleConsoleModal.tsx
+++ b/app/src/components/ScheduleConsoleModal.tsx
@@ -1,0 +1,366 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { CronExpressionParser } from "cron-parser";
+
+type SchedulePreset = "hourly" | "daily" | "every6h" | "weekly" | "custom";
+
+interface ScheduleConsoleModalProps {
+  open: boolean;
+  mode: "create" | "update";
+  initialName: string;
+  initialSchedule?: {
+    cron: string;
+    timezone: string;
+  };
+  connectionLabel?: string;
+  onClose: () => void;
+  onSave: (input: {
+    name: string;
+    cron: string;
+    timezone: string;
+  }) => Promise<void>;
+  onRemove?: () => Promise<void>;
+  onRunNow?: () => Promise<void>;
+}
+
+const intlWithSupportedValues = Intl as typeof Intl & {
+  supportedValuesOf?: (key: "timeZone") => string[];
+};
+
+const TIMEZONE_OPTIONS =
+  typeof intlWithSupportedValues.supportedValuesOf === "function"
+    ? intlWithSupportedValues.supportedValuesOf("timeZone")
+    : ["UTC"];
+
+const presetFromCron = (cron: string): SchedulePreset => {
+  if (cron === "0 * * * *") return "hourly";
+  if (cron === "0 0 * * *") return "daily";
+  if (cron === "0 */6 * * *") return "every6h";
+  if (cron === "0 0 * * 1") return "weekly";
+  return "custom";
+};
+
+const timeFromCron = (cron: string, fallback = "02:00") => {
+  const parts = cron.split(" ");
+  if (parts.length < 2) return fallback;
+  const hour = parts[1]?.padStart(2, "0") || "02";
+  const minute = parts[0]?.padStart(2, "0") || "00";
+  if (/^\d+$/.test(hour) && /^\d+$/.test(minute)) {
+    return `${hour}:${minute}`;
+  }
+  return fallback;
+};
+
+const cronFromPreset = (
+  preset: SchedulePreset,
+  time: string,
+  weekday: string,
+  customCron: string,
+) => {
+  const [hour = "02", minute = "00"] = time.split(":");
+  switch (preset) {
+    case "hourly":
+      return `0 * * * *`;
+    case "daily":
+      return `${minute} ${hour} * * *`;
+    case "every6h":
+      return `${minute} */6 * * *`;
+    case "weekly":
+      return `${minute} ${hour} * * ${weekday}`;
+    case "custom":
+    default:
+      return customCron.trim();
+  }
+};
+
+export default function ScheduleConsoleModal({
+  open,
+  mode,
+  initialName,
+  initialSchedule,
+  connectionLabel,
+  onClose,
+  onSave,
+  onRemove,
+  onRunNow,
+}: ScheduleConsoleModalProps) {
+  const [name, setName] = useState(initialName);
+  const [preset, setPreset] = useState<SchedulePreset>(
+    presetFromCron(initialSchedule?.cron || "0 0 * * *"),
+  );
+  const [time, setTime] = useState(timeFromCron(initialSchedule?.cron || ""));
+  const [weekday, setWeekday] = useState("1");
+  const [customCron, setCustomCron] = useState(initialSchedule?.cron || "");
+  const [timezone, setTimezone] = useState(
+    initialSchedule?.timezone ||
+      Intl.DateTimeFormat().resolvedOptions().timeZone ||
+      "UTC",
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isRunningNow, setIsRunningNow] = useState(false);
+  const [isRemoving, setIsRemoving] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setName(initialName);
+    setPreset(presetFromCron(initialSchedule?.cron || "0 0 * * *"));
+    setTime(timeFromCron(initialSchedule?.cron || ""));
+    setCustomCron(initialSchedule?.cron || "");
+    setTimezone(
+      initialSchedule?.timezone ||
+        Intl.DateTimeFormat().resolvedOptions().timeZone ||
+        "UTC",
+    );
+    setError(null);
+  }, [open, initialName, initialSchedule]);
+
+  const cron = useMemo(
+    () => cronFromPreset(preset, time, weekday, customCron),
+    [preset, time, weekday, customCron],
+  );
+
+  const previewRuns = useMemo(() => {
+    try {
+      if (!cron) return [];
+      const interval = CronExpressionParser.parse(cron, {
+        currentDate: new Date(),
+        tz: timezone,
+      });
+      return Array.from({ length: 3 }, () =>
+        interval.next().toDate().toLocaleString(),
+      );
+    } catch {
+      return [];
+    }
+  }, [cron, timezone]);
+
+  const handleSave = async () => {
+    try {
+      setIsSubmitting(true);
+      setError(null);
+      await onSave({ name: name.trim(), cron, timezone });
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save schedule");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleRunNow = async () => {
+    if (!onRunNow) return;
+    try {
+      setIsRunningNow(true);
+      await onRunNow();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to run query");
+    } finally {
+      setIsRunningNow(false);
+    }
+  };
+
+  const handleRemove = async () => {
+    if (!onRemove) return;
+    try {
+      setIsRemoving(true);
+      await onRemove();
+      onClose();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to remove schedule",
+      );
+    } finally {
+      setIsRemoving(false);
+    }
+  };
+
+  const isValid =
+    Boolean(name.trim()) && Boolean(cron.trim()) && previewRuns.length > 0;
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>
+        {mode === "create"
+          ? "Create scheduled query"
+          : "Update scheduled query"}
+      </DialogTitle>
+      <DialogContent dividers>
+        <Stack spacing={2.5} sx={{ pt: 1 }}>
+          {error && <Alert severity="error">{error}</Alert>}
+
+          <TextField
+            label="Name"
+            value={name}
+            onChange={event => setName(event.target.value)}
+            fullWidth
+            required
+          />
+
+          <Box>
+            <Typography variant="subtitle2" sx={{ mb: 1 }}>
+              Schedule
+            </Typography>
+            <RadioGroup
+              value={preset}
+              onChange={event =>
+                setPreset(event.target.value as SchedulePreset)
+              }
+            >
+              <FormControlLabel
+                value="hourly"
+                control={<Radio />}
+                label="Hourly"
+              />
+              <FormControlLabel
+                value="daily"
+                control={<Radio />}
+                label="Daily"
+              />
+              <FormControlLabel
+                value="every6h"
+                control={<Radio />}
+                label="Every 6 hours"
+              />
+              <FormControlLabel
+                value="weekly"
+                control={<Radio />}
+                label="Weekly"
+              />
+              <FormControlLabel
+                value="custom"
+                control={<Radio />}
+                label="Custom cron"
+              />
+            </RadioGroup>
+          </Box>
+
+          {preset === "weekly" && (
+            <TextField
+              select
+              label="Weekday"
+              value={weekday}
+              onChange={event => setWeekday(event.target.value)}
+              fullWidth
+              SelectProps={{ native: true }}
+            >
+              <option value="0">Sunday</option>
+              <option value="1">Monday</option>
+              <option value="2">Tuesday</option>
+              <option value="3">Wednesday</option>
+              <option value="4">Thursday</option>
+              <option value="5">Friday</option>
+              <option value="6">Saturday</option>
+            </TextField>
+          )}
+
+          {preset !== "hourly" && preset !== "custom" && (
+            <TextField
+              label="Time"
+              type="time"
+              value={time}
+              onChange={event => setTime(event.target.value)}
+              fullWidth
+              InputLabelProps={{ shrink: true }}
+            />
+          )}
+
+          {preset === "custom" && (
+            <TextField
+              label="Cron expression"
+              value={customCron}
+              onChange={event => setCustomCron(event.target.value)}
+              fullWidth
+            />
+          )}
+
+          <TextField
+            select
+            label="Timezone"
+            value={timezone}
+            onChange={event => setTimezone(event.target.value)}
+            fullWidth
+            SelectProps={{ native: true }}
+          >
+            {TIMEZONE_OPTIONS.map(option => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </TextField>
+
+          <Box>
+            <Typography variant="subtitle2">Next runs</Typography>
+            {previewRuns.length > 0 ? (
+              previewRuns.map(run => (
+                <Typography key={run} variant="body2" color="text.secondary">
+                  {run}
+                </Typography>
+              ))
+            ) : (
+              <Typography variant="body2" color="error">
+                Invalid cron expression
+              </Typography>
+            )}
+          </Box>
+
+          {connectionLabel && (
+            <Typography variant="body2" color="text.secondary">
+              Runs against: {connectionLabel}
+            </Typography>
+          )}
+
+          <Box>
+            <Typography variant="subtitle2" sx={{ mb: 0.75 }}>
+              Coming in v2
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Destination
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Notifications
+            </Typography>
+          </Box>
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{ justifyContent: "space-between", px: 3 }}>
+        <Box>
+          {mode === "update" && onRemove && (
+            <Button color="error" onClick={handleRemove} disabled={isRemoving}>
+              Remove schedule
+            </Button>
+          )}
+        </Box>
+        <Box sx={{ display: "flex", gap: 1 }}>
+          <Button onClick={onClose}>Cancel</Button>
+          {mode === "update" && onRunNow && (
+            <Button onClick={handleRunNow} disabled={isRunningNow}>
+              Run now
+            </Button>
+          )}
+          <Button
+            variant="contained"
+            onClick={handleSave}
+            disabled={!isValid || isSubmitting}
+          >
+            Save
+          </Button>
+        </Box>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/app/src/components/ScheduledRunsPanel.tsx
+++ b/app/src/components/ScheduledRunsPanel.tsx
@@ -1,0 +1,90 @@
+import {
+  Alert,
+  Box,
+  CircularProgress,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import type { ScheduledQueryRunItem } from "../lib/api-types";
+
+interface ScheduledRunsPanelProps {
+  loading: boolean;
+  error?: string | null;
+  runs: ScheduledQueryRunItem[];
+}
+
+export default function ScheduledRunsPanel({
+  loading,
+  error,
+  runs,
+}: ScheduledRunsPanelProps) {
+  if (loading) {
+    return (
+      <Box sx={{ height: "100%", display: "grid", placeItems: "center" }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return <Alert severity="error">{error}</Alert>;
+  }
+
+  if (runs.length === 0) {
+    return (
+      <Box sx={{ p: 3 }}>
+        <Typography variant="body2" color="text.secondary">
+          No scheduled runs yet.
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ height: "100%", overflow: "auto" }}>
+      <Table size="small" stickyHeader>
+        <TableHead>
+          <TableRow>
+            <TableCell>Triggered</TableCell>
+            <TableCell>Status</TableCell>
+            <TableCell>Duration</TableCell>
+            <TableCell>Rows</TableCell>
+            <TableCell>Trigger</TableCell>
+            <TableCell>Error</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {runs.map(run => (
+            <TableRow key={run.id} hover>
+              <TableCell>
+                {new Date(run.triggeredAt).toLocaleString()}
+              </TableCell>
+              <TableCell>{run.status}</TableCell>
+              <TableCell>
+                {typeof run.durationMs === "number"
+                  ? `${(run.durationMs / 1000).toFixed(1)}s`
+                  : "-"}
+              </TableCell>
+              <TableCell>{run.rowCount ?? run.rowsAffected ?? "-"}</TableCell>
+              <TableCell>{run.triggerType}</TableCell>
+              <TableCell
+                sx={{
+                  maxWidth: 320,
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                }}
+              >
+                {run.error?.message || "-"}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Box>
+  );
+}

--- a/app/src/lib/api-types.ts
+++ b/app/src/lib/api-types.ts
@@ -23,6 +23,21 @@ export interface ConsoleContentResponse {
   access?: "private" | "workspace";
   owner_id?: string;
   readOnly?: boolean;
+  schedule?: {
+    cron: string;
+    timezone: string;
+  };
+  scheduledRun?: {
+    nextAt?: string;
+    lastAt?: string;
+    lastStatus?: "success" | "error";
+    lastError?: string;
+    lastDurationMs?: number;
+    lastRowsAffected?: number;
+    lastRowCount?: number;
+    runCount: number;
+    consecutiveFailures: number;
+  };
 }
 
 export interface ConsoleSaveResponse {
@@ -58,6 +73,66 @@ export interface ConsoleListResponse {
 export interface ConsoleDeleteResponse {
   success: boolean;
   error?: string;
+}
+
+export interface ScheduledQueryRunItem {
+  id: string;
+  triggeredAt: string;
+  startedAt?: string;
+  completedAt?: string;
+  status: "queued" | "running" | "success" | "error";
+  triggerType: "schedule" | "manual";
+  triggeredBy?: string;
+  durationMs?: number;
+  rowsAffected?: number;
+  rowCount?: number;
+  error?: {
+    message: string;
+    code?: string;
+  };
+  inngestRunId?: string;
+}
+
+export interface ScheduledQueryRunsResponse {
+  success: boolean;
+  runs: ScheduledQueryRunItem[];
+  error?: string;
+}
+
+export interface ScheduledQueryScheduleResponse {
+  success: boolean;
+  schedule?: {
+    cron: string;
+    timezone: string;
+  };
+  scheduledRun?: ConsoleContentResponse["scheduledRun"];
+  console?: {
+    id: string;
+    name: string;
+  };
+  eventId?: string;
+  error?: string;
+}
+
+export interface ScheduledQueryListItem {
+  id: string;
+  name: string;
+  connectionId?: string;
+  databaseId?: string;
+  databaseName?: string;
+  schedule?: {
+    cron: string;
+    timezone: string;
+  };
+  scheduledRun?: ConsoleContentResponse["scheduledRun"];
+  access?: "private" | "workspace";
+  owner_id?: string;
+  updatedAt?: string;
+}
+
+export interface ScheduledQueryListResponse {
+  success: boolean;
+  scheduledQueries: ScheduledQueryListItem[];
 }
 
 // ==================== Query Execution Endpoints ====================

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -43,6 +43,7 @@ interface ConsoleActions {
   updateContent: (id: string, content: string) => void;
   updateTitle: (id: string, title: string) => void;
   updateDirty: (id: string, isDirty: boolean) => void;
+  updateMetadata: (id: string, metadata?: Record<string, unknown>) => void;
   updateIcon: (id: string, icon: string) => void;
   updateConnection: (id: string, connectionId?: string) => void;
   updateDatabase: (
@@ -66,7 +67,11 @@ interface ConsoleActions {
   getVersionManager: (consoleId: string) => ConsoleVersionManager | null;
 
   // API operations
-  loadConsole: (workspaceId: string, consoleId: string) => Promise<void>;
+  loadConsole: (
+    workspaceId: string,
+    consoleId: string,
+    options?: { openScheduledRuns?: boolean },
+  ) => Promise<void>;
   reloadConsole: (workspaceId: string, consoleId: string) => Promise<void>;
   fetchConsoleContent: (
     workspaceId: string,
@@ -317,6 +322,18 @@ export const useConsoleStore = create<ConsoleStore>()(
           }
         }),
 
+      updateMetadata: (id, metadata) =>
+        set(state => {
+          const tab = state.tabs[id];
+          if (tab) {
+            if (metadata && Object.keys(metadata).length > 0) {
+              tab.metadata = metadata;
+            } else {
+              delete tab.metadata;
+            }
+          }
+        }),
+
       updateIcon: (id, icon) =>
         set(state => {
           const tab = state.tabs[id];
@@ -379,9 +396,16 @@ export const useConsoleStore = create<ConsoleStore>()(
       getVersionManager: consoleId => versionManagers.get(consoleId) || null,
 
       // API operations
-      loadConsole: async (workspaceId, consoleId) => {
+      loadConsole: async (workspaceId, consoleId, options) => {
         // Check if console is already loaded
         if (get().tabs[consoleId]) {
+          if (options?.openScheduledRuns) {
+            const existingMetadata = get().tabs[consoleId].metadata;
+            get().updateMetadata(consoleId, {
+              ...(existingMetadata || {}),
+              openScheduledRuns: true,
+            });
+          }
           get().setActiveTab(consoleId);
           return;
         }
@@ -418,6 +442,9 @@ export const useConsoleStore = create<ConsoleStore>()(
               access: res.access,
               owner_id: res.owner_id,
               readOnly: res.readOnly,
+              metadata: options?.openScheduledRuns
+                ? { openScheduledRuns: true }
+                : undefined,
             });
             get().setActiveTab(res.id);
           } else {

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -12,6 +12,8 @@ import type {
   ConsoleSaveResponse,
   QueryCancelResponse,
   QueryExecuteResponse,
+  ScheduledQueryRunsResponse,
+  ScheduledQueryScheduleResponse,
 } from "../lib/api-types";
 
 interface ConsoleState {
@@ -135,6 +137,24 @@ interface ConsoleActions {
     },
     signal?: AbortSignal,
   ) => Promise<{ comment: string | null; diff: string | null }>;
+  setSchedule: (
+    workspaceId: string,
+    consoleId: string,
+    input: { name: string; cron: string; timezone: string },
+  ) => Promise<ScheduledQueryScheduleResponse>;
+  removeSchedule: (
+    workspaceId: string,
+    consoleId: string,
+  ) => Promise<{ success: boolean; error?: string }>;
+  runScheduledNow: (
+    workspaceId: string,
+    consoleId: string,
+  ) => Promise<ScheduledQueryScheduleResponse>;
+  listScheduledRuns: (
+    workspaceId: string,
+    consoleId: string,
+    limit?: number,
+  ) => Promise<ScheduledQueryRunsResponse>;
 }
 
 type ConsoleStore = ConsoleState & ConsoleActions;
@@ -393,6 +413,11 @@ export const useConsoleStore = create<ConsoleStore>()(
               kind: "console",
               chartSpec: res.chartSpec,
               resultsViewMode: res.resultsViewMode,
+              schedule: res.schedule,
+              scheduledRun: res.scheduledRun,
+              access: res.access,
+              owner_id: res.owner_id,
+              readOnly: res.readOnly,
             });
             get().setActiveTab(res.id);
           } else {
@@ -465,6 +490,8 @@ export const useConsoleStore = create<ConsoleStore>()(
                 tab.access = res.access;
                 tab.owner_id = res.owner_id;
                 tab.readOnly = res.readOnly;
+                tab.schedule = res.schedule;
+                tab.scheduledRun = res.scheduledRun;
               }
             });
 
@@ -681,6 +708,89 @@ export const useConsoleStore = create<ConsoleStore>()(
             : { comment: null, diff: null };
         } catch {
           return { comment: null, diff: null };
+        }
+      },
+
+      setSchedule: async (workspaceId, consoleId, input) => {
+        try {
+          const response = await apiClient.put<ScheduledQueryScheduleResponse>(
+            `/workspaces/${workspaceId}/consoles/${consoleId}/schedule`,
+            input,
+          );
+
+          if (response.success) {
+            set(state => {
+              const tab = state.tabs[consoleId];
+              if (tab) {
+                tab.title = response.console?.name || input.name;
+                tab.schedule = response.schedule;
+                tab.scheduledRun = response.scheduledRun;
+              }
+            });
+          }
+
+          return response;
+        } catch (e) {
+          return {
+            success: false,
+            error: e instanceof Error ? e.message : "Failed to update schedule",
+          } as ScheduledQueryScheduleResponse;
+        }
+      },
+
+      removeSchedule: async (workspaceId, consoleId) => {
+        try {
+          const response = await apiClient.delete<{
+            success: boolean;
+            error?: string;
+          }>(`/workspaces/${workspaceId}/consoles/${consoleId}/schedule`);
+
+          if (response.success) {
+            set(state => {
+              const tab = state.tabs[consoleId];
+              if (tab) {
+                delete tab.schedule;
+                if (tab.scheduledRun) {
+                  delete tab.scheduledRun.nextAt;
+                }
+              }
+            });
+          }
+
+          return response;
+        } catch (e) {
+          return {
+            success: false,
+            error: e instanceof Error ? e.message : "Failed to remove schedule",
+          };
+        }
+      },
+
+      runScheduledNow: async (workspaceId, consoleId) => {
+        try {
+          return await apiClient.post<ScheduledQueryScheduleResponse>(
+            `/workspaces/${workspaceId}/consoles/${consoleId}/schedule/run`,
+          );
+        } catch (e) {
+          return {
+            success: false,
+            error: e instanceof Error ? e.message : "Failed to run schedule",
+          } as ScheduledQueryScheduleResponse;
+        }
+      },
+
+      listScheduledRuns: async (workspaceId, consoleId, limit = 50) => {
+        try {
+          return await apiClient.get<ScheduledQueryRunsResponse>(
+            `/workspaces/${workspaceId}/consoles/${consoleId}/schedule/runs`,
+            { limit: String(limit) },
+          );
+        } catch (e) {
+          return {
+            success: false,
+            runs: [],
+            error: e instanceof Error ? e.message : "Failed to load runs",
+          } as ScheduledQueryRunsResponse & { error?: string };
         }
       },
 

--- a/app/src/store/lib/types.ts
+++ b/app/src/store/lib/types.ts
@@ -77,6 +77,21 @@ export interface ConsoleTab {
   owner_id?: string;
   /** True if the current user can only read (not edit) this console */
   readOnly?: boolean;
+  schedule?: {
+    cron: string;
+    timezone: string;
+  };
+  scheduledRun?: {
+    nextAt?: string;
+    lastAt?: string;
+    lastStatus?: "success" | "error";
+    lastError?: string;
+    lastDurationMs?: number;
+    lastRowsAffected?: number;
+    lastRowCount?: number;
+    runCount: number;
+    consecutiveFailures: number;
+  };
 }
 
 /**


### PR DESCRIPTION
## Why
We need scheduled queries as a first-class product surface for derived tables and recurring SQL execution, but without introducing a separate editor or duplicate query source of truth.

This implementation deliberately keeps the UX and model simple:
- a scheduled query is a saved console plus schedule metadata
- users always edit the query in the normal console experience
- the Flows sidebar surfaces scheduled queries alongside other flow types
- execution is handled by Inngest so scheduled runs use the same production scheduling infrastructure as the rest of the app

## Product / UX architecture
### Core UX decision
The central design decision is **"scheduled query = saved console + schedule"**, not a standalone document with its own editor.

That gives us:
- one place to author and update SQL
- no query drift between console content and scheduled execution
- a lighter mental model for users: open console, save query, add schedule
- a future path for v2 features like destinations and notifications without reworking the query authoring flow

### User flow
1. User creates or opens a normal saved console.
2. User clicks `Schedule` in the console toolbar.
3. User configures:
   - name
   - cron schedule
   - timezone
4. Saved console gets schedule metadata.
5. Scheduled query appears in `Flows > Scheduled Query`.
6. Clicking it opens the same console experience, with scheduled runs available from the scheduled-query surface.
7. `Run now` and historical runs are available from that same surface.

### Flows sidebar design
`FlowsExplorer` was refactored to use the shared `ResourceTree` / sticky section header pattern rather than a flat list.

Sections are now grouped by flow type:
- Connector Sync
- Webhook
- DB Sync
- CDC
- Scheduled Query

This keeps scheduled queries visually consistent with the rest of the product and avoids inventing another explorer paradigm.

## Backend architecture
### Data model
Scheduled query state is stored on `SavedConsole` in `api/src/database/workspace-schema.ts`:
- `schedule`
  - `cron`
  - `timezone`
- `scheduledRun`
  - `nextAt`
  - `lastAt`
  - `lastStatus`
  - `lastError`
  - `lastDurationMs`
  - `lastRowsAffected`
  - `lastRowCount`
  - `runCount`
  - `consecutiveFailures`

This is the denormalized "current state" needed for fast UI rendering.

Historical executions are stored separately in the new `ScheduledQueryRun` collection:
- `workspaceId`
- `consoleId`
- `triggeredAt`
- `startedAt`
- `completedAt`
- `status`
- `triggerType`
- `triggeredBy`
- `durationMs`
- `rowsAffected`
- `rowCount`
- `error`
- `inngestRunId`

This separation keeps the console document small while still giving us run history, debugging, and future observability hooks.

### API surface
Two API layers were added:

#### Console-scoped schedule operations
In `api/src/routes/consoles.ts`:
- `PUT /api/workspaces/:workspaceId/consoles/:id/schedule`
- `DELETE /api/workspaces/:workspaceId/consoles/:id/schedule`
- `POST /api/workspaces/:workspaceId/consoles/:id/schedule/run`
- `GET /api/workspaces/:workspaceId/consoles/:id/schedule/runs`

These are used by the console editor UX.

#### Workspace-wide scheduled query listing
In `api/src/routes/scheduled-queries.ts`:
- `GET /api/workspaces/:workspaceId/scheduled-queries`

This endpoint exists specifically to drive the `Scheduled Query` section in the Flows sidebar without forcing the frontend to derive it from the consoles tree.

### Security model
Scheduled query management is admin-only in v1.

A dedicated middleware was added in `api/src/middleware/workspace-admin.middleware.ts` and is applied to schedule mutating routes.

That means:
- any workspace member can still read/open the underlying console according to console access rules
- only workspace admins/owners can create, update, delete, or manually trigger schedules

This keeps v1 operationally safe while avoiding premature per-schedule ACL complexity.

## Scheduling / execution architecture
### Inngest functions
A new file `api/src/inngest/functions/scheduled-query.ts` adds two functions:

#### 1. Scheduler
`scheduledQuerySchedulerFunction`
- runs every minute
- scans saved consoles whose `scheduledRun.nextAt <= now`
- atomically advances `scheduledRun.nextAt`
- emits `scheduled_query/execute` events

Why this design:
- avoids creating one Inngest cron per query
- centralizes scheduling logic
- supports future scale controls in one place

#### 2. Executor
`scheduledQueryExecutorFunction`
- handles `scheduled_query/execute`
- concurrency limited by `consoleId`
- creates a `ScheduledQueryRun`
- loads the latest saved console content
- executes against the referenced database connection
- updates run history
- updates denormalized `scheduledRun` fields on `SavedConsole`
- tracks analytics via `QueryExecution.source = scheduled_query`

### Live query resolution
Execution resolves SQL from `SavedConsole.code` at run time.

That means:
- editing and saving the console changes the next scheduled run automatically
- there is no separate SQL snapshot document in v1
- the saved console remains the source of truth

This was chosen intentionally to keep v1 simple and aligned with the product goal of "schedule the query I already have in the editor".

### Cron helpers
`api/src/services/scheduled-query-schedule.service.ts` centralizes:
- normalization
- validation
- next-run calculation
- upcoming-run previews

This keeps cron behavior consistent between backend scheduling and frontend UX previews.

## Inngest configuration and deploy model
### Runtime registration
The Inngest endpoint is mounted at `GET|PUT|POST /api/inngest` in `api/src/index.ts` via `serveInngest({ client: inngest, functions: getFunctions() })`.

That means the app registers its function set from a single place, and deploy sync is just an HTTP `PUT` to the app's own `/api/inngest` endpoint.

### Which functions run in which environment
`api/src/inngest/index.ts` intentionally splits function registration by environment:
- `scheduledQueryExecutorFunction` is always included in `baseFunctions`
- `scheduledQuerySchedulerFunction` is only included when:
  - `NODE_ENV === production`
  - `DISABLE_SCHEDULED_SYNC !== true`

This is important because it gives us the desired operational behavior:
- local dev: manual execution works through the executor, but cron schedulers stay off
- PR previews: manual execution works, but cron schedulers stay off for cost/safety
- production: both executor and scheduler are active

### Preview deploy behavior
PR previews are configured to use a branch-scoped Inngest environment in `.github/workflows/deploy-app.yml`:
- `INNGEST_ENV=pr-<number>`
- `INNGEST_EVENT_KEY=<shared event key>`
- `INNGEST_SIGNING_KEY=<branch signing key>`
- `DISABLE_SCHEDULED_SYNC=true`
- `INNGEST_SERVE_PATH=/api/inngest`

After Cloud Run deploy, the workflow explicitly calls `PUT <preview-url>/api/inngest` to sync that preview app into the branch environment.

Net effect:
- preview apps have isolated Inngest routing and logs
- preview apps can still process manual `Run now` events
- cron schedulers do not fan out automatically in preview

### Production deploy behavior
Production deploy sets:
- `INNGEST_EVENT_KEY`
- `INNGEST_SIGNING_KEY`
- `INNGEST_SERVE_ORIGIN=<cloud-run-url>`
- `INNGEST_SERVE_PATH=/api/inngest`
- `NODE_ENV=production`

Then the workflow explicitly calls `PUT <cloud-run-url>/api/inngest` after deploy to register/sync the app's current function set.

Because production does **not** set `DISABLE_SCHEDULED_SYNC=true`, the scheduler function is included there, so scheduled queries run automatically only in production.

### Local development behavior
Local dev uses `pnpm dev`, which starts the API, app, and `inngest-cli dev` as documented in `INNGEST_DEV_CONFIG.md`.

This gives us a safe local loop:
- `/api/inngest` still exists locally
- manual event-driven execution can be exercised through the local dev server
- automatic cron scheduling is intentionally disabled by environment gating

### Confidence level
The configuration looks correct based on code and deploy wiring:
- endpoint mounted correctly
- executor always registered
- scheduler production-gated intentionally
- preview deploy syncs branch environments correctly
- production deploy syncs the live app correctly

The remaining caveat is operational rather than architectural: full proof of the cron path still requires observing one production-like scheduled run with schedulers enabled. Manual `Run now` is the best verification path in local/preview because that hits the same executor function used in production.

## Frontend architecture
### Console integration
The editor now owns the scheduled-query UX:
- `app/src/components/Console.tsx`
  - adds `Schedule` dropdown in the toolbar
- `app/src/components/ScheduleConsoleModal.tsx`
  - create/update schedule form
- `app/src/components/Editor.tsx`
  - wires modal open/close
  - saves schedule
  - runs manual trigger
  - loads and renders run history
- `app/src/components/ScheduledRunsPanel.tsx`
  - run history table in the bottom pane

The key architecture point is that **we did not build a separate scheduled-query editor**.

### Store / type changes
- `app/src/store/consoleStore.ts`
  - added schedule CRUD helpers
  - added run history fetch helper
- `app/src/lib/api-types.ts`
  - added scheduled query list / run / schedule response types
- `app/src/store/lib/types.ts`
  - extended console tab shape with schedule metadata

### Flows integration
`app/src/components/FlowsExplorer.tsx` now:
- fetches scheduled query list from the new backend endpoint
- merges that conceptually into the flows navigation surface
- opens scheduled query items in the console/scheduled-query experience

This keeps authoring in the console while discovery/operations live in Flows.

## Migration / rollout notes
### Migration
Added `api/src/migrations/2026-04-22-120000_create_scheduled_query_runs.ts` to:
- create `scheduled_query_runs`
- add execution history indexes
- add the `savedconsoles` next-run index

### Query analytics
`QueryExecution.source` now includes `scheduled_query`, so scheduled runs show up in the same execution analytics stream as console / API / flow runs.

## Tradeoffs / explicit non-goals in v1
This PR intentionally does **not** implement:
- multiple schedules per console
- query snapshotting per run
- destination table configuration
- notifications
- pause/resume beyond deleting the schedule
- parameterized scheduled runs
- non-admin schedule management

Those are valid v2 directions, but they all add complexity to the model and UX. This PR optimizes for shipping a coherent, minimal architecture first.

## Files of interest
Backend:
- `api/src/database/workspace-schema.ts`
- `api/src/routes/consoles.ts`
- `api/src/routes/scheduled-queries.ts`
- `api/src/inngest/functions/scheduled-query.ts`
- `api/src/inngest/index.ts`
- `api/src/services/scheduled-query-schedule.service.ts`
- `api/src/middleware/workspace-admin.middleware.ts`
- `api/src/migrations/2026-04-22-120000_create_scheduled_query_runs.ts`
- `.github/workflows/deploy-app.yml`
- `INNGEST_DEV_CONFIG.md`

Frontend:
- `app/src/components/Console.tsx`
- `app/src/components/Editor.tsx`
- `app/src/components/FlowsExplorer.tsx`
- `app/src/components/ScheduleConsoleModal.tsx`
- `app/src/components/ScheduledRunsPanel.tsx`
- `app/src/store/consoleStore.ts`
- `app/src/lib/api-types.ts`

## Test plan
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm app:build`
- [x] `pnpm api:build`
- [ ] Create a saved console, add a schedule, and verify it appears under `Flows > Scheduled Query`
- [ ] Trigger `Run now` from the schedule modal and verify a run appears in the console scheduled-query surface
- [ ] Confirm scheduled execution picks up saved console edits on the next run
- [ ] Verify only workspace admins can mutate schedules
- [ ] Verify preview deploy registers its branch Inngest app but does not run cron schedulers automatically