### PR TITLE
docs(connectors): reflect Stripe CDC parity + new entities (#527)

### DIFF
--- a/docs/src/content/docs/connectors.md
+++ b/docs/src/content/docs/connectors.md
@@ -13,7 +13,7 @@ Connectors pull data from external services and sync it into your connected data
 
 | Connector     | Source          | Entities                                                                         |
 | ------------- | --------------- | -------------------------------------------------------------------------------- |
-| **Stripe**    | Stripe API      | Customers, Subscriptions, Charges, Invoices, Products, Plans                     |
+| **Stripe**    | Stripe API      | Customers, Subscriptions, Charges, Invoices, Products, Prices, Plans, Payment Intents. *Supports backfill and CDC webhooks (auto-provisioning via Stripe webhook endpoints).* |
 | **Close CRM** | Close API       | Leads, Opportunities, Activities (10+ sub-types), Contacts, Users, Custom Fields. *Webhooks are automatically scoped to synced entities only.* |
 | **Claap**     | Claap API       | Recordings, Workspace. *Supports backfill and CDC webhooks (auto-provisioning via "Create in Claap").* |
 | **PostHog**   | PostHog HogQL   | Dynamic — each configured HogQL query becomes an entity                          |


### PR DESCRIPTION
## What

PR #527 brought the Stripe connector to CDC parity with Close/Calendly:
- CDC webhooks with auto-provisioning (`supportsWebhookProvisioning` + `createWebhookSubscription` via `stripe.webhookEndpoints.create`)
- New entities: **Prices** (modern `prices.list`) and **Payment Intents**
- Typed schemas + correct `_mako_source_ts` from Stripe Unix epochs

The `connectors.md` Available Connectors table still listed the old entity set and no webhook support for Stripe, which now misrepresents the connector.

## Change
Single-row update to the Stripe entry: added Prices + Payment Intents and the CDC/auto-provisioning note, matching the Close/Claap row pattern.

Verified against `api/src/connectors/stripe/{connector,schema}.ts` at 022ea933.

🤖 Generated by mako-docs-maintenance