### PR TITLE
fix(dbt): pin uv cache so local dbt commands stop re-downloading every run

### DIFF
--- a/api/src/dbt/runner.service.ts
+++ b/api/src/dbt/runner.service.ts
@@ -298,6 +298,16 @@ export async function runDbt(request: DbtRunRequest): Promise<DbtRunResult> {
       ...keyfileEnv,
       DBT_SEND_ANONYMOUS_USAGE_STATS: "false",
       HOME: projectDir,
+      // HOME points at the throwaway project dir to isolate dbt's profile and
+      // config, but that also relocates uv's cache for the `uvx` dev path
+      // (resolveDbtBin) into a dir we delete after every command — forcing a
+      // full dbt-core + adapter re-download (~20s and ~1GB) on every parse/
+      // compile/show/build. Pin uv's cache to a stable shared location so the
+      // first command warms it and the rest reuse it (~2s). Respect an
+      // operator-provided UV_CACHE_DIR if set. No effect in production, which
+      // runs a baked venv via DBT_VENV_BIN rather than uvx.
+      UV_CACHE_DIR:
+        process.env.UV_CACHE_DIR ?? join(tmpdir(), "mako-dbt-uv-cache"),
     };
 
     // Install packages first when declared. The executor runs one runDbt per


### PR DESCRIPTION
## Summary

Local debugging of the "dbt build takes forever / `dbt show` times out at 180s / build gets Interrupted" reports. Found a concrete, measurable root cause in the dbt runner.

`runDbt` sets `HOME` to the throwaway per-command project dir (`mkdtemp`) to isolate dbt's profile/config:

```ts
const childEnv = { ...process.env, ...secretEnv, ...keyfileEnv,
  DBT_SEND_ANONYMOUS_USAGE_STATS: "false", HOME: projectDir };
```

For the local `uvx` execution path (`resolveDbtBin` dev fallback), `uv` derives its cache location from `HOME`. So pointing `HOME` at the temp dir relocates uv's cache **inside the dir we delete in the `finally`** — meaning every `dbt parse / compile / show / build` re-resolves and re-downloads dbt-core + the adapter from scratch, and writes ~1GB into the temp dir before wiping it.

### Measured locally (`uvx --from dbt-core==1.9.10 --with dbt-bigquery dbt --version`)

| Scenario | Time | Temp dir |
|---|---|---|
| Normal `HOME`, warm cache | **1.7s** | — |
| Fresh temp `HOME` (current behavior) run 1 | **20.2s** | +972 MB |
| Fresh temp `HOME` run 2 | **21.0s** | +972 MB again |
| Fresh `HOME` **+ pinned `UV_CACHE_DIR`** run 1 | 21.1s (warms once) | 4 KB |
| Fresh `HOME` **+ pinned `UV_CACHE_DIR`** run 2 | **1.9s** | 4 KB |

That ~20s of cold start **per dbt command**, on top of the actual warehouse work, is the dominant driver of the slow builds and the 180s `dbt show` timeouts.

## Fix

Pin `UV_CACHE_DIR` to a stable shared location (respecting an operator-provided value) so the cache survives across runs while `HOME` still isolates dbt config:

```ts
UV_CACHE_DIR: process.env.UV_CACHE_DIR ?? join(tmpdir(), "mako-dbt-uv-cache"),
```

## Scope / impact

- **Local dev only.** Production resolves dbt via a baked venv (`DBT_VENV_BIN`), not `uvx`, so prod is unaffected.
- Complements the two other fixes from this investigation: #508 (client resolves a stranded tool card instead of a permanent "Running…") and #510 (SSE keepalive so the prod edge proxy doesn't idle-close long builds). This PR removes the local cause of the multi-minute waits/timeouts themselves.

## Test plan

- [ ] Local: run two dbt commands in a row from the agent/IDE; confirm only the first is slow (~20s cold) and subsequent ones are fast (~2s), and `/tmp` no longer fills with ~1GB-per-run `mako-dbt-*` cache copies.
- [ ] `dbt show` against a real connection completes well under the 180s timeout once the cache is warm.
- [ ] Operator override: setting `UV_CACHE_DIR` in the environment is respected.

Verified: `pnpm --filter api run lint`, `tsc -p tsconfig.build.json --noEmit`, and `prettier --check` all pass.

Made with [Cursor](https://cursor.com)