### PR TITLE
feat(stripe): bring connector to full CDC parity with Close/Calendly

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -13,7 +13,7 @@
     "worker:dev": "tsx watch src/worker.ts",
     "migrate:workspaces": "tsx src/migrations/migrate-to-workspaces.ts",
     "openapi:generate": "tsx src/openapi/generate-cli.ts",
-    "test": "tsx src/openapi/core.test.ts && tsx src/openapi/openapi.test.ts && tsx src/dbt/warm-dir-cache.test.ts",
+    "test": "tsx src/openapi/core.test.ts && tsx src/openapi/openapi.test.ts && tsx src/dbt/warm-dir-cache.test.ts && tsx src/connectors/stripe/connector.test.ts",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives",
     "lint:fix": "eslint . --ext ts,tsx --fix"
   },

--- a/api/src/connectors/stripe/connector.test.ts
+++ b/api/src/connectors/stripe/connector.test.ts
@@ -1,0 +1,283 @@
+import assert from "node:assert/strict";
+import { StripeConnector } from "./connector";
+
+function createConnector(config: Record<string, unknown> = {}) {
+  return new StripeConnector({
+    id: "ds_stripe",
+    name: "Stripe",
+    type: "stripe",
+    config: { api_key: "sk_test_123", ...config },
+  } as any);
+}
+
+// 1700000000 seconds = 2023-11-14T22:13:20.000Z
+const CREATED_EPOCH = 1700000000;
+const CREATED_MS = CREATED_EPOCH * 1000;
+
+function testConfigValidationRequiresApiKey() {
+  const connector = createConnector({ api_key: "" });
+  const result = connector.validateConfig();
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some(error => error.includes("API key")));
+}
+
+function testAvailableEntitiesIncludeModernEntities() {
+  const connector = createConnector();
+  const entities = connector.getAvailableEntities();
+  assert.ok(entities.includes("payment_intents"));
+  assert.ok(entities.includes("prices"));
+  assert.ok(entities.includes("plans"));
+
+  const metadata = connector.getEntityMetadata().map(entry => entry.name);
+  assert.ok(metadata.includes("payment_intents"));
+  assert.ok(metadata.includes("prices"));
+}
+
+function testResolveRecordTimestampUsesEpochCreated() {
+  const connector = createConnector() as unknown as {
+    resolveRecordTimestamp(payload: Record<string, unknown>): Date;
+  };
+
+  const date = connector.resolveRecordTimestamp({
+    id: "ch_1",
+    created: CREATED_EPOCH,
+  });
+  assert.ok(date instanceof Date);
+  assert.equal(date.getTime(), CREATED_MS);
+}
+
+function testResolveRecordTimestampHandlesMillisGuard() {
+  const connector = createConnector() as unknown as {
+    resolveRecordTimestamp(payload: Record<string, unknown>): Date;
+  };
+  // Already-millis epoch (> 1e12) should not be multiplied again.
+  const date = connector.resolveRecordTimestamp({ created: CREATED_MS });
+  assert.equal(date.getTime(), CREATED_MS);
+}
+
+function testResolveRecordTimestampFallsBackToStringFields() {
+  const connector = createConnector() as unknown as {
+    resolveRecordTimestamp(payload: Record<string, unknown>): Date;
+  };
+  const iso = "2026-05-20T07:00:00.000Z";
+  const date = connector.resolveRecordTimestamp({ updated_at: iso });
+  assert.equal(date.toISOString(), iso);
+}
+
+async function testResolveSchema() {
+  const connector = createConnector();
+  for (const entity of [
+    "customers",
+    "subscriptions",
+    "charges",
+    "invoices",
+    "products",
+    "plans",
+    "prices",
+    "payment_intents",
+  ]) {
+    const schema = await connector.resolveSchema(entity);
+    assert.ok(schema, `expected schema for ${entity}`);
+    assert.equal(schema?.entity, entity);
+    assert.equal(schema?.unknownFieldPolicy, "string");
+    assert.deepEqual(schema?.keyColumns, ["id"]);
+    assert.equal(schema?.fields.id?.type, "string");
+    assert.equal(schema?.fields.created?.type, "timestamp");
+  }
+
+  const charge = await connector.resolveSchema("charges");
+  assert.equal(charge?.fields.amount?.type, "integer");
+  assert.equal(charge?.fields.currency?.type, "string");
+  assert.equal(charge?.fields.billing_details?.type, "json");
+
+  assert.equal(await connector.resolveSchema("not_real"), null);
+}
+
+function testNormalizeBackfillRecordTsParityWithWebhook() {
+  const connector = createConnector();
+
+  const object = {
+    id: "pi_123",
+    object: "payment_intent",
+    created: CREATED_EPOCH,
+    amount: 4200,
+    currency: "usd",
+    status: "succeeded",
+  };
+
+  const backfill = connector.normalizeBackfillRecord("payment_intents", object);
+  assert.ok(backfill);
+  assert.equal(backfill?.recordId, "pi_123");
+  assert.equal(backfill?.source, "backfill");
+  assert.equal(backfill?.sourceTs.getTime(), CREATED_MS);
+
+  const webhookRecords = connector.extractWebhookCdcRecords(
+    {
+      id: "evt_1",
+      type: "payment_intent.succeeded",
+      data: { object },
+    },
+    "payment_intent.succeeded",
+  );
+
+  assert.equal(webhookRecords.length, 1);
+  const webhook = webhookRecords[0];
+  assert.equal(webhook.entity, "payment_intents");
+  assert.equal(webhook.recordId, "pi_123");
+  // Backfill and webhook records must agree on the source timestamp.
+  assert.equal(backfill?.sourceTs.getTime(), webhook.sourceTs.getTime());
+}
+
+function testPriceEventsMapToPricesEntity() {
+  const connector = createConnector();
+  assert.deepEqual(connector.getWebhookEventMapping("price.created"), {
+    entity: "prices",
+    operation: "upsert",
+  });
+  assert.deepEqual(connector.getWebhookEventMapping("price.updated"), {
+    entity: "prices",
+    operation: "upsert",
+  });
+  assert.deepEqual(connector.getWebhookEventMapping("price.deleted"), {
+    entity: "prices",
+    operation: "delete",
+  });
+
+  // Legacy plan events still map to the plans entity.
+  assert.deepEqual(connector.getWebhookEventMapping("plan.created"), {
+    entity: "plans",
+    operation: "upsert",
+  });
+
+  assert.deepEqual(
+    connector.getWebhookEventMapping("payment_intent.succeeded"),
+    { entity: "payment_intents", operation: "upsert" },
+  );
+}
+
+function testWebhookEventsForEntities() {
+  const connector = createConnector();
+
+  assert.deepEqual(connector.getWebhookEventsForEntities(["prices"]).sort(), [
+    "price.created",
+    "price.deleted",
+    "price.updated",
+  ]);
+
+  const piEvents = connector
+    .getWebhookEventsForEntities(["payment_intents"])
+    .sort();
+  assert.deepEqual(piEvents, [
+    "payment_intent.canceled",
+    "payment_intent.created",
+    "payment_intent.payment_failed",
+    "payment_intent.succeeded",
+  ]);
+
+  // Empty selection subscribes to everything.
+  assert.deepEqual(
+    connector.getWebhookEventsForEntities([]),
+    connector.getSupportedWebhookEvents(),
+  );
+}
+
+function testSupportsWebhookProvisioning() {
+  const connector = createConnector();
+  assert.equal(connector.supportsWebhooks(), true);
+  assert.equal(connector.supportsWebhookProvisioning(), true);
+}
+
+async function testCreateWebhookSubscriptionPayload() {
+  const connector = createConnector();
+
+  let capturedParams: any;
+  // Inject a mock Stripe client so no real API call is made.
+  (connector as any).stripe = {
+    webhookEndpoints: {
+      create: async (params: any) => {
+        capturedParams = params;
+        return {
+          id: "we_test_123",
+          url: params.url,
+          secret: "whsec_mock_secret",
+        };
+      },
+    },
+  };
+
+  const result = await connector.createWebhookSubscription({
+    endpointUrl: "https://example.com/api/webhooks/ws/flow",
+    enabledEntities: ["prices"],
+  });
+
+  assert.equal(result.providerWebhookId, "we_test_123");
+  assert.equal(result.endpointUrl, "https://example.com/api/webhooks/ws/flow");
+  assert.equal(result.signingSecret, "whsec_mock_secret");
+
+  assert.equal(capturedParams.url, "https://example.com/api/webhooks/ws/flow");
+  assert.equal(capturedParams.api_version, "2023-10-16");
+  assert.deepEqual([...capturedParams.enabled_events].sort(), [
+    "price.created",
+    "price.deleted",
+    "price.updated",
+  ]);
+}
+
+async function testCreateWebhookSubscriptionRejectsUnknownEvents() {
+  const connector = createConnector();
+  (connector as any).stripe = {
+    webhookEndpoints: { create: async () => ({ id: "x", url: "y" }) },
+  };
+
+  await assert.rejects(
+    () =>
+      connector.createWebhookSubscription({
+        endpointUrl: "https://example.com/hook",
+        events: ["not.a.real.event"],
+      }),
+    /No valid Stripe webhook events/,
+  );
+}
+
+function testHostConfigFromApiBaseUrl() {
+  const connector = createConnector({
+    api_base_url: "http://localhost:12111",
+  }) as unknown as {
+    resolveHostConfig(): Record<string, unknown>;
+  };
+  assert.deepEqual(connector.resolveHostConfig(), {
+    host: "localhost",
+    protocol: "http",
+    port: 12111,
+  });
+
+  const defaultConnector = createConnector({
+    api_base_url: "https://api.stripe.com",
+  }) as unknown as { resolveHostConfig(): Record<string, unknown> };
+  assert.deepEqual(defaultConnector.resolveHostConfig(), {});
+
+  const noUrlConnector = createConnector() as unknown as {
+    resolveHostConfig(): Record<string, unknown>;
+  };
+  assert.deepEqual(noUrlConnector.resolveHostConfig(), {});
+}
+
+async function main() {
+  testConfigValidationRequiresApiKey();
+  testAvailableEntitiesIncludeModernEntities();
+  testResolveRecordTimestampUsesEpochCreated();
+  testResolveRecordTimestampHandlesMillisGuard();
+  testResolveRecordTimestampFallsBackToStringFields();
+  await testResolveSchema();
+  testNormalizeBackfillRecordTsParityWithWebhook();
+  testPriceEventsMapToPricesEntity();
+  testWebhookEventsForEntities();
+  testSupportsWebhookProvisioning();
+  await testCreateWebhookSubscriptionPayload();
+  await testCreateWebhookSubscriptionRejectsUnknownEvents();
+  testHostConfigFromApiBaseUrl();
+}
+
+main().catch((error: unknown) => {
+  throw error;
+});

