### PR TITLE
Persist chat image attachments in object storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,13 @@ WEB_API_PORT=8080
 # GCS_DASHBOARD_BUCKET=revops-462013-dashboard-artifacts
 # DASHBOARD_ARTIFACT_PREFIX=dashboard-artifacts/local-yourname
 
+# Chat image attachments reuse the same object store configured above
+# (DASHBOARD_ARTIFACT_STORE + GCS_DASHBOARD_BUCKET / S3_* settings). Images are
+# stored under the `chat-attachments/` prefix instead of being inlined as
+# base64 in the chat document, then served lazily via an authenticated proxy at
+# /api/workspaces/:workspaceId/chat-images/:attachmentId. No extra config is
+# required; defaults to local filesystem when unset.
+
 # Rate Limiting
 RATE_LIMIT_WINDOW_MS=900000  # 15 minutes
 RATE_LIMIT_MAX_REQUESTS=5

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -591,6 +591,29 @@ export interface IChat extends Document {
 }
 
 /**
+ * Chat attachment model interface.
+ *
+ * Chat image attachments are uploaded to object storage (filesystem / GCS / S3)
+ * instead of being inlined as base64 data URLs in the chat document. This keeps
+ * chat documents well under the 16 MB BSON limit (the previous behaviour caused
+ * silent save failures and "lost" images on reload) and lets the browser fetch
+ * each image lazily through an authenticated proxy.
+ */
+export interface IChatAttachment extends Document {
+  _id: Types.ObjectId;
+  workspaceId: Types.ObjectId;
+  chatId: string; // Chat _id this attachment belongs to (string ObjectId hex)
+  createdBy: string; // User id that owns the attachment (matches Chat.createdBy)
+  storageKey: string; // Key within the object store
+  mediaType: string; // MIME type, e.g. "image/png"
+  filename?: string; // Optional original file name
+  size: number; // Byte size of the stored object
+  sha256: string; // Content hash, used to deduplicate re-uploads within a chat
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
  * Query configuration for GraphQL/PostHog flows
  */
 export interface IFlowQuery {
@@ -1761,6 +1784,61 @@ const ChatSchema = new Schema<IChat>(
 ChatSchema.index({ workspaceId: 1 });
 ChatSchema.index({ workspaceId: 1, title: 1 });
 ChatSchema.index({ workspaceId: 1, createdBy: 1 }); // For user-specific chat queries
+
+/**
+ * Chat Attachment Schema
+ *
+ * Stores metadata for chat image attachments whose bytes live in object
+ * storage. The proxy route streams these back to the browser, and the agent
+ * route resolves them to data URLs when replaying history to the model.
+ */
+const ChatAttachmentSchema = new Schema<IChatAttachment>(
+  {
+    workspaceId: {
+      type: Schema.Types.ObjectId,
+      ref: "Workspace",
+      required: true,
+    },
+    chatId: {
+      type: String,
+      required: true,
+    },
+    createdBy: {
+      type: String,
+      ref: "User",
+      required: true,
+    },
+    storageKey: {
+      type: String,
+      required: true,
+    },
+    mediaType: {
+      type: String,
+      required: true,
+    },
+    filename: {
+      type: String,
+      required: false,
+    },
+    size: {
+      type: Number,
+      required: true,
+    },
+    sha256: {
+      type: String,
+      required: true,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+// Dedupe re-uploads of the same image within a chat (same bytes -> same doc).
+ChatAttachmentSchema.index(
+  { workspaceId: 1, chatId: 1, sha256: 1 },
+  { unique: true },
+);
 
 /**
  * Flow Schema (data sync flow configuration)
@@ -3343,6 +3421,10 @@ export const SavedConsole = mongoose.model<ISavedConsole>(
   SavedConsoleSchema,
 );
 export const Chat = mongoose.model<IChat>("Chat", ChatSchema);
+export const ChatAttachment = mongoose.model<IChatAttachment>(
+  "ChatAttachment",
+  ChatAttachmentSchema,
+);
 export const Flow = mongoose.model<IFlow>("Flow", FlowSchema);
 export const FlowExecution = mongoose.model<IFlowExecution>(
   "FlowExecution",

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -11,6 +11,7 @@ import { dataSourceRoutes } from "./routes/sources";
 import { customPromptRoutes } from "./routes/custom-prompt";
 import { skillsRoutes } from "./routes/skills";
 import { chatsRoutes } from "./routes/chats";
+import { chatImagesRoutes } from "./routes/chat-images";
 import { agentRoutes } from "./routes/agent.routes";
 import { adminRoutes } from "./routes/admin.routes";
 import { authRoutes } from "./auth/auth.controller";
@@ -115,6 +116,7 @@ app.route("/api/workspaces/:workspaceId/databases", workspaceDatabaseRoutes);
 app.route("/api/workspaces/:workspaceId/execute", workspaceExecuteRoutes);
 app.route("/api/workspaces/:workspaceId/consoles", consoleRoutes);
 app.route("/api/workspaces/:workspaceId/chats", chatsRoutes);
+app.route("/api/workspaces/:workspaceId/chat-images", chatImagesRoutes);
 app.route("/api/workspaces/:workspaceId/custom-prompt", customPromptRoutes);
 app.route("/api/workspaces/:workspaceId/skills", skillsRoutes);
 // Connectors routes

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -51,6 +51,7 @@ import {
   renderSkillsPromptBlock,
 } from "../services/skills.service";
 import { sanitizeMessagesForModel } from "../utils/message-sanitizer";
+import { resolveChatAttachmentsForModel } from "../services/chat-attachment.service";
 import { loggers, enrichContextWithWorkspace } from "../logging";
 import { checkBillingLimits } from "../billing/usage-limit.middleware";
 import { getEffectiveBillingPlan } from "../billing/config";
@@ -602,9 +603,19 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
   const modelDef = await getModelById(resolvedModelId);
   logger.info("Using model", { model: resolvedModelId });
 
+  // Resolve object-storage-backed image attachments (from reopened chats) back
+  // into inline data URLs the model provider can read. Freshly attached images
+  // in the current turn already arrive as data URLs and pass through untouched.
+  // Runs before sanitization so its empty-parts guard covers any message left
+  // with no parts after a missing attachment is dropped.
+  const messagesWithAttachments = await resolveChatAttachmentsForModel(
+    messages,
+    workspaceId,
+  );
+
   // Sanitize messages to remove incomplete tool calls from interrupted streams
   // This prevents Anthropic API errors: "tool_use ids were found without tool_result blocks"
-  const sanitizedMessages = sanitizeMessagesForModel(messages);
+  const sanitizedMessages = sanitizeMessagesForModel(messagesWithAttachments);
 
   // Convert UI messages (from useChat) to model messages (for streamText)
   const modelMessages = await convertToModelMessages(sanitizedMessages);

--- a/api/src/routes/chat-images.ts
+++ b/api/src/routes/chat-images.ts
@@ -1,0 +1,151 @@
+import { Hono } from "hono";
+import { ObjectId } from "mongodb";
+import { unifiedAuthMiddleware } from "../auth/unified-auth.middleware";
+import { AuthenticatedContext } from "../middleware/workspace.middleware";
+import {
+  getChatAttachmentForUser,
+  openChatAttachmentStream,
+} from "../services/chat-attachment.service";
+import { loggers, enrichContextWithWorkspace } from "../logging";
+import { workspaceService } from "../services/workspace.service";
+
+const logger = loggers.api("chat-images");
+
+/**
+ * Authenticated proxy that streams chat image attachments from object storage.
+ *
+ * Classification: Authenticated + workspace-scoped. Attachments are private to
+ * the chat creator, mirroring the ownership model of the chats route.
+ *
+ * The browser fetches these lazily (`<img loading="lazy">`). Responses are
+ * immutable (attachment ids are content-addressed) so they are aggressively
+ * cached by the browser.
+ */
+export const chatImagesRoutes = new Hono();
+
+chatImagesRoutes.use("*", unifiedAuthMiddleware);
+
+// Verify workspace access (same defense-in-depth pattern as chats route).
+chatImagesRoutes.use("*", async (c: AuthenticatedContext, next) => {
+  const workspaceId = c.req.param("workspaceId");
+  if (workspaceId) {
+    const user = c.get("user");
+    const workspace = c.get("workspace");
+
+    if (workspace) {
+      if (workspace._id.toString() !== workspaceId) {
+        return c.json(
+          { error: "API key not authorized for this workspace" },
+          403,
+        );
+      }
+    } else if (user) {
+      const hasAccess = await workspaceService.hasAccess(workspaceId, user.id);
+      if (!hasAccess) {
+        return c.json({ error: "Access denied to workspace" }, 403);
+      }
+    } else {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    enrichContextWithWorkspace(workspaceId);
+  }
+  await next();
+});
+
+function nodeStreamToWeb(
+  nodeStream: NodeJS.ReadableStream,
+): ReadableStream<Uint8Array> {
+  let closed = false;
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      nodeStream.on("data", (chunk: Buffer) => {
+        if (!closed) {
+          controller.enqueue(new Uint8Array(chunk));
+        }
+      });
+      nodeStream.on("end", () => {
+        if (!closed) {
+          closed = true;
+          controller.close();
+        }
+      });
+      nodeStream.on("error", (err: Error) => {
+        if (!closed) {
+          closed = true;
+          controller.error(err);
+        }
+      });
+    },
+    cancel() {
+      closed = true;
+      if ("destroy" in nodeStream && typeof nodeStream.destroy === "function") {
+        (
+          nodeStream as NodeJS.ReadableStream & { destroy?: () => void }
+        ).destroy?.();
+      }
+    },
+  });
+}
+
+chatImagesRoutes.get("/:attachmentId", async (c: AuthenticatedContext) => {
+  try {
+    const user = c.get("user");
+    const userId = user?.id;
+    if (!userId) {
+      return c.json({ error: "User not authenticated" }, 401);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const workspaceId = c.req.param("workspaceId") as string;
+    const attachmentId = c.req.param("attachmentId");
+
+    if (!ObjectId.isValid(workspaceId)) {
+      return c.json({ error: "Invalid workspace id" }, 400);
+    }
+    if (!ObjectId.isValid(attachmentId)) {
+      return c.json({ error: "Invalid attachment id" }, 400);
+    }
+
+    const attachment = await getChatAttachmentForUser(
+      attachmentId,
+      workspaceId,
+      userId.toString(),
+    );
+    if (!attachment) {
+      return c.json({ error: "Attachment not found" }, 404);
+    }
+
+    // Content-addressed id => safe to cache forever in the browser.
+    const etag = `"${attachment.sha256}"`;
+    if (c.req.header("if-none-match") === etag) {
+      return c.body(null, 304);
+    }
+
+    const stream = await openChatAttachmentStream(attachment.storageKey);
+    if (!stream) {
+      logger.warn("Chat attachment bytes missing from object store", {
+        attachmentId,
+        workspaceId,
+      });
+      return c.json({ error: "Attachment not available" }, 404);
+    }
+
+    const headers: Record<string, string> = {
+      "Content-Type": attachment.mediaType,
+      "Cache-Control": "private, max-age=31536000, immutable",
+      ETag: etag,
+      "Content-Length": String(attachment.size),
+    };
+    if (attachment.filename) {
+      headers["Content-Disposition"] =
+        `inline; filename="${attachment.filename.replace(/"/g, "")}"`;
+    }
+
+    return c.body(nodeStreamToWeb(stream), 200, headers);
+  } catch (error) {
+    logger.error("Error serving chat image", { error });
+    return c.json({ error: "Failed to load attachment" }, 500);
+  }
+});

--- a/api/src/services/agent-thread.service.ts
+++ b/api/src/services/agent-thread.service.ts
@@ -5,6 +5,7 @@ import { Chat, SavedConsole } from "../database/workspace-schema";
 import type { AgentKind } from "../agent-lib";
 import { loggers } from "../logging";
 import { isModelReadyFilePart } from "../utils/message-sanitizer";
+import { externalizeChatAttachments } from "./chat-attachment.service";
 
 const logger = loggers.agent();
 
@@ -661,13 +662,32 @@ export const saveChat = async (
 ): Promise<typeof Chat.prototype | null> => {
   const now = new Date();
 
+  // Move inline base64 image attachments out to object storage and replace them
+  // with authenticated proxy URLs. This keeps the chat document small (the old
+  // inline-base64 approach could blow past MongoDB's 16 MB BSON limit, silently
+  // failing the save so images "disappeared" on reload) and lets images be
+  // fetched lazily. Best-effort: on failure the original part is kept inline.
+  let messagesToPersist = messages;
+  try {
+    messagesToPersist = await externalizeChatAttachments(messages, {
+      workspaceId,
+      chatId,
+      userId,
+    });
+  } catch (error) {
+    logger.error("Failed to externalize chat attachments; saving inline", {
+      error,
+      chatId,
+    });
+  }
+
   // Drop assistant messages that arrived with no parts. This happens when a
   // stream is aborted before any delta is emitted: `toUIMessageStreamResponse`
   // has already minted an assistant message id, so `onFinish` hands us a
   // zero-parts message. Persisting it would poison the chat — on the next
   // turn `convertToModelMessages` would reject the history with
   // "Invalid prompt: The messages do not match the ModelMessage[] schema."
-  const persistableMessages = messages.filter(
+  const persistableMessages = messagesToPersist.filter(
     m => m.role !== "assistant" || (m.parts && m.parts.length > 0),
   );
   if (persistableMessages.length !== messages.length) {

--- a/api/src/services/chat-attachment.service.ts
+++ b/api/src/services/chat-attachment.service.ts
@@ -1,0 +1,351 @@
+import crypto from "crypto";
+import { ObjectId } from "mongodb";
+import type { UIMessage } from "ai";
+import {
+  ChatAttachment,
+  type IChatAttachment,
+} from "../database/workspace-schema";
+import { getDashboardArtifactStore } from "./dashboard-artifact-store.service";
+import { loggers } from "../logging";
+
+const logger = loggers.agent();
+
+const KEY_PREFIX = "chat-attachments";
+
+/**
+ * Matches the relative proxy URL we persist for chat image attachments:
+ *   /api/workspaces/<workspaceId>/chat-images/<attachmentId>
+ */
+const PROXY_URL_REGEX =
+  /\/api\/workspaces\/([a-f0-9]{24})\/chat-images\/([a-f0-9]{24})/i;
+
+interface ParsedDataUrl {
+  mediaType: string;
+  buffer: Buffer;
+}
+
+/**
+ * Parse a base64 `data:` URL into its media type and bytes. Returns null for
+ * anything that is not a base64 data URL (e.g. an already-externalized proxy
+ * URL or a remote https URL), which the caller should leave untouched.
+ */
+function parseDataUrl(url: unknown): ParsedDataUrl | null {
+  if (typeof url !== "string" || !url.startsWith("data:")) {
+    return null;
+  }
+  const commaIndex = url.indexOf(",");
+  if (commaIndex === -1) {
+    return null;
+  }
+  const header = url.slice(5, commaIndex); // e.g. "image/png;base64"
+  const isBase64 = header.includes(";base64");
+  if (!isBase64) {
+    // We only externalize base64 payloads; non-base64 data URLs are rare and
+    // left inline.
+    return null;
+  }
+  const mediaType = header.split(";")[0] || "application/octet-stream";
+  const data = url.slice(commaIndex + 1);
+  try {
+    const buffer = Buffer.from(data, "base64");
+    if (buffer.byteLength === 0) {
+      return null;
+    }
+    return { mediaType, buffer };
+  } catch {
+    return null;
+  }
+}
+
+function buildStorageKey(
+  workspaceId: string,
+  chatId: string,
+  sha256: string,
+): string {
+  return `${KEY_PREFIX}/${workspaceId}/${chatId}/${sha256}`;
+}
+
+/**
+ * Build the relative, same-origin URL the browser uses to lazily fetch an
+ * attachment through the authenticated proxy.
+ */
+export function buildChatImageProxyUrl(
+  workspaceId: string,
+  attachmentId: string,
+): string {
+  return `/api/workspaces/${workspaceId}/chat-images/${attachmentId}`;
+}
+
+async function streamToBuffer(
+  stream: NodeJS.ReadableStream,
+): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  return await new Promise<Buffer>((resolve, reject) => {
+    stream.on("data", chunk =>
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)),
+    );
+    stream.on("end", () => resolve(Buffer.concat(chunks)));
+    stream.on("error", reject);
+  });
+}
+
+/**
+ * Upload a single image to object storage and return its attachment metadata,
+ * deduplicating by content hash within the chat so repeated turns in the same
+ * session do not create duplicate objects.
+ */
+async function uploadChatImage(params: {
+  workspaceId: string;
+  chatId: string;
+  createdBy: string;
+  mediaType: string;
+  buffer: Buffer;
+  filename?: string;
+}): Promise<IChatAttachment> {
+  const { workspaceId, chatId, createdBy, mediaType, buffer, filename } =
+    params;
+  const sha256 = crypto.createHash("sha256").update(buffer).digest("hex");
+
+  const existing = await ChatAttachment.findOne({
+    workspaceId: new ObjectId(workspaceId),
+    chatId,
+    sha256,
+  });
+  if (existing) {
+    return existing;
+  }
+
+  const storageKey = buildStorageKey(workspaceId, chatId, sha256);
+  const store = getDashboardArtifactStore();
+  await store.putBuffer(buffer, storageKey, mediaType, {
+    workspaceId,
+    chatId,
+  });
+
+  try {
+    const created = await ChatAttachment.create({
+      workspaceId: new ObjectId(workspaceId),
+      chatId,
+      createdBy,
+      storageKey,
+      mediaType,
+      filename,
+      size: buffer.byteLength,
+      sha256,
+    });
+    return created;
+  } catch (error) {
+    // Unique-index race: another concurrent save inserted the same content.
+    if ((error as { code?: number }).code === 11000) {
+      const raced = await ChatAttachment.findOne({
+        workspaceId: new ObjectId(workspaceId),
+        chatId,
+        sha256,
+      });
+      if (raced) {
+        return raced;
+      }
+    }
+    throw error;
+  }
+}
+
+function asRecord(part: unknown): Record<string, unknown> | null {
+  if (typeof part === "object" && part !== null) {
+    return part as Record<string, unknown>;
+  }
+  return null;
+}
+
+/**
+ * Replace inline base64 image `file` parts with object-storage-backed proxy
+ * URLs before the chat is persisted. This is the core of the fix: large base64
+ * blobs no longer bloat the chat document (which previously risked exceeding
+ * MongoDB's 16 MB BSON limit and silently dropping the whole save), so images
+ * survive a reload.
+ *
+ * Returns a new messages array; the input is not mutated. On any per-image
+ * failure the original (inline) part is preserved so the save still succeeds.
+ */
+export async function externalizeChatAttachments(
+  messages: UIMessage[],
+  ctx: { workspaceId: string; chatId: string; userId: string },
+): Promise<UIMessage[]> {
+  if (!ObjectId.isValid(ctx.chatId)) {
+    // Externalized attachments key off the chat ObjectId; if it is not a valid
+    // id (legacy/unexpected), skip externalization rather than fail the save.
+    return messages;
+  }
+
+  let uploadedCount = 0;
+
+  const result = await Promise.all(
+    messages.map(async msg => {
+      const parts = msg.parts;
+      if (!Array.isArray(parts) || parts.length === 0) {
+        return msg;
+      }
+
+      let changed = false;
+      const newParts = await Promise.all(
+        parts.map(async part => {
+          const p = asRecord(part);
+          if (!p || p.type !== "file") {
+            return part;
+          }
+          const parsed = parseDataUrl(p.url);
+          if (!parsed) {
+            return part;
+          }
+          try {
+            const attachment = await uploadChatImage({
+              workspaceId: ctx.workspaceId,
+              chatId: ctx.chatId,
+              createdBy: ctx.userId,
+              mediaType: parsed.mediaType,
+              buffer: parsed.buffer,
+              filename: p.filename as string | undefined,
+            });
+            changed = true;
+            uploadedCount += 1;
+            return {
+              ...p,
+              url: buildChatImageProxyUrl(
+                ctx.workspaceId,
+                attachment._id.toString(),
+              ),
+              mediaType: attachment.mediaType,
+            };
+          } catch (error) {
+            logger.error("Failed to externalize chat image attachment", {
+              error,
+              chatId: ctx.chatId,
+              workspaceId: ctx.workspaceId,
+            });
+            // Keep the inline data URL as a fallback so the save still works.
+            return part;
+          }
+        }),
+      );
+
+      if (!changed) {
+        return msg;
+      }
+      return { ...msg, parts: newParts as UIMessage["parts"] };
+    }),
+  );
+
+  if (uploadedCount > 0) {
+    logger.info("Externalized chat image attachments to object storage", {
+      chatId: ctx.chatId,
+      workspaceId: ctx.workspaceId,
+      count: uploadedCount,
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Resolve internal proxy URLs back into base64 data URLs before replaying
+ * history to the model. The model provider cannot fetch our authenticated,
+ * relative proxy URL, so historical attachments (loaded from a reopened chat)
+ * must be inlined again for the LLM. Freshly attached images in the current
+ * turn already arrive as data URLs and pass through untouched.
+ *
+ * Parts that reference a missing/invalid attachment are dropped; the message
+ * sanitizer downstream guards against empty parts arrays.
+ */
+export async function resolveChatAttachmentsForModel(
+  messages: UIMessage[],
+  workspaceId: string,
+): Promise<UIMessage[]> {
+  const store = getDashboardArtifactStore();
+
+  return await Promise.all(
+    messages.map(async msg => {
+      const parts = msg.parts;
+      if (!Array.isArray(parts) || parts.length === 0) {
+        return msg;
+      }
+
+      let changed = false;
+      const resolvedParts = await Promise.all(
+        parts.map(async part => {
+          const p = asRecord(part);
+          if (!p || p.type !== "file" || typeof p.url !== "string") {
+            return part;
+          }
+          const match = PROXY_URL_REGEX.exec(p.url);
+          if (!match) {
+            return part; // data URL or external URL — leave as-is
+          }
+          const [, urlWorkspaceId, attachmentId] = match;
+          if (urlWorkspaceId !== workspaceId) {
+            return null; // cross-workspace reference — drop defensively
+          }
+          try {
+            const attachment = await ChatAttachment.findOne({
+              _id: new ObjectId(attachmentId),
+              workspaceId: new ObjectId(workspaceId),
+            });
+            if (!attachment) {
+              return null;
+            }
+            const stream = await store.openReadStream(attachment.storageKey);
+            if (!stream) {
+              return null;
+            }
+            const buffer = await streamToBuffer(stream);
+            const dataUrl = `data:${attachment.mediaType};base64,${buffer.toString(
+              "base64",
+            )}`;
+            changed = true;
+            return { ...p, url: dataUrl, mediaType: attachment.mediaType };
+          } catch (error) {
+            logger.warn("Failed to resolve chat attachment for model", {
+              error,
+              attachmentId,
+              workspaceId,
+            });
+            return null;
+          }
+        }),
+      );
+
+      if (!changed) {
+        return msg;
+      }
+      const filtered = resolvedParts.filter(
+        (p): p is NonNullable<typeof p> => p !== null,
+      );
+      return { ...msg, parts: filtered as UIMessage["parts"] };
+    }),
+  );
+}
+
+/**
+ * Load an attachment scoped to the requesting workspace + user. Chats are
+ * private to their creator, so we enforce the same ownership check here.
+ */
+export async function getChatAttachmentForUser(
+  attachmentId: string,
+  workspaceId: string,
+  userId: string,
+): Promise<IChatAttachment | null> {
+  if (!ObjectId.isValid(attachmentId) || !ObjectId.isValid(workspaceId)) {
+    return null;
+  }
+  return await ChatAttachment.findOne({
+    _id: new ObjectId(attachmentId),
+    workspaceId: new ObjectId(workspaceId),
+    createdBy: userId,
+  });
+}
+
+export async function openChatAttachmentStream(
+  storageKey: string,
+): Promise<NodeJS.ReadableStream | null> {
+  const store = getDashboardArtifactStore();
+  return await store.openReadStream(storageKey);
+}

--- a/api/src/services/dashboard-artifact-store.service.ts
+++ b/api/src/services/dashboard-artifact-store.service.ts
@@ -14,6 +14,17 @@ export interface DashboardArtifactStore {
     key: string,
     metadata?: Record<string, string>,
   ): Promise<void>;
+  /**
+   * Store an in-memory buffer at `key` with an explicit content type. Used for
+   * non-Parquet artifacts (e.g. chat image attachments) where the bytes never
+   * touch a temp file on disk.
+   */
+  putBuffer(
+    buffer: Buffer | Uint8Array,
+    key: string,
+    contentType: string,
+    metadata?: Record<string, string>,
+  ): Promise<void>;
   getSignedUrl(key: string, ttlSeconds?: number): Promise<string | null>;
   openReadStream(key: string): Promise<NodeJS.ReadableStream | null>;
   getSize(key: string): Promise<number | null>;
@@ -102,6 +113,30 @@ class FilesystemDashboardArtifactStore implements DashboardArtifactStore {
     });
   }
 
+  async putBuffer(
+    buffer: Buffer | Uint8Array,
+    key: string,
+    contentType: string,
+    metadata?: Record<string, string>,
+  ): Promise<void> {
+    const startedAt = Date.now();
+    const targetPath = this.resolvePath(key);
+    await fsPromises.mkdir(path.dirname(targetPath), { recursive: true });
+    await fsPromises.writeFile(targetPath, buffer);
+    await fsPromises.writeFile(
+      `${targetPath}.meta.json`,
+      JSON.stringify({ contentType, ...(metadata || {}) }, null, 2),
+      "utf8",
+    );
+    logger.info("Stored buffer artifact in filesystem", {
+      key,
+      bytes: buffer.byteLength,
+      contentType,
+      durationMs: Date.now() - startedAt,
+      storeType: this.type,
+    });
+  }
+
   async getSignedUrl(): Promise<string | null> {
     return null;
   }
@@ -172,6 +207,27 @@ class GcsDashboardArtifactStore implements DashboardArtifactStore {
     logger.info("Stored dashboard artifact in GCS", {
       key,
       bytes: Number(metadataResult.size || 0),
+      durationMs: Date.now() - startedAt,
+      storeType: this.type,
+    });
+  }
+
+  async putBuffer(
+    buffer: Buffer | Uint8Array,
+    key: string,
+    contentType: string,
+    metadata?: Record<string, string>,
+  ): Promise<void> {
+    const startedAt = Date.now();
+    await this.file(key).save(Buffer.from(buffer), {
+      contentType,
+      resumable: false,
+      metadata: metadata ? { metadata } : undefined,
+    });
+    logger.info("Stored buffer artifact in GCS", {
+      key,
+      bytes: buffer.byteLength,
+      contentType,
       durationMs: Date.now() - startedAt,
       storeType: this.type,
     });
@@ -451,6 +507,31 @@ class S3DashboardArtifactStore implements DashboardArtifactStore {
       storeType: this.type,
     });
     void metadata;
+  }
+
+  async putBuffer(
+    buffer: Buffer | Uint8Array,
+    key: string,
+    contentType: string,
+  ): Promise<void> {
+    const startedAt = Date.now();
+    const body = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+    const response = await this.signedRequest("PUT", key, {
+      body,
+      contentType,
+    });
+    if (!response.ok) {
+      throw new Error(
+        `S3 PUT failed with ${response.status} ${response.statusText}`,
+      );
+    }
+    logger.info("Stored buffer artifact in S3", {
+      key,
+      bytes: body.byteLength,
+      contentType,
+      durationMs: Date.now() - startedAt,
+      storeType: this.type,
+    });
   }
 
   async getSignedUrl(key: string): Promise<string | null> {

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -676,6 +676,8 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
                     component="img"
                     src={fp.url}
                     alt="Attached image"
+                    loading="lazy"
+                    decoding="async"
                     sx={{
                       maxWidth: 200,
                       maxHeight: 200,

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -617,6 +617,69 @@ function computeReasoningGroups(parts: Array<Record<string, unknown>>) {
   return groups;
 }
 
+/**
+ * Lightweight, dependency-free image lightbox. Shows the full (uncropped) image
+ * centered over a dimmed backdrop; closes on backdrop click, the X button, or
+ * Escape (handled by MUI Dialog).
+ */
+function ImagePreviewDialog({
+  src,
+  onClose,
+}: {
+  src: string | null;
+  onClose: () => void;
+}) {
+  return (
+    <Dialog
+      open={Boolean(src)}
+      onClose={onClose}
+      maxWidth="lg"
+      slotProps={{
+        paper: {
+          sx: {
+            backgroundColor: "transparent",
+            boxShadow: "none",
+            m: 2,
+            overflow: "visible",
+          },
+        },
+      }}
+    >
+      <Box sx={{ position: "relative", display: "flex" }}>
+        <IconButton
+          onClick={onClose}
+          aria-label="Close preview"
+          size="small"
+          sx={{
+            position: "absolute",
+            top: 8,
+            right: 8,
+            color: "common.white",
+            backgroundColor: "rgba(0, 0, 0, 0.6)",
+            "&:hover": { backgroundColor: "rgba(0, 0, 0, 0.8)" },
+          }}
+        >
+          <X size={18} />
+        </IconButton>
+        {src && (
+          <Box
+            component="img"
+            src={src}
+            alt="Image preview"
+            sx={{
+              maxWidth: "90vw",
+              maxHeight: "85vh",
+              borderRadius: 1,
+              objectFit: "contain",
+              display: "block",
+            }}
+          />
+        )}
+      </Box>
+    </Dialog>
+  );
+}
+
 const ChatMessageRow = React.memo(function ChatMessageRow({
   message,
   isLastMessage,
@@ -642,6 +705,9 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
     connectionIconById,
     paletteMode,
   });
+
+  // Lightbox state for clicking an attached image to preview it full-size.
+  const [previewSrc, setPreviewSrc] = useState<string | null>(null);
 
   if (message.role === "user") {
     const fileParts = (message.parts || []).filter(
@@ -678,11 +744,15 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
                     alt="Attached image"
                     loading="lazy"
                     decoding="async"
+                    onClick={() => setPreviewSrc(fp.url)}
                     sx={{
-                      maxWidth: 200,
-                      maxHeight: 200,
+                      width: 120,
+                      height: 120,
                       borderRadius: 1,
-                      objectFit: "contain",
+                      objectFit: "cover",
+                      cursor: "pointer",
+                      border: 1,
+                      borderColor: "divider",
                     }}
                   />
                 ))}
@@ -699,6 +769,10 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
             )}
           </Paper>
         </Box>
+        <ImagePreviewDialog
+          src={previewSrc}
+          onClose={() => setPreviewSrc(null)}
+        />
       </ListItem>
     );
   }
@@ -876,6 +950,7 @@ const ChatInputArea = React.memo(
   }: ChatInputAreaProps) => {
     const [input, setInput] = useState("");
     const [images, setImages] = useState<ImageAttachment[]>([]);
+    const [previewSrc, setPreviewSrc] = useState<string | null>(null);
     const [isPreparingSubmission, setIsPreparingSubmission] = useState(false);
     const inputRef = useRef<HTMLInputElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
@@ -1020,7 +1095,7 @@ const ChatInputArea = React.memo(
                     width: 56,
                     height: 56,
                     borderRadius: 1.5,
-                    overflow: "visible",
+                    overflow: "hidden",
                     flexShrink: 0,
                     "&:hover .remove-btn": {
                       opacity: 1,
@@ -1031,44 +1106,55 @@ const ChatInputArea = React.memo(
                     component="img"
                     src={img.previewUrl}
                     alt="Attachment"
+                    onClick={() => setPreviewSrc(img.previewUrl)}
                     sx={{
                       width: 56,
                       height: 56,
                       borderRadius: 1.5,
                       objectFit: "cover",
+                      cursor: "pointer",
                       border: 1,
                       borderColor: "divider",
+                      display: "block",
                     }}
                   />
                   <IconButton
                     type="button"
                     className="remove-btn"
-                    onClick={() => removeImage(img.id)}
+                    aria-label="Remove image"
+                    onClick={e => {
+                      e.stopPropagation();
+                      removeImage(img.id);
+                    }}
                     size="small"
                     disabled={isPreparingSubmission}
                     sx={{
                       position: "absolute",
-                      top: -6,
-                      right: -6,
+                      top: 4,
+                      right: 4,
                       width: 18,
                       height: 18,
                       p: 0,
                       opacity: 0,
                       transition: "opacity 0.15s",
-                      backgroundColor: "background.paper",
-                      border: 1,
-                      borderColor: "divider",
+                      color: "common.white",
+                      backgroundColor: "rgba(0, 0, 0, 0.6)",
                       "&:hover": {
-                        backgroundColor: "action.hover",
+                        backgroundColor: "rgba(0, 0, 0, 0.8)",
                       },
                     }}
                   >
-                    <X size={10} />
+                    <X size={11} />
                   </IconButton>
                 </Box>
               ))}
             </Box>
           )}
+
+          <ImagePreviewDialog
+            src={previewSrc}
+            onClose={() => setPreviewSrc(null)}
+          />
 
           <TextField
             fullWidth

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -746,13 +746,14 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
                     decoding="async"
                     onClick={() => setPreviewSrc(fp.url)}
                     sx={{
-                      width: 120,
-                      height: 120,
-                      borderRadius: 1,
+                      width: 56,
+                      height: 56,
+                      borderRadius: 1.5,
                       objectFit: "cover",
                       cursor: "pointer",
                       border: 1,
                       borderColor: "divider",
+                      display: "block",
                     }}
                   />
                 ))}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When you send an image to the model it works for the live turn, but **reopening an old chat loses all images**.

