### PR TITLE
feat(admin): add hard refresh for model catalog

### DIFF
--- a/api/src/routes/admin.routes.ts
+++ b/api/src/routes/admin.routes.ts
@@ -12,6 +12,7 @@ import { unifiedAuthMiddleware } from "../auth/unified-auth.middleware";
 import { requireSuperAdmin } from "../auth/super-admin";
 import { loggers } from "../logging";
 import {
+  adminHardRefreshCatalog,
   adminRefreshCatalog,
   getAdminCatalogView,
   setCuratedDefaults,
@@ -94,6 +95,28 @@ adminRoutes.openapi(
     });
   },
 );
+
+// ---------------------------------------------------------------------------
+// POST /api/admin/catalog/hard-refresh
+// Resilient refresh: drops only malformed upstream rows (instead of skipping
+// the whole snapshot) and busts BOTH the catalog and gateway-models caches.
+// ---------------------------------------------------------------------------
+adminRoutes.post("/catalog/hard-refresh", async c => {
+  const result = await adminHardRefreshCatalog();
+  if (!result.ok) {
+    return c.json({ success: false, error: result.error }, 502);
+  }
+  const view = await getAdminCatalogView();
+  return c.json({
+    success: true,
+    refreshed: {
+      models: result.models,
+      pricedModels: result.pricedModels,
+      droppedEntries: result.droppedEntries,
+    },
+    ...view,
+  });
+});
 
 // ---------------------------------------------------------------------------
 // PUT /api/admin/catalog/models/:modelId

--- a/api/src/services/model-catalog.service.ts
+++ b/api/src/services/model-catalog.service.ts
@@ -18,6 +18,7 @@
 import { z } from "zod";
 import { loggers } from "../logging";
 import { ModelCatalogSnapshot } from "../database/schema";
