### PR TITLE
fix(app,api): do not rename console when saving scheduled query

### DIFF
--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -328,10 +328,6 @@ consoleRoutes.put("/:id/schedule", async (c: AuthenticatedContext) => {
     });
     const nextAt = getNextScheduledConsoleRunAt(schedule);
 
-    if (typeof body?.name === "string" && body.name.trim()) {
-      savedConsole.name = body.name.trim();
-    }
-
     savedConsole.schedule = schedule;
     savedConsole.scheduledRun = {
       nextAt,
@@ -351,10 +347,6 @@ consoleRoutes.put("/:id/schedule", async (c: AuthenticatedContext) => {
       success: true,
       schedule: savedConsole.schedule,
       scheduledRun: savedConsole.scheduledRun,
-      console: {
-        id: savedConsole._id.toString(),
-        name: savedConsole.name,
-      },
     });
   } catch (error) {
     logger.error("Error updating console schedule", { error });

--- a/api/src/routes/flows.ts
+++ b/api/src/routes/flows.ts
@@ -146,6 +146,18 @@ function escapeSqlLiteral(value: string): string {
   return `'${value.replace(/'/g, "''")}'`;
 }
 
+function escapePostgresIdentifier(identifier: string): string {
+  return `"${identifier.replace(/"/g, '""')}"`;
+}
+
+function escapeBigQueryPath(path: string): string {
+  return `\`${path.replace(/`/g, "\\`")}\``;
+}
+
+function isSafeSqlIdentifier(identifier: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(identifier);
+}
+
 function buildDestinationCountBatchQuery(params: {
   destinationType?: string;
   schema: string;
@@ -1595,9 +1607,12 @@ flowRoutes.post("/:flowId/sync-cdc/reset-entity", async c => {
       .drop()
       .catch(() => undefined);
 
-    for (const key of destinationCountCache.keys()) {
-      if (key.startsWith(`${workspaceId}:${flowId}:${entity}:`)) {
-        destinationCountCache.delete(key);
+    // The batch cache stores one entry per (workspace, flow, sorted entity
+    // list); invalidate every entry for this flow so the next read reflects
+    // the freshly-truncated entity table.
+    for (const key of destinationCountBatchCache.keys()) {
+      if (key.startsWith(`${workspaceId}:${flowId}:`)) {
+        destinationCountBatchCache.delete(key);
       }
     }
 

--- a/api/src/routes/flows.ts
+++ b/api/src/routes/flows.ts
@@ -136,57 +136,35 @@ function toLagSeconds(value: Date | null): number | null {
   return Math.max(Math.floor((Date.now() - value.getTime()) / 1000), 0);
 }
 
-const DESTINATION_COUNT_CACHE_TTL_MS = 30_000;
-const destinationCountCache = new Map<
+const DESTINATION_COUNT_CACHE_TTL_MS = 60_000;
+const destinationCountBatchCache = new Map<
   string,
-  { value: number | null; expiresAt: number }
+  { value: Record<string, number | null>; expiresAt: number }
 >();
 
-function escapePostgresIdentifier(identifier: string): string {
-  return `"${identifier.replace(/"/g, '""')}"`;
+function escapeSqlLiteral(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
 }
 
-function escapeBigQueryPath(path: string): string {
-  return `\`${path.replace(/`/g, "\\`")}\``;
-}
-
-function isSafeSqlIdentifier(identifier: string): boolean {
-  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(identifier);
-}
-
-function buildDestinationCountQuery(params: {
+function buildDestinationCountBatchQuery(params: {
   destinationType?: string;
   schema: string;
-  tableName: string;
+  tableNames: string[];
   projectId?: string;
 }): string | null {
+  if (params.tableNames.length === 0) return null;
   const type = (params.destinationType || "").toLowerCase();
+  const inList = params.tableNames.map(escapeSqlLiteral).join(",");
   if (type === "bigquery") {
     const dataset = params.projectId
       ? `\`${params.projectId}\`.\`${params.schema}\``
       : `\`${params.schema}\``;
-    return `SELECT row_count AS total_count FROM ${dataset}.__TABLES__ WHERE table_id = '${params.tableName}'`;
+    return `SELECT table_id, row_count FROM ${dataset}.__TABLES__ WHERE table_id IN (${inList})`;
   }
   if (type.includes("postgres")) {
-    const escLiteral = (v: string) => `'${v.replace(/'/g, "''")}'`;
-    return `SELECT reltuples::bigint AS total_count FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = ${escLiteral(params.schema)} AND c.relname = ${escLiteral(params.tableName)}`;
+    return `SELECT c.relname AS table_id, c.reltuples::bigint AS row_count FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = ${escapeSqlLiteral(params.schema)} AND c.relname IN (${inList})`;
   }
   return null;
-}
-
-function extractCountFromQueryResult(data: unknown): number | null {
-  if (!Array.isArray(data) || data.length === 0) return null;
-  const row = data[0];
-  if (!row || typeof row !== "object") return null;
-  const record = row as Record<string, unknown>;
-  const raw =
-    record.total_count ??
-    record.totalCount ??
-    record.count ??
-    record.cnt ??
-    record["COUNT(*)"];
-  const parsed = Number(raw);
-  return Number.isFinite(parsed) ? parsed : null;
 }
 
 function isTableMissingError(errorMessage?: string): boolean {
@@ -202,98 +180,131 @@ function isTableMissingError(errorMessage?: string): boolean {
   );
 }
 
-async function getDestinationEntityRowCount(params: {
+async function getDestinationEntityRowCountsBatch(params: {
   workspaceId: string;
   flowId: string;
-  entity: string;
+  entities: string[];
   destinationType?: string;
   destination: any;
   schema: string;
   baseTablePrefix?: string;
-}): Promise<number | null> {
+}): Promise<Record<string, number | null>> {
+  const sortedEntities = [...params.entities].sort();
   const cacheKey = [
     params.workspaceId,
     params.flowId,
-    params.entity,
     params.destinationType || "",
     params.schema,
     params.baseTablePrefix || "",
     String((params.destination as any)?.connection?.project_id || ""),
+    sortedEntities.join("|"),
   ].join(":");
-  const cached = destinationCountCache.get(cacheKey);
+  const cached = destinationCountBatchCache.get(cacheKey);
   if (cached && cached.expiresAt > Date.now()) {
     return cached.value;
   }
 
-  const tableName = cdcLiveTableName(
-    params.baseTablePrefix,
-    params.entity,
-    params.flowId,
-  );
-  const query = buildDestinationCountQuery({
+  const empty: Record<string, number | null> = {};
+  for (const entity of params.entities) empty[entity] = null;
+
+  if (params.entities.length === 0) {
+    destinationCountBatchCache.set(cacheKey, {
+      value: empty,
+      expiresAt: Date.now() + DESTINATION_COUNT_CACHE_TTL_MS,
+    });
+    return empty;
+  }
+
+  // Map each entity to its destination table name, keep both directions.
+  const tableToEntity = new Map<string, string>();
+  const tableNames: string[] = [];
+  for (const entity of params.entities) {
+    const tableName = cdcLiveTableName(
+      params.baseTablePrefix,
+      entity,
+      params.flowId,
+    );
+    tableToEntity.set(tableName, entity);
+    tableNames.push(tableName);
+  }
+
+  const query = buildDestinationCountBatchQuery({
     destinationType: params.destinationType,
     schema: params.schema,
-    tableName,
+    tableNames,
     projectId: (params.destination as any)?.connection?.project_id,
   });
   if (!query) {
-    destinationCountCache.set(cacheKey, {
-      value: null,
+    destinationCountBatchCache.set(cacheKey, {
+      value: empty,
       expiresAt: Date.now() + DESTINATION_COUNT_CACHE_TTL_MS,
     });
-    return null;
+    return empty;
   }
 
   const driver = databaseRegistry.getDriver(params.destination.type);
   if (!driver?.executeQuery) {
-    destinationCountCache.set(cacheKey, {
-      value: null,
+    destinationCountBatchCache.set(cacheKey, {
+      value: empty,
       expiresAt: Date.now() + DESTINATION_COUNT_CACHE_TTL_MS,
     });
-    return null;
+    return empty;
   }
 
+  // Default everything to 0 — if a table doesn't appear in __TABLES__/pg_class,
+  // it doesn't exist yet, which is semantically the same as "0 rows".
+  const result: Record<string, number | null> = {};
+  for (const entity of params.entities) result[entity] = 0;
+
   try {
-    const result = await driver.executeQuery(params.destination, query);
-    if (!result.success) {
-      if (isTableMissingError(result.error)) {
-        destinationCountCache.set(cacheKey, {
-          value: 0,
+    const queryResult = await driver.executeQuery(params.destination, query);
+    if (!queryResult.success) {
+      if (isTableMissingError(queryResult.error)) {
+        destinationCountBatchCache.set(cacheKey, {
+          value: result,
           expiresAt: Date.now() + DESTINATION_COUNT_CACHE_TTL_MS,
         });
-        return 0;
+        return result;
       }
-      logger.warn("Failed to count destination rows for CDC entity", {
+      logger.warn("Failed to count destination rows for CDC flow", {
         flowId: params.flowId,
-        entity: params.entity,
         destinationType: params.destinationType,
-        error: result.error,
+        error: queryResult.error,
       });
-      destinationCountCache.set(cacheKey, {
-        value: null,
+      destinationCountBatchCache.set(cacheKey, {
+        value: empty,
         expiresAt: Date.now() + DESTINATION_COUNT_CACHE_TTL_MS,
       });
-      return null;
+      return empty;
     }
 
-    const count = extractCountFromQueryResult(result.data);
-    destinationCountCache.set(cacheKey, {
-      value: count,
+    if (Array.isArray(queryResult.data)) {
+      for (const row of queryResult.data as Array<Record<string, unknown>>) {
+        const tableId = String(row.table_id ?? row.tableId ?? "");
+        const entity = tableToEntity.get(tableId);
+        if (!entity) continue;
+        const raw = row.row_count ?? row.rowCount ?? row.total_count;
+        const parsed = Number(raw);
+        result[entity] = Number.isFinite(parsed) ? parsed : null;
+      }
+    }
+
+    destinationCountBatchCache.set(cacheKey, {
+      value: result,
       expiresAt: Date.now() + DESTINATION_COUNT_CACHE_TTL_MS,
     });
-    return count;
+    return result;
   } catch (error) {
-    logger.warn("Destination row count query errored for CDC entity", {
+    logger.warn("Destination row count batch query errored", {
       flowId: params.flowId,
-      entity: params.entity,
       destinationType: params.destinationType,
       error: error instanceof Error ? error.message : String(error),
     });
-    destinationCountCache.set(cacheKey, {
-      value: null,
+    destinationCountBatchCache.set(cacheKey, {
+      value: empty,
       expiresAt: Date.now() + DESTINATION_COUNT_CACHE_TTL_MS,
     });
-    return null;
+    return empty;
   }
 }
 
@@ -2878,25 +2889,15 @@ flowRoutes.get("/:flowId/sync-cdc/destination-counts", async c => {
       ]),
     );
 
-    const counts = await Promise.all(
-      uniqueEntities.map(async entity => {
-        const value = await getDestinationEntityRowCount({
-          workspaceId,
-          flowId,
-          entity,
-          destinationType: destination.type,
-          destination,
-          schema: flow.tableDestination?.schema || "",
-          baseTablePrefix: flow.tableDestination?.tableName,
-        });
-        return [entity, value] as const;
-      }),
-    );
-
-    const data: Record<string, number | null> = {};
-    for (const [entity, count] of counts) {
-      data[entity] = count;
-    }
+    const data = await getDestinationEntityRowCountsBatch({
+      workspaceId,
+      flowId,
+      entities: uniqueEntities,
+      destinationType: destination.type,
+      destination,
+      schema: flow.tableDestination?.schema || "",
+      baseTablePrefix: flow.tableDestination?.tableName,
+    });
 
     return c.json({ success: true, data });
   } catch (error) {

--- a/app/src/components/BackfillPanel.tsx
+++ b/app/src/components/BackfillPanel.tsx
@@ -38,6 +38,7 @@ import {
   ExpandMore as ExpandMoreIcon,
   ExpandLess as ExpandLessIcon,
   Replay as RetryIcon,
+  Refresh as RefreshIcon,
   WarningAmber as WarningAmberIcon,
 } from "@mui/icons-material";
 import { useFlowStore } from "../store/flowStore";
@@ -383,6 +384,7 @@ export function BackfillPanel({
     string,
     number | null
   > | null>(null);
+  const [destCountsLoading, setDestCountsLoading] = useState(false);
 
   const cdcPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const logPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -571,17 +573,23 @@ export function BackfillPanel({
   }, [tab, fetchEventCounts]);
 
   const pollDestCounts = useCallback(async () => {
-    const counts = await fetchCdcDestinationCounts(workspaceId, flowId);
-    if (counts) setDestinationCounts(counts);
+    setDestCountsLoading(true);
+    try {
+      const counts = await fetchCdcDestinationCounts(workspaceId, flowId);
+      if (counts) setDestinationCounts(counts);
+    } finally {
+      setDestCountsLoading(false);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workspaceId, flowId]);
 
+  // Destination row counts are slow-moving and require a destination round
+  // trip. Fetch once when the panel opens for a flow; otherwise the user
+  // refreshes manually via the button next to "Destination rows".
   useEffect(() => {
+    setDestinationCounts(null);
     pollDestCounts();
-    const id = setInterval(pollDestCounts, 30_000);
-    return () => clearInterval(id);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [workspaceId, flowId]);
+  }, [workspaceId, flowId, pollDestCounts]);
 
   const withBusy = async (
     fn: () => Promise<unknown>,
@@ -1154,13 +1162,48 @@ export function BackfillPanel({
               >
                 Rows applied: {totalRowsApplied.toLocaleString()}
               </Typography>
-              <Typography
-                variant="caption"
-                color="text.secondary"
-                sx={{ display: "block", mt: 0.1, fontSize: "0.68rem" }}
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 0.5,
+                  mt: 0.1,
+                }}
               >
-                Destination rows: {totalDestinationRows.toLocaleString()}
-              </Typography>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ fontSize: "0.68rem" }}
+                >
+                  Destination rows:{" "}
+                  {destinationCounts === null
+                    ? "—"
+                    : totalDestinationRows.toLocaleString()}
+                </Typography>
+                <Tooltip title="Refresh destination row counts">
+                  <span>
+                    <IconButton
+                      size="small"
+                      onClick={pollDestCounts}
+                      disabled={destCountsLoading}
+                      sx={{ p: 0.25 }}
+                    >
+                      <RefreshIcon
+                        sx={{
+                          fontSize: 12,
+                          ...(destCountsLoading && {
+                            animation: "spin 1s linear infinite",
+                            "@keyframes spin": {
+                              "0%": { transform: "rotate(0deg)" },
+                              "100%": { transform: "rotate(360deg)" },
+                            },
+                          }),
+                        }}
+                      />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              </Box>
               {cdc.lastMaterializedAt && (
                 <Typography
                   variant="caption"

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -1345,7 +1345,7 @@ function Editor({
   );
 
   const handleSaveSchedule = useCallback(
-    async (input: { name: string; cron: string; timezone: string }) => {
+    async (input: { cron: string; timezone: string }) => {
       if (!currentWorkspace || !scheduleModalTabId) {
         throw new Error("No workspace selected");
       }

--- a/app/src/components/ScheduleConsoleModal.tsx
+++ b/app/src/components/ScheduleConsoleModal.tsx
@@ -28,11 +28,7 @@ interface ScheduleConsoleModalProps {
   };
   connectionLabel?: string;
   onClose: () => void;
-  onSave: (input: {
-    name: string;
-    cron: string;
-    timezone: string;
-  }) => Promise<void>;
+  onSave: (input: { cron: string; timezone: string }) => Promise<void>;
   onRemove?: () => Promise<void>;
   onRunNow?: () => Promise<void>;
 }
@@ -98,7 +94,9 @@ export default function ScheduleConsoleModal({
   onRemove,
   onRunNow,
 }: ScheduleConsoleModalProps) {
-  const [name, setName] = useState(initialName);
+  const displayConsoleName =
+    initialName.split("/").filter(Boolean).pop() ?? initialName;
+
   const [preset, setPreset] = useState<SchedulePreset>(
     presetFromCron(initialSchedule?.cron || "0 0 * * *"),
   );
@@ -117,7 +115,6 @@ export default function ScheduleConsoleModal({
 
   useEffect(() => {
     if (!open) return;
-    setName(initialName);
     setPreset(presetFromCron(initialSchedule?.cron || "0 0 * * *"));
     setTime(timeFromCron(initialSchedule?.cron || ""));
     setCustomCron(initialSchedule?.cron || "");
@@ -127,7 +124,7 @@ export default function ScheduleConsoleModal({
         "UTC",
     );
     setError(null);
-  }, [open, initialName, initialSchedule]);
+  }, [open, initialSchedule]);
 
   const cron = useMemo(
     () => cronFromPreset(preset, time, weekday, customCron),
@@ -153,7 +150,7 @@ export default function ScheduleConsoleModal({
     try {
       setIsSubmitting(true);
       setError(null);
-      await onSave({ name: name.trim(), cron, timezone });
+      await onSave({ cron, timezone });
       onClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to save schedule");
@@ -189,8 +186,7 @@ export default function ScheduleConsoleModal({
     }
   };
 
-  const isValid =
-    Boolean(name.trim()) && Boolean(cron.trim()) && previewRuns.length > 0;
+  const isValid = Boolean(cron.trim()) && previewRuns.length > 0;
 
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
@@ -203,13 +199,12 @@ export default function ScheduleConsoleModal({
         <Stack spacing={2.5} sx={{ pt: 1 }}>
           {error && <Alert severity="error">{error}</Alert>}
 
-          <TextField
-            label="Name"
-            value={name}
-            onChange={event => setName(event.target.value)}
-            fullWidth
-            required
-          />
+          <Box>
+            <Typography variant="subtitle2" color="text.secondary">
+              Console
+            </Typography>
+            <Typography variant="body1">{displayConsoleName}</Typography>
+          </Box>
 
           <Box>
             <Typography variant="subtitle2" sx={{ mb: 1 }}>

--- a/app/src/lib/api-types.ts
+++ b/app/src/lib/api-types.ts
@@ -108,10 +108,6 @@ export interface ScheduledQueryScheduleResponse {
     timezone: string;
   };
   scheduledRun?: ConsoleContentResponse["scheduledRun"];
-  console?: {
-    id: string;
-    name: string;
-  };
   eventId?: string;
   error?: string;
 }

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -146,7 +146,7 @@ interface ConsoleActions {
   setSchedule: (
     workspaceId: string,
     consoleId: string,
-    input: { name: string; cron: string; timezone: string },
+    input: { cron: string; timezone: string },
   ) => Promise<ScheduledQueryScheduleResponse>;
   removeSchedule: (
     workspaceId: string,
@@ -798,7 +798,6 @@ export const useConsoleStore = create<ConsoleStore>()(
             set(state => {
               const tab = state.tabs[consoleId];
               if (tab) {
-                tab.title = response.console?.name || input.name;
                 tab.schedule = response.schedule;
                 tab.scheduledRun = response.scheduledRun;
               }


### PR DESCRIPTION
## What was wrong

Saving a scheduled query sent a **name** field from the schedule modal (often the full explorer path) to `PUT /workspaces/:id/consoles/:consoleId/schedule`. The API wrote that string to `SavedConsole.name`, and the app store overwrote the tab title—so consoles looked “renamed” to paths like `revops_analytics/ch/ch_customer_map`.

## What we changed

- **App:** Schedule dialog is read-only for the console label (basename only). Save sends **only** `cron` and `timezone`. `setSchedule` updates `schedule` / `scheduledRun` on the tab and **does not** change `tab.title`.
- **API:** That schedule endpoint **no longer** reads `body.name` or returns a `console { id, name }` object for renames. Types updated accordingly.

## Note on commits

This branch is based on work that already had two other commits on it; the functional change for *this* fix is the last commit (`fix(consoles): schedule save must not rename console`). If you want a PR that is only that change against `master`, cherry-pick that commit onto a fresh branch from `master` and open a new PR (or reset this branch after those land).
