### PR TITLE
fix(ci): unblock all deploys — remove secrets context from step if:

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -206,9 +206,16 @@ jobs:
       SUPER_ADMIN_EMAILS: ${{ secrets.SUPER_ADMIN_EMAILS }}
     steps:
       - name: Warn if branch Inngest event key is missing
-        if: ${{ secrets.INNGEST_BRANCH_EVENT_KEY == '' }}
+        # NOTE: the `secrets` context is NOT allowed in `if:` conditionals — it
+        # makes the whole workflow file invalid (every run fails at 0s with no
+        # jobs, blocking ALL deploys). Surface the secret via step `env` and do
+        # the emptiness check in bash instead.
+        env:
+          INNGEST_BRANCH_EVENT_KEY: ${{ secrets.INNGEST_BRANCH_EVENT_KEY }}
         run: |
-          echo "::warning title=Inngest branch event key missing::INNGEST_BRANCH_EVENT_KEY is not set — preview events fall back to the PRODUCTION event key and route to the prod Inngest env, so event-triggered functions (e.g. dbt runs) will NOT fire on this preview (they stay 'queued'). Add the Branch Environments event key as a repo secret to enable event-driven flows on previews."
+          if [ -z "${INNGEST_BRANCH_EVENT_KEY}" ]; then
+            echo "::warning title=Inngest branch event key missing::INNGEST_BRANCH_EVENT_KEY is not set — preview events fall back to the PRODUCTION event key and route to the prod Inngest env, so event-triggered functions (e.g. dbt runs) will NOT fire on this preview (they stay 'queued'). Add the Branch Environments event key as a repo secret to enable event-driven flows on previews."
+          fi
 
       - name: Set PR-specific variables
         id: pr-vars


### PR DESCRIPTION
## TL;DR

**Production (app.mako.ai) has not deployed since #519.** Every deploy run since #516 fails in **0s with no jobs** because `deploy-app.yml` is invalid. That's why #520 (agent console diff review) — and #516 itself — never actually reached production, even though they're merged. This unblocks the pipeline.

## Root cause

#516 added this step to `.github/workflows/deploy-app.yml`:

```yaml
- name: Warn if branch Inngest event key is missing
  if: ${{ secrets.INNGEST_BRANCH_EVENT_KEY == '' }}
```

The **`secrets` context is not allowed in `if:` conditionals**. GitHub rejects the whole workflow file at parse time, so the run fails instantly with zero jobs — blocking **both** PR previews and production deploys.

`actionlint` confirms it on the pre-fix file:

```
deploy-app.yml:209:17: context "secrets" is not allowed here.
available contexts are "env", "github", "inputs", "job", "matrix",
"needs", "runner", "steps", "strategy", "vars". [expression]
```

Evidence of the breakage on `master`:
- #519 — deploy-app ✅ (last successful production deploy)
- #516 — deploy-app ❌ 0s
- #520 — deploy-app ❌ 0s

I also verified against live prod that the served frontend bundle contains **none** of #520's markers (`beginAgentReview`, `console-agent-diff`, `pendingAgentReview`, `lastDraftOrigin`), confirming prod predates the merge.

## Fix

Surface the secret via step `env` and do the emptiness check in bash, so the preview warning still fires without referencing `secrets` in `if:`.

- `actionlint` passes on the fixed workflow.
- `python -c yaml.safe_load` parses clean.
- Repo-wide scan: no other `if:` references `secrets`.

## After merge

Merging to `master` runs the now-valid workflow and deploys current `master` (this fix + #516 + #520) to production, which restores the agent-edit Accept/Reject diff review and ships the latest `run_console` results-surfacing path. I'll verify both live once prod is current.

Made with [Cursor](https://cursor.com)