### PR TITLE
fix(connectors): Stripe webhook provisioning + connector-agnostic webhook UI

### DIFF
--- a/api/src/connectors/base/BaseConnector.ts
+++ b/api/src/connectors/base/BaseConnector.ts
@@ -88,6 +88,34 @@ export interface ProvisionWebhookResult {
   signingSecret?: string;
 }
 
+/**
+ * Static, UI-facing description of a connector's webhook support. Surfaced
+ * through connector metadata so the generic webhook UI stays connector-agnostic
+ * (no `if (type === "stripe")` branching in components — see rule 15).
+ */
+export interface WebhookProvisioningCapability {
+  /** Connector can create the provider-side webhook subscription itself. */
+  supported: boolean;
+  /** Provider display name, used in copy like `Create in {providerLabel}`. */
+  providerLabel: string;
+  /** Provisioning persists the signing secret automatically on creation. */
+  storesSecretAutomatically: boolean;
+  /**
+   * Optional clause appended after "One click creates the {provider} webhook"
+   * (e.g. "and stores its signing secret").
+   */
+  actionHint?: string;
+}
+
+export interface WebhookCapabilities {
+  /** Connector can receive inbound webhooks at all. */
+  supported: boolean;
+  /** Auto-provisioning capability + UI copy. */
+  provisioning: WebhookProvisioningCapability;
+  /** Help text for the manual signing-secret input field. */
+  secretHelpText?: string;
+}
+
 export type NormalizedCdcRecord = Omit<NormalizedCdcEvent, "runId">;
 
 export type ConnectorLogicalType =
