### PR TITLE
Add Postgres column introspection to database explorer sidebar

### DIFF
--- a/api/src/databases/drivers/cloudsql-postgres/driver.ts
+++ b/api/src/databases/drivers/cloudsql-postgres/driver.ts
@@ -16,7 +16,7 @@ import {
   normalizePostgresFields,
   normalizePostgresRows,
 } from "../postgresql/pg-type-utils";
-import { listPostgresTableColumns } from "../postgresql/introspection";
+import { listPostgresTableLevelChildren } from "../postgresql/introspection";
 
 const logger = loggers.db("cloudsql-postgres");
 
@@ -131,8 +131,12 @@ export class CloudSQLPostgresDatabaseDriver implements DatabaseDriver {
       return this.listSchemas(database, dbName);
     }
 
-    if (parent.kind === "table" || parent.kind === "view") {
-      return listPostgresTableColumns(
+    if (
+      parent.kind === "table" ||
+      parent.kind === "view" ||
+      parent.kind === "group"
+    ) {
+      return listPostgresTableLevelChildren(
         (query, options) => this.executeQuery(database, query, options),
         parent,
       );

--- a/api/src/databases/drivers/cloudsql-postgres/driver.ts
+++ b/api/src/databases/drivers/cloudsql-postgres/driver.ts
@@ -16,6 +16,7 @@ import {
   normalizePostgresFields,
   normalizePostgresRows,
 } from "../postgresql/pg-type-utils";
+import { listPostgresTableColumns } from "../postgresql/introspection";
 
 const logger = loggers.db("cloudsql-postgres");
 
@@ -130,6 +131,13 @@ export class CloudSQLPostgresDatabaseDriver implements DatabaseDriver {
       return this.listSchemas(database, dbName);
     }
 
+    if (parent.kind === "table" || parent.kind === "view") {
+      return listPostgresTableColumns(
+        (query, options) => this.executeQuery(database, query, options),
+        parent,
+      );
+    }
+
     if (parent.kind !== "schema") return [];
 
     const schema = parent.metadata?.schema || parent.id;
@@ -149,7 +157,7 @@ export class CloudSQLPostgresDatabaseDriver implements DatabaseDriver {
       id: `${dbName ? dbName + "." : ""}${schema}.${r.table_name}`,
       label: r.table_name,
       kind: r.table_type === "VIEW" ? "view" : "table",
-      hasChildren: false,
+      hasChildren: true,
       metadata: {
         schema,
         table: r.table_name,

--- a/api/src/databases/drivers/postgresql/driver.ts
+++ b/api/src/databases/drivers/postgresql/driver.ts
@@ -15,7 +15,7 @@ import {
   mapPostgresOidToType,
   stripTrailingSqlSemicolon,
 } from "./pg-type-utils";
-import { listPostgresTableColumns } from "./introspection";
+import { listPostgresTableLevelChildren } from "./introspection";
 
 const logger = loggers.db("postgresql");
 
@@ -172,8 +172,15 @@ export class PostgreSQLDatabaseDriver implements DatabaseDriver {
       return this.listSchemas(database, dbName);
     }
 
-    if (parent.kind === "table" || parent.kind === "view") {
-      return this.listColumns(database, parent);
+    if (
+      parent.kind === "table" ||
+      parent.kind === "view" ||
+      parent.kind === "group"
+    ) {
+      return listPostgresTableLevelChildren(
+        (query, options) => this.executeQuery(database, query, options),
+        parent,
+      );
     }
 
     if (parent.kind !== "schema") return [];
@@ -203,20 +210,6 @@ export class PostgreSQLDatabaseDriver implements DatabaseDriver {
         databaseName: dbName,
       },
     }));
-  }
-
-  /**
-   * List the columns of a table or view as tree leaf nodes, including data
-   * type, nullability, and primary-key membership.
-   */
-  private async listColumns(
-    database: IDatabaseConnection,
-    parent: { kind: string; id: string; metadata?: any },
-  ): Promise<DatabaseTreeNode[]> {
-    return listPostgresTableColumns(
-      (query, options) => this.executeQuery(database, query, options),
-      parent,
-    );
   }
 
   async getAutocompleteData(

--- a/api/src/databases/drivers/postgresql/driver.ts
+++ b/api/src/databases/drivers/postgresql/driver.ts
@@ -171,6 +171,10 @@ export class PostgreSQLDatabaseDriver implements DatabaseDriver {
       return this.listSchemas(database, dbName);
     }
 
+    if (parent.kind === "table" || parent.kind === "view") {
+      return this.listColumns(database, parent);
+    }
+
     if (parent.kind !== "schema") return [];
 
     const schema = parent.metadata?.schema || parent.id;
@@ -190,7 +194,7 @@ export class PostgreSQLDatabaseDriver implements DatabaseDriver {
       id: `${dbName ? dbName + "." : ""}${schema}.${r.table_name}`,
       label: r.table_name,
       kind: r.table_type === "VIEW" ? "view" : "table",
-      hasChildren: false,
+      hasChildren: true,
       metadata: {
         schema,
         table: r.table_name,
@@ -198,6 +202,90 @@ export class PostgreSQLDatabaseDriver implements DatabaseDriver {
         databaseName: dbName,
       },
     }));
+  }
+
+  /**
+   * List the columns of a table or view as tree leaf nodes, including data
+   * type, nullability, and primary-key membership.
+   */
+  private async listColumns(
+    database: IDatabaseConnection,
+    parent: { kind: string; id: string; metadata?: any },
+  ): Promise<DatabaseTreeNode[]> {
+    const schema = parent.metadata?.schema;
+    const table = parent.metadata?.table;
+    if (!schema || !table) return [];
+
+    const dbName = parent.metadata?.databaseName || parent.metadata?.databaseId;
+    const safeSchema = String(schema).replace(/'/g, "''");
+    const safeTable = String(table).replace(/'/g, "''");
+
+    const result = await this.executeQuery(
+      database,
+      `SELECT
+         c.column_name,
+         c.data_type,
+         c.udt_name,
+         c.is_nullable,
+         (pk.column_name IS NOT NULL) AS is_primary_key
+       FROM information_schema.columns c
+       LEFT JOIN (
+         SELECT kcu.column_name
+         FROM information_schema.table_constraints tc
+         JOIN information_schema.key_column_usage kcu
+           ON kcu.constraint_name = tc.constraint_name
+          AND kcu.table_schema = tc.table_schema
+          AND kcu.table_name = tc.table_name
+         WHERE tc.constraint_type = 'PRIMARY KEY'
+           AND tc.table_schema = '${safeSchema}'
+           AND tc.table_name = '${safeTable}'
+       ) pk ON pk.column_name = c.column_name
+       WHERE c.table_schema = '${safeSchema}'
+         AND c.table_name = '${safeTable}'
+       ORDER BY c.ordinal_position;`,
+      { databaseName: dbName },
+    );
+
+    if (!result.success || !result.data) return [];
+
+    const rows: Array<{
+      column_name: string;
+      data_type: string;
+      udt_name?: string;
+      is_nullable: string;
+      is_primary_key: boolean;
+    }> = result.data;
+
+    return rows
+      .filter(r => !!r.column_name)
+      .map<DatabaseTreeNode>(r => {
+        // information_schema reports "USER-DEFINED" / "ARRAY" for enums and
+        // arrays; udt_name carries the real type (e.g. my_enum, _int4).
+        const dataType =
+          r.data_type === "USER-DEFINED" || r.data_type === "ARRAY"
+            ? r.udt_name
+              ? r.data_type === "ARRAY"
+                ? `${r.udt_name.replace(/^_/, "")}[]`
+                : r.udt_name
+              : r.data_type
+            : r.data_type;
+        return {
+          id: `${dbName ? dbName + "." : ""}${schema}.${table}.${r.column_name}`,
+          label: r.column_name,
+          kind: "column",
+          hasChildren: false,
+          metadata: {
+            schema,
+            table,
+            columnName: r.column_name,
+            columnType: dataType,
+            isNullable: r.is_nullable === "YES",
+            isPrimaryKey: r.is_primary_key === true,
+            databaseId: dbName,
+            databaseName: dbName,
+          },
+        };
+      });
   }
 
   async getAutocompleteData(

--- a/api/src/databases/drivers/postgresql/driver.ts
+++ b/api/src/databases/drivers/postgresql/driver.ts
@@ -15,6 +15,7 @@ import {
   mapPostgresOidToType,
   stripTrailingSqlSemicolon,
 } from "./pg-type-utils";
+import { listPostgresTableColumns } from "./introspection";
 
 const logger = loggers.db("postgresql");
 
@@ -212,80 +213,10 @@ export class PostgreSQLDatabaseDriver implements DatabaseDriver {
     database: IDatabaseConnection,
     parent: { kind: string; id: string; metadata?: any },
   ): Promise<DatabaseTreeNode[]> {
-    const schema = parent.metadata?.schema;
-    const table = parent.metadata?.table;
-    if (!schema || !table) return [];
-
-    const dbName = parent.metadata?.databaseName || parent.metadata?.databaseId;
-    const safeSchema = String(schema).replace(/'/g, "''");
-    const safeTable = String(table).replace(/'/g, "''");
-
-    const result = await this.executeQuery(
-      database,
-      `SELECT
-         c.column_name,
-         c.data_type,
-         c.udt_name,
-         c.is_nullable,
-         (pk.column_name IS NOT NULL) AS is_primary_key
-       FROM information_schema.columns c
-       LEFT JOIN (
-         SELECT kcu.column_name
-         FROM information_schema.table_constraints tc
-         JOIN information_schema.key_column_usage kcu
-           ON kcu.constraint_name = tc.constraint_name
-          AND kcu.table_schema = tc.table_schema
-          AND kcu.table_name = tc.table_name
-         WHERE tc.constraint_type = 'PRIMARY KEY'
-           AND tc.table_schema = '${safeSchema}'
-           AND tc.table_name = '${safeTable}'
-       ) pk ON pk.column_name = c.column_name
-       WHERE c.table_schema = '${safeSchema}'
-         AND c.table_name = '${safeTable}'
-       ORDER BY c.ordinal_position;`,
-      { databaseName: dbName },
+    return listPostgresTableColumns(
+      (query, options) => this.executeQuery(database, query, options),
+      parent,
     );
-
-    if (!result.success || !result.data) return [];
-
-    const rows: Array<{
-      column_name: string;
-      data_type: string;
-      udt_name?: string;
-      is_nullable: string;
-      is_primary_key: boolean;
-    }> = result.data;
-
-    return rows
-      .filter(r => !!r.column_name)
-      .map<DatabaseTreeNode>(r => {
-        // information_schema reports "USER-DEFINED" / "ARRAY" for enums and
-        // arrays; udt_name carries the real type (e.g. my_enum, _int4).
-        const dataType =
-          r.data_type === "USER-DEFINED" || r.data_type === "ARRAY"
-            ? r.udt_name
-              ? r.data_type === "ARRAY"
-                ? `${r.udt_name.replace(/^_/, "")}[]`
-                : r.udt_name
-              : r.data_type
-            : r.data_type;
-        return {
-          id: `${dbName ? dbName + "." : ""}${schema}.${table}.${r.column_name}`,
-          label: r.column_name,
-          kind: "column",
-          hasChildren: false,
-          metadata: {
-            schema,
-            table,
-            columnName: r.column_name,
-            columnType: dataType,
-            isNullable: r.is_nullable === "YES",
-            isPrimaryKey: r.is_primary_key === true,
-            databaseId: dbName,
-            databaseName: dbName,
-          },
-        };
-      });
   }
 
   async getAutocompleteData(

--- a/api/src/databases/drivers/postgresql/introspection.ts
+++ b/api/src/databases/drivers/postgresql/introspection.ts
@@ -5,6 +5,246 @@ type TreeQueryExecutor = (
   options?: { databaseName?: string },
 ) => Promise<{ success: boolean; data?: any; error?: string }>;
 
+/** Object groups shown under a table node (DataGrip-style). */
+export type PostgresTableGroup = "columns" | "keys" | "indexes" | "triggers";
+
+interface TableParentRef {
+  schema: string;
+  table: string;
+  dbName?: string;
+  safeSchema: string;
+  safeTable: string;
+}
+
+function resolveTableParent(parent: { metadata?: any }): TableParentRef | null {
+  const schema = parent.metadata?.schema;
+  const table = parent.metadata?.table;
+  if (!schema || !table) return null;
+  return {
+    schema: String(schema),
+    table: String(table),
+    dbName: parent.metadata?.databaseName || parent.metadata?.databaseId,
+    safeSchema: String(schema).replace(/'/g, "''"),
+    safeTable: String(table).replace(/'/g, "''"),
+  };
+}
+
+/**
+ * Children of a table/view node or one of its object-group folders.
+ *
+ * - table  → group folders (columns / keys / indexes / triggers) with counts
+ * - view   → columns group only (views have no keys/indexes; INSTEAD OF
+ *            triggers are rare enough to not warrant the extra folders)
+ * - group  → the actual objects of that group
+ */
+export async function listPostgresTableLevelChildren(
+  executeQuery: TreeQueryExecutor,
+  parent: { kind: string; id: string; metadata?: any },
+): Promise<DatabaseTreeNode[]> {
+  if (parent.kind === "table" || parent.kind === "view") {
+    return listPostgresTableGroups(executeQuery, parent);
+  }
+  if (parent.kind === "group") {
+    const group = parent.metadata?.group as PostgresTableGroup | undefined;
+    switch (group) {
+      case "columns":
+        return listPostgresTableColumns(executeQuery, parent);
+      case "keys":
+        return listPostgresTableKeys(executeQuery, parent);
+      case "indexes":
+        return listPostgresTableIndexes(executeQuery, parent);
+      case "triggers":
+        return listPostgresTableTriggers(executeQuery, parent);
+      default:
+        return [];
+    }
+  }
+  return [];
+}
+
+async function listPostgresTableGroups(
+  executeQuery: TreeQueryExecutor,
+  parent: { kind: string; id: string; metadata?: any },
+): Promise<DatabaseTreeNode[]> {
+  const ref = resolveTableParent(parent);
+  if (!ref) return [];
+  const { safeSchema, safeTable, dbName } = ref;
+
+  const result = await executeQuery(
+    `SELECT
+       (SELECT count(*)::int FROM information_schema.columns
+         WHERE table_schema = '${safeSchema}' AND table_name = '${safeTable}') AS columns,
+       (SELECT count(*)::int FROM information_schema.table_constraints
+         WHERE table_schema = '${safeSchema}' AND table_name = '${safeTable}'
+           AND constraint_type IN ('PRIMARY KEY', 'FOREIGN KEY', 'UNIQUE')) AS keys,
+       (SELECT count(*)::int FROM pg_indexes
+         WHERE schemaname = '${safeSchema}' AND tablename = '${safeTable}') AS indexes,
+       (SELECT count(DISTINCT trigger_name)::int FROM information_schema.triggers
+         WHERE event_object_schema = '${safeSchema}' AND event_object_table = '${safeTable}') AS triggers;`,
+    { databaseName: dbName },
+  );
+
+  if (!result.success || !result.data?.[0]) return [];
+  const counts = result.data[0] as Record<PostgresTableGroup, number>;
+
+  const groups: PostgresTableGroup[] =
+    parent.kind === "view"
+      ? ["columns"]
+      : ["columns", "keys", "indexes", "triggers"];
+
+  return groups.map<DatabaseTreeNode>(group => ({
+    id: `${parent.id}#${group}`,
+    label: group,
+    kind: "group",
+    hasChildren: true,
+    metadata: {
+      ...parent.metadata,
+      group,
+      count: Number(counts[group]) || 0,
+      tableKind: parent.kind,
+    },
+  }));
+}
+
+async function listPostgresTableKeys(
+  executeQuery: TreeQueryExecutor,
+  parent: { kind: string; id: string; metadata?: any },
+): Promise<DatabaseTreeNode[]> {
+  const ref = resolveTableParent(parent);
+  if (!ref) return [];
+  const { schema, table, safeSchema, safeTable, dbName } = ref;
+
+  const result = await executeQuery(
+    `SELECT
+       tc.constraint_name,
+       tc.constraint_type,
+       string_agg(kcu.column_name, ', ' ORDER BY kcu.ordinal_position) AS columns
+     FROM information_schema.table_constraints tc
+     LEFT JOIN information_schema.key_column_usage kcu
+       ON kcu.constraint_name = tc.constraint_name
+      AND kcu.table_schema = tc.table_schema
+      AND kcu.table_name = tc.table_name
+     WHERE tc.table_schema = '${safeSchema}'
+       AND tc.table_name = '${safeTable}'
+       AND tc.constraint_type IN ('PRIMARY KEY', 'FOREIGN KEY', 'UNIQUE')
+     GROUP BY tc.constraint_name, tc.constraint_type
+     ORDER BY CASE tc.constraint_type
+       WHEN 'PRIMARY KEY' THEN 0 WHEN 'UNIQUE' THEN 1 ELSE 2 END,
+       tc.constraint_name;`,
+    { databaseName: dbName },
+  );
+
+  if (!result.success || !result.data) return [];
+  const rows: Array<{
+    constraint_name: string;
+    constraint_type: string;
+    columns: string | null;
+  }> = result.data;
+
+  return rows.map<DatabaseTreeNode>(r => ({
+    id: `${parent.id}.${r.constraint_name}`,
+    label: r.constraint_name,
+    kind: "key",
+    hasChildren: false,
+    metadata: {
+      schema,
+      table,
+      keyName: r.constraint_name,
+      keyType: r.constraint_type,
+      columns: r.columns || undefined,
+      databaseId: dbName,
+      databaseName: dbName,
+    },
+  }));
+}
+
+async function listPostgresTableIndexes(
+  executeQuery: TreeQueryExecutor,
+  parent: { kind: string; id: string; metadata?: any },
+): Promise<DatabaseTreeNode[]> {
+  const ref = resolveTableParent(parent);
+  if (!ref) return [];
+  const { schema, table, safeSchema, safeTable, dbName } = ref;
+
+  const result = await executeQuery(
+    `SELECT indexname, indexdef
+     FROM pg_indexes
+     WHERE schemaname = '${safeSchema}' AND tablename = '${safeTable}'
+     ORDER BY indexname;`,
+    { databaseName: dbName },
+  );
+
+  if (!result.success || !result.data) return [];
+  const rows: Array<{ indexname: string; indexdef: string }> = result.data;
+
+  return rows.map<DatabaseTreeNode>(r => {
+    const def = r.indexdef || "";
+    const isUnique = /\bCREATE UNIQUE INDEX\b/i.test(def);
+    const methodMatch = def.match(/\bUSING\s+(\w+)/i);
+    return {
+      id: `${parent.id}.${r.indexname}`,
+      label: r.indexname,
+      kind: "index",
+      hasChildren: false,
+      metadata: {
+        schema,
+        table,
+        indexName: r.indexname,
+        isUnique,
+        method: methodMatch ? methodMatch[1] : undefined,
+        definition: def,
+        databaseId: dbName,
+        databaseName: dbName,
+      },
+    };
+  });
+}
+
+async function listPostgresTableTriggers(
+  executeQuery: TreeQueryExecutor,
+  parent: { kind: string; id: string; metadata?: any },
+): Promise<DatabaseTreeNode[]> {
+  const ref = resolveTableParent(parent);
+  if (!ref) return [];
+  const { schema, table, safeSchema, safeTable, dbName } = ref;
+
+  const result = await executeQuery(
+    `SELECT
+       trigger_name,
+       min(action_timing) AS timing,
+       string_agg(DISTINCT event_manipulation, ' OR ') AS events
+     FROM information_schema.triggers
+     WHERE event_object_schema = '${safeSchema}'
+       AND event_object_table = '${safeTable}'
+     GROUP BY trigger_name
+     ORDER BY trigger_name;`,
+    { databaseName: dbName },
+  );
+
+  if (!result.success || !result.data) return [];
+  const rows: Array<{
+    trigger_name: string;
+    timing: string | null;
+    events: string | null;
+  }> = result.data;
+
+  return rows.map<DatabaseTreeNode>(r => ({
+    id: `${parent.id}.${r.trigger_name}`,
+    label: r.trigger_name,
+    kind: "trigger",
+    hasChildren: false,
+    metadata: {
+      schema,
+      table,
+      triggerName: r.trigger_name,
+      timing: r.timing || undefined,
+      events: r.events || undefined,
+      databaseId: dbName,
+      databaseName: dbName,
+    },
+  }));
+}
+
 /**
  * List the columns of a Postgres table or view as tree leaf nodes, including
  * data type, nullability, and primary-key membership.

--- a/api/src/databases/drivers/postgresql/introspection.ts
+++ b/api/src/databases/drivers/postgresql/introspection.ts
@@ -1,0 +1,93 @@
+import { DatabaseTreeNode } from "../../driver";
+
+type TreeQueryExecutor = (
+  query: string,
+  options?: { databaseName?: string },
+) => Promise<{ success: boolean; data?: any; error?: string }>;
+
+/**
+ * List the columns of a Postgres table or view as tree leaf nodes, including
+ * data type, nullability, and primary-key membership.
+ *
+ * Shared by the Postgres-family drivers (postgresql, cloudsql-postgres,
+ * redshift) which differ only in how they execute queries. Kept in its own
+ * module (instead of driver.ts) to avoid circular imports between drivers.
+ */
+export async function listPostgresTableColumns(
+  executeQuery: TreeQueryExecutor,
+  parent: { kind: string; id: string; metadata?: any },
+): Promise<DatabaseTreeNode[]> {
+  const schema = parent.metadata?.schema;
+  const table = parent.metadata?.table;
+  if (!schema || !table) return [];
+
+  const dbName = parent.metadata?.databaseName || parent.metadata?.databaseId;
+  const safeSchema = String(schema).replace(/'/g, "''");
+  const safeTable = String(table).replace(/'/g, "''");
+
+  const result = await executeQuery(
+    `SELECT
+       c.column_name,
+       c.data_type,
+       c.udt_name,
+       c.is_nullable,
+       (pk.column_name IS NOT NULL) AS is_primary_key
+     FROM information_schema.columns c
+     LEFT JOIN (
+       SELECT kcu.column_name
+       FROM information_schema.table_constraints tc
+       JOIN information_schema.key_column_usage kcu
+         ON kcu.constraint_name = tc.constraint_name
+        AND kcu.table_schema = tc.table_schema
+        AND kcu.table_name = tc.table_name
+       WHERE tc.constraint_type = 'PRIMARY KEY'
+         AND tc.table_schema = '${safeSchema}'
+         AND tc.table_name = '${safeTable}'
+     ) pk ON pk.column_name = c.column_name
+     WHERE c.table_schema = '${safeSchema}'
+       AND c.table_name = '${safeTable}'
+     ORDER BY c.ordinal_position;`,
+    { databaseName: dbName },
+  );
+
+  if (!result.success || !result.data) return [];
+
+  const rows: Array<{
+    column_name: string;
+    data_type: string;
+    udt_name?: string;
+    is_nullable: string;
+    is_primary_key: boolean;
+  }> = result.data;
+
+  return rows
+    .filter(r => !!r.column_name)
+    .map<DatabaseTreeNode>(r => {
+      // information_schema reports "USER-DEFINED" / "ARRAY" for enums and
+      // arrays; udt_name carries the real type (e.g. my_enum, _int4).
+      const dataType =
+        r.data_type === "USER-DEFINED" || r.data_type === "ARRAY"
+          ? r.udt_name
+            ? r.data_type === "ARRAY"
+              ? `${r.udt_name.replace(/^_/, "")}[]`
+              : r.udt_name
+            : r.data_type
+          : r.data_type;
+      return {
+        id: `${dbName ? dbName + "." : ""}${schema}.${table}.${r.column_name}`,
+        label: r.column_name,
+        kind: "column",
+        hasChildren: false,
+        metadata: {
+          schema,
+          table,
+          columnName: r.column_name,
+          columnType: dataType,
+          isNullable: r.is_nullable === "YES",
+          isPrimaryKey: r.is_primary_key === true,
+          databaseId: dbName,
+          databaseName: dbName,
+        },
+      };
+    });
+}

--- a/api/src/databases/drivers/redshift/driver.ts
+++ b/api/src/databases/drivers/redshift/driver.ts
@@ -48,8 +48,13 @@ export class RedshiftDatabaseDriver implements DatabaseDriver {
     database: IDatabaseConnection,
     parent: { kind: string; id: string; metadata?: any },
   ): Promise<DatabaseTreeNode[]> {
-    // Schema expansion: list tables (same as PostgreSQL)
-    if (parent.kind === "schema") {
+    // Schema expansion lists tables; table/view expansion lists columns
+    // (both same as PostgreSQL).
+    if (
+      parent.kind === "schema" ||
+      parent.kind === "table" ||
+      parent.kind === "view"
+    ) {
       return postgresDriver.getChildren(database, parent);
     }
     if (parent.kind !== "database") return [];

--- a/api/src/databases/drivers/redshift/driver.ts
+++ b/api/src/databases/drivers/redshift/driver.ts
@@ -20,6 +20,7 @@ import {
 import { IDatabaseConnection } from "../../../database/workspace-schema";
 import { databaseConnectionService } from "../../../services/database-connection.service";
 import { PostgreSQLDatabaseDriver } from "../postgresql/driver";
+import { listPostgresTableColumns } from "../postgresql/introspection";
 
 // Shared instance — PostgreSQLDatabaseDriver is stateless (no instance-level
 // config or logging context), so a module-level singleton is safe here.
@@ -48,14 +49,17 @@ export class RedshiftDatabaseDriver implements DatabaseDriver {
     database: IDatabaseConnection,
     parent: { kind: string; id: string; metadata?: any },
   ): Promise<DatabaseTreeNode[]> {
-    // Schema expansion lists tables; table/view expansion lists columns
-    // (both same as PostgreSQL).
-    if (
-      parent.kind === "schema" ||
-      parent.kind === "table" ||
-      parent.kind === "view"
-    ) {
+    // Schema expansion: list tables (same as PostgreSQL)
+    if (parent.kind === "schema") {
       return postgresDriver.getChildren(database, parent);
+    }
+    // Redshift has no indexes/triggers, so tables expand straight to columns
+    // instead of the grouped folders the PostgreSQL driver returns.
+    if (parent.kind === "table" || parent.kind === "view") {
+      return listPostgresTableColumns(
+        (query, options) => this.executeQuery(database, query, options),
+        parent,
+      );
     }
     if (parent.kind !== "database") return [];
 

--- a/api/src/routes/database-tree.ts
+++ b/api/src/routes/database-tree.ts
@@ -259,11 +259,9 @@ databaseTreeRoutes.get(
       const dbName = metadata?.databaseName || "default";
       const table = metadata?.tableName || nodeId || "table_name";
       template = `SELECT * FROM "${dbName}"."${table}" LIMIT 500;`;
-    } else {
-      // Fallback SQL-like template
-      const table = nodeId || "table_name";
-      template = `SELECT * FROM ${table} LIMIT 500;`;
     }
+    // Postgres-family tables no longer use console templates: clicking a
+    // table in the explorer opens a paginated data tab instead.
 
     return c.json({ success: true, data: { language, template } });
   },

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -426,11 +426,8 @@ function MainApp() {
           if (tpl?.template) prefill = tpl.template;
         }
       } catch {
-        // If server call fails, fallback to type-based default
-        const kind = (collection.type || "").toLowerCase();
-        if (kind !== "collection" && kind !== "view") {
-          prefill = `SELECT * FROM ${collection.name} LIMIT 500;`;
-        }
+        // Server template unavailable; keep the collection default prefill.
+        // (SQL tables open a paginated data tab instead of a console now.)
       }
       openOrFocusConsoleTab(
         collection.name,

--- a/app/src/components/DatabaseExplorer.tsx
+++ b/app/src/components/DatabaseExplorer.tsx
@@ -20,6 +20,8 @@ import {
   Trash2 as DeleteIcon,
   Settings as SettingsIcon,
   Layers as LayersIcon,
+  Columns3 as ColumnIcon,
+  KeyRound as PrimaryKeyIcon,
 } from "lucide-react";
 import { useExplorerStore } from "../store";
 import { useWorkspace } from "../contexts/workspace-context";
@@ -370,6 +372,16 @@ function DatabaseExplorer({
             return <CollectionIcon size={18} strokeWidth={1.5} />;
           case "view":
             return <ViewIcon size={18} strokeWidth={1.5} />;
+          case "column":
+            return info.node.metadata?.isPrimaryKey === true ? (
+              <PrimaryKeyIcon
+                size={15}
+                strokeWidth={1.75}
+                style={{ color: "#d4a017" }}
+              />
+            ) : (
+              <ColumnIcon size={15} strokeWidth={1.5} />
+            );
           default:
             return null;
         }
@@ -377,6 +389,34 @@ function DatabaseExplorer({
       return iconEl;
     },
     [nodeInfoById, typeToIconUrl],
+  );
+
+  // Show the column's data type dimmed at the right edge of the row
+  // (DataGrip / TablePlus style).
+  const getRightAdornment = useCallback(
+    (node: ResourceTreeNode) => {
+      const info = nodeInfoById.get(node.id);
+      if (!info || info.type !== "node" || info.node.kind !== "column") {
+        return null;
+      }
+      const columnType = info.node.metadata?.columnType;
+      if (!columnType) return null;
+      return (
+        <Typography
+          variant="caption"
+          sx={{
+            color: "text.disabled",
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            maxWidth: 110,
+          }}
+        >
+          {String(columnType)}
+        </Typography>
+      );
+    },
+    [nodeInfoById],
   );
 
   const getContextMenuItems = useCallback(
@@ -476,6 +516,8 @@ function DatabaseExplorer({
       if (!info) return;
       if (info.type === "node") {
         const { node: treeNode, connectionId } = info;
+        // Column leaves are informational; don't open a console for them.
+        if (treeNode.kind === "column") return;
         if (!treeNode.hasChildren) {
           handleCollectionClick(connectionId, {
             name: treeNode.label,
@@ -564,6 +606,7 @@ function DatabaseExplorer({
               mode="sidebar"
               searchQuery={searchQuery}
               getItemIcon={getItemIcon}
+              getRightAdornment={getRightAdornment}
               isFolderExpanded={isFolderExpanded}
               onToggleFolder={onToggleFolder}
               onExpandFolder={onExpandFolder}

--- a/app/src/components/DatabaseExplorer.tsx
+++ b/app/src/components/DatabaseExplorer.tsx
@@ -21,7 +21,17 @@ import {
   Settings as SettingsIcon,
   Layers as LayersIcon,
   Columns3 as ColumnIcon,
-  KeyRound as PrimaryKeyIcon,
+  KeyRound as KeyIcon,
+  Type as StringIcon,
+  Hash as NumberIcon,
+  ToggleLeft as BooleanIcon,
+  Calendar as DateTimeIcon,
+  Braces as JsonIcon,
+  Brackets as ArrayIcon,
+  Fingerprint as UuidIcon,
+  Binary as BinaryIcon,
+  ListOrdered as IndexIcon,
+  Zap as TriggerIcon,
 } from "lucide-react";
 import { useExplorerStore } from "../store";
 import { useWorkspace } from "../contexts/workspace-context";
@@ -39,6 +49,34 @@ export interface CollectionInfo {
   name: string;
   type: string;
   options: unknown;
+}
+
+const PRIMARY_KEY_COLOR = "#d4a017";
+
+/** Connection types whose tables open the paginated data view on click. */
+const POSTGRES_FAMILY_TYPES = new Set([
+  "postgresql",
+  "cloudsql-postgres",
+  "redshift",
+]);
+
+/** Pick an icon for a column based on its (Postgres) data type. */
+function columnTypeIcon(columnType: unknown): React.ReactNode {
+  const t = String(columnType || "").toLowerCase();
+  const props = { size: 15, strokeWidth: 1.5 };
+  if (t.endsWith("[]")) return <ArrayIcon {...props} />;
+  if (t.includes("uuid")) return <UuidIcon {...props} />;
+  if (t.includes("bool")) return <BooleanIcon {...props} />;
+  if (t.includes("json")) return <JsonIcon {...props} />;
+  if (/timestamp|date|time|interval/.test(t)) {
+    return <DateTimeIcon {...props} />;
+  }
+  if (/int|serial|numeric|decimal|real|double|float|money/.test(t)) {
+    return <NumberIcon {...props} />;
+  }
+  if (/char|text|citext|name|string/.test(t)) return <StringIcon {...props} />;
+  if (/bytea|binary|blob/.test(t)) return <BinaryIcon {...props} />;
+  return <ColumnIcon {...props} />;
 }
 
 const IconImg = React.memo(
@@ -374,14 +412,30 @@ function DatabaseExplorer({
             return <ViewIcon size={18} strokeWidth={1.5} />;
           case "column":
             return info.node.metadata?.isPrimaryKey === true ? (
-              <PrimaryKeyIcon
+              <KeyIcon
                 size={15}
                 strokeWidth={1.75}
-                style={{ color: "#d4a017" }}
+                style={{ color: PRIMARY_KEY_COLOR }}
               />
             ) : (
-              <ColumnIcon size={15} strokeWidth={1.5} />
+              columnTypeIcon(info.node.metadata?.columnType)
             );
+          case "key":
+            return (
+              <KeyIcon
+                size={15}
+                strokeWidth={1.75}
+                style={
+                  info.node.metadata?.keyType === "PRIMARY KEY"
+                    ? { color: PRIMARY_KEY_COLOR }
+                    : undefined
+                }
+              />
+            );
+          case "index":
+            return <IndexIcon size={15} strokeWidth={1.5} />;
+          case "trigger":
+            return <TriggerIcon size={15} strokeWidth={1.5} />;
           default:
             return null;
         }
@@ -391,16 +445,48 @@ function DatabaseExplorer({
     [nodeInfoById, typeToIconUrl],
   );
 
-  // Show the column's data type dimmed at the right edge of the row
-  // (DataGrip / TablePlus style).
+  // Dimmed detail at the right edge of a row (DataGrip / TablePlus style):
+  // column types, group counts, key/index/trigger info.
   const getRightAdornment = useCallback(
     (node: ResourceTreeNode) => {
       const info = nodeInfoById.get(node.id);
-      if (!info || info.type !== "node" || info.node.kind !== "column") {
-        return null;
+      if (!info || info.type !== "node") return null;
+      const { kind, metadata } = info.node;
+
+      let text: string | null = null;
+      switch (kind) {
+        case "column":
+          text = metadata?.columnType ? String(metadata.columnType) : null;
+          break;
+        case "group":
+          text = metadata?.count !== undefined ? String(metadata.count) : null;
+          break;
+        case "key":
+          text = metadata?.keyType
+            ? String(metadata.keyType).toLowerCase()
+            : null;
+          break;
+        case "index": {
+          const parts = [
+            metadata?.isUnique ? "unique" : null,
+            metadata?.method ? String(metadata.method) : null,
+          ].filter(Boolean);
+          text = parts.length > 0 ? parts.join(" ") : null;
+          break;
+        }
+        case "trigger": {
+          const parts = [
+            metadata?.timing ? String(metadata.timing) : null,
+            metadata?.events ? String(metadata.events) : null,
+          ].filter(Boolean);
+          text = parts.length > 0 ? parts.join(" ").toLowerCase() : null;
+          break;
+        }
+        default:
+          return null;
       }
-      const columnType = info.node.metadata?.columnType;
-      if (!columnType) return null;
+
+      if (!text) return null;
       return (
         <Typography
           variant="caption"
@@ -412,7 +498,7 @@ function DatabaseExplorer({
             maxWidth: 110,
           }}
         >
-          {String(columnType)}
+          {text}
         </Typography>
       );
     },
@@ -510,24 +596,99 @@ function DatabaseExplorer({
     [nodeInfoById, currentWorkspace, deleteConnection],
   );
 
+  const connectionTypeById = useMemo(() => {
+    const map = new Map<string, string>();
+    databases.forEach(db => map.set(db.id, db.type));
+    return map;
+  }, [databases]);
+
+  const openTableDataTab = useCallback(
+    (connectionId: string, treeNode: TreeNode) => {
+      const schema = (treeNode.metadata?.schema as string) || "public";
+      const table = (treeNode.metadata?.table as string) || treeNode.label;
+      const databaseName = treeNode.metadata?.databaseName as
+        | string
+        | undefined;
+      const databaseId = treeNode.metadata?.databaseId as string | undefined;
+
+      const { tabs, openTab, setActiveTab } = useConsoleStore.getState();
+      const existing = Object.values(tabs).find(
+        t =>
+          t.kind === "table-data" &&
+          t.connectionId === connectionId &&
+          t.metadata?.schema === schema &&
+          t.metadata?.table === table &&
+          (t.databaseName || undefined) === (databaseName || undefined),
+      );
+      if (existing) {
+        setActiveTab(existing.id);
+        return;
+      }
+
+      const id = openTab({
+        title: table,
+        content: "",
+        kind: "table-data",
+        connectionId,
+        databaseId,
+        databaseName,
+        metadata: { schema, table },
+      });
+      setActiveTab(id);
+    },
+    [],
+  );
+
   const handleItemClick = useCallback(
     (node: ResourceTreeNode) => {
       const info = nodeInfoById.get(node.id);
-      if (!info) return;
-      if (info.type === "node") {
-        const { node: treeNode, connectionId } = info;
-        // Column leaves are informational; don't open a console for them.
-        if (treeNode.kind === "column") return;
-        if (!treeNode.hasChildren) {
-          handleCollectionClick(connectionId, {
-            name: treeNode.label,
-            type: treeNode.kind,
-            options: treeNode.metadata,
-          });
-        }
+      if (!info || info.type !== "node") return;
+      const { node: treeNode, connectionId } = info;
+
+      // Schema-object leaves (columns, keys, indexes, triggers) are
+      // informational only.
+      if (
+        treeNode.kind === "column" ||
+        treeNode.kind === "key" ||
+        treeNode.kind === "index" ||
+        treeNode.kind === "trigger"
+      ) {
+        return;
+      }
+
+      // Postgres-family tables/views open the paginated data view.
+      if (
+        (treeNode.kind === "table" || treeNode.kind === "view") &&
+        POSTGRES_FAMILY_TYPES.has(connectionTypeById.get(connectionId) || "")
+      ) {
+        openTableDataTab(connectionId, treeNode);
+        return;
+      }
+
+      if (!treeNode.hasChildren) {
+        handleCollectionClick(connectionId, {
+          name: treeNode.label,
+          type: treeNode.kind,
+          options: treeNode.metadata,
+        });
       }
     },
-    [nodeInfoById, handleCollectionClick],
+    [nodeInfoById, handleCollectionClick, connectionTypeById, openTableDataTab],
+  );
+
+  // Clicking a Postgres table/view *name* opens its data; the caret still
+  // expands the schema sub-tree (columns / keys / indexes / triggers).
+  const shouldFolderClickActivate = useCallback(
+    (node: ResourceTreeNode) => {
+      const info = nodeInfoById.get(node.id);
+      if (!info || info.type !== "node") return false;
+      const kind = info.node.kind;
+      if (kind !== "table" && kind !== "view") return false;
+      return POSTGRES_FAMILY_TYPES.has(
+        connectionTypeById.get(info.connectionId) || "",
+      );
+    },
+    [nodeInfoById, connectionTypeById],
   );
 
   const getFolderExpansionKey = useCallback(
@@ -615,6 +776,7 @@ function DatabaseExplorer({
               isLoadingChildren={isLoadingChildren}
               getContextMenuItems={getContextMenuItems}
               onItemClick={handleItemClick}
+              shouldFolderClickActivate={shouldFolderClickActivate}
             />
           )
         }

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -43,6 +43,7 @@ import {
   Webhook as WebhookIcon,
   CirclePause as PauseIcon,
   ChartPie as DashboardIcon,
+  Table as TableDataIcon,
   ChevronRight as BreadcrumbChevronIcon,
 } from "lucide-react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
@@ -54,6 +55,7 @@ import ConnectorTab from "./ConnectorTab";
 import { WorkspaceMembers } from "./WorkspaceMembers";
 import { FlowEditor } from "./FlowEditor";
 import DashboardCanvas from "./DashboardCanvas";
+import TableDataView from "./TableDataView";
 import ScheduleConsoleModal from "./ScheduleConsoleModal";
 import ScheduledRunsPanel from "./ScheduledRunsPanel";
 import type { DbFlowFormRef } from "./DbFlowForm";
@@ -1940,6 +1942,8 @@ function Editor({
                               )
                             ) : tab.kind === "dashboard" ? (
                               <DashboardIcon size={18} strokeWidth={1.5} />
+                            ) : tab.kind === "table-data" ? (
+                              <TableDataIcon size={18} strokeWidth={1.5} />
                             ) : connectionIconUrl ? (
                               <Box
                                 component="img"
@@ -2110,6 +2114,8 @@ function Editor({
                     }}
                     dbFlowFormRef={dbFlowFormRef}
                   />
+                ) : tab.kind === "table-data" ? (
+                  <TableDataView tabId={tab.id} />
                 ) : tab.kind === "dashboard" ? (
                   <DashboardCanvas
                     dashboardId={tab.metadata?.dashboardId as string}

--- a/app/src/components/ResourceTree.tsx
+++ b/app/src/components/ResourceTree.tsx
@@ -163,6 +163,13 @@ export interface ResourceTreeProps {
   enableNewFolder?: boolean;
 
   onItemClick?: (node: ResourceTreeNode) => void;
+  /**
+   * Opt-in: when this returns true for a directory node, clicking the row
+   * (name/icon area) fires `onItemClick` instead of toggling expansion. The
+   * chevron still expands/collapses. Used by the database explorer so
+   * clicking a table name opens its data while the caret browses the schema.
+   */
+  shouldFolderClickActivate?: (node: ResourceTreeNode) => boolean;
   onPickerFileClick?: (node: ResourceTreeNode) => void;
   onLocationChange?: (folderId: string | null, sectionKey: string) => void;
   selectedLocationId?: string | null;
@@ -227,6 +234,7 @@ function ResourceTreeInner(
     enableInfo = false,
     enableNewFolder = true,
     onItemClick,
+    shouldFolderClickActivate,
     onPickerFileClick,
     onLocationChange,
     selectedLocationId,
@@ -992,6 +1000,8 @@ function ResourceTreeInner(
               setFocusedNodeId(node.id);
               if (mode === "picker") {
                 updateLocationSelection(node.id, sectionKey);
+              } else if (shouldFolderClickActivate?.(node)) {
+                onItemClick?.(node);
               } else {
                 const willExpand = !isExpanded;
                 onToggleFolder(getExpansionKey(node));

--- a/app/src/components/TableDataView.tsx
+++ b/app/src/components/TableDataView.tsx
@@ -1,0 +1,238 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Box,
+  Typography,
+  Alert,
+  Button,
+  IconButton,
+  Tooltip,
+  CircularProgress,
+} from "@mui/material";
+import { RotateCw as RefreshIcon, Table as TableIcon } from "lucide-react";
+import { useConsoleStore } from "../store/consoleStore";
+import { useWorkspace } from "../contexts/workspace-context";
+import ResultsTable from "./ResultsTable";
+
+const PAGE_SIZE = 100;
+
+/** Quote a Postgres identifier. */
+function quoteIdent(name: string): string {
+  return `"${String(name).replace(/"/g, '""')}"`;
+}
+
+interface TableDataResult {
+  results: Array<Record<string, unknown>>;
+  executedAt: string;
+  resultCount: number;
+  executionTime?: number;
+  fields?: Array<{ name?: string; originalName?: string } | string>;
+  pageInfo?: {
+    pageSize: number;
+    hasMore: boolean;
+    nextCursor: string | null;
+    returnedRows: number;
+    capApplied: boolean;
+  } | null;
+  currentPage?: number;
+}
+
+interface TableDataViewProps {
+  tabId: string;
+}
+
+/**
+ * Full-screen, paginated browser for a table's rows. Opened from the database
+ * explorer by clicking a table name; fetches the first 100 rows immediately
+ * and pages with Previous / Next.
+ */
+function TableDataView({ tabId }: TableDataViewProps) {
+  const tab = useConsoleStore(s => s.tabs[tabId]);
+  const executeQuery = useConsoleStore(s => s.executeQuery);
+  const { currentWorkspace } = useWorkspace();
+
+  const [result, setResult] = useState<TableDataResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Cursor stack: cursorHistory[i] is the cursor used to fetch page i+1.
+  const cursorHistoryRef = useRef<Array<string | null>>([null]);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const schema = (tab?.metadata?.schema as string) || "public";
+  const table = tab?.metadata?.table as string | undefined;
+  const connectionId = tab?.connectionId;
+  const databaseName = tab?.databaseName;
+  const databaseId = tab?.databaseId;
+
+  const fetchPage = useCallback(
+    async (cursor: string | null, page: number) => {
+      if (!currentWorkspace || !connectionId || !table) return;
+
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      setLoading(true);
+      setError(null);
+      const startTime = Date.now();
+      const query = `SELECT * FROM ${quoteIdent(schema)}.${quoteIdent(table)}`;
+
+      const res = await executeQuery(currentWorkspace.id, connectionId, query, {
+        databaseId,
+        databaseName,
+        pageSize: PAGE_SIZE,
+        cursor,
+        signal: controller.signal,
+      });
+
+      if (controller.signal.aborted) return;
+      setLoading(false);
+
+      if (!res.success) {
+        if (res.error !== "Query cancelled") {
+          setError(res.error || "Failed to load table data");
+        }
+        return;
+      }
+
+      const rows = ("rows" in res ? res.rows : []) || [];
+      const fields = "fields" in res ? res.fields : undefined;
+      const pageInfo = ("pageInfo" in res ? res.pageInfo : null) || null;
+      setResult({
+        results: rows as Array<Record<string, unknown>>,
+        executedAt: new Date().toISOString(),
+        resultCount: Array.isArray(rows) ? rows.length : 0,
+        executionTime: Date.now() - startTime,
+        fields,
+        pageInfo,
+        currentPage: page,
+      });
+    },
+    [
+      currentWorkspace,
+      connectionId,
+      table,
+      schema,
+      databaseId,
+      databaseName,
+      executeQuery,
+    ],
+  );
+
+  // Initial load (and reload when the target table changes)
+  useEffect(() => {
+    cursorHistoryRef.current = [null];
+    fetchPage(null, 1);
+    return () => abortRef.current?.abort();
+  }, [fetchPage]);
+
+  const handleNextPage = useCallback(() => {
+    const nextCursor = result?.pageInfo?.nextCursor;
+    if (!nextCursor) return;
+    cursorHistoryRef.current = [...cursorHistoryRef.current, nextCursor];
+    fetchPage(nextCursor, (result?.currentPage ?? 1) + 1);
+  }, [result, fetchPage]);
+
+  const handlePreviousPage = useCallback(() => {
+    const page = result?.currentPage ?? 1;
+    if (page <= 1) return;
+    const history = cursorHistoryRef.current.slice(0, -1);
+    cursorHistoryRef.current = history.length > 0 ? history : [null];
+    const prevCursor =
+      cursorHistoryRef.current[cursorHistoryRef.current.length - 1] ?? null;
+    fetchPage(prevCursor, page - 1);
+  }, [result, fetchPage]);
+
+  const handleRefresh = useCallback(() => {
+    const cursor =
+      cursorHistoryRef.current[cursorHistoryRef.current.length - 1] ?? null;
+    fetchPage(cursor, result?.currentPage ?? 1);
+  }, [fetchPage, result]);
+
+  if (!tab || !table || !connectionId) {
+    return (
+      <Box sx={{ p: 3 }}>
+        <Alert severity="error">Table information is missing.</Alert>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
+      <Box
+        sx={{
+          px: 1.5,
+          py: 0.75,
+          display: "flex",
+          alignItems: "center",
+          gap: 1,
+          borderBottom: "1px solid",
+          borderColor: "divider",
+          flexShrink: 0,
+        }}
+      >
+        <TableIcon size={16} strokeWidth={1.5} />
+        <Typography variant="body2" sx={{ fontWeight: 600 }}>
+          {schema}.{table}
+        </Typography>
+        {databaseName ? (
+          <Typography variant="caption" color="text.secondary">
+            {databaseName}
+          </Typography>
+        ) : null}
+        <Box sx={{ ml: "auto", display: "flex", alignItems: "center" }}>
+          <Tooltip title="Refresh">
+            <span>
+              <IconButton
+                size="small"
+                onClick={handleRefresh}
+                disabled={loading}
+              >
+                <RefreshIcon size={16} strokeWidth={1.75} />
+              </IconButton>
+            </span>
+          </Tooltip>
+        </Box>
+      </Box>
+
+      {error ? (
+        <Box sx={{ p: 2 }}>
+          <Alert
+            severity="error"
+            action={
+              <Button
+                color="inherit"
+                size="small"
+                onClick={() => fetchPage(null, 1)}
+              >
+                Retry
+              </Button>
+            }
+          >
+            {error}
+          </Alert>
+        </Box>
+      ) : !result && loading ? (
+        <Box
+          sx={{
+            flex: 1,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <CircularProgress size={28} />
+        </Box>
+      ) : (
+        <Box sx={{ flex: 1, minHeight: 0, opacity: loading ? 0.6 : 1 }}>
+          <ResultsTable
+            results={result}
+            onNextPage={handleNextPage}
+            onPreviousPage={handlePreviousPage}
+          />
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+export default React.memo(TableDataView);

--- a/app/src/components/TableDataView.tsx
+++ b/app/src/components/TableDataView.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   Box,
   Typography,
@@ -8,8 +14,13 @@ import {
   Tooltip,
   CircularProgress,
 } from "@mui/material";
-import { RotateCw as RefreshIcon, Table as TableIcon } from "lucide-react";
+import {
+  RotateCw as RefreshIcon,
+  Table as TableIcon,
+  ChevronRight as BreadcrumbChevronIcon,
+} from "lucide-react";
 import { useConsoleStore } from "../store/consoleStore";
+import { useSchemaStore } from "../store/schemaStore";
 import { useWorkspace } from "../contexts/workspace-context";
 import ResultsTable from "./ResultsTable";
 
@@ -62,6 +73,22 @@ function TableDataView({ tabId }: TableDataViewProps) {
   const connectionId = tab?.connectionId;
   const databaseName = tab?.databaseName;
   const databaseId = tab?.databaseId;
+
+  const connections = useSchemaStore(s => s.connections);
+  const connectionName = useMemo(() => {
+    const list = currentWorkspace ? connections[currentWorkspace.id] || [] : [];
+    const conn = list.find(c => c.id === connectionId);
+    return conn?.displayName || conn?.name;
+  }, [connections, currentWorkspace, connectionId]);
+
+  // connection name > database > schema > table
+  const breadcrumbs = useMemo(
+    () =>
+      [connectionName, databaseName, schema, table].filter(
+        (part): part is string => !!part,
+      ),
+    [connectionName, databaseName, schema, table],
+  );
 
   const fetchPage = useCallback(
     async (cursor: string | null, page: number) => {
@@ -171,14 +198,42 @@ function TableDataView({ tabId }: TableDataViewProps) {
         }}
       >
         <TableIcon size={16} strokeWidth={1.5} />
-        <Typography variant="body2" sx={{ fontWeight: 600 }}>
-          {schema}.{table}
-        </Typography>
-        {databaseName ? (
-          <Typography variant="caption" color="text.secondary">
-            {databaseName}
-          </Typography>
-        ) : null}
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: 0.25,
+            minWidth: 0,
+            overflow: "hidden",
+          }}
+        >
+          {breadcrumbs.map((part, idx) => {
+            const isLast = idx === breadcrumbs.length - 1;
+            return (
+              <React.Fragment key={`${idx}-${part}`}>
+                {idx > 0 && (
+                  <BreadcrumbChevronIcon
+                    size={13}
+                    strokeWidth={1.75}
+                    style={{ flexShrink: 0, opacity: 0.45 }}
+                  />
+                )}
+                <Typography
+                  variant="body2"
+                  noWrap
+                  sx={{
+                    fontWeight: isLast ? 600 : 400,
+                    color: isLast ? "text.primary" : "text.secondary",
+                    flexShrink: isLast ? 0 : 1,
+                    minWidth: 0,
+                  }}
+                >
+                  {part}
+                </Typography>
+              </React.Fragment>
+            );
+          })}
+        </Box>
         <Box sx={{ ml: "auto", display: "flex", alignItems: "center" }}>
           <Tooltip title="Refresh">
             <span>

--- a/app/src/store/lib/types.ts
+++ b/app/src/store/lib/types.ts
@@ -14,7 +14,8 @@ export type TabKind =
   | "connectors"
   | "members"
   | "flow-editor"
-  | "dashboard";
+  | "dashboard"
+  | "table-data";
 
 /**
  * Sub-section for `kind === "settings"` tabs. Each section is rendered in its

--- a/app/src/store/schemaStore.ts
+++ b/app/src/store/schemaStore.ts
@@ -841,10 +841,10 @@ export const useSchemaStore = create<SchemaState>()(
     })),
     {
       name: "mako-schema-store",
-      // v2: table/view tree nodes became expandable (hasChildren) when column
-      // introspection was added; discard older cached trees so stale leaf
-      // nodes don't keep tables un-expandable.
-      version: 2,
+      // v3: Postgres tables now expand to grouped folders (columns / keys /
+      // indexes / triggers) instead of a flat column list; discard older
+      // cached trees so stale children don't linger.
+      version: 3,
       storage: createJSONStorage(() => indexedDBStorage),
       partialize: state => ({
         // Only persist the data, not loading/error states

--- a/app/src/store/schemaStore.ts
+++ b/app/src/store/schemaStore.ts
@@ -841,7 +841,10 @@ export const useSchemaStore = create<SchemaState>()(
     })),
     {
       name: "mako-schema-store",
-      version: 1,
+      // v2: table/view tree nodes became expandable (hasChildren) when column
+      // introspection was added; discard older cached trees so stale leaf
+      // nodes don't keep tables un-expandable.
+      version: 2,
       storage: createJSONStorage(() => indexedDBStorage),
       partialize: state => ({
         // Only persist the data, not loading/error states


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First step toward full schema introspection: PostgreSQL tables and views in the database explorer sidebar are now expandable and show their columns, like DataGrip / SSMS / TablePlus.

[postgres_column_introspection_sidebar_demo.mp4](https://cursor.com/agents/bc-2c8a796a-40c4-49f5-968f-8a2ace8dedce/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpostgres_column_introspection_sidebar_demo.mp4)

[Expanded Postgres tree with columns](https://cursor.com/agents/bc-2c8a796a-40c4-49f5-968f-8a2ace8dedce/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpostgres_columns_tree_expanded.webp)

### Backend

- `api/src/databases/drivers/postgresql/introspection.ts` (new): shared `listPostgresTableColumns` helper — queries `information_schema.columns` (joined with `table_constraints` / `key_column_usage` for primary-key membership), ordered by `ordinal_position`. Returns `kind: "column"` leaf nodes with `columnType`, `isNullable`, `isPrimaryKey` metadata. Enum (`USER-DEFINED`) and `ARRAY` types are resolved via `udt_name` (e.g. `mpaa_rating`, `text[]`). Lives in its own module to avoid a circular import between drivers.
- `api/src/databases/drivers/postgresql/driver.ts`: table/view nodes report `hasChildren: true`; `getChildren` handles `table` / `view` parents via the shared helper.
- `api/src/databases/drivers/cloudsql-postgres/driver.ts`: same wiring (this driver has its own copy of the tree code, so connections of type `cloudsql-postgres` — e.g. "ch-aggregates-db (PROD)" — would otherwise show no columns).
- `api/src/databases/drivers/redshift/driver.ts`: delegates table/view expansion to the Postgres driver (it already reuses it for table listing).

### Frontend

- `app/src/components/DatabaseExplorer.tsx`
  - `column` nodes render a column icon, or a gold key icon for primary-key columns (composite PKs supported).
  - Data type shown dimmed at the right edge of the row via `ResourceTree`'s `getRightAdornment`.
  - Clicking a column is a no-op (previously any leaf node opened a console tab).
- `app/src/store/schemaStore.ts`: persisted-cache version bumped 1 → 2 so previously cached trees (where table nodes were saved with `hasChildren: false`) are discarded once and refetched — without this, already-browsed connections would keep showing un-expandable tables until a manual refresh.

No new API routes — lazy loading reuses the existing `GET .../databases/:id/tree` endpoint and `ensureTreeChildren`, same pattern as the MySQL and ClickHouse drivers.

## Testing

- ✅ `pnpm --filter app run typecheck && pnpm --filter app run lint`
- ✅ `pnpm --filter api run lint` and `pnpm --filter api run build`
- ✅ API-level verification with curl against a local Postgres 16 (`pagila`-style sample db): column order, composite PKs (`film_actor`), enum (`mpaa_rating`), array (`text[]`), and view columns all correct.
- ✅ Cloud SQL driver verified end-to-end against the same local Postgres with only the GCP connector layer stubbed (`getConnection` → local `pg.Pool`); the driver's `executeQuery`, row normalization, and introspection SQL ran unmodified.
- ✅ Manual GUI test: expanded connection → database → schema → tables → columns in the sidebar; verified icons, dimmed types, key icons, and that clicking a column does not open a console (see video).
- ✅ Manual GUI test after cache version bump: reloaded the app, confirmed the stale tree cache is discarded and columns load fresh.

[Columns load after reload with cache version bump](https://cursor.com/agents/bc-2c8a796a-40c4-49f5-968f-8a2ace8dedce/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpostgres_columns_after_cache_bump_reload.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c8a796a-40c4-49f5-968f-8a2ace8dedce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c8a796a-40c4-49f5-968f-8a2ace8dedce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

