### PR TITLE
feat(cdc): scheduler self-heals drifted entities with pending events

### DIFF
--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -2497,6 +2497,18 @@ CdcChangeEventSchema.index({
   stageStatus: 1,
   ingestSeq: 1,
 });
+// Self-heal: lets the scheduler cheaply enumerate DISTINCT flow+entity pairs
+// that still have pending rows, independent of the consumer cursor. This is
+// what rescues entities whose cursor drifted past their pending events (so
+// findStaleEntities — which keys on lastIngestSeq > lastMaterializedSeq — no
+// longer flags them). Partial filter keeps the index tiny (only pending rows).
+CdcChangeEventSchema.index(
+  { flowId: 1, entity: 1 },
+  {
+    name: "cdc_pending_entities",
+    partialFilterExpression: { materializationStatus: "pending" },
+  },
+);
 /** Successfully materialized rows — shorter retention. */
 CdcChangeEventSchema.index(
   { appliedAt: 1 },

--- a/api/src/inngest/functions/webhook-flow.ts
+++ b/api/src/inngest/functions/webhook-flow.ts
@@ -5,6 +5,7 @@ import {
   Connector as DataSource,
   DatabaseConnection,
   CdcEntityState,
+  CdcChangeEvent,
 } from "../../database/workspace-schema";
 import { getSyncLogger } from "../logging";
 import { connectorRegistry } from "../../connectors/registry";
@@ -1026,6 +1027,87 @@ async function findStaleEntities(): Promise<
   return eligible.filter(c => existingFlowIdSet.has(c.flowId.toString()));
 }
 
