### PR TITLE
Polish Apps explorer: icons, alignment, and drag-to-share between sections

### DIFF
--- a/api/src/routes/apps.ts
+++ b/api/src/routes/apps.ts
@@ -213,12 +213,15 @@ app.get("/", async (c: AuthenticatedContext) => {
       .sort({ updatedAt: -1 })
       .lean<IMakoApp[]>();
 
+    // Mirror dashboards: section is determined by access, not ownership.
+    // Workspace-shared apps live under "Workspace" for everyone (owner
+    // included) so sharing an app visibly moves it between sections.
     const myApps: AppListItem[] = [];
     const workspaceApps: AppListItem[] = [];
     for (const doc of docs) {
       const item = toListItem(doc);
-      if (doc.owner_id === userId) myApps.push(item);
-      else workspaceApps.push(item);
+      if (doc.access === "workspace") workspaceApps.push(item);
+      else if (doc.owner_id === userId) myApps.push(item);
     }
 
     return c.json({ success: true, myApps, workspaceApps });

--- a/app/src/components/AppsExplorer.tsx
+++ b/app/src/components/AppsExplorer.tsx
@@ -18,15 +18,22 @@ import {
   Plus as AddIcon,
   RefreshCw as RefreshIcon,
   AppWindow as AppIcon,
-  FileCode as FileIcon,
+  FileCode as CodeFileIcon,
+  FileText as TextFileIcon,
+  File as PlainFileIcon,
+  Braces as JsonFileIcon,
+  Folder as FolderIcon,
+  FolderOpen as FolderOpenIcon,
   Database as BindingIcon,
   Globe as GlobeIcon,
   User as UserIcon,
+  Lock as LockIcon,
   ExternalLink as OpenIcon,
   Pencil as RenameIcon,
   Trash2 as DeleteIcon,
   Database as MaterializeIcon,
 } from "lucide-react";
+import { useAuth } from "../contexts/auth-context";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useConsoleStore } from "../store/consoleStore";
 import { useExplorerStore } from "../store/explorerStore";
@@ -56,6 +63,30 @@ function dirname(path: string): string {
   const parts = path.split("/").filter(Boolean);
   parts.pop();
   return parts.join("/");
+}
+
+// Per-extension file icons, mirroring the database explorer's per-kind icons.
+const CODE_FILE_EXTENSIONS = new Set([
+  "ts",
+  "tsx",
+  "js",
+  "jsx",
+  "css",
+  "scss",
+  "html",
+]);
+function fileIcon(name: string) {
+  const ext = name.split(".").pop()?.toLowerCase() ?? "";
+  if (CODE_FILE_EXTENSIONS.has(ext)) {
+    return <CodeFileIcon size={16} strokeWidth={1.5} />;
+  }
+  if (ext === "md" || ext === "mdx" || ext === "txt") {
+    return <TextFileIcon size={16} strokeWidth={1.5} />;
+  }
+  if (ext === "json") {
+    return <JsonFileIcon size={16} strokeWidth={1.5} />;
+  }
+  return <PlainFileIcon size={16} strokeWidth={1.5} />;
 }
 
 interface ParsedNode {
@@ -127,7 +158,10 @@ function buildAppFileNodes(
 
 export function AppsExplorer() {
   const { currentWorkspace } = useWorkspace();
+  const { user } = useAuth();
   const workspaceId = currentWorkspace?.id;
+  const isAdmin =
+    currentWorkspace?.role === "owner" || currentWorkspace?.role === "admin";
 
   const myApps = useAppStore(
     s => (workspaceId ? s.myApps[workspaceId] : undefined) || EMPTY_LIST,
@@ -150,6 +184,7 @@ export function AppsExplorer() {
   const removeDataBinding = useAppStore(s => s.removeDataBinding);
   const materializeBinding = useAppStore(s => s.materializeBinding);
   const persistApp = useAppStore(s => s.persistApp);
+  const setAppAccess = useAppStore(s => s.setAppAccess);
 
   const activeTabId = useConsoleStore(s => s.activeTabId);
   const tabs = useConsoleStore(s => s.tabs);
@@ -228,6 +263,7 @@ export function AppsExplorer() {
         label: "My Apps",
         icon: <UserIcon size={16} strokeWidth={1.5} />,
         nodes: buildSectionNodes(myApps),
+        droppableId: "__section_my",
         defaultAccess: "private" as const,
       },
       {
@@ -235,6 +271,7 @@ export function AppsExplorer() {
         label: "Workspace",
         icon: <GlobeIcon size={16} strokeWidth={1.5} />,
         nodes: buildSectionNodes(workspaceApps),
+        droppableId: "__section_workspace",
         defaultAccess: "workspace" as const,
       },
     ],
@@ -282,19 +319,93 @@ export function AppsExplorer() {
     [],
   );
 
-  const getItemIcon = useCallback((node: ResourceTreeNode) => {
-    const parsed = parseNodeId(node.id);
-    if (parsed.kind === "app") {
-      return <AppIcon size={16} strokeWidth={1.5} />;
+  // Only app rows are draggable / manageable through the tree itself; files
+  // and folders inside an app are edited through their own tabs.
+  const canManageNode = useCallback(
+    (node: ResourceTreeNode) => {
+      if (parseNodeId(node.id).kind !== "app") return false;
+      return isAdmin || node.owner_id === user?.id;
+    },
+    [isAdmin, user?.id],
+  );
+
+  // Which section an app currently lives in (drives drop no-op detection).
+  const sectionAccessOfApp = useCallback(
+    (appId: string): "private" | "workspace" | null => {
+      if (myApps.some(item => item.id === appId)) return "private";
+      if (workspaceApps.some(item => item.id === appId)) return "workspace";
+      return null;
+    },
+    [myApps, workspaceApps],
+  );
+
+  // Drag an app onto the "My Apps" / "Workspace" section (or onto any node
+  // inside it) to change its sharing. Drops within the same section no-op.
+  const handleMoveNode = useCallback(
+    (nodeId: string, targetId: string | null, access?: string) => {
+      if (!workspaceId) return;
+      const parsed = parseNodeId(nodeId);
+      if (parsed.kind !== "app") return;
+      let nextAccess: "private" | "workspace" | null =
+        access === "private" || access === "workspace" ? access : null;
+      if (!nextAccess && targetId) {
+        nextAccess = sectionAccessOfApp(parseNodeId(targetId).appId);
+      }
+      if (!nextAccess || sectionAccessOfApp(parsed.appId) === nextAccess) {
+        return;
+      }
+      void setAppAccess(workspaceId, parsed.appId, nextAccess);
+    },
+    [workspaceId, sectionAccessOfApp, setAppAccess],
+  );
+
+  // Dimmed file count on app rows, like the database explorer's group counts.
+  const fileCountByAppId = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const item of [...myApps, ...workspaceApps]) {
+      map.set(item.id, item.fileCount);
     }
-    if (parsed.kind === "file") {
-      return <FileIcon size={16} strokeWidth={1.5} />;
-    }
-    if (parsed.kind === "binding") {
-      return <BindingIcon size={16} strokeWidth={1.5} />;
-    }
-    return undefined; // folders use the default folder icon
-  }, []);
+    return map;
+  }, [myApps, workspaceApps]);
+
+  const getRightAdornment = useCallback(
+    (node: ResourceTreeNode) => {
+      const parsed = parseNodeId(node.id);
+      if (parsed.kind !== "app") return null;
+      const count = fileCountByAppId.get(parsed.appId);
+      if (count === undefined) return null;
+      return (
+        <Typography
+          variant="caption"
+          sx={{ color: "text.disabled", whiteSpace: "nowrap" }}
+        >
+          {count}
+        </Typography>
+      );
+    },
+    [fileCountByAppId],
+  );
+
+  const getItemIcon = useCallback(
+    (node: ResourceTreeNode, ctx?: { isExpanded: boolean }) => {
+      const parsed = parseNodeId(node.id);
+      if (parsed.kind === "app") {
+        return <AppIcon size={16} strokeWidth={1.5} />;
+      }
+      if (parsed.kind === "file") {
+        return fileIcon(node.name);
+      }
+      if (parsed.kind === "binding") {
+        return <BindingIcon size={16} strokeWidth={1.5} />;
+      }
+      return ctx?.isExpanded ? (
+        <FolderOpenIcon size={16} strokeWidth={1.5} />
+      ) : (
+        <FolderIcon size={16} strokeWidth={1.5} />
+      );
+    },
+    [],
+  );
 
   const getContextMenuItems = useCallback(
     (node: ResourceTreeNode, helpers: { closeMenu: () => void }) => {
@@ -321,6 +432,34 @@ export function AppsExplorer() {
           Open
         </MenuItem>,
       );
+
+      // Share / unshare — the menu twin of dragging the app between the
+      // "My Apps" and "Workspace" sections.
+      if (parsed.kind === "app" && workspaceId && canManageNode(node)) {
+        const isShared = node.access === "workspace";
+        items.push(
+          <MenuItem
+            key="share"
+            onClick={() => {
+              void setAppAccess(
+                workspaceId,
+                parsed.appId,
+                isShared ? "private" : "workspace",
+              );
+              helpers.closeMenu();
+            }}
+          >
+            <ListItemIcon>
+              {isShared ? (
+                <LockIcon size={16} strokeWidth={1.5} />
+              ) : (
+                <GlobeIcon size={16} strokeWidth={1.5} />
+              )}
+            </ListItemIcon>
+            {isShared ? "Move to My Apps" : "Move to Workspace"}
+          </MenuItem>,
+        );
+      }
 
       // Materialize action for parquet bindings.
       if (parsed.kind === "binding" && workspaceId) {
@@ -378,7 +517,7 @@ export function AppsExplorer() {
       );
       return items;
     },
-    [workspaceId, openApps, materializeBinding],
+    [workspaceId, openApps, materializeBinding, canManageNode, setAppAccess],
   );
 
   const handleRenameConfirm = useCallback(async () => {
@@ -478,8 +617,8 @@ export function AppsExplorer() {
             searchQuery={searchQuery}
             activeItemId={activeItemId}
             getItemIcon={getItemIcon}
+            getRightAdornment={getRightAdornment}
             getContextMenuItems={getContextMenuItems}
-            hideFolderIcon
             onItemClick={handleItemClick}
             shouldFolderClickActivate={shouldFolderClickActivate}
             onLoadChildren={handleLoadChildren}
@@ -487,7 +626,10 @@ export function AppsExplorer() {
               const parsed = parseNodeId(node.id);
               return parsed.kind === "app" && !!loadingApps[parsed.appId];
             }}
-            enableDragDrop={false}
+            enableDragDrop
+            onMoveItem={handleMoveNode}
+            onMoveFolder={handleMoveNode}
+            canManageItem={canManageNode}
             enableRename={false}
             enableDelete={false}
             enableNewFolder={false}

--- a/app/src/components/ResourceTree.tsx
+++ b/app/src/components/ResourceTree.tsx
@@ -1470,11 +1470,8 @@ function ResourceTreeInner(
               fontSize: "0.8125rem",
             }}
           >
-            {draggedNode.isDirectory ? (
-              <Folder size={14} />
-            ) : (
-              getItemIcon?.(draggedNode) || null
-            )}
+            {getItemIcon?.(draggedNode) ||
+              (draggedNode.isDirectory ? <Folder size={14} /> : null)}
             <span className="app-truncate-inline">{draggedNode.name}</span>
           </Box>
         ) : null}

--- a/app/src/store/appStore.ts
+++ b/app/src/store/appStore.ts
@@ -81,6 +81,16 @@ interface AppActions {
     appId: string,
     title: string,
   ) => Promise<void>;
+  /**
+   * Share an app to the workspace (or make it private again). Moves the app
+   * between the "My Apps" / "Workspace" explorer sections optimistically and
+   * persists the access change; refetches the list on failure.
+   */
+  setAppAccess: (
+    workspaceId: string,
+    appId: string,
+    access: "private" | "workspace",
+  ) => Promise<void>;
 
   setActiveApp: (appId: string | null) => void;
 
@@ -310,6 +320,40 @@ export const useAppStore = create<AppStore>()(
       });
       await get().persistApp(workspaceId, appId);
       void get().fetchList(workspaceId);
+    },
+
+    setAppAccess: async (workspaceId, appId, access) => {
+      const fromKey = access === "workspace" ? "myApps" : "workspaceApps";
+      const toKey = access === "workspace" ? "workspaceApps" : "myApps";
+
+      let moved = false;
+      set(state => {
+        const fromList = state[fromKey][workspaceId] || [];
+        const index = fromList.findIndex(item => item.id === appId);
+        if (index === -1) return; // already in the target section
+        const [item] = fromList.splice(index, 1);
+        item.access = access;
+        const toList = state[toKey][workspaceId] || [];
+        toList.unshift(item);
+        state[toKey][workspaceId] = toList;
+        const open = state.openApps[appId];
+        if (open) open.access = access;
+        moved = true;
+      });
+      if (!moved) return;
+
+      try {
+        await apiClient.put<{ success: boolean; app: AppEntity }>(
+          `/workspaces/${workspaceId}/apps/${appId}`,
+          { access },
+        );
+      } catch {
+        // Revert to server truth on failure.
+        void get().fetchList(workspaceId);
+        set(state => {
+          state.error[workspaceId] = "Failed to update app sharing";
+        });
+      }
     },
 
     setActiveApp: appId =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Polish Apps explorer to match the Database explorer

[apps_explorer_drag_and_share_demo.mp4](https://cursor.com/agents/bc-9e4c09f0-5984-471b-a7a7-c7f055108884/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapps_explorer_drag_and_share_demo.mp4)

Drag an app between **My Apps** and **Workspace** to share/unshare it; the context menu offers the same action.

[Apps explorer tree with app, folder, and file-type icons](https://cursor.com/agents/bc-9e4c09f0-5984-471b-a7a7-c7f055108884/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapps_explorer_tree_zoom.png)

## Changes

### Drag and drop between sections
- `AppsExplorer` now enables `ResourceTree` drag-and-drop with section drop targets (`__section_my` / `__section_workspace`), mirroring the Dashboards explorer. Dropping an app on the other section (or any node inside it) toggles its `access` between `private` and `workspace`. Only app rows are draggable (owner or workspace admin), never files/folders inside an app.
- New `appStore.setAppAccess` action: optimistic move between section lists, `PUT { access }`, refetch on failure.
- A context-menu twin: **Move to Workspace** / **Move to My Apps** on app rows.
- `GET /workspaces/:id/apps` now classifies the sections by `access` (like dashboards): workspace-shared apps appear under **Workspace** for everyone, including the owner — so sharing visibly moves the app.

### Icons
- Top-level app rows get the `AppWindow` icon (previously no icon at all).
- Folders get `Folder` / `FolderOpen` icons like the Database explorer (dropped the compact `hideFolderIcon` mode).
- File icons by type: code files (`FileCode`), markdown/text (`FileText`), JSON (`Braces`), other (`File`); data bindings keep `Database`.
- The shared `ResourceTree` drag overlay now uses the caller's item icon for directories, so dragging an app shows the app icon.

### Alignment & polish
- With the compact mode dropped, file rows render the hidden-chevron placeholder, so file names align exactly with sibling folder names at every depth (this fixed the off-looking indentation).
- App rows show a dimmed file count on the right, DataGrip-style, like the Database explorer's group counts.

## Testing
- ✅ `pnpm --filter app run typecheck`
- ✅ `pnpm --filter app run lint`
- ✅ `pnpm --filter api run lint` + `tsc --noEmit` in `api`
- ✅ API-level verification of list split + access toggling (curl)
- ✅ Manual end-to-end test in the running app: drag My Apps → Workspace, persistence across reload, context-menu move back (see video)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e4c09f0-5984-471b-a7a7-c7f055108884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e4c09f0-5984-471b-a7a7-c7f055108884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

