### PR TITLE
guides: ClickHouse SQL how-tos (Batch 8, day 1)

### DIFF
--- a/content/guides/clickhouse/aggregate-functions.mdx
+++ b/content/guides/clickhouse/aggregate-functions.mdx
@@ -1,0 +1,186 @@
+---
+title: "ClickHouse Aggregate Functions: Combinators, uniq, quantile, and groupArray"
+description: "How to use ClickHouse aggregate functions, including the -If/-Array/-State/-Merge combinators, approximate counting with uniq, quantiles, and groupArray for analytical queries."
+database: "clickhouse"
+category: "sql-how-to"
+tags: ["clickhouse", "sql", "aggregate-functions", "group-by", "analytics", "olap"]
+date: "2026-06-04"
+---
+
+# ClickHouse Aggregate Functions
+
+Aggregate functions collapse many rows into a single value per group. ClickHouse has the standard set (`count`, `sum`, `avg`, `min`, `max`) plus a large library of analytical aggregates and a combinator system that is unique among SQL databases. The combinators are what make ClickHouse aggregation expressive, so most of this guide is about them.
+
+## Sample Schema
+
+```sql
+CREATE TABLE events
+(
+    user_id     UInt32,
+    event_type  String,
+    country     String,
+    revenue     Decimal(10, 2),
+    ts          DateTime
+)
+ENGINE = MergeTree
+ORDER BY (country, ts);
+```
+
+## Standard Aggregates and GROUP BY
+
+```sql
+SELECT
+    country,
+    count()        AS event_count,
+    sum(revenue)   AS total_revenue,
+    avg(revenue)   AS avg_revenue,
+    max(ts)        AS last_event
+FROM events
+GROUP BY country
+HAVING event_count > 100
+ORDER BY total_revenue DESC;
+```
+
+`count()` (no argument) counts rows. `count(column)` counts non-NULL values of that column, the same as standard SQL. `HAVING` filters on the aggregated result; `WHERE` filters rows before aggregation. Put a predicate in `WHERE` whenever you can, because it runs first and processes less data.
+
+## The Combinator System
+
+A combinator is a suffix on an aggregate function name that changes how it behaves. You can stack them. This is the feature that separates ClickHouse aggregation from other engines, so it is worth learning well.
+
+### -If: Conditional Aggregation Without CASE
+
+The `-If` suffix adds a condition argument. The function only processes rows where the condition is true:
+
+```sql
+SELECT
+    country,
+    countIf(event_type = 'purchase')           AS purchases,
+    sumIf(revenue, event_type = 'purchase')     AS purchase_revenue,
+    avgIf(revenue, revenue > 0)                 AS avg_nonzero_revenue
+FROM events
+GROUP BY country;
+```
+
+This replaces the `sum(CASE WHEN ... THEN ... END)` pattern from standard SQL. It is shorter and the intent is clearer. You can compute many conditional metrics in a single pass over the data, which is exactly what you want for dashboards.
+
+### -Array: Aggregating Array Elements
+
+The `-Array` suffix applies the aggregate to each element of array-typed columns:
+
+```sql
+SELECT sumArray(scores) AS total_all_scores
+FROM (SELECT [10, 20, 30] AS scores);
+```
+
+This treats the array elements as if they were individual rows fed into `sum`.
+
+### -State and -Merge: Partial Aggregation
+
+This pair powers materialized views and incremental aggregation, and it is the reason ClickHouse can pre-aggregate at insert time.
+
+- A `-State` combinator returns an intermediate aggregation state instead of the final value. The state is a binary blob that can be stored.
+- A `-Merge` combinator takes those states and combines them into the final result.
+
+```sql
+-- Store intermediate states, typically in an AggregatingMergeTree table
+SELECT
+    country,
+    uniqState(user_id)   AS unique_users_state,
+    sumState(revenue)    AS revenue_state
+FROM events
+GROUP BY country;
+
+-- Later, merge the stored states into final answers
+SELECT
+    country,
+    uniqMerge(unique_users_state)  AS unique_users,
+    sumMerge(revenue_state)        AS total_revenue
+FROM aggregated_by_country
+GROUP BY country;
+```
+
+The point: you aggregate once at write time into states, then cheaply merge them at read time. A daily-rollup table built this way answers "unique users last month" by merging 30 daily states rather than rescanning raw events.
+
+## Approximate Counting: uniq and Friends
+
+Counting distinct values exactly is memory-intensive at scale. ClickHouse offers a family of distinct-count functions with different accuracy/cost tradeoffs:
+
+- `uniqExact(x)` is exact, like `count(DISTINCT x)`, and uses the most memory.
+- `uniq(x)` is approximate using an adaptive algorithm. It is the recommended default for large data, with a typical error around 0.5 to 2 percent.
+- `uniqHLL12(x)` uses HyperLogLog with fixed memory, useful when you need predictable memory bounds.
+- `uniqCombined(x)` balances accuracy and memory and is often a good middle choice.
+
+```sql
+SELECT
+    country,
+    uniq(user_id)       AS approx_unique_users,
+    uniqExact(user_id)  AS exact_unique_users
+FROM events
+GROUP BY country;
+```
+
+Use `uniq` unless you specifically need an exact count. On billions of rows the memory and speed difference is large, and a 1 percent error rarely changes a decision.
+
+## Quantiles and Percentiles
+
+```sql
+SELECT
+    country,
+    quantile(0.5)(revenue)   AS median_revenue,
+    quantile(0.95)(revenue)  AS p95_revenue,
+    quantiles(0.5, 0.9, 0.99)(revenue) AS p50_p90_p99
+FROM events
+GROUP BY country;
+```
+
+Note the two-part call syntax: `quantile(level)(column)`. The level is a parameter; the column is the argument. `quantile` is approximate. For an exact result use `quantileExact`, and for time-series latency data `quantileTiming` is optimized. `quantiles(...)` computes several levels in one pass, which is more efficient than several separate `quantile` calls.
+
+## groupArray and groupUniqArray
+
+`groupArray` collects values from a group into an array, which is ClickHouse's equivalent of PostgreSQL's `array_agg` or MySQL's `GROUP_CONCAT`:
+
+```sql
+SELECT
+    user_id,
+    groupArray(event_type)        AS event_sequence,
+    groupUniqArray(country)       AS countries_seen,
+    groupArray(10)(event_type)    AS first_10_events
+FROM events
+GROUP BY user_id;
+```
+
+`groupArray(N)(x)` caps the array at N elements, which protects you from a single huge group blowing up memory. `groupUniqArray` deduplicates. These are the building blocks for funnel and sessionization queries.
+
+## argMin and argMax
+
+These return the value of one column at the row where another column is minimal or maximal, in a single pass:
+
+```sql
+SELECT
+    country,
+    argMax(event_type, ts) AS most_recent_event,
+    argMin(event_type, ts) AS first_event
+FROM events
+GROUP BY country;
+```
+
+This avoids the subquery-and-join dance you would need in standard SQL to answer "what was the event type of the latest row per country".
+
+## Common Mistakes
+
+- **`count(DISTINCT x)` on huge tables.** Prefer `uniq(x)` unless you truly need an exact count.
+- **Wrong quantile syntax.** It is `quantile(0.95)(column)`, two sets of parentheses, not `quantile(column, 0.95)`.
+- **Filtering with `HAVING` when `WHERE` would do.** `WHERE` runs before aggregation and scans less data.
+- **Confusing `-State` output for a value.** A `-State` result is an intermediate blob and only becomes a number after a matching `-Merge`.
+
+When you are exploring an unfamiliar dataset, Mako's AI autocomplete can suggest the right combinator or quantile syntax as you type, which is helpful given how many aggregate variants ClickHouse exposes.
+
+## Related Guides
+
+- [ClickHouse Window Functions](/guides/clickhouse/window-functions) for per-row analytics that don't collapse groups.
+- [Import CSV to ClickHouse](/guides/import-csv-to-clickhouse) to load data for testing these queries.
+- [ClickHouse vs BigQuery](/guides/clickhouse-vs-bigquery) for choosing an analytical warehouse.
+
+---
+
+Mako connects to ClickHouse with AI-powered autocomplete for writing and exploring analytical queries. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/clickhouse/arrays.mdx
+++ b/content/guides/clickhouse/arrays.mdx
@@ -1,0 +1,186 @@
+---
+title: "ClickHouse Arrays: A Practical Guide"
+description: "Working with arrays in ClickHouse: building and indexing them, arrayJoin to unfold rows, the higher-order functions arrayMap/arrayFilter/arrayReduce with lambdas, the ARRAY JOIN clause, and the GROUP BY arrays produced by groupArray."
+database: "clickhouse"
+category: "sql-how-to"
+tags: ["clickhouse", "sql", "arrays", "arrayjoin", "higher-order-functions", "olap"]
+date: "2026-06-05"
+---
+
+# ClickHouse Arrays
+
+Arrays are a first-class data type in ClickHouse, not a bolt-on. Columns can be `Array(T)`, aggregate functions can return arrays, and a large family of functions transforms them in place. For analytical workloads this matters: storing a list of values in one row and processing it with vectorized array functions is often faster and tidier than normalizing into a second table. This guide covers building arrays, indexing them, unfolding them into rows, and the higher-order functions that do the real work.
+
+## Building and Indexing Arrays
+
+Create an array with the `array` function or the `[]` literal. Elements must share a common super-type; ClickHouse picks the smallest type that fits all of them.
+
+```sql
+SELECT [1, 2, 3] AS a, array('x', 'y') AS b;
+-- a: [1,2,3]   b: ['x','y']
+```
+
+Indexing is **1-based**, which trips up people coming from most programming languages. Negative indices count from the end.
+
+```sql
+SELECT
+    [10, 20, 30] AS a,
+    a[1]  AS first,   -- 10, not 20
+    a[-1] AS last;    -- 30
+```
+
+Out-of-bounds access returns the default value for the element type (0 for numbers, empty string for strings), not an error. Use `length(a)` to get the element count and `empty(a)` / `notEmpty(a)` to test for emptiness.
+
+```sql
+SELECT
+    length([10, 20, 30]) AS n,   -- 3
+    [1, 2, 3][99]        AS oob; -- 0  (no error)
+```
+
+`has(arr, x)`, `indexOf(arr, x)` (1-based, 0 if absent), and `hasAll` / `hasAny` cover membership tests:
+
+```sql
+SELECT
+    has([1, 2, 3], 2)        AS present,  -- 1
+    indexOf(['a','b'], 'b')  AS pos,      -- 2
+    hasAll([1,2,3,4], [2,4]) AS contains; -- 1
+```
+
+## arrayJoin: One Row Becomes Many
+
+`arrayJoin` is the workhorse for turning an array column into rows. Each element of the array produces a separate output row, with the rest of the row's columns duplicated.
+
+```sql
+SELECT
+    id,
+    arrayJoin([10, 20, 30]) AS value
+FROM (SELECT 1 AS id);
+-- (1, 10), (1, 20), (1, 30)
+```
+
+A common real case: an events table stores tags as `Array(String)` and you want one row per tag to count them.
+
+```sql
+SELECT
+    tag,
+    count() AS events
+FROM (
+    SELECT arrayJoin(tags) AS tag
+    FROM events
+)
+GROUP BY tag
+ORDER BY events DESC;
+```
+
+Two gotchas. First, if you reference `arrayJoin` more than once in a query, ClickHouse evaluates it once and reuses the result, which is rarely what you want; wrap it in a subquery if you need independent unfolds. Second, an empty array drops the row entirely (zero output rows for it). If you need to keep rows with empty arrays, the `LEFT ARRAY JOIN` clause below handles that.
+
+## The ARRAY JOIN Clause
+
+`ARRAY JOIN` is the clause form and is usually cleaner than `arrayJoin()` inside the SELECT list, especially when unfolding multiple arrays in parallel.
+
+```sql
+SELECT
+    id,
+    tag,
+    score
+FROM events
+ARRAY JOIN
+    tags  AS tag,
+    scores AS score;
+```
+
+When you join two arrays this way, they unfold **element by element in lockstep**, so `tags` and `scores` must have the same length per row. `LEFT ARRAY JOIN` keeps rows whose array is empty, emitting a single row with the default value instead of dropping it:
+
+```sql
+SELECT id, tag
+FROM events
+LEFT ARRAY JOIN tags AS tag;
+-- rows with empty tags still appear, with tag = ''
+```
+
+## Higher-Order Functions and Lambdas
+
+This is where arrays become expressive. `arrayMap`, `arrayFilter`, `arrayReduce`, and their relatives take a lambda written with the `->` syntax.
+
+`arrayMap` applies a function to every element:
+
+```sql
+SELECT arrayMap(x -> x * x, [1, 2, 3]) AS squared;
+-- [1,4,9]
+```
+
+`arrayFilter` keeps elements where the lambda returns nonzero:
+
+```sql
+SELECT arrayFilter(x -> x > 1, [1, 2, 3]) AS kept;
+-- [2,3]
+```
+
+Lambdas can take more than one array argument; the arrays are walked in parallel:
+
+```sql
+SELECT arrayMap((x, y) -> x + y, [1, 2, 3], [10, 20, 30]) AS summed;
+-- [11,22,33]
+```
+
+For every higher-order function except `arrayMap` and `arrayFilter`, the lambda can be omitted and identity mapping is assumed. Useful companions:
+
+- `arrayCount(x -> cond, arr)` counts matching elements.
+- `arrayExists(x -> cond, arr)` / `arrayAll(...)` return 0 or 1.
+- `arraySum`, `arrayMin`, `arrayMax`, `arrayAvg` reduce to a scalar, and each accepts an optional lambda to transform first: `arraySum(x -> x * 2, arr)`.
+- `arraySort` / `arrayReverseSort` accept an optional key lambda.
+
+```sql
+SELECT
+    arrayCount(x -> x > 100, prices)      AS expensive_items,
+    arraySum(x -> x * qty, prices)        AS would_not_work; -- see note
+```
+
+Note that a lambda only sees the array it iterates; it cannot reference a second array positionally unless that array is also passed as an argument. To combine `prices` and `quantities` element-wise, pass both:
+
+```sql
+SELECT arraySum((p, q) -> p * q, prices, quantities) AS revenue
+FROM orders;
+```
+
+`arrayReduce` applies a named **aggregate function** across the array's elements, which is how you reach functions that have no direct array form:
+
+```sql
+SELECT arrayReduce('uniqExact', ['a', 'b', 'a', 'c']) AS distinct_count;
+-- 3
+```
+
+## groupArray: Building Arrays in Aggregation
+
+The inverse of `arrayJoin` is `groupArray`, an aggregate function that collects values from a group into an array. `groupUniqArray` collects distinct values.
+
+```sql
+SELECT
+    user_id,
+    groupArray(product_id) AS products_viewed,
+    groupUniqArray(category) AS categories
+FROM events
+GROUP BY user_id;
+```
+
+`groupArray(N)(col)` caps the array at N elements. Combined with `arrayMap` and `arraySort`, this is a compact way to build per-group sequences (for example, the ordered list of pages in a session) without window functions.
+
+## Common Mistakes
+
+- **0-based indexing.** ClickHouse arrays start at index 1. `arr[0]` returns the type default, not the first element.
+- **Expecting an error on out-of-bounds.** It silently returns the default value. Guard with `length()` or `arrayElement` logic if that matters.
+- **Mismatched array lengths in `ARRAY JOIN`.** Parallel unfolds require equal lengths per row, or you get a runtime error.
+- **Empty arrays vanishing.** Plain `arrayJoin` / `ARRAY JOIN` drop rows with empty arrays. Use `LEFT ARRAY JOIN` to keep them.
+- **Trying to reference a sibling array inside a single-array lambda.** Pass every array the lambda needs as an explicit argument.
+
+When you are sketching out array transformations against an unfamiliar dataset, Mako's AI autocomplete can suggest the right higher-order function and lambda shape as you type, which helps given how many `array*` variants ClickHouse exposes.
+
+## Related Guides
+
+- [ClickHouse Aggregate Functions](/guides/clickhouse/aggregate-functions) for `groupArray` and the combinators that pair with arrays.
+- [ClickHouse JSON Queries](/guides/clickhouse/json-queries) since `JSONExtract` paths and arrays overlap.
+- [Import CSV to ClickHouse](/guides/import-csv-to-clickhouse) to load data for testing these queries.
+
+---
+
+Mako connects to ClickHouse with AI-powered autocomplete for writing and exploring analytical queries. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/clickhouse/choosing-data-types.mdx
+++ b/content/guides/clickhouse/choosing-data-types.mdx
@@ -1,0 +1,126 @@
+---
+title: "Choosing Data Types in ClickHouse for Compression and Speed"
+description: "How data type choice drives compression and query speed in ClickHouse. Covers right-sizing integers, LowCardinality dictionary encoding and when it helps, Enum vs LowCardinality, the real cost of Nullable, FixedString, Date vs DateTime sizing, and avoiding String for everything."
+database: "clickhouse"
+category: "sql-how-to"
+tags: ["clickhouse", "data-types", "lowcardinality", "compression", "schema-design", "olap"]
+date: "2026-06-08"
+---
+
+# Choosing Data Types in ClickHouse
+
+In an OLTP database the data type you pick is mostly about correctness. In ClickHouse it is also about money: type choice is one of the three biggest levers on compression, alongside the ordering key and codecs. Less data on disk means less I/O per query, and in a columnar engine that translates almost directly into query latency. This guide covers the type decisions that matter for an analytical schema and the traps that quietly bloat your storage.
+
+## Right-Size Your Integers
+
+ClickHouse offers `Int8/16/32/64/128/256` and unsigned `UInt8/16/32/64/128/256`. The numbers are bit widths, so `UInt8` holds 0 to 255 in one byte, `UInt32` holds up to ~4.3 billion in four bytes, and so on.
+
+Defaulting every integer to `Int64` because it is "safe" wastes bytes on every row. A status code that ranges 0 to 10 fits in `UInt8` and costs an eighth of what `UInt64` does before compression. Pick the smallest type that comfortably covers your range plus headroom:
+
+```sql
+CREATE TABLE pageviews (
+    user_id   UInt64,        -- genuinely large key space
+    status    UInt8,         -- 0..255 is plenty
+    duration  UInt16,        -- seconds, up to ~18 hours
+    bytes_out UInt32
+)
+ENGINE = MergeTree
+ORDER BY user_id;
+```
+
+Compression narrows the gap, since a column of small values in a wide type still compresses well, but it does not erase it. The narrower type also means less data decompressed and processed at query time, which compression does not help with.
+
+## Avoid String for Everything
+
+The most common schema mistake is storing everything as `String`: numbers, dates, enums, booleans. It works, and it is slow and large. Strings disable the semantics ClickHouse uses to filter and aggregate efficiently, and they compress worse than the typed equivalent. Store numbers as numeric types, timestamps as date/time types, and a fixed set of labels as `Enum` or `LowCardinality(String)`. The official best-practice guidance is blunt about this: use strict types, and reserve `String` for genuinely free-form text.
+
+## LowCardinality: Dictionary Encoding
+
+`LowCardinality(T)` changes the internal representation of a column to dictionary encoding. Instead of storing the full value in every row, ClickHouse keeps a dictionary of distinct values and stores a small integer index per row. For a column with few distinct values relative to its row count, this is a large win on both storage and query speed.
+
+```sql
+CREATE TABLE logs (
+    ts        DateTime,
+    level     LowCardinality(String),   -- 'info', 'warn', 'error', ...
+    service   LowCardinality(String),   -- a few dozen service names
+    message   String                    -- free-form, NOT LowCardinality
+)
+ENGINE = MergeTree
+ORDER BY ts;
+```
+
+The rule of thumb from ClickHouse's own guidance: `LowCardinality` pays off when a column has fewer than roughly 10,000 distinct values. Below that, the dictionary stays small and the integer indices compress beautifully. Above it, the dictionary itself grows large and you lose the benefit, sometimes making things worse than a plain `String`.
+
+`LowCardinality` wraps `String`, `FixedString`, `Date`, `DateTime`, and numeric types (except `Decimal`). Wrapping a high-cardinality column, or a type where it does not help, is exactly what the `allow_suspicious_low_cardinality_types` setting is there to discourage. Do not wrap a `user_id` or a free-text `message`.
+
+## Enum vs LowCardinality(String)
+
+Both handle a small set of recurring string labels. The difference is whether the set is fixed.
+
+`Enum8` / `Enum16` store an explicit, closed mapping of string to integer defined in the schema:
+
+```sql
+status Enum8('active' = 1, 'churned' = 2, 'trial' = 3)
+```
+
+This is the most compact option (one or two bytes per row, no separate dictionary) and it enforces the allowed values: inserting a label not in the enum is an error. The cost is rigidity. Adding a new label requires an `ALTER TABLE ... MODIFY COLUMN`, which means you must know the full set up front and accept schema changes to extend it.
+
+`LowCardinality(String)` is the pragmatic default when the set is stable but not strictly fixed: it gets most of the storage benefit, accepts new values without a schema change, and does not make you maintain an explicit mapping. Reach for `Enum` when the set is genuinely closed and you want the database to reject anything else (a state machine, a small fixed taxonomy). Reach for `LowCardinality(String)` when the set is small and slow-changing but you would rather not run a migration every time it grows.
+
+## The Real Cost of Nullable
+
+`Nullable(T)` is convenient and not free. ClickHouse implements it by storing a separate bitmap column alongside the data to mark which rows are NULL. That is extra storage and an extra read, and it blocks some optimizations. Wrapping every column in `Nullable` "just in case" is a measurable tax.
+
+Often you do not need it. If a sensible default carries the same meaning as "missing" for your queries, use the default instead:
+
+```sql
+-- Instead of: referrer Nullable(String)
+referrer String DEFAULT ''      -- empty string means "no referrer"
+
+-- Instead of: score Nullable(Int32)
+score Int32 DEFAULT 0           -- if 0 is unambiguous in your domain
+```
+
+Use `Nullable` when NULL is semantically distinct from any default value and you actually query for it (for example, "find rows where the measurement was never taken," where 0 is a legitimate measurement). Otherwise prefer a default and keep the column non-nullable.
+
+## FixedString: Only When Truly Fixed
+
+`FixedString(N)` stores exactly N bytes per value, padding shorter values with null bytes. It is the right choice for values that are genuinely a fixed width: a two-letter country code (`FixedString(2)`), a currency code, a hash of known length. For anything variable-length, plain `String` is better, because `FixedString` pads to the maximum and the padding wastes space and can leak into comparisons if you are not careful. The guidance: use `FixedString` only when the column values are strictly fixed-length.
+
+## Dates and Times
+
+`Date` is two bytes and covers day granularity to 2149. `Date32` extends the range at four bytes. `DateTime` is four bytes at second resolution; `DateTime64(precision)` adds sub-second precision at the cost of more bytes. Pick the coarsest resolution your queries need. If you only ever group by day, storing full `DateTime64(9)` nanosecond timestamps wastes bytes on precision you discard. See the [ClickHouse date functions guide](/guides/clickhouse/date-functions) for working with these once chosen.
+
+## A Worked Schema
+
+Putting it together for an events table:
+
+```sql
+CREATE TABLE events (
+    event_time DateTime,                              -- second resolution is enough
+    event_date Date DEFAULT toDate(event_time),       -- cheap, used in PARTITION BY
+    user_id    UInt64,                                -- large key space
+    event_type LowCardinality(String),               -- dozens of types, may grow
+    country    FixedString(2),                        -- ISO code, fixed width
+    status     Enum8('ok' = 1, 'fail' = 2),           -- closed set
+    latency_ms UInt32,                                -- right-sized
+    error_msg  String DEFAULT ''                      -- free text, '' means none
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(event_date)
+ORDER BY (event_type, user_id, event_time);
+```
+
+Every choice here is a storage decision: small integers where the range allows, dictionary encoding for repeating labels, a fixed-width type for the country code, an enum for the closed status set, and defaults instead of `Nullable`. None of it changes what the table can do; all of it changes what it costs.
+
+When you are profiling an existing schema, Mako's AI autocomplete can help you write the introspection queries against `system.columns` and `system.parts` to see compressed-vs-uncompressed sizes per column before deciding what to retype.
+
+## Related Guides
+
+- [ClickHouse MergeTree Table Engines](/guides/clickhouse/mergetree-engines) since the ordering key works with types to drive compression.
+- [ClickHouse Data Skipping Indexes](/guides/clickhouse/data-skipping-indexes) which depend on well-chosen types to be effective.
+- [Import CSV to ClickHouse](/guides/import-csv-to-clickhouse) where schema inference picks types you will often want to tighten.
+
+---
+
+Mako connects to ClickHouse with AI-powered autocomplete for writing and exploring analytical queries. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/clickhouse/cte.mdx
+++ b/content/guides/clickhouse/cte.mdx
@@ -1,0 +1,149 @@
+---
+title: "Common Table Expressions (CTEs) in ClickHouse"
+description: "How the WITH clause works in ClickHouse: scalar expressions, named subquery CTEs, the inlining-by-default behavior that catches people out, materialized CTEs, and recursive CTEs for hierarchical data."
+database: "clickhouse"
+category: "sql-how-to"
+tags: ["clickhouse", "sql", "cte", "with-clause", "recursive-queries", "olap"]
+date: "2026-06-05"
+---
+
+# Common Table Expressions in ClickHouse
+
+The `WITH` clause in ClickHouse does three related jobs: it defines scalar constants, it names subqueries (the classic CTE), and since version 24.4 it supports recursive queries. The syntax looks like standard SQL, but the default execution model differs from PostgreSQL in a way that affects performance, so it pays to understand what actually happens when you reference a CTE.
+
+## Scalar Expressions
+
+The simplest form binds a value or a single-row, single-column query result to a name. This is closer to a variable than to a temporary table.
+
+```sql
+WITH 7 AS days_back
+SELECT *
+FROM events
+WHERE event_date >= today() - days_back;
+```
+
+A scalar subquery works the same way and is evaluated once:
+
+```sql
+WITH (SELECT max(event_date) FROM events) AS last_day
+SELECT count()
+FROM events
+WHERE event_date = last_day;
+```
+
+Note the order: in ClickHouse the alias comes after the expression (`WITH expr AS name`), which is the opposite of the named-subquery form below. Both forms are valid and can appear in the same `WITH` clause.
+
+## Named Subqueries (the standard CTE)
+
+This is the form most people mean by "CTE": a named result set you reference like a table.
+
+```sql
+WITH recent_orders AS (
+    SELECT customer_id, sum(amount) AS total
+    FROM orders
+    WHERE order_date >= today() - 30
+    GROUP BY customer_id
+)
+SELECT customer_id, total
+FROM recent_orders
+WHERE total > 1000
+ORDER BY total DESC;
+```
+
+Here the alias comes first (`name AS (subquery)`), matching ANSI SQL. You can chain several CTEs, and a later one can reference an earlier one:
+
+```sql
+WITH
+    active AS (
+        SELECT user_id FROM sessions WHERE session_date = today()
+    ),
+    enriched AS (
+        SELECT u.user_id, u.country
+        FROM users AS u
+        WHERE u.user_id IN (SELECT user_id FROM active)
+    )
+SELECT country, count() AS active_users
+FROM enriched
+GROUP BY country;
+```
+
+## The Inlining Gotcha
+
+This is the part that surprises people coming from PostgreSQL. By default, ClickHouse does **not** compute a CTE once and reuse the result. Every reference to the CTE is replaced by its underlying subquery before execution. If you reference a CTE twice, its subquery runs twice.
+
+```sql
+WITH heavy AS (
+    SELECT user_id, count() AS n
+    FROM huge_events
+    GROUP BY user_id
+)
+-- 'heavy' is expanded into BOTH sides of this join,
+-- so the aggregation over huge_events runs twice.
+SELECT a.user_id, a.n, b.n
+FROM heavy AS a
+INNER JOIN heavy AS b ON a.user_id = b.user_id;
+```
+
+For a cheap subquery this is fine. For an expensive aggregation referenced multiple times, it doubles the work. The historical workaround was to push the subquery into a temporary table or a separate query. Recent versions also offer materialized CTEs (below) to avoid recomputation.
+
+## Materialized CTEs
+
+ClickHouse can materialize a CTE so it is computed once and the result reused across references. Support arrived in recent releases and is controlled by a setting rather than always-on, so confirm behavior on your version before relying on it. When available, materialization is the right choice for an expensive CTE referenced more than once; for a CTE referenced a single time, inlining is usually as good or better because it lets the optimizer push predicates into the subquery.
+
+The practical rule: inline (default) when the CTE is referenced once or is cheap; materialize when it is expensive and referenced multiple times.
+
+## Recursive CTEs
+
+Recursive CTEs landed in ClickHouse 24.4, built on the query analyzer that is enabled by default in current versions. The syntax is standard SQL: a non-recursive anchor term, `UNION ALL`, then a recursive term that references the CTE by name.
+
+```sql
+WITH RECURSIVE numbers AS (
+    SELECT 1 AS n               -- anchor
+    UNION ALL
+    SELECT n + 1                -- recursive step
+    FROM numbers
+    WHERE n < 10
+)
+SELECT n FROM numbers;
+-- 1, 2, ... 10
+```
+
+The common real-world use is walking a hierarchy, such as an org chart or a category tree stored as `(id, parent_id)`:
+
+```sql
+WITH RECURSIVE subtree AS (
+    SELECT id, parent_id, name, 1 AS depth
+    FROM categories
+    WHERE id = 100              -- start node
+
+    UNION ALL
+
+    SELECT c.id, c.parent_id, c.name, s.depth + 1
+    FROM categories AS c
+    INNER JOIN subtree AS s ON c.parent_id = s.id
+)
+SELECT id, name, depth
+FROM subtree
+ORDER BY depth, id;
+```
+
+A recursive CTE executes the anchor once, then repeats the recursive step against the rows produced by the previous iteration until no new rows appear. Guard against infinite loops on cyclic data with a depth limit in the `WHERE` clause, since ClickHouse will keep iterating otherwise.
+
+## Common Mistakes
+
+- **Expecting CTEs to be materialized by default.** They are inlined. A CTE referenced three times runs its subquery three times unless you explicitly materialize it or use a temporary table.
+- **Mixing up the two alias orders.** Scalar expressions are `WITH expr AS name`; named subqueries are `WITH name AS (subquery)`. Both can coexist, but swapping them is a syntax error.
+- **Running recursive CTEs on an old version.** They require 24.4 or later and the query analyzer. On older builds the `RECURSIVE` keyword is not recognized.
+- **No termination condition.** A recursive term with no bound, or one run over a graph with cycles, never stops. Always cap depth or detect already-visited nodes.
+
+When you are drafting a multi-stage `WITH` chain or a recursive traversal against an unfamiliar schema, Mako's AI autocomplete can suggest the join shape and the recursive step as you type, which helps given how easy it is to get the anchor-vs-recursive split wrong.
+
+## Related Guides
+
+- [ClickHouse Joins Guide](/guides/clickhouse/joins-guide) for the join strictness used inside recursive steps.
+- [ClickHouse Aggregate Functions](/guides/clickhouse/aggregate-functions) for the aggregations CTEs commonly wrap.
+- [ClickHouse Window Functions](/guides/clickhouse/window-functions) as an alternative to self-referencing CTEs for running totals and rankings.
+
+---
+
+Mako connects to ClickHouse with AI-powered autocomplete for writing and exploring analytical queries. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/clickhouse/data-skipping-indexes.mdx
+++ b/content/guides/clickhouse/data-skipping-indexes.mdx
@@ -1,0 +1,123 @@
+---
+title: "ClickHouse Data Skipping Indexes: minmax, set, and Bloom Filters"
+description: "How ClickHouse data skipping indexes work, the five index types (minmax, set, bloom_filter, ngrambf_v1, tokenbf_v1), how GRANULARITY controls the index block size, when a skip index actually helps, and the correlation rule that decides whether it skips anything at all."
+database: "clickhouse"
+category: "sql-how-to"
+tags: ["clickhouse", "data-skipping-indexes", "minmax", "bloom-filter", "performance", "olap"]
+date: "2026-06-08"
+---
+
+# ClickHouse Data Skipping Indexes
+
+ClickHouse has no row-level secondary index like the B-tree indexes in PostgreSQL or MySQL. A column-oriented engine stores no individual rows on disk to point at, so the classic "index this column for fast lookups" model does not apply. Instead, ClickHouse offers *data skipping indexes*: secondary structures that store a small summary of each block of rows, so the query engine can skip blocks that cannot possibly match a `WHERE` condition.
+
+Understanding the difference matters, because a skip index that is configured against the wrong data distribution does nothing useful, and the symptom is silent: the query still returns correct results, just without skipping any data.
+
+## The Granule Model
+
+A MergeTree table is divided into *granules*, each 8192 rows by default (set by `index_granularity`). The sparse primary index stores one mark per granule. When a query filters on the primary key, ClickHouse uses those marks to read only the granules that can contain matching rows.
+
+A data skipping index sits one level above the granules. Its `GRANULARITY` setting says how many primary-index granules each skip-index block covers. With `GRANULARITY 4` and the default 8192-row granules, each skip-index entry summarizes 4 × 8192 = 32768 rows. For each such block the index stores a compact summary (a min/max pair, a small value set, or a Bloom filter). At query time, ClickHouse checks the summary first; if the block cannot match, it skips all of those granules without reading the column data.
+
+This is the key mental model: a skip index does not find matching rows. It rules out blocks that definitely do not match. Everything else gets read and filtered normally.
+
+## The Correlation Rule
+
+A skip index only helps when the indexed values are physically clustered on disk, which in practice means correlated with the table's `ORDER BY` key.
+
+If you index a column whose values are scattered uniformly across every block (for example, a random UUID), every block's summary will say "this value might be here," nothing gets skipped, and you have paid for an index that only adds write overhead. If instead the column changes slowly relative to the sort order (a status that stays constant for long runs of rows, a timestamp that broadly tracks the primary key), the per-block summaries are tight and ClickHouse can discard large ranges.
+
+Before adding a skip index, ask: within a single block of ~32k consecutive rows, how many distinct values does this column have? Few distinct values per block means the index will work. Roughly all distinct means it will not.
+
+## The Five Index Types
+
+### minmax
+
+Stores the minimum and maximum of the indexed expression per block. ClickHouse skips a block when the filter range falls entirely outside `[min, max]`.
+
+```sql
+ALTER TABLE events
+    ADD INDEX idx_price minmax(price) GRANULARITY 4;
+```
+
+Best for numeric or date columns whose values move monotonically or in slow runs relative to the sort key. It is cheap to store and the first thing to reach for on range filters (`>`, `<`, `BETWEEN`).
+
+### set
+
+Stores up to N distinct values per block (`set(N)`). A block is skipped if none of the filter's values appear in the stored set. `set(0)` stores an unbounded set, which only makes sense when the per-block cardinality is genuinely small.
+
+```sql
+ALTER TABLE events
+    ADD INDEX idx_country set(100) GRANULARITY 4;
+```
+
+Best for low-cardinality columns used with equality or `IN` filters, where each block holds only a handful of distinct values. If a block exceeds N distinct values, the set for that block is dropped and it can no longer be skipped.
+
+### bloom_filter
+
+Stores a Bloom filter of the indexed values per block, giving probabilistic membership tests with a tunable false-positive rate (default 0.025).
+
+```sql
+ALTER TABLE events
+    ADD INDEX idx_tag bloom_filter(0.01) GRANULARITY 4;
+```
+
+Best for higher-cardinality columns tested with equality or `IN`, including array `has()` checks. A Bloom filter can report a false positive (read a block that turns out not to match) but never a false negative (it will not skip a block that does match), so correctness is preserved. It works on columns where `set` would overflow.
+
+### ngrambf_v1
+
+A Bloom filter over n-grams of string data, for substring matching with `LIKE '%...%'` and similar.
+
+```sql
+ALTER TABLE logs
+    ADD INDEX idx_msg ngrambf_v1(4, 65536, 3, 0) GRANULARITY 4;
+```
+
+The parameters are n-gram size, filter size in bytes, number of hash functions, and a seed. Tuning these wrong is the usual reason an ngram index skips nothing: too small a filter size for the block's cardinality saturates the Bloom filter so every block reports a possible match.
+
+### tokenbf_v1
+
+A Bloom filter over whole tokens (split on non-alphanumeric characters) rather than n-grams, for word-level matching with functions like `hasToken`.
+
+```sql
+ALTER TABLE logs
+    ADD INDEX idx_words tokenbf_v1(30720, 3, 0) GRANULARITY 4;
+```
+
+Parameters are filter size, hash count, and seed. Use it for whole-word search where you do not need arbitrary substrings; it is smaller and faster than an n-gram filter for that case. For full-text needs, newer ClickHouse versions also offer a dedicated `text` index, which is purpose-built for tokenized full-text search and worth checking before hand-tuning a `tokenbf_v1`.
+
+## Verifying That a Skip Index Works
+
+Adding the index does not retroactively index existing parts. Build it for current data with:
+
+```sql
+ALTER TABLE events MATERIALIZE INDEX idx_price;
+```
+
+New inserts index themselves automatically. To confirm an index is actually skipping data, read the query plan with the indexes flag:
+
+```sql
+EXPLAIN indexes = 1
+SELECT count() FROM events WHERE price > 9000;
+```
+
+The output lists each index and shows granules before and after it was applied. If the "after" count equals the "before" count, the index skipped nothing, and the cause is almost always the correlation rule: the indexed column is not clustered enough within blocks. Either change the table's `ORDER BY` so the column clusters, lower `GRANULARITY` so each block covers fewer rows (tighter summaries, more index overhead), or accept that a skip index is not the right tool for that filter.
+
+## Common Mistakes
+
+- **Treating a skip index like a B-tree.** It does not speed up point lookups on scattered data. If the column is uncorrelated with the sort order, it will not skip anything.
+- **Indexing a column that is already the primary key.** The sparse primary index already handles it; a skip index adds nothing.
+- **Forgetting to materialize.** Existing parts stay unindexed until `MATERIALIZE INDEX` runs.
+- **Under-sizing a Bloom filter.** A saturated filter reports every block as a possible match, silently disabling skipping.
+
+When you are testing whether a skip index actually changes the granule count, Mako's AI autocomplete can help you draft the `EXPLAIN indexes = 1` queries and compare plans as you tune `GRANULARITY`.
+
+## Related Guides
+
+- [ClickHouse Partitioning](/guides/clickhouse/partitioning) for the coarser, partition-level pruning that complements skip indexes.
+- [ClickHouse MergeTree Table Engines](/guides/clickhouse/mergetree-engines) for the granule and parts model these indexes build on.
+- [ClickHouse String Functions](/guides/clickhouse/string-functions) for the substring and token operations that pair with ngram and token Bloom filters.
+
+---
+
+Mako connects to ClickHouse with AI-powered autocomplete for writing and exploring analytical queries. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/clickhouse/date-functions.mdx
+++ b/content/guides/clickhouse/date-functions.mdx
@@ -1,0 +1,211 @@
+---
+title: "ClickHouse Date and Time Functions: A Practical Guide"
+description: "How to work with dates and times in ClickHouse: truncation with toStartOf*, dateDiff and date arithmetic, formatting and parsing, time zones, and the rounding gotchas that catch newcomers."
+database: "clickhouse"
+category: "sql-how-to"
+tags: ["clickhouse", "sql", "dates", "datetime", "timezones", "olap"]
+date: "2026-06-05"
+---
+
+# ClickHouse Date and Time Functions
+
+ClickHouse stores time in a few related types and gives you a large family of functions to truncate, shift, difference, format, and parse them. This guide covers the functions you reach for most, the time-zone rules that decide what the numbers mean, and the rounding behavior that surprises people coming from PostgreSQL or MySQL.
+
+## The Types First
+
+The functions only make sense once you know what they operate on.
+
+- `Date`: a day, stored as days since the Unix epoch. Range 1970-01-01 to 2149-06-06.
+- `Date32`: a wider day type, range 1900-01-01 to 2299-12-31.
+- `DateTime`: second precision, stored as a Unix timestamp (UTC) plus an optional time-zone attribute.
+- `DateTime64(P)`: sub-second precision, where `P` is the number of fractional digits (3 = milliseconds, 6 = microseconds, 9 = nanoseconds).
+
+A `DateTime` value is a UTC instant. The time zone attached to a column or returned by a function only changes how that instant is displayed and decomposed, not what is stored. That single fact explains most time-zone confusion below.
+
+```sql
+CREATE TABLE events
+(
+    event_id  UInt64,
+    user_id   UInt32,
+    ts        DateTime,            -- UTC instant
+    ts_ms     DateTime64(3)        -- millisecond precision
+)
+ENGINE = MergeTree ORDER BY ts;
+```
+
+## Current Time
+
+```sql
+SELECT
+    now(),                 -- DateTime, second precision
+    now64(3),              -- DateTime64(3), millisecond precision
+    today(),               -- Date for the current day
+    yesterday(),           -- Date for the previous day
+    toUnixTimestamp(now()); -- seconds since epoch as UInt32
+```
+
+For SQL-standard compatibility, `now`, `today`, `CURRENT_TIMESTAMP`, and `CURRENT_DATE` can be written without parentheses. `now()` evaluates once per query, so two references in the same statement return the same value.
+
+## Truncating with toStartOf*
+
+Truncation is the workhorse of analytics: it buckets rows into days, weeks, or months for grouping. ClickHouse exposes one function per granularity rather than a single `DATE_TRUNC`.
+
+```sql
+SELECT
+    toStartOfMinute(ts)   AS minute,
+    toStartOfHour(ts)     AS hour,
+    toStartOfDay(ts)      AS day,
+    toStartOfWeek(ts)     AS week,    -- Sunday by default
+    toMonday(ts)          AS iso_week,-- week starting Monday
+    toStartOfMonth(ts)    AS month,
+    toStartOfQuarter(ts)  AS quarter,
+    toStartOfYear(ts)     AS year
+FROM events;
+```
+
+`toStartOfWeek` takes an optional mode argument controlling which day starts the week and how the first week is numbered, following the same mode table as `toWeek`. If you want ISO weeks starting Monday, `toMonday` is the direct route.
+
+For arbitrary intervals, `toStartOfInterval` is the general form:
+
+```sql
+-- Bucket into 15-minute windows
+SELECT
+    toStartOfInterval(ts, INTERVAL 15 MINUTE) AS bucket,
+    count() AS events
+FROM events
+GROUP BY bucket
+ORDER BY bucket;
+
+-- Five-minute and three-hour buckets work the same way
+SELECT toStartOfInterval(ts, INTERVAL 3 HOUR) FROM events;
+```
+
+`toStartOfInterval` aligns buckets to a fixed origin (1970-01-01 for most units), so a 15-minute bucket always lands on :00, :15, :30, :45. That is usually what you want, but it means you cannot shift the phase without an explicit `origin` argument (supported in recent versions) or manual arithmetic.
+
+## Extracting Parts
+
+```sql
+SELECT
+    toYear(ts),
+    toMonth(ts),
+    toDayOfMonth(ts),
+    toDayOfWeek(ts),     -- 1 = Monday ... 7 = Sunday by default
+    toHour(ts),
+    toMinute(ts),
+    toSecond(ts),
+    toDayOfYear(ts),
+    toQuarter(ts)
+FROM events;
+```
+
+`toDayOfWeek` accepts a mode argument if you need Sunday-first or 0-based numbering. Always check the mode rather than assuming, because the default (Monday = 1) differs from MySQL's `DAYOFWEEK` (Sunday = 1).
+
+## Date Arithmetic
+
+Add or subtract intervals with `dateAdd` / `dateSub`, or use the `INTERVAL` keyword directly:
+
+```sql
+SELECT
+    dateAdd(DAY, 7, ts)        AS plus_one_week,
+    dateSub(MONTH, 1, ts)      AS minus_one_month,
+    ts + INTERVAL 30 MINUTE    AS plus_30_min,
+    ts - INTERVAL 1 YEAR       AS one_year_ago
+FROM events;
+```
+
+`addDays`, `addWeeks`, `addMonths`, `subtractHours`, and the rest of the family are shorthands for the same thing and read a little cleaner:
+
+```sql
+SELECT addMonths(ts, 3), subtractDays(ts, 14) FROM events;
+```
+
+Month and year arithmetic clamps to the end of the month, so adding one month to January 31 gives the last day of February rather than overflowing into March.
+
+## Differences with dateDiff
+
+`dateDiff` returns the number of crossed unit boundaries between two values, not a rounded elapsed duration:
+
+```sql
+SELECT
+    dateDiff('day',    toDate('2026-01-01'), toDate('2026-03-15')) AS days,   -- 73
+    dateDiff('month',  toDate('2026-01-31'), toDate('2026-02-01')) AS months, -- 1
+    dateDiff('second', toDateTime('2026-01-01 23:59:59'),
+                       toDateTime('2026-01-02 00:00:01'))          AS seconds; -- 2
+```
+
+The `month` example is the trap: one day apart, but it crosses a month boundary, so the answer is 1. If you need true elapsed time, difference in the smallest unit (`second` or `day`) and divide. `age` is the inverse mindset, returning the elapsed unit count without counting partially crossed boundaries the same way; check your version's docs for the exact rounding before relying on either across month boundaries.
+
+## Formatting and Parsing
+
+`formatDateTime` turns a value into a string using MySQL-style format codes:
+
+```sql
+SELECT
+    formatDateTime(ts, '%Y-%m-%d %H:%M:%S') AS iso_like,
+    formatDateTime(ts, '%d/%m/%Y')          AS european,
+    formatDateTime(ts, '%Y-W%V')            AS iso_week_label
+FROM events;
+```
+
+There is also `formatDateTimeInJodaSyntax` if you prefer Joda/Java patterns. Going the other direction, you have several parsers depending on how strict and how fast you need to be:
+
+```sql
+-- Strict, format-string driven (MySQL-style codes)
+SELECT parseDateTime('15/06/2026 14:30:00', '%d/%m/%Y %H:%M:%S');
+
+-- Best-effort: handles many common formats, returns 1970-01-01 on failure
+SELECT parseDateTimeBestEffort('2026-06-15T14:30:22Z');
+
+-- Best-effort variant that returns NULL instead of the epoch on failure
+SELECT parseDateTimeBestEffortOrNull('not a date');
+
+-- Packed numeric dates
+SELECT YYYYMMDDToDate(20260615);
+
+-- Unix timestamps
+SELECT fromUnixTimestamp(1781000000);
+```
+
+`parseDateTimeBestEffort` is convenient for messy ingestion, but it silently maps unparseable input to `1970-01-01`, which can hide bad data. The `OrNull` variant is safer in pipelines because a `NULL` is easy to filter and count.
+
+## Time Zones
+
+This is where instinct from other databases fails. A `DateTime` is a UTC instant; the time zone only controls display and decomposition.
+
+```sql
+SELECT
+    toDateTime('2016-06-15 23:00:00')                          AS server_local,
+    toTimeZone(toDateTime('2016-06-15 23:00:00', 'UTC'),
+               'Asia/Yekaterinburg')                           AS yekat;
+```
+
+`toTimeZone` does not move the instant in time; it returns the same instant labeled in a different zone, which changes the wall-clock fields you then extract. So `toHour(toTimeZone(ts, 'America/New_York'))` gives the New York hour for the same underlying moment. If your `GROUP BY toStartOfDay(ts)` produces day boundaries that look shifted, the cause is almost always the session or column time zone, not the function.
+
+You can pin the zone explicitly on parse so results are reproducible regardless of server settings:
+
+```sql
+SELECT toStartOfDay(toTimeZone(ts, 'Europe/Zurich')) AS zurich_day
+FROM events
+GROUP BY zurich_day;
+```
+
+## Common Mistakes
+
+- **Reading `dateDiff('month', ...)` as elapsed months.** It counts boundary crossings. One day apart can return 1.
+- **Assuming `toTimeZone` shifts the timestamp.** It relabels the same instant; the stored UTC value never changes.
+- **Trusting `parseDateTimeBestEffort` on dirty data.** Failures become `1970-01-01`. Use the `OrNull` variant and filter.
+- **Forgetting the week mode.** `toStartOfWeek` defaults to Sunday; use `toMonday` for ISO weeks.
+- **Mixing `Date` and `DateTime` in arithmetic.** Adding `INTERVAL 1 HOUR` to a `Date` promotes it to `DateTime`; know which type your column actually is before grouping on it.
+
+When you are exploring an unfamiliar dataset and cannot remember whether the column is `DateTime` or `DateTime64`, Mako's AI autocomplete suggests the matching functions as you type, which shortens the trial-and-error loop on time-zone and truncation queries.
+
+## Related Guides
+
+- [ClickHouse Aggregate Functions](/guides/clickhouse/aggregate-functions)
+- [ClickHouse Window Functions](/guides/clickhouse/window-functions)
+- [ClickHouse JOINs](/guides/clickhouse/joins-guide)
+- [ClickHouse JSON Queries](/guides/clickhouse/json-queries)
+
+---
+
+Mako connects to ClickHouse with AI-powered autocomplete for queries like these. Try it free at mako.ai.

