### PR TITLE
Fixed-width side panels on window resize

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -93,6 +93,17 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
 }
 
+function hasMeaningfulChange(
+  a: number | null,
+  b: number,
+  threshold = 2,
+): boolean {
+  if (a === null) {
+    return true;
+  }
+  return Math.abs(a - b) > threshold;
+}
+
 function MainApp() {
   const activeView = useUIStore(state => state.leftPane);
   const leftPaneOpen = useUIStore(state => state.leftPaneOpen);
@@ -107,7 +118,7 @@ function MainApp() {
   const rightPaneRef = useRef<ImperativePanelHandle | null>(null);
   const panelContainerRef = useRef<HTMLDivElement | null>(null);
   const isPanelDragRef = useRef(false);
-  const prevPanelContainerWidthRef = useRef(0);
+  const previousContainerWidthRef = useRef(0);
 
   // Initialize with window width to avoid 0 width on first render
   const [panelContainerWidth, setPanelContainerWidth] = useState(() =>
@@ -128,58 +139,51 @@ function MainApp() {
     return () => observer.disconnect();
   }, []);
 
-  // Calculate default and initial sizes
-  const defaultLeftPx = clamp(
-    (panelContainerWidth * DEFAULT_LEFT_PANE_SIZE) / 100,
-    SIDE_PANEL_MIN_DEFAULT_WIDTH_PX,
-    SIDE_PANEL_MAX_DEFAULT_WIDTH_PX,
-  );
+  // Freeze default pixel widths from the first measured container so side panels
+  // stay fixed even before the user has dragged a resize handle.
+  const defaultLeftPxRef = useRef<number | null>(null);
+  const defaultRightPxRef = useRef<number | null>(null);
+  if (panelContainerWidth > 0 && defaultLeftPxRef.current === null) {
+    defaultLeftPxRef.current = clamp(
+      (panelContainerWidth * DEFAULT_LEFT_PANE_SIZE) / 100,
+      SIDE_PANEL_MIN_DEFAULT_WIDTH_PX,
+      SIDE_PANEL_MAX_DEFAULT_WIDTH_PX,
+    );
+    defaultRightPxRef.current = clamp(
+      (panelContainerWidth * DEFAULT_RIGHT_PANE_SIZE) / 100,
+      SIDE_PANEL_MIN_DEFAULT_WIDTH_PX,
+      SIDE_PANEL_MAX_DEFAULT_WIDTH_PX,
+    );
+  }
+  const defaultLeftPx =
+    defaultLeftPxRef.current ?? SIDE_PANEL_MIN_DEFAULT_WIDTH_PX;
+  const defaultRightPx =
+    defaultRightPxRef.current ?? SIDE_PANEL_MIN_DEFAULT_WIDTH_PX;
 
-  const defaultRightPx = clamp(
-    (panelContainerWidth * DEFAULT_RIGHT_PANE_SIZE) / 100,
-    SIDE_PANEL_MIN_DEFAULT_WIDTH_PX,
-    SIDE_PANEL_MAX_DEFAULT_WIDTH_PX,
-  );
-
-  const initialLeftPx =
+  const targetLeftPx =
     leftPaneWidthPx && leftPaneWidthPx > 0 ? leftPaneWidthPx : defaultLeftPx;
-  const initialRightPx =
+  const targetRightPx =
     rightPaneWidthPx && rightPaneWidthPx > 0
       ? rightPaneWidthPx
       : defaultRightPx;
 
-  // Authoritative pixel widths for side panels (fixed on window resize).
-  const leftWidthPxRef = useRef(initialLeftPx);
-  const rightWidthPxRef = useRef(initialRightPx);
-  leftWidthPxRef.current = initialLeftPx;
-  rightWidthPxRef.current = initialRightPx;
-
   const toPanelPct = useCallback(
-    (px: number) => (px / panelContainerWidth) * 100,
+    (px: number) =>
+      panelContainerWidth > 0 ? (px / panelContainerWidth) * 100 : 0,
     [panelContainerWidth],
   );
 
-  // Convert to percentages for Panel
-  const leftSizePct = toPanelPct(initialLeftPx);
-  const rightSizePct = toPanelPct(initialRightPx);
+  const leftSizePct =
+    panelContainerWidth > 0 ? toPanelPct(targetLeftPx) : DEFAULT_LEFT_PANE_SIZE;
+  const rightSizePct =
+    panelContainerWidth > 0
+      ? toPanelPct(targetRightPx)
+      : DEFAULT_RIGHT_PANE_SIZE;
 
-  // Threshold for collapsing
   const collapseThresholdPct =
-    (SIDE_PANEL_COLLAPSE_THRESHOLD_PX / panelContainerWidth) * 100;
-
-  const applyFixedSidePanelSizes = useCallback(() => {
-    if (panelContainerWidth <= 0) return;
-
-    const leftPanel = leftPaneRef.current;
-    if (leftPaneOpen && leftPanel && !leftPanel.isCollapsed()) {
-      leftPanel.resize(toPanelPct(leftWidthPxRef.current));
-    }
-
-    const rightPanel = rightPaneRef.current;
-    if (rightPaneOpen && rightPanel && !rightPanel.isCollapsed()) {
-      rightPanel.resize(toPanelPct(rightWidthPxRef.current));
-    }
-  }, [leftPaneOpen, panelContainerWidth, rightPaneOpen, toPanelPct]);
+    panelContainerWidth > 0
+      ? (SIDE_PANEL_COLLAPSE_THRESHOLD_PX / panelContainerWidth) * 100
+      : 0;
 
   const persistSidePanelWidths = useCallback(
     (sizes: number[]) => {
@@ -190,21 +194,23 @@ function MainApp() {
         {};
 
       if (leftPct > 0) {
-        const px = (leftPct * panelContainerWidth) / 100;
-        leftWidthPxRef.current = px;
-        updates.leftPaneWidthPx = px;
+        const nextLeftPx = (leftPct * panelContainerWidth) / 100;
+        if (hasMeaningfulChange(leftPaneWidthPx, nextLeftPx)) {
+          updates.leftPaneWidthPx = nextLeftPx;
+        }
       }
       if (rightPct > 0) {
-        const px = (rightPct * panelContainerWidth) / 100;
-        rightWidthPxRef.current = px;
-        updates.rightPaneWidthPx = px;
+        const nextRightPx = (rightPct * panelContainerWidth) / 100;
+        if (hasMeaningfulChange(rightPaneWidthPx, nextRightPx)) {
+          updates.rightPaneWidthPx = nextRightPx;
+        }
       }
 
       if (Object.keys(updates).length > 0) {
         setPaneWidths(updates);
       }
     },
-    [panelContainerWidth, setPaneWidths],
+    [leftPaneWidthPx, panelContainerWidth, rightPaneWidthPx, setPaneWidths],
   );
 
   const persistSidePanelWidthsFromHandles = useCallback(() => {
@@ -214,37 +220,65 @@ function MainApp() {
 
     const leftPanel = leftPaneRef.current;
     if (leftPaneOpen && leftPanel && !leftPanel.isCollapsed()) {
-      const px = (leftPanel.getSize() * panelContainerWidth) / 100;
-      leftWidthPxRef.current = px;
-      updates.leftPaneWidthPx = px;
+      const nextLeftPx = (leftPanel.getSize() * panelContainerWidth) / 100;
+      if (hasMeaningfulChange(leftPaneWidthPx, nextLeftPx)) {
+        updates.leftPaneWidthPx = nextLeftPx;
+      }
     }
 
     const rightPanel = rightPaneRef.current;
     if (rightPaneOpen && rightPanel && !rightPanel.isCollapsed()) {
-      const px = (rightPanel.getSize() * panelContainerWidth) / 100;
-      rightWidthPxRef.current = px;
-      updates.rightPaneWidthPx = px;
+      const nextRightPx = (rightPanel.getSize() * panelContainerWidth) / 100;
+      if (hasMeaningfulChange(rightPaneWidthPx, nextRightPx)) {
+        updates.rightPaneWidthPx = nextRightPx;
+      }
     }
 
     if (Object.keys(updates).length > 0) {
       setPaneWidths(updates);
     }
-  }, [leftPaneOpen, panelContainerWidth, rightPaneOpen, setPaneWidths]);
+  }, [
+    leftPaneOpen,
+    leftPaneWidthPx,
+    panelContainerWidth,
+    rightPaneOpen,
+    rightPaneWidthPx,
+    setPaneWidths,
+  ]);
 
   // Keep side panels at fixed pixel width when the window/container resizes.
   useEffect(() => {
     if (panelContainerWidth <= 0) return;
 
-    const prevWidth = prevPanelContainerWidthRef.current;
-    prevPanelContainerWidthRef.current = panelContainerWidth;
+    const previousWidth = previousContainerWidthRef.current;
+    previousContainerWidthRef.current = panelContainerWidth;
 
-    if (prevWidth === 0 || prevWidth === panelContainerWidth) return;
+    if (
+      previousWidth === 0 ||
+      Math.abs(previousWidth - panelContainerWidth) < 1
+    ) {
+      return;
+    }
     if (isPanelDragRef.current) return;
 
-    applyFixedSidePanelSizes();
-  }, [applyFixedSidePanelSizes, panelContainerWidth]);
+    const leftPanel = leftPaneRef.current;
+    if (leftPaneOpen && leftPanel && !leftPanel.isCollapsed()) {
+      leftPanel.resize(toPanelPct(targetLeftPx));
+    }
 
-  // Handle layout changes (persistence) — only while the user drags a handle.
+    const rightPanel = rightPaneRef.current;
+    if (rightPaneOpen && rightPanel && !rightPanel.isCollapsed()) {
+      rightPanel.resize(toPanelPct(targetRightPx));
+    }
+  }, [
+    leftPaneOpen,
+    panelContainerWidth,
+    rightPaneOpen,
+    targetLeftPx,
+    targetRightPx,
+    toPanelPct,
+  ]);
+
   const persistTimeoutRef = useRef<number | null>(null);
   const handleLayout = useCallback(
     (sizes: number[]) => {
@@ -282,7 +316,7 @@ function MainApp() {
       const panel = leftPaneRef.current;
       if (panel && panel.isCollapsed()) {
         panel.expand();
-        panel.resize(toPanelPct(leftWidthPxRef.current));
+        panel.resize(toPanelPct(targetLeftPx));
       }
     } else if (!leftPaneOpen && prevLeftOpen.current) {
       const panel = leftPaneRef.current;
@@ -291,7 +325,7 @@ function MainApp() {
       }
     }
     prevLeftOpen.current = leftPaneOpen;
-  }, [leftPaneOpen, panelContainerWidth, toPanelPct]);
+  }, [leftPaneOpen, panelContainerWidth, targetLeftPx, toPanelPct]);
 
   // Handle external open/close for Right Pane
   const prevRightOpen = useRef(rightPaneOpen);
