### PR TITLE
fix(agent-chat): recover chats poisoned by malformed file parts

### DIFF
--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -516,6 +516,12 @@ export interface IMessagePart {
   input?: unknown; // Tool input/arguments (named 'input' for AI SDK v6 compat, was 'args')
   output?: unknown; // Tool result (named 'output' for AI SDK v6 compat, was 'result')
   state?: string; // Tool state: "input-streaming", "input-available", "output-streaming", "output-available", "error"
+  // File parts (AI SDK FileUIPart). Without these fields, persisted attachments
+  // are reduced to `{ type: "file", _id }` and break `convertToModelMessages`
+  // with "The messages do not match the ModelMessage[] schema."
+  url?: string; // Data URL or remote URL of the attachment
+  mediaType?: string; // MIME type, e.g. "image/png"
+  filename?: string; // Optional original file name
 }
 
 /**
@@ -1598,6 +1604,12 @@ const ChatSchema = new Schema<IChat>(
             input: Schema.Types.Mixed,
             output: Schema.Types.Mixed,
             state: String,
+            // File parts (AI SDK FileUIPart). Persisting these keeps attachments
+            // round-trippable; without them Mongoose strict mode strips the
+            // fields and breaks convertToModelMessages on the next turn.
+            url: String,
+            mediaType: String,
+            filename: String,
           },
         ],
         // Legacy fields - kept for backward compatibility with existing chats

--- a/api/src/services/agent-thread.service.ts
+++ b/api/src/services/agent-thread.service.ts
@@ -494,6 +494,9 @@ function convertUIMessageToStoredFormat(msg: UIMessage): {
     input?: unknown;
     output?: unknown;
     state?: string;
+    url?: string;
+    mediaType?: string;
+    filename?: string;
   }>;
   // Legacy fields for backward compatibility
   content: string;
@@ -519,6 +522,18 @@ function convertUIMessageToStoredFormat(msg: UIMessage): {
       return {
         type: "reasoning",
         reasoning: (p.reasoning as string) || (p.text as string),
+      };
+    }
+
+    // File parts (AI SDK FileUIPart): persist url/mediaType/filename explicitly
+    // so the attachment round-trips. Dropping these fields would reduce the part
+    // to `{ type: "file", _id }` and break convertToModelMessages on replay.
+    if (partType === "file") {
+      return {
+        type: "file",
+        url: p.url as string,
+        mediaType: p.mediaType as string,
+        filename: p.filename as string | undefined,
       };
     }
 

--- a/api/src/services/agent-thread.service.ts
+++ b/api/src/services/agent-thread.service.ts
@@ -4,6 +4,7 @@ import type { UIMessage } from "ai";
 import { Chat, SavedConsole } from "../database/workspace-schema";
 import type { AgentKind } from "../agent-lib";
 import { loggers } from "../logging";
+import { isModelReadyFilePart } from "../utils/message-sanitizer";
 
 const logger = loggers.agent();
 
@@ -509,53 +510,61 @@ function convertUIMessageToStoredFormat(msg: UIMessage): {
   }>;
 } {
   // NEW: Store raw parts array - this preserves chronological order
-  const storedParts = (msg.parts || []).map(part => {
-    const p = part as Record<string, unknown>;
-    const partType = p.type as string;
+  const storedParts = (msg.parts || [])
+    .map(part => {
+      const p = part as Record<string, unknown>;
+      const partType = p.type as string;
 
-    if (partType === "text") {
-      return { type: "text", text: p.text as string };
-    }
+      if (partType === "text") {
+        return { type: "text", text: p.text as string };
+      }
 
-    if (partType === "reasoning") {
-      // Reasoning parts may have text in 'text' or 'reasoning' field
-      return {
-        type: "reasoning",
-        reasoning: (p.reasoning as string) || (p.text as string),
-      };
-    }
+      if (partType === "reasoning") {
+        // Reasoning parts may have text in 'text' or 'reasoning' field
+        return {
+          type: "reasoning",
+          reasoning: (p.reasoning as string) || (p.text as string),
+        };
+      }
 
-    // File parts (AI SDK FileUIPart): persist url/mediaType/filename explicitly
-    // so the attachment round-trips. Dropping these fields would reduce the part
-    // to `{ type: "file", _id }` and break convertToModelMessages on replay.
-    if (partType === "file") {
-      return {
-        type: "file",
-        url: p.url as string,
-        mediaType: p.mediaType as string,
-        filename: p.filename as string | undefined,
-      };
-    }
+      // File parts (AI SDK FileUIPart): persist url/mediaType/filename
+      // explicitly so the attachment round-trips. Dropping these fields would
+      // reduce the part to `{ type: "file", _id }` and break
+      // convertToModelMessages on replay. Parts that are not model-ready
+      // (missing mediaType + payload) are unrecoverable, so drop them rather
+      // than persist a poison pill.
+      if (partType === "file") {
+        if (!isModelReadyFilePart(p)) {
+          return null;
+        }
+        return {
+          type: "file",
+          url: p.url as string,
+          mediaType: p.mediaType as string,
+          filename: p.filename as string | undefined,
+        };
+      }
 
-    // Tool parts: type is "tool-{toolName}" or "dynamic-tool"
-    if (partType.startsWith("tool-") || partType === "dynamic-tool") {
-      const toolName =
-        partType === "dynamic-tool"
-          ? (p.toolName as string)
-          : partType.split("-").slice(1).join("-");
-      return {
-        type: partType,
-        toolCallId: p.toolCallId as string,
-        toolName: toolName || (p.toolName as string),
-        input: p.input ?? {},
-        output: p.output ?? null,
-        state: (p.state as string) || "output-available",
-      };
-    }
+      // Tool parts: type is "tool-{toolName}" or "dynamic-tool"
+      if (partType.startsWith("tool-") || partType === "dynamic-tool") {
+        const toolName =
+          partType === "dynamic-tool"
+            ? (p.toolName as string)
+            : partType.split("-").slice(1).join("-");
+        return {
+          type: partType,
+          toolCallId: p.toolCallId as string,
+          toolName: toolName || (p.toolName as string),
+          input: p.input ?? {},
+          output: p.output ?? null,
+          state: (p.state as string) || "output-available",
+        };
+      }
 
-    // Unknown part type - store as-is
-    return { type: partType, ...p };
-  });
+      // Unknown part type - store as-is
+      return { type: partType, ...p };
+    })
+    .filter((part): part is NonNullable<typeof part> => part !== null);
 
   // TODO: Remove legacy field extraction once we're OK with losing backward compatibility
   // for old consumers that read content/reasoning/toolCalls instead of parts.

--- a/api/src/utils/message-sanitizer.ts
+++ b/api/src/utils/message-sanitizer.ts
@@ -1,6 +1,37 @@
 import type { UIMessage } from "ai";
 
 /**
+ * Returns true when a `file` UI part is well-formed enough to survive
+ * `convertToModelMessages`. The AI SDK `FileUIPart` schema requires a string
+ * `url` (data URL or remote URL); `mediaType` is also expected. Parts missing
+ * these fields cannot be converted and poison the whole request.
+ */
+function isValidFilePart(
+  part: { type: string } & Record<string, unknown>,
+): boolean {
+  const url = part.url;
+  return typeof url === "string" && url.length > 0;
+}
+
+/**
+ * Drop malformed `file` parts from a message's parts array.
+ *
+ * Historically, file attachments were persisted before the DB schema stored
+ * `url`/`mediaType`, so Mongoose stripped those fields and reduced the part to
+ * `{ type: "file", _id }`. When such a message is replayed, the AI SDK throws
+ * "Invalid prompt: The messages do not match the ModelMessage[] schema." Since
+ * the file payload is unrecoverable, we drop the broken part entirely so the
+ * rest of the conversation (and any sibling text part) still goes through.
+ */
+function dropMalformedFileParts(
+  parts: ReadonlyArray<{ type: string } & Record<string, unknown>>,
+): Array<{ type: string } & Record<string, unknown>> {
+  return parts.filter(part =>
+    part?.type === "file" ? isValidFilePart(part) : true,
+  );
+}
+
+/**
  * Sanitize UIMessages by removing incomplete tool parts.
  *
  * When a chat stream is interrupted (user closes browser, network failure, etc.),
@@ -17,26 +48,48 @@ import type { UIMessage } from "ai";
  *
  * This function filters out incomplete tool parts before sending to the model.
  * Complete tool states: output-available, output-error, output-denied.
+ *
+ * It also drops malformed `file` parts (missing `url`/`mediaType`) on any
+ * message role, which otherwise make `convertToModelMessages` reject the entire
+ * request with "The messages do not match the ModelMessage[] schema."
  */
 export function sanitizeMessagesForModel(messages: UIMessage[]): UIMessage[] {
   return messages.map(msg => {
-    // Only assistant messages can have tool parts
+    // Drop malformed file parts on every message role first — a single broken
+    // file part (e.g. a legacy `{ type: "file", _id }`) poisons the whole
+    // request, not just assistant messages.
+    const fileSafeParts = dropMalformedFileParts(
+      (msg.parts ?? []) as Array<{ type: string } & Record<string, unknown>>,
+    );
+
+    // Non-assistant messages only need the file-part repair. Guard against a
+    // user/system message being left with zero parts (e.g. it contained only a
+    // broken attachment) — an empty parts array also fails schema validation.
     if (msg.role !== "assistant") {
-      return msg;
+      if (fileSafeParts.length === (msg.parts?.length ?? 0)) {
+        return msg;
+      }
+      if (fileSafeParts.length === 0) {
+        return {
+          ...msg,
+          parts: [{ type: "text" as const, text: "[Attachment removed]" }],
+        };
+      }
+      return { ...msg, parts: fileSafeParts as UIMessage["parts"] };
     }
 
     // Empty assistant messages (e.g. from interrupted streams persisted with
     // no content) must not be forwarded to `convertToModelMessages`, which
     // throws "The messages do not match the ModelMessage[] schema." Replace
     // with the same placeholder we use for tool-only messages below.
-    if (!msg.parts || msg.parts.length === 0) {
+    if (fileSafeParts.length === 0) {
       return {
         ...msg,
         parts: [{ type: "text" as const, text: "[Response interrupted]" }],
       };
     }
 
-    const partsNormalized = msg.parts.map(part => {
+    const partsNormalized = fileSafeParts.map(part => {
       const partType = part.type;
       if (
         typeof partType !== "string" ||
@@ -103,6 +156,6 @@ export function sanitizeMessagesForModel(messages: UIMessage[]): UIMessage[] {
       };
     }
 
-    return { ...msg, parts: sanitizedParts };
+    return { ...msg, parts: sanitizedParts as UIMessage["parts"] };
   });
 }

--- a/api/src/utils/message-sanitizer.ts
+++ b/api/src/utils/message-sanitizer.ts
@@ -1,33 +1,51 @@
 import type { UIMessage } from "ai";
 
-/**
- * Returns true when a `file` UI part is well-formed enough to survive
- * `convertToModelMessages`. The AI SDK `FileUIPart` schema requires a string
- * `url` (data URL or remote URL); `mediaType` is also expected. Parts missing
- * these fields cannot be converted and poison the whole request.
- */
-function isValidFilePart(
-  part: { type: string } & Record<string, unknown>,
-): boolean {
-  const url = part.url;
-  return typeof url === "string" && url.length > 0;
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }
 
 /**
- * Drop malformed `file` parts from a message's parts array.
+ * Returns true when a `file` part is well-formed enough to be converted to
+ * model input. The AI SDK `FileUIPart` schema requires a non-empty `mediaType`
+ * plus a payload — either a string `url` (data URL or remote URL) or inline
+ * `data` (base64 string or `Uint8Array`).
  *
  * Historically, file attachments were persisted before the DB schema stored
  * `url`/`mediaType`, so Mongoose stripped those fields and reduced the part to
- * `{ type: "file", _id }`. When such a message is replayed, the AI SDK throws
- * "Invalid prompt: The messages do not match the ModelMessage[] schema." Since
- * the file payload is unrecoverable, we drop the broken part entirely so the
- * rest of the conversation (and any sibling text part) still goes through.
+ * `{ type: "file", _id }`. Replaying such a part makes the AI SDK throw
+ * "Invalid prompt: The messages do not match the ModelMessage[] schema."
+ * Validating here lets us drop the unrecoverable part both before sending to
+ * the model and before persisting it again.
+ */
+export function isModelReadyFilePart(part: unknown): boolean {
+  if (!isRecord(part) || part.type !== "file") {
+    return false;
+  }
+
+  const mediaType = part.mediaType;
+  const url = part.url;
+  const data = part.data;
+
+  return (
+    typeof mediaType === "string" &&
+    mediaType.length > 0 &&
+    ((typeof url === "string" && url.length > 0) ||
+      (typeof data === "string" && data.length > 0) ||
+      data instanceof Uint8Array)
+  );
+}
+
+/**
+ * Drop malformed `file` parts from a message's parts array. Non-file parts are
+ * always kept; file parts are kept only when model-ready. The unrecoverable
+ * file payload is dropped so the rest of the conversation (and any sibling text
+ * part) still goes through.
  */
 function dropMalformedFileParts(
   parts: ReadonlyArray<{ type: string } & Record<string, unknown>>,
 ): Array<{ type: string } & Record<string, unknown>> {
   return parts.filter(part =>
-    part?.type === "file" ? isValidFilePart(part) : true,
+    part?.type === "file" ? isModelReadyFilePart(part) : true,
   );
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

A chat becomes **permanently broken** once an image/file is attached to a message. The `POST /api/agent/chat` stream fails immediately with:

```
Invalid prompt: The messages do not match the ModelMessage[] schema.
```

Because the failure happens on every subsequent send, the user keeps appending user messages with no assistant reply.

## Root cause

The request payload contained a user message part:

```json
{ "type": "file", "_id": "6a1fef0a788f201efef3c2ab" }
```

— a `file` part with **no `url`/`mediaType`**. The AI SDK (`ai@6.0.0-beta.166`) `FileUIPart` schema requires those fields, so `convertToModelMessages(...)` rejects the entire request.

How the part got into that shape:

1. The client correctly submits `{ type: "file", url: "data:…", mediaType: "image/png" }`.
2. On stream finish, `saveChat` → `convertUIMessageToStoredFormat` spreads it as-is.
3. The Mongoose message-part subschema (`workspace-schema.ts`) only defined `type, text, reasoning, toolCallId, toolName, input, output, state` — **no `url`/`mediaType`**. Strict mode strips those fields, and Mongoose auto-adds an `_id` to the array subdocument.
4. The stored part collapses to `{ type: "file", _id }`.
5. On the next turn the client replays the history; `sanitizeMessagesForModel` only touched assistant messages, so the broken user file part reached `convertToModelMessages` → schema error.

## Fix

This branch fixes the bug at **both** the symptom layer and the root-cause layer:

- **`message-sanitizer.ts`**
  - New shared, exported `isModelReadyFilePart()` helper — a file part is valid only if it has a non-empty `mediaType` **and** a payload (`url` string, base64 `data` string, or `Uint8Array`).
  - `sanitizeMessagesForModel` now drops malformed `file` parts on **every** message role (not just assistant). This immediately recovers chats already poisoned in the DB — a sibling text part (the user's question) still goes through. Guards against a user message being left with zero parts.
- **`workspace-schema.ts`** — added `url`, `mediaType`, `filename` to the `parts` subschema and the `IMessagePart` interface so attachments round-trip and are no longer stripped on save. **This is the root-cause fix** that keeps multimodal/image chat working going forward.
- **`agent-thread.service.ts`** — `convertUIMessageToStoredFormat` persists `file` parts explicitly (`url`/`mediaType`/`filename`) and drops parts that are not model-ready (via the shared helper), so we never persist a poison pill again.

## Notes

- Pre-existing chats poisoned with `{ type: "file", _id }` are recovered by the sanitizer change (no data migration — the original attachment bytes are unrecoverable, so the broken part is dropped while the rest of the conversation continues).
- New attachments persist correctly thanks to the schema + persistence changes.

## Verification

- `pnpm --filter api run lint` ✅
- `pnpm --filter api run build` (typecheck) ✅

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83b002b8-e39c-42e3-b5f6-693d4d74e51f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83b002b8-e39c-42e3-b5f6-693d4d74e51f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

