### PR TITLE
Reduce app render churn and refine tool cards

### DIFF
--- a/.cursor/skills/react-render-profiling/SKILL.md
+++ b/.cursor/skills/react-render-profiling/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: react-render-profiling
+description: Investigate React render performance in the Mako app using React Scan, render-debug logs, and existing memoization contracts. Use when profiling render churn, slow chat streaming, Monaco console responsiveness, explorer/result table lag, or when the user mentions React Scan.
+---
+
+# React Render Profiling
+
+## Quick Start
+
+Use this workflow for frontend render-performance investigations in `app/`:
+
+1. Start the frontend profiler:
+
+   ```bash
+   pnpm run app:dev:scan
+   ```
+
+2. Open `http://localhost:5173` and reproduce the interaction.
+3. Watch React Scan overlays for re-render hotspots.
+4. Check browser console logs prefixed with `[render-debug]` for why instrumented components changed.
+5. Patch the smallest unstable boundary, then verify with focused tests plus app lint/typecheck.
+
+## Instrumentation
+
+- `VITE_REACT_SCAN=true` enables the React Scan Vite plugin.
+- `VITE_RENDER_DEBUG=true` enables Mako's `renderDebug` helpers.
+- Normal `pnpm run app:dev` keeps both off. Do not make profiling instrumentation active by default.
+
+## Mako Hot Paths
+
+Prioritize these areas when render churn appears:
+
+- `app/src/components/Chat.tsx`: streaming messages, tool cards, input area.
+- `app/src/components/StreamingToolCard.tsx`: terminal tool-card memo comparator and expandable previews.
+- `app/src/components/ResourceTree.tsx`: stable callbacks from explorers and tree props.
+- `app/src/components/Editor.tsx` and `Console.tsx`: Monaco tab/panel re-renders.
+- `app/src/components/ResultsTable.tsx`: stable grid props and result view resets.
+- `app/src/store/consoleStore.ts`: avoid no-op Zustand writes that still notify subscribers.
+
+## Rules
+
+- Keep `useChat({ experimental_throttle: 50 })` in `Chat.tsx`.
+- Avoid selectors that return fresh objects/arrays in hot components unless wrapped with `useShallow`.
+- For callback-only dynamic values, prefer refs or `useConsoleStore.getState()` at invocation time over object dependencies.
+- Do not replace `use-stick-to-bottom` with a `useEffect([messages])` scroll implementation.
+- Keep debug hooks and React Scan gated by env flags.
+
+## Verification
+
+For chat/render-boundary changes, run:
+
+```bash
+pnpm --filter app exec vitest run src/components/__tests__/Chat.perf.test.ts
+pnpm --filter app run typecheck
+pnpm --filter app run lint
+```
+
+Add focused tests for any new comparator or truncation behavior that could silently regress.

--- a/README.md
+++ b/README.md
@@ -187,15 +187,28 @@ This IP is used by Mako's cloud service for all outbound database connections.
 
 ## 💻 Development Commands
 
-| Command              | Description                                 |
-| -------------------- | ------------------------------------------- |
-| `pnpm run dev`       | Start API, frontend, and Inngest dev server |
-| `pnpm run sync`      | Run the interactive sync tool               |
-| `pnpm run migrate`   | Run database migrations                     |
-| `pnpm run docker:up` | Start MongoDB and other services            |
-| `pnpm run test`      | Run test suite                              |
-| `pnpm run build`     | Build all packages                          |
-| `pnpm run docs:dev`  | Start documentation site locally            |
+| Command                 | Description                                                   |
+| ----------------------- | ------------------------------------------------------------- |
+| `pnpm run dev`          | Start API, frontend, and Inngest dev server                   |
+| `pnpm run app:dev:scan` | Start the frontend with React Scan and render debug logging   |
+| `pnpm run sync`         | Run the interactive sync tool                                 |
+| `pnpm run migrate`      | Run database migrations                                       |
+| `pnpm run docker:up`    | Start MongoDB and other services                              |
+| `pnpm run test`         | Run test suite                                                |
+| `pnpm run build`        | Build all packages                                            |
+| `pnpm run docs:dev`     | Start documentation site locally                              |
+
+## 🔎 React Performance Profiling
+
+Use React Scan when working on render churn, streaming chat responsiveness, Monaco console performance, or explorer/result table interactions:
+
+```bash
+pnpm run app:dev:scan
+```
+
+This enables the React Scan Vite plugin via `VITE_REACT_SCAN=true` and turns on Mako's render-debug logs via `VITE_RENDER_DEBUG=true`. React Scan highlights components that re-render in the browser, while render-debug logs summarize why hot components such as `Chat`, `ResourceTree`, `Console`, and `ResultsTable` changed.
+
+Keep React Scan off during normal development. The plugin and debug hooks are gated behind env flags so regular `pnpm run app:dev` runs without profiling overlays or extra debug logging.
 
 ## 🤝 Community & Support
 

--- a/app/package.json
+++ b/app/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:scan": "VITE_REACT_SCAN=true VITE_RENDER_DEBUG=true vite",
     "build": "pnpm run lint && tsc --noEmit && vite build",
     "test:unit": "vitest run",
     "typecheck": "tsc --noEmit",

