### PR TITLE
feat(agent): prompt compaction — Foundation + Phase 0 + Phase 1 (issue #459)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,6 +96,23 @@ AI_GATEWAY_API_KEY=your_vercel_ai_gateway_key
 # Optional: Embeddings only (text-embedding-3-small via raw OpenAI SDK)
 OPENAI_API_KEY=your-openai-api-key
 
+# Prompt compaction (optional — provider-agnostic, application-level context
+# shrinking applied before the model call. Sensible defaults ship in code; set
+# these only to tune from Langfuse data. The full transcript is always persisted.)
+# COMPACTION_ENABLED=true
+# Clear/mask stale tool results once usage crosses this fraction of the model context window
+# COMPACTION_CLEAR_TRIGGER_FRACTION=0.6
+# Summarize the middle of long sessions past this fraction (Phase 2, ships later)
+# COMPACTION_SUMMARIZE_TRIGGER_FRACTION=0.8
+# Hard ceiling fraction — clear more aggressively above this
+# COMPACTION_HARD_CEILING_FRACTION=0.92
+# Most-recent tool results always kept verbatim
+# COMPACTION_KEEP_RECENT_TOOL_RESULTS=6
+# Minimum chars a clearing pass must reclaim to run (anti-thrash)
+# COMPACTION_MIN_CLEAR_DELTA_CHARS=4000
+# Tool results smaller than this (chars) are left alone when stale
+# COMPACTION_MIN_RESULT_CLEAR_CHARS=1000
+
 # Langfuse LLM observability (optional — tracing is a no-op when keys are unset)
 # Keys: Langfuse UI > Settings > API Keys. Region base URLs:
 #   EU: https://cloud.langfuse.com  US: https://us.cloud.langfuse.com

--- a/api/src/agent-lib/ai-models.ts
+++ b/api/src/agent-lib/ai-models.ts
@@ -28,6 +28,12 @@ export interface AIModel {
   supportsThinking?: boolean;
   thinkingMode?: AnthropicThinkingMode;
   thinkingBudgetTokens?: number;
+  /**
+   * Maximum context window in tokens, sourced from the gateway catalog. Used by
+   * prompt compaction to derive per-model budgets. Null when the gateway did
+   * not report a window for the model.
+   */
+  contextWindow?: number | null;
 }
 
 function catalogToAIModel(cm: CatalogModel): AIModel {
@@ -40,6 +46,7 @@ function catalogToAIModel(cm: CatalogModel): AIModel {
     supportsThinking: cm.supportsThinking,
     thinkingMode: cm.thinkingMode,
     thinkingBudgetTokens: cm.thinkingBudgetTokens,
+    contextWindow: cm.contextWindow,
   };
 }
 

--- a/api/src/agent-lib/compaction/compactor.integration.test.ts
+++ b/api/src/agent-lib/compaction/compactor.integration.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Integration test: real AI SDK `convertToModelMessages` -> compactor pipeline.
+ *
+ * Proves the masking transform produces ModelMessages that still pass the AI
+ * SDK's own `modelMessageSchema` (i.e. remain valid for providers and for
+ * `convertToModelMessages`), with tool-call/result pairing preserved.
+ */
+import assert from "node:assert/strict";
+import {
+  convertToModelMessages,
+  modelMessageSchema,
+  type UIMessage,
+} from "ai";
+import { compactModelMessages, CLEAR_MARKER_PREFIX } from "./compactor";
+import { resolveCompactionBudget, type CompactionConfig } from "./config";
+
+function t(label: string, fn: () => Promise<void> | void) {
+  return Promise.resolve(fn()).then(() => {
+    process.stdout.write(`ok  ${label}\n`);
+  });
+}
+
+const config: CompactionConfig = {
+  enabled: true,
+  clearTriggerFraction: 0.6,
+  summarizeTriggerFraction: 0.8,
+  hardCeilingFraction: 0.92,
+  keepRecentToolResults: 2,
+  minClearDeltaChars: 1000,
+  minResultClearChars: 500,
+};
+const budget = resolveCompactionBudget(1000, config);
+
+function buildUIMessages(pairs: number, blobChars: number): UIMessage[] {
+  const messages: UIMessage[] = [
+    { id: "u1", role: "user", parts: [{ type: "text", text: "run analysis" }] },
+  ];
+  for (let i = 0; i < pairs; i++) {
+    messages.push({
+      id: `a${i}`,
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-sql_execute_query",
+          toolCallId: `call-${i}`,
+          state: "output-available",
+          input: { query: `SELECT ${i}` },
+          output: { rows: "x".repeat(blobChars) },
+        },
+      ],
+    } as unknown as UIMessage);
+  }
+  messages.push({
+    id: "final",
+    role: "assistant",
+    parts: [{ type: "text", text: "done" }],
+  });
+  return messages;
+}
+
+async function run() {
+  await t(
+    "convertToModelMessages -> compact -> still schema-valid + paired",
+    async () => {
+      const ui = buildUIMessages(6, 2000);
+      const modelMessages = await convertToModelMessages(ui);
+
+      const { messages: out, stats } = compactModelMessages(modelMessages, {
+        budget,
+        config,
+        currentTokens: 700,
+      });
+
+      assert.equal(stats.applied, true);
+      assert.ok(stats.clearedCount >= 1, "should clear at least one result");
+      assert.ok(stats.charsAfter < stats.charsBefore);
+
+      // Every resulting message must validate against the AI SDK schema.
+      for (const m of out) {
+        const parsed = modelMessageSchema.safeParse(m);
+        assert.ok(
+          parsed.success,
+          `message not schema-valid: ${JSON.stringify(parsed.success ? {} : parsed.error.issues)}`,
+        );
+      }
+
+      // Pairing invariant: every tool-call has a matching tool-result id.
+      const callIds = new Set<string>();
+      const resultIds = new Set<string>();
+      for (const m of out) {
+        const content = (m as { content?: unknown }).content;
+        if (!Array.isArray(content)) continue;
+        for (const p of content) {
+          const part = p as Record<string, unknown>;
+          if (part.type === "tool-call") {
+            callIds.add(String(part.toolCallId));
+          }
+          if (part.type === "tool-result") {
+            resultIds.add(String(part.toolCallId));
+          }
+        }
+      }
+      assert.equal(callIds.size, resultIds.size);
+      for (const id of callIds) {
+        assert.ok(resultIds.has(id), `missing result for ${id}`);
+      }
+
+      // At least one masked placeholder is present.
+      const hasPlaceholder = out.some(m => {
+        const content = (m as { content?: unknown }).content;
+        if (!Array.isArray(content)) return false;
+        return content.some(p => {
+          const part = p as Record<string, unknown>;
+          const output = part.output as { type?: string; value?: unknown };
+          return (
+            part.type === "tool-result" &&
+            output?.type === "text" &&
+            typeof output.value === "string" &&
+            output.value.startsWith(CLEAR_MARKER_PREFIX)
+          );
+        });
+      });
+      assert.ok(hasPlaceholder, "expected at least one cleared placeholder");
+    },
+  );
+}
+
+run().catch((err: unknown) => {
+  const e = err as { stack?: string };
+  process.stderr.write(String(e?.stack ?? err) + "\n");
+  process.exitCode = 1;
+});