--- a/content/guides/clickhouse/dictionaries.mdx
+++ b/content/guides/clickhouse/dictionaries.mdx
@@ -1,0 +1,126 @@
+---
+title: "ClickHouse Dictionaries: A Practical Guide"
+description: "How dictionaries work in ClickHouse: creating them with CREATE DICTIONARY, the dictGet family of lookup functions, choosing a layout (flat, hashed, complex_key_hashed, range_hashed, cache, direct), and using a dictionary as a fast alternative to JOIN."
+database: "clickhouse"
+category: "sql-how-to"
+tags: ["clickhouse", "sql", "dictionaries", "dictget", "joins", "olap"]
+date: "2026-06-05"
+---
+
+# ClickHouse Dictionaries
+
+A dictionary in ClickHouse is an in-memory key-value lookup table, kept loaded and refreshed from a source you define. The point is latency: looking up an attribute by key with `dictGet` avoids the cost of a `JOIN` against a regular table, because the data is already indexed in memory by the key. Dictionaries are most useful for enriching wide fact tables with reference data (currency names, country codes, product attributes) and for replacing repeated lookup joins.
+
+## Creating a Dictionary
+
+You declare a dictionary with `CREATE DICTIONARY`, specifying its columns, the primary key, a source, a layout, and a lifetime (refresh interval).
+
+```sql
+CREATE DICTIONARY currencies_dict
+(
+    currency_id UInt64,
+    code        String,
+    name        String,
+    country     String
+)
+PRIMARY KEY currency_id
+SOURCE(CLICKHOUSE(TABLE 'currencies' DB 'reference'))
+LAYOUT(FLAT())
+LIFETIME(MIN 300 MAX 600);
+```
+
+The `SOURCE` can be another ClickHouse table, an external relational database (MySQL, PostgreSQL, MS SQL), a file, an HTTP endpoint, MongoDB, Redis, and more. `LIFETIME` controls how often the dictionary reloads from its source; a range like `MIN 300 MAX 600` reloads somewhere between 5 and 10 minutes to spread out reload load across replicas. Set `LIFETIME(0)` to disable automatic updates.
+
+## Looking Up Values with dictGet
+
+`dictGet` is the core function: give it the dictionary name, the attribute you want, and the key.
+
+```sql
+SELECT
+    order_id,
+    dictGet('currencies_dict', 'code', currency_id)    AS code,
+    dictGet('currencies_dict', 'name', currency_id)    AS name
+FROM orders;
+```
+
+There is a family of related functions:
+
+- `dictGetOrDefault('dict', 'attr', key, default)` returns a fallback when the key is missing, instead of the attribute's type default.
+- `dictGetOrNull('dict', 'attr', key)` returns `NULL` for a missing key.
+- `dictHas('dict', key)` tests whether a key exists.
+- `dictGetHierarchy`, `dictIsIn` work with hierarchical dictionaries (parent-child keys).
+
+Typed variants like `dictGetString` or `dictGetUInt64` exist, but the generic `dictGet` infers the return type from the dictionary definition and is the form to prefer.
+
+For composite keys, pass a tuple as the key:
+
+```sql
+SELECT dictGet('geo_dict', 'region', (country_code, city_id))
+FROM visits;
+```
+
+## Choosing a Layout
+
+The layout decides how the dictionary is stored in memory, trading RAM against lookup speed and key flexibility. The common choices:
+
+- **flat** -- data in flat arrays indexed by the key. Fastest lookups, but the key must be `UInt64` and stay below a bounded maximum. Best for small-to-medium integer-keyed reference tables.
+- **hashed** -- a hash table. No practical key-size limit, supports large numbers of elements, slightly slower than flat. The general-purpose default for single integer keys.
+- **sparse_hashed** -- like `hashed` but trades CPU for lower memory. Use when memory is tight and the dictionary is large.
+- **complex_key_hashed** -- `hashed` for composite (tuple) keys, e.g. `(country, city)`.
+- **range_hashed** -- supports lookups by key plus a date or numeric range, for slowly-changing reference data such as exchange rates valid over date ranges.
+- **hashed_array** -- attributes in arrays with a hash table mapping keys to indices. Memory-efficient when a dictionary has many attributes.
+- **cache / ssd_cache** -- a fixed-size cache that holds only recently used keys and fetches misses from the source. Useful for very large sources where loading everything is impractical, but the official docs note caching layouts can give inconsistent results and are not recommended unless you specifically need them.
+- **direct** -- no in-memory storage at all; every lookup queries the source. Only sensible for sources that are themselves fast and rarely queried.
+
+The recommendation in the ClickHouse docs is to reach for `flat`, `hashed`, or `complex_key_hashed` first; they give the best query performance for most cases.
+
+## Dictionary as a JOIN Replacement
+
+The classic use is turning a lookup join into a function call. Instead of:
+
+```sql
+SELECT o.order_id, c.name
+FROM orders AS o
+LEFT JOIN currencies AS c ON o.currency_id = c.currency_id;
+```
+
+you write:
+
+```sql
+SELECT order_id, dictGet('currencies_dict', 'name', currency_id) AS name
+FROM orders;
+```
+
+The second form skips building a hash table for the join on every query, because the dictionary is already in memory and indexed by key. ClickHouse can also use a dictionary to accelerate an actual `LEFT ANY JOIN` when the join key matches the dictionary key, via its Direct Join path, but the `dictGet` form is the more explicit and common pattern.
+
+## Inspecting and Refreshing Dictionaries
+
+```sql
+-- list dictionaries and their status
+SELECT name, status, element_count, load_factor
+FROM system.dictionaries;
+
+-- force a reload from source
+SYSTEM RELOAD DICTIONARY currencies_dict;
+```
+
+`status` tells you whether the dictionary is loaded; a dictionary is loaded lazily on first use unless you reload it explicitly.
+
+## Common Mistakes
+
+- **Picking a cache layout by default.** Cache layouts can return stale or inconsistent results when keys age out, and the docs advise against them unless the source is too large to load fully. Start with `flat` or `hashed`.
+- **Using `flat` with non-`UInt64` or unbounded keys.** `flat` requires a `UInt64` key under a size bound; large or string keys need `hashed` or `complex_key_hashed`.
+- **Forgetting `LIFETIME`.** Without a sensible refresh interval the dictionary can serve outdated reference data. Match the lifetime to how often the source changes.
+- **Expecting `dictGet` to return `NULL` for missing keys.** Plain `dictGet` returns the attribute type's default (empty string, 0). Use `dictGetOrDefault` or `dictGetOrNull` when you need to distinguish a real miss.
+
+Mako is a read and query tool: it connects to ClickHouse and runs `dictGet` lookups and `system.dictionaries` inspections, but it does not manage dictionary definitions or source configuration for you. When you are composing a `dictGet` against an unfamiliar dictionary, Mako's AI autocomplete can suggest the attribute names and key shape as you type.
+
+## Related Guides
+
+- [ClickHouse Joins Guide](/guides/clickhouse/joins-guide) for when a real join beats a dictionary lookup.
+- [ClickHouse Aggregate Functions](/guides/clickhouse/aggregate-functions) for enriching grouped results with dictionary attributes.
+- [PostgreSQL vs ClickHouse](/guides/postgresql-vs-clickhouse) if you are deciding where reference data should live.
+
+---
+
+Mako connects to ClickHouse with AI-powered autocomplete for writing and exploring analytical queries. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/clickhouse/joins-guide.mdx
+++ b/content/guides/clickhouse/joins-guide.mdx
@@ -1,0 +1,138 @@
+---
+title: "ClickHouse JOINs: Types, Algorithms, GLOBAL JOIN, and Dictionary Alternatives"
+description: "A practical guide to JOINs in ClickHouse: the supported join types and strictness modifiers, the join algorithms you can configure, GLOBAL JOIN for distributed tables, and when a dictionary beats a join."
+database: "clickhouse"
+category: "sql-how-to"
+tags: ["clickhouse", "sql", "joins", "distributed", "dictionaries", "olap"]
+date: "2026-06-04"
+---
+
+# ClickHouse JOINs
+
+ClickHouse supports the full range of SQL join types, plus modifiers and algorithms that other engines do not have. It is also an OLAP engine, which means joins are not its first instinct: denormalizing or using a dictionary is often faster. This guide covers the join types, the strictness modifiers, how to pick an algorithm, the distributed-table trap that `GLOBAL JOIN` solves, and when to skip joins entirely.
+
+## Sample Schema
+
+```sql
+CREATE TABLE orders
+(
+    order_id   UInt64,
+    user_id    UInt32,
+    amount     Decimal(10, 2),
+    ts         DateTime
+)
+ENGINE = MergeTree ORDER BY ts;
+
+CREATE TABLE users
+(
+    user_id  UInt32,
+    name     String,
+    country  String
+)
+ENGINE = MergeTree ORDER BY user_id;
+```
+
+## Join Types
+
+The syntax mirrors standard SQL with extra keywords:
+
+```sql
+SELECT [GLOBAL] [INNER|LEFT|RIGHT|FULL|CROSS]
+       [OUTER|SEMI|ANTI|ANY|ALL|ASOF] JOIN ...
+```
+
+- `INNER`, `LEFT`, `RIGHT`, `FULL`, `CROSS` behave as you expect.
+- `SEMI` returns rows from one side that have a match, without duplicating for multiple matches. `LEFT SEMI JOIN` is the efficient form of `WHERE user_id IN (SELECT ...)`.
+- `ANTI` returns rows that have no match. `LEFT ANTI JOIN` is the "find orphans" query.
+- `ANY` returns at most one matching row from the right side per left row, instead of the Cartesian product. Use it for lookups where you only need a single match.
+- `ALL` (the default for most types) returns every matching combination.
+- `ASOF` joins on the closest preceding value rather than an exact match, which is built for time-series alignment.
+
+A basic inner join:
+
+```sql
+SELECT o.order_id, o.amount, u.name, u.country
+FROM orders AS o
+INNER JOIN users AS u ON o.user_id = u.user_id;
+```
+
+### ASOF JOIN
+
+`ASOF JOIN` matches each left row to the right row whose key is the nearest one that is less than or equal to it. The inequality column comes last in the `ON` clause:
+
+```sql
+SELECT q.symbol, q.ts, q.price, t.ts AS trade_ts
+FROM quotes AS q
+ASOF LEFT JOIN trades AS t
+  ON q.symbol = t.symbol AND q.ts >= t.ts;
+```
+
+This answers "what was the most recent trade at or before each quote" in one pass, which would otherwise need a correlated subquery or window function.
+
+## Join Algorithms
+
+By default ClickHouse uses the direct or hash join algorithm depending on the join type, strictness, and the engine of the right-hand table. You can change the strategy with the `join_algorithm` setting:
+
+- `hash` (and `parallel_hash`): fast, builds an in-memory hash table from the right side. Memory-bound, so it can fail on very large right tables.
+- `grace_hash`: spills to disk in buckets, trading speed for the ability to join sets larger than RAM.
+- `partial_merge` / `full_sorting_merge`: sort-based, not memory-bound, can exploit existing row order.
+- `direct`: a key-value lookup that works when the right side is a dictionary or a `Join`/`Dictionary`-engine table. The fastest option when it applies.
+- `auto`: lets ClickHouse pick and switch at runtime based on available resources.
+
+```sql
+SELECT o.order_id, u.name
+FROM orders AS o
+INNER JOIN users AS u ON o.user_id = u.user_id
+SETTINGS join_algorithm = 'grace_hash';
+```
+
+A practical rule: always put the smaller table on the right, because that side is loaded into memory. As of v24.12 the query planner reorders this automatically in many cases, but being explicit still helps on older versions and complex queries.
+
+## GLOBAL JOIN and Distributed Tables
+
+This is the trap that catches people moving from single-node to a cluster. When you join against a `Distributed` table, a plain `JOIN` is executed independently on each shard, and each shard only sees its own local data on the right side. The result is silently incomplete.
+
+`GLOBAL JOIN` fixes this: the right-hand subquery is evaluated once on the initiating node, and the result is broadcast to every shard before the join runs.
+
+```sql
+SELECT o.order_id, u.name
+FROM distributed_orders AS o
+GLOBAL INNER JOIN (
+    SELECT user_id, name FROM distributed_users
+) AS u ON o.user_id = u.user_id;
+```
+
+The cost is the broadcast: if the right side is large, you ship a lot of data to every node. Keep the right side small, or use a dictionary instead.
+
+## When a Dictionary Beats a Join
+
+For small, mostly static lookup tables (countries, product catalogs, user metadata), a dictionary is usually the better tool. Dictionaries are held in memory in a lookup-optimized structure and queried with `dictGet`, avoiding the join machinery entirely. They also work cleanly across distributed queries because each node loads the same dictionary.
+
+```sql
+SELECT
+    order_id,
+    dictGet('users_dict', 'name', user_id)    AS name,
+    dictGet('users_dict', 'country', user_id) AS country
+FROM orders;
+```
+
+This sidesteps the `GLOBAL JOIN` broadcast problem and is typically faster for high-frequency lookups. See the [dictionaries guide](/guides/clickhouse/dictionaries) for defining and refreshing them.
+
+## Common Mistakes
+
+- **Plain JOIN on a distributed table.** Without `GLOBAL`, each shard joins only its local right-side rows, producing undercounted results. Use `GLOBAL JOIN` or a dictionary.
+- **Large table on the right.** The right side is loaded into memory for hash joins. Swap the order or switch to `grace_hash` if you hit memory limits.
+- **Reaching for JOIN by default.** ClickHouse rewards denormalization. If you join the same dimension table constantly, consider a dictionary or a flattened table instead.
+- **Expecting NULL-friendly outer-join semantics everywhere.** Unmatched cells are filled with type defaults (`0`, empty string) unless `join_use_nulls = 1` is set, which makes them real NULLs.
+
+When you are testing which join type or algorithm gives the right result and speed, Mako's AI autocomplete can scaffold the `ON` clause and suggest the `SETTINGS` line as you write the query.
+
+## Related Guides
+
+- [ClickHouse Aggregate Functions](/guides/clickhouse/aggregate-functions)
+- [ClickHouse Window Functions](/guides/clickhouse/window-functions)
+- [ClickHouse JSON Queries](/guides/clickhouse/json-queries)
+
+---
+
+Mako connects to ClickHouse with AI-powered autocomplete for queries like these. Try it free at mako.ai.

