### PR TITLE
Cloud Agent dev environment: dev-DB admin seed + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,79 @@
+# AGENTS.md
+
+Canonical project rules live in `.cursor/rules/` and `CLAUDE.md` (commands, env,
+tech stack, conventions). Read those first. This file adds context specific to
+running Mako inside a Cursor Cloud agent VM.
+
+## Cursor Cloud specific instructions
+
+### Services & how to run them
+
+Standard commands are documented in `README.md` / `CLAUDE.md` — don't duplicate
+them. The core dev experience is one command:
+
+- `pnpm dev` — runs the App (Vite, port `5173`), the API (Hono, port `8080`),
+  and the Inngest dev server (port `8288`) concurrently. The Vite dev server
+  proxies `/api` → `http://localhost:8080`.
+- Lint/typecheck/build gates per package are in `.cursor/rules/85-pre-commit.mdc`
+  (`pnpm --filter app run typecheck && lint`, `pnpm --filter api run lint`,
+  `pnpm --filter api run build`).
+
+The health check is `GET http://localhost:8080/health` (note: `/health`, not
+`/api/health`).
+
+### Database: use the Atlas **dev** DB, not a local Mongo
+
+Secrets are injected as real environment variables (see `CLOUD_AGENT_ALL_SECRET_NAMES`),
+so you do NOT need a `.env` file and you do NOT need to run a local `mongod`.
+Connection strings for `dev`, `staging`, and `prod` Atlas databases are all
+injected.
+
+- The injected `DATABASE_URL` points at **staging**. For development, start the
+  app against the **dev** database instead, which is periodically restored from a
+  prod snapshot (fast, with real prod-like data):
+
+  ```bash
+  export DATABASE_URL="$DEV_DATABASE_URL"
+  pnpm dev
+  ```
+
+- `api/src/index.ts` loads the root `.env` with `dotenv.config()` **without
+  `override`**, so injected/exported env vars always win over `.env`. That means
+  the only reliable way to point the app at the dev DB is to export
+  `DATABASE_URL` (a committed `.env` cannot override it).
+- Never run the app against `PROD_DATABASE_URL`.
+
+### Auto-seeded login (you are logged in out-of-the-box)
+
+The dev DB is regularly restored from prod, which wipes ad-hoc test accounts. The
+update script runs `api/src/scripts/seed-dev-admin.ts` on VM startup to
+idempotently (re)create a known admin login so you can sign in to the running app
+immediately:
+
+- **Email:** `cloud-agent@mako.dev`
+- **Password:** `CloudAgentDev!2024` (override via `DEV_ADMIN_PASSWORD`)
+
+The seed marks the user verified, completes onboarding, makes it the **owner** of
+a `Cloud Agent Dev` workspace, and attaches the `Chinook Music Store` demo
+Postgres DB (`DEMO_DATABASE_URL`) so there is queryable data on first login. It
+targets `DEV_DATABASE_URL` (falls back to `DATABASE_URL`), refuses to touch a
+production URI, and soft-fails (exits 0) if the DB is unreachable — so it never
+breaks VM startup. Re-run manually any time with:
+
+```bash
+pnpm --filter api exec tsx src/scripts/seed-dev-admin.ts
+```
+
+Email/password registration normally requires email verification before login
+(SendGrid sends the code, which you won't receive). The seed sidesteps this by
+setting `emailVerified: true` directly; if you create another account manually,
+flip `emailVerified` in the DB to log in.
+
+### Misc caveats
+
+- No `docker-compose.yml` is committed, so `pnpm docker:*` scripts don't work
+  here — rely on the injected Atlas DB instead.
+- The Chinook demo Postgres uses lowercase, unquoted table names (`album`,
+  `artist`, …); `SELECT * FROM "Artist"` fails, `SELECT * FROM artist` works.
+- AI features need `AI_GATEWAY_API_KEY` (injected). `BILLING_ENABLED` is injected
+  as `true`; raw SQL queries are not billing-gated.

--- a/api/src/scripts/seed-dev-admin.ts
+++ b/api/src/scripts/seed-dev-admin.ts
@@ -1,0 +1,168 @@
+/* eslint-disable no-console */
+/**
+ * Seed a deterministic admin test user into the DEV database.
+ *
+ * Why this exists
+ * ---------------
+ * The Mako dev database is periodically restored from a prod snapshot, which
+ * wipes any ad-hoc test accounts. Running this on Cloud Agent VM startup
+ * guarantees there is always a known-good login that future agents can use to
+ * sign in to the running app with prod-like data available.
+ *
+ * Behavior
+ * --------
+ * - Connects to DEV_DATABASE_URL (preferred) or DATABASE_URL.
+ * - REFUSES to run against the production database (safety guard).
+ * - Idempotently upserts a verified user, (re)sets its password to the known
+ *   dev password, marks onboarding complete, ensures it owns a workspace, and
+ *   attaches the Chinook demo Postgres database so there is queryable data.
+ * - Never throws on a "soft" failure (missing URL, unreachable DB): it logs and
+ *   exits 0 so it can be wired into VM startup without ever breaking it.
+ *
+ * Credentials (override via env if desired):
+ *   DEV_ADMIN_EMAIL    (default: cloud-agent@mako.dev)
+ *   DEV_ADMIN_PASSWORD (default: CloudAgentDev!2024)
+ */
+import path from "path";
+import fs from "fs";
+import dotenv from "dotenv";
+import mongoose from "mongoose";
+import bcrypt from "bcrypt";
+
+// Load root .env if present (matches api/src/index.ts behavior). Real injected
+// env vars take precedence because dotenv does not override existing values.
+const envPath = path.resolve(__dirname, "../../../.env");
+if (fs.existsSync(envPath)) {
+  dotenv.config({ path: envPath });
+}
+
+const DEV_ADMIN_EMAIL = (process.env.DEV_ADMIN_EMAIL || "cloud-agent@mako.dev")
+  .trim()
+  .toLowerCase();
+const DEV_ADMIN_PASSWORD =
+  process.env.DEV_ADMIN_PASSWORD || "CloudAgentDev!2024";
+const WORKSPACE_NAME = "Cloud Agent Dev";
+
+function resolveDevUri(): string | undefined {
+  // Prefer the explicit dev URL so we never accidentally seed staging/prod.
+  return process.env.DEV_DATABASE_URL || process.env.DATABASE_URL || undefined;
+}
+
+function isProductionUri(uri: string): boolean {
+  const prod = process.env.PROD_DATABASE_URL;
+  if (prod && uri === prod) return true;
+  // Heuristic: the prod database name in these connection strings is "production".
+  try {
+    const dbName = new URL(uri).pathname.replace(/^\//, "").split("?")[0];
+    if (dbName.toLowerCase() === "production") return true;
+  } catch {
+    // Non-standard URI; fall through to substring check below.
+  }
+  return /\/production(\b|\?|$)/i.test(uri);
+}
+
+async function main(): Promise<void> {
+  const uri = resolveDevUri();
+  if (!uri) {
+    console.log(
+      "[seed-dev-admin] No DEV_DATABASE_URL/DATABASE_URL set; skipping.",
+    );
+    return;
+  }
+
+  if (isProductionUri(uri)) {
+    console.log(
+      "[seed-dev-admin] Refusing to seed: resolved URI looks like PRODUCTION. Skipping.",
+    );
+    return;
+  }
+
+  await mongoose.connect(uri, { serverSelectionTimeoutMS: 15000 });
+
+  // Import models/services lazily so a connection failure above short-circuits
+  // before any model side effects run.
+  const { User } = await import("../database/schema");
+  const { DatabaseConnection } = await import("../database/workspace-schema");
+  const { workspaceService } = await import("../services/workspace.service");
+
+  const rounds = parseInt(process.env.BCRYPT_ROUNDS || "10", 10);
+  const hashedPassword = await bcrypt.hash(DEV_ADMIN_PASSWORD, rounds);
+
+  // Upsert the user: always (re)set the password + verified + onboarding-complete
+  // so login works reliably even after a prod restore.
+  let user = await User.findOne({ email: DEV_ADMIN_EMAIL });
+  if (!user) {
+    user = await User.create({
+      email: DEV_ADMIN_EMAIL,
+      hashedPassword,
+      emailVerified: true,
+      onboarding: { completedAt: new Date(), role: "developer" },
+    });
+    console.log(`[seed-dev-admin] Created user ${DEV_ADMIN_EMAIL}`);
+  } else {
+    user.hashedPassword = hashedPassword;
+    user.emailVerified = true;
+    user.onboarding = {
+      ...(user.onboarding || {}),
+      completedAt: user.onboarding?.completedAt || new Date(),
+    };
+    await user.save();
+    console.log(`[seed-dev-admin] Updated existing user ${DEV_ADMIN_EMAIL}`);
+  }
+
+  // Ensure the user owns a workspace (idempotent; creates on first run).
+  const { workspace } = await workspaceService.getOrCreateDefaultWorkspace(
+    user._id,
+    WORKSPACE_NAME,
+  );
+  console.log(
+    `[seed-dev-admin] Workspace ready: "${workspace.name}" (${workspace._id})`,
+  );
+
+  // Attach the Chinook demo Postgres DB so there is real queryable data.
+  const demoUrl = process.env.DEMO_DATABASE_URL;
+  if (demoUrl) {
+    const existingDemo = await DatabaseConnection.findOne({
+      workspaceId: workspace._id,
+      isDemo: true,
+    });
+    if (!existingDemo) {
+      await DatabaseConnection.create({
+        workspaceId: workspace._id,
+        name: "Chinook Music Store",
+        type: "postgresql",
+        connection: { connectionString: demoUrl },
+        isDemo: true,
+        createdBy: user._id,
+      });
+      console.log("[seed-dev-admin] Attached Chinook demo database.");
+    } else {
+      console.log("[seed-dev-admin] Demo database already present.");
+    }
+  } else {
+    console.log(
+      "[seed-dev-admin] DEMO_DATABASE_URL not set; skipping demo DB attach.",
+    );
+  }
+
+  console.log(
+    `[seed-dev-admin] Done. Login with ${DEV_ADMIN_EMAIL} / (DEV_ADMIN_PASSWORD).`,
+  );
+}
+
+main()
+  .catch(err => {
+    // Soft-fail: never break VM startup if the dev DB is unreachable.
+    console.log(
+      "[seed-dev-admin] Skipped due to error:",
+      err instanceof Error ? err.message : String(err),
+    );
+  })
+  .finally(async () => {
+    try {
+      await mongoose.disconnect();
+    } catch {
+      /* ignore */
+    }
+    process.exit(0);
+  });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Sets up the Cursor Cloud agent dev environment so future agents land **logged in** to a running Mako instance backed by the prod-like **dev** Atlas DB.

The dev DB is regularly restored from a prod snapshot (fast + real data), which wipes ad-hoc test accounts. To keep a stable login, VM startup now re-seeds a known admin user.

## Changes

- **`api/src/scripts/seed-dev-admin.ts`** — idempotent seed that connects to `DEV_DATABASE_URL` (falls back to `DATABASE_URL`) and:
  - upserts a verified admin user `cloud-agent@mako.dev` (password `CloudAgentDev!2024`, override via `DEV_ADMIN_PASSWORD`), marking onboarding complete;
  - makes it **owner** of a `Cloud Agent Dev` workspace (via `workspaceService.getOrCreateDefaultWorkspace`);
  - attaches the `Chinook Music Store` demo Postgres DB (`DEMO_DATABASE_URL`) so there is queryable data on first login.
  - **Safety:** refuses to run against a production URI and soft-fails (exits 0) if the DB is unreachable, so it can never break VM startup.
- **`AGENTS.md`** — `## Cursor Cloud specific instructions`: use the injected dev Atlas DB (export `DATABASE_URL="$DEV_DATABASE_URL"`), the seeded login, health endpoint, demo-DB lowercase-table caveat, and the no-committed-docker-compose note.

## Update script (configured separately)

```
pnpm install
if [ -f api/src/scripts/seed-dev-admin.ts ]; then pnpm --filter api exec tsx src/scripts/seed-dev-admin.ts || true; fi
```

## Verification

End-to-end: logged in as the seeded admin in a fresh incognito session, landed directly in the `Cloud Agent Dev` workspace (no onboarding) with the Chinook DB present, and ran a SQL query returning rows.

[mako_seeded_admin_login_and_query.mp4](https://cursor.com/agents/bc-eb55b5cd-65f6-405a-8787-2bd3431e21b5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmako_seeded_admin_login_and_query.mp4)

[Seeded workspace with Chinook DB after login](https://cursor.com/agents/bc-eb55b5cd-65f6-405a-8787-2bd3431e21b5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmako_seeded_workspace.webp)
[SQL query results](https://cursor.com/agents/bc-eb55b5cd-65f6-405a-8787-2bd3431e21b5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmako_seeded_query_results.webp)

- ✅ `pnpm --filter app run lint`
- ✅ `pnpm --filter app run typecheck`
- ✅ `pnpm --filter api run build` (lint + tsc)
- ✅ `node scripts/check-connector-agnosticism.js`
- ✅ Seed script: idempotent re-run, prod-guard, and no-URL guard all verified; login confirmed.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb55b5cd-65f6-405a-8787-2bd3431e21b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb55b5cd-65f6-405a-8787-2bd3431e21b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

