### PR TITLE
docs(dashboards): correct responsive layout reflow behavior

### DIFF
--- a/docs/src/content/docs/dashboards.md
+++ b/docs/src/content/docs/dashboards.md
@@ -93,7 +93,11 @@ Tabular display of query results. Supports column sorting, formatting, and pagin
 
 ### Responsive Layouts
 
-Widgets use a grid layout system with responsive breakpoints (`lg`, `md`, `sm`, `xs`). Each widget has position (`x`, `y`) and size (`w`, `h`) per breakpoint, with automatic derivation from `lg` to smaller sizes.
+Widgets use a grid layout system with responsive breakpoints. The `lg` breakpoint (12 columns) is the **authored source of truth** — the only one you (or the AI agent) need to set. The smaller breakpoints `md` (10 cols), `sm` (6 cols), and `xs` (4 cols) are **deterministically reflowed** from `lg`: rows of widgets wrap and tile cleanly so the board stays balanced on narrower screens.
+
+Each widget carries position (`x`, `y`) and size (`w`, `h`) per breakpoint. To keep the reflow balanced, use grid-friendly widths that evenly tile a row (e.g. four KPIs at `w: 3`, three cards at `w: 4`, two charts at `w: 6`, or one full-width widget at `w: 12`).
+
+Reflow is skipped per breakpoint when a user manually arranges that breakpoint: the affected widgets carry `layouts[bp].custom === true`, and Mako keeps the stored arrangement instead of recomputing it. Minimum widget sizes are enforced — widgets smaller than their type minimum are automatically enlarged.
 
 ## Cross-Filtering
 


### PR DESCRIPTION
## What

The **Responsive Layouts** section of `docs/src/content/docs/dashboards.md` described the old behavior: smaller breakpoints "automatically derived" from `lg`.

As of the row-aware responsive reflow work merged June 3 (#430, plus #426), that's no longer accurate:
- `lg` (12-col) is the **authored source of truth** — the only breakpoint the agent/user sets.
- `md`/`sm`/`xs` are **deterministically reflowed** (rows wrap and tile), not naively scaled.
- A new per-breakpoint `custom` flag (added to `workspace-schema.ts` `DashboardSchema` and `dashboard.schema.ts`) preserves user-arranged layouts.
- KPI card minimum height dropped to `h: 1` (#430).

## Why
Doc drift — the agent prompt (`api/src/agents/dashboard/prompt.ts`) now instructs the model to emit only `lg` and use grid-friendly widths. The user-facing doc still said breakpoints are auto-derived.

## Scope
Single section, prose only. No code touched.

🤖 Daily docs-maintenance run.