### PR TITLE
Fix shared console location persistence

### DIFF
--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -553,6 +553,7 @@ consoleRoutes.post("/", async (c: Context) => {
       description,
       language,
       isPrivate,
+      access,
     } = body;
     const user = c.get("user");
 
@@ -641,6 +642,7 @@ consoleRoutes.post("/", async (c: Context) => {
         description,
         language,
         isPrivate,
+        access,
       },
     );
 
@@ -856,6 +858,22 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
         if (body.resultsViewMode !== undefined) {
           setFields.resultsViewMode = body.resultsViewMode;
         }
+        if (body.access !== undefined) {
+          setFields.access = body.access;
+          setFields.isPrivate = body.access === "private";
+        }
+
+        const setOnInsertFields: Record<string, any> = {
+          createdBy: user.id,
+          owner_id: user.id,
+          language: "sql" as const,
+          executionCount: 0,
+          createdAt: now,
+        };
+        if (body.access === undefined) {
+          setOnInsertFields.isPrivate = true;
+          setOnInsertFields.access = "private" as const;
+        }
 
         const result = await SavedConsole.findOneAndUpdate(
           {
@@ -865,15 +883,7 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
           {
             $set: setFields,
             $inc: { version: 1 },
-            $setOnInsert: {
-              createdBy: user.id,
-              owner_id: user.id,
-              language: "sql" as const,
-              isPrivate: true,
-              access: "private" as const,
-              executionCount: 0,
-              createdAt: now,
-            },
+            $setOnInsert: setOnInsertFields,
           },
           { upsert: true, new: true },
         );
@@ -919,6 +929,10 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
       if (body.resultsViewMode !== undefined) {
         setFields.resultsViewMode = body.resultsViewMode;
       }
+      if (body.access !== undefined) {
+        setFields.access = body.access;
+        setFields.isPrivate = body.access === "private";
+      }
 
       // If this is an explicit save without path (e.g., Cmd+S on already saved), mark as saved
       if (isExplicitSave) {
@@ -930,11 +944,13 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
           createdBy: user.id,
           owner_id: user.id,
           language: "sql" as const,
-          isPrivate: true,
-          access: "private" as const,
           executionCount: 0,
           createdAt: now,
         };
+        if (body.access === undefined) {
+          setOnInsertFields.isPrivate = true;
+          setOnInsertFields.access = "private" as const;
+        }
         // Only add name to $setOnInsert if not already in $set (avoid MongoDB conflict)
         if (!setFields.name) {
           setOnInsertFields.name = body.title || "Untitled";
@@ -1083,6 +1099,7 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
         description: body.description,
         language: body.language,
         isPrivate: body.isPrivate,
+        access: body.access,
       },
     );
 

--- a/api/src/utils/console-manager.ts
+++ b/api/src/utils/console-manager.ts
@@ -186,6 +186,35 @@ export class ConsoleManager {
   }
 
   /**
+   * Resolve the access level a user sees after folder inheritance.
+   */
+  async resolveAccessWithInheritance(
+    console: ISavedConsole,
+  ): Promise<ConsoleAccessLevel> {
+    const ownAccess = ConsoleManager.resolveAccess(console);
+    if (ownAccess === "workspace") return "workspace";
+
+    let currentFolderId = console.folderId?.toString();
+    while (currentFolderId) {
+      const folder = (await ConsoleFolder.findById(currentFolderId)
+        .select("access isPrivate parentId")
+        .lean()) as {
+        access?: ConsoleAccessLevel;
+        isPrivate?: boolean;
+        parentId?: Types.ObjectId;
+      } | null;
+      if (!folder) break;
+
+      const folderAccess =
+        folder.access || (folder.isPrivate ? "private" : "workspace");
+      if (folderAccess === "workspace") return "workspace";
+      currentFolderId = folder.parentId?.toString();
+    }
+
+    return "private";
+  }
+
+  /**
    * Get all consoles in a tree structure from database.
    * Only returns explicitly saved consoles (isSaved: true), not drafts.
    */
@@ -517,6 +546,9 @@ export class ConsoleManager {
           }
         }
 
