### PR TITLE
Apps: surface DuckDB bridge truncation and make the row cap configurable

### DIFF
--- a/api/src/agent-skills/apps/SKILL.md
+++ b/api/src/agent-skills/apps/SKILL.md
@@ -51,6 +51,17 @@ Apps are React projects rendered live in a tab. You build them by editing files.
 
    Prefer parquet + useDuckDB for dashboards/aggregations over larger result sets; prefer
    live useQuery for small, always-fresh lookups.
+
+   **Result row cap:** rows delivered to the app are capped per query/binding read
+   (default 500,000 — the bridge into the sandboxed iframe). Both hooks return
+   `truncated: true` when rows beyond the cap were dropped, and `useDuckDB` also
+   returns `rowCount` (the full result size before the cap); the SDK logs a console
+   warning too. NEVER ignore `truncated` — aggregates computed in JS over a truncated
+   result are silently wrong (classic symptom: an unfiltered view showing smaller
+   totals than filtered views). Prefer aggregating in SQL so results stay small. If
+   you genuinely need more rows, pass `useDuckDB(sql, { rowLimit: 2_000_000 })` or
+   `{ rowLimit: null }` to disable the cap (costs memory + serialization time), and
+   surface `truncated` in the UI whenever you render row-level data.
 6. After a batch of edits, if something looks wrong, call `get_app_state` (or `run_app`)
    to read build/runtime errors and fix them. Iterate until the preview is error-free.
 7. Understand and validate data before coding against it using the shared data-source

--- a/app/src/app-runtime/duckdb.test.ts
+++ b/app/src/app-runtime/duckdb.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+
+// duckdb.ts imports the DuckDB-WASM helpers at module scope; stub them so the
+// pure sandbox-cap helpers can be tested in a node environment.
+vi.mock("../lib/duckdb", () => ({
+  createDuckDBInstance: vi.fn(),
+  loadParquetTable: vi.fn(),
+  queryDuckDB: vi.fn(),
+  collectStreamBytes: vi.fn(),
+  terminateTrackedDuckDBInstance: vi.fn(),
+}));
+
+import {
+  SANDBOX_DUCKDB_ROW_LIMIT,
+  resolveSandboxRowLimit,
+  applySandboxRowLimit,
+} from "./duckdb";
+
+describe("resolveSandboxRowLimit", () => {
+  it("uses the default cap when the iframe sends no limit", () => {
+    expect(resolveSandboxRowLimit(undefined)).toBe(SANDBOX_DUCKDB_ROW_LIMIT);
+  });
+
+  it("treats null and Infinity as an explicit opt-out (no cap)", () => {
+    expect(resolveSandboxRowLimit(null)).toBeNull();
+    expect(resolveSandboxRowLimit(Infinity)).toBeNull();
+  });
+
+  it("accepts positive finite limits, flooring fractions", () => {
+    expect(resolveSandboxRowLimit(1)).toBe(1);
+    expect(resolveSandboxRowLimit(2_000_000)).toBe(2_000_000);
+    expect(resolveSandboxRowLimit(99.9)).toBe(99);
+  });
+
+  it("falls back to the default cap for invalid input", () => {
+    expect(resolveSandboxRowLimit(0)).toBe(SANDBOX_DUCKDB_ROW_LIMIT);
+    expect(resolveSandboxRowLimit(-5)).toBe(SANDBOX_DUCKDB_ROW_LIMIT);
+    expect(resolveSandboxRowLimit(NaN)).toBe(SANDBOX_DUCKDB_ROW_LIMIT);
+    expect(resolveSandboxRowLimit(-Infinity)).toBe(SANDBOX_DUCKDB_ROW_LIMIT);
+    expect(resolveSandboxRowLimit("100")).toBe(SANDBOX_DUCKDB_ROW_LIMIT);
+    expect(resolveSandboxRowLimit({})).toBe(SANDBOX_DUCKDB_ROW_LIMIT);
+  });
+});
+
+describe("applySandboxRowLimit", () => {
+  const rows = [1, 2, 3, 4, 5];
+
+  it("passes results through untouched when below the cap", () => {
+    expect(applySandboxRowLimit(rows, 10)).toEqual({
+      rows,
+      truncated: false,
+    });
+    expect(applySandboxRowLimit(rows, 5)).toEqual({
+      rows,
+      truncated: false,
+    });
+  });
+
+  it("slices and flags results above the cap", () => {
+    expect(applySandboxRowLimit(rows, 3)).toEqual({
+      rows: [1, 2, 3],
+      truncated: true,
+    });
+  });
+
+  it("never truncates when the cap is disabled", () => {
+    expect(applySandboxRowLimit(rows, null)).toEqual({
+      rows,
+      truncated: false,
+    });
+  });
+});

