### PR TITLE
Add smart responsive dashboard layouts

### DIFF
--- a/api/src/agents/dashboard/prompt.ts
+++ b/api/src/agents/dashboard/prompt.ts
@@ -164,7 +164,7 @@ When \`run_data_source_query\` fails:
 
 ### Layout Guidelines
 
-Place widgets on a 12-column grid using the \`layouts\` field with at least an \`lg\` breakpoint. Smaller breakpoints (md/sm/xs) are auto-derived — you only need to provide \`lg\`.
+Place widgets on a 12-column grid using the \`layouts\` field with at least an \`lg\` breakpoint. Smaller breakpoints (md/sm/xs) are auto-derived from whole dashboard row intent — you only need to provide \`lg\` unless you intentionally want a custom tablet/mobile arrangement. Explicit md/sm/xs layouts are always preserved.
 
 **IMPORTANT — Minimum sizes are enforced. Widgets smaller than the minimums below will be automatically enlarged:**
 - Charts (line, bar, area, point, etc.): minimum w: 4, h: 3

--- a/api/src/agents/dashboard/prompt.ts
+++ b/api/src/agents/dashboard/prompt.ts
@@ -166,6 +166,8 @@ When \`run_data_source_query\` fails:
 
 Place widgets on a 12-column grid using the \`layouts\` field with at least an \`lg\` breakpoint. Smaller breakpoints (md/sm/xs) are auto-derived from whole dashboard row intent — you only need to provide \`lg\` unless you intentionally want a custom tablet/mobile arrangement. Explicit md/sm/xs layouts are always preserved.
 
+Use grid-friendly widths that evenly tile a row so the responsive reflow stays balanced. Within one row, prefer widths whose total is 12: for example 4 KPIs at w:3 each, 3 cards at w:4 each, 2 charts at w:6 each, or 1 full-width widget at w:12. Avoid awkward leftovers like three w:5 cards.
+
 **IMPORTANT — Minimum sizes are enforced. Widgets smaller than the minimums below will be automatically enlarged:**
 - Charts (line, bar, area, point, etc.): minimum w: 4, h: 3
 - Donut/pie charts (arc mark): minimum w: 3, h: 3

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -2750,6 +2750,7 @@ export interface IDashboard extends Document {
         h: number;
         minW?: number;
         minH?: number;
+        custom?: boolean;
       };
       md?: {
         x: number;
@@ -2758,6 +2759,7 @@ export interface IDashboard extends Document {
         h: number;
         minW?: number;
         minH?: number;
+        custom?: boolean;
       };
       sm?: {
         x: number;
@@ -2766,6 +2768,7 @@ export interface IDashboard extends Document {
         h: number;
         minW?: number;
         minH?: number;
+        custom?: boolean;
       };
       xs?: {
         x: number;
@@ -2774,6 +2777,7 @@ export interface IDashboard extends Document {
         h: number;
         minW?: number;
         minH?: number;
+        custom?: boolean;
       };
     };
   }>;
@@ -3058,6 +3062,7 @@ const DashboardSchema = new Schema<IDashboard>(
             h: { type: Number, required: true },
             minW: { type: Number },
             minH: { type: Number },
+            custom: { type: Boolean },
           },
           md: {
             x: { type: Number },
@@ -3066,6 +3071,7 @@ const DashboardSchema = new Schema<IDashboard>(
             h: { type: Number },
             minW: { type: Number },
             minH: { type: Number },
+            custom: { type: Boolean },
           },
           sm: {
             x: { type: Number },
@@ -3074,6 +3080,7 @@ const DashboardSchema = new Schema<IDashboard>(
             h: { type: Number },
             minW: { type: Number },
             minH: { type: Number },
+            custom: { type: Boolean },
           },
           xs: {
             x: { type: Number },
@@ -3082,6 +3089,7 @@ const DashboardSchema = new Schema<IDashboard>(
             h: { type: Number },
             minW: { type: Number },
             minH: { type: Number },
+            custom: { type: Boolean },
           },
         },
       },

--- a/api/src/routes/dashboards.ts
+++ b/api/src/routes/dashboards.ts
@@ -13,6 +13,7 @@ import { workspaceService } from "../services/workspace.service";
 import { AuthenticatedContext } from "../middleware/workspace.middleware";
 import {
   DashboardDefinitionSchema,
+  normalizeDashboardWidgetsLayouts,
   normalizeWidgetLayouts,
   sanitizeTableRef,
   buildTableRef,
@@ -192,9 +193,7 @@ async function normalizeDashboardDataSources(
 
 function normalizeDashboardWidgetLayouts(dashboard: Record<string, any>) {
   if (Array.isArray(dashboard.widgets)) {
-    dashboard.widgets = dashboard.widgets.map((w: Record<string, unknown>) =>
-      normalizeWidgetLayouts(w),
-    );
+    dashboard.widgets = normalizeDashboardWidgetsLayouts(dashboard.widgets);
   }
   return dashboard;
 }
@@ -753,7 +752,7 @@ app.patch("/:id", async (c: AuthenticatedContext) => {
 
     // Normalize widget layouts and defaults before schema validation
     if (Array.isArray(body.widgets)) {
-      body.widgets = body.widgets.map((w: Record<string, unknown>) => {
+      body.widgets = normalizeDashboardWidgetsLayouts(body.widgets).map(w => {
         const normalized = normalizeWidgetLayouts(w);
         if (!normalized.crossFilter) {
           normalized.crossFilter = { enabled: true };

--- a/api/src/routes/dashboards.ts
+++ b/api/src/routes/dashboards.ts
@@ -581,7 +581,15 @@ app.put("/:id", async (c: AuthenticatedContext) => {
       updateFields.dataSources = normalizedDataSources.dataSources || [];
     }
     if (body.widgets !== undefined) {
-      updateFields.widgets = body.widgets;
+      updateFields.widgets = Array.isArray(body.widgets)
+        ? body.widgets.map((w: Record<string, unknown>) => {
+            const normalized = normalizeWidgetLayouts(w);
+            if (!normalized.crossFilter) {
+              normalized.crossFilter = { enabled: true };
+            }
+            return normalized;
+          })
+        : body.widgets;
     }
     if (body.relationships !== undefined) {
       updateFields.relationships = body.relationships;

--- a/api/src/routes/dashboards.ts
+++ b/api/src/routes/dashboards.ts
@@ -13,7 +13,6 @@ import { workspaceService } from "../services/workspace.service";
 import { AuthenticatedContext } from "../middleware/workspace.middleware";
 import {
   DashboardDefinitionSchema,
-  normalizeDashboardWidgetsLayouts,
   normalizeWidgetLayouts,
   sanitizeTableRef,
   buildTableRef,
@@ -193,7 +192,9 @@ async function normalizeDashboardDataSources(
 
 function normalizeDashboardWidgetLayouts(dashboard: Record<string, any>) {
   if (Array.isArray(dashboard.widgets)) {
-    dashboard.widgets = normalizeDashboardWidgetsLayouts(dashboard.widgets);
+    dashboard.widgets = dashboard.widgets.map((w: Record<string, unknown>) =>
+      normalizeWidgetLayouts(w),
+    );
   }
   return dashboard;
 }
@@ -752,7 +753,7 @@ app.patch("/:id", async (c: AuthenticatedContext) => {
 
     // Normalize widget layouts and defaults before schema validation
     if (Array.isArray(body.widgets)) {
-      body.widgets = normalizeDashboardWidgetsLayouts(body.widgets).map(w => {
+      body.widgets = body.widgets.map((w: Record<string, unknown>) => {
         const normalized = normalizeWidgetLayouts(w);
         if (!normalized.crossFilter) {
           normalized.crossFilter = { enabled: true };

--- a/app/src/components/EmbeddableDashboard.tsx
+++ b/app/src/components/EmbeddableDashboard.tsx
@@ -16,6 +16,7 @@ import ChartWidget from "./widgets/ChartWidget";
 import KpiCard from "./widgets/KpiCard";
 import DataTableWidget from "./widgets/DataTableWidget";
 import type { AsyncDuckDB } from "@duckdb/duckdb-wasm";
+import { normalizeDashboardWidgetsLayouts } from "@mako/schemas";
 
 interface EmbedDashboardSpec {
   title: string;
@@ -156,12 +157,11 @@ const EmbeddableDashboard: React.FC = () => {
       static: boolean;
     };
     const result: Record<string, GridItem[]> = {};
+    const normalizedWidgets = normalizeDashboardWidgetsLayouts(spec.widgets);
     for (const bp of breakpoints) {
       const items: GridItem[] = [];
-      for (const w of spec.widgets) {
-        const wAny = w as any;
-        const bpLayout =
-          w.layouts?.[bp] ?? (bp === "lg" ? wAny.layout : undefined);
+      for (const w of normalizedWidgets) {
+        const bpLayout = w.layouts?.[bp];
         if (!bpLayout) continue;
         items.push({
           i: w.id,

--- a/app/src/components/dashboard/DashboardGrid.tsx
+++ b/app/src/components/dashboard/DashboardGrid.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { Box, Typography, IconButton, Tooltip } from "@mui/material";
 import { Database, Plus } from "lucide-react";
 import { ResponsiveGridLayout } from "react-grid-layout";
@@ -28,6 +28,8 @@ const {
   removeWidget: removeWidgetAction,
   addWidget: addWidgetAction,
 } = useDashboardStore.getState();
+
+type DashboardBreakpoint = "lg" | "md" | "sm" | "xs";
 
 function resolveWidgetLayout(widget: DashboardWidget) {
   const vegaMark =
@@ -86,6 +88,8 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
   onInspectWidget,
 }) => {
   const widgets = useMemo(() => dashboard?.widgets ?? [], [dashboard]);
+  const [activeBreakpoint, setActiveBreakpoint] =
+    useState<DashboardBreakpoint>("lg");
   const crossFilterResolution =
     dashboard?.crossFilter.resolution ?? "intersect";
   const isCrossFilterEnabled = dashboard?.crossFilter.enabled ?? false;
@@ -93,6 +97,8 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
   const handleLayoutChange = useCallback(
     (_layout: any, allLayouts: Record<string, any>) => {
       if (!dashboard || !dashboardId || !allLayouts || !isEditMode) return;
+      const activeItems = allLayouts[activeBreakpoint];
+      if (!Array.isArray(activeItems)) return;
 
       for (const widget of dashboard.widgets) {
         const currentLayouts =
@@ -106,22 +112,19 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
         > = {};
         let changed = false;
 
-        for (const [bp, items] of Object.entries(allLayouts)) {
-          if (!Array.isArray(items)) continue;
-          const item = items.find((i: any) => i.i === widget.id);
-          if (!item) continue;
-          const newPos = { x: item.x, y: item.y, w: item.w, h: item.h };
-          const existing = (currentLayouts as any)[bp];
-          if (
-            !existing ||
-            existing.x !== newPos.x ||
-            existing.y !== newPos.y ||
-            existing.w !== newPos.w ||
-            existing.h !== newPos.h
-          ) {
-            updatedLayouts[bp] = newPos;
-            changed = true;
-          }
+        const item = activeItems.find((i: any) => i.i === widget.id);
+        if (!item) continue;
+        const newPos = { x: item.x, y: item.y, w: item.w, h: item.h };
+        const existing = (currentLayouts as any)[activeBreakpoint];
+        if (
+          !existing ||
+          existing.x !== newPos.x ||
+          existing.y !== newPos.y ||
+          existing.w !== newPos.w ||
+          existing.h !== newPos.h
+        ) {
+          updatedLayouts[activeBreakpoint] = newPos;
+          changed = true;
         }
 
         if (changed) {
@@ -131,7 +134,7 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
         }
       }
     },
-    [dashboard, dashboardId, isEditMode],
+    [activeBreakpoint, dashboard, dashboardId, isEditMode],
   );
 
   const handleDuplicateWidget = useCallback(
@@ -139,14 +142,18 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
       if (!dashboardId) return;
       const { nanoid } = await import("nanoid");
       const lgLayout = widget.layouts?.lg ?? resolveWidgetLayout(widget);
+      const sourceLayouts = widget.layouts ?? { lg: lgLayout };
+      const shiftedLayouts = Object.fromEntries(
+        Object.entries(sourceLayouts).map(([bp, layout]) => [
+          bp,
+          { ...layout, y: layout.y + layout.h },
+        ]),
+      ) as DashboardWidget["layouts"];
       const newWidget: DashboardWidget = {
         ...widget,
         id: nanoid(),
         title: `${widget.title || "Widget"} (copy)`,
-        layouts: {
-          ...(widget.layouts ?? {}),
-          lg: { ...lgLayout, y: lgLayout.y + lgLayout.h },
-        },
+        layouts: shiftedLayouts,
       };
       addWidgetAction(dashboardId, newWidget);
     },
@@ -347,6 +354,9 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
         cols={{ lg: 12, md: 10, sm: 6, xs: 4 }}
         rowHeight={dashboard.layout?.rowHeight || 80}
         onLayoutChange={handleLayoutChange}
+        onBreakpointChange={breakpoint =>
+          setActiveBreakpoint(breakpoint as DashboardBreakpoint)
+        }
         dragConfig={{ handle: ".drag-handle", enabled: isEditMode }}
         resizeConfig={{ enabled: isEditMode }}
       >

--- a/app/src/components/dashboard/DashboardGrid.tsx
+++ b/app/src/components/dashboard/DashboardGrid.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import { Box, Typography, IconButton, Tooltip } from "@mui/material";
 import { Database, Plus } from "lucide-react";
 import { ResponsiveGridLayout } from "react-grid-layout";
@@ -104,6 +104,7 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
   const widgets = useMemo(() => dashboard?.widgets ?? [], [dashboard]);
   const [activeBreakpoint, setActiveBreakpoint] =
     useState<DashboardBreakpoint>("lg");
+  const isLayoutInteractionRef = useRef(false);
   const crossFilterResolution =
     dashboard?.crossFilter.resolution ?? "intersect";
   const isCrossFilterEnabled = dashboard?.crossFilter.enabled ?? false;
@@ -111,6 +112,7 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
   const handleLayoutChange = useCallback(
     (_layout: any, allLayouts: Record<string, any>) => {
       if (!dashboard || !dashboardId || !allLayouts || !isEditMode) return;
+      if (!isLayoutInteractionRef.current) return;
       const activeItems = allLayouts[activeBreakpoint];
       if (!Array.isArray(activeItems)) return;
 
@@ -391,6 +393,22 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
         onBreakpointChange={breakpoint =>
           setActiveBreakpoint(breakpoint as DashboardBreakpoint)
         }
+        onDragStart={() => {
+          isLayoutInteractionRef.current = true;
+        }}
+        onResizeStart={() => {
+          isLayoutInteractionRef.current = true;
+        }}
+        onDragStop={() => {
+          window.setTimeout(() => {
+            isLayoutInteractionRef.current = false;
+          }, 0);
+        }}
+        onResizeStop={() => {
+          window.setTimeout(() => {
+            isLayoutInteractionRef.current = false;
+          }, 0);
+        }}
         dragConfig={{ handle: ".drag-handle", enabled: isEditMode }}
         resizeConfig={{ enabled: isEditMode }}
       >

--- a/app/src/components/dashboard/DashboardGrid.tsx
+++ b/app/src/components/dashboard/DashboardGrid.tsx
@@ -15,6 +15,7 @@ import type {
   DashboardSessionRuntimeState,
 } from "../../dashboard-runtime/types";
 import {
+  deriveResponsiveLayouts,
   getWidgetSizeDefaults,
   normalizeDashboardWidgetsLayouts,
 } from "@mako/schemas";
@@ -30,6 +31,19 @@ const {
 } = useDashboardStore.getState();
 
 type DashboardBreakpoint = "lg" | "md" | "sm" | "xs";
+const RESPONSIVE_BREAKPOINTS: DashboardBreakpoint[] = ["lg", "md", "sm", "xs"];
+const SMALL_BREAKPOINTS: Exclude<DashboardBreakpoint, "lg">[] = [
+  "md",
+  "sm",
+  "xs",
+];
+
+function layoutsEqual(
+  a: { x: number; y: number; w: number; h: number },
+  b: { x: number; y: number; w: number; h: number },
+) {
+  return a.x === b.x && a.y === b.y && a.w === b.w && a.h === b.h;
+}
 
 function resolveWidgetLayout(widget: DashboardWidget) {
   const vegaMark =
@@ -106,16 +120,15 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
           ((widget as any).layout
             ? { lg: (widget as any).layout }
             : { lg: { x: 0, y: 0, w: 6, h: 4 } });
-        const updatedLayouts: Record<
-          string,
-          { x: number; y: number; w: number; h: number }
-        > = {};
-        let changed = false;
-
         const item = activeItems.find((i: any) => i.i === widget.id);
         if (!item) continue;
         const newPos = { x: item.x, y: item.y, w: item.w, h: item.h };
         const existing = (currentLayouts as any)[activeBreakpoint];
+        let changed = false;
+        let nextLayouts = currentLayouts as Record<
+          string,
+          { x: number; y: number; w: number; h: number }
+        >;
         if (
           !existing ||
           existing.x !== newPos.x ||
@@ -123,13 +136,29 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
           existing.w !== newPos.w ||
           existing.h !== newPos.h
         ) {
-          updatedLayouts[activeBreakpoint] = newPos;
+          nextLayouts = { ...nextLayouts, [activeBreakpoint]: newPos };
+          if (activeBreakpoint === "lg") {
+            const legacyLayouts = deriveResponsiveLayouts(
+              existing ?? resolveWidgetLayout(widget),
+            );
+            for (const bp of SMALL_BREAKPOINTS) {
+              const existingBreakpoint = nextLayouts[bp];
+              const legacyBreakpoint = legacyLayouts[bp];
+              if (
+                existingBreakpoint &&
+                legacyBreakpoint &&
+                layoutsEqual(existingBreakpoint, legacyBreakpoint)
+              ) {
+                delete nextLayouts[bp];
+              }
+            }
+          }
           changed = true;
         }
 
         if (changed) {
           modifyWidgetAction(dashboardId, widget.id, {
-            layouts: { ...currentLayouts, ...updatedLayouts },
+            layouts: nextLayouts,
           } as any);
         }
       }
@@ -161,7 +190,6 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
   );
 
   const allGridLayouts = useMemo(() => {
-    const breakpoints = ["lg", "md", "sm", "xs"] as const;
     type GridItem = {
       i: string;
       x: number;
@@ -173,7 +201,7 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
     };
     const result: Record<string, GridItem[]> = {};
     const normalizedWidgets = normalizeDashboardWidgetsLayouts(widgets);
-    for (const bp of breakpoints) {
+    for (const bp of RESPONSIVE_BREAKPOINTS) {
       const items: GridItem[] = [];
       for (const w of normalizedWidgets) {
         const vegaMark =

--- a/app/src/components/dashboard/DashboardGrid.tsx
+++ b/app/src/components/dashboard/DashboardGrid.tsx
@@ -122,12 +122,18 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
             : { lg: { x: 0, y: 0, w: 6, h: 4 } });
         const item = activeItems.find((i: any) => i.i === widget.id);
         if (!item) continue;
-        const newPos = { x: item.x, y: item.y, w: item.w, h: item.h };
+        const newPos = {
+          x: item.x,
+          y: item.y,
+          w: item.w,
+          h: item.h,
+          ...(activeBreakpoint === "lg" ? {} : { custom: true }),
+        };
         const existing = (currentLayouts as any)[activeBreakpoint];
         let changed = false;
         let nextLayouts = currentLayouts as Record<
           string,
-          { x: number; y: number; w: number; h: number }
+          { x: number; y: number; w: number; h: number; custom?: boolean }
         >;
         if (
           !existing ||

--- a/app/src/components/dashboard/DashboardGrid.tsx
+++ b/app/src/components/dashboard/DashboardGrid.tsx
@@ -14,7 +14,10 @@ import type {
   Dashboard,
   DashboardSessionRuntimeState,
 } from "../../dashboard-runtime/types";
-import { getWidgetSizeDefaults, deriveResponsiveLayouts } from "@mako/schemas";
+import {
+  getWidgetSizeDefaults,
+  normalizeDashboardWidgetsLayouts,
+} from "@mako/schemas";
 import WidgetContainer from "../widgets/WidgetContainer";
 import MosaicChart from "../widgets/MosaicChart";
 import MosaicKpiCard from "../widgets/MosaicKpiCard";
@@ -162,10 +165,10 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
       minH: number;
     };
     const result: Record<string, GridItem[]> = {};
+    const normalizedWidgets = normalizeDashboardWidgetsLayouts(widgets);
     for (const bp of breakpoints) {
       const items: GridItem[] = [];
-      for (const w of widgets) {
-        const wAny = w as any;
+      for (const w of normalizedWidgets) {
         const vegaMark =
           typeof w.vegaLiteSpec?.mark === "string"
             ? w.vegaLiteSpec.mark
@@ -173,18 +176,7 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
                 ?.type as string | undefined);
         const sizeDefaults = getWidgetSizeDefaults(w.type, vegaMark);
 
-        let bpLayout =
-          w.layouts?.[bp] ?? (bp === "lg" ? wAny.layout : undefined);
-
-        if (!bpLayout && w.layouts?.lg) {
-          const lgWithMins = {
-            ...w.layouts.lg,
-            minW: w.layouts.lg.minW ?? sizeDefaults.minW,
-            minH: w.layouts.lg.minH ?? sizeDefaults.minH,
-          };
-          bpLayout = deriveResponsiveLayouts(lgWithMins)[bp];
-        }
-
+        const bpLayout = w.layouts?.[bp];
         if (!bpLayout) continue;
         items.push({
           i: w.id,

--- a/app/src/components/dashboard/DashboardSettingsDialog.tsx
+++ b/app/src/components/dashboard/DashboardSettingsDialog.tsx
@@ -182,6 +182,7 @@ export default function DashboardSettingsDialog({
       .getState()
       .updateDashboard(workspaceId, dashboard._id, {
         widgets: resetWidgets,
+        version: dashboard.version,
       } as any);
   };
 

--- a/app/src/components/dashboard/DashboardSettingsDialog.tsx
+++ b/app/src/components/dashboard/DashboardSettingsDialog.tsx
@@ -18,7 +18,10 @@ import {
   Alert,
 } from "@mui/material";
 import { Copy, Trash2 } from "lucide-react";
-import { useDashboardStore } from "../../store/dashboardStore";
+import {
+  useDashboardStore,
+  type DashboardWidget,
+} from "../../store/dashboardStore";
 import { useWorkspace } from "../../contexts/workspace-context";
 import { useConsoleStore } from "../../store/consoleStore";
 
@@ -164,6 +167,24 @@ export default function DashboardSettingsDialog({
     onClose();
   };
 
+  const handleResetResponsiveLayouts = async () => {
+    if (!workspaceId || !dashboard || isReadOnly) return;
+    const resetWidgets = dashboard.widgets.map(widget => {
+      const lgLayout = widget.layouts?.lg ??
+        (widget as any).layout ?? { x: 0, y: 0, w: 6, h: 4 };
+      return {
+        ...widget,
+        layouts: { lg: lgLayout },
+      } as DashboardWidget;
+    });
+
+    await useDashboardStore
+      .getState()
+      .updateDashboard(workspaceId, dashboard._id, {
+        widgets: resetWidgets,
+      } as any);
+  };
+
   const handleDelete = async () => {
     if (!workspaceId || !dashboard) return;
     await useDashboardStore
@@ -241,6 +262,22 @@ export default function DashboardSettingsDialog({
             slotProps={{ htmlInput: { min: 20 } }}
             disabled={isReadOnly}
           />
+        </Box>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+          <Typography variant="body2" color="text.secondary">
+            Responsive tablet and mobile layouts are generated automatically
+            from the large-screen layout unless you edit those breakpoints.
+          </Typography>
+          <Box>
+            <Button
+              variant="outlined"
+              size="small"
+              onClick={handleResetResponsiveLayouts}
+              disabled={isReadOnly || !dashboard?.widgets.length}
+            >
+              Reset responsive layouts to auto
+            </Button>
+          </Box>
         </Box>
 
         <FormControlLabel

--- a/app/src/components/dashboard/PresentationMode.tsx
+++ b/app/src/components/dashboard/PresentationMode.tsx
@@ -15,6 +15,7 @@ import WidgetContainer from "../widgets/WidgetContainer";
 import ChartWidget from "../widgets/ChartWidget";
 import KpiCard from "../widgets/KpiCard";
 import DataTableWidget from "../widgets/DataTableWidget";
+import { normalizeDashboardWidgetsLayouts } from "@mako/schemas";
 
 interface PresentationModeProps {
   onExit: () => void;
@@ -100,12 +101,13 @@ const PresentationMode: React.FC<PresentationModeProps> = ({ onExit }) => {
       static: boolean;
     };
     const result: Record<string, GridItem[]> = {};
+    const normalizedWidgets = normalizeDashboardWidgetsLayouts(
+      activeDashboard.widgets,
+    );
     for (const bp of breakpoints) {
       const items: GridItem[] = [];
-      for (const w of activeDashboard.widgets) {
-        const wAny = w as any;
-        const bpLayout =
-          w.layouts?.[bp] ?? (bp === "lg" ? wAny.layout : undefined);
+      for (const w of normalizedWidgets) {
+        const bpLayout = w.layouts?.[bp];
         if (!bpLayout) continue;
         items.push({
           i: w.id,

--- a/app/src/components/dashboard/WidgetInspector.tsx
+++ b/app/src/components/dashboard/WidgetInspector.tsx
@@ -96,17 +96,18 @@ const WidgetInspector: React.FC<WidgetInspectorProps> = ({
   const handleDuplicate = async () => {
     const { nanoid } = await import("nanoid");
     const lgLayout = widget.layouts?.lg ?? resolveWidgetLayout(widget);
+    const sourceLayouts = widget.layouts ?? { lg: lgLayout };
+    const shiftedLayouts = Object.fromEntries(
+      Object.entries(sourceLayouts).map(([bp, layout]) => [
+        bp,
+        { ...layout, y: layout.y + layout.h },
+      ]),
+    ) as DashboardWidget["layouts"];
     const newWidget: DashboardWidget = {
       ...widget,
       id: nanoid(),
       title: `${widget.title || "Widget"} (copy)`,
-      layouts: {
-        ...(widget.layouts ?? {}),
-        lg: {
-          ...lgLayout,
-          y: lgLayout.y + lgLayout.h,
-        },
-      },
+      layouts: shiftedLayouts,
     };
     if (dashboardId) addWidget(dashboardId, newWidget);
     onClose();

--- a/app/src/dashboard-runtime/responsive-layout.test.ts
+++ b/app/src/dashboard-runtime/responsive-layout.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { normalizeDashboardWidgetsLayouts } from "@mako/schemas";
+
+function kpiWidget(id: string, x: number) {
+  return {
+    id,
+    type: "kpi" as const,
+    layouts: {
+      lg: { x, y: 0, w: 3, h: 2 },
+    },
+  };
+}
+
+describe("normalizeDashboardWidgetsLayouts", () => {
+  it("reflows a large-screen KPI row into balanced smaller rows", () => {
+    const [first, second, third, fourth] = normalizeDashboardWidgetsLayouts([
+      kpiWidget("visits", 0),
+      kpiWidget("optins", 3),
+      kpiWidget("quiz", 6),
+      kpiWidget("demos", 9),
+    ]);
+
+    expect(first.layouts.md).toMatchObject({ x: 0, y: 0, w: 5, h: 2 });
+    expect(second.layouts.md).toMatchObject({ x: 5, y: 0, w: 5, h: 2 });
+    expect(third.layouts.md).toMatchObject({ x: 0, y: 2, w: 5, h: 2 });
+    expect(fourth.layouts.md).toMatchObject({ x: 5, y: 2, w: 5, h: 2 });
+
+    expect(first.layouts.sm).toMatchObject({ x: 0, y: 0, w: 3, h: 2 });
+    expect(second.layouts.sm).toMatchObject({ x: 3, y: 0, w: 3, h: 2 });
+    expect(third.layouts.sm).toMatchObject({ x: 0, y: 2, w: 3, h: 2 });
+    expect(fourth.layouts.sm).toMatchObject({ x: 3, y: 2, w: 3, h: 2 });
+
+    expect(first.layouts.xs).toMatchObject({ x: 0, y: 0, w: 4, h: 2 });
+    expect(second.layouts.xs).toMatchObject({ x: 0, y: 2, w: 4, h: 2 });
+    expect(third.layouts.xs).toMatchObject({ x: 0, y: 4, w: 4, h: 2 });
+    expect(fourth.layouts.xs).toMatchObject({ x: 0, y: 6, w: 4, h: 2 });
+  });
+
+  it("preserves explicit user-authored breakpoint layouts", () => {
+    const [first, second] = normalizeDashboardWidgetsLayouts([
+      {
+        ...kpiWidget("visits", 0),
+        layouts: {
+          lg: { x: 0, y: 0, w: 3, h: 2 },
+          md: { x: 0, y: 8, w: 10, h: 2 },
+        },
+      },
+      kpiWidget("optins", 3),
+    ]);
+
+    expect(first.layouts.md).toMatchObject({ x: 0, y: 8, w: 10, h: 2 });
+    expect(second.layouts.md).toMatchObject({ x: 5, y: 0, w: 5, h: 2 });
+  });
+});

--- a/app/src/dashboard-runtime/responsive-layout.test.ts
+++ b/app/src/dashboard-runtime/responsive-layout.test.ts
@@ -105,4 +105,24 @@ describe("normalizeDashboardWidgetsLayouts", () => {
     expect(first.layouts.md).toMatchObject({ x: 0, y: 0, w: 10, h: 2 });
     expect(second.layouts.md).toMatchObject({ x: 5, y: 2, w: 5, h: 2 });
   });
+
+  it("preserves breakpoint layouts explicitly marked as custom", () => {
+    const [first] = normalizeDashboardWidgetsLayouts([
+      {
+        ...kpiWidget("visits", 0),
+        layouts: {
+          lg: { x: 0, y: 0, w: 3, h: 2 },
+          md: { x: 0, y: 0, w: 3, h: 2, custom: true },
+        },
+      },
+    ]);
+
+    expect(first.layouts.md).toMatchObject({
+      x: 0,
+      y: 0,
+      w: 3,
+      h: 2,
+      custom: true,
+    });
+  });
 });

--- a/app/src/dashboard-runtime/responsive-layout.test.ts
+++ b/app/src/dashboard-runtime/responsive-layout.test.ts
@@ -51,4 +51,58 @@ describe("normalizeDashboardWidgetsLayouts", () => {
     expect(first.layouts.md).toMatchObject({ x: 0, y: 8, w: 10, h: 2 });
     expect(second.layouts.md).toMatchObject({ x: 5, y: 0, w: 5, h: 2 });
   });
+
+  it("replaces legacy auto-derived breakpoint layouts with smart fallbacks", () => {
+    const [first, second, third, fourth] = normalizeDashboardWidgetsLayouts([
+      {
+        ...kpiWidget("visits", 0),
+        layouts: {
+          lg: { x: 0, y: 0, w: 3, h: 2 },
+          md: { x: 0, y: 0, w: 3, h: 2 },
+        },
+      },
+      {
+        ...kpiWidget("optins", 3),
+        layouts: {
+          lg: { x: 3, y: 0, w: 3, h: 2 },
+          md: { x: 3, y: 0, w: 3, h: 2 },
+        },
+      },
+      {
+        ...kpiWidget("quiz", 6),
+        layouts: {
+          lg: { x: 6, y: 0, w: 3, h: 2 },
+          md: { x: 5, y: 0, w: 3, h: 2 },
+        },
+      },
+      {
+        ...kpiWidget("demos", 9),
+        layouts: {
+          lg: { x: 9, y: 0, w: 3, h: 2 },
+          md: { x: 7, y: 0, w: 3, h: 2 },
+        },
+      },
+    ]);
+
+    expect(first.layouts.md).toMatchObject({ x: 0, y: 0, w: 5, h: 2 });
+    expect(second.layouts.md).toMatchObject({ x: 5, y: 0, w: 5, h: 2 });
+    expect(third.layouts.md).toMatchObject({ x: 0, y: 2, w: 5, h: 2 });
+    expect(fourth.layouts.md).toMatchObject({ x: 5, y: 2, w: 5, h: 2 });
+  });
+
+  it("keeps generated layouts out of explicit breakpoint space", () => {
+    const [first, second] = normalizeDashboardWidgetsLayouts([
+      {
+        ...kpiWidget("visits", 0),
+        layouts: {
+          lg: { x: 0, y: 0, w: 3, h: 2 },
+          md: { x: 0, y: 0, w: 10, h: 2 },
+        },
+      },
+      kpiWidget("optins", 3),
+    ]);
+
+    expect(first.layouts.md).toMatchObject({ x: 0, y: 0, w: 10, h: 2 });
+    expect(second.layouts.md).toMatchObject({ x: 5, y: 2, w: 5, h: 2 });
+  });
 });

--- a/app/src/store/dashboardStore.ts
+++ b/app/src/store/dashboardStore.ts
@@ -4,7 +4,7 @@ import { immer } from "zustand/middleware/immer";
 import { apiClient } from "../lib/api-client";
 import {
   DashboardDefinitionSchema,
-  normalizeDashboardWidgetsLayouts,
+  normalizeWidgetLayouts,
 } from "@mako/schemas";
 import { computeDashboardStateHash } from "../utils/stateHash";
 import { disposeDashboardRuntime } from "../dashboard-runtime/gateway";
@@ -462,9 +462,12 @@ export const useDashboardStore = create<DashboardStoreState>()(
           if (response.data) {
             const dashboard = response.data;
             if (Array.isArray(dashboard.widgets)) {
-              dashboard.widgets = normalizeDashboardWidgetsLayouts(
-                dashboard.widgets,
-              ) as typeof dashboard.widgets;
+              dashboard.widgets = dashboard.widgets.map(
+                w =>
+                  normalizeWidgetLayouts(
+                    w as Record<string, unknown>,
+                  ) as typeof w,
+              );
             }
             set(state => {
               state.openDashboards[dashboardId] = dashboard;

--- a/app/src/store/dashboardStore.ts
+++ b/app/src/store/dashboardStore.ts
@@ -4,7 +4,7 @@ import { immer } from "zustand/middleware/immer";
 import { apiClient } from "../lib/api-client";
 import {
   DashboardDefinitionSchema,
-  normalizeWidgetLayouts,
+  normalizeDashboardWidgetsLayouts,
 } from "@mako/schemas";
 import { computeDashboardStateHash } from "../utils/stateHash";
 import { disposeDashboardRuntime } from "../dashboard-runtime/gateway";
@@ -462,12 +462,9 @@ export const useDashboardStore = create<DashboardStoreState>()(
           if (response.data) {
             const dashboard = response.data;
             if (Array.isArray(dashboard.widgets)) {
-              dashboard.widgets = dashboard.widgets.map(
-                w =>
-                  normalizeWidgetLayouts(
-                    w as Record<string, unknown>,
-                  ) as typeof w,
-              );
+              dashboard.widgets = normalizeDashboardWidgetsLayouts(
+                dashboard.widgets,
+              ) as typeof dashboard.widgets;
             }
             set(state => {
               state.openDashboards[dashboardId] = dashboard;

--- a/packages/schemas/src/dashboard.schema.ts
+++ b/packages/schemas/src/dashboard.schema.ts
@@ -89,6 +89,8 @@ export const WidgetLayoutSchema = z.object({
   h: z.number(),
   minW: z.number().optional(),
   minH: z.number().optional(),
+  /** True when a user intentionally edited this breakpoint layout. */
+  custom: z.boolean().optional(),
 });
 
 export type WidgetLayout = z.infer<typeof WidgetLayoutSchema>;
@@ -443,6 +445,7 @@ function isUserAuthoredBreakpoint(
   breakpoint: Exclude<LayoutBreakpoint, "lg">,
 ): rawLayout is WidgetLayout {
   if (!rawLayout) return false;
+  if (rawLayout.custom === true) return true;
   const legacyDerived = deriveResponsiveLayouts(lg)[breakpoint];
   if (!legacyDerived) return true;
   return !layoutsMatch(rawLayout, legacyDerived);
@@ -551,6 +554,7 @@ function safeLayout(raw: Record<string, unknown> | undefined): WidgetLayout {
     h: typeof raw.h === "number" ? raw.h : DEFAULT_LAYOUT.h,
     ...(typeof raw.minW === "number" ? { minW: raw.minW } : {}),
     ...(typeof raw.minH === "number" ? { minH: raw.minH } : {}),
+    ...(typeof raw.custom === "boolean" ? { custom: raw.custom } : {}),
   };
 }
 

--- a/packages/schemas/src/dashboard.schema.ts
+++ b/packages/schemas/src/dashboard.schema.ts
@@ -194,6 +194,17 @@ export type DashboardDefinition = z.infer<typeof DashboardDefinitionSchema>;
 const DEFAULT_LAYOUT: WidgetLayout = { x: 0, y: 0, w: 6, h: 4 };
 
 const BREAKPOINT_COLS = { lg: 12, md: 10, sm: 6, xs: 4 } as const;
+type LayoutBreakpoint = keyof typeof BREAKPOINT_COLS;
+
+type LayoutWidgetInput = Record<string, unknown> & {
+  id?: unknown;
+  type?: unknown;
+  layouts?: unknown;
+  layout?: unknown;
+  vegaLiteSpec?: unknown;
+};
+
+const RESPONSIVE_BREAKPOINTS = ["lg", "md", "sm", "xs"] as const;
 
 /**
  * Returns recommended size and enforced minimums for a widget based on its
@@ -235,6 +246,227 @@ export function deriveResponsiveLayouts(
     sm: derive(BREAKPOINT_COLS.sm),
     xs: derive(BREAKPOINT_COLS.xs),
   };
+}
+
+function getWidgetVegaMark(widget: LayoutWidgetInput): string | undefined {
+  const spec = widget.vegaLiteSpec;
+  if (!spec || typeof spec !== "object") return undefined;
+  const mark = (spec as Record<string, unknown>).mark;
+  if (typeof mark === "string") return mark;
+  if (mark && typeof mark === "object") {
+    const type = (mark as Record<string, unknown>).type;
+    return typeof type === "string" ? type : undefined;
+  }
+  return undefined;
+}
+
+function getWidgetType(widget: LayoutWidgetInput): "chart" | "kpi" | "table" {
+  return widget.type === "kpi" || widget.type === "table"
+    ? widget.type
+    : "chart";
+}
+
+function readRawLayouts(
+  widget: LayoutWidgetInput,
+): Partial<Record<LayoutBreakpoint, WidgetLayout>> {
+  const result: Partial<Record<LayoutBreakpoint, WidgetLayout>> = {};
+  const rawLayouts =
+    widget.layouts && typeof widget.layouts === "object"
+      ? (widget.layouts as Record<string, unknown>)
+      : null;
+
+  for (const bp of RESPONSIVE_BREAKPOINTS) {
+    const raw = rawLayouts?.[bp];
+    if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+      result[bp] = safeLayout(raw as Record<string, unknown>);
+    }
+  }
+
+  if (
+    !result.lg &&
+    widget.layout &&
+    typeof widget.layout === "object" &&
+    !Array.isArray(widget.layout)
+  ) {
+    result.lg = safeLayout(widget.layout as Record<string, unknown>);
+  }
+
+  return result;
+}
+
+function withWidgetMinimums(
+  widget: LayoutWidgetInput,
+  layout: WidgetLayout,
+): WidgetLayout {
+  const defaults = getWidgetSizeDefaults(
+    getWidgetType(widget),
+    getWidgetVegaMark(widget),
+  );
+  return {
+    ...layout,
+    minW: layout.minW ?? defaults.minW,
+    minH: layout.minH ?? defaults.minH,
+  };
+}
+
+function preferredWidgetWidth(
+  widget: LayoutWidgetInput,
+  layout: WidgetLayout,
+  cols: number,
+): number {
+  const type = getWidgetType(widget);
+  const minW = Math.min(layout.minW ?? 2, cols);
+
+  if (type === "table") return cols;
+
+  if (type === "chart") {
+    if (layout.w >= 9) return cols;
+    if (layout.w >= 6) {
+      return cols >= 10 ? Math.max(Math.floor(cols / 2), minW) : cols;
+    }
+    if (cols <= 4) return cols;
+  }
+
+  const scaled = Math.round((layout.w * cols) / BREAKPOINT_COLS.lg);
+  return Math.min(Math.max(scaled, minW), cols);
+}
+
+function packKpiRow(
+  widgets: Array<{ widget: LayoutWidgetInput; lg: WidgetLayout }>,
+  cols: number,
+  y: number,
+): { layouts: Map<string, WidgetLayout>; nextY: number } {
+  const layouts = new Map<string, WidgetLayout>();
+  const perRow = cols <= 4 ? 1 : 2;
+  let cursorY = y;
+
+  for (let index = 0; index < widgets.length; index += perRow) {
+    const row = widgets.slice(index, index + perRow);
+    const singleRemainder = row.length === 1 && widgets.length > perRow;
+    const width = singleRemainder ? cols : Math.floor(cols / row.length);
+    const rowHeight = Math.max(...row.map(entry => entry.lg.h));
+    let cursorX = 0;
+
+    for (let rowIndex = 0; rowIndex < row.length; rowIndex += 1) {
+      const { widget, lg } = row[rowIndex];
+      const w = rowIndex === row.length - 1 ? cols - cursorX : width;
+      layouts.set(String(widget.id), {
+        x: cursorX,
+        y: cursorY,
+        w,
+        h: lg.h,
+        ...(lg.minW != null ? { minW: Math.min(lg.minW, cols) } : {}),
+        ...(lg.minH != null ? { minH: lg.minH } : {}),
+      });
+      cursorX += w;
+    }
+
+    cursorY += rowHeight;
+  }
+
+  return { layouts, nextY: cursorY };
+}
+
+function packMixedRow(
+  widgets: Array<{ widget: LayoutWidgetInput; lg: WidgetLayout }>,
+  cols: number,
+  y: number,
+): { layouts: Map<string, WidgetLayout>; nextY: number } {
+  const layouts = new Map<string, WidgetLayout>();
+  let cursorX = 0;
+  let cursorY = y;
+  let rowHeight = 0;
+
+  for (const { widget, lg } of widgets) {
+    const w = preferredWidgetWidth(widget, lg, cols);
+    if (cursorX > 0 && cursorX + w > cols) {
+      cursorY += rowHeight;
+      cursorX = 0;
+      rowHeight = 0;
+    }
+
+    layouts.set(String(widget.id), {
+      x: cursorX,
+      y: cursorY,
+      w,
+      h: lg.h,
+      ...(lg.minW != null ? { minW: Math.min(lg.minW, cols) } : {}),
+      ...(lg.minH != null ? { minH: lg.minH } : {}),
+    });
+    cursorX += w;
+    rowHeight = Math.max(rowHeight, lg.h);
+  }
+
+  return { layouts, nextY: cursorY + rowHeight };
+}
+
+function deriveBreakpointLayouts(
+  widgets: Array<{ widget: LayoutWidgetInput; lg: WidgetLayout }>,
+  breakpoint: Exclude<LayoutBreakpoint, "lg">,
+): Map<string, WidgetLayout> {
+  const cols = BREAKPOINT_COLS[breakpoint];
+  const rows = new Map<
+    number,
+    Array<{ widget: LayoutWidgetInput; lg: WidgetLayout }>
+  >();
+
+  for (const entry of widgets) {
+    const row = rows.get(entry.lg.y) ?? [];
+    row.push(entry);
+    rows.set(entry.lg.y, row);
+  }
+
+  const layouts = new Map<string, WidgetLayout>();
+  let cursorY = 0;
+
+  for (const [, row] of [...rows.entries()].sort(([a], [b]) => a - b)) {
+    row.sort((a, b) => a.lg.x - b.lg.x);
+    const packed = row.every(entry => getWidgetType(entry.widget) === "kpi")
+      ? packKpiRow(row, cols, cursorY)
+      : packMixedRow(row, cols, cursorY);
+    for (const [id, layout] of packed.layouts) {
+      layouts.set(id, layout);
+    }
+    cursorY = packed.nextY;
+  }
+
+  return layouts;
+}
+
+/**
+ * Normalize a full dashboard widget list while deriving responsive layouts from
+ * row intent rather than scaling each widget independently. Explicit user
+ * breakpoint layouts are preserved; only missing breakpoints are synthesized.
+ */
+export function normalizeDashboardWidgetsLayouts<T extends LayoutWidgetInput>(
+  widgets: T[],
+): Array<T & { layouts: DashboardWidget["layouts"] }> {
+  const entries = widgets.map(widget => {
+    const rawLayouts = readRawLayouts(widget);
+    const lg = withWidgetMinimums(
+      widget,
+      rawLayouts.lg ?? { ...DEFAULT_LAYOUT },
+    );
+    return { widget, rawLayouts, lg };
+  });
+
+  const derived = {
+    md: deriveBreakpointLayouts(entries, "md"),
+    sm: deriveBreakpointLayouts(entries, "sm"),
+    xs: deriveBreakpointLayouts(entries, "xs"),
+  };
+
+  return entries.map(({ widget, rawLayouts, lg }) => {
+    const id = String(widget.id);
+    const layouts: DashboardWidget["layouts"] = {
+      lg,
+      md: rawLayouts.md ?? derived.md.get(id) ?? deriveResponsiveLayouts(lg).md,
+      sm: rawLayouts.sm ?? derived.sm.get(id) ?? deriveResponsiveLayouts(lg).sm,
+      xs: rawLayouts.xs ?? derived.xs.get(id) ?? deriveResponsiveLayouts(lg).xs,
+    };
+    const { layout: _removed, ...rest } = widget;
+    return { ...rest, layouts } as T & { layouts: DashboardWidget["layouts"] };
+  });
 }
 
 function safeLayout(raw: Record<string, unknown> | undefined): WidgetLayout {

--- a/packages/schemas/src/dashboard.schema.ts
+++ b/packages/schemas/src/dashboard.schema.ts
@@ -294,6 +294,10 @@ function readRawLayouts(
   return result;
 }
 
+function layoutsMatch(a: WidgetLayout, b: WidgetLayout): boolean {
+  return a.x === b.x && a.y === b.y && a.w === b.w && a.h === b.h;
+}
+
 function withWidgetMinimums(
   widget: LayoutWidgetInput,
   layout: WidgetLayout,
@@ -433,10 +437,74 @@ function deriveBreakpointLayouts(
   return layouts;
 }
 
+function isUserAuthoredBreakpoint(
+  rawLayout: WidgetLayout | undefined,
+  lg: WidgetLayout,
+  breakpoint: Exclude<LayoutBreakpoint, "lg">,
+): rawLayout is WidgetLayout {
+  if (!rawLayout) return false;
+  const legacyDerived = deriveResponsiveLayouts(lg)[breakpoint];
+  if (!legacyDerived) return true;
+  return !layoutsMatch(rawLayout, legacyDerived);
+}
+
+function layoutsOverlap(a: WidgetLayout, b: WidgetLayout): boolean {
+  return (
+    a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y
+  );
+}
+
+function resolveBreakpointCollisions(
+  entries: Array<{
+    widget: LayoutWidgetInput;
+    rawLayouts: Partial<Record<LayoutBreakpoint, WidgetLayout>>;
+    lg: WidgetLayout;
+  }>,
+  generated: Map<string, WidgetLayout>,
+  breakpoint: Exclude<LayoutBreakpoint, "lg">,
+): Map<string, WidgetLayout> {
+  const resolved = new Map<string, WidgetLayout>();
+  const placed: WidgetLayout[] = [];
+  const generatedEntries: Array<{ id: string; layout: WidgetLayout }> = [];
+
+  for (const entry of entries) {
+    const id = String(entry.widget.id);
+    const rawLayout = entry.rawLayouts[breakpoint];
+    if (isUserAuthoredBreakpoint(rawLayout, entry.lg, breakpoint)) {
+      resolved.set(id, rawLayout);
+      placed.push(rawLayout);
+      continue;
+    }
+
+    const layout = generated.get(id);
+    if (layout) {
+      generatedEntries.push({ id, layout });
+    }
+  }
+
+  generatedEntries.sort(
+    (a, b) => a.layout.y - b.layout.y || a.layout.x - b.layout.x,
+  );
+
+  for (const { id, layout } of generatedEntries) {
+    const nextLayout = { ...layout };
+    while (
+      placed.some(placedLayout => layoutsOverlap(nextLayout, placedLayout))
+    ) {
+      nextLayout.y += 1;
+    }
+    resolved.set(id, nextLayout);
+    placed.push(nextLayout);
+  }
+
+  return resolved;
+}
+
 /**
  * Normalize a full dashboard widget list while deriving responsive layouts from
  * row intent rather than scaling each widget independently. Explicit user
- * breakpoint layouts are preserved; only missing breakpoints are synthesized.
+ * breakpoint layouts are preserved; missing or legacy auto-derived breakpoints
+ * are synthesized.
  */
 export function normalizeDashboardWidgetsLayouts<T extends LayoutWidgetInput>(
   widgets: T[],
@@ -450,19 +518,24 @@ export function normalizeDashboardWidgetsLayouts<T extends LayoutWidgetInput>(
     return { widget, rawLayouts, lg };
   });
 
-  const derived = {
+  const generated = {
     md: deriveBreakpointLayouts(entries, "md"),
     sm: deriveBreakpointLayouts(entries, "sm"),
     xs: deriveBreakpointLayouts(entries, "xs"),
+  };
+  const derived = {
+    md: resolveBreakpointCollisions(entries, generated.md, "md"),
+    sm: resolveBreakpointCollisions(entries, generated.sm, "sm"),
+    xs: resolveBreakpointCollisions(entries, generated.xs, "xs"),
   };
 
   return entries.map(({ widget, rawLayouts, lg }) => {
     const id = String(widget.id);
     const layouts: DashboardWidget["layouts"] = {
       lg,
-      md: rawLayouts.md ?? derived.md.get(id) ?? deriveResponsiveLayouts(lg).md,
-      sm: rawLayouts.sm ?? derived.sm.get(id) ?? deriveResponsiveLayouts(lg).sm,
-      xs: rawLayouts.xs ?? derived.xs.get(id) ?? deriveResponsiveLayouts(lg).xs,
+      md: derived.md.get(id) ?? deriveResponsiveLayouts(lg).md,
+      sm: derived.sm.get(id) ?? deriveResponsiveLayouts(lg).sm,
+      xs: derived.xs.get(id) ?? deriveResponsiveLayouts(lg).xs,
     };
     const { layout: _removed, ...rest } = widget;
     return { ...rest, layouts } as T & { layouts: DashboardWidget["layouts"] };

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -10,6 +10,7 @@ export {
   GlobalFilterSchema,
   DashboardDefinitionSchema,
   normalizeWidgetLayouts,
+  normalizeDashboardWidgetsLayouts,
   getWidgetSizeDefaults,
   deriveResponsiveLayouts,
   type WidgetLayout,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add whole-dashboard responsive layout synthesis that reflows visual rows instead of scaling widgets independently
- Preserve user-authored md/sm/xs breakpoint layouts while replacing missing or legacy auto-derived fallbacks with smarter generated layouts
- Move generated layouts out of explicit breakpoint space to avoid collisions
- Add optional `custom` breakpoint provenance, persist it in the workspace dashboard schema, and mark non-lg edits as custom only during real drag/resize interactions
- Keep smart fallbacks re-derivable instead of freezing them as persisted user-authored layouts
- Persist only the active edited breakpoint from React Grid Layout and prune legacy generated smaller breakpoints when lg changes
- Add a dashboard settings action to reset responsive layouts back to auto
- Offset all breakpoints when duplicating widgets
- Apply the shared smart fallback in dashboard grid, presentation mode, and embedded dashboards; keep API/store normalization legacy-safe and normalize PUT widget updates
- Update dashboard agent layout guidance with row-friendly width recommendations
- Add regression coverage for KPI row reflow, explicit/custom breakpoint preservation, legacy fallback replacement, and collision avoidance

## Comparison notes
- Compared against `cursor/responsive-dashboard-layout-packing-9258`, `cursor/smart-dashboard-fallbacks-d9e8`, and `cursor/smart-responsive-dashboard-reflow-8a00`
- Borrowed the explicit custom breakpoint provenance/reset-to-auto ideas from `cursor/smart-responsive-dashboard-reflow-8a00`
- Kept this branch's row-aware schema-level algorithm, presentation/embed coverage, interaction-gated persistence, and test coverage

## Testing
- `pnpm --filter @mako/schemas run build`
- `pnpm --filter app run test:unit -- responsive-layout.test.ts` (Vitest ran all app unit tests)
- `pnpm --filter app run typecheck`
- `pnpm --filter app run lint`
- `pnpm --filter api run lint`
- `pnpm --filter api run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78083f34-5d15-4e57-9970-9a6f2a04887f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78083f34-5d15-4e57-9970-9a6f2a04887f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

