### PR TITLE
Fix workspace member role update crash

### DIFF
--- a/api/src/routes/workspaces.ts
+++ b/api/src/routes/workspaces.ts
@@ -16,6 +16,29 @@ const logger = loggers.workspace();
 
 export const workspaceRoutes = new Hono();
 
+type WorkspaceMemberResponseSource = {
+  _id: unknown;
+  userId?: unknown;
+  role: string;
+  joinedAt: unknown;
+};
+
+function serializeWorkspaceMember(member: WorkspaceMemberResponseSource) {
+  const populatedUser =
+    member.userId && typeof member.userId === "object"
+      ? (member.userId as { _id?: unknown; email?: unknown })
+      : null;
+
+  return {
+    id: member._id,
+    userId: populatedUser?._id ?? member.userId,
+    email:
+      typeof populatedUser?.email === "string" ? populatedUser.email : "",
+    role: member.role,
+    joinedAt: member.joinedAt,
+  };
+}
+
 // Get pending invitations for current user's email
 workspaceRoutes.get(
   "/pending-invites",
@@ -672,13 +695,7 @@ workspaceRoutes.get(
 
       return c.json({
         success: true,
-        data: members.map((member: any) => ({
-          id: member._id,
-          userId: member.userId._id || member.userId,
-          email: member.userId.email || "",
-          role: member.role,
-          joinedAt: member.joinedAt,
-        })),
+        data: members.map(serializeWorkspaceMember),
       });
     } catch (error) {
       logger.error("Error getting members", { error });
@@ -737,12 +754,7 @@ workspaceRoutes.post(
       return c.json(
         {
           success: true,
-          data: {
-            id: member._id,
-            userId: member.userId,
-            role: member.role,
-            joinedAt: member.joinedAt,
-          },
+          data: serializeWorkspaceMember(member),
         },
         201,
       );
@@ -812,12 +824,7 @@ workspaceRoutes.put(
 
       return c.json({
         success: true,
-        data: {
-          id: updatedMember._id,
-          userId: updatedMember.userId,
-          role: updatedMember.role,
-          joinedAt: updatedMember.joinedAt,
-        },
+        data: serializeWorkspaceMember(updatedMember),
       });
     } catch (error) {
       logger.error("Error updating member role", { error });

--- a/api/src/services/workspace.service.ts
+++ b/api/src/services/workspace.service.ts
@@ -236,7 +236,8 @@ export class WorkspaceService {
       role,
       joinedAt: new Date(),
     });
-    return member.save();
+    await member.save();
+    return member.populate("userId", "email");
   }
 
   /**
@@ -254,7 +255,7 @@ export class WorkspaceService {
       },
       { role: newRole },
       { new: true },
-    );
+    ).populate("userId", "email");
   }
 
   /**

--- a/app/src/components/WorkspaceMembers.tsx
+++ b/app/src/components/WorkspaceMembers.tsx
@@ -102,6 +102,11 @@ export function WorkspaceMembers() {
     userId: string,
     newRole: "admin" | "member" | "viewer",
   ) => {
+    if (!userId) {
+      setError("Cannot update role for a member with missing user details");
+      return;
+    }
+
     try {
       await updateMemberRole(userId, newRole);
     } catch (error: any) {
@@ -110,6 +115,11 @@ export function WorkspaceMembers() {
   };
 
   const handleRemoveMember = async (userId: string) => {
+    if (!userId) {
+      setError("Cannot remove a member with missing user details");
+      return;
+    }
+
     if (window.confirm("Are you sure you want to remove this member?")) {
       try {
         await removeMember(userId);
@@ -157,7 +167,7 @@ export function WorkspaceMembers() {
   const rows: MemberRow[] = useMemo(() => {
     const memberRows: MemberRow[] = members.map(member => ({
       id: member.id,
-      email: member.email,
+      email: member.email ?? "",
       role: member.role,
       status: "active" as const,
       joinedAt: member.joinedAt,
@@ -166,7 +176,7 @@ export function WorkspaceMembers() {
 
     const inviteRows: MemberRow[] = invites.map(invite => ({
       id: invite.id,
-      email: invite.email,
+      email: invite.email ?? "",
       role: invite.role,
       status: "pending" as const,
       expiresAt: invite.expiresAt,
@@ -246,6 +256,14 @@ export function WorkspaceMembers() {
           </TableHead>
           <TableBody>
             {rows.map(row => {
+              const displayEmail = row.email || "Unknown user";
+              const avatarLabel =
+                displayEmail.trim().charAt(0).toUpperCase() || "?";
+              const rowDate =
+                row.status === "active" ? row.joinedAt : row.expiresAt;
+              const formattedDate = rowDate
+                ? new Date(rowDate).toLocaleDateString()
+                : "Unknown";
               const isCurrentUser = row.email === user?.email;
               const isOwner = row.role === "owner";
               const canEdit = canManageMembers && !isOwner && !isCurrentUser;
@@ -260,10 +278,10 @@ export function WorkspaceMembers() {
                         {row.status === "pending" ? (
                           <Email />
                         ) : (
-                          row.email[0].toUpperCase()
+                          avatarLabel
                         )}
                       </Avatar>
-                      <Typography variant="body2">{row.email}</Typography>
+                      <Typography variant="body2">{displayEmail}</Typography>
                     </Box>
                   </TableCell>
                   <TableCell>
@@ -284,11 +302,7 @@ export function WorkspaceMembers() {
                   <TableCell>
                     <Typography variant="caption" color="text.secondary">
                       {row.status === "active" ? "Joined" : "Expires"}{" "}
-                      {new Date(
-                        row.status === "active"
-                          ? (row.joinedAt ?? "")
-                          : (row.expiresAt ?? ""),
-                      ).toLocaleDateString()}
+                      {formattedDate}
                     </Typography>
                   </TableCell>
                   <TableCell>

--- a/app/src/components/WorkspaceMembers.tsx
+++ b/app/src/components/WorkspaceMembers.tsx
@@ -275,11 +275,7 @@ export function WorkspaceMembers() {
                       <Avatar
                         sx={{ width: 32, height: 32, fontSize: "0.875rem" }}
                       >
-                        {row.status === "pending" ? (
-                          <Email />
-                        ) : (
-                          avatarLabel
-                        )}
+                        {row.status === "pending" ? <Email /> : avatarLabel}
                       </Avatar>
                       <Typography variant="body2">{displayEmail}</Typography>
                     </Box>

--- a/app/src/contexts/workspace-context.tsx
+++ b/app/src/contexts/workspace-context.tsx
@@ -387,7 +387,18 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
           { role },
         );
         setMembers(prev =>
-          prev.map(member => (member.userId === userId ? updated : member)),
+          prev.map(member =>
+            member.userId === userId
+              ? {
+                  ...member,
+                  ...updated,
+                  id: updated.id || member.id,
+                  userId: updated.userId || member.userId,
+                  email: updated.email || member.email,
+                  joinedAt: updated.joinedAt || member.joinedAt,
+                }
+              : member,
+          ),
         );
       } catch (err: any) {
         setError(err.message || "Failed to update member role");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Return a consistent workspace member response shape, including email, from list/add/update member routes.
- Populate user email when adding or updating workspace members.
- Preserve existing member fields during role-update state merges and harden member row rendering against missing user details.

## Testing
- `pnpm --filter app run typecheck`
- `pnpm --filter app run lint`
- `pnpm --filter api run lint`
- `pnpm --filter api run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59ee3669-ce4d-4371-9b14-ad784d016656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59ee3669-ce4d-4371-9b14-ad784d016656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

