### PR TITLE
Auto-detect local databases; fix Mako Agent detection in the desktop shell

### DIFF
--- a/app/src/components/CreateDatabaseDialog.tsx
+++ b/app/src/components/CreateDatabaseDialog.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useState, useCallback, useRef } from "react";
+import React, {
+  useEffect,
+  useState,
+  useCallback,
+  useMemo,
+  useRef,
+} from "react";
 import {
   Dialog,
   DialogTitle,
@@ -19,9 +25,6 @@ import {
   Avatar,
   IconButton,
   InputAdornment,
-  FormControlLabel,
-  Switch,
-  Tooltip,
 } from "@mui/material";
 import Accordion from "@mui/material/Accordion";
 import AccordionSummary from "@mui/material/AccordionSummary";
@@ -36,7 +39,11 @@ import { useWorkspace } from "../contexts/workspace-context";
 import { useDatabaseCatalogStore } from "../store/databaseCatalogStore";
 import { useSchemaStore } from "../store/schemaStore";
 import { useLocalAgentStore } from "../store/localAgentStore";
-import { isLocalConnectionId } from "../lib/local-agent-client";
+import {
+  isLocalConnectionId,
+  connectionLooksLocal,
+} from "../lib/local-agent-client";
+import { isMakoDesktop } from "../lib/desktop";
 import { useForm, Controller } from "react-hook-form";
 import { trackEvent } from "../lib/analytics";
 import {
@@ -93,12 +100,17 @@ const CreateDatabaseDialog: React.FC<CreateDatabaseDialogProps> = ({
     error?: string;
   } | null>(null);
 
-  // Local connection (Mako Agent) state
+  // Local connection (Mako Agent) state. Local addresses are detected from
+  // the form values and routed through the agent automatically — no toggle.
   const isEditingLocal = isLocalConnectionId(databaseId);
-  const [storeLocally, setStoreLocally] = useState(false);
+  const isDesktop = isMakoDesktop();
   const agentStatus = useLocalAgentStore(s => s.status);
   const ensureAgentChecked = useLocalAgentStore(s => s.ensureChecked);
   const checkAgent = useLocalAgentStore(s => s.checkAgent);
+
+  const agentOfflineMessage = isDesktop
+    ? "The Mako Agent isn't reachable on this machine. Try restarting Mako Desktop."
+    : "This database is on your local network, which Mako Cloud can't reach. Install Mako Desktop or run the Mako Agent on this machine, then try again.";
 
   // Ref to prevent infinite loops in two-way binding
   const isUpdatingFromConnectionString = useRef(false);
@@ -150,15 +162,41 @@ const CreateDatabaseDialog: React.FC<CreateDatabaseDialogProps> = ({
     setTestingConnection(true);
     setTestResult(null);
 
+    const looksLocal = connectionLooksLocal(values.connection);
+    // Existing connections keep their home (cloud or agent); new connections
+    // are routed by address detection.
+    const local = isEditingLocal || (!databaseId && looksLocal);
+
     try {
+      if (local) {
+        // Fresh probe: the agent may have been started since the last check.
+        const status = await checkAgent();
+        if (status !== "online") {
+          setTestResult({ success: false, error: agentOfflineMessage });
+          return;
+        }
+      }
+
       const res = await testConnection(
         currentWorkspace.id,
         {
           type: values.type,
           connection: values.connection,
         },
-        { local: storeLocally || isEditingLocal },
+        { local },
       );
+
+      if (!res.success && !local && looksLocal) {
+        // Editing a cloud connection pointed at a local address: the cloud
+        // server can never reach it, so explain instead of surfacing a bare
+        // ECONNREFUSED.
+        setTestResult({
+          success: false,
+          error: `${res.error || "Connection failed"} — this address points at your local network, which Mako Cloud can't reach. Create a new connection instead; local addresses connect through the Mako Agent automatically.`,
+        });
+        return;
+      }
+
       setTestResult(res);
     } catch (err) {
       setTestResult({
@@ -168,11 +206,34 @@ const CreateDatabaseDialog: React.FC<CreateDatabaseDialogProps> = ({
     } finally {
       setTestingConnection(false);
     }
-  }, [currentWorkspace, watch, testConnection, storeLocally, isEditingLocal]);
+  }, [
+    currentWorkspace,
+    watch,
+    testConnection,
+    isEditingLocal,
+    databaseId,
+    checkAgent,
+    agentOfflineMessage,
+  ]);
 
   // Watch PostgreSQL fields for two-way binding
   const watchedConnection = watch("connection");
   const watchedType = watch("type");
+
+  // Detect local addresses (localhost, 127.0.0.1, private LAN ranges, ...)
+  // to drive routing and the web-only informational banner.
+  const looksLocal = useMemo(
+    () => connectionLooksLocal(watchedConnection),
+    [watchedConnection],
+  );
+
+  // Probe the agent as soon as a local address is detected so the banner and
+  // routing reflect reality (cheap no-op while a probe is already in flight).
+  useEffect(() => {
+    if (looksLocal) {
+      checkAgent().catch(() => undefined);
+    }
+  }, [looksLocal, checkAgent]);
 
   const supportsConnectionStringType =
     watchedType === "postgresql" ||
@@ -326,11 +387,10 @@ const CreateDatabaseDialog: React.FC<CreateDatabaseDialogProps> = ({
       reset({ name: "", type: "", connection: {} });
       setStep("select");
       setError(null);
-      setStoreLocally(false);
     }
 
-    // Detect the Mako Local Agent so the "local connection" toggle reflects
-    // availability when the dialog opens.
+    // Detect the Mako Local Agent early so local-address routing and the
+    // web banner are ready by the time the user fills in the form.
     ensureAgentChecked().catch(() => undefined);
   }, [
     open,
@@ -361,8 +421,19 @@ const CreateDatabaseDialog: React.FC<CreateDatabaseDialogProps> = ({
     setError(null);
     setTestResult(null);
     try {
+      const local =
+        isEditingLocal ||
+        (!databaseId && connectionLooksLocal(values.connection));
+
+      if (local) {
+        const status = await checkAgent();
+        if (status !== "online") {
+          throw new Error(agentOfflineMessage);
+        }
+      }
+
       const res = await saveDatabase(currentWorkspace.id, values, databaseId, {
-        local: storeLocally || isEditingLocal,
+        local,
       });
 
       if (!res.success) {
@@ -540,53 +611,27 @@ const CreateDatabaseDialog: React.FC<CreateDatabaseDialogProps> = ({
                 autoComplete="off"
               />
 
-              {/* Local connection toggle (Mako Agent) */}
-              <Box sx={{ mt: 1 }}>
-                <Tooltip
-                  title={
-                    agentStatus === "online" || isEditingLocal
-                      ? ""
-                      : "The Mako Agent is not running on this machine. Start it with: pnpm --filter @mako/local-agent dev"
+              {/* Local-address banner: web only. Inside Mako Desktop the
+                  agent is bundled and routing is automatic, so nothing is
+                  shown. */}
+              {!isDesktop && looksLocal && (
+                <Alert
+                  severity={
+                    databaseId && !isEditingLocal
+                      ? "warning"
+                      : agentStatus === "online"
+                        ? "info"
+                        : "warning"
                   }
-                  placement="top-start"
+                  sx={{ mt: 2 }}
                 >
-                  <span>
-                    <FormControlLabel
-                      control={
-                        <Switch
-                          checked={storeLocally || isEditingLocal}
-                          onChange={e => {
-                            if (e.target.checked && agentStatus !== "online") {
-                              // Re-probe in case the agent was just started.
-                              checkAgent().then(status => {
-                                if (status === "online") setStoreLocally(true);
-                              });
-                              return;
-                            }
-                            setStoreLocally(e.target.checked);
-                          }}
-                          disabled={
-                            isEditingLocal ||
-                            Boolean(databaseId) ||
-                            (agentStatus !== "online" && !storeLocally)
-                          }
-                          size="small"
-                        />
-                      }
-                      label="Local connection (via Mako Agent)"
-                    />
-                  </span>
-                </Tooltip>
-                <Typography
-                  variant="caption"
-                  color="text.secondary"
-                  display="block"
-                >
-                  {agentStatus === "online" || isEditingLocal
-                    ? "Queries run through the Mako Agent on this machine. Credentials are stored locally and never sent to Mako Cloud."
-                    : "Connect to databases running on this machine (localhost). Requires the Mako Agent."}
-                </Typography>
-              </Box>
+                  {databaseId && !isEditingLocal
+                    ? "This address points at your local network, which Mako Cloud can't reach. Create a new connection instead — local addresses connect through the Mako Agent automatically."
+                    : agentStatus === "online"
+                      ? "Local database detected. It will connect through the Mako Agent on this machine — credentials stay local and are never sent to Mako Cloud."
+                      : "Local database detected, which Mako Cloud can't reach. Install Mako Desktop or run the Mako Agent on this machine to connect."}
+                </Alert>
+              )}
 
               {/* Hidden input to register 'type' as required for validation */}
               <input

--- a/app/src/lib/desktop.ts
+++ b/app/src/lib/desktop.ts
@@ -1,0 +1,18 @@
+/**
+ * Detection for the Mako Desktop (Electron) shell. The desktop preload script
+ * exposes `window.makoDesktop`; the Electron UA token is stripped for OAuth
+ * compatibility, so user-agent sniffing does not work.
+ */
+
+declare global {
+  interface Window {
+    makoDesktop?: {
+      version: string;
+      platform: string;
+    };
+  }
+}
+
+export function isMakoDesktop(): boolean {
+  return typeof window !== "undefined" && Boolean(window.makoDesktop);
+}

--- a/app/src/lib/local-agent-client.ts
+++ b/app/src/lib/local-agent-client.ts
@@ -18,6 +18,69 @@ export function isLocalConnectionId(id: string | undefined | null): boolean {
   return Boolean(id && id.startsWith(LOCAL_CONNECTION_ID_PREFIX));
 }
 
+/**
+ * Hostnames/IPs that are only reachable from the user's machine or local
+ * network — i.e. addresses Mako Cloud can never connect to, which must be
+ * routed through the Local Agent instead.
+ */
+export function isLocalHostname(value: string | undefined | null): boolean {
+  if (!value) return false;
+  const host = value.trim().toLowerCase().replace(/^\[/, "").replace(/\]$/, "");
+  if (!host) return false;
+  if (host === "localhost" || host.endsWith(".localhost")) return true;
+  if (host === "::1" || host === "0:0:0:0:0:0:0:1") return true;
+  if (host.endsWith(".local") || host.endsWith(".internal")) return true;
+  const m = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!m) return false;
+  const a = Number(m[1]);
+  const b = Number(m[2]);
+  return (
+    a === 0 ||
+    a === 127 ||
+    a === 10 ||
+    (a === 192 && b === 168) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 169 && b === 254)
+  );
+}
+
+/** Extract hostnames from a URI-style connection string (handles multi-host
+ * lists like mongodb://h1:p1,h2:p2/db and bracketed IPv6 literals). */
+function extractHosts(connectionString: string): string[] {
+  const match = connectionString.match(
+    /^[a-z][a-z0-9+.-]*:\/\/(?:[^@/?#]*@)?([^/?#]+)/i,
+  );
+  if (!match) return [];
+  return match[1].split(",").map(part => {
+    const trimmed = part.trim();
+    const ipv6 = trimmed.match(/^\[([^\]]+)\]/);
+    return ipv6 ? ipv6[1] : trimmed.split(":")[0];
+  });
+}
+
+const HOST_FIELD_RE = /host|server|address|endpoint/i;
+const URL_FIELD_RE = /connectionstring|url|uri/i;
+
+/**
+ * True when a connection form's values point at a local address (localhost,
+ * 127.0.0.1, private LAN ranges, *.local, ...). Drives the automatic
+ * cloud-vs-agent routing decision so users never have to think about it.
+ */
+export function connectionLooksLocal(
+  connection: Record<string, unknown> | undefined | null,
+): boolean {
+  if (!connection) return false;
+  for (const [key, value] of Object.entries(connection)) {
+    if (typeof value !== "string" || !value) continue;
+    if (URL_FIELD_RE.test(key)) {
+      if (extractHosts(value).some(isLocalHostname)) return true;
+    } else if (HOST_FIELD_RE.test(key)) {
+      if (isLocalHostname(value)) return true;
+    }
+  }
+  return false;
+}
+
 interface AgentRequestOptions extends RequestInit {
   params?: Record<string, string>;
   timeoutMs?: number;
@@ -138,11 +201,19 @@ class LocalAgentClient {
     return this.request<T>(path, { method: "DELETE" });
   }
 
-  /** Quick liveness probe; resolves null when the agent is not running. */
+  /**
+   * Liveness probe; resolves null when the agent is not running.
+   *
+   * The timeout must outlive Chrome's Local Network Access permission prompt:
+   * the first probe from a browser blocks on the user accepting it, and a
+   * short timeout would abort the request (and mark the agent offline) before
+   * they can. When the agent is simply not running the socket is refused
+   * immediately, so the long timeout does not slow down that path.
+   */
   async ping(): Promise<AgentHealth | null> {
     try {
       return await this.get<AgentHealth>("/health", undefined, {
-        timeoutMs: 1500,
+        timeoutMs: 15000,
       });
     } catch {
       return null;

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mako/desktop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Mako Desktop: a thin Electron shell that loads the Mako web app and bundles the Mako Local Agent, enabling connections to databases on this machine.",
   "main": "dist/main.js",

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -131,6 +131,22 @@ app.userAgentFallback = app.userAgentFallback
   .replace(/ Electron\/[\d.]+/, "")
   .replace(/ mako-desktop\/[\d.]+/, "");
 
+// The HTTPS web app must call the plain-HTTP Local Agent on 127.0.0.1.
+// Chromium's Local/Private Network Access checks gate that behind a
+// permission prompt that Electron never renders, so the agent health probe
+// silently fails and the app believes the agent is offline. The shell only
+// loads the trusted Mako app, so disable those checks here. (Browsers keep
+// them; the web app handles the permission prompt there.)
+app.commandLine.appendSwitch(
+  "disable-features",
+  [
+    "LocalNetworkAccessChecks",
+    "PrivateNetworkAccessSendPreflights",
+    "PrivateNetworkAccessRespectPreflightResults",
+    "PrivateNetworkAccessPermissionPrompt",
+  ].join(","),
+);
+
 const hasSingleInstanceLock = app.requestSingleInstanceLock();
 if (!hasSingleInstanceLock) {
   app.quit();


### PR DESCRIPTION
## Summary

Follow-up to #474. The "Local connection (via Mako Agent)" toggle reported *"The Mako Agent is not running on this machine"* even inside Mako Desktop, where the shell had spawned the agent and it was healthy on `127.0.0.1:41720`.

**Root cause:** Chromium's Local/Private Network Access checks gate the HTTPS page's fetch to the plain-HTTP loopback agent behind a permission prompt that Electron never renders, so the health probe silently failed. On the web, the 1.5s ping timeout aborted the probe while Chrome's permission prompt was still waiting for the user.

### Changes

- **Toggle removed — routing is automatic.** `connectionLooksLocal()` detects local addresses (`localhost`, `127.x`, `::1`, `10/8`, `172.16/12`, `192.168/16`, `169.254/16`, `*.local`, `*.internal`) in host fields and URI-style connection strings (incl. multi-host MongoDB lists and bracketed IPv6). New connections with a local address are stored at and routed through the agent; credentials never leave the machine.
- **Web-only banner.** When a local address is detected, the browser shows an info banner (agent online) or a warning pointing at Mako Desktop / the agent (agent offline). Inside Mako Desktop nothing is shown — the agent is bundled and it just works (detected via the `window.makoDesktop` preload bridge, new `app/src/lib/desktop.ts`).
- **Actionable errors instead of bare ECONNREFUSED.** Editing an existing *cloud* connection pointed at a local address keeps cloud routing (its credentials live in the cloud), but test failures now explain that Mako Cloud can't reach the user's machine and suggest creating a new connection.
- **Desktop shell fix.** Disable `LocalNetworkAccessChecks` / `PrivateNetworkAccess*` features in the Electron shell (it only loads the trusted Mako app), so loopback fetches work without an invisible prompt. Version bumped to **0.1.1** → ships a desktop release on merge.
- **Health-ping timeout 1.5s → 15s** so the browser's LNA permission prompt can be answered; a stopped agent still fails instantly (connection refused).

### Verification

- `pnpm --filter app run typecheck && pnpm --filter app run lint` ✅
- `pnpm --filter @mako/desktop run typecheck && build` ✅
- Detection helper validated against 16 cases (Neon/Atlas/ClickHouse cloud hosts stay cloud; `172.20.x` local vs `172.32.x` cloud boundary correct) ✅
- End-to-end on macOS: dev shell (`MAKO_DESKTOP_URL=http://localhost:5173`) spawns the agent, auto-detects `postgresql://mock:mockpass@localhost:5433/mockdb`, no toggle/banner shown, test connection succeeds against a local OrbStack Postgres ✅

## Test plan

- [ ] Web (Chrome): create connection with a `localhost` address → banner appears, LNA permission prompt accepted, test connection succeeds via agent
- [ ] Web with agent stopped: warning banner + clear error on test
- [ ] Desktop: local address → no banner, test + save route through the bundled agent
- [ ] Desktop release 0.1.1 builds and agent detection works in the packaged app
- [ ] Cloud connections (e.g. Neon/Atlas) are unaffected and never routed to the agent

Made with [Cursor](https://cursor.com)