--- a/content/guides/clickhouse/json-queries.mdx
+++ b/content/guides/clickhouse/json-queries.mdx
@@ -1,0 +1,125 @@
+---
+title: "ClickHouse JSON Queries: JSONExtract, the JSON Type, and When to Use Each"
+description: "How to query JSON in ClickHouse, comparing the String + JSONExtract approach with the native JSON data type introduced in v24.8, plus parsing, paths, and performance tradeoffs."
+database: "clickhouse"
+category: "sql-how-to"
+tags: ["clickhouse", "sql", "json", "jsonextract", "semi-structured", "olap"]
+date: "2026-06-04"
+---
+
+# ClickHouse JSON Queries
+
+ClickHouse gives you two ways to work with JSON, and the right choice depends on how predictable your data is. You can store JSON as a `String` and pull values out at query time with the `JSONExtract*` family, or you can use the native `JSON` data type (production-ready since v24.8) that parses and columnarizes paths on insert. This guide covers both, when each fits, and the gotchas.
+
+## Sample Data
+
+```sql
+CREATE TABLE logs
+(
+    id       UInt64,
+    payload  String
+)
+ENGINE = MergeTree
+ORDER BY id;
+
+INSERT INTO logs VALUES
+    (1, '{"user": {"id": 42, "name": "Ada"}, "tags": ["a", "b"], "active": true}'),
+    (2, '{"user": {"id": 43, "name": "Linus"}, "tags": ["c"], "active": false}');
+```
+
+## Approach 1: String Column + JSONExtract
+
+If JSON is stored in a `String` column, the `JSONExtract*` functions parse it on every read. Each function is typed, so you tell ClickHouse what you expect back.
+
+```sql
+SELECT
+    JSONExtractUInt(payload, 'user', 'id')      AS user_id,
+    JSONExtractString(payload, 'user', 'name')  AS user_name,
+    JSONExtractBool(payload, 'active')           AS active
+FROM logs;
+```
+
+Path arguments are passed as a sequence of keys, not a dotted string. `JSONExtractUInt(payload, 'user', 'id')` walks into `user` then `id`. For array indices, pass an integer (1-based; negative counts from the end):
+
+```sql
+SELECT JSONExtractString(payload, 'tags', 1) AS first_tag
+FROM logs;
+```
+
+Other useful extractors:
+
+- `JSONExtractInt`, `JSONExtractFloat`, `JSONExtractRaw` (returns the raw JSON fragment as a string)
+- `JSONExtract(payload, 'tags', 'Array(String)')` parses into a typed ClickHouse value, including arrays and tuples
+- `JSONExtractKeys(payload, 'user')` returns the keys of an object
+- `JSONHas(payload, 'user', 'id')` checks for existence
+- `JSONType(payload, 'tags')` returns the JSON type of a value (`Array`, `Object`, `String`, etc.)
+- `isValidJSON(payload)` validates without extracting
+
+```sql
+SELECT
+    JSONExtract(payload, 'tags', 'Array(String)') AS tags,
+    length(JSONExtract(payload, 'tags', 'Array(String)')) AS tag_count
+FROM logs;
+```
+
+The cost: parsing runs at query time on the full string, for every matching row. If you repeatedly query the same path, this is wasted work. There is also the simpler `simpleJSONExtract*` family, which is faster but only handles flat, well-formed JSON without nested escaping. Reach for it only when you know the shape is trivial.
+
+## Approach 2: The Native JSON Type
+
+Since v24.8, ClickHouse has a native `JSON` type that stores each distinct path as its own subcolumn under the hood. Paths are parsed once on insert, so reads do not re-parse the whole document, and queries touch only the subcolumns they reference.
+
+```sql
+CREATE TABLE logs_json
+(
+    id       UInt64,
+    payload  JSON
+)
+ENGINE = MergeTree
+ORDER BY id;
+
+INSERT INTO logs_json VALUES
+    (1, '{"user": {"id": 42, "name": "Ada"}, "active": true}'),
+    (2, '{"user": {"id": 43, "name": "Linus"}, "active": false}');
+```
+
+Read paths with dotted access. Because a path can hold mixed types across rows, values come back wrapped in `Dynamic`, so cast when you need a concrete type:
+
+```sql
+SELECT
+    payload.user.id::UInt32   AS user_id,
+    payload.user.name::String AS user_name
+FROM logs_json;
+```
+
+Inspect what paths exist with `JSONAllPaths`:
+
+```sql
+SELECT JSONAllPaths(payload) FROM logs_json;
+```
+
+The type has a `max_dynamic_paths` parameter (default 1024). Paths beyond that limit are not given their own subcolumn; they fall back to a shared `Map`-like structure that is still queryable but slower. If your JSON has thousands of distinct keys (for example, high-cardinality event properties), tune this or model the hot paths as real columns.
+
+## Choosing Between Them
+
+Use the native `JSON` type when the same payloads are queried repeatedly and you care about scan performance, or when the schema drifts over time but a handful of paths dominate your queries. Use `String` + `JSONExtract` when JSON is rarely queried (cold storage, occasional debugging), when documents are huge and you only ever touch one or two fields, or when you are on a version older than v24.8.
+
+A common pattern is to keep the raw `String` for fidelity and materialize the hot paths into typed columns with a [materialized column or view](/guides/clickhouse/materialized-views), giving you both the original document and fast columnar reads.
+
+## Common Mistakes
+
+- **Dotted path strings.** `JSONExtractString(payload, 'user.name')` looks for a top-level key literally named `user.name`. Pass keys as separate arguments instead.
+- **Wrong extractor type.** `JSONExtractUInt` on a value that is actually a string returns `0`, not an error. Check with `JSONType` if results look empty.
+- **Forgetting array indices are 1-based.** `JSONExtractString(payload, 'tags', 0)` returns nothing; the first element is index `1`.
+- **Assuming the native type re-parses cheaply at any cardinality.** Past `max_dynamic_paths`, extra paths lose their dedicated subcolumn and query speed drops.
+
+If you are exploring an unfamiliar JSON column, Mako's AI autocomplete can suggest the right `JSONExtract*` variant and path arguments as you type, which saves a few round-trips through the docs.
+
+## Related Guides
+
+- [ClickHouse Aggregate Functions](/guides/clickhouse/aggregate-functions)
+- [ClickHouse Window Functions](/guides/clickhouse/window-functions)
+- [Import JSON to ClickHouse](/guides/import-json-to-clickhouse)
+
+---
+
+Mako connects to ClickHouse with AI-powered autocomplete for queries like these. Try it free at mako.ai.

