### PR TITLE
feat(agent): provider-agnostic context-window compaction for long chats

### DIFF
--- a/api/src/agent-lib/ai-models.ts
+++ b/api/src/agent-lib/ai-models.ts
@@ -28,6 +28,12 @@ export interface AIModel {
   supportsThinking?: boolean;
   thinkingMode?: AnthropicThinkingMode;
   thinkingBudgetTokens?: number;
+  /**
+   * Maximum input+output tokens the model accepts, from the gateway catalog.
+   * `null` when upstream doesn't report it — callers must treat unknown as
+   * "skip proactive budgeting and lean on the reactive overflow backstop".
+   */
+  contextWindow?: number | null;
 }
 
 function catalogToAIModel(cm: CatalogModel): AIModel {
@@ -40,6 +46,7 @@ function catalogToAIModel(cm: CatalogModel): AIModel {
     supportsThinking: cm.supportsThinking,
     thinkingMode: cm.thinkingMode,
     thinkingBudgetTokens: cm.thinkingBudgetTokens,
+    contextWindow: cm.contextWindow,
   };
 }
 

--- a/api/src/agent-lib/context-overflow-self-heal.ts
+++ b/api/src/agent-lib/context-overflow-self-heal.ts
@@ -1,0 +1,143 @@
+/**
+ * Reactive, provider-agnostic backstop for context-window overflow.
+ *
+ * The proactive compactor (`context/compaction.ts`) keeps the prompt under a
+ * budget computed from the model's catalog `contextWindow`. That budget relies
+ * on a token *estimate*, and tool-output sizes are heavy-tailed — so an
+ * occasional request can still slip past the real ceiling (or the context
+ * window may be unknown, in which case proactive budgeting is skipped). When
+ * that happens the provider rejects the request at request time with a
+ * "prompt is too long" / "context_length_exceeded" / token-count 400.
+ *
+ * This middleware mirrors `withThinkingSelfHeal`: it catches exactly that class
+ * of error in `wrapStream`/`wrapGenerate` and retries ONCE with the prompt
+ * aggressively trimmed to the most recent user turns. The rejection is a
+ * request-time 400 (no partial output emitted), so a whole-call retry is safe.
+ * It is provider-neutral — the trim operates on the AI SDK `ModelMessage[]`
+ * shape every provider receives — so it works for OpenAI, Anthropic, Google,
+ * and anything else routed through the gateway.
+ *
+ * Single retry (never loops): if the trimmed request still overflows, the
+ * original error surfaces and the route shows a friendly "chat too long"
+ * message. That bounded behavior is the circuit breaker.
+ */
+
+import {
+  wrapLanguageModel,
+  type LanguageModel,
+  type LanguageModelMiddleware,
+} from "ai";
+import { loggers } from "../logging";
+
+const logger = loggers.agent();
+
+const OVERFLOW_PATTERNS =
+  /context[_ ]length|maximum context|prompt is too long|input is too long|too many (input )?tokens|exceeds the (maximum|context)|model_context_window_exceeded|reduce the length of the (messages|prompt)|token count .* exceeds/i;
+
+/** Keep at most this many trailing user turns on the emergency retry. */
+const RETRY_KEEP_USER_TURNS = 3;
+
+export function isContextOverflowError(error: unknown): boolean {
+  if (!error) return false;
+  const blobs: string[] = [];
+  const err = error as Record<string, unknown>;
+  if (typeof err.message === "string") blobs.push(err.message);
+  if (typeof err.responseBody === "string") blobs.push(err.responseBody);
+  if (typeof err.data === "string") blobs.push(err.data);
+  // AI SDK APICallError nests provider payloads under `data`/`responseBody`;
+  // fall back to a defensive stringify of the whole error.
+  try {
+    blobs.push(JSON.stringify(error));
+  } catch {
+    blobs.push(String(error));
+  }
+  return blobs.some(b => OVERFLOW_PATTERNS.test(b));
+}
+
+type PromptMessage = { role: string; content: unknown };
+
+/**
+ * Trim a `ModelMessage[]` prompt to the last N user turns while keeping a valid
+ * provider prompt: preserve leading `system` messages, ensure the first
+ * non-system message is a `user` message (no orphan `tool` results, no leading
+ * `assistant`), and never drop the trailing messages (the current question).
+ */
+export function trimPromptToRecentUserTurns(
+  prompt: PromptMessage[],
+  keepUserTurns: number = RETRY_KEEP_USER_TURNS,
+): PromptMessage[] {
+  const system = prompt.filter(m => m.role === "system");
+  const rest = prompt.filter(m => m.role !== "system");
+
+  // Find the start indices of user turns from the end.
+  const userIdx: number[] = [];
+  for (let i = 0; i < rest.length; i++) {
+    if (rest[i].role === "user") userIdx.push(i);
+  }
+  if (userIdx.length === 0) return prompt; // nothing safe to do
+
+  const startUser = userIdx[Math.max(0, userIdx.length - keepUserTurns)];
+  const tail = rest.slice(startUser);
+  return [...system, ...tail];
+}
+
+function withTrimmedPrompt<
+  T extends { prompt?: unknown; providerOptions?: unknown },
+>(params: T): T {
+  const prompt = params.prompt;
+  if (!Array.isArray(prompt)) return params;
+  const trimmed = trimPromptToRecentUserTurns(prompt as PromptMessage[]);
+  return { ...params, prompt: trimmed } as T;
+}
+
+export function withContextOverflowSelfHeal(
+  model: LanguageModel,
+  modelId: string,
+): LanguageModel {
+  const log = (originalCount: number, retriedCount: number) =>
+    logger.warn(
+      "Model rejected prompt as too long; retrying with trimmed history",
+      {
+        modelId,
+        originalMessages: originalCount,
+        retriedMessages: retriedCount,
+      },
+    );
+
+  const middleware: LanguageModelMiddleware = {
+    specificationVersion: "v3",
+    wrapGenerate: async ({ doGenerate, params, model: inner }) => {
+      try {
+        return await doGenerate();
+      } catch (error) {
+        if (!isContextOverflowError(error)) throw error;
+        const retried = withTrimmedPrompt(params);
+        log(
+          Array.isArray(params.prompt) ? params.prompt.length : -1,
+          Array.isArray(retried.prompt) ? retried.prompt.length : -1,
+        );
+        return inner.doGenerate(retried);
+      }
+    },
+    wrapStream: async ({ doStream, params, model: inner }) => {
+      try {
+        // Request-time 400: doStream() rejects before the first chunk, so a
+        // whole-call retry emits no duplicate output.
+        return await doStream();
+      } catch (error) {
+        if (!isContextOverflowError(error)) throw error;
+        const retried = withTrimmedPrompt(params);
+        log(
+          Array.isArray(params.prompt) ? params.prompt.length : -1,
+          Array.isArray(retried.prompt) ? retried.prompt.length : -1,
+        );
+        return inner.doStream(retried);
+      }
+    },
+  };
+
+  return wrapLanguageModel({
+    model: model as Parameters<typeof wrapLanguageModel>[0]["model"],
+    middleware,
+  }) as unknown as LanguageModel;
+}

