### PR TITLE
Add isolated Reverse ETL flows

### DIFF
--- a/api/src/agents/reverse-etl/index.ts
+++ b/api/src/agents/reverse-etl/index.ts
@@ -1,0 +1,143 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { Types } from "mongoose";
+import { clientReverseEtlTools } from "@mako/agent-tools";
+import { Connector, DatabaseConnection } from "../../database/workspace-schema";
+import type { AgentContext } from "../types";
+import {
+  checkQuerySafety,
+  validateQuery as validateQueryService,
+} from "../../services/destination-writer.service";
+import { getOutboundConnector } from "../../services/reverse-etl/outbound";
+import { dryRunReverseEtl } from "../../services/reverse-etl/dry-run.service";
+import { REVERSE_FLOW_SPEC_SCHEMA } from "../../schemas/reverse-flow.schema";
+
+const inspectDestinationSchema = z.object({
+  connectorId: z.string().describe("Destination connector ID"),
+  entity: z.string().default("leads").describe("Destination entity"),
+});
+
+const validateReverseQuerySchema = z.object({
+  connectionId: z.string().describe("Source database connection ID"),
+  query: z.string().describe("SQL query to validate"),
+  database: z.string().optional().describe("Optional database or dataset"),
+});
+
+const dryRunMappingSchema = z.object({
+  spec: REVERSE_FLOW_SPEC_SCHEMA.describe(
+    "Complete ReverseFlowSpec to dry run",
+  ),
+  sampleSize: z.number().int().positive().max(100).default(25),
+});
+
+export function createReverseEtlTools(
+  workspaceId: string,
+  _toolExecutionContext?: AgentContext["toolExecutionContext"],
+) {
+  return {
+    list_connectors: tool({
+      description:
+        "List workspace connectors that may be usable as Reverse ETL destinations. Use inspect_destination to verify outbound support.",
+      inputSchema: z.object({}),
+      execute: async () => {
+        const connectors = await Connector.find({
+          workspaceId: new Types.ObjectId(workspaceId),
+          isActive: { $ne: false },
+        })
+          .select("_id name type")
+          .lean();
+        return {
+          success: true,
+          connectors: connectors.map(connector => ({
+            id: connector._id.toString(),
+            name: connector.name,
+            type: connector.type,
+          })),
+        };
+      },
+    }),
+
+    inspect_destination: tool({
+      description:
+        "Inspect writable destination fields, enum values, and matchable fields for a Reverse ETL connector entity.",
+      inputSchema: inspectDestinationSchema,
+      execute: async ({ connectorId, entity }) => {
+        try {
+          const outbound = await getOutboundConnector(connectorId);
+          const schema = await outbound.resolveOutboundSchema(entity);
+          return { success: true, schema };
+        } catch (error) {
+          return {
+            success: false,
+            error:
+              error instanceof Error
+                ? error.message
+                : "Failed to inspect destination",
+          };
+        }
+      },
+    }),
+
+    reverse_etl_validate_query: tool({
+      description:
+        "Validate a Reverse ETL source SQL query and return columns/sample info. Use before mappings.",
+      inputSchema: validateReverseQuerySchema,
+      execute: async ({ connectionId, query, database }) => {
+        try {
+          if (!Types.ObjectId.isValid(connectionId)) {
+            return { success: false, error: "Invalid connection ID" };
+          }
+          const safety = checkQuerySafety(query);
+          if (!safety.safe) {
+            return {
+              success: false,
+              errors: safety.errors,
+              warnings: safety.warnings,
+            };
+          }
+          const connection = await DatabaseConnection.findOne({
+            _id: new Types.ObjectId(connectionId),
+            workspaceId: new Types.ObjectId(workspaceId),
+          });
+          if (!connection)
+            return { success: false, error: "Connection not found" };
+          return await validateQueryService(
+            connection.toObject({ getters: true }) as any,
+            query,
+            database,
+          );
+        } catch (error) {
+          return {
+            success: false,
+            error:
+              error instanceof Error
+                ? error.message
+                : "Query validation failed",
+          };
+        }
+      },
+    }),
+
+    dry_run_mapping: tool({
+      description:
+        "Dry run a Reverse ETL mapping through the outbound connector. Writes nothing and returns payloads, matches, and field diffs.",
+      inputSchema: dryRunMappingSchema,
+      execute: async ({ spec, sampleSize }) => {
+        try {
+          const result = await dryRunReverseEtl(workspaceId, spec, sampleSize);
+          return { success: true, ...result };
+        } catch (error) {
+          return {
+            success: false,
+            error:
+              error instanceof Error
+                ? error.message
+                : "Reverse ETL dry run failed",
+          };
+        }
+      },
+    }),
+
+    ...clientReverseEtlTools,
+  };
+}

--- a/api/src/agents/reverse-etl/index.ts
+++ b/api/src/agents/reverse-etl/index.ts
@@ -99,8 +99,9 @@ export function createReverseEtlTools(
             _id: new Types.ObjectId(connectionId),
             workspaceId: new Types.ObjectId(workspaceId),
           });
