### PR TITLE
docs: dashboard collaborators + capture_screenshot tool

### DIFF
--- a/docs/src/content/docs/ai-agent.md
+++ b/docs/src/content/docs/ai-agent.md
@@ -110,6 +110,21 @@ Key capabilities:
 
 The agent handles edit-mode locking, so concurrent users cannot conflict.
 
+## Visual Inspection
+
+The agent can capture screenshots of the live UI for visual QA via the **`capture_screenshot`** client tool. It runs in the browser (no server round-trip) and returns a PNG that the agent inspects directly. Supported targets:
+
+| Target | Captures |
+|--------|----------|
+| `active_dashboard` | The current dashboard — for visual QA of layout and charts |
+| `active_tab` | The current main tab |
+| `app_shell` | The full Mako app UI |
+| `widget` | A specific dashboard widget |
+| `viewport` | The current visible page |
+| `selector` | A specific element matched by a CSS selector |
+
+This lets the agent verify dashboard rendering (chart legibility, overlap, layout reflow) and debug UI issues by actually looking at the result rather than reasoning blind.
+
 ## AI Models
 
 Mako routes all AI requests through the **Vercel AI Gateway**, which provides access to 180+ models across Anthropic, OpenAI, Google, DeepSeek, and others. Only `AI_GATEWAY_API_KEY` is required — no individual provider API keys needed.

--- a/docs/src/content/docs/api-reference.md
+++ b/docs/src/content/docs/api-reference.md
@@ -266,6 +266,9 @@ All endpoints require authentication and workspace access. Agent-side CRUD is av
 | `PUT`    | `/api/workspaces/:wid/dashboards/:did`                           | Update dashboard                     |
 | `DELETE` | `/api/workspaces/:wid/dashboards/:did`                           | Delete dashboard                     |
 | `POST`   | `/api/workspaces/:wid/dashboards/:did/duplicate`                 | Duplicate a dashboard                |
+| `GET`    | `/api/workspaces/:wid/dashboards/:did/collaborators`             | List per-user collaborators                  |
+| `POST`   | `/api/workspaces/:wid/dashboards/:did/collaborators`             | Add a collaborator (`{ userId }`, `editor` role; owner/admin only) |
+| `DELETE` | `/api/workspaces/:wid/dashboards/:did/collaborators/:userId`     | Remove a collaborator (owner/admin only)     |
 
 ### Dashboard Folders
 

--- a/docs/src/content/docs/dashboards.md
+++ b/docs/src/content/docs/dashboards.md
@@ -135,6 +135,16 @@ Dashboards use an edit lock to prevent concurrent editing conflicts:
 
 If another user holds the lock, a confirmation dialog offers to take over.
 
+## Sharing & Collaborators
+
+Beyond the workspace-level `access` setting, dashboards support **per-user collaborators** granted explicit edit access:
+
+- Each collaborator is added with the `editor` role, which allows them to read **and** write the dashboard regardless of the broader access level.
+- Collaborators are managed from the dashboard's **Share** dialog.
+- Only the dashboard **owner** or a workspace **owner/admin** can add or remove collaborators.
+
+Under the hood, collaborators are stored on the dashboard's `sharedWith` array (`{ userId, role: "editor", addedAt, addedBy }`), indexed for fast "shared with me" lookups.
+
 ## Scheduled Refresh
 
 Data sources can be refreshed on a schedule using cron expressions:


### PR DESCRIPTION
Documents two features merged June 5 that had no docs.

## P1 — Dashboard per-user collaborators (#439)
- `dashboards.md`: new **Sharing & Collaborators** section. Per-user `editor` access via `sharedWith` array, managed from the Share dialog, owner/admin-gated.
- `api-reference.md`: 3 new endpoints — `GET/POST/DELETE /dashboards/:did/collaborators`.

## P1 — `capture_screenshot` agent tool
- `ai-agent.md`: new **Visual Inspection** section documenting the client-side screenshot tool and its targets (active_dashboard, active_tab, app_shell, widget, viewport, selector).

Internal-only (no doc impact): agent-tools package extraction, AI SDK `tool()` helper migration, chat prompt-queue UI, abort/persist fixes.

Generated by daily mako-docs-maintenance.