### PR TITLE
feat(mobile): chat-first mobile-friendly experience

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
     <link rel="manifest" href="/manifest.json" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <title>Mako</title>
@@ -38,8 +41,14 @@
       html,
       body {
         height: 100%;
+        height: 100dvh;
         margin: 0;
         overflow: hidden;
+      }
+
+      #root {
+        height: 100%;
+        height: 100dvh;
       }
 
       /* Streamdown base styles - required for streaming markdown */

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -10,8 +10,6 @@ import {
   Box,
   CircularProgress,
   styled,
-  AppBar,
-  Toolbar,
   Drawer,
   BottomNavigation,
   BottomNavigationAction,
@@ -20,11 +18,10 @@ import {
   Typography,
 } from "@mui/material";
 import {
-  Menu as MenuIcon,
   MessageCircleMore as AskTabIcon,
   SquareTerminal as EditorTabIcon,
   Table as ResultsTabIcon,
-  Compass as ExploreTabIcon,
+  X as CloseDrawerIcon,
 } from "lucide-react";
 import {
   Routes,
@@ -71,7 +68,7 @@ const loadDbtExplorer = () => import("./components/DbtExplorer");
 const DbtExplorer = lazy(loadDbtExplorer);
 import { AuthWrapper } from "./components/AuthWrapper";
 import { AcceptInvite } from "./components/AcceptInvite";
-import { WorkspaceProvider } from "./contexts/workspace-context";
+import { WorkspaceProvider, useWorkspace } from "./contexts/workspace-context";
 import { OnboardingProvider } from "./contexts/onboarding-context";
 import type { DbFlowFormRef } from "./components/DbFlowForm";
 import { generateObjectId } from "./utils/objectId";
@@ -127,6 +124,50 @@ function clamp(value: number, min: number, max: number): number {
 
 type SidePane = "left" | "right";
 
+/**
+ * User identity + active workspace shown in the mobile explorer drawer header.
+ * Rendered inside `WorkspaceProvider` (unlike `MainApp`'s body), so it can read
+ * the current workspace via `useWorkspace()`.
+ */
+function MobileDrawerIdentity() {
+  const { user } = useAuth();
+  const { currentWorkspace } = useWorkspace();
+
+  return (
+    <Box sx={{ flex: 1, minWidth: 0 }}>
+      {user?.email && (
+        <Typography
+          variant="subtitle2"
+          sx={{
+            fontWeight: 600,
+            lineHeight: 1.2,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {user.email}
+        </Typography>
+      )}
+      {currentWorkspace?.name && (
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{
+            display: "block",
+            lineHeight: 1.2,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {currentWorkspace.name}
+        </Typography>
+      )}
+    </Box>
+  );
+}
+
 function MainApp() {
   const activeView = useUIStore(state => state.leftPane);
   const leftPaneOpen = useUIStore(state => state.leftPaneOpen);
@@ -144,7 +185,6 @@ function MainApp() {
   const mobileTab = useUIStore(state => state.mobileTab);
   const mobileDrawer = useUIStore(state => state.mobileDrawer);
   const setMobileTab = useUIStore(state => state.setMobileTab);
-  const openMobileDrawer = useUIStore(state => state.openMobileDrawer);
   const closeMobileDrawer = useUIStore(state => state.closeMobileDrawer);
 
   // On mobile, selecting a tree node in the explorer Drawer opens/focuses a
@@ -548,14 +588,9 @@ function MainApp() {
   // their state survives tab switches, mirroring the desktop dual-pane mount.
   if (isMobile) {
     const drawerOpen = mobileDrawer === "explorer";
-    const bottomValue = drawerOpen ? "explore" : mobileTab;
-    const title = drawerOpen
-      ? "Explore"
-      : mobileTab === "ask"
-        ? "Ask your data"
-        : mobileTab === "editor"
-          ? "Editor"
-          : "Results";
+    // Bottom nav only drives the content panes now; the explorer Drawer is
+    // opened from the hamburger in each pane header (top-left).
+    const bottomValue = mobileTab;
 
     return (
       <AuthWrapper>
@@ -570,43 +605,12 @@ function MainApp() {
             width: "100vw",
             maxWidth: "100vw",
             overflow: "hidden",
+            // No top app bar on mobile — navigation lives in the bottom nav and
+            // the explorer Drawer (which carries the user/workspace menu). Keep
+            // content clear of the status bar / notch on standalone installs.
+            pt: "env(safe-area-inset-top)",
           }}
         >
-          {/* Top bar: hamburger → explorer drawer, contextual title, user menu */}
-          <AppBar
-            position="static"
-            elevation={0}
-            color="default"
-            sx={{
-              backgroundColor: "background.paper",
-              borderBottom: 1,
-              borderColor: "divider",
-            }}
-          >
-            <Toolbar variant="dense" sx={{ minHeight: 48, gap: 1, px: 1 }}>
-              <IconButton
-                edge="start"
-                onClick={openMobileDrawer}
-                aria-label="Open explorer"
-              >
-                <MenuIcon size={22} />
-              </IconButton>
-              <Typography
-                variant="subtitle1"
-                sx={{
-                  flex: 1,
-                  fontWeight: 600,
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap",
-                }}
-              >
-                {title}
-              </Typography>
-              <SidebarUserMenu tooltipPlacement="bottom" />
-            </Toolbar>
-          </AppBar>
-
           {/* Content — one pane at a time, both kept mounted for state */}
           <Box sx={{ flex: 1, minHeight: 0, position: "relative" }}>
             <Box
@@ -656,11 +660,20 @@ function MainApp() {
                   sx={{
                     display: "flex",
                     alignItems: "center",
+                    gap: 1,
                     px: 1,
                     pt: 1,
                   }}
                 >
                   <SidebarUserMenu tooltipPlacement="bottom" />
+                  <MobileDrawerIdentity />
+                  <IconButton
+                    size="small"
+                    aria-label="Close explorer"
+                    onClick={closeMobileDrawer}
+                  >
+                    <CloseDrawerIcon size={20} />
+                  </IconButton>
                 </Box>
                 <SidebarMobileExplorerNav />
               </Box>
@@ -685,7 +698,8 @@ function MainApp() {
             </Box>
           </Drawer>
 
-          {/* Bottom navigation — Ask / Editor / Results / Explore */}
+          {/* Bottom navigation — Ask / Editor / Results.
+              Explore lives in the top-left hamburger of each pane header. */}
           <Paper
             square
             elevation={3}
@@ -699,7 +713,7 @@ function MainApp() {
               showLabels
               value={bottomValue}
               onChange={(_event, value) =>
-                setMobileTab(value as "ask" | "editor" | "results" | "explore")
+                setMobileTab(value as "ask" | "editor" | "results")
               }
             >
               <BottomNavigationAction
@@ -716,11 +730,6 @@ function MainApp() {
                 label="Results"
                 value="results"
                 icon={<ResultsTabIcon size={22} strokeWidth={1.5} />}
-              />
-              <BottomNavigationAction
-                label="Explore"
-                value="explore"
-                icon={<ExploreTabIcon size={22} strokeWidth={1.5} />}
               />
             </BottomNavigation>
           </Paper>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -6,7 +6,26 @@ import {
   useState,
   lazy,
 } from "react";
-import { Box, CircularProgress, styled } from "@mui/material";
+import {
+  Box,
+  CircularProgress,
+  styled,
+  AppBar,
+  Toolbar,
+  Drawer,
+  BottomNavigation,
+  BottomNavigationAction,
+  Paper,
+  IconButton,
+  Typography,
+} from "@mui/material";
+import {
+  Menu as MenuIcon,
+  MessageCircleMore as AskTabIcon,
+  SquareTerminal as EditorTabIcon,
+  Table as ResultsTabIcon,
+  Compass as ExploreTabIcon,
+} from "lucide-react";
 import {
   Routes,
   Route,
@@ -16,7 +35,11 @@ import {
   useLocation,
 } from "react-router-dom";
 import { trackPageView } from "./lib/analytics";
-import Sidebar from "./components/Sidebar";
+import Sidebar, {
+  SidebarUserMenu,
+  SidebarMobileExplorerNav,
+} from "./components/Sidebar";
+import { useIsMobile } from "./hooks/useIsMobile";
 import {
   CENTER_PANE_MIN_WIDTH_PX,
   DEFAULT_LEFT_PANE_WIDTH_PX,
@@ -115,6 +138,27 @@ function MainApp() {
   const leftPaneWidthPx = useUIStore(state => state.leftPaneWidthPx);
   const rightPaneWidthPx = useUIStore(state => state.rightPaneWidthPx);
   const setPaneWidths = useUIStore(state => state.setPaneWidths);
+
+  // Mobile (< md) shell state. Desktop ignores these entirely.
+  const isMobile = useIsMobile();
+  const mobileTab = useUIStore(state => state.mobileTab);
+  const mobileDrawer = useUIStore(state => state.mobileDrawer);
+  const setMobileTab = useUIStore(state => state.setMobileTab);
+  const openMobileDrawer = useUIStore(state => state.openMobileDrawer);
+  const closeMobileDrawer = useUIStore(state => state.closeMobileDrawer);
+
+  // On mobile, selecting a tree node in the explorer Drawer opens/focuses a
+  // console tab. Surface the editor and close the drawer so the result of the
+  // tap is visible. Gated on the drawer being open so chat-driven tab opens
+  // (e.g. the agent creating a console) don't yank the user out of the Ask
+  // view mid-conversation.
+  useEffect(() => {
+    if (!isMobile) return;
+    if (!activeTabId) return;
+    if (useUIStore.getState().mobileDrawer !== "explorer") return;
+    setMobileTab("editor");
+    closeMobileDrawer();
+  }, [activeTabId, isMobile, setMobileTab, closeMobileDrawer]);
 
   const panelContainerRef = useRef<HTMLDivElement | null>(null);
   const leftPaneElRef = useRef<HTMLDivElement | null>(null);
@@ -496,6 +540,194 @@ function MainApp() {
       }
     };
   }, []);
+
+  // ── Mobile shell (< md) ───────────────────────────────────────────────
+  // A chat-first, single-pane experience: one full-screen pane at a time
+  // (Ask / Editor / Results) switched by the BottomNavigation, plus an
+  // explorer Drawer. Chat and Editor stay mounted (visibility toggled) so
+  // their state survives tab switches, mirroring the desktop dual-pane mount.
+  if (isMobile) {
+    const drawerOpen = mobileDrawer === "explorer";
+    const bottomValue = drawerOpen ? "explore" : mobileTab;
+    const title = drawerOpen
+      ? "Explore"
+      : mobileTab === "ask"
+        ? "Ask your data"
+        : mobileTab === "editor"
+          ? "Editor"
+          : "Results";
+
+    return (
+      <AuthWrapper>
+        <UrlSync />
+        <Box
+          data-mako-app-shell="true"
+          data-mako-mobile="true"
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            height: "100dvh",
+            width: "100vw",
+            maxWidth: "100vw",
+            overflow: "hidden",
+          }}
+        >
+          {/* Top bar: hamburger → explorer drawer, contextual title, user menu */}
+          <AppBar
+            position="static"
+            elevation={0}
+            color="default"
+            sx={{
+              backgroundColor: "background.paper",
+              borderBottom: 1,
+              borderColor: "divider",
+            }}
+          >
+            <Toolbar variant="dense" sx={{ minHeight: 48, gap: 1, px: 1 }}>
+              <IconButton
+                edge="start"
+                onClick={openMobileDrawer}
+                aria-label="Open explorer"
+              >
+                <MenuIcon size={22} />
+              </IconButton>
+              <Typography
+                variant="subtitle1"
+                sx={{
+                  flex: 1,
+                  fontWeight: 600,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {title}
+              </Typography>
+              <SidebarUserMenu tooltipPlacement="bottom" />
+            </Toolbar>
+          </AppBar>
+
+          {/* Content — one pane at a time, both kept mounted for state */}
+          <Box sx={{ flex: 1, minHeight: 0, position: "relative" }}>
+            <Box
+              sx={{
+                position: "absolute",
+                inset: 0,
+                display: mobileTab === "ask" ? "block" : "none",
+              }}
+            >
+              <Chat
+                dbFlowFormRef={dbFlowFormRef}
+                onChartSpecChangeRef={onChartSpecChangeRef}
+                resultsContextRef={resultsContextRef}
+              />
+            </Box>
+            <Box
+              sx={{
+                position: "absolute",
+                inset: 0,
+                display:
+                  mobileTab === "editor" || mobileTab === "results"
+                    ? "block"
+                    : "none",
+              }}
+            >
+              <Editor
+                dbFlowFormRef={dbFlowFormRef}
+                onChartSpecChangeRef={onChartSpecChangeRef}
+                resultsContextRef={resultsContextRef}
+              />
+            </Box>
+          </Box>
+
+          {/* Explorer drawer — reuses the same explorer panels as desktop */}
+          <Drawer
+            anchor="left"
+            open={drawerOpen}
+            onClose={closeMobileDrawer}
+            ModalProps={{ keepMounted: true }}
+            PaperProps={{ sx: { width: "85vw", maxWidth: 340 } }}
+          >
+            <Box
+              sx={{ height: "100%", display: "flex", flexDirection: "column" }}
+            >
+              <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    px: 1,
+                    pt: 1,
+                  }}
+                >
+                  <SidebarUserMenu tooltipPlacement="bottom" />
+                </Box>
+                <SidebarMobileExplorerNav />
+              </Box>
+              <Box sx={{ flex: 1, minHeight: 0, overflow: "hidden" }}>
+                <Suspense
+                  fallback={
+                    <Box
+                      sx={{
+                        height: "100%",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                      }}
+                    >
+                      <CircularProgress size={20} />
+                    </Box>
+                  }
+                >
+                  {renderLeftPane()}
+                </Suspense>
+              </Box>
+            </Box>
+          </Drawer>
+
+          {/* Bottom navigation — Ask / Editor / Results / Explore */}
+          <Paper
+            square
+            elevation={3}
+            sx={{
+              borderTop: 1,
+              borderColor: "divider",
+              pb: "env(safe-area-inset-bottom)",
+            }}
+          >
+            <BottomNavigation
+              showLabels
+              value={bottomValue}
+              onChange={(_event, value) =>
+                setMobileTab(value as "ask" | "editor" | "results" | "explore")
+              }
+            >
+              <BottomNavigationAction
+                label="Ask"
+                value="ask"
+                icon={<AskTabIcon size={22} strokeWidth={1.5} />}
+              />
+              <BottomNavigationAction
+                label="Editor"
+                value="editor"
+                icon={<EditorTabIcon size={22} strokeWidth={1.5} />}
+              />
+              <BottomNavigationAction
+                label="Results"
+                value="results"
+                icon={<ResultsTabIcon size={22} strokeWidth={1.5} />}
+              />
+              <BottomNavigationAction
+                label="Explore"
+                value="explore"
+                icon={<ExploreTabIcon size={22} strokeWidth={1.5} />}
+              />
+            </BottomNavigation>
+          </Paper>
+        </Box>
+      </AuthWrapper>
+    );
+  }
 
   return (
     <AuthWrapper>

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -1762,6 +1762,22 @@ const MOBILE_ASK_SUGGESTIONS = [
   "Summarize my data with a chart",
 ];
 
+// Claude-style floating round button used in the mobile pane headers. Each
+// control carries its own paper fill + blur + hairline so it reads as floating
+// chrome over the content rather than sitting in a solid app bar.
+const MOBILE_FLOAT_BTN_SX = {
+  width: 38,
+  height: 38,
+  borderRadius: "50%",
+  color: "text.secondary",
+  bgcolor: "background.paper",
+  border: 1,
+  borderColor: "divider",
+  boxShadow: "0 1px 3px rgba(0, 0, 0, 0.08)",
+  backdropFilter: "blur(8px)",
+  "&:hover": { bgcolor: "action.hover" },
+} as const;
+
 const Chat: React.FC<ChatProps> = ({
   dbFlowFormRef,
   onChartSpecChangeRef,
@@ -3567,13 +3583,15 @@ const Chat: React.FC<ChatProps> = ({
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
-      {/* Header with history and new chat */}
+      {/* Header with history and new chat. On mobile this is Claude-style
+          floating chrome: a transparent strip with round buttons (hamburger
+          left, actions right). Desktop keeps the bordered title bar. */}
       <Box
         sx={{
           px: 1,
-          py: 0.25,
-          minHeight: 37,
-          borderBottom: 1,
+          py: isMobile ? 0.75 : 0.25,
+          minHeight: isMobile ? 52 : 37,
+          borderBottom: isMobile ? 0 : 1,
           borderColor: "divider",
         }}
       >
@@ -3595,39 +3613,46 @@ const Chat: React.FC<ChatProps> = ({
               gap: 1,
             }}
           >
-            {isMobile && (
+            {isMobile ? (
               <Tooltip title="Open explorer">
                 <IconButton
-                  size="small"
-                  edge="start"
                   aria-label="Open explorer"
                   onClick={() => useUIStore.getState().openMobileDrawer()}
+                  sx={MOBILE_FLOAT_BTN_SX}
                 >
                   <MenuIcon size={20} />
                 </IconButton>
               </Tooltip>
+            ) : (
+              <Typography
+                variant="h6"
+                sx={{
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                Chat
+              </Typography>
             )}
-            <Typography
-              variant="h6"
-              sx={{
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-              }}
-            >
-              Chat
-            </Typography>
           </Box>
-          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: isMobile ? 1 : 0.5,
+            }}
+          >
             <Tooltip
               title={copiedChat ? "Copied!" : "Copy chat history as JSON"}
             >
               <span>
                 <IconButton
-                  size="small"
+                  size={isMobile ? "medium" : "small"}
                   aria-label="Copy chat history as JSON"
                   onClick={handleCopyChatHistory}
                   disabled={messages.length === 0}
+                  sx={isMobile ? MOBILE_FLOAT_BTN_SX : undefined}
                 >
                   {copiedChat ? <Check size={20} /> : <Copy size={20} />}
                 </IconButton>
@@ -3635,18 +3660,20 @@ const Chat: React.FC<ChatProps> = ({
             </Tooltip>
             <Tooltip title="New chat">
               <IconButton
-                size="small"
+                size={isMobile ? "medium" : "small"}
                 aria-label="New chat"
                 onClick={createNewSession}
+                sx={isMobile ? MOBILE_FLOAT_BTN_SX : undefined}
               >
                 <Plus size={20} />
               </IconButton>
             </Tooltip>
             <Tooltip title="Chat history">
               <IconButton
-                size="small"
+                size={isMobile ? "medium" : "small"}
                 aria-label="Chat history"
                 onClick={handleHistoryMenuOpen}
+                sx={isMobile ? MOBILE_FLOAT_BTN_SX : undefined}
               >
                 <History size={20} />
               </IconButton>

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -47,6 +47,7 @@ import {
   Check,
   History,
   ImagePlus,
+  Menu as MenuIcon,
   Pencil,
   Plus,
   MessageSquare,
@@ -1668,6 +1669,7 @@ const ChatInputArea = React.memo(
             {isLoading ? (
               <IconButton
                 type="button"
+                aria-label="Stop generating"
                 onClick={onStop}
                 size="small"
                 sx={{
@@ -1695,6 +1697,7 @@ const ChatInputArea = React.memo(
             ) : (
               <IconButton
                 type="submit"
+                aria-label="Send message"
                 disabled={isSubmitDisabled}
                 size="small"
                 sx={{
@@ -3592,6 +3595,18 @@ const Chat: React.FC<ChatProps> = ({
               gap: 1,
             }}
           >
+            {isMobile && (
+              <Tooltip title="Open explorer">
+                <IconButton
+                  size="small"
+                  edge="start"
+                  aria-label="Open explorer"
+                  onClick={() => useUIStore.getState().openMobileDrawer()}
+                >
+                  <MenuIcon size={20} />
+                </IconButton>
+              </Tooltip>
+            )}
             <Typography
               variant="h6"
               sx={{
@@ -3610,6 +3625,7 @@ const Chat: React.FC<ChatProps> = ({
               <span>
                 <IconButton
                   size="small"
+                  aria-label="Copy chat history as JSON"
                   onClick={handleCopyChatHistory}
                   disabled={messages.length === 0}
                 >
@@ -3617,12 +3633,24 @@ const Chat: React.FC<ChatProps> = ({
                 </IconButton>
               </span>
             </Tooltip>
-            <IconButton size="small" onClick={createNewSession}>
-              <Plus size={20} />
-            </IconButton>
-            <IconButton size="small" onClick={handleHistoryMenuOpen}>
-              <History size={20} />
-            </IconButton>
+            <Tooltip title="New chat">
+              <IconButton
+                size="small"
+                aria-label="New chat"
+                onClick={createNewSession}
+              >
+                <Plus size={20} />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Chat history">
+              <IconButton
+                size="small"
+                aria-label="Chat history"
+                onClick={handleHistoryMenuOpen}
+              >
+                <History size={20} />
+              </IconButton>
+            </Tooltip>
           </Box>
         </Box>
       </Box>

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -12,6 +12,7 @@ import React, {
 import {
   Box,
   Button,
+  Chip,
   IconButton,
   List,
   ListItem,
@@ -69,6 +70,7 @@ import { useSettingsStore } from "../store/settingsStore";
 import { useSchemaStore } from "../store/schemaStore";
 import { selectActiveExplorer, useUIStore } from "../store/uiStore";
 import { useRealtimeStore } from "../store/realtimeStore";
+import { useIsMobile } from "../hooks/useIsMobile";
 import { ModelSelector } from "./ModelSelector";
 import { generateObjectId } from "../utils/objectId";
 import type { ConsoleModification } from "../hooks/useMonacoConsole";
@@ -1748,6 +1750,15 @@ function normalizeChatActiveView(kind: ConsoleTab["kind"]): ChatActiveView {
     : "empty";
 }
 
+// Starter prompts for the mobile "Ask your data" empty state. Tapping one runs
+// it through the normal send path.
+const MOBILE_ASK_SUGGESTIONS = [
+  "What tables are in my database?",
+  "Show me the 10 most recent records",
+  "How many rows are in each table?",
+  "Summarize my data with a chart",
+];
+
 const Chat: React.FC<ChatProps> = ({
   dbFlowFormRef,
   onChartSpecChangeRef,
@@ -1756,6 +1767,13 @@ const Chat: React.FC<ChatProps> = ({
   const paletteMode = useMuiTheme().palette.mode;
   const { currentWorkspace } = useWorkspace();
   const selectedModelId = useSettingsStore(s => s.selectedModelId);
+
+  // On mobile, Chat is the full-screen "Ask your data" home. Track viewport in
+  // a ref so stable useCallback handlers (e.g. console title click) can switch
+  // the mobile tab without widening their dependency arrays.
+  const isMobile = useIsMobile();
+  const isMobileRef = useRef(isMobile);
+  isMobileRef.current = isMobile;
 
   // Ref for dbFlowFormRef to avoid stale closure in onToolCall
   const dbFlowFormRefCurrent = useRef(dbFlowFormRef);
@@ -3198,6 +3216,11 @@ const Chat: React.FC<ChatProps> = ({
 
   const handleConsoleTitleClick = useCallback(async (consoleId: string) => {
     const store = useConsoleStore.getState();
+    // On mobile the editor lives behind the "Editor" tab — surface it so
+    // tapping a console reference in chat ("view SQL") shows the query.
+    if (isMobileRef.current) {
+      useUIStore.getState().setMobileTab("editor");
+    }
     const existingTab = store.tabs[consoleId];
     if (existingTab) {
       store.setActiveTab(consoleId);
@@ -3737,6 +3760,67 @@ const Chat: React.FC<ChatProps> = ({
           position: "relative",
         }}
       >
+        {/* Mobile "Ask your data" home: hero + starter chips when empty */}
+        {isMobile && messages.length === 0 && (
+          <Box
+            sx={{
+              position: "absolute",
+              inset: 0,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              textAlign: "center",
+              px: 3,
+              gap: 3,
+              pointerEvents: "none",
+            }}
+          >
+            <Box>
+              <Typography variant="h5" sx={{ fontWeight: 700 }}>
+                Ask your data
+              </Typography>
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ mt: 1, maxWidth: 360 }}
+              >
+                Ask a question in plain English — Mako writes and runs the query
+                for you.
+              </Typography>
+            </Box>
+            <Box
+              sx={{
+                display: "flex",
+                flexWrap: "wrap",
+                gap: 1,
+                justifyContent: "center",
+                maxWidth: 440,
+                pointerEvents: "auto",
+              }}
+            >
+              {MOBILE_ASK_SUGGESTIONS.map(suggestion => (
+                <Chip
+                  key={suggestion}
+                  label={suggestion}
+                  clickable
+                  variant="outlined"
+                  disabled={!currentWorkspace}
+                  onClick={() => handleChatSubmit(suggestion)}
+                  sx={{
+                    height: "auto",
+                    py: 0.75,
+                    "& .MuiChip-label": {
+                      whiteSpace: "normal",
+                      display: "block",
+                    },
+                  }}
+                />
+              ))}
+            </Box>
+          </Box>
+        )}
+
         <div ref={scrollContentRef}>
           <React.Profiler id="Chat.message-list" onRender={onRenderDebug}>
             <List dense>

--- a/app/src/components/Console.tsx
+++ b/app/src/components/Console.tsx
@@ -20,6 +20,8 @@ import {
   Alert,
   Badge,
   Chip,
+  Fab,
+  CircularProgress,
   ListItemIcon,
   ListItemText,
 } from "@mui/material";
@@ -56,6 +58,7 @@ import {
 import { computeConsoleStateHash } from "../utils/stateHash";
 import { applyModification as applyConsoleModification } from "../utils/consoleModification";
 import { ConnectionSelector } from "./ConnectionSelector";
+import { useIsMobile } from "../hooks/useIsMobile";
 import {
   onRenderDebug,
   useRenderCount,
@@ -204,6 +207,7 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
   const editorRef = useRef<any>(null);
   const diffEditorRef = useRef<any>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const isMobile = useIsMobile();
   const { effectiveMode } = useTheme();
   const { currentWorkspace } = useWorkspace();
   const autoSaveConsole = useConsoleStore(state => state.autoSaveConsole);
@@ -1158,6 +1162,7 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
         height: "100%",
         display: "flex",
         flexDirection: "column",
+        position: "relative",
       }}
     >
       <Box
@@ -1168,6 +1173,8 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
           backgroundColor: "background.paper",
           p: 0.5,
           gap: 0.5,
+          // Let the connection selector wrap below the actions on narrow screens
+          flexWrap: { xs: "wrap", md: "nowrap" },
         }}
       >
         <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
@@ -1196,7 +1203,7 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
                 <Button
                   variant="contained"
                   size="small"
-                  startIcon={<PlayIcon />}
+                  startIcon={isMobile ? undefined : <PlayIcon />}
                   onClick={handleExecute}
                   disabled={!connectionId}
                   disableElevation
@@ -1205,10 +1212,10 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
                     overflow: "hidden",
                     textOverflow: "ellipsis",
                     maxWidth: "200px",
-                    minWidth: "120px",
+                    minWidth: isMobile ? 0 : "120px",
                   }}
                 >
-                  Run (⌘/Ctrl+Enter)
+                  {isMobile ? <PlayIcon /> : "Run (⌘/Ctrl+Enter)"}
                 </Button>
               </span>
             </Tooltip>
@@ -1647,6 +1654,34 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
         consoleId={consoleId}
         workspaceId={currentWorkspace?.id}
       />
+
+      {/* Mobile run FAB — the primary "execute" affordance on a phone, where
+          the toolbar Run button is compact and the keyboard shortcut is
+          unavailable. */}
+      {isMobile && !isDiffMode && (
+        <Fab
+          color={isExecuting ? "error" : "primary"}
+          aria-label={isExecuting ? "Cancel query" : "Run query"}
+          onClick={isExecuting ? onCancel : handleExecute}
+          disabled={isExecuting ? isCancelling : !connectionId}
+          sx={{
+            position: "absolute",
+            right: 16,
+            bottom: "calc(16px + env(safe-area-inset-bottom))",
+            zIndex: 5,
+          }}
+        >
+          {isExecuting ? (
+            isCancelling ? (
+              <CircularProgress size={24} color="inherit" />
+            ) : (
+              <StopIcon size={22} />
+            )
+          ) : (
+            <PlayIcon />
+          )}
+        </Fab>
+      )}
     </Box>
   );
 });

--- a/app/src/components/Console.tsx
+++ b/app/src/components/Console.tsx
@@ -1177,49 +1177,61 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
           flexWrap: { xs: "wrap", md: "nowrap" },
         }}
       >
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-          {isExecuting ? (
-            <Button
-              variant="contained"
-              size="small"
-              color="error"
-              startIcon={<StopIcon size={18} />}
-              onClick={onCancel}
-              disabled={isCancelling}
-              disableElevation
-              sx={{ minWidth: "120px" }}
-            >
-              {isCancelling ? "Cancelling..." : "Cancel"}
-            </Button>
-          ) : (
-            <Tooltip
-              title={
-                !connectionId
-                  ? "Select a database connection to run queries"
-                  : ""
-              }
-            >
-              <span>
-                <Button
-                  variant="contained"
-                  size="small"
-                  startIcon={isMobile ? undefined : <PlayIcon />}
-                  onClick={handleExecute}
-                  disabled={!connectionId}
-                  disableElevation
-                  sx={{
-                    whiteSpace: "nowrap",
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    maxWidth: "200px",
-                    minWidth: isMobile ? 0 : "120px",
-                  }}
-                >
-                  {isMobile ? <PlayIcon /> : "Run (⌘/Ctrl+Enter)"}
-                </Button>
-              </span>
-            </Tooltip>
-          )}
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: 1,
+            // Wrap the action buttons onto a second line on phones instead of
+            // clipping them off the right edge.
+            flexWrap: { xs: "wrap", md: "nowrap" },
+          }}
+        >
+          {/* On mobile the run/cancel affordance is the floating FAB, so the
+              inline toolbar button is desktop-only to save horizontal space. */}
+          {!isMobile &&
+            (isExecuting ? (
+              <Button
+                variant="contained"
+                size="small"
+                color="error"
+                startIcon={<StopIcon size={18} />}
+                onClick={onCancel}
+                disabled={isCancelling}
+                disableElevation
+                sx={{ minWidth: "120px" }}
+              >
+                {isCancelling ? "Cancelling..." : "Cancel"}
+              </Button>
+            ) : (
+              <Tooltip
+                title={
+                  !connectionId
+                    ? "Select a database connection to run queries"
+                    : ""
+                }
+              >
+                <span>
+                  <Button
+                    variant="contained"
+                    size="small"
+                    startIcon={<PlayIcon />}
+                    onClick={handleExecute}
+                    disabled={!connectionId}
+                    disableElevation
+                    sx={{
+                      whiteSpace: "nowrap",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      maxWidth: "200px",
+                      minWidth: "120px",
+                    }}
+                  >
+                    Run (⌘/Ctrl+Enter)
+                  </Button>
+                </span>
+              </Tooltip>
+            ))}
 
           {isReadOnly && (
             <Chip
@@ -1245,6 +1257,29 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
                   size="small"
                   variant="outlined"
                   startIcon={
+                    isMobile ? undefined : (
+                      <Badge
+                        color="success"
+                        variant="dot"
+                        invisible={!hasSchedule}
+                        overlap="circular"
+                      >
+                        <ScheduleIcon size={16} />
+                      </Badge>
+                    )
+                  }
+                  onClick={() =>
+                    hasSchedule ? onUpdateSchedule?.() : onCreateSchedule?.()
+                  }
+                  disabled={!isSaved}
+                  sx={{
+                    ml: 1,
+                    whiteSpace: "nowrap",
+                    minWidth: isMobile ? 0 : undefined,
+                    px: isMobile ? 1 : undefined,
+                  }}
+                >
+                  {isMobile ? (
                     <Badge
                       color="success"
                       variant="dot"
@@ -1253,14 +1288,9 @@ const Console = forwardRef<ConsoleRef, ConsoleProps>((props, ref) => {
                     >
                       <ScheduleIcon size={16} />
                     </Badge>
-                  }
-                  onClick={() =>
-                    hasSchedule ? onUpdateSchedule?.() : onCreateSchedule?.()
-                  }
-                  disabled={!isSaved}
-                  sx={{ ml: 1, whiteSpace: "nowrap" }}
-                >
-                  Schedule
+                  ) : (
+                    "Schedule"
+                  )}
                 </Button>
               </span>
             </Tooltip>

--- a/app/src/components/DatabaseExplorer.tsx
+++ b/app/src/components/DatabaseExplorer.tsx
@@ -8,6 +8,7 @@ import {
   MenuItem,
   ListItemIcon,
   Tooltip,
+  Button,
 } from "@mui/material";
 import {
   Database as DatabaseIcon,
@@ -763,10 +764,52 @@ function DatabaseExplorer({
       >
         {({ searchQuery }) =>
           databases.length === 0 ? (
-            <Box sx={{ p: 3, textAlign: "center", color: "text.secondary" }}>
-              <Typography variant="body2">
-                No databases found in configuration
-              </Typography>
+            <Box
+              sx={{
+                px: 3,
+                py: 5,
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                textAlign: "center",
+                gap: 1.5,
+              }}
+            >
+              <Box
+                sx={{
+                  width: 48,
+                  height: 48,
+                  borderRadius: "50%",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  backgroundColor: "action.hover",
+                  color: "text.secondary",
+                }}
+              >
+                <DatabaseIcon size={24} strokeWidth={1.5} />
+              </Box>
+              <Box>
+                <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                  No databases yet
+                </Typography>
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ mt: 0.5 }}
+                >
+                  Connect a database to start exploring and querying your data.
+                </Typography>
+              </Box>
+              <Button
+                variant="contained"
+                size="small"
+                disableElevation
+                startIcon={<AddIcon size={16} strokeWidth={2} />}
+                onClick={() => setCreateDialogOpen(true)}
+              >
+                Add database
+              </Button>
             </Box>
           ) : (
             <ResourceTree

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -33,6 +33,7 @@ import {
   DialogActions,
   Alert,
   Snackbar,
+  Tooltip,
 } from "@mui/material";
 import { Close as CloseIcon } from "@mui/icons-material";
 import {
@@ -48,6 +49,7 @@ import {
   Database as DatabaseIcon,
   Table as TableDataIcon,
   ClipboardList as PlanIcon,
+  Menu as MenuIcon,
 } from "lucide-react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { loader } from "@monaco-editor/react";
@@ -2057,6 +2059,18 @@ function Editor({
               borderColor: "divider",
             }}
           >
+            {isMobile && (
+              <Tooltip title="Open explorer">
+                <IconButton
+                  size="small"
+                  aria-label="Open explorer"
+                  onClick={() => useUIStore.getState().openMobileDrawer()}
+                  sx={{ ml: 0.5, mr: 0.25, flexShrink: 0 }}
+                >
+                  <MenuIcon size={20} />
+                </IconButton>
+              </Tooltip>
+            )}
             <DndContext
               sensors={dndSensors}
               collisionDetection={closestCenter}
@@ -2661,24 +2675,54 @@ function Editor({
             height: "100%",
             display: "flex",
             flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: 2,
           }}
         >
-          <Typography>No console open</Typography>
-          <Button
-            variant="contained"
-            disableElevation
-            onClick={() => {
-              openTab({
-                title: "New Console",
-                content: "",
-              });
+          {isMobile && (
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                minHeight: 36,
+                px: 0.5,
+                borderBottom: 1,
+                borderColor: "divider",
+              }}
+            >
+              <Tooltip title="Open explorer">
+                <IconButton
+                  size="small"
+                  aria-label="Open explorer"
+                  onClick={() => useUIStore.getState().openMobileDrawer()}
+                >
+                  <MenuIcon size={20} />
+                </IconButton>
+              </Tooltip>
+            </Box>
+          )}
+          <Box
+            sx={{
+              flexGrow: 1,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 2,
             }}
           >
-            Open Console
-          </Button>
+            <Typography>No console open</Typography>
+            <Button
+              variant="contained"
+              disableElevation
+              onClick={() => {
+                openTab({
+                  title: "New Console",
+                  content: "",
+                });
+              }}
+            >
+              Open Console
+            </Button>
+          </Box>
         </Box>
       )}
 

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -90,6 +90,7 @@ import { useAuth } from "../contexts/auth-context";
 import { useIsWorkspaceAdmin } from "../hooks/useIsWorkspaceAdmin";
 import ShareDialog from "./ShareDialog";
 import { useSqlAutocomplete } from "../hooks/useSqlAutocomplete";
+import { useIsMobile } from "../hooks/useIsMobile";
 import { trackEvent } from "../lib/analytics";
 import { getApiBasePath } from "../lib/api-base-path";
 import { generateObjectId } from "../utils/objectId";
@@ -614,6 +615,24 @@ function Editor({
     state => state.setActiveEditorContent,
   );
 
+  // Mobile (< md): the editor and results live behind separate bottom-nav tabs
+  // instead of the desktop vertical split. `mobileResultsView` decides which of
+  // the two a console tab shows.
+  const isMobile = useIsMobile();
+  const mobileTab = useUIStore(state => state.mobileTab);
+  const setMobileTab = useUIStore(state => state.setMobileTab);
+  const mobileResultsView = isMobile && mobileTab === "results";
+
+  // Tabs whose editing surfaces are not usable on a phone; we show a dismissible
+  // notice instead of the cramped desktop UI.
+  const DESKTOP_ONLY_KINDS = useMemo(
+    () => new Set(["flow-editor", "app", "app-file", "app-binding"]),
+    [],
+  );
+  const [dismissedDesktopOnly, setDismissedDesktopOnly] = useState<
+    Record<string, boolean>
+  >({});
+
   // Update active editor content when tab focus changes AND focus the Monaco editor
   useEffect(() => {
     if (activeConsoleId && consoleRefs.current[activeConsoleId]?.current) {
@@ -1086,6 +1105,11 @@ function Editor({
             capApplied: result.pageInfo?.capApplied ?? false,
           },
         }));
+        // On mobile, jump to the Results pane so the answer is visible without
+        // the user having to switch tabs manually.
+        if (isMobile) {
+          setMobileTab("results");
+        }
       } else if (result.error !== "Query cancelled") {
         const errText =
           typeof result.error === "string"
@@ -2217,398 +2241,417 @@ function Editor({
 
           {/* Unified tab rendering: every tab stays mounted, visibility toggled with CSS */}
           <Box sx={{ flexGrow: 1, overflow: "hidden" }}>
-            {consoleTabs.map(tab => (
-              <Box
-                key={tab.id}
-                data-mako-tab-id={tab.id}
-                data-mako-tab-kind={tab.kind}
-                data-mako-active-tab-content={
-                  activeConsoleId === tab.id ? "true" : undefined
-                }
-                sx={{
-                  height: "100%",
-                  display: activeConsoleId === tab.id ? "block" : "none",
-                  overflow: "hidden",
-                }}
-              >
-                {tab.kind === "settings" ? (
-                  <Settings section={tab.settingsSection} />
-                ) : tab.kind === "members" ? (
-                  <WorkspaceMembers />
-                ) : tab.kind === "connectors" ? (
-                  <ConnectorTab
-                    tabId={tab.id}
-                    sourceId={
-                      typeof tab.content === "string" ? tab.content : undefined
-                    }
-                  />
-                ) : tab.kind === "flow-editor" ? (
-                  <FlowEditor
-                    flowId={tab.metadata?.flowId as string | undefined}
-                    isNew={tab.metadata?.isNew as boolean | undefined}
-                    flowType={
-                      tab.metadata?.flowType as
-                        | "webhook"
-                        | "scheduled"
-                        | "db-scheduled"
-                        | undefined
-                    }
-                    onSave={() => {
-                      // The FlowEditor already handles refreshing the flows list
-                    }}
-                    onCancel={() => {
-                      closeConsole(tab.id);
-                    }}
-                    dbFlowFormRef={dbFlowFormRef}
-                  />
-                ) : tab.kind === "table-data" ? (
-                  <TableDataView tabId={tab.id} />
-                ) : tab.kind === "dashboard" ? (
-                  <DashboardCanvas
-                    dashboardId={tab.metadata?.dashboardId as string}
-                    isNew={tab.metadata?.isNew as boolean}
-                    onCreated={(newId: string) => {
-                      useConsoleStore.setState(state => {
-                        const existingTab = state.tabs[tab.id];
-                        if (existingTab) {
-                          existingTab.metadata = {
-                            ...existingTab.metadata,
-                            dashboardId: newId,
-                            isNew: false,
-                          };
-                          existingTab.title = "Untitled Dashboard";
+            {consoleTabs.map(tab => {
+              const showDesktopOnlyNotice =
+                isMobile &&
+                !!tab.kind &&
+                DESKTOP_ONLY_KINDS.has(tab.kind) &&
+                !dismissedDesktopOnly[tab.id];
+
+              // Top (editor) and bottom (results) panes of a console tab.
+              // Extracted so the desktop vertical split and the mobile
+              // single-pane view can share the exact same children.
+              const consolePane = (
+                <Box
+                  sx={{
+                    height: "100%",
+                    display: "flex",
+                    flexDirection: "column",
+                  }}
+                >
+                  {tab.remoteUpdate && (
+                    <ConsoleRemoteUpdateBanner
+                      remoteUpdate={tab.remoteUpdate}
+                      onLoadLatest={() => {
+                        if (!currentWorkspace?.id) return;
+                        void useConsoleStore
+                          .getState()
+                          .applyRemoteConsoleUpdate(
+                            currentWorkspace.id,
+                            tab.id,
+                          );
+                      }}
+                      onKeepMine={() => {
+                        if (!currentWorkspace?.id) return;
+                        // Use the LIVE Monaco buffer, not the store
+                        // copy — it may lag keystrokes by a debounce.
+                        const live =
+                          consoleRefs.current[
+                            tab.id
+                          ]?.current?.getCurrentContent().content;
+                        void useConsoleStore
+                          .getState()
+                          .resolveRemoteUpdateKeepMine(
+                            currentWorkspace.id,
+                            tab.id,
+                            live ?? tab.content,
+                          );
+                      }}
+                      onDismiss={() =>
+                        useConsoleStore.getState().dismissRemoteUpdate(tab.id)
+                      }
+                      onCloseTab={() =>
+                        useConsoleStore.getState().closeTab(tab.id)
+                      }
+                    />
+                  )}
+                  <Box sx={{ flex: 1, minHeight: 0 }}>
+                    <Console
+                      ref={consoleRefs.current[tab.id]}
+                      consoleId={tab.id}
+                      initialContent={tab.content}
+                      title={tab.title}
+                      onExecute={(content, connectionId, databaseId) =>
+                        handleConsoleExecute(tab.id, content, connectionId, {
+                          databaseId: databaseId || tab.databaseId,
+                          databaseName: tab.databaseName,
+                        })
+                      }
+                      onCancel={() => handleConsoleCancel(tab.id)}
+                      onSave={(content, currentPath) =>
+                        handleConsoleSave(tab.id, content, currentPath)
+                      }
+                      onSaveAsCopy={content =>
+                        handleSaveAsCopy(tab.id, content)
+                      }
+                      onRenameMove={(content, currentPath) =>
+                        handleRenameMove(tab.id, content, currentPath)
+                      }
+                      isExecuting={executingTabs[tab.id] || false}
+                      isCancelling={cancellingTabs[tab.id] || false}
+                      isSaving={isSaving}
+                      onContentChange={content => {
+                        updateContent(tab.id, content);
+                        if (!tab.isDirty) {
+                          updateDirty(tab.id, true);
                         }
-                      });
+                        // Also refresh activeEditorContent for Chat consumers
+                        const ref = consoleRefs.current[tab.id]?.current;
+                        if (activeConsoleId === tab.id && ref) {
+                          setActiveEditorContent(ref.getCurrentContent());
+                        }
+                      }}
+                      connectionId={tab.connectionId}
+                      databaseId={tab.databaseId}
+                      databaseName={tab.databaseName}
+                      databases={availableDatabases}
+                      onDatabaseChange={connId =>
+                        updateConnection(tab.id, connId)
+                      }
+                      onDatabaseNameChange={(dbId, dbName) =>
+                        updateDatabase(tab.id, dbId, dbName)
+                      }
+                      filePath={tab.filePath}
+                      enableVersionControl={true}
+                      onHistoryClick={() => {
+                        setVersionHistoryTabId(tab.id);
+                        setVersionHistoryEntityType("console");
+                        setVersionHistoryOpen(true);
+                      }}
+                      historyAvailable={tab.isSaved}
+                      onShareClick={() => setShareConsoleTabId(tab.id)}
+                      shareAvailable={tab.isSaved}
+                      schedule={tab.schedule}
+                      onCreateSchedule={() =>
+                        handleOpenScheduleModal(tab.id, "create")
+                      }
+                      onUpdateSchedule={() =>
+                        handleOpenScheduleModal(tab.id, "update")
+                      }
+                    />
+                  </Box>
+                </Box>
+              );
+
+              const resultsPane = (
+                <Box
+                  sx={{
+                    height: "100%",
+                    overflow: "hidden",
+                    display: "flex",
+                    flexDirection: "column",
+                  }}
+                >
+                  <Box
+                    sx={{
+                      px: 1.5,
+                      borderBottom: 1,
+                      borderColor: "divider",
+                      minHeight: 36,
+                      display: "flex",
+                      alignItems: "center",
                     }}
-                  />
-                ) : tab.kind === "app" ? (
-                  <AppRenderer appId={tab.metadata?.appId as string} />
-                ) : tab.kind === "app-file" ? (
-                  <AppFileEditor
-                    tabId={tab.id}
-                    appId={tab.metadata?.appId as string}
-                    path={tab.metadata?.path as string}
-                  />
-                ) : tab.kind === "app-binding" ? (
-                  <AppBindingEditor
-                    tabId={tab.id}
-                    appId={tab.metadata?.appId as string}
-                    bindingId={tab.metadata?.bindingId as string}
-                  />
-                ) : tab.kind === "plan" ? (
-                  <PlanDocumentTab
-                    toolCallId={tab.metadata?.toolCallId as string}
-                  />
-                ) : tab.kind === "dbt-file" ? (
-                  <DbtFileEditor
-                    tabId={tab.id}
-                    projectId={tab.metadata?.projectId as string}
-                    path={tab.metadata?.path as string}
-                  />
-                ) : tab.kind === "dbt-job" ? (
-                  <DbtJobView
-                    projectId={tab.metadata?.projectId as string}
-                    jobId={tab.metadata?.jobId as string}
-                    autoEdit={tab.metadata?.autoEdit as boolean | undefined}
-                  />
-                ) : tab.kind === "dbt-console" ? (
-                  <DbtConsoleView
-                    projectId={tab.metadata?.projectId as string}
-                  />
-                ) : tab.kind === "dbt-runs" ? (
-                  <DbtRunsView
-                    tabId={tab.id}
-                    projectId={tab.metadata?.projectId as string}
-                    focusRunId={tab.metadata?.focusRunId as string | undefined}
-                  />
-                ) : tab.kind === "dashboard-data-source" ? (
-                  <DashboardDataSourceEditor
-                    tabId={tab.id}
-                    dashboardId={tab.metadata?.dashboardId as string}
-                    dataSourceId={tab.metadata?.dataSourceId as string}
-                  />
-                ) : (
-                  /* Console tab: editor + results split */
-                  <React.Profiler
-                    id={`Editor.console-panels.${tab.id}`}
-                    onRender={onRenderDebug}
                   >
-                    <PanelGroup
-                      direction="vertical"
-                      style={{ height: "100%", width: "100%" }}
-                      onLayout={
-                        renderDebugEnabled
-                          ? layout => handlePanelLayout(tab.id, layout)
+                    <Tabs
+                      value={tabBottomPanel[tab.id] || "results"}
+                      onChange={(_event, value: "results" | "runs") => {
+                        setTabBottomPanel(prev => ({
+                          ...prev,
+                          [tab.id]: value,
+                        }));
+                        if (value === "runs") {
+                          void loadScheduledRunsForTab(tab.id);
+                        }
+                      }}
+                      sx={{
+                        minHeight: 36,
+                        "& .MuiTabs-indicator": {
+                          height: 2,
+                        },
+                      }}
+                    >
+                      <Tab
+                        value="results"
+                        label="Results"
+                        disableRipple
+                        sx={{
+                          minHeight: 36,
+                          py: 0.25,
+                          px: 1.25,
+                          minWidth: 0,
+                          textTransform: "none",
+                          fontSize: "0.875rem",
+                          fontWeight: 600,
+                          color: "text.secondary",
+                          "&.Mui-selected": {
+                            color: "text.primary",
+                          },
+                        }}
+                      />
+                      <Tab
+                        value="runs"
+                        label={`Runs (${tab.scheduledRun?.runCount ?? 0})`}
+                        disabled={!tab.isSaved}
+                        disableRipple
+                        sx={{
+                          minHeight: 36,
+                          py: 0.25,
+                          px: 1.25,
+                          minWidth: 0,
+                          textTransform: "none",
+                          fontSize: "0.875rem",
+                          fontWeight: 600,
+                          color: "text.secondary",
+                          "&.Mui-selected": {
+                            color: "text.primary",
+                          },
+                          "&.Mui-disabled": {
+                            opacity: 0.5,
+                          },
+                        }}
+                      />
+                    </Tabs>
+                  </Box>
+                  <Box sx={{ flexGrow: 1, minHeight: 0 }}>
+                    {(tabBottomPanel[tab.id] || "results") === "runs" ? (
+                      <ScheduledRunsPanel
+                        loading={tabScheduledRunsLoading[tab.id] || false}
+                        error={tabScheduledRunsError[tab.id]}
+                        runs={tabScheduledRuns[tab.id] || []}
+                      />
+                    ) : (
+                      <ResultsTable
+                        results={tabResults[tab.id] || null}
+                        chartSpec={tabChartSpecs[tab.id] ?? null}
+                        onChartSpecChange={spec =>
+                          setChartSpecForTab(tab.id, spec)
+                        }
+                        viewMode={tabViewModes[tab.id] ?? "table"}
+                        onViewModeChange={mode =>
+                          setViewModeForTab(tab.id, mode)
+                        }
+                        onChartRenderError={error => {
+                          const cb = pendingRenderCallbackRef.current[tab.id];
+                          if (cb) {
+                            cb({ success: false, error });
+                            delete pendingRenderCallbackRef.current[tab.id];
+                          }
+                        }}
+                        onChartRenderSuccess={() => {
+                          const cb = pendingRenderCallbackRef.current[tab.id];
+                          if (cb) {
+                            cb({ success: true });
+                            delete pendingRenderCallbackRef.current[tab.id];
+                          }
+                        }}
+                        onPreviousPage={() => handlePreviousResultsPage(tab.id)}
+                        onNextPage={() => handleNextResultsPage(tab.id)}
+                        onDownload={format =>
+                          void handleDownloadResults(tab.id, format)
+                        }
+                      />
+                    )}
+                  </Box>
+                </Box>
+              );
+
+              return (
+                <Box
+                  key={tab.id}
+                  data-mako-tab-id={tab.id}
+                  data-mako-tab-kind={tab.kind}
+                  data-mako-active-tab-content={
+                    activeConsoleId === tab.id ? "true" : undefined
+                  }
+                  sx={{
+                    height: "100%",
+                    display: activeConsoleId === tab.id ? "block" : "none",
+                    overflow: "hidden",
+                  }}
+                >
+                  {showDesktopOnlyNotice ? (
+                    <Box sx={{ p: 2 }}>
+                      <Alert
+                        severity="info"
+                        onClose={() =>
+                          setDismissedDesktopOnly(prev => ({
+                            ...prev,
+                            [tab.id]: true,
+                          }))
+                        }
+                      >
+                        This view is designed for a larger screen and may be
+                        hard to use on a phone. Open Mako on a desktop for the
+                        full experience.
+                      </Alert>
+                    </Box>
+                  ) : tab.kind === "settings" ? (
+                    <Settings section={tab.settingsSection} />
+                  ) : tab.kind === "members" ? (
+                    <WorkspaceMembers />
+                  ) : tab.kind === "connectors" ? (
+                    <ConnectorTab
+                      tabId={tab.id}
+                      sourceId={
+                        typeof tab.content === "string"
+                          ? tab.content
                           : undefined
                       }
+                    />
+                  ) : tab.kind === "flow-editor" ? (
+                    <FlowEditor
+                      flowId={tab.metadata?.flowId as string | undefined}
+                      isNew={tab.metadata?.isNew as boolean | undefined}
+                      flowType={
+                        tab.metadata?.flowType as
+                          | "webhook"
+                          | "scheduled"
+                          | "db-scheduled"
+                          | undefined
+                      }
+                      onSave={() => {
+                        // The FlowEditor already handles refreshing the flows list
+                      }}
+                      onCancel={() => {
+                        closeConsole(tab.id);
+                      }}
+                      dbFlowFormRef={dbFlowFormRef}
+                    />
+                  ) : tab.kind === "table-data" ? (
+                    <TableDataView tabId={tab.id} />
+                  ) : tab.kind === "dashboard" ? (
+                    <DashboardCanvas
+                      dashboardId={tab.metadata?.dashboardId as string}
+                      isNew={tab.metadata?.isNew as boolean}
+                      onCreated={(newId: string) => {
+                        useConsoleStore.setState(state => {
+                          const existingTab = state.tabs[tab.id];
+                          if (existingTab) {
+                            existingTab.metadata = {
+                              ...existingTab.metadata,
+                              dashboardId: newId,
+                              isNew: false,
+                            };
+                            existingTab.title = "Untitled Dashboard";
+                          }
+                        });
+                      }}
+                    />
+                  ) : tab.kind === "app" ? (
+                    <AppRenderer appId={tab.metadata?.appId as string} />
+                  ) : tab.kind === "app-file" ? (
+                    <AppFileEditor
+                      tabId={tab.id}
+                      appId={tab.metadata?.appId as string}
+                      path={tab.metadata?.path as string}
+                    />
+                  ) : tab.kind === "app-binding" ? (
+                    <AppBindingEditor
+                      tabId={tab.id}
+                      appId={tab.metadata?.appId as string}
+                      bindingId={tab.metadata?.bindingId as string}
+                    />
+                  ) : tab.kind === "plan" ? (
+                    <PlanDocumentTab
+                      toolCallId={tab.metadata?.toolCallId as string}
+                    />
+                  ) : tab.kind === "dbt-file" ? (
+                    <DbtFileEditor
+                      tabId={tab.id}
+                      projectId={tab.metadata?.projectId as string}
+                      path={tab.metadata?.path as string}
+                    />
+                  ) : tab.kind === "dbt-job" ? (
+                    <DbtJobView
+                      projectId={tab.metadata?.projectId as string}
+                      jobId={tab.metadata?.jobId as string}
+                      autoEdit={tab.metadata?.autoEdit as boolean | undefined}
+                    />
+                  ) : tab.kind === "dbt-console" ? (
+                    <DbtConsoleView
+                      projectId={tab.metadata?.projectId as string}
+                    />
+                  ) : tab.kind === "dbt-runs" ? (
+                    <DbtRunsView
+                      tabId={tab.id}
+                      projectId={tab.metadata?.projectId as string}
+                      focusRunId={
+                        tab.metadata?.focusRunId as string | undefined
+                      }
+                    />
+                  ) : tab.kind === "dashboard-data-source" ? (
+                    <DashboardDataSourceEditor
+                      tabId={tab.id}
+                      dashboardId={tab.metadata?.dashboardId as string}
+                      dataSourceId={tab.metadata?.dataSourceId as string}
+                    />
+                  ) : (
+                    /* Console tab: editor + results split (desktop) or a single
+                     full-screen pane switched by the bottom nav (mobile). */
+                    <React.Profiler
+                      id={`Editor.console-panels.${tab.id}`}
+                      onRender={onRenderDebug}
                     >
-                      <Panel defaultSize={60} minSize={1}>
-                        <Box
-                          sx={{
-                            height: "100%",
-                            display: "flex",
-                            flexDirection: "column",
-                          }}
+                      {isMobile ? (
+                        <Box sx={{ height: "100%" }}>
+                          {mobileResultsView ? resultsPane : consolePane}
+                        </Box>
+                      ) : (
+                        <PanelGroup
+                          direction="vertical"
+                          style={{ height: "100%", width: "100%" }}
+                          onLayout={
+                            renderDebugEnabled
+                              ? layout => handlePanelLayout(tab.id, layout)
+                              : undefined
+                          }
                         >
-                          {tab.remoteUpdate && (
-                            <ConsoleRemoteUpdateBanner
-                              remoteUpdate={tab.remoteUpdate}
-                              onLoadLatest={() => {
-                                if (!currentWorkspace?.id) return;
-                                void useConsoleStore
-                                  .getState()
-                                  .applyRemoteConsoleUpdate(
-                                    currentWorkspace.id,
-                                    tab.id,
-                                  );
-                              }}
-                              onKeepMine={() => {
-                                if (!currentWorkspace?.id) return;
-                                // Use the LIVE Monaco buffer, not the store
-                                // copy — it may lag keystrokes by a debounce.
-                                const live =
-                                  consoleRefs.current[
-                                    tab.id
-                                  ]?.current?.getCurrentContent().content;
-                                void useConsoleStore
-                                  .getState()
-                                  .resolveRemoteUpdateKeepMine(
-                                    currentWorkspace.id,
-                                    tab.id,
-                                    live ?? tab.content,
-                                  );
-                              }}
-                              onDismiss={() =>
-                                useConsoleStore
-                                  .getState()
-                                  .dismissRemoteUpdate(tab.id)
-                              }
-                              onCloseTab={() =>
-                                useConsoleStore.getState().closeTab(tab.id)
-                              }
-                            />
-                          )}
-                          <Box sx={{ flex: 1, minHeight: 0 }}>
-                            <Console
-                              ref={consoleRefs.current[tab.id]}
-                              consoleId={tab.id}
-                              initialContent={tab.content}
-                              title={tab.title}
-                              onExecute={(content, connectionId, databaseId) =>
-                                handleConsoleExecute(
-                                  tab.id,
-                                  content,
-                                  connectionId,
-                                  {
-                                    databaseId: databaseId || tab.databaseId,
-                                    databaseName: tab.databaseName,
-                                  },
-                                )
-                              }
-                              onCancel={() => handleConsoleCancel(tab.id)}
-                              onSave={(content, currentPath) =>
-                                handleConsoleSave(tab.id, content, currentPath)
-                              }
-                              onSaveAsCopy={content =>
-                                handleSaveAsCopy(tab.id, content)
-                              }
-                              onRenameMove={(content, currentPath) =>
-                                handleRenameMove(tab.id, content, currentPath)
-                              }
-                              isExecuting={executingTabs[tab.id] || false}
-                              isCancelling={cancellingTabs[tab.id] || false}
-                              isSaving={isSaving}
-                              onContentChange={content => {
-                                updateContent(tab.id, content);
-                                if (!tab.isDirty) {
-                                  updateDirty(tab.id, true);
-                                }
-                                // Also refresh activeEditorContent for Chat consumers
-                                const ref =
-                                  consoleRefs.current[tab.id]?.current;
-                                if (activeConsoleId === tab.id && ref) {
-                                  setActiveEditorContent(
-                                    ref.getCurrentContent(),
-                                  );
-                                }
-                              }}
-                              connectionId={tab.connectionId}
-                              databaseId={tab.databaseId}
-                              databaseName={tab.databaseName}
-                              databases={availableDatabases}
-                              onDatabaseChange={connId =>
-                                updateConnection(tab.id, connId)
-                              }
-                              onDatabaseNameChange={(dbId, dbName) =>
-                                updateDatabase(tab.id, dbId, dbName)
-                              }
-                              filePath={tab.filePath}
-                              enableVersionControl={true}
-                              onHistoryClick={() => {
-                                setVersionHistoryTabId(tab.id);
-                                setVersionHistoryEntityType("console");
-                                setVersionHistoryOpen(true);
-                              }}
-                              historyAvailable={tab.isSaved}
-                              onShareClick={() => setShareConsoleTabId(tab.id)}
-                              shareAvailable={tab.isSaved}
-                              schedule={tab.schedule}
-                              onCreateSchedule={() =>
-                                handleOpenScheduleModal(tab.id, "create")
-                              }
-                              onUpdateSchedule={() =>
-                                handleOpenScheduleModal(tab.id, "update")
-                              }
-                            />
-                          </Box>
-                        </Box>
-                      </Panel>
+                          <Panel defaultSize={60} minSize={1}>
+                            {consolePane}
+                          </Panel>
 
-                      <StyledVerticalResizeHandle />
+                          <StyledVerticalResizeHandle />
 
-                      <Panel defaultSize={40} minSize={1}>
-                        <Box sx={{ height: "100%", overflow: "hidden" }}>
-                          <Box
-                            sx={{
-                              height: "100%",
-                              display: "flex",
-                              flexDirection: "column",
-                            }}
-                          >
-                            <Box
-                              sx={{
-                                px: 1.5,
-                                borderBottom: 1,
-                                borderColor: "divider",
-                                minHeight: 36,
-                                display: "flex",
-                                alignItems: "center",
-                              }}
-                            >
-                              <Tabs
-                                value={tabBottomPanel[tab.id] || "results"}
-                                onChange={(
-                                  _event,
-                                  value: "results" | "runs",
-                                ) => {
-                                  setTabBottomPanel(prev => ({
-                                    ...prev,
-                                    [tab.id]: value,
-                                  }));
-                                  if (value === "runs") {
-                                    void loadScheduledRunsForTab(tab.id);
-                                  }
-                                }}
-                                sx={{
-                                  minHeight: 36,
-                                  "& .MuiTabs-indicator": {
-                                    height: 2,
-                                  },
-                                }}
-                              >
-                                <Tab
-                                  value="results"
-                                  label="Results"
-                                  disableRipple
-                                  sx={{
-                                    minHeight: 36,
-                                    py: 0.25,
-                                    px: 1.25,
-                                    minWidth: 0,
-                                    textTransform: "none",
-                                    fontSize: "0.875rem",
-                                    fontWeight: 600,
-                                    color: "text.secondary",
-                                    "&.Mui-selected": {
-                                      color: "text.primary",
-                                    },
-                                  }}
-                                />
-                                <Tab
-                                  value="runs"
-                                  label={`Runs (${tab.scheduledRun?.runCount ?? 0})`}
-                                  disabled={!tab.isSaved}
-                                  disableRipple
-                                  sx={{
-                                    minHeight: 36,
-                                    py: 0.25,
-                                    px: 1.25,
-                                    minWidth: 0,
-                                    textTransform: "none",
-                                    fontSize: "0.875rem",
-                                    fontWeight: 600,
-                                    color: "text.secondary",
-                                    "&.Mui-selected": {
-                                      color: "text.primary",
-                                    },
-                                    "&.Mui-disabled": {
-                                      opacity: 0.5,
-                                    },
-                                  }}
-                                />
-                              </Tabs>
-                            </Box>
-                            <Box sx={{ flexGrow: 1, minHeight: 0 }}>
-                              {(tabBottomPanel[tab.id] || "results") ===
-                              "runs" ? (
-                                <ScheduledRunsPanel
-                                  loading={
-                                    tabScheduledRunsLoading[tab.id] || false
-                                  }
-                                  error={tabScheduledRunsError[tab.id]}
-                                  runs={tabScheduledRuns[tab.id] || []}
-                                />
-                              ) : (
-                                <ResultsTable
-                                  results={tabResults[tab.id] || null}
-                                  chartSpec={tabChartSpecs[tab.id] ?? null}
-                                  onChartSpecChange={spec =>
-                                    setChartSpecForTab(tab.id, spec)
-                                  }
-                                  viewMode={tabViewModes[tab.id] ?? "table"}
-                                  onViewModeChange={mode =>
-                                    setViewModeForTab(tab.id, mode)
-                                  }
-                                  onChartRenderError={error => {
-                                    const cb =
-                                      pendingRenderCallbackRef.current[tab.id];
-                                    if (cb) {
-                                      cb({ success: false, error });
-                                      delete pendingRenderCallbackRef.current[
-                                        tab.id
-                                      ];
-                                    }
-                                  }}
-                                  onChartRenderSuccess={() => {
-                                    const cb =
-                                      pendingRenderCallbackRef.current[tab.id];
-                                    if (cb) {
-                                      cb({ success: true });
-                                      delete pendingRenderCallbackRef.current[
-                                        tab.id
-                                      ];
-                                    }
-                                  }}
-                                  onPreviousPage={() =>
-                                    handlePreviousResultsPage(tab.id)
-                                  }
-                                  onNextPage={() =>
-                                    handleNextResultsPage(tab.id)
-                                  }
-                                  onDownload={format =>
-                                    void handleDownloadResults(tab.id, format)
-                                  }
-                                />
-                              )}
-                            </Box>
-                          </Box>
-                        </Box>
-                      </Panel>
-                    </PanelGroup>
-                  </React.Profiler>
-                )}
-              </Box>
-            ))}
+                          <Panel defaultSize={40} minSize={1}>
+                            {resultsPane}
+                          </Panel>
+                        </PanelGroup>
+                      )}
+                    </React.Profiler>
+                  )}
+                </Box>
+              );
+            })}
           </Box>
         </Box>
       ) : (

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -34,6 +34,11 @@ import {
   Alert,
   Snackbar,
   Tooltip,
+  Menu,
+  MenuItem,
+  ListItemIcon,
+  ListItemText,
+  Divider,
 } from "@mui/material";
 import { Close as CloseIcon } from "@mui/icons-material";
 import {
@@ -50,6 +55,9 @@ import {
   Table as TableDataIcon,
   ClipboardList as PlanIcon,
   Menu as MenuIcon,
+  ChevronDown as ChevronDownIcon,
+  Plus as PlusIcon,
+  X as CloseTabIcon,
 } from "lucide-react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { loader } from "@monaco-editor/react";
@@ -291,6 +299,40 @@ function SortableConsoleTab(props: React.ComponentProps<typeof Tab>) {
   );
 }
 
+// Claude-style floating round button for the mobile editor header — paper fill,
+// blur and a hairline so it reads as floating chrome over the editor content.
+const MOBILE_FLOAT_BTN_SX = {
+  width: 38,
+  height: 38,
+  flexShrink: 0,
+  borderRadius: "50%",
+  color: "text.secondary",
+  bgcolor: "background.paper",
+  border: 1,
+  borderColor: "divider",
+  boxShadow: "0 1px 3px rgba(0, 0, 0, 0.08)",
+  backdropFilter: "blur(8px)",
+  "&:hover": { bgcolor: "action.hover" },
+} as const;
+
+// Centered "current window" pill that opens the open-tabs switcher menu.
+const MOBILE_WINDOW_PILL_SX = {
+  flex: 1,
+  minWidth: 0,
+  maxWidth: 260,
+  height: 38,
+  px: 1.5,
+  textTransform: "none",
+  borderRadius: 999,
+  color: "text.primary",
+  bgcolor: "background.paper",
+  border: 1,
+  borderColor: "divider",
+  boxShadow: "0 1px 3px rgba(0, 0, 0, 0.08)",
+  backdropFilter: "blur(8px)",
+  "&:hover": { bgcolor: "action.hover" },
+} as const;
+
 function Editor({
   dbFlowFormRef,
   onChartSpecChangeRef,
@@ -346,6 +388,9 @@ function Editor({
     {},
   );
   const [isSaving, setIsSaving] = useState(false);
+  const [windowMenuAnchor, setWindowMenuAnchor] = useState<null | HTMLElement>(
+    null,
+  );
   const [errorModalOpen, setErrorModalOpen] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string>("");
   const [errorPreviewRetry, setErrorPreviewRetry] = useState<{
@@ -2049,191 +2094,296 @@ function Editor({
             flexDirection: "column",
           }}
         >
-          {/* Tabs */}
-          <Box
-            sx={{
-              display: "flex",
-              alignItems: "center",
-              minHeight: 36,
-              borderBottom: 1,
-              borderColor: "divider",
-            }}
-          >
-            {isMobile && (
+          {/* Tab bar (desktop) / Claude-style floating window switcher
+              (mobile): round hamburger + center window pill + new-console. */}
+          {isMobile ? (
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 1,
+                px: 1,
+                py: 0.75,
+                minHeight: 52,
+              }}
+            >
               <Tooltip title="Open explorer">
                 <IconButton
-                  size="small"
                   aria-label="Open explorer"
                   onClick={() => useUIStore.getState().openMobileDrawer()}
-                  sx={{ ml: 0.5, mr: 0.25, flexShrink: 0 }}
+                  sx={MOBILE_FLOAT_BTN_SX}
                 >
                   <MenuIcon size={20} />
                 </IconButton>
               </Tooltip>
-            )}
-            <DndContext
-              sensors={dndSensors}
-              collisionDetection={closestCenter}
-              modifiers={[restrictToHorizontalAxis]}
-              onDragEnd={handleTabDragEnd}
-            >
-              <SortableContext
-                items={sortableTabIds}
-                strategy={horizontalListSortingStrategy}
+              <Button
+                aria-label="Switch window"
+                onClick={e => setWindowMenuAnchor(e.currentTarget)}
+                endIcon={<ChevronDownIcon size={16} />}
+                sx={MOBILE_WINDOW_PILL_SX}
               >
-                <Tabs
-                  value={activeConsoleId}
-                  onChange={handleTabChange}
-                  variant="scrollable"
-                  scrollButtons={false}
+                <Box
+                  component="span"
                   sx={{
-                    minHeight: 36,
-                    "& .MuiTabs-indicator": { height: 2 },
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
                   }}
                 >
-                  {consoleTabs.map((tab, index) => {
-                    const isActiveTab = activeConsoleId === tab.id;
-                    const connectionIconUrl = tab.connectionId
-                      ? connectionIconById.get(tab.connectionId)
-                      : undefined;
-                    const nextTab = consoleTabs[index + 1];
-                    const isLastTab = index === consoleTabs.length - 1;
-                    // Cursor-style separator: thin vertical rule on the trailing
-                    // edge of every tab, hidden when this tab or the next one is
-                    // active, and hidden on the very last tab.
-                    const showSeparator =
-                      !isActiveTab &&
-                      !isLastTab &&
-                      nextTab?.id !== activeConsoleId;
-                    return (
-                      <SortableConsoleTab
-                        key={tab.id}
-                        value={tab.id}
-                        sx={{
-                          minHeight: 36,
-                          py: 0.25,
-                          px: 1.25,
-                          textTransform: "none",
-                          position: "relative",
-                          "& .tab-close-btn": {
-                            visibility: isActiveTab ? "visible" : "hidden",
-                          },
-                          "&:hover .tab-close-btn": {
-                            visibility: "visible",
-                          },
-                          "&::after": showSeparator
-                            ? {
-                                content: '""',
-                                position: "absolute",
-                                right: 0,
-                                top: 0,
-                                bottom: 0,
-                                width: "1px",
-                                backgroundColor: "divider",
-                                pointerEvents: "none",
-                              }
-                            : {},
-                        }}
-                        label={
-                          <Box
-                            sx={{
-                              display: "flex",
-                              alignItems: "center",
-                              gap: 0.5,
-                              minWidth: 0,
-                              maxWidth: "100%",
-                            }}
-                          >
-                            {tab.icon ? (
-                              <Box
-                                component="img"
-                                src={tab.icon}
-                                alt="tab icon"
-                                sx={{ width: 18, height: 18 }}
-                              />
-                            ) : tab.kind === "settings" ? (
-                              <SettingsIcon size={18} strokeWidth={1.5} />
-                            ) : tab.kind === "connectors" ? (
-                              <DataSourceIcon size={18} strokeWidth={1.5} />
-                            ) : tab.kind === "flow-editor" ? (
-                              tab.metadata?.flowType === "webhook" ? (
-                                <WebhookIcon size={18} strokeWidth={1.5} />
-                              ) : tab.metadata?.enabled === false ? (
-                                <PauseIcon size={18} strokeWidth={1.5} />
+                  {(activeConsoleId && tabs[activeConsoleId]?.title) ||
+                    "Console"}
+                </Box>
+              </Button>
+              <Tooltip title="New console">
+                <IconButton
+                  aria-label="New console"
+                  onClick={() => openTab({ title: "New Console", content: "" })}
+                  sx={MOBILE_FLOAT_BTN_SX}
+                >
+                  <PlusIcon size={20} />
+                </IconButton>
+              </Tooltip>
+            </Box>
+          ) : (
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                minHeight: 36,
+                borderBottom: 1,
+                borderColor: "divider",
+              }}
+            >
+              <DndContext
+                sensors={dndSensors}
+                collisionDetection={closestCenter}
+                modifiers={[restrictToHorizontalAxis]}
+                onDragEnd={handleTabDragEnd}
+              >
+                <SortableContext
+                  items={sortableTabIds}
+                  strategy={horizontalListSortingStrategy}
+                >
+                  <Tabs
+                    value={activeConsoleId}
+                    onChange={handleTabChange}
+                    variant="scrollable"
+                    scrollButtons={false}
+                    sx={{
+                      minHeight: 36,
+                      "& .MuiTabs-indicator": { height: 2 },
+                    }}
+                  >
+                    {consoleTabs.map((tab, index) => {
+                      const isActiveTab = activeConsoleId === tab.id;
+                      const connectionIconUrl = tab.connectionId
+                        ? connectionIconById.get(tab.connectionId)
+                        : undefined;
+                      const nextTab = consoleTabs[index + 1];
+                      const isLastTab = index === consoleTabs.length - 1;
+                      // Cursor-style separator: thin vertical rule on the trailing
+                      // edge of every tab, hidden when this tab or the next one is
+                      // active, and hidden on the very last tab.
+                      const showSeparator =
+                        !isActiveTab &&
+                        !isLastTab &&
+                        nextTab?.id !== activeConsoleId;
+                      return (
+                        <SortableConsoleTab
+                          key={tab.id}
+                          value={tab.id}
+                          sx={{
+                            minHeight: 36,
+                            py: 0.25,
+                            px: 1.25,
+                            textTransform: "none",
+                            position: "relative",
+                            "& .tab-close-btn": {
+                              visibility: isActiveTab ? "visible" : "hidden",
+                            },
+                            "&:hover .tab-close-btn": {
+                              visibility: "visible",
+                            },
+                            "&::after": showSeparator
+                              ? {
+                                  content: '""',
+                                  position: "absolute",
+                                  right: 0,
+                                  top: 0,
+                                  bottom: 0,
+                                  width: "1px",
+                                  backgroundColor: "divider",
+                                  pointerEvents: "none",
+                                }
+                              : {},
+                          }}
+                          label={
+                            <Box
+                              sx={{
+                                display: "flex",
+                                alignItems: "center",
+                                gap: 0.5,
+                                minWidth: 0,
+                                maxWidth: "100%",
+                              }}
+                            >
+                              {tab.icon ? (
+                                <Box
+                                  component="img"
+                                  src={tab.icon}
+                                  alt="tab icon"
+                                  sx={{ width: 18, height: 18 }}
+                                />
+                              ) : tab.kind === "settings" ? (
+                                <SettingsIcon size={18} strokeWidth={1.5} />
+                              ) : tab.kind === "connectors" ? (
+                                <DataSourceIcon size={18} strokeWidth={1.5} />
+                              ) : tab.kind === "flow-editor" ? (
+                                tab.metadata?.flowType === "webhook" ? (
+                                  <WebhookIcon size={18} strokeWidth={1.5} />
+                                ) : tab.metadata?.enabled === false ? (
+                                  <PauseIcon size={18} strokeWidth={1.5} />
+                                ) : (
+                                  <ScheduleIcon size={18} strokeWidth={1.5} />
+                                )
+                              ) : tab.kind === "dashboard" ? (
+                                <DashboardIcon size={18} strokeWidth={1.5} />
+                              ) : tab.kind === "app" ? (
+                                <AppIcon size={18} strokeWidth={1.5} />
+                              ) : tab.kind === "app-file" ? (
+                                <AppFileIcon size={18} strokeWidth={1.5} />
+                              ) : tab.kind === "app-binding" ||
+                                tab.kind === "dashboard-data-source" ? (
+                                <DatabaseIcon size={18} strokeWidth={1.5} />
+                              ) : tab.kind === "table-data" ? (
+                                <TableDataIcon size={18} strokeWidth={1.5} />
+                              ) : tab.kind === "plan" ? (
+                                <PlanIcon size={18} strokeWidth={1.5} />
+                              ) : connectionIconUrl ? (
+                                <Box
+                                  component="img"
+                                  src={connectionIconUrl}
+                                  alt="db icon"
+                                  sx={{
+                                    width: 18,
+                                    height: 18,
+                                    objectFit: "contain",
+                                  }}
+                                />
                               ) : (
-                                <ScheduleIcon size={18} strokeWidth={1.5} />
-                              )
-                            ) : tab.kind === "dashboard" ? (
-                              <DashboardIcon size={18} strokeWidth={1.5} />
-                            ) : tab.kind === "app" ? (
-                              <AppIcon size={18} strokeWidth={1.5} />
-                            ) : tab.kind === "app-file" ? (
-                              <AppFileIcon size={18} strokeWidth={1.5} />
-                            ) : tab.kind === "app-binding" ||
-                              tab.kind === "dashboard-data-source" ? (
-                              <DatabaseIcon size={18} strokeWidth={1.5} />
-                            ) : tab.kind === "table-data" ? (
-                              <TableDataIcon size={18} strokeWidth={1.5} />
-                            ) : tab.kind === "plan" ? (
-                              <PlanIcon size={18} strokeWidth={1.5} />
-                            ) : connectionIconUrl ? (
-                              <Box
-                                component="img"
-                                src={connectionIconUrl}
-                                alt="db icon"
-                                sx={{
-                                  width: 18,
-                                  height: 18,
-                                  objectFit: "contain",
+                                <ConsoleIcon size={18} strokeWidth={1.5} />
+                              )}
+                              <span
+                                style={{
+                                  fontStyle: tab.isDirty ? "normal" : "italic",
+                                  overflow: "hidden",
+                                  textOverflow: "ellipsis",
+                                  whiteSpace: "nowrap",
+                                  display: "inline-block",
+                                  maxWidth: "150px",
                                 }}
-                              />
-                            ) : (
-                              <ConsoleIcon size={18} strokeWidth={1.5} />
-                            )}
-                            <span
-                              style={{
-                                fontStyle: tab.isDirty ? "normal" : "italic",
-                                overflow: "hidden",
-                                textOverflow: "ellipsis",
-                                whiteSpace: "nowrap",
-                                display: "inline-block",
-                                maxWidth: "150px",
-                              }}
-                              onDoubleClick={e => {
-                                e.stopPropagation();
-                                updateDirty(tab.id, true);
-                              }}
-                              title={tab.title}
-                            >
-                              {tab.title?.split("/").filter(Boolean).pop() ||
-                                tab.title}
-                            </span>
-                            <IconButton
-                              component="span"
-                              size="small"
-                              className="tab-close-btn"
-                              onClick={e => {
-                                e.stopPropagation();
-                                closeConsole(tab.id);
-                              }}
-                              onPointerDown={e => {
-                                // Prevent the Tab's drag listener from starting
-                                // a drag when the user clicks the close button.
-                                e.stopPropagation();
-                              }}
-                              sx={{ p: 0.25, ml: 0 }}
-                            >
-                              <CloseIcon fontSize="inherit" />
-                            </IconButton>
-                          </Box>
-                        }
-                      />
-                    );
-                  })}
-                </Tabs>
-              </SortableContext>
-            </DndContext>
-          </Box>
+                                onDoubleClick={e => {
+                                  e.stopPropagation();
+                                  updateDirty(tab.id, true);
+                                }}
+                                title={tab.title}
+                              >
+                                {tab.title?.split("/").filter(Boolean).pop() ||
+                                  tab.title}
+                              </span>
+                              <IconButton
+                                component="span"
+                                size="small"
+                                className="tab-close-btn"
+                                onClick={e => {
+                                  e.stopPropagation();
+                                  closeConsole(tab.id);
+                                }}
+                                onPointerDown={e => {
+                                  // Prevent the Tab's drag listener from starting
+                                  // a drag when the user clicks the close button.
+                                  e.stopPropagation();
+                                }}
+                                sx={{ p: 0.25, ml: 0 }}
+                              >
+                                <CloseIcon fontSize="inherit" />
+                              </IconButton>
+                            </Box>
+                          }
+                        />
+                      );
+                    })}
+                  </Tabs>
+                </SortableContext>
+              </DndContext>
+            </Box>
+          )}
+
+          {/* Mobile window switcher menu — lists open tabs + new console. */}
+          <Menu
+            anchorEl={windowMenuAnchor}
+            open={Boolean(windowMenuAnchor)}
+            onClose={() => setWindowMenuAnchor(null)}
+            anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+            transformOrigin={{ vertical: "top", horizontal: "center" }}
+            slotProps={{ paper: { sx: { maxHeight: 360, minWidth: 240 } } }}
+          >
+            {consoleTabs.map(tab => (
+              <MenuItem
+                key={tab.id}
+                selected={tab.id === activeConsoleId}
+                onClick={() => {
+                  setActiveTab(tab.id);
+                  setWindowMenuAnchor(null);
+                }}
+                sx={{ pr: 1 }}
+              >
+                <ListItemIcon>
+                  {tab.icon ? (
+                    <Box
+                      component="img"
+                      src={tab.icon}
+                      alt=""
+                      sx={{ width: 18, height: 18 }}
+                    />
+                  ) : (
+                    <ConsoleIcon size={18} strokeWidth={1.5} />
+                  )}
+                </ListItemIcon>
+                <ListItemText
+                  primary={tab.title}
+                  primaryTypographyProps={{
+                    noWrap: true,
+                    sx: { maxWidth: 180 },
+                  }}
+                />
+                <IconButton
+                  size="small"
+                  aria-label={`Close ${tab.title}`}
+                  onClick={e => {
+                    e.stopPropagation();
+                    cleanupTab(tab.id);
+                  }}
+                  sx={{ ml: 1 }}
+                >
+                  <CloseTabIcon size={16} />
+                </IconButton>
+              </MenuItem>
+            ))}
+            <Divider />
+            <MenuItem
+              onClick={() => {
+                openTab({ title: "New Console", content: "" });
+                setWindowMenuAnchor(null);
+              }}
+            >
+              <ListItemIcon>
+                <PlusIcon size={18} strokeWidth={1.5} />
+              </ListItemIcon>
+              <ListItemText primary="New console" />
+            </MenuItem>
+          </Menu>
 
           {/* Breadcrumb path (Cursor-style) — one consistent bar for every
               tab kind. Views that embed their own actions in the bar
@@ -2682,17 +2832,16 @@ function Editor({
               sx={{
                 display: "flex",
                 alignItems: "center",
-                minHeight: 36,
-                px: 0.5,
-                borderBottom: 1,
-                borderColor: "divider",
+                minHeight: 52,
+                px: 1,
+                py: 0.75,
               }}
             >
               <Tooltip title="Open explorer">
                 <IconButton
-                  size="small"
                   aria-label="Open explorer"
                   onClick={() => useUIStore.getState().openMobileDrawer()}
+                  sx={MOBILE_FLOAT_BTN_SX}
                 >
                   <MenuIcon size={20} />
                 </IconButton>

--- a/app/src/components/ResourceTree.tsx
+++ b/app/src/components/ResourceTree.tsx
@@ -52,6 +52,7 @@ import {
   DroppableFolderContent,
   SectionScope,
 } from "./resource-tree/dnd";
+import { useIsMobile } from "../hooks/useIsMobile";
 
 // Pixel height of a single tree row. Used to stack sticky folder/section
 // headers so each ancestor pins one row below its parent as the user scrolls.
@@ -275,6 +276,14 @@ function ResourceTreeInner(
   }: ResourceTreeProps,
   ref: React.Ref<ResourceTreeRef>,
 ) {
+  // Larger, finger-friendly rows and caret hit areas on phones. `rowHeight`
+  // also feeds the sticky folder/section header stacking, so deriving it once
+  // here keeps everything aligned.
+  const isMobile = useIsMobile();
+  const rowHeight = isMobile ? 36 : ROW_HEIGHT;
+  const iconColWidth = isMobile ? 28 : ICON_COL_WIDTH;
+  const caretSize = isMobile ? 28 : 18;
+
   const [focusedNodeId, setFocusedNodeId] = useState<string | null>(null);
   const [renamingItemId, setRenamingItemId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
@@ -1020,7 +1029,7 @@ function ResourceTreeInner(
     pl: 1.5 + depth * 1.5,
     minWidth: 0,
     py: 0,
-    minHeight: ROW_HEIGHT,
+    minHeight: rowHeight,
     bgcolor: isDropTarget
       ? "action.hover"
       : isSelected
@@ -1122,7 +1131,7 @@ function ResourceTreeInner(
               // Stack ancestor headers: depth=1 sits just below the section
               // header (which is sticky at top: 0), depth=2 one row below
               // that, and so on.
-              top: depth * ROW_HEIGHT,
+              top: depth * rowHeight,
               // Deeper folders get a lower z-index so outer ancestors always
               // paint on top when sticky rows collide during scroll.
               zIndex: 20 - depth,
@@ -1140,7 +1149,7 @@ function ResourceTreeInner(
           >
             <ListItemIcon
               sx={{
-                minWidth: ICON_COL_WIDTH,
+                minWidth: iconColWidth,
                 mr: 0,
                 // MUI's ListItemIcon defaults to `action.active` which looks
                 // dimmed; the chevron should match the folder name's color.
@@ -1160,8 +1169,8 @@ function ResourceTreeInner(
                   display: "inline-flex",
                   alignItems: "center",
                   justifyContent: "center",
-                  width: 18,
-                  height: 18,
+                  width: caretSize,
+                  height: caretSize,
                 }}
               >
                 {isExpanded ? (
@@ -1172,7 +1181,7 @@ function ResourceTreeInner(
               </Box>
             </ListItemIcon>
             {!hideFolderIcon && (
-              <ListItemIcon sx={{ minWidth: ICON_COL_WIDTH, mr: 0.75 }}>
+              <ListItemIcon sx={{ minWidth: iconColWidth, mr: 0.75 }}>
                 {getItemIcon ? (
                   getItemIcon(node, { isExpanded })
                 ) : isExpanded ? (
@@ -1250,8 +1259,8 @@ function ResourceTreeInner(
                       sx={{
                         pl: 1.5 + (depth + 1) * 1.5 + 2.75,
                         py: 0,
-                        minHeight: ROW_HEIGHT,
-                        lineHeight: `${ROW_HEIGHT}px`,
+                        minHeight: rowHeight,
+                        lineHeight: `${rowHeight}px`,
                         display: "flex",
                         alignItems: "center",
                       }}
@@ -1324,10 +1333,10 @@ function ResourceTreeInner(
         >
           {!hideFolderIcon && (
             <ListItemIcon
-              sx={{ minWidth: ICON_COL_WIDTH, visibility: "hidden", mr: 0 }}
+              sx={{ minWidth: iconColWidth, visibility: "hidden", mr: 0 }}
             />
           )}
-          <ListItemIcon sx={{ minWidth: ICON_COL_WIDTH, mr: 0.75 }}>
+          <ListItemIcon sx={{ minWidth: iconColWidth, mr: 0.75 }}>
             {getItemIcon ? getItemIcon(node) : null}
           </ListItemIcon>
           <MuiListItemText
@@ -1400,7 +1409,7 @@ function ResourceTreeInner(
           py: 0,
           pl: 1.5,
           minWidth: 0,
-          minHeight: ROW_HEIGHT,
+          minHeight: rowHeight,
           bgcolor: isDropTarget
             ? "action.hover"
             : headerSelected
@@ -1425,7 +1434,7 @@ function ResourceTreeInner(
         }}
       >
         <ListItemIcon
-          sx={{ minWidth: ICON_COL_WIDTH, mr: 0, color: "text.primary" }}
+          sx={{ minWidth: iconColWidth, mr: 0, color: "text.primary" }}
         >
           <Box
             component="span"
@@ -1440,8 +1449,8 @@ function ResourceTreeInner(
               display: "inline-flex",
               alignItems: "center",
               justifyContent: "center",
-              width: 18,
-              height: 18,
+              width: caretSize,
+              height: caretSize,
             }}
           >
             {sectionExpanded[section.key] !== false ? (
@@ -1452,7 +1461,7 @@ function ResourceTreeInner(
           </Box>
         </ListItemIcon>
         {section.icon ? (
-          <ListItemIcon sx={{ minWidth: ICON_COL_WIDTH, mr: 0.75 }}>
+          <ListItemIcon sx={{ minWidth: iconColWidth, mr: 0.75 }}>
             {section.icon}
           </ListItemIcon>
         ) : null}

--- a/app/src/components/ResultsTable.tsx
+++ b/app/src/components/ResultsTable.tsx
@@ -4,6 +4,7 @@ import {
   Typography,
   Snackbar,
   Alert,
+  Chip,
   ToggleButtonGroup,
   ToggleButton,
   Tooltip,
@@ -21,12 +22,14 @@ import {
   Sheet as TableIcon,
   Braces as JsonIcon,
   BarChart3 as ChartIcon,
+  LayoutGrid as CardsIcon,
   ClipboardCopy as CopyIcon,
   Download as DownloadIcon,
   FileCode2 as StructureIcon,
 } from "lucide-react";
 import Editor from "@monaco-editor/react";
 import { useTheme } from "../contexts/ThemeContext";
+import { useIsMobile } from "../hooks/useIsMobile";
 import type { MakoChartSpec } from "../lib/chart-spec";
 import ResultsChart from "./ResultsChart";
 import {
@@ -53,12 +56,58 @@ interface QueryResult {
 
 type ViewMode = "table" | "json" | "chart";
 // "structure" is an extra, uncontrolled-only mode available when a
-// `structureView` slot is provided (table data tabs); it is intentionally not
-// part of the persisted console ViewMode.
-type ResultsViewMode = ViewMode | "structure";
+// `structureView` slot is provided (table data tabs); "cards" is the mobile
+// record-card view. Both are local-only and intentionally not part of the
+// persisted console ViewMode (the controlled `viewMode` prop stays table/json/
+// chart so the API and store contracts are unchanged).
+type ResultsViewMode = ViewMode | "structure" | "cards";
 
 const PINNED_RESULT_COLUMNS = { left: ["__rowIndex"], right: [] };
 const RESULTS_TABLE_LOCALE_TEXT = { noRowsLabel: "No rows returned" };
+
+// Max record cards rendered at once on mobile (cards are not virtualized).
+const MOBILE_CARD_LIMIT = 200;
+
+// Map common status-like cell values to a Chip color so mobile cards read at a
+// glance. Returns null for non-status values (rendered as plain text).
+const STATUS_CHIP_COLORS: Record<
+  string,
+  "success" | "error" | "warning" | "info"
+> = {
+  success: "success",
+  succeeded: "success",
+  active: "success",
+  completed: "success",
+  complete: "success",
+  done: "success",
+  enabled: "success",
+  paid: "success",
+  ok: "success",
+  passed: "success",
+  error: "error",
+  failed: "error",
+  failure: "error",
+  cancelled: "error",
+  canceled: "error",
+  rejected: "error",
+  disabled: "error",
+  inactive: "error",
+  pending: "warning",
+  processing: "warning",
+  running: "warning",
+  queued: "warning",
+  waiting: "warning",
+  draft: "info",
+  new: "info",
+};
+
+function statusChipColor(
+  value: string,
+): "success" | "error" | "warning" | "info" | null {
+  const key = value.trim().toLowerCase();
+  if (!key || key.length > 24) return null;
+  return STATUS_CHIP_COLORS[key] ?? null;
+}
 
 interface ResultsTableProps {
   results?: QueryResult | null;
@@ -91,16 +140,30 @@ const ResultsTable: React.FC<ResultsTableProps> = ({
   onDownload,
   structureView,
 }) => {
+  const isMobile = useIsMobile();
   const [snackbarOpen, setSnackbarOpen] = React.useState(false);
   const [internalViewMode, setInternalViewMode] =
     React.useState<ResultsViewMode>("table");
+  // "cards" is a local override that takes precedence over the controlled
+  // `viewMode` prop, so the mobile record-card view works even when the parent
+  // (Editor) drives table/json/chart. Defaults on for mobile.
+  const [localOverride, setLocalOverride] = React.useState<"cards" | null>(
+    isMobile ? "cards" : null,
+  );
   const [downloadAnchorEl, setDownloadAnchorEl] =
     React.useState<HTMLElement | null>(null);
   const { effectiveMode } = useTheme();
 
-  const viewMode: ResultsViewMode = controlledViewMode ?? internalViewMode;
+  const viewMode: ResultsViewMode =
+    localOverride ?? controlledViewMode ?? internalViewMode;
   const setViewMode = useCallback(
     (mode: ResultsViewMode) => {
+      if (mode === "cards") {
+        // Local-only; never propagated to the persisted console view mode.
+        setLocalOverride("cards");
+        return;
+      }
+      setLocalOverride(null);
       if (mode === "structure" || !onViewModeChange) {
         setInternalViewMode(mode);
       } else {
@@ -114,7 +177,8 @@ const ResultsTable: React.FC<ResultsTableProps> = ({
   const canGoForward = Boolean(results?.pageInfo?.hasMore && onNextPage);
   const lastTableResetExecutedAtRef = React.useRef<string | undefined>();
 
-  // Reset to table view whenever new results are received
+  // Reset the view whenever new results arrive: cards on mobile (answer-first),
+  // table on desktop.
   const executedAt = results?.executedAt;
   useEffect(() => {
     if (!executedAt || lastTableResetExecutedAtRef.current === executedAt) {
@@ -122,10 +186,15 @@ const ResultsTable: React.FC<ResultsTableProps> = ({
     }
 
     lastTableResetExecutedAtRef.current = executedAt;
-    if (viewMode !== "table") {
-      setViewMode("table");
+    if (isMobile) {
+      setLocalOverride("cards");
+    } else {
+      setLocalOverride(null);
+      if (viewMode !== "table") {
+        setViewMode("table");
+      }
     }
-  }, [executedAt, setViewMode, viewMode]);
+  }, [executedAt, isMobile, setViewMode, viewMode]);
 
   // Helper function to normalize any data into an array format
   const normalizeToArray = (data: any): any[] => {
@@ -503,6 +572,14 @@ const ResultsTable: React.FC<ResultsTableProps> = ({
   );
 
   const jsonContent = JSON.stringify(results, null, 2);
+
+  // Data columns excluding the synthetic row-index column, used by the mobile
+  // record-card view.
+  const dataColumns = useMemo(
+    () => columns.filter(col => col.field !== "__rowIndex"),
+    [columns],
+  );
+
   useRenderCount("ResultsTable", {
     executedAt,
     viewMode,
@@ -562,6 +639,186 @@ const ResultsTable: React.FC<ResultsTableProps> = ({
     );
   }
 
+  // ── Mobile record cards ───────────────────────────────────────────────
+  // Render up to a cap so large result sets don't blow up the DOM (cards are
+  // not virtualized like the DataGrid). Beyond the cap we point users at the
+  // Table view.
+  const renderCardValue = (value: unknown): React.ReactNode => {
+    if (value === null || value === undefined) {
+      return (
+        <Typography variant="body2" color="text.disabled">
+          —
+        </Typography>
+      );
+    }
+    if (typeof value === "object") {
+      return (
+        <Typography
+          variant="body2"
+          sx={{
+            fontFamily:
+              'Monaco, Menlo, "Ubuntu Mono", Consolas, "Courier New", monospace',
+            fontSize: "0.75rem",
+            wordBreak: "break-word",
+            textAlign: "right",
+          }}
+        >
+          {JSON.stringify(value)}
+        </Typography>
+      );
+    }
+    const str = String(value);
+    const chipColor = statusChipColor(str);
+    if (chipColor) {
+      return (
+        <Chip size="small" variant="outlined" color={chipColor} label={str} />
+      );
+    }
+    return (
+      <Typography
+        variant="body2"
+        sx={{ wordBreak: "break-word", textAlign: "right" }}
+      >
+        {str}
+      </Typography>
+    );
+  };
+
+  const cardRows = rows.slice(0, MOBILE_CARD_LIMIT);
+  const cardsView = (
+    <Box
+      sx={{
+        height: "100%",
+        overflow: "auto",
+        p: 1,
+        display: "flex",
+        flexDirection: "column",
+        gap: 1,
+      }}
+    >
+      {cardRows.map((row, index) => {
+        const [titleCol, ...restCols] = dataColumns;
+        const titleRaw = titleCol ? row[titleCol.field] : undefined;
+        const title =
+          titleRaw === null || titleRaw === undefined || titleRaw === ""
+            ? `Row ${index + 1}`
+            : typeof titleRaw === "object"
+              ? JSON.stringify(titleRaw)
+              : String(titleRaw);
+        return (
+          <Box
+            key={row.id ?? index}
+            sx={{
+              border: 1,
+              borderColor: "divider",
+              borderRadius: 1,
+              p: 1.5,
+              backgroundColor: "background.paper",
+            }}
+          >
+            <Typography
+              variant="subtitle2"
+              sx={{
+                fontWeight: 700,
+                mb: restCols.length ? 1 : 0,
+                wordBreak: "break-word",
+              }}
+            >
+              {title}
+            </Typography>
+            {restCols.length > 0 && (
+              <Box
+                sx={{
+                  display: "grid",
+                  gridTemplateColumns: "minmax(0, 45%) 1fr",
+                  columnGap: 1.5,
+                  rowGap: 0.75,
+                  alignItems: "start",
+                }}
+              >
+                {restCols.map(col => (
+                  <React.Fragment key={col.field}>
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ wordBreak: "break-word", pt: 0.25 }}
+                    >
+                      {col.headerName ?? col.field}
+                    </Typography>
+                    <Box
+                      sx={{
+                        minWidth: 0,
+                        display: "flex",
+                        justifyContent: "flex-end",
+                      }}
+                    >
+                      {renderCardValue(row[col.field])}
+                    </Box>
+                  </React.Fragment>
+                ))}
+              </Box>
+            )}
+          </Box>
+        );
+      })}
+      {rows.length > MOBILE_CARD_LIMIT && (
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{ textAlign: "center", py: 1 }}
+        >
+          Showing the first {MOBILE_CARD_LIMIT} of {rows.length} rows — switch
+          to Table view to see all.
+        </Typography>
+      )}
+    </Box>
+  );
+
+  // ── Mobile answer-first summary band ──────────────────────────────────
+  let kpi: { label: string; value: string } | null = null;
+  if (rows.length === 1 && dataColumns.length === 1) {
+    const col = dataColumns[0];
+    const v = rows[0][col.field];
+    if (v !== null && v !== undefined && typeof v !== "object") {
+      kpi = { label: col.headerName ?? col.field, value: String(v) };
+    }
+  }
+  const summaryBand =
+    isMobile && viewMode !== "structure" ? (
+      <Box
+        sx={{
+          px: 1.5,
+          py: 1,
+          borderBottom: "1px solid",
+          borderColor: "divider",
+          backgroundColor: "background.default",
+        }}
+      >
+        {kpi ? (
+          <>
+            <Typography variant="h5" sx={{ fontWeight: 700, lineHeight: 1.2 }}>
+              {kpi.value}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              {kpi.label}
+            </Typography>
+          </>
+        ) : (
+          <Box sx={{ display: "flex", alignItems: "baseline", gap: 1 }}>
+            <Typography variant="h6" sx={{ fontWeight: 700 }}>
+              {results.resultCount.toLocaleString()}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {results.resultCount === 1 ? "result" : "results"}
+              {results.executionTime !== undefined
+                ? ` • ${results.executionTime} ms`
+                : ""}
+            </Typography>
+          </Box>
+        )}
+      </Box>
+    ) : null;
+
   return (
     <Box
       sx={{
@@ -593,16 +850,25 @@ const ResultsTable: React.FC<ResultsTableProps> = ({
           size="small"
           aria-label="view mode"
         >
+          {isMobile && (
+            <Tooltip title="Cards view">
+              <ToggleButton value="cards" aria-label="cards view">
+                <CardsIcon strokeWidth={1.5} size={22} />
+              </ToggleButton>
+            </Tooltip>
+          )}
           <Tooltip title="Table view">
             <ToggleButton value="table" aria-label="table view">
               <TableIcon strokeWidth={1.5} size={22} />
             </ToggleButton>
           </Tooltip>
-          <Tooltip title="JSON view">
-            <ToggleButton value="json" aria-label="json view">
-              <JsonIcon strokeWidth={1.5} size={22} />
-            </ToggleButton>
-          </Tooltip>
+          {!isMobile && (
+            <Tooltip title="JSON view">
+              <ToggleButton value="json" aria-label="json view">
+                <JsonIcon strokeWidth={1.5} size={22} />
+              </ToggleButton>
+            </Tooltip>
+          )}
           <Tooltip title="Chart view">
             <ToggleButton value="chart" aria-label="chart view">
               <ChartIcon strokeWidth={1.5} size={22} />
@@ -659,6 +925,9 @@ const ResultsTable: React.FC<ResultsTableProps> = ({
         )}
       </Box>
 
+      {/* Answer-first summary band (mobile) */}
+      {summaryBand}
+
       {/* Results content */}
       <Box
         sx={{
@@ -668,6 +937,7 @@ const ResultsTable: React.FC<ResultsTableProps> = ({
           maxWidth: "100%",
         }}
       >
+        {viewMode === "cards" && cardsView}
         {viewMode === "table" && (
           <React.Profiler id="ResultsTable.DataGrid" onRender={onRenderDebug}>
             <DataGridPremium

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -217,11 +217,13 @@ export function SidebarMobileExplorerNav() {
   return (
     <Box
       sx={{
-        display: "flex",
-        gap: 0.5,
-        overflowX: "auto",
-        px: 1,
-        py: 0.5,
+        display: "grid",
+        // Wrap every destination into an even grid so nothing scrolls off
+        // the right edge or gets clipped mid-label on a phone.
+        gridTemplateColumns: "repeat(auto-fill, minmax(64px, 1fr))",
+        gap: 0.25,
+        px: 0.5,
+        py: 0.25,
       }}
     >
       {items.map(item => {
@@ -243,17 +245,27 @@ export function SidebarMobileExplorerNav() {
               flexDirection: "column",
               alignItems: "center",
               gap: 0.25,
-              minWidth: 64,
-              px: 1,
-              py: 0.75,
-              borderRadius: 2,
-              flexShrink: 0,
-              color: isActive ? "text.primary" : "text.secondary",
+              minWidth: 0,
+              width: "100%",
+              px: 0.5,
+              py: 0.5,
+              borderRadius: 1.5,
+              color: isActive ? "primary.main" : "text.secondary",
               backgroundColor: isActive ? "action.selected" : "transparent",
             }}
           >
-            <Icon size={22} strokeWidth={1.5} />
-            <Typography variant="caption" sx={{ fontSize: "0.65rem" }}>
+            <Icon size={18} strokeWidth={1.5} />
+            <Typography
+              variant="caption"
+              sx={{
+                fontSize: "0.6rem",
+                lineHeight: 1.1,
+                maxWidth: "100%",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
               {item.label}
             </Typography>
           </Button>

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -32,6 +32,7 @@ import { useFlowStore } from "../store/flowStore";
 import { useChatStore } from "../store/chatStore";
 import { useExplorerStore } from "../store/explorerStore";
 import { trackEvent, resetIdentity } from "../lib/analytics";
+import { useIsMobile } from "../hooks/useIsMobile";
 
 const NavButton = styled(Button, {
   shouldForwardProp: prop => prop !== "isActive",
@@ -65,16 +66,19 @@ type NavigationView =
   | "settings"
   | "views";
 
-const topNavigationItems: { view: NavigationView; icon: any; label: string }[] =
-  [
-    { view: "databases", icon: DatabaseIcon, label: "Databases" },
-    { view: "consoles", icon: ConsoleIcon, label: "Consoles" },
-    { view: "flows", icon: FlowsIcon, label: "Flows" },
-    { view: "dbt", icon: TransformsIcon, label: "Transforms" },
-    { view: "connectors", icon: DataSourceIcon, label: "Connectors" },
-    { view: "dashboards", icon: DashboardIcon, label: "Dashboards" },
-    { view: "apps", icon: AppsIcon, label: "Apps" },
-  ];
+const topNavigationItems: {
+  view: NavigationView;
+  icon: any;
+  label: string;
+}[] = [
+  { view: "databases", icon: DatabaseIcon, label: "Databases" },
+  { view: "consoles", icon: ConsoleIcon, label: "Consoles" },
+  { view: "flows", icon: FlowsIcon, label: "Flows" },
+  { view: "dbt", icon: TransformsIcon, label: "Transforms" },
+  { view: "connectors", icon: DataSourceIcon, label: "Connectors" },
+  { view: "dashboards", icon: DashboardIcon, label: "Dashboards" },
+  { view: "apps", icon: AppsIcon, label: "Apps" },
+];
 
 const bottomNavigationItems: {
   view: NavigationView;
@@ -82,17 +86,20 @@ const bottomNavigationItems: {
   label: string;
 }[] = [{ view: "settings", icon: SettingsIcon, label: "Settings" }];
 
-function Sidebar() {
-  // `activeExplorer` is the explorer that's actually visible on the left
-  // (null when the pane is collapsed). Use this — not `leftPane`, which is
-  // the last-selected view retained across collapse — to decide which icon
-  // is highlighted, so collapsing the pane clears the highlight.
-  const activeExplorer = useUIStore(selectActiveExplorer);
-  const leftPaneOpen = useUIStore(state => state.leftPaneOpen);
-  const rightPaneOpen = useUIStore(state => state.rightPaneOpen);
-  const setLeftPane = useUIStore(state => state.setLeftPane);
-  const openLeftPane = useUIStore(state => state.openLeftPane);
-  const openRightPane = useUIStore(state => state.openRightPane);
+const preloadDashboardsExplorer = () => {
+  void import("./DashboardsExplorer");
+};
+
+/**
+ * Avatar button + dropdown (workspace switcher + sign out). Shared between the
+ * desktop rail and the mobile AppBar / explorer drawer so logout and workspace
+ * switching behave identically everywhere.
+ */
+export function SidebarUserMenu({
+  tooltipPlacement = "right",
+}: {
+  tooltipPlacement?: "right" | "bottom" | "top" | "left";
+}) {
   const { user, logout } = useAuth();
   const [userMenuAnchorEl, setUserMenuAnchorEl] = useState<null | HTMLElement>(
     null,
@@ -107,14 +114,9 @@ function Sidebar() {
     setUserMenuAnchorEl(null);
   };
 
-  const preloadDashboardsExplorer = () => {
-    void import("./DashboardsExplorer");
-  };
-
   const handleLogout = async () => {
     handleUserMenuClose();
     try {
-      // Track logout event
       trackEvent("logout");
       resetIdentity();
 
@@ -140,6 +142,139 @@ function Sidebar() {
       console.error("Logout failed:", error);
     }
   };
+
+  return (
+    <>
+      <Tooltip title="User Menu" placement={tooltipPlacement}>
+        <NavButton onClick={handleUserMenuOpen}>
+          <UserIcon strokeWidth={1.5} />
+        </NavButton>
+      </Tooltip>
+
+      <Menu
+        anchorEl={userMenuAnchorEl}
+        open={isUserMenuOpen}
+        onClose={handleUserMenuClose}
+        anchorOrigin={{
+          vertical: "top",
+          horizontal: "right",
+        }}
+        transformOrigin={{
+          vertical: "bottom",
+          horizontal: "right",
+        }}
+        PaperProps={{
+          sx: {
+            minWidth: 300,
+          },
+        }}
+      >
+        {/* Workspace Switcher in User Menu */}
+        <Box sx={{ px: 1.5, py: 1.25, minWidth: 0 }}>
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ mb: 0.75, display: "block", letterSpacing: 0.2 }}
+          >
+            Workspace
+          </Typography>
+          <WorkspaceSwitcher />
+        </Box>
+        <Divider />
+
+        <Box sx={{ px: 2, py: 1 }}>
+          <Typography variant="body2" color="text.secondary">
+            Signed in as
+          </Typography>
+          <Typography variant="body2" fontWeight="medium">
+            {user?.email}
+          </Typography>
+        </Box>
+        <Divider />
+        <MenuItem onClick={handleLogout}>
+          <LogoutIcon sx={{ mr: 1, fontSize: 20 }} />
+          Sign out
+        </MenuItem>
+      </Menu>
+    </>
+  );
+}
+
+/**
+ * Horizontal explorer switcher for the mobile drawer header. Reuses the same
+ * nav item definitions as the desktop rail and switches which explorer the
+ * drawer body (App.tsx `renderLeftPane`) shows. The drawer stays open so the
+ * user can browse explorers; selecting a tree node closes it (handled in
+ * App.tsx).
+ */
+export function SidebarMobileExplorerNav() {
+  const activeExplorer = useUIStore(selectActiveExplorer);
+  const setLeftPane = useUIStore(state => state.setLeftPane);
+  const openLeftPane = useUIStore(state => state.openLeftPane);
+
+  const items = [...topNavigationItems, ...bottomNavigationItems];
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        gap: 0.5,
+        overflowX: "auto",
+        px: 1,
+        py: 0.5,
+      }}
+    >
+      {items.map(item => {
+        const Icon = item.icon;
+        const isActive = activeExplorer === item.view;
+        return (
+          <Button
+            key={item.view}
+            onClick={() => {
+              startTransition(() => {
+                setLeftPane(item.view as Exclude<NavigationView, "views">);
+                openLeftPane();
+              });
+            }}
+            onTouchStart={
+              item.view === "dashboards" ? preloadDashboardsExplorer : undefined
+            }
+            sx={{
+              flexDirection: "column",
+              alignItems: "center",
+              gap: 0.25,
+              minWidth: 64,
+              px: 1,
+              py: 0.75,
+              borderRadius: 2,
+              flexShrink: 0,
+              color: isActive ? "text.primary" : "text.secondary",
+              backgroundColor: isActive ? "action.selected" : "transparent",
+            }}
+          >
+            <Icon size={22} strokeWidth={1.5} />
+            <Typography variant="caption" sx={{ fontSize: "0.65rem" }}>
+              {item.label}
+            </Typography>
+          </Button>
+        );
+      })}
+    </Box>
+  );
+}
+
+function Sidebar() {
+  // `activeExplorer` is the explorer that's actually visible on the left
+  // (null when the pane is collapsed). Use this — not `leftPane`, which is
+  // the last-selected view retained across collapse — to decide which icon
+  // is highlighted, so collapsing the pane clears the highlight.
+  const activeExplorer = useUIStore(selectActiveExplorer);
+  const leftPaneOpen = useUIStore(state => state.leftPaneOpen);
+  const rightPaneOpen = useUIStore(state => state.rightPaneOpen);
+  const setLeftPane = useUIStore(state => state.setLeftPane);
+  const openLeftPane = useUIStore(state => state.openLeftPane);
+  const openRightPane = useUIStore(state => state.openRightPane);
+  const isMobile = useIsMobile();
 
   const handleNavigation = (view: NavigationView) => {
     // Settings now behaves like any other explorer: clicking the cog opens
@@ -174,6 +309,10 @@ function Sidebar() {
       });
     }
   };
+
+  // On mobile the 52px rail is hidden; navigation moves to the BottomNavigation
+  // and explorer Drawer rendered by App.tsx (which reuse the helpers above).
+  if (isMobile) return null;
 
   return (
     <Box
@@ -256,12 +395,8 @@ function Sidebar() {
             alignItems: "center",
           }}
         >
-          {/* User Menu */}
-          <Tooltip title="User Menu" placement="right">
-            <NavButton onClick={handleUserMenuOpen}>
-              <UserIcon strokeWidth={1.5} />
-            </NavButton>
-          </Tooltip>
+          {/* User Menu (avatar + workspace switcher + sign out) */}
+          <SidebarUserMenu />
 
           {/* Settings */}
           {bottomNavigationItems.map(item => {
@@ -281,52 +416,6 @@ function Sidebar() {
               </Tooltip>
             );
           })}
-
-          <Menu
-            anchorEl={userMenuAnchorEl}
-            open={isUserMenuOpen}
-            onClose={handleUserMenuClose}
-            anchorOrigin={{
-              vertical: "top",
-              horizontal: "right",
-            }}
-            transformOrigin={{
-              vertical: "bottom",
-              horizontal: "right",
-            }}
-            PaperProps={{
-              sx: {
-                minWidth: 300,
-              },
-            }}
-          >
-            {/* Workspace Switcher in User Menu */}
-            <Box sx={{ px: 1.5, py: 1.25, minWidth: 0 }}>
-              <Typography
-                variant="caption"
-                color="text.secondary"
-                sx={{ mb: 0.75, display: "block", letterSpacing: 0.2 }}
-              >
-                Workspace
-              </Typography>
-              <WorkspaceSwitcher />
-            </Box>
-            <Divider />
-
-            <Box sx={{ px: 2, py: 1 }}>
-              <Typography variant="body2" color="text.secondary">
-                Signed in as
-              </Typography>
-              <Typography variant="body2" fontWeight="medium">
-                {user?.email}
-              </Typography>
-            </Box>
-            <Divider />
-            <MenuItem onClick={handleLogout}>
-              <LogoutIcon sx={{ mr: 1, fontSize: 20 }} />
-              Sign out
-            </MenuItem>
-          </Menu>
         </Box>
       </Box>
     </Box>

--- a/app/src/components/dashboard/DataSourcePanel.tsx
+++ b/app/src/components/dashboard/DataSourcePanel.tsx
@@ -560,7 +560,13 @@ const DataSourcePanel: React.FC<DataSourcePanelProps> = ({
       open={open}
       onClose={onClose}
       PaperProps={{
-        sx: { width: 420, p: 0, display: "flex", flexDirection: "column" },
+        sx: {
+          width: { xs: "100vw", sm: 420 },
+          maxWidth: "100vw",
+          p: 0,
+          display: "flex",
+          flexDirection: "column",
+        },
       }}
     >
       {/* Header */}

--- a/app/src/contexts/ThemeContext.tsx
+++ b/app/src/contexts/ThemeContext.tsx
@@ -333,6 +333,10 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
             padding: theme.spacing(0.5, 1),
             color: theme.palette.text.secondary,
             ...truncateTextStyles,
+            // Larger touch target for tab strips on phones.
+            "@media (max-width:600px)": {
+              minHeight: 40,
+            },
             "&:hover": {
               color: theme.palette.text.primary,
             },
@@ -517,6 +521,31 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
         styleOverrides: {
           root: {
             borderRadius: 6, // Square with rounded corners instead of circular
+            // Touch-friendly hit area on phones. Explicit per-component sizes
+            // (e.g. compact 32px toolbar buttons) still win via `sx`.
+            "@media (max-width:600px)": {
+              minWidth: 40,
+              minHeight: 40,
+            },
+          },
+        },
+      },
+      MuiBottomNavigationAction: {
+        styleOverrides: {
+          root: ({ theme }: any) => ({
+            minWidth: 0,
+            paddingTop: theme.spacing(0.75),
+            paddingBottom: theme.spacing(0.75),
+            color: theme.palette.text.secondary,
+            "&.Mui-selected": {
+              color: theme.palette.primary.main,
+            },
+          }),
+          label: {
+            fontSize: "0.7rem",
+            "&.Mui-selected": {
+              fontSize: "0.7rem",
+            },
           },
         },
       },

--- a/app/src/hooks/useIsMobile.ts
+++ b/app/src/hooks/useIsMobile.ts
@@ -1,0 +1,20 @@
+import { useMediaQuery, useTheme } from "@mui/material";
+
+/**
+ * Single source of truth for the mobile breakpoint.
+ *
+ * Mako's desktop shell assumes ~1000px+ width. Anything below MUI's `md`
+ * breakpoint (900px by default) switches to the chat-first, single-pane
+ * mobile experience driven by `uiStore.mobileTab`.
+ *
+ * Components branch in place on this hook — there is intentionally no parallel
+ * mobile component tree.
+ */
+export function useIsMobile(): boolean {
+  const theme = useTheme();
+  // `noSsr` keeps the very first client render correct (no desktop flash on
+  // a phone) since Mako is a client-rendered SPA.
+  return useMediaQuery(theme.breakpoints.down("md"), { noSsr: true });
+}
+
+export default useIsMobile;

--- a/app/src/store/uiStore.ts
+++ b/app/src/store/uiStore.ts
@@ -32,6 +32,16 @@ interface ActiveEditorContent {
   language?: string;
 }
 
+/**
+ * Which full-screen pane is shown on mobile (< md). Desktop ignores this and
+ * keeps its 4-column flex shell. "explore" is surfaced via the explorer Drawer
+ * rather than a dedicated content pane (see `setMobileTab`).
+ */
+export type MobileTab = "ask" | "editor" | "results" | "explore";
+
+/** Mobile overlay drawer state. Only the explorer drawer exists today. */
+export type MobileDrawer = "none" | "explorer";
+
 interface UIState {
   // Navigation
   leftPane: LeftPaneView;
@@ -40,6 +50,11 @@ interface UIState {
   rightPaneOpen: boolean;
   leftPaneWidthPx: number | null;
   rightPaneWidthPx: number | null;
+
+  // Mobile (< md) navigation — ephemeral, never persisted. Desktop layout is
+  // driven by leftPaneOpen/rightPaneOpen; mobile is driven by mobileTab.
+  mobileTab: MobileTab;
+  mobileDrawer: MobileDrawer;
 
   // Loading indicators (keyed by operation name)
   loading: Record<string, boolean>;
@@ -66,6 +81,11 @@ interface UIActions {
     rightPaneWidthPx?: number | null;
   }) => void;
 
+  // Mobile navigation
+  setMobileTab: (tab: MobileTab) => void;
+  openMobileDrawer: () => void;
+  closeMobileDrawer: () => void;
+
   // Loading state
   setLoading: (key: string, value: boolean) => void;
   isLoading: (key: string) => boolean;
@@ -89,6 +109,8 @@ const initialState: UIState = {
   rightPaneOpen: true,
   leftPaneWidthPx: null,
   rightPaneWidthPx: null,
+  mobileTab: "ask",
+  mobileDrawer: "none",
   loading: {},
   activeEditorContent: undefined,
   currentWorkspaceId: null,
@@ -150,6 +172,29 @@ export const useUIStore = create<UIStore>()(
           if (widths.rightPaneWidthPx !== undefined) {
             state.rightPaneWidthPx = widths.rightPaneWidthPx;
           }
+        }),
+
+      // Mobile navigation. Selecting "explore" opens the explorer Drawer as an
+      // overlay rather than swapping the underlying content pane, so closing
+      // the drawer returns to the previous ask/editor/results view.
+      setMobileTab: tab =>
+        set(state => {
+          if (tab === "explore") {
+            state.mobileDrawer = "explorer";
+          } else {
+            state.mobileTab = tab;
+            state.mobileDrawer = "none";
+          }
+        }),
+
+      openMobileDrawer: () =>
+        set(state => {
+          state.mobileDrawer = "explorer";
+        }),
+
+      closeMobileDrawer: () =>
+        set(state => {
+          state.mobileDrawer = "none";
         }),
 
       // Loading state


### PR DESCRIPTION
## Summary

Chat-first, mobile-friendly experience for the Mako app (`< md`). On phones the app collapses its 4-column desktop shell into a single full-screen pane driven by a bottom navigation, with the explorer surfaced as an overlay drawer.

### Navigation & shell
- **Bottom navigation**: Ask / Editor / Results.
- **Claude-style floating top chrome**: pane headers are a transparent strip of round, blurred floating buttons instead of a solid app bar.
  - Left: round **hamburger** that opens the explorer Drawer (every pane, incl. the empty-console state).
  - Chat right cluster: round **Copy / New chat / Chat history**.
  - Editor center: a **"window" pill** (active tab + chevron) that opens a switcher menu of open tabs (with per-tab close) plus **New console**; round **+** on the right.
- Removed the redundant mobile top AppBar; the explorer Drawer header shows the **user + workspace identity** with a close affordance, and the shell respects `env(safe-area-inset-*)`.
- `useIsMobile` hook + ephemeral mobile state (`mobileTab`, `mobileDrawer`) in the UI store.

### Panes
- **Ask**: full-screen Chat home with an empty-state hero and starter chips; aria-labels/tooltips on header + composer icon buttons.
- **Editor/Results**: single-pane editor with a run **FAB** (inline Run hidden on mobile), record-card results view with an answer-first summary band, and a desktop-only notice where relevant.
- **Console toolbar**: actions wrap instead of clipping; Schedule is icon-only on mobile.
- **Explorer**: compact wrapping nav grid with larger touch targets; full-width dashboard drawer.
- Richer "No databases yet" empty state with an **Add database** CTA.

## Test plan
- [ ] iPhone viewport: bottom nav switches Ask / Editor / Results.
- [ ] Round floating hamburger opens the explorer Drawer from every pane (incl. empty console).
- [ ] Drawer header shows email + workspace and closes cleanly.
- [ ] Editor "window" pill opens the switcher; selecting a tab switches, close removes it, New console opens one.
- [ ] Run FAB executes queries; results render as record cards.
- [ ] Console toolbar doesn't overflow; Schedule is icon-only.
- [ ] Desktop layout/headers unchanged (4-column shell + tab strip intact).