### PR TITLE
fix(app): make public dashboard share view scrollable

### DIFF
--- a/app/src/components/public/PublicDashboardViewer.tsx
+++ b/app/src/components/public/PublicDashboardViewer.tsx
@@ -240,17 +240,22 @@ export default function PublicDashboardViewer({
   return (
     <Box
       sx={{
-        minHeight: "100vh",
+        height: "100vh",
+        overflowY: "auto",
         backgroundColor: "background.default",
         color: "text.primary",
       }}
     >
       <Box
         sx={{
+          position: "sticky",
+          top: 0,
+          zIndex: 1,
           px: 3,
           py: 2,
           borderBottom: "1px solid",
           borderColor: "divider",
+          backgroundColor: "background.default",
           display: "flex",
           alignItems: "center",
           gap: 2,


### PR DESCRIPTION
## Summary
- Public dashboard share links (`/share/:token`) couldn't scroll: the global `html, body { overflow: hidden }` in `app/index.html` clipped the page, while `PublicDashboardViewer` relied on document scroll via `minHeight: 100vh`.
- Fix scoped to the viewer: its own root is now the scroll container (`height: 100vh` + `overflowY: auto`), so overflow no longer fights the global body style.
- Header is now `position: sticky` (with solid background + `zIndex`) so the title and **Refresh data** button stay pinned while the grid scrolls.

No change to the global CSS the authenticated app depends on. `PublicAppViewer` already scrolled correctly (internal iframe).

## Test plan
- [ ] Open a public dashboard share link with enough widgets to overflow the viewport → page scrolls; header stays pinned.
- [ ] Verify the authenticated app layout is unaffected.
- [x] `pnpm --filter app run typecheck` passes
- [x] `pnpm --filter app run lint` passes

Made with [Cursor](https://cursor.com)