-          if (!connection)
+          if (!connection) {
             return { success: false, error: "Connection not found" };
+          }
           return await validateQueryService(
             connection.toObject({ getters: true }) as any,
             query,

--- a/api/src/agents/types.ts
+++ b/api/src/agents/types.ts
@@ -47,7 +47,12 @@ export interface AgentContext {
   /** Current workspace ID */
   workspaceId: string;
   /** What the user is currently looking at (the active editor tab's kind) */
-  activeView?: "console" | "dashboard" | "flow-editor" | "empty";
+  activeView?:
+    | "console"
+    | "dashboard"
+    | "flow-editor"
+    | "reverse-flow-editor"
+    | "empty";
   /**
    * Which left-pane explorer is currently open and visible, or `null` if the
    * left pane is collapsed. Use this when guiding the user to a specific
@@ -75,6 +80,7 @@ export interface AgentContext {
     isActive: boolean;
     dashboardId?: string;
     flowId?: string;
+    reverseFlowId?: string;
     connectionId?: string;
     databaseName?: string;
   }>;
@@ -93,6 +99,8 @@ export interface AgentContext {
   }>;
   /** Flow form state (for flow agent) - read-only snapshot */
   flowFormState?: Record<string, unknown>;
+  /** Reverse ETL form state - read-only snapshot */
+  reverseFlowFormState?: Record<string, unknown>;
   /** Custom workspace prompt */
   workspaceCustomPrompt?: string;
   /** Agent-editable self-directive (persisted workspace knowledge) */

--- a/api/src/agents/unified/index.ts
+++ b/api/src/agents/unified/index.ts
@@ -6,6 +6,7 @@ import { createSkillTools } from "../../agent-lib/tools/skill-tools";
 import { createConsoleSearchTools } from "../../agent-lib/tools/console-search-tools";
 import { createDashboardSearchTools } from "../../agent-lib/tools/dashboard-search-tools";
 import { createFlowTools } from "../flow";
+import { createReverseEtlTools } from "../reverse-etl";
 import { createVersionHistoryTools } from "../../agent-lib/tools/version-history-tools";
 import { UNIFIED_SYSTEM_PROMPT, buildCurrentScreenContext } from "./prompt";
 
@@ -28,6 +29,10 @@ export function unifiedAgentFactory(context: AgentContext): AgentConfig {
     context.toolExecutionContext,
   );
   const flowTools = createFlowTools(workspaceId, context.toolExecutionContext);
+  const reverseEtlTools = createReverseEtlTools(
+    workspaceId,
+    context.toolExecutionContext,
+  );
   const selfDirectiveTools = createSelfDirectiveTools(workspaceId);
   const skillTools = createSkillTools(workspaceId, userId);
   const consoleSearchTools = createConsoleSearchTools(
@@ -47,7 +52,6 @@ export function unifiedAgentFactory(context: AgentContext): AgentConfig {
     inspect_table: _flowInspectTable,
     ...flowUniqueTools
   } = flowTools;
-
   return {
     systemPrompt: [
       {
@@ -66,6 +70,7 @@ export function unifiedAgentFactory(context: AgentContext): AgentConfig {
       ...universalTools,
       ...clientDashboardTools,
       ...flowUniqueTools,
+      ...reverseEtlTools,
       ...selfDirectiveTools,
       ...skillTools,
       ...consoleSearchTools,

--- a/api/src/agents/unified/prompt.ts
+++ b/api/src/agents/unified/prompt.ts
@@ -27,6 +27,9 @@ message explicitly targets a different modality:
   to this dashboard", "fix the Enquiries widget", "modify this KPI card").
 - Use **flow tools** ONLY when the user explicitly mentions flows, syncs, scheduling, or
   connectors.
+- Use **Reverse ETL tools** when the user mentions CRM write-back, outbound sync,
+  pushing query results into SaaS tools, Close leads, or mapping rows into
+  production systems.
 - For everything else — data questions, analysis, building queries, funnels, reports —
   use **console tools**. This is the default.
 
@@ -90,7 +93,19 @@ ${DASHBOARD_SYSTEM_PROMPT}
 
 ## Flow Guidance
 
-${FLOW_PROMPT}`;
+${FLOW_PROMPT}
+
+---
+
+## Reverse ETL Guidance
+
+Reverse ETL writes query results into production systems of record. Use
+\`inspect_destination\` before choosing destination fields,
+\`reverse_etl_validate_query\` before mapping columns, and \`dry_run_mapping\`
+before recommending activation. Prefer \`fill_empty\` for CRM updates unless the
+user explicitly wants overwrite semantics. Use the dedicated Reverse ETL client
+tools (\`create_reverse_etl_tab\`, \`set_reverse_etl_form_field\`, etc.) for the
+ReverseFlow editor.`;
 
 function buildConsoleContext(context: AgentContext): string[] {
   const parts: string[] = [];
@@ -297,6 +312,22 @@ function buildFlowContext(context: AgentContext): string[] {
   return parts;
 }
 
+function buildReverseFlowContext(context: AgentContext): string[] {
+  const parts: string[] = [];
+
+  parts.push("### Active Reverse ETL Flow");
+  if (
+    !context.reverseFlowFormState ||
+    Object.keys(context.reverseFlowFormState).length === 0
+  ) {
+    parts.push("No active Reverse ETL form state is available.");
+    return parts;
+  }
+
+  parts.push(JSON.stringify(context.reverseFlowFormState, null, 2));
+  return parts;
+}
+
 function buildTabSummary(context: AgentContext): string[] {
   const parts: string[] = [];
   const tabs = context.openTabs || [];
@@ -319,11 +350,15 @@ function buildTabSummary(context: AgentContext): string[] {
       detail = ` (id: ${tab.dashboardId})`;
     } else if (tab.kind === "flow-editor" && tab.flowId) {
       detail = ` (flow: ${tab.flowId})`;
+    } else if (tab.kind === "reverse-flow-editor" && tab.reverseFlowId) {
+      detail = ` (reverse flow: ${tab.reverseFlowId})`;
     }
     const kindLabel =
       tab.kind === "flow-editor"
         ? "Flow"
-        : tab.kind.charAt(0).toUpperCase() + tab.kind.slice(1);
+        : tab.kind === "reverse-flow-editor"
+          ? "Reverse ETL"
+          : tab.kind.charAt(0).toUpperCase() + tab.kind.slice(1);
     parts.push(
       `${index + 1}. ${activeMarker}${kindLabel} "${tab.title}"${detail}`,
     );
@@ -334,7 +369,9 @@ function buildTabSummary(context: AgentContext): string[] {
     const kindLabel =
       activeTab.kind === "flow-editor"
         ? "Flow"
-        : activeTab.kind.charAt(0).toUpperCase() + activeTab.kind.slice(1);
+        : activeTab.kind === "reverse-flow-editor"
+          ? "Reverse ETL"
+          : activeTab.kind.charAt(0).toUpperCase() + activeTab.kind.slice(1);
     parts.push("");
     parts.push(
       `The user is currently viewing: ${kindLabel} "${activeTab.title}".`,
@@ -380,6 +417,14 @@ export function buildCurrentScreenContext(context: AgentContext): string {
 
   if (context.flowFormState && Object.keys(context.flowFormState).length > 0) {
     sections.push(...buildFlowContext(context));
+    sections.push("");
+  }
+
+  if (
+    context.reverseFlowFormState &&
+    Object.keys(context.reverseFlowFormState).length > 0
+  ) {
+    sections.push(...buildReverseFlowContext(context));
     sections.push("");
   }
 

--- a/api/src/connectors/base/BaseConnector.ts
+++ b/api/src/connectors/base/BaseConnector.ts
@@ -1,5 +1,6 @@
 import { IConnector } from "../../database/workspace-schema";
 import type { NormalizedCdcEvent } from "../../sync-cdc/events";
+import type { OutboundConnector } from "./OutboundConnector";
 
 export interface SyncLogger {
   log(
@@ -158,6 +159,13 @@ export abstract class BaseConnector {
    * including dynamically discovered custom fields.
    */
   async resolveSchema(_entity: string): Promise<ConnectorEntitySchema | null> {
+    return null;
+  }
+
+  /**
+   * Optional outbound/write capability for Reverse ETL destinations.
+   */
+  getOutboundCapability(): OutboundConnector | null {
     return null;
   }
 

--- a/api/src/connectors/base/OutboundConnector.ts
+++ b/api/src/connectors/base/OutboundConnector.ts
@@ -1,0 +1,73 @@
+import type { ConnectorLogicalType } from "./BaseConnector";
+
+export interface OutboundFieldSchema {
+  type: ConnectorLogicalType;
+  required?: boolean;
+  writable: boolean;
+  label?: string;
+  enumValues?: { value: string; label: string }[];
+}
+
+export interface OutboundEntitySchema {
+  entity: string;
+  fields: Record<string, OutboundFieldSchema>;
+  matchableFields: string[];
+}
+
+export interface OutboundFieldDiff {
+  field: string;
+  before: unknown;
+  after: unknown;
+  willOverwrite: boolean;
+}
+
+export interface OutboundRejectedField {
+  field: string;
+  reason: string;
+}
+
+export interface OutboundWriteOutcome {
+  sourcePk: string;
+  status: "created" | "updated" | "skipped" | "failed" | "ambiguous";
+  remoteId?: string;
+  fieldDiffs?: OutboundFieldDiff[];
+  rejectedFields?: OutboundRejectedField[];
+  matchCount?: number;
+  retryable?: boolean;
+  error?: string;
+}
+
+export interface OutboundConnector {
+  supportsOutbound(): boolean;
+  resolveOutboundSchema(entity: string): Promise<OutboundEntitySchema>;
+  writeBatch(params: {
+    entity: string;
+    records: {
+      sourcePk: string;
+      payload: Record<string, unknown>;
+      remoteId?: string;
+    }[];
+    writeMode: "create" | "update" | "upsert";
+    updateFieldStrategy: "overwrite" | "fill_empty" | "ignore";
+    match: {
+      lookupColumn: string;
+      remoteField: string;
+      onMultiple: "skip" | "update_first" | "fail";
+    };
+    dryRun: boolean;
+  }): Promise<{ results: OutboundWriteOutcome[] }>;
+}
+
+export function isOutboundConnector(
+  connector: unknown,
+): connector is OutboundConnector {
+  return (
+    typeof connector === "object" &&
+    connector !== null &&
+    typeof (connector as OutboundConnector).supportsOutbound === "function" &&
+    typeof (connector as OutboundConnector).resolveOutboundSchema ===
+      "function" &&
+    typeof (connector as OutboundConnector).writeBatch === "function" &&
+    (connector as OutboundConnector).supportsOutbound()
+  );
+}

--- a/api/src/connectors/close/connector.ts
+++ b/api/src/connectors/close/connector.ts
@@ -13,6 +13,12 @@ import {
   ProvisionWebhookResult,
   type ConnectorEntitySchema,
 } from "../base/BaseConnector";
+import type {
+  OutboundConnector,
+  OutboundEntitySchema,
+  OutboundFieldDiff,
+  OutboundWriteOutcome,
+} from "../base/OutboundConnector";
 import { resolveCloseEntitySchema, type CloseCustomField } from "./schema";
 import axios, { AxiosInstance } from "axios";
 import * as crypto from "crypto";
@@ -283,6 +289,421 @@ export class CloseConnector extends BaseConnector {
   async resolveSchema(entity: string): Promise<ConnectorEntitySchema | null> {
     const customFields = await this.fetchCustomFieldsForEntity(entity);
     return resolveCloseEntitySchema(entity, customFields);
+  }
+
+  getOutboundCapability(): OutboundConnector | null {
+    return this;
+  }
+
+  supportsOutbound(): boolean {
+    return true;
+  }
+
+  async resolveOutboundSchema(entity: string): Promise<OutboundEntitySchema> {
+    if (entity !== "leads") {
+      throw new Error("Close outbound writes currently support leads only");
+    }
+
+    const inboundSchema = await this.resolveSchema(entity);
+    if (!inboundSchema) {
+      throw new Error(`Unable to resolve Close schema for ${entity}`);
+    }
+
+    const readOnlyFields = new Set([
+      "id",
+      "display_name",
+      "date_created",
+      "date_updated",
+      "created_by",
+      "created_by_name",
+      "updated_by",
+      "updated_by_name",
+      "organization_id",
+      "html_url",
+      "contact_ids",
+      "opportunities",
+      "tasks",
+      "integration_links",
+      "primary_email",
+      "primary_phone",
+      "_mako_deleted_at",
+      "deleted_at",
+      "is_deleted",
+      "_mako_source_ts",
+      "_mako_ingest_seq",
+      "_dataSourceId",
+      "_dataSourceName",
+      "_syncedAt",
+    ]);
+    const fields: OutboundEntitySchema["fields"] = {};
+
+    for (const [field, schema] of Object.entries(inboundSchema.fields)) {
+      fields[field] = {
+        type: schema.type,
+        required: schema.required,
+        writable: !readOnlyFields.has(field),
+        label: field,
+      };
+    }
+
+    try {
+      const api = this.getCloseClient();
+      const response = await api.get("/status/lead/");
+      const statuses = Array.isArray(response.data?.data)
+        ? response.data.data
+        : [];
+      fields.status_id = {
+        ...(fields.status_id || { type: "string", writable: true }),
+        writable: true,
+        enumValues: statuses
+          .map((status: any) => ({
+            value: String(status.id || ""),
+            label: String(status.label || status.id || ""),
+          }))
+          .filter((status: { value: string }) => status.value),
+      };
+    } catch (error) {
+      logger.warn("Unable to resolve Close lead status enum values", { error });
+    }
+
+    return {
+      entity,
+      fields,
+      matchableFields: ["email", "primary_email", "contacts.emails.email"],
+    };
+  }
+
+  async writeBatch(params: {
+    entity: string;
+    records: {
+      sourcePk: string;
+      payload: Record<string, unknown>;
+      remoteId?: string;
+    }[];
+    writeMode: "create" | "update" | "upsert";
+    updateFieldStrategy: "overwrite" | "fill_empty" | "ignore";
+    match: {
+      lookupColumn: string;
+      remoteField: string;
+      onMultiple: "skip" | "update_first" | "fail";
+    };
+    dryRun: boolean;
+  }): Promise<{ results: OutboundWriteOutcome[] }> {
+    if (params.entity !== "leads") {
+      return {
+        results: params.records.map(record => ({
+          sourcePk: record.sourcePk,
+          status: "failed",
+          error: "Close outbound writes currently support leads only",
+          retryable: false,
+        })),
+      };
+    }
+
+    const results: OutboundWriteOutcome[] = [];
+    for (const record of params.records) {
+      results.push(await this.writeLeadRecord(params, record));
+    }
+    return { results };
+  }
+
+  private async writeLeadRecord(
+    params: {
+      writeMode: "create" | "update" | "upsert";
+      updateFieldStrategy: "overwrite" | "fill_empty" | "ignore";
+      match: {
+        lookupColumn: string;
+        remoteField: string;
+        onMultiple: "skip" | "update_first" | "fail";
+      };
+      dryRun: boolean;
+    },
+    record: {
+      sourcePk: string;
+      payload: Record<string, unknown>;
+      remoteId?: string;
+    },
+  ): Promise<OutboundWriteOutcome> {
+    const api = this.getCloseClient();
+    const normalizedPayload = this.normalizeLeadWritePayload(record.payload);
+
+    try {
+      const existingMatches = record.remoteId
+        ? [await this.fetchLeadById(record.remoteId)]
+        : await this.findLeadsForOutboundMatch(
+            params.match.remoteField,
+            this.getPathValue(
+              normalizedPayload,
+              params.match.remoteField || params.match.lookupColumn,
+            ) ??
+              this.getPathValue(normalizedPayload, params.match.lookupColumn),
+          );
+
+      const matches = existingMatches.filter(Boolean) as Record<
+        string,
+        unknown
+      >[];
+      if (matches.length > 1 && params.match.onMultiple !== "update_first") {
+        return {
+          sourcePk: record.sourcePk,
+          status: params.match.onMultiple === "fail" ? "failed" : "ambiguous",
+          matchCount: matches.length,
+          retryable: false,
+          error: "Multiple Close leads matched the configured key",
+        };
+      }
+
+      const existing = matches[0];
+      if (!existing && params.writeMode === "update") {
+        return {
+          sourcePk: record.sourcePk,
+          status: "failed",
+          retryable: false,
+          error: "No existing Close lead matched update-only write",
+        };
+      }
+
+      if (existing) {
+        const remoteId = String(existing.id || record.remoteId || "");
+        const { payload, fieldDiffs } = this.applyUpdateStrategy(
+          normalizedPayload,
+          existing,
+          params.updateFieldStrategy,
+        );
+
+        if (
+          params.updateFieldStrategy === "ignore" ||
+          Object.keys(payload).length === 0
+        ) {
+          return {
+            sourcePk: record.sourcePk,
+            status: "skipped",
+            remoteId,
+            fieldDiffs,
+            matchCount: matches.length,
+          };
+        }
+
+        if (!params.dryRun) {
+          await api.put(`/lead/${remoteId}/`, payload);
+        }
+
+        return {
+          sourcePk: record.sourcePk,
+          status: "updated",
+          remoteId,
+          fieldDiffs,
+          matchCount: matches.length,
+        };
+      }
+
+      if (params.writeMode === "update") {
+        return {
+          sourcePk: record.sourcePk,
+          status: "failed",
+          retryable: false,
+          error: "No existing Close lead matched update-only write",
+        };
+      }
+
+      if (params.dryRun) {
+        return {
+          sourcePk: record.sourcePk,
+          status: "created",
+          fieldDiffs: Object.keys(normalizedPayload).map(field => ({
+            field,
+            before: undefined,
+            after: normalizedPayload[field],
+            willOverwrite: false,
+          })),
+          matchCount: 0,
+        };
+      }
+
+      const response = await api.post("/lead/", normalizedPayload);
+      return {
+        sourcePk: record.sourcePk,
+        status: "created",
+        remoteId: String(response.data?.id || ""),
+        matchCount: 0,
+      };
+    } catch (error) {
+      return {
+        sourcePk: record.sourcePk,
+        status: "failed",
+        retryable: this.isRetryableCloseError(error),
+        error: axios.isAxiosError(error)
+          ? error.response?.data?.error || error.message
+          : error instanceof Error
+            ? error.message
+            : "Close write failed",
+      };
+    }
+  }
+
+  private normalizeLeadWritePayload(
+    payload: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+
+    for (const [key, value] of Object.entries(payload)) {
+      if (key === "custom" && this.isRecord(value)) {
+        for (const [customKey, customValue] of Object.entries(value)) {
+          out[`custom.${customKey}`] = customValue;
+        }
+        continue;
+      }
+      if (key.startsWith("custom_")) {
+        out[`custom.${key.slice("custom_".length)}`] = value;
+        continue;
+      }
+      out[key] = value;
+    }
+
+    return out;
+  }
+
+  private applyUpdateStrategy(
+    payload: Record<string, unknown>,
+    existing: Record<string, unknown>,
+    strategy: "overwrite" | "fill_empty" | "ignore",
+  ): { payload: Record<string, unknown>; fieldDiffs: OutboundFieldDiff[] } {
+    if (strategy === "ignore") {
+      return {
+        payload: {},
+        fieldDiffs: Object.keys(payload).map(field => ({
+          field,
+          before: this.getPathValue(existing, field),
+          after: payload[field],
+          willOverwrite: false,
+        })),
+      };
+    }
+
+    const updatePayload: Record<string, unknown> = {};
+    const fieldDiffs: OutboundFieldDiff[] = [];
+    for (const [field, after] of Object.entries(payload)) {
+      const before = this.getPathValue(existing, field);
+      const beforeEmpty = this.isEmptyValue(before);
+      const changed = !this.valuesEqual(before, after);
+      const willOverwrite = changed && !beforeEmpty && strategy === "overwrite";
+
+      if (!changed) continue;
+      fieldDiffs.push({ field, before, after, willOverwrite });
+
+      if (strategy === "fill_empty" && !beforeEmpty) {
+        continue;
+      }
+      updatePayload[field] = after;
+    }
+
+    return { payload: updatePayload, fieldDiffs };
+  }
+
+  private async fetchLeadById(
+    remoteId: string,
+  ): Promise<Record<string, unknown> | null> {
+    const api = this.getCloseClient();
+    const response = await api.get(`/lead/${remoteId}/`, {
+      params: { _fields: "_all,custom" },
+    });
+    return this.isRecord(response.data) ? response.data : null;
+  }
+
+  private async findLeadsForOutboundMatch(
+    remoteField: string,
+    value: unknown,
+  ): Promise<Record<string, unknown>[]> {
+    if (value === undefined || value === null || value === "") {
+      return [];
+    }
+
+    const api = this.getCloseClient();
+    const matchValue = String(value).trim();
+    const fieldName =
+      remoteField === "primary_email" || remoteField === "contacts.emails.email"
+        ? "email"
+        : remoteField;
+    const response = await api.post("/data/search/", {
+      query: {
+        negate: false,
+        type: "and",
+        queries: [
+          {
+            negate: false,
+            object_type: "lead",
+            type: "field_condition",
+            field: {
+              type: "regular_field",
+              object_type: "lead",
+              field_name: fieldName,
+            },
+            condition: {
+              type: "text",
+              mode: "full_words",
+              value: matchValue,
+            },
+          },
+        ],
+      },
+      results_limit: 10,
+      _fields: "_all,custom",
+    });
+
+    const data = response.data?.data;
+    if (!Array.isArray(data)) return [];
+    return data
+      .map((item: any) => (this.isRecord(item?.lead) ? item.lead : item))
+      .filter((item: unknown): item is Record<string, unknown> =>
+        this.isRecord(item),
+      );
+  }
+
+  private getPathValue(source: unknown, path: string): unknown {
+    if (!path || !this.isRecord(source)) return undefined;
+    if (path in source) return source[path];
+
+    const normalized = path.replace(/\[(\d+)\]/g, ".$1");
+    const parts = normalized.split(".").filter(Boolean);
+    let cursor: unknown = source;
+    for (let index = 0; index < parts.length; index++) {
+      if (cursor === undefined || cursor === null) return undefined;
+      if (this.isRecord(cursor)) {
+        const remaining = parts.slice(index).join(".");
+        if (remaining in cursor) return cursor[remaining];
+        cursor = cursor[parts[index]];
+        continue;
+      }
+      if (Array.isArray(cursor)) {
+        cursor = cursor[Number(parts[index])];
+        continue;
+      }
+      return undefined;
+    }
+    return cursor;
+  }
+
+  private isEmptyValue(value: unknown): boolean {
+    return (
+      value === undefined ||
+      value === null ||
+      value === "" ||
+      (Array.isArray(value) && value.length === 0)
+    );
+  }
+
+  private valuesEqual(left: unknown, right: unknown): boolean {
+    return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
+  }
+
+  private isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+  }
+
+  private isRetryableCloseError(error: unknown): boolean {
+    if (!axios.isAxiosError(error)) return false;
+    const status = error.response?.status;
+    return status === 429 || (typeof status === "number" && status >= 500);
   }
 
   private static readonly LEAD_FIELDS = [

--- a/api/src/connectors/close/outbound.test.ts
+++ b/api/src/connectors/close/outbound.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { CloseConnector } from "./connector";
+
+async function main() {
+  const connector = new CloseConnector({
+    _id: "connector_1",
+    name: "Close",
+    type: "close",
+    config: { api_key: "test" },
+    settings: { rate_limit_delay_ms: 0 },
+  } as any);
+
+  const calls: Array<{ method: string; path: string; body?: unknown }> = [];
+  (connector as any).closeApi = {
+    async get(path: string) {
+      calls.push({ method: "get", path });
+      if (path === "/status/lead/") {
+        return { data: { data: [{ id: "stat_1", label: "Qualified" }] } };
+      }
+      if (path === "/lead/lead_1/") {
+        return {
+          data: {
+            id: "lead_1",
+            name: "Existing",
+            "custom.cf_arr": null,
+            primary_email: { email: "jane@acme.com" },
+          },
+        };
+      }
+      return { data: {} };
+    },
+    async post(path: string, body: unknown) {
+      calls.push({ method: "post", path, body });
+      return {
+        data: {
+          data: [
+            {
+              id: "lead_1",
+              name: "Existing",
+              "custom.cf_arr": null,
+              primary_email: { email: "jane@acme.com" },
+            },
+          ],
+        },
+      };
+    },
+    async put(path: string, body: unknown) {
+      calls.push({ method: "put", path, body });
+      return { data: { id: "lead_1" } };
+    },
+  };
+
+  const schema = await connector.resolveOutboundSchema("leads");
+  assert.equal(schema.fields.status_id.enumValues?.[0].value, "stat_1");
+  assert.equal(schema.fields.id.writable, false);
+  assert.equal(schema.fields.name.writable, true);
+
+  const dryRun = await connector.writeBatch({
+    entity: "leads",
+    records: [
+      {
+        sourcePk: "jane@acme.com",
+        payload: {
+          name: "Jane Doe",
+          custom: { cf_arr: 1200 },
+          email: "jane@acme.com",
+        },
+      },
+    ],
+    writeMode: "upsert",
+    updateFieldStrategy: "fill_empty",
+    match: { lookupColumn: "email", remoteField: "email", onMultiple: "skip" },
+    dryRun: true,
+  });
+
+  assert.equal(dryRun.results[0].status, "updated");
+  assert.equal(dryRun.results[0].remoteId, "lead_1");
+  assert.equal(
+    calls.some(call => call.method === "put"),
+    false,
+  );
+  assert.equal(
+    dryRun.results[0].fieldDiffs?.some(
+      diff => diff.field === "name" && diff.willOverwrite === false,
+    ),
+    true,
+  );
+  assert.equal(
+    dryRun.results[0].fieldDiffs?.some(diff => diff.field === "custom.cf_arr"),
+    true,
+  );
+
+  (connector as any).closeApi.post = async (path: string, body: unknown) => {
+    calls.push({ method: "post", path, body });
+    return { data: { data: [{ id: "lead_1" }, { id: "lead_2" }] } };
+  };
+
+  const ambiguous = await connector.writeBatch({
+    entity: "leads",
+    records: [{ sourcePk: "dup", payload: { email: "dup@example.com" } }],
+    writeMode: "upsert",
+    updateFieldStrategy: "overwrite",
+    match: { lookupColumn: "email", remoteField: "email", onMultiple: "skip" },
+    dryRun: true,
+  });
+
+  assert.equal(ambiguous.results[0].status, "ambiguous");
+  assert.equal(ambiguous.results[0].matchCount, 2);
+}
+
+void main();

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -2,6 +2,7 @@ import mongoose, { Schema, Document, Types } from "mongoose";
 import { v4 as uuidv4 } from "uuid";
 import * as crypto from "crypto";
 import { loggers } from "../logging";
+import type { ReverseFlowSpec } from "../schemas/reverse-flow.schema";
 
 // Encryption helper functions
 let _encryptionKey: string | null = null;
@@ -433,7 +434,92 @@ export interface IScheduledQueryRun extends Document {
   inngestRunId?: string;
 }
 
-export type NotificationResourceType = "scheduled_query" | "flow";
+export interface IReverseFlowVersion {
+  version: number;
+  spec: ReverseFlowSpec;
+  authoredBy: string;
+  reason?: string;
+  createdAt: Date;
+}
+
+export interface IReverseFlow extends Document {
+  _id: Types.ObjectId;
+  workspaceId: Types.ObjectId;
+  name: string;
+  createdBy: string;
+  status: "draft" | "active" | "paused";
+  spec: ReverseFlowSpec;
+  version: number;
+  versions: IReverseFlowVersion[];
+  lastDryRun?: {
+    at: Date;
+    sampleSize: number;
+    accepted: number;
+    rejected: number;
+    ambiguous: number;
+    rejectedFields: { field: string; reason: string }[];
+    passed: boolean;
+  };
+  scheduledRun?: {
+    nextAt?: Date;
+    lastAt?: Date;
+    lastStatus?: "success" | "partial" | "error";
+    lastError?: string;
+    runCount: number;
+    consecutiveFailures: number;
+  };
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface IReverseFlowRowOutcome {
+  sourcePk: string;
+  status: "created" | "updated" | "skipped" | "failed" | "ambiguous";
+  remoteId?: string;
+  error?: string;
+}
+
+export interface IReverseFlowRun extends Document {
+  _id: Types.ObjectId;
+  workspaceId: Types.ObjectId;
+  reverseFlowId: Types.ObjectId;
+  specVersion: number;
+  status: "queued" | "running" | "success" | "partial" | "error";
+  triggerType: "schedule" | "manual";
+  triggeredBy?: string;
+  triggeredAt: Date;
+  startedAt?: Date;
+  completedAt?: Date;
+  durationMs?: number;
+  inngestRunId?: string;
+  rowsRead: number;
+  rowsCreated: number;
+  rowsUpdated: number;
+  rowsSkipped: number;
+  rowsFailed: number;
+  ambiguous: number;
+  rowOutcomes: IReverseFlowRowOutcome[];
+  error?: {
+    message: string;
+    code?: string;
+  };
+}
+
+export interface IOutboundLedger extends Document {
+  _id: Types.ObjectId;
+  workspaceId: Types.ObjectId;
+  reverseFlowId: Types.ObjectId;
+  sourcePk: string;
+  remoteId?: string;
+  contentHash: string;
+  lastSyncedAt: Date;
+  lastRunId: Types.ObjectId;
+}
+
+export type NotificationResourceType =
+  | "scheduled_query"
+  | "flow"
+  | "reverse_etl";
 
 export type NotificationTrigger = "success" | "failure";
 
@@ -2580,6 +2666,168 @@ ScheduledQueryRunSchema.index(
   { sparse: true, expireAfterSeconds: 7776000 },
 );
 
+const ReverseFlowSchema = new Schema<IReverseFlow>(
+  {
+    workspaceId: {
+      type: Schema.Types.ObjectId,
+      ref: "Workspace",
+      required: true,
+    },
+    name: { type: String, required: true },
+    createdBy: { type: String, required: true },
+    status: {
+      type: String,
+      enum: ["draft", "active", "paused"],
+      default: "draft",
+      required: true,
+    },
+    spec: { type: Schema.Types.Mixed, required: true },
+    version: { type: Number, default: 1 },
+    versions: {
+      type: [
+        {
+          version: Number,
+          spec: Schema.Types.Mixed,
+          authoredBy: String,
+          reason: String,
+          createdAt: Date,
+        },
+      ],
+      default: [],
+    },
+    lastDryRun: {
+      at: Date,
+      sampleSize: Number,
+      accepted: Number,
+      rejected: Number,
+      ambiguous: Number,
+      rejectedFields: [
+        {
+          field: String,
+          reason: String,
+        },
+      ],
+      passed: Boolean,
+    },
+    scheduledRun: {
+      nextAt: Date,
+      lastAt: Date,
+      lastStatus: {
+        type: String,
+        enum: ["success", "partial", "error"],
+      },
+      lastError: String,
+      runCount: { type: Number, default: 0 },
+      consecutiveFailures: { type: Number, default: 0 },
+    },
+  },
+  {
+    collection: "reverse_flows",
+    timestamps: true,
+  },
+);
+
+ReverseFlowSchema.index({ workspaceId: 1, status: 1 });
+ReverseFlowSchema.index({ "scheduledRun.nextAt": 1 }, { sparse: true });
+
+const ReverseFlowRunSchema = new Schema<IReverseFlowRun>(
+  {
+    workspaceId: {
+      type: Schema.Types.ObjectId,
+      ref: "Workspace",
+      required: true,
+    },
+    reverseFlowId: {
+      type: Schema.Types.ObjectId,
+      ref: "ReverseFlow",
+      required: true,
+    },
+    specVersion: { type: Number, required: true },
+    status: {
+      type: String,
+      enum: ["queued", "running", "success", "partial", "error"],
+      required: true,
+    },
+    triggerType: {
+      type: String,
+      enum: ["schedule", "manual"],
+      required: true,
+    },
+    triggeredBy: String,
+    triggeredAt: { type: Date, required: true },
+    startedAt: Date,
+    completedAt: Date,
+    durationMs: Number,
+    inngestRunId: String,
+    rowsRead: { type: Number, default: 0 },
+    rowsCreated: { type: Number, default: 0 },
+    rowsUpdated: { type: Number, default: 0 },
+    rowsSkipped: { type: Number, default: 0 },
+    rowsFailed: { type: Number, default: 0 },
+    ambiguous: { type: Number, default: 0 },
+    rowOutcomes: {
+      type: [
+        {
+          sourcePk: String,
+          status: String,
+          remoteId: String,
+          error: String,
+        },
+      ],
+      default: [],
+    },
+    error: {
+      message: String,
+      code: String,
+    },
+  },
+  {
+    collection: "reverse_flow_runs",
+    timestamps: false,
+  },
+);
+
+ReverseFlowRunSchema.index({
+  workspaceId: 1,
+  reverseFlowId: 1,
+  triggeredAt: -1,
+});
+ReverseFlowRunSchema.index(
+  { completedAt: 1 },
+  { sparse: true, expireAfterSeconds: 7776000 },
+);
+
+const OutboundLedgerSchema = new Schema<IOutboundLedger>(
+  {
+    workspaceId: {
+      type: Schema.Types.ObjectId,
+      ref: "Workspace",
+      required: true,
+    },
+    reverseFlowId: {
+      type: Schema.Types.ObjectId,
+      ref: "ReverseFlow",
+      required: true,
+    },
+    sourcePk: { type: String, required: true },
+    remoteId: String,
+    contentHash: { type: String, required: true },
+    lastSyncedAt: { type: Date, required: true },
+    lastRunId: {
+      type: Schema.Types.ObjectId,
+      ref: "ReverseFlowRun",
+      required: true,
+    },
+  },
+  {
+    collection: "reverse_flow_ledger",
+    timestamps: false,
+  },
+);
+
+OutboundLedgerSchema.index({ reverseFlowId: 1, sourcePk: 1 }, { unique: true });
+OutboundLedgerSchema.index({ workspaceId: 1, reverseFlowId: 1 });
+
 const NotificationRuleSchema = new Schema<INotificationRule>(
   {
     workspaceId: {
@@ -2589,7 +2837,7 @@ const NotificationRuleSchema = new Schema<INotificationRule>(
     },
     resourceType: {
       type: String,
-      enum: ["scheduled_query", "flow"],
+      enum: ["scheduled_query", "flow", "reverse_etl"],
       required: true,
     },
     resourceId: {
@@ -2648,7 +2896,7 @@ const NotificationDeliverySchema = new Schema<INotificationDelivery>(
     },
     resourceType: {
       type: String,
-      enum: ["scheduled_query", "flow"],
+      enum: ["scheduled_query", "flow", "reverse_etl"],
       required: true,
     },
     resourceId: {
@@ -3478,6 +3726,18 @@ export const QueryExecution = mongoose.model<IQueryExecution>(
 export const ScheduledQueryRun = mongoose.model<IScheduledQueryRun>(
   "ScheduledQueryRun",
   ScheduledQueryRunSchema,
+);
+export const ReverseFlow = mongoose.model<IReverseFlow>(
+  "ReverseFlow",
+  ReverseFlowSchema,
+);
+export const ReverseFlowRun = mongoose.model<IReverseFlowRun>(
+  "ReverseFlowRun",
+  ReverseFlowRunSchema,
+);
+export const OutboundLedger = mongoose.model<IOutboundLedger>(
+  "OutboundLedger",
+  OutboundLedgerSchema,
 );
 export const NotificationRule = mongoose.model<INotificationRule>(
   "NotificationRule",

--- a/api/src/emails/RunNotificationEmail.tsx
+++ b/api/src/emails/RunNotificationEmail.tsx
@@ -10,7 +10,9 @@ export type RunNotificationEmailProps = NotificationOutboundPayload;
 function resourceKindLabel(
   resourceType: NotificationOutboundPayload["resourceType"],
 ): string {
-  return resourceType === "scheduled_query" ? "Scheduled query" : "Flow";
+  if (resourceType === "scheduled_query") return "Scheduled query";
+  if (resourceType === "reverse_etl") return "Reverse ETL";
+  return "Flow";
 }
 
 function formatDuration(ms: number | undefined): string {

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -42,6 +42,7 @@ import { dashboardRoutes } from "./routes/dashboards";
 import { dashboardMaterializationRoutes } from "./routes/dashboard-materialization";
 import { scheduledQueryRoutes } from "./routes/scheduled-queries";
 import { notificationRulesRoutes } from "./routes/notification-rules";
+import { reverseFlowRoutes } from "./routes/reverse-flows";
 import { devEmailPreviewRoutes } from "./routes/dev-email-preview.routes";
 import { webhookRoutes } from "./routes/webhooks";
 import { getFunctions, inngest, logInngestStatus } from "./inngest";
@@ -122,6 +123,7 @@ app.route("/api/workspaces/:workspaceId/skills", skillsRoutes);
 // Connectors routes
 app.route("/api/workspaces/:workspaceId/connectors", dataSourceRoutes);
 app.route("/api/workspaces/:workspaceId/flows", flowRoutes);
+app.route("/api/workspaces/:workspaceId/reverse-flows", reverseFlowRoutes);
 app.route(
   "/api/workspaces/:workspaceId/scheduled-queries",
   scheduledQueryRoutes,

--- a/api/src/inngest/functions/reverse-etl.ts
+++ b/api/src/inngest/functions/reverse-etl.ts
@@ -1,0 +1,483 @@
+import { Types } from "mongoose";
+import { inngest } from "../client";
+import {
+  DatabaseConnection,
+  OutboundLedger,
+  ReverseFlow,
+  ReverseFlowRun,
+  type IDatabaseConnection,
+  type IReverseFlowRowOutcome,
+} from "../../database/workspace-schema";
+import {
+  getNextScheduledConsoleRunAt,
+  normalizeScheduledConsoleSchedule,
+} from "../../services/scheduled-query-schedule.service";
+import { emitReverseEtlTerminalEvent } from "../../services/flow-run-notification.emit";
+import { getOutboundConnector } from "../../services/reverse-etl/outbound";
+import {
+  assertSchema,
+  contentHash,
+  mapRow,
+} from "../../services/reverse-etl/mapping-engine";
+import {
+  readReverseEtlSourcePage,
+  type ReverseEtlSourceState,
+} from "../../services/reverse-etl/source-reader";
+import type { ReverseFlowSpec } from "../../schemas/reverse-flow.schema";
+import { loggers } from "../../logging";
+
+const logger = loggers.inngest();
+
+type Counters = {
+  rowsRead: number;
+  rowsCreated: number;
+  rowsUpdated: number;
+  rowsSkipped: number;
+  rowsFailed: number;
+  ambiguous: number;
+  rowOutcomes: IReverseFlowRowOutcome[];
+};
+
+function emptyCounters(): Counters {
+  return {
+    rowsRead: 0,
+    rowsCreated: 0,
+    rowsUpdated: 0,
+    rowsSkipped: 0,
+    rowsFailed: 0,
+    ambiguous: 0,
+    rowOutcomes: [],
+  };
+}
+
+function mergeCounters(target: Counters, source: Counters): Counters {
+  target.rowsRead += source.rowsRead;
+  target.rowsCreated += source.rowsCreated;
+  target.rowsUpdated += source.rowsUpdated;
+  target.rowsSkipped += source.rowsSkipped;
+  target.rowsFailed += source.rowsFailed;
+  target.ambiguous += source.ambiguous;
+  target.rowOutcomes.push(...source.rowOutcomes);
+  target.rowOutcomes = target.rowOutcomes.slice(0, 500);
+  return target;
+}
+
+export const reverseEtlSchedulerFunction = inngest.createFunction(
+  {
+    id: "reverse-etl-scheduler",
+    name: "Run Reverse ETL Flows",
+  },
+  { cron: "*/1 * * * *" },
+  async ({ step }) => {
+    const now = new Date();
+    const dueFlows = await step.run("fetch-due-reverse-flows", async () => {
+      const flows = await ReverseFlow.find({
+        status: "active",
+        "spec.schedule.enabled": true,
+        "scheduledRun.nextAt": { $lte: now },
+      })
+        .select("_id workspaceId spec scheduledRun")
+        .lean();
+
+      return flows.map(flow => ({
+        id: flow._id.toString(),
+        workspaceId: flow.workspaceId.toString(),
+        nextAt: flow.scheduledRun?.nextAt ?? null,
+        schedule: flow.spec.schedule,
+      }));
+    });
+
+    for (const flow of dueFlows) {
+      if (!flow.schedule?.cron || !flow.schedule?.timezone) continue;
+      const nextAt = getNextScheduledConsoleRunAt(
+        normalizeScheduledConsoleSchedule(flow.schedule),
+        now,
+      );
+      const updateResult = await step.run(`claim-${flow.id}`, async () =>
+        ReverseFlow.updateOne(
+          {
+            _id: new Types.ObjectId(flow.id),
+            "scheduledRun.nextAt": flow.nextAt,
+          },
+          { $set: { "scheduledRun.nextAt": nextAt } },
+        ),
+      );
+      if (updateResult.modifiedCount === 0) continue;
+
+      await inngest.send({
+        name: "reverse_etl/execute",
+        data: {
+          workspaceId: flow.workspaceId,
+          reverseFlowId: flow.id,
+          triggerType: "schedule",
+        },
+      });
+    }
+
+    return { checked: dueFlows.length };
+  },
+);
+
+export const reverseEtlExecutorFunction = inngest.createFunction(
+  {
+    id: "reverse-etl-executor",
+    name: "Execute Reverse ETL Flow",
+    retries: 3,
+    concurrency: {
+      key: "event.data.reverseFlowId",
+      limit: 1,
+    },
+    cancelOn: [{ event: "reverse_etl/cancel", match: "data.reverseFlowId" }],
+  },
+  { event: "reverse_etl/execute" },
+  async ({ event, step }) => {
+    const workspaceId = String(event.data.workspaceId);
+    const reverseFlowId = String(event.data.reverseFlowId);
+    const triggerType =
+      event.data.triggerType === "manual" ? "manual" : "schedule";
+    const triggeredBy =
+      typeof event.data.triggeredBy === "string"
+        ? event.data.triggeredBy
+        : undefined;
+
+    const run = await step.run("create-run", async () => {
+      const flow = await ReverseFlow.findOne({
+        _id: new Types.ObjectId(reverseFlowId),
+        workspaceId: new Types.ObjectId(workspaceId),
+      }).lean();
+      if (!flow) throw new Error("Reverse flow not found");
+
+      const created = await ReverseFlowRun.create({
+        workspaceId: new Types.ObjectId(workspaceId),
+        reverseFlowId: new Types.ObjectId(reverseFlowId),
+        specVersion: flow.version,
+        status: "queued",
+        triggerType,
+        triggeredBy,
+        triggeredAt: new Date(),
+        inngestRunId: event.id,
+      });
+      return { id: created._id.toString() };
+    });
+
+    const startedAt = new Date();
+    let isFinalized = false;
+    await step.run("mark-running", async () => {
+      await ReverseFlowRun.updateOne(
+        { _id: new Types.ObjectId(run.id) },
+        { $set: { status: "running", startedAt } },
+      );
+    });
+
+    try {
+      const loaded = (await step.run("load-spec", async () => {
+        const flowDoc = await ReverseFlow.findOne({
+          _id: new Types.ObjectId(reverseFlowId),
+          workspaceId: new Types.ObjectId(workspaceId),
+        });
+        if (!flowDoc || flowDoc.status !== "active") {
+          throw new Error("Reverse flow is not active");
+        }
+        const connectionDoc = await DatabaseConnection.findOne({
+          _id: new Types.ObjectId(flowDoc.spec.source.connectionId),
+          workspaceId: new Types.ObjectId(workspaceId),
+        });
+        if (!connectionDoc) {
+          throw new Error("Reverse flow source connection not found");
+        }
+        return {
+          flow: flowDoc.toObject({ getters: true }),
+          connection: connectionDoc.toObject({
+            getters: true,
+          }) as IDatabaseConnection,
+        };
+      })) as {
+        flow: { spec: ReverseFlowSpec; version: number };
+        connection: IDatabaseConnection;
+      };
+
+      const outboundConnector = await getOutboundConnector(
+        loaded.flow.spec.destination.connectorId,
+      );
+      const outboundSchema = await outboundConnector.resolveOutboundSchema(
+        loaded.flow.spec.destination.entity,
+      );
+
+      const counters = emptyCounters();
+      let state: ReverseEtlSourceState = {
+        offset: 0,
+        totalProcessed: 0,
+        hasMore: true,
+        lastTrackingValue: loaded.flow.spec.incremental?.lastValue,
+      };
+      let pageIndex = 0;
+      let maxTrackingValue: string | undefined;
+
+      while (state.hasMore) {
+        const pageResult = await step.run(`page-${pageIndex}`, async () => {
+          const page = await readReverseEtlSourcePage({
+            connection: loaded.connection,
+            spec: loaded.flow.spec,
+            state,
+          });
+          assertSchema(loaded.flow.spec, page.columns, outboundSchema);
+
+          const pageCounters = emptyCounters();
+          pageCounters.rowsRead = page.rows.length;
+          const recordsToWrite: {
+            sourcePk: string;
+            payload: Record<string, unknown>;
+            remoteId?: string;
+            hash: string;
+          }[] = [];
+
+          for (const row of page.rows) {
+            const sourcePk = String(
+              row[loaded.flow.spec.source.primaryKey] ?? "",
+            );
+            if (!sourcePk) {
+              pageCounters.rowsFailed++;
+              pageCounters.rowOutcomes.push({
+                sourcePk: "",
+                status: "failed",
+                error: "Missing source primary key",
+              });
+              continue;
+            }
+
+            const mapped = mapRow(loaded.flow.spec, row);
+            if (mapped.errors.length > 0) {
+              pageCounters.rowsFailed++;
+              pageCounters.rowOutcomes.push({
+                sourcePk,
+                status: "failed",
+                error: mapped.errors[0],
+              });
+              continue;
+            }
+
+            const hash = contentHash(mapped.payload);
+            const ledger = await OutboundLedger.findOne({
+              reverseFlowId: new Types.ObjectId(reverseFlowId),
+              sourcePk,
+            }).lean();
+            if (ledger?.contentHash === hash) {
+              pageCounters.rowsSkipped++;
+              pageCounters.rowOutcomes.push({
+                sourcePk,
+                status: "skipped",
+                remoteId: ledger.remoteId,
+              });
+              continue;
+            }
+            recordsToWrite.push({
+              sourcePk,
+              payload: mapped.payload,
+              remoteId: ledger?.remoteId,
+              hash,
+            });
+          }
+
+          if (recordsToWrite.length > 0) {
+            const write = await outboundConnector.writeBatch({
+              entity: loaded.flow.spec.destination.entity,
+              records: recordsToWrite.map(record => ({
+                sourcePk: record.sourcePk,
+                payload: record.payload,
+                remoteId: record.remoteId,
+              })),
+              writeMode: loaded.flow.spec.destination.allowCreate
+                ? loaded.flow.spec.destination.writeMode
+                : "update",
+              updateFieldStrategy:
+                loaded.flow.spec.destination.updateFieldStrategy,
+              match: loaded.flow.spec.destination.match,
+              dryRun: false,
+            });
+            const hashByPk = new Map(
+              recordsToWrite.map(record => [record.sourcePk, record.hash]),
+            );
+            for (const result of write.results) {
+              if (result.status === "created") pageCounters.rowsCreated++;
+              if (result.status === "updated") pageCounters.rowsUpdated++;
+              if (result.status === "skipped") pageCounters.rowsSkipped++;
+              if (result.status === "ambiguous") pageCounters.ambiguous++;
+              if (result.status === "failed") pageCounters.rowsFailed++;
+
+              pageCounters.rowOutcomes.push({
+                sourcePk: result.sourcePk,
+                status: result.status,
+                remoteId: result.remoteId,
+                error: result.error,
+              });
+
+              if (
+                (result.status === "created" || result.status === "updated") &&
+                result.remoteId
+              ) {
+                await OutboundLedger.updateOne(
+                  {
+                    reverseFlowId: new Types.ObjectId(reverseFlowId),
+                    sourcePk: result.sourcePk,
+                  },
+                  {
+                    $set: {
+                      workspaceId: new Types.ObjectId(workspaceId),
+                      reverseFlowId: new Types.ObjectId(reverseFlowId),
+                      sourcePk: result.sourcePk,
+                      remoteId: result.remoteId,
+                      contentHash: hashByPk.get(result.sourcePk),
+                      lastSyncedAt: new Date(),
+                      lastRunId: new Types.ObjectId(run.id),
+                    },
+                  },
+                  { upsert: true },
+                );
+              }
+
+              if (result.status === "failed" && result.retryable) {
+                throw new Error(
+                  result.error || "Retryable Reverse ETL write failed",
+                );
+              }
+            }
+          }
+
+          return {
+            counters: pageCounters,
+            state: page.state,
+            maxTrackingValue: page.maxTrackingValue,
+          };
+        });
+
+        mergeCounters(counters, pageResult.counters);
+        state = pageResult.state;
+        if (pageResult.maxTrackingValue) {
+          maxTrackingValue = pageResult.maxTrackingValue;
+        }
+        pageIndex++;
+      }
+
+      const completedAt = new Date();
+      const durationMs = completedAt.getTime() - startedAt.getTime();
+      const status =
+        counters.rowsFailed > 0 || counters.ambiguous > 0
+          ? "partial"
+          : "success";
+
+      await step.run("finalize-run", async () => {
+        await ReverseFlowRun.updateOne(
+          { _id: new Types.ObjectId(run.id) },
+          {
+            $set: {
+              status,
+              completedAt,
+              durationMs,
+              rowsRead: counters.rowsRead,
+              rowsCreated: counters.rowsCreated,
+              rowsUpdated: counters.rowsUpdated,
+              rowsSkipped: counters.rowsSkipped,
+              rowsFailed: counters.rowsFailed,
+              ambiguous: counters.ambiguous,
+              rowOutcomes: counters.rowOutcomes,
+            },
+          },
+        );
+
+        const schedule = loaded.flow.spec.schedule;
+        const nextAt =
+          schedule.enabled && schedule.cron
+            ? getNextScheduledConsoleRunAt(
+                normalizeScheduledConsoleSchedule(schedule),
+                completedAt,
+              )
+            : undefined;
+
+        await ReverseFlow.updateOne(
+          { _id: new Types.ObjectId(reverseFlowId) },
+          {
+            $set: {
+              "scheduledRun.lastAt": completedAt,
+              "scheduledRun.lastStatus": status,
+              "scheduledRun.lastError": undefined,
+              "scheduledRun.consecutiveFailures": 0,
+              ...(nextAt ? { "scheduledRun.nextAt": nextAt } : {}),
+              ...(maxTrackingValue
+                ? { "spec.incremental.lastValue": maxTrackingValue }
+                : {}),
+            },
+            $inc: { "scheduledRun.runCount": 1 },
+          },
+        );
+      });
+      isFinalized = true;
+
+      await step.run("emit-reverse-etl-terminal-notification", async () => {
+        await emitReverseEtlTerminalEvent({
+          workspaceId,
+          reverseFlowId,
+          runId: run.id,
+          triggerType,
+        });
+      });
+
+      return {
+        runId: run.id,
+        reverseFlowId,
+        workspaceId,
+        status,
+        rowsRead: counters.rowsRead,
+      };
+    } catch (error) {
+      logger.error("Reverse ETL execution failed", {
+        workspaceId,
+        reverseFlowId,
+        error,
+      });
+      if (!isFinalized) {
+        await step.run("finalize-run-error", async () => {
+          const completedAt = new Date();
+          const message =
+            error instanceof Error ? error.message : "Reverse ETL failed";
+          await ReverseFlowRun.updateOne(
+            { _id: new Types.ObjectId(run.id) },
+            {
+              $set: {
+                status: "error",
+                completedAt,
+                durationMs: completedAt.getTime() - startedAt.getTime(),
+                error: { message },
+              },
+            },
+          );
+          await ReverseFlow.updateOne(
+            { _id: new Types.ObjectId(reverseFlowId) },
+            {
+              $set: {
+                "scheduledRun.lastAt": completedAt,
+                "scheduledRun.lastStatus": "error",
+                "scheduledRun.lastError": message,
+              },
+              $inc: {
+                "scheduledRun.runCount": 1,
+                "scheduledRun.consecutiveFailures": 1,
+              },
+            },
+          );
+        });
+      }
+      await step.run(
+        "emit-reverse-etl-terminal-notification-error",
+        async () => {
+          await emitReverseEtlTerminalEvent({
+            workspaceId,
+            reverseFlowId,
+            runId: run.id,
+            triggerType,
+          });
+        },
+      );
+      throw error;
+    }
+  },
+);

--- a/api/src/inngest/index.ts
+++ b/api/src/inngest/index.ts
@@ -26,6 +26,10 @@ import {
   scheduledQuerySchedulerFunction,
 } from "./functions/scheduled-query";
 import {
+  reverseEtlExecutorFunction,
+  reverseEtlSchedulerFunction,
+} from "./functions/reverse-etl";
+import {
   flowRunTerminalFanoutFunction,
   notificationDeliverFunction,
 } from "./functions/flow-run-notifications";
@@ -42,6 +46,7 @@ const baseFunctions = [
   usageReportingFunction,
   modelCatalogRefreshFunction,
   scheduledQueryExecutorFunction,
+  reverseEtlExecutorFunction,
   flowRunTerminalFanoutFunction,
   notificationDeliverFunction,
 ];
@@ -79,6 +84,7 @@ export function getFunctions() {
         flowSchedulerFunction,
         dashboardSchedulerFunction,
         scheduledQuerySchedulerFunction,
+        reverseEtlSchedulerFunction,
       ];
 
   return _functions;
@@ -130,4 +136,6 @@ export {
   modelCatalogRefreshFunction,
   scheduledQueryExecutorFunction,
   scheduledQuerySchedulerFunction,
+  reverseEtlExecutorFunction,
+  reverseEtlSchedulerFunction,
 };

--- a/api/src/migrations/2026-06-06-174800_reverse_etl_collections.ts
+++ b/api/src/migrations/2026-06-06-174800_reverse_etl_collections.ts
@@ -1,0 +1,84 @@
+import { Db } from "mongodb";
+import { loggers } from "../logging";
+
+const log = loggers.migration();
+
+export const description =
+  "Create Reverse ETL collections and indexes for runs and outbound ledger";
+
+function hasIndexOnKeys(
+  indexes: { key: Record<string, number> }[],
+  keyPattern: Record<string, number>,
+): boolean {
+  const target = JSON.stringify(keyPattern);
+  return indexes.some(idx => JSON.stringify(idx.key) === target);
+}
+
+async function ensureCollection(db: Db, name: string): Promise<void> {
+  const exists = await db.listCollections({ name }).hasNext();
+  if (!exists) {
+    await db.createCollection(name);
+    log.info("Created collection", { name });
+  }
+}
+
+export async function up(db: Db): Promise<void> {
+  await ensureCollection(db, "reverse_flows");
+  await ensureCollection(db, "reverse_flow_runs");
+  await ensureCollection(db, "reverse_flow_ledger");
+
+  const reverseFlows = db.collection("reverse_flows");
+  const reverseFlowIndexes = await reverseFlows.listIndexes().toArray();
+  if (!hasIndexOnKeys(reverseFlowIndexes, { workspaceId: 1, status: 1 })) {
+    await reverseFlows.createIndex(
+      { workspaceId: 1, status: 1 },
+      { name: "reverse_flows_workspace_status_idx" },
+    );
+  }
+  if (!hasIndexOnKeys(reverseFlowIndexes, { "scheduledRun.nextAt": 1 })) {
+    await reverseFlows.createIndex(
+      { "scheduledRun.nextAt": 1 },
+      { name: "reverse_flows_next_at_idx", sparse: true },
+    );
+  }
+
+  const runs = db.collection("reverse_flow_runs");
+  const runIndexes = await runs.listIndexes().toArray();
+  if (
+    !hasIndexOnKeys(runIndexes, {
+      workspaceId: 1,
+      reverseFlowId: 1,
+      triggeredAt: -1,
+    })
+  ) {
+    await runs.createIndex(
+      { workspaceId: 1, reverseFlowId: 1, triggeredAt: -1 },
+      { name: "reverse_flow_runs_workspace_flow_triggered_idx" },
+    );
+  }
+  if (!hasIndexOnKeys(runIndexes, { completedAt: 1 })) {
+    await runs.createIndex(
+      { completedAt: 1 },
+      {
+        name: "reverse_flow_runs_completed_ttl_idx",
+        sparse: true,
+        expireAfterSeconds: 7776000,
+      },
+    );
+  }
+
+  const ledger = db.collection("reverse_flow_ledger");
+  const ledgerIndexes = await ledger.listIndexes().toArray();
+  if (!hasIndexOnKeys(ledgerIndexes, { reverseFlowId: 1, sourcePk: 1 })) {
+    await ledger.createIndex(
+      { reverseFlowId: 1, sourcePk: 1 },
+      { name: "reverse_flow_ledger_flow_source_unique_idx", unique: true },
+    );
+  }
+  if (!hasIndexOnKeys(ledgerIndexes, { workspaceId: 1, reverseFlowId: 1 })) {
+    await ledger.createIndex(
+      { workspaceId: 1, reverseFlowId: 1 },
+      { name: "reverse_flow_ledger_workspace_flow_idx" },
+    );
+  }
+}

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -325,6 +325,7 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
     tabKind,
     flowType,
     flowFormState,
+    reverseFlowFormState,
     activeDashboardContext,
     screenshotVisionAttachments,
   } = body as {
@@ -338,7 +339,12 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
     modelId?: string;
     activeConsoleResults?: ActiveConsoleResults;
     agentId?: string;
-    activeView?: "console" | "dashboard" | "flow-editor" | "empty";
+    activeView?:
+      | "console"
+      | "dashboard"
+      | "flow-editor"
+      | "reverse-flow-editor"
+      | "empty";
     activeExplorer?:
       | "databases"
       | "consoles"
@@ -349,6 +355,7 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
     tabKind?: string;
     flowType?: string;
     flowFormState?: Record<string, unknown>;
+    reverseFlowFormState?: Record<string, unknown>;
     screenshotVisionAttachments?: ScreenshotVisionAttachment[];
     activeDashboardContext?: {
       dashboardId: string;
@@ -665,6 +672,7 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
       sqlDialect: (db as any).sqlDialect || undefined,
     })),
     flowFormState,
+    reverseFlowFormState,
     workspaceCustomPrompt,
     selfDirective,
     consoleHints,

--- a/api/src/routes/notification-rules.ts
+++ b/api/src/routes/notification-rules.ts
@@ -9,6 +9,7 @@ import {
   Flow,
   NotificationDelivery,
   NotificationRule,
+  ReverseFlow,
   SavedConsole,
   decrypt,
   type INotificationRuleChannel,
@@ -72,6 +73,13 @@ async function assertResourceInWorkspace(
     }).lean();
     return !!doc;
   }
+  if (resourceType === "reverse_etl") {
+    const doc = await ReverseFlow.findOne({
+      _id: rid,
+      workspaceId: ws,
+    }).lean();
+    return !!doc;
+  }
   const doc = await Flow.findOne({
     _id: rid,
     workspaceId: ws,
@@ -114,8 +122,9 @@ function parseChannelFromBody(body: Record<string, unknown>): {
       typeof body.signingSecret === "string" && body.signingSecret.trim()
         ? body.signingSecret.trim()
         : generateWebhookSigningSecret();
-    const generatedNewSecret =
-      !(typeof body.signingSecret === "string" && body.signingSecret.trim());
+    const generatedNewSecret = !(
+      typeof body.signingSecret === "string" && body.signingSecret.trim()
+    );
     return {
       channel: {
         type: "webhook",
@@ -155,7 +164,9 @@ notificationRulesRoutes.get("/", async (c: AuthenticatedContext) => {
 
     if (
       !resourceType ||
-      (resourceType !== "flow" && resourceType !== "scheduled_query") ||
+      (resourceType !== "flow" &&
+        resourceType !== "scheduled_query" &&
+        resourceType !== "reverse_etl") ||
       !resourceId ||
       !Types.ObjectId.isValid(resourceId)
     ) {
@@ -214,7 +225,9 @@ notificationRulesRoutes.get("/deliveries", async (c: AuthenticatedContext) => {
 
     if (
       !resourceType ||
-      (resourceType !== "flow" && resourceType !== "scheduled_query") ||
+      (resourceType !== "flow" &&
+        resourceType !== "scheduled_query" &&
+        resourceType !== "reverse_etl") ||
       !resourceId ||
       !Types.ObjectId.isValid(resourceId)
     ) {
@@ -265,9 +278,7 @@ notificationRulesRoutes.get("/deliveries", async (c: AuthenticatedContext) => {
       {
         success: false,
         error:
-          error instanceof Error
-            ? error.message
-            : "Failed to list deliveries",
+          error instanceof Error ? error.message : "Failed to list deliveries",
       },
       500,
     );
@@ -284,13 +295,14 @@ notificationRulesRoutes.post("/", async (c: AuthenticatedContext) => {
 
     const resourceType = body.resourceType as NotificationResourceType;
     const resourceId = body.resourceId as string;
-    const enabled =
-      typeof body.enabled === "boolean" ? body.enabled : true;
+    const enabled = typeof body.enabled === "boolean" ? body.enabled : true;
     const triggers = parseTriggers(body.triggers);
 
     if (
       !resourceType ||
-      (resourceType !== "flow" && resourceType !== "scheduled_query") ||
+      (resourceType !== "flow" &&
+        resourceType !== "scheduled_query" &&
+        resourceType !== "reverse_etl") ||
       !resourceId ||
       !Types.ObjectId.isValid(resourceId) ||
       !triggers
@@ -312,7 +324,10 @@ notificationRulesRoutes.post("/", async (c: AuthenticatedContext) => {
 
     const parsed = parseChannelFromBody(body);
     if (!parsed) {
-      return c.json({ success: false, error: "Invalid channel configuration" }, 400);
+      return c.json(
+        { success: false, error: "Invalid channel configuration" },
+        400,
+      );
     }
 
     const channel = encryptNotificationChannel(parsed.channel);
@@ -480,7 +495,9 @@ notificationRulesRoutes.patch("/:ruleId", async (c: AuthenticatedContext) => {
     return c.json({
       success: true,
       rule: sanitizeRuleForClient(existing),
-      ...(signingSecretOnceOut ? { signingSecretOnce: signingSecretOnceOut } : {}),
+      ...(signingSecretOnceOut
+        ? { signingSecretOnce: signingSecretOnceOut }
+        : {}),
     });
   } catch (error) {
     logger.error("Update notification rule failed", { error });
@@ -542,14 +559,13 @@ notificationRulesRoutes.post("/test", async (c: AuthenticatedContext) => {
 
     if (
       !resourceType ||
-      (resourceType !== "flow" && resourceType !== "scheduled_query") ||
+      (resourceType !== "flow" &&
+        resourceType !== "scheduled_query" &&
+        resourceType !== "reverse_etl") ||
       !resourceId ||
       !Types.ObjectId.isValid(resourceId)
     ) {
-      return c.json(
-        { success: false, error: "Invalid resource" },
-        400,
-      );
+      return c.json({ success: false, error: "Invalid resource" }, 400);
     }
 
     const ok = await assertResourceInWorkspace(

--- a/api/src/routes/reverse-flows.ts
+++ b/api/src/routes/reverse-flows.ts
@@ -129,14 +129,16 @@ reverseFlowRoutes.get("/connectors/:connectorId/outbound-schema", async c => {
 reverseFlowRoutes.get("/:id", async c => {
   const workspaceId = c.req.param("workspaceId");
   const id = objectId(c.req.param("id"));
-  if (!id)
+  if (!id) {
     return c.json({ success: false, error: "Invalid reverse flow ID" }, 400);
+  }
   const flow = await ReverseFlow.findOne({
     _id: id,
     workspaceId: new Types.ObjectId(workspaceId),
   });
-  if (!flow)
+  if (!flow) {
     return c.json({ success: false, error: "Reverse flow not found" }, 404);
+  }
   return c.json({ success: true, data: serializeFlow(flow) });
 });
 
@@ -144,8 +146,9 @@ reverseFlowRoutes.put("/:id", async (c: AuthenticatedContext) => {
   const workspaceId = c.req.param("workspaceId");
   const id = objectId(c.req.param("id"));
   const user = c.get("user");
-  if (!id)
+  if (!id) {
     return c.json({ success: false, error: "Invalid reverse flow ID" }, 400);
+  }
 
   try {
     const body = (await c.req.json()) as Record<string, unknown>;
@@ -210,8 +213,9 @@ reverseFlowRoutes.post("/:id/dry-run", async c => {
   if (!workspaceId) {
     return c.json({ success: false, error: "Workspace ID is required" }, 400);
   }
-  if (!id)
+  if (!id) {
     return c.json({ success: false, error: "Invalid reverse flow ID" }, 400);
+  }
   try {
     const body = (await c.req.json().catch(() => ({}))) as {
       sampleSize?: number;
@@ -300,15 +304,17 @@ reverseFlowRoutes.post(
 reverseFlowRoutes.post("/:id/pause", async c => {
   const workspaceId = c.req.param("workspaceId");
   const id = objectId(c.req.param("id"));
-  if (!id)
+  if (!id) {
     return c.json({ success: false, error: "Invalid reverse flow ID" }, 400);
+  }
   const flow = await ReverseFlow.findOneAndUpdate(
     { _id: id, workspaceId: new Types.ObjectId(workspaceId) },
     { $set: { status: "paused", "scheduledRun.nextAt": undefined } },
     { new: true },
   );
-  if (!flow)
+  if (!flow) {
     return c.json({ success: false, error: "Reverse flow not found" }, 404);
+  }
   return c.json({ success: true, data: serializeFlow(flow) });
 });
 
@@ -326,8 +332,9 @@ reverseFlowRoutes.post(
       _id: id,
       workspaceId: new Types.ObjectId(workspaceId),
     }).lean();
-    if (!flow)
+    if (!flow) {
       return c.json({ success: false, error: "Reverse flow not found" }, 404);
+    }
     if (flow.status !== "active") {
       return c.json(
         { success: false, error: "Reverse flow must be active" },
@@ -350,8 +357,9 @@ reverseFlowRoutes.post(
 reverseFlowRoutes.get("/:id/runs", async c => {
   const workspaceId = c.req.param("workspaceId");
   const id = objectId(c.req.param("id"));
-  if (!id)
+  if (!id) {
     return c.json({ success: false, error: "Invalid reverse flow ID" }, 400);
+  }
   const runs = await ReverseFlowRun.find({
     workspaceId: new Types.ObjectId(workspaceId),
     reverseFlowId: id,
@@ -365,15 +373,17 @@ reverseFlowRoutes.get("/:id/runs", async c => {
 reverseFlowRoutes.get("/:id/versions", async c => {
   const workspaceId = c.req.param("workspaceId");
   const id = objectId(c.req.param("id"));
-  if (!id)
+  if (!id) {
     return c.json({ success: false, error: "Invalid reverse flow ID" }, 400);
+  }
   const flow = await ReverseFlow.findOne({
     _id: id,
     workspaceId: new Types.ObjectId(workspaceId),
   })
     .select("versions")
     .lean();
-  if (!flow)
+  if (!flow) {
     return c.json({ success: false, error: "Reverse flow not found" }, 404);
+  }
   return c.json({ success: true, data: flow.versions || [] });
 });

--- a/api/src/routes/reverse-flows.ts
+++ b/api/src/routes/reverse-flows.ts
@@ -1,0 +1,379 @@
+/**
+ * Workspace-scoped Reverse ETL flows.
+ * Authenticated + workspace member access; activation and runs require owner/admin.
+ */
+import { Hono } from "hono";
+import { Types } from "mongoose";
+import { unifiedAuthMiddleware } from "../auth/unified-auth.middleware";
+import {
+  ReverseFlow,
+  ReverseFlowRun,
+  type IReverseFlow,
+} from "../database/workspace-schema";
+import {
+  AuthenticatedContext,
+  requireWorkspace,
+  requireWorkspaceRole,
+} from "../middleware/workspace.middleware";
+import { loggers } from "../logging";
+import {
+  DEFAULT_REVERSE_FLOW_SPEC,
+  REVERSE_FLOW_SPEC_SCHEMA,
+  applyReverseFlowDefaults,
+} from "../schemas/reverse-flow.schema";
+import { dryRunReverseEtl } from "../services/reverse-etl/dry-run.service";
+import { getOutboundConnector } from "../services/reverse-etl/outbound";
+import { inngest } from "../inngest";
+import {
+  getNextScheduledConsoleRunAt,
+  normalizeScheduledConsoleSchedule,
+} from "../services/scheduled-query-schedule.service";
+
+const logger = loggers.api("reverse-flows");
+
+export const reverseFlowRoutes = new Hono();
+
+reverseFlowRoutes.use("*", unifiedAuthMiddleware);
+reverseFlowRoutes.use("*", requireWorkspace);
+
+function objectId(id: string): Types.ObjectId | null {
+  return Types.ObjectId.isValid(id) ? new Types.ObjectId(id) : null;
+}
+
+function serializeFlow(flow: IReverseFlow) {
+  const object = flow.toObject({ getters: true });
+  return {
+    ...object,
+    id: object._id?.toString(),
+    _id: object._id?.toString(),
+    workspaceId: object.workspaceId?.toString(),
+  };
+}
+
+reverseFlowRoutes.get("/", async c => {
+  const workspaceId = c.req.param("workspaceId");
+  try {
+    const flows = await ReverseFlow.find({
+      workspaceId: new Types.ObjectId(workspaceId),
+    }).sort({ updatedAt: -1 });
+    return c.json({
+      success: true,
+      data: flows.map(flow => serializeFlow(flow)),
+    });
+  } catch (error) {
+    logger.error("Failed to list reverse flows", { error, workspaceId });
+    return c.json(
+      { success: false, error: "Failed to list reverse flows" },
+      500,
+    );
+  }
+});
+
+reverseFlowRoutes.post("/", async (c: AuthenticatedContext) => {
+  const workspaceId = c.req.param("workspaceId");
+  const user = c.get("user");
+  try {
+    const body = (await c.req.json()) as Record<string, unknown>;
+    const spec = applyReverseFlowDefaults(
+      body.spec || DEFAULT_REVERSE_FLOW_SPEC,
+    );
+    const created = await ReverseFlow.create({
+      workspaceId: new Types.ObjectId(workspaceId),
+      name:
+        typeof body.name === "string" && body.name.trim()
+          ? body.name.trim()
+          : "Untitled Reverse ETL",
+      createdBy: user?.id || "unknown",
+      status: "draft",
+      spec,
+      version: 1,
+      versions: [
+        {
+          version: 1,
+          spec,
+          authoredBy: user?.id || "unknown",
+          reason: "created",
+          createdAt: new Date(),
+        },
+      ],
+      scheduledRun: {
+        runCount: 0,
+        consecutiveFailures: 0,
+      },
+    });
+    return c.json({ success: true, data: serializeFlow(created) }, 201);
+  } catch (error) {
+    logger.error("Failed to create reverse flow", { error, workspaceId });
+    return c.json(
+      { success: false, error: "Failed to create reverse flow" },
+      400,
+    );
+  }
+});
+
+reverseFlowRoutes.get("/connectors/:connectorId/outbound-schema", async c => {
+  const entity = c.req.query("entity") || "leads";
+  try {
+    const outbound = await getOutboundConnector(c.req.param("connectorId"));
+    const schema = await outbound.resolveOutboundSchema(entity);
+    return c.json({ success: true, data: schema });
+  } catch (error) {
+    logger.error("Failed to resolve outbound schema", { error, entity });
+    return c.json(
+      { success: false, error: "Failed to resolve outbound schema" },
+      400,
+    );
+  }
+});
+
+reverseFlowRoutes.get("/:id", async c => {
+  const workspaceId = c.req.param("workspaceId");
+  const id = objectId(c.req.param("id"));
+  if (!id)
+    return c.json({ success: false, error: "Invalid reverse flow ID" }, 400);
+  const flow = await ReverseFlow.findOne({
+    _id: id,
+    workspaceId: new Types.ObjectId(workspaceId),
+  });
+  if (!flow)
+    return c.json({ success: false, error: "Reverse flow not found" }, 404);
+  return c.json({ success: true, data: serializeFlow(flow) });
+});
+
+reverseFlowRoutes.put("/:id", async (c: AuthenticatedContext) => {
+  const workspaceId = c.req.param("workspaceId");
+  const id = objectId(c.req.param("id"));
+  const user = c.get("user");
+  if (!id)
+    return c.json({ success: false, error: "Invalid reverse flow ID" }, 400);
+
+  try {
+    const body = (await c.req.json()) as Record<string, unknown>;
+    const flow = await ReverseFlow.findOne({
+      _id: id,
+      workspaceId: new Types.ObjectId(workspaceId),
+    });
+    if (!flow) {
+      return c.json({ success: false, error: "Reverse flow not found" }, 404);
+    }
+
+    const nextSpec =
+      body.spec === undefined
+        ? flow.spec
+        : REVERSE_FLOW_SPEC_SCHEMA.parse(body.spec);
+    const nextVersion = flow.version + 1;
+    flow.name =
+      typeof body.name === "string" && body.name.trim()
+        ? body.name.trim()
+        : flow.name;
+    flow.spec = nextSpec;
+    flow.status = "draft";
+    flow.version = nextVersion;
+    flow.versions.push({
+      version: nextVersion,
+      spec: nextSpec,
+      authoredBy: user?.id || "unknown",
+      reason: typeof body.reason === "string" ? body.reason : "updated",
+      createdAt: new Date(),
+    });
+    await flow.save();
+    return c.json({ success: true, data: serializeFlow(flow) });
+  } catch (error) {
+    logger.error("Failed to update reverse flow", { error, workspaceId });
+    return c.json(
+      { success: false, error: "Failed to update reverse flow" },
+      400,
+    );
+  }
+});
+
+reverseFlowRoutes.delete(
+  "/:id",
+  requireWorkspaceRole(["owner", "admin"]),
+  async c => {
+    const workspaceId = c.req.param("workspaceId");
+    const id = objectId(c.req.param("id"));
+    if (!id) {
+      return c.json({ success: false, error: "Invalid reverse flow ID" }, 400);
+    }
+    await ReverseFlow.deleteOne({
+      _id: id,
+      workspaceId: new Types.ObjectId(workspaceId),
+    });
+    return c.json({ success: true });
+  },
+);
+
+reverseFlowRoutes.post("/:id/dry-run", async c => {
+  const workspaceId = c.req.param("workspaceId");
+  const id = objectId(c.req.param("id"));
+  if (!workspaceId) {
+    return c.json({ success: false, error: "Workspace ID is required" }, 400);
+  }
+  if (!id)
+    return c.json({ success: false, error: "Invalid reverse flow ID" }, 400);
+  try {
+    const body = (await c.req.json().catch(() => ({}))) as {
+      sampleSize?: number;
+      spec?: unknown;
+    };
+    const flow = await ReverseFlow.findOne({
+      _id: id,
+      workspaceId: new Types.ObjectId(workspaceId),
+    });
+    if (!flow) {
+      return c.json({ success: false, error: "Reverse flow not found" }, 404);
+    }
+    const spec = body.spec
+      ? REVERSE_FLOW_SPEC_SCHEMA.parse(body.spec)
+      : flow.spec;
+    const result = await dryRunReverseEtl(
+      workspaceId,
+      spec,
+      Math.min(body.sampleSize || 25, 100),
+    );
+    flow.lastDryRun = { at: new Date(), ...result.summary };
+    await flow.save();
+    return c.json({ success: true, data: result });
+  } catch (error) {
+    logger.error("Reverse flow dry run failed", { error, workspaceId });
+    return c.json(
+      { success: false, error: "Reverse flow dry run failed" },
+      400,
+    );
+  }
+});
+
+reverseFlowRoutes.post(
+  "/:id/activate",
+  requireWorkspaceRole(["owner", "admin"]),
+  async c => {
+    const workspaceId = c.req.param("workspaceId");
+    const id = objectId(c.req.param("id"));
+    if (!id) {
+      return c.json({ success: false, error: "Invalid reverse flow ID" }, 400);
+    }
+    try {
+      const flow = await ReverseFlow.findOne({
+        _id: id,
+        workspaceId: new Types.ObjectId(workspaceId),
+      });
+      if (!flow) {
+        return c.json({ success: false, error: "Reverse flow not found" }, 404);
+      }
+      if (
+        flow.spec.safety.dryRunRequiredBeforeActivate &&
+        !flow.lastDryRun?.passed
+      ) {
+        return c.json(
+          { success: false, error: "A passing dry run is required first" },
+          400,
+        );
+      }
+      const outbound = await getOutboundConnector(
+        flow.spec.destination.connectorId,
+      );
+      await outbound.resolveOutboundSchema(flow.spec.destination.entity);
+      const schedule = flow.spec.schedule;
+      flow.status = "active";
+      flow.scheduledRun = {
+        ...(flow.scheduledRun || { runCount: 0, consecutiveFailures: 0 }),
+        nextAt:
+          schedule.enabled && schedule.cron
+            ? getNextScheduledConsoleRunAt(
+                normalizeScheduledConsoleSchedule(schedule),
+              )
+            : undefined,
+      };
+      await flow.save();
+      return c.json({ success: true, data: serializeFlow(flow) });
+    } catch (error) {
+      logger.error("Failed to activate reverse flow", { error, workspaceId });
+      return c.json(
+        { success: false, error: "Failed to activate reverse flow" },
+        400,
+      );
+    }
+  },
+);
+
+reverseFlowRoutes.post("/:id/pause", async c => {
+  const workspaceId = c.req.param("workspaceId");
+  const id = objectId(c.req.param("id"));
+  if (!id)
+    return c.json({ success: false, error: "Invalid reverse flow ID" }, 400);
+  const flow = await ReverseFlow.findOneAndUpdate(
+    { _id: id, workspaceId: new Types.ObjectId(workspaceId) },
+    { $set: { status: "paused", "scheduledRun.nextAt": undefined } },
+    { new: true },
+  );
+  if (!flow)
+    return c.json({ success: false, error: "Reverse flow not found" }, 404);
+  return c.json({ success: true, data: serializeFlow(flow) });
+});
+
+reverseFlowRoutes.post(
+  "/:id/run",
+  requireWorkspaceRole(["owner", "admin"]),
+  async (c: AuthenticatedContext) => {
+    const workspaceId = c.req.param("workspaceId");
+    const id = objectId(c.req.param("id"));
+    const user = c.get("user");
+    if (!id) {
+      return c.json({ success: false, error: "Invalid reverse flow ID" }, 400);
+    }
+    const flow = await ReverseFlow.findOne({
+      _id: id,
+      workspaceId: new Types.ObjectId(workspaceId),
+    }).lean();
+    if (!flow)
+      return c.json({ success: false, error: "Reverse flow not found" }, 404);
+    if (flow.status !== "active") {
+      return c.json(
+        { success: false, error: "Reverse flow must be active" },
+        400,
+      );
+    }
+    await inngest.send({
+      name: "reverse_etl/execute",
+      data: {
+        workspaceId,
+        reverseFlowId: id.toString(),
+        triggerType: "manual",
+        triggeredBy: user?.id,
+      },
+    });
+    return c.json({ success: true });
+  },
+);
+
+reverseFlowRoutes.get("/:id/runs", async c => {
+  const workspaceId = c.req.param("workspaceId");
+  const id = objectId(c.req.param("id"));
+  if (!id)
+    return c.json({ success: false, error: "Invalid reverse flow ID" }, 400);
+  const runs = await ReverseFlowRun.find({
+    workspaceId: new Types.ObjectId(workspaceId),
+    reverseFlowId: id,
+  })
+    .sort({ triggeredAt: -1 })
+    .limit(100)
+    .lean();
+  return c.json({ success: true, data: runs });
+});
+
+reverseFlowRoutes.get("/:id/versions", async c => {
+  const workspaceId = c.req.param("workspaceId");
+  const id = objectId(c.req.param("id"));
+  if (!id)
+    return c.json({ success: false, error: "Invalid reverse flow ID" }, 400);
+  const flow = await ReverseFlow.findOne({
+    _id: id,
+    workspaceId: new Types.ObjectId(workspaceId),
+  })
+    .select("versions")
+    .lean();
+  if (!flow)
+    return c.json({ success: false, error: "Reverse flow not found" }, 404);
+  return c.json({ success: true, data: flow.versions || [] });
+});

--- a/api/src/schemas/reverse-flow.schema.ts
+++ b/api/src/schemas/reverse-flow.schema.ts
@@ -1,0 +1,281 @@
+import { z } from "zod";
+
+type FieldCategory =
+  | "source"
+  | "destination"
+  | "mapping"
+  | "schedule"
+  | "safety"
+  | "pagination";
+
+interface FieldMeta {
+  description: string;
+  injectInContext: boolean;
+  category: FieldCategory;
+  example?: string;
+  format?: "code" | "json" | "cron";
+}
+
+interface AgentField<T extends z.ZodTypeAny> {
+  schema: T;
+  meta: FieldMeta;
+}
+
+function agentField<T extends z.ZodTypeAny>(
+  schema: T,
+  meta: FieldMeta,
+): AgentField<T> {
+  return { schema: schema.describe(meta.description), meta };
+}
+
+export const TRANSFORM_SCHEMA = z.object({
+  ops: z
+    .array(
+      z.enum([
+        "trim",
+        "lowercase",
+        "uppercase",
+        "to_string",
+        "to_number",
+        "to_iso_date",
+      ]),
+    )
+    .optional(),
+  template: z.string().optional(),
+  lookupMap: z.record(z.string(), z.string()).optional(),
+  defaultValue: z.unknown().optional(),
+});
+
+export const MAPPING_SCHEMA = z.object({
+  target: z.string().min(1),
+  source: z.object({
+    column: z.string().optional(),
+    const: z.unknown().optional(),
+    transform: TRANSFORM_SCHEMA.optional(),
+  }),
+  required: z.boolean().default(false),
+  onConflict: z.enum(["overwrite", "fill_empty", "ignore"]).optional(),
+});
+
+export const MATCH_SCHEMA = z.object({
+  lookupColumn: z.string().min(1),
+  remoteField: z.string().min(1),
+  onMultiple: z.enum(["skip", "update_first", "fail"]).default("skip"),
+});
+
+export const SOURCE_FIELDS = {
+  connectionId: agentField(z.string().min(1), {
+    description: "Source database connection ID",
+    injectInContext: true,
+    category: "source",
+  }),
+  database: agentField(z.string().optional(), {
+    description: "Optional source database or dataset name",
+    injectInContext: true,
+    category: "source",
+  }),
+  query: agentField(z.string().min(1), {
+    description:
+      "SQL query to read rows, with optional {{limit}}, {{offset}}, {{last_sync_value}}, {{keyset_value}} placeholders",
+    injectInContext: true,
+    category: "source",
+    format: "code",
+  }),
+  primaryKey: agentField(z.string().min(1), {
+    description: "Source column that uniquely identifies each outbound row",
+    injectInContext: true,
+    category: "source",
+  }),
+} as const;
+
+export const SOURCE_SCHEMA = z.object({
+  connectionId: SOURCE_FIELDS.connectionId.schema,
+  database: SOURCE_FIELDS.database.schema,
+  query: SOURCE_FIELDS.query.schema,
+  primaryKey: SOURCE_FIELDS.primaryKey.schema,
+});
+
+export const DESTINATION_FIELDS = {
+  connectorId: agentField(z.string().min(1), {
+    description: "Destination connector ID",
+    injectInContext: true,
+    category: "destination",
+  }),
+  entity: agentField(z.string().min(1).default("leads"), {
+    description: "Destination entity, for example Close leads",
+    injectInContext: true,
+    category: "destination",
+  }),
+  writeMode: agentField(
+    z.enum(["create", "update", "upsert"]).default("upsert"),
+    {
+      description: "Whether to create, update, or upsert destination records",
+      injectInContext: true,
+      category: "destination",
+    },
+  ),
+  allowCreate: agentField(z.boolean().default(true), {
+    description: "Allow creating a new destination record when no match exists",
+    injectInContext: true,
+    category: "destination",
+  }),
+  updateFieldStrategy: agentField(
+    z.enum(["overwrite", "fill_empty", "ignore"]).default("fill_empty"),
+    {
+      description:
+        "How updates handle existing destination values: overwrite, fill_empty, or ignore",
+      injectInContext: true,
+      category: "destination",
+    },
+  ),
+  match: agentField(MATCH_SCHEMA, {
+    description: "Destination match configuration",
+    injectInContext: true,
+    category: "destination",
+    format: "json",
+  }),
+} as const;
+
+export const DESTINATION_SCHEMA = z.object({
+  connectorId: DESTINATION_FIELDS.connectorId.schema,
+  entity: DESTINATION_FIELDS.entity.schema,
+  writeMode: DESTINATION_FIELDS.writeMode.schema,
+  allowCreate: DESTINATION_FIELDS.allowCreate.schema,
+  updateFieldStrategy: DESTINATION_FIELDS.updateFieldStrategy.schema,
+  match: DESTINATION_FIELDS.match.schema,
+});
+
+export const INCREMENTAL_SCHEMA = z.object({
+  trackingColumn: z.string().min(1),
+  trackingType: z.enum(["timestamp", "numeric", "string"]).default("timestamp"),
+  lastValue: z.string().optional(),
+});
+
+export const PAGINATION_SCHEMA = z.object({
+  mode: z.enum(["offset", "keyset"]).default("offset"),
+  keysetColumn: z.string().optional(),
+  keysetDirection: z.enum(["asc", "desc"]).default("asc"),
+});
+
+export const SCHEDULE_SCHEMA = z.object({
+  enabled: z.boolean().default(false),
+  cron: z.string().optional(),
+  timezone: z.string().default("UTC"),
+});
+
+export const SAFETY_SCHEMA = z.object({
+  maxRowsPerRun: z.number().int().positive().max(50000).default(5000),
+  dryRunRequiredBeforeActivate: z.boolean().default(true),
+  batchSize: z.number().int().positive().max(1000).default(200),
+});
+
+export const REVERSE_FLOW_SPEC_SCHEMA = z.object({
+  source: SOURCE_SCHEMA,
+  destination: DESTINATION_SCHEMA,
+  mappings: z.array(MAPPING_SCHEMA).default([]),
+  incremental: INCREMENTAL_SCHEMA.optional(),
+  pagination: PAGINATION_SCHEMA.optional(),
+  schedule: SCHEDULE_SCHEMA.default({
+    enabled: false,
+    timezone: "UTC",
+  }),
+  safety: SAFETY_SCHEMA.default({
+    maxRowsPerRun: 5000,
+    dryRunRequiredBeforeActivate: true,
+    batchSize: 200,
+  }),
+});
+
+export type TransformSpec = z.infer<typeof TRANSFORM_SCHEMA>;
+export type MappingSpec = z.infer<typeof MAPPING_SCHEMA>;
+export type MatchSpec = z.infer<typeof MATCH_SCHEMA>;
+export type ReverseFlowSpec = z.infer<typeof REVERSE_FLOW_SPEC_SCHEMA>;
+
+export const DEFAULT_REVERSE_FLOW_SPEC: ReverseFlowSpec = {
+  source: {
+    connectionId: "",
+    query: "",
+    primaryKey: "",
+  },
+  destination: {
+    connectorId: "",
+    entity: "leads",
+    writeMode: "upsert",
+    allowCreate: true,
+    updateFieldStrategy: "fill_empty",
+    match: {
+      lookupColumn: "email",
+      remoteField: "email",
+      onMultiple: "skip",
+    },
+  },
+  mappings: [],
+  schedule: {
+    enabled: false,
+    timezone: "UTC",
+  },
+  safety: {
+    maxRowsPerRun: 5000,
+    dryRunRequiredBeforeActivate: true,
+    batchSize: 200,
+  },
+};
+
+export const FIELD_PATHS = [
+  "source.connectionId",
+  "source.database",
+  "source.query",
+  "source.primaryKey",
+  "destination.connectorId",
+  "destination.entity",
+  "destination.writeMode",
+  "destination.allowCreate",
+  "destination.updateFieldStrategy",
+  "destination.match",
+  "destination.match.lookupColumn",
+  "destination.match.remoteField",
+  "destination.match.onMultiple",
+  "mappings",
+  "incremental",
+  "incremental.trackingColumn",
+  "incremental.trackingType",
+  "incremental.lastValue",
+  "pagination",
+  "pagination.mode",
+  "pagination.keysetColumn",
+  "pagination.keysetDirection",
+  "schedule.enabled",
+  "schedule.cron",
+  "schedule.timezone",
+  "safety.maxRowsPerRun",
+  "safety.dryRunRequiredBeforeActivate",
+  "safety.batchSize",
+] as const;
+
+export const CONTEXT_FIELDS = FIELD_PATHS.filter(
+  path => !path.endsWith(".lastValue"),
+);
+
+export const formFieldValue = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.null(),
+  z.array(MAPPING_SCHEMA),
+  MATCH_SCHEMA,
+  INCREMENTAL_SCHEMA,
+  PAGINATION_SCHEMA,
+  SCHEDULE_SCHEMA,
+  SAFETY_SCHEMA,
+]);
+
+export function validateReverseFlowSpec(input: unknown): ReverseFlowSpec {
+  return REVERSE_FLOW_SPEC_SCHEMA.parse(input);
+}
+
+export function applyReverseFlowDefaults(input: unknown): ReverseFlowSpec {
+  return REVERSE_FLOW_SPEC_SCHEMA.parse({
+    ...DEFAULT_REVERSE_FLOW_SPEC,
+    ...(typeof input === "object" && input !== null ? input : {}),
+  });
+}

--- a/api/src/services/flow-run-notification.emit.ts
+++ b/api/src/services/flow-run-notification.emit.ts
@@ -1,17 +1,24 @@
 import { Types } from "mongoose";
-import { Flow, ScheduledQueryRun } from "../database/workspace-schema";
+import {
+  Flow,
+  ReverseFlowRun,
+  ScheduledQueryRun,
+} from "../database/workspace-schema";
 import { inngest } from "../inngest/client";
 import type { FlowRunTerminalEventData } from "./flow-run-notification.types";
 
 export async function emitScheduledQueryTerminalEvent(params: {
-    workspaceId: string;
-    consoleId: string;
-    runId: string;
-    triggerType: "schedule" | "manual";
-  },
-): Promise<void> {
+  workspaceId: string;
+  consoleId: string;
+  runId: string;
+  triggerType: "schedule" | "manual";
+}): Promise<void> {
   const run = await ScheduledQueryRun.findById(params.runId).lean();
-  if (!run?.completedAt || run.status === "queued" || run.status === "running") {
+  if (
+    !run?.completedAt ||
+    run.status === "queued" ||
+    run.status === "running"
+  ) {
     return;
   }
   const success = run.status === "success";
@@ -32,12 +39,11 @@ export async function emitScheduledQueryTerminalEvent(params: {
 }
 
 export async function emitFlowExecutionTerminalEvent(params: {
-    workspaceId: string;
-    flowId: string;
-    executionId: string;
-    triggerType: "schedule" | "manual";
-  },
-): Promise<void> {
+  workspaceId: string;
+  flowId: string;
+  executionId: string;
+  triggerType: "schedule" | "manual";
+}): Promise<void> {
   const collection = Flow.db.collection("flow_executions");
   const execution = await collection.findOne({
     _id: new Types.ObjectId(params.executionId),
@@ -67,6 +73,37 @@ export async function emitFlowExecutionTerminalEvent(params: {
     durationMs:
       typeof execution.duration === "number" ? execution.duration : undefined,
     errorMessage: err?.message,
+  };
+  await inngest.send({ name: "flow.run.terminal", data });
+}
+
+export async function emitReverseEtlTerminalEvent(params: {
+  workspaceId: string;
+  reverseFlowId: string;
+  runId: string;
+  triggerType: "schedule" | "manual";
+}): Promise<void> {
+  const run = await ReverseFlowRun.findById(params.runId).lean();
+  if (
+    !run?.completedAt ||
+    run.status === "queued" ||
+    run.status === "running"
+  ) {
+    return;
+  }
+
+  const data: FlowRunTerminalEventData = {
+    workspaceId: params.workspaceId,
+    resourceType: "reverse_etl",
+    resourceId: params.reverseFlowId,
+    runId: params.runId,
+    status: run.status,
+    success: run.status === "success",
+    triggerType: params.triggerType,
+    completedAt: run.completedAt.toISOString(),
+    durationMs: run.durationMs,
+    rowCount: run.rowsRead,
+    errorMessage: run.error?.message,
   };
   await inngest.send({ name: "flow.run.terminal", data });
 }

--- a/api/src/services/flow-run-notification.service.ts
+++ b/api/src/services/flow-run-notification.service.ts
@@ -3,6 +3,7 @@ import {
   Connector as DataSource,
   DatabaseConnection,
   Flow,
+  ReverseFlow,
   SavedConsole,
   NotificationRule,
   NotificationDelivery,
@@ -47,6 +48,10 @@ export async function resolveResourceDisplayName(params: {
   const id = params.resourceId;
   if (params.resourceType === "scheduled_query") {
     const doc = await SavedConsole.findById(id).select("name").lean();
+    return doc?.name || id;
+  }
+  if (params.resourceType === "reverse_etl") {
+    const doc = await ReverseFlow.findById(id).select("name").lean();
     return doc?.name || id;
   }
   const flowDoc = await Flow.findById(id);
@@ -100,9 +105,13 @@ export function buildOutboundPayload(params: {
       ? base
         ? `${base}/workspace/${params.event.workspaceId}/flows/${params.event.resourceId}`
         : undefined
-      : base
-        ? `${base}/workspace/${params.event.workspaceId}/console/${params.event.resourceId}`
-        : undefined;
+      : params.event.resourceType === "reverse_etl"
+        ? base
+          ? `${base}/workspace/${params.event.workspaceId}/reverse-flows/${params.event.resourceId}`
+          : undefined
+        : base
+          ? `${base}/workspace/${params.event.workspaceId}/console/${params.event.resourceId}`
+          : undefined;
 
   return {
     version: 1,
@@ -162,7 +171,9 @@ export async function fanOutTerminalRunNotifications(
       ruleId,
     });
 
-    const existing = await NotificationDelivery.findOne({ idempotencyKey }).lean();
+    const existing = await NotificationDelivery.findOne({
+      idempotencyKey,
+    }).lean();
     if (existing) {
       continue;
     }
@@ -336,7 +347,9 @@ async function deliverWebhook(
   });
   if (!response.ok) {
     const text = await response.text().catch(() => "");
-    throw new Error(`Webhook HTTP ${response.status}${text ? `: ${text.slice(0, 200)}` : ""}`);
+    throw new Error(
+      `Webhook HTTP ${response.status}${text ? `: ${text.slice(0, 200)}` : ""}`,
+    );
   }
 }
 
@@ -374,7 +387,9 @@ async function deliverSlack(
   });
   if (!response.ok) {
     const t = await response.text().catch(() => "");
-    throw new Error(`Slack webhook HTTP ${response.status}${t ? `: ${t.slice(0, 200)}` : ""}`);
+    throw new Error(
+      `Slack webhook HTTP ${response.status}${t ? `: ${t.slice(0, 200)}` : ""}`,
+    );
   }
 }
 
@@ -400,7 +415,9 @@ export function encryptNotificationChannel(
 }
 
 /** Strip secrets for API responses */
-export function sanitizeRuleForClient(rule: INotificationRule): Record<string, unknown> {
+export function sanitizeRuleForClient(
+  rule: INotificationRule,
+): Record<string, unknown> {
   const base = {
     id: rule._id.toString(),
     workspaceId: rule.workspaceId.toString(),

--- a/api/src/services/reverse-etl/dry-run.service.ts
+++ b/api/src/services/reverse-etl/dry-run.service.ts
@@ -1,0 +1,158 @@
+import { Types } from "mongoose";
+import {
+  DatabaseConnection,
+  type IDatabaseConnection,
+} from "../../database/workspace-schema";
+import type { ReverseFlowSpec } from "../../schemas/reverse-flow.schema";
+import { assertSchema, mapRow } from "./mapping-engine";
+import { readReverseEtlSourcePage } from "./source-reader";
+import { getOutboundConnector } from "./outbound";
+
+export interface ReverseEtlDryRunRow {
+  sourceRow: Record<string, unknown>;
+  payload: Record<string, unknown>;
+  match?: {
+    status: string;
+    remoteId?: string;
+    matchCount?: number;
+  };
+  fieldDiffs?: {
+    field: string;
+    before: unknown;
+    after: unknown;
+    willOverwrite: boolean;
+  }[];
+  outcome: {
+    status: string;
+    error?: string;
+    retryable?: boolean;
+  };
+}
+
+export interface ReverseEtlDryRunResult {
+  rows: ReverseEtlDryRunRow[];
+  summary: {
+    sampleSize: number;
+    accepted: number;
+    rejected: number;
+    ambiguous: number;
+    rejectedFields: { field: string; reason: string }[];
+    passed: boolean;
+  };
+}
+
+export async function dryRunReverseEtl(
+  workspaceId: string,
+  spec: ReverseFlowSpec,
+  sampleSize = 25,
+): Promise<ReverseEtlDryRunResult> {
+  const connectionDoc = await DatabaseConnection.findOne({
+    _id: new Types.ObjectId(spec.source.connectionId),
+    workspaceId: new Types.ObjectId(workspaceId),
+  });
+  if (!connectionDoc) {
+    throw new Error("Source database connection not found");
+  }
+
+  const outbound = await getOutboundConnector(spec.destination.connectorId);
+  const outboundSchema = await outbound.resolveOutboundSchema(
+    spec.destination.entity,
+  );
+  const connection = connectionDoc.toObject({
+    getters: true,
+  }) as IDatabaseConnection;
+  const page = await readReverseEtlSourcePage({
+    connection,
+    spec: {
+      ...spec,
+      safety: {
+        ...spec.safety,
+        batchSize: Math.min(sampleSize, spec.safety.batchSize),
+        maxRowsPerRun: Math.min(sampleSize, spec.safety.maxRowsPerRun),
+      },
+    },
+  });
+
+  assertSchema(spec, page.columns, outboundSchema);
+
+  const mapped = page.rows.map(row => ({
+    row,
+    mapped: mapRow(spec, row),
+  }));
+  const validRecords = mapped
+    .filter(item => item.mapped.errors.length === 0)
+    .map(item => ({
+      sourcePk: String(item.row[spec.source.primaryKey] ?? ""),
+      payload: item.mapped.payload,
+    }))
+    .filter(record => record.sourcePk);
+
+  const writeResults =
+    validRecords.length > 0
+      ? (
+          await outbound.writeBatch({
+            entity: spec.destination.entity,
+            records: validRecords,
+            writeMode: spec.destination.allowCreate
+              ? spec.destination.writeMode
+              : "update",
+            updateFieldStrategy: spec.destination.updateFieldStrategy,
+            match: spec.destination.match,
+            dryRun: true,
+          })
+        ).results
+      : [];
+  const resultsByPk = new Map(
+    writeResults.map(result => [result.sourcePk, result]),
+  );
+  const rejectedFields: { field: string; reason: string }[] = [];
+
+  const rows = mapped.map(({ row, mapped: mappedRow }) => {
+    const sourcePk = String(row[spec.source.primaryKey] ?? "");
+    const result = sourcePk ? resultsByPk.get(sourcePk) : undefined;
+    for (const error of mappedRow.errors) {
+      rejectedFields.push({ field: sourcePk || "row", reason: error });
+    }
+    for (const rejected of result?.rejectedFields || []) {
+      rejectedFields.push({ field: rejected.field, reason: rejected.reason });
+    }
+    return {
+      sourceRow: row,
+      payload: mappedRow.payload,
+      match: result
+        ? {
+            status: result.status,
+            remoteId: result.remoteId,
+            matchCount: result.matchCount,
+          }
+        : undefined,
+      fieldDiffs: result?.fieldDiffs,
+      outcome: {
+        status:
+          mappedRow.errors.length > 0 ? "failed" : result?.status || "skipped",
+        error: mappedRow.errors[0] || result?.error,
+        retryable: result?.retryable,
+      },
+    };
+  });
+
+  const accepted = rows.filter(row =>
+    ["created", "updated", "skipped"].includes(row.outcome.status),
+  ).length;
+  const ambiguous = rows.filter(
+    row => row.outcome.status === "ambiguous",
+  ).length;
+  const rejected = rows.length - accepted - ambiguous;
+
+  return {
+    rows,
+    summary: {
+      sampleSize: rows.length,
+      accepted,
+      rejected,
+      ambiguous,
+      rejectedFields,
+      passed: rejected === 0 && ambiguous === 0,
+    },
+  };
+}

--- a/api/src/services/reverse-etl/mapping-engine.test.ts
+++ b/api/src/services/reverse-etl/mapping-engine.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { assertSchema, contentHash, mapRow } from "./mapping-engine";
+import type { ReverseFlowSpec } from "../../schemas/reverse-flow.schema";
+
+const spec: Pick<ReverseFlowSpec, "mappings"> = {
+  mappings: [
+    {
+      target: "name",
+      source: { column: "full_name", transform: { ops: ["trim"] } },
+      required: true,
+    },
+    {
+      target: "contacts[0].emails[0].email",
+      source: { column: "email", transform: { ops: ["trim", "lowercase"] } },
+      required: true,
+    },
+    {
+      target: "custom.cf_arr",
+      source: { column: "mrr", transform: { ops: ["to_number"] } },
+    },
+    {
+      target: "custom.cf_tier",
+      source: {
+        column: "plan",
+        transform: { lookupMap: { ent: "Enterprise" }, defaultValue: "Other" },
+      },
+    },
+    {
+      target: "url",
+      source: {
+        transform: { template: "https://{{company_domain}}" },
+      },
+    },
+  ],
+};
+
+const row = {
+  email: " Jane@Acme.com ",
+  full_name: " Jane Doe ",
+  company_domain: "acme.com",
+  plan: "ent",
+  mrr: "1200",
+  lifecycle_stage: "enterprise",
+};
+
+const result = mapRow(spec, row);
+assert.deepEqual(result.errors, []);
+assert.equal(result.payload.name, "Jane Doe");
+assert.deepEqual(result.payload.contacts, [
+  { emails: [{ email: "jane@acme.com" }] },
+]);
+assert.deepEqual(result.payload.custom, {
+  cf_arr: 1200,
+  cf_tier: "Enterprise",
+});
+assert.equal(result.payload.url, "https://acme.com");
+assert.deepEqual(result.unmappedColumns, ["company_domain", "lifecycle_stage"]);
+
+assert.doesNotThrow(() => assertSchema(spec, Object.keys(row)));
+assert.throws(
+  () => assertSchema(spec, ["email", "full_name"]),
+  /Missing source columns/,
+);
+
+assert.equal(contentHash({ b: 2, a: 1 }), contentHash({ a: 1, b: 2 }));

--- a/api/src/services/reverse-etl/mapping-engine.ts
+++ b/api/src/services/reverse-etl/mapping-engine.ts
@@ -1,0 +1,239 @@
+import crypto from "crypto";
+import type {
+  MappingSpec,
+  ReverseFlowSpec,
+} from "../../schemas/reverse-flow.schema";
+import type { OutboundEntitySchema } from "../../connectors/base/OutboundConnector";
+
+export interface MapRowResult {
+  payload: Record<string, unknown>;
+  unmappedColumns: string[];
+  errors: string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getPathValue(source: Record<string, unknown>, path: string): unknown {
+  if (path in source) return source[path];
+  const parts = path
+    .replace(/\[(\d+)\]/g, ".$1")
+    .split(".")
+    .filter(Boolean);
+  let cursor: unknown = source;
+  for (const part of parts) {
+    if (isRecord(cursor)) {
+      cursor = cursor[part];
+      continue;
+    }
+    if (Array.isArray(cursor)) {
+      cursor = cursor[Number(part)];
+      continue;
+    }
+    return undefined;
+  }
+  return cursor;
+}
+
+function setPathValue(
+  target: Record<string, unknown>,
+  path: string,
+  value: unknown,
+): void {
+  const parts = path
+    .replace(/\[(\d+)\]/g, ".$1")
+    .split(".")
+    .filter(Boolean);
+  if (parts.length === 0) return;
+
+  let cursor: Record<string, unknown> | unknown[] = target;
+  for (let index = 0; index < parts.length; index++) {
+    const part = parts[index];
+    const isLast = index === parts.length - 1;
+    const nextPart = parts[index + 1];
+    const nextIsArray = nextPart !== undefined && /^\d+$/.test(nextPart);
+
+    if (isLast) {
+      if (Array.isArray(cursor)) {
+        cursor[Number(part)] = value;
+      } else {
+        cursor[part] = value;
+      }
+      return;
+    }
+
+    if (Array.isArray(cursor)) {
+      const arrayIndex = Number(part);
+      if (!cursor[arrayIndex]) {
+        cursor[arrayIndex] = nextIsArray ? [] : {};
+      }
+      cursor = cursor[arrayIndex] as Record<string, unknown> | unknown[];
+      continue;
+    }
+
+    if (!cursor[part]) {
+      cursor[part] = nextIsArray ? [] : {};
+    }
+    cursor = cursor[part] as Record<string, unknown> | unknown[];
+  }
+}
+
+function renderTemplate(
+  template: string,
+  row: Record<string, unknown>,
+): string {
+  return template.replace(/\{\{\s*([^}]+?)\s*\}\}/g, (_match, rawPath) => {
+    const value = getPathValue(row, String(rawPath).trim());
+    return value === undefined || value === null ? "" : String(value);
+  });
+}
+
+function toIsoDate(value: unknown): string | unknown {
+  if (value === undefined || value === null || value === "") return value;
+  const date = value instanceof Date ? value : new Date(String(value));
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toISOString().split("T")[0];
+}
+
+function applyTransforms(
+  value: unknown,
+  mapping: MappingSpec,
+  row: Record<string, unknown>,
+): unknown {
+  const transform = mapping.source.transform;
+  if (!transform) return value;
+
+  let next = transform.template
+    ? renderTemplate(transform.template, row)
+    : value;
+  if (
+    (next === undefined || next === null || next === "") &&
+    transform.defaultValue !== undefined
+  ) {
+    next = transform.defaultValue;
+  }
+
+  if (transform.lookupMap && next !== undefined && next !== null) {
+    const key = String(next);
+    if (Object.prototype.hasOwnProperty.call(transform.lookupMap, key)) {
+      next = transform.lookupMap[key];
+    }
+  }
+
+  for (const op of transform.ops || []) {
+    if (next === undefined || next === null) break;
+    if (op === "trim") next = String(next).trim();
+    if (op === "lowercase") next = String(next).toLowerCase();
+    if (op === "uppercase") next = String(next).toUpperCase();
+    if (op === "to_string") next = String(next);
+    if (op === "to_number") {
+      const parsed = Number(next);
+      next = Number.isFinite(parsed) ? parsed : next;
+    }
+    if (op === "to_iso_date") next = toIsoDate(next);
+  }
+
+  return next;
+}
+
+export function mapRow(
+  spec: Pick<ReverseFlowSpec, "mappings">,
+  row: Record<string, unknown>,
+): MapRowResult {
+  const payload: Record<string, unknown> = {};
+  const errors: string[] = [];
+  const usedColumns = new Set<string>();
+
+  for (const mapping of spec.mappings) {
+    let value =
+      mapping.source.const !== undefined
+        ? mapping.source.const
+        : mapping.source.column
+          ? getPathValue(row, mapping.source.column)
+          : undefined;
+
+    if (mapping.source.column) {
+      usedColumns.add(mapping.source.column);
+    }
+
+    value = applyTransforms(value, mapping, row);
+    if (
+      mapping.required &&
+      (value === undefined || value === null || value === "")
+    ) {
+      errors.push(`Required mapping '${mapping.target}' resolved empty`);
+      continue;
+    }
+    if (value === undefined) continue;
+    setPathValue(payload, mapping.target, value);
+  }
+
+  return {
+    payload,
+    errors,
+    unmappedColumns: Object.keys(row).filter(
+      column => !usedColumns.has(column),
+    ),
+  };
+}
+
+export function assertSchema(
+  spec: Pick<ReverseFlowSpec, "mappings">,
+  resultColumns: string[],
+  outboundSchema?: OutboundEntitySchema,
+): void {
+  const columns = new Set(resultColumns);
+  const missing = spec.mappings
+    .map(mapping => mapping.source.column)
+    .filter((column): column is string => Boolean(column))
+    .filter(column => !columns.has(column));
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing source columns: ${[...new Set(missing)].join(", ")}`,
+    );
+  }
+
+  if (!outboundSchema) return;
+  const invalidTargets = spec.mappings
+    .map(mapping => mapping.target)
+    .filter(target => !resolveOutboundField(outboundSchema, target));
+  if (invalidTargets.length > 0) {
+    throw new Error(
+      `Unknown or non-writable destination fields: ${[
+        ...new Set(invalidTargets),
+      ].join(", ")}`,
+    );
+  }
+}
+
+function resolveOutboundField(
+  outboundSchema: OutboundEntitySchema,
+  target: string,
+) {
+  if (outboundSchema.fields[target]?.writable)
+    return outboundSchema.fields[target];
+  if (target.startsWith("custom.")) {
+    return outboundSchema.fields[`custom_${target.slice("custom.".length)}`];
+  }
+  return undefined;
+}
+
+function stable(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stable);
+  if (!isRecord(value)) return value;
+  return Object.keys(value)
+    .sort()
+    .reduce<Record<string, unknown>>((acc, key) => {
+      acc[key] = stable(value[key]);
+      return acc;
+    }, {});
+}
+
+export function contentHash(payload: Record<string, unknown>): string {
+  return crypto
+    .createHash("sha256")
+    .update(JSON.stringify(stable(payload)))
+    .digest("hex");
+}

--- a/api/src/services/reverse-etl/mapping-engine.ts
+++ b/api/src/services/reverse-etl/mapping-engine.ts
@@ -212,8 +212,9 @@ function resolveOutboundField(
   outboundSchema: OutboundEntitySchema,
   target: string,
 ) {
-  if (outboundSchema.fields[target]?.writable)
+  if (outboundSchema.fields[target]?.writable) {
     return outboundSchema.fields[target];
+  }
   if (target.startsWith("custom.")) {
     return outboundSchema.fields[`custom_${target.slice("custom.".length)}`];
   }

--- a/api/src/services/reverse-etl/outbound.ts
+++ b/api/src/services/reverse-etl/outbound.ts
@@ -1,0 +1,22 @@
+import {
+  isOutboundConnector,
+  type OutboundConnector,
+} from "../../connectors/base/OutboundConnector";
+import { databaseDataSourceManager } from "../../sync/database-data-source-manager";
+import { syncConnectorRegistry } from "../../sync/connector-registry";
+
+export async function getOutboundConnector(
+  connectorId: string,
+): Promise<OutboundConnector> {
+  const dataSource = await databaseDataSourceManager.getDataSource(connectorId);
+  if (!dataSource) {
+    throw new Error("Destination connector not found");
+  }
+
+  const connector = await syncConnectorRegistry.getConnector(dataSource);
+  const outbound = connector?.getOutboundCapability();
+  if (!isOutboundConnector(outbound)) {
+    throw new Error("Destination connector does not support outbound writes");
+  }
+  return outbound;
+}

--- a/api/src/services/reverse-etl/source-reader.ts
+++ b/api/src/services/reverse-etl/source-reader.ts
@@ -1,0 +1,194 @@
+import type { IDatabaseConnection } from "../../database/workspace-schema";
+import { databaseConnectionService } from "../database-connection.service";
+import {
+  appendSqlClause,
+  appendWhereCondition,
+  findTopLevelKeyword,
+} from "../sql-query-utils";
+import {
+  detectTemplates,
+  substituteTemplates,
+} from "../../utils/template-substitution";
+import type { ReverseFlowSpec } from "../../schemas/reverse-flow.schema";
+
+export interface ReverseEtlSourceState {
+  offset: number;
+  totalProcessed: number;
+  hasMore: boolean;
+  lastTrackingValue?: string;
+  lastKeysetValue?: string;
+}
+
+export interface ReverseEtlSourcePage {
+  rows: Record<string, unknown>[];
+  columns: string[];
+  state: ReverseEtlSourceState;
+  maxTrackingValue?: string;
+}
+
+function escapeSqlValue(value: string | number): string | number {
+  return typeof value === "number" || !Number.isNaN(Number(value))
+    ? Number(value)
+    : `'${String(value).replace(/'/g, "''")}'`;
+}
+
+export function buildPaginatedSourceQuery(params: {
+  query: string;
+  paginationConfig?: ReverseFlowSpec["pagination"];
+  incrementalConfig?: ReverseFlowSpec["incremental"];
+  state: ReverseEtlSourceState;
+  limit: number;
+}): string {
+  const baseQuery = params.query.replace(/;\s*$/, "");
+  const paginationMode = params.paginationConfig?.mode || "offset";
+  const keysetColumn = params.paginationConfig?.keysetColumn;
+  const keysetDirection = params.paginationConfig?.keysetDirection || "asc";
+  const templates = detectTemplates(baseQuery);
+
+  if (
+    templates.hasLimit ||
+    templates.hasOffset ||
+    templates.hasLastSyncValue ||
+    templates.hasKeysetValue
+  ) {
+    return substituteTemplates(baseQuery, {
+      limit: params.limit,
+      offset: params.state.offset,
+      last_sync_value: params.incrementalConfig?.lastValue
+        ? escapeSqlValue(params.incrementalConfig.lastValue)
+        : params.state.lastTrackingValue
+          ? escapeSqlValue(params.state.lastTrackingValue)
+          : null,
+      keyset_value: params.state.lastKeysetValue
+        ? escapeSqlValue(params.state.lastKeysetValue)
+        : null,
+    });
+  }
+
+  let effectiveQuery = baseQuery;
+  const lastTrackingValue =
+    params.state.lastTrackingValue || params.incrementalConfig?.lastValue;
+  if (params.incrementalConfig?.trackingColumn && lastTrackingValue) {
+    effectiveQuery = appendWhereCondition(
+      effectiveQuery,
+      `${params.incrementalConfig.trackingColumn} > ${escapeSqlValue(
+        lastTrackingValue,
+      )}`,
+    );
+  }
+
+  if (paginationMode === "keyset" && keysetColumn) {
+    if (params.state.lastKeysetValue) {
+      const operator = keysetDirection === "asc" ? ">" : "<";
+      effectiveQuery = appendWhereCondition(
+        effectiveQuery,
+        `${keysetColumn} ${operator} ${escapeSqlValue(
+          params.state.lastKeysetValue,
+        )}`,
+      );
+    }
+
+    if (findTopLevelKeyword(effectiveQuery, /^ORDER\s+BY\b/i) === -1) {
+      effectiveQuery = appendSqlClause(
+        effectiveQuery,
+        `ORDER BY ${keysetColumn} ${keysetDirection.toUpperCase()}`,
+      );
+    }
+    return appendSqlClause(effectiveQuery, `LIMIT ${params.limit}`);
+  }
+
+  return appendSqlClause(
+    effectiveQuery,
+    `LIMIT ${params.limit} OFFSET ${params.state.offset}`,
+  );
+}
+
+export async function readReverseEtlSourcePage(params: {
+  connection: IDatabaseConnection;
+  spec: ReverseFlowSpec;
+  state?: Partial<ReverseEtlSourceState>;
+}): Promise<ReverseEtlSourcePage> {
+  const batchSize = Math.min(
+    params.spec.safety.batchSize,
+    params.spec.safety.maxRowsPerRun,
+  );
+  const state: ReverseEtlSourceState = {
+    offset: params.state?.offset ?? 0,
+    totalProcessed: params.state?.totalProcessed ?? 0,
+    hasMore: true,
+    lastTrackingValue: params.state?.lastTrackingValue,
+    lastKeysetValue: params.state?.lastKeysetValue,
+  };
+  const paginatedQuery = buildPaginatedSourceQuery({
+    query: params.spec.source.query,
+    paginationConfig: params.spec.pagination,
+    incrementalConfig: params.spec.incremental,
+    state,
+    limit: batchSize,
+  });
+  const result = await databaseConnectionService.executeQuery(
+    params.connection,
+    paginatedQuery,
+    {
+      databaseName: params.spec.source.database,
+      databaseId: params.spec.source.database,
+    },
+  );
+
+  if (!result.success) {
+    throw new Error(result.error || "Reverse ETL source query failed");
+  }
+
+  const rows = Array.isArray(result.data)
+    ? (result.data as Record<string, unknown>[])
+    : [];
+  const columns =
+    result.fields?.map((column: string | { name?: string }) =>
+      typeof column === "string" ? column : column.name || "",
+    ) || Object.keys(rows[0] || {});
+
+  const nextState: ReverseEtlSourceState = {
+    ...state,
+    totalProcessed: state.totalProcessed + rows.length,
+    hasMore:
+      rows.length === batchSize &&
+      state.totalProcessed + rows.length < params.spec.safety.maxRowsPerRun,
+  };
+
+  let maxTrackingValue: string | undefined;
+  if (params.spec.incremental?.trackingColumn) {
+    for (const row of rows) {
+      const value = row[params.spec.incremental.trackingColumn];
+      if (value === undefined || value === null) continue;
+      const serialized =
+        value instanceof Date ? value.toISOString() : String(value);
+      if (!maxTrackingValue || serialized > maxTrackingValue) {
+        maxTrackingValue = serialized;
+      }
+    }
+    if (maxTrackingValue) {
+      nextState.lastTrackingValue = maxTrackingValue;
+    }
+  }
+
+  if (
+    params.spec.pagination?.mode === "keyset" &&
+    params.spec.pagination.keysetColumn
+  ) {
+    const last = rows[rows.length - 1];
+    const value = last?.[params.spec.pagination.keysetColumn];
+    if (value !== undefined && value !== null) {
+      nextState.lastKeysetValue =
+        value instanceof Date ? value.toISOString() : String(value);
+    }
+  } else {
+    nextState.offset += rows.length;
+  }
+
+  return {
+    rows,
+    columns,
+    state: nextState,
+    maxTrackingValue,
+  };
+}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -44,6 +44,7 @@ import { WorkspaceProvider } from "./contexts/workspace-context";
 import { OnboardingProvider } from "./contexts/onboarding-context";
 import { ConsoleModificationPayload } from "./hooks/useMonacoConsole";
 import type { DbFlowFormRef } from "./components/DbFlowForm";
+import type { ReverseFlowFormRef } from "./components/ReverseFlowEditor";
 import { generateObjectId } from "./utils/objectId";
 import { LoginPage } from "./components/LoginPage";
 import { RegisterPage } from "./components/RegisterPage";
@@ -244,6 +245,7 @@ function MainApp() {
 
   // Ref for DbFlowForm - allows AI agent to manipulate form state
   const dbFlowFormRef = useRef<DbFlowFormRef | null>(null);
+  const reverseFlowFormRef = useRef<ReverseFlowFormRef | null>(null);
 
   // Ref for chart spec changes - allows AI agent to set chart specs on the active console tab
   const onChartSpecChangeRef = useRef<
@@ -591,6 +593,7 @@ function MainApp() {
           >
             <Editor
               dbFlowFormRef={dbFlowFormRef}
+              reverseFlowFormRef={reverseFlowFormRef}
               onChartSpecChangeRef={onChartSpecChangeRef}
               resultsContextRef={resultsContextRef}
             />
@@ -615,6 +618,7 @@ function MainApp() {
                 <Chat
                   onConsoleModification={handleConsoleModification}
                   dbFlowFormRef={dbFlowFormRef}
+                  reverseFlowFormRef={reverseFlowFormRef}
                   onChartSpecChangeRef={onChartSpecChangeRef}
                   resultsContextRef={resultsContextRef}
                 />

--- a/app/src/agent-runtime/client-tool-manifest.ts
+++ b/app/src/agent-runtime/client-tool-manifest.ts
@@ -502,6 +502,53 @@ export const AGENT_TOOL_MANIFEST = {
     getLabel: () => "Listing flow tabs",
     icon: "list",
   },
+  get_reverse_etl_form_state: {
+    domain: "flow",
+    execution: "client",
+    clientExecutor: "flow",
+    getLabel: () => "Reading Reverse ETL form",
+    icon: "eye",
+  },
+  set_reverse_etl_form_field: {
+    domain: "flow",
+    execution: "client",
+    clientExecutor: "flow",
+    getLabel: input => {
+      const field = (input as Record<string, unknown>)?.fieldName;
+      return field
+        ? `Setting Reverse ETL ${field}`
+        : "Setting Reverse ETL field";
+    },
+    icon: "pencil",
+  },
+  set_reverse_etl_multiple_fields: {
+    domain: "flow",
+    execution: "client",
+    clientExecutor: "flow",
+    getLabel: input => {
+      const fields = (input as Record<string, unknown>)?.fields;
+      const count =
+        fields && typeof fields === "object" ? Object.keys(fields).length : 0;
+      return count > 0
+        ? `Setting ${count} Reverse ETL fields`
+        : "Setting Reverse ETL fields";
+    },
+    icon: "pencil",
+  },
+  create_reverse_etl_tab: {
+    domain: "flow",
+    execution: "client",
+    clientExecutor: "flow",
+    getLabel: () => "Creating Reverse ETL tab",
+    icon: "plus",
+  },
+  list_reverse_etl_tabs: {
+    domain: "flow",
+    execution: "client",
+    clientExecutor: "flow",
+    getLabel: () => "Listing Reverse ETL tabs",
+    icon: "list",
+  },
   list_databases: {
     domain: "flow",
     execution: "server",

--- a/app/src/agent-runtime/request-context.ts
+++ b/app/src/agent-runtime/request-context.ts
@@ -4,7 +4,12 @@ import type { ActiveExplorer } from "../store/uiStore";
 import { getDashboardStateSnapshot } from "../dashboard-runtime/commands";
 import { useDashboardStore } from "../store/dashboardStore";
 
-export type ChatActiveView = "console" | "dashboard" | "flow-editor" | "empty";
+export type ChatActiveView =
+  | "console"
+  | "dashboard"
+  | "flow-editor"
+  | "reverse-flow-editor"
+  | "empty";
 
 export interface ActiveConsoleResultsContext {
   viewMode: "table" | "json" | "chart";
@@ -35,6 +40,7 @@ interface BuildChatRequestBodyOptions {
   activeConsoleId?: string | null;
   activeConsoleResults?: ActiveConsoleResultsContext;
   flowFormState?: Record<string, unknown>;
+  reverseFlowFormState?: Record<string, unknown>;
   workspaceConnections: Connection[];
   pinnedDashboardId?: string | null;
 }
@@ -77,6 +83,10 @@ function buildOpenTabs(tabs: ConsoleTab[], activeTabId?: string | null) {
     flowId:
       tab.kind === "flow-editor"
         ? (tab.metadata?.flowId as string | undefined)
+        : undefined,
+    reverseFlowId:
+      tab.kind === "reverse-flow-editor"
+        ? (tab.metadata?.reverseFlowId as string | undefined)
         : undefined,
     connectionId:
       tab.kind === "console" || !tab.kind ? tab.connectionId : undefined,
@@ -185,6 +195,7 @@ export function buildChatRequestBody({
   activeConsoleId,
   activeConsoleResults,
   flowFormState,
+  reverseFlowFormState,
   workspaceConnections,
   pinnedDashboardId,
 }: BuildChatRequestBodyOptions) {
@@ -203,6 +214,7 @@ export function buildChatRequestBody({
     tabKind: activeTab?.kind,
     flowType: activeTab?.metadata?.flowType,
     flowFormState,
+    reverseFlowFormState,
     ...buildDashboardRequestContext({
       activeView,
       pinnedDashboardId,

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -76,6 +76,7 @@ import type {
 } from "../hooks/useMonacoConsole";
 import { trackEvent } from "../lib/analytics";
 import { DbFlowFormRef } from "./DbFlowForm";
+import type { ReverseFlowFormRef } from "./ReverseFlowEditor";
 import { safeStringify, toJsonSafe } from "../lib/json-safe";
 import { StreamingToolCard, type ToolPartState } from "./StreamingToolCard";
 import {
@@ -1615,6 +1616,7 @@ ChatInputArea.displayName = "ChatInputArea";
 interface ChatProps {
   onConsoleModification?: (modification: ConsoleModificationPayload) => void;
   dbFlowFormRef?: React.RefObject<DbFlowFormRef | null>;
+  reverseFlowFormRef?: React.RefObject<ReverseFlowFormRef | null>;
   onChartSpecChangeRef?: React.MutableRefObject<
     ((payload: import("./Editor").ChartSpecChangePayload) => void) | undefined
   >;
@@ -1623,10 +1625,18 @@ interface ChatProps {
   >;
 }
 
-type ChatActiveView = "dashboard" | "flow-editor" | "console" | "empty";
+type ChatActiveView =
+  | "dashboard"
+  | "flow-editor"
+  | "reverse-flow-editor"
+  | "console"
+  | "empty";
 
 function normalizeChatActiveView(kind: ConsoleTab["kind"]): ChatActiveView {
-  return kind === "dashboard" || kind === "flow-editor" || kind === "console"
+  return kind === "dashboard" ||
+    kind === "flow-editor" ||
+    kind === "reverse-flow-editor" ||
+    kind === "console"
     ? kind
     : "empty";
 }
@@ -1634,6 +1644,7 @@ function normalizeChatActiveView(kind: ConsoleTab["kind"]): ChatActiveView {
 const Chat: React.FC<ChatProps> = ({
   onConsoleModification,
   dbFlowFormRef,
+  reverseFlowFormRef,
   onChartSpecChangeRef,
   resultsContextRef,
 }) => {
@@ -1644,6 +1655,8 @@ const Chat: React.FC<ChatProps> = ({
   // Ref for dbFlowFormRef to avoid stale closure in onToolCall
   const dbFlowFormRefCurrent = useRef(dbFlowFormRef);
   dbFlowFormRefCurrent.current = dbFlowFormRef;
+  const reverseFlowFormRefCurrent = useRef(reverseFlowFormRef);
+  reverseFlowFormRefCurrent.current = reverseFlowFormRef;
 
   // Connection metadata is only needed to decorate completed console tool cards.
   const connections = useSchemaStore(s => s.connections);
@@ -1800,9 +1813,16 @@ const Chat: React.FC<ChatProps> = ({
             ? useSchemaStore.getState().connections[workspaceId] || []
             : [];
 
-          const flowFormState = dbFlowFormRefCurrent.current?.current
-            ? dbFlowFormRefCurrent.current.current.getFormState()
-            : undefined;
+          const flowFormState =
+            activeTab?.kind === "flow-editor" &&
+            dbFlowFormRefCurrent.current?.current
+              ? dbFlowFormRefCurrent.current.current.getFormState()
+              : undefined;
+          const reverseFlowFormState =
+            activeTab?.kind === "reverse-flow-editor" &&
+            reverseFlowFormRefCurrent.current?.current
+              ? reverseFlowFormRefCurrent.current.current.getFormState()
+              : undefined;
 
           // Read results context from Editor at request time
           const resultsCtx = resultsContextRef?.current ?? null;
@@ -1833,6 +1853,7 @@ const Chat: React.FC<ChatProps> = ({
             activeConsoleId: activeConsoleIdRef.current,
             activeConsoleResults,
             flowFormState,
+            reverseFlowFormState,
             workspaceConnections: workspaceConnectionsForRequest,
             pinnedDashboardId: capturedDashboardIdRef.current,
           });
@@ -2062,6 +2083,113 @@ const Chat: React.FC<ChatProps> = ({
 
         // NOTE: set_column_mappings has been removed
         // Use set_form_field with fieldName="typeCoercions" instead
+
+        if (toolName === "get_reverse_etl_form_state") {
+          const formRef = reverseFlowFormRefCurrent.current?.current;
+          addToolOutput({
+            tool: "get_reverse_etl_form_state",
+            toolCallId: toolCall.toolCallId,
+            output: formRef
+              ? { success: true, formState: formRef.getFormState() }
+              : {
+                  success: false,
+                  error:
+                    "Reverse ETL form is not available. Open a ReverseFlow editor.",
+                },
+          });
+          return;
+        }
+
+        if (toolName === "set_reverse_etl_form_field") {
+          const formRef = reverseFlowFormRefCurrent.current?.current;
+          const { fieldName, value } = input as {
+            fieldName: string;
+            value: unknown;
+          };
+          if (!formRef) {
+            addToolOutput({
+              tool: "set_reverse_etl_form_field",
+              toolCallId: toolCall.toolCallId,
+              output: {
+                success: false,
+                error:
+                  "Reverse ETL form is not available. Open a ReverseFlow editor.",
+              },
+            });
+            return;
+          }
+          formRef.setField(fieldName, value);
+          addToolOutput({
+            tool: "set_reverse_etl_form_field",
+            toolCallId: toolCall.toolCallId,
+            output: { success: true, fieldName, value },
+          });
+          return;
+        }
+
+        if (toolName === "set_reverse_etl_multiple_fields") {
+          const formRef = reverseFlowFormRefCurrent.current?.current;
+          const { fields } = input as { fields: Record<string, unknown> };
+          if (!formRef) {
+            addToolOutput({
+              tool: "set_reverse_etl_multiple_fields",
+              toolCallId: toolCall.toolCallId,
+              output: {
+                success: false,
+                error:
+                  "Reverse ETL form is not available. Open a ReverseFlow editor.",
+              },
+            });
+            return;
+          }
+          formRef.setMultipleFields(fields);
+          addToolOutput({
+            tool: "set_reverse_etl_multiple_fields",
+            toolCallId: toolCall.toolCallId,
+            output: { success: true, fields: Object.keys(fields) },
+          });
+          return;
+        }
+
+        if (toolName === "create_reverse_etl_tab") {
+          const currentStore = useConsoleStore.getState();
+          const title = (input.title as string) || "New Reverse ETL";
+          const newTabId = generateObjectId();
+          currentStore.openTab({
+            id: newTabId,
+            title,
+            content: "",
+            kind: "reverse-flow-editor",
+            metadata: { isNew: true },
+          });
+          currentStore.setActiveTab(newTabId);
+          addToolOutput({
+            tool: "create_reverse_etl_tab",
+            toolCallId: toolCall.toolCallId,
+            output: { success: true, tabId: newTabId, title },
+          });
+          return;
+        }
+
+        if (toolName === "list_reverse_etl_tabs") {
+          const currentStore = useConsoleStore.getState();
+          const currentTabs = Object.values(currentStore.tabs);
+          const reverseFlowTabs = currentTabs
+            .filter((tab: any) => tab?.kind === "reverse-flow-editor")
+            .map((tab: any) => ({
+              id: tab.id,
+              title: tab.title || "Untitled Reverse ETL",
+              reverseFlowId: tab.metadata?.reverseFlowId,
+              isNew: tab.metadata?.isNew || false,
+              isActive: tab.id === currentStore.activeTabId,
+            }));
+          addToolOutput({
+            tool: "list_reverse_etl_tabs",
+            toolCallId: toolCall.toolCallId,
+            output: { success: true, reverseFlowTabs },
+          });
+          return;
+        }
 
         // create_flow_tab - Create a new db-scheduled flow tab
         if (toolName === "create_flow_tab") {

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -53,6 +53,10 @@ import Settings from "../pages/Settings";
 import ConnectorTab from "./ConnectorTab";
 import { WorkspaceMembers } from "./WorkspaceMembers";
 import { FlowEditor } from "./FlowEditor";
+import {
+  ReverseFlowEditor,
+  type ReverseFlowFormRef,
+} from "./ReverseFlowEditor";
 import DashboardCanvas from "./DashboardCanvas";
 import ScheduleConsoleModal from "./ScheduleConsoleModal";
 import ScheduledRunsPanel from "./ScheduledRunsPanel";
@@ -145,6 +149,7 @@ export interface ConsoleResultsContext {
 
 interface EditorProps {
   dbFlowFormRef?: React.RefObject<DbFlowFormRef | null>;
+  reverseFlowFormRef?: React.RefObject<ReverseFlowFormRef | null>;
   onChartSpecChangeRef?: React.MutableRefObject<
     ((payload: ChartSpecChangePayload) => void) | undefined
   >;
@@ -269,6 +274,7 @@ function SortableConsoleTab(props: React.ComponentProps<typeof Tab>) {
 
 function Editor({
   dbFlowFormRef,
+  reverseFlowFormRef,
   onChartSpecChangeRef,
   resultsContextRef,
 }: EditorProps = {}) {
@@ -1938,6 +1944,8 @@ function Editor({
                               ) : (
                                 <ScheduleIcon size={18} strokeWidth={1.5} />
                               )
+                            ) : tab.kind === "reverse-flow-editor" ? (
+                              <DataSourceIcon size={18} strokeWidth={1.5} />
                             ) : tab.kind === "dashboard" ? (
                               <DashboardIcon size={18} strokeWidth={1.5} />
                             ) : connectionIconUrl ? (
@@ -2109,6 +2117,21 @@ function Editor({
                       closeConsole(tab.id);
                     }}
                     dbFlowFormRef={dbFlowFormRef}
+                  />
+                ) : tab.kind === "reverse-flow-editor" ? (
+                  <ReverseFlowEditor
+                    ref={
+                      reverseFlowFormRef as
+                        | React.Ref<ReverseFlowFormRef>
+                        | undefined
+                    }
+                    reverseFlowId={
+                      tab.metadata?.reverseFlowId as string | undefined
+                    }
+                    isNew={tab.metadata?.isNew as boolean | undefined}
+                    onCancel={() => {
+                      closeConsole(tab.id);
+                    }}
                   />
                 ) : tab.kind === "dashboard" ? (
                   <DashboardCanvas

--- a/app/src/components/FlowsExplorer.tsx
+++ b/app/src/components/FlowsExplorer.tsx
@@ -113,8 +113,25 @@ export function FlowsExplorer() {
   };
 
   const handleCreateNew = (
-    flowType: "scheduled" | "webhook" | "db-scheduled" | "scheduled-query",
+    flowType:
+      | "scheduled"
+      | "webhook"
+      | "db-scheduled"
+      | "scheduled-query"
+      | "reverse-etl",
   ) => {
+    if (flowType === "reverse-etl") {
+      const id = openTab({
+        title: "New Reverse ETL",
+        content: "",
+        kind: "reverse-flow-editor",
+        metadata: { isNew: true },
+      });
+      setActiveTab(id);
+      setAnchorEl(null);
+      return;
+    }
+
     if (flowType === "scheduled-query") {
       const id = openTab({
         title: "New Scheduled Query",
@@ -389,6 +406,9 @@ export function FlowsExplorer() {
       >
         <MenuItem onClick={() => handleCreateNew("db-scheduled")}>
           Database Sync
+        </MenuItem>
+        <MenuItem onClick={() => handleCreateNew("reverse-etl")}>
+          Reverse ETL
         </MenuItem>
         <MenuItem onClick={() => handleCreateNew("scheduled")}>
           Connector Sync

--- a/app/src/components/ReverseFlowEditor.tsx
+++ b/app/src/components/ReverseFlowEditor.tsx
@@ -1,0 +1,530 @@
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useState,
+} from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Divider,
+  MenuItem,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { useWorkspace } from "../contexts/workspace-context";
+import {
+  DEFAULT_REVERSE_FLOW_SPEC,
+  ReverseFlowDryRunResult,
+  ReverseFlowMapping,
+  ReverseFlowSpec,
+  useReverseFlowStore,
+} from "../store/reverseFlowStore";
+
+export interface ReverseFlowFormRef {
+  getFormState: () => Record<string, unknown>;
+  setField: (path: string, value: unknown) => void;
+  setMultipleFields: (fields: Record<string, unknown>) => void;
+}
+
+interface ReverseFlowEditorProps {
+  reverseFlowId?: string;
+  isNew?: boolean;
+  onCancel?: () => void;
+}
+
+function cloneSpec(spec: ReverseFlowSpec): ReverseFlowSpec {
+  return JSON.parse(JSON.stringify(spec)) as ReverseFlowSpec;
+}
+
+function setPath(
+  target: Record<string, unknown>,
+  path: string,
+  value: unknown,
+) {
+  const parts = path.split(".");
+  let cursor: Record<string, unknown> = target;
+  for (let index = 0; index < parts.length - 1; index++) {
+    const part = parts[index];
+    if (!cursor[part] || typeof cursor[part] !== "object") {
+      cursor[part] = {};
+    }
+    cursor = cursor[part] as Record<string, unknown>;
+  }
+  cursor[parts[parts.length - 1]] = value;
+}
+
+function MappingTable({
+  mappings,
+  onChange,
+}: {
+  mappings: ReverseFlowMapping[];
+  onChange: (mappings: ReverseFlowMapping[]) => void;
+}) {
+  const update = (index: number, patch: Partial<ReverseFlowMapping>) => {
+    onChange(
+      mappings.map((mapping, idx) =>
+        idx === index ? { ...mapping, ...patch } : mapping,
+      ),
+    );
+  };
+
+  return (
+    <Stack spacing={1}>
+      <Stack direction="row" justifyContent="space-between" alignItems="center">
+        <Typography variant="h6">Mappings</Typography>
+        <Button
+          size="small"
+          onClick={() =>
+            onChange([
+              ...mappings,
+              {
+                target: "",
+                source: { column: "" },
+                required: false,
+                onConflict: "fill_empty",
+              },
+            ])
+          }
+        >
+          Add mapping
+        </Button>
+      </Stack>
+      {mappings.map((mapping, index) => (
+        <Paper key={index} variant="outlined" sx={{ p: 1.5 }}>
+          <Stack direction={{ xs: "column", md: "row" }} spacing={1}>
+            <TextField
+              label="Source column"
+              size="small"
+              value={mapping.source.column || ""}
+              onChange={event =>
+                update(index, {
+                  source: { ...mapping.source, column: event.target.value },
+                })
+              }
+              fullWidth
+            />
+            <TextField
+              label="Target field"
+              size="small"
+              value={mapping.target}
+              onChange={event => update(index, { target: event.target.value })}
+              fullWidth
+            />
+            <TextField
+              select
+              label="Conflict"
+              size="small"
+              value={mapping.onConflict || "fill_empty"}
+              onChange={event =>
+                update(index, {
+                  onConflict: event.target
+                    .value as ReverseFlowMapping["onConflict"],
+                })
+              }
+              sx={{ minWidth: 140 }}
+            >
+              <MenuItem value="overwrite">Overwrite</MenuItem>
+              <MenuItem value="fill_empty">Fill empty</MenuItem>
+              <MenuItem value="ignore">Ignore</MenuItem>
+            </TextField>
+            <TransformEditorPopover
+              mapping={mapping}
+              onChange={next => update(index, next)}
+            />
+            <Button
+              color="error"
+              onClick={() =>
+                onChange(mappings.filter((_, idx) => idx !== index))
+              }
+            >
+              Remove
+            </Button>
+          </Stack>
+        </Paper>
+      ))}
+    </Stack>
+  );
+}
+
+function TransformEditorPopover({
+  mapping,
+  onChange,
+}: {
+  mapping: ReverseFlowMapping;
+  onChange: (patch: Partial<ReverseFlowMapping>) => void;
+}) {
+  const [raw, setRaw] = useState(
+    JSON.stringify(mapping.source.transform || {}, null, 2),
+  );
+
+  return (
+    <TextField
+      label="Transform JSON"
+      size="small"
+      value={raw}
+      onChange={event => {
+        setRaw(event.target.value);
+        try {
+          const transform = JSON.parse(event.target.value);
+          onChange({ source: { ...mapping.source, transform } });
+        } catch {
+          // Keep invalid JSON local until the user finishes editing.
+        }
+      }}
+      multiline
+      minRows={1}
+      sx={{ minWidth: 180 }}
+    />
+  );
+}
+
+function DryRunPreview({ dryRun }: { dryRun?: ReverseFlowDryRunResult }) {
+  if (!dryRun) return null;
+  return (
+    <Paper variant="outlined" sx={{ p: 2 }}>
+      <Stack spacing={1}>
+        <Typography variant="h6">Dry run preview</Typography>
+        <Stack direction="row" spacing={1}>
+          <Chip label={`${dryRun.summary.accepted} OK`} color="success" />
+          <Chip label={`${dryRun.summary.rejected} rejected`} color="error" />
+          <Chip
+            label={`${dryRun.summary.ambiguous} ambiguous`}
+            color="warning"
+          />
+          <Chip
+            label={dryRun.summary.passed ? "passed" : "blocked"}
+            color={dryRun.summary.passed ? "success" : "warning"}
+          />
+        </Stack>
+        {dryRun.rows.slice(0, 10).map((row, index) => (
+          <Box key={index} sx={{ fontFamily: "monospace", fontSize: 12 }}>
+            <strong>{row.outcome.status}</strong> {JSON.stringify(row.payload)}
+            {row.fieldDiffs?.length ? (
+              <Box sx={{ mt: 0.5 }}>
+                {row.fieldDiffs.map(diff => (
+                  <div key={diff.field}>
+                    {diff.field}: {JSON.stringify(diff.before)} -&gt;{" "}
+                    {JSON.stringify(diff.after)}
+                    {diff.willOverwrite ? " (will overwrite)" : ""}
+                  </div>
+                ))}
+              </Box>
+            ) : null}
+          </Box>
+        ))}
+      </Stack>
+    </Paper>
+  );
+}
+
+function RunHistory() {
+  const runs = useReverseFlowStore(state => state.runs);
+  return (
+    <Paper variant="outlined" sx={{ p: 2 }}>
+      <Typography variant="h6" sx={{ mb: 1 }}>
+        Run history
+      </Typography>
+      <Stack spacing={1}>
+        {runs.map(run => (
+          <Box key={run._id}>
+            <Typography variant="body2">
+              {run.status} • read {run.rowsRead} • created {run.rowsCreated} •
+              updated {run.rowsUpdated} • failed {run.rowsFailed}
+            </Typography>
+            {run.rowOutcomes.slice(0, 5).map(outcome => (
+              <Typography
+                key={`${run._id}-${outcome.sourcePk}`}
+                variant="caption"
+                display="block"
+              >
+                {outcome.sourcePk}: {outcome.status}
+                {outcome.error ? ` (${outcome.error})` : ""}
+              </Typography>
+            ))}
+          </Box>
+        ))}
+      </Stack>
+    </Paper>
+  );
+}
+
+export const ReverseFlowEditor = forwardRef<
+  ReverseFlowFormRef,
+  ReverseFlowEditorProps
+>(function ReverseFlowEditor({ reverseFlowId, isNew, onCancel }, ref) {
+  const { currentWorkspace } = useWorkspace();
+  const workspaceId = currentWorkspace?.id;
+  const fetchFlow = useReverseFlowStore(state => state.fetchFlow);
+  const fetchRuns = useReverseFlowStore(state => state.fetchRuns);
+  const createFlow = useReverseFlowStore(state => state.createFlow);
+  const updateFlow = useReverseFlowStore(state => state.updateFlow);
+  const dryRunFlow = useReverseFlowStore(state => state.dryRunFlow);
+  const activateFlow = useReverseFlowStore(state => state.activateFlow);
+  const runFlow = useReverseFlowStore(state => state.runFlow);
+  const dryRunResult = useReverseFlowStore(state => state.dryRun);
+  const storeError = useReverseFlowStore(state => state.error);
+  const lastDryRunPassed = useReverseFlowStore(
+    state => state.activeFlow?.lastDryRun?.passed,
+  );
+  const [name, setName] = useState("Untitled Reverse ETL");
+  const [flowId, setFlowId] = useState(reverseFlowId);
+  const [spec, setSpec] = useState<ReverseFlowSpec>(() =>
+    cloneSpec(DEFAULT_REVERSE_FLOW_SPEC),
+  );
+  const [message, setMessage] = useState<string>();
+
+  useEffect(() => {
+    if (!workspaceId || !reverseFlowId || isNew) return;
+    void fetchFlow(workspaceId, reverseFlowId).then(flow => {
+      setName(flow.name);
+      setSpec(cloneSpec(flow.spec));
+      setFlowId(flow.id);
+      void fetchRuns(workspaceId, flow.id);
+    });
+  }, [workspaceId, reverseFlowId, isNew, fetchFlow, fetchRuns]);
+
+  const patchSpec = useCallback((path: string, value: unknown) => {
+    setSpec(current => {
+      const next = cloneSpec(current);
+      setPath(next as unknown as Record<string, unknown>, path, value);
+      return next;
+    });
+  }, []);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      getFormState: () => ({ name, spec, flowId }),
+      setField: (path, value) => {
+        if (path === "name") setName(String(value));
+        else patchSpec(path, value);
+      },
+      setMultipleFields: fields => {
+        for (const [path, value] of Object.entries(fields)) {
+          if (path === "name") setName(String(value));
+          else patchSpec(path, value);
+        }
+      },
+    }),
+    [flowId, name, patchSpec, spec],
+  );
+
+  const canActivate = useMemo(
+    () => !spec.safety.dryRunRequiredBeforeActivate || lastDryRunPassed,
+    [lastDryRunPassed, spec.safety.dryRunRequiredBeforeActivate],
+  );
+
+  const save = async () => {
+    if (!workspaceId) return;
+    const saved = flowId
+      ? await updateFlow(workspaceId, flowId, { name, spec })
+      : await createFlow(workspaceId, { name, spec });
+    setFlowId(saved.id);
+    setMessage("Saved reverse flow");
+  };
+
+  const dryRun = async () => {
+    if (!workspaceId) return;
+    const savedId =
+      flowId || (await createFlow(workspaceId, { name, spec })).id;
+    setFlowId(savedId);
+    await dryRunFlow(workspaceId, savedId, { spec, sampleSize: 25 });
+    setMessage("Dry run completed");
+  };
+
+  return (
+    <Box sx={{ height: "100%", overflow: "auto", p: 3 }}>
+      <Stack spacing={2}>
+        <Stack
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
+        >
+          <Box>
+            <Typography variant="h5">Reverse ETL</Typography>
+            <Typography variant="body2" color="text.secondary">
+              Writes mapped source rows to production CRM records with per-row
+              audit.
+            </Typography>
+          </Box>
+          <Stack direction="row" spacing={1}>
+            <Button onClick={onCancel}>Cancel</Button>
+            <Button variant="outlined" onClick={save}>
+              Save
+            </Button>
+            <Button variant="outlined" onClick={dryRun}>
+              Dry run
+            </Button>
+            <Button
+              variant="contained"
+              color="warning"
+              disabled={!workspaceId || !flowId || !canActivate}
+              onClick={async () => {
+                if (!workspaceId || !flowId) return;
+                await activateFlow(workspaceId, flowId);
+                setMessage("Activated; writes to production Close on run");
+              }}
+            >
+              Activate
+            </Button>
+            <Button
+              variant="contained"
+              disabled={!workspaceId || !flowId}
+              onClick={async () => {
+                if (!workspaceId || !flowId) return;
+                await runFlow(workspaceId, flowId);
+                setMessage("Run queued");
+              }}
+            >
+              Run
+            </Button>
+          </Stack>
+        </Stack>
+
+        <Alert severity="warning">
+          Activating this flow writes to PRODUCTION destination systems.
+        </Alert>
+        {message ? <Alert severity="success">{message}</Alert> : null}
+        {storeError ? <Alert severity="error">{storeError}</Alert> : null}
+
+        <Paper variant="outlined" sx={{ p: 2 }}>
+          <Stack spacing={2}>
+            <TextField
+              label="Name"
+              value={name}
+              onChange={e => setName(e.target.value)}
+            />
+            <TextField
+              label="Source connection ID"
+              value={spec.source.connectionId}
+              onChange={e => patchSpec("source.connectionId", e.target.value)}
+            />
+            <TextField
+              label="Source database"
+              value={spec.source.database || ""}
+              onChange={e => patchSpec("source.database", e.target.value)}
+            />
+            <TextField
+              label="SQL query"
+              value={spec.source.query}
+              onChange={e => patchSpec("source.query", e.target.value)}
+              multiline
+              minRows={5}
+            />
+            <TextField
+              label="Primary key column"
+              value={spec.source.primaryKey}
+              onChange={e => patchSpec("source.primaryKey", e.target.value)}
+            />
+          </Stack>
+        </Paper>
+
+        <Paper variant="outlined" sx={{ p: 2 }}>
+          <Stack spacing={2}>
+            <Typography variant="h6">Destination</Typography>
+            <TextField
+              label="Connector ID"
+              value={spec.destination.connectorId}
+              onChange={e =>
+                patchSpec("destination.connectorId", e.target.value)
+              }
+            />
+            <TextField
+              label="Entity"
+              value={spec.destination.entity}
+              onChange={e => patchSpec("destination.entity", e.target.value)}
+            />
+            <Stack direction={{ xs: "column", md: "row" }} spacing={1}>
+              <TextField
+                select
+                label="Write mode"
+                value={spec.destination.writeMode}
+                onChange={e =>
+                  patchSpec("destination.writeMode", e.target.value)
+                }
+                fullWidth
+              >
+                <MenuItem value="create">Create</MenuItem>
+                <MenuItem value="update">Update</MenuItem>
+                <MenuItem value="upsert">Upsert</MenuItem>
+              </TextField>
+              <TextField
+                select
+                label="Update strategy"
+                value={spec.destination.updateFieldStrategy}
+                onChange={e =>
+                  patchSpec("destination.updateFieldStrategy", e.target.value)
+                }
+                fullWidth
+              >
+                <MenuItem value="overwrite">Overwrite</MenuItem>
+                <MenuItem value="fill_empty">Fill empty</MenuItem>
+                <MenuItem value="ignore">Ignore</MenuItem>
+              </TextField>
+            </Stack>
+            <Stack direction={{ xs: "column", md: "row" }} spacing={1}>
+              <TextField
+                label="Lookup column"
+                value={spec.destination.match.lookupColumn}
+                onChange={e =>
+                  patchSpec("destination.match.lookupColumn", e.target.value)
+                }
+                fullWidth
+              />
+              <TextField
+                label="Remote field"
+                value={spec.destination.match.remoteField}
+                onChange={e =>
+                  patchSpec("destination.match.remoteField", e.target.value)
+                }
+                fullWidth
+              />
+            </Stack>
+          </Stack>
+        </Paper>
+
+        <MappingTable
+          mappings={spec.mappings}
+          onChange={mappings => patchSpec("mappings", mappings)}
+        />
+
+        <Paper variant="outlined" sx={{ p: 2 }}>
+          <Stack direction={{ xs: "column", md: "row" }} spacing={1}>
+            <TextField
+              label="Cron"
+              value={spec.schedule.cron || ""}
+              onChange={e => patchSpec("schedule.cron", e.target.value)}
+              fullWidth
+            />
+            <TextField
+              label="Timezone"
+              value={spec.schedule.timezone}
+              onChange={e => patchSpec("schedule.timezone", e.target.value)}
+              fullWidth
+            />
+            <TextField
+              label="Batch size"
+              type="number"
+              value={spec.safety.batchSize}
+              onChange={e =>
+                patchSpec("safety.batchSize", Number(e.target.value))
+              }
+              fullWidth
+            />
+          </Stack>
+        </Paper>
+
+        <DryRunPreview dryRun={dryRunResult} />
+        <Divider />
+        <RunHistory />
+      </Stack>
+    </Box>
+  );
+});

--- a/app/src/lib/api-types.ts
+++ b/app/src/lib/api-types.ts
@@ -135,7 +135,10 @@ export interface ScheduledQueryListResponse {
 
 // ==================== Flow run notifications ====================
 
-export type NotificationResourceTypeApi = "scheduled_query" | "flow";
+export type NotificationResourceTypeApi =
+  | "scheduled_query"
+  | "flow"
+  | "reverse_etl";
 
 export type NotificationTriggerApi = "success" | "failure";
 

--- a/app/src/store/lib/types.ts
+++ b/app/src/store/lib/types.ts
@@ -14,6 +14,7 @@ export type TabKind =
   | "connectors"
   | "members"
   | "flow-editor"
+  | "reverse-flow-editor"
   | "dashboard";
 
 /**

--- a/app/src/store/reverseFlowStore.ts
+++ b/app/src/store/reverseFlowStore.ts
@@ -1,0 +1,273 @@
+import { create } from "zustand";
+import { apiClient } from "../lib/api-client";
+
+export interface ReverseFlowMapping {
+  target: string;
+  source: {
+    column?: string;
+    const?: unknown;
+    transform?: {
+      ops?: string[];
+      template?: string;
+      lookupMap?: Record<string, string>;
+      defaultValue?: unknown;
+    };
+  };
+  required?: boolean;
+  onConflict?: "overwrite" | "fill_empty" | "ignore";
+}
+
+export interface ReverseFlowSpec {
+  source: {
+    connectionId: string;
+    database?: string;
+    query: string;
+    primaryKey: string;
+  };
+  destination: {
+    connectorId: string;
+    entity: string;
+    writeMode: "create" | "update" | "upsert";
+    allowCreate: boolean;
+    updateFieldStrategy: "overwrite" | "fill_empty" | "ignore";
+    match: {
+      lookupColumn: string;
+      remoteField: string;
+      onMultiple: "skip" | "update_first" | "fail";
+    };
+  };
+  mappings: ReverseFlowMapping[];
+  incremental?: {
+    trackingColumn: string;
+    trackingType: "timestamp" | "numeric" | "string";
+    lastValue?: string;
+  };
+  pagination?: {
+    mode: "offset" | "keyset";
+    keysetColumn?: string;
+    keysetDirection?: "asc" | "desc";
+  };
+  schedule: {
+    enabled: boolean;
+    cron?: string;
+    timezone: string;
+  };
+  safety: {
+    maxRowsPerRun: number;
+    dryRunRequiredBeforeActivate: boolean;
+    batchSize: number;
+  };
+}
+
+export interface ReverseFlow {
+  id: string;
+  _id?: string;
+  name: string;
+  status: "draft" | "active" | "paused";
+  spec: ReverseFlowSpec;
+  version: number;
+  lastDryRun?: {
+    at: string;
+    sampleSize: number;
+    accepted: number;
+    rejected: number;
+    ambiguous: number;
+    passed: boolean;
+  };
+  scheduledRun?: {
+    nextAt?: string;
+    lastAt?: string;
+    lastStatus?: "success" | "partial" | "error";
+    lastError?: string;
+    runCount: number;
+    consecutiveFailures: number;
+  };
+}
+
+export interface ReverseFlowRun {
+  _id: string;
+  status: "queued" | "running" | "success" | "partial" | "error";
+  triggerType: "schedule" | "manual";
+  triggeredAt: string;
+  completedAt?: string;
+  rowsRead: number;
+  rowsCreated: number;
+  rowsUpdated: number;
+  rowsSkipped: number;
+  rowsFailed: number;
+  ambiguous: number;
+  rowOutcomes: Array<{
+    sourcePk: string;
+    status: string;
+    remoteId?: string;
+    error?: string;
+  }>;
+}
+
+export interface ReverseFlowDryRunResult {
+  rows: Array<{
+    sourceRow: Record<string, unknown>;
+    payload: Record<string, unknown>;
+    match?: { status: string; remoteId?: string; matchCount?: number };
+    fieldDiffs?: Array<{
+      field: string;
+      before: unknown;
+      after: unknown;
+      willOverwrite: boolean;
+    }>;
+    outcome: { status: string; error?: string; retryable?: boolean };
+  }>;
+  summary: {
+    sampleSize: number;
+    accepted: number;
+    rejected: number;
+    ambiguous: number;
+    passed: boolean;
+  };
+}
+
+export const DEFAULT_REVERSE_FLOW_SPEC: ReverseFlowSpec = {
+  source: { connectionId: "", query: "", primaryKey: "" },
+  destination: {
+    connectorId: "",
+    entity: "leads",
+    writeMode: "upsert",
+    allowCreate: true,
+    updateFieldStrategy: "fill_empty",
+    match: { lookupColumn: "email", remoteField: "email", onMultiple: "skip" },
+  },
+  mappings: [],
+  schedule: { enabled: false, timezone: "UTC" },
+  safety: {
+    maxRowsPerRun: 5000,
+    dryRunRequiredBeforeActivate: true,
+    batchSize: 200,
+  },
+};
+
+interface ApiResponse<T> {
+  success: boolean;
+  data: T;
+  error?: string;
+}
+
+interface ReverseFlowStore {
+  flows: ReverseFlow[];
+  activeFlow?: ReverseFlow;
+  runs: ReverseFlowRun[];
+  dryRun?: ReverseFlowDryRunResult;
+  loading: boolean;
+  error?: string;
+  fetchFlows: (workspaceId: string) => Promise<void>;
+  fetchFlow: (workspaceId: string, id: string) => Promise<ReverseFlow>;
+  createFlow: (
+    workspaceId: string,
+    input: { name: string; spec: ReverseFlowSpec },
+  ) => Promise<ReverseFlow>;
+  updateFlow: (
+    workspaceId: string,
+    id: string,
+    input: { name: string; spec: ReverseFlowSpec; reason?: string },
+  ) => Promise<ReverseFlow>;
+  dryRunFlow: (
+    workspaceId: string,
+    id: string,
+    input?: { spec?: ReverseFlowSpec; sampleSize?: number },
+  ) => Promise<ReverseFlowDryRunResult>;
+  activateFlow: (workspaceId: string, id: string) => Promise<ReverseFlow>;
+  pauseFlow: (workspaceId: string, id: string) => Promise<ReverseFlow>;
+  runFlow: (workspaceId: string, id: string) => Promise<void>;
+  fetchRuns: (workspaceId: string, id: string) => Promise<ReverseFlowRun[]>;
+}
+
+function path(workspaceId: string, suffix = "") {
+  return `/workspaces/${workspaceId}/reverse-flows${suffix}`;
+}
+
+export const useReverseFlowStore = create<ReverseFlowStore>((set, get) => ({
+  flows: [],
+  runs: [],
+  loading: false,
+
+  async fetchFlows(workspaceId) {
+    set({ loading: true, error: undefined });
+    try {
+      const res = await apiClient.get<ApiResponse<ReverseFlow[]>>(
+        path(workspaceId),
+      );
+      set({ flows: res.data, loading: false });
+    } catch (error) {
+      set({
+        error: error instanceof Error ? error.message : String(error),
+        loading: false,
+      });
+    }
+  },
+
+  async fetchFlow(workspaceId, id) {
+    set({ loading: true, error: undefined });
+    const res = await apiClient.get<ApiResponse<ReverseFlow>>(
+      path(workspaceId, `/${id}`),
+    );
+    set({ activeFlow: res.data, loading: false });
+    return res.data;
+  },
+
+  async createFlow(workspaceId, input) {
+    const res = await apiClient.post<ApiResponse<ReverseFlow>>(
+      path(workspaceId),
+      input,
+    );
+    set({ activeFlow: res.data, flows: [res.data, ...get().flows] });
+    return res.data;
+  },
+
+  async updateFlow(workspaceId, id, input) {
+    const res = await apiClient.put<ApiResponse<ReverseFlow>>(
+      path(workspaceId, `/${id}`),
+      input,
+    );
+    set({
+      activeFlow: res.data,
+      flows: get().flows.map(flow => (flow.id === id ? res.data : flow)),
+    });
+    return res.data;
+  },
+
+  async dryRunFlow(workspaceId, id, input) {
+    const res = await apiClient.post<ApiResponse<ReverseFlowDryRunResult>>(
+      path(workspaceId, `/${id}/dry-run`),
+      input,
+    );
+    set({ dryRun: res.data });
+    return res.data;
+  },
+
+  async activateFlow(workspaceId, id) {
+    const res = await apiClient.post<ApiResponse<ReverseFlow>>(
+      path(workspaceId, `/${id}/activate`),
+    );
+    set({ activeFlow: res.data });
+    return res.data;
+  },
+
+  async pauseFlow(workspaceId, id) {
+    const res = await apiClient.post<ApiResponse<ReverseFlow>>(
+      path(workspaceId, `/${id}/pause`),
+    );
+    set({ activeFlow: res.data });
+    return res.data;
+  },
+
+  async runFlow(workspaceId, id) {
+    await apiClient.post<ApiResponse<void>>(path(workspaceId, `/${id}/run`));
+  },
+
+  async fetchRuns(workspaceId, id) {
+    const res = await apiClient.get<ApiResponse<ReverseFlowRun[]>>(
+      path(workspaceId, `/${id}/runs`),
+    );
+    set({ runs: res.data });
+    return res.data;
+  },
+}));

--- a/packages/agent-tools/src/index.ts
+++ b/packages/agent-tools/src/index.ts
@@ -17,6 +17,7 @@ import { clientConsoleTools } from "./console-tools";
 import { clientChartTools } from "./chart-tools";
 import { clientDashboardTools } from "./dashboard-tools";
 import { clientFlowTools } from "./flow-tools";
+import { clientReverseEtlTools } from "./reverse-etl-tools";
 import { clientScreenshotTools } from "./screenshot-tools";
 
 export { clientConsoleTools } from "./console-tools";
@@ -35,6 +36,7 @@ export type { ModifyChartSpecInput } from "./chart-tools";
 
 export { clientDashboardTools } from "./dashboard-tools";
 export { clientFlowTools } from "./flow-tools";
+export { clientReverseEtlTools } from "./reverse-etl-tools";
 
 export { clientScreenshotTools } from "./screenshot-tools";
 export type { CaptureScreenshotInput } from "./screenshot-tools";
@@ -55,6 +57,7 @@ export const clientAgentTools = {
   ...clientChartTools,
   ...clientDashboardTools,
   ...clientFlowTools,
+  ...clientReverseEtlTools,
 };
 
 /** Map of client tool name -> inferred input/output types. */

--- a/packages/agent-tools/src/reverse-etl-tools.ts
+++ b/packages/agent-tools/src/reverse-etl-tools.ts
@@ -1,0 +1,104 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+export const REVERSE_ETL_FIELD_PATHS = [
+  "name",
+  "source.connectionId",
+  "source.database",
+  "source.query",
+  "source.primaryKey",
+  "destination.connectorId",
+  "destination.entity",
+  "destination.writeMode",
+  "destination.allowCreate",
+  "destination.updateFieldStrategy",
+  "destination.match",
+  "destination.match.lookupColumn",
+  "destination.match.remoteField",
+  "destination.match.onMultiple",
+  "mappings",
+  "incremental",
+  "pagination",
+  "schedule.enabled",
+  "schedule.cron",
+  "schedule.timezone",
+  "safety.maxRowsPerRun",
+  "safety.dryRunRequiredBeforeActivate",
+  "safety.batchSize",
+] as const;
+
+const transformSchema = z.object({
+  ops: z
+    .array(
+      z.enum([
+        "trim",
+        "lowercase",
+        "uppercase",
+        "to_string",
+        "to_number",
+        "to_iso_date",
+      ]),
+    )
+    .optional(),
+  template: z.string().optional(),
+  lookupMap: z.record(z.string(), z.string()).optional(),
+  defaultValue: z.unknown().optional(),
+});
+
+const mappingSchema = z.object({
+  target: z.string(),
+  source: z.object({
+    column: z.string().optional(),
+    const: z.unknown().optional(),
+    transform: transformSchema.optional(),
+  }),
+  required: z.boolean().optional(),
+  onConflict: z.enum(["overwrite", "fill_empty", "ignore"]).optional(),
+});
+
+const formFieldValue = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.null(),
+  z.array(mappingSchema),
+  z.record(z.string(), z.unknown()),
+]);
+
+export const clientReverseEtlTools = {
+  get_reverse_etl_form_state: tool({
+    description:
+      "Get the current Reverse ETL form state, including source query, destination connector, mappings, schedule, and safety settings.",
+    inputSchema: z.object({}),
+  }),
+
+  set_reverse_etl_form_field: tool({
+    description:
+      "Update one Reverse ETL form field by nested path. Use mappings as a real JSON array, not a string.",
+    inputSchema: z.object({
+      fieldName: z.enum(
+        REVERSE_ETL_FIELD_PATHS as unknown as [string, ...string[]],
+      ),
+      value: formFieldValue,
+    }),
+  }),
+
+  set_reverse_etl_multiple_fields: tool({
+    description: "Update multiple Reverse ETL form fields at once.",
+    inputSchema: z.object({
+      fields: z.record(z.string(), formFieldValue),
+    }),
+  }),
+
+  create_reverse_etl_tab: tool({
+    description: "Create a new Reverse ETL editor tab.",
+    inputSchema: z.object({
+      title: z.string().optional(),
+    }),
+  }),
+
+  list_reverse_etl_tabs: tool({
+    description: "List open Reverse ETL editor tabs.",
+    inputSchema: z.object({}),
+  }),
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add isolated ReverseFlow/ReverseFlowRun/OutboundLedger models, migration, routes, dry-run service, source reader, mapper, and Inngest scheduler/executor.
- Add outbound connector capability with Close leads write support, schema inspection, dry-run field diffs, ambiguity handling, and retryable error classification.
- Wire terminal notifications for `reverse_etl`, unified agent tools, client tool definitions, and a dedicated ReverseFlow editor/store/tab path.

## Verification
- `pnpm --filter api exec tsx src/services/reverse-etl/mapping-engine.test.ts`
- `pnpm --filter api exec tsx src/connectors/close/outbound.test.ts`
- `pnpm --filter @mako/agent-tools run build`
- `pnpm --filter api run build`
- `pnpm --filter app run typecheck`
- `pnpm --filter app run lint`
- `pnpm run lint:all`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34f41fa0-f8a1-48a7-b8f5-c4543c0fe8d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34f41fa0-f8a1-48a7-b8f5-c4543c0fe8d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

