### PR TITLE
docs: utility model, dashboard version commit messages, chat image attachments

### DIFF
--- a/docs/src/content/docs/ai-agent.md
+++ b/docs/src/content/docs/ai-agent.md
@@ -137,6 +137,12 @@ Models tagged with `reasoning` in the Gateway catalog automatically enable exten
 
 Users pick their preferred model in the chat UI. The model is persisted per-user in workspace settings. If a user's saved model becomes unavailable (e.g. billing downgrade), Mako falls back to the best available model for their plan.
 
+### Utility / Fast Model
+
+Cheap, high-volume tasks — AI-suggested version commit messages, summaries, and other internal helpers — run on a dedicated **utility model** instead of the user's chosen chat model. By default Mako auto-selects the cheapest capable tool-use model, cheapest first.
+
+A super admin can pin an explicit utility model from **Settings → Admin → Model curation** (`PUT /api/admin/catalog/defaults` with `utilityModelId`). The pinned model is promoted to the front of the ranking as long as it stays visible in the catalog; if it disappears, Mako falls back to the cheapest available model. Set it to `null` to return to automatic selection.
+
 ## Safety
 
 - SELECT queries are auto-limited to 500 rows unless you explicitly override

--- a/docs/src/content/docs/api-reference.md
+++ b/docs/src/content/docs/api-reference.md
@@ -220,6 +220,7 @@ The response is a **Server-Sent Events (SSE)** stream:
 | `GET`    | `/api/workspaces/:wid/chats/:id` | Get chat details   |
 | `PUT`    | `/api/workspaces/:wid/chats/:id` | Update chat title  |
 | `DELETE` | `/api/workspaces/:wid/chats/:id` | Delete a chat      |
+| `GET`    | `/api/workspaces/:wid/chat-images/:attachmentId` | Fetch a stored chat image attachment (authenticated proxy) |
 
 
 ## Skills
@@ -266,6 +267,7 @@ All endpoints require authentication and workspace access. Agent-side CRUD is av
 | `PUT`    | `/api/workspaces/:wid/dashboards/:did`                           | Update dashboard                     |
 | `DELETE` | `/api/workspaces/:wid/dashboards/:did`                           | Delete dashboard                     |
 | `POST`   | `/api/workspaces/:wid/dashboards/:did/duplicate`                 | Duplicate a dashboard                |
+| `POST`   | `/api/workspaces/:wid/dashboards/:did/version-comment`           | AI-suggested commit message for pending changes |
 
 ### Dashboard Folders
 

--- a/docs/src/content/docs/dashboards.md
+++ b/docs/src/content/docs/dashboards.md
@@ -135,6 +135,18 @@ Dashboards use an edit lock to prevent concurrent editing conflicts:
 
 If another user holds the lock, a confirmation dialog offers to take over.
 
+## Versioning & Commit Messages
+
+Saving a dashboard creates a version snapshot in its history. When you save, the **Save version** dialog asks for a **Commit message** describing what changed — this labels the saved version in its history, not the dashboard itself.
+
+Mako can suggest the commit message for you. On save, it diffs the pending dashboard definition against the latest saved snapshot (volatile cache state stripped) and folds in the chat prompts that drove the changes, then drafts a message with the cheap [utility model](/ai-agent/#utility--fast-model). This mirrors how console versions work.
+
+```
+POST /api/workspaces/:wid/dashboards/:did/version-comment
+```
+
+Returns `{ "comment": "..." }` — the suggested message for the changes about to be saved. You can accept it as-is or edit before confirming the save.
+
 ## Scheduled Refresh
 
 Data sources can be refreshed on a schedule using cron expressions:


### PR DESCRIPTION
## What

Documents three features merged in the last 24h that had zero docs.

### 1. Super-admin configurable utility/fast model (`b2a4f53c`)
`ai-agent.md` → new **Utility / Fast Model** section. Cheap high-volume tasks (version comments, summaries) run on a dedicated utility model; super admins can pin `utilityModelId` via `PUT /api/admin/catalog/defaults`.

### 2. AI-suggested dashboard version commit messages (`0731dab9`)
`dashboards.md` → new **Versioning & Commit Messages** section. Documents the renamed 'Commit message' field and the new `POST .../dashboards/:did/version-comment` endpoint. Also added to `api-reference.md`.

### 3. Chat image attachments in object storage (`847d307e` / #436)
`api-reference.md` → documented the authenticated proxy `GET .../chat-images/:attachmentId`.

## Why
Daily docs-maintenance audit caught drift: 3 merged feature commits with no corresponding doc coverage.

🤖 Generated by Aura docs-maintenance job