### PR TITLE
feat(dbt): agent git tools + live git-status refresh on file edits

### DIFF
--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -36,6 +36,15 @@ import {
   parseDbtCommands,
 } from "../../dbt/commands";
 import {
+  commitAndPush,
+  createProjectBranch,
+  getGitStatus,
+  listProjectBranches,
+  openProjectPullRequest,
+  switchProjectBranch,
+} from "../../dbt/dbt-github-git.service";
+import { generateDbtCommitMessage } from "../../dbt/dbt-commit-message.service";
+import {
   DBT_COMPATIBLE_CONNECTION_TYPES,
   isDbtCompatibleConnectionType,
 } from "../../dbt/adapter-map";
@@ -99,7 +108,7 @@ function summarizeLogs(logs: DbtLogLine[], maxLines = 30): string[] {
   return selected.map(log => `[${log.level}] ${log.line}`);
 }
 
-export const createDbtServerTools = (workspaceId: string) => {
+export const createDbtServerTools = (workspaceId: string, userId?: string) => {
   const assertProject = async (projectId: string) => {
     if (!Types.ObjectId.isValid(projectId)) {
       throw new Error("Invalid dbt project id");
@@ -109,6 +118,18 @@ export const createDbtServerTools = (workspaceId: string) => {
       workspaceId: new Types.ObjectId(workspaceId),
     });
     if (!project) throw new Error("dbt project not found or access denied");
+    return project;
+  };
+
+  /** Like assertProject, but also requires a connected Git repository. */
+  const assertRepoProject = async (projectId: string) => {
+    const project = await assertProject(projectId);
+    if (!project.repo) {
+      throw new Error(
+        "This dbt project is not connected to a Git repository. Connect a " +
+          "repo in project settings before using git tools.",
+      );
+    }
     return project;
   };
 
@@ -762,6 +783,216 @@ export const createDbtServerTools = (workspaceId: string) => {
           };
         } catch (error) {
           return toolError(error, "Failed to update dbt job");
+        }
+      },
+    }),
+
+    dbt_git_status: tool({
+      description:
+        "Show the working-tree git status of a repo-bound dbt project: which " +
+        "files are added/modified/deleted relative to the tracked branch, " +
+        "and the branch name. Call this before dbt_commit_and_push to confirm " +
+        "what will be committed, and to summarize pending changes for the user.",
+      inputSchema: z.object({ projectId: projectIdField }),
+      execute: async ({ projectId }) => {
+        try {
+          const project = await assertRepoProject(projectId);
+          const status = await getGitStatus(project);
+          return {
+            success: true,
+            branch: status.branch,
+            hasChanges: status.hasChanges,
+            added: status.added,
+            modified: status.modified,
+            deleted: status.deleted,
+            changes: status.changes,
+          };
+        } catch (error) {
+          return toolError(error, "Failed to read git status");
+        }
+      },
+    }),
+
+    dbt_commit_and_push: tool({
+      description:
+        "Commit ALL working-tree changes and push them to the project's " +
+        "currently tracked branch in a single commit — the same action as the " +
+        "IDE 'Commit & push' button. ONLY call this after the user has " +
+        "explicitly asked you to commit/push (or clearly confirmed it in the " +
+        "conversation); never commit proactively. If you omit `message`, a " +
+        "Conventional Commits message is generated automatically from the " +
+        "diff. Returns the new commit sha and per-type counts. To put changes " +
+        "on a separate branch, call dbt_create_branch first, or use " +
+        "dbt_open_pull_request when the user wants a review.",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        message: z
+          .string()
+          .min(1)
+          .max(500)
+          .optional()
+          .describe("Commit message. Omit to auto-generate one from the diff."),
+      }),
+      execute: async ({ projectId, message }) => {
+        try {
+          const project = await assertRepoProject(projectId);
+          const status = await getGitStatus(project);
+          if (!status.hasChanges) {
+            return {
+              success: false,
+              error: "No changes to commit",
+              branch: status.branch,
+            };
+          }
+
+          let commitMessage = message?.trim();
+          let generated = false;
+          if (!commitMessage) {
+            const ai = await generateDbtCommitMessage(project, {
+              workspaceId,
+              userId: userId ?? "agent",
+            });
+            if (ai) {
+              commitMessage = ai;
+              generated = true;
+            }
+          }
+          if (!commitMessage) {
+            return {
+              success: false,
+              error:
+                "Could not generate a commit message — provide `message` " +
+                "explicitly and retry.",
+            };
+          }
+
+          const result = await commitAndPush(project, {
+            message: commitMessage,
+            updatedBy: userId ?? "agent",
+          });
+          return {
+            success: result.committed,
+            sha: result.sha,
+            branch: result.branch,
+            message: commitMessage,
+            messageGenerated: generated,
+            pushed: result.pushed,
+          };
+        } catch (error) {
+          return toolError(error, "Failed to commit and push");
+        }
+      },
+    }),
+
+    dbt_create_branch: tool({
+      description:
+        "Create a new branch off the project's current branch head and check " +
+        "it out (track it). Use before dbt_commit_and_push when the user " +
+        "wants changes isolated on a feature branch. Branch content is " +
+        "identical to the current branch — no re-sync needed.",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        name: z
+          .string()
+          .min(1)
+          .max(255)
+          .describe("New branch name, e.g. 'feat/add-orders-staging'"),
+      }),
+      execute: async ({ projectId, name }) => {
+        try {
+          const project = await assertRepoProject(projectId);
+          const result = await createProjectBranch(project, name.trim());
+          return { success: true, branch: result.branch };
+        } catch (error) {
+          return toolError(error, "Failed to create branch");
+        }
+      },
+    }),
+
+    dbt_switch_branch: tool({
+      description:
+        "Switch the project's tracked branch and pull its contents into the " +
+        "working tree. This OVERWRITES local working-tree files with the " +
+        "target branch — only call when the user confirms, and after any " +
+        "pending changes are committed (check dbt_git_status first).",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        branch: z.string().min(1).max(255).describe("Existing branch to track"),
+      }),
+      execute: async ({ projectId, branch }) => {
+        try {
+          const project = await assertRepoProject(projectId);
+          const result = await switchProjectBranch(
+            project,
+            branch.trim(),
+            userId ?? "agent",
+          );
+          return { success: true, branch: result.branch };
+        } catch (error) {
+          return toolError(error, "Failed to switch branch");
+        }
+      },
+    }),
+
+    dbt_list_branches: tool({
+      description:
+        "List the remote branches of the project's connected repository, plus " +
+        "the currently tracked branch. Use to pick a branch for " +
+        "dbt_switch_branch or a base for dbt_open_pull_request.",
+      inputSchema: z.object({ projectId: projectIdField }),
+      execute: async ({ projectId }) => {
+        try {
+          const project = await assertRepoProject(projectId);
+          const branches = await listProjectBranches(project);
+          return {
+            success: true,
+            branches,
+            current: project.repo?.branch,
+          };
+        } catch (error) {
+          return toolError(error, "Failed to list branches");
+        }
+      },
+    }),
+
+    dbt_open_pull_request: tool({
+      description:
+        "Open a GitHub pull request from the project's current branch into a " +
+        "base branch (defaults to the repo's default branch). Use this when " +
+        "the user wants their changes reviewed rather than pushed straight to " +
+        "the main branch. The current branch must differ from the base — " +
+        "create a feature branch with dbt_create_branch and commit to it " +
+        "first. Returns the PR number and URL.",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        title: z.string().min(1).max(255).describe("Pull request title"),
+        body: z
+          .string()
+          .max(10_000)
+          .optional()
+          .describe("Pull request description (Markdown)"),
+        base: z
+          .string()
+          .min(1)
+          .max(255)
+          .optional()
+          .describe("Base branch to merge into; defaults to the repo default"),
+      }),
+      execute: async ({ projectId, title, body, base }) => {
+        try {
+          const project = await assertRepoProject(projectId);
+          const result = await openProjectPullRequest(project, {
+            title: title.trim(),
+            body,
+            base,
+          });
+          return {
+            success: true,
+            number: result.number,
+            url: result.htmlUrl,
+          };
+        } catch (error) {
+          return toolError(error, "Failed to open pull request");
         }
       },
     }),