--- a/api/src/connectors/stripe/connector.ts
+++ b/api/src/connectors/stripe/connector.ts
@@ -8,11 +8,34 @@ import {
   WebhookHandlerOptions,
   WebhookEventMapping,
   EntityMetadata,
+  NormalizedCdcRecord,
+  ProvisionWebhookOptions,
+  ProvisionWebhookResult,
+  type ConnectorEntitySchema,
 } from "../base/BaseConnector";
 import Stripe from "stripe";
+import { resolveStripeEntitySchema } from "./schema";
 import { loggers } from "../../logging";
 
 const logger = loggers.connector("stripe");
+
+// Single source of truth for the Stripe API version so the SDK client and
+// webhook provisioning stay in sync.
+const STRIPE_API_VERSION: Stripe.LatestApiVersion = "2023-10-16";
+
+const STRIPE_DEFAULT_HOST = "api.stripe.com";
+
+// Entities that can be backfilled and webhook-materialized.
+const STRIPE_ENTITIES = [
+  "customers",
+  "subscriptions",
+  "charges",
+  "invoices",
+  "products",
+  "plans",
+  "prices",
+  "payment_intents",
+] as const;
 
 export class StripeConnector extends BaseConnector {
   private stripe: Stripe | null = null;
@@ -44,14 +67,7 @@ export class StripeConnector extends BaseConnector {
       name: "Stripe",
       version: "1.0.0",
       description: "Connector for Stripe payment platform",
-      supportedEntities: [
-        "customers",
-        "subscriptions",
-        "charges",
-        "invoices",
-        "products",
-        "plans",
-      ],
+      supportedEntities: [...STRIPE_ENTITIES],
     };
   }
 
