### PR TITLE
desktop: bump to 0.3.0 to cut the deep-link sign-in release

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mako/desktop",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "Mako Desktop: a thin Electron shell that loads the Mako web app and bundles the Mako Local Agent, enabling connections to databases on this machine.",
   "main": "dist/main.js",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

PR #480 (browser-based desktop sign-in via `mako://` deep link) was merged at a commit just before the desktop version bump landed on the branch, so master still reads `packages/desktop/package.json` at `0.2.0`. The release workflow therefore skipped: `desktop-v0.2.0` already exists (see the skipped run noted in review).

Without a new release there is no desktop binary that registers the `mako://` scheme — and nothing for the auto-updater on installed `0.2.0` builds to pick up.

## What

Single commit: bump `packages/desktop` version `0.2.0 → 0.3.0`.

Merging this touches `packages/desktop/**` on master, which triggers `release-desktop.yml`; `desktop-v0.3.0` doesn't exist, so it will build and publish the signed/notarized installers with deep-link sign-in support, and existing `0.2.0` installs will auto-update to it.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a551064-2796-49e9-8920-fc4a2d88524e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a551064-2796-49e9-8920-fc4a2d88524e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