@@ -300,7 +334,7 @@ function MainApp() {
       const panel = rightPaneRef.current;
       if (panel && panel.isCollapsed()) {
         panel.expand();
-        panel.resize(toPanelPct(rightWidthPxRef.current));
+        panel.resize(toPanelPct(targetRightPx));
       }
     } else if (!rightPaneOpen && prevRightOpen.current) {
       const panel = rightPaneRef.current;
@@ -309,7 +343,7 @@ function MainApp() {
       }
     }
     prevRightOpen.current = rightPaneOpen;
-  }, [rightPaneOpen, panelContainerWidth, toPanelPct]);
+  }, [panelContainerWidth, rightPaneOpen, targetRightPx, toPanelPct]);
 
   const defaultLeftPanelSize = leftPaneOpen ? leftSizePct : 0;
   const defaultRightPanelSize = rightPaneOpen ? rightSizePct : 0;

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -106,6 +106,8 @@ function MainApp() {
   const leftPaneRef = useRef<ImperativePanelHandle | null>(null);
   const rightPaneRef = useRef<ImperativePanelHandle | null>(null);
   const panelContainerRef = useRef<HTMLDivElement | null>(null);
+  const isPanelDragRef = useRef(false);
+  const prevPanelContainerWidthRef = useRef(0);
 
   // Initialize with window width to avoid 0 width on first render
   const [panelContainerWidth, setPanelContainerWidth] = useState(() =>
@@ -146,43 +148,131 @@ function MainApp() {
       ? rightPaneWidthPx
       : defaultRightPx;
 
+  // Authoritative pixel widths for side panels (fixed on window resize).
+  const leftWidthPxRef = useRef(initialLeftPx);
+  const rightWidthPxRef = useRef(initialRightPx);
+  leftWidthPxRef.current = initialLeftPx;
+  rightWidthPxRef.current = initialRightPx;
+
+  const toPanelPct = useCallback(
+    (px: number) => (px / panelContainerWidth) * 100,
+    [panelContainerWidth],
+  );
+
   // Convert to percentages for Panel
-  const leftSizePct = (initialLeftPx / panelContainerWidth) * 100;
-  const rightSizePct = (initialRightPx / panelContainerWidth) * 100;
+  const leftSizePct = toPanelPct(initialLeftPx);
+  const rightSizePct = toPanelPct(initialRightPx);
 
   // Threshold for collapsing
   const collapseThresholdPct =
     (SIDE_PANEL_COLLAPSE_THRESHOLD_PX / panelContainerWidth) * 100;
 
-  // Handle layout changes (persistence)
+  const applyFixedSidePanelSizes = useCallback(() => {
+    if (panelContainerWidth <= 0) return;
+
+    const leftPanel = leftPaneRef.current;
+    if (leftPaneOpen && leftPanel && !leftPanel.isCollapsed()) {
+      leftPanel.resize(toPanelPct(leftWidthPxRef.current));
+    }
+
+    const rightPanel = rightPaneRef.current;
+    if (rightPaneOpen && rightPanel && !rightPanel.isCollapsed()) {
+      rightPanel.resize(toPanelPct(rightWidthPxRef.current));
+    }
+  }, [leftPaneOpen, panelContainerWidth, rightPaneOpen, toPanelPct]);
+
+  const persistSidePanelWidths = useCallback(
+    (sizes: number[]) => {
+      if (panelContainerWidth <= 0) return;
+
+      const [leftPct, , rightPct] = sizes;
+      const updates: { leftPaneWidthPx?: number; rightPaneWidthPx?: number } =
+        {};
+
+      if (leftPct > 0) {
+        const px = (leftPct * panelContainerWidth) / 100;
+        leftWidthPxRef.current = px;
+        updates.leftPaneWidthPx = px;
+      }
+      if (rightPct > 0) {
+        const px = (rightPct * panelContainerWidth) / 100;
+        rightWidthPxRef.current = px;
+        updates.rightPaneWidthPx = px;
+      }
+
+      if (Object.keys(updates).length > 0) {
+        setPaneWidths(updates);
+      }
+    },
+    [panelContainerWidth, setPaneWidths],
+  );
+
+  const persistSidePanelWidthsFromHandles = useCallback(() => {
+    if (panelContainerWidth <= 0) return;
+
+    const updates: { leftPaneWidthPx?: number; rightPaneWidthPx?: number } = {};
+
+    const leftPanel = leftPaneRef.current;
+    if (leftPaneOpen && leftPanel && !leftPanel.isCollapsed()) {
+      const px = (leftPanel.getSize() * panelContainerWidth) / 100;
+      leftWidthPxRef.current = px;
+      updates.leftPaneWidthPx = px;
+    }
+
+    const rightPanel = rightPaneRef.current;
+    if (rightPaneOpen && rightPanel && !rightPanel.isCollapsed()) {
+      const px = (rightPanel.getSize() * panelContainerWidth) / 100;
+      rightWidthPxRef.current = px;
+      updates.rightPaneWidthPx = px;
+    }
+
+    if (Object.keys(updates).length > 0) {
+      setPaneWidths(updates);
+    }
+  }, [leftPaneOpen, panelContainerWidth, rightPaneOpen, setPaneWidths]);
+
+  // Keep side panels at fixed pixel width when the window/container resizes.
+  useEffect(() => {
+    if (panelContainerWidth <= 0) return;
+
+    const prevWidth = prevPanelContainerWidthRef.current;
+    prevPanelContainerWidthRef.current = panelContainerWidth;
+
+    if (prevWidth === 0 || prevWidth === panelContainerWidth) return;
+    if (isPanelDragRef.current) return;
+
+    applyFixedSidePanelSizes();
+  }, [applyFixedSidePanelSizes, panelContainerWidth]);
+
+  // Handle layout changes (persistence) — only while the user drags a handle.
   const persistTimeoutRef = useRef<number | null>(null);
   const handleLayout = useCallback(
     (sizes: number[]) => {
-      if (panelContainerWidth <= 0) return;
+      if (!isPanelDragRef.current || panelContainerWidth <= 0) return;
 
       if (persistTimeoutRef.current) {
         clearTimeout(persistTimeoutRef.current);
       }
 
       persistTimeoutRef.current = window.setTimeout(() => {
-        const [leftPct, , rightPct] = sizes;
-        const updates: { leftPaneWidthPx?: number; rightPaneWidthPx?: number } =
-          {};
-
-        // Only save if panel is actually open (size > 0)
-        if (leftPct > 0) {
-          updates.leftPaneWidthPx = (leftPct * panelContainerWidth) / 100;
-        }
-        if (rightPct > 0) {
-          updates.rightPaneWidthPx = (rightPct * panelContainerWidth) / 100;
-        }
-
-        if (Object.keys(updates).length > 0) {
-          setPaneWidths(updates);
-        }
+        persistSidePanelWidths(sizes);
       }, 200);
     },
-    [panelContainerWidth, setPaneWidths],
+    [panelContainerWidth, persistSidePanelWidths],
+  );
+
+  const handlePanelDrag = useCallback(
+    (isDragging: boolean) => {
+      isPanelDragRef.current = isDragging;
+      if (!isDragging) {
+        if (persistTimeoutRef.current) {
+          clearTimeout(persistTimeoutRef.current);
+          persistTimeoutRef.current = null;
+        }
+        persistSidePanelWidthsFromHandles();
+      }
+    },
+    [persistSidePanelWidthsFromHandles],
   );
 
   // Handle external open/close for Left Pane
@@ -192,7 +282,7 @@ function MainApp() {
       const panel = leftPaneRef.current;
       if (panel && panel.isCollapsed()) {
         panel.expand();
-        panel.resize((defaultLeftPx / panelContainerWidth) * 100);
+        panel.resize(toPanelPct(leftWidthPxRef.current));
       }
     } else if (!leftPaneOpen && prevLeftOpen.current) {
       const panel = leftPaneRef.current;
@@ -201,7 +291,7 @@ function MainApp() {
       }
     }
     prevLeftOpen.current = leftPaneOpen;
-  }, [leftPaneOpen, defaultLeftPx, panelContainerWidth]);
+  }, [leftPaneOpen, panelContainerWidth, toPanelPct]);
 
   // Handle external open/close for Right Pane
   const prevRightOpen = useRef(rightPaneOpen);