+import { warmModelsCache } from "./gateway-models.service";
 import {
   hasExplicitThinkingMode,
   resolveAnthropicThinkingMode,
@@ -288,31 +289,21 @@ async function probeAnthropicThinkingModes(
 // Snapshot refresh: Gateway (models + pricing)
 // ---------------------------------------------------------------------------
 
-export async function refreshGatewaySnapshot(): Promise<
+type GatewayModelRaw = z.infer<typeof GatewayModelRawSchema>;
+
+/**
+ * Shared tail for both refresh variants: given the already-validated raw
+ * gateway entries, filter to language models, enforce the < 10 floor, build +
+ * upsert the snapshot/pricing docs, and probe Anthropic thinking modes. The
+ * two refresh entry points differ only in how they validate `body.data`
+ * (all-or-nothing vs. per-row), so everything downstream lives here.
+ */
+async function persistLanguageSnapshot(
+  entries: GatewayModelRaw[],
+): Promise<
   { models: number; pricedModels: number } | { skipped: true; reason: string }
 > {
-  const res = await fetch(GATEWAY_API_URL, {
-    headers: { Accept: "application/json" },
-    signal: AbortSignal.timeout(10_000),
-  });
-
-  if (!res.ok) {
-    throw new Error(`Gateway fetch failed: ${res.status} ${res.statusText}`);
-  }
-
-  const body = await res.json();
-  const parsed = GatewayResponseSchema.safeParse(body);
-  if (!parsed.success) {
-    const reason = parsed.error.issues
-      .map(i => `${i.path.join(".")}: ${i.message}`)
-      .join("; ");
-    logger.warn("Gateway response failed Zod validation, skipping upsert", {
-      reason,
-    });
-    return { skipped: true, reason };
-  }
-
-  const languageModels = parsed.data.data.filter(m => m.type === "language");
+  const languageModels = entries.filter(m => m.type === "language");
   if (languageModels.length < 10) {
     const reason = `Only ${languageModels.length} language models after type filter`;
     logger.warn("Gateway snapshot too small, skipping upsert", { reason });
@@ -371,6 +362,86 @@ export async function refreshGatewaySnapshot(): Promise<
   }
 
   return { models: gatewayDocs.length, pricedModels: pricingDocs.length };
+}
+
+export async function refreshGatewaySnapshot(): Promise<
+  { models: number; pricedModels: number } | { skipped: true; reason: string }
+> {
+  const res = await fetch(GATEWAY_API_URL, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Gateway fetch failed: ${res.status} ${res.statusText}`);
+  }
+
+  const body = await res.json();
+  // All-or-nothing validation: a single malformed row skips the whole upsert.
+  const parsed = GatewayResponseSchema.safeParse(body);
+  if (!parsed.success) {
+    const reason = parsed.error.issues
+      .map(i => `${i.path.join(".")}: ${i.message}`)
+      .join("; ");
+    logger.warn("Gateway response failed Zod validation, skipping upsert", {
+      reason,
+    });
+    return { skipped: true, reason };
+  }
+
+  return persistLanguageSnapshot(parsed.data.data);
+}
+
+/**
+ * Resilient refresh: validates each upstream row independently and drops only
+ * the malformed ones instead of skipping the entire snapshot. Use when the
+ * strict refresh keeps reporting validation errors and new models aren't
+ * appearing because one bad row poisons the whole batch.
+ */
+export async function hardRefreshGatewaySnapshot(): Promise<
+  | { models: number; pricedModels: number; droppedEntries: number }
+  | { skipped: true; reason: string }
+> {
+  const res = await fetch(GATEWAY_API_URL, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Gateway fetch failed: ${res.status} ${res.statusText}`);
+  }
+
+  const body: unknown = await res.json();
+  const rawData =
+    body && typeof body === "object"
+      ? (body as { data?: unknown }).data
+      : undefined;
+  if (!Array.isArray(rawData)) {
+    throw new Error("Gateway response missing `data` array");
+  }
+
+  const validEntries: GatewayModelRaw[] = [];
+  let droppedEntries = 0;
+  for (const entry of rawData) {
+    const parsed = GatewayModelRawSchema.safeParse(entry);
+    if (parsed.success) {
+      validEntries.push(parsed.data);
+      continue;
+    }
+    droppedEntries += 1;
+    const id = (entry as { id?: unknown })?.id;
+    const reason = parsed.error.issues
+      .map(i => `${i.path.join(".")}: ${i.message}`)
+      .join("; ");
+    logger.warn("Dropping malformed gateway model entry", {
+      id: typeof id === "string" ? id : "unknown",
+      reason,
+    });
+  }
+
+  const result = await persistLanguageSnapshot(validEntries);
+  if ("skipped" in result) return result;
+  return { ...result, droppedEntries };
 }
 
 // ---------------------------------------------------------------------------
@@ -505,6 +576,40 @@ export async function adminRefreshCatalog(): Promise<
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     logger.error("Admin catalog refresh failed", { error: msg });
+    await setCurationRefreshError(msg);
+    return { ok: false, error: msg };
+  }
+}
+
+/**
+ * Admin "hard refresh": resilient per-row gateway parse that drops only
+ * malformed models, then busts BOTH caches — the Mongo-backed catalog cache
+ * (`warmCatalog`) and the separate in-process gateway-models cache
+ * (`warmModelsCache`) — so `/api/agent/gateway-models` can't keep serving a
+ * stale list after a refresh.
+ */
+export async function adminHardRefreshCatalog(): Promise<
+  | { ok: true; models: number; pricedModels: number; droppedEntries: number }
+  | { ok: false; error: string }
+> {
+  try {
+    const result = await hardRefreshGatewaySnapshot();
+    if ("skipped" in result) {
+      await setCurationRefreshError(`Skipped: ${result.reason}`);
+      return { ok: false, error: result.reason };
+    }
+    await setCurationRefreshError(null);
+    await warmCatalog();
+    await warmModelsCache();
+    return {
+      ok: true,
+      models: result.models,
+      pricedModels: result.pricedModels,
+      droppedEntries: result.droppedEntries,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error("Admin catalog hard refresh failed", { error: msg });
     await setCurationRefreshError(msg);
     return { ok: false, error: msg };
   }

--- a/app/src/pages/settings/SettingsAdmin.tsx
+++ b/app/src/pages/settings/SettingsAdmin.tsx
@@ -17,6 +17,7 @@ import {
   TableHead,
   TableRow,
   TextField,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import { Refresh as RefreshIcon } from "@mui/icons-material";
@@ -67,6 +68,7 @@ export default function SettingsAdmin() {
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
+  const [hardRefreshing, setHardRefreshing] = useState(false);
   const [refreshError, setRefreshError] = useState<string | null>(null);
   const [refreshNotice, setRefreshNotice] = useState<string | null>(null);
   const [search, setSearch] = useState("");
@@ -112,6 +114,38 @@ export default function SettingsAdmin() {
       setRefreshError(err instanceof Error ? err.message : String(err));
     } finally {
       setRefreshing(false);
+    }
+  };
+
+  const handleHardRefresh = async () => {
+    setHardRefreshing(true);
+    setRefreshError(null);
+    setRefreshNotice(null);
+    try {
+      const res = await apiJson<{
+        success: boolean;
+        refreshed?: {
+          models: number;
+          pricedModels: number;
+          droppedEntries?: number;
+        };
+        error?: string;
+      }>("/api/admin/catalog/hard-refresh", { method: "POST" });
+      if (!res.success) {
+        setRefreshError(res.error ?? "Unknown error");
+      } else if (res.refreshed) {
+        const dropped = res.refreshed.droppedEntries ?? 0;
+        setRefreshNotice(
+          `Hard refresh complete (${res.refreshed.models} models, ${res.refreshed.pricedModels} priced${
+            dropped ? `, ${dropped} invalid rows skipped` : ""
+          })`,
+        );
+      }
+      await loadCatalog();
+    } catch (err) {
+      setRefreshError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setHardRefreshing(false);
     }
   };
 
@@ -218,22 +252,47 @@ export default function SettingsAdmin() {
             <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
               Refresh catalog
             </Typography>
-            <Button
-              variant="contained"
-              size="small"
-              disableElevation
-              startIcon={
-                refreshing ? <CircularProgress size={14} /> : <RefreshIcon />
-              }
-              onClick={handleRefresh}
-              disabled={refreshing}
-            >
-              Refresh from AI Gateway
-            </Button>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+              <Button
+                variant="contained"
+                size="small"
+                disableElevation
+                startIcon={
+                  refreshing ? <CircularProgress size={14} /> : <RefreshIcon />
+                }
+                onClick={handleRefresh}
+                disabled={refreshing || hardRefreshing}
+              >
+                Refresh from AI Gateway
+              </Button>
+              <Tooltip title="Bypasses per-row validation (skips only malformed models) and clears all gateway caches. Use when new models aren't appearing.">
+                <span>
+                  <Button
+                    variant="outlined"
+                    color="warning"
+                    size="small"
+                    startIcon={
+                      hardRefreshing ? (
+                        <CircularProgress size={14} color="inherit" />
+                      ) : (
+                        <RefreshIcon />
+                      )
+                    }
+                    onClick={handleHardRefresh}
+                    disabled={refreshing || hardRefreshing}
+                  >
+                    Hard refresh
+                  </Button>
+                </span>
+              </Tooltip>
+            </Box>
           </Box>
           <Typography variant="body2" color="text.secondary">
             Pulls the latest model list + pricing from the Vercel AI Gateway.
-            Any validation errors are shown below.
+            Any validation errors are shown below. <strong>Hard refresh</strong>{" "}
+            validates each model row independently — dropping only malformed
+            rows instead of skipping the whole snapshot — and clears every
+            gateway cache, so use it when new models aren&apos;t showing up.
           </Typography>
           {data?.gatewayFetchedAt && (
             <Typography


### PR DESCRIPTION
## Summary

Adds a **"Hard refresh"** button to the Super Admin model catalog that fixes two root causes of new gateway models (e.g. `zai/glm-5.2`) never appearing in the catalogue UI.

- **Resilient per-row parse.** The existing "Refresh from AI Gateway" validates the upstream Vercel AI Gateway response with a single all-or-nothing `safeParse` — one malformed model row skips the *entire* snapshot upsert, freezing the catalog. The new `hardRefreshGatewaySnapshot()` validates each row independently, dropping only malformed rows (counted as `droppedEntries`) while still enforcing the `< 10` language-model floor.
- **Busts both caches.** There are two independent gateway caches (`model-catalog.service` snapshot/in-mem and the separate 1-hour `gateway-models.service` cache). The normal refresh only busts the first, so `/api/agent/gateway-models` could still serve a stale list. `adminHardRefreshCatalog()` busts **both** (`warmCatalog()` + `warmModelsCache()`).
- **UI.** A warning-colored, tooltipped "Hard refresh" button next to the existing one (both disable while either runs); the success notice surfaces the skipped-row count.

### Changes
- `api/src/services/model-catalog.service.ts` — extract shared tail into private `persistLanguageSnapshot()` (strict path unchanged), add `hardRefreshGatewaySnapshot()` + `adminHardRefreshCatalog()`.
- `api/src/routes/admin.routes.ts` — new `POST /api/admin/catalog/hard-refresh`.
- `app/src/pages/settings/SettingsAdmin.tsx` — "Hard refresh" button + handler.

## Test plan
- [ ] Super Admin → catalog: click **Hard refresh**, verify it returns the full gateway list including newly published models, and the notice shows model/priced counts (+ skipped rows if any).
- [ ] Confirm normal "Refresh from AI Gateway" behavior is unchanged (strict validation still skips on bad payloads).
- [ ] After a hard refresh, verify `/api/agent/gateway-models` reflects the fresh list immediately (no 1-hour stale window).
- [ ] `pnpm --filter api run lint` + `pnpm --filter app run typecheck && pnpm --filter app run lint` pass (verified locally).

Made with [Cursor](https://cursor.com)