### PR TITLE
Set up Cloud Agent dev environment (local Mongo + Postgres)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,59 +21,60 @@ them. The core dev experience is one command:
 The health check is `GET http://localhost:8080/health` (note: `/health`, not
 `/api/health`).
 
-### Database: use the Atlas **dev** DB, not a local Mongo
+### Databases run LOCALLY in this VM (no Atlas/cloud secrets injected)
 
-Secrets are injected as real environment variables (see `CLOUD_AGENT_ALL_SECRET_NAMES`),
-so you do NOT need a `.env` file and you do NOT need to run a local `mongod`.
-Connection strings for `dev`, `staging`, and `prod` Atlas databases are all
-injected.
+Only `GITHUB_TOKEN` is injected here (`CLOUD_AGENT_ALL_SECRET_NAMES`); there are
+no Atlas DB or AI-gateway secrets. The setup installed MongoDB 8.0 and
+PostgreSQL 16 locally (persist in the VM snapshot) and config lives in a
+gitignored root `.env` (also persisted in the snapshot — `api/src/index.ts`
+loads it via `dotenv.config()`).
 
-- The injected `DATABASE_URL` points at **staging**. For development, start the
-  app against the **dev** database instead, which is periodically restored from a
-  prod snapshot (fast, with real prod-like data):
+Both DB servers must be **started on each VM boot** (no systemd here); the update
+script does NOT start them. Start them before `pnpm dev`:
 
-  ```bash
-  export DATABASE_URL="$DEV_DATABASE_URL"
-  pnpm dev
-  ```
+```bash
+# MongoDB — single-node replica set (the app uses transactions, which REQUIRE a
+# replica set; a standalone mongod fails with "Transaction numbers are only
+# allowed on a replica set member"). Config already has replSetName: rs0.
+sudo mongod --config /etc/mongod.conf --bind_ip 127.0.0.1 &   # logs: /var/log/mongodb/mongod.log
+# First boot only (idempotent thereafter — already initiated in this snapshot):
+mongosh --quiet --eval 'try{rs.status()}catch(e){rs.initiate({_id:"rs0",members:[{_id:0,host:"127.0.0.1:27017"}]})}'
 
-- `api/src/index.ts` loads the root `.env` with `dotenv.config()` **without
-  `override`**, so injected/exported env vars always win over `.env`. That means
-  the only reliable way to point the app at the dev DB is to export
-  `DATABASE_URL` (a committed `.env` cannot override it).
-- Never run the app against `PROD_DATABASE_URL`.
+# PostgreSQL (demo data source)
+sudo pg_ctlcluster 16 main start
+```
+
+`.env` points the app at these: `DATABASE_URL=mongodb://127.0.0.1:27017/mako` and
+the demo source `DEMO_DATABASE_URL=postgresql://mako:mako@127.0.0.1:5432/demo`.
 
 ### Auto-seeded login (you are logged in out-of-the-box)
 
