### PR TITLE
fix(cdc): self-heal pending event backlog (cursor drift + stale cleanup)

### DIFF
--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -2406,6 +2406,10 @@ const WebhookEventSchema = new Schema<IWebhookEvent>(
 WebhookEventSchema.index({ flowId: 1, eventId: 1 }, { unique: true });
 WebhookEventSchema.index({ flowId: 1, status: 1, receivedAt: 1 });
 WebhookEventSchema.index({ flowId: 1, applyStatus: 1, receivedAt: 1 });
+// Supports the GLOBAL cron-ingest query in cdcMaterializeSchedulerFunction:
+// find({ status: "pending" }).sort({ receivedAt: 1 }). Without a flowId-free
+// index this query does a COLLSCAN + in-memory sort over the whole collection.
+WebhookEventSchema.index({ status: 1, receivedAt: 1 });
 WebhookEventSchema.index({ workspaceId: 1, receivedAt: -1 });
 WebhookEventSchema.index(
   { receivedAt: 1 },

--- a/api/src/inngest/functions/webhook-flow.ts
+++ b/api/src/inngest/functions/webhook-flow.ts
@@ -20,6 +20,7 @@ import {
 } from "../../sync-cdc/normalization";
 import { cdcIngestService } from "../../sync-cdc/ingest";
 import { cdcConsumerService } from "../../sync-cdc/consumer";
+import { cleanupStalePendingCdcEvents } from "../../sync-cdc/cdc-stale-pending-cleanup";
 import { enqueueWebhookProcess } from "../webhook-process-enqueue";
 
 const WEBHOOK_SQL_PROCESS_CONCURRENCY = Math.max(
@@ -1043,7 +1044,15 @@ function buildMaterializeEvents(
   }));
 }
 
-const CDC_INGEST_BATCH_LIMIT = 1000;
+// How many pending WebhookEvents the cron ingests per run, GLOBALLY across all
+// flows. The effective ingest ceiling is roughly
+//   CDC_INGEST_BATCH_LIMIT / (scheduler cron interval).
+// Raise this (and/or shorten the cron) if the pending WebhookEvent backlog
+// grows faster than it drains. Requires the { status, receivedAt } index.
+const CDC_INGEST_BATCH_LIMIT = Math.max(
+  parseInt(process.env.CDC_INGEST_BATCH_LIMIT || "2000", 10) || 2000,
+  100,
+);
 
 /**
  * Ingest pending WebhookEvents into CdcChangeEvents, grouped by flow.
@@ -1394,6 +1403,15 @@ export const cdcMaterializeSchedulerFunction = inngest.createFunction(
       ingestPendingWebhookEvents(logger),
     )) as { ingested: number; dropped: number; failed: number };
 
+    // Reap CDC events that are still materialization-pending but whose paired
+    // webhook completed long ago (apply never finalized). Without this, stuck
+    // pending CdcChangeEvents accumulate forever — there is no TTL on the
+    // "pending" status (only applied/dropped have TTL indexes).
+    const cleanupResult = (await step.run(
+      "cleanup-stale-pending-cdc",
+      cleanupStalePendingCdcEvents,
+    )) as Awaited<ReturnType<typeof cleanupStalePendingCdcEvents>>;
+
     const staleEntities = (await step.run(
       "find-stale-entities",
       findStaleEntities,
@@ -1416,12 +1434,19 @@ export const cdcMaterializeSchedulerFunction = inngest.createFunction(
       totalTriggered = staleEntities.length;
     }
 
-    if (ingestResult.ingested > 0 || totalTriggered > 0) {
+    if (
+      ingestResult.ingested > 0 ||
+      totalTriggered > 0 ||
+      cleanupResult.droppedCdc > 0
+    ) {
       logger.info("CDC scheduler completed", {
         ingested: ingestResult.ingested,
         dropped: ingestResult.dropped,
         failed: ingestResult.failed,
         materializeTriggered: totalTriggered,
+        staleCdcDropped: cleanupResult.droppedCdc,
+        staleWebhooksDropped: cleanupResult.droppedWebhooks,
+        staleCursorsAdvanced: cleanupResult.cursorsAdvanced,
       });
     }
 
@@ -1430,6 +1455,7 @@ export const cdcMaterializeSchedulerFunction = inngest.createFunction(
       dropped: ingestResult.dropped,
       failed: ingestResult.failed,
       materializeTriggered: totalTriggered,
+      staleCdcDropped: cleanupResult.droppedCdc,
     };
   },
 );

--- a/api/src/migrations/2026-06-21-120000_webhookevents_status_receivedat_index.ts
+++ b/api/src/migrations/2026-06-21-120000_webhookevents_status_receivedat_index.ts
@@ -1,0 +1,63 @@
+import { Db } from "mongodb";
+import { loggers } from "../logging";
+
+const log = loggers.migration();
+
+const COLLECTION = "webhookevents";
+const INDEX_NAME = "status_1_receivedAt_1";
+
+type IndexInfo = {
+  name: string;
+  key?: Record<string, unknown>;
+};
+
+/**
+ * The CDC cron-ingest step (cdcMaterializeSchedulerFunction) runs a GLOBAL
+ *   WebhookEvent.find({ status: "pending" }).sort({ receivedAt: 1 }).limit(1000)
+ * every few minutes. The existing indexes are all prefixed by `flowId`
+ * ({ flowId, status, receivedAt }), so a query that does not constrain
+ * `flowId` cannot use them — it falls back to a COLLSCAN + in-memory sort
+ * over the entire webhookevents collection, which gets slower as the pending
+ * backlog grows and starves the single-concurrency scheduler.
+ *
+ * This adds the matching { status: 1, receivedAt: 1 } index so the ingest
+ * query is a bounded index scan.
+ */
+export const description =
+  "Add { status, receivedAt } index on webhookevents for the global CDC cron-ingest query";
+
+function hasIndexOnKeys(
+  indexes: IndexInfo[],
+  keyPattern: Record<string, number>,
+): boolean {
+  const target = JSON.stringify(keyPattern);
+  return indexes.some(idx => JSON.stringify(idx.key) === target);
+}
+
+export async function up(db: Db): Promise<void> {
+  const names = new Set(
+    (await db.listCollections().toArray()).map(c => c.name),
+  );
+  if (!names.has(COLLECTION)) {
+    log.info("webhookevents collection not found, skipping", {
+      collection: COLLECTION,
+    });
+    return;
+  }
+
+  const col = db.collection(COLLECTION);
+  const indexes = (await col.indexes()) as IndexInfo[];
+
+  if (hasIndexOnKeys(indexes, { status: 1, receivedAt: 1 })) {
+    log.info("status/receivedAt index already present, skipping", {
+      collection: COLLECTION,
+    });
+    return;
+  }
+
+  await col.createIndex({ status: 1, receivedAt: 1 }, { name: INDEX_NAME });
+  log.info("Created webhookevents status/receivedAt index", {
+    collection: COLLECTION,
+    name: INDEX_NAME,
+  });
+}

