### PR TITLE
feat(dbt): agent git tools, live git-status refresh, and AI commit messages

### DIFF
--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -36,6 +36,15 @@ import {
   parseDbtCommands,
 } from "../../dbt/commands";
 import {
+  commitAndPush,
+  createProjectBranch,
+  getGitStatus,
+  listProjectBranches,
+  openProjectPullRequest,
+  switchProjectBranch,
+} from "../../dbt/dbt-github-git.service";
+import { generateDbtCommitMessage } from "../../dbt/dbt-commit-message.service";
+import {
   DBT_COMPATIBLE_CONNECTION_TYPES,
   isDbtCompatibleConnectionType,
 } from "../../dbt/adapter-map";
@@ -99,7 +108,7 @@ function summarizeLogs(logs: DbtLogLine[], maxLines = 30): string[] {
   return selected.map(log => `[${log.level}] ${log.line}`);
 }
 
-export const createDbtServerTools = (workspaceId: string) => {
+export const createDbtServerTools = (workspaceId: string, userId?: string) => {
   const assertProject = async (projectId: string) => {
     if (!Types.ObjectId.isValid(projectId)) {
       throw new Error("Invalid dbt project id");
@@ -109,6 +118,18 @@ export const createDbtServerTools = (workspaceId: string) => {
       workspaceId: new Types.ObjectId(workspaceId),
     });
     if (!project) throw new Error("dbt project not found or access denied");
+    return project;
+  };
+
+  /** Like assertProject, but also requires a connected Git repository. */
+  const assertRepoProject = async (projectId: string) => {
+    const project = await assertProject(projectId);
+    if (!project.repo) {
+      throw new Error(
+        "This dbt project is not connected to a Git repository. Connect a " +
+          "repo in project settings before using git tools.",
+      );
+    }
     return project;
   };
 
@@ -762,6 +783,216 @@ export const createDbtServerTools = (workspaceId: string) => {
           };
         } catch (error) {
           return toolError(error, "Failed to update dbt job");
+        }
+      },
+    }),
+
+    dbt_git_status: tool({
+      description:
+        "Show the working-tree git status of a repo-bound dbt project: which " +
+        "files are added/modified/deleted relative to the tracked branch, " +
+        "and the branch name. Call this before dbt_commit_and_push to confirm " +
+        "what will be committed, and to summarize pending changes for the user.",
+      inputSchema: z.object({ projectId: projectIdField }),
+      execute: async ({ projectId }) => {
+        try {
+          const project = await assertRepoProject(projectId);
+          const status = await getGitStatus(project);
+          return {
+            success: true,
+            branch: status.branch,
+            hasChanges: status.hasChanges,
+            added: status.added,
+            modified: status.modified,
+            deleted: status.deleted,
+            changes: status.changes,
+          };
+        } catch (error) {
+          return toolError(error, "Failed to read git status");
+        }
+      },
+    }),
+
+    dbt_commit_and_push: tool({
+      description:
+        "Commit ALL working-tree changes and push them to the project's " +
+        "currently tracked branch in a single commit — the same action as the " +
+        "IDE 'Commit & push' button. ONLY call this after the user has " +
+        "explicitly asked you to commit/push (or clearly confirmed it in the " +
+        "conversation); never commit proactively. If you omit `message`, a " +
+        "Conventional Commits message is generated automatically from the " +
+        "diff. Returns the new commit sha and per-type counts. To put changes " +
+        "on a separate branch, call dbt_create_branch first, or use " +
+        "dbt_open_pull_request when the user wants a review.",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        message: z
+          .string()
+          .min(1)
+          .max(500)
+          .optional()
+          .describe("Commit message. Omit to auto-generate one from the diff."),
+      }),
+      execute: async ({ projectId, message }) => {
+        try {
+          const project = await assertRepoProject(projectId);
+          const status = await getGitStatus(project);
+          if (!status.hasChanges) {
+            return {
+              success: false,
+              error: "No changes to commit",
+              branch: status.branch,
+            };
+          }
+
+          let commitMessage = message?.trim();
+          let generated = false;
+          if (!commitMessage) {
+            const ai = await generateDbtCommitMessage(project, {
+              workspaceId,
+              userId: userId ?? "agent",
+            });
+            if (ai) {
+              commitMessage = ai;
+              generated = true;
+            }
+          }
+          if (!commitMessage) {
+            return {
+              success: false,
+              error:
+                "Could not generate a commit message — provide `message` " +
+                "explicitly and retry.",
+            };
+          }
+
+          const result = await commitAndPush(project, {
+            message: commitMessage,
+            updatedBy: userId ?? "agent",
+          });
+          return {
+            success: result.committed,
+            sha: result.sha,
+            branch: result.branch,
+            message: commitMessage,
+            messageGenerated: generated,
+            pushed: result.pushed,
+          };
+        } catch (error) {
+          return toolError(error, "Failed to commit and push");
+        }
+      },
+    }),
+
+    dbt_create_branch: tool({
+      description:
+        "Create a new branch off the project's current branch head and check " +
+        "it out (track it). Use before dbt_commit_and_push when the user " +
+        "wants changes isolated on a feature branch. Branch content is " +
+        "identical to the current branch — no re-sync needed.",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        name: z
+          .string()
+          .min(1)
+          .max(255)
+          .describe("New branch name, e.g. 'feat/add-orders-staging'"),
+      }),
+      execute: async ({ projectId, name }) => {
+        try {
+          const project = await assertRepoProject(projectId);
+          const result = await createProjectBranch(project, name.trim());
+          return { success: true, branch: result.branch };
+        } catch (error) {
+          return toolError(error, "Failed to create branch");
+        }
+      },
+    }),
+
+    dbt_switch_branch: tool({
+      description:
+        "Switch the project's tracked branch and pull its contents into the " +
+        "working tree. This OVERWRITES local working-tree files with the " +
+        "target branch — only call when the user confirms, and after any " +
+        "pending changes are committed (check dbt_git_status first).",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        branch: z.string().min(1).max(255).describe("Existing branch to track"),
+      }),
+      execute: async ({ projectId, branch }) => {
+        try {
+          const project = await assertRepoProject(projectId);
+          const result = await switchProjectBranch(
+            project,
+            branch.trim(),
+            userId ?? "agent",
+          );
+          return { success: true, branch: result.branch };
+        } catch (error) {
+          return toolError(error, "Failed to switch branch");
+        }
+      },
+    }),
+
+    dbt_list_branches: tool({
+      description:
+        "List the remote branches of the project's connected repository, plus " +
+        "the currently tracked branch. Use to pick a branch for " +
+        "dbt_switch_branch or a base for dbt_open_pull_request.",
+      inputSchema: z.object({ projectId: projectIdField }),
+      execute: async ({ projectId }) => {
+        try {
+          const project = await assertRepoProject(projectId);
+          const branches = await listProjectBranches(project);
+          return {
+            success: true,
+            branches,
+            current: project.repo?.branch,
+          };
+        } catch (error) {
+          return toolError(error, "Failed to list branches");
+        }
+      },
+    }),
+
+    dbt_open_pull_request: tool({
+      description:
+        "Open a GitHub pull request from the project's current branch into a " +
+        "base branch (defaults to the repo's default branch). Use this when " +
+        "the user wants their changes reviewed rather than pushed straight to " +
+        "the main branch. The current branch must differ from the base — " +
+        "create a feature branch with dbt_create_branch and commit to it " +
+        "first. Returns the PR number and URL.",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        title: z.string().min(1).max(255).describe("Pull request title"),
+        body: z
+          .string()
+          .max(10_000)
+          .optional()
+          .describe("Pull request description (Markdown)"),
+        base: z
+          .string()
+          .min(1)
+          .max(255)
+          .optional()
+          .describe("Base branch to merge into; defaults to the repo default"),
+      }),
+      execute: async ({ projectId, title, body, base }) => {
+        try {
+          const project = await assertRepoProject(projectId);
+          const result = await openProjectPullRequest(project, {
+            title: title.trim(),
+            body,
+            base,
+          });
+          return {
+            success: true,
+            number: result.number,
+            url: result.htmlUrl,
+          };
+        } catch (error) {
+          return toolError(error, "Failed to open pull request");
         }
       },
     }),

