### PR TITLE
feat(dashboards): AI-suggested commit message on version save + super-admin fast model

### DIFF
--- a/api/src/routes/admin.routes.ts
+++ b/api/src/routes/admin.routes.ts
@@ -117,18 +117,21 @@ adminRoutes.put("/catalog/models/:modelId", async c => {
 
 // ---------------------------------------------------------------------------
 // PUT /api/admin/catalog/defaults
-// Body: { defaultChatModelId?: string | null, defaultFreeChatModelId?: string | null }
+// Body: { defaultChatModelId?, defaultFreeChatModelId?, utilityModelId? }
+//   (each string | null)
 // ---------------------------------------------------------------------------
 adminRoutes.put("/catalog/defaults", async c => {
   try {
     const body = (await c.req.json()) as {
       defaultChatModelId?: unknown;
       defaultFreeChatModelId?: unknown;
+      utilityModelId?: unknown;
     };
 
     const update: {
       defaultChatModelId?: string | null;
       defaultFreeChatModelId?: string | null;
+      utilityModelId?: string | null;
     } = {};
 
     if (body.defaultChatModelId !== undefined) {
@@ -145,6 +148,14 @@ adminRoutes.put("/catalog/defaults", async c => {
           ? null
           : typeof body.defaultFreeChatModelId === "string"
             ? body.defaultFreeChatModelId
+            : null;
+    }
+    if (body.utilityModelId !== undefined) {
+      update.utilityModelId =
+        body.utilityModelId === null
+          ? null
+          : typeof body.utilityModelId === "string"
+            ? body.utilityModelId
             : null;
     }
 

--- a/api/src/routes/dashboards.ts
+++ b/api/src/routes/dashboards.ts
@@ -3,6 +3,7 @@ import {
   Dashboard,
   DashboardFolder,
   DatabaseConnection,
+  EntityVersion,
   type IDashboard,
 } from "../database/workspace-schema";
 import { Types } from "mongoose";
@@ -32,6 +33,8 @@ import {
   getVersion,
   getUserDisplayName,
 } from "../services/entity-version.service";
+import { generateDashboardVersionComment } from "../services/version-comment.service";
+import { getDashboardChatPrompts } from "../services/dashboard-version-context.service";
 
 const logger = loggers.api("dashboards");
 
@@ -910,6 +913,72 @@ app.patch("/:id", async (c: AuthenticatedContext) => {
         success: false,
         error: error instanceof Error ? error.message : "Unknown error",
       },
+      500,
+    );
+  }
+});
+
+// POST /api/workspaces/:workspaceId/dashboards/:id/version-comment
+// Generate an AI-suggested commit message for the dashboard changes about to
+// be saved. Diffs the pending definition against the latest saved version and
+// folds in any chat prompts that drove the changes.
+app.post("/:id/version-comment", async (c: AuthenticatedContext) => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    const dashboardId = c.req.param("id");
+    const userId = c.get("user")?.id;
+
+    if (!userId) {
+      return c.json({ success: false, error: "Unauthorized" }, 401);
+    }
+    if (!Types.ObjectId.isValid(dashboardId)) {
+      return c.json(
+        { success: false, error: "Invalid dashboard ID format" },
+        400,
+      );
+    }
+
+    const body = await c.req.json().catch(() => ({}));
+    const definition =
+      body && typeof body.definition === "object" && body.definition !== null
+        ? (body.definition as Record<string, unknown>)
+        : (body as Record<string, unknown>);
+
+    const newSnapshot = buildDashboardSnapshot(definition);
+
+    const latestVersion = await EntityVersion.findOne(
+      {
+        entityId: new Types.ObjectId(dashboardId),
+        entityType: "dashboard",
+      },
+      { snapshot: 1, version: 1 },
+    )
+      .sort({ version: -1 })
+      .lean();
+
+    const previousSnapshot =
+      (latestVersion?.snapshot as Record<string, unknown> | undefined) ?? null;
+
+    const chatPrompts = await getDashboardChatPrompts(
+      workspaceId,
+      userId,
+      dashboardId,
+    );
+
+    const result = await generateDashboardVersionComment(
+      { previousSnapshot, newSnapshot, chatPrompts },
+      { workspaceId, userId },
+    );
+
+    return c.json({
+      success: true,
+      comment: result.comment,
+      diff: result.diff,
+    });
+  } catch (error) {
+    logger.error("Error generating dashboard version comment", { error });
+    return c.json(
+      { success: false, error: "Failed to generate version comment" },
       500,
     );
   }

--- a/api/src/services/dashboard-version-context.service.ts
+++ b/api/src/services/dashboard-version-context.service.ts
@@ -1,0 +1,134 @@
+/**
+ * Dashboard version context
+ *
+ * Best-effort extraction of the chat prompts that drove changes to a given
+ * dashboard. There is no persisted FK from a chat to a dashboard, so we scan
+ * the user's recent chats for tool calls that reference the dashboard id and
+ * collect the user prompts that immediately preceded those edits. This covers
+ * AI-driven dashboard changes; purely manual edits simply yield no prompts and
+ * the comment generator falls back to the diff alone.
+ */
+
+import { Types } from "mongoose";
+import { Chat } from "../database/workspace-schema";
+import { loggers } from "../logging";
+
+const logger = loggers.app();
+
+const MAX_CHATS_SCANNED = 15;
+const MAX_PROMPTS = 6;
+
+function extractTextFromParts(parts: unknown): string {
+  if (!Array.isArray(parts)) return "";
+  return parts
+    .filter((p: any) => p && p.type === "text" && typeof p.text === "string")
+    .map((p: any) => p.text as string)
+    .join("");
+}
+
+function extractText(msg: any): string {
+  if (typeof msg?.content === "string") return msg.content;
+  if (Array.isArray(msg?.parts)) return extractTextFromParts(msg.parts);
+  return "";
+}
+
+function extractToolInputs(msg: any): Array<Record<string, unknown>> {
+  const inputs: Array<Record<string, unknown>> = [];
+
+  if (Array.isArray(msg?.parts)) {
+    for (const part of msg.parts) {
+      if (!part || typeof part !== "object") continue;
+      const type = (part as any).type as string | undefined;
+      if (type === "tool-invocation" && (part as any).toolInvocation?.args) {
+        inputs.push((part as any).toolInvocation.args);
+      } else if (
+        (typeof type === "string" && type.startsWith("tool-")) ||
+        type === "dynamic-tool"
+      ) {
+        if ((part as any).input && typeof (part as any).input === "object") {
+          inputs.push((part as any).input);
+        }
+      }
+    }
+  }
+
+  if (Array.isArray(msg?.toolCalls)) {
+    for (const tc of msg.toolCalls) {
+      if (tc?.input && typeof tc.input === "object") {
+        inputs.push(tc.input);
+      }
+    }
+  }
+
+  return inputs;
+}
+
+function messageTouchesDashboard(msg: any, dashboardId: string): boolean {
+  for (const input of extractToolInputs(msg)) {
+    if (
+      typeof input.dashboardId === "string" &&
+      input.dashboardId === dashboardId
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Returns the most recent user prompts (oldest → newest) that triggered AI
+ * edits to the given dashboard, across the user's recent chats. Best effort:
+ * returns an empty array on any error or when no chat touched the dashboard.
+ */
+export async function getDashboardChatPrompts(
+  workspaceId: string,
+  userId: string,
+  dashboardId: string,
+): Promise<string[]> {
+  if (!Types.ObjectId.isValid(workspaceId)) return [];
+
+  try {
+    const chats = await Chat.find(
+      {
+        workspaceId: new Types.ObjectId(workspaceId),
+        createdBy: userId.toString(),
+      },
+      { messages: 1, updatedAt: 1 },
+    )
+      .sort({ updatedAt: -1 })
+      .limit(MAX_CHATS_SCANNED)
+      .lean();
+
+    const prompts: string[] = [];
+
+    for (const chat of chats) {
+      const messages = Array.isArray((chat as any).messages)
+        ? ((chat as any).messages as any[])
+        : [];
+
+      let lastUserPrompt: string | null = null;
+      for (const msg of messages) {
+        if (msg?.role === "user") {
+          const text = extractText(msg).trim();
+          if (text) lastUserPrompt = text;
+        } else if (
+          msg?.role === "assistant" &&
+          messageTouchesDashboard(msg, dashboardId) &&
+          lastUserPrompt
+        ) {
+          if (!prompts.includes(lastUserPrompt)) {
+            prompts.push(lastUserPrompt);
+          }
+        }
+      }
+    }
+
+    return prompts.slice(-MAX_PROMPTS);
+  } catch (err) {
+    logger.warn("Failed to gather dashboard chat prompts", {
+      error: String(err),
+      dashboardId,
+    });
+    return [];
+  }
+}

--- a/api/src/services/model-catalog.service.ts
+++ b/api/src/services/model-catalog.service.ts
@@ -53,6 +53,13 @@ export interface CurationDoc {
   models: CuratedModelEntry[];
   defaultChatModelId: string | null;
   defaultFreeChatModelId: string | null;
+  /**
+   * Explicit model used for cheap "utility" / fast tasks (version comments,
+   * titles, descriptions). When null, the cheapest tool-use model is picked
+   * heuristically. Super admins set this so they can, e.g., bump the Haiku
+   * version after refreshing the catalog.
+   */
+  utilityModelId: string | null;
   lastRefreshError: string | null;
 }
 
@@ -73,6 +80,7 @@ export interface AdminCatalogView {
   models: AdminCatalogModel[];
   defaultChatModelId: string | null;
   defaultFreeChatModelId: string | null;
+  utilityModelId: string | null;
   lastRefreshError: string | null;
   gatewayFetchedAt: string | null;
   curationUpdatedAt: string | null;
@@ -131,7 +139,12 @@ let cachedFreeTierIds: Set<string> | null = null;
 let cachedDefaults: {
   defaultChatModelId: string | null;
   defaultFreeChatModelId: string | null;
-} = { defaultChatModelId: null, defaultFreeChatModelId: null };
+  utilityModelId: string | null;
+} = {
+  defaultChatModelId: null,
+  defaultFreeChatModelId: null,
+  utilityModelId: null,
+};
 let cacheTimestamp = 0;
 
 // ---------------------------------------------------------------------------
@@ -239,6 +252,7 @@ const EMPTY_CURATION: CurationDoc = {
   models: [],
   defaultChatModelId: null,
   defaultFreeChatModelId: null,
+  utilityModelId: null,
   lastRefreshError: null,
 };
 
@@ -250,6 +264,7 @@ async function loadCuration(): Promise<CurationDoc> {
     models: Array.isArray(data.models) ? data.models : [],
     defaultChatModelId: data.defaultChatModelId ?? null,
     defaultFreeChatModelId: data.defaultFreeChatModelId ?? null,
+    utilityModelId: data.utilityModelId ?? null,
     lastRefreshError: data.lastRefreshError ?? null,
   };
 }
@@ -298,6 +313,9 @@ export async function setCuratedModel(
     if (curation.defaultFreeChatModelId === modelId) {
       curation.defaultFreeChatModelId = null;
     }
+    if (curation.utilityModelId === modelId) {
+      curation.utilityModelId = null;
+    }
   }
   // If tier flipped away from free, drop the free-default pointer
   if (update.tier === "pro" && curation.defaultFreeChatModelId === modelId) {
@@ -311,6 +329,7 @@ export async function setCuratedModel(
 export async function setCuratedDefaults(update: {
   defaultChatModelId?: string | null;
   defaultFreeChatModelId?: string | null;
+  utilityModelId?: string | null;
 }): Promise<CurationDoc> {
   const curation = await loadCuration();
   if (update.defaultChatModelId !== undefined) {
@@ -318,6 +337,9 @@ export async function setCuratedDefaults(update: {
   }
   if (update.defaultFreeChatModelId !== undefined) {
     curation.defaultFreeChatModelId = update.defaultFreeChatModelId;
+  }
+  if (update.utilityModelId !== undefined) {
+    curation.utilityModelId = update.utilityModelId;
   }
   await saveCuration(curation);
   return curation;
@@ -373,6 +395,7 @@ function mergeCatalog(
   defaults: {
     defaultChatModelId: string | null;
     defaultFreeChatModelId: string | null;
+    utilityModelId: string | null;
   };
 } {
   const pricingMap = new Map<string, { input: number; output: number }>();
@@ -421,6 +444,7 @@ function mergeCatalog(
     defaults: {
       defaultChatModelId: curation.defaultChatModelId,
       defaultFreeChatModelId: curation.defaultFreeChatModelId,
+      utilityModelId: curation.utilityModelId,
     },
   };
 }
@@ -435,6 +459,7 @@ async function loadFromDb(): Promise<{
   defaults: {
     defaultChatModelId: string | null;
     defaultFreeChatModelId: string | null;
+    utilityModelId: string | null;
   };
 } | null> {
   const docs = await ModelCatalogSnapshot.find({
@@ -461,6 +486,7 @@ async function loadFromDb(): Promise<{
           (curationDoc.data as any).defaultChatModelId ?? null,
         defaultFreeChatModelId:
           (curationDoc.data as any).defaultFreeChatModelId ?? null,
+        utilityModelId: (curationDoc.data as any).utilityModelId ?? null,
         lastRefreshError: (curationDoc.data as any).lastRefreshError ?? null,
       }
     : { ...EMPTY_CURATION };
@@ -497,7 +523,11 @@ async function ensureCatalog(): Promise<void> {
   );
   cachedCatalog = [];
   cachedFreeTierIds = new Set(FALLBACK_FREE);
-  cachedDefaults = { defaultChatModelId: null, defaultFreeChatModelId: null };
+  cachedDefaults = {
+    defaultChatModelId: null,
+    defaultFreeChatModelId: null,
+    utilityModelId: null,
+  };
   cacheTimestamp = 0;
 }
 
@@ -508,7 +538,11 @@ async function ensureCatalog(): Promise<void> {
 export function invalidateCatalog(): void {
   cachedCatalog = null;
   cachedFreeTierIds = null;
-  cachedDefaults = { defaultChatModelId: null, defaultFreeChatModelId: null };
+  cachedDefaults = {
+    defaultChatModelId: null,
+    defaultFreeChatModelId: null,
+    utilityModelId: null,
+  };
   cacheTimestamp = 0;
 }
 
@@ -558,7 +592,11 @@ export async function warmCatalog(): Promise<void> {
 
   cachedCatalog = [];
   cachedFreeTierIds = new Set(FALLBACK_FREE);
-  cachedDefaults = { defaultChatModelId: null, defaultFreeChatModelId: null };
+  cachedDefaults = {
+    defaultChatModelId: null,
+    defaultFreeChatModelId: null,
+    utilityModelId: null,
+  };
   cacheTimestamp = 0;
 }
 
@@ -614,26 +652,34 @@ export async function getDefaultFreeChatModelId(): Promise<string> {
   return FALLBACK_FREE[0];
 }
 
-export async function getUtilityChatModelId(): Promise<string> {
-  await ensureCatalog();
+/**
+ * Cheapest tool-use models, cheapest first. When the super admin has pinned an
+ * explicit utility model and it is still visible, it is promoted to the front.
+ */
+function rankedUtilityModelIds(): string[] {
   const candidates = (cachedCatalog ?? []).filter(
     m => m.tags.includes("tool-use") && m.blendedCostPerM !== null,
   );
   candidates.sort(
     (a, b) => (a.blendedCostPerM ?? Infinity) - (b.blendedCostPerM ?? Infinity),
   );
-  return candidates[0]?.id ?? FALLBACK_FREE[0];
+  const ids = candidates.map(m => m.id);
+
+  const pinned = cachedDefaults.utilityModelId;
+  if (pinned && (cachedCatalog ?? []).some(m => m.id === pinned)) {
+    return [pinned, ...ids.filter(id => id !== pinned)];
+  }
+  return ids;
+}
+
+export async function getUtilityChatModelId(): Promise<string> {
+  await ensureCatalog();
+  return rankedUtilityModelIds()[0] ?? FALLBACK_FREE[0];
 }
 
 export async function getUtilityModelIds(count = 3): Promise<string[]> {
   await ensureCatalog();
-  const candidates = (cachedCatalog ?? []).filter(
-    m => m.tags.includes("tool-use") && m.blendedCostPerM !== null,
-  );
-  candidates.sort(
-    (a, b) => (a.blendedCostPerM ?? Infinity) - (b.blendedCostPerM ?? Infinity),
-  );
-  return candidates.slice(0, count).map(m => m.id);
+  return rankedUtilityModelIds().slice(0, count);
 }
 
 // ---------------------------------------------------------------------------
@@ -692,6 +738,7 @@ export async function getAdminCatalogView(): Promise<AdminCatalogView> {
     models,
     defaultChatModelId: curation.defaultChatModelId,
     defaultFreeChatModelId: curation.defaultFreeChatModelId,
+    utilityModelId: curation.utilityModelId,
     lastRefreshError: curation.lastRefreshError,
     gatewayFetchedAt: gatewayDoc?.fetchedAt
       ? new Date(gatewayDoc.fetchedAt).toISOString()

--- a/api/src/services/version-comment.service.ts
+++ b/api/src/services/version-comment.service.ts
@@ -83,6 +83,76 @@ export interface VersionCommentResult {
   diff: string | null;
 }
 
+/**
+ * Shared utility-model call that turns a prompt into a single commit-message
+ * line. Routes through the cheapest utility model with gateway failover and
+ * tracks usage. Returns null on any failure or an empty/too-short result.
+ */
+async function generateCommitMessage(
+  system: string,
+  prompt: string,
+  trackingCtx?: VersionCommentTrackingContext,
+): Promise<string | null> {
+  const utilityModel = await getUtilityModelId();
+  if (!utilityModel) return null;
+
+  const failoverModels = await getUtilityModelIds(3);
+
+  const baseOpts = trackingCtx
+    ? buildProviderOptions({
+        userId: trackingCtx.userId,
+        workspaceId: trackingCtx.workspaceId,
+        invocationType: "version_comment",
+      })
+    : {};
+  const gatewayBase = (baseOpts.gateway ?? {}) as Record<string, unknown>;
+
+  const { text, usage, response } = await generateText({
+    model: getModel(utilityModel),
+    system,
+    prompt,
+    providerOptions: {
+      gateway: {
+        ...gatewayBase,
+        models: [
+          utilityModel,
+          ...failoverModels.filter(id => id !== utilityModel),
+        ],
+      } satisfies GatewayLanguageModelOptions,
+    },
+  });
+
+  const actualModelId = (response as Record<string, unknown>)?.modelId as
+    | string
+    | undefined;
+  const modelId = actualModelId || utilityModel;
+
+  if (trackingCtx) {
+    const { inputTokens, outputTokens } = extractTokenCounts(
+      usage as Record<string, unknown>,
+    );
+    void trackUsage({
+      workspaceId: trackingCtx.workspaceId,
+      userId: trackingCtx.userId,
+      invocationType: "version_comment",
+      modelId,
+      inputTokens,
+      outputTokens,
+      totalTokens: inputTokens + outputTokens,
+    }).catch(err =>
+      logger.warn("Failed to track version comment usage", { error: err }),
+    );
+  }
+
+  let comment = text.trim();
+  comment = comment.replace(/^["']|["']$/g, "");
+  comment = comment.replace(/\.+$/, "");
+  comment = comment.substring(0, 72);
+
+  if (comment.length < 3) return null;
+  return comment;
+}
+
 export async function generateVersionComment(
   context: VersionCommentContext,
   trackingCtx?: VersionCommentTrackingContext,
@@ -104,66 +174,120 @@ export async function generateVersionComment(
   const prompt = parts.join("\n");
 
   try {
-    const utilityModel = await getUtilityModelId();
-    if (!utilityModel) return { comment: null, diff };
-
-    const failoverModels = await getUtilityModelIds(3);
-
-    const baseOpts = trackingCtx
-      ? buildProviderOptions({
-          userId: trackingCtx.userId,
-          workspaceId: trackingCtx.workspaceId,
-          invocationType: "version_comment",
-        })
-      : {};
-    const gatewayBase = (baseOpts.gateway ?? {}) as Record<string, unknown>;
-
-    const { text, usage, response } = await generateText({
-      model: getModel(utilityModel),
-      system: VERSION_COMMENT_SYSTEM_PROMPT,
+    const comment = await generateCommitMessage(
+      VERSION_COMMENT_SYSTEM_PROMPT,
       prompt,
-      providerOptions: {
-        gateway: {
-          ...gatewayBase,
-          models: [
-            utilityModel,
-            ...failoverModels.filter(id => id !== utilityModel),
-          ],
-        } satisfies GatewayLanguageModelOptions,
-      },
-    });
-
-    const actualModelId = (response as Record<string, unknown>)?.modelId as
-      | string
-      | undefined;
-    const modelId = actualModelId || utilityModel;
-
-    if (trackingCtx) {
-      const { inputTokens, outputTokens } = extractTokenCounts(
-        usage as Record<string, unknown>,
-      );
-      void trackUsage({
-        workspaceId: trackingCtx.workspaceId,
-        userId: trackingCtx.userId,
-        invocationType: "version_comment",
-        modelId,
-        inputTokens,
-        outputTokens,
-        totalTokens: inputTokens + outputTokens,
-      }).catch(err =>
-        logger.warn("Failed to track version comment usage", { error: err }),
-      );
-    }
-
-    let comment = text.trim();
-    comment = comment.replace(/^["']|["']$/g, "");
-    comment = comment.replace(/\.+$/, "");
-    comment = comment.substring(0, 72);
-
-    if (comment.length < 3) return { comment: null, diff };
+      trackingCtx,
+    );
     return { comment, diff };
   } catch (err) {
     logger.error("Version comment generation failed", { error: err });
+    return { comment: null, diff };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Dashboard version comments
+// ---------------------------------------------------------------------------
+
+const DASHBOARD_VERSION_COMMENT_SYSTEM_PROMPT = `You are to act as an author of a version comment for a saved BI dashboard.
+Your mission is to create a clean, specific commit message that explains WHAT changed in the dashboard and WHY.
+I'll send you a JSON diff of the dashboard definition (widgets, data sources, layout, filters, relationships) and, when available, the chat prompts the user gave the AI that produced the change. You convert this into a single commit message.
+
+Rules:
+- Use present tense, imperative mood (e.g. "Add revenue-by-country pie chart", "Switch demos data source to last 40 weeks")
+- Be specific: mention widget titles/types, data source names, filters, metrics — not raw JSON keys or array indices
+- Prefer the user's intent from the chat prompts when it clarifies the change
+- Maximum 72 characters
+- Do NOT wrap the message in quotes or backticks
+- Do NOT add a trailing period
+- Do NOT add any prefix like "feat:" or "fix:"
+- Do NOT add explanations beyond the single commit line
+- Respond with ONLY the commit message text, nothing else`;
+
+export interface DashboardVersionCommentContext {
+  previousSnapshot: Record<string, unknown> | null;
+  newSnapshot: Record<string, unknown>;
+  /** User prompts from chat sessions that contributed to the change, if any. */
+  chatPrompts?: string[];
+}
+
+// Server-managed / materialization state that is irrelevant to a human-facing
+// "what changed" commit message and only adds noise to the JSON diff.
+const VOLATILE_SNAPSHOT_KEYS = new Set(["cache", "snapshots"]);
+
+function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeysDeep);
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      if (VOLATILE_SNAPSHOT_KEYS.has(key)) continue;
+      out[key] = sortKeysDeep((value as Record<string, unknown>)[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+function stableStringify(value: unknown): string {
+  try {
+    return JSON.stringify(sortKeysDeep(value), null, 2);
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Diff two dashboard snapshots by stable-stringifying their JSON (sorted keys
+ * so unrelated reordering doesn't show up) and producing a unified diff.
+ */
+export function computeSnapshotDiff(
+  previousSnapshot: Record<string, unknown> | null,
+  newSnapshot: Record<string, unknown>,
+): string | null {
+  const prev = previousSnapshot ? stableStringify(previousSnapshot) : "";
+  const next = stableStringify(newSnapshot);
+  return computeDiff(prev, next);
+}
+
+export async function generateDashboardVersionComment(
+  context: DashboardVersionCommentContext,
+  trackingCtx?: VersionCommentTrackingContext,
+): Promise<VersionCommentResult> {
+  const diff = computeSnapshotDiff(
+    context.previousSnapshot,
+    context.newSnapshot,
+  );
+  if (!diff) return { comment: null, diff: null };
+
+  const parts: string[] = [];
+
+  const prompts = (context.chatPrompts ?? [])
+    .map(p => p.trim())
+    .filter(Boolean)
+    .slice(-6);
+  if (prompts.length > 0) {
+    parts.push("Chat prompts that drove these dashboard changes:");
+    for (const p of prompts) {
+      parts.push(`- ${p.substring(0, 300)}`);
+    }
+    parts.push("");
+  }
+
+  parts.push("Dashboard definition diff:");
+  parts.push(diff);
+
+  const prompt = parts.join("\n");
+
+  try {
+    const comment = await generateCommitMessage(
+      DASHBOARD_VERSION_COMMENT_SYSTEM_PROMPT,
+      prompt,
+      trackingCtx,
+    );
+    return { comment, diff };
+  } catch (err) {
+    logger.error("Dashboard version comment generation failed", { error: err });
     return { comment: null, diff };
   }
 }

--- a/app/src/components/DashboardCanvas.tsx
+++ b/app/src/components/DashboardCanvas.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   Box,
   Typography,
@@ -61,6 +67,7 @@ type ViewMode = "canvas" | "code";
 
 const {
   saveDashboard: saveDashboardAction,
+  generateSaveComment: generateSaveCommentAction,
   undo: undoAction,
   redo: redoAction,
   releaseLock: releaseLockAction,
@@ -136,7 +143,45 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
     useState<DashboardWidget | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [commentDialogOpen, setCommentDialogOpen] = useState(false);
+  const [suggestedComment, setSuggestedComment] = useState<string | undefined>(
+    undefined,
+  );
+  const [suggestedCommentLoading, setSuggestedCommentLoading] = useState(false);
+  const [saveCommentDiff, setSaveCommentDiff] = useState<string | null>(null);
+  const saveCommentAbortRef = useRef<AbortController | null>(null);
   const [versionHistoryOpen, setVersionHistoryOpen] = useState(false);
+
+  const openSaveDialog = useCallback(() => {
+    setSuggestedComment(undefined);
+    setSaveCommentDiff(null);
+    setSuggestedCommentLoading(false);
+    setCommentDialogOpen(true);
+
+    // Only existing (persisted) dashboards can be diffed against a saved
+    // version for an AI suggestion.
+    if (!workspaceId || !dashboardId || isNew) return;
+
+    saveCommentAbortRef.current?.abort();
+    const controller = new AbortController();
+    saveCommentAbortRef.current = controller;
+    setSuggestedCommentLoading(true);
+    void generateSaveCommentAction(
+      workspaceId,
+      dashboardId,
+      controller.signal,
+    ).then(result => {
+      if (controller.signal.aborted) return;
+      setSuggestedComment(result.comment ?? undefined);
+      setSaveCommentDiff(result.diff);
+      setSuggestedCommentLoading(false);
+    });
+  }, [workspaceId, dashboardId, isNew]);
+
+  const closeSaveDialog = useCallback(() => {
+    saveCommentAbortRef.current?.abort();
+    setSuggestedCommentLoading(false);
+    setCommentDialogOpen(false);
+  }, []);
 
   const queryGeneration = runtimeSession?.queryGeneration ?? 0;
 
@@ -430,7 +475,7 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
                   disabled={
                     !hasUnsavedChanges || (viewMode === "code" && hasCodeError)
                   }
-                  onClick={() => setCommentDialogOpen(true)}
+                  onClick={openSaveDialog}
                 >
                   <Save size={16} />
                 </IconButton>
@@ -622,8 +667,13 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
 
       <SaveCommentDialog
         open={commentDialogOpen}
-        onCancel={() => setCommentDialogOpen(false)}
+        title="Save dashboard version"
+        defaultComment={suggestedComment}
+        loading={suggestedCommentLoading}
+        diff={saveCommentDiff}
+        onCancel={closeSaveDialog}
         onSave={async comment => {
+          saveCommentAbortRef.current?.abort();
           setCommentDialogOpen(false);
           if (!workspaceId || !dashboardId) return;
           try {
@@ -646,7 +696,6 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
             );
           }
         }}
-        title="Name Dashboard Version"
       />
 
       <Snackbar

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -2490,7 +2490,7 @@ function Editor({
         open={commentDialogOpen}
         onSave={handleCommentSaveConfirm}
         onCancel={handleCommentSaveCancel}
-        title="Name Console Version"
+        title="Save console version"
         defaultComment={suggestedComment}
         loading={suggestedCommentLoading}
         diff={saveCommentDiff}

--- a/app/src/components/SaveCommentDialog.tsx
+++ b/app/src/components/SaveCommentDialog.tsx
@@ -28,7 +28,7 @@ export function SaveCommentDialog({
   open,
   onSave,
   onCancel,
-  title = "Name Version",
+  title = "Save version",
   defaultComment,
   loading,
   diff,
@@ -77,9 +77,9 @@ export function SaveCommentDialog({
           multiline
           minRows={3}
           maxRows={4}
-          label="Version name"
+          label="Commit message"
           placeholder="Describe what changed in this version"
-          helperText="This labels the saved version, not the console itself."
+          helperText="This labels the saved version in its history."
           value={comment}
           onChange={e => {
             setComment(e.target.value);

--- a/app/src/pages/settings/SettingsAdmin.tsx
+++ b/app/src/pages/settings/SettingsAdmin.tsx
@@ -37,6 +37,7 @@ interface AdminCatalogResponse {
   models: AdminCuratedModel[];
   defaultChatModelId: string | null;
   defaultFreeChatModelId: string | null;
+  utilityModelId: string | null;
   gatewayFetchedAt: string | null;
   curationUpdatedAt: string | null;
   lastRefreshError: string | null;
@@ -149,6 +150,7 @@ export default function SettingsAdmin() {
   const updateDefaults = async (patch: {
     defaultChatModelId?: string | null;
     defaultFreeChatModelId?: string | null;
+    utilityModelId?: string | null;
   }) => {
     if (!data) return;
     setSavingDefaults(true);
@@ -162,6 +164,10 @@ export default function SettingsAdmin() {
         patch.defaultFreeChatModelId !== undefined
           ? patch.defaultFreeChatModelId
           : data.defaultFreeChatModelId,
+      utilityModelId:
+        patch.utilityModelId !== undefined
+          ? patch.utilityModelId
+          : data.utilityModelId,
     };
     setData(next);
     try {
@@ -170,6 +176,7 @@ export default function SettingsAdmin() {
         body: JSON.stringify({
           defaultChatModelId: next.defaultChatModelId,
           defaultFreeChatModelId: next.defaultFreeChatModelId,
+          utilityModelId: next.utilityModelId,
         }),
       });
     } catch (err) {
@@ -274,7 +281,9 @@ export default function SettingsAdmin() {
           <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
             Toggle visibility per model and assign each one to a tier.
             Workspaces on the free plan only see models assigned to the free
-            tier.
+            tier. The <strong>Fast</strong> model powers cheap utility tasks
+            (version/commit messages, chat titles, descriptions); leave it unset
+            to auto-pick the cheapest tool-use model.
           </Typography>
 
           {loadError && (
@@ -336,6 +345,9 @@ export default function SettingsAdmin() {
                     </TableCell>
                     <TableCell align="center" sx={{ width: 80 }}>
                       Default&nbsp;free
+                    </TableCell>
+                    <TableCell align="center" sx={{ width: 70 }}>
+                      Fast
                     </TableCell>
                   </TableRow>
                 </TableHead>
@@ -421,11 +433,25 @@ export default function SettingsAdmin() {
                           sx={{ p: 0.5 }}
                         />
                       </TableCell>
+                      <TableCell align="center">
+                        <Radio
+                          size="small"
+                          checked={data?.utilityModelId === m.id}
+                          onChange={() =>
+                            updateDefaults({
+                              utilityModelId:
+                                data?.utilityModelId === m.id ? null : m.id,
+                            })
+                          }
+                          disabled={!m.visible || savingDefaults}
+                          sx={{ p: 0.5 }}
+                        />
+                      </TableCell>
                     </TableRow>
                   ))}
                   {filteredModels.length === 0 && !loading && (
                     <TableRow>
-                      <TableCell colSpan={7} align="center">
+                      <TableCell colSpan={8} align="center">
                         <Typography variant="body2" color="text.secondary">
                           No models match the current filter.
                         </Typography>

--- a/app/src/store/dashboardStore.ts
+++ b/app/src/store/dashboardStore.ts
@@ -179,6 +179,11 @@ interface DashboardStoreState {
     dashboardId: string,
     comment?: string,
   ) => Promise<{ ok: boolean; error?: string }>;
+  generateSaveComment: (
+    workspaceId: string,
+    dashboardId: string,
+    signal?: AbortSignal,
+  ) => Promise<{ comment: string | null; diff: string | null }>;
   resolveConflict: (
     resolution: "discard" | "overwrite",
     workspaceId: string,
@@ -562,6 +567,32 @@ export const useDashboardStore = create<DashboardStoreState>()(
             err?.message ??
             "Failed to save dashboard";
           return { ok: false, error: msg };
+        }
+      },
+
+      generateSaveComment: async (
+        workspaceId: string,
+        dashboardId: string,
+        signal?: AbortSignal,
+      ) => {
+        const dashboard = get().openDashboards[dashboardId];
+        if (!dashboard) return { comment: null, diff: null };
+        try {
+          const definition = sanitizeEditableDashboardDefinition(dashboard);
+          const res = await apiClient.post<{
+            success: boolean;
+            comment: string | null;
+            diff: string | null;
+          }>(
+            `/workspaces/${workspaceId}/dashboards/${dashboardId}/version-comment`,
+            { definition },
+            { signal },
+          );
+          return res.success
+            ? { comment: res.comment ?? null, diff: res.diff ?? null }
+            : { comment: null, diff: null };
+        } catch {
+          return { comment: null, diff: null };
         }
       },
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Dashboards now get an AI-suggested version/commit message when you save a new version — matching what consoles already do. Also adds a super-admin setting to pin the cheap "fast" model used for these utility tasks, and renames the version dialog's `Version name` field to `Commit message`.

## What changed

### 1. AI commit message for dashboard versions
- New endpoint `POST /api/workspaces/:workspaceId/dashboards/:id/version-comment`.
- New service `generateDashboardVersionComment` (in `version-comment.service.ts`): diffs the pending dashboard definition against the latest saved `EntityVersion` snapshot using a stable, key-sorted JSON diff (volatile `cache`/`snapshots` state stripped to keep the diff focused), and feeds it to the utility/fast model with a dashboard-specific prompt.
- **Chat context**: `dashboard-version-context.service.ts` best-effort gathers the user prompts that drove AI dashboard edits, by scanning the user's recent chats for tool calls referencing the dashboard id and collecting the preceding user prompts. (There is no persisted chat↔dashboard FK, so this covers AI-driven edits; purely manual edits simply fall back to the diff alone, which is enough.)
- Frontend: `dashboardStore.generateSaveComment` action; `DashboardCanvas` requests a suggestion when the save dialog opens, shows the AI loading state + collapsible diff, and pre-fills the field — same UX as consoles.

### 2. Super-admin configurable "fast" model
- The cheap utility model (used for version/commit messages, chat titles, descriptions) was auto-picked as the cheapest tool-use model. Super admins can now pin an explicit model via a new **Fast** radio column in Super Admin → Curated models, so they can e.g. bump the Haiku version after refreshing the catalog.
- Stored on the existing `curation` doc as `utilityModelId` (`null` = keep auto-pick). `getUtilityChatModelId` / `getUtilityModelIds` promote the pinned model when set and still visible; hiding that model clears the pin.
- Extended `PUT /api/admin/catalog/defaults` and the admin catalog view to carry `utilityModelId`.

### 3. Rename "Version name" → "Commit message"
- `SaveCommentDialog` field label is now `Commit message`, with generic helper text (was console-specific). Dialog titles updated to `Save dashboard version` / `Save console version`.

## Notes
- No schema migration needed: `utilityModelId` defaults to `null` when absent from the curation doc.
- Reuses the existing utility-model + gateway-failover + usage-tracking path; usage is tracked as `version_comment`.

## Verification
- `pnpm --filter api run lint` ✅
- `pnpm --filter app run typecheck` ✅
- `pnpm --filter app run lint` ✅
- `tsc --noEmit` (api) ✅
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c229c30-2c93-4016-a16f-3c652125c5e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c229c30-2c93-4016-a16f-3c652125c5e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

