### PR TITLE
feat(chat): Cursor-style clarifying questions wizard

### DIFF
--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -59,6 +59,12 @@ YOU decide when these make sense:
 - \`ask_clarifying_questions\` — use whenever the request is ambiguous or you need a decision
   (which connection, which dashboard, scope, output format). Ask only what you genuinely need;
   do not ask things you can answer with read-only tools.
+  NEVER ask the user questions or present options as plain text, bullet points, or numbered
+  lists in your reply — ALWAYS call \`ask_clarifying_questions\` instead so the user gets an
+  interactive form. Give each question concrete \`options\` when you can enumerate them, set
+  \`allowMultiple\` when several answers are valid, and set \`allowOther: false\` only when the
+  listed options are exhaustive. NEVER include an "Other" / "Something else" option yourself —
+  the form automatically appends a free-text "Other" choice unless \`allowOther\` is false.
 - \`submit_plan\` — use BEFORE acting when the work is large, destructive, or spans multiple
   artifacts (e.g. building a dashboard from scratch, modifying many consoles, deleting or
   overwriting data, reconfiguring a sync flow), or when the user explicitly asks for a plan.

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -3420,11 +3420,16 @@ const Chat: React.FC<ChatProps> = ({
           only shows a read-only summary once the user has responded. */}
       {pendingInteractiveTool && (
         <Box
-          sx={{ mx: 1, mt: 1, mb: -0.5 }}
+          sx={
+            pendingInteractiveTool.toolName === "ask_clarifying_questions"
+              ? { mx: 2.25, mt: 1, mb: -1 }
+              : { mx: 1, mt: 1, mb: -0.5 }
+          }
           key={pendingInteractiveTool.toolCallId}
         >
           {pendingInteractiveTool.toolName === "ask_clarifying_questions" ? (
             <ClarifyingQuestionsCard
+              docked
               input={
                 pendingInteractiveTool.input as AskClarifyingQuestionsInput
               }

--- a/app/src/components/ClarifyingQuestionsCard.tsx
+++ b/app/src/components/ClarifyingQuestionsCard.tsx
@@ -1,6 +1,22 @@
-import React, { useMemo, useState } from "react";
-import { Box, Button, Chip, Stack, TextField, Typography } from "@mui/material";
-import { HelpCircle, PenLine } from "lucide-react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import {
+  Box,
+  Button,
+  Chip,
+  InputBase,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { keyframes } from "@mui/material/styles";
+import {
+  ChevronLeft,
+  Circle,
+  CircleDot,
+  HelpCircle,
+  PenLine,
+  Square,
+  SquareCheck,
+} from "lucide-react";
 import type {
   AskClarifyingQuestionsInput,
   AskClarifyingQuestionsOutput,
@@ -13,6 +29,8 @@ interface ClarifyingQuestionsCardProps {
   output?: AskClarifyingQuestionsOutput;
   /** Required for the pending (interactive) card; unused for summaries. */
   onResolve?: (output: AskClarifyingQuestionsOutput) => void;
+  /** Flat bottom edge so the card mates with the composer (pending dock). */
+  docked?: boolean;
 }
 
 interface QuestionAnswer {
@@ -35,6 +53,23 @@ const emptyAnswer = (): QuestionAnswer => ({
   text: "",
 });
 
+/**
+ * Models sometimes include their own "Other" / "Something else" option even
+ * though the form appends a free-text "Other…" row. Detect those so we can
+ * collapse them into our row instead of showing "Other" twice.
+ */
+const isOtherLikeOption = (option: string): boolean =>
+  /^(other|something else)[\s\W]*$/i.test(option.trim());
+
+/** Predefined options with model-provided "Other"-style entries removed. */
+const visibleOptions = (question: ClarifyingQuestion): string[] =>
+  (question.options ?? []).filter(o => !isOtherLikeOption(o));
+
+/** Whether to render the free-text "Other…" row for a choice question. */
+const showsOtherRow = (question: ClarifyingQuestion): boolean =>
+  question.allowOther !== false ||
+  (question.options ?? []).some(isOtherLikeOption);
+
 function buildResponse(
   question: ClarifyingQuestion,
   answer: QuestionAnswer,
@@ -48,17 +83,126 @@ function buildResponse(
   return question.allowMultiple ? values : (values[0] ?? "");
 }
 
+// Card slides up from behind the chat input, same as the prompt queue.
+const cardSlideUp = keyframes`
+  from { opacity: 0; transform: translateY(100%); }
+  to { opacity: 1; transform: translateY(0); }
+`;
+
+// Per-question screen change: quick fade + slide-in from the right.
+const stepFadeIn = keyframes`
+  from { opacity: 0; transform: translateX(8px); }
+  to { opacity: 1; transform: translateX(0); }
+`;
+
+const OPTION_ROW_SX = {
+  display: "flex",
+  alignItems: "center",
+  gap: 1,
+  px: 1,
+  py: 0.5,
+  minHeight: 32,
+  borderRadius: 1,
+  cursor: "pointer",
+  userSelect: "none",
+} as const;
+
+interface OptionRowProps {
+  label: string;
+  selected: boolean;
+  multiple: boolean;
+  icon?: React.ReactNode;
+  role?: "radio" | "checkbox";
+  onToggle: () => void;
+}
+
+/** Single-line selectable option row (radio or checkbox semantics). */
+const OptionRow: React.FC<OptionRowProps> = ({
+  label,
+  selected,
+  multiple,
+  icon,
+  role,
+  onToggle,
+}) => {
+  const indicator =
+    icon ??
+    (multiple ? (
+      selected ? (
+        <SquareCheck size={14} />
+      ) : (
+        <Square size={14} />
+      )
+    ) : selected ? (
+      <CircleDot size={14} />
+    ) : (
+      <Circle size={14} />
+    ));
+
+  return (
+    <Box
+      role={role ?? (multiple ? "checkbox" : "radio")}
+      aria-checked={selected}
+      tabIndex={0}
+      onClick={onToggle}
+      onKeyDown={e => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onToggle();
+        }
+      }}
+      sx={{
+        ...OPTION_ROW_SX,
+        backgroundColor: selected ? "action.selected" : "transparent",
+        "&:hover": {
+          backgroundColor: selected ? "action.selected" : "action.hover",
+        },
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          flexShrink: 0,
+          color: selected ? "primary.main" : "text.secondary",
+        }}
+      >
+        {indicator}
+      </Box>
+      <Typography sx={{ fontSize: 13, flex: 1, minWidth: 0 }}>
+        {label}
+      </Typography>
+    </Box>
+  );
+};
+
 /**
- * Inline form for the deferred `ask_clarifying_questions` tool. Choice
- * questions render their options as selectable chips plus an "Other" option
- * that reveals a free-text field. Resolves via `onResolve` on submit or skip.
+ * Cursor-style wizard for the deferred `ask_clarifying_questions` tool: one
+ * question per screen, single-line option rows (radio/checkbox), an optional
+ * "Other" free-text row, and Back / Skip / Next navigation. Resolves via
+ * `onResolve` on submit or skip. With `output` present it renders a compact
+ * read-only summary instead.
  */
 export const ClarifyingQuestionsCard: React.FC<
   ClarifyingQuestionsCardProps
-> = ({ input, output, onResolve }) => {
+> = ({ input, output, onResolve, docked }) => {
   const questions = useMemo(() => input?.questions ?? [], [input]);
   const [answers, setAnswers] = useState<AnswerMap>({});
+  const [step, setStep] = useState(0);
+  const advanceTimerRef = useRef<number | null>(null);
   const resolved = Boolean(output);
+
+  const lastStep = Math.max(questions.length - 1, 0);
+  const question = questions[Math.min(step, lastStep)];
+
+  useEffect(
+    () => () => {
+      if (advanceTimerRef.current !== null) {
+        window.clearTimeout(advanceTimerRef.current);
+      }
+    },
+    [],
+  );
 
   const getAnswer = (id: string): QuestionAnswer =>
     answers[id] ?? emptyAnswer();
@@ -69,30 +213,48 @@ export const ClarifyingQuestionsCard: React.FC<
       [id]: { ...(prev[id] ?? emptyAnswer()), ...patch },
     }));
 
-  const toggleOption = (question: ClarifyingQuestion, option: string) => {
-    const answer = getAnswer(question.id);
-    if (question.allowMultiple) {
-      updateAnswer(question.id, {
+  const cancelScheduledAdvance = () => {
+    if (advanceTimerRef.current !== null) {
+      window.clearTimeout(advanceTimerRef.current);
+      advanceTimerRef.current = null;
+    }
+  };
+
+  /** Brief delay so the selected state is visible before the screen changes. */
+  const scheduleAdvance = () => {
+    if (step >= lastStep) return;
+    cancelScheduledAdvance();
+    advanceTimerRef.current = window.setTimeout(() => {
+      advanceTimerRef.current = null;
+      setStep(prev => Math.min(prev + 1, lastStep));
+    }, 150);
+  };
+
+  const toggleOption = (q: ClarifyingQuestion, option: string) => {
+    const answer = getAnswer(q.id);
+    if (q.allowMultiple) {
+      updateAnswer(q.id, {
         selected: answer.selected.includes(option)
           ? answer.selected.filter(v => v !== option)
           : [...answer.selected, option],
       });
-    } else {
-      // Single choice: picking an option deselects "Other" and vice versa.
-      updateAnswer(question.id, {
-        selected: answer.selected.includes(option) ? [] : [option],
-        otherSelected: false,
-      });
+      return;
     }
+    // Single choice: picking an option deselects "Other" and vice versa.
+    const deselecting = answer.selected.includes(option);
+    updateAnswer(q.id, {
+      selected: deselecting ? [] : [option],
+      otherSelected: false,
+    });
+    if (!deselecting) scheduleAdvance();
   };
 
-  const toggleOther = (question: ClarifyingQuestion) => {
-    const answer = getAnswer(question.id);
-    updateAnswer(question.id, {
+  const toggleOther = (q: ClarifyingQuestion) => {
+    const answer = getAnswer(q.id);
+    cancelScheduledAdvance();
+    updateAnswer(q.id, {
       otherSelected: !answer.otherSelected,
-      ...(question.allowMultiple || answer.otherSelected
-        ? {}
-        : { selected: [] }),
+      ...(q.allowMultiple || answer.otherSelected ? {} : { selected: [] }),
     });
   };
 
@@ -108,131 +270,306 @@ export const ClarifyingQuestionsCard: React.FC<
     });
   };
 
+  const handleNext = () => {
+    cancelScheduledAdvance();
+    if (step < lastStep) {
+      setStep(step + 1);
+    } else {
+      handleSubmit();
+    }
+  };
+
+  const handleBack = () => {
+    cancelScheduledAdvance();
+    setStep(prev => Math.max(prev - 1, 0));
+  };
+
   const handleSkip = () => {
     if (resolved) return;
     onResolve?.({ success: true, skipped: true });
   };
+
+  /** Enter advances/submits from text fields (Shift+Enter inserts newline). */
+  const handleTextKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleNext();
+    }
+  };
+
+  const answer = question ? getAnswer(question.id) : emptyAnswer();
+  const isLast = step >= lastStep;
 
   return (
     <Box
       sx={{
         border: 1,
         borderColor: "divider",
-        borderRadius: 2,
-        p: 1.5,
-        my: 0.5,
+        borderRadius: 2.5,
         bgcolor: "background.paper",
+        p: 0.5,
+        ...(docked
+          ? {
+              borderBottom: 0,
+              borderBottomLeftRadius: 0,
+              borderBottomRightRadius: 0,
+              transformOrigin: "bottom",
+              animation: `${cardSlideUp} 220ms cubic-bezier(0.4, 0, 0.2, 1)`,
+            }
+          : { my: 0.5 }),
       }}
     >
-      <Stack direction="row" spacing={1} alignItems="center" mb={1}>
-        <HelpCircle size={15} />
-        <Typography variant="subtitle2" fontWeight={600}>
+      {/* Header — mirrors the queued-prompts "N Queued" header typography */}
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 0.5,
+          px: 1,
+          py: 0.5,
+          color: "text.secondary",
+        }}
+      >
+        <HelpCircle size={14} />
+        <Typography
+          variant="caption"
+          sx={{ fontWeight: 600, letterSpacing: 0.2 }}
+        >
           Clarifying questions
         </Typography>
-        {resolved && (
+        {resolved ? (
           <Chip
             size="small"
             label={output?.skipped ? "Skipped" : "Answered"}
             color={output?.skipped ? "default" : "success"}
             variant="outlined"
+            sx={{ ml: "auto" }}
           />
+        ) : (
+          questions.length > 1 && (
+            <Typography
+              variant="caption"
+              sx={{ ml: "auto", color: "text.secondary" }}
+            >
+              {step + 1} of {questions.length}
+            </Typography>
+          )
         )}
-      </Stack>
+      </Box>
 
-      <Stack spacing={1.5}>
-        {questions.map(question => {
-          const answer = getAnswer(question.id);
-          const resolvedAnswer = output?.answers?.find(
-            a => a.id === question.id,
-          )?.response;
+      {resolved ? (
+        /* Read-only summary: compact queue-style rows */
+        <Box>
+          {questions.map(q => {
+            const resolvedAnswer = output?.answers?.find(
+              a => a.id === q.id,
+            )?.response;
+            const display = Array.isArray(resolvedAnswer)
+              ? resolvedAnswer.join(", ") || "—"
+              : resolvedAnswer || (output?.skipped ? "Skipped" : "—");
 
-          return (
-            <Box key={question.id}>
-              <Typography variant="body2" fontWeight={500} mb={0.75}>
+            return (
+              <Box
+                key={q.id}
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1,
+                  px: 1,
+                  py: 0.5,
+                  minHeight: 28,
+                }}
+              >
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    color: "text.secondary",
+                    flexShrink: 0,
+                  }}
+                >
+                  <Circle size={10} />
+                </Box>
+                <Typography sx={{ fontSize: 13, minWidth: 0 }}>
+                  <Box component="span" sx={{ color: "text.secondary" }}>
+                    {q.prompt}
+                  </Box>
+                  <Box component="span" sx={{ color: "text.secondary" }}>
+                    {" — "}
+                  </Box>
+                  <Box component="span" sx={{ color: "text.primary" }}>
+                    {display}
+                  </Box>
+                </Typography>
+              </Box>
+            );
+          })}
+        </Box>
+      ) : (
+        question && (
+          <>
+            {/* One question per screen, animated on step change */}
+            <Box
+              key={question.id}
+              sx={{ animation: `${stepFadeIn} 150ms ease` }}
+            >
+              <Typography
+                sx={{ fontSize: 13, fontWeight: 600, px: 1, pt: 0.5, pb: 0.75 }}
+              >
                 {question.prompt}
               </Typography>
 
-              {resolved ? (
-                <Typography variant="body2" color="text.secondary">
-                  {Array.isArray(resolvedAnswer)
-                    ? resolvedAnswer.join(", ") || "—"
-                    : resolvedAnswer || (output?.skipped ? "Skipped" : "—")}
-                </Typography>
-              ) : question.type === "choice" ? (
-                <>
-                  <Stack
-                    direction="row"
-                    spacing={0.75}
-                    flexWrap="wrap"
-                    useFlexGap
-                  >
-                    {(question.options ?? []).map(option => {
-                      const selected = answer.selected.includes(option);
-                      return (
-                        <Chip
-                          key={option}
-                          label={option}
-                          size="small"
-                          color={selected ? "primary" : "default"}
-                          variant={selected ? "filled" : "outlined"}
-                          onClick={() => toggleOption(question, option)}
-                        />
-                      );
-                    })}
-                    <Chip
-                      icon={<PenLine size={12} />}
-                      label="Other"
-                      size="small"
-                      color={answer.otherSelected ? "primary" : "default"}
-                      variant={answer.otherSelected ? "filled" : "outlined"}
-                      onClick={() => toggleOther(question)}
-                    />
-                  </Stack>
-                  {answer.otherSelected && (
-                    <TextField
-                      size="small"
-                      fullWidth
-                      autoFocus
-                      multiline
-                      minRows={1}
-                      maxRows={4}
-                      placeholder="Type your answer…"
-                      value={answer.otherText}
-                      onChange={e =>
-                        updateAnswer(question.id, { otherText: e.target.value })
-                      }
-                      sx={{ mt: 0.75 }}
-                    />
+              {question.type === "choice" ? (
+                <Box
+                  role={question.allowMultiple ? "group" : "radiogroup"}
+                  aria-label={question.prompt}
+                >
+                  {question.allowMultiple && (
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        display: "block",
+                        px: 1,
+                        pb: 0.5,
+                        mt: -0.5,
+                        color: "text.secondary",
+                      }}
+                    >
+                      Select all that apply
+                    </Typography>
                   )}
-                </>
+                  {visibleOptions(question).map(option => (
+                    <OptionRow
+                      key={option}
+                      label={option}
+                      selected={answer.selected.includes(option)}
+                      multiple={Boolean(question.allowMultiple)}
+                      onToggle={() => toggleOption(question, option)}
+                    />
+                  ))}
+                  {showsOtherRow(question) &&
+                    (answer.otherSelected ? (
+                      /* In-place edit: the row itself becomes the input */
+                      <Box
+                        sx={{
+                          ...OPTION_ROW_SX,
+                          cursor: "text",
+                          backgroundColor: "action.selected",
+                        }}
+                      >
+                        <Box
+                          role="button"
+                          aria-label="Deselect Other"
+                          onClick={() => toggleOther(question)}
+                          sx={{
+                            display: "flex",
+                            alignItems: "center",
+                            flexShrink: 0,
+                            color: "primary.main",
+                            cursor: "pointer",
+                          }}
+                        >
+                          <PenLine size={14} />
+                        </Box>
+                        <InputBase
+                          autoFocus
+                          fullWidth
+                          multiline
+                          maxRows={3}
+                          placeholder="Type your answer…"
+                          value={answer.otherText}
+                          onChange={e =>
+                            updateAnswer(question.id, {
+                              otherText: e.target.value,
+                            })
+                          }
+                          onKeyDown={e => {
+                            if (e.key === "Escape") {
+                              e.preventDefault();
+                              toggleOther(question);
+                              return;
+                            }
+                            handleTextKeyDown(e);
+                          }}
+                          sx={{
+                            flex: 1,
+                            minWidth: 0,
+                            p: 0,
+                            fontSize: 13,
+                            lineHeight: 1.5,
+                          }}
+                        />
+                      </Box>
+                    ) : (
+                      <OptionRow
+                        label="Other…"
+                        selected={false}
+                        multiple={Boolean(question.allowMultiple)}
+                        icon={<PenLine size={14} />}
+                        onToggle={() => toggleOther(question)}
+                      />
+                    ))}
+                </Box>
               ) : (
-                <TextField
-                  size="small"
-                  fullWidth
-                  multiline
-                  minRows={1}
-                  maxRows={4}
-                  placeholder="Type your answer…"
-                  value={answer.text}
-                  onChange={e =>
-                    updateAnswer(question.id, { text: e.target.value })
-                  }
-                />
+                <Box sx={{ px: 1 }}>
+                  <TextField
+                    size="small"
+                    fullWidth
+                    autoFocus
+                    multiline
+                    minRows={1}
+                    maxRows={4}
+                    placeholder="Type your answer…"
+                    value={answer.text}
+                    onChange={e =>
+                      updateAnswer(question.id, { text: e.target.value })
+                    }
+                    onKeyDown={handleTextKeyDown}
+                  />
+                </Box>
               )}
             </Box>
-          );
-        })}
-      </Stack>
 
-      {!resolved && (
-        <Stack direction="row" spacing={1} mt={1.5} justifyContent="flex-end">
-          <Button size="small" color="inherit" onClick={handleSkip}>
-            Skip
-          </Button>
-          <Button size="small" variant="contained" onClick={handleSubmit}>
-            Send answers
-          </Button>
-        </Stack>
+            {/* Footer: Back / Skip on the left, Next or Send answers on the right */}
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1,
+                px: 1,
+                pt: 1,
+                pb: 0.5,
+              }}
+            >
+              {step > 0 && (
+                <Button
+                  size="small"
+                  color="inherit"
+                  startIcon={<ChevronLeft size={14} />}
+                  onClick={handleBack}
+                >
+                  Back
+                </Button>
+              )}
+              <Button
+                size="small"
+                color="inherit"
+                onClick={handleSkip}
+                sx={{ color: "text.secondary" }}
+              >
+                Skip
+              </Button>
+              <Button
+                size="small"
+                variant="contained"
+                onClick={handleNext}
+                sx={{ ml: "auto" }}
+              >
+                {isLast ? "Send answers" : "Next"}
+              </Button>
+            </Box>
+          </>
+        )
       )}
     </Box>
   );

--- a/packages/agent-tools/src/plan-tools.ts
+++ b/packages/agent-tools/src/plan-tools.ts
@@ -27,12 +27,23 @@ export const clarifyingQuestionSchema = z.object({
   options: z
     .array(z.string())
     .optional()
-    .describe("Selectable options (required when type is 'choice')."),
+    .describe(
+      "Selectable options (required when type is 'choice'). Do NOT include an " +
+        "'Other' / 'Something else' entry — the form appends a free-text " +
+        "'Other' choice automatically unless allowOther is false.",
+    ),
   allowMultiple: z
     .boolean()
     .optional()
     .describe(
       "For 'choice' questions, allow selecting more than one option.",
+    ),
+  allowOther: z
+    .boolean()
+    .optional()
+    .describe(
+      "For 'choice' questions, append an 'Other' free-text option (defaults to true). " +
+        "Set false when the listed options are exhaustive.",
     ),
 });
 
@@ -76,6 +87,8 @@ export const clientPlanTools = {
       "Pause and ask the user one or more targeted clarifying questions before planning or acting. " +
       "Use this whenever the request is ambiguous or you need a decision (which connection, " +
       "which dashboard, scope, etc.). The user answers in an inline form; their answers are returned to you. " +
+      "This is the ONLY way to ask the user questions — never present questions or option lists " +
+      "as plain text in a reply. Prefer 'choice' questions with concrete options over free text. " +
       "Only ask what you genuinely need — do not ask questions you can answer with read-only tools.",
     inputSchema: askClarifyingQuestionsSchema,
     // No execute function - resolved by the client via an interactive form.


### PR DESCRIPTION
## Summary

- Rebuilds `ClarifyingQuestionsCard` as a one-question-per-screen wizard: step counter, Back/Next navigation with answer persistence, 150ms screen transitions, and a footer `Skip` / `Send answers` flow (output shape unchanged — no changes to the submission path).
- Replaces option chips with single-line rows using radio/checkbox semantics: single choice auto-advances on select, multi choice toggles with a "Select all that apply" hint, and the "Other" option edits **in place** (the row morphs into an inline input; Enter advances, Escape reverts).
- Restyles the card with the queued-prompts visual language (border radius 2.5, 32px rows, `action.hover`/`action.selected`, slide-up reveal) and docks it flush above the composer via a new `docked` prop; the resolved state renders as compact summary rows.
- Adds an optional `allowOther` flag to `clarifyingQuestionSchema`, and hardens the system prompt + tool description so the model asks questions through the form instead of prose option lists and never emits its own "Other" option — the UI also dedupes model-provided "Other"/"Something else" entries defensively.

## Test plan

- [x] `pnpm --filter app run typecheck` + `pnpm --filter app run lint` + `pnpm --filter api run lint` green on this branch
- [x] Verified in the running app end to end: tool call renders the docked wizard; single-choice auto-advance, multi-choice + inline Other text, Back persistence, Enter-to-send; agent correctly receives `{ id, prompt, response }` answers and continues
- [x] Light and dark mode rendering checked
- [ ] Reviewer: trigger `ask_clarifying_questions` (e.g. "Ask me follow up questions") and confirm the form appears instead of a prose list

Made with [Cursor](https://cursor.com)