### PR TITLE
feat(dbt): AI-generate commit messages from the working-tree diff

### DIFF
--- a/api/src/dbt/dbt-commit-message.service.ts
+++ b/api/src/dbt/dbt-commit-message.service.ts
@@ -1,0 +1,222 @@
+/**
+ * AI commit-message generation for repo-bound dbt projects.
+ *
+ * Builds a compact, bounded unified diff of the working tree (reusing the same
+ * status/diff computation as the in-IDE git surface) and asks the cheapest
+ * utility model — with gateway failover — to write a conventional-commit
+ * message. Mirrors the `version-comment.service.ts` pattern.
+ */
+import { generateText } from "ai";
+import { propagateAttributes } from "@langfuse/tracing";
+import { createTwoFilesPatch } from "diff";
+import { getModel, buildProviderOptions } from "../agent-lib/ai-gateway";
+import { getUtilityModelId } from "../agent-lib/ai-models";
+import { getUtilityModelIds } from "../services/model-catalog.service";
+import type { GatewayLanguageModelOptions } from "@ai-sdk/gateway";
+import { trackUsage } from "../services/llm-usage.service";
+import { loggers } from "../logging";
+import { extractTokenCounts } from "../utils/safe-num";
+import type { IDbtProject } from "../database/workspace-schema";
+import { getGitStatus, getProjectFileDiff } from "./dbt-github-git.service";
+
+const logger = loggers.app();
+
+// Bounds to keep the prompt cheap and the GitHub blob fan-out reasonable.
+const MAX_FILES = 40;
+const MAX_FILE_CONTENT_CHARS = 20_000;
+const MAX_PATCH_CHARS_PER_FILE = 3_000;
+const MAX_PROMPT_CHARS = 12_000;
+const MAX_MESSAGE_CHARS = 500;
+
+const COMMIT_MESSAGE_SYSTEM_PROMPT = `You are an expert dbt analytics engineer writing a git commit message for changes to a dbt project (SQL models, YAML schema/config, macros, seeds, docs).
+
+I will send you a unified diff covering one or more changed files. Convert it into a clean, specific Conventional Commits message.
+
+Format:
+- First line: "<type>: <summary>" where <type> is one of feat, fix, refactor, chore, docs, test, perf, style. Max 72 characters. Imperative mood (e.g. "add", "fix", "refactor"), no trailing period.
+- If more than one file changed or the change is non-trivial, add a blank line then 1-4 short "- " bullet points describing the key changes.
+
+Rules:
+- Be specific: reference model/macro names, column names, materializations, tests, filters, joins — not file paths or line numbers.
+- Pick the type from the dominant intent: new model/test/column => feat, bug fix => fix, restructuring without behavior change => refactor, docs/yml descriptions => docs, config/version bumps => chore.
+- Do NOT wrap the message in quotes or backticks.
+- Do NOT invent changes that are not in the diff.
+- Respond with ONLY the commit message, nothing else.`;
+
+export interface CommitMessageTrackingContext {
+  workspaceId: string;
+  userId: string;
+  /** User email, used as the Langfuse user identifier when present. */
+  userEmail?: string;
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max)}\n…(truncated)…` : value;
+}
+
+/** Strip the file-header lines from a unified patch, keeping the hunks. */
+function patchBody(patch: string): string {
+  const lines = patch.split("\n");
+  const start = lines.findIndex(l => l.startsWith("@@"));
+  if (start === -1) return "";
+  return lines.slice(start).join("\n");
+}
+
+/**
+ * Assemble a bounded, multi-file unified diff for the project's working tree.
+ * Returns null when there is nothing meaningful to summarize.
+ */
+async function buildWorkingTreeDiff(project: IDbtProject): Promise<{
+  diff: string;
+  fileCount: number;
+} | null> {
+  const status = await getGitStatus(project);
+  if (!status.hasChanges) return null;
+
+  const changes = status.changes.slice(0, MAX_FILES);
+  const omitted = status.changes.length - changes.length;
+
+  const sections = await Promise.all(
+    changes.map(async change => {
+      try {
+        const { base, working } = await getProjectFileDiff(
+          project,
+          change.path,
+        );
+        const patch = createTwoFilesPatch(
+          change.path,
+          change.path,
+          truncate(base, MAX_FILE_CONTENT_CHARS),
+          truncate(working, MAX_FILE_CONTENT_CHARS),
+          "",
+          "",
+          { context: 3 },
+        );
+        const body = truncate(patchBody(patch), MAX_PATCH_CHARS_PER_FILE);
+        if (!body.trim()) return null;
+        return `### ${change.status.toUpperCase()} ${change.path}\n${body}`;
+      } catch (error) {
+        logger.warn("Failed to diff dbt file for commit message", {
+          path: change.path,
+          error,
+        });
+        return `### ${change.status.toUpperCase()} ${change.path}`;
+      }
+    }),
+  );
+
+  const parts = sections.filter((s): s is string => s !== null);
+  if (parts.length === 0) return null;
+
+  let diff = parts.join("\n\n");
+  if (diff.length > MAX_PROMPT_CHARS) {
+    diff = `${diff.slice(0, MAX_PROMPT_CHARS)}\n…(diff truncated)…`;
+  }
+  if (omitted > 0) {
+    diff += `\n\n(${omitted} more changed file${omitted === 1 ? "" : "s"} omitted)`;
+  }
+
+  return { diff, fileCount: status.changes.length };
+}
+
+/**
+ * Generate a Conventional Commits message from a repo-bound dbt project's
+ * working-tree changes. Returns null when there are no changes or generation
+ * fails (callers should fall back to a manual message).
+ */
+export async function generateDbtCommitMessage(
+  project: IDbtProject,
+  trackingCtx?: CommitMessageTrackingContext,
+): Promise<string | null> {
+  try {
+    const built = await buildWorkingTreeDiff(project);
+    if (!built) return null;
+
+    const utilityModel = await getUtilityModelId();
+    if (!utilityModel) {
+      logger.warn("No AI provider configured, skipping commit message");
+      return null;
+    }
+    const failoverModels = await getUtilityModelIds(3);
+
+    const baseOpts = trackingCtx
+      ? buildProviderOptions({
+          userId: trackingCtx.userId,
+          workspaceId: trackingCtx.workspaceId,
+          invocationType: "commit_message",
+        })
+      : {};
+    const gatewayBase = (baseOpts.gateway ?? {}) as Record<string, unknown>;
+
+    const prompt = `${built.fileCount} changed file${
+      built.fileCount === 1 ? "" : "s"
+    }:\n\n${built.diff}`;
+
+    const { text, usage, response } = await propagateAttributes(
+      {
+        traceName: "dbt-commit-message",
+        userId: trackingCtx?.userEmail ?? trackingCtx?.userId,
+        tags: ["type:commit_message"],
+        metadata: trackingCtx
+          ? { workspaceId: trackingCtx.workspaceId }
+          : undefined,
+      },
+      () =>
+        generateText({
+          model: getModel(utilityModel),
+          system: COMMIT_MESSAGE_SYSTEM_PROMPT,
+          prompt,
+          providerOptions: {
+            gateway: {
+              ...gatewayBase,
+              models: [
+                utilityModel,
+                ...failoverModels.filter(id => id !== utilityModel),
+              ],
+            } satisfies GatewayLanguageModelOptions,
+          },
+          experimental_telemetry: {
+            isEnabled: true,
+            functionId: "dbt-commit-message",
+            metadata: {
+              workspaceId: trackingCtx?.workspaceId ?? "unknown",
+              invocationType: "commit_message",
+            },
+          },
+        }),
+    );
+
+    const actualModelId = (response as Record<string, unknown>)?.modelId as
+      | string
+      | undefined;
+    const modelId = actualModelId || utilityModel;
+
+    if (trackingCtx) {
+      const { inputTokens, outputTokens } = extractTokenCounts(
+        usage as Record<string, unknown>,
+      );
+      void trackUsage({
+        workspaceId: trackingCtx.workspaceId,
+        userId: trackingCtx.userId,
+        invocationType: "commit_message",
+        modelId,
+        inputTokens,
+        outputTokens,
+        totalTokens: inputTokens + outputTokens,
+      }).catch(err =>
+        logger.warn("Failed to track commit message usage", { error: err }),
+      );
+    }
+
+    let message = text.trim();
+    // Strip a wrapping code fence if the model added one.
+    message = message.replace(/^```[a-z]*\n?|\n?```$/g, "").trim();
+    message = message.substring(0, MAX_MESSAGE_CHARS).trim();
+
+    if (message.length < 3) return null;
+    return message;
+  } catch (error) {
+    logger.error("dbt commit message generation failed", { error });
+    return null;
+  }
+}