--- a/api/src/agent-lib/compaction/compactor.test.ts
+++ b/api/src/agent-lib/compaction/compactor.test.ts
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+import type { ModelMessage } from "ai";
+import {
+  compactModelMessages,
+  CLEAR_MARKER_PREFIX,
+} from "./compactor";
+import { resolveCompactionBudget, type CompactionConfig } from "./config";
+
+function t(label: string, fn: () => void) {
+  fn();
+  process.stdout.write(`ok  ${label}\n`);
+}
+
+const config: CompactionConfig = {
+  enabled: true,
+  clearTriggerFraction: 0.6,
+  summarizeTriggerFraction: 0.8,
+  hardCeilingFraction: 0.92,
+  keepRecentToolResults: 6,
+  minClearDeltaChars: 4000,
+  minResultClearChars: 1000,
+};
+
+// contextWindow 1000 -> clearTrigger 600, summarize 800, hardCeiling 920
+const budget = resolveCompactionBudget(1000, config);
+
+function bigValue(chars: number) {
+  return { blob: "x".repeat(chars) };
+}
+
+function buildPairs(n: number, chars: number): ModelMessage[] {
+  const msgs: ModelMessage[] = [{ role: "user", content: "start the task" }];
+  for (let i = 0; i < n; i++) {
+    msgs.push({
+      role: "assistant",
+      content: [
+        {
+          type: "tool-call",
+          toolCallId: `call-${i}`,
+          toolName: "sql_execute_query",
+          input: { i },
+        },
+      ],
+    } as unknown as ModelMessage);
+    msgs.push({
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: `call-${i}`,
+          toolName: "sql_execute_query",
+          output: { type: "json", value: bigValue(chars) },
+        },
+      ],
+    } as unknown as ModelMessage);
+  }
+  return msgs;
+}
+
+function toolResultOutputs(messages: ModelMessage[]) {
+  const out: Array<{ toolCallId: unknown; toolName: unknown; output: unknown }> =
+    [];
+  for (const m of messages) {
+    const content = (m as { content?: unknown }).content;
+    if (!Array.isArray(content)) continue;
+    for (const p of content) {
+      if (p && (p as { type?: unknown }).type === "tool-result") {
+        out.push({
+          toolCallId: (p as Record<string, unknown>).toolCallId,
+          toolName: (p as Record<string, unknown>).toolName,
+          output: (p as Record<string, unknown>).output,
+        });
+      }
+    }
+  }
+  return out;
+}
+
+function countParts(messages: ModelMessage[], type: string): number {
+  let n = 0;
+  for (const m of messages) {
+    const content = (m as { content?: unknown }).content;
+    if (!Array.isArray(content)) continue;
+    for (const p of content) {
+      if (p && (p as { type?: unknown }).type === type) n++;
+    }
+  }
+  return n;
+}
+
+function isCleared(output: unknown): boolean {
+  return (
+    typeof output === "object" &&
+    output !== null &&
+    (output as { type?: unknown }).type === "text" &&
+    typeof (output as { value?: unknown }).value === "string" &&
+    ((output as { value: string }).value).startsWith(CLEAR_MARKER_PREFIX)
+  );
+}
+
+t("below clear trigger -> no-op, original reference returned", () => {
+  const messages = buildPairs(10, 2000);
+  const { messages: out, stats } = compactModelMessages(messages, {
+    budget,
+    config,
+    currentTokens: 100,
+  });
+  assert.equal(stats.applied, false);
+  assert.equal(stats.reason, "below-trigger");
+  assert.equal(out, messages);
+});
+
+t("over trigger -> masks older results, keeps recent N verbatim", () => {
+  const messages = buildPairs(10, 2000);
+  const { messages: out, stats } = compactModelMessages(messages, {
+    budget,
+    config,
+    currentTokens: 700, // > clearTrigger(600), < hardCeiling(920)
+  });
+
+  assert.equal(stats.applied, true);
+  assert.equal(stats.toolResultsTotal, 10);
+  // keepRecent=6 -> first 4 older results cleared
+  assert.equal(stats.clearedCount, 4);
+  assert.ok(stats.charsAfter < stats.charsBefore);
+
+  // Pairing preserved: same number of tool-calls and tool-results.
+  assert.equal(countParts(out, "tool-call"), 10);
+  assert.equal(countParts(out, "tool-result"), 10);
+
+  const outputs = toolResultOutputs(out);
+  // First 4 cleared, keep toolCallId/toolName.
+  for (let i = 0; i < 4; i++) {
+    assert.ok(isCleared(outputs[i].output), `result ${i} should be cleared`);
+    assert.equal(outputs[i].toolCallId, `call-${i}`);
+    assert.equal(outputs[i].toolName, "sql_execute_query");
+  }
+  // Last 6 untouched (still json).
+  for (let i = 4; i < 10; i++) {
+    assert.equal((outputs[i].output as { type: string }).type, "json");
+  }
+
+  // Original not mutated.
+  const origOutputs = toolResultOutputs(messages);
+  assert.equal((origOutputs[0].output as { type: string }).type, "json");
+});
+
+t("idempotent: re-running does not clear again", () => {
+  const messages = buildPairs(10, 2000);
+  const first = compactModelMessages(messages, {
+    budget,
+    config,
+    currentTokens: 700,
+  });
+  assert.equal(first.stats.applied, true);
+
+  const second = compactModelMessages(first.messages, {
+    budget,
+    config,
+    currentTokens: 700,
+  });
+  assert.equal(second.stats.applied, false);
+  assert.equal(second.stats.clearedCount, 0);
+  assert.equal(second.messages, first.messages);
+});
+
+t("respects minClearDelta: tiny savings are skipped", () => {
+  // 7 pairs, keepRecent 6 -> only 1 candidate; ~1.2k chars saved < 4k delta.
+  const messages = buildPairs(7, 1200);
+  const { stats } = compactModelMessages(messages, {
+    budget,
+    config,
+    currentTokens: 700,
+  });
+  assert.equal(stats.applied, false);
+  assert.equal(stats.reason, "below-min-delta");
+});
+
+t("disabled config is a no-op", () => {
+  const messages = buildPairs(10, 2000);
+  const { messages: out, stats } = compactModelMessages(messages, {
+    budget,
+    config: { ...config, enabled: false },
+    currentTokens: 999,
+  });
+  assert.equal(stats.applied, false);
+  assert.equal(stats.reason, "disabled");
+  assert.equal(out, messages);
+});
+
+t("aggressive past hard ceiling: keeps only 2 recent, ignores guards", () => {
+  // Small results (below minResultClearChars) + few pairs: only cleared when
+  // aggressive thresholds drop the guards to zero.
+  const messages = buildPairs(5, 300);
+  const { out: _omit, stats } = (() => {
+    const r = compactModelMessages(messages, {
+      budget,
+      config,
+      currentTokens: 950, // > hardCeiling(920)
+    });
+    return { out: r.messages, stats: r.stats };
+  })();
+  assert.equal(stats.applied, true);
+  assert.equal(stats.reason, "cleared-aggressive");
+  // keep 2 of 5 -> 3 cleared, even though each is < minResultClearChars.
+  assert.equal(stats.clearedCount, 3);
+});
+
+t("non-aggressive leaves small results alone (cheap to keep)", () => {
+  const messages = buildPairs(10, 300); // each result < minResultClearChars
+  const { stats } = compactModelMessages(messages, {
+    budget,
+    config,
+    currentTokens: 700,
+  });
+  assert.equal(stats.applied, false);
+  assert.equal(stats.reason, "nothing-to-clear");
+});