@@ -210,7 +300,7 @@ function MainApp() {
       const panel = rightPaneRef.current;
       if (panel && panel.isCollapsed()) {
         panel.expand();
-        panel.resize((defaultRightPx / panelContainerWidth) * 100);
+        panel.resize(toPanelPct(rightWidthPxRef.current));
       }
     } else if (!rightPaneOpen && prevRightOpen.current) {
       const panel = rightPaneRef.current;
@@ -219,7 +309,7 @@ function MainApp() {
       }
     }
     prevRightOpen.current = rightPaneOpen;
-  }, [rightPaneOpen, defaultRightPx, panelContainerWidth]);
+  }, [rightPaneOpen, panelContainerWidth, toPanelPct]);
 
   const defaultLeftPanelSize = leftPaneOpen ? leftSizePct : 0;
   const defaultRightPanelSize = rightPaneOpen ? rightSizePct : 0;
@@ -560,6 +650,7 @@ function MainApp() {
             </Panel>
 
             <StyledHorizontalResizeHandle
+              onDragging={handlePanelDrag}
               style={
                 leftPaneOpen
                   ? undefined
@@ -582,6 +673,7 @@ function MainApp() {
             </Panel>
 
             <StyledHorizontalResizeHandle
+              onDragging={handlePanelDrag}
               style={
                 rightPaneOpen
                   ? undefined

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,12 +1,5 @@
-import {
-  Suspense,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  lazy,
-} from "react";
-import { Box, CircularProgress, styled } from "@mui/material";
+import { Suspense, useCallback, useEffect, useRef, lazy } from "react";
+import { Box, CircularProgress } from "@mui/material";
 import {
   Routes,
   Route,
@@ -18,20 +11,12 @@ import {
 import { trackPageView } from "./lib/analytics";
 import Sidebar from "./components/Sidebar";
 import {
-  DEFAULT_LEFT_PANE_SIZE,
-  DEFAULT_RIGHT_PANE_SIZE,
-  SIDE_PANEL_COLLAPSE_THRESHOLD_PX,
-  SIDE_PANEL_MAX_DEFAULT_WIDTH_PX,
-  SIDE_PANEL_MIN_DEFAULT_WIDTH_PX,
+  DEFAULT_LEFT_PANE_WIDTH_PX,
+  DEFAULT_RIGHT_PANE_WIDTH_PX,
   useUIStore,
 } from "./store/uiStore";
 import { useConsoleStore } from "./store/consoleStore";
-import {
-  Panel,
-  PanelGroup,
-  PanelResizeHandle,
-  type ImperativePanelHandle,
-} from "react-resizable-panels";
+import { FixedPixelSplitLayout } from "./components/FixedPixelSplitLayout";
 import Chat from "./components/Chat";
 import DatabaseExplorer, {
   type CollectionInfo,
@@ -58,17 +43,6 @@ import { ResetPasswordPage } from "./components/ResetPasswordPage";
 import { useAuth } from "./contexts/auth-context";
 import { OnboardingFlow } from "./components/OnboardingFlow";
 
-// Styled PanelResizeHandle components (moved from Databases.tsx/Consoles.tsx)
-const StyledHorizontalResizeHandle = styled(PanelResizeHandle)(({ theme }) => ({
-  width: "4px",
-  background: theme.palette.divider,
-  cursor: "col-resize",
-  transition: "background-color 0.2s ease",
-  "&:hover": {
-    backgroundColor: theme.palette.primary.main,
-  },
-}));
-
 // Component for the invite page route
 function InvitePage() {
   const { token } = useParams<{ token: string }>();
@@ -87,23 +61,6 @@ function InvitePage() {
 import { UrlSync } from "./components/UrlSync";
 
 // Main application component (extracted from original App)
-const EDITOR_PANEL_MIN_SIZE = 30;
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(Math.max(value, min), max);
-}
-
-function hasMeaningfulChange(
-  a: number | null,
-  b: number,
-  threshold = 2,
-): boolean {
-  if (a === null) {
-    return true;
-  }
-  return Math.abs(a - b) > threshold;
-}
-
 function MainApp() {
   const activeView = useUIStore(state => state.leftPane);
   const leftPaneOpen = useUIStore(state => state.leftPaneOpen);
@@ -114,239 +71,28 @@ function MainApp() {
   const rightPaneWidthPx = useUIStore(state => state.rightPaneWidthPx);
   const setPaneWidths = useUIStore(state => state.setPaneWidths);
 
-  const leftPaneRef = useRef<ImperativePanelHandle | null>(null);
-  const rightPaneRef = useRef<ImperativePanelHandle | null>(null);
-  const panelContainerRef = useRef<HTMLDivElement | null>(null);
-  const isPanelDragRef = useRef(false);
-  const previousContainerWidthRef = useRef(0);
-
-  // Initialize with window width to avoid 0 width on first render
-  const [panelContainerWidth, setPanelContainerWidth] = useState(() =>
-    typeof window === "undefined" ? 1000 : window.innerWidth - 52,
-  );
-
-  // Keep container width updated
-  useEffect(() => {
-    const el = panelContainerRef.current;
-    if (!el) return;
-    const observer = new ResizeObserver(entries => {
-      const newWidth = entries[0].contentRect.width;
-      if (newWidth > 0) {
-        setPanelContainerWidth(newWidth);
-      }
-    });
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, []);
-
-  // Freeze default pixel widths from the first measured container so side panels
-  // stay fixed even before the user has dragged a resize handle.
-  const defaultLeftPxRef = useRef<number | null>(null);
-  const defaultRightPxRef = useRef<number | null>(null);
-  if (panelContainerWidth > 0 && defaultLeftPxRef.current === null) {
-    defaultLeftPxRef.current = clamp(
-      (panelContainerWidth * DEFAULT_LEFT_PANE_SIZE) / 100,
-      SIDE_PANEL_MIN_DEFAULT_WIDTH_PX,
-      SIDE_PANEL_MAX_DEFAULT_WIDTH_PX,
-    );
-    defaultRightPxRef.current = clamp(
-      (panelContainerWidth * DEFAULT_RIGHT_PANE_SIZE) / 100,
-      SIDE_PANEL_MIN_DEFAULT_WIDTH_PX,
-      SIDE_PANEL_MAX_DEFAULT_WIDTH_PX,
-    );
-  }
-  const defaultLeftPx =
-    defaultLeftPxRef.current ?? SIDE_PANEL_MIN_DEFAULT_WIDTH_PX;
-  const defaultRightPx =
-    defaultRightPxRef.current ?? SIDE_PANEL_MIN_DEFAULT_WIDTH_PX;
-
-  const targetLeftPx =
-    leftPaneWidthPx && leftPaneWidthPx > 0 ? leftPaneWidthPx : defaultLeftPx;
-  const targetRightPx =
+  const leftWidthPx =
+    leftPaneWidthPx && leftPaneWidthPx > 0
+      ? leftPaneWidthPx
+      : DEFAULT_LEFT_PANE_WIDTH_PX;
+  const rightWidthPx =
     rightPaneWidthPx && rightPaneWidthPx > 0
       ? rightPaneWidthPx
-      : defaultRightPx;
+      : DEFAULT_RIGHT_PANE_WIDTH_PX;
 
-  const toPanelPct = useCallback(
-    (px: number) =>
-      panelContainerWidth > 0 ? (px / panelContainerWidth) * 100 : 0,
-    [panelContainerWidth],
-  );
-
-  const leftSizePct =
-    panelContainerWidth > 0 ? toPanelPct(targetLeftPx) : DEFAULT_LEFT_PANE_SIZE;
-  const rightSizePct =
-    panelContainerWidth > 0
-      ? toPanelPct(targetRightPx)
-      : DEFAULT_RIGHT_PANE_SIZE;
-
-  const collapseThresholdPct =
-    panelContainerWidth > 0
-      ? (SIDE_PANEL_COLLAPSE_THRESHOLD_PX / panelContainerWidth) * 100
-      : 0;
-
-  const persistSidePanelWidths = useCallback(
-    (sizes: number[]) => {
-      if (panelContainerWidth <= 0) return;
-
-      const [leftPct, , rightPct] = sizes;
-      const updates: { leftPaneWidthPx?: number; rightPaneWidthPx?: number } =
-        {};
-
-      if (leftPct > 0) {
-        const nextLeftPx = (leftPct * panelContainerWidth) / 100;
-        if (hasMeaningfulChange(leftPaneWidthPx, nextLeftPx)) {
-          updates.leftPaneWidthPx = nextLeftPx;
-        }
-      }
-      if (rightPct > 0) {
-        const nextRightPx = (rightPct * panelContainerWidth) / 100;
-        if (hasMeaningfulChange(rightPaneWidthPx, nextRightPx)) {
-          updates.rightPaneWidthPx = nextRightPx;
-        }
-      }
-
-      if (Object.keys(updates).length > 0) {
-        setPaneWidths(updates);
-      }
+  const handleLeftWidthChange = useCallback(
+    (widthPx: number) => {
+      setPaneWidths({ leftPaneWidthPx: widthPx });
     },
-    [leftPaneWidthPx, panelContainerWidth, rightPaneWidthPx, setPaneWidths],
+    [setPaneWidths],
   );
 
-  const persistSidePanelWidthsFromHandles = useCallback(() => {
-    if (panelContainerWidth <= 0) return;
-
-    const updates: { leftPaneWidthPx?: number; rightPaneWidthPx?: number } = {};
-
-    const leftPanel = leftPaneRef.current;
-    if (leftPaneOpen && leftPanel && !leftPanel.isCollapsed()) {
-      const nextLeftPx = (leftPanel.getSize() * panelContainerWidth) / 100;
-      if (hasMeaningfulChange(leftPaneWidthPx, nextLeftPx)) {
-        updates.leftPaneWidthPx = nextLeftPx;
-      }
-    }
-
-    const rightPanel = rightPaneRef.current;
-    if (rightPaneOpen && rightPanel && !rightPanel.isCollapsed()) {
-      const nextRightPx = (rightPanel.getSize() * panelContainerWidth) / 100;
-      if (hasMeaningfulChange(rightPaneWidthPx, nextRightPx)) {
-        updates.rightPaneWidthPx = nextRightPx;
-      }
-    }
-
-    if (Object.keys(updates).length > 0) {
-      setPaneWidths(updates);
-    }
-  }, [
-    leftPaneOpen,
-    leftPaneWidthPx,
-    panelContainerWidth,
-    rightPaneOpen,
-    rightPaneWidthPx,
-    setPaneWidths,
-  ]);
-
-  // Keep side panels at fixed pixel width when the window/container resizes.
-  useEffect(() => {
-    if (panelContainerWidth <= 0) return;
-
-    const previousWidth = previousContainerWidthRef.current;
-    previousContainerWidthRef.current = panelContainerWidth;
-
-    if (
-      previousWidth === 0 ||
-      Math.abs(previousWidth - panelContainerWidth) < 1
-    ) {
-      return;
-    }
-    if (isPanelDragRef.current) return;
-
-    const leftPanel = leftPaneRef.current;
-    if (leftPaneOpen && leftPanel && !leftPanel.isCollapsed()) {
-      leftPanel.resize(toPanelPct(targetLeftPx));
-    }
-
-    const rightPanel = rightPaneRef.current;
-    if (rightPaneOpen && rightPanel && !rightPanel.isCollapsed()) {
-      rightPanel.resize(toPanelPct(targetRightPx));
-    }
-  }, [
-    leftPaneOpen,
-    panelContainerWidth,
-    rightPaneOpen,
-    targetLeftPx,
-    targetRightPx,
-    toPanelPct,
-  ]);
-
-  const persistTimeoutRef = useRef<number | null>(null);
-  const handleLayout = useCallback(
-    (sizes: number[]) => {
-      if (!isPanelDragRef.current || panelContainerWidth <= 0) return;
-
-      if (persistTimeoutRef.current) {
-        clearTimeout(persistTimeoutRef.current);
-      }
-
-      persistTimeoutRef.current = window.setTimeout(() => {
-        persistSidePanelWidths(sizes);
-      }, 200);
+  const handleRightWidthChange = useCallback(
+    (widthPx: number) => {
+      setPaneWidths({ rightPaneWidthPx: widthPx });
     },
-    [panelContainerWidth, persistSidePanelWidths],
+    [setPaneWidths],
   );
-
-  const handlePanelDrag = useCallback(
-    (isDragging: boolean) => {
-      isPanelDragRef.current = isDragging;
-      if (!isDragging) {
-        if (persistTimeoutRef.current) {
-          clearTimeout(persistTimeoutRef.current);
-          persistTimeoutRef.current = null;
-        }
-        persistSidePanelWidthsFromHandles();
-      }
-    },
-    [persistSidePanelWidthsFromHandles],
-  );
-
-  // Handle external open/close for Left Pane
-  const prevLeftOpen = useRef(leftPaneOpen);
-  useEffect(() => {
-    if (leftPaneOpen && !prevLeftOpen.current) {
-      const panel = leftPaneRef.current;
-      if (panel && panel.isCollapsed()) {
-        panel.expand();
-        panel.resize(toPanelPct(targetLeftPx));
-      }
-    } else if (!leftPaneOpen && prevLeftOpen.current) {
-      const panel = leftPaneRef.current;
-      if (panel && !panel.isCollapsed()) {
-        panel.collapse();
-      }
-    }
-    prevLeftOpen.current = leftPaneOpen;
-  }, [leftPaneOpen, panelContainerWidth, targetLeftPx, toPanelPct]);
-
-  // Handle external open/close for Right Pane
-  const prevRightOpen = useRef(rightPaneOpen);
-  useEffect(() => {
-    if (rightPaneOpen && !prevRightOpen.current) {
-      const panel = rightPaneRef.current;
-      if (panel && panel.isCollapsed()) {
-        panel.expand();
-        panel.resize(toPanelPct(targetRightPx));
-      }
-    } else if (!rightPaneOpen && prevRightOpen.current) {
-      const panel = rightPaneRef.current;
-      if (panel && !panel.isCollapsed()) {
-        panel.collapse();
-      }
-    }
-    prevRightOpen.current = rightPaneOpen;
-  }, [panelContainerWidth, rightPaneOpen, targetRightPx, toPanelPct]);
-
-  const defaultLeftPanelSize = leftPaneOpen ? leftSizePct : 0;
-  const defaultRightPanelSize = rightPaneOpen ? rightSizePct : 0;
 
   // Ref for DbFlowForm - allows AI agent to manipulate form state
   const dbFlowFormRef = useRef<DbFlowFormRef | null>(null);
@@ -645,107 +391,50 @@ function MainApp() {
         {/* Sidebar Navigation */}
         <Sidebar />
 
-        <Box
-          ref={panelContainerRef}
-          sx={{ height: "100%", flex: 1, minWidth: 0 }}
-        >
-          <PanelGroup
-            direction="horizontal"
-            style={{ height: "100%", width: "100%" }}
-            onLayout={handleLayout}
-          >
-            <Panel
-              ref={leftPaneRef}
-              collapsible
-              collapsedSize={0}
-              defaultSize={defaultLeftPanelSize}
-              minSize={collapseThresholdPct}
-              onCollapse={() => setLeftPaneOpen(false)}
-              onExpand={() => setLeftPaneOpen(true)}
-            >
-              <Box sx={{ height: "100%", overflow: "hidden" }}>
-                <Suspense
-                  fallback={
-                    <Box
-                      sx={{
-                        height: "100%",
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                      }}
-                    >
-                      <CircularProgress size={20} />
-                    </Box>
-                  }
-                >
-                  {renderLeftPane()}
-                </Suspense>
-              </Box>
-            </Panel>
-
-            <StyledHorizontalResizeHandle
-              onDragging={handlePanelDrag}
-              style={
-                leftPaneOpen
-                  ? undefined
-                  : {
-                      width: 0,
-                      minWidth: 0,
-                      opacity: 0,
-                      pointerEvents: "none",
-                    }
-              }
-            />
-
-            {/* Editor + Results vertical layout inside Editor component */}
-            <Panel minSize={EDITOR_PANEL_MIN_SIZE}>
+        <Box sx={{ height: "100%", flex: 1, minWidth: 0 }}>
+          <FixedPixelSplitLayout
+            leftOpen={leftPaneOpen}
+            rightOpen={rightPaneOpen}
+            leftWidthPx={leftWidthPx}
+            rightWidthPx={rightWidthPx}
+            onLeftWidthChange={handleLeftWidthChange}
+            onRightWidthChange={handleRightWidthChange}
+            onLeftCollapse={() => setLeftPaneOpen(false)}
+            onRightCollapse={() => setRightPaneOpen(false)}
+            left={
+              <Suspense
+                fallback={
+                  <Box
+                    sx={{
+                      height: "100%",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                    }}
+                  >
+                    <CircularProgress size={20} />
+                  </Box>
+                }
+              >
+                {renderLeftPane()}
+              </Suspense>
+            }
+            center={
               <Editor
                 dbFlowFormRef={dbFlowFormRef}
                 onChartSpecChangeRef={onChartSpecChangeRef}
                 resultsContextRef={resultsContextRef}
               />
-            </Panel>
-
-            <StyledHorizontalResizeHandle
-              onDragging={handlePanelDrag}
-              style={
-                rightPaneOpen
-                  ? undefined
-                  : {
-                      width: 0,
-                      minWidth: 0,
-                      opacity: 0,
-                      pointerEvents: "none",
-                    }
-              }
-            />
-
-            <Panel
-              ref={rightPaneRef}
-              collapsible
-              collapsedSize={0}
-              defaultSize={defaultRightPanelSize}
-              minSize={collapseThresholdPct}
-              onCollapse={() => setRightPaneOpen(false)}
-              onExpand={() => setRightPaneOpen(true)}
-            >
-              <Box
-                sx={{
-                  height: "100%",
-                  overflow: "hidden",
-                  borderLeft: "1px solid",
-                  borderColor: "divider",
-                }}
-              >
-                <Chat
-                  onConsoleModification={handleConsoleModification}
-                  dbFlowFormRef={dbFlowFormRef}
-                  onChartSpecChangeRef={onChartSpecChangeRef}
-                  resultsContextRef={resultsContextRef}
-                />
-              </Box>
-            </Panel>
-          </PanelGroup>
+            }
+            right={
+              <Chat
+                onConsoleModification={handleConsoleModification}
+                dbFlowFormRef={dbFlowFormRef}
+                onChartSpecChangeRef={onChartSpecChangeRef}
+                resultsContextRef={resultsContextRef}
+              />
+            }
+          />
         </Box>
       </Box>
     </AuthWrapper>

--- a/app/src/components/FixedPixelSplitLayout.tsx
+++ b/app/src/components/FixedPixelSplitLayout.tsx
@@ -1,0 +1,234 @@
+import { useCallback, useRef, type ReactNode } from "react";
+import { Box, styled } from "@mui/material";
+import {
+  SIDE_PANEL_COLLAPSE_THRESHOLD_PX,
+  SIDE_PANEL_MAX_WIDTH_PX,
+  SIDE_PANEL_MIN_WIDTH_PX,
+} from "../store/uiStore";
+
+const MIN_CENTER_PANEL_WIDTH_PX = 320;
+const HANDLE_WIDTH_PX = 4;
+
+const ResizeHandle = styled("div")(({ theme }) => ({
+  width: HANDLE_WIDTH_PX,
+  flexShrink: 0,
+  background: theme.palette.divider,
+  cursor: "col-resize",
+  transition: "background-color 0.2s ease",
+  touchAction: "none",
+  "&:hover": {
+    backgroundColor: theme.palette.primary.main,
+  },
+}));
+
+function clampWidth(px: number): number {
+  return Math.min(
+    Math.max(px, SIDE_PANEL_MIN_WIDTH_PX),
+    SIDE_PANEL_MAX_WIDTH_PX,
+  );
+}
+
+type DragSide = "left" | "right";
+
+function usePixelResizeDrag({
+  side,
+  getStartWidth,
+  onWidthChange,
+  onDragEnd,
+  getMaxWidth,
+}: {
+  side: DragSide;
+  getStartWidth: () => number;
+  onWidthChange: (widthPx: number) => void;
+  onDragEnd?: (widthPx: number) => void;
+  getMaxWidth: () => number;
+}) {
+  const dragStartXRef = useRef(0);
+  const dragStartWidthRef = useRef(0);
+
+  const onPointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      const handle = event.currentTarget;
+      handle.setPointerCapture(event.pointerId);
+      dragStartXRef.current = event.clientX;
+      dragStartWidthRef.current = getStartWidth();
+
+      const onPointerMove = (moveEvent: PointerEvent) => {
+        if (moveEvent.pointerId !== event.pointerId) return;
+        const deltaX = moveEvent.clientX - dragStartXRef.current;
+        const signedDelta = side === "left" ? deltaX : -deltaX;
+        const maxWidth = getMaxWidth();
+        const nextWidth = clampWidth(
+          Math.min(dragStartWidthRef.current + signedDelta, maxWidth),
+        );
+        onWidthChange(nextWidth);
+      };
+
+      const onPointerUp = (upEvent: PointerEvent) => {
+        if (upEvent.pointerId !== event.pointerId) return;
+        handle.releasePointerCapture(event.pointerId);
+        window.removeEventListener("pointermove", onPointerMove);
+        window.removeEventListener("pointerup", onPointerUp);
+        window.removeEventListener("pointercancel", onPointerUp);
+        const deltaX = upEvent.clientX - dragStartXRef.current;
+        const signedDelta = side === "left" ? deltaX : -deltaX;
+        const maxWidth = getMaxWidth();
+        const finalWidth = clampWidth(
+          Math.min(dragStartWidthRef.current + signedDelta, maxWidth),
+        );
+        onDragEnd?.(finalWidth);
+      };
+
+      window.addEventListener("pointermove", onPointerMove);
+      window.addEventListener("pointerup", onPointerUp);
+      window.addEventListener("pointercancel", onPointerUp);
+    },
+    [getMaxWidth, getStartWidth, onDragEnd, onWidthChange, side],
+  );
+
+  return onPointerDown;
+}
+
+export interface FixedPixelSplitLayoutProps {
+  leftOpen: boolean;
+  rightOpen: boolean;
+  leftWidthPx: number;
+  rightWidthPx: number;
+  onLeftWidthChange: (widthPx: number) => void;
+  onRightWidthChange: (widthPx: number) => void;
+  onLeftCollapse: () => void;
+  onRightCollapse: () => void;
+  left: ReactNode;
+  center: ReactNode;
+  right: ReactNode;
+}
+
+export function FixedPixelSplitLayout({
+  leftOpen,
+  rightOpen,
+  leftWidthPx,
+  rightWidthPx,
+  onLeftWidthChange,
+  onRightWidthChange,
+  onLeftCollapse,
+  onRightCollapse,
+  left,
+  center,
+  right,
+}: FixedPixelSplitLayoutProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const getMaxLeftWidth = useCallback(() => {
+    const containerWidth = containerRef.current?.clientWidth ?? 0;
+    if (containerWidth <= 0) return SIDE_PANEL_MAX_WIDTH_PX;
+    const rightOccupied = rightOpen ? rightWidthPx + HANDLE_WIDTH_PX : 0;
+    const leftHandle = leftOpen ? HANDLE_WIDTH_PX : 0;
+    return Math.max(
+      SIDE_PANEL_MIN_WIDTH_PX,
+      containerWidth - rightOccupied - leftHandle - MIN_CENTER_PANEL_WIDTH_PX,
+    );
+  }, [leftOpen, rightOpen, rightWidthPx]);
+
+  const getMaxRightWidth = useCallback(() => {
+    const containerWidth = containerRef.current?.clientWidth ?? 0;
+    if (containerWidth <= 0) return SIDE_PANEL_MAX_WIDTH_PX;
+    const leftOccupied = leftOpen ? leftWidthPx + HANDLE_WIDTH_PX : 0;
+    const rightHandle = rightOpen ? HANDLE_WIDTH_PX : 0;
+    return Math.max(
+      SIDE_PANEL_MIN_WIDTH_PX,
+      containerWidth - leftOccupied - rightHandle - MIN_CENTER_PANEL_WIDTH_PX,
+    );
+  }, [leftOpen, leftWidthPx, rightOpen]);
+
+  const finishLeftDrag = useCallback(
+    (widthPx: number) => {
+      if (widthPx < SIDE_PANEL_COLLAPSE_THRESHOLD_PX) {
+        onLeftCollapse();
+        return;
+      }
+      onLeftWidthChange(widthPx);
+    },
+    [onLeftCollapse, onLeftWidthChange],
+  );
+
+  const finishRightDrag = useCallback(
+    (widthPx: number) => {
+      if (widthPx < SIDE_PANEL_COLLAPSE_THRESHOLD_PX) {
+        onRightCollapse();
+        return;
+      }
+      onRightWidthChange(widthPx);
+    },
+    [onRightCollapse, onRightWidthChange],
+  );
+
+  const onLeftHandlePointerDown = usePixelResizeDrag({
+    side: "left",
+    getStartWidth: () => leftWidthPx,
+    onWidthChange: onLeftWidthChange,
+    onDragEnd: finishLeftDrag,
+    getMaxWidth: getMaxLeftWidth,
+  });
+
+  const onRightHandlePointerDown = usePixelResizeDrag({
+    side: "right",
+    getStartWidth: () => rightWidthPx,
+    onWidthChange: onRightWidthChange,
+    onDragEnd: finishRightDrag,
+    getMaxWidth: getMaxRightWidth,
+  });
+
+  return (
+    <Box
+      ref={containerRef}
+      sx={{
+        display: "flex",
+        height: "100%",
+        width: "100%",
+        minWidth: 0,
+        overflow: "hidden",
+      }}
+    >
+      {leftOpen ? (
+        <>
+          <Box
+            sx={{
+              width: leftWidthPx,
+              flexShrink: 0,
+              height: "100%",
+              overflow: "hidden",
+              minWidth: 0,
+            }}
+          >
+            {left}
+          </Box>
+          <ResizeHandle onPointerDown={onLeftHandlePointerDown} />
+        </>
+      ) : null}
+
+      <Box sx={{ flex: 1, minWidth: 0, height: "100%", overflow: "hidden" }}>
+        {center}
+      </Box>
+
+      {rightOpen ? (
+        <>
+          <ResizeHandle onPointerDown={onRightHandlePointerDown} />
+          <Box
+            sx={{
+              width: rightWidthPx,
+              flexShrink: 0,
+              height: "100%",
+              overflow: "hidden",
+              minWidth: 0,
+              borderLeft: "1px solid",
+              borderColor: "divider",
+            }}
+          >
+            {right}
+          </Box>
+        </>
+      ) : null}
+    </Box>
+  );
+}

--- a/app/src/store/uiStore.ts
+++ b/app/src/store/uiStore.ts
@@ -10,10 +10,20 @@ import { persist } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 import type { LeftPaneView } from "./lib/types";
 
+/** @deprecated Percent defaults — use DEFAULT_*_PANE_WIDTH_PX for layout */
 export const DEFAULT_LEFT_PANE_SIZE = 15;
+/** @deprecated Percent defaults — use DEFAULT_*_PANE_WIDTH_PX for layout */
 export const DEFAULT_RIGHT_PANE_SIZE = 20;
+/** @deprecated Use SIDE_PANEL_MIN_WIDTH_PX */
 export const SIDE_PANEL_MIN_DEFAULT_WIDTH_PX = 150;
+/** @deprecated Use SIDE_PANEL_MAX_WIDTH_PX */
 export const SIDE_PANEL_MAX_DEFAULT_WIDTH_PX = 300;
+
+/** Default fixed widths for explorer (left) and chat (right) panes */
+export const DEFAULT_LEFT_PANE_WIDTH_PX = 260;
+export const DEFAULT_RIGHT_PANE_WIDTH_PX = 400;
+export const SIDE_PANEL_MIN_WIDTH_PX = 150;
+export const SIDE_PANEL_MAX_WIDTH_PX = 600;
 export const SIDE_PANEL_COLLAPSE_THRESHOLD_PX = 120;
 
 interface ActiveEditorContent {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When resizing the browser window, the left explorer and right chat panels now keep their pixel width (like Slack/Cursor). Only the center console/editor panel grows or shrinks.

Manual drag-resize of the panel handles still works and persists widths to local storage as before.

## Changes

- Track authoritative side panel widths in refs (synced with persisted `leftPaneWidthPx` / `rightPaneWidthPx`)
- On container resize, imperatively restore side panels to their fixed pixel widths
- Only persist layout changes while the user is dragging a resize handle (`onDragging`)

## Test plan

- [ ] Resize browser window: left explorer and chat stay same width; editor area changes
- [ ] Drag left/right resize handles: panels resize and preference persists after reload
- [ ] Collapse/expand left or right pane via sidebar buttons: still works
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d19d760-e32d-4679-ac60-dd2281be9d9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d19d760-e32d-4679-ac60-dd2281be9d9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