--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -53,6 +53,7 @@ import {
   openProjectPullRequest,
   switchProjectBranch,
 } from "../dbt/dbt-github-git.service";
+import { generateDbtCommitMessage } from "../dbt/dbt-commit-message.service";
 import {
   DBT_COMPATIBLE_CONNECTION_TYPES,
   isDbtCompatibleConnectionType,
@@ -861,6 +862,33 @@ dbtRoutes.post(
       return c.json({ success: true, ...result });
     } catch (error) {
       return serverError(c, error, "Failed to commit and push");
+    }
+  },
+);
+
+// POST /projects/:projectId/git/commit-message — AI-generate a commit message
+// from the working-tree diff. Returns { message: null } when there are no
+// changes or generation is unavailable; the client keeps the manual field.
+dbtRoutes.post(
+  "/projects/:projectId/git/commit-message",
+  async (c: AuthenticatedContext) => {
+    try {
+      const project = await findProject(c);
+      if (!project) {
+        return c.json({ success: false, error: "dbt project not found" }, 404);
+      }
+      if (!project.repo) {
+        return badRequest(c, "Project is not connected to a repository");
+      }
+      const user = c.get("user");
+      const message = await generateDbtCommitMessage(project, {
+        workspaceId: c.req.param("workspaceId") ?? "unknown",
+        userId: getUserId(c),
+        userEmail: user?.email,
+      });
+      return c.json({ success: true, message });
+    } catch (error) {
+      return serverError(c, error, "Failed to generate commit message");
     }
   },
 );

