### PR TITLE
Flow run notifications: backend + schedule/flow UI

### DIFF
--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -19,7 +19,7 @@ function getEncryptionKey(): string {
 
 const IV_LENGTH = 16;
 
-function encrypt(text: string): string {
+export function encrypt(text: string): string {
   const iv = crypto.randomBytes(IV_LENGTH);
   const cipher = crypto.createCipheriv(
     "aes-256-cbc",
@@ -31,7 +31,7 @@ function encrypt(text: string): string {
   return iv.toString("hex") + ":" + encrypted.toString("hex");
 }
 
-function decrypt(text: string): string {
+export function decrypt(text: string): string {
   const textParts = text.split(":");
   const ivHex = textParts.shift();
   if (!ivHex) {
@@ -431,6 +431,76 @@ export interface IScheduledQueryRun extends Document {
     code?: string;
   };
   inngestRunId?: string;
+}
+
+export type NotificationResourceType = "scheduled_query" | "flow";
+
+export type NotificationTrigger = "success" | "failure";
+
+export type NotificationChannelType = "email" | "webhook" | "slack";
+
+export interface INotificationRuleChannelEmail {
+  type: "email";
+  recipients: string[];
+}
+
+export interface INotificationRuleChannelWebhook {
+  type: "webhook";
+  /** Encrypted URL */
+  urlEncrypted: string;
+  /** Encrypted signing secret (HMAC SHA256 over JSON body) */
+  signingSecretEncrypted: string;
+}
+
+export interface INotificationRuleChannelSlack {
+  type: "slack";
+  /** Encrypted incoming webhook URL */
+  webhookUrlEncrypted: string;
+  /** UI label only, e.g. #alerts */
+  displayLabel?: string;
+}
+
+export type INotificationRuleChannel =
+  | INotificationRuleChannelEmail
+  | INotificationRuleChannelWebhook
+  | INotificationRuleChannelSlack;
+
+export interface INotificationRule extends Document {
+  _id: Types.ObjectId;
+  workspaceId: Types.ObjectId;
+  resourceType: NotificationResourceType;
+  resourceId: Types.ObjectId;
+  enabled: boolean;
+  triggers: NotificationTrigger[];
+  channel: INotificationRuleChannel;
+  createdBy: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type NotificationDeliveryStatus =
+  | "pending"
+  | "sent"
+  | "failed"
+  | "skipped";
+
+export interface INotificationDelivery extends Document {
+  _id: Types.ObjectId;
+  workspaceId: Types.ObjectId;
+  ruleId: Types.ObjectId;
+  resourceType: NotificationResourceType;
+  resourceId: Types.ObjectId;
+  runId: string;
+  trigger: NotificationTrigger;
+  channelType: NotificationChannelType;
+  idempotencyKey: string;
+  status: NotificationDeliveryStatus;
+  attempts: number;
+  lastError?: string;
+  httpStatus?: number;
+  sentAt?: Date;
+  completedAt?: Date;
+  createdAt: Date;
 }
 
 /**
@@ -2390,6 +2460,131 @@ ScheduledQueryRunSchema.index(
   { sparse: true, expireAfterSeconds: 7776000 },
 );
 
+const NotificationRuleSchema = new Schema<INotificationRule>(
+  {
+    workspaceId: {
+      type: Schema.Types.ObjectId,
+      ref: "Workspace",
+      required: true,
+    },
+    resourceType: {
+      type: String,
+      enum: ["scheduled_query", "flow"],
+      required: true,
+    },
+    resourceId: {
+      type: Schema.Types.ObjectId,
+      required: true,
+    },
+    enabled: {
+      type: Boolean,
+      default: true,
+    },
+    triggers: {
+      type: [String],
+      enum: ["success", "failure"],
+      validate: {
+        validator: (v: string[]) =>
+          Array.isArray(v) &&
+          v.length > 0 &&
+          v.every(t => t === "success" || t === "failure"),
+        message: "At least one trigger required",
+      },
+      required: true,
+    },
+    channel: {
+      type: Schema.Types.Mixed,
+      required: true,
+    },
+    createdBy: {
+      type: String,
+      required: true,
+    },
+  },
+  {
+    collection: "notification_rules",
+    timestamps: true,
+  },
+);
+
+NotificationRuleSchema.index({
+  workspaceId: 1,
+  resourceType: 1,
+  resourceId: 1,
+  enabled: 1,
+});
+
+const NotificationDeliverySchema = new Schema<INotificationDelivery>(
+  {
+    workspaceId: {
+      type: Schema.Types.ObjectId,
+      ref: "Workspace",
+      required: true,
+    },
+    ruleId: {
+      type: Schema.Types.ObjectId,
+      ref: "NotificationRule",
+      required: true,
+    },
+    resourceType: {
+      type: String,
+      enum: ["scheduled_query", "flow"],
+      required: true,
+    },
+    resourceId: {
+      type: Schema.Types.ObjectId,
+      required: true,
+    },
+    runId: {
+      type: String,
+      required: true,
+    },
+    trigger: {
+      type: String,
+      enum: ["success", "failure"],
+      required: true,
+    },
+    channelType: {
+      type: String,
+      enum: ["email", "webhook", "slack"],
+      required: true,
+    },
+    idempotencyKey: {
+      type: String,
+      required: true,
+    },
+    status: {
+      type: String,
+      enum: ["pending", "sent", "failed", "skipped"],
+      required: true,
+    },
+    attempts: {
+      type: Number,
+      default: 0,
+    },
+    lastError: String,
+    httpStatus: Number,
+    sentAt: Date,
+    completedAt: Date,
+  },
+  {
+    collection: "notification_deliveries",
+    timestamps: { createdAt: true, updatedAt: false },
+  },
+);
+
+NotificationDeliverySchema.index({
+  workspaceId: 1,
+  resourceType: 1,
+  resourceId: 1,
+  completedAt: -1,
+});
+
+NotificationDeliverySchema.index(
+  { createdAt: 1 },
+  { expireAfterSeconds: 7776000 },
+);
+
 export interface IMaterializationRun extends Document {
   workspaceId: Types.ObjectId;
   dashboardId: Types.ObjectId;
@@ -3134,6 +3329,14 @@ export const QueryExecution = mongoose.model<IQueryExecution>(
 export const ScheduledQueryRun = mongoose.model<IScheduledQueryRun>(
   "ScheduledQueryRun",
   ScheduledQueryRunSchema,
+);
+export const NotificationRule = mongoose.model<INotificationRule>(
+  "NotificationRule",
+  NotificationRuleSchema,
+);
+export const NotificationDelivery = mongoose.model<INotificationDelivery>(
+  "NotificationDelivery",
+  NotificationDeliverySchema,
 );
 export const MaterializationRun = mongoose.model<IMaterializationRun>(
   "MaterializationRun",

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -42,6 +42,7 @@ import { stripeWebhookRoutes } from "./routes/stripe-webhook";
 import { dashboardRoutes } from "./routes/dashboards";
 import { dashboardMaterializationRoutes } from "./routes/dashboard-materialization";
 import { scheduledQueryRoutes } from "./routes/scheduled-queries";
+import { notificationRulesRoutes } from "./routes/notification-rules";
 import { webhookRoutes } from "./routes/webhooks";
 import { getFunctions, inngest, logInngestStatus } from "./inngest";
 import mongoose from "mongoose";
@@ -123,6 +124,10 @@ app.route("/api/workspaces/:workspaceId/flows", flowRoutes);
 app.route(
   "/api/workspaces/:workspaceId/scheduled-queries",
   scheduledQueryRoutes,
+);
+app.route(
+  "/api/workspaces/:workspaceId/notification-rules",
+  notificationRulesRoutes,
 );
 app.route("/api/workspaces/:workspaceId/usage", usageRoutes);
 app.route("/api/workspaces/:workspaceId/billing", billingRoutes);

--- a/api/src/inngest/functions/flow-run-notifications.ts
+++ b/api/src/inngest/functions/flow-run-notifications.ts
@@ -1,0 +1,46 @@
+import { inngest } from "../client";
+import { loggers } from "../../logging";
+import type { FlowRunTerminalEventData } from "../../services/flow-run-notification.types";
+import {
+  deliverNotificationJob,
+  fanOutTerminalRunNotifications,
+} from "../../services/flow-run-notification.service";
+
+const logger = loggers.inngest("notification");
+
+export const flowRunTerminalFanoutFunction = inngest.createFunction(
+  {
+    id: "flow-run-notification-fanout",
+    name: "Flow run notification fan-out",
+    retries: 3,
+  },
+  { event: "flow.run.terminal" },
+  async ({ event, step }) => {
+    const data = event.data as FlowRunTerminalEventData;
+    await step.run("fan-out-rules", async () => {
+      const result = await fanOutTerminalRunNotifications(data);
+      logger.info("Notification fan-out complete", {
+        workspaceId: data.workspaceId,
+        resourceType: data.resourceType,
+        resourceId: data.resourceId,
+        runId: data.runId,
+        deliveriesQueued: result.deliveriesQueued,
+      });
+      return result;
+    });
+  },
+);
+
+export const notificationDeliverFunction = inngest.createFunction(
+  {
+    id: "notification-deliver",
+    name: "Deliver notification",
+    retries: 5,
+  },
+  { event: "notification/deliver" },
+  async ({ event, step }) => {
+    await step.run("deliver", async () => {
+      await deliverNotificationJob(event.data);
+    });
+  },
+);

--- a/api/src/inngest/functions/flow.ts
+++ b/api/src/inngest/functions/flow.ts
@@ -34,6 +34,7 @@ import {
   purgeSoftDeletesAfterBackfill,
 } from "../../sync-cdc/backfill";
 import { syncBackfillEntityFunction } from "./sync-entity";
+import { emitFlowExecutionTerminalEvent } from "../../services/flow-run-notification.emit";
 
 const flowLogger = loggers.inngest("flow");
 
@@ -409,14 +410,29 @@ export const flowFunction = inngest.createFunction(
   },
   { event: "flow.execute" },
   async ({ event, step, logger }) => {
-    const { flowId, noJitter, backfill, backfillRunId, backfillEntities } =
-      event.data as {
-        flowId: string;
-        noJitter?: boolean;
-        backfill?: boolean;
-        backfillRunId?: string;
-        backfillEntities?: string[];
-      };
+    const {
+      flowId,
+      noJitter,
+      backfill,
+      backfillRunId,
+      backfillEntities,
+      triggerType: eventTriggerType,
+    } = event.data as {
+      flowId: string;
+      noJitter?: boolean;
+      backfill?: boolean;
+      backfillRunId?: string;
+      backfillEntities?: string[];
+      triggerType?: "manual" | "schedule";
+    };
+    const runTriggerType: "manual" | "schedule" =
+      eventTriggerType === "manual"
+        ? "manual"
+        : eventTriggerType === "schedule"
+          ? "schedule"
+          : noJitter
+            ? "manual"
+            : "schedule";
     const requestedBackfillEntities = Array.isArray(backfillEntities)
       ? Array.from(
           new Set(
@@ -447,7 +463,11 @@ export const flowFunction = inngest.createFunction(
         new Types.ObjectId(flowId),
         new Types.ObjectId(flow.workspaceId),
         {
-          dataSourceId: new Types.ObjectId(flow.dataSourceId),
+          dataSourceId: flow.dataSourceId
+            ? new Types.ObjectId(flow.dataSourceId)
+            : flow.databaseSource?.connectionId
+              ? new Types.ObjectId(flow.databaseSource.connectionId)
+              : new Types.ObjectId(flow.destinationDatabaseId),
           destinationDatabaseId: new Types.ObjectId(flow.destinationDatabaseId),
           destinationDatabaseName: flow.destinationDatabaseName,
           syncMode: flow.syncMode === "incremental" ? "incremental" : "full",
@@ -1104,6 +1124,17 @@ export const flowFunction = inngest.createFunction(
             }
           }
         });
+
+        if (executionId && flowRef) {
+          await step.run("emit-flow-terminal-notification", async () => {
+            await emitFlowExecutionTerminalEvent({
+              workspaceId: String(flowRef.workspaceId),
+              flowId,
+              executionId,
+              triggerType: runTriggerType,
+            });
+          });
+        }
 
         return {
           success: true,
@@ -1834,6 +1865,17 @@ export const flowFunction = inngest.createFunction(
         }
       });
 
+      if (executionId && flowRef) {
+        await step.run("emit-flow-terminal-notification", async () => {
+          await emitFlowExecutionTerminalEvent({
+            workspaceId: String(flowRef.workspaceId),
+            flowId,
+            executionId,
+            triggerType: runTriggerType,
+          });
+        });
+      }
+
       return { success: true, message: "Sync completed successfully" };
     } catch (error: any) {
       void appendExecutionLog("error", "Flow execution failed", {
@@ -1968,6 +2010,15 @@ export const flowFunction = inngest.createFunction(
               executionId,
               status: isCancelled ? "cancelled" : "failed",
             });
+
+            if (!isCancelled && flowRef) {
+              await emitFlowExecutionTerminalEvent({
+                workspaceId: String(flowRef.workspaceId),
+                flowId,
+                executionId,
+                triggerType: runTriggerType,
+              });
+            }
           } catch (completeError) {
             logger.error("Failed to complete error execution logging", {
               flowId,
@@ -2265,7 +2316,10 @@ export const flowSchedulerFunction = inngest.createFunction(
         // Trigger the flow (without noJitter flag, so jitter will be applied)
         await step.sendEvent(`trigger-flow-${flow._id}`, {
           name: "flow.execute",
-          data: { flowId: flow._id.toString() },
+          data: {
+            flowId: flow._id.toString(),
+            triggerType: "schedule",
+          },
         });
 
         const flowDisplayName = await getFlowDisplayName(flow);
@@ -2306,6 +2360,7 @@ export const manualFlowFunction = inngest.createFunction(
       data: {
         flowId,
         noJitter: true, // Skip jitter for manual execution
+        triggerType: "manual",
       },
     });
 

--- a/api/src/inngest/functions/flow.ts
+++ b/api/src/inngest/functions/flow.ts
@@ -1126,11 +1126,13 @@ export const flowFunction = inngest.createFunction(
         });
 
         if (executionId && flowRef) {
+          const terminalWorkspaceId = String(flowRef.workspaceId);
+          const terminalExecutionId = executionId;
           await step.run("emit-flow-terminal-notification", async () => {
             await emitFlowExecutionTerminalEvent({
-              workspaceId: String(flowRef.workspaceId),
+              workspaceId: terminalWorkspaceId,
               flowId,
-              executionId,
+              executionId: terminalExecutionId,
               triggerType: runTriggerType,
             });
           });
@@ -1866,11 +1868,13 @@ export const flowFunction = inngest.createFunction(
       });
 
       if (executionId && flowRef) {
+        const terminalWorkspaceId = String(flowRef.workspaceId);
+        const terminalExecutionId = executionId;
         await step.run("emit-flow-terminal-notification", async () => {
           await emitFlowExecutionTerminalEvent({
-            workspaceId: String(flowRef.workspaceId),
+            workspaceId: terminalWorkspaceId,
             flowId,
-            executionId,
+            executionId: terminalExecutionId,
             triggerType: runTriggerType,
           });
         });
@@ -2011,11 +2015,13 @@ export const flowFunction = inngest.createFunction(
               status: isCancelled ? "cancelled" : "failed",
             });
 
-            if (!isCancelled && flowRef) {
+            if (!isCancelled && flowRef && executionId) {
+              const failureTerminalWorkspaceId = String(flowRef.workspaceId);
+              const failureTerminalExecutionId = executionId;
               await emitFlowExecutionTerminalEvent({
-                workspaceId: String(flowRef.workspaceId),
+                workspaceId: failureTerminalWorkspaceId,
                 flowId,
-                executionId,
+                executionId: failureTerminalExecutionId,
                 triggerType: runTriggerType,
               });
             }

--- a/api/src/inngest/functions/scheduled-query.ts
+++ b/api/src/inngest/functions/scheduled-query.ts
@@ -11,6 +11,7 @@ import { databaseConnectionService } from "../../services/database-connection.se
 import { queryExecutionService } from "../../services/query-execution.service";
 import { loggers } from "../../logging";
 import { getNextScheduledConsoleRunAt } from "../../services/scheduled-query-schedule.service";
+import { emitScheduledQueryTerminalEvent } from "../../services/flow-run-notification.emit";
 
 const logger = loggers.inngest();
 
@@ -263,6 +264,15 @@ export const scheduledQueryExecutorFunction = inngest.createFunction(
       });
       isFinalized = true;
 
+      await step.run("emit-scheduled-query-terminal-notification", async () => {
+        await emitScheduledQueryTerminalEvent({
+          workspaceId,
+          consoleId,
+          runId: run.id,
+          triggerType,
+        });
+      });
+
       queryExecutionService.track({
         userId: triggeredBy || consoleDoc.savedConsole.createdBy,
         workspaceId: consoleDoc.savedConsole.workspaceId,
@@ -331,6 +341,17 @@ export const scheduledQueryExecutorFunction = inngest.createFunction(
           },
         );
       });
+      await step.run(
+        "emit-scheduled-query-terminal-notification-error",
+        async () => {
+          await emitScheduledQueryTerminalEvent({
+            workspaceId,
+            consoleId,
+            runId: run.id,
+            triggerType,
+          });
+        },
+      );
       throw error;
     }
   },

--- a/api/src/inngest/index.ts
+++ b/api/src/inngest/index.ts
@@ -25,6 +25,10 @@ import {
   scheduledQueryExecutorFunction,
   scheduledQuerySchedulerFunction,
 } from "./functions/scheduled-query";
+import {
+  flowRunTerminalFanoutFunction,
+  notificationDeliverFunction,
+} from "./functions/flow-run-notifications";
 import { loggers } from "../logging";
 
 const baseFunctions = [
@@ -38,6 +42,8 @@ const baseFunctions = [
   usageReportingFunction,
   modelCatalogRefreshFunction,
   scheduledQueryExecutorFunction,
+  flowRunTerminalFanoutFunction,
+  notificationDeliverFunction,
 ];
 
 const allWebhookFunctions = [
@@ -109,6 +115,8 @@ export {
   manualFlowFunction,
   cancelFlowFunction,
   cleanupAbandonedFlowsFunction,
+  flowRunTerminalFanoutFunction,
+  notificationDeliverFunction,
   syncBackfillEntityFunction,
   webhookEventProcessFunction,
   webhookEventProcessCdcFunction,

--- a/api/src/migrations/2026-05-01-140000_flow_run_notifications_collections.ts
+++ b/api/src/migrations/2026-05-01-140000_flow_run_notifications_collections.ts
@@ -1,0 +1,85 @@
+import { Db } from "mongodb";
+import { loggers } from "../logging";
+
+const log = loggers.migration();
+
+export const description =
+  "Create notification_rules and notification_deliveries collections with indexes";
+
+function hasIndexOnKeys(
+  indexes: { key: Record<string, number> }[],
+  keyPattern: Record<string, number>,
+): boolean {
+  const target = JSON.stringify(keyPattern);
+  return indexes.some(idx => JSON.stringify(idx.key) === target);
+}
+
+export async function up(db: Db): Promise<void> {
+  const collections = await db.listCollections().toArray();
+  const collectionNames = collections.map(c => c.name);
+
+  if (!collectionNames.includes("notification_rules")) {
+    await db.createCollection("notification_rules");
+    log.info("Created notification_rules collection");
+  }
+
+  if (!collectionNames.includes("notification_deliveries")) {
+    await db.createCollection("notification_deliveries");
+    log.info("Created notification_deliveries collection");
+  }
+
+  const rules = db.collection("notification_rules");
+  const ruleIndexes = await rules.listIndexes().toArray();
+
+  if (
+    !hasIndexOnKeys(ruleIndexes, {
+      workspaceId: 1,
+      resourceType: 1,
+      resourceId: 1,
+      enabled: 1,
+    })
+  ) {
+    await rules.createIndex(
+      { workspaceId: 1, resourceType: 1, resourceId: 1, enabled: 1 },
+      { name: "workspace_resource_enabled_idx" },
+    );
+  }
+
+  const deliveries = db.collection("notification_deliveries");
+  const deliveryIndexes = await deliveries.listIndexes().toArray();
+
+  if (
+    !hasIndexOnKeys(deliveryIndexes, {
+      workspaceId: 1,
+      resourceType: 1,
+      resourceId: 1,
+      completedAt: -1,
+    })
+  ) {
+    await deliveries.createIndex(
+      { workspaceId: 1, resourceType: 1, resourceId: 1, completedAt: -1 },
+      { name: "workspace_resource_completed_idx" },
+    );
+  }
+
+  if (
+    !hasIndexOnKeys(deliveryIndexes, {
+      idempotencyKey: 1,
+    })
+  ) {
+    await deliveries.createIndex(
+      { idempotencyKey: 1 },
+      { name: "idempotency_key_unique_idx", unique: true },
+    );
+  }
+
+  if (!hasIndexOnKeys(deliveryIndexes, { createdAt: 1 })) {
+    await deliveries.createIndex(
+      { createdAt: 1 },
+      {
+        name: "notification_deliveries_ttl_idx",
+        expireAfterSeconds: 7776000,
+      },
+    );
+  }
+}

--- a/api/src/routes/flows.ts
+++ b/api/src/routes/flows.ts
@@ -1351,6 +1351,7 @@ flowRoutes.post("/:flowId/backfill", async c => {
         flowId: flow._id.toString(),
         noJitter: true,
         backfill: true,
+        triggerType: "manual",
       },
     });
 

--- a/api/src/routes/notification-rules.ts
+++ b/api/src/routes/notification-rules.ts
@@ -1,0 +1,659 @@
+/**
+ * Workspace-scoped notification rules for scheduled queries and flows.
+ * Authenticated + workspace member access; admin-only for mutations.
+ */
+import { Hono } from "hono";
+import { Types } from "mongoose";
+import { unifiedAuthMiddleware } from "../auth/unified-auth.middleware";
+import {
+  Flow,
+  NotificationDelivery,
+  NotificationRule,
+  SavedConsole,
+  decrypt,
+  encrypt,
+  type INotificationRuleChannel,
+  type NotificationChannelType,
+  type NotificationResourceType,
+  type NotificationTrigger,
+} from "../database/workspace-schema";
+import { loggers } from "../logging";
+import { requireWorkspaceAdmin } from "../middleware/workspace-admin.middleware";
+import { AuthenticatedContext } from "../middleware/workspace.middleware";
+import { workspaceService } from "../services/workspace.service";
+import {
+  buildOutboundPayload,
+  deliverNotificationJobDirect,
+  encryptNotificationChannel,
+  resolveResourceDisplayName,
+  sanitizeRuleForClient,
+} from "../services/flow-run-notification.service";
+import type { NotificationDeliverJobData } from "../services/flow-run-notification.types";
+import {
+  generateWebhookSigningSecret,
+  hashForIdempotencySecret,
+} from "../services/flow-run-notification.helpers";
+import { inngest } from "../inngest";
+
+const logger = loggers.api("notification-rules");
+
+export const notificationRulesRoutes = new Hono();
+
+notificationRulesRoutes.use("*", unifiedAuthMiddleware);
+
+notificationRulesRoutes.use("*", async (c: AuthenticatedContext, next) => {
+  const workspaceId = c.req.param("workspaceId");
+  const user = c.get("user");
+
+  if (!workspaceId || !Types.ObjectId.isValid(workspaceId)) {
+    return c.json(
+      { success: false, error: "Invalid workspace ID format" },
+      400,
+    );
+  }
+
+  if (!user || !(await workspaceService.hasAccess(workspaceId, user.id))) {
+    return c.json({ success: false, error: "Access denied to workspace" }, 403);
+  }
+
+  await next();
+});
+
+async function assertResourceInWorkspace(
+  workspaceId: string,
+  resourceType: NotificationResourceType,
+  resourceId: string,
+): Promise<boolean> {
+  const ws = new Types.ObjectId(workspaceId);
+  const rid = new Types.ObjectId(resourceId);
+  if (resourceType === "scheduled_query") {
+    const doc = await SavedConsole.findOne({
+      _id: rid,
+      workspaceId: ws,
+    }).lean();
+    return !!doc;
+  }
+  const doc = await Flow.findOne({
+    _id: rid,
+    workspaceId: ws,
+  }).lean();
+  return !!doc;
+}
+
+function parseTriggers(raw: unknown): NotificationTrigger[] | null {
+  if (!Array.isArray(raw)) return null;
+  const out: NotificationTrigger[] = [];
+  for (const t of raw) {
+    if (t === "success" || t === "failure") out.push(t);
+  }
+  return out.length > 0 ? [...new Set(out)] : null;
+}
+
+function parseChannelFromBody(body: Record<string, unknown>): {
+  channel: INotificationRuleChannel;
+  rotateWebhookSecret?: boolean;
+  /** Present only when a new signing secret was generated (plain text, return once) */
+  webhookSigningSecretPlain?: string;
+} | null {
+  const type = body.channelType as NotificationChannelType | undefined;
+  if (type === "email") {
+    const recipients = body.recipients;
+    if (!Array.isArray(recipients) || recipients.length === 0) {
+      return null;
+    }
+    const emails = recipients
+      .filter((r): r is string => typeof r === "string")
+      .map(r => r.trim())
+      .filter(Boolean);
+    if (emails.length === 0) return null;
+    return { channel: { type: "email", recipients: emails } };
+  }
+  if (type === "webhook") {
+    const url = typeof body.url === "string" ? body.url.trim() : "";
+    if (!url) return null;
+    const signingSecret =
+      typeof body.signingSecret === "string" && body.signingSecret.trim()
+        ? body.signingSecret.trim()
+        : generateWebhookSigningSecret();
+    const generatedNewSecret =
+      !(typeof body.signingSecret === "string" && body.signingSecret.trim());
+    return {
+      channel: {
+        type: "webhook",
+        urlEncrypted: url,
+        signingSecretEncrypted: signingSecret,
+      },
+      rotateWebhookSecret: Boolean(body.rotateWebhookSecret),
+      webhookSigningSecretPlain: generatedNewSecret ? signingSecret : undefined,
+    };
+  }
+  if (type === "slack") {
+    const webhookUrl =
+      typeof body.slackWebhookUrl === "string"
+        ? body.slackWebhookUrl.trim()
+        : "";
+    if (!webhookUrl) return null;
+    const displayLabel =
+      typeof body.displayLabel === "string" ? body.displayLabel.trim() : "";
+    return {
+      channel: {
+        type: "slack",
+        webhookUrlEncrypted: webhookUrl,
+        displayLabel: displayLabel || undefined,
+      },
+    };
+  }
+  return null;
+}
+
+notificationRulesRoutes.get("/", async (c: AuthenticatedContext) => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const resourceType = c.req.query("resourceType") as
+      | NotificationResourceType
+      | undefined;
+    const resourceId = c.req.query("resourceId");
+
+    if (
+      !resourceType ||
+      (resourceType !== "flow" && resourceType !== "scheduled_query") ||
+      !resourceId ||
+      !Types.ObjectId.isValid(resourceId)
+    ) {
+      return c.json(
+        { success: false, error: "resourceType and resourceId required" },
+        400,
+      );
+    }
+
+    const ok = await assertResourceInWorkspace(
+      workspaceId,
+      resourceType,
+      resourceId,
+    );
+    if (!ok) {
+      return c.json({ success: false, error: "Resource not found" }, 404);
+    }
+
+    const rules = await NotificationRule.find({
+      workspaceId: new Types.ObjectId(workspaceId),
+      resourceType,
+      resourceId: new Types.ObjectId(resourceId),
+    }).sort({ createdAt: 1 });
+
+    return c.json({
+      success: true,
+      rules: rules.map(r => sanitizeRuleForClient(r)),
+    });
+  } catch (error) {
+    logger.error("List notification rules failed", { error });
+    return c.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to list notification rules",
+      },
+      500,
+    );
+  }
+});
+
+notificationRulesRoutes.get("/deliveries", async (c: AuthenticatedContext) => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const resourceType = c.req.query("resourceType") as
+      | NotificationResourceType
+      | undefined;
+    const resourceId = c.req.query("resourceId");
+    const limitRaw = c.req.query("limit");
+    const limit = Math.min(
+      100,
+      Math.max(1, Number.parseInt(limitRaw || "50", 10) || 50),
+    );
+
+    if (
+      !resourceType ||
+      (resourceType !== "flow" && resourceType !== "scheduled_query") ||
+      !resourceId ||
+      !Types.ObjectId.isValid(resourceId)
+    ) {
+      return c.json(
+        { success: false, error: "resourceType and resourceId required" },
+        400,
+      );
+    }
+
+    const ok = await assertResourceInWorkspace(
+      workspaceId,
+      resourceType,
+      resourceId,
+    );
+    if (!ok) {
+      return c.json({ success: false, error: "Resource not found" }, 404);
+    }
+
+    const deliveries = await NotificationDelivery.find({
+      workspaceId: new Types.ObjectId(workspaceId),
+      resourceType,
+      resourceId: new Types.ObjectId(resourceId),
+    })
+      .sort({ completedAt: -1, createdAt: -1 })
+      .limit(limit)
+      .lean();
+
+    return c.json({
+      success: true,
+      deliveries: deliveries.map(d => ({
+        id: d._id.toString(),
+        ruleId: d.ruleId.toString(),
+        runId: d.runId,
+        trigger: d.trigger,
+        channelType: d.channelType,
+        status: d.status,
+        attempts: d.attempts,
+        lastError: d.lastError,
+        httpStatus: d.httpStatus,
+        sentAt: d.sentAt,
+        completedAt: d.completedAt,
+        createdAt: d.createdAt,
+      })),
+    });
+  } catch (error) {
+    logger.error("List notification deliveries failed", { error });
+    return c.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to list deliveries",
+      },
+      500,
+    );
+  }
+});
+
+notificationRulesRoutes.use("*", requireWorkspaceAdmin);
+
+notificationRulesRoutes.post("/", async (c: AuthenticatedContext) => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const user = c.get("user");
+    const body = (await c.req.json()) as Record<string, unknown>;
+
+    const resourceType = body.resourceType as NotificationResourceType;
+    const resourceId = body.resourceId as string;
+    const enabled =
+      typeof body.enabled === "boolean" ? body.enabled : true;
+    const triggers = parseTriggers(body.triggers);
+
+    if (
+      !resourceType ||
+      (resourceType !== "flow" && resourceType !== "scheduled_query") ||
+      !resourceId ||
+      !Types.ObjectId.isValid(resourceId) ||
+      !triggers
+    ) {
+      return c.json(
+        { success: false, error: "Invalid resource or triggers" },
+        400,
+      );
+    }
+
+    const ok = await assertResourceInWorkspace(
+      workspaceId,
+      resourceType,
+      resourceId,
+    );
+    if (!ok) {
+      return c.json({ success: false, error: "Resource not found" }, 404);
+    }
+
+    const parsed = parseChannelFromBody(body);
+    if (!parsed) {
+      return c.json({ success: false, error: "Invalid channel configuration" }, 400);
+    }
+
+    const channel = encryptNotificationChannel(parsed.channel);
+
+    const doc = await NotificationRule.create({
+      workspaceId: new Types.ObjectId(workspaceId),
+      resourceType,
+      resourceId: new Types.ObjectId(resourceId),
+      enabled,
+      triggers,
+      channel,
+      createdBy: user?.id || "unknown",
+    });
+
+    const response: Record<string, unknown> = {
+      success: true,
+      rule: sanitizeRuleForClient(doc),
+    };
+    if (parsed.channel.type === "webhook" && parsed.webhookSigningSecretPlain) {
+      response.signingSecretOnce = parsed.webhookSigningSecretPlain;
+    }
+
+    return c.json(response);
+  } catch (error) {
+    logger.error("Create notification rule failed", { error });
+    return c.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to create notification rule",
+      },
+      500,
+    );
+  }
+});
+
+notificationRulesRoutes.patch("/:ruleId", async (c: AuthenticatedContext) => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const ruleId = c.req.param("ruleId");
+    if (!Types.ObjectId.isValid(ruleId)) {
+      return c.json({ success: false, error: "Invalid rule id" }, 400);
+    }
+
+    const existing = await NotificationRule.findOne({
+      _id: new Types.ObjectId(ruleId),
+      workspaceId: new Types.ObjectId(workspaceId),
+    });
+    if (!existing) {
+      return c.json({ success: false, error: "Rule not found" }, 404);
+    }
+
+    const body = (await c.req.json()) as Record<string, unknown>;
+    const update: Record<string, unknown> = {};
+    let signingSecretOnceOut: string | undefined;
+
+    if (typeof body.enabled === "boolean") {
+      update.enabled = body.enabled;
+    }
+    const triggers = parseTriggers(body.triggers);
+    if (triggers) {
+      update.triggers = triggers;
+    }
+
+    if (body.channelType !== undefined) {
+      const channelType = body.channelType as NotificationChannelType;
+      let channel: INotificationRuleChannel;
+
+      if (channelType === "email") {
+        const parsed = parseChannelFromBody(body);
+        if (!parsed || parsed.channel.type !== "email") {
+          return c.json(
+            { success: false, error: "Invalid email recipients" },
+            400,
+          );
+        }
+        channel = encryptNotificationChannel(parsed.channel);
+      } else if (channelType === "webhook") {
+        if (existing.channel.type !== "webhook") {
+          const parsed = parseChannelFromBody(body);
+          if (!parsed || parsed.channel.type !== "webhook") {
+            return c.json(
+              { success: false, error: "Webhook URL required" },
+              400,
+            );
+          }
+          channel = encryptNotificationChannel(parsed.channel);
+        } else {
+          const prev = existing.channel as {
+            urlEncrypted: string;
+            signingSecretEncrypted: string;
+          };
+          const urlRaw =
+            typeof body.url === "string" && body.url.trim()
+              ? body.url.trim()
+              : decrypt(prev.urlEncrypted);
+          let secretPlain: string;
+          let newSecretOnce: string | undefined;
+          if (body.rotateWebhookSecret) {
+            secretPlain = generateWebhookSigningSecret();
+            newSecretOnce = secretPlain;
+          } else if (
+            typeof body.signingSecret === "string" &&
+            body.signingSecret.trim()
+          ) {
+            secretPlain = body.signingSecret.trim();
+          } else {
+            secretPlain = decrypt(prev.signingSecretEncrypted);
+          }
+          channel = encryptNotificationChannel({
+            type: "webhook",
+            urlEncrypted: urlRaw,
+            signingSecretEncrypted: secretPlain,
+          });
+          if (newSecretOnce) {
+            signingSecretOnceOut = newSecretOnce;
+          }
+        }
+      } else if (channelType === "slack") {
+        if (existing.channel.type !== "slack") {
+          const parsed = parseChannelFromBody(body);
+          if (!parsed || parsed.channel.type !== "slack") {
+            return c.json(
+              { success: false, error: "Slack webhook URL required" },
+              400,
+            );
+          }
+          channel = encryptNotificationChannel(parsed.channel);
+        } else {
+          const prev = existing.channel as {
+            webhookUrlEncrypted: string;
+            displayLabel?: string;
+          };
+          const urlRaw =
+            typeof body.slackWebhookUrl === "string" &&
+            body.slackWebhookUrl.trim()
+              ? body.slackWebhookUrl.trim()
+              : decrypt(prev.webhookUrlEncrypted);
+          const displayLabel =
+            typeof body.displayLabel === "string"
+              ? body.displayLabel.trim()
+              : prev.displayLabel;
+          channel = encryptNotificationChannel({
+            type: "slack",
+            webhookUrlEncrypted: urlRaw,
+            displayLabel: displayLabel || undefined,
+          });
+        }
+      } else {
+        return c.json({ success: false, error: "Invalid channel type" }, 400);
+      }
+
+      update.channel = channel;
+    }
+
+    if (Object.keys(update).length === 0) {
+      return c.json({ success: true, rule: sanitizeRuleForClient(existing) });
+    }
+
+    Object.assign(existing, update);
+    await existing.save();
+
+    return c.json({
+      success: true,
+      rule: sanitizeRuleForClient(existing),
+      ...(signingSecretOnceOut ? { signingSecretOnce: signingSecretOnceOut } : {}),
+    });
+  } catch (error) {
+    logger.error("Update notification rule failed", { error });
+    return c.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to update notification rule",
+      },
+      500,
+    );
+  }
+});
+
+notificationRulesRoutes.delete("/:ruleId", async (c: AuthenticatedContext) => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const ruleId = c.req.param("ruleId");
+    if (!Types.ObjectId.isValid(ruleId)) {
+      return c.json({ success: false, error: "Invalid rule id" }, 400);
+    }
+
+    const result = await NotificationRule.deleteOne({
+      _id: new Types.ObjectId(ruleId),
+      workspaceId: new Types.ObjectId(workspaceId),
+    });
+
+    if (result.deletedCount === 0) {
+      return c.json({ success: false, error: "Rule not found" }, 404);
+    }
+
+    return c.json({ success: true });
+  } catch (error) {
+    logger.error("Delete notification rule failed", { error });
+    return c.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to delete notification rule",
+      },
+      500,
+    );
+  }
+});
+
+notificationRulesRoutes.post("/test", async (c: AuthenticatedContext) => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const body = (await c.req.json()) as Record<string, unknown>;
+
+    const resourceType = body.resourceType as NotificationResourceType;
+    const resourceId = body.resourceId as string;
+    const ruleId = typeof body.ruleId === "string" ? body.ruleId : undefined;
+    const trigger = body.trigger === "success" ? "success" : "failure";
+
+    if (
+      !resourceType ||
+      (resourceType !== "flow" && resourceType !== "scheduled_query") ||
+      !resourceId ||
+      !Types.ObjectId.isValid(resourceId)
+    ) {
+      return c.json(
+        { success: false, error: "Invalid resource" },
+        400,
+      );
+    }
+
+    const ok = await assertResourceInWorkspace(
+      workspaceId,
+      resourceType,
+      resourceId,
+    );
+    if (!ok) {
+      return c.json({ success: false, error: "Resource not found" }, 404);
+    }
+
+    let channel: INotificationRuleChannel;
+
+    if (ruleId && Types.ObjectId.isValid(ruleId)) {
+      const rule = await NotificationRule.findOne({
+        _id: new Types.ObjectId(ruleId),
+        workspaceId: new Types.ObjectId(workspaceId),
+      });
+      if (!rule) {
+        return c.json({ success: false, error: "Rule not found" }, 404);
+      }
+      channel = rule.channel as INotificationRuleChannel;
+    } else {
+      const parsed = parseChannelFromBody(body);
+      if (!parsed) {
+        return c.json(
+          { success: false, error: "Invalid channel configuration" },
+          400,
+        );
+      }
+      channel = encryptNotificationChannel(parsed.channel);
+    }
+
+    const resourceName = await resolveResourceDisplayName({
+      resourceType,
+      resourceId,
+    });
+
+    const payload = buildOutboundPayload({
+      event: {
+        workspaceId,
+        resourceType,
+        resourceId,
+        runId: "test-run",
+        status: trigger === "success" ? "completed" : "failed",
+        success: trigger === "success",
+        triggerType: "manual",
+        completedAt: new Date().toISOString(),
+        durationMs: 0,
+        errorMessage:
+          trigger === "failure" ? "Test failure notification" : undefined,
+      },
+      resourceName,
+      trigger,
+    });
+
+    const channelType = channel.type as NotificationChannelType;
+
+    if (ruleId && Types.ObjectId.isValid(ruleId)) {
+      const idempotencyKey = `test:${hashForIdempotencySecret(`${workspaceId}:${resourceType}:${resourceId}:${Date.now()}:${Math.random()}`)}`;
+      await inngest.send({
+        name: "notification/deliver",
+        data: {
+          workspaceId,
+          ruleId,
+          resourceType,
+          resourceId,
+          runId: "test-run",
+          trigger,
+          channelType,
+          idempotencyKey,
+          payload,
+        } satisfies NotificationDeliverJobData,
+      });
+      return c.json({ success: true, message: "Test notification queued" });
+    }
+
+    await deliverNotificationJobDirect(
+      {
+        workspaceId,
+        resourceType,
+        resourceId,
+        runId: "test-run",
+        trigger,
+        channelType,
+        idempotencyKey: "test:direct",
+        payload,
+      },
+      channel,
+    );
+
+    return c.json({ success: true, message: "Test notification sent" });
+  } catch (error) {
+    logger.error("Test notification failed", { error });
+    return c.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to queue test notification",
+      },
+      500,
+    );
+  }
+});

