### PR TITLE
guides: C#/.NET connection guides (Batch 12) — PostgreSQL, MySQL, SQLite, MongoDB

### DIFF
--- a/content/guides/mongodb/connect-from-csharp.mdx
+++ b/content/guides/mongodb/connect-from-csharp.mdx
@@ -1,0 +1,179 @@
+---
+title: "How to Connect to MongoDB from C# (.NET)"
+description: "Connect to MongoDB from C# with the official MongoDB.Driver: MongoClient lifetime, async CRUD, the typed vs BSON document APIs, SRV connection strings, Atlas, pooling, LINQ, and the errors you actually hit."
+database: "mongodb"
+category: "how-to"
+tags: ["mongodb", "csharp", "dotnet", "mongodb-driver", "atlas", "connection"]
+date: "2026-06-23"
+---
+
+MongoDB in .NET has one driver that matters: the official `MongoDB.Driver` package. Unlike the relational databases, there is no ADO.NET layer and no Dapper here. MongoDB is a document database, so the driver exposes collections of typed objects (or raw BSON documents) rather than rows and a SQL string. This guide covers the one piece people get wrong first (client lifetime), then async CRUD, the typed-versus-BSON choice, connection strings and Atlas, pooling, and LINQ.
+
+## The one driver
+
+```bash
+dotnet add package MongoDB.Driver
+```
+
+`MongoDB.Driver` 3.9.0 is current as of June 2026. It is the only official driver and the only one you should use; it bundles the BSON library and the LINQ provider. The older `MongoDB.Driver.Core` and the standalone `MongoDB.Bson` are now folded into this single package for normal use.
+
+## MongoClient: create one, reuse it
+
+The single most important rule: **`MongoClient` is meant to be created once and reused for the lifetime of your application.** It manages an internal connection pool. Creating a new `MongoClient` per request or per operation defeats the pool, leaks sockets, and will exhaust connections under load.
+
+Register it as a singleton:
+
+```csharp
+using MongoDB.Driver;
+
+var client = new MongoClient("mongodb://localhost:27017");
+// reuse `client` everywhere
+```
+
+In ASP.NET Core:
+
+```csharp
+builder.Services.AddSingleton<IMongoClient>(_ =>
+    new MongoClient(builder.Configuration.GetConnectionString("Mongo")));
+```
+
+`MongoClient` is thread-safe by design. `IMongoDatabase` and `IMongoCollection<T>` are also thread-safe and cheap to obtain from the client, so you can fetch them per operation or cache them; both are fine.
+
+## Lazy connection
+
+Constructing a `MongoClient` does **not** connect. It returns immediately and the driver connects lazily on the first real operation in the background. That means a wrong host or down server does not throw at construction; it throws when you run your first query, typically as a `TimeoutException` after server selection times out (30 seconds by default).
+
+To verify connectivity at startup, run a ping and fail fast:
+
+```csharp
+var db = client.GetDatabase("admin");
+await db.RunCommandAsync<BsonDocument>(new BsonDocument("ping", 1));
+```
+
+## A first query: typed documents
+
+The idiomatic approach maps collections to your own C# types. Define a class, get a typed collection, and query with a filter:
+
+```csharp
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Driver;
+
+public class User
+{
+    [BsonId]
+    public ObjectId Id { get; set; }
+    public string Email { get; set; } = "";
+    public bool Active { get; set; }
+}
+
+var db = client.GetDatabase("appdb");
+var users = db.GetCollection<User>("users");
+
+var filter = Builders<User>.Filter.Eq(u => u.Active, true);
+var active = await users.Find(filter).ToListAsync();
+
+foreach (var u in active)
+    Console.WriteLine($"{u.Id}: {u.Email}");
+```
+
+`[BsonId]` maps a property to the document's `_id`. The default `_id` type is `ObjectId` (a 12-byte value, not a GUID); if you want your own id type, set it explicitly and the driver will respect it.
+
+## Insert, update, delete
+
+```csharp
+// Insert
+await users.InsertOneAsync(new User { Email = "a@example.com", Active = true });
+
+// Update
+var filter = Builders<User>.Filter.Eq(u => u.Email, "a@example.com");
+var update = Builders<User>.Update.Set(u => u.Active, false);
+await users.UpdateOneAsync(filter, update);
+
+// Delete
+await users.DeleteOneAsync(filter);
+```
+
+Use the async methods throughout. Synchronous equivalents exist (`Find(...).ToList()`, `InsertOne`) but block a thread on a network round trip; in a server app prefer async.
+
+A common trap with updates: `ReplaceOneAsync` swaps the **entire** document, dropping any fields not present in the replacement object. Use `UpdateOneAsync` with `Builders<T>.Update` operators when you mean to change specific fields. See [MongoDB update operators](/guides/mongodb/update-operators) for the full set.
+
+## Typed vs BSON documents
+
+If you do not have (or want) a fixed C# class, work with `BsonDocument` directly:
+
+```csharp
+var coll = db.GetCollection<BsonDocument>("users");
+var filter = new BsonDocument("active", true);
+var docs = await coll.Find(filter).ToListAsync();
+
+foreach (var doc in docs)
+    Console.WriteLine(doc["email"].AsString);
+```
+
+Typed classes give you compile-time safety and IntelliSense; `BsonDocument` gives you flexibility for dynamic or schema-loose data. Most applications use typed classes and reach for `BsonDocument` only for ad hoc or migration code.
+
+## Connection strings and SRV
+
+The standard form is `mongodb://`. For replica sets and Atlas you usually get the `mongodb+srv://` form, which uses a DNS SRV record to discover the cluster members:
+
+```
+mongodb+srv://user:pass@cluster0.abcde.mongodb.net/?retryWrites=true&w=majority
+```
+
+A few things that trip people up:
+
+- **`mongodb+srv://` implies TLS.** You do not add a separate TLS flag; SRV connection strings enable TLS by default.
+- **Percent-encode credentials.** If your username or password contains `@`, `:`, `/`, or other reserved characters, URL-encode them or the string fails to parse.
+- **authSource is not the database you query.** Authentication happens against the database where the user was created (often `admin`), set via `authSource`. Querying `appdb` while the user lives in `admin` needs `?authSource=admin`. A wrong `authSource` produces an authentication failure even with correct credentials.
+
+## Atlas specifics
+
+For MongoDB Atlas, two non-driver things cause most "it works locally but not in the cloud" reports:
+
+- **IP allowlist.** Atlas blocks all inbound connections except allowlisted IPs. Add your app's egress IP (or `0.0.0.0/0` only for throwaway testing) in the Atlas Network Access panel.
+- **SRV DNS resolution.** `mongodb+srv://` needs working DNS SRV lookups from your host. Some locked-down container networks block this; if SRV fails, the driver cannot discover the cluster.
+
+## Pooling
+
+The driver maintains a connection pool per `MongoClient`, controlled in the connection string:
+
+```
+mongodb://host:27017/?maxPoolSize=100&minPoolSize=0
+```
+
+`maxPoolSize` defaults to 100. The relevant ceiling is the cluster's connection limit (and on Atlas, the tier's connection cap): `maxPoolSize` multiplied by the number of running app instances must stay under it. Oversizing the pool across many instances is a frequent cause of Atlas connection-limit errors.
+
+## LINQ
+
+The driver ships a LINQ provider, so you can query with LINQ syntax that is translated to the aggregation framework server-side:
+
+```csharp
+using MongoDB.Driver.Linq;
+
+var active = await users.AsQueryable()
+    .Where(u => u.Active)
+    .OrderBy(u => u.Email)
+    .ToListAsync();
+```
+
+The translation is genuine server-side execution, not in-memory filtering, as long as your expression maps to supported operators. Expressions the provider cannot translate throw at execution time rather than silently pulling the whole collection, which is the behavior you want.
+
+## Graceful shutdown
+
+`MongoClient` does not need explicit disposal in most apps; registering it as a singleton and letting the process exit is fine. If you want deterministic cleanup (for example in a short-lived console tool), there is no `Dispose` to call on older patterns, but the modern driver's client is safe to simply let go of when the app ends.
+
+## Common errors
+
+| Error | Cause | Fix |
+|---|---|---|
+| `TimeoutException` on first operation | Wrong host/port, server down, or lazy-connect surfacing late | Ping at startup to fail fast; check host and that the server is reachable |
+| Authentication failed (correct password) | Wrong `authSource` | Set `?authSource=admin` (or wherever the user was created) |
+| Connection refused on `localhost` | Driver resolved `localhost` to IPv6 `::1`, server on IPv4 | Use `127.0.0.1` explicitly |
+| Atlas connection times out | IP not allowlisted, or SRV DNS blocked | Allowlist your egress IP; confirm SRV lookups work |
+| Fields silently lost after update | Used `ReplaceOneAsync` | Use `UpdateOneAsync` with `Builders.Update` operators |
+| Connection-limit errors under load | `maxPoolSize` × instances exceeds cluster cap | Lower `maxPoolSize`; size against the tier's connection limit |
+
+For working with documents once connected, see [the MongoDB aggregation pipeline](/guides/mongodb/aggregation-pipeline), [query operators](/guides/mongodb/query-operators), and [indexes explained](/guides/mongodb/indexes-explained).
+
+Mako connects to MongoDB, PostgreSQL, MySQL, and more with AI-powered autocomplete for writing and exploring queries. Try it free at mako.ai.

