### PR TITLE
Persist chat image attachments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,14 @@ WEB_API_PORT=8080
 # GCS_DASHBOARD_BUCKET=revops-462013-dashboard-artifacts
 # DASHBOARD_ARTIFACT_PREFIX=dashboard-artifacts/local-yourname
 
+# Chat Image Attachments (optional - defaults to filesystem)
+# Reuses DASHBOARD_ARTIFACT_STORE and GCS_DASHBOARD_BUCKET when set. Override
+# these if chat images should live in a separate bucket/prefix.
+# CHAT_ATTACHMENT_STORE=gcs
+# GCS_CHAT_ATTACHMENTS_BUCKET=revops-462013-dashboard-artifacts
+# CHAT_ATTACHMENT_PREFIX=chat-attachments/local-yourname
+# CHAT_ATTACHMENT_MAX_BYTES=10485760
+
 # Rate Limiting
 RATE_LIMIT_WINDOW_MS=900000  # 15 minutes
 RATE_LIMIT_MAX_REQUESTS=5

--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,10 @@ WEB_API_PORT=8080
 # GCS_CHAT_ATTACHMENTS_BUCKET=revops-462013-dashboard-artifacts
 # CHAT_ATTACHMENT_PREFIX=chat-attachments/local-yourname
 # CHAT_ATTACHMENT_MAX_BYTES=10485760
