### PR TITLE
Fix flimsy realtime console sync: self-healing draft loop, agent-edit visibility, SSE watchdog, dual save guard

### DIFF
--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -47,6 +47,7 @@ import {
   validateScheduledConsoleSchedule,
 } from "../services/scheduled-query-schedule.service";
 import { publishRealtimeEvent } from "../services/realtime.service";
+import { buildConsoleWriteGuard } from "../services/console-save-guards";
 
 /**
  * Map console language to query language for tracking
@@ -915,9 +916,6 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
         body.expectedVersion >= 1
           ? (body.expectedVersion as number)
           : undefined;
-      const useVersionGuard =
-        expectedVersion !== undefined && existingById !== null;
-
       // Realtime sync (issue #475): `clientId` identifies the writing tab
       // (or `agent:<chatId>`) so subscribers can suppress their own echoes;
       // `expectedDraftRevision` makes draft auto-saves revision-checked so a
@@ -955,31 +953,15 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
       // them: `version` catches concurrent explicit saves, `draftRevision`
       // catches everything else that moves the draft (agent modify_console,
       // another tab's autosave) — without it a stale window's Cmd+S passes
-      // the version guard and silently reverts those edits.
-      const useDraftGuardOnSave =
-        expectedDraftRevision !== undefined && existingById !== null;
-      // The guards are applied atomically in the update filter (not as a
-      // read-then-write check). With any guard active we must not upsert:
-      // a mismatch would otherwise insert a duplicate document.
-      const guardedFilter: Record<string, unknown> = {
-        ...idFilter,
-        // Legacy documents predating the counters count as 1.
-        ...(useVersionGuard
-          ? {
-              version:
-                expectedVersion === 1 ? { $in: [1, null] } : expectedVersion,
-            }
-          : {}),
-        ...(useDraftGuardOnSave
-          ? {
-              draftRevision:
-                expectedDraftRevision === 1
-                  ? { $in: [1, null] }
-                  : expectedDraftRevision,
-            }
-          : {}),
-      };
-      const saveGuardActive = useVersionGuard || useDraftGuardOnSave;
+      // the version guard and silently reverts those edits. See
+      // console-save-guards.ts for the atomic-filter / no-upsert semantics.
+      const { filter: guardedFilter, guardActive: saveGuardActive } =
+        buildConsoleWriteGuard({
+          baseFilter: idFilter,
+          docExists: existingById !== null,
+          expectedVersion,
+          expectedDraftRevision,
+        });
       const versionConflictResponse = async () => {
         const current = await SavedConsole.findOne(idFilter);
         return c.json(
@@ -1264,20 +1246,14 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
         setOnInsertFields.name = "Untitled";
       }
 
-      const useDraftGuard =
-        expectedDraftRevision !== undefined && existingById !== null;
-      // Applied atomically in the update filter. With the guard active we
-      // must not upsert: a revision mismatch would insert a duplicate doc.
-      const draftFilter: Record<string, unknown> = useDraftGuard
-        ? {
-            ...idFilter,
-            // Legacy documents predating the field count as revision 1.
-            draftRevision:
-              expectedDraftRevision === 1
-                ? { $in: [1, null] }
-                : expectedDraftRevision,
-          }
-        : idFilter;
+      const { filter: draftFilter, guardActive: useDraftGuard } =
+        buildConsoleWriteGuard({
+          baseFilter: idFilter,
+          docExists: existingById !== null,
+          // Draft autosaves are deliberately NOT version-guarded (that
+          // counter belongs to explicit saves).
+          expectedDraftRevision,
+        });
 
       const result = await SavedConsole.findOneAndUpdate(
         draftFilter,

--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -382,6 +382,10 @@ consoleRoutes.post("/revisions-sync", async (c: Context) => {
         databaseId: doc.databaseId,
         databaseName: doc.databaseName,
         version: doc.version ?? 1,
+        // Server truth for draft-vs-saved: clients use this to keep the
+        // tab's autosave eligibility correct (drafts autosave, saved
+        // consoles don't). Missing on legacy docs ⇒ treated as saved.
+        isSaved: doc.isSaved ?? true,
         lastRun: doc.lastRun,
       });
     }

--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -951,17 +951,35 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
         _id: new Types.ObjectId(pathOrId),
         workspaceId: new Types.ObjectId(workspaceId),
       };
-      // The guard is applied atomically in the update filter (not as a
-      // read-then-write check). With the guard active we must not upsert:
-      // a version mismatch would otherwise insert a duplicate document.
-      const guardedFilter: Record<string, unknown> = useVersionGuard
-        ? {
-            ...idFilter,
-            // Legacy documents predating the version field count as version 1.
-            version:
-              expectedVersion === 1 ? { $in: [1, null] } : expectedVersion,
-          }
-        : idFilter;
+      // Explicit saves are guarded on BOTH counters when the client sent
+      // them: `version` catches concurrent explicit saves, `draftRevision`
+      // catches everything else that moves the draft (agent modify_console,
+      // another tab's autosave) — without it a stale window's Cmd+S passes
+      // the version guard and silently reverts those edits.
+      const useDraftGuardOnSave =
+        expectedDraftRevision !== undefined && existingById !== null;
+      // The guards are applied atomically in the update filter (not as a
+      // read-then-write check). With any guard active we must not upsert:
+      // a mismatch would otherwise insert a duplicate document.
+      const guardedFilter: Record<string, unknown> = {
+        ...idFilter,
+        // Legacy documents predating the counters count as 1.
+        ...(useVersionGuard
+          ? {
+              version:
+                expectedVersion === 1 ? { $in: [1, null] } : expectedVersion,
+            }
+          : {}),
+        ...(useDraftGuardOnSave
+          ? {
+              draftRevision:
+                expectedDraftRevision === 1
+                  ? { $in: [1, null] }
+                  : expectedDraftRevision,
+            }
+          : {}),
+      };
+      const saveGuardActive = useVersionGuard || useDraftGuardOnSave;
       const versionConflictResponse = async () => {
         const current = await SavedConsole.findOne(idFilter);
         return c.json(
@@ -970,6 +988,9 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
             error: "version_conflict",
             versionConflict: {
               currentVersion: current?.version ?? 1,
+              // Both bases are needed to retry an "Overwrite with mine":
+              // the retried save must pass BOTH guards.
+              currentDraftRevision: current?.draftRevision ?? 1,
               content: current?.code ?? "",
               name: current?.name,
               updatedAt: current?.updatedAt,
@@ -1061,7 +1082,7 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
             $inc: { version: 1, draftRevision: 1 },
             $setOnInsert: setOnInsertFields,
           },
-          { upsert: !useVersionGuard, new: true },
+          { upsert: !saveGuardActive, new: true },
         );
         if (!result) {
           return versionConflictResponse();
@@ -1146,7 +1167,7 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
             $inc: { version: 1, draftRevision: 1 },
             $setOnInsert: setOnInsertFields,
           },
-          { upsert: !useVersionGuard, new: true },
+          { upsert: !saveGuardActive, new: true },
         );
         if (!result) {
           return versionConflictResponse();

--- a/api/src/services/console-save-guards.test.ts
+++ b/api/src/services/console-save-guards.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Self-running test for the console write-guard matrix.
+ * Run with: pnpm --filter api exec tsx src/services/console-save-guards.test.ts
+ */
+import assert from "node:assert/strict";
+import { buildConsoleWriteGuard } from "./console-save-guards";
+
+const base = { _id: "X", workspaceId: "W" };
+
+// --- no guards ---------------------------------------------------------------
+
+{
+  const g = buildConsoleWriteGuard({ baseFilter: base, docExists: true });
+  assert.deepEqual(g.filter, base, "no expectations ⇒ identity filter");
+  assert.equal(g.guardActive, false, "no expectations ⇒ guard inactive");
+}
+
+{
+  // Guards never engage for documents that don't exist yet (first-time
+  // upsert has nothing to conflict with).
+  const g = buildConsoleWriteGuard({
+    baseFilter: base,
+    docExists: false,
+    expectedVersion: 3,
+    expectedDraftRevision: 7,
+  });
+  assert.deepEqual(g.filter, base, "missing doc ⇒ identity filter");
+  assert.equal(g.guardActive, false, "missing doc ⇒ guard inactive (upsert ok)");
+}
+
+// --- single guards -----------------------------------------------------------
+
+{
+  const g = buildConsoleWriteGuard({
+    baseFilter: base,
+    docExists: true,
+    expectedVersion: 3,
+  });
+  assert.deepEqual(g.filter, { ...base, version: 3 });
+  assert.equal(g.guardActive, true);
+}
+
+{
+  const g = buildConsoleWriteGuard({
+    baseFilter: base,
+    docExists: true,
+    expectedDraftRevision: 7,
+  });
+  assert.deepEqual(g.filter, { ...base, draftRevision: 7 });
+  assert.equal(g.guardActive, true);
+}
+
+// --- dual guard (explicit saves) ----------------------------------------------
+
+{
+  const g = buildConsoleWriteGuard({
+    baseFilter: base,
+    docExists: true,
+    expectedVersion: 3,
+    expectedDraftRevision: 7,
+  });
+  assert.deepEqual(
+    g.filter,
+    { ...base, version: 3, draftRevision: 7 },
+    "explicit saves check BOTH counters",
+  );
+  assert.equal(g.guardActive, true);
+}
+
+// --- legacy documents (counters predate the fields ⇒ count as 1) --------------
+
+{
+  const g = buildConsoleWriteGuard({
+    baseFilter: base,
+    docExists: true,
+    expectedVersion: 1,
+    expectedDraftRevision: 1,
+  });
+  assert.deepEqual(g.filter, {
+    ...base,
+    version: { $in: [1, null] },
+    draftRevision: { $in: [1, null] },
+  });
+}
+
+// --- invalid expectations are ignored (defensive parsing belongs here too) ----
+
+{
+  const g = buildConsoleWriteGuard({
+    baseFilter: base,
+    docExists: true,
+    expectedVersion: 0,
+    expectedDraftRevision: 2.5,
+  });
+  assert.deepEqual(g.filter, base, "non-positive / non-integer ⇒ ignored");
+  assert.equal(g.guardActive, false);
+}
+
+// eslint-disable-next-line no-console -- self-running test, not API code
+console.log("console-save-guards.test.ts: all assertions passed");

--- a/api/src/services/console-save-guards.ts
+++ b/api/src/services/console-save-guards.ts
@@ -1,0 +1,80 @@
+/**
+ * Optimistic-concurrency guards for console writes (PUT /consoles/:id).
+ *
+ * Two independent counters protect a SavedConsole document:
+ *   - `version`        — bumped by EXPLICIT saves only (checkpoint history);
+ *   - `draftRevision`  — bumped by every draft write: autosaves, agent
+ *                        modify_console / set_console_connection, run
+ *                        artifacts, renames.
+ *
+ * Explicit saves must check BOTH (a stale window's Cmd+S would otherwise
+ * pass the version guard and silently revert agent edits / other tabs'
+ * autosaves, which bump only draftRevision). Draft autosaves check only
+ * draftRevision.
+ *
+ * Guards are applied atomically inside the Mongo update filter — never as a
+ * read-then-write check. While any guard is active the write must NOT
+ * upsert: a mismatch would insert a duplicate document instead of failing.
+ *
+ * Pure module (no imports) so the matrix is unit-testable standalone:
+ *   pnpm --filter api exec tsx src/services/console-save-guards.test.ts
+ */
+
+export interface ConsoleWriteGuardInput {
+  /** Identity filter ({_id, workspaceId}) the guard conditions extend. */
+  baseFilter: Record<string, unknown>;
+  /**
+   * Whether the document already exists. Guards only engage for existing
+   * documents — first-time upserts have nothing to conflict with.
+   */
+  docExists: boolean;
+  /** Client's optimistic version base (explicit saves). */
+  expectedVersion?: number;
+  /** Client's draft revision base (autosaves AND explicit saves). */
+  expectedDraftRevision?: number;
+}
+
+export interface ConsoleWriteGuard {
+  /** Filter to use in findOneAndUpdate. */
+  filter: Record<string, unknown>;
+  /**
+   * True when at least one guard condition is present — the caller must set
+   * `upsert: false` and treat a null update result as a 409 conflict.
+   */
+  guardActive: boolean;
+}
+
+/**
+ * Documents created before the counters existed have no field at all; they
+ * count as 1 so old docs aren't permanently unguardable.
+ */
+function legacyAwareEquals(
+  expected: number,
+): number | { $in: Array<number | null> } {
+  return expected === 1 ? { $in: [1, null] } : expected;
+}
+
+function isValidExpectation(value: number | undefined): value is number {
+  return value !== undefined && Number.isInteger(value) && value >= 1;
+}
+
+export function buildConsoleWriteGuard(
+  input: ConsoleWriteGuardInput,
+): ConsoleWriteGuard {
+  const useVersionGuard =
+    input.docExists && isValidExpectation(input.expectedVersion);
+  const useDraftGuard =
+    input.docExists && isValidExpectation(input.expectedDraftRevision);
+
+  const filter: Record<string, unknown> = { ...input.baseFilter };
+  if (useVersionGuard) {
+    filter.version = legacyAwareEquals(input.expectedVersion as number);
+  }
+  if (useDraftGuard) {
+    filter.draftRevision = legacyAwareEquals(
+      input.expectedDraftRevision as number,
+    );
+  }
+
+  return { filter, guardActive: useVersionGuard || useDraftGuard };
+}

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -2479,6 +2479,51 @@ const Chat: React.FC<ChatProps> = ({
     };
   }, [chatId, currentWorkspace?.id]);
 
