### PR TITLE
feat(dbt): async run card + warm dirs + resident dbt engine (fast interactive dbt)

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -5,9 +5,10 @@
   "main": "dist/index.js",
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "pnpm run lint && cd ../packages/schemas && node ../../api/node_modules/typescript/bin/tsc && cd ../../api && node ./node_modules/typescript/bin/tsc -p tsconfig.build.json && copyfiles -u 1 'src/**/*.svg' 'src/agent-skills/**/*.md' dist",
+    "build": "pnpm run lint && cd ../packages/schemas && node ../../api/node_modules/typescript/bin/tsc && cd ../../api && node ./node_modules/typescript/bin/tsc -p tsconfig.build.json && copyfiles -u 1 'src/**/*.svg' 'src/agent-skills/**/*.md' 'src/**/*.py' dist",
     "start": "tsx src/index.ts",
     "sync": "tsx src/sync/cli.ts",
+    "seed:dbt-demo": "tsx src/scripts/seed-dbt-engine-demo.ts",
     "worker": "tsx src/worker.ts",
     "worker:dev": "tsx watch src/worker.ts",
     "migrate:workspaces": "tsx src/migrations/migrate-to-workspaces.ts",

--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -28,6 +28,7 @@ import { runAdhocDbtCommand } from "../../dbt/dbt-project.service";
 import {
   applyJobScheduleChange,
   triggerDbtJobRun,
+  triggerDbtRun,
 } from "../../dbt/dbt-run.service";
 import {
   DbtCommandValidationError,
@@ -59,6 +60,30 @@ function toolError(error: unknown, fallback: string) {
     success: false,
     error: error instanceof Error ? error.message : fallback,
   };
+}
+
+/** Upper bound on dbt_get_run's server-side wait, well under proxy timeouts. */
+const MAX_RUN_WAIT_MS = 90_000;
+/** Cadence for the dbt_get_run wait loop — mirrors the IDE run-detail poll. */
+const RUN_POLL_INTERVAL_MS = 2_000;
+
+/** Sleep that resolves early when the turn is aborted (chat Stop). */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise(resolve => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 /** Keep tool outputs small: errors + warnings + last few info lines. */
@@ -316,9 +341,12 @@ export const createDbtServerTools = (workspaceId: string) => {
         "against the project's dev environment (or the given environment). " +
         "This WRITES to the warehouse target schema. `model` accepts a node " +
         "name (stg_orders) or a dbt selector with graph operators/methods " +
-        "(stg_orders+, +marts.orders, tag:nightly, state:modified+). Returns " +
-        "per-node status, timing, rows affected, and test pass/fail outcomes. " +
-        "Use this as the final verification after compile succeeds.",
+        "(stg_orders+, +marts.orders, tag:nightly, state:modified+). " +
+        "Runs ASYNCHRONOUSLY in the runner and returns a `runId` immediately " +
+        "(it does NOT block until the build finishes). Poll `dbt_get_run` " +
+        "with that `runId` (pass `waitMs`) to get per-node status, timing, " +
+        "rows affected, and test pass/fail outcomes. Use this as the final " +
+        "verification after compile succeeds.",
       inputSchema: z.object({
         projectId: projectIdField,
         model: z
@@ -339,19 +367,30 @@ export const createDbtServerTools = (workspaceId: string) => {
           if (!SELECTOR_PATTERN.test(model)) {
             return { success: false, error: "Invalid model selector" };
           }
-          await assertProject(projectId);
-          const result = await runAdhocDbtCommand({
+          const project = await assertProject(projectId);
+          // Dispatch to the async runner instead of blocking the chat turn for
+          // the full build. The build executes in the Inngest worker
+          // (decoupled from this SSE connection), so it survives proxy idle
+          // timeouts and API restarts. The agent verifies the outcome by
+          // polling dbt_get_run; the chat renders a live run card from runId.
+          const run = await triggerDbtRun({
             workspaceId,
             projectId,
-            environmentName: environment,
-            command: `build --select ${model}`,
-            select: model,
-            timeoutMs: 5 * 60 * 1000,
+            environment: environment ?? project.defaultEnvironment,
+            commands: [`build --select ${model}`],
+            trigger: "agent",
+            triggeredBy: "agent",
           });
           return {
-            success: result.success,
-            stepResults: result.stepResults,
-            logs: summarizeLogs(result.logs),
+            success: true,
+            runId: run._id.toString(),
+            status: run.status,
+            environment: run.environment,
+            commands: run.commands,
+            message:
+              "Build started in the runner. Poll dbt_get_run with this runId " +
+              "(pass waitMs) until status is success/error. The user sees " +
+              "live progress in the run card.",
           };
         } catch (error) {
           return toolError(error, "Failed to run model");
@@ -405,18 +444,34 @@ export const createDbtServerTools = (workspaceId: string) => {
     dbt_get_run: tool({
       description:
         "Read the status, step results, and logs of a dbt run — use this " +
-        "AFTER dbt_run_job to see whether the run passed or failed (the " +
-        "trigger only queues it). Pass `runId` for a specific run, or `jobId` " +
-        "to get that job's most recent run.",
+        "AFTER dbt_run_model or dbt_run_job to see whether the run passed or " +
+        "failed (those only queue it). Pass `runId` for a specific run, or " +
+        "`jobId` to get that job's most recent run. Pass `waitMs` to block " +
+        "server-side until the run reaches a terminal status (success/error/" +
+        "cancelled) or the wait elapses — call it ONCE with waitMs ~90000 " +
+        "after dbt_run_model; if it returns still running, tell the user the " +
+        "build is in progress and stop (the run card shows live progress).",
       inputSchema: z.object({
         projectId: projectIdField,
-        runId: z.string().optional().describe("dbt run ID (from dbt_run_job)"),
+        runId: z
+          .string()
+          .optional()
+          .describe("dbt run ID (from dbt_run_model / dbt_run_job)"),
         jobId: z
           .string()
           .optional()
           .describe("dbt job ID — returns the latest run for this job"),
+        waitMs: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe(
+            "If set, wait up to this many ms (capped at 90000) for the run " +
+              "to finish before returning. Use ~90000 once after dbt_run_model.",
+          ),
       }),
-      execute: async ({ projectId, runId, jobId }) => {
+      execute: async ({ projectId, runId, jobId, waitMs }, { abortSignal }) => {
         try {
           const project = await assertProject(projectId);
           if (!runId && !jobId) {
@@ -439,10 +494,27 @@ export const createDbtServerTools = (workspaceId: string) => {
             query.jobId = new Types.ObjectId(jobId);
           }
 
-          const run = await DbtRun.findOne(query)
-            .sort({ createdAt: -1 })
-            .lean();
+          const isTerminal = (status: string) =>
+            status === "success" ||
+            status === "error" ||
+            status === "cancelled";
+
+          const deadline = Date.now() + Math.min(waitMs ?? 0, MAX_RUN_WAIT_MS);
+
+          let run = await DbtRun.findOne(query).sort({ createdAt: -1 }).lean();
           if (!run) return { success: false, error: "Run not found" };
+
+          // Bounded server-side wait: re-read until terminal, the budget
+          // elapses, or the turn is aborted. Keepalives keep the SSE warm.
+          while (
+            !isTerminal(run.status) &&
+            Date.now() + RUN_POLL_INTERVAL_MS <= deadline &&
+            !abortSignal?.aborted
+          ) {
+            await sleep(RUN_POLL_INTERVAL_MS, abortSignal);
+            run = await DbtRun.findOne(query).sort({ createdAt: -1 }).lean();
+            if (!run) return { success: false, error: "Run not found" };
+          }
 
           return {
             success: true,

--- a/api/src/agent-skills/dbt/SKILL.md
+++ b/api/src/agent-skills/dbt/SKILL.md
@@ -117,10 +117,17 @@ AND its tests — always add at least `unique` + `not_null` on the primary key.
    malformed schema.yml without touching the warehouse.
 2. `dbt_compile_model` — renders the Jinja; read the compiled SQL to confirm
    it targets the right relations.
-3. `dbt_run_model` on dev — reports per-node status, timing, rows affected,
-   and test outcomes. Surface these to the user.
+3. `dbt_run_model` on dev — runs ASYNCHRONOUSLY in the runner and returns a
+   `runId` immediately (it does NOT wait for the build). Then call
+   `dbt_get_run({ runId, waitMs: 90000 })` ONCE to wait for the result:
+   - terminal (`success`/`error`) → surface per-node status, timing, rows
+     affected, and test outcomes to the user.
+   - still `running`/`queued` after the wait → tell the user the build is
+     still in progress (the run card shows live logs/status); do NOT keep
+     polling in a tight loop. Poll again only if the user asks.
 4. Preview built tables with `sql_execute_query`
-   (`select * from <dev_schema>.<model> limit 100`).
+   (`select * from <dev_schema>.<model> limit 100`) — only after the run
+   reaches `success`.
 
 ## Environments and jobs
 

--- a/api/src/dbt/dbt-bin.ts
+++ b/api/src/dbt/dbt-bin.ts
@@ -10,6 +10,7 @@
 
 import { existsSync } from "fs";
 import { spawnSync } from "child_process";
+import { dirname, join } from "path";
 
 export const DEFAULT_DBT_CORE_VERSION = "1.9.10";
 
@@ -79,5 +80,73 @@ export function resolveDbtBin(
     "No dbt binary available. Set DBT_VENV_BIN to a dbt executable " +
       "(production image bakes one at /opt/dbt/bin/dbt) or install uv " +
       "(https://docs.astral.sh/uv/) so the runner can use `uvx` locally.",
+  );
+}
+
+function dbtCoreVersionFor(
+  adapterPackage: string,
+  dbtVersion?: string,
+): string {
+  if (adapterPackage === "dbt-mysql") return "1.7.19";
+  return dbtVersion && dbtVersion.split(".").length >= 3
+    ? dbtVersion
+    : DEFAULT_DBT_CORE_VERSION;
+}
+
+/**
+ * Resolve how to launch the resident dbt engine (a long-lived Python process
+ * running `enginePath`), mirroring {@link resolveDbtBin}'s resolution order so
+ * the engine uses the SAME dbt-core + adapter as the subprocess path.
+ *
+ *   1. DBT_ENGINE_PYTHON_CMD — JSON array override (tests / custom infra);
+ *      enginePath is appended.
+ *   2. The baked venv's python (sibling of DBT_VENV_BIN) in production.
+ *   3. `uv run` dev fallback with dbt-core + the adapter injected.
+ */
+export function resolveDbtEnginePython(
+  adapterPackage: string,
+  dbtVersion: string | undefined,
+  enginePath: string,
+): ResolvedDbtBin {
+  const override = process.env.DBT_ENGINE_PYTHON_CMD;
+  if (override) {
+    const parts = JSON.parse(override) as string[];
+    return { bin: parts[0], prefixArgs: [...parts.slice(1), enginePath] };
+  }
+
+  const venvBin =
+    adapterPackage === "dbt-mysql"
+      ? process.env.DBT_MYSQL_VENV_BIN
+      : process.env.DBT_VENV_BIN;
+  if (venvBin) {
+    const python = join(dirname(venvBin), "python");
+    if (!existsSync(python)) {
+      throw new Error(
+        `dbt venv python "${python}" does not exist (check DBT_VENV_BIN)`,
+      );
+    }
+    return { bin: python, prefixArgs: [enginePath] };
+  }
+
+  if (isUvxAvailable()) {
+    const coreVersion = dbtCoreVersionFor(adapterPackage, dbtVersion);
+    return {
+      bin: "uv",
+      prefixArgs: [
+        "run",
+        "--no-project",
+        "--with",
+        `dbt-core==${coreVersion}`,
+        "--with",
+        adapterPackage,
+        "python",
+        enginePath,
+      ],
+    };
+  }
+
+  throw new Error(
+    "No Python available for the dbt engine. Set DBT_VENV_BIN " +
+      "(production bakes /opt/dbt/bin/python) or install uv for local dev.",
   );
 }

--- a/api/src/dbt/dbt-cache.service.ts
+++ b/api/src/dbt/dbt-cache.service.ts
@@ -1,0 +1,170 @@
+/**
+ * dbt run cache — cross-run/cross-instance warm state stored in the artifact
+ * store so each dbt invocation doesn't start cold.
+ *
+ * Two caches, both BEST-EFFORT (any failure falls back to correct cold
+ * behavior — dbt validates its own partial-parse cache against file checksums
+ * and re-parses on any mismatch, so a stale/garbage cache never produces a
+ * wrong result):
+ *
+ *   1. partial_parse.msgpack — dbt's internal parse manifest. Seeding it into
+ *      target/ lets dbt re-parse only changed files instead of the whole
+ *      project (~seconds → <1s on non-trivial projects). Keyed per
+ *      (workspace, project, environment) because env_var rendering can affect
+ *      the parsed manifest.
+ *   2. dbt_packages/ (+ package-lock.yml) — the installed packages tree.
+ *      Caching it lets us skip `dbt deps` (git/registry downloads) when
+ *      packages.yml is unchanged. Keyed per (workspace, project) and validated
+ *      with a hash of the dependency declarations.
+ *
+ * Keys live under `dbt-cache/` so they never collide with per-run artifacts
+ * (`dbt-artifacts/`).
+ */
+
+import crypto from "crypto";
+import { getDashboardArtifactStore } from "../services/dashboard-artifact-store.service";
+import { loggers } from "../logging";
+
+const logger = loggers.app();
+
+export interface DbtCacheScope {
+  workspaceId: string;
+  projectId: string;
+  environment: string;
+}
+
+type ProjectFile = { path: string; content: string };
+
+function sanitizeSegment(value: string): string {
+  return value.replace(/[^\w.-]/g, "_");
+}
+
+function parsePrefix(scope: DbtCacheScope): string {
+  return `dbt-cache/${scope.workspaceId}/${scope.projectId}/${sanitizeSegment(scope.environment)}`;
+}
+
+function packagesPrefix(scope: DbtCacheScope): string {
+  // Packages depend only on packages.yml/dependencies.yml, not on the
+  // environment — share one cache across a project's environments.
+  return `dbt-cache/${scope.workspaceId}/${scope.projectId}`;
+}
+
+const PARTIAL_PARSE_FILE = "partial_parse.msgpack";
+
+/**
+ * sha256 of the dependency declarations, or null when the project declares no
+ * real packages (only comments / no file). Used to detect when the cached
+ * dbt_packages/ tree is still valid.
+ */
+export function computePackagesHash(files: ProjectFile[]): string | null {
+  const declarations = ["packages.yml", "dependencies.yml"]
+    .map(name => {
+      const file = files.find(candidate => candidate.path === name);
+      return file ? `${name}:${file.content}` : "";
+    })
+    .join("\n");
+
+  const hasRealPackages = declarations
+    .split("\n")
+    .map(line => line.trim())
+    .some(
+      line =>
+        line.length > 0 &&
+        !line.startsWith("#") &&
+        !line.endsWith(":") &&
+        line !== "packages.yml" &&
+        line !== "dependencies.yml",
+    );
+  if (!hasRealPackages) return null;
+
+  return crypto.createHash("sha256").update(declarations).digest("hex");
+}
+
+async function readKey(key: string): Promise<Buffer | undefined> {
+  try {
+    const stream = await getDashboardArtifactStore().openReadStream(key);
+    if (!stream) return undefined;
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    return chunks.length > 0 ? Buffer.concat(chunks) : undefined;
+  } catch {
+    // Missing key (cold cache) or transient store error — treat as a miss.
+    return undefined;
+  }
+}
+
+export interface LoadedDbtCaches {
+  /** Seed into target/partial_parse.msgpack to warm parsing. */
+  partialParse?: Buffer;
+  /** tgz of dbt_packages/ (+ package-lock.yml) to seed when packages match. */
+  packages?: Buffer;
+  /** True when the cached packages tree matches the current declarations. */
+  packagesFresh: boolean;
+}
+
+export async function loadDbtCaches(
+  scope: DbtCacheScope,
+  packagesHash: string | null,
+): Promise<LoadedDbtCaches> {
+  const partialParseKey = `${parsePrefix(scope)}/${PARTIAL_PARSE_FILE}`;
+  const hashKey = `${packagesPrefix(scope)}/packages_hash.txt`;
+
+  const [partialParse, cachedHashBuf] = await Promise.all([
+    readKey(partialParseKey),
+    packagesHash ? readKey(hashKey) : Promise.resolve(undefined),
+  ]);
+
+  const cachedHash = cachedHashBuf?.toString("utf8").trim();
+  const packagesFresh = Boolean(packagesHash) && cachedHash === packagesHash;
+  const packages = packagesFresh
+    ? await readKey(`${packagesPrefix(scope)}/dbt_packages.tgz`)
+    : undefined;
+
+  return { partialParse, packages, packagesFresh: Boolean(packages) };
+}
+
+export async function saveParseCache(
+  scope: DbtCacheScope,
+  partialParse: Buffer,
+): Promise<void> {
+  try {
+    await getDashboardArtifactStore().putBuffer(
+      partialParse,
+      `${parsePrefix(scope)}/${PARTIAL_PARSE_FILE}`,
+      "application/octet-stream",
+    );
+  } catch (error) {
+    logger.warn("Failed to save dbt partial-parse cache", {
+      error,
+      projectId: scope.projectId,
+      environment: scope.environment,
+    });
+  }
+}
+
+export async function savePackagesCache(
+  scope: DbtCacheScope,
+  archive: Buffer,
+  packagesHash: string,
+): Promise<void> {
+  try {
+    const store = getDashboardArtifactStore();
+    await store.putBuffer(
+      archive,
+      `${packagesPrefix(scope)}/dbt_packages.tgz`,
+      "application/gzip",
+    );
+    await store.putBuffer(
+      Buffer.from(packagesHash, "utf8"),
+      `${packagesPrefix(scope)}/packages_hash.txt`,
+      "text/plain",
+    );
+  } catch (error) {
+    logger.warn("Failed to save dbt packages cache", {
+      error,
+      projectId: scope.projectId,
+    });
+  }
+}

--- a/api/src/dbt/dbt-engine.contract.test.ts
+++ b/api/src/dbt/dbt-engine.contract.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Resident dbt engine CONTRACT test.
+ *
+ * Pins the dbt-core programmatic-API assumptions the engine depends on against
+ * a REAL dbt-core + dbt-duckdb (no warehouse server needed):
+ *   1. parse caches a reusable manifest (prepare returns node count)
+ *   2. dbtRunner(manifest=...) reuses it: compile returns compiled SQL
+ *   3. the same long-lived process handles compile -> show repeatedly
+ *
+ * Heavy (downloads dbt via `uv`), so it is gated behind RUN_DBT_ENGINE_CONTRACT
+ * and meant for a dedicated CI job — run locally with:
+ *   RUN_DBT_ENGINE_CONTRACT=1 pnpm --filter api exec vitest run dbt-engine.contract
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterAll, describe, expect, it } from "vitest";
+import {
+  disposeAllEngines,
+  engineCompile,
+  enginePrepare,
+  engineShow,
+} from "./dbt-engine.service";
+
+const ENABLED = process.env.RUN_DBT_ENGINE_CONTRACT === "1";
+
+describe.skipIf(!ENABLED)("dbt engine contract (real dbt-core 1.9.10)", () => {
+  process.env.DBT_ENGINE_ENABLED = "true";
+  process.env.DBT_ENGINE_PYTHON_CMD = JSON.stringify([
+    "uv",
+    "run",
+    "--no-project",
+    "--python",
+    "3.11",
+    "--with",
+    "dbt-core==1.9.10",
+    "--with",
+    "dbt-duckdb==1.9.4",
+    "python",
+  ]);
+
+  const dir = mkdtempSync(join(tmpdir(), "dbt-engine-contract-"));
+  mkdirSync(join(dir, "models"), { recursive: true });
+  writeFileSync(
+    join(dir, "dbt_project.yml"),
+    'name: probe\nprofile: probe\nversion: "1.0"\nconfig-version: 2\nmodel-paths: ["models"]\n',
+  );
+  writeFileSync(
+    join(dir, "profiles.yml"),
+    `probe:\n  target: dev\n  outputs:\n    dev:\n      type: duckdb\n      path: ${dir}/probe.duckdb\n      threads: 1\n`,
+  );
+  writeFileSync(
+    join(dir, "models", "my_model.sql"),
+    "select 1 as id, 2 as val\n",
+  );
+
+  const ctx = {
+    adapterPackage: "dbt-duckdb",
+    dbtVersion: "1.9.10",
+    connectionEnv: {},
+  };
+  const session = { key: "contract:probe:dev", projectDir: dir };
+
+  afterAll(() => disposeAllEngines());
+
+  it("parses, reuses the manifest to compile, and shows rows in one process", async () => {
+    const prep = await enginePrepare(ctx, session);
+    expect(prep.nodes).toBeGreaterThanOrEqual(1);
+
+    const compile = await engineCompile(ctx, session, "my_model");
+    expect(compile.ok).toBe(true);
+    expect(compile.compiled_sql).toContain("select 1 as id");
+
+    const show = await engineShow(ctx, session, {
+      inline: "select 1 as x, 'hi' as y",
+      limit: 5,
+    });
+    expect(show.ok).toBe(true);
+    expect(show.columns).toEqual(["x", "y"]);
+    expect(show.rows).toEqual([[1, "hi"]]);
+  }, 180_000);
+});

--- a/api/src/dbt/dbt-engine.service.ts
+++ b/api/src/dbt/dbt-engine.service.ts
@@ -1,0 +1,315 @@
+/**
+ * Resident dbt engine supervisor.
+ *
+ * Manages long-lived `dbt_engine.py` child processes that hold parsed dbt
+ * manifests in memory, so interactive `compile`/`show` reuse the manifest and
+ * skip re-parse (the dbt Cloud "develop" model). One process per
+ * `(adapterPackage, dbtCoreVersion)` — each holds manifests for many
+ * `(project, environment)` sessions using that adapter.
+ *
+ * Communication is newline-delimited JSON over a dedicated pipe (fd 3), so
+ * dbt's own stdout/stderr logging never corrupts the protocol. Every request
+ * is bounded by a timeout; a crashed process is reaped and respawned lazily,
+ * and all callers fall back to the subprocess path when the engine is
+ * unavailable — so this is strictly an optimization, never a dependency.
+ *
+ * Gated by DBT_ENGINE_ENABLED (default off) until validated against a real
+ * warehouse in staging.
+ */
+
+import { spawn, type ChildProcess } from "child_process";
+import { createHash } from "crypto";
+import { join } from "path";
+import { resolveDbtEnginePython } from "./dbt-bin";
+import { loggers } from "../logging";
+
+const logger = loggers.app();
+
+const ENGINE_SCRIPT = join(__dirname, "engine", "dbt_engine.py");
+const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
+/** Max resident engine processes per API instance (LRU-evicted). */
+const MAX_ENGINES = Number(process.env.DBT_ENGINE_MAX_PROCESSES ?? "4");
+
+export function dbtEngineEnabled(): boolean {
+  return process.env.DBT_ENGINE_ENABLED === "true";
+}
+
+export interface EngineSession {
+  /** Stable key, e.g. `${workspaceId}:${projectId}:${environment}`. */
+  key: string;
+  /** Warm working directory the supervisor keeps in sync on disk. */
+  projectDir: string;
+}
+
+interface PreparePayload {
+  parse_ms: number;
+  nodes: number;
+}
+interface CompilePayload {
+  ok: boolean;
+  compiled_sql: string | null;
+  elapsed_ms: number;
+  error: string | null;
+}
+interface ShowPayload {
+  ok: boolean;
+  columns: string[];
+  rows: unknown[][];
+  elapsed_ms: number;
+  error: string | null;
+}
+
+interface PendingRequest {
+  resolve: (value: Record<string, unknown>) => void;
+  reject: (error: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+/** One supervised Python engine process for a single adapter+version+connection. */
+class EngineProcess {
+  private child: ChildProcess | null = null;
+  private buffer = "";
+  private nextId = 1;
+  private readonly pending = new Map<number, PendingRequest>();
+  /** For LRU eviction. */
+  lastUsed = Date.now();
+
+  constructor(
+    private readonly adapterPackage: string,
+    private readonly dbtVersion: string | undefined,
+    /** Secret + keyfile env so dbt resolves env_var() at profile load. */
+    private readonly connectionEnv: Record<string, string>,
+  ) {}
+
+  private ensureStarted(): ChildProcess {
+    if (this.child && !this.child.killed && this.child.exitCode === null) {
+      return this.child;
+    }
+
+    const { bin, prefixArgs } = resolveDbtEnginePython(
+      this.adapterPackage,
+      this.dbtVersion,
+      ENGINE_SCRIPT,
+    );
+
+    // stdio: [stdin, stdout, stderr, protocol]. dbt logs flow to stdout/stderr
+    // (captured for debug); structured responses arrive on fd 3.
+    const child = spawn(bin, prefixArgs, {
+      stdio: ["pipe", "pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        ...this.connectionEnv,
+        DBT_SEND_ANONYMOUS_USAGE_STATS: "false",
+      },
+    });
+
+    const protocol = child.stdio[3] as NodeJS.ReadableStream;
+    protocol.setEncoding("utf8");
+    protocol.on("data", chunk => this.onProtocolData(chunk as string));
+
+    child.stderr?.on("data", (data: Buffer) => {
+      logger.debug("dbt-engine stderr", {
+        adapter: this.adapterPackage,
+        line: data.toString("utf8").trim().slice(0, 500),
+      });
+    });
+
+    child.on("exit", (code, signal) => {
+      this.failAllPending(
+        new Error(`dbt engine exited (code=${code} signal=${signal})`),
+      );
+      this.child = null;
+      this.buffer = "";
+    });
+    child.on("error", error => {
+      this.failAllPending(error);
+      this.child = null;
+    });
+
+    this.child = child;
+    return child;
+  }
+
+  private onProtocolData(chunk: string): void {
+    this.buffer += chunk;
+    let newline = this.buffer.indexOf("\n");
+    while (newline !== -1) {
+      const line = this.buffer.slice(0, newline).trim();
+      this.buffer = this.buffer.slice(newline + 1);
+      if (line) this.handleResponse(line);
+      newline = this.buffer.indexOf("\n");
+    }
+  }
+
+  private handleResponse(line: string): void {
+    let message: Record<string, unknown>;
+    try {
+      message = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      logger.warn("dbt-engine: unparseable response", {
+        line: line.slice(0, 200),
+      });
+      return;
+    }
+    const id = message.id as number | null;
+    if (id == null) return;
+    const entry = this.pending.get(id);
+    if (!entry) return;
+    this.pending.delete(id);
+    clearTimeout(entry.timer);
+    if (message.ok === true) {
+      entry.resolve(message);
+    } else {
+      entry.reject(new Error(String(message.error ?? "dbt engine error")));
+    }
+  }
+
+  private failAllPending(error: Error): void {
+    for (const [, entry] of this.pending) {
+      clearTimeout(entry.timer);
+      entry.reject(error);
+    }
+    this.pending.clear();
+  }
+
+  request(
+    op: string,
+    params: Record<string, unknown>,
+    timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
+  ): Promise<Record<string, unknown>> {
+    this.lastUsed = Date.now();
+    const child = this.ensureStarted();
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`dbt engine '${op}' timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      this.pending.set(id, { resolve, reject, timer });
+      const payload = JSON.stringify({ id, op, ...params }) + "\n";
+      child.stdin?.write(payload, error => {
+        if (error) {
+          this.pending.delete(id);
+          clearTimeout(timer);
+          reject(error);
+        }
+      });
+    });
+  }
+
+  dispose(): void {
+    this.failAllPending(new Error("engine disposed"));
+    this.child?.kill();
+    this.child = null;
+  }
+}
+
+// Pool keyed by adapter@version@connection. A single process can only serve
+// one set of warehouse credentials (env_var() is read at profile load), so the
+// key fingerprints the connection env. LRU-evicted to bound memory.
+const pool = new Map<string, EngineProcess>();
+
+export interface EngineContext {
+  adapterPackage: string;
+  dbtVersion?: string;
+  /** profile.secretEnv merged with the keyfile env (absolute paths). */
+  connectionEnv: Record<string, string>;
+}
+
+function poolKey(ctx: EngineContext): string {
+  const fingerprint = createHash("sha256")
+    .update(JSON.stringify(ctx.connectionEnv))
+    .digest("hex")
+    .slice(0, 16);
+  return `${ctx.adapterPackage}@${ctx.dbtVersion ?? "default"}@${fingerprint}`;
+}
+
+function engineFor(ctx: EngineContext): EngineProcess {
+  const key = poolKey(ctx);
+  let engine = pool.get(key);
+  if (!engine) {
+    // Evict the least-recently-used process if at capacity.
+    if (pool.size >= MAX_ENGINES) {
+      let lruKey: string | undefined;
+      let lruAt = Infinity;
+      for (const [k, e] of pool) {
+        if (e.lastUsed < lruAt) {
+          lruAt = e.lastUsed;
+          lruKey = k;
+        }
+      }
+      if (lruKey) {
+        pool.get(lruKey)?.dispose();
+        pool.delete(lruKey);
+      }
+    }
+    engine = new EngineProcess(
+      ctx.adapterPackage,
+      ctx.dbtVersion,
+      ctx.connectionEnv,
+    );
+    pool.set(key, engine);
+  }
+  return engine;
+}
+
+/** Parse the project on disk and cache its manifest for this session. */
+export async function enginePrepare(
+  ctx: EngineContext,
+  session: EngineSession,
+): Promise<PreparePayload> {
+  const engine = engineFor(ctx);
+  const res = await engine.request("prepare", {
+    session: session.key,
+    project_dir: session.projectDir,
+  });
+  return { parse_ms: Number(res.parse_ms ?? 0), nodes: Number(res.nodes ?? 0) };
+}
+
+/** Compile a model using the warm manifest. */
+export async function engineCompile(
+  ctx: EngineContext,
+  session: EngineSession,
+  select: string,
+): Promise<CompilePayload> {
+  const engine = engineFor(ctx);
+  const res = await engine.request("compile", { session: session.key, select });
+  return {
+    ok: Boolean(res.ok),
+    compiled_sql: (res.compiled_sql as string | null) ?? null,
+    elapsed_ms: Number(res.elapsed_ms ?? 0),
+    error: (res.error as string | null) ?? null,
+  };
+}
+
+/** Preview rows for a model or inline SQL using the warm manifest. */
+export async function engineShow(
+  ctx: EngineContext,
+  session: EngineSession,
+  args: { select?: string; inline?: string; limit?: number },
+): Promise<ShowPayload> {
+  const engine = engineFor(ctx);
+  const res = await engine.request("show", { session: session.key, ...args });
+  return {
+    ok: Boolean(res.ok),
+    columns: (res.columns as string[]) ?? [],
+    rows: (res.rows as unknown[][]) ?? [],
+    elapsed_ms: Number(res.elapsed_ms ?? 0),
+    error: (res.error as string | null) ?? null,
+  };
+}
+
+/** Drop the cached manifest (e.g. after a structural change). */
+export async function engineInvalidate(
+  ctx: EngineContext,
+  session: EngineSession,
+): Promise<void> {
+  const engine = engineFor(ctx);
+  await engine.request("invalidate", { session: session.key }, 5_000);
+}
+
+/** Tear down all engine processes (process shutdown / tests). */
+export function disposeAllEngines(): void {
+  for (const [, engine] of pool) engine.dispose();
+  pool.clear();
+}

--- a/api/src/dbt/dbt-project.service.ts
+++ b/api/src/dbt/dbt-project.service.ts
@@ -19,11 +19,28 @@ import {
 import { renderDbtProfile, type RenderedProfile } from "./adapter-map";
 import { parseDbtCommand, type ParsedDbtCommand } from "./commands";
 import {
+  materializeDbtProject,
   parseStepResults,
   runDbt,
+  seedDbtCaches,
   type DbtLogLine,
   type DbtRunResult,
 } from "./runner.service";
+import {
+  dbtEngineEnabled,
+  engineCompile,
+  enginePrepare,
+} from "./dbt-engine.service";
+import {
+  computePackagesHash,
+  loadDbtCaches,
+  saveParseCache,
+  savePackagesCache,
+} from "./dbt-cache.service";
+import { warmDirsEnabled, withProjectDir } from "./workspace-dir.service";
+import { loggers } from "../logging";
+
+const logger = loggers.app();
 
 export interface DbtProjectSnapshot {
   project: IDbtProject;
@@ -144,15 +161,124 @@ export async function runAdhocDbtCommand(params: {
     environmentName: params.environmentName,
   });
 
-  const raw = await runDbt({
-    files: snapshot.files,
-    profile: snapshot.profile,
-    commands: [parsed],
-    dbtVersion: snapshot.project.dbtVersion,
-    deferState: params.deferState,
-    commandTimeoutMs: params.timeoutMs ?? 5 * 60 * 1000,
-    signal: params.signal,
-  });
+  // Warm caches so parse/compile/show/build don't re-parse the whole project
+  // (and skip `dbt deps` when packages are unchanged). Best-effort.
+  const cacheScope = {
+    workspaceId: params.workspaceId,
+    projectId: params.projectId,
+    environment: snapshot.environment.name,
+  };
+  const packagesHash = computePackagesHash(snapshot.files);
+  const caches = await loadDbtCaches(cacheScope, packagesHash);
+
+  // Resident-engine fast path: an offline `compile --select X` reuses an
+  // in-memory manifest (no interpreter cold start, no full re-parse) — the
+  // dbt Cloud "develop" feel. Held under the same adhoc warm-dir mutex so the
+  // tree can't mutate while the engine reads it. Any failure (engine down,
+  // package macros needing an install we don't have, introspective compile)
+  // falls through to the subprocess path below, so correctness never depends
+  // on the engine. Gated by DBT_ENGINE_ENABLED (default off).
+  if (
+    dbtEngineEnabled() &&
+    warmDirsEnabled() &&
+    parsed.subcommand === "compile" &&
+    params.select
+  ) {
+    const select = params.select;
+    try {
+      const engineResult = await withProjectDir(
+        { ...cacheScope, role: "adhoc" },
+        async dir => {
+          const { keyfileEnv } = await materializeDbtProject(dir, {
+            files: snapshot.files,
+            profile: snapshot.profile,
+            reconcile: true,
+          });
+          await seedDbtCaches(dir, {
+            partialParse: caches.partialParse,
+            packagesArchive: caches.packages,
+          });
+          const ctx = {
+            adapterPackage: snapshot.profile.adapterPackage,
+            dbtVersion: snapshot.project.dbtVersion,
+            connectionEnv: { ...snapshot.profile.secretEnv, ...keyfileEnv },
+          };
+          const session = {
+            key: `${params.workspaceId}:${params.projectId}:${snapshot.environment.name}`,
+            projectDir: dir,
+          };
+          // Re-parse to pick up edits (cheap via partial parse), then reuse the
+          // warm manifest to compile.
+          await enginePrepare(ctx, session);
+          return engineCompile(ctx, session, select);
+        },
+      );
+      if (engineResult.ok) {
+        logger.debug("dbt engine compile hit", {
+          elapsedMs: engineResult.elapsed_ms,
+        });
+        return {
+          success: true,
+          exitCode: 0,
+          logs: [],
+          stepResults: [],
+          compiledSql: engineResult.compiled_sql ?? undefined,
+          raw: { success: true, commandResults: [], artifacts: {} },
+        };
+      }
+      logger.warn("dbt engine compile failed; falling back to subprocess", {
+        error: engineResult.error,
+      });
+    } catch (error) {
+      logger.warn("dbt engine unavailable; falling back to subprocess", {
+        error: String(error),
+      });
+    }
+  }
+
+  // Interactive commands run in a warm dir (role=adhoc) kept separate from the
+  // deploy executor's, so a long build never blocks a compile. The artifact
+  // caches above seed a cold dir; thereafter the on-disk tree stays warm.
+  const runOnce = (workingDir?: string) =>
+    runDbt({
+      files: snapshot.files,
+      profile: snapshot.profile,
+      commands: [parsed],
+      dbtVersion: snapshot.project.dbtVersion,
+      deferState: params.deferState,
+      commandTimeoutMs: params.timeoutMs ?? 5 * 60 * 1000,
+      seedPartialParse: caches.partialParse,
+      seedPackagesArchive: caches.packages,
+      skipDeps: caches.packagesFresh,
+      packagesHash,
+      workingDir,
+      signal: params.signal,
+    });
+
+  let raw: Awaited<ReturnType<typeof runDbt>> | undefined;
+  if (warmDirsEnabled()) {
+    try {
+      raw = await withProjectDir({ ...cacheScope, role: "adhoc" }, dir =>
+        runOnce(dir),
+      );
+    } catch (error) {
+      logger.warn("Warm dir run failed; falling back to throwaway dir", {
+        error: String(error),
+      });
+    }
+  }
+  if (!raw) raw = await runOnce(undefined);
+
+  if (raw.artifacts.partialParse) {
+    await saveParseCache(cacheScope, raw.artifacts.partialParse);
+  }
+  if (raw.artifacts.packagesArchive && packagesHash) {
+    await savePackagesCache(
+      cacheScope,
+      raw.artifacts.packagesArchive,
+      packagesHash,
+    );
+  }
 
   const commandResult = raw.commandResults[0];
   return {

--- a/api/src/dbt/engine/dbt_engine.py
+++ b/api/src/dbt/engine/dbt_engine.py
@@ -1,0 +1,192 @@
+"""Resident dbt engine.
+
+A long-lived Python process that keeps parsed dbt manifests in memory so the
+hot interactive loop (parse -> compile -> show) skips the expensive re-parse
+on every call. This is the dbt Cloud "develop" model: parse once, then reuse
+the in-memory Manifest via dbt-core's programmatic `dbtRunner(manifest=...)`.
+
+Protocol (newline-delimited JSON):
+  - Requests arrive on STDIN, one JSON object per line: {"id", "op", ...}.
+  - Responses are written to FILE DESCRIPTOR 3, one JSON object per line:
+    {"id", "ok", ...}. We do NOT use stdout because dbt-core writes its own
+    logs there; stdout/stderr are left for the supervisor to capture as logs.
+
+Sessions are keyed by an opaque string (the supervisor uses project+env). The
+supervisor owns the on-disk working directory; this process only reads it.
+
+All assumptions here were verified against dbt-core 1.9.10 + dbt-duckdb 1.9.4
+(see api/src/dbt/engine/__tests__ contract test).
+"""
+
+import json
+import os
+import sys
+import time
+import traceback
+
+import dbt.version
+from dbt.cli.main import dbtRunner
+
+# Dedicated protocol channel. dbt logs to stdout/stderr, so responses must not
+# share fd 1. Line-buffered so the supervisor sees each response promptly.
+_PROTOCOL = os.fdopen(3, "w", buffering=1)
+
+
+def _send(obj):
+    _PROTOCOL.write(json.dumps(obj, default=str) + "\n")
+    _PROTOCOL.flush()
+
+
+# session key -> {"manifest": Manifest, "project_dir": str}
+_SESSIONS = {}
+
+
+def _base(project_dir):
+    return [
+        "--project-dir",
+        project_dir,
+        "--profiles-dir",
+        project_dir,
+        "--no-use-colors",
+    ]
+
+
+def _session(req):
+    key = req["session"]
+    state = _SESSIONS.get(key)
+    if state is None:
+        raise RuntimeError(f"no warm session for {key!r}; call prepare first")
+    return state
+
+
+def op_ping(_req):
+    return {"dbt_version": dbt.version.get_installed_version().to_version_string()}
+
+
+def op_prepare(req):
+    """Parse the project on disk and cache the manifest under `session`.
+
+    Idempotent: re-parsing picks up file changes the supervisor has written
+    (dbt's own checksum-based partial parse keeps this cheap via target/).
+    """
+    key = req["session"]
+    project_dir = req["project_dir"]
+    started = time.time()
+    result = dbtRunner().invoke(["parse", *_base(project_dir)])
+    if not result.success:
+        raise RuntimeError(_first_error(result) or "parse failed")
+    manifest = result.result
+    _SESSIONS[key] = {"manifest": manifest, "project_dir": project_dir}
+    return {
+        "parse_ms": int((time.time() - started) * 1000),
+        "nodes": len(getattr(manifest, "nodes", {}) or {}),
+    }
+
+
+def op_compile(req):
+    state = _session(req)
+    started = time.time()
+    result = dbtRunner(manifest=state["manifest"]).invoke(
+        ["compile", *_base(state["project_dir"]), "--select", req["select"]]
+    )
+    compiled_sql = None
+    results = getattr(result.result, "results", None) if result.result else None
+    if results:
+        node = getattr(results[0], "node", None)
+        compiled_sql = getattr(node, "compiled_code", None)
+    return {
+        "ok": bool(result.success),
+        "compiled_sql": compiled_sql,
+        "elapsed_ms": int((time.time() - started) * 1000),
+        "error": None if result.success else _first_error(result),
+    }
+
+
+def op_show(req):
+    state = _session(req)
+    args = ["show", *_base(state["project_dir"]), "--limit", str(req.get("limit", 50))]
+    if req.get("inline"):
+        args += ["--inline", req["inline"]]
+    else:
+        args += ["--select", req["select"]]
+    started = time.time()
+    result = dbtRunner(manifest=state["manifest"]).invoke(args)
+    columns, rows = [], []
+    results = getattr(result.result, "results", None) if result.result else None
+    if results:
+        table = getattr(results[0], "agate_table", None)
+        if table is not None:
+            columns = list(table.column_names)
+            rows = [list(row) for row in table.rows]
+    return {
+        "ok": bool(result.success),
+        "columns": columns,
+        "rows": rows,
+        "elapsed_ms": int((time.time() - started) * 1000),
+        "error": None if result.success else _first_error(result),
+    }
+
+
+def op_invalidate(req):
+    _SESSIONS.pop(req["session"], None)
+    return {}
+
+
+def _first_error(result):
+    """Best-effort human-readable failure message from a dbtRunnerResult."""
+    if getattr(result, "exception", None):
+        return str(result.exception)
+    results = getattr(result.result, "results", None) if result.result else None
+    if results:
+        for node_result in results:
+            message = getattr(node_result, "message", None)
+            if message:
+                return str(message)
+    return None
+
+
+_OPS = {
+    "ping": op_ping,
+    "prepare": op_prepare,
+    "compile": op_compile,
+    "show": op_show,
+    "invalidate": op_invalidate,
+    "evict": op_invalidate,
+}
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            req = json.loads(line)
+        except Exception as error:  # noqa: BLE001 - report and continue
+            _send({"id": None, "ok": False, "error": f"bad json: {error}"})
+            continue
+
+        rid = req.get("id")
+        handler = _OPS.get(req.get("op"))
+        if handler is None:
+            _send({"id": rid, "ok": False, "error": f"unknown op {req.get('op')!r}"})
+            continue
+
+        try:
+            payload = handler(req)
+            response = {"id": rid, "ok": True}
+            response.update(payload)
+            _send(response)
+        except Exception as error:  # noqa: BLE001 - never let one request kill the loop
+            _send(
+                {
+                    "id": rid,
+                    "ok": False,
+                    "error": str(error),
+                    "trace": traceback.format_exc()[-1500:],
+                }
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/api/src/dbt/runner.service.ts
+++ b/api/src/dbt/runner.service.ts
@@ -8,9 +8,17 @@
  */
 
 import { spawn } from "child_process";
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "fs/promises";
+import {
+  access,
+  mkdtemp,
+  mkdir,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "fs/promises";
 import { tmpdir } from "os";
-import { dirname, join, normalize, sep } from "path";
+import { dirname, join, normalize, relative, sep } from "path";
 import { loggers } from "../logging";
 import type { ParsedDbtCommand } from "./commands";
 import type { RenderedProfile } from "./adapter-map";
@@ -46,6 +54,34 @@ export interface DbtRunRequest {
    * `--select state:modified+` only builds what changed.
    */
   deferState?: Buffer;
+  /**
+   * dbt's partial-parse manifest from a previous run. Seeded into
+   * target/partial_parse.msgpack so dbt re-parses only changed files. dbt
+   * validates it against file checksums + config and full-parses on mismatch,
+   * so a stale buffer is always safe.
+   */
+  seedPartialParse?: Buffer;
+  /**
+   * tgz of a previously-installed dbt_packages/ (+ package-lock.yml). Extracted
+   * into the project dir before commands so `dbt deps` can be skipped.
+   */
+  seedPackagesArchive?: Buffer;
+  /**
+   * Skip `dbt deps` (used together with seedPackagesArchive when the cached
+   * packages tree is still valid for the current packages.yml).
+   */
+  skipDeps?: boolean;
+  /**
+   * Reuse a stable warm directory instead of a throwaway temp dir. The caller
+   * owns its lifecycle (serialization + eviction); runDbt syncs files in place
+   * (write-if-changed + delete reconciliation) and does NOT delete it on exit.
+   */
+  workingDir?: string;
+  /**
+   * Hash of the dependency declarations. With a warm `workingDir`, lets runDbt
+   * skip `dbt deps` when the on-disk dbt_packages/ tree already matches.
+   */
+  packagesHash?: string | null;
   signal?: AbortSignal;
   onLog?: (line: DbtLogLine) => void;
 }
@@ -78,6 +114,10 @@ export interface DbtRunResult {
     catalog?: Buffer;
     /** Written by `dbt source freshness`. */
     sources?: Buffer;
+    /** dbt's partial-parse manifest — cache for the next run's parse. */
+    partialParse?: Buffer;
+    /** tgz of dbt_packages/ — only present when `dbt deps` ran this command. */
+    packagesArchive?: Buffer;
   };
 }
 
@@ -143,6 +183,147 @@ async function readArtifact(
     return await readFile(join(projectDir, "target", name));
   } catch {
     return undefined;
+  }
+}
+
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Run `tar` as a subprocess; rejects on non-zero exit. */
+function runTar(args: string[], cwd: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("tar", args, {
+      cwd,
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    let stderr = "";
+    child.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString("utf8");
+    });
+    child.on("error", reject);
+    child.on("close", code => {
+      if (code === 0) resolve();
+      else reject(new Error(`tar exited ${code}: ${stderr.slice(0, 500)}`));
+    });
+  });
+}
+
+/** gzip-tar the given entries (those that exist) under projectDir into a Buffer. */
+async function archiveEntries(
+  projectDir: string,
+  entries: string[],
+): Promise<Buffer | undefined> {
+  const present: string[] = [];
+  for (const entry of entries) {
+    if (await pathExists(join(projectDir, entry))) present.push(entry);
+  }
+  if (present.length === 0) return undefined;
+  const tarPath = join(projectDir, ".mako-cache-out.tgz");
+  try {
+    await runTar(["-czf", tarPath, ...present], projectDir);
+    return await readFile(tarPath);
+  } catch (error) {
+    logger.warn("Failed to archive dbt cache entries", {
+      error: String(error),
+    });
+    return undefined;
+  } finally {
+    await rm(tarPath, { force: true }).catch(() => {});
+  }
+}
+
+/** Extract a gzip-tar buffer into projectDir. Best-effort. */
+async function extractArchive(
+  buffer: Buffer,
+  projectDir: string,
+): Promise<void> {
+  const tarPath = join(projectDir, ".mako-cache-in.tgz");
+  try {
+    await writeFile(tarPath, buffer);
+    await runTar(["-xzf", tarPath], projectDir);
+  } finally {
+    await rm(tarPath, { force: true }).catch(() => {});
+  }
+}
+
+/** Write only when content differs — avoids needless mtime bumps that would
+ * defeat dbt's checksum-based partial parsing in a warm dir. */
+async function writeFileIfChanged(
+  absolute: string,
+  content: string,
+  mode?: number,
+): Promise<void> {
+  try {
+    const existing = await readFile(absolute, "utf8");
+    if (existing === content) return;
+  } catch {
+    // Missing — fall through to write.
+  }
+  await mkdir(dirname(absolute), { recursive: true });
+  await writeFile(
+    absolute,
+    content,
+    mode ? { encoding: "utf8", mode } : "utf8",
+  );
+}
+
+// Top-level entries dbt (or we) own — never pruned during reconciliation.
+const RECONCILE_PRESERVED_DIRS = new Set([
+  "target",
+  "dbt_packages",
+  "logs",
+  "state",
+]);
+const RECONCILE_PRESERVED_FILES = new Set(["profiles.yml", "package-lock.yml"]);
+
+async function listFilesRecursive(
+  root: string,
+  current: string,
+  out: string[],
+): Promise<void> {
+  let entries;
+  try {
+    entries = await readdir(current, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const abs = join(current, entry.name);
+    const rel = relative(root, abs).split(sep).join("/");
+    const top = rel.split("/")[0];
+    if (RECONCILE_PRESERVED_DIRS.has(top)) continue;
+    if (entry.isDirectory()) {
+      await listFilesRecursive(root, abs, out);
+    } else if (entry.isFile()) {
+      out.push(rel);
+    }
+  }
+}
+
+/**
+ * Delete files in a warm dir that are no longer part of the project snapshot
+ * (e.g. a model the user deleted), so a stale file can never be built. Keeps
+ * dbt-owned dirs, profiles.yml, keyfiles, and our dotfiles.
+ */
+async function reconcileWarmDir(
+  projectDir: string,
+  keep: Set<string>,
+): Promise<void> {
+  const present: string[] = [];
+  await listFilesRecursive(projectDir, projectDir, present);
+  for (const rel of present) {
+    if (keep.has(rel)) continue;
+    if (RECONCILE_PRESERVED_FILES.has(rel)) continue;
+    if (rel.startsWith(".")) continue; // our markers / cache scratch
+    await rm(join(projectDir, ...rel.split("/")), { force: true }).catch(
+      () => {},
+    );
   }
 }
 
@@ -223,42 +404,103 @@ function execDbtCommand(params: {
 }
 
 /**
+ * Sync a dbt project onto disk: project files + profiles.yml + credential
+ * keyfiles (0600). Writes only changed files (so warm dirs keep dbt's
+ * checksum-based partial parsing valid) and, when `reconcile` is set, prunes
+ * files no longer in the snapshot so a deleted model can never be built.
+ *
+ * Returns the keyfile env map (absolute paths the profile's env_var()
+ * references resolve to). Shared by {@link runDbt} (subprocess) and the
+ * resident engine's prepare so both operate on an identical tree.
+ */
+export async function materializeDbtProject(
+  projectDir: string,
+  params: {
+    files: Array<{ path: string; content: string }>;
+    profile: RenderedProfile;
+    reconcile?: boolean;
+  },
+): Promise<{ keyfileEnv: Record<string, string> }> {
+  // Preserve list for reconciliation (profiles.yml + every snapshot file +
+  // keyfiles get added below).
+  const keep = new Set<string>(["profiles.yml"]);
+
+  for (const file of params.files) {
+    const safePath = ensureSafeRelativePath(file.path);
+    keep.add(safePath);
+    await writeFileIfChanged(
+      join(projectDir, ...safePath.split("/")),
+      file.content,
+    );
+  }
+  await writeFileIfChanged(
+    join(projectDir, "profiles.yml"),
+    params.profile.profilesYml,
+  );
+
+  // Credential files (e.g. BigQuery service-account JSON) with restrictive
+  // perms; their absolute paths are exported so env_var() keyfile refs resolve.
+  const keyfileEnv: Record<string, string> = {};
+  for (const keyfile of params.profile.keyfiles ?? []) {
+    const safePath = ensureSafeRelativePath(keyfile.filename);
+    keep.add(safePath);
+    const absolute = join(projectDir, ...safePath.split("/"));
+    await writeFileIfChanged(absolute, keyfile.content, 0o600);
+    keyfileEnv[keyfile.envVar] = absolute;
+  }
+
+  if (params.reconcile) await reconcileWarmDir(projectDir, keep);
+  return { keyfileEnv };
+}
+
+/**
+ * Seed artifact-store caches into a cold project dir so the resident engine's
+ * first parse is incremental (partial-parse manifest) and package-aware
+ * (dbt_packages/ present, so `dbt parse` resolves package macros without a
+ * `dbt deps` install). No-op when the dir already has fresher on-disk state.
+ */
+export async function seedDbtCaches(
+  projectDir: string,
+  caches: { partialParse?: Buffer; packagesArchive?: Buffer },
+): Promise<void> {
+  if (caches.partialParse) {
+    const pp = join(projectDir, "target", "partial_parse.msgpack");
+    if (!(await pathExists(pp))) {
+      await mkdir(join(projectDir, "target"), { recursive: true });
+      await writeFile(pp, caches.partialParse).catch(() => {});
+    }
+  }
+  if (
+    caches.packagesArchive &&
+    !(await pathExists(join(projectDir, "dbt_packages")))
+  ) {
+    await extractArchive(caches.packagesArchive, projectDir).catch(() => {});
+  }
+}
+
+/**
  * Materialize project files + profiles.yml into a temp dir, run each
  * pre-validated command in order (stopping at the first failure), collect
  * target/ artifacts, and always clean up the temp dir.
  */
 export async function runDbt(request: DbtRunRequest): Promise<DbtRunResult> {
-  const projectDir = await mkdtemp(join(tmpdir(), "mako-dbt-"));
+  // A caller-provided warm dir is reused across runs (caller owns its
+  // lifecycle); otherwise use a throwaway temp dir we clean up on exit.
+  const ownsDir = !request.workingDir;
+  const projectDir =
+    request.workingDir ?? (await mkdtemp(join(tmpdir(), "mako-dbt-")));
   const commandResults: DbtCommandResult[] = [];
   const artifacts: DbtRunResult["artifacts"] = {};
 
   try {
-    for (const file of request.files) {
-      const safePath = ensureSafeRelativePath(file.path);
-      const absolute = join(projectDir, ...safePath.split("/"));
-      await mkdir(dirname(absolute), { recursive: true });
-      await writeFile(absolute, file.content, "utf8");
-    }
-    await writeFile(
-      join(projectDir, "profiles.yml"),
-      request.profile.profilesYml,
-      "utf8",
-    );
-
-    // Materialize credential files (e.g. BigQuery service-account JSON) with
-    // restrictive perms and export their absolute paths so the profile's
-    // env_var('...') keyfile references resolve. Contents are never logged.
-    const keyfileEnv: Record<string, string> = {};
-    for (const keyfile of request.profile.keyfiles ?? []) {
-      const safePath = ensureSafeRelativePath(keyfile.filename);
-      const absolute = join(projectDir, ...safePath.split("/"));
-      await mkdir(dirname(absolute), { recursive: true });
-      await writeFile(absolute, keyfile.content, {
-        encoding: "utf8",
-        mode: 0o600,
-      });
-      keyfileEnv[keyfile.envVar] = absolute;
-    }
+    // Sync project files + profiles.yml + keyfiles into the dir (write-if-
+    // changed + delete reconciliation for warm dirs). Shared with the resident
+    // engine's prepare so both see an identical on-disk tree.
+    const { keyfileEnv } = await materializeDbtProject(projectDir, {
+      files: request.files,
+      profile: request.profile,
+      reconcile: !ownsDir,
+    });
 
     // Seed prior artifacts into target/ for `dbt retry` (run_results.json is
     // what dbt reads to resume at the failed/skipped nodes).
@@ -287,6 +529,25 @@ export async function runDbt(request: DbtRunRequest): Promise<DbtRunResult> {
       await writeFile(join(stateDir, "manifest.json"), request.deferState);
     }
 
+    // Warm dbt's parser: seed the previous run's partial-parse manifest so
+    // only changed files are re-parsed. dbt self-invalidates on checksum /
+    // config mismatch, so a stale buffer just triggers a full parse. In a warm
+    // dir the on-disk manifest is fresher than any seed, so only seed when the
+    // dir is cold (no existing manifest).
+    if (request.seedPartialParse) {
+      const partialParsePath = join(
+        projectDir,
+        "target",
+        "partial_parse.msgpack",
+      );
+      if (!(await pathExists(partialParsePath))) {
+        await mkdir(join(projectDir, "target"), { recursive: true });
+        await writeFile(partialParsePath, request.seedPartialParse).catch(
+          () => {},
+        );
+      }
+    }
+
     const resolved = resolveDbtBin(
       request.profile.adapterPackage,
       request.dbtVersion,
@@ -302,41 +563,81 @@ export async function runDbt(request: DbtRunRequest): Promise<DbtRunResult> {
 
     // Install packages first when declared. The executor runs one runDbt per
     // command, each in its own temp dir, so deps must be (re)installed here
-    // before any command that depends on package macros can compile.
+    // before any command that depends on package macros can compile — unless
+    // we can restore a cached dbt_packages/ tree and skip the network install.
     if (projectHasPackages(request.files)) {
-      const depsLogLines: DbtLogLine[] = [];
-      const onDepsLog = (line: DbtLogLine) => {
-        depsLogLines.push(line);
-        request.onLog?.(line);
-      };
-      onDepsLog({ ts: new Date(), level: "info", line: "$ dbt deps" });
-      const depsExit = await execDbtCommand({
-        bin: resolved.bin,
-        args: [
-          ...resolved.prefixArgs,
-          "deps",
-          "--profiles-dir",
-          projectDir,
-          "--project-dir",
-          projectDir,
-          "--log-format",
-          "json",
-          "--no-use-colors",
-        ],
-        cwd: projectDir,
-        env: childEnv,
-        timeoutMs: request.commandTimeoutMs ?? 9 * 60 * 1000,
-        signal: request.signal,
-        onLog: onDepsLog,
-      });
-      if (depsExit !== 0) {
-        commandResults.push({
-          command: "deps",
-          exitCode: depsExit,
-          logLines: depsLogLines,
-          runResults: undefined,
+      const packagesMarker = join(projectDir, ".mako_packages_hash");
+
+      // Warm dir already has a matching dbt_packages/ tree → skip deps with no
+      // network call and no extract.
+      let warmFresh = false;
+      if (!ownsDir && request.packagesHash) {
+        const markerHash = await readFile(packagesMarker, "utf8")
+          .then(value => value.trim())
+          .catch(() => undefined);
+        warmFresh =
+          markerHash === request.packagesHash &&
+          (await pathExists(join(projectDir, "dbt_packages")));
+      }
+
+      let packagesSeeded = false;
+      if (!warmFresh && request.seedPackagesArchive) {
+        try {
+          await extractArchive(request.seedPackagesArchive, projectDir);
+          packagesSeeded = true;
+        } catch (error) {
+          logger.warn("Failed to seed dbt_packages cache; running dbt deps", {
+            error: String(error),
+          });
+        }
+      }
+
+      const skipDeps =
+        warmFresh || (request.skipDeps === true && packagesSeeded);
+      if (!skipDeps) {
+        const depsLogLines: DbtLogLine[] = [];
+        const onDepsLog = (line: DbtLogLine) => {
+          depsLogLines.push(line);
+          request.onLog?.(line);
+        };
+        onDepsLog({ ts: new Date(), level: "info", line: "$ dbt deps" });
+        const depsExit = await execDbtCommand({
+          bin: resolved.bin,
+          args: [
+            ...resolved.prefixArgs,
+            "deps",
+            "--profiles-dir",
+            projectDir,
+            "--project-dir",
+            projectDir,
+            "--log-format",
+            "json",
+            "--no-use-colors",
+          ],
+          cwd: projectDir,
+          env: childEnv,
+          timeoutMs: request.commandTimeoutMs ?? 9 * 60 * 1000,
+          signal: request.signal,
+          onLog: onDepsLog,
         });
-        return { success: false, commandResults, artifacts };
+        if (depsExit !== 0) {
+          commandResults.push({
+            command: "deps",
+            exitCode: depsExit,
+            logLines: depsLogLines,
+            runResults: undefined,
+          });
+          return { success: false, commandResults, artifacts };
+        }
+        // Freshly installed — archive so the next run can skip the install.
+        artifacts.packagesArchive = await archiveEntries(projectDir, [
+          "dbt_packages",
+          "package-lock.yml",
+        ]);
+        // Warm dir: record the hash so subsequent runs skip deps entirely.
+        if (!ownsDir && request.packagesHash) {
+          await writeFile(packagesMarker, request.packagesHash).catch(() => {});
+        }
       }
     }
 
@@ -426,10 +727,17 @@ export async function runDbt(request: DbtRunRequest): Promise<DbtRunResult> {
     artifacts.runResults = await readArtifact(projectDir, "run_results.json");
     artifacts.catalog = await readArtifact(projectDir, "catalog.json");
     artifacts.sources = await readArtifact(projectDir, "sources.json");
+    artifacts.partialParse = await readArtifact(
+      projectDir,
+      "partial_parse.msgpack",
+    );
 
     return { success, commandResults, artifacts };
   } finally {
-    await rm(projectDir, { recursive: true, force: true }).catch(() => {});
+    // Only delete throwaway dirs. Warm dirs are owned by the caller and reused.
+    if (ownsDir) {
+      await rm(projectDir, { recursive: true, force: true }).catch(() => {});
+    }
   }
 }
 

--- a/api/src/dbt/workspace-dir.service.ts
+++ b/api/src/dbt/workspace-dir.service.ts
@@ -1,0 +1,91 @@
+/**
+ * Warm dbt working directories.
+ *
+ * dbt-core is a filesystem tool, so every command must run against a real
+ * project directory. Instead of materializing a throwaway temp dir per command
+ * (cold parse + re-materialize every time), we keep a STABLE directory per
+ * (workspace, project, environment, role) and reuse it across runs. That keeps
+ * `target/partial_parse.msgpack` and `dbt_packages/` warm on the instance, so
+ * dbt re-parses only changed files and skips `dbt deps` — the same trick the
+ * dbt Cloud "develop" session uses, adapted to our single-container deploy.
+ *
+ * Roles isolate workloads so a long deploy build never blocks an interactive
+ * compile on the same project: "adhoc" (parse/compile/show from the IDE +
+ * agent) and "run" (the Inngest executor) get separate warm dirs.
+ *
+ * Access to a given dir is serialized by an in-process async mutex. Within one
+ * process (local dev runs the executor in the API process) this prevents two
+ * commands from corrupting the same dir. In production the executor and API
+ * are separate containers with separate disks, and the executor is already
+ * concurrency=1 per project, so the mutex is sufficient.
+ *
+ * Cloud Run instances are ephemeral (their /tmp is cleared on recycle), so
+ * warm dirs self-bound across deploys; a cold instance simply warms on first
+ * use (optionally seeded from the artifact-store cache).
+ */
+
+import { mkdir } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const WARM_ROOT =
+  process.env.DBT_WARM_DIR_ROOT ?? join(tmpdir(), "mako-dbt-warm");
+
+/** Escape hatch: set DBT_DISABLE_WARM_DIR=true to force throwaway temp dirs. */
+export function warmDirsEnabled(): boolean {
+  return process.env.DBT_DISABLE_WARM_DIR !== "true";
+}
+
+export type DbtDirRole = "adhoc" | "run";
+
+export interface ProjectDirScope {
+  workspaceId: string;
+  projectId: string;
+  environment: string;
+  role: DbtDirRole;
+}
+
+function sanitize(value: string): string {
+  return value.replace(/[^\w.-]/g, "_");
+}
+
+function dirFor(scope: ProjectDirScope): string {
+  return join(
+    WARM_ROOT,
+    sanitize(scope.workspaceId),
+    sanitize(scope.projectId),
+    `${sanitize(scope.environment)}__${scope.role}`,
+  );
+}
+
+// Per-dir promise chain: each acquirer waits on the previous holder's release.
+const locks = new Map<string, Promise<void>>();
+
+/**
+ * Run `fn` with exclusive access to the project's warm directory. Serializes
+ * concurrent callers for the same dir within this process.
+ */
+export async function withProjectDir<T>(
+  scope: ProjectDirScope,
+  fn: (dir: string) => Promise<T>,
+): Promise<T> {
+  const dir = dirFor(scope);
+
+  const previous = locks.get(dir) ?? Promise.resolve();
+  let release: () => void = () => {};
+  const gate = new Promise<void>(resolve => {
+    release = resolve;
+  });
+  const chained = previous.then(() => gate);
+  locks.set(dir, chained);
+
+  await previous;
+  try {
+    await mkdir(dir, { recursive: true });
+    return await fn(dir);
+  } finally {
+    release();
+    // Drop the entry if no one chained after us, to bound the map.
+    if (locks.get(dir) === chained) locks.delete(dir);
+  }
+}

--- a/api/src/inngest/functions/dbt-run.ts
+++ b/api/src/inngest/functions/dbt-run.ts
@@ -24,6 +24,16 @@ import {
   type DbtLogLine,
 } from "../../dbt/runner.service";
 import { triggerDbtJobRun } from "../../dbt/dbt-run.service";
+import {
+  computePackagesHash,
+  loadDbtCaches,
+  saveParseCache,
+  savePackagesCache,
+} from "../../dbt/dbt-cache.service";
+import {
+  warmDirsEnabled,
+  withProjectDir,
+} from "../../dbt/workspace-dir.service";
 import { getNextScheduledConsoleRunAt } from "../../services/scheduled-query-schedule.service";
 import { getDashboardArtifactStore } from "../../services/dashboard-artifact-store.service";
 
@@ -212,19 +222,69 @@ export const dbtRunExecutorFunction = inngest.createFunction(
           runInfo.deferStateKey ?? undefined,
         );
 
+        // Warm caches: skip a full re-parse (and `dbt deps` when packages are
+        // unchanged) by seeding the previous command/run's state. Best-effort.
+        const cacheScope = {
+          workspaceId: data.workspaceId,
+          projectId: data.projectId,
+          environment: runInfo.environment,
+        };
+        const packagesHash = computePackagesHash(snapshot.files);
+        const caches = await loadDbtCaches(cacheScope, packagesHash);
+
         try {
-          const result = await runDbt({
-            files: snapshot.files,
-            profile: snapshot.profile,
-            commands: [parsed],
-            dbtVersion: snapshot.project.dbtVersion,
-            // Cloud Run services deploy with --timeout=3600; leave buffer for
-            // snapshot loading + artifact upload within the step request.
-            commandTimeoutMs: 50 * 60 * 1000,
-            restoreTarget,
-            deferState,
-            onLog: logWriter.onLog,
-          });
+          // Deploy builds run in a warm dir (role=run), separate from the
+          // interactive (adhoc) dir so the two never block each other. The
+          // artifact caches above seed a cold instance; thereafter target/ and
+          // dbt_packages/ stay warm on disk across steps and runs.
+          const runOnce = (workingDir?: string) =>
+            runDbt({
+              files: snapshot.files,
+              profile: snapshot.profile,
+              commands: [parsed],
+              dbtVersion: snapshot.project.dbtVersion,
+              // Cloud Run services deploy with --timeout=3600; leave buffer for
+              // snapshot loading + artifact upload within the step request.
+              commandTimeoutMs: 50 * 60 * 1000,
+              restoreTarget,
+              deferState,
+              seedPartialParse: caches.partialParse,
+              seedPackagesArchive: caches.packages,
+              skipDeps: caches.packagesFresh,
+              packagesHash,
+              workingDir,
+              onLog: logWriter.onLog,
+            });
+
+          let result: Awaited<ReturnType<typeof runDbt>> | undefined;
+          if (warmDirsEnabled()) {
+            try {
+              result = await withProjectDir(
+                { ...cacheScope, role: "run" },
+                dir => runOnce(dir),
+              );
+            } catch (warmError) {
+              logger.warn(
+                "Warm dir run failed; falling back to throwaway dir",
+                {
+                  error: String(warmError),
+                },
+              );
+            }
+          }
+          if (!result) result = await runOnce(undefined);
+
+          // Persist refreshed caches for the next command/run.
+          if (result.artifacts.partialParse) {
+            await saveParseCache(cacheScope, result.artifacts.partialParse);
+          }
+          if (result.artifacts.packagesArchive && packagesHash) {
+            await savePackagesCache(
+              cacheScope,
+              result.artifacts.packagesArchive,
+              packagesHash,
+            );
+          }
 
           const commandResult = result.commandResults[0];
           const stepResults = [

--- a/api/src/scripts/seed-dbt-engine-demo.ts
+++ b/api/src/scripts/seed-dbt-engine-demo.ts
@@ -1,0 +1,246 @@
+/* eslint-disable no-console */
+/**
+ * Seed a local dbt project wired to a local Postgres so you can exercise the
+ * resident dbt engine end-to-end through the running app (open the project,
+ * hit Compile / use the agent's dbt_compile_model — with DBT_ENGINE_ENABLED=true
+ * the compile is served by the warm in-memory manifest).
+ *
+ * Companion Postgres (throwaway):
+ *   docker run -d --name mako-dbt-pg -e POSTGRES_PASSWORD=testpw \
+ *     -e POSTGRES_DB=mako -p 55432:5432 postgres:16
+ *
+ * Then:  pnpm --filter api run seed:dbt-demo
+ *
+ * Idempotent. REFUSES to run against a production-looking database.
+ * Credentials / target Postgres are overridable via env (see constants below).
+ */
+import path from "path";
+import fs from "fs";
+import dotenv from "dotenv";
+import mongoose from "mongoose";
+import bcrypt from "bcrypt";
+
+const envPath = path.resolve(__dirname, "../../../.env");
+if (fs.existsSync(envPath)) {
+  dotenv.config({ path: envPath });
+}
+
+const DEMO_EMAIL = (process.env.DBT_DEMO_EMAIL || "dbt-demo@mako.dev")
+  .trim()
+  .toLowerCase();
+const DEMO_PASSWORD = process.env.DBT_DEMO_PASSWORD || "DbtDemo!2024";
+const WORKSPACE_NAME = "dbt Engine Demo";
+const CONNECTION_NAME = "Local Postgres (dbt demo)";
+const PROJECT_NAME = "Engine Demo";
+
+// Target Postgres (the throwaway container above by default).
+const PG_HOST = process.env.DBT_DEMO_PG_HOST || "127.0.0.1";
+const PG_PORT = Number(process.env.DBT_DEMO_PG_PORT || "55432");
+const PG_USER = process.env.DBT_DEMO_PG_USER || "postgres";
+const PG_PASSWORD = process.env.DBT_DEMO_PG_PASSWORD || "testpw";
+const PG_DATABASE = process.env.DBT_DEMO_PG_DATABASE || "mako";
+
+const PROJECT_FILES: Array<{ path: string; content: string }> = [
+  {
+    path: "dbt_project.yml",
+    content: [
+      "name: engine_demo",
+      "profile: mako", // must match DBT_PROFILE_NAME rendered by adapter-map
+      'version: "1.0.0"',
+      "config-version: 2",
+      'model-paths: ["models"]',
+      "models:",
+      "  engine_demo:",
+      "    +materialized: view",
+      "",
+    ].join("\n"),
+  },
+  {
+    path: "models/example/my_first_model.sql",
+    content: [
+      "-- Edit me and hit Compile: the resident engine reuses the warm manifest.",
+      "select",
+      "  1 as id,",
+      "  'demo' as name,",
+      "  current_date as loaded_on",
+      "",
+    ].join("\n"),
+  },
+  {
+    path: "models/example/downstream.sql",
+    content: [
+      "select id, name from {{ ref('my_first_model') }} where id > 0",
+      "",
+    ].join("\n"),
+  },
+];
+
+function isProductionUri(uri: string): boolean {
+  if (process.env.PROD_DATABASE_URL && uri === process.env.PROD_DATABASE_URL) {
+    return true;
+  }
+  try {
+    const dbName = new URL(uri).pathname.replace(/^\//, "").split("?")[0];
+    if (dbName.toLowerCase() === "production") return true;
+  } catch {
+    /* non-standard URI */
+  }
+  return /\/production(\b|\?|$)/i.test(uri);
+}
+
+async function main(): Promise<void> {
+  const uri = process.env.DEV_DATABASE_URL || process.env.DATABASE_URL;
+  if (!uri) {
+    console.log("[seed-dbt-demo] No DATABASE_URL set; skipping.");
+    return;
+  }
+  if (isProductionUri(uri)) {
+    console.log("[seed-dbt-demo] Refusing to seed PRODUCTION. Skipping.");
+    return;
+  }
+
+  await mongoose.connect(uri, { serverSelectionTimeoutMS: 15000 });
+
+  const { User } = await import("../database/schema");
+  const { DatabaseConnection, DbtProject, DbtFile } = await import(
+    "../database/workspace-schema"
+  );
+  const { workspaceService } = await import("../services/workspace.service");
+
+  const rounds = parseInt(process.env.BCRYPT_ROUNDS || "10", 10);
+  const hashedPassword = await bcrypt.hash(DEMO_PASSWORD, rounds);
+
+  let user = await User.findOne({ email: DEMO_EMAIL });
+  if (!user) {
+    user = await User.create({
+      email: DEMO_EMAIL,
+      hashedPassword,
+      emailVerified: true,
+      onboarding: { completedAt: new Date(), role: "developer" },
+    });
+    console.log(`[seed-dbt-demo] Created user ${DEMO_EMAIL}`);
+  } else {
+    user.hashedPassword = hashedPassword;
+    user.emailVerified = true;
+    user.onboarding = {
+      ...(user.onboarding || {}),
+      completedAt: user.onboarding?.completedAt || new Date(),
+    };
+    await user.save();
+    console.log(`[seed-dbt-demo] Updated user ${DEMO_EMAIL}`);
+  }
+
+  const { workspace } = await workspaceService.getOrCreateDefaultWorkspace(
+    user._id,
+    WORKSPACE_NAME,
+  );
+  console.log(
+    `[seed-dbt-demo] Workspace: "${workspace.name}" (${workspace._id})`,
+  );
+
+  // Postgres connection (the `set: encryptObject` hook encrypts at rest).
+  let connection = await DatabaseConnection.findOne({
+    workspaceId: workspace._id,
+    name: CONNECTION_NAME,
+  });
+  const connectionFields = {
+    host: PG_HOST,
+    port: PG_PORT,
+    username: PG_USER,
+    password: PG_PASSWORD,
+    database: PG_DATABASE,
+  };
+  if (!connection) {
+    connection = await DatabaseConnection.create({
+      workspaceId: workspace._id,
+      name: CONNECTION_NAME,
+      type: "postgresql",
+      connection: connectionFields,
+      createdBy: user._id.toString(),
+    });
+    console.log("[seed-dbt-demo] Created Postgres connection.");
+  } else {
+    connection.set("connection", connectionFields);
+    await connection.save();
+    console.log("[seed-dbt-demo] Updated Postgres connection.");
+  }
+
+  // dbt project with a single "dev" environment pointing at the connection.
+  let project = await DbtProject.findOne({
+    workspaceId: workspace._id,
+    name: PROJECT_NAME,
+  });
+  const environments = [
+    {
+      name: "dev",
+      connectionId: connection._id,
+      targetSchema: "public",
+      threads: 4,
+    },
+  ];
+  if (!project) {
+    project = await DbtProject.create({
+      workspaceId: workspace._id,
+      name: PROJECT_NAME,
+      dbtVersion: "1.9",
+      environments,
+      defaultEnvironment: "dev",
+      createdBy: user._id.toString(),
+    });
+    console.log("[seed-dbt-demo] Created dbt project.");
+  } else {
+    project.environments = environments;
+    project.defaultEnvironment = "dev";
+    await project.save();
+    console.log("[seed-dbt-demo] Updated dbt project.");
+  }
+
+  for (const file of PROJECT_FILES) {
+    await DbtFile.findOneAndUpdate(
+      { projectId: project._id, path: file.path },
+      {
+        $set: {
+          workspaceId: workspace._id,
+          projectId: project._id,
+          path: file.path,
+          content: file.content,
+          updatedBy: user._id.toString(),
+          is_deleted: false,
+        },
+      },
+      { upsert: true, new: true, setDefaultsOnInsert: true },
+    );
+  }
+  console.log(`[seed-dbt-demo] Seeded ${PROJECT_FILES.length} dbt files.`);
+
+  console.log(
+    [
+      "",
+      "[seed-dbt-demo] Done. To exercise the resident engine:",
+      "  1) Ensure local Postgres is running (see header comment).",
+      "  2) Set DBT_ENGINE_ENABLED=true in your .env.",
+      "  3) pnpm dev",
+      `  4) Log in as ${DEMO_EMAIL} / ${DEMO_PASSWORD}`,
+      `  5) Open project "${PROJECT_NAME}" -> models/example/my_first_model.sql -> Compile.`,
+      "  6) Watch the API logs for: 'dbt engine compile hit'.",
+      "",
+    ].join("\n"),
+  );
+}
+
+main()
+  .catch(err => {
+    console.log(
+      "[seed-dbt-demo] Failed:",
+      err instanceof Error ? err.message : String(err),
+    );
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    try {
+      await mongoose.disconnect();
+    } catch {
+      /* ignore */
+    }
+    process.exit(process.exitCode ?? 0);
+  });

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -77,6 +77,7 @@ import { DbFlowFormRef } from "./DbFlowForm";
 import { safeStringify, toJsonSafe } from "../lib/json-safe";
 import { StreamingToolCard, type ToolPartState } from "./StreamingToolCard";
 import { ClarifyingQuestionsCard } from "./ClarifyingQuestionsCard";
+import { DbtRunCard } from "./DbtRunCard";
 import { PlanCard } from "./PlanCard";
 import {
   focusPlanTab,
@@ -912,6 +913,32 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
               }
               if (rawState !== "output-error") {
                 return null;
+              }
+            }
+
+            // Async dbt builds: once dbt_run_model has dispatched a run (output
+            // carries a runId), render a live run card that self-polls the run
+            // — decoupled from the agent turn, so it keeps updating after the
+            // turn ends and resumes on chat reload. While the dispatch is still
+            // in flight, or if it errored without a runId, fall through to the
+            // generic card.
+            if (
+              toolName === "dbt_run_model" &&
+              rawState === "output-available"
+            ) {
+              const dbtOutput = cardOutput as { runId?: string } | undefined;
+              const dbtInput = part.input as
+                | { projectId?: string; model?: string }
+                | undefined;
+              if (dbtOutput?.runId && dbtInput?.projectId) {
+                return (
+                  <DbtRunCard
+                    key={key}
+                    runId={dbtOutput.runId}
+                    projectId={dbtInput.projectId}
+                    label={dbtInput.model}
+                  />
+                );
               }
             }
             return (

--- a/app/src/components/DbtRunCard.tsx
+++ b/app/src/components/DbtRunCard.tsx
@@ -1,0 +1,341 @@
+/**
+ * DbtRunCard — live dbt run widget rendered inline in chat for the agent's
+ * `dbt_run_model` tool result.
+ *
+ * The build runs asynchronously in the runner (Inngest), so this card is
+ * fully decoupled from the agent turn / chat SSE: it self-polls
+ * `GET /runs/:runId` every 2s while the run is queued/running (same pattern as
+ * DbtJobView), keeps updating after the turn ends, and resumes on chat reload
+ * because the runId is persisted in the tool part. Cancel hits the existing
+ * `/runs/:runId/cancel` endpoint.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Box,
+  Chip,
+  CircularProgress,
+  IconButton,
+  Tooltip,
+} from "@mui/material";
+import {
+  Square as StopIcon,
+  ChevronRight as ChevronRightIcon,
+  ChevronDown as ChevronDownIcon,
+} from "lucide-react";
+import { useWorkspace } from "../contexts/workspace-context";
+import { useDbtStore, type DbtRunItem } from "../store/dbtStore";
+
+interface DbtRunCardProps {
+  runId: string;
+  projectId: string;
+  /** Selector/model label from the tool input (e.g. "stg_orders+"). */
+  label?: string;
+}
+
+const ACTIVE_POLL_INTERVAL_MS = 2_000;
+const MAX_VISIBLE_LOGS = 200;
+
+function statusColor(status: DbtRunItem["status"] | undefined): string {
+  switch (status) {
+    case "running":
+    case "queued":
+      return "primary.main";
+    case "success":
+      return "success.main";
+    case "error":
+      return "error.main";
+    case "cancelled":
+      return "text.secondary";
+    default:
+      return "text.secondary";
+  }
+}
+
+function formatDuration(ms: number | undefined): string {
+  if (ms === undefined) return "";
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = ms / 1000;
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  const minutes = Math.floor(seconds / 60);
+  const rest = Math.round(seconds % 60);
+  return `${minutes}m ${rest}s`;
+}
+
+export function DbtRunCard({ runId, projectId, label }: DbtRunCardProps) {
+  const { currentWorkspace } = useWorkspace();
+  const workspaceId = currentWorkspace?.id;
+
+  const run = useDbtStore(s => s.runDetails[runId]);
+  const fetchRunDetails = useDbtStore(s => s.fetchRunDetails);
+  const cancelRun = useDbtStore(s => s.cancelRun);
+
+  const [expanded, setExpanded] = useState(false);
+  const [cancelling, setCancelling] = useState(false);
+  const logScrollRef = useRef<HTMLDivElement | null>(null);
+
+  const status = run?.status;
+  const isActive = status === "running" || status === "queued";
+
+  // Self-poll while active — decoupled from the agent turn. Mirrors the
+  // run-detail poll in DbtJobView. Runs once for already-terminal runs
+  // (e.g. on chat reload) and then stops.
+  useEffect(() => {
+    if (!workspaceId) return;
+    let stopped = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const poll = async () => {
+      const details = await fetchRunDetails(workspaceId, projectId, runId);
+      if (stopped) return;
+      if (details?.status === "running" || details?.status === "queued") {
+        timer = setTimeout(() => void poll(), ACTIVE_POLL_INTERVAL_MS);
+      }
+    };
+    void poll();
+
+    return () => {
+      stopped = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [workspaceId, projectId, runId, fetchRunDetails]);
+
+  // Auto-scroll logs while expanded + running.
+  useEffect(() => {
+    if (expanded && isActive && logScrollRef.current) {
+      logScrollRef.current.scrollTop = logScrollRef.current.scrollHeight;
+    }
+  }, [run?.logs, expanded, isActive]);
+
+  const handleCancel = useCallback(
+    async (event: React.MouseEvent) => {
+      event.stopPropagation();
+      if (!workspaceId || cancelling) return;
+      setCancelling(true);
+      await cancelRun(workspaceId, projectId, runId);
+      await fetchRunDetails(workspaceId, projectId, runId);
+      setCancelling(false);
+    },
+    [workspaceId, projectId, runId, cancelling, cancelRun, fetchRunDetails],
+  );
+
+  const steps = run?.stepResults ?? [];
+  const logs = run?.logs ?? [];
+  const visibleLogs = logs.slice(-MAX_VISIBLE_LOGS);
+  const hasBody = steps.length > 0 || logs.length > 0;
+
+  const command = run?.commands?.[0];
+  const title = label
+    ? `Build ${label}`
+    : command
+      ? `dbt ${command}`
+      : "dbt build";
+
+  const statusLabel = status ?? "queued";
+
+  return (
+    <Box
+      sx={{
+        my: 0.75,
+        borderRadius: 1.5,
+        border: 1,
+        borderColor: isActive
+          ? "primary.main"
+          : status === "error"
+            ? "error.main"
+            : "divider",
+        overflow: "hidden",
+        transition: "border-color 0.3s",
+        backgroundColor: theme =>
+          theme.palette.mode === "dark"
+            ? "rgba(255,255,255,0.02)"
+            : "rgba(0,0,0,0.015)",
+      }}
+    >
+      {/* Header */}
+      <Box
+        onClick={() => hasBody && setExpanded(prev => !prev)}
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1,
+          px: 1.25,
+          py: 0.75,
+          cursor: hasBody ? "pointer" : "default",
+          "&:hover": hasBody ? { backgroundColor: "action.hover" } : undefined,
+        }}
+      >
+        {hasBody ? (
+          expanded ? (
+            <ChevronDownIcon size={14} />
+          ) : (
+            <ChevronRightIcon size={14} />
+          )
+        ) : (
+          <Box sx={{ width: 14 }} />
+        )}
+        <Box
+          component="span"
+          sx={{
+            fontFamily: "monospace",
+            fontSize: "0.8rem",
+            fontWeight: 600,
+            flex: 1,
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}
+          title={title}
+        >
+          {title}
+        </Box>
+        {run?.durationMs !== undefined && (
+          <Box
+            component="span"
+            sx={{ fontSize: "0.72rem", color: "text.secondary" }}
+          >
+            {formatDuration(run.durationMs)}
+          </Box>
+        )}
+        <Chip
+          size="small"
+          variant="outlined"
+          icon={isActive ? <CircularProgress size={10} /> : undefined}
+          label={statusLabel}
+          sx={{
+            height: 20,
+            textTransform: "capitalize",
+            fontWeight: 600,
+            color: statusColor(status),
+            borderColor: statusColor(status),
+          }}
+        />
+        {isActive && (
+          <Tooltip title="Cancel build">
+            <span>
+              <IconButton
+                size="small"
+                onClick={handleCancel}
+                disabled={cancelling}
+              >
+                <StopIcon size={13} />
+              </IconButton>
+            </span>
+          </Tooltip>
+        )}
+      </Box>
+
+      {/* Error summary (always visible when failed) */}
+      {status === "error" && run?.error && (
+        <Box
+          sx={{
+            px: 1.25,
+            py: 0.5,
+            fontSize: "0.72rem",
+            color: "error.main",
+            borderTop: "1px solid",
+            borderColor: "divider",
+          }}
+        >
+          {run.error}
+        </Box>
+      )}
+
+      {/* Expandable body: step results + logs */}
+      {expanded && hasBody && (
+        <Box sx={{ borderTop: "1px solid", borderColor: "divider" }}>
+          {steps.length > 0 && (
+            <Box
+              component="table"
+              sx={{
+                width: "100%",
+                fontSize: "0.72rem",
+                borderCollapse: "collapse",
+                "& td, & th": {
+                  borderBottom: "1px solid",
+                  borderColor: "divider",
+                  p: 0.5,
+                  textAlign: "left",
+                },
+              }}
+            >
+              <thead>
+                <tr>
+                  <th>Node</th>
+                  <th>Type</th>
+                  <th>Status</th>
+                  <th>Time</th>
+                  <th>Rows</th>
+                </tr>
+              </thead>
+              <tbody>
+                {steps.map(step => (
+                  <Box
+                    component="tr"
+                    key={step.uniqueId}
+                    sx={{
+                      color:
+                        step.status === "error" || step.status === "fail"
+                          ? "error.main"
+                          : step.status === "warn"
+                            ? "warning.main"
+                            : "inherit",
+                    }}
+                  >
+                    <td>{step.name}</td>
+                    <td>{step.resourceType}</td>
+                    <td>
+                      {step.status}
+                      {step.message &&
+                      (step.status === "error" ||
+                        step.status === "fail" ||
+                        step.status === "warn")
+                        ? ` — ${step.message}`
+                        : ""}
+                    </td>
+                    <td>{(step.executionTimeMs / 1000).toFixed(2)}s</td>
+                    <td>{step.rowsAffected ?? ""}</td>
+                  </Box>
+                ))}
+              </tbody>
+            </Box>
+          )}
+
+          {logs.length > 0 && (
+            <Box
+              ref={logScrollRef}
+              sx={{
+                maxHeight: 220,
+                overflow: "auto",
+                fontFamily: "monospace",
+                fontSize: "0.7rem",
+                p: 1,
+                whiteSpace: "pre-wrap",
+              }}
+            >
+              {visibleLogs.map((log, index) => (
+                <Box
+                  key={index}
+                  component="div"
+                  sx={{
+                    color:
+                      log.level === "error"
+                        ? "error.main"
+                        : log.level === "warn"
+                          ? "warning.main"
+                          : "text.primary",
+                  }}
+                >
+                  <Box component="span" sx={{ color: "text.secondary", mr: 1 }}>
+                    {new Date(log.ts).toLocaleTimeString()}
+                  </Box>
+                  {log.line}
+                </Box>
+              ))}
+            </Box>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}


### PR DESCRIPTION
## Why

Two pieces of dbt work, combined into one PR against `master`:

1. **Async run card** — `dbt_run_model` no longer blocks the chat SSE stream. It returns a `runId` immediately and the UI renders a live, self-polling `DbtRunCard`. This is the real fix for the "Building…/Interrupted" stalls chased in #508/#510/#511 (long runs were tied to a single live connection that proxies would time out).
2. **Warm dirs + resident dbt engine** — removes the per-call cold start that made interactive compile/show pathologically slow.

> Originally split as a stack (run-card on a feature branch + engine in #513). Combined here, rebased cleanly onto current `master`. The separate "IDE quick wins" commit was detected as already upstream and dropped during rebase.

## What

### Async run card
- `dbt_run_model` returns `{ runId }` right away; `dbt_get_run` gains `waitMs` for server-side polling.
- New `app/src/components/DbtRunCard.tsx`: live status, self-polls until terminal, survives stream disconnects.
- `Chat.tsx` renders `DbtRunCard` (instead of the generic `StreamingToolCard`) whenever a `dbt_run_model` output carries a `runId`.

### Warm working directories (`workspace-dir.service.ts`)
- Stable, mutex-protected dir per `(workspace, project, environment, role)` instead of a throwaway temp dir per call.
- `reconcileWarmDir` / `writeFileIfChanged` keep the on-disk project idempotently in sync, preserving `target/partial_parse.msgpack` and `dbt_packages/` between runs → partial parse + cached deps actually get reused.

### dbt artifact cache (`dbt-cache.service.ts`)
- Persists `partial_parse.msgpack` and a `dbt_packages/` archive to the artifact store, keyed by project + packages hash, so a fresh warm dir (or Inngest worker) seeds itself instead of paying full parse + `dbt deps` on first touch. Wired through `dbt-run.ts` + `runner.service.ts`.

### Resident dbt engine (flag-gated) — `engine/dbt_engine.py` + `dbt-engine.service.ts`
- Long-lived Python process holding parsed manifests **in memory** via dbt's programmatic `dbtRunner`. `prepare` parses once; subsequent `compile`/`show` reuse the warm manifest → sub-second.
- Node supervisor pools processes per `(adapter, version, connection-env hash)` with LRU eviction; warehouse creds are passed via `env_var()` so secrets stay scoped per pool entry.
- JSON-RPC over **fd 3** (not stdout) so dbt's own stdout logging can't corrupt the protocol.
- `dbt-project.service.ts` routes `compile` through the engine when both flags are on, with full fallback to the existing subprocess path.

### De-risking + local E2E
- `dbt-engine.contract.test.ts` (gated by `RUN_DBT_ENGINE_CONTRACT=1`) pins the `dbtRunner` programmatic-API assumptions against real `dbt-core + dbt-duckdb`.
- `scripts/seed-dbt-engine-demo.ts` (+ `seed:dbt-demo`) seeds a user/workspace/Postgres connection/project for click-testing. Validated E2E on throwaway Mongo (replica set) + Postgres: seed → `runAdhocDbtCommand` compile → `dbt engine compile hit` x3.

## Rollout / safety
- Engine + warm-dirs are **flag-gated** (`dbtEngineEnabled()` + warm-dirs flag). Flags off → behavior unchanged, subprocess runner.
- `api/package.json` `copyfiles` glob ships `src/**/*.py` into `dist`.

## Build
Rebased onto current `master`; clean (no conflicts). Green:
- `pnpm --filter api run build` (lint + tsc + copyfiles)
- `pnpm --filter app run typecheck && pnpm --filter app run lint`

## Test plan
- [ ] `RUN_DBT_ENGINE_CONTRACT=1 pnpm --filter api test dbt-engine.contract` against dbt-core + dbt-duckdb
- [ ] `pnpm seed:dbt-demo`, then run a model from chat → confirm `DbtRunCard` goes live and reaches a terminal state without a live SSE connection
- [ ] Repeat compiles hit the resident engine (sub-second)
- [ ] Flags off → subprocess fallback unchanged