--- a/api/src/agent-lib/compaction/compactor.ts
+++ b/api/src/agent-lib/compaction/compactor.ts
@@ -1,0 +1,249 @@
+/**
+ * Prompt Compaction — Phase 1: clear/mask stale tool results
+ *
+ * High-confidence, no-extra-LLM-call compaction. We keep the most recent N
+ * tool-call/result pairs verbatim and replace the *output* of older tool
+ * results with a short placeholder, while leaving the tool-call parts (and the
+ * `toolCallId`/`toolName` of the result) intact so the call/result pairing
+ * stays valid for every provider and for `convertToModelMessages`.
+ *
+ * This is the main lever against the in-loop growth where a single agent run
+ * accumulates many large query/discovery dumps and approaches (or blows past)
+ * the model context window. The full transcript is still persisted to Mongo;
+ * this only changes what is *sent* to the model.
+ *
+ * Caching note: only the system block is cache-prefixed, and messages live
+ * after it, so masking message content does NOT invalidate that prefix cache.
+ */
+
+import type { ModelMessage } from "ai";
+import {
+  getCompactionConfig,
+  type CompactionBudget,
+  type CompactionConfig,
+} from "./config";
+import {
+  estimateModelMessagesTokens,
+  modelMessagesCharSize,
+  pickUsageSignal,
+  serializedCharSize,
+} from "./token-estimate";
+
+/** Prefix used for placeholder outputs; also how we detect already-cleared results (idempotency). */
+export const CLEAR_MARKER_PREFIX = "[result cleared";
+
+function placeholderText(toolName: string): string {
+  const name = toolName && toolName.length > 0 ? toolName : "the tool";
+  return `${CLEAR_MARKER_PREFIX} to save context — re-run ${name} to retrieve]`;
+}
+
+interface ToolResultPartLike {
+  type: "tool-result";
+  toolCallId?: string;
+  toolName?: string;
+  output?: unknown;
+  [key: string]: unknown;
+}
+
+function isToolResultPart(part: unknown): part is ToolResultPartLike {
+  return (
+    typeof part === "object" &&
+    part !== null &&
+    (part as { type?: unknown }).type === "tool-result"
+  );
+}
+
+function isAlreadyCleared(output: unknown): boolean {
+  return (
+    typeof output === "object" &&
+    output !== null &&
+    (output as { type?: unknown }).type === "text" &&
+    typeof (output as { value?: unknown }).value === "string" &&
+    ((output as { value: string }).value).startsWith(CLEAR_MARKER_PREFIX)
+  );
+}
+
+export interface CompactionStats {
+  applied: boolean;
+  reason: string;
+  signalTokens: number;
+  signalSource: "usage" | "estimate";
+  clearTriggerTokens: number;
+  toolResultsTotal: number;
+  clearedCount: number;
+  charsBefore: number;
+  charsAfter: number;
+  estTokensBefore: number;
+  estTokensAfter: number;
+}
+
+export interface CompactOptions {
+  budget: CompactionBudget;
+  config?: CompactionConfig;
+  /**
+   * Best available current-size signal in tokens (prefer the provider's
+   * reported input tokens from the previous step). When omitted, it is
+   * estimated from the messages plus `systemTokens`.
+   */
+  currentTokens?: number | null;
+  /** Estimated system-prompt tokens, added to the message estimate fallback. */
+  systemTokens?: number;
+  signalSource?: "usage" | "estimate";
+}
+
+export interface CompactionResult {
+  messages: ModelMessage[];
+  stats: CompactionStats;
+}
+
+/**
+ * Clear/mask stale tool results when the request is large enough to warrant it.
+ *
+ * The decision to act lives here so callers (cross-turn boundary and the
+ * in-loop `prepareStep`) stay one-liners. Returns the original array reference
+ * unchanged when no clearing is performed.
+ */
+export function compactModelMessages(
+  messages: ModelMessage[],
+  opts: CompactOptions,
+): CompactionResult {
+  const config = opts.config ?? getCompactionConfig();
+  const { budget } = opts;
+
+  const signal = pickUsageSignal({
+    priorInputTokens: opts.currentTokens,
+    messages,
+    systemTokens: opts.systemTokens,
+  });
+  const signalTokens = opts.currentTokens ?? signal.tokens;
+  const signalSource = opts.signalSource ?? signal.source;
+
+  const charsBefore = modelMessagesCharSize(messages);
+  const baseStats: CompactionStats = {
+    applied: false,
+    reason: "below-trigger",
+    signalTokens,
+    signalSource,
+    clearTriggerTokens: budget.clearTriggerTokens,
+    toolResultsTotal: 0,
+    clearedCount: 0,
+    charsBefore,
+    charsAfter: charsBefore,
+    estTokensBefore: estimateModelMessagesTokens(messages),
+    estTokensAfter: estimateModelMessagesTokens(messages),
+  };
+
+  if (!config.enabled) {
+    return { messages, stats: { ...baseStats, reason: "disabled" } };
+  }
+
+  if (signalTokens < budget.clearTriggerTokens) {
+    return { messages, stats: baseStats };
+  }
+
+  // When we are past the hard ceiling, clear more aggressively: keep fewer
+  // recent results and ignore the "cheap to keep" / "worth it" guards.
+  const aggressive = signalTokens >= budget.hardCeilingTokens;
+  const keepRecent = aggressive
+    ? Math.min(config.keepRecentToolResults, 2)
+    : config.keepRecentToolResults;
+  const minResultClearChars = aggressive ? 0 : config.minResultClearChars;
+  const minClearDeltaChars = aggressive ? 0 : config.minClearDeltaChars;
+
+  // Locate every tool-result part in document order.
+  const located: Array<{ msgIndex: number; partIndex: number }> = [];
+  messages.forEach((message, msgIndex) => {
+    const content = (message as { content?: unknown }).content;
+    if (!Array.isArray(content)) return;
+    content.forEach((part, partIndex) => {
+      if (isToolResultPart(part)) {
+        located.push({ msgIndex, partIndex });
+      }
+    });
+  });
+
+  const toolResultsTotal = located.length;
+  // Protect the most recent N; older ones are candidates for masking.
+  const candidates = located.slice(0, Math.max(0, located.length - keepRecent));
+
+  const toClear = new Map<number, Set<number>>();
+  let savedChars = 0;
+  for (const { msgIndex, partIndex } of candidates) {
+    const content = (messages[msgIndex] as { content: unknown[] }).content;
+    const part = content[partIndex] as ToolResultPartLike;
+    if (isAlreadyCleared(part.output)) continue;
+
+    const currentSize = serializedCharSize(part.output);
+    if (currentSize < minResultClearChars) continue;
+
+    const newOutput = { type: "text" as const, value: placeholderText(part.toolName ?? "") };
+    const newSize = serializedCharSize(newOutput);
+    if (newSize >= currentSize) continue;
+
+    savedChars += currentSize - newSize;
+    let set = toClear.get(msgIndex);
+    if (!set) {
+      set = new Set<number>();
+      toClear.set(msgIndex, set);
+    }
+    set.add(partIndex);
+  }
+
+  const clearedCount = Array.from(toClear.values()).reduce(
+    (sum, set) => sum + set.size,
+    0,
+  );
+
+  if (clearedCount === 0) {
+    return {
+      messages,
+      stats: { ...baseStats, applied: false, reason: "nothing-to-clear", toolResultsTotal },
+    };
+  }
+
+  if (savedChars < minClearDeltaChars) {
+    return {
+      messages,
+      stats: {
+        ...baseStats,
+        applied: false,
+        reason: "below-min-delta",
+        toolResultsTotal,
+      },
+    };
+  }
+
+  // Build a new messages array, replacing only the targeted result outputs.
+  const nextMessages: ModelMessage[] = messages.map((message, msgIndex) => {
+    const set = toClear.get(msgIndex);
+    if (!set) return message;
+    const content = (message as { content: unknown[] }).content;
+    const nextContent = content.map((part, partIndex) => {
+      if (!set.has(partIndex)) return part;
+      const p = part as ToolResultPartLike;
+      return {
+        ...p,
+        output: { type: "text" as const, value: placeholderText(p.toolName ?? "") },
+      };
+    });
+    return { ...message, content: nextContent } as ModelMessage;
+  });
+
+  const charsAfter = modelMessagesCharSize(nextMessages);
+  return {
+    messages: nextMessages,
+    stats: {
+      applied: true,
+      reason: aggressive ? "cleared-aggressive" : "cleared",
+      signalTokens,
+      signalSource,
+      clearTriggerTokens: budget.clearTriggerTokens,
+      toolResultsTotal,
+      clearedCount,
+      charsBefore,
+      charsAfter,
+      estTokensBefore: baseStats.estTokensBefore,
+      estTokensAfter: estimateModelMessagesTokens(nextMessages),
+    },
+  };
+}