--- a/content/guides/clickhouse/maps-and-nested.mdx
+++ b/content/guides/clickhouse/maps-and-nested.mdx
@@ -1,0 +1,155 @@
+---
+title: "Map, Nested, and Tuple in ClickHouse: Modeling Semi-Structured Data"
+description: "How to model key-value and repeated-group data in ClickHouse with Map(K, V), Nested, and Tuple. Covers m[k] access and its linear cost, mapKeys/mapValues subcolumns, mapContains, the Nested-is-parallel-arrays model, the flatten_nested setting, and when to reach for a Map versus a Nested versus parallel arrays."
+database: "clickhouse"
+category: "sql-how-to"
+tags: ["clickhouse", "map", "nested", "tuple", "data-modeling", "olap"]
+date: "2026-06-08"
+---
+
+# Map, Nested, and Tuple in ClickHouse
+
+ClickHouse gives you three ways to store more than one value in a single column: `Map(K, V)` for key-value pairs, `Nested` for repeated groups of related fields, and `Tuple` for a fixed, heterogeneous set of named or positional values. They overlap enough to be confusing and differ enough that picking the wrong one costs either query speed or schema sanity. This guide covers what each one actually is under the hood, how to read from it, and how to choose.
+
+## Map(K, V): Key-Value Pairs
+
+A `Map` stores an arbitrary set of key-value pairs per row. It is the natural fit for things like HTTP headers, label sets, or user attributes where the set of keys is open-ended.
+
+```sql
+CREATE TABLE events (
+    id UInt64,
+    tags Map(String, String)
+)
+ENGINE = MergeTree
+ORDER BY id;
+
+INSERT INTO events VALUES
+    (1, {'env': 'prod', 'region': 'eu'}),
+    (2, {'env': 'staging'});
+```
+
+You read a value with bracket syntax:
+
+```sql
+SELECT id, tags['env'] FROM events;
+```
+
+Two behaviors surprise people coming from other databases:
+
+**Missing keys return the value type's default, not NULL.** Asking for `tags['region']` on row 2 returns `''` (the default for `String`), not NULL. For an integer-valued map it would return `0`. If you need to distinguish "key absent" from "key present with default value," test for the key explicitly:
+
+```sql
+SELECT id FROM events WHERE mapContains(tags, 'region');
+```
+
+**Keys are not unique.** A `Map` in ClickHouse is internally an `Array(Tuple(K, V))`, so it can physically hold two entries with the same key. ClickHouse does not deduplicate on insert. If your source data can produce duplicate keys, clean it before insert or treat the map as best-effort.
+
+### The cost of m[k]
+
+Because a map is stored as an array of pairs, `tags['env']` is not a hash lookup. It scans the whole map for that row, so the operation is linear in the number of keys. For maps with a handful of keys this is irrelevant. For maps with hundreds or thousands of keys queried hot, it adds up.
+
+Two things help. First, the `keys` and `values` subcolumns let you read just one side of the map without materializing the whole structure:
+
+```sql
+SELECT tags.keys, tags.values FROM events;   -- same as mapKeys(tags), mapValues(tags)
+```
+
+Second, on recent versions you can switch a MergeTree map column to bucketed serialization, which splits pairs into substreams by hashed key so that `m['key']` only reads the relevant bucket instead of the entire column:
+
+```sql
+CREATE TABLE events2 (id UInt64, tags Map(String, String))
+ENGINE = MergeTree ORDER BY id
+SETTINGS map_serialization_version = 'with_buckets', max_buckets_in_map = 32;
+```
+
+This trades a little insert overhead for much faster single-key reads on wide maps. If your maps are small, leave the default.
+
+## Nested: Repeated Groups of Columns
+
+`Nested` models a "table inside a cell": a set of named, typed sub-columns that share a length per row. The canonical example is an order with line items.
+
+```sql
+CREATE TABLE orders (
+    order_id UInt64,
+    items Nested(
+        sku String,
+        qty UInt32,
+        price Decimal(10, 2)
+    )
+)
+ENGINE = MergeTree
+ORDER BY order_id;
+```
+
+The thing to understand is that, by default, `Nested` is syntactic sugar over parallel arrays. With the default `flatten_nested = 1`, the table above actually stores three columns named `items.sku Array(String)`, `items.qty Array(UInt32)`, and `items.price Array(Decimal(10,2))`. You insert and query them as arrays:
+
+```sql
+INSERT INTO orders VALUES
+    (100, ['A1', 'B2'], [3, 1], [9.99, 49.00]);
+
+SELECT order_id, items.sku, items.qty FROM orders;
+```
+
+The arrays for one row must all have the same length. ClickHouse validates this on insert, and a length mismatch is a runtime error, not a silent truncation.
+
+To get one row per line item, unfold with `ARRAY JOIN`:
+
+```sql
+SELECT order_id, items.sku AS sku, items.qty AS qty
+FROM orders
+ARRAY JOIN items;
+```
+
+For more on the unfold mechanics, multi-array lockstep behavior, and higher-order functions, see the [ClickHouse arrays guide](/guides/clickhouse/arrays).
+
+### flatten_nested and the dots problem
+
+The default flattening has two consequences worth knowing. First, because the sub-columns are real columns named with dots (`items.sku`), column names containing dots elsewhere in your schema can be accidentally interpreted as flattened Nested structures, triggering surprise array-length validation. The official guidance is to avoid dots in ordinary column names and use underscores instead.
+
+Second, with `SET flatten_nested = 0` (set before table creation), a `Nested` column is stored as a single `Array(Tuple(...))` rather than parallel arrays. That keeps the group together as one unit, which is closer to what most people expect coming from document databases, and avoids the dotted-column pitfalls. The flattened default is older behavior; the array-of-tuples representation is often the cleaner model for new tables, especially if you add or rename fields over time.
+
+## Tuple: A Fixed, Heterogeneous Record
+
+A `Tuple` is a fixed-shape record: a known number of fields, each with its own type, optionally named. Unlike a `Map`, the shape is part of the type and cannot vary per row. Unlike `Nested`, there is exactly one tuple per row (not a variable-length group).
+
+```sql
+SELECT (1, 'Ready') AS t, t.1 AS num, t.2 AS label;
+```
+
+Named tuples let you address fields by name, which is far more readable:
+
+```sql
+SELECT tuple(1, 'Ready')::Tuple(id UInt8, label String) AS t, t.label;
+```
+
+Tuples show up most often as intermediate values: the element type of a `Map` (`Array(Tuple(K, V))`), the return of functions that produce several values at once, or a way to carry a small fixed record without declaring separate columns. They are not usually the right top-level storage choice for analytical tables, because querying an individual tuple field still reads the whole tuple, and separate columns compress and scan better.
+
+### Converting between Tuple and Map
+
+You can cast a tuple of two parallel arrays into a map, which is handy when reshaping data:
+
+```sql
+SELECT CAST(([1, 2, 3], ['Ready', 'Steady', 'Go']), 'Map(UInt8, String)') AS m;
+-- {1:'Ready',2:'Steady',3:'Go'}
+```
+
+## Choosing Between Them
+
+- **Open-ended keys that vary per row** (labels, headers, sparse attributes): use `Map`. Accept the linear `m[k]` cost, or enable bucketed serialization if maps are wide and read-heavy.
+- **A repeated group of related fields with a stable schema** (line items, events within a session): use `Nested`, and consider `flatten_nested = 0` so the group stays one logical unit.
+- **A fixed, small record of mixed types**: use `Tuple`, usually as an intermediate value rather than primary storage.
+- **A handful of known attributes queried independently and filtered on**: skip all three and use plain columns. Separate columns compress better, support data-skipping indexes, and scan faster than any nested structure. Reach for `Map`/`Nested`/`Tuple` when the shape genuinely varies or the group is genuinely repeated, not to save a few `CREATE TABLE` lines.
+
+The honest tradeoff: nested structures buy you flexibility and lose you some of ClickHouse's columnar advantages, because reading one key or field often means touching the whole structure for that row. When the access pattern is "give me this one attribute, filtered," flat columns win.
+
+When you are reshaping unfamiliar semi-structured data, Mako's AI autocomplete can suggest the right `mapKeys`/`ARRAY JOIN`/tuple-access shape as you type, which helps given how easy it is to mix up the three.
+
+## Related Guides
+
+- [ClickHouse Arrays](/guides/clickhouse/arrays) for `ARRAY JOIN` and the higher-order functions that operate on Nested sub-columns.
+- [ClickHouse JSON Queries](/guides/clickhouse/json-queries) for the alternative when the structure is fully dynamic.
+- [Import JSON to ClickHouse](/guides/import-json-to-clickhouse) to load nested source data.
+
+---
+
+Mako connects to ClickHouse with AI-powered autocomplete for writing and exploring analytical queries. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/clickhouse/materialized-views.mdx
+++ b/content/guides/clickhouse/materialized-views.mdx
@@ -1,0 +1,157 @@
+---
+title: "ClickHouse Materialized Views: A Practical Guide"
+description: "How incremental materialized views work in ClickHouse: the trigger-on-insert model, the target table and TO syntax, rolling up with SummingMergeTree and AggregatingMergeTree, the -State and -Merge combinators, and the gotchas around backfilling and source-table coupling."
+database: "clickhouse"
+category: "sql-how-to"
+tags: ["clickhouse", "sql", "materialized-views", "aggregatingmergetree", "summingmergetree", "olap"]
+date: "2026-06-05"
+---
+
+# ClickHouse Materialized Views
+
+A materialized view in ClickHouse is not what the name implies if you come from PostgreSQL. It is not a cached snapshot you refresh on a schedule. It is an **insert trigger**: a query that runs on each block of rows as they land in a source table, writing the result into a separate target table. This shifts aggregation cost from query time to insert time, so dashboards that read the target table stay fast as the source grows. This guide covers the model, the table engines that make rollups work, and the mistakes that cost people a weekend.
+
+## The Trigger Model
+
+When you insert rows into the source table, ClickHouse runs the view's `SELECT` over just that inserted block and appends the result to the target table. It never sees historical data and never re-reads the source. That single fact explains most of the surprising behavior below.
+
+```sql
+-- Source: raw events
+CREATE TABLE events (
+    event_time DateTime,
+    user_id    UInt64,
+    country    String,
+    revenue    Decimal(10, 2)
+) ENGINE = MergeTree
+ORDER BY event_time;
+```
+
+A view needs somewhere to write. The clean approach is to create the target table explicitly and point the view at it with `TO`.
+
+```sql
+-- Target: daily revenue per country
+CREATE TABLE revenue_by_day (
+    day      Date,
+    country  String,
+    revenue  Decimal(10, 2)
+) ENGINE = SummingMergeTree
+ORDER BY (day, country);
+
+-- The view: a trigger that fills the target on insert
+CREATE MATERIALIZED VIEW revenue_by_day_mv
+TO revenue_by_day
+AS
+SELECT
+    toDate(event_time) AS day,
+    country,
+    revenue
+FROM events;
+```
+
+From now on, every insert into `events` pushes a transformed copy into `revenue_by_day`. Queries hit the small pre-aggregated table.
+
+## Rolling Up with SummingMergeTree
+
+In the example above the view does not aggregate; it relies on `SummingMergeTree` to do the work. That engine collapses rows with the same sorting key during background merges, summing the numeric columns that are not part of the key.
+
+```sql
+SELECT day, country, sum(revenue) AS revenue
+FROM revenue_by_day
+GROUP BY day, country;
+```
+
+The `sum()` and `GROUP BY` at read time are still required. Merges happen asynchronously and may not have run yet, so the target table can hold several partial rows per key until a merge consolidates them. Always aggregate on read; never assume one row per key.
+
+`SummingMergeTree` only handles sums. For counts, averages, uniques, min/max, or anything else, you need `AggregatingMergeTree`.
+
+## AggregatingMergeTree and the State/Merge Combinators
+
+`AggregatingMergeTree` stores **intermediate aggregation states** rather than finished values. You produce a state with the `-State` combinator on insert, and resolve it to a number with the `-Merge` combinator on read.
+
+```sql
+CREATE TABLE user_stats (
+    day          Date,
+    country      String,
+    visits       AggregateFunction(count, UInt64),
+    unique_users AggregateFunction(uniq, UInt64),
+    avg_revenue  AggregateFunction(avg, Decimal(10, 2))
+) ENGINE = AggregatingMergeTree
+ORDER BY (day, country);
+
+CREATE MATERIALIZED VIEW user_stats_mv
+TO user_stats
+AS
+SELECT
+    toDate(event_time)     AS day,
+    country,
+    countState()           AS visits,
+    uniqState(user_id)     AS unique_users,
+    avgState(revenue)      AS avg_revenue
+FROM events
+GROUP BY day, country;
+```
+
+The columns hold opaque state blobs, not readable numbers. To get values back, apply the matching `-Merge` function and group:
+
+```sql
+SELECT
+    day,
+    country,
+    countMerge(visits)        AS visits,
+    uniqMerge(unique_users)   AS unique_users,
+    avgMerge(avg_revenue)     AS avg_revenue
+FROM user_stats
+GROUP BY day, country
+ORDER BY day, country;
+```
+
+The rule of thumb: `-State` on the way in, `-Merge` on the way out, and the `-State`/`-Merge` function names must match exactly. Querying the raw state column without `-Merge` returns gibberish, which is the most common confusion here. See the [aggregate functions guide](/guides/clickhouse/aggregate-functions) for the full combinator family.
+
+## Backfilling Existing Data
+
+Because the view only fires on new inserts, creating it does nothing for data already in the source table. To populate the target with history, run a one-time `INSERT INTO target SELECT ...` that mirrors the view's query.
+
+```sql
+INSERT INTO user_stats
+SELECT
+    toDate(event_time) AS day,
+    country,
+    countState(),
+    uniqState(user_id),
+    avgState(revenue)
+FROM events
+GROUP BY day, country;
+```
+
+Order matters: if you create the view first and then backfill, you risk double-counting any rows inserted in the gap. A safe pattern is to create the view, then backfill only data with timestamps older than the view's creation moment.
+
+## The POPULATE Keyword and Why to Avoid It
+
+`CREATE MATERIALIZED VIEW ... POPULATE` backfills automatically at creation time, but any rows inserted into the source **during** the populate run are missed, silently. For production tables that are actively receiving writes, prefer the manual backfill above. `POPULATE` is fine for static or paused tables.
+
+## Coupling and Cascades
+
+A materialized view is tied to its source table. Two consequences worth knowing:
+
+- If an insert into the source succeeds but the view's query throws (a type mismatch, a divide by zero), the behavior depends on the `materialized_views_ignore_errors` setting; by default the failing view can fail the whole insert. Test the view's SELECT independently before deploying it.
+- Inserting into the target table of one view can itself trigger another view if a second view reads that target. Chains of views are supported and useful for multi-level rollups, but they make data lineage harder to trace.
+
+## Common Mistakes
+
+- **Expecting a Postgres-style refreshable snapshot.** Incremental views are insert triggers; they never re-scan the source. (ClickHouse does have separate `REFRESH`able views for the schedule-based model, but they are a different feature.)
+- **Reading state columns without `-Merge`.** An `AggregateFunction` column is an intermediate blob until merged.
+- **Assuming one row per key in `SummingMergeTree`.** Merges are asynchronous; always `GROUP BY` and aggregate on read.
+- **Forgetting to backfill.** A new view ignores all pre-existing rows. History needs an explicit `INSERT ... SELECT`.
+- **Using `POPULATE` on a live table.** Rows written during populate are lost without warning.
+
+When you are validating that a view's target table actually matches a re-aggregation of the source, Mako's AI autocomplete helps you write the `-Merge` queries and side-by-side checks, which is handy given how easy it is to forget a combinator.
+
+## Related Guides
+
+- [ClickHouse Aggregate Functions](/guides/clickhouse/aggregate-functions) for the `-State`/`-Merge` combinator family in detail.
+- [ClickHouse Window Functions](/guides/clickhouse/window-functions) for analytics that don't need a pre-aggregated target.
+- [Import CSV to ClickHouse](/guides/import-csv-to-clickhouse) to load source data for testing views.
+
+---
+
+Mako connects to ClickHouse with AI-powered autocomplete for writing and exploring analytical queries. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/clickhouse/mergetree-engines.mdx
+++ b/content/guides/clickhouse/mergetree-engines.mdx
@@ -1,0 +1,153 @@
+---
+title: "ClickHouse MergeTree Table Engines: Choosing the Right One"
+description: "A practical guide to the MergeTree family in ClickHouse: plain MergeTree, ReplacingMergeTree, SummingMergeTree, AggregatingMergeTree, CollapsingMergeTree and VersionedCollapsingMergeTree. How merges work, what each engine deduplicates or pre-aggregates, the eventual-consistency trap, and how to pick one."
+database: "clickhouse"
+category: "sql-how-to"
+tags: ["clickhouse", "mergetree", "table-engines", "deduplication", "aggregation", "olap"]
+date: "2026-06-08"
+---
+
+# ClickHouse MergeTree Table Engines
+
+The table engine you choose in ClickHouse determines how rows are stored, how they are merged in the background, and what happens to rows that share a sorting key. The MergeTree family is the set of engines built for analytical workloads, and almost every production ClickHouse table uses one of them. They share the same physical layer (data is written as immutable parts, indexed by a sparse primary index, and merged in the background) but differ in what that background merge does to rows with the same sorting key.
+
+This guide covers the main MergeTree-family engines, what each one is for, and the one behavior that trips up nearly everyone: the special merge logic is only guaranteed to have happened *eventually*, not at query time.
+
+## How MergeTree Works Underneath
+
+When you insert into a MergeTree table, ClickHouse writes the rows into a new immutable *part* on disk, sorted by the table's `ORDER BY` key. It does not modify existing parts. A background process periodically merges smaller parts into larger ones, which is where the family name comes from. During those merges, sorting keeps rows with the same `ORDER BY` value adjacent, and that adjacency is what the specialized engines exploit.
+
+A plain `MergeTree` does nothing special on merge beyond combining parts:
+
+```sql
+CREATE TABLE events
+(
+    event_date Date,
+    user_id    UInt64,
+    event_type String,
+    value      Float64
+)
+ENGINE = MergeTree
+ORDER BY (event_date, user_id);
+```
+
+`ORDER BY` here is the sorting key, and (unless you set `PRIMARY KEY` separately) it also defines the sparse primary index used for skipping data during reads. It is not a uniqueness constraint. Plain `MergeTree` will happily store two rows with identical `ORDER BY` values. If you need uniqueness, summing, or aggregation, you need one of the specialized engines below, and even then "uniqueness" means something looser than it does in PostgreSQL or MySQL.
+
+## ReplacingMergeTree
+
+`ReplacingMergeTree` deduplicates rows that share the same sorting key, keeping one row per key. This is the engine people reach for when they want upsert-like behavior.
+
+```sql
+CREATE TABLE current_state
+(
+    user_id    UInt64,
+    status     String,
+    updated_at DateTime
+)
+ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY user_id;
+```
+
+The optional version column (`updated_at` above) tells ClickHouse which row wins when keys collide: the one with the highest version value. Without a version column, the last inserted row wins. Insert a new row for an existing `user_id`, and after a background merge only the newest survives.
+
+The trap: deduplication happens during merges, which run on ClickHouse's schedule, not yours. Between an insert and the next merge of the relevant parts, a plain `SELECT` will return *both* the old and new rows. There is no guarantee about when merges happen. To get the deduplicated result at query time you must do one of:
+
+- Add `FINAL` to the query (`SELECT * FROM current_state FINAL`), which forces the merge logic at read time. This is correct but can be expensive on large tables because it has to merge on the fly.
+- Aggregate the duplicates away yourself, for example `argMax(status, updated_at) ... GROUP BY user_id`, which sidesteps the engine entirely and is often faster than `FINAL`.
+
+`ReplacingMergeTree` also supports an optional `is_deleted` column (a second engine argument alongside the version column) so a row can mark a key as deleted during deduplication, which is useful for change-data-capture pipelines.
+
+## SummingMergeTree
+
+`SummingMergeTree` collapses rows with the same sorting key into a single row, summing the numeric columns that are not part of the key.
+
+```sql
+CREATE TABLE daily_totals
+(
+    event_date  Date,
+    metric_name String,
+    total       UInt64
+)
+ENGINE = SummingMergeTree
+ORDER BY (event_date, metric_name);
+```
+
+Insert `(2026-06-08, 'clicks', 5)` and later `(2026-06-08, 'clicks', 3)`, and after a merge you get a single row with `total = 8`. You can restrict which columns are summed by passing them as an argument: `SummingMergeTree((total, count))`. Columns not in the sorting key and not summed take an arbitrary value from one of the merged rows, so do not rely on them.
+
+The same eventual-consistency caveat applies: until the merge runs, both rows are present. Wrap reads in a `sum()` over `GROUP BY` (which you typically want anyway) and the result is correct regardless of merge state. `SummingMergeTree` is really an optimization that keeps the stored data pre-aggregated so those `GROUP BY` queries scan fewer rows.
+
+## AggregatingMergeTree
+
+`AggregatingMergeTree` generalizes the summing idea to arbitrary aggregate functions. Instead of storing raw values, columns store intermediate aggregation *states*, produced by the `-State` combinator and read back with the `-Merge` combinator.
+
+```sql
+CREATE TABLE user_metrics
+(
+    user_id      UInt64,
+    visits       AggregateFunction(sum, UInt64),
+    unique_pages AggregateFunction(uniq, UInt64)
+)
+ENGINE = AggregatingMergeTree
+ORDER BY user_id;
+
+-- Inserting requires -State functions
+INSERT INTO user_metrics
+SELECT user_id, sumState(toUInt64(1)), uniqState(page_id)
+FROM raw_events
+GROUP BY user_id;
+
+-- Reading requires -Merge functions
+SELECT user_id, sumMerge(visits), uniqMerge(unique_pages)
+FROM user_metrics
+GROUP BY user_id;
+```
+
+This is more involved than `SummingMergeTree`, but it handles aggregations that cannot be expressed as a plain sum, such as `uniq`, `quantile`, or `avg`. It is most often used as the target of a [materialized view](/guides/clickhouse/materialized-views) that maintains a rollup as data streams in. If your only need is summing integers, `SummingMergeTree` is simpler and SummingMergeTree is effectively a special case of this engine. For the combinator mechanics, see the [ClickHouse aggregate functions guide](/guides/clickhouse/aggregate-functions).
+
+## CollapsingMergeTree and VersionedCollapsingMergeTree
+
+`CollapsingMergeTree` handles mutable rows by storing pairs of "state" and "cancel" rows. You add a `Sign` column holding `1` (a row to add) or `-1` (a row that cancels a previous one). During merges, a matching `+1` and `-1` pair with the same sorting key cancel out and both disappear, leaving only the net state.
+
+```sql
+CREATE TABLE account_balance
+(
+    account_id UInt64,
+    balance    Int64,
+    sign       Int8
+)
+ENGINE = CollapsingMergeTree(sign)
+ORDER BY account_id;
+```
+
+To update a row you insert the old version with `sign = -1` and the new version with `sign = 1`. This avoids rewriting data parts, which is what a mutation would do. The cost is operational: your application has to track the previous row values to write the cancel row correctly, and if rows arrive out of order the collapse can fail. `VersionedCollapsingMergeTree` adds a version column so collapsing works correctly even when the cancel and state rows are inserted in any order, at the cost of one more column to manage.
+
+These engines suit high-throughput mutable data but they push real complexity into your write path. Most teams are better served by `ReplacingMergeTree` unless they specifically need the running-sum semantics that collapsing provides.
+
+## The Replicated and Distributed Prefixes
+
+Each engine above has a `Replicated` variant (for example `ReplicatedMergeTree`) that adds data replication across nodes via ClickHouse Keeper or ZooKeeper. On ClickHouse Cloud, replication is the default and you generally use the `Replicated` engines transparently. `Distributed` is a separate engine that does not store data itself; it routes queries across a cluster of underlying tables. Both are orthogonal to the merge behavior described here: you pick the merge semantics (Replacing, Summing, etc.) and the replication topology independently.
+
+## Choosing an Engine
+
+| Engine | Use it when | Read-time caveat |
+| --- | --- | --- |
+| `MergeTree` | General-purpose, append-only or rarely-modified data | None; no dedup or aggregation |
+| `ReplacingMergeTree` | You want one row per key (upsert-like) | Use `FINAL` or `argMax` until merges run |
+| `SummingMergeTree` | Pre-summing numeric metrics by key | `GROUP BY ... sum()` reads are always correct |
+| `AggregatingMergeTree` | Rollups with uniq/quantile/avg, usually via a materialized view | Read with `-Merge` and `GROUP BY` |
+| `CollapsingMergeTree` | High-throughput mutable rows, app tracks prior state | Use `sign`-aware aggregation; order-sensitive |
+| `VersionedCollapsingMergeTree` | Same, but inserts can arrive out of order | Version column resolves ordering |
+
+The single most common mistake is treating `ReplacingMergeTree` or `SummingMergeTree` as if deduplication or summing happens at insert time. It does not. The engine guarantees the result *after* a background merge, and you must write your read queries (`FINAL`, `argMax`, or `GROUP BY` aggregation) to be correct in the meantime. Start with plain `MergeTree`, and only move to a specialized engine when you have a concrete need for its merge behavior.
+
+When you are experimenting with these engines and want to compare what a raw `SELECT` returns against a `SELECT ... FINAL`, Mako's AI autocomplete can help you draft and adjust the queries quickly.
+
+## Related Guides
+
+- [ClickHouse Materialized Views](/guides/clickhouse/materialized-views) for the most common way to feed an AggregatingMergeTree or SummingMergeTree rollup.
+- [ClickHouse Aggregate Functions](/guides/clickhouse/aggregate-functions) for the `-State` and `-Merge` combinators that AggregatingMergeTree relies on.
+- [ClickHouse Partitioning](/guides/clickhouse/partitioning) for the data-management layer that sits alongside any MergeTree engine.
+
+---
+
+Mako connects to ClickHouse with AI-powered autocomplete for writing and exploring analytical queries. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/clickhouse/partitioning.mdx
+++ b/content/guides/clickhouse/partitioning.mdx
@@ -1,0 +1,124 @@
+---
+title: "ClickHouse Partitioning: When It Helps and When It Hurts"
+description: "How PARTITION BY works in ClickHouse: choosing a partition key, partition pruning, partition-level operations (DROP, DETACH, ATTACH, MOVE, FREEZE), the too-many-parts problem, and why most teams over-partition."
+database: "clickhouse"
+category: "sql-how-to"
+tags: ["clickhouse", "sql", "partitioning", "mergetree", "data-management", "olap"]
+date: "2026-06-08"
+---
+
+# ClickHouse Partitioning
+
+Partitioning in ClickHouse splits a table's data into separate logical chunks based on an expression you define in the `PARTITION BY` clause. Each partition is stored as its own set of directories on disk, which lets ClickHouse skip whole partitions during a query and lets you run bulk operations (drop, detach, move) on a partition without touching the rest of the table.
+
+The most important thing to understand up front: partitioning is a data-management feature, not a primary query-optimization feature. Query speed in ClickHouse comes mostly from the `ORDER BY` (sorting) key and its sparse primary index. Partitioning helps queries only when the query filters on the partition expression, and it can actively hurt performance when overused. The official guidance is blunt: in most cases you do not need a partition key, and when you do, you rarely need anything more granular than by month.
+
+## Defining a Partition Key
+
+`PARTITION BY` is declared at table creation and applies to `MergeTree`-family engines.
+
+```sql
+CREATE TABLE events
+(
+    event_time DateTime,
+    user_id    UInt64,
+    event_type String,
+    payload    String
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(event_time)
+ORDER BY (user_id, event_time);
+```
+
+Here `toYYYYMM(event_time)` produces a value like `202606`, so each calendar month becomes one partition. As rows are inserted, ClickHouse routes each row to the partition its expression evaluates to. You can inspect partitions through the `system.parts` table:
+
+```sql
+SELECT partition, name, rows, bytes_on_disk
+FROM system.parts
+WHERE table = 'events' AND active
+ORDER BY partition;
+```
+
+## How Partition Pruning Works
+
+When a query filters on a column used in the partition expression, ClickHouse evaluates which partitions can possibly contain matching rows and reads only those. This is partition pruning.
+
+```sql
+-- Only touches the 202606 and 202607 partitions
+SELECT count()
+FROM events
+WHERE event_time >= '2026-06-01' AND event_time < '2026-08-01';
+```
+
+A query that does not reference the partition expression gets no pruning benefit at all. It still reads every partition and relies entirely on the primary index inside each part. This is why partitioning by a column your queries never filter on is wasted effort.
+
+A subtle point: pruning works on the partition expression, not arbitrary columns. If you partition by `toYYYYMM(event_time)` but filter on `toDate(event_time)`, ClickHouse can still prune because the filter is derivable from the same column. But if you partition by `cityHash64(user_id) % 100`, a filter like `user_id = 42` will not prune unless ClickHouse can map the predicate onto the hashed expression, which in practice it usually cannot.
+
+## Partition-Level Operations
+
+The real payoff of partitioning is cheap bulk operations. Dropping a partition is close to instant because it just removes directories, unlike a `DELETE` that has to rewrite parts.
+
+```sql
+-- Drop one month of data, near-instant
+ALTER TABLE events DROP PARTITION '202601';
+
+-- Detach: move the partition out of the active set but keep files on disk
+ALTER TABLE events DETACH PARTITION '202601';
+
+-- Re-attach a detached (or backed-up) partition
+ALTER TABLE events ATTACH PARTITION '202601';
+```
+
+`DETACH` followed by `ATTACH` is the standard way to move data between tables with an identical structure, since you can detach from one table and attach the part files into another. You can also freeze a partition for backup, which makes hardlinked copies under the `shadow/` directory:
+
+```sql
+ALTER TABLE events FREEZE PARTITION '202606';
+```
+
+With multi-disk storage configured, you can move a partition to a different volume or disk, which is how cold data gets pushed to cheaper storage:
+
+```sql
+ALTER TABLE events MOVE PARTITION '202601' TO VOLUME 'cold';
+```
+
+This overlaps with what `TTL ... TO VOLUME` automates. The difference is that `MOVE PARTITION` is a manual, explicit operation, while TTL tiering runs automatically during merges. For age-based lifecycle rules, TTL is usually the better fit; `MOVE PARTITION` is for one-off or scripted moves.
+
+## The Too-Many-Parts Problem
+
+Every insert creates at least one new data part, and parts are merged in the background per partition. Partitioning multiplies the number of parts because a single insert spanning N partitions writes at least N parts. ClickHouse never merges parts across partition boundaries, so each partition maintains its own merge tree.
+
+If you partition too finely, for example by day on a table that only holds a few thousand rows per day, or worse by a high-cardinality key like user ID, you end up with thousands of tiny partitions and a flood of small parts. Symptoms include:
+
+- `Too many parts` errors on insert (the `parts_to_throw_insert` threshold, default 3000 active parts per partition).
+- Slow `SELECT`s because the query has to open and merge many small parts.
+- High memory and file-descriptor pressure on the server.
+
+The fix is almost always coarser partitioning. Monthly is the default recommendation for a reason. If you think you need daily, confirm your daily volume justifies it (observability workloads ingesting billions of rows a day are the classic legitimate case).
+
+## Choosing a Partition Key: Practical Rules
+
+- **Default to monthly** with `toYYYYMM(date_column)` unless you have a specific reason not to.
+- **Partition by the column you delete or archive by.** If you expire data by age, partition by time so `DROP PARTITION` does the cleanup cheaply.
+- **Never partition by a high-cardinality column** like user ID, session ID, or a name. Put that column first in `ORDER BY` instead, where it drives the sparse index without exploding part counts.
+- **Keep the partition count in the low hundreds, not thousands.** A few years of monthly partitions is fine; thousands of daily partitions on a low-volume table is not.
+- **Partitioning is not a substitute for a good ORDER BY.** The sorting key and primary index do the heavy lifting for query speed. Partitioning manages the lifecycle.
+
+## Common Mistakes
+
+- **Over-partitioning.** The single most common mistake. Daily or hourly partitions on a table that does not ingest enough to justify them. Start coarse and only go finer with evidence.
+- **Partitioning by a column queries never filter on.** No pruning benefit, all the part-count cost.
+- **Expecting pruning from a hashed or transformed partition key.** A filter on the raw column may not prune if the partition expression hashes or otherwise obscures it.
+- **Using DELETE for time-based cleanup when DROP PARTITION would do.** Aligning partitions with your retention boundary turns expensive mutations into near-instant directory drops.
+- **Forgetting that parts never merge across partitions.** More partitions means more independent merge trees and more small parts to manage.
+
+When you are sizing partitions and want to see how many parts and rows each one holds before committing to a key, Mako's AI autocomplete can help you draft the `system.parts` queries to inspect the layout.
+
+## Related Guides
+
+- [ClickHouse TTL](/guides/clickhouse/ttl) for automating age-based deletion and storage tiering that aligns with partition boundaries.
+- [ClickHouse Materialized Views](/guides/clickhouse/materialized-views) for pre-aggregating data, which is partitioned alongside the target table.
+- [ClickHouse Date and Time Functions](/guides/clickhouse/date-functions) for the toYYYYMM and toStartOfMonth expressions used in partition keys.
+
+---
+
+Mako connects to ClickHouse with AI-powered autocomplete for writing and exploring analytical queries. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/clickhouse/projections.mdx
+++ b/content/guides/clickhouse/projections.mdx
@@ -1,0 +1,139 @@
+---
+title: "ClickHouse Projections: Speeding Up Queries That Do Not Match Your Sort Key"
+description: "How projections work in ClickHouse: normal (reordering) projections and aggregating projections, how the optimizer picks them, the storage and write-amplification trade-offs, backfilling existing data, and when a materialized view is the better choice."
+database: "clickhouse"
+category: "sql-how-to"
+tags: ["clickhouse", "sql", "projections", "mergetree", "query-optimization", "olap"]
+date: "2026-06-08"
+---
+
+# ClickHouse Projections
+
+A `MergeTree` table can only be physically sorted one way, by its `ORDER BY` key. That sort order and its sparse primary index are what make filtered queries fast. The problem is that real workloads query the same table many different ways, and only the queries that align with the sort key benefit from the index. Projections are ClickHouse's answer to that: each projection is a hidden, query-optimized copy of the table's data stored inside the same parts, with its own ordering or its own pre-computed aggregation.
+
+You can think of a projection as an additional table that lives attached to the original. When a query runs against the main table, the optimizer checks whether any projection can answer it with less data scanned, and if so it transparently reads from the projection instead. The query text does not change; the speedup is automatic.
+
+## Two Kinds of Projection
+
+There are two practical shapes:
+
+1. **Normal projections** store the same rows in a different order, giving you a second primary index on columns the main sort key does not cover.
+2. **Aggregating projections** pre-compute aggregates (similar to a materialized view) with an ordering aligned to the aggregation, so `GROUP BY` queries read pre-rolled-up data.
+
+### Normal Projection: A Second Sort Order
+
+Suppose your table is sorted by `(user_id, event_time)` but you frequently filter by `event_type`. Those queries cannot use the primary index and scan a lot of data. A normal projection sorted by `event_type` fixes that.
+
+```sql
+ALTER TABLE events ADD PROJECTION proj_by_type
+(
+    SELECT *
+    ORDER BY event_type
+);
+
+ALTER TABLE events MATERIALIZE PROJECTION proj_by_type;
+```
+
+Now a query like `SELECT * FROM events WHERE event_type = 'purchase'` can use the projection's `event_type` ordering to skip irrelevant granules, even though the main table is sorted by `user_id`.
+
+### Aggregating Projection: Pre-Computed Rollups
+
+If you repeatedly run the same aggregation, an aggregating projection stores the rolled-up result and keeps it incrementally up to date as new data arrives.
+
+```sql
+ALTER TABLE events ADD PROJECTION proj_daily_counts
+(
+    SELECT
+        event_type,
+        toDate(event_time) AS day,
+        count() AS cnt
+    GROUP BY event_type, day
+);
+
+ALTER TABLE events MATERIALIZE PROJECTION proj_daily_counts;
+```
+
+A matching query reads the pre-aggregated rows instead of scanning raw events:
+
+```sql
+SELECT event_type, toDate(event_time) AS day, count() AS cnt
+FROM events
+GROUP BY event_type, day;
+```
+
+The optimizer matches the query's grouping against the projection's structure. The aggregation in the query has to line up with what the projection precomputed; an aggregating projection only helps queries whose `GROUP BY` and aggregate functions match its definition.
+
+## How the Optimizer Chooses
+
+You can define more than one projection on a table. During query analysis ClickHouse picks the projection that scans the least data, without you changing the query. If no projection helps, it falls back to the base table. Projection use is controlled by the `optimize_use_projections` setting (on by default). To confirm a projection is actually being used, read the query plan:
+
+```sql
+EXPLAIN projections = 1
+SELECT event_type, count() FROM events GROUP BY event_type;
+```
+
+This shows whether a projection was selected and which one.
+
+## Backfilling Existing Data
+
+This is the most common surprise. When you `ADD PROJECTION`, only data inserted *after* that point is written into the projection. Existing parts are not touched until you explicitly materialize:
+
+```sql
+ALTER TABLE events MATERIALIZE PROJECTION proj_by_type;
+```
+
+`MATERIALIZE PROJECTION` rebuilds the projection for existing parts in the background. It is a mutation, so it can take time and I/O on a large table. Until it finishes, queries can only use the projection for the newer parts that already contain it.
+
+## Restrictions
+
+Projections do not support everything a normal query does. The key limitations:
+
+- No `LIMIT` or `OFFSET` in the projection definition.
+- No subqueries.
+- Aggregating projections only accelerate queries whose aggregation structure matches the projection.
+- A projection cannot reference columns outside the table or join other tables.
+- Some operations on the base table (certain `ALTER`s, lightweight deletes interacting with projections) have caveats depending on version; check behavior on your specific version before relying on it in production.
+
+## The Storage and Write Trade-Off
+
+Projections are not free. A normal projection that does `SELECT *` in a different order stores a full second copy of the data, so it can roughly double storage for that table, and if the projection orders by a column with poor compression it can use even more space than the source. Every insert also has to write into each projection, which multiplies write I/O. Aggregating projections are usually much smaller because they store rolled-up rows, which is part of why they are often the better trade-off.
+
+Budget for this. A table with three `SELECT *` normal projections is storing four copies of itself. Measure storage with `system.parts`:
+
+```sql
+SELECT
+    name AS projection,
+    sum(rows) AS rows,
+    formatReadableSize(sum(bytes_on_disk)) AS size
+FROM system.projection_parts
+WHERE table = 'events' AND active
+GROUP BY name;
+```
+
+## Projection or Materialized View?
+
+Projections and aggregating materialized views solve overlapping problems, and choosing between them trips people up.
+
+- **Projections** live inside the source table's parts, are managed automatically, and are chosen transparently by the optimizer. You query the original table and get the speedup for free. They are the simplest choice when you just want a second sort order or a rollup of the same table.
+- **Materialized views** write to a separate target table you query directly. They are more flexible: they can join, transform, route to a differently engined table (SummingMergeTree, AggregatingMergeTree), and fan out to multiple targets. But you have to query the target table yourself, and there is no automatic fallback.
+
+A rough rule: if you want a transparent speedup on the same table with no query changes, reach for a projection. If you need to reshape, route, or combine data into a separate structure, use a materialized view.
+
+## Common Mistakes
+
+- **Forgetting to materialize.** Adding a projection without `MATERIALIZE PROJECTION` leaves all existing data uncovered, so queries silently keep scanning the base table.
+- **Underestimating storage.** A `SELECT *` projection doubles the data. Three of them quadruple it. Check `system.projection_parts`.
+- **Expecting an aggregating projection to serve a different aggregation.** It only matches queries whose grouping and aggregates line up with its definition.
+- **Not verifying with EXPLAIN.** Assuming a projection is used without checking `EXPLAIN projections = 1`. If the query does not match, ClickHouse silently uses the base table.
+
+When you are tuning which projections actually get picked, Mako's AI autocomplete can help you draft the `EXPLAIN projections = 1` and `system.projection_parts` queries to confirm what the optimizer is doing.
+
+## Related Guides
+
+- [ClickHouse Materialized Views](/guides/clickhouse/materialized-views) for the separate-target-table alternative to aggregating projections.
+- [ClickHouse Partitioning](/guides/clickhouse/partitioning) for how data parts (which hold projections) are organized on disk.
+- [ClickHouse Aggregate Functions](/guides/clickhouse/aggregate-functions) for the aggregates you precompute in aggregating projections.
+
+---
+
+Mako connects to ClickHouse with AI-powered autocomplete for writing and exploring analytical queries. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/clickhouse/sampling.mdx
+++ b/content/guides/clickhouse/sampling.mdx
@@ -1,0 +1,114 @@
+---
+title: "ClickHouse SAMPLE Clause: Approximate Queries on Large Tables"
+description: "How sampling works in ClickHouse: declaring a SAMPLE BY key, the SAMPLE k / SAMPLE n / SAMPLE k OFFSET m forms, scaling aggregates with _sample_factor, determinism, and when approximate results are worth the speedup."
+database: "clickhouse"
+category: "sql-how-to"
+tags: ["clickhouse", "sql", "sampling", "approximate-queries", "performance", "olap"]
+date: "2026-06-05"
+---
+
+# ClickHouse SAMPLE Clause
+
+The `SAMPLE` clause lets a `SELECT` run against a fraction of a table instead of every row. On a multi-billion-row table, reading 10% of the data and scaling the result up is often accurate enough for dashboards, exploratory analysis, and trend monitoring, and it returns in a fraction of the time. The tradeoff is approximation: you trade exactness for latency, and that is only a good trade when an estimate is acceptable.
+
+Sampling is not free to bolt on. It works only on tables in the `MergeTree` family, and only when a sampling expression was declared when the table was created. You cannot add `SAMPLE` to an arbitrary existing query if the table has no sampling key.
+
+## Declaring a Sampling Key
+
+The sampling key is part of the table definition, set with `SAMPLE BY`. It must be an expression over columns that are also in the primary key (`ORDER BY`), and it should produce a value that is uniformly distributed. The common pattern is to hash an identifier column with `sipHash64` and include that hash in both the ordering key and the sampling key.
+
+```sql
+CREATE TABLE hits
+(
+    event_date  Date,
+    user_id     UInt64,
+    url         String,
+    duration_ms UInt32
+)
+ENGINE = MergeTree
+ORDER BY (event_date, sipHash64(user_id))
+SAMPLE BY sipHash64(user_id);
+```
+
+Hashing the `user_id` matters: it spreads users evenly across the sampling range, so a 10% sample is a roughly random 10% of users rather than a contiguous block of IDs. It also makes sampling deterministic by user, which is what makes the same user appear in the same sample every time (useful when you want session-level consistency).
+
+## SAMPLE k: a Fraction of the Data
+
+The most common form is `SAMPLE k`, where `k` is between 0 and 1. Both fractional and decimal notation work, so `SAMPLE 0.1` and `SAMPLE 1/10` are the same.
+
+```sql
+SELECT
+    url,
+    count() * 10 AS approx_views
+FROM hits
+SAMPLE 0.1
+WHERE event_date = '2026-06-01'
+GROUP BY url
+ORDER BY approx_views DESC
+LIMIT 100;
+```
+
+ClickHouse does not rescale aggregates for you. Because the query saw roughly 10% of the rows, `count()` returns roughly a tenth of the true count, so you multiply by 10 by hand. The same applies to `sum()`. Averages and ratios (`avg()`, or a ratio of two counts) do not need scaling, because the factor cancels out in the division.
+
+## SAMPLE n: at Least n Rows
+
+`SAMPLE n`, where `n` is a large integer, asks for a sample of at least `n` rows rather than a fixed fraction.
+
+```sql
+SELECT count() * any(_sample_factor) AS approx_total
+FROM hits
+SAMPLE 1000000;
+```
+
+The catch is that you do not know in advance what fraction `n` rows represents, so you cannot hardcode a multiplier. ClickHouse exposes the `_sample_factor` virtual column for exactly this. It holds the dynamically computed coefficient (for a 10% sample it is 10), so multiplying an aggregate by it gives the scaled estimate without you knowing the fraction up front.
+
+```sql
+SELECT sum(duration_ms * _sample_factor) AS approx_total_duration
+FROM hits
+SAMPLE 1000000
+WHERE event_date = '2026-06-01';
+```
+
+Because the minimum unit ClickHouse reads is one granule (its size is the `index_granularity` setting, 8192 rows by default), `n` only makes sense when it is much larger than a single granule. Asking for `SAMPLE 100` on a granule of 8192 will still read a whole granule.
+
+## SAMPLE k OFFSET m
+
+`SAMPLE k OFFSET m` takes a `k` fraction starting from offset `m` (both 0 to 1). This lets you read non-overlapping slices, for example to spread a heavy computation across several queries or to cross-check two disjoint samples.
+
+```sql
+-- first 10%
+SELECT count() * 10 FROM hits SAMPLE 0.1 OFFSET 0;
+-- a different, non-overlapping 10%
+SELECT count() * 10 FROM hits SAMPLE 0.1 OFFSET 0.1;
+```
+
+## Determinism
+
+Sampling in ClickHouse is deterministic: it is a hash of the sampling key, not a random draw at query time. Running the same `SAMPLE 0.1` against unchanged data returns the same rows every time. That is what makes results reproducible across runs and comparable over time, but it also means a sample is not statistically independent between runs. If you need a genuinely fresh random subset, sampling is not the tool; it is built for consistency, not for redrawing.
+
+## When Sampling Is Worth It
+
+- Large `MergeTree` tables where a 1 to 10% estimate answers the question (traffic trends, top-N pages, rough cardinalities).
+- Interactive exploration where you want sub-second feedback before committing to a full-table query.
+- Repeatable dashboards where the same approximate number each run is fine, or even preferable.
+
+Sampling is the wrong choice when you need exact counts (billing, financial reconciliation, compliance), when the table is small enough that a full scan is already fast, or when the sampled column is skewed in a way that the sampling key does not capture. It also offers little benefit if the table has no sampling key, since adding one means recreating or rewriting the table.
+
+## Common Mistakes
+
+- **Forgetting to scale aggregates.** `count()` and `sum()` under `SAMPLE k` return the sampled magnitude. Multiply by `1/k` (or use `_sample_factor`) or your numbers are silently low.
+- **Sampling a table with no sampling key.** The query errors. The key must be declared at table creation as part of `SAMPLE BY`.
+- **Using a poorly distributed sampling key.** If the key is not uniform (for example, a raw sequential ID instead of its hash), the sample is biased and the scaled estimate is wrong.
+- **Treating the sample as random across runs.** It is deterministic. The same fraction returns the same rows; do not expect independent draws.
+
+When you are validating that a sampled estimate tracks the true value, Mako's AI autocomplete can help you write the paired full-scan and sampled queries side by side so you can compare them quickly.
+
+## Related Guides
+
+- [ClickHouse Aggregate Functions](/guides/clickhouse/aggregate-functions) for the count and sum functions you scale after sampling.
+- [ClickHouse Date and Time Functions](/guides/clickhouse/date-functions) for the date filters that pair with sampling on time-series tables.
+- [ClickHouse Materialized Views](/guides/clickhouse/materialized-views) as an exact-rollup alternative when approximate answers are not acceptable.
+
+---
+
+Mako connects to ClickHouse with AI-powered autocomplete for writing and exploring analytical queries. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/clickhouse/string-functions.mdx
+++ b/content/guides/clickhouse/string-functions.mdx
@@ -1,0 +1,172 @@
+---
+title: "ClickHouse String Functions: A Practical Guide"
+description: "Working with strings in ClickHouse: length and case, substrings with 1-based indexing, splitting and joining, search and replace including regular expressions, and the UTF-8 versus byte distinction that trips people up."
+database: "clickhouse"
+category: "sql-how-to"
+tags: ["clickhouse", "sql", "strings", "regex", "utf8", "olap"]
+date: "2026-06-05"
+---
+
+# ClickHouse String Functions
+
+ClickHouse has a deep catalog of string functions, split across three documentation pages: general string functions, search functions, and replace functions. This guide pulls the practical subset together, shows the 1-based indexing and byte-versus-character distinction that cause most mistakes, and covers regular expressions, splitting, and joining.
+
+## The Byte vs Character Distinction
+
+This is the single most important thing to understand. Most ClickHouse string functions operate on **bytes**, not Unicode characters. For ASCII data they are identical, but for UTF-8 text with multi-byte characters they differ. The UTF-8-aware variants carry a `UTF8` suffix.
+
+```sql
+SELECT
+    length('café'),        -- 5  (bytes: é is two bytes in UTF-8)
+    lengthUTF8('café'),    -- 4  (characters)
+    upper('café'),         -- CAFÉ only if your locale handles it; ASCII-only by default
+    upperUTF8('café');     -- CAFÉ, correct Unicode case folding
+```
+
+Rule of thumb: if your data is plain ASCII, the byte functions are faster and correct. If you have accented characters, emoji, or non-Latin scripts and you care about character counts or case, reach for the `UTF8` variants. Mixing them silently is a common source of off-by-a-few bugs in `substring` calls.
+
+## Length and Case
+
+```sql
+SELECT
+    length(s),         -- length in bytes
+    lengthUTF8(s),     -- length in characters
+    empty(s),          -- 1 if the string is empty, else 0
+    notEmpty(s),
+    lower(s),          -- ASCII lowercasing
+    upper(s),
+    lowerUTF8(s),      -- Unicode-aware
+    upperUTF8(s),
+    reverse(s),        -- byte reversal
+    reverseUTF8(s)     -- character reversal
+FROM strings;
+```
+
+## Substrings (1-based indexing)
+
+ClickHouse uses 1-based indexing for string positions, like MySQL and standard SQL, not the 0-based indexing some languages use.
+
+```sql
+SELECT
+    substring('clickhouse', 6, 5)      AS sub,    -- 'house'
+    substring('clickhouse', 6)         AS to_end, -- 'house'
+    substringUTF8('café latte', 1, 4)  AS chars,  -- 'café' counted by character
+    left('clickhouse', 5)              AS first5, -- 'click'
+    right('clickhouse', 5)             AS last5;  -- 'house'
+```
+
+A negative start position counts from the end:
+
+```sql
+SELECT substring('clickhouse', -5, 5);  -- 'house'
+```
+
+`substringUTF8` exists for the same character-aware reasons described above. Slicing a multi-byte string with plain `substring` can cut a character in half and produce invalid UTF-8.
+
+## Trimming, Padding, Concatenation
+
+```sql
+SELECT
+    trimLeft('  hi  '),       -- 'hi  '
+    trimRight('  hi  '),      -- '  hi'
+    trimBoth('  hi  '),       -- 'hi'
+    leftPad('7', 3, '0'),     -- '007'
+    rightPad('7', 3, '_'),    -- '7__'
+    concat('click', 'house'), -- 'clickhouse'
+    concatWithSeparator('-', '2026', '06', '05'); -- '2026-06-05'
+```
+
+`concat` takes any number of arguments. `concatWithSeparator` (also written `concat_ws`) puts a delimiter between them, which is handy for building keys or CSV-style fields.
+
+## Searching Within Strings
+
+Search functions live on their own documentation page. The core ones:
+
+```sql
+SELECT
+    position('clickhouse', 'house'),       -- 6, the 1-based byte offset (0 if not found)
+    positionUTF8('café latte', 'latte'),   -- character offset
+    positionCaseInsensitive('ClickHouse', 'HOUSE'), -- 6
+    like('clickhouse', '%house'),          -- 1, SQL LIKE as a function
+    notLike('clickhouse', 'mysql%'),       -- 1
+    multiSearchAny('clickhouse', ['sql', 'house']), -- 1 if any needle matches
+    countSubstrings('a.b.c.d', '.');       -- 3
+```
+
+`position` returns the 1-based offset of the first match, or `0` when there is no match. That zero-means-absent convention matters: do not treat the result as a boolean directly, since `0` is falsy but a valid match at position 1 is truthy as expected.
+
+For matching against many patterns at once, the `multiSearch*` family is built for it and far faster than chaining many `position` calls or `OR`-ed `LIKE`s.
+
+## Regular Expressions
+
+ClickHouse uses the RE2 engine, which is fast and linear-time but deliberately does not support backreferences or lookahead/lookbehind. Most everyday patterns work; some Perl-style tricks do not.
+
+```sql
+SELECT
+    match('2026-06-05', '^\d{4}-\d{2}-\d{2}$'),       -- 1, full-string regex test
+    extract('order-12345', '\d+'),                    -- '12345', first match
+    extractAll('a1b2c3', '\d'),                        -- ['1','2','3']
+    replaceRegexpOne('2026-06-05', '-', '/'),          -- '2026/06-05', first only
+    replaceRegexpAll('2026-06-05', '-', '/'),          -- '2026/06/05', all
+    replaceOne('aaa', 'a', 'b'),                        -- 'baa', literal, first
+    replaceAll('aaa', 'a', 'b');                        -- 'bbb', literal, all
+```
+
+Capture groups are referenced with `\1`, `\2` in the replacement string:
+
+```sql
+-- Swap day and month in a date string
+SELECT replaceRegexpOne('05/06/2026', '(\d{2})/(\d{2})/(\d{4})', '\2/\1/\3');
+-- '06/05/2026'
+```
+
+Because RE2 has no backreferences, a pattern like `(\w+)\s+\1` to find a repeated word will not compile. If you need that, restructure the query or preprocess the data.
+
+## Splitting and Joining
+
+```sql
+SELECT
+    splitByChar('.', 'a.b.c'),          -- ['a','b','c']
+    splitByString('::', 'a::b::c'),     -- ['a','b','c']
+    splitByRegexp('\s+', 'one   two  three'), -- ['one','two','three']
+    arrayStringConcat(['a','b','c'], '-'); -- 'a-b-c'
+```
+
+`splitByChar` is the fast path for single-character delimiters; `splitByString` handles multi-character delimiters; `splitByRegexp` handles patterns. The inverse, `arrayStringConcat`, joins an array back into a string with a separator. Splitting produces an `Array(String)`, which pairs naturally with `arrayJoin` to explode rows or with the array higher-order functions for filtering.
+
+## A Realistic Example
+
+Parse a log line into structured columns:
+
+```sql
+SELECT
+    extract(line, '^\S+')                        AS ip,
+    parseDateTimeBestEffortOrNull(
+        extract(line, '\[([^\]]+)\]'))           AS ts,
+    extract(line, '"(\w+)\s')                    AS method,
+    toUInt16OrNull(extract(line, '"\s(\d{3})\s')) AS status
+FROM (SELECT '192.168.1.1 [05/Jun/2026:14:30:00] "GET /api HTTP/1.1" 200' AS line);
+```
+
+The pattern uses `extract` for each field, RE2-compatible regex throughout, and the `OrNull` parsers so malformed lines yield `NULL` rather than failing the whole query.
+
+## Common Mistakes
+
+- **Using byte functions on UTF-8 text.** `length('café')` is 5, not 4. Use `lengthUTF8` and `substringUTF8` when characters matter.
+- **Assuming 0-based string indexing.** ClickHouse is 1-based; `substring(s, 1, n)` starts at the first character.
+- **Treating `position`'s `0` as a position.** Zero means "not found"; a real match starts at 1.
+- **Expecting backreferences or lookahead in regex.** RE2 does not support them. Patterns relying on them will not compile.
+- **Confusing `replaceOne`/`replaceAll` with `replaceRegexpOne`/`replaceRegexpAll`.** The non-regex versions treat the pattern as a literal string, which is what you want when the needle contains characters like `.` or `*`.
+
+When you are reverse-engineering an unfamiliar string column, Mako's AI autocomplete surfaces the matching function names and their byte-versus-UTF-8 pairs as you type, which saves a few trips back to the docs.
+
+## Related Guides
+
+- [ClickHouse Date and Time Functions](/guides/clickhouse/date-functions)
+- [ClickHouse Aggregate Functions](/guides/clickhouse/aggregate-functions)
+- [ClickHouse JSON Queries](/guides/clickhouse/json-queries)
+- [ClickHouse JOINs](/guides/clickhouse/joins-guide)
+
+---
+
+Mako connects to ClickHouse with AI-powered autocomplete for queries like these. Try it free at mako.ai.

