### PR TITLE
Allow async query runs without schedules

### DIFF
--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -1432,6 +1432,9 @@ function Editor({
       if (!response.success) {
         throw new Error(response.error || "Failed to run scheduled query");
       }
+      setTabBottomPanel(prev => ({ ...prev, [tabId]: "runs" }));
+      setSnackbarMessage("Async query run queued");
+      setSnackbarOpen(true);
       await loadScheduledRunsForTab(tabId);
     },
     [currentWorkspace, runScheduledNow, loadScheduledRunsForTab],
@@ -2246,7 +2249,7 @@ function Editor({
                                 <Tab
                                   value="runs"
                                   label={`Runs (${tab.scheduledRun?.runCount ?? 0})`}
-                                  disabled={!tab.schedule}
+                                  disabled={!tab.isSaved}
                                   disableRipple
                                   sx={{
                                     minHeight: 36,
@@ -2509,7 +2512,7 @@ function Editor({
               : undefined
           }
           onRunNow={
-            scheduleModalMode === "update" && scheduleModalHasSchedule
+            scheduleModalTab.isSaved
               ? async () => handleRunScheduledNow(scheduleModalTab.id)
               : undefined
           }

--- a/app/src/components/ScheduleConsoleModal.tsx
+++ b/app/src/components/ScheduleConsoleModal.tsx
@@ -196,8 +196,7 @@ export default function ScheduleConsoleModal({
 
   const isValid = Boolean(cron.trim()) && previewRuns.length > 0;
 
-  const title =
-    mode === "create" ? "Create scheduled query" : "Update scheduled query";
+  const title = mode === "create" ? "Schedule query" : "Update scheduled query";
 
   return (
     <Drawer
@@ -397,7 +396,7 @@ export default function ScheduleConsoleModal({
         </Box>
         <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
           <Button onClick={onClose}>Cancel</Button>
-          {mode === "update" && onRunNow && (
+          {onRunNow && (
             <Button onClick={handleRunNow} disabled={isRunningNow}>
               Run now
             </Button>


### PR DESCRIPTION
## Summary
- Enables `Run now` for saved consoles even when no schedule is attached.
- Opens the Runs panel and shows a queued snackbar after starting an async run.
- Allows the Runs tab for any saved console so manual async run history can be inspected.

## Test plan
- `pnpm --filter app run typecheck`
- `pnpm --filter app run lint`


Made with [Cursor](https://cursor.com)