### PR TITLE
docs(api-reference): clean Query Execution table + #401 migration callout

### DIFF
--- a/docs/src/content/docs/api-reference.md
+++ b/docs/src/content/docs/api-reference.md
@@ -49,10 +49,17 @@ Authorization: Bearer revops_YOUR_API_KEY
 
 Session cookie or `Authorization: Bearer revops_*` API key required. Use the database connection ID from `GET /api/workspaces/:wid/connectors`.
 
-| Method | Endpoint                                                      | Description                                        |
-| ------ | ------------------------------------------------------------- | -------------------------------------------------- |
-| `POST` | `/api/workspaces/:wid/databases/:databaseId/execute`        | Run a query against one connection (`body.query`) |
-| `POST` | `/api/workspaces/:wid/execute`                                | Execute with `query` / `queryDefinition`, pagination, exports (`POST …/execute/export` supports `format=arrow`, `parquet`, `ndjson`, `csv`) |
+| Method | Endpoint                                               | Description                                                                                                          |
+| ------ | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `POST` | `/api/workspaces/:wid/databases/:databaseId/execute`   | Run a query against a specific connection (`body.query`)                                                             |
+| `POST` | `/api/workspaces/:wid/execute`                         | Execute with `query` or `queryDefinition`; supports pagination via `body.pagination`                                 |
+| `POST` | `/api/workspaces/:wid/execute/export`                  | Stream results as `format` = `arrow`, `parquet`, `ndjson`, or `csv`                                                  |
+| `POST` | `/api/workspaces/:wid/execute/cancel`                  | Cancel an in-flight query by `executionId`                                                                           |
+
+:::caution[Breaking change]
+The legacy unauthenticated `POST /api/execute` and `POST /api/run/:path` endpoints were removed in [#401](https://github.com/mako-ai/mako/pull/401) (they allowed unauthenticated RCE). Callers must move to the workspace-scoped endpoints above and authenticate with a session cookie or `Bearer revops_*` API key.
+:::
+
 
 ## Consoles
 


### PR DESCRIPTION
## Why

PR #401 removed the unauthenticated `POST /api/execute` and `POST /api/run/:path` endpoints (they allowed unauthenticated RCE via `eval()` on request bodies) and updated `docs/src/content/docs/api-reference.md`. That update did the right thing on substance but left the `Query Execution` table awkward: `/execute/export` was glued into another row's description cell, and `/execute/cancel` (live in code at `api/src/routes/workspace-databases.ts` L1536) wasn't documented at all. There was also no migration note for anyone hitting the legacy unauthenticated endpoints.

## What

- One row per endpoint in the Query Execution table:
  - `POST /api/workspaces/:wid/databases/:databaseId/execute`
  - `POST /api/workspaces/:wid/execute`
  - `POST /api/workspaces/:wid/execute/export` (`format` = `arrow` | `parquet` | `ndjson` | `csv`)
  - `POST /api/workspaces/:wid/execute/cancel` (cancel by `executionId`)
- Added a `:::caution[Breaking change]` callout linking to #401 so anyone still calling the removed routes sees the migration path explicitly.

## Verify

`pnpm --filter docs run build` passes — 19 pages, no warnings.

---
_Filed by Aura's daily mako-docs-maintenance job._