### PR TITLE
feat(api): schedule_query tool for console agent

### DIFF
--- a/api/src/agent-lib/tools/schedule-query-tool.ts
+++ b/api/src/agent-lib/tools/schedule-query-tool.ts
@@ -1,0 +1,115 @@
+import { Types } from "mongoose";
+import { z } from "zod";
+import { SavedConsole } from "../../database/workspace-schema";
+import {
+  getNextScheduledConsoleRunAt,
+  validateScheduledConsoleSchedule,
+} from "../../services/scheduled-query-schedule.service";
+
+export interface ScheduleQueryToolOptions {
+  workspaceId: string;
+  /** Mirrors HTTP `PUT .../schedule`: owner/admin, or API key (workspace-scoped). */
+  canManageScheduledQueries: boolean;
+}
+
+const scheduleQueryInputSchema = z.object({
+  consoleId: z.string().describe("The _id of the SavedConsole to schedule."),
+  cron: z.string().describe("5-field cron expression, e.g. '0 9 * * 1-5'."),
+  timezone: z
+    .string()
+    .optional()
+    .describe("IANA timezone name, e.g. 'America/New_York'. Defaults to UTC."),
+});
+
+export function createScheduleQueryTool(options: ScheduleQueryToolOptions) {
+  const { workspaceId, canManageScheduledQueries } = options;
+  const wsOid = new Types.ObjectId(workspaceId);
+
+  return {
+    schedule_query: {
+      description:
+        "Schedule an existing saved console to run automatically on a cron (standard 5-field expression) in an IANA timezone. Replaces any existing schedule on that console. Requires a saved console id (from open tabs or search); the console must have a database connection. Only call after the user explicitly confirms they want this schedule.",
+      inputSchema: scheduleQueryInputSchema,
+      execute: async (input: z.infer<typeof scheduleQueryInputSchema>) => {
+        try {
+          if (!canManageScheduledQueries) {
+            return {
+              success: false,
+              error:
+                "Admin access required for scheduled queries (workspace owner or admin), or use a workspace API key.",
+            };
+          }
+
+          const { consoleId, cron, timezone } = input;
+
+          if (!Types.ObjectId.isValid(consoleId)) {
+            return {
+              success: false,
+              error: "INVALID_CONSOLE_ID",
+            };
+          }
+
+          const savedConsole = await SavedConsole.findOne({
+            _id: new Types.ObjectId(consoleId),
+            workspaceId: wsOid,
+            $or: [{ is_deleted: { $ne: true } }, { is_deleted: { $exists: false } }],
+          });
+
+          if (!savedConsole) {
+            return {
+              success: false,
+              error: "CONSOLE_NOT_FOUND",
+            };
+          }
+
+          if (!savedConsole.connectionId) {
+            return {
+              success: false,
+              error:
+                "MISSING_CONNECTION: bind a database connection to this console (e.g. set_console_connection) before scheduling.",
+            };
+          }
+
+          const schedule = validateScheduledConsoleSchedule({
+            cron,
+            timezone: timezone ?? "UTC",
+          });
+          const nextAt = getNextScheduledConsoleRunAt(schedule);
+
+          savedConsole.schedule = schedule;
+          savedConsole.scheduledRun = {
+            nextAt,
+            lastAt: savedConsole.scheduledRun?.lastAt,
+            lastStatus: savedConsole.scheduledRun?.lastStatus,
+            lastError: savedConsole.scheduledRun?.lastError,
+            lastDurationMs: savedConsole.scheduledRun?.lastDurationMs,
+            lastRowsAffected: savedConsole.scheduledRun?.lastRowsAffected,
+            lastRowCount: savedConsole.scheduledRun?.lastRowCount,
+            runCount: savedConsole.scheduledRun?.runCount ?? 0,
+            consecutiveFailures:
+              savedConsole.scheduledRun?.consecutiveFailures ?? 0,
+          };
+          savedConsole.isSaved = true;
+          await savedConsole.save();
+
+          return {
+            success: true,
+            consoleId: savedConsole._id.toString(),
+            name: savedConsole.name,
+            schedule: savedConsole.schedule,
+            nextAt: savedConsole.scheduledRun?.nextAt?.toISOString?.() ?? null,
+            scheduledRun: savedConsole.scheduledRun,
+          };
+        } catch (error) {
+          return {
+            success: false,
+            error:
+              error instanceof Error
+                ? error.message
+                : "Failed to schedule console query",
+          };
+        }
+      },
+    },
+  };
+}

--- a/api/src/agents/console/index.ts
+++ b/api/src/agents/console/index.ts
@@ -17,6 +17,7 @@ import { createSelfDirectiveTools } from "../../agent-lib/tools/self-directive-t
 import { createSkillTools } from "../../agent-lib/tools/skill-tools";
 import { createConsoleSearchTools } from "../../agent-lib/tools/console-search-tools";
 import { createVersionHistoryTools } from "../../agent-lib/tools/version-history-tools";