--- a/api/src/agents/dbt/index.ts
+++ b/api/src/agents/dbt/index.ts
@@ -73,7 +73,7 @@ export const dbtAgentFactory: AgentFactory = (
     context.toolExecutionContext,
     { chatId: context.chatId },
   );
-  const dbtServerTools = createDbtServerTools(workspaceId);
+  const dbtServerTools = createDbtServerTools(workspaceId, userId);
   const skillTools = createSkillTools(workspaceId, userId);
 
   return {

--- a/api/src/agents/dbt/prompt.ts
+++ b/api/src/agents/dbt/prompt.ts
@@ -24,8 +24,18 @@ runs execute against the project's warehouse environments (dev/prod).
    test results.
 5. **Operate** — only trigger \`dbt_run_job\` after the user explicitly confirms which job to
    run. Never run prod jobs proactively.
+6. **Ship (git)** — for repo-bound projects, your file edits land in the working tree but are
+   NOT pushed automatically. Only commit after the user explicitly asks. Then call
+   \`dbt_git_status\` to confirm what changed, and \`dbt_commit_and_push\` (omit \`message\` to
+   auto-generate one) to push to the tracked branch. Use \`dbt_create_branch\` first when the
+   user wants an isolated branch, and \`dbt_open_pull_request\` when they want review instead of
+   a direct push.
 
 ## Rules
+
+- Never commit or push proactively — file edits stay in the working tree until the user asks
+  you to commit. Prefer pushing to the tracked branch (mirrors the IDE button); only branch or
+  open a PR when the user asks for it.
 
 - Load the \`dbt\` system skill for materializations, incremental strategies, snapshots, and
   adapter quirks before writing non-trivial models.

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -153,6 +153,12 @@ only when the user asks for a recurring run). Trigger a saved job with \`dbt_run
 a job (possibly prod) without the user explicitly confirming it. \`dbt_run_job\` only QUEUES the
 run; always follow up with \`dbt_get_run\` to report whether it actually passed or failed.
 
+Git (repo-bound projects): your edits land in the working tree but are NOT pushed automatically.
+Only commit when the user asks. Check \`dbt_git_status\`, then \`dbt_commit_and_push\` (omit
+\`message\` to auto-generate one) to push to the tracked branch — same as the IDE button. Use
+\`dbt_create_branch\` first for an isolated branch, and \`dbt_open_pull_request\` only when the user
+wants review instead of a direct push. Never commit, push, switch branches, or open a PR proactively.
+
 For conventions (staging/marts layout, ref()/source(), materializations, incremental models,
 snapshots, schema.yml tests), load the \`dbt\` system skill.`;
 

--- a/api/src/agents/modes/registry.ts
+++ b/api/src/agents/modes/registry.ts
@@ -171,6 +171,13 @@ const TRANSFORM_MODE_TOOL_NAMES: string[] = [
   "dbt_show",
   "dbt_create_job",
   "dbt_update_job",
+  // Git: commit/push edits to the connected repo (only when the user asks).
+  "dbt_git_status",
+  "dbt_commit_and_push",
+  "dbt_create_branch",
+  "dbt_switch_branch",
+  "dbt_list_branches",
+  "dbt_open_pull_request",
   // Discovery: inspect sources before writing staging models; preview built
   // tables after dbt_run_model.
   "list_connections",

--- a/api/src/agents/unified/index.ts
+++ b/api/src/agents/unified/index.ts
@@ -46,7 +46,7 @@ export function unifiedAgentFactory(context: AgentContext): AgentConfig {
     context.toolExecutionContext,
   );
   const versionHistoryTools = createVersionHistoryTools(workspaceId);
-  const dbtServerTools = createDbtServerTools(workspaceId);
+  const dbtServerTools = createDbtServerTools(workspaceId, userId);
 
   const {
     list_connections: _flowListConnections,

--- a/api/src/dbt/dbt-commit-message.service.ts
+++ b/api/src/dbt/dbt-commit-message.service.ts
@@ -1,0 +1,222 @@
+/**
+ * AI commit-message generation for repo-bound dbt projects.
+ *
+ * Builds a compact, bounded unified diff of the working tree (reusing the same
+ * status/diff computation as the in-IDE git surface) and asks the cheapest
+ * utility model — with gateway failover — to write a conventional-commit
+ * message. Mirrors the `version-comment.service.ts` pattern.
+ */
+import { generateText } from "ai";
+import { propagateAttributes } from "@langfuse/tracing";
+import { createTwoFilesPatch } from "diff";
+import { getModel, buildProviderOptions } from "../agent-lib/ai-gateway";
+import { getUtilityModelId } from "../agent-lib/ai-models";
+import { getUtilityModelIds } from "../services/model-catalog.service";
+import type { GatewayLanguageModelOptions } from "@ai-sdk/gateway";
+import { trackUsage } from "../services/llm-usage.service";
+import { loggers } from "../logging";
+import { extractTokenCounts } from "../utils/safe-num";
+import type { IDbtProject } from "../database/workspace-schema";
+import { getGitStatus, getProjectFileDiff } from "./dbt-github-git.service";
+
+const logger = loggers.app();
+
+// Bounds to keep the prompt cheap and the GitHub blob fan-out reasonable.
+const MAX_FILES = 40;
+const MAX_FILE_CONTENT_CHARS = 20_000;
+const MAX_PATCH_CHARS_PER_FILE = 3_000;
+const MAX_PROMPT_CHARS = 12_000;
+const MAX_MESSAGE_CHARS = 500;
+
+const COMMIT_MESSAGE_SYSTEM_PROMPT = `You are an expert dbt analytics engineer writing a git commit message for changes to a dbt project (SQL models, YAML schema/config, macros, seeds, docs).
+
+I will send you a unified diff covering one or more changed files. Convert it into a clean, specific Conventional Commits message.
+
+Format:
+- First line: "<type>: <summary>" where <type> is one of feat, fix, refactor, chore, docs, test, perf, style. Max 72 characters. Imperative mood (e.g. "add", "fix", "refactor"), no trailing period.
+- If more than one file changed or the change is non-trivial, add a blank line then 1-4 short "- " bullet points describing the key changes.
+
+Rules:
+- Be specific: reference model/macro names, column names, materializations, tests, filters, joins — not file paths or line numbers.
+- Pick the type from the dominant intent: new model/test/column => feat, bug fix => fix, restructuring without behavior change => refactor, docs/yml descriptions => docs, config/version bumps => chore.
+- Do NOT wrap the message in quotes or backticks.
+- Do NOT invent changes that are not in the diff.
+- Respond with ONLY the commit message, nothing else.`;
+
+export interface CommitMessageTrackingContext {
+  workspaceId: string;
+  userId: string;
+  /** User email, used as the Langfuse user identifier when present. */
+  userEmail?: string;
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max)}\n…(truncated)…` : value;
+}
+
+/** Strip the file-header lines from a unified patch, keeping the hunks. */
+function patchBody(patch: string): string {
+  const lines = patch.split("\n");
+  const start = lines.findIndex(l => l.startsWith("@@"));
+  if (start === -1) return "";
+  return lines.slice(start).join("\n");
+}
+
+/**
+ * Assemble a bounded, multi-file unified diff for the project's working tree.
+ * Returns null when there is nothing meaningful to summarize.
+ */
+async function buildWorkingTreeDiff(project: IDbtProject): Promise<{
+  diff: string;
+  fileCount: number;
+} | null> {
+  const status = await getGitStatus(project);
+  if (!status.hasChanges) return null;
+
+  const changes = status.changes.slice(0, MAX_FILES);
+  const omitted = status.changes.length - changes.length;
+
+  const sections = await Promise.all(
+    changes.map(async change => {
+      try {
+        const { base, working } = await getProjectFileDiff(
+          project,
+          change.path,
+        );
+        const patch = createTwoFilesPatch(
+          change.path,
+          change.path,
+          truncate(base, MAX_FILE_CONTENT_CHARS),
+          truncate(working, MAX_FILE_CONTENT_CHARS),
+          "",
+          "",
+          { context: 3 },
+        );
+        const body = truncate(patchBody(patch), MAX_PATCH_CHARS_PER_FILE);
+        if (!body.trim()) return null;
+        return `### ${change.status.toUpperCase()} ${change.path}\n${body}`;
+      } catch (error) {
+        logger.warn("Failed to diff dbt file for commit message", {
+          path: change.path,
+          error,
+        });
+        return `### ${change.status.toUpperCase()} ${change.path}`;
+      }
+    }),
+  );
+
+  const parts = sections.filter((s): s is string => s !== null);
+  if (parts.length === 0) return null;
+
+  let diff = parts.join("\n\n");
+  if (diff.length > MAX_PROMPT_CHARS) {
+    diff = `${diff.slice(0, MAX_PROMPT_CHARS)}\n…(diff truncated)…`;
+  }
+  if (omitted > 0) {
+    diff += `\n\n(${omitted} more changed file${omitted === 1 ? "" : "s"} omitted)`;
+  }
+
+  return { diff, fileCount: status.changes.length };
+}
+
+/**
+ * Generate a Conventional Commits message from a repo-bound dbt project's
+ * working-tree changes. Returns null when there are no changes or generation
+ * fails (callers should fall back to a manual message).
+ */
+export async function generateDbtCommitMessage(
+  project: IDbtProject,
+  trackingCtx?: CommitMessageTrackingContext,
+): Promise<string | null> {
+  try {
+    const built = await buildWorkingTreeDiff(project);
+    if (!built) return null;
+
+    const utilityModel = await getUtilityModelId();
+    if (!utilityModel) {
+      logger.warn("No AI provider configured, skipping commit message");
+      return null;
+    }
+    const failoverModels = await getUtilityModelIds(3);
+
+    const baseOpts = trackingCtx
+      ? buildProviderOptions({
+          userId: trackingCtx.userId,
+          workspaceId: trackingCtx.workspaceId,
+          invocationType: "commit_message",
+        })
+      : {};
+    const gatewayBase = (baseOpts.gateway ?? {}) as Record<string, unknown>;
+
+    const prompt = `${built.fileCount} changed file${
+      built.fileCount === 1 ? "" : "s"
+    }:\n\n${built.diff}`;
+
+    const { text, usage, response } = await propagateAttributes(
+      {
+        traceName: "dbt-commit-message",
+        userId: trackingCtx?.userEmail ?? trackingCtx?.userId,
+        tags: ["type:commit_message"],
+        metadata: trackingCtx
+          ? { workspaceId: trackingCtx.workspaceId }
+          : undefined,
+      },
+      () =>
+        generateText({
+          model: getModel(utilityModel),
+          system: COMMIT_MESSAGE_SYSTEM_PROMPT,
+          prompt,
+          providerOptions: {
+            gateway: {
+              ...gatewayBase,
+              models: [
+                utilityModel,
+                ...failoverModels.filter(id => id !== utilityModel),
+              ],
+            } satisfies GatewayLanguageModelOptions,
+          },
+          experimental_telemetry: {
+            isEnabled: true,
+            functionId: "dbt-commit-message",
+            metadata: {
+              workspaceId: trackingCtx?.workspaceId ?? "unknown",
+              invocationType: "commit_message",
+            },
+          },
+        }),
+    );
+
+    const actualModelId = (response as Record<string, unknown>)?.modelId as
+      | string
+      | undefined;
+    const modelId = actualModelId || utilityModel;
+
+    if (trackingCtx) {
+      const { inputTokens, outputTokens } = extractTokenCounts(
+        usage as Record<string, unknown>,
+      );
+      void trackUsage({
+        workspaceId: trackingCtx.workspaceId,
+        userId: trackingCtx.userId,
+        invocationType: "commit_message",
+        modelId,
+        inputTokens,
+        outputTokens,
+        totalTokens: inputTokens + outputTokens,
+      }).catch(err =>
+        logger.warn("Failed to track commit message usage", { error: err }),
+      );
+    }
+
+    let message = text.trim();
+    // Strip a wrapping code fence if the model added one.
+    message = message.replace(/^```[a-z]*\n?|\n?```$/g, "").trim();
+    message = message.substring(0, MAX_MESSAGE_CHARS).trim();
+
+    if (message.length < 3) return null;
+    return message;
+  } catch (error) {
+    logger.error("dbt commit message generation failed", { error });
+    return null;
+  }
+}