--- a/content/guides/mysql/connect-from-csharp.mdx
+++ b/content/guides/mysql/connect-from-csharp.mdx
@@ -1,0 +1,166 @@
+---
+title: "How to Connect to MySQL from C# (.NET)"
+description: "Connect to MySQL from C# with MySqlConnector: ADO.NET basics, async commands, parameters, pooling, Dapper and EF Core, the MySql.Data vs MySqlConnector choice, SSL, and the errors you actually hit."
+database: "mysql"
+category: "how-to"
+tags: ["mysql", "csharp", "dotnet", "mysqlconnector", "dapper", "ef-core", "connection"]
+date: "2026-06-22"
+---
+
+Connecting to MySQL from .NET starts with a decision most other databases do not force on you: there are two ADO.NET drivers, and they are not equivalent. This guide explains the choice, shows the raw ADO.NET connection code, then layers on Dapper and EF Core, and covers the MySQL-specific traps around authentication, time zones, and SSL.
+
+## Two drivers: MySqlConnector vs MySql.Data
+
+| Driver | NuGet package | Notes |
+|---|---|---|
+| MySqlConnector | `MySqlConnector` | Open-source, async-first rewrite of the ADO.NET API. Recommended for new code. |
+| Connector/NET (MySql.Data) | `MySql.Data` | Oracle's official driver. Historically implemented async as sync-over-async, which can deadlock or block threads. |
+
+Both expose the same ADO.NET types (`MySqlConnection`, `MySqlCommand`), so most code looks identical. The practical difference is that MySqlConnector was built async from the ground up and tends to behave better under concurrency, while MySql.Data is the vendor-blessed option that some tooling and Oracle support expect. For a new application, MySqlConnector (current stable 2.6.0 as of June 2026) is the common recommendation. If you must use the official driver for support reasons, MySql.Data is at 9.7.0.
+
+The rest of this guide uses MySqlConnector. The API is the same if you switch, but the namespace differs (`MySqlConnector` vs `MySql.Data.MySqlClient`).
+
+```bash
+dotnet add package MySqlConnector
+```
+
+## A first connection with ADO.NET
+
+```csharp
+using MySqlConnector;
+
+var connString = "Server=localhost;Port=3306;User ID=root;Password=secret;Database=appdb";
+
+await using var conn = new MySqlConnection(connString);
+await conn.OpenAsync();
+
+await using var cmd = new MySqlCommand(
+    "SELECT id, email FROM users WHERE active = @active", conn);
+cmd.Parameters.AddWithValue("@active", true);
+
+await using var reader = await cmd.ExecuteReaderAsync();
+while (await reader.ReadAsync())
+{
+    Console.WriteLine($"{reader.GetInt32(0)}: {reader.GetString(1)}");
+}
+```
+
+Use the async methods in server code. The synchronous calls block a thread for the network round trip; with MySql.Data specifically, the async methods historically degrade to sync-over-async, which is another reason to prefer MySqlConnector when you actually need non-blocking I/O.
+
+## Parameters and the generated key
+
+Bind values; never concatenate them into the SQL.
+
+```csharp
+await using var cmd = new MySqlCommand(
+    "INSERT INTO users (email, age) VALUES (@email, @age)", conn);
+cmd.Parameters.AddWithValue("@email", "a@example.com");
+cmd.Parameters.AddWithValue("@age", 30);
+await cmd.ExecuteNonQueryAsync();
+
+long newId = cmd.LastInsertedId;
+```
+
+Unlike PostgreSQL's `RETURNING`, MySQL gives you the auto-increment value through `LastInsertedId` after the insert, which maps to `LAST_INSERT_ID()`.
+
+## Character set: use utf8mb4
+
+MySQL's legacy `utf8` is a three-byte encoding that cannot store four-byte characters such as emoji or some CJK glyphs. Always use `utf8mb4`, both on the table and on the connection. MySqlConnector defaults to `utf8mb4`, so the main thing to get right is the column and table definitions:
+
+```sql
+CREATE TABLE users (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  email VARCHAR(255)
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+```
+
+## Connection pooling
+
+Pooling is on by default. The pool size is controlled in the connection string:
+
+```
+Server=localhost;User ID=root;Password=secret;Database=appdb;Maximum Pool Size=100;Minimum Pool Size=0
+```
+
+`Maximum Pool Size` defaults to 100. As with any database, the constraint is total connections across all application instances versus MySQL's `max_connections` (default 151). If several instances each open a full pool you will exceed the server limit. Size the pool so `instances x max pool` stays under `max_connections` with headroom.
+
+A connection-string convenience worth knowing in MySqlConnector: `ConnectionReset` controls whether each pooled connection is reset on reuse. The defaults are safe; only change them if you have profiled a specific reason.
+
+## Dapper
+
+Dapper layers object mapping on top of either MySQL driver.
+
+```csharp
+using Dapper;
+
+public record User(int Id, string Email, int Age);
+
+await using var conn = new MySqlConnection(connString);
+
+var users = await conn.QueryAsync<User>(
+    "SELECT id, email, age FROM users WHERE age > @minAge",
+    new { minAge = 18 });
+```
+
+Dapper binds anonymous-object properties to `@named` parameters, so it is injection-safe and you keep full control of the SQL.
+
+## EF Core
+
+For MySQL with EF Core, the widely used provider is Pomelo (`Pomelo.EntityFrameworkCore.MySql`), which is built on MySqlConnector. Oracle also ships `MySql.EntityFrameworkCore` on top of MySql.Data.
+
+```bash
+dotnet add package Pomelo.EntityFrameworkCore.MySql
+```
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+
+protected override void OnConfiguring(DbContextOptionsBuilder options)
+    => options.UseMySql(connString, ServerVersion.AutoDetect(connString));
+```
+
+`ServerVersion.AutoDetect` opens a connection at startup to learn the server version, which Pomelo uses to enable version-specific SQL. In environments where you would rather not connect at configuration time, pass an explicit `ServerVersion.Create(...)` instead. Match the provider major version to your EF Core major version.
+
+## SSL
+
+MySqlConnector controls TLS through `SSL Mode`:
+
+```
+Server=db.example.com;User ID=app;Password=secret;Database=appdb;SSL Mode=VerifyFull
+```
+
+| SSL Mode | Behavior |
+|---|---|
+| `None` | No TLS. |
+| `Preferred` | TLS if available, else plaintext. The default. |
+| `Required` | Demand TLS, no certificate validation. |
+| `VerifyCA` | Require TLS and validate the certificate chain. |
+| `VerifyFull` | Validate chain and hostname. Use this over a network. |
+
+Managed MySQL (Amazon RDS, Azure Database for MySQL, PlanetScale) requires TLS. Use `VerifyFull` with the provider's CA root rather than `Required`, which skips validation.
+
+## Authentication: caching_sha2_password
+
+MySQL 8.0 and later default to the `caching_sha2_password` authentication plugin. MySqlConnector supports it. Two things commonly trip people up:
+
+- Over a non-TLS connection, `caching_sha2_password` needs the server's RSA public key to send the password securely on first authentication. Either connect over TLS (recommended) or allow public-key retrieval.
+- MySQL 9 removed the older `mysql_native_password` plugin entirely. Code or accounts that depended on it will fail to authenticate until the user is migrated to `caching_sha2_password`.
+
+## Time zones
+
+A frequent source of wrong timestamps: store and reason in UTC. MySqlConnector returns `DATETIME` values without a zone, so decide on a convention and apply it consistently. If you use the connection-string time-zone handling, set it explicitly rather than relying on the server's session zone, which may differ between environments.
+
+## Errors you will actually hit
+
+| Error | Cause | Fix |
+|---|---|---|
+| `Access denied for user 'x'@'host'` | Wrong credentials or the account is not allowed from your host | Check user/password and the account's host pattern (`'app'@'%'` vs `'app'@'localhost'`) |
+| `Unknown database 'x'` | Database missing or typo in `Database=` | Create it or fix the name |
+| `Unable to connect to any of the specified MySQL hosts` | Server down, wrong host/port, firewall | Check `Server`/`Port`, that MySQL is listening, and firewall rules |
+| `Authentication method 'caching_sha2_password' ... requires SSL` | Non-TLS connection on MySQL 8+ default auth | Connect over TLS or enable public-key retrieval |
+| `Too many connections` | Pool max x instances exceeds `max_connections` | Lower `Maximum Pool Size` or raise the server limit |
+| `Incorrect string value` | Inserting four-byte characters into a legacy `utf8` column | Convert the column and connection to `utf8mb4` |
+
+## Where Mako fits
+
+Mako connects to MySQL with AI-assisted SQL autocomplete, useful for exploring tables before you wire up MySqlConnector, Dapper, or EF Core in your application. It is a read and query tool, not a connection library: your app code still uses a driver. Try it free at mako.ai.

--- a/content/guides/postgresql/connect-from-csharp.mdx
+++ b/content/guides/postgresql/connect-from-csharp.mdx
@@ -1,0 +1,192 @@
+---
+title: "How to Connect to PostgreSQL from C# (.NET)"
+description: "Connect to PostgreSQL from C# with Npgsql: ADO.NET basics, async commands, parameters, connection pooling, NpgsqlDataSource, Dapper and EF Core, SSL, and the errors you actually hit."
+database: "postgresql"
+category: "how-to"
+tags: ["postgresql", "csharp", "dotnet", "npgsql", "dapper", "ef-core", "connection"]
+date: "2026-06-22"
+---
+
+In .NET, PostgreSQL has one driver that matters: Npgsql (`Npgsql` on NuGet). It is the ADO.NET data provider for PostgreSQL, and everything else in the ecosystem sits on top of it: Dapper executes its SQL through Npgsql, and Entity Framework Core's PostgreSQL provider (`Npgsql.EntityFrameworkCore.PostgreSQL`) wraps it as well. This guide starts with raw ADO.NET, then layers on pooling, Dapper, and EF Core, and ends with the SSL and authentication errors you will actually hit.
+
+## The one driver, and what sits on it
+
+| Library | Layer | When to use |
+|---|---|---|
+| Npgsql | ADO.NET driver | Always. The actual wire-protocol driver. |
+| Dapper | Micro-ORM over ADO.NET | You want to write SQL and map results to objects with almost no boilerplate. |
+| Npgsql.EntityFrameworkCore.PostgreSQL | EF Core provider | Full ORM: LINQ, change tracking, migrations. Uses Npgsql underneath. |
+| Npgsql.DependencyInjection | DI helper | Registering `NpgsqlDataSource` in ASP.NET Core. |
+
+For a normal application you need Npgsql plus one of Dapper or EF Core. You never talk to PostgreSQL without Npgsql somewhere in the stack.
+
+## Adding the package
+
+```bash
+dotnet add package Npgsql
+```
+
+Npgsql 10.0 (current stable as of June 2026) targets modern .NET (.NET 8 and later). Npgsql 8.0 was the last release to support .NET Framework via .NET Standard 2.0; if you are still on .NET Framework, pin to the 8.x line.
+
+## A first connection with ADO.NET
+
+The raw ADO.NET pattern is `NpgsqlConnection` to `NpgsqlCommand` to a reader. Everything is `IDisposable`, so wrap it in `using` so connections return to the pool deterministically.
+
+```csharp
+using Npgsql;
+
+var connString = "Host=localhost;Port=5432;Username=postgres;Password=secret;Database=appdb";
+
+await using var conn = new NpgsqlConnection(connString);
+await conn.OpenAsync();
+
+await using var cmd = new NpgsqlCommand("SELECT id, email FROM users WHERE active = @active", conn);
+cmd.Parameters.AddWithValue("active", true);
+
+await using var reader = await cmd.ExecuteReaderAsync();
+while (await reader.ReadAsync())
+{
+    var id = reader.GetInt32(0);
+    var email = reader.GetString(1);
+    Console.WriteLine($"{id}: {email}");
+}
+```
+
+Use the async methods (`OpenAsync`, `ExecuteReaderAsync`, `ReadAsync`) in any server application. The synchronous versions block a thread pool thread for the duration of the network round trip, which scales badly under load.
+
+## Parameters: never concatenate
+
+The `@name` placeholder is how you avoid SQL injection. Npgsql binds the value separately from the query text.
+
+```csharp
+await using var cmd = new NpgsqlCommand(
+    "INSERT INTO users (email, age) VALUES (@email, @age) RETURNING id", conn);
+cmd.Parameters.AddWithValue("email", "a@example.com");
+cmd.Parameters.AddWithValue("age", 30);
+
+var newId = (int)(await cmd.ExecuteScalarAsync())!;
+```
+
+`AddWithValue` infers the PostgreSQL type from the .NET type, which is fine most of the time. When you need an exact type (for example to disambiguate `text` from `jsonb`, or to send a `NULL` of a specific type), use the typed overload:
+
+```csharp
+cmd.Parameters.Add(new NpgsqlParameter("data", NpgsqlTypes.NpgsqlDbType.Jsonb) { Value = jsonString });
+```
+
+Note PostgreSQL uses `RETURNING` to get the generated key back in the same round trip. There is no separate "last insert id" call as in MySQL.
+
+## NpgsqlDataSource: the modern entry point
+
+Since Npgsql 7.0, the recommended way to manage connections is `NpgsqlDataSource`, not raw connection strings passed around your code. A data source owns the pool and is the object you should create once and reuse for the life of the application.
+
+```csharp
+await using var dataSource = NpgsqlDataSource.Create(connString);
+
+await using var cmd = dataSource.CreateCommand("SELECT count(*) FROM users");
+var count = (long)(await cmd.ExecuteScalarAsync())!;
+```
+
+In ASP.NET Core, register it once with DI and inject `NpgsqlDataSource` (or `NpgsqlConnection`) wherever you need it:
+
+```csharp
+builder.Services.AddNpgsqlDataSource(connString);
+```
+
+This requires the `Npgsql.DependencyInjection` package. Resolve `NpgsqlDataSource` from the container; do not `new` up a data source per request, because each one carries its own pool.
+
+## Connection pooling
+
+Npgsql pools connections automatically and the pool is on by default. The connection string controls it:
+
+```
+Host=localhost;Username=postgres;Password=secret;Database=appdb;Minimum Pool Size=0;Maximum Pool Size=100
+```
+
+`Maximum Pool Size` defaults to 100. The number that matters is total connections across all your application instances versus PostgreSQL's `max_connections` (default 100). Five app instances each opening 100 connections is 500 connections against a server that allows 100, and the surplus get refused. Size `Maximum Pool Size` so that `instances x max pool` stays under `max_connections`, leaving headroom for admin connections.
+
+If you front PostgreSQL with PgBouncer in transaction-pooling mode, disable server-side prepared statement caching by adding `Max Auto Prepare=0` and avoid persistent prepared statements, because they break under transaction pooling.
+
+## Dapper: SQL with object mapping
+
+Dapper (current stable 2.1.79 as of June 2026) is a set of extension methods on `IDbConnection`. You still write SQL; Dapper handles parameter binding and maps result columns to your types.
+
+```csharp
+using Dapper;
+
+public record User(int Id, string Email, int Age);
+
+await using var conn = dataSource.OpenConnection();
+
+var users = await conn.QueryAsync<User>(
+    "SELECT id, email, age FROM users WHERE age > @minAge",
+    new { minAge = 18 });
+
+var one = await conn.QuerySingleOrDefaultAsync<User>(
+    "SELECT id, email, age FROM users WHERE id = @id",
+    new { id = 42 });
+```
+
+Dapper binds anonymous-object properties to named parameters, so injection safety is the same as raw Npgsql. It does no change tracking and generates no SQL for you, which is the point: you keep full control of the query.
+
+## EF Core: the full ORM
+
+For LINQ, migrations, and change tracking, use the Npgsql EF Core provider.
+
+```bash
+dotnet add package Npgsql.EntityFrameworkCore.PostgreSQL
+```
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+
+public class AppDbContext : DbContext
+{
+    public DbSet<User> Users => Set<User>();
+
+    protected override void OnConfiguring(DbContextOptionsBuilder options)
+        => options.UseNpgsql(connString);
+}
+
+// querying
+using var db = new AppDbContext();
+var adults = await db.Users.Where(u => u.Age >= 18).ToListAsync();
+```
+
+As of June 2026 the stable EF Core line is 10.x; match your `Npgsql.EntityFrameworkCore.PostgreSQL` major version to your EF Core major version (provider 10.x for EF Core 10). EF Core 11 exists only as preview at this time, so do not pin production to it.
+
+The long-running benchmark wisdom that "Dapper is several times faster than EF Core" has narrowed considerably in recent versions; for most CRUD workloads EF Core is fast enough and the productivity wins, while Dapper still pulls ahead for hot paths where you want hand-tuned SQL. A hybrid (EF Core for most of the app, Dapper for a few hot queries) is a common and reasonable choice.
+
+## SSL and the connection-security settings
+
+Npgsql controls TLS through `SSL Mode` in the connection string:
+
+```
+Host=db.example.com;Username=app;Password=secret;Database=appdb;SSL Mode=VerifyFull
+```
+
+| SSL Mode | Behavior |
+|---|---|
+| `Disable` | No TLS. Local only. |
+| `Prefer` | Use TLS if the server offers it, otherwise plaintext. |
+| `Require` | Demand TLS, but do not validate the server certificate. |
+| `VerifyCA` | Require TLS and validate the certificate chain. |
+| `VerifyFull` | Validate the chain and that the hostname matches. Use this for anything over a network. |
+
+Managed PostgreSQL (Azure Database for PostgreSQL, Amazon RDS, Supabase) requires TLS. Reach for `VerifyFull` and supply the provider's CA root rather than reflexively dropping to `Require`, which silently skips certificate validation and leaves you open to interception.
+
+## Errors you will actually hit
+
+| Error | Cause | Fix |
+|---|---|---|
+| `28P01: password authentication failed` | Wrong password or user, or `pg_hba.conf` rejects the auth method | Check credentials; confirm `pg_hba.conf` allows `scram-sha-256` from your host |
+| `3D000: database "x" does not exist` | Database not created, or typo in `Database=` | Create it, or correct the name |
+| `Npgsql.NpgsqlException: connection ... was refused` | Server not listening on host/port, or firewall | Check `Host`/`Port`, `listen_addresses`, and firewall rules |
+| `53300: too many clients already` | Pool max x instances exceeds server `max_connections` | Lower `Maximum Pool Size` or raise server `max_connections`/use PgBouncer |
+| `The remote certificate is invalid` | `VerifyFull`/`VerifyCA` without a trusted CA root | Install the provider's CA certificate; do not drop to `Require` in production |
+| `System.InvalidOperationException: An open data reader` | A reader is still open on the connection when you run another command | Finish reading (or use a new connection); set `Multiplexing` if you need concurrent commands |
+
+The "open data reader" error is the most common ADO.NET surprise: a single `NpgsqlConnection` runs one command at a time, so dispose readers (the `await using` pattern) before issuing the next command, or use separate connections from the pool.
+
+## Where Mako fits
+
+Mako connects to PostgreSQL with AI-assisted SQL autocomplete, which is handy when you are exploring a schema before you wire up Npgsql, Dapper, or EF Core. It is a read and query tool, not a connection library: you still use Npgsql in your application code. Try it free at mako.ai.

