### PR TITLE
Add smart responsive fallback behavior for dashboard grids

### DIFF
--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -2758,6 +2758,7 @@ export interface IDashboard extends Document {
         h: number;
         minW?: number;
         minH?: number;
+        custom?: boolean;
       };
       sm?: {
         x: number;
@@ -2766,6 +2767,7 @@ export interface IDashboard extends Document {
         h: number;
         minW?: number;
         minH?: number;
+        custom?: boolean;
       };
       xs?: {
         x: number;
@@ -2774,6 +2776,7 @@ export interface IDashboard extends Document {
         h: number;
         minW?: number;
         minH?: number;
+        custom?: boolean;
       };
     };
   }>;
@@ -3066,6 +3069,7 @@ const DashboardSchema = new Schema<IDashboard>(
             h: { type: Number },
             minW: { type: Number },
             minH: { type: Number },
+            custom: { type: Boolean },
           },
           sm: {
             x: { type: Number },
@@ -3074,6 +3078,7 @@ const DashboardSchema = new Schema<IDashboard>(
             h: { type: Number },
             minW: { type: Number },
             minH: { type: Number },
+            custom: { type: Boolean },
           },
           xs: {
             x: { type: Number },
@@ -3082,6 +3087,7 @@ const DashboardSchema = new Schema<IDashboard>(
             h: { type: Number },
             minW: { type: Number },
             minH: { type: Number },
+            custom: { type: Boolean },
           },
         },
       },

--- a/app/src/components/EmbeddableDashboard.tsx
+++ b/app/src/components/EmbeddableDashboard.tsx
@@ -16,6 +16,7 @@ import ChartWidget from "./widgets/ChartWidget";
 import KpiCard from "./widgets/KpiCard";
 import DataTableWidget from "./widgets/DataTableWidget";
 import type { AsyncDuckDB } from "@duckdb/duckdb-wasm";
