### PR TITLE
docs: point API auth sections at in-app Workspace ID copy (#404 follow-up)

### DIFF
--- a/docs/src/content/docs/api-reference.md
+++ b/docs/src/content/docs/api-reference.md
@@ -17,6 +17,8 @@ Two authentication methods:
 Authorization: Bearer revops_YOUR_API_KEY
 ```
 
+Create API keys in **Workspace settings → API Keys**. The same page surfaces your **Workspace ID** (the value to substitute for `:wid` / `:workspaceId` / `WORKSPACE_ID` below) with a copy button.
+
 ### Auth Endpoints
 
 | Method | Endpoint             | Description                     |

--- a/docs/src/content/docs/console.md
+++ b/docs/src/content/docs/console.md
@@ -49,7 +49,7 @@ Saved consoles can be executed programmatically. This is useful for building das
 
 ### Authentication
 
-Create an API key in workspace settings. Include it in requests:
+Create an API key in **Workspace settings → API Keys**. The same page shows your **Workspace ID** with a copy button — substitute it for `WORKSPACE_ID` in the examples below. Include the key in requests:
 
 ```bash
 Authorization: Bearer revops_YOUR_API_KEY


### PR DESCRIPTION
PR #404 added a Workspace ID copy on the API Keys settings page. Up until now the docs left `WORKSPACE_ID` / `:wid` / `:workspaceId` as unexplained placeholders, so programmatic users had to dig URLs. This points them at the in-app source.

- `docs/src/content/docs/console.md` — Console API → Authentication: tell users API keys live in **Workspace settings → API Keys** and the same page exposes the Workspace ID with a copy button.
- `docs/src/content/docs/api-reference.md` — Authentication: same note, applied to all `:wid` / `:workspaceId` placeholders in the reference.

Build: `pnpm --filter docs run build` passes (19 pages, no warnings).