### PR TITLE
fix(scheduled-queries): decrypt credentials in executor; sync Runs tab counter

### DIFF
--- a/api/src/inngest/functions/scheduled-query.ts
+++ b/api/src/inngest/functions/scheduled-query.ts
@@ -141,24 +141,30 @@ export const scheduledQueryExecutorFunction = inngest.createFunction(
 
     try {
       const consoleDoc = (await step.run("load-console", async () => {
-        const savedConsole = (await SavedConsole.findOne({
+        const savedConsoleDoc = await SavedConsole.findOne({
           _id: new Types.ObjectId(consoleId),
           workspaceId: new Types.ObjectId(workspaceId),
-        }).lean()) as ISavedConsole | null;
+        });
 
-        if (!savedConsole) {
+        if (!savedConsoleDoc) {
           throw new Error("Scheduled console not found");
         }
 
-        const connection = savedConsole.connectionId
-          ? ((await DatabaseConnection.findById(
-              savedConsole.connectionId,
-            ).lean()) as IDatabaseConnection | null)
+        const savedConsole = savedConsoleDoc.toObject({
+          getters: true,
+        }) as ISavedConsole;
+
+        const connectionMongooseDoc = savedConsole.connectionId
+          ? await DatabaseConnection.findById(savedConsole.connectionId)
           : null;
 
-        if (!connection) {
+        if (!connectionMongooseDoc) {
           throw new Error("Scheduled console has no database connection");
         }
+
+        const connection = connectionMongooseDoc.toObject({
+          getters: true,
+        }) as IDatabaseConnection;
 
         return {
           savedConsole,

--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -469,16 +469,28 @@ consoleRoutes.get("/:id/schedule/runs", async (c: AuthenticatedContext) => {
       return c.json({ success: false, error: "Invalid console ID" }, 400);
     }
 
-    const runs = await ScheduledQueryRun.find({
-      workspaceId: new Types.ObjectId(workspaceId),
-      consoleId: new Types.ObjectId(consoleId),
-    })
-      .sort({ triggeredAt: -1 })
-      .limit(limit)
-      .lean();
+    const workspaceObjectId = new Types.ObjectId(workspaceId);
+    const consoleObjectId = new Types.ObjectId(consoleId);
+
+    const [runs, consoleDoc] = await Promise.all([
+      ScheduledQueryRun.find({
+        workspaceId: workspaceObjectId,
+        consoleId: consoleObjectId,
+      })
+        .sort({ triggeredAt: -1 })
+        .limit(limit)
+        .lean(),
+      SavedConsole.findOne({
+        _id: consoleObjectId,
+        workspaceId: workspaceObjectId,
+      })
+        .select("scheduledRun")
+        .lean(),
+    ]);
 
     return c.json({
       success: true,
+      scheduledRun: consoleDoc?.scheduledRun,
       runs: runs.map(run => ({
         id: run._id.toString(),
         triggeredAt: run.triggeredAt,

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -462,6 +462,9 @@ function Editor({
   const removeSchedule = useConsoleStore(state => state.removeSchedule);
   const runScheduledNow = useConsoleStore(state => state.runScheduledNow);
   const listScheduledRuns = useConsoleStore(state => state.listScheduledRuns);
+  const updateTabScheduledRun = useConsoleStore(
+    state => state.updateTabScheduledRun,
+  );
   const openTab = useConsoleStore(state => state.openTab);
   const reorderTabs = useConsoleStore(state => state.reorderTabs);
   const reloadConsole = useConsoleStore(state => state.reloadConsole);
@@ -1301,6 +1304,7 @@ function Editor({
       const response = await listScheduledRuns(currentWorkspace.id, tabId, 50);
       if (response.success) {
         setTabScheduledRuns(prev => ({ ...prev, [tabId]: response.runs }));
+        updateTabScheduledRun(tabId, response.scheduledRun);
       } else {
         setTabScheduledRunsError(prev => ({
           ...prev,
@@ -1310,7 +1314,7 @@ function Editor({
 
       setTabScheduledRunsLoading(prev => ({ ...prev, [tabId]: false }));
     },
-    [currentWorkspace, listScheduledRuns],
+    [currentWorkspace, listScheduledRuns, updateTabScheduledRun],
   );
 
   useEffect(() => {

--- a/app/src/lib/api-types.ts
+++ b/app/src/lib/api-types.ts
@@ -96,6 +96,8 @@ export interface ScheduledQueryRunItem {
 export interface ScheduledQueryRunsResponse {
   success: boolean;
   runs: ScheduledQueryRunItem[];
+  /** Latest snapshot from SavedConsole.scheduledRun (for Runs tab counter). */
+  scheduledRun?: ConsoleContentResponse["scheduledRun"];
   error?: string;
 }
 

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -161,6 +161,11 @@ interface ConsoleActions {
     consoleId: string,
     limit?: number,
   ) => Promise<ScheduledQueryRunsResponse>;
+  /** Merge latest scheduledRun snapshot (e.g. after GET schedule/runs). */
+  updateTabScheduledRun: (
+    tabId: string,
+    scheduledRun: ConsoleContentResponse["scheduledRun"] | undefined,
+  ) => void;
 }
 
 type ConsoleStore = ConsoleState & ConsoleActions;
@@ -197,6 +202,28 @@ const shouldAutoSave = (getState: () => ConsoleState, consoleId: string) => {
   const tab = getState().tabs[consoleId];
   return tab ? !tab.isSaved : true;
 };
+
+function normalizeScheduledRunSnapshotForTab(
+  scheduledRun: ConsoleContentResponse["scheduledRun"],
+): ConsoleTab["scheduledRun"] {
+  const toIso = (v: unknown): string | undefined => {
+    if (v == null) return undefined;
+    if (typeof v === "string") return v;
+    if (v instanceof Date) return v.toISOString();
+    return String(v);
+  };
+  return {
+    nextAt: toIso(scheduledRun?.nextAt),
+    lastAt: toIso(scheduledRun?.lastAt),
+    lastStatus: scheduledRun?.lastStatus,
+    lastError: scheduledRun?.lastError,
+    lastDurationMs: scheduledRun?.lastDurationMs,
+    lastRowsAffected: scheduledRun?.lastRowsAffected,
+    lastRowCount: scheduledRun?.lastRowCount,
+    runCount: scheduledRun?.runCount ?? 0,
+    consecutiveFailures: scheduledRun?.consecutiveFailures ?? 0,
+  };
+}
 
 export const useConsoleStore = create<ConsoleStore>()(
   persist(
@@ -842,6 +869,13 @@ export const useConsoleStore = create<ConsoleStore>()(
           } as ScheduledQueryRunsResponse & { error?: string };
         }
       },
+
+      updateTabScheduledRun: (tabId, scheduledRun) =>
+        set(state => {
+          const tab = state.tabs[tabId];
+          if (!tab || scheduledRun == null) return;
+          tab.scheduledRun = normalizeScheduledRunSnapshotForTab(scheduledRun);
+        }),
 
       autoSaveConsole: (
         workspaceId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Scheduled query executor** no longer loads `SavedConsole` / `DatabaseConnection` with `.lean()`, which skipped Mongoose getters on `connection` and left encrypted values (e.g. BigQuery `service_account_json`) flowing into `executeQuery`. Uses `.toObject({ getters: true })` instead so credentials decrypt like the rest of the API.

- **Runs tab counter** (`Runs (N)`) was stale because it only came from the initial console load. `GET .../consoles/:id/schedule/runs` now also returns `scheduledRun` from Mongo; the app merges that into the tab after loading runs so `runCount` matches reality.

## Test plan

- [ ] `pnpm --filter api run lint`
- [ ] `pnpm --filter app run typecheck && pnpm --filter app run lint`
- [ ] BigQuery scheduled console: Run now — no `Invalid service_account_json: Not a valid JSON string` from decrypt bypass.
- [ ] Open Runs tab after runs exist — tab label `Runs (N)` reflects `scheduledRun.runCount` from API.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-636ccdb6-3ce9-4a1a-a01c-f3be9bb4290b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-636ccdb6-3ce9-4a1a-a01c-f3be9bb4290b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