--- a/content/guides/clickhouse/table-functions.mdx
+++ b/content/guides/clickhouse/table-functions.mdx
@@ -1,0 +1,128 @@
+---
+title: "ClickHouse Table Functions: Querying External Data Without Importing"
+description: "How ClickHouse table functions let you SELECT from and INSERT into S3, files, URLs, remote ClickHouse, PostgreSQL, and MySQL without loading data first. Covers s3, file, url, remote, postgresql, mysql, schema inference, glob patterns, and when to promote a table function into a permanent table engine."
+database: "clickhouse"
+category: "sql-how-to"
+tags: ["clickhouse", "table-functions", "s3", "federated-queries", "data-import", "olap"]
+date: "2026-06-08"
+---
+
+# ClickHouse Table Functions
+
+A table function is a method for constructing a table on the fly inside a query. Instead of declaring a table with `CREATE TABLE` and loading data into it, you call a function in the `FROM` clause and ClickHouse treats the result as a readable (and sometimes writable) table for the duration of that query. This is how you query a Parquet file in S3, a CSV on disk, a PostgreSQL table, or another ClickHouse server without importing anything first.
+
+Table functions are the lighter half of a pair: most of them have a matching *table engine* (the `S3` engine, the `PostgreSQL` engine) that creates a persistent table backed by the same source. The function is for one-off and ad-hoc queries; the engine is for a connection you query repeatedly. This guide covers the common functions and when to graduate from one to the other.
+
+## Querying Files in Object Storage: s3
+
+The `s3` function reads and writes files in S3-compatible storage. ClickHouse infers the schema from the file format, so you often do not declare columns at all:
+
+```sql
+SELECT count()
+FROM s3(
+    'https://bucket.s3.amazonaws.com/data/events_2026.parquet',
+    'Parquet'
+);
+```
+
+A glob pattern reads many files as a single table, which is how you scan a partitioned data lake:
+
+```sql
+SELECT toStartOfMonth(event_time) AS month, count()
+FROM s3('https://bucket.s3.amazonaws.com/events/2026/*.parquet', 'Parquet')
+GROUP BY month
+ORDER BY month;
+```
+
+For private buckets, pass credentials as additional arguments (`s3(url, access_key_id, secret_access_key, format)`), though storing them in a named collection on the server is cleaner than inlining keys into every query. The same function also writes, which makes it an export path:
+
+```sql
+INSERT INTO FUNCTION s3('https://bucket.s3.amazonaws.com/export/out.parquet', 'Parquet')
+SELECT * FROM events WHERE event_date = today();
+```
+
+ClickHouse also ships `gcs` for Google Cloud Storage and `azureBlobStorage` for Azure, with the same shape as `s3`.
+
+## Local Files: file
+
+`file` does for the server's local filesystem what `s3` does for object storage. Paths are relative to the server's `user_files` directory unless configured otherwise:
+
+```sql
+SELECT * FROM file('logs/access.csv', 'CSVWithNames')
+LIMIT 10;
+```
+
+Schema inference works the same way, and glob patterns (`file('logs/*.csv', 'CSVWithNames')`) read directories. This is useful for loading data that has been staged on the same host, but note the path is on the *server*, not your client machine.
+
+## Remote Endpoints: url
+
+`url` reads from any HTTP(S) endpoint that returns data in a supported format:
+
+```sql
+SELECT *
+FROM url('https://example.com/data/sample.jsoneachrow', 'JSONEachRow')
+LIMIT 100;
+```
+
+It pairs well with quick exploration of published datasets and APIs that emit newline-delimited JSON or CSV. There is no caching: every query refetches the resource, so it is for ad-hoc reads, not a hot query path.
+
+## Other ClickHouse Servers: remote and remoteSecure
+
+`remote` runs a query against another ClickHouse instance and streams the result back, without setting up a Distributed table:
+
+```sql
+SELECT count()
+FROM remote('other-host:9000', 'analytics', 'events', 'default', 'password');
+```
+
+Use `remoteSecure` for TLS connections. It is handy for one-off cross-cluster checks and data copies (`INSERT INTO local SELECT * FROM remote(...)`), but for routine distributed reads a `Distributed` table or `clusterAllReplicas` is the better-engineered path.
+
+## Relational Sources: postgresql and mysql
+
+ClickHouse can query a live PostgreSQL or MySQL table directly. The argument order is the connection string, database, table, user, and password:
+
+```sql
+SELECT *
+FROM postgresql('pg-host:5432', 'app_db', 'customers', 'readonly_user', 'password')
+WHERE created_at >= '2026-01-01';
+```
+
+```sql
+SELECT *
+FROM mysql('mysql-host:3306', 'shop', 'orders', 'reader', 'password')
+LIMIT 1000;
+```
+
+ClickHouse pushes down what filters it can to the source database, but a query here hits the live OLTP server, so a heavy scan competes with that database's production traffic. For repeated access, prefer the `PostgreSQL` / `MySQL` table engine (a persistent table bound to the remote table) or, for PostgreSQL, the `MaterializedPostgreSQL` database engine, which replicates changes into ClickHouse so reads no longer touch the source. There is also the `INSERT INTO FUNCTION` form for writing back, where you must use the `FUNCTION` keyword so ClickHouse does not read the arguments as a column list.
+
+## Schema Inference and Its Limits
+
+For file-based functions (`s3`, `file`, `url`), ClickHouse samples the source and guesses column types. This is convenient for exploration but worth overriding for production loads: inference can pick a wider type than you need, or read everything as `Nullable`. You can supply an explicit structure as an argument, or inspect what ClickHouse guessed first:
+
+```sql
+DESCRIBE TABLE s3('https://bucket.s3.amazonaws.com/data/events.parquet', 'Parquet');
+```
+
+Self-describing formats like Parquet and ORC carry their own schema and infer reliably. CSV and TSV are guessed from a sample and are the most likely to need an explicit structure for stable, repeatable loads.
+
+## Function or Engine?
+
+The decision is about how often you touch the source:
+
+- **One-off query, ad-hoc export, exploring a new file**: use the table function. Nothing to declare, nothing to clean up.
+- **Repeated reads of the same external source**: create the matching table engine (`S3`, `PostgreSQL`, `MySQL`) so the connection details live in one place and queries stay short.
+- **You want the data to stop living elsewhere**: do a one-time `INSERT INTO local_table SELECT * FROM s3(...)` (or `postgresql(...)`) to land it in a MergeTree table, where ClickHouse's storage and indexing actually apply. A table function does not give you primary-key pruning or skip indexes; it reads the external source as-is.
+
+That last point is the common trap: querying a PostgreSQL table through the `postgresql` function repeatedly does not make it fast, because every query goes back to PostgreSQL. The speed comes from importing into a MergeTree table, at which point the table function was just the import mechanism.
+
+When you are exploring an external file or a remote table and want to draft the `DESCRIBE` and schema-inference queries quickly, Mako's AI autocomplete can help you shape them before you commit to a permanent table.
+
+## Related Guides
+
+- [Import CSV to ClickHouse](/guides/import-csv-to-clickhouse) for landing CSV data into a MergeTree table once you have explored it with `file` or `s3`.
+- [ClickHouse MergeTree Table Engines](/guides/clickhouse/mergetree-engines) for the storage layer you import into when a table function is too slow to query repeatedly.
+- [ClickHouse Dictionaries](/guides/clickhouse/dictionaries) for an alternative way to pull reference data from PostgreSQL or MySQL into fast in-memory lookups.
+
+---
+
+Mako connects to ClickHouse with AI-powered autocomplete for writing and exploring analytical queries. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/clickhouse/ttl.mdx
+++ b/content/guides/clickhouse/ttl.mdx
@@ -1,0 +1,159 @@
+---
+title: "ClickHouse TTL: Automating Data Lifecycle"
+description: "How TTL works in ClickHouse: row-level deletes, column-level expiry, moving data between storage tiers, rollups with TTL GROUP BY, recompression, when TTL actually fires during merges, and partitioning so whole partitions drop instead of rewriting parts."
+database: "clickhouse"
+category: "sql-how-to"
+tags: ["clickhouse", "sql", "ttl", "data-lifecycle", "storage", "olap"]
+date: "2026-06-05"
+---
+
+# ClickHouse TTL
+
+TTL (time-to-live) in ClickHouse is a set of declarative rules for what happens to data once it reaches a certain age. The name suggests deletion, but TTL covers more than that: it can delete rows, drop individual columns, move data to cheaper storage, recompress it, or roll it up into aggregates. The point is to manage the data lifecycle inside the database instead of running external cron jobs that issue `DELETE`s and `ALTER`s.
+
+TTL applies to `MergeTree`-family tables and works off an expression that resolves to a `Date` or `DateTime`. The expression is almost always a timestamp column plus an `INTERVAL`.
+
+## Row-Level TTL: Deleting Old Data
+
+The most common use is dropping rows after they expire. Declare it at the end of the table definition.
+
+```sql
+CREATE TABLE events
+(
+    event_time DateTime,
+    user_id    UInt64,
+    payload    String
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMMDD(event_time)
+ORDER BY (user_id, event_time)
+TTL event_time + INTERVAL 30 DAY;
+```
+
+Rows where `event_time` is more than 30 days old become eligible for deletion. You can also add a `WHERE` clause to delete only a subset:
+
+```sql
+TTL event_time + INTERVAL 30 DAY DELETE WHERE payload = ''
+```
+
+## Column-Level TTL
+
+A `TTL` clause can sit on a single column instead of the whole row. When it expires, the column is reset to its default value for the affected rows while the rest of the row stays. This is useful for dropping bulky fields (raw payloads, debug blobs) while keeping the lightweight columns around longer.
+
+```sql
+CREATE TABLE example1
+(
+    timestamp DateTime,
+    x UInt32 TTL timestamp + INTERVAL 1 MONTH,
+    y String TTL timestamp + INTERVAL 1 DAY,
+    z String
+)
+ENGINE = MergeTree
+ORDER BY tuple();
+```
+
+Here `y` is wiped a day after its timestamp, `x` a month after, and `z` is kept indefinitely.
+
+## Moving Data Between Storage Tiers
+
+With a storage policy that defines multiple volumes (for example fast SSD and cheaper HDD or object storage), TTL can move data between them as it ages. This is tiered storage: hot data on fast disks, cold data on cheap disks, all driven by one rule.
+
+```sql
+TTL
+    event_time + INTERVAL 7 DAY TO VOLUME 'hot',
+    event_time + INTERVAL 30 DAY TO VOLUME 'cold',
+    event_time + INTERVAL 365 DAY DELETE
+```
+
+`TO DISK 'name'` targets a specific disk; `TO VOLUME 'name'` targets a named volume in the policy. The moves and the final delete are all expressed in a single `TTL` clause.
+
+## Rollups with TTL GROUP BY
+
+TTL can aggregate expired rows instead of deleting them, collapsing fine-grained old data into coarser summaries. The `GROUP BY` must be a prefix of the table's `ORDER BY` key, and the aggregated columns are set with `SET`.
+
+```sql
+CREATE TABLE metrics
+(
+    event_date Date,
+    name       String,
+    value      UInt64
+)
+ENGINE = MergeTree
+ORDER BY (name, event_date)
+TTL event_date + INTERVAL 90 DAY
+    GROUP BY name
+    SET value = sum(value);
+```
+
+After 90 days, rows collapse to one row per `name` with the summed value, shrinking storage while keeping long-term totals. Note that you can only specify one `GROUP BY` rollup rule; multiple `GROUP BY` or `DELETE WHERE` rules in the same TTL are not supported.
+
+## Recompression
+
+TTL can switch the compression codec on aging data, trading CPU for a smaller footprint on cold data that is rarely read.
+
+```sql
+TTL
+    event_time + INTERVAL 7 DAY RECOMPRESS CODEC(ZSTD(1)),
+    event_time + INTERVAL 30 DAY RECOMPRESS CODEC(ZSTD(6));
+```
+
+Fresh data stays on a fast, light codec; older data is recompressed with a higher ZSTD level for better ratio.
+
+## When TTL Actually Fires
+
+This is the part that surprises people: TTL does not run on a timer the moment data expires. Deletion, moving, and rollups happen during background **merges**. If a table is not actively merging, expired data can sit around past its TTL.
+
+Two settings nudge this along: `merge_with_ttl_timeout` (for delete and move TTLs) and `merge_with_recompression_ttl_timeout` (for recompression TTLs). By default TTL rules are applied at least roughly every 4 hours. Lower these if you need expiry to happen sooner.
+
+To force it immediately, run a merge by hand:
+
+```sql
+OPTIMIZE TABLE events FINAL;
+```
+
+`OPTIMIZE` triggers an unscheduled merge, and `FINAL` forces reoptimization even if the table is already a single part. This is heavy on large tables, so reserve it for one-off cleanup, not routine operation.
+
+## Partition for Efficient Expiry
+
+For row-level delete TTL, partition the table by the same time field used in the TTL, at a granularity that matches the TTL period:
+
+- TTL in days or weeks: partition by day with `toYYYYMMDD(date_field)`.
+- TTL in months or years: partition by month with `toYYYYMM(date_field)` or `toStartOfMonth(date_field)`.
+
+When the partition key aligns with the TTL expression, ClickHouse drops whole expired partitions at once instead of rewriting data parts to strip out individual rows. Dropping a partition is far cheaper than rewriting parts, so this alignment is the single biggest lever on TTL cost.
+
+## Altering and Materializing TTL
+
+TTL rules are not fixed at creation. You can add or change them later:
+
+```sql
+ALTER TABLE events MODIFY TTL event_time + INTERVAL 60 DAY;
+```
+
+By default, modifying TTL does not immediately rewrite existing data. To apply a new rule to data already on disk, materialize it:
+
+```sql
+ALTER TABLE events MATERIALIZE TTL;
+```
+
+If you only want ClickHouse to recalculate which data is expired without a full rewrite, the `materialize_ttl_recalculate_only` setting controls that behavior.
+
+## Common Mistakes
+
+- **Expecting instant deletion.** TTL fires during merges, not at the expiry instant. Without merges, expired rows linger; tune `merge_with_ttl_timeout` or run `OPTIMIZE ... FINAL` for one-off cleanup.
+- **Not partitioning by the TTL field.** Without aligned partitioning, ClickHouse rewrites parts to remove rows instead of dropping whole partitions, which is much more expensive.
+- **Using a non-Date/DateTime expression.** The TTL expression must resolve to `Date` or `DateTime`. An integer epoch column will not work directly without conversion.
+- **Assuming MODIFY TTL rewrites old data.** It does not by default. Run `ALTER TABLE ... MATERIALIZE TTL` to apply a new rule to existing parts.
+- **Trying multiple GROUP BY rollup rules.** Only one `GROUP BY` rollup is allowed per table TTL.
+
+When you are layering several TTL actions (move, then recompress, then delete) on one table, Mako's AI autocomplete can help you draft and read the multi-rule TTL clause so the intervals and targets line up the way you intend.
+
+## Related Guides
+
+- [ClickHouse Materialized Views](/guides/clickhouse/materialized-views) for building the pre-aggregated tables that TTL rollups feed into.
+- [ClickHouse Date and Time Functions](/guides/clickhouse/date-functions) for the toYYYYMM/toStartOfMonth expressions used in partitioning and TTL.
+- [ClickHouse Aggregate Functions](/guides/clickhouse/aggregate-functions) for the sum and other aggregates used in TTL GROUP BY rollups.
+
+---
+
+Mako connects to ClickHouse with AI-powered autocomplete for writing and exploring analytical queries. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/clickhouse/updating-and-deleting-data.mdx
+++ b/content/guides/clickhouse/updating-and-deleting-data.mdx
@@ -1,0 +1,123 @@
+---
+title: "Updating and Deleting Data in ClickHouse"
+description: "How to update and delete rows in ClickHouse: heavyweight mutations (ALTER TABLE UPDATE/DELETE), lightweight deletes, lightweight updates, why they rewrite parts, how to monitor mutation progress in system.mutations, and engine-based alternatives that avoid mutations entirely."
+database: "clickhouse"
+category: "sql-how-to"
+tags: ["clickhouse", "mutations", "update", "delete", "lightweight-delete", "olap"]
+date: "2026-06-08"
+---
+
+# Updating and Deleting Data in ClickHouse
+
+ClickHouse is built for data that is written once and read many times, so it does not support row-level `UPDATE` and `DELETE` the way an OLTP database like PostgreSQL or MySQL does. There is no transaction that flips a few bytes in place. Instead, modifying existing data means rewriting the immutable parts that contain it, and ClickHouse gives you several mechanisms with very different cost profiles. Picking the wrong one is the difference between a query that finishes in milliseconds and a background operation that rewrites terabytes.
+
+This guide covers the four options (heavyweight mutations, lightweight deletes, lightweight updates, and avoiding mutations entirely through engine choice) and how to tell which one a given workload needs.
+
+## Why There Is No In-Place Update
+
+ClickHouse stores table data in immutable parts, sorted by the table's `ORDER BY` key. "Immutable" is the key word: a part is never edited after it is written. So changing even a single row means reading the parts that contain matching rows, producing new parts with the change applied, and discarding the old parts. That is inherently expensive, and it is why ClickHouse treats updates and deletes as background operations called *mutations* rather than instant statements.
+
+If you find yourself wanting frequent row-level updates, that is usually a signal to reconsider the table design (for example, a [ReplacingMergeTree](/guides/clickhouse/mergetree-engines) engine) rather than to lean on mutations.
+
+## Heavyweight Mutations: ALTER TABLE UPDATE and DELETE
+
+The original mechanism is the mutation, issued through `ALTER TABLE`:
+
+```sql
+-- Update
+ALTER TABLE events
+UPDATE value = value * 1.1
+WHERE event_type = 'purchase';
+
+-- Delete
+ALTER TABLE events
+DELETE WHERE event_date < '2025-01-01';
+```
+
+When you run one of these, ClickHouse identifies every part containing rows that match the `WHERE` clause and rewrites each of those parts in full, applying the change. A `DELETE WHERE event_date < '2025-01-01'` does not just drop the matching rows; it rewrites the entire part each matching row lived in. If your predicate touches rows scattered across many parts, the mutation rewrites all of them.
+
+Mutations are asynchronous by default. The `ALTER` statement returns almost immediately, and the actual work happens in the background. That means the change is not necessarily visible to subsequent `SELECT` queries right away. To wait for completion, set `mutations_sync`:
+
+```sql
+SET mutations_sync = 1;  -- wait for the current replica
+SET mutations_sync = 2;  -- wait for all replicas
+```
+
+You monitor in-flight and completed mutations through the `system.mutations` table:
+
+```sql
+SELECT database, table, mutation_id, command, is_done, latest_fail_reason
+FROM system.mutations
+WHERE is_done = 0;
+```
+
+`is_done = 0` means the mutation is still running. If a mutation is stuck or wrong, you can cancel it:
+
+```sql
+KILL MUTATION WHERE mutation_id = '0000000001';
+```
+
+Because each mutation rewrites whole parts, running many small mutations is far more expensive than batching changes into one. Avoid per-row updates in a loop; combine them into a single `WHERE` predicate where possible.
+
+## Lightweight Deletes
+
+The `DELETE FROM` statement (available for the MergeTree family) is the lightweight alternative to `ALTER TABLE ... DELETE`:
+
+```sql
+DELETE FROM events WHERE event_type = 'test';
+```
+
+Despite the name, a lightweight delete is still implemented as a mutation under the hood, but a cheaper one. Instead of immediately rewriting parts, it marks matching rows as deleted using an internal `_row_exists` mask. Subsequent queries automatically filter out the masked rows, so the data disappears from results right away even though it is still physically on disk. The physical removal happens later, during a normal background merge.
+
+This makes lightweight deletes much faster to issue than a heavyweight `ALTER TABLE ... DELETE`, and it is the right default for most ad-hoc deletes. The trade-offs to know:
+
+- The masked rows still occupy disk until merges reclaim the space, so a lightweight delete does not free storage instantly.
+- Because masked rows are filtered at read time, queries carry a small overhead until merges physically remove the rows.
+- It only works on `*MergeTree` engines.
+
+For deleting a whole time range that aligns with your partition key, neither delete type is the best tool. Use `ALTER TABLE ... DROP PARTITION` instead, which removes the data directory outright with almost no cost. See the [partitioning guide](/guides/clickhouse/partitioning) for how to align partitions with your deletion patterns, and [TTL](/guides/clickhouse/ttl) for automating age-based deletion without issuing any delete at all.
+
+## Lightweight Updates
+
+More recent ClickHouse versions add lightweight updates via the `UPDATE` statement, mirroring lightweight deletes:
+
+```sql
+UPDATE events SET value = 0 WHERE event_type = 'refund';
+```
+
+Rather than rewriting parts up front, a lightweight update records the change in a patch and applies it on the fly when rows are read, with the physical rewrite deferred to a later merge. This makes the `UPDATE` return quickly and makes the new value visible to reads without waiting for a full part rewrite. As with lightweight deletes, the underlying storage is reconciled during background merges. Lightweight updates are newer than the other mechanisms, so confirm support and behavior in your specific server version against the official docs before relying on them in production (as of mid-2026 the feature is still maturing across releases).
+
+## Avoiding Mutations Entirely
+
+Often the best update or delete is the one you never issue. ClickHouse offers engine-level patterns that handle changing data as part of normal merges:
+
+- **ReplacingMergeTree** keeps one row per sorting key, so writing a new version of a row supersedes the old one on merge. This covers most "upsert" needs. Reads use `FINAL` or an `argMax` aggregation to see the latest version before merges run.
+- **CollapsingMergeTree / VersionedCollapsingMergeTree** cancel out old rows using a `sign` column, suited to high-throughput mutable data.
+- **TTL** expires rows automatically based on a time expression, replacing scheduled delete jobs.
+
+These are covered in the [MergeTree engines guide](/guides/clickhouse/mergetree-engines). The pattern is the same in each case: instead of editing existing data, you write new data and let the merge process resolve it, which is what ClickHouse is optimized for.
+
+## Choosing an Approach
+
+| You want to | Use | Cost |
+| --- | --- | --- |
+| Delete a whole partition / time range | `DROP PARTITION` | Near-zero; drops directories |
+| Delete scattered rows ad hoc | `DELETE FROM` (lightweight) | Cheap to issue; merges reclaim space later |
+| Bulk one-off update across many parts | `ALTER TABLE ... UPDATE` | Heavy; rewrites whole parts |
+| Update rows and see the change fast | `UPDATE` (lightweight, recent versions) | Moderate; applied on read, reconciled on merge |
+| Continuously upsert by key | `ReplacingMergeTree` | Built into merges; no mutation |
+| Age out old data automatically | `TTL` | Built into merges; no mutation |
+
+The mental model that keeps you out of trouble: every modification in ClickHouse ultimately rewrites immutable parts, so the cheapest operation is the one that touches the fewest parts. Dropping a partition touches none of the surviving data. Lightweight deletes defer the rewrite. Heavyweight mutations rewrite everything matching immediately. And the engine-based patterns avoid the explicit operation altogether by folding the change into merges you are already paying for.
+
+When you are inspecting `system.mutations` to see whether a mutation has finished or diagnosing why one is stuck, Mako's AI autocomplete can help you draft the monitoring queries.
+
+## Related Guides
+
+- [ClickHouse MergeTree Table Engines](/guides/clickhouse/mergetree-engines) for the engine-based alternatives to mutations.
+- [ClickHouse Partitioning](/guides/clickhouse/partitioning) for dropping whole partitions instead of deleting rows.
+- [ClickHouse TTL](/guides/clickhouse/ttl) for automating age-based deletion.
+
+---
+
+Mako connects to ClickHouse with AI-powered autocomplete for writing and exploring analytical queries. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/clickhouse/window-functions.mdx
+++ b/content/guides/clickhouse/window-functions.mdx
@@ -162,6 +162,7 @@ When you are exploring these on a real dataset, Mako's AI autocomplete can sugge
 
 - [Import CSV to ClickHouse](/guides/import-csv-to-clickhouse) to load test data quickly.
 - [ClickHouse vs BigQuery](/guides/clickhouse-vs-bigquery) for choosing an analytical store.
