### PR TITLE
feat(close): sync outcomes lookup table and outcome fields on activities

### DIFF
--- a/api/src/connectors/close/connector.ts
+++ b/api/src/connectors/close/connector.ts
@@ -712,6 +712,7 @@ export class CloseConnector extends BaseConnector {
       "custom_objects",
       "lead_statuses",
       "opportunity_statuses",
+      "outcomes",
     ];
 
     const activitySubEntities = CLOSE_ACTIVITY_TYPES.map(
@@ -1128,6 +1129,9 @@ export class CloseConnector extends BaseConnector {
       "voicemail_url",
       "voicemail_duration",
       "outcome_id",
+      "outcome_reason",
+      "outcome_autofill_confidence",
+      "outcome_autofill_reasoning",
       "transferred_from",
       "transferred_to",
       "source",
@@ -1831,6 +1835,7 @@ export class CloseConnector extends BaseConnector {
     opportunity_statuses: "/status/opportunity/",
     custom_activity_types: "/custom_activity/",
     custom_object_types: "/custom_object_type/",
+    outcomes: "/outcome/",
   };
 
   private async fetchSimpleEntityChunk(

--- a/api/src/connectors/close/schema.ts
+++ b/api/src/connectors/close/schema.ts
@@ -478,6 +478,20 @@ export const OPPORTUNITY_STATUS_SCHEMA: Record<string, ConnectorFieldSchema> = {
   ...MAKO_SYSTEM_FIELDS,
 };
 
+export const OUTCOME_SCHEMA: Record<string, ConnectorFieldSchema> = {
+  id: { type: "string", required: true },
+  name: s(),
+  description: s(),
+  type: s(),
+  organization_id: s(),
+  created_by: s(),
+  updated_by: s(),
+  date_created: ts(),
+  date_updated: ts(),
+  applies_to: j(),
+  ...MAKO_SYSTEM_FIELDS,
+};
+
 // ---------------------------------------------------------------------------
 // Schema maps for resolveSchema lookup
 // ---------------------------------------------------------------------------
@@ -512,6 +526,7 @@ export const CORE_ENTITY_SCHEMA_MAP: Record<
   custom_objects: CUSTOM_OBJECT_SCHEMA,
   lead_statuses: LEAD_STATUS_SCHEMA,
   opportunity_statuses: OPPORTUNITY_STATUS_SCHEMA,
+  outcomes: OUTCOME_SCHEMA,
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add an `outcomes` entity to the Close connector (`GET /api/v1/outcome/`) via the existing `SIMPLE_ENTITY_ENDPOINTS` pattern, so the outcomes lookup table (id -> "Demo Booked", "Qualified", ...) referenced by `outcome_id` on calls/meetings is synced. Backfill-only — Close has no `outcome.*` webhook events (same as statuses/custom types).
- Add `OUTCOME_SCHEMA` (per Close OpenAPI spec) and register it in `CORE_ENTITY_SCHEMA_MAP`.
- Add `outcome_reason`, `outcome_autofill_confidence`, `outcome_autofill_reasoning` to the Search API `_fields` selection — these exist in `CALL_SCHEMA`/`MEETING_SCHEMA` but were silently dropped during backfill.
- **Schema-driven entity configuration UI**: replace the hardcoded per-connector entity lists in `WebhookFlowForm` with the `/connectors/:id/entities` endpoint (per the connector-agnostic rule). Close and Stripe now expose complete `getEntityMetadata()` with layout suggestions; `availableEntitiesStore` gained typed metadata + a generic `flattenConnectorEntities` helper that expands sub-entities (`activities:Call`, ...). Future connector entities appear in the flow form automatically.

## Test plan

- [x] `pnpm --filter api run lint` passes
- [x] `tsc -p tsconfig.build.json --noEmit` (api) passes
- [x] `pnpm --filter app run typecheck && pnpm --filter app run lint` passes
- [ ] Open the webhook flow form for a Close source and verify the entity list (incl. Outcomes) renders from the API with correct partition fields
- [ ] Verify an existing flow's saved entity layouts are preserved when reopening the form
- [ ] Trigger a Close flow sync and verify the `outcomes` collection materializes