--- a/api/src/agent-lib/compaction/config.test.ts
+++ b/api/src/agent-lib/compaction/config.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import {
+  getCompactionConfig,
+  resolveCompactionBudget,
+  DEFAULT_CONTEXT_WINDOW,
+} from "./config";
+
+function t(label: string, fn: () => void) {
+  fn();
+  process.stdout.write(`ok  ${label}\n`);
+}
+
+const COMPACTION_ENV_KEYS = [
+  "COMPACTION_ENABLED",
+  "COMPACTION_CLEAR_TRIGGER_FRACTION",
+  "COMPACTION_SUMMARIZE_TRIGGER_FRACTION",
+  "COMPACTION_HARD_CEILING_FRACTION",
+  "COMPACTION_KEEP_RECENT_TOOL_RESULTS",
+  "COMPACTION_MIN_CLEAR_DELTA_CHARS",
+  "COMPACTION_MIN_RESULT_CLEAR_CHARS",
+];
+
+function clearEnv() {
+  for (const k of COMPACTION_ENV_KEYS) delete process.env[k];
+}
+
+t("defaults are sensible and enabled", () => {
+  clearEnv();
+  const cfg = getCompactionConfig();
+  assert.equal(cfg.enabled, true);
+  assert.equal(cfg.clearTriggerFraction, 0.6);
+  assert.equal(cfg.summarizeTriggerFraction, 0.8);
+  assert.equal(cfg.hardCeilingFraction, 0.92);
+  assert.equal(cfg.keepRecentToolResults, 6);
+  assert.ok(cfg.minClearDeltaChars > 0);
+  assert.ok(cfg.minResultClearChars > 0);
+});
+
+t("env overrides are applied and validated", () => {
+  clearEnv();
+  process.env.COMPACTION_ENABLED = "false";
+  process.env.COMPACTION_CLEAR_TRIGGER_FRACTION = "0.5";
+  process.env.COMPACTION_KEEP_RECENT_TOOL_RESULTS = "3";
+  const cfg = getCompactionConfig();
+  assert.equal(cfg.enabled, false);
+  assert.equal(cfg.clearTriggerFraction, 0.5);
+  assert.equal(cfg.keepRecentToolResults, 3);
+  clearEnv();
+});
+
+t("invalid env values fall back to defaults", () => {
+  clearEnv();
+  process.env.COMPACTION_CLEAR_TRIGGER_FRACTION = "9"; // out of (0,1]
+  process.env.COMPACTION_KEEP_RECENT_TOOL_RESULTS = "-2"; // negative
+  const cfg = getCompactionConfig();
+  assert.equal(cfg.clearTriggerFraction, 0.6);
+  assert.equal(cfg.keepRecentToolResults, 6);
+  clearEnv();
+});
+
+t("resolveCompactionBudget derives absolute token budgets", () => {
+  clearEnv();
+  const b = resolveCompactionBudget(1000);
+  assert.equal(b.contextWindow, 1000);
+  assert.equal(b.clearTriggerTokens, 600);
+  assert.equal(b.summarizeTriggerTokens, 800);
+  assert.equal(b.hardCeilingTokens, 920);
+});
+
+t("resolveCompactionBudget falls back when window missing", () => {
+  clearEnv();
+  assert.equal(resolveCompactionBudget(null).contextWindow, DEFAULT_CONTEXT_WINDOW);
+  assert.equal(resolveCompactionBudget(0).contextWindow, DEFAULT_CONTEXT_WINDOW);
+  assert.equal(
+    resolveCompactionBudget(undefined).contextWindow,
+    DEFAULT_CONTEXT_WINDOW,
+  );
+});