--- a/api/src/routes/notification-rules.ts
+++ b/api/src/routes/notification-rules.ts
@@ -11,7 +11,6 @@ import {
   NotificationRule,
   SavedConsole,
   decrypt,
-  encrypt,
   type INotificationRuleChannel,
   type NotificationChannelType,
   type NotificationResourceType,

--- a/api/src/services/email.service.ts
+++ b/api/src/services/email.service.ts
@@ -33,6 +33,7 @@ interface EmailServiceConfig {
   invitationTemplateId?: string;
   verificationTemplateId?: string;
   passwordResetTemplateId?: string;
+  flowRunNotificationTemplateId?: string;
 }
 
 /**
@@ -55,6 +56,8 @@ function getConfig(): EmailServiceConfig {
     invitationTemplateId: process.env.SENDGRID_INVITATION_TEMPLATE_ID,
     verificationTemplateId: process.env.SENDGRID_VERIFICATION_TEMPLATE_ID,
     passwordResetTemplateId: process.env.SENDGRID_PASSWORD_RESET_TEMPLATE_ID,
+    flowRunNotificationTemplateId:
+      process.env.SENDGRID_FLOW_RUN_NOTIFICATION_TEMPLATE_ID,
   };
 }
 
@@ -252,6 +255,55 @@ export class EmailService {
     });
 
     logger.info("Password reset email sent", { to });
+  }
+
+  /**
+   * Flow / scheduled query run completion notifications (dynamic template).
+   */
+  async sendFlowRunNotificationEmails(
+    recipients: string[],
+    dynamicTemplateData: Record<string, unknown>,
+  ): Promise<void> {
+    const config = getConfig();
+    const subject =
+      typeof dynamicTemplateData.trigger === "string"
+        ? `Mako: Run ${dynamicTemplateData.trigger}`
+        : "Mako: Run notification";
+
+    if (!config.apiKey) {
+      for (const to of recipients) {
+        logEmailForDev(
+          "Flow run notification",
+          to,
+          subject,
+          dynamicTemplateData,
+        );
+      }
+      logger.info("Flow run notification emails logged (dev mode)", {
+        count: recipients.length,
+      });
+      return;
+    }
+
+    if (!config.flowRunNotificationTemplateId) {
+      logger.warn(
+        "SENDGRID_FLOW_RUN_NOTIFICATION_TEMPLATE_ID not configured — skipping flow run emails",
+      );
+      return;
+    }
+
+    for (const to of recipients) {
+      await sendMail({
+        to,
+        from: config.fromEmail,
+        subject,
+        templateId: config.flowRunNotificationTemplateId,
+        dynamicTemplateData,
+      });
+    }
+    logger.info("Flow run notification emails sent", {
+      count: recipients.length,
+    });
   }
 }
 

