### PR TITLE
docs(connectors): add Claap to available connectors list

### DIFF
--- a/docs/src/content/docs/connectors.md
+++ b/docs/src/content/docs/connectors.md
@@ -1,6 +1,6 @@
 ---
 title: SaaS Sync (Connectors)
-description: Pull data from SaaS tools like Stripe, PostHog, Close CRM, and more into your data warehouse.
+description: Pull data from SaaS tools like Stripe, Close CRM, Claap, PostHog, and more into your data warehouse.
 ---
 
 :::caution[Experimental]
@@ -15,6 +15,7 @@ Connectors pull data from external services and sync it into your connected data
 | ------------- | --------------- | -------------------------------------------------------------------------------- |
 | **Stripe**    | Stripe API      | Customers, Subscriptions, Charges, Invoices, Products, Plans                     |
 | **Close CRM** | Close API       | Leads, Opportunities, Activities (10+ sub-types), Contacts, Users, Custom Fields. *Webhooks are automatically scoped to synced entities only.* |
+| **Claap**     | Claap API       | Recordings, Workspace. *Supports backfill and CDC webhooks (auto-provisioning via "Create in Claap").* |
 | **PostHog**   | PostHog HogQL   | Dynamic — each configured HogQL query becomes an entity                          |
 | **GraphQL**   | Any GraphQL API | Dynamic — each configured query becomes an entity                                |
 | **BigQuery**  | Google BigQuery | Dynamic — each configured query becomes an entity                                |


### PR DESCRIPTION
Reflects #418 and #419 which landed the Claap source connector (recordings + workspace, backfill + CDC webhooks, auto-provisioning).

### Change
Added a Claap row to the connectors table in `docs/src/content/docs/connectors.md` and updated the frontmatter description.

### Why
Claap is now a first-class connector but had zero mention in the user-facing docs.

### Out of scope
A dedicated per-connector guide page (matching Stripe/Close) -- can follow if there's appetite, but this minimal change closes the most visible drift first.