### PR TITLE
fix(agent): make modify_console position optional

### DIFF
--- a/api/src/agent-lib/tools/console-tools-client.ts
+++ b/api/src/agent-lib/tools/console-tools-client.ts
@@ -27,7 +27,10 @@ export const modifyConsoleSchema = z.object({
   position: z
     .number()
     .nullable()
-    .describe("Position for insert action (null for replace/append/patch)"),
+    .optional()
+    .describe(
+      "Line number for the 'insert' action (1-indexed). Omit or pass null for 'replace', 'append', and 'patch' actions.",
+    ),
   consoleId: z
     .string()
     .describe(

--- a/app/src/agent-runtime/console-agent-tools.ts
+++ b/app/src/agent-runtime/console-agent-tools.ts
@@ -140,11 +140,26 @@ export async function executeConsoleAgentTool({
   if (toolName === "modify_console") {
     const action = input.action as "replace" | "insert" | "append" | "patch";
     const content = input.content as string;
-    const position = input.position as number | null;
     const consoleId = input.consoleId as string | undefined;
     const modifyTitle = input.title as string | undefined;
-    const startLine = input.startLine as number | undefined;
-    const endLine = input.endLine as number | undefined;
+
+    // Some tool-calling models (e.g. Qwen via Vercel AI Gateway) serialize
+    // numeric and nullable fields as strings (e.g. "" or "0"). Coerce here so
+    // we accept those without rejecting the call.
+    const coerceOptionalNumber = (raw: unknown): number | null | undefined => {
+      if (raw === undefined || raw === null) return raw as null | undefined;
+      if (typeof raw === "number") return Number.isFinite(raw) ? raw : null;
+      if (typeof raw === "string") {
+        const trimmed = raw.trim();
+        if (trimmed === "" || trimmed.toLowerCase() === "null") return null;
+        const parsed = Number(trimmed);
+        return Number.isFinite(parsed) ? parsed : null;
+      }
+      return null;
+    };
+    const position = coerceOptionalNumber(input.position) ?? null;
+    const startLine = coerceOptionalNumber(input.startLine) ?? undefined;
+    const endLine = coerceOptionalNumber(input.endLine) ?? undefined;
 
     if (!consoleId) {
       emitToolOutput(addToolOutput, toolName, toolCallId, {


### PR DESCRIPTION
## Summary

Both **Qwen** and **Opus** repeatedly fail to call `modify_console` with `action: "patch" | "replace" | "append"` because the schema marks `position` as required:

```ts
position: z.number().nullable(),   // required in JSON schema
```

`position` is only meaningful for `insert`. Different models fail in different ways:

- **Opus** (clean JSON transport): simply omits `position` on its first attempt → Zod rejects the call → Opus has to retry with `position: null`. Two tool calls burned per edit.
- **Qwen** (via AI Gateway, string-coerces everything): tries `null`, `""`, `0`, `"0"` across five attempts, every one fails Zod validation, eventually gives up and calls `create_console` as a workaround, creating a duplicate console.

Two small changes fix both:

1. **`api/src/agent-lib/tools/console-tools-client.ts`** — mark `position` as `.optional()` on top of `.nullable()`. This drops it from the JSON schema's `required` list, so models can just omit it when irrelevant. The handler already treated `undefined` and `null` identically, so behavior is unchanged for well-behaved models.
2. **`app/src/agent-runtime/console-agent-tools.ts`** — the client-side `modify_console` handler now coerces `position`, `startLine`, and `endLine` through a small helper that accepts `number`, `"5"`, `""`, `"null"`, `null`, and `undefined`. Belt-and-suspenders so we don't regress the next time a model runtime stringifies numeric args.

Verified via `zod-to-json-schema`:

```text
BEFORE required: ["action","content","position","consoleId"]
AFTER  required: ["action","content","consoleId"]
```

## Test plan

- [x] `pnpm --filter app run typecheck`
- [x] `pnpm --filter app run lint`
- [x] `pnpm --filter api run lint`
- [x] Manual: confirmed `position` no longer appears in the `required` array of the generated JSON schema.
- [ ] Follow-up in prod: next Opus/Qwen chat that edits a console should patch in a single `modify_console` call (no retry with `position: null`, no fallback to `create_console`).

Made with [Cursor](https://cursor.com)