### PR TITLE
Public dashboard publishing (share token + read-only view)

### DIFF
--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -2843,6 +2843,15 @@ export interface IDashboard extends Document {
   createdBy: string;
   createdAt: Date;
   updatedAt: Date;
+
+  /** Public read-only share (opaque token hash + frozen snapshot). */
+  published?: {
+    enabled: boolean;
+    tokenHash: string;
+    publishedAt: Date;
+    publishedBy: string;
+    snapshot: Record<string, unknown>;
+  };
 }
 
 /**
@@ -3167,6 +3176,20 @@ const DashboardSchema = new Schema<IDashboard>(
     },
     owner_id: { type: String },
     createdBy: { type: String, required: true },
+
+    published: {
+      type: new Schema(
+        {
+          enabled: { type: Boolean, required: true },
+          tokenHash: { type: String, required: true },
+          publishedAt: { type: Date, required: true },
+          publishedBy: { type: String, required: true },
+          snapshot: { type: Schema.Types.Mixed, required: true },
+        },
+        { _id: false },
+      ),
+      required: false,
+    },
   },
   {
     collection: "dashboards",
@@ -3177,6 +3200,16 @@ const DashboardSchema = new Schema<IDashboard>(
 DashboardSchema.index({ workspaceId: 1 });
 DashboardSchema.index({ workspaceId: 1, createdBy: 1 });
 DashboardSchema.index({ workspaceId: 1, access: 1, owner_id: 1 });
+DashboardSchema.index(
+  { "published.tokenHash": 1 },
+  {
+    unique: true,
+    partialFilterExpression: {
+      "published.enabled": true,
+      "published.tokenHash": { $type: "string" },
+    },
+  },
+);
 
 /**
  * DashboardFolder Schema

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -39,6 +39,7 @@ import { billingRoutes } from "./routes/billing";
 import { stripeWebhookRoutes } from "./routes/stripe-webhook";
 import { dashboardRoutes } from "./routes/dashboards";
 import { dashboardMaterializationRoutes } from "./routes/dashboard-materialization";
+import { publicDashboardRoutes } from "./routes/public-dashboards";
 import { scheduledQueryRoutes } from "./routes/scheduled-queries";
 import { notificationRulesRoutes } from "./routes/notification-rules";
 import { devEmailPreviewRoutes } from "./routes/dev-email-preview.routes";
@@ -110,6 +111,7 @@ app.get("/health", c => {
 
 // API routes
 app.route("/api/auth", authRoutes);
+app.route("/api/public/dashboards", publicDashboardRoutes);
 app.route("/api/workspaces", workspaceRoutes);
 app.route("/api/workspaces/:workspaceId/databases", workspaceDatabaseRoutes);
 app.route("/api/workspaces/:workspaceId/execute", workspaceExecuteRoutes);

--- a/api/src/routes/dashboards.ts
+++ b/api/src/routes/dashboards.ts
@@ -208,6 +208,7 @@ function sanitizeDashboardResponse<
   T extends Record<string, any> & {
     dataSources?: Array<Record<string, unknown>>;
     materializationSchedule?: unknown;
+    published?: unknown;
   },
 >(dashboard: T): T {
   delete dashboard.materializationMode;

--- a/api/src/routes/dashboards.ts
+++ b/api/src/routes/dashboards.ts
@@ -25,6 +25,11 @@ import {
   validateDashboardMaterializationSchedule,
 } from "../services/dashboard-materialization-schedule.service";
 import { queueDashboardArtifactRefresh } from "../services/dashboard-refresh-runner.service";
+import {
+  buildDashboardPublishedSnapshot,
+  hashDashboardShareToken,
+  newDashboardShareToken,
+} from "../services/dashboard-publish.service";
 import { DashboardManager } from "../utils/dashboard-manager";
 import {
   createVersion,
@@ -228,6 +233,13 @@ function sanitizeDashboardResponse<
         return next;
       },
     );
+  }
+  if (dashboard.published && typeof dashboard.published === "object") {
+    const p = dashboard.published as Record<string, unknown>;
+    dashboard.published = {
+      enabled: Boolean(p.enabled),
+      ...(p.publishedAt ? { publishedAt: p.publishedAt } : {}),
+    } as typeof dashboard.published;
   }
   return dashboard;
 }
@@ -501,6 +513,124 @@ app.get("/:id", async (c: AuthenticatedContext) => {
     });
   } catch (error) {
     logger.error("Error getting dashboard", { error });
+    return c.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      },
+      500,
+    );
+  }
+});
+
+// POST /api/workspaces/:workspaceId/dashboards/:id/publish — public share (materialized snapshot)
+app.post("/:id/publish", async (c: AuthenticatedContext) => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const id = c.req.param("id");
+
+    if (!Types.ObjectId.isValid(id)) {
+      return c.json({ success: false, error: "Invalid dashboard ID" }, 400);
+    }
+
+    const dashboard = await Dashboard.findOne({
+      _id: new Types.ObjectId(id),
+      workspaceId: new Types.ObjectId(workspaceId),
+    });
+
+    if (!dashboard) {
+      return c.json({ success: false, error: "Dashboard not found" }, 404);
+    }
+
+    const userId = c.get("user")?.id;
+    if (!userId) {
+      return c.json({ success: false, error: "Unauthorized" }, 401);
+    }
+    const memberRole = c.get("memberRole");
+    const isAdmin = memberRole === "owner" || memberRole === "admin";
+    if (!DashboardManager.canWrite(dashboard, userId, isAdmin)) {
+      return c.json(
+        { success: false, error: "You do not have permission to publish" },
+        403,
+      );
+    }
+
+    const built = await buildDashboardPublishedSnapshot(dashboard);
+    if (!built.ok) {
+      return c.json({ success: false, error: built.error }, 400);
+    }
+
+    const shareToken = newDashboardShareToken();
+    const tokenHash = hashDashboardShareToken(shareToken);
+
+    dashboard.set("published", {
+      enabled: true,
+      tokenHash,
+      publishedAt: new Date(),
+      publishedBy: userId,
+      snapshot: built.snapshot,
+    });
+    await dashboard.save();
+
+    return c.json({
+      success: true,
+      data: {
+        shareToken,
+        publicPath: `/p/d/${shareToken}`,
+      },
+    });
+  } catch (error) {
+    logger.error("Error publishing dashboard", { error });
+    return c.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      },
+      500,
+    );
+  }
+});
+
+// DELETE /api/workspaces/:workspaceId/dashboards/:id/publish — revoke public share
+app.delete("/:id/publish", async (c: AuthenticatedContext) => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const id = c.req.param("id");
+
+    if (!Types.ObjectId.isValid(id)) {
+      return c.json({ success: false, error: "Invalid dashboard ID" }, 400);
+    }
+
+    const dashboard = await Dashboard.findOne({
+      _id: new Types.ObjectId(id),
+      workspaceId: new Types.ObjectId(workspaceId),
+    });
+
+    if (!dashboard) {
+      return c.json({ success: false, error: "Dashboard not found" }, 404);
+    }
+
+    const userId = c.get("user")?.id;
+    if (!userId) {
+      return c.json({ success: false, error: "Unauthorized" }, 401);
+    }
+    const memberRole = c.get("memberRole");
+    const isAdmin = memberRole === "owner" || memberRole === "admin";
+    if (!DashboardManager.canWrite(dashboard, userId, isAdmin)) {
+      return c.json(
+        { success: false, error: "You do not have permission to unpublish" },
+        403,
+      );
+    }
+
+    await Dashboard.updateOne(
+      { _id: dashboard._id },
+      { $unset: { published: "" } },
+    );
+
+    return c.json({ success: true });
+  } catch (error) {
+    logger.error("Error unpublishing dashboard", { error });
     return c.json(
       {
         success: false,

--- a/api/src/routes/dashboards.ts
+++ b/api/src/routes/dashboards.ts
@@ -27,6 +27,7 @@ import {
 import { queueDashboardArtifactRefresh } from "../services/dashboard-refresh-runner.service";
 import {
   buildDashboardPublishedSnapshot,
+  ensureDashboardMaterializedForPublish,
   hashDashboardShareToken,
   newDashboardShareToken,
 } from "../services/dashboard-publish.service";
@@ -556,7 +557,15 @@ app.post("/:id/publish", async (c: AuthenticatedContext) => {
       );
     }
 
-    const built = await buildDashboardPublishedSnapshot(dashboard);
+    const ensured = await ensureDashboardMaterializedForPublish(
+      dashboard._id.toString(),
+      workspaceId,
+    );
+    if (!ensured.ok) {
+      return c.json({ success: false, error: ensured.error }, 400);
+    }
+
+    const built = await buildDashboardPublishedSnapshot(ensured.dashboard);
     if (!built.ok) {
       return c.json({ success: false, error: built.error }, 400);
     }
@@ -564,14 +573,14 @@ app.post("/:id/publish", async (c: AuthenticatedContext) => {
     const shareToken = newDashboardShareToken();
     const tokenHash = hashDashboardShareToken(shareToken);
 
-    dashboard.set("published", {
+    ensured.dashboard.set("published", {
       enabled: true,
       tokenHash,
       publishedAt: new Date(),
       publishedBy: userId,
       snapshot: built.snapshot,
     });
-    await dashboard.save();
+    await ensured.dashboard.save();
 
     return c.json({
       success: true,

--- a/api/src/routes/public-dashboards.ts
+++ b/api/src/routes/public-dashboards.ts
@@ -90,7 +90,8 @@ app.get("/:token", async c => {
     if (!doc?.published?.snapshot) {
       return c.json({ success: false, error: "Dashboard not found" }, 404);
     }
-    const snapshot = doc.published.snapshot as DashboardPublishedSnapshotDoc;
+    const snapshot = doc.published
+      .snapshot as unknown as DashboardPublishedSnapshotDoc;
     const data = embedPayloadFromPublishedSnapshot(snapshot, token);
     return c.json({ success: true, data });
   } catch (error) {
@@ -113,7 +114,8 @@ app.get("/:token/artifacts/:dataSourceId", async c => {
     if (!doc?.published?.snapshot) {
       return c.json({ success: false, error: "Dashboard not found" }, 404);
     }
-    const snapshot = doc.published.snapshot as DashboardPublishedSnapshotDoc;
+    const snapshot = doc.published
+      .snapshot as unknown as DashboardPublishedSnapshotDoc;
     const artifact = snapshot.artifacts?.find(
       a => a.dataSourceId === dataSourceId,
     );

--- a/api/src/routes/public-dashboards.ts
+++ b/api/src/routes/public-dashboards.ts
@@ -1,0 +1,214 @@
+/**
+ * Intentionally public routes — no auth middleware.
+ * Mounted at /api/public/dashboards
+ */
+import fs, { promises as fsPromises } from "fs";
+import { Hono } from "hono";
+import { loggers } from "../logging";
+import { Dashboard } from "../database/workspace-schema";
+import {
+  embedPayloadFromPublishedSnapshot,
+  hashDashboardShareToken,
+  type DashboardPublishedSnapshotDoc,
+} from "../services/dashboard-publish.service";
+import {
+  getDashboardArtifactStore,
+  getDashboardArtifactStoreType,
+  getFilesystemArtifactPath,
+} from "../services/dashboard-artifact-store.service";
+
+const logger = loggers.api("public-dashboards");
+const app = new Hono();
+
+function nodeStreamToWeb(
+  nodeStream: NodeJS.ReadableStream,
+): ReadableStream<Uint8Array> {
+  let closed = false;
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      nodeStream.on("data", (chunk: Buffer) => {
+        if (!closed) {
+          controller.enqueue(new Uint8Array(chunk));
+          if (controller.desiredSize !== null && controller.desiredSize <= 0) {
+            (
+              nodeStream as NodeJS.ReadableStream & { pause?: () => void }
+            ).pause?.();
+          }
+        }
+      });
+      nodeStream.on("end", () => {
+        if (!closed) {
+          closed = true;
+          controller.close();
+        }
+      });
+      nodeStream.on("error", (err: Error) => {
+        if (!closed) {
+          closed = true;
+          controller.error(err);
+        }
+      });
+    },
+    pull() {
+      (
+        nodeStream as NodeJS.ReadableStream & { resume?: () => void }
+      ).resume?.();
+    },
+    cancel() {
+      closed = true;
+      if ("destroy" in nodeStream && typeof nodeStream.destroy === "function") {
+        (
+          nodeStream as NodeJS.ReadableStream & { destroy?: () => void }
+        ).destroy?.();
+      }
+    },
+  });
+}
+
+function parseRangeHeader(rangeHeader: string, size: number) {
+  const match = rangeHeader.match(/bytes=(\d*)-(\d*)/);
+  if (!match) return null;
+  const start = match[1] ? Number(match[1]) : 0;
+  const end = match[2] ? Number(match[2]) : size - 1;
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return null;
+  if (start < 0 || end < start || end >= size) return null;
+  return { start, end };
+}
+
+async function findPublishedDashboardByToken(token: string) {
+  const tokenHash = hashDashboardShareToken(token);
+  return Dashboard.findOne({
+    "published.enabled": true,
+    "published.tokenHash": tokenHash,
+  }).lean();
+}
+
+app.get("/:token", async c => {
+  try {
+    const token = c.req.param("token");
+    const doc = await findPublishedDashboardByToken(token);
+    if (!doc?.published?.snapshot) {
+      return c.json({ success: false, error: "Dashboard not found" }, 404);
+    }
+    const snapshot = doc.published.snapshot as DashboardPublishedSnapshotDoc;
+    const data = embedPayloadFromPublishedSnapshot(snapshot, token);
+    return c.json({ success: true, data });
+  } catch (error) {
+    logger.error("Failed to load public dashboard", { error });
+    return c.json(
+      {
+        success: false,
+        error: "Dashboard not found",
+      },
+      404,
+    );
+  }
+});
+
+app.get("/:token/artifacts/:dataSourceId", async c => {
+  try {
+    const token = c.req.param("token");
+    const dataSourceId = c.req.param("dataSourceId");
+    const doc = await findPublishedDashboardByToken(token);
+    if (!doc?.published?.snapshot) {
+      return c.json({ success: false, error: "Dashboard not found" }, 404);
+    }
+    const snapshot = doc.published.snapshot as DashboardPublishedSnapshotDoc;
+    const artifact = snapshot.artifacts?.find(
+      a => a.dataSourceId === dataSourceId,
+    );
+    if (!artifact?.artifactKey) {
+      return c.json({ success: false, error: "Dashboard not found" }, 404);
+    }
+
+    const requestRevision = c.req.query("rev");
+    const isRevisionedRequest =
+      !!requestRevision &&
+      !!artifact.artifactRevision &&
+      requestRevision === artifact.artifactRevision;
+
+    const store = getDashboardArtifactStore();
+
+    if (getDashboardArtifactStoreType() === "filesystem") {
+      const filePath = getFilesystemArtifactPath(artifact.artifactKey);
+      let stat;
+      try {
+        stat = await fsPromises.stat(filePath);
+      } catch {
+        return c.json({ success: false, error: "Dashboard not found" }, 404);
+      }
+
+      const rangeHeader = c.req.header("range");
+      const cacheControl = isRevisionedRequest
+        ? "public, max-age=86400, immutable"
+        : "public, no-store";
+      const headers: Record<string, string> = {
+        "Content-Type": "application/vnd.apache.parquet",
+        "Accept-Ranges": "bytes",
+        "Cache-Control": cacheControl,
+      };
+
+      if (!rangeHeader) {
+        headers["Content-Length"] = String(stat.size);
+        headers["X-Row-Count"] = String(artifact.rowCount ?? "");
+        const nodeStream =
+          (await store.openReadStream(artifact.artifactKey)) ||
+          fs.createReadStream(filePath);
+        return c.body(nodeStreamToWeb(nodeStream), 200, headers);
+      }
+
+      const range = parseRangeHeader(rangeHeader, stat.size);
+      if (!range) {
+        return c.text("Invalid range", 416);
+      }
+
+      headers["Content-Range"] =
+        `bytes ${range.start}-${range.end}/${stat.size}`;
+      headers["Content-Length"] = String(range.end - range.start + 1);
+      headers["X-Row-Count"] = String(artifact.rowCount ?? "");
+      return c.body(
+        nodeStreamToWeb(
+          fs.createReadStream(filePath, {
+            start: range.start,
+            end: range.end,
+          }),
+        ),
+        206,
+        headers,
+      );
+    }
+
+    const stream = await store.openReadStream(artifact.artifactKey);
+    if (stream) {
+      const cacheControl = isRevisionedRequest
+        ? "public, max-age=86400, immutable"
+        : "public, no-store";
+      const headers: Record<string, string> = {
+        "Content-Type": "application/vnd.apache.parquet",
+        "Cache-Control": cacheControl,
+        "X-Row-Count": String(artifact.rowCount ?? ""),
+      };
+
+      const size =
+        artifact.byteSize ?? (await store.getSize(artifact.artifactKey));
+      if (size) {
+        headers["Content-Length"] = String(size);
+      }
+
+      return c.body(nodeStreamToWeb(stream), 200, headers);
+    }
+
+    return c.json({ success: false, error: "Dashboard not found" }, 404);
+  } catch (error) {
+    logger.error("Failed to stream public dashboard artifact", { error });
+    return c.json(
+      {
+        success: false,
+        error: "Dashboard not found",
+      },
+      404,
+    );
+  }
+});
+
+export const publicDashboardRoutes = app;