--- a/api/src/agents/dbt/index.ts
+++ b/api/src/agents/dbt/index.ts
@@ -73,7 +73,7 @@ export const dbtAgentFactory: AgentFactory = (
     context.toolExecutionContext,
     { chatId: context.chatId },
   );
-  const dbtServerTools = createDbtServerTools(workspaceId);
+  const dbtServerTools = createDbtServerTools(workspaceId, userId);
   const skillTools = createSkillTools(workspaceId, userId);
 
   return {

--- a/api/src/agents/dbt/prompt.ts
+++ b/api/src/agents/dbt/prompt.ts
@@ -24,8 +24,18 @@ runs execute against the project's warehouse environments (dev/prod).
    test results.
 5. **Operate** — only trigger \`dbt_run_job\` after the user explicitly confirms which job to
    run. Never run prod jobs proactively.
+6. **Ship (git)** — for repo-bound projects, your file edits land in the working tree but are
+   NOT pushed automatically. Only commit after the user explicitly asks. Then call
+   \`dbt_git_status\` to confirm what changed, and \`dbt_commit_and_push\` (omit \`message\` to
+   auto-generate one) to push to the tracked branch. Use \`dbt_create_branch\` first when the
+   user wants an isolated branch, and \`dbt_open_pull_request\` when they want review instead of
+   a direct push.
 
 ## Rules
+
+- Never commit or push proactively — file edits stay in the working tree until the user asks
+  you to commit. Prefer pushing to the tracked branch (mirrors the IDE button); only branch or
+  open a PR when the user asks for it.
 
 - Load the \`dbt\` system skill for materializations, incremental strategies, snapshots, and
   adapter quirks before writing non-trivial models.

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -153,6 +153,12 @@ only when the user asks for a recurring run). Trigger a saved job with \`dbt_run
 a job (possibly prod) without the user explicitly confirming it. \`dbt_run_job\` only QUEUES the
 run; always follow up with \`dbt_get_run\` to report whether it actually passed or failed.
 
+Git (repo-bound projects): your edits land in the working tree but are NOT pushed automatically.
+Only commit when the user asks. Check \`dbt_git_status\`, then \`dbt_commit_and_push\` (omit
+\`message\` to auto-generate one) to push to the tracked branch — same as the IDE button. Use
+\`dbt_create_branch\` first for an isolated branch, and \`dbt_open_pull_request\` only when the user
+wants review instead of a direct push. Never commit, push, switch branches, or open a PR proactively.
+
 For conventions (staging/marts layout, ref()/source(), materializations, incremental models,
 snapshots, schema.yml tests), load the \`dbt\` system skill.`;
 

--- a/api/src/agents/modes/registry.ts
+++ b/api/src/agents/modes/registry.ts
@@ -171,6 +171,13 @@ const TRANSFORM_MODE_TOOL_NAMES: string[] = [
   "dbt_show",
   "dbt_create_job",
   "dbt_update_job",
+  // Git: commit/push edits to the connected repo (only when the user asks).
+  "dbt_git_status",
+  "dbt_commit_and_push",
+  "dbt_create_branch",
+  "dbt_switch_branch",
+  "dbt_list_branches",
+  "dbt_open_pull_request",
   // Discovery: inspect sources before writing staging models; preview built
   // tables after dbt_run_model.
   "list_connections",

--- a/api/src/agents/unified/index.ts
+++ b/api/src/agents/unified/index.ts
@@ -46,7 +46,7 @@ export function unifiedAgentFactory(context: AgentContext): AgentConfig {
     context.toolExecutionContext,
   );
   const versionHistoryTools = createVersionHistoryTools(workspaceId);
-  const dbtServerTools = createDbtServerTools(workspaceId);
+  const dbtServerTools = createDbtServerTools(workspaceId, userId);
 
   const {
     list_connections: _flowListConnections,

--- a/app/src/components/DbtJobView.tsx
+++ b/app/src/components/DbtJobView.tsx
@@ -34,6 +34,11 @@ import { useWorkspace } from "../contexts/workspace-context";
 import { useDbtStore, type DbtJobItem } from "../store/dbtStore";
 import DbtRunHistory from "./DbtRunHistory";
 
+// Fast cadence while a run is active; slower idle cadence so scheduled runs
+// that fire (and progress updates) surface without a manual refresh.
+const ACTIVE_POLL_INTERVAL_MS = 3_000;
+const IDLE_POLL_INTERVAL_MS = 8_000;
+
 type SchedulePreset = "hourly" | "daily" | "every6h" | "weekly" | "custom";
 
 const PRESET_CRONS: Record<Exclude<SchedulePreset, "custom">, string> = {
@@ -143,6 +148,42 @@ export default function DbtJobView({
   const runningRun = jobRuns.find(
     run => run.status === "running" || run.status === "queued",
   );
+
+  // Keep this job's run history live while the tab is open: scheduled runs
+  // that fire and in-progress runs update without a manual refresh. Cadence
+  // adapts to whether a run is active; polling pauses while the tab is hidden.
+  const hasActiveRef = useRef(false);
+  hasActiveRef.current = !!runningRun;
+  useEffect(() => {
+    if (!workspaceId) return;
+    let stopped = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const schedule = () => {
+      if (stopped) return;
+      const interval = hasActiveRef.current
+        ? ACTIVE_POLL_INTERVAL_MS
+        : IDLE_POLL_INTERVAL_MS;
+      timer = setTimeout(() => void tick(), interval);
+    };
+    const tick = async () => {
+      if (document.visibilityState === "visible") {
+        await fetchRuns(workspaceId, projectId, jobId);
+      }
+      schedule();
+    };
+    schedule();
+    const onVisible = () => {
+      if (document.visibilityState === "visible") {
+        void fetchRuns(workspaceId, projectId, jobId);
+      }
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      stopped = true;
+      if (timer) clearTimeout(timer);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, [workspaceId, projectId, jobId, fetchRuns]);
 
   const handleRunNow = useCallback(async () => {
     if (!workspaceId) return;

--- a/app/src/components/DbtRunsView.tsx
+++ b/app/src/components/DbtRunsView.tsx
@@ -12,6 +12,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Box, IconButton, Tooltip, Typography } from "@mui/material";
 import { RefreshCw as RefreshIcon } from "lucide-react";
 import { useWorkspace } from "../contexts/workspace-context";
+import { useConsoleStore } from "../store/consoleStore";
 import { useDbtStore } from "../store/dbtStore";
 import DbtRunHistory from "./DbtRunHistory";
 import EntityBreadcrumbs from "./EntityBreadcrumbs";
@@ -65,6 +66,16 @@ export default function DbtRunsView({
     if (!jobs) void fetchJobs(workspaceId, projectId);
     void fetchRuns(workspaceId, projectId);
   }, [workspaceId, projectId, jobs, fetchJobs, fetchRuns]);
+
+  // Refresh whenever this tab becomes active — opening it, or clicking back to
+  // it after it stayed mounted in the background — so it never shows stale runs
+  // while waiting for the next poll tick.
+  const isActiveTab = useConsoleStore(s => s.activeTabId === tabId);
+  useEffect(() => {
+    if (isActiveTab && workspaceId) {
+      void fetchRuns(workspaceId, projectId);
+    }
+  }, [isActiveTab, workspaceId, projectId, fetchRuns]);
 
   // Poll the run list the whole time this tab is open so newly-triggered runs
   // (agent `dbt_run_model`, editor "Run model", scheduled jobs) appear and

--- a/app/src/components/DbtRunsView.tsx
+++ b/app/src/components/DbtRunsView.tsx
@@ -16,7 +16,10 @@ import { useDbtStore } from "../store/dbtStore";
 import DbtRunHistory from "./DbtRunHistory";
 import EntityBreadcrumbs from "./EntityBreadcrumbs";
 
-const LIST_POLL_INTERVAL_MS = 3_000;
+// Fast cadence while a run is active; slower idle cadence so newly-triggered
+// runs (agent, editor, schedule) still surface without a manual refresh.
+const ACTIVE_POLL_INTERVAL_MS = 3_000;
+const IDLE_POLL_INTERVAL_MS = 8_000;
 
 export default function DbtRunsView({
   tabId,
@@ -63,25 +66,43 @@ export default function DbtRunsView({
     void fetchRuns(workspaceId, projectId);
   }, [workspaceId, projectId, jobs, fetchJobs, fetchRuns]);
 
-  // Poll the run list while anything is active so agent-triggered runs appear
-  // and statuses stay fresh without manual refresh.
+  // Poll the run list the whole time this tab is open so newly-triggered runs
+  // (agent `dbt_run_model`, editor "Run model", scheduled jobs) appear and
+  // statuses stay fresh without a manual refresh. Cadence adapts to whether a
+  // run is active, and polling pauses while the tab is hidden.
   const hasActiveRef = useRef(hasActive);
   hasActiveRef.current = hasActive;
   useEffect(() => {
-    if (!workspaceId || !hasActive) return;
+    if (!workspaceId) return;
     let stopped = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
-    const poll = async () => {
-      await fetchRuns(workspaceId, projectId);
-      if (stopped || !hasActiveRef.current) return;
-      timer = setTimeout(() => void poll(), LIST_POLL_INTERVAL_MS);
+    const schedule = () => {
+      if (stopped) return;
+      const interval = hasActiveRef.current
+        ? ACTIVE_POLL_INTERVAL_MS
+        : IDLE_POLL_INTERVAL_MS;
+      timer = setTimeout(() => void tick(), interval);
     };
-    timer = setTimeout(() => void poll(), LIST_POLL_INTERVAL_MS);
+    const tick = async () => {
+      if (document.visibilityState === "visible") {
+        await fetchRuns(workspaceId, projectId);
+      }
+      schedule();
+    };
+    schedule();
+    // Refresh immediately when the tab regains focus after being hidden.
+    const onVisible = () => {
+      if (document.visibilityState === "visible") {
+        void fetchRuns(workspaceId, projectId);
+      }
+    };
+    document.addEventListener("visibilitychange", onVisible);
     return () => {
       stopped = true;
       if (timer) clearTimeout(timer);
+      document.removeEventListener("visibilitychange", onVisible);
     };
-  }, [workspaceId, projectId, hasActive, fetchRuns]);
+  }, [workspaceId, projectId, fetchRuns]);
 
   // Default selection: newest run.
   useEffect(() => {

--- a/app/src/store/dbtStore.ts
+++ b/app/src/store/dbtStore.ts
@@ -523,6 +523,21 @@ function encodeDbtPath(path: string): string {
   return path.split("/").map(encodeURIComponent).join("/");
 }
 
+/**
+ * Refresh the working-tree git status for a repo-bound project after a file
+ * write. Fire-and-forget: keeps the "Commit & push (N)" badge in sync when the
+ * agent (or the editor) creates/modifies/deletes/renames files. No-op for
+ * projects without a repo binding (the status endpoint would 400).
+ */
+function refreshGitStatusForRepoProject(
+  get: () => DbtStore,
+  workspaceId: string,
+  projectId: string,
+): void {
+  const project = get().projects.find(p => p._id === projectId);
+  if (project?.repo) void get().fetchGitStatus(workspaceId, projectId);
+}
+
 export const useDbtStore = create<DbtStore>()(
   immer((set, get) => ({
     ...initialState,
@@ -1006,6 +1021,7 @@ export const useDbtStore = create<DbtStore>()(
           const entry = state.filesByProject[projectId]?.[path];
           if (entry) entry.dirty = false;
         });
+        refreshGitStatusForRepoProject(get, workspaceId, projectId);
         return true;
       } catch (error) {
         set(state => {
@@ -1035,6 +1051,7 @@ export const useDbtStore = create<DbtStore>()(
             state.filePathsByProject[projectId] = paths.filter(p => p !== path);
           }
         });
+        refreshGitStatusForRepoProject(get, workspaceId, projectId);
         return true;
       } catch (error) {
         set(state => {
@@ -1066,6 +1083,7 @@ export const useDbtStore = create<DbtStore>()(
               .sort();
           }
         });
+        refreshGitStatusForRepoProject(get, workspaceId, projectId);
         return true;
       } catch (error) {
         set(state => {

--- a/packages/agent-tools/src/read-only-tools.ts
+++ b/packages/agent-tools/src/read-only-tools.ts
@@ -52,6 +52,9 @@ export const READ_ONLY_TOOL_NAMES: ReadonlySet<string> = new Set<string>([
   "dbt_compile_model",
   "dbt_get_run",
   "dbt_show",
+  // dbt git reads (status + branch listing never mutate the repo)
+  "dbt_git_status",
+  "dbt_list_branches",
   // Surface-scoped data-source reads (apps + dashboards, local DuckDB only)
   "list_data_sources",
   "inspect_data_source",


### PR DESCRIPTION
> Stacked on #537 (base branch `feat/dbt-ai-commit-message`). Review/merge that first.

## Summary

Two things from the follow-up:

### 1. Agent can now commit to the connected GitHub repo
New server-side tools for repo-bound dbt projects (gated into the `transform` expertise mode):

- `dbt_git_status` — pending working-tree changes + branch (read-only)
- `dbt_commit_and_push` — commits **all** changes to the **tracked branch** (same as the IDE button). Omit `message` → auto-generated from the diff via the #537 service. 🪄
- `dbt_create_branch` / `dbt_switch_branch` / `dbt_list_branches`
- `dbt_open_pull_request` — only when the user wants review

**Design (per discussion):** prefer a direct push to the tracked branch — no forced PRs, since Mako-managed dbt projects are usually managed end-to-end in-app. Branch/PR are opt-in. The agent **never commits/pushes/branches proactively** — confirmation is required in the prompt + every tool description (mirrors the `dbt_run_job` guardrail). Read-only git tools (`dbt_git_status`, `dbt_list_branches`) are added to `READ_ONLY_TOOL_NAMES` so plan mode allows them.

### 2. Fix: git status didn't refresh when the agent edited files
`executeDbtAgentTool` (and the editor's debounced save) wrote files but never refreshed git status, so the **"Commit & push (N)"** badge and dialog stayed stale. The dbt store now refreshes the working-tree status after every successful `persistFile` / `createFile` / `deleteFile` / `renameFile` on a repo-bound project — so agent **and** manual edits update the UI live.

## Test plan

- [ ] Ask the agent to add a model, then "commit and push" → it calls `dbt_git_status` + `dbt_commit_and_push`, the commit lands on the tracked branch with an auto-generated message.
- [ ] Agent edits a file → the explorer's "Commit & push (N)" badge updates without reopening the dialog.
- [ ] Manual editor edit → same live badge update.
- [ ] Agent does NOT commit unless explicitly asked.
- [ ] "Open a PR for this" → `dbt_create_branch` (if on default branch) + `dbt_open_pull_request` returns a PR URL.
- [ ] Non-repo project → git tools return a clear "not connected to a repository" error.

Made with [Cursor](https://cursor.com)