### PR TITLE
fix(app): wrap user chat messages over multiple lines

### DIFF
--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -560,15 +560,11 @@ const userMessagePaperSx = {
   backgroundColor: "background.paper",
   overflow: "hidden",
 } as const;
-const userMessageBoxSx = {
+const userMessageTextSx = {
   maxWidth: "100%",
-  "& .MuiListItemText-primary": {
-    whiteSpace: "pre-wrap",
-    wordBreak: "break-word",
-    overflowWrap: "break-word",
-    overflow: "visible",
-    textOverflow: "unset",
-  },
+  whiteSpace: "pre-wrap",
+  wordBreak: "break-word",
+  overflowWrap: "break-word",
 } as const;
 const assistantMessageSx = {
   flex: 1,
@@ -689,15 +685,13 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
               </Box>
             )}
             {textContent && (
-              <Box sx={userMessageBoxSx}>
-                <ListItemText
-                  primary={textContent}
-                  primaryTypographyProps={{
-                    variant: "body2",
-                    color: "text.primary",
-                  }}
-                />
-              </Box>
+              <Typography
+                variant="body2"
+                color="text.primary"
+                sx={userMessageTextSx}
+              >
+                {textContent}
+              </Typography>
             )}
           </Paper>
         </Box>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

A recent broad CSS change applied no-wrap + text-overflow ellipsis truncation (`truncateTextStyles` in `app/src/contexts/ThemeContext.tsx`) to many MUI components, including the `MuiListItemText` `primary` slot. User messages in the chat UI are rendered through `ListItemText`, so they inherited the global truncation and stopped wrapping over multiple lines.

A prior attempt added a wrapping override on the surrounding `Box` targeting `& .MuiListItemText-primary`. However, the theme applies its truncation via `& .MuiListItemText-primary` on the `ListItemTextRoot`, giving both rules identical CSS specificity `(0,2,0)`. The winner then depends on emotion stylesheet injection order, making the fix unreliable.

## Fix

Render the user message text in a plain `Typography` instead of `ListItemText`. `Typography` has no global truncate override in the theme, so the text deterministically wraps using `white-space: pre-wrap` / `word-break: break-word` / `overflow-wrap: break-word`. This keeps line breaks and long words contained, while leaving the global truncation behavior intact for buttons, titles, list items, etc.

## Testing

- `pnpm --filter app run typecheck` — passes
- `pnpm --filter app run lint` — passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17b05730-a9db-496f-b168-68c767c6d6e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17b05730-a9db-496f-b168-68c767c6d6e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

