### PR TITLE
Dark mode support for user-built React apps

### DIFF
--- a/api/src/agent-skills/apps/SKILL.md
+++ b/api/src/agent-skills/apps/SKILL.md
@@ -13,6 +13,8 @@ entities:
   - useduckdb
   - parquet
   - preview
+  - theme
+  - dark mode
 ---
 
 Apps are React projects rendered live in a tab. You build them by editing files.
@@ -77,10 +79,43 @@ Apps are React projects rendered live in a tab. You build them by editing files.
    `useDuckDB` calls. Data sources are also visible to the user under "Data sources" in the
    app's explorer tree.
 
+### Theming & dark mode
+
+Apps are themed by the runtime — do not build a theme system. The preview injects
+shadcn-named CSS variables that switch between light and dark automatically (the Mako
+theme when the app runs inside the workspace, the OS preference when opened standalone
+from a share link). The page background and text color are pre-wired; a new app is
+dark-mode-correct with zero theme code.
+
+The one rule: **never hardcode surface/text/border colors — use the tokens.**
+
+- Surfaces & text: `var(--background)` / `var(--foreground)`, `var(--card)` /
+  `var(--card-foreground)`, `var(--popover)` / `var(--popover-foreground)`,
+  `var(--muted)` / `var(--muted-foreground)`, `var(--secondary)`, `var(--accent)`
+- Lines & controls: `var(--border)`, `var(--input)`, `var(--ring)`, `var(--radius)`
+- Emphasis: `var(--primary)` / `var(--primary-foreground)`, `var(--destructive)` /
+  `var(--destructive-foreground)`
+- Charts: `var(--chart-1)` … `var(--chart-5)` — tokens are resolved colors, so they
+  work directly in inline styles, CSS-in-JS, and SVG `fill`/`stroke` (recharts, d3).
+
+When code needs the literal mode or a computed color (e.g. a canvas-based chart
+library's theme option), use the SDK hook:
+
+```tsx
+import { useTheme } from "@mako/app-sdk";
+const { theme } = useTheme(); // "light" | "dark", updates live on toggle
+```
+
+Brand colors are fine for accents — just keep backgrounds, text, and borders on the
+tokens so both modes stay readable.
+
 ### Constraints
 
 - The default `cdn` runtime runs React + ESM dependencies without a build step. Plain
   CSS and runtime libraries (d3, recharts, etc.) work well. A full Tailwind/shadcn build
   requires the `webcontainer` runtime (not yet enabled) — prefer plain CSS or CSS-in-JS
   for styling in the cdn runtime.
+- Use the injected theme tokens (`var(--background)`, `var(--card)`, `var(--border)`,
+  `var(--chart-1)`, …) instead of hardcoded colors so apps follow light/dark mode; see
+  "Theming & dark mode".
 - Keep components in their own files and import them; write idiomatic, modern React.

--- a/app/src/app-runtime/preview.test.ts
+++ b/app/src/app-runtime/preview.test.ts
@@ -40,4 +40,45 @@ describe("buildPreviewHtml", () => {
     // …and warn when the parent reports dropped rows.
     expect(script).toContain("warnTruncated");
   });
+
+  it("injects light/dark theme tokens and pre-wires the body colors", () => {
+    const html = buildPreviewHtml(app);
+    // Resolved color values (var(--background) usable directly), both modes.
+    expect(html).toContain("--background: hsl(0 0% 100%)");
+    expect(html).toContain(":root.dark");
+    expect(html).toContain("--background: hsl(240 10% 3.9%)");
+    expect(html).toContain("--chart-5");
+    // Zero-code default: apps inherit themed body background/text.
+    expect(html).toContain("background: var(--background)");
+    expect(html).toContain("color: var(--foreground)");
+  });
+
+  it("embeds the host theme in the payload (null = follow system)", () => {
+    const payloadOf = (html: string) =>
+      JSON.parse(
+        String(
+          html
+            .split('<script id="mako-payload" type="application/json">')[1]
+            ?.split("</script>")[0],
+        ),
+      ) as { theme: string | null };
+    expect(payloadOf(buildPreviewHtml(app, { theme: "dark" })).theme).toBe(
+      "dark",
+    );
+    expect(payloadOf(buildPreviewHtml(app, { theme: "light" })).theme).toBe(
+      "light",
+    );
+    expect(payloadOf(buildPreviewHtml(app)).theme).toBeNull();
+  });
+
+  it("wires live theme switching and the useTheme SDK hook in the bootstrap", () => {
+    const script = extractModuleScript(buildPreviewHtml(app));
+    // Parent-driven toggles (embedded in Mako)…
+    expect(script).toContain("mako-app:set-theme");
+    // …system fallback when standalone…
+    expect(script).toContain("prefers-color-scheme: dark");
+    // …applied before the app renders, and exposed to app code.
+    expect(script).toContain("setExplicitTheme(payload.theme)");
+    expect(script).toContain("useTheme()");
+  });
 });

