### PR TITLE
Highlight active explorer rows + clickable breadcrumbs & tab-switch reveal

### DIFF
--- a/.cursor/rules/71-tab-entities.mdc
+++ b/.cursor/rules/71-tab-entities.mdc
@@ -1,6 +1,6 @@
 ---
-globs: app/src/store/lib/types.ts,app/src/components/UrlSync.tsx,app/src/components/EntityBreadcrumbs.tsx,app/src/components/Editor.tsx,app/src/lib/tab-routing.ts
-description: Invariants for tab entities — unique URLs, breadcrumbs, page titles
+globs: app/src/store/lib/types.ts,app/src/components/UrlSync.tsx,app/src/components/EntityBreadcrumbs.tsx,app/src/components/Editor.tsx,app/src/lib/tab-routing.ts,app/src/lib/explorer-reveal.ts,app/src/components/ResourceTree.tsx
+description: Invariants for tab entities — unique URLs, breadcrumbs, page titles, sidebar highlight + reveal
 ---
 
 # Tab entities: URLs, breadcrumbs, page titles
@@ -37,6 +37,37 @@ Never "fix" a compile error from these guards by adding a `default` case,
 casting, or returning `null` without a deliberate decision. `null` is only
 acceptable for kinds that genuinely cannot be deep-linked (currently only
 the legacy `members` kind).
+
+## Sidebar highlight + reveal (do not weaken)
+
+Every entity that opens in a tab and has a sidebar explorer row MUST:
+
+1. **Highlight its row when focused.** The explorer passes `activeItemId` to
+   `ResourceTree`. `ResourceTree` decides the highlight via the single helper
+   [isSidebarRowActive](mdc:app/src/components/resource-tree/utils.ts) and
+   applies it to **both file and folder rows**. Apps and Postgres tables open
+   from a *directory* row, so folder rows must respect `activeItemId` too — a
+   past regression highlighted files but not folders, leaving open apps
+   un-highlighted. Guarded by `resource-tree/utils.test.ts` (a structural test
+   asserts folder rows use `isSelectedLocation || isActive`).
+2. **Be reachable by reveal.** [explorer-reveal.ts](mdc:app/src/lib/explorer-reveal.ts)
+   maps a tab → `{ explorer, nodeId }`, where `nodeId` MUST equal the id the
+   owning explorer builds for that `ResourceTree` node. The switch is
+   exhaustive over `TabKind` (return `null` for kinds with no sidebar home).
+   `tabUrlPath`/breadcrumbs and this mapping must agree on the owning explorer.
+
+Reveal flow: producers (the tab-switch effect in `App.tsx`, clickable
+breadcrumbs in `EntityBreadcrumbs.tsx`) call
+`useExplorerRevealStore.requestReveal(explorer, nodeId)`. Each explorer
+subscribes with `selectRevealFor(<explorer>)` and threads `revealNodeId` /
+`revealNonce` into its `ResourceTree`, which expands ancestors and scrolls the
+row into view. Tab-switch auto-scroll only fires when the owning explorer is
+already on screen; breadcrumb clicks also switch the explorer first.
+
+When adding a new tab kind with a sidebar row, add its case to
+`tabRevealTarget`, make sure the explorer passes `activeItemId` +
+`revealNodeId`/`revealNonce`, and (if it uses encoded node ids like apps)
+source the separators from `explorer-reveal.ts` so reveal ids never drift.
 
 ## Checklist for adding a new tab kind
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -27,6 +27,8 @@ import {
   useUIStore,
 } from "./store/uiStore";
 import { useConsoleStore } from "./store/consoleStore";