+  // In-band console opening: when a create_console / open_console tool
+  // result streams in (state "output-available"), open the console tab in
+  // THIS window. The chat stream is resumable, so unlike the legacy
+  // chat.ui-intent realtime poke this survives SSE drops, reconnects and
+  // page refreshes — the replayed part triggers the same idempotent open.
+  // Tool call ids seen in RESTORED history are pre-seeded into this set by
+  // loadSession (reopening a chat must not re-open every console it ever
+  // touched — the dedicated consoles-restore payload handles that).
+  const handledConsoleOpenToolCallIdsRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    handledConsoleOpenToolCallIdsRef.current = new Set();
+  }, [chatId]);
+  useEffect(() => {
+    const workspaceId = currentWorkspace?.id;
+    if (!workspaceId) return;
+    const last = messages.at(-1);
+    if (!last || last.role !== "assistant") return;
+    for (const part of last.parts ?? []) {
+      const p = part as {
+        type?: string;
+        toolName?: string;
+        state?: string;
+        toolCallId?: string;
+        output?: { success?: boolean; consoleId?: string };
+      };
+      const toolName =
+        p.type === "dynamic-tool"
+          ? p.toolName
+          : p.type?.startsWith("tool-")
+            ? p.type.slice("tool-".length)
+            : undefined;
+      if (toolName !== "create_console" && toolName !== "open_console") {
+        continue;
+      }
+      if (p.state !== "output-available") continue;
+      const consoleId = p.output?.consoleId;
+      if (!p.toolCallId || !p.output?.success || !consoleId) continue;
+      if (handledConsoleOpenToolCallIdsRef.current.has(p.toolCallId)) continue;
+      handledConsoleOpenToolCallIdsRef.current.add(p.toolCallId);
+      void useConsoleStore
+        .getState()
+        .openConsoleFromServer(workspaceId, consoleId);
+    }
+  }, [messages, currentWorkspace?.id]);
+
   // Load messages when selecting an existing chat from history
   useEffect(() => {
     // Flipped when this effect is superseded (chat switched / unmount) so a
@@ -2629,6 +2674,19 @@ const Chat: React.FC<ChatProps> = ({
                 parts,
               };
             }) || [];
+
+          // Restored tool parts must not re-trigger the in-band console
+          // opener (only LIVE streamed results should); the consoles-restore
+          // payload below already reopens what matters.
+          for (const msg of convertedMessages) {
+            for (const part of msg.parts ?? []) {
+              const toolCallId = (part as { toolCallId?: string }).toolCallId;
+              if (toolCallId) {
+                handledConsoleOpenToolCallIdsRef.current.add(toolCallId);
+              }
+            }
+          }
+
           setMessages(convertedMessages);
 
           // Restore consoles that were modified by the agent in this chat

--- a/app/src/components/Console.tsx
+++ b/app/src/components/Console.tsx
@@ -676,10 +676,17 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
 
         const currentContent = model.getValue();
 
-        // Auto-save new consoles created with content (e.g., by agent create_console)
-        // Skip if console is already explicitly saved (isSaved=true)
+        // Mount-autosave is ONLY for drafts that have never synced with the
+        // server (no draftRevision — e.g. legacy localStorage-restored tabs
+        // whose server doc may not exist). Re-saving an already-synced draft
+        // on every mount used to bump draftRevision with identical content,
+        // which made every OTHER window's revision base stale and dead-ended
+        // their autosaves in 409s. Agent-created consoles arrive with a
+        // server revision, so they never take this path either.
+        const mountTab = useConsoleStore.getState().tabs[consoleId];
         if (
           !isSaved &&
+          mountTab?.draftRevision === undefined &&
           currentWorkspace?.id &&
           consoleId &&
           currentContent.trim()

--- a/app/src/components/ConsoleRemoteUpdateBanner.tsx
+++ b/app/src/components/ConsoleRemoteUpdateBanner.tsx
@@ -10,6 +10,8 @@ import type { ConsoleTab } from "../store/lib/types";
 interface ConsoleRemoteUpdateBannerProps {
   remoteUpdate: NonNullable<ConsoleTab["remoteUpdate"]>;
   onLoadLatest: () => void;
+  /** Deliberately overwrite the server copy with this tab's content. */
+  onKeepMine?: () => void;
   onDismiss: () => void;
   onCloseTab: () => void;
 }
@@ -17,6 +19,7 @@ interface ConsoleRemoteUpdateBannerProps {
 export default function ConsoleRemoteUpdateBanner({
   remoteUpdate,
   onLoadLatest,
+  onKeepMine,
   onDismiss,
   onCloseTab,
 }: ConsoleRemoteUpdateBannerProps) {
@@ -34,9 +37,16 @@ export default function ConsoleRemoteUpdateBanner({
               Close tab
             </Button>
           ) : (
-            <Button color="inherit" size="small" onClick={onLoadLatest}>
-              Load latest
-            </Button>
+            <>
+              <Button color="inherit" size="small" onClick={onLoadLatest}>
+                Load latest
+              </Button>
+              {onKeepMine && (
+                <Button color="inherit" size="small" onClick={onKeepMine}>
+                  Keep mine
+                </Button>
+              )}
+            </>
           )}
           <Button color="inherit" size="small" onClick={onDismiss}>
             Dismiss

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -1859,9 +1859,14 @@ function Editor({
   const handleVersionConflictOverwrite = async () => {
     if (!pendingSaveData || !versionConflictData) return;
     const { tabId, content, path, comment } = pendingSaveData;
-    // Fast-forward to the server's version so the retried save passes the
-    // guard (unless someone saves yet again in the meantime).
+    // Fast-forward to the server's bases so the retried save passes BOTH
+    // guards (unless someone saves yet again in the meantime).
     updateVersion(tabId, versionConflictData.currentVersion);
+    if (typeof versionConflictData.currentDraftRevision === "number") {
+      useConsoleStore
+        .getState()
+        .updateDraftRevision(tabId, versionConflictData.currentDraftRevision);
+    }
     setVersionConflictData(null);
     const success = await executeConsoleSave(
       tabId,
@@ -1886,6 +1891,11 @@ function Editor({
     });
     updateContent(tabId, serverContent);
     updateVersion(tabId, versionConflictData.currentVersion);
+    if (typeof versionConflictData.currentDraftRevision === "number") {
+      useConsoleStore
+        .getState()
+        .updateDraftRevision(tabId, versionConflictData.currentDraftRevision);
+    }
     const currentTab = tabs[tabId];
     const newHash = computeConsoleStateHash(
       serverContent,

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -2256,10 +2256,26 @@ function Editor({
                                     tab.id,
                                   );
                               }}
+                              onKeepMine={() => {
+                                if (!currentWorkspace?.id) return;
+                                // Use the LIVE Monaco buffer, not the store
+                                // copy — it may lag keystrokes by a debounce.
+                                const live =
+                                  consoleRefs.current[
+                                    tab.id
+                                  ]?.current?.getCurrentContent().content;
+                                void useConsoleStore
+                                  .getState()
+                                  .resolveRemoteUpdateKeepMine(
+                                    currentWorkspace.id,
+                                    tab.id,
+                                    live ?? tab.content,
+                                  );
+                              }}
                               onDismiss={() =>
                                 useConsoleStore
                                   .getState()
-                                  .setRemoteUpdate(tab.id, null)
+                                  .dismissRemoteUpdate(tab.id)
                               }
                               onCloseTab={() =>
                                 useConsoleStore.getState().closeTab(tab.id)

--- a/app/src/lib/api-types.ts
+++ b/app/src/lib/api-types.ts
@@ -61,6 +61,11 @@ export interface ConsoleContentResponse {
 
 export interface ConsoleVersionConflict {
   currentVersion: number;
+  /**
+   * Draft-revision base at conflict time. A retried "overwrite with mine"
+   * must fast-forward to BOTH bases to pass the explicit save's dual guard.
+   */
+  currentDraftRevision?: number;
   content: string;
   name?: string;
   updatedAt?: string;

--- a/app/src/lib/api-types.ts
+++ b/app/src/lib/api-types.ts
@@ -103,6 +103,8 @@ export interface ConsoleRevisionSyncEntry {
   databaseId?: string;
   databaseName?: string;
   version?: number;
+  /** Server truth for draft-vs-saved (drives autosave eligibility). */
+  isSaved?: boolean;
   lastRun?: ConsoleLastRun;
 }
 

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -1412,6 +1412,16 @@ export const useConsoleStore = create<ConsoleStore>()(
           databaseName,
         );
         if (lastSavedContentHash.get(consoleId) === stateHash) {
+          // Content is back to the persisted baseline (e.g. type + undo).
+          // CANCEL any queued autosave too: it captured an intermediate
+          // keystroke state which is now obsolete — letting it fire would
+          // persist phantom content the editor no longer shows and steal
+          // the revision from concurrent writers.
+          const pending = draftSaveTimers.get(consoleId);
+          if (pending) {
+            clearTimeout(pending);
+            draftSaveTimers.delete(consoleId);
+          }
           return;
         }
 
@@ -1544,6 +1554,30 @@ export const useConsoleStore = create<ConsoleStore>()(
                 delete tab.savedConnectionId;
                 delete tab.savedDatabaseId;
                 delete tab.savedDatabaseName;
+
+                // Seed the autosave baseline with the persisted content.
+                // The module-level hash map is empty on every page load;
+                // without seeding, a net-zero edit (type + undo) in a
+                // rehydrated draft fires an autosave of unchanged content,
+                // which can only 409 against newer remote edits and locks
+                // the tab into a phantom conflict. The first revision sync
+                // re-seeds with the server copy if it moved while we were
+                // away (applyRemoteConsoleEntry / fetchConsoleContent).
+                if (
+                  (tab.kind === undefined || tab.kind === "console") &&
+                  typeof tab.content === "string" &&
+                  typeof tab.id === "string"
+                ) {
+                  lastSavedContentHash.set(
+                    tab.id,
+                    computeConsoleStateHash(
+                      tab.content,
+                      tab.connectionId,
+                      tab.databaseId,
+                      tab.databaseName,
+                    ),
+                  );
+                }
               });
             }
             return data;

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -47,6 +47,15 @@ interface ConsoleActions {
       id?: string;
       isSaved?: boolean;
     },
+    options?: {
+      /**
+       * When false, never close the "first pristine tab" to make room (VS
+       * Code preview-tab behavior). Agent-driven opens use this so that a
+       * console the agent just created isn't silently replaced by the next
+       * one it opens.
+       */
+      replacePristine?: boolean;
+    },
   ) => string;
   closeTab: (id: string) => void;
   setActiveTab: (id: string | null) => void;
@@ -85,6 +94,13 @@ interface ConsoleActions {
   /** Set/clear the "updated remotely while you have unsaved edits" flag. */
   setRemoteUpdate: (id: string, info: ConsoleTab["remoteUpdate"]) => void;
   /**
+   * User dismissed the remote-update banner: clear it AND unblock autosave.
+   * The next autosave is revision-checked, so if the conflict still exists
+   * it 409s and the banner honestly comes back — but edits never silently
+   * stop persisting with no affordance shown.
+   */
+  dismissRemoteUpdate: (id: string) => void;
+  /**
    * Apply a server-authoritative console payload (from revisions-sync) to a
    * CLEAN open tab: updates the store and pushes the content into the
    * mounted Monaco editor via the "console-remote-content" event. Dirty tabs
@@ -92,13 +108,53 @@ interface ConsoleActions {
    */
   applyRemoteConsoleEntry: (entry: ConsoleRevisionSyncEntry) => void;
   /**
+   * Apply a revisions-sync entry whose content already matches this tab's
+   * store content: fast-forward revision/version/metadata WITHOUT touching
+   * the Monaco buffer. Used when the local buffer may be AHEAD of the store
+   * by in-flight keystrokes — pushing the (identical-to-store) server copy
+   * into the editor would erase them.
+   */
+  fastForwardRemoteConsoleEntry: (entry: ConsoleRevisionSyncEntry) => void;
+  /**
    * Resolve the remote-update affordance: refetch the server copy, apply it
-   * (discarding local unsaved edits) and clear the dirty flag.
+   * (discarding local unsaved edits).
    */
   applyRemoteConsoleUpdate: (
     workspaceId: string,
     consoleId: string,
   ) => Promise<void>;
+  /**
+   * Resolve the remote-update affordance the other way: deliberately
+   * overwrite the server copy with this tab's content (revision-targeted at
+   * the conflict the banner reported). Re-banners on a fresh conflict.
+   */
+  resolveRemoteUpdateKeepMine: (
+    workspaceId: string,
+    consoleId: string,
+    content: string,
+  ) => Promise<void>;
+  /**
+   * Open a console tab from its server copy (agent open/create intents,
+   * in-band chat tool results). Idempotent: an already-open tab is just
+   * activated. The new tab carries the server's draftRevision/isSaved so
+   * the realtime layer starts from an accurate base, and it never replaces
+   * a pristine tab (agent-opened consoles must not swallow each other).
+   */
+  openConsoleFromServer: (
+    workspaceId: string,
+    consoleId: string,
+  ) => Promise<void>;
+  /**
+   * Fetch ONLY the latest server-side run artifact (lastRun) for a console.
+   * Unlike fetchConsoleContent this never touches content/draftRevision/
+   * isSaved/remoteUpdate — content replication is the realtime revision
+   * sync's job; this exists so run results can render without desyncing the
+   * editor from the revision base.
+   */
+  fetchConsoleRunArtifact: (
+    workspaceId: string,
+    consoleId: string,
+  ) => Promise<ConsoleContentResponse["lastRun"] | null>;
 
   // Versioning
   getVersionManager: (consoleId: string) => ConsoleVersionManager | null;
@@ -242,10 +298,17 @@ const draftSaveTimers = new Map<string, ReturnType<typeof setTimeout>>();
 const lastSavedContentHash = new Map<string, string>();
 const DRAFT_SAVE_DEBOUNCE_MS = 2000; // 2 seconds debounce
 
+// Consoles whose autosave is suspended because the last draft write hit a
+// real 409 draft_conflict (server moved past us with DIFFERENT content).
+// While a console is blocked we stop hammering the server with doomed
+// autosaves; the remote-update banner's "Load latest" / "Keep mine" actions
+// (or a remote apply that matches local content) unblock it.
+const blockedDraftSaves = new Set<string>();
+
 // Last user keystroke per console (module-level, non-reactive). The store's
-// isDirty flag lags typing by a debounce (~500ms in Console.tsx), so the
-// realtime layer uses this to avoid clobbering keystrokes that landed inside
-// that window when a remote update arrives.
+// content lags typing by a debounce (~500ms in Console.tsx), so the realtime
+// layer uses this to avoid clobbering keystrokes that landed inside that
+// window when a remote update arrives.
 const lastUserEditAt = new Map<string, number>();
 const USER_EDIT_RECENCY_MS = 3000;
 
@@ -258,6 +321,53 @@ export const hasRecentUserEdit = (consoleId: string): boolean => {
   return at !== undefined && Date.now() - at < USER_EDIT_RECENCY_MS;
 };
 
+/** A draft autosave is queued (debounce window) but not yet persisted. */
+export const hasPendingDraftSave = (consoleId: string): boolean =>
+  draftSaveTimers.has(consoleId);
+
+/** Autosave is suspended pending conflict resolution (banner shown). */
+export const hasBlockedDraftSave = (consoleId: string): boolean =>
+  blockedDraftSaves.has(consoleId);
+
+export const clearBlockedDraftSave = (consoleId: string): void => {
+  blockedDraftSaves.delete(consoleId);
+};
+
+/**
+ * Does this tab hold local edits that are not yet persisted on the server?
+ *
+ * This is the gate the realtime layer uses before applying a remote copy
+ * over the tab. NOTE: this is intentionally NOT `tab.isDirty` — that flag is
+ * the VS Code-style "pinned tab" marker (set on first keystroke, set again
+ * after explicit saves, never cleared) and says nothing about persistence.
+ *
+ *  - drafts persist via autosave: unsaved edits exist only in the keystroke
+ *    debounce window, while an autosave is queued, or while autosave is
+ *    blocked on an unresolved conflict;
+ *  - saved consoles persist via explicit save: unsaved edits exist when the
+ *    current state hash differs from the hash captured at the last save.
+ */
+export const hasUnsavedLocalEdits = (consoleId: string): boolean => {
+  if (hasRecentUserEdit(consoleId)) return true;
+  if (draftSaveTimers.has(consoleId)) return true;
+  if (blockedDraftSaves.has(consoleId)) return true;
+  const tab = useConsoleStore.getState().tabs[consoleId];
+  if (!tab) return false;
+  if (tab.isSaved) {
+    // Missing baseline hash: cannot prove the tab is clean — be conservative
+    // (banner instead of a potentially destructive silent replace).
+    if (!tab.savedStateHash) return true;
+    const currentHash = computeConsoleStateHash(
+      tab.content,
+      tab.connectionId,
+      tab.databaseId,
+      tab.databaseName,
+    );
+    return currentHash !== tab.savedStateHash;
+  }
+  return false;
+};
+
 const cancelAutoSave = (consoleId: string): void => {
   const timer = draftSaveTimers.get(consoleId);
   if (timer) {
@@ -265,6 +375,7 @@ const cancelAutoSave = (consoleId: string): void => {
     draftSaveTimers.delete(consoleId);
   }
   lastSavedContentHash.delete(consoleId);
+  blockedDraftSaves.delete(consoleId);
 };
 
 const shouldAutoSave = (getState: () => ConsoleState, consoleId: string) => {
@@ -300,14 +411,15 @@ export const useConsoleStore = create<ConsoleStore>()(
       ...initialState,
 
       // Tab management
-      openTab: tab => {
+      openTab: (tab, options) => {
         const id = tab.id || generateObjectId();
         const content = tab.content || "";
 
         // Replace first pristine tab if present
-        const pristineTabId = Object.keys(get().tabs).find(
-          tabId => !get().tabs[tabId].isDirty,
-        );
+        const replacePristine = options?.replacePristine ?? true;
+        const pristineTabId = replacePristine
+          ? Object.keys(get().tabs).find(tabId => !get().tabs[tabId].isDirty)
+          : undefined;
 
         if (tab.kind === undefined || tab.kind === "console") {
           versionManagers.set(id, new ConsoleVersionManager(id));
@@ -438,9 +550,28 @@ export const useConsoleStore = create<ConsoleStore>()(
           }
         }),
 
+      dismissRemoteUpdate: id => {
+        blockedDraftSaves.delete(id);
+        // Allow the retry even when content didn't change since the last
+        // (rejected) attempt.
+        lastSavedContentHash.delete(id);
+        set(state => {
+          const tab = state.tabs[id];
+          if (tab) {
+            tab.remoteUpdate = null;
+          }
+        });
+      },
+
       applyRemoteConsoleEntry: entry => {
         const tab = get().tabs[entry.id];
         if (!tab) return;
+        const newStateHash = computeConsoleStateHash(
+          entry.content,
+          entry.connectionId,
+          entry.databaseId,
+          entry.databaseName,
+        );
         set(state => {
           const t = state.tabs[entry.id];
           if (!t) return;
@@ -451,9 +582,18 @@ export const useConsoleStore = create<ConsoleStore>()(
           t.databaseName = entry.databaseName;
           t.draftRevision = entry.draftRevision;
           if (typeof entry.version === "number") t.version = entry.version;
+          if (typeof entry.isSaved === "boolean") t.isSaved = entry.isSaved;
+          // The applied copy IS the persisted state: refresh the explicit-
+          // save baseline so hasUnsavedLocalEdits doesn't misread the tab as
+          // locally edited from now on.
+          if (t.isSaved) t.savedStateHash = newStateHash;
           t.remoteUpdate = null;
           t.lastRun = entry.lastRun ?? t.lastRun;
         });
+        // Tab now mirrors the server: any previously blocked autosave state
+        // is moot, and an identical autosave would be redundant.
+        blockedDraftSaves.delete(entry.id);
+        lastSavedContentHash.set(entry.id, newStateHash);
         // Push into the mounted Monaco editor (Editor.tsx listens). The
         // store alone is not enough: Console is uncontrolled after mount.
         window.dispatchEvent(
@@ -463,20 +603,112 @@ export const useConsoleStore = create<ConsoleStore>()(
         );
       },
 
+      fastForwardRemoteConsoleEntry: entry => {
+        const tab = get().tabs[entry.id];
+        if (!tab) return;
+        const newStateHash = computeConsoleStateHash(
+          entry.content,
+          entry.connectionId,
+          entry.databaseId,
+          entry.databaseName,
+        );
+        set(state => {
+          const t = state.tabs[entry.id];
+          if (!t) return;
+          if (entry.name) t.title = entry.name;
+          t.connectionId = entry.connectionId;
+          t.databaseId = entry.databaseId;
+          t.databaseName = entry.databaseName;
+          t.draftRevision = entry.draftRevision;
+          if (typeof entry.version === "number") t.version = entry.version;
+          if (typeof entry.isSaved === "boolean") t.isSaved = entry.isSaved;
+          if (t.isSaved) t.savedStateHash = newStateHash;
+          // Server matches local content: any conflict affordance is moot.
+          t.remoteUpdate = null;
+          t.lastRun = entry.lastRun ?? t.lastRun;
+        });
+        blockedDraftSaves.delete(entry.id);
+        lastSavedContentHash.set(entry.id, newStateHash);
+      },
+
       applyRemoteConsoleUpdate: async (workspaceId, consoleId) => {
+        // Discarding local edits: a queued autosave would otherwise fire
+        // later with the pre-discard content captured in its closure.
+        cancelAutoSave(consoleId);
         const res = await get().fetchConsoleContent(workspaceId, consoleId);
         if (!res?.success) return;
         set(state => {
           const t = state.tabs[consoleId];
           if (!t) return;
-          t.isDirty = false;
           t.remoteUpdate = null;
         });
+        lastSavedContentHash.set(
+          consoleId,
+          computeConsoleStateHash(
+            res.content || "",
+            res.connectionId,
+            res.databaseId,
+            res.databaseName,
+          ),
+        );
         window.dispatchEvent(
           new CustomEvent("console-remote-content", {
             detail: { consoleId, content: res.content || "" },
           }),
         );
+      },
+
+      resolveRemoteUpdateKeepMine: async (workspaceId, consoleId, content) => {
+        const tab = get().tabs[consoleId];
+        if (!tab) return;
+        try {
+          // Deliberate overwrite: target the exact revision the banner told
+          // the user about. If the server moved again in the meantime we get
+          // another 409 and simply refresh the banner.
+          const expectedDraftRevision =
+            tab.remoteUpdate?.draftRevision ?? tab.draftRevision;
+          const { status, body } =
+            await apiClient.putWithStatus<ConsoleSaveResponse>(
+              `/workspaces/${workspaceId}/consoles/${consoleId}`,
+              {
+                content,
+                title: tab.title,
+                connectionId: cloudSafeConnectionId(tab.connectionId),
+                databaseId: tab.databaseId,
+                databaseName: tab.databaseName,
+                clientId: realtimeClientId,
+                expectedDraftRevision,
+              },
+              { alsoOk: [409] },
+            );
+
+          if (status === 409 && body.draftConflict) {
+            get().setRemoteUpdate(consoleId, {
+              draftRevision: body.draftConflict.currentDraftRevision,
+              kind: "updated",
+            });
+            return;
+          }
+
+          if (body.success) {
+            if (typeof body.draftRevision === "number") {
+              get().updateDraftRevision(consoleId, body.draftRevision);
+            }
+            get().setRemoteUpdate(consoleId, null);
+            blockedDraftSaves.delete(consoleId);
+            lastSavedContentHash.set(
+              consoleId,
+              computeConsoleStateHash(
+                content,
+                tab.connectionId,
+                tab.databaseId,
+                tab.databaseName,
+              ),
+            );
+          }
+        } catch (_e) {
+          // Best-effort; the banner stays until a retry succeeds.
+        }
       },
 
       updateDirty: (id, isDirty) =>
@@ -697,7 +929,13 @@ export const useConsoleStore = create<ConsoleStore>()(
           );
 
           if (res.success) {
-            const filePath = res.path || res.name;
+            // Saved-ness comes from the SERVER's isSaved flag. The previous
+            // `res.path || res.name` inference silently flipped drafts to
+            // isSaved=true (name is always set), which permanently disabled
+            // their autosave. Legacy docs without the field fall back to
+            // path presence (those predate drafts).
+            const isSaved = res.isSaved ?? !!res.path;
+            const filePath = isSaved ? res.path || res.name : undefined;
             set(state => {
               const tab = state.tabs[consoleId];
               if (tab) {
@@ -718,15 +956,13 @@ export const useConsoleStore = create<ConsoleStore>()(
               }
             });
 
-            if (filePath) {
-              const savedStateHash = computeConsoleStateHash(
-                res.content || "",
-                res.connectionId,
-                res.databaseId,
-                res.databaseName,
-              );
-              get().updateSavedState(consoleId, true, savedStateHash);
-            }
+            const savedStateHash = computeConsoleStateHash(
+              res.content || "",
+              res.connectionId,
+              res.databaseId,
+              res.databaseName,
+            );
+            get().updateSavedState(consoleId, isSaved, savedStateHash);
           }
 
           return res.success ? res : null;
@@ -735,6 +971,72 @@ export const useConsoleStore = create<ConsoleStore>()(
             return null;
           }
           console.error("Failed to fetch console content", e);
+          return null;
+        }
+      },
+
+      openConsoleFromServer: async (workspaceId, consoleId) => {
+        if (get().tabs[consoleId]) {
+          get().setActiveTab(consoleId);
+          return;
+        }
+        try {
+          const res = await apiClient.get<ConsoleContentResponse>(
+            `/workspaces/${workspaceId}/consoles/content`,
+            { id: consoleId },
+          );
+          if (!res.success) return;
+          // Re-check: the tab may have appeared while we fetched (e.g. the
+          // legacy ui-intent poke and the in-band tool result both firing).
+          if (get().tabs[consoleId]) {
+            get().setActiveTab(consoleId);
+            return;
+          }
+          const isSaved = res.isSaved ?? !!res.path;
+          get().openTab(
+            {
+              id: consoleId,
+              title: res.name || res.path || "Untitled",
+              content: res.content || "",
+              connectionId: res.connectionId,
+              databaseId: res.databaseId,
+              databaseName: res.databaseName,
+              isSaved,
+              filePath: isSaved ? res.path || res.name : undefined,
+              access: res.access,
+              owner_id: res.owner_id,
+              readOnly: res.readOnly,
+              version: res.version,
+              draftRevision: res.draftRevision ?? 1,
+              lastRun: res.lastRun,
+              kind: "console",
+            },
+            { replacePristine: false },
+          );
+          get().setActiveTab(consoleId);
+        } catch (e) {
+          console.error("Failed to open console from server", e);
+        }
+      },
+
+      fetchConsoleRunArtifact: async (workspaceId, consoleId) => {
+        try {
+          const res = await apiClient.get<ConsoleContentResponse>(
+            `/workspaces/${workspaceId}/consoles/content`,
+            { id: consoleId },
+          );
+          if (!res.success) return null;
+          // Merge ONLY the run artifact; content/revision replication is
+          // handled by the realtime revision sync (single guarded path).
+          set(state => {
+            const tab = state.tabs[consoleId];
+            if (tab && res.lastRun) {
+              tab.lastRun = res.lastRun;
+            }
+          });
+          return res.lastRun ?? null;
+        } catch (e) {
+          console.error("Failed to fetch console run artifact", e);
           return null;
         }
       },
@@ -1094,6 +1396,10 @@ export const useConsoleStore = create<ConsoleStore>()(
       ) => {
         if (!content?.trim() || content === "loading...") return;
         if (!shouldAutoSave(get, consoleId)) return;
+        // Conflict pending (banner shown): don't hammer the server with
+        // doomed 409s. Edits stay local until the user resolves (Load
+        // latest / Keep mine) or a matching remote apply unblocks us.
+        if (blockedDraftSaves.has(consoleId)) return;
 
         const stateHash = computeConsoleStateHash(
           content,
@@ -1113,6 +1419,7 @@ export const useConsoleStore = create<ConsoleStore>()(
         const timer = setTimeout(async () => {
           draftSaveTimers.delete(consoleId);
           if (!shouldAutoSave(get, consoleId)) return;
+          if (blockedDraftSaves.has(consoleId)) return;
 
           try {
             // Revision-checked write (LWW with revision check): if the
@@ -1136,8 +1443,21 @@ export const useConsoleStore = create<ConsoleStore>()(
               );
 
             if (status === 409 && body.draftConflict) {
-              // Surface the non-blocking "updated remotely" affordance; the
-              // user decides whether to load the latest copy.
+              if (body.draftConflict.content === content) {
+                // Pure echo: another window/tab already persisted exactly
+                // this content (e.g. duplicated autosave). Not a conflict —
+                // fast-forward our revision base and move on.
+                get().updateDraftRevision(
+                  consoleId,
+                  body.draftConflict.currentDraftRevision,
+                );
+                get().setRemoteUpdate(consoleId, null);
+                lastSavedContentHash.set(consoleId, stateHash);
+                return;
+              }
+              // Real conflict: suspend autosave and surface the non-blocking
+              // affordance; the user decides (Load latest / Keep mine).
+              blockedDraftSaves.add(consoleId);
               get().setRemoteUpdate(consoleId, {
                 draftRevision: body.draftConflict.currentDraftRevision,
                 kind: "updated",

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -1058,8 +1058,11 @@ export const useConsoleStore = create<ConsoleStore>()(
           const cleanPath = path.endsWith(".js") ? path.slice(0, -3) : path;
           // Optimistic concurrency: send the version this tab was loaded
           // from so the server rejects (409) instead of overwriting a
-          // concurrent save by someone else.
+          // concurrent save by someone else. The draft revision rides along
+          // so a stale window cannot silently revert agent edits / other
+          // tabs' autosaves (those bump draftRevision but not version).
           const expectedVersion = get().tabs[tabId]?.version;
+          const expectedDraftRevision = get().tabs[tabId]?.draftRevision;
           const response = await fetch(
             `/api/workspaces/${workspaceId}/consoles/${tabId}`,
             {
@@ -1080,6 +1083,7 @@ export const useConsoleStore = create<ConsoleStore>()(
                 isPrivate:
                   access === undefined ? undefined : access === "private",
                 expectedVersion,
+                expectedDraftRevision,
                 // Realtime sync: identifies this tab so its own
                 // console.updated poke is suppressed.
                 clientId: realtimeClientId,

--- a/app/src/store/lib/remoteApplyGate.test.ts
+++ b/app/src/store/lib/remoteApplyGate.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  decideRemoteApply,
+  type RemoteApplyDecisionInput,
+} from "./remoteApplyGate";
+
+function input(
+  overrides: Partial<RemoteApplyDecisionInput>,
+): RemoteApplyDecisionInput {
+  return {
+    tabExists: true,
+    tabRevision: 1,
+    entryRevision: 2,
+    contentMatches: false,
+    unsavedLocalEdits: false,
+    ...overrides,
+  };
+}
+
+describe("decideRemoteApply", () => {
+  it("skips consoles that are not open in this window", () => {
+    expect(decideRemoteApply(input({ tabExists: false }))).toBe("skip");
+  });
+
+  it("skips stale entries (tab already at or past the entry revision)", () => {
+    expect(decideRemoteApply(input({ tabRevision: 2, entryRevision: 2 }))).toBe(
+      "skip",
+    );
+    expect(decideRemoteApply(input({ tabRevision: 5, entryRevision: 2 }))).toBe(
+      "skip",
+    );
+  });
+
+  it("treats a never-synced tab as revision 0 so the first entry applies", () => {
+    expect(
+      decideRemoteApply(input({ tabRevision: undefined, entryRevision: 1 })),
+    ).toBe("apply");
+  });
+
+  it("fast-forwards when local content already matches the server copy", () => {
+    expect(decideRemoteApply(input({ contentMatches: true }))).toBe(
+      "fast-forward",
+    );
+  });
+
+  it("fast-forwards on matching content EVEN with unsaved local edits (the buffer may be ahead; revision base must advance so the pending autosave passes its guard)", () => {
+    expect(
+      decideRemoteApply(
+        input({ contentMatches: true, unsavedLocalEdits: true }),
+      ),
+    ).toBe("fast-forward");
+  });
+
+  it("banners instead of silently merging when content diverges and the tab holds unsaved local edits", () => {
+    expect(decideRemoteApply(input({ unsavedLocalEdits: true }))).toBe(
+      "banner",
+    );
+  });
+
+  it("applies divergent content to clean tabs", () => {
+    expect(decideRemoteApply(input({}))).toBe("apply");
+  });
+
+  it("revision check wins over everything (no banner for stale entries even when dirty)", () => {
+    expect(
+      decideRemoteApply(
+        input({ tabRevision: 9, entryRevision: 3, unsavedLocalEdits: true }),
+      ),
+    ).toBe("skip");
+  });
+});

--- a/app/src/store/lib/remoteApplyGate.ts
+++ b/app/src/store/lib/remoteApplyGate.ts
@@ -1,0 +1,43 @@
+/**
+ * Pure decision logic for applying a remote console copy (revisions-sync
+ * entry) to a local tab. Extracted from realtimeStore so the truth table is
+ * unit-testable without browsers, stores or Monaco.
+ *
+ * Decisions:
+ *  - "skip"          — tab missing or already at/past the entry's revision;
+ *  - "fast-forward"  — local content already matches the server copy:
+ *                      advance revision/metadata but DO NOT touch the Monaco
+ *                      buffer (it may be ahead by in-flight keystrokes);
+ *  - "banner"        — contents diverge while the tab holds unsaved local
+ *                      edits: never merge silently, surface the affordance;
+ *  - "apply"         — clean tab, divergent content: replace store + buffer.
+ */
+
+export interface RemoteApplyDecisionInput {
+  /** The console is open as a tab in this window. */
+  tabExists: boolean;
+  /** Tab's last-synced draft revision (missing counts as 0 = never synced). */
+  tabRevision: number | undefined;
+  /** The server entry's draft revision. */
+  entryRevision: number;
+  /** Store content equals the entry content (connection metadata aside). */
+  contentMatches: boolean;
+  /**
+   * The tab holds local edits that are not yet persisted (recent keystrokes,
+   * queued/blocked autosave, or an unsaved explicit-save delta). NOTE: this
+   * is NOT the `isDirty` pinned-tab flag.
+   */
+  unsavedLocalEdits: boolean;
+}
+
+export type RemoteApplyDecision = "skip" | "fast-forward" | "banner" | "apply";
+
+export function decideRemoteApply(
+  input: RemoteApplyDecisionInput,
+): RemoteApplyDecision {
+  if (!input.tabExists) return "skip";
+  if ((input.tabRevision ?? 0) >= input.entryRevision) return "skip";
+  if (input.contentMatches) return "fast-forward";
+  if (input.unsavedLocalEdits) return "banner";
+  return "apply";
+}

--- a/app/src/store/realtimeStore.ts
+++ b/app/src/store/realtimeStore.ts
@@ -17,7 +17,7 @@ import { immer } from "zustand/middleware/immer";
 import { apiClient } from "../lib/api-client";
 import { getApiBasePath } from "../lib/api-base-path";
 import { realtimeClientId } from "../lib/realtime-client-id";
-import { useConsoleStore, hasRecentUserEdit } from "./consoleStore";
+import { useConsoleStore, hasUnsavedLocalEdits } from "./consoleStore";
 import { useConsoleTreeStore } from "./consoleTreeStore";
 import type { ConsoleRevisionsSyncResponse } from "../lib/api-types";
 
@@ -163,12 +163,18 @@ export const useRealtimeStore = create<RealtimeStore>()(
       const workspaceId = get().workspaceId;
       if (!workspaceId) return;
 
-      // Pull the persisted run artifact and render it through the existing
-      // results-panel pipeline (same events the client run_console used).
-      // The agent runs queries fast: this event often races the tab being
-      // opened by the create/open ui-intent, so wait briefly for the tab.
+      // The run bumped the console's draftRevision (the artifact is part of
+      // replicated draft state). Pull any content/revision change through
+      // the normal guarded sync path — NEVER fast-forward the revision base
+      // out-of-band, or the Monaco buffer ends up permanently stale.
+      scheduleSync();
+
+      // Separately, pull the persisted run artifact and render it through
+      // the existing results-panel pipeline (same events the client
+      // run_console used). The agent runs queries fast: this event often
+      // races the tab being opened by the create/open intent, so wait
+      // briefly for the tab.
       void (async () => {
-        const consoleStore = useConsoleStore.getState();
         for (
           let attempt = 0;
           attempt < 10 && !useConsoleStore.getState().tabs[event.consoleId];
@@ -178,12 +184,10 @@ export const useRealtimeStore = create<RealtimeStore>()(
         }
         if (!useConsoleStore.getState().tabs[event.consoleId]) return;
 
-        const res = await consoleStore.fetchConsoleContent(
-          workspaceId,
-          event.consoleId,
-        );
-        const lastRun = res?.lastRun;
-        if (!res?.success || !lastRun) return;
+        const lastRun = await useConsoleStore
+          .getState()
+          .fetchConsoleRunArtifact(workspaceId, event.consoleId);
+        if (!lastRun) return;
         window.dispatchEvent(
           new CustomEvent("console-execution-result", {
             detail: {
@@ -219,22 +223,7 @@ export const useRealtimeStore = create<RealtimeStore>()(
         consoleStore.setActiveTab(event.consoleId);
         return;
       }
-      void (async () => {
-        const data = await consoleStore.fetchConsoleContent(
-          workspaceId,
-          event.consoleId,
-        );
-        if (!data?.success) return;
-        consoleStore.openTab({
-          id: event.consoleId,
-          title: data.name || data.path || "Untitled",
-          content: data.content || "",
-          connectionId: data.connectionId,
-          databaseId: data.databaseId,
-          databaseName: data.databaseName,
-        });
-        consoleStore.setActiveTab(event.consoleId);
-      })();
+      void consoleStore.openConsoleFromServer(workspaceId, event.consoleId);
     };
 
     const handleEvent = (event: RealtimeEvent) => {
@@ -407,13 +396,17 @@ export const useRealtimeStore = create<RealtimeStore>()(
             const tab = store.tabs[entry.id];
             if (!tab) continue;
             if ((tab.draftRevision ?? 0) >= entry.draftRevision) continue;
-            // isDirty lags raw typing by a debounce; hasRecentUserEdit
-            // covers keystrokes inside that window so they are never
-            // silently replaced.
-            if (tab.isDirty || hasRecentUserEdit(entry.id)) {
-              // The one overlap case: remote update while this tab holds
-              // unsaved keystrokes. Never merge silently — surface the
-              // affordance; the next save's revision check backstops.
+            if (tab.content === entry.content) {
+              // Server content already matches this tab (echoed write from
+              // another tab, run-artifact revision bump, …). Fast-forward
+              // revision/metadata WITHOUT touching the Monaco buffer — it
+              // may be ahead by keystrokes that haven't autosaved yet.
+              store.fastForwardRemoteConsoleEntry(entry);
+            } else if (hasUnsavedLocalEdits(entry.id)) {
+              // Remote update while this tab holds unsaved local edits
+              // (recent keystrokes, queued/blocked autosave, or an unsaved
+              // explicit-save delta). Never merge silently — surface the
+              // affordance; revision-checked writes backstop the rest.
               store.setRemoteUpdate(entry.id, {
                 draftRevision: entry.draftRevision,
                 updatedBy: lastUpdatedByConsole.get(entry.id),

--- a/app/src/store/realtimeStore.ts
+++ b/app/src/store/realtimeStore.ts
@@ -18,6 +18,7 @@ import { apiClient } from "../lib/api-client";
 import { getApiBasePath } from "../lib/api-base-path";
 import { realtimeClientId } from "../lib/realtime-client-id";
 import { useConsoleStore, hasUnsavedLocalEdits } from "./consoleStore";
+import { decideRemoteApply } from "./lib/remoteApplyGate";
 import { useConsoleTreeStore } from "./consoleTreeStore";
 import type { ConsoleRevisionsSyncResponse } from "../lib/api-types";
 
@@ -442,26 +443,37 @@ export const useRealtimeStore = create<RealtimeStore>()(
           const store = useConsoleStore.getState();
           for (const entry of res.changed) {
             const tab = store.tabs[entry.id];
-            if (!tab) continue;
-            if ((tab.draftRevision ?? 0) >= entry.draftRevision) continue;
-            if (tab.content === entry.content) {
-              // Server content already matches this tab (echoed write from
-              // another tab, run-artifact revision bump, …). Fast-forward
-              // revision/metadata WITHOUT touching the Monaco buffer — it
-              // may be ahead by keystrokes that haven't autosaved yet.
-              store.fastForwardRemoteConsoleEntry(entry);
-            } else if (hasUnsavedLocalEdits(entry.id)) {
-              // Remote update while this tab holds unsaved local edits
-              // (recent keystrokes, queued/blocked autosave, or an unsaved
-              // explicit-save delta). Never merge silently — surface the
-              // affordance; revision-checked writes backstop the rest.
-              store.setRemoteUpdate(entry.id, {
-                draftRevision: entry.draftRevision,
-                updatedBy: lastUpdatedByConsole.get(entry.id),
-                kind: "updated",
-              });
-            } else {
-              store.applyRemoteConsoleEntry(entry);
+            const decision = decideRemoteApply({
+              tabExists: Boolean(tab),
+              tabRevision: tab?.draftRevision,
+              entryRevision: entry.draftRevision,
+              contentMatches: tab?.content === entry.content,
+              unsavedLocalEdits: hasUnsavedLocalEdits(entry.id),
+            });
+            switch (decision) {
+              case "skip":
+                break;
+              case "fast-forward":
+                // Server content already matches this tab (echoed write from
+                // another tab, run-artifact revision bump, …). Fast-forward
+                // revision/metadata WITHOUT touching the Monaco buffer — it
+                // may be ahead by keystrokes that haven't autosaved yet.
+                store.fastForwardRemoteConsoleEntry(entry);
+                break;
+              case "banner":
+                // Remote update while this tab holds unsaved local edits
+                // (recent keystrokes, queued/blocked autosave, or an unsaved
+                // explicit-save delta). Never merge silently — surface the
+                // affordance; revision-checked writes backstop the rest.
+                store.setRemoteUpdate(entry.id, {
+                  draftRevision: entry.draftRevision,
+                  updatedBy: lastUpdatedByConsole.get(entry.id),
+                  kind: "updated",
+                });
+                break;
+              case "apply":
+                store.applyRemoteConsoleEntry(entry);
+                break;
             }
           }
           for (const deletedId of res.deleted) {

--- a/app/src/store/realtimeStore.ts
+++ b/app/src/store/realtimeStore.ts
@@ -17,7 +17,11 @@ import { immer } from "zustand/middleware/immer";
 import { apiClient } from "../lib/api-client";
 import { getApiBasePath } from "../lib/api-base-path";
 import { realtimeClientId } from "../lib/realtime-client-id";
-import { useConsoleStore, hasUnsavedLocalEdits } from "./consoleStore";
+import {
+  useConsoleStore,
+  hasUnsavedLocalEdits,
+  hasBlockedDraftSave,
+} from "./consoleStore";
 import { decideRemoteApply } from "./lib/remoteApplyGate";
 import { useConsoleTreeStore } from "./consoleTreeStore";
 import type { ConsoleRevisionsSyncResponse } from "../lib/api-types";
@@ -77,10 +81,13 @@ let eventSource: EventSource | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let reconnectAttempt = 0;
 let syncDebounceTimer: ReturnType<typeof setTimeout> | null = null;
-let visibilityListenerInstalled = false;
+let wakeListenersInstalled = false;
 let watchdogTimer: ReturnType<typeof setInterval> | null = null;
+let deferredResyncTimer: ReturnType<typeof setTimeout> | null = null;
 /** Timestamp of the last frame seen on the SSE stream (any event type). */
 let lastEventAt = 0;
+/** Timestamp of the last wake-trigger handling (focus/visibility burst). */
+let lastWakeAt = 0;
 
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 30_000;
@@ -93,6 +100,24 @@ const SYNC_DEBOUNCE_MS = 250;
  */
 const WATCHDOG_STALE_MS = 70_000;
 const WATCHDOG_INTERVAL_MS = 15_000;
+/**
+ * Wake-trigger staleness: when the user comes back to this window (focus /
+ * visibility / pageshow), a stream that hasn't produced a frame within ~1.5
+ * heartbeats is treated as dead and reconnected immediately instead of
+ * waiting for the slow watchdog. Chrome can freeze background tabs and kill
+ * their sockets without firing an `error` event, so `status === "open"`
+ * cannot be trusted on wake.
+ */
+const WAKE_STALE_MS = 40_000;
+/** Collapse the burst of focus+visibility events one window switch fires. */
+const WAKE_THROTTLE_MS = 1_000;
+/**
+ * Re-evaluation delay when a remote update was deferred only because the
+ * user was mid-typing (keystroke recency / in-flight autosave). Slightly
+ * longer than consoleStore's USER_EDIT_RECENCY_MS (3s) so the re-run sees a
+ * quiescent tab and can apply cleanly without user interaction.
+ */
+const DEFERRED_RESYNC_MS = 3_500;
 
 /** Last known writer per console (from pokes) — labels the dirty affordance. */
 const lastUpdatedByConsole = new Map<string, string>();
@@ -114,6 +139,10 @@ function clearTimers(): void {
     clearTimeout(syncDebounceTimer);
     syncDebounceTimer = null;
   }
+  if (deferredResyncTimer) {
+    clearTimeout(deferredResyncTimer);
+    deferredResyncTimer = null;
+  }
 }
 
 export const useRealtimeStore = create<RealtimeStore>()(
@@ -124,6 +153,21 @@ export const useRealtimeStore = create<RealtimeStore>()(
         syncDebounceTimer = null;
         void get().syncRevisions();
       }, SYNC_DEBOUNCE_MS);
+    };
+
+    /**
+     * A remote update was deferred (banner) only because the user was
+     * mid-typing — re-run the sync once the recency window has passed so a
+     * now-quiescent tab converges on its own. Without this, a single remote
+     * edit landing inside the typing window leaves the tab stale until the
+     * user clicks the banner or another event happens to arrive.
+     */
+    const scheduleDeferredResync = () => {
+      if (deferredResyncTimer) return;
+      deferredResyncTimer = setTimeout(() => {
+        deferredResyncTimer = null;
+        void get().syncRevisions();
+      }, DEFERRED_RESYNC_MS);
     };
 
     const handleConsoleUpdated = (
@@ -359,23 +403,49 @@ export const useRealtimeStore = create<RealtimeStore>()(
       };
     };
 
-    const installVisibilityListener = () => {
-      if (visibilityListenerInstalled) return;
-      visibilityListenerInstalled = true;
+    /**
+     * The user came back to this window. IMPORTANT: `visibilitychange` alone
+     * is NOT enough — two side-by-side windows are both permanently
+     * "visible", so switching between them never fires it. Window `focus` is
+     * the trigger that matches how people actually multi-window;
+     * `pageshow`/`resume` cover BFCache restores and unfrozen tabs.
+     */
+    const wake = () => {
+      const now = Date.now();
+      // One window switch fires a burst (focus + visibilitychange); the
+      // first one does the work.
+      if (now - lastWakeAt < WAKE_THROTTLE_MS) return;
+      lastWakeAt = now;
+
+      const { workspaceId, status } = get();
+      if (!workspaceId) return;
+
+      const streamSilentMs = now - lastEventAt;
+      if (status === "open" && eventSource && streamSilentMs <= WAKE_STALE_MS) {
+        // Connection looks healthy; revisions may still have moved while we
+        // were backgrounded (throttled timers) — reconcile.
+        void get().syncRevisions();
+      } else {
+        // Stream missing, mid-backoff, or silent past ~1.5 heartbeats.
+        // `status === "open"` is NOT trustworthy here: Chrome freezes
+        // background tabs and can drop their sockets without an `error`
+        // event. Reconnect now; `onopen` runs the revision sync.
+        clearTimers();
+        reconnectAttempt = 0;
+        openConnection(workspaceId);
+      }
+    };
+
+    const installWakeListeners = () => {
+      if (wakeListenersInstalled) return;
+      wakeListenersInstalled = true;
       document.addEventListener("visibilitychange", () => {
-        if (document.visibilityState !== "visible") return;
-        const { workspaceId, status } = get();
-        if (!workspaceId) return;
-        if (status === "open") {
-          // Connection survived the background period; revisions may not have.
-          void get().syncRevisions();
-        } else {
-          // Skip the remaining backoff — the user is looking at the tab now.
-          clearTimers();
-          reconnectAttempt = 0;
-          openConnection(workspaceId);
-        }
+        if (document.visibilityState === "visible") wake();
       });
+      window.addEventListener("focus", wake);
+      window.addEventListener("pageshow", wake);
+      // Page Lifecycle API: fired when Chrome unfreezes a frozen tab.
+      document.addEventListener("resume", wake);
     };
 
     return {
@@ -392,7 +462,7 @@ export const useRealtimeStore = create<RealtimeStore>()(
           state.workspaceId = workspaceId;
           state.chatActivity = {};
         });
-        installVisibilityListener();
+        installWakeListeners();
         startWatchdog();
         openConnection(workspaceId);
       },
@@ -470,6 +540,18 @@ export const useRealtimeStore = create<RealtimeStore>()(
                   updatedBy: lastUpdatedByConsole.get(entry.id),
                   kind: "updated",
                 });
+                // Transient deferral (typing recency / autosave in flight)
+                // without a CONFIRMED conflict: re-evaluate shortly — once
+                // the tab is quiescent the decision flips to "apply" and the
+                // banner clears itself. Confirmed conflicts (blocked
+                // autosave after a real 409, or unsaved explicit-save
+                // deltas) wait for the user instead of polling.
+                if (
+                  !hasBlockedDraftSave(entry.id) &&
+                  !(tab?.isSaved ?? false)
+                ) {
+                  scheduleDeferredResync();
+                }
                 break;
               case "apply":
                 store.applyRemoteConsoleEntry(entry);

--- a/app/src/store/realtimeStore.ts
+++ b/app/src/store/realtimeStore.ts
@@ -77,11 +77,21 @@ let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let reconnectAttempt = 0;
 let syncDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 let visibilityListenerInstalled = false;
+let watchdogTimer: ReturnType<typeof setInterval> | null = null;
+/** Timestamp of the last frame seen on the SSE stream (any event type). */
+let lastEventAt = 0;
 
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 30_000;
 /** Batch bursts of pokes (e.g. agent patching repeatedly) into one pull. */
 const SYNC_DEBOUNCE_MS = 250;
+/**
+ * Liveness watchdog: the server heartbeats every 25s, so a stream that has
+ * been silent longer than this is dead even though no `error` event fired
+ * (NAT/proxy half-close, sleeping machine). 70s tolerates two missed beats.
+ */
+const WATCHDOG_STALE_MS = 70_000;
+const WATCHDOG_INTERVAL_MS = 15_000;
 
 /** Last known writer per console (from pokes) — labels the dirty affordance. */
 const lastUpdatedByConsole = new Map<string, string>();
@@ -268,6 +278,30 @@ export const useRealtimeStore = create<RealtimeStore>()(
       }, jitter);
     };
 
+    const stopWatchdog = () => {
+      if (watchdogTimer) {
+        clearInterval(watchdogTimer);
+        watchdogTimer = null;
+      }
+    };
+
+    // Detect silently-dead connections (no `error` event ever fires for a
+    // NAT/proxy half-close): if nothing — message, ping, hello — arrived
+    // within the stale window while we believe the stream is open, drop the
+    // socket and reconnect. The reconnect's `onopen` runs syncRevisions, so
+    // missed pokes are repaired by the normal poke-then-pull reconciliation.
+    const startWatchdog = () => {
+      if (watchdogTimer) return;
+      watchdogTimer = setInterval(() => {
+        if (!eventSource) return;
+        if (get().status !== "open") return;
+        if (Date.now() - lastEventAt <= WATCHDOG_STALE_MS) return;
+        eventSource.close();
+        eventSource = null;
+        scheduleReconnect();
+      }, WATCHDOG_INTERVAL_MS);
+    };
+
     const openConnection = (workspaceId: string) => {
       if (eventSource) {
         eventSource.close();
@@ -287,6 +321,7 @@ export const useRealtimeStore = create<RealtimeStore>()(
       source.onopen = () => {
         if (eventSource !== source) return;
         reconnectAttempt = 0;
+        lastEventAt = Date.now();
         set(state => {
           state.status = "open";
         });
@@ -297,11 +332,22 @@ export const useRealtimeStore = create<RealtimeStore>()(
 
       source.addEventListener("message", (e: MessageEvent) => {
         if (eventSource !== source) return;
+        lastEventAt = Date.now();
         try {
           handleEvent(JSON.parse(e.data) as RealtimeEvent);
         } catch {
           // Malformed event — the next revision sync corrects any gap.
         }
+      });
+
+      // Liveness only — these carry no payload the store consumes.
+      source.addEventListener("ping", () => {
+        if (eventSource !== source) return;
+        lastEventAt = Date.now();
+      });
+      source.addEventListener("hello", () => {
+        if (eventSource !== source) return;
+        lastEventAt = Date.now();
       });
 
       source.onerror = () => {
@@ -346,11 +392,13 @@ export const useRealtimeStore = create<RealtimeStore>()(
           state.chatActivity = {};
         });
         installVisibilityListener();
+        startWatchdog();
         openConnection(workspaceId);
       },
 
       disconnect: () => {
         clearTimers();
+        stopWatchdog();
         reconnectAttempt = 0;
         if (eventSource) {
           eventSource.close();

--- a/scripts/realtime-e2e/.gitignore
+++ b/scripts/realtime-e2e/.gitignore
@@ -1,0 +1,4 @@
+.env.e2e
+node_modules/
+shots/
+package-lock.json

--- a/scripts/realtime-e2e/01-draft-two-windows.mjs
+++ b/scripts/realtime-e2e/01-draft-two-windows.mjs
@@ -1,0 +1,71 @@
+/**
+ * Scenario 01 — draft console, two windows of the same user.
+ *
+ * Window A creates a draft and types; window B (simulated same-profile second
+ * window via localStorage copy + reload) must:
+ *   - NOT bump the server draftRevision just by opening the draft
+ *     (mount-resave regression);
+ *   - receive A's subsequent edits LIVE in its Monaco buffer;
+ * and A — the only typist — must never see a conflict banner or lose edits.
+ */
+import * as h from "./helpers.mjs";
+
+h.requireConfig();
+const b = await h.launch();
+const A = await h.newWindow(b);
+const B = await h.newWindow(b);
+
+// A: open a console and type (autosave creates the server draft)
+await A.page.locator('button:has-text("Open Console")').click();
+await A.page.waitForTimeout(800);
+const tabId = Object.keys(await h.getTabs(A.page))[0];
+await h.clickEditorAndType(A.page, tabId, "select 1 -- from window A");
+await A.page.waitForTimeout(3500); // autosave debounce + margin
+
+const srv1 = await h.apiGetConsole(tabId);
+h.check("A's draft autosaved", srv1.success && srv1.draftRevision >= 1, {
+  rev: srv1.draftRevision,
+});
+
+// B: hydrate the same tabs (same-profile second window) and reload
+const storeRaw = await A.page.evaluate(() =>
+  localStorage.getItem("console-store"),
+);
+await B.page.evaluate(raw => localStorage.setItem("console-store", raw), storeRaw);
+await B.page.reload({ waitUntil: "domcontentloaded" });
+await B.page.waitForTimeout(3000);
+
+const srv2 = await h.apiGetConsole(tabId);
+h.check(
+  "opening the draft in B does NOT bump draftRevision (no mount-resave)",
+  srv2.draftRevision === srv1.draftRevision,
+  { before: srv1.draftRevision, after: srv2.draftRevision },
+);
+
+// A types more — B must converge live
+await h.clickEditorAndType(A.page, tabId, "\n-- second line from A");
+const bEditor = await h.waitFor(
+  async () => {
+    const text = await h.getEditorTextByTabId(B.page, tabId);
+    return text?.includes("second line from A") ? text : null;
+  },
+  { timeoutMs: 12_000 },
+);
+h.check("B's Monaco received A's edit live", Boolean(bEditor), bEditor);
+
+const aTabs = await h.getTabs(A.page);
+h.check(
+  "A (the only typist) has no conflict banner",
+  !aTabs[tabId]?.remoteUpdate,
+  aTabs[tabId]?.remoteUpdate ?? "none",
+);
+
+const srv3 = await h.apiGetConsole(tabId);
+h.check(
+  "server persisted A's full content",
+  srv3.content?.includes("second line from A"),
+  JSON.stringify(srv3.content),
+);
+
+await b.close();
+h.finish("01-draft-two-windows");

--- a/scripts/realtime-e2e/02-saved-console.mjs
+++ b/scripts/realtime-e2e/02-saved-console.mjs
@@ -1,0 +1,106 @@
+/**
+ * Scenario 02 — saved console, two windows.
+ *
+ *   - A saves a console; B opens it from the tree.
+ *   - A edits + explicit-saves → B (clean) live-applies.
+ *   - B types (unsaved edits); A saves again → B gets the banner, no clobber.
+ *   - B (stale + dirty) hits Cmd+S → version-conflict dialog, never a silent
+ *     overwrite; server keeps A's copy until B chooses.
+ */
+import * as h from "./helpers.mjs";
+
+h.requireConfig();
+const b = await h.launch();
+const A = await h.newWindow(b);
+const name = h.uniqueName("SavedSync");
+
+// A: create, type, save via the first-time save dialog
+await A.page.locator('button:has-text("Open Console")').click();
+await A.page.waitForTimeout(800);
+const tabId = Object.keys(await h.getTabs(A.page))[0];
+await h.clickEditorAndType(A.page, tabId, "select 2 -- saved v1");
+await A.page.waitForTimeout(500);
+await A.page.keyboard.press("Control+s");
+await A.page.waitForTimeout(1200);
+await A.page.locator('div[role="dialog"] input').first().fill(name);
+await A.page
+  .locator('div[role="dialog"] button:has-text("Save")')
+  .last()
+  .click();
+await A.page.waitForTimeout(2500);
+const aTab = (await h.getTabs(A.page))[tabId];
+h.check("A's console saved", aTab?.isSaved === true, { filePath: aTab?.filePath });
+
+// B: open from the consoles tree
+const B = await h.newWindow(b);
+await B.page.mouse.click(17, 76); // consoles explorer rail icon
+await B.page.waitForTimeout(800);
+await B.page.locator(`text=${name}`).first().click();
+await B.page.waitForTimeout(2000);
+h.check("B opened it from the tree", Boolean((await h.getTabs(B.page))[tabId]));
+
+// A edits + saves (comment dialog) → B clean must live-apply
+await h.clickEditorAndType(A.page, tabId, "\n-- A edit 1");
+await A.page.keyboard.press("Control+s");
+await A.page.waitForTimeout(1500);
+const save1 = A.page.locator('div[role="dialog"] button:has-text("Save")').last();
+if (await save1.isVisible().catch(() => false)) await save1.click();
+const bGot = await h.waitFor(
+  async () => {
+    const text = await h.getEditorTextByTabId(B.page, tabId);
+    return text?.includes("A edit 1") ? text : null;
+  },
+  { timeoutMs: 12_000 },
+);
+h.check("B (clean) live-applied A's explicit save", Boolean(bGot), bGot);
+
+// B types; A saves again → B must get the banner, content untouched
+await h.clickEditorAndType(B.page, tabId, "\n-- B local edit");
+await B.page.waitForTimeout(500);
+await h.clickEditorAndType(A.page, tabId, "\n-- A edit 2");
+await A.page.keyboard.press("Control+s");
+await A.page.waitForTimeout(1500);
+const save2 = A.page.locator('div[role="dialog"] button:has-text("Save")').last();
+if (await save2.isVisible().catch(() => false)) await save2.click();
+await A.page.waitForTimeout(3500);
+
+const bTabs = await h.getTabs(B.page);
+const bEditor = await h.getEditorTextByTabId(B.page, tabId);
+h.check(
+  "B (dirty) got the banner instead of a silent replace",
+  Boolean(bTabs[tabId]?.remoteUpdate),
+  bTabs[tabId]?.remoteUpdate,
+);
+h.check(
+  "B's local edit was NOT clobbered",
+  bEditor?.includes("B local edit") && !bEditor?.includes("A edit 2"),
+  bEditor,
+);
+
+// B (stale + dirty) saves → conflict dialog; server must keep A's copy
+await B.page
+  .locator(`[data-mako-tab-id="${tabId}"] .monaco-editor`)
+  .first()
+  .click();
+await B.page.keyboard.press("Control+s");
+await B.page.waitForTimeout(1500);
+const bSave = B.page.locator('div[role="dialog"] button:has-text("Save")').last();
+if (await bSave.isVisible().catch(() => false)) await bSave.click();
+await B.page.waitForTimeout(2500);
+const dialogText = (
+  await B.page.locator('div[role="dialog"]').allTextContents().catch(() => [])
+).join(" ");
+h.check(
+  "B's stale save hit the version-conflict dialog",
+  dialogText.includes("Console Was Modified"),
+  dialogText.slice(0, 120),
+);
+const srv = await h.apiGetConsole(tabId);
+h.check(
+  "server still has A's copy (no silent overwrite)",
+  srv.content?.includes("A edit 2") && !srv.content?.includes("B local edit"),
+  JSON.stringify(srv.content),
+);
+
+await b.close();
+h.finish("02-saved-console");

--- a/scripts/realtime-e2e/03-agent-modalities.mjs
+++ b/scripts/realtime-e2e/03-agent-modalities.mjs
@@ -1,0 +1,140 @@
+/**
+ * Scenario 03 — every agent console modality against an attached window.
+ *
+ *   - create_console → tab appears in the chat's window;
+ *   - modify_console + run_console in one turn → Monaco shows the NEW query
+ *     (not a stale buffer) AND the results render;
+ *   - set_console_connection → tab metadata follows;
+ *   - user types after the agent → the edit persists (autosave alive) and the
+ *     next agent patch lands on top of it (no lost updates in either
+ *     direction);
+ *   - open_console → activates the tab.
+ */
+import * as h from "./helpers.mjs";
+
+h.requireConfig();
+const b = await h.launch();
+const A = await h.newWindow(b);
+const chat = await h.getActiveChat(A.page);
+
+// (a) create
+await h.apiAgentChat(chat.chatId, [
+  {
+    tool: "create_console",
+    input: {
+      title: "AgentScenario",
+      content: "db.users.find({})",
+      connectionId: h.CONN_ID,
+    },
+  },
+]);
+const created = await h.waitFor(async () => {
+  const tabs = await h.getTabs(A.page);
+  return Object.values(tabs).find(t => t.title === "AgentScenario");
+});
+h.check("create_console opened a tab in the attached window", Boolean(created));
+const id = created?.id;
+
+// (b) modify + run in one turn
+await h.apiAgentChat(chat.chatId, [
+  {
+    tool: "modify_console",
+    input: {
+      consoleId: id,
+      action: "replace",
+      content: "db.users.find({ age: { $gt: 30 } })",
+    },
+  },
+  { tool: "run_console", input: { consoleId: id } },
+]);
+const editorAfterRun = await h.waitFor(
+  async () => {
+    const text = await h.getEditorTextByTabId(A.page, id);
+    return text?.includes("$gt") ? text : null;
+  },
+  { timeoutMs: 12_000 },
+);
+h.check(
+  "Monaco shows the agent's NEW query after modify+run",
+  Boolean(editorAfterRun),
+  editorAfterRun,
+);
+const srvB = await h.apiGetConsole(id);
+const tabB = (await h.getTabs(A.page))[id];
+h.check(
+  "store revision matches the server after the run",
+  tabB?.draftRevision === srvB.draftRevision,
+  { store: tabB?.draftRevision, server: srvB.draftRevision },
+);
+h.check(
+  "the run kept the tab a DRAFT (autosave must stay alive)",
+  tabB?.isSaved === false,
+  { isSaved: tabB?.isSaved },
+);
+const results = await A.page
+  .locator(`[data-mako-tab-id="${id}"]`)
+  .locator("text=/Alice|Carol/i")
+  .allTextContents()
+  .catch(() => []);
+h.check("run results rendered in the results panel", results.length > 0, results);
+
+// (c) user types after the agent → must persist; then agent appends on top
+await h.clickEditorAndType(A.page, id, "\n// user note");
+await A.page.waitForTimeout(3500); // autosave
+const srvC = await h.apiGetConsole(id);
+h.check(
+  "user's post-agent edit persisted (autosave alive)",
+  srvC.content?.includes("user note"),
+  JSON.stringify(srvC.content),
+);
+await h.apiAgentChat(chat.chatId, [
+  {
+    tool: "modify_console",
+    input: { consoleId: id, action: "append", content: "\n// agent appended" },
+  },
+]);
+const converged = await h.waitFor(
+  async () => {
+    const text = await h.getEditorTextByTabId(A.page, id);
+    return text?.includes("user note") && text?.includes("agent appended")
+      ? text
+      : null;
+  },
+  { timeoutMs: 12_000 },
+);
+h.check(
+  "agent append landed ON TOP of the user edit and reached Monaco",
+  Boolean(converged),
+  converged,
+);
+
+// (d) set_console_connection (re-attach to the same connection but with an
+// explicit databaseName) → tab metadata follows
+await h.apiAgentChat(chat.chatId, [
+  {
+    tool: "set_console_connection",
+    input: { consoleId: id, connectionId: h.CONN_ID, databaseName: "sampledb" },
+  },
+]);
+const tabD = await h.waitFor(async () => {
+  const t = (await h.getTabs(A.page))[id];
+  return t?.databaseName === "sampledb" ? t : null;
+});
+h.check(
+  "set_console_connection propagated to the tab",
+  Boolean(tabD),
+  tabD && { databaseName: tabD.databaseName },
+);
+
+// (e) open_console for an existing console → activates the tab
+await h.apiAgentChat(chat.chatId, [
+  { tool: "open_console", input: { consoleId: id } },
+]);
+const active = await h.waitFor(async () => {
+  const s = await h.getConsoleStore(A.page);
+  return s?.activeTabId === id;
+});
+h.check("open_console activated the tab", Boolean(active));
+
+await b.close();
+h.finish("03-agent-modalities");

--- a/scripts/realtime-e2e/04-dead-sse.mjs
+++ b/scripts/realtime-e2e/04-dead-sse.mjs
@@ -1,0 +1,94 @@
+/**
+ * Scenario 04 — silently-dead realtime SSE (NAT/proxy half-close: the
+ * browser never gets an `error` event).
+ *
+ *   - A console created by the agent through the chat UI must STILL appear
+ *     (in-band tool-result opening rides the resumable chat stream, not the
+ *     realtime poke channel) and its run results must render;
+ *   - the liveness watchdog must detect the dead stream and reconnect within
+ *     ~85s (70s stale + 15s sweep), after which edits made by another window
+ *     during the dead period are repaired by the reconnect revision sync.
+ *
+ * NOTE: this scenario takes ~2 minutes by design (watchdog window).
+ */
+import * as h from "./helpers.mjs";
+
+h.requireConfig();
+const b = await h.launch();
+const A = await h.newWindow(b);
+
+// A scratch console whose pokes will be missed while the stream is dead.
+await A.page.locator('button:has-text("Open Console")').click();
+await A.page.waitForTimeout(800);
+const scratchId = Object.keys(await h.getTabs(A.page))[0];
+await h.clickEditorAndType(A.page, scratchId, "select 1 -- watchdog probe");
+await A.page.waitForTimeout(3000);
+
+await h.killRealtimeSilently(A.page);
+
+// (1) agent create+run through the chat UI while the realtime SSE is dead
+await h.uiAgentChat(A.page, [
+  {
+    tool: "create_console",
+    input: {
+      title: "InBandConsole",
+      content: "db.users.find({})",
+      connectionId: h.CONN_ID,
+    },
+  },
+  { tool: "run_console", input: { consoleId: "$prev.consoleId" } },
+]);
+const inband = await h.waitFor(
+  async () => {
+    const tabs = await h.getTabs(A.page);
+    return Object.values(tabs).find(t => t.title === "InBandConsole");
+  },
+  { timeoutMs: 15_000 },
+);
+h.check(
+  "console created during dead SSE appears via the in-band chat stream",
+  Boolean(inband),
+);
+if (inband) {
+  const results = await h.waitFor(
+    async () =>
+      (
+        await A.page
+          .locator(`[data-mako-tab-id="${inband.id}"]`)
+          .locator("text=/Alice|Carol/i")
+          .allTextContents()
+          .catch(() => [])
+      ).length > 0,
+    { timeoutMs: 10_000 },
+  );
+  h.check("its run results rendered despite the dead poke channel", results);
+}
+
+// (2) another window edits the scratch console while A's stream is dead
+const B = await h.newWindow(b);
+const storeRaw = await A.page.evaluate(() =>
+  localStorage.getItem("console-store"),
+);
+await B.page.evaluate(raw => localStorage.setItem("console-store", raw), storeRaw);
+await B.page.reload({ waitUntil: "domcontentloaded" });
+await B.page.waitForTimeout(2500);
+await h.activateTabByTitle(B.page, "New Console");
+await h.clickEditorAndType(B.page, scratchId, "\n-- edited by B while A dead");
+await B.page.waitForTimeout(3500);
+
+// (3) the watchdog must reconnect and repair A within ~100s
+const repaired = await h.waitFor(
+  async () => {
+    const text = await h.getEditorTextByTabId(A.page, scratchId);
+    return text?.includes("edited by B while A dead") ? text : null;
+  },
+  { timeoutMs: 110_000, stepMs: 5000 },
+);
+h.check(
+  "watchdog reconnected and the revision sync repaired A's editor",
+  Boolean(repaired),
+  repaired,
+);
+
+await b.close();
+h.finish("04-dead-sse");

--- a/scripts/realtime-e2e/05-stale-save-dual-guard.mjs
+++ b/scripts/realtime-e2e/05-stale-save-dual-guard.mjs
@@ -1,0 +1,95 @@
+/**
+ * Scenario 05 — stale-window Cmd+S vs agent edits (dual save guard).
+ *
+ * Agent modify_console bumps draftRevision but NOT version. A window holding
+ * unsaved edits from before the agent's change must get the version-conflict
+ * dialog on Cmd+S — previously the version-only guard passed and the save
+ * silently reverted the agent's edit.
+ */
+import * as h from "./helpers.mjs";
+
+h.requireConfig();
+const b = await h.launch();
+const A = await h.newWindow(b);
+const name = h.uniqueName("DualGuard");
+
+// A: create + save
+await A.page.locator('button:has-text("Open Console")').click();
+await A.page.waitForTimeout(800);
+const tabId = Object.keys(await h.getTabs(A.page))[0];
+await h.clickEditorAndType(A.page, tabId, "select 10 -- base");
+await A.page.waitForTimeout(500);
+await A.page.keyboard.press("Control+s");
+await A.page.waitForTimeout(1200);
+await A.page.locator('div[role="dialog"] input').first().fill(name);
+await A.page
+  .locator('div[role="dialog"] button:has-text("Save")')
+  .last()
+  .click();
+await A.page.waitForTimeout(2500);
+
+// B: open from tree, type an UNSAVED local edit
+const B = await h.newWindow(b);
+await B.page.mouse.click(17, 76);
+await B.page.waitForTimeout(800);
+await B.page.locator(`text=${name}`).first().click();
+await B.page.waitForTimeout(2000);
+await h.clickEditorAndType(B.page, tabId, "\n-- B local unsaved edit");
+await B.page.waitForTimeout(1000);
+
+// Agent rewrites the console (draftRevision bump only)
+const chat = await h.getActiveChat(A.page);
+await h.apiAgentChat(chat.chatId, [
+  {
+    tool: "modify_console",
+    input: { consoleId: tabId, action: "replace", content: "select 99 -- AGENT EDIT" },
+  },
+]);
+await B.page.waitForTimeout(4000);
+h.check(
+  "B (holding unsaved edits) got the banner for the agent edit",
+  Boolean((await h.getTabs(B.page))[tabId]?.remoteUpdate),
+);
+
+// B saves while stale → must hit the conflict dialog, not silently revert
+await B.page
+  .locator(`[data-mako-tab-id="${tabId}"] .monaco-editor`)
+  .first()
+  .click();
+await B.page.keyboard.press("Control+s");
+await B.page.waitForTimeout(1500);
+const commentSave = B.page
+  .locator('div[role="dialog"] button:has-text("Save")')
+  .last();
+if (await commentSave.isVisible().catch(() => false)) await commentSave.click();
+await B.page.waitForTimeout(2500);
+const dialogText = (
+  await B.page.locator('div[role="dialog"]').allTextContents().catch(() => [])
+).join(" ");
+h.check(
+  "stale Cmd+S hit the version-conflict dialog",
+  dialogText.includes("Console Was Modified"),
+  dialogText.slice(0, 120),
+);
+const srv = await h.apiGetConsole(tabId);
+h.check(
+  "server kept the AGENT edit (no silent revert)",
+  srv.content?.includes("AGENT EDIT") && !srv.content?.includes("B local"),
+  JSON.stringify(srv.content),
+);
+
+// Resolve with "Discard Mine & Load Latest" → B converges
+const loadLatest = B.page.locator(
+  'button:has-text("Discard Mine & Load Latest")',
+);
+if (await loadLatest.isVisible().catch(() => false)) {
+  await loadLatest.click();
+  const converged = await h.waitFor(async () => {
+    const text = await h.getEditorTextByTabId(B.page, tabId);
+    return text?.includes("AGENT EDIT") ? text : null;
+  });
+  h.check("B converged after Load Latest", Boolean(converged), converged);
+}
+
+await b.close();
+h.finish("05-stale-save-dual-guard");

--- a/scripts/realtime-e2e/06-wake-triggers.mjs
+++ b/scripts/realtime-e2e/06-wake-triggers.mjs
@@ -1,0 +1,111 @@
+/**
+ * Scenario 06 — wake triggers for side-by-side windows.
+ *
+ * Two side-by-side windows are both permanently "visible", so switching
+ * between them never fires visibilitychange. This scenario verifies:
+ *   (1) a window FOCUS event repairs missed updates in ONE switch, even on
+ *       a silently-dead stream (the user's "I have to switch several times
+ *       to wake it up" report);
+ *   (2) a focus arriving while the stream has been silent past the
+ *       staleness window forces an immediate reconnect (no 70s watchdog
+ *       wait);
+ *   (3) a remote update deferred only by typing recency self-applies once
+ *       the tab goes quiescent (deferred re-evaluation) — no banner left
+ *       behind, no user interaction needed.
+ */
+import * as h from "./helpers.mjs";
+
+h.requireConfig();
+const b = await h.launch();
+const A = await h.newWindow(b);
+const B = await h.newWindow(b);
+
+// Shared draft: A creates it, B hydrates the same tab set.
+await A.page.locator('button:has-text("Open Console")').click();
+await A.page.waitForTimeout(800);
+const tabId = Object.keys(await h.getTabs(A.page))[0];
+await h.clickEditorAndType(A.page, tabId, "select 1 -- wake base");
+await A.page.waitForTimeout(3500);
+const storeRaw = await A.page.evaluate(() =>
+  localStorage.getItem("console-store"),
+);
+await B.page.evaluate(raw => localStorage.setItem("console-store", raw), storeRaw);
+await B.page.reload({ waitUntil: "domcontentloaded" });
+await B.page.waitForTimeout(3000);
+
+// ---- (1) dead stream + ONE focus event = converged content ---------------
+await h.killRealtimeSilently(B.page);
+await h.clickEditorAndType(A.page, tabId, "\n-- A edit while B dead");
+await A.page.waitForTimeout(3500); // autosave + (lost) poke
+
+let bText = await h.getEditorTextByTabId(B.page, tabId);
+h.check(
+  "B is stale while its stream is silently dead (precondition)",
+  !bText?.includes("A edit while B dead"),
+  bText,
+);
+
+await B.page.evaluate(() => window.dispatchEvent(new Event("focus")));
+const afterFocus = await h.waitFor(
+  async () => {
+    const text = await h.getEditorTextByTabId(B.page, tabId);
+    return text?.includes("A edit while B dead") ? text : null;
+  },
+  { timeoutMs: 8_000 },
+);
+h.check(
+  "ONE focus event repaired B's content (no repeated switching needed)",
+  Boolean(afterFocus),
+  afterFocus,
+);
+
+// ---- (2) focus during a stale-silent stream forces reconnect -------------
+// The stream is still the dead one (focus only reconciled). Backdate
+// activity by waiting is too slow (40s), so verify the mechanism: count
+// EventSource instances, dispatch focus after the staleness window via a
+// clock-independent check — here we simply wait out the watchdog-free
+// window using the wake path: kill again, wait 45s (> WAKE_STALE_MS),
+// then focus and expect a NEW EventSource within a couple of seconds
+// (the 70s watchdog alone could not have fired yet... it requires 70s).
+const esBefore = await B.page.evaluate(() => window.__esInstances.length);
+await B.page.waitForTimeout(45_000);
+await B.page.evaluate(() => window.dispatchEvent(new Event("focus")));
+const reconnected = await h.waitFor(
+  async () =>
+    (await B.page.evaluate(() => window.__esInstances.length)) > esBefore,
+  { timeoutMs: 5_000 },
+);
+h.check(
+  "focus on a silent-past-threshold stream reconnected immediately (<5s, not the 70s watchdog)",
+  Boolean(reconnected),
+  { esBefore },
+);
+
+// ---- (3) typing-recency deferral self-applies on quiescence ---------------
+// B types a char and immediately undoes it (recency marked, content back to
+// base, autosave hash-skips). A edits inside B's 3s recency window → B
+// defers to the banner; after the window passes, the deferred re-sync must
+// apply and clear the banner with NO user interaction.
+await B.page.waitForTimeout(2000); // let the reconnect's sync settle
+await h.clickEditorAndType(B.page, tabId, "x", { append: true });
+await B.page.keyboard.press("Backspace");
+await h.clickEditorAndType(A.page, tabId, "\n-- A edit during B recency");
+const autoApplied = await h.waitFor(
+  async () => {
+    const text = await h.getEditorTextByTabId(B.page, tabId);
+    const tabs = await h.getTabs(B.page);
+    return text?.includes("A edit during B recency") &&
+      !tabs[tabId]?.remoteUpdate
+      ? text
+      : null;
+  },
+  { timeoutMs: 15_000 },
+);
+h.check(
+  "update deferred by typing recency self-applied once B went quiescent (banner cleared)",
+  Boolean(autoApplied),
+  autoApplied,
+);
+
+await b.close();
+h.finish("06-wake-triggers");

--- a/scripts/realtime-e2e/README.md
+++ b/scripts/realtime-e2e/README.md
@@ -1,0 +1,94 @@
+# Realtime console sync — e2e harness
+
+Manual end-to-end scenarios for the server-authoritative draft + poke-then-pull
+realtime sync (PR #477 / issue #475 architecture). Two real browser windows,
+real Monaco buffers, the real agent pipeline — driven deterministically by a
+**mock AI gateway** with scripted tool calls instead of an LLM.
+
+Each scenario asserts equality across the three replicas that matter
+(**Monaco buffer ↔ zustand store ↔ server document**), so "looks fine" cannot
+hide divergence. Run it whenever the sync layer changes:
+
+- `consoleStore` / `realtimeStore` (apply gates, autosave, conflicts)
+- `routes/consoles.ts` (PUT guards, revisions-sync)
+- `server-console-tools.ts` / `console-execution.service.ts`
+- `Chat.tsx` in-band console opening, `Console.tsx` editor wiring
+
+## What is covered
+
+| Scenario | Asserts |
+|---|---|
+| `01-draft-two-windows` | opening a draft elsewhere doesn't bump revisions; live A→B propagation; typist never sees a false conflict |
+| `02-saved-console` | clean windows live-apply explicit saves; dirty windows get the banner (no clobber); stale Cmd+S → conflict dialog |
+| `03-agent-modalities` | create/modify/run/set-connection/open: Monaco shows agent edits, results render, user↔agent edits interleave without loss, tab stays a draft |
+| `04-dead-sse` | consoles created during a silently-dead SSE still appear (in-band chat stream); liveness watchdog reconnects ≲85s and repairs missed pokes (~2 min, real time) |
+| `05-stale-save-dual-guard` | agent edits (draftRevision-only) can't be silently reverted by a stale Cmd+S (dual version+draftRevision guard) |
+
+## One-time setup
+
+1. **MongoDB as a single-node replica set** (transactions are required):
+
+   ```bash
+   mongod --dbpath ~/mongo-data --port 27018 --replSet rs0 --fork --logpath ~/mongod.log
+   mongosh --port 27018 --eval 'rs.initiate({_id:"rs0",members:[{_id:0,host:"127.0.0.1:27018"}]})'
+   # seed sample data the scenarios query:
+   mongosh --port 27018 sampledb --eval 'db.users.insertMany([{name:"Alice",age:31},{name:"Bob",age:27},{name:"Carol",age:45}])'
+   ```
+
+2. **Root `.env`** — point the API at the replica set and the mock gateway:
+
+   ```env
+   DATABASE_URL=mongodb://localhost:27018/mako?replicaSet=rs0
+   AI_GATEWAY_API_KEY=dummy-key-for-local-testing
+   AI_GATEWAY_BASE_URL=http://localhost:9099
+   SESSION_SECRET=<openssl rand -hex 32>
+   ENCRYPTION_KEY=<openssl rand -hex 32>
+   ```
+
+3. **Run the stack** (three processes):
+
+   ```bash
+   pnpm api:dev          # API on :8080
+   pnpm app:dev          # Vite on :5173
+   node scripts/realtime-e2e/mock-gateway.mjs   # mock gateway on :9099
+   ```
+
+4. **Provision a user + workspace + connection** (writes `.env.e2e` here):
+
+   ```bash
+   cd scripts/realtime-e2e && npm install
+   node setup.mjs register e2e@example.com 'Password123!'
+   # without SendGrid configured the code is only stored in Mongo:
+   mongosh --port 27018 mako --eval 'db.emailverifications.find().sort({createdAt:-1}).limit(1).toArray()'
+   node setup.mjs verify e2e@example.com <code>
+   node setup.mjs provision <session> 'mongodb://localhost:27018/sampledb?replicaSet=rs0' sampledb
+   ```
+
+5. A Chrome/Chromium binary. Default path is `/usr/local/bin/google-chrome`;
+   override with `MAKO_E2E_CHROME=/path/to/chrome`.
+
+## Running
+
+```bash
+node run-all.mjs          # everything (~4 min)
+node 01-draft-two-windows.mjs   # one scenario
+```
+
+Each check prints `[PASS]`/`[FAIL]`; a scenario exits non-zero on any failure.
+Screenshots land in `shots/`.
+
+## Notes & gotchas
+
+- **Vite HMR caveat:** some scenarios read live stores via
+  `import("/src/store/…")` from the page. After editing store files, restart
+  the Vite dev server first — HMR's `?t=` stamps would otherwise give the
+  probe a *second* module instance with empty state.
+- The harness is deliberately **not** wired into CI: it needs a full local
+  stack (replica-set Mongo, two dev servers, Chrome). It is the regression
+  net for the realtime layer — run it before merging changes there.
+- Scenario 04 takes ~2 minutes of wall-clock time by design (the SSE
+  liveness watchdog fires after 70s of silence + ≤15s sweep interval).
+- The mock gateway protocol targets `@ai-sdk/gateway`'s LanguageModelV3
+  endpoint (`POST /language-model`, SSE stream parts). If the gateway SDK
+  majors, re-check the stream part shapes in
+  `node_modules/@ai-sdk/provider/dist/index.d.ts`.

--- a/scripts/realtime-e2e/helpers.mjs
+++ b/scripts/realtime-e2e/helpers.mjs
@@ -1,0 +1,253 @@
+/**
+ * Shared harness for the realtime-sync scenarios.
+ *
+ * Each "window" is its own browser context (isolated localStorage) carrying
+ * the same session cookie. Includes:
+ *  - SSE instrumentation (window.__sseLog / window.__esInstances) so tests
+ *    can observe and kill the realtime stream;
+ *  - console-store snapshots via the zustand persist localStorage key;
+ *  - Monaco buffer readers via window.monaco.editor.getEditors();
+ *  - direct API helpers (server ground truth + scripted agent turns).
+ *
+ * Configuration comes from scripts/realtime-e2e/.env.e2e (see setup.mjs).
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright-core";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+function loadEnvFile() {
+  const file = path.join(here, ".env.e2e");
+  if (!fs.existsSync(file)) return {};
+  const out = {};
+  for (const line of fs.readFileSync(file, "utf8").split("\n")) {
+    const m = line.match(/^([A-Z0-9_]+)=(.*)$/);
+    if (m) out[m[1]] = m[2];
+  }
+  return out;
+}
+const fileEnv = loadEnvFile();
+const env = key => process.env[key] || fileEnv[key];
+
+export const APP = env("MAKO_E2E_APP_URL") || "http://localhost:5173";
+export const API = env("MAKO_E2E_API_URL") || "http://localhost:8080";
+export const WS_ID = env("MAKO_E2E_WORKSPACE_ID");
+export const CONN_ID = env("MAKO_E2E_CONNECTION_ID");
+export const SESSION = env("MAKO_E2E_SESSION");
+export const CHROME =
+  env("MAKO_E2E_CHROME") || "/usr/local/bin/google-chrome";
+export const SHOTS_DIR = path.join(here, "shots");
+
+export function requireConfig() {
+  const missing = [];
+  if (!WS_ID) missing.push("MAKO_E2E_WORKSPACE_ID");
+  if (!CONN_ID) missing.push("MAKO_E2E_CONNECTION_ID");
+  if (!SESSION) missing.push("MAKO_E2E_SESSION");
+  if (missing.length) {
+    throw new Error(
+      `Missing config (${missing.join(", ")}). Run setup.mjs first — see README.md.`,
+    );
+  }
+}
+
+export async function launch() {
+  return chromium.launch({
+    executablePath: CHROME,
+    headless: true,
+    args: ["--no-sandbox", "--window-size=1500,950"],
+  });
+}
+
+export async function newWindow(browser, { session = SESSION } = {}) {
+  const ctx = await browser.newContext({
+    viewport: { width: 1500, height: 950 },
+  });
+  await ctx.addCookies([
+    { name: "auth_session", value: session, domain: "localhost", path: "/" },
+  ]);
+  // Capture every SSE event the app receives + keep handles so tests can
+  // simulate silently-dead connections (close() fires no error event).
+  await ctx.addInitScript(() => {
+    window.__sseLog = [];
+    window.__esInstances = [];
+    const Orig = window.EventSource;
+    window.EventSource = function (url, opts) {
+      const es = new Orig(url, opts);
+      window.__esInstances.push(es);
+      const log = type => e =>
+        window.__sseLog.push({
+          url: String(url),
+          type,
+          data: e.data,
+          ts: Date.now(),
+        });
+      for (const t of ["message", "hello", "ping", "open", "error"]) {
+        es.addEventListener(t, log(t));
+      }
+      return es;
+    };
+    window.EventSource.prototype = Orig.prototype;
+    Object.defineProperty(window.EventSource, "CONNECTING", { value: 0 });
+    Object.defineProperty(window.EventSource, "OPEN", { value: 1 });
+    Object.defineProperty(window.EventSource, "CLOSED", { value: 2 });
+  });
+  const page = await ctx.newPage();
+  await page.goto(APP, { waitUntil: "domcontentloaded" });
+  // networkidle never settles: the realtime SSE connection stays open.
+  await page.waitForTimeout(3000);
+  return { ctx, page };
+}
+
+// ---------- console-store introspection (zustand persist localStorage) ----
+export async function getConsoleStore(page) {
+  return page.evaluate(() => {
+    const raw = localStorage.getItem("console-store");
+    return raw ? JSON.parse(raw).state : null;
+  });
+}
+
+export async function getTabs(page) {
+  const s = await getConsoleStore(page);
+  return s ? s.tabs : {};
+}
+
+// ---------- Monaco access ---------------------------------------------------
+export async function getEditorTextByTabId(page, tabId) {
+  return page.evaluate(tid => {
+    const editors = window.monaco?.editor?.getEditors?.() || [];
+    for (const ed of editors) {
+      const node = ed.getContainerDomNode?.();
+      if (node && node.closest(`[data-mako-tab-id="${tid}"]`)) {
+        return ed.getValue();
+      }
+    }
+    return null;
+  }, tabId);
+}
+
+export async function activateTabByTitle(page, title) {
+  await page.locator(`[role="tab"]:has-text("${title}")`).first().click();
+  await page.waitForTimeout(400);
+}
+
+export async function clickEditorAndType(
+  page,
+  tabId,
+  text,
+  { append = true } = {},
+) {
+  const container = page
+    .locator(`[data-mako-tab-id="${tabId}"] .monaco-editor`)
+    .first();
+  await container.click();
+  if (append) {
+    await page.keyboard.press("Control+End");
+  }
+  await page.keyboard.type(text, { delay: 15 });
+}
+
+export async function killRealtimeSilently(page) {
+  await page.evaluate(() => {
+    for (const es of window.__esInstances) es.close();
+  });
+}
+
+export async function screenshot(page, name) {
+  fs.mkdirSync(SHOTS_DIR, { recursive: true });
+  await page.screenshot({ path: path.join(SHOTS_DIR, `${name}.png`) });
+}
+
+export async function waitMs(ms) {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+// ---------- API helpers (server ground truth + scripted agent) -------------
+export async function apiGetConsole(consoleId) {
+  const res = await fetch(
+    `${API}/api/workspaces/${WS_ID}/consoles/content?id=${consoleId}`,
+    { headers: { cookie: `auth_session=${SESSION}` } },
+  );
+  return res.json();
+}
+
+/** Drive a scripted agent turn directly against the API (mock gateway). */
+export async function apiAgentChat(chatId, script, opts = {}) {
+  const text = `MOCKSCRIPT::${JSON.stringify(script)}`;
+  const res = await fetch(`${API}/api/agent/chat`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      cookie: `auth_session=${SESSION}`,
+    },
+    body: JSON.stringify({
+      chatId,
+      workspaceId: WS_ID,
+      messages: [
+        { id: `m-${Date.now()}`, role: "user", parts: [{ type: "text", text }] },
+      ],
+      ...opts,
+    }),
+  });
+  return res.text(); // drain the SSE
+}
+
+/** Send a scripted agent turn through the browser's chat UI (in-band path). */
+export async function uiAgentChat(page, script) {
+  const input = page.locator('textarea[placeholder="Ask Chat..."]');
+  await input.click();
+  await input.fill(`MOCKSCRIPT::${JSON.stringify(script)}`);
+  await page.keyboard.press("Enter");
+}
+
+export async function getActiveChat(page) {
+  return page.evaluate(() =>
+    JSON.parse(sessionStorage.getItem("mako:active-chat") || "{}"),
+  );
+}
+
+export function oid() {
+  const hex = "0123456789abcdef";
+  let s = "";
+  for (let i = 0; i < 24; i++) s += hex[Math.floor(Math.random() * 16)];
+  return s;
+}
+
+export function uniqueName(prefix) {
+  return `${prefix}-${Date.now().toString(36)}`;
+}
+
+// ---------- assertions ------------------------------------------------------
+let failures = 0;
+
+export function check(label, condition, detail) {
+  const status = condition ? "PASS" : "FAIL";
+  if (!condition) failures += 1;
+  // eslint-disable-next-line no-console -- standalone dev tool, not API code
+  console.log(
+    `  [${status}] ${label}${detail !== undefined ? ` — ${typeof detail === "string" ? detail : JSON.stringify(detail)}` : ""}`,
+  );
+}
+
+export function finish(scenario) {
+  // eslint-disable-next-line no-console -- standalone dev tool, not API code
+  console.log(
+    failures === 0
+      ? `\n${scenario}: ALL CHECKS PASSED`
+      : `\n${scenario}: ${failures} CHECK(S) FAILED`,
+  );
+  process.exitCode = failures === 0 ? 0 : 1;
+}
+
+/** Poll until fn() is truthy or the timeout elapses; returns the last value. */
+export async function waitFor(fn, { timeoutMs = 10_000, stepMs = 500 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  let value;
+  while (Date.now() < deadline) {
+    value = await fn();
+    if (value) return value;
+    await waitMs(stepMs);
+  }
+  return value;
+}

--- a/scripts/realtime-e2e/mock-gateway.mjs
+++ b/scripts/realtime-e2e/mock-gateway.mjs
@@ -1,0 +1,166 @@
+/**
+ * Deterministic mock of the Vercel AI Gateway for driving the REAL agent
+ * pipeline with scripted tool calls (no LLM, no API key, fully repeatable).
+ *
+ * Speaks the @ai-sdk/gateway LanguageModelV3 protocol:
+ *   POST /language-model  ->  SSE stream of LanguageModelV3StreamPart events.
+ *
+ * Activate by pointing the API at it (root .env):
+ *   AI_GATEWAY_API_KEY=dummy-key-for-local-testing
+ *   AI_GATEWAY_BASE_URL=http://localhost:9099
+ *
+ * Scripting: the last USER message may contain a directive:
+ *   MOCKSCRIPT::[{"tool":"create_console","input":{...}},
+ *                {"tool":"run_console","input":{"consoleId":"$prev.consoleId"}}]
+ * Each gateway call (= one streamText step) emits the next unfinished script
+ * entry as a tool-call; once every entry has a tool result in the prompt the
+ * mock finishes with plain text. "$prev.consoleId" is substituted with the
+ * most recent tool result's consoleId (lets create -> modify -> run chain).
+ */
+import http from "node:http";
+
+const PORT = Number(process.env.MOCK_GATEWAY_PORT || 9099);
+
+function sse(res, obj) {
+  res.write(`data: ${JSON.stringify(obj)}\n\n`);
+}
+
+function lastUserDirective(prompt) {
+  for (let i = prompt.length - 1; i >= 0; i--) {
+    const m = prompt[i];
+    if (m.role !== "user") continue;
+    const text = (Array.isArray(m.content) ? m.content : [])
+      .filter(p => p.type === "text")
+      .map(p => p.text)
+      .join("");
+    const idx = text.indexOf("MOCKSCRIPT::");
+    if (idx >= 0) {
+      try {
+        return {
+          script: JSON.parse(text.slice(idx + "MOCKSCRIPT::".length)),
+          userIndex: i,
+        };
+      } catch (e) {
+        return { script: null, userIndex: i, parseError: String(e) };
+      }
+    }
+    return { script: null, userIndex: i };
+  }
+  return { script: null, userIndex: -1 };
+}
+
+function countToolResultsAfter(prompt, userIndex) {
+  let count = 0;
+  let lastResultValue = null;
+  for (let i = userIndex + 1; i < prompt.length; i++) {
+    const m = prompt[i];
+    if (m.role !== "tool") continue;
+    for (const part of m.content || []) {
+      if (part.type === "tool-result") {
+        count++;
+        const out = part.output;
+        lastResultValue =
+          out && typeof out === "object" && "value" in out ? out.value : out;
+      }
+    }
+  }
+  return { count, lastResultValue };
+}
+
+function substitute(input, lastResultValue) {
+  const str = JSON.stringify(input);
+  let consoleId = "";
+  const scan = v => {
+    if (!v || typeof v !== "object") return;
+    if (typeof v.consoleId === "string") consoleId = v.consoleId;
+    for (const k of Object.keys(v)) scan(v[k]);
+  };
+  scan(lastResultValue);
+  return JSON.parse(str.replaceAll("$prev.consoleId", consoleId));
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method !== "POST" || !req.url.startsWith("/language-model")) {
+    res.writeHead(404, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "not found" }));
+    return;
+  }
+  let body = "";
+  req.on("data", c => (body += c));
+  req.on("end", () => {
+    let payload;
+    try {
+      payload = JSON.parse(body);
+    } catch {
+      res.writeHead(400).end("bad json");
+      return;
+    }
+    const prompt = payload.prompt || [];
+    const { script, userIndex, parseError } = lastUserDirective(prompt);
+    const { count, lastResultValue } = countToolResultsAfter(prompt, userIndex);
+
+    res.writeHead(200, {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache",
+      connection: "keep-alive",
+    });
+    sse(res, {
+      type: "response-metadata",
+      id: `mock-${Date.now()}`,
+      modelId: "mock",
+      timestamp: new Date().toISOString(),
+    });
+
+    const usage = {
+      inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+      outputTokens: { total: 1, reasoning: 0 },
+      raw: {},
+    };
+
+    const finishWithText = text => {
+      sse(res, { type: "text-start", id: "t1" });
+      sse(res, { type: "text-delta", id: "t1", delta: text });
+      sse(res, { type: "text-end", id: "t1" });
+      sse(res, { type: "finish", finishReason: "stop", usage });
+      res.end();
+    };
+
+    if (parseError) {
+      return finishWithText(`MOCK SCRIPT PARSE ERROR: ${parseError}`);
+    }
+    if (!script || !Array.isArray(script) || script.length === 0) {
+      return finishWithText(
+        "MOCK: no MOCKSCRIPT:: directive found; replying with text only.",
+      );
+    }
+    if (count >= script.length) {
+      return finishWithText(
+        `MOCK DONE: executed ${script.length} scripted tool call(s).`,
+      );
+    }
+
+    const step = script[count];
+    const input = substitute(step.input || {}, lastResultValue);
+    const toolCallId = `mocktc-${count}-${Date.now()}`;
+    sse(res, { type: "tool-input-start", id: toolCallId, toolName: step.tool });
+    sse(res, {
+      type: "tool-input-delta",
+      id: toolCallId,
+      delta: JSON.stringify(input),
+    });
+    sse(res, { type: "tool-input-end", id: toolCallId });
+    sse(res, {
+      type: "tool-call",
+      toolCallId,
+      toolName: step.tool,
+      input: JSON.stringify(input),
+    });
+    sse(res, { type: "finish", finishReason: "tool-calls", usage });
+    res.end();
+  });
+});
+
+server.listen(PORT, () => {
+  // eslint-disable-next-line no-console -- standalone dev tool, not API code
+  console.log(`mock AI gateway listening on :${PORT}`);
+});

--- a/scripts/realtime-e2e/package.json
+++ b/scripts/realtime-e2e/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "mako-realtime-e2e",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Manual end-to-end harness for the realtime console sync (two browser windows + scripted agent via mock AI gateway). Not part of the workspace build or CI.",
+  "scripts": {
+    "gateway": "node mock-gateway.mjs",
+    "all": "node run-all.mjs"
+  },
+  "dependencies": {
+    "playwright-core": "^1.49.0"
+  }
+}

--- a/scripts/realtime-e2e/run-all.mjs
+++ b/scripts/realtime-e2e/run-all.mjs
@@ -14,6 +14,7 @@ const scenarios = [
   "03-agent-modalities.mjs",
   "04-dead-sse.mjs",
   "05-stale-save-dual-guard.mjs",
+  "06-wake-triggers.mjs",
 ];
 
 const results = [];

--- a/scripts/realtime-e2e/run-all.mjs
+++ b/scripts/realtime-e2e/run-all.mjs
@@ -1,0 +1,32 @@
+/**
+ * Runs every scenario sequentially and reports a summary. ~4 minutes total
+ * (scenario 04 alone takes ~2 minutes — the watchdog window is real time).
+ */
+/* eslint-disable no-console -- standalone dev tool, not API code */
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const scenarios = [
+  "01-draft-two-windows.mjs",
+  "02-saved-console.mjs",
+  "03-agent-modalities.mjs",
+  "04-dead-sse.mjs",
+  "05-stale-save-dual-guard.mjs",
+];
+
+const results = [];
+for (const scenario of scenarios) {
+  console.log(`\n=== ${scenario} ===`);
+  const res = spawnSync("node", [path.join(here, scenario)], {
+    stdio: "inherit",
+  });
+  results.push({ scenario, ok: res.status === 0 });
+}
+
+console.log("\n=== SUMMARY ===");
+for (const r of results) {
+  console.log(`  ${r.ok ? "PASS" : "FAIL"}  ${r.scenario}`);
+}
+process.exitCode = results.every(r => r.ok) ? 0 : 1;

--- a/scripts/realtime-e2e/setup.mjs
+++ b/scripts/realtime-e2e/setup.mjs
@@ -1,0 +1,106 @@
+/**
+ * One-time provisioning for the realtime-e2e harness. Uses only the API.
+ *
+ *   node setup.mjs register <email> <password>
+ *       → registers the user; fetch the emailed code (printed to the API log
+ *         when SendGrid is unconfigured, or read it from Mongo — see README)
+ *   node setup.mjs verify <email> <code>
+ *       → verifies the email, prints the session token
+ *   node setup.mjs provision <session> <mongoConnectionString> <database>
+ *       → logs in with the session, creates a workspace + a MongoDB
+ *         connection, and writes .env.e2e next to this script
+ *
+ * If the user already exists, skip straight to `provision` with a session
+ * obtained via POST /api/auth/login.
+ */
+/* eslint-disable no-console -- standalone dev tool, not API code */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const API = process.env.MAKO_E2E_API_URL || "http://localhost:8080";
+
+const [, , cmd, ...args] = process.argv;
+
+async function json(res) {
+  const text = await res.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`Non-JSON response (${res.status}): ${text.slice(0, 200)}`);
+  }
+}
+
+if (cmd === "register") {
+  const [email, password] = args;
+  const res = await fetch(`${API}/api/auth/register`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email, password, name: "Realtime E2E" }),
+  });
+  console.log(await json(res));
+  console.log(
+    "\nNext: grab the 6-digit verification code (see README) and run:\n" +
+      `  node setup.mjs verify ${email} <code>`,
+  );
+} else if (cmd === "verify") {
+  const [email, code] = args;
+  const res = await fetch(`${API}/api/auth/verify-email`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email, code }),
+  });
+  const setCookie = res.headers.get("set-cookie") || "";
+  const session = /auth_session=([^;]+)/.exec(setCookie)?.[1];
+  console.log(await json(res));
+  console.log(`\nSession token: ${session}`);
+  console.log(
+    `\nNext:\n  node setup.mjs provision ${session} mongodb://localhost:27018/sampledb?replicaSet=rs0 sampledb`,
+  );
+} else if (cmd === "provision") {
+  const [session, connectionString, database] = args;
+  const headers = {
+    "content-type": "application/json",
+    cookie: `auth_session=${session}`,
+  };
+
+  const wsRes = await fetch(`${API}/api/workspaces`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ name: "Realtime E2E" }),
+  });
+  const ws = await json(wsRes);
+  if (!ws.success) throw new Error(`workspace: ${JSON.stringify(ws)}`);
+  const wsId = ws.data.id;
+
+  const connRes = await fetch(`${API}/api/workspaces/${wsId}/databases`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      name: "E2E Sample Mongo",
+      type: "mongodb",
+      connection: { connectionString, database },
+    }),
+  });
+  const conn = await json(connRes);
+  if (!conn.success) throw new Error(`connection: ${JSON.stringify(conn)}`);
+
+  const envFile = path.join(here, ".env.e2e");
+  fs.writeFileSync(
+    envFile,
+    [
+      `MAKO_E2E_SESSION=${session}`,
+      `MAKO_E2E_WORKSPACE_ID=${wsId}`,
+      `MAKO_E2E_CONNECTION_ID=${conn.data.id}`,
+      "",
+    ].join("\n"),
+  );
+  console.log(`Wrote ${envFile}`);
+  console.log({ workspaceId: wsId, connectionId: conn.data.id });
+} else {
+  console.log(
+    "Usage:\n  node setup.mjs register <email> <password>\n  node setup.mjs verify <email> <code>\n  node setup.mjs provision <session> <mongoConnectionString> <database>",
+  );
+  process.exitCode = 1;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

PR #477 introduced server-authoritative drafts with poke-then-pull realtime sync, but propagation was flaky:

- changes sometimes propagated between clients, sometimes not;
- the agent would report it created/modified/executed a console while the user's window showed nothing (or stale content);
- (found during follow-up manual testing) with two side-by-side windows, sync only "woke up" after several window switches.

Every failure was reproduced deterministically in a local two-window environment (Playwright + a mock AI gateway driving the real agent pipeline with scripted tool calls) and root-caused before fixing.

## Root causes found (all verified live)

| # | Bug | Effect |
|---|---|---|
| 1 | `Console.tsx` mount-autosave re-saved identical drafts on every mount | opening a draft in a 2nd window bumped `draftRevision`, staled the 1st window's base → **all of its autosaves 409'd forever; edits silently stopped persisting** |
| 2 | sync gated remote applies on `tab.isDirty` — the *pinned-tab* flag (set on first keystroke, set after saves, never cleared) | any touched tab never live-applied remote updates again ("sometimes works, sometimes not") |
| 3 | autosave 409 was a dead end (banner only, no reconciliation, kept retrying) | typist's edits stayed local-only with a misleading banner |
| 4 | `console.run.completed` → `fetchConsoleContent` fast-forwarded `draftRevision` + store content **without updating Monaco** | after agent `modify_console`+`run_console` the editor showed the **old query next to the new query's results**, permanently |
| 5 | `fetchConsoleContent` inferred saved-ness from `path \|\| name` (name always set) | drafts flipped to `isSaved=true` → **autosave permanently disabled** for agent-created consoles |
| 6 | no SSE liveness detection | a silently-dead connection (NAT/proxy half-close) looked "open" forever; all pokes lost |
| 7 | `chat.ui-intent` (open created console) was fire-and-forget | consoles created during any gap / after "New Chat" **never appeared anywhere** |
| 8 | explicit saves checked `expectedVersion` only; agent edits bump only `draftRevision` | a stale window's Cmd+S **silently reverted agent edits** |
| 9 | resync trigger was `visibilitychange`-only | **side-by-side windows are both permanently "visible"** — switching focus between them fired nothing; recovery depended on accidental window occlusion or the 70s watchdog ("I have to switch several times to wake it up") |
| 10 | a poke landing inside the 3s typing-recency window deferred to the banner and was never re-evaluated | a single remote edit could leave a quiescent tab visibly stale until the user clicked |
| 11 | type+undo left the intermediate keystroke's queued autosave alive (hash-skip didn't cancel it; baseline map empty after page load) | **phantom content** persisted server-side and stole the revision from concurrent writers |

## Fixes

- **Self-healing draft loop** — mount-autosave only for never-synced drafts; remote applies gated on a real "unsaved local edits" signal (recent keystrokes / queued / blocked autosave / explicit-save hash delta), never on the pin flag; identical-content conflicts self-resolve; real conflicts suspend autosave (no 409 hammering) and the banner gains **Keep mine** (Dismiss unblocks, so edits never silently stop persisting).
- **Single guarded apply path** — every server payload flows through `applyRemoteConsoleEntry` (store + Monaco together) or a metadata-only fast-forward that protects in-flight keystrokes; the run-completed handler now pulls only the run artifact and routes content through the guarded sync.
- **Saved-ness from server truth** — `isSaved` comes from the API, not name inference; `revisions-sync` entries now carry it.
- **SSE liveness watchdog** — no frame (message/ping/hello) for 70s while "open" ⇒ drop + reconnect; the reconnect's revision sync repairs missed pokes.
- **In-band console opening** — `create_console`/`open_console` tool results streaming through the (resumable) chat open the tab directly; survives SSE drops, refreshes and the New-Chat race. Legacy ui-intent poke kept for one release; both paths idempotent.
- **Dual save guard** — explicit saves echo `expectedDraftRevision` alongside `expectedVersion`; the server applies both atomically and reports both bases in the conflict payload (extracted into `console-save-guards.ts`).
- **Wake triggers** — window `focus`, `pageshow` and Page-Lifecycle `resume` now funnel (throttled) into the resync handler alongside `visibilitychange`; on wake, a stream silent past ~1.5 heartbeats is force-reconnected instead of trusting `status === "open"` (Chrome freezes background tabs and kills sockets without `error` events).
- **Deferred re-evaluation** — updates deferred only by typing recency self-apply once the tab goes quiescent (one scheduled re-sync; confirmed conflicts still wait for the user — no polling loops).
- **Autosave hygiene** — net-zero edits cancel the queued intermediate autosave; the autosave baseline is seeded from persisted tabs on page load.

## Tests

- **`scripts/realtime-e2e/`** — permanent regression harness (own package, not in CI): two real browser windows + mock AI gateway, asserting equality across **Monaco buffer ↔ store ↔ server doc** in 6 scenarios (draft two-windows, saved console, all agent modalities, dead-SSE, dual guard, wake triggers). **All 6 pass**; before the fixes, 5 of 6 fail.
- Unit tests: `remoteApplyGate` truth table (vitest, app — 96/96 green) and the `console-save-guards` matrix (self-running, api).
- `pnpm --filter app run typecheck && lint`, `pnpm --filter api run lint` clean.

## Evidence

Agent `modify_console` + `run_console`: the editor now shows the **new** query with its results (previously stale buffer + new results):

[Agent modify+run with synced editor and results](https://cursor.com/agents/bc-12a90d89-5bac-4d4c-9b07-10e2304b806b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdemo1-agent-modify-run-editor-synced.png)

Window B receiving window A's keystrokes live on a draft (previously: revision dead-end, no propagation):

[Window B received live edit](https://cursor.com/agents/bc-12a90d89-5bac-4d4c-9b07-10e2304b806b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdemo2-windowB-received-live-edit.png)

## Notes / follow-ups

- Live autosave for *saved* consoles (two-way sync between explicit saves) is deliberately deferred — product decision; save-time propagation works and is now conflict-safe.
- Remove the legacy `chat.ui-intent` emission after one release of client overlap.
- Multi-instance (Redis pub/sub) is architecturally unchanged; worth one staging pass with `REDIS_URL` set.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12a90d89-5bac-4d4c-9b07-10e2304b806b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12a90d89-5bac-4d4c-9b07-10e2304b806b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