--- a/api/src/services/llm-usage.service.ts
+++ b/api/src/services/llm-usage.service.ts
@@ -21,7 +21,8 @@ export interface TrackUsageParams {
     | "title_generation"
     | "description_generation"
     | "embedding"
-    | "version_comment";
+    | "version_comment"
+    | "commit_message";
   modelId: string;
   inputTokens: number;
   outputTokens: number;

--- a/app/src/components/DbtExplorer.tsx
+++ b/app/src/components/DbtExplorer.tsx
@@ -56,6 +56,7 @@ import {
   ChevronRight as ChevronRightIcon,
   Check as CheckIcon,
   Box as ProjectBoxIcon,
+  Sparkles as GenerateIcon,
 } from "lucide-react";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useConsoleStore } from "../store/consoleStore";
@@ -295,6 +296,7 @@ export function DbtExplorer() {
   const fetchGitStatus = useDbtStore(s => s.fetchGitStatus);
   const fetchGitDiff = useDbtStore(s => s.fetchGitDiff);
   const commitAndPush = useDbtStore(s => s.commitAndPush);
+  const generateCommitMessage = useDbtStore(s => s.generateCommitMessage);
   const listBranches = useDbtStore(s => s.listBranches);
   const createBranch = useDbtStore(s => s.createBranch);
   const switchBranch = useDbtStore(s => s.switchBranch);
@@ -335,6 +337,7 @@ export function DbtExplorer() {
   // In-IDE git dialogs
   const [commitTarget, setCommitTarget] = useState<string | null>(null);
   const [commitMessage, setCommitMessage] = useState("");
+  const [generatingMessage, setGeneratingMessage] = useState(false);
   const [gitBusy, setGitBusy] = useState(false);
   const [gitResult, setGitResult] = useState<string | null>(null);
   const [diffData, setDiffData] = useState<GitFileDiff | null>(null);
@@ -603,6 +606,19 @@ export function DbtExplorer() {
       setGitResult("No changes to commit");
     }
   }, [workspaceId, commitTarget, commitMessage, commitAndPush]);
+
+  const handleGenerateMessage = useCallback(async () => {
+    if (!workspaceId || !commitTarget) return;
+    setGeneratingMessage(true);
+    setGitResult(null);
+    const message = await generateCommitMessage(workspaceId, commitTarget);
+    setGeneratingMessage(false);
+    if (message) {
+      setCommitMessage(message);
+    } else {
+      setGitResult("Could not generate a message — write one manually.");
+    }
+  }, [workspaceId, commitTarget, generateCommitMessage]);
 
   const handleCreateBranch = useCallback(async () => {
     if (!workspaceId || !branchTarget || !branchName.trim()) return;
@@ -1938,6 +1954,29 @@ export function DbtExplorer() {
                       </Box>
                     ))
                   )}
