### PR TITLE
Slack OAuth for workspace notifications (bot + webhook fallback)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,10 @@ GOOGLE_CLIENT_SECRET=your-google-client-secret
 GH_CLIENT_ID=your-github-client-id
 GH_CLIENT_SECRET=your-github-client-secret
 
+# Slack (workspace notifications — OAuth v2; callback must be registered as ${PRODUCTION_URL}/api/auth/slack/callback)
+# SLACK_CLIENT_ID=
+# SLACK_CLIENT_SECRET=
+
 # Session Configuration
 SESSION_SECRET=your-session-secret
 

--- a/api/src/auth/auth.controller.ts
+++ b/api/src/auth/auth.controller.ts
@@ -17,6 +17,19 @@ import {
   verifyTransferToken,
 } from "./oauth-proxy";
 import { loggers } from "../logging";
+import { Types } from "mongoose";
+import {
+  decodeSlackOAuthState,
+  exchangeSlackOAuthCode,
+  parseSlackOAuthResponse,
+  signSlackWebhookClaim,
+  slackOAuthConfigured,
+} from "./slack";
+import {
+  SlackConnection,
+  encrypt,
+} from "../database/workspace-schema";
+import { workspaceService } from "../services/workspace.service";
 
 const logger = loggers.auth();
 
@@ -660,6 +673,119 @@ authRoutes.get("/github/callback", async c => {
   } catch (error: any) {
     logger.error("GitHub OAuth error", { error });
     return c.redirect(`${process.env.CLIENT_URL}/login?error=oauth_error`);
+  }
+});
+
+// ── Slack OAuth callback (workspace notifications; registered redirect on Slack app) ──
+
+authRoutes.get("/slack/callback", async c => {
+  try {
+    const clientUrl = process.env.CLIENT_URL?.replace(/\/$/, "") || "";
+    const redirectErr = (msg: string) =>
+      c.redirect(`${clientUrl}/?slack_error=${encodeURIComponent(msg)}`);
+
+    if (!slackOAuthConfigured()) {
+      logger.warn("Slack callback: OAuth not configured");
+      return redirectErr("slack_not_configured");
+    }
+
+    const code = c.req.query("code");
+    const stateParam = c.req.query("state");
+    const storedNonce = getCookie(c, "slack_oauth_nonce");
+
+    const slackState = stateParam ? decodeSlackOAuthState(stateParam) : null;
+    if (
+      !code ||
+      !slackState ||
+      !storedNonce ||
+      slackState.nonce !== storedNonce
+    ) {
+      logger.warn("Slack OAuth callback: invalid state or missing params");
+      return redirectErr("oauth_error");
+    }
+
+    if (!isAllowedOrigin(slackState.origin)) {
+      logger.warn("Slack OAuth callback: untrusted caller origin", {
+        origin: slackState.origin,
+      });
+      return redirectErr("oauth_error");
+    }
+
+    const isAdmin = await workspaceService.hasRole(
+      slackState.workspaceId,
+      slackState.userId,
+      ["owner", "admin"],
+    );
+    if (!isAdmin) {
+      logger.warn("Slack OAuth callback: user not workspace admin", {
+        workspaceId: slackState.workspaceId,
+      });
+      return redirectErr("forbidden");
+    }
+
+    setCookie(c, "slack_oauth_nonce", "", { maxAge: 0, path: "/" });
+
+    const rawAccess = await exchangeSlackOAuthCode(code);
+    let parsed;
+    try {
+      parsed = parseSlackOAuthResponse(rawAccess, slackState.installType);
+    } catch (e) {
+      logger.error("Slack OAuth parse failed", { error: e });
+      return redirectErr("oauth_error");
+    }
+
+    const productionApiOrigin = getProductionUrl().replace(/\/$/, "");
+    let callerOrigin = slackState.origin.replace(/\/$/, "");
+    if (callerOrigin === productionApiOrigin && clientUrl) {
+      callerOrigin = clientUrl;
+    }
+
+    if (parsed.installType === "bot") {
+      const scopes = (parsed.scope || "")
+        .split(",")
+        .map(s => s.trim())
+        .filter(Boolean);
+      await SlackConnection.findOneAndUpdate(
+        { workspaceId: new Types.ObjectId(slackState.workspaceId) },
+        {
+          $set: {
+            workspaceId: new Types.ObjectId(slackState.workspaceId),
+            teamId: parsed.teamId,
+            teamName: parsed.teamName,
+            botUserId: parsed.botUserId!,
+            botTokenEncrypted: encrypt(parsed.botAccessToken!),
+            scopes,
+            installedByUserId: slackState.userId,
+            installedAt: new Date(),
+          },
+          $unset: { revokedAt: 1 },
+        },
+        { upsert: true },
+      );
+
+      const target = new URL(
+        `${callerOrigin}${slackState.returnTo.startsWith("/") ? slackState.returnTo : `/${slackState.returnTo}`}`,
+      );
+      target.searchParams.set("slack", "connected");
+      return c.redirect(target.toString());
+    }
+
+    const wh = parsed.incomingWebhook!;
+    const claim = signSlackWebhookClaim({
+      workspaceId: slackState.workspaceId,
+      webhookUrl: wh.url,
+      channelLabel: wh.channel || wh.channelId,
+      exp: Date.now() + 120_000,
+    });
+    const receiveUrl = new URL(
+      `${callerOrigin}/api/workspaces/${slackState.workspaceId}/slack/webhook-receive`,
+    );
+    receiveUrl.searchParams.set("token", claim);
+    return c.redirect(receiveUrl.toString());
+  } catch (error: unknown) {
+    logger.error("Slack OAuth callback error", { error });
+    const clientUrl = process.env.CLIENT_URL?.replace(/\/$/, "") || "/";
+    return c.redirect(`${clientUrl}/?slack_error=oauth_error`);
   }
 });
 

