### PR TITLE
fix(app): make DuckDB-WASM worker creation work on Safari/WebKit

### DIFF
--- a/app/src/lib/duckdb.ts
+++ b/app/src/lib/duckdb.ts
@@ -105,23 +105,20 @@ async function createWorkerAndInstantiate(): Promise<AsyncDuckDB> {
   if (!workerUrl) {
     throw new Error("DuckDB worker URL is unavailable");
   }
-  let worker: Worker;
-  try {
-    worker = new Worker(workerUrl);
-    console.log(
-      `[opfs-diag] createWorkerAndInstantiate: worker created from ${workerUrl}`,
-    );
-  } catch {
-    console.warn(
-      `[opfs-diag] createWorkerAndInstantiate: direct worker creation failed for ${workerUrl}, falling back to blob worker`,
-    );
-    const resp = await fetch(workerUrl);
-    const blob = new Blob([await resp.text()], { type: "text/javascript" });
-    worker = new Worker(URL.createObjectURL(blob));
-    console.log(
-      "[opfs-diag] createWorkerAndInstantiate: blob worker created successfully",
-    );
-  }
+  // Always create the worker through a same-origin blob shim (duckdb-wasm's
+  // documented pattern). A direct cross-origin `new Worker(cdnUrl)` throws
+  // synchronously in Chrome/Firefox (so a try/catch fallback would run), but
+  // Safari/WebKit fails *asynchronously* via an error event instead — the
+  // catch never fired and DuckDB silently never instantiated on Safari.
+  const blobUrl = URL.createObjectURL(
+    new Blob([`importScripts(${JSON.stringify(workerUrl)});`], {
+      type: "text/javascript",
+    }),
+  );
+  const worker = new Worker(blobUrl);
+  console.log(
+    `[opfs-diag] createWorkerAndInstantiate: blob worker created for ${workerUrl}`,
+  );
 
   const logger = new duckdb.ConsoleLogger(duckdb.LogLevel.WARNING);
   const db = new duckdb.AsyncDuckDB(logger, worker);


### PR DESCRIPTION
## Summary

- Public share pages (e.g. `/share/realadvisor/geneva-active-clients-map`) were stuck on "Loading…" with no data on iOS/macOS Safari.
- Root cause: Safari fails a cross-origin `new Worker(cdnUrl)` **asynchronously** via an error event, while Chrome/Firefox throw synchronously. The `try/catch` blob-worker fallback in `createWorkerAndInstantiate` was therefore unreachable on Safari, and DuckDB-WASM silently never instantiated (`error in duckdb worker: undefined`). All DuckDB consumers (public dashboard/app shares, dashboards, app bindings) were affected.
- Fix: always create the worker through a same-origin blob `importScripts` shim — duckdb-wasm's documented pattern — instead of relying on the browser to throw.

## Test plan

- [x] Reproduced the broken share page on Playwright WebKit (iPhone 13 profile): DuckDB worker error, bindings never load.
- [x] Verified `new Worker(crossOriginUrl)` does not throw synchronously on WebKit (async error event only) — confirming the old fallback was dead code there.
- [x] Verified blob `importScripts` shim + full DuckDB instantiate + query succeeds on WebKit and Chromium.
- [x] `pnpm --filter app run typecheck` and `pnpm --filter app run lint` pass.
- [ ] After deploy: re-check the live share link on an iPhone.

Made with [Cursor](https://cursor.com)