### PR TITLE
fix(agent): re-land stream-close finalization queue (lost from PR #424)

### DIFF
--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -61,54 +61,11 @@ import {
 import { databaseConnectionService } from "../services/database-connection.service";
 import { createAgentExecutionId } from "../agent-lib/tools/shared/truncation";
 import { toNum, extractTokenCounts } from "../utils/safe-num";
+import { scheduleChatFinalization } from "./chat-finalization-queue";
 
 const logger = loggers.agent();
 
 export const agentRoutes = new Hono();
-
-/**
- * Per-chat finalization queue.
- *
- * The AI SDK keeps the UI message stream open until the `onFinish` callback of
- * `toUIMessageStreamResponse` resolves (it is awaited inside the stream's
- * `flush()`). On the client, `useChat` only fires the tool-result auto-resume
- * once that stream closes. So any slow work in `onFinish` (gateway pricing
- * lookups, `saveChat`, etc.) is serialized *into the user-perceived latency* of
- * every client-side tool round-trip — the assistant appears frozen even though
- * the tool itself (e.g. an instant `modify_console` patch) resolved in
- * milliseconds, and a stuck round-trip only unblocks when the held-open stream
- * hits its proxy/HTTP timeout.
- *
- * To keep tool round-trips snappy we run finalization in the background instead
- * of blocking stream close. We still serialize finalizations per chat so that
- * the full-thread `$set` writes in `saveChat` always apply in step order (the
- * blocking behavior previously guaranteed this for free).
- */
-const chatFinalizationChains = new Map<string, Promise<void>>();
-
-function scheduleChatFinalization(
-  chatId: string,
-  task: () => Promise<void>,
-): void {
-  const previous = chatFinalizationChains.get(chatId) ?? Promise.resolve();
-  const next = previous
-    // Isolate this task from a prior task's failure so the chain keeps running.
-    .catch(() => {})
-    .then(task)
-    .catch(err =>
-      logger.error("Chat finalization failed", { chatId, error: err }),
-    );
-
-  chatFinalizationChains.set(chatId, next);
-
-  // Drop the map entry once this task is the tail and has settled, to avoid
-  // leaking one promise per chat for the lifetime of the process.
-  void next.finally(() => {
-    if (chatFinalizationChains.get(chatId) === next) {
-      chatFinalizationChains.delete(chatId);
-    }
-  });
-}
 
 interface ScreenshotVisionAttachment {
   renderer?: string;

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -66,6 +66,50 @@ const logger = loggers.agent();
 
 export const agentRoutes = new Hono();
 
+/**
+ * Per-chat finalization queue.
+ *
+ * The AI SDK keeps the UI message stream open until the `onFinish` callback of
+ * `toUIMessageStreamResponse` resolves (it is awaited inside the stream's
+ * `flush()`). On the client, `useChat` only fires the tool-result auto-resume
+ * once that stream closes. So any slow work in `onFinish` (gateway pricing
+ * lookups, `saveChat`, etc.) is serialized *into the user-perceived latency* of
+ * every client-side tool round-trip — the assistant appears frozen even though
+ * the tool itself (e.g. an instant `modify_console` patch) resolved in
+ * milliseconds, and a stuck round-trip only unblocks when the held-open stream
+ * hits its proxy/HTTP timeout.
+ *
+ * To keep tool round-trips snappy we run finalization in the background instead
+ * of blocking stream close. We still serialize finalizations per chat so that
+ * the full-thread `$set` writes in `saveChat` always apply in step order (the
+ * blocking behavior previously guaranteed this for free).
+ */
+const chatFinalizationChains = new Map<string, Promise<void>>();
+
+function scheduleChatFinalization(
+  chatId: string,
+  task: () => Promise<void>,
+): void {
+  const previous = chatFinalizationChains.get(chatId) ?? Promise.resolve();
+  const next = previous
+    // Isolate this task from a prior task's failure so the chain keeps running.
+    .catch(() => {})
+    .then(task)
+    .catch(err =>
+      logger.error("Chat finalization failed", { chatId, error: err }),
+    );
+
+  chatFinalizationChains.set(chatId, next);
+
+  // Drop the map entry once this task is the tail and has settled, to avoid
+  // leaking one promise per chat for the lifetime of the process.
+  void next.finally(() => {
+    if (chatFinalizationChains.get(chatId) === next) {
+      chatFinalizationChains.delete(chatId);
+    }
+  });
+}
+
 interface ScreenshotVisionAttachment {
   renderer?: string;
   filename?: string;
@@ -813,228 +857,238 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
         // Forward reasoning tokens from models that support extended thinking
         // (e.g., Claude claude-3-7-sonnet-20250219, DeepSeek deepseek-r1)
         sendReasoning: true,
-        onFinish: async ({ messages: allMessages, isAborted }) => {
-          if (requestExecutionIds.size > 0) {
-            await cancelRegisteredExecutions();
-            requestExecutionIds.clear();
-          }
-          const durationMs = Date.now() - startTime;
-
-          // Extract detailed per-step usage from result.steps
-          let steps: Array<Record<string, unknown>> = [];
-          try {
-            steps = (await result.steps) as unknown as Array<
-              Record<string, unknown>
-            >;
-          } catch (err) {
-            logger.warn("Failed to get steps from result", { error: err });
-          }
-
-          // Aggregate detailed token usage across all steps
-          let inputTokens = 0;
-          let outputTokens = 0;
-          let cacheReadTokens = 0;
-          let cacheWriteTokens = 0;
-          let reasoningTokens = 0;
-
-          let stepDetails: Array<{
-            modelId: string;
-            inputTokens: number;
-            outputTokens: number;
-            cacheReadTokens: number;
-            cacheWriteTokens: number;
-            reasoningTokens: number;
-            costUsd: number;
-          }> = [];
-
-          for (const step of steps) {
-            const usage = step.usage as Record<string, unknown> | undefined;
-            if (!usage) continue;
-
-            const { inputTokens: sInput, outputTokens: sOutput } =
-              extractTokenCounts(usage);
-
-            const details = usage.inputTokenDetails as
-              | Record<string, unknown>
-              | undefined;
-            const outDetails = usage.outputTokenDetails as
-              | Record<string, unknown>
-              | undefined;
-
-            const sCacheRead = toNum(details?.cacheReadTokens);
-            const sCacheWrite = toNum(details?.cacheWriteTokens);
-            const sReasoning = toNum(outDetails?.reasoningTokens);
-
-            inputTokens += sInput;
-            outputTokens += sOutput;
-            cacheReadTokens += sCacheRead;
-            cacheWriteTokens += sCacheWrite;
-            reasoningTokens += sReasoning;
-
-            const stepModelId = (
-              step.response as Record<string, unknown> | undefined
-            )?.modelId as string | undefined;
-
-            stepDetails.push({
-              modelId: stepModelId || resolvedModelId,
-              inputTokens: sInput,
-              outputTokens: sOutput,
-              cacheReadTokens: sCacheRead,
-              cacheWriteTokens: sCacheWrite,
-              reasoningTokens: sReasoning,
-              costUsd: 0, // filled in by cost calculator
-            });
-          }
-
-          // Fallback to top-level usage if no steps produced usage data
-          if (stepDetails.length === 0) {
-            try {
-              const usage = (await result.usage) as unknown as Record<
-                string,
-                unknown
-              >;
-              const extracted = extractTokenCounts(usage ?? {});
-              inputTokens = extracted.inputTokens;
-              outputTokens = extracted.outputTokens;
-
-              const details = usage?.inputTokenDetails as
-                | Record<string, unknown>
-                | undefined;
-              const outDetails = usage?.outputTokenDetails as
-                | Record<string, unknown>
-                | undefined;
-              cacheReadTokens = toNum(details?.cacheReadTokens);
-              cacheWriteTokens = toNum(details?.cacheWriteTokens);
-              reasoningTokens = toNum(outDetails?.reasoningTokens);
-            } catch (err) {
-              logger.warn("Failed to get usage from model", { error: err });
+        onFinish: ({ messages: allMessages, isAborted }) => {
+          // Run finalization in the background so it does not block the UI
+          // message stream from closing. The AI SDK awaits onFinish inside the
+          // stream's flush(), and useChat only fires the tool-result auto-resume
+          // once the stream closes — so any slow work here (cost computation,
+          // saveChat, etc.) is serialized into the user-perceived latency of
+          // every client-side tool round-trip, making fast tools (e.g. an
+          // instant modify_console patch) appear frozen. See
+          // scheduleChatFinalization above.
+          scheduleChatFinalization(chatId, async () => {
+            if (requestExecutionIds.size > 0) {
+              await cancelRegisteredExecutions();
+              requestExecutionIds.clear();
             }
-          }
+            const durationMs = Date.now() - startTime;
 
-          const totalTokens = inputTokens + outputTokens;
+            // Extract detailed per-step usage from result.steps
+            let steps: Array<Record<string, unknown>> = [];
+            try {
+              steps = (await result.steps) as unknown as Array<
+                Record<string, unknown>
+              >;
+            } catch (err) {
+              logger.warn("Failed to get steps from result", { error: err });
+            }
 
-          logger.info(
-            isAborted
-              ? "Stream aborted, saving partial chat"
-              : "Stream finished, saving chat",
-            {
+            // Aggregate detailed token usage across all steps
+            let inputTokens = 0;
+            let outputTokens = 0;
+            let cacheReadTokens = 0;
+            let cacheWriteTokens = 0;
+            let reasoningTokens = 0;
+
+            let stepDetails: Array<{
+              modelId: string;
+              inputTokens: number;
+              outputTokens: number;
+              cacheReadTokens: number;
+              cacheWriteTokens: number;
+              reasoningTokens: number;
+              costUsd: number;
+            }> = [];
+
+            for (const step of steps) {
+              const usage = step.usage as Record<string, unknown> | undefined;
+              if (!usage) continue;
+
+              const { inputTokens: sInput, outputTokens: sOutput } =
+                extractTokenCounts(usage);
+
+              const details = usage.inputTokenDetails as
+                | Record<string, unknown>
+                | undefined;
+              const outDetails = usage.outputTokenDetails as
+                | Record<string, unknown>
+                | undefined;
+
+              const sCacheRead = toNum(details?.cacheReadTokens);
+              const sCacheWrite = toNum(details?.cacheWriteTokens);
+              const sReasoning = toNum(outDetails?.reasoningTokens);
+
+              inputTokens += sInput;
+              outputTokens += sOutput;
+              cacheReadTokens += sCacheRead;
+              cacheWriteTokens += sCacheWrite;
+              reasoningTokens += sReasoning;
+
+              const stepModelId = (
+                step.response as Record<string, unknown> | undefined
+              )?.modelId as string | undefined;
+
+              stepDetails.push({
+                modelId: stepModelId || resolvedModelId,
+                inputTokens: sInput,
+                outputTokens: sOutput,
+                cacheReadTokens: sCacheRead,
+                cacheWriteTokens: sCacheWrite,
+                reasoningTokens: sReasoning,
+                costUsd: 0, // filled in by cost calculator
+              });
+            }
+
+            // Fallback to top-level usage if no steps produced usage data
+            if (stepDetails.length === 0) {
+              try {
+                const usage = (await result.usage) as unknown as Record<
+                  string,
+                  unknown
+                >;
+                const extracted = extractTokenCounts(usage ?? {});
+                inputTokens = extracted.inputTokens;
+                outputTokens = extracted.outputTokens;
+
+                const details = usage?.inputTokenDetails as
+                  | Record<string, unknown>
+                  | undefined;
+                const outDetails = usage?.outputTokenDetails as
+                  | Record<string, unknown>
+                  | undefined;
+                cacheReadTokens = toNum(details?.cacheReadTokens);
+                cacheWriteTokens = toNum(details?.cacheWriteTokens);
+                reasoningTokens = toNum(outDetails?.reasoningTokens);
+              } catch (err) {
+                logger.warn("Failed to get usage from model", { error: err });
+              }
+            }
+
+            const totalTokens = inputTokens + outputTokens;
+
+            logger.info(
+              isAborted
+                ? "Stream aborted, saving partial chat"
+                : "Stream finished, saving chat",
+              {
+                chatId,
+                isAborted,
+                messageCount: allMessages.length,
+                inputTokens,
+                outputTokens,
+                cacheReadTokens,
+                totalTokens,
+                durationMs,
+              },
+            );
+
+            // Compute cost before saving so both trackUsage and saveChat receive it
+            let costUsd: number | undefined;
+            try {
+              const costResult = await computeInvocationCost({
+                modelId: resolvedModelId,
+                inputTokens,
+                outputTokens,
+                cacheReadTokens,
+                cacheWriteTokens,
+                reasoningTokens,
+                steps: stepDetails,
+              });
+              costUsd = costResult.totalCostUsd;
+              if (costResult.steps) {
+                stepDetails = costResult.steps;
+              }
+            } catch (err) {
+              logger.warn("Failed to compute invocation cost", { error: err });
+            }
+
+            // Track usage (fire-and-forget)
+            void trackUsage({
+              workspaceId,
+              userId: actorId,
               chatId,
-              isAborted,
-              messageCount: allMessages.length,
-              inputTokens,
-              outputTokens,
-              cacheReadTokens,
-              totalTokens,
-              durationMs,
-            },
-          );
-
-          // Compute cost before saving so both trackUsage and saveChat receive it
-          let costUsd: number | undefined;
-          try {
-            const costResult = await computeInvocationCost({
+              invocationType: "chat",
               modelId: resolvedModelId,
               inputTokens,
               outputTokens,
               cacheReadTokens,
               cacheWriteTokens,
               reasoningTokens,
-              steps: stepDetails,
-            });
-            costUsd = costResult.totalCostUsd;
-            if (costResult.steps) {
-              stepDetails = costResult.steps;
-            }
-          } catch (err) {
-            logger.warn("Failed to compute invocation cost", { error: err });
-          }
-
-          // Track usage (fire-and-forget)
-          void trackUsage({
-            workspaceId,
-            userId: actorId,
-            chatId,
-            invocationType: "chat",
-            modelId: resolvedModelId,
-            inputTokens,
-            outputTokens,
-            cacheReadTokens,
-            cacheWriteTokens,
-            reasoningTokens,
-            totalTokens,
-            steps: stepDetails,
-            agentId: resolvedAgentId,
-            durationMs,
-            costUsd,
-          }).catch(err =>
-            logger.warn("Failed to track LLM usage", { error: err }),
-          );
-
-          try {
-            await saveChat(chatId, workspaceId, actorId, allMessages, {
-              promptTokens: inputTokens,
-              completionTokens: outputTokens,
               totalTokens,
-              cacheReadTokens,
-              cacheWriteTokens,
-              reasoningTokens,
+              steps: stepDetails,
+              agentId: resolvedAgentId,
+              durationMs,
               costUsd,
-              model: resolvedModelId,
-            });
-          } catch (error) {
-            logger.error("Error saving chat", { error });
-          }
+            }).catch(err =>
+              logger.warn("Failed to track LLM usage", { error: err }),
+            );
 
-          if (isDescriptionGenAvailable()) {
-            void (async () => {
-              try {
-                const consoleContexts =
-                  extractConsoleContextFromMessages(allMessages);
-                for (const [consoleId, ctx] of consoleContexts) {
-                  const console = await SavedConsole.findById(consoleId).select(
-                    "code name connectionId databaseName language",
-                  );
-                  if (!console) continue;
+            try {
+              await saveChat(chatId, workspaceId, actorId, allMessages, {
+                promptTokens: inputTokens,
+                completionTokens: outputTokens,
+                totalTokens,
+                cacheReadTokens,
+                cacheWriteTokens,
+                reasoningTokens,
+                costUsd,
+                model: resolvedModelId,
+              });
+            } catch (error) {
+              logger.error("Error saving chat", { error });
+            }
 
-                  const connDoc = console.connectionId
-                    ? await DatabaseConnection.findById(console.connectionId)
-                    : null;
+            if (isDescriptionGenAvailable()) {
+              void (async () => {
+                try {
+                  const consoleContexts =
+                    extractConsoleContextFromMessages(allMessages);
+                  for (const [consoleId, ctx] of consoleContexts) {
+                    const console = await SavedConsole.findById(
+                      consoleId,
+                    ).select("code name connectionId databaseName language");
+                    if (!console) continue;
 
-                  const { description, embedding, embeddingModel } =
-                    await generateDescriptionAndEmbedding(
-                      {
-                        code: console.code,
-                        title: console.name,
-                        connectionName: connDoc?.name,
-                        databaseType: connDoc?.type,
-                        databaseName: console.databaseName,
-                        language: console.language,
-                        conversationExcerpt: ctx.conversationExcerpt,
-                        resultSample: ctx.resultSample,
-                      },
-                      { workspaceId, userId: actorId, userEmail: actorEmail },
+                    const connDoc = console.connectionId
+                      ? await DatabaseConnection.findById(console.connectionId)
+                      : null;
+
+                    const { description, embedding, embeddingModel } =
+                      await generateDescriptionAndEmbedding(
+                        {
+                          code: console.code,
+                          title: console.name,
+                          connectionName: connDoc?.name,
+                          databaseType: connDoc?.type,
+                          databaseName: console.databaseName,
+                          language: console.language,
+                          conversationExcerpt: ctx.conversationExcerpt,
+                          resultSample: ctx.resultSample,
+                        },
+                        { workspaceId, userId: actorId, userEmail: actorEmail },
+                      );
+
+                    const $set: Record<string, any> = {
+                      descriptionGeneratedAt: new Date(),
+                    };
+                    if (description) $set.description = description;
+                    if (embedding) {
+                      $set.descriptionEmbedding = embedding;
+                      $set.embeddingModel = embeddingModel;
+                    }
+                    await SavedConsole.updateOne(
+                      { _id: new ObjectId(consoleId) },
+                      { $set },
                     );
-
-                  const $set: Record<string, any> = {
-                    descriptionGeneratedAt: new Date(),
-                  };
-                  if (description) $set.description = description;
-                  if (embedding) {
-                    $set.descriptionEmbedding = embedding;
-                    $set.embeddingModel = embeddingModel;
                   }
-                  await SavedConsole.updateOne(
-                    { _id: new ObjectId(consoleId) },
-                    { $set },
-                  );
+                } catch (err) {
+                  logger.error("Background description generation failed", {
+                    error: err,
+                  });
                 }
-              } catch (err) {
-                logger.error("Background description generation failed", {
-                  error: err,
-                });
-              }
-            })();
-          }
+              })();
+            }
+          });
         },
       });
     },

--- a/api/src/routes/chat-finalization-queue.test.ts
+++ b/api/src/routes/chat-finalization-queue.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import {
+  scheduleChatFinalization,
+  awaitChatFinalization,
+  getChatFinalizationChainCount,
+} from "./chat-finalization-queue";
+
+const delay = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+
+/**
+ * The load-bearing guarantee: scheduling finalization must NOT block the
+ * caller. The route schedules this inside `toUIMessageStreamResponse.onFinish`,
+ * and the AI SDK awaits that callback before closing the stream. Awaiting the
+ * task inline (the PR #424 / PR #440 regression) stalls every client-tool
+ * round-trip until the held-open stream times out.
+ */
+async function testReturnsBeforeTaskCompletes() {
+  let taskCompleted = false;
+  scheduleChatFinalization("chat-sync", async () => {
+    await delay(20);
+    taskCompleted = true;
+  });
+
+  // If scheduling awaited the task, this would already be true.
+  assert.equal(
+    taskCompleted,
+    false,
+    "scheduleChatFinalization must return before the task runs to completion",
+  );
+
+  await awaitChatFinalization("chat-sync");
+  assert.equal(taskCompleted, true, "task should eventually complete");
+}
+
+/** Per-chat tasks run in submission order even when the first is slower. */
+async function testSerializesPerChatInOrder() {
+  const order: number[] = [];
+  scheduleChatFinalization("chat-order", async () => {
+    await delay(25);
+    order.push(1);
+  });
+  scheduleChatFinalization("chat-order", async () => {
+    await delay(1);
+    order.push(2);
+  });
+
+  await awaitChatFinalization("chat-order");
+  assert.deepEqual(
+    order,
+    [1, 2],
+    "finalizations for one chat must apply in step order",
+  );
+}
+
+/** A failing task is isolated: it neither rejects to the caller nor breaks the chain. */
+async function testFailureIsolation() {
+  const ran: string[] = [];
+
+  assert.doesNotThrow(() => {
+    scheduleChatFinalization("chat-fail", async () => {
+      throw new Error("boom");
+    });
+  }, "a throwing task must not reject synchronously to the caller");
+
+  scheduleChatFinalization("chat-fail", async () => {
+    ran.push("after-failure");
+  });
+
+  await awaitChatFinalization("chat-fail");
+  assert.deepEqual(
+    ran,
+    ["after-failure"],
+    "a failed task must not prevent the next task from running",
+  );
+}
+
+/** The chain map must not leak an entry per chat after work settles. */
+async function testNoMapLeakAfterSettle() {
+  scheduleChatFinalization("chat-leak", async () => {
+    await delay(1);
+  });
+  await awaitChatFinalization("chat-leak");
+  // Allow the cleanup `finally` microtask to run.
+  await delay(0);
+
+  assert.equal(
+    getChatFinalizationChainCount(),
+    0,
+    "settled chats must be dropped from the finalization map",
+  );
+}
+
+async function main() {
+  await testReturnsBeforeTaskCompletes();
+  await testSerializesPerChatInOrder();
+  await testFailureIsolation();
+  await testNoMapLeakAfterSettle();
+}
+
+void main();

--- a/api/src/routes/chat-finalization-queue.ts
+++ b/api/src/routes/chat-finalization-queue.ts
@@ -1,0 +1,74 @@
+import { loggers } from "../logging";
+
+const logger = loggers.agent();
+
+/**
+ * Per-chat finalization queue.
+ *
+ * The AI SDK keeps the UI message stream open until the `onFinish` callback of
+ * `toUIMessageStreamResponse` resolves (it is awaited inside the stream's
+ * `flush()`). On the client, `useChat` only fires the tool-result auto-resume
+ * once that stream closes. So any slow work in `onFinish` (gateway pricing
+ * lookups, `saveChat`, etc.) is serialized *into the user-perceived latency* of
+ * every client-side tool round-trip — the assistant appears frozen even though
+ * the tool itself (e.g. an instant `modify_console` patch) resolved in
+ * milliseconds, and a stuck round-trip only unblocks when the held-open stream
+ * hits its proxy/HTTP timeout.
+ *
+ * To keep tool round-trips snappy we run finalization in the background instead
+ * of blocking stream close. We still serialize finalizations per chat so that
+ * the full-thread `$set` writes in `saveChat` always apply in step order (the
+ * blocking behavior previously guaranteed this for free).
+ *
+ * This regression has been re-introduced multiple times (PR #424, PR #440) by
+ * awaiting finalization inline again. `scheduleChatFinalization` MUST stay
+ * non-blocking — see `chat-finalization-queue.test.ts`.
+ */
+const chatFinalizationChains = new Map<string, Promise<void>>();
+
+/**
+ * Schedule post-stream finalization work for a chat WITHOUT blocking the caller.
+ *
+ * Returns synchronously (`void`). This is load-bearing: callers run inside the
+ * stream's `onFinish`, and awaiting here would stall every client-tool
+ * round-trip until the held-open stream times out. Keep it fire-and-forget.
+ */
+export function scheduleChatFinalization(
+  chatId: string,
+  task: () => Promise<void>,
+): void {
+  const previous = chatFinalizationChains.get(chatId) ?? Promise.resolve();
+  const next = previous
+    // Isolate this task from a prior task's failure so the chain keeps running.
+    .catch(() => {})
+    .then(task)
+    .catch(err =>
+      logger.error("Chat finalization failed", { chatId, error: err }),
+    );
+
+  chatFinalizationChains.set(chatId, next);
+
+  // Drop the map entry once this task is the tail and has settled, to avoid
+  // leaking one promise per chat for the lifetime of the process.
+  void next.finally(() => {
+    if (chatFinalizationChains.get(chatId) === next) {
+      chatFinalizationChains.delete(chatId);
+    }
+  });
+}
+
+/**
+ * Resolves when the currently-queued finalization work for `chatId` has
+ * settled. Intended for tests; resolves immediately if nothing is queued.
+ */
+export function awaitChatFinalization(chatId: string): Promise<void> {
+  return chatFinalizationChains.get(chatId) ?? Promise.resolve();
+}
+
+/**
+ * Number of chats with in-flight finalization chains. Intended for tests to
+ * assert the map does not leak entries after work settles.
+ */
+export function getChatFinalizationChainCount(): number {
+  return chatFinalizationChains.size;
+}


### PR DESCRIPTION
## Summary

Re-lands the **server-side half of PR #424** (`ea4d89de`, "don't block chat stream close on post-stream finalization"), which was lost and never merged to `master`.

`onFinish` in `result.toUIMessageStreamResponse({...})` ran all finalization **inline and awaited** — `result.steps`/`result.usage` aggregation, `computeInvocationCost` (gateway pricing), `saveChat` (full-thread Mongo write), and console description/embedding generation. The AI SDK awaits `onFinish` inside the stream's `flush()`, and on the client `useChat` only fires the tool-result auto-resume **once that stream closes**. So every client-side tool round-trip was serialized behind the full finalization:

- an instant client tool (e.g. a `modify_console` patch that settles in ~10ms) appeared **frozen**, and
- a stuck round-trip only unblocked when the held-open stream hit its proxy/HTTP timeout (**~120s**).

This moves finalization into a background, **per-chat-serialized** queue (`scheduleChatFinalization`) so `onFinish` returns synchronously and the stream closes immediately. Per-chat serialization preserves `saveChat`'s in-order full-thread writes.

### Evidence (Langfuse session `6a2820bd225ec01886d2b7ac`)
A single user message produced 5 `agent-chat` traces with **two ~127s gaps** (126.85s / 126.998s) between turns. The hung round-trips were gated by instant client tools (`modify_console` patch, `read_console`), which return in ms — confirming the delay was the stream not closing, not tool work or a DB query.

## How the fix was lost
On the PR #424 branch (`cursor/fix-client-tool-stream-resume-d3db`), the client and server fixes were **siblings off the old base** `fa19c3e2`, not a linear chain:

- `fa19c3e2` (base) → `3d68d816` → `00f846ed` (Chat.tsx) ← **merged tip**
- `fa19c3e2` (base) → `ea4d89de` (agent.routes.ts) ← **dangled, never on the branch ref**

`ea4d89de` was committed onto the stale base instead of the branch tip, so it was orphaned. The merge commit (`84235681`) only brought in the two `Chat.tsx` commits. Effectively a rebase/HEAD-management mistake during the agent's work on that branch.

## Test plan
- [x] `pnpm --filter api run lint` — clean
- [x] `tsc -p api/tsconfig.build.json --noEmit` — clean
- [ ] Manual: run a chat that calls an instant client tool (e.g. `modify_console` patch); verify the next turn auto-resumes immediately instead of hanging ~120s.
- [ ] Verify chat persistence, usage/cost tracking, and console description generation still occur (now in background).

## Follow-ups (not in this PR)
- PR #440 (`3b56fb6f`, dashboard-tool-stream-hang) is also missing from `master`.
- Optional: a uniform client-side watchdog over registered fire-and-forget client tools (only `run_console` has one today).

Made with [Cursor](https://cursor.com)