--- a/api/src/services/flow-run-notification.emit.ts
+++ b/api/src/services/flow-run-notification.emit.ts
@@ -1,0 +1,72 @@
+import { Types } from "mongoose";
+import { Flow, ScheduledQueryRun } from "../database/workspace-schema";
+import { inngest } from "../inngest/client";
+import type { FlowRunTerminalEventData } from "./flow-run-notification.types";
+
+export async function emitScheduledQueryTerminalEvent(params: {
+    workspaceId: string;
+    consoleId: string;
+    runId: string;
+    triggerType: "schedule" | "manual";
+  },
+): Promise<void> {
+  const run = await ScheduledQueryRun.findById(params.runId).lean();
+  if (!run?.completedAt || run.status === "queued" || run.status === "running") {
+    return;
+  }
+  const success = run.status === "success";
+  const data: FlowRunTerminalEventData = {
+    workspaceId: params.workspaceId,
+    resourceType: "scheduled_query",
+    resourceId: params.consoleId,
+    runId: params.runId,
+    status: run.status,
+    success,
+    triggerType: params.triggerType,
+    completedAt: run.completedAt.toISOString(),
+    durationMs: run.durationMs,
+    rowCount: run.rowCount,
+    errorMessage: run.error?.message,
+  };
+  await inngest.send({ name: "flow.run.terminal", data });
+}
+
+export async function emitFlowExecutionTerminalEvent(params: {
+    workspaceId: string;
+    flowId: string;
+    executionId: string;
+    triggerType: "schedule" | "manual";
+  },
+): Promise<void> {
+  const collection = Flow.db.collection("flow_executions");
+  const execution = await collection.findOne({
+    _id: new Types.ObjectId(params.executionId),
+  });
+  if (!execution?.completedAt) {
+    return;
+  }
+  const status = execution.status as string;
+  if (status === "cancelled" || status === "abandoned") {
+    return;
+  }
+  const success = status === "completed" && execution.success === true;
+  const failed = status === "failed";
+  if (!success && !failed) {
+    return;
+  }
+  const err = execution.error as { message?: string } | undefined;
+  const data: FlowRunTerminalEventData = {
+    workspaceId: params.workspaceId,
+    resourceType: "flow",
+    resourceId: params.flowId,
+    runId: params.executionId,
+    status,
+    success,
+    triggerType: params.triggerType,
+    completedAt: new Date(execution.completedAt).toISOString(),
+    durationMs:
+      typeof execution.duration === "number" ? execution.duration : undefined,
+    errorMessage: err?.message,
+  };
+  await inngest.send({ name: "flow.run.terminal", data });
+}

