### PR TITLE
Guides: Batch 10 — connection guides (2026-06-11)

### DIFF
--- a/content/guides/bigquery/connect-from-go.mdx
+++ b/content/guides/bigquery/connect-from-go.mdx
@@ -1,0 +1,198 @@
+---
+title: "How to Connect to BigQuery from Go"
+description: "Connect to BigQuery from Go with the official cloud.google.com/go/bigquery client. Working code for the ADC auth ladder, parameterized queries, RowIterator scanning, cost controls, and the dataset-location trap."
+database: "bigquery"
+category: "how-to"
+tags: ["bigquery", "go", "golang", "google-cloud", "connection"]
+date: "2026-06-16"
+---
+
+BigQuery is not a server you open a TCP connection to. There is no host, no port, no connection string. It is a REST API behind Google's auth layer, and the Go client (`cloud.google.com/go/bigquery`) wraps that API in a typed client. The two things that actually trip people up are authentication (which credential is the library picking up?) and the dataset location (a query that "can't find" a table is usually looking in the wrong region). This guide covers both, plus parameterized queries, result scanning, and the cost controls you want before you point this at production data.
+
+## The package
+
+| Package | Import path | Purpose | Version (as of June 2026) |
+|---|---|---|---|
+| BigQuery client | `cloud.google.com/go/bigquery` | queries, jobs, table management | v1.77.0 |
+| Storage Write API | `cloud.google.com/go/bigquery/storage/managedwriter` | high-throughput streaming ingestion | v1.70.0 (within the bigquery module's storage tree) |
+
+For querying and ordinary inserts, the main `bigquery` package is all you need. The Storage Write API is a separate, lower-level path for ingestion pipelines pushing large volumes of rows; most applications never touch it.
+
+```bash
+go get cloud.google.com/go/bigquery
+```
+
+## Authentication: the ADC ladder
+
+The client uses Application Default Credentials (ADC). You do not pass keys in code. The library walks a fixed search order and uses the first credential it finds:
+
+1. `GOOGLE_APPLICATION_CREDENTIALS` pointing at a service-account JSON key file.
+2. Credentials from `gcloud auth application-default login` (your user account, for local development).
+3. The service account attached to the compute resource (Cloud Run, GKE, GCE, Cloud Functions) when running on Google Cloud.
+
+The recommended setup:
+
+- **On Google Cloud:** attach a service account to the resource and grant it the right BigQuery roles. No keys, nothing to rotate or leak. This is option 3.
+- **Local development:** run `gcloud auth application-default login` once. This is option 2.
+- **Outside Google Cloud (another cloud, on-prem):** a service-account key file via the env var, treated as a secret. This is option 1, and the one to avoid if you have any alternative, because key files are the thing that ends up in a Git history.
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	"cloud.google.com/go/bigquery"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// projectID is the billing/compute project. It can differ from the
+	// project that owns the data you query (see the two-project note below).
+	client, err := bigquery.NewClient(ctx, "my-billing-project")
+	if err != nil {
+		log.Fatalf("bigquery.NewClient: %v", err)
+	}
+	defer client.Close()
+
+	// client is safe for concurrent use. Create it once and share it.
+	_ = client
+}
+```
+
+The client holds connections and an HTTP transport, so create one at startup and reuse it across goroutines rather than constructing one per request.
+
+## Running a query
+
+`client.Query` builds a query job; `Read` starts it and returns a `RowIterator`. Scan rows into a struct whose exported fields match the column names (case-insensitively), or into a `[]bigquery.Value` for ad-hoc shapes.
+
+```go
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	"cloud.google.com/go/bigquery"
+	"google.golang.org/api/iterator"
+)
+
+type Customer struct {
+	ID     int64
+	Name   string
+	Region string
+}
+
+func run(ctx context.Context, client *bigquery.Client) error {
+	q := client.Query(`
+		SELECT id, name, region
+		FROM ` + "`my-data-project.sales.customers`" + `
+		WHERE region = @region
+		LIMIT 100
+	`)
+	q.Parameters = []bigquery.QueryParameter{
+		{Name: "region", Value: "EMEA"},
+	}
+
+	it, err := q.Read(ctx)
+	if err != nil {
+		return fmt.Errorf("query: %w", err)
+	}
+
+	for {
+		var c Customer
+		err := it.Next(&c)
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("iterate: %w", err)
+		}
+		fmt.Printf("%d: %s (%s)\n", c.ID, c.Name, c.Region)
+	}
+	return nil
+}
+```
+
+A few things worth knowing:
+
+- Use named parameters (`@region`) with `bigquery.QueryParameter`. Never string-concatenate user input into the SQL; parameters are both safer and let BigQuery cache the query plan. Positional `?` parameters are also supported if you set them in order.
+- `iterator.Done` is the sentinel that ends the loop. It comes from `google.golang.org/api/iterator`, a separate import. Comparing against it with `errors.Is` is the idiomatic check.
+- Struct scanning matches field names to columns, so capitalize your Go fields (`ID`, not `Id`, will both match a column named `id`). For columns that do not map cleanly, use a `bigquery.ValueLoader` or scan into `[]bigquery.Value`.
+
+## The location trap
+
+This is the single most common BigQuery error that looks like something else. Datasets live in a specific location (region or multi-region, like `EU`, `US`, or `asia-northeast1`). If your query job runs in a different location than the dataset it reads, BigQuery returns a "Not found: Dataset ..." error that reads exactly like a permissions or typo problem. It is neither.
+
+Set the location on the query when your data is not in the default (`US`) multi-region:
+
+```go
+q := client.Query("SELECT ...")
+q.Location = "EU"
+it, err := q.Read(ctx)
+```
+
+If you store everything in one location, set `client.Location = "EU"` once after creating the client and forget about it. The symptom to remember: a table you can see in the console but the query says "Not found" means check the location before you check anything else.
+
+## Cost controls
+
+BigQuery charges by bytes scanned. A single careless `SELECT *` over a large table can cost real money, and from Go you cannot see the query editor's byte estimate. Two controls matter:
+
+```go
+q := client.Query("SELECT ...")
+
+// Hard cap: the job fails instead of running if it would scan more
+// than this many bytes. 1e9 = ~1 GB.
+q.MaxBytesBilled = 1_000_000_000
+
+// Dry run: validates the query and reports bytes that WOULD be
+// processed, without running it or incurring cost.
+q.DryRun = true
+job, err := q.Run(ctx)
+if err != nil {
+	log.Fatalf("dry run: %v", err)
+}
+status := job.LastStatus()
+fmt.Printf("would process %d bytes\n", status.Statistics.TotalBytesProcessed)
+```
+
+Set `MaxBytesBilled` on any query that runs against untrusted input or large tables. It is the equivalent of a circuit breaker, and it has saved teams from five-figure surprise bills. Use `DryRun` in tests or pre-flight checks to catch expensive queries before they ship.
+
+## Streaming large result sets
+
+The `RowIterator` pages through results automatically, fetching the next page as you iterate, so reading a million rows does not buffer them all in memory at once. You do not need a separate streaming API for reads. For very large extractions where even paged REST reads are a bottleneck, the BigQuery Storage Read API (`cloud.google.com/go/bigquery/storage`) provides a faster columnar path, but the standard iterator is correct for the overwhelming majority of cases.
+
+## Billing project vs data project
+
+Two project IDs show up and they are not always the same:
+
+- The **billing/compute project** is the one you pass to `bigquery.NewClient`. Query costs are charged here, and your credentials need the `bigquery.jobs.create` permission (the `BigQuery Job User` role) on it.
+- The **data project** is whatever appears in the fully-qualified table name (`` `my-data-project.sales.customers` ``). Your credentials need read access to that dataset (`BigQuery Data Viewer` is enough for reads).
+
+Querying data in someone else's project while paying for it from yours is normal and expected; just make sure the credential has both the job-creation permission on the billing project and the data-access permission on the data project.
+
+## Common errors
+
+| Error | Cause | Fix |
+|---|---|---|
+| `Not found: Dataset ...` | query location does not match dataset location | set `q.Location` or `client.Location` |
+| `could not find default credentials` | ADC found nothing | set `GOOGLE_APPLICATION_CREDENTIALS` or run `gcloud auth application-default login` |
+| `Access Denied: ... bigquery.jobs.create` | credential lacks job permission on billing project | grant `BigQuery Job User` |
+| `Access Denied: ... Table ...` | credential cannot read the data | grant `BigQuery Data Viewer` on the dataset |
+| `Query exceeded limit for bytes billed` | query scans more than `MaxBytesBilled` | raise the cap or narrow the query |
+| `Syntax error` on a backticked table | wrong quoting of the table identifier | wrap the full name in backticks, not quotes |
+
+## Related guides
+
+- [Importing CSV data into BigQuery](/guides/import-csv-to-bigquery)
+- [The best BigQuery GUI clients](/guides/bigquery-gui-client)
+- [Connecting to BigQuery from Python](/guides/bigquery/connect-from-python)
+- [Connecting to BigQuery from Node.js](/guides/bigquery/connect-from-node)
+
+---
+
+Mako connects to BigQuery, ClickHouse, PostgreSQL, and more, with AI-powered autocomplete for exploring your tables. Try it free at mako.ai.

--- a/content/guides/bigquery/connect-from-node.mdx
+++ b/content/guides/bigquery/connect-from-node.mdx
@@ -1,0 +1,190 @@
+---
+title: "How to Connect to BigQuery from Node.js"
+description: "Connect to BigQuery from Node.js with @google-cloud/bigquery. Working code for ADC and service-account auth, queries, named and positional parameters, DataFrame-free result handling, and cost controls."
+database: "bigquery"
+category: "how-to"
+tags: ["bigquery", "nodejs", "google-cloud-bigquery", "connection"]
+date: "2026-06-15"
+---
+
+Connecting to BigQuery from Node.js is unlike connecting to PostgreSQL or MySQL: there is no host, port, or connection string. BigQuery is an API, so "connecting" means authenticating with Google Cloud credentials and pointing a client at a project. The auth setup is the real work; the query code is a few lines.
+
+There is one client that matters: `@google-cloud/bigquery`, maintained by Google. Current version is 8.3.1 (as of June 2026). It requires Node.js 18 or later.
+
+```bash
+npm install @google-cloud/bigquery
+```
+
+## Step 0: authentication
+
+The client uses Application Default Credentials (ADC), the same resolution every Google Cloud library uses. It looks for credentials in this order:
+
+1. The `GOOGLE_APPLICATION_CREDENTIALS` environment variable pointing at a service-account JSON key file.
+2. Credentials from `gcloud auth application-default login` (local development).
+3. The service account attached to the runtime (Cloud Run, GCE, GKE, Cloud Functions) when running inside Google Cloud.
+
+For local development, the cleanest path is a service-account key referenced by environment variable:
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/key.json"
+```
+
+Treat that JSON file like a password: keep it out of git, rotate it, and prefer workload identity federation over long-lived keys where your platform supports it. Inside Google Cloud, do not ship a key file at all -- attach a service account to the workload and ADC picks it up automatically.
+
+You can also pass a key file path directly to the constructor, which is occasionally useful in scripts but should not be your default:
+
+```js
+const bigquery = new BigQuery({
+  projectId: "your-project-id",
+  keyFilename: "/path/to/key.json",
+});
+```
+
+## Connecting and querying
+
+```js
+import { BigQuery } from "@google-cloud/bigquery";
+
+const bigquery = new BigQuery({ projectId: "your-project-id" });
+// projectId is optional if ADC carries a default project
+
+async function main() {
+  const [rows] = await bigquery.query({
+    query: `
+      SELECT name, SUM(number) AS total
+      FROM \`bigquery-public-data.usa_names.usa_1910_2013\`
+      WHERE state = 'TX'
+      GROUP BY name
+      ORDER BY total DESC
+      LIMIT 10
+    `,
+  });
+
+  for (const row of rows) {
+    console.log(row.name, row.total);
+  }
+}
+
+main();
+```
+
+`query()` submits the job, waits for it to finish, and returns the rows in a single array destructured as `[rows]` (the method resolves to an array whose first element is the rows). Each row is a plain object keyed by column name.
+
+The `projectId` you give the client is the *billing* project -- where the query job runs and where the cost lands. The project in the table reference is where the *data* lives. That split is how you can query `bigquery-public-data` tables while the bill goes to your own project.
+
+### query() vs createQueryJob()
+
+`query()` is the right default: it runs the job and returns rows. When you need the job object itself -- to read its ID, poll statistics, or fire a long-running query without blocking -- use `createQueryJob()`:
+
+```js
+const [job] = await bigquery.createQueryJob({ query: sql });
+console.log("Job ID:", job.id);
+const [rows] = await job.getQueryResults();
+```
+
+## Query parameters
+
+Never build SQL with template literals around user input. BigQuery supports both named and positional parameters.
+
+Named parameters use `@name` in the SQL and a `params` object:
+
+```js
+const [rows] = await bigquery.query({
+  query: `
+    SELECT name
+    FROM \`bigquery-public-data.usa_names.usa_1910_2013\`
+    WHERE state = @state AND number > @minTotal
+  `,
+  params: { state: "TX", minTotal: 1000 },
+});
+```
+
+Positional parameters use `?` and a `params` array:
+
+```js
+const [rows] = await bigquery.query({
+  query: "SELECT name FROM `...` WHERE state = ? AND number > ?",
+  params: ["TX", 1000],
+});
+```
+
+The client infers BigQuery types from JavaScript values, which is usually right. When it cannot -- the most common case is a `NULL` value, where there is nothing to infer from -- pass an explicit `types` map:
+
+```js
+const [rows] = await bigquery.query({
+  query: "SELECT * FROM dataset.events WHERE country = @country",
+  params: { country: null },
+  types: { country: "STRING" },
+});
+```
+
+## Location
+
+BigQuery jobs run in the location (region or multi-region) of the data they touch. If your dataset lives in `EU` or `asia-northeast1` rather than the default `US`, a query that omits the location fails with a `Not found: Dataset` error that looks like a permissions problem but is not. Set it explicitly:
+
+```js
+const [rows] = await bigquery.query({
+  query: sql,
+  location: "EU",
+});
+```
+
+This is the single most common source of confusion when moving code between projects in different regions.
+
+## Cost controls
+
+You pay per byte scanned on on-demand pricing, and a careless `SELECT *` over a large table costs real money. Two mechanisms are worth wiring in from the start.
+
+A dry run reports the bytes a query would scan without running it:
+
+```js
+const [job] = await bigquery.createQueryJob({
+  query: sql,
+  dryRun: true,
+});
+const bytes = Number(job.metadata.statistics.totalBytesProcessed);
+console.log(`Would process ${(bytes / 1e9).toFixed(2)} GB`);
+```
+
+A maximum-bytes-billed cap aborts the query if it would scan more than the limit, which protects you from a runaway `JOIN`:
+
+```js
+const [rows] = await bigquery.query({
+  query: sql,
+  maximumBytesBilled: "1000000000", // 1 GB, as a string
+});
+```
+
+## Streaming large result sets
+
+`query()` buffers the entire result set into memory. For results too large to hold at once, use the streaming interface, which pages under the hood and emits rows as they arrive:
+
+```js
+bigquery
+  .createQueryStream({ query: sql })
+  .on("data", (row) => {
+    /* handle one row */
+  })
+  .on("end", () => console.log("done"))
+  .on("error", console.error);
+```
+
+For genuinely large extractions, the BigQuery Storage Read API (a separate gRPC client, `@google-cloud/bigquery-storage`) downloads results over parallel streams and is substantially faster, at the cost of more setup.
+
+## Error reference
+
+| Error | Cause | Fix |
+|---|---|---|
+| `Could not load the default credentials` | ADC found nothing | Set `GOOGLE_APPLICATION_CREDENTIALS` or run `gcloud auth application-default login` |
+| `Not found: Dataset ...` on a dataset that exists | Job ran in the wrong location | Pass `location` matching the dataset's region |
+| `Access Denied: ... bigquery.jobs.create` | Service account lacks job-creation rights | Grant **BigQuery Job User** on the billing project |
+| `Query exceeded limit for bytes billed` | `maximumBytesBilled` cap hit | Narrow the query or raise the cap deliberately |
+| `Syntax error: Unexpected ...` | Legacy SQL assumed | BigQuery defaults to Standard SQL; check backtick table refs |
+
+## Verifying your data
+
+Once connected, you usually want to browse what is in the warehouse. The BigQuery console works; a desktop client is faster for jumping between projects and datasets. We compared the options in [Best BigQuery GUI Clients](/guides/bigquery-gui-client). For loading data, see [Import CSV to BigQuery](/guides/import-csv-to-bigquery) and [Import JSON to BigQuery](/guides/import-json-to-bigquery).
+
+---
+
+Mako connects to BigQuery (and 8 other databases) with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/bigquery/connect-from-python.mdx
+++ b/content/guides/bigquery/connect-from-python.mdx
@@ -1,0 +1,196 @@
+---
+title: "How to Connect to BigQuery from Python"
+description: "Connect to BigQuery from Python with google-cloud-bigquery, pandas-gbq, or BigQuery DataFrames. Working code for auth (ADC and service accounts), queries, parameters, and cost controls."
+database: "bigquery"
+category: "how-to"
+tags: ["bigquery", "python", "google-cloud-bigquery", "pandas-gbq", "connection"]
+date: "2026-06-12"
+---
+
+Connecting to BigQuery is unlike connecting to PostgreSQL or MySQL: there is no host, port, or connection string. BigQuery is an API, and "connecting" means authenticating with Google Cloud credentials and pointing a client at a project. That makes the auth setup the actual hard part -- the query code is three lines.
+
+Three libraries matter, all installable from PyPI. Versions verified June 2026.
+
+## Which library should you use?
+
+| Library | Version | Maintainer | Use case |
+|---|---|---|---|
+| google-cloud-bigquery | 3.41.0 | Google | The core client. Queries, jobs, datasets, tables, admin. |
+| pandas-gbq | 0.35.0 | PyData / open source | Thin wrapper: SQL in, DataFrame out, DataFrame back up |
+| bigframes (BigQuery DataFrames) | 2.42.0 | Google | pandas-like API where computation runs server-side in BigQuery |
+
+Short version: use **google-cloud-bigquery** as the default. It wraps the full API and everything else builds on it. Reach for **pandas-gbq** if your whole interaction is "run SQL, get DataFrame" and you want the one-liner. Use **bigframes** when the data is too big to pull client-side -- it pushes pandas-style operations down into BigQuery slots instead of copying data to your machine.
+
+## Step 0: authentication
+
+Every option below uses the same credential resolution, called Application Default Credentials (ADC). The client looks for credentials in this order:
+
+1. The `GOOGLE_APPLICATION_CREDENTIALS` environment variable pointing at a service account JSON key file
+2. Credentials you set up with `gcloud auth application-default login`
+3. The built-in service account, if running on GCP (Cloud Run, GCE, Cloud Functions)
+
+For local development, the simplest correct setup is:
+
+```bash
+gcloud auth application-default login
+```
+
+For servers and CI outside Google Cloud, create a service account with the **BigQuery Job User** role (plus **BigQuery Data Viewer** on the datasets it reads), download a JSON key, and point the env var at it:
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/key.json"
+```
+
+Treat that JSON file like a password: keep it out of git, rotate it, and prefer workload identity federation over long-lived keys when your platform supports it. Inside Google Cloud, do not use key files at all -- attach a service account to the workload and ADC picks it up automatically.
+
+## google-cloud-bigquery (recommended)
+
+Install:
+
+```bash
+pip install google-cloud-bigquery
+```
+
+Requires Python 3.9+. Connect and query:
+
+```python
+from google.cloud import bigquery
+
+client = bigquery.Client(project="your-project-id")  # project optional if ADC carries a default
+
+rows = client.query_and_wait(
+    """
+    SELECT name, SUM(number) AS total
+    FROM `bigquery-public-data.usa_names.usa_1910_2013`
+    WHERE state = 'TX'
+    GROUP BY name
+    ORDER BY total DESC
+    LIMIT 10
+    """
+)
+
+for row in rows:
+    print(row.name, row.total)  # rows support attribute and dict-style access
+```
+
+`query_and_wait()` submits the query and blocks until results are ready. The older pattern you will see in most tutorials -- `client.query(sql)` followed by `.result()` -- still works and is what you want when you need the job object itself (for job IDs, statistics, or fire-and-forget jobs).
+
+Note the project in the client is the *billing* project (where the query job runs); the project in the table reference is where the *data* lives. That is how you can query `bigquery-public-data` tables while the bill lands on your project.
+
+### Query parameters
+
+BigQuery uses named `@parameters`, passed via job config -- never f-strings:
+
+```python
+from google.cloud import bigquery
+
+job_config = bigquery.QueryJobConfig(
+    query_parameters=[
+        bigquery.ScalarQueryParameter("state", "STRING", "TX"),
+        bigquery.ScalarQueryParameter("min_total", "INT64", 1000),
+    ]
+)
+
+rows = client.query_and_wait(
+    "SELECT name FROM `bigquery-public-data.usa_names.usa_1910_2013` WHERE state = @state AND number > @min_total",
+    job_config=job_config,
+)
+```
+
+### Results as a DataFrame
+
+```bash
+pip install 'google-cloud-bigquery[bqstorage,pandas]'
+```
+
+```python
+df = client.query_and_wait(sql).to_dataframe()
+```
+
+Two things hide in that extras bracket. `pandas` pulls in `db-dtypes`, which maps BigQuery types (DATE, TIME, NUMERIC) onto pandas -- without it, `to_dataframe()` raises an error telling you to install it. `bqstorage` installs the BigQuery Storage API client, which downloads results over a parallel gRPC stream instead of paging through the REST API. For results beyond a few tens of MB the difference is large; the client uses it automatically when installed (the service account also needs `bigquery.readsessions.create`, included in the **BigQuery Read Session User** role).
+
+### Cost controls
+
+You pay per byte scanned (on-demand pricing), and a careless `SELECT *` over a large table costs real money. Two mechanisms worth wiring in from day one:
+
+```python
+# Dry run: how much would this scan?
+job_config = bigquery.QueryJobConfig(dry_run=True, use_query_cache=False)
+job = client.query(sql, job_config=job_config)
+print(f"Would process {job.total_bytes_processed / 1e9:.2f} GB")
+
+# Hard cap: fail instead of scanning more than 1 GB
+job_config = bigquery.QueryJobConfig(maximum_bytes_billed=10**9)
+```
+
+`maximum_bytes_billed` fails the query *before* it runs if the estimate exceeds the cap -- cheap insurance on anything user-facing.
+
+### Loading data
+
+```python
+df_new = ...  # a pandas DataFrame
+job = client.load_table_from_dataframe(df_new, "your-project.dataset.table")
+job.result()
+```
+
+For files, `load_table_from_file` and `load_table_from_uri` (GCS) handle CSV, JSON, Parquet, and Avro. Loading is free (it uses the shared load pool); streaming inserts via `insert_rows_json` are not -- prefer batch loads unless you genuinely need rows visible within seconds.
+
+## pandas-gbq
+
+```bash
+pip install pandas-gbq
+```
+
+```python
+import pandas_gbq
+
+df = pandas_gbq.read_gbq(
+    "SELECT name, SUM(number) AS total FROM `bigquery-public-data.usa_names.usa_1910_2013` GROUP BY name",
+    project_id="your-project-id",
+)
+
+pandas_gbq.to_gbq(df, "dataset.table", project_id="your-project-id", if_exists="replace")
+```
+
+Same ADC auth, same Storage API speedup when installed. Use it when the wrapper is all you need; drop down to google-cloud-bigquery the moment you need job configs, parameters, or cost caps -- pandas-gbq accepts a raw API configuration dict, but at that point the core library is clearer.
+
+## BigQuery DataFrames (bigframes)
+
+```bash
+pip install bigframes
+```
+
+```python
+import bigframes.pandas as bpd
+
+bpd.options.bigquery.project = "your-project-id"
+
+df = bpd.read_gbq("bigquery-public-data.usa_names.usa_1910_2013")
+result = df.groupby("name")["number"].sum().sort_values(ascending=False).head(10)
+print(result.to_pandas())
+```
+
+The pandas-looking operations compile to SQL and execute in BigQuery; data only moves when you call `to_pandas()`. This is the right tool when the table is 500 GB and your laptop is not. The API covers a large subset of pandas (and scikit-learn, via `bigframes.ml`) but not all of it, and every operation is a query that bills like one -- the dry-run discipline above applies double.
+
+## SQLAlchemy
+
+`sqlalchemy-bigquery` (1.17.0, maintained by Google) provides a dialect with `bigquery://project-id` URLs. It works for SQLAlchemy Core queries and tools that speak SQLAlchemy (Superset, etc.). Know its place: BigQuery has no primary keys to enforce and DML is metered differently from OLTP databases, so ORM-style row manipulation is the wrong pattern even though it technically functions.
+
+## Common errors
+
+| Error | Likely cause |
+|---|---|
+| `DefaultCredentialsError: Could not automatically determine credentials` | No ADC set up -- run `gcloud auth application-default login` or set `GOOGLE_APPLICATION_CREDENTIALS` |
+| `403 Access Denied ... bigquery.jobs.create` | Service account lacks BigQuery Job User on the billing project |
+| `403 Access Denied` on a specific table | Missing BigQuery Data Viewer on that dataset |
+| `404 Not found: Dataset` | Wrong project in the table reference, or dataset in a different location than the job |
+| `Please install the 'db-dtypes' package` | `to_dataframe()` without the pandas extra |
+| `400 ... query exceeded limit for bytes billed` | Your own `maximum_bytes_billed` cap -- working as intended |
+
+The location one deserves a note: a query job runs in one location (US, EU, a region), and every dataset it touches must live there. Cross-location queries fail with a misleading "not found" error. Check dataset locations before assuming a permissions problem.
+
+## Verifying your connection
+
+`client.query_and_wait("SELECT SESSION_USER()")` confirms which identity you are authenticated as -- the answer is surprising often enough to make this the first debugging step. For browsing datasets, checking table schemas, and estimating scan sizes before you commit to a query, a GUI is faster than the API; see our [BigQuery GUI client guide](/guides/bigquery-gui-client) for options. For getting data in, the [CSV import guide](/guides/import-csv-to-bigquery) covers schema autodetection and its failure modes.
+
+Mako connects to BigQuery with AI-powered autocomplete. Try it free at mako.ai.