+import { createScheduleQueryTool } from "../../agent-lib/tools/schedule-query-tool";
 import type { ConsoleDataV2 } from "../../agent-lib/types";
 
 /**
@@ -164,6 +165,7 @@ export const consoleAgentFactory: AgentFactory = (
     consoleHints = "",
     skillsBlock = "",
     activeConsoleResults,
+    canManageScheduledQueries = false,
   } = context;
 
   // Build database lookup maps
@@ -201,6 +203,9 @@ export const consoleAgentFactory: AgentFactory = (
     activeConsoleResults,
   );
 
+  const scheduleQueryPrompt =
+    "\n\n---\n\n### Scheduled query runs\nTo run a **saved** console on a cron, use `schedule_query` only after the user explicitly confirms the cron expression, timezone, and which saved console id to use. The console must already be saved and bound to a connection. Workspace members who are not owner/admin cannot schedule (they need an admin or an API-key-authenticated request).\n";
+
   // Create tools
   const tools = createUniversalTools(
     workspaceId,
@@ -216,6 +221,10 @@ export const consoleAgentFactory: AgentFactory = (
     context.toolExecutionContext,
   );
   const versionHistoryTools = createVersionHistoryTools(workspaceId);
+  const scheduleQueryTools = createScheduleQueryTool({
+    workspaceId,
+    canManageScheduledQueries,
+  });
 
   return {
     systemPrompt: [
@@ -229,7 +238,11 @@ export const consoleAgentFactory: AgentFactory = (
       {
         role: "system" as const,
         content:
-          selfDirectiveContext + skillsBlock + consoleHints + runtimeContext,
+          selfDirectiveContext +
+          skillsBlock +
+          consoleHints +
+          scheduleQueryPrompt +
+          runtimeContext,
       },
     ],
     tools: {
@@ -238,6 +251,7 @@ export const consoleAgentFactory: AgentFactory = (
       ...skillTools,
       ...consoleSearchTools,
       ...versionHistoryTools,
+      ...scheduleQueryTools,
     } as Record<string, any>,
   };
 };

--- a/api/src/agents/types.ts
+++ b/api/src/agents/types.ts
@@ -154,6 +154,11 @@ export interface AgentContext {
   };
   /** Request-scoped execution registry for cancellable server tools */
   toolExecutionContext?: AgentToolExecutionContext;
+  /**
+   * Actor may attach cron schedules to saved consoles (workspace owner/admin),
+   * or API-key requests act as workspace-scoped automation (same as HTTP schedule routes).
+   */
+  canManageScheduledQueries?: boolean;
 }
 
 /**

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -330,6 +330,15 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
   // Only enrich logging context after authorization succeeds
   enrichContextWithWorkspace(workspaceId);
 
+  let canManageScheduledQueries = false;
+  if (workspace) {
+    canManageScheduledQueries = true;
+  } else if (user?.id) {
+    const member = await workspaceService.getMember(workspaceId, user.id);
+    canManageScheduledQueries =
+      member?.role === "owner" || member?.role === "admin";
+  }
+
   // Load billing plan + disabled model IDs for plan-appropriate defaults and blocklist.
   const wsForModels = await Workspace.findById(workspaceId).select(
     "billing.plan billing.subscriptionStatus settings.disabledModelIds",
@@ -582,6 +591,7 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
     activeConsoleResults,
     activeDashboardContext: dashboardContext.activeDashboardContext,
     toolExecutionContext,
+    canManageScheduledQueries,
   };
 
   // Create agent configuration


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a server-side agent tool `schedule_query` (console agent only) that attaches or replaces a cron schedule on an existing **saved** `SavedConsole`, using the same validation and persistence path as `PUT /api/workspaces/:workspaceId/consoles/:id/schedule`.

## Behavior

- **Inputs:** `consoleId`, `cron` (5-field), optional `timezone` (defaults to UTC).
- **Checks:** workspace-scoped console lookup; requires `connectionId`; validates cron/timezone via `validateScheduledConsoleSchedule` + `getNextScheduledConsoleRunAt`.
- **Auth:** Matches HTTP schedule routes — workspace **owner/admin**, or **API key** (workspace-scoped automation).
- **Prompt:** Console agent gets a short system section describing when to use the tool and that explicit user confirmation is required.

## Verification

`pnpm --filter api run lint` was not run in this environment (pnpm/npm unavailable). Please run locally before merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b48f338f-d845-4902-b8ef-81f962dad0b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b48f338f-d845-4902-b8ef-81f962dad0b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