--- a/api/src/services/flow-run-notification.helpers.test.ts
+++ b/api/src/services/flow-run-notification.helpers.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import {
+  buildIdempotencyKey,
+  signWebhookBody,
+  terminalTriggerFromRunEvent,
+} from "./flow-run-notification.helpers";
+
+function testTerminalTriggerMapsSuccessAndFailure() {
+  assert.equal(
+    terminalTriggerFromRunEvent({
+      workspaceId: "w",
+      resourceType: "flow",
+      resourceId: "f",
+      runId: "r",
+      status: "completed",
+      success: true,
+      completedAt: "",
+    }),
+    "success",
+  );
+  assert.equal(
+    terminalTriggerFromRunEvent({
+      workspaceId: "w",
+      resourceType: "flow",
+      resourceId: "f",
+      runId: "r",
+      status: "failed",
+      success: false,
+      completedAt: "",
+    }),
+    "failure",
+  );
+}
+
+function testBuildIdempotencyKeyJoinsParts() {
+  assert.equal(
+    buildIdempotencyKey({
+      resourceType: "scheduled_query",
+      resourceId: "abc",
+      runId: "run1",
+      trigger: "success",
+      channelType: "email",
+      ruleId: "rule1",
+    }),
+    "scheduled_query:abc:run1:success:email:rule1",
+  );
+}
+
+function testSignWebhookBodyIsStableHex() {
+  const sig = signWebhookBody("secret", '{"a":1}');
+  assert.match(sig, /^[0-9a-f]{64}$/);
+  assert.equal(signWebhookBody("secret", '{"a":1}'), sig);
+}
+
+function main() {
+  testTerminalTriggerMapsSuccessAndFailure();
+  testBuildIdempotencyKeyJoinsParts();
+  testSignWebhookBodyIsStableHex();
+}
+
+main();

--- a/api/src/services/flow-run-notification.helpers.ts
+++ b/api/src/services/flow-run-notification.helpers.ts
@@ -1,0 +1,44 @@
+import * as crypto from "crypto";
+import type {
+  NotificationChannelType,
+  NotificationResourceType,
+  NotificationTrigger,
+} from "../database/workspace-schema";
+import type { FlowRunTerminalEventData } from "./flow-run-notification.types";
+
+export function terminalTriggerFromRunEvent(
+  event: FlowRunTerminalEventData,
+): NotificationTrigger | null {
+  if (event.success) return "success";
+  return "failure";
+}
+
+export function hashForIdempotencySecret(input: string): string {
+  return crypto.createHash("sha256").update(input, "utf8").digest("hex");
+}
+
+export function buildIdempotencyKey(params: {
+  resourceType: NotificationResourceType;
+  resourceId: string;
+  runId: string;
+  trigger: NotificationTrigger;
+  channelType: NotificationChannelType;
+  ruleId: string;
+}): string {
+  return [
+    params.resourceType,
+    params.resourceId,
+    params.runId,
+    params.trigger,
+    params.channelType,
+    params.ruleId,
+  ].join(":");
+}
+
+export function generateWebhookSigningSecret(): string {
+  return `whsec_${crypto.randomBytes(32).toString("hex")}`;
+}
+
+export function signWebhookBody(secret: string, body: string): string {
+  return crypto.createHmac("sha256", secret).update(body, "utf8").digest("hex");
+}

--- a/api/src/services/flow-run-notification.service.ts
+++ b/api/src/services/flow-run-notification.service.ts
@@ -1,0 +1,449 @@
+import { Types } from "mongoose";
+import {
+  Connector as DataSource,
+  DatabaseConnection,
+  Flow,
+  SavedConsole,
+  NotificationRule,
+  NotificationDelivery,
+  decrypt,
+  encrypt,
+  type IFlow,
+  type INotificationRule,
+  type INotificationRuleChannel,
+  type NotificationChannelType,
+  type NotificationResourceType,
+  type NotificationTrigger,
+} from "../database/workspace-schema";
+import { loggers } from "../logging";
+import { emailService } from "./email.service";
+import {
+  buildIdempotencyKey,
+  signWebhookBody,
+  terminalTriggerFromRunEvent,
+} from "./flow-run-notification.helpers";
+import type {
+  FlowRunTerminalEventData,
+  NotificationDeliverJobData,
+  NotificationOutboundPayload,
+} from "./flow-run-notification.types";
+
+const logger = loggers.inngest("notification");
+
+function clientUrl(): string {
+  return (
+    process.env.CLIENT_URL?.replace(/\/$/, "") ||
+    process.env.PUBLIC_URL?.replace(/\/$/, "") ||
+    ""
+  );
+}
+
+export async function resolveResourceDisplayName(params: {
+  resourceType: NotificationResourceType;
+  resourceId: string;
+}): Promise<string> {
+  const id = params.resourceId;
+  if (params.resourceType === "scheduled_query") {
+    const doc = await SavedConsole.findById(id).select("name").lean();
+    return doc?.name || id;
+  }
+  const flowDoc = await Flow.findById(id);
+  if (!flowDoc) return id;
+  const flow = flowDoc.toObject({ getters: true }) as IFlow;
+  try {
+    let sourceName: string;
+    let destName: string;
+
+    if (flow.sourceType === "database" && flow.databaseSource?.connectionId) {
+      const sourceDb = await DatabaseConnection.findById(
+        flow.databaseSource.connectionId,
+      );
+      sourceName =
+        sourceDb?.name || flow.databaseSource.connectionId.toString();
+    } else if (flow.dataSourceId) {
+      const dataSource = await DataSource.findById(flow.dataSourceId);
+      sourceName = dataSource?.name || flow.dataSourceId.toString();
+    } else {
+      sourceName = "Unknown Source";
+    }
+
+    if (flow.tableDestination?.connectionId) {
+      const destDb = await DatabaseConnection.findById(
+        flow.tableDestination.connectionId,
+      );
+      destName = flow.tableDestination.tableName
+        ? `${destDb?.name || "DB"}.${flow.tableDestination.tableName}`
+        : destDb?.name || flow.tableDestination.connectionId.toString();
+    } else {
+      const database = await DatabaseConnection.findById(
+        flow.destinationDatabaseId,
+      );
+      destName = database?.name || flow.destinationDatabaseId.toString();
+    }
+
+    return `${sourceName} → ${destName}`;
+  } catch {
+    return id;
+  }
+}
+
+export function buildOutboundPayload(params: {
+  event: FlowRunTerminalEventData;
+  resourceName: string;
+  trigger: NotificationTrigger;
+}): NotificationOutboundPayload {
+  const base = clientUrl();
+  const deepLink =
+    params.event.resourceType === "flow"
+      ? base
+        ? `${base}/workspace/${params.event.workspaceId}/flows/${params.event.resourceId}`
+        : undefined
+      : base
+        ? `${base}/workspace/${params.event.workspaceId}/console/${params.event.resourceId}`
+        : undefined;
+
+  return {
+    version: 1,
+    event: "flow.run.terminal",
+    trigger: params.trigger,
+    resourceType: params.event.resourceType,
+    resourceId: params.event.resourceId,
+    resourceName: params.resourceName,
+    runId: params.event.runId,
+    completedAt: params.event.completedAt,
+    durationMs: params.event.durationMs,
+    rowCount: params.event.rowCount,
+    errorMessage: params.event.errorMessage,
+    triggerType: params.event.triggerType,
+    workspaceId: params.event.workspaceId,
+    deepLink,
+  };
+}
+
+export async function fanOutTerminalRunNotifications(
+  event: FlowRunTerminalEventData,
+): Promise<{ deliveriesQueued: number }> {
+  const trigger = terminalTriggerFromRunEvent(event);
+  if (!trigger) {
+    return { deliveriesQueued: 0 };
+  }
+
+  const rules = await NotificationRule.find({
+    workspaceId: new Types.ObjectId(event.workspaceId),
+    resourceType: event.resourceType,
+    resourceId: new Types.ObjectId(event.resourceId),
+    enabled: true,
+    triggers: trigger,
+  }).lean();
+
+  if (rules.length === 0) {
+    return { deliveriesQueued: 0 };
+  }
+
+  const resourceName = await resolveResourceDisplayName({
+    resourceType: event.resourceType,
+    resourceId: event.resourceId,
+  });
+  const payload = buildOutboundPayload({ event, resourceName, trigger });
+
+  const { inngest } = await import("../inngest/client");
+  let count = 0;
+  for (const rule of rules) {
+    const ruleId = rule._id.toString();
+    const channelType = rule.channel.type as NotificationChannelType;
+    const idempotencyKey = buildIdempotencyKey({
+      resourceType: event.resourceType,
+      resourceId: event.resourceId,
+      runId: event.runId,
+      trigger,
+      channelType,
+      ruleId,
+    });
+
+    const existing = await NotificationDelivery.findOne({ idempotencyKey }).lean();
+    if (existing) {
+      continue;
+    }
+
+    await NotificationDelivery.create({
+      workspaceId: new Types.ObjectId(event.workspaceId),
+      ruleId: new Types.ObjectId(ruleId),
+      resourceType: event.resourceType,
+      resourceId: new Types.ObjectId(event.resourceId),
+      runId: event.runId,
+      trigger,
+      channelType,
+      idempotencyKey,
+      status: "pending",
+      attempts: 0,
+    });
+
+    await inngest.send({
+      name: "notification/deliver",
+      data: {
+        workspaceId: event.workspaceId,
+        ruleId,
+        resourceType: event.resourceType,
+        resourceId: event.resourceId,
+        runId: event.runId,
+        trigger,
+        channelType,
+        idempotencyKey,
+        payload,
+      } satisfies NotificationDeliverJobData,
+    });
+    count++;
+  }
+
+  return { deliveriesQueued: count };
+}
+
+async function deliverToChannel(
+  channel: INotificationRuleChannel,
+  payload: NotificationOutboundPayload,
+): Promise<void> {
+  switch (channel.type) {
+    case "email":
+      await deliverEmail(channel.recipients, payload);
+      return;
+    case "webhook":
+      await deliverWebhook(
+        decrypt(channel.urlEncrypted),
+        decrypt(channel.signingSecretEncrypted),
+        payload,
+      );
+      return;
+    case "slack":
+      await deliverSlack(decrypt(channel.webhookUrlEncrypted), payload);
+      return;
+    default:
+      throw new Error("Unknown channel type");
+  }
+}
+
+export async function deliverNotificationJob(
+  job: NotificationDeliverJobData,
+): Promise<void> {
+  const isTestDelivery = job.idempotencyKey.startsWith("test:");
+  const rule = await NotificationRule.findById(job.ruleId).lean();
+  if (!rule || !rule.enabled) {
+    if (!isTestDelivery) {
+      await NotificationDelivery.updateOne(
+        { idempotencyKey: job.idempotencyKey },
+        {
+          $set: {
+            status: "skipped",
+            completedAt: new Date(),
+            lastError: "Rule disabled or deleted",
+          },
+        },
+      );
+    }
+    return;
+  }
+
+  const channel = rule.channel as INotificationRuleChannel;
+  try {
+    await deliverToChannel(channel, job.payload);
+
+    if (!isTestDelivery) {
+      await NotificationDelivery.updateOne(
+        { idempotencyKey: job.idempotencyKey },
+        {
+          $set: {
+            status: "sent",
+            sentAt: new Date(),
+            completedAt: new Date(),
+          },
+          $inc: { attempts: 1 },
+        },
+      );
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error("Notification delivery failed", {
+      idempotencyKey: job.idempotencyKey,
+      channelType: job.channelType,
+      error: message,
+    });
+    if (!isTestDelivery) {
+      await NotificationDelivery.updateOne(
+        { idempotencyKey: job.idempotencyKey },
+        {
+          $set: {
+            status: "failed",
+            lastError: message,
+            completedAt: new Date(),
+          },
+          $inc: { attempts: 1 },
+        },
+      );
+    }
+    throw err;
+  }
+}
+
+/** Direct delivery for UI tests or unsaved rule drafts */
+export async function deliverNotificationJobDirect(
+  job: Omit<NotificationDeliverJobData, "ruleId"> & { ruleId?: string },
+  channel: INotificationRuleChannel,
+): Promise<void> {
+  try {
+    await deliverToChannel(channel, job.payload);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error("Direct notification delivery failed", {
+      channelType: channel.type,
+      error: message,
+    });
+    throw err;
+  }
+}
+
+async function deliverEmail(
+  recipients: string[],
+  payload: NotificationOutboundPayload,
+): Promise<void> {
+  const list = recipients.map(r => r.trim()).filter(Boolean);
+  if (list.length === 0) return;
+  const templateData: Record<string, unknown> = {
+    trigger: payload.trigger,
+    resource_type: payload.resourceType,
+    resource_name: payload.resourceName,
+    run_id: payload.runId,
+    completed_at: payload.completedAt,
+    duration_ms: payload.durationMs ?? "",
+    row_count: payload.rowCount ?? "",
+    error_message: payload.errorMessage ?? "",
+    schedule_trigger: payload.triggerType ?? "",
+    open_url: payload.deepLink ?? "",
+    payload_json: JSON.stringify(payload),
+  };
+  await emailService.sendFlowRunNotificationEmails(list, templateData);
+}
+
+async function deliverWebhook(
+  url: string,
+  signingSecret: string,
+  payload: NotificationOutboundPayload,
+): Promise<void> {
+  const body = JSON.stringify(payload);
+  const sig = signWebhookBody(signingSecret, body);
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Mako-Signature": sig,
+    },
+    body,
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`Webhook HTTP ${response.status}${text ? `: ${text.slice(0, 200)}` : ""}`);
+  }
+}
+
+async function deliverSlack(
+  webhookUrl: string,
+  payload: NotificationOutboundPayload,
+): Promise<void> {
+  const text =
+    `*Mako run ${payload.trigger}*\n` +
+    `*${payload.resourceType}*: ${payload.resourceName}\n` +
+    `Run: \`${payload.runId}\`\n` +
+    `Completed: ${payload.completedAt}` +
+    (payload.durationMs != null ? `\nDuration: ${payload.durationMs}ms` : "") +
+    (payload.rowCount != null ? `\nRows: ${payload.rowCount}` : "") +
+    (payload.errorMessage ? `\nError: ${payload.errorMessage}` : "") +
+    (payload.deepLink ? `\n<${payload.deepLink}|Open in Mako>` : "");
+
+  const slackBody = JSON.stringify({
+    text,
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text,
+        },
+      },
+    ],
+  });
+
+  const response = await fetch(webhookUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: slackBody,
+  });
+  if (!response.ok) {
+    const t = await response.text().catch(() => "");
+    throw new Error(`Slack webhook HTTP ${response.status}${t ? `: ${t.slice(0, 200)}` : ""}`);
+  }
+}
+
+/** Encrypt channel secrets for persistence */
+export function encryptNotificationChannel(
+  channel: INotificationRuleChannel,
+): INotificationRuleChannel {
+  if (channel.type === "email") {
+    return channel;
+  }
+  if (channel.type === "webhook") {
+    return {
+      type: "webhook",
+      urlEncrypted: encrypt(channel.urlEncrypted),
+      signingSecretEncrypted: encrypt(channel.signingSecretEncrypted),
+    };
+  }
+  return {
+    type: "slack",
+    webhookUrlEncrypted: encrypt(channel.webhookUrlEncrypted),
+    displayLabel: channel.displayLabel,
+  };
+}
+
+/** Strip secrets for API responses */
+export function sanitizeRuleForClient(rule: INotificationRule): Record<string, unknown> {
+  const base = {
+    id: rule._id.toString(),
+    workspaceId: rule.workspaceId.toString(),
+    resourceType: rule.resourceType,
+    resourceId: rule.resourceId.toString(),
+    enabled: rule.enabled,
+    triggers: rule.triggers,
+    createdBy: rule.createdBy,
+    createdAt: rule.createdAt,
+    updatedAt: rule.updatedAt,
+  };
+  const ch = rule.channel;
+  if (ch.type === "email") {
+    return { ...base, channel: { type: "email", recipients: ch.recipients } };
+  }
+  if (ch.type === "webhook") {
+    return {
+      ...base,
+      channel: {
+        type: "webhook",
+        urlPreview: maskUrl(decrypt(ch.urlEncrypted)),
+        hasSigningSecret: Boolean(ch.signingSecretEncrypted),
+      },
+    };
+  }
+  return {
+    ...base,
+    channel: {
+      type: "slack",
+      displayLabel: ch.displayLabel || "",
+      webhookConfigured: Boolean(ch.webhookUrlEncrypted),
+    },
+  };
+}
+
+function maskUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    return `${u.protocol}//${u.host}${u.pathname.slice(0, 24)}…`;
+  } catch {
+    return "••••";
+  }
+}