--- a/content/guides/clickhouse/connect-from-go.mdx
+++ b/content/guides/clickhouse/connect-from-go.mdx
@@ -1,0 +1,247 @@
+---
+title: "How to Connect to ClickHouse from Go"
+description: "Connect to ClickHouse from Go with the official clickhouse-go driver. Working code for the native vs database/sql interface, the 9000 vs 9440 vs 8123 port question, connection pooling, batch inserts, and TLS."
+database: "clickhouse"
+category: "how-to"
+tags: ["clickhouse", "go", "golang", "clickhouse-go", "connection"]
+date: "2026-06-16"
+---
+
+ClickHouse has one official Go driver, and it gives you two faces: a native ClickHouse interface (`clickhouse.Open`) and a standard `database/sql` interface (`clickhouse.OpenDB`). The native interface is faster and exposes ClickHouse-specific features like typed batch inserts; the `database/sql` face trades some speed for compatibility with ORMs, query builders, and migration tools. This guide shows both, explains which transport port you actually want, and covers the configuration that matters for an OLAP workload: batching, pooling, and TLS.
+
+## The options
+
+| Package | Import path | Interface | Transport | Version (as of June 2026) |
+|---|---|---|---|---|
+| clickhouse-go (native) | `github.com/ClickHouse/clickhouse-go/v2` | ClickHouse-specific API | native TCP (9000/9440) or HTTP (8123/8443) | v2.46.0 |
+| clickhouse-go (stdlib) | `github.com/ClickHouse/clickhouse-go/v2` via `OpenDB` | `database/sql` | native or HTTP | v2.46.0 |
+| ch-go | `github.com/ClickHouse/ch-go` | low-level columnar API | native TCP | v0.72.0 |
+
+The decision tree:
+
+- **Most applications:** clickhouse-go v2 with the native interface (`clickhouse.Open`). You get batch inserts, typed scanning, and the binary protocol. This is the default recommendation.
+- **You need `database/sql`** (an ORM, `sqlx`, a migration runner): use `clickhouse.OpenDB`. Same driver, standard interface, slightly slower because it goes through `database/sql`'s row-by-row plumbing.
+- **You need maximum insert throughput and are willing to work at the column level:** `ch-go` is the low-level driver that clickhouse-go is built on. It speaks columns, not rows, and is the right tool for high-volume ingestion pipelines. Most teams do not need it.
+
+clickhouse-go v2 is a full rewrite of v1; v1 is no longer recommended for new code. Make sure your import path ends in `/v2`.
+
+## The port question
+
+This trips up nearly everyone the first time. ClickHouse exposes several ports, and the driver behaves differently depending on which protocol you point it at:
+
+| Port | Protocol | TLS | Notes |
+|---|---|---|---|
+| 9000 | native TCP | no | default for self-hosted, fastest |
+| 9440 | native TCP | yes | TLS native, common in production |
+| 8123 | HTTP | no | useful behind HTTP proxies/load balancers |
+| 8443 | HTTPS | yes | ClickHouse Cloud uses this |
+
+If you set up the native interface but point it at 8123, the connection fails with a protocol mismatch. ClickHouse Cloud listens on 9440 (native+TLS) and 8443 (HTTPS); pick the matching `Protocol` in the driver options. Set the protocol explicitly with `Protocol: clickhouse.Native` or `clickhouse.HTTP` so there is no ambiguity.
+
+## Native interface (recommended)
+
+```bash
+go get github.com/ClickHouse/clickhouse-go/v2
+```
+
+`clickhouse.Open` returns a connection object that manages its own pool internally. It is safe for concurrent use by multiple goroutines, so open it once at startup and share it.
+
+```go
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+func main() {
+	ctx := context.Background()
+
+	conn, err := clickhouse.Open(&clickhouse.Options{
+		Addr: []string{"localhost:9000"},
+		Auth: clickhouse.Auth{
+			Database: "default",
+			Username: "default",
+			Password: "",
+		},
+		Protocol: clickhouse.Native,
+		Settings: clickhouse.Settings{
+			"max_execution_time": 60,
+		},
+		DialTimeout:     10 * time.Second,
+		MaxOpenConns:    10,
+		MaxIdleConns:    5,
+		ConnMaxLifetime: time.Hour,
+	})
+	if err != nil {
+		log.Fatalf("open: %v", err)
+	}
+	defer conn.Close()
+
+	// Open is lazy. Force a real round trip at startup so misconfiguration
+	// surfaces here rather than on the first query under load.
+	if err := conn.Ping(ctx); err != nil {
+		log.Fatalf("ping: %v", err)
+	}
+
+	rows, err := conn.Query(ctx,
+		"SELECT id, name FROM events WHERE region = ? LIMIT 10",
+		"EMEA",
+	)
+	if err != nil {
+		log.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			id   uint64
+			name string
+		)
+		if err := rows.Scan(&id, &name); err != nil {
+			log.Fatalf("scan: %v", err)
+		}
+		fmt.Printf("%d: %s\n", id, name)
+	}
+	if err := rows.Err(); err != nil {
+		log.Fatalf("rows: %v", err)
+	}
+
+	_ = tls.Config{} // see TLS section below
+}
+```
+
+Two traps in that loop that the Go compiler will not catch:
+
+- `defer rows.Close()` is not optional. Leaking result sets eventually starves the pool.
+- `rows.Err()` after the loop catches errors that happen *during* iteration, such as a server-side timeout. `rows.Next()` returning `false` does not distinguish "done" from "failed."
+
+The native interface uses `?` placeholders for parameters. Values are sent typed over the binary protocol, so you do not build SQL strings by hand.
+
+## Batch inserts
+
+ClickHouse is built for large, infrequent inserts, not row-at-a-time writes. Sending one `INSERT` per row creates a flood of small parts and triggers the "Too many parts" error as the server struggles to merge them. The native driver's batch API is the correct pattern:
+
+```go
+batch, err := conn.PrepareBatch(ctx, "INSERT INTO events (id, name, region)")
+if err != nil {
+	log.Fatalf("prepare batch: %v", err)
+}
+
+for _, e := range incoming {
+	if err := batch.Append(e.ID, e.Name, e.Region); err != nil {
+		log.Fatalf("append: %v", err)
+	}
+}
+
+if err := batch.Send(); err != nil {
+	log.Fatalf("send: %v", err)
+}
+```
+
+Accumulate thousands to tens of thousands of rows per batch. If your rows trickle in continuously, either buffer them in your application and flush periodically, or enable server-side `async_insert` (set it in `Settings` and turn on `wait_for_async_insert` if you need confirmation that the write landed).
+
+## database/sql interface
+
+When a library demands the standard interface, use `clickhouse.OpenDB`. It takes the same `Options` struct, so all the configuration above carries over.
+
+```go
+package main
+
+import (
+	"context"
+	"database/sql"
+	"log"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+func main() {
+	db := clickhouse.OpenDB(&clickhouse.Options{
+		Addr: []string{"localhost:9000"},
+		Auth: clickhouse.Auth{Database: "default", Username: "default"},
+		Protocol: clickhouse.Native,
+	})
+	db.SetMaxOpenConns(10)
+	db.SetMaxIdleConns(5)
+	db.SetConnMaxLifetime(time.Hour)
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := db.PingContext(ctx); err != nil {
+		log.Fatalf("ping: %v", err)
+	}
+
+	var count uint64
+	err := db.QueryRowContext(ctx,
+		"SELECT count() FROM events WHERE region = ?", "EMEA").Scan(&count)
+	if err != nil {
+		log.Fatalf("query: %v", err)
+	}
+	log.Printf("count = %d", count)
+}
+```
+
+With `database/sql` you set pool sizes through the standard `db.SetMaxOpenConns` / `SetMaxIdleConns` / `SetConnMaxLifetime` methods rather than the `Options` fields. Batch inserts still work but go through the standard prepared-statement path inside a transaction, which is slower than the native `PrepareBatch`. If insert performance matters, that alone is a reason to prefer the native interface.
+
+## Context timeouts
+
+Every query method takes a `context.Context`. Use it. OLAP queries can scan billions of rows, and a context deadline is how you bound that:
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+defer cancel()
+
+rows, err := conn.Query(ctx, "SELECT ... ")
+```
+
+When the context expires, the driver cancels the query on the server side as well, so a runaway aggregation does not keep burning CPU after your client has given up. This is more reliable than the `max_execution_time` setting alone, though setting both is reasonable.
+
+## TLS
+
+For an encrypted native connection (port 9440) or ClickHouse Cloud (8443), pass a `tls.Config`:
+
+```go
+conn, err := clickhouse.Open(&clickhouse.Options{
+	Addr:     []string{"your-instance.clickhouse.cloud:9440"},
+	Protocol: clickhouse.Native,
+	Auth: clickhouse.Auth{
+		Database: "default",
+		Username: "default",
+		Password: "your-password",
+	},
+	TLS: &tls.Config{},
+})
+```
+
+An empty `&tls.Config{}` enables TLS and verifies the server certificate against the system root CAs, which is what you want for ClickHouse Cloud and any properly provisioned server. Do not reach for `InsecureSkipVerify: true` to make a connection work; that disables certificate verification and defeats the point of TLS. If you hit a verification error against a self-hosted server, add its CA to `RootCAs` instead.
+
+## Common errors
+
+| Error | Cause | Fix |
+|---|---|---|
+| `unexpected packet` / protocol mismatch | native interface pointed at HTTP port (8123) or vice versa | match `Protocol` to the port |
+| `Too many parts` | too many small inserts | batch rows, or use `async_insert` |
+| `code: 516, Authentication failed` | wrong user/password or database | check `Auth` fields |
+| `dial tcp ... connection refused` | server not listening on that port, or firewall | confirm the port; Cloud needs IP allowlisting |
+| `x509: certificate signed by unknown authority` | self-hosted CA not in system roots | add the CA to `tls.Config.RootCAs` |
+| context deadline exceeded | query slower than the deadline | raise the timeout or optimize the query |
+
+## Related guides
+
+- [Importing CSV data into ClickHouse](/guides/import-csv-to-clickhouse)
+- [The best ClickHouse GUI clients](/guides/clickhouse-gui-client)
+- [Connecting to ClickHouse from Python](/guides/clickhouse/connect-from-python)
+- [Connecting to ClickHouse from Node.js](/guides/clickhouse/connect-from-node)
+
+---
+
+Mako connects to ClickHouse, PostgreSQL, MySQL, and more, with AI-powered autocomplete for exploring your tables. Try it free at mako.ai.

--- a/content/guides/clickhouse/connect-from-node.mdx
+++ b/content/guides/clickhouse/connect-from-node.mdx
@@ -1,0 +1,160 @@
+---
+title: "How to Connect to ClickHouse from Node.js"
+description: "Connect to ClickHouse from Node.js with the official @clickhouse/client. Working code for queries, async inserts, streaming, the HTTP-vs-native port trap, and JSONEachRow result handling."
+database: "clickhouse"
+category: "how-to"
+tags: ["clickhouse", "nodejs", "clickhouse-client", "connection"]
+date: "2026-06-15"
+---
+
+ClickHouse has one official Node.js client, `@clickhouse/client`, written in TypeScript with zero dependencies and tested against real ClickHouse versions. Unlike Postgres or MySQL, there's no field of competing third-party drivers worth weighing -- the official package is the answer for server-side Node. This guide shows working code for queries, inserts, and streaming, plus the configuration that trips people up first.
+
+## The package
+
+```bash
+npm install @clickhouse/client
+```
+
+There are two published clients, and picking the wrong one is the first mistake:
+
+| Package | Use it for | Transport |
+|---|---|---|
+| `@clickhouse/client` | Node.js servers, scripts, backends | HTTP, with Node streams |
+| `@clickhouse/client-web` | Browsers, edge runtimes, Cloudflare Workers | HTTP via fetch/Web Streams |
+
+For a normal Node backend, always import from `@clickhouse/client`. The `-web` variant exists for environments without Node's stream APIs and lacks some features (no compression for inserts, web streams instead of Node streams). Current version is 1.20.0 (as of June 2026).
+
+Note the client speaks ClickHouse's **HTTP interface (port 8123)**, not the native TCP protocol (port 9000). This matters below.
+
+## Connecting and querying
+
+```js
+import { createClient } from "@clickhouse/client";
+
+const client = createClient({
+  url: "http://localhost:8123",
+  username: "default",
+  password: "",
+  database: "default",
+});
+
+const resultSet = await client.query({
+  query: "SELECT name, value FROM events WHERE value > {threshold:UInt32}",
+  query_params: { threshold: 100 },
+  format: "JSONEachRow",
+});
+
+const rows = await resultSet.json();
+console.log(rows);
+
+await client.close();
+```
+
+Two things to internalize:
+
+**`format` decides what `.json()` gives you.** `JSONEachRow` returns an array of row objects, which is what you want most of the time. Other formats (`JSON`, `CSV`, `TabSeparated`) change the shape, and the client doesn't pick one for you on `query()`. If you forget `format`, you get raw text.
+
+**Parameters use `{name:Type}`, not `?` or `$1`.** ClickHouse parameter binding is typed: `{threshold:UInt32}` in the SQL, `query_params: { threshold: 100 }` in the call. The type is mandatory and part of the placeholder. This is server-side substitution that prevents injection, so build queries this way rather than string-concatenating values.
+
+## The port trap
+
+`createClient` defaults to `http://localhost:8123`. The single most common connection failure is pointing it at 9000, ClickHouse's native TCP port, and getting a cryptic protocol error or a hang. The Node client does not speak the native protocol. If you've copied a port from a `clickhouse-client` CLI example or a JDBC string, it's likely 9000 (native) or 9440 (native TLS) -- the HTTP client needs 8123 (HTTP) or 8443 (HTTPS). For ClickHouse Cloud, use the HTTPS endpoint on 8443.
+
+## Inserting data
+
+`query()` is for reads. Use `insert()` for writes -- it's optimized for batching and avoids building giant SQL strings:
+
+```js
+await client.insert({
+  table: "events",
+  values: [
+    { name: "click", value: 1, ts: "2026-06-15 10:00:00" },
+    { name: "view", value: 1, ts: "2026-06-15 10:00:01" },
+  ],
+  format: "JSONEachRow",
+});
+```
+
+**Batch, don't trickle.** ClickHouse is a columnar store built for large inserts. One row per insert call creates one part per call, and ClickHouse will choke on the resulting part count (the `Too many parts` error). Buffer rows in your app and insert in batches of thousands to tens of thousands, or enable async inserts.
+
+**Async inserts** push the batching to the server, which is often easier than buffering in app code:
+
+```js
+await client.insert({
+  table: "events",
+  values: rows,
+  format: "JSONEachRow",
+  clickhouse_settings: {
+    async_insert: 1,
+    wait_for_async_insert: 1, // wait for the server-side flush to confirm
+  },
+});
+```
+
+With `async_insert`, the server collects small inserts into larger blocks before writing. Set `wait_for_async_insert: 1` if you need confirmation the data landed; `0` returns sooner but gives up the durability guarantee on that call.
+
+## Streaming large result sets
+
+Don't call `.json()` on a query that returns millions of rows -- it buffers everything in memory. Stream instead:
+
+```js
+const rs = await client.query({
+  query: "SELECT * FROM big_table",
+  format: "JSONEachRow",
+});
+
+const stream = rs.stream();
+for await (const rows of stream) {
+  for (const row of rows) {
+    process(row.json());
+  }
+}
+```
+
+The stream yields chunks of rows, so you process the result without holding it all at once.
+
+## Connection management
+
+`createClient` returns a client backed by an HTTP connection pool; create it once and reuse it, like any pooled client. Useful options:
+
+- **`max_open_connections`**: caps concurrent sockets. Default is fine for most apps; raise it for high-concurrency read workloads.
+- **`request_timeout`**: defaults to 30s. Long analytical queries may need more.
+- **`compression`**: `{ response: true }` enables gzip on responses, worth it for large result sets over a network.
+- **`keep_alive`**: on by default, reuses sockets across requests.
+
+Call `client.close()` on shutdown to drain the pool.
+
+## TLS and ClickHouse Cloud
+
+For ClickHouse Cloud or any TLS endpoint, use the HTTPS URL and credentials from the console:
+
+```js
+const client = createClient({
+  url: "https://abc123.eu-central-1.aws.clickhouse.cloud:8443",
+  username: "default",
+  password: process.env.CLICKHOUSE_PASSWORD,
+});
+```
+
+Cloud services idle to sleep; the first query after idle may take a few seconds to wake the service. Account for that in your `request_timeout` rather than treating the delay as a connection failure.
+
+## Error reference
+
+| Error | Cause | Fix |
+|---|---|---|
+| Protocol error / hang | Pointing at port 9000 (native) | Use 8123 (HTTP) or 8443 (HTTPS) |
+| `Too many parts` | Inserting one row at a time | Batch inserts, or enable `async_insert` |
+| `Authentication failed` | Wrong user/password | Check credentials; default user often has empty password locally |
+| `ECONNREFUSED` | Server not running or wrong host | Verify host/port, server up |
+| Out of memory in app | `.json()` on a huge result | Stream with `rs.stream()` |
+| `Unknown setting` | Setting name typo in `clickhouse_settings` | Check the setting exists for your server version |
+
+## Connecting with a GUI instead
+
+For exploring tables, checking the schema, or testing the SQL you're about to embed in code, a client beats `console.log`. [Mako](/guides/clickhouse-gui-client) connects to ClickHouse with AI-assisted SQL autocomplete; the same guide compares the rest of the ClickHouse tooling honestly.
+
+For the SQL side once you're connected, see our ClickHouse guides on [materialized views](/guides/clickhouse/materialized-views), [the MergeTree engine family](/guides/clickhouse/mergetree-engines), and [aggregate functions](/guides/clickhouse/aggregate-functions). For loading data, see [importing CSV to ClickHouse](/guides/import-csv-to-clickhouse).
+
+---
+
+Mako connects to ClickHouse (and 8 other databases) with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/clickhouse/connect-from-python.mdx
+++ b/content/guides/clickhouse/connect-from-python.mdx
@@ -1,0 +1,202 @@
+---
+title: "How to Connect to ClickHouse from Python"
+description: "Connect to ClickHouse from Python with clickhouse-connect or clickhouse-driver. Working code for HTTP and native protocol, async clients, inserts, pandas, and the port mistakes everyone makes."
+database: "clickhouse"
+category: "how-to"
+tags: ["clickhouse", "python", "clickhouse-connect", "clickhouse-driver", "connection"]
+date: "2026-06-12"
+---
+
+Python has two serious drivers for ClickHouse: **clickhouse-connect**, the official client maintained by ClickHouse Inc., and **clickhouse-driver**, the older community client. They speak different protocols to the server, which is the source of most connection errors people hit. This guide shows working code for both, plus async options and the gotchas around ports, inserts, and parameters.
+
+## Which driver should you use?
+
+| Driver | Maintainer | Protocol | Port | Async | Notes |
+|---|---|---|---|---|---|
+| clickhouse-connect | ClickHouse Inc. | HTTP(S) | 8123 / 8443 | Yes (`get_async_client`) | Default choice; pandas/Arrow built in; Python 3.10+ |
+| clickhouse-driver | Community (mymarilyn) | Native TCP | 9000 / 9440 | No (see asynch) | Mature, binary protocol, slightly different API |
+| asynch | Community | Native TCP | 9000 / 9440 | Only async | asyncio rewrite of the native protocol |
+
+Short version: new projects should use **clickhouse-connect**. It is the officially supported client, it is what ClickHouse Cloud documents, and it ships pandas, NumPy, and Arrow integration plus a SQLAlchemy dialect in one package (version 1.3.0 as of June 2026, requires Python 3.10+). Use **clickhouse-driver** if you specifically want the native TCP protocol -- it transfers compressed binary data and exposes some settings HTTP does not -- or if you are maintaining code that already uses it. For asyncio with the native protocol, use **asynch**; the older `aioch` wrapper has not been released since 2019 and should be avoided.
+
+## The port mistake everyone makes
+
+ClickHouse listens on multiple ports for different protocols, and pointing a driver at the wrong one fails with confusing errors:
+
+- **8123** -- HTTP (what clickhouse-connect uses by default)
+- **8443** -- HTTPS (what ClickHouse Cloud uses; clickhouse-connect switches to this when `secure=True` on the default ports)
+- **9000** -- native TCP (what clickhouse-driver uses)
+- **9440** -- native TCP over TLS
+
+If you point clickhouse-connect at 9000 you will get an HTTP error against a binary port; if you point clickhouse-driver at 8123 you will get an "Unexpected EOF" or packet parsing error. Match the driver to the port before debugging anything else.
+
+## clickhouse-connect (recommended)
+
+Install:
+
+```bash
+pip install clickhouse-connect
+```
+
+Connect and query:
+
+```python
+import os
+import clickhouse_connect
+
+client = clickhouse_connect.get_client(
+    host=os.environ["CLICKHOUSE_HOST"],   # e.g. "abc123.us-east-1.aws.clickhouse.cloud" or "localhost"
+    username=os.environ.get("CLICKHOUSE_USER", "default"),
+    password=os.environ["CLICKHOUSE_PASSWORD"],
+    database="default",
+    secure=True,  # HTTPS on 8443; omit for plain HTTP on localhost:8123
+)
+
+result = client.query("SELECT event_date, count() FROM events GROUP BY event_date ORDER BY event_date")
+for row in result.result_rows:
+    print(row)
+
+print(result.column_names)
+```
+
+`query()` returns a result object with `result_rows`, `column_names`, and metadata. For statements that return no data (DDL, `SET`, etc.) use `command()`:
+
+```python
+client.command("CREATE TABLE IF NOT EXISTS t (id UInt64, name String) ENGINE = MergeTree ORDER BY id")
+```
+
+### Query parameters
+
+clickhouse-connect supports server-side parameter binding with the `{name:Type}` syntax:
+
+```python
+result = client.query(
+    "SELECT * FROM events WHERE event_date >= {start:Date} AND user_id = {uid:UInt64}",
+    parameters={"start": "2026-01-01", "uid": 42},
+)
+```
+
+The type annotation is required -- ClickHouse validates and casts the value server-side. Never build queries with f-strings; user input in an analytical query is just as injectable as in OLTP.
+
+### Inserts are columnar-aware
+
+ClickHouse wants batches, not row-at-a-time inserts. `insert()` takes a list of rows plus column names:
+
+```python
+client.insert(
+    "events",
+    [[1, "signup", "2026-06-12 09:00:00"], [2, "login", "2026-06-12 09:01:00"]],
+    column_names=["user_id", "event_type", "ts"],
+)
+```
+
+Insert thousands of rows per call, not one. Single-row inserts create one data part each on a MergeTree table and will eventually trigger "too many parts" errors. If you have a streaming workload, buffer rows in your application and flush in batches, or use async inserts on the server side.
+
+### pandas and Arrow
+
+```python
+df = client.query_df("SELECT * FROM events LIMIT 100000")   # pandas DataFrame
+client.insert_df("events_copy", df)                          # DataFrame back in
+```
+
+`query_np` and `query_arrow` do the same for NumPy and Arrow. This is built into the package -- no extra adapter library needed.
+
+### Async client
+
+```python
+import clickhouse_connect
+
+async def main():
+    client = await clickhouse_connect.get_async_client(host="localhost", username="default", password="")
+    result = await client.query("SELECT 1")
+    print(result.result_rows)
+```
+
+The async client wraps the same HTTP transport in a thread pool executor, so it will not outrun the sync client on raw throughput -- it exists so you can use it inside an asyncio application without blocking the event loop.
+
+## clickhouse-driver (native protocol)
+
+Install:
+
+```bash
+pip install clickhouse-driver
+```
+
+Connect and query (note: port 9000, not 8123):
+
+```python
+import os
+from clickhouse_driver import Client
+
+client = Client(
+    host=os.environ["CLICKHOUSE_HOST"],
+    port=9000,
+    user=os.environ.get("CLICKHOUSE_USER", "default"),
+    password=os.environ["CLICKHOUSE_PASSWORD"],
+    database="default",
+)
+
+rows = client.execute("SELECT event_date, count() FROM events GROUP BY event_date")
+for row in rows:
+    print(row)
+```
+
+`execute()` returns a plain list of tuples. Parameters use `%(name)s` style with a dict:
+
+```python
+rows = client.execute(
+    "SELECT * FROM events WHERE user_id = %(uid)s",
+    {"uid": 42},
+)
+```
+
+Inserts pass values separately from the query -- never interpolate them into the SQL string:
+
+```python
+client.execute(
+    "INSERT INTO events (user_id, event_type) VALUES",
+    [(1, "signup"), (2, "login")],
+)
+```
+
+The same batching rule applies: large batches, few inserts.
+
+Two things to know about the native protocol: it transfers LZ4-compressed binary blocks, which is more compact than HTTP for large result sets, and it exposes query progress and profile info that the HTTP interface does not. The tradeoff is that you cannot reach it through HTTP load balancers or the ClickHouse Cloud HTTPS endpoint setup most proxies expect -- check that port 9440 is reachable before committing to it for a cloud deployment.
+
+For TLS:
+
+```python
+client = Client(host="...", port=9440, secure=True, user="default", password="...")
+```
+
+## SQLAlchemy
+
+clickhouse-connect ships its own dialect (`clickhouse_connect.cc_sqlalchemy`), aimed mainly at query workloads (it exists largely for Superset support). The community `clickhouse-sqlalchemy` package targets clickhouse-driver but has not had a release since mid-2024. Either way, treat SQLAlchemy with ClickHouse as a read/query convenience, not a full ORM experience -- ClickHouse is not an OLTP database and ORM-style row updates do not map onto it.
+
+## Embedded option: chdb
+
+If you want ClickHouse's SQL engine without a server -- the SQLite model -- `chdb` embeds ClickHouse in-process:
+
+```python
+import chdb
+print(chdb.query("SELECT count() FROM file('events.parquet')", "Pretty"))
+```
+
+Useful for local analytics on files; not a replacement for a server when multiple clients need the same data.
+
+## Common errors
+
+| Error | Likely cause |
+|---|---|
+| `Unexpected EOF while reading bytes` (clickhouse-driver) | Pointed native driver at HTTP port 8123 |
+| HTTP 400 / garbage response (clickhouse-connect) | Pointed HTTP driver at native port 9000 |
+| `Authentication failed: password is incorrect` | Wrong password, or user restricted by host/IP |
+| `Code: 516` | Same as above -- authentication failure code |
+| `Too many parts` on insert | Row-at-a-time inserts; batch them |
+| Connection timeout to ClickHouse Cloud | Missing `secure=True` or IP not in the cloud allowlist |
+
+## Verifying your connection
+
+Once connected, `SELECT version()` confirms the server, and `SELECT * FROM system.settings WHERE changed` shows what your session overrides. For exploring the data itself -- schemas in `system.tables`, part counts in `system.parts` -- a GUI saves round trips; see our [ClickHouse GUI client guide](/guides/clickhouse-gui-client) for the options. If you are loading data, the [CSV import guide](/guides/import-csv-to-clickhouse) covers the format settings that bite. And once you are querying, the [aggregate functions](/guides/clickhouse/aggregate-functions) and [materialized views](/guides/clickhouse/materialized-views) guides cover the ClickHouse-specific patterns that differ from OLTP SQL.
+
+Mako connects to ClickHouse with AI-powered autocomplete. Try it free at mako.ai.