+import { buildSmartResponsiveLayouts } from "../utils/dashboard-responsive-layouts";
 
 interface EmbedDashboardSpec {
   title: string;
@@ -156,12 +157,12 @@ const EmbeddableDashboard: React.FC = () => {
       static: boolean;
     };
     const result: Record<string, GridItem[]> = {};
+    const smartLayouts = buildSmartResponsiveLayouts(spec.widgets);
+
     for (const bp of breakpoints) {
       const items: GridItem[] = [];
       for (const w of spec.widgets) {
-        const wAny = w as any;
-        const bpLayout =
-          w.layouts?.[bp] ?? (bp === "lg" ? wAny.layout : undefined);
+        const bpLayout = smartLayouts[bp]?.[w.id];
         if (!bpLayout) continue;
         items.push({
           i: w.id,

--- a/app/src/components/dashboard/AddWidgetDialog.tsx
+++ b/app/src/components/dashboard/AddWidgetDialog.tsx
@@ -22,7 +22,7 @@ import {
   type DashboardWidget,
 } from "../../store/dashboardStore";
 import { executeDashboardSql } from "../../dashboard-runtime/commands";
-import { getWidgetSizeDefaults, deriveResponsiveLayouts } from "@mako/schemas";
+import { getWidgetSizeDefaults } from "@mako/schemas";
 
 interface AddWidgetDialogProps {
   open: boolean;
@@ -34,14 +34,16 @@ function buildDefaultLayouts(
   type: DashboardWidget["type"],
 ): DashboardWidget["layouts"] {
   const d = getWidgetSizeDefaults(type);
-  return deriveResponsiveLayouts({
-    x: 0,
-    y: 0,
-    w: d.w,
-    h: d.h,
-    minW: d.minW,
-    minH: d.minH,
-  });
+  return {
+    lg: {
+      x: 0,
+      y: 0,
+      w: d.w,
+      h: d.h,
+      minW: d.minW,
+      minH: d.minH,
+    },
+  };
 }
 
 export default function AddWidgetDialog({

--- a/app/src/components/dashboard/DashboardGrid.tsx
+++ b/app/src/components/dashboard/DashboardGrid.tsx
@@ -14,11 +14,12 @@ import type {
   Dashboard,
   DashboardSessionRuntimeState,
 } from "../../dashboard-runtime/types";
-import { getWidgetSizeDefaults, deriveResponsiveLayouts } from "@mako/schemas";
+import { getWidgetSizeDefaults } from "@mako/schemas";
 import WidgetContainer from "../widgets/WidgetContainer";
 import MosaicChart from "../widgets/MosaicChart";
 import MosaicKpiCard from "../widgets/MosaicKpiCard";
 import MosaicDataTable from "../widgets/MosaicDataTable";
+import { buildSmartResponsiveLayouts } from "../../utils/dashboard-responsive-layouts";
 
 const {
   modifyWidget: modifyWidgetAction,
@@ -162,29 +163,18 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
       minH: number;
     };
     const result: Record<string, GridItem[]> = {};
+    const smartLayouts = buildSmartResponsiveLayouts(widgets);
+
     for (const bp of breakpoints) {
       const items: GridItem[] = [];
       for (const w of widgets) {
-        const wAny = w as any;
         const vegaMark =
           typeof w.vegaLiteSpec?.mark === "string"
             ? w.vegaLiteSpec.mark
             : ((w.vegaLiteSpec?.mark as Record<string, unknown> | undefined)
                 ?.type as string | undefined);
         const sizeDefaults = getWidgetSizeDefaults(w.type, vegaMark);
-
-        let bpLayout =
-          w.layouts?.[bp] ?? (bp === "lg" ? wAny.layout : undefined);
-
-        if (!bpLayout && w.layouts?.lg) {
-          const lgWithMins = {
-            ...w.layouts.lg,
-            minW: w.layouts.lg.minW ?? sizeDefaults.minW,
-            minH: w.layouts.lg.minH ?? sizeDefaults.minH,
-          };
-          bpLayout = deriveResponsiveLayouts(lgWithMins)[bp];
-        }
-
+        const bpLayout = smartLayouts[bp]?.[w.id];
         if (!bpLayout) continue;
         items.push({
           i: w.id,

--- a/app/src/components/dashboard/DashboardGrid.tsx
+++ b/app/src/components/dashboard/DashboardGrid.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useMemo, useRef } from "react";
 import { Box, Typography, IconButton, Tooltip } from "@mui/material";
 import { Database, Plus } from "lucide-react";
 import { ResponsiveGridLayout } from "react-grid-layout";
@@ -88,45 +88,70 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
     dashboard?.crossFilter.resolution ?? "intersect";
   const isCrossFilterEnabled = dashboard?.crossFilter.enabled ?? false;
 
-  const handleLayoutChange = useCallback(
-    (_layout: any, allLayouts: Record<string, any>) => {
-      if (!dashboard || !dashboardId || !allLayouts || !isEditMode) return;
+  const currentBreakpointRef = useRef<"lg" | "md" | "sm" | "xs">("lg");
+  const handleBreakpointChange = useCallback((breakpoint: string) => {
+    if (
+      breakpoint === "lg" ||
+      breakpoint === "md" ||
+      breakpoint === "sm" ||
+      breakpoint === "xs"
+    ) {
+      currentBreakpointRef.current = breakpoint;
+    }
+  }, []);
+
+  const persistActiveBreakpointLayout = useCallback(
+    (
+      layout: ReadonlyArray<{
+        i: string;
+        x: number;
+        y: number;
+        w: number;
+        h: number;
+      }>,
+    ) => {
+      if (!dashboard || !dashboardId || !isEditMode) return;
+      const activeBreakpoint = currentBreakpointRef.current;
 
       for (const widget of dashboard.widgets) {
+        const item = layout.find(i => i.i === widget.id);
+        if (!item) continue;
+
         const currentLayouts =
           widget.layouts ??
           ((widget as any).layout
             ? { lg: (widget as any).layout }
             : { lg: { x: 0, y: 0, w: 6, h: 4 } });
-        const updatedLayouts: Record<
-          string,
-          { x: number; y: number; w: number; h: number }
-        > = {};
-        let changed = false;
+        const existing = (currentLayouts as any)[activeBreakpoint];
+        const next = {
+          x: item.x,
+          y: item.y,
+          w: item.w,
+          h: item.h,
+          ...(typeof existing?.minW === "number"
+            ? { minW: existing.minW }
+            : {}),
+          ...(typeof existing?.minH === "number"
+            ? { minH: existing.minH }
+            : {}),
+          ...(activeBreakpoint !== "lg" ? { custom: true } : {}),
+        };
 
-        for (const [bp, items] of Object.entries(allLayouts)) {
-          if (!Array.isArray(items)) continue;
-          const item = items.find((i: any) => i.i === widget.id);
-          if (!item) continue;
-          const newPos = { x: item.x, y: item.y, w: item.w, h: item.h };
-          const existing = (currentLayouts as any)[bp];
-          if (
-            !existing ||
-            existing.x !== newPos.x ||
-            existing.y !== newPos.y ||
-            existing.w !== newPos.w ||
-            existing.h !== newPos.h
-          ) {
-            updatedLayouts[bp] = newPos;
-            changed = true;
-          }
+        if (
+          existing &&
+          existing.x === next.x &&
+          existing.y === next.y &&
+          existing.w === next.w &&
+          existing.h === next.h &&
+          (activeBreakpoint === "lg" ||
+            (existing.custom === true && next.custom === true))
+        ) {
+          continue;
         }
 
-        if (changed) {
-          modifyWidgetAction(dashboardId, widget.id, {
-            layouts: { ...currentLayouts, ...updatedLayouts },
-          } as any);
-        }
+        modifyWidgetAction(dashboardId, widget.id, {
+          layouts: { ...currentLayouts, [activeBreakpoint]: next },
+        } as any);
       }
     },
     [dashboard, dashboardId, isEditMode],
@@ -344,7 +369,9 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
         breakpoints={{ lg: 1200, md: 996, sm: 768, xs: 480 }}
         cols={{ lg: 12, md: 10, sm: 6, xs: 4 }}
         rowHeight={dashboard.layout?.rowHeight || 80}
-        onLayoutChange={handleLayoutChange}
+        onBreakpointChange={handleBreakpointChange}
+        onDragStop={layout => persistActiveBreakpointLayout(layout)}
+        onResizeStop={layout => persistActiveBreakpointLayout(layout)}
         dragConfig={{ handle: ".drag-handle", enabled: isEditMode }}
         resizeConfig={{ enabled: isEditMode }}
       >

--- a/app/src/utils/dashboard-responsive-layouts.test.ts
+++ b/app/src/utils/dashboard-responsive-layouts.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { deriveResponsiveLayouts } from "@mako/schemas";
+import { buildSmartResponsiveLayouts } from "./dashboard-responsive-layouts";
+
+function kpiWidget(
+  id: string,
+  x: number,
+  layoutOverrides?: {
+    md?: { x: number; y: number; w: number; h: number; custom?: boolean };
+  },
+) {
+  return {
+    id,
+    type: "kpi" as const,
+    layouts: {
+      lg: { x, y: 0, w: 3, h: 2, minW: 2, minH: 2 },
+      ...(layoutOverrides?.md ? { md: layoutOverrides.md } : {}),
+    },
+  };
+}
+
+describe("buildSmartResponsiveLayouts", () => {
+  it("reflows fallback KPI rows into a balanced md grid", () => {
+    const layouts = buildSmartResponsiveLayouts([
+      kpiWidget("visits", 0),
+      kpiWidget("optins", 3),
+      kpiWidget("quiz", 6),
+      kpiWidget("demos", 9),
+    ]);
+
+    expect(layouts.md.visits).toMatchObject({ x: 0, y: 0, w: 5, h: 2 });
+    expect(layouts.md.optins).toMatchObject({ x: 5, y: 0, w: 5, h: 2 });
+    expect(layouts.md.quiz).toMatchObject({ x: 0, y: 2, w: 5, h: 2 });
+    expect(layouts.md.demos).toMatchObject({ x: 5, y: 2, w: 5, h: 2 });
+  });
+
+  it("preserves custom breakpoint layouts authored by the user", () => {
+    const layouts = buildSmartResponsiveLayouts([
+      kpiWidget("visits", 0, {
+        md: { x: 0, y: 7, w: 10, h: 2, custom: true },
+      }),
+      kpiWidget("optins", 3),
+    ]);
+
+    expect(layouts.md.visits).toMatchObject({ x: 0, y: 7, w: 10, h: 2 });
+    expect(layouts.md.optins).toMatchObject({ x: 3, y: 0, w: 3, h: 2 });
+  });
+
+  it("treats legacy proportional md layouts as fallback candidates", () => {
+    const lg = { x: 6, y: 0, w: 3, h: 2, minW: 2, minH: 2 };
+    const legacyMd = deriveResponsiveLayouts(lg).md;
+    const layouts = buildSmartResponsiveLayouts([
+      {
+        id: "quiz",
+        type: "kpi" as const,
+        layouts: { lg, md: legacyMd },
+      },
+      kpiWidget("demos", 9),
+      kpiWidget("optins", 0),
+    ]);
+
+    expect(layouts.md.quiz).toMatchObject({ x: 5, y: 0, w: 5, h: 2 });
+  });
+});

--- a/app/src/utils/dashboard-responsive-layouts.ts
+++ b/app/src/utils/dashboard-responsive-layouts.ts
@@ -1,0 +1,223 @@
+import {
+  deriveResponsiveLayouts,
+  getWidgetSizeDefaults,
+  type WidgetLayout,
+} from "@mako/schemas";
+
+type DashboardBreakpoint = "lg" | "md" | "sm" | "xs";
+
+const BREAKPOINTS: DashboardBreakpoint[] = ["lg", "md", "sm", "xs"];
+const BREAKPOINT_COLS: Record<DashboardBreakpoint, number> = {
+  lg: 12,
+  md: 10,
+  sm: 6,
+  xs: 4,
+};
+
+interface ResponsiveWidgetInput {
+  id: string;
+  type: "chart" | "kpi" | "table";
+  vegaLiteSpec?: Record<string, unknown>;
+  layouts?: Partial<Record<DashboardBreakpoint, Partial<WidgetLayout>>>;
+  layout?: Partial<WidgetLayout>;
+}
+
+interface WidgetModel {
+  id: string;
+  type: ResponsiveWidgetInput["type"];
+  lg: WidgetLayout;
+  explicitLayouts?: ResponsiveWidgetInput["layouts"];
+}
+
+type LayoutByWidgetId = Record<string, WidgetLayout>;
+type AutoDerivedByWidgetId = Record<string, boolean>;
+type LayoutsByBreakpoint = Record<DashboardBreakpoint, LayoutByWidgetId>;
+
+export function buildSmartResponsiveLayouts(
+  widgets: ResponsiveWidgetInput[],
+): LayoutsByBreakpoint {
+  const models = widgets.map(buildWidgetModel);
+
+  const layoutsByBreakpoint: LayoutsByBreakpoint = {
+    lg: {},
+    md: {},
+    sm: {},
+    xs: {},
+  };
+  const autoDerivedByBreakpoint: Record<
+    Exclude<DashboardBreakpoint, "lg">,
+    AutoDerivedByWidgetId
+  > = {
+    md: {},
+    sm: {},
+    xs: {},
+  };
+
+  for (const model of models) {
+    layoutsByBreakpoint.lg[model.id] = model.lg;
+    const derived = deriveResponsiveLayouts(model.lg);
+    for (const bp of BREAKPOINTS) {
+      if (bp === "lg") continue;
+
+      const explicit = model.explicitLayouts?.[bp];
+      const derivedBp = derived[bp] ?? model.lg;
+      if (explicit && typeof explicit === "object") {
+        const normalized = normalizeLayout(explicit, derivedBp);
+        const isAutoDerived = areLayoutsEqual(normalized, derivedBp);
+        layoutsByBreakpoint[bp][model.id] = normalized;
+        autoDerivedByBreakpoint[bp][model.id] = isAutoDerived;
+      } else {
+        layoutsByBreakpoint[bp][model.id] = derivedBp;
+        autoDerivedByBreakpoint[bp][model.id] = true;
+      }
+    }
+  }
+
+  applySmartKpiFallback(
+    "md",
+    models,
+    layoutsByBreakpoint.md,
+    autoDerivedByBreakpoint.md,
+  );
+  applySmartKpiFallback(
+    "sm",
+    models,
+    layoutsByBreakpoint.sm,
+    autoDerivedByBreakpoint.sm,
+  );
+  applySmartKpiFallback(
+    "xs",
+    models,
+    layoutsByBreakpoint.xs,
+    autoDerivedByBreakpoint.xs,
+  );
+
+  return layoutsByBreakpoint;
+}
+
+function buildWidgetModel(widget: ResponsiveWidgetInput): WidgetModel {
+  const vegaMark =
+    typeof widget.vegaLiteSpec?.mark === "string"
+      ? widget.vegaLiteSpec.mark
+      : ((widget.vegaLiteSpec?.mark as Record<string, unknown> | undefined)
+          ?.type as string | undefined);
+  const defaults = getWidgetSizeDefaults(widget.type, vegaMark);
+  const fallbackLg: WidgetLayout = {
+    x: 0,
+    y: 0,
+    w: defaults.w,
+    h: defaults.h,
+    minW: defaults.minW,
+    minH: defaults.minH,
+  };
+  const lg = normalizeLayout(widget.layouts?.lg ?? widget.layout, fallbackLg);
+  return {
+    id: widget.id,
+    type: widget.type,
+    lg,
+    explicitLayouts: widget.layouts,
+  };
+}
+
+function normalizeLayout(
+  raw: Partial<WidgetLayout> | undefined,
+  fallback: WidgetLayout,
+): WidgetLayout {
+  return {
+    x: typeof raw?.x === "number" ? raw.x : fallback.x,
+    y: typeof raw?.y === "number" ? raw.y : fallback.y,
+    w: typeof raw?.w === "number" ? raw.w : fallback.w,
+    h: typeof raw?.h === "number" ? raw.h : fallback.h,
+    minW: typeof raw?.minW === "number" ? raw.minW : fallback.minW,
+    minH: typeof raw?.minH === "number" ? raw.minH : fallback.minH,
+  };
+}
+
+function areLayoutsEqual(a: WidgetLayout, b: WidgetLayout): boolean {
+  return (
+    a.x === b.x &&
+    a.y === b.y &&
+    a.w === b.w &&
+    a.h === b.h &&
+    (a.minW ?? null) === (b.minW ?? null) &&
+    (a.minH ?? null) === (b.minH ?? null)
+  );
+}
+
+function applySmartKpiFallback(
+  breakpoint: Exclude<DashboardBreakpoint, "lg">,
+  models: WidgetModel[],
+  layoutsForBreakpoint: LayoutByWidgetId,
+  autoDerivedFlags: AutoDerivedByWidgetId,
+) {
+  const perRow = breakpoint === "md" ? 2 : 1;
+  if (perRow < 1) return;
+
+  const cols = BREAKPOINT_COLS[breakpoint];
+  const spans = splitColumns(cols, perRow);
+  if (spans.length === 0) return;
+
+  const modelsByLgY = new Map<number, WidgetModel[]>();
+  for (const model of models) {
+    const row = model.lg.y;
+    const existing = modelsByLgY.get(row);
+    if (existing) {
+      existing.push(model);
+    } else {
+      modelsByLgY.set(row, [model]);
+    }
+  }
+
+  for (const bandModels of modelsByLgY.values()) {
+    if (bandModels.length < 3) continue;
+    if (!bandModels.every(model => model.type === "kpi")) continue;
+    if (!bandModels.every(model => autoDerivedFlags[model.id])) continue;
+
+    const sorted = [...bandModels].sort((a, b) => a.lg.x - b.lg.x);
+    const minWViolation = sorted.some((model, index) => {
+      const targetSpan = spans[index % perRow];
+      return (model.lg.minW ?? 1) > targetSpan.w;
+    });
+    if (minWViolation) continue;
+
+    const baseY = Math.min(
+      ...sorted.map(model => layoutsForBreakpoint[model.id]?.y ?? 0),
+    );
+    const rowHeight = Math.max(
+      ...sorted.map(model => layoutsForBreakpoint[model.id]?.h ?? model.lg.h),
+      1,
+    );
+
+    sorted.forEach((model, index) => {
+      const existing = layoutsForBreakpoint[model.id];
+      if (!existing) return;
+
+      const col = index % perRow;
+      const row = Math.floor(index / perRow);
+      const targetSpan = spans[col];
+      layoutsForBreakpoint[model.id] = {
+        ...existing,
+        x: targetSpan.x,
+        y: baseY + row * rowHeight,
+        w: Math.max(existing.minW ?? 1, targetSpan.w),
+      };
+    });
+  }
+}
+
+function splitColumns(
+  cols: number,
+  count: number,
+): Array<{ x: number; w: number }> {
+  if (cols <= 0 || count <= 0) return [];
+  const base = Math.floor(cols / count);
+  const remainder = cols % count;
+  const spans: Array<{ x: number; w: number }> = [];
+  let cursor = 0;
+  for (let i = 0; i < count; i += 1) {
+    const width = base + (i < remainder ? 1 : 0);
+    spans.push({ x: cursor, w: width });
+    cursor += width;
+  }
+  return spans;
+}

--- a/app/src/utils/dashboard-responsive-layouts.ts
+++ b/app/src/utils/dashboard-responsive-layouts.ts
@@ -63,9 +63,15 @@ export function buildSmartResponsiveLayouts(
       const derivedBp = derived[bp] ?? model.lg;
       if (explicit && typeof explicit === "object") {
         const normalized = normalizeLayout(explicit, derivedBp);
-        const isAutoDerived = areLayoutsEqual(normalized, derivedBp);
         layoutsByBreakpoint[bp][model.id] = normalized;
-        autoDerivedByBreakpoint[bp][model.id] = isAutoDerived;
+        autoDerivedByBreakpoint[bp][model.id] =
+          normalized.custom === true
+            ? false
+            : isLegacyProportionalLayout(
+                model.lg,
+                normalized,
+                BREAKPOINT_COLS[bp],
+              ) || areLayoutsEqual(normalized, derivedBp);
       } else {
         layoutsByBreakpoint[bp][model.id] = derivedBp;
         autoDerivedByBreakpoint[bp][model.id] = true;
@@ -130,6 +136,7 @@ function normalizeLayout(
     h: typeof raw?.h === "number" ? raw.h : fallback.h,
     minW: typeof raw?.minW === "number" ? raw.minW : fallback.minW,
     minH: typeof raw?.minH === "number" ? raw.minH : fallback.minH,
+    custom: raw?.custom === true ? true : undefined,
   };
 }
 
@@ -144,18 +151,38 @@ function areLayoutsEqual(a: WidgetLayout, b: WidgetLayout): boolean {
   );
 }
 
+function scaledWidth(
+  layout: WidgetLayout,
+  cols: number,
+  lgCols: number = BREAKPOINT_COLS.lg,
+): number {
+  const minW = Math.min(Math.max(layout.minW ?? 1, 1), cols);
+  const scale = cols / lgCols;
+  return Math.min(Math.max(Math.round(layout.w * scale), minW), cols);
+}
+
+function isLegacyProportionalLayout(
+  lg: WidgetLayout,
+  bp: WidgetLayout,
+  cols: number,
+): boolean {
+  const expectedW = scaledWidth(lg, cols);
+  const expectedX = Math.min(
+    Math.round(lg.x * (cols / BREAKPOINT_COLS.lg)),
+    Math.max(0, cols - expectedW),
+  );
+  return bp.y === lg.y && bp.w === expectedW && bp.x === expectedX;
+}
+
 function applySmartKpiFallback(
   breakpoint: Exclude<DashboardBreakpoint, "lg">,
   models: WidgetModel[],
   layoutsForBreakpoint: LayoutByWidgetId,
   autoDerivedFlags: AutoDerivedByWidgetId,
 ) {
-  const perRow = breakpoint === "md" ? 2 : 1;
-  if (perRow < 1) return;
+  const preferredPerRow = breakpoint === "md" ? 2 : breakpoint === "sm" ? 2 : 1;
 
   const cols = BREAKPOINT_COLS[breakpoint];
-  const spans = splitColumns(cols, perRow);
-  if (spans.length === 0) return;
 
   const modelsByLgY = new Map<number, WidgetModel[]>();
   for (const model of models) {
@@ -174,11 +201,10 @@ function applySmartKpiFallback(
     if (!bandModels.every(model => autoDerivedFlags[model.id])) continue;
 
     const sorted = [...bandModels].sort((a, b) => a.lg.x - b.lg.x);
-    const minWViolation = sorted.some((model, index) => {
-      const targetSpan = spans[index % perRow];
-      return (model.lg.minW ?? 1) > targetSpan.w;
-    });
-    if (minWViolation) continue;
+    const perRow = resolvePerRow(sorted, cols, preferredPerRow);
+    if (perRow < 1) continue;
+    const spans = splitColumns(cols, perRow);
+    if (spans.length === 0) continue;
 
     const baseY = Math.min(
       ...sorted.map(model => layoutsForBreakpoint[model.id]?.y ?? 0),
@@ -220,4 +246,25 @@ function splitColumns(
     cursor += width;
   }
   return spans;
+}
+
+function resolvePerRow(
+  models: WidgetModel[],
+  cols: number,
+  preferredPerRow: number,
+): number {
+  for (
+    let perRow = Math.min(models.length, preferredPerRow);
+    perRow >= 1;
+    perRow -= 1
+  ) {
+    const spans = splitColumns(cols, perRow);
+    const minWViolation = models.some((model, index) => {
+      const targetSpan = spans[index % perRow];
+      return (model.lg.minW ?? 1) > targetSpan.w;
+    });
+    if (!minWViolation) return perRow;
+  }
+
+  return 1;
 }

--- a/packages/schemas/src/dashboard.schema.ts
+++ b/packages/schemas/src/dashboard.schema.ts
@@ -89,6 +89,8 @@ export const WidgetLayoutSchema = z.object({
   h: z.number(),
   minW: z.number().optional(),
   minH: z.number().optional(),
+  // Explicit user override marker for non-lg breakpoints.
+  custom: z.boolean().optional(),
 });
 
 export type WidgetLayout = z.infer<typeof WidgetLayoutSchema>;
@@ -246,6 +248,7 @@ function safeLayout(raw: Record<string, unknown> | undefined): WidgetLayout {
     h: typeof raw.h === "number" ? raw.h : DEFAULT_LAYOUT.h,
     ...(typeof raw.minW === "number" ? { minW: raw.minW } : {}),
     ...(typeof raw.minH === "number" ? { minH: raw.minH } : {}),
+    ...(raw.custom === true ? { custom: true } : {}),
   };
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- compare and benchmark three sibling implementations:
  - `cursor/responsive-dashboard-layout-packing-9258`
  - `cursor/smart-dashboard-breakpoints-887f`
  - `cursor/smart-responsive-dashboard-reflow-8a00`
- keep the existing deterministic fallback engine and improve it with the strongest ideas from the other branches:
  - explicit user-owned breakpoint overrides via `layouts.{md|sm|xs}.custom`
  - persist edits only for the active breakpoint (`onDragStop` / `onResizeStop`) so auto fallbacks are not accidentally frozen
  - detect legacy proportional breakpoint layouts and treat them as fallback candidates
  - store only `lg` by default for newly created widgets so responsive fallbacks stay re-derivable
- add unit coverage for responsive fallback behavior (`dashboard-responsive-layouts.test.ts`)

## Validation
- `pnpm --filter @mako/schemas run build`
- `pnpm --filter app run typecheck`
- `pnpm --filter app run lint`
- `pnpm --filter app run test:unit`
- `pnpm --filter api run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82a772ef-faa3-4535-8834-eed87400d9e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82a772ef-faa3-4535-8834-eed87400d9e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

