### PR TITLE
fix: Fable 5 thinking-mode 400 + self-healing capability probe

### DIFF
--- a/api/src/agent-lib/anthropic-thinking.test.ts
+++ b/api/src/agent-lib/anthropic-thinking.test.ts
@@ -93,6 +93,12 @@ t("mythos preview → adaptive", () => {
     "adaptive",
   );
 });
+t("fable-preview codename → adaptive", () => {
+  assert.equal(
+    resolveAnthropicThinkingMode("anthropic/claude-fable-preview", true),
+    "adaptive",
+  );
+});
 t("uncatalogued sonnet-4.0 → manual", () => {
   assert.equal(
     resolveAnthropicThinkingMode("anthropic/claude-sonnet-4.0", true),

--- a/api/src/agent-lib/anthropic-thinking.test.ts
+++ b/api/src/agent-lib/anthropic-thinking.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import {
   buildAnthropicThinkingConfig,
+  hasExplicitThinkingMode,
   resolveAnthropicThinkingMode,
+  thinkingErrorRequiresAdaptive,
 } from "./anthropic-thinking";
 
 function t(label: string, fn: () => void) {
@@ -14,6 +16,18 @@ function t(label: string, fn: () => void) {
 // resolve to the documented mode regardless of the version-regex fallback.
 // https://vercel.com/docs/ai-gateway/capabilities/reasoning/anthropic
 
+t("fable-5 (explicit) → adaptive", () => {
+  assert.equal(
+    resolveAnthropicThinkingMode("anthropic/claude-fable-5", true),
+    "adaptive",
+  );
+});
+t("opus-4.8 (explicit) → adaptive", () => {
+  assert.equal(
+    resolveAnthropicThinkingMode("anthropic/claude-opus-4.8", true),
+    "adaptive",
+  );
+});
 t("opus-4.7 (explicit) → adaptive", () => {
   assert.equal(
     resolveAnthropicThinkingMode("anthropic/claude-opus-4.7", true),
@@ -120,4 +134,55 @@ t("buildAnthropicThinkingConfig manual payload carries budgetTokens", () => {
 });
 t("buildAnthropicThinkingConfig none returns null", () => {
   assert.equal(buildAnthropicThinkingConfig("none", 10000), null);
+});
+
+// --- Unknown-Claude default flipped to adaptive ---------------------------
+// New Anthropic models have dropped the family-major.minor naming pattern
+// (claude-fable-5 was the first), so they never match the version regex.
+// Since every Claude model released since 4.6 is adaptive and `enabled` is
+// the deprecated path, the safe default for unmatched Claude IDs is adaptive.
+// All pre-4.6 manual models are pinned in EXPLICIT_MODES.
+
+t("unknown-naming claude model → adaptive (default flipped)", () => {
+  assert.equal(
+    resolveAnthropicThinkingMode("anthropic/claude-saga-6", true),
+    "adaptive",
+  );
+});
+t("fable is pinned explicitly", () => {
+  assert.equal(hasExplicitThinkingMode("anthropic/claude-fable-5"), true);
+});
+t("hypothetical future model is not pinned (probe candidate)", () => {
+  assert.equal(hasExplicitThinkingMode("anthropic/claude-saga-6"), false);
+});
+
+// --- Adaptive-only error predicate ----------------------------------------
+
+const ADAPTIVE_400 =
+  '"thinking.type.enabled" is not supported for this model. ' +
+  'Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.';
+
+t("detects adaptive-only 400 in message", () => {
+  assert.equal(thinkingErrorRequiresAdaptive(new Error(ADAPTIVE_400)), true);
+});
+t("detects adaptive-only 400 nested in cause", () => {
+  const err = new Error("Request failed", {
+    cause: new Error(ADAPTIVE_400),
+  });
+  assert.equal(thinkingErrorRequiresAdaptive(err), true);
+});
+t("detects adaptive-only 400 in AggregateError-style errors array", () => {
+  const err = new Error("fanout failed") as Error & { errors: unknown[] };
+  err.errors = [new Error("unrelated"), new Error(ADAPTIVE_400)];
+  assert.equal(thinkingErrorRequiresAdaptive(err), true);
+});
+t("ignores unrelated errors", () => {
+  assert.equal(
+    thinkingErrorRequiresAdaptive(new Error("rate limit exceeded")),
+    false,
+  );
+});
+t("handles non-Error values", () => {
+  assert.equal(thinkingErrorRequiresAdaptive(ADAPTIVE_400), true);
+  assert.equal(thinkingErrorRequiresAdaptive(null), false);
 });

--- a/api/src/agent-lib/anthropic-thinking.ts
+++ b/api/src/agent-lib/anthropic-thinking.ts
@@ -15,9 +15,13 @@
  *     ("thinking.type.enabled is not supported for this model")
  *   - manual  payload against 4.6             → accepted today but deprecated
  *
- * We keep the mapping in one place, keyed off documented model IDs, with a
- * version-range fallback so future Claude releases that follow the pattern
- * (4.8, 5.x, …) work without a code change.
+ * This static map is the FIRST layer of a three-layer resolution:
+ *   1. probed capabilities persisted in the model catalog (authoritative,
+ *      written by the catalog-refresh probe and the runtime self-heal —
+ *      see model-catalog.service.ts and thinking-self-heal.ts)
+ *   2. this explicit map (documented model IDs)
+ *   3. the version-regex fallback below, defaulting to adaptive for any
+ *      uncatalogued Claude model
  */
 
 export type AnthropicThinkingMode = "adaptive" | "manual" | "none";
@@ -27,6 +31,8 @@ export type AnthropicThinkingMode = "adaptive" | "manual" | "none";
 // a fallback for models we haven't catalogued yet.
 const EXPLICIT_MODES: Record<string, AnthropicThinkingMode> = {
   // Adaptive — Claude 4.6+ (manual deprecated on 4.6, rejected on 4.7+)
+  "anthropic/claude-fable-5": "adaptive",
+  "anthropic/claude-opus-4.8": "adaptive",
   "anthropic/claude-opus-4.7": "adaptive",
   "anthropic/claude-opus-4.6": "adaptive",
   "anthropic/claude-sonnet-4.6": "adaptive",
@@ -39,10 +45,15 @@ const EXPLICIT_MODES: Record<string, AnthropicThinkingMode> = {
   "anthropic/claude-haiku-4.5": "manual",
 };
 
+/** Whether the mode for this model ID is pinned in the explicit map. */
+export function hasExplicitThinkingMode(modelId: string): boolean {
+  return modelId in EXPLICIT_MODES;
+}
+
 /**
  * Resolve the thinking mode for a given model + capability tags.
  *
- *   modelId:       the gateway ID, e.g. "anthropic/claude-opus-4.7"
+ *   modelId:          the gateway ID, e.g. "anthropic/claude-opus-4.7"
  *   supportsThinking: whether the gateway tagged the model with "reasoning"
  */
 export function resolveAnthropicThinkingMode(
@@ -73,8 +84,16 @@ export function resolveAnthropicThinkingMode(
     if (major > 4 || (major === 4 && minor >= 6)) return "adaptive";
     return "manual";
   }
-  // Unknown Claude model with reasoning tag: conservative default.
-  return "manual";
+  // Unknown Claude model with a reasoning tag: default to ADAPTIVE.
+  //
+  // This used to default to "manual" as the conservative choice, which
+  // became backwards once Anthropic deprecated `thinking.type.enabled`:
+  // every Claude model released since 4.6 is adaptive, and new models have
+  // dropped the family-major.minor naming entirely (e.g. claude-fable-5),
+  // so they never match the regex above. All pre-4.6 manual models are
+  // pinned in EXPLICIT_MODES. If this default is ever wrong, the catalog
+  // probe and the runtime self-heal correct and persist the real mode.
+  return "adaptive";
 }
 
 /**
@@ -94,4 +113,32 @@ export function buildAnthropicThinkingConfig(
     return { type: "enabled", budgetTokens };
   }
   return null;
+}
+
+/**
+ * Whether an error (possibly nested in `cause` / AggregateError `errors`)
+ * is the Anthropic 400 telling us the model only accepts adaptive thinking:
+ *   '"thinking.type.enabled" is not supported for this model. Use
+ *    "thinking.type.adaptive" and "output_config.effort" ...'
+ */
+export function thinkingErrorRequiresAdaptive(error: unknown): boolean {
+  return errorIncludes(error, '"thinking.type.enabled" is not supported');
+}
+
+function errorIncludes(error: unknown, needle: string): boolean {
+  if (error instanceof Error) {
+    if (error.message.includes(needle) || String(error).includes(needle)) {
+      return true;
+    }
+    const cause = (error as { cause?: unknown }).cause;
+    if (cause && errorIncludes(cause, needle)) {
+      return true;
+    }
+    const nested = (error as { errors?: unknown }).errors;
+    if (Array.isArray(nested)) {
+      return nested.some(item => errorIncludes(item, needle));
+    }
+    return false;
+  }
+  return String(error).includes(needle);
 }

--- a/api/src/agent-lib/anthropic-thinking.ts
+++ b/api/src/agent-lib/anthropic-thinking.ts
@@ -65,7 +65,6 @@ export function resolveAnthropicThinkingMode(
   if (explicit) return explicit;
 
   const lower = modelId.toLowerCase();
-  if (lower.includes("mythos")) return "adaptive";
   if (!lower.includes("claude")) return "manual";
 
   // Fallback for uncatalogued Claude models. Vercel AI Gateway uses dot

--- a/api/src/agent-lib/thinking-self-heal.ts
+++ b/api/src/agent-lib/thinking-self-heal.ts
@@ -1,0 +1,96 @@
+/**
+ * Runtime self-heal for Anthropic thinking-mode misclassification.
+ *
+ * Safety net behind the catalog probe (model-catalog.service.ts): if a
+ * request still goes out with the manual `{type: "enabled", budgetTokens}`
+ * payload against an adaptive-only model, Anthropic rejects it with
+ *
+ *   '"thinking.type.enabled" is not supported for this model. Use
+ *    "thinking.type.adaptive" and "output_config.effort" ...'
+ *
+ * This middleware catches exactly that error, persists the corrected mode to
+ * the catalog capabilities snapshot (so every later request — and every other
+ * API instance after cache expiry — is right from the start), and retries the
+ * in-flight call once with the adaptive payload. The user never sees the 400.
+ */
+
+import {
+  wrapLanguageModel,
+  type LanguageModel,
+  type LanguageModelMiddleware,
+} from "ai";
+import { thinkingErrorRequiresAdaptive } from "./anthropic-thinking";
+import { saveProbedThinkingMode } from "../services/model-catalog.service";
+import { loggers } from "../logging";
+
+const logger = loggers.app();
+
+function withAdaptiveThinking<
+  T extends { providerOptions?: Record<string, Record<string, unknown>> },
+>(params: T): T {
+  const providerOptions = {
+    ...(params.providerOptions ?? {}),
+    anthropic: {
+      ...(params.providerOptions?.anthropic ?? {}),
+      thinking: { type: "adaptive", display: "summarized" },
+    },
+  };
+  return { ...params, providerOptions } as T;
+}
+
+/**
+ * Wrap a gateway model so that an adaptive-only 400 triggers persist + retry.
+ * Only meaningful for Anthropic models requested with a manual thinking
+ * payload; for everything else the middleware is a transparent pass-through
+ * (the error predicate never matches).
+ */
+export function withThinkingSelfHeal(
+  model: LanguageModel,
+  modelId: string,
+): LanguageModel {
+  const heal = async (error: unknown): Promise<boolean> => {
+    if (!thinkingErrorRequiresAdaptive(error)) return false;
+    logger.warn(
+      "Model rejected manual thinking payload; self-healing to adaptive",
+      { modelId },
+    );
+    try {
+      await saveProbedThinkingMode(modelId, "adaptive");
+    } catch (err) {
+      // Persisting is best-effort; still retry the in-flight call.
+      logger.error("Failed to persist self-healed thinking mode", {
+        modelId,
+        error: String(err),
+      });
+    }
+    return true;
+  };
+
+  const middleware: LanguageModelMiddleware = {
+    specificationVersion: "v3",
+    wrapGenerate: async ({ doGenerate, params, model: inner }) => {
+      try {
+        return await doGenerate();
+      } catch (error) {
+        if (!(await heal(error))) throw error;
+        return inner.doGenerate(withAdaptiveThinking(params));
+      }
+    },
+    wrapStream: async ({ doStream, params, model: inner }) => {
+      try {
+        // The adaptive-only rejection is a request-time 400: doStream()
+        // rejects before the first chunk, so a whole-call retry is safe
+        // (no partial output has been emitted).
+        return await doStream();
+      } catch (error) {
+        if (!(await heal(error))) throw error;
+        return inner.doStream(withAdaptiveThinking(params));
+      }
+    },
+  };
+
+  return wrapLanguageModel({
+    model: model as Parameters<typeof wrapLanguageModel>[0]["model"],
+    middleware,
+  }) as unknown as LanguageModel;
+}

--- a/api/src/database/schema.ts
+++ b/api/src/database/schema.ts
@@ -386,11 +386,15 @@ export const LlmUsage =
 // ---------------------------------------------------------------------------
 
 export interface IModelCatalogSnapshot extends Document {
-  _id: "gateway" | "arena" | "pricing" | "curation";
+  _id: "gateway" | "arena" | "pricing" | "curation" | "capabilities";
   /**
    * Free-form payload keyed by snapshot id:
    *  - gateway / pricing → array of normalized upstream records
    *  - curation          → `{ models, defaultChatModelId, defaultFreeChatModelId, lastRefreshError }`
+   *  - capabilities      → `{ thinkingModes: { [modelId]: "adaptive" | "manual" } }`
+   *                        probed overrides for Anthropic extended thinking,
+   *                        written by the catalog-refresh probe and the
+   *                        runtime self-heal (see anthropic-thinking.ts)
    *  - arena             → legacy, removed by the 2026-04-23 migration
    */
   data: any;
@@ -404,7 +408,7 @@ const ModelCatalogSnapshotSchema = new Schema(
     // the seed migration deletes them.
     _id: {
       type: String,
-      enum: ["gateway", "arena", "pricing", "curation"],
+      enum: ["gateway", "arena", "pricing", "curation", "capabilities"],
     },
     data: { type: Schema.Types.Mixed, default: [] },
     fetchedAt: { type: Date, required: true },

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -15,6 +15,7 @@ import {
 import { getModel, buildProviderOptions } from "../agent-lib/ai-gateway";
 import { propagateAttributes } from "@langfuse/tracing";
 import { buildAnthropicThinkingConfig } from "../agent-lib/anthropic-thinking";
+import { withThinkingSelfHeal } from "../agent-lib/thinking-self-heal";
 import { unifiedAuthMiddleware } from "../auth/unified-auth.middleware";
 import { AuthenticatedContext } from "../middleware/workspace.middleware";
 import { workspaceService } from "../services/workspace.service";
@@ -685,8 +686,13 @@ agentRoutes.post("/chat", async (c: AuthenticatedContext) => {
   const agentConfig = agentFactory(agentContext);
   const { systemPrompt, tools } = agentConfig;
 
-  const model = getModel(resolvedModelId);
   const modelDef = await getModelById(resolvedModelId);
+  // Self-heal wrapper: if the catalog still classifies this model as manual
+  // thinking but Anthropic rejects the payload with the adaptive-only 400,
+  // persist the corrected mode and retry the call transparently.
+  const model = resolvedModelId.startsWith("anthropic/")
+    ? withThinkingSelfHeal(getModel(resolvedModelId), resolvedModelId)
+    : getModel(resolvedModelId);
   logger.info("Using model", { model: resolvedModelId });
 
   // Resolve object-storage-backed image attachments (from reopened chats) back

--- a/api/src/services/model-catalog.service.ts
+++ b/api/src/services/model-catalog.service.ts
@@ -19,7 +19,9 @@ import { z } from "zod";
 import { loggers } from "../logging";
 import { ModelCatalogSnapshot } from "../database/schema";
 import {
+  hasExplicitThinkingMode,
   resolveAnthropicThinkingMode,
+  thinkingErrorRequiresAdaptive,
   type AnthropicThinkingMode,
 } from "../agent-lib/anthropic-thinking";
 
@@ -167,6 +169,122 @@ interface PricingEntry {
 }
 
 // ---------------------------------------------------------------------------
+// Probed thinking-mode capabilities (snapshot doc `_id: "capabilities"`)
+//
+// The static map in anthropic-thinking.ts can't know about models whose IDs
+// don't follow the family-major.minor pattern (e.g. claude-fable-5). For
+// those we PROBE: issue a tiny generateText with the manual payload and see
+// whether Anthropic rejects it with the "use thinking.type.adaptive" 400.
+// Results are persisted here and take precedence over the static resolver.
+// Written by probeAnthropicThinkingModes() (catalog refresh) and
+// saveProbedThinkingMode() (runtime self-heal, see thinking-self-heal.ts).
+// ---------------------------------------------------------------------------
+
+type ProbedThinkingModes = Record<
+  string,
+  Exclude<AnthropicThinkingMode, "none">
+>;
+
+async function loadProbedThinkingModes(): Promise<ProbedThinkingModes> {
+  const doc = await ModelCatalogSnapshot.findOne({
+    _id: "capabilities",
+  }).lean();
+  const data = doc?.data as { thinkingModes?: unknown } | undefined;
+  const raw = data?.thinkingModes;
+  if (!raw || typeof raw !== "object") return {};
+  const out: ProbedThinkingModes = {};
+  for (const [modelId, mode] of Object.entries(
+    raw as Record<string, unknown>,
+  )) {
+    if (mode === "adaptive" || mode === "manual") out[modelId] = mode;
+  }
+  return out;
+}
+
+export async function saveProbedThinkingMode(
+  modelId: string,
+  mode: Exclude<AnthropicThinkingMode, "none">,
+): Promise<void> {
+  const existing = await loadProbedThinkingModes();
+  if (existing[modelId] === mode) return;
+  const thinkingModes = { ...existing, [modelId]: mode };
+  await ModelCatalogSnapshot.findOneAndUpdate(
+    { _id: "capabilities" },
+    {
+      data: { thinkingModes },
+      fetchedAt: new Date(),
+      itemCount: Object.keys(thinkingModes).length,
+    },
+    { upsert: true },
+  );
+  invalidateCatalog();
+  logger.info("Persisted probed thinking mode", { modelId, mode });
+}
+
+async function probeThinkingMode(
+  modelId: string,
+): Promise<Exclude<AnthropicThinkingMode, "none"> | null> {
+  const [{ generateText }, { getModel }] = await Promise.all([
+    import("ai"),
+    import("../agent-lib/ai-gateway"),
+  ]);
+  try {
+    await generateText({
+      model: getModel(modelId),
+      prompt: "ok",
+      providerOptions: {
+        anthropic: { thinking: { type: "enabled", budgetTokens: 1024 } },
+      },
+      maxOutputTokens: 2048,
+    });
+    return "manual";
+  } catch (error) {
+    if (thinkingErrorRequiresAdaptive(error)) return "adaptive";
+    logger.warn("Thinking-mode probe inconclusive", {
+      modelId,
+      error: String(error),
+    });
+    return null;
+  }
+}
+
+/**
+ * Probe Anthropic reasoning models whose thinking mode is neither pinned in
+ * the explicit map nor already probed. Runs after each gateway snapshot
+ * refresh; new models are classified once, before any user request can hit
+ * them with the wrong payload. Probe failures are logged, never thrown —
+ * the runtime self-heal is the safety net.
+ */
+async function probeAnthropicThinkingModes(
+  gatewayDocs: GatewayModelNormalized[],
+): Promise<number> {
+  const probed = await loadProbedThinkingModes();
+  const candidates = gatewayDocs.filter(
+    gm =>
+      gm.id.startsWith("anthropic/") &&
+      gm.tags.includes("reasoning") &&
+      !hasExplicitThinkingMode(gm.id) &&
+      probed[gm.id] === undefined,
+  );
+  let classified = 0;
+  for (const gm of candidates) {
+    try {
+      const mode = await probeThinkingMode(gm.id);
+      if (mode) {
+        await saveProbedThinkingMode(gm.id, mode);
+        classified += 1;
+      }
+    } catch (err) {
+      logger.warn("Thinking-mode probe failed", {
+        modelId: gm.id,
+        error: String(err),
+      });
+    }
+  }
+  return classified;
+}
+
+// ---------------------------------------------------------------------------
 // Snapshot refresh: Gateway (models + pricing)
 // ---------------------------------------------------------------------------
 
@@ -240,6 +358,17 @@ export async function refreshGatewaySnapshot(): Promise<
     models: gatewayDocs.length,
     pricedModels: pricingDocs.length,
   });
+
+  try {
+    const classified = await probeAnthropicThinkingModes(gatewayDocs);
+    if (classified > 0) {
+      logger.info("Probed thinking modes for new Anthropic models", {
+        classified,
+      });
+    }
+  } catch (err) {
+    logger.warn("Thinking-mode probing skipped", { error: String(err) });
+  }
 
   return { models: gatewayDocs.length, pricedModels: pricingDocs.length };
 }
@@ -389,6 +518,7 @@ function mergeCatalog(
   gateway: GatewayModelNormalized[],
   pricing: PricingEntry[],
   curation: CurationDoc,
+  probedModes: ProbedThinkingModes = {},
 ): {
   models: CatalogModel[];
   freeTierIds: Set<string>;
@@ -417,7 +547,12 @@ function mergeCatalog(
     if (!cur || cur.visible === false) continue;
 
     const supportsThinking = gm.tags.includes("reasoning");
-    const thinkingMode = resolveAnthropicThinkingMode(gm.id, supportsThinking);
+    // Probed capabilities (catalog refresh / runtime self-heal) take
+    // precedence over the static resolver heuristic.
+    const thinkingMode: AnthropicThinkingMode = !supportsThinking
+      ? "none"
+      : (probedModes[gm.id] ??
+        resolveAnthropicThinkingMode(gm.id, supportsThinking));
     const p = pricingMap.get(gm.id);
     const blendedCostPerM = p ? (p.input + p.output) / 2 : null;
     const tier = cur.tier;
@@ -463,13 +598,27 @@ async function loadFromDb(): Promise<{
   };
 } | null> {
   const docs = await ModelCatalogSnapshot.find({
-    _id: { $in: ["gateway", "pricing", "curation"] },
+    _id: { $in: ["gateway", "pricing", "curation", "capabilities"] },
   }).lean();
   if (docs.length === 0) return null;
 
   const gatewayDoc = docs.find(d => d._id === "gateway");
   const pricingDoc = docs.find(d => d._id === "pricing");
   const curationDoc = docs.find(d => d._id === "curation");
+  const capabilitiesDoc = docs.find(d => d._id === "capabilities");
+
+  const probedModes: ProbedThinkingModes = {};
+  const rawModes = (capabilitiesDoc?.data as { thinkingModes?: unknown })
+    ?.thinkingModes;
+  if (rawModes && typeof rawModes === "object") {
+    for (const [modelId, mode] of Object.entries(
+      rawModes as Record<string, unknown>,
+    )) {
+      if (mode === "adaptive" || mode === "manual") {
+        probedModes[modelId] = mode;
+      }
+    }
+  }
 
   if (!gatewayDoc || !gatewayDoc.data || gatewayDoc.data.length === 0) {
     return null;
@@ -491,7 +640,7 @@ async function loadFromDb(): Promise<{
       }
     : { ...EMPTY_CURATION };
 
-  return mergeCatalog(gateway, pricing, curation);
+  return mergeCatalog(gateway, pricing, curation, probedModes);
 }
 
 async function ensureCatalog(): Promise<void> {


### PR DESCRIPTION
## Problem

`anthropic/claude-fable-5` fails in Mako with:

> "thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.

Root cause: the thinking-mode resolver in `anthropic-thinking.ts` is a naming-scheme heuristic (explicit map → `claude-(opus|sonnet|haiku)-X.Y` regex → conservative `manual` default). Fable dropped the family-major.minor naming entirely, so it falls through to `manual`, which builds the deprecated `{type: "enabled", budgetTokens}` payload and Anthropic 400s. Same failure class as the Opus 4.8 incident (May 29).

## Fix (both layers)

**1. Minimal patch**
- Pin `claude-fable-5` and `claude-opus-4.8` as `adaptive` in `EXPLICIT_MODES`
- Flip the unknown-Claude fallback from `manual` to `adaptive` — the conservative default is backwards now: every Claude model since 4.6 is adaptive and `enabled` is the deprecated path. All pre-4.6 manual models are pinned explicitly.

**2. Probed capabilities** (ported from AuraHQ-ai/aura#1051, which is why Aura survived the Fable upgrade without incident)
- New `capabilities` snapshot doc in `model_catalog` storing probed thinking modes
- Catalog refresh probes any Anthropic reasoning model not in the explicit map (tiny manual-payload request; adaptive-only 400 → persist `adaptive`)
- Probed modes take precedence over the static resolver in `mergeCatalog`
- Runtime self-heal (`thinking-self-heal.ts`): `wrapLanguageModel` middleware on `/chat` for Anthropic models — catches the adaptive-only 400 (incl. nested in `cause`/`errors`), persists the corrected mode, retries the in-flight call once with the adaptive payload. Safe for streams: the 400 is request-time, `doStream()` rejects before the first chunk.

Resolution order: probed capabilities → explicit map → regex → adaptive default.

## Testing
- `anthropic-thinking.test.ts` extended: fable/opus-4.8 explicit pins, flipped fallback, error-predicate detection (message, `cause`, AggregateError) — all green
- `tsc --noEmit` clean
- No migration needed: `capabilities` doc is created lazily on first probe/self-heal (Mongoose `Mixed` payload, `_id` enum extended)

---

## Consolidation note (post-comparison)

Three parallel Cursor agents were launched against the same bug. Two produced fix branches (`cursor/fix-fable-5-adaptive-thinking-ad6a`, `cursor/fix-fable-adaptive-thinking-c889`); the third recent cursor branch (`cursor/posthog-style-plan-mode-dcfa`) is unrelated (plan-mode UI, PR #465). Neither fix branch opened a PR; both only implemented the minimal resolver patch (no probe / self-heal).

Cherry-picked into this PR:
- **from ad6a**: removal of the hardcoded `mythos` special case — subsumed by the flipped adaptive default for unknown Claude codenames
- **from c889**: `claude-fable-preview` test case

Everything else here (explicit pins, flipped fallback, capabilities probe at catalog refresh, runtime self-heal middleware, nested-error predicate) was already on this branch.