--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -53,6 +53,7 @@ import {
   openProjectPullRequest,
   switchProjectBranch,
 } from "../dbt/dbt-github-git.service";
+import { generateDbtCommitMessage } from "../dbt/dbt-commit-message.service";
 import {
   DBT_COMPATIBLE_CONNECTION_TYPES,
   isDbtCompatibleConnectionType,
@@ -861,6 +862,33 @@ dbtRoutes.post(
       return c.json({ success: true, ...result });
     } catch (error) {
       return serverError(c, error, "Failed to commit and push");
+    }
+  },
+);
+
+// POST /projects/:projectId/git/commit-message — AI-generate a commit message
+// from the working-tree diff. Returns { message: null } when there are no
+// changes or generation is unavailable; the client keeps the manual field.
+dbtRoutes.post(
+  "/projects/:projectId/git/commit-message",
+  async (c: AuthenticatedContext) => {
+    try {
+      const project = await findProject(c);
+      if (!project) {
+        return c.json({ success: false, error: "dbt project not found" }, 404);
+      }
+      if (!project.repo) {
+        return badRequest(c, "Project is not connected to a repository");
+      }
+      const user = c.get("user");
+      const message = await generateDbtCommitMessage(project, {
+        workspaceId: c.req.param("workspaceId") ?? "unknown",
+        userId: getUserId(c),
+        userEmail: user?.email,
+      });
+      return c.json({ success: true, message });
+    } catch (error) {
+      return serverError(c, error, "Failed to generate commit message");
     }
   },
 );