-The dev DB is regularly restored from prod, which wipes ad-hoc test accounts. The
-update script runs `api/src/scripts/seed-dev-admin.ts` on VM startup to
-idempotently (re)create a known admin login so you can sign in to the running app
-immediately:
-
-- **Email:** `cloud-agent@mako.dev`
-- **Password:** `CloudAgentDev!2024` (override via `DEV_ADMIN_PASSWORD`)
-
-The seed marks the user verified, completes onboarding, makes it the **owner** of
-a `Cloud Agent Dev` workspace, and attaches the `Chinook Music Store` demo
-Postgres DB (`DEMO_DATABASE_URL`) so there is queryable data on first login. It
-targets `DEV_DATABASE_URL` (falls back to `DATABASE_URL`), refuses to touch a
-production URI, and soft-fails (exits 0) if the DB is unreachable — so it never
-breaks VM startup. Re-run manually any time with:
+`api/src/scripts/seed-dev-admin.ts` idempotently creates a known admin login,
+owning a `Cloud Agent Dev` workspace with the demo Postgres attached as the
+`Chinook Music Store` connection. Run it once after Mongo is up (data then
+persists in the snapshot; re-run any time it's missing):
 
 ```bash
 pnpm --filter api exec tsx src/scripts/seed-dev-admin.ts
 ```
 
-Email/password registration normally requires email verification before login
-(SendGrid sends the code, which you won't receive). The seed sidesteps this by
-setting `emailVerified: true` directly; if you create another account manually,
-flip `emailVerified` in the DB to log in.
+- **Email:** `cloud-agent@mako.dev`
+- **Password:** `CloudAgentDev!2024` (override via `DEV_ADMIN_PASSWORD`)
+
+It marks the user verified + onboarded, refuses any URI whose DB name is
+`production`, and soft-fails (exits 0) if Mongo is unreachable. Email/password
+registration normally requires SendGrid email verification (you won't receive the
+code); the seed sidesteps this with `emailVerified: true`. If you create another
+account manually, flip `emailVerified` in the DB to log in.
 
 ### Misc caveats
 
 - No `docker-compose.yml` is committed, so `pnpm docker:*` scripts don't work
-  here — rely on the injected Atlas DB instead.
-- The Chinook demo Postgres uses lowercase, unquoted table names (`album`,
-  `artist`, …); `SELECT * FROM "Artist"` fails, `SELECT * FROM artist` works.
-- AI features need `AI_GATEWAY_API_KEY` (injected). `BILLING_ENABLED` is injected
-  as `true`; raw SQL queries are not billing-gated.
+  here — use the local Mongo/Postgres above instead.
+- The demo Postgres (`demo` DB, role `mako`/`mako`) uses lowercase, unquoted
+  table names (`artist`, `album`); `SELECT * FROM "Artist"` fails,
+  `SELECT * FROM artist` works.
+- AI features (AI query generation / chat) need `AI_GATEWAY_API_KEY`, which is
+  **not** injected — add it as a secret to enable them. Core SQL-client flows
+  (login, connections, console queries) work without it. `BILLING_ENABLED=false`
+  in `.env`, so nothing is billing-gated.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,8 @@ account manually, flip `emailVerified` in the DB to log in.
 - The demo Postgres (`demo` DB, role `mako`/`mako`) uses lowercase, unquoted
   table names (`artist`, `album`); `SELECT * FROM "Artist"` fails,
   `SELECT * FROM artist` works.
-- AI features (AI query generation / chat) need `AI_GATEWAY_API_KEY`, which is
-  **not** injected — add it as a secret to enable them. Core SQL-client flows
-  (login, connections, console queries) work without it. `BILLING_ENABLED=false`
-  in `.env`, so nothing is billing-gated.
+- AI features (AI query generation / chat) need `AI_GATEWAY_API_KEY`. It is now
+  injected as a secret (also persisted in the gitignored `.env`), so AI works
+  out of the box; on startup the API logs `Refreshed gateway models cache`. Core
+  SQL-client flows (login, connections, console queries) work even without it.
+  `BILLING_ENABLED=false` in `.env`, so nothing is billing-gated.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up a fully working Mako development environment in the Cursor Cloud Agent VM and documents it for future agents.

The Cloud Agent VM injects only `GITHUB_TOKEN` + `AI_GATEWAY_API_KEY` (no Atlas DB secrets), so the previous AGENTS.md guidance — which assumed injected `DEV_DATABASE_URL` / `DEMO_DATABASE_URL` — was no longer accurate. This PR updates the `## Cursor Cloud specific instructions` to reflect running databases **locally**.

## Environment setup performed (persisted in the VM snapshot)

- Installed Node deps via `pnpm install`.
- Installed and ran **MongoDB 8.0** as a single-node replica set (`rs0`) on `127.0.0.1:27017` — required because the app uses transactions.
- Installed and ran **PostgreSQL 16** with a seeded `demo` database (small music-store dataset) used as the demo data source.
- Created a gitignored root `.env` (local Mongo/Postgres URLs, generated `ENCRYPTION_KEY`/`SESSION_SECRET`, `BILLING_ENABLED=false`, and the injected `AI_GATEWAY_API_KEY` as a durable fallback).
- Seeded the admin login (`cloud-agent@mako.dev`) owning the `Cloud Agent Dev` workspace with the demo Postgres attached.

## Verification

| Check | Command | Result |
|---|---|---|
| API lint | `pnpm --filter api run lint` | ✅ |
| App typecheck | `pnpm --filter app run typecheck` | ✅ |
| App lint | `pnpm --filter app run lint` | ✅ |
| API build | `pnpm --filter api run build` | ✅ |
| Connector check | `node scripts/check-connector-agnosticism.js` | ✅ |
| Run | `pnpm dev` → API `:8080` /health ok, Vite `:5173` 200, Inngest `:8288` 200 | ✅ |

### Hello-world (SQL console)
Logged in via the browser and ran a SQL query against the demo Postgres connection.

[mako_login_and_query.mp4](https://cursor.com/agents/bc-f7ef9483-470e-443a-b24b-46e05dd5d1f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmako_login_and_query.mp4)

### AI query generation (end-to-end, with `AI_GATEWAY_API_KEY`)
Asked the AI chat a natural-language question; it generated SQL, ran it, and returned results. API logs confirm `Refreshed gateway models cache` (197 models).

[mako_ai_query_generation.mp4](https://cursor.com/agents/bc-f7ef9483-470e-443a-b24b-46e05dd5d1f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmako_ai_query_generation.mp4)

[AI-generated SQL](https://cursor.com/agents/bc-f7ef9483-470e-443a-b24b-46e05dd5d1f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmako_ai_generated_sql.webp)

## Changes
- `AGENTS.md` — rewrote the cloud-specific DB/secrets/seed/caveats sections for the local-DB reality; noted AI now works out of the box.

> Note: the update script is set to `pnpm install` (dependency refresh only). Per-boot service startup (mongod/postgres) and seeding are documented in AGENTS.md, not the update script. The `MUI X Missing license key` watermark on result grids is an expected dev-mode overlay, not an error.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7ef9483-470e-443a-b24b-46e05dd5d1f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7ef9483-470e-443a-b24b-46e05dd5d1f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

