### PR TITLE
Unify materialization (apps + dashboards), async app builds, data source tabs, snapshot previews

### DIFF
--- a/api/src/agent-skills/apps/SKILL.md
+++ b/api/src/agent-skills/apps/SKILL.md
@@ -41,7 +41,10 @@ Apps are React projects rendered live in a tab. You build them by editing files.
    **Materialized bindings (DuckDB):** set `materialization: "parquet"` to materialize
    the query into a Parquet artifact (same pipeline as dashboards) that is loaded into
    DuckDB-WASM in the browser. After creating/editing a parquet binding, call
-   `materialize_binding`. Then the app can run fast analytical SQL client-side:
+   `materialize_binding`. The build runs server-side in the background; the tool waits
+   briefly and may return status `building` — that is not an error. The app loads the
+   data automatically when ready, and you can call `materialize_binding` again later to
+   confirm. Then the app can run fast analytical SQL client-side:
 
    ```tsx
    import { useDuckDB } from "@mako/app-sdk";

--- a/api/src/agent-skills/apps/SKILL.md
+++ b/api/src/agent-skills/apps/SKILL.md
@@ -42,9 +42,11 @@ Apps are React projects rendered live in a tab. You build them by editing files.
    the query into a Parquet artifact (same pipeline as dashboards) that is loaded into
    DuckDB-WASM in the browser. After creating/editing a parquet binding, call
    `materialize_binding`. The build runs server-side in the background; the tool waits
-   briefly and may return status `building` — that is not an error. The app loads the
-   data automatically when ready, and you can call `materialize_binding` again later to
-   confirm. Then the app can run fast analytical SQL client-side:
+   up to `waitSeconds` (default 120) and may return status `building` — that is not an
+   error. The app loads the data automatically when ready. To block until the build
+   finishes, call `materialize_binding` again — it resumes waiting on the in-flight
+   build (poll-with-timeout). Use `waitSeconds: 0` for an instant status check. Then
+   the app can run fast analytical SQL client-side:
 
    ```tsx
    import { useDuckDB } from "@mako/app-sdk";

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -3598,6 +3598,11 @@ export interface IMakoAppBindingCache {
     | "ready"
     | "error"
     | null;
+  /**
+   * Heartbeat for the current build. Refreshed periodically while a build is
+   * queued/running so stuck "building" statuses can be detected and recovered.
+   */
+  parquetBuildStatusAt?: Date | null;
   parquetLastError?: string | null;
   rowCount?: number;
   byteSize?: number;
@@ -3668,6 +3673,7 @@ const MakoAppBindingCacheSchema = new Schema<IMakoAppBindingCache>(
       enum: ["missing", "queued", "building", "ready", "error", null],
       default: null,
     },
+    parquetBuildStatusAt: { type: Date, default: null },
     parquetLastError: { type: String, default: null },
     rowCount: { type: Number },
     byteSize: { type: Number },

--- a/api/src/inngest/functions/app-binding-materialize.ts
+++ b/api/src/inngest/functions/app-binding-materialize.ts
@@ -1,0 +1,66 @@
+/**
+ * Background materialization of React App data bindings.
+ *
+ * Triggered by `app/binding.materialize` (sent from
+ * `queueAppBindingMaterialization`). Runs the query + Parquet build off the
+ * request path so the HTTP endpoint (and the agent's `materialize_binding`
+ * tool) returns immediately and the build survives client disconnects.
+ */
+import { inngest } from "../client";
+import { materializeAppBinding } from "../../services/app-binding-materialization.service";
+import { loggers } from "../../logging";
+
+const log = loggers.inngest();
+
+export const appBindingMaterializeFunction = inngest.createFunction(
+  {
+    id: "app-binding-materialize",
+    name: "Materialize App Data Binding",
+    // One build per binding at a time; the cache heartbeat dedupes at queue
+    // time, this guards against duplicate events.
+    concurrency: {
+      limit: 1,
+      key: "event.data.dedupeKey",
+    },
+    retries: 2,
+  },
+  { event: "app/binding.materialize" },
+  async ({ event, step }) => {
+    const { workspaceId, appId, bindingId, force } = event.data as {
+      workspaceId: string;
+      appId: string;
+      bindingId: string;
+      force?: boolean;
+    };
+
+    const result = await step.run("materialize-binding", async () => {
+      return await materializeAppBinding({
+        workspaceId,
+        appId,
+        bindingId,
+        force,
+      });
+    });
+
+    if (result.status === "error") {
+      // The error is already persisted on the binding cache + history; query
+      // errors are not transient, so don't throw (which would trigger retries).
+      log.warn("App binding materialization finished with error", {
+        workspaceId,
+        appId,
+        bindingId,
+        error: result.error,
+      });
+    } else {
+      log.info("App binding materialization complete", {
+        workspaceId,
+        appId,
+        bindingId,
+        rowCount: result.rowCount,
+        byteSize: result.byteSize,
+      });
+    }
+
+    return result;
+  },
+);

--- a/api/src/inngest/index.ts
+++ b/api/src/inngest/index.ts
@@ -18,6 +18,7 @@ import {
   dashboardSchedulerFunction,
   cleanupAbandonedMaterializationRunsFunction,
 } from "./functions/dashboard-refresh";
+import { appBindingMaterializeFunction } from "./functions/app-binding-materialize";
 import { syncBackfillEntityFunction } from "./functions/sync-entity";
 import { usageReportingFunction } from "./functions/usage-reporting";
 import { modelCatalogRefreshFunction } from "./functions/model-catalog-refresh";
@@ -39,6 +40,7 @@ const baseFunctions = [
   syncBackfillEntityFunction,
   dashboardRefreshFunction,
   cleanupAbandonedMaterializationRunsFunction,
+  appBindingMaterializeFunction,
   usageReportingFunction,
   modelCatalogRefreshFunction,
   scheduledQueryExecutorFunction,
@@ -126,6 +128,7 @@ export {
   dashboardRefreshFunction,
   dashboardSchedulerFunction,
   cleanupAbandonedMaterializationRunsFunction,
+  appBindingMaterializeFunction,
   usageReportingFunction,
   modelCatalogRefreshFunction,
   scheduledQueryExecutorFunction,

--- a/api/src/routes/apps.ts
+++ b/api/src/routes/apps.ts
@@ -24,7 +24,8 @@ import { workspaceService } from "../services/workspace.service";
 import { AuthenticatedContext } from "../middleware/workspace.middleware";
 import { AppDefinitionSchema, normalizeAppFiles } from "@mako/schemas";
 import {
-  materializeAppBinding,
+  queueAppBindingMaterialization,
+  buildAppBindingMaterializationStatus,
   hydrateAppBindingUrls,
   getBindingArtifactInfo,
 } from "../services/app-binding-materialization.service";
@@ -416,7 +417,9 @@ app.delete("/:id", async (c: AuthenticatedContext) => {
   }
 });
 
-// POST /:id/bindings/:bindingId/materialize — build the Parquet artifact
+// POST /:id/bindings/:bindingId/materialize — queue the Parquet build.
+// Returns immediately: the build runs in the background (Inngest). Clients
+// poll GET .../materialization until the status is ready/error.
 app.post(
   "/:id/bindings/:bindingId/materialize",
   async (c: AuthenticatedContext) => {
@@ -442,24 +445,73 @@ app.post(
       const body = (await c.req.json().catch(() => ({}))) as {
         force?: boolean;
       };
-      const status = await materializeAppBinding({
+      const result = await queueAppBindingMaterialization({
         workspaceId,
         appId: id,
         bindingId,
         force: body.force === true,
       });
 
-      // Return the refreshed app so the client gets the hydrated parquetUrl.
-      const refreshed = await MakoApp.findById(doc._id);
+      // On a cache hit nothing was queued — return the refreshed app so the
+      // client immediately gets the hydrated parquetUrl.
+      let app: ReturnType<typeof serializeApp> | undefined;
+      if (result.status === "ready") {
+        const refreshed = await MakoApp.findById(doc._id);
+        app = refreshed ? serializeApp(refreshed) : undefined;
+      }
+
       return c.json({
-        success: status.status === "ready",
-        status,
-        app: refreshed ? serializeApp(refreshed) : undefined,
+        success: result.status !== "error",
+        queued: result.queued,
+        alreadyRunning: result.alreadyRunning === true,
+        status: result,
+        app,
       });
     } catch (error) {
-      logger.error("Error materializing app binding", { error });
+      logger.error("Error queueing app binding materialization", { error });
       return c.json(
         { success: false, error: "Failed to materialize binding" },
+        500,
+      );
+    }
+  },
+);
+
+// GET /:id/bindings/:bindingId/materialization — build status (for polling)
+app.get(
+  "/:id/bindings/:bindingId/materialization",
+  async (c: AuthenticatedContext) => {
+    try {
+      const workspaceId = c.req.param("workspaceId");
+      const id = c.req.param("id");
+      const bindingId = c.req.param("bindingId");
+      const userId = c.get("user")?.id;
+
+      if (!Types.ObjectId.isValid(id)) {
+        return c.json({ success: false, error: "Invalid app ID" }, 400);
+      }
+
+      const doc = await MakoApp.findOne({
+        _id: new Types.ObjectId(id),
+        workspaceId: new Types.ObjectId(workspaceId),
+      });
+      if (!doc) return c.json({ success: false, error: "App not found" }, 404);
+      if (!canRead(doc, userId)) {
+        return c.json({ success: false, error: "Access denied" }, 403);
+      }
+
+      const status = buildAppBindingMaterializationStatus(doc, bindingId);
+      if (!status) {
+        return c.json({ success: false, error: "Binding not found" }, 404);
+      }
+
+      return c.json({ success: true, data: status });
+    } catch (error) {
+      logger.error("Error getting app binding materialization status", {
+        error,
+      });
+      return c.json(
+        { success: false, error: "Failed to get materialization status" },
         500,
       );
     }

--- a/api/src/services/app-binding-materialization.service.ts
+++ b/api/src/services/app-binding-materialization.service.ts
@@ -10,7 +10,6 @@
  * APIs verbatim; only the artifact key/hash and Mongo writes are app-specific.
  */
 
-import { promises as fsPromises } from "fs";
 import { Types } from "mongoose";
 import {
   MakoApp,
@@ -19,22 +18,20 @@ import {
   type IMakoAppDataBinding,
 } from "../database/workspace-schema";
 import {
-  buildParquetFromBatches,
-  type FieldMeta,
-} from "../utils/streaming-parquet-builder";
-import {
-  storeArtifact,
   artifactExists,
   withArtifactBuildLock,
+  getArtifactPrefix,
 } from "./dashboard-cache.service";
-import { databaseConnectionService } from "./database-connection.service";
-import { checkPreviewQuerySafety } from "./query-pagination.service";
+import {
+  buildQueryParquetFile,
+  storeParquetArtifactFile,
+  assertReadOnlyMaterializationQuery,
+  PARQUET_ROW_LIMIT,
+} from "./parquet-build.service";
 import { inngest } from "../inngest/client";
 import { loggers } from "../logging";
 
 const logger = loggers.api("app-materialization");
-
-const PARQUET_ROW_LIMIT = 500_000;
 
 /** How often a running build refreshes its heartbeat (`parquetBuildStatusAt`). */
 const BUILD_HEARTBEAT_INTERVAL_MS = 30 * 1000;
@@ -90,27 +87,13 @@ export function buildAppBindingDefinitionHash(
   return (hash >>> 0).toString(16);
 }
 
-/** Object-store key prefix, shared with the dashboard artifact bucket. */
-function artifactPrefix(): string {
-  if (process.env.DASHBOARD_ARTIFACT_PREFIX) {
-    return process.env.DASHBOARD_ARTIFACT_PREFIX;
-  }
-  if (process.env.PR_NUMBER) {
-    return `dashboard-artifacts/pr-${process.env.PR_NUMBER}`;
-  }
-  if (process.env.NODE_ENV === "production") {
-    return "dashboard-artifacts/prod";
-  }
-  return "dashboards";
-}
-
 export function buildAppBindingArtifactKey(input: {
   workspaceId: string;
   appId: string;
   bindingId: string;
   definitionHash: string;
 }): string {
-  return `${artifactPrefix()}/workspaces/${input.workspaceId}/apps/${input.appId}/bindings/${input.bindingId}/${input.definitionHash}.parquet`;
+  return `${getArtifactPrefix()}/workspaces/${input.workspaceId}/apps/${input.appId}/bindings/${input.bindingId}/${input.definitionHash}.parquet`;
 }
 
 /** Proxied API path the browser fetches to read a binding's Parquet artifact. */
@@ -383,21 +366,16 @@ export async function queueAppBindingMaterialization(input: {
 // SQL-family bindings execute the raw code. (MongoDB materialization would need
 // collection/operation metadata; not supported yet.)
 //
-// The binding code is user/agent-editable, so enforce the same read-only
-// safety gate as live preview execution: materialization must never run
-// DDL/DML against the source connection.
+// The binding code is user/agent-editable; the shared read-only safety gate
+// (also enforced inside the build core) is applied here too so queue-time
+// validation reports unsafe queries synchronously.
 function buildExecutableQuery(binding: IMakoAppDataBinding): string {
   if (binding.language !== "sql") {
     throw new Error(
       `Materialization is not supported for ${binding.language} bindings yet`,
     );
   }
-  const safety = checkPreviewQuerySafety(binding.code);
-  if (!safety.safe) {
-    throw new Error(
-      `Binding query failed read-only safety checks: ${safety.errors.join(" ")}`,
-    );
-  }
+  assertReadOnlyMaterializationQuery(binding.code);
   return binding.code;
 }
 
@@ -513,55 +491,23 @@ export async function materializeAppBinding(input: {
       );
       if (!connection) throw new Error("Connection not found");
 
-      const executableQuery = buildExecutableQuery(binding);
-      const fieldsResult =
-        await databaseConnectionService.getStreamingQueryFields(
-          connection,
-          executableQuery,
-          {
-            databaseId: binding.databaseId,
-            databaseName: binding.databaseName,
-          },
-        );
-      // A failed schema probe means the query itself is broken — surface it
-      // instead of silently building an empty "ready" artifact.
-      if (!fieldsResult.success) {
-        throw new Error(
-          fieldsResult.error || "Failed to resolve query schema",
-        );
-      }
-      const fields: FieldMeta[] = fieldsResult.fields ?? [];
-
-      const parquet = await buildParquetFromBatches({
-        filenameBase: `app-${appId}-${bindingId}`,
+      // Shared core: schema probe + streaming + Parquet build + upload.
+      // Strict probe — for SQL bindings a probe failure means the query is
+      // broken, so fail fast instead of building an empty artifact.
+      const parquet = await buildQueryParquetFile({
+        connection,
+        executableQuery: buildExecutableQuery(binding),
+        databaseId: binding.databaseId,
+        databaseName: binding.databaseName,
         rowLimit: PARQUET_ROW_LIMIT,
-        fields,
-        streamBatches: async insertBatch => {
-          const streamResult =
-            await databaseConnectionService.executeStreamingQuery(
-              connection,
-              executableQuery,
-              {
-                batchSize: 5000,
-                databaseId: binding.databaseId,
-                databaseName: binding.databaseName,
-                onBatch: insertBatch,
-              },
-            );
-          // Same rationale: a mid-stream failure must fail the build, not
-          // produce a silently truncated artifact.
-          if (!streamResult.success) {
-            throw new Error(streamResult.error || "Streaming query failed");
-          }
-        },
+        filenameBase: `app-${appId}-${bindingId}`,
+        schemaProbe: "strict",
       });
-
-      await storeArtifact(parquet.filePath, artifactKey, {
-        appId,
-        bindingId,
-        definitionHash,
+      await storeParquetArtifactFile({
+        filePath: parquet.filePath,
+        artifactKey,
+        metadata: { appId, bindingId, definitionHash },
       });
-      await fsPromises.rm(parquet.filePath, { force: true });
 
       const builtAt = new Date();
       const artifactRevision = String(builtAt.getTime());

--- a/api/src/services/app-binding-materialization.service.ts
+++ b/api/src/services/app-binding-materialization.service.ts
@@ -523,6 +523,13 @@ export async function materializeAppBinding(input: {
             databaseName: binding.databaseName,
           },
         );
+      // A failed schema probe means the query itself is broken — surface it
+      // instead of silently building an empty "ready" artifact.
+      if (!fieldsResult.success) {
+        throw new Error(
+          fieldsResult.error || "Failed to resolve query schema",
+        );
+      }
       const fields: FieldMeta[] = fieldsResult.fields ?? [];
 
       const parquet = await buildParquetFromBatches({
@@ -530,16 +537,22 @@ export async function materializeAppBinding(input: {
         rowLimit: PARQUET_ROW_LIMIT,
         fields,
         streamBatches: async insertBatch => {
-          await databaseConnectionService.executeStreamingQuery(
-            connection,
-            executableQuery,
-            {
-              batchSize: 5000,
-              databaseId: binding.databaseId,
-              databaseName: binding.databaseName,
-              onBatch: insertBatch,
-            },
-          );
+          const streamResult =
+            await databaseConnectionService.executeStreamingQuery(
+              connection,
+              executableQuery,
+              {
+                batchSize: 5000,
+                databaseId: binding.databaseId,
+                databaseName: binding.databaseName,
+                onBatch: insertBatch,
+              },
+            );
+          // Same rationale: a mid-stream failure must fail the build, not
+          // produce a silently truncated artifact.
+          if (!streamResult.success) {
+            throw new Error(streamResult.error || "Streaming query failed");
+          }
         },
       });
 

--- a/api/src/services/app-binding-materialization.service.ts
+++ b/api/src/services/app-binding-materialization.service.ts
@@ -29,15 +29,39 @@ import {
 } from "./dashboard-cache.service";
 import { databaseConnectionService } from "./database-connection.service";
 import { checkPreviewQuerySafety } from "./query-pagination.service";
+import { inngest } from "../inngest/client";
 import { loggers } from "../logging";
 
 const logger = loggers.api("app-materialization");
 
 const PARQUET_ROW_LIMIT = 500_000;
 
+/** How often a running build refreshes its heartbeat (`parquetBuildStatusAt`). */
+const BUILD_HEARTBEAT_INTERVAL_MS = 30 * 1000;
+
+/**
+ * A queued/building status with a heartbeat older than this is considered
+ * stale (the worker crashed or was redeployed mid-build) and may be re-queued.
+ */
+export const BUILD_STALE_THRESHOLD_MS = 3 * 60 * 1000;
+
 export interface AppBindingMaterializationStatus {
   bindingId: string;
   status: "ready" | "error";
+  rowCount?: number;
+  byteSize?: number;
+  artifactRevision?: string;
+  error?: string;
+}
+
+export interface AppBindingQueueResult {
+  bindingId: string;
+  /** `ready` means the existing artifact was reused (cache hit). */
+  status: "ready" | "queued" | "building" | "error";
+  /** True when a new background build was enqueued by this call. */
+  queued: boolean;
+  /** True when a build was already in flight for this binding. */
+  alreadyRunning?: boolean;
   rowCount?: number;
   byteSize?: number;
   artifactRevision?: string;
@@ -126,6 +150,236 @@ export function hydrateAppBindingUrls(app: {
   return app;
 }
 
+/** Whether a queued/building status is genuinely in flight (fresh heartbeat). */
+export function isAppBindingBuildActive(
+  cache:
+    | {
+        parquetBuildStatus?: string | null;
+        parquetBuildStatusAt?: Date | string | null;
+      }
+    | undefined,
+): boolean {
+  if (
+    cache?.parquetBuildStatus !== "queued" &&
+    cache?.parquetBuildStatus !== "building"
+  ) {
+    return false;
+  }
+  const at = cache.parquetBuildStatusAt
+    ? new Date(cache.parquetBuildStatusAt).getTime()
+    : 0;
+  return Date.now() - at < BUILD_STALE_THRESHOLD_MS;
+}
+
+/**
+ * Serializable materialization status for one binding, with stale
+ * queued/building states surfaced as errors so pollers always terminate.
+ */
+export function buildAppBindingMaterializationStatus(
+  app: IMakoApp,
+  bindingId: string,
+): {
+  bindingId: string;
+  materialization: "live" | "parquet";
+  status: "missing" | "queued" | "building" | "ready" | "error";
+  error?: string | null;
+  stale: boolean;
+  rowCount?: number;
+  byteSize?: number;
+  artifactRevision?: string;
+  lastRefreshedAt?: Date;
+  parquetBuiltAt?: Date;
+  updatedAt?: Date | null;
+} | null {
+  const binding = app.dataBindings.find(b => b.id === bindingId);
+  if (!binding) return null;
+  const cache = binding.cache;
+  const rawStatus = cache?.parquetBuildStatus ?? "missing";
+  const inFlight = rawStatus === "queued" || rawStatus === "building";
+  const stale = inFlight && !isAppBindingBuildActive(cache);
+  return {
+    bindingId,
+    materialization: binding.materialization,
+    status: stale ? "error" : rawStatus,
+    error: stale
+      ? "Materialization stalled (worker stopped reporting progress). Re-run materialize to retry."
+      : cache?.parquetLastError,
+    stale,
+    rowCount: cache?.rowCount,
+    byteSize: cache?.byteSize,
+    artifactRevision: cache?.artifactRevision,
+    lastRefreshedAt: cache?.lastRefreshedAt,
+    parquetBuiltAt: cache?.parquetBuiltAt,
+    updatedAt: cache?.parquetBuildStatusAt,
+  };
+}
+
+/**
+ * Queue a binding materialization to run in the background and return
+ * immediately. This is the only entry point HTTP handlers should use — the
+ * build itself runs in an Inngest worker (or, if enqueueing fails, in-process
+ * detached from the request) so callers never block on the query + Parquet
+ * build and the build survives client disconnects.
+ *
+ * Returns `ready` without queueing on a cache hit, and dedupes against builds
+ * that are already genuinely in flight. Stale queued/building states (crashed
+ * workers) are reclaimed atomically.
+ */
+export async function queueAppBindingMaterialization(input: {
+  workspaceId: string;
+  appId: string;
+  bindingId: string;
+  force?: boolean;
+}): Promise<AppBindingQueueResult> {
+  const { workspaceId, appId, bindingId, force } = input;
+
+  const appDoc = await MakoApp.findOne({
+    _id: new Types.ObjectId(appId),
+    workspaceId: new Types.ObjectId(workspaceId),
+  });
+  if (!appDoc) {
+    return {
+      bindingId,
+      status: "error",
+      queued: false,
+      error: "App not found",
+    };
+  }
+  const binding = appDoc.dataBindings.find(b => b.id === bindingId);
+  if (!binding) {
+    return {
+      bindingId,
+      status: "error",
+      queued: false,
+      error: "Binding not found",
+    };
+  }
+  if (binding.materialization !== "parquet") {
+    return {
+      bindingId,
+      status: "error",
+      queued: false,
+      error: "Binding is not configured for parquet materialization",
+    };
+  }
+
+  // Validate the query up front so obvious failures (unsupported language,
+  // unsafe SQL) are reported synchronously instead of from the background run.
+  try {
+    buildExecutableQuery(binding);
+  } catch (error) {
+    return {
+      bindingId,
+      status: "error",
+      queued: false,
+      error: error instanceof Error ? error.message : "Invalid binding query",
+    };
+  }
+
+  const definitionHash = buildAppBindingDefinitionHash(binding);
+  const artifactKey = buildAppBindingArtifactKey({
+    workspaceId,
+    appId,
+    bindingId,
+    definitionHash,
+  });
+
+  // Cache hit — reuse the existing artifact without queueing anything.
+  if (
+    !force &&
+    binding.cache?.parquetArtifactKey === artifactKey &&
+    binding.cache?.definitionHash === definitionHash &&
+    binding.cache?.parquetBuildStatus === "ready" &&
+    (await artifactExists(artifactKey))
+  ) {
+    return {
+      bindingId,
+      status: "ready",
+      queued: false,
+      rowCount: binding.cache?.rowCount,
+      byteSize: binding.cache?.byteSize,
+      artifactRevision: binding.cache?.artifactRevision,
+    };
+  }
+
+  if (isAppBindingBuildActive(binding.cache)) {
+    return {
+      bindingId,
+      status:
+        binding.cache?.parquetBuildStatus === "building"
+          ? "building"
+          : "queued",
+      queued: false,
+      alreadyRunning: true,
+    };
+  }
+
+  // Atomically claim the binding: only one caller can flip it to "queued"
+  // unless the previous build's heartbeat has gone stale.
+  const staleCutoff = new Date(Date.now() - BUILD_STALE_THRESHOLD_MS);
+  const claim = await MakoApp.updateOne(
+    {
+      _id: appDoc._id,
+      dataBindings: {
+        $elemMatch: {
+          id: bindingId,
+          $or: [
+            { "cache.parquetBuildStatus": { $nin: ["queued", "building"] } },
+            { "cache.parquetBuildStatusAt": { $lt: staleCutoff } },
+            { "cache.parquetBuildStatusAt": null },
+          ],
+        },
+      },
+    },
+    {
+      $set: {
+        "dataBindings.$.cache.parquetBuildStatus": "queued",
+        "dataBindings.$.cache.parquetBuildStatusAt": new Date(),
+        "dataBindings.$.cache.parquetLastError": null,
+      },
+    },
+  );
+  if (claim.modifiedCount === 0) {
+    return { bindingId, status: "queued", queued: false, alreadyRunning: true };
+  }
+
+  const eventData = {
+    workspaceId,
+    appId,
+    bindingId,
+    force: force === true,
+    dedupeKey: `${appId}:${bindingId}`,
+  };
+  try {
+    await inngest.send({ name: "app/binding.materialize", data: eventData });
+  } catch (error) {
+    // Inngest unavailable — fall back to an in-process background build so
+    // materialization still completes. The request never blocks on it.
+    logger.warn(
+      "Failed to enqueue app binding materialization; running in-process",
+      { workspaceId, appId, bindingId, error },
+    );
+    void materializeAppBinding({ workspaceId, appId, bindingId, force }).catch(
+      err => {
+        logger.error("In-process app binding materialization failed", {
+          workspaceId,
+          appId,
+          bindingId,
+          error: err,
+        });
+      },
+    );
+  }
+
+  logger.info("Queued app binding materialization", {
+    workspaceId,
+    appId,
+    bindingId,
+    force: force === true,
+  });
+  return { bindingId, status: "queued", queued: true };
+}
+
 // SQL-family bindings execute the raw code. (MongoDB materialization would need
 // collection/operation metadata; not supported yet.)
 //
@@ -210,10 +464,24 @@ export async function materializeAppBinding(input: {
       {
         $set: {
           "dataBindings.$.cache.parquetBuildStatus": "building",
+          "dataBindings.$.cache.parquetBuildStatusAt": new Date(),
           "dataBindings.$.cache.parquetLastError": null,
         },
       },
     );
+
+    // Heartbeat while the build runs so stuck "building" states are
+    // detectable: if the worker dies, the heartbeat stops and the status is
+    // treated as stale (reclaimable + reported as an error to pollers).
+    const heartbeat = setInterval(() => {
+      void MakoApp.updateOne(
+        { _id: appDoc._id, "dataBindings.id": bindingId },
+        {
+          $set: { "dataBindings.$.cache.parquetBuildStatusAt": new Date() },
+        },
+      ).catch(() => undefined);
+    }, BUILD_HEARTBEAT_INTERVAL_MS);
+    heartbeat.unref?.();
 
     const startedAt = Date.now();
     const recordRun = async (run: {
@@ -296,6 +564,7 @@ export async function materializeAppBinding(input: {
             "dataBindings.$.cache.parquetBuiltAt": builtAt,
             "dataBindings.$.cache.lastRefreshedAt": builtAt,
             "dataBindings.$.cache.parquetBuildStatus": "ready",
+            "dataBindings.$.cache.parquetBuildStatusAt": builtAt,
             "dataBindings.$.cache.parquetLastError": null,
           },
         },
@@ -330,6 +599,7 @@ export async function materializeAppBinding(input: {
         {
           $set: {
             "dataBindings.$.cache.parquetBuildStatus": "error",
+            "dataBindings.$.cache.parquetBuildStatusAt": new Date(),
             "dataBindings.$.cache.parquetLastError": message,
           },
         },
@@ -342,6 +612,8 @@ export async function materializeAppBinding(input: {
         error: message,
       });
       return { bindingId, status: "error" as const, error: message };
+    } finally {
+      clearInterval(heartbeat);
     }
   });
 }

--- a/api/src/services/dashboard-artifact-rebuild.service.ts
+++ b/api/src/services/dashboard-artifact-rebuild.service.ts
@@ -1,19 +1,17 @@
-import { promises as fsPromises } from "fs";
 import crypto from "crypto";
 import { Types } from "mongoose";
 import { Dashboard, DatabaseConnection } from "../database/workspace-schema";
 import { loggers } from "../logging";
-import { databaseConnectionService } from "./database-connection.service";
 import {
   artifactExists,
   buildDashboardArtifactKey,
-  storeArtifact,
   withArtifactBuildLock,
 } from "./dashboard-cache.service";
 import {
-  buildParquetFromBatches,
-  type FieldMeta,
-} from "../utils/streaming-parquet-builder";
+  buildQueryParquetFile,
+  storeParquetArtifactFile,
+  PARQUET_ROW_LIMIT,
+} from "./parquet-build.service";
 import { generateSnapshotsForDataSource } from "./dashboard-snapshot.service";
 import {
   appendMaterializationRunEvent,
@@ -294,31 +292,6 @@ export async function rebuildDashboardArtifacts(
           );
         }
 
-        let fields: FieldMeta[] = [];
-        try {
-          const schemaResult =
-            await databaseConnectionService.getStreamingQueryFields(
-              database,
-              executableQuery,
-              {
-                databaseId: dataSource.query.databaseId as string | undefined,
-                databaseName: dataSource.query.databaseName as
-                  | string
-                  | undefined,
-              },
-            );
-          if (schemaResult.success && schemaResult.fields) {
-            fields = schemaResult.fields;
-          }
-        } catch {
-          logger.warn(
-            "Schema probe failed, falling back to runtime inference",
-            {
-              dataSourceId: dataSource.id,
-            },
-          );
-        }
-
         const parquetWriteStartedEvent = pushRunEvent(currentRun, {
           type: "parquet_write_started",
           message: "Started streaming parquet build",
@@ -332,11 +305,18 @@ export async function rebuildDashboardArtifacts(
           stage: "parquet_streaming",
         });
 
-        const rowLimit = dataSource.rowLimit || 500000;
-        const parquetFile = await buildParquetFromBatches({
+        // Shared core: schema probe + streaming + Parquet build. Lenient
+        // probe preserves runtime column inference for MongoDB executables;
+        // stream failures are strict (a failed query fails the build instead
+        // of producing a silently truncated artifact).
+        const parquetFile = await buildQueryParquetFile({
+          connection: database,
+          executableQuery,
+          databaseId: dataSource.query.databaseId as string | undefined,
+          databaseName: dataSource.query.databaseName as string | undefined,
+          rowLimit: dataSource.rowLimit || PARQUET_ROW_LIMIT,
           filenameBase: `${dashboard._id}-${dataSource.id}`,
-          rowLimit,
-          fields,
+          schemaProbe: "lenient",
           onBatchInserted: async (totalRows: number) => {
             await updateMaterializationRunHeartbeat({
               runId: currentRun.runId,
@@ -348,20 +328,6 @@ export async function rebuildDashboardArtifacts(
                 `parquet_streaming:${totalRows}_rows`,
               );
             }
-          },
-          streamBatches: async insertBatch => {
-            await databaseConnectionService.executeStreamingQuery(
-              database,
-              executableQuery,
-              {
-                batchSize: 5000,
-                databaseId: dataSource.query.databaseId as string | undefined,
-                databaseName: dataSource.query.databaseName as
-                  | string
-                  | undefined,
-                onBatch: insertBatch,
-              },
-            );
           },
         });
 
@@ -410,17 +376,15 @@ export async function rebuildDashboardArtifacts(
           stage: "artifact_upload",
         });
 
-        try {
-          await storeArtifact(parquetFile.filePath, artifactKey, {
+        await storeParquetArtifactFile({
+          filePath: parquetFile.filePath,
+          artifactKey,
+          metadata: {
             dashboardId: dashboard._id.toString(),
             dataSourceId: dataSource.id,
             definitionHash,
-          });
-        } finally {
-          await fsPromises
-            .rm(parquetFile.filePath, { force: true })
-            .catch(() => undefined);
-        }
+          },
+        });
         const artifactStorePutFinishedEvent = pushRunEvent(currentRun, {
           type: "artifact_store_put_finished",
           message: "Stored artifact successfully",

--- a/api/src/services/dashboard-cache.service.ts
+++ b/api/src/services/dashboard-cache.service.ts
@@ -15,6 +15,14 @@ export interface DashboardArtifactDescriptor {
   rowCount?: number;
 }
 
+/**
+ * Object-store key prefix for all materialized artifacts (dashboards and app
+ * bindings share the same bucket/prefix).
+ */
+export function getArtifactPrefix(): string {
+  return getDashboardArtifactPrefix();
+}
+
 function getDashboardArtifactPrefix(): string {
   const rawPrefix = process.env.DASHBOARD_ARTIFACT_PREFIX;
   if (rawPrefix) {

--- a/api/src/services/parquet-build.service.ts
+++ b/api/src/services/parquet-build.service.ts
@@ -1,0 +1,167 @@
+/**
+ * Shared Parquet materialization core.
+ *
+ * The single "query -> Parquet artifact" pipeline used by BOTH dashboard data
+ * sources and app data bindings: schema probe -> streaming query -> node
+ * DuckDB Parquet build -> artifact store upload. Callers own everything
+ * domain-specific (definition hashes, artifact keys, cache metadata writes,
+ * run records, snapshots, queueing).
+ *
+ * Error semantics are strict by design: a failed stream must fail the build —
+ * silently producing an empty or truncated "ready" artifact is worse than an
+ * error. The schema probe can be lenient (fall back to runtime column
+ * inference) where drivers don't support probing, e.g. MongoDB executables.
+ */
+
+import { promises as fsPromises } from "fs";
+import type { IDatabaseConnection } from "../database/workspace-schema";
+import {
+  buildParquetFromBatches,
+  type FieldMeta,
+} from "../utils/streaming-parquet-builder";
+import { storeArtifact } from "./dashboard-cache.service";
+import { databaseConnectionService } from "./database-connection.service";
+import { checkPreviewQuerySafety } from "./query-pagination.service";
+import { loggers } from "../logging";
+
+const logger = loggers.api("parquet-build");
+
+/** Default/maximum rows materialized into a single Parquet artifact. */
+export const PARQUET_ROW_LIMIT = 500_000;
+
+const STREAM_BATCH_SIZE = 5000;
+
+/** SQL string, or a MongoDB executable descriptor (dashboard data sources). */
+export type ExecutableQuery =
+  | string
+  | { collection: string; operation: string; query: string };
+
+/**
+ * Read-only gate for SQL materialization queries. Materialization runs
+ * user/agent-editable code against the source connection, so it must never
+ * execute DDL/DML. MongoDB executables are validated by their drivers.
+ */
+export function assertReadOnlyMaterializationQuery(
+  executableQuery: ExecutableQuery,
+): void {
+  if (typeof executableQuery !== "string") return;
+  const safety = checkPreviewQuerySafety(executableQuery);
+  if (!safety.safe) {
+    throw new Error(
+      `Query failed read-only safety checks: ${safety.errors.join(" ")}`,
+    );
+  }
+}
+
+export interface BuildQueryParquetFileInput {
+  connection: IDatabaseConnection;
+  executableQuery: ExecutableQuery;
+  databaseId?: string;
+  databaseName?: string;
+  /** Capped at PARQUET_ROW_LIMIT-style limits by the caller; default 500k. */
+  rowLimit?: number;
+  /** Local temp-file name base, e.g. `app-{appId}-{bindingId}`. */
+  filenameBase: string;
+  /**
+   * `strict`: a failed schema probe fails the build (the probe executes the
+   * query, so a probe failure means the query itself is broken).
+   * `lenient`: fall back to runtime column inference (needed where probing is
+   * unsupported, e.g. MongoDB executables).
+   */
+  schemaProbe?: "strict" | "lenient";
+  /** Progress callback per inserted batch (heartbeats, run events). */
+  onBatchInserted?: (totalRows: number) => Promise<void>;
+}
+
+export interface BuiltParquetFile {
+  /** Local temp file; pass to `storeParquetArtifactFile` (which deletes it). */
+  filePath: string;
+  rowCount: number;
+  byteSize: number;
+}
+
+/**
+ * Execute a query and stream its results into a local Parquet file.
+ * Throws on any query failure — never returns a partial result.
+ */
+export async function buildQueryParquetFile(
+  input: BuildQueryParquetFileInput,
+): Promise<BuiltParquetFile> {
+  const {
+    connection,
+    executableQuery,
+    databaseId,
+    databaseName,
+    filenameBase,
+    onBatchInserted,
+  } = input;
+
+  assertReadOnlyMaterializationQuery(executableQuery);
+
+  let fields: FieldMeta[] = [];
+  try {
+    const schemaResult = await databaseConnectionService.getStreamingQueryFields(
+      connection,
+      executableQuery,
+      { databaseId, databaseName },
+    );
+    if (schemaResult.success && schemaResult.fields) {
+      fields = schemaResult.fields;
+    } else if (input.schemaProbe !== "lenient") {
+      throw new Error(
+        schemaResult.error || "Failed to resolve query schema",
+      );
+    } else {
+      logger.warn("Schema probe failed, falling back to runtime inference", {
+        filenameBase,
+        error: schemaResult.error,
+      });
+    }
+  } catch (error) {
+    if (input.schemaProbe !== "lenient") throw error;
+    logger.warn("Schema probe failed, falling back to runtime inference", {
+      filenameBase,
+      error,
+    });
+  }
+
+  return await buildParquetFromBatches({
+    filenameBase,
+    rowLimit: input.rowLimit ?? PARQUET_ROW_LIMIT,
+    fields,
+    onBatchInserted,
+    streamBatches: async insertBatch => {
+      const streamResult = await databaseConnectionService.executeStreamingQuery(
+        connection,
+        executableQuery,
+        {
+          batchSize: STREAM_BATCH_SIZE,
+          databaseId,
+          databaseName,
+          onBatch: insertBatch,
+        },
+      );
+      // A mid-stream failure must fail the build — otherwise a silently
+      // truncated (or empty) artifact would be reported as "ready".
+      if (!streamResult.success) {
+        throw new Error(streamResult.error || "Streaming query failed");
+      }
+    },
+  });
+}
+
+/**
+ * Upload a built Parquet file to the shared artifact store and remove the
+ * local temp file (always, even when the upload fails).
+ */
+export async function storeParquetArtifactFile(input: {
+  filePath: string;
+  artifactKey: string;
+  metadata?: Record<string, string>;
+}): Promise<void> {
+  try {
+    await storeArtifact(input.filePath, input.artifactKey, input.metadata);
+  } finally {
+    await fsPromises.rm(input.filePath, { force: true }).catch(() => undefined);
+  }
+}

--- a/app/src/app-runtime/agent-tools.ts
+++ b/app/src/app-runtime/agent-tools.ts
@@ -46,8 +46,12 @@ function listOpenApps() {
  * Bounded wait for `materialize_binding`. The build runs server-side in the
  * background; the tool waits at most this long before returning a "still
  * building" result, so the agent round-trip can never hang on a slow build.
+ * The agent can override per call via `waitSeconds` (0..600); re-calling the
+ * tool resumes waiting on the in-flight build, so polling with a timeout is
+ * just repeated calls.
  */
-const MATERIALIZE_TOOL_WAIT_MS = 120_000;
+const MATERIALIZE_TOOL_DEFAULT_WAIT_MS = 120_000;
+const MATERIALIZE_TOOL_MAX_WAIT_MS = 600_000;
 
 export async function executeAppAgentTool(
   toolName: string,
@@ -212,11 +216,15 @@ export async function executeAppAgentTool(
       const appEntity = await ensureApp(appId);
       const binding = appEntity?.dataBindings.find(b => b.name === input.name);
       if (!binding) return fail(`No data binding named "${input.name}"`);
+      const timeoutMs =
+        typeof input.waitSeconds === "number" && input.waitSeconds >= 0
+          ? Math.min(input.waitSeconds * 1000, MATERIALIZE_TOOL_MAX_WAIT_MS)
+          : MATERIALIZE_TOOL_DEFAULT_WAIT_MS;
       const result = await store.materializeBinding(
         workspaceId,
         appId,
         binding.id,
-        { signal: options?.signal, timeoutMs: MATERIALIZE_TOOL_WAIT_MS },
+        { signal: options?.signal, timeoutMs },
       );
       if (result.status === "building") {
         // Not an error: the build continues server-side. Return so the agent
@@ -228,7 +236,8 @@ export async function executeAppAgentTool(
           hint:
             `Materialization of "${binding.name}" is still running in the background. ` +
             "The app will load the data automatically once it is ready. " +
-            "Call materialize_binding again later to check completion if needed.",
+            "To wait for completion, call materialize_binding again (optionally " +
+            "with a larger waitSeconds); it resumes waiting on the in-flight build.",
         };
       }
       if (!result.success) {

--- a/app/src/app-runtime/agent-tools.ts
+++ b/app/src/app-runtime/agent-tools.ts
@@ -42,10 +42,17 @@ function listOpenApps() {
     });
 }
 
+/**
+ * Bounded wait for `materialize_binding`. The build runs server-side in the
+ * background; the tool waits at most this long before returning a "still
+ * building" result, so the agent round-trip can never hang on a slow build.
+ */
+const MATERIALIZE_TOOL_WAIT_MS = 120_000;
+
 export async function executeAppAgentTool(
   toolName: string,
   input: Record<string, unknown>,
-  _options?: { executionId?: string; signal?: AbortSignal },
+  options?: { executionId?: string; signal?: AbortSignal },
 ): Promise<ToolResult> {
   const store = useAppStore.getState();
   const workspaceId = getCurrentWorkspaceId();
@@ -209,13 +216,28 @@ export async function executeAppAgentTool(
         workspaceId,
         appId,
         binding.id,
+        { signal: options?.signal, timeoutMs: MATERIALIZE_TOOL_WAIT_MS },
       );
+      if (result.status === "building") {
+        // Not an error: the build continues server-side. Return so the agent
+        // can keep working instead of blocking on a long-running build.
+        return {
+          success: true,
+          binding: { name: binding.name },
+          status: "building",
+          hint:
+            `Materialization of "${binding.name}" is still running in the background. ` +
+            "The app will load the data automatically once it is ready. " +
+            "Call materialize_binding again later to check completion if needed.",
+        };
+      }
       if (!result.success) {
         return fail(result.error || "Materialization failed");
       }
       return {
         success: true,
         binding: { name: binding.name },
+        status: "ready",
         hint: `Materialized. Read it with useQuery("${binding.name}") or useDuckDB(sql).`,
       };
     }

--- a/app/src/components/AppBindingEditor.tsx
+++ b/app/src/components/AppBindingEditor.tsx
@@ -16,6 +16,7 @@ import {
   Database as MaterializeIcon,
   Info as InfoIcon,
   History as HistoryIcon,
+  Eye as PreviewIcon,
   CheckCircle2 as SuccessIcon,
   XCircle as ErrorIcon,
 } from "lucide-react";
@@ -23,6 +24,7 @@ import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useAppStore } from "../store/appStore";
 import { useConsoleStore } from "../store/consoleStore";
+import { previewParquetArtifact } from "../lib/parquet-preview";
 import Console from "./Console";
 import ResultsTable from "./ResultsTable";
 
@@ -68,6 +70,7 @@ export default function AppBindingEditor({
   const [viewMode, setViewMode] = useState<"table" | "json" | "chart">("table");
   const [running, setRunning] = useState(false);
   const [materializing, setMaterializing] = useState(false);
+  const [previewingSnapshot, setPreviewingSnapshot] = useState(false);
   const [historyAnchor, setHistoryAnchor] = useState<HTMLElement | null>(null);
 
   useEffect(() => {
@@ -123,6 +126,39 @@ export default function AppBindingEditor({
     await materializeBinding(workspaceId, appId, bindingId);
     setMaterializing(false);
   }, [workspaceId, appId, bindingId, materializeBinding]);
+
+  const bindingCache = binding?.cache;
+  const handlePreviewSnapshot = useCallback(async () => {
+    if (!bindingCache?.parquetUrl) return;
+    setPreviewingSnapshot(true);
+    const startedAt = Date.now();
+    try {
+      const result = await previewParquetArtifact(bindingCache.parquetUrl);
+      setPreview({
+        results: result.rows,
+        executedAt: new Date().toISOString(),
+        resultCount: result.totalRows,
+        executionTime: Date.now() - startedAt,
+        fields: result.fields.map(f => f.name),
+      });
+      setViewMode("table");
+    } catch (e) {
+      setPreview({
+        results: [
+          {
+            error:
+              e instanceof Error
+                ? e.message
+                : "Failed to preview the materialized data",
+          },
+        ],
+        executedAt: new Date().toISOString(),
+        resultCount: 0,
+      });
+    } finally {
+      setPreviewingSnapshot(false);
+    }
+  }, [bindingCache?.parquetUrl]);
 
   if (!appEntity) {
     return (
@@ -216,6 +252,19 @@ export default function AppBindingEditor({
                   : cache.parquetBuildStatus
               }
             />
+          )}
+          {cache?.parquetBuildStatus === "ready" && cache?.parquetUrl && (
+            <Tooltip title="Preview the materialized data">
+              <span>
+                <IconButton
+                  size="small"
+                  onClick={() => void handlePreviewSnapshot()}
+                  disabled={previewingSnapshot}
+                >
+                  <PreviewIcon size={18} strokeWidth={1.5} />
+                </IconButton>
+              </span>
+            </Tooltip>
           )}
           <Tooltip title="Materialization history">
             <span>

--- a/app/src/components/DashboardDataSourceEditor.tsx
+++ b/app/src/components/DashboardDataSourceEditor.tsx
@@ -1,0 +1,495 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  Box,
+  Typography,
+  Button,
+  Chip,
+  Tooltip,
+  IconButton,
+  Popover,
+  Divider,
+} from "@mui/material";
+import {
+  ChevronRight as BreadcrumbChevronIcon,
+  Database as MaterializeIcon,
+  History as HistoryIcon,
+  Eye as PreviewIcon,
+  CheckCircle2 as SuccessIcon,
+  XCircle as ErrorIcon,
+} from "lucide-react";
+import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
+import { useWorkspace } from "../contexts/workspace-context";
+import {
+  useDashboardStore,
+  type MaterializationRunRecord,
+} from "../store/dashboardStore";
+import { useConsoleStore } from "../store/consoleStore";
+import { previewParquetArtifact } from "../lib/parquet-preview";
+import Console from "./Console";
+import ResultsTable from "./ResultsTable";
+
+interface PreviewResult {
+  results: Record<string, unknown>[];
+  executedAt: string;
+  resultCount: number;
+  executionTime?: number;
+  fields?: Array<{ name?: string; originalName?: string } | string>;
+}
+
+const MATERIALIZE_POLL_INTERVAL_MS = 2500;
+const MATERIALIZE_POLL_TIMEOUT_MS = 10 * 60 * 1000;
+
+function dataSourceFilePath(name: string): string {
+  return `${name.replace(/[^a-zA-Z0-9_-]/g, "_")}.sql`;
+}
+
+/**
+ * Full-screen editor tab for a dashboard data source — the same experience as
+ * app data bindings (Console editor + results + materialization controls),
+ * opened from the dashboard's data source panel.
+ */
+export default function DashboardDataSourceEditor({
+  tabId,
+  dashboardId,
+  dataSourceId,
+}: {
+  tabId: string;
+  dashboardId: string;
+  dataSourceId: string;
+}) {
+  const { currentWorkspace } = useWorkspace();
+  const workspaceId = currentWorkspace?.id;
+
+  const dashboard = useDashboardStore(s => s.openDashboards[dashboardId]);
+  const openDashboard = useDashboardStore(s => s.openDashboard);
+  const updateDataSource = useDashboardStore(s => s.updateDataSource);
+  const saveDashboard = useDashboardStore(s => s.saveDashboard);
+  const materializeDataSource = useDashboardStore(
+    s => s.materializeDashboardDataSource,
+  );
+  const fetchMaterializationStatus = useDashboardStore(
+    s => s.fetchDashboardMaterializationStatus,
+  );
+  const fetchMaterializationRuns = useDashboardStore(
+    s => s.fetchMaterializationRuns,
+  );
+  const executeQuery = useConsoleStore(s => s.executeQuery);
+
+  const [preview, setPreview] = useState<PreviewResult | null>(null);
+  const [viewMode, setViewMode] = useState<"table" | "json" | "chart">("table");
+  const [running, setRunning] = useState(false);
+  const [materializing, setMaterializing] = useState(false);
+  const [previewingSnapshot, setPreviewingSnapshot] = useState(false);
+  const [historyAnchor, setHistoryAnchor] = useState<HTMLElement | null>(null);
+  const [historyRuns, setHistoryRuns] = useState<MaterializationRunRecord[]>(
+    [],
+  );
+
+  useEffect(() => {
+    if (!dashboard && workspaceId) {
+      void openDashboard(workspaceId, dashboardId);
+    }
+  }, [dashboard, workspaceId, dashboardId, openDashboard]);
+
+  const dataSource = dashboard?.dataSources.find(ds => ds.id === dataSourceId);
+
+  const handleExecute = useCallback(
+    async (content: string, connectionId?: string, databaseId?: string) => {
+      if (!workspaceId || !connectionId) return;
+      setRunning(true);
+      try {
+        const res = await executeQuery(workspaceId, connectionId, content, {
+          databaseId,
+          databaseName: dataSource?.query.databaseName,
+        });
+        if (res.success) {
+          setPreview({
+            results: res.rows || [],
+            executedAt: new Date().toISOString(),
+            resultCount: res.rows?.length ?? 0,
+            executionTime: res.executionTime,
+            fields: res.fields,
+          });
+        } else {
+          setPreview({
+            results: [{ error: res.error || "Query failed" }],
+            executedAt: new Date().toISOString(),
+            resultCount: 0,
+          });
+        }
+      } finally {
+        setRunning(false);
+      }
+    },
+    [workspaceId, executeQuery, dataSource?.query.databaseName],
+  );
+
+  const handleSave = useCallback(
+    async (content: string) => {
+      if (!workspaceId || !dataSource) return false;
+      updateDataSource(dashboardId, dataSourceId, {
+        query: { ...dataSource.query, code: content },
+      });
+      const result = await saveDashboard(workspaceId, dashboardId);
+      return result.ok;
+    },
+    [
+      workspaceId,
+      dashboardId,
+      dataSourceId,
+      dataSource,
+      updateDataSource,
+      saveDashboard,
+    ],
+  );
+
+  const handleMaterialize = useCallback(async () => {
+    if (!workspaceId) return;
+    setMaterializing(true);
+    try {
+      await materializeDataSource(workspaceId, dashboardId, dataSourceId, {
+        force: true,
+      });
+      // Poll until this data source leaves queued/building (status fetch also
+      // syncs cache onto the open dashboard, so the chip updates live).
+      const deadline = Date.now() + MATERIALIZE_POLL_TIMEOUT_MS;
+      while (Date.now() < deadline) {
+        await new Promise(resolve =>
+          setTimeout(resolve, MATERIALIZE_POLL_INTERVAL_MS),
+        );
+        const status = await fetchMaterializationStatus(
+          workspaceId,
+          dashboardId,
+        );
+        const sourceStatus = status?.dataSources.find(
+          source => source.dataSourceId === dataSourceId,
+        );
+        if (
+          !sourceStatus ||
+          (sourceStatus.status !== "queued" &&
+            sourceStatus.status !== "building")
+        ) {
+          break;
+        }
+      }
+    } finally {
+      setMaterializing(false);
+    }
+  }, [
+    workspaceId,
+    dashboardId,
+    dataSourceId,
+    materializeDataSource,
+    fetchMaterializationStatus,
+  ]);
+
+  const cache = dataSource?.cache;
+
+  const handlePreviewSnapshot = useCallback(async () => {
+    if (!workspaceId) return;
+    const base = `/api/workspaces/${workspaceId}/dashboards/${dashboardId}/data-sources/${dataSourceId}/materialization/artifact`;
+    const url =
+      cache?.parquetUrl ||
+      (cache?.artifactRevision
+        ? `${base}?rev=${encodeURIComponent(cache.artifactRevision)}`
+        : base);
+    setPreviewingSnapshot(true);
+    const startedAt = Date.now();
+    try {
+      const result = await previewParquetArtifact(url);
+      setPreview({
+        results: result.rows,
+        executedAt: new Date().toISOString(),
+        resultCount: result.totalRows,
+        executionTime: Date.now() - startedAt,
+        fields: result.fields.map(f => f.name),
+      });
+      setViewMode("table");
+    } catch (e) {
+      setPreview({
+        results: [
+          {
+            error:
+              e instanceof Error
+                ? e.message
+                : "Failed to preview the materialized data",
+          },
+        ],
+        executedAt: new Date().toISOString(),
+        resultCount: 0,
+      });
+    } finally {
+      setPreviewingSnapshot(false);
+    }
+  }, [workspaceId, dashboardId, dataSourceId, cache]);
+
+  const openHistory = useCallback(
+    async (anchor: HTMLElement) => {
+      setHistoryAnchor(anchor);
+      if (!workspaceId) return;
+      const runs = await fetchMaterializationRuns(
+        workspaceId,
+        dashboardId,
+        dataSourceId,
+      );
+      setHistoryRuns(runs);
+    },
+    [workspaceId, dashboardId, dataSourceId, fetchMaterializationRuns],
+  );
+
+  if (!dashboard) {
+    return (
+      <Box sx={{ p: 3, color: "text.secondary" }}>
+        <Typography variant="body2">Loading…</Typography>
+      </Box>
+    );
+  }
+  if (!dataSource) {
+    return (
+      <Box sx={{ p: 3, color: "text.secondary" }}>
+        <Typography variant="body2">
+          This data source no longer exists.
+        </Typography>
+      </Box>
+    );
+  }
+
+  const breadcrumb = [
+    "Dashboards",
+    dashboard.title || "Dashboard",
+    "Data sources",
+    dataSource.name,
+  ];
+
+  const headerExtras = (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, ml: 1 }}>
+      <Button
+        size="small"
+        variant="outlined"
+        startIcon={<MaterializeIcon size={16} strokeWidth={1.5} />}
+        onClick={() => void handleMaterialize()}
+        disabled={materializing}
+      >
+        {materializing ? "Materializing…" : "Materialize"}
+      </Button>
+      {cache?.parquetBuildStatus && (
+        <Chip
+          size="small"
+          variant="outlined"
+          color={
+            cache.parquetBuildStatus === "ready"
+              ? "success"
+              : cache.parquetBuildStatus === "error"
+                ? "error"
+                : "default"
+          }
+          label={
+            cache.parquetBuildStatus === "ready" && cache.rowCount != null
+              ? `${cache.rowCount.toLocaleString()} rows`
+              : cache.parquetBuildStatus
+          }
+        />
+      )}
+      {cache?.parquetBuildStatus === "ready" && (
+        <Tooltip title="Preview the materialized data">
+          <span>
+            <IconButton
+              size="small"
+              onClick={() => void handlePreviewSnapshot()}
+              disabled={previewingSnapshot}
+            >
+              <PreviewIcon size={18} strokeWidth={1.5} />
+            </IconButton>
+          </span>
+        </Tooltip>
+      )}
+      <Tooltip title="Materialization history">
+        <IconButton
+          size="small"
+          onClick={e => void openHistory(e.currentTarget)}
+        >
+          <HistoryIcon size={18} strokeWidth={1.5} />
+        </IconButton>
+      </Tooltip>
+    </Box>
+  );
+
+  return (
+    <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
+      {/* Breadcrumb — matches the console breadcrumb style */}
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          minHeight: 22,
+          px: 1.5,
+          py: 0.25,
+          backgroundColor: "background.paper",
+          color: "text.secondary",
+          fontSize: "0.75rem",
+          gap: 0.25,
+          borderBottom: "1px solid",
+          borderColor: "divider",
+        }}
+      >
+        {breadcrumb.map((segment, index) => (
+          <Box
+            key={`${index}-${segment}`}
+            component="span"
+            sx={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 0.25,
+              minWidth: 0,
+            }}
+          >
+            {index > 0 && (
+              <BreadcrumbChevronIcon
+                size={12}
+                strokeWidth={2}
+                style={{ flexShrink: 0, opacity: 0.6 }}
+              />
+            )}
+            <Box
+              component="span"
+              sx={{
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {segment}
+            </Box>
+          </Box>
+        ))}
+      </Box>
+
+      <Box sx={{ flexGrow: 1, minHeight: 0 }}>
+        <PanelGroup direction="vertical" style={{ height: "100%" }}>
+          <Panel defaultSize={55} minSize={20}>
+            <Console
+              variant="data-source"
+              consoleId={tabId}
+              initialContent={dataSource.query.code || ""}
+              filePath={dataSourceFilePath(dataSource.name)}
+              onExecute={handleExecute}
+              onSave={handleSave}
+              isExecuting={running}
+              connectionId={dataSource.query.connectionId}
+              onDatabaseChange={connectionId => {
+                if (workspaceId) {
+                  updateDataSource(dashboardId, dataSourceId, {
+                    query: { ...dataSource.query, connectionId },
+                  });
+                  void saveDashboard(workspaceId, dashboardId);
+                }
+              }}
+              onDatabaseNameChange={(databaseId, databaseName) => {
+                if (workspaceId) {
+                  updateDataSource(dashboardId, dataSourceId, {
+                    query: { ...dataSource.query, databaseId, databaseName },
+                  });
+                  void saveDashboard(workspaceId, dashboardId);
+                }
+              }}
+              databaseId={dataSource.query.databaseId}
+              databaseName={dataSource.query.databaseName}
+              headerExtras={headerExtras}
+            />
+          </Panel>
+          <PanelResizeHandle
+            style={{
+              height: 4,
+              background: "var(--mui-palette-divider, #ddd)",
+            }}
+          />
+          <Panel defaultSize={45} minSize={10}>
+            <ResultsTable
+              results={preview}
+              viewMode={viewMode}
+              onViewModeChange={setViewMode}
+            />
+          </Panel>
+        </PanelGroup>
+      </Box>
+
+      {/* Materialization history */}
+      <Popover
+        open={Boolean(historyAnchor)}
+        anchorEl={historyAnchor}
+        onClose={() => setHistoryAnchor(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+      >
+        <Box sx={{ p: 1.5, minWidth: 320, maxWidth: 460 }}>
+          <Typography variant="subtitle2" sx={{ mb: 1 }}>
+            Materialization history
+          </Typography>
+          {historyRuns.length === 0 ? (
+            <Typography variant="caption" color="text.secondary">
+              No runs yet.
+            </Typography>
+          ) : (
+            historyRuns.map((run, i) => {
+              const finishedAt = run.finishedAt
+                ? new Date(run.finishedAt)
+                : null;
+              const startedAt = run.startedAt
+                ? new Date(run.startedAt)
+                : new Date(run.requestedAt);
+              const durationMs =
+                finishedAt && startedAt
+                  ? finishedAt.getTime() - startedAt.getTime()
+                  : null;
+              return (
+                <Box key={run.runId}>
+                  {i > 0 && <Divider sx={{ my: 0.5 }} />}
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                    {run.status === "ready" ? (
+                      <SuccessIcon
+                        size={16}
+                        strokeWidth={1.5}
+                        style={{
+                          color: "var(--mui-palette-success-main, green)",
+                        }}
+                      />
+                    ) : (
+                      <ErrorIcon
+                        size={16}
+                        strokeWidth={1.5}
+                        style={{
+                          color: "var(--mui-palette-error-main, crimson)",
+                        }}
+                      />
+                    )}
+                    <Typography variant="caption" sx={{ flex: 1 }}>
+                      {new Date(run.requestedAt).toLocaleString()}
+                    </Typography>
+                    {run.status === "ready" && run.rowCount != null && (
+                      <Typography variant="caption" color="text.secondary">
+                        {run.rowCount.toLocaleString()} rows
+                      </Typography>
+                    )}
+                    {durationMs != null && durationMs >= 0 && (
+                      <Typography variant="caption" color="text.secondary">
+                        {(durationMs / 1000).toFixed(1)}s
+                      </Typography>
+                    )}
+                  </Box>
+                  {run.error && (
+                    <Typography
+                      variant="caption"
+                      color="error"
+                      sx={{ display: "block", pl: 3, whiteSpace: "pre-wrap" }}
+                    >
+                      {run.error}
+                    </Typography>
+                  )}
+                </Box>
+              );
+            })
+          )}
+        </Box>
+      </Popover>
+    </Box>
+  );
+}

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -61,6 +61,7 @@ import DashboardCanvas from "./DashboardCanvas";
 import AppRenderer from "./AppRenderer";
 import AppFileEditor from "./AppFileEditor";
 import AppBindingEditor from "./AppBindingEditor";
+import DashboardDataSourceEditor from "./DashboardDataSourceEditor";
 import TableDataView from "./TableDataView";
 import ScheduleConsoleModal from "./ScheduleConsoleModal";
 import ConsoleRemoteUpdateBanner from "./ConsoleRemoteUpdateBanner";
@@ -2049,7 +2050,8 @@ function Editor({
                               <AppIcon size={18} strokeWidth={1.5} />
                             ) : tab.kind === "app-file" ? (
                               <AppFileIcon size={18} strokeWidth={1.5} />
-                            ) : tab.kind === "app-binding" ? (
+                            ) : tab.kind === "app-binding" ||
+                              tab.kind === "dashboard-data-source" ? (
                               <DatabaseIcon size={18} strokeWidth={1.5} />
                             ) : tab.kind === "table-data" ? (
                               <TableDataIcon size={18} strokeWidth={1.5} />
@@ -2255,6 +2257,12 @@ function Editor({
                     tabId={tab.id}
                     appId={tab.metadata?.appId as string}
                     bindingId={tab.metadata?.bindingId as string}
+                  />
+                ) : tab.kind === "dashboard-data-source" ? (
+                  <DashboardDataSourceEditor
+                    tabId={tab.id}
+                    dashboardId={tab.metadata?.dashboardId as string}
+                    dataSourceId={tab.metadata?.dataSourceId as string}
                   />
                 ) : (
                   /* Console tab: editor + results split */

--- a/app/src/components/dashboard/DataSourcePanel.tsx
+++ b/app/src/components/dashboard/DataSourcePanel.tsx
@@ -38,6 +38,7 @@ import {
   Import,
   ChevronUp,
   Eye,
+  Maximize2,
 } from "lucide-react";
 import {
   useDashboardStore,
@@ -56,6 +57,7 @@ import {
   previewDashboardQuery,
 } from "../../dashboard-runtime/commands";
 import { useDashboardRuntimeStore } from "../../dashboard-runtime/store";
+import { focusDashboardDataSourceTab } from "../../dashboard-runtime/shell";
 import { useSchemaStore } from "../../store/schemaStore";
 
 interface ConsoleResult {
@@ -1028,6 +1030,22 @@ const DataSourcePanel: React.FC<DataSourcePanelProps> = ({
                       title="Preview rows"
                     >
                       <Eye size={14} />
+                    </IconButton>
+                    <IconButton
+                      size="small"
+                      onClick={() => {
+                        if (dashboardId) {
+                          focusDashboardDataSourceTab(
+                            dashboardId,
+                            ds.id,
+                            ds.name,
+                          );
+                        }
+                      }}
+                      sx={{ p: 0.5 }}
+                      title="Open in tab"
+                    >
+                      <Maximize2 size={14} />
                     </IconButton>
                     <IconButton
                       size="small"

--- a/app/src/dashboard-runtime/shell.ts
+++ b/app/src/dashboard-runtime/shell.ts
@@ -25,3 +25,34 @@ export function focusDashboardTab(dashboardId: string, title: string): string {
   useUIStore.getState().setLeftPane("dashboards");
   return tabId;
 }
+
+/**
+ * Open a dashboard data source full-screen in its own editor tab (same
+ * experience as app data bindings).
+ */
+export function focusDashboardDataSourceTab(
+  dashboardId: string,
+  dataSourceId: string,
+  title: string,
+): string {
+  const consoleStore = useConsoleStore.getState();
+  const existingTab = Object.values(consoleStore.tabs).find(
+    (tab: any) =>
+      tab.kind === "dashboard-data-source" &&
+      tab.metadata?.dashboardId === dashboardId &&
+      tab.metadata?.dataSourceId === dataSourceId,
+  );
+
+  const tabId =
+    existingTab?.id ??
+    consoleStore.openTab({
+      title,
+      content: "",
+      kind: "dashboard-data-source",
+      isSaved: true,
+      metadata: { dashboardId, dataSourceId },
+    });
+
+  consoleStore.setActiveTab(tabId);
+  return tabId;
+}

--- a/app/src/lib/parquet-preview.ts
+++ b/app/src/lib/parquet-preview.ts
@@ -1,0 +1,57 @@
+/**
+ * Materialized-data preview: fetch a Parquet artifact (app binding or
+ * dashboard data source) and read its first rows through a transient
+ * DuckDB-WASM instance. Used by the data source editors to show a snapshot of
+ * what was actually materialized — like the table previews in the explorer,
+ * but for artifacts.
+ */
+
+import {
+  createDuckDBInstance,
+  loadParquetTable,
+  queryDuckDB,
+  collectStreamBytes,
+  terminateTrackedDuckDBInstance,
+  type DuckDBQueryResult,
+} from "./duckdb";
+
+export const PARQUET_PREVIEW_ROW_LIMIT = 100;
+
+/**
+ * Fetch `artifactUrl` (workspace-scoped serve route) and return the first
+ * `limit` rows plus the artifact's total row count.
+ */
+export async function previewParquetArtifact(
+  artifactUrl: string,
+  options?: { limit?: number; signal?: AbortSignal },
+): Promise<DuckDBQueryResult & { totalRows: number }> {
+  const limit = options?.limit ?? PARQUET_PREVIEW_ROW_LIMIT;
+
+  const response = await fetch(artifactUrl, {
+    credentials: "include",
+    signal: options?.signal,
+  });
+  if (!response.ok || !response.body) {
+    throw new Error("Failed to fetch the materialized artifact");
+  }
+  const buffer = await collectStreamBytes(response.body);
+
+  const db = await createDuckDBInstance();
+  try {
+    await loadParquetTable(db, "artifact_preview", buffer);
+    const result = await queryDuckDB(
+      db,
+      `SELECT * FROM "artifact_preview" LIMIT ${limit}`,
+    );
+    const count = await queryDuckDB(
+      db,
+      `SELECT count(*)::DOUBLE AS n FROM "artifact_preview"`,
+    );
+    const totalRows = Number(count.rows[0]?.n ?? result.rowCount);
+    return { ...result, totalRows };
+  } finally {
+    void terminateTrackedDuckDBInstance(db, "parquet-preview").catch(
+      () => undefined,
+    );
+  }
+}

--- a/app/src/store/appStore.ts
+++ b/app/src/store/appStore.ts
@@ -110,11 +110,22 @@ interface AppActions {
     bindingName: string,
   ) => Promise<{ success: boolean; rows?: unknown[]; error?: string }>;
 
+  /**
+   * Queue a parquet binding build (server-side, background) and poll until it
+   * is ready, fails, or the bounded wait elapses. Never hangs: `timeoutMs`
+   * caps the wait and `signal` aborts the polling (the build itself keeps
+   * running server-side either way).
+   */
   materializeBinding: (
     workspaceId: string,
     appId: string,
     bindingId: string,
-  ) => Promise<{ success: boolean; error?: string }>;
+    options?: { force?: boolean; signal?: AbortSignal; timeoutMs?: number },
+  ) => Promise<{
+    success: boolean;
+    status: "ready" | "building" | "error";
+    error?: string;
+  }>;
 
   reset: () => void;
 }
@@ -134,6 +145,38 @@ const initialState: AppState = {
 
 function genId(): string {
   return Math.random().toString(36).slice(2, 12);
+}
+
+const MATERIALIZE_POLL_INTERVAL_MS = 2500;
+const MATERIALIZE_DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
+
+interface BindingMaterializationStatus {
+  status: "missing" | "queued" | "building" | "ready" | "error";
+  error?: string | null;
+  rowCount?: number;
+  artifactRevision?: string;
+}
+
+function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException("Aborted", "AbortError"));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function isAbortError(e: unknown): boolean {
+  return e instanceof DOMException && e.name === "AbortError";
 }
 
 export const useAppStore = create<AppStore>()(
@@ -436,34 +479,111 @@ export const useAppStore = create<AppStore>()(
       }
     },
 
-    materializeBinding: async (workspaceId, appId, bindingId) => {
+    materializeBinding: async (workspaceId, appId, bindingId, options) => {
+      const signal = options?.signal;
+      const timeoutMs = options?.timeoutMs ?? MATERIALIZE_DEFAULT_TIMEOUT_MS;
+      const base = `/workspaces/${workspaceId}/apps/${appId}/bindings/${bindingId}`;
+
+      // Mirror the server-reported status onto the open app so UI chips
+      // (binding editor, explorer) update live while the build runs.
+      const setLocalStatus = (
+        status: BindingMaterializationStatus["status"],
+        error?: string | null,
+      ) => {
+        set(state => {
+          const binding = state.openApps[appId]?.dataBindings.find(
+            b => b.id === bindingId,
+          );
+          if (!binding) return;
+          binding.cache = {
+            ...(binding.cache ?? {}),
+            parquetBuildStatus: status,
+            parquetLastError: error ?? null,
+          };
+        });
+      };
+
+      const finishReady = async () => {
+        await get().fetchApp(workspaceId, appId);
+        get().bumpPreview(appId);
+        return { success: true, status: "ready" as const };
+      };
+
       try {
         const res = await apiClient.post<{
           success: boolean;
+          queued?: boolean;
           status?: { status: string; error?: string };
           app?: AppEntity;
           error?: string;
         }>(
-          `/workspaces/${workspaceId}/apps/${appId}/bindings/${bindingId}/materialize`,
+          `${base}/materialize`,
+          options?.force ? { force: true } : undefined,
+          { signal },
         );
-        if (res.app) {
-          set(state => {
-            state.openApps[appId] = res.app as AppEntity;
-          });
-          get().bumpPreview(appId);
-        }
         if (!res.success) {
-          return {
-            success: false,
-            error: res.status?.error || res.error || "Materialization failed",
-          };
+          const error =
+            res.status?.error || res.error || "Materialization failed";
+          setLocalStatus("error", error);
+          return { success: false, status: "error", error };
         }
-        return { success: true };
-      } catch (e) {
+        // Cache hit — artifact already built, nothing queued.
+        if (res.status?.status === "ready") {
+          if (res.app) {
+            set(state => {
+              state.openApps[appId] = res.app as AppEntity;
+            });
+            get().bumpPreview(appId);
+            return { success: true, status: "ready" };
+          }
+          return await finishReady();
+        }
+
+        setLocalStatus(
+          res.status?.status === "building" ? "building" : "queued",
+        );
+
+        // Poll the status endpoint until the background build terminates,
+        // the bounded wait elapses, or the caller aborts.
+        const deadline = Date.now() + timeoutMs;
+        while (Date.now() < deadline) {
+          await abortableSleep(MATERIALIZE_POLL_INTERVAL_MS, signal);
+          const poll = await apiClient.get<{
+            success: boolean;
+            data?: BindingMaterializationStatus;
+          }>(`${base}/materialization`, undefined, { signal });
+          const data = poll.data;
+          if (!data) continue;
+          setLocalStatus(data.status, data.error);
+          if (data.status === "ready") {
+            return await finishReady();
+          }
+          if (data.status === "error") {
+            return {
+              success: false,
+              status: "error",
+              error: data.error || "Materialization failed",
+            };
+          }
+        }
         return {
           success: false,
-          error: e instanceof Error ? e.message : "Materialization failed",
+          status: "building",
+          error:
+            "Materialization is still running in the background; it will finish server-side.",
         };
+      } catch (e) {
+        if (isAbortError(e)) {
+          return {
+            success: false,
+            status: "building",
+            error:
+              "Stopped waiting; materialization continues in the background.",
+          };
+        }
+        const error = e instanceof Error ? e.message : "Materialization failed";
+        setLocalStatus("error", error);
+        return { success: false, status: "error", error };
       }
     },
 

--- a/app/src/store/lib/types.ts
+++ b/app/src/store/lib/types.ts
@@ -15,6 +15,7 @@ export type TabKind =
   | "members"
   | "flow-editor"
   | "dashboard"
+  | "dashboard-data-source"
   | "table-data"
   | "app"
   | "app-file"

--- a/packages/agent-tools/src/app-tools.ts
+++ b/packages/agent-tools/src/app-tools.ts
@@ -81,6 +81,17 @@ const createDataBindingSchema = z.object({
 const materializeBindingSchema = z.object({
   appId: appIdField,
   name: z.string().describe("Name of the parquet binding to (re)materialize"),
+  waitSeconds: z
+    .number()
+    .min(0)
+    .max(600)
+    .optional()
+    .describe(
+      "How long to wait for the background build before returning (default " +
+        "120, max 600). Use 0 to check the current status without waiting. " +
+        "If the build is still running when the wait elapses, the tool " +
+        "returns status 'building' — call again to keep waiting.",
+    ),
 });
 
 const createAppSchema = z.object({
@@ -159,10 +170,12 @@ export const clientAppTools = {
       "Build (or rebuild) the Parquet artifact for a 'parquet' data binding and " +
       "load it into the app's DuckDB-WASM instance. Run this after creating or " +
       "editing a parquet binding so useQuery/useDuckDB return fresh data. " +
-      "The build runs server-side in the background: the tool waits up to ~2 " +
-      "minutes and returns status 'building' if it is still running — that is " +
-      "not an error; the app picks up the data automatically when ready, and " +
-      "you can call this tool again later to confirm completion.",
+      "The build runs server-side in the background: the tool waits up to " +
+      "waitSeconds (default 120) and returns status 'building' if it is still " +
+      "running — that is not an error; the app picks up the data automatically " +
+      "when ready. To block until completion, call this tool again (it resumes " +
+      "waiting on the in-flight build); use waitSeconds: 0 for an instant " +
+      "status check.",
     inputSchema: materializeBindingSchema,
   }),
   run_app: tool({

--- a/packages/agent-tools/src/app-tools.ts
+++ b/packages/agent-tools/src/app-tools.ts
@@ -158,7 +158,11 @@ export const clientAppTools = {
     description:
       "Build (or rebuild) the Parquet artifact for a 'parquet' data binding and " +
       "load it into the app's DuckDB-WASM instance. Run this after creating or " +
-      "editing a parquet binding so useQuery/useDuckDB return fresh data.",
+      "editing a parquet binding so useQuery/useDuckDB return fresh data. " +
+      "The build runs server-side in the background: the tool waits up to ~2 " +
+      "minutes and returns status 'building' if it is still running — that is " +
+      "not an error; the app picks up the data automatically when ready, and " +
+      "you can call this tool again later to confirm completion.",
     inputSchema: materializeBindingSchema,
   }),
   run_app: tool({

--- a/packages/schemas/src/app.schema.ts
+++ b/packages/schemas/src/app.schema.ts
@@ -81,6 +81,11 @@ export const AppBindingCacheSchema = z.object({
   definitionHash: z.string().optional(),
   artifactRevision: z.string().optional(),
   parquetBuildStatus: AppBindingParquetStatusSchema.nullish(),
+  /**
+   * Heartbeat for the current build. Refreshed periodically while a build is
+   * queued/running so stuck "building" statuses can be detected and recovered.
+   */
+  parquetBuildStatusAt: z.string().nullish(),
   parquetLastError: z.string().nullish(),
   rowCount: z.number().optional(),
   byteSize: z.number().optional(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

1. App (React Apps) parquet binding materialization ran **synchronously inside a single HTTP request** — the agent's `materialize_binding` tool blocked for the entire query + Parquet build with no timeout, abort, or crash recovery.
2. The materialization *orchestration* was **duplicated** between dashboards and apps (the low-level primitives were shared, but the query→Parquet pipeline was copy-pasted), and the dashboard copy silently swallowed query failures — a failed stream produced an empty/truncated artifact reported as `ready`.
3. Dashboard data sources had no full-screen editing (panel drawer only), unlike app bindings.
4. No way to preview the actual materialized data.

## Changes

**One materialization mechanism (api)**
- New `parquet-build.service.ts`: the single query→Parquet pipeline (read-only SQL safety gate, schema probe, streaming with **strict error surfacing**, artifact upload + temp cleanup) now used by BOTH `app-binding-materialization.service.ts` and `dashboard-artifact-rebuild.service.ts`. Callers keep only domain-specific code (hashes, keys, cache writes, run records, snapshots, queueing).
- Dashboards now **fail builds on mid-stream query errors** (previously: silent empty/truncated "ready" artifacts) and SQL data sources pass the same read-only safety gate as apps. Schema probe stays lenient for dashboards (MongoDB executables fall back to runtime inference) and strict for apps.
- Removed the duplicated artifact-prefix logic (single `getArtifactPrefix()`).

**Async, self-healing app materialization (api)**
- `POST .../bindings/:bindingId/materialize` queues the build (Inngest `app-binding-materialize`, in-process fallback if enqueue fails) and returns immediately; new `GET .../materialization` status endpoint for polling.
- `parquetBuildStatusAt` heartbeat (30s) + stale detection (3 min): crashed builds surface as errors to pollers and are atomically reclaimed by the next materialize. Atomic queue claim dedupes concurrent builds.

**Agent tool (apps)**
- `materialize_binding` takes `waitSeconds` (0–600, default 120): bounded poll-with-timeout inside tool execution, between inference turns. `0` = instant status check; re-calling resumes waiting on the in-flight build; a single call can never hang the agent.

**Dashboard data sources as first-class tabs (app)**
- New `dashboard-data-source` tab kind + `DashboardDataSourceEditor`: open any dashboard data source full screen in a console tab (run, save, materialize, status chip, history popover) — same experience as app bindings. Opened via a new "Open in tab" icon in the dashboard's Data Sources panel.

**Materialized data preview (app)**
- New eye icon in both editors: fetches the Parquet artifact, loads it into a transient DuckDB-WASM instance, and shows the first rows + total count in the results panel (`lib/parquet-preview.ts`) — like the explorer table previews, but for artifacts.

## Demos

[dashboard_data_source_tab_and_snapshot_preview_demo.mp4](https://cursor.com/agents/bc-8ea41efb-78db-4f60-a06a-fd7aff291b91/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_data_source_tab_and_snapshot_preview_demo.mp4)

Dashboard data source: open in tab → snapshot preview → materialize → history.

[app_binding_background_materialization_demo.mp4](https://cursor.com/agents/bc-8ea41efb-78db-4f60-a06a-fd7aff291b91/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_binding_background_materialization_demo.mp4)

App binding: background materialize, chip queued → building → 50,000 rows.

[app_binding_snapshot_preview_demo.mp4](https://cursor.com/agents/bc-8ea41efb-78db-4f60-a06a-fd7aff291b91/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_binding_snapshot_preview_demo.mp4)

App binding: materialized snapshot preview.

[Data Sources panel with Open in tab icon](https://cursor.com/agents/bc-8ea41efb-78db-4f60-a06a-fd7aff291b91/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdata_source_panel_open_in_tab_icons.webp)
[Dashboard data source editor with snapshot preview](https://cursor.com/agents/bc-8ea41efb-78db-4f60-a06a-fd7aff291b91/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_ds_editor_snapshot_preview.webp)
[App binding snapshot preview](https://cursor.com/agents/bc-8ea41efb-78db-4f60-a06a-fd7aff291b91/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_binding_snapshot_preview.webp)

## Testing (local stack: MongoDB rs + Postgres source with 50k rows + API + app + Inngest dev)

- App binding rebuild through the shared core: queue returns in ms, background build reaches `ready` (50,000 rows).
- Dashboard with a good + a broken data source: `orders_src` ready (50,000 rows); `bad_src` fails with the real Postgres error (`relation "missing_table" does not exist`) — previously this produced an empty "ready" artifact.
- Stale recovery, concurrent dedupe, Inngest-down in-process fallback, unsafe SQL rejection (earlier rounds).
- GUI: open-in-tab, snapshot preview, materialize + history verified in both editors (videos above).
- `tsc --noEmit` + `eslint` clean for `app` and `api`; `@mako/schemas` + `@mako/agent-tools` build clean.

Note: the "Missing license key" watermark in the demo videos is the MUI X Premium watermark from the unlicensed local dev environment, unrelated to these changes.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ea41efb-78db-4f60-a06a-fd7aff291b91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ea41efb-78db-4f60-a06a-fd7aff291b91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