--- a/app/src/app-runtime/duckdb.ts
+++ b/app/src/app-runtime/duckdb.ts
@@ -94,8 +94,45 @@ export async function queryAppDuckDB(
   return queryDuckDB(inst.db, sql);
 }
 
-/** Max rows posted back to the sandboxed iframe per query / binding read. */
-export const SANDBOX_DUCKDB_ROW_LIMIT = 50_000;
+/**
+ * Default max rows posted back to the sandboxed iframe per query / binding
+ * read. The cap exists to bound the structured-clone cost of the postMessage
+ * bridge, not to protect data access (the instance only holds this app's own
+ * materialized tables). It matches the 500k-row parquet materialization cap
+ * (api/src/services/app-binding-materialization.service.ts), so a plain
+ * binding read can never be truncated — only row-multiplying SQL (joins,
+ * cross products, generate_series, ...) can exceed it. Apps override it per
+ * call via the SDK's `rowLimit` option; `rowLimit: null` disables it.
+ */
+export const SANDBOX_DUCKDB_ROW_LIMIT = 500_000;
+
+/**
+ * Sanitize a row limit requested by the (untrusted) preview iframe.
+ * - `null` / `Infinity` -> no cap (explicit opt-out)
+ * - finite number >= 1  -> that many rows (floored)
+ * - anything else       -> the default cap
+ */
+export function resolveSandboxRowLimit(requested: unknown): number | null {
+  if (requested === null) return null;
+  if (typeof requested === "number") {
+    if (requested === Infinity) return null;
+    if (Number.isFinite(requested) && requested >= 1) {
+      return Math.floor(requested);
+    }
+  }
+  return SANDBOX_DUCKDB_ROW_LIMIT;
+}
+
+/** Apply a resolved row limit to a query result, flagging dropped rows. */
+export function applySandboxRowLimit<T>(
+  rows: T[],
+  rowLimit: number | null,
+): { rows: T[]; truncated: boolean } {
+  if (rowLimit == null || rows.length <= rowLimit) {
+    return { rows, truncated: false };
+  }
+  return { rows: rows.slice(0, rowLimit), truncated: true };
+}
 
 const LEADING_SQL_COMMENTS = /^(\s*(--[^\n]*(\n|$)|\/\*[\s\S]*?\*\/))*\s*/;
 

--- a/app/src/app-runtime/preview.test.ts
+++ b/app/src/app-runtime/preview.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import vm from "node:vm";
+import { buildPreviewHtml } from "./preview";
+import type { AppEntity } from "../store/appStore";
+
+const app = {
+  _id: "app1",
+  title: "Test app",
+  entrypoint: "src/App.tsx",
+  dependencies: { react: "^18.2.0", "react-dom": "^18.2.0" },
+  files: [
+    {
+      path: "src/App.tsx",
+      contents: "export default function App() { return null; }",
+    },
+  ],
+} as unknown as AppEntity;
+
+function extractModuleScript(html: string): string {
+  const script = html.split('<script type="module">')[1]?.split("</script>")[0];
+  expect(script).toBeTruthy();
+  return String(script);
+}
+
+describe("buildPreviewHtml", () => {
+  it("embeds a syntactically valid bootstrap script", () => {
+    // BOOTSTRAP_SOURCE is a String.raw template embedded verbatim into the
+    // srcdoc — a stray backtick or ${ inside it corrupts the literal and
+    // breaks every app preview. Parsing the generated script catches that.
+    const script = extractModuleScript(buildPreviewHtml(app));
+    expect(() => new vm.Script(script)).not.toThrow();
+  });
+
+  it("injects the rowLimit/truncated plumbing into the SDK hooks", () => {
+    const script = extractModuleScript(buildPreviewHtml(app));
+    expect(script).toContain("useQuery(name, opts)");
+    expect(script).toContain("useDuckDB(sql, opts)");
+    // The hooks must forward the requested cap to the parent bridge…
+    expect(script).toContain("rowLimit: rowLimit");
+    // …and warn when the parent reports dropped rows.
+    expect(script).toContain("warnTruncated");
+  });
+});

