### PR TITLE
Detect stale frontend bundle and prompt reload

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -265,11 +265,16 @@ jobs:
           echo "latest_tag=${IMAGE_URI}:latest" >> "$GITHUB_OUTPUT"
 
       - name: Create .env.production for Docker build
+        env:
+          # Build ID baked into the frontend bundle + version.json so clients
+          # can detect stale bundles (served back via GET /api/version)
+          VITE_BUILD_ID: ${{ needs.detect-changes.outputs.pr_sha || github.sha }}
         run: |
           cat <<EOF > .env.production
           VITE_API_URL=${VITE_API_URL}
           VITE_MUI_LICENSE_KEY=${VITE_MUI_LICENSE_KEY}
           VITE_GTM_ID=${VITE_GTM_ID}
+          VITE_BUILD_ID=${VITE_BUILD_ID}
           EOF
 
       - name: Build Docker image
@@ -864,6 +869,7 @@ jobs:
           VITE_API_URL=${VITE_API_URL}
           VITE_MUI_LICENSE_KEY=${VITE_MUI_LICENSE_KEY}
           VITE_GTM_ID=${VITE_GTM_ID}
+          VITE_BUILD_ID=${GITHUB_SHA}
           EOF
 
       - name: Build Docker image

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -132,6 +132,37 @@ app.get("/health", c => {
   return c.json({ status: "ok", timestamp: new Date().toISOString() });
 });
 
+// Frontend build version - public, used by long-lived clients (especially the
+// desktop app) to detect that their loaded bundle is stale and prompt a
+// reload. The build ID is emitted into public/version.json by the Vite build
+// (git SHA in CI), so it is always in sync with the bundle shipped in this
+// image. Falls back to "dev" locally where no version.json exists.
+let cachedBuildId: string | null = null;
+function getFrontendBuildId(): string {
+  if (cachedBuildId === null) {
+    try {
+      const versionPath = path.join(process.cwd(), "public", "version.json");
+      const parsed = JSON.parse(fs.readFileSync(versionPath, "utf8")) as {
+        buildId?: unknown;
+      };
+      cachedBuildId =
+        typeof parsed.buildId === "string" && parsed.buildId
+          ? parsed.buildId
+          : "dev";
+    } catch {
+      cachedBuildId = "dev";
+    }
+  }
+  return cachedBuildId;
+}
+
+app.get("/api/version", c => {
+  // no-store: this endpoint exists to detect new deploys, so neither the
+  // browser nor any CDN in front may ever serve a cached response.
+  c.header("Cache-Control", "no-store");
+  return c.json({ buildId: getFrontendBuildId() });
+});
+
 // API routes
 app.route("/api/auth", authRoutes);
 app.route("/api/workspaces", workspaceRoutes);
