### PR TITLE
Sync Close user webhook events

### DIFF
--- a/api/src/connectors/close/connector.test.ts
+++ b/api/src/connectors/close/connector.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { CloseConnector } from "./connector";
+
+function createConnector() {
+  return new CloseConnector({
+    id: "ds_close",
+    name: "Close",
+    type: "close",
+    config: { api_key: "test-key" },
+  } as any);
+}
+
+function testUserWebhookEventsAreSupported() {
+  const connector = createConnector();
+
+  assert.deepEqual(connector.getWebhookEventsForEntities(["users"]), [
+    "user.created",
+    "user.updated",
+    "user.deleted",
+  ]);
+}
+
+function testUserWebhookEventsAreMapped() {
+  const connector = createConnector();
+
+  assert.deepEqual(connector.getWebhookEventMapping("user.created"), {
+    entity: "users",
+    operation: "upsert",
+  });
+  assert.deepEqual(connector.getWebhookEventMapping("user.updated"), {
+    entity: "users",
+    operation: "upsert",
+  });
+  assert.deepEqual(connector.getWebhookEventMapping("user.deleted"), {
+    entity: "users",
+    operation: "delete",
+  });
+}
+
+function testUserWebhookPayloadIsExtractedForProcessing() {
+  const connector = createConnector();
+
+  assert.deepEqual(
+    connector.extractWebhookData({
+      event: {
+        object_type: "user",
+        action: "updated",
+        object_id: "user_123",
+        data: {
+          id: "user_123",
+          email: "user@example.com",
+          first_name: "Test",
+          date_updated: "2026-05-20T07:00:00.000Z",
+        },
+      },
+    }),
+    {
+      id: "user_123",
+      data: {
+        id: "user_123",
+        email: "user@example.com",
+        first_name: "Test",
+        date_updated: "2026-05-20T07:00:00.000Z",
+      },
+    },
+  );
+}
+
+function testUserWebhookCdcRecordUsesUsersEntity() {
+  const connector = createConnector();
+
+  const records = connector.extractWebhookCdcRecords(
+    {
+      id: "evt_123",
+      event: {
+        object_type: "user",
+        action: "deleted",
+        object_id: "user_123",
+      },
+    },
+    "user.deleted",
+  );
+
+  assert.equal(records.length, 1);
+  assert.equal(records[0].entity, "users");
+  assert.equal(records[0].recordId, "user_123");
+  assert.equal(records[0].operation, "delete");
+  assert.deepEqual(records[0].payload, { id: "user_123" });
+}
+
+function main() {
+  testUserWebhookEventsAreSupported();
+  testUserWebhookEventsAreMapped();
+  testUserWebhookPayloadIsExtractedForProcessing();
+  testUserWebhookCdcRecordUsesUsersEntity();
+}
+
+main();

--- a/api/src/connectors/close/connector.ts
+++ b/api/src/connectors/close/connector.ts
@@ -68,6 +68,9 @@ const CLOSE_SUPPORTED_WEBHOOK_SELECTORS: CloseWebhookSelector[] = [
   { object_type: "contact", action: "created" },
   { object_type: "contact", action: "updated" },
   { object_type: "contact", action: "deleted" },
+  { object_type: "user", action: "created" },
+  { object_type: "user", action: "updated" },
+  { object_type: "user", action: "deleted" },
   { object_type: "opportunity", action: "created" },
   { object_type: "opportunity", action: "updated" },
   { object_type: "opportunity", action: "deleted" },
@@ -2216,6 +2219,11 @@ export class CloseConnector extends BaseConnector {
       "contact.updated": { entity: "contacts", operation: "upsert" },
       "contact.deleted": { entity: "contacts", operation: "delete" },
 
+      // Users
+      "user.created": { entity: "users", operation: "upsert" },
+      "user.updated": { entity: "users", operation: "upsert" },
+      "user.deleted": { entity: "users", operation: "delete" },
+
       // Opportunities
       "opportunity.created": { entity: "opportunities", operation: "upsert" },
       "opportunity.updated": { entity: "opportunities", operation: "upsert" },
@@ -2337,6 +2345,7 @@ export class CloseConnector extends BaseConnector {
     const entityToObjectTypes: Record<string, string[]> = {
       leads: ["lead"],
       contacts: ["contact"],
+      users: ["user"],
       opportunities: ["opportunity"],
       custom_fields: [
         "custom_fields.lead",


### PR DESCRIPTION
## Summary
- Subscribe Close webhook provisioning to `user.created`, `user.updated`, and `user.deleted` events.
- Map Close user webhook events to the existing `users` entity so CDC upserts/deletes update user records in real time.
- Add connector coverage for user event selection, mapping, payload extraction, and CDC record normalization.

## Test plan
- `pnpm --filter api exec tsx src/connectors/close/connector.test.ts`
- `pnpm --filter api run lint`
- `pnpm --filter api run build`