### PR TITLE
fix(agent): find existing consoles by name before recreating

### DIFF
--- a/api/src/agent-lib/prompts/universal.ts
+++ b/api/src/agent-lib/prompts/universal.ts
@@ -28,6 +28,7 @@ When working with consoles, your primary goal is to provide a working, executabl
 - Determine if this is a NEW question or a FOLLOW-UP to your previous work
 
 **Step 2: Choose your console**
+- **User references a console by name/topic that is NOT in Open Tabs:** You MUST call \`search_consoles\` FIRST to find it. If a match is found, \`open_console\` then \`read_console\` and modify that console. Only fall through to creating a new console if the search returns nothing. Do NOT create a new console for a console the user is clearly referring to by name (e.g. "update the franc engagement score console").
 - **Follow-up on same topic:** Use the same console you've been working with
 - **New question, active console is suitable:** Use active console (if empty or user's question relates to its content)
 - **New question, active console has unrelated valuable content:** Create a NEW console
@@ -217,6 +218,8 @@ Calculates monthly sales by product using BigQuery's backtick identifiers and FO
 ### **10. Console Management**
 
 **Golden rule: never overwrite a console that has unrelated content. Create a new one instead.**
+
+**Find-before-create rule (applies BEFORE the golden rule):** If the user refers to an existing console by name or topic (e.g. "update the franc engagement score console") and it is NOT listed in Open Tabs / Open Consoles, call \`search_consoles\` to locate it. Note that the injected "Relevant Saved Consoles" hints may be empty even when the console exists — so when the user clearly names a console, search for it explicitly rather than assuming it's absent. If found, \`open_console\` + \`read_console\`, then modify it. Creating a new console is the LAST resort, only after search returns no match.
 
 **Decision Tree: Which console to use?**
 

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -41,10 +41,6 @@ import {
   extractConsoleContextFromMessages,
   generateDescriptionAndEmbedding,
 } from "../services/console-description.service";
-import {
-  isEmbeddingAvailable,
-  isVectorSearchAvailable,
-} from "../services/embedding.service";
 import { searchConsoles } from "../agent-lib/tools/console-search-tools";
 import {
   retrieveRelevantSkills,
@@ -517,15 +513,19 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
       .map(p => p.text)
       .join("") ?? "";
 
-  // Auto-discover relevant consoles via embedding search (parallel with other setup)
+  // Auto-discover relevant consoles (parallel with other setup).
+  // `searchConsoles` internally prefers vector search but falls back to
+  // MongoDB $text and regex-name search, so we run it regardless of whether
+  // Atlas vector search / embeddings are available — otherwise self-hosted /
+  // local Mongo deployments would get zero hints and the agent would recreate
+  // consoles it could have found by name.
   let consoleHints = "";
   if (
     (resolvedAgentId === "console" || resolvedAgentId === "unified") &&
-    isEmbeddingAvailable() &&
     messages.length > 0
   ) {
     try {
-      if (lastUserText.length >= 5 && (await isVectorSearchAvailable())) {
+      if (lastUserText.length >= 5) {
         const hints = await searchConsoles(lastUserText, workspaceId, 3);
         if (hints.length > 0) {
           consoleHints =


### PR DESCRIPTION
## Summary

The console agent often **recreated a new console** when asked to update an existing one (e.g. *"update the franc engagement score console"*) instead of finding and opening the existing one. Root causes:

- **Auto-discovery was gated behind Atlas vector search.** The "Relevant Saved Consoles" hint injection only ran when `isVectorSearchAvailable()` was true, so self-hosted / local Mongo deployments got **zero hints** — even though `searchConsoles` already has `$text` and regex-name fallbacks.
- **The prompt was open-tab-centric.** `UNIVERSAL_PROMPT_V2` reasoned only over open tabs + the active console, with no instruction to look up a console by name. With no hints and the loud "create a new one" golden rule, the agent defaulted to creating a new console.

## Changes

- `api/src/routes/agent.routes.ts`: always run `searchConsoles` for console/unified agents (relying on its built-in text/regex fallback) instead of short-circuiting on `isVectorSearchAvailable()`. Removed now-unused embedding-availability imports.
- `api/src/agent-lib/prompts/universal.ts`: added an explicit **find-before-create** rule (in both the Standard Workflow and Console Management sections). When the user names a console that isn't in Open Tabs, the agent must `search_consoles` → `open_console` → `read_console`; creating a new console is the last resort.

## Test plan

- [ ] With a saved console named e.g. "Franc Engagement Score" **not** open as a tab, ask the agent to "update the franc engagement score console" and confirm it calls `search_consoles` + `open_console` and edits the existing console rather than creating a new one.
- [ ] Verify on a local/non-Atlas Mongo that "Relevant Saved Consoles" hints now appear (text/regex fallback path).
- [ ] Confirm `pnpm --filter api run lint` passes (clean aside from pre-existing untracked temp files).

Made with [Cursor](https://cursor.com)