+import { useExplorerRevealStore } from "./store/explorerRevealStore";
+import { tabRevealTarget } from "./lib/explorer-reveal";
 import Chat from "./components/Chat";
 import DatabaseExplorer, {
   type CollectionInfo,
@@ -102,6 +104,8 @@ type SidePane = "left" | "right";
 function MainApp() {
   const activeView = useUIStore(state => state.leftPane);
   const leftPaneOpen = useUIStore(state => state.leftPaneOpen);
+  const activeTabId = useConsoleStore(state => state.activeTabId);
+  const requestReveal = useExplorerRevealStore(state => state.requestReveal);
   const rightPaneOpen = useUIStore(state => state.rightPaneOpen);
   const closeLeftPane = useUIStore(state => state.closeLeftPane);
   const closeRightPane = useUIStore(state => state.closeRightPane);
@@ -417,6 +421,20 @@ function MainApp() {
     },
     [openOrFocusConsoleTab],
   );
+
+  // When the focused tab changes, scroll the sidebar explorer to its row —
+  // but only when that explorer is already the one on screen. If the user is
+  // looking at a different explorer (or the pane is collapsed), leave it as is.
+  useEffect(() => {
+    if (!activeTabId) return;
+    const tab = useConsoleStore.getState().tabs[activeTabId];
+    const target = tabRevealTarget(tab);
+    if (!target) return;
+    const { leftPane, leftPaneOpen: paneOpen } = useUIStore.getState();
+    if (paneOpen && leftPane === target.explorer) {
+      requestReveal(target.explorer, target.nodeId);
+    }
+  }, [activeTabId, requestReveal]);
 
   // Left pane content renderer
   const renderLeftPane = () => {

--- a/app/src/components/AppsExplorer.tsx
+++ b/app/src/components/AppsExplorer.tsx
@@ -37,7 +37,16 @@ import { useAuth } from "../contexts/auth-context";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useConsoleStore } from "../store/consoleStore";
 import { useExplorerStore } from "../store/explorerStore";
+import {
+  useExplorerRevealStore,
+  selectRevealFor,
+} from "../store/explorerRevealStore";
 import { useAppStore, type AppListItem } from "../store/appStore";
+import {
+  APP_FILE_SEP as FILE_SEP,
+  APP_DIR_SEP as DIR_SEP,
+  APP_BINDING_SEP as BINDING_SEP,
+} from "../lib/explorer-reveal";
 import {
   focusAppTab,
   focusAppFileTab,
@@ -54,9 +63,7 @@ const EMPTY_LIST: AppListItem[] = [];
 // Folder node:  "<appId>::dir::<dirPath>"
 // File node:    "<appId>::file::<filePath>"
 // Binding node: "<appId>::binding::<bindingId>"
-const FILE_SEP = "::file::";
-const DIR_SEP = "::dir::";
-const BINDING_SEP = "::binding::";
+// (separators are shared with lib/explorer-reveal so reveal ids never drift)
 const DATA_SOURCES_DIR = "__datasources";
 
 function dirname(path: string): string {
@@ -199,6 +206,8 @@ export function AppsExplorer() {
     }
     return null;
   }, [activeTab]);
+
+  const reveal = useExplorerRevealStore(selectRevealFor("apps"));
 
   const expandedFolders = useExplorerStore(s => s.app.expandedFolders);
   const toggleAppFolder = useExplorerStore(s => s.toggleAppFolder);
@@ -616,6 +625,8 @@ export function AppsExplorer() {
             mode="sidebar"
             searchQuery={searchQuery}
             activeItemId={activeItemId}
+            revealNodeId={reveal?.nodeId}
+            revealNonce={reveal?.nonce}
             getItemIcon={getItemIcon}
             getRightAdornment={getRightAdornment}
             getContextMenuItems={getContextMenuItems}

--- a/app/src/components/ConnectorExplorer.tsx
+++ b/app/src/components/ConnectorExplorer.tsx
@@ -22,6 +22,10 @@ import {
 import { useWorkspace } from "../contexts/workspace-context";
 import { useConsoleStore } from "../store/consoleStore";
 import { useDataSourceEntitiesStore } from "../store/dataSourceEntitiesStore";
+import {
+  useExplorerRevealStore,
+  selectRevealFor,
+} from "../store/explorerRevealStore";
 import ResourceTree, {
   type ResourceTreeNode,
   type ResourceTreeSection,
@@ -166,6 +170,8 @@ function ConnectorExplorer() {
     return tab?.content ?? null;
   }, [consoleTabs, activeConsoleId]);
 
+  const reveal = useExplorerRevealStore(selectRevealFor("connectors"));
+
   const actions = (
     <>
       <Tooltip title="Add Connector">
@@ -208,6 +214,8 @@ function ConnectorExplorer() {
               mode="sidebar"
               searchQuery={searchQuery}
               activeItemId={activeConnectorId || undefined}
+              revealNodeId={reveal?.nodeId}
+              revealNonce={reveal?.nonce}
               getItemIcon={getItemIcon}
               hideFolderIcon
               isFolderExpanded={() => true}

--- a/app/src/components/ConsoleTree.tsx
+++ b/app/src/components/ConsoleTree.tsx
@@ -10,6 +10,10 @@ import {
 import { Eye as EyeIcon, SquareTerminal as ConsoleIcon } from "lucide-react";
 import { Box, Tooltip } from "@mui/material";
 import { useExplorerStore } from "../store/explorerStore";
+import {
+  useExplorerRevealStore,
+  selectRevealFor,
+} from "../store/explorerRevealStore";
 import { useConsoleStore } from "../store/consoleStore";
 import { useSchemaStore } from "../store/schemaStore";
 import { useDatabaseCatalogStore } from "../store/databaseCatalogStore";
@@ -141,6 +145,10 @@ function ConsoleTreeInner(
   const resortItem = useConsoleTreeStore(state => state.resortItem);
 
   const activeTabId = useConsoleStore(state => state.activeTabId);
+
+  // Only the sidebar tree honors reveal requests; pickers ignore them.
+  const revealRequest = useExplorerRevealStore(selectRevealFor("consoles"));
+  const reveal = mode === "sidebar" ? revealRequest : null;
 
   const storeExpandedFolders = useExplorerStore(
     state => state.console.expandedFolders,
@@ -429,6 +437,8 @@ function ConsoleTreeInner(
       sections={sections}
       mode={mode}
       activeItemId={mode === "sidebar" ? activeTabId : null}
+      revealNodeId={reveal?.nodeId}
+      revealNonce={reveal?.nonce}
       searchQuery={searchQuery}
       getItemIcon={getResourceItemIcon}
       showFiles={showFiles}

--- a/app/src/components/DashboardsExplorer.tsx
+++ b/app/src/components/DashboardsExplorer.tsx
@@ -26,6 +26,10 @@ import { useConsoleStore } from "../store/consoleStore";
 import { useDashboardStore } from "../store/dashboardStore";
 import { useDashboardTreeStore } from "../store/dashboardTreeStore";
 import { useExplorerStore } from "../store/explorerStore";
+import {
+  useExplorerRevealStore,
+  selectRevealFor,
+} from "../store/explorerRevealStore";
 import { focusDashboardTab } from "../dashboard-runtime/shell";
 import type { Dashboard } from "../dashboard-runtime/types";
 import { computeDashboardStateHash } from "../utils/stateHash";
@@ -93,6 +97,8 @@ export function DashboardsExplorer() {
     (key: string) => !!dashboardExpandedFolders[key],
     [dashboardExpandedFolders],
   );
+
+  const reveal = useExplorerRevealStore(selectRevealFor("dashboards"));
 
   const { openTab, setActiveTab, activeTabId, tabs } = useConsoleStore();
 
@@ -337,6 +343,8 @@ export function DashboardsExplorer() {
             mode="sidebar"
             searchQuery={searchQuery}
             activeItemId={activeDashboardTabId}
+            revealNodeId={reveal?.nodeId}
+            revealNonce={reveal?.nonce}
             getItemIcon={getItemIcon}
             enableDragDrop
             enableRename

--- a/app/src/components/EntityBreadcrumbs.tsx
+++ b/app/src/components/EntityBreadcrumbs.tsx
@@ -5,6 +5,9 @@ import { useConsoleStore } from "../store/consoleStore";
 import { useSchemaStore } from "../store/schemaStore";
 import { useAppStore } from "../store/appStore";
 import { useDashboardStore } from "../store/dashboardStore";
+import { useUIStore } from "../store/uiStore";
+import { useExplorerRevealStore } from "../store/explorerRevealStore";
+import { tabRevealTarget } from "../lib/explorer-reveal";
 import { useWorkspace } from "../contexts/workspace-context";
 import { SECTION_LABELS } from "../pages/settings/sections";
 import type { ConsoleTab, TabKind } from "../store/lib/types";
@@ -136,6 +139,21 @@ function EntityBreadcrumbs({ tabId, trailing }: EntityBreadcrumbsProps) {
   const tab = useConsoleStore(s => s.tabs[tabId]);
   const { currentWorkspace } = useWorkspace();
 
+  const setLeftPane = useUIStore(s => s.setLeftPane);
+  const openLeftPane = useUIStore(s => s.openLeftPane);
+  const requestReveal = useExplorerRevealStore(s => s.requestReveal);
+
+  // The breadcrumb is clickable when its entity has a sidebar home: clicking
+  // switches to that explorer (even from a different one) and scrolls the
+  // entity's row into view.
+  const revealTarget = tabRevealTarget(tab);
+  const handleNavigateToExplorer = React.useCallback(() => {
+    if (!revealTarget) return;
+    setLeftPane(revealTarget.explorer);
+    openLeftPane();
+    requestReveal(revealTarget.explorer, revealTarget.nodeId);
+  }, [revealTarget, setLeftPane, openLeftPane, requestReveal]);
+
   const connectionId = tab?.connectionId;
   const connectionName = useSchemaStore(s => {
     if (tab?.kind !== "table-data" || !currentWorkspace || !connectionId) {
@@ -223,7 +241,10 @@ function EntityBreadcrumbs({ tabId, trailing }: EntityBreadcrumbsProps) {
               />
             )}
             <Box
-              component="span"
+              component={revealTarget ? "button" : "span"}
+              type={revealTarget ? "button" : undefined}
+              onClick={revealTarget ? handleNavigateToExplorer : undefined}
+              title={revealTarget ? "Reveal in explorer" : undefined}
               sx={{
                 overflow: "hidden",
                 textOverflow: "ellipsis",
@@ -231,6 +252,28 @@ function EntityBreadcrumbs({ tabId, trailing }: EntityBreadcrumbsProps) {
                 fontStyle: segment.italic ? "italic" : "normal",
                 color: isLast ? "text.primary" : "inherit",
                 fontWeight: isLast ? 500 : 400,
+                ...(revealTarget
+                  ? {
+                      cursor: "pointer",
+                      appearance: "none",
+                      background: "none",
+                      border: "none",
+                      p: 0,
+                      m: 0,
+                      font: "inherit",
+                      color: isLast ? "text.primary" : "inherit",
+                      maxWidth: "100%",
+                      "&:hover": {
+                        textDecoration: "underline",
+                        color: "text.primary",
+                      },
+                      "&:focus-visible": {
+                        outline: "1px solid",
+                        outlineColor: "primary.main",
+                        borderRadius: 0.5,
+                      },
+                    }
+                  : {}),
               }}
             >
               {segment.label}

--- a/app/src/components/FlowsExplorer.tsx
+++ b/app/src/components/FlowsExplorer.tsx
@@ -25,6 +25,10 @@ import type {
 import { useWorkspace } from "../contexts/workspace-context";
 import { useFlowStore } from "../store/flowStore";
 import { useConsoleStore } from "../store/consoleStore";
+import {
+  useExplorerRevealStore,
+  selectRevealFor,
+} from "../store/explorerRevealStore";
 import ResourceTree, { type ResourceTreeNode } from "./ResourceTree";
 
 interface FlowTreeNode extends ResourceTreeNode {
@@ -253,6 +257,8 @@ export function FlowsExplorer() {
     return null;
   }, [activeTabId, tabs]);
 
+  const reveal = useExplorerRevealStore(selectRevealFor("flows"));
+
   const getItemIcon = useCallback((node: ResourceTreeNode) => {
     const flowNode = node as FlowTreeNode;
     if (flowNode.itemType === "scheduled-query") {
@@ -361,6 +367,8 @@ export function FlowsExplorer() {
             sections={sections}
             mode="sidebar"
             activeItemId={activeItemId}
+            revealNodeId={reveal?.nodeId}
+            revealNonce={reveal?.nonce}
             getItemIcon={getItemIcon}
             enableDragDrop={false}
             enableRename={false}

--- a/app/src/components/ResourceTree.tsx
+++ b/app/src/components/ResourceTree.tsx
@@ -66,6 +66,7 @@ const ICON_COL_WIDTH = 20;
 import {
   findNodeInSections,
   getFolderDropTargetId,
+  isSidebarRowActive,
   resolveTreeDropTarget,
 } from "./resource-tree/utils";
 import {
@@ -114,6 +115,16 @@ export interface ResourceTreeProps {
   mode?: "sidebar" | "picker";
   activeItemId?: string | null;
   searchQuery?: string;
+
+  /**
+   * Reveal request: the id of a node to expand-to and scroll into view. Pair
+   * it with `revealNonce` — the reveal runs whenever the nonce changes (so the
+   * same node can be revealed repeatedly, e.g. re-clicking a breadcrumb). The
+   * tree expands every ancestor folder, then scrolls the row into view,
+   * retrying briefly to accommodate lazily-loaded children (e.g. app files).
+   */
+  revealNodeId?: string | null;
+  revealNonce?: number;
 
   getItemIcon?: (
     node: ResourceTreeNode,
@@ -221,6 +232,8 @@ function ResourceTreeInner(
     mode = "sidebar",
     activeItemId,
     searchQuery = "",
+    revealNodeId,
+    revealNonce,
     getItemIcon,
     getRightAdornment,
     onLoadChildren,
@@ -266,6 +279,9 @@ function ResourceTreeInner(
   const [renamingItemId, setRenamingItemId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
   const renameInputRef = useRef<HTMLInputElement>(null);
+  // Scopes the reveal `querySelector` to this tree so we don't accidentally
+  // scroll an identically-id'd row in another tree (e.g. a picker dialog).
+  const rootRef = useRef<HTMLDivElement>(null);
 
   const [contextMenu, setContextMenu] = useState<{
     anchorPosition: { top: number; left: number };
@@ -902,6 +918,61 @@ function ResourceTreeInner(
     updateLocationSelection,
   ]);
 
+  // Reveal-to-node: expand ancestor folders and scroll the target row into
+  // view whenever `revealNonce` changes (e.g. a tab switch or breadcrumb
+  // click). `sections` is a dep so the reveal re-attempts once lazily-loaded
+  // children arrive (apps fetch their file tree on demand); the
+  // `revealDoneNonceRef` guard stops it from re-firing once the row is found,
+  // so later unrelated tree changes don't yank the scroll position.
+  const revealDoneNonceRef = useRef<number | undefined>(undefined);
+  useEffect(() => {
+    if (!revealNonce || !revealNodeId) return;
+    if (revealDoneNonceRef.current === revealNonce) return;
+
+    const location = findNodeLocation(revealNodeId);
+    if (location) {
+      const sectionNodes =
+        sections.find(section => section.key === location.sectionKey)?.nodes ??
+        [];
+      for (const expansionKey of findAncestorExpansionKeys(
+        sectionNodes,
+        revealNodeId,
+      )) {
+        onExpandFolder(expansionKey);
+      }
+      setSectionExpanded(prev =>
+        prev[location.sectionKey] === false
+          ? { ...prev, [location.sectionKey]: true }
+          : prev,
+      );
+    }
+
+    const escapeId =
+      typeof CSS !== "undefined" && typeof CSS.escape === "function"
+        ? CSS.escape(revealNodeId)
+        : revealNodeId.replace(/["\\]/g, "\\$&");
+    let cancelled = false;
+    const tryScroll = () => {
+      if (cancelled) return;
+      const el = rootRef.current?.querySelector(`[data-node-id="${escapeId}"]`);
+      if (el) {
+        el.scrollIntoView({ block: "nearest", behavior: "smooth" });
+        revealDoneNonceRef.current = revealNonce;
+        cancelled = true;
+      }
+    };
+    // Retry on a short ramp to cover render + lazy child fetch latency.
+    const timeouts = [0, 80, 200, 450, 900, 1600].map(delay =>
+      window.setTimeout(tryScroll, delay),
+    );
+
+    return () => {
+      cancelled = true;
+      timeouts.forEach(id => window.clearTimeout(id));
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [revealNonce, revealNodeId, sections]);
+
   const renderInlineRenameInput = (nodeId: string) => (
     <input
       ref={renameInputRef}
@@ -985,7 +1056,11 @@ function ResourceTreeInner(
       const isExpanded = node.isDirectory && isNodeExpanded(node);
       const isSelectedLocation =
         mode === "picker" && currentSelectedLocation === node.id;
-      const isActive = mode === "sidebar" && activeItemId === node.id;
+      const isActive = isSidebarRowActive({
+        mode,
+        activeItemId,
+        nodeId: node.id,
+      });
       const isRenaming = renamingItemId === node.id;
       const isDropTarget =
         dropTargetId === node.id ||
@@ -997,7 +1072,7 @@ function ResourceTreeInner(
           <ListItemButton
             key={node.id}
             data-node-id={node.id}
-            selected={isSelectedLocation}
+            selected={isSelectedLocation || isActive}
             onClick={event => {
               setFocusedNodeId(node.id);
               if (mode === "picker") {
@@ -1035,7 +1110,11 @@ function ResourceTreeInner(
               ...buildRowSx({
                 depth,
                 isDropTarget,
-                isSelected: isSelectedLocation,
+                // Folder rows must respect the sidebar active highlight too —
+                // entities like apps and Postgres tables open from a directory
+                // row (see isSidebarRowActive). Picker selection still wins via
+                // `isSelectedLocation`.
+                isSelected: isSelectedLocation || isActive,
               }),
               position: "sticky",
               // Stack ancestor headers: depth=1 sits just below the section
@@ -1052,7 +1131,7 @@ function ResourceTreeInner(
               // visually invisible against the surrounding tree at rest.
               // Selected / drop-target states from buildRowSx still win.
               backgroundColor:
-                isDropTarget || isSelectedLocation
+                isDropTarget || isSelectedLocation || isActive
                   ? undefined
                   : "background.default",
             }}
@@ -1483,9 +1562,11 @@ function ResourceTreeInner(
 
   return (
     <>
-      <React.Profiler id="ResourceTree.content" onRender={onRenderDebug}>
-        {content}
-      </React.Profiler>
+      <Box ref={rootRef} sx={{ display: "contents" }}>
+        <React.Profiler id="ResourceTree.content" onRender={onRenderDebug}>
+          {content}
+        </React.Profiler>
+      </Box>
 
       <Menu
         open={!!contextMenu}

--- a/app/src/components/ResourceTree.tsx
+++ b/app/src/components/ResourceTree.tsx
@@ -956,7 +956,9 @@ function ResourceTreeInner(
       if (cancelled) return;
       const el = rootRef.current?.querySelector(`[data-node-id="${escapeId}"]`);
       if (el) {
-        el.scrollIntoView({ block: "nearest", behavior: "smooth" });
+        // Center the revealed row vertically rather than nudging it just barely
+        // into view, so the focused entity lands near the middle of the panel.
+        el.scrollIntoView({ block: "center", behavior: "smooth" });
         revealDoneNonceRef.current = revealNonce;
         cancelled = true;
       }

--- a/app/src/components/resource-tree/utils.test.ts
+++ b/app/src/components/resource-tree/utils.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
 import {
   findAncestorPaths,
   findNodeInSections,
   flattenVisibleNodeIds,
   getFolderDropTargetId,
+  isSidebarRowActive,
   resolveTreeDropTarget,
   type ResourceTreeLikeNode,
   type ResourceTreeLikeSection,
@@ -82,6 +85,76 @@ describe("resource-tree utils", () => {
     });
 
     expect(visible).toEqual(["folder-a", "folder-b"]);
+  });
+
+  describe("isSidebarRowActive", () => {
+    it("matches the active node in sidebar mode", () => {
+      expect(
+        isSidebarRowActive({
+          mode: "sidebar",
+          activeItemId: "app-1",
+          nodeId: "app-1",
+        }),
+      ).toBe(true);
+    });
+
+    it("does not match a different node", () => {
+      expect(
+        isSidebarRowActive({
+          mode: "sidebar",
+          activeItemId: "app-1",
+          nodeId: "app-2",
+        }),
+      ).toBe(false);
+    });
+
+    it("never highlights in picker mode", () => {
+      expect(
+        isSidebarRowActive({
+          mode: "picker",
+          activeItemId: "app-1",
+          nodeId: "app-1",
+        }),
+      ).toBe(false);
+    });
+
+    it("returns false when there is no active item", () => {
+      expect(
+        isSidebarRowActive({
+          mode: "sidebar",
+          activeItemId: null,
+          nodeId: "app-1",
+        }),
+      ).toBe(false);
+      expect(
+        isSidebarRowActive({
+          mode: "sidebar",
+          activeItemId: undefined,
+          nodeId: "app-1",
+        }),
+      ).toBe(false);
+    });
+  });
+
+  // Structural regression guard: the highlight bug was that *folder* rows in
+  // ResourceTree ignored the sidebar active state, so an open app/table left
+  // its directory row un-highlighted. Both row types must derive `isActive`
+  // from `isSidebarRowActive` and feed it into the row's `selected` state.
+  describe("ResourceTree active-row highlight wiring", () => {
+    const source = fs.readFileSync(
+      path.resolve(__dirname, "../ResourceTree.tsx"),
+      "utf-8",
+    );
+
+    it("derives isActive from the shared helper", () => {
+      expect(source).toMatch(/const isActive = isSidebarRowActive\(/);
+    });
+
+    it("applies the active highlight to folder rows", () => {
+      // Folder row uses ListItemButton selected + buildRowSx isSelected.
+      expect(source).toMatch(/selected=\{isSelectedLocation \|\| isActive\}/);
+      expect(source).toMatch(/isSelected: isSelectedLocation \|\| isActive/);
+    });
   });
 
   it("resolves drops into sections and folders", () => {

--- a/app/src/components/resource-tree/utils.ts
+++ b/app/src/components/resource-tree/utils.ts
@@ -38,6 +38,30 @@ export type ResourceTreeDropResolution =
 export const getFolderDropTargetId = (folderId: string) =>
   `__folder_content_${folderId}`;
 
+/**
+ * Whether a sidebar tree row should render with the "active entity" highlight
+ * (i.e. its tab is the focused one).
+ *
+ * REGRESSION GUARD: this is the single source of truth for the sidebar
+ * active-row highlight and MUST be applied to BOTH folder and file rows in
+ * `ResourceTree`. Several entities open from a *directory* row — an app, a
+ * Postgres table/view (its caret browses the schema while its name opens the
+ * data tab) — so if folder rows skip this check, an open app/table leaves its
+ * sidebar row un-highlighted. A previous regression did exactly that for apps.
+ * See `ResourceTree.tsx` and `ResourceTree.highlight.test.ts`.
+ */
+export function isSidebarRowActive(options: {
+  mode: "sidebar" | "picker";
+  activeItemId: string | null | undefined;
+  nodeId: string;
+}): boolean {
+  return (
+    options.mode === "sidebar" &&
+    !!options.activeItemId &&
+    options.activeItemId === options.nodeId
+  );
+}
+
 export function findNodeById<TNode extends ResourceTreeLikeNode>(
   nodes: TNode[],
   id: string,

--- a/app/src/lib/explorer-reveal.test.ts
+++ b/app/src/lib/explorer-reveal.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+  APP_BINDING_SEP,
+  APP_FILE_SEP,
+  tabRevealTarget,
+} from "./explorer-reveal";
+import type { ConsoleTab } from "../store/lib/types";
+
+function makeTab(overrides: Partial<ConsoleTab>): ConsoleTab {
+  return {
+    id: "tab-1",
+    title: "Tab",
+    content: "",
+    isSaved: true,
+    ...overrides,
+  };
+}
+
+describe("tabRevealTarget", () => {
+  it("maps consoles to the consoles explorer by tab id", () => {
+    expect(tabRevealTarget(makeTab({ id: "c1", kind: "console" }))).toEqual({
+      explorer: "consoles",
+      nodeId: "c1",
+    });
+  });
+
+  it("treats an undefined kind as a console", () => {
+    expect(tabRevealTarget(makeTab({ id: "c2", kind: undefined }))).toEqual({
+      explorer: "consoles",
+      nodeId: "c2",
+    });
+  });
+
+  it("maps dashboards (and their data sources) to the dashboard row", () => {
+    expect(
+      tabRevealTarget(
+        makeTab({ kind: "dashboard", metadata: { dashboardId: "d1" } }),
+      ),
+    ).toEqual({ explorer: "dashboards", nodeId: "d1" });
+    expect(
+      tabRevealTarget(
+        makeTab({
+          kind: "dashboard-data-source",
+          metadata: { dashboardId: "d1", dataSourceId: "ds1" },
+        }),
+      ),
+    ).toEqual({ explorer: "dashboards", nodeId: "d1" });
+  });
+
+  it("maps apps, app files and bindings using the shared separators", () => {
+    expect(
+      tabRevealTarget(makeTab({ kind: "app", metadata: { appId: "a1" } })),
+    ).toEqual({ explorer: "apps", nodeId: "a1" });
+    expect(
+      tabRevealTarget(
+        makeTab({
+          kind: "app-file",
+          metadata: { appId: "a1", path: "src/App.tsx" },
+        }),
+      ),
+    ).toEqual({ explorer: "apps", nodeId: `a1${APP_FILE_SEP}src/App.tsx` });
+    expect(
+      tabRevealTarget(
+        makeTab({
+          kind: "app-binding",
+          metadata: { appId: "a1", bindingId: "b1" },
+        }),
+      ),
+    ).toEqual({ explorer: "apps", nodeId: `a1${APP_BINDING_SEP}b1` });
+  });
+
+  it("maps connectors by their content id", () => {
+    expect(
+      tabRevealTarget(makeTab({ kind: "connectors", content: "conn-1" })),
+    ).toEqual({ explorer: "connectors", nodeId: "conn-1" });
+  });
+
+  it("maps flow editors by flow id", () => {
+    expect(
+      tabRevealTarget(
+        makeTab({ kind: "flow-editor", metadata: { flowId: "f1" } }),
+      ),
+    ).toEqual({ explorer: "flows", nodeId: "f1" });
+  });
+
+  it("returns null for kinds without a stable sidebar row", () => {
+    expect(
+      tabRevealTarget(
+        makeTab({
+          kind: "table-data",
+          connectionId: "x",
+          metadata: { schema: "public", table: "t" },
+        }),
+      ),
+    ).toBeNull();
+    expect(tabRevealTarget(makeTab({ kind: "settings" }))).toBeNull();
+    expect(tabRevealTarget(makeTab({ kind: "plan" }))).toBeNull();
+    expect(tabRevealTarget(null)).toBeNull();
+  });
+
+  it("returns null when required metadata is missing", () => {
+    expect(tabRevealTarget(makeTab({ kind: "app", metadata: {} }))).toBeNull();
+    expect(
+      tabRevealTarget(makeTab({ kind: "dashboard", metadata: {} })),
+    ).toBeNull();
+  });
+});

--- a/app/src/lib/explorer-reveal.ts
+++ b/app/src/lib/explorer-reveal.ts
@@ -1,0 +1,108 @@
+/**
+ * Explorer reveal mapping — single source of truth for "which sidebar explorer
+ * owns a tab, and what tree-node id should be highlighted / scrolled to".
+ *
+ * Used by:
+ *  - the tab-switch auto-scroll effect (App.tsx), which reveals the focused
+ *    tab's row *only* when its owning explorer is already open;
+ *  - clickable breadcrumbs (EntityBreadcrumbs.tsx), which switch to the owning
+ *    explorer and then reveal the row.
+ *
+ * The `nodeId`s here MUST match the ids each explorer builds for its
+ * `ResourceTree` nodes — see the per-case notes. The app separators are
+ * exported and imported by `AppsExplorer` so the two never drift.
+ */
+import type { ConsoleTab, TabKind } from "../store/lib/types";
+
+// App ResourceTree node-id encoding (kept in sync with AppsExplorer, which
+// imports these). App node: "<appId>"; file: "<appId>::file::<path>";
+// binding: "<appId>::binding::<bindingId>".
+export const APP_FILE_SEP = "::file::";
+export const APP_DIR_SEP = "::dir::";
+export const APP_BINDING_SEP = "::binding::";
+
+/** Left-pane explorers that support reveal/scroll-to-row. */
+export type RevealExplorer =
+  | "consoles"
+  | "dashboards"
+  | "apps"
+  | "connectors"
+  | "flows";
+
+export interface ExplorerRevealTarget {
+  explorer: RevealExplorer;
+  /** Id of the `ResourceTree` node to expand-to, highlight and scroll into view. */
+  nodeId: string;
+}
+
+/**
+ * Resolve the explorer + tree-node a tab lives in, or `null` for tabs that
+ * have no sidebar home (e.g. settings, plans) or that can't be addressed yet.
+ *
+ * The switch is exhaustive over `TabKind` so adding a new kind forces a
+ * deliberate decision here (mirrors the tab-routing / breadcrumb guards).
+ */
+export function tabRevealTarget(
+  tab: ConsoleTab | null | undefined,
+): ExplorerRevealTarget | null {
+  if (!tab) return null;
+  const kind: NonNullable<TabKind> = tab.kind ?? "console";
+  const meta = tab.metadata ?? {};
+
+  switch (kind) {
+    case "console":
+      // Console rows in the Consoles explorer use the console (tab) id.
+      return { explorer: "consoles", nodeId: tab.id };
+    case "dashboard": {
+      const id = meta.dashboardId as string | undefined;
+      return id ? { explorer: "dashboards", nodeId: id } : null;
+    }
+    case "dashboard-data-source": {
+      // Data-source tabs live under their dashboard — reveal the dashboard row.
+      const id = meta.dashboardId as string | undefined;
+      return id ? { explorer: "dashboards", nodeId: id } : null;
+    }
+    case "app": {
+      const appId = meta.appId as string | undefined;
+      return appId ? { explorer: "apps", nodeId: appId } : null;
+    }
+    case "app-file": {
+      const appId = meta.appId as string | undefined;
+      const path = meta.path as string | undefined;
+      return appId && path
+        ? { explorer: "apps", nodeId: `${appId}${APP_FILE_SEP}${path}` }
+        : null;
+    }
+    case "app-binding": {
+      const appId = meta.appId as string | undefined;
+      const bindingId = meta.bindingId as string | undefined;
+      return appId && bindingId
+        ? { explorer: "apps", nodeId: `${appId}${APP_BINDING_SEP}${bindingId}` }
+        : null;
+    }
+    case "connectors": {
+      // Connector explorer rows are keyed by connector id, stored in `content`.
+      const id = typeof tab.content === "string" ? tab.content : undefined;
+      return id ? { explorer: "connectors", nodeId: id } : null;
+    }
+    case "flow-editor": {
+      const flowId = meta.flowId as string | undefined;
+      return flowId ? { explorer: "flows", nodeId: flowId } : null;
+    }
+    case "table-data":
+      // Database explorer node ids depend on the (lazily-loaded) schema tree,
+      // so there is no stable reveal id to scroll to.
+      return null;
+    case "plan":
+    case "settings":
+    case "members":
+      // No sidebar tree row.
+      return null;
+    default: {
+      // Compile-time exhaustiveness: a new TabKind must be handled above.
+      const exhaustivenessCheck: never = kind;
+      void exhaustivenessCheck;
+      return null;
+    }
+  }
+}

--- a/app/src/store/explorerRevealStore.ts
+++ b/app/src/store/explorerRevealStore.ts
@@ -1,0 +1,49 @@
+/**
+ * Explorer reveal store
+ *
+ * Tiny cross-component channel for "scroll the sidebar explorer to this row".
+ * A producer (tab-switch effect, clickable breadcrumb) calls `requestReveal`;
+ * the matching explorer reads the request and threads `revealNodeId` /
+ * `revealNonce` into its `ResourceTree`, which expands ancestors and scrolls
+ * the row into view. The monotonically-increasing `nonce` lets the same node
+ * be revealed repeatedly (e.g. re-clicking a breadcrumb).
+ *
+ * Not persisted — it's ephemeral UI intent.
+ */
+import { create } from "zustand";
+import type { RevealExplorer } from "../lib/explorer-reveal";
+
+export interface ExplorerRevealRequest {
+  explorer: RevealExplorer;
+  nodeId: string;
+  nonce: number;
+}
+
+interface ExplorerRevealStore {
+  request: ExplorerRevealRequest | null;
+  requestReveal: (explorer: RevealExplorer, nodeId: string) => void;
+}
+
+export const useExplorerRevealStore = create<ExplorerRevealStore>()(
+  (set, get) => ({
+    request: null,
+    requestReveal: (explorer, nodeId) =>
+      set({
+        request: {
+          explorer,
+          nodeId,
+          nonce: (get().request?.nonce ?? 0) + 1,
+        },
+      }),
+  }),
+);
+
+/**
+ * Selector factory: returns the current reveal request only when it targets
+ * `explorer`, else `null`. Lets each explorer subscribe to just its own
+ * requests without re-rendering on unrelated reveals.
+ */
+export const selectRevealFor =
+  (explorer: RevealExplorer) =>
+  (state: ExplorerRevealStore): ExplorerRevealRequest | null =>
+    state.request && state.request.explorer === explorer ? state.request : null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves sidebar navigation in three ways requested in the task:

1. **Fix app-row highlight regression.** When an app is open and focused, its row in the Apps explorer is now highlighted. The bug was that `ResourceTree` only applied the sidebar `activeItemId` highlight to *file* rows; apps (and Postgres tables) open from a *directory* row, so their row stayed un-highlighted. Folder rows now respect the active state via a single shared helper `isSidebarRowActive`.

2. **Clickable breadcrumbs.** Every breadcrumb segment in `EntityBreadcrumbs` is now clickable. Clicking switches to the entity's owning explorer (even from a different one) and scrolls its row into view.

3. **Auto-scroll explorer to the focused tab on tab switch** — but only when that explorer is already on screen. If the user is looking at a different explorer (or the pane is collapsed), nothing changes.

The reveal **centers** the focused row vertically (`scrollIntoView({ block: "center" })`) — it strives to place the entity in the middle of the panel height, clamping near an edge only when the row is close to the start/end of the list.

## How it works

- New `app/src/lib/explorer-reveal.ts` maps a tab → `{ explorer, nodeId }` (exhaustive over `TabKind`). App node-id separators live here so the Apps explorer and the reveal mapping never drift.
- New `app/src/store/explorerRevealStore.ts` is a tiny ephemeral channel: producers call `requestReveal(explorer, nodeId)`; each explorer subscribes via `selectRevealFor(...)` and threads `revealNodeId`/`revealNonce` into its `ResourceTree`.
- `ResourceTree` gains reveal support: expand ancestor folders + scroll the row to the vertical center, retrying briefly to cover lazily-loaded children (e.g. app files).
- Producers: tab-switch effect in `App.tsx` (gated on `leftPane === target.explorer`) and clickable breadcrumbs in `EntityBreadcrumbs.tsx` (also switches the explorer first).

## Regression guard

- `isSidebarRowActive` is the single source of truth for the highlight, used by both file and folder rows.
- `resource-tree/utils.test.ts` adds unit tests for the helper **and** a structural test asserting folder rows wire in `isActive`.
- `explorer-reveal.test.ts` covers the tab→explorer mapping.
- Rule `71-tab-entities.mdc` documents the highlight + reveal invariants and the checklist for new tab kinds.

## Walkthrough

Clickable breadcrumb switches the explorer from Databases to Apps:
[breadcrumb_click_switches_databases_to_apps.mp4](https://cursor.com/agents/bc-1de72389-57e7-415c-8e18-e61651e0c245/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbreadcrumb_click_switches_databases_to_apps.mp4)

Switching tabs while a *different* explorer is open leaves it unchanged:
[other_explorer_unchanged_on_tab_switch.mp4](https://cursor.com/agents/bc-1de72389-57e7-415c-8e18-e61651e0c245/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fother_explorer_unchanged_on_tab_switch.mp4)

Focused app row highlighted in the Apps explorer:
[App row highlight](https://cursor.com/agents/bc-1de72389-57e7-415c-8e18-e61651e0c245/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_row_highlight.webp)

Reveal centers the focused row vertically — before (highlighted row pinned at the bottom edge) vs after the reveal (highlighted row moved to the middle of the panel):
[Before: focused row at bottom](https://cursor.com/agents/bc-1de72389-57e7-415c-8e18-e61651e0c245/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freveal_centers_before_row_at_bottom.webp)
[After: focused row centered](https://cursor.com/agents/bc-1de72389-57e7-415c-8e18-e61651e0c245/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freveal_centers_after_row_centered.webp)

## Testing

- `pnpm --filter app run typecheck`
- `pnpm --filter app run test:unit`
- `pnpm --filter app run lint`
- Manual GUI testing in the running app (evidence above).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1de72389-57e7-415c-8e18-e61651e0c245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1de72389-57e7-415c-8e18-e61651e0c245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

