### PR TITLE
docs: document React Apps (apps page, App Agent, API reference)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -30,6 +30,7 @@ export default defineConfig({
             { label: "AI-Powered SQL Client", slug: "ai-agent" },
             { label: "Console", slug: "console" },
             { label: "Dashboards", slug: "dashboards" },
+            { label: "Apps", slug: "apps" },
             { label: "Query Runner", slug: "query-runner" },
             { label: "Self-Directive", slug: "self-directive" },
             { label: "Skills", slug: "skills" },

--- a/docs/src/content/docs/ai-agent.md
+++ b/docs/src/content/docs/ai-agent.md
@@ -110,6 +110,10 @@ Key capabilities:
 
 The agent handles edit-mode locking, so concurrent users cannot conflict.
 
+### App Agent
+
+Active when building [Apps](/apps/) — live React projects inside the workspace. The agent scaffolds a React + TypeScript starter, edits files (always writing complete file contents), manages npm dependencies, and wires up data bindings so the app reads workspace data without ever seeing credentials. It validates queries with the shared data-source tools before coding against them, and reads build/runtime errors from the live preview to iterate until the app renders clean.
+
 ## Visual Inspection
 
 The agent can capture screenshots of the live UI for visual QA via the **`capture_screenshot`** client tool. It runs in the browser (no server round-trip) and returns a PNG that the agent inspects directly. Supported targets:

--- a/docs/src/content/docs/api-reference.md
+++ b/docs/src/content/docs/api-reference.md
@@ -73,6 +73,20 @@ For MongoDB connections, collection and view management is exposed under the sam
 The legacy `/api/database/collections`, `/api/database/views`, and related top-level routes were removed in [#408](https://github.com/mako-ai/mako/pull/408). Callers must use the workspace-scoped endpoints above and authenticate with a session cookie or `Bearer revops_*` API key.
 :::
 
+## Apps
+
+React apps built inside the workspace ([Apps](/apps/)). Private apps are owner-only — admins and API keys cannot access another member's private app.
+
+| Method   | Endpoint                                                                | Description                                              |
+| -------- | ----------------------------------------------------------------------- | -------------------------------------------------------- |
+| `GET`    | `/api/workspaces/:wid/apps`                                             | List apps visible to the caller                          |
+| `POST`   | `/api/workspaces/:wid/apps`                                             | Create an app (scaffolds a React + TypeScript starter)   |
+| `GET`    | `/api/workspaces/:wid/apps/:id`                                         | Get an app (files, dependencies, data bindings)          |
+| `PUT`    | `/api/workspaces/:wid/apps/:id`                                         | Update an app (files, dependencies, bindings, access)    |
+| `DELETE` | `/api/workspaces/:wid/apps/:id`                                         | Delete an app                                            |
+| `POST`   | `/api/workspaces/:wid/apps/:id/bindings/:bid/materialize`               | Build/rebuild a binding's Parquet artifact (`{force}`)   |
+| `GET`    | `/api/workspaces/:wid/apps/:id/bindings/:bid/materialization/artifact`  | Stream the materialized Parquet artifact                 |
+
 ## Query Execution
 
 Session cookie or `Authorization: Bearer revops_*` API key required. Use the database connection ID from `GET /api/workspaces/:wid/databases`.

--- a/docs/src/content/docs/apps.md
+++ b/docs/src/content/docs/apps.md
@@ -1,0 +1,62 @@
+---
+title: Apps
+description: Build live React apps inside your workspace — AI-authored, with secure data bindings to your database connections and fast client-side analytics via DuckDB.
+---
+
+Apps are React projects that run live inside a Mako tab. You (or the AI agent) build them by editing files — think Lovable or v0, but with first-class, credential-free access to your workspace's database connections.
+
+## How It Works
+
+An app is three things:
+
+- **A virtual filesystem** — TypeScript/React source files. The entrypoint is `src/App.tsx` (its default export is rendered).
+- **An npm dependency manifest** — libraries like `d3`, `recharts`, or `framer-motion`, resolved as ES modules at preview time.
+- **Data bindings** — named queries against your workspace connections that the app reads at runtime.
+
+The default runtime is `cdn`: React plus ESM dependencies run directly in a sandboxed preview iframe with no build step. Plain CSS and CSS-in-JS work well; full Tailwind/shadcn builds require the `webcontainer` runtime, which is not yet enabled.
+
+## Building Apps with the AI Agent
+
+Ask the agent to build an app and it scaffolds a React + TypeScript starter, opens it in a tab, and iterates: writing files, adding dependencies, creating data bindings, and reading build/runtime errors from the live preview until it renders clean. The agent can also screenshot the running preview to visually inspect what it built.
+
+You can edit everything yourself too — files open in the editor, and the Apps explorer shows the file tree, dependencies, and data sources.
+
+## Data Bindings
+
+Bindings are how apps reach workspace data. Each binding maps a name to a query (SQL, MongoDB, or JavaScript) against one of your connections. Queries execute server-side through Mako's scoped execute API — **the app code never sees credentials or connection strings**.
+
+Two delivery modes:
+
+| Mode | Behavior | Best for |
+| --- | --- | --- |
+| `live` | Query runs server-side on every read | Small, always-fresh lookups |
+| `parquet` | Query is materialized into a Parquet artifact (same pipeline as dashboards) and loaded into DuckDB-WASM in the browser | Dashboards and aggregations over larger result sets |
+
+Materialized bindings record a run history (row count, size, duration, errors) and can be rebuilt on demand. In the app code, read bindings through the injected `@mako/app-sdk`:
+
+```tsx
+import { useQuery, useDuckDB } from "@mako/app-sdk";
+
+// Live binding: fetches through the execute API
+const { data, loading, error } = useQuery("recent_orders");
+
+// Parquet binding: analytical SQL against DuckDB-WASM, table name = binding name
+const { data: totals } = useDuckDB(
+  'SELECT category, SUM(amount) AS total FROM "orders" GROUP BY 1'
+);
+```
+
+Data sources are visible under **Data sources** in the app's explorer tree, with a Live/Materialized mode control and materialization run history.
+
+## Access Control
+
+Apps follow the same model as dashboards:
+
+- **`private`** (default): owner-only. Workspace admins and API keys cannot read or modify another member's private app.
+- **`workspace`**: visible and editable by any workspace member.
+
+## Security Model
+
+- Binding queries are validated against the workspace's connections and run server-side with read-only enforcement on materialization SQL.
+- The preview runs in a sandboxed iframe; in-sandbox DuckDB SQL is gated and rows posted to the preview are capped.
+- App code receives query *results* only — never credentials.


### PR DESCRIPTION
## Why

The React Apps feature merged in #450 / #484 (~7.5k lines: app routes, agent tools, app-runtime, data bindings with Parquet/DuckDB materialization) with internal docs only (agent-skills/apps/SKILL.md). The Starlight site had zero mention of apps.

## What

- **New `apps.md` page**: what apps are (virtual FS + deps + data bindings), cdn runtime constraints, AI-driven building workflow, live vs parquet bindings with `useQuery`/`useDuckDB` examples, private/workspace access model, security model.
- **ai-agent.md**: new *App Agent* section under Multi-Agent Architecture.
- **api-reference.md**: new Apps section — 7 endpoints (CRUD + materialize + artifact stream).
- **astro.config.mjs**: sidebar entry under Core Features.

## Verified against

- `packages/schemas/src/app.schema.ts` (binding modes, runtime default, schema doc comments)
- `api/src/routes/apps.ts` (endpoints, canManage/canRead: private = owner-only, admin/API-key bypass closed in d2b8f655)
- `api/src/agent-skills/apps/SKILL.md` (workflow, useQuery/useDuckDB, cdn vs webcontainer)
- `app/src/app-runtime/preview.ts` (@mako/app-sdk injection)

Part of daily docs maintenance.