--- a/api/src/agent-lib/context/compaction.ts
+++ b/api/src/agent-lib/context/compaction.ts
@@ -1,0 +1,471 @@
+/**
+ * Provider-agnostic conversation compaction.
+ *
+ * Long agent chats replay their full history every turn (the client sends the
+ * whole `messages[]`, tool outputs and reasoning blocks are persisted verbatim
+ * and replayed forever). Eventually the prompt exceeds the model's context
+ * window and the provider rejects the request ("prompt is too long", OpenAI
+ * "context_length_exceeded", Gemini token errors, …).
+ *
+ * This module keeps the model input under a computed budget BEFORE the request
+ * goes out, working entirely on `UIMessage[]` (the shape the route controls)
+ * so it is identical for every provider routed through the gateway. Because
+ * tool calls/results live as *parts inside* a single assistant `UIMessage` in
+ * this codebase, keeping/dropping/eliding whole messages preserves tool
+ * call↔result pairing automatically.
+ *
+ * Tiered strategy (stop as soon as we fit):
+ *   1. Elide large tool outputs in OLDER messages (cheap, mostly lossless).
+ *   2. Summarize older turns with a cheap utility model, drop the raw turns,
+ *      and fold the summary into the first surviving user message.
+ *   3. Emergency: elide/truncate within the recent window, always keeping the
+ *      latest user message intact.
+ *
+ * The reactive backstop in `context-overflow-self-heal.ts` covers the rare
+ * case where the estimate was still too optimistic (tool-output sizes are
+ * heavy-tailed) or where `contextWindow` is unknown.
+ */
+
+import { generateText, type UIMessage } from "ai";
+import { getModel } from "../ai-gateway";
+import { getUtilityModelId } from "../ai-models";
+import { loggers } from "../../logging";
+import {
+  estimateTokensFromText,
+  estimateTokensFromValue,
+  estimateUiMessagesTokens,
+  estimateUiMessageTokens,
+} from "./token-estimate";
+
+const logger = loggers.agent();
+
+// ---------------------------------------------------------------------------
+// Tunables
+// ---------------------------------------------------------------------------
+
+/** Turns kept verbatim at the tail of the conversation. */
+const DEFAULT_KEEP_RECENT_TURNS = 6;
+
+/** Fraction of the context window reserved as a safety margin. */
+const SAFETY_MARGIN_RATIO = 0.1;
+
+/** Tokens reserved for the model's own output when no thinking budget known. */
+const DEFAULT_OUTPUT_RESERVE_TOKENS = 16_000;
+
+/** A tool output bigger than this (estimated tokens) is elided when old. */
+const ELIDE_TOOL_OUTPUT_TOKENS = 400;
+
+/** Cap on the transcript (chars) fed to the summarizer to protect ITS window. */
+const SUMMARY_INPUT_CHAR_CAP = 120_000;
+
+/** Max output tokens for the summary itself. */
+const SUMMARY_MAX_OUTPUT_TOKENS = 1_500;
+
+const ELIDED_OUTPUT_PLACEHOLDER = {
+  _compacted: true as const,
+  note: "Large tool output omitted to fit the context window. Re-run the tool if you need the full result.",
+};
+
+// ---------------------------------------------------------------------------
+// Budget
+// ---------------------------------------------------------------------------
+
+export interface InputBudgetOptions {
+  contextWindow: number | null | undefined;
+  /**
+   * The system prompt. Accepts the AI SDK system shape (string or
+   * `SystemModelMessage[]`); only its serialised size matters for budgeting.
+   */
+  systemText: unknown;
+  /** Reasoning budget tokens (Anthropic extended thinking, etc.). */
+  thinkingBudgetTokens?: number;
+  /** Override the default output reserve. */
+  outputReserveTokens?: number;
+}
+
+/**
+ * Tokens available for the message history. Returns `null` when the context
+ * window is unknown (caller should skip proactive compaction and rely on the
+ * reactive backstop).
+ */
+export function computeInputBudget(opts: InputBudgetOptions): number | null {
+  if (!opts.contextWindow || opts.contextWindow <= 0) return null;
+  const margin = Math.ceil(opts.contextWindow * SAFETY_MARGIN_RATIO);
+  const output = opts.outputReserveTokens ?? DEFAULT_OUTPUT_RESERVE_TOKENS;
+  const thinking = opts.thinkingBudgetTokens ?? 0;
+  const system =
+    typeof opts.systemText === "string"
+      ? estimateTokensFromText(opts.systemText)
+      : estimateTokensFromValue(opts.systemText);
+  const budget = opts.contextWindow - margin - output - thinking - system;
+  // Never return a non-positive budget; clamp to a small floor so the recent
+  // turn(s) still get a chance (the reactive backstop handles the rest).
+  return Math.max(budget, 2_000);
+}
+
+// ---------------------------------------------------------------------------
+// Turn grouping
+// ---------------------------------------------------------------------------
+
+interface Turn {
+  /** Index in the original messages array where this turn starts. */
+  start: number;
+  messages: UIMessage[];
+}
+
+/** A turn begins at each user message; assistant/tool messages attach to it. */
+function groupIntoTurns(messages: UIMessage[]): Turn[] {
+  const turns: Turn[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (msg.role === "user" || turns.length === 0) {
+      turns.push({ start: i, messages: [msg] });
+    } else {
+      turns[turns.length - 1].messages.push(msg);
+    }
+  }
+  return turns;
+}
+
+// ---------------------------------------------------------------------------
+// Tool-output elision (lossless-ish)
+// ---------------------------------------------------------------------------
+
+function elideToolOutputsInMessage(message: UIMessage): {
+  message: UIMessage;
+  changed: boolean;
+} {
+  const parts = (message.parts ?? []) as Array<Record<string, unknown>>;
+  let changed = false;
+  const nextParts = parts.map(part => {
+    const type = typeof part.type === "string" ? part.type : "";
+    const isTool = type.startsWith("tool-") || type === "dynamic-tool";
+    if (!isTool) return part;
+    if (part.output == null) return part;
+    if (
+      (part as { output?: { _compacted?: boolean } }).output?._compacted ===
+      true
+    ) {
+      return part;
+    }
+    if (estimateTokensFromValue(part.output) < ELIDE_TOOL_OUTPUT_TOKENS) {
+      return part;
+    }
+    changed = true;
+    return { ...part, output: ELIDED_OUTPUT_PLACEHOLDER };
+  });
+  if (!changed) return { message, changed: false };
+  return {
+    message: { ...message, parts: nextParts as UIMessage["parts"] },
+    changed: true,
+  };
+}
+
+function elideToolOutputs(
+  messages: UIMessage[],
+  range: { from: number; to: number },
+): { messages: UIMessage[]; changed: boolean } {
+  let changed = false;
+  const next = messages.map((msg, idx) => {
+    if (idx < range.from || idx >= range.to) return msg;
+    if (msg.role !== "assistant") return msg;
+    const res = elideToolOutputsInMessage(msg);
+    if (res.changed) changed = true;
+    return res.message;
+  });
+  return { messages: next, changed };
+}
+
+// ---------------------------------------------------------------------------
+// Summarization (agnostic — cheapest curated tool-use model)
+// ---------------------------------------------------------------------------
+
+function renderMessageForSummary(message: UIMessage): string {
+  const role = message.role === "assistant" ? "Assistant" : "User";
+  const parts = (message.parts ?? []) as Array<Record<string, unknown>>;
+  const chunks: string[] = [];
+  for (const part of parts) {
+    const type = typeof part.type === "string" ? part.type : "";
+    if (type === "text" && typeof part.text === "string") {
+      chunks.push(part.text);
+    } else if (type.startsWith("tool-") || type === "dynamic-tool") {
+      const toolName =
+        type === "dynamic-tool"
+          ? String(part.toolName ?? "tool")
+          : type.slice("tool-".length);
+      const input = truncate(safeStringify(part.input), 300);
+      const output = truncate(safeStringify(part.output), 400);
+      chunks.push(`[tool ${toolName}] in=${input} out=${output}`);
+    }
+    // reasoning/file parts are intentionally skipped to save summarizer tokens.
+  }
+  const body = chunks.join("\n").trim();
+  return body ? `${role}: ${body}` : "";
+}
+
+function safeStringify(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max)}…`;
+}
+
+/** Keep head + tail when the transcript is too large for the summarizer. */
+function capTranscript(text: string): string {
+  if (text.length <= SUMMARY_INPUT_CHAR_CAP) return text;
+  const half = Math.floor(SUMMARY_INPUT_CHAR_CAP / 2);
+  return `${text.slice(0, half)}\n\n…[middle of earlier conversation omitted]…\n\n${text.slice(-half)}`;
+}
+
+const SUMMARY_INSTRUCTIONS = `You are compacting the earlier part of a conversation between a user and an AI data/SQL assistant so it fits in the context window. Write a dense, factual summary using EXACTLY these markdown sections (omit a section only if truly empty):
+
+## User intent & goals
+## Databases, schemas & tables referenced
+## Key decisions & conclusions
+## SQL / queries written or run (with the actual statements when short)
+## Important tool results & findings
+## Open tasks / next steps
+
+Rules: preserve concrete identifiers (table names, column names, IDs, file paths, exact SQL). Do not invent anything. Be concise but lossless on facts. Output only the summary.`;
+
+async function summarizeMessages(
+  messages: UIMessage[],
+  abortSignal?: AbortSignal,
+): Promise<string | null> {
+  const rendered = messages
+    .map(renderMessageForSummary)
+    .filter(Boolean)
+    .join("\n\n");
+  if (!rendered.trim()) return null;
+
+  const transcript = capTranscript(rendered);
+  try {
+    const modelId = await getUtilityModelId();
+    const { text } = await generateText({
+      model: getModel(modelId),
+      system: SUMMARY_INSTRUCTIONS,
+      prompt: `Summarize this earlier conversation:\n\n${transcript}`,
+      maxOutputTokens: SUMMARY_MAX_OUTPUT_TOKENS,
+      abortSignal,
+    });
+    const trimmed = text.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch (error) {
+    logger.warn("Conversation summarization failed; will hard-drop instead", {
+      error: String(error),
+    });
+    return null;
+  }
+}
+
+/** Prepend a summary block into the first user message of `messages`. */
+function injectSummary(messages: UIMessage[], summary: string): UIMessage[] {
+  const block = `[Summary of the earlier conversation, compacted to fit the context window]\n\n${summary}\n\n[End of summary — the most recent messages follow verbatim.]`;
+  const idx = messages.findIndex(m => m.role === "user");
+  if (idx === -1) {
+    // No user message in the kept window (unusual) — prepend a synthetic one.
+    const synthetic = {
+      id: `compaction-${Date.now()}`,
+      role: "user",
+      parts: [{ type: "text", text: block }],
+    } as UIMessage;
+    return [synthetic, ...messages];
+  }
+  const target = messages[idx];
+  const parts = [...((target.parts ?? []) as Array<Record<string, unknown>>)];
+  const firstText = parts.findIndex(p => p.type === "text");
+  if (firstText === -1) {
+    parts.unshift({ type: "text", text: block } as Record<string, unknown>);
+  } else {
+    parts[firstText] = {
+      ...parts[firstText],
+      text: `${block}\n\n${String(parts[firstText].text ?? "")}`,
+    };
+  }
+  const next = [...messages];
+  next[idx] = { ...target, parts: parts as UIMessage["parts"] };
+  return next;
+}
+
+// ---------------------------------------------------------------------------
+// Main entry
+// ---------------------------------------------------------------------------
+
+export interface CompactionOptions {
+  messages: UIMessage[];
+  /** Token budget for the message history (from `computeInputBudget`). */
+  budgetTokens: number;
+  keepRecentTurns?: number;
+  /** Whether to summarize older turns (vs. elide+drop only). */
+  summarize?: boolean;
+  abortSignal?: AbortSignal;
+}
+
+export type CompactionStrategy =
+  | "none"
+  | "elide"
+  | "summarize"
+  | "emergency-drop";
+
+export interface CompactionResult {
+  messages: UIMessage[];
+  didCompact: boolean;
+  strategy: CompactionStrategy;
+  estimatedTokensBefore: number;
+  estimatedTokensAfter: number;
+}
+
+export async function compactUiMessagesForBudget(
+  opts: CompactionOptions,
+): Promise<CompactionResult> {
+  const { messages, budgetTokens } = opts;
+  const keepRecentTurns = opts.keepRecentTurns ?? DEFAULT_KEEP_RECENT_TURNS;
+  const summarize = opts.summarize ?? true;
+
+  const estimatedTokensBefore = estimateUiMessagesTokens(messages);
+  if (estimatedTokensBefore <= budgetTokens) {
+    return {
+      messages,
+      didCompact: false,
+      strategy: "none",
+      estimatedTokensBefore,
+      estimatedTokensAfter: estimatedTokensBefore,
+    };
+  }
+
+  const turns = groupIntoTurns(messages);
+  const recentStartTurn = Math.max(0, turns.length - keepRecentTurns);
+  // First message index that belongs to the protected recent window.
+  const recentStartIdx =
+    recentStartTurn < turns.length ? turns[recentStartTurn].start : 0;
+
+  // --- Step 1: elide large tool outputs in the older region ---------------
+  let working = messages;
+  const elided = elideToolOutputs(working, { from: 0, to: recentStartIdx });
+  working = elided.messages;
+  let strategy: CompactionStrategy = elided.changed ? "elide" : "none";
+
+  if (estimateUiMessagesTokens(working) <= budgetTokens) {
+    return finalize(
+      working,
+      strategy === "none" ? "elide" : strategy,
+      estimatedTokensBefore,
+    );
+  }
+
+  // --- Step 2: summarize + drop older turns -------------------------------
+  if (recentStartIdx > 0) {
+    const older = working.slice(0, recentStartIdx);
+    const recent = working.slice(recentStartIdx);
+
+    let summary: string | null = null;
+    if (summarize) {
+      summary = await summarizeMessages(older, opts.abortSignal);
+    }
+
+    working = summary ? injectSummary(recent, summary) : recent;
+    strategy = summary ? "summarize" : "emergency-drop";
+
+    if (estimateUiMessagesTokens(working) <= budgetTokens) {
+      return finalize(working, strategy, estimatedTokensBefore);
+    }
+  }
+
+  // --- Step 3: emergency — elide everything, keep last user msg intact -----
+  const emergency = emergencyCompact(working, budgetTokens);
+  return finalize(emergency, "emergency-drop", estimatedTokensBefore);
+
+  function finalize(
+    msgs: UIMessage[],
+    strat: CompactionStrategy,
+    before: number,
+  ): CompactionResult {
+    const after = estimateUiMessagesTokens(msgs);
+    logger.info("Compacted conversation for context budget", {
+      strategy: strat,
+      budgetTokens,
+      estimatedTokensBefore: before,
+      estimatedTokensAfter: after,
+      messagesBefore: messages.length,
+      messagesAfter: msgs.length,
+    });
+    return {
+      messages: msgs,
+      didCompact: true,
+      strategy: strat,
+      estimatedTokensBefore: before,
+      estimatedTokensAfter: after,
+    };
+  }
+}
+
+/**
+ * Last resort: elide ALL tool outputs, then drop oldest whole messages while
+ * always preserving the final user message (the current question). Used when
+ * even the recent window blows the budget or summarization failed.
+ */
+function emergencyCompact(
+  messages: UIMessage[],
+  budgetTokens: number,
+): UIMessage[] {
+  // Elide every tool output regardless of age.
+  let working = messages.map(msg =>
+    msg.role === "assistant" ? elideToolOutputsInMessage(msg).message : msg,
+  );
+
+  if (estimateUiMessagesTokens(working) <= budgetTokens) return working;
+
+  // Index of the last user message — never drop it or anything after it.
+  let lastUserIdx = -1;
+  for (let i = working.length - 1; i >= 0; i--) {
+    if (working[i].role === "user") {
+      lastUserIdx = i;
+      break;
+    }
+  }
+  const protectedFrom = lastUserIdx === -1 ? working.length - 1 : lastUserIdx;
+
+  // Drop from the front until we fit (or only the protected tail remains).
+  while (
+    working.length > 1 &&
+    estimateUiMessagesTokens(working) > budgetTokens
+  ) {
+    // Stop dropping once we'd eat into the protected tail.
+    if (working.length <= messages.length - protectedFrom) break;
+    working = working.slice(1);
+  }
+
+  if (estimateUiMessagesTokens(working) <= budgetTokens) return working;
+
+  // Still too big: the protected tail itself is oversized. Hard-truncate the
+  // text parts of everything except the very last message.
+  working = working.map((msg, idx) =>
+    idx === working.length - 1 ? msg : truncateMessageText(msg),
+  );
+  return working;
+}
+
+function truncateMessageText(message: UIMessage): UIMessage {
+  const parts = (message.parts ?? []) as Array<Record<string, unknown>>;
+  const next = parts.map(part => {
+    if (part.type === "text" && typeof part.text === "string") {
+      const tokens = estimateUiMessageTokens({
+        ...message,
+        parts: [part] as UIMessage["parts"],
+      });
+      if (tokens > 1_000) {
+        return { ...part, text: truncate(part.text, 2_000) };
+      }
+    }
+    return part;
+  });
+  return { ...message, parts: next as UIMessage["parts"] };
+}

--- a/api/src/agent-lib/context/token-estimate.ts
+++ b/api/src/agent-lib/context/token-estimate.ts
@@ -1,0 +1,91 @@
+/**
+ * Provider-agnostic token estimation.
+ *
+ * We deliberately avoid a real per-provider tokenizer here: the agent routes
+ * every model through the Vercel AI Gateway (OpenAI, Anthropic, Google, …),
+ * and shipping a tokenizer per family is both heavy and still approximate for
+ * tool-call / image parts. A character heuristic with a conservative ratio is
+ * accurate enough for *budgeting* (we only need to know when we are nearing a
+ * limit, not the exact count) and is the same shape every provider sees.
+ *
+ * `CHARS_PER_TOKEN` is intentionally low (≈3.5) so we OVER-estimate token
+ * counts. Over-estimating is the safe direction: it makes us compact slightly
+ * earlier rather than sail past the real ceiling. The reactive overflow
+ * backstop (`context-overflow-self-heal.ts`) covers the rare case where the
+ * estimate was still too optimistic.
+ */
+
+import type { UIMessage } from "ai";
+
+/** Lower = more conservative (higher estimated token count). */
+const CHARS_PER_TOKEN = 3.5;
+
+/** Flat per-part overhead (role markers, tool framing, JSON punctuation). */
+const PART_OVERHEAD_TOKENS = 8;
+
+/** Per-message overhead the provider adds around every message envelope. */
+const MESSAGE_OVERHEAD_TOKENS = 8;
+
+export function estimateTokensFromText(text: string): number {
+  if (!text) return 0;
+  return Math.ceil(text.length / CHARS_PER_TOKEN);
+}
+
+/**
+ * Estimate the token cost of an arbitrary JSON-serialisable value (tool
+ * inputs/outputs). Falls back to a small constant if serialisation fails.
+ */
+export function estimateTokensFromValue(value: unknown): number {
+  if (value == null) return 0;
+  if (typeof value === "string") return estimateTokensFromText(value);
+  try {
+    return estimateTokensFromText(JSON.stringify(value));
+  } catch {
+    return PART_OVERHEAD_TOKENS;
+  }
+}
+
+function estimatePartTokens(part: Record<string, unknown>): number {
+  const type = typeof part.type === "string" ? part.type : "";
+  let tokens = PART_OVERHEAD_TOKENS;
+
+  if (type === "text") {
+    tokens += estimateTokensFromText(String(part.text ?? ""));
+  } else if (type === "reasoning") {
+    tokens += estimateTokensFromText(String(part.text ?? part.reasoning ?? ""));
+  } else if (type === "file") {
+    // Inline data URLs are the expensive case; a remote/proxied url is cheap.
+    const url = typeof part.url === "string" ? part.url : "";
+    const data = typeof part.data === "string" ? part.data : "";
+    tokens += estimateTokensFromText(url.startsWith("data:") ? url : "");
+    tokens += estimateTokensFromText(data);
+  } else if (type.startsWith("tool-") || type === "dynamic-tool") {
+    tokens += estimateTokensFromValue(part.input);
+    tokens += estimateTokensFromValue(part.output);
+    if (typeof part.errorText === "string") {
+      tokens += estimateTokensFromText(part.errorText);
+    }
+  } else {
+    // Unknown part — price the whole serialised blob defensively.
+    tokens += estimateTokensFromValue(part);
+  }
+
+  return tokens;
+}
+
+export function estimateUiMessageTokens(message: UIMessage): number {
+  const parts = (message.parts ?? []) as Array<Record<string, unknown>>;
+  let tokens = MESSAGE_OVERHEAD_TOKENS;
+  for (const part of parts) {
+    tokens += estimatePartTokens(part);
+  }
+  return tokens;
+}
+
+export function estimateUiMessagesTokens(messages: UIMessage[]): number {
+  let tokens = 0;
+  for (const message of messages) {
+    tokens += estimateUiMessageTokens(message);
+  }
+  return tokens;
+}

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -17,6 +17,11 @@ import { getModel, buildProviderOptions } from "../agent-lib/ai-gateway";
 import { propagateAttributes } from "@langfuse/tracing";
 import { buildAnthropicThinkingConfig } from "../agent-lib/anthropic-thinking";
 import { withThinkingSelfHeal } from "../agent-lib/thinking-self-heal";
+import { withContextOverflowSelfHeal } from "../agent-lib/context-overflow-self-heal";
+import {
+  computeInputBudget,
+  compactUiMessagesForBudget,
+} from "../agent-lib/context/compaction";
 import { unifiedAuthMiddleware } from "../auth/unified-auth.middleware";
 import { AuthenticatedContext } from "../middleware/workspace.middleware";
 import { workspaceService } from "../services/workspace.service";
@@ -859,9 +864,13 @@ agentRoutes.openapi(
     // Self-heal wrapper: if the catalog still classifies this model as manual
     // thinking but Anthropic rejects the payload with the adaptive-only 400,
     // persist the corrected mode and retry the call transparently.
-    const model = resolvedModelId.startsWith("anthropic/")
+    const baseModel = resolvedModelId.startsWith("anthropic/")
       ? withThinkingSelfHeal(getModel(resolvedModelId), resolvedModelId)
       : getModel(resolvedModelId);
+    // Provider-agnostic backstop: if the prompt still overflows the context
+    // window (estimate was too optimistic, or contextWindow unknown), retry
+    // once with aggressively trimmed history instead of surfacing a raw 400.
+    const model = withContextOverflowSelfHeal(baseModel, resolvedModelId);
     logger.info("Using model", { model: resolvedModelId });
 
     /**
@@ -887,7 +896,39 @@ agentRoutes.openapi(
       const sanitizedMessages = sanitizeMessagesForModel(
         messagesWithAttachments,
       );
-      const modelMessages = await convertToModelMessages(sanitizedMessages);
+      // Proactively keep the prompt under the model's context window. Budget is
+      // derived from the catalog `contextWindow` (provider-agnostic — every
+      // gateway model reports it); when unknown we skip this and rely on the
+      // reactive overflow backstop wrapping the model. Tool calls/results live
+      // as parts inside a single assistant UIMessage here, so compacting whole
+      // messages preserves tool call↔result pairing automatically.
+      const inputBudget = computeInputBudget({
+        contextWindow: modelDef?.contextWindow,
+        systemText: systemPrompt,
+        thinkingBudgetTokens: modelDef?.thinkingBudgetTokens,
+      });
+      let messagesForModel = sanitizedMessages;
+      if (inputBudget !== null) {
+        const compaction = await compactUiMessagesForBudget({
+          messages: sanitizedMessages,
+          budgetTokens: inputBudget,
+          summarize: true,
+          abortSignal: turnSignal,
+        });
+        messagesForModel = compaction.messages;
+        if (compaction.didCompact) {
+          logger.info("Compacted chat history before generation", {
+            chatId,
+            workspaceId,
+            modelId: resolvedModelId,
+            strategy: compaction.strategy,
+            estimatedTokensBefore: compaction.estimatedTokensBefore,
+            estimatedTokensAfter: compaction.estimatedTokensAfter,
+            budgetTokens: inputBudget,
+          });
+        }
+      }
+      const modelMessages = await convertToModelMessages(messagesForModel);
       if (includeVisionAttachments) {
         const screenshotVisionMessage = buildScreenshotVisionModelMessage(
           screenshotVisionAttachments,


### PR DESCRIPTION
## Summary

Long agent chats hit provider context-window limits ("prompt is too long", `context_length_exceeded`, Gemini token-count 400s) because the full history — including verbatim tool outputs and reasoning blocks — is replayed every turn with **no budgeting**. The provider error currently surfaces raw to the user.

This adds a **two-layer, fully model-agnostic** fix (works for every model routed through the AI Gateway — OpenAI, Anthropic, Google, …), so end users stop hitting the wall.

### Layer 1 — proactive compaction (before the request)
In `buildSegmentModelMessages` ([api/src/routes/agent.routes.ts](api/src/routes/agent.routes.ts)), derive a token budget from the catalog `contextWindow` (minus system prompt + thinking budget + output reserve + 10% margin) and run a tiered compaction over the `UIMessage` history:
1. **Elide** large tool outputs in older messages (cheap, near-lossless).
2. **Summarize** older turns with the cheap utility model (`getUtilityModelId()`) using a structured template, drop the raw turns, and fold the summary into the first surviving user message.
3. **Emergency** elide-all + drop-oldest, always keeping the latest user message intact.

Because tool calls/results live as parts **inside** a single assistant `UIMessage` in this codebase, compacting whole messages preserves tool call↔result pairing automatically. Normal-length chats are untouched (early-return when under budget).

### Layer 2 — reactive backstop (if it still overflows)
`withContextOverflowSelfHeal` ([api/src/agent-lib/context-overflow-self-heal.ts](api/src/agent-lib/context-overflow-self-heal.ts)) mirrors the existing `withThinkingSelfHeal` middleware: it catches a cross-provider overflow regex at request time and retries **once** with history trimmed to the most recent user turns. Single retry = built-in circuit breaker (never loops). Covers the rare estimate miss and the case where `contextWindow` is unknown.

## Files
- `api/src/agent-lib/context/token-estimate.ts` (new) — provider-agnostic token estimator
- `api/src/agent-lib/context/compaction.ts` (new) — tiered compactor + budget calc
- `api/src/agent-lib/context-overflow-self-heal.ts` (new) — cross-provider reactive middleware
- `api/src/agent-lib/ai-models.ts` — thread `contextWindow` through `AIModel` (was dropped by `catalogToAIModel`)
- `api/src/routes/agent.routes.ts` — wire proactive compaction + wrap model with overflow self-heal

## Test plan
- [x] `pnpm --filter api run build` (lint + typecheck) green on a clean `master` base
- [ ] Manual: drive a chat past the model's context window; confirm it compacts/summarizes instead of erroring
- [ ] Confirm normal-length chats are byte-for-byte unaffected (under-budget early return)

## Deferred (intentional)
- No cross-turn summary cache yet — the rolling summary is recomputed per over-budget turn. Follow-up: persist on the `Chat` doc for incremental roll-up.
- Anthropic-native server-side `contextManagement` omitted on purpose to keep this 100% provider-agnostic; can be layered on later as an opportunistic optimization for Claude.

Made with [Cursor](https://cursor.com)