### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,13 @@
+{
+  "name": "Mako dev (App + API + Inngest)",
+  "install": "bash .cursor/setup/install.sh",
+  "start": "bash .cursor/setup/start.sh",
+  "terminals": [
+    {
+      "name": "dev",
+      "command": "pnpm dev",
+      "description": "App (5173) + API (8080) + Inngest dev UI (8288)"
+    }
+  ],
+  "ports": [5173, 8080, 8288, 27017]
+}

--- a/.cursor/setup/install.sh
+++ b/.cursor/setup/install.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Cursor Cloud `install` phase: cached + idempotent dependency setup.
+# Runs once when the snapshot is built (and is re-cached). Must NOT depend on
+# any running services (MongoDB/Docker are brought up later in start.sh).
+set -euo pipefail
+
+# Resolve repo root regardless of where this is invoked from.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+# --- 1. .env bootstrap -------------------------------------------------------
+# Only create .env if absent so we never clobber a configured one. Real secrets
+# are generated for the two values that block boot; AI_GATEWAY_API_KEY stays a
+# placeholder (server boots; AI calls fail until a real key is set).
+set_env() {
+  local key="$1" val="$2" tmp
+  if grep -q "^${key}=" .env; then
+    tmp="$(mktemp)"
+    sed "s|^${key}=.*|${key}=${val}|" .env >"$tmp" && mv "$tmp" .env
+  else
+    printf '%s=%s\n' "$key" "$val" >>.env
+  fi
+}
+
+if [ ! -f .env ]; then
+  cp .env.example .env
+  set_env DATABASE_URL "mongodb://localhost:27017/myapp"
+  set_env ENCRYPTION_KEY "$(openssl rand -hex 32)"
+  set_env SESSION_SECRET "$(openssl rand -hex 32)"
+  set_env NODE_ENV "development"
+  echo "[install] created .env from .env.example (generated ENCRYPTION_KEY + SESSION_SECRET)"
+else
+  echo "[install] .env already present - leaving untouched"
+fi
+
+# --- 2. dependencies ---------------------------------------------------------
+# Built scripts (ssh2) are approved declaratively via pnpm-workspace.yaml
+# (onlyBuiltDependencies); bcrypt is intentionally ignored there. No interactive
+# `pnpm approve-builds` step is needed.
+echo "[install] installing workspace dependencies..."
+pnpm install --frozen-lockfile || pnpm install
+
+echo "[install] done."

--- a/.cursor/setup/start.sh
+++ b/.cursor/setup/start.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Cursor Cloud `start` phase: one-shot service bootstrap on every machine start.
+# Brings up the Docker daemon + a single-node MongoDB replica set, then applies
+# migrations. The long-running dev servers run separately in the `dev` terminal.
+#
+# A replica set is mandatory: workspace creation and other flows use MongoDB
+# transactions, which fail on a standalone mongod with
+#   "Transaction numbers are only allowed on a replica set member or mongos".
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+DOCKER="sudo docker"
+
+# --- 1. Docker daemon (not managed by systemd on the cloud image) ------------
+if ! $DOCKER info >/dev/null 2>&1; then
+  echo "[start] starting dockerd..."
+  sudo dockerd >/tmp/dockerd.log 2>&1 &
+  for _ in $(seq 1 30); do
+    $DOCKER info >/dev/null 2>&1 && break
+    sleep 1
+  done
+fi
+if ! $DOCKER info >/dev/null 2>&1; then
+  echo "[start] ERROR: Docker daemon is not reachable (see /tmp/dockerd.log)" >&2
+  exit 1
+fi
+
+# --- 2. MongoDB single-node replica set --------------------------------------
+if $DOCKER ps --format '{{.Names}}' | grep -qx mongodb; then
+  echo "[start] mongodb container already running"
+elif $DOCKER ps -a --format '{{.Names}}' | grep -qx mongodb; then
+  echo "[start] starting existing mongodb container"
+  $DOCKER start mongodb >/dev/null
+else
+  echo "[start] creating mongodb container (mongo:7, replSet rs0)"
+  $DOCKER run -d -p 27017:27017 --name mongodb mongo:7 --replSet rs0 >/dev/null
+fi
+
+echo "[start] waiting for mongod to accept connections..."
+for _ in $(seq 1 30); do
+  $DOCKER exec mongodb mongosh --quiet --eval 'db.runCommand({ ping: 1 })' >/dev/null 2>&1 && break
+  sleep 1
+done
+
+# Initiate the replica set (idempotent: rs.status() throws until initiated).
+$DOCKER exec mongodb mongosh --quiet --eval '
+  try { rs.status(); }
+  catch (e) {
+    rs.initiate({ _id: "rs0", members: [{ _id: 0, host: "localhost:27017" }] });
+  }
+' >/dev/null 2>&1 || true
+
+echo "[start] waiting for replica-set PRIMARY..."
+for _ in $(seq 1 30); do
+  $DOCKER exec mongodb mongosh --quiet --eval 'db.hello().isWritablePrimary' 2>/dev/null | grep -qx true && break
+  sleep 1
+done
+
+# --- 3. Migrations -----------------------------------------------------------
+# One migration (add_entity_versions_collection) can fail on a brand-new DB;
+# core auth/workspace flows still work, so a failure here must not block boot.
+echo "[start] applying migrations..."
+pnpm migrate || echo "[start] WARN: some migrations failed (expected on a fresh DB) - continuing"
+
+echo "[start] services ready - MongoDB on localhost:27017 (rs0). Dev servers start in the 'dev' terminal."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@ Guidance for cloud agents and automated development environments working in the 
 
 ## Cursor Cloud specific instructions
 
