### PR TITLE
Fix delayed continuation after instant client tools

### DIFF
--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -86,7 +86,9 @@ import {
 import { executeConsoleAgentTool } from "../agent-runtime/console-agent-tools";
 import { buildModificationDiff } from "../utils/consoleModification";
 import {
+  DASHBOARD_EXECUTOR_TOOL_NAMES,
   LONG_RUNNING_DASHBOARD_TOOL_NAMES,
+  getAgentToolManifestEntry,
   type AgentToolName,
 } from "../agent-runtime/client-tool-manifest";
 import { UpgradePrompt } from "./UpgradePrompt";
@@ -1496,55 +1498,70 @@ const Chat: React.FC<ChatProps> = ({
         }
 
         // --- Dashboard tools (client-side) ---
-        try {
-          const activeDashboardTool = LONG_RUNNING_DASHBOARD_TOOL_NAMES.has(
-            toolName as AgentToolName,
-          )
-            ? registerActiveClientToolCall(toolName, toolCall.toolCallId)
-            : null;
+        if (DASHBOARD_EXECUTOR_TOOL_NAMES.has(toolName as AgentToolName)) {
+          const isLongRunningDashboardTool =
+            LONG_RUNNING_DASHBOARD_TOOL_NAMES.has(toolName as AgentToolName);
 
-          const dashboardToolOutput = await executeDashboardAgentTool(
-            toolName,
-            input,
-            activeDashboardTool
-              ? {
-                  executionId: activeDashboardTool.executionId,
-                  signal: activeDashboardTool.abortController.signal,
+          if (isLongRunningDashboardTool) {
+            const activeDashboardTool = registerActiveClientToolCall(
+              toolName,
+              toolCall.toolCallId,
+            );
+
+            // Fire-and-forget for long-running dashboard work. The AI SDK
+            // awaits onToolCall while reading the SSE stream; awaiting here can
+            // prevent the finish chunk from being processed, which delays the
+            // automatic continuation until the HTTP stream times out.
+            void (async () => {
+              try {
+                const dashboardToolOutput = await executeDashboardAgentTool(
+                  toolName,
+                  input,
+                  {
+                    executionId: activeDashboardTool.executionId,
+                    signal: activeDashboardTool.abortController.signal,
+                  },
+                );
+
+                settleActiveClientToolCall(
+                  toolName,
+                  toolCall.toolCallId,
+                  dashboardToolOutput ?? {
+                    success: false,
+                    error: `Dashboard tool "${toolName}" did not return a result.`,
+                  },
+                );
+              } catch (dashboardError) {
+                if (manualStopRequestedRef.current) {
+                  return;
                 }
-              : undefined,
-          );
-
-          if (dashboardToolOutput !== null) {
-            if (activeDashboardTool) {
-              settleActiveClientToolCall(
-                toolName,
-                toolCall.toolCallId,
-                dashboardToolOutput,
-              );
-            } else {
-              addToolOutput({
-                tool: toolName,
-                toolCallId: toolCall.toolCallId,
-                output: dashboardToolOutput,
-              });
-            }
+                settleActiveClientToolCall(toolName, toolCall.toolCallId, {
+                  success: false,
+                  error:
+                    dashboardError instanceof Error
+                      ? dashboardError.message
+                      : "Dashboard tool execution failed",
+                });
+              }
+            })();
             return;
           }
-        } catch (dashboardError) {
-          if (
-            LONG_RUNNING_DASHBOARD_TOOL_NAMES.has(toolName as AgentToolName)
-          ) {
-            if (manualStopRequestedRef.current) {
-              return;
-            }
-            settleActiveClientToolCall(toolName, toolCall.toolCallId, {
-              success: false,
-              error:
-                dashboardError instanceof Error
-                  ? dashboardError.message
-                  : "Dashboard tool execution failed",
+
+          try {
+            const dashboardToolOutput = await executeDashboardAgentTool(
+              toolName,
+              input,
+            );
+
+            addToolOutput({
+              tool: toolName,
+              toolCallId: toolCall.toolCallId,
+              output: dashboardToolOutput ?? {
+                success: false,
+                error: `Dashboard tool "${toolName}" did not return a result.`,
+              },
             });
-          } else {
+          } catch (dashboardError) {
             addToolOutput({
               tool: toolName,
               toolCallId: toolCall.toolCallId,
@@ -1713,6 +1730,19 @@ const Chat: React.FC<ChatProps> = ({
               success: true,
               flowTabs,
               message: `Found ${flowTabs.length} open flow tab(s)`,
+            },
+          });
+          return;
+        }
+
+        const manifestEntry = getAgentToolManifestEntry(toolName);
+        if (manifestEntry?.execution === "client") {
+          addToolOutput({
+            tool: toolName,
+            toolCallId: toolCall.toolCallId,
+            output: {
+              success: false,
+              error: `Client-side tool "${toolName}" is registered but has no browser handler.`,
             },
           });
           return;

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -1372,9 +1372,23 @@ const Chat: React.FC<ChatProps> = ({
   const activeClientToolCallsRef = useRef(
     new Map<string, ActiveClientToolCall>(),
   );
+  const cancelledClientToolCallIdsRef = useRef(new Set<string>());
+  const [activeClientToolCallCount, setActiveClientToolCallCount] = useState(0);
   workspaceIdRef.current = currentWorkspace?.id;
   modelIdRef.current = selectedModelId;
   chatIdRef.current = chatId;
+
+  const cancelActiveClientToolCalls = useCallback((reason: string): void => {
+    for (const activeToolCall of activeClientToolCallsRef.current.values()) {
+      cancelledClientToolCallIdsRef.current.add(activeToolCall.toolCallId);
+      activeToolCall.abortController.abort(reason);
+      activeToolCall.settled = true;
+      void Promise.resolve(activeToolCall.cancel()).catch(() => undefined);
+    }
+
+    activeClientToolCallsRef.current.clear();
+    setActiveClientToolCallCount(0);
+  }, []);
 
   const autoSendWhenComplete = useCallback((options: AutoSendPredicateArgs) => {
     if (manualStopRequestedRef.current) {
@@ -1523,6 +1537,10 @@ const Chat: React.FC<ChatProps> = ({
                   },
                 );
 
+                if (activeDashboardTool.abortController.signal.aborted) {
+                  return;
+                }
+
                 settleActiveClientToolCall(
                   toolName,
                   toolCall.toolCallId,
@@ -1532,7 +1550,10 @@ const Chat: React.FC<ChatProps> = ({
                   },
                 );
               } catch (dashboardError) {
-                if (manualStopRequestedRef.current) {
+                if (
+                  manualStopRequestedRef.current ||
+                  activeDashboardTool.abortController.signal.aborted
+                ) {
                   return;
                 }
                 settleActiveClientToolCall(toolName, toolCall.toolCallId, {
@@ -1768,6 +1789,7 @@ const Chat: React.FC<ChatProps> = ({
 
     onError: err => {
       console.error("[Chat] Error:", err);
+      cancelActiveClientToolCalls("stream-error");
       // When the stream disconnects (e.g. 524 timeout), tool calls may be
       // stuck in "input-available" state. The AI SDK blocks sendMessage until
       // all tool calls are settled. Patch them to "error" so the chat remains
@@ -1831,6 +1853,7 @@ const Chat: React.FC<ChatProps> = ({
       const executionId =
         options?.executionId ?? `chat-tool-${generateObjectId()}`;
 
+      cancelledClientToolCallIdsRef.current.delete(toolCallId);
       activeClientToolCallsRef.current.set(toolCallId, {
         toolCallId,
         toolName,
@@ -1841,6 +1864,7 @@ const Chat: React.FC<ChatProps> = ({
           options?.cancellationOutput ?? createCancellationOutput(toolName),
         settled: false,
       });
+      setActiveClientToolCallCount(activeClientToolCallsRef.current.size);
 
       return { abortController, executionId };
     },
@@ -1853,6 +1877,10 @@ const Chat: React.FC<ChatProps> = ({
       toolCallId: string,
       output: Record<string, unknown>,
     ): void => {
+      if (cancelledClientToolCallIdsRef.current.delete(toolCallId)) {
+        return;
+      }
+
       const activeToolCall = activeClientToolCallsRef.current.get(toolCallId);
       if (!activeToolCall) {
         if (!manualStopRequestedRef.current) {
@@ -1871,6 +1899,7 @@ const Chat: React.FC<ChatProps> = ({
       }
 
       activeClientToolCallsRef.current.delete(toolCallId);
+      setActiveClientToolCallCount(activeClientToolCallsRef.current.size);
     },
     [addToolOutput],
   );
@@ -1879,8 +1908,9 @@ const Chat: React.FC<ChatProps> = ({
     manualStopRequestedRef.current = true;
 
     for (const activeToolCall of activeClientToolCallsRef.current.values()) {
+      cancelledClientToolCallIdsRef.current.add(activeToolCall.toolCallId);
       activeToolCall.abortController.abort("chat-stop");
-      void activeToolCall.cancel();
+      void Promise.resolve(activeToolCall.cancel()).catch(() => undefined);
 
       if (!activeToolCall.settled) {
         activeToolCall.settled = true;
@@ -1893,10 +1923,14 @@ const Chat: React.FC<ChatProps> = ({
     }
 
     activeClientToolCallsRef.current.clear();
+    setActiveClientToolCallCount(0);
     stop();
   }, [addToolOutput, stop]);
 
-  const isLoading = status === "streaming" || status === "submitted";
+  const isLoading =
+    status === "streaming" ||
+    status === "submitted" ||
+    activeClientToolCallCount > 0;
   const lastMessage = messages.at(-1);
   const lastMessageParts = lastMessage?.parts ?? [];
   useRenderCount("Chat", {
@@ -2110,6 +2144,7 @@ const Chat: React.FC<ChatProps> = ({
 
   // Create new chat session - just generate a new ID locally (no API call needed)
   const createNewSession = () => {
+    cancelActiveClientToolCalls("session-change");
     manualStopRequestedRef.current = false;
     setChatId(generateObjectId());
     setMessages([]);
@@ -2125,6 +2160,7 @@ const Chat: React.FC<ChatProps> = ({
   };
 
   const handleSelectSession = (id: string) => {
+    cancelActiveClientToolCalls("session-change");
     manualStopRequestedRef.current = false;
     setChatId(id);
     setMessages([]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fix the user-visible bug where instant client-side tools like creating/opening a tab or setting a console connection resolve locally in milliseconds, but the assistant does not resume until much later.
- Root cause: AI SDK only sends the follow-up request with client tool outputs after the current SSE stream reaches its finish chunk. Awaited client-tool handling could block that stream reader from processing the finish chunk, so a fast tool result appeared to hang until an HTTP/proxy timeout.
- Run long-running dashboard client work asynchronously from `onToolCall`, matching the existing console tool pattern, so fast tool outputs are not held behind unrelated awaited client work.
- Keep active background client tools cancellable and counted in loading state so the Stop affordance remains available until tool output settles.
- Tombstone cancelled client tool calls and cancel active calls on stream errors/session changes to prevent stale late completions from writing into later chat state.
- Return an explicit error output for registered client tools that fall through without a browser handler, preventing pending tool calls from silently wedging chat continuation.

## Testing
- `pnpm --filter app run typecheck`
- `pnpm --filter app run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c36ea03-68d5-4ad7-9afd-85cea3e1d3db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c36ea03-68d5-4ad7-9afd-85cea3e1d3db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

