### PR TITLE
fix(api): fix calendly backfill 400

### DIFF
--- a/api/src/connectors/calendly/connector.ts
+++ b/api/src/connectors/calendly/connector.ts
@@ -264,6 +264,12 @@ export class CalendlyConnector extends BaseConnector {
           (status !== undefined && status >= 500 && status < 600);
 
         if (!retryable || attempt >= maxRetries) {
+          // Surface Calendly's actual error body (parameter + message) instead
+          // of the opaque "Request failed with status code 400". Keep it an
+          // axios error so callers can still inspect error.response.status.
+          if (axios.isAxiosError(error)) {
+            error.message = formatCalendlyApiError(error);
+          }
           throw error;
         }
 
@@ -285,6 +291,16 @@ export class CalendlyConnector extends BaseConnector {
         attempt++;
       }
     }
+  }
+
+  // Calendly requires count in [1, 100]. `batchSize ?? getBatchSize()` is not
+  // enough because `??` lets a 0 through, which Calendly rejects with a 400.
+  private resolvePageCount(batchSize?: number): number {
+    const requested =
+      typeof batchSize === "number" && batchSize > 0
+        ? batchSize
+        : this.getBatchSize();
+    return Math.min(Math.max(requested, 1), MAX_PAGE_LIMIT);
   }
 
   private async getCurrentUser(): Promise<{
@@ -496,7 +512,7 @@ export class CalendlyConnector extends BaseConnector {
 
     while (iterations < maxIterations) {
       const params: Record<string, string | number | undefined> = {
-        count: Math.min(batchSize ?? this.getBatchSize(), MAX_PAGE_LIMIT),
+        count: this.resolvePageCount(batchSize),
         page_token: cursor,
         organization,
       };
@@ -603,7 +619,7 @@ export class CalendlyConnector extends BaseConnector {
     ): Promise<CalendlyListResponse> => {
       const path = `${this.toRelativePath(eventUri)}/invitees`;
       const params: Record<string, string | number> = {
-        count: Math.min(options.batchSize ?? this.getBatchSize(), MAX_PAGE_LIMIT),
+        count: this.resolvePageCount(options.batchSize),
       };
       if (cursor) params.page_token = cursor;
       const response = await this.executeWithRetry(() =>
@@ -653,13 +669,31 @@ export class CalendlyConnector extends BaseConnector {
     };
 
     // Fetch every invitee page for a single event (most events are 1 page).
+    // A single event that Calendly rejects (e.g. deleted/canceled event ->
+    // 400/404) must not kill the whole concurrent wave / backfill: skip it and
+    // log. Anything else (auth, 429-exhausted, 5xx) still propagates.
     const drainInvitees = async (
       eventUri: string,
     ): Promise<Record<string, unknown>[]> => {
       const records: Record<string, unknown>[] = [];
       let cursor: string | undefined;
       do {
-        const page = await fetchInviteesPage(eventUri, cursor);
+        let page: CalendlyListResponse;
+        try {
+          page = await fetchInviteesPage(eventUri, cursor);
+        } catch (error) {
+          const status = axios.isAxiosError(error)
+            ? error.response?.status
+            : undefined;
+          if (status === 400 || status === 404) {
+            logger.warn("Skipping invitees for unreadable scheduled_event", {
+              event: this.toRelativePath(eventUri),
+              detail: formatCalendlyApiError(error),
+            });
+            return records;
+          }
+          throw error;
+        }
         for (const item of page.collection) {
           records.push(withId(item as Record<string, unknown>));
         }


### PR DESCRIPTION
## Fix Calendly invitees backfill 400 crash

The concurrent invitees backfill could fail the whole flow with an opaque
`Request failed with status code 400`, with no indication of which request or
why. This hardens the Calendly connector against that.

All changes are in `api/src/connectors/calendly/connector.ts`.

### Changes

- **Surface the real Calendly error** - `executeWithRetry` now rewrites the
  thrown error's message via `formatCalendlyApiError` (parameter + message from
  Calendly's body) while keeping it an axios error so callers can still read
  `error.response.status`. Logs now show `HTTP 400: <parameter>: <reason>`
  instead of the generic axios message.
- **One bad event no longer kills the backfill** - `drainInvitees` catches
  `400`/`404` for a single scheduled_event (deleted/canceled/unreadable),
  logs a warning, and skips it. With `INVITEES_CONCURRENCY = 8` + `Promise.all`,
  a single poison event previously rejected the whole wave → chunk → flow.
  Auth, rate-limit-exhausted, and 5xx errors still propagate.
- **Guard `count` against 0** - added `resolvePageCount()` which clamps to
  `[1, 100]` and treats `0`/missing as the default. `batchSize ?? getBatchSize()`
  let a `0` through (nullish coalescing doesn't catch `0`), which Calendly
  rejects with a 400. Applied to both the invitees and simple-entity fetch
  paths.

### Testing

- `pnpm --filter api run lint` - clean
- `api/src/connectors/calendly/connector.test.ts` - passing

### Notes / follow-up

- Separate, full-sync-only durability gap (not addressed here): backfill fetch
  state is only checkpointed on the CDC/webhook path. On a full sync that
  crosses the Inngest step budget and yields, state isn't persisted, so the
  re-invocation re-lists from scratch (dedup hides it as a "stuck" row count
  plus wasted API calls). Worth a follow-up if large full syncs are common.