+                </Box>
+                <Box
+                  sx={{
+                    display: "flex",
+                    justifyContent: "flex-end",
+                    mb: 0.5,
+                  }}
+                >
+                  <Button
+                    size="small"
+                    onClick={handleGenerateMessage}
+                    disabled={generatingMessage || changes.length === 0}
+                    startIcon={
+                      generatingMessage ? (
+                        <CircularProgress size={13} />
+                      ) : (
+                        <GenerateIcon size={14} strokeWidth={1.75} />
+                      )
+                    }
+                    sx={{ textTransform: "none" }}
+                  >
+                    {generatingMessage ? "Generating…" : "Generate with AI"}
+                  </Button>
                 </Box>
                 <TextField
                   autoFocus

--- a/app/src/components/DbtExplorer.tsx
+++ b/app/src/components/DbtExplorer.tsx
@@ -602,6 +602,12 @@ export function DbtExplorer() {
         `Pushed to ${result.branch}: +${added} ~${modified} -${deleted}`,
       );
       setCommitMessage("");
+      // Briefly show the confirmation, then close — the working tree is now
+      // clean, so leaving the dialog open just shows a dead "0 changes" state.
+      window.setTimeout(() => {
+        setCommitTarget(null);
+        setGitResult(null);
+      }, 1500);
     } else if (result) {
       setGitResult("No changes to commit");
     }

--- a/app/src/store/dbtStore.ts
+++ b/app/src/store/dbtStore.ts
@@ -356,6 +356,10 @@ interface DbtActions {
     projectId: string,
     message: string,
   ) => Promise<CommitResult | null>;
+  generateCommitMessage: (
+    workspaceId: string,
+    projectId: string,
+  ) => Promise<string | null>;
   listBranches: (
     workspaceId: string,
     projectId: string,
@@ -805,6 +809,27 @@ export const useDbtStore = create<DbtStore>()(
       } catch (error) {
         set(state => {
           state.error.projects = errMessage(error, "Failed to commit and push");
+        });
+        return null;
+      }
+    },
+
+    generateCommitMessage: async (workspaceId, projectId) => {
+      try {
+        const response = await apiClient.post<{
+          success: boolean;
+          message: string | null;
+        }>(
+          `/workspaces/${workspaceId}/dbt/projects/${projectId}/git/commit-message`,
+          {},
+        );
+        return response.message ?? null;
+      } catch (error) {
+        set(state => {
+          state.error.projects = errMessage(
+            error,
+            "Failed to generate commit message",
+          );
         });
         return null;
       }


### PR DESCRIPTION
## Summary

- Adds a **Generate with AI** button to the dbt **Commit & push** dialog. One click drafts a Conventional Commits message from the project's pending changes.
- New `dbt-commit-message.service.ts` builds a bounded, multi-file unified diff of the working tree (reusing the existing `getGitStatus` / `getProjectFileDiff` computation), then calls the utility model via the AI gateway with failover + usage tracking — mirroring the `version-comment.service.ts` pattern.
- New route `POST /workspaces/:id/dbt/projects/:projectId/git/commit-message` returns `{ message }` (or `null` when there are no changes / generation is unavailable, so the manual field is preserved).
- Store action `generateCommitMessage` wires the dialog to the endpoint.

### Bounds (keep it cheap)
- Max 40 files diffed, per-file content capped at 20k chars, per-file patch capped at 3k chars, total prompt capped at 12k chars, output capped at 500 chars (matches the commit body limit).

## Test plan

- [ ] Open a repo-bound dbt project, edit/add/delete a few models + YAML, open **Commit & push**, click **Generate with AI** → a sensible `<type>: <summary>` message (plus bullets for multi-file changes) populates the field.
- [ ] With no pending changes, the button is disabled.
- [ ] When the AI gateway is unavailable, the dialog shows the fallback hint and the field stays editable.
- [ ] Generated message commits & pushes successfully.

Made with [Cursor](https://cursor.com)