### PR TITLE
fix(api): update webhook flow for calendly

### DIFF
--- a/api/src/routes/sources.ts
+++ b/api/src/routes/sources.ts
@@ -569,7 +569,7 @@ dataSourceRoutes.get("/:id/entities", async c => {
     }
 
     // Try to get structured metadata first, fallback to flat list
-    let entityData: any;
+    let entityData: any[];
     if (typeof connector.getEntityMetadata === "function") {
       // Return structured metadata if available
       entityData = connector.getEntityMetadata();
@@ -580,6 +580,40 @@ dataSourceRoutes.get("/:id/entities", async c => {
         name: entity,
         label: entity.charAt(0).toUpperCase() + entity.slice(1),
       }));
+    }
+
+    // Enrich each entity (and sub-entity) with its field list from the
+    // connector schema so the UI can build schema-driven partition/cluster
+    // selectors (see 15-connector-agnostic.mdc). Sub-entities are resolved
+    // with the flattened `parent:Sub` key used elsewhere in the pipeline.
+    const attachFields = async (node: any, schemaKey: string) => {
+      try {
+        const schema = await connector.resolveSchema(schemaKey);
+        if (schema?.fields) {
+          node.fields = Object.entries(schema.fields).map(
+            ([name, field]) => ({ name, type: field.type }),
+          );
+        }
+      } catch {
+        // Skip entities where schema resolution fails; the UI falls back
+        // to system fields only.
+      }
+    };
+
+    try {
+      await Promise.all(
+        entityData.flatMap((node: any) => {
+          const subs = Array.isArray(node.subEntities) ? node.subEntities : [];
+          if (subs.length > 0) {
+            return subs.map((sub: any) =>
+              attachFields(sub, `${node.name}:${sub.name}`),
+            );
+          }
+          return [attachFields(node, node.name)];
+        }),
+      );
+    } catch {
+      // Never fail the entities endpoint because of schema enrichment.
     }
 
     return c.json({

--- a/app/src/components/WebhookFlowForm.tsx
+++ b/app/src/components/WebhookFlowForm.tsx
@@ -36,6 +36,7 @@ import { useSchemaStore } from "../store/schemaStore";
 import {
   useAvailableEntitiesStore,
   flattenConnectorEntities,
+  type FlattenedConnectorEntity,
 } from "../store/availableEntitiesStore";
 import { trackEvent } from "../lib/analytics";
 import { FlowRunNotificationsSection } from "./FlowRunNotificationsSection";
@@ -72,270 +73,8 @@ const WEBHOOK_PROVISIONING_CONNECTOR_TYPES = new Set([
 const SYNC_ENGINE_PERMISSION_ERROR =
   "The flow was saved, but changing the sync engine requires the workspace Owner or Admin role. Ask an admin to upgrade your role, then set the sync engine again.";
 
-const CLAAP_ENTITY_FIELDS: Record<string, string[]> = {
-  recordings: [
-    "id",
-    "title",
-    "state",
-    "createdAt",
-    "durationSeconds",
-    "source",
-    "url",
-    "thumbnailUrl",
-    "labels",
-    "channel",
-    "recorder",
-    "workspace",
-    "meeting",
-    "deal",
-    "companies",
-    "crmInfo",
-    "_dataSourceId",
-    "_dataSourceName",
-    "_syncedAt",
-  ],
-  workspace: [
-    "id",
-    "name",
-    "createdAt",
-    "membersCount",
-    "recordingsCount",
-    "_dataSourceId",
-    "_dataSourceName",
-    "_syncedAt",
-  ],
-};
-
-const CLOSE_ENTITY_FIELDS: Record<string, string[]> = {
-  leads: [
-    "id",
-    "display_name",
-    "status_id",
-    "status_label",
-    "date_created",
-    "date_updated",
-    "organization_id",
-    "_dataSourceId",
-    "_dataSourceName",
-    "_syncedAt",
-  ],
-  opportunities: [
-    "id",
-    "lead_id",
-    "status_id",
-    "status_label",
-    "status_type",
-    "value",
-    "date_created",
-    "date_updated",
-    "date_won",
-    "user_id",
-    "_dataSourceId",
-    "_dataSourceName",
-    "_syncedAt",
-  ],
-  "activities:Call": [
-    "id",
-    "lead_id",
-    "user_id",
-    "direction",
-    "duration",
-    "phone",
-    "date_created",
-    "date_updated",
-    "_dataSourceId",
-    "_dataSourceName",
-    "_syncedAt",
-  ],
-  "activities:Email": [
-    "id",
-    "lead_id",
-    "user_id",
-    "subject",
-    "sender",
-    "date_created",
-    "date_updated",
-    "_dataSourceId",
-    "_dataSourceName",
-    "_syncedAt",
-  ],
-  "activities:EmailThread": [
-    "id",
-    "lead_id",
-    "user_id",
-    "subject",
-    "date_created",
-    "date_updated",
-    "_dataSourceId",
-    "_dataSourceName",
-    "_syncedAt",
-  ],
-  "activities:SMS": [
-    "id",
-    "lead_id",
-    "user_id",
-    "text",
-    "direction",
-    "phone",
-    "date_created",
-    "date_updated",
-    "_dataSourceId",
-    "_dataSourceName",
-    "_syncedAt",
-  ],
-  "activities:Meeting": [
-    "id",
-    "lead_id",
-    "user_id",
-    "title",
-    "starts_at",
-    "ends_at",
-    "date_created",
-    "date_updated",
-    "_dataSourceId",
-    "_dataSourceName",
-    "_syncedAt",
-  ],
-  "activities:Note": [
-    "id",
-    "lead_id",
-    "user_id",
-    "note",
-    "date_created",
-    "date_updated",
-    "_dataSourceId",
-    "_dataSourceName",
-    "_syncedAt",
-  ],
-  "activities:LeadStatusChange": [
-    "id",
-    "lead_id",
-    "user_id",
-    "old_status_label",
-    "new_status_label",
-    "date_created",
-    "date_updated",
-    "_dataSourceId",
-    "_dataSourceName",
-    "_syncedAt",
-  ],
-  "activities:OpportunityStatusChange": [
-    "id",
-    "lead_id",
-    "user_id",
-    "old_status_label",
-    "new_status_label",
-    "date_created",
-    "date_updated",
-    "_dataSourceId",
-    "_dataSourceName",
-    "_syncedAt",
-  ],
-  "activities:TaskCompleted": [
-    "id",
-    "lead_id",
-    "user_id",
-    "text",
-    "date_created",
-    "date_updated",
-    "_dataSourceId",
-    "_dataSourceName",
-    "_syncedAt",
-  ],
-  contacts: [
-    "id",
-    "lead_id",
-    "first_name",
-    "last_name",
-    "display_name",
-    "date_created",
-    "date_updated",
-    "_dataSourceId",
-    "_dataSourceName",
-    "_syncedAt",
-  ],
-  users: [
-    "id",
-    "email",
-    "first_name",
-    "last_name",
-    "date_created",
-    "date_updated",
-    "_dataSourceId",
-    "_dataSourceName",
-    "_syncedAt",
-  ],
-  custom_fields: [
-    "id",
-    "name",
-    "custom_field_type",
-    "_dataSourceId",
-    "_dataSourceName",
-    "_syncedAt",
-  ],
-  "activities:CustomActivity": [
-    "id",
-    "lead_id",
-    "user_id",
-    "_type",
-    "date_created",
-    "date_updated",
-    "_dataSourceId",
-    "_dataSourceName",
-    "_syncedAt",
-  ],
-  custom_activity_types: [
-    "id",
-    "name",
-    "description",
-    "api_create_only",
-    "date_created",
-    "date_updated",
-    "_dataSourceId",
-    "_dataSourceName",
-    "_syncedAt",
-  ],
-  custom_object_types: [
-    "id",
-    "name",
-    "description",
-    "date_created",
-    "date_updated",
-    "_dataSourceId",
-    "_dataSourceName",
-    "_syncedAt",
-  ],
-  custom_objects: [
-    "id",
-    "custom_object_type",
-    "date_created",
-    "date_updated",
-    "_dataSourceId",
-    "_dataSourceName",
-    "_syncedAt",
-  ],
-  lead_statuses: [
-    "id",
-    "label",
-    "organization_id",
-    "date_created",
-    "date_updated",
-    "_dataSourceId",
-    "_dataSourceName",
-    "_syncedAt",
-  ],
-  opportunity_statuses: [
-    "id",
-    "label",
-    "type",
-    "organization_id",
-    "date_created",
-    "date_updated",
-    "_dataSourceId",
-    "_dataSourceName",
-    "_syncedAt",
-  ],
-};
+// Always-selectable fallback when the connector exposes no schema fields.
+const SYSTEM_ENTITY_FIELDS = ["_syncedAt", "_dataSourceId", "id"];
 
 interface FormData {
   dataSourceId: string;
@@ -411,7 +150,9 @@ export function WebhookFlowForm({
     flowId,
   );
   const [isNewMode, setIsNewMode] = useState(isNew);
-  const [_entityMetadata, setEntityMetadata] = useState<any[]>([]);
+  const [entityMetadata, setEntityMetadata] = useState<
+    FlattenedConnectorEntity[]
+  >([]);
   const [openSteps, setOpenSteps] = useState<Set<number>>(new Set([0]));
 
   const toggleStep = (stepIndex: number) => {
@@ -1358,22 +1099,23 @@ export function WebhookFlowForm({
                               </Typography>
                             </Box>
                             {watchEntityLayouts.map((layout, idx) => {
-                              const entityFieldMap =
-                                selectedConnectorType === "close"
-                                  ? CLOSE_ENTITY_FIELDS
-                                  : selectedConnectorType === "claap"
-                                    ? CLAAP_ENTITY_FIELDS
-                                    : {};
-                              const entityFields = entityFieldMap[
-                                layout.entity
-                              ] || ["_syncedAt", "_dataSourceId", "id"];
-                              const timestampFields = entityFields.filter(
-                                f =>
-                                  f.includes("date") ||
-                                  f.includes("created") ||
-                                  f.includes("updated") ||
-                                  f === "_syncedAt",
-                              );
+                              const schemaFields =
+                                entityMetadata.find(
+                                  e => e.name === layout.entity,
+                                )?.fields ?? [];
+                              const entityFields =
+                                schemaFields.length > 0
+                                  ? schemaFields.map(f => f.name)
+                                  : SYSTEM_ENTITY_FIELDS;
+                              const timestampFields =
+                                schemaFields.length > 0
+                                  ? schemaFields
+                                      .filter(f => f.type === "timestamp")
+                                      .map(f => f.name)
+                                  : ["_syncedAt"];
+                              if (!timestampFields.includes("_syncedAt")) {
+                                timestampFields.push("_syncedAt");
+                              }
                               const isEnabled = layout.enabled !== false;
                               return (
                                 <Box

--- a/app/src/store/availableEntitiesStore.ts
+++ b/app/src/store/availableEntitiesStore.ts
@@ -8,12 +8,19 @@ export interface ConnectorEntityLayoutSuggestion {
   clusterFields?: string[];
 }
 
+export interface ConnectorEntityField {
+  name: string;
+  type: string;
+}
+
 export interface ConnectorEntityMetadata {
   name: string;
   label?: string;
   description?: string;
   subEntities?: ConnectorEntityMetadata[];
   layoutSuggestion?: ConnectorEntityLayoutSuggestion;
+  /** Field list resolved from the connector schema (name + logical type). */
+  fields?: ConnectorEntityField[];
 }
 
 /** Older connectors may return a flat string list instead of metadata. */
@@ -25,6 +32,7 @@ export interface FlattenedConnectorEntity {
   partitionField: string;
   partitionGranularity: "day" | "hour" | "month" | "year";
   clusterFields: string[];
+  fields?: ConnectorEntityField[];
 }
 
 function fallbackLabel(name: string): string {
@@ -55,7 +63,8 @@ export function flattenConnectorEntities(
           label: sub.label || fallbackLabel(sub.name),
           partitionField: subLayout?.partitionField || "_syncedAt",
           partitionGranularity: subLayout?.partitionGranularity || "day",
-          clusterFields: [],
+          clusterFields: subLayout?.clusterFields ?? [],
+          fields: sub.fields ?? meta.fields,
         });
       }
       continue;
@@ -66,7 +75,8 @@ export function flattenConnectorEntities(
       label: meta.label || fallbackLabel(meta.name),
       partitionField: layout?.partitionField || "_syncedAt",
       partitionGranularity: layout?.partitionGranularity || "day",
-      clusterFields: [],
+      clusterFields: layout?.clusterFields ?? [],
+      fields: meta.fields,
     });
   }
 


### PR DESCRIPTION
# Schema-driven partition/cluster field options for Webhook flows

## Summary

The Webhook flow form built its **Partition Field** and **Cluster Fields**
dropdown options from hardcoded per-connector maps (`CLOSE_ENTITY_FIELDS`,
`CLAAP_ENTITY_FIELDS`). Any connector not in those maps — e.g. the new
**Calendly** connector — fell back to `["_syncedAt", "_dataSourceId", "id"]`,
so users couldn't select a real partition or cluster field.

This PR makes the dropdowns schema-driven: the field options now come from each
connector's `resolveSchema()` output, so every connector (current and future)
works with zero UI changes. It also removes a `.cursor/rules/15-connector-agnostic.mdc`
violation (UI branching on `selectedConnectorType`).

## Changes

**Backend** — `GET /workspaces/:id/connectors/:id/entities`
([api/src/routes/sources.ts](api/src/routes/sources.ts))
- After building entity metadata from `getEntityMetadata()`, enrich each entity
  (and sub-entity) with `fields: { name, type }[]` resolved via
  `connector.resolveSchema()`.
- Sub-entities are resolved with the flattened `parent:Sub` key already used
  elsewhere in the pipeline.
- Per-entity `try/catch` + an outer guard so schema enrichment can never fail
  the endpoint; connectors without `resolveSchema` return metadata as before.

**Store** — [app/src/store/availableEntitiesStore.ts](app/src/store/availableEntitiesStore.ts)
- Add `ConnectorEntityField` and thread `fields` through
  `ConnectorEntityMetadata` → `FlattenedConnectorEntity` via
  `flattenConnectorEntities`.
- Fix a latent bug: preserve `layoutSuggestion.clusterFields` instead of
  hardcoding `clusterFields: []`.

**Form** — [app/src/components/WebhookFlowForm.tsx](app/src/components/WebhookFlowForm.tsx)
- Delete ~265 lines of `CLOSE_ENTITY_FIELDS` / `CLAAP_ENTITY_FIELDS` and the
  `selectedConnectorType === "close"/"claap"` branching.
- Derive options from fetched schema: cluster fields = all schema fields,
  partition fields = fields with `type === "timestamp"` (plus `_syncedAt`).
- Replaces the brittle substring heuristic (`includes("date")` etc.) that was
  silently dropping fields like `start_time` / `end_time`.

## Impact on existing connectors

- **Close**: `resolveSchema()` covers every entity in the old hardcoded list,
  including `activities:Call`-style sub-entity keys (`ACTIVITY_SCHEMA_MAP`).
  Same options as before, **plus** dynamically discovered custom fields. New
  Close flows now pre-populate cluster fields with the connector's suggestion
  (`["_dataSourceId", "id"]`) instead of starting empty.
- **Claap**: `resolveSchema()` covers `recordings` and `workspace` — the only
  two entities the old map had. No change in options.
- **Stripe**: no `resolveSchema`, so it falls back to system fields — identical
  to its previous behavior (it was never in the hardcoded maps).
- **Existing saved flows**: untouched. Saved `entityLayouts` are preserved on
  edit, and partition/cluster selects are disabled outside new-flow mode
  (`!isNewMode`), so stored values can't be clobbered.

## Notes / tradeoffs

- Close's `resolveSchema` hits the Close API per entity for custom fields, so
  the entities endpoint does a burst of calls on first load. It's cached
  client-side per `${workspaceId}:${connectorId}` and degrades gracefully to
  system fields on failure, so eager resolution is acceptable for this admin
  config screen.

## Test plan

- [ ] Calendly webhook flow: partition dropdown shows `created_at`,
      `start_time`, `end_time`, `updated_at`, `_syncedAt`; cluster dropdown
      shows the full field list.
- [ ] Close webhook flow: options match prior behavior (+ custom fields);
      sub-entities (e.g. `activities:Call`) populate correctly.
- [ ] Claap webhook flow: `recordings` / `workspace` options unchanged.
- [ ] Stripe webhook flow: falls back to system fields, no errors.
- [ ] Editing an existing flow preserves saved partition/cluster values.
- [ ] `pnpm --filter app run typecheck && pnpm --filter app run lint`
- [ ] `pnpm --filter api run lint`

## Files changed

- `api/src/routes/sources.ts` (+36 / -2)
- `app/src/store/availableEntitiesStore.ts` (+14 / -2)
- `app/src/components/WebhookFlowForm.tsx` (+~40 / -~265)