+const CDC_PENDING_ENTITY_DISCOVERY_LIMIT = Math.max(
+  parseInt(process.env.CDC_PENDING_ENTITY_DISCOVERY_LIMIT || "5000", 10) || 5000,
+  100,
+);
+
+/**
+ * Self-heal discovery: find DISTINCT flow+entity pairs that still have
+ * `materializationStatus: "pending"` rows, regardless of the consumer cursor.
+ *
+ * findStaleEntities only flags entities where lastIngestSeq > lastMaterializedSeq.
+ * An entity whose cursor drifted PAST its pending rows (e.g. a backfill advanced
+ * lastMaterializedSeq, or a stale read jumped the cursor) has
+ * lastIngestSeq <= lastMaterializedSeq, so it is never flagged — and if it has
+ * also gone quiet (no new webhooks to bump lastIngestSeq), it would stay stuck
+ * forever. This authoritative scan rescues those entities. Backed by the
+ * `cdc_pending_entities` partial index, so it only touches pending rows.
+ */
+async function findEntitiesWithPendingEvents(): Promise<
+  Array<{
+    workspaceId: { toString(): string };
+    flowId: { toString(): string };
+    entity: string;
+  }>
+> {
+  const grouped = await CdcChangeEvent.aggregate<{
+    _id: { workspaceId: Types.ObjectId; flowId: Types.ObjectId; entity: string };
+  }>([
+    { $match: { materializationStatus: "pending" } },
+    {
+      $group: {
+        _id: {
+          workspaceId: "$workspaceId",
+          flowId: "$flowId",
+          entity: "$entity",
+        },
+      },
+    },
+    { $limit: CDC_PENDING_ENTITY_DISCOVERY_LIMIT },
+  ]);
+
+  if (grouped.length === 0) return [];
+
+  const candidates = grouped.map(g => ({
+    workspaceId: g._id.workspaceId,
+    flowId: g._id.flowId,
+    entity: g._id.entity,
+  }));
+
+  // Respect the circuit-breaker backoff so we don't hammer entities that are
+  // failing for a real reason (same policy as findStaleEntities).
+  const states = await CdcEntityState.find({
+    flowId: { $in: candidates.map(c => c.flowId) },
+  })
+    .select("flowId entity consecutiveFailures lastFailedAt")
+    .lean();
+  const stateKey = (flowId: string, entity: string) => `${flowId}:${entity}`;
+  const stateMap = new Map(
+    states.map(s => [stateKey(s.flowId.toString(), s.entity), s]),
+  );
+
+  const now = Date.now();
+  const eligible = candidates.filter(c => {
+    const s = stateMap.get(stateKey(c.flowId.toString(), c.entity));
+    const failures = (s as any)?.consecutiveFailures || 0;
+    if (failures === 0) return true;
+    const lastFailed = (s as any)?.lastFailedAt
+      ? new Date((s as any).lastFailedAt).getTime()
+      : 0;
+    return now - lastFailed >= circuitBreakerBackoffMs(failures);
+  });
+
+  const flowIds = Array.from(new Set(eligible.map(c => c.flowId.toString())));
+  if (flowIds.length === 0) return [];
+  const existingFlows = await Flow.find({ _id: { $in: flowIds } })
+    .select("_id")
+    .lean();
+  const existingFlowIdSet = new Set(existingFlows.map(f => f._id.toString()));
+
+  return eligible.filter(c => existingFlowIdSet.has(c.flowId.toString()));
+}
+
 function buildMaterializeEvents(
   entities: Array<{
     workspaceId: { toString(): string };
@@ -1412,26 +1494,52 @@ export const cdcMaterializeSchedulerFunction = inngest.createFunction(
       cleanupStalePendingCdcEvents,
     )) as Awaited<ReturnType<typeof cleanupStalePendingCdcEvents>>;
 
-    const staleEntities = (await step.run(
-      "find-stale-entities",
-      findStaleEntities,
-    )) as Array<{
+    type CdcEntityRef = {
       workspaceId: { toString(): string };
       flowId: { toString(): string };
       entity: string;
-    }>;
+    };
+
+    // Cursor-based triggering (entities whose ingest is ahead of materialize).
+    const staleEntities = (await step.run(
+      "find-stale-entities",
+      findStaleEntities,
+    )) as CdcEntityRef[];
+
+    // Self-heal: entities that still have pending rows but were NOT flagged as
+    // stale (cursor drifted past them and they went quiet). This is what makes
+    // a drifted backlog drain without a manual "Reprocess pending events" click.
+    const pendingEntities = (await step.run(
+      "find-pending-entities",
+      findEntitiesWithPendingEvents,
+    )) as CdcEntityRef[];
+
+    // Union, de-duplicated by flow+entity (cdc/materialize is idempotent +
+    // singleton-guarded, but avoid emitting obvious duplicates).
+    const seen = new Set<string>();
+    const allEntities: CdcEntityRef[] = [];
+    for (const e of [...staleEntities, ...pendingEntities]) {
+      const key = `${String(e.flowId)}:${e.entity}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      allEntities.push(e);
+    }
+    const selfHealedCount = Math.max(
+      allEntities.length - staleEntities.length,
+      0,
+    );
 
     let totalTriggered = 0;
-    if (staleEntities.length > 0) {
+    if (allEntities.length > 0) {
       const DISPATCH_BATCH = 20;
-      for (let i = 0; i < staleEntities.length; i += DISPATCH_BATCH) {
-        const batch = staleEntities.slice(i, i + DISPATCH_BATCH);
+      for (let i = 0; i < allEntities.length; i += DISPATCH_BATCH) {
+        const batch = allEntities.slice(i, i + DISPATCH_BATCH);
         await step.sendEvent(
           `trigger-materializations-${i}`,
           buildMaterializeEvents(batch),
         );
       }
-      totalTriggered = staleEntities.length;
+      totalTriggered = allEntities.length;
     }
 
     if (
@@ -1444,6 +1552,9 @@ export const cdcMaterializeSchedulerFunction = inngest.createFunction(
         dropped: ingestResult.dropped,
         failed: ingestResult.failed,
         materializeTriggered: totalTriggered,
+        staleEntities: staleEntities.length,
+        pendingEntities: pendingEntities.length,
+        selfHealed: selfHealedCount,
         staleCdcDropped: cleanupResult.droppedCdc,
         staleWebhooksDropped: cleanupResult.droppedWebhooks,
         staleCursorsAdvanced: cleanupResult.cursorsAdvanced,
@@ -1455,6 +1566,7 @@ export const cdcMaterializeSchedulerFunction = inngest.createFunction(
       dropped: ingestResult.dropped,
       failed: ingestResult.failed,
       materializeTriggered: totalTriggered,
+      selfHealed: selfHealedCount,
       staleCdcDropped: cleanupResult.droppedCdc,
     };
   },

--- a/api/src/migrations/2026-06-21-130000_cdc_change_events_pending_entities_index.ts
+++ b/api/src/migrations/2026-06-21-130000_cdc_change_events_pending_entities_index.ts
@@ -1,0 +1,66 @@
+import { Db } from "mongodb";
+import { loggers } from "../logging";
+
+const log = loggers.migration();
+
+const COLLECTION = "cdc_change_events";
+const INDEX_NAME = "cdc_pending_entities";
+
+type IndexInfo = {
+  name: string;
+  key?: Record<string, unknown>;
+};
+
+/**
+ * The CDC scheduler self-heal step (findEntitiesWithPendingEvents) enumerates
+ * DISTINCT flow+entity pairs that still have `materializationStatus: "pending"`
+ * rows, independent of the consumer cursor — this is what rescues entities
+ * whose cursor drifted past their pending events (so findStaleEntities, which
+ * keys on lastIngestSeq > lastMaterializedSeq, never flags them).
+ *
+ * Without an index, that `$match { materializationStatus: "pending" } $group`
+ * is a COLLSCAN over the whole cdc_change_events collection every cron tick.
+ * This partial index covers only pending rows (so it stays tiny and is not
+ * bloated by the millions of applied/dropped rows) and lets the grouping run
+ * as a bounded index scan ordered by flowId+entity.
+ */
+export const description =
+  "Add partial { flowId, entity } index on cdc_change_events for pending rows (CDC self-heal discovery)";
+
+function hasIndexNamed(indexes: IndexInfo[], name: string): boolean {
+  return indexes.some(idx => idx.name === name);
+}
+
+export async function up(db: Db): Promise<void> {
+  const names = new Set(
+    (await db.listCollections().toArray()).map(c => c.name),
+  );
+  if (!names.has(COLLECTION)) {
+    log.info("cdc_change_events collection not found, skipping", {
+      collection: COLLECTION,
+    });
+    return;
+  }
+
+  const col = db.collection(COLLECTION);
+  const indexes = (await col.indexes()) as IndexInfo[];
+
+  if (hasIndexNamed(indexes, INDEX_NAME)) {
+    log.info("cdc_pending_entities index already present, skipping", {
+      collection: COLLECTION,
+    });
+    return;
+  }
+
+  await col.createIndex(
+    { flowId: 1, entity: 1 },
+    {
+      name: INDEX_NAME,
+      partialFilterExpression: { materializationStatus: "pending" },
+    },
+  );
+  log.info("Created cdc_change_events pending-entities partial index", {
+    collection: COLLECTION,
+    name: INDEX_NAME,
+  });
+}


### PR DESCRIPTION
## Summary

Follow-up to #543. That PR made orphaned `pending` events **readable** (cursor-independent `readAfter`), but an entity still has to be **triggered** — and the trigger query was unchanged:

```ts
// findStaleEntities
{ $expr: { $gt: ["$lastIngestSeq", "$lastMaterializedSeq"] } }
```

An entity whose cursor **drifted past** its pending rows (a backfill advanced `lastMaterializedSeq`, or a stale read jumped it) has `lastIngestSeq <= lastMaterializedSeq`, so it is **never flagged**. If it also goes **quiet** (no new webhooks to bump `lastIngestSeq`), it stays stuck forever and only a manual **Reprocess pending events** click recovers it. Prod Inngest confirmed the symptom: healthy live draining, but **no** large-batch drains for the drifted backlog (it wasn't being triggered).

This closes the gap so drifted/quiet backlogs drain automatically.

## Changes

- **`findEntitiesWithPendingEvents()`** — authoritative scan for DISTINCT `flow+entity` pairs that still have `materializationStatus: "pending"` rows, independent of the cursor.
- **Scheduler triggers the UNION** of stale (cursor-based) + pending-bearing entities, de-duplicated by `flow:entity`.
- **`cdc_pending_entities` partial index** (`{flowId, entity}` where `pending`) keeps the discovery query a bounded index scan instead of a COLLSCAN. Partial filter ⇒ tiny index (only pending rows). Includes migration `2026-06-21-130000`.
- Reuses the same **circuit-breaker backoff** + flow-existence checks as `findStaleEntities`.
- Discovery cap via `CDC_PENDING_ENTITY_DISCOVERY_LIMIT` (default 5000 distinct entities).
- Scheduler log/return now expose `staleEntities` / `pendingEntities` / `selfHealed`.

## Test plan

- [ ] Run migration `2026-06-21-130000_cdc_change_events_pending_entities_index` (`pnpm migrate`); confirm `cdc_pending_entities` partial index exists.
- [ ] On a drifted+quiet entity (pending rows, `lastIngestSeq <= lastMaterializedSeq`), confirm the scheduler now triggers it without any manual action and it drains to 0.
- [ ] Confirm `selfHealed > 0` in the `CDC scheduler completed` log while a drifted backlog exists, then returns to 0.
- [ ] Verify the discovery query uses `cdc_pending_entities` (IXSCAN), not a COLLSCAN.
- [ ] Confirm no regression in normal cursor-based triggering (stale entities still fire).

## Notes

- Built off latest `master` (includes #543 + #544) in an isolated worktree; unrelated WIP excluded.

Made with [Cursor](https://cursor.com)