### PR TITLE
feat(dashboards): per-user collaborators with editor access

### DIFF
--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -2929,6 +2929,16 @@ export interface IDashboard extends Document {
 
   folderId?: Types.ObjectId;
   access: "private" | "workspace";
+  /**
+   * Per-user collaborators granted explicit edit access, independent of the
+   * `access` level. Anyone listed here can read + write the dashboard.
+   */
+  sharedWith?: Array<{
+    userId: string;
+    role: "editor";
+    addedAt: Date;
+    addedBy?: string;
+  }>;
   owner_id?: string;
   createdBy: string;
   createdAt: Date;
@@ -3258,6 +3268,17 @@ const DashboardSchema = new Schema<IDashboard>(
       enum: ["private", "workspace"],
       default: "private",
     },
+    sharedWith: {
+      type: [
+        {
+          userId: { type: String, required: true },
+          role: { type: String, enum: ["editor"], default: "editor" },
+          addedAt: { type: Date, default: Date.now },
+          addedBy: { type: String },
+        },
+      ],
+      default: [],
+    },
     owner_id: { type: String },
     createdBy: { type: String, required: true },
   },
@@ -3270,6 +3291,7 @@ const DashboardSchema = new Schema<IDashboard>(
 DashboardSchema.index({ workspaceId: 1 });
 DashboardSchema.index({ workspaceId: 1, createdBy: 1 });
 DashboardSchema.index({ workspaceId: 1, access: 1, owner_id: 1 });
+DashboardSchema.index({ workspaceId: 1, "sharedWith.userId": 1 });
 
 /**
  * DashboardFolder Schema

--- a/api/src/migrations/2026-06-04-113137_dashboard_shared_with.ts
+++ b/api/src/migrations/2026-06-04-113137_dashboard_shared_with.ts
@@ -1,0 +1,61 @@
+import { Db } from "mongodb";
+import { loggers } from "../logging";
+
+const log = loggers.migration();
+
+export const description =
+  "Initialize sharedWith collaborator array on dashboards and create lookup index";
+
+/**
+ * Migration: Dashboard per-user collaborators
+ *
+ * Backfills `sharedWith: []` for all dashboards missing the field so that
+ * collaborator lookups never hit `undefined`. Creates index:
+ * { workspaceId: 1, "sharedWith.userId": 1 } for fast "shared with me" queries.
+ */
+function hasIndexOnKeys(
+  indexes: Array<{ key?: Record<string, unknown> }>,
+  keyPattern: Record<string, unknown>,
+): boolean {
+  const target = JSON.stringify(keyPattern);
+  return indexes.some(idx => idx.key && JSON.stringify(idx.key) === target);
+}
+
+export async function up(db: Db): Promise<void> {
+  const collections = await db.listCollections().toArray();
+  const collectionNames = collections.map(c => c.name);
+
+  if (!collectionNames.includes("dashboards")) {
+    log.info("Collection 'dashboards' not found, skipping migration.");
+    return;
+  }
+
+  const col = db.collection("dashboards");
+
+  const result = await col.updateMany(
+    { sharedWith: { $exists: false } },
+    { $set: { sharedWith: [] } },
+  );
+  log.info(`Initialized sharedWith=[] for ${result.modifiedCount} dashboards`);
+
+  const keyPattern = { workspaceId: 1, "sharedWith.userId": 1 };
+  try {
+    const existingIndexes = await col.indexes();
+    if (hasIndexOnKeys(existingIndexes, keyPattern)) {
+      log.info(
+        'Index on { workspaceId, "sharedWith.userId" } already exists, skipping creation',
+      );
+    } else {
+      await col.createIndex(keyPattern, { background: true });
+      log.info('Created index: { workspaceId: 1, "sharedWith.userId": 1 }');
+    }
+  } catch (err: any) {
+    if (err?.code === 85 || err?.codeName === "IndexOptionsConflict") {
+      log.info(
+        "Index already exists (possibly under a different name), skipping",
+      );
+    } else {
+      throw err;
+    }
+  }
+}

--- a/api/src/routes/dashboards.ts
+++ b/api/src/routes/dashboards.ts
@@ -615,6 +615,17 @@ app.put("/:id", async (c: AuthenticatedContext) => {
       }
     }
     if (body.access !== undefined) {
+      // Changing visibility is owner/admin-only — collaborators can edit
+      // content but must not be able to re-scope who can see the dashboard.
+      if (!DashboardManager.isOwner(dashboard, userId) && !isAdmin) {
+        return c.json(
+          {
+            success: false,
+            error: "Only the owner or an admin can change dashboard visibility",
+          },
+          403,
+        );
+      }
       updateFields.access = body.access;
     }
 
@@ -1034,6 +1045,10 @@ app.post("/:id/duplicate", async (c: AuthenticatedContext) => {
     const spec: any = dashboard.toObject();
     delete spec._id;
     delete spec.__v;
+    // A duplicate is a fresh, owner-only private copy: never inherit the
+    // original's collaborators or a stale edit lock.
+    delete spec.sharedWith;
+    delete spec.editLock;
     spec.title = `${spec.title} (copy)`;
     spec.createdBy = userId;
     spec.owner_id = userId;
@@ -1549,6 +1564,16 @@ app.patch("/:id/move", async (c: AuthenticatedContext) => {
       dashboard.folderId = folderId ? new Types.ObjectId(folderId) : undefined;
     }
     if (access !== undefined) {
+      // Visibility changes are owner/admin-only (see PUT handler).
+      if (!DashboardManager.isOwner(dashboard, userId) && !isAdmin) {
+        return c.json(
+          {
+            success: false,
+            error: "Only the owner or an admin can change dashboard visibility",
+          },
+          403,
+        );
+      }
       dashboard.access = access;
     }
     await dashboard.save();

--- a/api/src/routes/dashboards.ts
+++ b/api/src/routes/dashboards.ts
@@ -1751,4 +1751,179 @@ app.post("/:id/versions/:version/restore", async (c: AuthenticatedContext) => {
   }
 });
 
+// ── Collaborators (per-user editor access) ──
+
+async function loadDashboardForCollaborators(c: AuthenticatedContext) {
+  const workspaceId = c.req.param("workspaceId");
+  const id = c.req.param("id");
+  if (!Types.ObjectId.isValid(id)) {
+    return {
+      error: c.json({ success: false, error: "Invalid dashboard ID" }, 400),
+    };
+  }
+  const dashboard = await Dashboard.findOne({
+    _id: new Types.ObjectId(id),
+    workspaceId: new Types.ObjectId(workspaceId),
+  });
+  if (!dashboard) {
+    return {
+      error: c.json({ success: false, error: "Dashboard not found" }, 404),
+    };
+  }
+  return { dashboard, workspaceId };
+}
+
+/**
+ * Only the owner or a workspace admin/owner may manage collaborators.
+ */
+function canManageCollaborators(
+  dashboard: IDashboard,
+  userId: string,
+  memberRole?: string,
+): boolean {
+  if (DashboardManager.isOwner(dashboard, userId)) return true;
+  return memberRole === "owner" || memberRole === "admin";
+}
+
+// GET collaborators - anyone who can read the dashboard can see the list
+app.get("/:id/collaborators", async (c: AuthenticatedContext) => {
+  try {
+    const userId = c.get("user")?.id;
+    if (!userId) {
+      return c.json({ success: false, error: "Unauthorized" }, 401);
+    }
+    const result = await loadDashboardForCollaborators(c);
+    if (result.error) return result.error;
+    const { dashboard, workspaceId } = result;
+
+    if (!DashboardManager.canRead(dashboard, userId)) {
+      return c.json({ success: false, error: "Access denied" }, 403);
+    }
+
+    const members = await workspaceService.getMembers(workspaceId);
+    const emailByUserId = new Map<string, string>(
+      members.map((m: any) => [
+        (m.userId?._id || m.userId)?.toString(),
+        m.userId?.email || "",
+      ]),
+    );
+
+    const collaborators = (dashboard.sharedWith || []).map(s => ({
+      userId: s.userId,
+      role: s.role,
+      email: emailByUserId.get(s.userId) || "",
+      addedAt: s.addedAt,
+    }));
+
+    return c.json({ success: true, data: collaborators });
+  } catch (error) {
+    logger.error("Error listing dashboard collaborators", { error });
+    return c.json(
+      { success: false, error: "Failed to list collaborators" },
+      500,
+    );
+  }
+});
+
+// POST collaborator - add an editor (owner/admin only)
+app.post("/:id/collaborators", async (c: AuthenticatedContext) => {
+  try {
+    const userId = c.get("user")?.id;
+    if (!userId) {
+      return c.json({ success: false, error: "Unauthorized" }, 401);
+    }
+    const result = await loadDashboardForCollaborators(c);
+    if (result.error) return result.error;
+    const { dashboard, workspaceId } = result;
+
+    const memberRole = c.get("memberRole");
+    if (!canManageCollaborators(dashboard, userId, memberRole)) {
+      return c.json(
+        { success: false, error: "Only the owner or an admin can share" },
+        403,
+      );
+    }
+
+    const body = await c.req.json().catch(() => ({}));
+    const targetUserId = String(body?.userId || "").trim();
+    if (!targetUserId) {
+      return c.json({ success: false, error: "userId is required" }, 400);
+    }
+
+    if (DashboardManager.isOwner(dashboard, targetUserId)) {
+      return c.json(
+        { success: false, error: "Owner already has full access" },
+        400,
+      );
+    }
+
+    const members = await workspaceService.getMembers(workspaceId);
+    const isMember = members.some(
+      (m: any) => (m.userId?._id || m.userId)?.toString() === targetUserId,
+    );
+    if (!isMember) {
+      return c.json(
+        { success: false, error: "User is not a member of this workspace" },
+        400,
+      );
+    }
+
+    const alreadyShared = (dashboard.sharedWith || []).some(
+      s => s.userId === targetUserId,
+    );
+    if (!alreadyShared) {
+      dashboard.sharedWith = [
+        ...(dashboard.sharedWith || []),
+        {
+          userId: targetUserId,
+          role: "editor",
+          addedAt: new Date(),
+          addedBy: userId,
+        },
+      ];
+      await dashboard.save();
+    }
+
+    return c.json({ success: true, data: dashboard.sharedWith });
+  } catch (error) {
+    logger.error("Error adding dashboard collaborator", { error });
+    return c.json({ success: false, error: "Failed to add collaborator" }, 500);
+  }
+});
+
+// DELETE collaborator - revoke access (owner/admin only)
+app.delete("/:id/collaborators/:userId", async (c: AuthenticatedContext) => {
+  try {
+    const userId = c.get("user")?.id;
+    if (!userId) {
+      return c.json({ success: false, error: "Unauthorized" }, 401);
+    }
+    const result = await loadDashboardForCollaborators(c);
+    if (result.error) return result.error;
+    const { dashboard } = result;
+
+    const memberRole = c.get("memberRole");
+    if (!canManageCollaborators(dashboard, userId, memberRole)) {
+      return c.json(
+        { success: false, error: "Only the owner or an admin can share" },
+        403,
+      );
+    }
+
+    const targetUserId = c.req.param("userId");
+    dashboard.sharedWith = (dashboard.sharedWith || []).filter(
+      s => s.userId !== targetUserId,
+    );
+    await dashboard.save();
+
+    return c.json({ success: true, data: dashboard.sharedWith });
+  } catch (error) {
+    logger.error("Error removing dashboard collaborator", { error });
+    return c.json(
+      { success: false, error: "Failed to remove collaborator" },
+      500,
+    );
+  }
+});
+
 export const dashboardRoutes = app;

--- a/api/src/utils/dashboard-manager.ts
+++ b/api/src/utils/dashboard-manager.ts
@@ -32,6 +32,7 @@ export interface DashboardTreeNode {
  * - `owner_id` tracks the dashboard creator (backfilled from `createdBy`)
  * - Private dashboards are only visible/editable by the owner
  * - Workspace dashboards are visible to all members; editable by owner + admins
+ * - `sharedWith` grants explicit per-user edit access regardless of `access`
  */
 export class DashboardManager {
   static getOwnerId(dashboard: IDashboard): string {
@@ -42,8 +43,17 @@ export class DashboardManager {
     return DashboardManager.getOwnerId(dashboard) === userId;
   }
 
+  /**
+   * Whether `userId` is an explicit collaborator on the dashboard.
+   * All collaborators currently have the "editor" role (read + write).
+   */
+  static isCollaborator(dashboard: IDashboard, userId: string): boolean {
+    return (dashboard.sharedWith || []).some(s => s.userId === userId);
+  }
+
   static canRead(dashboard: IDashboard, userId: string): boolean {
     if (DashboardManager.isOwner(dashboard, userId)) return true;
+    if (DashboardManager.isCollaborator(dashboard, userId)) return true;
     return dashboard.access === "workspace";
   }
 
@@ -53,6 +63,7 @@ export class DashboardManager {
     isAdmin: boolean = false,
   ): boolean {
     if (DashboardManager.isOwner(dashboard, userId)) return true;
+    if (DashboardManager.isCollaborator(dashboard, userId)) return true;
     if (dashboard.access === "private") return false;
     return isAdmin;
   }
@@ -63,6 +74,7 @@ export class DashboardManager {
   ): "my" | "workspace" | null {
     if (DashboardManager.isOwner(dashboard, userId)) return "my";
     if (dashboard.access === "workspace") return "workspace";
+    if (DashboardManager.isCollaborator(dashboard, userId)) return "workspace";
     return null;
   }
 
@@ -185,6 +197,7 @@ export class DashboardManager {
             { access: "workspace" },
             { access: "private", createdBy: userId },
             { access: "private", owner_id: userId },
+            { "sharedWith.userId": userId },
           ],
         }).sort({ title: 1 }),
       ]);
@@ -225,7 +238,12 @@ export class DashboardManager {
 
       for (const d of dashboards) {
         const ownerId = (d.owner_id || d.createdBy)?.toString();
-        const section = classify(d.access || "private", ownerId, d.folderId);
+        let section = classify(d.access || "private", ownerId, d.folderId);
+        // Private dashboards shared explicitly with this user surface under
+        // the "Workspace" (shared) section so collaborators can find them.
+        if (section === null && DashboardManager.isCollaborator(d, userId)) {
+          section = "workspace";
+        }
         if (section === "my") myDashboardsRaw.push(d);
         else if (section === "workspace") sharedDashboardsRaw.push(d);
       }

--- a/app/src/components/DashboardCanvas.tsx
+++ b/app/src/components/DashboardCanvas.tsx
@@ -30,6 +30,7 @@ import {
   Pencil,
   Eye,
   History,
+  Share2,
 } from "lucide-react";
 import {
   useDashboardStore,
@@ -53,6 +54,8 @@ import DashboardCodeEditor from "./dashboard/DashboardCodeEditor";
 import DataSourcePanel from "./dashboard/DataSourcePanel";
 import AddWidgetDialog from "./dashboard/AddWidgetDialog";
 import DashboardSettingsDialog from "./dashboard/DashboardSettingsDialog";
+import DashboardShareDialog from "./dashboard/DashboardShareDialog";
+import { useIsWorkspaceAdmin } from "../hooks/useIsWorkspaceAdmin";
 import WidgetInspector from "./dashboard/WidgetInspector";
 import { SaveCommentDialog } from "./SaveCommentDialog";
 import { VersionHistoryPanel } from "./VersionHistoryPanel";
@@ -109,6 +112,8 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
     resolveConflictAction,
   } = useDashboardEditSession({ dashboardId, workspaceId });
 
+  const isWorkspaceAdmin = useIsWorkspaceAdmin();
+
   const tabId = useConsoleStore(state =>
     Object.keys(state.tabs).find(id => {
       const tab = state.tabs[id];
@@ -131,6 +136,7 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
   const [dataSourcePanelOpen, setDataSourcePanelOpen] = useState(false);
   const [addWidgetOpen, setAddWidgetOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
   const [showEventLog, setShowEventLog] = useState(false);
   const [inspectedWidget, setInspectedWidget] =
     useState<DashboardWidget | null>(null);
@@ -261,6 +267,10 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
       </Box>
     );
   }
+
+  const isDashboardOwner =
+    !!user?.id && (dashboard.owner_id ?? dashboard.createdBy) === user.id;
+  const canManageShare = isDashboardOwner || isWorkspaceAdmin;
 
   return (
     <Box
@@ -413,6 +423,14 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
           </IconButton>
         </Tooltip>
 
+        {canManageShare && (
+          <Tooltip title="Share dashboard">
+            <IconButton size="small" onClick={() => setShareOpen(true)}>
+              <Share2 size={16} />
+            </IconButton>
+          </Tooltip>
+        )}
+
         {isEditMode && (
           <>
             <Tooltip
@@ -551,6 +569,11 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
       <DashboardSettingsDialog
         open={settingsOpen}
         onClose={() => setSettingsOpen(false)}
+        dashboardId={dashboardId}
+      />
+      <DashboardShareDialog
+        open={shareOpen}
+        onClose={() => setShareOpen(false)}
         dashboardId={dashboardId}
       />
       <Dialog open={!!conflict} maxWidth="sm" fullWidth>

--- a/app/src/components/dashboard/DashboardShareDialog.tsx
+++ b/app/src/components/dashboard/DashboardShareDialog.tsx
@@ -17,7 +17,7 @@ import {
   Alert,
   Tooltip,
 } from "@mui/material";
-import { Trash2, UserPlus } from "lucide-react";
+import { Trash2 } from "lucide-react";
 import { useDashboardStore } from "../../store/dashboardStore";
 import { useWorkspace } from "../../contexts/workspace-context";
 import { useAuth } from "../../contexts/auth-context";
@@ -43,14 +43,12 @@ export default function DashboardShareDialog({
   const shareDashboard = useDashboardStore(s => s.shareDashboard);
   const unshareDashboard = useDashboardStore(s => s.unshareDashboard);
 
-  const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (open) {
       setError(null);
-      setSelectedUserId(null);
       void loadMembers();
     }
   }, [open, loadMembers]);
@@ -75,21 +73,15 @@ export default function DashboardShareDialog({
 
   const collaborators = dashboard?.sharedWith || [];
 
-  const handleAdd = async () => {
-    if (!workspaceId || !dashboardId || !selectedUserId) return;
+  const handleAdd = async (targetUserId: string) => {
+    if (!workspaceId || !dashboardId || !targetUserId) return;
     setBusy(true);
     setError(null);
-    const result = await shareDashboard(
-      workspaceId,
-      dashboardId,
-      selectedUserId,
-    );
+    const result = await shareDashboard(workspaceId, dashboardId, targetUserId);
     setBusy(false);
     if (!result.ok) {
       setError(result.error || "Failed to share dashboard");
-      return;
     }
-    setSelectedUserId(null);
   };
 
   const handleRemove = async (targetUserId: string) => {
@@ -125,15 +117,16 @@ export default function DashboardShareDialog({
         <Typography variant="subtitle2" sx={{ mb: 1 }}>
           Add people
         </Typography>
-        <Box sx={{ display: "flex", gap: 1, alignItems: "center", mb: 3 }}>
+        <Box sx={{ mb: 3 }}>
           <Autocomplete
-            sx={{ flex: 1 }}
             options={addableMembers}
             getOptionLabel={option => option.email || option.userId}
-            value={
-              addableMembers.find(m => m.userId === selectedUserId) ?? null
-            }
-            onChange={(_, value) => setSelectedUserId(value?.userId ?? null)}
+            value={null}
+            blurOnSelect
+            clearOnBlur
+            onChange={(_, value) => {
+              if (value) void handleAdd(value.userId);
+            }}
             isOptionEqualToValue={(option, value) =>
               option.userId === value.userId
             }
@@ -146,14 +139,6 @@ export default function DashboardShareDialog({
             )}
             disabled={busy}
           />
-          <Button
-            variant="contained"
-            startIcon={<UserPlus size={16} />}
-            onClick={handleAdd}
-            disabled={!selectedUserId || busy}
-          >
-            Add
-          </Button>
         </Box>
 
         <Typography variant="subtitle2" sx={{ mb: 1 }}>

--- a/app/src/components/dashboard/DashboardShareDialog.tsx
+++ b/app/src/components/dashboard/DashboardShareDialog.tsx
@@ -1,0 +1,222 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Autocomplete,
+  TextField,
+  Box,
+  Typography,
+  List,
+  ListItem,
+  ListItemText,
+  IconButton,
+  Chip,
+  Alert,
+  Tooltip,
+} from "@mui/material";
+import { Trash2, UserPlus } from "lucide-react";
+import { useDashboardStore } from "../../store/dashboardStore";
+import { useWorkspace } from "../../contexts/workspace-context";
+import { useAuth } from "../../contexts/auth-context";
+
+interface DashboardShareDialogProps {
+  open: boolean;
+  onClose: () => void;
+  dashboardId?: string;
+}
+
+export default function DashboardShareDialog({
+  open,
+  onClose,
+  dashboardId,
+}: DashboardShareDialogProps) {
+  const { user } = useAuth();
+  const { currentWorkspace, members, loadMembers } = useWorkspace();
+  const workspaceId = currentWorkspace?.id;
+
+  const dashboard = useDashboardStore(s =>
+    dashboardId ? s.openDashboards[dashboardId] : undefined,
+  );
+  const shareDashboard = useDashboardStore(s => s.shareDashboard);
+  const unshareDashboard = useDashboardStore(s => s.unshareDashboard);
+
+  const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setError(null);
+      setSelectedUserId(null);
+      void loadMembers();
+    }
+  }, [open, loadMembers]);
+
+  const ownerId = dashboard?.owner_id || dashboard?.createdBy;
+  const sharedUserIds = useMemo(
+    () => new Set((dashboard?.sharedWith || []).map(s => s.userId)),
+    [dashboard?.sharedWith],
+  );
+
+  const emailByUserId = useMemo(
+    () => new Map(members.map(m => [m.userId, m.email])),
+    [members],
+  );
+
+  // Members eligible to be added: not the owner and not already shared.
+  const addableMembers = useMemo(
+    () =>
+      members.filter(m => m.userId !== ownerId && !sharedUserIds.has(m.userId)),
+    [members, ownerId, sharedUserIds],
+  );
+
+  const collaborators = dashboard?.sharedWith || [];
+
+  const handleAdd = async () => {
+    if (!workspaceId || !dashboardId || !selectedUserId) return;
+    setBusy(true);
+    setError(null);
+    const result = await shareDashboard(
+      workspaceId,
+      dashboardId,
+      selectedUserId,
+    );
+    setBusy(false);
+    if (!result.ok) {
+      setError(result.error || "Failed to share dashboard");
+      return;
+    }
+    setSelectedUserId(null);
+  };
+
+  const handleRemove = async (targetUserId: string) => {
+    if (!workspaceId || !dashboardId) return;
+    setBusy(true);
+    setError(null);
+    const result = await unshareDashboard(
+      workspaceId,
+      dashboardId,
+      targetUserId,
+    );
+    setBusy(false);
+    if (!result.ok) {
+      setError(result.error || "Failed to remove collaborator");
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Share dashboard</DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          People you add here can view and edit this dashboard, regardless of
+          its workspace visibility setting.
+        </Typography>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
+
+        <Box sx={{ display: "flex", gap: 1, alignItems: "flex-start", mb: 2 }}>
+          <Autocomplete
+            sx={{ flex: 1 }}
+            options={addableMembers}
+            getOptionLabel={option => option.email || option.userId}
+            value={
+              addableMembers.find(m => m.userId === selectedUserId) ?? null
+            }
+            onChange={(_, value) => setSelectedUserId(value?.userId ?? null)}
+            isOptionEqualToValue={(option, value) =>
+              option.userId === value.userId
+            }
+            renderInput={params => (
+              <TextField
+                {...params}
+                label="Add people"
+                placeholder="Search members by email"
+                size="small"
+              />
+            )}
+            disabled={busy}
+          />
+          <Button
+            variant="contained"
+            startIcon={<UserPlus size={16} />}
+            onClick={handleAdd}
+            disabled={!selectedUserId || busy}
+            sx={{ mt: 0.25 }}
+          >
+            Add
+          </Button>
+        </Box>
+
+        <Typography variant="subtitle2" sx={{ mb: 1 }}>
+          People with access
+        </Typography>
+
+        <List dense disablePadding>
+          <ListItem
+            disableGutters
+            secondaryAction={<Chip size="small" label="Owner" />}
+          >
+            <ListItemText
+              primary={
+                ownerId === user?.id
+                  ? "You"
+                  : emailByUserId.get(ownerId || "") || ownerId
+              }
+            />
+          </ListItem>
+
+          {collaborators.length === 0 && (
+            <ListItem disableGutters>
+              <ListItemText
+                primaryTypographyProps={{
+                  variant: "body2",
+                  color: "text.secondary",
+                }}
+                primary="Not shared with anyone yet."
+              />
+            </ListItem>
+          )}
+
+          {collaborators.map(collab => (
+            <ListItem
+              key={collab.userId}
+              disableGutters
+              secondaryAction={
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                  <Chip size="small" label="Editor" variant="outlined" />
+                  <Tooltip title="Remove access">
+                    <span>
+                      <IconButton
+                        edge="end"
+                        size="small"
+                        onClick={() => handleRemove(collab.userId)}
+                        disabled={busy}
+                      >
+                        <Trash2 size={16} />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                </Box>
+              }
+            >
+              <ListItemText
+                primary={emailByUserId.get(collab.userId) || collab.userId}
+              />
+            </ListItem>
+          ))}
+        </List>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Done</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/app/src/components/dashboard/DashboardShareDialog.tsx
+++ b/app/src/components/dashboard/DashboardShareDialog.tsx
@@ -122,7 +122,10 @@ export default function DashboardShareDialog({
           </Alert>
         )}
 
-        <Box sx={{ display: "flex", gap: 1, alignItems: "flex-start", mb: 2 }}>
+        <Typography variant="subtitle2" sx={{ mb: 1 }}>
+          Add people
+        </Typography>
+        <Box sx={{ display: "flex", gap: 1, alignItems: "center", mb: 3 }}>
           <Autocomplete
             sx={{ flex: 1 }}
             options={addableMembers}
@@ -137,7 +140,6 @@ export default function DashboardShareDialog({
             renderInput={params => (
               <TextField
                 {...params}
-                label="Add people"
                 placeholder="Search members by email"
                 size="small"
               />
@@ -149,7 +151,6 @@ export default function DashboardShareDialog({
             startIcon={<UserPlus size={16} />}
             onClick={handleAdd}
             disabled={!selectedUserId || busy}
-            sx={{ mt: 0.25 }}
           >
             Add
           </Button>

--- a/app/src/contexts/ThemeContext.tsx
+++ b/app/src/contexts/ThemeContext.tsx
@@ -499,19 +499,17 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
         defaultProps: {
           size: "small",
           autoComplete: "off",
-          // Forward HTML input attributes to the underlying <input /> element
+          // Forward HTML input attributes to the underlying <input /> element.
+          // NOTE: do NOT also set `slotProps.input` here. In MUI v7 a
+          // `slotProps.input` (the modern replacement for `InputProps`) injected
+          // via defaultProps takes precedence over and DISCARDS the legacy
+          // `InputProps` that components like Autocomplete pass through
+          // `renderInput` — which silently drops the Autocomplete end adornment
+          // and its `anchorEl` ref, so the dropdown popup never mounts.
           inputProps: {
             autoComplete: "off",
             autoCorrect: "off",
             autoCapitalize: "off",
-          },
-          // For the new slot-based API (v5+)
-          slotProps: {
-            input: {
-              autoComplete: "off",
-              autoCorrect: "off",
-              autoCapitalize: "off",
-            },
           },
         },
       },

--- a/app/src/dashboard-runtime/types.ts
+++ b/app/src/dashboard-runtime/types.ts
@@ -69,6 +69,12 @@ export interface Dashboard
   /** false = draft (auto-save enabled), true = saved (no auto-save) */
   isSaved?: boolean;
   access: "private" | "workspace";
+  /** Per-user collaborators with explicit edit access. */
+  sharedWith?: Array<{
+    userId: string;
+    role: "editor";
+    addedAt?: string;
+  }>;
   owner_id?: string;
   createdBy: string;
   readOnly?: boolean;

--- a/app/src/store/dashboardStore.ts
+++ b/app/src/store/dashboardStore.ts
@@ -163,6 +163,16 @@ interface DashboardStoreState {
     workspaceId: string,
     id: string,
   ) => Promise<Dashboard | null>;
+  shareDashboard: (
+    workspaceId: string,
+    dashboardId: string,
+    userId: string,
+  ) => Promise<{ ok: boolean; error?: string }>;
+  unshareDashboard: (
+    workspaceId: string,
+    dashboardId: string,
+    userId: string,
+  ) => Promise<{ ok: boolean; error?: string }>;
   openDashboard: (
     workspaceId: string,
     dashboardId: string,
@@ -946,6 +956,57 @@ export const useDashboardStore = create<DashboardStoreState>()(
             await get().reloadDashboard(workspaceId, dashboardId);
           }
           return false;
+        }
+      },
+
+      shareDashboard: async (
+        workspaceId: string,
+        dashboardId: string,
+        userId: string,
+      ) => {
+        try {
+          const response = await apiClient.post<{
+            success: boolean;
+            data: Dashboard["sharedWith"];
+          }>(
+            `/workspaces/${workspaceId}/dashboards/${dashboardId}/collaborators`,
+            { userId },
+          );
+          set(state => {
+            const d = state.openDashboards[dashboardId];
+            if (d) d.sharedWith = response.data ?? [];
+          });
+          return { ok: true };
+        } catch (error) {
+          return {
+            ok: false,
+            error: error instanceof Error ? error.message : "Failed to share",
+          };
+        }
+      },
+
+      unshareDashboard: async (
+        workspaceId: string,
+        dashboardId: string,
+        userId: string,
+      ) => {
+        try {
+          const response = await apiClient.delete<{
+            success: boolean;
+            data: Dashboard["sharedWith"];
+          }>(
+            `/workspaces/${workspaceId}/dashboards/${dashboardId}/collaborators/${userId}`,
+          );
+          set(state => {
+            const d = state.openDashboards[dashboardId];
+            if (d) d.sharedWith = response?.data ?? [];
+          });
+          return { ok: true };
+        } catch (error) {
+          return {
+            ok: false,
+            error: error instanceof Error ? error.message : "Failed to remove",
+          };
         }
       },
 


### PR DESCRIPTION
## Summary

Lets dashboard owners (and workspace admins) grant **explicit edit access** to specific workspace members, independent of the private/workspace visibility setting. Previously a non-owner could only edit a dashboard if it was set to `workspace` access **and** they were a workspace admin — so there was no way to let a specific teammate co-edit a private dashboard.

Collaborators are stored as a `sharedWith` list and get full read + write. All gating flows through `DashboardManager.canRead`/`canWrite`, so the `readOnly` flag, edit/view toggle, grid drag/resize, save, and agent edit tools all light up automatically. The existing 5‑minute `editLock` still prevents two editors from clobbering each other.

Roles are **editor-only** for now (no viewer tier); the schema keeps a `role` field so a viewer tier can be added later without migration churn.

## Changes

**Backend**
- `workspace-schema.ts` — `sharedWith: [{ userId, role: "editor", addedAt, addedBy }]` on `IDashboard` + Mongoose schema + index `{ workspaceId, "sharedWith.userId" }`.
- Migration `2026-06-04-113137_dashboard_shared_with.ts` — backfills `sharedWith: []` and creates the index (idempotent).
- `dashboard-manager.ts` — `canRead`/`canWrite`/`classifyForUser` honor collaborators; `listDashboardsSplit` surfaces shared dashboards under the **Workspace** section for invited users.
- `dashboards.ts` — new routes (owner/admin gated for writes):
  - `GET /:id/collaborators` (any reader; emails joined from workspace members)
  - `POST /:id/collaborators` `{ userId }`
  - `DELETE /:id/collaborators/:userId`

**Frontend**
- `Dashboard` type gains `sharedWith`.
- `dashboardStore` — `shareDashboard` / `unshareDashboard` actions.
- New `DashboardShareDialog` — member autocomplete + "people with access" list (owner chip + removable editors).
- `DashboardCanvas` — **Share** button (shown to owner or workspace admin via `useIsWorkspaceAdmin`) in both view and edit modes.

## Deployment note

Run `pnpm migrate` before/at deploy. New docs are safe without it (all reads guard with `sharedWith || []`), but the backfill + index should land.

## Test plan

- [ ] Owner adds a member via Share → invited member sees the dashboard under **Workspace** and can enter edit mode
- [ ] Non-collaborator on a `private` dashboard still gets 403 / read-only
- [ ] Workspace admin can manage collaborators on a dashboard they don't own
- [ ] Non-owner/non-admin does not see the Share button and `POST /collaborators` returns 403
- [ ] Removing a collaborator revokes edit access (dashboard becomes read-only / hidden if private)
- [ ] `editLock` still blocks concurrent edits between two collaborators
- [ ] `pnpm migrate` runs cleanly and is idempotent on re-run

Made with [Cursor](https://cursor.com)