--- a/content/guides/mariadb/connect-from-go.mdx
+++ b/content/guides/mariadb/connect-from-go.mdx
@@ -1,0 +1,206 @@
+---
+title: "How to Connect to MariaDB from Go"
+description: "Connect to MariaDB from Go with go-sql-driver/mysql. Working code for the database/sql interface, the parseTime trap, the ed25519 auth plugin, RETURNING support, connection pooling, and where MariaDB differs from MySQL."
+database: "mariadb"
+category: "how-to"
+tags: ["mariadb", "go", "golang", "go-sql-driver", "database-sql", "connection"]
+date: "2026-06-16"
+---
+
+There is no MariaDB-specific Go driver, and you do not need one. MariaDB speaks the MySQL wire protocol, so the standard `go-sql-driver/mysql` driver connects to it the same way it connects to MySQL. The maintainers explicitly support MariaDB 10.5+. What this guide adds over a plain MySQL connect guide is the MariaDB-specific parts: the `ed25519` authentication plugin, MariaDB's `RETURNING` clause, and a few behavioral differences worth knowing when your code might run against either server.
+
+## The driver
+
+| Driver | Import path | Interface | Version (as of June 2026) |
+|---|---|---|---|
+| go-sql-driver/mysql | `github.com/go-sql-driver/mysql` | `database/sql` | v1.10.0 |
+
+It is pure Go, with no cgo and no `libmariadb` dependency, so cross-compilation and minimal container images work without a C toolchain. There is no separately maintained MariaDB connector for Go, which makes the choice simple.
+
+```sh
+go get github.com/go-sql-driver/mysql
+```
+
+The driver registers itself with `database/sql` via a blank import, and you work through the standard library from there:
+
+```go
+import (
+	"database/sql"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+```
+
+## Connect
+
+The DSN format is `username:password@protocol(host:port)/dbname?param=value`:
+
+```go
+package main
+
+import (
+	"database/sql"
+	"log"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+func main() {
+	dsn := "appuser:secret@tcp(127.0.0.1:3306)/mydb?parseTime=true&loc=UTC&charset=utf8mb4"
+
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		log.Fatal(err) // only DSN parse errors surface here
+	}
+	defer db.Close()
+
+	db.SetMaxOpenConns(25)
+	db.SetMaxIdleConns(25)
+	db.SetConnMaxLifetime(5 * time.Minute)
+
+	if err := db.Ping(); err != nil {
+		log.Fatal(err)
+	}
+
+	var version string
+	if err := db.QueryRow("SELECT VERSION()").Scan(&version); err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("connected to %s", version) // e.g. 11.4.2-MariaDB
+}
+```
+
+Note the driver name passed to `sql.Open` is `"mysql"`, not `"mariadb"`. There is no `mariadb` driver registered, because the same driver handles both. Running `SELECT VERSION()` is a quick way to confirm you actually reached MariaDB and not a MySQL server on the same host.
+
+As with every `database/sql` driver, `sql.Open` does not connect. It validates the DSN and returns a pool handle. The first real connection happens on `Ping` or the first query, so the `Ping` above is your actual connection check.
+
+## The parseTime trap
+
+This catches almost everyone the first time. By default the driver returns `DATE`, `DATETIME`, and `TIMESTAMP` columns as `[]byte`, not `time.Time`. Scanning one into a `time.Time` fails:
+
+```
+sql: Scan error on column index 2: unsupported Scan, storing driver.Value type []uint8 into type *time.Time
+```
+
+Add `parseTime=true` to the DSN, and set `loc` so the driver knows which time zone to attach to the parsed values:
+
+```
+?parseTime=true&loc=UTC
+```
+
+Pick a `loc` deliberately. If your MariaDB columns store UTC, set `loc=UTC` so the driver does not silently relabel timestamps with the server's local zone.
+
+## Use utf8mb4, not utf8
+
+On MariaDB, the historical `utf8` alias maps to a three-byte encoding that cannot store emoji or some CJK characters. Use `utf8mb4` both in the DSN (`charset=utf8mb4`) and when creating tables. MariaDB's own default has moved toward `utf8mb4`, but being explicit avoids surprises against older servers.
+
+## The ed25519 authentication plugin
+
+This is the one genuinely MariaDB-specific connection detail. MariaDB ships an authentication plugin called `ed25519` that does not exist in MySQL. If your user was created with it:
+
+```sql
+CREATE USER 'appuser'@'%' IDENTIFIED VIA ed25519 USING PASSWORD('secret');
+```
+
+then a MySQL-only client would fail to authenticate. `go-sql-driver/mysql` handles `client_ed25519` natively, so no extra configuration is needed: the same DSN works. This is worth knowing because if you switch a connection from MySQL to MariaDB and authentication suddenly fails with an unsupported-plugin error, the auth plugin on the account is the usual cause, and this driver is one of the few clients that supports it out of the box.
+
+MariaDB also supports the standard `mysql_native_password` plugin, which works everywhere. If portability across clients matters more than ed25519's properties, that remains the safe default.
+
+## Parameterized queries
+
+MariaDB uses positional `?` placeholders. Never build SQL with string concatenation:
+
+```go
+rows, err := db.Query(
+	"SELECT id, email FROM users WHERE country = ? AND created_at > ?",
+	"CH", "2026-01-01",
+)
+if err != nil {
+	log.Fatal(err)
+}
+defer rows.Close()
+
+for rows.Next() {
+	var id int64
+	var email string
+	if err := rows.Scan(&id, &email); err != nil {
+		log.Fatal(err)
+	}
+	// use id, email
+}
+if err := rows.Err(); err != nil { // distinguishes a real error from clean end-of-rows
+	log.Fatal(err)
+}
+```
+
+Always `defer rows.Close()` and check `rows.Err()` after the loop. The loop ending does not by itself mean iteration succeeded.
+
+## RETURNING is a MariaDB advantage
+
+MariaDB supports `INSERT ... RETURNING` (since 10.5) and `DELETE ... RETURNING`, which MySQL does not. That changes how you get a generated id. On MySQL you would use `result.LastInsertId()`; on MariaDB you can ask for the row back directly, which also works for non-auto-increment columns and composite keys:
+
+```go
+var id int64
+err := db.QueryRow(
+	"INSERT INTO users (email) VALUES (?) RETURNING id",
+	"new@example.com",
+).Scan(&id)
+```
+
+If you need code that runs against both MySQL and MariaDB, stick to `Exec` plus `LastInsertId()`, since `RETURNING` is not portable. If you are MariaDB-only, `RETURNING` is cleaner and avoids the auto-increment-only limitation of `LastInsertId`.
+
+## Connection pooling
+
+`*sql.DB` is a pool and is safe for concurrent use, so create one at startup and share it. The settings that matter:
+
+```go
+db.SetMaxOpenConns(25)
+db.SetMaxIdleConns(25)
+db.SetConnMaxLifetime(5 * time.Minute)
+```
+
+- `SetMaxOpenConns` should be sized against MariaDB's `max_connections` (default 151), divided across all the processes that connect. Leave headroom for admin sessions.
+- `SetConnMaxLifetime` should be shorter than the server's `wait_timeout` (default 28800 seconds). If a connection idles past `wait_timeout`, MariaDB closes it and you get an `invalid connection` / "bad connection" error on next use. Recycling connections before that prevents it.
+- Keep `MaxIdleConns` equal to `MaxOpenConns` for steady workloads so you are not constantly opening and closing connections.
+
+## Context and cancellation
+
+Use the context-aware methods so a cancelled request or a deadline actually stops the work:
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+defer cancel()
+
+var n int
+err := db.QueryRowContext(ctx, "SELECT count(*) FROM orders").Scan(&n)
+```
+
+## TLS
+
+For a connection over an untrusted network, enable TLS in the DSN. `tls=true` requires a valid server certificate; `tls=skip-verify` encrypts but does not verify the certificate (acceptable only in development):
+
+```
+?parseTime=true&tls=true
+```
+
+For a custom CA, register a `tls.Config` with `mysql.RegisterTLSConfig("custom", cfg)` and reference it as `tls=custom`.
+
+## Common errors
+
+| Error | Likely cause |
+|---|---|
+| `Error 1045: Access denied for user` | Wrong credentials, or host pattern in the grant does not match where you connect from |
+| `this user requires mysql native password ...` / unsupported auth plugin | Account uses ed25519 on a client that lacks support (this driver supports it) |
+| `unsupported Scan, storing driver.Value type []uint8 into type *time.Time` | Missing `parseTime=true` in the DSN |
+| `invalid connection` / `bad connection` | Idle connection killed by `wait_timeout`; set `SetConnMaxLifetime` shorter |
+| `Error 1049: Unknown database` | Database name in the DSN does not exist |
+| `dial tcp ...: connect: connection refused` | Server not listening on that host/port, or bound to localhost only |
+
+## Where Mako fits
+
+Once the connection works, you still have to explore the schema and iterate on queries before wiring them into Go. Mako connects to MariaDB (and MySQL, PostgreSQL, ClickHouse, BigQuery, and more) with AI-powered autocomplete, so you can draft and test the exact queries your service will run. It is a read and query tool, not a schema-management GUI, so `CREATE`/`ALTER` work stays in your MariaDB client or migration tool.
+
+For loading data first, see our [import CSV to MariaDB](/guides/import-csv-to-mariadb) and [import JSON to MariaDB](/guides/import-json-to-mariadb) guides. To connect from other languages, see [connect to MariaDB from Python](/guides/mariadb/connect-from-python) and [connect to MariaDB from Node.js](/guides/mariadb/connect-from-node). If you are weighing the engines, see [MySQL vs MariaDB](/guides/mysql-vs-mariadb).
+
+Mako connects to MariaDB with AI-powered autocomplete. Try it free at mako.ai.

--- a/content/guides/mariadb/connect-from-node.mdx
+++ b/content/guides/mariadb/connect-from-node.mdx
@@ -1,0 +1,107 @@
+---
+title: "How to Connect to MariaDB from Node.js"
+description: "Connect to MariaDB from Node.js using the official mariadb driver. Working code for connection pools, promise vs callback APIs, the named-pipe and socket traps, and how it differs from mysql2."
+database: "mariadb"
+category: "how-to"
+tags: ["mariadb", "nodejs", "mariadb-driver", "connection"]
+date: "2026-06-15"
+---
+
+MariaDB has its own official Node.js driver, `mariadb`, maintained by MariaDB Corporation. It is current at version 3.5.3 (as of June 2026). You can also connect with `mysql2`, since MariaDB speaks the MySQL wire protocol, but the official driver is faster on bulk inserts and exposes MariaDB-specific features the MySQL drivers do not. Pick based on which database you actually run against, not habit.
+
+```bash
+npm install mariadb
+```
+
+## Promise API, not callbacks
+
+Unlike the older `mysql` package, the `mariadb` driver is promise-first. The main entry point exposes a promise interface directly, so you do not need a wrapper:
+
+```js
+import mariadb from "mariadb";
+
+const pool = mariadb.createPool({
+  host: "127.0.0.1",
+  port: 3306,
+  user: "app_user",
+  password: process.env.MARIADB_PASSWORD,
+  database: "analytics",
+  connectionLimit: 5,
+});
+
+const conn = await pool.getConnection();
+try {
+  const rows = await conn.query("SELECT id, email FROM users WHERE active = ?", [true]);
+  console.log(rows);
+} finally {
+  conn.release();
+}
+```
+
+There is also a callback API at `mariadb/callback` for legacy codebases, but new code should use the promise interface above.
+
+## Use a pool, and always release
+
+`createPool` is the right default for any server. The single most common leak is forgetting `conn.release()` -- once `connectionLimit` connections are checked out and never returned, every subsequent `getConnection()` hangs until `acquireTimeout` fires. The `try/finally` pattern above guarantees release even when the query throws. Call `pool.end()` on shutdown to close the pool cleanly.
+
+For one-off scripts where pooling is overkill, `mariadb.createConnection()` returns a single connection you close with `conn.end()`.
+
+## The localhost socket trap
+
+If `host` is `localhost`, some setups route through a Unix socket instead of TCP, and the socket path the driver expects may not match where your MariaDB server actually puts it. The symptom is a connection that fails locally but works from another machine. Use `127.0.0.1` to force TCP, or set `socketPath` explicitly:
+
+```js
+const conn = await mariadb.createConnection({
+  socketPath: "/run/mysqld/mysqld.sock",
+  user: "app_user",
+  password: process.env.MARIADB_PASSWORD,
+  database: "analytics",
+});
+```
+
+This is the same trap MySQL drivers hit -- see our [MySQL Node.js guide](/guides/mysql/connect-from-node) for the parallel case.
+
+## Result metadata and bulk inserts
+
+By default `query()` returns an array of row objects. For large inserts, the driver's `batch()` method sends rows far more efficiently than looping individual `INSERT` statements:
+
+```js
+await conn.batch(
+  "INSERT INTO events (user_id, action) VALUES (?, ?)",
+  [[1, "login"], [2, "signup"], [3, "logout"]]
+);
+```
+
+One behavior to know: integer columns large enough to overflow JavaScript's safe integer range come back as `BigInt` by default. If your IDs fit in a regular number and you want plain numbers, set `insertIdAsNumber: true` and `decimalAsNumber: true` (or `bigIntAsNumber: true`) in the connection options, but be deliberate -- silently truncating a real BigInt is worse than dealing with the type.
+
+## TLS for managed MariaDB
+
+SkySQL, Amazon RDS, and other managed MariaDB instances require TLS. Point the driver at the CA certificate rather than disabling verification:
+
+```js
+import fs from "node:fs";
+
+const pool = mariadb.createPool({
+  host: "db.example.com",
+  user: "app_user",
+  password: process.env.MARIADB_PASSWORD,
+  database: "analytics",
+  ssl: { ca: fs.readFileSync("/path/to/ca.pem") },
+});
+```
+
+Setting `ssl: { rejectUnauthorized: false }` makes the connection encrypted but unauthenticated against a forged certificate. Use the CA file in production.
+
+## Verifying the connection
+
+A quick sanity check before wiring the pool into an app:
+
+```js
+const conn = await pool.getConnection();
+const [{ version }] = await conn.query("SELECT VERSION() AS version");
+console.log("Connected to", version);
+conn.release();
+await pool.end();
+```
+
+If you want to inspect tables and run exploratory queries against MariaDB without writing connection code, Mako connects to MariaDB with AI-powered autocomplete. Try it free at mako.ai.

--- a/content/guides/mariadb/connect-from-python.mdx
+++ b/content/guides/mariadb/connect-from-python.mdx
@@ -1,0 +1,166 @@
+---
+title: "How to Connect to MariaDB from Python"
+description: "Connect to MariaDB from Python with the official mariadb connector, mysqlclient, or PyMySQL. Working code, the qmark vs %s parameter difference, the C build dependency trap, and when a MySQL driver is the better choice."
+database: "mariadb"
+category: "how-to"
+tags: ["mariadb", "python", "mariadb-connector-python", "pymysql", "connection"]
+date: "2026-06-12"
+---
+
+MariaDB speaks the MySQL wire protocol, so you have an unusual choice: use MariaDB's own official connector, or use any of the MySQL drivers, which work fine against MariaDB. Plenty of production MariaDB deployments run on PyMySQL or mysqlclient and never touch the official connector. This guide covers when each choice makes sense, with working code for all of them.
+
+## The options
+
+| Driver | Maintainer | Implementation | paramstyle | Version (as of June 2026) |
+|---|---|---|---|---|
+| mariadb (Connector/Python) | MariaDB | C extension over Connector/C | `qmark` (`?`) | 1.1.14 stable, 2.0 in RC |
+| mysqlclient | PyMySQL org | C extension over libmysqlclient/Connector/C | `format` (`%s`) | 2.2.8 |
+| PyMySQL | PyMySQL org | Pure Python | `format` (`%s`) | 1.2.0 |
+| mysql-connector-python | Oracle | Pure Python (+ optional C) | `format` (`%s`) | 9.7.0 |
+
+Rules of thumb:
+
+- **Greenfield MariaDB-only project:** the official `mariadb` connector. It is the only driver that exposes MariaDB-specific capabilities directly and tracks MariaDB server releases.
+- **Code that might run against MySQL too, or a team that already knows the MySQL drivers:** mysqlclient (speed) or PyMySQL (zero build dependencies). Nothing breaks; you just write `%s` placeholders instead of `?`.
+- **Django:** mysqlclient remains the documented default for MariaDB backends. Don't fight the framework.
+
+The drivers are *not* drop-in compatible with each other -- the official connector uses `?` placeholders (qmark) while every MySQL driver uses `%s`. Switching means touching every query. Pick once.
+
+## The official mariadb connector
+
+### The build dependency trap
+
+Version 1.1 is a C extension that links against MariaDB Connector/C. On Windows, pip installs a prebuilt wheel. On Linux and macOS, **there are no binary wheels for 1.1** -- pip compiles from source, which fails with a `mariadb_config not found` or `Python.h: No such file or directory` error unless the system packages are present:
+
+```bash
+# Debian/Ubuntu
+sudo apt install libmariadb-dev python3-dev
+pip install mariadb
+
+# macOS
+brew install mariadb-connector-c
+pip install mariadb
+```
+
+This is the single most common installation failure, and it is the main reason teams quietly use PyMySQL instead. The upcoming 2.0 release fixes it: 2.0 (release candidate as of June 2026) is a ground-up rewrite distributed as pure Python with an optional C accelerator, installable via `pip install mariadb[binary]` with Connector/C bundled, and it adds native asyncio support. Until 2.0 goes stable, expect the apt/brew step on 1.1.
+
+### Connecting
+
+```python
+import mariadb
+
+conn = mariadb.connect(
+    host="localhost",
+    port=3306,
+    user="app",
+    password="secret",
+    database="shop",
+)
+
+cur = conn.cursor()
+cur.execute("SELECT id, name FROM customers WHERE country = ?", ("CH",))
+for row in cur:
+    print(row)
+conn.close()
+```
+
+Note the `?` placeholder -- qmark style, like SQLite, unlike every MySQL driver. Tuples in, tuples out. `cur.execute(sql, ("CH",))` needs the trailing comma for single parameters; passing a bare string is the classic mistake (each character becomes a parameter).
+
+Autocommit is **off** by default, matching the DB API spec. Your INSERTs vanish on close unless you call `conn.commit()` or set `conn.autocommit = True`.
+
+### Connection pooling
+
+Built in, no extra package:
+
+```python
+pool = mariadb.ConnectionPool(
+    pool_name="app",
+    pool_size=5,
+    host="localhost",
+    user="app",
+    password="secret",
+    database="shop",
+)
+
+conn = pool.get_connection()
+try:
+    cur = conn.cursor()
+    cur.execute("SELECT 1")
+finally:
+    conn.close()  # returns the connection to the pool
+```
+
+### MariaDB-specific: INSERT ... RETURNING
+
+MariaDB 10.5+ supports `RETURNING` on INSERT (and DELETE since 10.0, REPLACE since 10.5) -- a feature MySQL does not have. Any driver can use it since it is just SQL, but it replaces the `lastrowid` dance cleanly:
+
+```python
+cur.execute(
+    "INSERT INTO orders (customer_id, total) VALUES (?, ?) RETURNING id, created_at",
+    (42, 199.90),
+)
+order_id, created_at = cur.fetchone()
+```
+
+## Using the MySQL drivers against MariaDB
+
+Everything in our [MySQL from Python guide](/guides/mysql/connect-from-python) applies to MariaDB: same connection parameters, same `%s` placeholders, same `utf8mb4` charset advice, same `wait_timeout` reconnection traps. A minimal PyMySQL example for completeness:
+
+```python
+import pymysql
+
+conn = pymysql.connect(
+    host="localhost",
+    user="app",
+    password="secret",
+    database="shop",
+    charset="utf8mb4",
+    cursorclass=pymysql.cursors.DictCursor,
+)
+
+with conn.cursor() as cur:
+    cur.execute("SELECT id, name FROM customers WHERE country = %s", ("CH",))
+    print(cur.fetchall())
+conn.commit()
+```
+
+Two MariaDB-vs-MySQL differences worth knowing when you reuse MySQL drivers:
+
+- **Authentication plugins.** MySQL 8 defaults to `caching_sha2_password`, which older drivers struggled with; MariaDB defaults to `mysql_native_password` (and offers `ed25519`). Connecting to MariaDB therefore avoids the auth-plugin errors common with MySQL 8 -- but if you followed MySQL hardening guides that force `caching_sha2_password`, note MariaDB does not implement it.
+- **Version strings.** MariaDB reports versions like `11.8.3-MariaDB`. Code that parses server versions (some ORMs, migration tools) occasionally misreads this. SQLAlchemy handles it via dedicated `mariadb` dialect naming (below).
+
+## SQLAlchemy
+
+SQLAlchemy 2.0 has explicit MariaDB-only dialect prefixes, which enable MariaDB-specific features (like `INSERT...RETURNING` support in the ORM) and refuse to connect to a MySQL server:
+
+```python
+from sqlalchemy import create_engine
+
+# Official mariadb connector
+engine = create_engine("mariadb+mariadbconnector://app:secret@localhost/shop")
+
+# Or via the MySQL drivers
+engine = create_engine("mariadb+pymysql://app:secret@localhost/shop?charset=utf8mb4")
+```
+
+Add `pool_pre_ping=True` if connections sit idle long enough to hit the server's `wait_timeout`.
+
+## Async
+
+As of June 2026 the stable official connector (1.1) has no asyncio support -- that arrives with 2.0. Today your async options are the MySQL ecosystem drivers, which work against MariaDB: **asyncmy** (0.2.11, C-accelerated) or **aiomysql** (built on PyMySQL). Both use `%s` placeholders and integrate with SQLAlchemy's async engine (`mariadb+asyncmy://` is not a registered dialect, so async SQLAlchemy users connect with the `mysql+asyncmy://` prefix and lose the MariaDB-only dialect features).
+
+## Common errors
+
+| Error | Cause |
+|---|---|
+| `mariadb_config not found` / `Python.h: No such file` during pip install | Missing `libmariadb-dev` (or Connector/C) and `python3-dev` |
+| `Commands out of sync` | Unread result set; consume or use buffered cursors |
+| Inserts silently missing | Autocommit off (DB API default), no `conn.commit()` |
+| `Access denied for user 'app'@'172.x.x.x'` | MariaDB accounts are user@host patterns; the Docker bridge IP needs its own grant or `'app'@'%'` |
+| `Server has gone away` after idle | `wait_timeout` closed the connection; use `pool_pre_ping`, `conn.ping()`, or `auto_reconnect` |
+
+## Verifying your data
+
+After connecting, you usually want to browse schemas and check rows landed. The `mariadb` CLI works; a GUI is faster -- we compared the options in [Best MariaDB GUI Clients](/guides/mariadb-gui-client). For loading data, see [Import CSV to MariaDB](/guides/import-csv-to-mariadb) and [Import Excel to MariaDB](/guides/import-excel-to-mariadb).
+
+Mako connects to MariaDB with AI-powered autocomplete. Try it free at mako.ai.