--- a/api/src/services/llm-usage.service.ts
+++ b/api/src/services/llm-usage.service.ts
@@ -21,7 +21,8 @@ export interface TrackUsageParams {
     | "title_generation"
     | "description_generation"
     | "embedding"
-    | "version_comment";
+    | "version_comment"
+    | "commit_message";
   modelId: string;
   inputTokens: number;
   outputTokens: number;

--- a/app/src/components/DbtExplorer.tsx
+++ b/app/src/components/DbtExplorer.tsx
@@ -56,6 +56,7 @@ import {
   ChevronRight as ChevronRightIcon,
   Check as CheckIcon,
   Box as ProjectBoxIcon,
+  Sparkles as GenerateIcon,
 } from "lucide-react";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useConsoleStore } from "../store/consoleStore";
@@ -295,6 +296,7 @@ export function DbtExplorer() {
   const fetchGitStatus = useDbtStore(s => s.fetchGitStatus);
   const fetchGitDiff = useDbtStore(s => s.fetchGitDiff);
   const commitAndPush = useDbtStore(s => s.commitAndPush);
+  const generateCommitMessage = useDbtStore(s => s.generateCommitMessage);
   const listBranches = useDbtStore(s => s.listBranches);
   const createBranch = useDbtStore(s => s.createBranch);
   const switchBranch = useDbtStore(s => s.switchBranch);
@@ -335,6 +337,7 @@ export function DbtExplorer() {
   // In-IDE git dialogs
   const [commitTarget, setCommitTarget] = useState<string | null>(null);
   const [commitMessage, setCommitMessage] = useState("");
+  const [generatingMessage, setGeneratingMessage] = useState(false);
   const [gitBusy, setGitBusy] = useState(false);
   const [gitResult, setGitResult] = useState<string | null>(null);
   const [diffData, setDiffData] = useState<GitFileDiff | null>(null);
@@ -603,6 +606,19 @@ export function DbtExplorer() {
       setGitResult("No changes to commit");
     }
   }, [workspaceId, commitTarget, commitMessage, commitAndPush]);
