### PR TITLE
refactor(flows): schema-driven entity table configuration

### DIFF
--- a/api/src/connectors/close/connector.ts
+++ b/api/src/connectors/close/connector.ts
@@ -731,6 +731,12 @@ export class CloseConnector extends BaseConnector {
       partitionGranularity: "day" as const,
       clusterFields: ["_dataSourceId", "id"],
     };
+    // Lookup tables have no stable creation timestamp worth partitioning on.
+    const lookupLayout = {
+      partitionField: "_syncedAt",
+      partitionGranularity: "day" as const,
+      clusterFields: ["_dataSourceId", "id"],
+    };
     return [
       { name: "leads", label: "Leads", layoutSuggestion: defaultLayout },
       {
@@ -758,7 +764,37 @@ export class CloseConnector extends BaseConnector {
       {
         name: "custom_fields",
         label: "Custom Fields",
+        layoutSuggestion: lookupLayout,
+      },
+      {
+        name: "custom_activity_types",
+        label: "Custom Activity Types",
+        layoutSuggestion: lookupLayout,
+      },
+      {
+        name: "custom_object_types",
+        label: "Custom Object Types",
+        layoutSuggestion: lookupLayout,
+      },
+      {
+        name: "custom_objects",
+        label: "Custom Objects",
         layoutSuggestion: defaultLayout,
+      },
+      {
+        name: "lead_statuses",
+        label: "Lead Statuses",
+        layoutSuggestion: lookupLayout,
+      },
+      {
+        name: "opportunity_statuses",
+        label: "Opportunity Statuses",
+        layoutSuggestion: lookupLayout,
+      },
+      {
+        name: "outcomes",
+        label: "Outcomes",
+        layoutSuggestion: lookupLayout,
       },
     ];
   }

--- a/api/src/connectors/stripe/connector.ts
+++ b/api/src/connectors/stripe/connector.ts
@@ -7,6 +7,7 @@ import {
   WebhookVerificationResult,
   WebhookHandlerOptions,
   WebhookEventMapping,
+  EntityMetadata,
 } from "../base/BaseConnector";
 import Stripe from "stripe";
 import { loggers } from "../../logging";
@@ -114,6 +115,23 @@ export class StripeConnector extends BaseConnector {
       "invoices",
       "products",
       "plans",
+    ];
+  }
+
+  getEntityMetadata(): EntityMetadata[] {
+    // Stripe records are upserted in place; partition on sync time.
+    const layoutSuggestion = {
+      partitionField: "_syncedAt",
+      partitionGranularity: "day" as const,
+      clusterFields: ["_dataSourceId", "id"],
+    };
+    return [
+      { name: "customers", label: "Customers", layoutSuggestion },
+      { name: "subscriptions", label: "Subscriptions", layoutSuggestion },
+      { name: "charges", label: "Charges", layoutSuggestion },
+      { name: "invoices", label: "Invoices", layoutSuggestion },
+      { name: "products", label: "Products", layoutSuggestion },
+      { name: "plans", label: "Plans", layoutSuggestion },
     ];
   }
 

