### PR TITLE
fix(stripe): backfill all subscription statuses + type missing invoice fields

### DIFF
--- a/api/src/connectors/stripe/connector.test.ts
+++ b/api/src/connectors/stripe/connector.test.ts
@@ -90,7 +90,57 @@ async function testResolveSchema() {
   assert.equal(charge?.fields.currency?.type, "string");
   assert.equal(charge?.fields.billing_details?.type, "json");
 
+  // Invoice fields that were previously absent (and therefore string-coerced
+  // by the unknown-field policy) must now carry their real types.
+  const invoice = await connector.resolveSchema("invoices");
+  assert.equal(invoice?.fields.paid_out_of_band?.type, "boolean");
+  assert.equal(invoice?.fields.automatic_tax?.type, "json");
+  assert.equal(invoice?.fields.transfer_data?.type, "json");
+  assert.equal(invoice?.fields.subtotal_excluding_tax?.type, "integer");
+  assert.equal(invoice?.fields.total_excluding_tax?.type, "integer");
+  assert.equal(invoice?.fields.ending_balance?.type, "integer");
+
   assert.equal(await connector.resolveSchema("not_real"), null);
+}
+
+async function testSubscriptionsBackfillRequestsAllStatuses() {
+  const connector = createConnector();
+
+  const capturedParams: Array<Record<string, unknown>> = [];
+  (connector as any).stripe = {
+    subscriptions: {
+      list: async (params: Record<string, unknown>) => {
+        capturedParams.push(params);
+        return { data: [], has_more: false };
+      },
+    },
+  };
+
+  await connector.fetchEntity({
+    entity: "subscriptions",
+    onBatch: async () => {},
+  } as any);
+
+  assert.equal(capturedParams.length, 1);
+  // Without status:"all" Stripe omits canceled/incomplete_expired subs.
+  assert.equal(capturedParams[0].status, "all");
+}
+
+function testNoLegacySubscriptionWebhookEvents() {
+  const connector = createConnector();
+  // Stripe never emits bare `subscription.*` events (only
+  // `customer.subscription.*`); ensure the dead entries are gone.
+  assert.equal(connector.getWebhookEventMapping("subscription.created"), null);
+  assert.equal(connector.getWebhookEventMapping("subscription.updated"), null);
+  assert.equal(connector.getWebhookEventMapping("subscription.deleted"), null);
+
+  const events = connector.getSupportedWebhookEvents();
+  assert.ok(!events.includes("subscription.created"));
+  assert.ok(!events.includes("subscription.updated"));
+  assert.ok(!events.includes("subscription.deleted"));
+  // The real, prefixed events remain supported.
+  assert.ok(events.includes("customer.subscription.created"));
+  assert.ok(events.includes("customer.subscription.deleted"));
 }
 
 function testNormalizeBackfillRecordTsParityWithWebhook() {
@@ -269,8 +319,10 @@ async function main() {
   testResolveRecordTimestampHandlesMillisGuard();
   testResolveRecordTimestampFallsBackToStringFields();
   await testResolveSchema();
+  await testSubscriptionsBackfillRequestsAllStatuses();
   testNormalizeBackfillRecordTsParityWithWebhook();
   testPriceEventsMapToPricesEntity();
+  testNoLegacySubscriptionWebhookEvents();
   testWebhookEventsForEntities();
   testSupportsWebhookProvisioning();
   await testCreateWebhookSubscriptionPayload();

--- a/api/src/connectors/stripe/connector.ts
+++ b/api/src/connectors/stripe/connector.ts
@@ -279,6 +279,10 @@ export class StripeConnector extends BaseConnector {
         case "subscriptions":
           response = await stripe.subscriptions.list({
             limit: batchSize,
+            // Stripe defaults to excluding canceled/incomplete_expired subs;
+            // without `status: "all"` the backfill silently drops all churned
+            // subscriptions, corrupting churn/retention/historical-MRR.
+            status: "all",
             ...(startingAfter && { starting_after: startingAfter }),
             ...(since && {
               created: { gte: Math.floor(since.getTime() / 1000) },
@@ -417,6 +421,10 @@ export class StripeConnector extends BaseConnector {
         case "subscriptions":
           response = await stripe.subscriptions.list({
             limit: batchSize,
+            // Stripe defaults to excluding canceled/incomplete_expired subs;
+            // without `status: "all"` the backfill silently drops all churned
+            // subscriptions, corrupting churn/retention/historical-MRR.
+            status: "all",
             ...(startingAfter && { starting_after: startingAfter }),
             ...(since && {
               created: { gte: Math.floor(since.getTime() / 1000) },
@@ -618,9 +626,6 @@ export class StripeConnector extends BaseConnector {
         entity: "subscriptions",
         operation: "delete",
       },
-      "subscription.created": { entity: "subscriptions", operation: "upsert" },
-      "subscription.updated": { entity: "subscriptions", operation: "upsert" },
-      "subscription.deleted": { entity: "subscriptions", operation: "delete" },
 
       // Charges/Payments
       "charge.succeeded": { entity: "charges", operation: "upsert" },
@@ -686,9 +691,6 @@ export class StripeConnector extends BaseConnector {
       "customer.subscription.created",
       "customer.subscription.updated",
       "customer.subscription.deleted",
-      "subscription.created",
-      "subscription.updated",
-      "subscription.deleted",
       // Charges
       "charge.succeeded",
       "charge.failed",

--- a/api/src/connectors/stripe/schema.ts
+++ b/api/src/connectors/stripe/schema.ts
@@ -148,13 +148,21 @@ export const INVOICE_SCHEMA: Record<string, ConnectorFieldSchema> = {
   amount_paid: i(),
   amount_remaining: i(),
   subtotal: i(),
+  subtotal_excluding_tax: i(),
   tax: i(),
   total: i(),
+  total_excluding_tax: i(),
+  starting_balance: i(),
+  ending_balance: i(),
   attempt_count: i(),
   period_start: ts(),
   period_end: ts(),
   due_date: ts(),
   paid: b(),
+  // Out-of-band (e.g. bank transfer) invoices are common in some markets;
+  // declaring the type prevents the unknown-field policy from coercing this
+  // boolean to a string.
+  paid_out_of_band: b(),
   attempted: b(),
   auto_advance: b(),
   lines: j(),
@@ -164,6 +172,11 @@ export const INVOICE_SCHEMA: Record<string, ConnectorFieldSchema> = {
   customer_shipping: j(),
   status_transitions: j(),
   total_tax_amounts: j(),
+  automatic_tax: j(),
+  transfer_data: j(),
+  payment_settings: j(),
+  issuer: j(),
+  from_invoice: j(),
 };
 
 export const PRODUCT_SCHEMA: Record<string, ConnectorFieldSchema> = {


### PR DESCRIPTION
## Summary

Three contained correctness fixes in the Stripe connector, surfaced while reconciling `ch_stripe_cdc` against Airbyte (canceled/incomplete_expired subs missing, `paid_out_of_band` landing as STRING).

- **`status: "all"` on subscriptions backfill (🔴 correctness bug).** Stripe's `subscriptions.list` defaults to excluding `canceled` and `incomplete_expired`. Both the resumable (`fetchEntityChunk`) and non-resumable (`fetchEntity`) paths omitted `status`, so the backfill silently dropped every churned subscription — corrupting churn, retention, and historical-MRR. Now passes `status: "all"`.
- **Typed previously-absent invoice fields.** Our normalizer uses `unknownFieldPolicy: "string"`, which force-stringifies any field not declared in the schema. `paid_out_of_band` (a boolean) and several nested/money fields were undeclared and therefore stored as STRING. Added explicit types: `paid_out_of_band` (bool), `automatic_tax`/`transfer_data`/`payment_settings`/`issuer`/`from_invoice` (json), `subtotal_excluding_tax`/`total_excluding_tax`/`starting_balance`/`ending_balance` (int).
- **Removed dead webhook mappings.** Stripe only emits `customer.subscription.*`; the bare `subscription.created|updated|deleted` mappings/events never fire. Dropped them.

Note: this is a connector-only fix. A **full re-sync of the subscriptions stream** is required after deploy to backfill the previously-missing canceled subscriptions.

## Test plan

- [x] `tsx src/connectors/stripe/connector.test.ts` passes (new assertions: subscriptions backfill requests `status: "all"`; invoice fields carry real types; bare `subscription.*` events are gone).
- [x] `pnpm --filter api run lint` clean.
- [x] `tsc --noEmit` shows no Stripe-related errors.
- [ ] After merge + deploy: trigger a full subscriptions re-sync, then re-verify the status breakdown matches Airbyte (active/past_due/trialing + canceled/incomplete_expired).

Made with [Cursor](https://cursor.com)