--- a/api/src/scripts/cdc-pending-diagnostic.ts
+++ b/api/src/scripts/cdc-pending-diagnostic.ts
@@ -213,6 +213,106 @@ async function main(): Promise<void> {
     );
   }
 
+  // ---- 5b. THE TRAP: pending rows at/below the consumer cursor ----------
+  // This is the decisive query. A pending CdcChangeEvent whose ingestSeq is
+  // <= its entity's lastMaterializedSeq is INVISIBLE to the (pre-fix) reader
+  // (readAfter gated on ingestSeq > cursor) AND, if lastIngestSeq == cursor,
+  // UNTRIGGERED by findStaleEntities ($gt). Those two together = stuck forever.
+  // If this count is large for your stuck entities, the cursor-drift trap is
+  // PROVEN regardless of which seed first advanced the cursor.
+  header("5b. Orphaned-below-cursor pending (THE trap) — top entities");
+  let totalOrphanedBelowCursor = 0;
+  let invisibleAndUntriggered = 0;
+  for (const r of cdcPendingByEntity) {
+    const flowId = r._id.flowId;
+    const entity = r._id.entity;
+    const st = await entityState.findOne(
+      { flowId, entity },
+      { projection: { lastMaterializedSeq: 1, lastIngestSeq: 1 } },
+    );
+    const cursor = Number(st?.lastMaterializedSeq || 0);
+    const ingest = Number(st?.lastIngestSeq || 0);
+    const belowCursor = await cdc.countDocuments({
+      flowId,
+      entity,
+      materializationStatus: "pending",
+      ingestSeq: { $lte: cursor },
+    });
+    if (belowCursor <= 0) continue;
+    totalOrphanedBelowCursor += belowCursor;
+    // Would the scheduler ever re-fire this entity? Only if lastIngestSeq > cursor.
+    const triggered = ingest > cursor;
+    if (!triggered) invisibleAndUntriggered += belowCursor;
+    // What produced the orphaned rows? webhook vs backfill discriminates the seed.
+    const bySource = await cdc
+      .aggregate([
+        {
+          $match: {
+            flowId,
+            entity,
+            materializationStatus: "pending",
+            ingestSeq: { $lte: cursor },
+          },
+        },
+        {
+          $group: {
+            _id: "$source",
+            n: { $sum: 1 },
+            oldest: { $min: "$ingestTs" },
+            newest: { $max: "$ingestTs" },
+          },
+        },
+      ])
+      .toArray();
+    const srcStr = bySource
+      .map(
+        s =>
+          `${s._id || "?"}=${s.n} (${fmtAge(s.oldest)}..${fmtAge(s.newest)})`,
+      )
+      .join(", ");
+    console.log(
+      `  flow ${String(flowId)} entity=${entity} ` +
+        `belowCursor=${belowCursor}/${r.n} cursor=${cursor} ingest=${ingest} ` +
+        `${triggered ? "(triggered)" : "INVISIBLE+UNTRIGGERED"}\n      src: ${srcStr}`,
+    );
+  }
+  console.log(
+    `  TOTAL orphaned-below-cursor pending (top ${TOP_N}) : ${totalOrphanedBelowCursor}`,
+  );
+  console.log(
+    `  of which invisible AND untriggered (truly stuck)  : ${invisibleAndUntriggered}`,
+  );
+
+  // ---- 5c. Seed discrimination: backfill timing vs orphaned rows --------
+  // If the orphaned pending rows are source="webhook" and their ingestTs sits
+  // inside/just-before a COMPLETED backfill window for the same flow, the most
+  // likely seed is backfill advancing lastMaterializedSeq past them (seed #2).
+  header("5c. Backfill timing for flows with pending CdcChangeEvents");
+  const flowIdsWithPending = Array.from(
+    new Set(cdcPendingByEntity.map(r => String(r._id.flowId))),
+  );
+  for (const fidStr of flowIdsWithPending.slice(0, TOP_N)) {
+    const f = await flows.findOne(
+      { _id: new mongoose.Types.ObjectId(fidStr) },
+      {
+        projection: {
+          name: 1,
+          streamState: 1,
+          backfillState: 1,
+          deleteMode: 1,
+        },
+      },
+    );
+    if (!f) continue;
+    const bf = (f as any).backfillState || {};
+    console.log(
+      `  flow ${fidStr} "${(f as any).name ?? ""}" stream=${
+        (f as any).streamState
+      } backfill.status=${bf.status ?? "n/a"} ` +
+        `started=${fmtAge(bf.startedAt)} completed=${fmtAge(bf.completedAt)}`,
+    );
+  }
+
   // ---- 6. Paused streams / incomplete backfills -------------------------
   header("6. Flow states blocking the consumer");
   const pausedStreams = await flows.countDocuments({
@@ -266,8 +366,10 @@ async function main(): Promise<void> {
   const pendingCdc = cdcByStatus.find(r => r._id === "pending")?.n || 0;
   console.log(`  pending WebhookEvents (ingest backlog) : ${pendingWh}`);
   console.log(`  pending CdcChangeEvents (mat. backlog) : ${pendingCdc}`);
+  console.log(`  >> orphaned-below-cursor pending       : ${totalOrphanedBelowCursor}  <-- the trap`);
+  console.log(`  >> invisible AND untriggered           : ${invisibleAndUntriggered}  <-- stuck forever`);
   console.log(`  circuit-breaker-stuck entities         : ${failing.length}`);
-  console.log(`  drifted cursors                        : ${driftedCursors.length}`);
+  console.log(`  drifted cursors (ingest<cursor)        : ${driftedCursors.length}`);
   console.log(`  paused streams / incomplete backfills  : ${pausedStreams} / ${incompleteBackfills}`);
   console.log("\nInterpretation:");
   console.log("  - Big & growing pending WebhookEvents -> ingest throughput-bound");

--- a/api/src/scripts/cdc-pending-diagnostic.ts
+++ b/api/src/scripts/cdc-pending-diagnostic.ts
@@ -1,0 +1,291 @@
+/* eslint-disable no-console */
+/**
+ * READ-ONLY diagnostic for "too many pending events in CDC flows".
+ *
+ * Why this exists
+ * ---------------
+ * CDC has two independent "pending" surfaces that pile up for different
+ * reasons (see api/src/inngest/functions/webhook-flow.ts):
+ *
+ *   1. WebhookEvent.status      = "pending"  -> raw webhook not yet INGESTED
+ *   2. CdcChangeEvent.materializationStatus = "pending" -> ingested, not yet
+ *                                                          MATERIALIZED
+ *
+ * This script reports the distribution across both surfaces, the top
+ * offending flows/entities, circuit-breaker-stuck entities, cursor drift,
+ * paused streams, incomplete backfills, and whether the index that the
+ * global cron-ingest query relies on actually exists.
+ *
+ * Safety
+ * ------
+ * - STRICTLY read-only: only count / find / aggregate / listIndexes are used.
+ * - Connects to DATABASE_URL. To point at prod, run with the prod URI
+ *   exported, e.g.:
+ *       DATABASE_URL="$PROD_DATABASE_URL" \
+ *         pnpm --filter api exec tsx src/scripts/cdc-pending-diagnostic.ts
+ *
+ * Usage
+ * -----
+ *   pnpm --filter api exec tsx src/scripts/cdc-pending-diagnostic.ts
+ */
+import path from "path";
+import fs from "fs";
+import dotenv from "dotenv";
+import mongoose from "mongoose";
+
+const envPath = path.resolve(__dirname, "../../../.env");
+if (fs.existsSync(envPath)) {
+  dotenv.config({ path: envPath });
+}
+
+const TOP_N = Number(process.env.CDC_DIAG_TOP_N || 20);
+
+function fmtAge(date: Date | null | undefined): string {
+  if (!date) return "n/a";
+  const ms = Date.now() - new Date(date).getTime();
+  const min = ms / 60000;
+  if (min < 60) return `${min.toFixed(1)}m`;
+  const hrs = min / 60;
+  if (hrs < 48) return `${hrs.toFixed(1)}h`;
+  return `${(hrs / 24).toFixed(1)}d`;
+}
+
+function header(title: string): void {
+  console.log("\n" + "=".repeat(72));
+  console.log(title);
+  console.log("=".repeat(72));
+}
+
+async function main(): Promise<void> {
+  const uri = process.env.DATABASE_URL;
+  if (!uri) {
+    console.error("No DATABASE_URL set. Aborting.");
+    process.exit(1);
+  }
+
+  let dbName = "(unknown)";
+  try {
+    dbName = new URL(uri).pathname.replace(/^\//, "").split("?")[0] || "(none)";
+  } catch {
+    /* non-standard uri */
+  }
+
+  console.log(`Connecting to db="${dbName}" (read-only diagnostic)...`);
+  await mongoose.connect(uri, {
+    maxPoolSize: 5,
+    serverSelectionTimeoutMS: 8000,
+  });
+  const db = mongoose.connection.db;
+  if (!db) throw new Error("No database handle after connect");
+
+  const webhooks = db.collection("webhookevents");
+  const cdc = db.collection("cdc_change_events");
+  const entityState = db.collection("cdc_entity_state");
+  const flows = db.collection("flows");
+
+  // ---- 1. WebhookEvent status distribution -----------------------------
+  header("1. WebhookEvent.status distribution (ingest backlog)");
+  const whByStatus = await webhooks
+    .aggregate([{ $group: { _id: "$status", n: { $sum: 1 } } }, { $sort: { n: -1 } }])
+    .toArray();
+  for (const r of whByStatus) console.log(`  ${String(r._id).padEnd(12)} ${r.n}`);
+
+  const oldestPending = await webhooks
+    .find({ status: "pending" })
+    .sort({ receivedAt: 1 })
+    .limit(1)
+    .project({ receivedAt: 1 })
+    .toArray();
+  if (oldestPending[0]) {
+    console.log(
+      `  oldest pending received: ${new Date(
+        oldestPending[0].receivedAt,
+      ).toISOString()} (age ${fmtAge(oldestPending[0].receivedAt)})`,
+    );
+  }
+
+  header("1b. Top flows by pending WebhookEvents");
+  const whPendingByFlow = await webhooks
+    .aggregate([
+      { $match: { status: "pending" } },
+      {
+        $group: {
+          _id: "$flowId",
+          n: { $sum: 1 },
+          oldest: { $min: "$receivedAt" },
+        },
+      },
+      { $sort: { n: -1 } },
+      { $limit: TOP_N },
+    ])
+    .toArray();
+  for (const r of whPendingByFlow) {
+    console.log(`  flow ${String(r._id)}  pending=${r.n}  oldest=${fmtAge(r.oldest)}`);
+  }
+
+  // ---- 2. Orphaned apply (completed ingest, apply never finalized) ------
+  header("2. WebhookEvents completed-but-apply-pending (orphaned apply)");
+  const orphanApply = await webhooks.countDocuments({
+    status: "completed",
+    applyStatus: "pending",
+  });
+  const orphanApplyStale = await webhooks.countDocuments({
+    status: "completed",
+    applyStatus: "pending",
+    receivedAt: { $lte: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000) },
+  });
+  console.log(`  status=completed & applyStatus=pending : ${orphanApply}`);
+  console.log(`    of which older than 7d (reapable)     : ${orphanApplyStale}`);
+
+  // ---- 3. CdcChangeEvent materialization distribution -------------------
+  header("3. CdcChangeEvent.materializationStatus distribution");
+  const cdcByStatus = await cdc
+    .aggregate([
+      { $group: { _id: "$materializationStatus", n: { $sum: 1 } } },
+      { $sort: { n: -1 } },
+    ])
+    .toArray();
+  for (const r of cdcByStatus) console.log(`  ${String(r._id).padEnd(12)} ${r.n}`);
+
+  header("3b. Top flow+entity by pending CdcChangeEvents");
+  const cdcPendingByEntity = await cdc
+    .aggregate([
+      { $match: { materializationStatus: "pending" } },
+      {
+        $group: {
+          _id: { flowId: "$flowId", entity: "$entity" },
+          n: { $sum: 1 },
+          oldest: { $min: "$ingestTs" },
+          minSeq: { $min: "$ingestSeq" },
+          maxSeq: { $max: "$ingestSeq" },
+        },
+      },
+      { $sort: { n: -1 } },
+      { $limit: TOP_N },
+    ])
+    .toArray();
+  for (const r of cdcPendingByEntity) {
+    console.log(
+      `  flow ${String(r._id.flowId)} entity=${r._id.entity} pending=${r.n} ` +
+        `seq=[${r.minSeq}..${r.maxSeq}] oldest=${fmtAge(r.oldest)}`,
+    );
+  }
+
+  // ---- 4. Circuit-breaker-stuck entities --------------------------------
+  header("4. Entities tripping the circuit breaker (consecutiveFailures > 0)");
+  const failing = await entityState
+    .find({ consecutiveFailures: { $gt: 0 } })
+    .project({
+      flowId: 1,
+      entity: 1,
+      consecutiveFailures: 1,
+      lastFailedAt: 1,
+      lastFailureError: 1,
+    })
+    .sort({ consecutiveFailures: -1 })
+    .limit(TOP_N)
+    .toArray();
+  if (failing.length === 0) console.log("  (none)");
+  for (const r of failing) {
+    console.log(
+      `  flow ${String(r.flowId)} entity=${r.entity} fails=${r.consecutiveFailures} ` +
+        `lastFailed=${fmtAge(r.lastFailedAt)}\n      err: ${String(
+          r.lastFailureError || "",
+        ).slice(0, 160)}`,
+    );
+  }
+
+  // ---- 5. Cursor drift --------------------------------------------------
+  header("5. Cursor state (lastIngestSeq vs lastMaterializedSeq)");
+  const staleCursors = await entityState.countDocuments({
+    $expr: { $gt: ["$lastIngestSeq", "$lastMaterializedSeq"] },
+  });
+  const driftedCursors = await entityState
+    .find({ $expr: { $lt: ["$lastIngestSeq", "$lastMaterializedSeq"] } })
+    .project({ flowId: 1, entity: 1, lastIngestSeq: 1, lastMaterializedSeq: 1 })
+    .limit(TOP_N)
+    .toArray();
+  console.log(`  entities behind (lastIngestSeq > lastMaterializedSeq): ${staleCursors}`);
+  console.log(`  entities with cursor AHEAD of ingest (drift): ${driftedCursors.length}`);
+  for (const r of driftedCursors) {
+    console.log(
+      `    flow ${String(r.flowId)} entity=${r.entity} ingestSeq=${r.lastIngestSeq} matSeq=${r.lastMaterializedSeq}`,
+    );
+  }
+
+  // ---- 6. Paused streams / incomplete backfills -------------------------
+  header("6. Flow states blocking the consumer");
+  const pausedStreams = await flows.countDocuments({
+    syncEngine: "cdc",
+    streamState: "paused",
+  });
+  const incompleteBackfills = await flows.countDocuments({
+    syncEngine: "cdc",
+    "backfillState.runId": { $exists: true, $ne: null },
+  });
+  console.log(`  CDC flows with streamState=paused      : ${pausedStreams}`);
+  console.log(`  CDC flows with incomplete backfill runId: ${incompleteBackfills}`);
+
+  // ---- 7. Index coverage check for the global cron-ingest query ---------
+  header("7. Index coverage for cron-ingest query find({status}).sort({receivedAt})");
+  const whIndexes = await webhooks.listIndexes().toArray();
+  const idxKeys = whIndexes.map(i => JSON.stringify(i.key));
+  const hasStatusReceivedAt = whIndexes.some(i => {
+    const k = i.key as Record<string, number>;
+    const keys = Object.keys(k);
+    return keys[0] === "status" && keys[1] === "receivedAt";
+  });
+  console.log(`  webhookevents indexes: ${idxKeys.join(", ")}`);
+  console.log(
+    hasStatusReceivedAt
+      ? "  OK: { status: 1, receivedAt: 1 } index present."
+      : "  MISSING: no { status, receivedAt } index -> the every-5-min global\n" +
+          "    ingest query does a COLLSCAN + in-memory sort over webhookevents.",
+  );
+
+  // ---- explain the global ingest query ---------------------------------
+  try {
+    const explain = await webhooks
+      .find({ status: "pending" })
+      .sort({ receivedAt: 1 })
+      .limit(1000)
+      .explain("queryPlanner");
+    const winning = JSON.stringify(
+      (explain as any)?.queryPlanner?.winningPlan || {},
+    );
+    const isCollScan = /COLLSCAN/.test(winning);
+    console.log(
+      `  winning plan: ${isCollScan ? "COLLSCAN (BAD)" : "IXSCAN (ok)"}`,
+    );
+  } catch (e) {
+    console.log(`  explain failed: ${(e as Error).message}`);
+  }
+
+  header("VERDICT");
+  const pendingWh = whByStatus.find(r => r._id === "pending")?.n || 0;
+  const pendingCdc = cdcByStatus.find(r => r._id === "pending")?.n || 0;
+  console.log(`  pending WebhookEvents (ingest backlog) : ${pendingWh}`);
+  console.log(`  pending CdcChangeEvents (mat. backlog) : ${pendingCdc}`);
+  console.log(`  circuit-breaker-stuck entities         : ${failing.length}`);
+  console.log(`  drifted cursors                        : ${driftedCursors.length}`);
+  console.log(`  paused streams / incomplete backfills  : ${pausedStreams} / ${incompleteBackfills}`);
+  console.log("\nInterpretation:");
+  console.log("  - Big & growing pending WebhookEvents -> ingest throughput-bound");
+  console.log("    (cron */5, concurrency 1, batch 1000) and/or missing index.");
+  console.log("  - Big pending CdcChangeEvents + failing entities -> real");
+  console.log("    materialization errors held off by the circuit breaker.");
+  console.log("  - Drifted cursors -> orphaned pending; needs reprocess/force-drain.");
+  console.log("  - Paused/backfilling flows -> consumer intentionally skips.");
+
+  await mongoose.disconnect();
+}
+
+main().catch(async err => {
+  console.error("Diagnostic failed:", err);
+  try {
+    await mongoose.disconnect();
+  } catch {
+    /* ignore */
+  }
+  process.exit(1);
+});

--- a/api/src/sync-cdc/backfill.ts
+++ b/api/src/sync-cdc/backfill.ts
@@ -16,7 +16,6 @@ import { loggers } from "../logging";
 import { databaseRegistry } from "../databases/registry";
 import { resolveConfiguredEntities } from "./entity-selection";
 import { hasCdcDestinationAdapter } from "./adapters/registry";
-import { BIGQUERY_WORKING_DATASET } from "../utils/bigquery-working-dataset";
 import { cdcLiveTableName, cdcStageTableName } from "./normalization";
 import { getCdcEventStore } from "./event-store";
 import { cdcSyncStateService } from "./sync-state";
@@ -696,15 +695,26 @@ export class CdcBackfillService {
 
     let materializeTriggered = 0;
     let cursorsRewound = 0;
-    try {
-      const byEntity = await getCdcEventStore().countEventsByEntity({
-        workspaceId: params.workspaceId,
-        flowId: params.flowId,
-        materializationStatus: "pending",
-      });
-      for (const item of byEntity) {
-        if (item.count <= 0) continue;
+    let pendingEntities = 0;
+    const drainErrors: string[] = [];
 
+    // Enumerate entities with pending events. If THIS fails we must surface it
+    // (the "Reprocess pending events" button previously swallowed every error
+    // here and returned success:true, so a broken drain looked like a no-op).
+    const byEntity = await getCdcEventStore().countEventsByEntity({
+      workspaceId: params.workspaceId,
+      flowId: params.flowId,
+      materializationStatus: "pending",
+    });
+
+    for (const item of byEntity) {
+      if (item.count <= 0) continue;
+      pendingEntities++;
+
+      try {
+        // Rewind the consumer cursor just below the oldest pending event so the
+        // scheduler's findStaleEntities re-flags this entity (lastIngestSeq >
+        // lastMaterializedSeq) and a forced materialize actually reads it.
         const minPending = await CdcChangeEvent.findOne({
           flowId: new Types.ObjectId(params.flowId),
           entity: item.entity,
@@ -747,12 +757,26 @@ export class CdcBackfillService {
           },
         });
         materializeTriggered++;
+      } catch (error) {
+        // One bad entity must not abort the rest of the drain.
+        const message = error instanceof Error ? error.message : String(error);
+        drainErrors.push(`${item.entity}: ${message}`);
+        log.warn("Failed to force-drain CDC entity during reprocess-stale", {
+          flowId: params.flowId,
+          entity: item.entity,
+          error: message,
+        });
       }
-    } catch (error) {
-      log.warn("Failed to force-drain CDC during reprocess-stale", {
-        flowId: params.flowId,
-        error: error instanceof Error ? error.message : String(error),
-      });
+    }
+
+    // If there was pending work but we couldn't trigger a single materialize,
+    // the operation genuinely failed — surface it so the UI doesn't lie.
+    if (pendingEntities > 0 && materializeTriggered === 0) {
+      throw new Error(
+        `Failed to trigger materialization for any of ${pendingEntities} pending entities: ${
+          drainErrors[0] ?? "unknown error"
+        }`,
+      );
     }
 
     const orphanedResolved = await this.resolveOrphanedWebhookApplyStatus(
@@ -765,18 +789,22 @@ export class CdcBackfillService {
       reconciledWebhooks,
       drainedWebhooks,
       resetFailedWebhooks,
+      pendingEntities,
       materializeTriggered,
       cursorsRewound,
       orphanedResolved,
+      drainErrors: drainErrors.length,
     });
 
     return {
       reconciledWebhooks,
       drainedWebhooks,
       resetFailedWebhooks,
+      pendingEntities,
       materializeTriggered,
       cursorsRewound,
       orphanedResolved,
+      drainErrors,
     };
   }
 
@@ -1286,8 +1314,7 @@ export class CdcBackfillService {
       );
       const tablePrefix = flow.tableDestination.tableName || "";
       const schema = flow.tableDestination.schema;
-      const stageSchema =
-        destination.type === "bigquery" ? BIGQUERY_WORKING_DATASET : schema;
+      const stageSchema = driver.getStagingSchema?.(schema) ?? schema;
       const flowToken = flowId.replace(/[^a-zA-Z0-9]/g, "").slice(-8);
       let dropped = 0;
 
@@ -1434,8 +1461,7 @@ export class CdcBackfillService {
     const enabledEntities = resolveConfiguredEntities(flow).entities;
     const tablePrefix = flow.tableDestination.tableName || "";
     const schema = flow.tableDestination.schema;
-    const stageSchema =
-      destination.type === "bigquery" ? BIGQUERY_WORKING_DATASET : schema;
+    const stageSchema = driver.getStagingSchema?.(schema) ?? schema;
     const flowId = flow._id.toString();
 
     const flowToken = flowId.replace(/[^a-zA-Z0-9]/g, "").slice(-8);
@@ -1524,10 +1550,9 @@ export async function purgeSoftDeletesAfterBackfill(params: {
 
   for (const entity of enabledEntities) {
     const tableName = cdcLiveTableName(tablePrefix, entity);
-    const fullTable =
-      destination.type === "bigquery"
-        ? `\`${schema}\`.${tableName}`
-        : `"${schema}"."${tableName}"`;
+    const fullTable = driver.formatTableRef
+      ? driver.formatTableRef(schema, tableName)
+      : `"${schema}"."${tableName}"`;
     const query = `DELETE FROM ${fullTable} WHERE is_deleted = true`;
     try {
       await driver.executeQuery(destination, query);

--- a/api/src/sync-cdc/backfill.ts
+++ b/api/src/sync-cdc/backfill.ts
@@ -16,6 +16,7 @@ import { loggers } from "../logging";
 import { databaseRegistry } from "../databases/registry";
 import { resolveConfiguredEntities } from "./entity-selection";
 import { hasCdcDestinationAdapter } from "./adapters/registry";
+import { BIGQUERY_WORKING_DATASET } from "../utils/bigquery-working-dataset";
 import { cdcLiveTableName, cdcStageTableName } from "./normalization";
 import { getCdcEventStore } from "./event-store";
 import { cdcSyncStateService } from "./sync-state";
@@ -1314,7 +1315,8 @@ export class CdcBackfillService {
       );
       const tablePrefix = flow.tableDestination.tableName || "";
       const schema = flow.tableDestination.schema;
-      const stageSchema = driver.getStagingSchema?.(schema) ?? schema;
+      const stageSchema =
+        destination.type === "bigquery" ? BIGQUERY_WORKING_DATASET : schema;
       const flowToken = flowId.replace(/[^a-zA-Z0-9]/g, "").slice(-8);
       let dropped = 0;
 
@@ -1461,7 +1463,8 @@ export class CdcBackfillService {
     const enabledEntities = resolveConfiguredEntities(flow).entities;
     const tablePrefix = flow.tableDestination.tableName || "";
     const schema = flow.tableDestination.schema;
-    const stageSchema = driver.getStagingSchema?.(schema) ?? schema;
+    const stageSchema =
+      destination.type === "bigquery" ? BIGQUERY_WORKING_DATASET : schema;
     const flowId = flow._id.toString();
 
     const flowToken = flowId.replace(/[^a-zA-Z0-9]/g, "").slice(-8);
@@ -1550,9 +1553,10 @@ export async function purgeSoftDeletesAfterBackfill(params: {
 
   for (const entity of enabledEntities) {
     const tableName = cdcLiveTableName(tablePrefix, entity);
-    const fullTable = driver.formatTableRef
-      ? driver.formatTableRef(schema, tableName)
-      : `"${schema}"."${tableName}"`;
+    const fullTable =
+      destination.type === "bigquery"
+        ? `\`${schema}\`.${tableName}`
+        : `"${schema}"."${tableName}"`;
     const query = `DELETE FROM ${fullTable} WHERE is_deleted = true`;
     try {
       await driver.executeQuery(destination, query);

--- a/api/src/sync-cdc/consumer.ts
+++ b/api/src/sync-cdc/consumer.ts
@@ -1,5 +1,6 @@
 import { Types } from "mongoose";
 import {
+  CdcChangeEvent,
   CdcEntityState,
   DatabaseConnection,
   Flow,
@@ -129,14 +130,28 @@ export class CdcConsumerService {
       // have already been applied/failed/dropped by a previous run.
       const currentIngestSeq = Number(state?.lastIngestSeq || 0);
       if (currentIngestSeq > afterIngestSeq) {
-        await cdcSyncStateService.advanceConsumerCursor({
-          workspaceId: params.workspaceId,
-          flowId: params.flowId,
+        // Drift-seed guard: `readAfter` already selects ALL pending rows for
+        // this entity, so an empty result *should* mean nothing is pending.
+        // Confirm with a direct count before jumping the cursor forward — if a
+        // pending row exists (e.g. a backfill or concurrent ingest raced ahead
+        // of this read), advancing would orphan it below lastMaterializedSeq
+        // and findStaleEntities would stop re-triggering it. Never advance the
+        // cursor past a still-pending event.
+        const stillPending = await CdcChangeEvent.countDocuments({
+          flowId: new Types.ObjectId(params.flowId),
           entity: params.entity,
-          lastIngestSeq: currentIngestSeq,
-          processedEventsDelta: 0,
-          rowsAppliedDelta: 0,
+          materializationStatus: "pending",
         });
+        if (stillPending === 0) {
+          await cdcSyncStateService.advanceConsumerCursor({
+            workspaceId: params.workspaceId,
+            flowId: params.flowId,
+            entity: params.entity,
+            lastIngestSeq: currentIngestSeq,
+            processedEventsDelta: 0,
+            rowsAppliedDelta: 0,
+          });
+        }
       }
       return {
         processed: 0,

--- a/api/src/sync-cdc/event-store.ts
+++ b/api/src/sync-cdc/event-store.ts
@@ -291,11 +291,22 @@ class MongoCdcEventStore implements CdcEventStore {
     afterIngestSeq: number;
     limit: number;
   }): Promise<CdcStoredEvent[]> {
+    // Authoritative selection is `materializationStatus: "pending"` ONLY —
+    // we intentionally do NOT gate on `ingestSeq > lastMaterializedSeq`.
+    //
+    // Gating on the cursor caused permanent "cursor drift": if the consumer
+    // cursor (lastMaterializedSeq) ever advanced past a still-pending event
+    // (e.g. the pending.length===0 branch jumping the cursor to lastIngestSeq
+    // under an Atlas primary/secondary read race), those pending rows became
+    // invisible forever — readAfter skipped them (ingestSeq <= cursor) and the
+    // scheduler's findStaleEntities no longer flagged the entity. Reading the
+    // OLDEST pending rows regardless of cursor makes the backlog self-draining
+    // and is safe: applied/dropped/failed rows already leave the pending set,
+    // and destination writes are idempotent upserts.
     const rows = await CdcChangeEvent.find({
       flowId: new Types.ObjectId(params.flowId),
       entity: params.entity,
       materializationStatus: "pending",
-      ingestSeq: { $gt: Math.max(params.afterIngestSeq, 0) },
     })
       .sort({ ingestSeq: 1 })
       .limit(Math.max(params.limit, 1))


### PR DESCRIPTION
## Summary

CDC flows (`ch_close_crm`, `fr_close`, `ch_close_sellers`, …) accumulated tens of thousands of **permanently-stuck `materializationStatus: "pending"` events** that never drained, and the **"Reprocess pending events"** button did nothing. This PR makes the pipeline self-healing both automatically (every cron cycle) and manually (the button).

### Root causes & fixes

- **Cursor drift (primary cause).** `event-store.readAfter` gated selection on `ingestSeq > lastMaterializedSeq`. When the consumer cursor advanced past still-pending rows (a backfill or concurrent ingest racing ahead), those rows became invisible to the materializer **forever** — `readAfter` skipped them and `findStaleEntities` stopped flagging the entity. `readAfter` now selects the **oldest `pending` rows regardless of cursor**, so any orphaned backlog self-drains. Safe because destination writes are idempotent upserts and applied/dropped/failed rows already leave the pending set.

- **Drift-seed guard (`consumer.ts`).** The `pending.length === 0` branch no longer jumps the cursor to `lastIngestSeq` without first confirming (`countDocuments`) there are genuinely zero pending rows for the entity — so it can never re-orphan a row.

- **Dead "Reprocess pending events" button (`backfill.ts`).** `reprocessStaleEvents` wrapped the whole force-drain in one swallowed `try/catch` and still returned `success: true`, so a failed drain looked like a no-op. It now drains each entity independently, collects per-entity errors, and **throws if zero materializations fired while pending work existed**. Return payload exposes `pendingEntities` + `drainErrors`.

- **Missing index.** Added `WebhookEvent { status, receivedAt }` (+ migration). The global cron-ingest query `find({ status: "pending" }).sort({ receivedAt: 1 })` previously did a COLLSCAN + in-memory sort over the whole collection.

- **Stale cleanup wiring + throughput.** The cron scheduler now runs `cleanupStalePendingCdcEvents` every cycle (reaps `pending` CDC events whose webhook completed >7d ago — there is no TTL on `pending`). `CDC_INGEST_BATCH_LIMIT` is now env-configurable (default `2000`).

- **Ops tooling.** Adds a read-only `cdc-pending-diagnostic` script for triaging backlog, circuit-breaker state, cursor drift, and index coverage.

## Test plan

- [ ] Run migration `2026-06-21-120000_webhookevents_status_receivedat_index` (`pnpm migrate`); confirm `{status, receivedAt}` index exists.
- [ ] On a drifted flow, confirm the cron cycle now drains the orphaned `pending` backlog to zero.
- [ ] Click **Reprocess pending events** on a flow with pending work — confirm forced materializes fire and that a forced failure now surfaces an error instead of silent success.
- [ ] Verify the `pending.length===0` guard does not advance the cursor while pending rows exist.
- [ ] Confirm `cleanup-stale-pending-cdc` step runs in the scheduler and reports `staleCdcDropped`.

## Notes

- Branched off `master` in an isolated worktree; unrelated WIP in the working tree was intentionally excluded.
- Depends only on `cleanupStalePendingCdcEvents` from #388, which is already on `master`.

Made with [Cursor](https://cursor.com)