--- a/app/src/app-runtime/preview.ts
+++ b/app/src/app-runtime/preview.ts
@@ -172,19 +172,28 @@ window.addEventListener("message", (event) => {
     resolve(data);
   }
 });
-function runBinding(name) {
+function runBinding(name, rowLimit) {
   return new Promise((resolve) => {
     const requestId = "req_" + ++reqSeq;
     pending.set(requestId, resolve);
-    POST({ type: "mako-app:run-binding", requestId, binding: name });
+    POST({ type: "mako-app:run-binding", requestId, binding: name, rowLimit: rowLimit });
   });
 }
-function runDuckDb(sql) {
+function runDuckDb(sql, rowLimit) {
   return new Promise((resolve) => {
     const requestId = "duck_" + ++reqSeq;
     pending.set(requestId, resolve);
-    POST({ type: "mako-app:run-duckdb", requestId, sql: sql });
+    POST({ type: "mako-app:run-duckdb", requestId, sql: sql, rowLimit: rowLimit });
   });
+}
+function warnTruncated(source, res) {
+  console.warn(
+    "[mako/app-sdk] " + source + " hit the " + res.rowLimit + "-row cap" +
+      (typeof res.rowCount === "number" ? "; the query produced " + res.rowCount + " rows" : "") +
+      ". Rows beyond the cap were dropped, so derived numbers may be wrong. " +
+      "Aggregate in SQL instead, or pass { rowLimit: <n> } to raise the cap " +
+      "({ rowLimit: null } disables it).",
+  );
 }
 
 // --- Self-capture: the parent cannot rasterize this opaque-origin iframe, so
@@ -238,34 +247,58 @@ async function main() {
   const makoSdk = {
     // Read a named binding. Live bindings run server-side; parquet bindings
     // return the materialized table rows from DuckDB-WASM (parent decides).
-    useQuery(name) {
-      const [state, setState] = React.useState({ data: null, error: null, loading: true });
+    // opts: { rowLimit?: number | null } — max rows delivered for parquet
+    // bindings (default 500k; null disables the cap). When rows beyond the
+    // cap were dropped, "truncated" is true and a console warning is logged.
+    useQuery(name, opts) {
+      const rowLimit = opts ? opts.rowLimit : undefined;
+      const [state, setState] = React.useState({ data: null, error: null, loading: true, truncated: false });
       React.useEffect(() => {
         let active = true;
-        setState({ data: null, error: null, loading: true });
-        runBinding(name).then((res) => {
+        setState({ data: null, error: null, loading: true, truncated: false });
+        runBinding(name, rowLimit).then((res) => {
           if (!active) return;
-          if (res.success) setState({ data: res.rows, error: null, loading: false });
-          else setState({ data: null, error: res.error || "Query failed", loading: false });
+          if (res.success) {
+            if (res.truncated) warnTruncated('useQuery("' + name + '")', res);
+            setState({ data: res.rows, error: null, loading: false, truncated: !!res.truncated });
+          } else {
+            setState({ data: null, error: res.error || "Query failed", loading: false, truncated: false });
+          }
         });
         return () => { active = false; };
-      }, [name]);
+      }, [name, rowLimit]);
       return state;
     },
     // Run analytical SQL over the app's materialized (parquet) tables in
-    // DuckDB-WASM. Table names are the binding names. Returns { data, fields }.
-    useDuckDB(sql) {
-      const [state, setState] = React.useState({ data: null, fields: null, error: null, loading: true });
+    // DuckDB-WASM. Table names are the binding names.
+    // opts: { rowLimit?: number | null } — max rows delivered (default 500k;
+    // null disables the cap). Returns { data, fields, rowCount, truncated }:
+    // "rowCount" is the full result size before the cap, "truncated" is true
+    // when rows beyond the cap were dropped (also logs a console warning).
+    useDuckDB(sql, opts) {
+      const rowLimit = opts ? opts.rowLimit : undefined;
+      const [state, setState] = React.useState({ data: null, fields: null, error: null, loading: true, truncated: false, rowCount: null });
       React.useEffect(() => {
         let active = true;
-        setState({ data: null, fields: null, error: null, loading: true });
-        runDuckDb(sql).then((res) => {
+        setState({ data: null, fields: null, error: null, loading: true, truncated: false, rowCount: null });
+        runDuckDb(sql, rowLimit).then((res) => {
           if (!active) return;
-          if (res.success) setState({ data: res.rows, fields: res.fields, error: null, loading: false });
-          else setState({ data: null, fields: null, error: res.error || "DuckDB query failed", loading: false });
+          if (res.success) {
+            if (res.truncated) warnTruncated("useDuckDB", res);
+            setState({
+              data: res.rows,
+              fields: res.fields,
+              error: null,
+              loading: false,
+              truncated: !!res.truncated,
+              rowCount: typeof res.rowCount === "number" ? res.rowCount : (res.rows ? res.rows.length : null),
+            });
+          } else {
+            setState({ data: null, fields: null, error: res.error || "DuckDB query failed", loading: false, truncated: false, rowCount: null });
+          }
         });
         return () => { active = false; };
-      }, [sql]);
+      }, [sql, rowLimit]);
       return state;
     },
   };

--- a/app/src/components/AppRenderer.tsx
+++ b/app/src/components/AppRenderer.tsx
@@ -18,7 +18,8 @@ import {
   disposeAppDuckDB,
   bindingTableName,
   checkSandboxDuckDbSql,
-  SANDBOX_DUCKDB_ROW_LIMIT,
+  resolveSandboxRowLimit,
+  applySandboxRowLimit,
 } from "../app-runtime/duckdb";
 
 /**
@@ -88,23 +89,28 @@ export default function AppRenderer({ appId }: { appId: string }) {
         );
         // Materialized binding -> read its table from DuckDB-WASM.
         if (binding?.materialization === "parquet") {
+          const rowLimit = resolveSandboxRowLimit(data.rowLimit);
           void ensureBindingLoaded(appId, binding)
             .then(() =>
               queryAppDuckDB(
                 appId,
                 // +1 so we can tell the iframe when the read was truncated.
-                `SELECT * FROM "${bindingTableName(binding.name)}" LIMIT ${SANDBOX_DUCKDB_ROW_LIMIT + 1}`,
+                rowLimit == null
+                  ? `SELECT * FROM "${bindingTableName(binding.name)}"`
+                  : `SELECT * FROM "${bindingTableName(binding.name)}" LIMIT ${rowLimit + 1}`,
               ),
             )
-            .then(result =>
+            .then(result => {
+              const limited = applySandboxRowLimit(result.rows, rowLimit);
               post({
                 type: PREVIEW_MESSAGE.bindingResult,
                 requestId: data.requestId,
                 success: true,
-                rows: result.rows.slice(0, SANDBOX_DUCKDB_ROW_LIMIT),
-                truncated: result.rows.length > SANDBOX_DUCKDB_ROW_LIMIT,
-              }),
-            )
+                rows: limited.rows,
+                truncated: limited.truncated,
+                rowLimit,
+              });
+            })
             .catch(err =>
               post({
                 type: PREVIEW_MESSAGE.bindingResult,
@@ -142,22 +148,27 @@ export default function AppRenderer({ appId }: { appId: string }) {
         const parquetBindings = (appEntity?.dataBindings || []).filter(
           b => b.materialization === "parquet",
         );
+        const rowLimit = resolveSandboxRowLimit(data.rowLimit);
         void Promise.all(
           parquetBindings.map(b =>
             ensureBindingLoaded(appId, b).catch(() => false),
           ),
         )
           .then(() => queryAppDuckDB(appId, data.sql))
-          .then(result =>
+          .then(result => {
+            const limited = applySandboxRowLimit(result.rows, rowLimit);
             post({
               type: PREVIEW_MESSAGE.duckDbResult,
               requestId: data.requestId,
               success: true,
-              rows: result.rows.slice(0, SANDBOX_DUCKDB_ROW_LIMIT),
+              rows: limited.rows,
               fields: result.fields,
-              truncated: result.rows.length > SANDBOX_DUCKDB_ROW_LIMIT,
-            }),
-          )
+              // True size of the query result, before the bridge cap.
+              rowCount: result.rows.length,
+              truncated: limited.truncated,
+              rowLimit,
+            });
+          })
           .catch(err =>
             post({
               type: PREVIEW_MESSAGE.duckDbResult,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The app preview bridge silently capped every `useDuckDB` / `useQuery` (parquet) result at 50,000 rows. The host computed a `truncated` flag, but the injected `@mako/app-sdk` dropped it, so neither app code nor the agent could tell rows were missing. Aggregates computed in JS over a truncated result were silently wrong — the classic symptom being an unfiltered "All countries" view showing *smaller* totals than filtered views (which each fit under the cap). This was diagnosed in production: a 71,823-row query lost ~30% of customer-months with no signal.

## Changes

- **Default cap raised 50k → 500k** (`SANDBOX_DUCKDB_ROW_LIMIT` in `app/src/app-runtime/duckdb.ts`). 500k matches the parquet materialization cap (`PARQUET_ROW_LIMIT`), so a plain binding read can never truncate anymore — only row-multiplying SQL (joins, cross products, `generate_series`) can exceed it.
- **Cap is now configurable and optional per call**: `useDuckDB(sql, { rowLimit: 2_000_000 })`, `useQuery(name, { rowLimit })`, and `{ rowLimit: null }` (or `Infinity`) disables it entirely. The iframe-supplied value is sanitized host-side (`resolveSandboxRowLimit`); invalid input falls back to the default.
- **Truncation is now visible to the client**: both hooks expose `truncated` in their state, `useDuckDB` also exposes the full pre-cap `rowCount`, and the SDK logs a `console.warn` with the cap, the true row count, and how to raise/disable it.
- **Truncation is now visible to the agent**: the apps skill (`api/src/agent-skills/apps/SKILL.md`) documents the cap, the `truncated`/`rowCount` fields, the `rowLimit` override, and the "unfiltered < filtered" failure symptom.

## Tests

- `app/src/app-runtime/duckdb.test.ts` — unit tests for `resolveSandboxRowLimit` (default / opt-out / clamping / garbage input) and `applySandboxRowLimit`.
- `app/src/app-runtime/preview.test.ts` — parses the generated bootstrap module script with `vm.Script` (a stray backtick or `${` in `BOOTSTRAP_SOURCE` corrupts the `String.raw` template and breaks every preview — this exact failure mode came up while writing this change) and asserts the `rowLimit`/`truncated` plumbing is present in the injected SDK.

✅ `pnpm --filter app run typecheck` · ✅ `pnpm --filter app run lint` · ✅ `pnpm --filter app run test:unit` (16 files, 105 tests) · ✅ `pnpm --filter api run lint`

## Notes

- The cap exists to bound the structured-clone cost of the `postMessage` bridge, not for data access control (the per-app DuckDB instance only holds that app's own materialized tables), so letting apps opt out is safe.
- Live (non-parquet) `useQuery` bindings run server-side and are untouched; their `truncated` is always `false`. If the execute endpoint has its own cap, surfacing it would be a follow-up.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4517b6d6-2796-495c-b771-3f1314187207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4517b6d6-2796-495c-b771-3f1314187207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

