### PR TITLE
docs: clarify CDC destination row counts

### DIFF
--- a/docs/src/content/docs/api-reference.md
+++ b/docs/src/content/docs/api-reference.md
@@ -69,7 +69,22 @@ See [Console](/console/) for full API documentation with examples.
 | `GET`  | `/api/workspaces/:wid/flows/:id`                                   | Get flow status                                              |
 | `GET`  | `/api/workspaces/:wid/flows/:id/sync-cdc/status`                   | Get CDC stream status                                        |
 | `GET`  | `/api/workspaces/:wid/flows/:id/sync-cdc/schema-health`            | Compare live destination column types to the connector schema (BigQuery; detects drift) |
-| `GET`  | `/api/workspaces/:wid/flows/:id/sync-cdc/destination-counts`       | Row counts per entity in the destination                     |
+| `GET`  | `/api/workspaces/:wid/flows/:id/sync-cdc/destination-counts`       | Batched row counts per entity in the destination             |
+
+### Destination Counts Response
+
+Returns a map of CDC entity name to destination row count. Mako batches BigQuery and PostgreSQL counts into one metadata query and may return `0` for configured entities whose destination table does not exist yet.
+
+```json
+{
+  "success": true,
+  "data": {
+    "contacts": 125000,
+    "organizations": 8421,
+    "opportunities": 0
+  }
+}
+```
 
 ### Schema Health Response
 

--- a/docs/src/content/docs/data-sync.md
+++ b/docs/src/content/docs/data-sync.md
@@ -46,6 +46,12 @@ Drift detection and correction is best-effort: if any step fails for a column, t
 
 The console surfaces drift in the **Backfill Panel** with an auto-correction notice per affected entity. Under the hood this calls the `sync-cdc/schema-health` endpoint (see [API Reference](/api-reference/#flows)) which compares each live column's `data_type` from `INFORMATION_SCHEMA.COLUMNS` against the connector schema.
 
+### Destination Row Counts
+
+The **Backfill Panel** shows destination row totals next to CDC progress. Counts are fetched lazily when the panel opens and when you click the refresh icon beside **Destination rows**; they do not poll continuously.
+
+For BigQuery and PostgreSQL destinations, Mako batches all entity counts into a single metadata query and caches the result briefly. Missing destination tables are shown as `0` rows.
+
 
 ## Job Queue
 


### PR DESCRIPTION
## Summary
- document how CDC destination row counts are loaded in the Backfill Panel
- clarify that destination-counts batches BigQuery/Postgres metadata queries and returns entity-count maps

## Validation
- pnpm docs:build

Existing warnings only: unsupported `env` code fence language in `deployment.md`; existing Starlight 404 entry warning.