### PR TITLE
fix(app): commit recipient chips on Enter in notification dialog

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -38,6 +38,7 @@
     "immer": "^10.1.1",
     "jspdf": "^4.2.1",
     "lucide-react": "^0.511.0",
+    "mui-chips-input": "^9.0.0",
     "nanoid": "^5.1.7",
     "openai": "^4.103.0",
     "react": "^18.2.0",

--- a/app/src/components/FlowRunNotificationsSection.tsx
+++ b/app/src/components/FlowRunNotificationsSection.tsx
@@ -1,7 +1,6 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   Alert,
-  Autocomplete,
   Box,
   Button,
   Card,
@@ -26,6 +25,7 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
+import { MuiChipsInput } from "mui-chips-input";
 import {
   Add as AddIcon,
   Close as CloseIcon,
@@ -87,12 +87,8 @@ function formatDeliveryLine(d: NotificationDeliveryApi): string {
   }`;
 }
 
-/** Loose client-side check — invalid chips block save until corrected */
+/** Loose client-side check — used by `MuiChipsInput`'s `validate` to block bad chips */
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-function splitRecipientTokens(raw: string): string[] {
-  return raw.split(/[\s,;]+/).map(s => s.trim());
-}
 
 function channelTitle(type: NotificationChannelTypeApi): string {
   switch (type) {
@@ -139,7 +135,6 @@ export function FlowRunNotificationsSection({
   const [channelType, setChannelType] =
     useState<NotificationChannelTypeApi>("email");
   const [recipients, setRecipients] = useState<string[]>([]);
-  const [recipientsInput, setRecipientsInput] = useState("");
   const [webhookUrl, setWebhookUrl] = useState("");
   const [webhookSigningSecret, setWebhookSigningSecret] = useState("");
   const [rotateWebhookSecret, setRotateWebhookSecret] = useState(false);
@@ -162,7 +157,6 @@ export function FlowRunNotificationsSection({
     setFailureChecked(true);
     setChannelType("email");
     setRecipients([]);
-    setRecipientsInput("");
     setWebhookUrl("");
     setWebhookSigningSecret("");
     setRotateWebhookSecret(false);
@@ -189,7 +183,6 @@ export function FlowRunNotificationsSection({
     } else {
       setRecipients([]);
     }
-    setRecipientsInput("");
     setWebhookUrl("");
     setWebhookSigningSecret("");
     setRotateWebhookSecret(false);
@@ -243,46 +236,26 @@ export function FlowRunNotificationsSection({
     void loadDeliveryLog();
   }, [loadDeliveryLog]);
 
-  const commitRecipientsInput = useCallback((raw: string): string[] => {
-    const tokens = splitRecipientTokens(raw).filter(Boolean);
-    if (tokens.length === 0) return [];
-    let merged: string[] = [];
-    setRecipients(prev => {
-      const seen = new Set(prev);
-      const next = [...prev];
-      for (const t of tokens) {
-        if (!seen.has(t)) {
-          seen.add(t);
-          next.push(t);
-        }
-      }
-      merged = next;
-      return next;
-    });
-    return merged;
-  }, []);
+  // `MuiChipsInput`'s `validate` prevents invalid emails from ever entering
+  // `recipients`, so all we need to gate Save on is "at least one chip".
+  const emailRecipientsSaveBlocked =
+    channelType === "email" && recipients.length === 0;
 
-  const invalidRecipients = useMemo(
-    () => recipients.filter(r => !EMAIL_RE.test(r)),
+  const validateRecipientChip = useCallback(
+    (chipValue: string) => {
+      const trimmed = chipValue.trim();
+      if (!EMAIL_RE.test(trimmed)) {
+        return { isError: true, textError: `${trimmed} is not a valid email` };
+      }
+      if (recipients.includes(trimmed)) {
+        return { isError: true, textError: `${trimmed} is already added` };
+      }
+      return true;
+    },
     [recipients],
   );
-  const hasInvalidRecipients = invalidRecipients.length > 0;
 
-  // Treat a pending valid email in the input box as if it were already chipped,
-  // so the Save button stays enabled even if the user forgets to press Enter.
-  const pendingInputIsValidEmail =
-    recipientsInput.trim() !== "" &&
-    EMAIL_RE.test(recipientsInput.trim()) &&
-    !recipients.includes(recipientsInput.trim());
-
-  const emailRecipientsSaveBlocked =
-    channelType === "email" &&
-    (hasInvalidRecipients ||
-      (recipients.length === 0 && !pendingInputIsValidEmail));
-
-  const buildPayloadBase = (
-    effectiveRecipients: string[] = recipients,
-  ): Record<string, unknown> | null => {
+  const buildPayloadBase = (): Record<string, unknown> | null => {
     const triggers: NotificationTriggerApi[] = [];
     if (successChecked) triggers.push("success");
     if (failureChecked) triggers.push("failure");
@@ -294,11 +267,8 @@ export function FlowRunNotificationsSection({
     };
 
     if (channelType === "email") {
-      const valid = effectiveRecipients.filter(r => EMAIL_RE.test(r));
-      if (valid.length === 0 || valid.length !== effectiveRecipients.length) {
-        return null;
-      }
-      base.recipients = valid;
+      if (recipients.length === 0) return null;
+      base.recipients = recipients;
     } else if (channelType === "webhook") {
       if (editingRule && webhookUrl.trim() === "") {
         // keep URL server-side
@@ -329,12 +299,7 @@ export function FlowRunNotificationsSection({
 
   const handleSaveDialog = async () => {
     if (!workspaceId || !resourceId || !canManage) return;
-    let effectiveRecipients = recipients;
-    if (channelType === "email" && recipientsInput.trim() !== "") {
-      effectiveRecipients = commitRecipientsInput(recipientsInput);
-      setRecipientsInput("");
-    }
-    const body = buildPayloadBase(effectiveRecipients);
+    const body = buildPayloadBase();
     if (!body) {
       setLoadError(
         "Choose at least one event (success or failure) and complete the channel fields.",
@@ -698,90 +663,19 @@ export function FlowRunNotificationsSection({
             </FormControl>
 
             {channelType === "email" && (
-              <Autocomplete
-                multiple
-                freeSolo
-                options={[]}
+              <MuiChipsInput
+                fullWidth
+                size="small"
+                label="Recipients"
+                placeholder="Type an email and press Enter"
+                helperText="Press Enter to add. Backspace removes the last chip."
                 value={recipients}
-                inputValue={recipientsInput}
-                onInputChange={(_, val, reason) => {
-                  if (reason === "reset") {
-                    setRecipientsInput("");
-                    return;
-                  }
-                  // Pasting/typing a separator commits everything up to the
-                  // last (still-being-typed) token. Catches comma, semicolon,
-                  // whitespace, and bulk paste like "a@b.com, c@d.com".
-                  if (/[\s,;]/.test(val)) {
-                    const parts = val.split(/[\s,;]+/);
-                    const trailing = parts.pop() ?? "";
-                    const completed = parts.filter(Boolean).join(" ");
-                    if (completed) commitRecipientsInput(completed);
-                    setRecipientsInput(trailing);
-                    return;
-                  }
-                  setRecipientsInput(val);
-                }}
-                onChange={(_, next, reason) => {
-                  // Only used for chip removal (Backspace / Delete icon) — chip
-                  // creation is handled explicitly via onKeyDown / onBlur /
-                  // onInputChange so MUI's freeSolo flow can't swallow Enter.
-                  if (
-                    reason === "removeOption" ||
-                    reason === "clear" ||
-                    reason === "blur"
-                  ) {
-                    const strs = next.filter(
-                      (v): v is string => typeof v === "string",
-                    );
-                    setRecipients(strs);
-                  }
-                }}
-                renderTags={(value, getTagProps) =>
-                  value.map((email, index) => {
-                    const valid = EMAIL_RE.test(email);
-                    const tagProps = getTagProps({ index });
-                    return (
-                      <Chip
-                        {...tagProps}
-                        key={email}
-                        label={email}
-                        size="small"
-                        color={valid ? "default" : "error"}
-                        variant={valid ? "filled" : "outlined"}
-                      />
-                    );
-                  })
-                }
-                renderInput={params => (
-                  <TextField
-                    {...params}
-                    label="Recipients"
-                    placeholder="Type an email and press Enter"
-                    error={hasInvalidRecipients}
-                    helperText={
-                      hasInvalidRecipients
-                        ? `Invalid: ${invalidRecipients.join(", ")}`
-                        : "Press Enter, comma, or blur to add"
-                    }
-                    onKeyDown={e => {
-                      if (
-                        (e.key === "Enter" || e.key === "Tab") &&
-                        recipientsInput.trim() !== ""
-                      ) {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        commitRecipientsInput(recipientsInput);
-                        setRecipientsInput("");
-                      }
-                    }}
-                    onBlur={() => {
-                      if (recipientsInput.trim() !== "") {
-                        commitRecipientsInput(recipientsInput);
-                        setRecipientsInput("");
-                      }
-                    }}
-                  />
+                onChange={setRecipients}
+                addOnBlur
+                hideClearAll
+                validate={validateRecipientChip}
+                renderChip={(Component, key, chipProps) => (
+                  <Component {...chipProps} key={key} size="small" />
                 )}
               />
             )}

--- a/app/src/components/FlowRunNotificationsSection.tsx
+++ b/app/src/components/FlowRunNotificationsSection.tsx
@@ -139,6 +139,7 @@ export function FlowRunNotificationsSection({
   const [channelType, setChannelType] =
     useState<NotificationChannelTypeApi>("email");
   const [recipients, setRecipients] = useState<string[]>([]);
+  const [recipientsInput, setRecipientsInput] = useState("");
   const [webhookUrl, setWebhookUrl] = useState("");
   const [webhookSigningSecret, setWebhookSigningSecret] = useState("");
   const [rotateWebhookSecret, setRotateWebhookSecret] = useState(false);
@@ -161,6 +162,7 @@ export function FlowRunNotificationsSection({
     setFailureChecked(true);
     setChannelType("email");
     setRecipients([]);
+    setRecipientsInput("");
     setWebhookUrl("");
     setWebhookSigningSecret("");
     setRotateWebhookSecret(false);
@@ -187,6 +189,7 @@ export function FlowRunNotificationsSection({
     } else {
       setRecipients([]);
     }
+    setRecipientsInput("");
     setWebhookUrl("");
     setWebhookSigningSecret("");
     setRotateWebhookSecret(false);
@@ -240,10 +243,24 @@ export function FlowRunNotificationsSection({
     void loadDeliveryLog();
   }, [loadDeliveryLog]);
 
-  const parsedRecipients = useMemo(
-    () => recipients.filter(r => EMAIL_RE.test(r)),
-    [recipients],
-  );
+  const commitRecipientsInput = useCallback((raw: string): string[] => {
+    const tokens = splitRecipientTokens(raw).filter(Boolean);
+    if (tokens.length === 0) return [];
+    let merged: string[] = [];
+    setRecipients(prev => {
+      const seen = new Set(prev);
+      const next = [...prev];
+      for (const t of tokens) {
+        if (!seen.has(t)) {
+          seen.add(t);
+          next.push(t);
+        }
+      }
+      merged = next;
+      return next;
+    });
+    return merged;
+  }, []);
 
   const invalidRecipients = useMemo(
     () => recipients.filter(r => !EMAIL_RE.test(r)),
@@ -251,11 +268,21 @@ export function FlowRunNotificationsSection({
   );
   const hasInvalidRecipients = invalidRecipients.length > 0;
 
+  // Treat a pending valid email in the input box as if it were already chipped,
+  // so the Save button stays enabled even if the user forgets to press Enter.
+  const pendingInputIsValidEmail =
+    recipientsInput.trim() !== "" &&
+    EMAIL_RE.test(recipientsInput.trim()) &&
+    !recipients.includes(recipientsInput.trim());
+
   const emailRecipientsSaveBlocked =
     channelType === "email" &&
-    (recipients.length === 0 || hasInvalidRecipients);
+    (hasInvalidRecipients ||
+      (recipients.length === 0 && !pendingInputIsValidEmail));
 
-  const buildPayloadBase = (): Record<string, unknown> | null => {
+  const buildPayloadBase = (
+    effectiveRecipients: string[] = recipients,
+  ): Record<string, unknown> | null => {
     const triggers: NotificationTriggerApi[] = [];
     if (successChecked) triggers.push("success");
     if (failureChecked) triggers.push("failure");
@@ -267,8 +294,11 @@ export function FlowRunNotificationsSection({
     };
 
     if (channelType === "email") {
-      if (parsedRecipients.length === 0) return null;
-      base.recipients = parsedRecipients;
+      const valid = effectiveRecipients.filter(r => EMAIL_RE.test(r));
+      if (valid.length === 0 || valid.length !== effectiveRecipients.length) {
+        return null;
+      }
+      base.recipients = valid;
     } else if (channelType === "webhook") {
       if (editingRule && webhookUrl.trim() === "") {
         // keep URL server-side
@@ -299,7 +329,12 @@ export function FlowRunNotificationsSection({
 
   const handleSaveDialog = async () => {
     if (!workspaceId || !resourceId || !canManage) return;
-    const body = buildPayloadBase();
+    let effectiveRecipients = recipients;
+    if (channelType === "email" && recipientsInput.trim() !== "") {
+      effectiveRecipients = commitRecipientsInput(recipientsInput);
+      setRecipientsInput("");
+    }
+    const body = buildPayloadBase(effectiveRecipients);
     if (!body) {
       setLoadError(
         "Choose at least one event (success or failure) and complete the channel fields.",
@@ -666,22 +701,41 @@ export function FlowRunNotificationsSection({
               <Autocomplete
                 multiple
                 freeSolo
-                autoSelect
                 options={[]}
                 value={recipients}
-                onChange={(_, next) => {
-                  const expanded = next.flatMap(v =>
-                    typeof v === "string" ? splitRecipientTokens(v) : [v],
-                  );
-                  const seen = new Set<string>();
-                  const deduped: string[] = [];
-                  for (const s of expanded) {
-                    const t = s.trim();
-                    if (!t || seen.has(t)) continue;
-                    seen.add(t);
-                    deduped.push(t);
+                inputValue={recipientsInput}
+                onInputChange={(_, val, reason) => {
+                  if (reason === "reset") {
+                    setRecipientsInput("");
+                    return;
                   }
-                  setRecipients(deduped);
+                  // Pasting/typing a separator commits everything up to the
+                  // last (still-being-typed) token. Catches comma, semicolon,
+                  // whitespace, and bulk paste like "a@b.com, c@d.com".
+                  if (/[\s,;]/.test(val)) {
+                    const parts = val.split(/[\s,;]+/);
+                    const trailing = parts.pop() ?? "";
+                    const completed = parts.filter(Boolean).join(" ");
+                    if (completed) commitRecipientsInput(completed);
+                    setRecipientsInput(trailing);
+                    return;
+                  }
+                  setRecipientsInput(val);
+                }}
+                onChange={(_, next, reason) => {
+                  // Only used for chip removal (Backspace / Delete icon) — chip
+                  // creation is handled explicitly via onKeyDown / onBlur /
+                  // onInputChange so MUI's freeSolo flow can't swallow Enter.
+                  if (
+                    reason === "removeOption" ||
+                    reason === "clear" ||
+                    reason === "blur"
+                  ) {
+                    const strs = next.filter(
+                      (v): v is string => typeof v === "string",
+                    );
+                    setRecipients(strs);
+                  }
                 }}
                 renderTags={(value, getTagProps) =>
                   value.map((email, index) => {
@@ -710,6 +764,23 @@ export function FlowRunNotificationsSection({
                         ? `Invalid: ${invalidRecipients.join(", ")}`
                         : "Press Enter, comma, or blur to add"
                     }
+                    onKeyDown={e => {
+                      if (
+                        (e.key === "Enter" || e.key === "Tab") &&
+                        recipientsInput.trim() !== ""
+                      ) {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        commitRecipientsInput(recipientsInput);
+                        setRecipientsInput("");
+                      }
+                    }}
+                    onBlur={() => {
+                      if (recipientsInput.trim() !== "") {
+                        commitRecipientsInput(recipientsInput);
+                        setRecipientsInput("");
+                      }
+                    }}
                   />
                 )}
               />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -367,6 +367,9 @@ importers:
       lucide-react:
         specifier: ^0.511.0
         version: 0.511.0(react@18.3.1)
+      mui-chips-input:
+        specifier: ^9.0.0
+        version: 9.0.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@mui/icons-material@7.1.0(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       nanoid:
         specifier: ^5.1.7
         version: 5.1.7
@@ -1850,155 +1853,183 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -2295,24 +2326,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@14.2.33':
     resolution: {integrity: sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@14.2.33':
     resolution: {integrity: sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@14.2.33':
     resolution: {integrity: sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@14.2.33':
     resolution: {integrity: sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==}
@@ -3205,56 +3240,67 @@ packages:
     resolution: {integrity: sha512-wC53ZNDgt0pqx5xCAgNunkTzFE8GTgdZ9EwYGVcg+jEjJdZGtq9xPjDnFgfFozQI/Xm1mh+D9YlYtl+ueswNEg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.41.1':
     resolution: {integrity: sha512-jwKCca1gbZkZLhLRtsrka5N8sFAaxrGz/7wRJ8Wwvq3jug7toO21vWlViihG85ei7uJTpzbXZRcORotE+xyrLA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.41.1':
     resolution: {integrity: sha512-g0UBcNknsmmNQ8V2d/zD2P7WWfJKU0F1nu0k5pW4rvdb+BIqMm8ToluW/eeRmxCared5dD76lS04uL4UaNgpNA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.41.1':
     resolution: {integrity: sha512-XZpeGB5TKEZWzIrj7sXr+BEaSgo/ma/kCgrZgL0oo5qdB1JlTzIYQKel/RmhT6vMAvOdM2teYlAaOGJpJ9lahg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.41.1':
     resolution: {integrity: sha512-bkCfDJ4qzWfFRCNt5RVV4DOw6KEgFTUZi2r2RuYhGWC8WhCA8lCAJhDeAmrM/fdiAH54m0mA0Vk2FGRPyzI+tw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.41.1':
     resolution: {integrity: sha512-3mr3Xm+gvMX+/8EKogIZSIEF0WUu0HL9di+YWlJpO8CQBnoLAEL/roTCxuLncEdgcfJcvA4UMOf+2dnjl4Ut1A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.41.1':
     resolution: {integrity: sha512-3rwCIh6MQ1LGrvKJitQjZFuQnT2wxfU+ivhNBzmxXTXPllewOF7JR1s2vMX/tWtUYFgphygxjqMl76q4aMotGw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.41.1':
     resolution: {integrity: sha512-LdIUOb3gvfmpkgFZuccNa2uYiqtgZAz3PTzjuM5bH3nvuy9ty6RGc/Q0+HDFrHrizJGVpjnTZ1yS5TNNjFlklw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.41.1':
     resolution: {integrity: sha512-oIE6M8WC9ma6xYqjvPhzZYk6NbobIURvP/lEbh7FWplcMO6gn7MM2yHKA1eC/GvYwzNKK/1LYgqzdkZ8YFxR8g==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.41.1':
     resolution: {integrity: sha512-cWBOvayNvA+SyeQMp79BHPK8ws6sHSsYnK5zDcsC3Hsxr1dgTABKjMnMslPq1DvZIp6uO7kIWhiGwaTdR4Og9A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.41.1':
     resolution: {integrity: sha512-y5CbN44M+pUCdGDlZFzGGBSKCA4A/J2ZH4edTYSSxFg7ce1Xt3GtydbVKWLlzL+INfFIZAEg1ZV6hh9+QQf9YQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.41.1':
     resolution: {integrity: sha512-lZkCxIrjlJlMt1dLO/FbpZbzt6J/A8p4DnqzSa4PWqPEUUUnzXLeki/iyPLfV0BmHItlYgHUqJe+3KiyydmiNQ==}
@@ -3568,24 +3614,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -6942,48 +6992,56 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.31.0:
     resolution: {integrity: sha512-EpAQTq6TXL+200bDNMzhbFpqAJsto01R//xuE8yAWN0l4wmJhmS1r/FxoudIUM9PxHMPEiWeLw+1thdF5ZPg7Q==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.31.0:
     resolution: {integrity: sha512-6tuU37nXStA3kxNnjC49z1tPFEoviC9ZLyB34O3X1/VTLXdZX2vmPZ+45XesagvlgoeJQ9r9XVSovUZny41AQA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.31.0:
     resolution: {integrity: sha512-enNePbgDKmJybVz90/8dAGTOulvpn0IwxamHHnIj32gmdbuSPJ9mk+Nob4UmiqLMAdHlH+0c+lpsZkv4TSxi3w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-musl@1.31.0:
     resolution: {integrity: sha512-EM4jGT+V+PdFkcrIB5m5yiSzfV7z43k0pOtUmODhFSbuay5JvbVChK1uoaMmwPTKGWatwSRbiu90BUzU262B9g==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -7615,6 +7673,20 @@ packages:
     resolution: {integrity: sha512-KlGNsugoT90enKlR8/G36H0kTxPthDhmtNUCwEHvgRza5Cjpjoj+P2X6eMpFUDN7pFrJZsKadL4x990G8RBE1w==}
     engines: {node: '>=18'}
     hasBin: true
+
+  mui-chips-input@9.0.0:
+    resolution: {integrity: sha512-2GSHSK6fp+s6fJWEEMUsYIecgy6Iy6AzB1/7CM048a3GERzDJMbebTYdQbaokpCyx+Fg4mh7yGLRcO5O/yEYFg==}
+    peerDependencies:
+      '@emotion/react': ^11.13.0
+      '@emotion/styled': ^11.13.0
+      '@mui/icons-material': ^7.0.0 || ^9.0.0
+      '@mui/material': ^7.0.0 || ^9.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   mustache@4.2.0:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
@@ -19099,6 +19171,17 @@ snapshots:
       tedious: 18.6.1
     transitivePeerDependencies:
       - supports-color
+
+  mui-chips-input@9.0.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@mui/icons-material@7.1.0(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
+      '@mui/icons-material': 7.1.0(@mui/material@7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
+      '@mui/material': 7.1.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.23
 
   mustache@4.2.0: {}
 


### PR DESCRIPTION
## Summary

The recipients chip input in the run-notification dialog was not creating chips on Enter — Gmail-style chip input was broken, blocking users from saving email rules.

This PR replaces the hand-rolled `<Autocomplete multiple freeSolo>` (which fought MUI's internal Enter handler depending on keydown bubbling order) with [`mui-chips-input`](https://github.com/viclafouch/mui-chips-input) — a small (15 kB, **0 deps**) MUI v7-compatible chips library that ships with rock-solid Enter / blur / backspace / double-click-to-edit handling.

- Per-chip email validation moves into the lib's `validate` prop, which prevents invalid chips from entering state at all.
- Save-blocked logic collapses from "any invalid chip OR no chips OR no pending valid email" down to just `recipients.length === 0`.
- ~140 lines of brittle event-handling code deleted.

Touches `app/src/components/FlowRunNotificationsSection.tsx` and adds `mui-chips-input@^9.0.0` to `app/package.json`.

## Test plan

- [ ] Open Edit/Add notification on a scheduled query → Email type
- [ ] Type `jonas@realadvisor.com` + Enter → chip appears, input clears
- [ ] Type a chip, then click Save without pressing Enter → `addOnBlur` commits the chip first, save succeeds
- [ ] Type `foo` + Enter → red error helper "foo is not a valid email", no chip added
- [ ] Type the same email twice → second attempt blocked with "already added" helper
- [ ] Backspace on empty input → removes last chip
- [ ] Double-click an existing chip → input becomes editable, validation re-runs on commit
- [ ] Editing an existing rule preserves existing recipients