--- a/content/guides/mongodb/connect-from-go.mdx
+++ b/content/guides/mongodb/connect-from-go.mdx
@@ -1,0 +1,135 @@
+---
+title: "How to Connect to MongoDB from Go"
+description: "Connect to MongoDB from Go with the official mongo-driver v2. Working code for one-client-per-app, the v2 Connect signature change, ping-at-startup, connection pooling with SetMaxPoolSize, SRV and Atlas TLS, and BSON struct tags."
+database: "mongodb"
+category: "how-to"
+tags: ["mongodb", "go", "golang", "mongo-driver", "bson", "connection"]
+date: "2026-06-16"
+---
+
+For MongoDB and Go there is one driver worth using: the official `go.mongodb.org/mongo-driver`, now on the v2 line. There is no real third-party alternative the way there is for SQL databases, so the interesting decisions are not which driver but how to use it correctly: creating a single client for the whole application, surviving the v2 API changes, and getting pooling and BSON mapping right. This guide covers all of that with working code.
+
+## The driver
+
+| Package | Import path | Version (as of June 2026) |
+|---|---|---|
+| Official Go driver (v2) | `go.mongodb.org/mongo-driver/v2/mongo` | v2.6.1 |
+
+Install it with `go get go.mongodb.org/mongo-driver/v2/mongo`. The driver requires a recent Go toolchain (Go 1.25+ for the v2.6 line) and supports MongoDB 4.2 and higher.
+
+If you are reading an older tutorial that imports `go.mongodb.org/mongo-driver/mongo` (no `/v2`), that is the v1 line. v2 is a separate module path, and the import change is the first thing to get right when following old material.
+
+## The v2 Connect change that breaks old code
+
+The single biggest difference between v1 and v2 is the `Connect` signature. In v1 you called `mongo.Connect(ctx, opts)`. In v2, `Connect` no longer takes a context:
+
+```go
+client, err := mongo.Connect(options.Client().ApplyURI(uri))
+```
+
+The context moved onto the individual operations (`client.Ping(ctx, ...)`, `coll.Find(ctx, ...)`), which is where it always belonged. If you copy v1 code into a v2 project, the compiler will complain about the extra argument. That is the expected signal, not a bug.
+
+## Connecting: one client, created once
+
+`mongo.Client` is safe for concurrent use and manages its own connection pool internally. The cardinal rule is to create exactly one client when your application starts and reuse it everywhere. Creating a client per request defeats the pool and exhausts connections under load.
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+func main() {
+	uri := "mongodb://user:pass@localhost:27017/?authSource=admin"
+
+	opts := options.Client().
+		ApplyURI(uri).
+		SetMaxPoolSize(50).
+		SetServerSelectionTimeout(5 * time.Second)
+
+	// v2: no context argument here.
+	client, err := mongo.Connect(opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() {
+		if err := client.Disconnect(context.Background()); err != nil {
+			log.Print(err)
+		}
+	}()
+
+	// Connect does not actually talk to the server. Ping forces it.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := client.Ping(ctx, nil); err != nil {
+		log.Fatal(err)
+	}
+
+	coll := client.Database("app").Collection("users")
+	n, err := coll.CountDocuments(ctx, map[string]any{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("users: %d", n)
+}
+```
+
+### Connect is lazy; Ping is the real check
+
+`mongo.Connect` returns a client immediately without verifying that any server is reachable. The driver connects lazily on the first operation. That means a wrong host, a firewall block, or bad credentials surface later, often inside a request handler. Call `client.Ping` at startup with a bounded context so connection problems fail loudly where you can handle them. Set `SetServerSelectionTimeout` so a dead server fails in seconds instead of the default 30.
+
+## Pooling
+
+The driver maintains an internal pool per server. The setting that matters most is `SetMaxPoolSize` (default 100). The total connections your fleet opens is roughly `maxPoolSize × number of app processes × number of mongod nodes the driver talks to`. On a replica set or a shared cluster, multiply accordingly and keep the total under the server's connection limit. Lower the pool size if you run many application instances against one cluster. `SetMinPoolSize` keeps a warm floor of connections ready, which trims latency on the first requests after idle periods at the cost of holding connections open.
+
+## SRV connection strings and Atlas
+
+MongoDB Atlas and many self-hosted setups hand you an `mongodb+srv://` URI. The `+srv` scheme does two things automatically: it resolves the seed list via a DNS SRV record, and it implies `tls=true`. The Go driver handles SRV resolution natively, so no extra package is needed (unlike some other languages' drivers).
+
+```go
+uri := "mongodb+srv://user:pass@cluster0.abcde.mongodb.net/?retryWrites=true&w=majority"
+client, err := mongo.Connect(options.Client().ApplyURI(uri))
+```
+
+Two recurring gotchas:
+
+- **Percent-encode credentials.** If your username or password contains `@`, `:`, `/`, or other reserved characters, they must be URL-encoded in the URI or parsing fails or misreads the host.
+- **Atlas IP allowlist.** A correct URI that times out on server selection from a new environment is almost always the Atlas network access list, not your code. Add the client IP (or a VPC peering rule) before debugging the driver.
+
+## BSON and struct tags
+
+MongoDB stores BSON, and the driver maps it to Go structs using `bson` struct tags. Without tags, the driver lowercases the Go field name, which is rarely what your documents use.
+
+```go
+type User struct {
+	ID    bson.ObjectID `bson:"_id,omitempty"`
+	Name  string        `bson:"name"`
+	Email string        `bson:"email"`
+}
+```
+
+Note that in v2 the ObjectID type lives in the `bson` package (`bson.ObjectID`), another move from where v1 kept it (`primitive.ObjectID`). Use `omitempty` on `_id` so MongoDB generates the ObjectID on insert instead of writing a zero value.
+
+## Common errors
+
+| Error | Likely cause |
+|---|---|
+| `server selection error: context deadline exceeded` | Unreachable host, firewall, or Atlas IP allowlist not updated |
+| `(AuthenticationFailed) ... auth error` | Wrong credentials, or missing/incorrect `authSource` (often `admin`) |
+| `error parsing uri` | Unencoded special characters in username/password |
+| `Connect undefined: too many arguments` | Passing a context to v2 `mongo.Connect` (v1 habit) |
+| `client is disconnected` | Using a client after `Disconnect`, or sharing a closed client |
+
+The `authSource` case is the most common silent failure: credentials created in the `admin` database fail to authenticate against another database unless you tell the driver where the user lives, via `?authSource=admin` in the URI.
+
+## Querying without writing connection code
+
+If your goal is to explore a MongoDB database rather than build a service, a GUI client skips the driver setup. Mako connects to MongoDB with AI-assisted querying -- see our [MongoDB GUI client guide](/guides/mongodb-gui-client) for how it compares to Compass and Studio 3T. Connecting from another language? See [How to Connect to MongoDB from Python](/guides/mongodb/connect-from-python) and [from Node.js](/guides/mongodb/connect-from-node).
+
+Mako connects to MongoDB with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/mongodb/connect-from-node.mdx
+++ b/content/guides/mongodb/connect-from-node.mdx
@@ -1,0 +1,156 @@
+---
+title: "How to Connect to MongoDB from Node.js"
+description: "Connect to MongoDB from Node.js with the official driver or Mongoose. Working code for connection pooling, the localhost IPv6 trap, SRV strings, and which library to pick."
+database: "mongodb"
+category: "how-to"
+tags: ["mongodb", "nodejs", "mongodb-driver", "mongoose", "connection"]
+date: "2026-06-15"
+---
+
+MongoDB is the database Node developers reach for most often, and the connection story is correspondingly mature. There are two real choices: the official `mongodb` driver, and Mongoose, an ODM (object-document mapper) layered on top of it. This guide shows working code for both, the configuration that matters (pooling, SRV strings, TLS), and the connection errors you'll hit first.
+
+## The options
+
+| Library | Package | What it is | Version (as of June 2026) |
+|---|---|---|---|
+| Official driver | `mongodb` | The low-level driver. Direct access to collections, raw documents. | 7.3.0 |
+| Mongoose | `mongoose` | ODM with schemas, validation, middleware, populate. Bundles the driver. | 9.7.0 |
+
+Rules of thumb:
+
+- **You want schemas, validation, and model-level structure** (most application backends): Mongoose. It enforces shape on a schemaless database, which is usually what you actually want.
+- **You want raw driver access, minimum abstraction, or you're building tooling/scripts:** the official `mongodb` driver. Mongoose installs it anyway, so there's no extra dependency cost to dropping down to it.
+
+Mongoose is not a replacement for the driver, it's a layer on top. Under load, both pool connections the same way because Mongoose delegates to the driver's pool.
+
+## The official driver
+
+```bash
+npm install mongodb
+```
+
+```js
+import { MongoClient } from "mongodb";
+
+const uri = "mongodb://127.0.0.1:27017";
+const client = new MongoClient(uri);
+
+try {
+  await client.connect();
+  const db = client.db("myapp");
+  const users = db.collection("users");
+
+  const user = await users.findOne({ email: "ada@example.com" });
+  console.log(user);
+} finally {
+  await client.close();
+}
+```
+
+### One client for the whole app
+
+`MongoClient` is not a single socket. It owns a connection pool and is designed to be created once and shared for the lifetime of the process. The common mistake is opening a new client per request, which exhausts connections and tanks throughput. Create it at startup, reuse the instance everywhere, close it on shutdown.
+
+```js
+// db.js -- a single shared client
+import { MongoClient } from "mongodb";
+
+const client = new MongoClient(process.env.MONGODB_URI, {
+  maxPoolSize: 20,    // default is 100
+  minPoolSize: 0,
+});
+
+let connected;
+export async function getDb() {
+  if (!connected) connected = client.connect();
+  await connected;
+  return client.db("myapp");
+}
+```
+
+`client.connect()` is also idempotent in modern versions and largely optional -- the driver connects lazily on first operation. Calling it explicitly at startup is still worth it: you find out about a bad URI or unreachable host immediately instead of on the first query.
+
+## Mongoose
+
+```bash
+npm install mongoose
+```
+
+```js
+import mongoose from "mongoose";
+
+await mongoose.connect("mongodb://127.0.0.1:27017/myapp");
+
+const User = mongoose.model("User", new mongoose.Schema({
+  email: { type: String, required: true, unique: true },
+  name: String,
+  createdAt: { type: Date, default: Date.now },
+}));
+
+const user = await User.findOne({ email: "ada@example.com" });
+console.log(user);
+```
+
+`mongoose.connect()` uses one shared connection (the default connection) for all models. Like the driver's client, call it once at startup, not per request. Mongoose buffers model operations issued before the connection is ready, so you won't get errors if a query fires during the connection window -- it queues until the socket is up.
+
+## Connection strings
+
+Two forms:
+
+```
+# Standard -- explicit host(s) and port
+mongodb://user:pass@host1:27017,host2:27017/myapp?replicaSet=rs0
+
+# SRV -- one DNS record resolves to the hosts. Atlas uses this.
+mongodb+srv://user:pass@cluster0.abcde.mongodb.net/myapp
+```
+
+`mongodb+srv://` looks up the cluster's members via a DNS SRV record, so you don't hardcode hostnames. It implies `tls=true` automatically. It's the format MongoDB Atlas hands you, and you don't need an extra DNS package -- SRV resolution is built into the driver.
+
+**Percent-encode credentials.** If your username or password contains `@`, `:`, `/`, or other reserved characters, encode them or the URI parser will misread the string. `p@ss` becomes `p%40ss`.
+
+## Three traps that catch everyone
+
+**`localhost` resolves to IPv6.** Node 18+ prefers IPv6, so on many machines `localhost` resolves to `::1`, but a default MongoDB install only listens on the IPv4 `127.0.0.1`. The result is a confusing `ECONNREFUSED` against a server that's clearly running. Use `127.0.0.1` in your connection string for local databases, or bind MongoDB to `::1` as well.
+
+**`authSource`.** Your user is created in one database (often `admin`) but you're connecting to another (`myapp`). The driver authenticates against the database in the path by default, so you get `Authentication failed`. Add `?authSource=admin` (or wherever the user lives). On Atlas this is handled for you; on self-hosted it bites constantly.
+
+**Atlas IP allowlist.** A first connection to Atlas that times out with a server-selection error is almost always your current IP not being on the cluster's allowlist, not a code problem. Check Network Access in the Atlas console before debugging your URI.
+
+## Pooling, the short version
+
+The driver opens sockets on demand up to `maxPoolSize` (default 100) and reuses them. You rarely need to tune this for a single process. Where it matters:
+
+- **Serverless** (Lambda, Vercel functions): cache the client across invocations on a module-level/global variable so warm instances reuse the pool instead of opening a new one per request. A cold start opens one pool; a leaked client-per-invocation opens hundreds.
+- **Many process replicas:** total connections to the server is roughly `maxPoolSize × number of processes`. Size it against the server's connection limit (Atlas tiers cap this).
+
+## Graceful shutdown
+
+Close the client (or `mongoose.disconnect()`) when the process is terminating so in-flight operations finish and sockets close cleanly:
+
+```js
+process.on("SIGINT", async () => {
+  await client.close();
+  process.exit(0);
+});
+```
+
+## Error reference
+
+| Error | Cause | Fix |
+|---|---|---|
+| `ECONNREFUSED ::1:27017` | `localhost` resolved to IPv6, server only on IPv4 | Use `127.0.0.1` |
+| `Authentication failed` | Wrong `authSource`, or bad credentials | Add `?authSource=admin`; check user/password |
+| `MongoServerSelectionError` | Can't reach any cluster member (timeout) | Atlas IP allowlist, network path, wrong host |
+| `URI must include hostname...` | Malformed connection string | Check format; percent-encode credentials |
+| `MongoParseError` | Unencoded special char in user/pass | Percent-encode (`@` → `%40`) |
+
+## Connecting with a GUI instead
+
+For exploring collections, checking document shapes, or sketching the aggregation pipeline you're about to embed in code, a client beats `console.log`. [Mako](/guides/mongodb-gui-client) connects to MongoDB with AI-assisted query building; the same guide compares Compass, Studio 3T, and the rest of the field honestly.
+
+For the query side once you're connected, see our MongoDB guides on the [aggregation pipeline](/guides/mongodb/aggregation-pipeline), [query operators](/guides/mongodb/query-operators), and [indexes](/guides/mongodb/indexes-explained). For loading data, see [importing CSV to MongoDB](/guides/import-csv-to-mongodb).
+
+---
+
+Mako connects to MongoDB (and 8 other databases) with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/mongodb/connect-from-python.mdx
+++ b/content/guides/mongodb/connect-from-python.mdx
@@ -1,0 +1,170 @@
+---
+title: "How to Connect to MongoDB from Python"
+description: "Connect to MongoDB from Python with PyMongo, the PyMongo Async API, or Motor. Working code for connection strings, Atlas SRV URIs, pooling, and the lazy-connection gotcha that hides bad credentials."
+database: "mongodb"
+category: "how-to"
+tags: ["mongodb", "python", "pymongo", "motor", "connection"]
+date: "2026-06-11"
+---
+
+Python's MongoDB story consolidated recently: PyMongo is now the official driver for both synchronous and asynchronous code. Motor, the long-standing asyncio driver, was deprecated in May 2025 and its support window ended in May 2026 -- its functionality moved into PyMongo's Async API. This guide shows working connection code for both styles, plus the connection-string and pooling details that matter in production.
+
+## Which option should you use?
+
+| Option | Install | Async | Notes |
+|---|---|---|---|
+| PyMongo (sync) | `pip install pymongo` | No | The default choice for scripts, Django, Flask |
+| PyMongo Async API | `pip install pymongo` | Yes | Same package, `AsyncMongoClient`. Successor to Motor |
+| Motor | `pip install motor` | Yes | Deprecated May 2025, support ended May 2026. Migrate off it |
+| MongoEngine / Beanie / ODMantic | varies | varies | ODMs layered on PyMongo -- pick one if you want a schema layer |
+
+Short version: install **pymongo** (4.17.0 as of June 2026) and use `MongoClient` for synchronous code or `AsyncMongoClient` for asyncio. Do not start new projects on Motor; MongoDB's own docs tell existing Motor users to migrate to the PyMongo Async API.
+
+## Connection strings
+
+Two formats exist:
+
+```
+mongodb://user:password@host1:27017,host2:27017/?replicaSet=rs0&authSource=admin
+mongodb+srv://user:password@cluster0.abc123.mongodb.net/
+```
+
+`mongodb://` lists hosts explicitly. `mongodb+srv://` (what Atlas gives you) resolves the host list and options from DNS SRV records, so the cluster can change topology without you editing the string. SRV URIs imply TLS and require the `dnspython` package:
+
+```bash
+pip install "pymongo[srv]"
+```
+
+Forgetting that extra produces `ConfigurationError: The "dnspython" module must be installed to use mongodb+srv:// URIs` -- probably the most-searched PyMongo error.
+
+Two details that bite:
+
+- If your password contains `@`, `:`, `/` or `%`, percent-encode it (`urllib.parse.quote_plus`), or the URI parser will split the string in the wrong place.
+- `authSource` defaults to the database in the URI path, or `admin` if none is given. If you created the user in `admin` but connect to `mydb`, set `authSource=admin` explicitly or authentication fails.
+
+## PyMongo (synchronous)
+
+```bash
+pip install pymongo
+```
+
+```python
+import os
+from pymongo import MongoClient
+
+client = MongoClient(os.environ["MONGODB_URI"])
+db = client["shop"]
+orders = db["orders"]
+
+doc = orders.find_one({"status": "pending"})
+print(doc)
+
+client.close()
+```
+
+No `connect()` call, no cursor objects to manage -- you index into databases and collections, and PyMongo handles the rest.
+
+### The lazy-connection gotcha
+
+`MongoClient(...)` does **not** connect. It returns immediately, even if the host is unreachable or the password is wrong. The connection happens on the first actual operation, which is where the error surfaces -- often far from the configuration mistake that caused it. Verify connectivity at startup with an explicit ping:
+
+```python
+from pymongo.errors import ConnectionFailure
+
+try:
+    client.admin.command("ping")
+except ConnectionFailure as e:
+    raise SystemExit(f"MongoDB unreachable: {e}")
+```
+
+Failures show up as `ServerSelectionTimeoutError` after `serverSelectionTimeoutMS` (default 30 seconds). For a startup check, 30 seconds of silence is a long time; tighten it:
+
+```python
+client = MongoClient(uri, serverSelectionTimeoutMS=5000)
+```
+
+## PyMongo Async API
+
+Same package, same API shape, `await` in front of operations:
+
+```python
+import asyncio, os
+from pymongo import AsyncMongoClient
+
+async def main():
+    client = AsyncMongoClient(os.environ["MONGODB_URI"])
+    orders = client["shop"]["orders"]
+
+    doc = await orders.find_one({"status": "pending"})
+    print(doc)
+
+    async for order in orders.find({"status": "shipped"}).limit(10):
+        print(order["_id"])
+
+    await client.close()
+
+asyncio.run(main())
+```
+
+Cursors are async iterators, and methods that perform I/O are coroutines. Unlike Motor, which wrapped PyMongo in a thread pool, the Async API implements asyncio natively, so there is no hidden thread hop per operation.
+
+### Migrating from Motor
+
+Mechanically the change is small: `AsyncIOMotorClient` becomes `AsyncMongoClient`, the `motor` import becomes `pymongo`, and the method names already match. MongoDB publishes a [migration guide](https://www.mongodb.com/docs/languages/python/pymongo-driver/current/reference/migration/) covering the edge cases (custom executors, `io_loop` arguments, Tornado integration). If you are on Motor today, schedule the migration -- the support window has already closed.
+
+## Pooling: you already have it
+
+`MongoClient` and `AsyncMongoClient` maintain a connection pool internally. The pattern is **one client per process, created once, reused everywhere** -- not one client per request. Useful knobs:
+
+```python
+client = MongoClient(
+    uri,
+    maxPoolSize=100,   # default 100 connections per host
+    minPoolSize=0,     # default 0
+    maxIdleTimeMS=None # how long an idle connection may live
+)
+```
+
+Two process-model rules:
+
+- **Fork safety:** never create the client before `fork()` and use it after. With Gunicorn's default prefork worker model, construct the client inside the worker (e.g. in a `post_fork` hook or lazily on first use), not at module import time in the master. PyMongo will warn `MongoClient opened before fork` if you get this wrong.
+- **Serverless:** in AWS Lambda and similar, cache the client in a module-level variable so warm invocations reuse it, and keep `maxPoolSize` small.
+
+## TLS and Atlas
+
+Atlas requires TLS; `mongodb+srv://` URIs enable it automatically. For self-hosted deployments:
+
+```python
+client = MongoClient(uri, tls=True, tlsCAFile="/path/to/ca.pem")
+```
+
+Atlas also enforces an IP access list. `ServerSelectionTimeoutError` with an SSL handshake message against a correct URI is, more often than not, your IP missing from the Atlas allowlist rather than a code problem.
+
+## Timezone-aware datetimes
+
+By default PyMongo returns naive `datetime` objects even though BSON dates are UTC. Make it explicit:
+
+```python
+client = MongoClient(uri, tz_aware=True)
+```
+
+Returned datetimes then carry UTC tzinfo, which prevents the classic bug of comparing naive and aware datetimes. More on BSON dates in [MongoDB data types and BSON](/guides/mongodb/data-types-bson).
+
+## Common errors
+
+| Error | Cause | Fix |
+|---|---|---|
+| `ServerSelectionTimeoutError` | Host unreachable, wrong port, Atlas IP allowlist, replica set name mismatch | Ping at startup, check allowlist, lower `serverSelectionTimeoutMS` to fail fast |
+| `ConfigurationError: "dnspython" must be installed` | SRV URI without the srv extra | `pip install "pymongo[srv]"` |
+| `OperationFailure: Authentication failed` | Wrong credentials or wrong `authSource` | Set `authSource` to the DB where the user was created |
+| `InvalidURI` / wrong host parsed | Unescaped `@` or `:` in password | `urllib.parse.quote_plus` the password |
+| `MongoClient opened before fork` warning | Client created in prefork master process | Create the client per worker process |
+
+## Related guides
+
+- [MongoDB query operators](/guides/mongodb/query-operators) -- what to do once you are connected
+- [MongoDB aggregation pipeline](/guides/mongodb/aggregation-pipeline)
+- [Import JSON to MongoDB](/guides/import-json-to-mongodb)
+- [Best MongoDB GUI clients](/guides/mongodb-gui-client)
+
+Mako connects to MongoDB with AI-powered autocomplete. Try it free at mako.ai.

--- a/content/guides/mssql/connect-from-go.mdx
+++ b/content/guides/mssql/connect-from-go.mdx
@@ -1,0 +1,233 @@
+---
+title: "How to Connect to SQL Server from Go"
+description: "Connect to Microsoft SQL Server from Go with the official microsoft/go-mssqldb driver. Working code for the URL DSN, @p1 named parameters, the LastInsertId trap, the encrypt default, named instances, Azure AD auth, and connection pooling."
+database: "mssql"
+category: "how-to"
+tags: ["sqlserver", "mssql", "go", "golang", "go-mssqldb", "database-sql", "connection"]
+date: "2026-06-16"
+---
+
+Connecting to Microsoft SQL Server from Go has settled on a single official driver: `microsoft/go-mssqldb`. It is a pure Go implementation of the TDS protocol that plugs into the standard `database/sql` interface, so the connection mechanics look familiar if you have used any other Go SQL driver. What does not carry over is the parameter syntax, the way you retrieve a generated ID, and the encryption defaults. Those three are where most first connections go wrong, so this guide covers them in detail.
+
+## The driver
+
+| Driver | Import path | Interface | Version (as of June 2026) |
+|---|---|---|---|
+| microsoft/go-mssqldb | `github.com/microsoft/go-mssqldb` | `database/sql` | v1.10.0 |
+
+There used to be two relevant packages. The original `denisenkom/go-mssqldb` is now in maintenance only (last release v0.12.3, October 2022) and its README points to the Microsoft fork. The Microsoft fork is the one to use: it is actively maintained, requires Go 1.17 or newer, and adds Azure AD / Microsoft Entra authentication through a sub-package. There is no cgo dependency, so cross-compilation and minimal container images work without a C toolchain.
+
+```sh
+go get github.com/microsoft/go-mssqldb
+```
+
+The driver registers itself with `database/sql` under the name `sqlserver` via a blank import:
+
+```go
+import (
+	"database/sql"
+
+	_ "github.com/microsoft/go-mssqldb"
+)
+```
+
+## Connect
+
+The recommended DSN is a URL. The driver also accepts ADO and ODBC style connection strings, but the URL form is the easiest to read and the one most examples use:
+
+```go
+package main
+
+import (
+	"context"
+	"database/sql"
+	"log"
+	"time"
+
+	_ "github.com/microsoft/go-mssqldb"
+)
+
+func main() {
+	dsn := "sqlserver://appuser:secret@127.0.0.1:1433?database=mydb&encrypt=true&app+name=myservice"
+
+	db, err := sql.Open("sqlserver", dsn)
+	if err != nil {
+		log.Fatal(err) // only DSN parse errors surface here
+	}
+	defer db.Close()
+
+	db.SetMaxOpenConns(25)
+	db.SetMaxIdleConns(25)
+	db.SetConnMaxLifetime(5 * time.Minute)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := db.PingContext(ctx); err != nil {
+		log.Fatal(err) // the real connection error shows up here
+	}
+	log.Println("connected")
+}
+```
+
+`sql.Open` does not open a connection. It validates the DSN and returns a pool handle. The first real network round trip happens on `PingContext` or your first query, so ping at startup if you want connection failures to surface immediately rather than on the first request. Pass the database with the `database` query parameter; putting it in the URL path is for the named-instance form described below.
+
+## Parameters use @p1, not ? or $1
+
+This is the difference that trips up everyone coming from MySQL or PostgreSQL drivers. The `sqlserver` driver does not accept `?` placeholders. It expects SQL Server's own syntax: positional `@p1` through `@pN`, or named parameters with `sql.Named`.
+
+Positional:
+
+```go
+var name string
+var price float64
+err := db.QueryRowContext(ctx,
+	"SELECT name, price FROM products WHERE id = @p1",
+	42,
+).Scan(&name, &price)
+```
+
+Named, which reads better when a value is used more than once:
+
+```go
+rows, err := db.QueryContext(ctx,
+	"SELECT id, name FROM products WHERE category = @cat AND price < @max",
+	sql.Named("cat", "tools"),
+	sql.Named("max", 100),
+)
+if err != nil {
+	log.Fatal(err)
+}
+defer rows.Close()
+
+for rows.Next() {
+	var id int
+	var name string
+	if err := rows.Scan(&id, &name); err != nil {
+		log.Fatal(err)
+	}
+	log.Println(id, name)
+}
+if err := rows.Err(); err != nil { // catches errors mid-iteration
+	log.Fatal(err)
+}
+```
+
+Two loop habits worth keeping: `defer rows.Close()` so a connection is not held when you return early, and check `rows.Err()` after the loop because `rows.Next()` returning `false` can mean either "done" or "failed".
+
+## LastInsertId does not work
+
+The other SQL Server specific trap. Calling `result.LastInsertId()` returns an error, not an ID:
+
+```
+LastInsertId is not supported. Please use the OUTPUT clause or add
+`select ID = convert(bigint, SCOPE_IDENTITY())` to the end of your query.
+```
+
+This is by design. SQL Server does not hand back generated keys the way MySQL does, so the driver refuses to guess. Retrieve the new ID explicitly. The cleanest way is an `OUTPUT` clause read with `QueryRow`:
+
+```go
+var newID int64
+err := db.QueryRowContext(ctx,
+	"INSERT INTO products (name, price) OUTPUT INSERTED.id VALUES (@p1, @p2)",
+	"Hammer", 19.99,
+).Scan(&newID)
+```
+
+`OUTPUT INSERTED.id` returns the generated value as a result set, so you treat the insert as a query. `SCOPE_IDENTITY()` works too, but `OUTPUT` is safe in the presence of triggers and handles multi-row inserts.
+
+## The encrypt default is weaker than you expect
+
+The Microsoft .NET and ODBC drivers default to encrypting connections. This Go driver does not. With `encrypt` unset, only the login packet is encrypted and the rest of the session travels in clear text. The accepted values:
+
+| `encrypt` value | Behavior |
+|---|---|
+| `false` / `optional` (default) | Only the login packet is encrypted |
+| `true` / `mandatory` | The whole session is encrypted; a valid server certificate is required |
+| `strict` | Full end-to-end TDS 8 encryption |
+| `disable` | No encryption at all |
+
+For anything beyond a local connection, set `encrypt=true`. If the server uses a self-signed certificate (common in development) the handshake will fail with a certificate error; add `trustservercertificate=true` to skip verification. Use that flag in development only, never against a production or Azure SQL endpoint, since it removes protection against a man-in-the-middle. Azure SQL Database always requires encryption and presents a valid certificate, so `encrypt=true` alone is correct there.
+
+```go
+dsn := "sqlserver://appuser:secret@db.example.com?database=mydb&encrypt=true"
+```
+
+## Named instances and ports
+
+SQL Server often runs as a named instance rather than on the default port 1433. Two ways to reach one. Give an explicit port if you know it:
+
+```
+sqlserver://user:pass@host:1455?database=mydb
+```
+
+Or name the instance in the URL path and let the driver discover the port through the SQL Server Browser service:
+
+```
+sqlserver://user:pass@host/SQLEXPRESS?database=mydb
+```
+
+The path form requires the SQL Server Browser service to be running on the host and UDP port 1434 to be reachable. If discovery fails, fall back to specifying the port directly.
+
+## Connection pooling
+
+`*sql.DB` is a pool and is safe for concurrent use, so create one at startup and share it. The defaults are unbounded open connections and two idle connections, which is rarely what you want against SQL Server. Size the pool against the server's connection limits and your process count:
+
+```go
+db.SetMaxOpenConns(25)              // ceiling on concurrent connections
+db.SetMaxIdleConns(25)              // keep idle ones ready, match MaxOpenConns
+db.SetConnMaxLifetime(5 * time.Minute) // recycle before the server drops them
+```
+
+Remember the total connection count is `MaxOpenConns` multiplied by the number of running processes. A handful of replicas with a high cap can exhaust the server's worker threads, so coordinate the value with your deployment topology.
+
+## Context and cancellation
+
+Use the `...Context` methods everywhere so a cancelled request or an expired deadline actually stops the work on the server rather than leaving it running:
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+defer cancel()
+
+var total int
+err := db.QueryRowContext(ctx, "SELECT count(*) FROM orders").Scan(&total)
+```
+
+The driver also recommends leaving `connection timeout` at 0 in the DSN and managing all timeouts through context, which keeps timeout handling in one place.
+
+## Azure AD / Microsoft Entra authentication
+
+For Azure SQL Database with Entra authentication instead of SQL logins, import the `azuread` sub-package, which registers a separate driver named `azuresql`:
+
+```go
+import (
+	"database/sql"
+
+	_ "github.com/microsoft/go-mssqldb/azuread"
+)
+
+// ...
+db, err := sql.Open("azuresql",
+	"sqlserver://your-server.database.windows.net?database=mydb&fedauth=ActiveDirectoryDefault")
+```
+
+`ActiveDirectoryDefault` walks the standard Azure credential chain (environment variables, managed identity, Azure CLI login), which is the right choice for code that runs both locally and on Azure infrastructure. Other `fedauth` modes cover managed identity, service principals, and interactive login.
+
+## Common errors
+
+| Error | Likely cause |
+|---|---|
+| `LastInsertId is not supported` | Calling `result.LastInsertId()`; use `OUTPUT INSERTED` or `SCOPE_IDENTITY()` instead |
+| `mssql: Login failed for user '...'` | Wrong credentials, or the login lacks access to the target database |
+| `TLS Handshake failed: ... certificate signed by unknown authority` | `encrypt=true` against a self-signed cert; add `trustservercertificate=true` in development |
+| `Unable to open tcp connection ... connectex: ... refused` | Server not listening on that host/port, or TCP/IP disabled in SQL Server Configuration Manager |
+| `Cannot open database "..." requested by the login` | The `database` parameter names a database the login cannot reach |
+| `sql: converting argument ... unsupported` / parameter not found | Used `?` or `$1` placeholders; switch to `@p1` or `sql.Named` |
+
+## Where Mako fits
+
+Once the connection works, you still have to explore the schema and get your queries right before wiring them into Go, and SQL Server's `@p1` parameters and `OUTPUT` clauses are easy to get subtly wrong in a code editor. Mako connects to SQL Server (and PostgreSQL, MySQL, ClickHouse, BigQuery, and more) with AI-powered autocomplete, so you can draft and test the exact statements your service will run. It is a read and query tool, not a schema-management GUI, so `CREATE`/`ALTER` work stays in SSMS, Azure Data Studio, or your migration tool.
+
+For loading data first, see our [import CSV to SQL Server](/guides/import-csv-to-mssql) and [import JSON to SQL Server](/guides/import-json-to-mssql) guides. To connect from other languages, see [connect to SQL Server from Python](/guides/mssql/connect-from-python) and [connect to SQL Server from Node.js](/guides/mssql/connect-from-node). For a desktop client, see our [SQL Server GUI client](/guides/mssql-gui-client) guide.
+
+Mako connects to SQL Server with AI-powered autocomplete. Try it free at mako.ai.

--- a/content/guides/mssql/connect-from-node.mdx
+++ b/content/guides/mssql/connect-from-node.mdx
@@ -1,0 +1,96 @@
+---
+title: "How to Connect to SQL Server from Node.js"
+description: "Connect to Microsoft SQL Server from Node.js using the mssql package over the Tedious driver. Working code for connection pools, the encrypt/trustServerCertificate trap, Azure AD auth, and parameterized queries."
+database: "mssql"
+category: "how-to"
+tags: ["sqlserver", "mssql", "nodejs", "tedious", "connection"]
+date: "2026-06-15"
+---
+
+The standard way to reach Microsoft SQL Server from Node.js is the `mssql` package, a higher-level wrapper over the `tedious` driver. `tedious` is the pure-JavaScript implementation of SQL Server's TDS protocol; `mssql` adds connection pooling, a promise API, and prepared statements on top. Use `mssql` unless you have a specific reason to drop down to raw Tedious. Current versions are `mssql` 12.5.5 and `tedious` 19.2.1 (as of June 2026).
+
+```bash
+npm install mssql
+```
+
+## The encrypt + trustServerCertificate trap
+
+This is the single most common reason a first connection fails. Since `mssql` 8, encryption is **on by default**. Against a local SQL Server or a container with a self-signed certificate, the driver then rejects the certificate and the connection dies with a TLS error -- even though your username and password are correct.
+
+For local development against a self-signed cert, you accept the certificate explicitly:
+
+```js
+import sql from "mssql";
+
+const pool = await sql.connect({
+  server: "localhost",
+  port: 1433,
+  user: "sa",
+  password: process.env.MSSQL_PASSWORD,
+  database: "analytics",
+  options: {
+    encrypt: true,
+    trustServerCertificate: true, // local/self-signed only
+  },
+});
+```
+
+In production against Azure SQL or a server with a real certificate, keep `encrypt: true` and **leave `trustServerCertificate` at its default of false** so the certificate is actually verified. Setting it to `true` in production gives you an encrypted-but-unauthenticated channel, which defeats the point.
+
+## Use the pool, query with parameters
+
+`sql.connect()` returns a global pool. For most apps that single pool is what you want -- create it once at startup and reuse it, rather than connecting per request. Use the `request().input()` API to bind parameters; never string-concatenate values into the SQL:
+
+```js
+const result = await pool.request()
+  .input("active", sql.Bit, true)
+  .query("SELECT id, email FROM users WHERE active = @active");
+
+console.log(result.recordset);
+```
+
+`result.recordset` is the array of rows. For statements that return multiple result sets, they arrive in `result.recordsets` (note the plural). Typing the input with `sql.Bit`, `sql.Int`, `sql.NVarChar`, etc. avoids implicit-conversion surprises on the server side.
+
+## Managing multiple pools
+
+If you connect to more than one database, do not call `sql.connect()` repeatedly -- it manages a single global pool and the second call returns the first connection. Instead create explicit pools:
+
+```js
+const reporting = new sql.ConnectionPool(reportingConfig);
+await reporting.connect();
+const rows = await reporting.request().query("SELECT * FROM daily_totals");
+```
+
+Call `pool.close()` on shutdown.
+
+## Azure AD authentication
+
+For Azure SQL Database, password auth is often disabled in favor of Entra ID (Azure AD). The `mssql` config takes an `authentication` block:
+
+```js
+const pool = await sql.connect({
+  server: "myserver.database.windows.net",
+  database: "analytics",
+  options: { encrypt: true },
+  authentication: {
+    type: "azure-active-directory-default",
+    options: { /* picks up managed identity or az login */ },
+  },
+});
+```
+
+The `azure-active-directory-default` type uses the same credential chain as the Azure SDK (managed identity in production, `az login` locally), so you avoid storing secrets at all.
+
+## The named instance and port question
+
+If you connect to a named instance (`SERVER\\SQLEXPRESS`) rather than a port, the driver needs the SQL Server Browser service running to resolve the instance to a dynamic port. That service is often firewalled off. When a named-instance connection times out, the simplest fix is to find the instance's actual TCP port and connect to `server` + `port` directly instead of using the instance name.
+
+## Verifying the connection
+
+```js
+const result = await pool.request().query("SELECT @@VERSION AS version");
+console.log(result.recordset[0].version);
+await pool.close();
+```
+
+To browse SQL Server tables and run ad-hoc queries without writing a connection script first, Mako connects to SQL Server with AI-powered autocomplete. Try it free at mako.ai.

--- a/content/guides/mssql/connect-from-python.mdx
+++ b/content/guides/mssql/connect-from-python.mdx
@@ -1,0 +1,194 @@
+---
+title: "How to Connect to SQL Server from Python"
+description: "Connect to Microsoft SQL Server from Python with pyodbc, the new official mssql-python driver, or pymssql. Working code, the ODBC Driver 18 encryption trap, Linux setup, and which driver to pick in 2026."
+database: "mssql"
+category: "how-to"
+tags: ["sql-server", "mssql", "python", "pyodbc", "mssql-python", "connection"]
+date: "2026-06-12"
+---
+
+For most of the last decade, connecting to SQL Server from Python meant pyodbc plus a separately installed Microsoft ODBC driver. That changed in late 2025 when Microsoft shipped `mssql-python`, its first official first-party Python driver, now generally available. pyodbc is still the most widely deployed option and the safest default for existing code, but the recommendation for new projects is shifting. This guide covers all three serious options with working code.
+
+## The options
+
+| Driver | Maintainer | How it talks to SQL Server | paramstyle | Version (as of June 2026) |
+|---|---|---|---|---|
+| pyodbc | Michael Kleehammer / community | unixODBC/ODBC + separately installed MS ODBC driver | `qmark` (`?`) | 5.3.0 |
+| mssql-python | Microsoft (official) | Bundled Microsoft ODBC driver, no separate install | `qmark` (`?`) | 1.9.0 |
+| pymssql | Community | FreeTDS (no ODBC layer) | `pyformat` (`%s`) | 2.3.13 |
+
+Rules of thumb:
+
+- **Existing codebase or maximum ecosystem compatibility:** pyodbc. Every tutorial, every SQLAlchemy setup, every Stack Overflow answer assumes it.
+- **New project:** mssql-python. It is Microsoft's official driver, GA since November 2025, installs with a single `pip install` (the ODBC driver is bundled -- currently 18.6.x), supports Windows, macOS (Intel and Apple Silicon), and Linux, and its API is deliberately pyodbc-compatible, so migration is mostly changing the import.
+- **You cannot install system packages** (locked-down hosts where adding the Microsoft ODBC driver isn't possible) and mssql-python doesn't cover your platform: pymssql. It uses FreeTDS instead of ODBC, so there is no driver to install -- but note its parameter style differs and the project went through a near-death period in 2019 before maintenance resumed.
+
+## pyodbc
+
+pyodbc is a generic ODBC bridge: it needs an ODBC driver manager plus the Microsoft ODBC Driver for SQL Server installed on the machine.
+
+### The Linux setup trap
+
+`pip install pyodbc` succeeds on Linux, then the import fails:
+
+```
+ImportError: libodbc.so.2: cannot open shared object file: No such file or directory
+```
+
+The wheel includes pyodbc but not unixODBC, and not the SQL Server driver. You need both:
+
+```bash
+# Debian/Ubuntu -- unixODBC runtime
+sudo apt install unixodbc
+
+# Microsoft ODBC Driver 18 (from Microsoft's repo, not Debian's)
+curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | sudo gpg --dearmor -o /usr/share/keyrings/microsoft.gpg
+curl -fsSL https://packages.microsoft.com/config/ubuntu/22.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
+sudo apt update
+sudo ACCEPT_EULA=Y apt install msodbcsql18
+```
+
+On macOS, use Homebrew (`brew install unixodbc` plus Microsoft's `msodbcsql18` tap). On Windows, the ODBC driver is usually already present or installs from a standalone MSI.
+
+### Connecting
+
+```python
+import pyodbc
+
+conn = pyodbc.connect(
+    "DRIVER={ODBC Driver 18 for SQL Server};"
+    "SERVER=db.example.com,1433;"
+    "DATABASE=sales;"
+    "UID=app_user;"
+    "PWD=secret;"
+    "Encrypt=yes;"
+)
+cursor = conn.cursor()
+cursor.execute("SELECT id, name FROM customers WHERE region = ?", ("EMEA",))
+for row in cursor.fetchall():
+    print(row.id, row.name)
+conn.close()
+```
+
+Parameters use `?` placeholders (qmark style). Note the server syntax: port is appended with a comma (`host,1433`), not a colon.
+
+### The ODBC Driver 18 encryption trap
+
+This is the error that fills the support forums:
+
+```
+SSL Provider: The certificate chain was issued by an authority that is not trusted.
+```
+
+ODBC Driver 18 changed the default from `Encrypt=no` to `Encrypt=yes`. Connections that worked for years under Driver 17 break on upgrade, because the server's TLS certificate (often self-signed by default on on-prem SQL Server) fails validation. Your options, in order of preference:
+
+1. **Install a properly signed certificate on the server** -- the right fix for production.
+2. **`TrustServerCertificate=yes`** in the connection string -- encrypts the connection but skips certificate validation. Acceptable for dev/test; in production it leaves you open to man-in-the-middle attacks.
+3. **`Encrypt=no`** -- plaintext. Avoid.
+
+Azure SQL is unaffected (its certificates chain to a public CA), which is why this trap bites on-prem and Docker setups specifically.
+
+### Bulk inserts: fast_executemany
+
+By default `cursor.executemany()` sends one round trip per row, which is painfully slow for large batches. One flag fixes it:
+
+```python
+cursor.fast_executemany = True
+cursor.executemany(
+    "INSERT INTO events (ts, payload) VALUES (?, ?)",
+    rows,  # list of tuples
+)
+```
+
+This packs rows into a parameter array and can be orders of magnitude faster. Watch for two gotchas: it allocates memory based on the widest value per column, and `varchar(max)` columns can degrade it back to slow mode.
+
+## mssql-python (the official Microsoft driver)
+
+```bash
+pip install mssql-python
+```
+
+That's the whole setup -- the Microsoft ODBC driver is bundled inside the wheel, so the unixODBC/msodbcsql18 dance above disappears. The API is intentionally pyodbc-shaped:
+
+```python
+import mssql_python
+
+conn = mssql_python.connect(
+    "SERVER=db.example.com,1433;"
+    "DATABASE=sales;"
+    "UID=app_user;"
+    "PWD=secret;"
+    "Encrypt=yes;"
+)
+cursor = conn.cursor()
+cursor.execute("SELECT id, name FROM customers WHERE region = ?", ("EMEA",))
+for row in cursor.fetchall():
+    print(row.id, row.name)
+conn.close()
+```
+
+No `DRIVER=` clause needed -- it always uses its bundled driver. Encryption defaults match ODBC Driver 18 (`Encrypt=yes`), so the certificate trap above applies identically; `TrustServerCertificate=yes` works the same way.
+
+Beyond the pyodbc-compatible surface, it adds first-party conveniences: built-in connection pooling (`PoolingManager`), Microsoft Entra ID authentication (`AuthType`), and native UUID handling. Since it is the driver Microsoft now actively develops (pyodbc receives community maintenance), expect new SQL Server features to land here first.
+
+The honest caveats: it is barely a year old, third-party ecosystem support is still catching up (SQLAlchemy's bundled dialect targets pyodbc and pymssql; the mssql-python dialect is provided by a separate package), and pinning matters more with a fast-moving 1.x project.
+
+## pymssql
+
+pymssql skips ODBC entirely and talks TDS via FreeTDS. Modern wheels bundle FreeTDS with TLS support, so `pip install pymssql` is genuinely all you need:
+
+```python
+import pymssql
+
+conn = pymssql.connect(
+    server="db.example.com",
+    port=1433,
+    user="app_user",
+    password="secret",
+    database="sales",
+)
+cursor = conn.cursor(as_dict=True)
+cursor.execute("SELECT id, name FROM customers WHERE region = %s", ("EMEA",))
+for row in cursor.fetchall():
+    print(row["id"], row["name"])
+conn.close()
+```
+
+Note the parameter style: `%s`, like the MySQL drivers, not `?`. Moving code between pymssql and the ODBC-based drivers means touching every query.
+
+Worth knowing: the project announced its own discontinuation in 2019 (the maintainers recommended pyodbc), then new maintainers revived it in 2021 and it has been actively released since -- 2.3.13 is current. Historically its Azure SQL story was weak because older wheels lacked TLS; current wheels fixed this, but if you find old advice saying "pymssql can't connect to Azure," that's what it refers to.
+
+## SQLAlchemy
+
+SQLAlchemy's `mssql` dialect supports pyodbc (recommended) and pymssql out of the box:
+
+```python
+from sqlalchemy import create_engine, text
+
+engine = create_engine(
+    "mssql+pyodbc://app_user:secret@db.example.com:1433/sales"
+    "?driver=ODBC+Driver+18+for+SQL+Server&Encrypt=yes",
+    fast_executemany=True,
+)
+with engine.connect() as conn:
+    rows = conn.execute(text("SELECT TOP 5 id, name FROM customers")).fetchall()
+```
+
+The driver name goes in the query string with `+` for spaces. `fast_executemany=True` at engine level enables the bulk-insert fast path for all inserts. For mssql-python, install the separate `mssql-python-sqlalchemy` dialect package and use the `mssql+mssql_python://` scheme.
+
+## Common connection errors
+
+| Error | Likely cause |
+|---|---|
+| `libodbc.so.2: cannot open shared object file` | unixODBC not installed (pyodbc on Linux) |
+| `Data source name not found and no default driver specified` | `DRIVER=` name doesn't match an installed driver -- check `odbcinst -q -d` |
+| `certificate chain was issued by an authority that is not trusted` | Driver 18 `Encrypt=yes` default vs self-signed server cert (see above) |
+| `Login failed for user` (18456) | Wrong credentials, or SQL auth disabled (Windows-auth-only server) |
+| `Login timeout expired` | Network/firewall, wrong port, or SQL Server not listening on TCP (enable TCP/IP in Configuration Manager) |
+| `Adaptive Server connection failed` | pymssql/FreeTDS-specific catch-all -- check host, port, and TLS settings |
+
+## Querying without writing connection code
+
+If the goal is to explore a SQL Server database rather than build an application, a GUI client skips all of this. Mako connects to SQL Server (along with PostgreSQL, MySQL, and six other engines) and gives you AI-assisted SQL directly -- see our [SQL Server GUI client guide](/guides/mssql-gui-client) for how it compares to SSMS, Azure Data Studio, and DBeaver. For getting data in, see [importing CSV to SQL Server](/guides/import-csv-to-mssql).
+
+Mako connects to SQL Server with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/mysql/connect-from-go.mdx
+++ b/content/guides/mysql/connect-from-go.mdx
@@ -1,0 +1,194 @@
+---
+title: "How to Connect to MySQL from Go"
+description: "Connect to MySQL from Go with go-sql-driver/mysql and database/sql. Working code for connection pools, the DSN parseTime and loc traps, context timeouts, parameterized queries, and common authentication errors."
+database: "mysql"
+category: "how-to"
+tags: ["mysql", "go", "golang", "go-sql-driver", "database-sql", "connection"]
+date: "2026-06-15"
+---
+
+For MySQL in Go there is one driver everyone uses: go-sql-driver/mysql. It implements Go's standard `database/sql/driver` interface, so once you import it you work entirely through the standard `database/sql` API. There is no real competitor with comparable maintenance and adoption, which makes the choice simple. This guide shows working code, the DSN options that quietly cause bugs (especially `parseTime`), and the errors you'll hit first.
+
+## The driver
+
+| Driver | Import path | Interface | Version (as of June 2026) |
+|---|---|---|---|
+| go-sql-driver/mysql | `github.com/go-sql-driver/mysql` | `database/sql` | v1.9.0 |
+
+It is a pure Go implementation -- no cgo, no libmysqlclient, no native build step. That makes cross-compilation and container builds trivial.
+
+```bash
+go get github.com/go-sql-driver/mysql
+```
+
+You import it as a side-effecting blank import (it registers itself with `database/sql`) and use the standard package directly:
+
+```go
+import (
+	"database/sql"
+	_ "github.com/go-sql-driver/mysql"
+)
+```
+
+## A working connection
+
+```go
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+func main() {
+	db, err := sql.Open("mysql", os.Getenv("MYSQL_DSN"))
+	if err != nil {
+		log.Fatal(err) // only DSN parse errors land here
+	}
+	defer db.Close()
+
+	// Pool tuning -- see the section below for why these matter.
+	db.SetMaxOpenConns(10)
+	db.SetMaxIdleConns(5)
+	db.SetConnMaxLifetime(3 * time.Minute)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := db.PingContext(ctx); err != nil {
+		log.Fatalf("cannot reach MySQL: %v", err)
+	}
+
+	rows, err := db.QueryContext(ctx,
+		"SELECT id, name FROM customers WHERE region = ?",
+		"EMEA",
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id int
+		var name string
+		if err := rows.Scan(&id, &name); err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(id, name)
+	}
+	if err := rows.Err(); err != nil { // mid-loop errors surface here
+		log.Fatal(err)
+	}
+}
+```
+
+Three habits worth burning in:
+
+- **`sql.Open` does not connect.** It only parses the DSN and prepares the lazy pool. The first real connection happens on the first query or on an explicit `db.PingContext`. Always ping at startup so a bad host or password fails immediately rather than on a user's first request.
+- **Always `defer rows.Close()` and check `rows.Err()`** after the loop. A failure mid-iteration ends the loop normally; the error only appears in `rows.Err()`. Skipping it silently truncates results, and leaked result sets pin a pooled connection.
+- **Placeholders are `?`**, MySQL-style. Pass values as arguments so the driver parameterizes them. Never assemble SQL with `fmt.Sprintf`.
+
+## The DSN, and the two traps inside it
+
+The data source name is a single string and most connection bugs live here. The general form:
+
+```
+username:password@protocol(address:port)/dbname?param=value
+```
+
+A realistic one:
+
+```
+app_user:secret@tcp(db.example.com:3306)/sales?parseTime=true&loc=UTC&charset=utf8mb4
+```
+
+### Trap 1: parseTime
+
+By default the driver returns `DATE`, `DATETIME`, and `TIMESTAMP` columns as `[]byte`, not `time.Time`. If you try to `Scan` one into a `time.Time` you get a conversion error. Set `parseTime=true` so the driver hands you real `time.Time` values:
+
+```
+?parseTime=true
+```
+
+This is the single most common surprise for newcomers. Almost every real application wants it on.
+
+### Trap 2: loc and time zones
+
+Once `parseTime=true` is set, the `loc` parameter decides which location the driver attaches to parsed times. The default is `UTC`. If your server stores wall-clock times in a non-UTC zone and you don't set `loc`, you'll get times shifted by the offset. The safe pattern is to store and interpret everything in UTC:
+
+```
+?parseTime=true&loc=UTC
+```
+
+Set the value to a URL-encoded IANA name (e.g. `loc=America%2FNew_York`) only if you have a specific reason. Mixing time zones between the database, the `loc` setting, and your application is a classic source of off-by-an-hour bugs.
+
+### charset and collation
+
+Use `charset=utf8mb4` (or set the column/connection collation explicitly) so full Unicode -- including emoji and supplementary characters -- round-trips. The legacy `utf8` alias in MySQL is really `utf8mb3` and cannot store 4-byte characters.
+
+## Connection pool sizing
+
+`database/sql` manages the pool; the driver does not. The three knobs:
+
+```go
+db.SetMaxOpenConns(10)         // hard cap on open connections; 0 = unlimited (risky)
+db.SetMaxIdleConns(5)          // idle connections kept ready
+db.SetConnMaxLifetime(3 * time.Minute) // recycle connections before the server drops them
+```
+
+Two specifics matter for MySQL:
+
+- **Set `SetConnMaxLifetime` shorter than the server's `wait_timeout`.** MySQL closes idle connections after `wait_timeout` (default 8 hours, but managed providers and proxies often set it to minutes). If the pool hands you a connection the server already dropped, the first query fails with a "bad connection" / "invalid connection" error. Recycling connections before that window avoids it.
+- **Account for multiple processes.** Each instance of your service gets its own pool. Eight pods × `SetMaxOpenConns(10)` = 80 connections, against MySQL's default `max_connections` of 151. Size accordingly.
+
+## Context timeouts
+
+Use `...Context` method variants everywhere and bound query time with a context:
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+defer cancel()
+
+var name string
+err := db.QueryRowContext(ctx,
+	"SELECT name FROM customers WHERE id = ?", 42,
+).Scan(&name)
+if err != nil {
+	if errors.Is(err, sql.ErrNoRows) { // no matching row
+		// handle "not found"
+	}
+	log.Fatal(err)
+}
+```
+
+When the context is cancelled or times out, the driver attempts to cancel the running query rather than leaving it to finish on its own. This keeps a slow query from pinning a pooled connection.
+
+## Authentication notes
+
+MySQL 8.0 made `caching_sha2_password` the default authentication plugin, and MySQL 9 removed the old `mysql_native_password` plugin entirely. The Go driver supports `caching_sha2_password` natively, so this is usually a non-issue. Two things to know:
+
+- Over a plaintext (non-TLS) connection, `caching_sha2_password` requires the server's RSA public key for the initial handshake. The driver handles this, but if you've locked the server down you may need `allowNativePasswords` or to provide the key explicitly.
+- For TLS, add `tls=true` (or a custom registered TLS config) to the DSN. Hosted MySQL providers typically require it: `...?parseTime=true&tls=true`.
+
+## Common errors
+
+| Error | Likely cause |
+|---|---|
+| `dial tcp ... connection refused` | Wrong host/port, or MySQL not listening on TCP |
+| `Error 1045: Access denied for user` | Wrong credentials, or the user lacks host-pattern access (`user@%` vs `user@localhost`) |
+| `sql: Scan error ... converting ... to time.Time` | `parseTime=true` missing from the DSN |
+| `invalid connection` / `bad connection` on first query | Server dropped an idle connection -- set `SetConnMaxLifetime` below `wait_timeout` |
+| `Error 1040: Too many connections` | Pool size × process count exceeds server `max_connections` |
+| `this authentication plugin is not supported` | Server uses an auth plugin the DSN config disallows -- check `tls`/`allowNativePasswords` |
+
+## Querying without writing connection code
+
+If you want to explore a MySQL database rather than build an application, a GUI client skips all of this. Mako connects to MySQL with AI-assisted SQL -- see our [MySQL GUI client guide](/guides/mysql-gui-client) for how it compares to MySQL Workbench, DBeaver, and TablePlus. Connecting from another language? See [How to Connect to MySQL from Python](/guides/mysql/connect-from-python) and [from Node.js](/guides/mysql/connect-from-node).
+
+Mako connects to MySQL with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/mysql/connect-from-node.mdx
+++ b/content/guides/mysql/connect-from-node.mdx
@@ -1,0 +1,171 @@
+---
+title: "How to Connect to MySQL from Node.js"
+description: "Connect to MySQL from Node.js with mysql2. Working code for pools, prepared statements, and async/await, the caching_sha2_password auth error explained, and why the legacy mysql package is no longer an option."
+database: "mysql"
+category: "how-to"
+tags: ["mysql", "nodejs", "mysql2", "connection", "connection-pool"]
+date: "2026-06-12"
+---
+
+For new Node.js projects there is one answer: `mysql2`. The package it succeeded, `mysql` (felixge's node-mysql), hasn't shipped a release since January 2020 and cannot authenticate against MySQL 8's default auth plugin without a workaround. This guide shows working mysql2 code for connections, pools, and prepared statements, then covers the configuration and errors that actually trip people up.
+
+## The options
+
+| Client | Package | Status | Version (as of June 2026) |
+|---|---|---|---|
+| mysql2 | `mysql2` | Actively maintained, the default choice | 3.22.5 |
+| node-mysql (legacy) | `mysql` | Last release Jan 2020 | 2.18.1 |
+| MariaDB connector | `mariadb` | Maintained by MariaDB Corp, also speaks MySQL protocol | 3.5.3 |
+
+mysql2 is API-compatible with the legacy `mysql` package (it started as a drop-in replacement), adds a native Promise API, prepared statements, and support for MySQL 8+ authentication. Every major ORM and query builder (Prisma, Drizzle, Knex, Sequelize, TypeORM) uses or recommends it.
+
+The `mariadb` connector is a reasonable pick if your server is actually MariaDB -- it supports MariaDB-specific features like `INSERT ... RETURNING`. Against a MySQL server, stick with mysql2.
+
+## Basic connection
+
+```bash
+npm install mysql2
+```
+
+Import from `mysql2/promise` for async/await. The callback API (`require("mysql2")`) exists for legacy compatibility, but there's no reason to use it in new code:
+
+```js
+import mysql from "mysql2/promise";
+
+const connection = await mysql.createConnection({
+  host: "db.example.com",
+  port: 3306,
+  user: "app_user",
+  password: "secret",
+  database: "sales",
+});
+
+const [rows] = await connection.query(
+  "SELECT id, name FROM customers WHERE region = ?",
+  ["EMEA"]
+);
+console.log(rows);
+
+await connection.end();
+```
+
+Two things to notice:
+
+- Placeholders are `?`, positional. Never interpolate values into the SQL string.
+- Results come back as `[rows, fields]` -- a two-element array you destructure. Forgetting the destructure and treating the whole array as rows is a classic first-hour bug.
+
+A connection URI works too: `mysql.createConnection("mysql://app_user:secret@db.example.com:3306/sales")`.
+
+## Use a pool for anything serving requests
+
+A single connection processes one query at a time and dies permanently if the server drops it. A pool manages multiple connections and replaces broken ones:
+
+```js
+import mysql from "mysql2/promise";
+
+const pool = mysql.createPool({
+  host: "db.example.com",
+  user: "app_user",
+  password: "secret",
+  database: "sales",
+  connectionLimit: 10,     // default: 10
+  maxIdle: 10,             // default: same as connectionLimit
+  idleTimeout: 60000,      // default: idle connections closed after 60s
+  queueLimit: 0,           // default: 0 = unlimited queued requests
+});
+
+const [rows] = await pool.query("SELECT * FROM orders WHERE status = ?", ["open"]);
+```
+
+`pool.query()` grabs a connection, runs the query, and releases it automatically. The defaults above were verified against mysql2 3.22.5.
+
+Size `connectionLimit` against the server's `max_connections` (default 151 on MySQL 8), remembering that every worker process gets its own pool. Four Node processes with `connectionLimit: 50` can exhaust a default server.
+
+### Transactions need a dedicated connection
+
+`pool.query()` may run consecutive statements on different connections, which silently breaks transactions. Check a connection out explicitly:
+
+```js
+const conn = await pool.getConnection();
+try {
+  await conn.beginTransaction();
+  await conn.query("UPDATE accounts SET balance = balance - ? WHERE id = ?", [100, 1]);
+  await conn.query("UPDATE accounts SET balance = balance + ? WHERE id = ?", [100, 2]);
+  await conn.commit();
+} catch (err) {
+  await conn.rollback();
+  throw err;
+} finally {
+  conn.release();   // forget this and the pool eventually deadlocks
+}
+```
+
+## query() vs execute()
+
+mysql2 has two query methods. `query()` does client-side escaping and sends plain SQL text. `execute()` uses true server-side prepared statements: the statement is compiled once, parameters travel separately from the SQL, and mysql2 caches the prepared statement per connection:
+
+```js
+// Prepared statement -- compiled once per connection, parameters sent separately
+const [rows] = await pool.execute(
+  "SELECT * FROM orders WHERE customer_id = ? AND status = ?",
+  [42, "open"]
+);
+```
+
+Use `execute()` for hot-path queries that run repeatedly. Two caveats: prepared statements can't parameterize identifiers (table or column names), and some statements (`USE`, certain DDL) can't be prepared at all -- use `query()` for those.
+
+Named placeholders are available behind a flag, with `:name` syntax:
+
+```js
+const pool = mysql.createPool({ /* ... */, namedPlaceholders: true });
+const [rows] = await pool.execute(
+  "SELECT * FROM orders WHERE customer_id = :id AND status = :status",
+  { id: 42, status: "open" }
+);
+```
+
+## The auth error everyone hits: ER_NOT_SUPPORTED_AUTH_MODE
+
+MySQL 8 changed the default authentication plugin from `mysql_native_password` to `caching_sha2_password`. The legacy `mysql` package never gained support for it, so connecting to a stock MySQL 8+ server fails with:
+
+```
+ER_NOT_SUPPORTED_AUTH_MODE: Client does not support authentication protocol
+requested by server; consider upgrading MySQL client
+```
+
+The fix is to use mysql2, which supports `caching_sha2_password` natively (along with `mysql_native_password` and `sha256_password`). If you see this error *with* mysql2, the user was likely created with a plugin the server can't negotiate over an insecure channel -- `caching_sha2_password` requires either TLS or an RSA key exchange for the initial handshake, both of which mysql2 handles automatically against a normally configured server.
+
+The wrong fix, still circulating in old Stack Overflow answers, is downgrading the user with `ALTER USER ... IDENTIFIED WITH mysql_native_password`. MySQL 9 removed `mysql_native_password` entirely, so that workaround now has an expiry date attached.
+
+## Other gotchas
+
+**"Connection lost: The server closed the connection."** MySQL drops connections idle longer than `wait_timeout` (default 8 hours, often minutes on managed platforms). Single long-lived connections will eventually hit this; pools replace dead connections on checkout, which is the main practical reason to use one even at low traffic.
+
+**Charset and emoji.** Modern mysql2 defaults to `utf8mb4`, which handles all of Unicode. But if your *tables* were created with legacy `utf8` (a 3-byte-max encoding), inserting an emoji fails with `Incorrect string value`. Fix the table: `ALTER TABLE t CONVERT TO CHARACTER SET utf8mb4`.
+
+**BIGINT precision.** JavaScript numbers lose precision past 2^53. mysql2 returns `BIGINT` columns as JS numbers by default; for ID columns beyond that range, set `supportBigNumbers: true` and `bigNumberStrings: true` to get strings back instead of silently wrong numbers.
+
+**Dates and timezones.** mysql2 converts `DATETIME`/`TIMESTAMP` to JS `Date` objects using the connection's `timezone` setting (default: local). For servers storing UTC, set `timezone: "Z"` -- or `dateStrings: true` to get raw strings and side-step `Date` entirely.
+
+**SSL.** Off by default. For managed databases (PlanetScale, RDS, Cloud SQL over public IP), enable it: `ssl: { rejectUnauthorized: true }` with the provider's CA if needed. Don't ship `rejectUnauthorized: false` -- it disables certificate verification, leaving the connection encrypted but unauthenticated.
+
+## Error reference
+
+| Error | Cause | Fix |
+|---|---|---|
+| `ECONNREFUSED` | Nothing listening at host:port | Check host/port, server running, firewall |
+| `ER_ACCESS_DENIED_ERROR` | Wrong user/password, or user not allowed from this host | Check credentials; MySQL accounts are `user@host` pairs |
+| `ER_NOT_SUPPORTED_AUTH_MODE` | Legacy `mysql` package vs MySQL 8+ auth | Use mysql2 |
+| `ER_BAD_DB_ERROR` | Database doesn't exist | Check `database` name |
+| `ETIMEDOUT` | Host unreachable (security group, VPC, wrong host) | Network path, not credentials |
+| `Connection lost` | Server closed an idle connection | Use a pool |
+
+## Connecting with a GUI instead
+
+For exploring data, checking schemas, or debugging the queries you're about to embed in code, a client beats `console.log`. [Mako](/guides/mysql-gui-client) connects to MySQL with AI-assisted SQL autocomplete; the same guide compares MySQL Workbench, DBeaver, TablePlus, and the rest of the field honestly.
+
+For the SQL side of things once you're connected, see our MySQL guides on [joins](/guides/mysql/joins-guide), [transactions](/guides/mysql/transactions), and [upserts](/guides/mysql/upsert). For loading data, see [importing CSV to MySQL](/guides/import-csv-to-mysql).
+
+---
+
+Mako connects to MySQL (and 8 other databases) with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/mysql/connect-from-python.mdx
+++ b/content/guides/mysql/connect-from-python.mdx
@@ -1,0 +1,226 @@
+---
+title: "How to Connect to MySQL from Python"
+description: "Connect to MySQL from Python with mysqlclient, PyMySQL, MySQL Connector/Python, or SQLAlchemy. Working code for connections, queries, pooling, and common errors."
+database: "mysql"
+category: "how-to"
+tags: ["mysql", "python", "pymysql", "mysqlclient", "sqlalchemy", "connection"]
+date: "2026-06-11"
+---
+
+Python has three main MySQL drivers -- mysqlclient, PyMySQL, and MySQL Connector/Python -- plus SQLAlchemy as an abstraction on top, and aiomysql/asyncmy for asyncio. They all get the job done; they differ in installation friction, speed, and async support. This guide shows working code for each and the trade-offs that decide between them.
+
+## Which driver should you use?
+
+| Driver | Implementation | Async | Notes |
+|---|---|---|---|
+| mysqlclient | C extension (libmysqlclient) | No | Fastest sync driver; needs build tools or wheels |
+| PyMySQL | Pure Python | No | Installs anywhere, no compilation, slower on big result sets |
+| MySQL Connector/Python | Pure Python + optional C extension | No | Oracle's official driver, GPLv2 with FOSS exception |
+| aiomysql | Pure Python (reuses PyMySQL) | Yes | The established asyncio option |
+| asyncmy | Cython (reuses PyMySQL/aiomysql) | Yes | Faster asyncio fork of aiomysql |
+
+Rules of thumb: **mysqlclient** when you control the environment and want raw speed (it wraps the C client library, so it is the fastest at fetching large result sets). **PyMySQL** when you want zero installation drama -- pure Python, works on any platform, and is a drop-in replacement for mysqlclient's API. **MySQL Connector/Python** when you want the vendor-supported driver or features like the X DevAPI. For asyncio, **aiomysql** or **asyncmy**. All three sync drivers implement DB-API 2.0, so the query code looks nearly identical; switching later is cheap.
+
+These drivers also speak to MariaDB, which uses the same wire protocol. (MariaDB additionally ships its own `mariadb` connector.)
+
+## Connection details you need
+
+Host, port (3306 by default), database name, user, password. The examples read from environment variables -- never hardcode credentials.
+
+## PyMySQL
+
+```bash
+pip install PyMySQL
+```
+
+```python
+import os
+import pymysql
+
+conn = pymysql.connect(
+    host=os.environ["MYSQL_HOST"],
+    port=3306,
+    user=os.environ["MYSQL_USER"],
+    password=os.environ["MYSQL_PASSWORD"],
+    database=os.environ["MYSQL_DATABASE"],
+    charset="utf8mb4",
+    cursorclass=pymysql.cursors.DictCursor,
+)
+
+try:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id, email FROM users WHERE created_at > %s",
+            ("2026-01-01",),
+        )
+        for row in cur.fetchall():
+            print(row["id"], row["email"])
+    conn.commit()
+finally:
+    conn.close()
+```
+
+Three details worth knowing:
+
+- **`charset="utf8mb4"`**: always set this. MySQL's legacy `utf8` charset is a 3-byte subset that cannot store emoji or many CJK characters; `utf8mb4` is actual UTF-8.
+- **autocommit is off by default** (per DB-API). Writes are invisible to other connections until you call `conn.commit()`. Forgetting this is the single most common "my INSERT disappeared" report. Pass `autocommit=True` if you want MySQL's native behavior.
+- **Parameters use `%s`** regardless of type -- it is not Python string formatting, the driver escapes values for you. Never build SQL with f-strings.
+
+## mysqlclient
+
+The C-extension descendant of the old MySQLdb project, and the driver Django's MySQL backend recommends.
+
+```bash
+pip install mysqlclient
+```
+
+On Linux you may need headers first (`default-libmysqlclient-dev` on Debian/Ubuntu); macOS users typically `brew install mysql-client pkg-config`. Recent versions ship binary wheels for common platforms, which removes most of the historical pain.
+
+```python
+import MySQLdb
+
+conn = MySQLdb.connect(
+    host="localhost",
+    user="app",
+    password="...",
+    database="mydb",
+    charset="utf8mb4",
+)
+cur = conn.cursor()
+cur.execute("SELECT id, email FROM users WHERE id = %s", (42,))
+print(cur.fetchone())
+conn.commit()
+conn.close()
+```
+
+Same DB-API shape as PyMySQL -- intentionally so. PyMySQL was written as a pure-Python drop-in for this exact API. If you start on PyMySQL and later need mysqlclient's speed, the migration is mostly the import line.
+
+## MySQL Connector/Python
+
+Oracle's official driver. Pure Python by default with an optional C extension; licensed GPLv2 with the FOSS exception (fine for most uses, but check if you ship proprietary software -- the other two drivers are MIT/dual-licensed and avoid the question).
+
+```bash
+pip install mysql-connector-python
+```
+
+```python
+import mysql.connector
+
+conn = mysql.connector.connect(
+    host="localhost",
+    user="app",
+    password="...",
+    database="mydb",
+)
+cur = conn.cursor(dictionary=True)
+cur.execute("SELECT id, email FROM users WHERE id = %s", (42,))
+print(cur.fetchone())
+cur.close()
+conn.close()
+```
+
+It also ships a built-in pool:
+
+```python
+from mysql.connector import pooling
+
+pool = pooling.MySQLConnectionPool(pool_name="app", pool_size=5, host="localhost", user="app", password="...", database="mydb")
+conn = pool.get_connection()  # returns to the pool on conn.close()
+```
+
+## Async: aiomysql and asyncmy
+
+Both reuse PyMySQL's protocol implementation. aiomysql is the established choice; asyncmy rewrites the hot paths in Cython for speed and is the one SQLAlchemy's docs point to for async MySQL.
+
+```bash
+pip install aiomysql
+```
+
+```python
+import asyncio
+import aiomysql
+
+async def main():
+    pool = await aiomysql.create_pool(
+        host="localhost", user="app", password="...", db="mydb", autocommit=True
+    )
+    async with pool.acquire() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute("SELECT count(*) FROM users")
+            print(await cur.fetchone())
+    pool.close()
+    await pool.wait_closed()
+
+asyncio.run(main())
+```
+
+## SQLAlchemy
+
+Not a driver -- it needs one of the above underneath, selected by the URL scheme:
+
+```bash
+pip install sqlalchemy mysqlclient
+```
+
+```python
+import os
+from sqlalchemy import create_engine, text
+
+# mysql+mysqldb:// for mysqlclient, mysql+pymysql:// for PyMySQL,
+# mysql+mysqlconnector:// for Connector/Python, mysql+asyncmy:// for async
+engine = create_engine(
+    "mysql+mysqldb://app:password@localhost:3306/mydb?charset=utf8mb4",
+    pool_size=5,
+    max_overflow=10,
+    pool_recycle=3600,
+    pool_pre_ping=True,
+)
+
+with engine.connect() as conn:
+    result = conn.execute(text("SELECT id, email FROM users WHERE id = :id"), {"id": 42})
+    print(result.fetchone())
+```
+
+`pool_recycle` and `pool_pre_ping` are not optional decoration for MySQL -- see the next section.
+
+## Connection pooling and the wait_timeout trap
+
+MySQL servers drop idle connections after `wait_timeout` seconds (28800 by default, but cloud providers and DBAs often set it much lower). A pooled connection that sat idle past the timeout produces the classic:
+
+```
+MySQL server has gone away (error 2006)
+```
+
+on its next query. Defenses, in order of preference:
+
+1. **`pool_pre_ping=True`** (SQLAlchemy): emits a lightweight ping before handing out a pooled connection and transparently replaces dead ones.
+2. **`pool_recycle=3600`**: proactively retires connections older than N seconds. Set it below your server's `wait_timeout`.
+3. With raw drivers, `conn.ping(reconnect=True)` (PyMySQL/mysqlclient) before use accomplishes the same manually.
+
+For serverless or many-instance deployments where in-process pools multiply into thousands of connections, put ProxySQL or your cloud provider's pooler (e.g. RDS Proxy) in front of the server.
+
+## SSL/TLS
+
+Hosted MySQL (RDS, Cloud SQL, PlanetScale, Aiven) generally requires TLS. With PyMySQL:
+
+```python
+conn = pymysql.connect(..., ssl={"ca": "/path/to/ca.pem"})
+```
+
+With SQLAlchemy, append `?ssl_ca=/path/to/ca.pem` to the URL (parameter names vary slightly per underlying driver). Passing a CA bundle enables server certificate verification; connecting with TLS but no CA check encrypts the traffic without proving you reached the right server.
+
+## Common errors and what they mean
+
+- `(2003) Can't connect to MySQL server`: wrong host/port, server down, or firewall. On Linux servers also check `bind-address` in MySQL config -- `127.0.0.1` means no remote connections.
+- `(1045) Access denied for user`: bad credentials, or the user exists for a different host pattern (`'app'@'localhost'` is a different account than `'app'@'%'`).
+- `(1049) Unknown database`: the database name in your connection call does not exist; `SHOW DATABASES` to verify.
+- `(2006) MySQL server has gone away`: idle timeout (see pooling section) or a query exceeding `max_allowed_packet`.
+- `(1156) caching_sha2_password` auth errors on MySQL 8+: old driver versions lack the default auth plugin. Upgrade the driver; switching the user to `mysql_native_password` is the legacy workaround, not the fix.
+
+## Verifying your connection and exploring the data
+
+After connecting, you usually want to see the schema and check your data landed. The `mysql` CLI with `SHOW TABLES` works; a GUI is faster for browsing -- we compared the options in [Best MySQL GUI Clients](/guides/mysql-gui-client). For loading data, see [Import CSV to MySQL](/guides/import-csv-to-mysql) and [Import JSON to MySQL](/guides/import-json-to-mysql). When you start writing real queries, the [MySQL window functions](/guides/mysql/window-functions) and [JSON queries](/guides/mysql/json-queries) guides cover the highest-leverage SQL features.
+
+Version notes (as of June 2026): mysqlclient 2.2.x, PyMySQL 1.2.x, MySQL Connector/Python 9.x, aiomysql 0.3.x, asyncmy 0.2.x.
+
+Mako connects to MySQL with AI-powered autocomplete for writing queries. Try it free at mako.ai.

--- a/content/guides/postgresql/connect-from-go.mdx
+++ b/content/guides/postgresql/connect-from-go.mdx
@@ -1,0 +1,222 @@
+---
+title: "How to Connect to PostgreSQL from Go"
+description: "Connect to PostgreSQL from Go with pgx or lib/pq. Working code for connection pools, the database/sql vs native pgx interface decision, context timeouts, parameterized queries, and the TLS sslmode trap."
+database: "postgresql"
+category: "how-to"
+tags: ["postgresql", "go", "golang", "pgx", "lib-pq", "connection"]
+date: "2026-06-15"
+---
+
+Go has one clear recommendation for PostgreSQL today: pgx. The older `lib/pq` driver still works and still appears in countless tutorials, but its README now states it is in maintenance mode and points new projects to pgx. This guide shows working code for both, explains the `database/sql` vs native-pgx interface choice that trips up most newcomers, and covers the configuration that actually matters: pooling, context timeouts, and TLS.
+
+## The options
+
+| Driver | Import path | Interface | Pooling | Version (as of June 2026) |
+|---|---|---|---|---|
+| pgx (native) | `github.com/jackc/pgx/v5` | pgx-specific API | `pgxpool` | v5.10.0 |
+| pgx (stdlib) | `github.com/jackc/pgx/v5/stdlib` | `database/sql` | `database/sql` pool | v5.10.0 |
+| lib/pq | `github.com/lib/pq` | `database/sql` | `database/sql` pool | v1.10.9 (maintenance mode) |
+
+The decision tree:
+
+- **New project, want the best PostgreSQL support:** pgx with its native interface (`pgxpool`). You get PostgreSQL-specific types, the binary protocol, `LISTEN`/`NOTIFY`, `COPY`, and better performance.
+- **You need `database/sql`** (because an ORM, query builder, or migration tool requires the standard interface): use pgx through its `stdlib` adapter. You keep the standard API and still get a well-maintained driver.
+- **Existing codebase already on lib/pq:** it works and is stable, but no new features are coming. Migrating to pgx's `stdlib` adapter is usually a near drop-in change of the import and driver name.
+
+A key point that confuses people: pgx is *both* a standalone driver with its own API *and* a `database/sql` driver. You pick which face to use. lib/pq only offers the `database/sql` face.
+
+## pgx with the native interface (recommended)
+
+```bash
+go get github.com/jackc/pgx/v5
+go get github.com/jackc/pgx/v5/pgxpool
+```
+
+For anything serving concurrent requests, use `pgxpool`, not a single `pgx.Conn`. A single connection is not safe for concurrent use by multiple goroutines; the pool hands out connections per query and is concurrency-safe.
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func main() {
+	ctx := context.Background()
+
+	pool, err := pgxpool.New(ctx, os.Getenv("DATABASE_URL"))
+	if err != nil {
+		log.Fatalf("unable to create pool: %v", err)
+	}
+	defer pool.Close()
+
+	rows, err := pool.Query(ctx,
+		"SELECT id, name FROM customers WHERE region = $1",
+		"EMEA",
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id int
+		var name string
+		if err := rows.Scan(&id, &name); err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(id, name)
+	}
+	if err := rows.Err(); err != nil { // errors surface here, not in the loop
+		log.Fatal(err)
+	}
+}
+```
+
+Two things every Go database loop gets wrong at least once:
+
+- **Always check `rows.Err()` after the loop.** A failure mid-iteration ends the loop normally; the error only appears here. Skipping it silently truncates results.
+- **Always `defer rows.Close()`.** Leaked result sets hold a pooled connection until garbage collection, starving the pool.
+
+Placeholders are `$1`, `$2`, ... -- PostgreSQL's native numbered parameters. Never build SQL with `fmt.Sprintf`; pass values as arguments so the driver parameterizes them.
+
+For a single row, `QueryRow` plus `Scan` is cleaner:
+
+```go
+var name string
+err := pool.QueryRow(ctx,
+	"SELECT name FROM customers WHERE id = $1", 42,
+).Scan(&name)
+if err != nil {
+	if errors.Is(err, pgx.ErrNoRows) { // no row matched
+		// handle "not found"
+	}
+	log.Fatal(err)
+}
+```
+
+### Connection string vs struct config
+
+The `DATABASE_URL` form is the simplest:
+
+```
+postgres://app_user:secret@db.example.com:5432/sales?sslmode=verify-full
+```
+
+For programmatic control, parse it and adjust pool settings:
+
+```go
+cfg, err := pgxpool.ParseConfig(os.Getenv("DATABASE_URL"))
+if err != nil {
+	log.Fatal(err)
+}
+cfg.MaxConns = 10                       // default: greater of 4 or runtime.NumCPU()
+cfg.MinConns = 0
+cfg.MaxConnLifetime = time.Hour
+cfg.MaxConnIdleTime = 30 * time.Minute
+
+pool, err := pgxpool.NewWithConfig(ctx, cfg)
+```
+
+The pool default for `MaxConns` is the larger of 4 and the number of CPUs -- often fine for one process, but remember that each running instance of your service gets its own pool. Eight pods × 10 connections = 80 server connections, and PostgreSQL's default `max_connections` is 100. Size accordingly or put PgBouncer in front.
+
+### Context timeouts are not optional
+
+Every pgx call takes a `context.Context`. Use it to bound query time so a slow query doesn't pin a connection forever:
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+defer cancel()
+
+rows, err := pool.Query(ctx, "SELECT ...")
+```
+
+When the context expires, pgx cancels the in-flight query on the server side too, not just client-side. This is the single most useful habit for keeping a Go service responsive under load.
+
+## pgx through database/sql
+
+If a tool needs the standard interface, import the `stdlib` adapter as a side-effecting blank import:
+
+```go
+import (
+	"database/sql"
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+db, err := sql.Open("pgx", os.Getenv("DATABASE_URL"))
+if err != nil {
+	log.Fatal(err)
+}
+defer db.Close()
+
+db.SetMaxOpenConns(10)
+db.SetMaxIdleConns(5)
+db.SetConnMaxLifetime(time.Hour)
+```
+
+Note that `sql.Open` does *not* connect -- it only validates arguments and prepares the pool lazily. The first real connection happens on the first query. To verify connectivity at startup, call `db.PingContext(ctx)`. This catches a bad host or credentials immediately instead of on the first user request.
+
+## lib/pq (legacy, maintenance mode)
+
+```go
+import (
+	"database/sql"
+	_ "github.com/lib/pq"
+)
+
+db, err := sql.Open("postgres",
+	"host=db.example.com port=5432 user=app_user password=secret dbname=sales sslmode=verify-full")
+```
+
+It works the same way through `database/sql`, including the lazy-connect behavior. The reason not to start a new project here is simply that the project is in maintenance mode -- bug fixes only, no new features -- and the maintainers themselves recommend pgx. If you already depend on it, there's no fire to put out; plan the migration when convenient.
+
+## The TLS / sslmode trap
+
+The most common first error against a hosted PostgreSQL (RDS, Supabase, Neon, Cloud SQL, DigitalOcean) is a TLS one:
+
+```
+pq: SSL is not enabled on the server
+# or, the opposite problem:
+failed to connect: tls: failed to verify certificate: x509: certificate signed by unknown authority
+```
+
+`sslmode` controls this, and the values are not all equally safe:
+
+| sslmode | Encrypts | Verifies certificate | Verifies hostname |
+|---|---|---|---|
+| `disable` | No | No | No |
+| `require` | Yes | No | No |
+| `verify-ca` | Yes | Yes | No |
+| `verify-full` | Yes | Yes | Yes |
+
+`require` encrypts the connection but does not protect against a man-in-the-middle, because it doesn't check who it's talking to. For production, use `verify-full` and point the driver at the provider's CA bundle:
+
+```
+postgres://user:pass@host:5432/db?sslmode=verify-full&sslrootcert=/etc/ssl/rds-ca.pem
+```
+
+Every major provider documents where to download its CA certificate. Reaching for `sslmode=disable` to "make it work" is the wrong move on any network you don't fully control.
+
+## Common errors
+
+| Error | Likely cause |
+|---|---|
+| `dial tcp ... connection refused` | Wrong host/port, or PostgreSQL not listening on TCP (`listen_addresses`) |
+| `password authentication failed for user` | Wrong credentials, or `pg_hba.conf` auth method mismatch |
+| `pq: SSL is not enabled on the server` | `sslmode` requires TLS but the server isn't configured for it |
+| `x509: certificate signed by unknown authority` | `verify-ca`/`verify-full` without `sslrootcert` pointing at the provider CA |
+| `sorry, too many clients already` | Pool size × process count exceeds server `max_connections` |
+| `conn busy` (pgx native) | Sharing one `pgx.Conn` across goroutines -- use `pgxpool` instead |
+
+That last one is the classic native-pgx mistake: a single `pgx.Conn` is not concurrency-safe. If you see `conn busy`, you're sharing a connection across goroutines and should be using the pool.
+
+## Querying without writing connection code
+
+If your goal is to explore a PostgreSQL database rather than build a service, a GUI client skips all of the above. Mako connects to PostgreSQL with AI-assisted SQL -- see our [PostgreSQL GUI client guide](/guides/postgresql-gui-client) for how it compares to pgAdmin, DBeaver, and TablePlus. Connecting from another language? See [How to Connect to PostgreSQL from Python](/guides/postgresql/connect-from-python) and [from Node.js](/guides/postgresql/connect-from-node).
+
+Mako connects to PostgreSQL with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/postgresql/connect-from-node.mdx
+++ b/content/guides/postgresql/connect-from-node.mdx
@@ -1,0 +1,177 @@
+---
+title: "How to Connect to PostgreSQL from Node.js"
+description: "Connect to PostgreSQL from Node.js with node-postgres (pg) or Postgres.js. Working code for pools and queries, the SSL self-signed certificate trap, parameterized queries, and which client to pick."
+database: "postgresql"
+category: "how-to"
+tags: ["postgresql", "nodejs", "node-postgres", "pg", "postgres-js", "connection"]
+date: "2026-06-12"
+---
+
+Node has two serious PostgreSQL clients: node-postgres (`pg`), the long-standing default that nearly every ORM builds on, and Postgres.js (`postgres`), a newer client built around tagged template literals and automatic pipelining. Both are production-grade. This guide shows working code for each, the configuration that actually matters (pooling, SSL), and the errors you'll hit first.
+
+## The options
+
+| Client | Package | API style | Pooling | Version (as of June 2026) |
+|---|---|---|---|---|
+| node-postgres | `pg` | Callback/Promise, `$1` placeholders | Separate `Pool` class | 8.21.0 |
+| Postgres.js | `postgres` | Tagged template literals | Built-in, always on | 3.4.9 |
+| pg-promise | `pg-promise` | Promise layer over pg | Via pg | 12.6.2 |
+
+Rules of thumb:
+
+- **Default choice, or you're using an ORM/query builder** (Prisma, Drizzle, Knex, TypeORM, Sequelize -- all use or support `pg` underneath): node-postgres. Largest ecosystem, most documentation.
+- **Hand-written SQL and you want the most ergonomic API:** Postgres.js. Tagged templates make parameterization automatic, and it benchmarks faster than `pg` thanks to pipelining and prepared statements.
+- **pg-promise** is a mature Promise/task layer on top of `pg` -- worth knowing it exists, but with modern async/await on plain `pg`, fewer new projects need it.
+
+Neither client requires libpq or any native compilation; both are pure JavaScript. (`pg-native` exists for libpq bindings but the maintainers don't recommend it for most apps -- the performance difference is small and it complicates deployment.)
+
+## node-postgres (pg)
+
+```bash
+npm install pg
+```
+
+### Use a Pool, not a Client
+
+A `Client` is one connection. A `Pool` manages many and hands them out per query. For anything serving concurrent requests (i.e., any web app), use the pool:
+
+```js
+import pg from "pg";
+const { Pool } = pg;
+
+const pool = new Pool({
+  host: "db.example.com",
+  port: 5432,
+  database: "sales",
+  user: "app_user",
+  password: "secret",
+  max: 10,                      // default: 10 connections
+  idleTimeoutMillis: 10000,     // default: idle clients dropped after 10s
+});
+
+const { rows } = await pool.query(
+  "SELECT id, name FROM customers WHERE region = $1",
+  ["EMEA"]
+);
+console.log(rows);
+```
+
+Placeholders are `$1`, `$2`, ... -- never interpolate values into the SQL string. A connection string works too:
+
+```js
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+```
+
+### Transactions need a dedicated client
+
+`pool.query()` may run each statement on a *different* connection, which silently breaks transactions. Check out a client explicitly:
+
+```js
+const client = await pool.connect();
+try {
+  await client.query("BEGIN");
+  await client.query("UPDATE accounts SET balance = balance - $1 WHERE id = $2", [100, 1]);
+  await client.query("UPDATE accounts SET balance = balance + $1 WHERE id = $2", [100, 2]);
+  await client.query("COMMIT");
+} catch (e) {
+  await client.query("ROLLBACK");
+  throw e;
+} finally {
+  client.release();   // forget this and the pool leaks a connection
+}
+```
+
+The `finally { client.release() }` is the part people forget. Leak enough clients and the pool deadlocks waiting for a free connection.
+
+### The pool error handler
+
+Idle pooled connections can be terminated by the server (restarts, failovers, load balancer timeouts). Without an error listener, that crashes the whole Node process:
+
+```js
+pool.on("error", (err) => {
+  console.error("Unexpected error on idle client", err);
+});
+```
+
+Add this to every pool. It is the single most common cause of "my Node app crashes randomly at night."
+
+## Postgres.js
+
+```bash
+npm install postgres
+```
+
+```js
+import postgres from "postgres";
+
+const sql = postgres("postgres://app_user:secret@db.example.com:5432/sales");
+
+const customers = await sql`
+  SELECT id, name FROM customers WHERE region = ${"EMEA"}
+`;
+console.log(customers);
+```
+
+The `sql` tagged template is the whole API. Every `${value}` becomes a query parameter automatically -- this is *not* string interpolation, and it is immune to SQL injection by construction. Pooling is built in (`max: 10` by default) and there is no separate Pool class to manage.
+
+Transactions are a callback:
+
+```js
+await sql.begin(async (sql) => {
+  await sql`UPDATE accounts SET balance = balance - 100 WHERE id = 1`;
+  await sql`UPDATE accounts SET balance = balance + 100 WHERE id = 2`;
+});  // commits on success, rolls back on throw
+```
+
+One trap: because the API looks like template strings, people try `sql("SELECT ...")` with a plain string -- that's not how it works. Dynamic identifiers (table/column names) go through `sql(name)` helpers, and partial queries compose with nested `sql` fragments.
+
+## The SSL trap
+
+Hosted PostgreSQL (RDS, Supabase, Neon, DigitalOcean, Heroku) requires TLS, and the first attempt usually fails with one of:
+
+```
+Error: self signed certificate in certificate chain
+Error: The server does not support SSL connections
+```
+
+With `pg`, the commonly pasted fix is:
+
+```js
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: { rejectUnauthorized: false },
+});
+```
+
+Understand what this does: it encrypts the connection but skips certificate verification, so it does not protect against man-in-the-middle attacks. The correct production setup verifies the provider's CA:
+
+```js
+import fs from "node:fs";
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: { ca: fs.readFileSync("ca-certificate.crt").toString() },
+});
+```
+
+Every major provider documents where to download its CA bundle. With Postgres.js the equivalent options are `ssl: "require"` (no verification) and `ssl: { ca }`.
+
+If you're on a serverless platform connecting to a serverless Postgres provider, also look at the provider's own driver (e.g. `@neondatabase/serverless`, which speaks the pg API over WebSockets/HTTP) and use a pooled connection string -- classic TCP pools and short-lived functions don't mix well.
+
+## Common errors
+
+| Error | Likely cause |
+|---|---|
+| `ECONNREFUSED` | Wrong host/port, or PostgreSQL not listening on TCP (`listen_addresses`) |
+| `password authentication failed for user` | Wrong credentials, or wrong `pg_hba.conf` auth method |
+| `SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a string` | Password is `undefined` -- usually a missing env var, or a number in config instead of a string |
+| `self signed certificate in certificate chain` | TLS verification against a provider CA (see SSL section) |
+| `Connection terminated unexpectedly` | Server restarted or idle connection killed -- add the pool `error` handler |
+| `sorry, too many clients already` | Pool `max` × process count exceeds the server's `max_connections` -- lower `max` or add PgBouncer |
+
+That last one matters at scale: each Node process gets its *own* pool, so 8 cluster workers × `max: 10` = 80 server connections. Size accordingly or put PgBouncer in front.
+
+## Querying without writing connection code
+
+If you want to explore a PostgreSQL database rather than build an application, a GUI client skips all of this. Mako connects to PostgreSQL with AI-assisted SQL -- see our [PostgreSQL GUI client guide](/guides/postgresql-gui-client) for how it compares to pgAdmin, DBeaver, and TablePlus. Connecting from Python instead? See [How to Connect to PostgreSQL from Python](/guides/postgresql/connect-from-python).
+
+Mako connects to PostgreSQL with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/postgresql/connect-from-python.mdx
+++ b/content/guides/postgresql/connect-from-python.mdx
@@ -1,0 +1,236 @@
+---
+title: "How to Connect to PostgreSQL from Python"
+description: "Connect to PostgreSQL from Python with psycopg 3, psycopg2, asyncpg, or SQLAlchemy. Working code for connections, queries, pooling, and the gotchas that bite in production."
+database: "postgresql"
+category: "how-to"
+tags: ["postgresql", "python", "psycopg", "asyncpg", "sqlalchemy", "connection"]
+date: "2026-06-11"
+---
+
+Python has four serious options for talking to PostgreSQL: psycopg 3, psycopg2, asyncpg, and SQLAlchemy on top of one of those drivers. They differ in API style, async support, and performance characteristics. This guide shows working connection code for each, then covers pooling, SSL, and the errors you will actually hit.
+
+## Which driver should you use?
+
+| Driver | Style | Async | Notes |
+|---|---|---|---|
+| psycopg 3 | DB-API 2.0 | Yes (native) | Current default choice for new projects |
+| psycopg2 | DB-API 2.0 | No | Mature, enormous install base, maintenance mode |
+| asyncpg | Custom API | Only async | Fastest driver, asyncio-only, no sync mode |
+| SQLAlchemy | ORM / Core | Yes (with psycopg 3 or asyncpg) | Abstraction layer, not a driver itself |
+
+Short version: new projects should use **psycopg 3** (`pip install "psycopg[binary]"`). It is the actively developed successor to psycopg2, supports both sync and async from one codebase, and uses server-side parameter binding by default. Use **asyncpg** when you are all-in on asyncio and want maximum throughput. Use **psycopg2** when an existing dependency requires it. Use **SQLAlchemy** when you want an ORM or database-agnostic code, and pick the driver underneath it.
+
+## Connection details you need
+
+Whatever driver you choose, you need the same five things: host, port (5432 by default), database name, user, and password. Most drivers also accept a single connection string:
+
+```
+postgresql://user:password@localhost:5432/mydb
+```
+
+Keep credentials out of source code. The examples below read from environment variables, which is the minimum bar; a secrets manager is better in production.
+
+## psycopg 3 (recommended)
+
+Install:
+
+```bash
+pip install "psycopg[binary]"
+```
+
+The `[binary]` extra ships a precompiled C implementation. For production images where you want to compile against your own libpq, use `psycopg[c]`; the pure-Python fallback (plain `psycopg`) works everywhere but is slower.
+
+Connect and query:
+
+```python
+import os
+import psycopg
+
+conninfo = os.environ["DATABASE_URL"]  # postgresql://user:pass@host:5432/db
+
+with psycopg.connect(conninfo) as conn:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id, email FROM users WHERE created_at > %s",
+            ("2026-01-01",),
+        )
+        for row in cur.fetchall():
+            print(row)
+# leaving the with-block commits (or rolls back on exception) and closes
+```
+
+Two things to notice. First, parameters are passed as a separate tuple, never interpolated into the SQL string. This is what prevents SQL injection; psycopg 3 sends query and parameters separately to the server. Second, the `with` block on the connection commits on clean exit and rolls back on exceptions, which is a behavior change from psycopg2, where exiting the block only closed the cursor and you committed manually.
+
+Dict rows instead of tuples:
+
+```python
+from psycopg.rows import dict_row
+
+with psycopg.connect(conninfo, row_factory=dict_row) as conn:
+    row = conn.execute("SELECT id, email FROM users LIMIT 1").fetchone()
+    print(row["email"])
+```
+
+`conn.execute()` is a psycopg 3 shortcut that creates the cursor for you.
+
+Async, same API surface:
+
+```python
+import asyncio
+import psycopg
+
+async def main():
+    async with await psycopg.AsyncConnection.connect(conninfo) as conn:
+        async with conn.cursor() as cur:
+            await cur.execute("SELECT count(*) FROM users")
+            print(await cur.fetchone())
+
+asyncio.run(main())
+```
+
+## psycopg2
+
+Still everywhere, still works, but in maintenance mode: new features land in psycopg 3. If you are starting fresh, skip to psycopg 3. If you are maintaining existing code:
+
+```bash
+pip install psycopg2-binary
+```
+
+```python
+import os
+import psycopg2
+
+conn = psycopg2.connect(
+    host=os.environ["PGHOST"],
+    port=5432,
+    dbname=os.environ["PGDATABASE"],
+    user=os.environ["PGUSER"],
+    password=os.environ["PGPASSWORD"],
+)
+
+try:
+    with conn.cursor() as cur:
+        cur.execute("SELECT id, email FROM users WHERE id = %s", (42,))
+        print(cur.fetchone())
+    conn.commit()
+finally:
+    conn.close()
+```
+
+The classic psycopg2 trap: `with conn:` does NOT close the connection. It wraps a transaction (commit/rollback) but leaves the connection open. You still need `conn.close()` or a `try/finally`. psycopg 3 fixed this; the same syntax there closes the connection too.
+
+Note on packaging: `psycopg2-binary` is fine for development, but the maintainers recommend building `psycopg2` from source against your system libpq for production to avoid potential binary incompatibilities with other compiled packages.
+
+## asyncpg
+
+asyncpg skips the DB-API spec and talks PostgreSQL's binary protocol directly, which is why it benchmarks faster than the alternatives. The trade-offs: asyncio only, no sync mode, and a parameter style (`$1`, `$2`) that differs from every other Python driver.
+
+```bash
+pip install asyncpg
+```
+
+```python
+import asyncio
+import os
+import asyncpg
+
+async def main():
+    conn = await asyncpg.connect(os.environ["DATABASE_URL"])
+    try:
+        rows = await conn.fetch(
+            "SELECT id, email FROM users WHERE created_at > $1",
+            "2026-01-01",
+        )
+        for r in rows:
+            print(r["id"], r["email"])
+    finally:
+        await conn.close()
+
+asyncio.run(main())
+```
+
+Rows come back as `Record` objects supporting both index and key access. `fetch`, `fetchrow`, `fetchval`, and `execute` replace the cursor dance entirely.
+
+## SQLAlchemy
+
+SQLAlchemy is not a driver; it sits on top of one. As of SQLAlchemy 2.0, the PostgreSQL dialects you care about are `postgresql+psycopg` (psycopg 3, sync and async), `postgresql+psycopg2`, and `postgresql+asyncpg`.
+
+```bash
+pip install sqlalchemy "psycopg[binary]"
+```
+
+Core (raw-ish SQL with pooling handled for you):
+
+```python
+import os
+from sqlalchemy import create_engine, text
+
+engine = create_engine(
+    os.environ["DATABASE_URL"].replace("postgresql://", "postgresql+psycopg://"),
+    pool_size=5,
+    max_overflow=10,
+)
+
+with engine.connect() as conn:
+    result = conn.execute(text("SELECT id, email FROM users WHERE id = :id"), {"id": 42})
+    print(result.fetchone())
+```
+
+The URL scheme matters: plain `postgresql://` makes SQLAlchemy default to psycopg2. Be explicit with `postgresql+psycopg://` if you want psycopg 3, or `postgresql+asyncpg://` with `create_async_engine` for async.
+
+## Connection pooling
+
+Opening a PostgreSQL connection costs a TCP handshake, authentication, and a backend process fork on the server. Doing that per request will dominate your latency, and PostgreSQL's `max_connections` (often 100) runs out fast. Any long-running service needs a pool.
+
+With psycopg 3, the pool lives in a separate package:
+
+```bash
+pip install psycopg_pool
+```
+
+```python
+from psycopg_pool import ConnectionPool
+
+pool = ConnectionPool(conninfo, min_size=2, max_size=10, open=True)
+
+with pool.connection() as conn:
+    print(conn.execute("SELECT now()").fetchone())
+```
+
+asyncpg ships its own:
+
+```python
+pool = await asyncpg.create_pool(dsn, min_size=2, max_size=10)
+async with pool.acquire() as conn:
+    await conn.fetchval("SELECT now()")
+```
+
+SQLAlchemy engines pool by default (`pool_size=5` plus `max_overflow=10` unless configured otherwise).
+
+If you run serverless functions or hundreds of app instances, an in-process pool is not enough, because every instance holds its own connections. That is when a server-side pooler like PgBouncer (or your cloud provider's equivalent, e.g. Supabase's pooler or RDS Proxy) goes in front of the database. One caveat: PgBouncer in transaction mode breaks session-level features like prepared statements; asyncpg users typically need `statement_cache_size=0` in that setup.
+
+## SSL/TLS
+
+Hosted PostgreSQL (RDS, Cloud SQL, Supabase, Neon) generally requires TLS. Append `sslmode=require` to the connection string:
+
+```
+postgresql://user:pass@host:5432/db?sslmode=require
+```
+
+`require` encrypts but does not verify the server certificate; `verify-full` also checks the certificate and hostname against a CA bundle you provide via `sslrootcert`. For anything where the network path is not fully trusted, `verify-full` is the correct setting. asyncpg accepts the same URL parameter or an `ssl` argument with a Python `SSLContext`.
+
+## Common errors and what they mean
+
+- `connection refused`: PostgreSQL is not listening where you think. Check host/port, check `listen_addresses` in `postgresql.conf` (it defaults to `localhost`, so remote connections need it changed), and check firewalls.
+- `FATAL: no pg_hba.conf entry for host ...`: the server is reachable but its access rules reject your host/user/database/TLS combination. Fix the matching line in `pg_hba.conf` or your provider's network allow-list.
+- `FATAL: password authentication failed`: wrong credentials, or the user lacks a password while `pg_hba.conf` demands one. Watch out for special characters in passwords inside URLs; percent-encode them.
+- `FATAL: too many connections`: you exhausted `max_connections`. Almost always means missing or misconfigured pooling, not a need to raise the limit.
+- `SSL connection has been closed unexpectedly` mid-query: usually an idle connection killed by a load balancer or the server. Pools with `max_idle`/`pre_ping`-style checks recover from this; raw long-lived connections do not.
+
+## Verifying your connection and exploring the data
+
+Once connected, the next step is usually inspecting what is actually in the database: which tables exist, what the schema looks like, whether your inserts landed. You can do that with `psql` and `\dt`, or use a GUI client; we compared the options in [Best PostgreSQL GUI Clients](/guides/postgresql-gui-client). For getting data in, see [Import CSV to PostgreSQL](/guides/import-csv-to-postgresql) and [Import JSON to PostgreSQL](/guides/import-json-to-postgresql). Once you are writing real queries, the [PostgreSQL window functions](/guides/postgresql/window-functions) and [JSON queries](/guides/postgresql/json-queries) guides cover the parts of SQL that pay off most.
+
+Version notes (as of June 2026): psycopg 3.x is the actively developed line (3.3 current), psycopg2 is at 2.9.x in maintenance mode, asyncpg is on 0.x but stable and widely used in production, SQLAlchemy 2.0 is the current major version.
+
+Mako connects to PostgreSQL with AI-powered autocomplete for writing queries. Try it free at mako.ai.

--- a/content/guides/snowflake/connect-from-go.mdx
+++ b/content/guides/snowflake/connect-from-go.mdx
@@ -1,0 +1,268 @@
+---
+title: "How to Connect to Snowflake from Go"
+description: "Connect to Snowflake from Go with the official gosnowflake driver. Working code for the database/sql interface, the v2 import path, the org-account identifier trap, key-pair (JWT) authentication, and warehouse and pooling configuration."
+database: "snowflake"
+category: "how-to"
+tags: ["snowflake", "go", "golang", "gosnowflake", "connection"]
+date: "2026-06-16"
+---
+
+Snowflake has exactly one Go driver: the official `gosnowflake` from Snowflake itself. It implements the standard `database/sql` interface, so you connect, query, and scan rows the same way you would against any other SQL database in Go. The parts that trip people up are Snowflake-specific: the account identifier format, the move to v2 of the driver in March 2026, and the fact that Snowflake now blocks single-factor password auth for new accounts, which pushes you toward key-pair (JWT) authentication.
+
+## The options
+
+| Package | Import path | Interface | Version (as of June 2026) |
+|---|---|---|---|
+| gosnowflake v2 | `github.com/snowflakedb/gosnowflake/v2` | `database/sql` | v2.1.0 |
+| gosnowflake v1 | `github.com/snowflakedb/gosnowflake` | `database/sql` | v1.19.1 |
+
+There is no third-party alternative worth considering. Snowflake speaks its own protocol over HTTPS, not the Postgres or MySQL wire protocol, so the official driver is the only one that understands it.
+
+**v1 vs v2:** Version 2.0.0 was released on March 3rd, 2026 and is a major version with breaking changes. v1 (currently v1.19.1) is still maintained and receives fixes, so existing code does not have to migrate immediately. New projects should start on v2 because that is where active development lives. The two cannot be imported under the same name in the same module, so pick one. The v2 changes that matter to most code:
+
+- **Import path gains `/v2`** (`github.com/snowflakedb/gosnowflake/v2`).
+- **Arrow batches moved** to a separate sub-package, `gosnowflake/v2/arrowbatches`, so you only pull the Arrow dependency if you use it.
+- **Config fields renamed:** `KeepSessionAlive` is now `ServerSessionKeepAlive`, and `InsecureMode` is replaced by `DisableOCSPChecks`. `DisableTelemetry` was removed (use the `CLIENT_TELEMETRY_ENABLED` session parameter).
+- **The skip-registration env var typo was fixed:** `GOSNOWFLAKE_SKIP_REGISTERATION` became `GOSNOWFLAKE_SKIP_REGISTRATION`.
+
+The rest of this guide uses v2.
+
+## Install
+
+```sh
+go get github.com/snowflakedb/gosnowflake/v2
+```
+
+## The account identifier trap
+
+Snowflake's biggest connection gotcha is the account identifier. The current recommended format is `<organization>-<account_name>` with a hyphen, not a dot:
+
+```
+myorg-myaccount
+```
+
+You will also see the legacy format that includes a region and cloud, like `xy12345.eu-central-1.aws`. Both still work, but the org-account form is what Snowflake recommends today. The value goes after the `@` in the DSN. A frequent mistake is pasting the full account URL (`myorg-myaccount.snowflakecomputing.com`) as the identifier; use just the identifier part, or pass the full hostname explicitly via the `Config.Host` field.
+
+You can find your account identifier in the Snowsight UI under your account menu, or by running `SELECT CURRENT_ORGANIZATION_NAME(), CURRENT_ACCOUNT_NAME();`.
+
+## Connect with a DSN
+
+The driver registers itself under the name `snowflake`. The DSN format is:
+
+```
+username[:password]@<account_identifier>/dbname/schemaname?warehouse=wh&role=myrole
+```
+
+```go
+package main
+
+import (
+	"database/sql"
+	"log"
+
+	_ "github.com/snowflakedb/gosnowflake/v2"
+)
+
+func main() {
+	dsn := "jsmith:mypassword@myorg-myaccount/mydb/public?warehouse=compute_wh&role=analyst"
+
+	db, err := sql.Open("snowflake", dsn)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	if err := db.Ping(); err != nil {
+		log.Fatal(err)
+	}
+
+	var version string
+	if err := db.QueryRow("SELECT CURRENT_VERSION()").Scan(&version); err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("connected to Snowflake %s", version)
+}
+```
+
+Two things mirror every other `database/sql` driver and are worth repeating:
+
+- `sql.Open` does not open a connection. It validates the DSN and returns a handle. The first real network round-trip happens on `Ping` or the first query, which is why the `Ping` above is how you actually confirm the credentials and warehouse are valid.
+- The blank import (`_ "...gosnowflake/v2"`) is what registers the `snowflake` driver name. Forget it and `sql.Open` returns `sql: unknown driver "snowflake"`.
+
+### Building the DSN safely
+
+Passwords and identifiers with special characters need escaping. Rather than concatenating strings, build a `Config` and let the driver produce a correct DSN:
+
+```go
+import sf "github.com/snowflakedb/gosnowflake/v2"
+
+cfg := &sf.Config{
+	Account:   "myorg-myaccount",
+	User:      "jsmith",
+	Password:  "mypassword",
+	Database:  "mydb",
+	Schema:    "public",
+	Warehouse: "compute_wh",
+	Role:      "analyst",
+}
+
+dsn, err := sf.DSN(cfg)
+if err != nil {
+	log.Fatal(err)
+}
+db, err := sql.Open("snowflake", dsn)
+```
+
+## Key-pair (JWT) authentication
+
+As of late 2025, Snowflake blocks new connections that use a password as the only factor. For programmatic access (which is what a Go service is), the recommended path is key-pair authentication. You generate an RSA key pair, register the public key on the Snowflake user, and the driver signs a JWT with the private key.
+
+Generate the key pair:
+
+```sh
+# 2048-bit PKCS8 private key
+openssl genpkey -algorithm RSA \
+  -pkeyopt rsa_keygen_bits:2048 \
+  -pkeyopt rsa_keygen_pubexp:65537 | \
+  openssl pkcs8 -topk8 -outform der -nocrypt > rsa_key.p8
+
+# matching public key
+openssl pkey -pubout -inform der -outform der \
+  -in rsa_key.p8 -out rsa_key.pub
+```
+
+Register the public key on the user (base64 of the DER public key, no header lines):
+
+```sql
+ALTER USER jsmith SET RSA_PUBLIC_KEY='MIIBIjANBgkq...';
+```
+
+Then load and parse the private key in Go and pass it via `Config`:
+
+```go
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"database/sql"
+	"log"
+	"os"
+
+	sf "github.com/snowflakedb/gosnowflake/v2"
+)
+
+func connect() (*sql.DB, error) {
+	der, err := os.ReadFile("rsa_key.p8")
+	if err != nil {
+		return nil, err
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(der)
+	if err != nil {
+		return nil, err
+	}
+	privKey := parsed.(*rsa.PrivateKey)
+
+	cfg := &sf.Config{
+		Account:       "myorg-myaccount",
+		User:          "jsmith",
+		Authenticator: sf.AuthTypeJwt,
+		PrivateKey:    privKey,
+		Database:      "mydb",
+		Schema:        "public",
+		Warehouse:     "compute_wh",
+	}
+	dsn, err := sf.DSN(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return sql.Open("snowflake", dsn)
+}
+```
+
+Note that Go's standard library does not support passphrase-encrypted PKCS8 keys, so generate the key with `-nocrypt` as above, or decrypt it in your application before parsing. The JWT is recreated on each retry and is short-lived, so you do not manage token expiry yourself.
+
+For SSO in interactive contexts, set `Authenticator: sf.AuthTypeExternalBrowser`, but that is for human logins, not a server.
+
+## Parameter binding
+
+Snowflake uses positional `?` placeholders with `database/sql`:
+
+```go
+rows, err := db.Query(
+	"SELECT id, email FROM users WHERE country = ? AND created_at > ?",
+	"CH", "2026-01-01",
+)
+if err != nil {
+	log.Fatal(err)
+}
+defer rows.Close()
+
+for rows.Next() {
+	var id int64
+	var email string
+	if err := rows.Scan(&id, &email); err != nil {
+		log.Fatal(err)
+	}
+	// use id, email
+}
+if err := rows.Err(); err != nil { // catches errors that ended iteration
+	log.Fatal(err)
+}
+```
+
+Always `defer rows.Close()` and check `rows.Err()` after the loop. A `for rows.Next()` loop can stop because the data ended or because an error occurred mid-stream, and only `rows.Err()` distinguishes the two.
+
+## Identifiers come back uppercase
+
+Snowflake folds unquoted identifiers to uppercase. A column written as `select email` comes back as `EMAIL` in result metadata, and a table created as `users` is stored as `USERS`. This matters when you read column names dynamically or build a tool that lists tables. If you created an object with quotes to force mixed case (`CREATE TABLE "myTable"`), you must quote it everywhere, including inside the DSN, which means escaping the inner quotes. Avoid mixed-case identifiers unless you have a reason.
+
+## The "no active warehouse" error
+
+```
+000606: No active warehouse selected in the current session.
+```
+
+This is not a connection failure. It means you connected but never selected a warehouse, so Snowflake has nowhere to run the query. Set `warehouse=` in the DSN or `Warehouse` in the `Config`, and make sure the role you connect with has `USAGE` on that warehouse. Unlike a Postgres or MySQL server, Snowflake separates storage from compute, and a query needs a running warehouse to execute.
+
+## Connection pooling
+
+`*sql.DB` is a pool, and it is safe for concurrent use, so create one and share it across goroutines. Snowflake connections are HTTPS sessions rather than long-lived TCP connections to a single server, so the tuning advice differs slightly from a traditional database:
+
+```go
+db.SetMaxOpenConns(10)
+db.SetMaxIdleConns(5)
+db.SetConnMaxLifetime(0) // sessions are managed server-side; no hard need to recycle
+```
+
+Each open connection corresponds to a Snowflake session, and sessions have their own timeout managed by the server. If your workload is bursty, keep `MaxIdleConns` low so you are not holding idle sessions. For long-running services that keep connections parked, set `ServerSessionKeepAlive: true` in the `Config` to stop the server from expiring idle sessions out from under you.
+
+## Context and cancellation
+
+Use the context-aware methods so a cancelled request or a timeout actually cancels the running query in Snowflake, rather than leaking a warehouse-consuming query:
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+defer cancel()
+
+rows, err := db.QueryContext(ctx, "SELECT count(*) FROM large_table")
+```
+
+Because Snowflake bills for warehouse time, cancelling abandoned queries is not just hygiene, it has a direct cost impact.
+
+## Common errors
+
+| Error | Likely cause |
+|---|---|
+| `sql: unknown driver "snowflake"` | Missing the blank import of the driver package |
+| `260008: account is empty` | Account identifier missing or malformed in the DSN |
+| `390100: Incorrect username or password` | Wrong credentials, or password auth blocked (switch to key-pair) |
+| `JWT token is invalid` | Public key not registered, key mismatch, or clock skew on the client |
+| `000606: No active warehouse selected` | No warehouse set, or role lacks `USAGE` on it |
+| `390201: cannot perform operation; no database selected` | `database` not set and queries use unqualified names |
+
+## Where Mako fits
+
+Once you can connect, you still need to explore the data: list tables, check column types, write and iterate on queries. Mako connects to Snowflake (and PostgreSQL, MySQL, ClickHouse, BigQuery, and more) with AI-powered autocomplete, so you can prototype the exact queries your Go service will run before you hardcode them. It is a read and query tool, not a schema-management console, so you will still use Snowsight or SQL for `CREATE`/`ALTER` work.
+
+For loading data into Snowflake first, see our [import CSV to Snowflake](/guides/import-csv-to-snowflake) and [import JSON to Snowflake](/guides/import-json-to-snowflake) guides. To connect from other languages, see [connect to Snowflake from Python](/guides/snowflake/connect-from-python) and [connect to Snowflake from Node.js](/guides/snowflake/connect-from-node).
+
+Mako connects to Snowflake with AI-powered autocomplete. Try it free at mako.ai.

--- a/content/guides/snowflake/connect-from-node.mdx
+++ b/content/guides/snowflake/connect-from-node.mdx
@@ -1,0 +1,154 @@
+---
+title: "How to Connect to Snowflake from Node.js"
+description: "Connect to Snowflake from Node.js with the official snowflake-sdk driver. Working code for key-pair authentication, the account identifier format, parameter binds, promises vs callbacks, and warehouse setup."
+database: "snowflake"
+category: "how-to"
+tags: ["snowflake", "nodejs", "snowflake-sdk", "connection"]
+date: "2026-06-15"
+---
+
+Snowflake has one official Node.js driver, `snowflake-sdk`, written in pure JavaScript and maintained by Snowflake. There is no serious third-party alternative for server-side Node, so the package choice is settled. Current version is 2.4.3 (as of June 2026). What trips people up is not the driver but two things around it: the account identifier format and the shift away from password authentication.
+
+```bash
+npm install snowflake-sdk
+```
+
+## Authentication: key-pair, not password
+
+Starting in 2025, Snowflake blocks single-factor password authentication for programmatic connections by default. A username and password alone will be rejected on new accounts and on existing ones as the policy rolls out. The supported path for service connections is **key-pair authentication**, and it is worth setting up from the start rather than discovering it when a password stops working.
+
+Generate an encrypted private key and a public key:
+
+```bash
+openssl genrsa 2048 | openssl pkcs8 -topk8 -v2 aes-256-cbc -inform PEM -out rsa_key.p8
+openssl rsa -in rsa_key.p8 -pubout -out rsa_key.pub
+```
+
+Register the public key on the Snowflake user (strip the header, footer, and newlines from `rsa_key.pub` first):
+
+```sql
+ALTER USER my_service_user SET RSA_PUBLIC_KEY='MIIBIjANBgkq...';
+```
+
+Then connect with the private key. The driver reads the PEM file, so you point it at the path and supply the passphrase:
+
+```js
+import snowflake from "snowflake-sdk";
+import fs from "node:fs";
+
+const connection = snowflake.createConnection({
+  account: "myorg-myaccount",
+  username: "MY_SERVICE_USER",
+  authenticator: "SNOWFLAKE_JWT",
+  privateKeyPath: "/path/to/rsa_key.p8",
+  privateKeyPass: process.env.SNOWFLAKE_KEY_PASSPHRASE,
+  warehouse: "COMPUTE_WH",
+  database: "ANALYTICS",
+  schema: "PUBLIC",
+});
+```
+
+Keep the private key and its passphrase out of git. Password authentication still works in the examples below for local experimentation against older accounts (`password: "..."` instead of the key options), but do not build production connections on it.
+
+## The account identifier
+
+The `account` option is the most common reason a connection fails before it does anything useful. The recommended format is the **organization-account** form: `myorg-myaccount` (your organization name, a hyphen, your account name). You can find both in Snowsight under your account details.
+
+Older account-locator forms also exist (for example `xy12345.eu-central-1`), and which one you need depends on the account's age and region. If DNS resolution fails or you get `Could not connect to Snowflake backend`, the identifier format is the first thing to check, not the network.
+
+## Connecting and querying
+
+The driver's classic API is callback-based. `connect()` takes a callback, and `execute()` takes a `complete` callback that receives the rows:
+
+```js
+connection.connect((err, conn) => {
+  if (err) {
+    console.error("Unable to connect:", err.message);
+    return;
+  }
+
+  conn.execute({
+    sqlText: "SELECT C_NAME, C_ACCTBAL FROM CUSTOMER ORDER BY C_ACCTBAL DESC LIMIT 10",
+    complete: (err, stmt, rows) => {
+      if (err) {
+        console.error("Query failed:", err.message);
+        return;
+      }
+      for (const row of rows) {
+        console.log(row.C_NAME, row.C_ACCTBAL);
+      }
+    },
+  });
+});
+```
+
+Note that unquoted Snowflake identifiers are uppercase, so result columns come back uppercase (`row.C_NAME`) unless you quoted them in the table definition.
+
+### Promises with connectAsync
+
+For modern async/await code, use `connectAsync()`, which returns a promise. `execute()` itself stays callback-based, so a small wrapper makes it awaitable:
+
+```js
+await connection.connectAsync();
+
+function query(sqlText, binds = []) {
+  return new Promise((resolve, reject) => {
+    connection.execute({
+      sqlText,
+      binds,
+      complete: (err, stmt, rows) => (err ? reject(err) : resolve(rows)),
+    });
+  });
+}
+
+const rows = await query("SELECT CURRENT_VERSION() AS V");
+console.log(rows[0].V);
+```
+
+## Parameter binds
+
+Never concatenate user input into SQL. The driver uses positional `?` placeholders and a `binds` array:
+
+```js
+connection.execute({
+  sqlText: "SELECT * FROM ORDERS WHERE STATUS = ? AND O_TOTALPRICE > ?",
+  binds: ["OPEN", 50000],
+  complete: (err, stmt, rows) => {
+    /* ... */
+  },
+});
+```
+
+Bind values are limited to strings, numbers, booleans, and null. For arrays of rows in a bulk insert, pass an array of arrays and the driver expands them.
+
+## You need a warehouse
+
+Snowflake separates compute (warehouses) from storage. A query cannot run without an active warehouse, and "active" means either named in the connection options or set as the user's default. The error `No active warehouse selected in the current session` means neither was set. Add `warehouse: "COMPUTE_WH"` to the connection options or run `USE WAREHOUSE COMPUTE_WH` as your first statement.
+
+## Connection lifecycle
+
+Snowflake connections are session-oriented, not a high-frequency pool like Postgres. Reuse one connection across requests rather than opening one per query. The driver offers a built-in connection pool via `snowflake.createPool()` for concurrent workloads, but many applications run fine with a single long-lived connection plus `clientSessionKeepAlive: true` for jobs that hold a session open for hours. Close cleanly when shutting down:
+
+```js
+connection.destroy((err) => {
+  if (err) console.error("Error closing:", err.message);
+});
+```
+
+## Error reference
+
+| Error | Cause | Fix |
+|---|---|---|
+| `Could not connect to Snowflake backend` / DNS failure | Wrong `account` identifier format | Use the `myorg-myaccount` form from Snowsight |
+| `JWT token is invalid` | Public key on the user does not match the private key, or wrong user | Re-register the public key; confirm the username |
+| `Password was not specified` / auth rejected | Single-factor password blocked | Switch to key-pair authentication |
+| `No active warehouse selected in the current session` | No warehouse in options or user default | Set `warehouse` or run `USE WAREHOUSE` |
+| `Authentication token has expired` mid-job | Long-running session timed out | Set `clientSessionKeepAlive: true` |
+
+## Verifying your data
+
+After connecting, you usually want to browse what is in the warehouse. Snowsight works; a desktop client is faster for jumping between databases and schemas. We compared the options in [Best Snowflake GUI Clients](/guides/snowflake-gui-client). For loading data, see [Import CSV to Snowflake](/guides/import-csv-to-snowflake) and [Import JSON to Snowflake](/guides/import-json-to-snowflake).
+
+---
+
+Mako connects to Snowflake (and 8 other databases) with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/snowflake/connect-from-python.mdx
+++ b/content/guides/snowflake/connect-from-python.mdx
@@ -1,0 +1,169 @@
+---
+title: "How to Connect to Snowflake from Python"
+description: "Connect to Snowflake from Python with snowflake-connector-python. Working code for key-pair auth, SSO, query parameters, pandas integration, and the account identifier confusion that breaks most first attempts."
+database: "snowflake"
+category: "how-to"
+tags: ["snowflake", "python", "snowflake-connector-python", "key-pair-authentication", "connection"]
+date: "2026-06-12"
+---
+
+Connecting to Snowflake from Python has one official answer: **snowflake-connector-python**, maintained by Snowflake and implementing the Python DB API 2.0. There is no community-vs-official driver debate like with MySQL or ClickHouse. What there is instead: an authentication landscape that changed significantly in 2025, when Snowflake started blocking single-factor password logins. If you are setting up a new programmatic connection today, you should plan for key-pair authentication from the start, not passwords.
+
+## The packages
+
+| Package | What it is | Version (as of June 2026) |
+|---|---|---|
+| snowflake-connector-python | Official DB API 2.0 driver | 4.6.0, Python 3.10+ |
+| snowflake-snowpark-python | DataFrame API that pushes compute to Snowflake | 1.52.0 |
+| snowflake-sqlalchemy | SQLAlchemy dialect on top of the connector | 1.10.0 |
+
+This guide focuses on the connector. Snowpark is worth knowing about: it gives you a pandas-like DataFrame API where operations compile to SQL and run in the warehouse instead of pulling data to your machine. If your workload is "transform large tables", Snowpark is often the better tool. If it is "run queries, fetch results", the connector is simpler.
+
+Install:
+
+```bash
+pip install snowflake-connector-python
+```
+
+## The account identifier (where most first attempts fail)
+
+Snowflake has no host or port parameter. You pass an `account` identifier and the connector builds the URL `https://<account>.snowflakecomputing.com`. The preferred format is **organization-account**:
+
+```
+myorg-account123
+```
+
+You can find it in Snowsight under your account menu, or with `SELECT CURRENT_ORGANIZATION_NAME() || '-' || CURRENT_ACCOUNT_NAME();`. Two traps:
+
+- **The legacy locator format** (`xy12345.us-east-1`) still appears in old tutorials and still works, but Snowflake documents it as not recommended. Use the org-account form.
+- **Copying from the browser URL.** If your Snowsight URL is `https://app.snowflake.com/myorg/account123/...`, the account parameter is `myorg-account123` with a hyphen, not a slash, and without any `.snowflakecomputing.com` suffix. Passing the full URL fails with a DNS or 404-style error.
+
+## Authentication: passwords are no longer enough
+
+Since November 2025, Snowflake blocks single-factor password authentication. Human users with passwords must enroll in MFA; service users cannot use passwords at all. For scripts and applications, that leaves you with these options, in rough order of preference:
+
+1. **Key-pair authentication** -- the standard for service accounts and any unattended code
+2. **External browser SSO** (`authenticator="externalbrowser"`) -- for humans running ad-hoc scripts on machines with a browser
+3. **OAuth / programmatic access tokens** -- when you are integrating with an identity provider
+
+### Key-pair auth setup
+
+Generate an RSA key pair (Snowflake requires PKCS#8 format for the private key):
+
+```bash
+# Encrypted private key (you'll be prompted for a passphrase)
+openssl genrsa 2048 | openssl pkcs8 -topk8 -v2 aes256 -inform PEM -out rsa_key.p8
+
+# Public key to register in Snowflake
+openssl rsa -in rsa_key.p8 -pubout -out rsa_key.pub
+```
+
+Register the public key on your Snowflake user (strip the PEM header/footer and line breaks, or paste the whole block in Snowsight):
+
+```sql
+ALTER USER etl_service SET RSA_PUBLIC_KEY='MIIBIjANBgkq...';
+```
+
+Then connect:
+
+```python
+import snowflake.connector
+
+conn = snowflake.connector.connect(
+    account="myorg-account123",
+    user="ETL_SERVICE",
+    private_key_file="/path/to/rsa_key.p8",
+    private_key_file_pwd="key-passphrase",
+    warehouse="COMPUTE_WH",
+    database="ANALYTICS",
+    schema="PUBLIC",
+    role="ETL_ROLE",
+)
+
+cur = conn.cursor()
+cur.execute("SELECT CURRENT_VERSION()")
+print(cur.fetchone())
+conn.close()
+```
+
+The `private_key_file` parameter reads and decrypts the key for you (the older pattern of loading the key with `cryptography` and passing DER bytes to `private_key` still works, but is no longer necessary). For humans, swap the key parameters for `authenticator="externalbrowser"` and the connector opens your identity provider's login page.
+
+### connections.toml
+
+The connector reads named connections from `~/.snowflake/connections.toml`, which keeps credentials out of code:
+
+```toml
+[etl]
+account = "myorg-account123"
+user = "ETL_SERVICE"
+private_key_file = "/path/to/rsa_key.p8"
+warehouse = "COMPUTE_WH"
+database = "ANALYTICS"
+```
+
+```python
+conn = snowflake.connector.connect(connection_name="etl")
+```
+
+## Context: warehouse, database, schema, role
+
+A Snowflake session has four context settings, and queries fail in confusing ways when they are missing. The big one is the warehouse: if no warehouse is set (none passed, no user default), any query that needs compute fails with `No active warehouse selected in the current session`. Set `warehouse=` in the connection or run `cur.execute("USE WAREHOUSE COMPUTE_WH")`.
+
+Remember that a running warehouse bills per second with a 60-second minimum, and auto-suspends after an idle period (default 10 minutes on new warehouses). A connection left open does not keep the warehouse alive by itself; the first query after suspension auto-resumes it with a second or two of latency. That is normal, not a bug.
+
+## Query parameters
+
+The connector defaults to `pyformat` style (`%(name)s`), and you can switch to `qmark` (`?`) globally. Never use f-strings to build SQL:
+
+```python
+# pyformat (default)
+cur.execute(
+    "SELECT * FROM orders WHERE status = %(status)s AND amount > %(min)s",
+    {"status": "shipped", "min": 100},
+)
+
+# qmark -- set once before connecting
+snowflake.connector.paramstyle = "qmark"
+cur.execute("SELECT * FROM orders WHERE status = ? AND amount > ?", ("shipped", 100))
+```
+
+Snowflake's own docs recommend qmark for server-side binding, which matters for `executemany` batch inserts: with qmark the connector sends one batched statement instead of interpolating values client-side.
+
+## pandas integration
+
+Install the extra (it pulls in pyarrow):
+
+```bash
+pip install "snowflake-connector-python[pandas]"
+```
+
+Reading is built into the cursor, and writing has a dedicated helper:
+
+```python
+# Read
+cur.execute("SELECT * FROM orders WHERE order_date >= '2026-01-01'")
+df = cur.fetch_pandas_all()          # one DataFrame
+# or cur.fetch_pandas_batches()     # iterator of DataFrames for large results
+
+# Write
+from snowflake.connector.pandas_tools import write_pandas
+write_pandas(conn, df, table_name="ORDERS_STAGED", auto_create_table=True)
+```
+
+`write_pandas` stages the DataFrame as Parquet files and runs `COPY INTO` under the hood, which is dramatically faster than `executemany` INSERTs for anything beyond a few thousand rows. One gotcha: unquoted Snowflake identifiers are uppercase, and `write_pandas` quotes column names from the DataFrame as-is by default. Lowercase DataFrame columns produce case-sensitive quoted columns unless you uppercase them first or pass `quote_identifiers=False`.
+
+## Common errors
+
+| Error | Cause |
+|---|---|
+| `250001: Could not connect to Snowflake backend` / DNS failure | Wrong account identifier format |
+| `No active warehouse selected` | No warehouse in connection params or user defaults |
+| `390144: JWT token is invalid` | Public key on the user does not match the private key, or wrong user |
+| `Password was not specified` with a service user | Single-factor password auth is blocked; switch to key-pair |
+| `Authentication token has expired` mid-job | Long-running session; set `client_session_keep_alive=True` for jobs that hold connections over 4 hours |
+
+## Verifying your data
+
+After connecting, you usually want to browse what is in the warehouse. Snowsight works; a desktop client is faster for jumping between databases. We compared the options in [Best Snowflake GUI Clients](/guides/snowflake-gui-client). For loading data, see [Import CSV to Snowflake](/guides/import-csv-to-snowflake) and [Import JSON to Snowflake](/guides/import-json-to-snowflake).
+
+Mako connects to Snowflake with AI-powered autocomplete. Try it free at mako.ai.

--- a/content/guides/sqlite/connect-from-go.mdx
+++ b/content/guides/sqlite/connect-from-go.mdx
@@ -1,0 +1,124 @@
+---
+title: "How to Connect to SQLite from Go"
+description: "Connect to SQLite from Go with mattn/go-sqlite3, modernc.org/sqlite, or ncruces/go-sqlite3. Working code, the cgo vs pure-Go cross-compilation decision, WAL mode, busy_timeout for 'database is locked', and pool settings for an embedded database."
+database: "sqlite"
+category: "how-to"
+tags: ["sqlite", "go", "golang", "mattn", "modernc", "cgo", "connection"]
+date: "2026-06-16"
+---
+
+Connecting to SQLite from Go forces a decision the moment you pick a driver: do you accept a C dependency or not? SQLite is a C library, and the long-standing default driver, `mattn/go-sqlite3`, binds to it through cgo. That means a C compiler at build time and a harder cross-compile story. The pure-Go alternatives transpile or reimplement SQLite so your binary stays cgo-free. This guide shows working code for the main options, explains the tradeoff that actually matters, and covers the SQLite-specific configuration most tutorials skip: WAL mode, `busy_timeout`, and why an embedded database barely needs a pool.
+
+## The options
+
+| Driver | Import path | cgo | Driver name | Version (as of June 2026) |
+|---|---|---|---|---|
+| mattn/go-sqlite3 | `github.com/mattn/go-sqlite3` | yes | `sqlite3` | v1.14.45 |
+| modernc.org/sqlite | `modernc.org/sqlite` | no | `sqlite` | v1.52.0 |
+| ncruces/go-sqlite3 | `github.com/ncruces/go-sqlite3/driver` | no | `sqlite3` | v0.35.0 |
+
+The decision tree:
+
+- **You're fine with cgo and want the de-facto standard:** `mattn/go-sqlite3`. It is a thin binding over the real SQLite C library, so behavior matches upstream SQLite exactly, and it has the largest install base and tutorial coverage. The cost is a C toolchain at build time and friction when cross-compiling.
+- **You want a pure-Go binary (easy cross-compilation, static builds, no C compiler):** `modernc.org/sqlite`. It is SQLite's C source transpiled to Go, so there is no cgo. This is the common choice for projects that cross-compile or want a single statically linked binary. It tends to be somewhat slower than the cgo driver on write-heavy benchmarks, but for most applications the difference is not the bottleneck.
+- **You want pure Go via a WASM-embedded SQLite:** `ncruces/go-sqlite3`. It runs an actual SQLite WASM build inside a Go runtime. Also cgo-free, with good standards conformance, and it exposes some lower-level SQLite features through its own API in addition to a `database/sql` driver.
+
+All three implement Go's standard `database/sql` interface, so your query code is nearly identical across them. The import you choose and the driver name string are the only things that change.
+
+## The cgo decision in one paragraph
+
+If you have ever run `CGO_ENABLED=0 go build` and watched a project that uses `mattn/go-sqlite3` fail to link, this is the whole story. cgo ties your build to a C compiler for the target platform. Building a Linux binary on a Mac, or a small static binary for a scratch Docker image, becomes a cross-compilation exercise. Pure-Go drivers (`modernc.org/sqlite`, `ncruces/go-sqlite3`) sidestep all of it: `CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build` just works. That single property is why a lot of teams moved off the cgo driver despite its longer track record.
+
+## Connecting with database/sql
+
+Because SQLite is a file, there is no host, port, username, or password. The data source name is a path (or `:memory:`). Here is the standard pattern, shown with the pure-Go `modernc.org/sqlite` driver:
+
+```go
+package main
+
+import (
+	"context"
+	"database/sql"
+	"log"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func main() {
+	// driver name "sqlite" for modernc; the DSN is a file path.
+	db, err := sql.Open("sqlite", "file:app.db?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	// sql.Open does not connect or even open the file. Ping forces it.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
+		log.Fatal(err)
+	}
+
+	var n int
+	if err := db.QueryRowContext(ctx,
+		"SELECT count(*) FROM sqlite_master WHERE type = ?", "table",
+	).Scan(&n); err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("tables: %d", n)
+}
+```
+
+To switch to `mattn/go-sqlite3`, change the import to `_ "github.com/mattn/go-sqlite3"` and the driver name to `"sqlite3"`. The PRAGMA syntax in the DSN differs between drivers (see below), but the `database/sql` calls do not change at all.
+
+### sql.Open does not open the file
+
+This is the same trap as every other Go SQL driver: `sql.Open` only validates arguments and prepares a handle. It does not touch the disk. A typo in the path, a permissions problem, or a missing directory surfaces only on the first real operation. Call `db.PingContext` at startup so failures appear where you expect them, not deep inside a request handler later.
+
+### The accidental-creation trap
+
+By default SQLite creates the database file if it does not exist. That is convenient until a typo in the path silently spawns a fresh empty database and your app reports zero rows instead of an error. If the file must already exist, open it read-write without create using a URI flag. With `mattn/go-sqlite3` the file is created on open by default; to forbid creation, open with `mode=rw` in the DSN (`file:app.db?mode=rw`), which returns an error rather than creating a new file.
+
+## "database is locked" and WAL mode
+
+The error new SQLite users hit most is `database is locked` (`SQLITE_BUSY`). SQLite allows one writer at a time. If a second connection tries to write while the first holds the lock, it fails immediately unless you tell it to wait.
+
+Two settings fix the common cases:
+
+- **`busy_timeout`** makes a blocked connection retry for the given number of milliseconds before giving up, instead of erroring instantly. Set it to a few seconds.
+- **WAL (write-ahead logging) journal mode** lets readers and a writer proceed concurrently. In the default rollback-journal mode, a writer blocks readers. WAL is almost always the right choice for an application that does concurrent reads and writes.
+
+Both are set as PRAGMAs. With `modernc.org/sqlite` you pass them in the DSN as `_pragma=busy_timeout(5000)` and `_pragma=journal_mode(WAL)`, as shown above. With `mattn/go-sqlite3` the DSN parameters are named differently, for example `file:app.db?_busy_timeout=5000&_journal_mode=WAL`. Always confirm the parameter names against the driver you actually imported, because they are not standardized across drivers.
+
+## Pooling: an embedded database is not a server
+
+`database/sql` manages a connection pool, and that abstraction was designed for client/server databases. SQLite is a local file, so the usual reasons to grow a pool do not apply, and a large pool of writers actively makes lock contention worse.
+
+A robust pattern for a write-capable SQLite handle:
+
+```go
+db.SetMaxOpenConns(1) // serialize writers; avoids most SQLITE_BUSY
+db.SetMaxIdleConns(1)
+db.SetConnMaxLifetime(0) // a local file connection does not go stale
+```
+
+Limiting to a single open connection serializes all access through one connection and eliminates most lock contention at the cost of write concurrency, which SQLite does not really offer anyway. A common refinement is to keep one write connection (`MaxOpenConns(1)`) and a separate read-only connection (or pool) opened with `mode=ro`, since WAL allows concurrent readers. Setting `ConnMaxLifetime` to zero is correct here: unlike a network connection to a remote server, a handle to a local file does not time out or get killed by an idle-connection reaper.
+
+## Common errors
+
+| Error | Likely cause |
+|---|---|
+| `unable to open database file` | Bad path, missing parent directory, or no write permission |
+| `database is locked` (`SQLITE_BUSY`) | Concurrent writers without `busy_timeout`; set it and enable WAL |
+| `no such table` | Opened a freshly auto-created empty file (wrong path); use `mode=rw` to forbid creation |
+| `binary was built with CGO_ENABLED=0` build failure | Using `mattn/go-sqlite3` without a C toolchain; switch to a pure-Go driver or enable cgo |
+| `cannot find -lsqlite3` / C compiler errors | cgo driver on a machine without a C compiler installed |
+
+The cgo-related failures are the giveaway that you picked the C-binding driver in an environment that cannot compile C. Either install a C toolchain for the target, or move to `modernc.org/sqlite` and keep `CGO_ENABLED=0`.
+
+## Querying without writing connection code
+
+If your goal is to explore a SQLite database rather than embed one in a service, a GUI client skips the driver question entirely. Mako opens SQLite files with AI-assisted SQL -- see our [SQLite GUI client guide](/guides/sqlite-gui-client) for how it compares to the alternatives. Connecting from another language? See [How to Connect to SQLite from Python](/guides/sqlite/connect-from-python) and [from Node.js](/guides/sqlite/connect-from-node).
+
+Mako connects to SQLite with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/sqlite/connect-from-node.mdx
+++ b/content/guides/sqlite/connect-from-node.mdx
@@ -1,0 +1,139 @@
+---
+title: "How to Connect to SQLite from Node.js"
+description: "Use SQLite from Node.js with the built-in node:sqlite module or better-sqlite3. Working code for both, why the classic sqlite3 package is deprecated, and when synchronous database access is actually the right call."
+database: "sqlite"
+category: "how-to"
+tags: ["sqlite", "nodejs", "node-sqlite", "better-sqlite3", "connection"]
+date: "2026-06-12"
+---
+
+SQLite in Node.js went through a changing of the guard. The classic `sqlite3` package -- the async, callback-based driver that dominated for a decade -- was marked deprecated and unmaintained by its stewards at Ghost. Meanwhile Node.js shipped a built-in `node:sqlite` module (v22.5.0, available without a flag since v22.13.0), and `better-sqlite3` remains the fastest and most complete third-party option. This guide shows working code for the two you should actually consider and explains how to pick.
+
+## The options
+
+| Driver | Package | API style | Status (as of June 2026) |
+|---|---|---|---|
+| Built-in module | `node:sqlite` (no install) | Synchronous | Release candidate on Node 24+; works without flags on 22.13+ |
+| better-sqlite3 | `better-sqlite3` | Synchronous | Actively maintained, v12.10.0 |
+| node-sqlite3 | `sqlite3` | Async callbacks | Deprecated, repo unmaintained (v6.0.1 final) |
+
+Rules of thumb:
+
+- **No dependencies, scripts, CLIs, tests:** `node:sqlite`. Zero install, no native compilation, ships with the runtime.
+- **Production apps, or you need extensions, user-defined aggregates beyond the basics, backup APIs, or the larger ecosystem:** `better-sqlite3`. More complete API, excellent documentation, slightly faster in most benchmarks.
+- **`sqlite3`:** only in legacy codebases. Don't start anything new on it.
+
+Both recommended options are *synchronous*. That sounds wrong for Node until you remember what SQLite is: an in-process library reading a local file. There's no network round-trip to overlap with other work. A typical indexed query completes in microseconds -- less than the overhead of scheduling a Promise. The async API of the old `sqlite3` package never bought concurrency (SQLite serializes writes anyway); it just bought callback ceremony. For long-running analytical queries that genuinely block the event loop, run them in a worker thread.
+
+## node:sqlite (built-in)
+
+Nothing to install:
+
+```js
+import { DatabaseSync } from "node:sqlite";
+
+const db = new DatabaseSync("app.db");
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY,
+    email TEXT UNIQUE NOT NULL
+  ) STRICT
+`);
+
+const insert = db.prepare("INSERT INTO users (email) VALUES (?)");
+const info = insert.run("ada@example.com");
+console.log(info);  // { lastInsertRowid: 1, changes: 1 }
+
+const query = db.prepare("SELECT * FROM users WHERE email = ?");
+console.log(query.get("ada@example.com"));  // { id: 1, email: 'ada@example.com' }
+console.log(query.all());                   // array of all matching rows
+
+db.close();
+```
+
+Named parameters use `$name`, `:name`, or `@name` prefixes and bind from an object:
+
+```js
+const stmt = db.prepare("INSERT INTO users (email) VALUES ($email)");
+stmt.run({ email: "grace@example.com" });
+```
+
+In-memory databases work as expected: `new DatabaseSync(":memory:")`.
+
+One status caveat, stated plainly: `node:sqlite` is not yet marked fully stable. It runs without flags since 22.13.0 and prints an experimental warning on Node 22; on Node 24+ it's classified as a release candidate (Stability 1.2), meaning the API is settled barring significant issues but hasn't received the final stamp. For scripts and internal tools that's a non-issue. For a long-lived production service, it's a small but real consideration in favor of better-sqlite3.
+
+## better-sqlite3
+
+```bash
+npm install better-sqlite3
+```
+
+It's a native addon; prebuilt binaries cover common platforms, so installs rarely compile from source.
+
+```js
+import Database from "better-sqlite3";
+
+const db = new Database("app.db");
+db.pragma("journal_mode = WAL");   // do this once -- see below
+
+const insert = db.prepare("INSERT INTO users (email) VALUES (?)");
+const info = insert.run("ada@example.com");
+console.log(info);  // { changes: 1, lastInsertRowid: 1 }
+
+const user = db.prepare("SELECT * FROM users WHERE email = ?").get("ada@example.com");
+const all  = db.prepare("SELECT * FROM users").all();
+
+db.close();
+```
+
+The API mirrors `node:sqlite` closely (prepare/run/get/all), which is no accident -- the built-in module took heavy inspiration from it. better-sqlite3 adds, among other things:
+
+- **Transactions as functions.** `db.transaction(fn)` wraps `fn` in BEGIN/COMMIT with automatic rollback on throw, and handles nesting via savepoints:
+
+```js
+const insertMany = db.transaction((users) => {
+  for (const u of users) insert.run(u.email);
+});
+insertMany([{ email: "a@x.com" }, { email: "b@x.com" }]);  // all-or-nothing
+```
+
+- **Iteration without buffering.** `stmt.iterate()` yields rows one at a time instead of materializing the full result array.
+- **User-defined functions and aggregates** in JavaScript, callable from SQL (`db.function()`, `db.aggregate()`), plus extension loading and an online backup API.
+
+## Configuration that matters
+
+**Enable WAL mode.** SQLite's default rollback journal blocks readers during writes. Write-Ahead Logging lets readers and one writer proceed concurrently, which is what you want in practically every application:
+
+```js
+db.pragma("journal_mode = WAL");           // better-sqlite3
+db.exec("PRAGMA journal_mode = WAL");      // node:sqlite
+```
+
+It's persistent per database file, so once set it sticks.
+
+**"Database is locked" (SQLITE_BUSY).** Two processes writing to the same file will eventually collide. Set a busy timeout so the second writer waits instead of failing instantly: `db.pragma("busy_timeout = 5000")`. If you're hitting this *within* one process, you're opening multiple connections where one would do -- with synchronous drivers, a single shared connection is the normal pattern.
+
+**Accidental file creation.** Opening a path that doesn't exist silently creates an empty database -- so a typo'd path produces "no such table" errors rather than "file not found". better-sqlite3 supports `new Database(path, { fileMustExist: true })`; with `node:sqlite`, check the path yourself first.
+
+**One connection is fine.** There's no pool to configure. SQLite serializes writes at the file level regardless of how many connections you open; for a typical Node service, one long-lived connection (plus WAL) is the standard setup.
+
+## What about the old sqlite3 package?
+
+The `sqlite3` package (TryGhost/node-sqlite3) is deprecated: the README is marked `[DEPRECATED]` and the maintainers state the repository is unmaintained, with issues and pull requests no longer reviewed. The final release is 6.0.1. Existing code keeps working, but anything new should use `node:sqlite` or better-sqlite3 -- and libraries that depend on `sqlite3` (some Sequelize and Knex setups) are migrating off it.
+
+If you're porting: the old `db.run("INSERT ...", cb)` callback style maps to `stmt.run()` return values, `db.get`/`db.all` map directly to `stmt.get()`/`stmt.all()`, and you can delete every callback and most error-handling pyramids in the process.
+
+## ORMs and query builders
+
+Drizzle and Knex support better-sqlite3 natively, and Drizzle also supports `node:sqlite`. Prisma ships its own SQLite engine. If you're on an ORM, the driver choice is mostly made for you -- the gotchas above (WAL, busy timeout, file creation) still apply.
+
+## Working with the data
+
+For browsing tables, checking what a migration actually did, or prototyping queries before they go into code, a GUI is faster than the REPL. [Mako](/guides/sqlite-gui-client) connects to SQLite files with AI-assisted autocomplete; that guide compares DB Browser for SQLite, DBeaver, and the other options fairly.
+
+Once connected, our SQLite guides cover [transactions and locking](/guides/sqlite/transactions), [upserts](/guides/sqlite/upsert), and [full-text search](/guides/sqlite/full-text-search). For loading data, see [importing CSV to SQLite](/guides/import-csv-to-sqlite).
+
+---
+
+Mako connects to SQLite (and 8 other databases) with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/sqlite/connect-from-python.mdx
+++ b/content/guides/sqlite/connect-from-python.mdx
@@ -1,0 +1,171 @@
+---
+title: "How to Connect to SQLite from Python"
+description: "Connect to SQLite from Python with the built-in sqlite3 module or aiosqlite for asyncio. Working code for connections, parameters, WAL mode, and the concurrency gotchas that bite in production."
+database: "sqlite"
+category: "how-to"
+tags: ["sqlite", "python", "sqlite3", "aiosqlite", "connection"]
+date: "2026-06-11"
+---
+
+SQLite is the one database Python can talk to with zero installation: the `sqlite3` module ships in the standard library. There is no server, no port, no credentials. A database is a file, and connecting means opening that file. That simplicity hides a few sharp edges around transactions, threading, and concurrent writes, which is what most of this guide is about.
+
+## Which option should you use?
+
+| Option | Install | Async | Notes |
+|---|---|---|---|
+| sqlite3 (stdlib) | None | No | The default choice. DB-API 2.0, ships with Python |
+| aiosqlite | `pip install aiosqlite` | Yes | Thin asyncio wrapper around sqlite3, runs queries in a thread |
+| APSW | `pip install apsw` | No | Thinner wrapper, exposes more of SQLite's C API, no DB-API transaction magic |
+| SQLAlchemy | `pip install sqlalchemy` | Yes (via aiosqlite) | ORM/abstraction layer on top of sqlite3 |
+
+Short version: use **sqlite3** unless you have a reason not to. Use **aiosqlite** (0.22.1 as of June 2026) in asyncio applications. Use **APSW** when you need precise control over SQLite behavior and want to opt out of the stdlib's transaction handling. SQLAlchemy makes sense when the same code must also run against PostgreSQL or MySQL.
+
+## Connecting with sqlite3
+
+```python
+import sqlite3
+
+conn = sqlite3.connect("app.db")
+cursor = conn.execute("SELECT sqlite_version()")
+print(cursor.fetchone()[0])
+conn.close()
+```
+
+`connect()` creates the file if it does not exist. That is convenient and also a classic bug: a typo in the path silently gives you a new empty database instead of an error. If the file should already exist, open it in read-only mode with a URI (below) or check `os.path.exists` first.
+
+An in-memory database lives only as long as the connection:
+
+```python
+conn = sqlite3.connect(":memory:")
+```
+
+### Read-only and other URI options
+
+Pass `uri=True` to unlock the `file:` URI syntax:
+
+```python
+conn = sqlite3.connect("file:app.db?mode=ro", uri=True)
+```
+
+`mode=ro` fails with an error if the file is missing and rejects writes -- the safe way to open a database you only intend to query. `mode=rwc` (the default) creates the file if needed; `mode=memory` gives a shared in-memory database when combined with `cache=shared`.
+
+## Parameters: always `?`, never f-strings
+
+```python
+# Right
+conn.execute("SELECT * FROM users WHERE email = ?", (email,))
+
+# Also right: named parameters
+conn.execute("SELECT * FROM users WHERE email = :email", {"email": email})
+
+# Wrong: SQL injection
+conn.execute(f"SELECT * FROM users WHERE email = '{email}'")
+```
+
+Note the one-element tuple `(email,)` -- passing a bare string is a common first-day error because `sqlite3` will iterate it character by character and complain about the wrong number of bindings.
+
+## Rows as dictionaries
+
+By default rows come back as plain tuples. Set a row factory to access columns by name:
+
+```python
+conn.row_factory = sqlite3.Row
+row = conn.execute("SELECT id, email FROM users LIMIT 1").fetchone()
+print(row["email"])
+```
+
+`sqlite3.Row` is implemented in C and costs almost nothing. `dict(row)` converts a `Row` when you need a real dictionary, for example to serialize as JSON.
+
+## Transactions: the `with` trap
+
+This is the most misunderstood part of the module. Using a connection as a context manager commits or rolls back a transaction -- it does **not** close the connection:
+
+```python
+with sqlite3.connect("app.db") as conn:
+    conn.execute("INSERT INTO logs (msg) VALUES (?)", ("hello",))
+# transaction committed here, but conn is STILL OPEN
+
+conn.close()  # you still have to do this
+```
+
+If you want both behaviors, combine `contextlib.closing` with the transaction context manager, or just call `close()` explicitly.
+
+The second surprise is implicit transactions. In the default (legacy) mode, `sqlite3` opens a transaction before your first `INSERT`/`UPDATE`/`DELETE` and holds it until you call `commit()`. Forgetting `commit()` means your writes vanish when the process exits, and the open transaction blocks other writers in the meantime.
+
+Python 3.12 added an explicit `autocommit` parameter that makes the behavior PEP 249-compliant:
+
+```python
+conn = sqlite3.connect("app.db", autocommit=False)  # explicit transactions, recommended
+```
+
+With `autocommit=False` a transaction is always open and `commit()`/`rollback()` behave the way users of other databases expect. With `autocommit=True` every statement commits immediately. If you support Python older than 3.12 you are stuck with the legacy `isolation_level` behavior; just remember to commit.
+
+## Concurrency: WAL mode and busy timeouts
+
+SQLite allows many concurrent readers but only one writer. Out of the box (rollback journal mode), a writer also blocks readers. If your application has any concurrency at all -- a web app, background jobs -- enable write-ahead logging once per database:
+
+```python
+conn.execute("PRAGMA journal_mode=WAL")
+```
+
+WAL is persistent: set it once and the database file stays in WAL mode. Readers no longer block the writer and vice versa. There is still only one writer at a time, so concurrent writes queue up. Control how long a connection waits for the write lock before raising `sqlite3.OperationalError: database is locked`:
+
+```python
+conn = sqlite3.connect("app.db", timeout=10)  # seconds, default 5
+```
+
+If you see `database is locked` in production, the fix is almost always: WAL mode on, a reasonable timeout, and keeping write transactions short. It is not by itself a reason to abandon SQLite.
+
+### Threads
+
+By default a connection can only be used from the thread that created it (`check_same_thread=True`). The simple, correct pattern is one connection per thread. Passing `check_same_thread=False` is only safe if you serialize access yourself; sharing one connection across threads without a lock is a recipe for corrupted state.
+
+## Async with aiosqlite
+
+SQLite has no network protocol, so "async SQLite" really means running blocking calls in a worker thread. That is exactly what aiosqlite does, with an API that mirrors `sqlite3`:
+
+```python
+import asyncio
+import aiosqlite
+
+async def main():
+    async with aiosqlite.connect("app.db") as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute("SELECT id, email FROM users") as cursor:
+            async for row in cursor:
+                print(row["email"])
+        await db.commit()
+
+asyncio.run(main())
+```
+
+Unlike the stdlib, aiosqlite's `async with connect(...)` **does** close the connection on exit. Because each connection owns a thread, do not open one per request in a busy service; reuse a connection or use a small pool. If an asyncio web app is bottlenecked on SQLite writes, that is usually the moment to ask whether you have outgrown SQLite -- see [SQLite vs MySQL](/guides/sqlite-vs-mysql) for where the line sits.
+
+## Common errors
+
+| Error | Cause | Fix |
+|---|---|---|
+| `OperationalError: database is locked` | Concurrent write while another transaction holds the lock | WAL mode, raise `timeout`, shorten write transactions |
+| `OperationalError: no such table` | Wrong file path created a fresh empty DB | Open with `mode=ro` URI or verify the path |
+| `ProgrammingError: Incorrect number of bindings` | Passed a string instead of a tuple for parameters | Use `(value,)` |
+| `ProgrammingError: SQLite objects created in a thread...` | Connection shared across threads | One connection per thread, or manage locking yourself |
+| `InterfaceError: Error binding parameter` | Unsupported type (e.g. dict, list) passed as a parameter | Serialize to TEXT/BLOB first (e.g. `json.dumps`) |
+
+## Dates and types
+
+SQLite has no native date type, and Python's old implicit datetime adapters were deprecated in Python 3.12. Store dates as ISO 8601 strings or Unix timestamps and convert explicitly:
+
+```python
+from datetime import datetime, timezone
+conn.execute("INSERT INTO events (at) VALUES (?)", (datetime.now(timezone.utc).isoformat(),))
+```
+
+Explicit conversion is less magical and survives across language versions and tools. For querying date columns, see [SQLite date functions](/guides/sqlite/date-functions).
+
+## Related guides
+
+- [SQLite transactions](/guides/sqlite/transactions) -- locking modes, SQLITE_BUSY, savepoints
+- [Import CSV to SQLite](/guides/import-csv-to-sqlite)
+- [Best SQLite GUI clients](/guides/sqlite-gui-client)
+
+Mako connects to SQLite files with AI-powered autocomplete. Try it free at mako.ai.


### PR DESCRIPTION
Batch 10 kickoff: connection guides (connect from Python/Node/Go × 9 DBs — new keyword surface, maps directly to Mako's core action).

This PR (so far):
- `postgresql/connect-from-python` — psycopg 3 (recommended), psycopg2, asyncpg, SQLAlchemy 2.0; pooling (psycopg_pool, PgBouncer caveats), SSL modes, common FATAL errors. Versions verified against PyPI 2026-06-11.
- `mysql/connect-from-python` — mysqlclient vs PyMySQL vs Connector/Python (+licensing note), aiomysql/asyncmy, SQLAlchemy dialects; utf8mb4, autocommit trap, wait_timeout/gone-away + pool_pre_ping, caching_sha2_password. Versions verified against PyPI 2026-06-11.

More connection guides will be appended by subsequent runs.