### PR TITLE
fix(sync-cdc): strip NUL bytes in DuckDB Parquet builder

### DIFF
--- a/api/src/utils/streaming-parquet-builder.test.ts
+++ b/api/src/utils/streaming-parquet-builder.test.ts
@@ -223,6 +223,61 @@ async function testBuildParquetPreservesNullsInTypedColumns() {
   }
 }
 
+async function testBuildParquetStripsNulBytesInVarcharColumns() {
+  console.log(
+    "  buildParquetFromBatches: NUL bytes in VARCHAR values do not break the batch",
+  );
+
+  // Connector payloads occasionally contain raw binary bytes (e.g. Close email
+  // bodies with inlined PNG attachments — magic header `\x89PNG\r\n\x1a\n`
+  // followed by `\x00 \x00 \x00 \x0d`). Without NUL stripping the embedded
+  // `\u0000` truncates the SQL at the napi/C++ boundary and DuckDB throws
+  // `Parser Error: unterminated quoted string`.
+  const png = "\u0089PNG\r\n\u001a\n\u0000\u0000\u0000\rIHDR";
+  const body = `Bonjour\nje n'ai aucun numéro\n\n${png}\nPowered by [**Intercom**](https://www.intercom.com/)`;
+
+  const rows = [
+    { id: "row-with-nul", body },
+    { id: "row-also-nul", body: `prefix\u0000suffix` },
+    { id: "row-nested-json", body: { nested: `inner\u0000value` } },
+    { id: "row-clean", body: "no nul here" },
+  ];
+
+  const result = await buildParquetFromBatches({
+    filenameBase: "test-nul-bytes",
+    streamBatches: async insertBatch => {
+      await insertBatch(rows);
+    },
+  });
+
+  assert.equal(result.rowCount, 4);
+
+  const instance = await DuckDBInstance.create(":memory:");
+  const conn = await instance.connect();
+  try {
+    await conn.run(
+      `CREATE TABLE _verify AS SELECT * FROM read_parquet('${result.filePath.replace(/'/g, "''")}')`,
+    );
+
+    const readback = await conn.run("SELECT id, body FROM _verify ORDER BY id");
+    const readbackRows = await readback.getRows();
+    assert.equal(readbackRows.length, 4);
+
+    for (const row of readbackRows) {
+      const value = String(row[1] ?? "");
+      assert.ok(
+        !value.includes("\u0000"),
+        `row ${row[0]} should have no NUL bytes after stripping`,
+      );
+    }
+  } finally {
+    conn.closeSync();
+    await fsPromises
+      .rm(result.filePath, { force: true })
+      .catch(() => undefined);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Runner
 // ---------------------------------------------------------------------------
@@ -240,6 +295,8 @@ async function main() {
   await testBuildParquetWithoutFields();
   console.log("  PASSED");
   await testBuildParquetPreservesNullsInTypedColumns();
+  console.log("  PASSED");
+  await testBuildParquetStripsNulBytesInVarcharColumns();
   console.log("  PASSED\n");
 
   console.log("All tests passed.");

--- a/api/src/utils/streaming-parquet-builder.ts
+++ b/api/src/utils/streaming-parquet-builder.ts
@@ -170,10 +170,16 @@ function escapeDuckDBValue(
       return "NULL";
     }
     default: {
-      if (typeof value === "object") {
-        return `'${JSON.stringify(value).replace(/'/g, "''")}'`;
-      }
-      return `'${String(value).replace(/'/g, "''")}'`;
+      // DuckDB VARCHAR cannot store \u0000, and an embedded NUL truncates the
+      // SQL at the napi/C++ boundary — the parser then sees an unterminated
+      // '...' literal. Strip NULs at the boundary before the single-quote
+      // escape so connector payloads with inlined binary (e.g. Close emails
+      // with embedded PNG bytes) don't kill the whole batch.
+      const raw =
+        typeof value === "object" ? JSON.stringify(value) : String(value);
+      // eslint-disable-next-line no-control-regex
+      const stripped = raw.replace(/\u0000/g, "");
+      return `'${stripped.replace(/'/g, "''")}'`;
     }
   }
 }


### PR DESCRIPTION
## Summary

The Close-CRM email backfill on flow `69cd52e7fc5195fc16b26040` (workspace `6846e6a01b05af0948070582`, scope `activities:Email`) was failing with:

```
Parser Error: unterminated quoted string at or near "'\n\nBonjour Eva..."
LINE 5940: >>>> Powered by [**Intercom**](https://www.intercom.com/intercom-
                                ^
```

Despite the destination being BigQuery, the error is from **DuckDB** — both the BigQuery and ClickHouse CDC adapters route through `buildParquetFromBatches`, which uses DuckDB to materialise rows before writing the Parquet file.

The Close email body contains an inlined PNG attachment. PNG files start with `\x89 P N G \r \n \x1a \n` followed by `\x00 \x00 \x00 \x0d` (the IHDR length field). When the row is serialised into `INSERT INTO _data VALUES ('…<email body with \u0000>…')`, the embedded NUL byte truncates the SQL at the napi/C++ boundary. DuckDB's parser then sees an unterminated `'…'` literal, walks forward looking for a closing quote, and bails 5000+ lines later — killing the entire CDC apply batch and the whole `activities:Email` backfill with it.

DuckDB VARCHAR cannot store `\u0000` regardless, so stripping NULs at the boundary is correct. One dirty row no longer poisons the batch.

## Changes

- `api/src/utils/streaming-parquet-builder.ts` — strip `\u0000` from VARCHAR/JSON values in `escapeDuckDBValue` before the single-quote escape.
- `api/src/utils/streaming-parquet-builder.test.ts` — regression test covering: NUL inside text, NUL inside JSON-stringified objects, and a body containing the actual PNG magic header.

## Test plan

- [x] `pnpm --filter api exec tsx src/utils/streaming-parquet-builder.test.ts` — all four tests green, including the new NUL-byte regression.
- [x] `pnpm --filter api run lint` — clean.
- [ ] After merge: redeploy and `POST /api/workspaces/6846e6a01b05af0948070582/flows/69cd52e7fc5195fc16b26040/sync-cdc/recover-backfill` to resume the email backfill from checkpoint.

## Follow-ups (separate PRs)

- Switch the DuckDB writer to the **Appender API** so we stop materialising multi-megabyte SQL strings in JS for every batch — same class of bug avoided structurally, plus a big throughput win.
- The PostgreSQL driver's `formatValue` has the same NUL-byte hazard (`api/src/databases/drivers/postgresql/driver.ts`) — worth the same one-line fix and, longer term, parameterized queries.
- Close connector should sanitize control characters in text fields (strip C0 except `\t \n \r`, base64 inlined attachments) so binary garbage never reaches the sync pipeline in the first place.

Made with [Cursor](https://cursor.com)