### PR TITLE
fix(chat): resolve tool cards stuck on "Running…" after clean stream end

### DIFF
--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -2558,6 +2558,72 @@ const Chat: React.FC<ChatProps> = ({
     status === "submitted" ||
     activeClientToolCallCount > 0;
   isLoadingRef.current = isLoading;
+
+  // Rescue tool cards orphaned by a clean stream end.
+  //
+  // A tool card's "Running…" status is derived purely from the AI SDK tool
+  // part `state` — it only resolves once a terminal `output-available` /
+  // `output-error` chunk arrives. `onError` patches stuck parts when the
+  // stream *throws* (e.g. a 524), and the history-load path rewrites them when
+  // a chat is reopened. But with resumable streams a long server-side tool can
+  // outlive the edge proxy's idle timeout: the SSE connection is closed, the
+  // SDK silently reconnects, the reconnect returns 204 ("nothing streaming"),
+  // and `status` settles back to "ready" without any error ever surfacing. The
+  // live in-memory message then keeps a tool part frozen at "input-available"
+  // → a permanent "Running…" card that also blocks the composer (the SDK won't
+  // accept a new message until every tool call is settled).
+  //
+  // Once the turn has settled (`status === "ready"`) and no client-side tool is
+  // still executing, any non-terminal tool part on the last assistant message
+  // is orphaned. Patch it to an error so the card resolves and input unblocks.
+  // Mirrors the `onError` rescue; uses `setMessages` (not `addToolOutput`) so
+  // it does not feed back into `sendAutomaticallyWhen` and kick off a new turn.
+  useEffect(() => {
+    if (status !== "ready" || activeClientToolCallCount > 0) return;
+    if (activeClientToolCallsRef.current.size > 0) return;
+    setMessages(prev => {
+      const lastIndex = prev.length - 1;
+      const last = prev[lastIndex];
+      if (!last || last.role !== "assistant") return prev;
+      const hasPending = last.parts?.some(p => {
+        const pt = p.type as string;
+        if (!pt?.startsWith("tool-") && pt !== "dynamic-tool") return false;
+        const s = (p as Record<string, unknown>).state as string;
+        return (
+          s !== "output-available" && s !== "output-error" && s !== "error"
+        );
+      });
+      if (!hasPending) return prev;
+      return prev.map((msg, i) => {
+        if (i !== lastIndex) return msg;
+        return {
+          ...msg,
+          parts: msg.parts.map(p => {
+            const pt = p.type as string;
+            if (!pt?.startsWith("tool-") && pt !== "dynamic-tool") return p;
+            const s = (p as Record<string, unknown>).state as string;
+            if (
+              s === "output-available" ||
+              s === "output-error" ||
+              s === "error"
+            ) {
+              return p;
+            }
+            return {
+              ...p,
+              state: "error" as const,
+              output: {
+                success: false,
+                error:
+                  "Interrupted — stream disconnected before tool completed",
+              },
+            };
+          }) as any,
+        };
+      });
+    });
+  }, [status, activeClientToolCallCount, setMessages]);
+
   const lastMessage = messages.at(-1);
   const lastMessageParts = lastMessage?.parts ?? [];
   useRenderCount("Chat", {


### PR DESCRIPTION
## Summary

Fixes a production issue where a tool card (e.g. **"Building int_engagement_score_organisations"**) stays stuck on **"Running…"** forever, even after the underlying server-side job already finished or failed. This also silently blocks the composer, since the AI SDK won't accept a new message until every tool call is settled.

### Root cause

A tool card's status is **pure client-side state** derived from the AI SDK tool-part `state` (see `StreamingToolCard`): it shows `Running…` for `input-available`/`output-streaming` and only resolves to Done/Error on a terminal `output-available`/`output-error` chunk. It never polls the backend.

There were three places that rescued a non-terminal tool part, and a long-running tool on a **resumable stream** slipped through all of them:

1. **`onError`** patches stuck parts → only fires when the stream *throws* (e.g. a 524).
2. **History-load rewrite** → only runs when a chat is *reopened* from the DB.
3. **`handleStop`** → only on an explicit user Stop.

With resumable streams, a long server-side tool (e.g. a heavy dbt/BigQuery build) can outlive the edge proxy's idle timeout. The SSE connection is closed, the SDK silently reconnects via `prepareReconnectToStreamRequest`, the reconnect returns **204 ("nothing streaming")**, and `status` settles back to `"ready"` with **no error surfaced**. The live in-memory message keeps a tool part frozen at `input-available` → permanent "Running…".

### Fix

Add an effect in `Chat.tsx` that, once the turn has settled (`status === "ready"` and no client-side tool still executing), patches any non-terminal tool part on the last assistant message to an error state — so the card resolves and the composer unblocks. It mirrors the existing `onError` rescue and uses `setMessages` (not `addToolOutput`), so it does **not** feed back into `sendAutomaticallyWhen` and kick off an unintended new turn.

This complements the existing rescues rather than replacing them:
- `onError` → stream error (524, etc.)
- history-load → reopening a chat
- **this effect → resumable stream that ends cleanly** (the gap)

### Follow-ups (out of scope, server-side)

- The dbt/transform agent runtime should always flush a terminal `tool-output-*` (success or error) before the turn closes, including on timeout.
- Emit periodic SSE heartbeats during long dbt runs so the edge proxy doesn't idle-kill the connection in the first place.

## Test plan

- [ ] Start a long server-side tool, then sever the SSE connection (or let it idle-timeout) so the resumable reconnect returns 204 → card flips from "Running…" to an "Interrupted — stream disconnected before tool completed" error and the composer unblocks.
- [ ] Normal tool completion still shows "Done" (no false interruption).
- [ ] A client-side tool mid-execution is **not** prematurely settled (`activeClientToolCallCount`/ref guard).
- [ ] Explicit Stop and stream-error (`onError`) paths still behave as before.
- [ ] Reopening an interrupted chat from history still rewrites parts correctly.

`pnpm --filter app run typecheck` and `pnpm --filter app run lint` both pass.

Made with [Cursor](https://cursor.com)