@@ -215,6 +246,9 @@ app.use("*", async (c, next) => {
     const indexPath = path.join(publicPath, "index.html");
     if (fs.existsSync(indexPath)) {
       const content = fs.readFileSync(indexPath, "utf8");
+      // index.html must always be revalidated so a reload after a deploy
+      // picks up the new bundle (stale-client detection depends on this).
+      c.header("Cache-Control", "no-cache");
       return c.html(content);
     }
   }
@@ -224,13 +258,21 @@ app.use("*", async (c, next) => {
     const ext = path.extname(filePath);
     const contentType = getContentType(ext);
     const content = fs.readFileSync(filePath);
-    return c.body(content, { headers: { "Content-Type": contentType } });
+    // Vite assets are content-hashed, so they can be cached forever; anything
+    // else (index.html handled above) gets revalidation.
+    const cacheControl = requestPath.startsWith("/assets/")
+      ? "public, max-age=31536000, immutable"
+      : "no-cache";
+    return c.body(content, {
+      headers: { "Content-Type": contentType, "Cache-Control": cacheControl },
+    });
   }
 
   // Fallback to index.html for SPA routing
   const indexPath = path.join(publicPath, "index.html");
   if (fs.existsSync(indexPath)) {
     const content = fs.readFileSync(indexPath, "utf8");
+    c.header("Cache-Control", "no-cache");
     return c.html(content);
   }
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -55,6 +55,7 @@ import { ForgotPasswordPage } from "./components/ForgotPasswordPage";
 import { ResetPasswordPage } from "./components/ResetPasswordPage";
 import { useAuth } from "./contexts/auth-context";
 import { OnboardingFlow } from "./components/OnboardingFlow";
+import { UpdateNotification } from "./components/UpdateNotification";
 
 // Draggable divider between a fixed-width side pane and the flexible center.
 // Resizing changes the side pane's pixel width directly (not a percentage),
@@ -706,6 +707,7 @@ function App() {
     <>
       <PageViewTracker />
       <DesktopAuthResume />
+      <UpdateNotification />
       <Routes>
         {/* Invite route - no authentication required */}
         <Route path="/invite/:token" element={<InvitePage />} />

--- a/app/src/components/UpdateNotification.tsx
+++ b/app/src/components/UpdateNotification.tsx
@@ -1,0 +1,47 @@
+import { Alert, Button, IconButton, Snackbar } from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import { useAppVersionStore } from "../store/appVersionStore";
+import { useVersionCheck } from "../hooks/useVersionCheck";
+
+/**
+ * Watches for newly deployed frontend builds and shows a non-blocking prompt
+ * to reload. Critical for the desktop app, where the window can stay open for
+ * days and the loaded bundle silently goes stale.
+ */
+export function UpdateNotification() {
+  useVersionCheck();
+
+  const updateAvailable = useAppVersionStore(state => state.updateAvailable);
+  const dismissed = useAppVersionStore(state => state.dismissed);
+  const dismiss = useAppVersionStore(state => state.dismiss);
+  const reloadToUpdate = useAppVersionStore(state => state.reloadToUpdate);
+
+  return (
+    <Snackbar
+      open={updateAvailable && !dismissed}
+      anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+    >
+      <Alert
+        severity="info"
+        variant="filled"
+        action={
+          <>
+            <Button color="inherit" size="small" onClick={reloadToUpdate}>
+              Reload
+            </Button>
+            <IconButton
+              size="small"
+              color="inherit"
+              aria-label="Dismiss update notification"
+              onClick={dismiss}
+            >
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </>
+        }
+      >
+        A new version of Mako is available.
+      </Alert>
+    </Snackbar>
+  );
+}

--- a/app/src/hooks/useVersionCheck.ts
+++ b/app/src/hooks/useVersionCheck.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from "react";
+import { useAppVersionStore, CURRENT_BUILD_ID } from "../store/appVersionStore";
+
+/** Background polling interval while the app is open */
+const CHECK_INTERVAL_MS = 10 * 60 * 1000;
+/** Minimum gap between checks triggered by focus/visibility events */
+const FOCUS_CHECK_THROTTLE_MS = 60 * 1000;
+
+/**
+ * Periodically checks whether a newer frontend build has been deployed.
+ *
+ * Checks run on an interval and — most importantly for the desktop app, where
+ * the window stays open for days — whenever the window regains focus or
+ * becomes visible again, throttled so rapid focus changes don't spam the API.
+ */
+export function useVersionCheck(): void {
+  const checkForUpdate = useAppVersionStore(state => state.checkForUpdate);
+  const lastCheckAtRef = useRef(0);
+
+  useEffect(() => {
+    if (CURRENT_BUILD_ID === "dev") return;
+
+    const check = () => {
+      lastCheckAtRef.current = Date.now();
+      void checkForUpdate();
+    };
+
+    const throttledCheck = () => {
+      if (Date.now() - lastCheckAtRef.current < FOCUS_CHECK_THROTTLE_MS) return;
+      check();
+    };
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") throttledCheck();
+    };
+
+    // Initial check shortly after load (deferred so it never competes with
+    // app startup work).
+    const initialTimeout = window.setTimeout(check, 15_000);
+    const intervalId = window.setInterval(check, CHECK_INTERVAL_MS);
+    window.addEventListener("focus", throttledCheck);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      window.clearTimeout(initialTimeout);
+      window.clearInterval(intervalId);
+      window.removeEventListener("focus", throttledCheck);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [checkForUpdate]);
+}

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -17,6 +17,19 @@ LicenseInfo.setLicenseKey(import.meta.env.VITE_MUI_LICENSE_KEY || "");
 // This clears localStorage when the schema version changes
 initializeStoreVersion();
 
+// Stale-bundle safety net: after a deploy, old content-hashed chunks no longer
+// exist on the server, so lazy route/component imports from a stale client
+// fail. Reload once to pick up the new build (guarded against reload loops).
+window.addEventListener("vite:preloadError", event => {
+  const LAST_RELOAD_KEY = "mako:chunk-error-reload-at";
+  const lastReloadAt = Number(sessionStorage.getItem(LAST_RELOAD_KEY) || 0);
+  if (Date.now() - lastReloadAt > 60_000) {
+    sessionStorage.setItem(LAST_RELOAD_KEY, String(Date.now()));
+    event.preventDefault();
+    window.location.reload();
+  }
+});
+
 enableMapSet();
 
 const rootElement = document.getElementById("root");

--- a/app/src/store/appVersionStore.ts
+++ b/app/src/store/appVersionStore.ts
@@ -1,0 +1,71 @@
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+import { apiClient } from "../lib/api-client";
+
+/**
+ * Detects when the running frontend bundle is stale (a newer version has been
+ * deployed). This matters most for the desktop app, where the window can stay
+ * open for days and nobody ever refreshes.
+ *
+ * The build ID is baked into the bundle at build time (git SHA in CI) and the
+ * server reports the currently-deployed build ID at GET /api/version.
+ */
+
+// "dev" locally (no VITE_BUILD_ID) — version checks are skipped entirely.
+export const CURRENT_BUILD_ID: string = import.meta.env.VITE_BUILD_ID || "dev";
+
+interface AppVersionState {
+  /** A newer build than the one currently loaded has been deployed */
+  updateAvailable: boolean;
+  /** Build ID reported by the server when the update was detected */
+  latestBuildId: string | null;
+  /** User dismissed the update notification (until next page load) */
+  dismissed: boolean;
+
+  checkForUpdate: () => Promise<void>;
+  dismiss: () => void;
+  reloadToUpdate: () => void;
+}
+
+export const useAppVersionStore = create<AppVersionState>()(
+  immer((set, get) => ({
+    updateAvailable: false,
+    latestBuildId: null,
+    dismissed: false,
+
+    checkForUpdate: async () => {
+      // Local dev builds have no meaningful build ID; nothing to compare.
+      if (CURRENT_BUILD_ID === "dev") return;
+      // Already detected — no need to keep polling.
+      if (get().updateAvailable) return;
+
+      try {
+        const response = await apiClient.get<{ buildId?: string }>("/version");
+        const serverBuildId = response?.buildId;
+        if (
+          serverBuildId &&
+          serverBuildId !== "dev" &&
+          serverBuildId !== CURRENT_BUILD_ID
+        ) {
+          set(state => {
+            state.updateAvailable = true;
+            state.latestBuildId = serverBuildId;
+          });
+        }
+      } catch {
+        // Network errors (offline, server restarting mid-deploy) are
+        // expected; the next scheduled check will retry.
+      }
+    },
+
+    dismiss: () => {
+      set(state => {
+        state.dismissed = true;
+      });
+    },
+
+    reloadToUpdate: () => {
+      window.location.reload();
+    },
+  })),
+);

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -4,6 +4,7 @@ interface ImportMetaEnv {
   readonly VITE_API_URL: string;
   readonly VITE_MUI_LICENSE_KEY: string;
   readonly VITE_DISABLE_OAUTH?: string; // Set to "true" to disable OAuth (for PR previews)
+  readonly VITE_BUILD_ID?: string; // Git SHA injected by CI; "dev" / unset locally
   // Add more env variables as needed
 }
 

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,36 +1,65 @@
-import { defineConfig } from "vite";
+import path from "node:path";
+import { defineConfig, loadEnv, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import reactScan from "@react-scan/vite-plugin-react-scan";
 import tailwindcss from "@tailwindcss/vite";
 
-export default defineConfig({
-  plugins: [
-    react(),
-    reactScan({
-      enable: process.env.VITE_REACT_SCAN === "true",
-      autoDisplayNames: true,
-    }),
-    tailwindcss(),
-  ],
-  envDir: "..",
-  server: {
-    port: 5173,
-    allowedHosts: true,
-    proxy: {
-      "/api": {
-        target: "http://localhost:8080",
-        changeOrigin: true,
-        configure: proxy => {
-          proxy.on("proxyReq", (proxyReq, req) => {
-            const host =
-              (req.headers["x-forwarded-host"] as string) || req.headers.host;
-            if (host) proxyReq.setHeader("x-forwarded-host", host);
-            const proto =
-              (req.headers["x-forwarded-proto"] as string) || "http";
-            proxyReq.setHeader("x-forwarded-proto", proto);
-          });
+/**
+ * Emits a version.json file into the build output containing the build ID
+ * (git SHA in CI). It ships inside the same Docker image as the API, which
+ * serves it back via GET /api/version so long-lived clients (especially the
+ * desktop app) can detect when their loaded bundle is stale.
+ */
+function emitVersionJson(buildId: string): Plugin {
+  return {
+    name: "mako:emit-version-json",
+    apply: "build",
+    generateBundle() {
+      this.emitFile({
+        type: "asset",
+        fileName: "version.json",
+        source: JSON.stringify({ buildId }),
+      });
+    },
+  };
+}
+
+export default defineConfig(({ mode }) => {
+  // envDir is the repo root (".." relative to app/) — same place Vite loads
+  // .env.production from during the Docker build.
+  const env = loadEnv(mode, path.resolve(process.cwd(), ".."), "");
+  const buildId = env.VITE_BUILD_ID || "dev";
+
+  return {
+    plugins: [
+      react(),
+      reactScan({
+        enable: process.env.VITE_REACT_SCAN === "true",
+        autoDisplayNames: true,
+      }),
+      tailwindcss(),
+      emitVersionJson(buildId),
+    ],
+    envDir: "..",
+    server: {
+      port: 5173,
+      allowedHosts: true,
+      proxy: {
+        "/api": {
+          target: "http://localhost:8080",
+          changeOrigin: true,
+          configure: proxy => {
+            proxy.on("proxyReq", (proxyReq, req) => {
+              const host =
+                (req.headers["x-forwarded-host"] as string) || req.headers.host;
+              if (host) proxyReq.setHeader("x-forwarded-host", host);
+              const proto =
+                (req.headers["x-forwarded-proto"] as string) || "http";
+              proxyReq.setHeader("x-forwarded-proto", proto);
+            });
+          },
         },
       },
     },
-  },
+  };
 });


### PR DESCRIPTION
## Summary

The desktop app loads `app.mako.ai` in an Electron window that can stay open for days, with no mechanism to detect that the loaded React bundle has gone stale after a deploy. This adds version detection in the web app itself, so both browser and desktop clients (with no desktop release needed) get notified to reload.

- **Build ID injection**: CI bakes the git SHA into the bundle (`VITE_BUILD_ID`), and a Vite plugin emits a matching `version.json` into `dist` — shipped in the same Docker image as the API, so bundle and reported version can never drift.
- **`GET /api/version`** (public): returns the deployed build ID with `Cache-Control: no-store`.
- **Detection**: `appVersionStore` + `useVersionCheck` compare the embedded build ID against the server's — every 10 minutes plus on window focus/visibility (throttled to 1/min). Skipped entirely in local dev.
- **UX**: non-blocking snackbar with a Reload button — no forced reload, so streaming chats and unsaved queries are never destroyed. Dismissible.
- **Safety net**: `vite:preloadError` handler reloads once (60s loop guard) when a stale client fails to lazy-load a content-hashed chunk that disappeared after a deploy.
- **Cache headers**: static serving previously sent none; now `no-cache` for `index.html` (so reloads actually fetch the new build) and `immutable, max-age=1y` for hashed `/assets/*`.

Note: the first deploy of this change establishes the baseline; detection kicks in from the second deploy onward.

## Test plan

- [x] `pnpm --filter app run lint`, `pnpm --filter api run build` (lint + typecheck) pass
- [x] Production build with `VITE_BUILD_ID=test-sha-123` emits correct `version.json` and bakes the SHA into the bundle
- [ ] On the PR preview: `curl https://pr-<n>.mako.ai/api/version` returns the deploy SHA with `no-store`
- [ ] After a second push to this PR, a client left open on the old preview shows the update snackbar within ~10 min (or immediately on refocus) and Reload picks up the new build
- [ ] Verify `index.html` response has `Cache-Control: no-cache` and `/assets/*.js` has `immutable`

Made with [Cursor](https://cursor.com)