--- a/api/src/services/flow-run-notification.types.ts
+++ b/api/src/services/flow-run-notification.types.ts
@@ -1,0 +1,52 @@
+import type {
+  NotificationChannelType,
+  NotificationResourceType,
+  NotificationTrigger,
+} from "../database/workspace-schema";
+
+/** Persisted run terminal event emitted after DB commit */
+export interface FlowRunTerminalEventData {
+  workspaceId: string;
+  resourceType: NotificationResourceType;
+  resourceId: string;
+  runId: string;
+  /** Raw terminal status from ScheduledQueryRun or FlowExecution */
+  status: string;
+  success: boolean;
+  triggerType?: "schedule" | "manual";
+  completedAt: string;
+  durationMs?: number;
+  rowCount?: number;
+  errorMessage?: string;
+}
+
+/** Fan-out sends one delivery job per matching rule */
+export interface NotificationDeliverJobData {
+  workspaceId: string;
+  ruleId: string;
+  resourceType: NotificationResourceType;
+  resourceId: string;
+  runId: string;
+  trigger: NotificationTrigger;
+  channelType: NotificationChannelType;
+  idempotencyKey: string;
+  /** Serialized snapshot for delivery (no secrets) */
+  payload: NotificationOutboundPayload;
+}
+
+export interface NotificationOutboundPayload {
+  version: 1;
+  event: "flow.run.terminal";
+  trigger: NotificationTrigger;
+  resourceType: NotificationResourceType;
+  resourceId: string;
+  resourceName: string;
+  runId: string;
+  completedAt: string;
+  durationMs?: number;
+  rowCount?: number;
+  errorMessage?: string;
+  triggerType?: "schedule" | "manual";
+  workspaceId: string;
+  deepLink?: string;
+}