+        const effectiveAccess =
+          await this.resolveAccessWithInheritance(savedConsole);
+
         return {
           content: savedConsole.code,
           connectionId: savedConsole.connectionId?.toString(),
@@ -529,7 +561,7 @@ export class ConsoleManager {
           isSaved: savedConsole.isSaved,
           chartSpec: savedConsole.chartSpec,
           resultsViewMode: savedConsole.resultsViewMode,
-          access: ConsoleManager.resolveAccess(savedConsole),
+          access: effectiveAccess,
           owner_id: savedConsole.owner_id || savedConsole.createdBy,
           _raw: savedConsole,
         };
@@ -708,6 +740,7 @@ export class ConsoleManager {
       description?: string;
       language?: "sql" | "javascript" | "mongodb";
       isPrivate?: boolean;
+      access?: ConsoleAccessLevel;
     },
   ): Promise<ISavedConsole> {
     try {
@@ -759,6 +792,14 @@ export class ConsoleManager {
         savedConsole = await SavedConsole.findOne(query);
       }
 
+      const requestedAccess =
+        options?.access ??
+        (options?.isPrivate === undefined
+          ? undefined
+          : options.isPrivate
+            ? "private"
+            : "workspace");
+
       if (savedConsole) {
         // Update existing console (draft -> saved)
         savedConsole.name = consoleName; // Update name (may change if draft is being saved with a path)
@@ -783,8 +824,9 @@ export class ConsoleManager {
           savedConsole.description = options.description;
         }
         if (options?.language) savedConsole.language = options.language;
-        if (options?.isPrivate !== undefined) {
-          savedConsole.isPrivate = options.isPrivate;
+        if (requestedAccess !== undefined) {
+          savedConsole.access = requestedAccess;
+          savedConsole.isPrivate = requestedAccess === "private";
         }
         // Backfill owner_id if missing
         if (!savedConsole.owner_id) {
@@ -800,7 +842,9 @@ export class ConsoleManager {
         await savedConsole.save();
       } else {
         // Create new console (explicitly saved)
-        const isPrivate = options?.isPrivate || false;
+        const access =
+          options?.access ?? (options?.isPrivate ? "private" : "workspace");
+        const isPrivate = access === "private";
         const consoleData: any = {
           workspaceId: new Types.ObjectId(workspaceId),
           folderId: folderId ? new Types.ObjectId(folderId) : undefined,
@@ -814,10 +858,10 @@ export class ConsoleManager {
           code: content,
           language: options?.language || this.detectLanguage(content),
           createdBy: userId,
-          isPrivate: isPrivate,
+          isPrivate,
           isSaved: true,
           executionCount: 0,
-          access: (isPrivate ? "private" : "workspace") as ConsoleAccessLevel,
+          access,
           owner_id: userId,
         };
 

--- a/app/src/components/ConsoleExplorer.tsx
+++ b/app/src/components/ConsoleExplorer.tsx
@@ -37,6 +37,7 @@ import {
   type ConsoleEntry,
   type ConsoleSearchResult,
 } from "../store/consoleTreeStore";
+import { useConsoleStore } from "../store/consoleStore";
 import { useConsoleContentStore } from "../store/consoleContentStore";
 import { filterTree } from "../store/lib/tree-helpers";
 import FileExplorerDialog from "./FileExplorerDialog";
@@ -77,6 +78,9 @@ function ConsoleExplorer(
   const clearSearch = useConsoleTreeStore(state => state.clearSearch);
   const searchResults = useConsoleTreeStore(state => state.searchResults);
   const searchLoading = useConsoleTreeStore(state => state.searchLoading);
+  const updateTabFilePath = useConsoleStore(state => state.updateFilePath);
+  const updateTabTitle = useConsoleStore(state => state.updateTitle);
+  const updateTabAccess = useConsoleStore(state => state.updateAccess);
   const myConsolesMap = useConsoleTreeStore(state => state.myConsoles);
   const sharedWithWorkspaceMap = useConsoleTreeStore(
     state => state.sharedWithWorkspace,
@@ -311,6 +315,37 @@ function ConsoleExplorer(
     return null;
   };
 
+  const getSectionForItem = (item: ConsoleEntry): "my" | "workspace" => {
+    if (!item.id) return "my";
+    const inWorkspace = findParentFolderId(sharedWithWorkspace, item.id);
+    return inWorkspace !== undefined ? "workspace" : "my";
+  };
+
+  const findFolderPathById = (
+    nodes: ConsoleEntry[],
+    folderId: string,
+  ): string | null => {
+    for (const node of nodes) {
+      if (node.id === folderId && node.isDirectory) return node.path;
+      if (node.isDirectory && node.children) {
+        const found = findFolderPathById(node.children, folderId);
+        if (found) return found;
+      }
+    }
+    return null;
+  };
+
+  const getPathForMoveTarget = (
+    targetFolderId: string | null,
+    section: "my" | "workspace",
+    itemName: string,
+  ): string => {
+    if (!targetFolderId) return itemName;
+    const tree = section === "workspace" ? sharedWithWorkspace : myConsoles;
+    const folderPath = findFolderPathById(tree, targetFolderId);
+    return folderPath ? `${folderPath}/${itemName}` : itemName;
+  };
+
   const handleMoveTo = (item: ConsoleEntry) => {
     setSelectedItem(item);
     setExplorerDialogOpen(true);
@@ -319,6 +354,7 @@ function ConsoleExplorer(
   const handleMoveConfirm = async (
     targetFolderId: string | null,
     newName?: string,
+    section: "my" | "workspace" = "my",
   ) => {
     if (!currentWorkspace || !selectedItem?.id) return;
 
@@ -333,9 +369,33 @@ function ConsoleExplorer(
     }
 
     if (selectedItem.isDirectory) {
-      await moveFolder(currentWorkspace.id, selectedItem.id, targetFolderId);
+      await moveFolder(
+        currentWorkspace.id,
+        selectedItem.id,
+        targetFolderId,
+        section === "workspace" ? "workspace" : "private",
+      );
     } else {
-      await moveConsole(currentWorkspace.id, selectedItem.id, targetFolderId);
+      const success = await moveConsole(
+        currentWorkspace.id,
+        selectedItem.id,
+        targetFolderId,
+        section === "workspace" ? "workspace" : "private",
+      );
+      if (success) {
+        const nextName = newName || selectedItem.name;
+        const nextPath = getPathForMoveTarget(
+          targetFolderId,
+          section,
+          nextName,
+        );
+        updateTabFilePath(selectedItem.id, nextPath);
+        updateTabTitle(selectedItem.id, nextPath);
+        updateTabAccess(
+          selectedItem.id,
+          section === "workspace" ? "workspace" : "private",
+        );
+      }
     }
 
     setExplorerDialogOpen(false);
@@ -636,6 +696,7 @@ function ConsoleExplorer(
         initialFolderId={
           selectedItem ? getParentFolderIdForItem(selectedItem) : null
         }
+        initialSection={selectedItem ? getSectionForItem(selectedItem) : "my"}
       />
     </>
   );

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -441,6 +441,7 @@ function Editor({
     databaseId?: string;
     databaseName?: string;
     comment?: string;
+    access?: "private" | "workspace";
   } | null>(null);
 
   // Refs for query cancellation (per-tab to support parallel queries)
@@ -456,6 +457,7 @@ function Editor({
   const updateConnection = useConsoleStore(state => state.updateConnection);
   const updateDatabase = useConsoleStore(state => state.updateDatabase);
   const updateFilePath = useConsoleStore(state => state.updateFilePath);
+  const updateAccess = useConsoleStore(state => state.updateAccess);
   const updateTitle = useConsoleStore(state => state.updateTitle);
   const updateDirty = useConsoleStore(state => state.updateDirty);
   const updateSavedState = useConsoleStore(state => state.updateSavedState);
@@ -1178,6 +1180,7 @@ function Editor({
         tabChartSpecs[tabId] ?? undefined,
         tabViewModes[tabId],
         comment,
+        currentTab?.access,
       );
 
       // Handle conflict - show resolution dialog
@@ -1190,6 +1193,7 @@ function Editor({
           databaseId,
           databaseName,
           comment,
+          access: currentTab?.access,
         });
         setConflictData(result.conflict);
         setConflictDialogOpen(true);
@@ -1201,6 +1205,7 @@ function Editor({
         // Update file path and title
         updateFilePath(tabId, savePath);
         updateTitle(tabId, savePath);
+        updateAccess(tabId, currentTab?.access);
         updateDirty(tabId, true);
 
         // Update saved state (isSaved=true, new savedStateHash)
@@ -1500,6 +1505,7 @@ function Editor({
         tabChartSpecs[pendingSaveData.tabId] ?? undefined,
         tabViewModes[pendingSaveData.tabId],
         pendingSaveData.comment,
+        pendingSaveData.access,
       );
 
       if (result.success) {
@@ -1508,6 +1514,7 @@ function Editor({
         // Update the tab properties
         updateFilePath(tabId, pendingSaveData.path);
         updateTitle(tabId, pendingSaveData.path);
+        updateAccess(tabId, pendingSaveData.access);
         updateDirty(tabId, true);
 
         // Update saved state (isSaved=true, new savedStateHash)
@@ -1552,7 +1559,7 @@ function Editor({
   const handleSaveDialogConfirm = async (
     name: string,
     folderId: string | null,
-    _section: "my" | "workspace",
+    section: "my" | "workspace",
   ) => {
     if (!saveDialogTabId || !currentWorkspace) return;
     setSaveDialogOpen(false);
@@ -1583,6 +1590,8 @@ function Editor({
           databaseId,
           tabChartSpecs[saveDialogTabId] ?? undefined,
           tabViewModes[saveDialogTabId],
+          undefined,
+          section === "workspace" ? "workspace" : "private",
         );
 
         if (result.error === "conflict" && result.conflict) {
@@ -1593,6 +1602,7 @@ function Editor({
             connectionId,
             databaseId,
             databaseName,
+            access: section === "workspace" ? "workspace" : "private",
           });
           setConflictData(result.conflict);
           setConflictDialogOpen(true);
@@ -1603,6 +1613,10 @@ function Editor({
         if (result.success) {
           updateFilePath(targetId, savePath);
           updateTitle(targetId, savePath);
+          updateAccess(
+            targetId,
+            section === "workspace" ? "workspace" : "private",
+          );
           updateDirty(targetId, true);
 
           const newHash = computeConsoleStateHash(
@@ -1648,6 +1662,8 @@ function Editor({
             databaseName,
             databaseId,
             folderId: folderId || undefined,
+            access: section === "workspace" ? "workspace" : "private",
+            isPrivate: section !== "workspace",
             chartSpec: tabChartSpecs[saveDialogTabId] ?? null,
             resultsViewMode: tabViewModes[saveDialogTabId],
             comment: "",
@@ -1665,6 +1681,7 @@ function Editor({
           connectionId,
           databaseId,
           databaseName,
+          access: section === "workspace" ? "workspace" : "private",
         });
         setConflictData(result.conflict);
         setConflictDialogOpen(true);
@@ -1687,6 +1704,10 @@ function Editor({
           // "new" — first-time save of a draft; update the originating tab.
           updateFilePath(targetId, savePath);
           updateTitle(targetId, savePath);
+          updateAccess(
+            targetId,
+            section === "workspace" ? "workspace" : "private",
+          );
           updateDirty(targetId, true);
 
           const newHash = computeConsoleStateHash(
@@ -2453,6 +2474,11 @@ function Editor({
           }
           return tab.title || "";
         })()}
+        initialSection={
+          saveDialogTabId && tabs[saveDialogTabId]?.access === "workspace"
+            ? "workspace"
+            : "my"
+        }
         isSaving={isSaving}
       />
 

--- a/app/src/components/FileExplorerDialog.tsx
+++ b/app/src/components/FileExplorerDialog.tsx
@@ -35,8 +35,12 @@ interface FileExplorerDialogProps {
   defaultName?: string;
   isSaving?: boolean;
 
-  /** move mode: called with (targetFolderId, newName) */
-  onMove?: (targetFolderId: string | null, newName?: string) => void;
+  /** move mode: called with (targetFolderId, newName, section) */
+  onMove?: (
+    targetFolderId: string | null,
+    newName?: string,
+    section?: "my" | "workspace",
+  ) => void;
   itemName?: string;
   isDirectory?: boolean;
 
@@ -45,6 +49,7 @@ interface FileExplorerDialogProps {
 
   /** Pre-select this folder on open (e.g. the item's current parent) */
   initialFolderId?: string | null;
+  initialSection?: "my" | "workspace";
 }
 
 export default function FileExplorerDialog({
@@ -58,6 +63,7 @@ export default function FileExplorerDialog({
   itemName = "",
   onNewFolder,
   initialFolderId,
+  initialSection,
   isDirectory = false,
 }: FileExplorerDialogProps) {
   const { currentWorkspace } = useWorkspace();
@@ -83,10 +89,10 @@ export default function FileExplorerDialog({
       setConsoleName(effectiveName);
       setFolderName("");
       setSelectedFolderId(initialFolderId ?? null);
-      setSelectedSection("my");
+      setSelectedSection(initialSection ?? "my");
       setOverwriteConfirm(false);
     }
-  }, [open, effectiveName, initialFolderId]);
+  }, [open, effectiveName, initialFolderId, initialSection]);
 
   const handleLocationChange = (
     folderId: string | null,
@@ -156,7 +162,11 @@ export default function FileExplorerDialog({
     } else if (mode === "move") {
       const newName = consoleName.trim();
       const nameChanged = newName && newName !== itemName;
-      onMove?.(selectedFolderId, nameChanged ? newName : undefined);
+      onMove?.(
+        selectedFolderId,
+        nameChanged ? newName : undefined,
+        selectedSection,
+      );
     } else if (mode === "new-folder") {
       if (!folderName.trim()) return;
       onNewFolder?.(selectedFolderId, folderName.trim());

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -61,6 +61,7 @@ interface ConsoleActions {
     databaseName?: string,
   ) => void;
   updateFilePath: (id: string, filePath: string) => void;
+  updateAccess: (id: string, access?: "private" | "workspace") => void;
   updateSavedState: (
     id: string,
     isSaved: boolean,
@@ -98,6 +99,7 @@ interface ConsoleActions {
     chartSpec?: Record<string, unknown>,
     resultsViewMode?: string,
     comment?: string,
+    access?: "private" | "workspace",
   ) => Promise<ConsoleSaveResponse>;
   deleteConsole: (
     workspaceId: string,
@@ -417,6 +419,15 @@ export const useConsoleStore = create<ConsoleStore>()(
           }
         }),
 
+      updateAccess: (id, access) =>
+        set(state => {
+          const tab = state.tabs[id];
+          if (tab) {
+            if (tab.access === access) return;
+            tab.access = access;
+          }
+        }),
+
       updateSavedState: (id, isSaved, savedStateHash) =>
         set(state => {
           const tab = state.tabs[id];
@@ -612,6 +623,7 @@ export const useConsoleStore = create<ConsoleStore>()(
         chartSpec,
         resultsViewMode,
         comment,
+        access,
       ) => {
         try {
           const cleanPath = path.endsWith(".js") ? path.slice(0, -3) : path;
@@ -631,6 +643,9 @@ export const useConsoleStore = create<ConsoleStore>()(
                 chartSpec: chartSpec ?? null,
                 resultsViewMode,
                 comment: comment ?? "",
+                access,
+                isPrivate:
+                  access === undefined ? undefined : access === "private",
               }),
             },
           );


### PR DESCRIPTION
## Summary
- Preserve the selected My Consoles vs Workspace section when moving or saving consoles.
- Persist console access during create/update flows so shared consoles stay in the workspace tree after resave.
- Resolve inherited workspace access for opened consoles and update open-tab breadcrumbs immediately after moves/saves.

## Test plan
- pnpm --filter app run typecheck
- pnpm --filter app run lint
- pnpm --filter api run lint


Made with [Cursor](https://cursor.com)