### PR TITLE
feat(dbt): fast interactive dbt + run visibility — async card, SSE keepalive, warm dirs + resident engine, Transforms Runs view

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -166,7 +166,14 @@ jobs:
       GH_CLIENT_SECRET: ${{ secrets.GH_CLIENT_SECRET }}
       GOOGLE_CLIENT_ID: ${{ vars.GOOGLE_CLIENT_ID }}
       GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
-      INNGEST_EVENT_KEY: ${{ vars.INNGEST_EVENT_KEY }}
+      # Inngest routes a sent event to an environment by its EVENT KEY, not by
+      # INNGEST_ENV / the x-inngest-env header. Branch environments share a single
+      # "Branch Environments" event key; pairing it with INNGEST_ENV=pr-<n> routes
+      # events to that branch env. Using the production event key here would make
+      # event-triggered functions (e.g. dbt/run.requested) escape to prod and the
+      # branch executor never fires (runs stuck "queued"). Falls back to the prod
+      # key only if the branch key secret is unset, to avoid breaking deploys.
+      INNGEST_EVENT_KEY: ${{ secrets.INNGEST_BRANCH_EVENT_KEY || vars.INNGEST_EVENT_KEY }}
       INNGEST_SIGNING_KEY: ${{ secrets.INNGEST_BRANCH_SIGNING_KEY }}
       AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -205,6 +205,11 @@ jobs:
       DASHBOARD_ARTIFACT_PREFIX: dashboard-artifacts/pr-${{ needs.detect-changes.outputs.pr_number }}
       SUPER_ADMIN_EMAILS: ${{ secrets.SUPER_ADMIN_EMAILS }}
     steps:
+      - name: Warn if branch Inngest event key is missing
+        if: ${{ secrets.INNGEST_BRANCH_EVENT_KEY == '' }}
+        run: |
+          echo "::warning title=Inngest branch event key missing::INNGEST_BRANCH_EVENT_KEY is not set — preview events fall back to the PRODUCTION event key and route to the prod Inngest env, so event-triggered functions (e.g. dbt runs) will NOT fire on this preview (they stay 'queued'). Add the Branch Environments event key as a repo secret to enable event-driven flows on previews."
+
       - name: Set PR-specific variables
         id: pr-vars
         run: |

--- a/api/package.json
+++ b/api/package.json
@@ -5,9 +5,10 @@
   "main": "dist/index.js",
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "pnpm run lint && cd ../packages/schemas && node ../../api/node_modules/typescript/bin/tsc && cd ../../api && node ./node_modules/typescript/bin/tsc -p tsconfig.build.json && copyfiles -u 1 'src/**/*.svg' 'src/agent-skills/**/*.md' dist",
+    "build": "pnpm run lint && cd ../packages/schemas && node ../../api/node_modules/typescript/bin/tsc && cd ../../api && node ./node_modules/typescript/bin/tsc -p tsconfig.build.json && copyfiles -u 1 'src/**/*.svg' 'src/agent-skills/**/*.md' 'src/**/*.py' dist",
     "start": "tsx src/index.ts",
     "sync": "tsx src/sync/cli.ts",
+    "seed:dbt-demo": "tsx src/scripts/seed-dbt-engine-demo.ts",
     "worker": "tsx src/worker.ts",
     "worker:dev": "tsx watch src/worker.ts",
     "migrate:workspaces": "tsx src/migrations/migrate-to-workspaces.ts",

--- a/api/package.json
+++ b/api/package.json
@@ -13,7 +13,7 @@
     "worker:dev": "tsx watch src/worker.ts",
     "migrate:workspaces": "tsx src/migrations/migrate-to-workspaces.ts",
     "openapi:generate": "tsx src/openapi/generate-cli.ts",
-    "test": "tsx src/openapi/core.test.ts && tsx src/openapi/openapi.test.ts",
+    "test": "tsx src/openapi/core.test.ts && tsx src/openapi/openapi.test.ts && tsx src/dbt/warm-dir-cache.test.ts",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives",
     "lint:fix": "eslint . --ext ts,tsx --fix"
   },