@@ -72,10 +88,95 @@ export class StripeConnector extends BaseConnector {
         throw new Error("Stripe API key not configured");
       }
       this.stripe = new Stripe(this.dataSource.config.api_key, {
-        apiVersion: "2023-10-16",
+        apiVersion: STRIPE_API_VERSION,
+        ...this.resolveHostConfig(),
       });
     }
     return this.stripe;
+  }
+
+  /**
+   * Derive Stripe SDK host/protocol/port from the optional `api_base_url`
+   * config field so the schema field is actually wired (rule 15). Defaults to
+   * Stripe's public API host when unset or unparseable.
+   */
+  private resolveHostConfig(): Pick<
+    Stripe.StripeConfig,
+    "host" | "protocol" | "port"
+  > {
+    const baseUrl = this.dataSource.config.api_base_url;
+    if (!baseUrl || typeof baseUrl !== "string") {
+      return {};
+    }
+
+    try {
+      const url = new URL(baseUrl);
+      if (url.hostname === STRIPE_DEFAULT_HOST) {
+        return {};
+      }
+      const protocol = url.protocol.replace(/:$/, "");
+      return {
+        host: url.hostname,
+        protocol: protocol === "http" ? "http" : "https",
+        ...(url.port ? { port: Number(url.port) } : {}),
+      };
+    } catch {
+      logger.warn("Ignoring invalid Stripe api_base_url", { baseUrl });
+      return {};
+    }
+  }
+
+  async resolveSchema(entity: string): Promise<ConnectorEntitySchema | null> {
+    return resolveStripeEntitySchema(entity);
+  }
+
+  /**
+   * Stripe exposes timestamps as Unix-seconds integers (`created`, `*_at`),
+   * not ISO strings. The base resolver only understands string/Date fields, so
+   * Stripe records would otherwise default to `new Date()` and corrupt CDC
+   * ordering/dedup. Convert numeric epochs (seconds) to Dates here.
+   */
+  protected resolveRecordTimestamp(payload?: Record<string, unknown>): Date {
+    const epochCandidates = [
+      payload?.created,
+      payload?.start_date,
+      (payload as Record<string, unknown> | undefined)?.["updated"],
+    ];
+
+    for (const candidate of epochCandidates) {
+      if (typeof candidate === "number" && Number.isFinite(candidate)) {
+        // Stripe epochs are seconds; guard against accidental millis.
+        const ms = candidate > 1e12 ? candidate : candidate * 1000;
+        const date = new Date(ms);
+        if (!Number.isNaN(date.getTime())) {
+          return date;
+        }
+      }
+    }
+
+    return super.resolveRecordTimestamp(payload);
+  }
+
+  /**
+   * Stripe `list()` rows and webhook `event.data.object` payloads share the
+   * same object shape, so no per-entity flattening is needed. We only re-derive
+   * `sourceTs` via the Stripe-aware resolver and pin `recordId` to `id` so
+   * backfill rows match webhook records emitted by `extractWebhookCdcRecords`.
+   */
+  normalizeBackfillRecord(
+    entity: string,
+    record: Record<string, unknown>,
+  ): NormalizedCdcRecord | null {
+    const normalized = super.normalizeBackfillRecord(entity, record);
+    if (!normalized) {
+      return null;
+    }
+
+    return {
+      ...normalized,
+      recordId: String(record.id ?? normalized.recordId),
+      sourceTs: this.resolveRecordTimestamp(record),
+    };
   }
 
   async testConnection(): Promise<ConnectionTestResult> {
@@ -108,14 +209,7 @@ export class StripeConnector extends BaseConnector {
   }
 
   getAvailableEntities(): string[] {
-    return [
-      "customers",
-      "subscriptions",
-      "charges",
-      "invoices",
-      "products",
-      "plans",
-    ];
+    return [...STRIPE_ENTITIES];
   }
 
   getEntityMetadata(): EntityMetadata[] {
@@ -132,6 +226,8 @@ export class StripeConnector extends BaseConnector {
       { name: "invoices", label: "Invoices", layoutSuggestion },
       { name: "products", label: "Products", layoutSuggestion },
       { name: "plans", label: "Plans", layoutSuggestion },
+      { name: "prices", label: "Prices", layoutSuggestion },
+      { name: "payment_intents", label: "Payment Intents", layoutSuggestion },
     ];
   }
 
@@ -221,6 +317,26 @@ export class StripeConnector extends BaseConnector {
 
         case "plans":
           response = await stripe.plans.list({
+            limit: batchSize,
+            ...(startingAfter && { starting_after: startingAfter }),
+            ...(since && {
+              created: { gte: Math.floor(since.getTime() / 1000) },
+            }),
+          });
+          break;
+
+        case "prices":
+          response = await stripe.prices.list({
+            limit: batchSize,
+            ...(startingAfter && { starting_after: startingAfter }),
+            ...(since && {
+              created: { gte: Math.floor(since.getTime() / 1000) },
+            }),
+          });
+          break;
+
+        case "payment_intents":
+          response = await stripe.paymentIntents.list({
             limit: batchSize,
             ...(startingAfter && { starting_after: startingAfter }),
             ...(since && {
@@ -339,6 +455,26 @@ export class StripeConnector extends BaseConnector {
 
         case "plans":
           response = await stripe.plans.list({
+            limit: batchSize,
+            ...(startingAfter && { starting_after: startingAfter }),
+            ...(since && {
+              created: { gte: Math.floor(since.getTime() / 1000) },
+            }),
+          });
+          break;
+
+        case "prices":
+          response = await stripe.prices.list({
+            limit: batchSize,
+            ...(startingAfter && { starting_after: startingAfter }),
+            ...(since && {
+              created: { gte: Math.floor(since.getTime() / 1000) },
+            }),
+          });
+          break;
+
+        case "payment_intents":
+          response = await stripe.paymentIntents.list({
             limit: batchSize,
             ...(startingAfter && { starting_after: startingAfter }),
             ...(since && {
@@ -523,10 +659,11 @@ export class StripeConnector extends BaseConnector {
       "product.updated": { entity: "products", operation: "upsert" },
       "product.deleted": { entity: "products", operation: "delete" },
 
-      // Prices/Plans
-      "price.created": { entity: "plans", operation: "upsert" },
-      "price.updated": { entity: "plans", operation: "upsert" },
-      "price.deleted": { entity: "plans", operation: "delete" },
+      // Prices (modern API → `prices` entity)
+      "price.created": { entity: "prices", operation: "upsert" },
+      "price.updated": { entity: "prices", operation: "upsert" },
+      "price.deleted": { entity: "prices", operation: "delete" },
+      // Plans (legacy API → `plans` entity, kept for back-compat)
       "plan.created": { entity: "plans", operation: "upsert" },
       "plan.updated": { entity: "plans", operation: "upsert" },
       "plan.deleted": { entity: "plans", operation: "delete" },
@@ -581,6 +718,90 @@ export class StripeConnector extends BaseConnector {
       "plan.updated",
       "plan.deleted",
     ];
+  }
+
+  /**
+   * Return only the webhook event strings relevant to the given entities.
+   * Falls back to all supported events when the entity list is empty
+   * (no explicit selection — subscribe to everything).
+   */
+  getWebhookEventsForEntities(entities: string[]): string[] {
+    if (entities.length === 0) {
+      return this.getSupportedWebhookEvents();
+    }
+
+    const entitySet = new Set(entities.map(e => e.toLowerCase()));
+    return this.getSupportedWebhookEvents().filter(eventType => {
+      const mapping = this.getWebhookEventMapping(eventType);
+      return mapping ? entitySet.has(mapping.entity.toLowerCase()) : false;
+    });
+  }
+
+  /**
+   * Check if connector can provision provider webhooks automatically.
+   */
+  supportsWebhookProvisioning(): boolean {
+    return true;
+  }
+
+  /**
+   * Create a Stripe webhook endpoint subscribed to the events for the
+   * selected entities. Makes `POST /flows/:id/provision-webhook` work
+   * end-to-end without manual dashboard setup.
+   */
+  async createWebhookSubscription(
+    options: ProvisionWebhookOptions,
+  ): Promise<ProvisionWebhookResult> {
+    const stripe = this.getStripeClient();
+
+    const requestedEvents = Array.isArray(options.events)
+      ? options.events
+          .map(event => event.trim())
+          .filter((event): event is string => event.length > 0)
+      : [];
+
+    const supported = new Set(this.getSupportedWebhookEvents());
+    const effectiveEvents = (
+      requestedEvents.length > 0
+        ? requestedEvents
+        : this.getWebhookEventsForEntities(options.enabledEntities ?? [])
+    ).filter(event => supported.has(event));
+
+    if (effectiveEvents.length === 0) {
+      throw new Error(
+        requestedEvents.length > 0
+          ? `No valid Stripe webhook events configured. Unsupported events: ${requestedEvents.join(", ")}`
+          : "No webhook events resolved for the selected entities",
+      );
+    }
+
+    try {
+      const endpoint = await stripe.webhookEndpoints.create({
+        url: options.endpointUrl,
+        enabled_events:
+          effectiveEvents as Stripe.WebhookEndpointCreateParams.EnabledEvent[],
+        api_version: STRIPE_API_VERSION,
+      });
+
+      return {
+        providerWebhookId: endpoint.id,
+        endpointUrl: endpoint.url,
+        signingSecret:
+          typeof endpoint.secret === "string" && endpoint.secret.length > 0
+            ? endpoint.secret
+            : undefined,
+      };
+    } catch (error) {
+      const message =
+        error instanceof Stripe.errors.StripeError
+          ? error.message
+          : error instanceof Error
+            ? error.message
+            : String(error);
+      throw new Error(
+        `Failed to create Stripe webhook subscription: ${message}`,
+      );
+    }
   }
 
   /**

--- a/api/src/connectors/stripe/schema.ts
+++ b/api/src/connectors/stripe/schema.ts
@@ -1,0 +1,288 @@
+import {
+  type ConnectorFieldSchema,
+  type ConnectorEntitySchema,
+  MAKO_SYSTEM_FIELDS,
+} from "../base/BaseConnector";
+
+const s = (nullable = true): ConnectorFieldSchema => ({
+  type: "string",
+  nullable,
+});
+const ts = (nullable = true): ConnectorFieldSchema => ({
+  type: "timestamp",
+  nullable,
+});
+const i = (nullable = true): ConnectorFieldSchema => ({
+  type: "integer",
+  nullable,
+});
+const b = (nullable = true): ConnectorFieldSchema => ({
+  type: "boolean",
+  nullable,
+});
+const j = (nullable = true): ConnectorFieldSchema => ({
+  type: "json",
+  nullable,
+});
+
+// ---------------------------------------------------------------------------
+// Fields common to every Stripe object. `created` is a Unix-seconds epoch
+// integer in the raw payload but is declared as `timestamp`; the CDC
+// normalizer coerces numeric epochs (seconds) into Dates.
+// ---------------------------------------------------------------------------
+
+const COMMON_STRIPE_SCHEMA: Record<string, ConnectorFieldSchema> = {
+  id: { type: "string", required: true },
+  object: s(),
+  created: ts(),
+  livemode: b(),
+  metadata: j(),
+  ...MAKO_SYSTEM_FIELDS,
+};
+
+export const CUSTOMER_SCHEMA: Record<string, ConnectorFieldSchema> = {
+  ...COMMON_STRIPE_SCHEMA,
+  email: s(),
+  name: s(),
+  description: s(),
+  phone: s(),
+  currency: s(),
+  balance: i(),
+  delinquent: b(),
+  default_source: s(),
+  invoice_prefix: s(),
+  tax_exempt: s(),
+  test_clock: s(),
+  next_invoice_sequence: i(),
+  address: j(),
+  shipping: j(),
+  discount: j(),
+  invoice_settings: j(),
+  preferred_locales: j(),
+  sources: j(),
+  subscriptions: j(),
+  tax_ids: j(),
+};
+
+export const SUBSCRIPTION_SCHEMA: Record<string, ConnectorFieldSchema> = {
+  ...COMMON_STRIPE_SCHEMA,
+  customer: s(),
+  status: s(),
+  currency: s(),
+  collection_method: s(),
+  default_payment_method: s(),
+  default_source: s(),
+  latest_invoice: s(),
+  schedule: s(),
+  description: s(),
+  start_date: ts(),
+  current_period_start: ts(),
+  current_period_end: ts(),
+  billing_cycle_anchor: ts(),
+  canceled_at: ts(),
+  cancel_at: ts(),
+  ended_at: ts(),
+  trial_start: ts(),
+  trial_end: ts(),
+  cancel_at_period_end: b(),
+  days_until_due: i(),
+  quantity: i(),
+  items: j(),
+  plan: j(),
+  discount: j(),
+  default_tax_rates: j(),
+  pause_collection: j(),
+  pending_update: j(),
+  automatic_tax: j(),
+  cancellation_details: j(),
+};
+
+export const CHARGE_SCHEMA: Record<string, ConnectorFieldSchema> = {
+  ...COMMON_STRIPE_SCHEMA,
+  amount: i(),
+  amount_captured: i(),
+  amount_refunded: i(),
+  currency: s(),
+  customer: s(),
+  status: s(),
+  description: s(),
+  receipt_email: s(),
+  receipt_url: s(),
+  receipt_number: s(),
+  payment_intent: s(),
+  payment_method: s(),
+  invoice: s(),
+  balance_transaction: s(),
+  failure_code: s(),
+  failure_message: s(),
+  calculated_statement_descriptor: s(),
+  statement_descriptor: s(),
+  captured: b(),
+  paid: b(),
+  refunded: b(),
+  disputed: b(),
+  billing_details: j(),
+  payment_method_details: j(),
+  outcome: j(),
+  refunds: j(),
+  fraud_details: j(),
+  shipping: j(),
+};
+
+export const INVOICE_SCHEMA: Record<string, ConnectorFieldSchema> = {
+  ...COMMON_STRIPE_SCHEMA,
+  customer: s(),
+  subscription: s(),
+  status: s(),
+  currency: s(),
+  number: s(),
+  collection_method: s(),
+  billing_reason: s(),
+  hosted_invoice_url: s(),
+  invoice_pdf: s(),
+  payment_intent: s(),
+  charge: s(),
+  customer_email: s(),
+  customer_name: s(),
+  amount_due: i(),
+  amount_paid: i(),
+  amount_remaining: i(),
+  subtotal: i(),
+  tax: i(),
+  total: i(),
+  attempt_count: i(),
+  period_start: ts(),
+  period_end: ts(),
+  due_date: ts(),
+  paid: b(),
+  attempted: b(),
+  auto_advance: b(),
+  lines: j(),
+  discount: j(),
+  discounts: j(),
+  customer_address: j(),
+  customer_shipping: j(),
+  status_transitions: j(),
+  total_tax_amounts: j(),
+};
+
+export const PRODUCT_SCHEMA: Record<string, ConnectorFieldSchema> = {
+  ...COMMON_STRIPE_SCHEMA,
+  updated: ts(),
+  name: s(),
+  description: s(),
+  type: s(),
+  default_price: s(),
+  url: s(),
+  unit_label: s(),
+  statement_descriptor: s(),
+  tax_code: s(),
+  active: b(),
+  shippable: b(),
+  images: j(),
+  package_dimensions: j(),
+  features: j(),
+  marketing_features: j(),
+};
+
+// Legacy plans (stripe.plans.list). Retained for back-compat; `price.*`
+// webhook events now target the `prices` entity instead.
+export const PLAN_SCHEMA: Record<string, ConnectorFieldSchema> = {
+  ...COMMON_STRIPE_SCHEMA,
+  nickname: s(),
+  product: s(),
+  currency: s(),
+  interval: s(),
+  usage_type: s(),
+  billing_scheme: s(),
+  aggregate_usage: s(),
+  amount_decimal: s(),
+  active: b(),
+  amount: i(),
+  interval_count: i(),
+  trial_period_days: i(),
+  tiers: j(),
+  tiers_mode: j(),
+  transform_usage: j(),
+};
+
+export const PAYMENT_INTENT_SCHEMA: Record<string, ConnectorFieldSchema> = {
+  ...COMMON_STRIPE_SCHEMA,
+  amount: i(),
+  amount_received: i(),
+  amount_capturable: i(),
+  currency: s(),
+  customer: s(),
+  status: s(),
+  description: s(),
+  receipt_email: s(),
+  payment_method: s(),
+  latest_charge: s(),
+  invoice: s(),
+  client_secret: s(),
+  capture_method: s(),
+  confirmation_method: s(),
+  setup_future_usage: s(),
+  cancellation_reason: s(),
+  statement_descriptor: s(),
+  canceled_at: ts(),
+  payment_method_types: j(),
+  charges: j(),
+  next_action: j(),
+  last_payment_error: j(),
+  automatic_payment_methods: j(),
+  payment_method_options: j(),
+  shipping: j(),
+  amount_details: j(),
+};
+
+// Modern prices (stripe.prices.list) — target for `price.*` webhook events.
+export const PRICE_SCHEMA: Record<string, ConnectorFieldSchema> = {
+  ...COMMON_STRIPE_SCHEMA,
+  nickname: s(),
+  product: s(),
+  currency: s(),
+  type: s(),
+  billing_scheme: s(),
+  tax_behavior: s(),
+  tiers_mode: s(),
+  lookup_key: s(),
+  unit_amount_decimal: s(),
+  active: b(),
+  unit_amount: i(),
+  recurring: j(),
+  tiers: j(),
+  transform_quantity: j(),
+  custom_unit_amount: j(),
+  currency_options: j(),
+};
+
+export const STRIPE_ENTITY_SCHEMA_MAP: Record<
+  string,
+  Record<string, ConnectorFieldSchema>
+> = {
+  customers: CUSTOMER_SCHEMA,
+  subscriptions: SUBSCRIPTION_SCHEMA,
+  charges: CHARGE_SCHEMA,
+  invoices: INVOICE_SCHEMA,
+  products: PRODUCT_SCHEMA,
+  plans: PLAN_SCHEMA,
+  payment_intents: PAYMENT_INTENT_SCHEMA,
+  prices: PRICE_SCHEMA,
+};
+
+export function resolveStripeEntitySchema(
+  entity: string,
+): ConnectorEntitySchema | null {
+  const fields = STRIPE_ENTITY_SCHEMA_MAP[entity];
+  if (!fields) {
+    return null;
+  }
+
+  return {
+    entity,
+    fields,
+    unknownFieldPolicy: "string",
+    keyColumns: ["id"],
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview

Closes correctness/parity gaps in the Stripe connector so it behaves like the reference CDC connectors (`close` / `calendly`). All changes are inside `api/src/connectors/stripe/**` — no CDC engine, adapter, or route changes.

## Changes

### 1. Source-timestamp resolution (`resolveRecordTimestamp`)
Stripe exposes timestamps as Unix‑seconds integers (`created`, `start_date`), which the base resolver doesn't understand — so every Stripe record's `sourceTs` defaulted to `new Date()`, corrupting CDC ordering/dedup and `_mako_source_ts`. The override converts numeric epochs (seconds → ms, with a `> 1e12` millis guard) to `Date`, falling back to the base string/Date resolver otherwise.

### 2. Typed entity schema (`schema.ts` + `resolveSchema`)
New `api/src/connectors/stripe/schema.ts` mirrors Close's `resolveCloseEntitySchema`. Every entity returns `keyColumns: ["id"]`, `unknownFieldPolicy: "string"`, `id: string`, `created: timestamp` (the CDC normalizer coerces epoch seconds), money fields as `integer`, status/currency as `string`, and nested objects as `json`.

### 3. Backfill/webhook shape parity (`normalizeBackfillRecord`)
Calls `super`, then re-derives `sourceTs` via the Stripe‑aware resolver and pins `recordId = record.id`, so `list()` backfill rows and webhook `event.data.object` payloads produce identical canonical records.

### 4. Entities aligned with webhook events (modern API)
- Added `payment_intents` (was webhook‑mapped but missing from `getAvailableEntities()`), backfilled via `stripe.paymentIntents.list`.
- Added `prices` (modern `stripe.prices.list`); remapped `price.*` webhooks to the `prices` entity.
- Kept legacy `plans` entity + `plan.*` mapping for back-compat.
- Added the matching `case` branches in both `fetchEntity` and `fetchEntityChunk`.

### 5. Webhook auto-provisioning
`supportsWebhookProvisioning(): true` + `createWebhookSubscription()` using `stripe.webhookEndpoints.create({ url, enabled_events, api_version })`, returning `{ providerWebhookId, endpointUrl, signingSecret }`. A new `getWebhookEventsForEntities()` filters events to the selected entities so provisioning only subscribes to enabled entities. Makes `POST /flows/:id/provision-webhook` work end‑to‑end.

### 6. Connector-agnostic cleanup
- Wired the previously-dead `api_base_url` schema field into the Stripe client via `host`/`protocol`/`port` (rule 15).
- Centralized the hardcoded API version into a single `STRIPE_API_VERSION` constant shared by the client and provisioning.

### 7. Tests
Added `api/src/connectors/stripe/connector.test.ts` (Stripe had none) covering epoch timestamp resolution, schema keyColumns/types, backfill↔webhook ts parity, `price.*` → `prices` mapping, `getWebhookEventsForEntities`, `createWebhookSubscription` payload (mocked `webhookEndpoints.create`), and `api_base_url` host parsing. Wired into the api `test` script.

## Validation
- `pnpm --filter api run lint` ✅
- `pnpm --filter api run test` ✅ (incl. new Stripe tests)
- `tsc -p tsconfig.build.json --noEmit` ✅

## Out of scope
No changes to `api/src/sync-cdc/**`, `api/src/inngest/**`, or `api/src/routes/webhooks.ts`; no new destination adapters.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-880a5ba4-7f22-4132-80f3-10fb887e6526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-880a5ba4-7f22-4132-80f3-10fb887e6526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