--- a/api/src/agent-lib/compaction/config.ts
+++ b/api/src/agent-lib/compaction/config.ts
@@ -1,0 +1,149 @@
+/**
+ * Prompt Compaction — configuration
+ *
+ * Provider-agnostic, application-level compaction config. All thresholds are
+ * env-overridable so they can be tuned from Langfuse data without a redeploy.
+ *
+ * Compaction is a read-time transform: we shrink what we send to the model on a
+ * given turn/step but always persist the FULL transcript to Mongo. Nothing in
+ * here mutates the saved chat history.
+ */
+
+/** Fallback context window (tokens) when the model catalog reports none. */
+export const DEFAULT_CONTEXT_WINDOW = 200_000;
+
+export interface CompactionConfig {
+  /** Master switch — when false, compaction is a no-op. */
+  enabled: boolean;
+  /**
+   * Fraction of the context window at which stale tool results start getting
+   * cleared/masked (Phase 1). Leaves headroom for the system prompt + tool
+   * schemas which are not counted in the message estimate.
+   */
+  clearTriggerFraction: number;
+  /**
+   * Fraction of the context window at which middle-of-session summarization
+   * should kick in (Phase 2). Surfaced here so the budget math lives in one
+   * place even though the summarizer ships later.
+   */
+  summarizeTriggerFraction: number;
+  /**
+   * Hard ceiling fraction. We never want the request to approach the model
+   * maximum; used as a guard/escalation point for aggressive clearing.
+   */
+  hardCeilingFraction: number;
+  /**
+   * Number of most-recent tool-result payloads to always keep verbatim. Older
+   * results are eligible for masking.
+   */
+  keepRecentToolResults: number;
+  /**
+   * Minimum characters that clearing must reclaim for it to be worth doing.
+   * Prevents churn (and cache thrash) when only a tiny amount would be saved.
+   */
+  minClearDeltaChars: number;
+  /**
+   * Tool-result payloads smaller than this (serialized chars) are left alone
+   * even when stale — they are cheap to keep and clearing them hurts quality.
+   */
+  minResultClearChars: number;
+}
+
+const DEFAULTS: CompactionConfig = {
+  enabled: true,
+  clearTriggerFraction: 0.6,
+  summarizeTriggerFraction: 0.8,
+  hardCeilingFraction: 0.92,
+  keepRecentToolResults: 6,
+  minClearDeltaChars: 4_000,
+  minResultClearChars: 1_000,
+};
+
+function envBool(name: string, fallback: boolean): boolean {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  return raw === "1" || raw.toLowerCase() === "true";
+}
+
+function envFraction(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0 || n > 1) return fallback;
+  return n;
+}
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 0) return fallback;
+  return n;
+}
+
+/**
+ * Resolve the active compaction config from env (falling back to defaults).
+ * Read fresh each call so tests / Langfuse-driven tuning can flip env without a
+ * process restart; the work here is trivial.
+ */
+export function getCompactionConfig(): CompactionConfig {
+  return {
+    enabled: envBool("COMPACTION_ENABLED", DEFAULTS.enabled),
+    clearTriggerFraction: envFraction(
+      "COMPACTION_CLEAR_TRIGGER_FRACTION",
+      DEFAULTS.clearTriggerFraction,
+    ),
+    summarizeTriggerFraction: envFraction(
+      "COMPACTION_SUMMARIZE_TRIGGER_FRACTION",
+      DEFAULTS.summarizeTriggerFraction,
+    ),
+    hardCeilingFraction: envFraction(
+      "COMPACTION_HARD_CEILING_FRACTION",
+      DEFAULTS.hardCeilingFraction,
+    ),
+    keepRecentToolResults: envInt(
+      "COMPACTION_KEEP_RECENT_TOOL_RESULTS",
+      DEFAULTS.keepRecentToolResults,
+    ),
+    minClearDeltaChars: envInt(
+      "COMPACTION_MIN_CLEAR_DELTA_CHARS",
+      DEFAULTS.minClearDeltaChars,
+    ),
+    minResultClearChars: envInt(
+      "COMPACTION_MIN_RESULT_CLEAR_CHARS",
+      DEFAULTS.minResultClearChars,
+    ),
+  };
+}
+
+export interface CompactionBudget {
+  /** Effective context window in tokens used for all fraction math. */
+  contextWindow: number;
+  /** Token count at/above which Phase 1 clearing should run. */
+  clearTriggerTokens: number;
+  /** Token count at/above which Phase 2 summarization should run. */
+  summarizeTriggerTokens: number;
+  /** Token count we never want to exceed; escalation point. */
+  hardCeilingTokens: number;
+}
+
+/**
+ * Derive absolute token budgets from a model context window and config.
+ * A null/0/negative window falls back to {@link DEFAULT_CONTEXT_WINDOW}.
+ */
+export function resolveCompactionBudget(
+  contextWindow: number | null | undefined,
+  config: CompactionConfig = getCompactionConfig(),
+): CompactionBudget {
+  const window =
+    typeof contextWindow === "number" && contextWindow > 0
+      ? contextWindow
+      : DEFAULT_CONTEXT_WINDOW;
+
+  return {
+    contextWindow: window,
+    clearTriggerTokens: Math.floor(window * config.clearTriggerFraction),
+    summarizeTriggerTokens: Math.floor(window * config.summarizeTriggerFraction),
+    hardCeilingTokens: Math.floor(window * config.hardCeilingFraction),
+  };
+}