Root cause: chat images are attached as base64 `data:` URLs and stored **inline inside the chat document** in MongoDB. A few high‑res images easily push the whole chat document past MongoDB's **16 MB BSON limit**, so the `saveChat` write fails silently (the error was only logged) and the attachments — sometimes the entire latest turn — never persist.

## Fix

Externalize chat images to the object store we already use for dashboard artifacts (filesystem locally, **GCS** in Google Cloud, S3 supported), referenced by an authenticated, content‑addressed proxy URL instead of inlined base64:

```
GET /api/workspaces/:workspaceId/chat-images/:attachmentId
```

### Flow
- **On save** (`saveChat`): inline base64 `file` parts are uploaded to object storage and rewritten to the proxy URL. Deduplicated per chat by SHA‑256 so re‑sending the same image across turns doesn't duplicate objects. Best‑effort — if upload fails the inline part is kept so the save still succeeds. Self‑healing for older chats too.
- **On reload**: the chat GET returns parts with the proxy URL; the browser fetches each image lazily; responses are immutable + browser‑cached (ETag + `max-age` immutable).
- **On continued conversation in a reopened chat**: stored proxy URLs are resolved back to inline data URLs before the model call (the provider can't fetch our private relative URL). Freshly attached images already arrive as data URLs and pass through untouched.

### Storage / config
Reuses the existing artifact‑store config — no new env vars required (`DASHBOARD_ARTIFACT_STORE`, `GCS_DASHBOARD_BUCKET` / `S3_*`). Chat images live under a `chat-attachments/` prefix. Documented in `.env.example`.

> The Cloudflare image‑proxy/thumbnail idea was considered and dropped: `/cdn-cgi/image/` strips `Cookie`/`Authorization`, so resizing our private images would have required a dedicated Worker with `cf.image` + `origin-auth`. Not worth it for now — full images are downscaled client‑side.

## UI tweak (follow‑up commit)
- Attachment thumbnails are **always square** (`object-fit: cover`) in both the composer and sent messages, regardless of aspect ratio.
- **Click a thumbnail → full‑size, uncropped image preview** (lightbox); closes on backdrop click, the X, or Escape.
- Composer thumbnails show a **close icon top‑right on hover** to drop the image; the close button stops propagation so it never opens the preview.

## Changes
- `dashboard-artifact-store.service.ts` — add `putBuffer()` to the store interface and all three backends (additive).
- `workspace-schema.ts` — add `ChatAttachment` model with unique `{workspaceId, chatId, sha256}` index.
- `chat-attachment.service.ts` (new) — upload/externalize, resolve‑for‑model, owner‑scoped lookup + streaming.
- `chat-images.ts` (new route) — authenticated streaming proxy.
- `agent-thread.service.ts` — `saveChat` externalizes before persisting.
- `agent.routes.ts` — resolve attachments → sanitize → `convertToModelMessages`.
- `Chat.tsx` — square thumbnails, lightbox preview, hover‑to‑remove.

## Verification
- `api` ESLint + `tsc -p tsconfig.build.json --noEmit`: pass
- `app` `tsc --noEmit` + ESLint: pass

> Note: the local `husky` pre‑commit hook fails in this environment on an unrelated pnpm `ERR_PNPM_IGNORED_BUILDS` install check; the package lint/typecheck gates were run directly and pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ad121bc-c151-41ad-b2bb-ea94ad9ca49f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ad121bc-c151-41ad-b2bb-ea94ad9ca49f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

