### PR TITLE
dbt Cloud replica: workspace dbt projects, runner, jobs/runs, IDE, lineage, and dbt agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,12 +25,33 @@ RUN pnpm run api:build
 FROM node:20-slim
 WORKDIR /app
 
-# Install build tools needed for native modules
+# Install build tools needed for native modules (+ venv for the dbt runner)
 RUN apt-get update && apt-get install -y \
     python3 \
+    python3-venv \
+    python3-pip \
     make \
     g++ \
     && rm -rf /var/lib/apt/lists/*
+
+# Bake a pinned dbt Core venv with the supported warehouse adapters.
+# The dbt runner (api/src/dbt/dbt-bin.ts) resolves the binary via DBT_VENV_BIN.
+RUN python3 -m venv /opt/dbt \
+    && /opt/dbt/bin/pip install --no-cache-dir \
+    "dbt-core==1.9.10" \
+    "dbt-postgres==1.9.1" \
+    "dbt-redshift==1.9.5" \
+    "dbt-bigquery==1.9.2" \
+    "dbt-clickhouse==1.9.2" \
+    "dbt-sqlserver==1.9.0"
+ENV DBT_VENV_BIN=/opt/dbt/bin/dbt
+
+# dbt-mysql lags upstream (requires dbt-core ~=1.7), so it gets its own venv.
+RUN python3 -m venv /opt/dbt-mysql \
+    && /opt/dbt-mysql/bin/pip install --no-cache-dir \
+    "dbt-core==1.7.19" \
+    "dbt-mysql==1.7.0"
+ENV DBT_MYSQL_VENV_BIN=/opt/dbt-mysql/bin/dbt
 
 # Install pnpm in production too (this layer will be cached)
 RUN npm install -g pnpm

--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -1,0 +1,224 @@
+/**
+ * Server-side dbt verification tools.
+ *
+ * The agent edits dbt files through the CLIENT tools (create_dbt_file /
+ * modify_dbt_file in @mako/agent-tools) and then verifies its work here:
+ *   dbt_parse          — project-wide validation after YAML edits
+ *   dbt_compile_model  — Jinja render check, returns compiled SQL
+ *   dbt_run_model      — `build --select <model>` on the dev environment,
+ *                        returns step results incl. test outcomes
+ *   dbt_run_job        — trigger a saved job (requires explicit user
+ *                        confirmation in the prompt, like schedule_query)
+ *
+ * All tools go through the same workspace-scoped ad-hoc service path as the
+ * IDE buttons (api/src/dbt/dbt-project.service.ts).
+ */
+
+import { tool } from "ai";
+import { z } from "zod";
+import { Types } from "mongoose";
+import { DbtJob, DbtProject } from "../../database/workspace-schema";
+import { runAdhocDbtCommand } from "../../dbt/dbt-project.service";
+import { triggerDbtJobRun } from "../../dbt/dbt-run.service";
+import type { DbtLogLine } from "../../dbt/runner.service";
+
+const MODEL_NAME_PATTERN = /^[\w.]+$/;
+
+const projectIdField = z
+  .string()
+  .describe("dbt project ID (from read_dbt_project_tree)");
+
+function toolError(error: unknown, fallback: string) {
+  return {
+    success: false,
+    error: error instanceof Error ? error.message : fallback,
+  };
+}
+
+/** Keep tool outputs small: errors + warnings + last few info lines. */
+function summarizeLogs(logs: DbtLogLine[], maxLines = 30): string[] {
+  const important = logs.filter(
+    log => log.level === "error" || log.level === "warn",
+  );
+  const rest = logs.filter(
+    log => log.level !== "error" && log.level !== "warn",
+  );
+  const selected = [...important, ...rest.slice(-10)].slice(0, maxLines);
+  return selected.map(log => `[${log.level}] ${log.line}`);
+}
+
+export const createDbtServerTools = (workspaceId: string) => {
+  const assertProject = async (projectId: string) => {
+    if (!Types.ObjectId.isValid(projectId)) {
+      throw new Error("Invalid dbt project id");
+    }
+    const project = await DbtProject.findOne({
+      _id: new Types.ObjectId(projectId),
+      workspaceId: new Types.ObjectId(workspaceId),
+    });
+    if (!project) throw new Error("dbt project not found or access denied");
+    return project;
+  };
+
+  return {
+    dbt_parse: tool({
+      description:
+        "Validate the entire dbt project (dbt parse): catches Jinja errors, " +
+        "bad refs/sources, and schema.yml problems WITHOUT touching the " +
+        "warehouse. Run this after editing YAML or multiple files.",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        environment: z
+          .string()
+          .optional()
+          .describe("Environment name; defaults to the project default (dev)"),
+      }),
+      execute: async ({ projectId, environment }) => {
+        try {
+          await assertProject(projectId);
+          const result = await runAdhocDbtCommand({
+            workspaceId,
+            projectId,
+            environmentName: environment,
+            command: "parse",
+            timeoutMs: 2 * 60 * 1000,
+          });
+          return {
+            success: result.success,
+            ...(result.success
+              ? { message: "Project parsed successfully" }
+              : { error: "dbt parse failed" }),
+            logs: summarizeLogs(result.logs),
+          };
+        } catch (error) {
+          return toolError(error, "Failed to run dbt parse");
+        }
+      },
+    }),
+
+    dbt_compile_model: tool({
+      description:
+        "Compile one dbt model (dbt compile --select <model>) and return the " +
+        "rendered SQL, or the Jinja/compilation error. No warehouse writes. " +
+        "Use after writing or editing a model to verify it renders.",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        model: z
+          .string()
+          .describe("Model name without extension, e.g. stg_orders"),
+        environment: z.string().optional(),
+      }),
+      execute: async ({ projectId, model, environment }) => {
+        try {
+          if (!MODEL_NAME_PATTERN.test(model)) {
+            return { success: false, error: "Invalid model name" };
+          }
+          await assertProject(projectId);
+          const result = await runAdhocDbtCommand({
+            workspaceId,
+            projectId,
+            environmentName: environment,
+            command: `compile --select ${model}`,
+            select: model,
+            timeoutMs: 3 * 60 * 1000,
+          });
+          return {
+            success: result.success,
+            compiledSql: result.compiledSql,
+            logs: summarizeLogs(result.logs),
+          };
+        } catch (error) {
+          return toolError(error, "Failed to compile model");
+        }
+      },
+    }),
+
+    dbt_run_model: tool({
+      description:
+        "Build one dbt model AND its tests (dbt build --select <model>) " +
+        "against the project's dev environment (or the given environment). " +
+        "This WRITES to the warehouse target schema. Returns per-node status, " +
+        "timing, rows affected, and test pass/fail outcomes. Use this as the " +
+        "final verification after compile succeeds.",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        model: z
+          .string()
+          .describe("Model name without extension, e.g. stg_orders"),
+        environment: z
+          .string()
+          .optional()
+          .describe(
+            "Environment name; defaults to the project default (dev). Only " +
+              "use prod when the user explicitly asks.",
+          ),
+      }),
+      execute: async ({ projectId, model, environment }) => {
+        try {
+          if (!MODEL_NAME_PATTERN.test(model)) {
+            return { success: false, error: "Invalid model name" };
+          }
+          await assertProject(projectId);
+          const result = await runAdhocDbtCommand({
+            workspaceId,
+            projectId,
+            environmentName: environment,
+            command: `build --select ${model}`,
+            select: model,
+            timeoutMs: 5 * 60 * 1000,
+          });
+          return {
+            success: result.success,
+            stepResults: result.stepResults,
+            logs: summarizeLogs(result.logs),
+          };
+        } catch (error) {
+          return toolError(error, "Failed to run model");
+        }
+      },
+    }),
+
+    dbt_run_job: tool({
+      description:
+        "Trigger a saved dbt job (full command list, possibly against prod). " +
+        "Runs asynchronously via the job runner; returns the runId to share " +
+        "with the user. Only call after the user explicitly confirms which " +
+        "job to run — never trigger prod jobs proactively.",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        jobId: z.string().describe("dbt job ID (from read_dbt_project_tree)"),
+      }),
+      execute: async ({ projectId, jobId }) => {
+        try {
+          const project = await assertProject(projectId);
+          if (!Types.ObjectId.isValid(jobId)) {
+            return { success: false, error: "Invalid job id" };
+          }
+          const job = await DbtJob.findOne({
+            _id: new Types.ObjectId(jobId),
+            projectId: project._id,
+          });
+          if (!job) return { success: false, error: "Job not found" };
+          const run = await triggerDbtJobRun({
+            workspaceId,
+            job,
+            trigger: "agent",
+            triggeredBy: "agent",
+          });
+          return {
+            success: true,
+            runId: run._id.toString(),
+            jobName: job.name,
+            environment: job.environment,
+            commands: job.commands,
+            message:
+              "Run queued. The user can watch live logs in the job tab " +
+              "(Transforms → Jobs).",
+          };
+        } catch (error) {
+          return toolError(error, "Failed to trigger job");
+        }
+      },
+    }),
+  };
+};

--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -17,12 +17,27 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { Types } from "mongoose";
-import { DbtJob, DbtProject } from "../../database/workspace-schema";
+import { DbtJob, DbtProject, DbtRun } from "../../database/workspace-schema";
 import { runAdhocDbtCommand } from "../../dbt/dbt-project.service";
-import { triggerDbtJobRun } from "../../dbt/dbt-run.service";
+import {
+  applyJobScheduleChange,
+  triggerDbtJobRun,
+} from "../../dbt/dbt-run.service";
+import {
+  DbtCommandValidationError,
+  parseDbtCommands,
+} from "../../dbt/commands";
+import { validateScheduledConsoleSchedule } from "../../services/scheduled-query-schedule.service";
 import type { DbtLogLine } from "../../dbt/runner.service";
 
-const MODEL_NAME_PATTERN = /^[\w.]+$/;
+/**
+ * A single dbt node name (e.g. `stg_orders`) OR a dbt selector with graph
+ * operators / methods, e.g. `+stg_orders`, `stg_orders+`, `tag:nightly`,
+ * `path:models/staging`, `state:modified+`, `source:raw.orders+`, `a,b`.
+ * Disallows whitespace and shell metacharacters so it can never inject extra
+ * argv tokens (args are passed to spawn without a shell).
+ */
+const SELECTOR_PATTERN = /^[\w.@:+*/,-]+$/;
 
 const projectIdField = z
   .string()
@@ -58,6 +73,37 @@ export const createDbtServerTools = (workspaceId: string) => {
     });
     if (!project) throw new Error("dbt project not found or access denied");
     return project;
+  };
+
+  /**
+   * Validate a job's environment, commands (allowlist), and optional schedule.
+   * Mirrors validateJobBody in dbt.routes.ts. Returns an error string or null.
+   */
+  const validateJob = (
+    project: { environments: Array<{ name: string }> },
+    job: {
+      environment: string;
+      commands: string[];
+      schedule?: { cron: string; timezone: string } | null;
+    },
+  ): string | null => {
+    if (!project.environments.some(env => env.name === job.environment)) {
+      return `Environment "${job.environment}" not found on project`;
+    }
+    try {
+      parseDbtCommands(job.commands);
+    } catch (error) {
+      if (error instanceof DbtCommandValidationError) return error.message;
+      throw error;
+    }
+    if (job.schedule) {
+      try {
+        validateScheduledConsoleSchedule(job.schedule);
+      } catch (error) {
+        return error instanceof Error ? error.message : "Invalid schedule";
+      }
+    }
+    return null;
   };
 
   return {
@@ -98,20 +144,24 @@ export const createDbtServerTools = (workspaceId: string) => {
 
     dbt_compile_model: tool({
       description:
-        "Compile one dbt model (dbt compile --select <model>) and return the " +
-        "rendered SQL, or the Jinja/compilation error. No warehouse writes. " +
-        "Use after writing or editing a model to verify it renders.",
+        "Compile dbt nodes (dbt compile --select <selector>) and return the " +
+        "rendered SQL for a single model, or the Jinja/compilation error. No " +
+        "warehouse writes. `model` accepts a node name (stg_orders) or a dbt " +
+        "selector with graph operators/methods (+stg_orders, tag:nightly, " +
+        "path:models/staging). Use after writing or editing a model.",
       inputSchema: z.object({
         projectId: projectIdField,
         model: z
           .string()
-          .describe("Model name without extension, e.g. stg_orders"),
+          .describe(
+            "Node name (stg_orders) or dbt selector (+stg_orders, tag:nightly)",
+          ),
         environment: z.string().optional(),
       }),
       execute: async ({ projectId, model, environment }) => {
         try {
-          if (!MODEL_NAME_PATTERN.test(model)) {
-            return { success: false, error: "Invalid model name" };
+          if (!SELECTOR_PATTERN.test(model)) {
+            return { success: false, error: "Invalid model selector" };
           }
           await assertProject(projectId);
           const result = await runAdhocDbtCommand({
@@ -135,16 +185,20 @@ export const createDbtServerTools = (workspaceId: string) => {
 
     dbt_run_model: tool({
       description:
-        "Build one dbt model AND its tests (dbt build --select <model>) " +
+        "Build dbt nodes AND their tests (dbt build --select <selector>) " +
         "against the project's dev environment (or the given environment). " +
-        "This WRITES to the warehouse target schema. Returns per-node status, " +
-        "timing, rows affected, and test pass/fail outcomes. Use this as the " +
-        "final verification after compile succeeds.",
+        "This WRITES to the warehouse target schema. `model` accepts a node " +
+        "name (stg_orders) or a dbt selector with graph operators/methods " +
+        "(stg_orders+, +marts.orders, tag:nightly, state:modified+). Returns " +
+        "per-node status, timing, rows affected, and test pass/fail outcomes. " +
+        "Use this as the final verification after compile succeeds.",
       inputSchema: z.object({
         projectId: projectIdField,
         model: z
           .string()
-          .describe("Model name without extension, e.g. stg_orders"),
+          .describe(
+            "Node name (stg_orders) or dbt selector (stg_orders+, tag:nightly)",
+          ),
         environment: z
           .string()
           .optional()
@@ -155,8 +209,8 @@ export const createDbtServerTools = (workspaceId: string) => {
       }),
       execute: async ({ projectId, model, environment }) => {
         try {
-          if (!MODEL_NAME_PATTERN.test(model)) {
-            return { success: false, error: "Invalid model name" };
+          if (!SELECTOR_PATTERN.test(model)) {
+            return { success: false, error: "Invalid model selector" };
           }
           await assertProject(projectId);
           const result = await runAdhocDbtCommand({
@@ -217,6 +271,290 @@ export const createDbtServerTools = (workspaceId: string) => {
           };
         } catch (error) {
           return toolError(error, "Failed to trigger job");
+        }
+      },
+    }),
+
+    dbt_get_run: tool({
+      description:
+        "Read the status, step results, and logs of a dbt run — use this " +
+        "AFTER dbt_run_job to see whether the run passed or failed (the " +
+        "trigger only queues it). Pass `runId` for a specific run, or `jobId` " +
+        "to get that job's most recent run.",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        runId: z.string().optional().describe("dbt run ID (from dbt_run_job)"),
+        jobId: z
+          .string()
+          .optional()
+          .describe("dbt job ID — returns the latest run for this job"),
+      }),
+      execute: async ({ projectId, runId, jobId }) => {
+        try {
+          const project = await assertProject(projectId);
+          if (!runId && !jobId) {
+            return { success: false, error: "Provide runId or jobId" };
+          }
+
+          const query: Record<string, unknown> = {
+            workspaceId: new Types.ObjectId(workspaceId),
+            projectId: project._id,
+          };
+          if (runId) {
+            if (!Types.ObjectId.isValid(runId)) {
+              return { success: false, error: "Invalid run id" };
+            }
+            query._id = new Types.ObjectId(runId);
+          } else if (jobId) {
+            if (!Types.ObjectId.isValid(jobId)) {
+              return { success: false, error: "Invalid job id" };
+            }
+            query.jobId = new Types.ObjectId(jobId);
+          }
+
+          const run = await DbtRun.findOne(query)
+            .sort({ createdAt: -1 })
+            .lean();
+          if (!run) return { success: false, error: "Run not found" };
+
+          return {
+            success: true,
+            runId: run._id.toString(),
+            status: run.status,
+            trigger: run.trigger,
+            environment: run.environment,
+            commands: run.commands,
+            startedAt: run.startedAt,
+            completedAt: run.completedAt,
+            durationMs: run.durationMs,
+            error: run.error,
+            stepResults: (run.stepResults ?? []).map(step => ({
+              name: step.name,
+              resourceType: step.resourceType,
+              status: step.status,
+              executionTimeMs: step.executionTimeMs,
+              rowsAffected: step.rowsAffected,
+              message: step.message,
+            })),
+            logs: summarizeLogs(
+              (run.logs ?? []).map(log => ({
+                ts: log.ts,
+                level: log.level,
+                line: log.line,
+              })) as DbtLogLine[],
+            ),
+          };
+        } catch (error) {
+          return toolError(error, "Failed to read dbt run");
+        }
+      },
+    }),
+
+    dbt_show: tool({
+      description:
+        "Preview the rows a model/selector would return (dbt show --select " +
+        "<selector> --limit N) WITHOUT materializing it. Runs a bounded " +
+        "SELECT against the environment; no warehouse writes. Use to validate " +
+        "that a transform produces the expected output.",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        model: z
+          .string()
+          .describe("Node name (stg_orders) or dbt selector (+stg_orders)"),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(100)
+          .default(5)
+          .describe("Max rows to preview (default 5)"),
+        environment: z.string().optional(),
+      }),
+      execute: async ({ projectId, model, limit, environment }) => {
+        try {
+          if (!SELECTOR_PATTERN.test(model)) {
+            return { success: false, error: "Invalid model selector" };
+          }
+          await assertProject(projectId);
+          const result = await runAdhocDbtCommand({
+            workspaceId,
+            projectId,
+            environmentName: environment,
+            command: `show --select ${model} --limit ${limit}`,
+            timeoutMs: 3 * 60 * 1000,
+          });
+          // The preview table arrives as info-level log line(s) (ShowNode);
+          // anchor on the "Previewing" marker to drop dbt startup boilerplate,
+          // falling back to all info lines if the marker text ever changes.
+          const infoLines = result.logs
+            .filter(log => log.level === "info")
+            .map(log => log.line);
+          const markerIdx = infoLines.findIndex(line =>
+            line.includes("Previewing"),
+          );
+          const preview = (
+            markerIdx >= 0 ? infoLines.slice(markerIdx) : infoLines
+          )
+            .join("\n")
+            .slice(0, 8000);
+          if (!result.success) {
+            const reason = result.logs
+              .filter(log => log.level === "error")
+              .map(log => log.line)
+              .join("\n");
+            return {
+              success: false,
+              error: reason || "dbt show failed",
+              logs: summarizeLogs(result.logs),
+            };
+          }
+          return {
+            success: true,
+            preview,
+            logs: summarizeLogs(result.logs),
+          };
+        } catch (error) {
+          return toolError(error, "Failed to preview model");
+        }
+      },
+    }),
+
+    dbt_create_job: tool({
+      description:
+        "Create a saved dbt job (a named command list, optionally scheduled). " +
+        "Commands are validated against the dbt allowlist. Provide a cron " +
+        "schedule only when the user asks for a recurring run.",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        name: z.string().min(1).max(128),
+        commands: z
+          .array(z.string().min(1))
+          .min(1)
+          .max(10)
+          .describe('dbt commands, e.g. ["build --select tag:nightly"]'),
+        environment: z
+          .string()
+          .optional()
+          .describe("Environment name; defaults to the project default"),
+        schedule: z
+          .object({ cron: z.string().min(1), timezone: z.string().min(1) })
+          .optional()
+          .describe("Optional cron schedule, e.g. { cron: '0 6 * * *' }"),
+        enabled: z.boolean().default(true),
+        deferToProduction: z.boolean().default(false),
+      }),
+      execute: async ({
+        projectId,
+        name,
+        commands,
+        environment,
+        schedule,
+        enabled,
+        deferToProduction,
+      }) => {
+        try {
+          const project = await assertProject(projectId);
+          const env = environment ?? project.defaultEnvironment;
+          const validationError = validateJob(project, {
+            environment: env,
+            commands,
+            schedule,
+          });
+          if (validationError) {
+            return { success: false, error: validationError };
+          }
+          const job = await DbtJob.create({
+            workspaceId: project.workspaceId,
+            projectId: project._id,
+            name,
+            environment: env,
+            commands,
+            schedule: schedule ?? undefined,
+            enabled,
+            deferToProduction,
+            createdBy: "agent",
+          });
+          await applyJobScheduleChange(job);
+          return {
+            success: true,
+            jobId: job._id.toString(),
+            name: job.name,
+            environment: job.environment,
+            commands: job.commands,
+            schedule: job.schedule,
+            enabled: job.enabled,
+          };
+        } catch (error) {
+          return toolError(error, "Failed to create dbt job");
+        }
+      },
+    }),
+
+    dbt_update_job: tool({
+      description:
+        "Update a saved dbt job's name, environment, commands, schedule, " +
+        "enabled flag, or Slim-CI defer. Only the provided fields change. " +
+        "Pass schedule: null to remove a schedule.",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        jobId: z.string().describe("dbt job ID (from read_dbt_project_tree)"),
+        name: z.string().min(1).max(128).optional(),
+        commands: z.array(z.string().min(1)).min(1).max(10).optional(),
+        environment: z.string().optional(),
+        schedule: z
+          .object({ cron: z.string().min(1), timezone: z.string().min(1) })
+          .nullable()
+          .optional()
+          .describe("Cron schedule; pass null to remove scheduling"),
+        enabled: z.boolean().optional(),
+        deferToProduction: z.boolean().optional(),
+      }),
+      execute: async ({ projectId, jobId, ...updates }) => {
+        try {
+          const project = await assertProject(projectId);
+          if (!Types.ObjectId.isValid(jobId)) {
+            return { success: false, error: "Invalid job id" };
+          }
+          const job = await DbtJob.findOne({
+            _id: new Types.ObjectId(jobId),
+            projectId: project._id,
+          });
+          if (!job) return { success: false, error: "Job not found" };
+
+          const merged = {
+            environment: updates.environment ?? job.environment,
+            commands: updates.commands ?? job.commands,
+            schedule:
+              updates.schedule === undefined
+                ? (job.schedule ?? null)
+                : updates.schedule,
+          };
+          const validationError = validateJob(project, merged);
+          if (validationError) {
+            return { success: false, error: validationError };
+          }
+
+          if (updates.name !== undefined) job.name = updates.name;
+          job.environment = merged.environment;
+          job.commands = merged.commands;
+          job.schedule = merged.schedule ?? undefined;
+          if (updates.enabled !== undefined) job.enabled = updates.enabled;
+          if (updates.deferToProduction !== undefined) {
+            job.deferToProduction = updates.deferToProduction;
+          }
+          await job.save();
+          await applyJobScheduleChange(job);
+          return {
+            success: true,
+            jobId: job._id.toString(),
+            name: job.name,
+            environment: job.environment,
+            commands: job.commands,
+            schedule: job.schedule,
+            enabled: job.enabled,
+          };
+        } catch (error) {
+          return toolError(error, "Failed to update dbt job");
         }
       },
     }),

--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -17,7 +17,13 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { Types } from "mongoose";
-import { DbtJob, DbtProject, DbtRun } from "../../database/workspace-schema";
+import {
+  DatabaseConnection,
+  DbtFile,
+  DbtJob,
+  DbtProject,
+  DbtRun,
+} from "../../database/workspace-schema";
 import { runAdhocDbtCommand } from "../../dbt/dbt-project.service";
 import {
   applyJobScheduleChange,
@@ -27,6 +33,11 @@ import {
   DbtCommandValidationError,
   parseDbtCommands,
 } from "../../dbt/commands";
+import {
+  DBT_COMPATIBLE_CONNECTION_TYPES,
+  isDbtCompatibleConnectionType,
+} from "../../dbt/adapter-map";
+import { buildStarterScaffold } from "../../dbt/scaffold";
 import { validateScheduledConsoleSchedule } from "../../services/scheduled-query-schedule.service";
 import type { DbtLogLine } from "../../dbt/runner.service";
 
@@ -107,6 +118,122 @@ export const createDbtServerTools = (workspaceId: string) => {
   };
 
   return {
+    dbt_create_project: tool({
+      description:
+        "Initialize a new dbt project in this workspace. Use this when " +
+        'read_dbt_project_tree returns no projects ({"projects": []}) and you ' +
+        "need to start building transforms. Creates the project with one " +
+        "environment pointing at a warehouse connection, scaffolds starter " +
+        "files (dbt_project.yml, example model, schema.yml), and returns the " +
+        "projectId to pass to every other dbt tool. Pick the warehouse " +
+        "connection with list_connections / sql_list_connections first.",
+      inputSchema: z.object({
+        name: z
+          .string()
+          .min(1)
+          .max(128)
+          .describe("Project name, e.g. 'analytics'"),
+        connectionId: z
+          .string()
+          .describe(
+            "DatabaseConnection id for the warehouse dbt builds into " +
+              "(from list_connections / sql_list_connections). Must be a " +
+              `dbt-compatible type: ${DBT_COMPATIBLE_CONNECTION_TYPES.join(", ")}.`,
+          ),
+        targetSchema: z
+          .string()
+          .min(1)
+          .max(128)
+          .default("dbt_dev")
+          .describe("Schema/dataset dbt builds into (default dbt_dev)"),
+        environmentName: z
+          .string()
+          .min(1)
+          .max(64)
+          .default("dev")
+          .describe("Environment name (default dev)"),
+        dbtVersion: z.string().max(16).optional(),
+      }),
+      execute: async ({
+        name,
+        connectionId,
+        targetSchema,
+        environmentName,
+        dbtVersion,
+      }) => {
+        try {
+          if (!Types.ObjectId.isValid(connectionId)) {
+            return { success: false, error: "Invalid connection id" };
+          }
+          const connection = await DatabaseConnection.findOne({
+            _id: new Types.ObjectId(connectionId),
+            workspaceId: new Types.ObjectId(workspaceId),
+          }).select("type");
+          if (!connection) {
+            return {
+              success: false,
+              error: "Connection not found or access denied",
+            };
+          }
+          if (!isDbtCompatibleConnectionType(connection.type)) {
+            return {
+              success: false,
+              error:
+                `Connection type "${connection.type}" is not dbt-compatible. ` +
+                `Supported: ${DBT_COMPATIBLE_CONNECTION_TYPES.join(", ")}`,
+            };
+          }
+
+          const project = await DbtProject.create({
+            workspaceId: new Types.ObjectId(workspaceId),
+            name,
+            dbtVersion: dbtVersion ?? "1.9",
+            environments: [
+              {
+                name: environmentName,
+                connectionId: connection._id,
+                targetSchema,
+                threads: 4,
+              },
+            ],
+            defaultEnvironment: environmentName,
+            createdBy: "agent",
+          });
+
+          const scaffold = buildStarterScaffold(name);
+          await DbtFile.insertMany(
+            scaffold.map(file => ({
+              workspaceId: project.workspaceId,
+              projectId: project._id,
+              path: file.path,
+              content: file.content,
+              updatedBy: "agent",
+            })),
+          );
+
+          return {
+            success: true,
+            projectId: project._id.toString(),
+            name: project.name,
+            environment: environmentName,
+            targetSchema,
+            scaffoldedFiles: scaffold.map(file => file.path),
+            message:
+              "Project created. Call read_dbt_project_tree to see the " +
+              "scaffolded files, then build your models.",
+          };
+        } catch (error) {
+          if ((error as { code?: number }).code === 11000) {
+            return {
+              success: false,
+              error: "A dbt project with this name already exists",
+            };
+          }
+          return toolError(error, "Failed to create dbt project");
+        }
+      },
+    }),
+
     dbt_parse: tool({
       description:
         "Validate the entire dbt project (dbt parse): catches Jinja errors, " +

--- a/api/src/agent-lib/tools/mode-tools.ts
+++ b/api/src/agent-lib/tools/mode-tools.ts
@@ -21,8 +21,11 @@ import {
 import type { ExpertiseModeId, ModeState } from "../../agents/modes/types";
 
 const enableModeSchema = z.object({
+  // Derived from the registry so new modes (e.g. dbt) can never drift out of
+  // sync with the enum — a hard-coded list previously omitted "dbt", which
+  // made the model unable to enter dbt mode from a non-dbt surface.
   mode: z
-    .enum(["query", "dashboard", "flow", "app", "explore"])
+    .enum(EXPERTISE_MODE_IDS as [ExpertiseModeId, ...ExpertiseModeId[]])
     .describe(
       "Which expertise mode to enable. Loads that mode's tools and guidance.",
     ),

--- a/api/src/agent-skills/dbt/SKILL.md
+++ b/api/src/agent-skills/dbt/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: dbt
+description: Load when building, editing, running, or debugging dbt models, dbt projects, schema.yml tests, sources, seeds, snapshots, incremental models, materializations, or dbt jobs in the Transforms section.
+entities:
+  - dbt
+  - transform
+  - transforms
+  - model
+  - models
+  - staging
+  - marts
+  - schema.yml
+  - ref
+  - source
+  - materialization
+  - incremental
+  - snapshot
+  - seed
+  - dbt job
+  - dbt run
+  - dbt build
+  - dbt test
+---
+
+# dbt in Mako (Transforms)
+
+Mako runs dbt Core projects whose files live in the workspace database (one
+document per file) and execute as subprocesses against the project's warehouse
+environments. The agent edits files with `create_dbt_file` / `modify_dbt_file`
+and verifies with `dbt_parse` → `dbt_compile_model` → `dbt_run_model`.
+
+## Project layout
+
+```text
+dbt_project.yml        # project config — name, model defaults
+models/
+  staging/             # 1:1 source cleanup, materialized as views
+    schema.yml         # sources + staging model tests
+    stg_<src>_<entity>.sql
+  marts/               # business-facing models, materialized as tables
+    <mart>.sql
+seeds/                 # small CSV reference data (dbt seed)
+macros/                # Jinja macros
+snapshots/             # SCD2 snapshots (see references/snapshots.md)
+tests/                 # singular SQL tests
+```
+
+## Core concepts
+
+- `{{ ref('model_name') }}` — reference another model. Builds the DAG; never
+  hard-code schema-qualified names between models.
+- `{{ source('source_name', 'table_name') }}` — reference a raw table declared
+  under `sources:` in a schema.yml. Always declare sources before using them.
+- Materializations: `view` (default for staging), `table`, `incremental`,
+  `ephemeral`. Set per folder in `dbt_project.yml` or per model with
+  `{{ config(materialized='table') }}`.
+
+## Staging model conventions
+
+```sql
+-- models/staging/stg_shop_orders.sql
+with source as (
+    select * from {{ source('shop', 'orders') }}
+),
+renamed as (
+    select
+        id          as order_id,
+        customer_id,
+        status,
+        total_cents / 100.0 as total_amount,
+        created_at
+    from source
+)
+select * from renamed
+```
+
+- One staging model per source table, named `stg_<source>_<entity>`.
+- Rename to snake_case, cast types, convert cents→currency, no joins.
+- Marts join staging models, never raw sources.
+
+## schema.yml — sources + tests
+
+```yaml
+version: 2
+
+sources:
+  - name: shop
+    schema: public          # where the raw tables live
+    tables:
+      - name: orders
+      - name: customers
+
+models:
+  - name: stg_shop_orders
+    columns:
+      - name: order_id
+        data_tests:
+          - unique
+          - not_null
+      - name: status
+        data_tests:
+          - accepted_values:
+              values: ['pending', 'paid', 'shipped', 'cancelled']
+      - name: customer_id
+        data_tests:
+          - relationships:
+              to: ref('stg_shop_customers')
+              field: customer_id
+```
+
+`dbt_run_model` runs `dbt build --select <model>`, which executes the model
+AND its tests — always add at least `unique` + `not_null` on the primary key.
+
+## Verification loop (mandatory)
+
+1. `dbt_parse` after YAML edits — catches bad refs, undeclared sources,
+   malformed schema.yml without touching the warehouse.
+2. `dbt_compile_model` — renders the Jinja; read the compiled SQL to confirm
+   it targets the right relations.
+3. `dbt_run_model` on dev — reports per-node status, timing, rows affected,
+   and test outcomes. Surface these to the user.
+4. Preview built tables with `sql_execute_query`
+   (`select * from <dev_schema>.<model> limit 100`).
+
+## Environments and jobs
+
+- Projects have environments (dev/prod) mapping to a workspace connection +
+  target schema. Ad-hoc agent builds ALWAYS default to dev.
+- Jobs are saved command lists (`build`, `test`, `seed`, `snapshot`,
+  `source freshness`, `docs generate` + `--select/--exclude/--full-refresh`
+  flags) with optional cron schedules. Trigger via `dbt_run_job` only after
+  explicit user confirmation.
+
+## Tier-3 references
+
+Load with `read_skill_resource` when needed:
+
+- `references/incremental-strategies.md` — incremental models, is_incremental(),
+  unique_key, strategy per adapter, full refresh.
+- `references/snapshots.md` — SCD2 snapshots, timestamp vs check strategy.
+- `references/adapter-quirks.md` — Postgres/BigQuery/ClickHouse/MySQL/
+  Redshift/SQL Server differences that affect model SQL and configs.

--- a/api/src/agent-skills/dbt/references/adapter-quirks.md
+++ b/api/src/agent-skills/dbt/references/adapter-quirks.md
@@ -1,0 +1,56 @@
+# Adapter quirks
+
+Mako maps connection types to dbt adapters (api/src/dbt/adapter-map.ts):
+postgresql / cloudsql-postgres → dbt-postgres, redshift → dbt-redshift,
+bigquery → dbt-bigquery, clickhouse → dbt-clickhouse, mysql → dbt-mysql,
+mssql → dbt-sqlserver. MongoDB, SQLite, Cloudflare D1/KV are NOT dbt targets.
+
+## Postgres / Cloud SQL Postgres
+
+- `schema` in profiles = the target schema; dev/prod separation is by schema.
+- Quoting: dbt lowercases identifiers by default — avoid mixed-case columns.
+- `merge` incremental strategy needs PG ≥ 15; otherwise use `delete+insert`.
+
+## BigQuery
+
+- "schema" means dataset; `targetSchema` is the dataset name.
+- Always prefer `insert_overwrite` + `partition_by` for large date-partitioned
+  facts; `merge` scans the whole table.
+- Use `partition_by={'field': 'created_at', 'data_type': 'timestamp'}` and
+  `cluster_by` in config for big tables.
+- No `interval` arithmetic like Postgres: use `timestamp_sub(current_timestamp(), interval 3 day)`.
+
+## ClickHouse
+
+- Models default to `MergeTree`; set `engine`, `order_by` via config:
+  `{{ config(materialized='table', engine='MergeTree()', order_by='(event_date, user_id)') }}`.
+- Views are real (not materialized views); incremental uses append-style
+  strategies. Consider `ReplacingMergeTree` for dedup semantics instead of
+  merge upserts.
+- No multi-statement transactions — failed table builds can leave partial
+  state; prefer full-refresh on small models.
+- Joins are memory-hungry: filter before joining, prefer `IN` over join for
+  semi-joins.
+
+## Redshift
+
+- Late-binding views (`bind: false`) avoid dependency breakage when upstream
+  tables are rebuilt.
+- `dist`/`sort` keys via config: `{{ config(dist='customer_id', sort='created_at') }}`.
+- VARCHAR lengths are byte lengths; multibyte text needs headroom.
+
+## MySQL
+
+- dbt-mysql lags on dbt-core 1.7 (separate venv in the Mako runner image) —
+  avoid dbt ≥1.8-only features (e.g. new YAML snapshot format, `data_tests:`
+  key; use legacy `tests:` in schema.yml for MySQL projects).
+- No schemas: the target "schema" IS the database name.
+- Window function support requires MySQL 8+.
+
+## SQL Server
+
+- Adapter is dbt-sqlserver via ODBC Driver 18; `trust_cert` is enabled in the
+  rendered profile.
+- Use `TOP` instead of `LIMIT` in raw SQL previews; dbt handles materialization
+  SQL itself.
+- Index/clustering via `{{ config(as_columnstore=true) }}` (default for tables).

--- a/api/src/agent-skills/dbt/references/incremental-strategies.md
+++ b/api/src/agent-skills/dbt/references/incremental-strategies.md
@@ -1,0 +1,57 @@
+# Incremental models
+
+Use `incremental` materialization when a table is too large to rebuild every
+run. The model only processes new/changed rows after the first build.
+
+## Skeleton
+
+```sql
+{{ config(
+    materialized='incremental',
+    unique_key='event_id',
+    on_schema_change='append_new_columns'
+) }}
+
+select
+    event_id,
+    user_id,
+    event_type,
+    occurred_at
+from {{ source('app', 'events') }}
+
+{% if is_incremental() %}
+  -- this filter only applies on incremental runs; `this` is the existing table
+  where occurred_at > (select coalesce(max(occurred_at), '1970-01-01') from {{ this }})
+{% endif %}
+```
+
+Rules:
+
+- `is_incremental()` is false on the first run and after `--full-refresh`.
+- Always use a monotonically increasing column (timestamp, sequence id) in the
+  incremental filter; add a small lookback window (`occurred_at > ... - interval '3 days'`)
+  when late-arriving data is possible.
+- `unique_key` enables merge/upsert semantics; without it, rows are appended.
+
+## Strategy per adapter
+
+| Adapter | Default | Notes |
+|---|---|---|
+| dbt-postgres | `append` (no unique_key) / `delete+insert` | `merge` available on PG 15+ |
+| dbt-bigquery | `merge` | `insert_overwrite` with `partition_by` is much cheaper for date-partitioned facts |
+| dbt-clickhouse | `default` (append) | `delete+insert` and `insert_overwrite` available; ReplacingMergeTree often replaces the need for merge |
+| dbt-redshift | `append` / `delete+insert` | no real merge until RA3 merge support |
+| dbt-mysql | `delete+insert` | dbt-mysql is on dbt-core 1.7; avoid newer config keys |
+| dbt-sqlserver | `merge` | |
+
+Set explicitly when it matters:
+
+```sql
+{{ config(materialized='incremental', incremental_strategy='delete+insert', unique_key='id') }}
+```
+
+## Full refresh
+
+A job command `run --select my_model --full-refresh` rebuilds the table from
+scratch. Recommend a scheduled weekly full refresh for models with mutable
+history when using append-only strategies.

--- a/api/src/agent-skills/dbt/references/snapshots.md
+++ b/api/src/agent-skills/dbt/references/snapshots.md
@@ -1,0 +1,49 @@
+# Snapshots (SCD Type 2)
+
+Snapshots record how mutable source rows change over time. dbt adds
+`dbt_valid_from` / `dbt_valid_to` columns; the current row has
+`dbt_valid_to IS NULL`.
+
+## Definition (dbt 1.9 YAML style)
+
+`snapshots/orders_snapshot.yml`:
+
+```yaml
+snapshots:
+  - name: orders_snapshot
+    relation: source('shop', 'orders')
+    config:
+      schema: snapshots
+      unique_key: id
+      strategy: timestamp
+      updated_at: updated_at
+```
+
+Legacy SQL block style (still supported, lives in `snapshots/*.sql`):
+
+```sql
+{% snapshot orders_snapshot %}
+{{ config(
+    target_schema='snapshots',
+    unique_key='id',
+    strategy='timestamp',
+    updated_at='updated_at'
+) }}
+select * from {{ source('shop', 'orders') }}
+{% endsnapshot %}
+```
+
+## Strategy choice
+
+- `timestamp` (preferred): needs a reliable `updated_at` column.
+- `check`: compares listed columns (`check_cols: ['status', 'amount']`) — use
+  when there is no trustworthy updated_at; more expensive.
+
+## Operating
+
+- Run via a job command `snapshot` (validated by the command allowlist).
+- Snapshots should run on a schedule (e.g. hourly/daily job) — gaps in
+  snapshot runs are unrecorded history.
+- Downstream models select the current version with
+  `where dbt_valid_to is null`, or join on validity ranges for point-in-time
+  analysis.

--- a/api/src/agents/dbt/index.ts
+++ b/api/src/agents/dbt/index.ts
@@ -1,0 +1,105 @@
+/**
+ * Standalone dbt agent.
+ *
+ * Auto-detected for dbt-file / dbt-job tabs (production chat resolves to the
+ * unified agent, which carries the same tools via the `dbt` expertise mode —
+ * this standalone agent exists for direct `agentId: "dbt"` calls and API
+ * consumers).
+ */
+
+import type {
+  AgentConfig,
+  AgentContext,
+  AgentFactory,
+  AgentMeta,
+} from "../types";
+import { clientDbtTools } from "@mako/agent-tools";
+import { createDbtServerTools } from "../../agent-lib/tools/dbt-tools";
+import { createUniversalTools } from "../../agent-lib/tools/universal-tools";
+import { createSkillTools } from "../../agent-lib/tools/skill-tools";
+import { DBT_AGENT_PROMPT } from "./prompt";
+
+export const dbtAgentMeta: AgentMeta = {
+  id: "dbt",
+  name: "dbt Assistant",
+  description:
+    "Builds and operates dbt Core projects: models, tests, jobs, and runs",
+  tabKinds: ["dbt-file", "dbt-job"],
+  enabled: true,
+};
+
+function buildRuntimeContext(context: AgentContext): string {
+  const sections: string[] = ["\n\n---\n\n## Current State (auto-injected)\n"];
+
+  const dbtTabs = (context.openTabs ?? []).filter(
+    tab => tab.kind === "dbt-file" || tab.kind === "dbt-job",
+  );
+  if (dbtTabs.length > 0) {
+    sections.push("### Open dbt tabs:\n");
+    for (const tab of dbtTabs) {
+      sections.push(
+        `- [${tab.kind}] ${tab.title}${tab.isActive ? " (active)" : ""}\n`,
+      );
+    }
+  } else {
+    sections.push(
+      "### Open dbt tabs:\nNone — call read_dbt_project_tree to orient.\n",
+    );
+  }
+
+  if (context.databases && context.databases.length > 0) {
+    sections.push("\n### Available connections:\n");
+    for (const database of context.databases) {
+      sections.push(
+        `- ${database.name} (${database.type}) id=${database.id}\n`,
+      );
+    }
+  }
+
+  sections.push("\n---");
+  return sections.join("");
+}
+
+export const dbtAgentFactory: AgentFactory = (
+  context: AgentContext,
+): AgentConfig => {
+  const { workspaceId, consoles = [], consoleId, userId } = context;
+
+  const universalTools = createUniversalTools(
+    workspaceId,
+    consoles,
+    consoleId,
+    userId,
+    context.toolExecutionContext,
+    { chatId: context.chatId },
+  );
+  const dbtServerTools = createDbtServerTools(workspaceId);
+  const skillTools = createSkillTools(workspaceId, userId);
+
+  return {
+    systemPrompt: [
+      {
+        role: "system" as const,
+        content: DBT_AGENT_PROMPT,
+        providerOptions: {
+          anthropic: { cacheControl: { type: "ephemeral", ttl: "1h" } },
+        },
+      },
+      {
+        role: "system" as const,
+        content:
+          (context.skillsBlock ?? "") +
+          (context.workspaceCustomPrompt
+            ? `\n\n## Workspace instructions\n${context.workspaceCustomPrompt}`
+            : "") +
+          buildRuntimeContext(context),
+      },
+    ],
+    tools: {
+      ...universalTools,
+      ...clientDbtTools,
+      ...dbtServerTools,
+      ...skillTools,
+    },
+  };
+};

--- a/api/src/agents/dbt/prompt.ts
+++ b/api/src/agents/dbt/prompt.ts
@@ -1,0 +1,34 @@
+/**
+ * dbt agent base prompt. Kept lean per the agent-prompts rule: role,
+ * workflow, and tool contract only. Durable dbt reference material lives in
+ * the `dbt` system skill (api/src/agent-skills/dbt/SKILL.md).
+ */
+
+export const DBT_AGENT_PROMPT = `You are Mako's dbt assistant. You help users build, test, and
+operate dbt Core projects whose files live in the workspace (Transforms section) and whose
+runs execute against the project's warehouse environments (dev/prod).
+
+## Workflow
+
+1. **Orient** — call \`read_dbt_project_tree\` to get project IDs, file paths, environments,
+   and jobs. Read existing files before changing them.
+2. **Inspect sources** — use the SQL discovery tools (\`sql_list_tables\`,
+   \`sql_inspect_table\`, \`sql_execute_query\`) on the target connection before writing
+   staging models, so column names and types are real.
+3. **Edit** — \`create_dbt_file\` / \`modify_dbt_file\` with COMPLETE file contents (never a
+   diff). Keep dbt conventions: staging models under \`models/staging/\` as views named
+   \`stg_<source>_<entity>\`, marts under \`models/marts/\` as tables; declare sources and tests
+   in \`schema.yml\`.
+4. **Verify** — after edits run \`dbt_parse\`; then \`dbt_compile_model\` for changed models;
+   then \`dbt_run_model\` on the dev environment and report status, timing, row counts, and
+   test results.
+5. **Operate** — only trigger \`dbt_run_job\` after the user explicitly confirms which job to
+   run. Never run prod jobs proactively.
+
+## Rules
+
+- Load the \`dbt\` system skill for materializations, incremental strategies, snapshots, and
+  adapter quirks before writing non-trivial models.
+- Never invent columns or tables — inspect first.
+- Surface dbt errors verbatim (they are usually actionable) and fix them iteratively.
+- Default to the dev environment for every build; treat prod as requiring explicit user intent.`;

--- a/api/src/agents/index.ts
+++ b/api/src/agents/index.ts
@@ -7,6 +7,7 @@
 
 import { consoleAgentFactory, consoleAgentMeta } from "./console";
 import { dashboardAgentFactory, dashboardAgentMeta } from "./dashboard";
+import { dbtAgentFactory, dbtAgentMeta } from "./dbt";
 import { flowAgentFactory, flowAgentMeta } from "./flow";
 import { unifiedAgentFactory, unifiedAgentMeta } from "./unified";
 import type { AgentFactory, AgentMeta, AgentRegistryEntry } from "./types";
@@ -24,6 +25,7 @@ const agents: Record<string, AgentRegistryEntry> = {
   console: { factory: consoleAgentFactory, meta: consoleAgentMeta },
   dashboard: { factory: dashboardAgentFactory, meta: dashboardAgentMeta },
   flow: { factory: flowAgentFactory, meta: flowAgentMeta },
+  dbt: { factory: dbtAgentFactory, meta: dbtAgentMeta },
 };
 
 /**

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -130,6 +130,11 @@ IDs, file paths, environments, and jobs. Edit with \`create_dbt_file\` / \`modif
 (always write COMPLETE file contents). Inspect source tables with the SQL discovery tools
 before writing staging models.
 
+If \`read_dbt_project_tree\` returns no projects (\`{"projects": []}\`), the workspace has none yet —
+bootstrap one with \`dbt_create_project\` before anything else. Pick the warehouse connection with
+\`list_connections\` / \`sql_list_connections\` first, then pass its id; the tool scaffolds starter
+files and returns the new \`projectId\`.
+
 The verification loop is mandatory after edits:
 1. \`dbt_parse\` — project-wide validation (cheap, no warehouse access)
 2. \`dbt_compile_model\` — confirm the Jinja renders to valid SQL

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -35,6 +35,9 @@ based on what the user is currently looking at — you can switch or add modes a
 - \`app\` — build React apps wired to workspace data: edit files, add dependencies, create data
   bindings. Enable ONLY when the user explicitly mentions building an app, a React app, a
   page/screen/component, installing a library, or references something visible in the active app.
+- \`transform\` — build and run dbt transformations: edit dbt project files (models, schema.yml,
+  sources), compile, test, and run models/jobs against the warehouse. Enable when the user
+  mentions dbt, transforms, models, staging/marts, \`ref()\`/\`source()\`, or running a dbt job.
 - \`explore\` — read-only research across connections, consoles, dashboards, and memory. Enable
   when you need to investigate before committing to an action.
 
@@ -119,7 +122,7 @@ For the full app-building workflow (data bindings, \`@mako/app-sdk\` hooks, mate
 Parquet/DuckDB bindings, preview debugging, and runtime constraints), load the \`apps\`
 system skill.`;
 
-export const DBT_MODE_SYSTEM_PROMPT = `## dbt Mode
+export const TRANSFORM_MODE_SYSTEM_PROMPT = `## Transform (dbt) Mode
 
 dbt projects are virtual filesystems edited through tools; runs execute dbt Core against the
 project's warehouse environments (dev/prod). Start with \`read_dbt_project_tree\` to get project
@@ -133,9 +136,20 @@ The verification loop is mandatory after edits:
 3. \`dbt_run_model\` — build the model + its tests on the dev environment and report
    row counts and test results to the user
 
-Never run \`dbt_run_job\` (full jobs, possibly prod) without the user explicitly confirming the
-job. For conventions (staging/marts layout, ref()/source(), materializations, incremental
-models, snapshots, schema.yml tests), load the \`dbt\` system skill.`;
+\`dbt_compile_model\` and \`dbt_run_model\` accept dbt selectors, not just a single node:
+use graph operators and methods like \`+stg_orders\` (upstream), \`stg_orders+\` (downstream),
+\`tag:nightly\`, \`path:models/staging\`, and \`state:modified+\` to target sets of nodes.
+
+Use \`dbt_show\` to preview the rows a model would return (bounded SELECT, no writes) when you
+want to validate output, not just that it compiles.
+
+Jobs: create or edit saved jobs with \`dbt_create_job\` / \`dbt_update_job\` (add a cron schedule
+only when the user asks for a recurring run). Trigger a saved job with \`dbt_run_job\` — never run
+a job (possibly prod) without the user explicitly confirming it. \`dbt_run_job\` only QUEUES the
+run; always follow up with \`dbt_get_run\` to report whether it actually passed or failed.
+
+For conventions (staging/marts layout, ref()/source(), materializations, incremental models,
+snapshots, schema.yml tests), load the \`dbt\` system skill.`;
 
 export const EXPLORE_MODE_SYSTEM_PROMPT = `## Explore Mode (read-only)
 

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -119,6 +119,24 @@ For the full app-building workflow (data bindings, \`@mako/app-sdk\` hooks, mate
 Parquet/DuckDB bindings, preview debugging, and runtime constraints), load the \`apps\`
 system skill.`;
 
+export const DBT_MODE_SYSTEM_PROMPT = `## dbt Mode
+
+dbt projects are virtual filesystems edited through tools; runs execute dbt Core against the
+project's warehouse environments (dev/prod). Start with \`read_dbt_project_tree\` to get project
+IDs, file paths, environments, and jobs. Edit with \`create_dbt_file\` / \`modify_dbt_file\`
+(always write COMPLETE file contents). Inspect source tables with the SQL discovery tools
+before writing staging models.
+
+The verification loop is mandatory after edits:
+1. \`dbt_parse\` — project-wide validation (cheap, no warehouse access)
+2. \`dbt_compile_model\` — confirm the Jinja renders to valid SQL
+3. \`dbt_run_model\` — build the model + its tests on the dev environment and report
+   row counts and test results to the user
+
+Never run \`dbt_run_job\` (full jobs, possibly prod) without the user explicitly confirming the
+job. For conventions (staging/marts layout, ref()/source(), materializations, incremental
+models, snapshots, schema.yml tests), load the \`dbt\` system skill.`;
+
 export const EXPLORE_MODE_SYSTEM_PROMPT = `## Explore Mode (read-only)
 
 You are investigating, not changing anything. Use discovery and inspection tools to understand

--- a/api/src/agents/modes/registry.ts
+++ b/api/src/agents/modes/registry.ts
@@ -153,6 +153,8 @@ const APP_MODE_TOOL_NAMES: string[] = [
 ];
 
 const TRANSFORM_MODE_TOOL_NAMES: string[] = [
+  // Bootstrap: create a project when the workspace has none
+  "dbt_create_project",
   // Client dbt file tools
   "read_dbt_project_tree",
   "read_dbt_file",

--- a/api/src/agents/modes/registry.ts
+++ b/api/src/agents/modes/registry.ts
@@ -6,7 +6,7 @@ import {
   DASHBOARD_MODE_SYSTEM_PROMPT,
   FLOW_MODE_SYSTEM_PROMPT,
   APP_MODE_SYSTEM_PROMPT,
-  DBT_MODE_SYSTEM_PROMPT,
+  TRANSFORM_MODE_SYSTEM_PROMPT,
   EXPLORE_MODE_SYSTEM_PROMPT,
 } from "./prompts";
 
@@ -152,18 +152,22 @@ const APP_MODE_TOOL_NAMES: string[] = [
   "mongo_execute_query",
 ];
 
-const DBT_MODE_TOOL_NAMES: string[] = [
+const TRANSFORM_MODE_TOOL_NAMES: string[] = [
   // Client dbt file tools
   "read_dbt_project_tree",
   "read_dbt_file",
   "create_dbt_file",
   "modify_dbt_file",
   "delete_dbt_file",
-  // Server dbt verification tools
+  // Server dbt verification + execution tools
   "dbt_parse",
   "dbt_compile_model",
   "dbt_run_model",
   "dbt_run_job",
+  "dbt_get_run",
+  "dbt_show",
+  "dbt_create_job",
+  "dbt_update_job",
   // Discovery: inspect sources before writing staging models; preview built
   // tables after dbt_run_model.
   "list_connections",
@@ -246,13 +250,13 @@ export const modeRegistry: Record<ExpertiseModeId, AgentMode> = {
       "Edit app files and verify the preview builds without errors",
     ],
   },
-  dbt: {
-    id: "dbt",
-    name: "dbt Transforms",
+  transform: {
+    id: "transform",
+    name: "Transforms",
     routingPrompt:
-      "Build and run dbt models: edit project files, compile, test, and run transformations against the warehouse.",
-    systemPrompt: DBT_MODE_SYSTEM_PROMPT,
-    toolNames: DBT_MODE_TOOL_NAMES,
+      "Build and run dbt transformations: edit project files, compile, test, and run models against the warehouse.",
+    systemPrompt: TRANSFORM_MODE_SYSTEM_PROMPT,
+    toolNames: TRANSFORM_MODE_TOOL_NAMES,
     trajectories: [
       "Inspect the source tables for the model",
       "Write the model SQL + schema.yml entries",
@@ -279,6 +283,27 @@ export function isExpertiseModeId(value: unknown): value is ExpertiseModeId {
 }
 
 /**
+ * Legacy mode ids → current ids. Existing chats persist `enable_mode` tool
+ * calls; `deriveModeState` replays them, so a rename must keep resolving the
+ * old id (e.g. the dbt mode was renamed to "transform").
+ */
+const LEGACY_MODE_ALIASES: Record<string, ExpertiseModeId> = {
+  dbt: "transform",
+};
+
+/**
+ * Resolve a (possibly legacy) mode id to a current `ExpertiseModeId`, or
+ * `undefined` if it is not a known mode.
+ */
+export function resolveExpertiseModeId(
+  value: unknown,
+): ExpertiseModeId | undefined {
+  if (typeof value !== "string") return undefined;
+  const resolved = LEGACY_MODE_ALIASES[value] ?? value;
+  return isExpertiseModeId(resolved) ? resolved : undefined;
+}
+
+/**
  * Pick the expertise mode to enable by default for a fresh request, based on
  * what the user is currently looking at. This replaces PostHog's small-model
  * router with a zero-cost heuristic; a model router can be layered on later.
@@ -291,7 +316,9 @@ export function defaultExpertiseMode(
   if (view === "dashboard" || tabKind === "dashboard") return "dashboard";
   if (view === "flow-editor" || tabKind === "flow-editor") return "flow";
   if (view === "app" || tabKind === "app") return "app";
-  if (tabKind === "dbt-file" || tabKind === "dbt-job") return "dbt";
+  if (view === "dbt" || tabKind === "dbt-file" || tabKind === "dbt-job") {
+    return "transform";
+  }
   return "query";
 }
 

--- a/api/src/agents/modes/registry.ts
+++ b/api/src/agents/modes/registry.ts
@@ -6,6 +6,7 @@ import {
   DASHBOARD_MODE_SYSTEM_PROMPT,
   FLOW_MODE_SYSTEM_PROMPT,
   APP_MODE_SYSTEM_PROMPT,
+  DBT_MODE_SYSTEM_PROMPT,
   EXPLORE_MODE_SYSTEM_PROMPT,
 } from "./prompts";
 
@@ -151,6 +152,28 @@ const APP_MODE_TOOL_NAMES: string[] = [
   "mongo_execute_query",
 ];
 
+const DBT_MODE_TOOL_NAMES: string[] = [
+  // Client dbt file tools
+  "read_dbt_project_tree",
+  "read_dbt_file",
+  "create_dbt_file",
+  "modify_dbt_file",
+  "delete_dbt_file",
+  // Server dbt verification tools
+  "dbt_parse",
+  "dbt_compile_model",
+  "dbt_run_model",
+  "dbt_run_job",
+  // Discovery: inspect sources before writing staging models; preview built
+  // tables after dbt_run_model.
+  "list_connections",
+  "sql_list_connections",
+  "sql_list_databases",
+  "sql_list_tables",
+  "sql_inspect_table",
+  "sql_execute_query",
+];
+
 const EXPLORE_MODE_TOOL_NAMES: string[] = [
   "list_connections",
   "sql_list_connections",
@@ -223,6 +246,19 @@ export const modeRegistry: Record<ExpertiseModeId, AgentMode> = {
       "Edit app files and verify the preview builds without errors",
     ],
   },
+  dbt: {
+    id: "dbt",
+    name: "dbt Transforms",
+    routingPrompt:
+      "Build and run dbt models: edit project files, compile, test, and run transformations against the warehouse.",
+    systemPrompt: DBT_MODE_SYSTEM_PROMPT,
+    toolNames: DBT_MODE_TOOL_NAMES,
+    trajectories: [
+      "Inspect the source tables for the model",
+      "Write the model SQL + schema.yml entries",
+      "Verify with dbt_parse, dbt_compile_model, then dbt_run_model on dev",
+    ],
+  },
   explore: {
     id: "explore",
     name: "Explore",
@@ -255,6 +291,7 @@ export function defaultExpertiseMode(
   if (view === "dashboard" || tabKind === "dashboard") return "dashboard";
   if (view === "flow-editor" || tabKind === "flow-editor") return "flow";
   if (view === "app" || tabKind === "app") return "app";
+  if (tabKind === "dbt-file" || tabKind === "dbt-job") return "dbt";
   return "query";
 }
 

--- a/api/src/agents/modes/runtime.ts
+++ b/api/src/agents/modes/runtime.ts
@@ -25,7 +25,7 @@ import {
   modeRegistry,
   defaultExpertiseMode,
   toolNamesForModes,
-  isExpertiseModeId,
+  resolveExpertiseModeId,
 } from "./registry";
 import {
   BASE_SYSTEM_PROMPT,
@@ -84,7 +84,8 @@ export function deriveModeState(
 
       if (toolName === "enable_mode") {
         const mode = (part.input as { mode?: unknown } | undefined)?.mode;
-        if (isExpertiseModeId(mode)) enabledModes.add(mode);
+        const resolved = resolveExpertiseModeId(mode);
+        if (resolved) enabledModes.add(resolved);
       } else if (toolName === "submit_plan") {
         planSubmitted = true;
         const decision = (part.output as { decision?: unknown } | undefined)

--- a/api/src/agents/modes/types.ts
+++ b/api/src/agents/modes/types.ts
@@ -16,6 +16,7 @@ export type ExpertiseModeId =
   | "dashboard"
   | "flow"
   | "app"
+  | "dbt"
   | "explore";
 
 /**

--- a/api/src/agents/modes/types.ts
+++ b/api/src/agents/modes/types.ts
@@ -16,7 +16,7 @@ export type ExpertiseModeId =
   | "dashboard"
   | "flow"
   | "app"
-  | "dbt"
+  | "transform"
   | "explore";
 
 /**

--- a/api/src/agents/types.ts
+++ b/api/src/agents/types.ts
@@ -53,7 +53,13 @@ export interface AgentContext {
    */
   chatId?: string;
   /** What the user is currently looking at (the active editor tab's kind) */
-  activeView?: "console" | "dashboard" | "flow-editor" | "app" | "empty";
+  activeView?:
+    | "console"
+    | "dashboard"
+    | "flow-editor"
+    | "app"
+    | "dbt"
+    | "empty";
   /**
    * Which left-pane explorer is currently open and visible, or `null` if the
    * left pane is collapsed. Use this when guiding the user to a specific

--- a/api/src/agents/unified/index.ts
+++ b/api/src/agents/unified/index.ts
@@ -3,8 +3,10 @@ import { createUniversalTools } from "../../agent-lib/tools/universal-tools";
 import {
   clientDashboardTools,
   clientAppTools,
+  clientDbtTools,
   clientDataSourceTools,
 } from "@mako/agent-tools";
+import { createDbtServerTools } from "../../agent-lib/tools/dbt-tools";
 import { createSelfDirectiveTools } from "../../agent-lib/tools/self-directive-tool";
 import { createSkillTools } from "../../agent-lib/tools/skill-tools";
 import { createConsoleSearchTools } from "../../agent-lib/tools/console-search-tools";
@@ -44,6 +46,7 @@ export function unifiedAgentFactory(context: AgentContext): AgentConfig {
     context.toolExecutionContext,
   );
   const versionHistoryTools = createVersionHistoryTools(workspaceId);
+  const dbtServerTools = createDbtServerTools(workspaceId);
 
   const {
     list_connections: _flowListConnections,
@@ -71,6 +74,8 @@ export function unifiedAgentFactory(context: AgentContext): AgentConfig {
       ...universalTools,
       ...clientDashboardTools,
       ...clientAppTools,
+      ...clientDbtTools,
+      ...dbtServerTools,
       ...clientDataSourceTools,
       ...flowUniqueTools,
       ...selfDirectiveTools,

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -4195,6 +4195,7 @@ export interface IDbtRun extends Document {
     manifest?: string;
     runResults?: string;
     catalog?: string;
+    sources?: string;
   };
   /** Set on retry runs: the run this was retried from. */
   retryOfRunId?: Types.ObjectId;
@@ -4276,6 +4277,7 @@ const DbtRunSchema = new Schema<IDbtRun>(
       manifest: { type: String },
       runResults: { type: String },
       catalog: { type: String },
+      sources: { type: String },
     },
     retryOfRunId: { type: Schema.Types.ObjectId, ref: "DbtRun" },
     restoreArtifactKeys: {

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -3499,7 +3499,7 @@ export const Connector = mongoose.model<IConnector>(
  * EntityVersion — immutable append-only version snapshots for consoles and dashboards.
  * Every explicit save creates a new version record; history is never rewritten.
  */
-export type VersionableEntityType = "console" | "dashboard";
+export type VersionableEntityType = "console" | "dashboard" | "dbt-file";
 
 export interface IEntityVersion extends Document {
   _id: Types.ObjectId;
@@ -3524,7 +3524,7 @@ const EntityVersionSchema = new Schema<IEntityVersion>(
     },
     entityType: {
       type: String,
-      enum: ["console", "dashboard"],
+      enum: ["console", "dashboard", "dbt-file"],
       required: true,
     },
     entityId: {
@@ -3959,3 +3959,321 @@ export const RealtimePresence = mongoose.model<IRealtimePresence>(
   "RealtimePresence",
   RealtimePresenceSchema,
 );
+
+/**
+ * dbt — workspace-scoped dbt Core projects ("dbt Cloud replica").
+ *
+ * A project is a virtual filesystem in Mongo (one DbtFile doc per file)
+ * materialized to a temp dir at run time by api/src/dbt/runner.service.ts.
+ * Jobs hold command lists + cron schedules (claim pattern mirrors
+ * SavedConsole.scheduledRun); runs are the per-execution records with
+ * capped logs and parsed run_results.json step results.
+ */
+
+export interface IDbtEnvironment {
+  /** Environment name, e.g. "dev" or "prod". Unique within the project. */
+  name: string;
+  /** DatabaseConnection id used as the warehouse target. */
+  connectionId: Types.ObjectId;
+  /** Target schema (dataset for BigQuery) dbt builds into. */
+  targetSchema: string;
+  /** dbt threads; default low (4) — prod container is memory-constrained. */
+  threads: number;
+  /** dbt vars passed as --vars for every command in this environment. */
+  vars?: Record<string, unknown>;
+}
+
+export interface IDbtProject extends Document {
+  _id: Types.ObjectId;
+  workspaceId: Types.ObjectId;
+  name: string;
+  /** Pinned dbt-core minor version, e.g. "1.9". Informational for now. */
+  dbtVersion: string;
+  environments: IDbtEnvironment[];
+  defaultEnvironment: string;
+  /**
+   * Artifact-store key of the last successful prod manifest.json. This is
+   * the state artifact for --defer / state:modified+ (Slim CI, later phase).
+   */
+  lastProdManifestKey?: string;
+  createdBy: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const DbtEnvironmentSchema = new Schema<IDbtEnvironment>(
+  {
+    name: { type: String, required: true, trim: true },
+    connectionId: {
+      type: Schema.Types.ObjectId,
+      ref: "DatabaseConnection",
+      required: true,
+    },
+    targetSchema: { type: String, required: true, trim: true },
+    threads: { type: Number, default: 4, min: 1, max: 16 },
+    vars: { type: Schema.Types.Mixed },
+  },
+  { _id: false },
+);
+
+const DbtProjectSchema = new Schema<IDbtProject>(
+  {
+    workspaceId: {
+      type: Schema.Types.ObjectId,
+      ref: "Workspace",
+      required: true,
+    },
+    name: { type: String, required: true, trim: true },
+    dbtVersion: { type: String, default: "1.9" },
+    environments: { type: [DbtEnvironmentSchema], default: [] },
+    defaultEnvironment: { type: String, default: "dev" },
+    lastProdManifestKey: { type: String },
+    createdBy: { type: String, required: true },
+  },
+  { collection: "dbt_projects", timestamps: true },
+);
+
+DbtProjectSchema.index({ workspaceId: 1, name: 1 }, { unique: true });
+DbtProjectSchema.index({ workspaceId: 1, updatedAt: -1 });
+
+export const DbtProject = mongoose.model<IDbtProject>(
+  "DbtProject",
+  DbtProjectSchema,
+);
+
+export interface IDbtFile extends Document {
+  _id: Types.ObjectId;
+  workspaceId: Types.ObjectId;
+  projectId: Types.ObjectId;
+  /** POSIX path relative to project root, e.g. "models/staging/stg_x.sql". */
+  path: string;
+  content: string;
+  updatedBy: string;
+  is_deleted: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const DbtFileSchema = new Schema<IDbtFile>(
+  {
+    workspaceId: {
+      type: Schema.Types.ObjectId,
+      ref: "Workspace",
+      required: true,
+    },
+    projectId: {
+      type: Schema.Types.ObjectId,
+      ref: "DbtProject",
+      required: true,
+    },
+    path: { type: String, required: true, trim: true },
+    content: { type: String, default: "" },
+    updatedBy: { type: String, required: true },
+    is_deleted: { type: Boolean, default: false },
+  },
+  { collection: "dbt_files", timestamps: true },
+);
+
+DbtFileSchema.index({ projectId: 1, path: 1 }, { unique: true });
+DbtFileSchema.index({ workspaceId: 1, projectId: 1, is_deleted: 1 });
+
+export const DbtFile = mongoose.model<IDbtFile>("DbtFile", DbtFileSchema);
+
+export interface IDbtJob extends Document {
+  _id: Types.ObjectId;
+  workspaceId: Types.ObjectId;
+  projectId: Types.ObjectId;
+  name: string;
+  /** Environment name from the project's environments list. */
+  environment: string;
+  /** Validated against the dbt command allowlist (api/src/dbt/commands.ts). */
+  commands: string[];
+  schedule?: {
+    cron: string;
+    timezone: string;
+  };
+  /** Mirrors SavedConsole.scheduledRun so the optimistic claim transfers. */
+  scheduledRun?: {
+    nextAt?: Date;
+    lastAt?: Date;
+    lastStatus?: "success" | "error";
+    lastError?: string;
+    lastDurationMs?: number;
+    runCount: number;
+    consecutiveFailures: number;
+  };
+  enabled: boolean;
+  /** Reserved for Slim CI (--defer against the stored prod manifest). */
+  deferToProduction: boolean;
+  createdBy: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const DbtJobSchema = new Schema<IDbtJob>(
+  {
+    workspaceId: {
+      type: Schema.Types.ObjectId,
+      ref: "Workspace",
+      required: true,
+    },
+    projectId: {
+      type: Schema.Types.ObjectId,
+      ref: "DbtProject",
+      required: true,
+    },
+    name: { type: String, required: true, trim: true },
+    environment: { type: String, required: true },
+    commands: { type: [String], default: [] },
+    schedule: {
+      cron: { type: String },
+      timezone: { type: String },
+    },
+    scheduledRun: {
+      nextAt: { type: Date },
+      lastAt: { type: Date },
+      lastStatus: { type: String, enum: ["success", "error"] },
+      lastError: { type: String },
+      lastDurationMs: { type: Number },
+      runCount: { type: Number, default: 0 },
+      consecutiveFailures: { type: Number, default: 0 },
+    },
+    enabled: { type: Boolean, default: true },
+    deferToProduction: { type: Boolean, default: false },
+    createdBy: { type: String, required: true },
+  },
+  { collection: "dbt_jobs", timestamps: true },
+);
+
+DbtJobSchema.index({ workspaceId: 1, projectId: 1 });
+DbtJobSchema.index({ "scheduledRun.nextAt": 1, enabled: 1 }, { sparse: true });
+
+export const DbtJob = mongoose.model<IDbtJob>("DbtJob", DbtJobSchema);
+
+export type DbtRunStatus =
+  | "queued"
+  | "running"
+  | "success"
+  | "error"
+  | "cancelled";
+
+export interface IDbtRunLogLine {
+  ts: Date;
+  level: string;
+  line: string;
+}
+
+export interface IDbtRunStepResult {
+  uniqueId: string;
+  name: string;
+  resourceType: string;
+  status: string;
+  executionTimeMs: number;
+  rowsAffected?: number;
+  message?: string;
+}
+
+export interface IDbtRun extends Document {
+  _id: Types.ObjectId;
+  workspaceId: Types.ObjectId;
+  projectId: Types.ObjectId;
+  jobId?: Types.ObjectId;
+  environment: string;
+  commands: string[];
+  status: DbtRunStatus;
+  trigger: "schedule" | "manual" | "agent";
+  /** User id for manual triggers, "scheduler" / "agent" otherwise. */
+  triggeredBy: string;
+  startedAt?: Date;
+  completedAt?: Date;
+  durationMs?: number;
+  /** Capped, batch-written log lines (parsed from --log-format json). */
+  logs: IDbtRunLogLine[];
+  /** Parsed from run_results.json after each command. */
+  stepResults: IDbtRunStepResult[];
+  artifactKeys: {
+    manifest?: string;
+    runResults?: string;
+    catalog?: string;
+  };
+  error?: string;
+  inngestRunId?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const DbtRunSchema = new Schema<IDbtRun>(
+  {
+    workspaceId: {
+      type: Schema.Types.ObjectId,
+      ref: "Workspace",
+      required: true,
+    },
+    projectId: {
+      type: Schema.Types.ObjectId,
+      ref: "DbtProject",
+      required: true,
+    },
+    jobId: { type: Schema.Types.ObjectId, ref: "DbtJob" },
+    environment: { type: String, required: true },
+    commands: { type: [String], default: [] },
+    status: {
+      type: String,
+      enum: ["queued", "running", "success", "error", "cancelled"],
+      default: "queued",
+      required: true,
+    },
+    trigger: {
+      type: String,
+      enum: ["schedule", "manual", "agent"],
+      required: true,
+    },
+    triggeredBy: { type: String, required: true },
+    startedAt: { type: Date },
+    completedAt: { type: Date },
+    durationMs: { type: Number },
+    logs: {
+      type: [
+        new Schema<IDbtRunLogLine>(
+          {
+            ts: { type: Date, required: true },
+            level: { type: String, default: "info" },
+            line: { type: String, required: true },
+          },
+          { _id: false },
+        ),
+      ],
+      default: [],
+    },
+    stepResults: {
+      type: [
+        new Schema<IDbtRunStepResult>(
+          {
+            uniqueId: { type: String, required: true },
+            name: { type: String, required: true },
+            resourceType: { type: String, default: "model" },
+            status: { type: String, required: true },
+            executionTimeMs: { type: Number, default: 0 },
+            rowsAffected: { type: Number },
+            message: { type: String },
+          },
+          { _id: false },
+        ),
+      ],
+      default: [],
+    },
+    artifactKeys: {
+      manifest: { type: String },
+      runResults: { type: String },
+      catalog: { type: String },
+    },
+    error: { type: String },
+    inngestRunId: { type: String },
+  },
+  { collection: "dbt_runs", timestamps: true },
+);
+
+DbtRunSchema.index({ workspaceId: 1, projectId: 1, createdAt: -1 });
+DbtRunSchema.index({ jobId: 1, createdAt: -1 }, { sparse: true });
+
+export const DbtRun = mongoose.model<IDbtRun>("DbtRun", DbtRunSchema);

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -4196,6 +4196,16 @@ export interface IDbtRun extends Document {
     runResults?: string;
     catalog?: string;
   };
+  /** Set on retry runs: the run this was retried from. */
+  retryOfRunId?: Types.ObjectId;
+  /**
+   * Artifact keys restored into target/ before commands run (retry-from-
+   * failure: run_results.json drives `dbt retry`).
+   */
+  restoreArtifactKeys?: {
+    runResults?: string;
+    manifest?: string;
+  };
   error?: string;
   inngestRunId?: string;
   createdAt: Date;
@@ -4266,6 +4276,11 @@ const DbtRunSchema = new Schema<IDbtRun>(
       manifest: { type: String },
       runResults: { type: String },
       catalog: { type: String },
+    },
+    retryOfRunId: { type: Schema.Types.ObjectId, ref: "DbtRun" },
+    restoreArtifactKeys: {
+      runResults: { type: String },
+      manifest: { type: String },
     },
     error: { type: String },
     inngestRunId: { type: String },

--- a/api/src/dbt/adapter-map.test.ts
+++ b/api/src/dbt/adapter-map.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  getDbtAdapterPackage,
+  isDbtCompatibleConnectionType,
+  renderDbtProfile,
+} from "./adapter-map";
+import type {
+  IDatabaseConnection,
+  IDbtEnvironment,
+} from "../database/workspace-schema";
+
+function connection(
+  type: string,
+  overrides: Record<string, unknown> = {},
+): IDatabaseConnection {
+  return {
+    type,
+    connection: {
+      host: "db.internal",
+      port: 5432,
+      username: "analytics",
+      password: "s3cr3t-do-not-leak",
+      database: "warehouse",
+      ...overrides,
+    },
+  } as unknown as IDatabaseConnection;
+}
+
+const env: IDbtEnvironment = {
+  name: "prod",
+  connectionId: "000000000000000000000000",
+  targetSchema: "analytics",
+  threads: 4,
+} as unknown as IDbtEnvironment;
+
+describe("renderDbtProfile secret isolation", () => {
+  const secretBearingTypes = [
+    "postgresql",
+    "cloudsql-postgres",
+    "redshift",
+    "clickhouse",
+    "mysql",
+    "mssql",
+  ];
+
+  it.each(secretBearingTypes)(
+    "%s keeps the password out of profiles.yml and in the env map",
+    type => {
+      const { profilesYml, secretEnv } = renderDbtProfile(
+        connection(type),
+        env,
+      );
+      expect(profilesYml).not.toContain("s3cr3t-do-not-leak");
+      expect(profilesYml).toContain("DBT_SECRET_PASSWORD");
+      expect(secretEnv.DBT_SECRET_PASSWORD).toBe("s3cr3t-do-not-leak");
+    },
+  );
+
+  it("bigquery keeps the service-account JSON out of profiles.yml", () => {
+    const sa = JSON.stringify({ project_id: "my-proj", private_key: "PK" });
+    const { profilesYml, secretEnv } = renderDbtProfile(
+      connection("bigquery", { service_account_json: sa }),
+      env,
+    );
+    expect(profilesYml).not.toContain("PK");
+    expect(profilesYml).toContain("my-proj");
+    expect(secretEnv.DBT_SECRET_BQ_KEYFILE_JSON).toBe(sa);
+  });
+
+  it("emits the correct adapter package per type", () => {
+    expect(getDbtAdapterPackage("postgresql")).toBe("dbt-postgres");
+    expect(getDbtAdapterPackage("redshift")).toBe("dbt-redshift");
+    expect(getDbtAdapterPackage("bigquery")).toBe("dbt-bigquery");
+    expect(getDbtAdapterPackage("clickhouse")).toBe("dbt-clickhouse");
+    expect(getDbtAdapterPackage("mysql")).toBe("dbt-mysql");
+    expect(getDbtAdapterPackage("mssql")).toBe("dbt-sqlserver");
+  });
+
+  it("rejects non-dbt-compatible connection types", () => {
+    expect(isDbtCompatibleConnectionType("mongodb")).toBe(false);
+    expect(() => renderDbtProfile(connection("mongodb"), env)).toThrow();
+  });
+});

--- a/api/src/dbt/adapter-map.ts
+++ b/api/src/dbt/adapter-map.ts
@@ -14,6 +14,21 @@ import type {
   IDbtEnvironment,
 } from "../database/workspace-schema";
 
+/**
+ * A credential file the runner must materialize before invoking dbt. The
+ * content is written to `<runDir>/<filename>` with 0600 perms and its absolute
+ * path is exported as `envVar`, which the profile references via env_var().
+ * Used for adapters (BigQuery) whose secrets are a file/dict, not a scalar.
+ */
+export interface ProfileKeyfile {
+  /** Env var that will hold the absolute path to the written file. */
+  envVar: string;
+  /** Relative filename within the runner's ephemeral project dir. */
+  filename: string;
+  /** File content (never logged). */
+  content: string;
+}
+
 export interface RenderedProfile {
   /** profiles.yml text to write into the runner temp dir. */
   profilesYml: string;
@@ -21,6 +36,8 @@ export interface RenderedProfile {
   secretEnv: Record<string, string>;
   /** dbt adapter package, e.g. "dbt-postgres". */
   adapterPackage: string;
+  /** Credential files the runner writes to disk (0600) before running dbt. */
+  keyfiles: ProfileKeyfile[];
 }
 
 export const DBT_PROFILE_NAME = "mako";
@@ -31,6 +48,7 @@ interface AdapterEntry {
     connection: IDatabaseConnection,
     env: Pick<IDbtEnvironment, "targetSchema" | "threads">,
     secretEnv: Record<string, string>,
+    keyfiles: ProfileKeyfile[],
   ) => Record<string, unknown>;
 }
 
@@ -80,28 +98,52 @@ const ADAPTERS: Record<string, AdapterEntry> = {
   },
   bigquery: {
     adapterPackage: "dbt-bigquery",
-    renderTarget: (connection, env, secretEnv) => {
-      const c = connection.connection;
-      const serviceAccountJson = c.service_account_json ?? "";
-      let projectId = "";
-      try {
-        projectId =
-          (JSON.parse(serviceAccountJson) as { project_id?: string })
-            .project_id ?? "";
-      } catch {
-        // keyfile missing/invalid — dbt will surface a clear error
+    renderTarget: (connection, env, _secretEnv, keyfiles) => {
+      const c = connection.connection as Record<string, unknown>;
+      // Credentials may be stored as a JSON string or an already-parsed object
+      // (the BigQuery query driver accepts both — mirror that here).
+      const rawSa = c.service_account_json;
+      let keyfileContent = "";
+      let saProjectId: string | undefined;
+      if (typeof rawSa === "string") {
+        keyfileContent = rawSa;
+        try {
+          saProjectId = (JSON.parse(rawSa) as { project_id?: string })
+            .project_id;
+        } catch {
+          // invalid/missing keyfile — dbt surfaces a clear error at startup
+        }
+      } else if (rawSa && typeof rawSa === "object") {
+        keyfileContent = JSON.stringify(rawSa);
+        saProjectId = (rawSa as { project_id?: string }).project_id;
       }
+
+      // Prefer the connection's configured project (what the query driver uses
+      // via getProjectId), falling back to the service account's own project.
+      const project =
+        (typeof c.project_id === "string" && c.project_id) || saProjectId || "";
+      const location =
+        typeof c.location === "string" && c.location ? c.location : undefined;
+
+      // dbt-bigquery's `service-account-json`/`keyfile_json` wants a parsed
+      // dict, which can't be supplied via env_var without mangling the private
+      // key's newlines. Write the keyfile to a 0600 temp file and reference its
+      // path with `method: service-account` + `keyfile` instead.
+      const KEYFILE_ENV = "DBT_BQ_KEYFILE";
+      keyfiles.push({
+        envVar: KEYFILE_ENV,
+        filename: ".dbt-bq-keyfile.json",
+        content: keyfileContent,
+      });
+
       return {
         type: "bigquery",
-        method: "service-account-json",
-        project: projectId,
+        method: "service-account",
+        project,
         dataset: env.targetSchema,
         threads: env.threads,
-        keyfile_json: secretRef(
-          secretEnv,
-          "bq_keyfile_json",
-          serviceAccountJson,
-        ),
+        keyfile: `{{ env_var('${KEYFILE_ENV}') }}`,
+        ...(location ? { location } : {}),
       };
     },
   },
@@ -187,7 +229,13 @@ export function renderDbtProfile(
   }
 
   const secretEnv: Record<string, string> = {};
-  const target = adapter.renderTarget(connection, environment, secretEnv);
+  const keyfiles: ProfileKeyfile[] = [];
+  const target = adapter.renderTarget(
+    connection,
+    environment,
+    secretEnv,
+    keyfiles,
+  );
 
   const profile = {
     [DBT_PROFILE_NAME]: {
@@ -203,5 +251,6 @@ export function renderDbtProfile(
     profilesYml: yamlDump(profile, { lineWidth: 200 }),
     secretEnv,
     adapterPackage: adapter.adapterPackage,
+    keyfiles,
   };
 }

--- a/api/src/dbt/adapter-map.ts
+++ b/api/src/dbt/adapter-map.ts
@@ -1,0 +1,207 @@
+/**
+ * Connection type → dbt adapter mapping + profiles.yml target renderers.
+ *
+ * Each renderer takes the DECRYPTED connection (Mongoose getters already
+ * applied via .toObject({ getters: true })) and emits a profile target where
+ * secrets are referenced as {{ env_var('DBT_SECRET_...') }}. The actual
+ * secret values are only ever passed via the child-process env — credentials
+ * are never written to disk.
+ */
+
+import { dump as yamlDump } from "js-yaml";
+import type {
+  IDatabaseConnection,
+  IDbtEnvironment,
+} from "../database/workspace-schema";
+
+export interface RenderedProfile {
+  /** profiles.yml text to write into the runner temp dir. */
+  profilesYml: string;
+  /** Secret env vars to pass to the dbt child process. */
+  secretEnv: Record<string, string>;
+  /** dbt adapter package, e.g. "dbt-postgres". */
+  adapterPackage: string;
+}
+
+export const DBT_PROFILE_NAME = "mako";
+
+interface AdapterEntry {
+  adapterPackage: string;
+  renderTarget: (
+    connection: IDatabaseConnection,
+    env: Pick<IDbtEnvironment, "targetSchema" | "threads">,
+    secretEnv: Record<string, string>,
+  ) => Record<string, unknown>;
+}
+
+function secretRef(
+  secretEnv: Record<string, string>,
+  name: string,
+  value: string,
+): string {
+  const envName = `DBT_SECRET_${name.toUpperCase()}`;
+  secretEnv[envName] = value;
+  return `{{ env_var('${envName}') }}`;
+}
+
+const postgresLike =
+  (defaultPort: number) =>
+  (
+    connection: IDatabaseConnection,
+    env: Pick<IDbtEnvironment, "targetSchema" | "threads">,
+    secretEnv: Record<string, string>,
+  ): Record<string, unknown> => {
+    const c = connection.connection;
+    return {
+      type: connection.type === "redshift" ? "redshift" : "postgres",
+      host: c.host ?? "localhost",
+      port: c.port ?? defaultPort,
+      user: c.username ?? "",
+      password: secretRef(secretEnv, "password", c.password ?? ""),
+      dbname: c.database ?? "",
+      schema: env.targetSchema,
+      threads: env.threads,
+      ...(c.ssl ? { sslmode: "require" } : {}),
+    };
+  };
+
+const ADAPTERS: Record<string, AdapterEntry> = {
+  postgresql: {
+    adapterPackage: "dbt-postgres",
+    renderTarget: postgresLike(5432),
+  },
+  "cloudsql-postgres": {
+    adapterPackage: "dbt-postgres",
+    renderTarget: postgresLike(5432),
+  },
+  redshift: {
+    adapterPackage: "dbt-redshift",
+    renderTarget: postgresLike(5439),
+  },
+  bigquery: {
+    adapterPackage: "dbt-bigquery",
+    renderTarget: (connection, env, secretEnv) => {
+      const c = connection.connection;
+      const serviceAccountJson = c.service_account_json ?? "";
+      let projectId = "";
+      try {
+        projectId =
+          (JSON.parse(serviceAccountJson) as { project_id?: string })
+            .project_id ?? "";
+      } catch {
+        // keyfile missing/invalid — dbt will surface a clear error
+      }
+      return {
+        type: "bigquery",
+        method: "service-account-json",
+        project: projectId,
+        dataset: env.targetSchema,
+        threads: env.threads,
+        keyfile_json: secretRef(
+          secretEnv,
+          "bq_keyfile_json",
+          serviceAccountJson,
+        ),
+      };
+    },
+  },
+  clickhouse: {
+    adapterPackage: "dbt-clickhouse",
+    renderTarget: (connection, env, secretEnv) => {
+      const c = connection.connection;
+      return {
+        type: "clickhouse",
+        host: c.host ?? "localhost",
+        port: c.port ?? 8443,
+        user: c.username ?? "default",
+        password: secretRef(secretEnv, "password", c.password ?? ""),
+        schema: env.targetSchema,
+        threads: env.threads,
+        secure: c.ssl !== false,
+      };
+    },
+  },
+  mysql: {
+    adapterPackage: "dbt-mysql",
+    renderTarget: (connection, env, secretEnv) => {
+      const c = connection.connection;
+      return {
+        type: "mysql",
+        server: c.host ?? "localhost",
+        port: c.port ?? 3306,
+        username: c.username ?? "",
+        password: secretRef(secretEnv, "password", c.password ?? ""),
+        // dbt-mysql has no schema/database split — the target schema is the
+        // database dbt builds into.
+        schema: env.targetSchema,
+        database: env.targetSchema,
+        threads: env.threads,
+      };
+    },
+  },
+  mssql: {
+    adapterPackage: "dbt-sqlserver",
+    renderTarget: (connection, env, secretEnv) => {
+      const c = connection.connection;
+      return {
+        type: "sqlserver",
+        driver: "ODBC Driver 18 for SQL Server",
+        server: c.host ?? "localhost",
+        port: c.port ?? 1433,
+        user: c.username ?? "",
+        password: secretRef(secretEnv, "password", c.password ?? ""),
+        database: c.database ?? "",
+        schema: env.targetSchema,
+        threads: env.threads,
+        trust_cert: true,
+      };
+    },
+  },
+};
+
+/** Connection types that can be used as dbt targets. */
+export const DBT_COMPATIBLE_CONNECTION_TYPES = Object.keys(ADAPTERS);
+
+export function isDbtCompatibleConnectionType(type: string): boolean {
+  return type in ADAPTERS;
+}
+
+export function getDbtAdapterPackage(type: string): string | undefined {
+  return ADAPTERS[type]?.adapterPackage;
+}
+
+/**
+ * Render profiles.yml + secret env for a project environment. The caller is
+ * responsible for fetching + decrypting the connection within the workspace.
+ */
+export function renderDbtProfile(
+  connection: IDatabaseConnection,
+  environment: IDbtEnvironment,
+): RenderedProfile {
+  const adapter = ADAPTERS[connection.type];
+  if (!adapter) {
+    throw new Error(
+      `Connection type "${connection.type}" is not dbt-compatible. ` +
+        `Supported: ${DBT_COMPATIBLE_CONNECTION_TYPES.join(", ")}`,
+    );
+  }
+
+  const secretEnv: Record<string, string> = {};
+  const target = adapter.renderTarget(connection, environment, secretEnv);
+
+  const profile = {
+    [DBT_PROFILE_NAME]: {
+      target: environment.name,
+      outputs: {
+        [environment.name]: target,
+      },
+    },
+  };
+
+  return {
+    // js-yaml quotes the {{ env_var(...) }} strings, which dbt parses fine.
+    profilesYml: yamlDump(profile, { lineWidth: 200 }),
+    secretEnv,
+    adapterPackage: adapter.adapterPackage,
+  };
+}

--- a/api/src/dbt/commands.test.ts
+++ b/api/src/dbt/commands.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  DbtCommandValidationError,
+  parseDbtCommand,
+  parseDbtCommands,
+} from "./commands";
+
+describe("parseDbtCommand", () => {
+  it("accepts plain subcommands", () => {
+    expect(parseDbtCommand("run").argv).toEqual(["run"]);
+    expect(parseDbtCommand("build").subcommand).toBe("build");
+    expect(parseDbtCommand("deps").argv).toEqual(["deps"]);
+    expect(parseDbtCommand("retry").argv).toEqual(["retry"]);
+  });
+
+  it("accepts selector flags including tag and graph operators", () => {
+    expect(parseDbtCommand("build --select tag:nightly").argv).toEqual([
+      "build",
+      "--select",
+      "tag:nightly",
+    ]);
+    expect(parseDbtCommand("run --select +my_model+").argv).toEqual([
+      "run",
+      "--select",
+      "+my_model+",
+    ]);
+    expect(
+      parseDbtCommand("run --select stg_orders --exclude stg_users").argv,
+    ).toEqual(["run", "--select", "stg_orders", "--exclude", "stg_users"]);
+  });
+
+  it("accepts allowed boolean flags", () => {
+    expect(parseDbtCommand("build --full-refresh --fail-fast").argv).toEqual([
+      "build",
+      "--full-refresh",
+      "--fail-fast",
+    ]);
+  });
+
+  it("gates `source` to freshness and `docs` to generate", () => {
+    expect(parseDbtCommand("source freshness").argv).toEqual([
+      "source",
+      "freshness",
+    ]);
+    expect(parseDbtCommand("docs generate").argv).toEqual(["docs", "generate"]);
+    expect(() => parseDbtCommand("source")).toThrow(DbtCommandValidationError);
+    expect(() => parseDbtCommand("docs serve")).toThrow(
+      DbtCommandValidationError,
+    );
+  });
+
+  it("rejects unknown subcommands", () => {
+    expect(() => parseDbtCommand("run-operation foo")).toThrow(
+      DbtCommandValidationError,
+    );
+    expect(() => parseDbtCommand("clean")).toThrow(DbtCommandValidationError);
+  });
+
+  it("rejects attempts to override profile/project dirs", () => {
+    expect(() => parseDbtCommand("run --profiles-dir /etc")).toThrow(
+      DbtCommandValidationError,
+    );
+    expect(() => parseDbtCommand("run --project-dir /tmp")).toThrow(
+      DbtCommandValidationError,
+    );
+  });
+
+  it("rejects bare node tokens (selection must use --select)", () => {
+    expect(() => parseDbtCommand("run my_model")).toThrow(
+      DbtCommandValidationError,
+    );
+  });
+
+  it("rejects value flags missing their value", () => {
+    expect(() => parseDbtCommand("run --select")).toThrow(
+      DbtCommandValidationError,
+    );
+    expect(() => parseDbtCommand("run --select --full-refresh")).toThrow(
+      DbtCommandValidationError,
+    );
+  });
+
+  it("rejects empty commands", () => {
+    expect(() => parseDbtCommand("")).toThrow(DbtCommandValidationError);
+    expect(() => parseDbtCommands([])).toThrow(DbtCommandValidationError);
+  });
+});

--- a/api/src/dbt/commands.test.ts
+++ b/api/src/dbt/commands.test.ts
@@ -29,6 +29,16 @@ describe("parseDbtCommand", () => {
     ).toEqual(["run", "--select", "stg_orders", "--exclude", "stg_users"]);
   });
 
+  it("accepts `show` with --select and --limit (preview tool)", () => {
+    expect(parseDbtCommand("show --select stg_orders --limit 5").argv).toEqual([
+      "show",
+      "--select",
+      "stg_orders",
+      "--limit",
+      "5",
+    ]);
+  });
+
   it("accepts allowed boolean flags", () => {
     expect(parseDbtCommand("build --full-refresh --fail-fast").argv).toEqual([
       "build",

--- a/api/src/dbt/commands.ts
+++ b/api/src/dbt/commands.ts
@@ -20,6 +20,7 @@ const ALLOWED_SUBCOMMANDS = new Set([
   "docs",
   "deps",
   "retry",
+  "show",
 ]);
 
 /** Flags that take a value (the next token is consumed as the value). */
@@ -30,6 +31,8 @@ const VALUE_FLAGS = new Set([
   "--selector",
   "--threads",
   "--vars",
+  "--limit",
+  "--output",
 ]);
 
 /** Boolean flags. */

--- a/api/src/dbt/commands.ts
+++ b/api/src/dbt/commands.ts
@@ -18,6 +18,8 @@ const ALLOWED_SUBCOMMANDS = new Set([
   "parse",
   "source",
   "docs",
+  "deps",
+  "retry",
 ]);
 
 /** Flags that take a value (the next token is consumed as the value). */

--- a/api/src/dbt/commands.ts
+++ b/api/src/dbt/commands.ts
@@ -1,0 +1,131 @@
+/**
+ * dbt command validation.
+ *
+ * Job/run commands are stored as plain strings ("build --select staging").
+ * Before anything reaches the subprocess they are tokenized and validated
+ * against an allowlist of subcommands and flags, so a stored job can never
+ * smuggle --profiles-dir / --project-dir / arbitrary CLI surface into the
+ * runner.
+ */
+
+const ALLOWED_SUBCOMMANDS = new Set([
+  "run",
+  "build",
+  "test",
+  "seed",
+  "snapshot",
+  "compile",
+  "parse",
+  "source",
+  "docs",
+]);
+
+/** Flags that take a value (the next token is consumed as the value). */
+const VALUE_FLAGS = new Set([
+  "--select",
+  "-s",
+  "--exclude",
+  "--selector",
+  "--threads",
+  "--vars",
+]);
+
+/** Boolean flags. */
+const BOOLEAN_FLAGS = new Set([
+  "--full-refresh",
+  "--fail-fast",
+  "--store-failures",
+  "--empty",
+  "--favor-state",
+  "--indirect-selection",
+]);
+
+export interface ParsedDbtCommand {
+  /** argv tokens, e.g. ["run", "--select", "stg_orders"] */
+  argv: string[];
+  /** The dbt subcommand ("run", "build", ...). */
+  subcommand: string;
+}
+
+export class DbtCommandValidationError extends Error {}
+
+function tokenize(command: string): string[] {
+  return command
+    .trim()
+    .split(/\s+/)
+    .filter(token => token.length > 0);
+}
+
+/**
+ * Validate one stored command string. Throws DbtCommandValidationError with a
+ * human-readable message when the command is not allowed.
+ */
+export function parseDbtCommand(command: string): ParsedDbtCommand {
+  const tokens = tokenize(command);
+  if (tokens.length === 0) {
+    throw new DbtCommandValidationError("Empty dbt command");
+  }
+
+  const subcommand = tokens[0];
+  if (!ALLOWED_SUBCOMMANDS.has(subcommand)) {
+    throw new DbtCommandValidationError(
+      `dbt subcommand "${subcommand}" is not allowed. Allowed: ${[...ALLOWED_SUBCOMMANDS].join(", ")}`,
+    );
+  }
+
+  let rest = tokens.slice(1);
+  if (subcommand === "source") {
+    if (rest[0] !== "freshness") {
+      throw new DbtCommandValidationError(
+        'Only "source freshness" is supported',
+      );
+    }
+    rest = rest.slice(1);
+  }
+  if (subcommand === "docs") {
+    if (rest[0] !== "generate") {
+      throw new DbtCommandValidationError('Only "docs generate" is supported');
+    }
+    rest = rest.slice(1);
+  }
+
+  for (let i = 0; i < rest.length; i++) {
+    const token = rest[i];
+    if (token.startsWith("-")) {
+      if (VALUE_FLAGS.has(token)) {
+        const value = rest[i + 1];
+        if (value === undefined || value.startsWith("-")) {
+          throw new DbtCommandValidationError(`Flag ${token} requires a value`);
+        }
+        i++;
+        continue;
+      }
+      if (BOOLEAN_FLAGS.has(token)) continue;
+      throw new DbtCommandValidationError(
+        `Flag "${token}" is not allowed in dbt commands`,
+      );
+    }
+    // Bare selector token (e.g. "dbt run my_model" style) — reject so all
+    // selections go through --select explicitly.
+    throw new DbtCommandValidationError(
+      `Unexpected token "${token}" — use --select for node selection`,
+    );
+  }
+
+  const argv =
+    subcommand === "source"
+      ? ["source", "freshness", ...rest]
+      : subcommand === "docs"
+        ? ["docs", "generate", ...rest]
+        : [subcommand, ...rest];
+
+  return { argv, subcommand };
+}
+
+/** Validate a job's command list; returns parsed commands or throws. */
+export function parseDbtCommands(commands: string[]): ParsedDbtCommand[] {
+  if (commands.length === 0) {
+    throw new DbtCommandValidationError("At least one dbt command is required");
+  }
+  return commands.map(parseDbtCommand);
+}

--- a/api/src/dbt/dbt-bin.ts
+++ b/api/src/dbt/dbt-bin.ts
@@ -1,0 +1,83 @@
+/**
+ * dbt binary resolution.
+ *
+ * Order:
+ *   1. DBT_VENV_BIN env (prod — Dockerfile bakes a pinned venv at /opt/dbt)
+ *   2. `uvx` dev fallback: runs dbt-core pinned with the adapter package
+ *      injected (`uvx --from dbt-core==<v> --with <adapter> dbt ...`)
+ *   3. Clear error telling the operator what to install.
+ */
+
+import { existsSync } from "fs";
+import { spawnSync } from "child_process";
+
+export const DEFAULT_DBT_CORE_VERSION = "1.9.10";
+
+export interface ResolvedDbtBin {
+  /** Executable to spawn. */
+  bin: string;
+  /** Args to prepend before the dbt subcommand argv. */
+  prefixArgs: string[];
+}
+
+let cachedUvxAvailable: boolean | null = null;
+
+function isUvxAvailable(): boolean {
+  if (cachedUvxAvailable !== null) return cachedUvxAvailable;
+  try {
+    const result = spawnSync("uvx", ["--version"], { timeout: 10_000 });
+    cachedUvxAvailable = result.status === 0;
+  } catch {
+    cachedUvxAvailable = false;
+  }
+  return cachedUvxAvailable;
+}
+
+/**
+ * Resolve how to invoke dbt for a given adapter package.
+ * @param adapterPackage e.g. "dbt-postgres"
+ * @param dbtVersion pinned dbt-core minor/patch, e.g. "1.9" or "1.9.4"
+ */
+export function resolveDbtBin(
+  adapterPackage: string,
+  dbtVersion?: string,
+): ResolvedDbtBin {
+  // dbt-mysql lags upstream (dbt-core ~=1.7) so it lives in its own venv.
+  const venvBin =
+    adapterPackage === "dbt-mysql"
+      ? process.env.DBT_MYSQL_VENV_BIN
+      : process.env.DBT_VENV_BIN;
+  if (venvBin) {
+    if (!existsSync(venvBin)) {
+      throw new Error(
+        `dbt venv binary "${venvBin}" does not exist (check DBT_VENV_BIN / DBT_MYSQL_VENV_BIN)`,
+      );
+    }
+    return { bin: venvBin, prefixArgs: [] };
+  }
+
+  if (isUvxAvailable()) {
+    const coreVersion =
+      adapterPackage === "dbt-mysql"
+        ? "1.7.19"
+        : dbtVersion && dbtVersion.split(".").length >= 3
+          ? dbtVersion
+          : DEFAULT_DBT_CORE_VERSION;
+    return {
+      bin: "uvx",
+      prefixArgs: [
+        "--from",
+        `dbt-core==${coreVersion}`,
+        "--with",
+        adapterPackage,
+        "dbt",
+      ],
+    };
+  }
+
+  throw new Error(
+    "No dbt binary available. Set DBT_VENV_BIN to a dbt executable " +
+      "(production image bakes one at /opt/dbt/bin/dbt) or install uv " +
+      "(https://docs.astral.sh/uv/) so the runner can use `uvx` locally.",
+  );
+}

--- a/api/src/dbt/dbt-project.service.ts
+++ b/api/src/dbt/dbt-project.service.ts
@@ -129,6 +129,11 @@ export async function runAdhocDbtCommand(params: {
   command: string;
   /** Used to extract compiled SQL from the manifest after compile. */
   select?: string;
+  /**
+   * Prod manifest.json for Slim CI. When set, the command runs with
+   * `--defer --state <dir>` so unselected refs resolve to the prod build.
+   */
+  deferState?: Buffer;
   timeoutMs?: number;
   signal?: AbortSignal;
 }): Promise<AdhocDbtResult> {
@@ -144,6 +149,7 @@ export async function runAdhocDbtCommand(params: {
     profile: snapshot.profile,
     commands: [parsed],
     dbtVersion: snapshot.project.dbtVersion,
+    deferState: params.deferState,
     commandTimeoutMs: params.timeoutMs ?? 5 * 60 * 1000,
     signal: params.signal,
   });

--- a/api/src/dbt/dbt-project.service.ts
+++ b/api/src/dbt/dbt-project.service.ts
@@ -1,0 +1,160 @@
+/**
+ * dbt project snapshot loading + ad-hoc execution helpers.
+ *
+ * Shared by the routes (compile / run-select endpoints), the Inngest
+ * executor, and the agent's server-side verification tools so they all go
+ * through identical validation: workspace scoping, environment resolution,
+ * connection decryption, and command allowlisting.
+ */
+
+import { Types } from "mongoose";
+import {
+  DatabaseConnection,
+  DbtFile,
+  DbtProject,
+  type IDatabaseConnection,
+  type IDbtEnvironment,
+  type IDbtProject,
+} from "../database/workspace-schema";
+import { renderDbtProfile, type RenderedProfile } from "./adapter-map";
+import { parseDbtCommand, type ParsedDbtCommand } from "./commands";
+import {
+  parseStepResults,
+  runDbt,
+  type DbtLogLine,
+  type DbtRunResult,
+} from "./runner.service";
+
+export interface DbtProjectSnapshot {
+  project: IDbtProject;
+  environment: IDbtEnvironment;
+  files: Array<{ path: string; content: string }>;
+  profile: RenderedProfile;
+}
+
+export async function loadDbtProjectSnapshot(params: {
+  workspaceId: string;
+  projectId: string;
+  environmentName?: string;
+}): Promise<DbtProjectSnapshot> {
+  const project = await DbtProject.findOne({
+    _id: new Types.ObjectId(params.projectId),
+    workspaceId: new Types.ObjectId(params.workspaceId),
+  });
+  if (!project) {
+    throw new Error("dbt project not found");
+  }
+
+  const envName = params.environmentName ?? project.defaultEnvironment;
+  const environment = project.environments.find(env => env.name === envName);
+  if (!environment) {
+    throw new Error(
+      `Environment "${envName}" not found on project "${project.name}"`,
+    );
+  }
+
+  const connectionDoc = await DatabaseConnection.findOne({
+    _id: environment.connectionId,
+    workspaceId: project.workspaceId,
+  });
+  if (!connectionDoc) {
+    throw new Error(
+      `Connection for environment "${envName}" not found or access denied`,
+    );
+  }
+  const connection = connectionDoc.toObject({
+    getters: true,
+  }) as IDatabaseConnection;
+
+  const profile = renderDbtProfile(connection, environment);
+
+  const fileDocs = await DbtFile.find({
+    projectId: project._id,
+    is_deleted: { $ne: true },
+  })
+    .select("path content")
+    .lean();
+
+  const files = fileDocs.map(file => ({
+    path: file.path,
+    content: file.content ?? "",
+  }));
+
+  // Environment vars: merge into every command via a vars file would change
+  // semantics; instead they're applied by callers via --vars when present.
+
+  return { project, environment, files, profile };
+}
+
+export interface AdhocDbtResult {
+  success: boolean;
+  exitCode: number;
+  logs: DbtLogLine[];
+  stepResults: ReturnType<typeof parseStepResults>;
+  compiledSql?: string;
+  raw: DbtRunResult;
+}
+
+function findCompiledSql(
+  raw: DbtRunResult,
+  select: string | undefined,
+): string | undefined {
+  if (!select || !raw.artifacts.manifest) return undefined;
+  try {
+    const manifest = JSON.parse(raw.artifacts.manifest.toString("utf8")) as {
+      nodes?: Record<
+        string,
+        { name?: string; compiled_code?: string; compiled_sql?: string }
+      >;
+    };
+    for (const node of Object.values(manifest.nodes ?? {})) {
+      if (node.name === select) {
+        return node.compiled_code ?? node.compiled_sql;
+      }
+    }
+  } catch {
+    // ignore parse failures — compiled SQL is best-effort
+  }
+  return undefined;
+}
+
+/**
+ * Run an ad-hoc dbt command (compile / parse / build --select <node>) against
+ * a project environment. Synchronous path used by IDE buttons + agent tools.
+ */
+export async function runAdhocDbtCommand(params: {
+  workspaceId: string;
+  projectId: string;
+  environmentName?: string;
+  command: string;
+  /** Used to extract compiled SQL from the manifest after compile. */
+  select?: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}): Promise<AdhocDbtResult> {
+  const parsed: ParsedDbtCommand = parseDbtCommand(params.command);
+  const snapshot = await loadDbtProjectSnapshot({
+    workspaceId: params.workspaceId,
+    projectId: params.projectId,
+    environmentName: params.environmentName,
+  });
+
+  const raw = await runDbt({
+    files: snapshot.files,
+    profile: snapshot.profile,
+    commands: [parsed],
+    dbtVersion: snapshot.project.dbtVersion,
+    commandTimeoutMs: params.timeoutMs ?? 5 * 60 * 1000,
+    signal: params.signal,
+  });
+
+  const commandResult = raw.commandResults[0];
+  return {
+    success: raw.success,
+    exitCode: commandResult?.exitCode ?? 1,
+    logs: commandResult?.logLines ?? [],
+    stepResults: parseStepResults(commandResult?.runResults),
+    compiledSql: findCompiledSql(raw, params.select),
+    raw,
+  };
+}

--- a/api/src/dbt/dbt-run.service.ts
+++ b/api/src/dbt/dbt-run.service.ts
@@ -23,9 +23,24 @@ export async function triggerDbtRun(params: {
   commands: string[];
   trigger: "schedule" | "manual" | "agent";
   triggeredBy: string;
+  /**
+   * When set (scheduled runs), collapse onto an already-active run for the
+   * same job instead of stacking a new one — the executor only runs one run
+   * per project at a time, so overlapping schedule ticks would otherwise queue
+   * up redundant work (dbt Cloud skips overlapping scheduled runs likewise).
+   */
+  skipIfActive?: boolean;
 }): Promise<IDbtRun> {
   // Validate before persisting anything — bad commands never reach a run doc.
   parseDbtCommands(params.commands);
+
+  if (params.skipIfActive && params.jobId) {
+    const active = await DbtRun.findOne({
+      jobId: new Types.ObjectId(params.jobId),
+      status: { $in: ["queued", "running"] },
+    }).sort({ createdAt: -1 });
+    if (active) return active;
+  }
 
   const run = await DbtRun.create({
     workspaceId: new Types.ObjectId(params.workspaceId),
@@ -65,6 +80,8 @@ export async function triggerDbtJobRun(params: {
     commands: params.job.commands,
     trigger: params.trigger,
     triggeredBy: params.triggeredBy,
+    // Scheduled ticks must not stack behind a still-running run.
+    skipIfActive: params.trigger === "schedule",
   });
 }
 

--- a/api/src/dbt/dbt-run.service.ts
+++ b/api/src/dbt/dbt-run.service.ts
@@ -85,6 +85,54 @@ export async function triggerDbtJobRun(params: {
   });
 }
 
+/**
+ * Retry a failed run from its point of failure. Creates a new run that runs
+ * `dbt retry`, seeding the source run's run_results.json into target/ so dbt
+ * resumes at the failed/skipped nodes. Requires the source run to have a
+ * persisted run_results.json artifact.
+ */
+export async function triggerDbtRunRetry(params: {
+  workspaceId: string;
+  runId: string;
+  triggeredBy: string;
+}): Promise<IDbtRun | null> {
+  const source = await DbtRun.findOne({
+    _id: new Types.ObjectId(params.runId),
+    workspaceId: new Types.ObjectId(params.workspaceId),
+  }).lean();
+  if (!source) return null;
+  if (source.status !== "error") return null;
+  if (!source.artifactKeys?.runResults) return null;
+
+  const run = await DbtRun.create({
+    workspaceId: source.workspaceId,
+    projectId: source.projectId,
+    jobId: source.jobId,
+    environment: source.environment,
+    commands: ["retry"],
+    status: "queued",
+    trigger: "manual",
+    triggeredBy: params.triggeredBy,
+    retryOfRunId: source._id,
+    restoreArtifactKeys: {
+      runResults: source.artifactKeys.runResults,
+      manifest: source.artifactKeys.manifest,
+    },
+  });
+
+  await inngest.send({
+    name: "dbt/run.requested",
+    data: {
+      workspaceId: params.workspaceId,
+      projectId: source.projectId.toString(),
+      runId: run._id.toString(),
+      jobId: source.jobId?.toString(),
+    },
+  });
+
+  return run;
+}
+
 export async function requestDbtRunCancel(params: {
   workspaceId: string;
   runId: string;

--- a/api/src/dbt/dbt-run.service.ts
+++ b/api/src/dbt/dbt-run.service.ts
@@ -1,0 +1,116 @@
+/**
+ * dbt run lifecycle helpers shared by the routes, the Inngest scheduler,
+ * and the agent's server tools. The trigger path always creates the run
+ * document first (so callers get a runId immediately) and then hands
+ * execution to the Inngest executor via "dbt/run.requested".
+ */
+
+import { Types } from "mongoose";
+import { inngest } from "../inngest/client";
+import {
+  DbtJob,
+  DbtRun,
+  type IDbtJob,
+  type IDbtRun,
+} from "../database/workspace-schema";
+import { parseDbtCommands } from "./commands";
+
+export async function triggerDbtRun(params: {
+  workspaceId: string;
+  projectId: string;
+  jobId?: string;
+  environment: string;
+  commands: string[];
+  trigger: "schedule" | "manual" | "agent";
+  triggeredBy: string;
+}): Promise<IDbtRun> {
+  // Validate before persisting anything — bad commands never reach a run doc.
+  parseDbtCommands(params.commands);
+
+  const run = await DbtRun.create({
+    workspaceId: new Types.ObjectId(params.workspaceId),
+    projectId: new Types.ObjectId(params.projectId),
+    jobId: params.jobId ? new Types.ObjectId(params.jobId) : undefined,
+    environment: params.environment,
+    commands: params.commands,
+    status: "queued",
+    trigger: params.trigger,
+    triggeredBy: params.triggeredBy,
+  });
+
+  await inngest.send({
+    name: "dbt/run.requested",
+    data: {
+      workspaceId: params.workspaceId,
+      projectId: params.projectId,
+      runId: run._id.toString(),
+      jobId: params.jobId,
+    },
+  });
+
+  return run;
+}
+
+export async function triggerDbtJobRun(params: {
+  workspaceId: string;
+  job: IDbtJob;
+  trigger: "schedule" | "manual" | "agent";
+  triggeredBy: string;
+}): Promise<IDbtRun> {
+  return triggerDbtRun({
+    workspaceId: params.workspaceId,
+    projectId: params.job.projectId.toString(),
+    jobId: params.job._id.toString(),
+    environment: params.job.environment,
+    commands: params.job.commands,
+    trigger: params.trigger,
+    triggeredBy: params.triggeredBy,
+  });
+}
+
+export async function requestDbtRunCancel(params: {
+  workspaceId: string;
+  runId: string;
+}): Promise<boolean> {
+  const run = await DbtRun.findOne({
+    _id: new Types.ObjectId(params.runId),
+    workspaceId: new Types.ObjectId(params.workspaceId),
+  });
+  if (!run) return false;
+  if (run.status !== "queued" && run.status !== "running") return false;
+
+  // cancelOn match in the executor; queued runs are finalized directly since
+  // the executor may not have started yet.
+  await inngest.send({
+    name: "dbt/run.cancel",
+    data: { runId: params.runId },
+  });
+
+  await DbtRun.updateOne(
+    { _id: run._id, status: "queued" },
+    { $set: { status: "cancelled", completedAt: new Date() } },
+  );
+  return true;
+}
+
+/** Recompute a job's next scheduled run after a schedule edit. */
+export async function applyJobScheduleChange(job: IDbtJob): Promise<void> {
+  if (job.schedule?.cron && job.enabled) {
+    const { getNextScheduledConsoleRunAt } = await import(
+      "../services/scheduled-query-schedule.service"
+    );
+    const nextAt = getNextScheduledConsoleRunAt({
+      cron: job.schedule.cron,
+      timezone: job.schedule.timezone || "UTC",
+    });
+    await DbtJob.updateOne(
+      { _id: job._id },
+      { $set: { "scheduledRun.nextAt": nextAt } },
+    );
+  } else {
+    await DbtJob.updateOne(
+      { _id: job._id },
+      { $unset: { "scheduledRun.nextAt": "" } },
+    );
+  }
+}

--- a/api/src/dbt/runner.service.ts
+++ b/api/src/dbt/runner.service.ts
@@ -64,6 +64,23 @@ export interface DbtRunResult {
   };
 }
 
+/**
+ * True when the project declares at least one dbt package (ignoring the
+ * commented scaffold). Drives whether we run `dbt deps` before commands.
+ */
+function projectHasPackages(
+  files: Array<{ path: string; content: string }>,
+): boolean {
+  const pkg = files.find(
+    file => file.path === "packages.yml" || file.path === "dependencies.yml",
+  );
+  if (!pkg) return false;
+  return pkg.content
+    .split("\n")
+    .map(line => line.trim())
+    .some(line => line.length > 0 && !line.startsWith("#"));
+}
+
 function ensureSafeRelativePath(path: string): string {
   const normalized = normalize(path).replace(/\\/g, "/");
   if (
@@ -222,6 +239,46 @@ export async function runDbt(request: DbtRunRequest): Promise<DbtRunResult> {
       DBT_SEND_ANONYMOUS_USAGE_STATS: "false",
       HOME: projectDir,
     };
+
+    // Install packages first when declared. The executor runs one runDbt per
+    // command, each in its own temp dir, so deps must be (re)installed here
+    // before any command that depends on package macros can compile.
+    if (projectHasPackages(request.files)) {
+      const depsLogLines: DbtLogLine[] = [];
+      const onDepsLog = (line: DbtLogLine) => {
+        depsLogLines.push(line);
+        request.onLog?.(line);
+      };
+      onDepsLog({ ts: new Date(), level: "info", line: "$ dbt deps" });
+      const depsExit = await execDbtCommand({
+        bin: resolved.bin,
+        args: [
+          ...resolved.prefixArgs,
+          "deps",
+          "--profiles-dir",
+          projectDir,
+          "--project-dir",
+          projectDir,
+          "--log-format",
+          "json",
+          "--no-use-colors",
+        ],
+        cwd: projectDir,
+        env: childEnv,
+        timeoutMs: request.commandTimeoutMs ?? 9 * 60 * 1000,
+        signal: request.signal,
+        onLog: onDepsLog,
+      });
+      if (depsExit !== 0) {
+        commandResults.push({
+          command: "deps",
+          exitCode: depsExit,
+          logLines: depsLogLines,
+          runResults: undefined,
+        });
+        return { success: false, commandResults, artifacts };
+      }
+    }
 
     let success = true;
     for (const command of request.commands) {

--- a/api/src/dbt/runner.service.ts
+++ b/api/src/dbt/runner.service.ts
@@ -40,6 +40,12 @@ export interface DbtRunRequest {
     runResults?: Buffer;
     manifest?: Buffer;
   };
+  /**
+   * Prod manifest.json for Slim CI. When set, commands run with
+   * `--defer --state <dir>` so unselected refs resolve to prod and
+   * `--select state:modified+` only builds what changed.
+   */
+  deferState?: Buffer;
   signal?: AbortSignal;
   onLog?: (line: DbtLogLine) => void;
 }
@@ -258,6 +264,14 @@ export async function runDbt(request: DbtRunRequest): Promise<DbtRunResult> {
       }
     }
 
+    // Slim CI: stage the prod manifest in a state dir for `--defer --state`.
+    let stateDir: string | undefined;
+    if (request.deferState) {
+      stateDir = join(projectDir, "state");
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, "manifest.json"), request.deferState);
+    }
+
     const resolved = resolveDbtBin(
       request.profile.adapterPackage,
       request.dbtVersion,
@@ -323,9 +337,24 @@ export async function runDbt(request: DbtRunRequest): Promise<DbtRunResult> {
         request.onLog?.(line);
       };
 
+      // --defer/--state only apply to node-executing/compiling subcommands.
+      const stateAware = new Set([
+        "run",
+        "build",
+        "test",
+        "compile",
+        "seed",
+        "snapshot",
+      ]);
+      const deferArgs =
+        stateDir && stateAware.has(command.subcommand)
+          ? ["--defer", "--state", stateDir]
+          : [];
+
       const args = [
         ...resolved.prefixArgs,
         ...command.argv,
+        ...deferArgs,
         "--profiles-dir",
         projectDir,
         "--project-dir",

--- a/api/src/dbt/runner.service.ts
+++ b/api/src/dbt/runner.service.ts
@@ -245,6 +245,21 @@ export async function runDbt(request: DbtRunRequest): Promise<DbtRunResult> {
       "utf8",
     );
 
+    // Materialize credential files (e.g. BigQuery service-account JSON) with
+    // restrictive perms and export their absolute paths so the profile's
+    // env_var('...') keyfile references resolve. Contents are never logged.
+    const keyfileEnv: Record<string, string> = {};
+    for (const keyfile of request.profile.keyfiles ?? []) {
+      const safePath = ensureSafeRelativePath(keyfile.filename);
+      const absolute = join(projectDir, ...safePath.split("/"));
+      await mkdir(dirname(absolute), { recursive: true });
+      await writeFile(absolute, keyfile.content, {
+        encoding: "utf8",
+        mode: 0o600,
+      });
+      keyfileEnv[keyfile.envVar] = absolute;
+    }
+
     // Seed prior artifacts into target/ for `dbt retry` (run_results.json is
     // what dbt reads to resume at the failed/skipped nodes).
     if (request.restoreTarget) {
@@ -280,6 +295,7 @@ export async function runDbt(request: DbtRunRequest): Promise<DbtRunResult> {
     const childEnv: Record<string, string> = {
       ...(process.env as Record<string, string>),
       ...request.profile.secretEnv,
+      ...keyfileEnv,
       DBT_SEND_ANONYMOUS_USAGE_STATS: "false",
       HOME: projectDir,
     };

--- a/api/src/dbt/runner.service.ts
+++ b/api/src/dbt/runner.service.ts
@@ -1,0 +1,329 @@
+/**
+ * dbt runner — materializes a project snapshot to a temp dir and executes
+ * dbt commands as a subprocess with JSON log streaming.
+ *
+ * Security: credentials are passed only through the child-process env
+ * (profiles.yml references {{ env_var(...) }}); file paths are validated
+ * against traversal; commands are pre-validated by commands.ts.
+ */
+
+import { spawn } from "child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { dirname, join, normalize, sep } from "path";
+import { loggers } from "../logging";
+import type { ParsedDbtCommand } from "./commands";
+import type { RenderedProfile } from "./adapter-map";
+import { resolveDbtBin } from "./dbt-bin";
+
+const logger = loggers.app();
+
+export interface DbtLogLine {
+  ts: Date;
+  level: string;
+  line: string;
+}
+
+export interface DbtRunRequest {
+  files: Array<{ path: string; content: string }>;
+  profile: RenderedProfile;
+  commands: ParsedDbtCommand[];
+  dbtVersion?: string;
+  /** Per-command timeout (ms). Defaults to 9 minutes (Cloud Run is 600s). */
+  commandTimeoutMs?: number;
+  signal?: AbortSignal;
+  onLog?: (line: DbtLogLine) => void;
+}
+
+export interface RunResultsArtifact {
+  results: Array<{
+    unique_id: string;
+    status: string;
+    execution_time: number;
+    message?: string | null;
+    adapter_response?: { rows_affected?: number };
+  }>;
+  elapsed_time?: number;
+}
+
+export interface DbtCommandResult {
+  command: string;
+  exitCode: number;
+  logLines: DbtLogLine[];
+  runResults?: RunResultsArtifact;
+}
+
+export interface DbtRunResult {
+  success: boolean;
+  commandResults: DbtCommandResult[];
+  /** Raw artifact contents collected from target/ after the last command. */
+  artifacts: {
+    manifest?: Buffer;
+    runResults?: Buffer;
+    catalog?: Buffer;
+  };
+}
+
+function ensureSafeRelativePath(path: string): string {
+  const normalized = normalize(path).replace(/\\/g, "/");
+  if (
+    !normalized ||
+    normalized.startsWith("/") ||
+    normalized.startsWith("..") ||
+    normalized.split("/").includes("..")
+  ) {
+    throw new Error(`Invalid dbt file path: ${path}`);
+  }
+  return normalized;
+}
+
+interface DbtJsonLogEvent {
+  info?: {
+    ts?: string;
+    level?: string;
+    msg?: string;
+  };
+}
+
+function parseLogLine(raw: string): DbtLogLine {
+  try {
+    const event = JSON.parse(raw) as DbtJsonLogEvent;
+    if (event.info) {
+      return {
+        ts: event.info.ts ? new Date(event.info.ts) : new Date(),
+        level: event.info.level ?? "info",
+        line: event.info.msg ?? raw,
+      };
+    }
+  } catch {
+    // Non-JSON output (e.g. tracebacks) — keep the raw line.
+  }
+  return { ts: new Date(), level: "info", line: raw };
+}
+
+async function readArtifact(
+  projectDir: string,
+  name: string,
+): Promise<Buffer | undefined> {
+  try {
+    return await readFile(join(projectDir, "target", name));
+  } catch {
+    return undefined;
+  }
+}
+
+function execDbtCommand(params: {
+  bin: string;
+  args: string[];
+  cwd: string;
+  env: Record<string, string>;
+  timeoutMs: number;
+  signal?: AbortSignal;
+  onLog: (line: DbtLogLine) => void;
+}): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(params.bin, params.args, {
+      cwd: params.cwd,
+      env: params.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdoutBuffer = "";
+    let settled = false;
+
+    const timeout = setTimeout(() => {
+      params.onLog({
+        ts: new Date(),
+        level: "error",
+        line: `Command timed out after ${Math.round(params.timeoutMs / 1000)}s — sending SIGTERM`,
+      });
+      child.kill("SIGTERM");
+    }, params.timeoutMs);
+
+    const onAbort = () => child.kill("SIGTERM");
+    params.signal?.addEventListener("abort", onAbort, { once: true });
+
+    const flushLines = (chunk: string, isStderr: boolean) => {
+      if (isStderr) {
+        for (const line of chunk.split("\n")) {
+          if (line.trim()) {
+            params.onLog({ ts: new Date(), level: "error", line });
+          }
+        }
+        return;
+      }
+      stdoutBuffer += chunk;
+      let newlineIdx = stdoutBuffer.indexOf("\n");
+      while (newlineIdx >= 0) {
+        const raw = stdoutBuffer.slice(0, newlineIdx).trim();
+        stdoutBuffer = stdoutBuffer.slice(newlineIdx + 1);
+        if (raw) params.onLog(parseLogLine(raw));
+        newlineIdx = stdoutBuffer.indexOf("\n");
+      }
+    };
+
+    child.stdout.on("data", (data: Buffer) =>
+      flushLines(data.toString("utf8"), false),
+    );
+    child.stderr.on("data", (data: Buffer) =>
+      flushLines(data.toString("utf8"), true),
+    );
+
+    child.on("error", error => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      params.signal?.removeEventListener("abort", onAbort);
+      reject(error);
+    });
+
+    child.on("close", code => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      params.signal?.removeEventListener("abort", onAbort);
+      if (stdoutBuffer.trim()) params.onLog(parseLogLine(stdoutBuffer.trim()));
+      resolve(code ?? 1);
+    });
+  });
+}
+
+/**
+ * Materialize project files + profiles.yml into a temp dir, run each
+ * pre-validated command in order (stopping at the first failure), collect
+ * target/ artifacts, and always clean up the temp dir.
+ */
+export async function runDbt(request: DbtRunRequest): Promise<DbtRunResult> {
+  const projectDir = await mkdtemp(join(tmpdir(), "mako-dbt-"));
+  const commandResults: DbtCommandResult[] = [];
+  const artifacts: DbtRunResult["artifacts"] = {};
+
+  try {
+    for (const file of request.files) {
+      const safePath = ensureSafeRelativePath(file.path);
+      const absolute = join(projectDir, ...safePath.split("/"));
+      await mkdir(dirname(absolute), { recursive: true });
+      await writeFile(absolute, file.content, "utf8");
+    }
+    await writeFile(
+      join(projectDir, "profiles.yml"),
+      request.profile.profilesYml,
+      "utf8",
+    );
+
+    const resolved = resolveDbtBin(
+      request.profile.adapterPackage,
+      request.dbtVersion,
+    );
+
+    const childEnv: Record<string, string> = {
+      ...(process.env as Record<string, string>),
+      ...request.profile.secretEnv,
+      DBT_SEND_ANONYMOUS_USAGE_STATS: "false",
+      HOME: projectDir,
+    };
+
+    let success = true;
+    for (const command of request.commands) {
+      if (request.signal?.aborted) {
+        success = false;
+        break;
+      }
+
+      const logLines: DbtLogLine[] = [];
+      const onLog = (line: DbtLogLine) => {
+        logLines.push(line);
+        request.onLog?.(line);
+      };
+
+      const args = [
+        ...resolved.prefixArgs,
+        ...command.argv,
+        "--profiles-dir",
+        projectDir,
+        "--project-dir",
+        projectDir,
+        "--profile",
+        "mako",
+        "--log-format",
+        "json",
+        "--no-use-colors",
+      ];
+
+      logger.info("Executing dbt command", {
+        subcommand: command.subcommand,
+        projectDir: projectDir.split(sep).pop(),
+      });
+
+      const exitCode = await execDbtCommand({
+        bin: resolved.bin,
+        args,
+        cwd: projectDir,
+        env: childEnv,
+        timeoutMs: request.commandTimeoutMs ?? 9 * 60 * 1000,
+        signal: request.signal,
+        onLog,
+      });
+
+      let runResults: RunResultsArtifact | undefined;
+      const runResultsRaw = await readArtifact(projectDir, "run_results.json");
+      if (runResultsRaw) {
+        try {
+          runResults = JSON.parse(
+            runResultsRaw.toString("utf8"),
+          ) as RunResultsArtifact;
+        } catch {
+          // corrupt artifact — ignore
+        }
+      }
+
+      commandResults.push({
+        command: command.argv.join(" "),
+        exitCode,
+        logLines,
+        runResults,
+      });
+
+      if (exitCode !== 0) {
+        success = false;
+        break;
+      }
+    }
+
+    artifacts.manifest = await readArtifact(projectDir, "manifest.json");
+    artifacts.runResults = await readArtifact(projectDir, "run_results.json");
+    artifacts.catalog = await readArtifact(projectDir, "catalog.json");
+
+    return { success, commandResults, artifacts };
+  } finally {
+    await rm(projectDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+/** Map a run_results.json artifact to the dbt_runs.stepResults shape. */
+export function parseStepResults(
+  runResults: RunResultsArtifact | undefined,
+): Array<{
+  uniqueId: string;
+  name: string;
+  resourceType: string;
+  status: string;
+  executionTimeMs: number;
+  rowsAffected?: number;
+  message?: string;
+}> {
+  if (!runResults?.results) return [];
+  return runResults.results.map(result => {
+    // unique_id format: "model.project_name.model_name" / "test.project.x.hash"
+    const parts = result.unique_id.split(".");
+    return {
+      uniqueId: result.unique_id,
+      name: parts[parts.length - 1] ?? result.unique_id,
+      resourceType: parts[0] ?? "model",
+      status: result.status,
+      executionTimeMs: Math.round((result.execution_time ?? 0) * 1000),
+      rowsAffected: result.adapter_response?.rows_affected,
+      message: result.message ?? undefined,
+    };
+  });
+}

--- a/api/src/dbt/runner.service.ts
+++ b/api/src/dbt/runner.service.ts
@@ -31,6 +31,15 @@ export interface DbtRunRequest {
   dbtVersion?: string;
   /** Per-command timeout (ms). Defaults to 9 minutes (Cloud Run is 600s). */
   commandTimeoutMs?: number;
+  /**
+   * Artifacts to seed into target/ before commands run. Used by retry-from-
+   * failure: `dbt retry` reads target/run_results.json to resume at the
+   * failed/skipped nodes.
+   */
+  restoreTarget?: {
+    runResults?: Buffer;
+    manifest?: Buffer;
+  };
   signal?: AbortSignal;
   onLog?: (line: DbtLogLine) => void;
 }
@@ -227,6 +236,25 @@ export async function runDbt(request: DbtRunRequest): Promise<DbtRunResult> {
       request.profile.profilesYml,
       "utf8",
     );
+
+    // Seed prior artifacts into target/ for `dbt retry` (run_results.json is
+    // what dbt reads to resume at the failed/skipped nodes).
+    if (request.restoreTarget) {
+      const targetDir = join(projectDir, "target");
+      await mkdir(targetDir, { recursive: true });
+      if (request.restoreTarget.runResults) {
+        await writeFile(
+          join(targetDir, "run_results.json"),
+          request.restoreTarget.runResults,
+        );
+      }
+      if (request.restoreTarget.manifest) {
+        await writeFile(
+          join(targetDir, "manifest.json"),
+          request.restoreTarget.manifest,
+        );
+      }
+    }
 
     const resolved = resolveDbtBin(
       request.profile.adapterPackage,

--- a/api/src/dbt/runner.service.ts
+++ b/api/src/dbt/runner.service.ts
@@ -70,6 +70,8 @@ export interface DbtRunResult {
     manifest?: Buffer;
     runResults?: Buffer;
     catalog?: Buffer;
+    /** Written by `dbt source freshness`. */
+    sources?: Buffer;
   };
 }
 
@@ -378,6 +380,7 @@ export async function runDbt(request: DbtRunRequest): Promise<DbtRunResult> {
     artifacts.manifest = await readArtifact(projectDir, "manifest.json");
     artifacts.runResults = await readArtifact(projectDir, "run_results.json");
     artifacts.catalog = await readArtifact(projectDir, "catalog.json");
+    artifacts.sources = await readArtifact(projectDir, "sources.json");
 
     return { success, commandResults, artifacts };
   } finally {
@@ -409,6 +412,55 @@ export function parseStepResults(
       executionTimeMs: Math.round((result.execution_time ?? 0) * 1000),
       rowsAffected: result.adapter_response?.rows_affected,
       message: result.message ?? undefined,
+    };
+  });
+}
+
+interface SourceFreshnessResult {
+  unique_id: string;
+  status: string;
+  max_loaded_at?: string;
+  snapshotted_at?: string;
+  max_loaded_at_time_ago_in_s?: number;
+  execution_time?: number;
+}
+
+/**
+ * Map a sources.json (`dbt source freshness`) artifact to the stepResults
+ * shape so source freshness surfaces in the same run-detail table as models.
+ */
+export function parseSourceFreshness(sources: Buffer | undefined): Array<{
+  uniqueId: string;
+  name: string;
+  resourceType: string;
+  status: string;
+  executionTimeMs: number;
+  message?: string;
+}> {
+  if (!sources) return [];
+  let parsed: { results?: SourceFreshnessResult[] };
+  try {
+    parsed = JSON.parse(sources.toString("utf8")) as {
+      results?: SourceFreshnessResult[];
+    };
+  } catch {
+    return [];
+  }
+  if (!parsed.results) return [];
+  return parsed.results.map(result => {
+    const parts = result.unique_id.split(".");
+    const ageSeconds = result.max_loaded_at_time_ago_in_s;
+    const ageLabel =
+      typeof ageSeconds === "number"
+        ? `loaded ${Math.round(ageSeconds / 60)}m ago`
+        : undefined;
+    return {
+      uniqueId: result.unique_id,
+      name: parts.slice(2).join(".") || result.unique_id,
+      resourceType: "source",
+      status: result.status,
+      executionTimeMs: Math.round((result.execution_time ?? 0) * 1000),
+      message: ageLabel,
     };
   });
 }

--- a/api/src/dbt/scaffold.ts
+++ b/api/src/dbt/scaffold.ts
@@ -1,0 +1,89 @@
+/**
+ * Starter scaffold seeded into dbt_files when a project is created.
+ * The dbt_project.yml lives in dbt_files like any other file so the agent
+ * and the IDE edit it through the same path.
+ */
+
+export const DBT_PROJECT_FILE = "dbt_project.yml";
+
+export function buildStarterScaffold(
+  projectName: string,
+): Array<{ path: string; content: string }> {
+  const safeName = projectName
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .replace(/^(\d)/, "p$1");
+  const dbtName = safeName || "mako_project";
+
+  return [
+    {
+      path: DBT_PROJECT_FILE,
+      content: `name: "${dbtName}"
+version: "1.0.0"
+profile: "mako"
+
+model-paths: ["models"]
+seed-paths: ["seeds"]
+test-paths: ["tests"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+target-path: "target"
+clean-targets:
+  - "target"
+  - "dbt_packages"
+
+models:
+  ${dbtName}:
+    staging:
+      +materialized: view
+    marts:
+      +materialized: table
+`,
+    },
+    {
+      path: "models/staging/.gitkeep",
+      content: "",
+    },
+    {
+      path: "models/marts/.gitkeep",
+      content: "",
+    },
+    {
+      path: "models/staging/schema.yml",
+      content: `version: 2
+
+# Declare sources here, then reference them in staging models with
+# {{ source('source_name', 'table_name') }}.
+#
+# sources:
+#   - name: raw
+#     schema: public
+#     tables:
+#       - name: orders
+#
+# models:
+#   - name: stg_orders
+#     columns:
+#       - name: order_id
+#         data_tests:
+#           - unique
+#           - not_null
+`,
+    },
+    {
+      path: "README.md",
+      content: `# ${projectName}
+
+A dbt project managed in Mako.
+
+- \`models/staging/\` — 1:1 source cleanup models (views)
+- \`models/marts/\` — business-facing models (tables)
+
+Use the dbt agent in chat to scaffold models, or edit files directly and
+use Compile / Run model from the editor.
+`,
+    },
+  ];
+}

--- a/api/src/dbt/scaffold.ts
+++ b/api/src/dbt/scaffold.ts
@@ -43,6 +43,16 @@ models:
 `,
     },
     {
+      path: "packages.yml",
+      content: `# Add dbt packages here, then they install automatically on the next run.
+# See https://hub.getdbt.com for available packages.
+#
+# packages:
+#   - package: dbt-labs/dbt_utils
+#     version: [">=1.1.0", "<2.0.0"]
+`,
+    },
+    {
       path: "models/staging/.gitkeep",
       content: "",
     },

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -11,6 +11,7 @@ import { realtimeRoutes } from "./routes/realtime";
 import { dataSourceRoutes } from "./routes/sources";
 import { customPromptRoutes } from "./routes/custom-prompt";
 import { skillsRoutes } from "./routes/skills";
+import { dbtRoutes } from "./routes/dbt.routes";
 import { chatsRoutes } from "./routes/chats";
 import { chatImagesRoutes } from "./routes/chat-images";
 import { agentRoutes } from "./routes/agent.routes";
@@ -175,6 +176,7 @@ app.route("/api/workspaces/:workspaceId/chats", chatsRoutes);
 app.route("/api/workspaces/:workspaceId/chat-images", chatImagesRoutes);
 app.route("/api/workspaces/:workspaceId/custom-prompt", customPromptRoutes);
 app.route("/api/workspaces/:workspaceId/skills", skillsRoutes);
+app.route("/api/workspaces/:workspaceId/dbt", dbtRoutes);
 // Connectors routes
 app.route("/api/workspaces/:workspaceId/connectors", dataSourceRoutes);
 app.route("/api/workspaces/:workspaceId/flows", flowRoutes);

--- a/api/src/inngest/functions/dbt-run.ts
+++ b/api/src/inngest/functions/dbt-run.ts
@@ -138,6 +138,24 @@ export const dbtRunExecutorFunction = inngest.createFunction(
         { new: true },
       ).lean();
       if (!run) return null;
+
+      // Slim CI: when the job defers to production, resolve the project's last
+      // prod manifest so the executor can run `--defer --state`.
+      let deferStateKey: string | null = null;
+      if (run.jobId) {
+        const job = await DbtJob.findById(run.jobId)
+          .select("deferToProduction")
+          .lean();
+        if (job?.deferToProduction) {
+          const project = await DbtProject.findById(run.projectId)
+            .select("lastProdManifestKey")
+            .lean();
+          deferStateKey =
+            (project as { lastProdManifestKey?: string })
+              ?.lastProdManifestKey ?? null;
+        }
+      }
+
       return {
         environment: run.environment,
         commands: run.commands,
@@ -148,6 +166,7 @@ export const dbtRunExecutorFunction = inngest.createFunction(
               manifest: run.restoreArtifactKeys.manifest,
             }
           : null,
+        deferStateKey,
       };
     });
 
@@ -189,6 +208,9 @@ export const dbtRunExecutorFunction = inngest.createFunction(
               manifest: await readArtifactBuffer(restoreKeys.manifest),
             }
           : undefined;
+        const deferState = await readArtifactBuffer(
+          runInfo.deferStateKey ?? undefined,
+        );
 
         try {
           const result = await runDbt({
@@ -200,6 +222,7 @@ export const dbtRunExecutorFunction = inngest.createFunction(
             // snapshot loading + artifact upload within the step request.
             commandTimeoutMs: 50 * 60 * 1000,
             restoreTarget,
+            deferState,
             onLog: logWriter.onLog,
           });
 

--- a/api/src/inngest/functions/dbt-run.ts
+++ b/api/src/inngest/functions/dbt-run.ts
@@ -1,0 +1,405 @@
+/**
+ * dbt run orchestration.
+ *
+ * - dbtRunExecutorFunction: executes a queued DbtRun. One step.run per
+ *   command (each must finish inside the Cloud Run request timeout), with
+ *   batched log writes into dbt_runs.logs and artifact upload to the
+ *   artifact store. Secrets never cross step boundaries — every step loads
+ *   the project snapshot + decrypted profile itself.
+ * - dbtSchedulerFunction: cron sweep over due dbt_jobs with the same
+ *   optimistic claim pattern as scheduled-query.ts.
+ * - dbtRunCancelFunction: companion that finalizes runs killed by cancelOn.
+ */
+
+import { Types } from "mongoose";
+import { inngest } from "../client";
+import { DbtJob, DbtProject, DbtRun } from "../../database/workspace-schema";
+import { loggers } from "../../logging";
+import { parseDbtCommand } from "../../dbt/commands";
+import { loadDbtProjectSnapshot } from "../../dbt/dbt-project.service";
+import {
+  parseStepResults,
+  runDbt,
+  type DbtLogLine,
+} from "../../dbt/runner.service";
+import { triggerDbtJobRun } from "../../dbt/dbt-run.service";
+import { getNextScheduledConsoleRunAt } from "../../services/scheduled-query-schedule.service";
+import { getDashboardArtifactStore } from "../../services/dashboard-artifact-store.service";
+
+const logger = loggers.inngest("dbt");
+
+const MAX_LOG_LINES = 5000;
+const LOG_FLUSH_INTERVAL_MS = 2000;
+
+/** Buffered writer for dbt_runs.logs — capped, batched $push. */
+function createLogWriter(runId: Types.ObjectId) {
+  let buffer: DbtLogLine[] = [];
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let flushing = Promise.resolve();
+
+  const flush = () => {
+    if (buffer.length === 0) return flushing;
+    const lines = buffer;
+    buffer = [];
+    flushing = flushing.then(async () => {
+      await DbtRun.updateOne(
+        { _id: runId },
+        {
+          $push: {
+            logs: {
+              $each: lines.map(line => ({
+                ts: line.ts,
+                level: line.level,
+                line: line.line.slice(0, 2000),
+              })),
+              $slice: -MAX_LOG_LINES,
+            },
+          },
+        },
+      ).catch(error => {
+        logger.warn("dbt log flush failed", { error, runId: runId.toString() });
+      });
+    });
+    return flushing;
+  };
+
+  return {
+    onLog: (line: DbtLogLine) => {
+      buffer.push(line);
+      if (!timer) {
+        timer = setTimeout(() => {
+          timer = null;
+          void flush();
+        }, LOG_FLUSH_INTERVAL_MS);
+      }
+    },
+    finish: async () => {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      await flush();
+    },
+  };
+}
+
+interface DbtRunRequestedEvent {
+  workspaceId: string;
+  projectId: string;
+  runId: string;
+  jobId?: string;
+}
+
+export const dbtRunExecutorFunction = inngest.createFunction(
+  {
+    id: "dbt-run-executor",
+    name: "Execute dbt Run",
+    retries: 0,
+    concurrency: {
+      key: "event.data.projectId",
+      limit: 1,
+    },
+    cancelOn: [
+      {
+        event: "dbt/run.cancel",
+        if: "async.data.runId == event.data.runId",
+      },
+    ],
+  },
+  { event: "dbt/run.requested" },
+  async ({ event, step }) => {
+    const data = event.data as DbtRunRequestedEvent;
+    const runObjectId = new Types.ObjectId(data.runId);
+
+    const runInfo = await step.run("mark-running", async () => {
+      const run = await DbtRun.findOneAndUpdate(
+        { _id: runObjectId, status: "queued" },
+        { $set: { status: "running", startedAt: new Date() } },
+        { new: true },
+      ).lean();
+      if (!run) return null;
+      return {
+        environment: run.environment,
+        commands: run.commands,
+        jobId: run.jobId?.toString(),
+      };
+    });
+
+    if (!runInfo) {
+      // Already cancelled or duplicate delivery.
+      return { skipped: true };
+    }
+
+    let failed = false;
+    let errorMessage: string | undefined;
+    const allStepResults: ReturnType<typeof parseStepResults> = [];
+
+    for (let i = 0; i < runInfo.commands.length; i++) {
+      const commandText = runInfo.commands[i];
+
+      const stepOutcome = await step.run(`exec-cmd-${i}`, async () => {
+        // Snapshot (files + decrypted profile) is loaded inside the step so
+        // credentials never land in Inngest step state.
+        const snapshot = await loadDbtProjectSnapshot({
+          workspaceId: data.workspaceId,
+          projectId: data.projectId,
+          environmentName: runInfo.environment,
+        });
+        const parsed = parseDbtCommand(commandText);
+        const logWriter = createLogWriter(runObjectId);
+
+        logWriter.onLog({
+          ts: new Date(),
+          level: "info",
+          line: `$ dbt ${parsed.argv.join(" ")}`,
+        });
+
+        try {
+          const result = await runDbt({
+            files: snapshot.files,
+            profile: snapshot.profile,
+            commands: [parsed],
+            dbtVersion: snapshot.project.dbtVersion,
+            onLog: logWriter.onLog,
+          });
+
+          const commandResult = result.commandResults[0];
+          const stepResults = parseStepResults(commandResult?.runResults);
+
+          // Upload artifacts after every command — the last successful
+          // upload wins, which matches dbt's own target/ behavior.
+          const store = getDashboardArtifactStore();
+          const prefix = `dbt-artifacts/${data.workspaceId}/${data.runId}`;
+          const artifactKeys: Record<string, string> = {};
+          const uploads: Array<[string, Buffer | undefined, string]> = [
+            ["manifest", result.artifacts.manifest, "manifest.json"],
+            ["runResults", result.artifacts.runResults, "run_results.json"],
+            ["catalog", result.artifacts.catalog, "catalog.json"],
+          ];
+          for (const [kind, buffer, filename] of uploads) {
+            if (!buffer) continue;
+            const key = `${prefix}/${filename}`;
+            try {
+              await store.putBuffer(buffer, key, "application/json");
+              artifactKeys[kind] = key;
+            } catch (uploadError) {
+              logger.warn("dbt artifact upload failed", {
+                error: uploadError,
+                key,
+              });
+            }
+          }
+
+          const update: Record<string, unknown> = {};
+          for (const [kind, key] of Object.entries(artifactKeys)) {
+            update[`artifactKeys.${kind}`] = key;
+          }
+          if (stepResults.length > 0 || Object.keys(update).length > 0) {
+            await DbtRun.updateOne(
+              { _id: runObjectId },
+              {
+                ...(Object.keys(update).length > 0 ? { $set: update } : {}),
+                ...(stepResults.length > 0
+                  ? { $push: { stepResults: { $each: stepResults } } }
+                  : {}),
+              },
+            );
+          }
+
+          return {
+            exitCode: commandResult?.exitCode ?? 1,
+            success: result.success,
+            stepResultCount: stepResults.length,
+            failedSteps: stepResults.filter(
+              stepResult =>
+                stepResult.status === "error" || stepResult.status === "fail",
+            ).length,
+          };
+        } finally {
+          await logWriter.finish();
+        }
+      });
+
+      if (!stepOutcome.success) {
+        failed = true;
+        errorMessage = `dbt command "${commandText}" exited with code ${stepOutcome.exitCode}`;
+        break;
+      }
+    }
+
+    await step.run("finalize-run", async () => {
+      const completedAt = new Date();
+      const run = await DbtRun.findById(runObjectId).select("startedAt").lean();
+      const durationMs = run?.startedAt
+        ? completedAt.getTime() - new Date(run.startedAt).getTime()
+        : undefined;
+
+      await DbtRun.updateOne(
+        { _id: runObjectId, status: "running" },
+        {
+          $set: {
+            status: failed ? "error" : "success",
+            completedAt,
+            ...(durationMs !== undefined ? { durationMs } : {}),
+            ...(errorMessage ? { error: errorMessage } : {}),
+          },
+        },
+      );
+
+      if (runInfo.jobId) {
+        await DbtJob.updateOne(
+          { _id: new Types.ObjectId(runInfo.jobId) },
+          {
+            $set: {
+              "scheduledRun.lastAt": completedAt,
+              "scheduledRun.lastStatus": failed ? "error" : "success",
+              "scheduledRun.lastError": failed ? errorMessage : undefined,
+              ...(durationMs !== undefined
+                ? { "scheduledRun.lastDurationMs": durationMs }
+                : {}),
+              ...(failed ? {} : { "scheduledRun.consecutiveFailures": 0 }),
+            },
+            $inc: {
+              "scheduledRun.runCount": 1,
+              ...(failed ? { "scheduledRun.consecutiveFailures": 1 } : {}),
+            },
+          },
+        );
+      }
+
+      // Keep the last successful prod manifest as the state artifact for
+      // --defer / state:modified+ (Slim CI, later phase).
+      if (!failed) {
+        const finishedRun = await DbtRun.findById(runObjectId)
+          .select("artifactKeys environment")
+          .lean();
+        if (finishedRun?.artifactKeys?.manifest) {
+          const project = await DbtProject.findById(
+            new Types.ObjectId(data.projectId),
+          ).select("defaultEnvironment");
+          const prodLike =
+            finishedRun.environment === "prod" ||
+            finishedRun.environment === project?.defaultEnvironment;
+          if (prodLike) {
+            await DbtProject.updateOne(
+              { _id: new Types.ObjectId(data.projectId) },
+              {
+                $set: {
+                  lastProdManifestKey: finishedRun.artifactKeys.manifest,
+                },
+              },
+            );
+          }
+        }
+      }
+    });
+
+    return {
+      runId: data.runId,
+      status: failed ? "error" : "success",
+      stepResults: allStepResults.length,
+    };
+  },
+);
+
+/**
+ * Finalize runs whose executor was killed by cancelOn. Waits briefly so the
+ * in-flight subprocess SIGTERM (queued runs are finalized synchronously by
+ * requestDbtRunCancel) settles, then flips any still-active status.
+ */
+export const dbtRunCancelFunction = inngest.createFunction(
+  {
+    id: "dbt-run-cancel-finalizer",
+    name: "Finalize cancelled dbt Run",
+    retries: 1,
+  },
+  { event: "dbt/run.cancel" },
+  async ({ event, step }) => {
+    const runId = (event.data as { runId: string }).runId;
+    await step.sleep("allow-executor-teardown", "10s");
+    await step.run("finalize-cancelled", async () => {
+      await DbtRun.updateOne(
+        {
+          _id: new Types.ObjectId(runId),
+          status: { $in: ["queued", "running"] },
+        },
+        {
+          $set: {
+            status: "cancelled",
+            completedAt: new Date(),
+            error: "Cancelled by user",
+          },
+        },
+      );
+    });
+    return { runId };
+  },
+);
+
+export const dbtSchedulerFunction = inngest.createFunction(
+  {
+    id: "dbt-job-scheduler",
+    name: "Run Scheduled dbt Jobs",
+  },
+  { cron: "*/1 * * * *" },
+  async ({ step }) => {
+    const now = new Date();
+
+    const dueJobs = await step.run("fetch-due-dbt-jobs", async () => {
+      const jobs = await DbtJob.find({
+        enabled: true,
+        "schedule.cron": { $exists: true, $ne: "" },
+        "scheduledRun.nextAt": { $lte: now },
+      })
+        .select("_id workspaceId schedule scheduledRun")
+        .lean();
+
+      return jobs.map(job => ({
+        id: job._id.toString(),
+        workspaceId: job.workspaceId.toString(),
+        nextAt: job.scheduledRun?.nextAt ?? null,
+        schedule: job.schedule,
+      }));
+    });
+
+    let triggered = 0;
+    for (const dueJob of dueJobs) {
+      if (!dueJob.schedule?.cron || !dueJob.schedule?.timezone) continue;
+
+      const nextAt = getNextScheduledConsoleRunAt(
+        { cron: dueJob.schedule.cron, timezone: dueJob.schedule.timezone },
+        now,
+      );
+
+      // Optimistic claim — only the instance that flips nextAt triggers.
+      const updateResult = await step.run(
+        `claim-${dueJob.id}-${dueJob.nextAt?.toString() ?? "none"}`,
+        async () =>
+          DbtJob.updateOne(
+            {
+              _id: new Types.ObjectId(dueJob.id),
+              "scheduledRun.nextAt": dueJob.nextAt,
+            },
+            { $set: { "scheduledRun.nextAt": nextAt } },
+          ),
+      );
+
+      if (updateResult.modifiedCount === 0) continue;
+
+      await step.run(`trigger-${dueJob.id}`, async () => {
+        const job = await DbtJob.findById(new Types.ObjectId(dueJob.id));
+        if (!job) return null;
+        const run = await triggerDbtJobRun({
+          workspaceId: dueJob.workspaceId,
+          job,
+          trigger: "schedule",
+          triggeredBy: "scheduler",
+        });
+        return run._id.toString();
+      });
+      triggered++;
+    }
+
+    return { checked: dueJobs.length, triggered };
+  },
+);

--- a/api/src/inngest/functions/dbt-run.ts
+++ b/api/src/inngest/functions/dbt-run.ts
@@ -18,6 +18,7 @@ import { loggers } from "../../logging";
 import { parseDbtCommand } from "../../dbt/commands";
 import { loadDbtProjectSnapshot } from "../../dbt/dbt-project.service";
 import {
+  parseSourceFreshness,
   parseStepResults,
   runDbt,
   type DbtLogLine,
@@ -203,7 +204,10 @@ export const dbtRunExecutorFunction = inngest.createFunction(
           });
 
           const commandResult = result.commandResults[0];
-          const stepResults = parseStepResults(commandResult?.runResults);
+          const stepResults = [
+            ...parseStepResults(commandResult?.runResults),
+            ...parseSourceFreshness(result.artifacts.sources),
+          ];
 
           // Upload artifacts after every command — the last successful
           // upload wins, which matches dbt's own target/ behavior.
@@ -214,6 +218,7 @@ export const dbtRunExecutorFunction = inngest.createFunction(
             ["manifest", result.artifacts.manifest, "manifest.json"],
             ["runResults", result.artifacts.runResults, "run_results.json"],
             ["catalog", result.artifacts.catalog, "catalog.json"],
+            ["sources", result.artifacts.sources, "sources.json"],
           ];
           for (const [kind, buffer, filename] of uploads) {
             if (!buffer) continue;

--- a/api/src/inngest/functions/dbt-run.ts
+++ b/api/src/inngest/functions/dbt-run.ts
@@ -406,3 +406,102 @@ export const dbtSchedulerFunction = inngest.createFunction(
     return { checked: dueJobs.length, triggered };
   },
 );
+
+/**
+ * Sweep dbt runs whose executor died (instance crash/recycle mid-step).
+ * With retries: 0 Inngest never re-invokes the executor, so the run doc
+ * would stay "running" forever. A live run always has log activity (2s
+ * flush cadence) and a 50m per-command timeout, so >60m of log silence
+ * means the process is gone.
+ */
+const DBT_RUN_STALL_MS = 60 * 60 * 1000;
+const DBT_RUN_QUEUED_STALL_MS = 6 * 60 * 60 * 1000;
+
+export const dbtRunSweeperFunction = inngest.createFunction(
+  {
+    id: "dbt-run-sweeper",
+    name: "Cleanup Abandoned dbt Runs",
+  },
+  { cron: "*/5 * * * *" },
+  async ({ step }) => {
+    const swept = await step.run("sweep-abandoned-dbt-runs", async () => {
+      const now = Date.now();
+
+      // Active runs are rare; fetch and filter in JS so we can look at the
+      // last log timestamp (capped array — $slice: -1 keeps this cheap).
+      const activeRuns = await DbtRun.find({
+        status: { $in: ["queued", "running"] },
+      })
+        .select({
+          status: 1,
+          startedAt: 1,
+          createdAt: 1,
+          jobId: 1,
+          logs: { $slice: -1 },
+        })
+        .lean();
+
+      const abandoned = activeRuns.filter(run => {
+        if (run.status === "queued") {
+          // Queued runs can legitimately wait behind the per-project
+          // concurrency lock — only sweep clearly lost events.
+          return now - run.createdAt.getTime() > DBT_RUN_QUEUED_STALL_MS;
+        }
+        const lastActivity =
+          run.logs?.[0]?.ts ?? run.startedAt ?? run.createdAt;
+        return now - new Date(lastActivity).getTime() > DBT_RUN_STALL_MS;
+      });
+
+      for (const run of abandoned) {
+        const completedAt = new Date();
+        const updated = await DbtRun.updateOne(
+          { _id: run._id, status: { $in: ["queued", "running"] } },
+          {
+            $set: {
+              status: "error",
+              completedAt,
+              error:
+                "Run abandoned — executor terminated without finalizing (instance crash or deploy)",
+              ...(run.startedAt
+                ? {
+                    durationMs:
+                      completedAt.getTime() - new Date(run.startedAt).getTime(),
+                  }
+                : {}),
+            },
+          },
+        );
+        // Finalized concurrently by the executor or cancel finalizer.
+        if (updated.modifiedCount === 0) continue;
+
+        // Mirror finalize-run so job health stats don't silently drift.
+        if (run.jobId) {
+          await DbtJob.updateOne(
+            { _id: run.jobId },
+            {
+              $set: {
+                "scheduledRun.lastAt": completedAt,
+                "scheduledRun.lastStatus": "error",
+                "scheduledRun.lastError": "Run abandoned by executor",
+              },
+              $inc: {
+                "scheduledRun.runCount": 1,
+                "scheduledRun.consecutiveFailures": 1,
+              },
+            },
+          );
+        }
+
+        logger.warn("Swept abandoned dbt run", {
+          runId: run._id.toString(),
+          jobId: run.jobId?.toString(),
+          status: run.status,
+        });
+      }
+
+      return abandoned.length;
+    });
+
+    return { swept };
+  },
+);

--- a/api/src/inngest/functions/dbt-run.ts
+++ b/api/src/inngest/functions/dbt-run.ts
@@ -286,7 +286,7 @@ export const dbtRunExecutorFunction = inngest.createFunction(
       );
 
       if (runInfo.jobId) {
-        await DbtJob.updateOne(
+        const updatedJob = await DbtJob.findOneAndUpdate(
           { _id: new Types.ObjectId(runInfo.jobId) },
           {
             $set: {
@@ -303,7 +303,36 @@ export const dbtRunExecutorFunction = inngest.createFunction(
               ...(failed ? { "scheduledRun.consecutiveFailures": 1 } : {}),
             },
           },
+          { new: true },
         );
+
+        // Stop a broken scheduled job from hammering the warehouse forever:
+        // after a threshold of consecutive failures, disable the schedule and
+        // surface why. A manual run (which resets consecutiveFailures on
+        // success) re-enables normal cadence after the user re-enables it.
+        const failures = updatedJob?.scheduledRun?.consecutiveFailures ?? 0;
+        if (
+          failed &&
+          updatedJob?.enabled &&
+          updatedJob.schedule?.cron &&
+          DBT_AUTO_DISABLE_AFTER_FAILURES > 0 &&
+          failures >= DBT_AUTO_DISABLE_AFTER_FAILURES
+        ) {
+          await DbtJob.updateOne(
+            { _id: updatedJob._id },
+            {
+              $set: {
+                enabled: false,
+                "scheduledRun.lastError": `Auto-disabled after ${failures} consecutive failures. Last error: ${errorMessage ?? "unknown"}`,
+              },
+              $unset: { "scheduledRun.nextAt": "" },
+            },
+          );
+          logger.warn("Auto-disabled dbt job after repeated failures", {
+            jobId: updatedJob._id.toString(),
+            consecutiveFailures: failures,
+          });
+        }
       }
 
       // Keep the last successful prod manifest as the state artifact for
@@ -461,6 +490,15 @@ const DBT_RUN_QUEUED_STALL_MS = 6 * 60 * 60 * 1000;
  */
 const DBT_RUN_RETENTION_DAYS = Number(
   process.env.DBT_RUN_RETENTION_DAYS ?? "30",
+);
+
+/**
+ * Auto-disable a scheduled job after this many consecutive failures so a
+ * persistently broken job stops re-running on every tick. 0 disables the
+ * behavior. Override with DBT_AUTO_DISABLE_AFTER_FAILURES.
+ */
+const DBT_AUTO_DISABLE_AFTER_FAILURES = Number(
+  process.env.DBT_AUTO_DISABLE_AFTER_FAILURES ?? "10",
 );
 
 export const dbtRunSweeperFunction = inngest.createFunction(

--- a/api/src/inngest/functions/dbt-run.ts
+++ b/api/src/inngest/functions/dbt-run.ts
@@ -417,6 +417,16 @@ export const dbtSchedulerFunction = inngest.createFunction(
 const DBT_RUN_STALL_MS = 60 * 60 * 1000;
 const DBT_RUN_QUEUED_STALL_MS = 6 * 60 * 60 * 1000;
 
+/**
+ * Run-history retention. dbt_runs embed capped logs + stepResults and would
+ * otherwise grow unbounded. The parent job preserves last status/error in
+ * `scheduledRun`, so pruning completed history rows past the window is safe.
+ * Override with DBT_RUN_RETENTION_DAYS.
+ */
+const DBT_RUN_RETENTION_DAYS = Number(
+  process.env.DBT_RUN_RETENTION_DAYS ?? "30",
+);
+
 export const dbtRunSweeperFunction = inngest.createFunction(
   {
     id: "dbt-run-sweeper",
@@ -502,6 +512,29 @@ export const dbtRunSweeperFunction = inngest.createFunction(
       return abandoned.length;
     });
 
-    return { swept };
+    const pruned = await step.run("prune-old-dbt-runs", async () => {
+      if (
+        !Number.isFinite(DBT_RUN_RETENTION_DAYS) ||
+        DBT_RUN_RETENTION_DAYS <= 0
+      ) {
+        return 0;
+      }
+      const cutoff = new Date(
+        Date.now() - DBT_RUN_RETENTION_DAYS * 24 * 60 * 60 * 1000,
+      );
+      const result = await DbtRun.deleteMany({
+        status: { $in: ["success", "error", "cancelled"] },
+        completedAt: { $lt: cutoff },
+      });
+      if (result.deletedCount) {
+        logger.info("Pruned old dbt runs", {
+          deleted: result.deletedCount,
+          retentionDays: DBT_RUN_RETENTION_DAYS,
+        });
+      }
+      return result.deletedCount ?? 0;
+    });
+
+    return { swept, pruned };
   },
 );

--- a/api/src/inngest/functions/dbt-run.ts
+++ b/api/src/inngest/functions/dbt-run.ts
@@ -90,6 +90,25 @@ interface DbtRunRequestedEvent {
   jobId?: string;
 }
 
+/** Read an artifact key into a Buffer, or undefined if missing/unreadable. */
+async function readArtifactBuffer(
+  key: string | undefined,
+): Promise<Buffer | undefined> {
+  if (!key) return undefined;
+  try {
+    const stream = await getDashboardArtifactStore().openReadStream(key);
+    if (!stream) return undefined;
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    return Buffer.concat(chunks);
+  } catch (error) {
+    logger.warn("dbt restore artifact read failed", { error, key });
+    return undefined;
+  }
+}
+
 export const dbtRunExecutorFunction = inngest.createFunction(
   {
     id: "dbt-run-executor",
@@ -122,6 +141,12 @@ export const dbtRunExecutorFunction = inngest.createFunction(
         environment: run.environment,
         commands: run.commands,
         jobId: run.jobId?.toString(),
+        restoreArtifactKeys: run.restoreArtifactKeys
+          ? {
+              runResults: run.restoreArtifactKeys.runResults,
+              manifest: run.restoreArtifactKeys.manifest,
+            }
+          : null,
       };
     });
 
@@ -154,6 +179,16 @@ export const dbtRunExecutorFunction = inngest.createFunction(
           line: `$ dbt ${parsed.argv.join(" ")}`,
         });
 
+        // Retry runs seed the prior run_results.json into target/ so
+        // `dbt retry` resumes at the failed/skipped nodes.
+        const restoreKeys = runInfo.restoreArtifactKeys;
+        const restoreTarget = restoreKeys
+          ? {
+              runResults: await readArtifactBuffer(restoreKeys.runResults),
+              manifest: await readArtifactBuffer(restoreKeys.manifest),
+            }
+          : undefined;
+
         try {
           const result = await runDbt({
             files: snapshot.files,
@@ -163,6 +198,7 @@ export const dbtRunExecutorFunction = inngest.createFunction(
             // Cloud Run services deploy with --timeout=3600; leave buffer for
             // snapshot loading + artifact upload within the step request.
             commandTimeoutMs: 50 * 60 * 1000,
+            restoreTarget,
             onLog: logWriter.onLog,
           });
 

--- a/api/src/inngest/functions/dbt-run.ts
+++ b/api/src/inngest/functions/dbt-run.ts
@@ -160,6 +160,9 @@ export const dbtRunExecutorFunction = inngest.createFunction(
             profile: snapshot.profile,
             commands: [parsed],
             dbtVersion: snapshot.project.dbtVersion,
+            // Cloud Run services deploy with --timeout=3600; leave buffer for
+            // snapshot loading + artifact upload within the step request.
+            commandTimeoutMs: 50 * 60 * 1000,
             onLog: logWriter.onLog,
           });
 

--- a/api/src/inngest/index.ts
+++ b/api/src/inngest/index.ts
@@ -30,6 +30,11 @@ import {
   flowRunTerminalFanoutFunction,
   notificationDeliverFunction,
 } from "./functions/flow-run-notifications";
+import {
+  dbtRunExecutorFunction,
+  dbtRunCancelFunction,
+  dbtSchedulerFunction,
+} from "./functions/dbt-run";
 import { loggers } from "../logging";
 
 const baseFunctions = [
@@ -46,6 +51,8 @@ const baseFunctions = [
   scheduledQueryExecutorFunction,
   flowRunTerminalFanoutFunction,
   notificationDeliverFunction,
+  dbtRunExecutorFunction,
+  dbtRunCancelFunction,
 ];
 
 const allWebhookFunctions = [
@@ -81,6 +88,7 @@ export function getFunctions() {
         flowSchedulerFunction,
         dashboardSchedulerFunction,
         scheduledQuerySchedulerFunction,
+        dbtSchedulerFunction,
       ];
 
   return _functions;
@@ -133,4 +141,7 @@ export {
   modelCatalogRefreshFunction,
   scheduledQueryExecutorFunction,
   scheduledQuerySchedulerFunction,
+  dbtRunExecutorFunction,
+  dbtRunCancelFunction,
+  dbtSchedulerFunction,
 };

--- a/api/src/inngest/index.ts
+++ b/api/src/inngest/index.ts
@@ -34,6 +34,7 @@ import {
   dbtRunExecutorFunction,
   dbtRunCancelFunction,
   dbtSchedulerFunction,
+  dbtRunSweeperFunction,
 } from "./functions/dbt-run";
 import { loggers } from "../logging";
 
@@ -53,6 +54,7 @@ const baseFunctions = [
   notificationDeliverFunction,
   dbtRunExecutorFunction,
   dbtRunCancelFunction,
+  dbtRunSweeperFunction,
 ];
 
 const allWebhookFunctions = [
@@ -144,4 +146,5 @@ export {
   dbtRunExecutorFunction,
   dbtRunCancelFunction,
   dbtSchedulerFunction,
+  dbtRunSweeperFunction,
 };

--- a/api/src/migrations/2026-06-12-160000_create_dbt_collections.ts
+++ b/api/src/migrations/2026-06-12-160000_create_dbt_collections.ts
@@ -1,0 +1,107 @@
+import { Db } from "mongodb";
+import { loggers } from "../logging";
+
+const log = loggers.migration();
+
+export const description =
+  "Create dbt_projects/dbt_files/dbt_jobs/dbt_runs collections with indexes " +
+  "for the dbt Cloud replica (workspace-scoped dbt Core projects)";
+
+function hasIndexOnKeys(
+  indexes: { key: Record<string, number | string> }[],
+  keyPattern: Record<string, number | string>,
+): boolean {
+  const target = JSON.stringify(keyPattern);
+  return indexes.some(idx => JSON.stringify(idx.key) === target);
+}
+
+async function ensureCollection(db: Db, name: string): Promise<void> {
+  const existing = await db.listCollections({ name }).toArray();
+  if (existing.length === 0) {
+    await db.createCollection(name);
+    log.info(`Created '${name}' collection`);
+  } else {
+    log.info(`'${name}' collection already exists`);
+  }
+}
+
+export async function up(db: Db): Promise<void> {
+  await ensureCollection(db, "dbt_projects");
+  await ensureCollection(db, "dbt_files");
+  await ensureCollection(db, "dbt_jobs");
+  await ensureCollection(db, "dbt_runs");
+
+  const projects = db.collection("dbt_projects");
+  let indexes = await projects.indexes();
+  if (!hasIndexOnKeys(indexes, { workspaceId: 1, name: 1 })) {
+    await projects.createIndex(
+      { workspaceId: 1, name: 1 },
+      { unique: true, name: "dbt_projects_workspace_name_unique" },
+    );
+    log.info("Created unique index on dbt_projects { workspaceId, name }");
+  }
+  if (!hasIndexOnKeys(indexes, { workspaceId: 1, updatedAt: -1 })) {
+    await projects.createIndex(
+      { workspaceId: 1, updatedAt: -1 },
+      { name: "dbt_projects_workspace_updated" },
+    );
+    log.info("Created index on dbt_projects { workspaceId, updatedAt }");
+  }
+
+  const files = db.collection("dbt_files");
+  indexes = await files.indexes();
+  if (!hasIndexOnKeys(indexes, { projectId: 1, path: 1 })) {
+    await files.createIndex(
+      { projectId: 1, path: 1 },
+      { unique: true, name: "dbt_files_project_path_unique" },
+    );
+    log.info("Created unique index on dbt_files { projectId, path }");
+  }
+  if (
+    !hasIndexOnKeys(indexes, { workspaceId: 1, projectId: 1, is_deleted: 1 })
+  ) {
+    await files.createIndex(
+      { workspaceId: 1, projectId: 1, is_deleted: 1 },
+      { name: "dbt_files_workspace_project" },
+    );
+    log.info(
+      "Created index on dbt_files { workspaceId, projectId, is_deleted }",
+    );
+  }
+
+  const jobs = db.collection("dbt_jobs");
+  indexes = await jobs.indexes();
+  if (!hasIndexOnKeys(indexes, { workspaceId: 1, projectId: 1 })) {
+    await jobs.createIndex(
+      { workspaceId: 1, projectId: 1 },
+      { name: "dbt_jobs_workspace_project" },
+    );
+    log.info("Created index on dbt_jobs { workspaceId, projectId }");
+  }
+  if (!hasIndexOnKeys(indexes, { "scheduledRun.nextAt": 1, enabled: 1 })) {
+    await jobs.createIndex(
+      { "scheduledRun.nextAt": 1, enabled: 1 },
+      { sparse: true, name: "dbt_jobs_scheduler_due" },
+    );
+    log.info("Created index on dbt_jobs { scheduledRun.nextAt, enabled }");
+  }
+
+  const runs = db.collection("dbt_runs");
+  indexes = await runs.indexes();
+  if (
+    !hasIndexOnKeys(indexes, { workspaceId: 1, projectId: 1, createdAt: -1 })
+  ) {
+    await runs.createIndex(
+      { workspaceId: 1, projectId: 1, createdAt: -1 },
+      { name: "dbt_runs_workspace_project_created" },
+    );
+    log.info("Created index on dbt_runs { workspaceId, projectId, createdAt }");
+  }
+  if (!hasIndexOnKeys(indexes, { jobId: 1, createdAt: -1 })) {
+    await runs.createIndex(
+      { jobId: 1, createdAt: -1 },
+      { sparse: true, name: "dbt_runs_job_created" },
+    );
+    log.info("Created index on dbt_runs { jobId, createdAt }");
+  }
+}

--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -968,20 +968,58 @@ dbtRoutes.post(
 // Lineage — flattened manifest parent_map for the DAG view
 // ---------------------------------------------------------------------------
 
+interface ManifestColumn {
+  name?: string;
+  description?: string;
+  data_type?: string | null;
+}
+
+interface ManifestNode {
+  name?: string;
+  resource_type?: string;
+  original_file_path?: string;
+  description?: string;
+  columns?: Record<string, ManifestColumn>;
+  tags?: string[];
+  config?: { materialized?: string };
+}
+
 interface ManifestForLineage {
-  nodes?: Record<
+  nodes?: Record<string, ManifestNode>;
+  sources?: Record<
     string,
     {
       name?: string;
+      source_name?: string;
       resource_type?: string;
-      original_file_path?: string;
+      description?: string;
+      columns?: Record<string, ManifestColumn>;
     }
   >;
-  sources?: Record<
+  exposures?: Record<
     string,
-    { name?: string; source_name?: string; resource_type?: string }
+    {
+      name?: string;
+      label?: string;
+      type?: string;
+      url?: string;
+      description?: string;
+      maturity?: string;
+      owner?: { name?: string; email?: string };
+    }
   >;
   parent_map?: Record<string, string[]>;
+}
+
+function mapColumns(
+  columns: Record<string, ManifestColumn> | undefined,
+): Array<{ name: string; type?: string; description?: string }> {
+  if (!columns) return [];
+  return Object.values(columns).map(col => ({
+    name: col.name ?? "",
+    type: col.data_type ?? undefined,
+    description: col.description || undefined,
+  }));
 }
 
 dbtRoutes.get(
@@ -1030,6 +1068,12 @@ dbtRoutes.get(
         resourceType: string;
         filePath?: string;
         lastStatus?: string;
+        description?: string;
+        materialized?: string;
+        tags?: string[];
+        columns?: Array<{ name: string; type?: string; description?: string }>;
+        url?: string;
+        owner?: string;
       }> = [];
 
       for (const [id, node] of Object.entries(manifest.nodes ?? {})) {
@@ -1041,6 +1085,10 @@ dbtRoutes.get(
           resourceType,
           filePath: node.original_file_path,
           lastStatus: statusByUniqueId.get(id),
+          description: node.description || undefined,
+          materialized: node.config?.materialized,
+          tags: node.tags?.length ? node.tags : undefined,
+          columns: mapColumns(node.columns),
         });
       }
       for (const [id, source] of Object.entries(manifest.sources ?? {})) {
@@ -1050,6 +1098,21 @@ dbtRoutes.get(
             ? `${source.source_name}.${source.name}`
             : (source.name ?? id),
           resourceType: "source",
+          description: source.description || undefined,
+          columns: mapColumns(source.columns),
+        });
+      }
+      // Exposures are leaf consumers (dashboards/apps) — render them as
+      // terminal nodes so the DAG shows what downstream depends on each model.
+      for (const [id, exposure] of Object.entries(manifest.exposures ?? {})) {
+        nodes.push({
+          id,
+          name: exposure.label || exposure.name || id,
+          resourceType: "exposure",
+          description: exposure.description || undefined,
+          materialized: exposure.type,
+          url: exposure.url,
+          owner: exposure.owner?.name || exposure.owner?.email,
         });
       }
 

--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -25,7 +25,11 @@ import {
   DBT_COMPATIBLE_CONNECTION_TYPES,
   isDbtCompatibleConnectionType,
 } from "../dbt/adapter-map";
-import { DbtCommandValidationError, parseDbtCommands } from "../dbt/commands";
+import {
+  DbtCommandValidationError,
+  parseDbtCommand,
+  parseDbtCommands,
+} from "../dbt/commands";
 import { buildStarterScaffold } from "../dbt/scaffold";
 import { runAdhocDbtCommand } from "../dbt/dbt-project.service";
 import {
@@ -879,9 +883,58 @@ dbtRoutes.get(
 const adhocSchema = z.object({
   select: z.string().min(1).max(256).optional(),
   environment: z.string().min(1).optional(),
+  /** Slim CI: resolve unselected refs against the last prod manifest. */
+  defer: z.boolean().optional(),
+});
+
+const commandSchema = z.object({
+  command: z.string().min(1).max(512),
+  environment: z.string().min(1).optional(),
+  defer: z.boolean().optional(),
 });
 
 const SELECT_PATTERN = /^[\w.+@:*\-/]+$/;
+
+/**
+ * Read the project's last production manifest for `--defer --state`, or
+ * `undefined` when defer is off / no prod build exists yet. Never throws —
+ * a missing manifest just disables defer for this invocation.
+ */
+async function loadDeferState(project: {
+  lastProdManifestKey?: string;
+}): Promise<Buffer | undefined> {
+  const key = project.lastProdManifestKey;
+  if (!key) return undefined;
+  try {
+    const stream = await getDashboardArtifactStore().openReadStream(key);
+    if (!stream) return undefined;
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    return Buffer.concat(chunks);
+  } catch (error) {
+    logger.warn("Failed to load defer state manifest", { error, key });
+    return undefined;
+  }
+}
+
+/**
+ * Prepend a warning when defer was requested but no prod manifest exists, so
+ * the UI doesn't silently run without `--defer`. Mutates and returns `logs`.
+ */
+function noteDeferUnavailable<
+  T extends { ts: Date; level: string; line: string },
+>(logs: T[], deferRequested: boolean, deferState: Buffer | undefined): T[] {
+  if (deferRequested && !deferState) {
+    logs.unshift({
+      ts: new Date(),
+      level: "warn",
+      line: "Defer requested but this project has no production manifest yet — ran without --defer. Run the prod environment once to enable defer.",
+    } as T);
+  }
+  return logs;
+}
 
 dbtRoutes.post(
   "/projects/:projectId/compile",
@@ -897,17 +950,19 @@ dbtRoutes.post(
       if (!parsed.success) {
         return badRequest(c, parsed.error.issues[0]?.message ?? "Invalid body");
       }
-      const { select, environment } = parsed.data;
+      const { select, environment, defer } = parsed.data;
       if (select && !SELECT_PATTERN.test(select)) {
         return badRequest(c, "Invalid --select value");
       }
       const command = select ? `compile --select ${select}` : "parse";
+      const deferState = defer ? await loadDeferState(project) : undefined;
       const result = await runAdhocDbtCommand({
         workspaceId: project.workspaceId.toString(),
         projectId: project._id.toString(),
         environmentName: environment,
         command,
         select,
+        deferState,
         timeoutMs: 3 * 60 * 1000,
       });
       return c.json({
@@ -916,7 +971,7 @@ dbtRoutes.post(
           ok: result.success,
           exitCode: result.exitCode,
           compiledSql: result.compiledSql,
-          logs: result.logs,
+          logs: noteDeferUnavailable(result.logs, !!defer, deferState),
         },
       });
     } catch (error) {
@@ -937,16 +992,18 @@ dbtRoutes.post(
       if (!parsed.success || !parsed.data.select) {
         return badRequest(c, "select is required");
       }
-      const { select, environment } = parsed.data;
+      const { select, environment, defer } = parsed.data;
       if (!SELECT_PATTERN.test(select)) {
         return badRequest(c, "Invalid --select value");
       }
+      const deferState = defer ? await loadDeferState(project) : undefined;
       const result = await runAdhocDbtCommand({
         workspaceId: project.workspaceId.toString(),
         projectId: project._id.toString(),
         environmentName: environment,
         command: `build --select ${select}`,
         select,
+        deferState,
         timeoutMs: 5 * 60 * 1000,
       });
       return c.json({
@@ -955,11 +1012,65 @@ dbtRoutes.post(
           ok: result.success,
           exitCode: result.exitCode,
           stepResults: result.stepResults,
-          logs: result.logs,
+          logs: noteDeferUnavailable(result.logs, !!defer, deferState),
         },
       });
     } catch (error) {
       return serverError(c, error, "Failed to run dbt model");
+    }
+  },
+);
+
+// Free-form command bar (dbt Cloud parity). The command is tokenized and
+// validated against the same allowlist as stored jobs before it reaches the
+// runner, so no extra CLI surface (--profiles-dir, shell metachars) leaks in.
+dbtRoutes.post(
+  "/projects/:projectId/command",
+  async (c: AuthenticatedContext) => {
+    try {
+      const project = await findProject(c);
+      if (!project) {
+        return c.json({ success: false, error: "dbt project not found" }, 404);
+      }
+      const parsed = commandSchema.safeParse(
+        await c.req.json().catch(() => ({})),
+      );
+      if (!parsed.success) {
+        return badRequest(c, parsed.error.issues[0]?.message ?? "Invalid body");
+      }
+      const { command, environment, defer } = parsed.data;
+      // Accept an optional leading "dbt" so users can paste full commands.
+      const normalized = command.trim().replace(/^dbt\s+/i, "");
+      let validated;
+      try {
+        validated = parseDbtCommand(normalized);
+      } catch (error) {
+        if (error instanceof DbtCommandValidationError) {
+          return badRequest(c, error.message);
+        }
+        throw error;
+      }
+      const deferState = defer ? await loadDeferState(project) : undefined;
+      const result = await runAdhocDbtCommand({
+        workspaceId: project.workspaceId.toString(),
+        projectId: project._id.toString(),
+        environmentName: environment,
+        command: normalized,
+        deferState,
+        timeoutMs: 9 * 60 * 1000,
+      });
+      return c.json({
+        success: true,
+        result: {
+          ok: result.success,
+          exitCode: result.exitCode,
+          subcommand: validated.subcommand,
+          stepResults: result.stepResults,
+          logs: noteDeferUnavailable(result.logs, !!defer, deferState),
+        },
+      });
+    } catch (error) {
+      return serverError(c, error, "Failed to run dbt command");
     }
   },
 );

--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -833,8 +833,11 @@ dbtRoutes.get(
       if (!Types.ObjectId.isValid(runId)) {
         return badRequest(c, "Invalid run id");
       }
-      if (!["manifest", "runResults", "catalog"].includes(kind)) {
-        return badRequest(c, "kind must be manifest | runResults | catalog");
+      if (!["manifest", "runResults", "catalog", "sources"].includes(kind)) {
+        return badRequest(
+          c,
+          "kind must be manifest | runResults | catalog | sources",
+        );
       }
       const run = await DbtRun.findOne({
         _id: new Types.ObjectId(runId),
@@ -843,7 +846,9 @@ dbtRoutes.get(
         .select("artifactKeys")
         .lean();
       const key =
-        run?.artifactKeys?.[kind as "manifest" | "runResults" | "catalog"];
+        run?.artifactKeys?.[
+          kind as "manifest" | "runResults" | "catalog" | "sources"
+        ];
       if (!key) {
         return c.json({ success: false, error: "Artifact not found" }, 404);
       }

--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -32,6 +32,7 @@ import {
   applyJobScheduleChange,
   requestDbtRunCancel,
   triggerDbtJobRun,
+  triggerDbtRunRetry,
 } from "../dbt/dbt-run.service";
 import { validateScheduledConsoleSchedule } from "../services/scheduled-query-schedule.service";
 import { getDashboardArtifactStore } from "../services/dashboard-artifact-store.service";
@@ -785,6 +786,36 @@ dbtRoutes.post(
       return c.json({ success: true });
     } catch (error) {
       return serverError(c, error, "Failed to cancel dbt run");
+    }
+  },
+);
+
+dbtRoutes.post(
+  "/projects/:projectId/runs/:runId/retry",
+  async (c: AuthenticatedContext) => {
+    try {
+      const project = await findProject(c);
+      if (!project) {
+        return c.json({ success: false, error: "dbt project not found" }, 404);
+      }
+      const runId = c.req.param("runId");
+      if (!Types.ObjectId.isValid(runId)) {
+        return badRequest(c, "Invalid run id");
+      }
+      const run = await triggerDbtRunRetry({
+        workspaceId: project.workspaceId.toString(),
+        runId,
+        triggeredBy: getUserId(c),
+      });
+      if (!run) {
+        return badRequest(
+          c,
+          "Run cannot be retried (must be a failed run with results)",
+        );
+      }
+      return c.json({ success: true, runId: run._id.toString() });
+    } catch (error) {
+      return serverError(c, error, "Failed to retry dbt run");
     }
   },
 );

--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -1,0 +1,1034 @@
+/**
+ * dbt routes — projects, files, jobs, runs, ad-hoc compile/run, lineage.
+ *
+ * Mounted at `/api/workspaces/:workspaceId/dbt`. Authenticated +
+ * workspace-scoped (unifiedAuthMiddleware then the same workspace access
+ * check as skills.ts). Business logic lives in api/src/dbt/**.
+ */
+
+import { Hono } from "hono";
+import { Readable } from "stream";
+import { Types } from "mongoose";
+import { z } from "zod";
+import { loggers, enrichContextWithWorkspace } from "../logging";
+import { unifiedAuthMiddleware } from "../auth/unified-auth.middleware";
+import { workspaceService } from "../services/workspace.service";
+import { AuthenticatedContext } from "../middleware/workspace.middleware";
+import {
+  DbtFile,
+  DbtJob,
+  DbtProject,
+  DbtRun,
+  DatabaseConnection,
+} from "../database/workspace-schema";
+import {
+  DBT_COMPATIBLE_CONNECTION_TYPES,
+  isDbtCompatibleConnectionType,
+} from "../dbt/adapter-map";
+import { DbtCommandValidationError, parseDbtCommands } from "../dbt/commands";
+import { buildStarterScaffold } from "../dbt/scaffold";
+import { runAdhocDbtCommand } from "../dbt/dbt-project.service";
+import {
+  applyJobScheduleChange,
+  requestDbtRunCancel,
+  triggerDbtJobRun,
+} from "../dbt/dbt-run.service";
+import { validateScheduledConsoleSchedule } from "../services/scheduled-query-schedule.service";
+import { getDashboardArtifactStore } from "../services/dashboard-artifact-store.service";
+import {
+  createVersion,
+  getLatestVersionNumber,
+  getUserDisplayName,
+} from "../services/entity-version.service";
+
+const logger = loggers.api("dbt");
+
+export const dbtRoutes = new Hono();
+
+dbtRoutes.use("*", unifiedAuthMiddleware);
+
+// Workspace access check — mirrors skills.ts
+dbtRoutes.use("*", async (c: AuthenticatedContext, next) => {
+  const workspaceId = c.req.param("workspaceId");
+  if (!workspaceId) {
+    await next();
+    return;
+  }
+  const user = c.get("user");
+  const workspace = c.get("workspace");
+
+  if (workspace) {
+    if (workspace._id.toString() !== workspaceId) {
+      return c.json(
+        { success: false, error: "API key not authorized for this workspace" },
+        403,
+      );
+    }
+  } else if (user) {
+    const hasAccess = await workspaceService.hasAccess(workspaceId, user.id);
+    if (!hasAccess) {
+      return c.json(
+        { success: false, error: "Access denied to workspace" },
+        403,
+      );
+    }
+  } else {
+    return c.json({ success: false, error: "Unauthorized" }, 401);
+  }
+
+  enrichContextWithWorkspace(workspaceId);
+  await next();
+});
+
+function getUserId(c: AuthenticatedContext): string {
+  return c.get("user")?.id ?? "api-key";
+}
+
+function badRequest(c: AuthenticatedContext, message: string) {
+  return c.json({ success: false, error: message }, 400);
+}
+
+function serverError(
+  c: AuthenticatedContext,
+  error: unknown,
+  fallback: string,
+) {
+  logger.error(fallback, { error });
+  return c.json(
+    {
+      success: false,
+      error: error instanceof Error ? error.message : fallback,
+    },
+    500,
+  );
+}
+
+const environmentSchema = z.object({
+  name: z.string().min(1).max(64),
+  connectionId: z
+    .string()
+    .refine(Types.ObjectId.isValid, "Invalid connection id"),
+  targetSchema: z.string().min(1).max(128),
+  threads: z.number().int().min(1).max(16).default(4),
+  vars: z.record(z.string(), z.unknown()).optional(),
+});
+
+const createProjectSchema = z.object({
+  name: z.string().min(1).max(128),
+  dbtVersion: z.string().max(16).optional(),
+  environments: z.array(environmentSchema).min(1),
+  defaultEnvironment: z.string().min(1),
+});
+
+const patchProjectSchema = z.object({
+  name: z.string().min(1).max(128).optional(),
+  dbtVersion: z.string().max(16).optional(),
+  environments: z.array(environmentSchema).min(1).optional(),
+  defaultEnvironment: z.string().min(1).optional(),
+});
+
+async function validateEnvironments(
+  workspaceId: string,
+  environments: z.infer<typeof environmentSchema>[],
+): Promise<string | null> {
+  const names = new Set<string>();
+  for (const env of environments) {
+    if (names.has(env.name)) return `Duplicate environment name "${env.name}"`;
+    names.add(env.name);
+    const connection = await DatabaseConnection.findOne({
+      _id: new Types.ObjectId(env.connectionId),
+      workspaceId: new Types.ObjectId(workspaceId),
+    }).select("type");
+    if (!connection) {
+      return `Connection not found for environment "${env.name}"`;
+    }
+    if (!isDbtCompatibleConnectionType(connection.type)) {
+      return (
+        `Connection type "${connection.type}" is not dbt-compatible. ` +
+        `Supported: ${DBT_COMPATIBLE_CONNECTION_TYPES.join(", ")}`
+      );
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Projects
+// ---------------------------------------------------------------------------
+
+// GET / — list projects with job/run rollups for the explorer
+dbtRoutes.get("/projects", async (c: AuthenticatedContext) => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    if (!workspaceId || !Types.ObjectId.isValid(workspaceId)) {
+      return badRequest(c, "Valid workspace ID is required");
+    }
+    const projects = await DbtProject.find({
+      workspaceId: new Types.ObjectId(workspaceId),
+    })
+      .sort({ updatedAt: -1 })
+      .lean();
+    return c.json({ success: true, projects });
+  } catch (error) {
+    return serverError(c, error, "Failed to list dbt projects");
+  }
+});
+
+dbtRoutes.post("/projects", async (c: AuthenticatedContext) => {
+  try {
+    const workspaceId = c.req.param("workspaceId");
+    if (!workspaceId || !Types.ObjectId.isValid(workspaceId)) {
+      return badRequest(c, "Valid workspace ID is required");
+    }
+    const parsed = createProjectSchema.safeParse(await c.req.json());
+    if (!parsed.success) {
+      return badRequest(
+        c,
+        parsed.error.issues[0]?.message ?? "Invalid project",
+      );
+    }
+    const body = parsed.data;
+    if (!body.environments.some(env => env.name === body.defaultEnvironment)) {
+      return badRequest(
+        c,
+        `Default environment "${body.defaultEnvironment}" is not in environments`,
+      );
+    }
+    const envError = await validateEnvironments(workspaceId, body.environments);
+    if (envError) return badRequest(c, envError);
+
+    const userId = getUserId(c);
+    const project = await DbtProject.create({
+      workspaceId: new Types.ObjectId(workspaceId),
+      name: body.name,
+      dbtVersion: body.dbtVersion ?? "1.9",
+      environments: body.environments.map(env => ({
+        ...env,
+        connectionId: new Types.ObjectId(env.connectionId),
+      })),
+      defaultEnvironment: body.defaultEnvironment,
+      createdBy: userId,
+    });
+
+    const scaffold = buildStarterScaffold(body.name);
+    await DbtFile.insertMany(
+      scaffold.map(file => ({
+        workspaceId: project.workspaceId,
+        projectId: project._id,
+        path: file.path,
+        content: file.content,
+        updatedBy: userId,
+      })),
+    );
+
+    return c.json({ success: true, project });
+  } catch (error) {
+    if ((error as { code?: number }).code === 11000) {
+      return badRequest(c, "A dbt project with this name already exists");
+    }
+    return serverError(c, error, "Failed to create dbt project");
+  }
+});
+
+async function findProject(c: AuthenticatedContext) {
+  const workspaceId = c.req.param("workspaceId");
+  const projectId = c.req.param("projectId");
+  if (
+    !workspaceId ||
+    !Types.ObjectId.isValid(workspaceId) ||
+    !projectId ||
+    !Types.ObjectId.isValid(projectId)
+  ) {
+    return null;
+  }
+  return DbtProject.findOne({
+    _id: new Types.ObjectId(projectId),
+    workspaceId: new Types.ObjectId(workspaceId),
+  });
+}
+
+dbtRoutes.get("/projects/:projectId", async (c: AuthenticatedContext) => {
+  try {
+    const project = await findProject(c);
+    if (!project) {
+      return c.json({ success: false, error: "dbt project not found" }, 404);
+    }
+    return c.json({ success: true, project });
+  } catch (error) {
+    return serverError(c, error, "Failed to fetch dbt project");
+  }
+});
+
+dbtRoutes.patch("/projects/:projectId", async (c: AuthenticatedContext) => {
+  try {
+    const project = await findProject(c);
+    if (!project) {
+      return c.json({ success: false, error: "dbt project not found" }, 404);
+    }
+    const parsed = patchProjectSchema.safeParse(await c.req.json());
+    if (!parsed.success) {
+      return badRequest(c, parsed.error.issues[0]?.message ?? "Invalid patch");
+    }
+    const body = parsed.data;
+
+    if (body.environments) {
+      const envError = await validateEnvironments(
+        project.workspaceId.toString(),
+        body.environments,
+      );
+      if (envError) return badRequest(c, envError);
+      project.environments = body.environments.map(env => ({
+        ...env,
+        connectionId: new Types.ObjectId(env.connectionId),
+      }));
+    }
+    if (body.name) project.name = body.name;
+    if (body.dbtVersion) project.dbtVersion = body.dbtVersion;
+    if (body.defaultEnvironment) {
+      project.defaultEnvironment = body.defaultEnvironment;
+    }
+    if (
+      !project.environments.some(env => env.name === project.defaultEnvironment)
+    ) {
+      return badRequest(
+        c,
+        `Default environment "${project.defaultEnvironment}" is not in environments`,
+      );
+    }
+    await project.save();
+    return c.json({ success: true, project });
+  } catch (error) {
+    return serverError(c, error, "Failed to update dbt project");
+  }
+});
+
+dbtRoutes.delete("/projects/:projectId", async (c: AuthenticatedContext) => {
+  try {
+    const project = await findProject(c);
+    if (!project) {
+      return c.json({ success: false, error: "dbt project not found" }, 404);
+    }
+    await Promise.all([
+      DbtFile.deleteMany({ projectId: project._id }),
+      DbtJob.deleteMany({ projectId: project._id }),
+      DbtRun.deleteMany({ projectId: project._id }),
+    ]);
+    await project.deleteOne();
+    return c.json({ success: true });
+  } catch (error) {
+    return serverError(c, error, "Failed to delete dbt project");
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Files
+// ---------------------------------------------------------------------------
+
+function isSafeDbtPath(path: string): boolean {
+  return (
+    path.length > 0 &&
+    path.length <= 512 &&
+    !path.startsWith("/") &&
+    !path.split("/").includes("..") &&
+    !path.includes("\\")
+  );
+}
+
+dbtRoutes.get("/projects/:projectId/files", async (c: AuthenticatedContext) => {
+  try {
+    const project = await findProject(c);
+    if (!project) {
+      return c.json({ success: false, error: "dbt project not found" }, 404);
+    }
+    const files = await DbtFile.find({
+      projectId: project._id,
+      is_deleted: { $ne: true },
+    })
+      .select("path updatedAt updatedBy")
+      .sort({ path: 1 })
+      .lean();
+    return c.json({ success: true, files });
+  } catch (error) {
+    return serverError(c, error, "Failed to list dbt files");
+  }
+});
+
+dbtRoutes.get(
+  "/projects/:projectId/files/:path{.+}",
+  async (c: AuthenticatedContext) => {
+    try {
+      const project = await findProject(c);
+      if (!project) {
+        return c.json({ success: false, error: "dbt project not found" }, 404);
+      }
+      const path = c.req.param("path");
+      const file = await DbtFile.findOne({
+        projectId: project._id,
+        path,
+        is_deleted: { $ne: true },
+      }).lean();
+      if (!file) {
+        return c.json({ success: false, error: "File not found" }, 404);
+      }
+      return c.json({ success: true, file });
+    } catch (error) {
+      return serverError(c, error, "Failed to read dbt file");
+    }
+  },
+);
+
+dbtRoutes.put(
+  "/projects/:projectId/files/:path{.+}",
+  async (c: AuthenticatedContext) => {
+    try {
+      const project = await findProject(c);
+      if (!project) {
+        return c.json({ success: false, error: "dbt project not found" }, 404);
+      }
+      const path = c.req.param("path");
+      if (!isSafeDbtPath(path)) return badRequest(c, "Invalid file path");
+
+      const body = (await c.req.json()) as { content?: unknown };
+      if (typeof body.content !== "string") {
+        return badRequest(c, "content (string) is required");
+      }
+      if (body.content.length > 1_000_000) {
+        return badRequest(c, "File too large (max 1MB)");
+      }
+
+      const userId = getUserId(c);
+      const file = await DbtFile.findOneAndUpdate(
+        { projectId: project._id, path },
+        {
+          $set: {
+            content: body.content,
+            updatedBy: userId,
+            is_deleted: false,
+            workspaceId: project.workspaceId,
+          },
+        },
+        { upsert: true, new: true, setDefaultsOnInsert: true },
+      );
+
+      // Version snapshot (entity-version pattern) — undo/version history.
+      try {
+        const latest = await getLatestVersionNumber(file._id, "dbt-file");
+        await createVersion({
+          entityType: "dbt-file",
+          entityId: file._id,
+          workspaceId: project.workspaceId,
+          snapshot: { path: file.path, content: body.content },
+          savedBy: userId,
+          savedByName: await getUserDisplayName(userId),
+          comment: `Save ${file.path} (v${latest + 1})`,
+        });
+      } catch (versionError) {
+        logger.warn("dbt file version snapshot failed", {
+          error: versionError,
+        });
+      }
+
+      await DbtProject.updateOne(
+        { _id: project._id },
+        { $currentDate: { updatedAt: true } },
+      );
+      return c.json({ success: true, file });
+    } catch (error) {
+      return serverError(c, error, "Failed to save dbt file");
+    }
+  },
+);
+
+dbtRoutes.delete(
+  "/projects/:projectId/files/:path{.+}",
+  async (c: AuthenticatedContext) => {
+    try {
+      const project = await findProject(c);
+      if (!project) {
+        return c.json({ success: false, error: "dbt project not found" }, 404);
+      }
+      const path = c.req.param("path");
+      const result = await DbtFile.updateOne(
+        { projectId: project._id, path },
+        { $set: { is_deleted: true, updatedBy: getUserId(c) } },
+      );
+      if (result.matchedCount === 0) {
+        return c.json({ success: false, error: "File not found" }, 404);
+      }
+      return c.json({ success: true });
+    } catch (error) {
+      return serverError(c, error, "Failed to delete dbt file");
+    }
+  },
+);
+
+dbtRoutes.post(
+  "/projects/:projectId/files/rename",
+  async (c: AuthenticatedContext) => {
+    try {
+      const project = await findProject(c);
+      if (!project) {
+        return c.json({ success: false, error: "dbt project not found" }, 404);
+      }
+      const body = (await c.req.json()) as { from?: unknown; to?: unknown };
+      const from = typeof body.from === "string" ? body.from : "";
+      const to = typeof body.to === "string" ? body.to : "";
+      if (!isSafeDbtPath(from) || !isSafeDbtPath(to)) {
+        return badRequest(c, "Invalid from/to path");
+      }
+      const existing = await DbtFile.findOne({
+        projectId: project._id,
+        path: to,
+        is_deleted: { $ne: true },
+      });
+      if (existing) return badRequest(c, `"${to}" already exists`);
+
+      // Replace any soft-deleted doc occupying the target path.
+      await DbtFile.deleteOne({ projectId: project._id, path: to });
+      const result = await DbtFile.updateOne(
+        { projectId: project._id, path: from, is_deleted: { $ne: true } },
+        { $set: { path: to, updatedBy: getUserId(c) } },
+      );
+      if (result.matchedCount === 0) {
+        return c.json({ success: false, error: "File not found" }, 404);
+      }
+      return c.json({ success: true });
+    } catch (error) {
+      return serverError(c, error, "Failed to rename dbt file");
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Jobs
+// ---------------------------------------------------------------------------
+
+const jobSchema = z.object({
+  name: z.string().min(1).max(128),
+  environment: z.string().min(1),
+  commands: z.array(z.string().min(1)).min(1).max(10),
+  schedule: z
+    .object({
+      cron: z.string().min(1),
+      timezone: z.string().min(1),
+    })
+    .nullable()
+    .optional(),
+  enabled: z.boolean().default(true),
+  deferToProduction: z.boolean().default(false),
+});
+
+function validateJobBody(
+  project: { environments: Array<{ name: string }> },
+  body: z.infer<typeof jobSchema>,
+): string | null {
+  if (!project.environments.some(env => env.name === body.environment)) {
+    return `Environment "${body.environment}" not found on project`;
+  }
+  try {
+    parseDbtCommands(body.commands);
+  } catch (error) {
+    if (error instanceof DbtCommandValidationError) return error.message;
+    throw error;
+  }
+  if (body.schedule) {
+    try {
+      validateScheduledConsoleSchedule(body.schedule);
+    } catch (error) {
+      return error instanceof Error ? error.message : "Invalid schedule";
+    }
+  }
+  return null;
+}
+
+dbtRoutes.get("/projects/:projectId/jobs", async (c: AuthenticatedContext) => {
+  try {
+    const project = await findProject(c);
+    if (!project) {
+      return c.json({ success: false, error: "dbt project not found" }, 404);
+    }
+    const jobs = await DbtJob.find({ projectId: project._id })
+      .sort({ createdAt: 1 })
+      .lean();
+    return c.json({ success: true, jobs });
+  } catch (error) {
+    return serverError(c, error, "Failed to list dbt jobs");
+  }
+});
+
+dbtRoutes.post("/projects/:projectId/jobs", async (c: AuthenticatedContext) => {
+  try {
+    const project = await findProject(c);
+    if (!project) {
+      return c.json({ success: false, error: "dbt project not found" }, 404);
+    }
+    const parsed = jobSchema.safeParse(await c.req.json());
+    if (!parsed.success) {
+      return badRequest(c, parsed.error.issues[0]?.message ?? "Invalid job");
+    }
+    const validationError = validateJobBody(project, parsed.data);
+    if (validationError) return badRequest(c, validationError);
+
+    const job = await DbtJob.create({
+      workspaceId: project.workspaceId,
+      projectId: project._id,
+      name: parsed.data.name,
+      environment: parsed.data.environment,
+      commands: parsed.data.commands,
+      schedule: parsed.data.schedule ?? undefined,
+      enabled: parsed.data.enabled,
+      deferToProduction: parsed.data.deferToProduction,
+      createdBy: getUserId(c),
+    });
+    await applyJobScheduleChange(job);
+    const fresh = await DbtJob.findById(job._id).lean();
+    return c.json({ success: true, job: fresh });
+  } catch (error) {
+    return serverError(c, error, "Failed to create dbt job");
+  }
+});
+
+dbtRoutes.patch(
+  "/projects/:projectId/jobs/:jobId",
+  async (c: AuthenticatedContext) => {
+    try {
+      const project = await findProject(c);
+      if (!project) {
+        return c.json({ success: false, error: "dbt project not found" }, 404);
+      }
+      const jobId = c.req.param("jobId");
+      if (!Types.ObjectId.isValid(jobId))
+        return badRequest(c, "Invalid job id");
+      const job = await DbtJob.findOne({
+        _id: new Types.ObjectId(jobId),
+        projectId: project._id,
+      });
+      if (!job) {
+        return c.json({ success: false, error: "Job not found" }, 404);
+      }
+      const parsed = jobSchema.partial().safeParse(await c.req.json());
+      if (!parsed.success) {
+        return badRequest(c, parsed.error.issues[0]?.message ?? "Invalid job");
+      }
+      const merged = {
+        name: parsed.data.name ?? job.name,
+        environment: parsed.data.environment ?? job.environment,
+        commands: parsed.data.commands ?? job.commands,
+        schedule:
+          parsed.data.schedule === undefined
+            ? (job.schedule ?? null)
+            : parsed.data.schedule,
+        enabled: parsed.data.enabled ?? job.enabled,
+        deferToProduction:
+          parsed.data.deferToProduction ?? job.deferToProduction,
+      };
+      const validationError = validateJobBody(project, merged);
+      if (validationError) return badRequest(c, validationError);
+
+      job.name = merged.name;
+      job.environment = merged.environment;
+      job.commands = merged.commands;
+      job.schedule = merged.schedule ?? undefined;
+      job.enabled = merged.enabled;
+      job.deferToProduction = merged.deferToProduction;
+      await job.save();
+      await applyJobScheduleChange(job);
+      const fresh = await DbtJob.findById(job._id).lean();
+      return c.json({ success: true, job: fresh });
+    } catch (error) {
+      return serverError(c, error, "Failed to update dbt job");
+    }
+  },
+);
+
+dbtRoutes.delete(
+  "/projects/:projectId/jobs/:jobId",
+  async (c: AuthenticatedContext) => {
+    try {
+      const project = await findProject(c);
+      if (!project) {
+        return c.json({ success: false, error: "dbt project not found" }, 404);
+      }
+      const jobId = c.req.param("jobId");
+      if (!Types.ObjectId.isValid(jobId))
+        return badRequest(c, "Invalid job id");
+      const result = await DbtJob.deleteOne({
+        _id: new Types.ObjectId(jobId),
+        projectId: project._id,
+      });
+      if (result.deletedCount === 0) {
+        return c.json({ success: false, error: "Job not found" }, 404);
+      }
+      return c.json({ success: true });
+    } catch (error) {
+      return serverError(c, error, "Failed to delete dbt job");
+    }
+  },
+);
+
+dbtRoutes.post(
+  "/projects/:projectId/jobs/:jobId/trigger",
+  async (c: AuthenticatedContext) => {
+    try {
+      const project = await findProject(c);
+      if (!project) {
+        return c.json({ success: false, error: "dbt project not found" }, 404);
+      }
+      const jobId = c.req.param("jobId");
+      if (!Types.ObjectId.isValid(jobId))
+        return badRequest(c, "Invalid job id");
+      const job = await DbtJob.findOne({
+        _id: new Types.ObjectId(jobId),
+        projectId: project._id,
+      });
+      if (!job) {
+        return c.json({ success: false, error: "Job not found" }, 404);
+      }
+      const run = await triggerDbtJobRun({
+        workspaceId: project.workspaceId.toString(),
+        job,
+        trigger: "manual",
+        triggeredBy: getUserId(c),
+      });
+      return c.json({ success: true, runId: run._id.toString() });
+    } catch (error) {
+      return serverError(c, error, "Failed to trigger dbt job");
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Runs
+// ---------------------------------------------------------------------------
+
+dbtRoutes.get("/projects/:projectId/runs", async (c: AuthenticatedContext) => {
+  try {
+    const project = await findProject(c);
+    if (!project) {
+      return c.json({ success: false, error: "dbt project not found" }, 404);
+    }
+    const jobId = c.req.query("jobId");
+    const limit = Math.min(Number(c.req.query("limit")) || 50, 100);
+    const filter: Record<string, unknown> = { projectId: project._id };
+    if (jobId && Types.ObjectId.isValid(jobId)) {
+      filter.jobId = new Types.ObjectId(jobId);
+    }
+    const runs = await DbtRun.find(filter)
+      .select("-logs")
+      .sort({ createdAt: -1 })
+      .limit(limit)
+      .lean();
+    return c.json({ success: true, runs });
+  } catch (error) {
+    return serverError(c, error, "Failed to list dbt runs");
+  }
+});
+
+dbtRoutes.get(
+  "/projects/:projectId/runs/:runId",
+  async (c: AuthenticatedContext) => {
+    try {
+      const project = await findProject(c);
+      if (!project) {
+        return c.json({ success: false, error: "dbt project not found" }, 404);
+      }
+      const runId = c.req.param("runId");
+      if (!Types.ObjectId.isValid(runId))
+        return badRequest(c, "Invalid run id");
+      const run = await DbtRun.findOne({
+        _id: new Types.ObjectId(runId),
+        projectId: project._id,
+      }).lean();
+      if (!run) {
+        return c.json({ success: false, error: "Run not found" }, 404);
+      }
+      // logsSince = number of log lines the client already has (cursor).
+      const logsSince = Number(c.req.query("logsSince")) || 0;
+      const logs = run.logs ?? [];
+      return c.json({
+        success: true,
+        run: {
+          ...run,
+          logs: logs.slice(logsSince),
+          logCursor: logs.length,
+        },
+      });
+    } catch (error) {
+      return serverError(c, error, "Failed to fetch dbt run");
+    }
+  },
+);
+
+dbtRoutes.post(
+  "/projects/:projectId/runs/:runId/cancel",
+  async (c: AuthenticatedContext) => {
+    try {
+      const project = await findProject(c);
+      if (!project) {
+        return c.json({ success: false, error: "dbt project not found" }, 404);
+      }
+      const runId = c.req.param("runId");
+      if (!Types.ObjectId.isValid(runId))
+        return badRequest(c, "Invalid run id");
+      const cancelled = await requestDbtRunCancel({
+        workspaceId: project.workspaceId.toString(),
+        runId,
+      });
+      if (!cancelled) {
+        return badRequest(c, "Run is not cancellable (already finished?)");
+      }
+      return c.json({ success: true });
+    } catch (error) {
+      return serverError(c, error, "Failed to cancel dbt run");
+    }
+  },
+);
+
+dbtRoutes.get(
+  "/projects/:projectId/runs/:runId/artifacts/:kind",
+  async (c: AuthenticatedContext) => {
+    try {
+      const project = await findProject(c);
+      if (!project) {
+        return c.json({ success: false, error: "dbt project not found" }, 404);
+      }
+      const runId = c.req.param("runId");
+      const kind = c.req.param("kind");
+      if (!Types.ObjectId.isValid(runId))
+        return badRequest(c, "Invalid run id");
+      if (!["manifest", "runResults", "catalog"].includes(kind)) {
+        return badRequest(c, "kind must be manifest | runResults | catalog");
+      }
+      const run = await DbtRun.findOne({
+        _id: new Types.ObjectId(runId),
+        projectId: project._id,
+      })
+        .select("artifactKeys")
+        .lean();
+      const key =
+        run?.artifactKeys?.[kind as "manifest" | "runResults" | "catalog"];
+      if (!key) {
+        return c.json({ success: false, error: "Artifact not found" }, 404);
+      }
+      const store = getDashboardArtifactStore();
+      const stream = await store.openReadStream(key);
+      if (!stream) {
+        return c.json({ success: false, error: "Artifact not found" }, 404);
+      }
+      return new Response(
+        Readable.toWeb(stream as Readable) as ReadableStream,
+        {
+          headers: {
+            "Content-Type": "application/json",
+            "Cache-Control": "private, max-age=86400, immutable",
+          },
+        },
+      );
+    } catch (error) {
+      return serverError(c, error, "Failed to stream dbt artifact");
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Ad-hoc compile / run-select (synchronous runner invocations)
+// ---------------------------------------------------------------------------
+
+const adhocSchema = z.object({
+  select: z.string().min(1).max(256).optional(),
+  environment: z.string().min(1).optional(),
+});
+
+const SELECT_PATTERN = /^[\w.+@:*\-/]+$/;
+
+dbtRoutes.post(
+  "/projects/:projectId/compile",
+  async (c: AuthenticatedContext) => {
+    try {
+      const project = await findProject(c);
+      if (!project) {
+        return c.json({ success: false, error: "dbt project not found" }, 404);
+      }
+      const parsed = adhocSchema.safeParse(
+        await c.req.json().catch(() => ({})),
+      );
+      if (!parsed.success) {
+        return badRequest(c, parsed.error.issues[0]?.message ?? "Invalid body");
+      }
+      const { select, environment } = parsed.data;
+      if (select && !SELECT_PATTERN.test(select)) {
+        return badRequest(c, "Invalid --select value");
+      }
+      const command = select ? `compile --select ${select}` : "parse";
+      const result = await runAdhocDbtCommand({
+        workspaceId: project.workspaceId.toString(),
+        projectId: project._id.toString(),
+        environmentName: environment,
+        command,
+        select,
+        timeoutMs: 3 * 60 * 1000,
+      });
+      return c.json({
+        success: true,
+        compile: {
+          ok: result.success,
+          exitCode: result.exitCode,
+          compiledSql: result.compiledSql,
+          logs: result.logs,
+        },
+      });
+    } catch (error) {
+      return serverError(c, error, "Failed to compile dbt project");
+    }
+  },
+);
+
+dbtRoutes.post(
+  "/projects/:projectId/run-select",
+  async (c: AuthenticatedContext) => {
+    try {
+      const project = await findProject(c);
+      if (!project) {
+        return c.json({ success: false, error: "dbt project not found" }, 404);
+      }
+      const parsed = adhocSchema.safeParse(await c.req.json());
+      if (!parsed.success || !parsed.data.select) {
+        return badRequest(c, "select is required");
+      }
+      const { select, environment } = parsed.data;
+      if (!SELECT_PATTERN.test(select)) {
+        return badRequest(c, "Invalid --select value");
+      }
+      const result = await runAdhocDbtCommand({
+        workspaceId: project.workspaceId.toString(),
+        projectId: project._id.toString(),
+        environmentName: environment,
+        command: `build --select ${select}`,
+        select,
+        timeoutMs: 5 * 60 * 1000,
+      });
+      return c.json({
+        success: true,
+        run: {
+          ok: result.success,
+          exitCode: result.exitCode,
+          stepResults: result.stepResults,
+          logs: result.logs,
+        },
+      });
+    } catch (error) {
+      return serverError(c, error, "Failed to run dbt model");
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Lineage — flattened manifest parent_map for the DAG view
+// ---------------------------------------------------------------------------
+
+interface ManifestForLineage {
+  nodes?: Record<
+    string,
+    {
+      name?: string;
+      resource_type?: string;
+      original_file_path?: string;
+    }
+  >;
+  sources?: Record<
+    string,
+    { name?: string; source_name?: string; resource_type?: string }
+  >;
+  parent_map?: Record<string, string[]>;
+}
+
+dbtRoutes.get(
+  "/projects/:projectId/lineage",
+  async (c: AuthenticatedContext) => {
+    try {
+      const project = await findProject(c);
+      if (!project) {
+        return c.json({ success: false, error: "dbt project not found" }, 404);
+      }
+      // Latest run with a manifest artifact wins.
+      const run = await DbtRun.findOne({
+        projectId: project._id,
+        "artifactKeys.manifest": { $exists: true, $ne: null },
+      })
+        .select("artifactKeys stepResults createdAt")
+        .sort({ createdAt: -1 })
+        .lean();
+      if (!run?.artifactKeys?.manifest) {
+        return c.json({
+          success: true,
+          lineage: { nodes: [], edges: [], generatedAt: null },
+        });
+      }
+      const store = getDashboardArtifactStore();
+      const stream = await store.openReadStream(run.artifactKeys.manifest);
+      if (!stream) {
+        return c.json({ success: false, error: "Manifest not found" }, 404);
+      }
+      const chunks: Buffer[] = [];
+      for await (const chunk of stream) {
+        chunks.push(Buffer.from(chunk as Buffer));
+      }
+      const manifest = JSON.parse(
+        Buffer.concat(chunks).toString("utf8"),
+      ) as ManifestForLineage;
+
+      const statusByUniqueId = new Map(
+        (run.stepResults ?? []).map(step => [step.uniqueId, step.status]),
+      );
+
+      const includedTypes = new Set(["model", "seed", "snapshot", "source"]);
+      const nodes: Array<{
+        id: string;
+        name: string;
+        resourceType: string;
+        filePath?: string;
+        lastStatus?: string;
+      }> = [];
+
+      for (const [id, node] of Object.entries(manifest.nodes ?? {})) {
+        const resourceType = node.resource_type ?? id.split(".")[0];
+        if (!includedTypes.has(resourceType)) continue;
+        nodes.push({
+          id,
+          name: node.name ?? id,
+          resourceType,
+          filePath: node.original_file_path,
+          lastStatus: statusByUniqueId.get(id),
+        });
+      }
+      for (const [id, source] of Object.entries(manifest.sources ?? {})) {
+        nodes.push({
+          id,
+          name: source.source_name
+            ? `${source.source_name}.${source.name}`
+            : (source.name ?? id),
+          resourceType: "source",
+        });
+      }
+
+      const nodeIds = new Set(nodes.map(node => node.id));
+      const edges: Array<{ source: string; target: string }> = [];
+      for (const [child, parents] of Object.entries(
+        manifest.parent_map ?? {},
+      )) {
+        if (!nodeIds.has(child)) continue;
+        for (const parent of parents) {
+          if (!nodeIds.has(parent)) continue;
+          edges.push({ source: parent, target: child });
+        }
+      }
+
+      return c.json({
+        success: true,
+        lineage: { nodes, edges, generatedAt: run.createdAt },
+      });
+    } catch (error) {
+      return serverError(c, error, "Failed to build dbt lineage");
+    }
+  },
+);

--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -597,8 +597,9 @@ dbtRoutes.patch(
         return c.json({ success: false, error: "dbt project not found" }, 404);
       }
       const jobId = c.req.param("jobId");
-      if (!Types.ObjectId.isValid(jobId))
+      if (!Types.ObjectId.isValid(jobId)) {
         return badRequest(c, "Invalid job id");
+      }
       const job = await DbtJob.findOne({
         _id: new Types.ObjectId(jobId),
         projectId: project._id,
@@ -650,8 +651,9 @@ dbtRoutes.delete(
         return c.json({ success: false, error: "dbt project not found" }, 404);
       }
       const jobId = c.req.param("jobId");
-      if (!Types.ObjectId.isValid(jobId))
+      if (!Types.ObjectId.isValid(jobId)) {
         return badRequest(c, "Invalid job id");
+      }
       const result = await DbtJob.deleteOne({
         _id: new Types.ObjectId(jobId),
         projectId: project._id,
@@ -675,8 +677,9 @@ dbtRoutes.post(
         return c.json({ success: false, error: "dbt project not found" }, 404);
       }
       const jobId = c.req.param("jobId");
-      if (!Types.ObjectId.isValid(jobId))
+      if (!Types.ObjectId.isValid(jobId)) {
         return badRequest(c, "Invalid job id");
+      }
       const job = await DbtJob.findOne({
         _id: new Types.ObjectId(jobId),
         projectId: project._id,
@@ -733,8 +736,9 @@ dbtRoutes.get(
         return c.json({ success: false, error: "dbt project not found" }, 404);
       }
       const runId = c.req.param("runId");
-      if (!Types.ObjectId.isValid(runId))
+      if (!Types.ObjectId.isValid(runId)) {
         return badRequest(c, "Invalid run id");
+      }
       const run = await DbtRun.findOne({
         _id: new Types.ObjectId(runId),
         projectId: project._id,
@@ -768,8 +772,9 @@ dbtRoutes.post(
         return c.json({ success: false, error: "dbt project not found" }, 404);
       }
       const runId = c.req.param("runId");
-      if (!Types.ObjectId.isValid(runId))
+      if (!Types.ObjectId.isValid(runId)) {
         return badRequest(c, "Invalid run id");
+      }
       const cancelled = await requestDbtRunCancel({
         workspaceId: project.workspaceId.toString(),
         runId,
@@ -794,8 +799,9 @@ dbtRoutes.get(
       }
       const runId = c.req.param("runId");
       const kind = c.req.param("kind");
-      if (!Types.ObjectId.isValid(runId))
+      if (!Types.ObjectId.isValid(runId)) {
         return badRequest(c, "Invalid run id");
+      }
       if (!["manifest", "runResults", "catalog"].includes(kind)) {
         return badRequest(c, "kind must be manifest | runResults | catalog");
       }

--- a/app/package.json
+++ b/app/package.json
@@ -31,6 +31,7 @@
     "@streamdown/code": "^1.1.1",
     "@types/react-syntax-highlighter": "^15.5.13",
     "@uwdata/mosaic-core": "^0.21.1",
+    "@xyflow/react": "^12.11.0",
     "ai": "6.0.196",
     "axios": "^1.6.2",
     "date-fns": "^4.1.0",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -43,6 +43,8 @@ const DashboardsExplorer = lazy(loadDashboardsExplorer);
 const loadAppsExplorer = () => import("./components/AppsExplorer");
 const AppsExplorer = lazy(loadAppsExplorer);
 const PublicSharePage = lazy(() => import("./pages/PublicSharePage"));
+const loadDbtExplorer = () => import("./components/DbtExplorer");
+const DbtExplorer = lazy(loadDbtExplorer);
 import { AuthWrapper } from "./components/AuthWrapper";
 import { AcceptInvite } from "./components/AcceptInvite";
 import { WorkspaceProvider } from "./contexts/workspace-context";
@@ -453,6 +455,8 @@ function MainApp() {
         return <DashboardsExplorer />;
       case "apps":
         return <AppsExplorer />;
+      case "dbt":
+        return <DbtExplorer />;
       case "settings":
         return <SettingsExplorer />;
       default:

--- a/app/src/agent-runtime/client-tool-manifest.ts
+++ b/app/src/agent-runtime/client-tool-manifest.ts
@@ -26,6 +26,7 @@ export type AgentToolDomain =
   | "dashboard"
   | "flow"
   | "app"
+  | "dbt"
   | "search"
   | "memory"
   | "database"
@@ -36,6 +37,7 @@ export type ClientToolExecutor =
   | "dashboard"
   | "flow"
   | "app"
+  | "dbt"
   | "data";
 
 export interface ToolUiConfig {
@@ -537,6 +539,94 @@ export const AGENT_TOOL_MANIFEST = {
     getLabel: () => "Rebuilding app preview",
     icon: "play",
   },
+  read_dbt_project_tree: {
+    domain: "dbt",
+    execution: "client",
+    clientExecutor: "dbt",
+    getLabel: () => "Reading dbt project tree",
+    icon: "list",
+  },
+  read_dbt_file: {
+    domain: "dbt",
+    execution: "client",
+    clientExecutor: "dbt",
+    getLabel: input => {
+      const path = (input as Record<string, unknown>)?.path;
+      return path ? `Reading ${path}` : "Reading dbt file";
+    },
+    icon: "eye",
+  },
+  create_dbt_file: {
+    domain: "dbt",
+    execution: "client",
+    clientExecutor: "dbt",
+    longRunning: true,
+    getLabel: input => {
+      const path = (input as Record<string, unknown>)?.path;
+      return path ? `Creating ${path}` : "Creating dbt file";
+    },
+    icon: "plus",
+    preview: { field: "contents", language: "sql" },
+  },
+  modify_dbt_file: {
+    domain: "dbt",
+    execution: "client",
+    clientExecutor: "dbt",
+    longRunning: true,
+    getLabel: input => {
+      const path = (input as Record<string, unknown>)?.path;
+      return path ? `Editing ${path}` : "Editing dbt file";
+    },
+    icon: "pencil",
+    preview: { field: "contents", language: "sql" },
+  },
+  delete_dbt_file: {
+    domain: "dbt",
+    execution: "client",
+    clientExecutor: "dbt",
+    getLabel: input => {
+      const path = (input as Record<string, unknown>)?.path;
+      return path ? `Deleting ${path}` : "Deleting dbt file";
+    },
+    icon: "trash",
+  },
+  dbt_parse: {
+    domain: "dbt",
+    execution: "server",
+    longRunning: true,
+    getLabel: () => "Validating dbt project",
+    icon: "shield-check",
+  },
+  dbt_compile_model: {
+    domain: "dbt",
+    execution: "server",
+    longRunning: true,
+    getLabel: input => {
+      const model = (input as Record<string, unknown>)?.model;
+      return model ? `Compiling ${model}` : "Compiling model";
+    },
+    icon: "shield-check",
+  },
+  dbt_run_model: {
+    domain: "dbt",
+    execution: "server",
+    longRunning: true,
+    getLabel: input => {
+      const model = (input as Record<string, unknown>)?.model;
+      return model ? `Building ${model}` : "Building model";
+    },
+    icon: "play",
+  },
+  dbt_run_job: {
+    domain: "dbt",
+    execution: "server",
+    longRunning: true,
+    getLabel: input => {
+      const jobName = (input as Record<string, unknown>)?.jobName;
+      return jobName ? `Running job "${jobName}"` : "Running dbt job";
+    },
+    icon: "play",
+  },
   search_consoles: {
     domain: "search",
     execution: "server",
@@ -758,6 +848,10 @@ export const CONSOLE_EXECUTOR_TOOL_NAMES = createToolNameSet(
 
 export const APP_EXECUTOR_TOOL_NAMES = createToolNameSet(
   entry => entry.execution === "client" && entry.clientExecutor === "app",
+);
+
+export const DBT_EXECUTOR_TOOL_NAMES = createToolNameSet(
+  entry => entry.execution === "client" && entry.clientExecutor === "dbt",
 );
 
 export const DATA_SOURCE_EXECUTOR_TOOL_NAMES = createToolNameSet(

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -108,11 +108,13 @@ import { buildModificationDiff } from "../utils/consoleModification";
 import {
   DASHBOARD_EXECUTOR_TOOL_NAMES,
   APP_EXECUTOR_TOOL_NAMES,
+  DBT_EXECUTOR_TOOL_NAMES,
   DATA_SOURCE_EXECUTOR_TOOL_NAMES,
   getAgentToolManifestEntry,
   type AgentToolName,
 } from "../agent-runtime/client-tool-manifest";
 import { executeAppAgentTool } from "../app-runtime/agent-tools";
+import { executeDbtAgentTool } from "../dbt-runtime/agent-tools";
 import { executeDataSourceTool } from "../agent-runtime/data-source-tools";
 import { UpgradePrompt } from "./UpgradePrompt";
 import {
@@ -2122,6 +2124,44 @@ const Chat: React.FC<ChatProps> = ({
                   appError instanceof Error
                     ? appError.message
                     : "App tool execution failed",
+              });
+            }
+          })();
+          return;
+        }
+
+        // --- dbt tools (client-side) ---
+        if (DBT_EXECUTOR_TOOL_NAMES.has(toolName as AgentToolName)) {
+          const activeDbtTool = registerActiveClientToolCall(
+            toolName,
+            toolCall.toolCallId,
+          );
+          // Fire-and-forget, same rationale as app tools above.
+          void (async () => {
+            try {
+              const dbtToolOutput = await executeDbtAgentTool(toolName, input);
+              if (activeDbtTool.abortController.signal.aborted) return;
+              settleActiveClientToolCall(
+                toolName,
+                toolCall.toolCallId,
+                dbtToolOutput ?? {
+                  success: false,
+                  error: `dbt tool "${toolName}" did not return a result.`,
+                },
+              );
+            } catch (dbtError) {
+              if (
+                manualStopRequestedRef.current ||
+                activeDbtTool.abortController.signal.aborted
+              ) {
+                return;
+              }
+              settleActiveClientToolCall(toolName, toolCall.toolCallId, {
+                success: false,
+                error:
+                  dbtError instanceof Error
+                    ? dbtError.message
+                    : "dbt tool execution failed",
               });
             }
           })();

--- a/app/src/components/DbtConsoleView.tsx
+++ b/app/src/components/DbtConsoleView.tsx
@@ -1,0 +1,507 @@
+/**
+ * DbtConsoleView — per-project command bar + Problems panel (dbt Cloud
+ * parity). Hosts:
+ *   - a free-form dbt command input (validated server-side against the same
+ *     allowlist as stored jobs) with an environment + "defer to prod" toggle;
+ *   - a Problems tab that runs `dbt parse` and surfaces compile/parse
+ *     diagnostics, each clickable to open the offending file;
+ *   - Results + Logs tabs for the most recent command.
+ */
+
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import {
+  Box,
+  Button,
+  Checkbox,
+  Chip,
+  CircularProgress,
+  FormControlLabel,
+  MenuItem,
+  Select,
+  Tab,
+  Tabs,
+  TextField,
+  Typography,
+} from "@mui/material";
+import {
+  AlertTriangle as WarnIcon,
+  CircleX as ErrorIcon,
+  Play as RunIcon,
+} from "lucide-react";
+import { useWorkspace } from "../contexts/workspace-context";
+import {
+  useDbtStore,
+  type DbtCommandRunResult,
+  type DbtRunLogLine,
+} from "../store/dbtStore";
+import { focusDbtFileTab } from "../dbt-runtime/shell";
+
+const DbtLineageView = lazy(() => import("./DbtLineageView"));
+
+interface Problem {
+  severity: "error" | "warn";
+  message: string;
+  filePath?: string;
+}
+
+// dbt error messages frequently embed the offending file path, e.g.
+//   "Compilation Error in model stg_orders (models/staging/stg_orders.sql)"
+//   "Parsing Error ... path: models/schema.yml"
+const FILE_IN_PARENS = /\(([^()]+\.(?:sql|yml|yaml))\)/i;
+const FILE_AFTER_PATH = /\bpath:\s*([^\s,)]+\.(?:sql|yml|yaml))/i;
+
+function extractFilePath(message: string): string | undefined {
+  const m = message.match(FILE_IN_PARENS) ?? message.match(FILE_AFTER_PATH);
+  return m?.[1];
+}
+
+/** Pull error/warn diagnostics out of a parse run's JSON log stream. */
+function logsToProblems(logs: DbtRunLogLine[]): Problem[] {
+  const problems: Problem[] = [];
+  const seen = new Set<string>();
+  for (const log of logs) {
+    const severity =
+      log.level === "error" ? "error" : log.level === "warn" ? "warn" : null;
+    if (!severity) continue;
+    const message = log.line.trim();
+    if (!message || seen.has(message)) continue;
+    seen.add(message);
+    problems.push({ severity, message, filePath: extractFilePath(message) });
+  }
+  return problems;
+}
+
+function LogLines({ logs }: { logs: DbtRunLogLine[] }) {
+  return (
+    <Box
+      sx={{
+        fontFamily: "monospace",
+        fontSize: "0.75rem",
+        whiteSpace: "pre-wrap",
+        p: 1,
+        overflow: "auto",
+        height: "100%",
+      }}
+    >
+      {logs.length === 0 ? (
+        <Typography variant="caption" color="text.secondary">
+          No output yet — run a command.
+        </Typography>
+      ) : (
+        logs.map((log, index) => (
+          <Box
+            key={index}
+            sx={{
+              color:
+                log.level === "error"
+                  ? "error.main"
+                  : log.level === "warn"
+                    ? "warning.main"
+                    : "text.primary",
+            }}
+          >
+            {log.line}
+          </Box>
+        ))
+      )}
+    </Box>
+  );
+}
+
+export default function DbtConsoleView({ projectId }: { projectId: string }) {
+  const { currentWorkspace } = useWorkspace();
+  const workspaceId = currentWorkspace?.id;
+
+  const project = useDbtStore(s => s.projects.find(p => p._id === projectId));
+  const fetchProjects = useDbtStore(s => s.fetchProjects);
+  const compileModel = useDbtStore(s => s.compileModel);
+  const runCommand = useDbtStore(s => s.runCommand);
+
+  const [view, setView] = useState<"console" | "lineage">("console");
+  const [environment, setEnvironment] = useState("");
+  const [defer, setDefer] = useState(false);
+  const [command, setCommand] = useState("");
+  const [tab, setTab] = useState<"problems" | "results" | "logs">("problems");
+  const [busy, setBusy] = useState<"command" | "parse" | null>(null);
+  const [result, setResult] = useState<DbtCommandRunResult | null>(null);
+  const [problems, setProblems] = useState<Problem[] | null>(null);
+
+  useEffect(() => {
+    if (!project && workspaceId) void fetchProjects(workspaceId);
+  }, [project, workspaceId, fetchProjects]);
+
+  useEffect(() => {
+    if (project && !environment) setEnvironment(project.defaultEnvironment);
+  }, [project, environment]);
+
+  const runParse = useCallback(async () => {
+    if (!workspaceId) return;
+    setBusy("parse");
+    const compile = await compileModel(
+      workspaceId,
+      projectId,
+      undefined,
+      environment || undefined,
+    );
+    setProblems(logsToProblems(compile?.logs ?? []));
+    setBusy(null);
+  }, [workspaceId, projectId, environment, compileModel]);
+
+  // Parse once on open (and whenever the environment changes) so the Problems
+  // tab is populated without an explicit click.
+  useEffect(() => {
+    if (workspaceId && environment) void runParse();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaceId, environment]);
+
+  const handleRunCommand = useCallback(async () => {
+    if (!workspaceId || !command.trim()) return;
+    if (
+      environment === "prod" &&
+      !window.confirm(`Run "${command}" against the prod environment?`)
+    ) {
+      return;
+    }
+    setBusy("command");
+    setTab("logs");
+    const res = await runCommand(
+      workspaceId,
+      projectId,
+      command.trim(),
+      environment || undefined,
+      defer,
+    );
+    setResult(res);
+    if (res && res.stepResults.length > 0) setTab("results");
+    setBusy(null);
+  }, [workspaceId, projectId, command, environment, defer, runCommand]);
+
+  const errorCount = useMemo(
+    () => problems?.filter(p => p.severity === "error").length ?? 0,
+    [problems],
+  );
+  const warnCount = useMemo(
+    () => problems?.filter(p => p.severity === "warn").length ?? 0,
+    [problems],
+  );
+
+  if (!project) {
+    return (
+      <Box sx={{ p: 3, color: "text.secondary" }}>
+        <Typography variant="body2">Loading project…</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
+      <Tabs
+        value={view}
+        onChange={(_e, value) => setView(value)}
+        sx={{
+          minHeight: 32,
+          borderBottom: "1px solid",
+          borderColor: "divider",
+        }}
+      >
+        <Tab label="Console" value="console" sx={{ minHeight: 32, py: 0 }} />
+        <Tab label="Lineage" value="lineage" sx={{ minHeight: 32, py: 0 }} />
+      </Tabs>
+
+      {view === "lineage" ? (
+        <Box sx={{ flex: 1, minHeight: 0 }}>
+          <Suspense
+            fallback={
+              <Box sx={{ p: 3, display: "flex", justifyContent: "center" }}>
+                <CircularProgress size={20} />
+              </Box>
+            }
+          >
+            <DbtLineageView projectId={projectId} />
+          </Suspense>
+        </Box>
+      ) : (
+        <Box
+          sx={{
+            flex: 1,
+            minHeight: 0,
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
+          {/* Command bar */}
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 1,
+              px: 1.5,
+              py: 1,
+              borderBottom: "1px solid",
+              borderColor: "divider",
+            }}
+          >
+            <Select
+              size="small"
+              value={environment}
+              onChange={e => setEnvironment(e.target.value)}
+              sx={{ fontSize: "0.8rem", minWidth: 90 }}
+            >
+              {project.environments.map(env => (
+                <MenuItem key={env.name} value={env.name}>
+                  {env.name}
+                </MenuItem>
+              ))}
+            </Select>
+            <TextField
+              size="small"
+              fullWidth
+              placeholder="dbt build --select stg_orders+"
+              value={command}
+              onChange={e => setCommand(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === "Enter") void handleRunCommand();
+              }}
+              InputProps={{
+                sx: { fontFamily: "monospace", fontSize: "0.8rem" },
+              }}
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  size="small"
+                  checked={defer}
+                  onChange={e => setDefer(e.target.checked)}
+                />
+              }
+              label={
+                <Typography variant="caption" sx={{ whiteSpace: "nowrap" }}>
+                  Defer to prod
+                </Typography>
+              }
+              sx={{ mr: 0 }}
+            />
+            <Button
+              size="small"
+              variant="contained"
+              disabled={busy !== null || !command.trim()}
+              startIcon={
+                busy === "command" ? (
+                  <CircularProgress size={12} color="inherit" />
+                ) : (
+                  <RunIcon size={14} />
+                )
+              }
+              onClick={handleRunCommand}
+            >
+              Run
+            </Button>
+          </Box>
+
+          {/* Output tabs */}
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              borderBottom: "1px solid",
+              borderColor: "divider",
+            }}
+          >
+            <Tabs
+              value={tab}
+              onChange={(_e, value) => setTab(value)}
+              sx={{ minHeight: 32, flex: 1 }}
+            >
+              <Tab
+                label={`Problems${problems ? ` (${errorCount + warnCount})` : ""}`}
+                value="problems"
+                sx={{ minHeight: 32, py: 0 }}
+              />
+              <Tab
+                label="Results"
+                value="results"
+                sx={{ minHeight: 32, py: 0 }}
+              />
+              <Tab label="Logs" value="logs" sx={{ minHeight: 32, py: 0 }} />
+            </Tabs>
+            {tab === "problems" && (
+              <Button
+                size="small"
+                disabled={busy !== null}
+                onClick={runParse}
+                sx={{ mr: 1 }}
+              >
+                {busy === "parse" ? "Parsing…" : "Re-parse"}
+              </Button>
+            )}
+          </Box>
+
+          <Box sx={{ flex: 1, minHeight: 0, overflow: "auto" }}>
+            {tab === "problems" && (
+              <Box>
+                {problems === null || busy === "parse" ? (
+                  <Box sx={{ p: 2 }}>
+                    <Typography variant="caption" color="text.secondary">
+                      {busy === "parse"
+                        ? "Parsing project…"
+                        : "Press Re-parse."}
+                    </Typography>
+                  </Box>
+                ) : problems.length === 0 ? (
+                  <Box sx={{ p: 2 }}>
+                    <Typography variant="caption" color="success.main">
+                      No problems — project parses cleanly.
+                    </Typography>
+                  </Box>
+                ) : (
+                  problems.map((problem, index) => (
+                    <Box
+                      key={index}
+                      onClick={() => {
+                        if (problem.filePath) {
+                          focusDbtFileTab(projectId, problem.filePath);
+                        }
+                      }}
+                      sx={{
+                        display: "flex",
+                        alignItems: "flex-start",
+                        gap: 1,
+                        px: 1.5,
+                        py: 0.75,
+                        borderBottom: "1px solid",
+                        borderColor: "divider",
+                        cursor: problem.filePath ? "pointer" : "default",
+                        "&:hover": problem.filePath
+                          ? { bgcolor: "action.hover" }
+                          : undefined,
+                      }}
+                    >
+                      {problem.severity === "error" ? (
+                        <ErrorIcon
+                          size={15}
+                          style={{ marginTop: 2, flexShrink: 0 }}
+                          color="var(--mui-palette-error-main)"
+                        />
+                      ) : (
+                        <WarnIcon
+                          size={15}
+                          style={{ marginTop: 2, flexShrink: 0 }}
+                          color="var(--mui-palette-warning-main)"
+                        />
+                      )}
+                      <Box sx={{ minWidth: 0 }}>
+                        <Typography
+                          variant="caption"
+                          sx={{
+                            display: "block",
+                            fontFamily: "monospace",
+                            whiteSpace: "pre-wrap",
+                          }}
+                        >
+                          {problem.message}
+                        </Typography>
+                        {problem.filePath && (
+                          <Typography variant="caption" color="primary">
+                            {problem.filePath}
+                          </Typography>
+                        )}
+                      </Box>
+                    </Box>
+                  ))
+                )}
+              </Box>
+            )}
+
+            {tab === "results" && (
+              <Box sx={{ p: 1 }}>
+                {!result || result.stepResults.length === 0 ? (
+                  <Typography variant="caption" color="text.secondary">
+                    {busy === "command"
+                      ? "Running…"
+                      : "Run a build/run/test command to see node results."}
+                  </Typography>
+                ) : (
+                  <Box
+                    component="table"
+                    sx={{
+                      width: "100%",
+                      fontSize: "0.75rem",
+                      borderCollapse: "collapse",
+                      "& td, & th": {
+                        borderBottom: "1px solid",
+                        borderColor: "divider",
+                        p: 0.5,
+                        textAlign: "left",
+                      },
+                    }}
+                  >
+                    <thead>
+                      <tr>
+                        <th>Node</th>
+                        <th>Type</th>
+                        <th>Status</th>
+                        <th>Time</th>
+                        <th>Rows</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {result.stepResults.map(step => (
+                        <Box
+                          component="tr"
+                          key={step.uniqueId}
+                          sx={{
+                            color:
+                              step.status === "error" || step.status === "fail"
+                                ? "error.main"
+                                : step.status === "warn"
+                                  ? "warning.main"
+                                  : "inherit",
+                          }}
+                        >
+                          <td>{step.name}</td>
+                          <td>{step.resourceType}</td>
+                          <td>{step.status}</td>
+                          <td>{(step.executionTimeMs / 1000).toFixed(2)}s</td>
+                          <td>{step.rowsAffected ?? ""}</td>
+                        </Box>
+                      ))}
+                    </tbody>
+                  </Box>
+                )}
+              </Box>
+            )}
+
+            {tab === "logs" && <LogLines logs={result?.logs ?? []} />}
+          </Box>
+
+          {result && tab !== "logs" && (
+            <Box
+              sx={{
+                px: 1.5,
+                py: 0.5,
+                borderTop: "1px solid",
+                borderColor: "divider",
+              }}
+            >
+              <Chip
+                size="small"
+                label={
+                  result.ok ? "Last command: success" : "Last command: failed"
+                }
+                color={result.ok ? "success" : "error"}
+                variant="outlined"
+              />
+            </Box>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/app/src/components/DbtExplorer.tsx
+++ b/app/src/components/DbtExplorer.tsx
@@ -1,0 +1,755 @@
+/**
+ * DbtExplorer — left-pane tree for dbt projects (pattern: AppsExplorer).
+ *
+ * Per project:
+ *   Files — folder tree of dbt_files (click → dbt-file tab)
+ *   Jobs  — one row per dbt job (click → dbt-job tab)
+ */
+
+import { useState, useEffect, useCallback, useMemo } from "react";
+import {
+  Box,
+  IconButton,
+  Tooltip,
+  Typography,
+  MenuItem,
+  ListItemIcon,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  TextField,
+  Button,
+  Select,
+  FormControl,
+  InputLabel,
+} from "@mui/material";
+import {
+  Plus as AddIcon,
+  RefreshCw as RefreshIcon,
+  GitBranch as ProjectIcon,
+  FileCode as FileIcon,
+  CalendarClock as JobIcon,
+  Pencil as RenameIcon,
+  Trash2 as DeleteIcon,
+  ExternalLink as OpenIcon,
+  FilePlus as NewFileIcon,
+} from "lucide-react";
+import { useWorkspace } from "../contexts/workspace-context";
+import { useConsoleStore } from "../store/consoleStore";
+import { useExplorerStore } from "../store/explorerStore";
+import { useSchemaStore, type Connection } from "../store/schemaStore";
+import {
+  useDbtStore,
+  type DbtJobItem,
+  type DbtProjectItem,
+} from "../store/dbtStore";
+import { focusDbtFileTab, focusDbtJobTab } from "../dbt-runtime/shell";
+import ResourceTree, { type ResourceTreeNode } from "./ResourceTree";
+import ExplorerShell from "./ExplorerShell";
+
+// Node id encoding (flat ResourceTree ids stay unique and parseable):
+// Project node: "<projectId>"
+// Folder node:  "<projectId>::dir::<dirPath>"
+// File node:    "<projectId>::file::<filePath>"
+// Job node:     "<projectId>::job::<jobId>"
+const FILE_SEP = "::file::";
+const DIR_SEP = "::dir::";
+const JOB_SEP = "::job::";
+const JOBS_DIR = "__jobs";
+
+const DBT_COMPATIBLE_TYPES = new Set([
+  "postgresql",
+  "cloudsql-postgres",
+  "redshift",
+  "bigquery",
+  "clickhouse",
+  "mysql",
+  "mssql",
+]);
+
+function dirname(path: string): string {
+  const parts = path.split("/").filter(Boolean);
+  parts.pop();
+  return parts.join("/");
+}
+
+interface ParsedNode {
+  kind: "project" | "dir" | "file" | "job";
+  projectId: string;
+  path: string;
+}
+
+function parseNodeId(id: string): ParsedNode {
+  if (id.includes(JOB_SEP)) {
+    const [projectId, path] = id.split(JOB_SEP);
+    return { kind: "job", projectId, path };
+  }
+  if (id.includes(FILE_SEP)) {
+    const [projectId, path] = id.split(FILE_SEP);
+    return { kind: "file", projectId, path };
+  }
+  if (id.includes(DIR_SEP)) {
+    const [projectId, path] = id.split(DIR_SEP);
+    return { kind: "dir", projectId, path };
+  }
+  return { kind: "project", projectId: id, path: "" };
+}
+
+/** Build nested folder/file nodes for one project's file paths. */
+function buildFileNodes(
+  projectId: string,
+  paths: string[],
+): ResourceTreeNode[] {
+  const root: ResourceTreeNode = {
+    id: `${projectId}${DIR_SEP}`,
+    name: "",
+    path: "",
+    isDirectory: true,
+    children: [],
+  };
+  for (const filePath of paths) {
+    // .gitkeep files exist only to materialize empty scaffold dirs.
+    if (filePath.endsWith(".gitkeep")) {
+      const dir = dirname(filePath);
+      if (dir) {
+        // Ensure the directory chain exists even with no visible files.
+        const segments = dir.split("/").filter(Boolean);
+        let cursor = root;
+        segments.forEach((segment, index) => {
+          const path = segments.slice(0, index + 1).join("/");
+          const id = `${projectId}${DIR_SEP}${path}`;
+          let child = cursor.children?.find(c => c.id === id);
+          if (!child) {
+            child = {
+              id,
+              name: segment,
+              path,
+              isDirectory: true,
+              children: [],
+            };
+            cursor.children?.push(child);
+          }
+          cursor = child;
+        });
+      }
+      continue;
+    }
+    const segments = filePath.split("/").filter(Boolean);
+    let cursor = root;
+    segments.forEach((segment, index) => {
+      const isLeaf = index === segments.length - 1;
+      const path = segments.slice(0, index + 1).join("/");
+      const id = isLeaf
+        ? `${projectId}${FILE_SEP}${path}`
+        : `${projectId}${DIR_SEP}${path}`;
+      let child = cursor.children?.find(c => c.id === id);
+      if (!child) {
+        child = {
+          id,
+          name: segment,
+          path,
+          isDirectory: !isLeaf,
+          children: isLeaf ? undefined : [],
+        };
+        cursor.children?.push(child);
+      }
+      cursor = child;
+    });
+  }
+  const sort = (nodes: ResourceTreeNode[]) => {
+    nodes.sort((a, b) => {
+      if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+    nodes.forEach(n => n.children && sort(n.children));
+  };
+  sort(root.children || []);
+  return root.children || [];
+}
+
+function scheduleSummary(job: DbtJobItem): string {
+  if (!job.schedule?.cron) return "manual";
+  return `${job.schedule.cron} ${job.schedule.timezone ?? "UTC"}`;
+}
+
+export function DbtExplorer() {
+  const { currentWorkspace } = useWorkspace();
+  const workspaceId = currentWorkspace?.id;
+
+  const projects = useDbtStore(s => s.projects);
+  const projectsLoaded = useDbtStore(s => s.projectsLoaded);
+  const filePathsByProject = useDbtStore(s => s.filePathsByProject);
+  const jobsByProject = useDbtStore(s => s.jobsByProject);
+  const loading = useDbtStore(s => !!s.loading.projects);
+  const error = useDbtStore(s => s.error.projects ?? null);
+  const fetchProjects = useDbtStore(s => s.fetchProjects);
+  const fetchFiles = useDbtStore(s => s.fetchFiles);
+  const fetchJobs = useDbtStore(s => s.fetchJobs);
+  const createProject = useDbtStore(s => s.createProject);
+  const deleteProject = useDbtStore(s => s.deleteProject);
+  const createFile = useDbtStore(s => s.createFile);
+  const deleteFile = useDbtStore(s => s.deleteFile);
+  const renameFile = useDbtStore(s => s.renameFile);
+  const deleteJob = useDbtStore(s => s.deleteJob);
+
+  const connections = useSchemaStore(s => s.connections);
+  const ensureConnections = useSchemaStore(s => s.ensureConnections);
+
+  const activeTabId = useConsoleStore(s => s.activeTabId);
+  const tabs = useConsoleStore(s => s.tabs);
+  const activeTab = activeTabId ? tabs[activeTabId] : undefined;
+  const activeItemId = useMemo(() => {
+    if (activeTab?.kind === "dbt-file") {
+      return `${activeTab.metadata?.projectId}${FILE_SEP}${activeTab.metadata?.path}`;
+    }
+    if (activeTab?.kind === "dbt-job") {
+      return `${activeTab.metadata?.projectId}${JOB_SEP}${activeTab.metadata?.jobId}`;
+    }
+    return null;
+  }, [activeTab]);
+
+  const expandedFolders = useExplorerStore(s => s.dbt.expandedFolders);
+  const toggleDbtFolder = useExplorerStore(s => s.toggleDbtFolder);
+  const expandDbtFolder = useExplorerStore(s => s.expandDbtFolder);
+
+  const [loadingProjects, setLoadingProjects] = useState<
+    Record<string, boolean>
+  >({});
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createName, setCreateName] = useState("");
+  const [createConnectionId, setCreateConnectionId] = useState("");
+  const [createDevSchema, setCreateDevSchema] = useState("dbt_dev");
+  const [createProdSchema, setCreateProdSchema] = useState("analytics");
+  const [creating, setCreating] = useState(false);
+  const [newFileTarget, setNewFileTarget] = useState<{
+    projectId: string;
+    dir: string;
+  } | null>(null);
+  const [newFileName, setNewFileName] = useState("");
+  const [renameTarget, setRenameTarget] = useState<{
+    parsed: ParsedNode;
+    name: string;
+  } | null>(null);
+  const [renameValue, setRenameValue] = useState("");
+  const [deleteTarget, setDeleteTarget] = useState<{
+    parsed: ParsedNode;
+    name: string;
+  } | null>(null);
+
+  useEffect(() => {
+    if (workspaceId) void fetchProjects(workspaceId);
+  }, [workspaceId, fetchProjects]);
+
+  useEffect(() => {
+    if (createOpen && workspaceId) void ensureConnections(workspaceId);
+  }, [createOpen, workspaceId, ensureConnections]);
+
+  const dbtConnections: Connection[] = useMemo(() => {
+    const all = workspaceId ? (connections[workspaceId] ?? []) : [];
+    return all.filter(conn => DBT_COMPATIBLE_TYPES.has(conn.type));
+  }, [workspaceId, connections]);
+
+  const buildProjectNodes = useCallback(
+    (items: DbtProjectItem[]): ResourceTreeNode[] =>
+      items.map(project => {
+        const paths = filePathsByProject[project._id];
+        const jobs = jobsByProject[project._id];
+        let children: ResourceTreeNode[] | undefined;
+        if (paths) {
+          children = buildFileNodes(project._id, paths);
+          children.push({
+            id: `${project._id}${DIR_SEP}${JOBS_DIR}`,
+            name: "Jobs",
+            path: JOBS_DIR,
+            isDirectory: true,
+            children: (jobs ?? []).map(job => ({
+              id: `${project._id}${JOB_SEP}${job._id}`,
+              name: `${job.name} (${scheduleSummary(job)})`,
+              path: `job/${job._id}`,
+              isDirectory: false,
+            })),
+          });
+        }
+        return {
+          id: project._id,
+          name: `${project.name} (${project.defaultEnvironment})`,
+          path: project._id,
+          isDirectory: true,
+          children,
+        };
+      }),
+    [filePathsByProject, jobsByProject],
+  );
+
+  const sections = useMemo(
+    () => [
+      {
+        key: "projects",
+        label: "Projects",
+        icon: <ProjectIcon size={16} strokeWidth={1.5} />,
+        nodes: buildProjectNodes(projects),
+      },
+    ],
+    [projects, buildProjectNodes],
+  );
+
+  const handleRefresh = useCallback(() => {
+    if (workspaceId) void fetchProjects(workspaceId);
+  }, [workspaceId, fetchProjects]);
+
+  const handleLoadChildren = useCallback(
+    async (node: ResourceTreeNode) => {
+      const parsed = parseNodeId(node.id);
+      if (
+        parsed.kind !== "project" ||
+        !workspaceId ||
+        filePathsByProject[parsed.projectId]
+      ) {
+        return;
+      }
+      setLoadingProjects(prev => ({ ...prev, [parsed.projectId]: true }));
+      await Promise.all([
+        fetchFiles(workspaceId, parsed.projectId),
+        fetchJobs(workspaceId, parsed.projectId),
+      ]);
+      setLoadingProjects(prev => ({ ...prev, [parsed.projectId]: false }));
+    },
+    [workspaceId, filePathsByProject, fetchFiles, fetchJobs],
+  );
+
+  const handleItemClick = useCallback(
+    (node: ResourceTreeNode) => {
+      const parsed = parseNodeId(node.id);
+      if (parsed.kind === "file") {
+        focusDbtFileTab(parsed.projectId, parsed.path);
+      } else if (parsed.kind === "job") {
+        const job = (jobsByProject[parsed.projectId] ?? []).find(
+          j => j._id === parsed.path,
+        );
+        focusDbtJobTab(parsed.projectId, parsed.path, job?.name ?? node.name);
+      }
+    },
+    [jobsByProject],
+  );
+
+  const getItemIcon = useCallback((node: ResourceTreeNode) => {
+    const parsed = parseNodeId(node.id);
+    if (parsed.kind === "project") {
+      return <ProjectIcon size={16} strokeWidth={1.5} />;
+    }
+    if (parsed.kind === "file") {
+      return <FileIcon size={16} strokeWidth={1.5} />;
+    }
+    if (parsed.kind === "job") {
+      return <JobIcon size={16} strokeWidth={1.5} />;
+    }
+    return undefined;
+  }, []);
+
+  const getContextMenuItems = useCallback(
+    (node: ResourceTreeNode, helpers: { closeMenu: () => void }) => {
+      const parsed = parseNodeId(node.id);
+      const items = [];
+
+      if (parsed.kind === "file" || parsed.kind === "job") {
+        items.push(
+          <MenuItem
+            key="open"
+            onClick={() => {
+              handleItemClick(node);
+              helpers.closeMenu();
+            }}
+          >
+            <ListItemIcon>
+              <OpenIcon size={16} strokeWidth={1.5} />
+            </ListItemIcon>
+            Open
+          </MenuItem>,
+        );
+      }
+
+      if (
+        parsed.kind === "project" ||
+        (parsed.kind === "dir" && parsed.path !== JOBS_DIR)
+      ) {
+        items.push(
+          <MenuItem
+            key="new-file"
+            onClick={() => {
+              setNewFileTarget({
+                projectId: parsed.projectId,
+                dir: parsed.kind === "dir" ? parsed.path : "",
+              });
+              setNewFileName("");
+              helpers.closeMenu();
+            }}
+          >
+            <ListItemIcon>
+              <NewFileIcon size={16} strokeWidth={1.5} />
+            </ListItemIcon>
+            New file
+          </MenuItem>,
+        );
+      }
+
+      if (parsed.kind === "file") {
+        items.push(
+          <MenuItem
+            key="rename"
+            onClick={() => {
+              setRenameTarget({ parsed, name: node.name });
+              setRenameValue(node.name);
+              helpers.closeMenu();
+            }}
+          >
+            <ListItemIcon>
+              <RenameIcon size={16} strokeWidth={1.5} />
+            </ListItemIcon>
+            Rename
+          </MenuItem>,
+        );
+      }
+
+      if (
+        parsed.kind === "file" ||
+        parsed.kind === "job" ||
+        parsed.kind === "project"
+      ) {
+        items.push(
+          <MenuItem
+            key="delete"
+            onClick={() => {
+              setDeleteTarget({ parsed, name: node.name });
+              helpers.closeMenu();
+            }}
+          >
+            <ListItemIcon>
+              <DeleteIcon size={16} strokeWidth={1.5} />
+            </ListItemIcon>
+            Delete
+          </MenuItem>,
+        );
+      }
+      return items;
+    },
+    [handleItemClick],
+  );
+
+  const handleCreateProject = useCallback(async () => {
+    if (!workspaceId || !createName.trim() || !createConnectionId) return;
+    setCreating(true);
+    const created = await createProject(workspaceId, {
+      name: createName.trim(),
+      environments: [
+        {
+          name: "dev",
+          connectionId: createConnectionId,
+          targetSchema: createDevSchema.trim() || "dbt_dev",
+          threads: 4,
+        },
+        {
+          name: "prod",
+          connectionId: createConnectionId,
+          targetSchema: createProdSchema.trim() || "analytics",
+          threads: 4,
+        },
+      ],
+      defaultEnvironment: "dev",
+    });
+    setCreating(false);
+    if (created) {
+      setCreateOpen(false);
+      setCreateName("");
+      await Promise.all([
+        fetchFiles(workspaceId, created._id),
+        fetchJobs(workspaceId, created._id),
+      ]);
+      expandDbtFolder(created._id);
+      focusDbtFileTab(created._id, "dbt_project.yml");
+    }
+  }, [
+    workspaceId,
+    createName,
+    createConnectionId,
+    createDevSchema,
+    createProdSchema,
+    createProject,
+    fetchFiles,
+    fetchJobs,
+    expandDbtFolder,
+  ]);
+
+  const handleNewFileConfirm = useCallback(async () => {
+    if (!workspaceId || !newFileTarget) return;
+    const name = newFileName.trim();
+    if (!name) return;
+    const path = newFileTarget.dir ? `${newFileTarget.dir}/${name}` : name;
+    const ok = await createFile(workspaceId, newFileTarget.projectId, path);
+    if (ok) focusDbtFileTab(newFileTarget.projectId, path);
+    setNewFileTarget(null);
+  }, [workspaceId, newFileTarget, newFileName, createFile]);
+
+  const handleRenameConfirm = useCallback(async () => {
+    if (!renameTarget || !workspaceId) return;
+    const next = renameValue.trim();
+    const { parsed } = renameTarget;
+    if (next && next !== renameTarget.name && parsed.kind === "file") {
+      const dir = dirname(parsed.path);
+      const newPath = dir ? `${dir}/${next}` : next;
+      await renameFile(workspaceId, parsed.projectId, parsed.path, newPath);
+    }
+    setRenameTarget(null);
+  }, [renameTarget, renameValue, workspaceId, renameFile]);
+
+  const handleDeleteConfirm = useCallback(async () => {
+    if (!deleteTarget || !workspaceId) return;
+    const { parsed } = deleteTarget;
+    if (parsed.kind === "project") {
+      await deleteProject(workspaceId, parsed.projectId);
+    } else if (parsed.kind === "file") {
+      await deleteFile(workspaceId, parsed.projectId, parsed.path);
+    } else if (parsed.kind === "job") {
+      await deleteJob(workspaceId, parsed.projectId, parsed.path);
+    }
+    setDeleteTarget(null);
+  }, [deleteTarget, workspaceId, deleteProject, deleteFile, deleteJob]);
+
+  const actions = (
+    <>
+      <Tooltip title="New dbt project">
+        <IconButton size="small" onClick={() => setCreateOpen(true)}>
+          <AddIcon size={20} strokeWidth={2} />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Refresh">
+        <IconButton size="small" onClick={handleRefresh} disabled={loading}>
+          <RefreshIcon size={20} strokeWidth={2} />
+        </IconButton>
+      </Tooltip>
+    </>
+  );
+
+  const deleteKindLabel =
+    deleteTarget?.parsed.kind === "project"
+      ? "Project"
+      : deleteTarget?.parsed.kind === "job"
+        ? "Job"
+        : "File";
+
+  return (
+    <>
+      <ExplorerShell
+        title="Transforms"
+        actions={actions}
+        searchPlaceholder="Search dbt projects..."
+        error={error}
+        onErrorClose={() => {
+          useDbtStore.setState(state => {
+            state.error.projects = null;
+          });
+        }}
+        loading={loading && !projectsLoaded}
+        skeleton={
+          <Box sx={{ p: 3, textAlign: "center", color: "text.secondary" }}>
+            <Typography variant="body2">Loading...</Typography>
+          </Box>
+        }
+      >
+        {({ searchQuery }) =>
+          projects.length === 0 && projectsLoaded ? (
+            <Box sx={{ p: 3, textAlign: "center", color: "text.secondary" }}>
+              <Typography variant="body2" sx={{ mb: 1 }}>
+                No dbt projects yet.
+              </Typography>
+              <Button
+                size="small"
+                variant="outlined"
+                onClick={() => setCreateOpen(true)}
+              >
+                New dbt project
+              </Button>
+            </Box>
+          ) : (
+            <ResourceTree
+              sections={sections}
+              mode="sidebar"
+              searchQuery={searchQuery}
+              activeItemId={activeItemId}
+              getItemIcon={getItemIcon}
+              getContextMenuItems={getContextMenuItems}
+              hideFolderIcon
+              onItemClick={handleItemClick}
+              onLoadChildren={handleLoadChildren}
+              isLoadingChildren={node => {
+                const parsed = parseNodeId(node.id);
+                return (
+                  parsed.kind === "project" &&
+                  !!loadingProjects[parsed.projectId]
+                );
+              }}
+              enableDragDrop={false}
+              enableRename={false}
+              enableDelete={false}
+              enableNewFolder={false}
+              isFolderExpanded={key => !!expandedFolders[key]}
+              onToggleFolder={toggleDbtFolder}
+              onExpandFolder={expandDbtFolder}
+              getFolderExpansionKey={node => node.id}
+            />
+          )
+        }
+      </ExplorerShell>
+
+      {/* New project dialog */}
+      <Dialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>New dbt project</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            fullWidth
+            size="small"
+            label="Project name"
+            value={createName}
+            onChange={e => setCreateName(e.target.value)}
+            sx={{ mt: 1, mb: 2 }}
+          />
+          <FormControl fullWidth size="small" sx={{ mb: 2 }}>
+            <InputLabel id="dbt-target-connection">
+              Target connection
+            </InputLabel>
+            <Select
+              labelId="dbt-target-connection"
+              label="Target connection"
+              value={createConnectionId}
+              onChange={e => setCreateConnectionId(e.target.value)}
+            >
+              {dbtConnections.map(conn => (
+                <MenuItem key={conn.id} value={conn.id}>
+                  {conn.name} ({conn.type})
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          {dbtConnections.length === 0 && (
+            <Typography variant="caption" color="text.secondary">
+              No dbt-compatible connections found. Add a Postgres, BigQuery,
+              ClickHouse, MySQL, Redshift or SQL Server connection first.
+            </Typography>
+          )}
+          <TextField
+            fullWidth
+            size="small"
+            label="Dev schema"
+            value={createDevSchema}
+            onChange={e => setCreateDevSchema(e.target.value)}
+            sx={{ mb: 2 }}
+          />
+          <TextField
+            fullWidth
+            size="small"
+            label="Prod schema"
+            value={createProdSchema}
+            onChange={e => setCreateProdSchema(e.target.value)}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setCreateOpen(false)}>Cancel</Button>
+          <Button
+            onClick={handleCreateProject}
+            disabled={creating || !createName.trim() || !createConnectionId}
+          >
+            Create
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* New file dialog */}
+      <Dialog
+        open={!!newFileTarget}
+        onClose={() => setNewFileTarget(null)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>New file</DialogTitle>
+        <DialogContent>
+          <DialogContentText sx={{ mb: 1 }}>
+            {newFileTarget?.dir
+              ? `In ${newFileTarget.dir}/`
+              : "In project root"}
+          </DialogContentText>
+          <TextField
+            autoFocus
+            fullWidth
+            size="small"
+            placeholder="stg_orders.sql"
+            value={newFileName}
+            onChange={e => setNewFileName(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === "Enter") void handleNewFileConfirm();
+            }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setNewFileTarget(null)}>Cancel</Button>
+          <Button onClick={handleNewFileConfirm}>Create</Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Rename dialog */}
+      <Dialog
+        open={!!renameTarget}
+        onClose={() => setRenameTarget(null)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>Rename file</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            fullWidth
+            size="small"
+            value={renameValue}
+            onChange={e => setRenameValue(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === "Enter") void handleRenameConfirm();
+            }}
+            sx={{ mt: 1 }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setRenameTarget(null)}>Cancel</Button>
+          <Button onClick={handleRenameConfirm}>Rename</Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Delete confirmation */}
+      <Dialog open={!!deleteTarget} onClose={() => setDeleteTarget(null)}>
+        <DialogTitle>Delete {deleteKindLabel}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Are you sure you want to delete &quot;{deleteTarget?.name}&quot;?
+            {deleteTarget?.parsed.kind === "project"
+              ? " This deletes all files, jobs and run history."
+              : ""}{" "}
+            This action cannot be undone.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteTarget(null)}>Cancel</Button>
+          <Button onClick={handleDeleteConfirm} color="error">
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}
+
+export default DbtExplorer;

--- a/app/src/components/DbtExplorer.tsx
+++ b/app/src/components/DbtExplorer.tsx
@@ -24,6 +24,7 @@ import {
   Select,
   FormControl,
   InputLabel,
+  Menu,
 } from "@mui/material";
 import {
   Plus as AddIcon,
@@ -35,6 +36,8 @@ import {
   Trash2 as DeleteIcon,
   ExternalLink as OpenIcon,
   FilePlus as NewFileIcon,
+  Settings as EditProjectIcon,
+  MoreVertical as KebabIcon,
 } from "lucide-react";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useConsoleStore } from "../store/consoleStore";
@@ -42,6 +45,7 @@ import { useExplorerStore } from "../store/explorerStore";
 import { useSchemaStore, type Connection } from "../store/schemaStore";
 import {
   useDbtStore,
+  type DbtEnvironment,
   type DbtJobItem,
   type DbtProjectItem,
 } from "../store/dbtStore";
@@ -188,6 +192,7 @@ export function DbtExplorer() {
   const fetchFiles = useDbtStore(s => s.fetchFiles);
   const fetchJobs = useDbtStore(s => s.fetchJobs);
   const createProject = useDbtStore(s => s.createProject);
+  const updateProject = useDbtStore(s => s.updateProject);
   const deleteProject = useDbtStore(s => s.deleteProject);
   const createFile = useDbtStore(s => s.createFile);
   const deleteFile = useDbtStore(s => s.deleteFile);
@@ -238,13 +243,29 @@ export function DbtExplorer() {
     name: string;
   } | null>(null);
 
+  // Edit-project dialog state
+  const [editProjectId, setEditProjectId] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editDbtVersion, setEditDbtVersion] = useState("");
+  const [editDefaultEnv, setEditDefaultEnv] = useState("");
+  const [editEnvs, setEditEnvs] = useState<DbtEnvironment[]>([]);
+  const [savingEdit, setSavingEdit] = useState(false);
+
+  // Hover kebab menu (reuses getContextMenuItems for the same actions).
+  const [kebabMenu, setKebabMenu] = useState<{
+    anchorEl: HTMLElement;
+    node: ResourceTreeNode;
+  } | null>(null);
+
   useEffect(() => {
     if (workspaceId) void fetchProjects(workspaceId);
   }, [workspaceId, fetchProjects]);
 
   useEffect(() => {
-    if (createOpen && workspaceId) void ensureConnections(workspaceId);
-  }, [createOpen, workspaceId, ensureConnections]);
+    if ((createOpen || editProjectId) && workspaceId) {
+      void ensureConnections(workspaceId);
+    }
+  }, [createOpen, editProjectId, workspaceId, ensureConnections]);
 
   const dbtConnections: Connection[] = useMemo(() => {
     const all = workspaceId ? (connections[workspaceId] ?? []) : [];
@@ -334,6 +355,19 @@ export function DbtExplorer() {
     [jobsByProject],
   );
 
+  const openEditProject = useCallback(
+    (projectId: string) => {
+      const project = projects.find(p => p._id === projectId);
+      if (!project) return;
+      setEditProjectId(projectId);
+      setEditName(project.name);
+      setEditDbtVersion(project.dbtVersion ?? "");
+      setEditDefaultEnv(project.defaultEnvironment);
+      setEditEnvs(project.environments.map(env => ({ ...env })));
+    },
+    [projects],
+  );
+
   const getItemIcon = useCallback((node: ResourceTreeNode) => {
     const parsed = parseNodeId(node.id);
     if (parsed.kind === "project") {
@@ -394,6 +428,23 @@ export function DbtExplorer() {
         );
       }
 
+      if (parsed.kind === "project") {
+        items.push(
+          <MenuItem
+            key="edit-project"
+            onClick={() => {
+              openEditProject(parsed.projectId);
+              helpers.closeMenu();
+            }}
+          >
+            <ListItemIcon>
+              <EditProjectIcon size={16} strokeWidth={1.5} />
+            </ListItemIcon>
+            Edit project
+          </MenuItem>,
+        );
+      }
+
       if (parsed.kind === "file") {
         items.push(
           <MenuItem
@@ -434,8 +485,34 @@ export function DbtExplorer() {
       }
       return items;
     },
-    [handleItemClick],
+    [handleItemClick, openEditProject],
   );
+
+  // Hover kebab: same actions as the right-click menu, but discoverable.
+  const getRightAdornment = useCallback((node: ResourceTreeNode) => {
+    const parsed = parseNodeId(node.id);
+    if (parsed.kind === "dir") return null;
+    return (
+      <IconButton
+        size="small"
+        aria-label="Actions"
+        className="dbt-row-kebab"
+        onClick={event => {
+          event.stopPropagation();
+          setKebabMenu({ anchorEl: event.currentTarget, node });
+        }}
+        sx={{
+          p: 0.25,
+          opacity: 0,
+          transition: "opacity 0.1s",
+          ".MuiListItemButton-root:hover &": { opacity: 1 },
+          "&:focus-visible, &[aria-expanded='true']": { opacity: 1 },
+        }}
+      >
+        <KebabIcon size={15} strokeWidth={1.5} />
+      </IconButton>
+    );
+  }, []);
 
   const handleCreateProject = useCallback(async () => {
     if (!workspaceId || !createName.trim() || !createConnectionId) return;
@@ -480,6 +557,40 @@ export function DbtExplorer() {
     fetchJobs,
     expandDbtFolder,
   ]);
+
+  const handleUpdateProject = useCallback(async () => {
+    if (!workspaceId || !editProjectId || !editName.trim()) return;
+    setSavingEdit(true);
+    const updated = await updateProject(workspaceId, editProjectId, {
+      name: editName.trim(),
+      environments: editEnvs.map(env => ({
+        ...env,
+        targetSchema: env.targetSchema.trim(),
+        threads: Number(env.threads) || 1,
+      })),
+      defaultEnvironment: editDefaultEnv,
+      dbtVersion: editDbtVersion.trim() || undefined,
+    });
+    setSavingEdit(false);
+    if (updated) setEditProjectId(null);
+  }, [
+    workspaceId,
+    editProjectId,
+    editName,
+    editEnvs,
+    editDefaultEnv,
+    editDbtVersion,
+    updateProject,
+  ]);
+
+  const updateEditEnv = useCallback(
+    (index: number, patch: Partial<DbtEnvironment>) => {
+      setEditEnvs(prev =>
+        prev.map((env, i) => (i === index ? { ...env, ...patch } : env)),
+      );
+    },
+    [],
+  );
 
   const handleNewFileConfirm = useCallback(async () => {
     if (!workspaceId || !newFileTarget) return;
@@ -579,6 +690,7 @@ export function DbtExplorer() {
               activeItemId={activeItemId}
               getItemIcon={getItemIcon}
               getContextMenuItems={getContextMenuItems}
+              getRightAdornment={getRightAdornment}
               hideFolderIcon
               onItemClick={handleItemClick}
               onLoadChildren={handleLoadChildren}
@@ -726,6 +838,133 @@ export function DbtExplorer() {
         <DialogActions>
           <Button onClick={() => setRenameTarget(null)}>Cancel</Button>
           <Button onClick={handleRenameConfirm}>Rename</Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Hover kebab menu — reuses the right-click action items */}
+      <Menu
+        open={!!kebabMenu}
+        anchorEl={kebabMenu?.anchorEl ?? null}
+        onClose={() => setKebabMenu(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+        transformOrigin={{ vertical: "top", horizontal: "right" }}
+      >
+        {kebabMenu
+          ? getContextMenuItems(kebabMenu.node, {
+              closeMenu: () => setKebabMenu(null),
+            })
+          : null}
+      </Menu>
+
+      {/* Edit project dialog */}
+      <Dialog
+        open={!!editProjectId}
+        onClose={() => setEditProjectId(null)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>Edit dbt project</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            fullWidth
+            size="small"
+            label="Project name"
+            value={editName}
+            onChange={e => setEditName(e.target.value)}
+            sx={{ mt: 1, mb: 2 }}
+          />
+          <TextField
+            fullWidth
+            size="small"
+            label="dbt version"
+            placeholder="1.9.10"
+            value={editDbtVersion}
+            onChange={e => setEditDbtVersion(e.target.value)}
+            sx={{ mb: 2 }}
+          />
+          {editEnvs.map((env, index) => (
+            <Box
+              key={env.name}
+              sx={{
+                mb: 2,
+                p: 1.5,
+                border: 1,
+                borderColor: "divider",
+                borderRadius: 1,
+              }}
+            >
+              <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                {env.name}
+              </Typography>
+              <FormControl fullWidth size="small" sx={{ mb: 1.5 }}>
+                <InputLabel id={`dbt-edit-conn-${env.name}`}>
+                  Connection
+                </InputLabel>
+                <Select
+                  labelId={`dbt-edit-conn-${env.name}`}
+                  label="Connection"
+                  value={env.connectionId}
+                  onChange={e =>
+                    updateEditEnv(index, { connectionId: e.target.value })
+                  }
+                >
+                  {dbtConnections.map(conn => (
+                    <MenuItem key={conn.id} value={conn.id}>
+                      {conn.name} ({conn.type})
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <TextField
+                fullWidth
+                size="small"
+                label="Target schema"
+                value={env.targetSchema}
+                onChange={e =>
+                  updateEditEnv(index, { targetSchema: e.target.value })
+                }
+                sx={{ mb: 1.5 }}
+              />
+              <TextField
+                fullWidth
+                size="small"
+                type="number"
+                label="Threads"
+                value={env.threads}
+                onChange={e =>
+                  updateEditEnv(index, { threads: Number(e.target.value) })
+                }
+                inputProps={{ min: 1, max: 32 }}
+              />
+            </Box>
+          ))}
+          <FormControl fullWidth size="small">
+            <InputLabel id="dbt-edit-default-env">
+              Default environment
+            </InputLabel>
+            <Select
+              labelId="dbt-edit-default-env"
+              label="Default environment"
+              value={editDefaultEnv}
+              onChange={e => setEditDefaultEnv(e.target.value)}
+            >
+              {editEnvs.map(env => (
+                <MenuItem key={env.name} value={env.name}>
+                  {env.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setEditProjectId(null)}>Cancel</Button>
+          <Button
+            onClick={handleUpdateProject}
+            disabled={savingEdit || !editName.trim()}
+          >
+            Save
+          </Button>
         </DialogActions>
       </Dialog>
 

--- a/app/src/components/DbtExplorer.tsx
+++ b/app/src/components/DbtExplorer.tsx
@@ -38,6 +38,7 @@ import {
   FilePlus as NewFileIcon,
   Settings as EditProjectIcon,
   MoreVertical as KebabIcon,
+  Terminal as ConsoleIcon,
 } from "lucide-react";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useConsoleStore } from "../store/consoleStore";
@@ -49,7 +50,11 @@ import {
   type DbtJobItem,
   type DbtProjectItem,
 } from "../store/dbtStore";
-import { focusDbtFileTab, focusDbtJobTab } from "../dbt-runtime/shell";
+import {
+  focusDbtConsoleTab,
+  focusDbtFileTab,
+  focusDbtJobTab,
+} from "../dbt-runtime/shell";
 import ResourceTree, { type ResourceTreeNode } from "./ResourceTree";
 import ExplorerShell from "./ExplorerShell";
 
@@ -429,6 +434,24 @@ export function DbtExplorer() {
       }
 
       if (parsed.kind === "project") {
+        const project = projects.find(p => p._id === parsed.projectId);
+        items.push(
+          <MenuItem
+            key="open-console"
+            onClick={() => {
+              focusDbtConsoleTab(
+                parsed.projectId,
+                `${project?.name ?? "dbt"} console`,
+              );
+              helpers.closeMenu();
+            }}
+          >
+            <ListItemIcon>
+              <ConsoleIcon size={16} strokeWidth={1.5} />
+            </ListItemIcon>
+            Open console
+          </MenuItem>,
+        );
         items.push(
           <MenuItem
             key="edit-project"
@@ -485,7 +508,7 @@ export function DbtExplorer() {
       }
       return items;
     },
-    [handleItemClick, openEditProject],
+    [handleItemClick, openEditProject, projects],
   );
 
   // Hover kebab: same actions as the right-click menu, but discoverable.

--- a/app/src/components/DbtFileEditor.tsx
+++ b/app/src/components/DbtFileEditor.tsx
@@ -1,0 +1,443 @@
+/**
+ * DbtFileEditor — full-screen Monaco editor for one dbt project file
+ * (pattern: AppFileEditor) plus a Compile / Run model verification panel
+ * for SQL model files under models/.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  MenuItem,
+  Select,
+  Tab,
+  Tabs,
+  Typography,
+  useTheme,
+} from "@mui/material";
+import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
+import MonacoEditor from "@monaco-editor/react";
+import { useWorkspace } from "../contexts/workspace-context";
+import {
+  useDbtStore,
+  type DbtCompileResult,
+  type DbtRunModelResult,
+  type DbtRunLogLine,
+} from "../store/dbtStore";
+
+function languageForDbtPath(path: string): string {
+  if (path.endsWith(".sql")) return "sql";
+  if (path.endsWith(".yml") || path.endsWith(".yaml")) return "yaml";
+  if (path.endsWith(".md")) return "markdown";
+  return "plaintext";
+}
+
+function modelNameForPath(path: string): string | null {
+  if (!path.startsWith("models/") || !path.endsWith(".sql")) return null;
+  const base = path.split("/").pop() ?? "";
+  return base.replace(/\.sql$/, "");
+}
+
+function LogLines({ logs }: { logs: DbtRunLogLine[] }) {
+  return (
+    <Box
+      sx={{
+        fontFamily: "monospace",
+        fontSize: "0.75rem",
+        whiteSpace: "pre-wrap",
+        p: 1,
+        overflow: "auto",
+        height: "100%",
+      }}
+    >
+      {logs.length === 0 ? (
+        <Typography variant="caption" color="text.secondary">
+          No output.
+        </Typography>
+      ) : (
+        logs.map((log, index) => (
+          <Box
+            key={index}
+            component="div"
+            sx={{
+              color:
+                log.level === "error"
+                  ? "error.main"
+                  : log.level === "warn"
+                    ? "warning.main"
+                    : "text.primary",
+            }}
+          >
+            {log.line}
+          </Box>
+        ))
+      )}
+    </Box>
+  );
+}
+
+export default function DbtFileEditor({
+  projectId,
+  path,
+}: {
+  projectId: string;
+  path: string;
+}) {
+  const { currentWorkspace } = useWorkspace();
+  const workspaceId = currentWorkspace?.id;
+  const monacoTheme = useTheme().palette.mode === "dark" ? "vs-dark" : "vs";
+
+  const project = useDbtStore(s => s.projects.find(p => p._id === projectId));
+  const file = useDbtStore(s => s.filesByProject[projectId]?.[path]);
+  const fetchProjects = useDbtStore(s => s.fetchProjects);
+  const readFile = useDbtStore(s => s.readFile);
+  const writeFile = useDbtStore(s => s.writeFile);
+  const persistFile = useDbtStore(s => s.persistFile);
+  const compileModel = useDbtStore(s => s.compileModel);
+  const runModel = useDbtStore(s => s.runModel);
+
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [environment, setEnvironment] = useState<string>("");
+  const [panelOpen, setPanelOpen] = useState(false);
+  const [panelTab, setPanelTab] = useState<"compiled" | "results" | "logs">(
+    "compiled",
+  );
+  const [busy, setBusy] = useState<"compile" | "run" | null>(null);
+  const [compileResult, setCompileResult] = useState<DbtCompileResult | null>(
+    null,
+  );
+  const [runResult, setRunResult] = useState<DbtRunModelResult | null>(null);
+
+  const modelName = useMemo(() => modelNameForPath(path), [path]);
+
+  useEffect(() => {
+    if (!project && workspaceId) void fetchProjects(workspaceId);
+  }, [project, workspaceId, fetchProjects]);
+
+  useEffect(() => {
+    if (workspaceId && !file?.loaded) {
+      void readFile(workspaceId, projectId, path);
+    }
+  }, [workspaceId, projectId, path, file?.loaded, readFile]);
+
+  useEffect(() => {
+    if (project && !environment) {
+      setEnvironment(project.defaultEnvironment);
+    }
+  }, [project, environment]);
+
+  const handleChange = useCallback(
+    (value: string | undefined) => {
+      writeFile(projectId, path, value ?? "");
+      if (saveTimer.current) clearTimeout(saveTimer.current);
+      if (workspaceId) {
+        saveTimer.current = setTimeout(() => {
+          void persistFile(workspaceId, projectId, path);
+        }, 1200);
+      }
+    },
+    [projectId, path, workspaceId, writeFile, persistFile],
+  );
+
+  const saveNow = useCallback(() => {
+    if (saveTimer.current) {
+      clearTimeout(saveTimer.current);
+      saveTimer.current = null;
+    }
+    if (workspaceId) void persistFile(workspaceId, projectId, path);
+  }, [workspaceId, projectId, path, persistFile]);
+
+  const handleEditorMount = useCallback(
+    (
+      editor: { addCommand: (keys: number, handler: () => void) => void },
+      monaco: { KeyMod: { CtrlCmd: number }; KeyCode: { KeyS: number } },
+    ) => {
+      editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, saveNow);
+    },
+    [saveNow],
+  );
+
+  const handleCompile = useCallback(async () => {
+    if (!workspaceId || !modelName) return;
+    saveNow();
+    setBusy("compile");
+    setPanelOpen(true);
+    setPanelTab("compiled");
+    const result = await compileModel(
+      workspaceId,
+      projectId,
+      modelName,
+      environment || undefined,
+    );
+    setCompileResult(result);
+    if (result && !result.ok) setPanelTab("logs");
+    setBusy(null);
+  }, [workspaceId, projectId, modelName, environment, compileModel, saveNow]);
+
+  const handleRunModel = useCallback(async () => {
+    if (!workspaceId || !modelName) return;
+    if (
+      environment === "prod" &&
+      !window.confirm(`Run ${modelName} against the prod environment?`)
+    ) {
+      return;
+    }
+    saveNow();
+    setBusy("run");
+    setPanelOpen(true);
+    setPanelTab("results");
+    const result = await runModel(
+      workspaceId,
+      projectId,
+      modelName,
+      environment || undefined,
+    );
+    setRunResult(result);
+    if (result && !result.ok) setPanelTab("logs");
+    setBusy(null);
+  }, [workspaceId, projectId, modelName, environment, runModel, saveNow]);
+
+  if (!file?.loaded) {
+    return (
+      <Box sx={{ p: 3, color: "text.secondary" }}>
+        <Typography variant="body2">Loading file…</Typography>
+      </Box>
+    );
+  }
+
+  const activeLogs =
+    panelTab === "logs"
+      ? busy === "compile" || (!runResult && compileResult)
+        ? (compileResult?.logs ?? [])
+        : (runResult?.logs ?? compileResult?.logs ?? [])
+      : [];
+
+  const editorPane = (
+    <Box sx={{ height: "100%", minHeight: 0 }}>
+      <MonacoEditor
+        height="100%"
+        path={`dbt/${projectId}/${path}`}
+        language={languageForDbtPath(path)}
+        value={file.content}
+        theme={monacoTheme}
+        onChange={handleChange}
+        onMount={handleEditorMount as never}
+        options={{
+          minimap: { enabled: false },
+          fontSize: 13,
+          automaticLayout: true,
+          scrollBeyondLastLine: false,
+        }}
+      />
+    </Box>
+  );
+
+  return (
+    <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
+      {/* Breadcrumb + actions */}
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1,
+          minHeight: 30,
+          px: 1.5,
+          py: 0.25,
+          backgroundColor: "background.paper",
+          color: "text.secondary",
+          fontSize: "0.75rem",
+          borderBottom: "1px solid",
+          borderColor: "divider",
+        }}
+      >
+        <Box sx={{ flex: 1, overflow: "hidden", textOverflow: "ellipsis" }}>
+          {project?.name ?? "dbt"} / {path}
+          {file.dirty ? " •" : ""}
+        </Box>
+        {modelName && (
+          <>
+            <Select
+              size="small"
+              value={environment}
+              onChange={e => setEnvironment(e.target.value)}
+              sx={{ fontSize: "0.75rem", minWidth: 90 }}
+            >
+              {(project?.environments ?? []).map(env => (
+                <MenuItem key={env.name} value={env.name}>
+                  {env.name}
+                </MenuItem>
+              ))}
+            </Select>
+            <Button
+              size="small"
+              variant="outlined"
+              disabled={busy !== null}
+              onClick={handleCompile}
+            >
+              {busy === "compile" ? "Compiling…" : "Compile"}
+            </Button>
+            <Button
+              size="small"
+              variant="contained"
+              disabled={busy !== null}
+              onClick={handleRunModel}
+            >
+              {busy === "run" ? "Running…" : "Run model"}
+            </Button>
+          </>
+        )}
+      </Box>
+
+      <Box sx={{ flex: 1, minHeight: 0 }}>
+        {panelOpen ? (
+          <PanelGroup direction="vertical">
+            <Panel defaultSize={60} minSize={20}>
+              {editorPane}
+            </Panel>
+            <PanelResizeHandle
+              style={{ height: 4, background: "var(--mui-palette-divider)" }}
+            />
+            <Panel defaultSize={40} minSize={15}>
+              <Box
+                sx={{
+                  height: "100%",
+                  display: "flex",
+                  flexDirection: "column",
+                  borderTop: "1px solid",
+                  borderColor: "divider",
+                }}
+              >
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    borderBottom: "1px solid",
+                    borderColor: "divider",
+                  }}
+                >
+                  <Tabs
+                    value={panelTab}
+                    onChange={(_e, value) => setPanelTab(value)}
+                    sx={{ minHeight: 32, flex: 1 }}
+                  >
+                    <Tab
+                      label="Compiled SQL"
+                      value="compiled"
+                      sx={{ minHeight: 32, py: 0 }}
+                    />
+                    <Tab
+                      label="Results"
+                      value="results"
+                      sx={{ minHeight: 32, py: 0 }}
+                    />
+                    <Tab
+                      label="Logs"
+                      value="logs"
+                      sx={{ minHeight: 32, py: 0 }}
+                    />
+                  </Tabs>
+                  {busy && <CircularProgress size={14} sx={{ mr: 1 }} />}
+                  <Button size="small" onClick={() => setPanelOpen(false)}>
+                    Close
+                  </Button>
+                </Box>
+                <Box sx={{ flex: 1, minHeight: 0, overflow: "auto" }}>
+                  {panelTab === "compiled" &&
+                    (compileResult?.compiledSql ? (
+                      <MonacoEditor
+                        height="100%"
+                        language="sql"
+                        value={compileResult.compiledSql}
+                        theme={monacoTheme}
+                        options={{
+                          readOnly: true,
+                          minimap: { enabled: false },
+                          fontSize: 12,
+                          scrollBeyondLastLine: false,
+                        }}
+                      />
+                    ) : (
+                      <Box sx={{ p: 2 }}>
+                        <Typography variant="caption" color="text.secondary">
+                          {busy === "compile"
+                            ? "Compiling…"
+                            : compileResult && !compileResult.ok
+                              ? "Compile failed — see Logs."
+                              : "Press Compile to see the rendered SQL."}
+                        </Typography>
+                      </Box>
+                    ))}
+                  {panelTab === "results" && (
+                    <Box sx={{ p: 1 }}>
+                      {!runResult ? (
+                        <Typography variant="caption" color="text.secondary">
+                          {busy === "run"
+                            ? "Running model…"
+                            : "Press Run model to build this model on the selected environment."}
+                        </Typography>
+                      ) : (
+                        <Box
+                          component="table"
+                          sx={{
+                            width: "100%",
+                            fontSize: "0.75rem",
+                            borderCollapse: "collapse",
+                            "& td, & th": {
+                              borderBottom: "1px solid",
+                              borderColor: "divider",
+                              p: 0.5,
+                              textAlign: "left",
+                            },
+                          }}
+                        >
+                          <thead>
+                            <tr>
+                              <th>Node</th>
+                              <th>Type</th>
+                              <th>Status</th>
+                              <th>Time</th>
+                              <th>Rows</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {runResult.stepResults.map(step => (
+                              <Box
+                                component="tr"
+                                key={step.uniqueId}
+                                sx={{
+                                  color:
+                                    step.status === "error" ||
+                                    step.status === "fail"
+                                      ? "error.main"
+                                      : step.status === "warn"
+                                        ? "warning.main"
+                                        : "inherit",
+                                }}
+                              >
+                                <td>{step.name}</td>
+                                <td>{step.resourceType}</td>
+                                <td>{step.status}</td>
+                                <td>
+                                  {(step.executionTimeMs / 1000).toFixed(2)}s
+                                </td>
+                                <td>{step.rowsAffected ?? ""}</td>
+                              </Box>
+                            ))}
+                          </tbody>
+                        </Box>
+                      )}
+                    </Box>
+                  )}
+                  {panelTab === "logs" && <LogLines logs={activeLogs} />}
+                </Box>
+              </Box>
+            </Panel>
+          </PanelGroup>
+        ) : (
+          editorPane
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/app/src/components/DbtFileEditor.tsx
+++ b/app/src/components/DbtFileEditor.tsx
@@ -8,11 +8,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Box,
   Button,
+  Checkbox,
   CircularProgress,
+  FormControlLabel,
   MenuItem,
   Select,
   Tab,
   Tabs,
+  Tooltip,
   Typography,
   useTheme,
 } from "@mui/material";
@@ -99,6 +102,7 @@ export default function DbtFileEditor({
 
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [environment, setEnvironment] = useState<string>("");
+  const [defer, setDefer] = useState(false);
   const [panelOpen, setPanelOpen] = useState(false);
   const [panelTab, setPanelTab] = useState<"compiled" | "results" | "logs">(
     "compiled",
@@ -169,11 +173,20 @@ export default function DbtFileEditor({
       projectId,
       modelName,
       environment || undefined,
+      defer,
     );
     setCompileResult(result);
     if (result && !result.ok) setPanelTab("logs");
     setBusy(null);
-  }, [workspaceId, projectId, modelName, environment, compileModel, saveNow]);
+  }, [
+    workspaceId,
+    projectId,
+    modelName,
+    environment,
+    defer,
+    compileModel,
+    saveNow,
+  ]);
 
   const handleRunModel = useCallback(async () => {
     if (!workspaceId || !modelName) return;
@@ -192,11 +205,20 @@ export default function DbtFileEditor({
       projectId,
       modelName,
       environment || undefined,
+      defer,
     );
     setRunResult(result);
     if (result && !result.ok) setPanelTab("logs");
     setBusy(null);
-  }, [workspaceId, projectId, modelName, environment, runModel, saveNow]);
+  }, [
+    workspaceId,
+    projectId,
+    modelName,
+    environment,
+    defer,
+    runModel,
+    saveNow,
+  ]);
 
   if (!file?.loaded) {
     return (
@@ -269,6 +291,23 @@ export default function DbtFileEditor({
                 </MenuItem>
               ))}
             </Select>
+            <Tooltip title="Resolve unselected refs against the last prod build (dbt --defer)">
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    size="small"
+                    checked={defer}
+                    onChange={e => setDefer(e.target.checked)}
+                  />
+                }
+                label={
+                  <Typography variant="caption" sx={{ whiteSpace: "nowrap" }}>
+                    Defer
+                  </Typography>
+                }
+                sx={{ mr: 0 }}
+              />
+            </Tooltip>
             <Button
               size="small"
               variant="outlined"

--- a/app/src/components/DbtJobView.tsx
+++ b/app/src/components/DbtJobView.tsx
@@ -1,0 +1,865 @@
+/**
+ * DbtJobView — run history + live logs (view mode, pattern: FlowLogs) and
+ * the job edit form (commands list + schedule, pattern: ScheduleConsoleModal).
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  FormControl,
+  FormControlLabel,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Radio,
+  RadioGroup,
+  Select,
+  Switch,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import {
+  Play as RunIcon,
+  Square as StopIcon,
+  Pencil as EditIcon,
+  RefreshCw as RefreshIcon,
+  Plus as AddIcon,
+  Trash2 as RemoveIcon,
+  FileCode as ModelIcon,
+} from "lucide-react";
+import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
+import { CronExpressionParser } from "cron-parser";
+import { useWorkspace } from "../contexts/workspace-context";
+import {
+  useDbtStore,
+  type DbtJobItem,
+  type DbtRunItem,
+} from "../store/dbtStore";
+import { focusDbtFileTab } from "../dbt-runtime/shell";
+
+type SchedulePreset = "hourly" | "daily" | "every6h" | "weekly" | "custom";
+
+const PRESET_CRONS: Record<Exclude<SchedulePreset, "custom">, string> = {
+  hourly: "0 * * * *",
+  daily: "0 6 * * *",
+  every6h: "0 */6 * * *",
+  weekly: "0 6 * * 1",
+};
+
+const COMMAND_PRESETS = [
+  "build",
+  "run",
+  "test",
+  "seed",
+  "snapshot",
+  "compile",
+  "source freshness",
+  "docs generate",
+];
+
+function presetFromCron(cron: string): SchedulePreset {
+  if (cron === PRESET_CRONS.hourly) return "hourly";
+  if (cron === PRESET_CRONS.daily) return "daily";
+  if (cron === PRESET_CRONS.every6h) return "every6h";
+  if (cron === PRESET_CRONS.weekly) return "weekly";
+  return "custom";
+}
+
+function statusColor(status: DbtRunItem["status"]): string {
+  switch (status) {
+    case "running":
+      return "primary.main";
+    case "success":
+      return "success.main";
+    case "error":
+      return "error.main";
+    case "cancelled":
+      return "warning.main";
+    default:
+      return "text.secondary";
+  }
+}
+
+function formatDuration(ms?: number): string {
+  if (ms === undefined || ms === null) return "—";
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = ms / 1000;
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  return `${Math.floor(seconds / 60)}m ${Math.round(seconds % 60)}s`;
+}
+
+function relativeTime(iso?: string): string {
+  if (!iso) return "—";
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const minutes = Math.floor(diffMs / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+export default function DbtJobView({
+  projectId,
+  jobId,
+}: {
+  projectId: string;
+  jobId: string;
+}) {
+  const { currentWorkspace } = useWorkspace();
+  const workspaceId = currentWorkspace?.id;
+
+  const project = useDbtStore(s => s.projects.find(p => p._id === projectId));
+  const jobs = useDbtStore(s => s.jobsByProject[projectId]);
+  const runs = useDbtStore(s => s.runsByProject[projectId]);
+  const runDetails = useDbtStore(s => s.runDetails);
+  const fetchProjects = useDbtStore(s => s.fetchProjects);
+  const fetchJobs = useDbtStore(s => s.fetchJobs);
+  const fetchRuns = useDbtStore(s => s.fetchRuns);
+  const fetchRunDetails = useDbtStore(s => s.fetchRunDetails);
+  const triggerJob = useDbtStore(s => s.triggerJob);
+  const cancelRun = useDbtStore(s => s.cancelRun);
+  const saveJob = useDbtStore(s => s.saveJob);
+
+  const job = useMemo(
+    () => (jobs ?? []).find(j => j._id === jobId),
+    [jobs, jobId],
+  );
+
+  const jobRuns = useMemo(
+    () => (runs ?? []).filter(run => run.jobId === jobId),
+    [runs, jobId],
+  );
+
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
+  const [editing, setEditing] = useState(false);
+  const logScrollRef = useRef<HTMLDivElement | null>(null);
+
+  // Edit-form state
+  const [formName, setFormName] = useState("");
+  const [formEnvironment, setFormEnvironment] = useState("");
+  const [formCommands, setFormCommands] = useState<string[]>(["build"]);
+  const [formScheduleEnabled, setFormScheduleEnabled] = useState(false);
+  const [formPreset, setFormPreset] = useState<SchedulePreset>("daily");
+  const [formCron, setFormCron] = useState(PRESET_CRONS.daily);
+  const [formTimezone, setFormTimezone] = useState("UTC");
+  const [formEnabled, setFormEnabled] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  const timezones = useMemo<string[]>(() => {
+    const intlWithSupportedValues = Intl as typeof Intl & {
+      supportedValuesOf?: (key: "timeZone") => string[];
+    };
+    return typeof intlWithSupportedValues.supportedValuesOf === "function"
+      ? intlWithSupportedValues.supportedValuesOf("timeZone")
+      : ["UTC"];
+  }, []);
+
+  useEffect(() => {
+    if (!workspaceId) return;
+    if (!project) void fetchProjects(workspaceId);
+    if (!jobs) void fetchJobs(workspaceId, projectId);
+    void fetchRuns(workspaceId, projectId, jobId);
+  }, [
+    workspaceId,
+    projectId,
+    jobId,
+    project,
+    jobs,
+    fetchProjects,
+    fetchJobs,
+    fetchRuns,
+  ]);
+
+  useEffect(() => {
+    if (!selectedRunId && jobRuns.length > 0) {
+      setSelectedRunId(jobRuns[0]._id);
+    }
+  }, [selectedRunId, jobRuns]);
+
+  const selectedRun = selectedRunId ? runDetails[selectedRunId] : undefined;
+  const selectedRunListItem = jobRuns.find(run => run._id === selectedRunId);
+  const selectedStatus = selectedRun?.status ?? selectedRunListItem?.status;
+  const runningRun = jobRuns.find(
+    run => run.status === "running" || run.status === "queued",
+  );
+
+  // Fetch details when selection changes; poll every 2s while running.
+  useEffect(() => {
+    if (!workspaceId || !selectedRunId) return;
+    let stopped = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const poll = async () => {
+      const details = await fetchRunDetails(
+        workspaceId,
+        projectId,
+        selectedRunId,
+      );
+      if (stopped) return;
+      if (details?.status === "running" || details?.status === "queued") {
+        timer = setTimeout(() => void poll(), 2000);
+      }
+    };
+    void poll();
+
+    return () => {
+      stopped = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [workspaceId, projectId, selectedRunId, fetchRunDetails]);
+
+  // Auto-scroll logs while running.
+  useEffect(() => {
+    if (selectedStatus === "running" && logScrollRef.current) {
+      logScrollRef.current.scrollTop = logScrollRef.current.scrollHeight;
+    }
+  }, [selectedRun?.logs.length, selectedStatus]);
+
+  const handleRunNow = useCallback(async () => {
+    if (!workspaceId) return;
+    const runId = await triggerJob(workspaceId, projectId, jobId);
+    if (runId) setSelectedRunId(runId);
+  }, [workspaceId, projectId, jobId, triggerJob]);
+
+  const handleStop = useCallback(async () => {
+    if (!workspaceId || !runningRun) return;
+    await cancelRun(workspaceId, projectId, runningRun._id);
+    await fetchRuns(workspaceId, projectId, jobId);
+  }, [workspaceId, projectId, jobId, runningRun, cancelRun, fetchRuns]);
+
+  const handleRefresh = useCallback(() => {
+    if (workspaceId) void fetchRuns(workspaceId, projectId, jobId);
+  }, [workspaceId, projectId, jobId, fetchRuns]);
+
+  const beginEdit = useCallback(() => {
+    if (!job) return;
+    setFormName(job.name);
+    setFormEnvironment(job.environment);
+    setFormCommands(job.commands.length > 0 ? [...job.commands] : ["build"]);
+    setFormScheduleEnabled(!!job.schedule?.cron);
+    const cron = job.schedule?.cron ?? PRESET_CRONS.daily;
+    setFormCron(cron);
+    setFormPreset(presetFromCron(cron));
+    setFormTimezone(job.schedule?.timezone ?? "UTC");
+    setFormEnabled(job.enabled);
+    setEditing(true);
+  }, [job]);
+
+  const previewRuns = useMemo(() => {
+    if (!formScheduleEnabled || !formCron) return [];
+    try {
+      const interval = CronExpressionParser.parse(formCron, {
+        currentDate: new Date(),
+        tz: formTimezone,
+      });
+      return Array.from({ length: 3 }, () =>
+        interval.next().toDate().toLocaleString(),
+      );
+    } catch {
+      return [];
+    }
+  }, [formScheduleEnabled, formCron, formTimezone]);
+
+  const handlePresetChange = useCallback((preset: SchedulePreset) => {
+    setFormPreset(preset);
+    if (preset !== "custom") {
+      setFormCron(PRESET_CRONS[preset]);
+    }
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!workspaceId) return;
+    setSaving(true);
+    const payload: Partial<DbtJobItem> & { name: string } = {
+      name: formName.trim() || "Untitled job",
+      environment: formEnvironment,
+      commands: formCommands.map(c => c.trim()).filter(Boolean),
+      schedule: formScheduleEnabled
+        ? { cron: formCron, timezone: formTimezone }
+        : null,
+      enabled: formEnabled,
+    };
+    const saved = await saveJob(workspaceId, projectId, payload, jobId);
+    setSaving(false);
+    if (saved) setEditing(false);
+  }, [
+    workspaceId,
+    projectId,
+    jobId,
+    formName,
+    formEnvironment,
+    formCommands,
+    formScheduleEnabled,
+    formCron,
+    formTimezone,
+    formEnabled,
+    saveJob,
+  ]);
+
+  if (!job) {
+    return (
+      <Box sx={{ p: 3, color: "text.secondary" }}>
+        <Typography variant="body2">Loading job…</Typography>
+      </Box>
+    );
+  }
+
+  const topBar = (
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 1,
+        px: 1.5,
+        py: 0.75,
+        borderBottom: "1px solid",
+        borderColor: "divider",
+        backgroundColor: "background.paper",
+      }}
+    >
+      <Typography variant="subtitle2" sx={{ flexShrink: 0 }}>
+        {job.name}
+      </Typography>
+      <Chip label={job.environment} size="small" variant="outlined" />
+      {!job.enabled && (
+        <Chip
+          label="disabled"
+          size="small"
+          color="warning"
+          variant="outlined"
+        />
+      )}
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ flex: 1, overflow: "hidden", textOverflow: "ellipsis" }}
+      >
+        {job.commands.map(command => `dbt ${command}`).join(" → ")}
+        {job.schedule?.cron
+          ? ` · ${job.schedule.cron} ${job.schedule.timezone}`
+          : " · manual"}
+      </Typography>
+      {runningRun ? (
+        <Button
+          size="small"
+          color="warning"
+          variant="outlined"
+          startIcon={<StopIcon size={14} />}
+          onClick={handleStop}
+        >
+          Stop
+        </Button>
+      ) : (
+        <Button
+          size="small"
+          variant="contained"
+          startIcon={<RunIcon size={14} />}
+          onClick={handleRunNow}
+        >
+          Run now
+        </Button>
+      )}
+      <Button
+        size="small"
+        variant="outlined"
+        startIcon={<EditIcon size={14} />}
+        onClick={editing ? () => setEditing(false) : beginEdit}
+      >
+        {editing ? "Cancel" : "Edit"}
+      </Button>
+      <Tooltip title="Refresh">
+        <IconButton size="small" onClick={handleRefresh}>
+          <RefreshIcon size={16} />
+        </IconButton>
+      </Tooltip>
+    </Box>
+  );
+
+  if (editing) {
+    return (
+      <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
+        {topBar}
+        <Box sx={{ flex: 1, overflow: "auto", p: 2, maxWidth: 560 }}>
+          <TextField
+            fullWidth
+            size="small"
+            label="Job name"
+            value={formName}
+            onChange={e => setFormName(e.target.value)}
+            sx={{ mb: 2 }}
+          />
+          <FormControl fullWidth size="small" sx={{ mb: 2 }}>
+            <InputLabel id="dbt-job-env">Environment</InputLabel>
+            <Select
+              labelId="dbt-job-env"
+              label="Environment"
+              value={formEnvironment}
+              onChange={e => setFormEnvironment(e.target.value)}
+            >
+              {(project?.environments ?? []).map(env => (
+                <MenuItem key={env.name} value={env.name}>
+                  {env.name} ({env.targetSchema})
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <Typography variant="subtitle2" sx={{ mb: 1 }}>
+            Commands
+          </Typography>
+          {formCommands.map((command, index) => {
+            const preset = COMMAND_PRESETS.find(
+              p => command === p || command.startsWith(`${p} `),
+            );
+            const flags = preset ? command.slice(preset.length).trim() : "";
+            return (
+              <Box
+                key={index}
+                sx={{ display: "flex", gap: 1, mb: 1, alignItems: "center" }}
+              >
+                <Select
+                  size="small"
+                  value={preset ?? "build"}
+                  onChange={e => {
+                    const next = [...formCommands];
+                    next[index] = flags
+                      ? `${e.target.value} ${flags}`
+                      : e.target.value;
+                    setFormCommands(next);
+                  }}
+                  sx={{ minWidth: 150 }}
+                >
+                  {COMMAND_PRESETS.map(p => (
+                    <MenuItem key={p} value={p}>
+                      dbt {p}
+                    </MenuItem>
+                  ))}
+                </Select>
+                <TextField
+                  size="small"
+                  placeholder="--select staging --full-refresh"
+                  value={flags}
+                  onChange={e => {
+                    const next = [...formCommands];
+                    const base = preset ?? "build";
+                    next[index] = e.target.value.trim()
+                      ? `${base} ${e.target.value}`
+                      : base;
+                    setFormCommands(next);
+                  }}
+                  sx={{ flex: 1 }}
+                />
+                <IconButton
+                  size="small"
+                  disabled={formCommands.length <= 1}
+                  onClick={() =>
+                    setFormCommands(formCommands.filter((_c, i) => i !== index))
+                  }
+                >
+                  <RemoveIcon size={14} />
+                </IconButton>
+              </Box>
+            );
+          })}
+          <Button
+            size="small"
+            startIcon={<AddIcon size={14} />}
+            onClick={() => setFormCommands([...formCommands, "test"])}
+            sx={{ mb: 2 }}
+          >
+            Add command
+          </Button>
+
+          <Box sx={{ mb: 2 }}>
+            <FormControlLabel
+              control={
+                <Switch
+                  size="small"
+                  checked={formScheduleEnabled}
+                  onChange={e => setFormScheduleEnabled(e.target.checked)}
+                />
+              }
+              label="Run on a schedule"
+            />
+            {formScheduleEnabled && (
+              <Box sx={{ pl: 1, pt: 1 }}>
+                <RadioGroup
+                  value={formPreset}
+                  onChange={e =>
+                    handlePresetChange(e.target.value as SchedulePreset)
+                  }
+                >
+                  <FormControlLabel
+                    value="hourly"
+                    control={<Radio size="small" />}
+                    label="Hourly"
+                  />
+                  <FormControlLabel
+                    value="daily"
+                    control={<Radio size="small" />}
+                    label="Daily at 06:00"
+                  />
+                  <FormControlLabel
+                    value="every6h"
+                    control={<Radio size="small" />}
+                    label="Every 6 hours"
+                  />
+                  <FormControlLabel
+                    value="weekly"
+                    control={<Radio size="small" />}
+                    label="Weekly (Mon 06:00)"
+                  />
+                  <FormControlLabel
+                    value="custom"
+                    control={<Radio size="small" />}
+                    label="Custom cron"
+                  />
+                </RadioGroup>
+                {formPreset === "custom" && (
+                  <TextField
+                    size="small"
+                    label="Cron expression"
+                    value={formCron}
+                    onChange={e => setFormCron(e.target.value)}
+                    sx={{ mt: 1, mb: 1 }}
+                  />
+                )}
+                <FormControl fullWidth size="small" sx={{ mt: 1, mb: 1 }}>
+                  <InputLabel id="dbt-job-tz">Timezone</InputLabel>
+                  <Select
+                    labelId="dbt-job-tz"
+                    label="Timezone"
+                    value={formTimezone}
+                    onChange={e => setFormTimezone(e.target.value)}
+                  >
+                    {timezones.map(tz => (
+                      <MenuItem key={tz} value={tz}>
+                        {tz}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+                {previewRuns.length > 0 ? (
+                  <Typography variant="caption" color="text.secondary">
+                    Next runs: {previewRuns.join(" · ")}
+                  </Typography>
+                ) : (
+                  <Typography variant="caption" color="error">
+                    Invalid cron expression
+                  </Typography>
+                )}
+              </Box>
+            )}
+          </Box>
+
+          <FormControlLabel
+            control={
+              <Switch
+                size="small"
+                checked={formEnabled}
+                onChange={e => setFormEnabled(e.target.checked)}
+              />
+            }
+            label="Enabled"
+            sx={{ display: "block", mb: 2 }}
+          />
+
+          <Button
+            variant="contained"
+            disabled={
+              saving ||
+              !formEnvironment ||
+              formCommands.length === 0 ||
+              (formScheduleEnabled && previewRuns.length === 0)
+            }
+            onClick={handleSave}
+          >
+            {saving ? "Saving…" : "Save job"}
+          </Button>
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
+      {topBar}
+      <Box sx={{ flex: 1, minHeight: 0 }}>
+        <PanelGroup direction="horizontal">
+          {/* Run history */}
+          <Panel defaultSize={25} minSize={15}>
+            <Box
+              sx={{
+                height: "100%",
+                overflow: "auto",
+                borderRight: "1px solid",
+                borderColor: "divider",
+              }}
+            >
+              {jobRuns.length === 0 ? (
+                <Box sx={{ p: 2 }}>
+                  <Typography variant="caption" color="text.secondary">
+                    No runs yet. Press Run now to start one.
+                  </Typography>
+                </Box>
+              ) : (
+                jobRuns.map(run => (
+                  <Box
+                    key={run._id}
+                    onClick={() => setSelectedRunId(run._id)}
+                    sx={{
+                      px: 1.5,
+                      py: 0.75,
+                      cursor: "pointer",
+                      borderBottom: "1px solid",
+                      borderColor: "divider",
+                      backgroundColor:
+                        run._id === selectedRunId
+                          ? "action.selected"
+                          : "transparent",
+                      "&:hover": { backgroundColor: "action.hover" },
+                    }}
+                  >
+                    <Box
+                      sx={{ display: "flex", alignItems: "center", gap: 0.75 }}
+                    >
+                      <Box
+                        sx={{
+                          width: 8,
+                          height: 8,
+                          borderRadius: "50%",
+                          backgroundColor: statusColor(run.status),
+                          flexShrink: 0,
+                        }}
+                      />
+                      <Typography variant="caption" sx={{ flex: 1 }}>
+                        {relativeTime(run.createdAt)}
+                      </Typography>
+                      <Chip
+                        label={run.trigger}
+                        size="small"
+                        variant="outlined"
+                        sx={{ height: 16, fontSize: "0.6rem" }}
+                      />
+                    </Box>
+                    <Typography
+                      variant="caption"
+                      sx={{ color: statusColor(run.status) }}
+                    >
+                      {run.status}
+                      {run.durationMs !== undefined
+                        ? ` · ${formatDuration(run.durationMs)}`
+                        : ""}
+                    </Typography>
+                  </Box>
+                ))
+              )}
+            </Box>
+          </Panel>
+          <PanelResizeHandle
+            style={{ width: 4, background: "var(--mui-palette-divider)" }}
+          />
+          {/* Run details */}
+          <Panel defaultSize={75} minSize={30}>
+            {!selectedRun && !selectedRunListItem ? (
+              <Box sx={{ p: 2 }}>
+                <Typography variant="caption" color="text.secondary">
+                  Select a run to see details.
+                </Typography>
+              </Box>
+            ) : (
+              <Box
+                sx={{
+                  height: "100%",
+                  display: "flex",
+                  flexDirection: "column",
+                }}
+              >
+                {/* Summary strip */}
+                <Box
+                  sx={{
+                    display: "flex",
+                    gap: 2,
+                    alignItems: "center",
+                    px: 1.5,
+                    py: 0.75,
+                    borderBottom: "1px solid",
+                    borderColor: "divider",
+                    flexWrap: "wrap",
+                  }}
+                >
+                  <Typography
+                    variant="caption"
+                    sx={{
+                      color: statusColor(
+                        (selectedStatus ?? "queued") as DbtRunItem["status"],
+                      ),
+                      fontWeight: 600,
+                    }}
+                  >
+                    {selectedStatus}
+                    {selectedStatus === "running" && (
+                      <CircularProgress size={10} sx={{ ml: 0.5 }} />
+                    )}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {(selectedRun ?? selectedRunListItem)?.commands
+                      .map(command => `dbt ${command}`)
+                      .join(" → ")}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {formatDuration(
+                      (selectedRun ?? selectedRunListItem)?.durationMs,
+                    )}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {(selectedRun ?? selectedRunListItem)?.trigger} ·{" "}
+                    {(selectedRun ?? selectedRunListItem)?.triggeredBy}
+                  </Typography>
+                  {(selectedRun ?? selectedRunListItem)?.error && (
+                    <Typography variant="caption" color="error">
+                      {(selectedRun ?? selectedRunListItem)?.error}
+                    </Typography>
+                  )}
+                </Box>
+
+                {/* Models table */}
+                {(selectedRun?.stepResults?.length ?? 0) > 0 && (
+                  <Box
+                    sx={{
+                      maxHeight: "40%",
+                      overflow: "auto",
+                      borderBottom: "1px solid",
+                      borderColor: "divider",
+                    }}
+                  >
+                    <Box
+                      component="table"
+                      sx={{
+                        width: "100%",
+                        fontSize: "0.75rem",
+                        borderCollapse: "collapse",
+                        "& td, & th": {
+                          borderBottom: "1px solid",
+                          borderColor: "divider",
+                          p: 0.5,
+                          textAlign: "left",
+                        },
+                      }}
+                    >
+                      <thead>
+                        <tr>
+                          <th>Node</th>
+                          <th>Type</th>
+                          <th>Status</th>
+                          <th>Time</th>
+                          <th>Rows</th>
+                          <th></th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {selectedRun?.stepResults?.map(step => (
+                          <Box
+                            component="tr"
+                            key={step.uniqueId}
+                            sx={{
+                              color:
+                                step.status === "error" ||
+                                step.status === "fail"
+                                  ? "error.main"
+                                  : step.status === "warn"
+                                    ? "warning.main"
+                                    : "inherit",
+                            }}
+                          >
+                            <td>{step.name}</td>
+                            <td>{step.resourceType}</td>
+                            <td>
+                              {step.status}
+                              {step.message &&
+                              (step.status === "error" ||
+                                step.status === "fail")
+                                ? ` — ${step.message}`
+                                : ""}
+                            </td>
+                            <td>{(step.executionTimeMs / 1000).toFixed(2)}s</td>
+                            <td>{step.rowsAffected ?? ""}</td>
+                            <td>
+                              {step.resourceType === "model" && (
+                                <Tooltip title="Open model">
+                                  <IconButton
+                                    size="small"
+                                    onClick={() =>
+                                      focusDbtFileTab(
+                                        projectId,
+                                        `models/${step.name}.sql`,
+                                      )
+                                    }
+                                  >
+                                    <ModelIcon size={12} />
+                                  </IconButton>
+                                </Tooltip>
+                              )}
+                            </td>
+                          </Box>
+                        ))}
+                      </tbody>
+                    </Box>
+                  </Box>
+                )}
+
+                {/* Logs */}
+                <Box
+                  ref={logScrollRef}
+                  sx={{
+                    flex: 1,
+                    minHeight: 0,
+                    overflow: "auto",
+                    fontFamily: "monospace",
+                    fontSize: "0.72rem",
+                    p: 1,
+                    whiteSpace: "pre-wrap",
+                  }}
+                >
+                  {(selectedRun?.logs ?? []).length === 0 ? (
+                    <Typography variant="caption" color="text.secondary">
+                      {selectedStatus === "queued" ? "Run queued…" : "No logs."}
+                    </Typography>
+                  ) : (
+                    selectedRun?.logs.map((log, index) => (
+                      <Box
+                        key={index}
+                        component="div"
+                        sx={{
+                          color:
+                            log.level === "error"
+                              ? "error.main"
+                              : log.level === "warn"
+                                ? "warning.main"
+                                : "text.primary",
+                        }}
+                      >
+                        <Box
+                          component="span"
+                          sx={{ color: "text.secondary", mr: 1 }}
+                        >
+                          {new Date(log.ts).toLocaleTimeString()}
+                        </Box>
+                        {log.line}
+                      </Box>
+                    ))
+                  )}
+                </Box>
+              </Box>
+            )}
+          </Panel>
+        </PanelGroup>
+      </Box>
+    </Box>
+  );
+}

--- a/app/src/components/DbtJobView.tsx
+++ b/app/src/components/DbtJobView.tsx
@@ -3,22 +3,12 @@
  * the job edit form (commands list + schedule, pattern: ScheduleConsoleModal).
  */
 
-import {
-  lazy,
-  Suspense,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Box,
   Button,
   Chip,
   CircularProgress,
-  Tab,
-  Tabs,
   FormControl,
   FormControlLabel,
   IconButton,
@@ -51,8 +41,6 @@ import {
   type DbtRunItem,
 } from "../store/dbtStore";
 import { focusDbtFileTab } from "../dbt-runtime/shell";
-
-const DbtLineageView = lazy(() => import("./DbtLineageView"));
 
 type SchedulePreset = "hourly" | "daily" | "every6h" | "weekly" | "custom";
 
@@ -116,6 +104,11 @@ function relativeTime(iso?: string): string {
   return `${Math.floor(hours / 24)}d ago`;
 }
 
+function absoluteTime(iso?: string): string {
+  if (!iso) return "";
+  return new Date(iso).toLocaleString();
+}
+
 export default function DbtJobView({
   projectId,
   jobId,
@@ -151,7 +144,6 @@ export default function DbtJobView({
 
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
   const [editing, setEditing] = useState(false);
-  const [viewTab, setViewTab] = useState<"runs" | "lineage">("runs");
   const logScrollRef = useRef<HTMLDivElement | null>(null);
 
   // Edit-form state
@@ -334,81 +326,131 @@ export default function DbtJobView({
     );
   }
 
-  const topBar = (
+  const commandSummary = job.commands
+    .map(command => `dbt ${command}`)
+    .join(" → ");
+  const scheduleSummary = job.schedule?.cron
+    ? `${job.schedule.cron} ${job.schedule.timezone}`
+    : "manual";
+
+  const header = (
     <Box
       sx={{
-        display: "flex",
-        alignItems: "center",
-        gap: 1,
-        px: 1.5,
-        py: 0.75,
         borderBottom: "1px solid",
         borderColor: "divider",
         backgroundColor: "background.paper",
       }}
     >
-      <Typography variant="subtitle2" sx={{ flexShrink: 0 }}>
-        {job.name}
-      </Typography>
-      <Chip label={job.environment} size="small" variant="outlined" />
-      {!job.enabled && (
+      {/* Line 1 — identity + actions */}
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1,
+          px: 1.5,
+          pt: 0.75,
+          pb: editing ? 0.75 : 0.25,
+        }}
+      >
+        <Typography
+          variant="subtitle2"
+          sx={{
+            minWidth: 0,
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}
+        >
+          {job.name}
+        </Typography>
         <Chip
-          label="disabled"
+          label={job.environment}
           size="small"
-          color="warning"
           variant="outlined"
+          sx={{ flexShrink: 0 }}
         />
-      )}
-      <Typography
-        variant="caption"
-        color="text.secondary"
-        sx={{ flex: 1, overflow: "hidden", textOverflow: "ellipsis" }}
-      >
-        {job.commands.map(command => `dbt ${command}`).join(" → ")}
-        {job.schedule?.cron
-          ? ` · ${job.schedule.cron} ${job.schedule.timezone}`
-          : " · manual"}
-      </Typography>
-      {runningRun ? (
+        {!job.enabled && (
+          <Chip
+            label="disabled"
+            size="small"
+            color="warning"
+            variant="outlined"
+            sx={{ flexShrink: 0 }}
+          />
+        )}
+        {editing && (
+          <Chip
+            label="editing"
+            size="small"
+            color="info"
+            variant="outlined"
+            sx={{ flexShrink: 0 }}
+          />
+        )}
+        <Box sx={{ flex: 1 }} />
+        {!editing &&
+          (runningRun ? (
+            <Button
+              size="small"
+              color="warning"
+              variant="outlined"
+              startIcon={<StopIcon size={14} />}
+              onClick={handleStop}
+            >
+              Stop
+            </Button>
+          ) : (
+            <Button
+              size="small"
+              variant="contained"
+              startIcon={<RunIcon size={14} />}
+              onClick={handleRunNow}
+            >
+              Run now
+            </Button>
+          ))}
         <Button
           size="small"
-          color="warning"
           variant="outlined"
-          startIcon={<StopIcon size={14} />}
-          onClick={handleStop}
+          startIcon={<EditIcon size={14} />}
+          onClick={editing ? () => setEditing(false) : beginEdit}
         >
-          Stop
+          {editing ? "Cancel" : "Edit"}
         </Button>
-      ) : (
-        <Button
-          size="small"
-          variant="contained"
-          startIcon={<RunIcon size={14} />}
-          onClick={handleRunNow}
-        >
-          Run now
-        </Button>
+        {!editing && (
+          <Tooltip title="Refresh">
+            <IconButton size="small" onClick={handleRefresh}>
+              <RefreshIcon size={16} />
+            </IconButton>
+          </Tooltip>
+        )}
+      </Box>
+      {/* Line 2 — muted command + schedule summary (view mode only) */}
+      {!editing && (
+        <Box sx={{ display: "flex", px: 1.5, pb: 0.5 }}>
+          <Tooltip title={`${commandSummary} · ${scheduleSummary}`}>
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{
+                minWidth: 0,
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+              }}
+            >
+              {commandSummary} · {scheduleSummary}
+            </Typography>
+          </Tooltip>
+        </Box>
       )}
-      <Button
-        size="small"
-        variant="outlined"
-        startIcon={<EditIcon size={14} />}
-        onClick={editing ? () => setEditing(false) : beginEdit}
-      >
-        {editing ? "Cancel" : "Edit"}
-      </Button>
-      <Tooltip title="Refresh">
-        <IconButton size="small" onClick={handleRefresh}>
-          <RefreshIcon size={16} />
-        </IconButton>
-      </Tooltip>
     </Box>
   );
 
   if (editing) {
     return (
       <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
-        {topBar}
+        {header}
         <Box sx={{ flex: 1, overflow: "auto", p: 2, maxWidth: 560 }}>
           <TextField
             fullWidth
@@ -500,7 +542,15 @@ export default function DbtJobView({
             Add command
           </Button>
 
-          <Box sx={{ mb: 2 }}>
+          <Box
+            sx={{
+              mb: 2,
+              p: 1.5,
+              border: 1,
+              borderColor: "divider",
+              borderRadius: 1,
+            }}
+          >
             <FormControlLabel
               control={
                 <Switch
@@ -578,21 +628,27 @@ export default function DbtJobView({
                     Invalid cron expression
                   </Typography>
                 )}
+                <FormControlLabel
+                  control={
+                    <Switch
+                      size="small"
+                      checked={formEnabled}
+                      onChange={e => setFormEnabled(e.target.checked)}
+                    />
+                  }
+                  label="Schedule enabled"
+                  sx={{ display: "block", mt: 1 }}
+                />
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ display: "block" }}
+                >
+                  Turn off to keep the schedule but pause automatic runs.
+                </Typography>
               </Box>
             )}
           </Box>
-
-          <FormControlLabel
-            control={
-              <Switch
-                size="small"
-                checked={formEnabled}
-                onChange={e => setFormEnabled(e.target.checked)}
-              />
-            }
-            label="Enabled"
-            sx={{ display: "block", mb: 1 }}
-          />
 
           <Tooltip title="Run with --defer --state against the last successful prod manifest. Use with `--select state:modified+` to build only what changed (Slim CI).">
             <FormControlLabel
@@ -627,66 +683,59 @@ export default function DbtJobView({
 
   return (
     <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
-      {topBar}
-      <Tabs
-        value={viewTab}
-        onChange={(_e, value) => setViewTab(value)}
-        sx={{
-          minHeight: 32,
-          borderBottom: "1px solid",
-          borderColor: "divider",
-        }}
-      >
-        <Tab label="Runs" value="runs" sx={{ minHeight: 32, py: 0 }} />
-        <Tab label="Lineage" value="lineage" sx={{ minHeight: 32, py: 0 }} />
-      </Tabs>
-      {viewTab === "lineage" ? (
-        <Box sx={{ flex: 1, minHeight: 0 }}>
-          <Suspense
-            fallback={
-              <Box sx={{ p: 3, display: "flex", justifyContent: "center" }}>
-                <CircularProgress size={20} />
-              </Box>
-            }
-          >
-            <DbtLineageView projectId={projectId} />
-          </Suspense>
-        </Box>
-      ) : (
-        <Box sx={{ flex: 1, minHeight: 0 }}>
-          <PanelGroup direction="horizontal">
-            {/* Run history */}
-            <Panel defaultSize={25} minSize={15}>
-              <Box
-                sx={{
-                  height: "100%",
-                  overflow: "auto",
-                  borderRight: "1px solid",
-                  borderColor: "divider",
-                }}
-              >
-                {jobRuns.length === 0 ? (
-                  <Box sx={{ p: 2 }}>
-                    <Typography variant="caption" color="text.secondary">
-                      No runs yet. Press Run now to start one.
-                    </Typography>
-                  </Box>
-                ) : (
-                  jobRuns.map(run => (
+      {header}
+      <Box sx={{ flex: 1, minHeight: 0 }}>
+        <PanelGroup direction="horizontal">
+          {/* Run history */}
+          <Panel defaultSize={25} minSize={15}>
+            <Box
+              sx={{
+                height: "100%",
+                overflow: "auto",
+                borderRight: "1px solid",
+                borderColor: "divider",
+              }}
+            >
+              {jobRuns.length === 0 ? (
+                <Box sx={{ p: 2 }}>
+                  <Typography variant="caption" color="text.secondary">
+                    No runs yet. Press Run now to start one.
+                  </Typography>
+                </Box>
+              ) : (
+                jobRuns.map(run => {
+                  const isSelected = run._id === selectedRunId;
+                  const isActive =
+                    run.status === "running" || run.status === "queued";
+                  const select = () => setSelectedRunId(run._id);
+                  return (
                     <Box
                       key={run._id}
-                      onClick={() => setSelectedRunId(run._id)}
+                      role="button"
+                      tabIndex={0}
+                      onClick={select}
+                      onKeyDown={e => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          select();
+                        }
+                      }}
+                      title={absoluteTime(run.createdAt)}
                       sx={{
                         px: 1.5,
                         py: 0.75,
                         cursor: "pointer",
                         borderBottom: "1px solid",
                         borderColor: "divider",
-                        backgroundColor:
-                          run._id === selectedRunId
-                            ? "action.selected"
-                            : "transparent",
+                        backgroundColor: isSelected
+                          ? "action.selected"
+                          : "transparent",
                         "&:hover": { backgroundColor: "action.hover" },
+                        "&:focus-visible": {
+                          outline: "2px solid",
+                          outlineColor: "primary.main",
+                          outlineOffset: "-2px",
+                        },
                       }}
                     >
                       <Box
@@ -705,249 +754,302 @@ export default function DbtJobView({
                             flexShrink: 0,
                           }}
                         />
-                        <Typography variant="caption" sx={{ flex: 1 }}>
-                          {relativeTime(run.createdAt)}
-                        </Typography>
-                        <Chip
-                          label={run.trigger}
-                          size="small"
-                          variant="outlined"
-                          sx={{ height: 16, fontSize: "0.6rem" }}
-                        />
-                      </Box>
-                      <Typography
-                        variant="caption"
-                        sx={{ color: statusColor(run.status) }}
-                      >
-                        {run.status}
-                        {run.durationMs !== undefined
-                          ? ` · ${formatDuration(run.durationMs)}`
-                          : ""}
-                      </Typography>
-                    </Box>
-                  ))
-                )}
-              </Box>
-            </Panel>
-            <PanelResizeHandle
-              style={{ width: 4, background: "var(--mui-palette-divider)" }}
-            />
-            {/* Run details */}
-            <Panel defaultSize={75} minSize={30}>
-              {!selectedRun && !selectedRunListItem ? (
-                <Box sx={{ p: 2 }}>
-                  <Typography variant="caption" color="text.secondary">
-                    Select a run to see details.
-                  </Typography>
-                </Box>
-              ) : (
-                <Box
-                  sx={{
-                    height: "100%",
-                    display: "flex",
-                    flexDirection: "column",
-                  }}
-                >
-                  {/* Summary strip */}
-                  <Box
-                    sx={{
-                      display: "flex",
-                      gap: 2,
-                      alignItems: "center",
-                      px: 1.5,
-                      py: 0.75,
-                      borderBottom: "1px solid",
-                      borderColor: "divider",
-                      flexWrap: "wrap",
-                    }}
-                  >
-                    <Typography
-                      variant="caption"
-                      sx={{
-                        color: statusColor(
-                          (selectedStatus ?? "queued") as DbtRunItem["status"],
-                        ),
-                        fontWeight: 600,
-                      }}
-                    >
-                      {selectedStatus}
-                      {selectedStatus === "running" && (
-                        <CircularProgress size={10} sx={{ ml: 0.5 }} />
-                      )}
-                    </Typography>
-                    <Typography variant="caption" color="text.secondary">
-                      {(selectedRun ?? selectedRunListItem)?.commands
-                        .map(command => `dbt ${command}`)
-                        .join(" → ")}
-                    </Typography>
-                    <Typography variant="caption" color="text.secondary">
-                      {formatDuration(
-                        (selectedRun ?? selectedRunListItem)?.durationMs,
-                      )}
-                    </Typography>
-                    <Typography variant="caption" color="text.secondary">
-                      {(selectedRun ?? selectedRunListItem)?.trigger} ·{" "}
-                      {(selectedRun ?? selectedRunListItem)?.triggeredBy}
-                    </Typography>
-                    {(selectedRun ?? selectedRunListItem)?.error && (
-                      <Typography variant="caption" color="error">
-                        {(selectedRun ?? selectedRunListItem)?.error}
-                      </Typography>
-                    )}
-                    {selectedStatus === "error" && (
-                      <Tooltip title="Re-run only the failed/skipped nodes">
-                        <Button
-                          size="small"
-                          variant="outlined"
-                          startIcon={<RetryIcon size={14} />}
-                          onClick={handleRetry}
-                          sx={{ ml: "auto" }}
-                        >
-                          Retry from failure
-                        </Button>
-                      </Tooltip>
-                    )}
-                  </Box>
-
-                  {/* Models table */}
-                  {(selectedRun?.stepResults?.length ?? 0) > 0 && (
-                    <Box
-                      sx={{
-                        maxHeight: "40%",
-                        overflow: "auto",
-                        borderBottom: "1px solid",
-                        borderColor: "divider",
-                      }}
-                    >
-                      <Box
-                        component="table"
-                        sx={{
-                          width: "100%",
-                          fontSize: "0.75rem",
-                          borderCollapse: "collapse",
-                          "& td, & th": {
-                            borderBottom: "1px solid",
-                            borderColor: "divider",
-                            p: 0.5,
-                            textAlign: "left",
-                          },
-                        }}
-                      >
-                        <thead>
-                          <tr>
-                            <th>Node</th>
-                            <th>Type</th>
-                            <th>Status</th>
-                            <th>Time</th>
-                            <th>Rows</th>
-                            <th></th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          {selectedRun?.stepResults?.map(step => (
-                            <Box
-                              component="tr"
-                              key={step.uniqueId}
-                              sx={{
-                                color:
-                                  step.status === "error" ||
-                                  step.status === "fail"
-                                    ? "error.main"
-                                    : step.status === "warn"
-                                      ? "warning.main"
-                                      : "inherit",
-                              }}
-                            >
-                              <td>{step.name}</td>
-                              <td>{step.resourceType}</td>
-                              <td>
-                                {step.status}
-                                {step.message &&
-                                (step.status === "error" ||
-                                  step.status === "fail" ||
-                                  step.status === "warn" ||
-                                  step.resourceType === "source")
-                                  ? ` — ${step.message}`
-                                  : ""}
-                              </td>
-                              <td>
-                                {(step.executionTimeMs / 1000).toFixed(2)}s
-                              </td>
-                              <td>{step.rowsAffected ?? ""}</td>
-                              <td>
-                                {step.resourceType === "model" && (
-                                  <Tooltip title="Open model">
-                                    <IconButton
-                                      size="small"
-                                      onClick={() =>
-                                        focusDbtFileTab(
-                                          projectId,
-                                          `models/${step.name}.sql`,
-                                        )
-                                      }
-                                    >
-                                      <ModelIcon size={12} />
-                                    </IconButton>
-                                  </Tooltip>
-                                )}
-                              </td>
-                            </Box>
-                          ))}
-                        </tbody>
-                      </Box>
-                    </Box>
-                  )}
-
-                  {/* Logs */}
-                  <Box
-                    ref={logScrollRef}
-                    sx={{
-                      flex: 1,
-                      minHeight: 0,
-                      overflow: "auto",
-                      fontFamily: "monospace",
-                      fontSize: "0.72rem",
-                      p: 1,
-                      whiteSpace: "pre-wrap",
-                    }}
-                  >
-                    {(selectedRun?.logs ?? []).length === 0 ? (
-                      <Typography variant="caption" color="text.secondary">
-                        {selectedStatus === "queued"
-                          ? "Run queued…"
-                          : "No logs."}
-                      </Typography>
-                    ) : (
-                      selectedRun?.logs.map((log, index) => (
-                        <Box
-                          key={index}
-                          component="div"
+                        <Typography
+                          variant="caption"
                           sx={{
-                            color:
-                              log.level === "error"
-                                ? "error.main"
-                                : log.level === "warn"
-                                  ? "warning.main"
-                                  : "text.primary",
+                            flex: 1,
+                            fontWeight: 600,
+                            color: statusColor(run.status),
+                            textTransform: "capitalize",
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 0.5,
                           }}
                         >
-                          <Box
-                            component="span"
-                            sx={{ color: "text.secondary", mr: 1 }}
-                          >
-                            {new Date(log.ts).toLocaleTimeString()}
-                          </Box>
-                          {log.line}
-                        </Box>
-                      ))
-                    )}
-                  </Box>
-                </Box>
+                          {run.status}
+                          {isActive && <CircularProgress size={9} />}
+                        </Typography>
+                        {run.durationMs !== undefined && (
+                          <Typography variant="caption" color="text.secondary">
+                            {formatDuration(run.durationMs)}
+                          </Typography>
+                        )}
+                      </Box>
+                      <Box
+                        sx={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 0.5,
+                          mt: 0.25,
+                        }}
+                      >
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{ flex: 1 }}
+                        >
+                          {relativeTime(run.createdAt)}
+                        </Typography>
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{ fontSize: "0.65rem" }}
+                        >
+                          {run.trigger}
+                        </Typography>
+                      </Box>
+                    </Box>
+                  );
+                })
               )}
-            </Panel>
-          </PanelGroup>
-        </Box>
-      )}
+            </Box>
+          </Panel>
+          <PanelResizeHandle
+            style={{ width: 4, background: "var(--mui-palette-divider)" }}
+          />
+          {/* Run details */}
+          <Panel defaultSize={75} minSize={30}>
+            {!selectedRun && !selectedRunListItem ? (
+              <Box sx={{ p: 2 }}>
+                <Typography variant="caption" color="text.secondary">
+                  Select a run to see details.
+                </Typography>
+              </Box>
+            ) : (
+              <Box
+                sx={{
+                  height: "100%",
+                  display: "flex",
+                  flexDirection: "column",
+                }}
+              >
+                {/* Summary strip */}
+                <Box
+                  sx={{
+                    display: "flex",
+                    gap: 2,
+                    alignItems: "center",
+                    px: 1.5,
+                    py: 0.75,
+                    borderBottom: "1px solid",
+                    borderColor: "divider",
+                    flexWrap: "wrap",
+                  }}
+                >
+                  <Chip
+                    size="small"
+                    variant="outlined"
+                    icon={
+                      selectedStatus === "running" ||
+                      selectedStatus === "queued" ? (
+                        <CircularProgress size={10} />
+                      ) : undefined
+                    }
+                    label={selectedStatus ?? "queued"}
+                    sx={{
+                      height: 20,
+                      textTransform: "capitalize",
+                      fontWeight: 600,
+                      color: statusColor(
+                        (selectedStatus ?? "queued") as DbtRunItem["status"],
+                      ),
+                      borderColor: statusColor(
+                        (selectedStatus ?? "queued") as DbtRunItem["status"],
+                      ),
+                    }}
+                  />
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    title={absoluteTime(
+                      (selectedRun ?? selectedRunListItem)?.createdAt,
+                    )}
+                  >
+                    {relativeTime(
+                      (selectedRun ?? selectedRunListItem)?.createdAt,
+                    )}
+                  </Typography>
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{
+                      fontFamily: "monospace",
+                      maxWidth: 360,
+                      whiteSpace: "nowrap",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                    }}
+                    title={(selectedRun ?? selectedRunListItem)?.commands
+                      .map(command => `dbt ${command}`)
+                      .join(" → ")}
+                  >
+                    {(selectedRun ?? selectedRunListItem)?.commands
+                      .map(command => `dbt ${command}`)
+                      .join(" → ")}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {formatDuration(
+                      (selectedRun ?? selectedRunListItem)?.durationMs,
+                    )}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {(selectedRun ?? selectedRunListItem)?.trigger} ·{" "}
+                    {(selectedRun ?? selectedRunListItem)?.triggeredBy}
+                  </Typography>
+                  {(selectedRun ?? selectedRunListItem)?.error && (
+                    <Typography variant="caption" color="error">
+                      {(selectedRun ?? selectedRunListItem)?.error}
+                    </Typography>
+                  )}
+                  {selectedStatus === "error" && (
+                    <Tooltip title="Re-run only the failed/skipped nodes">
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        startIcon={<RetryIcon size={14} />}
+                        onClick={handleRetry}
+                        sx={{ ml: "auto" }}
+                      >
+                        Retry from failure
+                      </Button>
+                    </Tooltip>
+                  )}
+                </Box>
+
+                {/* Models table */}
+                {(selectedRun?.stepResults?.length ?? 0) > 0 && (
+                  <Box
+                    sx={{
+                      maxHeight: "40%",
+                      overflow: "auto",
+                      borderBottom: "1px solid",
+                      borderColor: "divider",
+                    }}
+                  >
+                    <Box
+                      component="table"
+                      sx={{
+                        width: "100%",
+                        fontSize: "0.75rem",
+                        borderCollapse: "collapse",
+                        "& td, & th": {
+                          borderBottom: "1px solid",
+                          borderColor: "divider",
+                          p: 0.5,
+                          textAlign: "left",
+                        },
+                      }}
+                    >
+                      <thead>
+                        <tr>
+                          <th>Node</th>
+                          <th>Type</th>
+                          <th>Status</th>
+                          <th>Time</th>
+                          <th>Rows</th>
+                          <th></th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {selectedRun?.stepResults?.map(step => (
+                          <Box
+                            component="tr"
+                            key={step.uniqueId}
+                            sx={{
+                              color:
+                                step.status === "error" ||
+                                step.status === "fail"
+                                  ? "error.main"
+                                  : step.status === "warn"
+                                    ? "warning.main"
+                                    : "inherit",
+                            }}
+                          >
+                            <td>{step.name}</td>
+                            <td>{step.resourceType}</td>
+                            <td>
+                              {step.status}
+                              {step.message &&
+                              (step.status === "error" ||
+                                step.status === "fail" ||
+                                step.status === "warn" ||
+                                step.resourceType === "source")
+                                ? ` — ${step.message}`
+                                : ""}
+                            </td>
+                            <td>{(step.executionTimeMs / 1000).toFixed(2)}s</td>
+                            <td>{step.rowsAffected ?? ""}</td>
+                            <td>
+                              {step.resourceType === "model" && (
+                                <Tooltip title="Open model">
+                                  <IconButton
+                                    size="small"
+                                    onClick={() =>
+                                      focusDbtFileTab(
+                                        projectId,
+                                        `models/${step.name}.sql`,
+                                      )
+                                    }
+                                  >
+                                    <ModelIcon size={12} />
+                                  </IconButton>
+                                </Tooltip>
+                              )}
+                            </td>
+                          </Box>
+                        ))}
+                      </tbody>
+                    </Box>
+                  </Box>
+                )}
+
+                {/* Logs */}
+                <Box
+                  ref={logScrollRef}
+                  sx={{
+                    flex: 1,
+                    minHeight: 0,
+                    overflow: "auto",
+                    fontFamily: "monospace",
+                    fontSize: "0.72rem",
+                    p: 1,
+                    whiteSpace: "pre-wrap",
+                  }}
+                >
+                  {(selectedRun?.logs ?? []).length === 0 ? (
+                    <Typography variant="caption" color="text.secondary">
+                      {selectedStatus === "queued" ? "Run queued…" : "No logs."}
+                    </Typography>
+                  ) : (
+                    selectedRun?.logs.map((log, index) => (
+                      <Box
+                        key={index}
+                        component="div"
+                        sx={{
+                          color:
+                            log.level === "error"
+                              ? "error.main"
+                              : log.level === "warn"
+                                ? "warning.main"
+                                : "text.primary",
+                        }}
+                      >
+                        <Box
+                          component="span"
+                          sx={{ color: "text.secondary", mr: 1 }}
+                        >
+                          {new Date(log.ts).toLocaleTimeString()}
+                        </Box>
+                        {log.line}
+                      </Box>
+                    ))
+                  )}
+                </Box>
+              </Box>
+            )}
+          </Panel>
+        </PanelGroup>
+      </Box>
     </Box>
   );
 }

--- a/app/src/components/DbtJobView.tsx
+++ b/app/src/components/DbtJobView.tsx
@@ -846,7 +846,9 @@ export default function DbtJobView({
                                 {step.status}
                                 {step.message &&
                                 (step.status === "error" ||
-                                  step.status === "fail")
+                                  step.status === "fail" ||
+                                  step.status === "warn" ||
+                                  step.resourceType === "source")
                                   ? ` — ${step.message}`
                                   : ""}
                               </td>

--- a/app/src/components/DbtJobView.tsx
+++ b/app/src/components/DbtJobView.tsx
@@ -163,6 +163,7 @@ export default function DbtJobView({
   const [formCron, setFormCron] = useState(PRESET_CRONS.daily);
   const [formTimezone, setFormTimezone] = useState("UTC");
   const [formEnabled, setFormEnabled] = useState(true);
+  const [formDefer, setFormDefer] = useState(false);
   const [saving, setSaving] = useState(false);
 
   const timezones = useMemo<string[]>(() => {
@@ -268,6 +269,7 @@ export default function DbtJobView({
     setFormPreset(presetFromCron(cron));
     setFormTimezone(job.schedule?.timezone ?? "UTC");
     setFormEnabled(job.enabled);
+    setFormDefer(!!job.deferToProduction);
     setEditing(true);
   }, [job]);
 
@@ -304,6 +306,7 @@ export default function DbtJobView({
         ? { cron: formCron, timezone: formTimezone }
         : null,
       enabled: formEnabled,
+      deferToProduction: formDefer,
     };
     const saved = await saveJob(workspaceId, projectId, payload, jobId);
     setSaving(false);
@@ -319,6 +322,7 @@ export default function DbtJobView({
     formCron,
     formTimezone,
     formEnabled,
+    formDefer,
     saveJob,
   ]);
 
@@ -587,8 +591,22 @@ export default function DbtJobView({
               />
             }
             label="Enabled"
-            sx={{ display: "block", mb: 2 }}
+            sx={{ display: "block", mb: 1 }}
           />
+
+          <Tooltip title="Run with --defer --state against the last successful prod manifest. Use with `--select state:modified+` to build only what changed (Slim CI).">
+            <FormControlLabel
+              control={
+                <Switch
+                  size="small"
+                  checked={formDefer}
+                  onChange={e => setFormDefer(e.target.checked)}
+                />
+              }
+              label="Defer to production (Slim CI)"
+              sx={{ display: "block", mb: 2 }}
+            />
+          </Tooltip>
 
           <Button
             variant="contained"

--- a/app/src/components/DbtJobView.tsx
+++ b/app/src/components/DbtJobView.tsx
@@ -40,6 +40,7 @@ import {
   Plus as AddIcon,
   Trash2 as RemoveIcon,
   FileCode as ModelIcon,
+  RotateCcw as RetryIcon,
 } from "lucide-react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { CronExpressionParser } from "cron-parser";
@@ -135,6 +136,7 @@ export default function DbtJobView({
   const fetchRunDetails = useDbtStore(s => s.fetchRunDetails);
   const triggerJob = useDbtStore(s => s.triggerJob);
   const cancelRun = useDbtStore(s => s.cancelRun);
+  const retryRun = useDbtStore(s => s.retryRun);
   const saveJob = useDbtStore(s => s.saveJob);
 
   const job = useMemo(
@@ -244,6 +246,12 @@ export default function DbtJobView({
     await cancelRun(workspaceId, projectId, runningRun._id);
     await fetchRuns(workspaceId, projectId, jobId);
   }, [workspaceId, projectId, jobId, runningRun, cancelRun, fetchRuns]);
+
+  const handleRetry = useCallback(async () => {
+    if (!workspaceId || !selectedRunId) return;
+    const runId = await retryRun(workspaceId, projectId, selectedRunId, jobId);
+    if (runId) setSelectedRunId(runId);
+  }, [workspaceId, projectId, jobId, selectedRunId, retryRun]);
 
   const handleRefresh = useCallback(() => {
     if (workspaceId) void fetchRuns(workspaceId, projectId, jobId);
@@ -767,6 +775,19 @@ export default function DbtJobView({
                       <Typography variant="caption" color="error">
                         {(selectedRun ?? selectedRunListItem)?.error}
                       </Typography>
+                    )}
+                    {selectedStatus === "error" && (
+                      <Tooltip title="Re-run only the failed/skipped nodes">
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          startIcon={<RetryIcon size={14} />}
+                          onClick={handleRetry}
+                          sx={{ ml: "auto" }}
+                        >
+                          Retry from failure
+                        </Button>
+                      </Tooltip>
                     )}
                   </Box>
 

--- a/app/src/components/DbtJobView.tsx
+++ b/app/src/components/DbtJobView.tsx
@@ -3,12 +3,22 @@
  * the job edit form (commands list + schedule, pattern: ScheduleConsoleModal).
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   Box,
   Button,
   Chip,
   CircularProgress,
+  Tab,
+  Tabs,
   FormControl,
   FormControlLabel,
   IconButton,
@@ -40,6 +50,8 @@ import {
   type DbtRunItem,
 } from "../store/dbtStore";
 import { focusDbtFileTab } from "../dbt-runtime/shell";
+
+const DbtLineageView = lazy(() => import("./DbtLineageView"));
 
 type SchedulePreset = "hourly" | "daily" | "every6h" | "weekly" | "custom";
 
@@ -137,6 +149,7 @@ export default function DbtJobView({
 
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
   const [editing, setEditing] = useState(false);
+  const [viewTab, setViewTab] = useState<"runs" | "lineage">("runs");
   const logScrollRef = useRef<HTMLDivElement | null>(null);
 
   // Edit-form state
@@ -589,277 +602,311 @@ export default function DbtJobView({
   return (
     <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
       {topBar}
-      <Box sx={{ flex: 1, minHeight: 0 }}>
-        <PanelGroup direction="horizontal">
-          {/* Run history */}
-          <Panel defaultSize={25} minSize={15}>
-            <Box
-              sx={{
-                height: "100%",
-                overflow: "auto",
-                borderRight: "1px solid",
-                borderColor: "divider",
-              }}
-            >
-              {jobRuns.length === 0 ? (
-                <Box sx={{ p: 2 }}>
-                  <Typography variant="caption" color="text.secondary">
-                    No runs yet. Press Run now to start one.
-                  </Typography>
-                </Box>
-              ) : (
-                jobRuns.map(run => (
-                  <Box
-                    key={run._id}
-                    onClick={() => setSelectedRunId(run._id)}
-                    sx={{
-                      px: 1.5,
-                      py: 0.75,
-                      cursor: "pointer",
-                      borderBottom: "1px solid",
-                      borderColor: "divider",
-                      backgroundColor:
-                        run._id === selectedRunId
-                          ? "action.selected"
-                          : "transparent",
-                      "&:hover": { backgroundColor: "action.hover" },
-                    }}
-                  >
-                    <Box
-                      sx={{ display: "flex", alignItems: "center", gap: 0.75 }}
-                    >
-                      <Box
-                        sx={{
-                          width: 8,
-                          height: 8,
-                          borderRadius: "50%",
-                          backgroundColor: statusColor(run.status),
-                          flexShrink: 0,
-                        }}
-                      />
-                      <Typography variant="caption" sx={{ flex: 1 }}>
-                        {relativeTime(run.createdAt)}
-                      </Typography>
-                      <Chip
-                        label={run.trigger}
-                        size="small"
-                        variant="outlined"
-                        sx={{ height: 16, fontSize: "0.6rem" }}
-                      />
-                    </Box>
-                    <Typography
-                      variant="caption"
-                      sx={{ color: statusColor(run.status) }}
-                    >
-                      {run.status}
-                      {run.durationMs !== undefined
-                        ? ` · ${formatDuration(run.durationMs)}`
-                        : ""}
-                    </Typography>
-                  </Box>
-                ))
-              )}
-            </Box>
-          </Panel>
-          <PanelResizeHandle
-            style={{ width: 4, background: "var(--mui-palette-divider)" }}
-          />
-          {/* Run details */}
-          <Panel defaultSize={75} minSize={30}>
-            {!selectedRun && !selectedRunListItem ? (
-              <Box sx={{ p: 2 }}>
-                <Typography variant="caption" color="text.secondary">
-                  Select a run to see details.
-                </Typography>
+      <Tabs
+        value={viewTab}
+        onChange={(_e, value) => setViewTab(value)}
+        sx={{
+          minHeight: 32,
+          borderBottom: "1px solid",
+          borderColor: "divider",
+        }}
+      >
+        <Tab label="Runs" value="runs" sx={{ minHeight: 32, py: 0 }} />
+        <Tab label="Lineage" value="lineage" sx={{ minHeight: 32, py: 0 }} />
+      </Tabs>
+      {viewTab === "lineage" ? (
+        <Box sx={{ flex: 1, minHeight: 0 }}>
+          <Suspense
+            fallback={
+              <Box sx={{ p: 3, display: "flex", justifyContent: "center" }}>
+                <CircularProgress size={20} />
               </Box>
-            ) : (
+            }
+          >
+            <DbtLineageView projectId={projectId} />
+          </Suspense>
+        </Box>
+      ) : (
+        <Box sx={{ flex: 1, minHeight: 0 }}>
+          <PanelGroup direction="horizontal">
+            {/* Run history */}
+            <Panel defaultSize={25} minSize={15}>
               <Box
                 sx={{
                   height: "100%",
-                  display: "flex",
-                  flexDirection: "column",
+                  overflow: "auto",
+                  borderRight: "1px solid",
+                  borderColor: "divider",
                 }}
               >
-                {/* Summary strip */}
-                <Box
-                  sx={{
-                    display: "flex",
-                    gap: 2,
-                    alignItems: "center",
-                    px: 1.5,
-                    py: 0.75,
-                    borderBottom: "1px solid",
-                    borderColor: "divider",
-                    flexWrap: "wrap",
-                  }}
-                >
-                  <Typography
-                    variant="caption"
-                    sx={{
-                      color: statusColor(
-                        (selectedStatus ?? "queued") as DbtRunItem["status"],
-                      ),
-                      fontWeight: 600,
-                    }}
-                  >
-                    {selectedStatus}
-                    {selectedStatus === "running" && (
-                      <CircularProgress size={10} sx={{ ml: 0.5 }} />
-                    )}
-                  </Typography>
-                  <Typography variant="caption" color="text.secondary">
-                    {(selectedRun ?? selectedRunListItem)?.commands
-                      .map(command => `dbt ${command}`)
-                      .join(" → ")}
-                  </Typography>
-                  <Typography variant="caption" color="text.secondary">
-                    {formatDuration(
-                      (selectedRun ?? selectedRunListItem)?.durationMs,
-                    )}
-                  </Typography>
-                  <Typography variant="caption" color="text.secondary">
-                    {(selectedRun ?? selectedRunListItem)?.trigger} ·{" "}
-                    {(selectedRun ?? selectedRunListItem)?.triggeredBy}
-                  </Typography>
-                  {(selectedRun ?? selectedRunListItem)?.error && (
-                    <Typography variant="caption" color="error">
-                      {(selectedRun ?? selectedRunListItem)?.error}
+                {jobRuns.length === 0 ? (
+                  <Box sx={{ p: 2 }}>
+                    <Typography variant="caption" color="text.secondary">
+                      No runs yet. Press Run now to start one.
                     </Typography>
-                  )}
-                </Box>
-
-                {/* Models table */}
-                {(selectedRun?.stepResults?.length ?? 0) > 0 && (
-                  <Box
-                    sx={{
-                      maxHeight: "40%",
-                      overflow: "auto",
-                      borderBottom: "1px solid",
-                      borderColor: "divider",
-                    }}
-                  >
+                  </Box>
+                ) : (
+                  jobRuns.map(run => (
                     <Box
-                      component="table"
+                      key={run._id}
+                      onClick={() => setSelectedRunId(run._id)}
                       sx={{
-                        width: "100%",
-                        fontSize: "0.75rem",
-                        borderCollapse: "collapse",
-                        "& td, & th": {
-                          borderBottom: "1px solid",
-                          borderColor: "divider",
-                          p: 0.5,
-                          textAlign: "left",
-                        },
+                        px: 1.5,
+                        py: 0.75,
+                        cursor: "pointer",
+                        borderBottom: "1px solid",
+                        borderColor: "divider",
+                        backgroundColor:
+                          run._id === selectedRunId
+                            ? "action.selected"
+                            : "transparent",
+                        "&:hover": { backgroundColor: "action.hover" },
                       }}
                     >
-                      <thead>
-                        <tr>
-                          <th>Node</th>
-                          <th>Type</th>
-                          <th>Status</th>
-                          <th>Time</th>
-                          <th>Rows</th>
-                          <th></th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {selectedRun?.stepResults?.map(step => (
-                          <Box
-                            component="tr"
-                            key={step.uniqueId}
-                            sx={{
-                              color:
-                                step.status === "error" ||
-                                step.status === "fail"
-                                  ? "error.main"
-                                  : step.status === "warn"
-                                    ? "warning.main"
-                                    : "inherit",
-                            }}
-                          >
-                            <td>{step.name}</td>
-                            <td>{step.resourceType}</td>
-                            <td>
-                              {step.status}
-                              {step.message &&
-                              (step.status === "error" ||
-                                step.status === "fail")
-                                ? ` — ${step.message}`
-                                : ""}
-                            </td>
-                            <td>{(step.executionTimeMs / 1000).toFixed(2)}s</td>
-                            <td>{step.rowsAffected ?? ""}</td>
-                            <td>
-                              {step.resourceType === "model" && (
-                                <Tooltip title="Open model">
-                                  <IconButton
-                                    size="small"
-                                    onClick={() =>
-                                      focusDbtFileTab(
-                                        projectId,
-                                        `models/${step.name}.sql`,
-                                      )
-                                    }
-                                  >
-                                    <ModelIcon size={12} />
-                                  </IconButton>
-                                </Tooltip>
-                              )}
-                            </td>
-                          </Box>
-                        ))}
-                      </tbody>
-                    </Box>
-                  </Box>
-                )}
-
-                {/* Logs */}
-                <Box
-                  ref={logScrollRef}
-                  sx={{
-                    flex: 1,
-                    minHeight: 0,
-                    overflow: "auto",
-                    fontFamily: "monospace",
-                    fontSize: "0.72rem",
-                    p: 1,
-                    whiteSpace: "pre-wrap",
-                  }}
-                >
-                  {(selectedRun?.logs ?? []).length === 0 ? (
-                    <Typography variant="caption" color="text.secondary">
-                      {selectedStatus === "queued" ? "Run queued…" : "No logs."}
-                    </Typography>
-                  ) : (
-                    selectedRun?.logs.map((log, index) => (
                       <Box
-                        key={index}
-                        component="div"
                         sx={{
-                          color:
-                            log.level === "error"
-                              ? "error.main"
-                              : log.level === "warn"
-                                ? "warning.main"
-                                : "text.primary",
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 0.75,
                         }}
                       >
                         <Box
-                          component="span"
-                          sx={{ color: "text.secondary", mr: 1 }}
-                        >
-                          {new Date(log.ts).toLocaleTimeString()}
-                        </Box>
-                        {log.line}
+                          sx={{
+                            width: 8,
+                            height: 8,
+                            borderRadius: "50%",
+                            backgroundColor: statusColor(run.status),
+                            flexShrink: 0,
+                          }}
+                        />
+                        <Typography variant="caption" sx={{ flex: 1 }}>
+                          {relativeTime(run.createdAt)}
+                        </Typography>
+                        <Chip
+                          label={run.trigger}
+                          size="small"
+                          variant="outlined"
+                          sx={{ height: 16, fontSize: "0.6rem" }}
+                        />
                       </Box>
-                    ))
-                  )}
-                </Box>
+                      <Typography
+                        variant="caption"
+                        sx={{ color: statusColor(run.status) }}
+                      >
+                        {run.status}
+                        {run.durationMs !== undefined
+                          ? ` · ${formatDuration(run.durationMs)}`
+                          : ""}
+                      </Typography>
+                    </Box>
+                  ))
+                )}
               </Box>
-            )}
-          </Panel>
-        </PanelGroup>
-      </Box>
+            </Panel>
+            <PanelResizeHandle
+              style={{ width: 4, background: "var(--mui-palette-divider)" }}
+            />
+            {/* Run details */}
+            <Panel defaultSize={75} minSize={30}>
+              {!selectedRun && !selectedRunListItem ? (
+                <Box sx={{ p: 2 }}>
+                  <Typography variant="caption" color="text.secondary">
+                    Select a run to see details.
+                  </Typography>
+                </Box>
+              ) : (
+                <Box
+                  sx={{
+                    height: "100%",
+                    display: "flex",
+                    flexDirection: "column",
+                  }}
+                >
+                  {/* Summary strip */}
+                  <Box
+                    sx={{
+                      display: "flex",
+                      gap: 2,
+                      alignItems: "center",
+                      px: 1.5,
+                      py: 0.75,
+                      borderBottom: "1px solid",
+                      borderColor: "divider",
+                      flexWrap: "wrap",
+                    }}
+                  >
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        color: statusColor(
+                          (selectedStatus ?? "queued") as DbtRunItem["status"],
+                        ),
+                        fontWeight: 600,
+                      }}
+                    >
+                      {selectedStatus}
+                      {selectedStatus === "running" && (
+                        <CircularProgress size={10} sx={{ ml: 0.5 }} />
+                      )}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {(selectedRun ?? selectedRunListItem)?.commands
+                        .map(command => `dbt ${command}`)
+                        .join(" → ")}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {formatDuration(
+                        (selectedRun ?? selectedRunListItem)?.durationMs,
+                      )}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {(selectedRun ?? selectedRunListItem)?.trigger} ·{" "}
+                      {(selectedRun ?? selectedRunListItem)?.triggeredBy}
+                    </Typography>
+                    {(selectedRun ?? selectedRunListItem)?.error && (
+                      <Typography variant="caption" color="error">
+                        {(selectedRun ?? selectedRunListItem)?.error}
+                      </Typography>
+                    )}
+                  </Box>
+
+                  {/* Models table */}
+                  {(selectedRun?.stepResults?.length ?? 0) > 0 && (
+                    <Box
+                      sx={{
+                        maxHeight: "40%",
+                        overflow: "auto",
+                        borderBottom: "1px solid",
+                        borderColor: "divider",
+                      }}
+                    >
+                      <Box
+                        component="table"
+                        sx={{
+                          width: "100%",
+                          fontSize: "0.75rem",
+                          borderCollapse: "collapse",
+                          "& td, & th": {
+                            borderBottom: "1px solid",
+                            borderColor: "divider",
+                            p: 0.5,
+                            textAlign: "left",
+                          },
+                        }}
+                      >
+                        <thead>
+                          <tr>
+                            <th>Node</th>
+                            <th>Type</th>
+                            <th>Status</th>
+                            <th>Time</th>
+                            <th>Rows</th>
+                            <th></th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {selectedRun?.stepResults?.map(step => (
+                            <Box
+                              component="tr"
+                              key={step.uniqueId}
+                              sx={{
+                                color:
+                                  step.status === "error" ||
+                                  step.status === "fail"
+                                    ? "error.main"
+                                    : step.status === "warn"
+                                      ? "warning.main"
+                                      : "inherit",
+                              }}
+                            >
+                              <td>{step.name}</td>
+                              <td>{step.resourceType}</td>
+                              <td>
+                                {step.status}
+                                {step.message &&
+                                (step.status === "error" ||
+                                  step.status === "fail")
+                                  ? ` — ${step.message}`
+                                  : ""}
+                              </td>
+                              <td>
+                                {(step.executionTimeMs / 1000).toFixed(2)}s
+                              </td>
+                              <td>{step.rowsAffected ?? ""}</td>
+                              <td>
+                                {step.resourceType === "model" && (
+                                  <Tooltip title="Open model">
+                                    <IconButton
+                                      size="small"
+                                      onClick={() =>
+                                        focusDbtFileTab(
+                                          projectId,
+                                          `models/${step.name}.sql`,
+                                        )
+                                      }
+                                    >
+                                      <ModelIcon size={12} />
+                                    </IconButton>
+                                  </Tooltip>
+                                )}
+                              </td>
+                            </Box>
+                          ))}
+                        </tbody>
+                      </Box>
+                    </Box>
+                  )}
+
+                  {/* Logs */}
+                  <Box
+                    ref={logScrollRef}
+                    sx={{
+                      flex: 1,
+                      minHeight: 0,
+                      overflow: "auto",
+                      fontFamily: "monospace",
+                      fontSize: "0.72rem",
+                      p: 1,
+                      whiteSpace: "pre-wrap",
+                    }}
+                  >
+                    {(selectedRun?.logs ?? []).length === 0 ? (
+                      <Typography variant="caption" color="text.secondary">
+                        {selectedStatus === "queued"
+                          ? "Run queued…"
+                          : "No logs."}
+                      </Typography>
+                    ) : (
+                      selectedRun?.logs.map((log, index) => (
+                        <Box
+                          key={index}
+                          component="div"
+                          sx={{
+                            color:
+                              log.level === "error"
+                                ? "error.main"
+                                : log.level === "warn"
+                                  ? "warning.main"
+                                  : "text.primary",
+                          }}
+                        >
+                          <Box
+                            component="span"
+                            sx={{ color: "text.secondary", mr: 1 }}
+                          >
+                            {new Date(log.ts).toLocaleTimeString()}
+                          </Box>
+                          {log.line}
+                        </Box>
+                      ))
+                    )}
+                  </Box>
+                </Box>
+              )}
+            </Panel>
+          </PanelGroup>
+        </Box>
+      )}
     </Box>
   );
 }

--- a/app/src/components/DbtLineageView.tsx
+++ b/app/src/components/DbtLineageView.tsx
@@ -5,7 +5,18 @@
  */
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Box, CircularProgress, Typography, useTheme } from "@mui/material";
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Divider,
+  IconButton,
+  Link,
+  Typography,
+  useTheme,
+} from "@mui/material";
+import { X as CloseIcon, ExternalLink as OpenIcon } from "lucide-react";
 import {
   Background,
   Controls,
@@ -16,7 +27,11 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { useWorkspace } from "../contexts/workspace-context";
-import { useDbtStore, type DbtLineage } from "../store/dbtStore";
+import {
+  useDbtStore,
+  type DbtLineage,
+  type DbtLineageNode,
+} from "../store/dbtStore";
 import { focusDbtFileTab } from "../dbt-runtime/shell";
 
 const NODE_WIDTH = 190;
@@ -60,6 +75,7 @@ export default function DbtLineageView({ projectId }: { projectId: string }) {
   const fetchLineage = useDbtStore(s => s.fetchLineage);
   const [lineage, setLineage] = useState<DbtLineage | null>(null);
   const [loading, setLoading] = useState(true);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
 
   useEffect(() => {
     if (!workspaceId) return;
@@ -91,6 +107,7 @@ export default function DbtLineageView({ projectId }: { projectId: string }) {
         return theme.palette.error.main;
       }
       if (resourceType === "source") return theme.palette.info.main;
+      if (resourceType === "exposure") return theme.palette.secondary.main;
       return theme.palette.divider;
     };
 
@@ -111,9 +128,12 @@ export default function DbtLineageView({ projectId }: { projectId: string }) {
           width: NODE_WIDTH,
           height: NODE_HEIGHT,
           fontSize: 12,
-          borderRadius: 8,
-          border: `2px solid ${colorFor(node.lastStatus, node.resourceType)}`,
-          background: theme.palette.background.paper,
+          borderRadius: node.resourceType === "exposure" ? 22 : 8,
+          border: `2px ${node.resourceType === "exposure" ? "dashed" : "solid"} ${colorFor(node.lastStatus, node.resourceType)}`,
+          background:
+            node.id === selectedNodeId
+              ? theme.palette.action.selected
+              : theme.palette.background.paper,
           color: theme.palette.text.primary,
         },
       };
@@ -128,16 +148,15 @@ export default function DbtLineageView({ projectId }: { projectId: string }) {
     }));
 
     return { nodes: flowNodes, edges: flowEdges };
-  }, [lineage, theme]);
+  }, [lineage, theme, selectedNodeId]);
 
-  const handleNodeClick = useCallback(
-    (_event: unknown, node: Node) => {
-      const meta = lineage?.nodes.find(n => n.id === node.id);
-      if (meta?.filePath) {
-        focusDbtFileTab(projectId, meta.filePath);
-      }
-    },
-    [lineage, projectId],
+  const handleNodeClick = useCallback((_event: unknown, node: Node) => {
+    setSelectedNodeId(node.id);
+  }, []);
+
+  const selectedNode: DbtLineageNode | undefined = useMemo(
+    () => lineage?.nodes.find(n => n.id === selectedNodeId),
+    [lineage, selectedNodeId],
   );
 
   if (loading) {
@@ -160,20 +179,162 @@ export default function DbtLineageView({ projectId }: { projectId: string }) {
   }
 
   return (
-    <Box sx={{ height: "100%", width: "100%" }}>
-      <ReactFlow
-        nodes={nodes}
-        edges={edges}
-        onNodeClick={handleNodeClick}
-        fitView
-        nodesDraggable={false}
-        nodesConnectable={false}
-        proOptions={{ hideAttribution: true }}
-        colorMode={theme.palette.mode === "dark" ? "dark" : "light"}
-      >
-        <Background gap={16} />
-        <Controls showInteractive={false} />
-      </ReactFlow>
+    <Box sx={{ height: "100%", width: "100%", display: "flex" }}>
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          onNodeClick={handleNodeClick}
+          fitView
+          nodesDraggable={false}
+          nodesConnectable={false}
+          proOptions={{ hideAttribution: true }}
+          colorMode={theme.palette.mode === "dark" ? "dark" : "light"}
+        >
+          <Background gap={16} />
+          <Controls showInteractive={false} />
+        </ReactFlow>
+      </Box>
+      {selectedNode && (
+        <Box
+          sx={{
+            width: 320,
+            flexShrink: 0,
+            borderLeft: "1px solid",
+            borderColor: "divider",
+            overflow: "auto",
+            p: 2,
+          }}
+        >
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              mb: 1,
+            }}
+          >
+            <Typography variant="subtitle2" sx={{ wordBreak: "break-word" }}>
+              {selectedNode.name}
+            </Typography>
+            <IconButton size="small" onClick={() => setSelectedNodeId(null)}>
+              <CloseIcon size={16} />
+            </IconButton>
+          </Box>
+          <Box sx={{ display: "flex", gap: 0.5, flexWrap: "wrap", mb: 1.5 }}>
+            <Chip size="small" label={selectedNode.resourceType} />
+            {selectedNode.materialized && (
+              <Chip
+                size="small"
+                variant="outlined"
+                label={selectedNode.materialized}
+              />
+            )}
+            {selectedNode.lastStatus && (
+              <Chip
+                size="small"
+                variant="outlined"
+                label={selectedNode.lastStatus}
+              />
+            )}
+            {selectedNode.tags?.map(tag => (
+              <Chip key={tag} size="small" variant="outlined" label={tag} />
+            ))}
+          </Box>
+
+          {selectedNode.description ? (
+            <Typography variant="body2" sx={{ mb: 1.5 }}>
+              {selectedNode.description}
+            </Typography>
+          ) : (
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ display: "block", mb: 1.5 }}
+            >
+              No description in the manifest.
+            </Typography>
+          )}
+
+          {selectedNode.owner && (
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ display: "block", mb: 0.5 }}
+            >
+              Owner: {selectedNode.owner}
+            </Typography>
+          )}
+          {selectedNode.url && (
+            <Link
+              href={selectedNode.url}
+              target="_blank"
+              rel="noopener"
+              variant="caption"
+              sx={{ display: "block", mb: 1.5 }}
+            >
+              {selectedNode.url}
+            </Link>
+          )}
+
+          {selectedNode.columns && selectedNode.columns.length > 0 && (
+            <>
+              <Divider sx={{ my: 1 }} />
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ fontWeight: 600 }}
+              >
+                Columns ({selectedNode.columns.length})
+              </Typography>
+              <Box sx={{ mt: 0.5 }}>
+                {selectedNode.columns.map(col => (
+                  <Box key={col.name} sx={{ mb: 0.75 }}>
+                    <Typography variant="caption" sx={{ fontWeight: 600 }}>
+                      {col.name}
+                      {col.type ? (
+                        <Box
+                          component="span"
+                          sx={{ color: "text.secondary", fontWeight: 400 }}
+                        >
+                          {" "}
+                          · {col.type}
+                        </Box>
+                      ) : null}
+                    </Typography>
+                    {col.description && (
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ display: "block" }}
+                      >
+                        {col.description}
+                      </Typography>
+                    )}
+                  </Box>
+                ))}
+              </Box>
+            </>
+          )}
+
+          {selectedNode.filePath && (
+            <Button
+              size="small"
+              variant="outlined"
+              fullWidth
+              startIcon={<OpenIcon size={14} />}
+              onClick={() => {
+                if (selectedNode.filePath) {
+                  focusDbtFileTab(projectId, selectedNode.filePath);
+                }
+              }}
+              sx={{ mt: 1.5 }}
+            >
+              Open file
+            </Button>
+          )}
+        </Box>
+      )}
     </Box>
   );
 }

--- a/app/src/components/DbtLineageView.tsx
+++ b/app/src/components/DbtLineageView.tsx
@@ -1,0 +1,179 @@
+/**
+ * DbtLineageView — DAG of the project's manifest parent_map, layered
+ * left-to-right (sources → staging → marts). Node color reflects last-run
+ * status; clicking a model node opens its file tab.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Box, CircularProgress, Typography, useTheme } from "@mui/material";
+import {
+  Background,
+  Controls,
+  Position,
+  ReactFlow,
+  type Edge,
+  type Node,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { useWorkspace } from "../contexts/workspace-context";
+import { useDbtStore, type DbtLineage } from "../store/dbtStore";
+import { focusDbtFileTab } from "../dbt-runtime/shell";
+
+const NODE_WIDTH = 190;
+const NODE_HEIGHT = 44;
+const COLUMN_GAP = 90;
+const ROW_GAP = 24;
+
+/** Longest-path layering: column = max(parent column) + 1. */
+function computeLayers(lineage: DbtLineage): Map<string, number> {
+  const parents = new Map<string, string[]>();
+  for (const node of lineage.nodes) parents.set(node.id, []);
+  for (const edge of lineage.edges) {
+    parents.get(edge.target)?.push(edge.source);
+  }
+
+  const layers = new Map<string, number>();
+  const visiting = new Set<string>();
+
+  const layerOf = (id: string): number => {
+    const cached = layers.get(id);
+    if (cached !== undefined) return cached;
+    if (visiting.has(id)) return 0; // cycle guard — manifests are acyclic
+    visiting.add(id);
+    const nodeParents = parents.get(id) ?? [];
+    const layer =
+      nodeParents.length === 0 ? 0 : Math.max(...nodeParents.map(layerOf)) + 1;
+    visiting.delete(id);
+    layers.set(id, layer);
+    return layer;
+  };
+
+  for (const node of lineage.nodes) layerOf(node.id);
+  return layers;
+}
+
+export default function DbtLineageView({ projectId }: { projectId: string }) {
+  const { currentWorkspace } = useWorkspace();
+  const workspaceId = currentWorkspace?.id;
+  const theme = useTheme();
+
+  const fetchLineage = useDbtStore(s => s.fetchLineage);
+  const [lineage, setLineage] = useState<DbtLineage | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!workspaceId) return;
+    let cancelled = false;
+    setLoading(true);
+    void fetchLineage(workspaceId, projectId).then(result => {
+      if (!cancelled) {
+        setLineage(result);
+        setLoading(false);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId, projectId, fetchLineage]);
+
+  const { nodes, edges } = useMemo<{ nodes: Node[]; edges: Edge[] }>(() => {
+    if (!lineage || lineage.nodes.length === 0) {
+      return { nodes: [], edges: [] };
+    }
+    const layers = computeLayers(lineage);
+    const rowsPerLayer = new Map<number, number>();
+
+    const colorFor = (status?: string, resourceType?: string) => {
+      if (status === "success" || status === "pass") {
+        return theme.palette.success.main;
+      }
+      if (status === "error" || status === "fail") {
+        return theme.palette.error.main;
+      }
+      if (resourceType === "source") return theme.palette.info.main;
+      return theme.palette.divider;
+    };
+
+    const flowNodes: Node[] = lineage.nodes.map(node => {
+      const layer = layers.get(node.id) ?? 0;
+      const row = rowsPerLayer.get(layer) ?? 0;
+      rowsPerLayer.set(layer, row + 1);
+      return {
+        id: node.id,
+        position: {
+          x: layer * (NODE_WIDTH + COLUMN_GAP),
+          y: row * (NODE_HEIGHT + ROW_GAP),
+        },
+        data: { label: node.name },
+        sourcePosition: Position.Right,
+        targetPosition: Position.Left,
+        style: {
+          width: NODE_WIDTH,
+          height: NODE_HEIGHT,
+          fontSize: 12,
+          borderRadius: 8,
+          border: `2px solid ${colorFor(node.lastStatus, node.resourceType)}`,
+          background: theme.palette.background.paper,
+          color: theme.palette.text.primary,
+        },
+      };
+    });
+
+    const flowEdges: Edge[] = lineage.edges.map(edge => ({
+      id: `${edge.source}->${edge.target}`,
+      source: edge.source,
+      target: edge.target,
+      animated: false,
+      style: { stroke: theme.palette.divider },
+    }));
+
+    return { nodes: flowNodes, edges: flowEdges };
+  }, [lineage, theme]);
+
+  const handleNodeClick = useCallback(
+    (_event: unknown, node: Node) => {
+      const meta = lineage?.nodes.find(n => n.id === node.id);
+      if (meta?.filePath) {
+        focusDbtFileTab(projectId, meta.filePath);
+      }
+    },
+    [lineage, projectId],
+  );
+
+  if (loading) {
+    return (
+      <Box sx={{ p: 3, display: "flex", justifyContent: "center" }}>
+        <CircularProgress size={20} />
+      </Box>
+    );
+  }
+
+  if (!lineage || lineage.nodes.length === 0) {
+    return (
+      <Box sx={{ p: 3, color: "text.secondary" }}>
+        <Typography variant="body2">
+          No lineage yet — run the project once (dbt builds the manifest during
+          a run) and refresh.
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ height: "100%", width: "100%" }}>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodeClick={handleNodeClick}
+        fitView
+        nodesDraggable={false}
+        nodesConnectable={false}
+        proOptions={{ hideAttribution: true }}
+        colorMode={theme.palette.mode === "dark" ? "dark" : "light"}
+      >
+        <Background gap={16} />
+        <Controls showInteractive={false} />
+      </ReactFlow>
+    </Box>
+  );
+}

--- a/app/src/components/DbtLineageView.tsx
+++ b/app/src/components/DbtLineageView.tsx
@@ -12,11 +12,18 @@ import {
   CircularProgress,
   Divider,
   IconButton,
+  InputAdornment,
   Link,
+  TextField,
+  Tooltip,
   Typography,
   useTheme,
 } from "@mui/material";
-import { X as CloseIcon, ExternalLink as OpenIcon } from "lucide-react";
+import {
+  X as CloseIcon,
+  ExternalLink as OpenIcon,
+  Filter as FilterIcon,
+} from "lucide-react";
 import {
   Background,
   Controls,
@@ -67,6 +74,120 @@ function computeLayers(lineage: DbtLineage): Map<string, number> {
   return layers;
 }
 
+/**
+ * One comma-separated piece of a dbt graph selector, e.g. `2+stg_orders+`.
+ * `degree === null` means unbounded (`+`), `0` means "no graph traversal in
+ * this direction", and `N` means N hops.
+ */
+interface SelectorSpec {
+  upstream: number | null;
+  downstream: number | null;
+  match: (node: DbtLineageNode) => boolean;
+}
+
+function parseSelectorPart(raw: string): SelectorSpec | null {
+  let s = raw.trim();
+  if (!s) return null;
+
+  let upstream: number | null = 0;
+  let downstream: number | null = 0;
+
+  const up = s.match(/^(\d*)\+/);
+  if (up) {
+    upstream = up[1] === "" ? null : Number(up[1]);
+    s = s.slice(up[0].length);
+  }
+  const down = s.match(/\+(\d*)$/);
+  if (down) {
+    downstream = down[1] === "" ? null : Number(down[1]);
+    s = s.slice(0, s.length - down[0].length);
+  }
+
+  const core = s.trim();
+  if (!core) return null;
+
+  let match: (node: DbtLineageNode) => boolean;
+  if (core.startsWith("tag:")) {
+    const tag = core.slice(4).toLowerCase();
+    match = node => !!node.tags?.some(t => t.toLowerCase() === tag);
+  } else if (core.startsWith("path:")) {
+    const prefix = core.slice(5);
+    match = node => !!node.filePath && node.filePath.startsWith(prefix);
+  } else {
+    const lower = core.toLowerCase();
+    match = node =>
+      node.name.toLowerCase() === lower ||
+      node.id.toLowerCase().endsWith(`.${lower}`);
+  }
+  return { upstream, downstream, match };
+}
+
+/** Traverse `adjacency` from `seed` up to `degree` hops, adding ids to `out`. */
+function traverse(
+  seed: string,
+  adjacency: Map<string, string[]>,
+  degree: number | null,
+  out: Set<string>,
+): void {
+  if (degree === 0) return;
+  const seen = new Set<string>([seed]);
+  let frontier = [seed];
+  let depth = 0;
+  while (frontier.length > 0) {
+    if (degree !== null && depth >= degree) break;
+    const next: string[] = [];
+    for (const id of frontier) {
+      for (const neighbor of adjacency.get(id) ?? []) {
+        if (!seen.has(neighbor)) {
+          seen.add(neighbor);
+          out.add(neighbor);
+          next.push(neighbor);
+        }
+      }
+    }
+    frontier = next;
+    depth += 1;
+  }
+}
+
+/**
+ * Resolve a dbt-style selector (`+model+`, `2+model`, `tag:x`, `path:models/`,
+ * comma = union) to the visible node ids, or `null` for "show everything".
+ */
+function resolveSelector(
+  lineage: DbtLineage,
+  selector: string,
+): Set<string> | null {
+  const specs = selector
+    .split(",")
+    .map(parseSelectorPart)
+    .filter((s): s is SelectorSpec => s !== null);
+  if (specs.length === 0) return null;
+
+  const childrenMap = new Map<string, string[]>();
+  const parentsMap = new Map<string, string[]>();
+  const push = (map: Map<string, string[]>, key: string, value: string) => {
+    const list = map.get(key);
+    if (list) list.push(value);
+    else map.set(key, [value]);
+  };
+  for (const edge of lineage.edges) {
+    push(childrenMap, edge.source, edge.target);
+    push(parentsMap, edge.target, edge.source);
+  }
+
+  const result = new Set<string>();
+  for (const spec of specs) {
+    for (const node of lineage.nodes) {
+      if (!spec.match(node)) continue;
+      result.add(node.id);
+      traverse(node.id, parentsMap, spec.upstream, result);
+      traverse(node.id, childrenMap, spec.downstream, result);
+    }
+  }
+  return result;
+}
+
 export default function DbtLineageView({ projectId }: { projectId: string }) {
   const { currentWorkspace } = useWorkspace();
   const workspaceId = currentWorkspace?.id;
@@ -76,6 +197,8 @@ export default function DbtLineageView({ projectId }: { projectId: string }) {
   const [lineage, setLineage] = useState<DbtLineage | null>(null);
   const [loading, setLoading] = useState(true);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [selectorText, setSelectorText] = useState("");
+  const [appliedSelector, setAppliedSelector] = useState("");
 
   useEffect(() => {
     if (!workspaceId) return;
@@ -92,11 +215,32 @@ export default function DbtLineageView({ projectId }: { projectId: string }) {
     };
   }, [workspaceId, projectId, fetchLineage]);
 
+  // Apply the dbt graph selector (client-side BFS over the fetched DAG).
+  const visibleLineage = useMemo<DbtLineage | null>(() => {
+    if (!lineage) return null;
+    const selected = resolveSelector(lineage, appliedSelector);
+    if (!selected) return lineage;
+    const nodes = lineage.nodes.filter(n => selected.has(n.id));
+    const edges = lineage.edges.filter(
+      e => selected.has(e.source) && selected.has(e.target),
+    );
+    return { ...lineage, nodes, edges };
+  }, [lineage, appliedSelector]);
+
+  const applySelector = useCallback(() => {
+    setAppliedSelector(selectorText.trim());
+  }, [selectorText]);
+
+  const clearSelector = useCallback(() => {
+    setSelectorText("");
+    setAppliedSelector("");
+  }, []);
+
   const { nodes, edges } = useMemo<{ nodes: Node[]; edges: Edge[] }>(() => {
-    if (!lineage || lineage.nodes.length === 0) {
+    if (!visibleLineage || visibleLineage.nodes.length === 0) {
       return { nodes: [], edges: [] };
     }
-    const layers = computeLayers(lineage);
+    const layers = computeLayers(visibleLineage);
     const rowsPerLayer = new Map<number, number>();
 
     const colorFor = (status?: string, resourceType?: string) => {
@@ -111,7 +255,7 @@ export default function DbtLineageView({ projectId }: { projectId: string }) {
       return theme.palette.divider;
     };
 
-    const flowNodes: Node[] = lineage.nodes.map(node => {
+    const flowNodes: Node[] = visibleLineage.nodes.map(node => {
       const layer = layers.get(node.id) ?? 0;
       const row = rowsPerLayer.get(layer) ?? 0;
       rowsPerLayer.set(layer, row + 1);
@@ -139,7 +283,7 @@ export default function DbtLineageView({ projectId }: { projectId: string }) {
       };
     });
 
-    const flowEdges: Edge[] = lineage.edges.map(edge => ({
+    const flowEdges: Edge[] = visibleLineage.edges.map(edge => ({
       id: `${edge.source}->${edge.target}`,
       source: edge.source,
       target: edge.target,
@@ -148,15 +292,15 @@ export default function DbtLineageView({ projectId }: { projectId: string }) {
     }));
 
     return { nodes: flowNodes, edges: flowEdges };
-  }, [lineage, theme, selectedNodeId]);
+  }, [visibleLineage, theme, selectedNodeId]);
 
   const handleNodeClick = useCallback((_event: unknown, node: Node) => {
     setSelectedNodeId(node.id);
   }, []);
 
   const selectedNode: DbtLineageNode | undefined = useMemo(
-    () => lineage?.nodes.find(n => n.id === selectedNodeId),
-    [lineage, selectedNodeId],
+    () => visibleLineage?.nodes.find(n => n.id === selectedNodeId),
+    [visibleLineage, selectedNodeId],
   );
 
   if (loading) {
@@ -178,22 +322,90 @@ export default function DbtLineageView({ projectId }: { projectId: string }) {
     );
   }
 
+  const totalCount = lineage.nodes.length;
+  const visibleCount = visibleLineage?.nodes.length ?? 0;
+
   return (
     <Box sx={{ height: "100%", width: "100%", display: "flex" }}>
-      <Box sx={{ flex: 1, minWidth: 0 }}>
-        <ReactFlow
-          nodes={nodes}
-          edges={edges}
-          onNodeClick={handleNodeClick}
-          fitView
-          nodesDraggable={false}
-          nodesConnectable={false}
-          proOptions={{ hideAttribution: true }}
-          colorMode={theme.palette.mode === "dark" ? "dark" : "light"}
+      <Box
+        sx={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column" }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: 1,
+            px: 1.5,
+            py: 0.75,
+            borderBottom: "1px solid",
+            borderColor: "divider",
+          }}
         >
-          <Background gap={16} />
-          <Controls showInteractive={false} />
-        </ReactFlow>
+          <TextField
+            size="small"
+            fullWidth
+            placeholder="Graph selector — e.g. +stg_orders+, 2+orders, tag:nightly, path:models/staging"
+            value={selectorText}
+            onChange={e => setSelectorText(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === "Enter") applySelector();
+            }}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <FilterIcon size={14} />
+                </InputAdornment>
+              ),
+              sx: { fontSize: "0.8rem" },
+            }}
+          />
+          <Tooltip title="Focus the graph on the selected nodes">
+            <span>
+              <Button size="small" variant="outlined" onClick={applySelector}>
+                Update graph
+              </Button>
+            </span>
+          </Tooltip>
+          {appliedSelector && (
+            <Button size="small" onClick={clearSelector}>
+              Clear
+            </Button>
+          )}
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ whiteSpace: "nowrap" }}
+          >
+            {appliedSelector
+              ? `${visibleCount} / ${totalCount}`
+              : `${totalCount} nodes`}
+          </Typography>
+        </Box>
+        <Box sx={{ flex: 1, minHeight: 0 }}>
+          {visibleCount === 0 ? (
+            <Box sx={{ p: 3, color: "text.secondary" }}>
+              <Typography variant="body2">
+                No nodes match <Box component="code">{appliedSelector}</Box>.
+                Try another selector or clear it.
+              </Typography>
+            </Box>
+          ) : (
+            <ReactFlow
+              key={appliedSelector || "all"}
+              nodes={nodes}
+              edges={edges}
+              onNodeClick={handleNodeClick}
+              fitView
+              nodesDraggable={false}
+              nodesConnectable={false}
+              proOptions={{ hideAttribution: true }}
+              colorMode={theme.palette.mode === "dark" ? "dark" : "light"}
+            >
+              <Background gap={16} />
+              <Controls showInteractive={false} />
+            </ReactFlow>
+          )}
+        </Box>
       </Box>
       {selectedNode && (
         <Box

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -62,6 +62,8 @@ import AppRenderer from "./AppRenderer";
 import AppFileEditor from "./AppFileEditor";
 import AppBindingEditor from "./AppBindingEditor";
 import PlanDocumentTab from "./PlanDocumentTab";
+import DbtFileEditor from "./DbtFileEditor";
+import DbtJobView from "./DbtJobView";
 import DashboardDataSourceEditor from "./DashboardDataSourceEditor";
 import TableDataView from "./TableDataView";
 import EntityBreadcrumbs from "./EntityBreadcrumbs";
@@ -2228,6 +2230,16 @@ function Editor({
                 ) : tab.kind === "plan" ? (
                   <PlanDocumentTab
                     toolCallId={tab.metadata?.toolCallId as string}
+                  />
+                ) : tab.kind === "dbt-file" ? (
+                  <DbtFileEditor
+                    projectId={tab.metadata?.projectId as string}
+                    path={tab.metadata?.path as string}
+                  />
+                ) : tab.kind === "dbt-job" ? (
+                  <DbtJobView
+                    projectId={tab.metadata?.projectId as string}
+                    jobId={tab.metadata?.jobId as string}
                   />
                 ) : tab.kind === "dashboard-data-source" ? (
                   <DashboardDataSourceEditor

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -64,6 +64,7 @@ import AppBindingEditor from "./AppBindingEditor";
 import PlanDocumentTab from "./PlanDocumentTab";
 import DbtFileEditor from "./DbtFileEditor";
 import DbtJobView from "./DbtJobView";
+import DbtConsoleView from "./DbtConsoleView";
 import DashboardDataSourceEditor from "./DashboardDataSourceEditor";
 import TableDataView from "./TableDataView";
 import EntityBreadcrumbs from "./EntityBreadcrumbs";
@@ -2240,6 +2241,10 @@ function Editor({
                   <DbtJobView
                     projectId={tab.metadata?.projectId as string}
                     jobId={tab.metadata?.jobId as string}
+                  />
+                ) : tab.kind === "dbt-console" ? (
+                  <DbtConsoleView
+                    projectId={tab.metadata?.projectId as string}
                   />
                 ) : tab.kind === "dashboard-data-source" ? (
                   <DashboardDataSourceEditor

--- a/app/src/components/EntityBreadcrumbs.tsx
+++ b/app/src/components/EntityBreadcrumbs.tsx
@@ -114,6 +114,12 @@ function segmentsForTab(
       return plain(["Settings", "Members"]);
     case "plan":
       return plain(["Plans", tab.title || "Plan"]);
+    case "dbt-file": {
+      const path = (tab.metadata?.path as string | undefined) || "";
+      return plain(["Transforms", ...path.split("/").filter(Boolean)]);
+    }
+    case "dbt-job":
+      return plain(["Transforms", "Jobs", tab.title || "Job"]);
     default: {
       // Compile-time exhaustiveness: a new TabKind must be handled above.
       // Runtime still degrades gracefully for stale persisted tabs.

--- a/app/src/components/EntityBreadcrumbs.tsx
+++ b/app/src/components/EntityBreadcrumbs.tsx
@@ -120,6 +120,8 @@ function segmentsForTab(
     }
     case "dbt-job":
       return plain(["Transforms", "Jobs", tab.title || "Job"]);
+    case "dbt-console":
+      return plain(["Transforms", tab.title || "Console"]);
     default: {
       // Compile-time exhaustiveness: a new TabKind must be handled above.
       // Runtime still degrades gracefully for stale persisted tabs.

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
   ArrowLeftRight as FlowsIcon,
   ChartPie as DashboardIcon,
   AppWindow as AppsIcon,
+  GitBranch as TransformsIcon,
   CircleUserRound as UserIcon,
   MessageCircleMore as ChatIcon,
 } from "lucide-react";
@@ -60,6 +61,7 @@ type NavigationView =
   | "flows"
   | "dashboards"
   | "apps"
+  | "dbt"
   | "settings"
   | "views";
 
@@ -68,6 +70,7 @@ const topNavigationItems: { view: NavigationView; icon: any; label: string }[] =
     { view: "databases", icon: DatabaseIcon, label: "Databases" },
     { view: "consoles", icon: ConsoleIcon, label: "Consoles" },
     { view: "flows", icon: FlowsIcon, label: "Flows" },
+    { view: "dbt", icon: TransformsIcon, label: "Transforms" },
     { view: "connectors", icon: DataSourceIcon, label: "Connectors" },
     { view: "dashboards", icon: DashboardIcon, label: "Dashboards" },
     { view: "apps", icon: AppsIcon, label: "Apps" },
@@ -149,6 +152,7 @@ function Sidebar() {
       view === "flows" ||
       view === "dashboards" ||
       view === "apps" ||
+      view === "dbt" ||
       view === "settings"
     ) {
       startTransition(() => {
@@ -160,6 +164,7 @@ function Sidebar() {
             | "flows"
             | "dashboards"
             | "apps"
+            | "dbt"
             | "settings",
         );
 

--- a/app/src/dbt-runtime/agent-tools.ts
+++ b/app/src/dbt-runtime/agent-tools.ts
@@ -1,0 +1,130 @@
+/**
+ * Client-side executor for the dbt agent tools.
+ *
+ * Mirrors `executeAppAgentTool`: the AI SDK routes dbt file tool calls to the
+ * browser via `onToolCall`, and this dispatcher applies them through the same
+ * dbtStore writeFile/persistFile path the editor uses, so agent edits show up
+ * live in any open dbt-file tab.
+ */
+
+import { useDbtStore } from "../store/dbtStore";
+import { focusDbtFileTab, getCurrentWorkspaceId } from "./shell";
+
+type ToolResult = Record<string, unknown>;
+
+function fail(error: string): ToolResult {
+  return { success: false, error };
+}
+
+export async function executeDbtAgentTool(
+  toolName: string,
+  input: Record<string, unknown>,
+): Promise<ToolResult> {
+  const store = useDbtStore.getState();
+  const workspaceId = getCurrentWorkspaceId();
+  if (!workspaceId) return fail("No active workspace");
+
+  const projectId = input.projectId as string | undefined;
+  const path = input.path as string | undefined;
+
+  const ensureProjectLoaded = async (id: string) => {
+    if (!useDbtStore.getState().projectsLoaded) {
+      await store.fetchProjects(workspaceId);
+    }
+    if (!useDbtStore.getState().filePathsByProject[id]) {
+      await store.fetchFiles(workspaceId, id);
+    }
+    return useDbtStore.getState().projects.find(p => p._id === id);
+  };
+
+  switch (toolName) {
+    case "read_dbt_project_tree": {
+      if (!useDbtStore.getState().projectsLoaded) {
+        await store.fetchProjects(workspaceId);
+      }
+      const projects = useDbtStore.getState().projects;
+      if (!projectId) {
+        return {
+          success: true,
+          projects: projects.map(project => ({
+            id: project._id,
+            name: project.name,
+            defaultEnvironment: project.defaultEnvironment,
+            environments: project.environments.map(env => ({
+              name: env.name,
+              targetSchema: env.targetSchema,
+              connectionId: env.connectionId,
+            })),
+          })),
+        };
+      }
+      const project = await ensureProjectLoaded(projectId);
+      if (!project) return fail("dbt project not found");
+      await store.fetchJobs(workspaceId, projectId);
+      const state = useDbtStore.getState();
+      return {
+        success: true,
+        projectId,
+        name: project.name,
+        defaultEnvironment: project.defaultEnvironment,
+        environments: project.environments,
+        files: state.filePathsByProject[projectId] ?? [],
+        jobs: (state.jobsByProject[projectId] ?? []).map(job => ({
+          id: job._id,
+          name: job.name,
+          environment: job.environment,
+          commands: job.commands,
+          schedule: job.schedule ?? null,
+          enabled: job.enabled,
+        })),
+      };
+    }
+
+    case "read_dbt_file": {
+      if (!projectId || !path) return fail("projectId and path are required");
+      const content = await store.readFile(workspaceId, projectId, path);
+      if (content === null) return fail(`File not found: ${path}`);
+      return { success: true, path, contents: content };
+    }
+
+    case "create_dbt_file": {
+      if (!projectId || !path) return fail("projectId and path are required");
+      await ensureProjectLoaded(projectId);
+      const existingPaths =
+        useDbtStore.getState().filePathsByProject[projectId] ?? [];
+      if (existingPaths.includes(path)) {
+        return fail(
+          `File already exists: ${path}. Use modify_dbt_file to change it.`,
+        );
+      }
+      const ok = await store.createFile(
+        workspaceId,
+        projectId,
+        path,
+        (input.contents as string) ?? "",
+      );
+      if (!ok) return fail(`Failed to create ${path}`);
+      focusDbtFileTab(projectId, path);
+      return { success: true, path };
+    }
+
+    case "modify_dbt_file": {
+      if (!projectId || !path) return fail("projectId and path are required");
+      await ensureProjectLoaded(projectId);
+      store.writeFile(projectId, path, (input.contents as string) ?? "");
+      const ok = await store.persistFile(workspaceId, projectId, path);
+      if (!ok) return fail(`Failed to save ${path}`);
+      return { success: true, path };
+    }
+
+    case "delete_dbt_file": {
+      if (!projectId || !path) return fail("projectId and path are required");
+      const ok = await store.deleteFile(workspaceId, projectId, path);
+      if (!ok) return fail(`Failed to delete ${path}`);
+      return { success: true, path };
+    }
+
+    default:
+      return fail(`Unknown dbt tool: ${toolName}`);
+  }
+}

--- a/app/src/dbt-runtime/shell.ts
+++ b/app/src/dbt-runtime/shell.ts
@@ -41,6 +41,27 @@ export function focusDbtFileTab(projectId: string, path: string): string {
   return tabId;
 }
 
+/** Open (or focus) the project Console tab (command bar + problems). */
+export function focusDbtConsoleTab(projectId: string, title: string): string {
+  const consoleStore = useConsoleStore.getState();
+  const existingTab = Object.values(consoleStore.tabs).find(
+    (tab: { kind?: string; metadata?: { projectId?: string } }) =>
+      tab.kind === "dbt-console" && tab.metadata?.projectId === projectId,
+  );
+
+  const tabId =
+    existingTab?.id ??
+    consoleStore.openTab({
+      title,
+      content: "",
+      kind: "dbt-console",
+      metadata: { projectId },
+    });
+
+  consoleStore.setActiveTab(tabId);
+  return tabId;
+}
+
 /** Open (or focus) the job view tab (run history + edit) for a dbt job. */
 export function focusDbtJobTab(
   projectId: string,

--- a/app/src/dbt-runtime/shell.ts
+++ b/app/src/dbt-runtime/shell.ts
@@ -1,0 +1,72 @@
+/**
+ * dbt tab-open helpers — clones of app-runtime/shell.ts. Both the explorer
+ * and the agent's client tools open tabs through these so dedupe behavior
+ * is identical everywhere.
+ */
+
+import { useConsoleStore } from "../store/consoleStore";
+import { useUIStore } from "../store/uiStore";
+
+export function getCurrentWorkspaceId(): string | null {
+  return useUIStore.getState().currentWorkspaceId ?? null;
+}
+
+function basename(path: string): string {
+  return path.split("/").filter(Boolean).pop() || path;
+}
+
+/** Open (or focus) a full-screen editor tab for a single dbt project file. */
+export function focusDbtFileTab(projectId: string, path: string): string {
+  const consoleStore = useConsoleStore.getState();
+  const existingTab = Object.values(consoleStore.tabs).find(
+    (tab: {
+      kind?: string;
+      metadata?: { projectId?: string; path?: string };
+    }) =>
+      tab.kind === "dbt-file" &&
+      tab.metadata?.projectId === projectId &&
+      tab.metadata?.path === path,
+  );
+
+  const tabId =
+    existingTab?.id ??
+    consoleStore.openTab({
+      title: basename(path),
+      content: "",
+      kind: "dbt-file",
+      metadata: { projectId, path },
+    });
+
+  consoleStore.setActiveTab(tabId);
+  return tabId;
+}
+
+/** Open (or focus) the job view tab (run history + edit) for a dbt job. */
+export function focusDbtJobTab(
+  projectId: string,
+  jobId: string,
+  title: string,
+): string {
+  const consoleStore = useConsoleStore.getState();
+  const existingTab = Object.values(consoleStore.tabs).find(
+    (tab: {
+      kind?: string;
+      metadata?: { projectId?: string; jobId?: string };
+    }) =>
+      tab.kind === "dbt-job" &&
+      tab.metadata?.projectId === projectId &&
+      tab.metadata?.jobId === jobId,
+  );
+
+  const tabId =
+    existingTab?.id ??
+    consoleStore.openTab({
+      title,
+      content: "",
+      kind: "dbt-job",
+      metadata: { projectId, jobId },
+    });
+
+  consoleStore.setActiveTab(tabId);
+  return tabId;
+}

--- a/app/src/lib/explorer-reveal.ts
+++ b/app/src/lib/explorer-reveal.ts
@@ -98,6 +98,11 @@ export function tabRevealTarget(
     case "members":
       // No sidebar tree row.
       return null;
+    case "dbt-file":
+    case "dbt-job":
+      // dbt tabs live in the Transforms explorer; no stable reveal id yet
+      // (mirrors tab-routing.ts — not deep-linkable yet).
+      return null;
     default: {
       // Compile-time exhaustiveness: a new TabKind must be handled above.
       const exhaustivenessCheck: never = kind;

--- a/app/src/lib/explorer-reveal.ts
+++ b/app/src/lib/explorer-reveal.ts
@@ -100,6 +100,7 @@ export function tabRevealTarget(
       return null;
     case "dbt-file":
     case "dbt-job":
+    case "dbt-console":
       // dbt tabs live in the Transforms explorer; no stable reveal id yet
       // (mirrors tab-routing.ts — not deep-linkable yet).
       return null;

--- a/app/src/lib/tab-routing.test.ts
+++ b/app/src/lib/tab-routing.test.ts
@@ -56,6 +56,14 @@ const FIXTURES: Record<NonNullable<TabKind>, ConsoleTab> = {
   plan: baseTab({ kind: "plan", metadata: { chatId: "chat-1" } }),
   settings: baseTab({ kind: "settings", settingsSection: "models" }),
   members: baseTab({ kind: "members" }),
+  "dbt-file": baseTab({
+    kind: "dbt-file",
+    metadata: { projectId: "proj-1", path: "models/stg.sql" },
+  }),
+  "dbt-job": baseTab({
+    kind: "dbt-job",
+    metadata: { projectId: "proj-1", jobId: "job-1" },
+  }),
 };
 
 const ALL_KINDS = Object.keys(FIXTURES) as Array<NonNullable<TabKind>>;

--- a/app/src/lib/tab-routing.test.ts
+++ b/app/src/lib/tab-routing.test.ts
@@ -64,6 +64,10 @@ const FIXTURES: Record<NonNullable<TabKind>, ConsoleTab> = {
     kind: "dbt-job",
     metadata: { projectId: "proj-1", jobId: "job-1" },
   }),
+  "dbt-console": baseTab({
+    kind: "dbt-console",
+    metadata: { projectId: "proj-1" },
+  }),
 };
 
 const ALL_KINDS = Object.keys(FIXTURES) as Array<NonNullable<TabKind>>;

--- a/app/src/lib/tab-routing.ts
+++ b/app/src/lib/tab-routing.ts
@@ -47,6 +47,9 @@ export const TAB_DEEP_LINK_PATTERNS = {
   settings: /^\/settings\/([a-z-]+)$/,
   // Legacy tab kind superseded by the settings "members" section.
   members: null,
+  // dbt tabs are opened from the Transforms explorer; not deep-linkable yet.
+  "dbt-file": null,
+  "dbt-job": null,
 } as const satisfies Record<NonNullable<TabKind>, RegExp | null>;
 
 /**
@@ -113,6 +116,9 @@ export function tabUrlPath(tabId: string, tab: ConsoleTab): string | null {
         ? `/settings/${tab.settingsSection}`
         : "/settings";
     case "members":
+      return null;
+    case "dbt-file":
+    case "dbt-job":
       return null;
     default: {
       // Compile-time exhaustiveness: a new TabKind must be handled above.

--- a/app/src/lib/tab-routing.ts
+++ b/app/src/lib/tab-routing.ts
@@ -50,6 +50,7 @@ export const TAB_DEEP_LINK_PATTERNS = {
   // dbt tabs are opened from the Transforms explorer; not deep-linkable yet.
   "dbt-file": null,
   "dbt-job": null,
+  "dbt-console": null,
 } as const satisfies Record<NonNullable<TabKind>, RegExp | null>;
 
 /**
@@ -119,6 +120,7 @@ export function tabUrlPath(tabId: string, tab: ConsoleTab): string | null {
       return null;
     case "dbt-file":
     case "dbt-job":
+    case "dbt-console":
       return null;
     default: {
       // Compile-time exhaustiveness: a new TabKind must be handled above.

--- a/app/src/store/dbtStore.ts
+++ b/app/src/store/dbtStore.ts
@@ -107,6 +107,14 @@ export interface DbtRunModelResult {
   logs: DbtRunLogLine[];
 }
 
+export interface DbtCommandRunResult {
+  ok: boolean;
+  exitCode: number;
+  subcommand: string;
+  stepResults: DbtStepResult[];
+  logs: DbtRunLogLine[];
+}
+
 export interface DbtLineageNode {
   id: string;
   name: string;
@@ -241,13 +249,22 @@ interface DbtActions {
     projectId: string,
     select: string | undefined,
     environment?: string,
+    defer?: boolean,
   ) => Promise<DbtCompileResult | null>;
   runModel: (
     workspaceId: string,
     projectId: string,
     select: string,
     environment?: string,
+    defer?: boolean,
   ) => Promise<DbtRunModelResult | null>;
+  runCommand: (
+    workspaceId: string,
+    projectId: string,
+    command: string,
+    environment?: string,
+    defer?: boolean,
+  ) => Promise<DbtCommandRunResult | null>;
   fetchLineage: (
     workspaceId: string,
     projectId: string,
@@ -713,7 +730,13 @@ export const useDbtStore = create<DbtStore>()(
       }
     },
 
-    compileModel: async (workspaceId, projectId, select, environment) => {
+    compileModel: async (
+      workspaceId,
+      projectId,
+      select,
+      environment,
+      defer,
+    ) => {
       try {
         const response = await apiClient.post<{
           success: boolean;
@@ -721,6 +744,7 @@ export const useDbtStore = create<DbtStore>()(
         }>(`/workspaces/${workspaceId}/dbt/projects/${projectId}/compile`, {
           ...(select ? { select } : {}),
           ...(environment ? { environment } : {}),
+          ...(defer ? { defer } : {}),
         });
         return response.compile ?? null;
       } catch (error) {
@@ -738,7 +762,7 @@ export const useDbtStore = create<DbtStore>()(
       }
     },
 
-    runModel: async (workspaceId, projectId, select, environment) => {
+    runModel: async (workspaceId, projectId, select, environment, defer) => {
       try {
         const response = await apiClient.post<{
           success: boolean;
@@ -746,6 +770,7 @@ export const useDbtStore = create<DbtStore>()(
         }>(`/workspaces/${workspaceId}/dbt/projects/${projectId}/run-select`, {
           select,
           ...(environment ? { environment } : {}),
+          ...(defer ? { defer } : {}),
         });
         return response.run ?? null;
       } catch (error) {
@@ -758,6 +783,34 @@ export const useDbtStore = create<DbtStore>()(
               ts: new Date().toISOString(),
               level: "error",
               line: errMessage(error, "Run failed"),
+            },
+          ],
+        };
+      }
+    },
+
+    runCommand: async (workspaceId, projectId, command, environment, defer) => {
+      try {
+        const response = await apiClient.post<{
+          success: boolean;
+          result: DbtCommandRunResult;
+        }>(`/workspaces/${workspaceId}/dbt/projects/${projectId}/command`, {
+          command,
+          ...(environment ? { environment } : {}),
+          ...(defer ? { defer } : {}),
+        });
+        return response.result ?? null;
+      } catch (error) {
+        return {
+          ok: false,
+          exitCode: 1,
+          subcommand: "",
+          stepResults: [],
+          logs: [
+            {
+              ts: new Date().toISOString(),
+              level: "error",
+              line: errMessage(error, "Command failed"),
             },
           ],
         };

--- a/app/src/store/dbtStore.ts
+++ b/app/src/store/dbtStore.ts
@@ -146,6 +146,16 @@ interface DbtActions {
       defaultEnvironment: string;
     },
   ) => Promise<DbtProjectItem | null>;
+  updateProject: (
+    workspaceId: string,
+    projectId: string,
+    patch: {
+      name?: string;
+      environments?: DbtEnvironment[];
+      defaultEnvironment?: string;
+      dbtVersion?: string;
+    },
+  ) => Promise<DbtProjectItem | null>;
   deleteProject: (workspaceId: string, projectId: string) => Promise<boolean>;
 
   fetchFiles: (workspaceId: string, projectId: string) => Promise<void>;
@@ -291,6 +301,26 @@ export const useDbtStore = create<DbtStore>()(
       } catch (error) {
         set(state => {
           state.error.projects = errMessage(error, "Failed to create project");
+        });
+        return null;
+      }
+    },
+
+    updateProject: async (workspaceId, projectId, patch) => {
+      try {
+        const response = await apiClient.patch<{
+          success: boolean;
+          project: DbtProjectItem;
+        }>(`/workspaces/${workspaceId}/dbt/projects/${projectId}`, patch);
+        const project = response.project;
+        set(state => {
+          const idx = state.projects.findIndex(p => p._id === projectId);
+          if (idx >= 0) state.projects[idx] = project;
+        });
+        return project;
+      } catch (error) {
+        set(state => {
+          state.error.projects = errMessage(error, "Failed to update project");
         });
         return null;
       }

--- a/app/src/store/dbtStore.ts
+++ b/app/src/store/dbtStore.ts
@@ -107,14 +107,22 @@ export interface DbtRunModelResult {
   logs: DbtRunLogLine[];
 }
 
+export interface DbtLineageNode {
+  id: string;
+  name: string;
+  resourceType: string;
+  filePath?: string;
+  lastStatus?: string;
+  description?: string;
+  materialized?: string;
+  tags?: string[];
+  columns?: Array<{ name: string; type?: string; description?: string }>;
+  url?: string;
+  owner?: string;
+}
+
 export interface DbtLineage {
-  nodes: Array<{
-    id: string;
-    name: string;
-    resourceType: string;
-    filePath?: string;
-    lastStatus?: string;
-  }>;
+  nodes: DbtLineageNode[];
   edges: Array<{ source: string; target: string }>;
   generatedAt: string | null;
 }

--- a/app/src/store/dbtStore.ts
+++ b/app/src/store/dbtStore.ts
@@ -205,6 +205,12 @@ interface DbtActions {
     projectId: string,
     jobId: string,
   ) => Promise<string | null>;
+  retryRun: (
+    workspaceId: string,
+    projectId: string,
+    runId: string,
+    jobId?: string,
+  ) => Promise<string | null>;
 
   fetchRuns: (
     workspaceId: string,
@@ -595,6 +601,27 @@ export const useDbtStore = create<DbtStore>()(
           state.error[`runs:${projectId}`] = errMessage(
             error,
             "Failed to trigger job",
+          );
+        });
+        return null;
+      }
+    },
+
+    retryRun: async (workspaceId, projectId, runId, jobId) => {
+      try {
+        const response = await apiClient.post<{
+          success: boolean;
+          runId: string;
+        }>(
+          `/workspaces/${workspaceId}/dbt/projects/${projectId}/runs/${runId}/retry`,
+        );
+        await get().fetchRuns(workspaceId, projectId, jobId);
+        return response.runId ?? null;
+      } catch (error) {
+        set(state => {
+          state.error[`runs:${projectId}`] = errMessage(
+            error,
+            "Failed to retry run",
           );
         });
         return null;

--- a/app/src/store/dbtStore.ts
+++ b/app/src/store/dbtStore.ts
@@ -1,0 +1,722 @@
+/**
+ * dbt Store
+ *
+ * State + API access for the dbt IDE: projects, virtual files, jobs, runs.
+ * Mirrors the appStore/flowStore shapes. The agent's client tools mutate
+ * through the same writeFile/persistFile path as the editor so UI and agent
+ * edits share one code path.
+ */
+
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+import { apiClient } from "../lib/api-client";
+
+export interface DbtEnvironment {
+  name: string;
+  connectionId: string;
+  targetSchema: string;
+  threads: number;
+  vars?: Record<string, unknown>;
+}
+
+export interface DbtProjectItem {
+  _id: string;
+  name: string;
+  dbtVersion: string;
+  environments: DbtEnvironment[];
+  defaultEnvironment: string;
+  updatedAt?: string;
+}
+
+export interface DbtFileEntry {
+  content: string;
+  /** True while local edits have not been persisted yet. */
+  dirty: boolean;
+  loaded: boolean;
+}
+
+export interface DbtJobItem {
+  _id: string;
+  projectId: string;
+  name: string;
+  environment: string;
+  commands: string[];
+  schedule?: { cron: string; timezone: string } | null;
+  scheduledRun?: {
+    nextAt?: string;
+    lastAt?: string;
+    lastStatus?: "success" | "error";
+    lastError?: string;
+    lastDurationMs?: number;
+    runCount?: number;
+    consecutiveFailures?: number;
+  };
+  enabled: boolean;
+  deferToProduction?: boolean;
+}
+
+export interface DbtRunLogLine {
+  ts: string;
+  level: string;
+  line: string;
+}
+
+export interface DbtStepResult {
+  uniqueId: string;
+  name: string;
+  resourceType: string;
+  status: string;
+  executionTimeMs: number;
+  rowsAffected?: number;
+  message?: string;
+}
+
+export interface DbtRunItem {
+  _id: string;
+  projectId: string;
+  jobId?: string;
+  environment: string;
+  commands: string[];
+  status: "queued" | "running" | "success" | "error" | "cancelled";
+  trigger: "schedule" | "manual" | "agent";
+  triggeredBy: string;
+  startedAt?: string;
+  completedAt?: string;
+  durationMs?: number;
+  stepResults?: DbtStepResult[];
+  error?: string;
+  createdAt: string;
+}
+
+export interface DbtRunDetails extends DbtRunItem {
+  logs: DbtRunLogLine[];
+  logCursor: number;
+}
+
+export interface DbtCompileResult {
+  ok: boolean;
+  exitCode: number;
+  compiledSql?: string;
+  logs: DbtRunLogLine[];
+}
+
+export interface DbtRunModelResult {
+  ok: boolean;
+  exitCode: number;
+  stepResults: DbtStepResult[];
+  logs: DbtRunLogLine[];
+}
+
+export interface DbtLineage {
+  nodes: Array<{
+    id: string;
+    name: string;
+    resourceType: string;
+    filePath?: string;
+    lastStatus?: string;
+  }>;
+  edges: Array<{ source: string; target: string }>;
+  generatedAt: string | null;
+}
+
+interface DbtState {
+  projects: DbtProjectItem[];
+  projectsLoaded: boolean;
+  /** projectId → sorted file paths (tree source of truth). */
+  filePathsByProject: Record<string, string[]>;
+  /** projectId → path → file entry. */
+  filesByProject: Record<string, Record<string, DbtFileEntry>>;
+  /** projectId → jobs. */
+  jobsByProject: Record<string, DbtJobItem[]>;
+  /** projectId → recent runs (newest first). */
+  runsByProject: Record<string, DbtRunItem[]>;
+  /** runId → details incl. accumulated logs. */
+  runDetails: Record<string, DbtRunDetails>;
+  loading: Record<string, boolean>;
+  error: Record<string, string | null>;
+}
+
+interface DbtActions {
+  fetchProjects: (workspaceId: string) => Promise<void>;
+  createProject: (
+    workspaceId: string,
+    payload: {
+      name: string;
+      environments: DbtEnvironment[];
+      defaultEnvironment: string;
+    },
+  ) => Promise<DbtProjectItem | null>;
+  deleteProject: (workspaceId: string, projectId: string) => Promise<boolean>;
+
+  fetchFiles: (workspaceId: string, projectId: string) => Promise<void>;
+  readFile: (
+    workspaceId: string,
+    projectId: string,
+    path: string,
+  ) => Promise<string | null>;
+  writeFile: (projectId: string, path: string, content: string) => void;
+  persistFile: (
+    workspaceId: string,
+    projectId: string,
+    path: string,
+  ) => Promise<boolean>;
+  createFile: (
+    workspaceId: string,
+    projectId: string,
+    path: string,
+    content?: string,
+  ) => Promise<boolean>;
+  deleteFile: (
+    workspaceId: string,
+    projectId: string,
+    path: string,
+  ) => Promise<boolean>;
+  renameFile: (
+    workspaceId: string,
+    projectId: string,
+    from: string,
+    to: string,
+  ) => Promise<boolean>;
+
+  fetchJobs: (workspaceId: string, projectId: string) => Promise<void>;
+  saveJob: (
+    workspaceId: string,
+    projectId: string,
+    job: Partial<DbtJobItem> & { name: string },
+    jobId?: string,
+  ) => Promise<DbtJobItem | null>;
+  deleteJob: (
+    workspaceId: string,
+    projectId: string,
+    jobId: string,
+  ) => Promise<boolean>;
+  triggerJob: (
+    workspaceId: string,
+    projectId: string,
+    jobId: string,
+  ) => Promise<string | null>;
+
+  fetchRuns: (
+    workspaceId: string,
+    projectId: string,
+    jobId?: string,
+  ) => Promise<void>;
+  fetchRunDetails: (
+    workspaceId: string,
+    projectId: string,
+    runId: string,
+  ) => Promise<DbtRunDetails | null>;
+  cancelRun: (
+    workspaceId: string,
+    projectId: string,
+    runId: string,
+  ) => Promise<boolean>;
+
+  compileModel: (
+    workspaceId: string,
+    projectId: string,
+    select: string | undefined,
+    environment?: string,
+  ) => Promise<DbtCompileResult | null>;
+  runModel: (
+    workspaceId: string,
+    projectId: string,
+    select: string,
+    environment?: string,
+  ) => Promise<DbtRunModelResult | null>;
+  fetchLineage: (
+    workspaceId: string,
+    projectId: string,
+  ) => Promise<DbtLineage | null>;
+
+  reset: () => void;
+}
+
+type DbtStore = DbtState & DbtActions;
+
+const initialState: DbtState = {
+  projects: [],
+  projectsLoaded: false,
+  filePathsByProject: {},
+  filesByProject: {},
+  jobsByProject: {},
+  runsByProject: {},
+  runDetails: {},
+  loading: {},
+  error: {},
+};
+
+function errMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
+export const useDbtStore = create<DbtStore>()(
+  immer((set, get) => ({
+    ...initialState,
+
+    fetchProjects: async workspaceId => {
+      set(state => {
+        state.loading.projects = true;
+        state.error.projects = null;
+      });
+      try {
+        const response = await apiClient.get<{
+          success: boolean;
+          projects: DbtProjectItem[];
+        }>(`/workspaces/${workspaceId}/dbt/projects`);
+        set(state => {
+          state.projects = response.projects ?? [];
+          state.projectsLoaded = true;
+          state.loading.projects = false;
+        });
+      } catch (error) {
+        set(state => {
+          state.loading.projects = false;
+          state.error.projects = errMessage(error, "Failed to load projects");
+        });
+      }
+    },
+
+    createProject: async (workspaceId, payload) => {
+      try {
+        const response = await apiClient.post<{
+          success: boolean;
+          project: DbtProjectItem;
+        }>(`/workspaces/${workspaceId}/dbt/projects`, payload);
+        const project = response.project;
+        set(state => {
+          state.projects.unshift(project);
+        });
+        return project;
+      } catch (error) {
+        set(state => {
+          state.error.projects = errMessage(error, "Failed to create project");
+        });
+        return null;
+      }
+    },
+
+    deleteProject: async (workspaceId, projectId) => {
+      try {
+        await apiClient.delete(
+          `/workspaces/${workspaceId}/dbt/projects/${projectId}`,
+        );
+        set(state => {
+          state.projects = state.projects.filter(p => p._id !== projectId);
+          delete state.filePathsByProject[projectId];
+          delete state.filesByProject[projectId];
+          delete state.jobsByProject[projectId];
+          delete state.runsByProject[projectId];
+        });
+        return true;
+      } catch (error) {
+        set(state => {
+          state.error.projects = errMessage(error, "Failed to delete project");
+        });
+        return false;
+      }
+    },
+
+    fetchFiles: async (workspaceId, projectId) => {
+      set(state => {
+        state.loading[`files:${projectId}`] = true;
+      });
+      try {
+        const response = await apiClient.get<{
+          success: boolean;
+          files: Array<{ path: string }>;
+        }>(`/workspaces/${workspaceId}/dbt/projects/${projectId}/files`);
+        set(state => {
+          state.filePathsByProject[projectId] = (response.files ?? []).map(
+            file => file.path,
+          );
+          state.loading[`files:${projectId}`] = false;
+        });
+      } catch (error) {
+        set(state => {
+          state.loading[`files:${projectId}`] = false;
+          state.error[`files:${projectId}`] = errMessage(
+            error,
+            "Failed to load files",
+          );
+        });
+      }
+    },
+
+    readFile: async (workspaceId, projectId, path) => {
+      const existing = get().filesByProject[projectId]?.[path];
+      if (existing?.loaded) return existing.content;
+      try {
+        const response = await apiClient.get<{
+          success: boolean;
+          file: { path: string; content: string };
+        }>(
+          `/workspaces/${workspaceId}/dbt/projects/${projectId}/files/${encodeURI(path)}`,
+        );
+        const content = response.file?.content ?? "";
+        set(state => {
+          if (!state.filesByProject[projectId]) {
+            state.filesByProject[projectId] = {};
+          }
+          state.filesByProject[projectId][path] = {
+            content,
+            dirty: false,
+            loaded: true,
+          };
+        });
+        return content;
+      } catch (error) {
+        set(state => {
+          state.error[`file:${projectId}:${path}`] = errMessage(
+            error,
+            "Failed to read file",
+          );
+        });
+        return null;
+      }
+    },
+
+    writeFile: (projectId, path, content) => {
+      set(state => {
+        if (!state.filesByProject[projectId]) {
+          state.filesByProject[projectId] = {};
+        }
+        state.filesByProject[projectId][path] = {
+          content,
+          dirty: true,
+          loaded: true,
+        };
+        const paths = state.filePathsByProject[projectId];
+        if (paths && !paths.includes(path)) {
+          paths.push(path);
+          paths.sort();
+        }
+      });
+    },
+
+    persistFile: async (workspaceId, projectId, path) => {
+      const file = get().filesByProject[projectId]?.[path];
+      if (!file) return false;
+      try {
+        await apiClient.put(
+          `/workspaces/${workspaceId}/dbt/projects/${projectId}/files/${encodeURI(path)}`,
+          { content: file.content },
+        );
+        set(state => {
+          const entry = state.filesByProject[projectId]?.[path];
+          if (entry) entry.dirty = false;
+        });
+        return true;
+      } catch (error) {
+        set(state => {
+          state.error[`file:${projectId}:${path}`] = errMessage(
+            error,
+            "Failed to save file",
+          );
+        });
+        return false;
+      }
+    },
+
+    createFile: async (workspaceId, projectId, path, content = "") => {
+      get().writeFile(projectId, path, content);
+      return get().persistFile(workspaceId, projectId, path);
+    },
+
+    deleteFile: async (workspaceId, projectId, path) => {
+      try {
+        await apiClient.delete(
+          `/workspaces/${workspaceId}/dbt/projects/${projectId}/files/${encodeURI(path)}`,
+        );
+        set(state => {
+          delete state.filesByProject[projectId]?.[path];
+          const paths = state.filePathsByProject[projectId];
+          if (paths) {
+            state.filePathsByProject[projectId] = paths.filter(p => p !== path);
+          }
+        });
+        return true;
+      } catch (error) {
+        set(state => {
+          state.error[`file:${projectId}:${path}`] = errMessage(
+            error,
+            "Failed to delete file",
+          );
+        });
+        return false;
+      }
+    },
+
+    renameFile: async (workspaceId, projectId, from, to) => {
+      try {
+        await apiClient.post(
+          `/workspaces/${workspaceId}/dbt/projects/${projectId}/files/rename`,
+          { from, to },
+        );
+        set(state => {
+          const files = state.filesByProject[projectId];
+          if (files?.[from]) {
+            files[to] = files[from];
+            delete files[from];
+          }
+          const paths = state.filePathsByProject[projectId];
+          if (paths) {
+            state.filePathsByProject[projectId] = paths
+              .map(p => (p === from ? to : p))
+              .sort();
+          }
+        });
+        return true;
+      } catch (error) {
+        set(state => {
+          state.error[`file:${projectId}:${from}`] = errMessage(
+            error,
+            "Failed to rename file",
+          );
+        });
+        return false;
+      }
+    },
+
+    fetchJobs: async (workspaceId, projectId) => {
+      try {
+        const response = await apiClient.get<{
+          success: boolean;
+          jobs: DbtJobItem[];
+        }>(`/workspaces/${workspaceId}/dbt/projects/${projectId}/jobs`);
+        set(state => {
+          state.jobsByProject[projectId] = response.jobs ?? [];
+        });
+      } catch (error) {
+        set(state => {
+          state.error[`jobs:${projectId}`] = errMessage(
+            error,
+            "Failed to load jobs",
+          );
+        });
+      }
+    },
+
+    saveJob: async (workspaceId, projectId, job, jobId) => {
+      try {
+        const response = jobId
+          ? await apiClient.patch<{ success: boolean; job: DbtJobItem }>(
+              `/workspaces/${workspaceId}/dbt/projects/${projectId}/jobs/${jobId}`,
+              job,
+            )
+          : await apiClient.post<{ success: boolean; job: DbtJobItem }>(
+              `/workspaces/${workspaceId}/dbt/projects/${projectId}/jobs`,
+              job,
+            );
+        const saved = response.job;
+        set(state => {
+          const jobs = state.jobsByProject[projectId] ?? [];
+          const idx = jobs.findIndex(j => j._id === saved._id);
+          if (idx >= 0) jobs[idx] = saved;
+          else jobs.push(saved);
+          state.jobsByProject[projectId] = jobs;
+        });
+        return saved;
+      } catch (error) {
+        set(state => {
+          state.error[`jobs:${projectId}`] = errMessage(
+            error,
+            "Failed to save job",
+          );
+        });
+        return null;
+      }
+    },
+
+    deleteJob: async (workspaceId, projectId, jobId) => {
+      try {
+        await apiClient.delete(
+          `/workspaces/${workspaceId}/dbt/projects/${projectId}/jobs/${jobId}`,
+        );
+        set(state => {
+          state.jobsByProject[projectId] = (
+            state.jobsByProject[projectId] ?? []
+          ).filter(j => j._id !== jobId);
+        });
+        return true;
+      } catch (error) {
+        set(state => {
+          state.error[`jobs:${projectId}`] = errMessage(
+            error,
+            "Failed to delete job",
+          );
+        });
+        return false;
+      }
+    },
+
+    triggerJob: async (workspaceId, projectId, jobId) => {
+      try {
+        const response = await apiClient.post<{
+          success: boolean;
+          runId: string;
+        }>(
+          `/workspaces/${workspaceId}/dbt/projects/${projectId}/jobs/${jobId}/trigger`,
+        );
+        await get().fetchRuns(workspaceId, projectId, jobId);
+        return response.runId ?? null;
+      } catch (error) {
+        set(state => {
+          state.error[`runs:${projectId}`] = errMessage(
+            error,
+            "Failed to trigger job",
+          );
+        });
+        return null;
+      }
+    },
+
+    fetchRuns: async (workspaceId, projectId, jobId) => {
+      try {
+        const response = await apiClient.get<{
+          success: boolean;
+          runs: DbtRunItem[];
+        }>(
+          `/workspaces/${workspaceId}/dbt/projects/${projectId}/runs`,
+          jobId ? { jobId, limit: "100" } : { limit: "100" },
+        );
+        set(state => {
+          state.runsByProject[projectId] = response.runs ?? [];
+        });
+      } catch (error) {
+        set(state => {
+          state.error[`runs:${projectId}`] = errMessage(
+            error,
+            "Failed to load runs",
+          );
+        });
+      }
+    },
+
+    fetchRunDetails: async (workspaceId, projectId, runId) => {
+      const cursor = get().runDetails[runId]?.logCursor ?? 0;
+      try {
+        const response = await apiClient.get<{
+          success: boolean;
+          run: DbtRunDetails;
+        }>(
+          `/workspaces/${workspaceId}/dbt/projects/${projectId}/runs/${runId}`,
+          { logsSince: String(cursor) },
+        );
+        const run = response.run;
+        let merged: DbtRunDetails | null = null;
+        set(state => {
+          const previous = state.runDetails[runId];
+          const logs = previous
+            ? [...previous.logs, ...(run.logs ?? [])]
+            : (run.logs ?? []);
+          state.runDetails[runId] = { ...run, logs };
+          merged = state.runDetails[runId];
+          // Keep the run list row in sync (status/duration changes).
+          const runs = state.runsByProject[projectId];
+          if (runs) {
+            const idx = runs.findIndex(r => r._id === runId);
+            if (idx >= 0) {
+              const { logs: _logs, logCursor: _cursor, ...listItem } = run;
+              runs[idx] = { ...runs[idx], ...listItem };
+            }
+          }
+        });
+        return merged;
+      } catch (error) {
+        set(state => {
+          state.error[`run:${runId}`] = errMessage(error, "Failed to load run");
+        });
+        return null;
+      }
+    },
+
+    cancelRun: async (workspaceId, projectId, runId) => {
+      try {
+        await apiClient.post(
+          `/workspaces/${workspaceId}/dbt/projects/${projectId}/runs/${runId}/cancel`,
+        );
+        return true;
+      } catch (error) {
+        set(state => {
+          state.error[`run:${runId}`] = errMessage(
+            error,
+            "Failed to cancel run",
+          );
+        });
+        return false;
+      }
+    },
+
+    compileModel: async (workspaceId, projectId, select, environment) => {
+      try {
+        const response = await apiClient.post<{
+          success: boolean;
+          compile: DbtCompileResult;
+        }>(`/workspaces/${workspaceId}/dbt/projects/${projectId}/compile`, {
+          ...(select ? { select } : {}),
+          ...(environment ? { environment } : {}),
+        });
+        return response.compile ?? null;
+      } catch (error) {
+        return {
+          ok: false,
+          exitCode: 1,
+          logs: [
+            {
+              ts: new Date().toISOString(),
+              level: "error",
+              line: errMessage(error, "Compile failed"),
+            },
+          ],
+        };
+      }
+    },
+
+    runModel: async (workspaceId, projectId, select, environment) => {
+      try {
+        const response = await apiClient.post<{
+          success: boolean;
+          run: DbtRunModelResult;
+        }>(`/workspaces/${workspaceId}/dbt/projects/${projectId}/run-select`, {
+          select,
+          ...(environment ? { environment } : {}),
+        });
+        return response.run ?? null;
+      } catch (error) {
+        return {
+          ok: false,
+          exitCode: 1,
+          stepResults: [],
+          logs: [
+            {
+              ts: new Date().toISOString(),
+              level: "error",
+              line: errMessage(error, "Run failed"),
+            },
+          ],
+        };
+      }
+    },
+
+    fetchLineage: async (workspaceId, projectId) => {
+      try {
+        const response = await apiClient.get<{
+          success: boolean;
+          lineage: DbtLineage;
+        }>(`/workspaces/${workspaceId}/dbt/projects/${projectId}/lineage`);
+        return response.lineage ?? null;
+      } catch (error) {
+        set(state => {
+          state.error[`lineage:${projectId}`] = errMessage(
+            error,
+            "Failed to load lineage",
+          );
+        });
+        return null;
+      }
+    },
+
+    reset: () => set(initialState),
+  })),
+);

--- a/app/src/store/explorerStore.ts
+++ b/app/src/store/explorerStore.ts
@@ -38,6 +38,10 @@ interface ExplorerState {
     expandedFolders: ExpandedMap;
   };
 
+  dbt: {
+    expandedFolders: ExpandedMap;
+  };
+
   view: {
     expandedCollections: ExpandedMap;
   };
@@ -74,6 +78,11 @@ interface ExplorerActions {
   expandAppFolder: (folderKey: string) => void;
   isAppFolderExpanded: (folderKey: string) => boolean;
 
+  // dbt explorer
+  toggleDbtFolder: (folderKey: string) => void;
+  expandDbtFolder: (folderKey: string) => void;
+  isDbtFolderExpanded: (folderKey: string) => boolean;
+
   // View explorer
   toggleCollection: (collectionName: string) => void;
   expandCollection: (collectionName: string) => void;
@@ -100,6 +109,9 @@ const createInitialState = (): ExplorerState => ({
     expandedFolders: {},
   },
   app: {
+    expandedFolders: {},
+  },
+  dbt: {
     expandedFolders: {},
   },
   view: {
@@ -201,6 +213,18 @@ export const useExplorerStore = create<ExplorerStore>()(
 
       isAppFolderExpanded: folderKey => !!get().app.expandedFolders[folderKey],
 
+      toggleDbtFolder: folderKey =>
+        set(state => {
+          toggleKey(state.dbt.expandedFolders, folderKey);
+        }),
+
+      expandDbtFolder: folderKey =>
+        set(state => {
+          state.dbt.expandedFolders[folderKey] = true;
+        }),
+
+      isDbtFolderExpanded: folderKey => !!get().dbt.expandedFolders[folderKey],
+
       toggleCollection: collectionName =>
         set(state => {
           toggleKey(state.view.expandedCollections, collectionName);
@@ -270,6 +294,11 @@ export const useExplorerStore = create<ExplorerStore>()(
             s.app.expandedFolders = migrateArray(s.app.expandedFolders);
           } else {
             s.app = { expandedFolders: {} };
+          }
+          if (s?.dbt) {
+            s.dbt.expandedFolders = migrateArray(s.dbt.expandedFolders);
+          } else {
+            s.dbt = { expandedFolders: {} };
           }
           if (s?.view) {
             s.view.expandedCollections = migrateArray(

--- a/app/src/store/lib/types.ts
+++ b/app/src/store/lib/types.ts
@@ -22,7 +22,8 @@ export type TabKind =
   | "app-binding"
   | "plan"
   | "dbt-file"
-  | "dbt-job";
+  | "dbt-job"
+  | "dbt-console";
 
 /**
  * Sub-section for `kind === "settings"` tabs. Each section is rendered in its

--- a/app/src/store/lib/types.ts
+++ b/app/src/store/lib/types.ts
@@ -20,7 +20,9 @@ export type TabKind =
   | "app"
   | "app-file"
   | "app-binding"
-  | "plan";
+  | "plan"
+  | "dbt-file"
+  | "dbt-job";
 
 /**
  * Sub-section for `kind === "settings"` tabs. Each section is rendered in its
@@ -170,6 +172,7 @@ export type LeftPaneView =
   | "flows"
   | "dashboards"
   | "apps"
+  | "dbt"
   | "settings";
 
 /**

--- a/app/src/store/uiStore.ts
+++ b/app/src/store/uiStore.ts
@@ -217,6 +217,7 @@ export type ActiveExplorer =
   | "flows"
   | "dashboards"
   | "apps"
+  | "dbt"
   | "settings"
   | null;
 
@@ -227,6 +228,7 @@ const EXPLORER_VIEWS: ReadonlySet<LeftPaneView> = new Set([
   "flows",
   "dashboards",
   "apps",
+  "dbt",
   "settings",
 ]);
 

--- a/packages/agent-tools/src/dbt-tools.ts
+++ b/packages/agent-tools/src/dbt-tools.ts
@@ -1,0 +1,98 @@
+/**
+ * Client-Side dbt Tools
+ *
+ * File-editing tools for the dbt IDE ("dbt Cloud replica"). Like the app
+ * tools these have no `execute` function, so the AI SDK routes them to the
+ * browser via `onToolCall`, where `executeDbtAgentTool` applies them to the
+ * dbtStore (the same writeFile path the editor uses) and persists them.
+ *
+ * Server-side verification tools (dbt_parse / dbt_compile_model /
+ * dbt_run_model / dbt_run_job) live in api/src/agent-lib/tools/dbt-tools.ts
+ * because they invoke the dbt runner.
+ */
+
+import { tool } from "ai";
+import { z } from "zod";
+
+const projectIdField = z
+  .string()
+  .describe("dbt project ID (from read_dbt_project_tree)");
+
+const dbtPathField = z
+  .string()
+  .describe(
+    "POSIX file path relative to the project root, e.g. models/staging/stg_orders.sql",
+  );
+
+const readTreeSchema = z.object({
+  projectId: z
+    .string()
+    .optional()
+    .describe(
+      "dbt project ID. Omit to list all projects in the workspace with their environments.",
+    ),
+});
+
+const readFileSchema = z.object({
+  projectId: projectIdField,
+  path: dbtPathField,
+});
+
+const createFileSchema = z.object({
+  projectId: projectIdField,
+  path: dbtPathField,
+  contents: z.string().describe("Full UTF-8 file contents"),
+});
+
+const modifyFileSchema = z.object({
+  projectId: projectIdField,
+  path: dbtPathField,
+  contents: z
+    .string()
+    .describe(
+      "Full replacement contents for the file. Write the complete file, not a diff.",
+    ),
+});
+
+const deleteFileSchema = z.object({
+  projectId: projectIdField,
+  path: dbtPathField,
+});
+
+export const clientDbtTools = {
+  read_dbt_project_tree: tool({
+    description:
+      "List dbt projects in the workspace, or the file tree + jobs of one " +
+      "project when projectId is given. Call this FIRST to get project IDs " +
+      "and file paths before using any other dbt tool.",
+    inputSchema: readTreeSchema,
+  }),
+  read_dbt_file: tool({
+    description:
+      "Read the full contents of a single file in a dbt project " +
+      "(models, schema.yml, dbt_project.yml, seeds, macros...).",
+    inputSchema: readFileSchema,
+  }),
+  create_dbt_file: tool({
+    description:
+      "Create a new file in a dbt project (e.g. a staging model + its " +
+      "schema.yml entry). Fails if the file already exists — use " +
+      "modify_dbt_file to change existing files. After writing models, " +
+      "verify with dbt_parse and dbt_compile_model.",
+    inputSchema: createFileSchema,
+  }),
+  modify_dbt_file: tool({
+    description:
+      "Overwrite an existing dbt project file with full contents. The open " +
+      "editor tab updates live; every save snapshots a version for undo. " +
+      "After editing, verify with dbt_parse / dbt_compile_model.",
+    inputSchema: modifyFileSchema,
+  }),
+  delete_dbt_file: tool({
+    description: "Delete a file from a dbt project.",
+    inputSchema: deleteFileSchema,
+  }),
+};
+
+export type DbtCreateFileInput = z.infer<typeof createFileSchema>;
+export type DbtModifyFileInput = z.infer<typeof modifyFileSchema>;

--- a/packages/agent-tools/src/index.ts
+++ b/packages/agent-tools/src/index.ts
@@ -18,6 +18,7 @@ import { clientChartTools } from "./chart-tools";
 import { clientDashboardTools } from "./dashboard-tools";
 import { clientFlowTools } from "./flow-tools";
 import { clientAppTools } from "./app-tools";
+import { clientDbtTools } from "./dbt-tools";
 import { clientDataSourceTools } from "./data-source-tools";
 import { clientScreenshotTools } from "./screenshot-tools";
 import { clientPlanTools } from "./plan-tools";
@@ -52,6 +53,9 @@ export { clientFlowTools } from "./flow-tools";
 
 export { clientAppTools } from "./app-tools";
 export type { AppWriteFileInput, AppCreateDataBindingInput } from "./app-tools";
+
+export { clientDbtTools } from "./dbt-tools";
+export type { DbtCreateFileInput, DbtModifyFileInput } from "./dbt-tools";
 
 export { clientDataSourceTools } from "./data-source-tools";
 
@@ -98,6 +102,7 @@ export const clientAgentTools = {
   ...clientDashboardTools,
   ...clientFlowTools,
   ...clientAppTools,
+  ...clientDbtTools,
   ...clientDataSourceTools,
   ...clientPlanTools,
 };

--- a/packages/agent-tools/src/read-only-tools.ts
+++ b/packages/agent-tools/src/read-only-tools.ts
@@ -44,6 +44,11 @@ export const READ_ONLY_TOOL_NAMES: ReadonlySet<string> = new Set<string>([
   "list_open_apps",
   "get_app_state",
   "app_read_file",
+  // dbt reads + verification (parse/compile never mutate the warehouse)
+  "read_dbt_project_tree",
+  "read_dbt_file",
+  "dbt_parse",
+  "dbt_compile_model",
   // Surface-scoped data-source reads (apps + dashboards, local DuckDB only)
   "list_data_sources",
   "inspect_data_source",

--- a/packages/agent-tools/src/read-only-tools.ts
+++ b/packages/agent-tools/src/read-only-tools.ts
@@ -44,11 +44,14 @@ export const READ_ONLY_TOOL_NAMES: ReadonlySet<string> = new Set<string>([
   "list_open_apps",
   "get_app_state",
   "app_read_file",
-  // dbt reads + verification (parse/compile never mutate the warehouse)
+  // dbt reads + verification (parse/compile/show/get_run never mutate the
+  // warehouse; show runs a bounded SELECT, get_run reads run history)
   "read_dbt_project_tree",
   "read_dbt_file",
   "dbt_parse",
   "dbt_compile_model",
+  "dbt_get_run",
+  "dbt_show",
   // Surface-scoped data-source reads (apps + dashboards, local DuckDB only)
   "list_data_sources",
   "inspect_data_source",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -367,6 +367,9 @@ importers:
       '@uwdata/mosaic-core':
         specifier: ^0.21.1
         version: 0.21.1
+      '@xyflow/react':
+        specifier: ^12.11.0
+        version: 12.11.0(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ai:
         specifier: 6.0.196
         version: 6.0.196(zod@4.2.1)
@@ -1960,155 +1963,183 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -2440,24 +2471,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@14.2.33':
     resolution: {integrity: sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@14.2.33':
     resolution: {integrity: sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@14.2.33':
     resolution: {integrity: sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@14.2.33':
     resolution: {integrity: sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==}
@@ -3402,56 +3437,67 @@ packages:
     resolution: {integrity: sha512-wC53ZNDgt0pqx5xCAgNunkTzFE8GTgdZ9EwYGVcg+jEjJdZGtq9xPjDnFgfFozQI/Xm1mh+D9YlYtl+ueswNEg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.41.1':
     resolution: {integrity: sha512-jwKCca1gbZkZLhLRtsrka5N8sFAaxrGz/7wRJ8Wwvq3jug7toO21vWlViihG85ei7uJTpzbXZRcORotE+xyrLA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.41.1':
     resolution: {integrity: sha512-g0UBcNknsmmNQ8V2d/zD2P7WWfJKU0F1nu0k5pW4rvdb+BIqMm8ToluW/eeRmxCared5dD76lS04uL4UaNgpNA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.41.1':
     resolution: {integrity: sha512-XZpeGB5TKEZWzIrj7sXr+BEaSgo/ma/kCgrZgL0oo5qdB1JlTzIYQKel/RmhT6vMAvOdM2teYlAaOGJpJ9lahg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.41.1':
     resolution: {integrity: sha512-bkCfDJ4qzWfFRCNt5RVV4DOw6KEgFTUZi2r2RuYhGWC8WhCA8lCAJhDeAmrM/fdiAH54m0mA0Vk2FGRPyzI+tw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.41.1':
     resolution: {integrity: sha512-3mr3Xm+gvMX+/8EKogIZSIEF0WUu0HL9di+YWlJpO8CQBnoLAEL/roTCxuLncEdgcfJcvA4UMOf+2dnjl4Ut1A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.41.1':
     resolution: {integrity: sha512-3rwCIh6MQ1LGrvKJitQjZFuQnT2wxfU+ivhNBzmxXTXPllewOF7JR1s2vMX/tWtUYFgphygxjqMl76q4aMotGw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.41.1':
     resolution: {integrity: sha512-LdIUOb3gvfmpkgFZuccNa2uYiqtgZAz3PTzjuM5bH3nvuy9ty6RGc/Q0+HDFrHrizJGVpjnTZ1yS5TNNjFlklw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.41.1':
     resolution: {integrity: sha512-oIE6M8WC9ma6xYqjvPhzZYk6NbobIURvP/lEbh7FWplcMO6gn7MM2yHKA1eC/GvYwzNKK/1LYgqzdkZ8YFxR8g==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.41.1':
     resolution: {integrity: sha512-cWBOvayNvA+SyeQMp79BHPK8ws6sHSsYnK5zDcsC3Hsxr1dgTABKjMnMslPq1DvZIp6uO7kIWhiGwaTdR4Og9A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.41.1':
     resolution: {integrity: sha512-y5CbN44M+pUCdGDlZFzGGBSKCA4A/J2ZH4edTYSSxFg7ce1Xt3GtydbVKWLlzL+INfFIZAEg1ZV6hh9+QQf9YQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.41.1':
     resolution: {integrity: sha512-lZkCxIrjlJlMt1dLO/FbpZbzt6J/A8p4DnqzSa4PWqPEUUUnzXLeki/iyPLfV0BmHItlYgHUqJe+3KiyydmiNQ==}
@@ -3773,24 +3819,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -4362,6 +4412,22 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+
+  '@xyflow/react@12.11.0':
+    resolution: {integrity: sha512-na4IO33FSs2OS72hASgZDmTYwFAkef7Z74uBUVrong3ARmQQHfnRUVaCFn1kTt5LbS6pK03TbYjCPGLjLFfziA==}
+    peerDependencies:
+      '@types/react': '>=17'
+      '@types/react-dom': '>=17'
+      react: '>=17'
+      react-dom: '>=17'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@xyflow/system@0.0.77':
+    resolution: {integrity: sha512-qCDCMCQAAgUu8yHnhloHG9F5mwPX5E+Wl8McpYIOPSSXfzFJJoZcwOcsDiAjitVKIg2de1WmJbCHfpcvxprsgg==}
 
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -5031,6 +5097,9 @@ packages:
 
   cjs-module-lexer@2.2.0:
     resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
+
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
 
   clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
@@ -7398,48 +7467,56 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.31.0:
     resolution: {integrity: sha512-EpAQTq6TXL+200bDNMzhbFpqAJsto01R//xuE8yAWN0l4wmJhmS1r/FxoudIUM9PxHMPEiWeLw+1thdF5ZPg7Q==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.31.0:
     resolution: {integrity: sha512-6tuU37nXStA3kxNnjC49z1tPFEoviC9ZLyB34O3X1/VTLXdZX2vmPZ+45XesagvlgoeJQ9r9XVSovUZny41AQA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.31.0:
     resolution: {integrity: sha512-enNePbgDKmJybVz90/8dAGTOulvpn0IwxamHHnIj32gmdbuSPJ9mk+Nob4UmiqLMAdHlH+0c+lpsZkv4TSxi3w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-musl@1.31.0:
     resolution: {integrity: sha512-EM4jGT+V+PdFkcrIB5m5yiSzfV7z43k0pOtUmODhFSbuay5JvbVChK1uoaMmwPTKGWatwSRbiu90BUzU262B9g==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -10957,6 +11034,21 @@ packages:
 
   zod@4.2.1:
     resolution: {integrity: sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
   zustand@5.0.5:
     resolution: {integrity: sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg==}
@@ -15542,6 +15634,31 @@ snapshots:
 
   '@xmldom/xmldom@0.8.13': {}
 
+  '@xyflow/react@12.11.0(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@xyflow/system': 0.0.77
+      classcat: 5.0.5
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      zustand: 4.5.7(@types/react@18.3.23)(immer@10.1.1)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.23
+      '@types/react-dom': 18.3.7(@types/react@18.3.23)
+    transitivePeerDependencies:
+      - immer
+
+  '@xyflow/system@0.0.77':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+
   abbrev@1.1.1:
     optional: true
 
@@ -16485,6 +16602,8 @@ snapshots:
   cjs-module-lexer@1.4.3: {}
 
   cjs-module-lexer@2.2.0: {}
+
+  classcat@5.0.5: {}
 
   clean-stack@2.2.0:
     optional: true
@@ -23788,6 +23907,14 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.2.1: {}
+
+  zustand@4.5.7(@types/react@18.3.23)(immer@10.1.1)(react@18.3.1):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.23
+      immer: 10.1.1
+      react: 18.3.1
 
   zustand@5.0.5(@types/react@18.3.23)(immer@10.1.1)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1)):
     optionalDependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# dbt Cloud in Mako (dbt Core engine)

Builds a dbt Cloud replica inside Mako: workspace-scoped dbt projects stored in Mongo, a subprocess runner that renders `profiles.yml` from existing encrypted connections, Inngest-orchestrated runs with logs/artifacts, a Monaco IDE under a new **Transforms** section, a lineage DAG, and a dbt agent with a compile/run verification loop.

## Backend

- **Data model** (`workspace-schema.ts` + idempotent migration): `dbt_projects` (environments → connectionId/targetSchema/threads), `dbt_files` (virtual filesystem, one doc per file, unique `{projectId, path}`), `dbt_jobs` (allowlisted command lists, cron `schedule` + `scheduledRun` claim state mirroring `SavedConsole`), `dbt_runs` (capped batched logs, `stepResults` parsed from `run_results.json`, artifact keys).
- **Runner** (`api/src/dbt/`): command allowlist (rejects `--profiles-dir`, unknown subcommands/flags), adapter map for postgres/cloudsql-postgres/redshift/bigquery/clickhouse/mysql/mssql with profile renderers that reference secrets as `{{ env_var('DBT_SECRET_…') }}` (values passed only via child-process env, never written to disk), binary resolution (`DBT_VENV_BIN` → `uvx` dev fallback; separate venv for dbt-mysql which is pinned upstream to dbt-core 1.7), `mkdtemp` materialization with traversal rejection, JSON log streaming, artifact collection, guaranteed cleanup, SIGTERM on abort/timeout.
- **Routes** (`/api/workspaces/:workspaceId/dbt`): project/file/job CRUD with zod validation (connection-type compatibility, command allowlist, cron validation), run trigger/cancel/list/details with `logsSince` cursor, artifact streaming, synchronous `compile` + `run-select` endpoints (shared by IDE buttons and agent tools), manifest-`parent_map` lineage endpoint.
- **Inngest**: `dbt-run-executor` (retries 0, per-project concurrency 1, `cancelOn` dbt/run.cancel; one `step.run` per command — snapshots + decrypted profiles loaded inside the step so secrets never enter step state; batched `$push`/`$slice` log writes; artifact upload per command; finalize updates job `scheduledRun` stats and the prod manifest key for future Slim CI), cancel finalizer, and a cron scheduler using the verbatim optimistic-claim pattern from scheduled-query (prod-only registration like the other schedulers).
- **Dockerfile**: bakes `/opt/dbt` venv (dbt-core 1.9.10 + postgres/redshift/bigquery/clickhouse/sqlserver adapters, versions verified on PyPI) and `/opt/dbt-mysql`; sets `DBT_VENV_BIN`/`DBT_MYSQL_VENV_BIN`. No deploy-workflow change needed: Cloud Run already runs `--timeout=3600`; executor per-command timeout is 50m.

## Frontend

- **Transforms** icon-rail entry → `DbtExplorer` (AppsExplorer pattern): project tree with Files + Jobs, new-project dialog (dbt-compatible connection filter, dev/prod schemas, scaffold seeding, opens `dbt_project.yml`), new file/rename/delete.
- New tab kinds: `dbt-file` → `DbtFileEditor` (Monaco sql/yaml/md, 1.2s debounced persist + Cmd/Ctrl+S, Compile/Run-model bottom panel with Compiled SQL / Results / Logs tabs, environment selector with prod confirm) and `dbt-job` → `DbtJobView` (run-history split pane, summary strip, models table with open-model links, 2s live log tail via the `logsSince` cursor, edit form with command presets + flag fields, cron presets/timezone/next-3-runs preview; **Lineage** tab rendering the layered DAG via lazy-loaded `@xyflow/react`, node color by last-run status, click-through to model files).
- `dbtStore` (zustand + immer): all network access through `apiClient`; the agent's client tools mutate through the same `writeFile`/`persistFile` path as the editor.

## Agent ("vibe" layer)

- Client tools in `@mako/agent-tools` (`read_dbt_project_tree`, `read_dbt_file`, `create/modify/delete_dbt_file`) + manifest entries, `dbt-runtime` executor, and `Chat.tsx` dispatch branch.
- Server verification tools (`dbt_parse`, `dbt_compile_model`, `dbt_run_model`, `dbt_run_job` — the latter requiring explicit user confirmation, like `schedule_query`), workspace-scoped through the same ad-hoc service path.
- `dbt` expertise mode in the unified agent (default for dbt tabs) + a standalone `dbt` agent in the registry; reads/parse/compile classified read-only for the plan gate.
- `api/src/agent-skills/dbt/SKILL.md` + references (incremental strategies, snapshots, adapter quirks).

## E2E verification (live stack: Postgres 16 + Mongo 8 + Inngest dev server + real dbt-core 1.9.10)

- Runner: parse / compile (source resolution) / `build --select` with **2 passing schema tests**, secret isolation asserted (password absent from `profiles.yml`, present in env map), bad-ref failure surfaced in logs, traversal + disallowed-command rejection.
- HTTP: project create with scaffold, file save/version, path-traversal 400, ad-hoc compile returns compiled SQL, run-select builds model + tests on dev.
- Async: job create computes `scheduledRun.nextAt` (Berlin TZ correct), bad command/cron rejected, trigger → Inngest executor ran both commands → status `success` in ~5s with 40 log lines, cursor pagination, manifest/run_results in the artifact store, lineage `source → stg` edge with statuses, job stats (`runCount`, `consecutiveFailures`) updated, cancellation finalizes as `cancelled`.
- Gates: `app` typecheck + lint, `api` lint (typecheck via tsc) all green.

## Follow-up enhancements (later commits in this PR)

- **Project/job management UI**: `updateProject` store method + **Edit Project** dialog (name, per-environment connection/schema/threads, default env, dbt version) — projects were previously uneditable. A hover **kebab** on every Transforms row surfaces Edit/Delete/New-file (previously right-click only).
- **Reliability**:
  - `dbt-run-sweeper` cron finalizes runs abandoned by a dead executor (instance crash/deploy) — with `retries: 0` these would otherwise stay `running` forever.
  - Run-history **retention** prune (`DBT_RUN_RETENTION_DAYS`, default 30) so `dbt_runs` (embedded logs/stepResults) don't grow unbounded; the parent job keeps last status.
  - **Overlapping-run collapse**: scheduled ticks fold onto an already-active run for the same job instead of stacking behind the per-project concurrency lock.
  - **Auto-disable** a scheduled job after `DBT_AUTO_DISABLE_AFTER_FAILURES` (default 10) consecutive failures.
- **Packages**: `dbt deps` runs automatically when a project declares packages (commented `packages.yml` seeded in the scaffold); `deps`/`retry` allowlisted.
- **Retry from failure**: a retry run seeds the prior `run_results.json` into `target/` and runs `dbt retry`; new route + store action + button on failed runs.
- **Source freshness**: `sources.json` collected, uploaded, and surfaced in the run-detail table (status + "loaded Nm ago", warn/error coloring).
- **Slim CI**: `deferToProduction` job toggle wires `--defer --state` against the persisted prod manifest; pair with `--select state:modified+`.
- **Docs + exposures**: lineage endpoint returns per-node docs (description, columns w/ type+description, tags, materialization); exposures render as terminal dashed nodes; clicking a node opens an in-DAG docs drawer.
- **Tests**: vitest suites for the command allowlist and adapter-map secret isolation.

## Known gaps / follow-ups

- **Notification-rule delivery for dbt jobs**: auto-disable ships, but wiring dbt jobs into the `flow.run.terminal` notification pipeline needs `NotificationResourceType` + the rule-creation UI to gain a `dbt_job` resource (deferred to keep this PR focused).
- **Package caching**: `dbt deps` re-installs per `runDbt` invocation (no `dbt_packages` archive cache yet — no tar/zip dep in the repo). Correct but adds latency for package-heavy projects.
- **Native dbt-docs hosting**: the docs drawer reads the manifest directly rather than serving dbt's bundled `index.html` (auth-in-iframe deferred).
- **Sweeper/scheduler unit tests**: covered by the live E2E stack but not yet mocked into vitest (CI doesn't run unit tests today).
- Still out of scope: git export/import and the ephemeral-container runner (the `runner.service.ts` contract is designed so only the executor swaps).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1eb22b96-9ad2-47ad-9031-db2d5ff0b74b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1eb22b96-9ad2-47ad-9031-db2d5ff0b74b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