--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -27,6 +27,7 @@ import {
 import { runAdhocDbtCommand } from "../../dbt/dbt-project.service";
 import {
   applyJobScheduleChange,
+  reconcileStaleQueuedRun,
   triggerDbtJobRun,
   triggerDbtRun,
 } from "../../dbt/dbt-run.service";
@@ -501,8 +502,14 @@ export const createDbtServerTools = (workspaceId: string) => {
 
           const deadline = Date.now() + Math.min(waitMs ?? 0, MAX_RUN_WAIT_MS);
 
-          let run = await DbtRun.findOne(query).sort({ createdAt: -1 }).lean();
-          if (!run) return { success: false, error: "Run not found" };
+          let found = await DbtRun.findOne(query)
+            .sort({ createdAt: -1 })
+            .lean();
+          if (!found) return { success: false, error: "Run not found" };
+          // A run stuck in "queued" past the watchdog deadline is finalized as
+          // an error here, so a never-picked-up run terminates the wait loop
+          // instead of spinning to the full budget.
+          let run = await reconcileStaleQueuedRun(found);
 
           // Bounded server-side wait: re-read until terminal, the budget
           // elapses, or the turn is aborted. Keepalives keep the SSE warm.
@@ -512,8 +519,9 @@ export const createDbtServerTools = (workspaceId: string) => {
             !abortSignal?.aborted
           ) {
             await sleep(RUN_POLL_INTERVAL_MS, abortSignal);
-            run = await DbtRun.findOne(query).sort({ createdAt: -1 }).lean();
-            if (!run) return { success: false, error: "Run not found" };
+            found = await DbtRun.findOne(query).sort({ createdAt: -1 }).lean();
+            if (!found) return { success: false, error: "Run not found" };
+            run = await reconcileStaleQueuedRun(found);
           }
 
           return {

--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -28,6 +28,7 @@ import { runAdhocDbtCommand } from "../../dbt/dbt-project.service";
 import {
   applyJobScheduleChange,
   triggerDbtJobRun,
+  triggerDbtRun,
 } from "../../dbt/dbt-run.service";
 import {
   DbtCommandValidationError,
@@ -59,6 +60,30 @@ function toolError(error: unknown, fallback: string) {
     success: false,
     error: error instanceof Error ? error.message : fallback,
   };
+}
+
+/** Upper bound on dbt_get_run's server-side wait, well under proxy timeouts. */
+const MAX_RUN_WAIT_MS = 90_000;
+/** Cadence for the dbt_get_run wait loop — mirrors the IDE run-detail poll. */
+const RUN_POLL_INTERVAL_MS = 2_000;
+
+/** Sleep that resolves early when the turn is aborted (chat Stop). */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise(resolve => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 /** Keep tool outputs small: errors + warnings + last few info lines. */
@@ -316,9 +341,12 @@ export const createDbtServerTools = (workspaceId: string) => {
         "against the project's dev environment (or the given environment). " +
         "This WRITES to the warehouse target schema. `model` accepts a node " +
         "name (stg_orders) or a dbt selector with graph operators/methods " +
-        "(stg_orders+, +marts.orders, tag:nightly, state:modified+). Returns " +
-        "per-node status, timing, rows affected, and test pass/fail outcomes. " +
-        "Use this as the final verification after compile succeeds.",
+        "(stg_orders+, +marts.orders, tag:nightly, state:modified+). " +
+        "Runs ASYNCHRONOUSLY in the runner and returns a `runId` immediately " +
+        "(it does NOT block until the build finishes). Poll `dbt_get_run` " +
+        "with that `runId` (pass `waitMs`) to get per-node status, timing, " +
+        "rows affected, and test pass/fail outcomes. Use this as the final " +
+        "verification after compile succeeds.",
       inputSchema: z.object({
         projectId: projectIdField,
         model: z
@@ -339,19 +367,30 @@ export const createDbtServerTools = (workspaceId: string) => {
           if (!SELECTOR_PATTERN.test(model)) {
             return { success: false, error: "Invalid model selector" };
           }
-          await assertProject(projectId);
-          const result = await runAdhocDbtCommand({
+          const project = await assertProject(projectId);
+          // Dispatch to the async runner instead of blocking the chat turn for
+          // the full build. The build executes in the Inngest worker
+          // (decoupled from this SSE connection), so it survives proxy idle
+          // timeouts and API restarts. The agent verifies the outcome by
+          // polling dbt_get_run; the chat renders a live run card from runId.
+          const run = await triggerDbtRun({
             workspaceId,
             projectId,
-            environmentName: environment,
-            command: `build --select ${model}`,
-            select: model,
-            timeoutMs: 5 * 60 * 1000,
+            environment: environment ?? project.defaultEnvironment,
+            commands: [`build --select ${model}`],
+            trigger: "agent",
+            triggeredBy: "agent",
           });
           return {
-            success: result.success,
-            stepResults: result.stepResults,
-            logs: summarizeLogs(result.logs),
+            success: true,
+            runId: run._id.toString(),
+            status: run.status,
+            environment: run.environment,
+            commands: run.commands,
+            message:
+              "Build started in the runner. Poll dbt_get_run with this runId " +
+              "(pass waitMs) until status is success/error. The user sees " +
+              "live progress in the run card.",
           };
         } catch (error) {
           return toolError(error, "Failed to run model");
@@ -405,18 +444,34 @@ export const createDbtServerTools = (workspaceId: string) => {
     dbt_get_run: tool({
       description:
         "Read the status, step results, and logs of a dbt run — use this " +
-        "AFTER dbt_run_job to see whether the run passed or failed (the " +
-        "trigger only queues it). Pass `runId` for a specific run, or `jobId` " +
-        "to get that job's most recent run.",
+        "AFTER dbt_run_model or dbt_run_job to see whether the run passed or " +
+        "failed (those only queue it). Pass `runId` for a specific run, or " +
+        "`jobId` to get that job's most recent run. Pass `waitMs` to block " +
+        "server-side until the run reaches a terminal status (success/error/" +
+        "cancelled) or the wait elapses — call it ONCE with waitMs ~90000 " +
+        "after dbt_run_model; if it returns still running, tell the user the " +
+        "build is in progress and stop (the run card shows live progress).",
       inputSchema: z.object({
         projectId: projectIdField,
-        runId: z.string().optional().describe("dbt run ID (from dbt_run_job)"),
+        runId: z
+          .string()
+          .optional()
+          .describe("dbt run ID (from dbt_run_model / dbt_run_job)"),
         jobId: z
           .string()
           .optional()
           .describe("dbt job ID — returns the latest run for this job"),
+        waitMs: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe(
+            "If set, wait up to this many ms (capped at 90000) for the run " +
+              "to finish before returning. Use ~90000 once after dbt_run_model.",
+          ),
       }),
-      execute: async ({ projectId, runId, jobId }) => {
+      execute: async ({ projectId, runId, jobId, waitMs }, { abortSignal }) => {
         try {
           const project = await assertProject(projectId);
           if (!runId && !jobId) {
@@ -439,10 +494,27 @@ export const createDbtServerTools = (workspaceId: string) => {
             query.jobId = new Types.ObjectId(jobId);
           }
 
-          const run = await DbtRun.findOne(query)
-            .sort({ createdAt: -1 })
-            .lean();
+          const isTerminal = (status: string) =>
+            status === "success" ||
+            status === "error" ||
+            status === "cancelled";
+
+          const deadline = Date.now() + Math.min(waitMs ?? 0, MAX_RUN_WAIT_MS);
+
+          let run = await DbtRun.findOne(query).sort({ createdAt: -1 }).lean();
           if (!run) return { success: false, error: "Run not found" };
+
+          // Bounded server-side wait: re-read until terminal, the budget
+          // elapses, or the turn is aborted. Keepalives keep the SSE warm.
+          while (
+            !isTerminal(run.status) &&
+            Date.now() + RUN_POLL_INTERVAL_MS <= deadline &&
+            !abortSignal?.aborted
+          ) {
+            await sleep(RUN_POLL_INTERVAL_MS, abortSignal);
+            run = await DbtRun.findOne(query).sort({ createdAt: -1 }).lean();
+            if (!run) return { success: false, error: "Run not found" };
+          }
 
           return {
             success: true,

--- a/api/src/agent-skills/dbt/SKILL.md
+++ b/api/src/agent-skills/dbt/SKILL.md
@@ -117,10 +117,17 @@ AND its tests — always add at least `unique` + `not_null` on the primary key.
    malformed schema.yml without touching the warehouse.
 2. `dbt_compile_model` — renders the Jinja; read the compiled SQL to confirm
    it targets the right relations.
-3. `dbt_run_model` on dev — reports per-node status, timing, rows affected,
-   and test outcomes. Surface these to the user.
+3. `dbt_run_model` on dev — runs ASYNCHRONOUSLY in the runner and returns a
+   `runId` immediately (it does NOT wait for the build). Then call
+   `dbt_get_run({ runId, waitMs: 90000 })` ONCE to wait for the result:
+   - terminal (`success`/`error`) → surface per-node status, timing, rows
+     affected, and test outcomes to the user.
+   - still `running`/`queued` after the wait → tell the user the build is
+     still in progress (the run card shows live logs/status); do NOT keep
+     polling in a tight loop. Poll again only if the user asks.
 4. Preview built tables with `sql_execute_query`
-   (`select * from <dev_schema>.<model> limit 100`).
+   (`select * from <dev_schema>.<model> limit 100`) — only after the run
+   reaches `success`.
 
 ## Environments and jobs
 

--- a/api/src/dbt/dbt-bin.ts
+++ b/api/src/dbt/dbt-bin.ts
@@ -10,6 +10,7 @@
 
 import { existsSync } from "fs";
 import { spawnSync } from "child_process";
+import { dirname, join } from "path";
 
 export const DEFAULT_DBT_CORE_VERSION = "1.9.10";
 
@@ -79,5 +80,73 @@ export function resolveDbtBin(
     "No dbt binary available. Set DBT_VENV_BIN to a dbt executable " +
       "(production image bakes one at /opt/dbt/bin/dbt) or install uv " +
       "(https://docs.astral.sh/uv/) so the runner can use `uvx` locally.",
+  );
+}
+
+function dbtCoreVersionFor(
+  adapterPackage: string,
+  dbtVersion?: string,
+): string {
+  if (adapterPackage === "dbt-mysql") return "1.7.19";
+  return dbtVersion && dbtVersion.split(".").length >= 3
+    ? dbtVersion
+    : DEFAULT_DBT_CORE_VERSION;
+}
+
+/**
+ * Resolve how to launch the resident dbt engine (a long-lived Python process
+ * running `enginePath`), mirroring {@link resolveDbtBin}'s resolution order so
+ * the engine uses the SAME dbt-core + adapter as the subprocess path.
+ *
+ *   1. DBT_ENGINE_PYTHON_CMD — JSON array override (tests / custom infra);
+ *      enginePath is appended.
+ *   2. The baked venv's python (sibling of DBT_VENV_BIN) in production.
+ *   3. `uv run` dev fallback with dbt-core + the adapter injected.
+ */
+export function resolveDbtEnginePython(
+  adapterPackage: string,
+  dbtVersion: string | undefined,
+  enginePath: string,
+): ResolvedDbtBin {
+  const override = process.env.DBT_ENGINE_PYTHON_CMD;
+  if (override) {
+    const parts = JSON.parse(override) as string[];
+    return { bin: parts[0], prefixArgs: [...parts.slice(1), enginePath] };
+  }
+
+  const venvBin =
+    adapterPackage === "dbt-mysql"
+      ? process.env.DBT_MYSQL_VENV_BIN
+      : process.env.DBT_VENV_BIN;
+  if (venvBin) {
+    const python = join(dirname(venvBin), "python");
+    if (!existsSync(python)) {
+      throw new Error(
+        `dbt venv python "${python}" does not exist (check DBT_VENV_BIN)`,
+      );
+    }
+    return { bin: python, prefixArgs: [enginePath] };
+  }
+
+  if (isUvxAvailable()) {
+    const coreVersion = dbtCoreVersionFor(adapterPackage, dbtVersion);
+    return {
+      bin: "uv",
+      prefixArgs: [
+        "run",
+        "--no-project",
+        "--with",
+        `dbt-core==${coreVersion}`,
+        "--with",
+        adapterPackage,
+        "python",
+        enginePath,
+      ],
+    };
+  }
+
+  throw new Error(
+    "No Python available for the dbt engine. Set DBT_VENV_BIN " +
+      "(production bakes /opt/dbt/bin/python) or install uv for local dev.",
   );
 }

--- a/api/src/dbt/dbt-cache.service.ts
+++ b/api/src/dbt/dbt-cache.service.ts
@@ -1,0 +1,170 @@
+/**
+ * dbt run cache — cross-run/cross-instance warm state stored in the artifact
+ * store so each dbt invocation doesn't start cold.
+ *
+ * Two caches, both BEST-EFFORT (any failure falls back to correct cold
+ * behavior — dbt validates its own partial-parse cache against file checksums
+ * and re-parses on any mismatch, so a stale/garbage cache never produces a
+ * wrong result):
+ *
+ *   1. partial_parse.msgpack — dbt's internal parse manifest. Seeding it into
+ *      target/ lets dbt re-parse only changed files instead of the whole
+ *      project (~seconds → <1s on non-trivial projects). Keyed per
+ *      (workspace, project, environment) because env_var rendering can affect
+ *      the parsed manifest.
+ *   2. dbt_packages/ (+ package-lock.yml) — the installed packages tree.
+ *      Caching it lets us skip `dbt deps` (git/registry downloads) when
+ *      packages.yml is unchanged. Keyed per (workspace, project) and validated
+ *      with a hash of the dependency declarations.
+ *
+ * Keys live under `dbt-cache/` so they never collide with per-run artifacts
+ * (`dbt-artifacts/`).
+ */
+
+import crypto from "crypto";
+import { getDashboardArtifactStore } from "../services/dashboard-artifact-store.service";
+import { loggers } from "../logging";
+
+const logger = loggers.app();
+
+export interface DbtCacheScope {
+  workspaceId: string;
+  projectId: string;
+  environment: string;
+}
+
+type ProjectFile = { path: string; content: string };
+
+function sanitizeSegment(value: string): string {
+  return value.replace(/[^\w.-]/g, "_");
+}
+
+function parsePrefix(scope: DbtCacheScope): string {
+  return `dbt-cache/${scope.workspaceId}/${scope.projectId}/${sanitizeSegment(scope.environment)}`;
+}
+
+function packagesPrefix(scope: DbtCacheScope): string {
+  // Packages depend only on packages.yml/dependencies.yml, not on the
+  // environment — share one cache across a project's environments.
+  return `dbt-cache/${scope.workspaceId}/${scope.projectId}`;
+}
+
+const PARTIAL_PARSE_FILE = "partial_parse.msgpack";
+
+/**
+ * sha256 of the dependency declarations, or null when the project declares no
+ * real packages (only comments / no file). Used to detect when the cached
+ * dbt_packages/ tree is still valid.
+ */
+export function computePackagesHash(files: ProjectFile[]): string | null {
+  const declarations = ["packages.yml", "dependencies.yml"]
+    .map(name => {
+      const file = files.find(candidate => candidate.path === name);
+      return file ? `${name}:${file.content}` : "";
+    })
+    .join("\n");
+
+  const hasRealPackages = declarations
+    .split("\n")
+    .map(line => line.trim())
+    .some(
+      line =>
+        line.length > 0 &&
+        !line.startsWith("#") &&
+        !line.endsWith(":") &&
+        line !== "packages.yml" &&
+        line !== "dependencies.yml",
+    );
+  if (!hasRealPackages) return null;
+
+  return crypto.createHash("sha256").update(declarations).digest("hex");
+}
+
+async function readKey(key: string): Promise<Buffer | undefined> {
+  try {
+    const stream = await getDashboardArtifactStore().openReadStream(key);
+    if (!stream) return undefined;
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    return chunks.length > 0 ? Buffer.concat(chunks) : undefined;
+  } catch {
+    // Missing key (cold cache) or transient store error — treat as a miss.
+    return undefined;
+  }
+}
+
+export interface LoadedDbtCaches {
+  /** Seed into target/partial_parse.msgpack to warm parsing. */
+  partialParse?: Buffer;
+  /** tgz of dbt_packages/ (+ package-lock.yml) to seed when packages match. */
+  packages?: Buffer;
+  /** True when the cached packages tree matches the current declarations. */
+  packagesFresh: boolean;
+}
+
+export async function loadDbtCaches(
+  scope: DbtCacheScope,
+  packagesHash: string | null,
+): Promise<LoadedDbtCaches> {
+  const partialParseKey = `${parsePrefix(scope)}/${PARTIAL_PARSE_FILE}`;
+  const hashKey = `${packagesPrefix(scope)}/packages_hash.txt`;
+
+  const [partialParse, cachedHashBuf] = await Promise.all([
+    readKey(partialParseKey),
+    packagesHash ? readKey(hashKey) : Promise.resolve(undefined),
+  ]);
+
+  const cachedHash = cachedHashBuf?.toString("utf8").trim();
+  const packagesFresh = Boolean(packagesHash) && cachedHash === packagesHash;
+  const packages = packagesFresh
+    ? await readKey(`${packagesPrefix(scope)}/dbt_packages.tgz`)
+    : undefined;
+
+  return { partialParse, packages, packagesFresh: Boolean(packages) };
+}
+
+export async function saveParseCache(
+  scope: DbtCacheScope,
+  partialParse: Buffer,
+): Promise<void> {
+  try {
+    await getDashboardArtifactStore().putBuffer(
+      partialParse,
+      `${parsePrefix(scope)}/${PARTIAL_PARSE_FILE}`,
+      "application/octet-stream",
+    );
+  } catch (error) {
+    logger.warn("Failed to save dbt partial-parse cache", {
+      error,
+      projectId: scope.projectId,
+      environment: scope.environment,
+    });
+  }
+}
+
+export async function savePackagesCache(
+  scope: DbtCacheScope,
+  archive: Buffer,
+  packagesHash: string,
+): Promise<void> {
+  try {
+    const store = getDashboardArtifactStore();
+    await store.putBuffer(
+      archive,
+      `${packagesPrefix(scope)}/dbt_packages.tgz`,
+      "application/gzip",
+    );
+    await store.putBuffer(
+      Buffer.from(packagesHash, "utf8"),
+      `${packagesPrefix(scope)}/packages_hash.txt`,
+      "text/plain",
+    );
+  } catch (error) {
+    logger.warn("Failed to save dbt packages cache", {
+      error,
+      projectId: scope.projectId,
+    });
+  }
+}

--- a/api/src/dbt/dbt-engine.contract.test.ts
+++ b/api/src/dbt/dbt-engine.contract.test.ts
@@ -15,7 +15,7 @@
 import { mkdtempSync, mkdirSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { afterAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   disposeAllEngines,
   engineCompile,
@@ -26,41 +26,48 @@ import {
 const ENABLED = process.env.RUN_DBT_ENGINE_CONTRACT === "1";
 
 describe.skipIf(!ENABLED)("dbt engine contract (real dbt-core 1.9.10)", () => {
-  process.env.DBT_ENGINE_ENABLED = "true";
-  process.env.DBT_ENGINE_PYTHON_CMD = JSON.stringify([
-    "uv",
-    "run",
-    "--no-project",
-    "--python",
-    "3.11",
-    "--with",
-    "dbt-core==1.9.10",
-    "--with",
-    "dbt-duckdb==1.9.4",
-    "python",
-  ]);
-
-  const dir = mkdtempSync(join(tmpdir(), "dbt-engine-contract-"));
-  mkdirSync(join(dir, "models"), { recursive: true });
-  writeFileSync(
-    join(dir, "dbt_project.yml"),
-    'name: probe\nprofile: probe\nversion: "1.0"\nconfig-version: 2\nmodel-paths: ["models"]\n',
-  );
-  writeFileSync(
-    join(dir, "profiles.yml"),
-    `probe:\n  target: dev\n  outputs:\n    dev:\n      type: duckdb\n      path: ${dir}/probe.duckdb\n      threads: 1\n`,
-  );
-  writeFileSync(
-    join(dir, "models", "my_model.sql"),
-    "select 1 as id, 2 as val\n",
-  );
-
   const ctx = {
     adapterPackage: "dbt-duckdb",
     dbtVersion: "1.9.10",
     connectionEnv: {},
   };
-  const session = { key: "contract:probe:dev", projectDir: dir };
+  // Assigned in beforeAll so the env mutation + fixture writes never run during
+  // vitest's collection phase when the suite is skipped (avoids leaking
+  // DBT_ENGINE_ENABLED into other API tests sharing the process).
+  let session: { key: string; projectDir: string };
+
+  beforeAll(() => {
+    process.env.DBT_ENGINE_ENABLED = "true";
+    process.env.DBT_ENGINE_PYTHON_CMD = JSON.stringify([
+      "uv",
+      "run",
+      "--no-project",
+      "--python",
+      "3.11",
+      "--with",
+      "dbt-core==1.9.10",
+      "--with",
+      "dbt-duckdb==1.9.4",
+      "python",
+    ]);
+
+    const dir = mkdtempSync(join(tmpdir(), "dbt-engine-contract-"));
+    mkdirSync(join(dir, "models"), { recursive: true });
+    writeFileSync(
+      join(dir, "dbt_project.yml"),
+      'name: probe\nprofile: probe\nversion: "1.0"\nconfig-version: 2\nmodel-paths: ["models"]\n',
+    );
+    writeFileSync(
+      join(dir, "profiles.yml"),
+      `probe:\n  target: dev\n  outputs:\n    dev:\n      type: duckdb\n      path: ${dir}/probe.duckdb\n      threads: 1\n`,
+    );
+    writeFileSync(
+      join(dir, "models", "my_model.sql"),
+      "select 1 as id, 2 as val\n",
+    );
+
+    session = { key: "contract:probe:dev", projectDir: dir };
+  });
 
   afterAll(() => disposeAllEngines());
 

--- a/api/src/dbt/dbt-engine.contract.test.ts
+++ b/api/src/dbt/dbt-engine.contract.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Resident dbt engine CONTRACT test.
+ *
+ * Pins the dbt-core programmatic-API assumptions the engine depends on against
+ * a REAL dbt-core + dbt-duckdb (no warehouse server needed):
+ *   1. parse caches a reusable manifest (prepare returns node count)
+ *   2. dbtRunner(manifest=...) reuses it: compile returns compiled SQL
+ *   3. the same long-lived process handles compile -> show repeatedly
+ *
+ * Heavy (downloads dbt via `uv`), so it is gated behind RUN_DBT_ENGINE_CONTRACT
+ * and meant for a dedicated CI job — run locally with:
+ *   RUN_DBT_ENGINE_CONTRACT=1 pnpm --filter api exec vitest run dbt-engine.contract
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterAll, describe, expect, it } from "vitest";
+import {
+  disposeAllEngines,
+  engineCompile,
+  enginePrepare,
+  engineShow,
+} from "./dbt-engine.service";
+
+const ENABLED = process.env.RUN_DBT_ENGINE_CONTRACT === "1";
+
+describe.skipIf(!ENABLED)("dbt engine contract (real dbt-core 1.9.10)", () => {
+  process.env.DBT_ENGINE_ENABLED = "true";
+  process.env.DBT_ENGINE_PYTHON_CMD = JSON.stringify([
+    "uv",
+    "run",
+    "--no-project",
+    "--python",
+    "3.11",
+    "--with",
+    "dbt-core==1.9.10",
+    "--with",
+    "dbt-duckdb==1.9.4",
+    "python",
+  ]);
+
+  const dir = mkdtempSync(join(tmpdir(), "dbt-engine-contract-"));
+  mkdirSync(join(dir, "models"), { recursive: true });
+  writeFileSync(
+    join(dir, "dbt_project.yml"),
+    'name: probe\nprofile: probe\nversion: "1.0"\nconfig-version: 2\nmodel-paths: ["models"]\n',
+  );
+  writeFileSync(
+    join(dir, "profiles.yml"),
+    `probe:\n  target: dev\n  outputs:\n    dev:\n      type: duckdb\n      path: ${dir}/probe.duckdb\n      threads: 1\n`,
+  );
+  writeFileSync(
+    join(dir, "models", "my_model.sql"),
+    "select 1 as id, 2 as val\n",
+  );
+
+  const ctx = {
+    adapterPackage: "dbt-duckdb",
+    dbtVersion: "1.9.10",
+    connectionEnv: {},
+  };
+  const session = { key: "contract:probe:dev", projectDir: dir };
+
+  afterAll(() => disposeAllEngines());
+
+  it("parses, reuses the manifest to compile, and shows rows in one process", async () => {
+    const prep = await enginePrepare(ctx, session);
+    expect(prep.nodes).toBeGreaterThanOrEqual(1);
+
+    const compile = await engineCompile(ctx, session, "my_model");
+    expect(compile.ok).toBe(true);
+    expect(compile.compiled_sql).toContain("select 1 as id");
+
+    const show = await engineShow(ctx, session, {
+      inline: "select 1 as x, 'hi' as y",
+      limit: 5,
+    });
+    expect(show.ok).toBe(true);
+    expect(show.columns).toEqual(["x", "y"]);
+    expect(show.rows).toEqual([[1, "hi"]]);
+  }, 180_000);
+});

--- a/api/src/dbt/dbt-engine.service.ts
+++ b/api/src/dbt/dbt-engine.service.ts
@@ -1,0 +1,315 @@
+/**
+ * Resident dbt engine supervisor.
+ *
+ * Manages long-lived `dbt_engine.py` child processes that hold parsed dbt
+ * manifests in memory, so interactive `compile`/`show` reuse the manifest and
+ * skip re-parse (the dbt Cloud "develop" model). One process per
+ * `(adapterPackage, dbtCoreVersion)` — each holds manifests for many
+ * `(project, environment)` sessions using that adapter.
+ *
+ * Communication is newline-delimited JSON over a dedicated pipe (fd 3), so
+ * dbt's own stdout/stderr logging never corrupts the protocol. Every request
+ * is bounded by a timeout; a crashed process is reaped and respawned lazily,
+ * and all callers fall back to the subprocess path when the engine is
+ * unavailable — so this is strictly an optimization, never a dependency.
+ *
+ * Gated by DBT_ENGINE_ENABLED (default off) until validated against a real
+ * warehouse in staging.
+ */
+
+import { spawn, type ChildProcess } from "child_process";
+import { createHash } from "crypto";
+import { join } from "path";
+import { resolveDbtEnginePython } from "./dbt-bin";
+import { loggers } from "../logging";
+
+const logger = loggers.app();
+
+const ENGINE_SCRIPT = join(__dirname, "engine", "dbt_engine.py");
+const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
+/** Max resident engine processes per API instance (LRU-evicted). */
+const MAX_ENGINES = Number(process.env.DBT_ENGINE_MAX_PROCESSES ?? "4");
+
+export function dbtEngineEnabled(): boolean {
+  return process.env.DBT_ENGINE_ENABLED === "true";
+}
+
+export interface EngineSession {
+  /** Stable key, e.g. `${workspaceId}:${projectId}:${environment}`. */
+  key: string;
+  /** Warm working directory the supervisor keeps in sync on disk. */
+  projectDir: string;
+}
+
+interface PreparePayload {
+  parse_ms: number;
+  nodes: number;
+}
+interface CompilePayload {
+  ok: boolean;
+  compiled_sql: string | null;
+  elapsed_ms: number;
+  error: string | null;
+}
+interface ShowPayload {
+  ok: boolean;
+  columns: string[];
+  rows: unknown[][];
+  elapsed_ms: number;
+  error: string | null;
+}
+
+interface PendingRequest {
+  resolve: (value: Record<string, unknown>) => void;
+  reject: (error: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+/** One supervised Python engine process for a single adapter+version+connection. */
+class EngineProcess {
+  private child: ChildProcess | null = null;
+  private buffer = "";
+  private nextId = 1;
+  private readonly pending = new Map<number, PendingRequest>();
+  /** For LRU eviction. */
+  lastUsed = Date.now();
+
+  constructor(
+    private readonly adapterPackage: string,
+    private readonly dbtVersion: string | undefined,
+    /** Secret + keyfile env so dbt resolves env_var() at profile load. */
+    private readonly connectionEnv: Record<string, string>,
+  ) {}
+
+  private ensureStarted(): ChildProcess {
+    if (this.child && !this.child.killed && this.child.exitCode === null) {
+      return this.child;
+    }
+
+    const { bin, prefixArgs } = resolveDbtEnginePython(
+      this.adapterPackage,
+      this.dbtVersion,
+      ENGINE_SCRIPT,
+    );
+
+    // stdio: [stdin, stdout, stderr, protocol]. dbt logs flow to stdout/stderr
+    // (captured for debug); structured responses arrive on fd 3.
+    const child = spawn(bin, prefixArgs, {
+      stdio: ["pipe", "pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        ...this.connectionEnv,
+        DBT_SEND_ANONYMOUS_USAGE_STATS: "false",
+      },
+    });
+
+    const protocol = child.stdio[3] as NodeJS.ReadableStream;
+    protocol.setEncoding("utf8");
+    protocol.on("data", chunk => this.onProtocolData(chunk as string));
+
+    child.stderr?.on("data", (data: Buffer) => {
+      logger.debug("dbt-engine stderr", {
+        adapter: this.adapterPackage,
+        line: data.toString("utf8").trim().slice(0, 500),
+      });
+    });
+
+    child.on("exit", (code, signal) => {
+      this.failAllPending(
+        new Error(`dbt engine exited (code=${code} signal=${signal})`),
+      );
+      this.child = null;
+      this.buffer = "";
+    });
+    child.on("error", error => {
+      this.failAllPending(error);
+      this.child = null;
+    });
+
+    this.child = child;
+    return child;
+  }
+
+  private onProtocolData(chunk: string): void {
+    this.buffer += chunk;
+    let newline = this.buffer.indexOf("\n");
+    while (newline !== -1) {
+      const line = this.buffer.slice(0, newline).trim();
+      this.buffer = this.buffer.slice(newline + 1);
+      if (line) this.handleResponse(line);
+      newline = this.buffer.indexOf("\n");
+    }
+  }
+
+  private handleResponse(line: string): void {
+    let message: Record<string, unknown>;
+    try {
+      message = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      logger.warn("dbt-engine: unparseable response", {
+        line: line.slice(0, 200),
+      });
+      return;
+    }
+    const id = message.id as number | null;
+    if (id == null) return;
+    const entry = this.pending.get(id);
+    if (!entry) return;
+    this.pending.delete(id);
+    clearTimeout(entry.timer);
+    if (message.ok === true) {
+      entry.resolve(message);
+    } else {
+      entry.reject(new Error(String(message.error ?? "dbt engine error")));
+    }
+  }
+
+  private failAllPending(error: Error): void {
+    for (const [, entry] of this.pending) {
+      clearTimeout(entry.timer);
+      entry.reject(error);
+    }
+    this.pending.clear();
+  }
+
+  request(
+    op: string,
+    params: Record<string, unknown>,
+    timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
+  ): Promise<Record<string, unknown>> {
+    this.lastUsed = Date.now();
+    const child = this.ensureStarted();
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`dbt engine '${op}' timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      this.pending.set(id, { resolve, reject, timer });
+      const payload = JSON.stringify({ id, op, ...params }) + "\n";
+      child.stdin?.write(payload, error => {
+        if (error) {
+          this.pending.delete(id);
+          clearTimeout(timer);
+          reject(error);
+        }
+      });
+    });
+  }
+
+  dispose(): void {
+    this.failAllPending(new Error("engine disposed"));
+    this.child?.kill();
+    this.child = null;
+  }
+}
+
+// Pool keyed by adapter@version@connection. A single process can only serve
+// one set of warehouse credentials (env_var() is read at profile load), so the
+// key fingerprints the connection env. LRU-evicted to bound memory.
+const pool = new Map<string, EngineProcess>();
+
+export interface EngineContext {
+  adapterPackage: string;
+  dbtVersion?: string;
+  /** profile.secretEnv merged with the keyfile env (absolute paths). */
+  connectionEnv: Record<string, string>;
+}
+
+function poolKey(ctx: EngineContext): string {
+  const fingerprint = createHash("sha256")
+    .update(JSON.stringify(ctx.connectionEnv))
+    .digest("hex")
+    .slice(0, 16);
+  return `${ctx.adapterPackage}@${ctx.dbtVersion ?? "default"}@${fingerprint}`;
+}
+
+function engineFor(ctx: EngineContext): EngineProcess {
+  const key = poolKey(ctx);
+  let engine = pool.get(key);
+  if (!engine) {
+    // Evict the least-recently-used process if at capacity.
+    if (pool.size >= MAX_ENGINES) {
+      let lruKey: string | undefined;
+      let lruAt = Infinity;
+      for (const [k, e] of pool) {
+        if (e.lastUsed < lruAt) {
+          lruAt = e.lastUsed;
+          lruKey = k;
+        }
+      }
+      if (lruKey) {
+        pool.get(lruKey)?.dispose();
+        pool.delete(lruKey);
+      }
+    }
+    engine = new EngineProcess(
+      ctx.adapterPackage,
+      ctx.dbtVersion,
+      ctx.connectionEnv,
+    );
+    pool.set(key, engine);
+  }
+  return engine;
+}
+
+/** Parse the project on disk and cache its manifest for this session. */
+export async function enginePrepare(
+  ctx: EngineContext,
+  session: EngineSession,
+): Promise<PreparePayload> {
+  const engine = engineFor(ctx);
+  const res = await engine.request("prepare", {
+    session: session.key,
+    project_dir: session.projectDir,
+  });
+  return { parse_ms: Number(res.parse_ms ?? 0), nodes: Number(res.nodes ?? 0) };
+}
+
+/** Compile a model using the warm manifest. */
+export async function engineCompile(
+  ctx: EngineContext,
+  session: EngineSession,
+  select: string,
+): Promise<CompilePayload> {
+  const engine = engineFor(ctx);
+  const res = await engine.request("compile", { session: session.key, select });
+  return {
+    ok: Boolean(res.ok),
+    compiled_sql: (res.compiled_sql as string | null) ?? null,
+    elapsed_ms: Number(res.elapsed_ms ?? 0),
+    error: (res.error as string | null) ?? null,
+  };
+}
+
+/** Preview rows for a model or inline SQL using the warm manifest. */
+export async function engineShow(
+  ctx: EngineContext,
+  session: EngineSession,
+  args: { select?: string; inline?: string; limit?: number },
+): Promise<ShowPayload> {
+  const engine = engineFor(ctx);
+  const res = await engine.request("show", { session: session.key, ...args });
+  return {
+    ok: Boolean(res.ok),
+    columns: (res.columns as string[]) ?? [],
+    rows: (res.rows as unknown[][]) ?? [],
+    elapsed_ms: Number(res.elapsed_ms ?? 0),
+    error: (res.error as string | null) ?? null,
+  };
+}
+
+/** Drop the cached manifest (e.g. after a structural change). */
+export async function engineInvalidate(
+  ctx: EngineContext,
+  session: EngineSession,
+): Promise<void> {
+  const engine = engineFor(ctx);
+  await engine.request("invalidate", { session: session.key }, 5_000);
+}
+
+/** Tear down all engine processes (process shutdown / tests). */
+export function disposeAllEngines(): void {
+  for (const [, engine] of pool) engine.dispose();
+  pool.clear();
+}

--- a/api/src/dbt/dbt-engine.service.ts
+++ b/api/src/dbt/dbt-engine.service.ts
@@ -74,6 +74,11 @@ class EngineProcess {
   /** For LRU eviction. */
   lastUsed = Date.now();
 
+  /** True when no request is in flight — safe to evict/dispose. */
+  get isIdle(): boolean {
+    return this.pending.size === 0;
+  }
+
   constructor(
     private readonly adapterPackage: string,
     private readonly dbtVersion: string | undefined,
@@ -228,12 +233,15 @@ function engineFor(ctx: EngineContext): EngineProcess {
   const key = poolKey(ctx);
   let engine = pool.get(key);
   if (!engine) {
-    // Evict the least-recently-used process if at capacity.
+    // Evict the least-recently-used *idle* process if at capacity. Never evict
+    // an engine with an in-flight request — disposing it would abort live work
+    // and force a subprocess fallback mid-compile. If every engine is busy we
+    // let the pool temporarily exceed MAX_ENGINES rather than kill active work.
     if (pool.size >= MAX_ENGINES) {
       let lruKey: string | undefined;
       let lruAt = Infinity;
       for (const [k, e] of pool) {
-        if (e.lastUsed < lruAt) {
+        if (e.isIdle && e.lastUsed < lruAt) {
           lruAt = e.lastUsed;
           lruKey = k;
         }

--- a/api/src/dbt/dbt-project.service.ts
+++ b/api/src/dbt/dbt-project.service.ts
@@ -214,8 +214,14 @@ export async function runAdhocDbtCommand(params: {
         },
       );
       if (engineResult.ok) {
-        logger.debug("dbt engine compile hit", {
+        // info (not debug) so the hit rate is visible in prod once the engine
+        // flag is on — pairs with the fallback warns below for a hit/miss rate.
+        logger.info("dbt engine compile hit", {
+          event: "dbt_engine_compile",
+          outcome: "hit",
           elapsedMs: engineResult.elapsed_ms,
+          projectId: cacheScope.projectId,
+          environment: cacheScope.environment,
         });
         return {
           success: true,
@@ -232,11 +238,21 @@ export async function runAdhocDbtCommand(params: {
         };
       }
       logger.warn("dbt engine compile failed; falling back to subprocess", {
+        event: "dbt_engine_compile",
+        outcome: "fallback",
+        reason: "compile_failed",
         error: engineResult.error,
+        projectId: cacheScope.projectId,
+        environment: cacheScope.environment,
       });
     } catch (error) {
       logger.warn("dbt engine unavailable; falling back to subprocess", {
+        event: "dbt_engine_compile",
+        outcome: "fallback",
+        reason: "unavailable",
         error: String(error),
+        projectId: cacheScope.projectId,
+        environment: cacheScope.environment,
       });
     }
   }
@@ -266,9 +282,23 @@ export async function runAdhocDbtCommand(params: {
       raw = await withProjectDir({ ...cacheScope, role: "adhoc" }, dir =>
         runOnce(dir),
       );
+      // Positive signal so warm-dir engagement is observable, not faith-based:
+      // (hit count) vs the fallback warn below gives the warm-dir success rate.
+      logger.info("dbt warm dir used", {
+        event: "dbt_warm_dir",
+        outcome: "hit",
+        role: "adhoc",
+        projectId: cacheScope.projectId,
+        environment: cacheScope.environment,
+      });
     } catch (error) {
       logger.warn("Warm dir run failed; falling back to throwaway dir", {
+        event: "dbt_warm_dir",
+        outcome: "fallback",
+        role: "adhoc",
         error: String(error),
+        projectId: cacheScope.projectId,
+        environment: cacheScope.environment,
       });
     }
   }

--- a/api/src/dbt/dbt-project.service.ts
+++ b/api/src/dbt/dbt-project.service.ts
@@ -223,7 +223,12 @@ export async function runAdhocDbtCommand(params: {
           logs: [],
           stepResults: [],
           compiledSql: engineResult.compiled_sql ?? undefined,
-          raw: { success: true, commandResults: [], artifacts: {} },
+          raw: {
+            success: true,
+            commandResults: [],
+            artifacts: {},
+            projectChanged: false,
+          },
         };
       }
       logger.warn("dbt engine compile failed; falling back to subprocess", {
@@ -269,7 +274,14 @@ export async function runAdhocDbtCommand(params: {
   }
   if (!raw) raw = await runOnce(undefined);
 
-  if (raw.artifacts.partialParse) {
+  // Only re-upload the parse cache when something actually changed (or the
+  // store had no cache yet). A no-change run leaves the seeded cache current,
+  // so skip the redundant upload — the msgpack's embedded timestamps would
+  // otherwise make every run look "new".
+  if (
+    raw.artifacts.partialParse &&
+    (raw.projectChanged || !caches.partialParse)
+  ) {
     await saveParseCache(cacheScope, raw.artifacts.partialParse);
   }
   if (raw.artifacts.packagesArchive && packagesHash) {

--- a/api/src/dbt/dbt-project.service.ts
+++ b/api/src/dbt/dbt-project.service.ts
@@ -19,11 +19,28 @@ import {
 import { renderDbtProfile, type RenderedProfile } from "./adapter-map";
 import { parseDbtCommand, type ParsedDbtCommand } from "./commands";
 import {
+  materializeDbtProject,
   parseStepResults,
   runDbt,
+  seedDbtCaches,
   type DbtLogLine,
   type DbtRunResult,
 } from "./runner.service";
+import {
+  dbtEngineEnabled,
+  engineCompile,
+  enginePrepare,
+} from "./dbt-engine.service";
+import {
+  computePackagesHash,
+  loadDbtCaches,
+  saveParseCache,
+  savePackagesCache,
+} from "./dbt-cache.service";
+import { warmDirsEnabled, withProjectDir } from "./workspace-dir.service";
+import { loggers } from "../logging";
+
+const logger = loggers.app();
 
 export interface DbtProjectSnapshot {
   project: IDbtProject;
@@ -144,15 +161,124 @@ export async function runAdhocDbtCommand(params: {
     environmentName: params.environmentName,
   });
 
-  const raw = await runDbt({
-    files: snapshot.files,
-    profile: snapshot.profile,
-    commands: [parsed],
-    dbtVersion: snapshot.project.dbtVersion,
-    deferState: params.deferState,
-    commandTimeoutMs: params.timeoutMs ?? 5 * 60 * 1000,
-    signal: params.signal,
-  });
+  // Warm caches so parse/compile/show/build don't re-parse the whole project
+  // (and skip `dbt deps` when packages are unchanged). Best-effort.
+  const cacheScope = {
+    workspaceId: params.workspaceId,
+    projectId: params.projectId,
+    environment: snapshot.environment.name,
+  };
+  const packagesHash = computePackagesHash(snapshot.files);
+  const caches = await loadDbtCaches(cacheScope, packagesHash);
+
+  // Resident-engine fast path: an offline `compile --select X` reuses an
+  // in-memory manifest (no interpreter cold start, no full re-parse) — the
+  // dbt Cloud "develop" feel. Held under the same adhoc warm-dir mutex so the
+  // tree can't mutate while the engine reads it. Any failure (engine down,
+  // package macros needing an install we don't have, introspective compile)
+  // falls through to the subprocess path below, so correctness never depends
+  // on the engine. Gated by DBT_ENGINE_ENABLED (default off).
+  if (
+    dbtEngineEnabled() &&
+    warmDirsEnabled() &&
+    parsed.subcommand === "compile" &&
+    params.select
+  ) {
+    const select = params.select;
+    try {
+      const engineResult = await withProjectDir(
+        { ...cacheScope, role: "adhoc" },
+        async dir => {
+          const { keyfileEnv } = await materializeDbtProject(dir, {
+            files: snapshot.files,
+            profile: snapshot.profile,
+            reconcile: true,
+          });
+          await seedDbtCaches(dir, {
+            partialParse: caches.partialParse,
+            packagesArchive: caches.packages,
+          });
+          const ctx = {
+            adapterPackage: snapshot.profile.adapterPackage,
+            dbtVersion: snapshot.project.dbtVersion,
+            connectionEnv: { ...snapshot.profile.secretEnv, ...keyfileEnv },
+          };
+          const session = {
+            key: `${params.workspaceId}:${params.projectId}:${snapshot.environment.name}`,
+            projectDir: dir,
+          };
+          // Re-parse to pick up edits (cheap via partial parse), then reuse the
+          // warm manifest to compile.
+          await enginePrepare(ctx, session);
+          return engineCompile(ctx, session, select);
+        },
+      );
+      if (engineResult.ok) {
+        logger.debug("dbt engine compile hit", {
+          elapsedMs: engineResult.elapsed_ms,
+        });
+        return {
+          success: true,
+          exitCode: 0,
+          logs: [],
+          stepResults: [],
+          compiledSql: engineResult.compiled_sql ?? undefined,
+          raw: { success: true, commandResults: [], artifacts: {} },
+        };
+      }
+      logger.warn("dbt engine compile failed; falling back to subprocess", {
+        error: engineResult.error,
+      });
+    } catch (error) {
+      logger.warn("dbt engine unavailable; falling back to subprocess", {
+        error: String(error),
+      });
+    }
+  }
+
+  // Interactive commands run in a warm dir (role=adhoc) kept separate from the
+  // deploy executor's, so a long build never blocks a compile. The artifact
+  // caches above seed a cold dir; thereafter the on-disk tree stays warm.
+  const runOnce = (workingDir?: string) =>
+    runDbt({
+      files: snapshot.files,
+      profile: snapshot.profile,
+      commands: [parsed],
+      dbtVersion: snapshot.project.dbtVersion,
+      deferState: params.deferState,
+      commandTimeoutMs: params.timeoutMs ?? 5 * 60 * 1000,
+      seedPartialParse: caches.partialParse,
+      seedPackagesArchive: caches.packages,
+      skipDeps: caches.packagesFresh,
+      packagesHash,
+      workingDir,
+      signal: params.signal,
+    });
+
+  let raw: Awaited<ReturnType<typeof runDbt>> | undefined;
+  if (warmDirsEnabled()) {
+    try {
+      raw = await withProjectDir({ ...cacheScope, role: "adhoc" }, dir =>
+        runOnce(dir),
+      );
+    } catch (error) {
+      logger.warn("Warm dir run failed; falling back to throwaway dir", {
+        error: String(error),
+      });
+    }
+  }
+  if (!raw) raw = await runOnce(undefined);
+
+  if (raw.artifacts.partialParse) {
+    await saveParseCache(cacheScope, raw.artifacts.partialParse);
+  }
+  if (raw.artifacts.packagesArchive && packagesHash) {
+    await savePackagesCache(
+      cacheScope,
+      raw.artifacts.packagesArchive,
+      packagesHash,
+    );
+  }
 
   const commandResult = raw.commandResults[0];
   return {

--- a/api/src/dbt/dbt-run.service.ts
+++ b/api/src/dbt/dbt-run.service.ts
@@ -19,16 +19,23 @@ import { loggers } from "../logging";
 const logger = loggers.api("dbt-run");
 
 /**
- * How long a run may sit in "queued" before the read-side watchdog declares it
- * failed. The executor claims a run within seconds; anything still queued past
- * this window means the Inngest worker never picked it up (unavailable, or — on
- * branch/preview envs — "dbt/run.requested" events not routed to this env). We
- * never want the UI to spin on "queued" forever, so we finalize it as an error.
+ * How long an ad-hoc run may sit in "queued" before the read-side watchdog
+ * declares it failed. With no sibling run executing for the project, the
+ * executor claims a run within seconds, so anything still queued past this
+ * window (and with nothing running ahead of it) means the event was never
+ * delivered — worker down, or events not routed to this env (branch/preview).
+ *
+ * This is a fast, interactive complement to the cron `dbtRunSweeperFunction`,
+ * which is the authoritative backstop (6h) and the only path that finalizes
+ * *scheduled* job runs (it also mirrors job-health stats). We intentionally do
+ * NOT fast-fail job runs here to avoid that stat drift.
  */
-const QUEUE_TIMEOUT_MS = Number(process.env.DBT_QUEUE_TIMEOUT_MS) || 3 * 60_000;
+const QUEUE_TIMEOUT_MS = Number(process.env.DBT_QUEUE_TIMEOUT_MS) || 5 * 60_000;
 
 type ReconcilableRun = {
   _id: Types.ObjectId;
+  projectId?: Types.ObjectId;
+  jobId?: Types.ObjectId;
   status: string;
   createdAt?: Date;
   startedAt?: Date;
@@ -47,16 +54,34 @@ export function isStaleQueued(
 }
 
 /**
- * Finalize a run that has been stuck in "queued" past QUEUE_TIMEOUT_MS as an
- * error, so callers never observe a perpetually-queued run. The update is
- * guarded on `status: "queued"` — mutually exclusive with the executor's
- * `mark-running` claim — so a run that the worker grabs at the last moment is
- * left untouched. Returns the (possibly patched) run for immediate display.
+ * Finalize an ad-hoc run stuck in "queued" past QUEUE_TIMEOUT_MS as an error,
+ * so the run card / Runs view never spin forever on a lost event. Guards:
+ *
+ *  - **Ad-hoc only.** Scheduled job runs (jobId set) are left to the cron
+ *    sweeper, which mirrors job-health stats; failing them here would drift.
+ *  - **No sibling executing.** The executor serializes per project
+ *    (concurrency limit 1 / projectId), so a queued run with a peer already
+ *    `running` is legitimately waiting its turn — never fail those.
+ *  - **Guarded write** on `status: "queued"`, mutually exclusive with the
+ *    executor's `mark-running` claim, so a last-moment pickup is never clobbered.
+ *
+ * Returns the (possibly patched) run for immediate display.
  */
 export async function reconcileStaleQueuedRun<T extends ReconcilableRun>(
   run: T,
 ): Promise<T> {
   if (!isStaleQueued(run)) return run;
+  // Scheduled job runs are the cron sweeper's responsibility (+ stat mirroring).
+  if (run.jobId) return run;
+  // Still waiting behind the per-project concurrency lock? Not a lost event.
+  if (run.projectId) {
+    const peerRunning = await DbtRun.exists({
+      projectId: run.projectId,
+      status: "running",
+      _id: { $ne: run._id },
+    });
+    if (peerRunning) return run;
+  }
 
   const completedAt = new Date();
   const error =

--- a/api/src/dbt/dbt-run.service.ts
+++ b/api/src/dbt/dbt-run.service.ts
@@ -14,6 +14,104 @@ import {
   type IDbtRun,
 } from "../database/workspace-schema";
 import { parseDbtCommands } from "./commands";
+import { loggers } from "../logging";
+
+const logger = loggers.api("dbt-run");
+
+/**
+ * How long a run may sit in "queued" before the read-side watchdog declares it
+ * failed. The executor claims a run within seconds; anything still queued past
+ * this window means the Inngest worker never picked it up (unavailable, or — on
+ * branch/preview envs — "dbt/run.requested" events not routed to this env). We
+ * never want the UI to spin on "queued" forever, so we finalize it as an error.
+ */
+const QUEUE_TIMEOUT_MS = Number(process.env.DBT_QUEUE_TIMEOUT_MS) || 3 * 60_000;
+
+type ReconcilableRun = {
+  _id: Types.ObjectId;
+  status: string;
+  createdAt?: Date;
+  startedAt?: Date;
+  error?: string;
+  completedAt?: Date;
+};
+
+export function isStaleQueued(
+  run: ReconcilableRun,
+  now: number = Date.now(),
+  timeoutMs: number = QUEUE_TIMEOUT_MS,
+): boolean {
+  if (run.status !== "queued" || run.startedAt) return false;
+  const created = run.createdAt ? new Date(run.createdAt).getTime() : 0;
+  return created > 0 && now - created > timeoutMs;
+}
+
+/**
+ * Finalize a run that has been stuck in "queued" past QUEUE_TIMEOUT_MS as an
+ * error, so callers never observe a perpetually-queued run. The update is
+ * guarded on `status: "queued"` — mutually exclusive with the executor's
+ * `mark-running` claim — so a run that the worker grabs at the last moment is
+ * left untouched. Returns the (possibly patched) run for immediate display.
+ */
+export async function reconcileStaleQueuedRun<T extends ReconcilableRun>(
+  run: T,
+): Promise<T> {
+  if (!isStaleQueued(run)) return run;
+
+  const completedAt = new Date();
+  const error =
+    `Run timed out in "queued" after ${Math.round(QUEUE_TIMEOUT_MS / 1000)}s — ` +
+    `the dbt worker never picked it up. The Inngest worker may be unavailable, ` +
+    `or "dbt/run.requested" events are not being routed to this environment.`;
+
+  const res = await DbtRun.updateOne(
+    { _id: run._id, status: "queued" },
+    { $set: { status: "error", error, completedAt } },
+  );
+
+  // modifiedCount === 0 means the executor claimed it first; leave it alone.
+  if (res.modifiedCount !== 1) return run;
+
+  logger.warn("dbt run timed out in queued; finalized as error", {
+    event: "dbt.run.queue_timeout",
+    runId: run._id.toString(),
+    queueTimeoutMs: QUEUE_TIMEOUT_MS,
+  });
+  return { ...run, status: "error", error, completedAt } as T;
+}
+
+/** Batch variant — only touches the DB for runs that are actually stale. */
+export async function reconcileStaleQueuedRuns<T extends ReconcilableRun>(
+  runs: T[],
+): Promise<T[]> {
+  return Promise.all(
+    runs.map(run => (isStaleQueued(run) ? reconcileStaleQueuedRun(run) : run)),
+  );
+}
+
+/**
+ * Mark a freshly-created run as failed when we cannot even hand it to the
+ * executor (e.g. inngest.send throws). Guarded on "queued" so it never clobbers
+ * a run that somehow already started.
+ */
+async function failUnenqueuedRun(
+  runId: Types.ObjectId,
+  cause: unknown,
+): Promise<void> {
+  const message = cause instanceof Error ? cause.message : String(cause);
+  await DbtRun.updateOne(
+    { _id: runId, status: "queued" },
+    {
+      $set: {
+        status: "error",
+        error: `Failed to enqueue dbt run: ${message}`,
+        completedAt: new Date(),
+      },
+    },
+  ).catch(() => {
+    /* best-effort: the original send error is what we surface */
+  });
+}
 
 export async function triggerDbtRun(params: {
   workspaceId: string;
@@ -53,15 +151,20 @@ export async function triggerDbtRun(params: {
     triggeredBy: params.triggeredBy,
   });
 
-  await inngest.send({
-    name: "dbt/run.requested",
-    data: {
-      workspaceId: params.workspaceId,
-      projectId: params.projectId,
-      runId: run._id.toString(),
-      jobId: params.jobId,
-    },
-  });
+  try {
+    await inngest.send({
+      name: "dbt/run.requested",
+      data: {
+        workspaceId: params.workspaceId,
+        projectId: params.projectId,
+        runId: run._id.toString(),
+        jobId: params.jobId,
+      },
+    });
+  } catch (sendError) {
+    await failUnenqueuedRun(run._id, sendError);
+    throw sendError;
+  }
 
   return run;
 }
@@ -120,15 +223,20 @@ export async function triggerDbtRunRetry(params: {
     },
   });
 
-  await inngest.send({
-    name: "dbt/run.requested",
-    data: {
-      workspaceId: params.workspaceId,
-      projectId: source.projectId.toString(),
-      runId: run._id.toString(),
-      jobId: source.jobId?.toString(),
-    },
-  });
+  try {
+    await inngest.send({
+      name: "dbt/run.requested",
+      data: {
+        workspaceId: params.workspaceId,
+        projectId: source.projectId.toString(),
+        runId: run._id.toString(),
+        jobId: source.jobId?.toString(),
+      },
+    });
+  } catch (sendError) {
+    await failUnenqueuedRun(run._id, sendError);
+    throw sendError;
+  }
 
   return run;
 }

--- a/api/src/dbt/engine/dbt_engine.py
+++ b/api/src/dbt/engine/dbt_engine.py
@@ -15,7 +15,7 @@ Sessions are keyed by an opaque string (the supervisor uses project+env). The
 supervisor owns the on-disk working directory; this process only reads it.
 
 All assumptions here were verified against dbt-core 1.9.10 + dbt-duckdb 1.9.4
-(see api/src/dbt/engine/__tests__ contract test).
+(see api/src/dbt/dbt-engine.contract.test.ts).
 """
 
 import json

--- a/api/src/dbt/engine/dbt_engine.py
+++ b/api/src/dbt/engine/dbt_engine.py
@@ -1,0 +1,192 @@
+"""Resident dbt engine.
+
+A long-lived Python process that keeps parsed dbt manifests in memory so the
+hot interactive loop (parse -> compile -> show) skips the expensive re-parse
+on every call. This is the dbt Cloud "develop" model: parse once, then reuse
+the in-memory Manifest via dbt-core's programmatic `dbtRunner(manifest=...)`.
+
+Protocol (newline-delimited JSON):
+  - Requests arrive on STDIN, one JSON object per line: {"id", "op", ...}.
+  - Responses are written to FILE DESCRIPTOR 3, one JSON object per line:
+    {"id", "ok", ...}. We do NOT use stdout because dbt-core writes its own
+    logs there; stdout/stderr are left for the supervisor to capture as logs.
+
+Sessions are keyed by an opaque string (the supervisor uses project+env). The
+supervisor owns the on-disk working directory; this process only reads it.
+
+All assumptions here were verified against dbt-core 1.9.10 + dbt-duckdb 1.9.4
+(see api/src/dbt/engine/__tests__ contract test).
+"""
+
+import json
+import os
+import sys
+import time
+import traceback
+
+import dbt.version
+from dbt.cli.main import dbtRunner
+
+# Dedicated protocol channel. dbt logs to stdout/stderr, so responses must not
+# share fd 1. Line-buffered so the supervisor sees each response promptly.
+_PROTOCOL = os.fdopen(3, "w", buffering=1)
+
+
+def _send(obj):
+    _PROTOCOL.write(json.dumps(obj, default=str) + "\n")
+    _PROTOCOL.flush()
+
+
+# session key -> {"manifest": Manifest, "project_dir": str}
+_SESSIONS = {}
+
+
+def _base(project_dir):
+    return [
+        "--project-dir",
+        project_dir,
+        "--profiles-dir",
+        project_dir,
+        "--no-use-colors",
+    ]
+
+
+def _session(req):
+    key = req["session"]
+    state = _SESSIONS.get(key)
+    if state is None:
+        raise RuntimeError(f"no warm session for {key!r}; call prepare first")
+    return state
+
+
+def op_ping(_req):
+    return {"dbt_version": dbt.version.get_installed_version().to_version_string()}
+
+
+def op_prepare(req):
+    """Parse the project on disk and cache the manifest under `session`.
+
+    Idempotent: re-parsing picks up file changes the supervisor has written
+    (dbt's own checksum-based partial parse keeps this cheap via target/).
+    """
+    key = req["session"]
+    project_dir = req["project_dir"]
+    started = time.time()
+    result = dbtRunner().invoke(["parse", *_base(project_dir)])
+    if not result.success:
+        raise RuntimeError(_first_error(result) or "parse failed")
+    manifest = result.result
+    _SESSIONS[key] = {"manifest": manifest, "project_dir": project_dir}
+    return {
+        "parse_ms": int((time.time() - started) * 1000),
+        "nodes": len(getattr(manifest, "nodes", {}) or {}),
+    }
+
+
+def op_compile(req):
+    state = _session(req)
+    started = time.time()
+    result = dbtRunner(manifest=state["manifest"]).invoke(
+        ["compile", *_base(state["project_dir"]), "--select", req["select"]]
+    )
+    compiled_sql = None
+    results = getattr(result.result, "results", None) if result.result else None
+    if results:
+        node = getattr(results[0], "node", None)
+        compiled_sql = getattr(node, "compiled_code", None)
+    return {
+        "ok": bool(result.success),
+        "compiled_sql": compiled_sql,
+        "elapsed_ms": int((time.time() - started) * 1000),
+        "error": None if result.success else _first_error(result),
+    }
+
+
+def op_show(req):
+    state = _session(req)
+    args = ["show", *_base(state["project_dir"]), "--limit", str(req.get("limit", 50))]
+    if req.get("inline"):
+        args += ["--inline", req["inline"]]
+    else:
+        args += ["--select", req["select"]]
+    started = time.time()
+    result = dbtRunner(manifest=state["manifest"]).invoke(args)
+    columns, rows = [], []
+    results = getattr(result.result, "results", None) if result.result else None
+    if results:
+        table = getattr(results[0], "agate_table", None)
+        if table is not None:
+            columns = list(table.column_names)
+            rows = [list(row) for row in table.rows]
+    return {
+        "ok": bool(result.success),
+        "columns": columns,
+        "rows": rows,
+        "elapsed_ms": int((time.time() - started) * 1000),
+        "error": None if result.success else _first_error(result),
+    }
+
+
+def op_invalidate(req):
+    _SESSIONS.pop(req["session"], None)
+    return {}
+
+
+def _first_error(result):
+    """Best-effort human-readable failure message from a dbtRunnerResult."""
+    if getattr(result, "exception", None):
+        return str(result.exception)
+    results = getattr(result.result, "results", None) if result.result else None
+    if results:
+        for node_result in results:
+            message = getattr(node_result, "message", None)
+            if message:
+                return str(message)
+    return None
+
+
+_OPS = {
+    "ping": op_ping,
+    "prepare": op_prepare,
+    "compile": op_compile,
+    "show": op_show,
+    "invalidate": op_invalidate,
+    "evict": op_invalidate,
+}
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            req = json.loads(line)
+        except Exception as error:  # noqa: BLE001 - report and continue
+            _send({"id": None, "ok": False, "error": f"bad json: {error}"})
+            continue
+
+        rid = req.get("id")
+        handler = _OPS.get(req.get("op"))
+        if handler is None:
+            _send({"id": rid, "ok": False, "error": f"unknown op {req.get('op')!r}"})
+            continue
+
+        try:
+            payload = handler(req)
+            response = {"id": rid, "ok": True}
+            response.update(payload)
+            _send(response)
+        except Exception as error:  # noqa: BLE001 - never let one request kill the loop
+            _send(
+                {
+                    "id": rid,
+                    "ok": False,
+                    "error": str(error),
+                    "trace": traceback.format_exc()[-1500:],
+                }
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/api/src/dbt/runner.service.ts
+++ b/api/src/dbt/runner.service.ts
@@ -107,6 +107,12 @@ export interface DbtCommandResult {
 export interface DbtRunResult {
   success: boolean;
   commandResults: DbtCommandResult[];
+  /**
+   * Whether materialization wrote or pruned any project file this run. False
+   * means the warm dir was already in sync, so the parse cache the caller
+   * seeded is still current and need not be re-uploaded.
+   */
+  projectChanged: boolean;
   /** Raw artifact contents collected from target/ after the last command. */
   artifacts: {
     manifest?: Buffer;
@@ -253,15 +259,16 @@ async function extractArchive(
 }
 
 /** Write only when content differs — avoids needless mtime bumps that would
- * defeat dbt's checksum-based partial parsing in a warm dir. */
+ * defeat dbt's checksum-based partial parsing in a warm dir. Returns true when
+ * it actually wrote (i.e. content changed or the file was missing). */
 async function writeFileIfChanged(
   absolute: string,
   content: string,
   mode?: number,
-): Promise<void> {
+): Promise<boolean> {
   try {
     const existing = await readFile(absolute, "utf8");
-    if (existing === content) return;
+    if (existing === content) return false;
   } catch {
     // Missing — fall through to write.
   }
@@ -271,6 +278,7 @@ async function writeFileIfChanged(
     content,
     mode ? { encoding: "utf8", mode } : "utf8",
   );
+  return true;
 }
 
 // Top-level entries dbt (or we) own — never pruned during reconciliation.
@@ -314,9 +322,10 @@ async function listFilesRecursive(
 async function reconcileWarmDir(
   projectDir: string,
   keep: Set<string>,
-): Promise<void> {
+): Promise<boolean> {
   const present: string[] = [];
   await listFilesRecursive(projectDir, projectDir, present);
+  let deleted = false;
   for (const rel of present) {
     if (keep.has(rel)) continue;
     if (RECONCILE_PRESERVED_FILES.has(rel)) continue;
@@ -324,7 +333,9 @@ async function reconcileWarmDir(
     await rm(join(projectDir, ...rel.split("/")), { force: true }).catch(
       () => {},
     );
+    deleted = true;
   }
+  return deleted;
 }
 
 function execDbtCommand(params: {
@@ -410,8 +421,11 @@ function execDbtCommand(params: {
  * files no longer in the snapshot so a deleted model can never be built.
  *
  * Returns the keyfile env map (absolute paths the profile's env_var()
- * references resolve to). Shared by {@link runDbt} (subprocess) and the
- * resident engine's prepare so both operate on an identical tree.
+ * references resolve to) and `changed` — whether any file was written or
+ * pruned this call. `changed` lets callers skip redundant work (e.g. re-saving
+ * the parse cache) when a warm dir was already in sync. Shared by
+ * {@link runDbt} (subprocess) and the resident engine's prepare so both
+ * operate on an identical tree.
  */
 export async function materializeDbtProject(
   projectDir: string,
@@ -420,23 +434,32 @@ export async function materializeDbtProject(
     profile: RenderedProfile;
     reconcile?: boolean;
   },
-): Promise<{ keyfileEnv: Record<string, string> }> {
+): Promise<{ keyfileEnv: Record<string, string>; changed: boolean }> {
   // Preserve list for reconciliation (profiles.yml + every snapshot file +
   // keyfiles get added below).
   const keep = new Set<string>(["profiles.yml"]);
+  let changed = false;
 
   for (const file of params.files) {
     const safePath = ensureSafeRelativePath(file.path);
     keep.add(safePath);
-    await writeFileIfChanged(
-      join(projectDir, ...safePath.split("/")),
-      file.content,
-    );
+    if (
+      await writeFileIfChanged(
+        join(projectDir, ...safePath.split("/")),
+        file.content,
+      )
+    ) {
+      changed = true;
+    }
   }
-  await writeFileIfChanged(
-    join(projectDir, "profiles.yml"),
-    params.profile.profilesYml,
-  );
+  if (
+    await writeFileIfChanged(
+      join(projectDir, "profiles.yml"),
+      params.profile.profilesYml,
+    )
+  ) {
+    changed = true;
+  }
 
   // Credential files (e.g. BigQuery service-account JSON) with restrictive
   // perms; their absolute paths are exported so env_var() keyfile refs resolve.
@@ -445,12 +468,16 @@ export async function materializeDbtProject(
     const safePath = ensureSafeRelativePath(keyfile.filename);
     keep.add(safePath);
     const absolute = join(projectDir, ...safePath.split("/"));
-    await writeFileIfChanged(absolute, keyfile.content, 0o600);
+    if (await writeFileIfChanged(absolute, keyfile.content, 0o600)) {
+      changed = true;
+    }
     keyfileEnv[keyfile.envVar] = absolute;
   }
 
-  if (params.reconcile) await reconcileWarmDir(projectDir, keep);
-  return { keyfileEnv };
+  if (params.reconcile && (await reconcileWarmDir(projectDir, keep))) {
+    changed = true;
+  }
+  return { keyfileEnv, changed };
 }
 
 /**
@@ -496,11 +523,14 @@ export async function runDbt(request: DbtRunRequest): Promise<DbtRunResult> {
     // Sync project files + profiles.yml + keyfiles into the dir (write-if-
     // changed + delete reconciliation for warm dirs). Shared with the resident
     // engine's prepare so both see an identical on-disk tree.
-    const { keyfileEnv } = await materializeDbtProject(projectDir, {
-      files: request.files,
-      profile: request.profile,
-      reconcile: !ownsDir,
-    });
+    const { keyfileEnv, changed: projectChanged } = await materializeDbtProject(
+      projectDir,
+      {
+        files: request.files,
+        profile: request.profile,
+        reconcile: !ownsDir,
+      },
+    );
 
     // Seed prior artifacts into target/ for `dbt retry` (run_results.json is
     // what dbt reads to resume at the failed/skipped nodes).
@@ -637,7 +667,7 @@ export async function runDbt(request: DbtRunRequest): Promise<DbtRunResult> {
             logLines: depsLogLines,
             runResults: undefined,
           });
-          return { success: false, commandResults, artifacts };
+          return { success: false, commandResults, artifacts, projectChanged };
         }
         // Freshly installed — archive so the next run can skip the install.
         artifacts.packagesArchive = await archiveEntries(projectDir, [
@@ -742,7 +772,7 @@ export async function runDbt(request: DbtRunRequest): Promise<DbtRunResult> {
       "partial_parse.msgpack",
     );
 
-    return { success, commandResults, artifacts };
+    return { success, commandResults, artifacts, projectChanged };
   } finally {
     // Only delete throwaway dirs. Warm dirs are owned by the caller and reused.
     if (ownsDir) {

--- a/api/src/dbt/runner.service.ts
+++ b/api/src/dbt/runner.service.ts
@@ -8,9 +8,17 @@
  */
 
 import { spawn } from "child_process";
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "fs/promises";
+import {
+  access,
+  mkdtemp,
+  mkdir,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "fs/promises";
 import { tmpdir } from "os";
-import { dirname, join, normalize, sep } from "path";
+import { dirname, join, normalize, relative, sep } from "path";
 import { loggers } from "../logging";
 import type { ParsedDbtCommand } from "./commands";
 import type { RenderedProfile } from "./adapter-map";
@@ -46,6 +54,34 @@ export interface DbtRunRequest {
    * `--select state:modified+` only builds what changed.
    */
   deferState?: Buffer;
+  /**
+   * dbt's partial-parse manifest from a previous run. Seeded into
+   * target/partial_parse.msgpack so dbt re-parses only changed files. dbt
+   * validates it against file checksums + config and full-parses on mismatch,
+   * so a stale buffer is always safe.
+   */
+  seedPartialParse?: Buffer;
+  /**
+   * tgz of a previously-installed dbt_packages/ (+ package-lock.yml). Extracted
+   * into the project dir before commands so `dbt deps` can be skipped.
+   */
+  seedPackagesArchive?: Buffer;
+  /**
+   * Skip `dbt deps` (used together with seedPackagesArchive when the cached
+   * packages tree is still valid for the current packages.yml).
+   */
+  skipDeps?: boolean;
+  /**
+   * Reuse a stable warm directory instead of a throwaway temp dir. The caller
+   * owns its lifecycle (serialization + eviction); runDbt syncs files in place
+   * (write-if-changed + delete reconciliation) and does NOT delete it on exit.
+   */
+  workingDir?: string;
+  /**
+   * Hash of the dependency declarations. With a warm `workingDir`, lets runDbt
+   * skip `dbt deps` when the on-disk dbt_packages/ tree already matches.
+   */
+  packagesHash?: string | null;
   signal?: AbortSignal;
   onLog?: (line: DbtLogLine) => void;
 }
@@ -78,6 +114,10 @@ export interface DbtRunResult {
     catalog?: Buffer;
     /** Written by `dbt source freshness`. */
     sources?: Buffer;
+    /** dbt's partial-parse manifest — cache for the next run's parse. */
+    partialParse?: Buffer;
+    /** tgz of dbt_packages/ — only present when `dbt deps` ran this command. */
+    packagesArchive?: Buffer;
   };
 }
 
@@ -143,6 +183,147 @@ async function readArtifact(
     return await readFile(join(projectDir, "target", name));
   } catch {
     return undefined;
+  }
+}
+
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Run `tar` as a subprocess; rejects on non-zero exit. */
+function runTar(args: string[], cwd: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("tar", args, {
+      cwd,
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    let stderr = "";
+    child.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString("utf8");
+    });
+    child.on("error", reject);
+    child.on("close", code => {
+      if (code === 0) resolve();
+      else reject(new Error(`tar exited ${code}: ${stderr.slice(0, 500)}`));
+    });
+  });
+}
+
+/** gzip-tar the given entries (those that exist) under projectDir into a Buffer. */
+async function archiveEntries(
+  projectDir: string,
+  entries: string[],
+): Promise<Buffer | undefined> {
+  const present: string[] = [];
+  for (const entry of entries) {
+    if (await pathExists(join(projectDir, entry))) present.push(entry);
+  }
+  if (present.length === 0) return undefined;
+  const tarPath = join(projectDir, ".mako-cache-out.tgz");
+  try {
+    await runTar(["-czf", tarPath, ...present], projectDir);
+    return await readFile(tarPath);
+  } catch (error) {
+    logger.warn("Failed to archive dbt cache entries", {
+      error: String(error),
+    });
+    return undefined;
+  } finally {
+    await rm(tarPath, { force: true }).catch(() => {});
+  }
+}
+
+/** Extract a gzip-tar buffer into projectDir. Best-effort. */
+async function extractArchive(
+  buffer: Buffer,
+  projectDir: string,
+): Promise<void> {
+  const tarPath = join(projectDir, ".mako-cache-in.tgz");
+  try {
+    await writeFile(tarPath, buffer);
+    await runTar(["-xzf", tarPath], projectDir);
+  } finally {
+    await rm(tarPath, { force: true }).catch(() => {});
+  }
+}
+
+/** Write only when content differs — avoids needless mtime bumps that would
+ * defeat dbt's checksum-based partial parsing in a warm dir. */
+async function writeFileIfChanged(
+  absolute: string,
+  content: string,
+  mode?: number,
+): Promise<void> {
+  try {
+    const existing = await readFile(absolute, "utf8");
+    if (existing === content) return;
+  } catch {
+    // Missing — fall through to write.
+  }
+  await mkdir(dirname(absolute), { recursive: true });
+  await writeFile(
+    absolute,
+    content,
+    mode ? { encoding: "utf8", mode } : "utf8",
+  );
+}
+
+// Top-level entries dbt (or we) own — never pruned during reconciliation.
+const RECONCILE_PRESERVED_DIRS = new Set([
+  "target",
+  "dbt_packages",
+  "logs",
+  "state",
+]);
+const RECONCILE_PRESERVED_FILES = new Set(["profiles.yml", "package-lock.yml"]);
+
+async function listFilesRecursive(
+  root: string,
+  current: string,
+  out: string[],
+): Promise<void> {
+  let entries;
+  try {
+    entries = await readdir(current, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const abs = join(current, entry.name);
+    const rel = relative(root, abs).split(sep).join("/");
+    const top = rel.split("/")[0];
+    if (RECONCILE_PRESERVED_DIRS.has(top)) continue;
+    if (entry.isDirectory()) {
+      await listFilesRecursive(root, abs, out);
+    } else if (entry.isFile()) {
+      out.push(rel);
+    }
+  }
+}
+
+/**
+ * Delete files in a warm dir that are no longer part of the project snapshot
+ * (e.g. a model the user deleted), so a stale file can never be built. Keeps
+ * dbt-owned dirs, profiles.yml, keyfiles, and our dotfiles.
+ */
+async function reconcileWarmDir(
+  projectDir: string,
+  keep: Set<string>,
+): Promise<void> {
+  const present: string[] = [];
+  await listFilesRecursive(projectDir, projectDir, present);
+  for (const rel of present) {
+    if (keep.has(rel)) continue;
+    if (RECONCILE_PRESERVED_FILES.has(rel)) continue;
+    if (rel.startsWith(".")) continue; // our markers / cache scratch
+    await rm(join(projectDir, ...rel.split("/")), { force: true }).catch(
+      () => {},
+    );
   }
 }
 
@@ -223,42 +404,103 @@ function execDbtCommand(params: {
 }
 
 /**
+ * Sync a dbt project onto disk: project files + profiles.yml + credential
+ * keyfiles (0600). Writes only changed files (so warm dirs keep dbt's
+ * checksum-based partial parsing valid) and, when `reconcile` is set, prunes
+ * files no longer in the snapshot so a deleted model can never be built.
+ *
+ * Returns the keyfile env map (absolute paths the profile's env_var()
+ * references resolve to). Shared by {@link runDbt} (subprocess) and the
+ * resident engine's prepare so both operate on an identical tree.
+ */
+export async function materializeDbtProject(
+  projectDir: string,
+  params: {
+    files: Array<{ path: string; content: string }>;
+    profile: RenderedProfile;
+    reconcile?: boolean;
+  },
+): Promise<{ keyfileEnv: Record<string, string> }> {
+  // Preserve list for reconciliation (profiles.yml + every snapshot file +
+  // keyfiles get added below).
+  const keep = new Set<string>(["profiles.yml"]);
+
+  for (const file of params.files) {
+    const safePath = ensureSafeRelativePath(file.path);
+    keep.add(safePath);
+    await writeFileIfChanged(
+      join(projectDir, ...safePath.split("/")),
+      file.content,
+    );
+  }
+  await writeFileIfChanged(
+    join(projectDir, "profiles.yml"),
+    params.profile.profilesYml,
+  );
+
+  // Credential files (e.g. BigQuery service-account JSON) with restrictive
+  // perms; their absolute paths are exported so env_var() keyfile refs resolve.
+  const keyfileEnv: Record<string, string> = {};
+  for (const keyfile of params.profile.keyfiles ?? []) {
+    const safePath = ensureSafeRelativePath(keyfile.filename);
+    keep.add(safePath);
+    const absolute = join(projectDir, ...safePath.split("/"));
+    await writeFileIfChanged(absolute, keyfile.content, 0o600);
+    keyfileEnv[keyfile.envVar] = absolute;
+  }
+
+  if (params.reconcile) await reconcileWarmDir(projectDir, keep);
+  return { keyfileEnv };
+}
+
+/**
+ * Seed artifact-store caches into a cold project dir so the resident engine's
+ * first parse is incremental (partial-parse manifest) and package-aware
+ * (dbt_packages/ present, so `dbt parse` resolves package macros without a
+ * `dbt deps` install). No-op when the dir already has fresher on-disk state.
+ */
+export async function seedDbtCaches(
+  projectDir: string,
+  caches: { partialParse?: Buffer; packagesArchive?: Buffer },
+): Promise<void> {
+  if (caches.partialParse) {
+    const pp = join(projectDir, "target", "partial_parse.msgpack");
+    if (!(await pathExists(pp))) {
+      await mkdir(join(projectDir, "target"), { recursive: true });
+      await writeFile(pp, caches.partialParse).catch(() => {});
+    }
+  }
+  if (
+    caches.packagesArchive &&
+    !(await pathExists(join(projectDir, "dbt_packages")))
+  ) {
+    await extractArchive(caches.packagesArchive, projectDir).catch(() => {});
+  }
+}
+
+/**
  * Materialize project files + profiles.yml into a temp dir, run each
  * pre-validated command in order (stopping at the first failure), collect
  * target/ artifacts, and always clean up the temp dir.
  */
 export async function runDbt(request: DbtRunRequest): Promise<DbtRunResult> {
-  const projectDir = await mkdtemp(join(tmpdir(), "mako-dbt-"));
+  // A caller-provided warm dir is reused across runs (caller owns its
+  // lifecycle); otherwise use a throwaway temp dir we clean up on exit.
+  const ownsDir = !request.workingDir;
+  const projectDir =
+    request.workingDir ?? (await mkdtemp(join(tmpdir(), "mako-dbt-")));
   const commandResults: DbtCommandResult[] = [];
   const artifacts: DbtRunResult["artifacts"] = {};
 
   try {
-    for (const file of request.files) {
-      const safePath = ensureSafeRelativePath(file.path);
-      const absolute = join(projectDir, ...safePath.split("/"));
-      await mkdir(dirname(absolute), { recursive: true });
-      await writeFile(absolute, file.content, "utf8");
-    }
-    await writeFile(
-      join(projectDir, "profiles.yml"),
-      request.profile.profilesYml,
-      "utf8",
-    );
-
-    // Materialize credential files (e.g. BigQuery service-account JSON) with
-    // restrictive perms and export their absolute paths so the profile's
-    // env_var('...') keyfile references resolve. Contents are never logged.
-    const keyfileEnv: Record<string, string> = {};
-    for (const keyfile of request.profile.keyfiles ?? []) {
-      const safePath = ensureSafeRelativePath(keyfile.filename);
-      const absolute = join(projectDir, ...safePath.split("/"));
-      await mkdir(dirname(absolute), { recursive: true });
-      await writeFile(absolute, keyfile.content, {
-        encoding: "utf8",
-        mode: 0o600,
-      });
-      keyfileEnv[keyfile.envVar] = absolute;
-    }
+    // Sync project files + profiles.yml + keyfiles into the dir (write-if-
+    // changed + delete reconciliation for warm dirs). Shared with the resident
+    // engine's prepare so both see an identical on-disk tree.
+    const { keyfileEnv } = await materializeDbtProject(projectDir, {
+      files: request.files,
+      profile: request.profile,
+      reconcile: !ownsDir,
+    });
 
     // Seed prior artifacts into target/ for `dbt retry` (run_results.json is
     // what dbt reads to resume at the failed/skipped nodes).
@@ -287,6 +529,25 @@ export async function runDbt(request: DbtRunRequest): Promise<DbtRunResult> {
       await writeFile(join(stateDir, "manifest.json"), request.deferState);
     }
 
+    // Warm dbt's parser: seed the previous run's partial-parse manifest so
+    // only changed files are re-parsed. dbt self-invalidates on checksum /
+    // config mismatch, so a stale buffer just triggers a full parse. In a warm
+    // dir the on-disk manifest is fresher than any seed, so only seed when the
+    // dir is cold (no existing manifest).
+    if (request.seedPartialParse) {
+      const partialParsePath = join(
+        projectDir,
+        "target",
+        "partial_parse.msgpack",
+      );
+      if (!(await pathExists(partialParsePath))) {
+        await mkdir(join(projectDir, "target"), { recursive: true });
+        await writeFile(partialParsePath, request.seedPartialParse).catch(
+          () => {},
+        );
+      }
+    }
+
     const resolved = resolveDbtBin(
       request.profile.adapterPackage,
       request.dbtVersion,
@@ -302,41 +563,81 @@ export async function runDbt(request: DbtRunRequest): Promise<DbtRunResult> {
 
     // Install packages first when declared. The executor runs one runDbt per
     // command, each in its own temp dir, so deps must be (re)installed here
-    // before any command that depends on package macros can compile.
+    // before any command that depends on package macros can compile — unless
+    // we can restore a cached dbt_packages/ tree and skip the network install.
     if (projectHasPackages(request.files)) {
-      const depsLogLines: DbtLogLine[] = [];
-      const onDepsLog = (line: DbtLogLine) => {
-        depsLogLines.push(line);
-        request.onLog?.(line);
-      };
-      onDepsLog({ ts: new Date(), level: "info", line: "$ dbt deps" });
-      const depsExit = await execDbtCommand({
-        bin: resolved.bin,
-        args: [
-          ...resolved.prefixArgs,
-          "deps",
-          "--profiles-dir",
-          projectDir,
-          "--project-dir",
-          projectDir,
-          "--log-format",
-          "json",
-          "--no-use-colors",
-        ],
-        cwd: projectDir,
-        env: childEnv,
-        timeoutMs: request.commandTimeoutMs ?? 9 * 60 * 1000,
-        signal: request.signal,
-        onLog: onDepsLog,
-      });
-      if (depsExit !== 0) {
-        commandResults.push({
-          command: "deps",
-          exitCode: depsExit,
-          logLines: depsLogLines,
-          runResults: undefined,
+      const packagesMarker = join(projectDir, ".mako_packages_hash");
+
+      // Warm dir already has a matching dbt_packages/ tree → skip deps with no
+      // network call and no extract.
+      let warmFresh = false;
+      if (!ownsDir && request.packagesHash) {
+        const markerHash = await readFile(packagesMarker, "utf8")
+          .then(value => value.trim())
+          .catch(() => undefined);
+        warmFresh =
+          markerHash === request.packagesHash &&
+          (await pathExists(join(projectDir, "dbt_packages")));
+      }
+
+      let packagesSeeded = false;
+      if (!warmFresh && request.seedPackagesArchive) {
+        try {
+          await extractArchive(request.seedPackagesArchive, projectDir);
+          packagesSeeded = true;
+        } catch (error) {
+          logger.warn("Failed to seed dbt_packages cache; running dbt deps", {
+            error: String(error),
+          });
+        }
+      }
+
+      const skipDeps =
+        warmFresh || (request.skipDeps === true && packagesSeeded);
+      if (!skipDeps) {
+        const depsLogLines: DbtLogLine[] = [];
+        const onDepsLog = (line: DbtLogLine) => {
+          depsLogLines.push(line);
+          request.onLog?.(line);
+        };
+        onDepsLog({ ts: new Date(), level: "info", line: "$ dbt deps" });
+        const depsExit = await execDbtCommand({
+          bin: resolved.bin,
+          args: [
+            ...resolved.prefixArgs,
+            "deps",
+            "--profiles-dir",
+            projectDir,
+            "--project-dir",
+            projectDir,
+            "--log-format",
+            "json",
+            "--no-use-colors",
+          ],
+          cwd: projectDir,
+          env: childEnv,
+          timeoutMs: request.commandTimeoutMs ?? 9 * 60 * 1000,
+          signal: request.signal,
+          onLog: onDepsLog,
         });
-        return { success: false, commandResults, artifacts };
+        if (depsExit !== 0) {
+          commandResults.push({
+            command: "deps",
+            exitCode: depsExit,
+            logLines: depsLogLines,
+            runResults: undefined,
+          });
+          return { success: false, commandResults, artifacts };
+        }
+        // Freshly installed — archive so the next run can skip the install.
+        artifacts.packagesArchive = await archiveEntries(projectDir, [
+          "dbt_packages",
+          "package-lock.yml",
+        ]);
+        // Warm dir: record the hash so subsequent runs skip deps entirely.
+        if (!ownsDir && request.packagesHash) {
+          await writeFile(packagesMarker, request.packagesHash).catch(() => {});
+        }
       }
     }
 
@@ -426,10 +727,17 @@ export async function runDbt(request: DbtRunRequest): Promise<DbtRunResult> {
     artifacts.runResults = await readArtifact(projectDir, "run_results.json");
     artifacts.catalog = await readArtifact(projectDir, "catalog.json");
     artifacts.sources = await readArtifact(projectDir, "sources.json");
+    artifacts.partialParse = await readArtifact(
+      projectDir,
+      "partial_parse.msgpack",
+    );
 
     return { success, commandResults, artifacts };
   } finally {
-    await rm(projectDir, { recursive: true, force: true }).catch(() => {});
+    // Only delete throwaway dirs. Warm dirs are owned by the caller and reused.
+    if (ownsDir) {
+      await rm(projectDir, { recursive: true, force: true }).catch(() => {});
+    }
   }
 }
 

--- a/api/src/dbt/runner.service.ts
+++ b/api/src/dbt/runner.service.ts
@@ -559,6 +559,16 @@ export async function runDbt(request: DbtRunRequest): Promise<DbtRunResult> {
       ...keyfileEnv,
       DBT_SEND_ANONYMOUS_USAGE_STATS: "false",
       HOME: projectDir,
+      // HOME points at the (warm or throwaway) project dir to isolate dbt's
+      // profile and config, but that also relocates uv's cache for the `uvx`
+      // dev path (resolveDbtBin) into that dir — forcing a full dbt-core +
+      // adapter re-download (~20s and ~1GB) on every parse/compile/show/build
+      // when the dir is throwaway. Pin uv's cache to a stable shared location
+      // so the first command warms it and the rest reuse it (~2s). Respect an
+      // operator-provided UV_CACHE_DIR if set. No effect in production, which
+      // runs a baked venv via DBT_VENV_BIN rather than uvx.
+      UV_CACHE_DIR:
+        process.env.UV_CACHE_DIR ?? join(tmpdir(), "mako-dbt-uv-cache"),
     };
 
     // Install packages first when declared. The executor runs one runDbt per

--- a/api/src/dbt/runner.service.ts
+++ b/api/src/dbt/runner.service.ts
@@ -261,7 +261,7 @@ async function extractArchive(
 /** Write only when content differs — avoids needless mtime bumps that would
  * defeat dbt's checksum-based partial parsing in a warm dir. Returns true when
  * it actually wrote (i.e. content changed or the file was missing). */
-async function writeFileIfChanged(
+export async function writeFileIfChanged(
   absolute: string,
   content: string,
   mode?: number,

--- a/api/src/dbt/warm-dir-cache.test.ts
+++ b/api/src/dbt/warm-dir-cache.test.ts
@@ -1,0 +1,198 @@
+/* eslint-disable no-console, no-process-exit */
+/**
+ * Unit tests for the dbt warm-dir / cache pure logic that ships on-by-default.
+ *
+ * Run with: tsx src/dbt/warm-dir-cache.test.ts (no DB / network / dbt needed).
+ *
+ * Covers:
+ *   - selectWarmDirsToReap — eviction policy (count cap LRU, TTL, lock skip)
+ *   - computePackagesHash  — "are there real packages?" heuristic + stable hash
+ *   - writeFileIfChanged   — change detection (must NOT rewrite identical
+ *                            content, or it bumps mtime and defeats dbt's
+ *                            checksum-based partial parsing)
+ */
+import assert from "node:assert/strict";
+import { mkdtempSync } from "fs";
+import { readFile, rm, stat, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { selectWarmDirsToReap } from "./workspace-dir.service";
+import { computePackagesHash } from "./dbt-cache.service";
+import { writeFileIfChanged } from "./runner.service";
+
+const HOUR = 60 * 60 * 1000;
+const noLocks = () => false;
+
+function testReapNothingWhenHealthy() {
+  const now = 1_000_000;
+  const reaped = selectWarmDirsToReap(
+    [
+      { dir: "a", mtimeMs: now - 1000 },
+      { dir: "b", mtimeMs: now - 2000 },
+    ],
+    { now, maxDirs: 40, ttlMs: 24 * HOUR, isLocked: noLocks },
+  );
+  assert.deepEqual(reaped, [], "under cap + within TTL → reap nothing");
+}
+
+function testCountCapEvictsOldest() {
+  const now = 1_000_000;
+  const reaped = selectWarmDirsToReap(
+    [
+      { dir: "newest", mtimeMs: now - 100 },
+      { dir: "oldest", mtimeMs: now - 9000 },
+      { dir: "middle", mtimeMs: now - 5000 },
+    ],
+    { now, maxDirs: 2, ttlMs: 24 * HOUR, isLocked: noLocks },
+  );
+  assert.deepEqual(reaped, ["oldest"], "count cap evicts the LRU dir first");
+}
+
+function testTtlEvictsStale() {
+  const now = 1_000_000;
+  const reaped = selectWarmDirsToReap(
+    [
+      { dir: "fresh", mtimeMs: now - 1 * HOUR },
+      { dir: "stale", mtimeMs: now - 30 * HOUR },
+    ],
+    { now, maxDirs: 40, ttlMs: 24 * HOUR, isLocked: noLocks },
+  );
+  assert.deepEqual(
+    reaped,
+    ["stale"],
+    "TTL evicts the idle dir regardless of cap",
+  );
+}
+
+function testNeverReapsLockedDir() {
+  const now = 1_000_000;
+  const reaped = selectWarmDirsToReap(
+    [
+      { dir: "locked-stale", mtimeMs: now - 30 * HOUR },
+      { dir: "idle-stale", mtimeMs: now - 30 * HOUR },
+    ],
+    {
+      now,
+      maxDirs: 1,
+      ttlMs: 24 * HOUR,
+      isLocked: dir => dir === "locked-stale",
+    },
+  );
+  assert.deepEqual(
+    reaped,
+    ["idle-stale"],
+    "an in-flight (locked) dir is never reaped",
+  );
+  assert.ok(!reaped.includes("locked-stale"));
+}
+
+function testCountCapAndTtlDeduped() {
+  const now = 1_000_000;
+  const reaped = selectWarmDirsToReap(
+    [
+      { dir: "a", mtimeMs: now - 40 * HOUR }, // overflow AND stale
+      { dir: "b", mtimeMs: now - 2000 },
+      { dir: "c", mtimeMs: now - 1000 },
+    ],
+    { now, maxDirs: 2, ttlMs: 24 * HOUR, isLocked: noLocks },
+  );
+  assert.deepEqual(reaped, ["a"], "a dir hit by both rules appears once");
+}
+
+function testPackagesHash() {
+  assert.equal(
+    computePackagesHash([{ path: "dbt_project.yml", content: "x" }]),
+    null,
+    "no packages files → null",
+  );
+  assert.equal(
+    computePackagesHash([
+      { path: "packages.yml", content: "# packages:\n#  - package: foo" },
+    ]),
+    null,
+    "comments-only → null",
+  );
+  assert.equal(
+    computePackagesHash([{ path: "packages.yml", content: "packages:\n" }]),
+    null,
+    "empty declaration → null",
+  );
+
+  const files = [
+    {
+      path: "packages.yml",
+      content: "packages:\n  - package: dbt-labs/dbt_utils\n    version: 1.1.1",
+    },
+  ];
+  const h1 = computePackagesHash(files);
+  const h2 = computePackagesHash([...files]);
+  assert.match(h1 ?? "", /^[0-9a-f]{64}$/, "real packages → sha256 hex");
+  assert.equal(h1, h2, "hash is stable for identical declarations");
+
+  const other = computePackagesHash([
+    {
+      path: "packages.yml",
+      content: "packages:\n  - package: a/x\n    version: 2",
+    },
+  ]);
+  assert.notEqual(h1, other, "different declarations → different hash");
+}
+
+async function testWriteFileIfChanged(dir: string) {
+  const missing = join(dir, "new.txt");
+  assert.equal(
+    await writeFileIfChanged(missing, "hello"),
+    true,
+    "writes when missing",
+  );
+  assert.equal(await readFile(missing, "utf8"), "hello");
+
+  const stable = join(dir, "stable.txt");
+  assert.equal(await writeFileIfChanged(stable, "same"), true);
+  const before = (await stat(stable)).mtimeMs;
+  await new Promise(r => setTimeout(r, 20));
+  assert.equal(
+    await writeFileIfChanged(stable, "same"),
+    false,
+    "identical content → no write",
+  );
+  const after = (await stat(stable)).mtimeMs;
+  assert.equal(
+    after,
+    before,
+    "mtime untouched so dbt partial parse stays valid",
+  );
+
+  const changing = join(dir, "changing.txt");
+  await writeFile(changing, "v1");
+  assert.equal(
+    await writeFileIfChanged(changing, "v2"),
+    true,
+    "rewrites on change",
+  );
+  assert.equal(await readFile(changing, "utf8"), "v2");
+}
+
+async function main() {
+  testReapNothingWhenHealthy();
+  testCountCapEvictsOldest();
+  testTtlEvictsStale();
+  testNeverReapsLockedDir();
+  testCountCapAndTtlDeduped();
+  testPackagesHash();
+
+  const dir = mkdtempSync(join(tmpdir(), "mako-wfc-"));
+  try {
+    await testWriteFileIfChanged(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+
+  console.log(
+    "warm-dir-cache.test: OK — reaper policy, packages hash, change-detection",
+  );
+  process.exit(0);
+}
+
+void main();

--- a/api/src/dbt/warm-dir-cache.test.ts
+++ b/api/src/dbt/warm-dir-cache.test.ts
@@ -20,6 +20,7 @@ import { join } from "path";
 import { selectWarmDirsToReap } from "./workspace-dir.service";
 import { computePackagesHash } from "./dbt-cache.service";
 import { writeFileIfChanged } from "./runner.service";
+import { isStaleQueued } from "./dbt-run.service";
 
 const HOUR = 60 * 60 * 1000;
 const noLocks = () => false;
@@ -139,6 +140,60 @@ function testPackagesHash() {
   assert.notEqual(h1, other, "different declarations → different hash");
 }
 
+function testStaleQueuedWatchdog() {
+  const now = 1_000_000_000;
+  const timeout = 3 * 60 * 1000;
+  const oid = (s: string) => ({ toString: () => s }) as never;
+
+  assert.equal(
+    isStaleQueued(
+      { _id: oid("a"), status: "queued", createdAt: new Date(now - 10_000) },
+      now,
+      timeout,
+    ),
+    false,
+    "fresh queued run is not stale",
+  );
+  assert.equal(
+    isStaleQueued(
+      {
+        _id: oid("b"),
+        status: "queued",
+        createdAt: new Date(now - 4 * 60_000),
+      },
+      now,
+      timeout,
+    ),
+    true,
+    "queued past the deadline is stale",
+  );
+  assert.equal(
+    isStaleQueued(
+      {
+        _id: oid("c"),
+        status: "queued",
+        createdAt: new Date(now - 4 * 60_000),
+        startedAt: new Date(now - 3 * 60_000),
+      },
+      now,
+      timeout,
+    ),
+    false,
+    "a run that has startedAt was claimed → never stale",
+  );
+  for (const status of ["running", "success", "error", "cancelled"]) {
+    assert.equal(
+      isStaleQueued(
+        { _id: oid("d"), status, createdAt: new Date(now - 4 * 60_000) },
+        now,
+        timeout,
+      ),
+      false,
+      `non-queued status (${status}) is never stale`,
+    );
+  }
+}
+
 async function testWriteFileIfChanged(dir: string) {
   const missing = join(dir, "new.txt");
   assert.equal(
@@ -181,6 +236,7 @@ async function main() {
   testNeverReapsLockedDir();
   testCountCapAndTtlDeduped();
   testPackagesHash();
+  testStaleQueuedWatchdog();
 
   const dir = mkdtempSync(join(tmpdir(), "mako-wfc-"));
   try {
@@ -190,7 +246,7 @@ async function main() {
   }
 
   console.log(
-    "warm-dir-cache.test: OK — reaper policy, packages hash, change-detection",
+    "warm-dir-cache.test: OK — reaper policy, packages hash, change-detection, queue watchdog",
   );
   process.exit(0);
 }

--- a/api/src/dbt/workspace-dir.service.ts
+++ b/api/src/dbt/workspace-dir.service.ts
@@ -119,6 +119,33 @@ async function listWarmLeafDirs(): Promise<
 }
 
 /**
+ * Pure eviction policy: given the warm leaves + their mtimes, decide which to
+ * reap. Idle (unlocked) dirs only; evict by count cap (LRU, oldest first) and
+ * TTL. Extracted from the sweep so it can be unit-tested without touching fs.
+ */
+export function selectWarmDirsToReap(
+  leaves: Array<{ dir: string; mtimeMs: number }>,
+  opts: {
+    now: number;
+    maxDirs: number;
+    ttlMs: number;
+    isLocked: (dir: string) => boolean;
+  },
+): string[] {
+  const idle = leaves
+    .filter(l => !opts.isLocked(l.dir))
+    .sort((a, b) => a.mtimeMs - b.mtimeMs); // oldest first
+
+  const toRemove = new Set<string>();
+  const overflow = Math.max(0, idle.length - opts.maxDirs);
+  idle.slice(0, overflow).forEach(l => toRemove.add(l.dir)); // count cap
+  for (const l of idle) {
+    if (opts.now - l.mtimeMs > opts.ttlMs) toRemove.add(l.dir); // ttl
+  }
+  return [...toRemove];
+}
+
+/**
  * Best-effort, throttled reaping of idle warm dirs so tmpfs can't grow
  * unbounded on a long-lived instance. Evicts by TTL and a count cap (LRU).
  * Never touches a dir that currently holds a lock (an in-flight command), so
@@ -130,22 +157,32 @@ async function maybeSweepWarmDirs(): Promise<void> {
   lastSweepAt = now;
 
   try {
-    const idle = (await listWarmLeafDirs())
-      .filter(l => !locks.has(l.dir))
-      .sort((a, b) => a.mtimeMs - b.mtimeMs); // oldest first
-
-    const toRemove = new Set<string>();
-    const overflow = Math.max(0, idle.length - MAX_WARM_DIRS);
-    idle.slice(0, overflow).forEach(l => toRemove.add(l.dir)); // count cap
-    for (const l of idle) {
-      if (now - l.mtimeMs > WARM_DIR_TTL_MS) toRemove.add(l.dir); // ttl
-    }
+    const toRemove = selectWarmDirsToReap(await listWarmLeafDirs(), {
+      now,
+      maxDirs: MAX_WARM_DIRS,
+      ttlMs: WARM_DIR_TTL_MS,
+      isLocked: dir => locks.has(dir),
+    });
 
     let removed = 0;
     for (const dir of toRemove) {
-      if (locks.has(dir)) continue; // re-check immediately before removal
-      await rm(dir, { recursive: true, force: true });
-      removed += 1;
+      // Claim the lock SYNCHRONOUSLY before deleting: the has()-check and the
+      // set() below run in a single tick with no await between them, so no
+      // withProjectDir can interleave and start using the dir mid-rm. Any
+      // acquirer that arrives after chains on our gate and waits for the rm.
+      if (locks.has(dir)) continue;
+      let release: () => void = () => {};
+      const gate = new Promise<void>(resolve => {
+        release = resolve;
+      });
+      locks.set(dir, gate);
+      try {
+        await rm(dir, { recursive: true, force: true });
+        removed += 1;
+      } finally {
+        release();
+        if (locks.get(dir) === gate) locks.delete(dir);
+      }
     }
     if (removed > 0) {
       logger.debug("Reaped idle dbt warm dirs", { removed });

--- a/api/src/dbt/workspace-dir.service.ts
+++ b/api/src/dbt/workspace-dir.service.ts
@@ -24,12 +24,29 @@
  * use (optionally seeded from the artifact-store cache).
  */
 
-import { mkdir } from "fs/promises";
+import { mkdir, readdir, rm, stat, utimes } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
+import { loggers } from "../logging";
+
+const logger = loggers.app();
 
 const WARM_ROOT =
   process.env.DBT_WARM_DIR_ROOT ?? join(tmpdir(), "mako-dbt-warm");
+
+/**
+ * Bound how much warm state accumulates per instance. Warm dirs live in /tmp
+ * (tmpfs on Cloud Run, so RAM-backed), and nothing else deletes them, so a
+ * long-lived instance would otherwise grow a dir per project it ever served.
+ */
+const MAX_WARM_DIRS = Number(process.env.DBT_WARM_DIR_MAX ?? "40");
+/** Idle warm dirs untouched for longer than this are reaped (default 24h). */
+const WARM_DIR_TTL_MS = Number(
+  process.env.DBT_WARM_DIR_TTL_MS ?? String(24 * 60 * 60 * 1000),
+);
+/** Minimum gap between opportunistic sweeps within one process. */
+const SWEEP_INTERVAL_MS = 10 * 60 * 1000;
+let lastSweepAt = 0;
 
 /** Escape hatch: set DBT_DISABLE_WARM_DIR=true to force throwaway temp dirs. */
 export function warmDirsEnabled(): boolean {
@@ -61,6 +78,83 @@ function dirFor(scope: ProjectDirScope): string {
 // Per-dir promise chain: each acquirer waits on the previous holder's release.
 const locks = new Map<string, Promise<void>>();
 
+/** Enumerate warm leaf dirs (WARM_ROOT/<ws>/<project>/<env__role>) + mtime. */
+async function listWarmLeafDirs(): Promise<
+  Array<{ dir: string; mtimeMs: number }>
+> {
+  const leaves: Array<{ dir: string; mtimeMs: number }> = [];
+  let workspaces: string[];
+  try {
+    workspaces = await readdir(WARM_ROOT);
+  } catch {
+    return leaves; // root not created yet
+  }
+  for (const ws of workspaces) {
+    let projects: string[];
+    try {
+      projects = await readdir(join(WARM_ROOT, ws));
+    } catch {
+      continue;
+    }
+    for (const proj of projects) {
+      const projDir = join(WARM_ROOT, ws, proj);
+      let envs: string[];
+      try {
+        envs = await readdir(projDir);
+      } catch {
+        continue;
+      }
+      for (const env of envs) {
+        const dir = join(projDir, env);
+        try {
+          const s = await stat(dir);
+          if (s.isDirectory()) leaves.push({ dir, mtimeMs: s.mtimeMs });
+        } catch {
+          // raced removal — ignore
+        }
+      }
+    }
+  }
+  return leaves;
+}
+
+/**
+ * Best-effort, throttled reaping of idle warm dirs so tmpfs can't grow
+ * unbounded on a long-lived instance. Evicts by TTL and a count cap (LRU).
+ * Never touches a dir that currently holds a lock (an in-flight command), so
+ * it can't corrupt a live run; idle dirs only lose a re-warmable cache.
+ */
+async function maybeSweepWarmDirs(): Promise<void> {
+  const now = Date.now();
+  if (now - lastSweepAt < SWEEP_INTERVAL_MS) return;
+  lastSweepAt = now;
+
+  try {
+    const idle = (await listWarmLeafDirs())
+      .filter(l => !locks.has(l.dir))
+      .sort((a, b) => a.mtimeMs - b.mtimeMs); // oldest first
+
+    const toRemove = new Set<string>();
+    const overflow = Math.max(0, idle.length - MAX_WARM_DIRS);
+    idle.slice(0, overflow).forEach(l => toRemove.add(l.dir)); // count cap
+    for (const l of idle) {
+      if (now - l.mtimeMs > WARM_DIR_TTL_MS) toRemove.add(l.dir); // ttl
+    }
+
+    let removed = 0;
+    for (const dir of toRemove) {
+      if (locks.has(dir)) continue; // re-check immediately before removal
+      await rm(dir, { recursive: true, force: true });
+      removed += 1;
+    }
+    if (removed > 0) {
+      logger.debug("Reaped idle dbt warm dirs", { removed });
+    }
+  } catch (error) {
+    logger.warn("dbt warm-dir sweep failed", { error: String(error) });
+  }
+}
+
 /**
  * Run `fn` with exclusive access to the project's warm directory. Serializes
  * concurrent callers for the same dir within this process.
@@ -82,6 +176,10 @@ export async function withProjectDir<T>(
   await previous;
   try {
     await mkdir(dir, { recursive: true });
+    // Touch mtime so the count-cap LRU reflects "last acquired", not just
+    // last dbt write, then opportunistically reap other idle dirs.
+    await utimes(dir, new Date(), new Date()).catch(() => {});
+    void maybeSweepWarmDirs();
     return await fn(dir);
   } finally {
     release();

--- a/api/src/dbt/workspace-dir.service.ts
+++ b/api/src/dbt/workspace-dir.service.ts
@@ -1,0 +1,91 @@
+/**
+ * Warm dbt working directories.
+ *
+ * dbt-core is a filesystem tool, so every command must run against a real
+ * project directory. Instead of materializing a throwaway temp dir per command
+ * (cold parse + re-materialize every time), we keep a STABLE directory per
+ * (workspace, project, environment, role) and reuse it across runs. That keeps
+ * `target/partial_parse.msgpack` and `dbt_packages/` warm on the instance, so
+ * dbt re-parses only changed files and skips `dbt deps` — the same trick the
+ * dbt Cloud "develop" session uses, adapted to our single-container deploy.
+ *
+ * Roles isolate workloads so a long deploy build never blocks an interactive
+ * compile on the same project: "adhoc" (parse/compile/show from the IDE +
+ * agent) and "run" (the Inngest executor) get separate warm dirs.
+ *
+ * Access to a given dir is serialized by an in-process async mutex. Within one
+ * process (local dev runs the executor in the API process) this prevents two
+ * commands from corrupting the same dir. In production the executor and API
+ * are separate containers with separate disks, and the executor is already
+ * concurrency=1 per project, so the mutex is sufficient.
+ *
+ * Cloud Run instances are ephemeral (their /tmp is cleared on recycle), so
+ * warm dirs self-bound across deploys; a cold instance simply warms on first
+ * use (optionally seeded from the artifact-store cache).
+ */
+
+import { mkdir } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const WARM_ROOT =
+  process.env.DBT_WARM_DIR_ROOT ?? join(tmpdir(), "mako-dbt-warm");
+
+/** Escape hatch: set DBT_DISABLE_WARM_DIR=true to force throwaway temp dirs. */
+export function warmDirsEnabled(): boolean {
+  return process.env.DBT_DISABLE_WARM_DIR !== "true";
+}
+
+export type DbtDirRole = "adhoc" | "run";
+
+export interface ProjectDirScope {
+  workspaceId: string;
+  projectId: string;
+  environment: string;
+  role: DbtDirRole;
+}
+
+function sanitize(value: string): string {
+  return value.replace(/[^\w.-]/g, "_");
+}
+
+function dirFor(scope: ProjectDirScope): string {
+  return join(
+    WARM_ROOT,
+    sanitize(scope.workspaceId),
+    sanitize(scope.projectId),
+    `${sanitize(scope.environment)}__${scope.role}`,
+  );
+}
+
+// Per-dir promise chain: each acquirer waits on the previous holder's release.
+const locks = new Map<string, Promise<void>>();
+
+/**
+ * Run `fn` with exclusive access to the project's warm directory. Serializes
+ * concurrent callers for the same dir within this process.
+ */
+export async function withProjectDir<T>(
+  scope: ProjectDirScope,
+  fn: (dir: string) => Promise<T>,
+): Promise<T> {
+  const dir = dirFor(scope);
+
+  const previous = locks.get(dir) ?? Promise.resolve();
+  let release: () => void = () => {};
+  const gate = new Promise<void>(resolve => {
+    release = resolve;
+  });
+  const chained = previous.then(() => gate);
+  locks.set(dir, chained);
+
+  await previous;
+  try {
+    await mkdir(dir, { recursive: true });
+    return await fn(dir);
+  } finally {
+    release();
+    // Drop the entry if no one chained after us, to bound the map.
+    if (locks.get(dir) === chained) locks.delete(dir);
+  }
+}

--- a/api/src/dbt/workspace-dir.service.ts
+++ b/api/src/dbt/workspace-dir.service.ts
@@ -36,10 +36,14 @@ const WARM_ROOT =
 
 /**
  * Bound how much warm state accumulates per instance. Warm dirs live in /tmp
- * (tmpfs on Cloud Run, so RAM-backed), and nothing else deletes them, so a
- * long-lived instance would otherwise grow a dir per project it ever served.
+ * (tmpfs on Cloud Run, so RAM-backed), and each can hold 100s of MB
+ * (`dbt_packages/` + `target/`), so the cap is intentionally conservative to
+ * avoid OOMing a memory-limited instance. Evicted dirs re-seed cheaply from the
+ * cross-instance artifact cache, so a low cap costs little. Raise
+ * `DBT_WARM_DIR_MAX` on roomy instances; lower it (or 0/`DBT_DISABLE_WARM_DIR`)
+ * on tight ones.
  */
-const MAX_WARM_DIRS = Number(process.env.DBT_WARM_DIR_MAX ?? "40");
+const MAX_WARM_DIRS = Number(process.env.DBT_WARM_DIR_MAX ?? "12");
 /** Idle warm dirs untouched for longer than this are reaped (default 24h). */
 const WARM_DIR_TTL_MS = Number(
   process.env.DBT_WARM_DIR_TTL_MS ?? String(24 * 60 * 60 * 1000),

--- a/api/src/inngest/functions/dbt-run.ts
+++ b/api/src/inngest/functions/dbt-run.ts
@@ -24,6 +24,16 @@ import {
   type DbtLogLine,
 } from "../../dbt/runner.service";
 import { triggerDbtJobRun } from "../../dbt/dbt-run.service";
+import {
+  computePackagesHash,
+  loadDbtCaches,
+  saveParseCache,
+  savePackagesCache,
+} from "../../dbt/dbt-cache.service";
+import {
+  warmDirsEnabled,
+  withProjectDir,
+} from "../../dbt/workspace-dir.service";
 import { getNextScheduledConsoleRunAt } from "../../services/scheduled-query-schedule.service";
 import { getDashboardArtifactStore } from "../../services/dashboard-artifact-store.service";
 
@@ -212,19 +222,69 @@ export const dbtRunExecutorFunction = inngest.createFunction(
           runInfo.deferStateKey ?? undefined,
         );
 
+        // Warm caches: skip a full re-parse (and `dbt deps` when packages are
+        // unchanged) by seeding the previous command/run's state. Best-effort.
+        const cacheScope = {
+          workspaceId: data.workspaceId,
+          projectId: data.projectId,
+          environment: runInfo.environment,
+        };
+        const packagesHash = computePackagesHash(snapshot.files);
+        const caches = await loadDbtCaches(cacheScope, packagesHash);
+
         try {
-          const result = await runDbt({
-            files: snapshot.files,
-            profile: snapshot.profile,
-            commands: [parsed],
-            dbtVersion: snapshot.project.dbtVersion,
-            // Cloud Run services deploy with --timeout=3600; leave buffer for
-            // snapshot loading + artifact upload within the step request.
-            commandTimeoutMs: 50 * 60 * 1000,
-            restoreTarget,
-            deferState,
-            onLog: logWriter.onLog,
-          });
+          // Deploy builds run in a warm dir (role=run), separate from the
+          // interactive (adhoc) dir so the two never block each other. The
+          // artifact caches above seed a cold instance; thereafter target/ and
+          // dbt_packages/ stay warm on disk across steps and runs.
+          const runOnce = (workingDir?: string) =>
+            runDbt({
+              files: snapshot.files,
+              profile: snapshot.profile,
+              commands: [parsed],
+              dbtVersion: snapshot.project.dbtVersion,
+              // Cloud Run services deploy with --timeout=3600; leave buffer for
+              // snapshot loading + artifact upload within the step request.
+              commandTimeoutMs: 50 * 60 * 1000,
+              restoreTarget,
+              deferState,
+              seedPartialParse: caches.partialParse,
+              seedPackagesArchive: caches.packages,
+              skipDeps: caches.packagesFresh,
+              packagesHash,
+              workingDir,
+              onLog: logWriter.onLog,
+            });
+
+          let result: Awaited<ReturnType<typeof runDbt>> | undefined;
+          if (warmDirsEnabled()) {
+            try {
+              result = await withProjectDir(
+                { ...cacheScope, role: "run" },
+                dir => runOnce(dir),
+              );
+            } catch (warmError) {
+              logger.warn(
+                "Warm dir run failed; falling back to throwaway dir",
+                {
+                  error: String(warmError),
+                },
+              );
+            }
+          }
+          if (!result) result = await runOnce(undefined);
+
+          // Persist refreshed caches for the next command/run.
+          if (result.artifacts.partialParse) {
+            await saveParseCache(cacheScope, result.artifacts.partialParse);
+          }
+          if (result.artifacts.packagesArchive && packagesHash) {
+            await savePackagesCache(
+              cacheScope,
+              result.artifacts.packagesArchive,
+              packagesHash,
+            );
+          }
 
           const commandResult = result.commandResults[0];
           const stepResults = [

--- a/api/src/inngest/functions/dbt-run.ts
+++ b/api/src/inngest/functions/dbt-run.ts
@@ -263,11 +263,25 @@ export const dbtRunExecutorFunction = inngest.createFunction(
                 { ...cacheScope, role: "run" },
                 dir => runOnce(dir),
               );
+              // Positive signal so warm-dir engagement on the executor is
+              // observable; pairs with the fallback warn for a success rate.
+              logger.info("dbt warm dir used", {
+                event: "dbt_warm_dir",
+                outcome: "hit",
+                role: "run",
+                projectId: cacheScope.projectId,
+                environment: cacheScope.environment,
+              });
             } catch (warmError) {
               logger.warn(
                 "Warm dir run failed; falling back to throwaway dir",
                 {
+                  event: "dbt_warm_dir",
+                  outcome: "fallback",
+                  role: "run",
                   error: String(warmError),
+                  projectId: cacheScope.projectId,
+                  environment: cacheScope.environment,
                 },
               );
             }

--- a/api/src/inngest/functions/dbt-run.ts
+++ b/api/src/inngest/functions/dbt-run.ts
@@ -275,7 +275,13 @@ export const dbtRunExecutorFunction = inngest.createFunction(
           if (!result) result = await runOnce(undefined);
 
           // Persist refreshed caches for the next command/run.
-          if (result.artifacts.partialParse) {
+          // Skip the re-upload when nothing changed (the seeded cache is still
+          // current); the msgpack's embedded timestamps would otherwise make
+          // every hourly run re-push an effectively identical blob.
+          if (
+            result.artifacts.partialParse &&
+            (result.projectChanged || !caches.partialParse)
+          ) {
             await saveParseCache(cacheScope, result.artifacts.partialParse);
           }
           if (result.artifacts.packagesArchive && packagesHash) {

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -105,6 +105,76 @@ interface ScreenshotVisionAttachment {
 const MAX_SCREENSHOT_VISION_ATTACHMENTS = 6;
 const MAX_SCREENSHOT_VISION_BYTES = 2_000_000;
 
+// Keep the SSE connection warm during long silent gaps.
+//
+// While a server-side tool runs (e.g. a multi-minute `dbt build`) the AI SDK
+// emits the `tool-input-available` chunk and then sends nothing on the wire
+// until the tool resolves. Edge proxies (Cloudflare's origin idle timeout is
+// ~100s with no bytes) terminate a connection that goes quiet for too long —
+// which drops the live stream and strands the in-flight tool card on
+// "Running…" in the browser. Emitting an SSE comment line on a fixed interval
+// keeps bytes flowing without affecting the protocol: lines beginning with
+// `:` are comments per the SSE spec and are ignored by the AI SDK's stream
+// parser. We wrap only the live client-facing branch; the tee'd
+// resumable-stream copy is untouched, so keepalives are never buffered or
+// replayed on reconnect.
+const SSE_KEEPALIVE_INTERVAL_MS = 15_000;
+
+function withSseKeepAlive(
+  response: Response,
+  intervalMs = SSE_KEEPALIVE_INTERVAL_MS,
+): Response {
+  if (!response.body) return response;
+
+  const encoder = new TextEncoder();
+  const reader = response.body.getReader();
+  let keepAlive: ReturnType<typeof setInterval> | null = null;
+
+  const stopKeepAlive = () => {
+    if (keepAlive) {
+      clearInterval(keepAlive);
+      keepAlive = null;
+    }
+  };
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      keepAlive = setInterval(() => {
+        try {
+          controller.enqueue(encoder.encode(": keep-alive\n\n"));
+        } catch {
+          // Controller already closed/errored — stop pinging.
+          stopKeepAlive();
+        }
+      }, intervalMs);
+    },
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          stopKeepAlive();
+          controller.close();
+          return;
+        }
+        controller.enqueue(value);
+      } catch (error) {
+        stopKeepAlive();
+        controller.error(error);
+      }
+    },
+    cancel(reason) {
+      stopKeepAlive();
+      void reader.cancel(reason);
+    },
+  });
+
+  return new Response(stream, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
 function estimateDataUrlBytes(dataUrl: string): number {
   const commaIndex = dataUrl.indexOf(",");
   if (commaIndex === -1) return dataUrl.length;
@@ -989,7 +1059,7 @@ agentRoutes.openapi(
 
           // Return native AI SDK UI message stream response (for useChat compatibility)
           // Using AI SDK best practice: save once at the end with all messages
-          return result.toUIMessageStreamResponse({
+          const streamResponse = result.toUIMessageStreamResponse({
             originalMessages: segmentUiMessages,
             generateMessageId: () => new ObjectId().toString(),
             // Forward reasoning tokens from models that support extended thinking
@@ -1349,6 +1419,8 @@ agentRoutes.openapi(
               });
             },
           });
+
+          return withSseKeepAlive(streamResponse);
         };
 
         /**

--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -34,6 +34,8 @@ import { buildStarterScaffold } from "../dbt/scaffold";
 import { runAdhocDbtCommand } from "../dbt/dbt-project.service";
 import {
   applyJobScheduleChange,
+  reconcileStaleQueuedRun,
+  reconcileStaleQueuedRuns,
   requestDbtRunCancel,
   triggerDbtJobRun,
   triggerDbtRunRetry,
@@ -726,7 +728,10 @@ dbtRoutes.get("/projects/:projectId/runs", async (c: AuthenticatedContext) => {
       .sort({ createdAt: -1 })
       .limit(limit)
       .lean();
-    return c.json({ success: true, runs });
+    // Finalize any run stuck in "queued" past the worker-pickup deadline so the
+    // history never shows a perpetually-queued run.
+    const reconciled = await reconcileStaleQueuedRuns(runs);
+    return c.json({ success: true, runs: reconciled });
   } catch (error) {
     return serverError(c, error, "Failed to list dbt runs");
   }
@@ -744,13 +749,16 @@ dbtRoutes.get(
       if (!Types.ObjectId.isValid(runId)) {
         return badRequest(c, "Invalid run id");
       }
-      const run = await DbtRun.findOne({
+      const found = await DbtRun.findOne({
         _id: new Types.ObjectId(runId),
         projectId: project._id,
       }).lean();
-      if (!run) {
+      if (!found) {
         return c.json({ success: false, error: "Run not found" }, 404);
       }
+      // Finalize a stuck-queued run before returning so the poller (DbtRunCard /
+      // Runs view) sees a terminal error instead of spinning on "queued".
+      const run = await reconcileStaleQueuedRun(found);
       // logsSince = number of log lines the client already has (cursor).
       const logsSince = Number(c.req.query("logsSince")) || 0;
       const logs = run.logs ?? [];

--- a/api/src/scripts/seed-dbt-engine-demo.ts
+++ b/api/src/scripts/seed-dbt-engine-demo.ts
@@ -1,0 +1,246 @@
+/* eslint-disable no-console */
+/**
+ * Seed a local dbt project wired to a local Postgres so you can exercise the
+ * resident dbt engine end-to-end through the running app (open the project,
+ * hit Compile / use the agent's dbt_compile_model — with DBT_ENGINE_ENABLED=true
+ * the compile is served by the warm in-memory manifest).
+ *
+ * Companion Postgres (throwaway):
+ *   docker run -d --name mako-dbt-pg -e POSTGRES_PASSWORD=testpw \
+ *     -e POSTGRES_DB=mako -p 55432:5432 postgres:16
+ *
+ * Then:  pnpm --filter api run seed:dbt-demo
+ *
+ * Idempotent. REFUSES to run against a production-looking database.
+ * Credentials / target Postgres are overridable via env (see constants below).
+ */
+import path from "path";
+import fs from "fs";
+import dotenv from "dotenv";
+import mongoose from "mongoose";
+import bcrypt from "bcrypt";
+
+const envPath = path.resolve(__dirname, "../../../.env");
+if (fs.existsSync(envPath)) {
+  dotenv.config({ path: envPath });
+}
+
+const DEMO_EMAIL = (process.env.DBT_DEMO_EMAIL || "dbt-demo@mako.dev")
+  .trim()
+  .toLowerCase();
+const DEMO_PASSWORD = process.env.DBT_DEMO_PASSWORD || "DbtDemo!2024";
+const WORKSPACE_NAME = "dbt Engine Demo";
+const CONNECTION_NAME = "Local Postgres (dbt demo)";
+const PROJECT_NAME = "Engine Demo";
+
+// Target Postgres (the throwaway container above by default).
+const PG_HOST = process.env.DBT_DEMO_PG_HOST || "127.0.0.1";
+const PG_PORT = Number(process.env.DBT_DEMO_PG_PORT || "55432");
+const PG_USER = process.env.DBT_DEMO_PG_USER || "postgres";
+const PG_PASSWORD = process.env.DBT_DEMO_PG_PASSWORD || "testpw";
+const PG_DATABASE = process.env.DBT_DEMO_PG_DATABASE || "mako";
+
+const PROJECT_FILES: Array<{ path: string; content: string }> = [
+  {
+    path: "dbt_project.yml",
+    content: [
+      "name: engine_demo",
+      "profile: mako", // must match DBT_PROFILE_NAME rendered by adapter-map
+      'version: "1.0.0"',
+      "config-version: 2",
+      'model-paths: ["models"]',
+      "models:",
+      "  engine_demo:",
+      "    +materialized: view",
+      "",
+    ].join("\n"),
+  },
+  {
+    path: "models/example/my_first_model.sql",
+    content: [
+      "-- Edit me and hit Compile: the resident engine reuses the warm manifest.",
+      "select",
+      "  1 as id,",
+      "  'demo' as name,",
+      "  current_date as loaded_on",
+      "",
+    ].join("\n"),
+  },
+  {
+    path: "models/example/downstream.sql",
+    content: [
+      "select id, name from {{ ref('my_first_model') }} where id > 0",
+      "",
+    ].join("\n"),
+  },
+];
+
+function isProductionUri(uri: string): boolean {
+  if (process.env.PROD_DATABASE_URL && uri === process.env.PROD_DATABASE_URL) {
+    return true;
+  }
+  try {
+    const dbName = new URL(uri).pathname.replace(/^\//, "").split("?")[0];
+    if (dbName.toLowerCase() === "production") return true;
+  } catch {
+    /* non-standard URI */
+  }
+  return /\/production(\b|\?|$)/i.test(uri);
+}
+
+async function main(): Promise<void> {
+  const uri = process.env.DEV_DATABASE_URL || process.env.DATABASE_URL;
+  if (!uri) {
+    console.log("[seed-dbt-demo] No DATABASE_URL set; skipping.");
+    return;
+  }
+  if (isProductionUri(uri)) {
+    console.log("[seed-dbt-demo] Refusing to seed PRODUCTION. Skipping.");
+    return;
+  }
+
+  await mongoose.connect(uri, { serverSelectionTimeoutMS: 15000 });
+
+  const { User } = await import("../database/schema");
+  const { DatabaseConnection, DbtProject, DbtFile } = await import(
+    "../database/workspace-schema"
+  );
+  const { workspaceService } = await import("../services/workspace.service");
+
+  const rounds = parseInt(process.env.BCRYPT_ROUNDS || "10", 10);
+  const hashedPassword = await bcrypt.hash(DEMO_PASSWORD, rounds);
+
+  let user = await User.findOne({ email: DEMO_EMAIL });
+  if (!user) {
+    user = await User.create({
+      email: DEMO_EMAIL,
+      hashedPassword,
+      emailVerified: true,
+      onboarding: { completedAt: new Date(), role: "developer" },
+    });
+    console.log(`[seed-dbt-demo] Created user ${DEMO_EMAIL}`);
+  } else {
+    user.hashedPassword = hashedPassword;
+    user.emailVerified = true;
+    user.onboarding = {
+      ...(user.onboarding || {}),
+      completedAt: user.onboarding?.completedAt || new Date(),
+    };
+    await user.save();
+    console.log(`[seed-dbt-demo] Updated user ${DEMO_EMAIL}`);
+  }
+
+  const { workspace } = await workspaceService.getOrCreateDefaultWorkspace(
+    user._id,
+    WORKSPACE_NAME,
+  );
+  console.log(
+    `[seed-dbt-demo] Workspace: "${workspace.name}" (${workspace._id})`,
+  );
+
+  // Postgres connection (the `set: encryptObject` hook encrypts at rest).
+  let connection = await DatabaseConnection.findOne({
+    workspaceId: workspace._id,
+    name: CONNECTION_NAME,
+  });
+  const connectionFields = {
+    host: PG_HOST,
+    port: PG_PORT,
+    username: PG_USER,
+    password: PG_PASSWORD,
+    database: PG_DATABASE,
+  };
+  if (!connection) {
+    connection = await DatabaseConnection.create({
+      workspaceId: workspace._id,
+      name: CONNECTION_NAME,
+      type: "postgresql",
+      connection: connectionFields,
+      createdBy: user._id.toString(),
+    });
+    console.log("[seed-dbt-demo] Created Postgres connection.");
+  } else {
+    connection.set("connection", connectionFields);
+    await connection.save();
+    console.log("[seed-dbt-demo] Updated Postgres connection.");
+  }
+
+  // dbt project with a single "dev" environment pointing at the connection.
+  let project = await DbtProject.findOne({
+    workspaceId: workspace._id,
+    name: PROJECT_NAME,
+  });
+  const environments = [
+    {
+      name: "dev",
+      connectionId: connection._id,
+      targetSchema: "public",
+      threads: 4,
+    },
+  ];
+  if (!project) {
+    project = await DbtProject.create({
+      workspaceId: workspace._id,
+      name: PROJECT_NAME,
+      dbtVersion: "1.9",
+      environments,
+      defaultEnvironment: "dev",
+      createdBy: user._id.toString(),
+    });
+    console.log("[seed-dbt-demo] Created dbt project.");
+  } else {
+    project.environments = environments;
+    project.defaultEnvironment = "dev";
+    await project.save();
+    console.log("[seed-dbt-demo] Updated dbt project.");
+  }
+
+  for (const file of PROJECT_FILES) {
+    await DbtFile.findOneAndUpdate(
+      { projectId: project._id, path: file.path },
+      {
+        $set: {
+          workspaceId: workspace._id,
+          projectId: project._id,
+          path: file.path,
+          content: file.content,
+          updatedBy: user._id.toString(),
+          is_deleted: false,
+        },
+      },
+      { upsert: true, new: true, setDefaultsOnInsert: true },
+    );
+  }
+  console.log(`[seed-dbt-demo] Seeded ${PROJECT_FILES.length} dbt files.`);
+
+  console.log(
+    [
+      "",
+      "[seed-dbt-demo] Done. To exercise the resident engine:",
+      "  1) Ensure local Postgres is running (see header comment).",
+      "  2) Set DBT_ENGINE_ENABLED=true in your .env.",
+      "  3) pnpm dev",
+      `  4) Log in as ${DEMO_EMAIL} / ${DEMO_PASSWORD}`,
+      `  5) Open project "${PROJECT_NAME}" -> models/example/my_first_model.sql -> Compile.`,
+      "  6) Watch the API logs for: 'dbt engine compile hit'.",
+      "",
+    ].join("\n"),
+  );
+}
+
+main()
+  .catch(err => {
+    console.log(
+      "[seed-dbt-demo] Failed:",
+      err instanceof Error ? err.message : String(err),
+    );
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    try {
+      await mongoose.disconnect();
+    } catch {
+      /* ignore */
+    }
+    process.exit(process.exitCode ?? 0);
+  });

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -77,6 +77,7 @@ import { DbFlowFormRef } from "./DbFlowForm";
 import { safeStringify, toJsonSafe } from "../lib/json-safe";
 import { StreamingToolCard, type ToolPartState } from "./StreamingToolCard";
 import { ClarifyingQuestionsCard } from "./ClarifyingQuestionsCard";
+import { DbtRunCard } from "./DbtRunCard";
 import { PlanCard } from "./PlanCard";
 import {
   focusPlanTab,
@@ -912,6 +913,32 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
               }
               if (rawState !== "output-error") {
                 return null;
+              }
+            }
+
+            // Async dbt builds: once dbt_run_model has dispatched a run (output
+            // carries a runId), render a live run card that self-polls the run
+            // — decoupled from the agent turn, so it keeps updating after the
+            // turn ends and resumes on chat reload. While the dispatch is still
+            // in flight, or if it errored without a runId, fall through to the
+            // generic card.
+            if (
+              toolName === "dbt_run_model" &&
+              rawState === "output-available"
+            ) {
+              const dbtOutput = cardOutput as { runId?: string } | undefined;
+              const dbtInput = part.input as
+                | { projectId?: string; model?: string }
+                | undefined;
+              if (dbtOutput?.runId && dbtInput?.projectId) {
+                return (
+                  <DbtRunCard
+                    key={key}
+                    runId={dbtOutput.runId}
+                    projectId={dbtInput.projectId}
+                    label={dbtInput.model}
+                  />
+                );
               }
             }
             return (

--- a/app/src/components/DbtExplorer.tsx
+++ b/app/src/components/DbtExplorer.tsx
@@ -39,6 +39,7 @@ import {
   Settings as EditProjectIcon,
   MoreVertical as KebabIcon,
   Terminal as ConsoleIcon,
+  History as RunsIcon,
 } from "lucide-react";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useConsoleStore } from "../store/consoleStore";
@@ -54,6 +55,7 @@ import {
   focusDbtConsoleTab,
   focusDbtFileTab,
   focusDbtJobTab,
+  focusDbtRunsTab,
 } from "../dbt-runtime/shell";
 import ResourceTree, { type ResourceTreeNode } from "./ResourceTree";
 import ExplorerShell from "./ExplorerShell";
@@ -66,6 +68,7 @@ import ExplorerShell from "./ExplorerShell";
 const FILE_SEP = "::file::";
 const DIR_SEP = "::dir::";
 const JOB_SEP = "::job::";
+const RUNS_SEP = "::runs::";
 const JOBS_DIR = "__jobs";
 
 const DBT_COMPATIBLE_TYPES = new Set([
@@ -85,12 +88,16 @@ function dirname(path: string): string {
 }
 
 interface ParsedNode {
-  kind: "project" | "dir" | "file" | "job";
+  kind: "project" | "dir" | "file" | "job" | "runs";
   projectId: string;
   path: string;
 }
 
 function parseNodeId(id: string): ParsedNode {
+  if (id.includes(RUNS_SEP)) {
+    const [projectId] = id.split(RUNS_SEP);
+    return { kind: "runs", projectId, path: "" };
+  }
   if (id.includes(JOB_SEP)) {
     const [projectId, path] = id.split(JOB_SEP);
     return { kind: "job", projectId, path };
@@ -217,6 +224,9 @@ export function DbtExplorer() {
     if (activeTab?.kind === "dbt-job") {
       return `${activeTab.metadata?.projectId}${JOB_SEP}${activeTab.metadata?.jobId}`;
     }
+    if (activeTab?.kind === "dbt-runs") {
+      return `${activeTab.metadata?.projectId}${RUNS_SEP}`;
+    }
     return null;
   }, [activeTab]);
 
@@ -297,6 +307,12 @@ export function DbtExplorer() {
               isDirectory: false,
             })),
           });
+          children.push({
+            id: `${project._id}${RUNS_SEP}`,
+            name: "Runs",
+            path: "runs",
+            isDirectory: false,
+          });
         }
         return {
           id: project._id,
@@ -355,6 +371,8 @@ export function DbtExplorer() {
           j => j._id === parsed.path,
         );
         focusDbtJobTab(parsed.projectId, parsed.path, job?.name ?? node.name);
+      } else if (parsed.kind === "runs") {
+        focusDbtRunsTab(parsed.projectId, "Runs");
       }
     },
     [jobsByProject],
@@ -383,6 +401,9 @@ export function DbtExplorer() {
     }
     if (parsed.kind === "job") {
       return <JobIcon size={16} strokeWidth={1.5} />;
+    }
+    if (parsed.kind === "runs") {
+      return <RunsIcon size={16} strokeWidth={1.5} />;
     }
     return undefined;
   }, []);
@@ -514,7 +535,7 @@ export function DbtExplorer() {
   // Hover kebab: same actions as the right-click menu, but discoverable.
   const getRightAdornment = useCallback((node: ResourceTreeNode) => {
     const parsed = parseNodeId(node.id);
-    if (parsed.kind === "dir") return null;
+    if (parsed.kind === "dir" || parsed.kind === "runs") return null;
     return (
       <IconButton
         size="small"

--- a/app/src/components/DbtFileEditor.tsx
+++ b/app/src/components/DbtFileEditor.tsx
@@ -28,6 +28,7 @@ import {
   type DbtRunModelResult,
   type DbtRunLogLine,
 } from "../store/dbtStore";
+import EntityBreadcrumbs from "./EntityBreadcrumbs";
 
 function languageForDbtPath(path: string): string {
   if (path.endsWith(".sql")) return "sql";
@@ -81,9 +82,11 @@ function LogLines({ logs }: { logs: DbtRunLogLine[] }) {
 }
 
 export default function DbtFileEditor({
+  tabId,
   projectId,
   path,
 }: {
+  tabId: string;
   projectId: string;
   path: string;
 }) {
@@ -257,76 +260,62 @@ export default function DbtFileEditor({
 
   return (
     <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
-      {/* Breadcrumb + actions */}
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          gap: 1,
-          minHeight: 30,
-          px: 1.5,
-          py: 0.25,
-          backgroundColor: "background.paper",
-          color: "text.secondary",
-          fontSize: "0.75rem",
-          borderBottom: "1px solid",
-          borderColor: "divider",
-        }}
-      >
-        <Box sx={{ flex: 1, overflow: "hidden", textOverflow: "ellipsis" }}>
-          {project?.name ?? "dbt"} / {path}
-          {file.dirty ? " •" : ""}
-        </Box>
-        {modelName && (
-          <>
-            <Select
-              size="small"
-              value={environment}
-              onChange={e => setEnvironment(e.target.value)}
-              sx={{ fontSize: "0.75rem", minWidth: 90 }}
-            >
-              {(project?.environments ?? []).map(env => (
-                <MenuItem key={env.name} value={env.name}>
-                  {env.name}
-                </MenuItem>
-              ))}
-            </Select>
-            <Tooltip title="Resolve unselected refs against the last prod build (dbt --defer)">
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    size="small"
-                    checked={defer}
-                    onChange={e => setDefer(e.target.checked)}
-                  />
-                }
-                label={
-                  <Typography variant="caption" sx={{ whiteSpace: "nowrap" }}>
-                    Defer
-                  </Typography>
-                }
-                sx={{ mr: 0 }}
-              />
-            </Tooltip>
-            <Button
-              size="small"
-              variant="outlined"
-              disabled={busy !== null}
-              onClick={handleCompile}
-            >
-              {busy === "compile" ? "Compiling…" : "Compile"}
-            </Button>
-            <Button
-              size="small"
-              variant="contained"
-              disabled={busy !== null}
-              onClick={handleRunModel}
-            >
-              {busy === "run" ? "Running…" : "Run model"}
-            </Button>
-          </>
-        )}
-      </Box>
+      {/* Single bar: breadcrumb (workspace › Transforms › project › path) with
+          the model actions in the trailing slot. */}
+      <EntityBreadcrumbs
+        tabId={tabId}
+        trailing={
+          modelName ? (
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+              <Select
+                size="small"
+                value={environment}
+                onChange={e => setEnvironment(e.target.value)}
+                sx={{ fontSize: "0.75rem", minWidth: 90 }}
+              >
+                {(project?.environments ?? []).map(env => (
+                  <MenuItem key={env.name} value={env.name}>
+                    {env.name}
+                  </MenuItem>
+                ))}
+              </Select>
+              <Tooltip title="Resolve unselected refs against the last prod build (dbt --defer)">
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      size="small"
+                      checked={defer}
+                      onChange={e => setDefer(e.target.checked)}
+                    />
+                  }
+                  label={
+                    <Typography variant="caption" sx={{ whiteSpace: "nowrap" }}>
+                      Defer
+                    </Typography>
+                  }
+                  sx={{ mr: 0 }}
+                />
+              </Tooltip>
+              <Button
+                size="small"
+                variant="outlined"
+                disabled={busy !== null}
+                onClick={handleCompile}
+              >
+                {busy === "compile" ? "Compiling…" : "Compile"}
+              </Button>
+              <Button
+                size="small"
+                variant="contained"
+                disabled={busy !== null}
+                onClick={handleRunModel}
+              >
+                {busy === "run" ? "Running…" : "Run model"}
+              </Button>
+            </Box>
+          ) : undefined
+        }
+      />
 
       <Box sx={{ flex: 1, minHeight: 0 }}>
         {panelOpen ? (

--- a/app/src/components/DbtJobView.tsx
+++ b/app/src/components/DbtJobView.tsx
@@ -3,12 +3,11 @@
  * the job edit form (commands list + schedule, pattern: ScheduleConsoleModal).
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Box,
   Button,
   Chip,
-  CircularProgress,
   FormControl,
   FormControlLabel,
   IconButton,
@@ -29,18 +28,11 @@ import {
   RefreshCw as RefreshIcon,
   Plus as AddIcon,
   Trash2 as RemoveIcon,
-  FileCode as ModelIcon,
-  RotateCcw as RetryIcon,
 } from "lucide-react";
-import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { CronExpressionParser } from "cron-parser";
 import { useWorkspace } from "../contexts/workspace-context";
-import {
-  useDbtStore,
-  type DbtJobItem,
-  type DbtRunItem,
-} from "../store/dbtStore";
-import { focusDbtFileTab } from "../dbt-runtime/shell";
+import { useDbtStore, type DbtJobItem } from "../store/dbtStore";
+import DbtRunHistory from "./DbtRunHistory";
 
 type SchedulePreset = "hourly" | "daily" | "every6h" | "weekly" | "custom";
 
@@ -70,45 +62,6 @@ function presetFromCron(cron: string): SchedulePreset {
   return "custom";
 }
 
-function statusColor(status: DbtRunItem["status"]): string {
-  switch (status) {
-    case "running":
-      return "primary.main";
-    case "success":
-      return "success.main";
-    case "error":
-      return "error.main";
-    case "cancelled":
-      return "warning.main";
-    default:
-      return "text.secondary";
-  }
-}
-
-function formatDuration(ms?: number): string {
-  if (ms === undefined || ms === null) return "—";
-  if (ms < 1000) return `${ms}ms`;
-  const seconds = ms / 1000;
-  if (seconds < 60) return `${seconds.toFixed(1)}s`;
-  return `${Math.floor(seconds / 60)}m ${Math.round(seconds % 60)}s`;
-}
-
-function relativeTime(iso?: string): string {
-  if (!iso) return "—";
-  const diffMs = Date.now() - new Date(iso).getTime();
-  const minutes = Math.floor(diffMs / 60000);
-  if (minutes < 1) return "just now";
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  return `${Math.floor(hours / 24)}d ago`;
-}
-
-function absoluteTime(iso?: string): string {
-  if (!iso) return "";
-  return new Date(iso).toLocaleString();
-}
-
 export default function DbtJobView({
   projectId,
   jobId,
@@ -122,14 +75,11 @@ export default function DbtJobView({
   const project = useDbtStore(s => s.projects.find(p => p._id === projectId));
   const jobs = useDbtStore(s => s.jobsByProject[projectId]);
   const runs = useDbtStore(s => s.runsByProject[projectId]);
-  const runDetails = useDbtStore(s => s.runDetails);
   const fetchProjects = useDbtStore(s => s.fetchProjects);
   const fetchJobs = useDbtStore(s => s.fetchJobs);
   const fetchRuns = useDbtStore(s => s.fetchRuns);
-  const fetchRunDetails = useDbtStore(s => s.fetchRunDetails);
   const triggerJob = useDbtStore(s => s.triggerJob);
   const cancelRun = useDbtStore(s => s.cancelRun);
-  const retryRun = useDbtStore(s => s.retryRun);
   const saveJob = useDbtStore(s => s.saveJob);
 
   const job = useMemo(
@@ -144,7 +94,6 @@ export default function DbtJobView({
 
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
   const [editing, setEditing] = useState(false);
-  const logScrollRef = useRef<HTMLDivElement | null>(null);
 
   // Edit-form state
   const [formName, setFormName] = useState("");
@@ -189,44 +138,9 @@ export default function DbtJobView({
     }
   }, [selectedRunId, jobRuns]);
 
-  const selectedRun = selectedRunId ? runDetails[selectedRunId] : undefined;
-  const selectedRunListItem = jobRuns.find(run => run._id === selectedRunId);
-  const selectedStatus = selectedRun?.status ?? selectedRunListItem?.status;
   const runningRun = jobRuns.find(
     run => run.status === "running" || run.status === "queued",
   );
-
-  // Fetch details when selection changes; poll every 2s while running.
-  useEffect(() => {
-    if (!workspaceId || !selectedRunId) return;
-    let stopped = false;
-    let timer: ReturnType<typeof setTimeout> | null = null;
-
-    const poll = async () => {
-      const details = await fetchRunDetails(
-        workspaceId,
-        projectId,
-        selectedRunId,
-      );
-      if (stopped) return;
-      if (details?.status === "running" || details?.status === "queued") {
-        timer = setTimeout(() => void poll(), 2000);
-      }
-    };
-    void poll();
-
-    return () => {
-      stopped = true;
-      if (timer) clearTimeout(timer);
-    };
-  }, [workspaceId, projectId, selectedRunId, fetchRunDetails]);
-
-  // Auto-scroll logs while running.
-  useEffect(() => {
-    if (selectedStatus === "running" && logScrollRef.current) {
-      logScrollRef.current.scrollTop = logScrollRef.current.scrollHeight;
-    }
-  }, [selectedRun?.logs.length, selectedStatus]);
 
   const handleRunNow = useCallback(async () => {
     if (!workspaceId) return;
@@ -239,12 +153,6 @@ export default function DbtJobView({
     await cancelRun(workspaceId, projectId, runningRun._id);
     await fetchRuns(workspaceId, projectId, jobId);
   }, [workspaceId, projectId, jobId, runningRun, cancelRun, fetchRuns]);
-
-  const handleRetry = useCallback(async () => {
-    if (!workspaceId || !selectedRunId) return;
-    const runId = await retryRun(workspaceId, projectId, selectedRunId, jobId);
-    if (runId) setSelectedRunId(runId);
-  }, [workspaceId, projectId, jobId, selectedRunId, retryRun]);
 
   const handleRefresh = useCallback(() => {
     if (workspaceId) void fetchRuns(workspaceId, projectId, jobId);
@@ -685,370 +593,14 @@ export default function DbtJobView({
     <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
       {header}
       <Box sx={{ flex: 1, minHeight: 0 }}>
-        <PanelGroup direction="horizontal">
-          {/* Run history */}
-          <Panel defaultSize={25} minSize={15}>
-            <Box
-              sx={{
-                height: "100%",
-                overflow: "auto",
-                borderRight: "1px solid",
-                borderColor: "divider",
-              }}
-            >
-              {jobRuns.length === 0 ? (
-                <Box sx={{ p: 2 }}>
-                  <Typography variant="caption" color="text.secondary">
-                    No runs yet. Press Run now to start one.
-                  </Typography>
-                </Box>
-              ) : (
-                jobRuns.map(run => {
-                  const isSelected = run._id === selectedRunId;
-                  const isActive =
-                    run.status === "running" || run.status === "queued";
-                  const select = () => setSelectedRunId(run._id);
-                  return (
-                    <Box
-                      key={run._id}
-                      role="button"
-                      tabIndex={0}
-                      onClick={select}
-                      onKeyDown={e => {
-                        if (e.key === "Enter" || e.key === " ") {
-                          e.preventDefault();
-                          select();
-                        }
-                      }}
-                      title={absoluteTime(run.createdAt)}
-                      sx={{
-                        px: 1.5,
-                        py: 0.75,
-                        cursor: "pointer",
-                        borderBottom: "1px solid",
-                        borderColor: "divider",
-                        backgroundColor: isSelected
-                          ? "action.selected"
-                          : "transparent",
-                        "&:hover": { backgroundColor: "action.hover" },
-                        "&:focus-visible": {
-                          outline: "2px solid",
-                          outlineColor: "primary.main",
-                          outlineOffset: "-2px",
-                        },
-                      }}
-                    >
-                      <Box
-                        sx={{
-                          display: "flex",
-                          alignItems: "center",
-                          gap: 0.75,
-                        }}
-                      >
-                        <Box
-                          sx={{
-                            width: 8,
-                            height: 8,
-                            borderRadius: "50%",
-                            backgroundColor: statusColor(run.status),
-                            flexShrink: 0,
-                          }}
-                        />
-                        <Typography
-                          variant="caption"
-                          sx={{
-                            flex: 1,
-                            fontWeight: 600,
-                            color: statusColor(run.status),
-                            textTransform: "capitalize",
-                            display: "flex",
-                            alignItems: "center",
-                            gap: 0.5,
-                          }}
-                        >
-                          {run.status}
-                          {isActive && <CircularProgress size={9} />}
-                        </Typography>
-                        {run.durationMs !== undefined && (
-                          <Typography variant="caption" color="text.secondary">
-                            {formatDuration(run.durationMs)}
-                          </Typography>
-                        )}
-                      </Box>
-                      <Box
-                        sx={{
-                          display: "flex",
-                          alignItems: "center",
-                          gap: 0.5,
-                          mt: 0.25,
-                        }}
-                      >
-                        <Typography
-                          variant="caption"
-                          color="text.secondary"
-                          sx={{ flex: 1 }}
-                        >
-                          {relativeTime(run.createdAt)}
-                        </Typography>
-                        <Typography
-                          variant="caption"
-                          color="text.secondary"
-                          sx={{ fontSize: "0.65rem" }}
-                        >
-                          {run.trigger}
-                        </Typography>
-                      </Box>
-                    </Box>
-                  );
-                })
-              )}
-            </Box>
-          </Panel>
-          <PanelResizeHandle
-            style={{ width: 4, background: "var(--mui-palette-divider)" }}
-          />
-          {/* Run details */}
-          <Panel defaultSize={75} minSize={30}>
-            {!selectedRun && !selectedRunListItem ? (
-              <Box sx={{ p: 2 }}>
-                <Typography variant="caption" color="text.secondary">
-                  Select a run to see details.
-                </Typography>
-              </Box>
-            ) : (
-              <Box
-                sx={{
-                  height: "100%",
-                  display: "flex",
-                  flexDirection: "column",
-                }}
-              >
-                {/* Summary strip */}
-                <Box
-                  sx={{
-                    display: "flex",
-                    gap: 2,
-                    alignItems: "center",
-                    px: 1.5,
-                    py: 0.75,
-                    borderBottom: "1px solid",
-                    borderColor: "divider",
-                    flexWrap: "wrap",
-                  }}
-                >
-                  <Chip
-                    size="small"
-                    variant="outlined"
-                    icon={
-                      selectedStatus === "running" ||
-                      selectedStatus === "queued" ? (
-                        <CircularProgress size={10} />
-                      ) : undefined
-                    }
-                    label={selectedStatus ?? "queued"}
-                    sx={{
-                      height: 20,
-                      textTransform: "capitalize",
-                      fontWeight: 600,
-                      color: statusColor(
-                        (selectedStatus ?? "queued") as DbtRunItem["status"],
-                      ),
-                      borderColor: statusColor(
-                        (selectedStatus ?? "queued") as DbtRunItem["status"],
-                      ),
-                    }}
-                  />
-                  <Typography
-                    variant="caption"
-                    color="text.secondary"
-                    title={absoluteTime(
-                      (selectedRun ?? selectedRunListItem)?.createdAt,
-                    )}
-                  >
-                    {relativeTime(
-                      (selectedRun ?? selectedRunListItem)?.createdAt,
-                    )}
-                  </Typography>
-                  <Typography
-                    variant="caption"
-                    color="text.secondary"
-                    sx={{
-                      fontFamily: "monospace",
-                      maxWidth: 360,
-                      whiteSpace: "nowrap",
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
-                    }}
-                    title={(selectedRun ?? selectedRunListItem)?.commands
-                      .map(command => `dbt ${command}`)
-                      .join(" → ")}
-                  >
-                    {(selectedRun ?? selectedRunListItem)?.commands
-                      .map(command => `dbt ${command}`)
-                      .join(" → ")}
-                  </Typography>
-                  <Typography variant="caption" color="text.secondary">
-                    {formatDuration(
-                      (selectedRun ?? selectedRunListItem)?.durationMs,
-                    )}
-                  </Typography>
-                  <Typography variant="caption" color="text.secondary">
-                    {(selectedRun ?? selectedRunListItem)?.trigger} ·{" "}
-                    {(selectedRun ?? selectedRunListItem)?.triggeredBy}
-                  </Typography>
-                  {(selectedRun ?? selectedRunListItem)?.error && (
-                    <Typography variant="caption" color="error">
-                      {(selectedRun ?? selectedRunListItem)?.error}
-                    </Typography>
-                  )}
-                  {selectedStatus === "error" && (
-                    <Tooltip title="Re-run only the failed/skipped nodes">
-                      <Button
-                        size="small"
-                        variant="outlined"
-                        startIcon={<RetryIcon size={14} />}
-                        onClick={handleRetry}
-                        sx={{ ml: "auto" }}
-                      >
-                        Retry from failure
-                      </Button>
-                    </Tooltip>
-                  )}
-                </Box>
-
-                {/* Models table */}
-                {(selectedRun?.stepResults?.length ?? 0) > 0 && (
-                  <Box
-                    sx={{
-                      maxHeight: "40%",
-                      overflow: "auto",
-                      borderBottom: "1px solid",
-                      borderColor: "divider",
-                    }}
-                  >
-                    <Box
-                      component="table"
-                      sx={{
-                        width: "100%",
-                        fontSize: "0.75rem",
-                        borderCollapse: "collapse",
-                        "& td, & th": {
-                          borderBottom: "1px solid",
-                          borderColor: "divider",
-                          p: 0.5,
-                          textAlign: "left",
-                        },
-                      }}
-                    >
-                      <thead>
-                        <tr>
-                          <th>Node</th>
-                          <th>Type</th>
-                          <th>Status</th>
-                          <th>Time</th>
-                          <th>Rows</th>
-                          <th></th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {selectedRun?.stepResults?.map(step => (
-                          <Box
-                            component="tr"
-                            key={step.uniqueId}
-                            sx={{
-                              color:
-                                step.status === "error" ||
-                                step.status === "fail"
-                                  ? "error.main"
-                                  : step.status === "warn"
-                                    ? "warning.main"
-                                    : "inherit",
-                            }}
-                          >
-                            <td>{step.name}</td>
-                            <td>{step.resourceType}</td>
-                            <td>
-                              {step.status}
-                              {step.message &&
-                              (step.status === "error" ||
-                                step.status === "fail" ||
-                                step.status === "warn" ||
-                                step.resourceType === "source")
-                                ? ` — ${step.message}`
-                                : ""}
-                            </td>
-                            <td>{(step.executionTimeMs / 1000).toFixed(2)}s</td>
-                            <td>{step.rowsAffected ?? ""}</td>
-                            <td>
-                              {step.resourceType === "model" && (
-                                <Tooltip title="Open model">
-                                  <IconButton
-                                    size="small"
-                                    onClick={() =>
-                                      focusDbtFileTab(
-                                        projectId,
-                                        `models/${step.name}.sql`,
-                                      )
-                                    }
-                                  >
-                                    <ModelIcon size={12} />
-                                  </IconButton>
-                                </Tooltip>
-                              )}
-                            </td>
-                          </Box>
-                        ))}
-                      </tbody>
-                    </Box>
-                  </Box>
-                )}
-
-                {/* Logs */}
-                <Box
-                  ref={logScrollRef}
-                  sx={{
-                    flex: 1,
-                    minHeight: 0,
-                    overflow: "auto",
-                    fontFamily: "monospace",
-                    fontSize: "0.72rem",
-                    p: 1,
-                    whiteSpace: "pre-wrap",
-                  }}
-                >
-                  {(selectedRun?.logs ?? []).length === 0 ? (
-                    <Typography variant="caption" color="text.secondary">
-                      {selectedStatus === "queued" ? "Run queued…" : "No logs."}
-                    </Typography>
-                  ) : (
-                    selectedRun?.logs.map((log, index) => (
-                      <Box
-                        key={index}
-                        component="div"
-                        sx={{
-                          color:
-                            log.level === "error"
-                              ? "error.main"
-                              : log.level === "warn"
-                                ? "warning.main"
-                                : "text.primary",
-                        }}
-                      >
-                        <Box
-                          component="span"
-                          sx={{ color: "text.secondary", mr: 1 }}
-                        >
-                          {new Date(log.ts).toLocaleTimeString()}
-                        </Box>
-                        {log.line}
-                      </Box>
-                    ))
-                  )}
-                </Box>
-              </Box>
-            )}
-          </Panel>
-        </PanelGroup>
+        <DbtRunHistory
+          workspaceId={workspaceId}
+          projectId={projectId}
+          runs={jobRuns}
+          selectedRunId={selectedRunId}
+          onSelectRun={setSelectedRunId}
+          emptyHint="No runs yet. Press Run now to start one."
+        />
       </Box>
     </Box>
   );

--- a/app/src/components/DbtRunCard.tsx
+++ b/app/src/components/DbtRunCard.tsx
@@ -1,0 +1,341 @@
+/**
+ * DbtRunCard — live dbt run widget rendered inline in chat for the agent's
+ * `dbt_run_model` tool result.
+ *
+ * The build runs asynchronously in the runner (Inngest), so this card is
+ * fully decoupled from the agent turn / chat SSE: it self-polls
+ * `GET /runs/:runId` every 2s while the run is queued/running (same pattern as
+ * DbtJobView), keeps updating after the turn ends, and resumes on chat reload
+ * because the runId is persisted in the tool part. Cancel hits the existing
+ * `/runs/:runId/cancel` endpoint.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Box,
+  Chip,
+  CircularProgress,
+  IconButton,
+  Tooltip,
+} from "@mui/material";
+import {
+  Square as StopIcon,
+  ChevronRight as ChevronRightIcon,
+  ChevronDown as ChevronDownIcon,
+} from "lucide-react";
+import { useWorkspace } from "../contexts/workspace-context";
+import { useDbtStore, type DbtRunItem } from "../store/dbtStore";
+
+interface DbtRunCardProps {
+  runId: string;
+  projectId: string;
+  /** Selector/model label from the tool input (e.g. "stg_orders+"). */
+  label?: string;
+}
+
+const ACTIVE_POLL_INTERVAL_MS = 2_000;
+const MAX_VISIBLE_LOGS = 200;
+
+function statusColor(status: DbtRunItem["status"] | undefined): string {
+  switch (status) {
+    case "running":
+    case "queued":
+      return "primary.main";
+    case "success":
+      return "success.main";
+    case "error":
+      return "error.main";
+    case "cancelled":
+      return "text.secondary";
+    default:
+      return "text.secondary";
+  }
+}
+
+function formatDuration(ms: number | undefined): string {
+  if (ms === undefined) return "";
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = ms / 1000;
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  const minutes = Math.floor(seconds / 60);
+  const rest = Math.round(seconds % 60);
+  return `${minutes}m ${rest}s`;
+}
+
+export function DbtRunCard({ runId, projectId, label }: DbtRunCardProps) {
+  const { currentWorkspace } = useWorkspace();
+  const workspaceId = currentWorkspace?.id;
+
+  const run = useDbtStore(s => s.runDetails[runId]);
+  const fetchRunDetails = useDbtStore(s => s.fetchRunDetails);
+  const cancelRun = useDbtStore(s => s.cancelRun);
+
+  const [expanded, setExpanded] = useState(false);
+  const [cancelling, setCancelling] = useState(false);
+  const logScrollRef = useRef<HTMLDivElement | null>(null);
+
+  const status = run?.status;
+  const isActive = status === "running" || status === "queued";
+
+  // Self-poll while active — decoupled from the agent turn. Mirrors the
+  // run-detail poll in DbtJobView. Runs once for already-terminal runs
+  // (e.g. on chat reload) and then stops.
+  useEffect(() => {
+    if (!workspaceId) return;
+    let stopped = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const poll = async () => {
+      const details = await fetchRunDetails(workspaceId, projectId, runId);
+      if (stopped) return;
+      if (details?.status === "running" || details?.status === "queued") {
+        timer = setTimeout(() => void poll(), ACTIVE_POLL_INTERVAL_MS);
+      }
+    };
+    void poll();
+
+    return () => {
+      stopped = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [workspaceId, projectId, runId, fetchRunDetails]);
+
+  // Auto-scroll logs while expanded + running.
+  useEffect(() => {
+    if (expanded && isActive && logScrollRef.current) {
+      logScrollRef.current.scrollTop = logScrollRef.current.scrollHeight;
+    }
+  }, [run?.logs, expanded, isActive]);
+
+  const handleCancel = useCallback(
+    async (event: React.MouseEvent) => {
+      event.stopPropagation();
+      if (!workspaceId || cancelling) return;
+      setCancelling(true);
+      await cancelRun(workspaceId, projectId, runId);
+      await fetchRunDetails(workspaceId, projectId, runId);
+      setCancelling(false);
+    },
+    [workspaceId, projectId, runId, cancelling, cancelRun, fetchRunDetails],
+  );
+
+  const steps = run?.stepResults ?? [];
+  const logs = run?.logs ?? [];
+  const visibleLogs = logs.slice(-MAX_VISIBLE_LOGS);
+  const hasBody = steps.length > 0 || logs.length > 0;
+
+  const command = run?.commands?.[0];
+  const title = label
+    ? `Build ${label}`
+    : command
+      ? `dbt ${command}`
+      : "dbt build";
+
+  const statusLabel = status ?? "queued";
+
+  return (
+    <Box
+      sx={{
+        my: 0.75,
+        borderRadius: 1.5,
+        border: 1,
+        borderColor: isActive
+          ? "primary.main"
+          : status === "error"
+            ? "error.main"
+            : "divider",
+        overflow: "hidden",
+        transition: "border-color 0.3s",
+        backgroundColor: theme =>
+          theme.palette.mode === "dark"
+            ? "rgba(255,255,255,0.02)"
+            : "rgba(0,0,0,0.015)",
+      }}
+    >
+      {/* Header */}
+      <Box
+        onClick={() => hasBody && setExpanded(prev => !prev)}
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1,
+          px: 1.25,
+          py: 0.75,
+          cursor: hasBody ? "pointer" : "default",
+          "&:hover": hasBody ? { backgroundColor: "action.hover" } : undefined,
+        }}
+      >
+        {hasBody ? (
+          expanded ? (
+            <ChevronDownIcon size={14} />
+          ) : (
+            <ChevronRightIcon size={14} />
+          )
+        ) : (
+          <Box sx={{ width: 14 }} />
+        )}
+        <Box
+          component="span"
+          sx={{
+            fontFamily: "monospace",
+            fontSize: "0.8rem",
+            fontWeight: 600,
+            flex: 1,
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}
+          title={title}
+        >
+          {title}
+        </Box>
+        {run?.durationMs !== undefined && (
+          <Box
+            component="span"
+            sx={{ fontSize: "0.72rem", color: "text.secondary" }}
+          >
+            {formatDuration(run.durationMs)}
+          </Box>
+        )}
+        <Chip
+          size="small"
+          variant="outlined"
+          icon={isActive ? <CircularProgress size={10} /> : undefined}
+          label={statusLabel}
+          sx={{
+            height: 20,
+            textTransform: "capitalize",
+            fontWeight: 600,
+            color: statusColor(status),
+            borderColor: statusColor(status),
+          }}
+        />
+        {isActive && (
+          <Tooltip title="Cancel build">
+            <span>
+              <IconButton
+                size="small"
+                onClick={handleCancel}
+                disabled={cancelling}
+              >
+                <StopIcon size={13} />
+              </IconButton>
+            </span>
+          </Tooltip>
+        )}
+      </Box>
+
+      {/* Error summary (always visible when failed) */}
+      {status === "error" && run?.error && (
+        <Box
+          sx={{
+            px: 1.25,
+            py: 0.5,
+            fontSize: "0.72rem",
+            color: "error.main",
+            borderTop: "1px solid",
+            borderColor: "divider",
+          }}
+        >
+          {run.error}
+        </Box>
+      )}
+
+      {/* Expandable body: step results + logs */}
+      {expanded && hasBody && (
+        <Box sx={{ borderTop: "1px solid", borderColor: "divider" }}>
+          {steps.length > 0 && (
+            <Box
+              component="table"
+              sx={{
+                width: "100%",
+                fontSize: "0.72rem",
+                borderCollapse: "collapse",
+                "& td, & th": {
+                  borderBottom: "1px solid",
+                  borderColor: "divider",
+                  p: 0.5,
+                  textAlign: "left",
+                },
+              }}
+            >
+              <thead>
+                <tr>
+                  <th>Node</th>
+                  <th>Type</th>
+                  <th>Status</th>
+                  <th>Time</th>
+                  <th>Rows</th>
+                </tr>
+              </thead>
+              <tbody>
+                {steps.map(step => (
+                  <Box
+                    component="tr"
+                    key={step.uniqueId}
+                    sx={{
+                      color:
+                        step.status === "error" || step.status === "fail"
+                          ? "error.main"
+                          : step.status === "warn"
+                            ? "warning.main"
+                            : "inherit",
+                    }}
+                  >
+                    <td>{step.name}</td>
+                    <td>{step.resourceType}</td>
+                    <td>
+                      {step.status}
+                      {step.message &&
+                      (step.status === "error" ||
+                        step.status === "fail" ||
+                        step.status === "warn")
+                        ? ` — ${step.message}`
+                        : ""}
+                    </td>
+                    <td>{(step.executionTimeMs / 1000).toFixed(2)}s</td>
+                    <td>{step.rowsAffected ?? ""}</td>
+                  </Box>
+                ))}
+              </tbody>
+            </Box>
+          )}
+
+          {logs.length > 0 && (
+            <Box
+              ref={logScrollRef}
+              sx={{
+                maxHeight: 220,
+                overflow: "auto",
+                fontFamily: "monospace",
+                fontSize: "0.7rem",
+                p: 1,
+                whiteSpace: "pre-wrap",
+              }}
+            >
+              {visibleLogs.map((log, index) => (
+                <Box
+                  key={index}
+                  component="div"
+                  sx={{
+                    color:
+                      log.level === "error"
+                        ? "error.main"
+                        : log.level === "warn"
+                          ? "warning.main"
+                          : "text.primary",
+                  }}
+                >
+                  <Box component="span" sx={{ color: "text.secondary", mr: 1 }}>
+                    {new Date(log.ts).toLocaleTimeString()}
+                  </Box>
+                  {log.line}
+                </Box>
+              ))}
+            </Box>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/app/src/components/DbtRunCard.tsx
+++ b/app/src/components/DbtRunCard.tsx
@@ -22,9 +22,11 @@ import {
   Square as StopIcon,
   ChevronRight as ChevronRightIcon,
   ChevronDown as ChevronDownIcon,
+  ExternalLink as OpenIcon,
 } from "lucide-react";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useDbtStore, type DbtRunItem } from "../store/dbtStore";
+import { focusDbtRunsTab } from "../dbt-runtime/shell";
 
 interface DbtRunCardProps {
   runId: string;
@@ -197,6 +199,17 @@ export function DbtRunCard({ runId, projectId, label }: DbtRunCardProps) {
             {formatDuration(run.durationMs)}
           </Box>
         )}
+        <Tooltip title="Open in Transforms → Runs">
+          <IconButton
+            size="small"
+            onClick={event => {
+              event.stopPropagation();
+              focusDbtRunsTab(projectId, "Runs", runId);
+            }}
+          >
+            <OpenIcon size={13} />
+          </IconButton>
+        </Tooltip>
         <Chip
           size="small"
           variant="outlined"

--- a/app/src/components/DbtRunCard.tsx
+++ b/app/src/components/DbtRunCard.tsx
@@ -36,6 +36,9 @@ interface DbtRunCardProps {
 }
 
 const ACTIVE_POLL_INTERVAL_MS = 2_000;
+// Give up polling only after sustained fetch failures (~20s of transient
+// errors) so a brief network blip doesn't permanently freeze a live card.
+const MAX_POLL_ERRORS = 10;
 const MAX_VISIBLE_LOGS = 200;
 
 function statusColor(status: DbtRunItem["status"] | undefined): string {
@@ -86,13 +89,24 @@ export function DbtRunCard({ runId, projectId, label }: DbtRunCardProps) {
     if (!workspaceId) return;
     let stopped = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
+    let consecutiveErrors = 0;
 
     const poll = async () => {
       const details = await fetchRunDetails(workspaceId, projectId, runId);
       if (stopped) return;
-      if (details?.status === "running" || details?.status === "queued") {
-        timer = setTimeout(() => void poll(), ACTIVE_POLL_INTERVAL_MS);
+      const status = details?.status;
+      // Stop only on a confirmed terminal status. A transient fetch failure
+      // returns null — keep polling (bounded) instead of freezing on "running".
+      if (
+        status === "success" ||
+        status === "error" ||
+        status === "cancelled"
+      ) {
+        return;
       }
+      if (!details && ++consecutiveErrors >= MAX_POLL_ERRORS) return;
+      if (details) consecutiveErrors = 0;
+      timer = setTimeout(() => void poll(), ACTIVE_POLL_INTERVAL_MS);
     };
     void poll();
 

--- a/app/src/components/DbtRunHistory.tsx
+++ b/app/src/components/DbtRunHistory.tsx
@@ -1,0 +1,552 @@
+/**
+ * DbtRunHistory — shared run-history list + live-log detail panel.
+ *
+ * Extracted from DbtJobView so the same UI backs both the job-scoped run
+ * history and the project-wide Runs view (DbtRunsView), which also surfaces
+ * ad-hoc agent/editor runs that have no jobId. Selection is controlled by the
+ * parent so callers can focus a specific run (e.g. from the chat card or after
+ * triggering a run). This component owns run-detail polling, log auto-scroll,
+ * and the retry action.
+ */
+
+import { useCallback, useEffect, useRef } from "react";
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  IconButton,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { FileCode as ModelIcon, RotateCcw as RetryIcon } from "lucide-react";
+import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
+import { useDbtStore, type DbtRunItem } from "../store/dbtStore";
+import { focusDbtFileTab } from "../dbt-runtime/shell";
+
+function statusColor(status: DbtRunItem["status"]): string {
+  switch (status) {
+    case "running":
+    case "queued":
+      return "primary.main";
+    case "success":
+      return "success.main";
+    case "error":
+      return "error.main";
+    case "cancelled":
+      return "warning.main";
+    default:
+      return "text.secondary";
+  }
+}
+
+function formatDuration(ms?: number): string {
+  if (ms === undefined || ms === null) return "—";
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = ms / 1000;
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  return `${Math.floor(seconds / 60)}m ${Math.round(seconds % 60)}s`;
+}
+
+function relativeTime(iso?: string): string {
+  if (!iso) return "—";
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const minutes = Math.floor(diffMs / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function absoluteTime(iso?: string): string {
+  if (!iso) return "";
+  return new Date(iso).toLocaleString();
+}
+
+function commandSummary(run: DbtRunItem): string {
+  return run.commands.map(command => `dbt ${command}`).join(" → ");
+}
+
+/** Short, human label for a run row in the project-wide view. */
+function runSourceLabel(
+  run: DbtRunItem,
+  jobNameById?: Record<string, string>,
+): string {
+  if (run.jobId && jobNameById?.[run.jobId]) return jobNameById[run.jobId];
+  return commandSummary(run);
+}
+
+export interface DbtRunHistoryProps {
+  workspaceId: string | undefined;
+  projectId: string;
+  runs: DbtRunItem[];
+  selectedRunId: string | null;
+  onSelectRun: (runId: string) => void;
+  /** Project-wide Runs view: surface the source (job name / command) per row. */
+  showSource?: boolean;
+  /** jobId → name, used to label job runs in the project-wide view. */
+  jobNameById?: Record<string, string>;
+  /** Message shown when there are no runs. */
+  emptyHint?: string;
+}
+
+export default function DbtRunHistory({
+  workspaceId,
+  projectId,
+  runs,
+  selectedRunId,
+  onSelectRun,
+  showSource = false,
+  jobNameById,
+  emptyHint = "No runs yet.",
+}: DbtRunHistoryProps) {
+  const runDetails = useDbtStore(s => s.runDetails);
+  const fetchRunDetails = useDbtStore(s => s.fetchRunDetails);
+  const retryRun = useDbtStore(s => s.retryRun);
+
+  const logScrollRef = useRef<HTMLDivElement | null>(null);
+
+  const selectedRun = selectedRunId ? runDetails[selectedRunId] : undefined;
+  const selectedRunListItem = runs.find(run => run._id === selectedRunId);
+  const selectedStatus = selectedRun?.status ?? selectedRunListItem?.status;
+
+  // Fetch details when selection changes; poll every 2s while running/queued.
+  useEffect(() => {
+    if (!workspaceId || !selectedRunId) return;
+    let stopped = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const poll = async () => {
+      const details = await fetchRunDetails(
+        workspaceId,
+        projectId,
+        selectedRunId,
+      );
+      if (stopped) return;
+      if (details?.status === "running" || details?.status === "queued") {
+        timer = setTimeout(() => void poll(), 2000);
+      }
+    };
+    void poll();
+
+    return () => {
+      stopped = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [workspaceId, projectId, selectedRunId, fetchRunDetails]);
+
+  // Auto-scroll logs while running.
+  useEffect(() => {
+    if (
+      (selectedStatus === "running" || selectedStatus === "queued") &&
+      logScrollRef.current
+    ) {
+      logScrollRef.current.scrollTop = logScrollRef.current.scrollHeight;
+    }
+  }, [selectedRun?.logs.length, selectedStatus]);
+
+  const handleRetry = useCallback(async () => {
+    if (!workspaceId || !selectedRunId) return;
+    const runId = await retryRun(
+      workspaceId,
+      projectId,
+      selectedRunId,
+      selectedRunListItem?.jobId,
+    );
+    if (runId) onSelectRun(runId);
+  }, [
+    workspaceId,
+    projectId,
+    selectedRunId,
+    selectedRunListItem?.jobId,
+    retryRun,
+    onSelectRun,
+  ]);
+
+  return (
+    <Box sx={{ height: "100%", minHeight: 0 }}>
+      <PanelGroup direction="horizontal">
+        {/* Run history list */}
+        <Panel defaultSize={showSource ? 32 : 25} minSize={15}>
+          <Box
+            sx={{
+              height: "100%",
+              overflow: "auto",
+              borderRight: "1px solid",
+              borderColor: "divider",
+            }}
+          >
+            {runs.length === 0 ? (
+              <Box sx={{ p: 2 }}>
+                <Typography variant="caption" color="text.secondary">
+                  {emptyHint}
+                </Typography>
+              </Box>
+            ) : (
+              runs.map(run => {
+                const isSelected = run._id === selectedRunId;
+                const isActive =
+                  run.status === "running" || run.status === "queued";
+                const select = () => onSelectRun(run._id);
+                return (
+                  <Box
+                    key={run._id}
+                    role="button"
+                    tabIndex={0}
+                    onClick={select}
+                    onKeyDown={e => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        select();
+                      }
+                    }}
+                    title={absoluteTime(run.createdAt)}
+                    sx={{
+                      px: 1.5,
+                      py: 0.75,
+                      cursor: "pointer",
+                      borderBottom: "1px solid",
+                      borderColor: "divider",
+                      backgroundColor: isSelected
+                        ? "action.selected"
+                        : "transparent",
+                      "&:hover": { backgroundColor: "action.hover" },
+                      "&:focus-visible": {
+                        outline: "2px solid",
+                        outlineColor: "primary.main",
+                        outlineOffset: "-2px",
+                      },
+                    }}
+                  >
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 0.75,
+                      }}
+                    >
+                      <Box
+                        sx={{
+                          width: 8,
+                          height: 8,
+                          borderRadius: "50%",
+                          backgroundColor: statusColor(run.status),
+                          flexShrink: 0,
+                        }}
+                      />
+                      <Typography
+                        variant="caption"
+                        sx={{
+                          flex: 1,
+                          fontWeight: 600,
+                          color: statusColor(run.status),
+                          textTransform: "capitalize",
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 0.5,
+                        }}
+                      >
+                        {run.status}
+                        {isActive && <CircularProgress size={9} />}
+                      </Typography>
+                      {run.durationMs !== undefined && (
+                        <Typography variant="caption" color="text.secondary">
+                          {formatDuration(run.durationMs)}
+                        </Typography>
+                      )}
+                    </Box>
+                    {showSource && (
+                      <Typography
+                        variant="caption"
+                        sx={{
+                          display: "block",
+                          mt: 0.25,
+                          fontFamily: "monospace",
+                          fontSize: "0.68rem",
+                          whiteSpace: "nowrap",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          color: "text.primary",
+                        }}
+                        title={runSourceLabel(run, jobNameById)}
+                      >
+                        {runSourceLabel(run, jobNameById)}
+                      </Typography>
+                    )}
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 0.5,
+                        mt: 0.25,
+                      }}
+                    >
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ flex: 1 }}
+                      >
+                        {relativeTime(run.createdAt)}
+                      </Typography>
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ fontSize: "0.65rem" }}
+                      >
+                        {run.trigger}
+                      </Typography>
+                    </Box>
+                  </Box>
+                );
+              })
+            )}
+          </Box>
+        </Panel>
+        <PanelResizeHandle
+          style={{ width: 4, background: "var(--mui-palette-divider)" }}
+        />
+        {/* Run details */}
+        <Panel defaultSize={showSource ? 68 : 75} minSize={30}>
+          {!selectedRun && !selectedRunListItem ? (
+            <Box sx={{ p: 2 }}>
+              <Typography variant="caption" color="text.secondary">
+                Select a run to see details.
+              </Typography>
+            </Box>
+          ) : (
+            <Box
+              sx={{
+                height: "100%",
+                display: "flex",
+                flexDirection: "column",
+              }}
+            >
+              {/* Summary strip */}
+              <Box
+                sx={{
+                  display: "flex",
+                  gap: 2,
+                  alignItems: "center",
+                  px: 1.5,
+                  py: 0.75,
+                  borderBottom: "1px solid",
+                  borderColor: "divider",
+                  flexWrap: "wrap",
+                }}
+              >
+                <Chip
+                  size="small"
+                  variant="outlined"
+                  icon={
+                    selectedStatus === "running" ||
+                    selectedStatus === "queued" ? (
+                      <CircularProgress size={10} />
+                    ) : undefined
+                  }
+                  label={selectedStatus ?? "queued"}
+                  sx={{
+                    height: 20,
+                    textTransform: "capitalize",
+                    fontWeight: 600,
+                    color: statusColor(
+                      (selectedStatus ?? "queued") as DbtRunItem["status"],
+                    ),
+                    borderColor: statusColor(
+                      (selectedStatus ?? "queued") as DbtRunItem["status"],
+                    ),
+                  }}
+                />
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  title={absoluteTime(
+                    (selectedRun ?? selectedRunListItem)?.createdAt,
+                  )}
+                >
+                  {relativeTime(
+                    (selectedRun ?? selectedRunListItem)?.createdAt,
+                  )}
+                </Typography>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{
+                    fontFamily: "monospace",
+                    maxWidth: 360,
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                  }}
+                  title={(selectedRun ?? selectedRunListItem)?.commands
+                    .map(command => `dbt ${command}`)
+                    .join(" → ")}
+                >
+                  {(selectedRun ?? selectedRunListItem)?.commands
+                    .map(command => `dbt ${command}`)
+                    .join(" → ")}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {formatDuration(
+                    (selectedRun ?? selectedRunListItem)?.durationMs,
+                  )}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {(selectedRun ?? selectedRunListItem)?.trigger} ·{" "}
+                  {(selectedRun ?? selectedRunListItem)?.triggeredBy}
+                </Typography>
+                {(selectedRun ?? selectedRunListItem)?.error && (
+                  <Typography variant="caption" color="error">
+                    {(selectedRun ?? selectedRunListItem)?.error}
+                  </Typography>
+                )}
+                {selectedStatus === "error" && (
+                  <Tooltip title="Re-run only the failed/skipped nodes">
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      startIcon={<RetryIcon size={14} />}
+                      onClick={handleRetry}
+                      sx={{ ml: "auto" }}
+                    >
+                      Retry from failure
+                    </Button>
+                  </Tooltip>
+                )}
+              </Box>
+
+              {/* Models table */}
+              {(selectedRun?.stepResults?.length ?? 0) > 0 && (
+                <Box
+                  sx={{
+                    maxHeight: "40%",
+                    overflow: "auto",
+                    borderBottom: "1px solid",
+                    borderColor: "divider",
+                  }}
+                >
+                  <Box
+                    component="table"
+                    sx={{
+                      width: "100%",
+                      fontSize: "0.75rem",
+                      borderCollapse: "collapse",
+                      "& td, & th": {
+                        borderBottom: "1px solid",
+                        borderColor: "divider",
+                        p: 0.5,
+                        textAlign: "left",
+                      },
+                    }}
+                  >
+                    <thead>
+                      <tr>
+                        <th>Node</th>
+                        <th>Type</th>
+                        <th>Status</th>
+                        <th>Time</th>
+                        <th>Rows</th>
+                        <th></th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {selectedRun?.stepResults?.map(step => (
+                        <Box
+                          component="tr"
+                          key={step.uniqueId}
+                          sx={{
+                            color:
+                              step.status === "error" || step.status === "fail"
+                                ? "error.main"
+                                : step.status === "warn"
+                                  ? "warning.main"
+                                  : "inherit",
+                          }}
+                        >
+                          <td>{step.name}</td>
+                          <td>{step.resourceType}</td>
+                          <td>
+                            {step.status}
+                            {step.message &&
+                            (step.status === "error" ||
+                              step.status === "fail" ||
+                              step.status === "warn" ||
+                              step.resourceType === "source")
+                              ? ` — ${step.message}`
+                              : ""}
+                          </td>
+                          <td>{(step.executionTimeMs / 1000).toFixed(2)}s</td>
+                          <td>{step.rowsAffected ?? ""}</td>
+                          <td>
+                            {step.resourceType === "model" && (
+                              <Tooltip title="Open model">
+                                <IconButton
+                                  size="small"
+                                  onClick={() =>
+                                    focusDbtFileTab(
+                                      projectId,
+                                      `models/${step.name}.sql`,
+                                    )
+                                  }
+                                >
+                                  <ModelIcon size={12} />
+                                </IconButton>
+                              </Tooltip>
+                            )}
+                          </td>
+                        </Box>
+                      ))}
+                    </tbody>
+                  </Box>
+                </Box>
+              )}
+
+              {/* Logs */}
+              <Box
+                ref={logScrollRef}
+                sx={{
+                  flex: 1,
+                  minHeight: 0,
+                  overflow: "auto",
+                  fontFamily: "monospace",
+                  fontSize: "0.72rem",
+                  p: 1,
+                  whiteSpace: "pre-wrap",
+                }}
+              >
+                {(selectedRun?.logs ?? []).length === 0 ? (
+                  <Typography variant="caption" color="text.secondary">
+                    {selectedStatus === "queued" ? "Run queued…" : "No logs."}
+                  </Typography>
+                ) : (
+                  selectedRun?.logs.map((log, index) => (
+                    <Box
+                      key={index}
+                      component="div"
+                      sx={{
+                        color:
+                          log.level === "error"
+                            ? "error.main"
+                            : log.level === "warn"
+                              ? "warning.main"
+                              : "text.primary",
+                      }}
+                    >
+                      <Box
+                        component="span"
+                        sx={{ color: "text.secondary", mr: 1 }}
+                      >
+                        {new Date(log.ts).toLocaleTimeString()}
+                      </Box>
+                      {log.line}
+                    </Box>
+                  ))
+                )}
+              </Box>
+            </Box>
+          )}
+        </Panel>
+      </PanelGroup>
+    </Box>
+  );
+}

--- a/app/src/components/DbtRunHistory.tsx
+++ b/app/src/components/DbtRunHistory.tsx
@@ -24,6 +24,10 @@ import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { useDbtStore, type DbtRunItem } from "../store/dbtStore";
 import { focusDbtFileTab } from "../dbt-runtime/shell";
 
+// Stop polling only after sustained fetch failures (~20s) so a transient blip
+// doesn't permanently freeze the detail panel on a non-terminal status.
+const MAX_POLL_ERRORS = 10;
+
 function statusColor(status: DbtRunItem["status"]): string {
   switch (status) {
     case "running":
@@ -116,6 +120,7 @@ export default function DbtRunHistory({
     if (!workspaceId || !selectedRunId) return;
     let stopped = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
+    let consecutiveErrors = 0;
 
     const poll = async () => {
       const details = await fetchRunDetails(
@@ -124,9 +129,19 @@ export default function DbtRunHistory({
         selectedRunId,
       );
       if (stopped) return;
-      if (details?.status === "running" || details?.status === "queued") {
-        timer = setTimeout(() => void poll(), 2000);
+      const status = details?.status;
+      // Stop only on a confirmed terminal status. A transient fetch failure
+      // returns null — keep polling (bounded) rather than freezing on "running".
+      if (
+        status === "success" ||
+        status === "error" ||
+        status === "cancelled"
+      ) {
+        return;
       }
+      if (!details && ++consecutiveErrors >= MAX_POLL_ERRORS) return;
+      if (details) consecutiveErrors = 0;
+      timer = setTimeout(() => void poll(), 2000);
     };
     void poll();
 

--- a/app/src/components/DbtRunsView.tsx
+++ b/app/src/components/DbtRunsView.tsx
@@ -1,0 +1,129 @@
+/**
+ * DbtRunsView — project-wide run history with live logs.
+ *
+ * Unlike DbtJobView (scoped to one job), this lists every run for the project,
+ * including ad-hoc runs triggered by the agent (`dbt_run_model`) and the editor
+ * "Run model" button — runs that have no jobId and therefore never appear in
+ * any job's history. Backed by `GET /runs` (no jobId filter). Self-polls the
+ * list while any run is active so newly-triggered agent runs show up live.
+ */
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Box, IconButton, Tooltip, Typography } from "@mui/material";
+import { RefreshCw as RefreshIcon } from "lucide-react";
+import { useWorkspace } from "../contexts/workspace-context";
+import { useDbtStore } from "../store/dbtStore";
+import DbtRunHistory from "./DbtRunHistory";
+import EntityBreadcrumbs from "./EntityBreadcrumbs";
+
+const LIST_POLL_INTERVAL_MS = 3_000;
+
+export default function DbtRunsView({
+  tabId,
+  projectId,
+  focusRunId,
+}: {
+  tabId: string;
+  projectId: string;
+  focusRunId?: string;
+}) {
+  const { currentWorkspace } = useWorkspace();
+  const workspaceId = currentWorkspace?.id;
+
+  const runs = useDbtStore(s => s.runsByProject[projectId]);
+  const jobs = useDbtStore(s => s.jobsByProject[projectId]);
+  const fetchRuns = useDbtStore(s => s.fetchRuns);
+  const fetchJobs = useDbtStore(s => s.fetchJobs);
+
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(
+    focusRunId ?? null,
+  );
+
+  // Follow tab-metadata focus changes (e.g. chat card re-opening this tab).
+  useEffect(() => {
+    if (focusRunId) setSelectedRunId(focusRunId);
+  }, [focusRunId]);
+
+  const projectRuns = useMemo(() => runs ?? [], [runs]);
+
+  const jobNameById = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const job of jobs ?? []) map[job._id] = job.name;
+    return map;
+  }, [jobs]);
+
+  const hasActive = projectRuns.some(
+    run => run.status === "running" || run.status === "queued",
+  );
+
+  // Initial load: jobs (for labels) + all runs.
+  useEffect(() => {
+    if (!workspaceId) return;
+    if (!jobs) void fetchJobs(workspaceId, projectId);
+    void fetchRuns(workspaceId, projectId);
+  }, [workspaceId, projectId, jobs, fetchJobs, fetchRuns]);
+
+  // Poll the run list while anything is active so agent-triggered runs appear
+  // and statuses stay fresh without manual refresh.
+  const hasActiveRef = useRef(hasActive);
+  hasActiveRef.current = hasActive;
+  useEffect(() => {
+    if (!workspaceId || !hasActive) return;
+    let stopped = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const poll = async () => {
+      await fetchRuns(workspaceId, projectId);
+      if (stopped || !hasActiveRef.current) return;
+      timer = setTimeout(() => void poll(), LIST_POLL_INTERVAL_MS);
+    };
+    timer = setTimeout(() => void poll(), LIST_POLL_INTERVAL_MS);
+    return () => {
+      stopped = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [workspaceId, projectId, hasActive, fetchRuns]);
+
+  // Default selection: newest run.
+  useEffect(() => {
+    if (!selectedRunId && projectRuns.length > 0) {
+      setSelectedRunId(projectRuns[0]._id);
+    }
+  }, [selectedRunId, projectRuns]);
+
+  return (
+    <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
+      <EntityBreadcrumbs
+        tabId={tabId}
+        trailing={
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+            <Typography variant="caption" color="text.secondary">
+              {projectRuns.length} recent · agent, manual &amp; scheduled
+            </Typography>
+            <Tooltip title="Refresh">
+              <IconButton
+                size="small"
+                onClick={() => {
+                  if (workspaceId) void fetchRuns(workspaceId, projectId);
+                }}
+              >
+                <RefreshIcon size={16} />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        }
+      />
+      <Box sx={{ flex: 1, minHeight: 0 }}>
+        <DbtRunHistory
+          workspaceId={workspaceId}
+          projectId={projectId}
+          runs={projectRuns}
+          selectedRunId={selectedRunId}
+          onSelectRun={setSelectedRunId}
+          showSource
+          jobNameById={jobNameById}
+          emptyHint="No runs yet. Build a model from chat or the editor, or run a job."
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -65,6 +65,7 @@ import PlanDocumentTab from "./PlanDocumentTab";
 import DbtFileEditor from "./DbtFileEditor";
 import DbtJobView from "./DbtJobView";
 import DbtConsoleView from "./DbtConsoleView";
+import DbtRunsView from "./DbtRunsView";
 import DashboardDataSourceEditor from "./DashboardDataSourceEditor";
 import TableDataView from "./TableDataView";
 import EntityBreadcrumbs from "./EntityBreadcrumbs";
@@ -2143,7 +2144,9 @@ function Editor({
               activeTab.kind === "table-data" ||
               activeTab.kind === "app-file" ||
               activeTab.kind === "app-binding" ||
-              activeTab.kind === "dashboard-data-source";
+              activeTab.kind === "dashboard-data-source" ||
+              activeTab.kind === "dbt-file" ||
+              activeTab.kind === "dbt-runs";
             if (rendersOwnBreadcrumbs) return null;
             return <EntityBreadcrumbs tabId={activeTab.id} />;
           })()}
@@ -2234,6 +2237,7 @@ function Editor({
                   />
                 ) : tab.kind === "dbt-file" ? (
                   <DbtFileEditor
+                    tabId={tab.id}
                     projectId={tab.metadata?.projectId as string}
                     path={tab.metadata?.path as string}
                   />
@@ -2245,6 +2249,12 @@ function Editor({
                 ) : tab.kind === "dbt-console" ? (
                   <DbtConsoleView
                     projectId={tab.metadata?.projectId as string}
+                  />
+                ) : tab.kind === "dbt-runs" ? (
+                  <DbtRunsView
+                    tabId={tab.id}
+                    projectId={tab.metadata?.projectId as string}
+                    focusRunId={tab.metadata?.focusRunId as string | undefined}
                   />
                 ) : tab.kind === "dashboard-data-source" ? (
                   <DashboardDataSourceEditor

--- a/app/src/components/EntityBreadcrumbs.tsx
+++ b/app/src/components/EntityBreadcrumbs.tsx
@@ -5,6 +5,7 @@ import { useConsoleStore } from "../store/consoleStore";
 import { useSchemaStore } from "../store/schemaStore";
 import { useAppStore } from "../store/appStore";
 import { useDashboardStore } from "../store/dashboardStore";
+import { useDbtStore } from "../store/dbtStore";
 import { useUIStore } from "../store/uiStore";
 import { useExplorerRevealStore } from "../store/explorerRevealStore";
 import { tabRevealTarget } from "../lib/explorer-reveal";
@@ -25,6 +26,7 @@ interface EntityContext {
   dashboardDataSourceName?: string;
   appTitle?: string;
   appBindingName?: string;
+  dbtProjectName?: string;
 }
 
 /**
@@ -116,12 +118,23 @@ function segmentsForTab(
       return plain(["Plans", tab.title || "Plan"]);
     case "dbt-file": {
       const path = (tab.metadata?.path as string | undefined) || "";
-      return plain(["Transforms", ...path.split("/").filter(Boolean)]);
+      return plain([
+        "Transforms",
+        ctx.dbtProjectName,
+        ...path.split("/").filter(Boolean),
+      ]);
     }
     case "dbt-job":
-      return plain(["Transforms", "Jobs", tab.title || "Job"]);
+      return plain([
+        "Transforms",
+        ctx.dbtProjectName,
+        "Jobs",
+        tab.title || "Job",
+      ]);
     case "dbt-console":
-      return plain(["Transforms", tab.title || "Console"]);
+      return plain(["Transforms", ctx.dbtProjectName, tab.title || "Console"]);
+    case "dbt-runs":
+      return plain(["Transforms", ctx.dbtProjectName, tab.title || "Runs"]);
     default: {
       // Compile-time exhaustiveness: a new TabKind must be handled above.
       // Runtime still degrades gracefully for stale persisted tabs.
@@ -184,6 +197,18 @@ function EntityBreadcrumbs({ tabId, trailing }: EntityBreadcrumbsProps) {
       : undefined,
   );
 
+  const dbtProjectId = tab?.metadata?.projectId as string | undefined;
+  const isDbtTab =
+    tab?.kind === "dbt-file" ||
+    tab?.kind === "dbt-job" ||
+    tab?.kind === "dbt-console" ||
+    tab?.kind === "dbt-runs";
+  const dbtProjectName = useDbtStore(s =>
+    isDbtTab && dbtProjectId
+      ? s.projects.find(p => p._id === dbtProjectId)?.name
+      : undefined,
+  );
+
   const dashboardId = tab?.metadata?.dashboardId as string | undefined;
   const dataSourceId = tab?.metadata?.dataSourceId as string | undefined;
   const dashboardTitle = useDashboardStore(s =>
@@ -206,6 +231,7 @@ function EntityBreadcrumbs({ tabId, trailing }: EntityBreadcrumbsProps) {
     dashboardDataSourceName,
     appTitle,
     appBindingName,
+    dbtProjectName,
   });
 
   return (

--- a/app/src/dbt-runtime/shell.ts
+++ b/app/src/dbt-runtime/shell.ts
@@ -62,6 +62,42 @@ export function focusDbtConsoleTab(projectId: string, title: string): string {
   return tabId;
 }
 
+/**
+ * Open (or focus) the project-wide Runs tab (run history + live logs for every
+ * run, including ad-hoc agent/editor runs that have no jobId). When `runId` is
+ * given, the Runs view selects that run on open (used by the chat run card).
+ */
+export function focusDbtRunsTab(
+  projectId: string,
+  title: string,
+  runId?: string,
+): string {
+  const consoleStore = useConsoleStore.getState();
+  const existingTab = Object.values(consoleStore.tabs).find(
+    (tab: { kind?: string; metadata?: { projectId?: string } }) =>
+      tab.kind === "dbt-runs" && tab.metadata?.projectId === projectId,
+  );
+
+  const tabId =
+    existingTab?.id ??
+    consoleStore.openTab({
+      title,
+      content: "",
+      kind: "dbt-runs",
+      metadata: { projectId, focusRunId: runId },
+    });
+
+  // If re-focusing an existing tab with a new target run, update the metadata
+  // so DbtRunsView can react and select it. updateMetadata replaces the whole
+  // object, so pass the full set.
+  if (existingTab && runId) {
+    consoleStore.updateMetadata(tabId, { projectId, focusRunId: runId });
+  }
+
+  consoleStore.setActiveTab(tabId);
+  return tabId;
+}
+
 /** Open (or focus) the job view tab (run history + edit) for a dbt job. */
 export function focusDbtJobTab(
   projectId: string,

--- a/app/src/lib/explorer-reveal.ts
+++ b/app/src/lib/explorer-reveal.ts
@@ -101,6 +101,7 @@ export function tabRevealTarget(
     case "dbt-file":
     case "dbt-job":
     case "dbt-console":
+    case "dbt-runs":
       // dbt tabs live in the Transforms explorer; no stable reveal id yet
       // (mirrors tab-routing.ts — not deep-linkable yet).
       return null;

--- a/app/src/lib/tab-routing.test.ts
+++ b/app/src/lib/tab-routing.test.ts
@@ -68,6 +68,10 @@ const FIXTURES: Record<NonNullable<TabKind>, ConsoleTab> = {
     kind: "dbt-console",
     metadata: { projectId: "proj-1" },
   }),
+  "dbt-runs": baseTab({
+    kind: "dbt-runs",
+    metadata: { projectId: "proj-1" },
+  }),
 };
 
 const ALL_KINDS = Object.keys(FIXTURES) as Array<NonNullable<TabKind>>;

--- a/app/src/lib/tab-routing.ts
+++ b/app/src/lib/tab-routing.ts
@@ -51,6 +51,7 @@ export const TAB_DEEP_LINK_PATTERNS = {
   "dbt-file": null,
   "dbt-job": null,
   "dbt-console": null,
+  "dbt-runs": null,
 } as const satisfies Record<NonNullable<TabKind>, RegExp | null>;
 
 /**
@@ -121,6 +122,7 @@ export function tabUrlPath(tabId: string, tab: ConsoleTab): string | null {
     case "dbt-file":
     case "dbt-job":
     case "dbt-console":
+    case "dbt-runs":
       return null;
     default: {
       // Compile-time exhaustiveness: a new TabKind must be handled above.

--- a/app/src/store/lib/types.ts
+++ b/app/src/store/lib/types.ts
@@ -23,7 +23,8 @@ export type TabKind =
   | "plan"
   | "dbt-file"
   | "dbt-job"
-  | "dbt-console";
+  | "dbt-console"
+  | "dbt-runs";
 
 /**
  * Sub-section for `kind === "settings"` tabs. Each section is rendered in its


### PR DESCRIPTION
Consolidates the "make dbt fast, reliable, and **visible**" effort into one PR against `master`. Supersedes and replaces **#510**, **#511**, **#513** (all closed in favor of this). **29 files, ~+3.6k LOC, 10 commits.** Beyond the chat-perf core, it now also **surfaces dbt runs in the Transforms UI** and collapses the dbt editor's double header into a single breadcrumb bar.

---

## 1. The problem

A `dbt build`/compile from chat would sit on "Building…" for minutes and then strand on "Running…"/"Interrupted". Four independent root causes, each fixed here:

| # | Root cause | Fix |
|---|---|---|
| 1 | The long run was tied to a single live SSE connection that edge proxies killed when it went quiet | Async run card |
| 2 | The UI had no recovery once the stream dropped | Self-polling `DbtRunCard` (+ client reconcile from merged #508) |
| 3 | Proxies killed connections idle >~100s even when the run was healthy | SSE keepalive |
| 4 | Every dbt command paid a full cold start (re-materialize, re-parse, `dbt deps`, cold Python import) | Warm dirs + artifact cache + resident engine |

Plus a visibility gap that surfaced during testing: an async/agent run is a first-class persisted `DbtRun`, but it could **only be seen inside the chat card** — there was no run history for ad-hoc runs anywhere in the Transforms UI (§2H).

---

## 2. What changed + architectural choices

### A. Async run card — decouple long runs from the live stream
`dbt_run_model` no longer blocks the chat stream: it calls `triggerDbtRun` and returns `{ runId }` immediately. The client renders `DbtRunCard` which **self-polls `GET /runs/:runId` every 2s** until terminal, so the result survives a dropped SSE connection, refresh, or second viewer. `dbt_get_run` gained `waitMs` (server-side long-poll) **capped at 90s** (`MAX_RUN_WAIT_MS`, abort-aware) so the agent can do one bounded wait. `Chat.tsx` only swaps in the card when the output carries a `runId` **and** the input a `projectId`; otherwise it falls through to the generic tool card.

### B. SSE keepalive — stop proxies killing healthy streams
`withSseKeepAlive()` in `agent.routes.ts` wraps the live client response and emits an SSE comment (`: keep-alive\n\n`, ignored by the AI SDK parser) every 15s during idle gaps. Comment line → invisible to the protocol. Only the live branch is wrapped; the tee'd resumable-stream copy is untouched so keepalives are never buffered/replayed.

### C. uv cache pin — kill the local re-download
`runDbt` sets `HOME` to the project dir (isolates dbt's profile), which also relocated uv's cache into a throwaway dir → every command re-downloaded dbt-core + adapter (~20s, ~1GB). Pin `UV_CACHE_DIR` to a stable location. Prod-safe: prod resolves dbt via the baked venv (`DBT_VENV_BIN`), never `uvx`, so this only affects local/dev. Operator-overridable.

### D. Warm working directories — keep dbt's on-disk state hot
`workspace-dir.service.ts` keeps a **stable mutex-protected dir per `(workspace, project, environment, role)`** instead of a throwaway temp dir per command, so `target/partial_parse.msgpack` and `dbt_packages/` survive across runs.
- **Roles** (`adhoc` vs `run`) isolate interactive compile from the Inngest deploy build.
- **In-process async mutex** serializes same-dir access; executor is concurrency=1 per project.
- **Default ON**, with a **try/catch fallback to a throwaway dir** — identical behavior on any failure. Kill switch: `DBT_DISABLE_WARM_DIR=true`.
- **Bounded reaper:** warm dirs live in `/tmp` (tmpfs/RAM on Cloud Run) and nothing else deletes them, so a throttled (≤1/10min) best-effort sweep evicts idle dirs by **TTL (default 24h)** and a **count cap (default 40, LRU by last-acquired mtime)**. The reaper **claims the per-dir lock synchronously before deleting**, so it is mutually exclusive with an in-flight command (can't `rm` a dir mid-run). Idle dirs only lose a re-warmable cache. Tunable via `DBT_WARM_DIR_MAX` / `DBT_WARM_DIR_TTL_MS` / `DBT_WARM_DIR_ROOT`.

### E. dbt artifact cache — seed cold dirs without paying full cost
`dbt-cache.service.ts` persists `partial_parse.msgpack` + a `dbt_packages/` archive to the artifact store, keyed by project (+ packages hash), so a brand-new warm dir (cold instance / Inngest worker) self-seeds instead of paying full parse + `dbt deps`. **Cross-instance**, unlike the on-disk warm dir. Best-effort: dbt validates its own partial-parse against checksums, so a stale/garbage cache never yields a wrong result. Save ordering is archive-then-hash so a partial write fails safe (falls back to `dbt deps`).

### F. Only-on-change guarantee
A no-change warm run does **zero** redundant work: `writeFileIfChanged` skips identical files (no mtime bump → partial parse valid), `dbt deps` is skipped via the `.mako_packages_hash` marker / `packagesFresh`, and `materializeDbtProject` now returns `projectChanged` (threaded through `runDbt`) so the parse cache is **re-uploaded only when something changed or the store had no cache** (the msgpack's embedded timestamps otherwise make every run look new). The only per-run cost is dbt's own incremental parse + the warehouse materialization the job exists to do.

### G. Resident dbt engine (flag-gated, default OFF) — sub-second interactive compile
`engine/dbt_engine.py` is a long-lived Python process holding parsed manifests **in memory** via `dbtRunner(manifest=...)` (the dbt Cloud "develop" model). `dbt-engine.service.ts` supervises it.
- **JSON-RPC over fd 3**, not stdout (dbt logs to stdout) — line-buffered, uncorrupted protocol.
- **Pool keyed by `(adapter, version, sha256(connectionEnv))`** with LRU eviction — a process serves one set of warehouse creds (`env_var()` read at profile load). `MAX_ENGINES` bounds memory.
- **Crash-safe + always falls back:** dead process reaped + lazily respawned; per-request timeouts; `dbt-project.service.ts` wraps the engine call in try/catch and falls through to the subprocess path. Strictly an optimization, never a dependency.
- **Same dbt-core + adapter as the subprocess path:** `resolveDbtEnginePython()` uses the baked venv's `python` (`/opt/dbt/bin/python`) in prod, `uv run` locally, or `DBT_ENGINE_PYTHON_CMD` in tests.
- Wired for interactive `compile` today (`engineShow` exists but is not yet routed — follow-up); gated by `DBT_ENGINE_ENABLED` until validated against a real warehouse in staging.

### H. Run visibility — project-wide "Runs" view in Transforms
Async runs (and editor "Run model" runs) are persisted `DbtRun` rows with a `trigger` (`agent` | `manual` | `schedule`) and an optional `jobId`, but previously only the agent's run surfaced — inside the chat card. Run history elsewhere was **job-scoped only** (`DbtJobView` requires a `jobId`), so ad-hoc runs fell through every UI surface.
- New **Runs** node in the Transforms explorer (project root, sibling to Models/Jobs) opens a `dbt-runs` tab (`DbtRunsView`) listing **every** run for the project via `GET /runs` (no `jobId` filter), with a source/command label + trigger per row and a live-log detail panel.
- The run-history list + log panel were **extracted from `DbtJobView` into a shared `DbtRunHistory`** — `DbtJobView` now delegates to it (no behavior change for job history; −~280 lines of duplication).
- `DbtRunsView` self-polls the run list while any run is active so agent-triggered runs appear live; the chat `DbtRunCard` gained an **"open in Transforms → Runs"** button that deep-focuses the run.
- **Backend unchanged** — the `/runs` endpoint already returned ad-hoc runs; this is purely a frontend surface over existing data.

### I. UI cleanup — one breadcrumb bar for dbt tabs
The dbt file editor stacked a redundant `project / path` sub-header under the standard breadcrumb (two bars showing the same filename). Collapsed into one bar:
- `EntityBreadcrumbs` now includes the **project name** for dbt tabs → `Workspace › Transforms › <project> › <path>`.
- The dbt file editor and Runs view render their **own** `EntityBreadcrumbs` with actions in the **trailing slot** (env / Defer / Compile / Run model for models; run count + refresh for Runs) — matching the existing `app-file` / `table-data` pattern, and added to `rendersOwnBreadcrumbs` so the editor shell doesn't double-render.
- The new `dbt-runs` tab kind is threaded through the exhaustive tab-routing / breadcrumb / reveal guards (`TabKind`, `tab-routing`, `explorer-reveal`, `EntityBreadcrumbs`, plus the round-trip test fixture).

### De-risking
- `warm-dir-cache.test.ts` (runs in `pnpm --filter api test`, no deps) unit-tests the on-by-default pure logic: reaper eviction policy (count-cap LRU / TTL / lock-exclusion / dedupe), `computePackagesHash`, and `writeFileIfChanged` change-detection (asserts identical content does **not** bump mtime).
- `dbt-engine.contract.test.ts` (gated `RUN_DBT_ENGINE_CONTRACT=1`, needs a manual `vitest` + `uv`) pins the `dbtRunner` API against **real dbt-core 1.9.10 + dbt-duckdb**.
- `scripts/seed-dbt-engine-demo.ts` (+ `seed:dbt-demo`) for local click-through. Validated E2E on throwaway Mongo (RS) + Postgres.

---

## 3. Deployment

Verified against `Dockerfile` + `deploy-app.yml`:
- Prod image (`node:20-slim`) installs `python3` + **bakes a pinned dbt venv** at `/opt/dbt` (`DBT_VENV_BIN`). Engine reuses that `python` — **no new system deps, no runtime network**. `tar` (used for the packages archive) is in the base image; if absent it degrades to `dbt deps`.
- `api:build`'s `copyfiles` ships `src/**/*.py` → `dist/dbt/engine/dbt_engine.py`; image copies `api/dist`. API is CommonJS so the `__dirname` path resolves. **No new npm deps.**
- `WARM_ROOT` defaults to `/tmp` (the only writable Cloud Run path) — same filesystem the runner already used.
- Run visibility / breadcrumb work (§2H–I) is **frontend-only** — ships in the `app` bundle, no API/schema/migration change.
- **PR preview:** changes `api/**`+`app/**` → builds the image and deploys `https://pr-516.mako.ai` (staging DB, `--timeout=3600`, Inngest branch env synced).

**Flag posture on deploy (workflow sets none of these):**
- Resident engine **OFF** → dormant.
- Warm dirs **ON** → the one behavior change shipping active (with throwaway-dir fallback + kill switch).
- uv pin + keepalive: always on, inert/safe in prod.

So this PR ships the always-on wins (async card, keepalive, warm dirs, uv pin, Runs view + breadcrumb) + the engine *plumbing*; the engine's sub-second compile is opt-in via `DBT_ENGINE_ENABLED` after a staging soak.

---

## 4. Testing on the PR preview

> **One-time setup for event-driven flows on previews:** add a GitHub Actions secret `INNGEST_BRANCH_EVENT_KEY` (Inngest dashboard → Branch Environments → Event Key), then re-run the preview deploy. Without it, async runs route to prod and stay `queued` (see §5).

Wait for the "🚀 Preview Deployment Ready" bot comment, then on `https://pr-516.mako.ai` (needs a workspace with a dbt project + warehouse connection):
1. **Async run card** — ask the agent to build a model → card appears immediately, shows live status, reaches terminal state. **Refresh mid-run** → it recovers via polling (no strand).
2. **SSE keepalive** — a tool running >~100s stays connected; response stream carries periodic `: keep-alive` comments.
3. **Warm dirs / only-on-change** — compile twice; 2nd is faster (partial parse + cached `dbt_packages/` reused). A no-file-change run does no writes, no `dbt deps`, no cache upload.
4. **Runs view + single breadcrumb** — open a dbt file → **one** bar `… › Transforms › <project> › <path>` (no duplicate sub-header). Expand a project → **Runs** node lists every run (agent / manual / scheduled) with trigger labels; click one for live logs. The chat run card's open-icon jumps straight to the run. ✅ *Verified live on `pr-516`.*

**Resident engine (optional):** set `DBT_ENGINE_ENABLED=true` on the `mako-pr-516` Cloud Run revision, compile twice → 2nd sub-second; logs show "dbt engine compile hit", with "falling back to subprocess" on any error.

**Local:** `pnpm --filter api test` (runs the warm-dir/cache unit spec); `RUN_DBT_ENGINE_CONTRACT=1 pnpm --filter api exec vitest run dbt-engine.contract` (needs `vitest` + `uv`); `pnpm seed:dbt-demo` for full-stack click-through.

---

## 5. Risks / open questions

**Addressed during review:**
- ~~Reaper could `rm` a dir mid-run (TOCTOU)~~ → fixed: the reaper now claims the per-dir lock synchronously before deleting, mutually exclusive with `withProjectDir`.
- ~~No tests for the on-by-default pure logic~~ → added `warm-dir-cache.test.ts` (reaper policy, packages hash, change-detection) to the `api` test script.
- ~~Agent runs only visible in chat~~ → added the project-wide Runs view (§2H); frontend-only over the existing `/runs` data, verified on `pr-516`.
- ~~Inngest preview runs stuck `queued`~~ → **root-caused + fixed.** Previews registered functions in the `pr-<n>` branch env (`INNGEST_ENV` + `INNGEST_BRANCH_SIGNING_KEY`) but **sent** events with the **production** event key. Inngest routes a sent event by its **event key**, not the `x-inngest-env` header — so `dbt/run.requested` escaped to prod and the branch executor never fired. Fixed by sending previews with a Branch Environments event key (`secrets.INNGEST_BRANCH_EVENT_KEY`, falling back to the prod key if unset). Requires the secret to be added once (see §4). Crons worked all along because Inngest schedules them per-env from the synced registration (no event key involved). Prod deploy unchanged.

- ~~A run could hang on `queued` forever if the worker never picked it up~~ → added two guards. **(1) Fail-fast:** if `inngest.send()` throws at trigger time, the just-created run is finalized as `error` and the error rethrown. **(2) Read-side watchdog:** an *ad-hoc* run still `queued` past `DBT_QUEUE_TIMEOUT_MS` (default **5m**) is finalized as `error` on read (runs list, single-run endpoint, agent `dbt_get_run` poll) — but **only** when no sibling run is `running` for that project, since the executor serializes per project (`concurrency: { key: projectId, limit: 1 }`) and a run can legitimately wait behind a long build. Scheduled *job* runs are intentionally left to the existing cron `dbtRunSweeperFunction` (6h backstop, which also mirrors job-health stats), so no stat drift. Guarded on `status:"queued"`, mutually exclusive with the executor's `mark-running` claim. Pure threshold logic is unit-tested. Net: the run card shows a clear failure within minutes instead of spinning.

- ~~Run pollers froze on a transient fetch error~~ → `DbtRunCard` / `DbtRunHistory` now stop only on a confirmed terminal status; a null (transient) fetch keeps polling, bounded by a consecutive-error cap.
- ~~Engine LRU eviction could abort an in-flight compile~~ → eviction skips engines with pending requests (pool may briefly exceed cap rather than kill live work).
- ~~Warm-dir cap (40) risked tmpfs/RAM OOM on small instances~~ → default lowered to **12** (env `DBT_WARM_DIR_MAX`); evicted dirs re-seed cheaply from the cross-instance artifact cache.
- ~~CI silently fell back to the prod Inngest key~~ → preview deploy now emits a loud `::warning::` when `INNGEST_BRANCH_EVENT_KEY` is unset.

**Still open:**
- **Warm dirs default-ON is the only active behavior change.** Well-guarded (per-dir mutex, throwaway fallback, bounded race-safe reaper, kill switch `DBT_DISABLE_WARM_DIR=true`), but it's the main risk surface. Reviewers may prefer to soak it in staging first, or land it default-OFF and flip after a day.
- **Secrets linger longer.** `profiles.yml` + credential keyfiles (0600) now persist in the warm dir (tmpfs/RAM, per-instance) until the reaper evicts, vs being deleted right after each command. Low risk (RAM, instance-local, short-lived containers), but a longer exposure window — could scrub keyfiles post-run while keeping the parse/packages cache if we want to tighten it (deferred).
- **`dbt_get_run` waitMs holds an API request up to 90s**, consuming a Cloud Run concurrency slot. Bounded + abort-aware; fine at chat volume, worth noting under heavy concurrency.
- **Per-instance warm dirs** aren't shared across autoscaled instances (the artifact cache is, so cold instances re-warm cheaply). Acceptable; the long-term fix is a dedicated pinned dbt-worker service (dbt-server model) — tracked separately.
- **`engineShow` is implemented but not yet wired** into routing (only `compile` is) — unused surface until a follow-up.
- **Minor, deferred (from review):** live log tail caps at `MAX_LOG_LINES` (5000) — past that the tail stops growing (capped `$slice`), acceptable for now; `disposeAllEngines()` isn't wired into a graceful-shutdown hook (engine is flag-gated OFF, and processes are reaped on exit anyway); a worker crash *after* claiming a run (status `running`) is reconciled by the cron sweeper's 1h activity stall, not the read-side watchdog.

---

## 6. Build
Rebased clean onto current `master`. Green: `pnpm --filter api run build` (lint + tsc + copyfiles) and `pnpm --filter api test` (incl. the warm-dir/cache unit spec); `pnpm --filter app run typecheck && pnpm --filter app run lint` (incl. the tab-routing round-trip test for the new `dbt-runs` kind).