--- a/api/src/services/dashboard-publish.service.ts
+++ b/api/src/services/dashboard-publish.service.ts
@@ -1,0 +1,112 @@
+import crypto from "crypto";
+import type { IDashboard } from "../database/workspace-schema";
+import { buildDashboardMaterializationStatus } from "./dashboard-materialization.service";
+
+export function hashDashboardShareToken(token: string): string {
+  return crypto.createHash("sha256").update(token, "utf8").digest("hex");
+}
+
+export function newDashboardShareToken(): string {
+  return crypto.randomBytes(32).toString("base64url");
+}
+
+export interface DashboardPublishedArtifactSnapshot {
+  dataSourceId: string;
+  name: string;
+  artifactKey: string;
+  artifactRevision: string | null;
+  rowCount: number | null;
+  byteSize: number | null;
+}
+
+export interface DashboardPublishedSnapshotDoc {
+  title: string;
+  layout: { columns: number; rowHeight: number };
+  theme?: "light" | "dark";
+  widgets: Array<Record<string, unknown>>;
+  artifacts: DashboardPublishedArtifactSnapshot[];
+}
+
+export async function buildDashboardPublishedSnapshot(
+  dashboard: IDashboard,
+): Promise<
+  | { ok: true; snapshot: DashboardPublishedSnapshotDoc }
+  | { ok: false; error: string }
+> {
+  if (!dashboard.dataSources?.length) {
+    return { ok: false, error: "Dashboard has no data sources to publish." };
+  }
+
+  const status = await buildDashboardMaterializationStatus(dashboard);
+  if (!status.allReady) {
+    return {
+      ok: false,
+      error:
+        "All data sources must be materialized (ready) before publishing. Run materialization and try again.",
+    };
+  }
+
+  const artifacts: DashboardPublishedArtifactSnapshot[] = [];
+  for (const ds of status.dataSources) {
+    if (!ds.artifactKey) {
+      return {
+        ok: false,
+        error: `Missing artifact for data source "${ds.name}".`,
+      };
+    }
+    artifacts.push({
+      dataSourceId: ds.dataSourceId,
+      name: ds.name,
+      artifactKey: ds.artifactKey,
+      artifactRevision: ds.artifactRevision,
+      rowCount: ds.rowCount,
+      byteSize: ds.byteSize,
+    });
+  }
+
+  const widgets = (dashboard.widgets || []).map(w => ({
+    id: w.id,
+    title: w.title,
+    type: w.type,
+    dataSourceId: w.dataSourceId,
+    localSql: w.localSql,
+    vegaLiteSpec: w.vegaLiteSpec,
+    kpiConfig: w.kpiConfig,
+    tableConfig: w.tableConfig,
+    layouts: w.layouts,
+  }));
+
+  return {
+    ok: true,
+    snapshot: {
+      title: dashboard.title,
+      layout: {
+        columns: dashboard.layout?.columns ?? 12,
+        rowHeight: dashboard.layout?.rowHeight ?? 80,
+      },
+      theme: "light",
+      widgets,
+      artifacts,
+    },
+  };
+}
+
+export function embedPayloadFromPublishedSnapshot(
+  snapshot: DashboardPublishedSnapshotDoc,
+  shareToken: string,
+): Record<string, unknown> {
+  const enc = encodeURIComponent;
+  return {
+    title: snapshot.title,
+    layout: snapshot.layout,
+    theme: snapshot.theme ?? "light",
+    widgets: snapshot.widgets,
+    dataSources: snapshot.artifacts.map(a => ({
+      id: a.dataSourceId,
+      name: a.name,
+      exportUrl: `/api/public/dashboards/${enc(shareToken)}/artifacts/${enc(a.dataSourceId)}${
+        a.artifactRevision ? `?rev=${enc(a.artifactRevision)}` : ""
+      }`,
+    })),
+  };
+}