+
+  const handleGenerateMessage = useCallback(async () => {
+    if (!workspaceId || !commitTarget) return;
+    setGeneratingMessage(true);
+    setGitResult(null);
+    const message = await generateCommitMessage(workspaceId, commitTarget);
+    setGeneratingMessage(false);
+    if (message) {
+      setCommitMessage(message);
+    } else {
+      setGitResult("Could not generate a message — write one manually.");
+    }
+  }, [workspaceId, commitTarget, generateCommitMessage]);
 
   const handleCreateBranch = useCallback(async () => {
     if (!workspaceId || !branchTarget || !branchName.trim()) return;
@@ -1938,6 +1954,29 @@ export function DbtExplorer() {
                       </Box>
                     ))
                   )}
+                </Box>
+                <Box
+                  sx={{
+                    display: "flex",
+                    justifyContent: "flex-end",
+                    mb: 0.5,
+                  }}
+                >
+                  <Button
+                    size="small"
+                    onClick={handleGenerateMessage}
+                    disabled={generatingMessage || changes.length === 0}
+                    startIcon={
+                      generatingMessage ? (
+                        <CircularProgress size={13} />
+                      ) : (
+                        <GenerateIcon size={14} strokeWidth={1.75} />
+                      )
+                    }
+                    sx={{ textTransform: "none" }}
+                  >
+                    {generatingMessage ? "Generating…" : "Generate with AI"}
+                  </Button>
                 </Box>
                 <TextField
                   autoFocus