--- a/api/src/agent-lib/compaction/index.ts
+++ b/api/src/agent-lib/compaction/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Prompt Compaction — provider-agnostic, application-level context shrinking.
+ *
+ * Public surface for the agent request path. Compaction is a read-time
+ * transform: it only changes what is sent to the model, never the persisted
+ * transcript.
+ */
+
+export {
+  getCompactionConfig,
+  resolveCompactionBudget,
+  DEFAULT_CONTEXT_WINDOW,
+  type CompactionConfig,
+  type CompactionBudget,
+} from "./config";
+export {
+  estimateModelMessagesTokens,
+  estimateTokensFromText,
+  pickUsageSignal,
+} from "./token-estimate";
+export {
+  compactModelMessages,
+  CLEAR_MARKER_PREFIX,
+  type CompactionResult,
+  type CompactionStats,
+  type CompactOptions,
+} from "./compactor";

--- a/api/src/agent-lib/compaction/token-estimate.test.ts
+++ b/api/src/agent-lib/compaction/token-estimate.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import type { ModelMessage } from "ai";
+import {
+  CHARS_PER_TOKEN,
+  estimateTokensFromChars,
+  estimateTokensFromText,
+  serializedCharSize,
+  modelMessageCharSize,
+  estimateModelMessagesTokens,
+  pickUsageSignal,
+} from "./token-estimate";
+
+function t(label: string, fn: () => void) {
+  fn();
+  process.stdout.write(`ok  ${label}\n`);
+}
+
+t("chars/4 heuristic rounds up", () => {
+  assert.equal(estimateTokensFromChars(40), 10);
+  assert.equal(estimateTokensFromChars(41), 11);
+  assert.equal(estimateTokensFromChars(0), 0);
+  assert.equal(estimateTokensFromChars(-5), 0);
+  assert.equal(CHARS_PER_TOKEN, 4);
+});
+
+t("estimateTokensFromText measures string length", () => {
+  assert.equal(estimateTokensFromText("a".repeat(40)), 10);
+  assert.equal(estimateTokensFromText(""), 0);
+});
+
+t("serializedCharSize handles strings, objects, nullish", () => {
+  assert.equal(serializedCharSize("hello"), 5);
+  assert.equal(serializedCharSize(null), 0);
+  assert.equal(serializedCharSize(undefined), 0);
+  assert.equal(serializedCharSize({ a: 1 }), JSON.stringify({ a: 1 }).length);
+});
+
+t("modelMessageCharSize counts string and structured content", () => {
+  const stringMsg: ModelMessage = { role: "user", content: "hi there" };
+  assert.equal(modelMessageCharSize(stringMsg), 8);
+
+  const toolMsg = {
+    role: "tool",
+    content: [
+      { type: "tool-result", toolCallId: "c1", toolName: "x", output: { type: "json", value: { n: 1 } } },
+    ],
+  } as unknown as ModelMessage;
+  assert.equal(
+    modelMessageCharSize(toolMsg),
+    JSON.stringify((toolMsg as { content: unknown }).content).length,
+  );
+});
+
+t("estimateModelMessagesTokens sums message content", () => {
+  const messages: ModelMessage[] = [
+    { role: "user", content: "a".repeat(40) },
+    { role: "assistant", content: "b".repeat(40) },
+  ];
+  assert.equal(estimateModelMessagesTokens(messages), 20);
+});
+
+t("pickUsageSignal prefers reported usage when present", () => {
+  const messages: ModelMessage[] = [{ role: "user", content: "a".repeat(40) }];
+  const withUsage = pickUsageSignal({ priorInputTokens: 1234, messages });
+  assert.equal(withUsage.source, "usage");
+  assert.equal(withUsage.tokens, 1234);
+});
+
+t("pickUsageSignal falls back to estimate + system tokens", () => {
+  const messages: ModelMessage[] = [{ role: "user", content: "a".repeat(40) }];
+  const est = pickUsageSignal({ priorInputTokens: 0, messages, systemTokens: 5 });
+  assert.equal(est.source, "estimate");
+  assert.equal(est.tokens, 5 + 10);
+});

--- a/api/src/agent-lib/compaction/token-estimate.ts
+++ b/api/src/agent-lib/compaction/token-estimate.ts
@@ -1,0 +1,91 @@
+/**
+ * Prompt Compaction — cheap token estimator
+ *
+ * There is no tokenizer dependency in this package, and pulling one in per
+ * provider would be both heavy and provider-specific. Compaction only needs a
+ * rough, monotonic signal of "how big is this request", so we use the standard
+ * ~4-chars-per-token heuristic over the JSON-serialized message content.
+ *
+ * For accuracy where it matters, callers should prefer the AI SDK's reported
+ * `usage` from the previous step/turn (see {@link pickUsageSignal}); the
+ * estimate is the first-call fallback only.
+ */
+
+import type { ModelMessage } from "ai";
+
+/** Average characters per token for the char/4 heuristic. */
+export const CHARS_PER_TOKEN = 4;
+
+/** Estimate tokens for a raw string. */
+export function estimateTokensFromChars(charCount: number): number {
+  if (!Number.isFinite(charCount) || charCount <= 0) return 0;
+  return Math.ceil(charCount / CHARS_PER_TOKEN);
+}
+
+/** Estimate tokens for a string of text. */
+export function estimateTokensFromText(text: string): number {
+  return estimateTokensFromChars(text.length);
+}
+
+/**
+ * Serialized character size of an arbitrary value. Strings are measured
+ * directly; everything else is JSON-stringified. Circular/oversized values
+ * fall back to a coarse `String()` length so estimation never throws.
+ */
+export function serializedCharSize(value: unknown): number {
+  if (value === null || value === undefined) return 0;
+  if (typeof value === "string") return value.length;
+  try {
+    return JSON.stringify(value)?.length ?? 0;
+  } catch {
+    return String(value).length;
+  }
+}
+
+/** Serialized character size of a single model message. */
+export function modelMessageCharSize(message: ModelMessage): number {
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === "string") return content.length;
+  return serializedCharSize(content);
+}
+
+/** Serialized character size across all model messages. */
+export function modelMessagesCharSize(messages: ModelMessage[]): number {
+  let total = 0;
+  for (const message of messages) {
+    total += modelMessageCharSize(message);
+  }
+  return total;
+}
+
+/** Estimate tokens for a list of model messages (char/4 heuristic). */
+export function estimateModelMessagesTokens(messages: ModelMessage[]): number {
+  return estimateTokensFromChars(modelMessagesCharSize(messages));
+}
+
+/**
+ * Choose the best available "current size" signal in tokens.
+ *
+ * Prefers the actual input-token count the provider reported for the previous
+ * step/turn (which includes system prompt + tool schemas, so it is the truest
+ * measure of how close we are to the window). Falls back to the char/4 estimate
+ * over the messages plus an optional system-prompt token estimate.
+ */
+export function pickUsageSignal(opts: {
+  priorInputTokens?: number | null;
+  messages: ModelMessage[];
+  systemTokens?: number;
+}): { tokens: number; source: "usage" | "estimate" } {
+  const { priorInputTokens, messages, systemTokens = 0 } = opts;
+  if (
+    typeof priorInputTokens === "number" &&
+    Number.isFinite(priorInputTokens) &&
+    priorInputTokens > 0
+  ) {
+    return { tokens: priorInputTokens, source: "usage" };
+  }
+  return {
+    tokens: systemTokens + estimateModelMessagesTokens(messages),
+    source: "estimate",
+  };
+}

