### PR TITLE
docs: document unified Google-style sharing (collaborators, general access, public links)

### DIFF
--- a/docs/src/content/docs/api-reference.md
+++ b/docs/src/content/docs/api-reference.md
@@ -101,6 +101,11 @@ The legacy unauthenticated `POST /api/execute` and `POST /api/run/:path` endpoin
 | `POST` | `/api/workspaces/:wid/consoles/:id/schedule/run` | Trigger a scheduled console immediately (admin only) |
 | `GET` | `/api/workspaces/:wid/consoles/:id/schedule/runs` | List scheduled run history (admin only) |
 | `GET` | `/api/workspaces/:wid/scheduled-queries` | List scheduled consoles in the workspace (admin only) |
+| `GET`    | `/api/workspaces/:wid/consoles/:id/collaborators`           | List per-user collaborators                  |
+| `POST`   | `/api/workspaces/:wid/consoles/:id/collaborators`           | Add/update a collaborator (`{ userId, role }`; owner/admin only) |
+| `PATCH`  | `/api/workspaces/:wid/consoles/:id/collaborators/:userId`   | Change a collaborator's role (owner/admin only) |
+| `DELETE` | `/api/workspaces/:wid/consoles/:id/collaborators/:userId`   | Remove a collaborator (owner/admin only)     |
+| `PATCH`  | `/api/workspaces/:wid/consoles/:id/sharing`                 | Update general access (`{ access, workspaceRole }`; owner/admin only) |
 
 See [Console](/console/) for full API documentation with examples. Scheduled query endpoints require workspace admin access and use the same session/API-key authentication as other workspace endpoints.
 
@@ -267,8 +272,14 @@ All endpoints require authentication and workspace access. Agent-side CRUD is av
 | `DELETE` | `/api/workspaces/:wid/dashboards/:did`                           | Delete dashboard                     |
 | `POST`   | `/api/workspaces/:wid/dashboards/:did/duplicate`                 | Duplicate a dashboard                |
 | `GET`    | `/api/workspaces/:wid/dashboards/:did/collaborators`             | List per-user collaborators                  |
-| `POST`   | `/api/workspaces/:wid/dashboards/:did/collaborators`             | Add a collaborator (`{ userId }`, `editor` role; owner/admin only) |
+| `POST`   | `/api/workspaces/:wid/dashboards/:did/collaborators`             | Add/update a collaborator (`{ userId, role }`, role `viewer`\|`editor`; owner/admin only) |
+| `PATCH`  | `/api/workspaces/:wid/dashboards/:did/collaborators/:userId`     | Change a collaborator's role (owner/admin only) |
 | `DELETE` | `/api/workspaces/:wid/dashboards/:did/collaborators/:userId`     | Remove a collaborator (owner/admin only)     |
+| `PATCH`  | `/api/workspaces/:wid/dashboards/:did/sharing`                   | Update general access (`{ access, workspaceRole }`; owner/admin only) |
+| `POST`   | `/api/workspaces/:wid/dashboards/:did/public-share`             | Enable/create a public link (`{ password? }`; owner/admin only) |
+| `GET`    | `/api/workspaces/:wid/dashboards/:did/public-share/password`    | Reveal the public-link password (owner/admin only) |
+| `PATCH`  | `/api/workspaces/:wid/dashboards/:did/public-share`            | Update password / rotate token / rename slug (owner/admin only) |
+| `DELETE` | `/api/workspaces/:wid/dashboards/:did/public-share`            | Disable the public link (owner/admin only)   |
 
 ### Dashboard Folders
 
@@ -287,6 +298,18 @@ All endpoints require authentication and workspace access. Agent-side CRUD is av
 | `POST` | `/api/workspaces/:wid/dashboards/:did/materialization/trigger`                | Trigger materialization for a data source       |
 | `POST` | `/api/workspaces/:wid/dashboards/:did/materialization/trigger-all`            | Trigger materialization for all data sources    |
 | `GET`  | `/api/workspaces/:wid/dashboards/:did/materialization/stream/:dataSourceId`   | Stream Parquet artifact (supports range requests) |
+
+## Public Shares
+
+Token-gated, **read-only** endpoints for published dashboard/app links. These are intentionally unauthenticated (no session or API key) and serve only materialized snapshots.
+
+| Method | Endpoint                                  | Description                                              |
+| ------ | ----------------------------------------- | ------------------------------------------------------- |
+| `GET`  | `/api/share/:token`                       | Get public-share metadata (title, whether a password is required) |
+| `POST` | `/api/share/:token/unlock`                | Exchange a password for access to a protected link      |
+| `GET`  | `/api/share/:token/content`               | Get the shared resource's materialized content          |
+| `GET`  | `/api/share/:token/artifacts/:artifactId` | Stream a materialized Parquet artifact (supports range requests) |
+| `POST` | `/api/share/:token/refresh`               | Throttled anonymous re-materialization of the snapshot  |
 
 ## Inngest
 

--- a/docs/src/content/docs/console.md
+++ b/docs/src/content/docs/console.md
@@ -10,7 +10,7 @@ The Console is Mako's query editor. It connects to any database you've added and
 - **Multi-database**: One editor for PostgreSQL, MongoDB, BigQuery, MySQL, ClickHouse, SQLite, and more
 - **AI-assisted**: Ask questions in natural language, get working queries placed in your editor
 - **Saved queries**: Consoles persist in your workspace, organized in folders