+- [ClickHouse Aggregate Functions](/guides/clickhouse/aggregate-functions) for combinators, uniq, and quantiles.
 - [Best ClickHouse GUI Client](/guides/clickhouse-gui-client) for running these queries interactively.
 
 ---

--- a/content/guides/clickhouse/window-functions.mdx
+++ b/content/guides/clickhouse/window-functions.mdx
@@ -1,0 +1,169 @@
+---
+title: "ClickHouse Window Functions: ROW_NUMBER, RANK, LAG, Running Totals"
+description: "How to use window functions in ClickHouse with OVER, PARTITION BY, and frame clauses. Covers ROW_NUMBER, RANK, LAG/LEAD, moving averages, and the RANGE-default gotcha."
+database: "clickhouse"
+category: "sql-how-to"
+tags: ["clickhouse", "sql", "window-functions", "analytics", "olap"]
+date: "2026-06-04"
+---
+
+# ClickHouse Window Functions
+
+Window functions compute values across a set of rows related to the current row, without collapsing those rows into one. They are the standard way to express running totals, rankings, and row-to-row comparisons that would otherwise need self-joins.
+
+ClickHouse added window functions in version 21.1 (early 2021) and removed the experimental flag in 21.9. If you are on a recent release, they work out of the box.
+
+## Sample Schema
+
+```sql
+CREATE TABLE sales
+(
+    region      String,
+    sale_date   Date,
+    amount      UInt32
+)
+ENGINE = MergeTree
+ORDER BY (region, sale_date);
+
+INSERT INTO sales VALUES
+    ('north', '2026-01-01', 100),
+    ('north', '2026-01-02', 150),
+    ('north', '2026-01-03', 120),
+    ('south', '2026-01-01', 200),
+    ('south', '2026-01-02', 180);
+```
+
+## The Anatomy of a Window Function
+
+```sql
+SELECT
+    region,
+    sale_date,
+    amount,
+    sum(amount) OVER (PARTITION BY region ORDER BY sale_date) AS running_total
+FROM sales
+ORDER BY region, sale_date;
+```
+
+- `PARTITION BY region` splits rows into independent groups. The window restarts for each region.
+- `ORDER BY sale_date` orders rows within each partition. It also defines the default frame (see the gotcha below).
+- `OVER (...)` marks the function as a window function rather than a grouping aggregate.
+
+If you omit `PARTITION BY`, the whole result set is one partition.
+
+## Ranking Functions
+
+```sql
+SELECT
+    region,
+    amount,
+    row_number() OVER (PARTITION BY region ORDER BY amount DESC) AS rn,
+    rank()       OVER (PARTITION BY region ORDER BY amount DESC) AS rnk,
+    dense_rank() OVER (PARTITION BY region ORDER BY amount DESC) AS dense_rnk
+FROM sales;
+```
+
+- `row_number()` assigns a unique sequential number, even for ties.
+- `rank()` gives tied rows the same rank, then skips the next values (1, 1, 3).
+- `dense_rank()` gives tied rows the same rank without gaps (1, 1, 2).
+
+To get the top N rows per group, wrap this in a subquery and filter on `rn <= N`. ClickHouse also has `LIMIT N BY` for the simple "top N per key" case, which is often faster:
+
+```sql
+SELECT region, amount
+FROM sales
+ORDER BY region, amount DESC
+LIMIT 2 BY region;
+```
+
+`LIMIT BY` is a ClickHouse extension, not standard SQL. Reach for it when you only need top-N and don't need the rank value itself.
+
+## LAG and LEAD: Comparing to Neighboring Rows
+
+ClickHouse provides `lagInFrame` and `leadInFrame`. The plain `lag`/`lead` names are not the standard implementation here, so use the `InFrame` variants:
+
+```sql
+SELECT
+    region,
+    sale_date,
+    amount,
+    lagInFrame(amount) OVER w AS prev_amount,
+    amount - lagInFrame(amount) OVER w AS day_over_day
+FROM sales
+WINDOW w AS (PARTITION BY region ORDER BY sale_date
+             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+ORDER BY region, sale_date;
+```
+
+Two things to note. First, `lagInFrame` looks within the current frame, so to see all preceding and following rows you usually want an explicit `ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING` frame. Second, the `WINDOW` clause names a window once and reuses it, which keeps long queries readable.
+
+`lagInFrame` and `leadInFrame` accept an optional offset and default value: `lagInFrame(amount, 2, 0)` looks two rows back and returns 0 at the boundary.
+
+## Frame Clauses and the RANGE Default
+
+A frame restricts which rows within the partition the function sees. The two common modes:
+
+- `ROWS` counts physical rows relative to the current row.
+- `RANGE` works on logical value ranges, treating rows with equal `ORDER BY` values (peers) as one unit.
+
+The detail that trips people up: in ClickHouse, when you specify `ORDER BY` without an explicit frame, the default frame is `RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`. Because `RANGE` includes all peer rows, a running `sum` over a column with duplicate sort values will jump to the full peer-group total at each tie, not increment row by row. If you want strict row-by-row accumulation, be explicit:
+
+```sql
+sum(amount) OVER (PARTITION BY region ORDER BY sale_date
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+```
+
+One ClickHouse-specific limitation worth knowing (verified against the ClickHouse window-functions docs, as of June 2026): the `INTERVAL` syntax for a `DateTime` `RANGE OFFSET` frame is not supported. You cannot write `RANGE BETWEEN INTERVAL 7 DAY PRECEDING AND CURRENT ROW`. Instead you specify the offset as a number of seconds, or restructure the query to use `ROWS` over pre-bucketed data.
+
+## Moving Averages
+
+A 3-row moving average, including the current row and the two before it:
+
+```sql
+SELECT
+    region,
+    sale_date,
+    amount,
+    avg(amount) OVER (PARTITION BY region ORDER BY sale_date
+                      ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) AS moving_avg_3
+FROM sales
+ORDER BY region, sale_date;
+```
+
+At the start of each partition the frame simply contains fewer rows, so the first row's average is just its own value. This is correct behavior, not an edge case to guard against, but be aware your early data points are averaged over a smaller window.
+
+## First and Last Values in a Frame
+
+```sql
+SELECT
+    region,
+    sale_date,
+    amount,
+    first_value(amount) OVER w AS first_in_partition,
+    last_value(amount)  OVER w AS last_in_partition
+FROM sales
+WINDOW w AS (PARTITION BY region ORDER BY sale_date
+             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+ORDER BY region, sale_date;
+```
+
+`last_value` is the classic trap across every SQL engine: with the default frame ending at the current row, `last_value` returns the current row, not the partition's last row. The explicit `UNBOUNDED FOLLOWING` frame above fixes it.
+
+## Common Mistakes
+
+- **Forgetting the `lagInFrame` frame.** With the default `CURRENT ROW`-bounded frame, `lagInFrame` and `leadInFrame` can return defaults where you expected neighbors. Set an explicit wide frame.
+- **Assuming `RANGE` increments per row.** It groups peers. Use `ROWS` for true running counters.
+- **Reaching for `INTERVAL` in a frame.** Not supported; convert to seconds or pre-bucket.
+- **Using `lag`/`lead` instead of `lagInFrame`/`leadInFrame`.** Use the `InFrame` variants in ClickHouse.
+
+When you are exploring these on a real dataset, Mako's AI autocomplete can suggest the window and frame syntax as you type, which helps when you are switching between the `ROWS` and `RANGE` semantics.
+
+## Related Guides
+
+- [Import CSV to ClickHouse](/guides/import-csv-to-clickhouse) to load test data quickly.
+- [ClickHouse vs BigQuery](/guides/clickhouse-vs-bigquery) for choosing an analytical store.
+- [Best ClickHouse GUI Client](/guides/clickhouse-gui-client) for running these queries interactively.
+
+---
+
+Mako connects to ClickHouse with AI-powered autocomplete for writing and exploring analytical queries. Try it free at [mako.ai](https://mako.ai).


### PR DESCRIPTION
Batch 8 opens the ClickHouse SQL how-to series, mirroring the PostgreSQL/MySQL/SQLite batches (5/6/7).

**This run (2 guides):**
- `clickhouse/window-functions` — ROW_NUMBER/RANK/DENSE_RANK, lagInFrame/leadInFrame, frame clauses + the RANGE-default gotcha, moving averages, first/last_value trap, LIMIT BY extension.
- `clickhouse/aggregate-functions` — the combinator system (-If/-Array/-State/-Merge), uniq vs uniqExact, quantile two-part syntax, groupArray/groupUniqArray, argMin/argMax.

Facts verified against official ClickHouse docs (June 2026): RANGE is the default frame; INTERVAL syntax for RANGE OFFSET is unsupported (seconds only); combinator suffixes confirmed on the combinators reference page.

Quality: 0 banned words, 0 em dashes, single CTA each, full frontmatter, internal cross-links.

**Why ClickHouse for Batch 8:** only remaining axis that's SQL-native enough to reuse the how-to mirror format directly. MongoDB needs an aggregation-pipeline shape; BigQuery is heavily covered by Google's own docs. We already have ClickHouse GUI + import guides, so the internal-link web and CTA hold.