+> **Automated provisioning.** Cursor Cloud now builds this environment from [`.cursor/environment.json`](.cursor/environment.json): `install` runs [`.cursor/setup/install.sh`](.cursor/setup/install.sh) (`.env` bootstrap + `pnpm install`) and `start` runs [`.cursor/setup/start.sh`](.cursor/setup/start.sh) (Docker daemon + MongoDB replica set + migrations), then the `dev` terminal runs `pnpm dev`. The sections below document the equivalent manual steps and the rationale behind them.
+
 ### Product scope (default dev setup)
 
 The primary product is **App + API** (AI-native SQL client). Full local dev also starts **Inngest dev** via `pnpm dev`. `website` and `docs` are optional standalone packages.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,95 @@
+# AGENTS.md
+
+Guidance for cloud agents and automated development environments working in the Mako monorepo.
+
+## Cursor Cloud specific instructions
+
+### Product scope (default dev setup)
+
+The primary product is **App + API** (AI-native SQL client). Full local dev also starts **Inngest dev** via `pnpm dev`. `website` and `docs` are optional standalone packages.
+
+| Service | Port | Start |
+| --- | --- | --- |
+| MongoDB | 27017 | See MongoDB section below |
+| API (Hono) | 8080 | `pnpm api:dev` or `pnpm dev` |
+| App (Vite) | 5173 | `pnpm app:dev` or `pnpm dev` |
+| Inngest dev UI | 8288 | Included in `pnpm dev` |
+
+Standard commands are documented in [CLAUDE.md](CLAUDE.md) and [README.md](README.md).
+
+### MongoDB (required, replica set)
+
+`docker-compose.yml` is **not** in this repo. Start MongoDB with Docker directly:
+
+```bash
+sudo docker run -d -p 27017:27017 --name mongodb mongo:7 --replSet rs0
+sudo docker exec mongodb mongosh --quiet --eval 'rs.initiate({_id:"rs0", members:[{_id:0, host:"localhost:27017"}]})'
+```
+
+**Replica set is required.** Workspace creation and other flows use MongoDB transactions; a standalone `mongod` without `--replSet` fails with: `Transaction numbers are only allowed on a replica set member or mongos`.
+
+After a fresh MongoDB container, run `pnpm migrate` (see migration caveat below).
+
+### Docker daemon
+
+Docker CE is installed on the VM image but **dockerd is not managed by systemd** in this environment. Start it once per VM session before using Docker:
+
+```bash
+sudo dockerd > /tmp/dockerd.log 2>&1 &
+```
+
+Use `sudo docker …` if the current user is not in the `docker` group.
+
+### Environment file
+
+Copy `.env.example` to `.env` and set at minimum:
+
+- `DATABASE_URL=mongodb://localhost:27017/myapp`
+- `ENCRYPTION_KEY` — `openssl rand -hex 32`
+- `SESSION_SECRET` — `openssl rand -hex 32`
+- `AI_GATEWAY_API_KEY` — required for AI chat; placeholder allows boot but AI calls fail
+
+OAuth (`GOOGLE_*`, `GH_*`) and SendGrid are optional for local dev. Without SendGrid, verification emails are logged server-side; fetch codes from `emailverifications` in MongoDB or use `/api/dev/email-preview` routes.
+
+### pnpm native build scripts
+
+On a clean `pnpm install`, approve dependency build scripts once:
+
+```bash
+pnpm approve-builds --all
+```
+
+`bcrypt` is intentionally in `ignoredBuiltDependencies` in `pnpm-workspace.yaml`.
+
+### Migrations
+
+`pnpm migrate` applies pending migrations. On a fresh database, migration `2026-04-05-075746_add_entity_versions_collection` may fail with `ns does not exist: myapp.entity_versions` (18/29 still apply). Core auth and workspace flows work despite this failure.
+
+### Running dev servers
+
+Use a tmux session so API, App, and Inngest stay up:
+
+```bash
+pnpm dev
+```
+
+Health checks:
+
+- API: `curl http://localhost:8080/health`
+- App: `curl -o /dev/null -w '%{http_code}' http://localhost:5173/`
+- Inngest: `curl http://localhost:8288/health`
+
+### Lint and tests
+
+| Package | Command |
+| --- | --- |
+| API lint | `pnpm --filter api run lint` |
+| App lint + typecheck | `pnpm --filter app run lint && pnpm --filter app run typecheck` |
+| App unit tests | `pnpm --filter app run test:unit` |
+| All lint | `pnpm run lint:all` |
+
+Pre-commit hooks (`husky` + `lint-staged`) only lint **staged** files; run full package lint before PRs (see `.cursor/rules/85-pre-commit.mdc`).
+
+### Inngest in development
+
+Cron schedulers are disabled when `NODE_ENV !== "production"`. Trigger jobs manually from the Inngest UI at http://localhost:8288. See [INNGEST_DEV_CONFIG.md](INNGEST_DEV_CONFIG.md).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` documenting how cloud agents should set up and run the Mako monorepo in Cursor Cloud VMs.

Covers:
- MongoDB replica-set requirement (transactions for workspace creation)
- Docker daemon startup in this environment
- `.env` prerequisites
- `pnpm approve-builds --all` for native deps
- Migration caveat on fresh DBs
- Lint/test commands and Inngest dev notes

Created as part of dev environment setup validation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62eb1010-4eec-4082-8507-e0a93d1453f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62eb1010-4eec-4082-8507-e0a93d1453f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

