### PR TITLE
fix(app): surface agent run_console results when the live event is missed

### DIFF
--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -849,34 +849,54 @@ function Editor({
     };
   }, []);
 
-  // Detached-return path: a console opened with a persisted server-side run
-  // artifact (agent ran it while no window was attached) renders those
-  // results without re-running. In-memory results always win.
+  // Persisted server-side run artifact (tab.lastRun) -> results panel.
+  //
+  // Two cases, both driven by the revision sync that keeps tab.lastRun fresh:
+  //   1. Detached return: a console opened with a persisted artifact (the agent
+  //      ran it while no window was attached) renders results without re-running.
+  //   2. Missed live event catch-up: the agent ran the console while this window
+  //      was backgrounded/disconnected, so the ephemeral console.run.completed
+  //      event never landed — but the reconnect sync refreshed tab.lastRun. Show
+  //      the newer agent run instead of leaving stale results on screen.
+  //
+  // In-memory results from a LOCAL run always win: they hold the full row set
+  // while the artifact is capped (~50 rows), so we only override a displayed
+  // result for AGENT runs that are strictly newer than what's shown. The live
+  // console-execution-result path already handles connected windows; this is the
+  // durable backstop for when that event is missed.
   useEffect(() => {
     for (const tab of consoleTabs) {
       const lastRun = tab.lastRun;
       if (!lastRun || lastRun.status !== "success" || !lastRun.sampleRows) {
         continue;
       }
-      if (tabResults[tab.id] !== undefined) continue;
-      setTabResults(prev =>
-        prev[tab.id] !== undefined
-          ? prev
-          : {
-              ...prev,
-              [tab.id]: {
-                results: lastRun.sampleRows ?? [],
-                executedAt: lastRun.at,
-                resultCount:
-                  lastRun.rowCount ?? lastRun.sampleRows?.length ?? 0,
-                executionTime: lastRun.durationMs,
-                fields: (lastRun.fields as QueryResult["fields"]) ?? null,
-                pageInfo: null,
-              } as QueryResult,
-            },
-      );
+      const lastRunAt = new Date(lastRun.at).getTime();
+      setTabResults(prev => {
+        const shown = prev[tab.id];
+        if (shown !== undefined) {
+          // Only catch up agent runs (the user never holds full agent results
+          // locally) that are strictly newer than the displayed run. Never
+          // clobber an equal/older artifact or a local run's full results.
+          const shownAt = shown?.executedAt
+            ? new Date(shown.executedAt).getTime()
+            : NaN;
+          if (lastRun.source !== "agent" || !(lastRunAt > shownAt)) {
+            return prev;
+          }
+        }
+        return {
+          ...prev,
+          [tab.id]: {
+            results: lastRun.sampleRows ?? [],
+            executedAt: lastRun.at,
+            resultCount: lastRun.rowCount ?? lastRun.sampleRows?.length ?? 0,
+            executionTime: lastRun.durationMs,
+            fields: (lastRun.fields as QueryResult["fields"]) ?? null,
+            pageInfo: null,
+          } as QueryResult,
+        };
+      });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [consoleTabs]);
 
   /* ------------------------ Console Actions ------------------------ */

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -710,18 +710,20 @@ export const useConsoleStore = create<ConsoleStore>()(
           proposedContent: entry.content,
           proposedRevision: entry.draftRevision,
         });
-        // A rename is metadata, not part of the content diff: apply it
-        // immediately (mirrors applyRemoteConsoleUpdate/fastForward) so the tab
-        // title tracks the server. The Accept/Reject controls govern only the
-        // code shown in the diff; content + draftRevision stay on the baseline
-        // until the user resolves the review.
+        // A rename and the run artifact are metadata, not part of the content
+        // diff: apply them immediately (mirrors applyRemoteConsoleUpdate/
+        // fastForward) so the tab title tracks the server and an agent run that
+        // accompanied this edit (modify_console + run_console) surfaces its
+        // results without waiting for the user to resolve the diff. The
+        // Accept/Reject controls govern only the code shown in the diff;
+        // content + draftRevision stay on the baseline until the user resolves.
         const proposedName = entry.name;
-        if (proposedName && proposedName !== tab.title) {
-          set(state => {
-            const t = state.tabs[entry.id];
-            if (t) t.title = proposedName;
-          });
-        }
+        set(state => {
+          const t = state.tabs[entry.id];
+          if (!t) return;
+          if (proposedName && proposedName !== t.title) t.title = proposedName;
+          if (entry.lastRun) t.lastRun = entry.lastRun;
+        });
         // Push the proposal into the mounted Monaco editor as a diff. The
         // store content/revision stay on the baseline until the user
         // resolves the review (Editor.tsx listens).

--- a/app/src/store/lib/types.ts
+++ b/app/src/store/lib/types.ts
@@ -124,6 +124,8 @@ export interface ConsoleTab {
     error?: string;
     sampleRows?: Record<string, unknown>[];
     fields?: unknown;
+    /** Origin of the run ("agent", "user", …) — drives results catch-up. */
+    source?: string;
   } | null;
   schedule?: {
     cron: string;


### PR DESCRIPTION
## Problem

The agent's `run_console` publishes an **ephemeral** `console.run.completed` poke; the attached window then fetches the artifact and renders it into the results panel. If that live event is **missed** — the window was backgrounded/disconnected during the agent turn, or the new agent-edit diff review is holding the tab — the results panel keeps showing the **previous** run, even though the reconnect revision sync already refreshed `tab.lastRun`. The agent's new results never appear.

This is the second half of the report in #520's follow-up: "it ran the console … but the results have not changed." (The missing Accept/Reject diff was a separate issue — production hadn't deployed #520 at all; see #522.)

## Why it happened

`Editor.tsx`'s `tab.lastRun → results` effect only hydrated when **nothing** was shown (`tabResults[id] === undefined`). With a stale run already on screen, a newer artifact arriving via sync was ignored. And `beginAgentReview` applied the rename as metadata but not the run artifact, so a `modify_console` + `run_console` turn left results stale while the diff was pending.

## Fix

- **`Editor.tsx`** — the artifact→panel effect now also catches up an **agent** run that is strictly newer than what's displayed, not just the empty case. Local runs still win: the override is gated on `lastRun.source === "agent"` **and** a newer timestamp, so the capped (~50-row) artifact never clobbers richer, full in-memory results from a local run.
- **`consoleStore.beginAgentReview`** — apply `lastRun` immediately as metadata (alongside the rename), so a combined modify+run turn surfaces results while the content diff is still pending Accept/Reject.
- **`store/lib/types.ts`** — add `lastRun.source` to the tab artifact shape.

## Validation

- `pnpm --filter app run typecheck` ✅
- `pnpm --filter app run lint` (with `--report-unused-disable-directives`) ✅

## Notes

- Depends on #522 (which unblocks the deploy pipeline); without it nothing reaches production.
- Will verify live once production is current.

Made with [Cursor](https://cursor.com)