+# Cloudflare Image Resizing for chat thumbnails. Defaults to enabled in
+# production builds and disabled in dev; set explicitly to override.
+# VITE_CLOUDFLARE_IMAGE_RESIZING=true
+# VITE_CHAT_ATTACHMENT_IMAGE_OPTIONS=width=400,height=400,fit=scale-down,quality=85,format=auto
 
 # Rate Limiting
 RATE_LIMIT_WINDOW_MS=900000  # 15 minutes

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -522,6 +522,9 @@ export interface IMessagePart {
   url?: string; // Data URL or remote URL of the attachment
   mediaType?: string; // MIME type, e.g. "image/png"
   filename?: string; // Optional original file name
+  storageKey?: string; // Object-store key for durable chat attachments
+  attachmentId?: string; // Encoded storage key used by the authenticated proxy URL
+  size?: number; // Original attachment size in bytes, when known
 }
 
 /**
@@ -1610,6 +1613,9 @@ const ChatSchema = new Schema<IChat>(
             url: String,
             mediaType: String,
             filename: String,
+            storageKey: String,
+            attachmentId: String,
+            size: Number,
           },
         ],
         // Legacy fields - kept for backward compatibility with existing chats

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -11,6 +11,7 @@ import { dataSourceRoutes } from "./routes/sources";
 import { customPromptRoutes } from "./routes/custom-prompt";
 import { skillsRoutes } from "./routes/skills";
 import { chatsRoutes } from "./routes/chats";
+import { chatAttachmentRoutes } from "./routes/chat-attachments";
 import { agentRoutes } from "./routes/agent.routes";
 import { adminRoutes } from "./routes/admin.routes";
 import { authRoutes } from "./auth/auth.controller";
@@ -115,6 +116,7 @@ app.route("/api/workspaces/:workspaceId/databases", workspaceDatabaseRoutes);
 app.route("/api/workspaces/:workspaceId/execute", workspaceExecuteRoutes);
 app.route("/api/workspaces/:workspaceId/consoles", consoleRoutes);
 app.route("/api/workspaces/:workspaceId/chats", chatsRoutes);
+app.route("/api/workspaces/:workspaceId/chat-attachments", chatAttachmentRoutes);
 app.route("/api/workspaces/:workspaceId/custom-prompt", customPromptRoutes);
 app.route("/api/workspaces/:workspaceId/skills", skillsRoutes);
 // Connectors routes

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -55,6 +55,11 @@ import { loggers, enrichContextWithWorkspace } from "../logging";
 import { checkBillingLimits } from "../billing/usage-limit.middleware";
 import { getEffectiveBillingPlan } from "../billing/config";
 import {
+  decodeAttachmentKey,
+  getChatAttachmentStore,
+  readAttachmentAsDataUrl,
+} from "../services/chat-attachment-store.service";
+import {
   getAgentFactory,
   detectAgentId,
   getAllAgentMeta,
@@ -67,6 +72,76 @@ import { toNum, extractTokenCounts } from "../utils/safe-num";
 const logger = loggers.agent();
 
 export const agentRoutes = new Hono();
+
+function getStoredAttachmentKey(
+  part: Record<string, unknown>,
+  workspaceId: string,
+): string | null {
+  if (typeof part.storageKey === "string" && part.storageKey.length > 0) {
+    return part.storageKey.split("/").includes(workspaceId)
+      ? part.storageKey
+      : null;
+  }
+
+  if (typeof part.url !== "string") {
+    return null;
+  }
+
+  const marker = "/chat-attachments/";
+  const markerIndex = part.url.indexOf(marker);
+  if (markerIndex === -1) {
+    return null;
+  }
+
+  const attachmentId = part.url
+    .slice(markerIndex + marker.length)
+    .split(/[/?#]/)[0];
+  const decoded = decodeAttachmentKey(attachmentId);
+  return decoded?.split("/").includes(workspaceId) ? decoded : null;
+}
+
+async function hydrateChatAttachmentUrlsForModel(
+  messages: UIMessage[],
+  workspaceId: string,
+): Promise<UIMessage[]> {
+  const store = getChatAttachmentStore();
+
+  return Promise.all(
+    messages.map(async msg => {
+      const parts = msg.parts ?? [];
+      const hydratedParts = await Promise.all(
+        parts.map(async part => {
+          const p = part as Record<string, unknown>;
+          if (p.type !== "file") {
+            return part;
+          }
+
+          const storageKey = getStoredAttachmentKey(p, workspaceId);
+          const mediaType = p.mediaType;
+          if (!storageKey || typeof mediaType !== "string") {
+            return part;
+          }
+
+          try {
+            const signedUrl = await store.getSignedUrl(storageKey, 3600);
+            if (signedUrl) {
+              return { ...p, url: signedUrl };
+            }
+          } catch (error) {
+            logger.warn("Failed to sign chat attachment for model", {
+              error,
+              storageKey,
+            });
+          }
+
+          const dataUrl = await readAttachmentAsDataUrl(storageKey, mediaType);
+          return dataUrl ? { ...p, url: dataUrl } : part;
+        }),
+      );
+      return { ...msg, parts: hydratedParts as UIMessage["parts"] };
+    }),
+  );
+}
 
 // Apply unified auth middleware to all routes
 agentRoutes.use("*", unifiedAuthMiddleware);
@@ -604,7 +679,11 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
 
   // Sanitize messages to remove incomplete tool calls from interrupted streams
   // This prevents Anthropic API errors: "tool_use ids were found without tool_result blocks"
-  const sanitizedMessages = sanitizeMessagesForModel(messages);
+  const modelReadyMessages = await hydrateChatAttachmentUrlsForModel(
+    messages,
+    workspaceId,
+  );
+  const sanitizedMessages = sanitizeMessagesForModel(modelReadyMessages);
 
   // Convert UI messages (from useChat) to model messages (for streamText)
   const modelMessages = await convertToModelMessages(sanitizedMessages);

--- a/api/src/routes/chat-attachments.ts
+++ b/api/src/routes/chat-attachments.ts
@@ -63,11 +63,15 @@ function nodeStreamToWeb(
       });
     },
     pull() {
-      (nodeStream as NodeJS.ReadableStream & { resume?: () => void }).resume?.();
+      (
+        nodeStream as NodeJS.ReadableStream & { resume?: () => void }
+      ).resume?.();
     },
     cancel() {
       closed = true;
-      (nodeStream as NodeJS.ReadableStream & { destroy?: () => void }).destroy?.();
+      (
+        nodeStream as NodeJS.ReadableStream & { destroy?: () => void }
+      ).destroy?.();
     },
   });
 }
@@ -81,7 +85,10 @@ async function verifyWorkspaceAccess(
 
   if (workspace) {
     if (workspace._id.toString() !== workspaceId) {
-      return c.json({ error: "API key not authorized for this workspace" }, 403);
+      return c.json(
+        { error: "API key not authorized for this workspace" },
+        403,
+      );
     }
   } else if (user) {
     const hasAccess = await workspaceService.hasAccess(workspaceId, user.id);
@@ -143,7 +150,10 @@ chatAttachmentRoutes.post("/", async (c: AuthenticatedContext) => {
     return c.json({ error: "Only image attachments are supported" }, 400);
   }
 
-  if (typeof uploaded.size === "number" && uploaded.size > MAX_ATTACHMENT_BYTES) {
+  if (
+    typeof uploaded.size === "number" &&
+    uploaded.size > MAX_ATTACHMENT_BYTES
+  ) {
     return c.json({ error: "Image attachment is too large" }, 413);
   }
 
@@ -205,6 +215,7 @@ chatAttachmentRoutes.get("/:attachmentId", async (c: AuthenticatedContext) => {
     "Content-Type": metadata.contentType,
     "Cache-Control": "private, max-age=86400, immutable",
     "X-Content-Type-Options": "nosniff",
+    Vary: "Cookie, Authorization",
   };
   if (metadata.size != null) {
     headers["Content-Length"] = String(metadata.size);

--- a/api/src/routes/chat-attachments.ts
+++ b/api/src/routes/chat-attachments.ts
@@ -1,0 +1,214 @@
+import { Hono } from "hono";
+import { ObjectId } from "mongodb";
+import { unifiedAuthMiddleware } from "../auth/unified-auth.middleware";
+import { Chat } from "../database/workspace-schema";
+import { loggers, enrichContextWithWorkspace } from "../logging";
+import { AuthenticatedContext } from "../middleware/workspace.middleware";
+import {
+  buildChatAttachmentKey,
+  decodeAttachmentKey,
+  encodeAttachmentKey,
+  getChatAttachmentStore,
+} from "../services/chat-attachment-store.service";
+import { workspaceService } from "../services/workspace.service";
+
+const logger = loggers.api("chat-attachments");
+const MAX_ATTACHMENT_BYTES = Number(
+  process.env.CHAT_ATTACHMENT_MAX_BYTES || 10 * 1024 * 1024,
+);
+
+interface UploadedFileLike {
+  arrayBuffer(): Promise<ArrayBuffer>;
+  type?: string;
+  name?: string;
+  size?: number;
+}
+
+function isUploadedFileLike(value: unknown): value is UploadedFileLike {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "arrayBuffer" in value &&
+    typeof (value as { arrayBuffer?: unknown }).arrayBuffer === "function"
+  );
+}
+
+function nodeStreamToWeb(
+  nodeStream: NodeJS.ReadableStream,
+): ReadableStream<Uint8Array> {
+  let closed = false;
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      nodeStream.on("data", (chunk: Buffer) => {
+        if (!closed) {
+          controller.enqueue(new Uint8Array(chunk));
+          if (controller.desiredSize !== null && controller.desiredSize <= 0) {
+            (
+              nodeStream as NodeJS.ReadableStream & { pause?: () => void }
+            ).pause?.();
+          }
+        }
+      });
+      nodeStream.on("end", () => {
+        if (!closed) {
+          closed = true;
+          controller.close();
+        }
+      });
+      nodeStream.on("error", error => {
+        if (!closed) {
+          closed = true;
+          controller.error(error);
+        }
+      });
+    },
+    pull() {
+      (nodeStream as NodeJS.ReadableStream & { resume?: () => void }).resume?.();
+    },
+    cancel() {
+      closed = true;
+      (nodeStream as NodeJS.ReadableStream & { destroy?: () => void }).destroy?.();
+    },
+  });
+}
+
+async function verifyWorkspaceAccess(
+  c: AuthenticatedContext,
+  workspaceId: string,
+): Promise<Response | null> {
+  const user = c.get("user");
+  const workspace = c.get("workspace");
+
+  if (workspace) {
+    if (workspace._id.toString() !== workspaceId) {
+      return c.json({ error: "API key not authorized for this workspace" }, 403);
+    }
+  } else if (user) {
+    const hasAccess = await workspaceService.hasAccess(workspaceId, user.id);
+    if (!hasAccess) {
+      return c.json({ error: "Access denied to workspace" }, 403);
+    }
+  } else {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  enrichContextWithWorkspace(workspaceId);
+  return null;
+}
+
+export const chatAttachmentRoutes = new Hono();
+
+chatAttachmentRoutes.use("*", unifiedAuthMiddleware);
+
+chatAttachmentRoutes.post("/", async (c: AuthenticatedContext) => {
+  const workspaceId = c.req.param("workspaceId");
+  if (!ObjectId.isValid(workspaceId)) {
+    return c.json({ error: "Invalid workspace id" }, 400);
+  }
+
+  const accessError = await verifyWorkspaceAccess(c, workspaceId);
+  if (accessError) {
+    return accessError;
+  }
+
+  const form = await c.req.raw.formData().catch(error => {
+    logger.warn("Failed to parse chat attachment upload form", { error });
+    return null;
+  });
+  if (!form) {
+    return c.json({ error: "Invalid multipart form data" }, 400);
+  }
+
+  const chatId = String(form.get("chatId") || "");
+  if (!ObjectId.isValid(chatId)) {
+    return c.json({ error: "'chatId' is required and must be valid" }, 400);
+  }
+
+  const user = c.get("user");
+  const existingChat = await Chat.findOne({
+    _id: new ObjectId(chatId),
+    workspaceId: new ObjectId(workspaceId),
+  }).select({ createdBy: 1 });
+  if (existingChat && user && existingChat.createdBy !== user.id) {
+    return c.json({ error: "Access denied to chat" }, 403);
+  }
+
+  const uploaded = form.get("file");
+  if (!isUploadedFileLike(uploaded)) {
+    return c.json({ error: "'file' image upload is required" }, 400);
+  }
+
+  const mediaType = uploaded.type || "application/octet-stream";
+  if (!mediaType.startsWith("image/")) {
+    return c.json({ error: "Only image attachments are supported" }, 400);
+  }
+
+  if (typeof uploaded.size === "number" && uploaded.size > MAX_ATTACHMENT_BYTES) {
+    return c.json({ error: "Image attachment is too large" }, 413);
+  }
+
+  const body = Buffer.from(await uploaded.arrayBuffer());
+  if (body.byteLength > MAX_ATTACHMENT_BYTES) {
+    return c.json({ error: "Image attachment is too large" }, 413);
+  }
+
+  const key = buildChatAttachmentKey({
+    workspaceId,
+    chatId,
+    filename: uploaded.name,
+    mediaType,
+  });
+  await getChatAttachmentStore().putBuffer(key, body, mediaType, {
+    workspaceId,
+    chatId,
+    filename: uploaded.name || "",
+  });
+
+  const attachmentId = encodeAttachmentKey(key);
+  return c.json({
+    url: `/api/workspaces/${workspaceId}/chat-attachments/${attachmentId}`,
+    storageKey: key,
+    attachmentId,
+    mediaType,
+    filename: uploaded.name || undefined,
+    size: body.byteLength,
+  });
+});
+
+chatAttachmentRoutes.get("/:attachmentId", async (c: AuthenticatedContext) => {
+  const workspaceId = c.req.param("workspaceId");
+  if (!ObjectId.isValid(workspaceId)) {
+    return c.json({ error: "Invalid workspace id" }, 400);
+  }
+
+  const accessError = await verifyWorkspaceAccess(c, workspaceId);
+  if (accessError) {
+    return accessError;
+  }
+
+  const key = decodeAttachmentKey(c.req.param("attachmentId"));
+  if (!key || !key.split("/").includes(workspaceId)) {
+    return c.json({ error: "Attachment not found" }, 404);
+  }
+
+  const store = getChatAttachmentStore();
+  const [metadata, stream] = await Promise.all([
+    store.getMetadata(key),
+    store.openReadStream(key),
+  ]);
+
+  if (!metadata || !stream) {
+    return c.json({ error: "Attachment not found" }, 404);
+  }
+
+  const headers: Record<string, string> = {
+    "Content-Type": metadata.contentType,
+    "Cache-Control": "private, max-age=86400, immutable",
+    "X-Content-Type-Options": "nosniff",
+  };
+  if (metadata.size != null) {
+    headers["Content-Length"] = String(metadata.size);
+  }
+
+  return c.body(nodeStreamToWeb(stream), 200, headers);
+});

--- a/api/src/services/agent-thread.service.ts
+++ b/api/src/services/agent-thread.service.ts
@@ -498,6 +498,9 @@ function convertUIMessageToStoredFormat(msg: UIMessage): {
     url?: string;
     mediaType?: string;
     filename?: string;
+    storageKey?: string;
+    attachmentId?: string;
+    size?: number;
   }>;
   // Legacy fields for backward compatibility
   content: string;
@@ -542,6 +545,9 @@ function convertUIMessageToStoredFormat(msg: UIMessage): {
           url: p.url as string,
           mediaType: p.mediaType as string,
           filename: p.filename as string | undefined,
+          storageKey: p.storageKey as string | undefined,
+          attachmentId: p.attachmentId as string | undefined,
+          size: p.size as number | undefined,
         };
       }
 

--- a/api/src/services/chat-attachment-store.service.ts
+++ b/api/src/services/chat-attachment-store.service.ts
@@ -1,0 +1,565 @@
+import fs, { promises as fsPromises } from "fs";
+import crypto from "crypto";
+import path from "path";
+import { Readable } from "stream";
+import { Storage } from "@google-cloud/storage";
+import { loggers } from "../logging";
+
+export type ChatAttachmentStoreType = "filesystem" | "gcs" | "s3";
+
+export interface ChatAttachmentMetadata {
+  contentType: string;
+  size: number | null;
+}
+
+export interface ChatAttachmentStore {
+  readonly type: ChatAttachmentStoreType;
+  putBuffer(
+    key: string,
+    body: Buffer,
+    contentType: string,
+    metadata?: Record<string, string>,
+  ): Promise<void>;
+  getSignedUrl(key: string, ttlSeconds?: number): Promise<string | null>;
+  openReadStream(key: string): Promise<NodeJS.ReadableStream | null>;
+  getMetadata(key: string): Promise<ChatAttachmentMetadata | null>;
+  delete(key: string): Promise<void>;
+}
+
+const logger = loggers.api("chat-attachment-store");
+
+function getStoreType(): ChatAttachmentStoreType {
+  const raw =
+    process.env.CHAT_ATTACHMENT_STORE || process.env.DASHBOARD_ARTIFACT_STORE;
+  return raw === "gcs" || raw === "s3" ? raw : "filesystem";
+}
+
+function ensureSafeKey(key: string): string {
+  const normalized = key.replace(/^\/+/, "").replace(/\\/g, "/");
+  if (!normalized || normalized.includes("..")) {
+    throw new Error(`Invalid chat attachment key: ${key}`);
+  }
+  return normalized;
+}
+
+function getFilesystemRoot(): string {
+  if (process.env.CHAT_ATTACHMENT_DIR) {
+    return process.env.CHAT_ATTACHMENT_DIR;
+  }
+
+  if (process.env.NODE_ENV === "production") {
+    return "/data/chat-attachments";
+  }
+
+  return path.resolve(process.cwd(), ".data", "chat-attachments");
+}
+
+function metadataPath(filePath: string): string {
+  return `${filePath}.meta.json`;
+}
+
+class FilesystemChatAttachmentStore implements ChatAttachmentStore {
+  readonly type = "filesystem" as const;
+
+  private resolvePath(key: string): string {
+    return path.join(getFilesystemRoot(), ensureSafeKey(key));
+  }
+
+  async putBuffer(
+    key: string,
+    body: Buffer,
+    contentType: string,
+    metadata?: Record<string, string>,
+  ): Promise<void> {
+    const startedAt = Date.now();
+    const targetPath = this.resolvePath(key);
+    await fsPromises.mkdir(path.dirname(targetPath), { recursive: true });
+    await fsPromises.writeFile(targetPath, body);
+    await fsPromises.writeFile(
+      metadataPath(targetPath),
+      JSON.stringify({ contentType, metadata: metadata ?? {} }, null, 2),
+      "utf8",
+    );
+    logger.info("Stored chat attachment in filesystem", {
+      key,
+      bytes: body.byteLength,
+      durationMs: Date.now() - startedAt,
+      storeType: this.type,
+    });
+  }
+
+  async getSignedUrl(): Promise<string | null> {
+    return null;
+  }
+
+  async openReadStream(key: string): Promise<NodeJS.ReadableStream | null> {
+    try {
+      return fs.createReadStream(this.resolvePath(key));
+    } catch {
+      return null;
+    }
+  }
+
+  async getMetadata(key: string): Promise<ChatAttachmentMetadata | null> {
+    try {
+      const filePath = this.resolvePath(key);
+      const [stat, rawMetadata] = await Promise.all([
+        fsPromises.stat(filePath),
+        fsPromises.readFile(metadataPath(filePath), "utf8").catch(() => null),
+      ]);
+      const parsed =
+        rawMetadata != null
+          ? (JSON.parse(rawMetadata) as { contentType?: string })
+          : {};
+      return {
+        contentType: parsed.contentType || "application/octet-stream",
+        size: stat.size,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  async delete(key: string): Promise<void> {
+    const targetPath = this.resolvePath(key);
+    await fsPromises.rm(targetPath, { force: true }).catch(() => undefined);
+    await fsPromises
+      .rm(metadataPath(targetPath), { force: true })
+      .catch(() => undefined);
+  }
+}
+
+class GcsChatAttachmentStore implements ChatAttachmentStore {
+  readonly type = "gcs" as const;
+  private readonly storage = new Storage();
+  private readonly bucketName =
+    process.env.GCS_CHAT_ATTACHMENTS_BUCKET ||
+    process.env.GCS_DASHBOARD_BUCKET ||
+    "";
+
+  private file(key: string) {
+    if (!this.bucketName) {
+      throw new Error(
+        "GCS_CHAT_ATTACHMENTS_BUCKET or GCS_DASHBOARD_BUCKET is required for gcs chat attachment store",
+      );
+    }
+    return this.storage.bucket(this.bucketName).file(ensureSafeKey(key));
+  }
+
+  async putBuffer(
+    key: string,
+    body: Buffer,
+    contentType: string,
+    metadata?: Record<string, string>,
+  ): Promise<void> {
+    const startedAt = Date.now();
+    await this.file(key).save(body, {
+      contentType,
+      metadata: { metadata: metadata ?? {} },
+      resumable: false,
+    });
+    logger.info("Stored chat attachment in GCS", {
+      key,
+      bytes: body.byteLength,
+      durationMs: Date.now() - startedAt,
+      storeType: this.type,
+    });
+  }
+
+  async getSignedUrl(key: string, ttlSeconds = 3600): Promise<string | null> {
+    const [signedUrl] = await this.file(key).getSignedUrl({
+      action: "read",
+      expires: Date.now() + ttlSeconds * 1000,
+    });
+    return signedUrl;
+  }
+
+  async openReadStream(key: string): Promise<NodeJS.ReadableStream | null> {
+    try {
+      return this.file(key).createReadStream();
+    } catch {
+      return null;
+    }
+  }
+
+  async getMetadata(key: string): Promise<ChatAttachmentMetadata | null> {
+    try {
+      const [metadata] = await this.file(key).getMetadata();
+      return {
+        contentType: metadata.contentType || "application/octet-stream",
+        size: metadata.size ? Number(metadata.size) : null,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.file(key)
+      .delete({ ignoreNotFound: true })
+      .catch(() => undefined);
+  }
+}
+
+class S3ChatAttachmentStore implements ChatAttachmentStore {
+  readonly type = "s3" as const;
+  private readonly bucket =
+    process.env.S3_CHAT_ATTACHMENTS_BUCKET ||
+    process.env.S3_DASHBOARD_BUCKET ||
+    "";
+  private readonly region = process.env.S3_REGION || "us-east-1";
+  private readonly endpoint =
+    process.env.S3_ENDPOINT || "https://s3.amazonaws.com";
+  private readonly accessKeyId = process.env.S3_ACCESS_KEY_ID || "";
+  private readonly secretAccessKey = process.env.S3_SECRET_ACCESS_KEY || "";
+  private readonly sessionToken = process.env.S3_SESSION_TOKEN || "";
+  private readonly forcePathStyle = process.env.S3_FORCE_PATH_STYLE === "true";
+
+  private requireBucket(): string {
+    if (!this.bucket) {
+      throw new Error(
+        "S3_CHAT_ATTACHMENTS_BUCKET or S3_DASHBOARD_BUCKET is required for s3 chat attachment store",
+      );
+    }
+    return this.bucket;
+  }
+
+  private requireCredentials(): void {
+    if (!this.accessKeyId || !this.secretAccessKey) {
+      throw new Error(
+        "S3_ACCESS_KEY_ID and S3_SECRET_ACCESS_KEY are required for s3 chat attachment store",
+      );
+    }
+  }
+
+  private sha256Hex(value: string | Uint8Array): string {
+    return crypto.createHash("sha256").update(value).digest("hex");
+  }
+
+  private hmac(key: Buffer | string, value: string): Buffer {
+    return crypto.createHmac("sha256", key).update(value).digest();
+  }
+
+  private getSigningKey(shortDate: string): Buffer {
+    const kDate = this.hmac(`AWS4${this.secretAccessKey}`, shortDate);
+    const kRegion = this.hmac(kDate, this.region);
+    const kService = this.hmac(kRegion, "s3");
+    return this.hmac(kService, "aws4_request");
+  }
+
+  private formatAmzDate(now: Date): { amzDate: string; shortDate: string } {
+    const iso = now.toISOString().replace(/[:-]|\.\d{3}/g, "");
+    return {
+      amzDate: iso,
+      shortDate: iso.slice(0, 8),
+    };
+  }
+
+  private getObjectAddress(key: string): {
+    url: URL;
+    host: string;
+    canonicalUri: string;
+  } {
+    const safeKey = ensureSafeKey(key);
+    const endpoint = new URL(this.endpoint);
+    const normalizedPath = safeKey
+      .split("/")
+      .map(segment => encodeURIComponent(segment))
+      .join("/");
+
+    if (this.forcePathStyle) {
+      endpoint.pathname = `${endpoint.pathname.replace(/\/$/, "")}/${encodeURIComponent(this.requireBucket())}/${normalizedPath}`;
+      return {
+        url: endpoint,
+        host: endpoint.host,
+        canonicalUri: endpoint.pathname,
+      };
+    }
+
+    endpoint.hostname = `${this.requireBucket()}.${endpoint.hostname}`;
+    endpoint.pathname = `${endpoint.pathname.replace(/\/$/, "")}/${normalizedPath}`;
+    return {
+      url: endpoint,
+      host: endpoint.host,
+      canonicalUri: endpoint.pathname,
+    };
+  }
+
+  private buildCanonicalQuery(params: URLSearchParams): string {
+    return Array.from(params.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(
+        ([key, value]) =>
+          `${encodeURIComponent(key)}=${encodeURIComponent(value)}`,
+      )
+      .join("&");
+  }
+
+  private buildSignedHeaders(extraHeaders: Record<string, string>) {
+    const normalized = Object.entries(extraHeaders)
+      .map(([key, value]) => [key.toLowerCase(), value.trim()] as const)
+      .sort(([a], [b]) => a.localeCompare(b));
+    const canonicalHeaders = normalized
+      .map(([key, value]) => `${key}:${value}\n`)
+      .join("");
+    const signedHeaders = normalized.map(([key]) => key).join(";");
+    return { canonicalHeaders, signedHeaders };
+  }
+
+  private async signedRequest(
+    method: "HEAD" | "PUT" | "DELETE",
+    key: string,
+    options?: { body?: Uint8Array; contentType?: string },
+  ): Promise<Response> {
+    this.requireCredentials();
+    const { url, host, canonicalUri } = this.getObjectAddress(key);
+    const now = new Date();
+    const { amzDate, shortDate } = this.formatAmzDate(now);
+    const payloadHash =
+      method === "HEAD" || method === "DELETE"
+        ? "UNSIGNED-PAYLOAD"
+        : this.sha256Hex(options?.body || new Uint8Array());
+    const headers: Record<string, string> = {
+      host,
+      "x-amz-content-sha256": payloadHash,
+      "x-amz-date": amzDate,
+    };
+    if (options?.contentType) {
+      headers["content-type"] = options.contentType;
+    }
+    if (this.sessionToken) {
+      headers["x-amz-security-token"] = this.sessionToken;
+    }
+    const { canonicalHeaders, signedHeaders } =
+      this.buildSignedHeaders(headers);
+    const canonicalRequest = [
+      method,
+      canonicalUri,
+      "",
+      canonicalHeaders,
+      signedHeaders,
+      payloadHash,
+    ].join("\n");
+    const credentialScope = `${shortDate}/${this.region}/s3/aws4_request`;
+    const stringToSign = [
+      "AWS4-HMAC-SHA256",
+      amzDate,
+      credentialScope,
+      this.sha256Hex(canonicalRequest),
+    ].join("\n");
+    const signature = crypto
+      .createHmac("sha256", this.getSigningKey(shortDate))
+      .update(stringToSign)
+      .digest("hex");
+
+    const requestHeaders = new Headers();
+    for (const [keyName, value] of Object.entries(headers)) {
+      requestHeaders.set(keyName, value);
+    }
+    requestHeaders.set(
+      "Authorization",
+      `AWS4-HMAC-SHA256 Credential=${this.accessKeyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`,
+    );
+
+    return await fetch(url, {
+      method,
+      headers: requestHeaders,
+      body: options?.body ? Buffer.from(options.body) : undefined,
+    });
+  }
+
+  private async createSignedGetUrl(
+    key: string,
+    ttlSeconds: number,
+  ): Promise<string> {
+    this.requireCredentials();
+    const { url, host, canonicalUri } = this.getObjectAddress(key);
+    const now = new Date();
+    const { amzDate, shortDate } = this.formatAmzDate(now);
+    const credentialScope = `${shortDate}/${this.region}/s3/aws4_request`;
+    const params = new URLSearchParams({
+      "X-Amz-Algorithm": "AWS4-HMAC-SHA256",
+      "X-Amz-Credential": `${this.accessKeyId}/${credentialScope}`,
+      "X-Amz-Date": amzDate,
+      "X-Amz-Expires": String(ttlSeconds),
+      "X-Amz-SignedHeaders": "host",
+    });
+    if (this.sessionToken) {
+      params.set("X-Amz-Security-Token", this.sessionToken);
+    }
+    const canonicalQuery = this.buildCanonicalQuery(params);
+    const canonicalRequest = [
+      "GET",
+      canonicalUri,
+      canonicalQuery,
+      `host:${host}\n`,
+      "host",
+      "UNSIGNED-PAYLOAD",
+    ].join("\n");
+    const stringToSign = [
+      "AWS4-HMAC-SHA256",
+      amzDate,
+      credentialScope,
+      this.sha256Hex(canonicalRequest),
+    ].join("\n");
+    const signature = crypto
+      .createHmac("sha256", this.getSigningKey(shortDate))
+      .update(stringToSign)
+      .digest("hex");
+    params.set("X-Amz-Signature", signature);
+    url.search = params.toString();
+    return url.toString();
+  }
+
+  async putBuffer(
+    key: string,
+    body: Buffer,
+    contentType: string,
+  ): Promise<void> {
+    const startedAt = Date.now();
+    const response = await this.signedRequest("PUT", key, {
+      body,
+      contentType,
+    });
+    if (!response.ok) {
+      throw new Error(
+        `S3 chat attachment PUT failed with ${response.status} ${response.statusText}`,
+      );
+    }
+    logger.info("Stored chat attachment in S3", {
+      key,
+      bytes: body.byteLength,
+      durationMs: Date.now() - startedAt,
+      storeType: this.type,
+    });
+  }
+
+  async getSignedUrl(key: string, ttlSeconds = 3600): Promise<string | null> {
+    return await this.createSignedGetUrl(key, ttlSeconds);
+  }
+
+  async openReadStream(key: string): Promise<NodeJS.ReadableStream | null> {
+    try {
+      const url = await this.createSignedGetUrl(key, 3600);
+      const response = await fetch(url);
+      if (!response.ok || !response.body) {
+        return null;
+      }
+      return Readable.fromWeb(response.body);
+    } catch {
+      return null;
+    }
+  }
+
+  async getMetadata(key: string): Promise<ChatAttachmentMetadata | null> {
+    try {
+      const response = await this.signedRequest("HEAD", key);
+      if (!response.ok) {
+        return null;
+      }
+      return {
+        contentType:
+          response.headers.get("content-type") || "application/octet-stream",
+        size: Number(response.headers.get("content-length")) || null,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.signedRequest("DELETE", key).catch(() => undefined);
+  }
+}
+
+let attachmentStore: ChatAttachmentStore | null = null;
+
+export function getChatAttachmentStore(): ChatAttachmentStore {
+  if (attachmentStore) {
+    return attachmentStore;
+  }
+
+  switch (getStoreType()) {
+    case "gcs":
+      attachmentStore = new GcsChatAttachmentStore();
+      break;
+    case "s3":
+      attachmentStore = new S3ChatAttachmentStore();
+      break;
+    default:
+      attachmentStore = new FilesystemChatAttachmentStore();
+      break;
+  }
+
+  return attachmentStore;
+}
+
+export function getChatAttachmentStoreType(): ChatAttachmentStoreType {
+  return getChatAttachmentStore().type;
+}
+
+export function encodeAttachmentKey(key: string): string {
+  return Buffer.from(ensureSafeKey(key), "utf8").toString("base64url");
+}
+
+export function decodeAttachmentKey(encoded: string): string | null {
+  try {
+    return ensureSafeKey(Buffer.from(encoded, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+}
+
+export function buildChatAttachmentKey(options: {
+  workspaceId: string;
+  chatId: string;
+  filename?: string;
+  mediaType: string;
+}): string {
+  const configuredPrefix =
+    process.env.CHAT_ATTACHMENT_PREFIX || "chat-attachments";
+  const prefix = ensureSafeKey(configuredPrefix);
+  const extension = extensionForMediaType(options.mediaType, options.filename);
+  return [
+    prefix,
+    options.workspaceId,
+    options.chatId,
+    `${crypto.randomUUID()}${extension}`,
+  ].join("/");
+}
+
+function extensionForMediaType(mediaType: string, filename?: string): string {
+  const filenameExtension = filename ? path.extname(filename).toLowerCase() : "";
+  if (/^\.[a-z0-9]+$/i.test(filenameExtension)) {
+    return filenameExtension;
+  }
+
+  switch (mediaType) {
+    case "image/jpeg":
+      return ".jpg";
+    case "image/png":
+      return ".png";
+    case "image/gif":
+      return ".gif";
+    case "image/webp":
+      return ".webp";
+    default:
+      return "";
+  }
+}
+
+export async function readAttachmentAsDataUrl(
+  key: string,
+  mediaType: string,
+): Promise<string | null> {
+  const stream = await getChatAttachmentStore().openReadStream(key);
+  if (!stream) {
+    return null;
+  }
+
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return `data:${mediaType};base64,${Buffer.concat(chunks).toString("base64")}`;
+}

--- a/api/src/services/chat-attachment-store.service.ts
+++ b/api/src/services/chat-attachment-store.service.ts
@@ -445,7 +445,9 @@ class S3ChatAttachmentStore implements ChatAttachmentStore {
       if (!response.ok || !response.body) {
         return null;
       }
-      return Readable.fromWeb(response.body);
+      return Readable.fromWeb(
+        response.body as unknown as Parameters<typeof Readable.fromWeb>[0],
+      );
     } catch {
       return null;
     }
@@ -529,7 +531,9 @@ export function buildChatAttachmentKey(options: {
 }
 
 function extensionForMediaType(mediaType: string, filename?: string): string {
-  const filenameExtension = filename ? path.extname(filename).toLowerCase() : "";
+  const filenameExtension = filename
+    ? path.extname(filename).toLowerCase()
+    : "";
   if (/^\.[a-z0-9]+$/i.test(filenameExtension)) {
     return filenameExtension;
   }

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -105,6 +105,57 @@ interface ChatSessionMeta {
   updatedAt?: string;
 }
 
+const DEFAULT_CHAT_IMAGE_RESIZING_OPTIONS =
+  "width=400,height=400,fit=scale-down,quality=85,format=auto";
+
+function isCloudflareImageResizingEnabled(): boolean {
+  const configured = import.meta.env.VITE_CLOUDFLARE_IMAGE_RESIZING;
+  if (configured === "true") return true;
+  if (configured === "false") return false;
+  return import.meta.env.PROD;
+}
+
+function buildCloudflareImageUrl(originUrl: string): string {
+  if (!isCloudflareImageResizingEnabled() || !originUrl.startsWith("/")) {
+    return originUrl;
+  }
+
+  const options =
+    import.meta.env.VITE_CHAT_ATTACHMENT_IMAGE_OPTIONS ||
+    DEFAULT_CHAT_IMAGE_RESIZING_OPTIONS;
+  return `/cdn-cgi/image/${options.replace(/^\/+|\/+$/g, "")}${originUrl}`;
+}
+
+function ChatAttachmentImage({ url, alt }: { url: string; alt: string }) {
+  const optimizedUrl = useMemo(() => buildCloudflareImageUrl(url), [url]);
+  const [src, setSrc] = useState(optimizedUrl);
+
+  useEffect(() => {
+    setSrc(optimizedUrl);
+  }, [optimizedUrl]);
+
+  return (
+    <Box
+      component="img"
+      src={src}
+      alt={alt}
+      loading="lazy"
+      decoding="async"
+      onError={() => {
+        if (src !== url) {
+          setSrc(url);
+        }
+      }}
+      sx={{
+        maxWidth: 200,
+        maxHeight: 200,
+        borderRadius: 1,
+        objectFit: "contain",
+      }}
+    />
+  );
+}
+
 // CodeBlock component for syntax highlighting
 const CodeBlock = React.memo(
   ({
@@ -671,19 +722,10 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
                 }}
               >
                 {fileParts.map((fp, i) => (
-                  <Box
+                  <ChatAttachmentImage
                     key={i}
-                    component="img"
-                    src={fp.url}
+                    url={fp.url}
                     alt="Attached image"
-                    loading="lazy"
-                    decoding="async"
-                    sx={{
-                      maxWidth: 200,
-                      maxHeight: 200,
-                      borderRadius: 1,
-                      objectFit: "contain",
-                    }}
                   />
                 ))}
               </Box>

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -676,6 +676,8 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
                     component="img"
                     src={fp.url}
                     alt="Attached image"
+                    loading="lazy"
+                    decoding="async"
                     sx={{
                       maxWidth: 200,
                       maxHeight: 200,
@@ -845,6 +847,13 @@ interface ImageAttachment {
   previewUrl: string;
 }
 
+type DurableFileUIPart = FileUIPart & {
+  storageKey?: string;
+  attachmentId?: string;
+  filename?: string;
+  size?: number;
+};
+
 interface ChatInputAreaProps {
   onSubmit: (text: string, files?: FileUIPart[]) => void;
   onStop: () => void;
@@ -852,15 +861,52 @@ interface ChatInputAreaProps {
   disabled: boolean;
   focusKey: string | number;
   paletteMode: "light" | "dark";
+  workspaceId?: string;
+  chatId: string;
 }
 
-function readFileAsDataUrl(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(reader.result as string);
-    reader.onerror = reject;
-    reader.readAsDataURL(file);
-  });
+async function uploadChatImageAttachment(options: {
+  workspaceId: string;
+  chatId: string;
+  file: File;
+}): Promise<DurableFileUIPart> {
+  const form = new FormData();
+  form.set("chatId", options.chatId);
+  form.set("file", options.file);
+
+  const response = await fetch(
+    `/api/workspaces/${options.workspaceId}/chat-attachments`,
+    {
+      method: "POST",
+      body: form,
+    },
+  );
+
+  if (!response.ok) {
+    const payload = (await response.json().catch(() => null)) as {
+      error?: string;
+    } | null;
+    throw new Error(payload?.error || "Failed to upload image attachment");
+  }
+
+  const uploaded = (await response.json()) as {
+    url: string;
+    storageKey?: string;
+    attachmentId?: string;
+    mediaType: string;
+    filename?: string;
+    size?: number;
+  };
+
+  return {
+    type: "file",
+    url: uploaded.url,
+    mediaType: uploaded.mediaType,
+    filename: uploaded.filename || options.file.name || undefined,
+    storageKey: uploaded.storageKey,
+    attachmentId: uploaded.attachmentId,
+    size: uploaded.size,
+  };
 }
 
 const ChatInputArea = React.memo(
@@ -871,10 +917,13 @@ const ChatInputArea = React.memo(
     disabled,
     focusKey,
     paletteMode: _paletteMode,
+    workspaceId,
+    chatId,
   }: ChatInputAreaProps) => {
     const [input, setInput] = useState("");
     const [images, setImages] = useState<ImageAttachment[]>([]);
     const [isPreparingSubmission, setIsPreparingSubmission] = useState(false);
+    const [submissionError, setSubmissionError] = useState<string | null>(null);
     const inputRef = useRef<HTMLInputElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
     const imagesRef = useRef<ImageAttachment[]>([]);
@@ -907,6 +956,7 @@ const ChatInputArea = React.memo(
     const addImages = useCallback((files: File[]) => {
       const imageFiles = files.filter(f => f.type.startsWith("image/"));
       if (imageFiles.length === 0) return;
+      setSubmissionError(null);
       setImages(prev => [
         ...prev,
         ...imageFiles.map(file => ({
@@ -955,14 +1005,21 @@ const ChatInputArea = React.memo(
 
       setIsPreparingSubmission(true);
       let fileParts: FileUIPart[] | undefined;
+      setSubmissionError(null);
       try {
         if (hasImages) {
+          if (!workspaceId) {
+            setSubmissionError("Select a workspace before attaching images.");
+            return;
+          }
           fileParts = await Promise.all(
-            currentImages.map(async img => ({
-              type: "file" as const,
-              url: await readFileAsDataUrl(img.file),
-              mediaType: img.file.type,
-            })),
+            currentImages.map(img =>
+              uploadChatImageAttachment({
+                workspaceId,
+                chatId,
+                file: img.file,
+              }),
+            ),
           );
           currentImages.forEach(img => URL.revokeObjectURL(img.previewUrl));
         }
@@ -970,10 +1027,24 @@ const ChatInputArea = React.memo(
         onSubmit(input, fileParts);
         setInput("");
         setImages([]);
+      } catch (error) {
+        setSubmissionError(
+          error instanceof Error
+            ? error.message
+            : "Failed to upload image attachment",
+        );
       } finally {
         setIsPreparingSubmission(false);
       }
-    }, [images, input, isLoading, isPreparingSubmission, onSubmit]);
+    }, [
+      chatId,
+      images,
+      input,
+      isLoading,
+      isPreparingSubmission,
+      onSubmit,
+      workspaceId,
+    ]);
 
     const hasContent = input.trim() || images.length > 0;
     const isSubmitDisabled =
@@ -1000,6 +1071,11 @@ const ChatInputArea = React.memo(
           }}
           onPaste={handlePaste}
         >
+          {submissionError && (
+            <Alert severity="error" sx={{ m: 0.5 }}>
+              {submissionError}
+            </Alert>
+          )}
           {images.length > 0 && (
             <Box
               sx={{
@@ -2532,6 +2608,8 @@ const Chat: React.FC<ChatProps> = ({
         disabled={!currentWorkspace}
         focusKey={`${chatId}-${messages.length}`}
         paletteMode={paletteMode}
+        workspaceId={currentWorkspace?.id}
+        chatId={chatId}
       />
 
       {/* Tool Debug Dialog */}

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -4,6 +4,8 @@ interface ImportMetaEnv {
   readonly VITE_API_URL: string;
   readonly VITE_MUI_LICENSE_KEY: string;
   readonly VITE_DISABLE_OAUTH?: string; // Set to "true" to disable OAuth (for PR previews)
+  readonly VITE_CLOUDFLARE_IMAGE_RESIZING?: string;
+  readonly VITE_CHAT_ATTACHMENT_IMAGE_OPTIONS?: string;
   // Add more env variables as needed
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a workspace-scoped chat attachment upload and authenticated image streaming route
- add filesystem/GCS/S3-compatible attachment storage with GCS bucket reuse support
- persist durable file-part metadata and hydrate signed/data URLs for model replay
- upload chat images before sending and render saved images lazily
- use Cloudflare Image Resizing (`/cdn-cgi/image/...`) for chat thumbnails when enabled, with fallback to the authenticated origin URL

## Verification
- `pnpm --filter app run typecheck`
- `pnpm --filter app run lint`
- `pnpm --filter api run lint`
- `pnpm --filter api run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-063c06f5-9dc5-408d-be18-3610aa54ba3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-063c06f5-9dc5-408d-be18-3610aa54ba3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