--- a/app/package.json
+++ b/app/package.json
@@ -56,6 +56,7 @@
     "zustand": "^5.0.5"
   },
   "devDependencies": {
+    "@react-scan/vite-plugin-react-scan": "^0.2.3",
     "@tailwindcss/vite": "^4.1.18",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
@@ -67,6 +68,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
+    "react-scan": "^0.5.3",
     "tailwindcss": "^4.1.18",
     "typescript": "^5.2.2",
     "vite": "^5.0.8",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -33,7 +33,9 @@ import {
   type ImperativePanelHandle,
 } from "react-resizable-panels";
 import Chat from "./components/Chat";
-import DatabaseExplorer from "./components/DatabaseExplorer";
+import DatabaseExplorer, {
+  type CollectionInfo,
+} from "./components/DatabaseExplorer";
 import ConsoleExplorer from "./components/ConsoleExplorer";
 import DataSourceExplorer from "./components/ConnectorExplorer";
 import Editor from "./components/Editor";
@@ -237,216 +239,228 @@ function MainApp() {
   >(null);
 
   // Handle console modification from AI
-  const handleConsoleModification = async (
-    modification: ConsoleModificationPayload,
-  ) => {
-    // handleConsoleModification called
+  const handleConsoleModification = useCallback(
+    async (modification: ConsoleModificationPayload) => {
+      // handleConsoleModification called
 
-    const { tabs, activeTabId, openTab, setActiveTab } =
-      useConsoleStore.getState();
-    const consoleTabs = Object.values(tabs);
-    const activeConsoleId = activeTabId;
+      const { tabs, activeTabId, openTab, setActiveTab } =
+        useConsoleStore.getState();
+      const consoleTabs = Object.values(tabs);
+      const activeConsoleId = activeTabId;
 
-    const realConsoleTabs = (consoleTabs || []).filter(
-      (t: any) => t?.kind === undefined || t?.kind === "console",
-    );
-    const activeRealConsoleId = realConsoleTabs.some(
-      (t: any) => t.id === activeConsoleId,
-    )
-      ? activeConsoleId
-      : null;
+      const realConsoleTabs = (consoleTabs || []).filter(
+        (t: any) => t?.kind === undefined || t?.kind === "console",
+      );
+      const activeRealConsoleId = realConsoleTabs.some(
+        (t: any) => t.id === activeConsoleId,
+      )
+        ? activeConsoleId
+        : null;
 
-    // Handle console creation
-    if (modification.action === "create" && modification.title) {
-      const newConsoleId = openTab({
-        id: modification.consoleId,
-        title: modification.title,
-        content: modification.content || "",
-        connectionId: modification.connectionId,
-        databaseId: modification.databaseId,
-        databaseName: modification.databaseName,
-        kind: "console",
-        isDirty: modification.isDirty ?? true, // Agent-created consoles are dirty by default
-      });
-      setActiveTab(newConsoleId);
-      return;
-    }
-
-    // Use the provided consoleId if available, otherwise use the active console
-    let targetConsoleId = modification.consoleId || activeRealConsoleId;
-    let isNewConsole = false;
-
-    // If a consoleId was explicitly provided by the agent, trust it - the console was just created
-    // and may not be in realConsoleTabs yet due to React state update timing.
-    // Only fall back if no explicit consoleId was provided AND the resolved ID doesn't exist.
-    if (
-      !modification.consoleId &&
-      targetConsoleId &&
-      !realConsoleTabs.some((t: any) => t.id === targetConsoleId)
-    ) {
-      targetConsoleId = activeRealConsoleId;
-    }
-
-    if (!targetConsoleId) {
-      // If no active console, try to open one
-      if (realConsoleTabs.length > 0) {
-        // Focus the first available real console
-        targetConsoleId = realConsoleTabs[0].id;
-        setActiveTab(targetConsoleId);
-      } else {
-        // Create a new console if none exist
-        isNewConsole = true;
-        const id = openTab({
-          title: "AI Query",
-          content: "",
+      // Handle console creation
+      if (modification.action === "create" && modification.title) {
+        const newConsoleId = openTab({
+          id: modification.consoleId,
+          title: modification.title,
+          content: modification.content || "",
+          connectionId: modification.connectionId,
+          databaseId: modification.databaseId,
+          databaseName: modification.databaseName,
+          kind: "console",
+          isDirty: modification.isDirty ?? true, // Agent-created consoles are dirty by default
         });
-        targetConsoleId = id;
-        setActiveTab(id);
+        setActiveTab(newConsoleId);
+        return;
       }
-    }
 
-    // If we just created a new console, wait a bit for it to mount
-    if (isNewConsole) {
-      // wait for mount
-      await new Promise(resolve => setTimeout(resolve, 200));
-    }
+      // Use the provided consoleId if available, otherwise use the active console
+      let targetConsoleId = modification.consoleId || activeRealConsoleId;
+      let isNewConsole = false;
 
-    // using console ID
+      // If a consoleId was explicitly provided by the agent, trust it - the console was just created
+      // and may not be in realConsoleTabs yet due to React state update timing.
+      // Only fall back if no explicit consoleId was provided AND the resolved ID doesn't exist.
+      if (
+        !modification.consoleId &&
+        targetConsoleId &&
+        !realConsoleTabs.some((t: any) => t.id === targetConsoleId)
+      ) {
+        targetConsoleId = activeRealConsoleId;
+      }
 
-    // Dispatch a custom event that the Editor component can listen to
-    const event = new CustomEvent("console-modification", {
-      detail: { consoleId: targetConsoleId, modification },
-    });
-    window.dispatchEvent(event);
-  };
+      if (!targetConsoleId) {
+        // If no active console, try to open one
+        if (realConsoleTabs.length > 0) {
+          // Focus the first available real console
+          targetConsoleId = realConsoleTabs[0].id;
+          setActiveTab(targetConsoleId);
+        } else {
+          // Create a new console if none exist
+          isNewConsole = true;
+          const id = openTab({
+            title: "AI Query",
+            content: "",
+          });
+          targetConsoleId = id;
+          setActiveTab(id);
+        }
+      }
 
-  const openOrFocusConsoleTab = (
-    title: string,
-    content: string,
-    connectionId?: string, // DatabaseConnection ID (renamed from databaseId)
-    filePath?: string,
-    consoleId?: string, // Add optional consoleId parameter
-    isPlaceholder?: boolean,
-    queryOptions?: Record<string, any>, // Options to pass when executing (e.g., D1 databaseId)
-    explicitDatabaseId?: string, // Explicit database ID (e.g., D1 UUID from saved console)
-    explicitDatabaseName?: string, // Explicit database name from saved console
-  ) => {
-    // For existing consoles, use the server ID as the tab ID
-    const tabId = consoleId || generateObjectId();
+      // If we just created a new console, wait a bit for it to mount
+      if (isNewConsole) {
+        // wait for mount
+        await new Promise(resolve => setTimeout(resolve, 200));
+      }
 
-    const { tabs, setActiveTab, openTab, updateContent } =
-      useConsoleStore.getState();
-    const consoleTabs = Object.values(tabs);
+      // using console ID
 
-    // Check if a tab with this ID already exists
-    const existing = consoleTabs.find(t => t.id === tabId);
+      // Dispatch a custom event that the Editor component can listen to
+      const event = new CustomEvent("console-modification", {
+        detail: { consoleId: targetConsoleId, modification },
+      });
+      window.dispatchEvent(event);
+    },
+    [],
+  );
 
-    if (existing) {
-      // Tab already exists, just focus it
-      setActiveTab(existing.id);
-      // Update the content in case it changed on the server
-      updateContent(existing.id, content);
-      return;
-    }
+  const openOrFocusConsoleTab = useCallback(
+    (
+      title: string,
+      content: string,
+      connectionId?: string, // DatabaseConnection ID (renamed from databaseId)
+      filePath?: string,
+      consoleId?: string, // Add optional consoleId parameter
+      isPlaceholder?: boolean,
+      queryOptions?: Record<string, any>, // Options to pass when executing (e.g., D1 databaseId)
+      explicitDatabaseId?: string, // Explicit database ID (e.g., D1 UUID from saved console)
+      explicitDatabaseName?: string, // Explicit database name from saved console
+    ) => {
+      // For existing consoles, use the server ID as the tab ID
+      const tabId = consoleId || generateObjectId();
 
-    // Use explicit values if provided, otherwise extract from queryOptions (tree node metadata)
-    // databaseId: used for selector value, saving to DB, and API calls (UUID for D1, name for MongoDB/PostgreSQL)
-    // databaseName: used for display in selector (human-readable name, falls back to databaseId)
-    const databaseId =
-      explicitDatabaseId ||
-      queryOptions?.databaseId ||
-      queryOptions?.databaseName;
-    const databaseName =
-      explicitDatabaseName || queryOptions?.databaseName || databaseId;
+      const { tabs, setActiveTab, openTab, updateContent } =
+        useConsoleStore.getState();
+      const consoleTabs = Object.values(tabs);
 
-    // Create a new tab with the determined ID
-    // If consoleId is provided, this is an existing saved console from the database
-    // Set isSaved=true to prevent auto-save (especially important for placeholder content)
-    const isExistingSavedConsole = !!consoleId;
-    const id = openTab({
-      id: tabId, // Pass the ID explicitly
-      title,
-      content,
-      connectionId,
-      databaseId, // D1 database UUID or other DB-specific ID
-      databaseName, // Human-readable database name
-      // If placeholder, defer setting filePath so savedStateHash isn't computed
-      filePath: isPlaceholder ? undefined : filePath,
-      // Mark as saved if this is an existing console to prevent auto-save of placeholder content
-      isSaved: isExistingSavedConsole,
-      // Store query execution options for backward compatibility
-      metadata: queryOptions ? { queryOptions } : undefined,
-    });
-    setActiveTab(id);
-  };
+      // Check if a tab with this ID already exists
+      const existing = consoleTabs.find(t => t.id === tabId);
+
+      if (existing) {
+        // Tab already exists, just focus it
+        setActiveTab(existing.id);
+        // Never replace an already-open console with placeholder content while
+        // the background fetch is in flight. The eventual fetch update is guarded
+        // by no-op store writes, so repeated explorer clicks stay cheap.
+        if (!isPlaceholder && existing.content !== content) {
+          updateContent(existing.id, content);
+        }
+        return;
+      }
+
+      // Use explicit values if provided, otherwise extract from queryOptions (tree node metadata)
+      // databaseId: used for selector value, saving to DB, and API calls (UUID for D1, name for MongoDB/PostgreSQL)
+      // databaseName: used for display in selector (human-readable name, falls back to databaseId)
+      const databaseId =
+        explicitDatabaseId ||
+        queryOptions?.databaseId ||
+        queryOptions?.databaseName;
+      const databaseName =
+        explicitDatabaseName || queryOptions?.databaseName || databaseId;
+
+      // Create a new tab with the determined ID
+      // If consoleId is provided, this is an existing saved console from the database
+      // Set isSaved=true to prevent auto-save (especially important for placeholder content)
+      const isExistingSavedConsole = !!consoleId;
+      const id = openTab({
+        id: tabId, // Pass the ID explicitly
+        title,
+        content,
+        connectionId,
+        databaseId, // D1 database UUID or other DB-specific ID
+        databaseName, // Human-readable database name
+        // If placeholder, defer setting filePath so savedStateHash isn't computed
+        filePath: isPlaceholder ? undefined : filePath,
+        // Mark as saved if this is an existing console to prevent auto-save of placeholder content
+        isSaved: isExistingSavedConsole,
+        // Store query execution options for backward compatibility
+        metadata: queryOptions ? { queryOptions } : undefined,
+      });
+      setActiveTab(id);
+    },
+    [],
+  );
+
+  const handleDatabaseCollectionClick = useCallback(
+    async (dbId: string, collection: CollectionInfo) => {
+      // Try server-provided template first
+      let prefill = `db.getCollection("${collection.name}").find({}).limit(500)`;
+      try {
+        const { useSchemaStore } = await import("./store/schemaStore");
+        const workspaceId = localStorage.getItem("activeWorkspaceId");
+        if (workspaceId) {
+          const tpl = await useSchemaStore
+            .getState()
+            .fetchConsoleTemplate(workspaceId, dbId, {
+              id: collection.name,
+              kind: collection.type || "collection",
+              metadata: collection.options as Record<string, unknown>,
+            });
+          if (tpl?.template) prefill = tpl.template;
+        }
+      } catch {
+        // If server call fails, fallback to type-based default
+        const kind = (collection.type || "").toLowerCase();
+        if (kind !== "collection" && kind !== "view") {
+          prefill = `SELECT * FROM ${collection.name} LIMIT 500;`;
+        }
+      }
+      openOrFocusConsoleTab(
+        collection.name,
+        prefill,
+        dbId, // connectionId
+        undefined, // filePath
+        undefined, // consoleId
+        undefined, // isPlaceholder
+        collection.options as Record<string, unknown> | undefined, // queryOptions - contains D1 databaseName (UUID), MongoDB dbName, etc.
+      );
+    },
+    [openOrFocusConsoleTab],
+  );
+
+  const handleConsoleSelect = useCallback(
+    (
+      path: string,
+      content: string,
+      connectionId?: string,
+      consoleId?: string,
+      isPlaceholder?: boolean,
+      databaseId?: string,
+      databaseName?: string,
+    ) => {
+      openOrFocusConsoleTab(
+        path,
+        content,
+        connectionId,
+        path,
+        consoleId,
+        isPlaceholder,
+        undefined, // queryOptions - not needed for saved consoles
+        databaseId,
+        databaseName,
+      );
+    },
+    [openOrFocusConsoleTab],
+  );
 
   // Left pane content renderer
   const renderLeftPane = () => {
     switch (activeView) {
       case "databases":
         return (
-          <DatabaseExplorer
-            onCollectionClick={async (dbId, collection) => {
-              // Try server-provided template first
-              let prefill = `db.getCollection("${collection.name}").find({}).limit(500)`;
-              try {
-                const { useSchemaStore } = await import("./store/schemaStore");
-                const workspaceId = localStorage.getItem("activeWorkspaceId");
-                if (workspaceId) {
-                  const tpl = await useSchemaStore
-                    .getState()
-                    .fetchConsoleTemplate(workspaceId, dbId, {
-                      id: collection.name,
-                      kind: collection.type || "collection",
-                      metadata: collection.options as Record<string, unknown>,
-                    });
-                  if (tpl?.template) prefill = tpl.template;
-                }
-              } catch {
-                // If server call fails, fallback to type-based default
-                const kind = (collection.type || "").toLowerCase();
-                if (kind !== "collection" && kind !== "view") {
-                  prefill = `SELECT * FROM ${collection.name} LIMIT 500;`;
-                }
-              }
-              openOrFocusConsoleTab(
-                collection.name,
-                prefill,
-                dbId, // connectionId
-                undefined, // filePath
-                undefined, // consoleId
-                undefined, // isPlaceholder
-                collection.options as Record<string, unknown> | undefined, // queryOptions - contains D1 databaseName (UUID), MongoDB dbName, etc.
-              );
-            }}
-          />
+          <DatabaseExplorer onCollectionClick={handleDatabaseCollectionClick} />
         );
       case "consoles":
-        return (
-          <ConsoleExplorer
-            onConsoleSelect={(
-              path,
-              content,
-              connectionId,
-              consoleId,
-              isPlaceholder,
-              databaseId,
-              databaseName,
-            ) => {
-              openOrFocusConsoleTab(
-                path,
-                content,
-                connectionId,
-                path,
-                consoleId,
-                isPlaceholder,
-                undefined, // queryOptions - not needed for saved consoles
-                databaseId,
-                databaseName,
-              );
-            }}
-          />
-        );
+        return <ConsoleExplorer onConsoleSelect={handleConsoleSelect} />;
       case "connectors":
         return <DataSourceExplorer />;
       case "flows":

--- a/app/src/agent-runtime/console-agent-tools.ts
+++ b/app/src/agent-runtime/console-agent-tools.ts
@@ -5,7 +5,10 @@ import type {
 import type { ConsoleTab } from "../store/lib/types";
 import { useConsoleStore } from "../store/consoleStore";
 import { generateObjectId } from "../utils/objectId";
-import { applyModification } from "../utils/consoleModification";
+import {
+  applyModification,
+  buildModificationDiff,
+} from "../utils/consoleModification";
 import {
   CONSOLE_EXECUTOR_TOOL_NAMES,
   type AgentToolName,
@@ -218,6 +221,7 @@ export async function executeConsoleAgentTool({
       endLine,
     };
     const newContent = applyModification(currentContent, modification);
+    const diff = buildModificationDiff(currentContent, modification);
     currentStore.updateContent(consoleId, newContent);
 
     if (modifyTitle) {
@@ -227,6 +231,8 @@ export async function executeConsoleAgentTool({
     emitToolOutput(addToolOutput, toolName, toolCallId, {
       success: true,
       consoleId,
+      title: modifyTitle ?? targetConsole.title,
+      diff,
       message: `Console ${action}${action === "patch" ? "ed" : "d"} successfully`,
     });
     return true;

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -12,7 +12,6 @@ import React, {
 import {
   Box,
   Button,
-  Chip,
   IconButton,
   List,
   ListItem,
@@ -62,12 +61,16 @@ import { useWorkspace } from "../contexts/workspace-context";
 import { useConsoleStore } from "../store/consoleStore";
 import { executeDashboardAgentTool } from "../dashboard-runtime/agent-tools";
 import type { ConsoleTab } from "../store/lib/types";
+import { useDatabaseCatalogStore } from "../store/databaseCatalogStore";
 import { useSettingsStore } from "../store/settingsStore";
 import { useSchemaStore } from "../store/schemaStore";
 import { selectActiveExplorer, useUIStore } from "../store/uiStore";
 import { ModelSelector } from "./ModelSelector";
 import { generateObjectId } from "../utils/objectId";
-import { ConsoleModificationPayload } from "../hooks/useMonacoConsole";
+import type {
+  ConsoleModification,
+  ConsoleModificationPayload,
+} from "../hooks/useMonacoConsole";
 import { trackEvent } from "../lib/analytics";
 import { DbFlowFormRef } from "./DbFlowForm";
 import { safeStringify, toJsonSafe } from "../lib/json-safe";
@@ -81,11 +84,17 @@ import {
   type ActiveConsoleResultsContext,
 } from "../agent-runtime/request-context";
 import { executeConsoleAgentTool } from "../agent-runtime/console-agent-tools";
+import { buildModificationDiff } from "../utils/consoleModification";
 import {
   LONG_RUNNING_DASHBOARD_TOOL_NAMES,
   type AgentToolName,
 } from "../agent-runtime/client-tool-manifest";
 import { UpgradePrompt } from "./UpgradePrompt";
+import {
+  onRenderDebug,
+  useRenderCount,
+  useWhyChanged,
+} from "../utils/renderDebug";
 
 interface ChatSessionMeta {
   _id: string;
@@ -282,6 +291,101 @@ interface ActiveClientToolCall {
   settled: boolean;
 }
 
+function asToolPayload(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function getConsoleIdFromToolPayload(
+  input: unknown,
+  output: unknown,
+): string | null {
+  const inputObj = asToolPayload(input);
+  const outputObj = asToolPayload(output);
+  const consoleId = inputObj?.consoleId ?? outputObj?.consoleId;
+  return typeof consoleId === "string" && consoleId.length > 0
+    ? consoleId
+    : null;
+}
+
+interface ConsoleToolPresentation {
+  consoleId: string;
+  title: string;
+  iconUrl?: string;
+  diff?: string;
+}
+
+function getConsoleToolPresentation(
+  toolName: string,
+  input: unknown,
+  output: unknown,
+  connectionIconById: ReadonlyMap<string, string>,
+): ConsoleToolPresentation | null {
+  if (toolName !== "modify_console") return null;
+
+  const store = useConsoleStore.getState();
+  const inputObj = asToolPayload(input);
+  const outputObj = asToolPayload(output);
+  const consoleId = getConsoleIdFromToolPayload(input, output);
+  if (!consoleId) return null;
+
+  const consoleTab = store.tabs[consoleId];
+  const inputTitle = inputObj?.title;
+  const outputTitle = outputObj?.title;
+  const title =
+    consoleTab?.title ??
+    (typeof inputTitle === "string" ? inputTitle : undefined) ??
+    (typeof outputTitle === "string" ? outputTitle : undefined) ??
+    "Untitled console";
+
+  const outputDiff = outputObj?.diff;
+  const diff =
+    typeof outputDiff === "string" && outputDiff.length > 0
+      ? outputDiff
+      : buildStreamingModificationDiff(inputObj, consoleTab);
+
+  return {
+    consoleId,
+    title,
+    iconUrl: consoleTab?.connectionId
+      ? connectionIconById.get(consoleTab.connectionId)
+      : undefined,
+    diff,
+  };
+}
+
+function buildStreamingModificationDiff(
+  input: Record<string, unknown> | undefined,
+  consoleTab: ConsoleTab | undefined,
+): string | undefined {
+  const action = input?.action;
+  const content = input?.content;
+  if (
+    !input ||
+    !consoleTab ||
+    typeof action !== "string" ||
+    typeof content !== "string" ||
+    content.length === 0
+  ) {
+    return undefined;
+  }
+
+  const position = input.position;
+  const startLine = input.startLine;
+  const endLine = input.endLine;
+  const modification: ConsoleModification = {
+    action: action as ConsoleModification["action"],
+    content,
+    position:
+      typeof position === "number" ? { line: position, column: 1 } : undefined,
+    startLine: typeof startLine === "number" ? startLine : undefined,
+    endLine: typeof endLine === "number" ? endLine : undefined,
+  };
+
+  return buildModificationDiff(consoleTab.content || "", modification);
+}
+
 // ReasoningDisplay for showing reasoning/thinking parts inline.
 // - Auto-opens while streaming, auto-collapses when done.
 // - Shows elapsed thinking time ("Thought for Xs").
@@ -415,12 +519,6 @@ const pulseAnimation = keyframes`
   50% { opacity: 1; transform: scale(1.35); }
 `;
 
-// Shimmer animation for "Working on" indicator
-const shimmerAnimation = keyframes`
-  0% { background-position: -200% 0; }
-  100% { background-position: 200% 0; }
-`;
-
 // Stable style objects to prevent re-renders
 const streamingIndicatorContainerSx = {
   display: "flex",
@@ -526,8 +624,27 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
   isLastMessage,
   isStreaming,
   onToolClick,
+  onConsoleTitleClick,
+  connectionIconById,
   paletteMode,
 }: ChatMessageRowProps) {
+  const parts = (message.parts || []) as Array<Record<string, unknown>>;
+  useRenderCount(`ChatMessageRow:${message.id}`, {
+    role: message.role,
+    partCount: parts.length,
+  });
+  useWhyChanged(`ChatMessageRow:${message.id}`, {
+    messageRef: message,
+    partsRef: message.parts,
+    partCount: parts.length,
+    isLastMessage,
+    isStreaming,
+    onToolClick,
+    onConsoleTitleClick,
+    connectionIconById,
+    paletteMode,
+  });
+
   if (message.role === "user") {
     const fileParts = (message.parts || []).filter(
       (p): p is { type: "file"; url: string; mediaType: string } =>
@@ -588,7 +705,6 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
     );
   }
 
-  const parts = (message.parts || []) as Array<Record<string, unknown>>;
   const isStreamingNow = isStreaming;
 
   const reasoningGroups = computeReasoningGroups(parts);
@@ -630,6 +746,12 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
                   }
                 : part.output;
             const toolCallId = (part.toolCallId as string) || "";
+            const consoleToolPresentation = getConsoleToolPresentation(
+              toolName,
+              part.input,
+              cardOutput,
+              connectionIconById,
+            );
             // Key by toolCallId when available so reordering/insertion in the
             // parts array doesn't remount completed tool cards. Falls back to
             // a type+index tag for the (rare) case where toolCallId is missing.
@@ -644,6 +766,25 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
                 state={cardState}
                 input={part.input}
                 output={cardOutput}
+                labelOverride={consoleToolPresentation?.title}
+                leadingIconUrl={consoleToolPresentation?.iconUrl}
+                leadingIconAlt={
+                  consoleToolPresentation ? "Database" : undefined
+                }
+                bodyPreview={
+                  consoleToolPresentation?.diff
+                    ? {
+                        content: consoleToolPresentation.diff,
+                        language: "diff",
+                      }
+                    : undefined
+                }
+                onTitleClick={
+                  consoleToolPresentation
+                    ? () =>
+                        onConsoleTitleClick(consoleToolPresentation.consoleId)
+                    : undefined
+                }
                 onDetailClick={() =>
                   onToolClick({
                     toolCallId,
@@ -741,6 +882,19 @@ const ChatInputArea = React.memo(
     const inputRef = useRef<HTMLInputElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
     const imagesRef = useRef<ImageAttachment[]>([]);
+    useRenderCount("ChatInputArea", {
+      isLoading,
+      disabled,
+      imageCount: images.length,
+    });
+    useWhyChanged("ChatInputArea", {
+      onSubmit,
+      onStop,
+      isLoading,
+      disabled,
+      focusKey,
+      imageCount: images.length,
+    });
     imagesRef.current = images;
 
     useEffect(() => {
@@ -1095,28 +1249,13 @@ interface ChatProps {
   >;
 }
 
-// Suggestion prompts for the demo Chinook database
-const CHINOOK_SUGGESTIONS = [
-  "Who are the top 10 best-selling artists?",
-  "What are the most popular genres by revenue?",
-  "Show me monthly revenue trends",
-  "Who are our top 5 customers by spending?",
-];
+type ChatActiveView = "dashboard" | "flow-editor" | "console" | "empty";
 
-// Generic suggestions for any database
-const GENERIC_SUGGESTIONS = [
-  "What tables are in this database?",
-  "Show me the schema structure",
-  "Help me write a query to...",
-];
-
-// Suggestions for db-flow assistant
-const DB_FLOW_SUGGESTIONS = [
-  "Help me write a query to sync all users",
-  "What template placeholders should I use?",
-  "Suggest an incremental sync configuration",
-  "Validate my query setup",
-];
+function normalizeChatActiveView(kind: ConsoleTab["kind"]): ChatActiveView {
+  return kind === "dashboard" || kind === "flow-editor" || kind === "console"
+    ? kind
+    : "empty";
+}
 
 const Chat: React.FC<ChatProps> = ({
   onConsoleModification,
@@ -1127,37 +1266,35 @@ const Chat: React.FC<ChatProps> = ({
   const paletteMode = useMuiTheme().palette.mode;
   const { currentWorkspace } = useWorkspace();
   const selectedModelId = useSettingsStore(s => s.selectedModelId);
-  const activeTabId = useConsoleStore(state => state.activeTabId);
-  // Narrow selector: only re-render when the active tab's kind changes,
-  // not when unrelated tabs are mutated (e.g. query results arriving).
-  const activeTabKind = useConsoleStore(state => {
-    const tab = state.tabs[state.activeTabId || ""];
-    return tab?.kind;
-  });
-  const activeConsoleId = activeTabId;
-
-  const activeView =
-    activeTabKind === "dashboard" ||
-    activeTabKind === "flow-editor" ||
-    activeTabKind === "console"
-      ? activeTabKind
-      : "empty";
 
   // Ref for dbFlowFormRef to avoid stale closure in onToolCall
   const dbFlowFormRefCurrent = useRef(dbFlowFormRef);
   dbFlowFormRefCurrent.current = dbFlowFormRef;
 
-  // Get connections to check if only database is the demo
+  // Connection metadata is only needed to decorate completed console tool cards.
   const connections = useSchemaStore(s => s.connections);
+  const dbTypes = useDatabaseCatalogStore(s => s.types);
+  const fetchDbTypes = useDatabaseCatalogStore(s => s.fetchTypes);
+  useEffect(() => {
+    void fetchDbTypes();
+  }, [fetchDbTypes]);
   const workspaceConnections = useMemo(
     () => (currentWorkspace ? connections[currentWorkspace.id] || [] : []),
     [connections, currentWorkspace],
   );
+  const connectionIconById = useMemo(() => {
+    const iconByType = new Map<string, string>();
+    for (const dbType of dbTypes ?? []) {
+      if (dbType.iconUrl) iconByType.set(dbType.type, dbType.iconUrl);
+    }
 
-  // Show Chinook suggestions if the only database in workspace is the demo database
-  const hasOnlyDemoDatabase =
-    workspaceConnections.length === 1 &&
-    workspaceConnections[0]?.isDemo === true;
+    const iconByConnectionId = new Map<string, string>();
+    for (const connection of workspaceConnections) {
+      const iconUrl = iconByType.get(connection.type);
+      if (iconUrl) iconByConnectionId.set(connection.id, iconUrl);
+    }
+    return iconByConnectionId;
+  }, [dbTypes, workspaceConnections]);
 
   const [sessions, setSessions] = useState<ChatSessionMeta[]>([]);
   // chatId is a MongoDB ObjectId generated locally - frontend owns the ID (AI SDK best practice)
@@ -1214,13 +1351,16 @@ const Chat: React.FC<ChatProps> = ({
   const [selectedTool, setSelectedTool] = useState<ToolInvocationInfo | null>(
     null,
   );
-  const [capturedConsoleTitle, setCapturedConsoleTitle] = useState<
-    string | null
-  >(null);
 
-  // Ref to get current activeConsoleId at request time (avoids stale closure)
-  const activeConsoleIdRef = useRef(activeConsoleId);
-  activeConsoleIdRef.current = activeConsoleId;
+  // Keep the active console ID fresh without subscribing the whole chat panel
+  // to every console switch. This avoids disrupting chat streaming when users
+  // browse consoles/databases in the left explorer.
+  const activeConsoleIdRef = useRef(useConsoleStore.getState().activeTabId);
+  useEffect(() => {
+    return useConsoleStore.subscribe(state => {
+      activeConsoleIdRef.current = state.activeTabId;
+    });
+  }, []);
 
   // Refs for values needed in prepareSendMessagesRequest (avoids stale closures)
   const workspaceIdRef = useRef(currentWorkspace?.id);
@@ -1241,13 +1381,6 @@ const Chat: React.FC<ChatProps> = ({
     return lastAssistantMessageIsCompleteWithToolCalls(options);
   }, []);
 
-  // Refs so the transport closure always reads fresh values without
-  // needing to be recreated (which would reset the useChat hook).
-  const activeViewRef = useRef(activeView);
-  activeViewRef.current = activeView;
-  const workspaceConnectionsRef = useRef(workspaceConnections);
-  workspaceConnectionsRef.current = workspaceConnections;
-
   // Create transport once — prepareSendMessagesRequest reads all dynamic
   // values from getState() / refs at request time, so the transport identity
   // is stable for the lifetime of the component.
@@ -1260,13 +1393,11 @@ const Chat: React.FC<ChatProps> = ({
           const store = useConsoleStore.getState();
           const tabs = Object.values(store.tabs) as ConsoleTab[];
           const activeTab = tabs.find(t => t.id === store.activeTabId);
-
-          const computedActiveView =
-            activeTab?.kind === "dashboard" ||
-            activeTab?.kind === "flow-editor" ||
-            activeTab?.kind === "console"
-              ? activeTab.kind
-              : "empty";
+          const computedActiveView = normalizeChatActiveView(activeTab?.kind);
+          const workspaceId = workspaceIdRef.current;
+          const workspaceConnectionsForRequest = workspaceId
+            ? useSchemaStore.getState().connections[workspaceId] || []
+            : [];
 
           const flowFormState = dbFlowFormRefCurrent.current?.current
             ? dbFlowFormRefCurrent.current.current.getFormState()
@@ -1290,7 +1421,7 @@ const Chat: React.FC<ChatProps> = ({
             body: toJsonSafe(
               buildChatRequestBody({
                 messages,
-                workspaceId: workspaceIdRef.current,
+                workspaceId,
                 modelId: modelIdRef.current,
                 chatId: chatIdRef.current,
                 tabs,
@@ -1301,7 +1432,7 @@ const Chat: React.FC<ChatProps> = ({
                 activeConsoleId: activeConsoleIdRef.current,
                 activeConsoleResults,
                 flowFormState,
-                workspaceConnections: workspaceConnectionsRef.current,
+                workspaceConnections: workspaceConnectionsForRequest,
                 pinnedDashboardId: capturedDashboardIdRef.current,
               }),
             ) as Record<string, unknown>,
@@ -1736,6 +1867,25 @@ const Chat: React.FC<ChatProps> = ({
   }, [addToolOutput, stop]);
 
   const isLoading = status === "streaming" || status === "submitted";
+  const lastMessage = messages.at(-1);
+  const lastMessageParts = lastMessage?.parts ?? [];
+  useRenderCount("Chat", {
+    messageCount: messages.length,
+    status,
+  });
+  useWhyChanged("Chat", {
+    chatId,
+    currentWorkspaceId: currentWorkspace?.id,
+    selectedModelId,
+    messagesRef: messages,
+    messageCount: messages.length,
+    lastMessageId: lastMessage?.id,
+    lastMessageRole: lastMessage?.role,
+    lastMessagePartCount: lastMessageParts.length,
+    status,
+    isLoading,
+    connectionIconById,
+  });
 
   // Session management - fetch available chat sessions for history menu
   useEffect(() => {
@@ -1979,6 +2129,38 @@ const Chat: React.FC<ChatProps> = ({
     setToolDialogOpen(true);
   }, []);
 
+  const handleConsoleTitleClick = useCallback(async (consoleId: string) => {
+    const store = useConsoleStore.getState();
+    const existingTab = store.tabs[consoleId];
+    if (existingTab) {
+      store.setActiveTab(consoleId);
+      return;
+    }
+
+    const workspaceId = workspaceIdRef.current;
+    if (!workspaceId) return;
+
+    try {
+      const data = await store.fetchConsoleContent(workspaceId, consoleId);
+      if (!data) return;
+
+      const currentStore = useConsoleStore.getState();
+      currentStore.openTab({
+        id: consoleId,
+        title: data.name || data.path || "Untitled",
+        content: data.content || "",
+        connectionId: data.connectionId,
+        databaseId: data.databaseId,
+        databaseName: data.databaseName,
+        filePath: data.path,
+        isSaved: true,
+      });
+      currentStore.setActiveTab(consoleId);
+    } catch {
+      /* ignore focus failures */
+    }
+  }, []);
+
   const handleCloseToolDialog = () => {
     setToolDialogOpen(false);
     setSelectedTool(null);
@@ -1999,13 +2181,7 @@ const Chat: React.FC<ChatProps> = ({
       currentTab?.kind === "dashboard"
         ? ((currentTab.metadata?.dashboardId as string | undefined) ?? null)
         : null;
-    const currentTabs = Object.values(store.tabs);
-    const activeConsole = currentTabs.find(t => t.id === store.activeTabId);
-    setCapturedConsoleTitle(
-      activeConsole?.kind === undefined || activeConsole?.kind === "console"
-        ? activeConsole?.title || null
-        : null,
-    );
+    const activeConsole = store.tabs[store.activeTabId || ""];
     trackEvent("ai_chat_message_sent", {
       model: modelIdRef.current,
       has_context: !!activeConsole?.content,
@@ -2234,115 +2410,33 @@ const Chat: React.FC<ChatProps> = ({
         </Box>
       )}
 
-      {/* Suggestions when chat is empty */}
-      {messages.length === 0 && (
-        <Box
-          sx={{
-            flex: 1,
-            display: "flex",
-            flexDirection: "column",
-            justifyContent: "center",
-            alignItems: "center",
-            p: 2,
-            gap: 2,
-          }}
-        >
-          <Typography
-            variant="body2"
-            color="text.secondary"
-            sx={{ textAlign: "center", mb: 1 }}
-          >
-            {activeView === "flow-editor"
-              ? "I can help you configure your flow"
-              : hasOnlyDemoDatabase
-                ? "Try asking about the Chinook music store data"
-                : "Ask a question about your data"}
-          </Typography>
-          <Box
-            sx={{
-              display: "flex",
-              flexWrap: "wrap",
-              gap: 1,
-              justifyContent: "center",
-              maxWidth: 400,
-            }}
-          >
-            {(activeView === "flow-editor"
-              ? DB_FLOW_SUGGESTIONS
-              : hasOnlyDemoDatabase
-                ? CHINOOK_SUGGESTIONS
-                : GENERIC_SUGGESTIONS
-            ).map(suggestion => (
-              <Chip
-                key={suggestion}
-                label={suggestion}
-                variant="outlined"
-                size="small"
-                onClick={() => {
-                  manualStopRequestedRef.current = false;
-                  capturedConsoleIdRef.current = activeConsoleIdRef.current;
-                  const store = useConsoleStore.getState();
-                  const currentTab = store.tabs[store.activeTabId || ""] as
-                    | (ConsoleTab & { metadata?: Record<string, unknown> })
-                    | undefined;
-                  capturedDashboardIdRef.current =
-                    currentTab?.kind === "dashboard"
-                      ? ((currentTab.metadata?.dashboardId as
-                          | string
-                          | undefined) ?? null)
-                      : null;
-                  const currentTabs = Object.values(store.tabs);
-                  const console_ = currentTabs.find(
-                    t => t.id === store.activeTabId,
-                  );
-                  setCapturedConsoleTitle(
-                    console_?.kind === undefined || console_?.kind === "console"
-                      ? console_?.title || null
-                      : null,
-                  );
-                  trackEvent("ai_chat_message_sent", {
-                    model: modelIdRef.current,
-                    has_context: false,
-                    from_suggestion: true,
-                  });
-                  sendMessageRef.current({ text: suggestion });
-                }}
-                sx={{
-                  cursor: "pointer",
-                  "&:hover": {
-                    backgroundColor: "action.hover",
-                    borderColor: "primary.main",
-                  },
-                }}
-              />
-            ))}
-          </Box>
-        </Box>
-      )}
-
       {/* Messages */}
       <Box
         ref={scrollContainerRef}
         sx={{
-          flex: messages.length > 0 ? 1 : 0,
+          flex: 1,
           overflow: "auto",
           p: 1,
           position: "relative",
         }}
       >
         <div ref={scrollContentRef}>
-          <List dense>
-            {messages.map((message, msgIdx) => (
-              <ChatMessageRow
-                key={message.id}
-                message={message}
-                isLastMessage={msgIdx === messages.length - 1}
-                isStreaming={status === "streaming"}
-                onToolClick={handleToolClick}
-                paletteMode={paletteMode}
-              />
-            ))}
-          </List>
+          <React.Profiler id="Chat.message-list" onRender={onRenderDebug}>
+            <List dense>
+              {messages.map((message, msgIdx) => (
+                <ChatMessageRow
+                  key={message.id}
+                  message={message}
+                  isLastMessage={msgIdx === messages.length - 1}
+                  isStreaming={status === "streaming"}
+                  onToolClick={handleToolClick}
+                  onConsoleTitleClick={handleConsoleTitleClick}
+                  connectionIconById={connectionIconById}
+                  paletteMode={paletteMode}
+                />
+              ))}
+            </List>
+          </React.Profiler>
           <div ref={messagesEndRef} />
         </div>
 
@@ -2369,36 +2463,6 @@ const Chat: React.FC<ChatProps> = ({
           </IconButton>
         )}
       </Box>
-
-      {/* Working on console indicator - shows which console the agent is targeting */}
-      {isLoading && capturedConsoleTitle && (
-        <Box
-          sx={{
-            px: 1,
-            py: 0.5,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-          }}
-        >
-          <Typography
-            variant="caption"
-            sx={{
-              background: theme =>
-                theme.palette.mode === "dark"
-                  ? "linear-gradient(90deg, #666 0%, #999 50%, #666 100%)"
-                  : "linear-gradient(90deg, #999 0%, #333 50%, #999 100%)",
-              backgroundSize: "200% 100%",
-              backgroundClip: "text",
-              WebkitBackgroundClip: "text",
-              WebkitTextFillColor: "transparent",
-              animation: `${shimmerAnimation} 2s linear infinite`,
-            }}
-          >
-            {capturedConsoleTitle}
-          </Typography>
-        </Box>
-      )}
 
       {/* Input — isolated component so keystrokes don't re-render messages */}
       <ChatInputArea
@@ -2464,4 +2528,6 @@ const Chat: React.FC<ChatProps> = ({
   );
 };
 
-export default Chat;
+Chat.displayName = "Chat";
+
+export default React.memo(Chat);

--- a/app/src/components/Console.tsx
+++ b/app/src/components/Console.tsx
@@ -1,4 +1,4 @@
-import {
+import React, {
   useRef,
   useEffect,
   useState,
@@ -49,6 +49,11 @@ import { useConsoleStore } from "../store/consoleStore";
 import { computeConsoleStateHash } from "../utils/stateHash";
 import { applyModification as applyConsoleModification } from "../utils/consoleModification";
 import { ConnectionSelector } from "./ConnectionSelector";
+import {
+  onRenderDebug,
+  useRenderCount,
+  useWhyChanged,
+} from "../utils/renderDebug";
 
 interface DatabaseConnection {
   id: string;
@@ -235,6 +240,37 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
     onContentChange: enableVersionControl ? onContentChange : undefined,
     workspaceId: currentWorkspace?.id,
     title,
+  });
+  useRenderCount("Console", {
+    consoleId,
+    title,
+    isDiffMode,
+    editorKey,
+  });
+  useWhyChanged("Console", {
+    consoleId,
+    initialContentRef: initialContent,
+    title,
+    tabRef: tab,
+    tabContentRef: tab?.content,
+    savedStateHash,
+    isSaved,
+    isReadOnly,
+    hasUnsavedChanges,
+    isExecuting,
+    isCancelling,
+    isSaving,
+    isDiffMode,
+    editorKey,
+    connectionId,
+    databaseId,
+    databaseName,
+    databasesRef: databases,
+    onExecute,
+    onCancel,
+    onSave,
+    onContentChange,
+    effectiveMode,
   });
 
   // Track if we've saved the initial version
@@ -1304,45 +1340,50 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
       )}
 
       <Box ref={containerRef} sx={{ flexGrow: 1, height: 0 }}>
-        {!isDiffMode ? (
-          <Editor
-            key={editorKey}
-            language={editorLanguage || "javascript"}
-            defaultValue={lastInitialContentRef.current || initialContent}
-            height="100%"
-            theme={effectiveMode === "dark" ? "vs-dark" : "vs"}
-            onMount={handleEditorDidMount}
-            onChange={handleEditorChange}
-            options={{
-              automaticLayout: true,
-              readOnly: isReadOnly,
-              minimap: { enabled: false },
-              fontSize: 12,
-              wordWrap: "on",
-              scrollBeyondLastLine: false,
-            }}
-          />
-        ) : (
-          <DiffEditor
-            height="100%"
-            theme={effectiveMode === "dark" ? "vs-dark" : "vs"}
-            language={editorLanguage || "javascript"}
-            original={originalContent}
-            modified={modifiedContent}
-            onMount={handleDiffEditorDidMount}
-            options={{
-              automaticLayout: true,
-              readOnly: true,
-              minimap: { enabled: false },
-              fontSize: 12,
-              wordWrap: "on",
-              scrollBeyondLastLine: false,
-              renderSideBySide: false,
-              enableSplitViewResizing: false,
-              diffWordWrap: "on",
-            }}
-          />
-        )}
+        <React.Profiler
+          id={`Console.monaco.${consoleId}`}
+          onRender={onRenderDebug}
+        >
+          {!isDiffMode ? (
+            <Editor
+              key={editorKey}
+              language={editorLanguage || "javascript"}
+              defaultValue={lastInitialContentRef.current || initialContent}
+              height="100%"
+              theme={effectiveMode === "dark" ? "vs-dark" : "vs"}
+              onMount={handleEditorDidMount}
+              onChange={handleEditorChange}
+              options={{
+                automaticLayout: true,
+                readOnly: isReadOnly,
+                minimap: { enabled: false },
+                fontSize: 12,
+                wordWrap: "on",
+                scrollBeyondLastLine: false,
+              }}
+            />
+          ) : (
+            <DiffEditor
+              height="100%"
+              theme={effectiveMode === "dark" ? "vs-dark" : "vs"}
+              language={editorLanguage || "javascript"}
+              original={originalContent}
+              modified={modifiedContent}
+              onMount={handleDiffEditorDidMount}
+              options={{
+                automaticLayout: true,
+                readOnly: true,
+                minimap: { enabled: false },
+                fontSize: 12,
+                wordWrap: "on",
+                scrollBeyondLastLine: false,
+                renderSideBySide: false,
+                enableSplitViewResizing: false,
+                diffWordWrap: "on",
+              }}
+            />
+          )}
+        </React.Profiler>
       </Box>
 
       {/* Info Modal */}

--- a/app/src/components/ConsoleExplorer.tsx
+++ b/app/src/components/ConsoleExplorer.tsx
@@ -202,68 +202,73 @@ function ConsoleExplorer(
     })();
   };
 
-  const handleFileOpen = async (node: ConsoleEntry) => {
-    if (!currentWorkspace) return;
-    if (!node.id) return;
+  const handleFileOpen = useCallback(
+    async (node: ConsoleEntry) => {
+      if (!currentWorkspace) return;
+      if (!node.id) return;
 
-    const consoleId = node.id;
-    const cached = useConsoleContentStore.getState().get(consoleId);
-    const initialContent = cached?.content ?? "loading...";
-    const connectionId = cached?.connectionId || node.connectionId;
-    const databaseId = cached?.databaseId || node.databaseId;
-    const databaseName = cached?.databaseName || node.databaseName;
-    onConsoleSelect(
-      node.path,
-      initialContent,
-      connectionId,
-      consoleId,
-      !cached,
-      databaseId,
-      databaseName,
-    );
+      const consoleId = node.id;
+      const cached = useConsoleContentStore.getState().get(consoleId);
+      const initialContent = cached?.content ?? "loading...";
+      const connectionId = cached?.connectionId || node.connectionId;
+      const databaseId = cached?.databaseId || node.databaseId;
+      const databaseName = cached?.databaseName || node.databaseName;
+      onConsoleSelect(
+        node.path,
+        initialContent,
+        connectionId,
+        consoleId,
+        !cached,
+        databaseId,
+        databaseName,
+      );
 
-    try {
-      const consoleStore = await import("../store/consoleStore");
-      const { fetchConsoleContent } = consoleStore.useConsoleStore.getState();
-      const data = await fetchConsoleContent(currentWorkspace.id, consoleId);
-      if (data) {
-        useConsoleContentStore.getState().set(consoleId, {
-          content: data.content,
-          connectionId: data.connectionId || node.connectionId,
-          databaseId: data.databaseId || node.databaseId,
-          databaseName: data.databaseName || node.databaseName,
-        });
-        const {
-          updateContent,
-          updateFilePath,
-          updateDatabase,
-          updateConnection,
-          updateSavedState,
-        } = consoleStore.useConsoleStore.getState();
-        updateContent(consoleId, data.content);
+      try {
+        const consoleStore = await import("../store/consoleStore");
+        const { fetchConsoleContent } = consoleStore.useConsoleStore.getState();
+        const data = await fetchConsoleContent(currentWorkspace.id, consoleId);
+        if (data) {
+          useConsoleContentStore.getState().set(consoleId, {
+            content: data.content,
+            connectionId: data.connectionId || node.connectionId,
+            databaseId: data.databaseId || node.databaseId,
+            databaseName: data.databaseName || node.databaseName,
+          });
+          const {
+            updateContent,
+            updateFilePath,
+            updateDatabase,
+            updateConnection,
+            updateSavedState,
+          } = consoleStore.useConsoleStore.getState();
+          updateContent(consoleId, data.content);
 
-        if (data.connectionId) {
-          updateConnection(consoleId, data.connectionId);
+          if (data.connectionId) {
+            updateConnection(consoleId, data.connectionId);
+          }
+          if (data.databaseId || data.databaseName) {
+            updateDatabase(consoleId, data.databaseId, data.databaseName);
+          }
+
+          updateFilePath(consoleId, node.path);
+
+          const { computeConsoleStateHash } = await import(
+            "../utils/stateHash"
+          );
+          const savedStateHash = computeConsoleStateHash(
+            data.content,
+            data.connectionId,
+            data.databaseId,
+            data.databaseName,
+          );
+          updateSavedState(consoleId, true, savedStateHash);
         }
-        if (data.databaseId || data.databaseName) {
-          updateDatabase(consoleId, data.databaseId, data.databaseName);
-        }
-
-        updateFilePath(consoleId, node.path);
-
-        const { computeConsoleStateHash } = await import("../utils/stateHash");
-        const savedStateHash = computeConsoleStateHash(
-          data.content,
-          data.connectionId,
-          data.databaseId,
-          data.databaseName,
-        );
-        updateSavedState(consoleId, true, savedStateHash);
+      } catch (e) {
+        console.error("Background fetch failed", e);
       }
-    } catch (e) {
-      console.error("Background fetch failed", e);
-    }
-  };
+    },
+    [currentWorkspace, onConsoleSelect],
+  );
 
   const handleMenuOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
     setMenuAnchor(event.currentTarget);

--- a/app/src/components/ConsoleTree.tsx
+++ b/app/src/components/ConsoleTree.tsx
@@ -379,6 +379,50 @@ function ConsoleTreeInner(
     [],
   );
 
+  const handleResourceItemClick = useCallback(
+    (node: ResourceTreeNode) => onFileOpen?.(node as ConsoleEntry),
+    [onFileOpen],
+  );
+  const handlePickerFileClick = useCallback(
+    (node: ResourceTreeNode) => onFileClick?.(node as ConsoleEntry),
+    [onFileClick],
+  );
+  const handleDuplicateItem = useCallback(
+    (node: ResourceTreeNode) => onDuplicate?.(node as ConsoleEntry),
+    [onDuplicate],
+  );
+  const handleInfoRequest = useCallback(
+    (node: ResourceTreeNode) => onInfoRequest?.(node as ConsoleEntry),
+    [onInfoRequest],
+  );
+  const handleFolderInfoRequest = useCallback(
+    (node: ResourceTreeNode) => onFolderInfoRequest?.(node as ConsoleEntry),
+    [onFolderInfoRequest],
+  );
+  const handleMoveRequest = useCallback(
+    (node: ResourceTreeNode) => onMoveRequest?.(node as ConsoleEntry),
+    [onMoveRequest],
+  );
+  const handleResortItem = useCallback(
+    (id: string) => {
+      if (!currentWorkspace) return;
+      resortItem(currentWorkspace.id, id);
+    },
+    [currentWorkspace, resortItem],
+  );
+  const handleCanManageItem = useCallback(
+    (node: ResourceTreeNode) => canManage(node as ConsoleEntry),
+    [canManage],
+  );
+  const getResourceItemIcon = useCallback(
+    (node: ResourceTreeNode) => getItemIcon(node as ConsoleEntry),
+    [getItemIcon],
+  );
+  const getResourceFolderExpansionKey = useCallback(
+    (node: ResourceTreeNode) => node.id,
+    [],
+  );
+
   return (
     <ResourceTree
       ref={resourceTreeRef}
@@ -386,7 +430,7 @@ function ConsoleTreeInner(
       mode={mode}
       activeItemId={mode === "sidebar" ? activeTabId : null}
       searchQuery={searchQuery}
-      getItemIcon={node => getItemIcon(node as ConsoleEntry)}
+      getItemIcon={getResourceItemIcon}
       showFiles={showFiles}
       hideFolderIcon
       enableDragDrop={enableDragDrop}
@@ -396,8 +440,8 @@ function ConsoleTreeInner(
       enableMove={enableMove}
       enableInfo={enableInfo}
       enableNewFolder
-      onItemClick={node => onFileOpen?.(node as ConsoleEntry)}
-      onPickerFileClick={node => onFileClick?.(node as ConsoleEntry)}
+      onItemClick={handleResourceItemClick}
+      onPickerFileClick={handlePickerFileClick}
       onLocationChange={handleLocationChange}
       selectedLocationId={selectedLocationId}
       selectedSectionKey={selectedSectionKey}
@@ -407,21 +451,18 @@ function ConsoleTreeInner(
       onMoveFolder={handleMoveFolder}
       onRenameItem={handleRenameItem}
       onDeleteItem={handleDeleteItem}
-      onDuplicateItem={node => onDuplicate?.(node as ConsoleEntry)}
+      onDuplicateItem={handleDuplicateItem}
       onCreateFolder={handleCreateFolder}
-      onInfoRequest={node => onInfoRequest?.(node as ConsoleEntry)}
-      onFolderInfoRequest={node => onFolderInfoRequest?.(node as ConsoleEntry)}
-      onMoveRequest={node => onMoveRequest?.(node as ConsoleEntry)}
-      onResortItem={id => {
-        if (!currentWorkspace) return;
-        resortItem(currentWorkspace.id, id);
-      }}
+      onInfoRequest={handleInfoRequest}
+      onFolderInfoRequest={handleFolderInfoRequest}
+      onMoveRequest={handleMoveRequest}
+      onResortItem={handleResortItem}
       onUndo={onUndo}
       isFolderExpanded={isFolderExpandedLocal}
       onToggleFolder={toggleFolder}
       onExpandFolder={expandFolder}
-      getFolderExpansionKey={node => node.id}
-      canManageItem={node => canManage(node as ConsoleEntry)}
+      getFolderExpansionKey={getResourceFolderExpansionKey}
+      canManageItem={handleCanManageItem}
     />
   );
 }

--- a/app/src/components/DashboardCanvas.tsx
+++ b/app/src/components/DashboardCanvas.tsx
@@ -646,7 +646,7 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
             );
           }
         }}
-        title="Save Dashboard"
+        title="Name Dashboard Version"
       />
 
       <Snackbar

--- a/app/src/components/DatabaseExplorer.tsx
+++ b/app/src/components/DatabaseExplorer.tsx
@@ -21,7 +21,7 @@ import {
   Settings as SettingsIcon,
   Layers as LayersIcon,
 } from "lucide-react";
-import { useDatabaseExplorerStore } from "../store";
+import { useExplorerStore } from "../store";
 import { useWorkspace } from "../contexts/workspace-context";
 import CreateDatabaseDialog from "./CreateDatabaseDialog";
 import { useSchemaStore, Connection, TreeNode } from "../store/schemaStore";
@@ -133,8 +133,10 @@ function DatabaseExplorer({
     [dbTypes],
   );
 
-  const { toggleDatabase, isDatabaseExpanded, expandedNodes, toggleNode } =
-    useDatabaseExplorerStore();
+  const expandedDatabases = useExplorerStore(s => s.database.expandedDatabases);
+  const expandedNodes = useExplorerStore(s => s.database.expandedNodes);
+  const toggleDatabase = useExplorerStore(s => s.toggleDatabase);
+  const toggleNode = useExplorerStore(s => s.toggleNode);
 
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [editingDatabaseId, setEditingDatabaseId] = useState<
@@ -263,14 +265,14 @@ function DatabaseExplorer({
       const info = nodeInfoById.get(key);
       if (!info) return false;
       if (info.type === "connection") {
-        return isDatabaseExpanded(info.connectionId);
+        return !!expandedDatabases[info.connectionId];
       }
       // For non-connection nodes, expansion is tracked in expandedNodes under
       // the `${connectionId}:${kind}:${id}` key (which is the same as the
       // ResourceTreeNode id we've chosen).
       return !!expandedNodes[key];
     },
-    [nodeInfoById, isDatabaseExpanded, expandedNodes],
+    [nodeInfoById, expandedDatabases, expandedNodes],
   );
 
   const onToggleFolder = useCallback(
@@ -291,7 +293,7 @@ function DatabaseExplorer({
       const info = nodeInfoById.get(key);
       if (!info) return;
       if (info.type === "connection") {
-        if (!isDatabaseExpanded(info.connectionId)) {
+        if (!expandedDatabases[info.connectionId]) {
           toggleDatabase(info.connectionId);
         }
       } else if (!expandedNodes[key]) {
@@ -300,7 +302,7 @@ function DatabaseExplorer({
     },
     [
       nodeInfoById,
-      isDatabaseExpanded,
+      expandedDatabases,
       toggleDatabase,
       expandedNodes,
       toggleNode,
@@ -486,6 +488,11 @@ function DatabaseExplorer({
     [nodeInfoById, handleCollectionClick],
   );
 
+  const getFolderExpansionKey = useCallback(
+    (node: ResourceTreeNode) => node.id,
+    [],
+  );
+
   const renderSkeletonItems = () => (
     <Box sx={{ p: 1 }}>
       {Array.from({ length: 3 }).map((_, index) => (
@@ -560,7 +567,7 @@ function DatabaseExplorer({
               isFolderExpanded={isFolderExpanded}
               onToggleFolder={onToggleFolder}
               onExpandFolder={onExpandFolder}
-              getFolderExpansionKey={node => node.id}
+              getFolderExpansionKey={getFolderExpansionKey}
               onLoadChildren={onLoadChildren}
               isLoadingChildren={isLoadingChildren}
               getContextMenuItems={getContextMenuItems}

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -77,6 +77,13 @@ import {
   computeConsoleStateHash,
   computeDashboardStateHash,
 } from "../utils/stateHash";
+import {
+  logRenderDebug,
+  onRenderDebug,
+  renderDebugEnabled,
+  useRenderCount,
+  useWhyChanged,
+} from "../utils/renderDebug";
 
 interface QueryPageInfo {
   pageSize: number;
@@ -437,6 +444,30 @@ function Editor({
   // detect a change every render and trigger a re-render loop.
   const consoleTabs = useConsoleStore(useShallow(selectConsoleTabs));
   const activeConsoleId = activeTabId;
+  const activeTab = activeConsoleId ? tabs[activeConsoleId] : undefined;
+  useRenderCount("Editor", {
+    activeConsoleId,
+    tabCount: consoleTabs.length,
+  });
+  useWhyChanged("Editor", {
+    currentWorkspaceId: currentWorkspace?.id,
+    tabsRef: tabs,
+    consoleTabsRef: consoleTabs,
+    tabCount: consoleTabs.length,
+    activeConsoleId,
+    activeTabKind: activeTab?.kind,
+    activeTabContentRef: activeTab?.content,
+    activeTabResultsRef: activeConsoleId ? tabResults[activeConsoleId] : null,
+    activeTabResultsExecutedAt: activeConsoleId
+      ? tabResults[activeConsoleId]?.executedAt
+      : undefined,
+    executingTabsRef: executingTabs,
+    cancellingTabsRef: cancellingTabs,
+    isSaving,
+    tabViewModesRef: tabViewModes,
+    tabChartSpecsRef: tabChartSpecs,
+    availableDatabasesRef: availableDatabases,
+  });
 
   const setChartSpecForTab = useCallback(
     (tabId: string, spec: import("../lib/chart-spec").MakoChartSpec | null) => {
@@ -453,6 +484,9 @@ function Editor({
     },
     [updateResultsViewMode],
   );
+  const handlePanelLayout = useCallback((tabId: string, layout: number[]) => {
+    logRenderDebug("Editor.panel-layout", { tabId, layout });
+  }, []);
 
   // Refs for each Console instance
   const consoleRefs = useRef<Record<string, React.RefObject<ConsoleRef>>>({});
@@ -1868,106 +1902,123 @@ function Editor({
                   />
                 ) : (
                   /* Console tab: editor + results split */
-                  <PanelGroup
-                    direction="vertical"
-                    style={{ height: "100%", width: "100%" }}
+                  <React.Profiler
+                    id={`Editor.console-panels.${tab.id}`}
+                    onRender={onRenderDebug}
                   >
-                    <Panel defaultSize={60} minSize={1}>
-                      <Console
-                        ref={consoleRefs.current[tab.id]}
-                        consoleId={tab.id}
-                        initialContent={tab.content}
-                        title={tab.title}
-                        onExecute={(content, connectionId, databaseId) =>
-                          handleConsoleExecute(tab.id, content, connectionId, {
-                            databaseId: databaseId || tab.databaseId,
-                            databaseName: tab.databaseName,
-                          })
-                        }
-                        onCancel={() => handleConsoleCancel(tab.id)}
-                        onSave={(content, currentPath) =>
-                          handleConsoleSave(tab.id, content, currentPath)
-                        }
-                        onSaveAsCopy={content =>
-                          handleSaveAsCopy(tab.id, content)
-                        }
-                        onRenameMove={(content, currentPath) =>
-                          handleRenameMove(tab.id, content, currentPath)
-                        }
-                        isExecuting={executingTabs[tab.id] || false}
-                        isCancelling={cancellingTabs[tab.id] || false}
-                        isSaving={isSaving}
-                        onContentChange={content => {
-                          updateContent(tab.id, content);
-                          if (!tab.isDirty) {
-                            updateDirty(tab.id, true);
+                    <PanelGroup
+                      direction="vertical"
+                      style={{ height: "100%", width: "100%" }}
+                      onLayout={
+                        renderDebugEnabled
+                          ? layout => handlePanelLayout(tab.id, layout)
+                          : undefined
+                      }
+                    >
+                      <Panel defaultSize={60} minSize={1}>
+                        <Console
+                          ref={consoleRefs.current[tab.id]}
+                          consoleId={tab.id}
+                          initialContent={tab.content}
+                          title={tab.title}
+                          onExecute={(content, connectionId, databaseId) =>
+                            handleConsoleExecute(
+                              tab.id,
+                              content,
+                              connectionId,
+                              {
+                                databaseId: databaseId || tab.databaseId,
+                                databaseName: tab.databaseName,
+                              },
+                            )
                           }
-                          // Also refresh activeEditorContent for Chat consumers
-                          const ref = consoleRefs.current[tab.id]?.current;
-                          if (activeConsoleId === tab.id && ref) {
-                            setActiveEditorContent(ref.getCurrentContent());
+                          onCancel={() => handleConsoleCancel(tab.id)}
+                          onSave={(content, currentPath) =>
+                            handleConsoleSave(tab.id, content, currentPath)
                           }
-                        }}
-                        connectionId={tab.connectionId}
-                        databaseId={tab.databaseId}
-                        databaseName={tab.databaseName}
-                        databases={availableDatabases}
-                        onDatabaseChange={connId =>
-                          updateConnection(tab.id, connId)
-                        }
-                        onDatabaseNameChange={(dbId, dbName) =>
-                          updateDatabase(tab.id, dbId, dbName)
-                        }
-                        filePath={tab.filePath}
-                        enableVersionControl={true}
-                        onHistoryClick={() => {
-                          setVersionHistoryTabId(tab.id);
-                          setVersionHistoryEntityType("console");
-                          setVersionHistoryOpen(true);
-                        }}
-                        historyAvailable={tab.isSaved}
-                      />
-                    </Panel>
-
-                    <StyledVerticalResizeHandle />
-
-                    <Panel defaultSize={40} minSize={1}>
-                      <Box sx={{ height: "100%", overflow: "hidden" }}>
-                        <ResultsTable
-                          results={tabResults[tab.id] || null}
-                          chartSpec={tabChartSpecs[tab.id] ?? null}
-                          onChartSpecChange={spec =>
-                            setChartSpecForTab(tab.id, spec)
+                          onSaveAsCopy={content =>
+                            handleSaveAsCopy(tab.id, content)
                           }
-                          viewMode={tabViewModes[tab.id] ?? "table"}
-                          onViewModeChange={mode =>
-                            setViewModeForTab(tab.id, mode)
+                          onRenameMove={(content, currentPath) =>
+                            handleRenameMove(tab.id, content, currentPath)
                           }
-                          onChartRenderError={error => {
-                            const cb = pendingRenderCallbackRef.current[tab.id];
-                            if (cb) {
-                              cb({ success: false, error });
-                              delete pendingRenderCallbackRef.current[tab.id];
+                          isExecuting={executingTabs[tab.id] || false}
+                          isCancelling={cancellingTabs[tab.id] || false}
+                          isSaving={isSaving}
+                          onContentChange={content => {
+                            updateContent(tab.id, content);
+                            if (!tab.isDirty) {
+                              updateDirty(tab.id, true);
+                            }
+                            // Also refresh activeEditorContent for Chat consumers
+                            const ref = consoleRefs.current[tab.id]?.current;
+                            if (activeConsoleId === tab.id && ref) {
+                              setActiveEditorContent(ref.getCurrentContent());
                             }
                           }}
-                          onChartRenderSuccess={() => {
-                            const cb = pendingRenderCallbackRef.current[tab.id];
-                            if (cb) {
-                              cb({ success: true });
-                              delete pendingRenderCallbackRef.current[tab.id];
-                            }
+                          connectionId={tab.connectionId}
+                          databaseId={tab.databaseId}
+                          databaseName={tab.databaseName}
+                          databases={availableDatabases}
+                          onDatabaseChange={connId =>
+                            updateConnection(tab.id, connId)
+                          }
+                          onDatabaseNameChange={(dbId, dbName) =>
+                            updateDatabase(tab.id, dbId, dbName)
+                          }
+                          filePath={tab.filePath}
+                          enableVersionControl={true}
+                          onHistoryClick={() => {
+                            setVersionHistoryTabId(tab.id);
+                            setVersionHistoryEntityType("console");
+                            setVersionHistoryOpen(true);
                           }}
-                          onPreviousPage={() =>
-                            handlePreviousResultsPage(tab.id)
-                          }
-                          onNextPage={() => handleNextResultsPage(tab.id)}
-                          onDownload={format =>
-                            handleDownloadResults(tab.id, format)
-                          }
+                          historyAvailable={tab.isSaved}
                         />
-                      </Box>
-                    </Panel>
-                  </PanelGroup>
+                      </Panel>
+
+                      <StyledVerticalResizeHandle />
+
+                      <Panel defaultSize={40} minSize={1}>
+                        <Box sx={{ height: "100%", overflow: "hidden" }}>
+                          <ResultsTable
+                            results={tabResults[tab.id] || null}
+                            chartSpec={tabChartSpecs[tab.id] ?? null}
+                            onChartSpecChange={spec =>
+                              setChartSpecForTab(tab.id, spec)
+                            }
+                            viewMode={tabViewModes[tab.id] ?? "table"}
+                            onViewModeChange={mode =>
+                              setViewModeForTab(tab.id, mode)
+                            }
+                            onChartRenderError={error => {
+                              const cb =
+                                pendingRenderCallbackRef.current[tab.id];
+                              if (cb) {
+                                cb({ success: false, error });
+                                delete pendingRenderCallbackRef.current[tab.id];
+                              }
+                            }}
+                            onChartRenderSuccess={() => {
+                              const cb =
+                                pendingRenderCallbackRef.current[tab.id];
+                              if (cb) {
+                                cb({ success: true });
+                                delete pendingRenderCallbackRef.current[tab.id];
+                              }
+                            }}
+                            onPreviousPage={() =>
+                              handlePreviousResultsPage(tab.id)
+                            }
+                            onNextPage={() => handleNextResultsPage(tab.id)}
+                            onDownload={format =>
+                              handleDownloadResults(tab.id, format)
+                            }
+                          />
+                        </Box>
+                      </Panel>
+                    </PanelGroup>
+                  </React.Profiler>
                 )}
               </Box>
             ))}
@@ -2083,7 +2134,7 @@ function Editor({
         open={commentDialogOpen}
         onSave={handleCommentSaveConfirm}
         onCancel={handleCommentSaveCancel}
-        title="Save Console"
+        title="Name Console Version"
         defaultComment={suggestedComment}
         loading={suggestedCommentLoading}
         diff={saveCommentDiff}

--- a/app/src/components/ResourceTree.tsx
+++ b/app/src/components/ResourceTree.tsx
@@ -68,6 +68,11 @@ import {
   getFolderDropTargetId,
   resolveTreeDropTarget,
 } from "./resource-tree/utils";
+import {
+  onRenderDebug,
+  useRenderCount,
+  useWhyChanged,
+} from "../utils/renderDebug";
 
 export interface ResourceTreeNode {
   id: string;
@@ -288,6 +293,45 @@ function ResourceTreeInner(
     selectedSectionKey !== undefined
       ? selectedSectionKey
       : internalSelectedSectionKey;
+  const debugSectionSummary = useMemo(
+    () =>
+      sections
+        .map(section => `${section.key}:${section.nodes.length}`)
+        .join(","),
+    [sections],
+  );
+  useRenderCount("ResourceTree", {
+    mode,
+    sectionCount: sections.length,
+    activeItemId,
+  });
+  useWhyChanged("ResourceTree", {
+    sectionsRef: sections,
+    debugSectionSummary,
+    mode,
+    activeItemId,
+    searchQuery,
+    focusedNodeId,
+    contextMenuItemId: contextMenu?.item.id,
+    sectionContextMenuKey: sectionContextMenu?.sectionKey,
+    draggedNodeId: draggedNode?.id,
+    dropTargetId,
+    pendingCreatedFolderId,
+    currentSelectedLocation,
+    currentSelectedSectionKey,
+    showFiles,
+    hideFolderIcon,
+    enableDragDrop,
+    onItemClick,
+    onLoadChildren,
+    isLoadingChildren,
+    getItemIcon,
+    getRightAdornment,
+    isFolderExpanded,
+    onToggleFolder,
+    onExpandFolder,
+    getFolderExpansionKey,
+  });
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -1415,7 +1459,9 @@ function ResourceTreeInner(
 
   return (
     <>
-      {content}
+      <React.Profiler id="ResourceTree.content" onRender={onRenderDebug}>
+        {content}
+      </React.Profiler>
 
       <Menu
         open={!!contextMenu}

--- a/app/src/components/ResultsTable.tsx
+++ b/app/src/components/ResultsTable.tsx
@@ -28,6 +28,11 @@ import Editor from "@monaco-editor/react";
 import { useTheme } from "../contexts/ThemeContext";
 import type { MakoChartSpec } from "../lib/chart-spec";
 import ResultsChart from "./ResultsChart";
+import {
+  onRenderDebug,
+  useRenderCount,
+  useWhyChanged,
+} from "../utils/renderDebug";
 
 interface QueryResult {
   results?: any; // Can be anything: array, object, primitive, etc.
@@ -46,6 +51,9 @@ interface QueryResult {
 }
 
 type ViewMode = "table" | "json" | "chart";
+
+const PINNED_RESULT_COLUMNS = { left: ["__rowIndex"], right: [] };
+const RESULTS_TABLE_LOCALE_TEXT = { noRowsLabel: "No rows returned" };
 
 interface ResultsTableProps {
   results?: QueryResult | null;
@@ -84,14 +92,20 @@ const ResultsTable: React.FC<ResultsTableProps> = ({
   const currentPage = results?.currentPage ?? 1;
   const canGoBack = currentPage > 1 && Boolean(onPreviousPage);
   const canGoForward = Boolean(results?.pageInfo?.hasMore && onNextPage);
+  const lastTableResetExecutedAtRef = React.useRef<string | undefined>();
 
   // Reset to table view whenever new results are received
   const executedAt = results?.executedAt;
   useEffect(() => {
-    if (executedAt) {
+    if (!executedAt || lastTableResetExecutedAtRef.current === executedAt) {
+      return;
+    }
+
+    lastTableResetExecutedAtRef.current = executedAt;
+    if (viewMode !== "table") {
       setViewMode("table");
     }
-  }, [executedAt, setViewMode]);
+  }, [executedAt, setViewMode, viewMode]);
 
   // Helper function to normalize any data into an array format
   const normalizeToArray = (data: any): any[] => {
@@ -469,6 +483,30 @@ const ResultsTable: React.FC<ResultsTableProps> = ({
   );
 
   const jsonContent = JSON.stringify(results, null, 2);
+  useRenderCount("ResultsTable", {
+    executedAt,
+    viewMode,
+    rowCount: rows.length,
+    columnCount: columns.length,
+  });
+  useWhyChanged("ResultsTable", {
+    resultsRef: results,
+    resultsPayloadRef: results?.results,
+    fieldsRef: results?.fields,
+    executedAt,
+    resultCount: results?.resultCount,
+    chartSpec,
+    viewMode,
+    onChartSpecChange,
+    onViewModeChange,
+    onNextPage,
+    onPreviousPage,
+    onDownload,
+    rowsRef: rows,
+    columnsRef: columns,
+    rowCount: rows.length,
+    columnCount: columns.length,
+  });
 
   if (!results) {
     return (
@@ -602,61 +640,63 @@ const ResultsTable: React.FC<ResultsTableProps> = ({
         }}
       >
         {viewMode === "table" && (
-          <DataGridPremium
-            key={results.executedAt}
-            rows={rows}
-            columns={columns}
-            pinnedColumns={{ left: ["__rowIndex"], right: [] }}
-            density="compact"
-            disableRowSelectionOnClick
-            hideFooter
-            localeText={{ noRowsLabel: "No rows returned" }}
-            columnHeaderHeight={40}
-            rowHeight={40}
-            style={{
-              height: "100%",
-              width: "auto",
-            }}
-            sx={{
-              "& .MuiDataGrid-cell": {
-                fontSize: "12px",
-                fontFamily:
-                  'Monaco, Menlo, "Ubuntu Mono", Consolas, "Courier New", monospace',
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                borderRight: "1px solid",
-                borderColor: "divider",
-              },
-              "& .MuiDataGrid-columnHeaders": {
-                backgroundColor: "background.default",
-                fontFamily:
-                  'Monaco, Menlo, "Ubuntu Mono", Consolas, "Courier New", monospace',
-              },
-              "& .MuiDataGrid-columnHeader": {
-                backgroundColor: "background.default",
-                fontFamily:
-                  'Monaco, Menlo, "Ubuntu Mono", Consolas, "Courier New", monospace',
-              },
-              "& .MuiDataGrid-root": {
-                overflow: "hidden",
-              },
-              "& .MuiDataGrid-row:first-of-type .MuiDataGrid-cell": {
-                borderTop: "none",
-              },
-              "& .MuiDataGrid-main": {
-                overflow: "hidden",
-                backgroundColor: "background.default",
-              },
-              "& .MuiDataGrid-virtualScroller": {
-                overflow: "auto",
-              },
-              "& .MuiDataGrid-virtualScrollerContent": {
-                backgroundColor: "background.paper",
-              },
-              borderRadius: 0,
-              border: "none",
-            }}
-          />
+          <React.Profiler id="ResultsTable.DataGrid" onRender={onRenderDebug}>
+            <DataGridPremium
+              key={results.executedAt}
+              rows={rows}
+              columns={columns}
+              pinnedColumns={PINNED_RESULT_COLUMNS}
+              density="compact"
+              disableRowSelectionOnClick
+              hideFooter
+              localeText={RESULTS_TABLE_LOCALE_TEXT}
+              columnHeaderHeight={40}
+              rowHeight={40}
+              style={{
+                height: "100%",
+                width: "auto",
+              }}
+              sx={{
+                "& .MuiDataGrid-cell": {
+                  fontSize: "12px",
+                  fontFamily:
+                    'Monaco, Menlo, "Ubuntu Mono", Consolas, "Courier New", monospace',
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  borderRight: "1px solid",
+                  borderColor: "divider",
+                },
+                "& .MuiDataGrid-columnHeaders": {
+                  backgroundColor: "background.default",
+                  fontFamily:
+                    'Monaco, Menlo, "Ubuntu Mono", Consolas, "Courier New", monospace',
+                },
+                "& .MuiDataGrid-columnHeader": {
+                  backgroundColor: "background.default",
+                  fontFamily:
+                    'Monaco, Menlo, "Ubuntu Mono", Consolas, "Courier New", monospace',
+                },
+                "& .MuiDataGrid-root": {
+                  overflow: "hidden",
+                },
+                "& .MuiDataGrid-row:first-of-type .MuiDataGrid-cell": {
+                  borderTop: "none",
+                },
+                "& .MuiDataGrid-main": {
+                  overflow: "hidden",
+                  backgroundColor: "background.default",
+                },
+                "& .MuiDataGrid-virtualScroller": {
+                  overflow: "auto",
+                },
+                "& .MuiDataGrid-virtualScrollerContent": {
+                  backgroundColor: "background.paper",
+                },
+                borderRadius: 0,
+                border: "none",
+              }}
+            />
+          </React.Profiler>
         )}
         {viewMode === "json" && (
           <Box

--- a/app/src/components/SaveCommentDialog.tsx
+++ b/app/src/components/SaveCommentDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import {
   Dialog,
   DialogTitle,
@@ -28,7 +28,7 @@ export function SaveCommentDialog({
   open,
   onSave,
   onCancel,
-  title = "Save",
+  title = "Name Version",
   defaultComment,
   loading,
   diff,
@@ -36,20 +36,22 @@ export function SaveCommentDialog({
   const [comment, setComment] = useState("");
   const [userEdited, setUserEdited] = useState(false);
   const [diffExpanded, setDiffExpanded] = useState(false);
+  const wasOpenRef = useRef(false);
 
   useEffect(() => {
-    if (open) {
+    if (open && !wasOpenRef.current) {
       setComment(defaultComment ?? "");
       setUserEdited(false);
       setDiffExpanded(false);
     }
-  }, [open]);
+    wasOpenRef.current = open;
+  }, [defaultComment, open]);
 
   useEffect(() => {
-    if (defaultComment && !userEdited) {
+    if (open && defaultComment && !userEdited) {
       setComment(defaultComment);
     }
-  }, [defaultComment, userEdited]);
+  }, [defaultComment, open, userEdited]);
 
   const handleSave = useCallback(() => {
     onSave(comment);
@@ -73,9 +75,11 @@ export function SaveCommentDialog({
           autoFocus
           fullWidth
           multiline
-          minRows={2}
+          minRows={3}
           maxRows={4}
-          placeholder="Describe your changes (optional)"
+          label="Version name"
+          placeholder="Describe what changed in this version"
+          helperText="This labels the saved version, not the console itself."
           value={comment}
           onChange={e => {
             setComment(e.target.value);
@@ -178,7 +182,7 @@ export function SaveCommentDialog({
           Cancel
         </Button>
         <Button onClick={handleSave} variant="contained" size="small">
-          Save
+          Save version
         </Button>
       </DialogActions>
     </Dialog>

--- a/app/src/components/StreamingToolCard.tsx
+++ b/app/src/components/StreamingToolCard.tsx
@@ -36,6 +36,7 @@ import {
   Wrench,
   X,
   ExternalLink,
+  SquareTerminal,
 } from "lucide-react";
 import {
   getAgentToolManifestEntry,
@@ -55,6 +56,11 @@ interface StreamingToolCardProps {
   state: ToolPartState;
   input?: unknown;
   output?: unknown;
+  labelOverride?: string;
+  leadingIconUrl?: string;
+  leadingIconAlt?: string;
+  bodyPreview?: { content: string; language: string };
+  onTitleClick?: () => void;
   onDetailClick?: () => void;
   /**
    * Optional — used as a defensive check in the memo comparator so that
@@ -218,6 +224,11 @@ const pulseKf = keyframes`
   50% { opacity: 1; transform: scale(1.35); }
 `;
 
+const titleShimmerKf = keyframes`
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+`;
+
 // ── Component ────────────────────────────────────────────────
 
 // Terminal states: once the tool call reaches one of these, `input` and
@@ -252,6 +263,11 @@ export const StreamingToolCard = React.memo(
     state,
     input,
     output,
+    labelOverride,
+    leadingIconUrl,
+    leadingIconAlt,
+    bodyPreview,
+    onTitleClick,
     onDetailClick,
   }: StreamingToolCardProps) {
     const config = getToolConfig(toolName);
@@ -303,12 +319,15 @@ export const StreamingToolCard = React.memo(
     const rawContent = config.preview
       ? inputObj?.[config.preview.field]
       : undefined;
-    const code =
+    const defaultCode =
       typeof rawContent === "string"
         ? rawContent
         : rawContent && typeof rawContent === "object"
           ? JSON.stringify(rawContent, null, 2)
           : "";
+    const code = bodyPreview?.content ?? defaultCode;
+    const codeLanguage =
+      bodyPreview?.language ?? config.preview?.language ?? "text";
 
     useEffect(() => {
       if (isStreaming && !userScrolled && codeContainerRef.current) {
@@ -324,7 +343,7 @@ export const StreamingToolCard = React.memo(
       setUserScrolled(!isAtBottom);
     }, []);
 
-    const label = config.getLabel(input);
+    const label = labelOverride ?? config.getLabel(input);
 
     const outputSummary = useMemo(
       () => (isDone || isError ? getOutputSummary(output) : null),
@@ -342,6 +361,8 @@ export const StreamingToolCard = React.memo(
 
     const hasVisibleBody =
       code.length > 0 || ((isDone || isError) && formattedOutput.length > 0);
+
+    const canExpand = hasVisibleBody;
 
     const statusText = isStreaming
       ? "Generating…"
@@ -374,8 +395,9 @@ export const StreamingToolCard = React.memo(
       >
         {/* Header */}
         <Box
+          className="tool-card-header"
           onClick={() => {
-            if ((isDone || isError) && hasVisibleBody) {
+            if (canExpand) {
               setExpanded(prev => !prev);
             } else {
               onDetailClick?.();
@@ -398,23 +420,74 @@ export const StreamingToolCard = React.memo(
         >
           <Box
             sx={{
+              position: "relative",
               display: "flex",
               alignItems: "center",
+              justifyContent: "center",
+              width: ICON_SIZE + 3,
+              height: ICON_SIZE + 3,
+              flexShrink: 0,
               color: isActive ? "primary.main" : "text.secondary",
+              "& .tool-card-leading-icon, & .tool-card-chevron-icon": {
+                position: "absolute",
+                inset: 0,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                transition: "opacity 0.12s ease",
+              },
+              "& .tool-card-leading-icon": {
+                opacity: canExpand && expanded ? 0 : 1,
+              },
+              "& .tool-card-chevron-icon": {
+                opacity: canExpand ? (expanded ? 1 : 0) : 0,
+              },
+              ...(canExpand && {
+                ".tool-card-header:hover & .tool-card-leading-icon": {
+                  opacity: 0,
+                },
+                ".tool-card-header:hover & .tool-card-chevron-icon": {
+                  opacity: 1,
+                },
+              }),
             }}
           >
-            {(isDone || isError) && hasVisibleBody ? (
-              expanded ? (
+            <Box className="tool-card-leading-icon">
+              {leadingIconUrl ? (
+                <Box
+                  component="img"
+                  src={leadingIconUrl}
+                  alt={leadingIconAlt ?? ""}
+                  sx={{
+                    width: ICON_SIZE + 3,
+                    height: ICON_SIZE + 3,
+                    objectFit: "contain",
+                    display: "block",
+                  }}
+                  draggable={false}
+                />
+              ) : labelOverride ? (
+                <SquareTerminal size={ICON_SIZE + 2} strokeWidth={1.6} />
+              ) : (
+                renderToolIcon(config.icon)
+              )}
+            </Box>
+            <Box className="tool-card-chevron-icon">
+              {expanded ? (
                 <ChevronDown size={14} />
               ) : (
                 <ChevronRight size={14} />
-              )
-            ) : (
-              renderToolIcon(config.icon)
-            )}
+              )}
+            </Box>
           </Box>
 
           <Typography
+            component={onTitleClick ? "button" : "span"}
+            onClick={(event: React.MouseEvent<HTMLElement>) => {
+              if (!onTitleClick) return;
+              event.stopPropagation();
+              onTitleClick();
+            }}
             variant="caption"
             sx={{
               fontWeight: 500,
@@ -423,6 +496,30 @@ export const StreamingToolCard = React.memo(
               overflow: "hidden",
               textOverflow: "ellipsis",
               whiteSpace: "nowrap",
+              fontSize: "0.75rem",
+              ...(isStreaming && {
+                background: theme =>
+                  theme.palette.mode === "dark"
+                    ? "linear-gradient(90deg, rgba(255,255,255,0.55) 0%, rgba(255,255,255,0.95) 45%, rgba(255,255,255,0.55) 90%)"
+                    : "linear-gradient(90deg, rgba(0,0,0,0.45) 0%, rgba(0,0,0,0.9) 45%, rgba(0,0,0,0.45) 90%)",
+                backgroundSize: "200% 100%",
+                backgroundClip: "text",
+                WebkitBackgroundClip: "text",
+                WebkitTextFillColor: "transparent",
+                animation: `${titleShimmerKf} 1.6s linear infinite`,
+              }),
+              ...(onTitleClick && {
+                p: 0,
+                border: 0,
+                backgroundColor: "transparent",
+                textAlign: "left",
+                cursor: "pointer",
+                fontFamily: "inherit",
+                lineHeight: "inherit",
+                "&:hover": {
+                  textDecoration: "underline",
+                },
+              }),
             }}
           >
             {label}
@@ -484,7 +581,7 @@ export const StreamingToolCard = React.memo(
             >
               <SyntaxHighlighter
                 style={syntaxTheme}
-                language={config.preview?.language ?? "text"}
+                language={codeLanguage}
                 PreTag="div"
                 customStyle={{
                   fontSize: "0.78rem",
@@ -541,6 +638,11 @@ export const StreamingToolCard = React.memo(
     if (prev.toolCallId !== next.toolCallId) return false;
     if (prev.toolName !== next.toolName) return false;
     if (prev.state !== next.state) return false;
+    if (prev.labelOverride !== next.labelOverride) return false;
+    if (prev.leadingIconUrl !== next.leadingIconUrl) return false;
+    if (prev.leadingIconAlt !== next.leadingIconAlt) return false;
+    if (prev.bodyPreview?.content !== next.bodyPreview?.content) return false;
+    if (prev.bodyPreview?.language !== next.bodyPreview?.language) return false;
 
     // Terminal states are immutable. Even if useChat handed us new cloned
     // references for `input` / `output` this tick, the contents are the

--- a/app/src/components/__tests__/Chat.perf.test.ts
+++ b/app/src/components/__tests__/Chat.perf.test.ts
@@ -16,6 +16,9 @@ import { StreamingToolCard } from "../StreamingToolCard";
 
 // ── Helpers ──────────────────────────────────────────────────
 
+const stableNoop = () => {};
+const stableConnectionIconById = new Map<string, string>();
+
 function makeProps(
   overrides: Partial<Parameters<typeof chatMessageRowArePropsEqual>[0]> = {},
 ): Parameters<typeof chatMessageRowArePropsEqual>[0] {
@@ -27,7 +30,9 @@ function makeProps(
     },
     isLastMessage: false,
     isStreaming: false,
-    onToolClick: () => {},
+    onToolClick: stableNoop,
+    onConsoleTitleClick: stableNoop,
+    connectionIconById: stableConnectionIconById,
     paletteMode: "light",
     ...overrides,
   };
@@ -112,13 +117,25 @@ describe("chatMessageRowArePropsEqual", () => {
     expect(chatMessageRowArePropsEqual(prev, next)).toBe(false);
   });
 
+  it("returns false when onConsoleTitleClick reference changes", () => {
+    const prev = makeProps({ onConsoleTitleClick: () => {} });
+    const next = makeProps({ onConsoleTitleClick: () => {} });
+    expect(chatMessageRowArePropsEqual(prev, next)).toBe(false);
+  });
+
+  it("returns false when connectionIconById reference changes", () => {
+    const prev = makeProps({ connectionIconById: new Map() });
+    const next = makeProps({ connectionIconById: new Map() });
+    expect(chatMessageRowArePropsEqual(prev, next)).toBe(false);
+  });
+
   it("skips re-render when a completed user message keeps its ref across streaming ticks", () => {
     // The AI SDK's replaceMessage only clones messages[last]; earlier
     // messages retain their references across ticks. So completed messages
     // (e.g. the user prompt) correctly skip re-rendering while the assistant
     // streams below them.
     //
-    // Chat.tsx uses `useCallback` to keep `onToolClick` stable across renders,
+    // Chat.tsx uses `useCallback` to keep callbacks stable across renders,
     // which is what makes this skip safe — all other prop references match too.
     const sharedUserMessage = {
       id: "user-1",
@@ -126,15 +143,21 @@ describe("chatMessageRowArePropsEqual", () => {
       parts: [{ type: "text", text: "What tables exist?" }],
     };
     const stableOnToolClick = () => {};
+    const stableOnConsoleTitleClick = () => {};
+    const stableConnectionIconById = new Map<string, string>();
     const prev = makeProps({
       message: sharedUserMessage,
       onToolClick: stableOnToolClick,
+      onConsoleTitleClick: stableOnConsoleTitleClick,
+      connectionIconById: stableConnectionIconById,
       isLastMessage: false,
       isStreaming: true,
     });
     const next = makeProps({
       message: sharedUserMessage,
       onToolClick: stableOnToolClick,
+      onConsoleTitleClick: stableOnConsoleTitleClick,
+      connectionIconById: stableConnectionIconById,
       isLastMessage: false,
       isStreaming: true,
     });

--- a/app/src/components/chat-message-comparator.ts
+++ b/app/src/components/chat-message-comparator.ts
@@ -14,6 +14,8 @@ export interface ChatMessageRowProps {
   isLastMessage: boolean;
   isStreaming: boolean;
   onToolClick: (tool: any) => void;
+  onConsoleTitleClick: (consoleId: string) => void;
+  connectionIconById: ReadonlyMap<string, string>;
   /** Bust memo when MUI palette mode changes so row styles stay in sync */
   paletteMode: "light" | "dark";
 }
@@ -51,5 +53,7 @@ export function chatMessageRowArePropsEqual(
   if (prev.isLastMessage !== next.isLastMessage) return false;
   if (prev.isStreaming !== next.isStreaming) return false;
   if (prev.onToolClick !== next.onToolClick) return false;
+  if (prev.onConsoleTitleClick !== next.onConsoleTitleClick) return false;
+  if (prev.connectionIconById !== next.connectionIconById) return false;
   return prev.message === next.message;
 }

--- a/app/src/contexts/workspace-context.tsx
+++ b/app/src/contexts/workspace-context.tsx
@@ -4,6 +4,7 @@ import {
   useState,
   useEffect,
   useCallback,
+  useMemo,
   ReactNode,
 } from "react";
 import {
@@ -477,36 +478,61 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
     [setCurrentWorkspaceId],
   );
 
-  const value: WorkspaceContextState = {
-    // State
-    workspaces,
-    currentWorkspace,
-    members,
-    invites,
-    loading,
-    initialized,
-    error,
+  const value: WorkspaceContextState = useMemo(
+    () => ({
+      // State
+      workspaces,
+      currentWorkspace,
+      members,
+      invites,
+      loading,
+      initialized,
+      error,
 
-    // Actions
-    loadWorkspaces,
-    refreshWorkspaces,
-    createWorkspace,
-    createWorkspaceForOnboarding,
-    updateWorkspace,
-    deleteWorkspace,
-    switchWorkspace,
+      // Actions
+      loadWorkspaces,
+      refreshWorkspaces,
+      createWorkspace,
+      createWorkspaceForOnboarding,
+      updateWorkspace,
+      deleteWorkspace,
+      switchWorkspace,
 
-    // Member management
-    loadMembers,
-    inviteMember,
-    updateMemberRole,
-    removeMember,
+      // Member management
+      loadMembers,
+      inviteMember,
+      updateMemberRole,
+      removeMember,
 
-    // Invitation management
-    loadInvites,
-    cancelInvite,
-    acceptInvite,
-  };
+      // Invitation management
+      loadInvites,
+      cancelInvite,
+      acceptInvite,
+    }),
+    [
+      workspaces,
+      currentWorkspace,
+      members,
+      invites,
+      loading,
+      initialized,
+      error,
+      loadWorkspaces,
+      refreshWorkspaces,
+      createWorkspace,
+      createWorkspaceForOnboarding,
+      updateWorkspace,
+      deleteWorkspace,
+      switchWorkspace,
+      loadMembers,
+      inviteMember,
+      updateMemberRole,
+      removeMember,
+      loadInvites,
+      cancelInvite,
+      acceptInvite,
+    ],
+  );
 
   return (
     <WorkspaceContext.Provider value={value}>

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -5,6 +5,7 @@ import { apiClient } from "../lib/api-client";
 import { generateObjectId } from "../utils/objectId";
 import { ConsoleVersionManager } from "../utils/ConsoleVersionManager";
 import { computeConsoleStateHash } from "../utils/stateHash";
+import { logRenderDebug, renderDebugEnabled } from "../utils/renderDebug";
 import type { ConsoleTab, SettingsSection, TabKind } from "./lib/types";
 import type {
   ConsoleContentResponse,
@@ -254,6 +255,7 @@ export const useConsoleStore = create<ConsoleStore>()(
 
       setActiveTab: id =>
         set(state => {
+          if (state.activeTabId === id) return;
           state.activeTabId = id;
         }),
 
@@ -277,6 +279,7 @@ export const useConsoleStore = create<ConsoleStore>()(
         set(state => {
           const tab = state.tabs[id];
           if (tab) {
+            if (tab.content === content) return;
             tab.content = content;
           }
         }),
@@ -285,6 +288,7 @@ export const useConsoleStore = create<ConsoleStore>()(
         set(state => {
           const tab = state.tabs[id];
           if (tab) {
+            if (tab.title === title) return;
             tab.title = title;
           }
         }),
@@ -293,6 +297,7 @@ export const useConsoleStore = create<ConsoleStore>()(
         set(state => {
           const tab = state.tabs[id];
           if (tab) {
+            if (tab.isDirty === isDirty) return;
             tab.isDirty = isDirty;
           }
         }),
@@ -301,6 +306,7 @@ export const useConsoleStore = create<ConsoleStore>()(
         set(state => {
           const tab = state.tabs[id];
           if (tab) {
+            if (tab.icon === icon) return;
             tab.icon = icon;
           }
         }),
@@ -309,6 +315,7 @@ export const useConsoleStore = create<ConsoleStore>()(
         set(state => {
           const tab = state.tabs[id];
           if (tab) {
+            if (tab.connectionId === connectionId) return;
             tab.connectionId = connectionId;
           }
         }),
@@ -317,6 +324,12 @@ export const useConsoleStore = create<ConsoleStore>()(
         set(state => {
           const tab = state.tabs[id];
           if (tab) {
+            if (
+              tab.databaseId === databaseId &&
+              tab.databaseName === databaseName
+            ) {
+              return;
+            }
             tab.databaseId = databaseId;
             tab.databaseName = databaseName;
           }
@@ -326,6 +339,7 @@ export const useConsoleStore = create<ConsoleStore>()(
         set(state => {
           const tab = state.tabs[id];
           if (tab) {
+            if (tab.filePath === filePath) return;
             tab.filePath = filePath;
           }
         }),
@@ -334,6 +348,12 @@ export const useConsoleStore = create<ConsoleStore>()(
         set(state => {
           const tab = state.tabs[id];
           if (tab) {
+            if (
+              tab.isSaved === isSaved &&
+              tab.savedStateHash === savedStateHash
+            ) {
+              return;
+            }
             tab.isSaved = isSaved;
             tab.savedStateHash = savedStateHash;
           }
@@ -343,6 +363,7 @@ export const useConsoleStore = create<ConsoleStore>()(
         set(state => {
           const tab = state.tabs[id];
           if (tab) {
+            if (tab.chartSpec === (chartSpec ?? undefined)) return;
             tab.chartSpec = chartSpec ?? undefined;
           }
         }),
@@ -351,6 +372,7 @@ export const useConsoleStore = create<ConsoleStore>()(
         set(state => {
           const tab = state.tabs[id];
           if (tab) {
+            if (tab.resultsViewMode === mode) return;
             tab.resultsViewMode = mode;
           }
         }),
@@ -813,6 +835,66 @@ export const useConsoleStore = create<ConsoleStore>()(
     },
   ),
 );
+
+type ConsoleStoreDebugSnapshot = {
+  tabCount: number;
+  activeTabId: string | null;
+  tabOrder: string;
+  loadingKeys: string;
+  errorKeys: string;
+  activeTabContentLength: number | undefined;
+  activeTabViewMode: string | undefined;
+};
+
+const createConsoleStoreDebugSnapshot = (
+  state: ConsoleStore,
+): ConsoleStoreDebugSnapshot => {
+  const activeTab = state.activeTabId
+    ? state.tabs[state.activeTabId]
+    : undefined;
+  return {
+    tabCount: Object.keys(state.tabs).length,
+    activeTabId: state.activeTabId,
+    tabOrder: state.tabOrder.join("|"),
+    loadingKeys: Object.keys(state.loading)
+      .filter(key => state.loading[key])
+      .sort()
+      .join("|"),
+    errorKeys: Object.keys(state.error)
+      .filter(key => Boolean(state.error[key]))
+      .sort()
+      .join("|"),
+    activeTabContentLength: activeTab?.content.length,
+    activeTabViewMode: activeTab?.resultsViewMode,
+  };
+};
+
+if (renderDebugEnabled) {
+  let previousSnapshot = createConsoleStoreDebugSnapshot(
+    useConsoleStore.getState(),
+  );
+
+  useConsoleStore.subscribe(state => {
+    const nextSnapshot = createConsoleStoreDebugSnapshot(state);
+    const changedKeys = Object.keys(nextSnapshot).filter(
+      key =>
+        !Object.is(
+          previousSnapshot[key as keyof ConsoleStoreDebugSnapshot],
+          nextSnapshot[key as keyof ConsoleStoreDebugSnapshot],
+        ),
+    );
+
+    if (changedKeys.length > 0) {
+      logRenderDebug("consoleStore changed", {
+        changedKeys,
+        previous: previousSnapshot,
+        next: nextSnapshot,
+      });
+    }
+
+    previousSnapshot = nextSnapshot;
+  });
+}
 
 // Selectors
 export const selectConsoleTabs = (state: ConsoleStore): ConsoleTab[] => {

--- a/app/src/utils/consoleModification.test.ts
+++ b/app/src/utils/consoleModification.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { buildModificationDiff } from "./consoleModification";
+
+describe("buildModificationDiff", () => {
+  it("keeps patch previews focused on the modified range", () => {
+    const diff = buildModificationDiff("one\ntwo\nthree\nfour", {
+      action: "patch",
+      content: "TWO",
+      startLine: 2,
+      endLine: 3,
+    });
+
+    expect(diff).toBe("@@ -2,2 +2,1 @@\n-two\n-three\n+TWO");
+  });
+
+  it("truncates large replace previews", () => {
+    const currentContent = Array.from(
+      { length: 140 },
+      (_, index) => `old ${index + 1}`,
+    ).join("\n");
+    const nextContent = Array.from(
+      { length: 140 },
+      (_, index) => `new ${index + 1}`,
+    ).join("\n");
+
+    const diff = buildModificationDiff(currentContent, {
+      action: "replace",
+      content: nextContent,
+    });
+
+    expect(diff).toContain("@@ -1,140 +1,140 @@");
+    expect(diff).toContain("diff lines omitted");
+    expect(diff.split("\n")).toHaveLength(121);
+  });
+});

--- a/app/src/utils/consoleModification.ts
+++ b/app/src/utils/consoleModification.ts
@@ -1,5 +1,7 @@
 import { ConsoleModification } from "../hooks/useMonacoConsole";
 
+const MAX_DIFF_BODY_LINES = 120;
+
 /**
  * Apply a modification to console content.
  * This is the single source of truth for how modifications are applied.
@@ -63,5 +65,96 @@ export function applyModification(
 
     default:
       return currentContent;
+  }
+}
+
+function withLinePrefix(prefix: string, content: string): string[] {
+  if (!content) return [];
+  return content.split("\n").map(line => `${prefix}${line}`);
+}
+
+function limitDiffBodyLines(lines: string[]): string[] {
+  if (lines.length <= MAX_DIFF_BODY_LINES) return lines;
+
+  const visibleLines = MAX_DIFF_BODY_LINES - 1;
+  const headCount = Math.ceil(visibleLines / 2);
+  const tailCount = Math.floor(visibleLines / 2);
+  const omittedCount = lines.length - headCount - tailCount;
+
+  return [
+    ...lines.slice(0, headCount),
+    `... ${omittedCount} diff lines omitted ...`,
+    ...lines.slice(-tailCount),
+  ];
+}
+
+function formatDiffPreview(header: string, bodyLines: string[]): string {
+  return [header, ...limitDiffBodyLines(bodyLines)].join("\n");
+}
+
+/**
+ * Build a compact unified-diff preview for a console modification.
+ * The preview is intentionally local to the changed region so tool cards stay
+ * readable even when the console is large.
+ */
+export function buildModificationDiff(
+  currentContent: string,
+  modification: ConsoleModification,
+): string {
+  const currentLines = currentContent.split("\n");
+  const contentLines = modification.content
+    ? modification.content.split("\n")
+    : [];
+
+  switch (modification.action) {
+    case "patch": {
+      const startLine = modification.startLine ?? 1;
+      const endLine = modification.endLine ?? startLine;
+      const safeStartLine = Math.max(
+        1,
+        Math.min(startLine, currentLines.length),
+      );
+      const safeEndLine = Math.max(
+        safeStartLine,
+        Math.min(endLine, currentLines.length),
+      );
+      const removedLines = currentLines.slice(safeStartLine - 1, safeEndLine);
+      return formatDiffPreview(
+        `@@ -${safeStartLine},${removedLines.length} +${safeStartLine},${contentLines.length} @@`,
+        [
+          ...withLinePrefix("-", removedLines.join("\n")),
+          ...withLinePrefix("+", modification.content),
+        ],
+      );
+    }
+
+    case "insert": {
+      const line = modification.position?.line ?? 1;
+      return formatDiffPreview(
+        `@@ -${line},0 +${line},${contentLines.length} @@`,
+        withLinePrefix("+", modification.content),
+      );
+    }
+
+    case "append": {
+      const line = currentLines.length + 1;
+      return formatDiffPreview(
+        `@@ -${line},0 +${line},${contentLines.length} @@`,
+        withLinePrefix("+", modification.content),
+      );
+    }
+
+    case "replace": {
+      return formatDiffPreview(
+        `@@ -1,${currentLines.length} +1,${contentLines.length} @@`,
+        [
+          ...withLinePrefix("-", currentContent),
+          ...withLinePrefix("+", modification.content),
+        ],
+      );
+    }
+
+    default:
+      return "";
   }
 }

--- a/app/src/utils/renderDebug.ts
+++ b/app/src/utils/renderDebug.ts
@@ -1,0 +1,185 @@
+/* eslint-disable no-console */
+import { type ProfilerOnRenderCallback, useEffect, useRef } from "react";
+
+type DebugMetadata = Record<string, unknown>;
+
+const DEBUG_PREFIX = "[render-debug]";
+const MAX_CHANGED_KEYS_TO_LOG = 12;
+
+export const renderDebugEnabled =
+  import.meta.env.DEV && import.meta.env.VITE_RENDER_DEBUG === "true";
+
+function summarizeDebugValue(value: unknown): unknown {
+  if (
+    value === null ||
+    value === undefined ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+
+  if (typeof value === "function") {
+    return `[function ${(value as { name?: string }).name || "anonymous"}]`;
+  }
+
+  if (Array.isArray(value)) {
+    return `Array(${value.length})`;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const previewKeys = ["id", "_id", "title", "kind", "role", "type", "name"];
+    const preview = previewKeys.reduce<Record<string, unknown>>((acc, key) => {
+      if (key in record) {
+        acc[key] = record[key];
+      }
+      return acc;
+    }, {});
+    const constructorName = value.constructor?.name ?? "Object";
+
+    return Object.keys(preview).length > 0
+      ? `[${constructorName} ${JSON.stringify(preview)}]`
+      : `[${constructorName}]`;
+  }
+
+  return String(value);
+}
+
+function summarizeDebugMetadata(metadata?: DebugMetadata): DebugMetadata {
+  if (!metadata) return {};
+
+  return Object.entries(metadata).reduce<DebugMetadata>((acc, [key, value]) => {
+    if (
+      key === "changes" &&
+      value &&
+      typeof value === "object" &&
+      !Array.isArray(value)
+    ) {
+      acc[key] = Object.entries(
+        value as Record<string, DebugMetadata>,
+      ).reduce<DebugMetadata>((changeAcc, [changeKey, change]) => {
+        changeAcc[changeKey] = {
+          previous: summarizeDebugValue(change.previous),
+          next: summarizeDebugValue(change.next),
+        };
+        return changeAcc;
+      }, {});
+      return acc;
+    }
+
+    acc[key] = summarizeDebugValue(value);
+    return acc;
+  }, {});
+}
+
+export function logRenderDebug(label: string, metadata?: DebugMetadata): void {
+  if (!renderDebugEnabled) return;
+
+  const summary = summarizeDebugMetadata(metadata);
+  console.debug(`${DEBUG_PREFIX} ${label} ${JSON.stringify(summary)}`);
+}
+
+function useRenderCountEnabled(
+  componentName: string,
+  metadata?: DebugMetadata,
+): void {
+  const renderCountRef = useRef(0);
+  renderCountRef.current += 1;
+
+  useEffect(() => {
+    logRenderDebug(`${componentName} render`, {
+      count: renderCountRef.current,
+      ...metadata,
+    });
+  });
+}
+
+function useRenderCountDisabled(): void {
+  return;
+}
+
+export const useRenderCount: (
+  componentName: string,
+  metadata?: DebugMetadata,
+) => void = renderDebugEnabled ? useRenderCountEnabled : useRenderCountDisabled;
+
+function useWhyChangedEnabled(
+  componentName: string,
+  values: DebugMetadata,
+): void {
+  const previousValuesRef = useRef<DebugMetadata | undefined>();
+
+  useEffect(() => {
+    const previousValues = previousValuesRef.current;
+    previousValuesRef.current = values;
+
+    if (!previousValues) {
+      logRenderDebug(`${componentName} mounted`, values);
+      return;
+    }
+
+    const changedKeys = Object.keys(values).filter(
+      key => !Object.is(previousValues[key], values[key]),
+    );
+
+    if (changedKeys.length === 0) return;
+
+    const changes = changedKeys
+      .slice(0, MAX_CHANGED_KEYS_TO_LOG)
+      .reduce<
+        Record<string, { previous: unknown; next: unknown }>
+      >((acc, key) => {
+        acc[key] = {
+          previous: previousValues[key],
+          next: values[key],
+        };
+        return acc;
+      }, {});
+
+    logRenderDebug(`${componentName} changed`, {
+      changedKeys,
+      changes,
+      truncated: changedKeys.length > MAX_CHANGED_KEYS_TO_LOG,
+    });
+  });
+}
+
+function useWhyChangedDisabled(): void {
+  return;
+}
+
+export const useWhyChanged: (
+  componentName: string,
+  values: DebugMetadata,
+) => void = renderDebugEnabled ? useWhyChangedEnabled : useWhyChangedDisabled;
+
+const handleProfilerRenderDebug: ProfilerOnRenderCallback = (
+  id,
+  phase,
+  actualDuration,
+  baseDuration,
+  startTime,
+  commitTime,
+) => {
+  logRenderDebug(`profiler ${id}`, {
+    phase,
+    actualDuration: Number(actualDuration.toFixed(2)),
+    baseDuration: Number(baseDuration.toFixed(2)),
+    startTime: Number(startTime.toFixed(2)),
+    commitTime: Number(commitTime.toFixed(2)),
+  });
+};
+
+const noopProfilerRenderDebug: ProfilerOnRenderCallback = () => {
+  return;
+};
+
+export const onRenderDebug: ProfilerOnRenderCallback = renderDebugEnabled
+  ? handleProfilerRenderDebug
+  : noopProfilerRenderDebug;

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,9 +1,17 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import reactScan from "@react-scan/vite-plugin-react-scan";
 import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [
+    react(),
+    reactScan({
+      enable: process.env.VITE_REACT_SCAN === "true",
+      autoDisplayNames: true,
+    }),
+    tailwindcss(),
+  ],
   envDir: "..",
   server: {
     port: 5173,

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "docker:rebuild": "docker compose down && docker compose build && docker compose up -d",
     "docker:clean": "docker compose down -v",
     "app:dev": "pnpm --filter app run dev",
+    "app:dev:scan": "pnpm --filter app run dev:scan",
     "app:build": "pnpm --filter app run build",
     "app:preview": "pnpm --filter app run preview",
     "app:lint": "pnpm --filter app run lint",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,6 +401,9 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(@types/react@18.3.23)(immer@10.1.1)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
     devDependencies:
+      '@react-scan/vite-plugin-react-scan':
+        specifier: ^0.2.3
+        version: 0.2.3(react-scan@0.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.41.1))(vite@5.4.19(@types/node@24.12.0)(lightningcss@1.31.0))
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@5.4.19(@types/node@24.12.0)(lightningcss@1.31.0))
@@ -434,6 +437,9 @@ importers:
       eslint-plugin-react-refresh:
         specifier: ^0.4.20
         version: 0.4.20(eslint@8.57.1)
+      react-scan:
+        specifier: ^0.5.3
+        version: 0.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.41.1)
       tailwindcss:
         specifier: ^4.1.18
         version: 4.1.18
@@ -800,6 +806,10 @@ packages:
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.27.3':
     resolution: {integrity: sha512-V42wFfx1ymFte+ecf6iXghnnP8kWTO+ZLXIyZq+1LAXHHvTZdVxicn4yiVYdYMGaCO3tmqub11AorKkv+iodqw==}
     engines: {node: '>=6.9.0'}
@@ -812,12 +822,38 @@ packages:
     resolution: {integrity: sha512-xnlJYj5zepml8NXtjkG0WquFUv8RskFqyFcVgTBp5k+NaA/8uw/K+OSVf8AMGw5e9HKP2ETd5xpK5MLZQD6b4Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-annotate-as-pure@7.27.3':
+    resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-compilation-targets@7.27.2':
     resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-create-class-features-plugin@7.28.6':
+    resolution: {integrity: sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-member-expression-to-functions@7.28.5':
+    resolution: {integrity: sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-module-imports@7.27.1':
     resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-transforms@7.27.3':
@@ -826,8 +862,32 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-optimise-call-expression@7.27.1':
+    resolution: {integrity: sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-plugin-utils@7.27.1':
     resolution: {integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-replace-supers@7.28.6':
+    resolution: {integrity: sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
+    resolution: {integrity: sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.27.1':
@@ -856,6 +916,29 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-syntax-jsx@7.28.6':
+    resolution: {integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-typescript@7.28.6':
+    resolution: {integrity: sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-modules-commonjs@7.28.6':
+    resolution: {integrity: sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-react-jsx-self@7.27.1':
     resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
     engines: {node: '>=6.9.0'}
@@ -864,6 +947,24 @@ packages:
 
   '@babel/plugin-transform-react-jsx-source@7.27.1':
     resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx@7.28.6':
+    resolution: {integrity: sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-typescript@7.28.6':
+    resolution: {integrity: sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/preset-typescript@7.28.5':
+    resolution: {integrity: sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -880,8 +981,16 @@ packages:
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/traverse@7.27.3':
     resolution: {integrity: sha512-lId/IfN/Ye1CIu8xG7oKBHXd2iNb2aW1ilPszzGcJug6M8RCKfVNcYhpI5+bMvFYjK7lXIM0R+a+6r8xhHp2FQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.27.3':
@@ -890,6 +999,10 @@ packages:
 
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@braintree/sanitize-url@7.1.2':
@@ -1719,183 +1832,155 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -2192,28 +2277,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@14.2.33':
     resolution: {integrity: sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@14.2.33':
     resolution: {integrity: sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@14.2.33':
     resolution: {integrity: sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@14.2.33':
     resolution: {integrity: sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==}
@@ -2767,6 +2848,14 @@ packages:
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
+  '@preact/signals-core@1.14.1':
+    resolution: {integrity: sha512-vxPpfXqrwUe9lpjqfYNjAF/0RF/eFGeLgdJzdmIIZjpOnTmGmAB4BjWone562mJGMRP4frU6iZ6ei3PDsu52Ng==}
+
+  '@preact/signals@1.3.4':
+    resolution: {integrity: sha512-TPMkStdT0QpSc8FpB63aOwXoSiZyIrPsP9Uj347KopdS6olZdAYeeird/5FZv/M1Yc1ge5qstub2o8VDbvkT4g==}
+    peerDependencies:
+      preact: 10.x
+
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -2796,6 +2885,12 @@ packages:
 
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
+  '@react-scan/vite-plugin-react-scan@0.2.3':
+    resolution: {integrity: sha512-iCguMDp08xPQjB9XB6mnKdc1iLY7Jb5TEyqhNALxfHBRZZFutw1iTkpnEianCgY7I0Kce8Pk4OwrETx0VA+6vA==}
+    peerDependencies:
+      react-scan: '>=0.5.3'
+      vite: ^2 || ^3 || ^4 || ^5 || ^6
 
   '@readme/better-ajv-errors@2.3.2':
     resolution: {integrity: sha512-T4GGnRAlY3C339NhoUpgJJFsMYko9vIgFAlhgV+/vEGFw66qEY4a4TRJIAZBcX/qT1pq5DvXSme+SQODHOoBrw==}
@@ -2889,67 +2984,56 @@ packages:
     resolution: {integrity: sha512-wC53ZNDgt0pqx5xCAgNunkTzFE8GTgdZ9EwYGVcg+jEjJdZGtq9xPjDnFgfFozQI/Xm1mh+D9YlYtl+ueswNEg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.41.1':
     resolution: {integrity: sha512-jwKCca1gbZkZLhLRtsrka5N8sFAaxrGz/7wRJ8Wwvq3jug7toO21vWlViihG85ei7uJTpzbXZRcORotE+xyrLA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.41.1':
     resolution: {integrity: sha512-g0UBcNknsmmNQ8V2d/zD2P7WWfJKU0F1nu0k5pW4rvdb+BIqMm8ToluW/eeRmxCared5dD76lS04uL4UaNgpNA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.41.1':
     resolution: {integrity: sha512-XZpeGB5TKEZWzIrj7sXr+BEaSgo/ma/kCgrZgL0oo5qdB1JlTzIYQKel/RmhT6vMAvOdM2teYlAaOGJpJ9lahg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.41.1':
     resolution: {integrity: sha512-bkCfDJ4qzWfFRCNt5RVV4DOw6KEgFTUZi2r2RuYhGWC8WhCA8lCAJhDeAmrM/fdiAH54m0mA0Vk2FGRPyzI+tw==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.41.1':
     resolution: {integrity: sha512-3mr3Xm+gvMX+/8EKogIZSIEF0WUu0HL9di+YWlJpO8CQBnoLAEL/roTCxuLncEdgcfJcvA4UMOf+2dnjl4Ut1A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.41.1':
     resolution: {integrity: sha512-3rwCIh6MQ1LGrvKJitQjZFuQnT2wxfU+ivhNBzmxXTXPllewOF7JR1s2vMX/tWtUYFgphygxjqMl76q4aMotGw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.41.1':
     resolution: {integrity: sha512-LdIUOb3gvfmpkgFZuccNa2uYiqtgZAz3PTzjuM5bH3nvuy9ty6RGc/Q0+HDFrHrizJGVpjnTZ1yS5TNNjFlklw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.41.1':
     resolution: {integrity: sha512-oIE6M8WC9ma6xYqjvPhzZYk6NbobIURvP/lEbh7FWplcMO6gn7MM2yHKA1eC/GvYwzNKK/1LYgqzdkZ8YFxR8g==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.41.1':
     resolution: {integrity: sha512-cWBOvayNvA+SyeQMp79BHPK8ws6sHSsYnK5zDcsC3Hsxr1dgTABKjMnMslPq1DvZIp6uO7kIWhiGwaTdR4Og9A==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.41.1':
     resolution: {integrity: sha512-y5CbN44M+pUCdGDlZFzGGBSKCA4A/J2ZH4edTYSSxFg7ce1Xt3GtydbVKWLlzL+INfFIZAEg1ZV6hh9+QQf9YQ==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.41.1':
     resolution: {integrity: sha512-lZkCxIrjlJlMt1dLO/FbpZbzt6J/A8p4DnqzSa4PWqPEUUUnzXLeki/iyPLfV0BmHItlYgHUqJe+3KiyydmiNQ==}
@@ -3260,28 +3344,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -4123,6 +4203,9 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  babel-plugin-add-react-displayname@0.0.5:
+    resolution: {integrity: sha512-LY3+Y0XVDYcShHHorshrDbt4KFWL4bSeniCtl4SYZbask+Syngk1uMPCeN9+nSiZo6zX5s0RTq/J9Pnaaf/KHw==}
+
   babel-plugin-macros@3.1.0:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
@@ -4179,6 +4262,11 @@ packages:
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bippy@0.5.39:
+    resolution: {integrity: sha512-8hE8rKSl8JWyeaY+JjpnmceWAZPpLEyzOZQpWXM5Rc7861c5WotMJHy2aRZKZrGA8nMpvLNF01t4yQQ+HcZG3w==}
+    peerDependencies:
+      react: '>=17.0.1'
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -4373,6 +4461,13 @@ packages:
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
+
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.2.0:
+    resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
+    engines: {node: '>=20.18.1'}
 
   chevrotain-allstar@0.3.1:
     resolution: {integrity: sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==}
@@ -4667,12 +4762,19 @@ packages:
   css-line-break@2.1.0:
     resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
 
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
   css-selector-parser@3.2.0:
     resolution: {integrity: sha512-L1bdkNKUP5WYxiW5dW6vA2hd3sL8BdRNLy2FCX0rLVise4eNw9nBdeBuJHxlELieSE2H1f6bYQFfwVUwWCV9rQ==}
 
   css-tree@3.1.0:
     resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -5028,8 +5130,21 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
   dompurify@3.3.3:
     resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   dot-prop@7.2.0:
     resolution: {integrity: sha512-Ol/IPXUARn9CSbkrdV4VJo7uCy1I3VuSiWCaFSg+8BdUOzF9n3jefIpcgAydvUZbTdEBZs2vEiTiS9m61ssiDA==}
@@ -5081,6 +5196,9 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  encoding-sniffer@0.2.1:
+    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
   encoding@0.1.13:
     resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
 
@@ -5091,8 +5209,16 @@ packages:
     resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
     engines: {node: '>=10.13.0'}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   env-paths@2.2.1:
@@ -5917,6 +6043,9 @@ packages:
     resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
     engines: {node: '>=8.0.0'}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
@@ -6039,6 +6168,7 @@ packages:
   inngest@3.39.2:
     resolution: {integrity: sha512-P71dUa16SUsFnhsBvzWICj/i3BiXDNZ1UVf+qXXAGQQ6BcszEW8ZHgk5t4tQvfKJ7KZ8oYrLvq2JGat+dhXx0Q==}
     engines: {node: '>=14'}
+    deprecated: 'CRITICAL SECURITY: upgrade to >=3.54.0'
     peerDependencies:
       '@sveltejs/kit': '>=1.27.3'
       '@vercel/node': '>=2.15.9'
@@ -6555,56 +6685,48 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.31.0:
     resolution: {integrity: sha512-EpAQTq6TXL+200bDNMzhbFpqAJsto01R//xuE8yAWN0l4wmJhmS1r/FxoudIUM9PxHMPEiWeLw+1thdF5ZPg7Q==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.31.0:
     resolution: {integrity: sha512-6tuU37nXStA3kxNnjC49z1tPFEoviC9ZLyB34O3X1/VTLXdZX2vmPZ+45XesagvlgoeJQ9r9XVSovUZny41AQA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.31.0:
     resolution: {integrity: sha512-enNePbgDKmJybVz90/8dAGTOulvpn0IwxamHHnIj32gmdbuSPJ9mk+Nob4UmiqLMAdHlH+0c+lpsZkv4TSxi3w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-musl@1.31.0:
     resolution: {integrity: sha512-EM4jGT+V+PdFkcrIB5m5yiSzfV7z43k0pOtUmODhFSbuay5JvbVChK1uoaMmwPTKGWatwSRbiu90BUzU262B9g==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -7635,6 +7757,12 @@ packages:
   parse-numeric-range@1.3.0:
     resolution: {integrity: sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==}
 
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
+
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
@@ -7836,6 +7964,9 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  preact@10.29.1:
+    resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
+
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
@@ -8015,6 +8146,13 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
+
+  react-scan@0.5.3:
+    resolution: {integrity: sha512-qde9PupmUf0L3MU1H6bjmoukZNbCXdMyTEwP4Gh8RQ4rZPd2GGNBgEKWszwLm96E8k+sGtMpc0B9P0KyFDP6Bw==}
+    hasBin: true
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-syntax-highlighter@15.6.1:
     resolution: {integrity: sha512-OqJ2/vL7lEeV5zTJyG7kmARppUjiB9h9udl4qHQjjgEos66z00Ia0OckwYfRxCSFrW8RJIBnsBwQsHZbVPspqg==}
@@ -9105,6 +9243,10 @@ packages:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
     engines: {node: '>=14.0'}
 
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
+
   unenv@2.0.0-rc.14:
     resolution: {integrity: sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==}
 
@@ -9168,6 +9310,10 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  unplugin@2.1.0:
+    resolution: {integrity: sha512-us4j03/499KhbGP8BU7Hrzrgseo+KdfJYWcbcajCOqsAyb8Gk0Yn2kiUIcZISYCb1JFaZfIuG3b42HmguVOKCQ==}
+    engines: {node: '>=18.12.0'}
 
   unstorage@1.17.2:
     resolution: {integrity: sha512-cKEsD6iBWJgOMJ6vW1ID/SYuqNf8oN4yqRk8OYqaVQ3nnkJXOT1PSpaMh2QfzLs78UN5kSNRD2c/mgjT8tX7+w==}
@@ -9595,8 +9741,20 @@ packages:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
 
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
 
   whatwg-url@14.2.0:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
@@ -10562,6 +10720,12 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.27.3': {}
 
   '@babel/core@7.27.3':
@@ -10586,11 +10750,23 @@ snapshots:
 
   '@babel/generator@7.27.3':
     dependencies:
-      '@babel/parser': 7.27.3
-      '@babel/types': 7.27.3
-      '@jridgewell/gen-mapping': 0.3.8
-      '@jridgewell/trace-mapping': 0.3.25
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-annotate-as-pure@7.27.3':
+    dependencies:
+      '@babel/types': 7.29.0
 
   '@babel/helper-compilation-targets@7.27.2':
     dependencies:
@@ -10600,10 +10776,39 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
+  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.27.3)':
+    dependencies:
+      '@babel/core': 7.27.3
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.27.3)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/traverse': 7.29.0
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-member-expression-to-functions@7.28.5':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-imports@7.27.1':
     dependencies:
       '@babel/traverse': 7.27.3
-      '@babel/types': 7.27.3
+      '@babel/types': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10616,7 +10821,38 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.27.3)':
+    dependencies:
+      '@babel/core': 7.27.3
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-optimise-call-expression@7.27.1':
+    dependencies:
+      '@babel/types': 7.28.5
+
   '@babel/helper-plugin-utils@7.27.1': {}
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-replace-supers@7.28.6(@babel/core@7.27.3)':
+    dependencies:
+      '@babel/core': 7.27.3
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
+    dependencies:
+      '@babel/traverse': 7.27.3
+      '@babel/types': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -10627,15 +10863,37 @@ snapshots:
   '@babel/helpers@7.27.3':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.27.3
+      '@babel/types': 7.28.5
 
   '@babel/parser@7.27.3':
     dependencies:
-      '@babel/types': 7.27.3
+      '@babel/types': 7.28.5
 
   '@babel/parser@7.28.5':
     dependencies:
       '@babel/types': 7.28.5
+
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.27.3)':
+    dependencies:
+      '@babel/core': 7.27.3
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.27.3)':
+    dependencies:
+      '@babel/core': 7.27.3
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.27.3)':
+    dependencies:
+      '@babel/core': 7.27.3
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.27.3)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.27.3)':
     dependencies:
@@ -10647,6 +10905,39 @@ snapshots:
       '@babel/core': 7.27.3
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.27.3)':
+    dependencies:
+      '@babel/core': 7.27.3
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.27.3)
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.27.3)':
+    dependencies:
+      '@babel/core': 7.27.3
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.27.3)
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.27.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/preset-typescript@7.28.5(@babel/core@7.27.3)':
+    dependencies:
+      '@babel/core': 7.27.3
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-validator-option': 7.27.1
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.27.3)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.27.3)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.27.3)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/runtime@7.27.3': {}
 
   '@babel/runtime@7.29.2': {}
@@ -10655,7 +10946,13 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/parser': 7.27.3
-      '@babel/types': 7.27.3
+      '@babel/types': 7.28.5
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
 
   '@babel/traverse@7.27.3':
     dependencies:
@@ -10663,9 +10960,21 @@ snapshots:
       '@babel/generator': 7.27.3
       '@babel/parser': 7.27.3
       '@babel/template': 7.27.2
-      '@babel/types': 7.27.3
+      '@babel/types': 7.28.5
       debug: 4.4.1(supports-color@5.5.0)
       globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -10675,6 +10984,11 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.28.5':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
@@ -12562,6 +12876,13 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
+  '@preact/signals-core@1.14.1': {}
+
+  '@preact/signals@1.3.4(preact@10.29.1)':
+    dependencies:
+      '@preact/signals-core': 1.14.1
+      preact: 10.29.1
+
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -12584,6 +12905,18 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.0': {}
+
+  '@react-scan/vite-plugin-react-scan@0.2.3(react-scan@0.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.41.1))(vite@5.4.19(@types/node@24.12.0)(lightningcss@1.31.0))':
+    dependencies:
+      '@babel/core': 7.27.3
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.27.3)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.27.3)
+      babel-plugin-add-react-displayname: 0.0.5
+      cheerio: 1.2.0
+      react-scan: 0.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.41.1)
+      vite: 5.4.19(@types/node@24.12.0)(lightningcss@1.31.0)
+    transitivePeerDependencies:
+      - supports-color
 
   '@readme/better-ajv-errors@2.3.2(ajv@8.17.1)':
     dependencies:
@@ -12649,7 +12982,7 @@ snapshots:
 
   '@rollup/pluginutils@5.3.0(rollup@4.41.1)':
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.3
     optionalDependencies:
@@ -13254,16 +13587,16 @@ snapshots:
 
   '@types/babel__generator@7.27.0':
     dependencies:
-      '@babel/types': 7.27.3
+      '@babel/types': 7.28.5
 
   '@types/babel__template@7.4.4':
     dependencies:
       '@babel/parser': 7.27.3
-      '@babel/types': 7.27.3
+      '@babel/types': 7.28.5
 
   '@types/babel__traverse@7.20.7':
     dependencies:
-      '@babel/types': 7.27.3
+      '@babel/types': 7.28.5
 
   '@types/bcrypt@5.0.2':
     dependencies:
@@ -13882,6 +14215,10 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn-walk@8.3.2: {}
 
   acorn-walk@8.3.4:
@@ -14326,6 +14663,8 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  babel-plugin-add-react-displayname@0.0.5: {}
+
   babel-plugin-macros@3.1.0:
     dependencies:
       '@babel/runtime': 7.27.3
@@ -14377,6 +14716,10 @@ snapshots:
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
+
+  bippy@0.5.39(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   bl@4.1.0:
     dependencies:
@@ -14605,6 +14948,29 @@ snapshots:
   chardet@0.7.0: {}
 
   check-error@2.1.3: {}
+
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.2.2
+      css-what: 6.2.2
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+
+  cheerio@1.2.0:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.1
+      htmlparser2: 10.1.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 7.25.0
+      whatwg-mimetype: 4.0.0
 
   chevrotain-allstar@0.3.1(chevrotain@11.1.2):
     dependencies:
@@ -14911,12 +15277,22 @@ snapshots:
     dependencies:
       utrie: 1.0.2
 
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
   css-selector-parser@3.2.0: {}
 
   css-tree@3.1.0:
     dependencies:
       mdn-data: 2.12.2
       source-map-js: 1.2.1
+
+  css-what@6.2.2: {}
 
   cssesc@3.0.0: {}
 
@@ -15269,9 +15645,27 @@ snapshots:
       '@babel/runtime': 7.27.3
       csstype: 3.1.3
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
   dompurify@3.3.3:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
 
   dot-prop@7.2.0:
     dependencies:
@@ -15318,6 +15712,11 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
+  encoding-sniffer@0.2.1:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
+
   encoding@0.1.13:
     dependencies:
       iconv-lite: 0.6.3
@@ -15332,7 +15731,11 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.0
 
+  entities@4.5.0: {}
+
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   env-paths@2.2.1:
     optional: true
@@ -15488,7 +15891,7 @@ snapshots:
   esast-util-from-js@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
-      acorn: 8.15.0
+      acorn: 8.16.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.2
 
@@ -15716,7 +16119,7 @@ snapshots:
 
   estree-util-attach-comments@3.0.0:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
 
   estree-util-build-jsx@3.0.1:
     dependencies:
@@ -15749,7 +16152,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
 
   esutils@2.0.3: {}
 
@@ -16467,7 +16870,7 @@ snapshots:
 
   hast-util-to-estree@3.1.3:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       comma-separated-tokens: 2.0.3
@@ -16585,6 +16988,13 @@ snapshots:
     dependencies:
       css-line-break: 2.1.0
       text-segmentation: 1.0.3
+
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
 
   http-cache-semantics@4.2.0: {}
 
@@ -17781,7 +18191,7 @@ snapshots:
 
   micromark-extension-mdx-expression@3.0.1:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       micromark-factory-mdx-expression: 2.0.3
       micromark-factory-space: 2.0.1
@@ -17792,7 +18202,7 @@ snapshots:
 
   micromark-extension-mdx-jsx@3.0.2:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       micromark-factory-mdx-expression: 2.0.3
@@ -17809,7 +18219,7 @@ snapshots:
 
   micromark-extension-mdxjs-esm@3.0.0:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
       micromark-util-character: 2.1.1
@@ -17821,8 +18231,8 @@ snapshots:
 
   micromark-extension-mdxjs@3.0.0:
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
       micromark-extension-mdx-expression: 3.0.1
       micromark-extension-mdx-jsx: 3.0.2
       micromark-extension-mdx-md: 2.0.0
@@ -17845,7 +18255,7 @@ snapshots:
 
   micromark-factory-mdx-expression@2.0.3:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       micromark-factory-space: 2.0.1
       micromark-util-character: 2.1.1
@@ -17909,7 +18319,7 @@ snapshots:
 
   micromark-util-events-to-acorn@2.0.3:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       '@types/unist': 3.0.3
       devlop: 1.1.0
       estree-util-visit: 2.0.0
@@ -18649,6 +19059,15 @@ snapshots:
 
   parse-numeric-range@1.3.0: {}
 
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.3.0
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
+      parse5: 7.3.0
+
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
@@ -18809,6 +19228,8 @@ snapshots:
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
+
+  preact@10.29.1: {}
 
   prebuild-install@7.1.3:
     dependencies:
@@ -18999,6 +19420,29 @@ snapshots:
       '@remix-run/router': 1.23.0
       react: 18.3.1
 
+  react-scan@0.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.41.1):
+    dependencies:
+      '@babel/core': 7.27.3
+      '@babel/generator': 7.27.3
+      '@babel/types': 7.28.5
+      '@preact/signals': 1.3.4(preact@10.29.1)
+      '@rollup/pluginutils': 5.3.0(rollup@4.41.1)
+      '@types/node': 20.17.50
+      bippy: 0.5.39(react@18.3.1)
+      commander: 14.0.2
+      esbuild: 0.25.5
+      estree-walker: 3.0.3
+      picocolors: 1.1.1
+      preact: 10.29.1
+      prompts: 2.4.2
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      unplugin: 2.1.0
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+
   react-syntax-highlighter@15.6.1(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.27.3
@@ -19086,7 +19530,7 @@ snapshots:
 
   recma-parse@1.0.0:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       esast-util-from-js: 2.0.1
       unified: 11.0.5
       vfile: 6.0.3
@@ -20420,6 +20864,8 @@ snapshots:
     dependencies:
       '@fastify/busboy': 2.1.1
 
+  undici@7.25.0: {}
+
   unenv@2.0.0-rc.14:
     dependencies:
       defu: 6.1.4
@@ -20528,6 +20974,12 @@ snapshots:
       unist-util-visit-parents: 6.0.2
 
   unpipe@1.0.0: {}
+
+  unplugin@2.1.0:
+    dependencies:
+      acorn: 8.16.0
+      webpack-virtual-modules: 0.6.2
+    optional: true
 
   unstorage@1.17.2(@azure/identity@4.10.0)(idb-keyval@6.2.2):
     dependencies:
@@ -21019,7 +21471,16 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
+  webpack-virtual-modules@0.6.2:
+    optional: true
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
   whatwg-fetch@3.6.20: {}
+
+  whatwg-mimetype@4.0.0: {}
 
   whatwg-url@14.2.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Stabilize hot-path callbacks, memo boundaries, and store no-op writes across the console UI, explorers, results table, and workspace context.
- Add render-debug/react-scan instrumentation gated behind env flags for diagnosing render churn without normal-run hook overhead.
- Refine chat tool cards for console modifications with console title/icon diff previews, safer failed-tool behavior, and bounded diff output.
- Document the React Scan workflow with `pnpm run app:dev:scan` and a project skill for future render profiling work.

## Test plan
- pnpm --filter app exec vitest run src/components/__tests__/Chat.perf.test.ts src/utils/consoleModification.test.ts
- pnpm --filter app run typecheck
- pnpm --filter app run lint
- pnpm run app:dev:scan --help