### PR TITLE
fix(api): stop AI Models settings page hanging on /gateway-models

### DIFF
--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -27,8 +27,7 @@ import {
   getDefaultModelId,
   getDefaultFreeModelId,
 } from "../agent-lib/ai-models";
-import { getGatewayModels } from "../services/gateway-models.service";
-import { getCatalogModels } from "../services/model-catalog.service";
+import { getWorkspaceGatewayModelListings } from "../services/model-catalog.service";
 import {
   Workspace,
   DatabaseConnection,
@@ -313,15 +312,9 @@ agentRoutes.openapi(
 /**
  * GET /gateway-models - Model catalog available to workspaces.
  *
- * Returns the Vercel AI Gateway catalog intersected with the super-admin
- * curation: only models with `visible: true` in the curation document are
- * exposed. This is the list the workspace "AI Models" settings UI picks
- * from, so workspace admins can never enable a model that the platform
- * super-admin has hidden.
- *
- * If curation is empty (e.g. fresh install before the seed migration), we
- * fall back to the unfiltered gateway list to avoid a hard "no models"
- * state — super-admins will still see everything in `/api/admin/catalog`.
+ * Returns the super-admin-curated catalog from MongoDB (same source as
+ * GET /models). Avoids a live fetch to ai-gateway.vercel.sh in the request
+ * path — that upstream call is refreshed out-of-band by Inngest/startup.
  */
 agentRoutes.openapi(
   createRoute({
@@ -333,15 +326,7 @@ agentRoutes.openapi(
     responses: { ...OPEN_RESPONSES },
   }),
   async c => {
-    const [gateway, catalog] = await Promise.all([
-      getGatewayModels(),
-      getCatalogModels(),
-    ]);
-    if (catalog.length === 0) {
-      return c.json({ models: gateway });
-    }
-    const visible = new Set(catalog.map(m => m.id));
-    const models = gateway.filter(m => visible.has(m.id));
+    const models = await getWorkspaceGatewayModelListings();
     return c.json({ models });
   },
 );

--- a/api/src/services/gateway-models.service.ts
+++ b/api/src/services/gateway-models.service.ts
@@ -62,6 +62,7 @@ export interface GatewayModelPricing {
 // ---------------------------------------------------------------------------
 
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+const FETCH_HARD_TIMEOUT_MS = 15_000;
 const GATEWAY_API_URL = "https://ai-gateway.vercel.sh/v1/models";
 
 let cachedModels: GatewayModelInfo[] | null = null;
@@ -79,6 +80,23 @@ function normalizeModel(raw: GatewayModelRaw): GatewayModelInfo {
     contextWindow: raw.context_window ?? null,
     tags: raw.tags ?? [],
   };
+}
+
+function withHardTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string,
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(
+      () => reject(new Error(`${label} timed out after ${ms}ms`)),
+      ms,
+    );
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  });
 }
 
 async function fetchAllModels(): Promise<GatewayModelInfo[]> {
@@ -134,18 +152,23 @@ export async function getGatewayModels(): Promise<GatewayModelInfo[]> {
 
   if (fetchInFlight) return fetchInFlight;
 
-  fetchInFlight = fetchAllModels()
+  fetchInFlight = withHardTimeout(
+    fetchAllModels(),
+    FETCH_HARD_TIMEOUT_MS,
+    "Gateway models fetch",
+  )
     .then(models => {
       cachedModels = models;
       cacheTimestamp = Date.now();
-      fetchInFlight = null;
       return models;
     })
     .catch(err => {
-      fetchInFlight = null;
       logger.warn("Failed to fetch gateway models", { error: String(err) });
       if (cachedModels) return cachedModels;
       return [];
+    })
+    .finally(() => {
+      fetchInFlight = null;
     });
 
   return fetchInFlight;

--- a/api/src/services/model-catalog.service.ts
+++ b/api/src/services/model-catalog.service.ts
@@ -858,6 +858,65 @@ export async function warmCatalog(): Promise<void> {
 // Public API (unchanged signatures — callers don't know the source switched)
 // ---------------------------------------------------------------------------
 
+/** Shape returned by GET /agent/gateway-models for the workspace settings UI. */
+export interface WorkspaceGatewayModelListing {
+  id: string;
+  name: string;
+  description: string;
+  provider: string;
+  contextWindow: number | null;
+  tags: string[];
+}
+
+function catalogToWorkspaceListing(
+  model: CatalogModel,
+): WorkspaceGatewayModelListing {
+  return {
+    id: model.id,
+    name: model.name,
+    description: model.description,
+    provider: model.provider,
+    contextWindow: model.contextWindow,
+    tags: model.tags,
+  };
+}
+
+async function getPersistedGatewaySnapshotListings(): Promise<
+  WorkspaceGatewayModelListing[]
+> {
+  const doc = await ModelCatalogSnapshot.findOne({ _id: "gateway" }).lean();
+  if (!doc?.data || !Array.isArray(doc.data) || doc.data.length === 0) {
+    return [];
+  }
+
+  const gateway = doc.data as GatewayModelNormalized[];
+  return gateway.map(gm => ({
+    id: gm.id,
+    name: gm.name,
+    description: gm.description,
+    provider: gm.provider,
+    contextWindow: gm.contextWindow,
+    tags: gm.tags,
+  }));
+}
+
+/**
+ * Super-admin-curated models for the workspace "AI Models" settings page.
+ * Reads from the in-memory/DB catalog — never hits the live AI Gateway.
+ *
+ * When curation is empty (fresh install), falls back to the persisted
+ * gateway snapshot in MongoDB (same source Inngest/startup refresh uses).
+ */
+export async function getWorkspaceGatewayModelListings(): Promise<
+  WorkspaceGatewayModelListing[]
+> {
+  const catalog = await getCatalogModels();
+  if (catalog.length > 0) {
+    return catalog.map(catalogToWorkspaceListing);
+  }
+  return getPersistedGatewaySnapshotListings();
+}
+
 export async function getCatalogModels(): Promise<CatalogModel[]> {
   await ensureCatalog();
   return cachedCatalog ?? [];


### PR DESCRIPTION
## Summary
- Serve `GET /api/agent/gateway-models` from the DB-backed curated catalog (same source as `/models`) instead of live-fetching `ai-gateway.vercel.sh` on every request.
- Add `getWorkspaceGatewayModelListings()` with a Mongo gateway-snapshot fallback for fresh installs with empty curation.
- Harden `getGatewayModels()` with a 15s hard timeout and always clear the in-flight singleton in `finally`, so stalled background fetches cannot poison Cloud Run instances until restart.

Fixes the infinite "Loading models…" spinner on `/settings/models` caused by Cloudflare 524 timeouts on the live upstream fetch.

## Test plan
- [ ] Open `/settings/models` in prod — models list loads within a few seconds (no spinner hang)
- [ ] Confirm `GET /api/agent/gateway-models` returns 200 with populated `models` array
- [ ] Confirm `GET /api/agent/models` still returns the same curated set
- [ ] Toggle model enable/disable and save — blocklist persists via `PUT /workspaces/:id/settings/models`
- [ ] Fresh install / empty curation: endpoint falls back to persisted gateway snapshot (no live fetch)


Made with [Cursor](https://cursor.com)