--- a/api/src/sync-cdc/backfill.ts
+++ b/api/src/sync-cdc/backfill.ts
@@ -428,6 +428,7 @@ export class CdcBackfillService {
         flowId,
         noJitter: true,
         backfill: true,
+        triggerType: "manual",
         backfillRunId: runId,
         ...(effectiveScope.length > 0
           ? { backfillEntities: effectiveScope }

--- a/app/src/components/DbFlowForm.tsx
+++ b/app/src/components/DbFlowForm.tsx
@@ -52,6 +52,7 @@ import { trackEvent } from "../lib/analytics";
 import { ConnectionSelector } from "./ConnectionSelector";
 import { useSqlAutocomplete } from "../hooks/useSqlAutocomplete";
 import { SchemaMappingTable, TypeCoercion } from "./SchemaMappingTable";
+import { FlowRunNotificationsSection } from "./FlowRunNotificationsSection";
 
 interface DbFlowFormProps {
   flowId?: string;
@@ -2463,6 +2464,15 @@ export const DbFlowForm = forwardRef<DbFlowFormRef, DbFlowFormProps>(
                               You can enable automatic scheduling at any time.
                             </Typography>
                           </Alert>
+                        )}
+
+                        {currentWorkspace && (
+                          <FlowRunNotificationsSection
+                            workspaceId={currentWorkspace.id}
+                            resourceType="flow"
+                            resourceId={currentFlowId}
+                            workspaceRole={currentWorkspace.role}
+                          />
                         )}
 
                         {/* Save Button */}

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -2435,6 +2435,11 @@ function Editor({
               connection => connection.id === scheduleModalTab.connectionId,
             )?.displayName || scheduleModalTab.databaseName
           }
+          workspaceId={currentWorkspace?.id}
+          notificationConsoleId={
+            scheduleModalTab.isSaved ? scheduleModalTab.id : undefined
+          }
+          workspaceRole={currentWorkspace?.role}
           onClose={() => setScheduleModalTabId(null)}
           onSave={handleSaveSchedule}
           onRemove={

--- a/app/src/components/FlowRunNotificationsSection.tsx
+++ b/app/src/components/FlowRunNotificationsSection.tsx
@@ -27,8 +27,10 @@ import {
 } from "@mui/material";
 import {
   Add as AddIcon,
+  Close as CloseIcon,
   Delete as DeleteIcon,
   Edit as EditIcon,
+  History as HistoryIcon,
   NotificationsActive as NotifyIcon,
   Science as TestIcon,
 } from "@mui/icons-material";
@@ -110,9 +112,6 @@ export function FlowRunNotificationsSection({
   const rules = useNotificationRuleStore(s =>
     cacheKey ? s.rulesByKey[cacheKey] : undefined,
   );
-  const deliveries = useNotificationRuleStore(s =>
-    cacheKey ? s.deliveriesByKey[cacheKey] : undefined,
-  );
   const fetchRules = useNotificationRuleStore(s => s.fetchRules);
   const fetchDeliveries = useNotificationRuleStore(s => s.fetchDeliveries);
   const createRule = useNotificationRuleStore(s => s.createRule);
@@ -138,7 +137,11 @@ export function FlowRunNotificationsSection({
   const [slackWebhookUrl, setSlackWebhookUrl] = useState("");
   const [slackLabel, setSlackLabel] = useState("");
 
-  const [deliveriesLoading, setDeliveriesLoading] = useState(false);
+  const [deliveryLogOpen, setDeliveryLogOpen] = useState(false);
+  const [deliveryLogItems, setDeliveryLogItems] = useState<
+    NotificationDeliveryApi[]
+  >([]);
+  const [deliveryLogLoading, setDeliveryLogLoading] = useState(false);
   const [testDialogOpen, setTestDialogOpen] = useState(false);
   const [testRuleId, setTestRuleId] = useState<string | null>(null);
   const [testTrigger, setTestTrigger] =
@@ -190,10 +193,7 @@ export function FlowRunNotificationsSection({
     setLoadError(null);
     void (async () => {
       try {
-        await Promise.all([
-          fetchRules(workspaceId, resourceType, resourceId),
-          fetchDeliveries(workspaceId, resourceType, resourceId),
-        ]);
+        await fetchRules(workspaceId, resourceType, resourceId);
       } catch (e) {
         if (!cancelled) {
           setLoadError(
@@ -205,27 +205,32 @@ export function FlowRunNotificationsSection({
     return () => {
       cancelled = true;
     };
-  }, [
-    workspaceId,
-    resourceId,
-    resourceType,
-    fetchRules,
-    fetchDeliveries,
-  ]);
+  }, [workspaceId, resourceId, resourceType, fetchRules]);
 
-  const handleRefreshDeliveries = useCallback(async () => {
+  const loadDeliveryLog = useCallback(async () => {
     if (!workspaceId || !resourceId) return;
-    setDeliveriesLoading(true);
+    setDeliveryLogLoading(true);
     try {
-      await fetchDeliveries(workspaceId, resourceType, resourceId);
+      const list = await fetchDeliveries(
+        workspaceId,
+        resourceType,
+        resourceId,
+        { limit: 100, skipCache: true },
+      );
+      setDeliveryLogItems(list);
     } catch (e) {
       setLoadError(
         e instanceof Error ? e.message : "Failed to load delivery history",
       );
     } finally {
-      setDeliveriesLoading(false);
+      setDeliveryLogLoading(false);
     }
   }, [workspaceId, resourceId, resourceType, fetchDeliveries]);
+
+  const handleOpenDeliveryLog = useCallback(() => {
+    setDeliveryLogOpen(true);
+    void loadDeliveryLog();
+  }, [loadDeliveryLog]);
 
   const parsedRecipients = useMemo(() => {
     return recipientsText
@@ -379,19 +384,33 @@ export function FlowRunNotificationsSection({
         alignItems="center"
         justifyContent="space-between"
         sx={{ mb: 1 }}
+        flexWrap="wrap"
+        gap={1}
       >
         <Typography variant="subtitle2" color="text.secondary">
           Run notifications
         </Typography>
-        {canManage && (
+        <Stack direction="row" alignItems="center" spacing={0.5} flexWrap="wrap">
           <Button
             size="small"
-            startIcon={<AddIcon />}
-            onClick={openCreateDialog}
+            variant="text"
+            startIcon={<HistoryIcon fontSize="small" />}
+            onClick={handleOpenDeliveryLog}
+            disabled={!resourceId}
+            sx={{ textTransform: "none" }}
           >
-            Add notification
+            View delivery log
           </Button>
-        )}
+          {canManage && (
+            <Button
+              size="small"
+              startIcon={<AddIcon />}
+              onClick={openCreateDialog}
+            >
+              Add notification
+            </Button>
+          )}
+        </Stack>
       </Stack>
 
       {!canManage && (
@@ -481,60 +500,90 @@ export function FlowRunNotificationsSection({
         )}
       </Stack>
 
-      <Box sx={{ mt: 2 }}>
-        <Stack
-          direction="row"
-          alignItems="baseline"
-          justifyContent="space-between"
-          spacing={1}
-          sx={{ mb: 0.75 }}
+      <Dialog
+        open={deliveryLogOpen}
+        onClose={() => setDeliveryLogOpen(false)}
+        fullWidth
+        maxWidth="sm"
+        scroll="paper"
+        PaperProps={{
+          sx: {
+            maxHeight: "min(560px, 85vh)",
+            display: "flex",
+            flexDirection: "column",
+          },
+        }}
+      >
+        <DialogTitle
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 1,
+            pr: 1,
+          }}
         >
-          <Typography variant="subtitle2" color="text.secondary">
+          <Typography component="span" variant="h6" fontWeight={600}>
             Delivery log
           </Typography>
-          <Button
+          <IconButton
             size="small"
-            variant="text"
-            onClick={() => void handleRefreshDeliveries()}
-            disabled={deliveriesLoading}
-            sx={{ minWidth: "auto", textTransform: "none" }}
+            aria-label="Close delivery log"
+            onClick={() => setDeliveryLogOpen(false)}
           >
-            {deliveriesLoading ? "Loading…" : "Refresh"}
-          </Button>
-        </Stack>
-        <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
-          Last attempts for this query or flow (newest first).
-        </Typography>
-        {(deliveries ?? []).length === 0 ? (
-          <Typography variant="body2" color="text.secondary">
-            No deliveries yet. They appear here after a run completes and a
-            notification is sent.
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent dividers sx={{ flex: 1, overflow: "auto", py: 2 }}>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            Notification send attempts for this {resourceType === "flow" ? "flow" : "scheduled query"}, newest first (up to 100).
           </Typography>
-        ) : (
-          <Stack
-            component="ul"
-            spacing={0.5}
-            sx={{
-              m: 0,
-              pl: 2,
-              listStyleType: "disc",
-              "& li": { display: "list-item", pl: 0.25 },
-            }}
+          {deliveryLogLoading ? (
+            <Typography variant="body2" color="text.secondary">
+              Loading…
+            </Typography>
+          ) : deliveryLogItems.length === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              No deliveries yet. Entries appear after a run finishes and a
+              notification is sent.
+            </Typography>
+          ) : (
+            <Stack
+              component="ul"
+              spacing={1}
+              sx={{
+                m: 0,
+                pl: 2,
+                listStyleType: "disc",
+                "& li": { display: "list-item", pl: 0.25 },
+              }}
+            >
+              {deliveryLogItems.map(d => (
+                <Typography
+                  key={d.id}
+                  component="li"
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ wordBreak: "break-word" }}
+                >
+                  {formatDeliveryLine(d)}
+                </Typography>
+              ))}
+            </Stack>
+          )}
+        </DialogContent>
+        <DialogActions sx={{ px: 2, py: 1.5 }}>
+          <Button
+            onClick={() => void loadDeliveryLog()}
+            disabled={deliveryLogLoading}
           >
-            {(deliveries ?? []).slice(0, 10).map(d => (
-              <Typography
-                key={d.id}
-                component="li"
-                variant="body2"
-                color="text.secondary"
-                sx={{ wordBreak: "break-word" }}
-              >
-                {formatDeliveryLine(d)}
-              </Typography>
-            ))}
-          </Stack>
-        )}
-      </Box>
+            Refresh
+          </Button>
+          <Button variant="contained" onClick={() => setDeliveryLogOpen(false)}>
+            Close
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       <Dialog
         open={dialogOpen}

--- a/app/src/components/FlowRunNotificationsSection.tsx
+++ b/app/src/components/FlowRunNotificationsSection.tsx
@@ -90,12 +90,8 @@ export function FlowRunNotificationsSection({
   workspaceRole,
   compact,
 }: FlowRunNotificationsSectionProps) {
-  const canManage =
-    workspaceRole === "owner" || workspaceRole === "admin";
-
-  const cacheKey = resourceId
-    ? resourceCacheKey(resourceType, resourceId)
-    : "";
+  const canManage = workspaceRole === "owner" || workspaceRole === "admin";
+  const cacheKey = resourceId ? resourceCacheKey(resourceType, resourceId) : "";
 
   const rules = useNotificationRuleStore(s =>
     cacheKey ? s.rulesByKey[cacheKey] : undefined,
@@ -197,13 +193,7 @@ export function FlowRunNotificationsSection({
   useEffect(() => {
     if (!deliveriesOpen || !workspaceId || !resourceId) return;
     void fetchDeliveries(workspaceId, resourceType, resourceId);
-  }, [
-    deliveriesOpen,
-    workspaceId,
-    resourceId,
-    resourceType,
-    fetchDeliveries,
-  ]);
+  }, [deliveriesOpen, workspaceId, resourceId, resourceType, fetchDeliveries]);
 
   const parsedRecipients = useMemo(() => {
     return recipientsText
@@ -294,7 +284,10 @@ export function FlowRunNotificationsSection({
     }
   };
 
-  const handleToggleEnabled = async (rule: NotificationRuleApi, on: boolean) => {
+  const handleToggleEnabled = async (
+    rule: NotificationRuleApi,
+    on: boolean,
+  ) => {
     if (!workspaceId || !canManage) return;
     setBusyRuleId(rule.id);
     try {
@@ -340,8 +333,9 @@ export function FlowRunNotificationsSection({
   if (!resourceId) {
     return (
       <Alert severity="info" sx={{ mt: compact ? 0 : 2 }}>
-        Save this {resourceType === "scheduled_query" ? "query" : "flow"}{" "}
-        first to configure run notifications.
+        {`Save this ${
+          resourceType === "scheduled_query" ? "query" : "flow"
+        } first to configure run notifications.`}
       </Alert>
     );
   }
@@ -369,7 +363,12 @@ export function FlowRunNotificationsSection({
       </Stack>
 
       {!canManage && (
-        <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          display="block"
+          sx={{ mb: 1 }}
+        >
           Only workspace admins can edit notifications.
         </Typography>
       )}
@@ -573,9 +572,7 @@ export function FlowRunNotificationsSection({
                     control={
                       <Checkbox
                         checked={rotateWebhookSecret}
-                        onChange={e =>
-                          setRotateWebhookSecret(e.target.checked)
-                        }
+                        onChange={e => setRotateWebhookSecret(e.target.checked)}
                       />
                     }
                     label="Rotate signing secret"

--- a/app/src/components/FlowRunNotificationsSection.tsx
+++ b/app/src/components/FlowRunNotificationsSection.tsx
@@ -1,0 +1,664 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Checkbox,
+  Chip,
+  Collapse,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControl,
+  FormControlLabel,
+  FormGroup,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Switch,
+  TextField,
+  Typography,
+} from "@mui/material";
+import {
+  Add as AddIcon,
+  Delete as DeleteIcon,
+  Edit as EditIcon,
+  ExpandLess as ExpandLessIcon,
+  ExpandMore as ExpandMoreIcon,
+  NotificationsActive as NotifyIcon,
+  Science as TestIcon,
+} from "@mui/icons-material";
+import type {
+  NotificationChannelTypeApi,
+  NotificationResourceTypeApi,
+  NotificationRuleApi,
+  NotificationTriggerApi,
+} from "../lib/api-types";
+import {
+  ruleSummary,
+  useNotificationRuleStore,
+} from "../store/notificationRuleStore";
+
+export interface FlowRunNotificationsSectionProps {
+  workspaceId: string;
+  resourceType: NotificationResourceTypeApi;
+  resourceId: string | undefined;
+  /** From workspace.role — only owner/admin can mutate rules */
+  workspaceRole: string;
+  /** Compact layout for dialogs */
+  compact?: boolean;
+}
+
+function resourceCacheKey(
+  resourceType: NotificationResourceTypeApi,
+  resourceId: string,
+): string {
+  return `${resourceType}:${resourceId}`;
+}
+
+function triggersLabel(triggers: NotificationTriggerApi[]): string {
+  const parts: string[] = [];
+  if (triggers.includes("success")) parts.push("Success");
+  if (triggers.includes("failure")) parts.push("Failure");
+  return parts.join(" · ");
+}
+
+function channelTitle(type: NotificationChannelTypeApi): string {
+  switch (type) {
+    case "email":
+      return "Email notification";
+    case "webhook":
+      return "Webhook notification";
+    case "slack":
+      return "Slack notification";
+    default:
+      return "Notification";
+  }
+}
+
+export function FlowRunNotificationsSection({
+  workspaceId,
+  resourceType,
+  resourceId,
+  workspaceRole,
+  compact,
+}: FlowRunNotificationsSectionProps) {
+  const canManage =
+    workspaceRole === "owner" || workspaceRole === "admin";
+
+  const cacheKey = resourceId
+    ? resourceCacheKey(resourceType, resourceId)
+    : "";
+
+  const rules = useNotificationRuleStore(s =>
+    cacheKey ? s.rulesByKey[cacheKey] : undefined,
+  );
+  const deliveries = useNotificationRuleStore(s =>
+    cacheKey ? s.deliveriesByKey[cacheKey] : undefined,
+  );
+  const fetchRules = useNotificationRuleStore(s => s.fetchRules);
+  const fetchDeliveries = useNotificationRuleStore(s => s.fetchDeliveries);
+  const createRule = useNotificationRuleStore(s => s.createRule);
+  const updateRule = useNotificationRuleStore(s => s.updateRule);
+  const deleteRule = useNotificationRuleStore(s => s.deleteRule);
+  const testNotification = useNotificationRuleStore(s => s.testNotification);
+
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingRule, setEditingRule] = useState<NotificationRuleApi | null>(
+    null,
+  );
+  const [secretBanner, setSecretBanner] = useState<string | null>(null);
+
+  const [successChecked, setSuccessChecked] = useState(true);
+  const [failureChecked, setFailureChecked] = useState(true);
+  const [channelType, setChannelType] =
+    useState<NotificationChannelTypeApi>("email");
+  const [recipientsText, setRecipientsText] = useState("");
+  const [webhookUrl, setWebhookUrl] = useState("");
+  const [webhookSigningSecret, setWebhookSigningSecret] = useState("");
+  const [rotateWebhookSecret, setRotateWebhookSecret] = useState(false);
+  const [slackWebhookUrl, setSlackWebhookUrl] = useState("");
+  const [slackLabel, setSlackLabel] = useState("");
+
+  const [deliveriesOpen, setDeliveriesOpen] = useState(false);
+  const [testDialogOpen, setTestDialogOpen] = useState(false);
+  const [testRuleId, setTestRuleId] = useState<string | null>(null);
+  const [testTrigger, setTestTrigger] =
+    useState<NotificationTriggerApi>("success");
+  const [busyRuleId, setBusyRuleId] = useState<string | null>(null);
+
+  const resetDialogFields = useCallback(() => {
+    setSuccessChecked(true);
+    setFailureChecked(true);
+    setChannelType("email");
+    setRecipientsText("");
+    setWebhookUrl("");
+    setWebhookSigningSecret("");
+    setRotateWebhookSecret(false);
+    setSlackWebhookUrl("");
+    setSlackLabel("");
+    setSecretBanner(null);
+  }, []);
+
+  const openCreateDialog = () => {
+    setEditingRule(null);
+    resetDialogFields();
+    setDialogOpen(true);
+  };
+
+  const openEditDialog = (rule: NotificationRuleApi) => {
+    setEditingRule(rule);
+    setSecretBanner(null);
+    setSuccessChecked(rule.triggers.includes("success"));
+    setFailureChecked(rule.triggers.includes("failure"));
+    const ch = rule.channel;
+    setChannelType(ch.type);
+    if (ch.type === "email") {
+      setRecipientsText(ch.recipients.join(", "));
+    } else {
+      setRecipientsText("");
+    }
+    setWebhookUrl("");
+    setWebhookSigningSecret("");
+    setRotateWebhookSecret(false);
+    setSlackWebhookUrl("");
+    setSlackLabel(ch.type === "slack" ? ch.displayLabel || "" : "");
+    setDialogOpen(true);
+  };
+
+  useEffect(() => {
+    if (!workspaceId || !resourceId) return;
+    let cancelled = false;
+    setLoadError(null);
+    void (async () => {
+      try {
+        await fetchRules(workspaceId, resourceType, resourceId);
+      } catch (e) {
+        if (!cancelled) {
+          setLoadError(
+            e instanceof Error ? e.message : "Failed to load notifications",
+          );
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId, resourceId, resourceType, fetchRules]);
+
+  useEffect(() => {
+    if (!deliveriesOpen || !workspaceId || !resourceId) return;
+    void fetchDeliveries(workspaceId, resourceType, resourceId);
+  }, [
+    deliveriesOpen,
+    workspaceId,
+    resourceId,
+    resourceType,
+    fetchDeliveries,
+  ]);
+
+  const parsedRecipients = useMemo(() => {
+    return recipientsText
+      .split(/[\n,]+/)
+      .map(s => s.trim())
+      .filter(Boolean);
+  }, [recipientsText]);
+
+  const buildPayloadBase = (): Record<string, unknown> | null => {
+    const triggers: NotificationTriggerApi[] = [];
+    if (successChecked) triggers.push("success");
+    if (failureChecked) triggers.push("failure");
+    if (triggers.length === 0) return null;
+
+    const base: Record<string, unknown> = {
+      triggers,
+      channelType,
+    };
+
+    if (channelType === "email") {
+      if (parsedRecipients.length === 0) return null;
+      base.recipients = parsedRecipients;
+    } else if (channelType === "webhook") {
+      if (editingRule && webhookUrl.trim() === "") {
+        // keep URL server-side
+      } else if (!webhookUrl.trim()) {
+        return null;
+      } else {
+        base.url = webhookUrl.trim();
+      }
+      if (webhookSigningSecret.trim()) {
+        base.signingSecret = webhookSigningSecret.trim();
+      }
+      if (editingRule?.channel.type === "webhook" && rotateWebhookSecret) {
+        base.rotateWebhookSecret = true;
+      }
+    } else if (channelType === "slack") {
+      if (editingRule && slackWebhookUrl.trim() === "") {
+        // keep URL server-side
+      } else if (!slackWebhookUrl.trim()) {
+        return null;
+      } else {
+        base.slackWebhookUrl = slackWebhookUrl.trim();
+      }
+      if (slackLabel.trim()) base.displayLabel = slackLabel.trim();
+    }
+
+    return base;
+  };
+
+  const handleSaveDialog = async () => {
+    if (!workspaceId || !resourceId || !canManage) return;
+    const body = buildPayloadBase();
+    if (!body) {
+      setLoadError(
+        "Choose at least one event (success or failure) and complete the channel fields.",
+      );
+      return;
+    }
+
+    try {
+      if (editingRule) {
+        const res = await updateRule(workspaceId, editingRule.id, body);
+        if (res.signingSecretOnce) {
+          setSecretBanner(
+            `Signing secret (copy now; shown once): ${res.signingSecretOnce}`,
+          );
+        } else {
+          setDialogOpen(false);
+        }
+      } else {
+        const res = await createRule(workspaceId, {
+          resourceType,
+          resourceId,
+          enabled: true,
+          ...body,
+        });
+        if (res.signingSecretOnce) {
+          setSecretBanner(
+            `Signing secret (copy now; shown once): ${res.signingSecretOnce}`,
+          );
+        } else {
+          setDialogOpen(false);
+        }
+      }
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : "Failed to save rule");
+    }
+  };
+
+  const handleToggleEnabled = async (rule: NotificationRuleApi, on: boolean) => {
+    if (!workspaceId || !canManage) return;
+    setBusyRuleId(rule.id);
+    try {
+      await updateRule(workspaceId, rule.id, { enabled: on });
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : "Failed to update rule");
+    } finally {
+      setBusyRuleId(null);
+    }
+  };
+
+  const handleDelete = async (ruleId: string) => {
+    if (!workspaceId || !canManage) return;
+    if (!confirm("Delete this notification?")) return;
+    try {
+      await deleteRule(workspaceId, ruleId);
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : "Failed to delete");
+    }
+  };
+
+  const handleOpenTest = (ruleId: string) => {
+    setTestRuleId(ruleId);
+    setTestTrigger("success");
+    setTestDialogOpen(true);
+  };
+
+  const handleSendTest = async () => {
+    if (!workspaceId || !resourceId || !testRuleId) return;
+    try {
+      await testNotification(workspaceId, {
+        ruleId: testRuleId,
+        resourceType,
+        resourceId,
+        trigger: testTrigger,
+      });
+      setTestDialogOpen(false);
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : "Test failed");
+    }
+  };
+
+  if (!resourceId) {
+    return (
+      <Alert severity="info" sx={{ mt: compact ? 0 : 2 }}>
+        Save this {resourceType === "scheduled_query" ? "query" : "flow"}{" "}
+        first to configure run notifications.
+      </Alert>
+    );
+  }
+
+  return (
+    <Box sx={{ mt: compact ? 0 : 2 }}>
+      <Stack
+        direction="row"
+        alignItems="center"
+        justifyContent="space-between"
+        sx={{ mb: 1 }}
+      >
+        <Typography variant="subtitle2" color="text.secondary">
+          Run notifications
+        </Typography>
+        {canManage && (
+          <Button
+            size="small"
+            startIcon={<AddIcon />}
+            onClick={openCreateDialog}
+          >
+            Add notification
+          </Button>
+        )}
+      </Stack>
+
+      {!canManage && (
+        <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
+          Only workspace admins can edit notifications.
+        </Typography>
+      )}
+
+      {loadError && (
+        <Alert
+          severity="error"
+          sx={{ mb: 1 }}
+          onClose={() => setLoadError(null)}
+        >
+          {loadError}
+        </Alert>
+      )}
+
+      <Stack spacing={1}>
+        {(rules ?? []).length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            No notifications yet. Notify on success or failure via email,
+            webhook, or Slack.
+          </Typography>
+        ) : (
+          (rules ?? []).map(rule => (
+            <Card key={rule.id} variant="outlined">
+              <CardContent sx={{ py: 1.5, "&:last-child": { pb: 1.5 } }}>
+                <Stack spacing={0.75}>
+                  <Stack direction="row" alignItems="center" spacing={1}>
+                    <NotifyIcon fontSize="small" color="action" />
+                    <Typography variant="subtitle2">
+                      {channelTitle(rule.channel.type)}
+                    </Typography>
+                    <Chip size="small" label={triggersLabel(rule.triggers)} />
+                  </Stack>
+                  <Typography variant="body2" color="text.secondary">
+                    {ruleSummary(rule)}
+                  </Typography>
+                </Stack>
+              </CardContent>
+              <CardActions sx={{ justifyContent: "flex-end", pt: 0 }}>
+                <FormControlLabel
+                  control={
+                    <Switch
+                      size="small"
+                      checked={rule.enabled}
+                      disabled={!canManage || busyRuleId === rule.id}
+                      onChange={(_, v) => void handleToggleEnabled(rule, v)}
+                    />
+                  }
+                  label="On"
+                  sx={{ mr: 1 }}
+                />
+                <IconButton
+                  size="small"
+                  aria-label="Test notification"
+                  onClick={() => handleOpenTest(rule.id)}
+                  disabled={!canManage}
+                >
+                  <TestIcon fontSize="small" />
+                </IconButton>
+                <IconButton
+                  size="small"
+                  aria-label="Edit"
+                  onClick={() => openEditDialog(rule)}
+                  disabled={!canManage}
+                >
+                  <EditIcon fontSize="small" />
+                </IconButton>
+                <IconButton
+                  size="small"
+                  aria-label="Delete"
+                  onClick={() => void handleDelete(rule.id)}
+                  disabled={!canManage}
+                >
+                  <DeleteIcon fontSize="small" />
+                </IconButton>
+              </CardActions>
+            </Card>
+          ))
+        )}
+      </Stack>
+
+      <Button
+        size="small"
+        onClick={() => setDeliveriesOpen(o => !o)}
+        endIcon={deliveriesOpen ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+        sx={{ mt: 1 }}
+      >
+        Recent deliveries
+      </Button>
+      <Collapse in={deliveriesOpen}>
+        <Stack spacing={0.5} sx={{ mt: 1, pl: 0.5 }}>
+          {(deliveries ?? []).length === 0 ? (
+            <Typography variant="caption" color="text.secondary">
+              No delivery history yet.
+            </Typography>
+          ) : (
+            (deliveries ?? []).slice(0, 10).map(d => (
+              <Typography key={d.id} variant="caption" display="block">
+                {d.trigger} · {d.channelType} · {d.status}
+                {d.lastError ? ` — ${d.lastError}` : ""}
+              </Typography>
+            ))
+          )}
+        </Stack>
+      </Collapse>
+
+      <Dialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        fullWidth
+        maxWidth="sm"
+      >
+        <DialogTitle>
+          {editingRule ? "Edit notification" : "Add notification"}
+        </DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            {secretBanner && (
+              <Alert severity="warning" onClose={() => setSecretBanner(null)}>
+                {secretBanner}
+              </Alert>
+            )}
+            <Typography variant="subtitle2">When</Typography>
+            <FormGroup>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={successChecked}
+                    onChange={e => setSuccessChecked(e.target.checked)}
+                  />
+                }
+                label="Run succeeds"
+              />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={failureChecked}
+                    onChange={e => setFailureChecked(e.target.checked)}
+                  />
+                }
+                label="Run fails"
+              />
+            </FormGroup>
+            <Divider />
+            <Typography variant="subtitle2">Channel</Typography>
+            <FormControl fullWidth size="small">
+              <InputLabel>Type</InputLabel>
+              <Select
+                label="Type"
+                value={channelType}
+                onChange={e =>
+                  setChannelType(e.target.value as NotificationChannelTypeApi)
+                }
+              >
+                <MenuItem value="email">Email</MenuItem>
+                <MenuItem value="webhook">Webhook</MenuItem>
+                <MenuItem value="slack">Slack</MenuItem>
+              </Select>
+            </FormControl>
+
+            {channelType === "email" && (
+              <TextField
+                label="Recipients"
+                placeholder="comma or newline separated"
+                fullWidth
+                multiline
+                minRows={2}
+                value={recipientsText}
+                onChange={e => setRecipientsText(e.target.value)}
+              />
+            )}
+
+            {channelType === "webhook" && (
+              <>
+                <TextField
+                  label="Webhook URL"
+                  fullWidth
+                  required={!editingRule}
+                  placeholder={
+                    editingRule?.channel.type === "webhook"
+                      ? "Leave blank to keep current URL"
+                      : undefined
+                  }
+                  value={webhookUrl}
+                  onChange={e => setWebhookUrl(e.target.value)}
+                />
+                <TextField
+                  label="Signing secret (optional)"
+                  fullWidth
+                  type="password"
+                  autoComplete="new-password"
+                  helperText={
+                    editingRule?.channel.type === "webhook"
+                      ? "Leave blank to keep the existing secret"
+                      : "Leave blank to generate a secret automatically"
+                  }
+                  value={webhookSigningSecret}
+                  onChange={e => setWebhookSigningSecret(e.target.value)}
+                />
+                {editingRule?.channel.type === "webhook" && (
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={rotateWebhookSecret}
+                        onChange={e =>
+                          setRotateWebhookSecret(e.target.checked)
+                        }
+                      />
+                    }
+                    label="Rotate signing secret"
+                  />
+                )}
+              </>
+            )}
+
+            {channelType === "slack" && (
+              <>
+                <TextField
+                  label="Slack incoming webhook URL"
+                  fullWidth
+                  required={!editingRule}
+                  placeholder={
+                    editingRule?.channel.type === "slack"
+                      ? "Leave blank to keep current webhook"
+                      : undefined
+                  }
+                  value={slackWebhookUrl}
+                  onChange={e => setSlackWebhookUrl(e.target.value)}
+                />
+                <TextField
+                  label="Label (optional)"
+                  fullWidth
+                  value={slackLabel}
+                  onChange={e => setSlackLabel(e.target.value)}
+                />
+              </>
+            )}
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => {
+              setDialogOpen(false);
+              setSecretBanner(null);
+            }}
+          >
+            {secretBanner ? "Done" : "Cancel"}
+          </Button>
+          {!secretBanner && (
+            <Button variant="contained" onClick={() => void handleSaveDialog()}>
+              Save
+            </Button>
+          )}
+        </DialogActions>
+      </Dialog>
+
+      <Dialog
+        open={testDialogOpen}
+        onClose={() => setTestDialogOpen(false)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>Send test</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <Typography variant="body2" color="text.secondary">
+              Sends a sample payload so you can verify the channel.
+            </Typography>
+            <FormControl fullWidth size="small">
+              <InputLabel>Event</InputLabel>
+              <Select
+                label="Event"
+                value={testTrigger}
+                onChange={e =>
+                  setTestTrigger(e.target.value as NotificationTriggerApi)
+                }
+              >
+                <MenuItem value="success">Success</MenuItem>
+                <MenuItem value="failure">Failure</MenuItem>
+              </Select>
+            </FormControl>
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setTestDialogOpen(false)}>Cancel</Button>
+          <Button variant="contained" onClick={() => void handleSendTest()}>
+            Send test
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/app/src/components/FlowRunNotificationsSection.tsx
+++ b/app/src/components/FlowRunNotificationsSection.tsx
@@ -390,7 +390,12 @@ export function FlowRunNotificationsSection({
         <Typography variant="subtitle2" color="text.secondary">
           Run notifications
         </Typography>
-        <Stack direction="row" alignItems="center" spacing={0.5} flexWrap="wrap">
+        <Stack
+          direction="row"
+          alignItems="center"
+          spacing={0.5}
+          flexWrap="wrap"
+        >
           <Button
             size="small"
             variant="text"
@@ -536,7 +541,9 @@ export function FlowRunNotificationsSection({
         </DialogTitle>
         <DialogContent dividers sx={{ flex: 1, overflow: "auto", py: 2 }}>
           <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            Notification send attempts for this {resourceType === "flow" ? "flow" : "scheduled query"}, newest first (up to 100).
+            Notification send attempts for this{" "}
+            {resourceType === "flow" ? "flow" : "scheduled query"}, newest first
+            (up to 100).
           </Typography>
           {deliveryLogLoading ? (
             <Typography variant="body2" color="text.secondary">

--- a/app/src/components/FlowRunNotificationsSection.tsx
+++ b/app/src/components/FlowRunNotificationsSection.tsx
@@ -8,7 +8,6 @@ import {
   CardContent,
   Checkbox,
   Chip,
-  Collapse,
   Dialog,
   DialogActions,
   DialogContent,
@@ -30,13 +29,12 @@ import {
   Add as AddIcon,
   Delete as DeleteIcon,
   Edit as EditIcon,
-  ExpandLess as ExpandLessIcon,
-  ExpandMore as ExpandMoreIcon,
   NotificationsActive as NotifyIcon,
   Science as TestIcon,
 } from "@mui/icons-material";
 import type {
   NotificationChannelTypeApi,
+  NotificationDeliveryApi,
   NotificationResourceTypeApi,
   NotificationRuleApi,
   NotificationTriggerApi,
@@ -68,6 +66,22 @@ function triggersLabel(triggers: NotificationTriggerApi[]): string {
   if (triggers.includes("success")) parts.push("Success");
   if (triggers.includes("failure")) parts.push("Failure");
   return parts.join(" · ");
+}
+
+function formatDeliveryWhen(d: NotificationDeliveryApi): string {
+  const raw = d.completedAt ?? d.sentAt ?? d.createdAt;
+  try {
+    return new Date(raw).toLocaleString();
+  } catch {
+    return raw;
+  }
+}
+
+function formatDeliveryLine(d: NotificationDeliveryApi): string {
+  const when = formatDeliveryWhen(d);
+  return `${when} · ${d.trigger} · ${d.channelType} · ${d.status}${
+    d.lastError ? ` — ${d.lastError}` : ""
+  }`;
 }
 
 function channelTitle(type: NotificationChannelTypeApi): string {
@@ -124,7 +138,7 @@ export function FlowRunNotificationsSection({
   const [slackWebhookUrl, setSlackWebhookUrl] = useState("");
   const [slackLabel, setSlackLabel] = useState("");
 
-  const [deliveriesOpen, setDeliveriesOpen] = useState(false);
+  const [deliveriesLoading, setDeliveriesLoading] = useState(false);
   const [testDialogOpen, setTestDialogOpen] = useState(false);
   const [testRuleId, setTestRuleId] = useState<string | null>(null);
   const [testTrigger, setTestTrigger] =
@@ -176,7 +190,10 @@ export function FlowRunNotificationsSection({
     setLoadError(null);
     void (async () => {
       try {
-        await fetchRules(workspaceId, resourceType, resourceId);
+        await Promise.all([
+          fetchRules(workspaceId, resourceType, resourceId),
+          fetchDeliveries(workspaceId, resourceType, resourceId),
+        ]);
       } catch (e) {
         if (!cancelled) {
           setLoadError(
@@ -188,12 +205,27 @@ export function FlowRunNotificationsSection({
     return () => {
       cancelled = true;
     };
-  }, [workspaceId, resourceId, resourceType, fetchRules]);
+  }, [
+    workspaceId,
+    resourceId,
+    resourceType,
+    fetchRules,
+    fetchDeliveries,
+  ]);
 
-  useEffect(() => {
-    if (!deliveriesOpen || !workspaceId || !resourceId) return;
-    void fetchDeliveries(workspaceId, resourceType, resourceId);
-  }, [deliveriesOpen, workspaceId, resourceId, resourceType, fetchDeliveries]);
+  const handleRefreshDeliveries = useCallback(async () => {
+    if (!workspaceId || !resourceId) return;
+    setDeliveriesLoading(true);
+    try {
+      await fetchDeliveries(workspaceId, resourceType, resourceId);
+    } catch (e) {
+      setLoadError(
+        e instanceof Error ? e.message : "Failed to load delivery history",
+      );
+    } finally {
+      setDeliveriesLoading(false);
+    }
+  }, [workspaceId, resourceId, resourceType, fetchDeliveries]);
 
   const parsedRecipients = useMemo(() => {
     return recipientsText
@@ -449,30 +481,60 @@ export function FlowRunNotificationsSection({
         )}
       </Stack>
 
-      <Button
-        size="small"
-        onClick={() => setDeliveriesOpen(o => !o)}
-        endIcon={deliveriesOpen ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-        sx={{ mt: 1 }}
-      >
-        Recent deliveries
-      </Button>
-      <Collapse in={deliveriesOpen}>
-        <Stack spacing={0.5} sx={{ mt: 1, pl: 0.5 }}>
-          {(deliveries ?? []).length === 0 ? (
-            <Typography variant="caption" color="text.secondary">
-              No delivery history yet.
-            </Typography>
-          ) : (
-            (deliveries ?? []).slice(0, 10).map(d => (
-              <Typography key={d.id} variant="caption" display="block">
-                {d.trigger} · {d.channelType} · {d.status}
-                {d.lastError ? ` — ${d.lastError}` : ""}
-              </Typography>
-            ))
-          )}
+      <Box sx={{ mt: 2 }}>
+        <Stack
+          direction="row"
+          alignItems="baseline"
+          justifyContent="space-between"
+          spacing={1}
+          sx={{ mb: 0.75 }}
+        >
+          <Typography variant="subtitle2" color="text.secondary">
+            Delivery log
+          </Typography>
+          <Button
+            size="small"
+            variant="text"
+            onClick={() => void handleRefreshDeliveries()}
+            disabled={deliveriesLoading}
+            sx={{ minWidth: "auto", textTransform: "none" }}
+          >
+            {deliveriesLoading ? "Loading…" : "Refresh"}
+          </Button>
         </Stack>
-      </Collapse>
+        <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
+          Last attempts for this query or flow (newest first).
+        </Typography>
+        {(deliveries ?? []).length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            No deliveries yet. They appear here after a run completes and a
+            notification is sent.
+          </Typography>
+        ) : (
+          <Stack
+            component="ul"
+            spacing={0.5}
+            sx={{
+              m: 0,
+              pl: 2,
+              listStyleType: "disc",
+              "& li": { display: "list-item", pl: 0.25 },
+            }}
+          >
+            {(deliveries ?? []).slice(0, 10).map(d => (
+              <Typography
+                key={d.id}
+                component="li"
+                variant="body2"
+                color="text.secondary"
+                sx={{ wordBreak: "break-word" }}
+              >
+                {formatDeliveryLine(d)}
+              </Typography>
+            ))}
+          </Stack>
+        )}
+      </Box>
 
       <Dialog
         open={dialogOpen}

--- a/app/src/components/ScheduleConsoleModal.tsx
+++ b/app/src/components/ScheduleConsoleModal.tsx
@@ -15,6 +15,7 @@ import {
   Typography,
 } from "@mui/material";
 import { CronExpressionParser } from "cron-parser";
+import { FlowRunNotificationsSection } from "./FlowRunNotificationsSection";
 
 type SchedulePreset = "hourly" | "daily" | "every6h" | "weekly" | "custom";
 
@@ -27,6 +28,11 @@ interface ScheduleConsoleModalProps {
     timezone: string;
   };
   connectionLabel?: string;
+  /** Workspace containing the console — enables notification UI when set */
+  workspaceId?: string;
+  /** Saved console id for notification rules (omit until console is saved server-side) */
+  notificationConsoleId?: string;
+  workspaceRole?: string;
   onClose: () => void;
   onSave: (input: { cron: string; timezone: string }) => Promise<void>;
   onRemove?: () => Promise<void>;
@@ -89,6 +95,9 @@ export default function ScheduleConsoleModal({
   initialName,
   initialSchedule,
   connectionLabel,
+  workspaceId,
+  notificationConsoleId,
+  workspaceRole,
   onClose,
   onSave,
   onRemove,
@@ -319,17 +328,15 @@ export default function ScheduleConsoleModal({
             </Typography>
           )}
 
-          <Box>
-            <Typography variant="subtitle2" sx={{ mb: 0.75 }}>
-              Coming in v2
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              Destination
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              Notifications
-            </Typography>
-          </Box>
+          {workspaceId && workspaceRole && (
+            <FlowRunNotificationsSection
+              workspaceId={workspaceId}
+              resourceType="scheduled_query"
+              resourceId={notificationConsoleId}
+              workspaceRole={workspaceRole}
+              compact
+            />
+          )}
         </Stack>
       </DialogContent>
       <DialogActions sx={{ justifyContent: "space-between", px: 3 }}>

--- a/app/src/components/ScheduleConsoleModal.tsx
+++ b/app/src/components/ScheduleConsoleModal.tsx
@@ -3,17 +3,16 @@ import {
   Alert,
   Box,
   Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
+  Drawer,
   FormControlLabel,
+  IconButton,
   Radio,
   RadioGroup,
   Stack,
   TextField,
   Typography,
 } from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
 import { CronExpressionParser } from "cron-parser";
 import { FlowRunNotificationsSection } from "./FlowRunNotificationsSection";
 
@@ -197,15 +196,50 @@ export default function ScheduleConsoleModal({
 
   const isValid = Boolean(cron.trim()) && previewRuns.length > 0;
 
+  const title =
+    mode === "create" ? "Create scheduled query" : "Update scheduled query";
+
   return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
-      <DialogTitle>
-        {mode === "create"
-          ? "Create scheduled query"
-          : "Update scheduled query"}
-      </DialogTitle>
-      <DialogContent dividers>
-        <Stack spacing={2.5} sx={{ pt: 1 }}>
+    <Drawer
+      anchor="right"
+      open={open}
+      onClose={onClose}
+      PaperProps={{
+        sx: {
+          width: { xs: "100%", sm: 440 },
+          maxWidth: "100vw",
+          display: "flex",
+          flexDirection: "column",
+        },
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 1,
+          px: 2,
+          py: 1.5,
+          borderBottom: 1,
+          borderColor: "divider",
+          flexShrink: 0,
+        }}
+      >
+        <Typography variant="subtitle1" fontWeight={600}>
+          {title}
+        </Typography>
+        <IconButton
+          size="small"
+          onClick={onClose}
+          aria-label="Close schedule panel"
+        >
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </Box>
+
+      <Box sx={{ flex: 1, overflow: "auto", px: 2, py: 2 }}>
+        <Stack spacing={2.5}>
           {error && <Alert severity="error">{error}</Alert>}
 
           <Box>
@@ -338,8 +372,22 @@ export default function ScheduleConsoleModal({
             />
           )}
         </Stack>
-      </DialogContent>
-      <DialogActions sx={{ justifyContent: "space-between", px: 3 }}>
+      </Box>
+
+      <Box
+        sx={{
+          flexShrink: 0,
+          borderTop: 1,
+          borderColor: "divider",
+          px: 2,
+          py: 1.5,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          flexWrap: "wrap",
+          gap: 1,
+        }}
+      >
         <Box>
           {mode === "update" && onRemove && (
             <Button color="error" onClick={handleRemove} disabled={isRemoving}>
@@ -347,7 +395,7 @@ export default function ScheduleConsoleModal({
             </Button>
           )}
         </Box>
-        <Box sx={{ display: "flex", gap: 1 }}>
+        <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
           <Button onClick={onClose}>Cancel</Button>
           {mode === "update" && onRunNow && (
             <Button onClick={handleRunNow} disabled={isRunningNow}>
@@ -362,7 +410,7 @@ export default function ScheduleConsoleModal({
             Save
           </Button>
         </Box>
-      </DialogActions>
-    </Dialog>
+      </Box>
+    </Drawer>
   );
 }

--- a/app/src/components/ScheduledFlowForm.tsx
+++ b/app/src/components/ScheduledFlowForm.tsx
@@ -41,6 +41,7 @@ import { useSchemaStore, TreeNode } from "../store/schemaStore";
 import { useAvailableEntitiesStore } from "../store/availableEntitiesStore";
 import { useConnectorCatalogStore } from "../store/connectorCatalogStore";
 import { trackEvent } from "../lib/analytics";
+import { FlowRunNotificationsSection } from "./FlowRunNotificationsSection";
 
 interface ScheduledFlowFormProps {
   flowId?: string;
@@ -1544,6 +1545,15 @@ export function ScheduledFlowForm({
                     {watchTimezone && ` in ${watchTimezone}`}
                   </Typography>
                 </Alert>
+              )}
+
+              {currentWorkspace && (
+                <FlowRunNotificationsSection
+                  workspaceId={currentWorkspace.id}
+                  resourceType="flow"
+                  resourceId={currentFlowId}
+                  workspaceRole={currentWorkspace.role}
+                />
               )}
             </Stack>
           </form>

--- a/app/src/components/WebhookFlowForm.tsx
+++ b/app/src/components/WebhookFlowForm.tsx
@@ -34,6 +34,7 @@ import { useWorkspace } from "../contexts/workspace-context";
 import { useFlowStore } from "../store/flowStore";
 import { useSchemaStore } from "../store/schemaStore";
 import { trackEvent } from "../lib/analytics";
+import { FlowRunNotificationsSection } from "./FlowRunNotificationsSection";
 
 interface WebhookFlowFormProps {
   flowId?: string;
@@ -1803,6 +1804,15 @@ export function WebhookFlowForm({
                         provisioning.
                       </Typography>
                     </Alert>
+                  )}
+
+                  {currentWorkspace && (
+                    <FlowRunNotificationsSection
+                      workspaceId={currentWorkspace.id}
+                      resourceType="flow"
+                      resourceId={currentFlowId ?? undefined}
+                      workspaceRole={currentWorkspace.role}
+                    />
                   )}
                 </Stack>
               </AccordionDetails>

--- a/app/src/lib/api-types.ts
+++ b/app/src/lib/api-types.ts
@@ -133,6 +133,91 @@ export interface ScheduledQueryListResponse {
   scheduledQueries: ScheduledQueryListItem[];
 }
 
+// ==================== Flow run notifications ====================
+
+export type NotificationResourceTypeApi = "scheduled_query" | "flow";
+
+export type NotificationTriggerApi = "success" | "failure";
+
+export type NotificationChannelTypeApi = "email" | "webhook" | "slack";
+
+export interface NotificationRuleChannelEmailApi {
+  type: "email";
+  recipients: string[];
+}
+
+export interface NotificationRuleChannelWebhookApi {
+  type: "webhook";
+  urlPreview: string;
+  hasSigningSecret: boolean;
+}
+
+export interface NotificationRuleChannelSlackApi {
+  type: "slack";
+  displayLabel: string;
+  webhookConfigured: boolean;
+}
+
+export type NotificationRuleChannelApi =
+  | NotificationRuleChannelEmailApi
+  | NotificationRuleChannelWebhookApi
+  | NotificationRuleChannelSlackApi;
+
+export interface NotificationRuleApi {
+  id: string;
+  workspaceId: string;
+  resourceType: NotificationResourceTypeApi;
+  resourceId: string;
+  enabled: boolean;
+  triggers: NotificationTriggerApi[];
+  channel: NotificationRuleChannelApi;
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface NotificationRulesListResponse {
+  success: boolean;
+  rules: NotificationRuleApi[];
+}
+
+export interface NotificationDeliveryApi {
+  id: string;
+  ruleId: string;
+  runId: string;
+  trigger: NotificationTriggerApi;
+  channelType: NotificationChannelTypeApi;
+  status: "pending" | "sent" | "failed" | "skipped";
+  attempts: number;
+  lastError?: string;
+  httpStatus?: number;
+  sentAt?: string;
+  completedAt?: string;
+  createdAt: string;
+}
+
+export interface NotificationDeliveriesResponse {
+  success: boolean;
+  deliveries: NotificationDeliveryApi[];
+}
+
+export interface NotificationRuleCreateResponse {
+  success: boolean;
+  rule: NotificationRuleApi;
+  signingSecretOnce?: string;
+}
+
+export interface NotificationRuleUpdateResponse {
+  success: boolean;
+  rule: NotificationRuleApi;
+  signingSecretOnce?: string;
+}
+
+export interface NotificationTestResponse {
+  success: boolean;
+  message?: string;
+}
+
 // ==================== Query Execution Endpoints ====================
 
 export interface QueryExecuteResponse {

--- a/app/src/store/notificationRuleStore.ts
+++ b/app/src/store/notificationRuleStore.ts
@@ -29,6 +29,7 @@ interface NotificationRuleActions {
     workspaceId: string,
     resourceType: NotificationResourceTypeApi,
     resourceId: string,
+    options?: { limit?: number; skipCache?: boolean },
   ) => Promise<NotificationDeliveryApi[]>;
   createRule: (
     workspaceId: string,
@@ -72,19 +73,31 @@ export const useNotificationRuleStore = create<
       return res.rules || [];
     },
 
-    fetchDeliveries: async (workspaceId, resourceType, resourceId) => {
+    fetchDeliveries: async (
+      workspaceId,
+      resourceType,
+      resourceId,
+      options,
+    ) => {
       const key = resourceKey(resourceType, resourceId);
+      const params: Record<string, string> = {
+        resourceType,
+        resourceId,
+      };
+      if (options?.limit != null) {
+        params.limit = String(options.limit);
+      }
       const res = await apiClient.get<{
         success: boolean;
         deliveries: NotificationDeliveryApi[];
-      }>(`/workspaces/${workspaceId}/notification-rules/deliveries`, {
-        resourceType,
-        resourceId,
-      });
-      set(s => {
-        s.deliveriesByKey[key] = res.deliveries || [];
-      });
-      return res.deliveries || [];
+      }>(`/workspaces/${workspaceId}/notification-rules/deliveries`, params);
+      const list = res.deliveries || [];
+      if (!options?.skipCache) {
+        set(s => {
+          s.deliveriesByKey[key] = list;
+        });
+      }
+      return list;
     },
 
     createRule: async (workspaceId, body) => {

--- a/app/src/store/notificationRuleStore.ts
+++ b/app/src/store/notificationRuleStore.ts
@@ -2,11 +2,9 @@ import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import { apiClient } from "../lib/api-client";
 import type {
-  NotificationChannelTypeApi,
   NotificationDeliveryApi,
   NotificationResourceTypeApi,
   NotificationRuleApi,
-  NotificationTriggerApi,
 } from "../lib/api-types";
 
 function resourceKey(
@@ -110,18 +108,13 @@ export const useNotificationRuleStore = create<
         success: boolean;
         rule: NotificationRuleApi;
         signingSecretOnce?: string;
-      }>(
-        `/workspaces/${workspaceId}/notification-rules/${ruleId}`,
-        body,
-      );
+      }>(`/workspaces/${workspaceId}/notification-rules/${ruleId}`, body);
       const rt = res.rule.resourceType;
       const rid = res.rule.resourceId;
       const key = resourceKey(rt, rid);
       set(s => {
         const list = s.rulesByKey[key] || [];
-        s.rulesByKey[key] = list.map(r =>
-          r.id === ruleId ? res.rule : r,
-        );
+        s.rulesByKey[key] = list.map(r => (r.id === ruleId ? res.rule : r));
       });
       return { rule: res.rule, signingSecretOnce: res.signingSecretOnce };
     },
@@ -138,7 +131,10 @@ export const useNotificationRuleStore = create<
     },
 
     testNotification: async (workspaceId, body) => {
-      await apiClient.post(`/workspaces/${workspaceId}/notification-rules/test`, body);
+      await apiClient.post(
+        `/workspaces/${workspaceId}/notification-rules/test`,
+        body,
+      );
     },
 
     clearCacheForResource: (resourceType, resourceId) => {

--- a/app/src/store/notificationRuleStore.ts
+++ b/app/src/store/notificationRuleStore.ts
@@ -73,12 +73,7 @@ export const useNotificationRuleStore = create<
       return res.rules || [];
     },
 
-    fetchDeliveries: async (
-      workspaceId,
-      resourceType,
-      resourceId,
-      options,
-    ) => {
+    fetchDeliveries: async (workspaceId, resourceType, resourceId, options) => {
       const key = resourceKey(resourceType, resourceId);
       const params: Record<string, string> = {
         resourceType,

--- a/app/src/store/notificationRuleStore.ts
+++ b/app/src/store/notificationRuleStore.ts
@@ -1,0 +1,159 @@
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+import { apiClient } from "../lib/api-client";
+import type {
+  NotificationChannelTypeApi,
+  NotificationDeliveryApi,
+  NotificationResourceTypeApi,
+  NotificationRuleApi,
+  NotificationTriggerApi,
+} from "../lib/api-types";
+
+function resourceKey(
+  resourceType: NotificationResourceTypeApi,
+  resourceId: string,
+): string {
+  return `${resourceType}:${resourceId}`;
+}
+
+interface NotificationRuleState {
+  rulesByKey: Record<string, NotificationRuleApi[]>;
+  deliveriesByKey: Record<string, NotificationDeliveryApi[]>;
+}
+
+interface NotificationRuleActions {
+  fetchRules: (
+    workspaceId: string,
+    resourceType: NotificationResourceTypeApi,
+    resourceId: string,
+  ) => Promise<NotificationRuleApi[]>;
+  fetchDeliveries: (
+    workspaceId: string,
+    resourceType: NotificationResourceTypeApi,
+    resourceId: string,
+  ) => Promise<NotificationDeliveryApi[]>;
+  createRule: (
+    workspaceId: string,
+    body: Record<string, unknown>,
+  ) => Promise<{ rule: NotificationRuleApi; signingSecretOnce?: string }>;
+  updateRule: (
+    workspaceId: string,
+    ruleId: string,
+    body: Record<string, unknown>,
+  ) => Promise<{ rule: NotificationRuleApi; signingSecretOnce?: string }>;
+  deleteRule: (workspaceId: string, ruleId: string) => Promise<void>;
+  testNotification: (
+    workspaceId: string,
+    body: Record<string, unknown>,
+  ) => Promise<void>;
+  clearCacheForResource: (
+    resourceType: NotificationResourceTypeApi,
+    resourceId: string,
+  ) => void;
+}
+
+export const useNotificationRuleStore = create<
+  NotificationRuleState & NotificationRuleActions
+>()(
+  immer((set, _get) => ({
+    rulesByKey: {},
+    deliveriesByKey: {},
+
+    fetchRules: async (workspaceId, resourceType, resourceId) => {
+      const key = resourceKey(resourceType, resourceId);
+      const res = await apiClient.get<{
+        success: boolean;
+        rules: NotificationRuleApi[];
+      }>(`/workspaces/${workspaceId}/notification-rules`, {
+        resourceType,
+        resourceId,
+      });
+      set(s => {
+        s.rulesByKey[key] = res.rules || [];
+      });
+      return res.rules || [];
+    },
+
+    fetchDeliveries: async (workspaceId, resourceType, resourceId) => {
+      const key = resourceKey(resourceType, resourceId);
+      const res = await apiClient.get<{
+        success: boolean;
+        deliveries: NotificationDeliveryApi[];
+      }>(`/workspaces/${workspaceId}/notification-rules/deliveries`, {
+        resourceType,
+        resourceId,
+      });
+      set(s => {
+        s.deliveriesByKey[key] = res.deliveries || [];
+      });
+      return res.deliveries || [];
+    },
+
+    createRule: async (workspaceId, body) => {
+      const res = await apiClient.post<{
+        success: boolean;
+        rule: NotificationRuleApi;
+        signingSecretOnce?: string;
+      }>(`/workspaces/${workspaceId}/notification-rules`, body);
+      const rt = res.rule.resourceType;
+      const rid = res.rule.resourceId;
+      const key = resourceKey(rt, rid);
+      set(s => {
+        const list = s.rulesByKey[key] || [];
+        s.rulesByKey[key] = [...list, res.rule];
+      });
+      return { rule: res.rule, signingSecretOnce: res.signingSecretOnce };
+    },
+
+    updateRule: async (workspaceId, ruleId, body) => {
+      const res = await apiClient.patch<{
+        success: boolean;
+        rule: NotificationRuleApi;
+        signingSecretOnce?: string;
+      }>(
+        `/workspaces/${workspaceId}/notification-rules/${ruleId}`,
+        body,
+      );
+      const rt = res.rule.resourceType;
+      const rid = res.rule.resourceId;
+      const key = resourceKey(rt, rid);
+      set(s => {
+        const list = s.rulesByKey[key] || [];
+        s.rulesByKey[key] = list.map(r =>
+          r.id === ruleId ? res.rule : r,
+        );
+      });
+      return { rule: res.rule, signingSecretOnce: res.signingSecretOnce };
+    },
+
+    deleteRule: async (workspaceId, ruleId) => {
+      await apiClient.delete(
+        `/workspaces/${workspaceId}/notification-rules/${ruleId}`,
+      );
+      set(s => {
+        for (const k of Object.keys(s.rulesByKey)) {
+          s.rulesByKey[k] = s.rulesByKey[k].filter(r => r.id !== ruleId);
+        }
+      });
+    },
+
+    testNotification: async (workspaceId, body) => {
+      await apiClient.post(`/workspaces/${workspaceId}/notification-rules/test`, body);
+    },
+
+    clearCacheForResource: (resourceType, resourceId) => {
+      const key = resourceKey(resourceType, resourceId);
+      set(s => {
+        delete s.rulesByKey[key];
+        delete s.deliveriesByKey[key];
+      });
+    },
+  })),
+);
+
+export function ruleSummary(rule: NotificationRuleApi): string {
+  const ch = rule.channel;
+  if (ch.type === "email") return ch.recipients.join(", ");
+  if (ch.type === "webhook") return ch.urlPreview || "Webhook";
+  return ch.displayLabel || "Slack";
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements flow-completed notifications for **scheduled console queries** and **flows** (scheduled, database, webhook): Mongo models + migration, workspace-scoped notification-rule CRUD and delivery history, Inngest fan-out/delivery, and a reusable **`FlowRunNotificationsSection`** embedded in the schedule modal and flow forms.

## Frontend

- **`FlowRunNotificationsSection`**: list rules as cards, add/edit dialog (success/failure + email/webhook/Slack), enable toggle, delete, test send, collapsible recent deliveries.
- **Scheduled query**: wired from **`Editor`** → **`ScheduleConsoleModal`** when the console is saved (`isSaved`); unsaved consoles show a short prompt to save first.
- **Flows**: section at bottom of **`ScheduledFlowForm`**, DB flow schedule step (**`DbFlowForm`**), webhook setup step (**`WebhookFlowForm`**).
- **`notificationRuleStore`**: fixed `apiClient.get` usage (params as second argument).

## Backend (included in this branch)

- `flow.run.terminal` emission from flow + scheduled-query executors; `notification/deliver` jobs; encrypted webhook/Slack URLs; SendGrid template hook for email.
- Backfill/manual `flow.execute` events now pass **`triggerType: "manual"`** for consistent notification metadata.

## Ops / testing

CI should run **`pnpm --filter api run lint`** and **`pnpm --filter app run typecheck && pnpm --filter app run lint`** (local agent environment lacked Node/pnpm).

## Env

Ensure **`SENDGRID_FLOW_RUN_NOTIFICATION_TEMPLATE_ID`** (or equivalent configured in `EmailService`) is set for email channel delivery.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b000021-b666-43bd-a787-1cfde6df5973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b000021-b666-43bd-a787-1cfde6df5973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