--- a/api/src/agent-lib/tools/mongodb-tools.ts
+++ b/api/src/agent-lib/tools/mongodb-tools.ts
@@ -16,8 +16,8 @@ import {
   inferBsonType,
   truncateSamples,
   truncateQueryResults,
+  clampTruncatedResults,
   MAX_SAMPLE_ROWS,
-  MAX_TOTAL_OUTPUT_SIZE,
   AGENT_QUERY_TIMEOUT_MS,
   registerAgentExecution,
   throwIfAborted,
@@ -400,17 +400,12 @@ async function executeQueryImpl(
 
   if (result && result.success && result.data) {
     const truncatedData = truncateQueryResults(result.data);
-    const outputSize = JSON.stringify(truncatedData).length;
-    if (outputSize > MAX_TOTAL_OUTPUT_SIZE) {
-      return {
-        ...result,
-        data: Array.isArray(truncatedData)
-          ? truncatedData.slice(0, 50)
-          : truncatedData,
-        _warning: `Results truncated. Add .limit() to your query for smaller result sets.`,
-      };
-    }
-    return { ...result, data: truncatedData };
+    const { data: clampedData, warning } = clampTruncatedResults(truncatedData);
+    return {
+      ...result,
+      data: clampedData,
+      ...(warning ? { _warning: warning } : {}),
+    };
   }
 
   return result;

--- a/api/src/agent-lib/tools/shared/truncation.ts
+++ b/api/src/agent-lib/tools/shared/truncation.ts
@@ -274,6 +274,32 @@ export const truncateQueryResults = (results: unknown): unknown => {
 };
 
 /**
+ * Final safety clamp on already-truncated query result data.
+ *
+ * `truncateQueryResults` caps row count and per-value size, but a result with
+ * many medium-sized rows can still serialize past {@link MAX_TOTAL_OUTPUT_SIZE}.
+ * This is the last line of defense before a raw dump enters the conversation
+ * history (and the model context). Shared by the SQL and MongoDB query tools so
+ * every large-output path enforces the same ceiling.
+ *
+ * Returns the (possibly further-reduced) data plus an optional warning string
+ * the caller can surface to the model so it knows to add a `LIMIT`/`.limit()`.
+ */
+export const clampTruncatedResults = (
+  truncatedData: unknown,
+): { data: unknown; warning?: string } => {
+  const outputSize = JSON.stringify(truncatedData ?? null)?.length ?? 0;
+  if (outputSize <= MAX_TOTAL_OUTPUT_SIZE) {
+    return { data: truncatedData };
+  }
+  return {
+    data: Array.isArray(truncatedData) ? truncatedData.slice(0, 50) : truncatedData,
+    warning:
+      "Results truncated to fit context. Add a LIMIT / .limit() to your query for smaller result sets.",
+  };
+};
+
+/**
  * Truncate sample rows/documents for inspection output
  */
 export const truncateSamples = (

--- a/api/src/agent-lib/tools/sql-tools.ts
+++ b/api/src/agent-lib/tools/sql-tools.ts
@@ -15,6 +15,7 @@ import { clientConsoleTools } from "@mako/agent-tools";
 import {
   truncateSamples,
   truncateQueryResults,
+  clampTruncatedResults,
   MAX_SAMPLE_ROWS,
   AGENT_QUERY_TIMEOUT_MS,
   registerAgentExecution,
@@ -949,7 +950,13 @@ async function executeQueryImpl(
 
     if (result && result.success && result.data) {
       const truncatedData = truncateQueryResults(result.data);
-      return { ...result, data: truncatedData, sqlDialect: dialect };
+      const { data: clampedData, warning } = clampTruncatedResults(truncatedData);
+      return {
+        ...result,
+        data: clampedData,
+        sqlDialect: dialect,
+        ...(warning ? { _warning: warning } : {}),
+      };
     }
 
     return { ...result, sqlDialect: dialect };

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -61,6 +61,12 @@ import {
 import { databaseConnectionService } from "../services/database-connection.service";
 import { createAgentExecutionId } from "../agent-lib/tools/shared/truncation";
 import { toNum, extractTokenCounts } from "../utils/safe-num";
+import {
+  getCompactionConfig,
+  resolveCompactionBudget,
+  compactModelMessages,
+  estimateTokensFromText,
+} from "../agent-lib/compaction";
 
 const logger = loggers.agent();
 
@@ -718,6 +724,51 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
     });
   }
 
+  // Prompt compaction (Phase 1): provider-agnostic, application-level context
+  // shrinking applied to what we *send* the model. The full transcript is still
+  // persisted via onFinish below — this is a read-time transform only.
+  //
+  // - Cross-turn: clear/mask stale tool results once the conversation crosses
+  //   the clear trigger (a fraction of the model context window).
+  // - In-loop: the `prepareStep` hook on streamText re-runs the clearer between
+  //   tool steps, which is where a single run can balloon (large query dumps).
+  const compactionConfig = getCompactionConfig();
+  const compactionBudget = resolveCompactionBudget(
+    modelDef?.contextWindow,
+    compactionConfig,
+  );
+  const systemPromptTokens = estimateTokensFromText(
+    typeof systemPrompt === "string" ? systemPrompt : JSON.stringify(systemPrompt),
+  );
+
+  if (compactionConfig.enabled) {
+    const { messages: compacted, stats } = compactModelMessages(modelMessages, {
+      budget: compactionBudget,
+      config: compactionConfig,
+      systemTokens: systemPromptTokens,
+    });
+    if (stats.applied) {
+      // Replace contents in place so the (typed) array reference passed to
+      // streamText carries the masked results.
+      modelMessages.length = 0;
+      modelMessages.push(...(compacted as typeof modelMessages));
+      logger.info("Compaction cleared stale tool results (cross-turn)", {
+        chatId,
+        workspaceId,
+        modelId: resolvedModelId,
+        contextWindow: compactionBudget.contextWindow,
+        ...stats,
+      });
+    } else {
+      logger.debug("Compaction skipped (cross-turn)", {
+        chatId,
+        reason: stats.reason,
+        signalTokens: stats.signalTokens,
+        clearTriggerTokens: stats.clearTriggerTokens,
+      });
+    }
+  }
+
   const MAX_STEPS = 256;
   let stepsCompleted = 0;
 
@@ -765,6 +816,41 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
         stopWhen: stepCountIs(MAX_STEPS),
         providerOptions,
         abortSignal: requestSignal,
+        // In-loop compaction: this is the real source of single-run growth
+        // (160k -> 180k within one streamText call as tool dumps accumulate).
+        // We prefer the provider's reported input tokens from the prior step as
+        // the size signal, falling back to the char/4 estimate on the first
+        // step. Returning undefined leaves the outer messages untouched.
+        prepareStep: ({ steps, messages: stepMessages }) => {
+          if (!compactionConfig.enabled) return undefined;
+          const last = steps[steps.length - 1] as
+            | { usage?: Record<string, unknown> }
+            | undefined;
+          const usage = last?.usage;
+          const priorInputTokens = usage
+            ? (toNum(usage.totalTokens) ||
+              toNum(usage.inputTokens) + toNum(usage.outputTokens))
+            : undefined;
+          const { messages: compacted, stats } = compactModelMessages(
+            stepMessages,
+            {
+              budget: compactionBudget,
+              config: compactionConfig,
+              currentTokens: priorInputTokens,
+              signalSource: priorInputTokens ? "usage" : "estimate",
+              systemTokens: systemPromptTokens,
+            },
+          );
+          if (!stats.applied) return undefined;
+          logger.info("Compaction cleared stale tool results (in-loop)", {
+            chatId,
+            workspaceId,
+            modelId: resolvedModelId,
+            stepNumber: steps.length,
+            ...stats,
+          });
+          return { messages: compacted };
+        },
         experimental_telemetry: {
           isEnabled: true,
           functionId: `agent-chat:${resolvedAgentId}`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt Compaction (issue #459)

Provider-agnostic, **application-level** compaction implemented in the API backend (`api/`) in the request path before the model call. Compaction is a **read-time transform**: we shrink what we send to the model but always persist the FULL transcript to Mongo (`onFinish` in `agent.routes.ts` is untouched).

This PR lands the cheapest, highest-confidence slice that directly attacks the in-loop `160k -> 180k` growth within a single `streamText` run and eliminates `CONTEXT SIZE EXCEEDED`, with **no extra LLM calls**.

### Foundation (shared by all phases)
- Thread per-model `contextWindow` from the gateway catalog (`CatalogModel.contextWindow`) through `AIModel` into the chat handler.
- `compaction/token-estimate.ts`: cheap char/4 estimator (no tokenizer dep exists). Prefers the AI SDK's reported `usage` input tokens from the prior step; falls back to the estimate on the first call.
- `compaction/config.ts`: config-driven budget fractions (clear ~60%, summarize ~80%, hard ceiling ~92%) resolved against the context window, all env-overridable (`COMPACTION_*`).

### Phase 0 — cap tool outputs at the boundary
- New shared `clampTruncatedResults` in `tools/shared/truncation.ts` enforces a final `MAX_TOTAL_OUTPUT_SIZE` ceiling on already-truncated query data.
- Routed both `sql_execute_query` and `mongo_execute_query` through it. Previously only MongoDB applied this clamp inline; SQL results could exceed it. Standardizes the compact result shape so raw dumps never enter history.

### Phase 1 — clear/mask stale tool results
- `compaction/compactor.ts` `compactModelMessages()`: keep the most recent N tool-call/result pairs verbatim; replace older `tool-result` payloads with a short placeholder (`[result cleared … re-run <tool> to retrieve]`), **preserving `toolCallId`/`toolName` pairing** so providers and `convertToModelMessages` stay valid.
  - Anti-thrash: min-clear-delta + "cheap to keep" guards; idempotent placeholder detection.
  - Escalation: clears more aggressively past the hard ceiling.
- Wired in `agent.routes.ts`:
  - **Cross-turn** after `convertToModelMessages`.
  - **In-loop** via `streamText({ prepareStep })` (AI SDK v6) — re-runs the clearer between steps using the prior step's reported input tokens as the size signal.
- Caching note: only the system block is cache-prefixed and messages live after it, so masking message content does **not** invalidate the system-prefix cache.

### Config & safety
- All thresholds are env-tunable (see `.env.example`), so they can be tuned from Langfuse data without a redeploy. Master switch `COMPACTION_ENABLED` makes the whole path a no-op.

## Testing

Backend request-path change; no UI surface, so evidence is automated tests + typecheck/lint. The integration test runs the **real** AI SDK `convertToModelMessages -> compactor` pipeline and validates every masked message against the SDK's own `modelMessageSchema` (proving provider/convert validity) with pairing preserved.

- ✅ `tsx src/agent-lib/compaction/{token-estimate,config,compactor}.test.ts` (19 unit tests)
- ✅ `tsx src/agent-lib/compaction/compactor.integration.test.ts` (real convert + schema validation)
- ✅ `tsc -p tsconfig.build.json --noEmit`
- ✅ `eslint .` (full api package)

[compaction_tests.log](https://cursor.com/agents/bc-1ba323cb-e978-4d1c-a99a-c370e1bba6bc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompaction_tests.log)

## Follow-ups (deliberately out of this PR; gated on Phase 1 results)
- **Phase 2** — anchored + rolling summarization (`compaction/summarizer.ts`) via the utility model, persisted on the chat doc, with turn-boundary safe points. Trigger fraction + budget already defined here.
- **Phase 3** — sub-agent delegation (`delegate`/`explore_dataset`) and external scratchpad memory.
- Langfuse golden-set regression + before/after token & `input_cache_creation` measurement.

## Out of scope
- Anthropic server-side `context_management` (we chose provider-agnostic, application-level compaction).
- Rewriting persisted history (we compact only what's sent to the model).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ba323cb-e978-4d1c-a99a-c370e1bba6bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ba323cb-e978-4d1c-a99a-c370e1bba6bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

