### PR TITLE
fix(dbt): reconcile files removed upstream so git status/commit can't get stuck

### DIFF
--- a/api/src/dbt/dbt-github-git.service.ts
+++ b/api/src/dbt/dbt-github-git.service.ts
@@ -17,6 +17,7 @@ import {
   getBlobContent,
   getRefCommit,
   getRepoInfo,
+  getRepoTree,
   listBranches,
   type TreeChange,
 } from "../integrations/github/github-api";
@@ -163,29 +164,37 @@ export async function commitAndPush(
     .lean();
   const byPath = new Map(files.map(f => [f.path, f]));
 
-  const treeChanges: TreeChange[] = status.changes.map(change => ({
-    path: repoPath(project, change.path),
-    content:
-      change.status === "deleted"
-        ? null
-        : (byPath.get(change.path)?.content ?? ""),
-  }));
-
   const { commitSha, treeSha } = await getRefCommit(owner, repo, branch, token);
-  const newSha = await commitChanges(
-    owner,
-    repo,
-    {
-      branch,
-      parentSha: commitSha,
-      baseTreeSha: treeSha,
-      message: params.message,
-      changes: treeChanges,
-    },
-    token,
+
+  // GitHub returns 422 GitRPC::BadObject if a tree entry deletes (sha:null) a
+  // path that isn't in base_tree. Phantom deletions (files removed upstream but
+  // still flagged is_deleted locally) would trip this, so drop any deletion
+  // whose path no longer exists on the branch and just reconcile it locally.
+  const baseTree = await getRepoTree(owner, repo, treeSha, token);
+  const baseTreePaths = new Set(
+    baseTree.entries.filter(e => e.type === "blob").map(e => e.path),
   );
 
-  // Reconcile local state to the just-pushed commit.
+  const treeChanges: TreeChange[] = [];
+  const phantomDeletions: string[] = [];
+  for (const change of status.changes) {
+    const path = repoPath(project, change.path);
+    if (change.status === "deleted") {
+      if (!baseTreePaths.has(path)) {
+        phantomDeletions.push(change.path);
+        continue;
+      }
+      treeChanges.push({ path, content: null });
+    } else {
+      treeChanges.push({
+        path,
+        content: byPath.get(change.path)?.content ?? "",
+      });
+    }
+  }
+
+  // Reconcile local state. Phantom deletions never reach GitHub but must still
+  // be cleaned up so they stop showing as pending changes.
   const ops: Array<Promise<unknown>> = [];
   for (const change of status.changes) {
     if (change.status === "deleted") {
@@ -202,6 +211,31 @@ export async function commitAndPush(
       );
     }
   }
+
+  // Nothing real to push (every change was a phantom deletion): heal local
+  // state without creating an empty commit.
+  if (treeChanges.length === 0) {
+    await Promise.all(ops);
+    return {
+      committed: false,
+      branch,
+      pushed: { added: 0, modified: 0, deleted: 0 },
+    };
+  }
+
+  const newSha = await commitChanges(
+    owner,
+    repo,
+    {
+      branch,
+      parentSha: commitSha,
+      baseTreeSha: treeSha,
+      message: params.message,
+      changes: treeChanges,
+    },
+    token,
+  );
+
   await Promise.all(ops);
 
   project.repo.lastSyncedSha = newSha;
@@ -216,7 +250,7 @@ export async function commitAndPush(
     pushed: {
       added: status.added,
       modified: status.modified,
-      deleted: status.deleted,
+      deleted: status.deleted - phantomDeletions.length,
     },
   };
 }

--- a/api/src/dbt/dbt-github-sync.service.ts
+++ b/api/src/dbt/dbt-github-sync.service.ts
@@ -177,7 +177,7 @@ export async function syncProjectFromRepo(
   const { sha, files, skippedLarge } = await fetchRepoDbtFiles(project.repo);
 
   const existing = await DbtFile.find({ projectId: project._id })
-    .select("path content is_deleted")
+    .select("path content is_deleted repoBlobSha")
     .lean();
   const existingByPath = new Map(existing.map(f => [f.path, f]));
   const remotePaths = new Set(files.map(f => f.path));
@@ -220,14 +220,29 @@ export async function syncProjectFromRepo(
     );
   }
 
-  // Soft-delete files that were imported before but are gone from the branch.
+  // Reconcile files that are no longer on the branch. Pulling makes the remote
+  // the source of truth, so a file absent upstream is "in sync when deleted" —
+  // it must NOT keep a repoBlobSha, or getGitStatus() would surface it as a
+  // permanent phantom "deleted" change that can never be committed (committing
+  // a sha:null delete for a path missing from base_tree → 422 GitRPC::BadObject)
+  // nor discarded (the next pull would re-create it).
   for (const prev of existing) {
-    if (!prev.is_deleted && !remotePaths.has(prev.path)) {
+    if (remotePaths.has(prev.path)) continue;
+    if (!prev.is_deleted) {
       deleted++;
       ops.push(
         DbtFile.updateOne(
           { projectId: project._id, path: prev.path },
-          { $set: { is_deleted: true, updatedBy } },
+          { $set: { is_deleted: true, updatedBy }, $unset: { repoBlobSha: "" } },
+        ).exec(),
+      );
+    } else if (prev.repoBlobSha) {
+      // Already soft-deleted locally and gone upstream: drop the stale blob SHA
+      // so it stops counting as a pending deletion (heals previously-stuck rows).
+      ops.push(
+        DbtFile.updateOne(
+          { projectId: project._id, path: prev.path },
+          { $unset: { repoBlobSha: "" } },
         ).exec(),
       );
     }


### PR DESCRIPTION
## Summary

A repo-bound dbt project could get **permanently stuck** showing phantom "deleted" changes that could neither be committed nor discarded — surfacing as a `422 GitRPC::BadObject` on commit (often misread as remote/object-store corruption). The remote is fine; this is a local working-tree reconciliation bug.

### Root cause

Mongo (`DbtFile`) is the dbt working tree, and each file's `repoBlobSha` records its blob at the last sync/push. `getGitStatus()` treats `is_deleted && repoBlobSha` as a pending deletion. When a file was removed on the branch upstream (e.g. the Stripe staging models dropped by a merged CDC migration), `syncProjectFromRepo` soft-deleted it locally **but kept `repoBlobSha`**, so:

- every **Pull from remote** / **Switch branch** re-flagged it deleted → can't discard, and
- **commit** emitted a `sha: null` tree entry for a path missing from `base_tree` → GitHub rejects with `422 GitRPC::BadObject` (["Returns an error if you try to delete a file that does not exist"](https://docs.github.com/en/rest/git/trees)) → can't commit.

Both escape hatches were broken, which is why the in-IDE agent couldn't recover.

### Changes

- **`syncProjectFromRepo`** (`dbt-github-sync.service.ts`): unset `repoBlobSha` for any file absent upstream — both newly-removed and already-soft-deleted rows. A pull now reconciles the diff and **heals previously-stuck projects**.
- **`commitAndPush`** (`dbt-github-git.service.ts`): fetch the base tree and drop deletions whose path isn't in it (reconcile locally instead), so a commit can never trip `BadObject`; skip the empty commit when every change was a phantom.

## Test plan

- [ ] Stuck project: remove a tracked model on the branch upstream → **Pull from remote** clears the phantom "deleted" change (no lingering count).
- [ ] Commit with a phantom deletion present → succeeds (or no-ops cleanly) instead of `422 GitRPC::BadObject`; real adds/modifies/deletes still push in one commit.
- [ ] Normal delete of a file that **does** exist upstream → still commits and removes it on the branch.
- [ ] `pnpm --filter api run lint` passes (verified locally).

## Immediate remediation (existing stuck projects)

Once deployed, **Pull from remote** clears the phantom diff. To unstick a project before deploy, unset `repoBlobSha` on the affected soft-deleted `dbtfiles` rows.

Made with [Cursor](https://cursor.com)