@@ -288,6 +316,24 @@ export abstract class BaseConnector {
   supportsWebhookProvisioning(): boolean {
     // Connectors that can create provider-side subscriptions should override.
     return false;
+  }
+
+  /**
+   * Static, UI-facing webhook capabilities. Defaults are derived from the
+   * existing capability predicates; connectors override to provide provider
+   * labels and help text so the generic webhook UI never hardcodes connector
+   * types. Must be safe to call on a metadata-only (dummy) instance.
+   */
+  getWebhookCapabilities(): WebhookCapabilities {
+    return {
+      supported: this.supportsWebhooks(),
+      provisioning: {
+        supported: this.supportsWebhookProvisioning(),
+        providerLabel: this.getMetadata().name,
+        storesSecretAutomatically: false,
+      },
+      secretHelpText: "Enter the webhook signing secret from your provider",
+    };
   }
 
   /**

--- a/api/src/connectors/calendly/connector.ts
+++ b/api/src/connectors/calendly/connector.ts
@@ -13,6 +13,7 @@ import {
   NormalizedCdcRecord,
   ProvisionWebhookOptions,
   ProvisionWebhookResult,
+  type WebhookCapabilities,
   type ConnectorEntitySchema,
 } from "../base/BaseConnector";
 import { resolveCalendlyEntitySchema } from "./schema";
@@ -136,8 +137,10 @@ function formatCalendlyApiError(error: unknown): string {
             : undefined;
 
     const details = Array.isArray((data as { details?: unknown[] })?.details)
-      ? (data as { details: Array<{ message?: string; parameter?: string }> })
-          .details.map(d => `${d.parameter ?? "?"}: ${d.message ?? "?"}`)
+      ? (
+          data as { details: Array<{ message?: string; parameter?: string }> }
+        ).details
+          .map(d => `${d.parameter ?? "?"}: ${d.message ?? "?"}`)
           .join("; ")
       : undefined;
 
@@ -274,10 +277,7 @@ export class CalendlyConnector extends BaseConnector {
         }
 
         const retryAfterHeader = axiosError.response?.headers?.["retry-after"];
-        const retryAfterSeconds = parseInt(
-          String(retryAfterHeader ?? "1"),
-          10,
-        );
+        const retryAfterSeconds = parseInt(String(retryAfterHeader ?? "1"), 10);
         const delayMs = Number.isFinite(retryAfterSeconds)
           ? retryAfterSeconds * 1000
           : Math.min(1000 * 2 ** attempt, 60_000);
@@ -842,6 +842,18 @@ export class CalendlyConnector extends BaseConnector {
     return true;
   }
 
+  getWebhookCapabilities(): WebhookCapabilities {
+    return {
+      supported: true,
+      provisioning: {
+        supported: true,
+        providerLabel: "Calendly",
+        storesSecretAutomatically: true,
+      },
+      secretHelpText: "Enter the webhook signing secret from your provider",
+    };
+  }
+
   async createWebhookSubscription(
     options: ProvisionWebhookOptions,
   ): Promise<ProvisionWebhookResult> {
@@ -924,14 +936,13 @@ export class CalendlyConnector extends BaseConnector {
       };
     }
 
-    const parts = sigHeader.split(",").reduce<Record<string, string>>(
-      (acc, part) => {
+    const parts = sigHeader
+      .split(",")
+      .reduce<Record<string, string>>((acc, part) => {
         const [k, v] = part.split("=");
         if (k && v) acc[k.trim()] = v.trim();
         return acc;
-      },
-      {},
-    );
+      }, {});
 
     const t = parts.t;
     const v1 = parts.v1;
@@ -986,7 +997,9 @@ export class CalendlyConnector extends BaseConnector {
         event: {
           ...parsed,
           type: eventType,
-          id: resourceUri ? `${parsed?.created_at ?? ""}:${resourceUri}` : undefined,
+          id: resourceUri
+            ? `${parsed?.created_at ?? ""}:${resourceUri}`
+            : undefined,
         },
       };
     } catch (err) {

--- a/api/src/connectors/claap/connector.ts
+++ b/api/src/connectors/claap/connector.ts
@@ -11,6 +11,7 @@ import {
   NormalizedCdcRecord,
   ProvisionWebhookOptions,
   ProvisionWebhookResult,
+  type WebhookCapabilities,
   type ConnectorEntitySchema,
 } from "../base/BaseConnector";
 import { resolveClaapEntitySchema } from "./schema";
@@ -502,6 +503,20 @@ export class ClaapConnector extends BaseConnector {
 
   supportsWebhookProvisioning(): boolean {
     return true;
+  }
+
+  getWebhookCapabilities(): WebhookCapabilities {
+    return {
+      supported: true,
+      provisioning: {
+        supported: true,
+        providerLabel: "Claap",
+        storesSecretAutomatically: false,
+        actionHint: "(copy the secret into this form if Claap shows it once)",
+      },
+      secretHelpText:
+        "Enter the X-Claap-Webhook-Secret from your Claap webhook settings",
+    };
   }
 
   async createWebhookSubscription(

--- a/api/src/connectors/close/connector.ts
+++ b/api/src/connectors/close/connector.ts
@@ -11,6 +11,7 @@ import {
   NormalizedCdcRecord,
   ProvisionWebhookOptions,
   ProvisionWebhookResult,
+  type WebhookCapabilities,
   type ConnectorEntitySchema,
 } from "../base/BaseConnector";
 import { resolveCloseEntitySchema, type CloseCustomField } from "./schema";
@@ -2016,6 +2017,19 @@ export class CloseConnector extends BaseConnector {
 
   supportsWebhookProvisioning(): boolean {
     return true;
+  }
+
+  getWebhookCapabilities(): WebhookCapabilities {
+    return {
+      supported: true,
+      provisioning: {
+        supported: true,
+        providerLabel: "Close",
+        storesSecretAutomatically: true,
+        actionHint: "and stores its signing secret",
+      },
+      secretHelpText: "Enter the webhook signing secret from your provider",
+    };
   }
 
   async createWebhookSubscription(

--- a/api/src/connectors/registry.ts
+++ b/api/src/connectors/registry.ts
@@ -1,4 +1,4 @@
-import { BaseConnector } from "./base/BaseConnector";
+import { BaseConnector, type WebhookCapabilities } from "./base/BaseConnector";
 import { IConnector } from "../database/workspace-schema";
 import * as fs from "fs";
 import * as path from "path";
@@ -19,8 +19,18 @@ interface ConnectorRegistryMetadata {
     description: string;
     author?: string;
     supportedEntities: string[];
+    webhook: WebhookCapabilities;
   };
 }
+
+const DEFAULT_WEBHOOK_CAPABILITIES: WebhookCapabilities = {
+  supported: false,
+  provisioning: {
+    supported: false,
+    providerLabel: "Provider",
+    storesSecretAutomatically: false,
+  },
+};
 
 /**
  * Connector Registry
@@ -138,7 +148,10 @@ class ConnectorRegistry {
       let metadata;
       try {
         const tempConnector = new ConnectorClass(dummyDataSource);
-        metadata = tempConnector.getMetadata();
+        metadata = {
+          ...tempConnector.getMetadata(),
+          webhook: tempConnector.getWebhookCapabilities(),
+        };
       } catch {
         // If constructor fails, try to get static metadata
         metadata = {
@@ -146,6 +159,7 @@ class ConnectorRegistry {
           version: "1.0.0",
           description: `${dirName} connector`,
           supportedEntities: [],
+          webhook: DEFAULT_WEBHOOK_CAPABILITIES,
         };
       }
 

--- a/api/src/connectors/stripe/connector.ts
+++ b/api/src/connectors/stripe/connector.ts
@@ -11,6 +11,7 @@ import {
   NormalizedCdcRecord,
   ProvisionWebhookOptions,
   ProvisionWebhookResult,
+  type WebhookCapabilities,
   type ConnectorEntitySchema,
 } from "../base/BaseConnector";
 import Stripe from "stripe";
@@ -742,6 +743,20 @@ export class StripeConnector extends BaseConnector {
    */
   supportsWebhookProvisioning(): boolean {
     return true;
+  }
+
+  getWebhookCapabilities(): WebhookCapabilities {
+    return {
+      supported: true,
+      provisioning: {
+        supported: true,
+        providerLabel: "Stripe",
+        storesSecretAutomatically: true,
+        actionHint: "and stores its signing secret",
+      },
+      secretHelpText:
+        "Get this from Stripe Dashboard > Webhooks > Your endpoint > Signing secret",
+    };
   }
 
   /**

--- a/api/src/routes/connectors.ts
+++ b/api/src/routes/connectors.ts
@@ -16,6 +16,17 @@ import {
  */
 export const connectorRoutes = createRouter();
 
+const WebhookCapabilitiesSchema = z.object({
+  supported: z.boolean(),
+  provisioning: z.object({
+    supported: z.boolean(),
+    providerLabel: z.string(),
+    storesSecretAutomatically: z.boolean(),
+    actionHint: z.string().optional(),
+  }),
+  secretHelpText: z.string().optional(),
+});
+
 const ConnectorMetadataSchema = z
   .object({
     type: z.string(),
@@ -24,6 +35,7 @@ const ConnectorMetadataSchema = z
     description: z.string(),
     author: z.string().optional(),
     supportedEntities: z.array(z.string()),
+    webhook: WebhookCapabilitiesSchema,
   })
   .openapi("ConnectorMetadata");
 

--- a/app/src/api/schema.d.ts
+++ b/app/src/api/schema.d.ts
@@ -3953,6 +3953,16 @@ export interface components {
             description: string;
             author?: string;
             supportedEntities: string[];
+            webhook: {
+                supported: boolean;
+                provisioning: {
+                    supported: boolean;
+                    providerLabel: string;
+                    storesSecretAutomatically: boolean;
+                    actionHint?: string;
+                };
+                secretHelpText?: string;
+            };
         };
         DatabaseType: {
             type: string;

--- a/app/src/components/WebhookFlowForm.tsx
+++ b/app/src/components/WebhookFlowForm.tsx
@@ -34,6 +34,10 @@ import { useWorkspace } from "../contexts/workspace-context";
 import { useFlowStore } from "../store/flowStore";
 import { useSchemaStore } from "../store/schemaStore";
 import {
+  useConnectorCatalogStore,
+  type WebhookCapabilities,
+} from "../store/connectorCatalogStore";
+import {
   useAvailableEntitiesStore,
   flattenConnectorEntities,
   type FlattenedConnectorEntity,
@@ -57,18 +61,6 @@ interface EntityLayoutConfig {
   clusterFields: string[];
   enabled?: boolean;
 }
-
-const WEBHOOK_CAPABLE_CONNECTOR_TYPES = new Set([
-  "stripe",
-  "close",
-  "claap",
-  "calendly",
-]);
-const WEBHOOK_PROVISIONING_CONNECTOR_TYPES = new Set([
-  "close",
-  "claap",
-  "calendly",
-]);
 
 const SYNC_ENGINE_PERMISSION_ERROR =
   "The flow was saved, but changing the sync engine requires the workspace Owner or Admin role. Ask an admin to upgrade your role, then set the sync engine again.";
@@ -123,6 +115,18 @@ export function WebhookFlowForm({
     fetchConnectors,
     provisionFlowWebhook,
   } = useFlowStore();
+
+  const connectorTypes = useConnectorCatalogStore(state => state.types);
+  const fetchCatalog = useConnectorCatalogStore(state => state.fetchCatalog);
+  const webhookCapabilitiesByType = useMemo(() => {
+    const map: Record<string, WebhookCapabilities> = {};
+    for (const entry of connectorTypes || []) {
+      map[entry.type] = entry.webhook;
+    }
+    return map;
+  }, [connectorTypes]);
+  const isWebhookCapableType = (type: string | undefined): boolean =>
+    Boolean(type && webhookCapabilitiesByType[type]?.supported);
 
   // Get workspace-specific data
   const flows = useMemo(
@@ -209,18 +213,30 @@ export function WebhookFlowForm({
   const watchDeleteMode = watch("deleteMode");
   const selectedConnector = connectors.find(ds => ds._id === watchDataSourceId);
   const selectedConnectorType = selectedConnector?.type;
+  const selectedWebhookCapabilities = selectedConnectorType
+    ? webhookCapabilitiesByType[selectedConnectorType]
+    : undefined;
+  const provisioning = selectedWebhookCapabilities?.provisioning;
   const canProvisionWebhook =
-    !isNewMode &&
-    Boolean(currentFlowId) &&
-    WEBHOOK_PROVISIONING_CONNECTOR_TYPES.has(selectedConnectorType || "");
-  const provisionProviderLabel =
-    selectedConnectorType === "claap"
-      ? "Claap"
-      : selectedConnectorType === "close"
-        ? "Close"
-        : selectedConnectorType === "calendly"
-          ? "Calendly"
-          : "Provider";
+    !isNewMode && Boolean(currentFlowId) && Boolean(provisioning?.supported);
+  const provisionProviderLabel = provisioning?.providerLabel ?? "Provider";
+  const provisionActionHint = provisioning?.actionHint;
+  const webhookSecretHelpText =
+    selectedWebhookCapabilities?.secretHelpText ??
+    "Enter the webhook signing secret from your provider";
+  const webhookCapableConnectors = useMemo(
+    () => connectors.filter(source => isWebhookCapableType(source.type)),
+    // isWebhookCapableType is derived from webhookCapabilitiesByType
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [connectors, webhookCapabilitiesByType],
+  );
+  const webhookCapableConnectorNames = useMemo(
+    () =>
+      (connectorTypes || [])
+        .filter(entry => entry.webhook?.supported)
+        .map(entry => entry.name),
+    [connectorTypes],
+  );
 
   const selectedDestination = databases.find(
     db => db.id === watchDestinationId,
@@ -332,10 +348,7 @@ export function WebhookFlowForm({
     setIsLoadingConnectors(true);
     try {
       const sources = await fetchConnectors(workspaceId);
-      const webhookCapable = (sources || []).filter(source =>
-        WEBHOOK_CAPABLE_CONNECTOR_TYPES.has(source.type),
-      );
-      setConnectors(webhookCapable);
+      setConnectors(sources || []);
     } catch (error) {
       console.error("Failed to fetch connectors:", error);
       setError("Failed to load connectors");
@@ -349,9 +362,10 @@ export function WebhookFlowForm({
     if (currentWorkspace?.id) {
       fetchDataSources(currentWorkspace.id);
       ensureConnections(currentWorkspace.id);
+      fetchCatalog(currentWorkspace.id);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentWorkspace?.id, ensureConnections]);
+  }, [currentWorkspace?.id, ensureConnections, fetchCatalog]);
 
   // Load flow data if editing
   useEffect(() => {
@@ -765,7 +779,7 @@ export function WebhookFlowForm({
                           }
                           disabled={isLoadingConnectors || !isNewMode}
                         >
-                          {connectors.map(source => (
+                          {webhookCapableConnectors.map(source => (
                             <MenuItem key={source._id} value={source._id}>
                               <Box
                                 sx={{
@@ -785,12 +799,14 @@ export function WebhookFlowForm({
                             {errors.dataSourceId.message}
                           </FormHelperText>
                         )}
-                        {connectors.length === 0 && !isLoadingConnectors && (
-                          <FormHelperText>
-                            Create a Stripe, Close, or Claap data source to use
-                            webhook flows
-                          </FormHelperText>
-                        )}
+                        {webhookCapableConnectors.length === 0 &&
+                          !isLoadingConnectors && (
+                            <FormHelperText>
+                              {webhookCapableConnectorNames.length > 0
+                                ? `Create a ${webhookCapableConnectorNames.join(", ")} data source to use webhook flows`
+                                : "Create a webhook-capable data source to use webhook flows"}
+                            </FormHelperText>
+                          )}
                       </FormControl>
                     )}
                   />
@@ -1367,8 +1383,11 @@ export function WebhookFlowForm({
                           />
                         </Box>
                         <Typography variant="caption" color="text.secondary">
-                          Copy this URL to your Stripe, Close, or Claap webhook
-                          settings
+                          Copy this URL to your{" "}
+                          {provisionProviderLabel !== "Provider"
+                            ? provisionProviderLabel
+                            : "provider's"}{" "}
+                          webhook settings
                         </Typography>
                         {canProvisionWebhook && (
                           <Box
@@ -1396,11 +1415,9 @@ export function WebhookFlowForm({
                             >
                               One click creates the {provisionProviderLabel}{" "}
                               webhook
-                              {selectedConnectorType === "close"
-                                ? " and stores its signing secret"
-                                : selectedConnectorType === "claap"
-                                  ? " (copy the secret into this form if Claap shows it once)"
-                                  : ""}
+                              {provisionActionHint
+                                ? ` ${provisionActionHint}`
+                                : ""}
                               .
                             </Typography>
                           </Box>
@@ -1421,7 +1438,7 @@ export function WebhookFlowForm({
                           render={({ field }) => (
                             <TextField
                               {...field}
-                              placeholder="Enter webhook secret (e.g., whsec_...)"
+                              placeholder="Enter webhook secret"
                               fullWidth
                               size="small"
                               type="text"
@@ -1448,11 +1465,7 @@ export function WebhookFlowForm({
                           )}
                         />
                         <Typography variant="caption" color="text.secondary">
-                          {selectedConnectorType === "stripe"
-                            ? "Get this from Stripe Dashboard > Webhooks > Your endpoint > Signing secret"
-                            : selectedConnectorType === "claap"
-                              ? "Enter the X-Claap-Webhook-Secret from your Claap webhook settings"
-                              : "Enter the webhook signing secret from your provider"}
+                          {webhookSecretHelpText}
                         </Typography>
                       </Box>
                     </Stack>

--- a/app/src/store/connectorCatalogStore.ts
+++ b/app/src/store/connectorCatalogStore.ts
@@ -3,12 +3,26 @@ import { persist } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 import { api, unwrapBody } from "../api";
 
+export interface WebhookProvisioningCapability {
+  supported: boolean;
+  providerLabel: string;
+  storesSecretAutomatically: boolean;
+  actionHint?: string;
+}
+
+export interface WebhookCapabilities {
+  supported: boolean;
+  provisioning: WebhookProvisioningCapability;
+  secretHelpText?: string;
+}
+
 export interface ConnectorType {
   type: string;
   name: string;
   version: string;
   description: string;
   supportedEntities: string[];
+  webhook: WebhookCapabilities;
 }
 
 export interface ConnectorSchemaResponse {

--- a/docs/src/openapi/mako-api.json
+++ b/docs/src/openapi/mako-api.json
@@ -1014,6 +1014,43 @@
             "items": {
               "type": "string"
             }
+          },
+          "webhook": {
+            "type": "object",
+            "properties": {
+              "supported": {
+                "type": "boolean"
+              },
+              "provisioning": {
+                "type": "object",
+                "properties": {
+                  "supported": {
+                    "type": "boolean"
+                  },
+                  "providerLabel": {
+                    "type": "string"
+                  },
+                  "storesSecretAutomatically": {
+                    "type": "boolean"
+                  },
+                  "actionHint": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "supported",
+                  "providerLabel",
+                  "storesSecretAutomatically"
+                ]
+              },
+              "secretHelpText": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "supported",
+              "provisioning"
+            ]
           }
         },
         "required": [
@@ -1021,7 +1058,8 @@
           "name",
           "version",
           "description",
-          "supportedEntities"
+          "supportedEntities",
+          "webhook"
         ]
       },
       "DatabaseType": {


### PR DESCRIPTION
## Summary

- **Bug fix:** Stripe CDC/webhook flows could never capture a signing secret. The generic `WebhookFlowForm` gated the "Create webhook" button behind a hardcoded `WEBHOOK_PROVISIONING_CONNECTOR_TYPES` set that omitted `"stripe"`, so the provisioning route — which creates the Stripe endpoint and stores its `whsec_...` signing secret — was never callable. Signature verification therefore failed.
- **Architecture:** Instead of just adding `"stripe"` to the set, removed *all* connector-specific branching from the component (per `.cursor/rules/15-connector-agnostic.mdc`). Connectors now declare their own webhook capabilities; the UI renders entirely from connector metadata.

## How it works now

- `BaseConnector.getWebhookCapabilities()` returns `{ supported, provisioning: { supported, providerLabel, storesSecretAutomatically, actionHint }, secretHelpText }` (sensible defaults derived from existing predicates).
- `stripe`, `close`, `claap`, `calendly` override it with their own labels/help text.
- The registry collects it into connector metadata, exposed via `GET /api/connectors/types` (new `webhook` field on `ConnectorMetadata`).
- `WebhookFlowForm` reads the catalog metadata to filter the source dropdown, gate the provision button, and render all labels/help text. No more `if (type === "stripe")`.

Adding a webhook connector now requires **zero** changes to shared UI.

## Files

- API: `connectors/base/BaseConnector.ts`, `stripe|close|claap|calendly/connector.ts`, `connectors/registry.ts`, `routes/connectors.ts`
- Generated: `docs/src/openapi/mako-api.json`, `app/src/api/schema.d.ts` (via `pnpm openapi:sync`)
- App: `store/connectorCatalogStore.ts`, `components/WebhookFlowForm.tsx`

## Test plan

- [ ] On a Stripe webhook/CDC flow, "Create in Stripe" button appears and provisioning stores the `whsec_...` secret
- [ ] Inbound Stripe webhook signature verification passes
- [ ] Close / Claap / Calendly provisioning still show correct labels + help text
- [ ] Source dropdown lists only webhook-capable connectors
- [x] `pnpm --filter app run typecheck && lint`, `pnpm --filter api run lint` pass

Made with [Cursor](https://cursor.com)