--- a/app/src/components/WebhookFlowForm.tsx
+++ b/app/src/components/WebhookFlowForm.tsx
@@ -33,6 +33,10 @@ import {
 import { useWorkspace } from "../contexts/workspace-context";
 import { useFlowStore } from "../store/flowStore";
 import { useSchemaStore } from "../store/schemaStore";
+import {
+  useAvailableEntitiesStore,
+  flattenConnectorEntities,
+} from "../store/availableEntitiesStore";
 import { trackEvent } from "../lib/analytics";
 import { FlowRunNotificationsSection } from "./FlowRunNotificationsSection";
 
@@ -507,143 +511,25 @@ export function WebhookFlowForm({
     isNewMode,
   ]);
 
-  // Fetch entity metadata from connector and build per-entity layout defaults
+  // Fetch entity metadata from the connector API and build per-entity layout
+  // defaults. Schema-driven: connectors expose entities + layout suggestions
+  // via /connectors/:id/entities, so new connector entities appear here
+  // automatically (see 15-connector-agnostic.mdc).
   useEffect(() => {
     if (hasStagingDest && watchDataSourceId && connectors.length > 0) {
       const source = connectors.find(c => c._id === watchDataSourceId);
-      if (!source) return;
+      if (!source || !currentWorkspace?.id) return;
 
-      const connectorType = source.type;
-      if (connectorType === "close") {
-        const entities = [
-          {
-            name: "leads",
-            label: "Leads",
-            partitionField: "date_created",
-            clusterFields: [] as string[],
-          },
-          {
-            name: "opportunities",
-            label: "Opportunities",
-            partitionField: "date_created",
-            clusterFields: [] as string[],
-          },
-          {
-            name: "contacts",
-            label: "Contacts",
-            partitionField: "date_created",
-            clusterFields: [] as string[],
-          },
-          {
-            name: "activities:Call",
-            label: "Calls",
-            partitionField: "date_created",
-            clusterFields: [] as string[],
-          },
-          {
-            name: "activities:Email",
-            label: "Emails",
-            partitionField: "date_created",
-            clusterFields: [] as string[],
-          },
-          {
-            name: "activities:EmailThread",
-            label: "Email Threads",
-            partitionField: "date_created",
-            clusterFields: [] as string[],
-          },
-          {
-            name: "activities:SMS",
-            label: "SMS",
-            partitionField: "date_created",
-            clusterFields: [] as string[],
-          },
-          {
-            name: "activities:Meeting",
-            label: "Meetings",
-            partitionField: "date_created",
-            clusterFields: [] as string[],
-          },
-          {
-            name: "activities:Note",
-            label: "Notes",
-            partitionField: "date_created",
-            clusterFields: [] as string[],
-          },
-          {
-            name: "activities:LeadStatusChange",
-            label: "Lead Status Changes",
-            partitionField: "date_created",
-            clusterFields: [] as string[],
-          },
-          {
-            name: "activities:OpportunityStatusChange",
-            label: "Opportunity Status Changes",
-            partitionField: "date_created",
-            clusterFields: [] as string[],
-          },
-          {
-            name: "activities:TaskCompleted",
-            label: "Completed Tasks",
-            partitionField: "date_created",
-            clusterFields: [] as string[],
-          },
-          {
-            name: "users",
-            label: "Users",
-            partitionField: "date_created",
-            clusterFields: [] as string[],
-          },
-          {
-            name: "custom_fields",
-            label: "Custom Fields",
-            partitionField: "_syncedAt",
-            clusterFields: [] as string[],
-          },
-          {
-            name: "activities:CustomActivity",
-            label: "Custom Activities",
-            partitionField: "date_created",
-            clusterFields: [] as string[],
-          },
-          {
-            name: "custom_activity_types",
-            label: "Custom Activity Types",
-            partitionField: "_syncedAt",
-            clusterFields: [] as string[],
-          },
-          {
-            name: "custom_object_types",
-            label: "Custom Object Types",
-            partitionField: "_syncedAt",
-            clusterFields: [] as string[],
-          },
-          {
-            name: "custom_objects",
-            label: "Custom Objects",
-            partitionField: "date_created",
-            clusterFields: [] as string[],
-          },
-          {
-            name: "lead_statuses",
-            label: "Lead Statuses",
-            partitionField: "_syncedAt",
-            clusterFields: [] as string[],
-          },
-          {
-            name: "opportunity_statuses",
-            label: "Opportunity Statuses",
-            partitionField: "_syncedAt",
-            clusterFields: [] as string[],
-          },
-          {
-            name: "outcomes",
-            label: "Outcomes",
-            partitionField: "_syncedAt",
-            clusterFields: [] as string[],
-          },
-        ];
+      let cancelled = false;
+      (async () => {
+        const list = await useAvailableEntitiesStore
+          .getState()
+          .fetch(currentWorkspace.id, watchDataSourceId);
+        if (cancelled || list.length === 0) return;
+
+        const entities = flattenConnectorEntities(list);
         setEntityMetadata(entities);
+
         // Read saved layouts from the flow object (store), not watch(),
         // because watch() may return stale state when effects race.
         const existingFlow =
@@ -653,7 +539,7 @@ export function WebhookFlowForm({
         const savedLayouts: EntityLayoutConfig[] =
           existingFlow?.entityLayouts || watch("entityLayouts") || [];
         const savedByEntity = new Map(
-          savedLayouts.map((l: any) => [l.entity, l]),
+          savedLayouts.map((l: EntityLayoutConfig) => [l.entity, l]),
         );
         setValue(
           "entityLayouts",
@@ -669,127 +555,16 @@ export function WebhookFlowForm({
                   entity: e.name,
                   label: e.label,
                   partitionField: e.partitionField,
-                  partitionGranularity: "day" as const,
-                  clusterFields: e.clusterFields || [],
+                  partitionGranularity: e.partitionGranularity,
+                  clusterFields: e.clusterFields,
                   enabled: true,
                 };
           }),
         );
-      } else if (connectorType === "claap") {
-        const entities = [
-          {
-            name: "recordings",
-            label: "Recordings",
-            partitionField: "createdAt",
-            clusterFields: [] as string[],
-          },
-          {
-            name: "workspace",
-            label: "Workspace",
-            partitionField: "createdAt",
-            clusterFields: [] as string[],
-          },
-        ];
-        setEntityMetadata(entities);
-        const existingFlowClaap =
-          !isNewMode && currentFlowId
-            ? flows.find(j => j._id === currentFlowId)
-            : null;
-        const savedLayoutsClaap: EntityLayoutConfig[] =
-          existingFlowClaap?.entityLayouts || watch("entityLayouts") || [];
-        const savedByEntity = new Map(
-          savedLayoutsClaap.map((l: EntityLayoutConfig) => [l.entity, l]),
-        );
-        setValue(
-          "entityLayouts",
-          entities.map(e => {
-            const saved = savedByEntity.get(e.name);
-            return saved
-              ? {
-                  ...saved,
-                  label: e.label,
-                  enabled: saved.enabled !== false,
-                }
-              : {
-                  entity: e.name,
-                  label: e.label,
-                  partitionField: e.partitionField,
-                  partitionGranularity: "day" as const,
-                  clusterFields: e.clusterFields || [],
-                  enabled: true,
-                };
-          }),
-        );
-      } else if (connectorType === "stripe") {
-        const entities = [
-          {
-            name: "customers",
-            label: "Customers",
-            partitionField: "_syncedAt",
-            clusterFields: [] as string[],
-          },
-          {
-            name: "subscriptions",
-            label: "Subscriptions",
-            partitionField: "_syncedAt",
-            clusterFields: [] as string[],
-          },
-          {
-            name: "charges",
-            label: "Charges",
-            partitionField: "_syncedAt",
-            clusterFields: [] as string[],
-          },
-          {
-            name: "invoices",
-            label: "Invoices",
-            partitionField: "_syncedAt",
-            clusterFields: [] as string[],
-          },
-          {
-            name: "products",
-            label: "Products",
-            partitionField: "_syncedAt",
-            clusterFields: [] as string[],
-          },
-          {
-            name: "plans",
-            label: "Plans",
-            partitionField: "_syncedAt",
-            clusterFields: [] as string[],
-          },
-        ];
-        setEntityMetadata(entities);
-        const existingFlowStripe =
-          !isNewMode && currentFlowId
-            ? flows.find(j => j._id === currentFlowId)
-            : null;
-        const savedLayoutsStripe: EntityLayoutConfig[] =
-          existingFlowStripe?.entityLayouts || watch("entityLayouts") || [];
-        const savedByEntity = new Map(
-          savedLayoutsStripe.map((l: any) => [l.entity, l]),
-        );
-        setValue(
-          "entityLayouts",
-          entities.map(e => {
-            const saved = savedByEntity.get(e.name);
-            return saved
-              ? {
-                  ...saved,
-                  label: e.label,
-                  enabled: saved.enabled !== false,
-                }
-              : {
-                  entity: e.name,
-                  label: e.label,
-                  partitionField: e.partitionField || "_syncedAt",
-                  partitionGranularity: "day" as const,
-                  clusterFields: e.clusterFields || [],
-                  enabled: true,
-                };
-          }),
-        );
-      }
+      })();
+      return () => {
+        cancelled = true;
+      };
     } else if (
       watchDataSourceId &&
       connectors.length > 0 &&

--- a/app/src/components/WebhookFlowForm.tsx
+++ b/app/src/components/WebhookFlowForm.tsx
@@ -636,6 +636,12 @@ export function WebhookFlowForm({
             partitionField: "_syncedAt",
             clusterFields: [] as string[],
           },
+          {
+            name: "outcomes",
+            label: "Outcomes",
+            partitionField: "_syncedAt",
+            clusterFields: [] as string[],
+          },
         ];
         setEntityMetadata(entities);
         // Read saved layouts from the flow object (store), not watch(),

--- a/app/src/store/availableEntitiesStore.ts
+++ b/app/src/store/availableEntitiesStore.ts
@@ -2,15 +2,86 @@ import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import { apiClient } from "../lib/api-client";
 
+export interface ConnectorEntityLayoutSuggestion {
+  partitionField?: string;
+  partitionGranularity?: "day" | "hour" | "month" | "year";
+  clusterFields?: string[];
+}
+
+export interface ConnectorEntityMetadata {
+  name: string;
+  label?: string;
+  description?: string;
+  subEntities?: ConnectorEntityMetadata[];
+  layoutSuggestion?: ConnectorEntityLayoutSuggestion;
+}
+
+/** Older connectors may return a flat string list instead of metadata. */
+export type AvailableConnectorEntity = string | ConnectorEntityMetadata;
+
+export interface FlattenedConnectorEntity {
+  name: string;
+  label: string;
+  partitionField: string;
+  partitionGranularity: "day" | "hour" | "month" | "year";
+  clusterFields: string[];
+}
+
+function fallbackLabel(name: string): string {
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+/**
+ * Flatten connector entity metadata into one selectable row per syncable
+ * entity. Parents with sub-entities (e.g. Close "activities") cannot be
+ * synced bare, so they are expanded into `parent:Sub` rows.
+ */
+export function flattenConnectorEntities(
+  list: AvailableConnectorEntity[],
+): FlattenedConnectorEntity[] {
+  const result: FlattenedConnectorEntity[] = [];
+
+  for (const item of list) {
+    const meta: ConnectorEntityMetadata =
+      typeof item === "string" ? { name: item } : item;
+    const layout = meta.layoutSuggestion;
+    const subEntities = meta.subEntities ?? [];
+
+    if (subEntities.length > 0) {
+      for (const sub of subEntities) {
+        const subLayout = sub.layoutSuggestion ?? layout;
+        result.push({
+          name: `${meta.name}:${sub.name}`,
+          label: sub.label || fallbackLabel(sub.name),
+          partitionField: subLayout?.partitionField || "_syncedAt",
+          partitionGranularity: subLayout?.partitionGranularity || "day",
+          clusterFields: [],
+        });
+      }
+      continue;
+    }
+
+    result.push({
+      name: meta.name,
+      label: meta.label || fallbackLabel(meta.name),
+      partitionField: layout?.partitionField || "_syncedAt",
+      partitionGranularity: layout?.partitionGranularity || "day",
+      clusterFields: [],
+    });
+  }
+
+  return result;
+}
+
 interface AvailableEntitiesState {
-  byConnector: Record<string, string[]>; // key = `${workspaceId}:${connectorId}`
+  byConnector: Record<string, AvailableConnectorEntity[]>; // key = `${workspaceId}:${connectorId}`
   loading: Record<string, boolean>;
   error: Record<string, string | null>;
   fetch: (
     workspaceId: string,
     connectorId: string,
     force?: boolean,
-  ) => Promise<string[]>;
+  ) => Promise<AvailableConnectorEntity[]>;
   clear: (workspaceId: string, connectorId: string) => void;
 }
 
@@ -42,11 +113,11 @@ export const useAvailableEntitiesStore = create<AvailableEntitiesState>()(
       });
 
       try {
-        const json = await apiClient.get<ApiResponse<string[]>>(
-          `/workspaces/${workspaceId}/connectors/${connectorId}/entities`,
-        );
+        const json = await apiClient.get<
+          ApiResponse<AvailableConnectorEntity[]>
+        >(`/workspaces/${workspaceId}/connectors/${connectorId}/entities`);
         if (json.success) {
-          const list: string[] = json.data || [];
+          const list: AvailableConnectorEntity[] = json.data || [];
           set(state => {
             state.byConnector[key] = list;
             delete state.loading[key];


### PR DESCRIPTION
## Summary

Follow-up to #476 (the two commits here were pushed to that branch after it was already merged, so they never landed).

- Replace the hardcoded per-connector entity lists in `WebhookFlowForm` (~290 lines for close/claap/stripe) with the `/connectors/:id/entities` endpoint, per the connector-agnostic rule. New connector entities (like Close `outcomes` from #476) now appear in the flow form automatically — this also gives Calendly an entity configuration step, which it never had since it lacked a hardcoded branch.
- Complete `CloseConnector.getEntityMetadata()`: adds the previously missing lookup tables (`custom_activity_types`, `custom_object_types`, `custom_objects`, `lead_statuses`, `opportunity_statuses`, `outcomes`) with layout suggestions (`_syncedAt` partition for lookup tables).
- Add `StripeConnector.getEntityMetadata()` override with layout suggestions (previously fell back to the bare default with no layouts).
- Type `availableEntitiesStore` properly (`ConnectorEntityMetadata`, was `string[]`) and add a generic `flattenConnectorEntities()` helper that expands sub-entities into `activities:Call`-style rows; saved entity layouts on existing flows are preserved by the unchanged merge logic.

## Test plan

- [x] `pnpm --filter app run typecheck && pnpm --filter app run lint` passes
- [x] api `tsc --noEmit` + eslint on touched files passes
- [ ] Open the webhook flow form for a Close source: entity list (incl. Outcomes) renders from the API with correct partition fields
- [ ] Reopen an existing flow: saved entity layouts/enabled flags preserved
- [ ] Open the form for a Calendly source: entities now render

Made with [Cursor](https://cursor.com)