--- a/content/guides/sqlite/connect-from-csharp.mdx
+++ b/content/guides/sqlite/connect-from-csharp.mdx
@@ -1,0 +1,226 @@
+---
+title: "How to Connect to SQLite from C# (.NET)"
+description: "Connect to SQLite from C# with Microsoft.Data.Sqlite: ADO.NET basics, async, parameters, transactions, WAL and busy_timeout, Dapper and EF Core, plus System.Data.SQLite and the errors you actually hit."
+database: "sqlite"
+category: "how-to"
+tags: ["sqlite", "csharp", "dotnet", "microsoft-data-sqlite", "dapper", "ef-core", "connection"]
+date: "2026-06-23"
+---
+
+SQLite in .NET comes down to two providers: Microsoft.Data.Sqlite and System.Data.SQLite. For new code, Microsoft.Data.Sqlite is the default choice. It is the lightweight, cross-platform ADO.NET provider the Entity Framework Core team built and maintains, and it bundles the native SQLite library so there is nothing to install at the OS level. System.Data.SQLite is the older provider from the SQLite authors themselves; it carries more features (encryption, a full LINQ-to-Entities legacy stack) but a heavier footprint. This guide starts with raw ADO.NET on Microsoft.Data.Sqlite, then covers the SQLite-specific traps (file creation, locking, WAL), then layers on Dapper and EF Core.
+
+## The two providers
+
+| Library | Maintainer | When to use |
+|---|---|---|
+| Microsoft.Data.Sqlite | .NET / EF Core team | New code. Lightweight, cross-platform, bundles native SQLite. |
+| System.Data.SQLite | SQLite developers (Hipp et al.) | You need built-in encryption (SEE/legacy), or you are on a long-lived .NET Framework codebase already using it. |
+
+Unless you have a specific reason to pick System.Data.SQLite, use Microsoft.Data.Sqlite. The rest of this guide uses it; a short System.Data.SQLite section is at the end.
+
+## Adding the package
+
+```bash
+dotnet add package Microsoft.Data.Sqlite
+```
+
+Microsoft.Data.Sqlite 10.0 (current stable as of June 2026) targets modern .NET. The `Microsoft.Data.Sqlite` package pulls in the bundled native library (SQLitePCLRaw) automatically, so it works out of the box on Windows, Linux, and macOS. There is no separate "install SQLite" step.
+
+## A first connection with ADO.NET
+
+SQLite is a file, not a server, so the connection string is mostly a path. The pattern is the standard ADO.NET one: `SqliteConnection` to `SqliteCommand` to a reader.
+
+```csharp
+using Microsoft.Data.Sqlite;
+
+var connString = "Data Source=app.db";
+
+using var conn = new SqliteConnection(connString);
+conn.Open();
+
+using var cmd = conn.CreateCommand();
+cmd.CommandText = "SELECT id, email FROM users WHERE active = $active";
+cmd.Parameters.AddWithValue("$active", 1);
+
+using var reader = cmd.ExecuteReader();
+while (reader.Read())
+{
+    var id = reader.GetInt64(0);
+    var email = reader.GetString(1);
+    Console.WriteLine($"{id}: {email}");
+}
+```
+
+Note `GetInt64`: SQLite's integer type is 64-bit, so map it to `long`, not `int`. Async methods (`OpenAsync`, `ExecuteReaderAsync`, `ReadAsync`) exist and are worth using in a server app, but for SQLite the I/O is a local file rather than a network round trip, so the win is smaller than with a client/server database. Still use them in ASP.NET to avoid blocking thread pool threads.
+
+## The file-creation trap
+
+By default, opening a connection to a path that does not exist **creates an empty database file**. That means a typo in the path silently gives you a brand-new, empty database instead of an error, and your queries fail with "no such table".
+
+If you want to fail loudly when the file is missing, set the open mode:
+
+```csharp
+var connString = new SqliteConnectionStringBuilder
+{
+    DataSource = "app.db",
+    Mode = SqliteOpenMode.ReadWrite  // do NOT create if missing
+}.ToString();
+```
+
+`SqliteOpenMode` options: `ReadWriteCreate` (default, creates if missing), `ReadWrite`, `ReadOnly`, and `Memory`. For an in-memory database use `Mode=Memory` (data lives only as long as the connection is open; see the connection-lifetime note below).
+
+## Parameters: never concatenate
+
+Microsoft.Data.Sqlite accepts `$name`, `@name`, and `:name` placeholders. `$name` is the SQLite-native form and the one the provider recommends. Bind values rather than building SQL strings:
+
+```csharp
+cmd.CommandText = "INSERT INTO users (email, active) VALUES ($email, $active)";
+cmd.Parameters.AddWithValue("$email", "a@example.com");
+cmd.Parameters.AddWithValue("$active", 1);
+cmd.ExecuteNonQuery();
+```
+
+SQLite has no `bool` type; store booleans as `0`/`1` integers. There is also no native `DateTime`: Microsoft.Data.Sqlite stores `DateTime` as TEXT in ISO 8601 format by default, which sorts and compares correctly. Just be consistent, and read it back with `GetDateTime`.
+
+## Getting the inserted row id
+
+SQLite exposes the last inserted rowid through `last_insert_rowid()`, or you can use a `RETURNING` clause (SQLite 3.35+, which the bundled library is well past):
+
+```csharp
+cmd.CommandText = "INSERT INTO users (email) VALUES ($email) RETURNING id";
+cmd.Parameters.AddWithValue("$email", "a@example.com");
+var newId = (long)cmd.ExecuteScalar()!;
+```
+
+## Transactions
+
+Wrapping many writes in a single transaction is the single biggest performance lever in SQLite. Without one, each `INSERT` is its own transaction with its own disk sync, which is slow. Batch them:
+
+```csharp
+using var tx = conn.BeginTransaction();
+using var cmd = conn.CreateCommand();
+cmd.Transaction = tx;
+cmd.CommandText = "INSERT INTO events (name) VALUES ($name)";
+var p = cmd.CreateParameter();
+p.ParameterName = "$name";
+cmd.Parameters.Add(p);
+
+foreach (var name in names)
+{
+    p.Value = name;
+    cmd.ExecuteNonQuery();
+}
+tx.Commit();
+```
+
+Reuse the command and just swap the parameter value inside the loop. Tens of thousands of inserts per second per transaction is normal; the same inserts without a transaction can be hundreds of times slower.
+
+## "database is locked": WAL and busy_timeout
+
+SQLite allows one writer at a time. If a second connection tries to write while another write is in progress, you get `SQLITE_BUSY` surfaced as a `SqliteException` with "database is locked". Two settings handle the common cases:
+
+```csharp
+using var conn = new SqliteConnection("Data Source=app.db");
+conn.Open();
+
+using (var pragma = conn.CreateCommand())
+{
+    pragma.CommandText = "PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;";
+    pragma.ExecuteNonQuery();
+}
+```
+
+- **WAL (write-ahead logging)** lets readers run concurrently with a writer, which removes most contention in a read-heavy app. It is a persistent setting on the database file, so you only need to set it once, but setting it per-connection is harmless.
+- **busy_timeout** tells SQLite to wait (here, 5000 ms) for a lock to clear instead of failing immediately. Without it, a momentary lock throws right away.
+
+WAL plus a busy timeout resolves the large majority of "database is locked" reports. It does not make SQLite a high-concurrency multi-writer database; if you genuinely need many concurrent writers, that is the signal to move to a client/server database.
+
+## Connection lifetime and pooling
+
+Microsoft.Data.Sqlite pools connections by default, so the open/close cost of file-backed databases is cheap and the standard `using` pattern is correct: open late, dispose early.
+
+One exception: an in-memory database (`Mode=Memory`) is destroyed when its last connection closes. If you open, write, and close, the data is gone. To keep an in-memory database alive across operations, either hold one connection open for the lifetime you need, or use a shared cache (`Data Source=...;Mode=Memory;Cache=Shared`) and keep at least one connection open.
+
+## Dapper
+
+Dapper works on any ADO.NET connection, so it layers onto `SqliteConnection` directly. Add it:
+
+```bash
+dotnet add package Dapper
+```
+
+```csharp
+using Dapper;
+using Microsoft.Data.Sqlite;
+
+using var conn = new SqliteConnection("Data Source=app.db");
+
+var users = conn.Query<User>(
+    "SELECT id, email FROM users WHERE active = $active",
+    new { active = 1 });
+
+record User(long Id, string Email);
+```
+
+Dapper opens the connection if it is closed and maps columns to your type by name. Dapper 2.1.79 is current as of June 2026.
+
+## Entity Framework Core
+
+For a full ORM, the EF Core SQLite provider sits on Microsoft.Data.Sqlite:
+
+```bash
+dotnet add package Microsoft.EntityFrameworkCore.Sqlite
+```
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+
+public class AppDb : DbContext
+{
+    public DbSet<User> Users => Set<User>();
+
+    protected override void OnConfiguring(DbContextOptionsBuilder options)
+        => options.UseSqlite("Data Source=app.db");
+}
+
+public class User
+{
+    public long Id { get; set; }
+    public string Email { get; set; } = "";
+}
+```
+
+Match the EF Core provider's major version to your other EF Core packages: provider 10.x goes with EF Core 10.x. Be aware SQLite has a deliberately limited type and schema system, so some EF Core migrations (dropping a column, altering a column type) require a table rebuild that EF Core handles for you but that you should understand before relying on it in production.
+
+## System.Data.SQLite (the other provider)
+
+If you specifically need it (encryption, or an existing codebase):
+
+```bash
+dotnet add package System.Data.SQLite.Core
+```
+
+```csharp
+using System.Data.SQLite;
+
+using var conn = new SQLiteConnection("Data Source=app.db;Version=3;");
+conn.Open();
+using var cmd = new SQLiteCommand("SELECT id, email FROM users", conn);
+using var reader = cmd.ExecuteReader();
+```
+
+System.Data.SQLite.Core 1.0.119 is current as of June 2026. The class names use `SQLite` (capitalized), the connection string carries a `Version=3` segment, and the default parameter prefix is `@`. The API shape is otherwise familiar. It tracks SQLite releases closely and supports the SQLite Encryption Extension, which Microsoft.Data.Sqlite does not bundle.
+
+## Common errors
+
+| Error | Cause | Fix |
+|---|---|---|
+| `no such table` after a path typo | Wrong path created a new empty file | Use `Mode=ReadWrite` to fail on missing file; check the resolved absolute path |
+| `database is locked` (SQLITE_BUSY) | Concurrent writer | `PRAGMA journal_mode=WAL` and `PRAGMA busy_timeout` |
+| In-memory data disappears | Last connection closed | Keep one connection open, or use `Cache=Shared` |
+| `InvalidCastException` reading an integer | Read SQLite INTEGER as `int` | SQLite integers are 64-bit; use `GetInt64`/`long` |
+| Native library load failure | Wrong package on a trimmed/AOT build | Use the bundled `Microsoft.Data.Sqlite` (not `.Core` without a SQLitePCLRaw bundle) |
+
+For loading data into SQLite from files, see our guide on [importing CSV to SQLite](/guides/sqlite/import-csv-to-sqlite). For querying patterns once connected, see [SQLite window functions](/guides/sqlite/window-functions) and [CTEs in SQLite](/guides/sqlite/cte).
+
+Mako connects to SQLite, PostgreSQL, MySQL, and more with AI-powered autocomplete for writing and exploring queries. Try it free at mako.ai.


### PR DESCRIPTION
Batch 12: C#/.NET connection guides. 4 of 9 DBs done.

- postgresql/connect-from-csharp — Npgsql 10.0.3
- mysql/connect-from-csharp — MySqlConnector vs MySql.Data
- sqlite/connect-from-csharp — Microsoft.Data.Sqlite 10.0.9 vs System.Data.SQLite.Core 1.0.119
- mongodb/connect-from-csharp — MongoDB.Driver 3.9.0

Remaining: clickhouse, bigquery, snowflake, mariadb, mssql. All driver versions verified live via NuGet. No em dashes, no banned words.