### PR TITLE
fix(app): Version History snapshot drawer above backdrop

### DIFF
--- a/app/src/components/VersionHistoryPanel.tsx
+++ b/app/src/components/VersionHistoryPanel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import {
   Drawer,
+  Backdrop,
   Box,
   Typography,
   List,
@@ -108,6 +109,17 @@ export function VersionHistoryPanel({
     }
   }, [open, workspaceId, entityType, entityId, fetchHistory]);
 
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      if (restoreDialogOpen) return;
+      onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open, restoreDialogOpen, onClose]);
+
   const handleVersionClick = useCallback(
     async (item: VersionListItem) => {
       if (!workspaceId) return;
@@ -166,6 +178,12 @@ export function VersionHistoryPanel({
 
   return (
     <>
+      <Backdrop
+        open={open}
+        onClick={onClose}
+        sx={{ zIndex: theme => theme.zIndex.drawer - 2 }}
+      />
+
       <Drawer
         variant="persistent"
         anchor="right"
@@ -184,7 +202,6 @@ export function VersionHistoryPanel({
             zIndex: theme => theme.zIndex.drawer - 1,
           },
         }}
-        ModalProps={{ keepMounted: false }}
       >
         {selectedVersion && (
           <>
@@ -277,9 +294,10 @@ export function VersionHistoryPanel({
       </Drawer>
 
       <Drawer
+        variant="persistent"
         anchor="right"
         open={open}
-        onClose={onClose}
+        hideBackdrop
         PaperProps={{
           sx: {
             width: LIST_WIDTH,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Version History list used MUI's temporary `Drawer`, which mounts a modal backdrop at `zIndex.modal` above the snapshot preview pane (`zIndex.drawer - 1`). The snapshot appeared grayed out behind that backdrop.

## Changes

- Render a single shared `Backdrop` at `theme.zIndex.drawer - 2` when the panel is open.
- Make both the list and snapshot drawers `persistent` with `hideBackdrop` so both papers sit above the shared backdrop (1199 / 1200).
- Add an `Escape` key listener that calls `onClose` when the restore confirmation dialog is not open (replacing temporary-drawer Escape behavior).

## Verification

- `pnpm --filter app run typecheck && pnpm --filter app run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5c545e9-6ac3-4b19-bd2c-2ebf21b23497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5c545e9-6ac3-4b19-bd2c-2ebf21b23497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

