### PR TITLE
feat(clickhouse): honor per-query database selection for cluster mode

### DIFF
--- a/api/src/routes/database-schemas.ts
+++ b/api/src/routes/database-schemas.ts
@@ -194,6 +194,8 @@ const DATABASE_SCHEMAS: Record<string, DatabaseSchemaResponse> = {
         type: "string",
         required: false,
         placeholder: "default",
+        helperText:
+          "Leave empty to browse all databases and switch between them (cluster mode)",
       },
       {
         name: "username",

--- a/api/src/services/database-connection.service.ts
+++ b/api/src/services/database-connection.service.ts
@@ -4182,7 +4182,10 @@ export class DatabaseConnectionService {
    * Supports both connection string and individual fields
    * Includes timeout and keep_alive settings for resilience
    */
-  private buildClickHouseClientConfig(database: IDatabaseConnection): {
+  private buildClickHouseClientConfig(
+    database: IDatabaseConnection,
+    databaseNameOverride?: string,
+  ): {
     url: string;
     username: string;
     password: string;
@@ -4206,6 +4209,11 @@ export class DatabaseConnectionService {
       const parsed = this.parseClickHouseConnectionString(
         conn.connectionString,
       );
+      // In cluster mode the active database is chosen per-query (e.g. from the
+      // console picker), so it must take precedence over the connection string.
+      if (databaseNameOverride) {
+        parsed.database = databaseNameOverride;
+      }
       return { ...parsed, ...baseConfig };
     }
 
@@ -4219,7 +4227,7 @@ export class DatabaseConnectionService {
       url: `${host}:${conn.port || 8123}`,
       username: conn.username || "default",
       password: conn.password || "",
-      database: conn.database || "default",
+      database: databaseNameOverride || conn.database || "default",
       ...baseConfig,
     };
   }
@@ -4285,7 +4293,13 @@ export class DatabaseConnectionService {
         return { success: false, error: "Query cancelled" };
       }
 
-      const config = this.buildClickHouseClientConfig(database);
+      // Honor a per-query database selection (cluster mode) so unqualified
+      // table references resolve against the chosen database, not just the
+      // connection's default.
+      const config = this.buildClickHouseClientConfig(
+        database,
+        options?.databaseName,
+      );
 
       // Track running query for cancellation
       if (executionId) {


### PR DESCRIPTION
## Summary

- ClickHouse query execution now respects `options.databaseName`, so the database chosen in the console picker (cluster mode) actually scopes unqualified table references — matching how PostgreSQL/MySQL already behave.
- `buildClickHouseClientConfig` accepts a runtime `databaseNameOverride` that takes precedence over both the connection's `database` field and any `?database=` baked into a connection string.
- Added a cluster-mode `helperText` to the ClickHouse connection form's Database field so users know to leave it empty to browse and switch between all databases.

## Why

The whole `databaseName` pipeline (console picker → `onDatabaseNameChange` → request body → route `options.databaseName` → driver) already existed end-to-end and was consumed by Postgres/MySQL. ClickHouse was the only driver throwing it away: `executeClickHouseQuery` always built the client with `database: conn.database || "default"`. As a result, even though the explorer tree lists every database via `SHOW DATABASES`, clicking a table in a different database and running an unqualified query hit the wrong DB — forcing users to fully-qualify `"db"."table"` or hardcode the database in the connection.

## Behavior after this change

1. Leave the ClickHouse connection's **Database** field empty → `isClusterMode` is true → the console database picker appears.
2. Pick a database from the dropdown → unqualified `SELECT * FROM my_table` resolves against it.
3. Fully-qualified `"db"."table"` still works for cross-database queries.
4. The explorer tree and connection test are unchanged (already database-agnostic).

## Test plan

- [ ] Create a ClickHouse connection with the Database field left empty; confirm the console shows the database picker and lists all non-system databases.
- [ ] Select a non-default database and run an unqualified `SELECT` against a table that only exists there; confirm it resolves.
- [ ] Repeat with a connection that uses a connection string containing `?database=foo`; confirm the picker selection overrides it.
- [ ] Confirm a connection with an explicit Database set still works (single-DB mode, no picker).

Made with [Cursor](https://cursor.com)