### PR TITLE
docs: document async Run now + EMAIL_LOGO_URL env var

### DIFF
--- a/docs/src/content/docs/console.md
+++ b/docs/src/content/docs/console.md
@@ -41,7 +41,17 @@ Consoles can be organized into folders. Use the sidebar tree to drag and arrange
 
 Workspace admins can schedule a saved console to run automatically from the console header. Scheduled consoles use five-field cron expressions plus an IANA timezone, for example `0 0 * * *` with `UTC` for a daily midnight run.
 
-When a console is scheduled, Mako stores the next run time and executes it through Inngest. The schedule panel shows the latest run status, duration, row count, consecutive failures, and recent run history. Admins can also trigger a scheduled console manually with **Run now**. You can attach **notifications** to a schedule (email, webhook, or Slack) — see [Notifications](/notifications/).
+When a console is scheduled, Mako stores the next run time and executes it through Inngest. The schedule panel shows the latest run status, duration, row count, consecutive failures, and recent run history. You can attach **notifications** to a schedule (email, webhook, or Slack) — see [Notifications](/notifications/).
+
+### Async Runs (Run now)
+
+**Run now** triggers an asynchronous run of any saved console — no schedule required. Each run is queued through Inngest, executes in the background, and is recorded in the **Runs** tab below the editor. Use this to:
+
+- Test a query end-to-end before attaching a schedule (notifications, retry behavior, row counts).
+- Kick off a one-off backfill or ad-hoc refresh without blocking your editor session.
+- Re-run a scheduled query immediately, off-cycle.
+
+The Runs tab is enabled for any saved console and shows historical runs alongside scheduled ones. Triggering an async run requires workspace admin access and hits `POST /api/workspaces/:wid/consoles/:id/schedule/run`.
 
 ## Console API
 

--- a/docs/src/content/docs/deployment.md
+++ b/docs/src/content/docs/deployment.md
@@ -69,6 +69,7 @@ Set these in Cloud Run's environment configuration (or via `cloud-run-env.yaml`)
 | `GOOGLE_CLIENT_ID` + `SECRET`  | Optional    | Google OAuth                             |
 | `GH_CLIENT_ID` + `SECRET`      | Optional    | GitHub OAuth                             |
 | `SENDGRID_API_KEY`             | Optional    | Email invitations                        |
+| `EMAIL_LOGO_URL`               | Optional    | Logo for run-notification emails (default: `https://app.mako.ai/email/mako-logo.png`). Override for self-hosted/staging. |
 | `BILLING_ENABLED`              | Optional    | Set `true` to enable Stripe billing (default: `false`) |
 | `STRIPE_SECRET_KEY`            | Optional    | Stripe secret key (required if billing enabled) |
 | `STRIPE_WEBHOOK_SECRET`        | Optional    | Stripe webhook signing secret |


### PR DESCRIPTION
## What

Two small doc gaps from yesterday's master commits.

### 1. `console.md` — async Run now (#412)

#412 changed Run now / async run behavior:

- **Before:** the Runs tab and Run now were gated on having an active schedule (`disabled={!tab.schedule}`, `scheduleModalMode === 'update' && scheduleModalHasSchedule`).
- **After:** any saved console can be run asynchronously through Inngest. Gated only on `isSaved`. The schedule modal title flipped from 'Create scheduled query' to 'Schedule query' to reflect this.

The current docs still say "Admins can also trigger a scheduled console manually with **Run now**" — implies scheduling is a prerequisite, which is no longer true. Rewrote the paragraph and added a small "Async Runs (Run now)" subsection covering when to use it (test before scheduling, ad-hoc backfill, off-cycle re-run) and the endpoint (`POST /api/workspaces/:wid/consoles/:id/schedule/run`).

### 2. `deployment.md` — `EMAIL_LOGO_URL` (#413)

#413 added the `EMAIL_LOGO_URL` env var (defaults to `https://app.mako.ai/email/mako-logo.png`, override for staging / self-hosted). Documented in `.env.example` but missing from the deployment env table — meaning self-hosted deploys that can't reach `app.mako.ai` would silently render broken logos in run-notification emails. Added a row.

## Validation

- `pnpm --filter docs run build` passes — 20 pages, no new warnings.

## Out of scope

- #405 (mui-chips-input recipient UX): internal UI fix; notifications API still takes a JSON `recipients` array, no doc change.
- #414 (console workspace location persistence): adds an internal `access` field to the app-only POST/PUT routes; not part of the public Console API surface in docs.