### PR TITLE
fix(webhooks): surface missing signing secret on provision

### DIFF
--- a/api/src/routes/flows.ts
+++ b/api/src/routes/flows.ts
@@ -2671,6 +2671,29 @@ flowRoutes.openapi(
       }
       await flow.save();
 
+      if (!created.signingSecret) {
+        // Some providers create the endpoint but omit the signing secret from
+        // the API response (e.g. Stripe restricted keys, rk_…). Without it the
+        // flow can't verify incoming webhooks, so surface an actionable error
+        // instead of reporting a misleading success. The endpoint URL is still
+        // persisted above so the user can find/reuse it.
+        return c.json(
+          {
+            success: false,
+            error:
+              `The ${connectorSource.type} webhook endpoint` +
+              (created.providerWebhookId
+                ? ` (${created.providerWebhookId})`
+                : "") +
+              " was created, but the provider did not return a signing secret. " +
+              "This typically happens with restricted API keys. Reveal the " +
+              "signing secret in your provider's dashboard and paste it into the " +
+              "Webhook Secret field, or use a full-access API key and re-provision.",
+          },
+          400,
+        );
+      }
+
       return c.json({
         success: true,
         data: {


### PR DESCRIPTION
## Summary

Webhook provisioning could silently half-succeed. With a Stripe **restricted API key** (`rk_…`), `stripe.webhookEndpoints.create()` succeeds and returns the endpoint, but **omits the signing secret** from the response. The provision route saved the endpoint with an empty secret and returned `success: true`, so the UI showed a configured webhook URL with **no error** — yet the flow could never verify incoming webhooks (this is why `ch_stripe` worked but `fr_stripe` didn't).

This makes the failure explicit: when the provider creates the endpoint but returns no signing secret, the route now responds `400` with an actionable message. The endpoint URL is still persisted (it really was created), so the user can find/reuse it.

## Changes

- `api/src/routes/flows.ts` — in `POST /:flowId/webhook/provision`, after saving the endpoint, return a `400` with a clear message when `created.signingSecret` is missing (instead of reporting success with an empty secret).

## Behavior

- **Full-access key** (`sk_…`): unchanged — secret returned, saved, `success: true`.
- **Restricted key / secret omitted**: endpoint persisted, response `400` with guidance to reveal the secret in the provider dashboard and paste it into **Webhook Secret**, or use a full-access key and re-provision. The created endpoint id is included in the message for cleanup.

## Test plan

- [ ] Provision a Stripe webhook with a restricted key (`rk_…`) → UI shows the actionable error (no silent success).
- [ ] Provision with a full secret key (`sk_…`) → succeeds and the signing secret is stored.
- [ ] Manually paste the secret into Webhook Secret after a restricted-key attempt → flow verifies webhooks.

Made with [Cursor](https://cursor.com)