-- **Shareable**: Share consoles with your team via the workspace
+- **Shareable**: Share with specific teammates as viewer/editor, or with the whole workspace (see [Sharing](#sharing))
 - **API access**: Execute saved consoles programmatically via REST API
 - **Scheduled queries**: Run saved consoles on cron schedules and inspect run history
 
@@ -42,6 +42,16 @@ Consoles can be organized into folders. Use the sidebar tree to drag and arrange
 Workspace admins can schedule a saved console to run automatically from the console header. Scheduled consoles use five-field cron expressions plus an IANA timezone, for example `0 0 * * *` with `UTC` for a daily midnight run.
 
 When a console is scheduled, Mako stores the next run time and executes it through Inngest. The schedule panel shows the latest run status, duration, row count, consecutive failures, and recent run history. Admins can also trigger a scheduled console manually with **Run now**. You can attach **notifications** to a schedule (email, webhook, or Slack) — see [Notifications](/notifications/).
+
+## Sharing
+
+Consoles use the same **Google Workspace-style** sharing model as [dashboards](/dashboards/#sharing--collaborators):
+
+- **Per-user collaborators** — add specific teammates as `viewer` (read-only) or `editor` (read + write) from the console's **Share** dialog.
+- **General access** — set the console to `private` (owner + collaborators only) or `workspace` (every member), with a `workspaceRole` of `viewer` or `editor` controlling what members can do.
+- Only the **owner**, or a workspace **owner/admin** for non-private consoles, can manage sharing.
+
+Unlike dashboards and apps, consoles do **not** support unauthenticated public links — they execute live queries against your databases, so access always requires workspace authentication.
 
 ## Console API
 

--- a/docs/src/content/docs/dashboards.md
+++ b/docs/src/content/docs/dashboards.md
@@ -137,13 +137,24 @@ If another user holds the lock, a confirmation dialog offers to take over.
 
 ## Sharing & Collaborators
 
-Beyond the workspace-level `access` setting, dashboards support **per-user collaborators** granted explicit edit access:
+Dashboards, [consoles](/console/), and apps use a single **Google Workspace-style** sharing model, managed from each resource's **Share** dialog. Three layers stack on top of each other:
 
-- Each collaborator is added with the `editor` role, which allows them to read **and** write the dashboard regardless of the broader access level.
-- Collaborators are managed from the dashboard's **Share** dialog.
-- Only the dashboard **owner** or a workspace **owner/admin** can add or remove collaborators.
+1. **Owner** — the creator (`owner_id`, falling back to `createdBy`) always has full access and can manage sharing.
+2. **Per-user collaborators** (`sharedWith`) — specific users granted a `viewer` (read-only) or `editor` (read + write) role, independent of the resource's general access scope.
+3. **General access** (`access`) — `private` (only the owner + collaborators) or `workspace` (every workspace member). When `workspace`, the `workspaceRole` field sets the role members get: `viewer` (default) or `editor`. Workspace admins/owners always resolve to `editor`; the `viewer` member role caps them at read-only.
 
-Under the hood, collaborators are stored on the dashboard's `sharedWith` array (`{ userId, role: "editor", addedAt, addedBy }`), indexed for fast "shared with me" lookups.
+Access resolution is first-match-wins in that order (see `api/src/utils/resource-acl.ts`). Admins do **not** gain access to private resources they neither own nor are shared on — this preserves the privacy guarantee. Only the **owner**, or a workspace **owner/admin** for non-private resources, can change sharing settings or manage collaborators.
+
+Collaborators are stored on the resource's `sharedWith` array (`{ userId, role, addedAt, addedBy }`), indexed for fast "shared with me" lookups.
+
+### Public links (dashboards & apps)
+
+Dashboards and apps can be published as read-only **public links** at `/share/:token`, served without authentication:
+
+- Public links serve **materialized snapshots only** (the last-materialized Parquet artifacts), never live database connections.
+- An optional **password** protects the link. It is stored as a bcrypt hash, plus an AES-encrypted copy so the owner/admin can reveal it later in the UI.
+- Links get a readable workspace/title **slug** (with conflict suffixes), support inline rename, **token rotation**, and a throttled anonymous **refresh** endpoint.
+- Consoles do **not** support public links — they share via collaborators and workspace access only.
 
 ## Scheduled Refresh
 


### PR DESCRIPTION
Documents the unified ACL / Google-style sharing model shipped in #497, which replaced the old dashboard-only `editor`-role collaborators (previously documented from #439).

## What changed
- **dashboards.md** — rewrote *Sharing & Collaborators* to the unified model: owner → per-user collaborators (`viewer`/`editor`) → general access (`private`/`workspace` + `workspaceRole`). Added a *Public links* subsection (dashboards + apps only): materialized snapshots, optional bcrypt password with AES-encrypted reveal copy, readable slugs, token rotation, throttled anonymous refresh.
- **console.md** — added a *Sharing* section and clarified consoles share via collaborators/workspace access but have **no** public links (they run live queries).
- **api-reference.md** — updated dashboard collaborator endpoints (now `viewer`/`editor` + `PATCH` role change), added `/sharing` and `/public-share` management routes, added console collaborator/sharing rows, and added a new *Public Shares* section for the unauthenticated `/api/share/:token` endpoints.

## Verified against
`api/src/utils/resource-acl.ts`, `api/src/routes/lib/collaborator-routes.ts`, `api/src/routes/lib/public-share-routes.ts`, `api/src/routes/public-share.ts`, `api/src/database/workspace-schema.ts`, and the route mounts in `api/src/index.ts`.

Markdown-only; no sidebar/frontmatter changes.