--- a/app/src/components/DbtExplorer.tsx
+++ b/app/src/components/DbtExplorer.tsx
@@ -602,6 +602,12 @@ export function DbtExplorer() {
         `Pushed to ${result.branch}: +${added} ~${modified} -${deleted}`,
       );
       setCommitMessage("");
+      // Briefly show the confirmation, then close — the working tree is now
+      // clean, so leaving the dialog open just shows a dead "0 changes" state.
+      window.setTimeout(() => {
+        setCommitTarget(null);
+        setGitResult(null);
+      }, 1500);
     } else if (result) {
       setGitResult("No changes to commit");
     }

--- a/app/src/components/DbtJobView.tsx
+++ b/app/src/components/DbtJobView.tsx
@@ -34,6 +34,11 @@ import { useWorkspace } from "../contexts/workspace-context";
 import { useDbtStore, type DbtJobItem } from "../store/dbtStore";
 import DbtRunHistory from "./DbtRunHistory";
 
+// Fast cadence while a run is active; slower idle cadence so scheduled runs
+// that fire (and progress updates) surface without a manual refresh.
+const ACTIVE_POLL_INTERVAL_MS = 3_000;
+const IDLE_POLL_INTERVAL_MS = 8_000;
+
 type SchedulePreset = "hourly" | "daily" | "every6h" | "weekly" | "custom";
 
 const PRESET_CRONS: Record<Exclude<SchedulePreset, "custom">, string> = {
@@ -143,6 +148,42 @@ export default function DbtJobView({
   const runningRun = jobRuns.find(
     run => run.status === "running" || run.status === "queued",
   );
+
+  // Keep this job's run history live while the tab is open: scheduled runs
+  // that fire and in-progress runs update without a manual refresh. Cadence
+  // adapts to whether a run is active; polling pauses while the tab is hidden.
+  const hasActiveRef = useRef(false);
+  hasActiveRef.current = !!runningRun;
+  useEffect(() => {
+    if (!workspaceId) return;
+    let stopped = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const schedule = () => {
+      if (stopped) return;
+      const interval = hasActiveRef.current
+        ? ACTIVE_POLL_INTERVAL_MS
+        : IDLE_POLL_INTERVAL_MS;
+      timer = setTimeout(() => void tick(), interval);
+    };
+    const tick = async () => {
+      if (document.visibilityState === "visible") {
+        await fetchRuns(workspaceId, projectId, jobId);
+      }
+      schedule();
+    };
+    schedule();
+    const onVisible = () => {
+      if (document.visibilityState === "visible") {
+        void fetchRuns(workspaceId, projectId, jobId);
+      }
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      stopped = true;
+      if (timer) clearTimeout(timer);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, [workspaceId, projectId, jobId, fetchRuns]);
 
   const handleRunNow = useCallback(async () => {
     if (!workspaceId) return;

--- a/app/src/components/DbtRunsView.tsx
+++ b/app/src/components/DbtRunsView.tsx
@@ -12,6 +12,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Box, IconButton, Tooltip, Typography } from "@mui/material";
 import { RefreshCw as RefreshIcon } from "lucide-react";
 import { useWorkspace } from "../contexts/workspace-context";
+import { useConsoleStore } from "../store/consoleStore";
 import { useDbtStore } from "../store/dbtStore";
 import DbtRunHistory from "./DbtRunHistory";
 import EntityBreadcrumbs from "./EntityBreadcrumbs";
@@ -65,6 +66,16 @@ export default function DbtRunsView({
     if (!jobs) void fetchJobs(workspaceId, projectId);
     void fetchRuns(workspaceId, projectId);
   }, [workspaceId, projectId, jobs, fetchJobs, fetchRuns]);
+
+  // Refresh whenever this tab becomes active — opening it, or clicking back to
+  // it after it stayed mounted in the background — so it never shows stale runs
+  // while waiting for the next poll tick.
+  const isActiveTab = useConsoleStore(s => s.activeTabId === tabId);
+  useEffect(() => {
+    if (isActiveTab && workspaceId) {
+      void fetchRuns(workspaceId, projectId);
+    }
+  }, [isActiveTab, workspaceId, projectId, fetchRuns]);
 
   // Poll the run list the whole time this tab is open so newly-triggered runs
   // (agent `dbt_run_model`, editor "Run model", scheduled jobs) appear and

--- a/app/src/components/DbtRunsView.tsx
+++ b/app/src/components/DbtRunsView.tsx
@@ -16,7 +16,10 @@ import { useDbtStore } from "../store/dbtStore";
 import DbtRunHistory from "./DbtRunHistory";
 import EntityBreadcrumbs from "./EntityBreadcrumbs";
 
-const LIST_POLL_INTERVAL_MS = 3_000;
+// Fast cadence while a run is active; slower idle cadence so newly-triggered
+// runs (agent, editor, schedule) still surface without a manual refresh.
+const ACTIVE_POLL_INTERVAL_MS = 3_000;
+const IDLE_POLL_INTERVAL_MS = 8_000;
 
 export default function DbtRunsView({
   tabId,
@@ -63,25 +66,43 @@ export default function DbtRunsView({
     void fetchRuns(workspaceId, projectId);
   }, [workspaceId, projectId, jobs, fetchJobs, fetchRuns]);
 
-  // Poll the run list while anything is active so agent-triggered runs appear
-  // and statuses stay fresh without manual refresh.
+  // Poll the run list the whole time this tab is open so newly-triggered runs
+  // (agent `dbt_run_model`, editor "Run model", scheduled jobs) appear and
+  // statuses stay fresh without a manual refresh. Cadence adapts to whether a
+  // run is active, and polling pauses while the tab is hidden.
   const hasActiveRef = useRef(hasActive);
   hasActiveRef.current = hasActive;
   useEffect(() => {
-    if (!workspaceId || !hasActive) return;
+    if (!workspaceId) return;
     let stopped = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
-    const poll = async () => {
-      await fetchRuns(workspaceId, projectId);
-      if (stopped || !hasActiveRef.current) return;
-      timer = setTimeout(() => void poll(), LIST_POLL_INTERVAL_MS);
+    const schedule = () => {
+      if (stopped) return;
+      const interval = hasActiveRef.current
+        ? ACTIVE_POLL_INTERVAL_MS
+        : IDLE_POLL_INTERVAL_MS;
+      timer = setTimeout(() => void tick(), interval);
     };
-    timer = setTimeout(() => void poll(), LIST_POLL_INTERVAL_MS);
+    const tick = async () => {
+      if (document.visibilityState === "visible") {
+        await fetchRuns(workspaceId, projectId);
+      }
+      schedule();
+    };
+    schedule();
+    // Refresh immediately when the tab regains focus after being hidden.
+    const onVisible = () => {
+      if (document.visibilityState === "visible") {
+        void fetchRuns(workspaceId, projectId);
+      }
+    };
+    document.addEventListener("visibilitychange", onVisible);
     return () => {
       stopped = true;
       if (timer) clearTimeout(timer);
+      document.removeEventListener("visibilitychange", onVisible);
     };
-  }, [workspaceId, projectId, hasActive, fetchRuns]);
+  }, [workspaceId, projectId, fetchRuns]);
 
   // Default selection: newest run.
   useEffect(() => {

--- a/app/src/store/dbtStore.ts
+++ b/app/src/store/dbtStore.ts
@@ -523,6 +523,21 @@ function encodeDbtPath(path: string): string {
   return path.split("/").map(encodeURIComponent).join("/");
 }
 
+/**
+ * Refresh the working-tree git status for a repo-bound project after a file
+ * write. Fire-and-forget: keeps the "Commit & push (N)" badge in sync when the
+ * agent (or the editor) creates/modifies/deletes/renames files. No-op for
+ * projects without a repo binding (the status endpoint would 400).
+ */
+function refreshGitStatusForRepoProject(
+  get: () => DbtStore,
+  workspaceId: string,
+  projectId: string,
+): void {
+  const project = get().projects.find(p => p._id === projectId);
+  if (project?.repo) void get().fetchGitStatus(workspaceId, projectId);
+}
+
 export const useDbtStore = create<DbtStore>()(
   immer((set, get) => ({
     ...initialState,
@@ -1006,6 +1021,7 @@ export const useDbtStore = create<DbtStore>()(
           const entry = state.filesByProject[projectId]?.[path];
           if (entry) entry.dirty = false;
         });
+        refreshGitStatusForRepoProject(get, workspaceId, projectId);
         return true;
       } catch (error) {
         set(state => {
@@ -1035,6 +1051,7 @@ export const useDbtStore = create<DbtStore>()(
             state.filePathsByProject[projectId] = paths.filter(p => p !== path);
           }
         });
+        refreshGitStatusForRepoProject(get, workspaceId, projectId);
         return true;
       } catch (error) {
         set(state => {
@@ -1066,6 +1083,7 @@ export const useDbtStore = create<DbtStore>()(
               .sort();
           }
         });
+        refreshGitStatusForRepoProject(get, workspaceId, projectId);
         return true;
       } catch (error) {
         set(state => {

--- a/app/src/store/dbtStore.ts
+++ b/app/src/store/dbtStore.ts
@@ -356,6 +356,10 @@ interface DbtActions {
     projectId: string,
     message: string,
   ) => Promise<CommitResult | null>;
+  generateCommitMessage: (
+    workspaceId: string,
+    projectId: string,
+  ) => Promise<string | null>;
   listBranches: (
     workspaceId: string,
     projectId: string,
@@ -805,6 +809,27 @@ export const useDbtStore = create<DbtStore>()(
       } catch (error) {
         set(state => {
           state.error.projects = errMessage(error, "Failed to commit and push");
+        });
+        return null;
+      }
+    },
+
+    generateCommitMessage: async (workspaceId, projectId) => {
+      try {
+        const response = await apiClient.post<{
+          success: boolean;
+          message: string | null;
+        }>(
+          `/workspaces/${workspaceId}/dbt/projects/${projectId}/git/commit-message`,
+          {},
+        );
+        return response.message ?? null;
+      } catch (error) {
+        set(state => {
+          state.error.projects = errMessage(
+            error,
+            "Failed to generate commit message",
+          );
         });
         return null;
       }

--- a/packages/agent-tools/src/read-only-tools.ts
+++ b/packages/agent-tools/src/read-only-tools.ts
@@ -52,6 +52,9 @@ export const READ_ONLY_TOOL_NAMES: ReadonlySet<string> = new Set<string>([
   "dbt_compile_model",
   "dbt_get_run",
   "dbt_show",
+  // dbt git reads (status + branch listing never mutate the repo)
+  "dbt_git_status",
+  "dbt_list_branches",
   // Surface-scoped data-source reads (apps + dashboards, local DuckDB only)
   "list_data_sources",
   "inspect_data_source",


### PR DESCRIPTION
## Summary

Surfaces the dbt project's GitHub git capability (which already existed at the service + REST + UI layers) to the AI agent, and adds supporting UX so the in-IDE git experience matches dbt Cloud.

- **Agent git tools** (`api/src/agent-lib/tools/dbt-tools.ts`): wrap the existing `dbt-github-git.service` (status, diff, commit & push, list/create/switch branch, open PR) as agent tools, wired into both the standalone dbt agent and the unified agent's Transform mode (`agents/{dbt,unified}/index.ts`, `modes/registry.ts`), with prompt guidance (`agents/dbt/prompt.ts`, `modes/prompts.ts`). Read-only git tools registered in `packages/agent-tools/src/read-only-tools.ts`. Fixes the agent reporting "I have no git tool".
- **AI commit messages** (`api/src/dbt/dbt-commit-message.service.ts`, `routes/dbt.routes.ts`): generate a commit message from the working-tree diff, surfaced in the Commit & push dialog.
- **Live git-status refresh** (`app/src/components/DbtExplorer.tsx`, `store/dbtStore.ts`): keep git status fresh on file edits; auto-close the Commit & push dialog after a successful push.
- **Runs UI liveness** (`app/src/components/DbtRunsView.tsx`, `DbtJobView.tsx`): keep the runs view live without a manual refresh and refresh when its tab becomes active.

## Test plan

- [ ] In a repo-bound dbt project, ask the agent to commit & push a change; verify it uses the new git tools and the push lands on the tracked branch.
- [ ] Ask the agent to create a feature branch and open a PR; verify the PR is created with the expected base.
- [ ] Confirm git tools error cleanly on a project with no connected repository.
- [ ] Open the Commit & push dialog; verify the AI-generated commit message populates and the dialog auto-closes after a successful push.
- [ ] Edit a dbt file and confirm git status updates without a manual refresh; confirm runs view stays live.

Made with [Cursor](https://cursor.com)