--- a/app/src/app-runtime/preview.ts
+++ b/app/src/app-runtime/preview.ts
@@ -31,8 +31,12 @@ export const PREVIEW_MESSAGE = {
   duckDbResult: "mako-app:duckdb-result",
   capture: "mako-app:capture",
   captureResult: "mako-app:capture-result",
+  setTheme: "mako-app:set-theme",
   error: "mako-app:error",
 } as const;
+
+/** Effective color mode delivered to the sandboxed app. */
+export type PreviewTheme = "light" | "dark";
 
 /**
  * DOM-capture library loaded *inside* the sandboxed iframe for self-capture.
@@ -47,6 +51,82 @@ export const PREVIEW_MESSAGE = {
  * inlines computed styles directly with no helper iframe.
  */
 const CAPTURE_LIB_URL = `${ESM_HOST}/html-to-image@1`;
+
+/**
+ * Design tokens injected into every app preview.
+ *
+ * Shadcn-style names with the same palette as the Mako shell
+ * (`app/src/index.css`), but shipped as ready-to-use colors — app code writes
+ * `var(--background)` directly (works in inline styles, CSS-in-JS, and SVG
+ * fill/stroke) instead of the host's `hsl(var(--background))` triplet idiom.
+ *
+ * Light values live on `:root`, dark overrides on `:root.dark`. The bootstrap
+ * toggles the `dark` class from the embedded payload theme, parent
+ * `mako-app:set-theme` messages, or `prefers-color-scheme` when standalone.
+ * Body background/text are pre-wired so apps inherit a correct theme with no
+ * theme code at all. The (future) `webcontainer` runtime should keep this
+ * same token + message contract.
+ */
+const THEME_TOKENS_CSS = `
+      :root {
+        color-scheme: light;
+        --background: hsl(0 0% 100%);
+        --foreground: hsl(240 10% 3.9%);
+        --card: hsl(0 0% 100%);
+        --card-foreground: hsl(240 10% 3.9%);
+        --popover: hsl(0 0% 100%);
+        --popover-foreground: hsl(240 10% 3.9%);
+        --primary: hsl(240 5.9% 10%);
+        --primary-foreground: hsl(0 0% 98%);
+        --secondary: hsl(240 4.8% 95.9%);
+        --secondary-foreground: hsl(240 5.9% 10%);
+        --muted: hsl(240 4.8% 95.9%);
+        --muted-foreground: hsl(240 3.8% 46.1%);
+        --accent: hsl(240 4.8% 95.9%);
+        --accent-foreground: hsl(240 5.9% 10%);
+        --destructive: hsl(0 84.2% 60.2%);
+        --destructive-foreground: hsl(0 0% 98%);
+        --border: hsl(240 5.9% 90%);
+        --input: hsl(240 5.9% 90%);
+        --ring: hsl(240 5.9% 10%);
+        --chart-1: hsl(12 76% 61%);
+        --chart-2: hsl(173 58% 39%);
+        --chart-3: hsl(197 37% 24%);
+        --chart-4: hsl(43 74% 66%);
+        --chart-5: hsl(27 87% 67%);
+        --radius: 0.5rem;
+      }
+      :root.dark {
+        color-scheme: dark;
+        --background: hsl(240 10% 3.9%);
+        --foreground: hsl(0 0% 98%);
+        --card: hsl(240 10% 3.9%);
+        --card-foreground: hsl(0 0% 98%);
+        --popover: hsl(240 10% 3.9%);
+        --popover-foreground: hsl(0 0% 98%);
+        --primary: hsl(0 0% 98%);
+        --primary-foreground: hsl(240 5.9% 10%);
+        --secondary: hsl(240 3.7% 15.9%);
+        --secondary-foreground: hsl(0 0% 98%);
+        --muted: hsl(240 3.7% 15.9%);
+        --muted-foreground: hsl(240 5% 64.9%);
+        --accent: hsl(240 3.7% 15.9%);
+        --accent-foreground: hsl(0 0% 98%);
+        --destructive: hsl(0 62.8% 30.6%);
+        --destructive-foreground: hsl(0 0% 98%);
+        --border: hsl(240 3.7% 15.9%);
+        --input: hsl(240 3.7% 15.9%);
+        --ring: hsl(240 4.9% 83.9%);
+        --chart-1: hsl(220 70% 50%);
+        --chart-2: hsl(160 60% 45%);
+        --chart-3: hsl(30 80% 55%);
+        --chart-4: hsl(280 65% 60%);
+        --chart-5: hsl(340 75% 55%);
+      }
+      body {
+        background: var(--background);
+        color: var(--foreground);
+      }`;
 
 function buildImportMap(dependencies: Record<string, string>): string {
   const imports: Record<string, string> = {
@@ -80,7 +160,17 @@ function bareSpecifiers(dependencies: Record<string, string>): string[] {
   return [...set];
 }
 
-export function buildPreviewHtml(appEntity: AppEntity): string {
+export function buildPreviewHtml(
+  appEntity: AppEntity,
+  options?: {
+    /**
+     * Effective theme to boot with. Hosts embedding the preview pass their
+     * current mode (and post `mako-app:set-theme` on later toggles); when
+     * omitted/null the iframe follows `prefers-color-scheme` (standalone).
+     */
+    theme?: PreviewTheme | null;
+  },
+): string {
   const scriptFiles: Record<string, string> = {};
   for (const file of appEntity.files) {
     if (SCRIPT_EXT.test(file.path)) {
@@ -96,6 +186,7 @@ export function buildPreviewHtml(appEntity: AppEntity): string {
     files: scriptFiles,
     bareDeps,
     entrypoint,
+    theme: options?.theme ?? null,
   });
 
   return `<!DOCTYPE html>
@@ -107,6 +198,7 @@ export function buildPreviewHtml(appEntity: AppEntity): string {
     <script src="https://unpkg.com/@babel/standalone@7.25.6/babel.min.js"></script>
     <style>
       html, body, #root { margin: 0; height: 100%; }
+${THEME_TOKENS_CSS}
       #mako-error {
         position: fixed; inset: 0; background: #1e1e1e; color: #f48771;
         font-family: ui-monospace, monospace; font-size: 13px; padding: 16px;
@@ -147,6 +239,49 @@ window.addEventListener("error", (e) => showError(e.message || "Runtime error", 
 window.addEventListener("unhandledrejection", (e) =>
   showError((e.reason && e.reason.message) || "Unhandled promise rejection", "runtime"),
 );
+
+// --- Theme: the injected CSS tokens flip via the 'dark' class on <html>.
+// An explicit theme comes from the embedded payload (host's mode at build
+// time) or parent "mako-app:set-theme" messages (live toggles); with no
+// explicit theme the app follows prefers-color-scheme (standalone). ---
+const themeListeners = new Set();
+const systemDark = window.matchMedia
+  ? window.matchMedia("(prefers-color-scheme: dark)")
+  : null;
+let explicitTheme = null; // "light" | "dark" | null (null = follow system)
+let currentTheme = "light";
+
+function resolveTheme() {
+  if (explicitTheme === "light" || explicitTheme === "dark") return explicitTheme;
+  return systemDark && systemDark.matches ? "dark" : "light";
+}
+function applyTheme() {
+  const next = resolveTheme();
+  document.documentElement.classList.toggle("dark", next === "dark");
+  if (next !== currentTheme) {
+    currentTheme = next;
+    themeListeners.forEach((listener) => {
+      try {
+        listener(next);
+      } catch (_) {
+        /* listener errors must not break theming */
+      }
+    });
+  }
+}
+function setExplicitTheme(theme) {
+  explicitTheme = theme === "light" || theme === "dark" ? theme : null;
+  applyTheme();
+}
+if (systemDark && systemDark.addEventListener) {
+  systemDark.addEventListener("change", () => {
+    if (explicitTheme == null) applyTheme();
+  });
+}
+window.addEventListener("message", (event) => {
+  const data = event.data || {};
+  if (data.type === "mako-app:set-theme") setExplicitTheme(data.theme);
+});
 
 async function waitForBabel(timeoutMs = 10000) {
   const start = Date.now();
@@ -198,13 +333,25 @@ function warnTruncated(source, res) {
 
 // --- Self-capture: the parent cannot rasterize this opaque-origin iframe, so
 // it asks us to screenshot ourselves and posts the PNG back. ---
+function defaultCaptureBackground() {
+  // Match the active theme (--background flips with the 'dark' class) so dark
+  // apps aren't composited onto a white backdrop.
+  try {
+    const bg = getComputedStyle(document.documentElement)
+      .getPropertyValue("--background")
+      .trim();
+    return bg || "#ffffff";
+  } catch (_) {
+    return "#ffffff";
+  }
+}
 window.addEventListener("message", (event) => {
   const data = event.data || {};
   if (data.type !== "mako-app:capture" || !data.requestId) return;
   import(MAKO_CAPTURE_LIB_URL)
     .then((mod) =>
       mod.toPng(document.documentElement, {
-        backgroundColor: data.backgroundColor == null ? "#ffffff" : data.backgroundColor,
+        backgroundColor: data.backgroundColor == null ? defaultCaptureBackground() : data.backgroundColor,
         pixelRatio: typeof data.scale === "number" ? data.scale : 1,
       }),
     )
@@ -227,8 +374,13 @@ window.addEventListener("message", (event) => {
 });
 
 async function main() {
-  const Babel = await waitForBabel();
   const payload = JSON.parse(document.getElementById("mako-payload").textContent);
+
+  // Apply the host-provided theme (or the system fallback) before anything
+  // renders so the first paint already uses the right tokens.
+  setExplicitTheme(payload.theme);
+
+  const Babel = await waitForBabel();
 
   // Pre-import bare npm dependencies as ESM (via the import map).
   const deps = {};
@@ -300,6 +452,22 @@ async function main() {
         return () => { active = false; };
       }, [sql, rowLimit]);
       return state;
+    },
+    // Effective color mode: { theme: "light" | "dark" }. Tracks the host app
+    // theme when embedded in Mako and the OS preference when standalone. Use
+    // it for chart configs or conditional logic that needs a literal value;
+    // for styling prefer the injected CSS variables (var(--background),
+    // var(--card), var(--chart-1), ...) which switch automatically.
+    useTheme() {
+      const [theme, setTheme] = React.useState(currentTheme);
+      React.useEffect(() => {
+        const listener = (next) => setTheme(next);
+        themeListeners.add(listener);
+        // Re-sync in case the theme changed between render and subscribe.
+        setTheme(currentTheme);
+        return () => { themeListeners.delete(listener); };
+      }, []);
+      return { theme: theme };
     },
   };
 

--- a/app/src/components/AppRenderer.tsx
+++ b/app/src/components/AppRenderer.tsx
@@ -11,6 +11,7 @@ import {
 import { RefreshCw as RefreshIcon, Share2 as ShareIcon } from "lucide-react";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useAuth } from "../contexts/auth-context";
+import { useTheme } from "../contexts/ThemeContext";
 import { useIsWorkspaceAdmin } from "../hooks/useIsWorkspaceAdmin";
 import { useAppStore } from "../store/appStore";
 import ShareDialog from "./ShareDialog";
@@ -36,6 +37,13 @@ export default function AppRenderer({ appId }: { appId: string }) {
   const isWorkspaceAdmin = useIsWorkspaceAdmin();
   const workspaceId = currentWorkspace?.id;
   const [shareOpen, setShareOpen] = useState(false);
+
+  // The sandboxed preview inherits the host theme: the current mode seeds the
+  // srcdoc, and later toggles are pushed via postMessage (rebuilding the
+  // preview takes seconds, so theme changes must never bump the srcdoc).
+  const { effectiveMode } = useTheme();
+  const effectiveModeRef = useRef(effectiveMode);
+  effectiveModeRef.current = effectiveMode;
 
   const appEntity = useAppStore(s => s.openApps[appId]);
   const previewNonce = useAppStore(s => s.previewNonce[appId] ?? 0);
@@ -191,16 +199,31 @@ export default function AppRenderer({ appId }: { appId: string }) {
       } else if (data.type === PREVIEW_MESSAGE.ready) {
         setBooting(false);
         setPreviewErrors(appId, []);
+        // Covers a theme toggle that raced the (slow) preview boot.
+        post({
+          type: PREVIEW_MESSAGE.setTheme,
+          theme: effectiveModeRef.current,
+        });
       }
     };
     window.addEventListener("message", handler);
     return () => window.removeEventListener("message", handler);
   }, [appId, workspaceId, appEntity, runBinding, setPreviewErrors]);
 
+  // Keep the booted preview's theme in sync with the host toggle.
+  useEffect(() => {
+    iframeRef.current?.contentWindow?.postMessage(
+      { type: PREVIEW_MESSAGE.setTheme, theme: effectiveMode },
+      "*",
+    );
+  }, [effectiveMode]);
+
   // Rebuild the preview document whenever files/deps change (nonce bumps).
+  // The theme is read from a ref on purpose: it only seeds the boot paint and
+  // must not trigger an expensive rebuild on toggle (set-theme handles that).
   const srcDoc = useMemo(() => {
     if (!appEntity) return "";
-    return buildPreviewHtml(appEntity);
+    return buildPreviewHtml(appEntity, { theme: effectiveModeRef.current });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [appEntity?._id, previewNonce]);
 
@@ -286,7 +309,12 @@ export default function AppRenderer({ appId }: { appId: string }) {
 
       {/* Full-screen preview */}
       <Box
-        sx={{ flex: 1, minHeight: 0, bgcolor: "#fff", position: "relative" }}
+        sx={{
+          flex: 1,
+          minHeight: 0,
+          bgcolor: "background.default",
+          position: "relative",
+        }}
       >
         <iframe
           ref={iframeRef}

--- a/app/src/components/public/PublicAppViewer.tsx
+++ b/app/src/components/public/PublicAppViewer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Box, CircularProgress, Typography, Alert } from "@mui/material";
+import { useTheme } from "../../contexts/ThemeContext";
 import { buildPreviewHtml, PREVIEW_MESSAGE } from "../../app-runtime/preview";
 import {
   ensureBindingLoaded,
@@ -68,6 +69,14 @@ export default function PublicAppViewer({ token, content }: Props) {
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const [booting, setBooting] = useState(true);
   const [previewError, setPreviewError] = useState<string | null>(null);
+
+  // Anonymous visitors have no saved theme preference, so the ThemeProvider
+  // default ("system") makes effectiveMode track the OS preference — exactly
+  // what a standalone app should inherit. Seed the srcdoc with it and push
+  // later changes via postMessage (no srcdoc rebuild).
+  const { effectiveMode } = useTheme();
+  const effectiveModeRef = useRef(effectiveMode);
+  effectiveModeRef.current = effectiveMode;
 
   const duckAppId = `share-${token}`;
 
@@ -191,19 +200,37 @@ export default function PublicAppViewer({ token, content }: Props) {
       } else if (data.type === PREVIEW_MESSAGE.ready) {
         setBooting(false);
         setPreviewError(null);
+        // Covers a theme change that raced the (slow) preview boot.
+        post({
+          type: PREVIEW_MESSAGE.setTheme,
+          theme: effectiveModeRef.current,
+        });
       }
     };
     window.addEventListener("message", handler);
     return () => window.removeEventListener("message", handler);
   }, [duckAppId, content]);
 
+  // Keep the booted preview's theme in sync with system/theme changes.
+  useEffect(() => {
+    iframeRef.current?.contentWindow?.postMessage(
+      { type: PREVIEW_MESSAGE.setTheme, theme: effectiveMode },
+      "*",
+    );
+  }, [effectiveMode]);
+
+  // Theme comes from a ref on purpose: it only seeds the boot paint and must
+  // not rebuild the (slow, Babel-compiled) preview — set-theme handles toggles.
   const srcDoc = useMemo(
     () =>
-      buildPreviewHtml({
-        files: content.files,
-        dependencies: content.dependencies,
-        entrypoint: content.entrypoint,
-      } as Parameters<typeof buildPreviewHtml>[0]),
+      buildPreviewHtml(
+        {
+          files: content.files,
+          dependencies: content.dependencies,
+          entrypoint: content.entrypoint,
+        } as Parameters<typeof buildPreviewHtml>[0],
+        { theme: effectiveModeRef.current },
+      ),
     [content],
   );
 
@@ -240,7 +267,12 @@ export default function PublicAppViewer({ token, content }: Props) {
       )}
 
       <Box
-        sx={{ flex: 1, minHeight: 0, bgcolor: "#fff", position: "relative" }}
+        sx={{
+          flex: 1,
+          minHeight: 0,
+          bgcolor: "background.default",
+          position: "relative",
+        }}
       >
         <iframe
           ref={iframeRef}

--- a/packages/schemas/src/app-scaffold.ts
+++ b/packages/schemas/src/app-scaffold.ts
@@ -15,12 +15,33 @@ const APP_TSX = `// Read workspace data with the injected SDK once a data bindin
 //   const { data, loading, error } = useQuery("my_binding");
 //
 // Create bindings from the chat ("bind the revenue query") or the data panel.
+//
+// Theming: the runtime provides CSS variables (--background, --foreground,
+// --card, --border, --muted-foreground, --primary, --chart-1..5, --radius, …)
+// that switch with light/dark automatically — use var(--token) instead of
+// hardcoded colors. The page background/text are already wired up.
 
 export default function App() {
   return (
     <div style={{ fontFamily: "system-ui, sans-serif", padding: 24 }}>
       <h1>Hello from your Mako app</h1>
-      <p>Edit <code>src/App.tsx</code> and ask the assistant to build features.</p>
+      <div
+        style={{
+          background: "var(--card)",
+          color: "var(--card-foreground)",
+          border: "1px solid var(--border)",
+          borderRadius: "var(--radius)",
+          padding: 16,
+          maxWidth: 480,
+        }}
+      >
+        <p style={{ margin: 0 }}>
+          Edit <code>src/App.tsx</code> and ask the assistant to build features.
+        </p>
+        <p style={{ margin: "8px 0 0", color: "var(--muted-foreground)" }}>
+          This card follows the light/dark theme on its own.
+        </p>
+      </div>
     </div>
   );
 }
@@ -42,6 +63,29 @@ const { data, loading, error } = useQuery("my_binding");
 
 Queries execute server-side, scoped to your workspace — the app never sees
 database credentials.
+
+## Theming (light/dark)
+
+The app inherits its theme automatically: Mako's theme when opened inside the
+workspace, the OS preference when opened from a share link. The runtime injects
+ready-to-use CSS variables that switch between modes:
+
+\`--background\`, \`--foreground\`, \`--card\`, \`--card-foreground\`,
+\`--popover\`, \`--popover-foreground\`, \`--primary\`, \`--primary-foreground\`,
+\`--secondary\`, \`--secondary-foreground\`, \`--muted\`, \`--muted-foreground\`,
+\`--accent\`, \`--accent-foreground\`, \`--destructive\`,
+\`--destructive-foreground\`, \`--border\`, \`--input\`, \`--ring\`,
+\`--chart-1\`…\`--chart-5\`, \`--radius\`
+
+Use \`var(--token)\` instead of hardcoded colors (works in inline styles,
+CSS-in-JS, and SVG/chart \`fill\`/\`stroke\`). The page background and text are
+pre-wired. When code needs the literal mode (e.g. a chart library option):
+
+\`\`\`tsx
+import { useTheme } from "@mako/app-sdk";
+
+const { theme } = useTheme(); // "light" | "dark"
+\`\`\`
 `;
 
 export const DEFAULT_APP_SCAFFOLD_FILES: AppFile[] = [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

User-built React apps render in a sandboxed `<iframe srcdoc>` (opaque origin), so they can't see the host's MUI theme or CSS variables — every app was effectively light-only unless the user hand-rolled theming. Dashboards already follow dark mode because they render in the host DOM.

## Approach: a theme contract owned by the preview runtime

Neither the user nor the agent should have to "build dark mode support":

- **Runtime-injected design tokens** — the preview bootstrap injects shadcn-named CSS variables (`--background`, `--card`, `--border`, `--muted-foreground`, `--primary`, `--chart-1..5`, `--radius`, …) with the same palette as the Mako shell; light values on `:root`, dark on `:root.dark`. Tokens are **resolved colors**, so app code writes `var(--background)` directly (inline styles, CSS-in-JS, SVG `fill`/`stroke`). `body` background/text and `color-scheme` are pre-wired ⇒ apps are dark-mode-correct with zero theme code.
- **Embedded in Mako ⇒ inherit the host theme** — `AppRenderer` seeds the srcdoc with the current `effectiveMode` and pushes toggles via a new `mako-app:set-theme` message, so the (slow, Babel-compiled) preview is **never rebuilt** on a theme switch. A re-post on `ready` covers toggles that race the boot.
- **Standalone ⇒ inherit the system** — with no explicit theme the bootstrap follows `prefers-color-scheme` (with a live change listener). The `/share/:token` viewer passes its `effectiveMode` through, which for anonymous visitors *is* the system preference (ThemeProvider default `"system"`).
- **SDK escape hatch** — `@mako/app-sdk` gains `useTheme()` → `{ theme: "light" | "dark" }` (live-updating) for chart configs that need a literal mode.
- **Agent bootstrapping** — the new-app scaffold demonstrates the token idiom, and the `apps` system skill gets a short "Theming & dark mode" section with one rule: use `var(--token)`, never hardcode surface/text/border colors. No base-prompt bloat.

Also fixed: the iframe self-capture (agent screenshots) defaulted to a white backdrop — it now defaults to the computed `--background`; both preview hosts had a hardcoded `#fff` frame around the iframe, now `background.default`.

No schema/API/DB changes — theme is runtime state, never persisted.

## Testing

- Unit: 3 new tests in `preview.test.ts` (token CSS, payload theme embedding, bootstrap wiring); the existing `vm.Script` parse test guards the modified bootstrap. Full app vitest suite: 124 passed.
- Gates: `@mako/schemas` build, `app` typecheck + lint, `api` lint — all green.
- E2E (headless Chrome against the dev stack, real login → API-created app → preview boot → emulated `prefers-color-scheme`):
  - Embedded preview flipped white `[255,255,255]` → dark `[9,9,11]` live, with **no rebuild** (srcdoc unchanged, no "Building preview…"); `useTheme()` text flipped to `dark`; chart palette swapped.
  - Standalone share link in a fresh incognito context followed the dark system preference and flipped back live.
  - Self-capture of a dark app returned a dark PNG (corner pixel `[9,9,11]`).
  - A pre-existing app (old scaffold, zero theme code) renders cleanly in dark mode.

| Embedded — light | Embedded — dark (live flip, no rebuild) |
| --- | --- |
| [App preview in light mode](https://cursor.com/agents/bc-0bd69d42-ac7c-482e-bdf4-6df74eabc378/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F1-app-light.png) | [App preview in dark mode](https://cursor.com/agents/bc-0bd69d42-ac7c-482e-bdf4-6df74eabc378/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F2-app-dark.png) |

| Standalone share — dark system pref | Standalone share — light system pref |
| --- | --- |
| [Share page dark](https://cursor.com/agents/bc-0bd69d42-ac7c-482e-bdf4-6df74eabc378/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F3-share-dark.png) | [Share page light](https://cursor.com/agents/bc-0bd69d42-ac7c-482e-bdf4-6df74eabc378/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F4-share-light.png) |

<details><summary>Legacy app (zero theme code) in dark mode</summary>
[Legacy app dark](https://cursor.com/agents/bc-0bd69d42-ac7c-482e-bdf4-6df74eabc378/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F6-legacy-app-dark.png)
</details>

## Accepted tradeoff

Existing apps with hardcoded colors keep working (their styles paint over the new body defaults). The one edge: an app that relied on default black-on-white body text while only partially setting backgrounds may show low-contrast text in dark mode until the agent next touches it (the skill now makes it migrate to tokens).


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0bd69d42-ac7c-482e-bdf4-6df74eabc378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0bd69d42-ac7c-482e-bdf4-6df74eabc378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

