### PR TITLE
docs(ai-agent): document agent-edit Accept/Reject diff review

### DIFF
--- a/docs/src/content/docs/ai-agent.md
+++ b/docs/src/content/docs/ai-agent.md
@@ -28,6 +28,7 @@ The console is a full SQL editor — not a chat window with code blocks you copy
 - **Reads before writing** — always checks the current console state before modifying
 - **Supports patching** — for small edits (adding a WHERE clause, fixing a column name), it patches specific lines instead of replacing everything
 - **Multiple consoles** — each query gets its own tab, organized by topic
+- **Reviewable edits** — agent edits to an existing console arrive as a Monaco Accept/Reject diff rather than overwriting your buffer. Your editor keeps the pre-agent baseline until you resolve the review: **Accept** adopts the agent's version, **Reject** reverts it. Cumulative edits across a turn diff against the original baseline, and a pending review re-surfaces if you reload or reconnect mid-edit. (Renames apply immediately as metadata, not part of the content diff.)
 
 ## Multi-Database Support
 


### PR DESCRIPTION
## What

Updates the **Console-First Design** section of `ai-agent.md` to document the new agent-edit review behavior shipped in 3be1af02 (#520).

## Why

Docs previously described agent `modify_console`/`create_console` edits as silently appearing in the editor. As of #520 they now arrive as a **reviewable Monaco Accept/Reject diff**:
- Editor keeps the pre-agent baseline until the user resolves the review
- **Accept** adopts the agent's version; **Reject** reverts (revision-checked)
- Cumulative edits diff against the original baseline
- Pending review re-surfaces on reload/reconnect
- Renames apply immediately as metadata (not part of the content diff)

Verified against `app/src/store/consoleStore.ts` (`beginAgentReview`/`resolveAgentReview`, `PendingAgentReview`) and the commit message — no guessing.

P2 stale-section fix. One doc file, no behavior change.