### PR TITLE
fix(app): keep side-pane resize tracking when dragging over iframes

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -169,6 +169,30 @@ function MainApp() {
     (side: SidePane, e: React.PointerEvent<HTMLDivElement>) => {
       e.preventDefault();
 
+      // Capture the pointer so move/up events keep flowing to the divider even
+      // when the cursor crosses an iframe (e.g. the app preview), which would
+      // otherwise swallow them and freeze the drag.
+      const divider = e.currentTarget;
+      try {
+        divider.setPointerCapture(e.pointerId);
+      } catch {
+        // Pointer may already be gone (e.g. released between events).
+      }
+
+      // Belt-and-suspenders for browsers with flaky pointer capture across
+      // (cross-origin) iframes: make iframes transparent to pointer events
+      // for the duration of the drag.
+      const iframes = Array.from(document.querySelectorAll("iframe"));
+      const savedPointerEvents = iframes.map(f => f.style.pointerEvents);
+      iframes.forEach(f => {
+        f.style.pointerEvents = "none";
+      });
+      const restoreIframes = () => {
+        iframes.forEach((f, i) => {
+          f.style.pointerEvents = savedPointerEvents[i];
+        });
+      };
+
       const container = panelContainerRef.current;
       const containerWidth = container
         ? container.clientWidth
@@ -216,6 +240,8 @@ function MainApp() {
       const onUp = () => {
         window.removeEventListener("pointermove", onMove);
         window.removeEventListener("pointerup", onUp);
+        window.removeEventListener("pointercancel", onUp);
+        restoreIframes();
         document.body.style.cursor = "";
         document.body.style.userSelect = "";
 
@@ -241,6 +267,7 @@ function MainApp() {
       document.body.style.userSelect = "none";
       window.addEventListener("pointermove", onMove);
       window.addEventListener("pointerup", onUp);
+      window.addEventListener("pointercancel", onUp);
     },
     [closeLeftPane, closeRightPane, leftPaneOpen, rightPaneOpen, setPaneWidths],
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Dragging the side-pane resize dividers in `App.tsx` freezes the moment the cursor crosses into an iframe — most notably the app preview (`AppRenderer`). The drag is tracked with `window`-level `pointermove`/`pointerup` listeners, but once the pointer is over an iframe, the iframe document receives the events instead of the parent page, so the resize stops responding.

Reproduced before the fix: dragging the chat-panel divider 300px leftward over the app preview left the panel width unchanged.

[Resize frozen over iframe before fix](https://cursor.com/agents/bc-d56273b4-92d7-4a37-90d0-94ba408c4772/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fresize_frozen_over_iframe_before_fix.webp)

## Fix

In `beginResize` in `app/src/App.tsx`:

- Call `setPointerCapture(e.pointerId)` on the divider on pointer-down, so all subsequent pointer events for the drag are retargeted to the divider (and bubble to the `window` listeners) regardless of what the cursor is over — including sandboxed/cross-origin iframes.
- Belt-and-suspenders: set `pointer-events: none` on all iframes for the duration of the drag and restore their previous values on release, covering browsers with flaky pointer capture across iframes.
- Also clean up on `pointercancel` so a cancelled drag can't leave iframes inert or the body cursor stuck.

## Demo (after fix)

The chat panel tracks the cursor continuously while it travels deep over the app preview iframe, in both directions:

[panel_resize_over_iframe_demo.mp4](https://cursor.com/agents/bc-d56273b4-92d7-4a37-90d0-94ba408c4772/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpanel_resize_over_iframe_demo.mp4)

A DOM width sampler (100ms interval) during the demo recorded the panel stepping 299 → 353 → 406 → 460 → 512 → 566 → 600 (the `SIDE_PANEL_MAX_WIDTH_PX` clamp) on the leftward drag over the iframe, then symmetrically back to 299 on the return drag.

## Testing

- ✅ `pnpm --filter app run typecheck`
- ✅ `pnpm --filter app run lint`
- ✅ Manual browser test: reproduced the freeze on the unfixed code, then verified the divider tracks the full drag distance over the app preview iframe with the fix (see video).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d56273b4-92d7-4a37-90d0-94ba408c4772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d56273b4-92d7-4a37-90d0-94ba408c4772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

