### PR TITLE
feat(app): restore agent console edits as a reviewable Monaco diff

### DIFF
--- a/api/src/agent-lib/tools/server-console-tools.ts
+++ b/api/src/agent-lib/tools/server-console-tools.ts
@@ -59,9 +59,7 @@ interface LoadedConsole {
   doc: ISavedConsole;
 }
 
-type LoadResult =
-  | LoadedConsole
-  | { error: string };
+type LoadResult = LoadedConsole | { error: string };
 
 function isLoadError(r: LoadResult): r is { error: string } {
   return (r as { error?: string }).error !== undefined;
@@ -180,9 +178,7 @@ export function createServerConsoleTools({
           return {
             success: false,
             error:
-              error instanceof Error
-                ? error.message
-                : "Failed to read console",
+              error instanceof Error ? error.message : "Failed to read console",
           };
         }
       },
@@ -198,16 +194,16 @@ export function createServerConsoleTools({
 
           // Some tool-calling models serialize numeric/nullable fields as
           // strings; coerce so those calls aren't rejected.
-          const coerceOptionalNumber = (
-            raw: unknown,
-          ): number | undefined => {
+          const coerceOptionalNumber = (raw: unknown): number | undefined => {
             if (raw === undefined || raw === null) return undefined;
-            if (typeof raw === "number")
-              {return Number.isFinite(raw) ? raw : undefined;}
+            if (typeof raw === "number") {
+              return Number.isFinite(raw) ? raw : undefined;
+            }
             if (typeof raw === "string") {
               const trimmed = raw.trim();
-              if (trimmed === "" || trimmed.toLowerCase() === "null")
-                {return undefined;}
+              if (trimmed === "" || trimmed.toLowerCase() === "null") {
+                return undefined;
+              }
               const parsed = Number(trimmed);
               return Number.isFinite(parsed) ? parsed : undefined;
             }
@@ -266,6 +262,9 @@ export function createServerConsoleTools({
             const setFields: Record<string, unknown> = {
               code: newContent,
               updatedAt: new Date(),
+              // Mark agent origin so a reconnecting client surfaces this as a
+              // reviewable diff even if it missed the realtime poke.
+              lastDraftOrigin: "agent",
             };
             if (title) setFields.name = title;
 
@@ -274,9 +273,7 @@ export function createServerConsoleTools({
                 _id: doc._id,
                 workspaceId: new Types.ObjectId(workspaceId),
                 draftRevision:
-                  currentRevision === 1
-                    ? { $in: [1, null] }
-                    : currentRevision,
+                  currentRevision === 1 ? { $in: [1, null] } : currentRevision,
               },
               { $set: setFields, $inc: { draftRevision: 1 } },
               { new: true },
@@ -366,6 +363,7 @@ export function createServerConsoleTools({
             access: "private",
             isSaved: false,
             draftRevision: 1,
+            lastDraftOrigin: "agent",
             executionCount: 0,
           });
 
@@ -399,7 +397,12 @@ export function createServerConsoleTools({
       description:
         "Attach a console to a database connection, or change its current attachment (applied server-side; open windows update live). Use this when you need to run queries against a different database than what the console is currently attached to. After setting the connection, you can use run_console to execute queries against that database.",
       inputSchema: setConsoleConnectionSchema,
-      execute: async ({ consoleId, connectionId, databaseId, databaseName }) => {
+      execute: async ({
+        consoleId,
+        connectionId,
+        databaseId,
+        databaseName,
+      }) => {
         try {
           const loaded = await loadConsole(consoleId);
           if (isLoadError(loaded)) return { success: false, ...loaded };
@@ -496,9 +499,7 @@ export function createServerConsoleTools({
           return {
             success: false,
             error:
-              error instanceof Error
-                ? error.message
-                : "Failed to open console",
+              error instanceof Error ? error.message : "Failed to open console",
           };
         }
       },
@@ -516,7 +517,8 @@ export function createServerConsoleTools({
         if (!doc.code?.trim()) {
           return {
             success: false,
-            error: "Console is empty. Write a query first using modify_console.",
+            error:
+              "Console is empty. Write a query first using modify_console.",
           };
         }
         if (!doc.connectionId) {

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -455,6 +455,14 @@ export interface ISavedConsole extends Document {
    */
   draftRevision: number;
   /**
+   * Who produced the most recent content-bearing draft write: "agent"
+   * (modify_console / create_console) or "user" (autosave, explicit save).
+   * Lets reconnecting clients surface an agent edit as a reviewable diff even
+   * when the live `console.updated` poke was missed (the revision sync echoes
+   * this back). Undefined on legacy docs ⇒ treated as a user edit.
+   */
+  lastDraftOrigin?: "user" | "agent";
+  /**
    * Latest run artifact (server-side run_console / console execution).
    * Persisted so results survive a detached agent session — when the user
    * reopens the console, the results are still there. sampleRows is capped
@@ -1663,6 +1671,13 @@ const SavedConsoleSchema = new Schema<ISavedConsole>(
     draftRevision: {
       type: Number,
       default: 1,
+    },
+    // Origin of the latest content-bearing draft write ("agent" | "user").
+    // Drives reconnect-safe agent diff review; undefined ⇒ treated as "user".
+    lastDraftOrigin: {
+      type: String,
+      enum: ["user", "agent"],
+      required: false,
     },
     // Latest server-side run artifact. Schema.Types.Mixed members are
     // size-capped by the writer (console-execution.service.ts).

--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -482,6 +482,9 @@ consoleRoutes.openapi(
           // tab's autosave eligibility correct (drafts autosave, saved
           // consoles don't). Missing on legacy docs ⇒ treated as saved.
           isSaved: doc.isSaved ?? true,
+          // Lets the client route an agent edit into the diff-review flow even
+          // when the live poke was missed (reconnect/reload). Undefined ⇒ user.
+          lastDraftOrigin: doc.lastDraftOrigin,
           lastRun: doc.lastRun,
         });
       }
@@ -1289,6 +1292,9 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
           databaseId: body.databaseId,
           isSaved: true,
           updatedAt: now,
+          // User-initiated write: clears any prior agent origin so a later
+          // reconnect doesn't re-surface this as an agent diff.
+          lastDraftOrigin: "user",
         };
         if (body.chartSpec !== undefined) setFields.chartSpec = body.chartSpec;
         if (body.resultsViewMode !== undefined) {
@@ -1358,6 +1364,9 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
         databaseName: body.databaseName,
         databaseId: body.databaseId,
         updatedAt: now,
+        // User-initiated write (autosave / explicit save / agent-edit revert):
+        // clears any prior agent origin so reconnect won't re-surface a diff.
+        lastDraftOrigin: "user",
       };
 
       // Only update name if explicitly provided

--- a/app/src/components/Console.tsx
+++ b/app/src/components/Console.tsx
@@ -48,7 +48,11 @@ import {
   ConsoleModification,
 } from "../hooks/useMonacoConsole";
 import ConsoleInfoModal from "./ConsoleInfoModal";
-import { useConsoleStore, markUserEditActivity } from "../store/consoleStore";
+import {
+  useConsoleStore,
+  markUserEditActivity,
+  getPendingAgentReview,
+} from "../store/consoleStore";
 import { computeConsoleStateHash } from "../utils/stateHash";
 import { applyModification as applyConsoleModification } from "../utils/consoleModification";
 import { ConnectionSelector } from "./ConnectionSelector";
@@ -153,6 +157,12 @@ export interface ConsoleRef {
   canUndo: boolean;
   canRedo: boolean;
   showDiff: (modification: ConsoleModification) => void;
+  /**
+   * Show an agent (modify_console) edit as a reviewable Accept/Reject diff.
+   * The proposed content is the server-authoritative copy; the editor keeps
+   * the pre-agent baseline until the user resolves the review.
+   */
+  showRemoteDiff: (proposedContent: string) => void;
   focus: () => void;
 }
 
@@ -197,6 +207,7 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
   const { effectiveMode } = useTheme();
   const { currentWorkspace } = useWorkspace();
   const autoSaveConsole = useConsoleStore(state => state.autoSaveConsole);
+  const resolveAgentReview = useConsoleStore(state => state.resolveAgentReview);
   const tabs = useConsoleStore(state => state.tabs);
 
   // Get tab state for savedStateHash (used for dirty tracking)
@@ -240,6 +251,13 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
   const [modifiedContent, setModifiedContent] = useState("");
   const [pendingModification, setPendingModification] =
     useState<ConsoleModification | null>(null);
+  // True while the active diff is an agent (modify_console) edit awaiting
+  // review — resolved against the server draft via the console store rather
+  // than the legacy local-modification path.
+  const isRemoteDiffRef = useRef(false);
+  // Flips true once Monaco has mounted; used to surface a pending agent diff
+  // when this tab becomes active after the edit landed in the background.
+  const [editorMounted, setEditorMounted] = useState(false);
   // Editor key to force remount when needed
   const [editorKey, setEditorKey] = useState(0);
 
@@ -647,6 +665,7 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
       editorRef.current = editor;
       monacoRef.current = monaco;
       setMonacoInstance(monaco);
+      setEditorMounted(true);
 
       // Always connect editor to the hook (needed for AI modifications)
       setEditor(editor);
@@ -851,6 +870,7 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
         setOriginalContent(currentContent);
       }
 
+      isRemoteDiffRef.current = false;
       setModifiedContent(newContent);
       setPendingModification(modification);
       setIsDiffMode(true);
@@ -858,8 +878,58 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
     [getFullEditorContent, isDiffMode],
   );
 
+  // Surface an agent (modify_console) edit as a reviewable diff. The change is
+  // already persisted to the server draft; the editor keeps the pre-agent
+  // baseline (originalContent) until the user accepts/rejects. Cumulative
+  // agent edits preserve the baseline and just refresh the modified side.
+  const showRemoteDiff = useCallback(
+    (proposedContent: string) => {
+      if (!isDiffMode) {
+        setOriginalContent(getFullEditorContent());
+      }
+      isRemoteDiffRef.current = true;
+      setPendingModification(null);
+      setModifiedContent(proposedContent);
+      setIsDiffMode(true);
+    },
+    [getFullEditorContent, isDiffMode],
+  );
+
   // Accept the changes
   const acceptChanges = useCallback(() => {
+    // Agent diff: the server already holds the proposed content — adopt it in
+    // the editor and let the store reconcile revision/baseline.
+    if (isRemoteDiffRef.current) {
+      const proposed = modifiedContent;
+      const base = originalContent;
+      setIsDiffMode(false);
+      setEditorKey(prev => prev + 1);
+      isRemoteDiffRef.current = false;
+      isProgrammaticUpdateRef.current = true;
+      lastInitialContentRef.current = proposed;
+      setPendingModification(null);
+      setOriginalContent("");
+      setModifiedContent("");
+
+      if (enableVersionControl) {
+        saveUserEdit(base, "Before AI modification");
+        saveUserEdit(proposed, "AI modification");
+      }
+
+      setTimeout(() => {
+        const model = editorRef.current?.getModel();
+        if (model && model.getValue() !== proposed) {
+          model.setValue(proposed);
+        }
+        isProgrammaticUpdateRef.current = false;
+      }, 100);
+
+      if (currentWorkspace?.id) {
+        void resolveAgentReview(currentWorkspace.id, consoleId, "accept");
+      }
+      return;
+    }
+
     if (pendingModification && modifiedContent) {
       setIsDiffMode(false);
       setEditorKey(prev => prev + 1);
@@ -929,10 +999,38 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
     databaseName,
     isSaved,
     autoSaveConsole,
+    resolveAgentReview,
   ]);
 
   // Reject the changes and restore the original baseline
   const rejectChanges = useCallback(() => {
+    // Agent diff: the server holds the agent's content — restore the editor to
+    // the pre-agent baseline and let the store revert the server draft.
+    if (isRemoteDiffRef.current) {
+      const base = originalContent;
+      setIsDiffMode(false);
+      setEditorKey(prev => prev + 1);
+      isRemoteDiffRef.current = false;
+      isProgrammaticUpdateRef.current = true;
+      lastInitialContentRef.current = base;
+      setPendingModification(null);
+      setOriginalContent("");
+      setModifiedContent("");
+
+      setTimeout(() => {
+        const model = editorRef.current?.getModel();
+        if (model && model.getValue() !== base) {
+          model.setValue(base);
+        }
+        isProgrammaticUpdateRef.current = false;
+      }, 100);
+
+      if (currentWorkspace?.id) {
+        void resolveAgentReview(currentWorkspace.id, consoleId, "reject");
+      }
+      return;
+    }
+
     // Restore editor content to original baseline and sync store
     if (originalContent && onContentChange) {
       onContentChange(originalContent);
@@ -942,7 +1040,25 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
     setPendingModification(null);
     setOriginalContent("");
     setModifiedContent("");
-  }, [originalContent, onContentChange]);
+  }, [
+    originalContent,
+    onContentChange,
+    currentWorkspace,
+    consoleId,
+    resolveAgentReview,
+  ]);
+
+  // Surface a pending agent diff when this tab mounts/activates after the edit
+  // landed while it was in the background (the dispatch from beginAgentReview
+  // is idempotent and won't re-fire once a review is recorded, so a freshly
+  // mounted editor pulls the proposal from the store itself).
+  useEffect(() => {
+    if (!editorMounted || isDiffMode) return;
+    const review = getPendingAgentReview(consoleId);
+    if (review) {
+      showRemoteDiff(review.proposedContent);
+    }
+  }, [editorMounted, isDiffMode, consoleId, showRemoteDiff]);
 
   // DiffEditor mount handler - set up CMD+Enter and store ref
   const handleDiffEditorDidMount = useCallback(
@@ -1012,6 +1128,7 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
       canUndo,
       canRedo,
       showDiff,
+      showRemoteDiff,
       focus: () => {
         if (isDiffMode && diffEditorRef.current) {
           diffEditorRef.current.getModifiedEditor()?.focus();
@@ -1030,6 +1147,7 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
       canUndo,
       canRedo,
       showDiff,
+      showRemoteDiff,
       isDiffMode,
     ],
   );

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -794,6 +794,25 @@ function Editor({
     };
   }, []);
 
+  // Agent (modify_console) edits arrive server-authoritative (issue #475) but
+  // are surfaced as a reviewable Accept/Reject diff instead of replacing the
+  // buffer silently. consoleStore.beginAgentReview dispatches this with the
+  // proposed content; the editor keeps the pre-agent baseline until resolved.
+  useEffect(() => {
+    const handleAgentDiff = (event: Event) => {
+      const { consoleId, content } = (
+        event as CustomEvent<{ consoleId: string; content: string }>
+      ).detail;
+      if (!consoleId) return;
+      consoleRefs.current[consoleId]?.current?.showRemoteDiff(content);
+    };
+
+    window.addEventListener("console-agent-diff", handleAgentDiff);
+    return () => {
+      window.removeEventListener("console-agent-diff", handleAgentDiff);
+    };
+  }, []);
+
   // Listen for console execution events from AI (run_console tool)
   useEffect(() => {
     const handleExecutionStart = (event: Event) => {

--- a/app/src/lib/api-types.ts
+++ b/app/src/lib/api-types.ts
@@ -112,6 +112,12 @@ export interface ConsoleRevisionSyncEntry {
   version?: number;
   /** Server truth for draft-vs-saved (drives autosave eligibility). */
   isSaved?: boolean;
+  /**
+   * Who produced the latest draft write ("agent" | "user"). Lets the client
+   * surface an agent edit as a reviewable diff on reconnect/reload even when
+   * the live `console.updated` poke was missed. Undefined ⇒ treated as user.
+   */
+  lastDraftOrigin?: "user" | "agent";
   lastRun?: ConsoleLastRun;
 }
 

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -117,6 +117,27 @@ interface ConsoleActions {
    */
   fastForwardRemoteConsoleEntry: (entry: ConsoleRevisionSyncEntry) => void;
   /**
+   * Start (or update) a Monaco diff review for an agent (modify_console)
+   * edit. The change is already persisted to the server draft; this surfaces
+   * it for Accept/Reject review instead of applying it silently. The editor
+   * keeps the pre-agent baseline until resolveAgentReview runs. Cumulative
+   * agent edits update the diff's "modified" side while preserving the
+   * original baseline. No-op when the proposed content already matches the
+   * tab (nothing to review).
+   */
+  beginAgentReview: (entry: ConsoleRevisionSyncEntry) => void;
+  /**
+   * Resolve a pending agent diff review. "accept" adopts the agent's content
+   * locally (the server already holds it); "reject" reverts the server draft
+   * back to the pre-agent baseline with a revision-checked write. The editor
+   * buffer is restored by the Console component; this syncs store + server.
+   */
+  resolveAgentReview: (
+    workspaceId: string,
+    consoleId: string,
+    action: "accept" | "reject",
+  ) => Promise<void>;
+  /**
    * Resolve the remote-update affordance: refetch the server copy, apply it
    * (discarding local unsaved edits).
    */
@@ -322,6 +343,36 @@ export const hasRecentUserEdit = (consoleId: string): boolean => {
   return at !== undefined && Date.now() - at < USER_EDIT_RECENCY_MS;
 };
 
+/**
+ * Consoles whose latest agent (modify_console) edit is awaiting user review
+ * in the Monaco diff view. modify_console runs server-side (issue #475) and
+ * the change is already persisted to the draft, but instead of silently
+ * replacing the editor we surface it as an Accept/Reject diff (the pre-#475
+ * UX). While a console is under review the realtime layer routes further
+ * server copies into the diff rather than applying them, and the editor keeps
+ * the pre-agent baseline until the user resolves the review. Keyed by
+ * consoleId; module-level (non-reactive) like the autosave bookkeeping.
+ */
+export interface PendingAgentReview {
+  /** Store content before the agent's first edit (restored on reject). */
+  baseContent: string;
+  /** Draft revision the tab held before the agent's first edit. */
+  baseRevision: number;
+  /** Latest agent-proposed content (the diff's "modified" side). */
+  proposedContent: string;
+  /** Server draft revision carrying the proposed content. */
+  proposedRevision: number;
+}
+
+const pendingAgentReviews = new Map<string, PendingAgentReview>();
+
+export const hasPendingAgentReview = (consoleId: string): boolean =>
+  pendingAgentReviews.has(consoleId);
+
+export const getPendingAgentReview = (
+  consoleId: string,
+): PendingAgentReview | undefined => pendingAgentReviews.get(consoleId);
+
 /** A draft autosave is queued (debounce window) but not yet persisted. */
 export const hasPendingDraftSave = (consoleId: string): boolean =>
   draftSaveTimers.has(consoleId);
@@ -467,6 +518,7 @@ export const useConsoleStore = create<ConsoleStore>()(
         }
 
         cancelAutoSave(id);
+        pendingAgentReviews.delete(id);
 
         set(state => {
           delete state.tabs[id];
@@ -630,6 +682,152 @@ export const useConsoleStore = create<ConsoleStore>()(
         });
         blockedDraftSaves.delete(entry.id);
         lastSavedContentHash.set(entry.id, newStateHash);
+      },
+
+      beginAgentReview: entry => {
+        const tab = get().tabs[entry.id];
+        if (!tab) return;
+        const existing = pendingAgentReviews.get(entry.id);
+        // Nothing to review: the proposed content already matches the tab
+        // (e.g. a stale re-sync after the user just accepted, or an echo).
+        if (!existing && tab.content === entry.content) return;
+        // Idempotent: same proposal already on screen — don't re-dispatch
+        // (avoids resetting the diff scroll on every unrelated poke).
+        if (
+          existing &&
+          existing.proposedRevision === entry.draftRevision &&
+          existing.proposedContent === entry.content
+        ) {
+          return;
+        }
+        // Preserve the true baseline across cumulative agent edits: only the
+        // FIRST edit captures the pre-agent content/revision.
+        const baseContent = existing?.baseContent ?? tab.content;
+        const baseRevision = existing?.baseRevision ?? tab.draftRevision ?? 0;
+        pendingAgentReviews.set(entry.id, {
+          baseContent,
+          baseRevision,
+          proposedContent: entry.content,
+          proposedRevision: entry.draftRevision,
+        });
+        // A rename is metadata, not part of the content diff: apply it
+        // immediately (mirrors applyRemoteConsoleUpdate/fastForward) so the tab
+        // title tracks the server. The Accept/Reject controls govern only the
+        // code shown in the diff; content + draftRevision stay on the baseline
+        // until the user resolves the review.
+        const proposedName = entry.name;
+        if (proposedName && proposedName !== tab.title) {
+          set(state => {
+            const t = state.tabs[entry.id];
+            if (t) t.title = proposedName;
+          });
+        }
+        // Push the proposal into the mounted Monaco editor as a diff. The
+        // store content/revision stay on the baseline until the user
+        // resolves the review (Editor.tsx listens).
+        window.dispatchEvent(
+          new CustomEvent("console-agent-diff", {
+            detail: { consoleId: entry.id, content: entry.content },
+          }),
+        );
+      },
+
+      resolveAgentReview: async (workspaceId, consoleId, action) => {
+        const review = pendingAgentReviews.get(consoleId);
+        if (!review) return;
+        pendingAgentReviews.delete(consoleId);
+        const tab = get().tabs[consoleId];
+        if (!tab) return;
+
+        if (action === "accept") {
+          // The server already holds the proposed content at proposedRevision;
+          // adopt it locally so the tab mirrors the server and autosave stays
+          // quiet. The editor buffer is set to the proposal by Console.
+          const newStateHash = computeConsoleStateHash(
+            review.proposedContent,
+            tab.connectionId,
+            tab.databaseId,
+            tab.databaseName,
+          );
+          set(state => {
+            const t = state.tabs[consoleId];
+            if (!t) return;
+            t.content = review.proposedContent;
+            t.draftRevision = review.proposedRevision;
+            if (t.isSaved) t.savedStateHash = newStateHash;
+            t.remoteUpdate = null;
+          });
+          blockedDraftSaves.delete(consoleId);
+          lastSavedContentHash.set(consoleId, newStateHash);
+          return;
+        }
+
+        // Reject: the agent's content is persisted on the server draft, so a
+        // plain local restore would reappear on the next revision sync. Write
+        // the pre-agent baseline back with a revision-checked PUT targeting
+        // the proposed revision the server currently holds.
+        const baseStateHash = computeConsoleStateHash(
+          review.baseContent,
+          tab.connectionId,
+          tab.databaseId,
+          tab.databaseName,
+        );
+        set(state => {
+          const t = state.tabs[consoleId];
+          if (!t) return;
+          t.content = review.baseContent;
+          t.remoteUpdate = null;
+        });
+        try {
+          // Same intentional catch-all save endpoint as autosave / keep-mine
+          // (not in the documented OpenAPI surface) — stays on legacy client.
+          // Keep the current title (any agent rename already applied and is not
+          // part of the rejected content diff).
+          const { status, body } =
+            await apiClient.putWithStatus<ConsoleSaveResponse>(
+              `/workspaces/${workspaceId}/consoles/${consoleId}`,
+              {
+                content: review.baseContent,
+                title: tab.title,
+                connectionId: cloudSafeConnectionId(tab.connectionId),
+                databaseId: tab.databaseId,
+                databaseName: tab.databaseName,
+                clientId: realtimeClientId,
+                expectedDraftRevision: review.proposedRevision,
+              },
+              { alsoOk: [409] },
+            );
+
+          if (status === 409 && body.draftConflict) {
+            // Someone wrote concurrently after the agent. If they happened to
+            // land on our baseline, just fast-forward; otherwise surface the
+            // standard remote-update affordance instead of silently fighting.
+            if (body.draftConflict.content === review.baseContent) {
+              get().updateDraftRevision(
+                consoleId,
+                body.draftConflict.currentDraftRevision,
+              );
+              lastSavedContentHash.set(consoleId, baseStateHash);
+            } else {
+              get().setRemoteUpdate(consoleId, {
+                draftRevision: body.draftConflict.currentDraftRevision,
+                kind: "updated",
+              });
+            }
+            return;
+          }
+
+          if (body.success) {
+            if (typeof body.draftRevision === "number") {
+              get().updateDraftRevision(consoleId, body.draftRevision);
+            }
+            blockedDraftSaves.delete(consoleId);
+            lastSavedContentHash.set(consoleId, baseStateHash);
+          }
+        } catch (_e) {
+          // Best-effort: the revision base is unchanged, so the next sync
+          // re-surfaces the agent edit for review rather than losing data.
+        }
       },
 
       applyRemoteConsoleUpdate: async (workspaceId, consoleId) => {

--- a/app/src/store/realtimeStore.ts
+++ b/app/src/store/realtimeStore.ts
@@ -21,6 +21,7 @@ import {
   useConsoleStore,
   hasUnsavedLocalEdits,
   hasBlockedDraftSave,
+  hasPendingAgentReview,
 } from "./consoleStore";
 import { decideRemoteApply } from "./lib/remoteApplyGate";
 import { useConsoleTreeStore } from "./consoleTreeStore";
@@ -122,6 +123,17 @@ const DEFERRED_RESYNC_MS = 3_500;
 /** Last known writer per console (from pokes) — labels the dirty affordance. */
 const lastUpdatedByConsole = new Map<string, string>();
 
+/**
+ * Consoles whose most recent poke was an agent (modify_console) edit. The
+ * poke only carries metadata; origin is known here but the authoritative
+ * content arrives later via the pull (syncRevisions). This bridges the two:
+ * when the pulled copy lands, an agent-origin console is routed into the
+ * Monaco diff review (beginAgentReview) instead of being applied silently.
+ * Consumed on pull; a console already under review stays in review until the
+ * user accepts/rejects (tracked by consoleStore.hasPendingAgentReview).
+ */
+const agentOriginConsoles = new Set<string>();
+
 function isConsoleTabKind(kind: string | undefined): boolean {
   return kind === undefined || kind === "console";
 }
@@ -188,6 +200,13 @@ export const useRealtimeStore = create<RealtimeStore>()(
 
       const tab = useConsoleStore.getState().tabs[event.consoleId];
       if (!tab) return; // not open in this window — nothing to update
+
+      // Remember agent-origin edits on OPEN consoles so the pull routes them
+      // into the diff review (editor keeps the baseline until accept/reject).
+      if (event.origin === "agent") {
+        agentOriginConsoles.add(event.consoleId);
+      }
+
       // A tab that never synced (no draftRevision) counts as revision 0 so
       // even the server's first revision is pulled.
       if ((tab.draftRevision ?? 0) >= event.draftRevision) return; // stale
@@ -515,6 +534,28 @@ export const useRealtimeStore = create<RealtimeStore>()(
           const store = useConsoleStore.getState();
           for (const entry of res.changed) {
             const tab = store.tabs[entry.id];
+
+            // Agent (modify_console) edits surface as a Monaco Accept/Reject
+            // diff instead of being applied silently. Route the pulled copy
+            // into the review when:
+            //   - the latest live poke for this console was the agent's, OR
+            //   - the console is already mid-review (cumulative agent edits /
+            //     unrelated re-syncs keep refreshing the diff, never the
+            //     buffer), OR
+            //   - the synced copy itself says the last write was the agent's
+            //     (reconnect/reload after a MISSED poke — the durable signal).
+            // beginAgentReview no-ops when the proposed content already
+            // matches the tab, so non-content bumps never spuriously trigger.
+            const isAgentEdit =
+              agentOriginConsoles.has(entry.id) ||
+              hasPendingAgentReview(entry.id) ||
+              entry.lastDraftOrigin === "agent";
+            if (isAgentEdit) {
+              agentOriginConsoles.delete(entry.id);
+              store.beginAgentReview(entry);
+              continue;
+            }
+
             const decision = decideRemoteApply({
               tabExists: Boolean(tab),
               tabRevision: tab?.draftRevision,


### PR DESCRIPTION
## Summary

After the move to server-side streaming with client-side tool calls, agent (`modify_console` / `create_console`) edits write the server draft directly and were applied to the Monaco editor **silently** — we lost the Accept/Reject **diff review** users previously got for every agent edit.

This restores the diff-review UX **without giving up server-authoritative writes** (durability, agent read-after-write, multi-client consistency). Approach: the agent still writes the server draft; the client surfaces that write as a reviewable diff and, on reject, reverts the server draft.

## What changed

- **Poke-then-pull routing** (`realtimeStore.ts`): an agent-origin `console.updated` poke marks the console; the follow-up revision pull routes the authoritative copy into a Monaco **Accept/Reject** diff (`beginAgentReview`) instead of applying it silently. The editor keeps the pre-agent baseline until the user resolves.
- **Review lifecycle** (`consoleStore.ts`): tracks pending agent reviews (baseline vs proposed content/revision).
  - **Accept** adopts the server's proposed content/revision locally (no extra write).
  - **Reject** writes the baseline back with a **revision-checked PUT** (incl. `409` draft-conflict handling) so the agent's persisted draft is actually reverted, not just hidden locally.
- **Reconnect safety** (`workspace-schema.ts`, `consoles.ts`, `api-types.ts`): persist `lastDraftOrigin` (`"agent" | "user"`) on `SavedConsole` and echo it via `revisions-sync`, so a reconnecting/reloading client re-surfaces an agent diff **even when the live poke was missed**. User-initiated writes (autosave / explicit save / reject-revert) reset it to `"user"`.
- **Editor wiring** (`Console.tsx`, `Editor.tsx`): `showRemoteDiff` imperative method + `console-agent-diff` event listener; cumulative agent edits preserve the original baseline; renames apply immediately as metadata (not part of the content diff).

## Test plan

- [x] `pnpm --filter app run typecheck` + `pnpm --filter app run lint`
- [x] `pnpm --filter api run lint`
- [x] Unsaved draft console: agent edit shows diff; Accept adopts; Reject reverts
- [x] Saved console: agent edit shows diff; Accept persists; Reject reverts server draft; title/rename propagates
- [x] Cross-window: agent edit triggered in window A surfaces the Accept/Reject diff in **both** windows; Reject in one window propagates the revert to the other (last-write-wins, consistent final state)
- [ ] Reconnect/reload after a missed poke re-surfaces the pending agent diff (`lastDraftOrigin` path)

## Known follow-up

Accepting in one window does not yet auto-dismiss the pending banner in **other** open windows (accept emits no server change/poke). Final content stays consistent; clearing the stale banner would require a lightweight "review resolved" realtime signal — left as a follow-up.

Made with [Cursor](https://cursor.com)