### PR TITLE
fix(mobile): stop iOS Safari zoom on chat input focus

### DIFF
--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -1594,11 +1594,11 @@ const ChatInputArea = React.memo(
               maxHeight: "50vh",
               overflowY: "auto",
               "& .MuiInputBase-input": {
-                fontSize: 14,
+                fontSize: { xs: 16, sm: 14 },
               },
               "& .MuiInputBase-root": {
                 p: 0,
-                fontSize: 14,
+                fontSize: { xs: 16, sm: 14 },
               },
               "& .MuiOutlinedInput-notchedOutline": {
                 border: "none",


### PR DESCRIPTION
## Summary
- On mobile, tapping the chat composer caused iOS Safari to auto-zoom the viewport. iOS zooms any focused `input`/`textarea` whose computed `font-size` is below `16px`, and the composer was hard-coded to `14px`.
- Bumped the input font-size to `16px` on the `xs` breakpoint (phones, `<600px`) while keeping `14px` on `sm`+ desktop, so the zoom no longer triggers and the desktop look is unchanged.

## Test plan
- [ ] On an iPhone (or Safari responsive design mode at a phone width), open a chat and tap the composer — the viewport should no longer zoom in.
- [ ] On desktop, confirm the composer text still renders at the tighter 14px size.

## Notes
Other inputs that use `font-size < 16px` (SQL editor, search fields, etc.) have the same latent issue. A follow-up could push a global guard into the MUI theme (`app/src/contexts/ThemeContext.tsx`) so this never regresses app-wide.

Made with [Cursor](https://cursor.com)