### PR TITLE
fix(dbt): refresh git status on Transforms refresh

### DIFF
--- a/app/src/components/DbtExplorer.tsx
+++ b/app/src/components/DbtExplorer.tsx
@@ -468,8 +468,24 @@ export function DbtExplorer() {
   const activeChangeCount = activeStatus?.changes.length ?? 0;
 
   const handleRefresh = useCallback(() => {
-    if (workspaceId) void fetchProjects(workspaceId);
-  }, [workspaceId, fetchProjects]);
+    if (!workspaceId) return;
+    void fetchProjects(workspaceId);
+    // Re-pull working-tree git status so change badges reflect commits made
+    // outside this view (e.g. the agent committing server-side) without
+    // forcing a full page reload — the mount effect only runs once.
+    for (const id of repoProjectIds ? repoProjectIds.split(",") : []) {
+      void fetchGitStatus(workspaceId, id);
+    }
+    // Refresh the active project's file tree so agent-added/removed files show.
+    if (activeProjectId) void fetchFiles(workspaceId, activeProjectId);
+  }, [
+    workspaceId,
+    repoProjectIds,
+    activeProjectId,
+    fetchProjects,
+    fetchGitStatus,
+    fetchFiles,
+  ]);
 
   const handleLoadChildren = useCallback(
     async (node: ResourceTreeNode) => {


### PR DESCRIPTION
## Summary

- The Transforms explorer refresh button only refetched the **project list** — it never re-pulled git status. Working-tree git status was fetched exactly once in a mount effect keyed on `repoProjectIds`, which doesn't change when commits happen outside this view (e.g. the **agent committing server-side**). So the `Commit & push (N)` change badge stayed stale until a full page reload.
- `handleRefresh` now also re-pulls working-tree git status for every repo-bound project and refreshes the active project's file tree, so externally-committed changes appear on refresh without reloading the page.

## Test plan

- [ ] Open a repo-bound dbt project in Transforms with pending changes.
- [ ] Have the agent commit & push (or commit externally) so the working tree goes clean.
- [ ] Click the Transforms refresh button → the `Commit & push (N)` badge updates to reflect the new state (no full page reload needed).
- [ ] Agent-added/removed files appear in the file tree after refresh.

Made with [Cursor](https://cursor.com)