--- a/api/src/services/dashboard-publish.service.ts
+++ b/api/src/services/dashboard-publish.service.ts
@@ -1,6 +1,94 @@
 import crypto from "crypto";
-import type { IDashboard } from "../database/workspace-schema";
+import { Dashboard, type IDashboard } from "../database/workspace-schema";
+import { loggers } from "../logging";
 import { buildDashboardMaterializationStatus } from "./dashboard-materialization.service";
+import { queueDashboardArtifactRefresh } from "./dashboard-refresh-runner.service";
+
+const logger = loggers.api("dashboard-publish");
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+const PUBLISH_MATERIALIZATION_POLL_MS = 2_000;
+const PUBLISH_MATERIALIZATION_MAX_WAIT_MS = 120_000;
+
+/**
+ * Ensures dashboard parquet artifacts exist so a public snapshot can be built.
+ * Queues the same refresh path as manual materialize, then polls until ready or timeout.
+ */
+export async function ensureDashboardMaterializedForPublish(
+  dashboardId: string,
+  workspaceId: string,
+): Promise<{ ok: true; dashboard: IDashboard } | { ok: false; error: string }> {
+  const fresh = await Dashboard.findById(dashboardId);
+  if (!fresh) {
+    return { ok: false, error: "Dashboard not found" };
+  }
+  if (fresh.workspaceId.toString() !== workspaceId) {
+    return { ok: false, error: "Dashboard not found" };
+  }
+
+  let status = await buildDashboardMaterializationStatus(fresh);
+  if (status.allReady) {
+    return { ok: true, dashboard: fresh };
+  }
+
+  try {
+    await queueDashboardArtifactRefresh({
+      dashboardId,
+      workspaceId,
+      force: true,
+      triggerType: "manual",
+    });
+  } catch (error) {
+    logger.error("Failed to queue dashboard materialization for publish", {
+      error,
+      dashboardId,
+    });
+    return {
+      ok: false,
+      error:
+        "Could not start materialization. Check that background jobs (Inngest) are running, then try Publish again.",
+    };
+  }
+
+  const deadline = Date.now() + PUBLISH_MATERIALIZATION_MAX_WAIT_MS;
+
+  while (Date.now() < deadline) {
+    await sleep(PUBLISH_MATERIALIZATION_POLL_MS);
+    const doc = await Dashboard.findById(dashboardId);
+    if (!doc) {
+      return { ok: false, error: "Dashboard not found" };
+    }
+    status = await buildDashboardMaterializationStatus(doc);
+    if (status.allReady) {
+      return { ok: true, dashboard: doc };
+    }
+
+    if (
+      !status.anyBuilding &&
+      status.dataSources.some(ds => ds.status === "error")
+    ) {
+      const parts = status.dataSources
+        .filter(ds => ds.status === "error" && ds.lastError)
+        .map(ds => `${ds.name}: ${ds.lastError}`);
+      return {
+        ok: false,
+        error:
+          parts.length > 0
+            ? `Materialization failed: ${parts.join(" | ")}`
+            : "Materialization failed. Fix the data sources and try Publish again.",
+      };
+    }
+  }
+
+  return {
+    ok: false,
+    error:
+      "Materialization is still in progress after waiting two minutes. Try Publish again in a moment once data sources show Ready.",
+  };
+}
 
 export function hashDashboardShareToken(token: string): string {
   return crypto.createHash("sha256").update(token, "utf8").digest("hex");
@@ -42,7 +130,7 @@ export async function buildDashboardPublishedSnapshot(
     return {
       ok: false,
       error:
-        "All data sources must be materialized (ready) before publishing. Run materialization and try again.",
+        "All data sources must be materialized (ready) before publishing. Use Publish from the dashboard settings to run materialization automatically, or refresh materialization manually.",
     };
   }
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -43,6 +43,8 @@ import { FlowsExplorer } from "./components/FlowsExplorer";
 import SettingsExplorer from "./components/SettingsExplorer";
 const loadDashboardsExplorer = () => import("./components/DashboardsExplorer");
 const DashboardsExplorer = lazy(loadDashboardsExplorer);
+const loadPublicDashboard = () => import("./components/EmbeddableDashboard");
+const PublicDashboardPage = lazy(loadPublicDashboard);
 import { AuthWrapper } from "./components/AuthWrapper";
 import { AcceptInvite } from "./components/AcceptInvite";
 import { WorkspaceProvider } from "./contexts/workspace-context";
@@ -768,6 +770,16 @@ function App() {
       <Routes>
         {/* Invite route - no authentication required */}
         <Route path="/invite/:token" element={<InvitePage />} />
+
+        {/* Published dashboard — no authentication */}
+        <Route
+          path="/p/d/:token"
+          element={
+            <Suspense fallback={<LoadingScreen />}>
+              <PublicDashboardPage />
+            </Suspense>
+          }
+        />
 
         {/* Auth routes - redirect to "/" if already logged in */}
         <Route path="/login" element={<LoginRoute />} />

--- a/app/src/components/EmbeddableDashboard.tsx
+++ b/app/src/components/EmbeddableDashboard.tsx
@@ -6,6 +6,7 @@ import {
   ThemeProvider,
   createTheme,
 } from "@mui/material";
+import { useParams } from "react-router-dom";
 import { ResponsiveGridLayout, useContainerWidth } from "react-grid-layout";
 import "react-grid-layout/css/styles.css";
 import "react-resizable/css/styles.css";
@@ -53,6 +54,7 @@ const darkTheme = createTheme({ palette: { mode: "dark" } });
 const lightTheme = createTheme({ palette: { mode: "light" } });
 
 const EmbeddableDashboard: React.FC = () => {
+  const { token } = useParams<{ token: string }>();
   const [spec, setSpec] = useState<EmbedDashboardSpec | null>(null);
   const [db, setDb] = useState<AsyncDuckDB | null>(null);
   const [loading, setLoading] = useState(true);
@@ -72,30 +74,35 @@ const EmbeddableDashboard: React.FC = () => {
   );
 
   useEffect(() => {
-    const token = window.location.pathname.split("/embed/")[1];
     if (!token) {
-      setError("Missing embed token");
+      setError("Missing share token");
       setLoading(false);
       return;
     }
 
     (async () => {
       try {
-        const res = await fetch(`/api/embed/dashboards/${token}`);
+        const res = await fetch(
+          `/api/public/dashboards/${encodeURIComponent(token)}`,
+        );
         if (!res.ok) {
           throw new Error(`Failed to load dashboard: ${res.statusText}`);
         }
-        const data = await res.json();
-        if (!data.success) throw new Error(data.error || "Failed to load");
-        setSpec(data.data);
+        const body = (await res.json()) as {
+          success: boolean;
+          data?: EmbedDashboardSpec;
+          error?: string;
+        };
+        if (!body.success || !body.data) {
+          throw new Error(body.error || "Failed to load");
+        }
+        setSpec(body.data);
 
         const duckdb = await initDuckDB();
         setDb(duckdb);
 
-        for (const ds of data.data.dataSources) {
-          const exportRes = await fetch(ds.exportUrl, {
-            credentials: "include",
-          });
+        for (const ds of body.data.dataSources) {
+          const exportRes = await fetch(ds.exportUrl);
           if (exportRes.ok) {
             const buffer = new Uint8Array(await exportRes.arrayBuffer());
             await loadArrowTable(duckdb, ds.name, buffer);
@@ -111,7 +118,7 @@ const EmbeddableDashboard: React.FC = () => {
         setLoading(false);
       }
     })();
-  }, []);
+  }, [token]);
 
   if (loading) {
     return (
@@ -196,19 +203,6 @@ const EmbeddableDashboard: React.FC = () => {
           color: "text.primary",
         }}
       >
-        <Box
-          sx={{
-            px: 3,
-            py: 2,
-            borderBottom: "1px solid",
-            borderColor: "divider",
-          }}
-        >
-          <Typography variant="h5" sx={{ fontWeight: 600 }}>
-            {spec.title}
-          </Typography>
-        </Box>
-
         <Box ref={gridContainerRef} sx={{ p: 2 }}>
           {dataReady && db ? (
             <ResponsiveGridLayout

--- a/app/src/components/dashboard/DashboardSettingsDialog.tsx
+++ b/app/src/components/dashboard/DashboardSettingsDialog.tsx
@@ -390,8 +390,9 @@ export default function DashboardSettingsDialog({
             Public link
           </Typography>
           <Typography variant="body2" color="text.secondary">
-            Read-only page for anyone with the link. Every data source must be
-            materialized (ready) before publishing.
+            Read-only page for anyone with the link. Publish refreshes
+            materialization if needed (this can take up to a couple of minutes
+            for large data sources).
           </Typography>
           {dashboard?.published?.enabled ? (
             <>

--- a/app/src/components/dashboard/DashboardSettingsDialog.tsx
+++ b/app/src/components/dashboard/DashboardSettingsDialog.tsx
@@ -89,7 +89,17 @@ export default function DashboardSettingsDialog({
     "mosaic" | "legacy"
   >("mosaic");
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [publishBusy, setPublishBusy] = useState(false);
+  const [publishError, setPublishError] = useState<string | null>(null);
+  const [lastPublishedUrl, setLastPublishedUrl] = useState<string | null>(null);
   const isReadOnly = dashboard?.readOnly === true;
+
+  useEffect(() => {
+    if (open) {
+      setPublishError(null);
+      setLastPublishedUrl(null);
+    }
+  }, [open]);
 
   useEffect(() => {
     if (dashboard && open) {
@@ -162,6 +172,37 @@ export default function DashboardSettingsDialog({
       .getState()
       .duplicateDashboard(workspaceId, dashboard._id);
     onClose();
+  };
+
+  const handlePublish = async () => {
+    if (!workspaceId || !dashboard) return;
+    setPublishBusy(true);
+    setPublishError(null);
+    setLastPublishedUrl(null);
+    const result = await useDashboardStore
+      .getState()
+      .publishDashboard(workspaceId, dashboard._id);
+    setPublishBusy(false);
+    if (result.ok) {
+      setLastPublishedUrl(`${window.location.origin}${result.publicPath}`);
+    } else {
+      setPublishError(result.error);
+    }
+  };
+
+  const handleUnpublish = async () => {
+    if (!workspaceId || !dashboard) return;
+    setPublishBusy(true);
+    setPublishError(null);
+    const result = await useDashboardStore
+      .getState()
+      .unpublishDashboard(workspaceId, dashboard._id);
+    setPublishBusy(false);
+    if (!result.ok) {
+      setPublishError(result.error);
+    } else {
+      setLastPublishedUrl(null);
+    }
   };
 
   const handleDelete = async () => {
@@ -341,6 +382,80 @@ export default function DashboardSettingsDialog({
             </FormControl>
           </>
         )}
+
+        <Divider />
+
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+          <Typography variant="subtitle2" color="text.secondary">
+            Public link
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Read-only page for anyone with the link. Every data source must be
+            materialized (ready) before publishing.
+          </Typography>
+          {dashboard?.published?.enabled ? (
+            <>
+              <Alert severity="info">
+                Published
+                {dashboard.published.publishedAt
+                  ? ` · ${new Date(dashboard.published.publishedAt).toLocaleString()}`
+                  : ""}
+                . The URL is only shown when you publish; publish again to
+                rotate the link.
+              </Alert>
+              {!isReadOnly && (
+                <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    disabled={publishBusy}
+                    onClick={() => void handlePublish()}
+                  >
+                    Publish again
+                  </Button>
+                  <Button
+                    variant="outlined"
+                    color="error"
+                    size="small"
+                    disabled={publishBusy}
+                    onClick={() => void handleUnpublish()}
+                  >
+                    Unpublish
+                  </Button>
+                </Box>
+              )}
+            </>
+          ) : (
+            !isReadOnly && (
+              <Button
+                variant="outlined"
+                size="small"
+                disabled={publishBusy}
+                onClick={() => void handlePublish()}
+              >
+                Publish
+              </Button>
+            )
+          )}
+          {publishError ? <Alert severity="error">{publishError}</Alert> : null}
+          {lastPublishedUrl ? (
+            <Alert
+              severity="success"
+              action={
+                <Button
+                  size="small"
+                  onClick={() =>
+                    void navigator.clipboard.writeText(lastPublishedUrl)
+                  }
+                >
+                  Copy
+                </Button>
+              }
+            >
+              {lastPublishedUrl}
+            </Alert>
+          ) : null}
+        </Box>
 
         <Divider sx={{ mt: 1 }} />
 

--- a/app/src/dashboard-runtime/types.ts
+++ b/app/src/dashboard-runtime/types.ts
@@ -72,6 +72,8 @@ export interface Dashboard
   owner_id?: string;
   createdBy: string;
   readOnly?: boolean;
+  /** Sanitized from API — no token or snapshot payload. */
+  published?: { enabled: boolean; publishedAt?: string };
   createdAt: string;
   updatedAt: string;
   snapshots?: Record<

--- a/app/src/store/dashboardStore.ts
+++ b/app/src/store/dashboardStore.ts
@@ -163,6 +163,17 @@ interface DashboardStoreState {
     workspaceId: string,
     id: string,
   ) => Promise<Dashboard | null>;
+  publishDashboard: (
+    workspaceId: string,
+    dashboardId: string,
+  ) => Promise<
+    | { ok: true; shareToken: string; publicPath: string }
+    | { ok: false; error: string }
+  >;
+  unpublishDashboard: (
+    workspaceId: string,
+    dashboardId: string,
+  ) => Promise<{ ok: true } | { ok: false; error: string }>;
   openDashboard: (
     workspaceId: string,
     dashboardId: string,
@@ -423,6 +434,52 @@ export const useDashboardStore = create<DashboardStoreState>()(
           return null;
         } catch {
           return null;
+        }
+      },
+
+      publishDashboard: async (workspaceId: string, dashboardId: string) => {
+        try {
+          const response = await apiClient.post<{
+            success: boolean;
+            data: { shareToken: string; publicPath: string };
+            error?: string;
+          }>(
+            `/workspaces/${workspaceId}/dashboards/${dashboardId}/publish`,
+            {},
+          );
+
+          if (response.success && response.data?.shareToken) {
+            await get().reloadDashboard(workspaceId, dashboardId);
+            return {
+              ok: true,
+              shareToken: response.data.shareToken,
+              publicPath: response.data.publicPath,
+            };
+          }
+          return {
+            ok: false,
+            error: response.error || "Failed to publish",
+          };
+        } catch (e: unknown) {
+          return {
+            ok: false,
+            error: e instanceof Error ? e.message : "Failed to publish",
+          };
+        }
+      },
+
+      unpublishDashboard: async (workspaceId: string, dashboardId: string) => {
+        try {
+          await apiClient.delete(
+            `/workspaces/${workspaceId}/dashboards/${dashboardId}/publish`,
+          );
+          await get().reloadDashboard(workspaceId, dashboardId);
+          return { ok: true };
+        } catch (e: unknown) {
+          return {
+            ok: false,
+            error: e instanceof Error ? e.message : "Failed to unpublish",
+          };
         }
       },
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds opt-in public dashboard links backed by an opaque share token and a frozen snapshot of the dashboard definition plus materialized parquet artifacts.

## Changes

- **Schema**: Optional `published` on dashboard documents (`enabled`, `tokenHash`, `publishedAt`, `publishedBy`, `snapshot`) with a unique partial index on `published.tokenHash`.
- **Authenticated API**: `POST` / `DELETE` `/api/workspaces/:workspaceId/dashboards/:id/publish` — requires dashboard write access; publish only succeeds when all data sources are materialized (`ready`).
- **Public API**: `GET /api/public/dashboards/:token` returns the embed payload; `GET .../artifacts/:dataSourceId` streams parquet for that published snapshot (same artifact store as materialization).
- **App**: Route `/p/d/:token` (no auth shell) renders `EmbeddableDashboard`, which loads the public API without credentials. Dashboard settings include Publish / Publish again / Unpublish and copy-to-clipboard for the new URL.
- **Privacy**: Authenticated dashboard responses strip `published` down to `{ enabled, publishedAt }` (no token hash or snapshot in the editor API).

## How to verify

1. Open a dashboard, ensure all data sources are materialized (ready).
2. Dashboard settings → **Publish** → copy the URL, open in a private window (no login).
3. **Unpublish** and confirm the public URL returns not found.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-567e8a84-0213-4984-a5cd-4a467bd289b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-567e8a84-0213-4984-a5cd-4a467bd289b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