--- a/api/src/auth/slack.ts
+++ b/api/src/auth/slack.ts
@@ -1,0 +1,356 @@
+import { createHmac, timingSafeEqual } from "crypto";
+import { loggers } from "../logging";
+import { getProductionUrl } from "./oauth-proxy";
+
+const logger = loggers.auth();
+
+export type SlackInstallType = "bot" | "webhook";
+
+/** Parsed oauth.v2.access response subset */
+export interface SlackOAuthAccessResult {
+  ok: boolean;
+  access_token?: string;
+  token_type?: string;
+  scope?: string;
+  bot_user_id?: string;
+  team?: { id?: string; name?: string };
+  incoming_webhook?: {
+    url?: string;
+    channel?: string;
+    channel_id?: string;
+    configuration_url?: string;
+  };
+  error?: string;
+}
+
+export interface SlackOAuthParsed {
+  installType: SlackInstallType;
+  teamId: string;
+  teamName: string;
+  botUserId?: string;
+  botAccessToken?: string;
+  scope?: string;
+  incomingWebhook?: { url: string; channel: string; channelId: string };
+}
+
+function getHmacSecret(): string {
+  const secret = process.env.SESSION_SECRET || process.env.ENCRYPTION_KEY;
+  if (!secret) {
+    throw new Error(
+      "Missing HMAC secret: set SESSION_SECRET or ENCRYPTION_KEY",
+    );
+  }
+  return secret;
+}
+
+export function getSlackCallbackRedirectUri(): string {
+  const base = getProductionUrl();
+  if (!base) {
+    throw new Error("Missing PRODUCTION_URL or BASE_URL for Slack OAuth");
+  }
+  return `${base.replace(/\/$/, "")}/api/auth/slack/callback`;
+}
+
+export function slackOAuthConfigured(): boolean {
+  return Boolean(
+    process.env.SLACK_CLIENT_ID?.trim() && process.env.SLACK_CLIENT_SECRET?.trim(),
+  );
+}
+
+export function assertSlackOAuthEnv(): void {
+  if (!process.env.SLACK_CLIENT_ID?.trim()) {
+    throw new Error("Missing SLACK_CLIENT_ID");
+  }
+  if (!process.env.SLACK_CLIENT_SECRET?.trim()) {
+    throw new Error("Missing SLACK_CLIENT_SECRET");
+  }
+}
+
+export interface SlackOAuthStatePayload {
+  nonce: string;
+  origin: string;
+  workspaceId: string;
+  installType: SlackInstallType;
+  returnTo: string;
+  userId: string;
+}
+
+/**
+ * HMAC-signed OAuth state for Slack: CSRF nonce, redirect origin, and install context.
+ */
+export function encodeSlackOAuthState(payload: SlackOAuthStatePayload): string {
+  const data = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const signature = createHmac("sha256", getHmacSecret())
+    .update(data)
+    .digest("base64url");
+  return `${data}.${signature}`;
+}
+
+export function decodeSlackOAuthState(
+  state: string,
+): SlackOAuthStatePayload | null {
+  try {
+    const dot = state.lastIndexOf(".");
+    if (dot === -1) return null;
+    const data = state.slice(0, dot);
+    const signature = state.slice(dot + 1);
+    const expected = createHmac("sha256", getHmacSecret())
+      .update(data)
+      .digest("base64url");
+    const sigBuf = Buffer.from(signature);
+    const expBuf = Buffer.from(expected);
+    if (sigBuf.length !== expBuf.length || !timingSafeEqual(sigBuf, expBuf)) {
+      logger.warn("Slack OAuth state signature mismatch");
+      return null;
+    }
+    const parsed = JSON.parse(
+      Buffer.from(data, "base64url").toString("utf8"),
+    ) as Record<string, unknown>;
+    if (
+      typeof parsed.nonce !== "string" ||
+      typeof parsed.origin !== "string" ||
+      typeof parsed.workspaceId !== "string" ||
+      (parsed.installType !== "bot" && parsed.installType !== "webhook") ||
+      typeof parsed.returnTo !== "string" ||
+      typeof parsed.userId !== "string"
+    ) {
+      return null;
+    }
+    return {
+      nonce: parsed.nonce,
+      origin: parsed.origin,
+      workspaceId: parsed.workspaceId,
+      installType: parsed.installType,
+      returnTo: parsed.returnTo,
+      userId: parsed.userId,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Bot workspace install scopes */
+export const SLACK_BOT_SCOPES = [
+  "chat:write",
+  "channels:read",
+  "groups:read",
+].join(",");
+
+/** Per-rule incoming webhook */
+export const SLACK_WEBHOOK_USER_SCOPE = "incoming-webhook";
+
+export function buildSlackAuthorizeUrl(params: {
+  state: string;
+  installType: SlackInstallType;
+}): string {
+  assertSlackOAuthEnv();
+  const redirectUri = getSlackCallbackRedirectUri();
+  const u = new URL("https://slack.com/oauth/v2/authorize");
+  u.searchParams.set("client_id", process.env.SLACK_CLIENT_ID!.trim());
+  u.searchParams.set("redirect_uri", redirectUri);
+  u.searchParams.set("state", params.state);
+  if (params.installType === "bot") {
+    u.searchParams.set("scope", SLACK_BOT_SCOPES);
+  } else {
+    u.searchParams.set("user_scope", SLACK_WEBHOOK_USER_SCOPE);
+  }
+  return u.toString();
+}
+
+export async function exchangeSlackOAuthCode(
+  code: string,
+): Promise<SlackOAuthAccessResult> {
+  assertSlackOAuthEnv();
+  const redirectUri = getSlackCallbackRedirectUri();
+  const body = new URLSearchParams({
+    client_id: process.env.SLACK_CLIENT_ID!.trim(),
+    client_secret: process.env.SLACK_CLIENT_SECRET!.trim(),
+    code,
+    redirect_uri: redirectUri,
+  });
+  const res = await fetch("https://slack.com/api/oauth.v2.access", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+  if (!res.ok) {
+    const t = await res.text().catch(() => "");
+    throw new Error(
+      `Slack oauth.v2.access HTTP ${res.status}${t ? `: ${t.slice(0, 200)}` : ""}`,
+    );
+  }
+  return (await res.json()) as SlackOAuthAccessResult;
+}
+
+export function parseSlackOAuthResponse(
+  raw: SlackOAuthAccessResult,
+  installType: SlackInstallType,
+): SlackOAuthParsed {
+  if (!raw.ok) {
+    throw new Error(raw.error || "Slack OAuth failed");
+  }
+  const teamId = raw.team?.id;
+  const teamName = raw.team?.name;
+  if (!teamId || !teamName) {
+    throw new Error("Slack OAuth response missing team");
+  }
+  if (installType === "bot") {
+    const token = raw.access_token;
+    if (!token || !token.startsWith("xoxb-")) {
+      throw new Error("Slack bot install did not return a bot token (xoxb-)");
+    }
+    if (!raw.bot_user_id) {
+      throw new Error("Slack bot install missing bot_user_id");
+    }
+    return {
+      installType: "bot",
+      teamId,
+      teamName,
+      botUserId: raw.bot_user_id,
+      botAccessToken: token,
+      scope: raw.scope,
+    };
+  }
+  const wh = raw.incoming_webhook;
+  const url = wh?.url;
+  const channelId = wh?.channel_id;
+  const channel = wh?.channel || "";
+  if (!url || !channelId) {
+    throw new Error(
+      "Slack incoming webhook install missing webhook URL or channel id",
+    );
+  }
+  return {
+    installType: "webhook",
+    teamId,
+    teamName,
+    scope: raw.scope,
+    incomingWebhook: { url, channel, channelId },
+  };
+}
+
+/** Short-lived signed payload so the app can claim the webhook URL without exposing it in long-lived URLs. */
+export interface SlackWebhookClaimPayload {
+  workspaceId: string;
+  webhookUrl: string;
+  channelLabel: string;
+  exp: number;
+}
+
+export function signSlackWebhookClaim(payload: SlackWebhookClaimPayload): string {
+  const data = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const signature = createHmac("sha256", getHmacSecret())
+    .update(data)
+    .digest("base64url");
+  return `${data}.${signature}`;
+}
+
+export function verifySlackWebhookClaim(
+  token: string,
+): SlackWebhookClaimPayload | null {
+  try {
+    const dot = token.lastIndexOf(".");
+    if (dot === -1) return null;
+    const data = token.slice(0, dot);
+    const signature = token.slice(dot + 1);
+    const expected = createHmac("sha256", getHmacSecret())
+      .update(data)
+      .digest("base64url");
+    const sigBuf = Buffer.from(signature);
+    const expBuf = Buffer.from(expected);
+    if (sigBuf.length !== expBuf.length || !timingSafeEqual(sigBuf, expBuf)) {
+      return null;
+    }
+    const parsed = JSON.parse(
+      Buffer.from(data, "base64url").toString("utf8"),
+    ) as Record<string, unknown>;
+    if (
+      typeof parsed.workspaceId !== "string" ||
+      typeof parsed.webhookUrl !== "string" ||
+      typeof parsed.channelLabel !== "string" ||
+      typeof parsed.exp !== "number"
+    ) {
+      return null;
+    }
+    if (parsed.exp < Date.now()) {
+      return null;
+    }
+    return {
+      workspaceId: parsed.workspaceId,
+      webhookUrl: parsed.webhookUrl,
+      channelLabel: parsed.channelLabel,
+      exp: parsed.exp,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Lets production start Slack OAuth when the user authenticated on preview/local API (same secret as callback state). */
+export interface SlackInstallTicketPayload {
+  workspaceId: string;
+  userId: string;
+  installType: SlackInstallType;
+  returnTo: string;
+  callerOrigin: string;
+  exp: number;
+}
+
+export function signSlackInstallTicket(
+  payload: Omit<SlackInstallTicketPayload, "exp"> & { exp?: number },
+): string {
+  const full: SlackInstallTicketPayload = {
+    ...payload,
+    exp: payload.exp ?? Date.now() + 120_000,
+  };
+  const data = Buffer.from(JSON.stringify(full)).toString("base64url");
+  const signature = createHmac("sha256", getHmacSecret())
+    .update(data)
+    .digest("base64url");
+  return `${data}.${signature}`;
+}
+
+export function verifySlackInstallTicket(
+  token: string,
+): SlackInstallTicketPayload | null {
+  try {
+    const dot = token.lastIndexOf(".");
+    if (dot === -1) return null;
+    const data = token.slice(0, dot);
+    const signature = token.slice(dot + 1);
+    const expected = createHmac("sha256", getHmacSecret())
+      .update(data)
+      .digest("base64url");
+    const sigBuf = Buffer.from(signature);
+    const expBuf = Buffer.from(expected);
+    if (sigBuf.length !== expBuf.length || !timingSafeEqual(sigBuf, expBuf)) {
+      return null;
+    }
+    const parsed = JSON.parse(
+      Buffer.from(data, "base64url").toString("utf8"),
+    ) as Record<string, unknown>;
+    if (
+      typeof parsed.workspaceId !== "string" ||
+      typeof parsed.userId !== "string" ||
+      (parsed.installType !== "bot" && parsed.installType !== "webhook") ||
+      typeof parsed.returnTo !== "string" ||
+      typeof parsed.callerOrigin !== "string" ||
+      typeof parsed.exp !== "number"
+    ) {
+      return null;
+    }
+    if (parsed.exp < Date.now()) {
+      return null;
+    }
+    return {
+      workspaceId: parsed.workspaceId,
+      userId: parsed.userId,
+      installType: parsed.installType,
+      returnTo: parsed.returnTo,
+      callerOrigin: parsed.callerOrigin,
+      exp: parsed.exp,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -454,9 +454,14 @@ export interface INotificationRuleChannelWebhook {
 
 export interface INotificationRuleChannelSlack {
   type: "slack";
-  /** Encrypted incoming webhook URL */
-  webhookUrlEncrypted: string;
-  /** UI label only, e.g. #alerts */
+  /** Workspace Slack bot connection (preferred); posts via chat.postMessage */
+  connectionId?: Types.ObjectId;
+  channelId?: string;
+  /** Cached label for UI, e.g. #alerts */
+  channelName?: string;
+  /** Encrypted incoming webhook URL (legacy / per-rule install) */
+  webhookUrlEncrypted?: string;
+  /** UI label for webhook mode */
   displayLabel?: string;
 }
 
@@ -501,6 +506,20 @@ export interface INotificationDelivery extends Document {
   sentAt?: Date;
   completedAt?: Date;
   createdAt: Date;
+}
+
+/** One Slack workspace connection per Mako workspace (bot token for notifications). */
+export interface ISlackConnection extends Document {
+  _id: Types.ObjectId;
+  workspaceId: Types.ObjectId;
+  teamId: string;
+  teamName: string;
+  botUserId: string;
+  botTokenEncrypted: string;
+  scopes: string[];
+  installedByUserId: string;
+  installedAt: Date;
+  revokedAt?: Date;
 }
 
 /**
@@ -2615,6 +2634,33 @@ NotificationDeliverySchema.index(
   { expireAfterSeconds: 7776000 },
 );
 
+const SlackConnectionSchema = new Schema<ISlackConnection>(
+  {
+    workspaceId: {
+      type: Schema.Types.ObjectId,
+      ref: "Workspace",
+      required: true,
+    },
+    teamId: { type: String, required: true },
+    teamName: { type: String, required: true },
+    botUserId: { type: String, required: true },
+    botTokenEncrypted: { type: String, required: true },
+    scopes: {
+      type: [String],
+      default: [],
+    },
+    installedByUserId: { type: String, required: true },
+    installedAt: { type: Date, required: true, default: Date.now },
+    revokedAt: { type: Date },
+  },
+  {
+    collection: "slack_connections",
+    timestamps: false,
+  },
+);
+
+SlackConnectionSchema.index({ workspaceId: 1 }, { unique: true });
+
 export interface IMaterializationRun extends Document {
   workspaceId: Types.ObjectId;
   dashboardId: Types.ObjectId;
@@ -3367,6 +3413,10 @@ export const NotificationRule = mongoose.model<INotificationRule>(
 export const NotificationDelivery = mongoose.model<INotificationDelivery>(
   "NotificationDelivery",
   NotificationDeliverySchema,
+);
+export const SlackConnection = mongoose.model<ISlackConnection>(
+  "SlackConnection",
+  SlackConnectionSchema,
 );
 export const MaterializationRun = mongoose.model<IMaterializationRun>(
   "MaterializationRun",

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -43,6 +43,7 @@ import { dashboardRoutes } from "./routes/dashboards";
 import { dashboardMaterializationRoutes } from "./routes/dashboard-materialization";
 import { scheduledQueryRoutes } from "./routes/scheduled-queries";
 import { notificationRulesRoutes } from "./routes/notification-rules";
+import { slackRoutes } from "./routes/slack";
 import { webhookRoutes } from "./routes/webhooks";
 import { getFunctions, inngest, logInngestStatus } from "./inngest";
 import mongoose from "mongoose";
@@ -129,6 +130,7 @@ app.route(
   "/api/workspaces/:workspaceId/notification-rules",
   notificationRulesRoutes,
 );
+app.route("/api/workspaces/:workspaceId/slack", slackRoutes);
 app.route("/api/workspaces/:workspaceId/usage", usageRoutes);
 app.route("/api/workspaces/:workspaceId/billing", billingRoutes);
 app.route("/api/workspaces/:workspaceId/dashboards", dashboardRoutes);

--- a/api/src/migrations/2026-05-02-090000_slack_connections_collection.ts
+++ b/api/src/migrations/2026-05-02-090000_slack_connections_collection.ts
@@ -1,0 +1,35 @@
+import { Db } from "mongodb";
+import { loggers } from "../logging";
+
+const log = loggers.migration();
+
+export const description =
+  "Create slack_connections collection with unique workspaceId index";
+
+function hasIndexOnKeys(
+  indexes: { key: Record<string, number> }[],
+  keyPattern: Record<string, number>,
+): boolean {
+  const target = JSON.stringify(keyPattern);
+  return indexes.some(idx => JSON.stringify(idx.key) === target);
+}
+
+export async function up(db: Db): Promise<void> {
+  const collections = await db.listCollections().toArray();
+  const names = collections.map(c => c.name);
+
+  if (!names.includes("slack_connections")) {
+    await db.createCollection("slack_connections");
+    log.info("Created slack_connections collection");
+  }
+
+  const coll = db.collection("slack_connections");
+  const indexes = await coll.listIndexes().toArray();
+
+  if (!hasIndexOnKeys(indexes, { workspaceId: 1 })) {
+    await coll.createIndex(
+      { workspaceId: 1 },
+      { name: "slack_connections_workspace_unique", unique: true },
+    );
+  }
+}

--- a/api/src/routes/notification-rules.ts
+++ b/api/src/routes/notification-rules.ts
@@ -10,8 +10,10 @@ import {
   NotificationDelivery,
   NotificationRule,
   SavedConsole,
+  SlackConnection,
   decrypt,
   type INotificationRuleChannel,
+  type INotificationRuleChannelSlack,
   type NotificationChannelType,
   type NotificationResourceType,
   type NotificationTrigger,
@@ -88,12 +90,15 @@ function parseTriggers(raw: unknown): NotificationTrigger[] | null {
   return out.length > 0 ? [...new Set(out)] : null;
 }
 
-function parseChannelFromBody(body: Record<string, unknown>): {
+async function parseChannelFromBody(
+  workspaceId: string,
+  body: Record<string, unknown>,
+): Promise<{
   channel: INotificationRuleChannel;
   rotateWebhookSecret?: boolean;
   /** Present only when a new signing secret was generated (plain text, return once) */
   webhookSigningSecretPlain?: string;
-} | null {
+} | null> {
   const type = body.channelType as NotificationChannelType | undefined;
   if (type === "email") {
     const recipients = body.recipients;
@@ -127,17 +132,39 @@ function parseChannelFromBody(body: Record<string, unknown>): {
     };
   }
   if (type === "slack") {
-    const webhookUrl =
+    const slackChannelId =
+      typeof body.slackChannelId === "string" ? body.slackChannelId.trim() : "";
+    const slackWebhookUrl =
       typeof body.slackWebhookUrl === "string"
         ? body.slackWebhookUrl.trim()
         : "";
-    if (!webhookUrl) return null;
+    if (slackChannelId && slackWebhookUrl) return null;
+    if (slackChannelId) {
+      const conn = await SlackConnection.findOne({
+        workspaceId: new Types.ObjectId(workspaceId),
+        revokedAt: { $exists: false },
+      }).lean();
+      if (!conn) return null;
+      const channelName =
+        typeof body.slackChannelName === "string"
+          ? body.slackChannelName.trim()
+          : "";
+      return {
+        channel: {
+          type: "slack",
+          connectionId: conn._id,
+          channelId: slackChannelId,
+          channelName: channelName || undefined,
+        },
+      };
+    }
+    if (!slackWebhookUrl) return null;
     const displayLabel =
       typeof body.displayLabel === "string" ? body.displayLabel.trim() : "";
     return {
       channel: {
         type: "slack",
-        webhookUrlEncrypted: webhookUrl,
+        webhookUrlEncrypted: slackWebhookUrl,
         displayLabel: displayLabel || undefined,
       },
     };
@@ -310,7 +337,7 @@ notificationRulesRoutes.post("/", async (c: AuthenticatedContext) => {
       return c.json({ success: false, error: "Resource not found" }, 404);
     }
 
-    const parsed = parseChannelFromBody(body);
+    const parsed = await parseChannelFromBody(workspaceId, body);
     if (!parsed) {
       return c.json({ success: false, error: "Invalid channel configuration" }, 400);
     }
@@ -384,7 +411,7 @@ notificationRulesRoutes.patch("/:ruleId", async (c: AuthenticatedContext) => {
       let channel: INotificationRuleChannel;
 
       if (channelType === "email") {
-        const parsed = parseChannelFromBody(body);
+        const parsed = await parseChannelFromBody(workspaceId, body);
         if (!parsed || parsed.channel.type !== "email") {
           return c.json(
             { success: false, error: "Invalid email recipients" },
@@ -394,7 +421,7 @@ notificationRulesRoutes.patch("/:ruleId", async (c: AuthenticatedContext) => {
         channel = encryptNotificationChannel(parsed.channel);
       } else if (channelType === "webhook") {
         if (existing.channel.type !== "webhook") {
-          const parsed = parseChannelFromBody(body);
+          const parsed = await parseChannelFromBody(workspaceId, body);
           if (!parsed || parsed.channel.type !== "webhook") {
             return c.json(
               { success: false, error: "Webhook URL required" },
@@ -435,33 +462,94 @@ notificationRulesRoutes.patch("/:ruleId", async (c: AuthenticatedContext) => {
         }
       } else if (channelType === "slack") {
         if (existing.channel.type !== "slack") {
-          const parsed = parseChannelFromBody(body);
+          const parsed = await parseChannelFromBody(workspaceId, body);
           if (!parsed || parsed.channel.type !== "slack") {
             return c.json(
-              { success: false, error: "Slack webhook URL required" },
+              {
+                success: false,
+                error:
+                  "Slack: provide slackChannelId (workspace bot) or slackWebhookUrl",
+              },
               400,
             );
           }
           channel = encryptNotificationChannel(parsed.channel);
         } else {
-          const prev = existing.channel as {
-            webhookUrlEncrypted: string;
-            displayLabel?: string;
-          };
-          const urlRaw =
+          const prev = existing.channel as INotificationRuleChannelSlack;
+          const urlFromBody =
             typeof body.slackWebhookUrl === "string" &&
             body.slackWebhookUrl.trim()
               ? body.slackWebhookUrl.trim()
-              : decrypt(prev.webhookUrlEncrypted);
-          const displayLabel =
-            typeof body.displayLabel === "string"
-              ? body.displayLabel.trim()
-              : prev.displayLabel;
-          channel = encryptNotificationChannel({
-            type: "slack",
-            webhookUrlEncrypted: urlRaw,
-            displayLabel: displayLabel || undefined,
-          });
+              : undefined;
+          const slackChannelId =
+            typeof body.slackChannelId === "string"
+              ? body.slackChannelId.trim()
+              : "";
+
+          if (urlFromBody) {
+            const displayLabel =
+              typeof body.displayLabel === "string"
+                ? body.displayLabel.trim()
+                : prev.displayLabel;
+            channel = encryptNotificationChannel({
+              type: "slack",
+              webhookUrlEncrypted: urlFromBody,
+              displayLabel: displayLabel || undefined,
+            });
+          } else if (slackChannelId || (prev.connectionId && prev.channelId)) {
+            const conn = await SlackConnection.findOne({
+              workspaceId: new Types.ObjectId(workspaceId),
+              revokedAt: { $exists: false },
+            }).lean();
+            if (!conn) {
+              return c.json(
+                { success: false, error: "Connect Slack workspace first" },
+                400,
+              );
+            }
+            if (
+              prev.connectionId &&
+              conn._id.toString() !== prev.connectionId.toString()
+            ) {
+              return c.json(
+                { success: false, error: "Slack workspace connection mismatch" },
+                400,
+              );
+            }
+            const channelId = slackChannelId || prev.channelId;
+            if (!channelId) {
+              return c.json(
+                { success: false, error: "slackChannelId required" },
+                400,
+              );
+            }
+            const channelName =
+              typeof body.slackChannelName === "string"
+                ? body.slackChannelName.trim()
+                : prev.channelName;
+            channel = encryptNotificationChannel({
+              type: "slack",
+              connectionId: conn._id,
+              channelId,
+              channelName: channelName || undefined,
+            });
+          } else if (prev.webhookUrlEncrypted) {
+            const urlRaw = decrypt(prev.webhookUrlEncrypted);
+            const displayLabel =
+              typeof body.displayLabel === "string"
+                ? body.displayLabel.trim()
+                : prev.displayLabel;
+            channel = encryptNotificationChannel({
+              type: "slack",
+              webhookUrlEncrypted: urlRaw,
+              displayLabel: displayLabel || undefined,
+            });
+          } else {
+            return c.json(
+              { success: false, error: "Invalid existing Slack channel" },
+              400,
+            );
+          }
         }
       } else {
         return c.json({ success: false, error: "Invalid channel type" }, 400);
@@ -573,7 +661,7 @@ notificationRulesRoutes.post("/test", async (c: AuthenticatedContext) => {
       }
       channel = rule.channel as INotificationRuleChannel;
     } else {
-      const parsed = parseChannelFromBody(body);
+      const parsed = await parseChannelFromBody(workspaceId, body);
       if (!parsed) {
         return c.json(
           { success: false, error: "Invalid channel configuration" },

--- a/api/src/routes/slack.ts
+++ b/api/src/routes/slack.ts
@@ -1,0 +1,452 @@
+/**
+ * Slack OAuth for workspace notifications (bot + optional incoming-webhook install).
+ * Authenticated + workspace-scoped; admin for install / disconnect / channels / token exchange.
+ */
+import { Hono } from "hono";
+import { getCookie, setCookie } from "hono/cookie";
+import { Types } from "mongoose";
+import { generateState } from "arctic";
+import { unifiedAuthMiddleware } from "../auth/unified-auth.middleware";
+import { SlackConnection, decrypt, type ISlackConnection } from "../database/workspace-schema";
+import { enrichContextWithWorkspace, loggers } from "../logging";
+import { requireWorkspaceAdmin } from "../middleware/workspace-admin.middleware";
+import { AuthenticatedContext } from "../middleware/workspace.middleware";
+import { workspaceService } from "../services/workspace.service";
+import {
+  buildSlackAuthorizeUrl,
+  encodeSlackOAuthState,
+  signSlackInstallTicket,
+  slackOAuthConfigured,
+  verifySlackInstallTicket,
+  verifySlackWebhookClaim,
+  type SlackInstallType,
+} from "../auth/slack";
+import {
+  getProductionUrl,
+  getRequestOrigin,
+  isAllowedOrigin,
+  isProduction,
+} from "../auth/oauth-proxy";
+
+const logger = loggers.api("slack");
+
+export const slackRoutes = new Hono();
+
+slackRoutes.get("/webhook-receive", async c => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    if (!workspaceId || !Types.ObjectId.isValid(workspaceId)) {
+      return c.json({ success: false, error: "Invalid workspace" }, 400);
+    }
+    const token = c.req.query("token");
+    if (!token) {
+      return c.json({ success: false, error: "Missing token" }, 400);
+    }
+    const claim = verifySlackWebhookClaim(token);
+    if (!claim || claim.workspaceId !== workspaceId) {
+      return c.json({ success: false, error: "Invalid or expired token" }, 400);
+    }
+    const clientUrl = process.env.CLIENT_URL?.replace(/\/$/, "") || "";
+    if (!clientUrl) {
+      return c.json({ success: false, error: "CLIENT_URL not configured" }, 500);
+    }
+    const redirect = new URL(`${clientUrl}/workspace/${workspaceId}/slack-webhook-complete`);
+    redirect.searchParams.set("token", token);
+    return c.redirect(redirect.toString());
+  } catch (error) {
+    logger.error("Slack webhook-receive failed", { error });
+    return c.json({ success: false, error: "Webhook receive failed" }, 500);
+  }
+});
+
+slackRoutes.use("*", unifiedAuthMiddleware);
+
+slackRoutes.use("*", async (c: AuthenticatedContext, next) => {
+  const workspaceId = c.req.param("workspaceId");
+  const user = c.get("user");
+  const workspace = c.get("workspace");
+
+  if (!workspaceId || !Types.ObjectId.isValid(workspaceId)) {
+    return c.json({ success: false, error: "Invalid workspace ID format" }, 400);
+  }
+
+  if (!user && !workspace) {
+    return c.json({ success: false, error: "Unauthorized" }, 401);
+  }
+
+  if (workspace) {
+    if (workspace._id.toString() !== workspaceId) {
+      return c.json(
+        { success: false, error: "API key not authorized for this workspace" },
+        403,
+      );
+    }
+  } else if (user) {
+    if (!(await workspaceService.hasAccess(workspaceId, user.id))) {
+      return c.json({ success: false, error: "Access denied to workspace" }, 403);
+    }
+  } else {
+    return c.json({ success: false, error: "Unauthorized" }, 401);
+  }
+
+  enrichContextWithWorkspace(workspaceId);
+  await next();
+});
+
+function normalizeReturnTo(raw: string | undefined): string {
+  if (!raw || typeof raw !== "string") return "/";
+  if (!raw.startsWith("/") || raw.startsWith("//")) return "/";
+  return raw.slice(0, 2048);
+}
+
+slackRoutes.get("/install", requireWorkspaceAdmin, async (c: AuthenticatedContext) => {
+  try {
+    if (!slackOAuthConfigured()) {
+      return c.json(
+        { success: false, error: "Slack integration is not configured" },
+        503,
+      );
+    }
+
+    const workspaceId = c.req.param("workspaceId");
+    const sessionUser = c.get("user");
+
+    const installRaw = c.req.query("installType");
+    let installType: SlackInstallType =
+      installRaw === "webhook" ? "webhook" : "bot";
+    let returnTo = normalizeReturnTo(c.req.query("returnTo"));
+
+    const productionUrl = getProductionUrl();
+    if (!productionUrl) {
+      return c.json(
+        { success: false, error: "PRODUCTION_URL or BASE_URL must be set" },
+        500,
+      );
+    }
+
+    if (!isProduction(c)) {
+      if (!sessionUser?.id) {
+        return c.json({ success: false, error: "Unauthorized" }, 401);
+      }
+      const callerOrigin = getRequestOrigin(c);
+      if (!isAllowedOrigin(callerOrigin)) {
+        return c.json({ success: false, error: "Invalid request origin" }, 400);
+      }
+      const ticket = signSlackInstallTicket({
+        workspaceId,
+        userId: sessionUser.id,
+        installType,
+        returnTo,
+        callerOrigin,
+      });
+      const target = new URL(
+        `${productionUrl}/api/workspaces/${workspaceId}/slack/install`,
+      );
+      target.searchParams.set("ticket", ticket);
+      logger.info("Slack OAuth proxy: redirecting to production with ticket", {
+        workspaceId,
+        installType,
+      });
+      return c.redirect(target.toString());
+    }
+
+    const ticketParam = c.req.query("ticket");
+    let actingUserId: string;
+    let callerOrigin: string;
+
+    if (ticketParam) {
+      const ticket = verifySlackInstallTicket(ticketParam);
+      if (!ticket || ticket.workspaceId !== workspaceId) {
+        return c.json({ success: false, error: "Invalid or expired ticket" }, 400);
+      }
+      if (!isAllowedOrigin(ticket.callerOrigin)) {
+        return c.json({ success: false, error: "Invalid ticket origin" }, 400);
+      }
+      actingUserId = ticket.userId;
+      callerOrigin = ticket.callerOrigin;
+      installType = ticket.installType;
+      returnTo = normalizeReturnTo(ticket.returnTo);
+    } else {
+      if (!sessionUser?.id) {
+        return c.json({ success: false, error: "Unauthorized" }, 401);
+      }
+      actingUserId = sessionUser.id;
+      const rawOrigin = c.req.query("origin");
+      if (rawOrigin && !isAllowedOrigin(rawOrigin)) {
+        logger.warn("Slack install: rejected untrusted origin", {
+          origin: rawOrigin,
+        });
+        return c.json({ success: false, error: "Invalid redirect origin" }, 400);
+      }
+      callerOrigin =
+        rawOrigin || productionUrl || getRequestOrigin(c);
+      if (!isAllowedOrigin(callerOrigin)) {
+        return c.json({ success: false, error: "Invalid redirect origin" }, 400);
+      }
+    }
+
+    const isAdmin = await workspaceService.hasRole(workspaceId, actingUserId, [
+      "owner",
+      "admin",
+    ]);
+    if (!isAdmin) {
+      return c.json({ success: false, error: "Admin access required" }, 403);
+    }
+
+    const nonce = generateState();
+    const state = encodeSlackOAuthState({
+      nonce,
+      origin: callerOrigin,
+      workspaceId,
+      installType,
+      returnTo,
+      userId: actingUserId,
+    });
+
+    setCookie(c, "slack_oauth_nonce", nonce, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      maxAge: 60 * 10,
+      sameSite: "Lax",
+      path: "/",
+    });
+
+    const url = buildSlackAuthorizeUrl({ state, installType });
+    return c.redirect(url);
+  } catch (error) {
+    logger.error("Slack install failed", { error });
+    return c.json(
+      {
+        success: false,
+        error:
+          error instanceof Error ? error.message : "Failed to start Slack OAuth",
+      },
+      500,
+    );
+  }
+});
+
+slackRoutes.get("/connection", async (c: AuthenticatedContext) => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const doc = await SlackConnection.findOne({
+      workspaceId: new Types.ObjectId(workspaceId),
+      revokedAt: { $exists: false },
+    }).lean();
+
+    if (!doc) {
+      return c.json({ success: false, error: "No Slack connection" }, 404);
+    }
+
+    return c.json({
+      success: true,
+      connection: slackConnectionPublic(doc),
+    });
+  } catch (error) {
+    logger.error("Slack connection GET failed", { error });
+    return c.json(
+      {
+        success: false,
+        error:
+          error instanceof Error ? error.message : "Failed to load connection",
+      },
+      500,
+    );
+  }
+});
+
+const channelsCache = new Map<
+  string,
+  { expiresAt: number; channels: SlackChannelRow[] }
+>();
+const CHANNELS_TTL_MS = 60_000;
+
+export interface SlackChannelRow {
+  id: string;
+  name: string;
+  isPrivate: boolean;
+}
+
+slackRoutes.get("/channels", requireWorkspaceAdmin, async (c: AuthenticatedContext) => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const cursor = c.req.query("cursor") || undefined;
+
+    const cached = channelsCache.get(workspaceId);
+    if (cached && Date.now() < cached.expiresAt && !cursor) {
+      return c.json({
+        success: true,
+        channels: cached.channels,
+        nextCursor: null as string | null,
+      });
+    }
+
+    const conn = await SlackConnection.findOne({
+      workspaceId: new Types.ObjectId(workspaceId),
+      revokedAt: { $exists: false },
+    }).lean();
+    if (!conn) {
+      return c.json(
+        { success: false, error: "Connect Slack workspace first" },
+        400,
+      );
+    }
+
+    const token = decrypt(conn.botTokenEncrypted);
+
+    const params = new URLSearchParams({
+      types: "public_channel,private_channel",
+      exclude_archived: "true",
+      limit: "200",
+    });
+    if (cursor) params.set("cursor", cursor);
+
+    const res = await fetch(
+      `https://slack.com/api/conversations.list?${params.toString()}`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+    const body = (await res.json()) as {
+      ok: boolean;
+      channels?: Array<{
+        id: string;
+        name?: string;
+        is_private?: boolean;
+      }>;
+      response_metadata?: { next_cursor?: string };
+      error?: string;
+    };
+
+    if (!body.ok) {
+      throw new Error(body.error || "conversations.list failed");
+    }
+
+    const rows: SlackChannelRow[] = (body.channels || [])
+      .filter(ch => ch.id && ch.name)
+      .map(ch => ({
+        id: ch.id,
+        name: ch.name as string,
+        isPrivate: Boolean(ch.is_private),
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    if (!cursor) {
+      channelsCache.set(workspaceId, {
+        expiresAt: Date.now() + CHANNELS_TTL_MS,
+        channels: rows,
+      });
+    }
+
+    return c.json({
+      success: true,
+      channels: rows,
+      nextCursor: body.response_metadata?.next_cursor || null,
+    });
+  } catch (error) {
+    logger.error("Slack channels list failed", { error });
+    return c.json(
+      {
+        success: false,
+        error:
+          error instanceof Error ? error.message : "Failed to list channels",
+      },
+      500,
+    );
+  }
+});
+
+slackRoutes.delete("/connection", requireWorkspaceAdmin, async (c: AuthenticatedContext) => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const doc = await SlackConnection.findOne({
+      workspaceId: new Types.ObjectId(workspaceId),
+      revokedAt: { $exists: false },
+    });
+
+    if (!doc) {
+      return c.json({ success: false, error: "No Slack connection" }, 404);
+    }
+
+    const token = decrypt(doc.botTokenEncrypted);
+
+    const revokeRes = await fetch("https://slack.com/api/auth.revoke", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Authorization: `Bearer ${token}`,
+      },
+      body: new URLSearchParams({ token }).toString(),
+    });
+    const revokeJson = (await revokeRes.json()) as { ok?: boolean };
+    if (!revokeJson.ok) {
+      logger.warn("Slack auth.revoke returned not ok", { workspaceId });
+    }
+
+    await SlackConnection.deleteOne({ _id: doc._id });
+    channelsCache.delete(workspaceId);
+
+    return c.json({ success: true });
+  } catch (error) {
+    logger.error("Slack disconnect failed", { error });
+    return c.json(
+      {
+        success: false,
+        error:
+          error instanceof Error ? error.message : "Failed to disconnect Slack",
+      },
+      500,
+    );
+  }
+});
+
+slackRoutes.post(
+  "/exchange-webhook-token",
+  requireWorkspaceAdmin,
+  async (c: AuthenticatedContext) => {
+    try {
+      const workspaceId = c.req.param("workspaceId");
+      const body = (await c.req.json()) as { token?: string };
+      const token = typeof body.token === "string" ? body.token.trim() : "";
+      if (!token) {
+        return c.json({ success: false, error: "token required" }, 400);
+      }
+
+      const claim = verifySlackWebhookClaim(token);
+      if (!claim || claim.workspaceId !== workspaceId) {
+        return c.json({ success: false, error: "Invalid or expired token" }, 400);
+      }
+
+      return c.json({
+        success: true,
+        slackWebhookUrl: claim.webhookUrl,
+        displayLabel: claim.channelLabel,
+      });
+    } catch (error) {
+      logger.error("Slack webhook token exchange failed", { error });
+      return c.json(
+        {
+          success: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Failed to exchange webhook token",
+        },
+        500,
+      );
+    }
+  },
+);
+
+function slackConnectionPublic(doc: ISlackConnection & { _id: Types.ObjectId }) {
+  return {
+    id: doc._id.toString(),
+    workspaceId: doc.workspaceId.toString(),
+    teamId: doc.teamId,
+    teamName: doc.teamName,
+    botUserId: doc.botUserId,
+    scopes: doc.scopes,
+    installedByUserId: doc.installedByUserId,
+    installedAt: doc.installedAt,
+  };
+}

--- a/api/src/services/flow-run-notification.service.ts
+++ b/api/src/services/flow-run-notification.service.ts
@@ -6,11 +6,13 @@ import {
   SavedConsole,
   NotificationRule,
   NotificationDelivery,
+  SlackConnection,
   decrypt,
   encrypt,
   type IFlow,
   type INotificationRule,
   type INotificationRuleChannel,
+  type INotificationRuleChannelSlack,
   type NotificationChannelType,
   type NotificationResourceType,
   type NotificationTrigger,
@@ -214,7 +216,7 @@ async function deliverToChannel(
       );
       return;
     case "slack":
-      await deliverSlack(decrypt(channel.webhookUrlEncrypted), payload);
+      await deliverSlack(channel, payload);
       return;
     default:
       throw new Error("Unknown channel type");
@@ -343,11 +345,8 @@ async function deliverWebhook(
   }
 }
 
-async function deliverSlack(
-  webhookUrl: string,
-  payload: NotificationOutboundPayload,
-): Promise<void> {
-  const text =
+function buildSlackMrkdwn(payload: NotificationOutboundPayload): string {
+  return (
     `*Mako run ${payload.trigger}*\n` +
     `*${payload.resourceType}*: ${payload.resourceName}\n` +
     `Run: \`${payload.runId}\`\n` +
@@ -355,30 +354,74 @@ async function deliverSlack(
     (payload.durationMs != null ? `\nDuration: ${payload.durationMs}ms` : "") +
     (payload.rowCount != null ? `\nRows: ${payload.rowCount}` : "") +
     (payload.errorMessage ? `\nError: ${payload.errorMessage}` : "") +
-    (payload.deepLink ? `\n<${payload.deepLink}|Open in Mako>` : "");
+    (payload.deepLink ? `\n<${payload.deepLink}|Open in Mako>` : "")
+  );
+}
 
-  const slackBody = JSON.stringify({
-    text,
-    blocks: [
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text,
-        },
+function buildSlackBlocks(text: string): Array<Record<string, unknown>> {
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text,
       },
-    ],
-  });
+    },
+  ];
+}
 
-  const response = await fetch(webhookUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: slackBody,
-  });
-  if (!response.ok) {
-    const t = await response.text().catch(() => "");
-    throw new Error(`Slack webhook HTTP ${response.status}${t ? `: ${t.slice(0, 200)}` : ""}`);
+async function deliverSlack(
+  channel: INotificationRuleChannelSlack,
+  payload: NotificationOutboundPayload,
+): Promise<void> {
+  const text = buildSlackMrkdwn(payload);
+  const blocks = buildSlackBlocks(text);
+
+  if (channel.connectionId && channel.channelId) {
+    const conn = await SlackConnection.findById(channel.connectionId).lean();
+    if (!conn || conn.revokedAt) {
+      throw new Error("Slack connection missing or revoked");
+    }
+    const token = decrypt(conn.botTokenEncrypted);
+    const res = await fetch("https://slack.com/api/chat.postMessage", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        channel: channel.channelId,
+        text,
+        blocks,
+      }),
+    });
+    const json = (await res.json()) as { ok: boolean; error?: string };
+    if (!json.ok) {
+      throw new Error(
+        `Slack chat.postMessage failed: ${json.error || "unknown"}`,
+      );
+    }
+    return;
   }
+
+  if (channel.webhookUrlEncrypted) {
+    const webhookUrl = decrypt(channel.webhookUrlEncrypted);
+    const slackBody = JSON.stringify({ text, blocks });
+    const response = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: slackBody,
+    });
+    if (!response.ok) {
+      const t = await response.text().catch(() => "");
+      throw new Error(
+        `Slack webhook HTTP ${response.status}${t ? `: ${t.slice(0, 200)}` : ""}`,
+      );
+    }
+    return;
+  }
+
+  throw new Error("Slack channel has no connection or webhook configured");
 }
 
 /** Encrypt channel secrets for persistence */
@@ -395,10 +438,26 @@ export function encryptNotificationChannel(
       signingSecretEncrypted: encrypt(channel.signingSecretEncrypted),
     };
   }
+  const slack = channel as INotificationRuleChannelSlack;
+  if (slack.connectionId && slack.channelId) {
+    return {
+      type: "slack",
+      connectionId: slack.connectionId,
+      channelId: slack.channelId,
+      channelName: slack.channelName,
+      ...(slack.webhookUrlEncrypted
+        ? { webhookUrlEncrypted: encrypt(slack.webhookUrlEncrypted) }
+        : {}),
+      displayLabel: slack.displayLabel,
+    };
+  }
+  if (!slack.webhookUrlEncrypted) {
+    throw new Error("Slack channel requires webhook URL or connection + channel");
+  }
   return {
     type: "slack",
-    webhookUrlEncrypted: encrypt(channel.webhookUrlEncrypted),
-    displayLabel: channel.displayLabel,
+    webhookUrlEncrypted: encrypt(slack.webhookUrlEncrypted),
+    displayLabel: slack.displayLabel,
   };
 }
 
@@ -429,12 +488,17 @@ export function sanitizeRuleForClient(rule: INotificationRule): Record<string, u
       },
     };
   }
+  const slackCh = ch as INotificationRuleChannelSlack;
   return {
     ...base,
     channel: {
       type: "slack",
-      displayLabel: ch.displayLabel || "",
-      webhookConfigured: Boolean(ch.webhookUrlEncrypted),
+      displayLabel: slackCh.displayLabel || slackCh.channelName || "",
+      webhookConfigured: Boolean(slackCh.webhookUrlEncrypted),
+      slackConnectionId: slackCh.connectionId?.toString(),
+      slackChannelId: slackCh.channelId,
+      slackChannelName: slackCh.channelName,
+      slackBotMode: Boolean(slackCh.connectionId && slackCh.channelId),
     },
   };
 }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -57,6 +57,7 @@ import { ForgotPasswordPage } from "./components/ForgotPasswordPage";
 import { ResetPasswordPage } from "./components/ResetPasswordPage";
 import { useAuth } from "./contexts/auth-context";
 import { OnboardingFlow } from "./components/OnboardingFlow";
+import SlackWebhookCompletePage from "./pages/SlackWebhookCompletePage";
 
 // Styled PanelResizeHandle components (moved from Databases.tsx/Consoles.tsx)
 const StyledHorizontalResizeHandle = styled(PanelResizeHandle)(({ theme }) => ({
@@ -778,6 +779,15 @@ function App() {
 
         {/* Onboarding test route - for manual testing */}
         <Route path="/onboarding" element={<OnboardingTestRoute />} />
+
+        <Route
+          path="/workspace/:workspaceId/slack-webhook-complete"
+          element={
+            <AuthWrapper>
+              <SlackWebhookCompletePage />
+            </AuthWrapper>
+          }
+        />
 
         {/* Main app route - authentication required */}
         <Route path="/*" element={<MainApp />} />

--- a/app/src/components/FlowRunNotificationsSection.tsx
+++ b/app/src/components/FlowRunNotificationsSection.tsx
@@ -45,6 +45,10 @@ import {
   ruleSummary,
   useNotificationRuleStore,
 } from "../store/notificationRuleStore";
+import { useSlackIntegrationStore } from "../store/slackIntegrationStore";
+import { getApiBasePath } from "../lib/api-base-path";
+
+const SLACK_WEBHOOK_PENDING_KEY = "slack_webhook_oauth_pending";
 
 export interface FlowRunNotificationsSectionProps {
   workspaceId: string;
@@ -118,6 +122,14 @@ export function FlowRunNotificationsSection({
   const updateRule = useNotificationRuleStore(s => s.updateRule);
   const deleteRule = useNotificationRuleStore(s => s.deleteRule);
   const testNotification = useNotificationRuleStore(s => s.testNotification);
+  const fetchSlackConnection = useSlackIntegrationStore(s => s.fetchConnection);
+  const fetchSlackChannels = useSlackIntegrationStore(s => s.fetchChannels);
+  const slackConn = useSlackIntegrationStore(s =>
+    s.connectionByWorkspace[workspaceId],
+  );
+  const slackChannelOptions = useSlackIntegrationStore(s =>
+    s.channelsByWorkspace[workspaceId],
+  );
 
   const [loadError, setLoadError] = useState<string | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -136,6 +148,9 @@ export function FlowRunNotificationsSection({
   const [rotateWebhookSecret, setRotateWebhookSecret] = useState(false);
   const [slackWebhookUrl, setSlackWebhookUrl] = useState("");
   const [slackLabel, setSlackLabel] = useState("");
+  const [slackChannelSelectId, setSlackChannelSelectId] = useState("");
+  const [slackUseWebhookManual, setSlackUseWebhookManual] = useState(false);
+  const [slackChannelsLoading, setSlackChannelsLoading] = useState(false);
 
   const [deliveryLogOpen, setDeliveryLogOpen] = useState(false);
   const [deliveryLogItems, setDeliveryLogItems] = useState<
@@ -158,6 +173,8 @@ export function FlowRunNotificationsSection({
     setRotateWebhookSecret(false);
     setSlackWebhookUrl("");
     setSlackLabel("");
+    setSlackChannelSelectId("");
+    setSlackUseWebhookManual(false);
     setSecretBanner(null);
   }, []);
 
@@ -183,7 +200,21 @@ export function FlowRunNotificationsSection({
     setWebhookSigningSecret("");
     setRotateWebhookSecret(false);
     setSlackWebhookUrl("");
-    setSlackLabel(ch.type === "slack" ? ch.displayLabel || "" : "");
+    if (ch.type === "slack") {
+      if (ch.slackBotMode && ch.slackChannelId) {
+        setSlackChannelSelectId(ch.slackChannelId);
+        setSlackUseWebhookManual(false);
+        setSlackLabel(ch.slackChannelName || "");
+      } else {
+        setSlackChannelSelectId("");
+        setSlackUseWebhookManual(true);
+        setSlackLabel(ch.displayLabel || "");
+      }
+    } else {
+      setSlackLabel("");
+      setSlackChannelSelectId("");
+      setSlackUseWebhookManual(false);
+    }
     setDialogOpen(true);
   };
 
@@ -206,6 +237,72 @@ export function FlowRunNotificationsSection({
       cancelled = true;
     };
   }, [workspaceId, resourceId, resourceType, fetchRules]);
+
+  useEffect(() => {
+    if (!dialogOpen || channelType !== "slack" || !workspaceId || !canManage) {
+      return;
+    }
+    void (async () => {
+      await fetchSlackConnection(workspaceId);
+    })();
+  }, [
+    dialogOpen,
+    channelType,
+    workspaceId,
+    canManage,
+    fetchSlackConnection,
+  ]);
+
+  useEffect(() => {
+    if (
+      !dialogOpen ||
+      channelType !== "slack" ||
+      !workspaceId ||
+      slackUseWebhookManual ||
+      slackConn === undefined ||
+      slackConn === null
+    ) {
+      return;
+    }
+    setSlackChannelsLoading(true);
+    void (async () => {
+      try {
+        await fetchSlackChannels(workspaceId);
+      } catch {
+        // channels optional; user can still paste webhook
+      } finally {
+        setSlackChannelsLoading(false);
+      }
+    })();
+  }, [
+    dialogOpen,
+    channelType,
+    workspaceId,
+    slackConn,
+    slackUseWebhookManual,
+    fetchSlackChannels,
+  ]);
+
+  useEffect(() => {
+    if (!workspaceId) return;
+    try {
+      const raw = sessionStorage.getItem(SLACK_WEBHOOK_PENDING_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw) as {
+        workspaceId?: string;
+        slackWebhookUrl?: string;
+        displayLabel?: string;
+      };
+      if (parsed.workspaceId !== workspaceId || !parsed.slackWebhookUrl) return;
+      sessionStorage.removeItem(SLACK_WEBHOOK_PENDING_KEY);
+      setChannelType("slack");
+      setSlackUseWebhookManual(true);
+      setSlackWebhookUrl(parsed.slackWebhookUrl);
+      if (parsed.displayLabel) setSlackLabel(parsed.displayLabel);
+    } catch {
+      sessionStorage.removeItem(SLACK_WEBHOOK_PENDING_KEY);
+    }
+  }, [workspaceId]);
 
   const loadDeliveryLog = useCallback(async () => {
     if (!workspaceId || !resourceId) return;
@@ -268,14 +365,28 @@ export function FlowRunNotificationsSection({
         base.rotateWebhookSecret = true;
       }
     } else if (channelType === "slack") {
-      if (editingRule && slackWebhookUrl.trim() === "") {
-        // keep URL server-side
-      } else if (!slackWebhookUrl.trim()) {
-        return null;
+      const wsConnected = slackConn !== undefined && slackConn !== null;
+      if (wsConnected && !slackUseWebhookManual) {
+        if (!slackChannelSelectId.trim()) return null;
+        base.slackChannelId = slackChannelSelectId.trim();
+        const opt = slackChannelOptions?.find(
+          c => c.id === slackChannelSelectId.trim(),
+        );
+        const label =
+          opt?.name?.startsWith("#") || opt?.isPrivate
+            ? opt?.name || slackLabel.trim()
+            : slackLabel.trim() || (opt ? `#${opt.name}` : "");
+        if (label) base.slackChannelName = label;
       } else {
-        base.slackWebhookUrl = slackWebhookUrl.trim();
+        if (editingRule && slackWebhookUrl.trim() === "") {
+          // keep URL server-side (webhook mode)
+        } else if (!slackWebhookUrl.trim()) {
+          return null;
+        } else {
+          base.slackWebhookUrl = slackWebhookUrl.trim();
+        }
+        if (slackLabel.trim()) base.displayLabel = slackLabel.trim();
       }
-      if (slackLabel.trim()) base.displayLabel = slackLabel.trim();
     }
 
     return base;
@@ -701,24 +812,126 @@ export function FlowRunNotificationsSection({
 
             {channelType === "slack" && (
               <>
-                <TextField
-                  label="Slack incoming webhook URL"
-                  fullWidth
-                  required={!editingRule}
-                  placeholder={
-                    editingRule?.channel.type === "slack"
-                      ? "Leave blank to keep current webhook"
-                      : undefined
-                  }
-                  value={slackWebhookUrl}
-                  onChange={e => setSlackWebhookUrl(e.target.value)}
-                />
-                <TextField
-                  label="Label (optional)"
-                  fullWidth
-                  value={slackLabel}
-                  onChange={e => setSlackLabel(e.target.value)}
-                />
+                {canManage && slackConn === undefined && (
+                  <Typography variant="caption" color="text.secondary">
+                    Checking Slack workspace connection…
+                  </Typography>
+                )}
+                {canManage &&
+                  slackConn === null &&
+                  !slackUseWebhookManual && (
+                    <Stack spacing={1}>
+                      <Typography variant="body2" color="text.secondary">
+                        Connect Slack once to pick channels from a list, or add a
+                        channel-only webhook (legacy).
+                      </Typography>
+                      <Stack direction="row" spacing={1} flexWrap="wrap">
+                        <Button
+                          size="small"
+                          variant="contained"
+                          onClick={() => {
+                            if (!workspaceId) return;
+                            const base = getApiBasePath(
+                              import.meta.env.VITE_API_URL,
+                            );
+                            const returnTo = encodeURIComponent("/");
+                            window.location.href = `${base}/workspaces/${workspaceId}/slack/install?installType=bot&returnTo=${returnTo}`;
+                          }}
+                        >
+                          Connect Slack workspace
+                        </Button>
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          onClick={() => {
+                            if (!workspaceId) return;
+                            const base = getApiBasePath(
+                              import.meta.env.VITE_API_URL,
+                            );
+                            const returnTo = encodeURIComponent("/");
+                            window.location.href = `${base}/workspaces/${workspaceId}/slack/install?installType=webhook&returnTo=${returnTo}`;
+                          }}
+                        >
+                          Add Slack channel (webhook)
+                        </Button>
+                      </Stack>
+                      <Button
+                        size="small"
+                        onClick={() => setSlackUseWebhookManual(true)}
+                      >
+                        Paste webhook URL manually
+                      </Button>
+                    </Stack>
+                  )}
+                {canManage && slackConn != null && !slackUseWebhookManual && (
+                  <Stack spacing={1}>
+                    <FormControl fullWidth size="small" disabled={slackChannelsLoading}>
+                      <InputLabel>Slack channel</InputLabel>
+                      <Select
+                        label="Slack channel"
+                        value={slackChannelSelectId}
+                        onChange={e => setSlackChannelSelectId(e.target.value)}
+                      >
+                        <MenuItem value="">
+                          <em>Select a channel</em>
+                        </MenuItem>
+                        {(slackChannelOptions || []).map(ch => (
+                          <MenuItem key={ch.id} value={ch.id}>
+                            {ch.isPrivate ? "Private: " : "#"}
+                            {ch.name}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                    <Typography variant="caption" color="text.secondary">
+                      Invite the Mako app to private channels so it can post
+                      there.
+                    </Typography>
+                    <Button
+                      size="small"
+                      onClick={() => {
+                        setSlackUseWebhookManual(true);
+                        setSlackChannelSelectId("");
+                      }}
+                    >
+                      Use per-channel webhook instead
+                    </Button>
+                  </Stack>
+                )}
+                {slackUseWebhookManual && (
+                  <>
+                    <TextField
+                      label="Slack incoming webhook URL"
+                      fullWidth
+                      required={!editingRule}
+                      placeholder={
+                        editingRule?.channel.type === "slack" &&
+                        !editingRule.channel.slackBotMode
+                          ? "Leave blank to keep current webhook"
+                          : undefined
+                      }
+                      value={slackWebhookUrl}
+                      onChange={e => setSlackWebhookUrl(e.target.value)}
+                    />
+                    <TextField
+                      label="Label (optional)"
+                      fullWidth
+                      value={slackLabel}
+                      onChange={e => setSlackLabel(e.target.value)}
+                    />
+                    {slackConn != null && (
+                      <Button
+                        size="small"
+                        onClick={() => {
+                          setSlackUseWebhookManual(false);
+                          setSlackWebhookUrl("");
+                        }}
+                      >
+                        Use workspace bot + channel list
+                      </Button>
+                    )}
+                  </>
+                )}
               </>
             )}
           </Stack>

--- a/app/src/components/FlowRunNotificationsSection.tsx
+++ b/app/src/components/FlowRunNotificationsSection.tsx
@@ -124,11 +124,11 @@ export function FlowRunNotificationsSection({
   const testNotification = useNotificationRuleStore(s => s.testNotification);
   const fetchSlackConnection = useSlackIntegrationStore(s => s.fetchConnection);
   const fetchSlackChannels = useSlackIntegrationStore(s => s.fetchChannels);
-  const slackConn = useSlackIntegrationStore(s =>
-    s.connectionByWorkspace[workspaceId],
+  const slackConn = useSlackIntegrationStore(
+    s => s.connectionByWorkspace[workspaceId],
   );
-  const slackChannelOptions = useSlackIntegrationStore(s =>
-    s.channelsByWorkspace[workspaceId],
+  const slackChannelOptions = useSlackIntegrationStore(
+    s => s.channelsByWorkspace[workspaceId],
   );
 
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -245,13 +245,7 @@ export function FlowRunNotificationsSection({
     void (async () => {
       await fetchSlackConnection(workspaceId);
     })();
-  }, [
-    dialogOpen,
-    channelType,
-    workspaceId,
-    canManage,
-    fetchSlackConnection,
-  ]);
+  }, [dialogOpen, channelType, workspaceId, canManage, fetchSlackConnection]);
 
   useEffect(() => {
     if (
@@ -817,55 +811,57 @@ export function FlowRunNotificationsSection({
                     Checking Slack workspace connection…
                   </Typography>
                 )}
-                {canManage &&
-                  slackConn === null &&
-                  !slackUseWebhookManual && (
-                    <Stack spacing={1}>
-                      <Typography variant="body2" color="text.secondary">
-                        Connect Slack once to pick channels from a list, or add a
-                        channel-only webhook (legacy).
-                      </Typography>
-                      <Stack direction="row" spacing={1} flexWrap="wrap">
-                        <Button
-                          size="small"
-                          variant="contained"
-                          onClick={() => {
-                            if (!workspaceId) return;
-                            const base = getApiBasePath(
-                              import.meta.env.VITE_API_URL,
-                            );
-                            const returnTo = encodeURIComponent("/");
-                            window.location.href = `${base}/workspaces/${workspaceId}/slack/install?installType=bot&returnTo=${returnTo}`;
-                          }}
-                        >
-                          Connect Slack workspace
-                        </Button>
-                        <Button
-                          size="small"
-                          variant="outlined"
-                          onClick={() => {
-                            if (!workspaceId) return;
-                            const base = getApiBasePath(
-                              import.meta.env.VITE_API_URL,
-                            );
-                            const returnTo = encodeURIComponent("/");
-                            window.location.href = `${base}/workspaces/${workspaceId}/slack/install?installType=webhook&returnTo=${returnTo}`;
-                          }}
-                        >
-                          Add Slack channel (webhook)
-                        </Button>
-                      </Stack>
+                {canManage && slackConn === null && !slackUseWebhookManual && (
+                  <Stack spacing={1}>
+                    <Typography variant="body2" color="text.secondary">
+                      Connect Slack once to pick channels from a list, or add a
+                      channel-only webhook (legacy).
+                    </Typography>
+                    <Stack direction="row" spacing={1} flexWrap="wrap">
                       <Button
                         size="small"
-                        onClick={() => setSlackUseWebhookManual(true)}
+                        variant="contained"
+                        onClick={() => {
+                          if (!workspaceId) return;
+                          const base = getApiBasePath(
+                            import.meta.env.VITE_API_URL,
+                          );
+                          const returnTo = encodeURIComponent("/");
+                          window.location.href = `${base}/workspaces/${workspaceId}/slack/install?installType=bot&returnTo=${returnTo}`;
+                        }}
                       >
-                        Paste webhook URL manually
+                        Connect Slack workspace
+                      </Button>
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        onClick={() => {
+                          if (!workspaceId) return;
+                          const base = getApiBasePath(
+                            import.meta.env.VITE_API_URL,
+                          );
+                          const returnTo = encodeURIComponent("/");
+                          window.location.href = `${base}/workspaces/${workspaceId}/slack/install?installType=webhook&returnTo=${returnTo}`;
+                        }}
+                      >
+                        Add Slack channel (webhook)
                       </Button>
                     </Stack>
-                  )}
+                    <Button
+                      size="small"
+                      onClick={() => setSlackUseWebhookManual(true)}
+                    >
+                      Paste webhook URL manually
+                    </Button>
+                  </Stack>
+                )}
                 {canManage && slackConn != null && !slackUseWebhookManual && (
                   <Stack spacing={1}>
-                    <FormControl fullWidth size="small" disabled={slackChannelsLoading}>
+                    <FormControl
+                      fullWidth
+                      size="small"
+                      disabled={slackChannelsLoading}
+                    >
                       <InputLabel>Slack channel</InputLabel>
                       <Select
                         label="Slack channel"

--- a/app/src/components/SettingsExplorer.tsx
+++ b/app/src/components/SettingsExplorer.tsx
@@ -8,6 +8,7 @@ import {
   KeySquare as ApiKeyIcon,
   Palette as AppearanceIcon,
   ShieldCheck as AdminIcon,
+  Plug as IntegrationsIcon,
 } from "lucide-react";
 import ExplorerShell from "./ExplorerShell";
 import { useAuth } from "../contexts/auth-context";
@@ -28,6 +29,7 @@ const SECTION_ICONS: Record<
   billing: props => <BillingIcon {...props} />,
   members: props => <MembersIcon {...props} />,
   "api-keys": props => <ApiKeyIcon {...props} />,
+  integrations: props => <IntegrationsIcon {...props} />,
   appearance: props => <AppearanceIcon {...props} />,
   admin: props => <AdminIcon {...props} />,
 };

--- a/app/src/components/SlackIntegrationCard.tsx
+++ b/app/src/components/SlackIntegrationCard.tsx
@@ -76,11 +76,7 @@ export default function SlackIntegrationCard() {
           notifications can post to any channel the bot is invited to.
         </Typography>
         {error && (
-          <Alert
-            severity="error"
-            sx={{ mb: 2 }}
-            onClose={() => setError(null)}
-          >
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
             {error}
           </Alert>
         )}

--- a/app/src/components/SlackIntegrationCard.tsx
+++ b/app/src/components/SlackIntegrationCard.tsx
@@ -72,20 +72,29 @@ export default function SlackIntegrationCard() {
           Slack
         </Typography>
         <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          Connect your Slack workspace once. Flow and scheduled query notifications
-          can post to any channel the bot is invited to.
+          Connect your Slack workspace once. Flow and scheduled query
+          notifications can post to any channel the bot is invited to.
         </Typography>
         {error && (
-          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+          <Alert
+            severity="error"
+            sx={{ mb: 2 }}
+            onClose={() => setError(null)}
+          >
             {error}
           </Alert>
         )}
         {connected && connection ? (
           <Box>
             <Typography variant="body2">
-              Connected: <strong>{connection.teamName}</strong> ({connection.teamId})
+              Connected: <strong>{connection.teamName}</strong> (
+              {connection.teamId})
             </Typography>
-            <Typography variant="caption" color="text.secondary" display="block">
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              display="block"
+            >
               Installed by user {connection.installedByUserId} ·{" "}
               {new Date(connection.installedAt).toLocaleString()}
             </Typography>

--- a/app/src/components/SlackIntegrationCard.tsx
+++ b/app/src/components/SlackIntegrationCard.tsx
@@ -1,0 +1,119 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Typography,
+} from "@mui/material";
+import { useWorkspace } from "../contexts/workspace-context";
+import { useIsWorkspaceAdmin } from "../hooks/useIsWorkspaceAdmin";
+import { getApiBasePath } from "../lib/api-base-path";
+import { useSlackIntegrationStore } from "../store/slackIntegrationStore";
+
+export default function SlackIntegrationCard() {
+  const { currentWorkspace } = useWorkspace();
+  const workspaceId = currentWorkspace?.id;
+  const isAdmin = useIsWorkspaceAdmin();
+  const fetchConnection = useSlackIntegrationStore(s => s.fetchConnection);
+  const disconnectSlack = useSlackIntegrationStore(s => s.disconnectSlack);
+  const connection = useSlackIntegrationStore(s =>
+    workspaceId ? s.connectionByWorkspace[workspaceId] : undefined,
+  );
+
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!workspaceId) return;
+    setError(null);
+    try {
+      await fetchConnection(workspaceId);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load Slack status");
+    }
+  }, [workspaceId, fetchConnection]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleConnect = () => {
+    if (!workspaceId) return;
+    const base = getApiBasePath(import.meta.env.VITE_API_URL);
+    const returnTo = encodeURIComponent("/settings/integrations");
+    window.location.href = `${base}/workspaces/${workspaceId}/slack/install?installType=bot&returnTo=${returnTo}`;
+  };
+
+  const handleDisconnect = async () => {
+    if (!workspaceId) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await disconnectSlack(workspaceId);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Disconnect failed");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!workspaceId) {
+    return null;
+  }
+
+  const connected = Boolean(connection);
+
+  return (
+    <Card variant="outlined">
+      <CardContent>
+        <Typography variant="h6" gutterBottom>
+          Slack
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Connect your Slack workspace once. Flow and scheduled query notifications
+          can post to any channel the bot is invited to.
+        </Typography>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
+        {connected && connection ? (
+          <Box>
+            <Typography variant="body2">
+              Connected: <strong>{connection.teamName}</strong> ({connection.teamId})
+            </Typography>
+            <Typography variant="caption" color="text.secondary" display="block">
+              Installed by user {connection.installedByUserId} ·{" "}
+              {new Date(connection.installedAt).toLocaleString()}
+            </Typography>
+            {isAdmin && (
+              <Button
+                sx={{ mt: 2 }}
+                color="error"
+                variant="outlined"
+                disabled={busy}
+                onClick={() => void handleDisconnect()}
+              >
+                Disconnect Slack
+              </Button>
+            )}
+          </Box>
+        ) : (
+          isAdmin && (
+            <Button variant="contained" onClick={handleConnect}>
+              Add to Slack
+            </Button>
+          )
+        )}
+        {!isAdmin && !connected && (
+          <Typography variant="body2" color="text.secondary">
+            Ask a workspace admin to connect Slack.
+          </Typography>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/src/lib/api-types.ts
+++ b/app/src/lib/api-types.ts
@@ -156,6 +156,10 @@ export interface NotificationRuleChannelSlackApi {
   type: "slack";
   displayLabel: string;
   webhookConfigured: boolean;
+  slackBotMode?: boolean;
+  slackConnectionId?: string;
+  slackChannelId?: string;
+  slackChannelName?: string;
 }
 
 export type NotificationRuleChannelApi =

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -7,6 +7,7 @@ import SettingsMembers from "./settings/SettingsMembers";
 import SettingsApiKeys from "./settings/SettingsApiKeys";
 import SettingsAppearance from "./settings/SettingsAppearance";
 import SettingsAdmin from "./settings/SettingsAdmin";
+import SettingsIntegrations from "./settings/SettingsIntegrations";
 
 interface Props {
   /**
@@ -34,6 +35,8 @@ function Settings({ section = "prompt" }: Props) {
       return <SettingsMembers />;
     case "api-keys":
       return <SettingsApiKeys />;
+    case "integrations":
+      return <SettingsIntegrations />;
     case "appearance":
       return <SettingsAppearance />;
     case "admin":

--- a/app/src/pages/SlackWebhookCompletePage.tsx
+++ b/app/src/pages/SlackWebhookCompletePage.tsx
@@ -43,7 +43,9 @@ export default function SlackWebhookCompletePage() {
         navigate("/", { replace: true });
       } catch (e) {
         if (!cancelled) {
-          setMessage(e instanceof Error ? e.message : "Could not complete Slack setup");
+          setMessage(
+            e instanceof Error ? e.message : "Could not complete Slack setup",
+          );
           setWorking(false);
         }
       }

--- a/app/src/pages/SlackWebhookCompletePage.tsx
+++ b/app/src/pages/SlackWebhookCompletePage.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from "react";
+import { Box, CircularProgress, Typography } from "@mui/material";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import { useSlackIntegrationStore } from "../store/slackIntegrationStore";
+
+const STORAGE_KEY = "slack_webhook_oauth_pending";
+
+export default function SlackWebhookCompletePage() {
+  const { workspaceId } = useParams<{ workspaceId: string }>();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const exchangeWebhookToken = useSlackIntegrationStore(
+    s => s.exchangeWebhookToken,
+  );
+  const [message, setMessage] = useState("Completing Slack connection…");
+  const [working, setWorking] = useState(true);
+
+  useEffect(() => {
+    const token = searchParams.get("token");
+    if (!workspaceId || !token) {
+      setMessage("Missing workspace or token.");
+      setWorking(false);
+      return;
+    }
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const { slackWebhookUrl, displayLabel } = await exchangeWebhookToken(
+          workspaceId,
+          token,
+        );
+        if (cancelled) return;
+        localStorage.setItem("activeWorkspaceId", workspaceId);
+        sessionStorage.setItem(
+          STORAGE_KEY,
+          JSON.stringify({
+            workspaceId,
+            slackWebhookUrl,
+            displayLabel,
+          }),
+        );
+        navigate("/", { replace: true });
+      } catch (e) {
+        if (!cancelled) {
+          setMessage(e instanceof Error ? e.message : "Could not complete Slack setup");
+          setWorking(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId, searchParams, exchangeWebhookToken, navigate]);
+
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+      minHeight="100vh"
+      gap={2}
+      p={3}
+    >
+      {working && <CircularProgress size={40} />}
+      <Typography variant="body1">{message}</Typography>
+    </Box>
+  );
+}

--- a/app/src/pages/settings/SettingsIntegrations.tsx
+++ b/app/src/pages/settings/SettingsIntegrations.tsx
@@ -1,0 +1,10 @@
+import SettingsLayout from "./SettingsLayout";
+import SlackIntegrationCard from "../../components/SlackIntegrationCard";
+
+export default function SettingsIntegrations() {
+  return (
+    <SettingsLayout title="Integrations">
+      <SlackIntegrationCard />
+    </SettingsLayout>
+  );
+}

--- a/app/src/pages/settings/sections.ts
+++ b/app/src/pages/settings/sections.ts
@@ -13,6 +13,7 @@ export const SECTION_LABELS: Record<SettingsSection, string> = {
   billing: "Billing",
   members: "Members",
   "api-keys": "API Keys",
+  integrations: "Integrations",
   appearance: "Appearance",
   admin: "Super Admin",
 };
@@ -28,6 +29,7 @@ export const SECTION_ORDER: SettingsSection[] = [
   "billing",
   "members",
   "api-keys",
+  "integrations",
   "appearance",
   "admin",
 ];

--- a/app/src/store/lib/types.ts
+++ b/app/src/store/lib/types.ts
@@ -27,6 +27,7 @@ export type SettingsSection =
   | "billing"
   | "members"
   | "api-keys"
+  | "integrations"
   | "appearance"
   | "admin";
 

--- a/app/src/store/notificationRuleStore.ts
+++ b/app/src/store/notificationRuleStore.ts
@@ -159,5 +159,11 @@ export function ruleSummary(rule: NotificationRuleApi): string {
   const ch = rule.channel;
   if (ch.type === "email") return ch.recipients.join(", ");
   if (ch.type === "webhook") return ch.urlPreview || "Webhook";
+  if (ch.type === "slack" && ch.slackBotMode && ch.slackChannelName) {
+    return ch.slackChannelName;
+  }
+  if (ch.type === "slack" && ch.slackBotMode && ch.slackChannelId) {
+    return ch.slackChannelId;
+  }
   return ch.displayLabel || "Slack";
 }

--- a/app/src/store/slackIntegrationStore.ts
+++ b/app/src/store/slackIntegrationStore.ts
@@ -1,0 +1,104 @@
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+import { apiClient } from "../lib/api-client";
+
+export interface SlackConnectionApi {
+  id: string;
+  workspaceId: string;
+  teamId: string;
+  teamName: string;
+  botUserId: string;
+  scopes: string[];
+  installedByUserId: string;
+  installedAt: string;
+}
+
+export interface SlackChannelApi {
+  id: string;
+  name: string;
+  isPrivate: boolean;
+}
+
+interface SlackIntegrationState {
+  connectionByWorkspace: Record<string, SlackConnectionApi | null | undefined>;
+  channelsByWorkspace: Record<string, SlackChannelApi[] | undefined>;
+}
+
+interface SlackIntegrationActions {
+  fetchConnection: (workspaceId: string) => Promise<SlackConnectionApi | null>;
+  disconnectSlack: (workspaceId: string) => Promise<void>;
+  fetchChannels: (workspaceId: string) => Promise<SlackChannelApi[]>;
+  exchangeWebhookToken: (
+    workspaceId: string,
+    token: string,
+  ) => Promise<{ slackWebhookUrl: string; displayLabel: string }>;
+  clearWorkspaceCache: (workspaceId: string) => void;
+}
+
+export const useSlackIntegrationStore = create<
+  SlackIntegrationState & SlackIntegrationActions
+>()(
+  immer(set => ({
+    connectionByWorkspace: {},
+    channelsByWorkspace: {},
+
+    fetchConnection: async workspaceId => {
+      try {
+        const res = await apiClient.get<{
+          success: boolean;
+          connection: SlackConnectionApi;
+        }>(`/workspaces/${workspaceId}/slack/connection`);
+        set(s => {
+          s.connectionByWorkspace[workspaceId] = res.connection;
+        });
+        return res.connection;
+      } catch {
+        set(s => {
+          s.connectionByWorkspace[workspaceId] = null;
+        });
+        return null;
+      }
+    },
+
+    disconnectSlack: async workspaceId => {
+      await apiClient.delete(`/workspaces/${workspaceId}/slack/connection`);
+      set(s => {
+        s.connectionByWorkspace[workspaceId] = null;
+        delete s.channelsByWorkspace[workspaceId];
+      });
+    },
+
+    fetchChannels: async workspaceId => {
+      const res = await apiClient.get<{
+        success: boolean;
+        channels: SlackChannelApi[];
+      }>(`/workspaces/${workspaceId}/slack/channels`);
+      const list = res.channels || [];
+      set(s => {
+        s.channelsByWorkspace[workspaceId] = list;
+      });
+      return list;
+    },
+
+    exchangeWebhookToken: async (workspaceId, token) => {
+      const res = await apiClient.post<{
+        success: boolean;
+        slackWebhookUrl: string;
+        displayLabel: string;
+      }>(`/workspaces/${workspaceId}/slack/exchange-webhook-token`, {
+        token,
+      });
+      return {
+        slackWebhookUrl: res.slackWebhookUrl,
+        displayLabel: res.displayLabel,
+      };
+    },
+
+    clearWorkspaceCache: workspaceId => {
+      set(s => {
+        delete s.connectionByWorkspace[workspaceId];
+        delete s.channelsByWorkspace[workspaceId];
+      });
+    },
+  })),
+);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Slack workspace notifications via OAuth v2 with two paths:

1. **Workspace bot (default):** One install per Mako workspace (`chat:write`, `channels:read`, `groups:read`). Rules pick a channel from `conversations.list`; delivery uses `chat.postMessage`.
2. **Per-rule incoming webhook:** User-scope `incoming-webhook` OAuth returns a signed short-lived token → frontend exchanges it for the webhook URL via POST `/slack/exchange-webhook-token`.

Non-production APIs redirect through production with a signed **install ticket** (same pattern as login OAuth proxy) so Slack only needs one redirect URI registered.

## Backend

- New `slack_connections` collection + Mongoose model; migration `2026-05-02-090000_slack_connections_collection.ts`.
- `api/src/auth/slack.ts`: authorize URL builder, `oauth.v2.access`, state encoding, webhook claim + install ticket signing.
- `GET /api/auth/slack/callback`: bot upsert → redirect to `callerOrigin + returnTo?slack=connected`; webhook → redirect to `/api/workspaces/:id/slack/webhook-receive?token=…`.
- `api/src/routes/slack.ts`: `install`, `connection`, `channels`, `disconnect`, `exchange-webhook-token`, public `webhook-receive` (before auth middleware).
- Notification rules: `slackChannelId` + optional `slackChannelName` resolves workspace connection; legacy `slackWebhookUrl` unchanged.

## Frontend

- Settings → **Integrations** with `SlackIntegrationCard` (connect/disconnect).
- Flow/scheduled-query notification dialog: bot channel select vs webhook OAuth vs manual URL.
- `/workspace/:workspaceId/slack-webhook-complete` completes webhook OAuth and stashes URL in `sessionStorage` for the notification dialog.

## Env

- `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET` (documented in `.env.example`).
- Slack app redirect URL: `{PRODUCTION_URL}/api/auth/slack/callback`.

## Verification

CI should run `pnpm --filter api run lint` and `pnpm --filter app run typecheck && pnpm --filter app run lint` (local sandbox had no Node/pnpm).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7f93021-4eb8-4a30-b40a-5036cbb68d3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7f93021-4eb8-4a30-b40a-5036cbb68d3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

