### PR TITLE
Cut long-chat token cost + speed up chat rendering on mobile

### DIFF
--- a/.cursor/rules/75-chat-performance.mdc
+++ b/.cursor/rules/75-chat-performance.mdc
@@ -54,23 +54,42 @@ When you need a fresh value inside `onToolCall` or `prepareSendMessagesRequest`,
 call `useConsoleStore.getState()` at invocation time rather than closing over
 render-time state.
 
-## Auto-scroll contract (`use-stick-to-bottom`)
+## Virtualized message list + auto-scroll (`react-virtuoso`)
 
-Auto-scroll uses the **`use-stick-to-bottom`** library (same library used in
-Vercel's official `ai-chatbot` template). It observes container/content resizes
-via `ResizeObserver` and uses spring-based animations — no `useEffect([messages])`
-or `MutationObserver` hacks.
+The message list is **virtualized with `react-virtuoso`**. Only on-screen rows
+(plus a viewport overscan) are mounted in the DOM. This keeps the DOM node count
+roughly constant regardless of chat length — essential for mobile Safari, which
+crawls once a long chat accumulates thousands of nodes.
 
-Key pieces:
-- `scrollContainerRef` / `scrollContentRef` — refs from `useStickToBottom()` hook,
-  attached to the outer scroll `<Box>` and inner content `<div>` respectively.
-- `isAtBottom` — boolean state for showing the "scroll to bottom" button.
-- `scrollToBottom()` — imperative scroll for the button's `onClick`.
+Key pieces (in `Chat.tsx`):
+- `<Virtuoso data={messages} itemContent={...} />` renders each row via the
+  memoized `ChatMessageRow`.
+- `computeItemKey={(_, m) => m.id}` — stable keys so rows aren't remounted (which
+  would drop tool-card expand state) as the visible range shifts.
+- `key={chatId}` on `<Virtuoso>` — remounts per chat so each opens at the bottom
+  (`initialTopMostItemIndex`).
+- `followOutput="auto"` — sticks to the bottom while streaming **only when the
+  user is already at the bottom** (Virtuoso re-measures the growing last row via
+  its internal `ResizeObserver`).
+- `atBottomStateChange={setIsAtBottom}` drives the "scroll to bottom" button;
+  `scrollToBottom()` calls `virtuosoRef.current.scrollToIndex({ index: "LAST" })`.
 
 **Never replace this with a DIY `useEffect([messages])` → `scrollIntoView`.
 That fires on every chunk and causes scroll jank + broken hover/click events.**
-The library correctly distinguishes user scrolling from programmatic scrolling
-and handles edge cases like content shrinking and mobile devices.
+Virtuoso correctly distinguishes user scrolling from programmatic scrolling and
+handles content shrinking and mobile devices.
+
+## Tool-card DOM cost (`StreamingToolCard`)
+
+Collapsed tool cards MUST unmount their body, not just hide it:
+- The expandable body uses MUI `<Collapse ... unmountOnExit>` so the
+  syntax-highlighted code/JSON DOM is removed entirely when collapsed (the
+  default `Collapse` keeps children mounted at height 0).
+- Heavy body strings (`code`, `formattedOutput`) are built **only** when the body
+  will render (`shouldRenderBody = (expanded || isActive) && hasVisibleBody`).
+- Inline output/code is capped (`capForDisplay`, `MAX_INLINE_CHARS` /
+  `MAX_INLINE_LINES`) so a huge tool result never expands into thousands of DOM
+  nodes; the full payload stays available via the tool-details dialog.
 
 ## Zustand selector rules
 
@@ -115,7 +134,9 @@ callback, not via a selector subscription.
 - [ ] No new `useCallback`/`useMemo` with object dependencies
 - [ ] No new `useEffect` depending on `messages` that touches the DOM
 - [ ] `experimental_throttle: 50` is present on `useChat`
-- [ ] Auto-scroll uses `use-stick-to-bottom`, not a DIY `useEffect`
+- [ ] Message list stays virtualized (`react-virtuoso`); auto-scroll uses
+      Virtuoso's `followOutput`, not a DIY `useEffect`
+- [ ] Collapsed `StreamingToolCard` bodies unmount (`Collapse unmountOnExit`)
 - [ ] Any new child component inside `ChatMessageRow` is `React.memo`-wrapped
 - [ ] Zustand selectors return primitives, not object references
 - [ ] Render-count test (`Chat.perf.test.ts`) still passes

--- a/api/package.json
+++ b/api/package.json
@@ -13,7 +13,7 @@
     "worker:dev": "tsx watch src/worker.ts",
     "migrate:workspaces": "tsx src/migrations/migrate-to-workspaces.ts",
     "openapi:generate": "tsx src/openapi/generate-cli.ts",
-    "test": "tsx src/openapi/core.test.ts && tsx src/openapi/openapi.test.ts && tsx src/dbt/warm-dir-cache.test.ts && tsx src/connectors/stripe/connector.test.ts && tsx src/connectors/close/connector.test.ts && tsx src/sync-cdc/idempotency.test.ts",
+    "test": "tsx src/openapi/core.test.ts && tsx src/openapi/openapi.test.ts && tsx src/dbt/warm-dir-cache.test.ts && tsx src/connectors/stripe/connector.test.ts && tsx src/connectors/close/connector.test.ts && tsx src/sync-cdc/idempotency.test.ts && tsx src/agent-lib/context/compaction.test.ts",
     "test:dbt": "vitest run",
     "test:dbt:watch": "vitest",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives",

--- a/api/src/agent-lib/context/compaction.test.ts
+++ b/api/src/agent-lib/context/compaction.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import type { UIMessage } from "ai";
+import { elideOldToolOutputs } from "./compaction";
+import { estimateUiMessagesTokens } from "./token-estimate";
+
+function t(label: string, fn: () => void) {
+  fn();
+  process.stdout.write(`ok  ${label}\n`);
+}
+
+// A big tool output that comfortably clears the elision token threshold.
+function bigOutput(tag: string) {
+  return {
+    success: true,
+    data: Array.from({ length: 200 }, (_, i) => ({
+      id: i,
+      tag,
+      value: `row-${i}-${"x".repeat(40)}`,
+    })),
+  };
+}
+
+function userMsg(id: string, text: string): UIMessage {
+  return { id, role: "user", parts: [{ type: "text", text }] } as UIMessage;
+}
+
+function assistantWithTool(id: string, tag: string): UIMessage {
+  return {
+    id,
+    role: "assistant",
+    parts: [
+      { type: "text", text: "Running a query." },
+      {
+        type: "tool-sql_execute_query",
+        toolCallId: `call-${id}`,
+        toolName: "sql_execute_query",
+        input: { sql: `SELECT * FROM t_${tag}` },
+        output: bigOutput(tag),
+        state: "output-available",
+      },
+    ],
+  } as UIMessage;
+}
+
+function isElided(msg: UIMessage): boolean {
+  const parts = (msg.parts ?? []) as Array<Record<string, unknown>>;
+  return parts.some(
+    p =>
+      (p as { output?: { _compacted?: boolean } }).output?._compacted === true,
+  );
+}
+
+// Build a conversation of N turns; each turn = user msg + assistant w/ big tool.
+function conversation(turns: number): UIMessage[] {
+  const msgs: UIMessage[] = [];
+  for (let i = 0; i < turns; i++) {
+    msgs.push(userMsg(`u${i}`, `Question ${i}`));
+    msgs.push(assistantWithTool(`a${i}`, String(i)));
+  }
+  return msgs;
+}
+
+// --- Tests ----------------------------------------------------------------
+
+t("no-op when conversation is within the keep-recent window", () => {
+  const msgs = conversation(2); // 2 turns, default keepRecentTurns=2
+  const res = elideOldToolOutputs(msgs);
+  assert.equal(res.changed, false);
+  assert.equal(res.elidedCount, 0);
+  assert.equal(res.messages, msgs); // same reference, untouched
+});
+
+t("elides large tool outputs in OLD turns, keeps recent turns verbatim", () => {
+  const msgs = conversation(6); // turns 0..5; keep last 2 (turns 4,5)
+  const res = elideOldToolOutputs(msgs);
+  assert.equal(res.changed, true);
+  // 4 old assistant turns each had 1 big tool output elided.
+  assert.equal(res.elidedCount, 4);
+
+  // messages are: [u0,a0, u1,a1, u2,a2, u3,a3, u4,a4, u5,a5]
+  // recent window = last 2 turns => indices for u4,a4,u5,a5 (idx 8..11).
+  const assistants = res.messages.filter(m => m.role === "assistant");
+  // a0..a3 elided, a4,a5 verbatim
+  assert.equal(isElided(assistants[0]), true, "a0 should be elided");
+  assert.equal(isElided(assistants[3]), true, "a3 should be elided");
+  assert.equal(isElided(assistants[4]), false, "a4 (recent) verbatim");
+  assert.equal(isElided(assistants[5]), false, "a5 (recent) verbatim");
+});
+
+t("preserves tool call identity and input when eliding output", () => {
+  const msgs = conversation(4);
+  const res = elideOldToolOutputs(msgs);
+  const a0 = res.messages.find(m => m.id === "a0");
+  assert.ok(a0, "a0 message present");
+  const toolPart = (a0.parts as Array<Record<string, unknown>>).find(p =>
+    String(p.type).startsWith("tool-"),
+  );
+  assert.ok(toolPart, "tool part present");
+  assert.equal(toolPart.toolCallId, "call-a0");
+  assert.deepEqual(toolPart.input, { sql: "SELECT * FROM t_0" });
+  assert.equal((toolPart.output as { _compacted?: boolean })._compacted, true);
+});
+
+t("significantly reduces estimated token count", () => {
+  const msgs = conversation(10);
+  const before = estimateUiMessagesTokens(msgs);
+  const res = elideOldToolOutputs(msgs);
+  const after = estimateUiMessagesTokens(res.messages);
+  assert.ok(
+    after < before * 0.5,
+    `expected >50% reduction, got before=${before} after=${after}`,
+  );
+});
+
+t("is idempotent (second pass elides nothing new)", () => {
+  const msgs = conversation(6);
+  const first = elideOldToolOutputs(msgs);
+  const second = elideOldToolOutputs(first.messages);
+  assert.equal(second.changed, false);
+  assert.equal(second.elidedCount, 0);
+});
+
+t("leaves small tool outputs alone even in old turns", () => {
+  const msgs: UIMessage[] = [
+    userMsg("u0", "q0"),
+    {
+      id: "a0",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-get_count",
+          toolCallId: "c0",
+          toolName: "get_count",
+          input: {},
+          output: { count: 3 },
+          state: "output-available",
+        },
+      ],
+    } as UIMessage,
+    userMsg("u1", "q1"),
+    assistantWithTool("a1", "1"),
+    userMsg("u2", "q2"),
+    assistantWithTool("a2", "2"),
+  ];
+  const res = elideOldToolOutputs(msgs);
+  // a0's tiny output is below threshold → untouched even though it's old.
+  const a0 = res.messages.find(m => m.id === "a0");
+  assert.ok(a0, "a0 message present");
+  assert.equal(isElided(a0), false);
+});
+
+t("respects custom keepRecentTurns and minTokens", () => {
+  const msgs = conversation(5);
+  const res = elideOldToolOutputs(msgs, { keepRecentTurns: 1 });
+  // keep only the last turn => 4 old turns elided.
+  assert.equal(res.elidedCount, 4);
+
+  const none = elideOldToolOutputs(msgs, { minTokens: 10_000_000 });
+  assert.equal(none.changed, false);
+});
+
+process.stdout.write("\nAll compaction elision tests passed.\n");

--- a/api/src/agent-lib/context/compaction.test.ts
+++ b/api/src/agent-lib/context/compaction.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import type { UIMessage } from "ai";
-import { elideOldToolOutputs } from "./compaction";
+import { elideOldToolOutputs, stripReplayedReasoning } from "./compaction";
 import { estimateUiMessagesTokens } from "./token-estimate";
 
 function t(label: string, fn: () => void) {
@@ -159,4 +159,96 @@ t("respects custom keepRecentTurns and minTokens", () => {
   assert.equal(none.changed, false);
 });
 
-process.stdout.write("\nAll compaction elision tests passed.\n");
+// --- stripReplayedReasoning ----------------------------------------------
+
+function assistantWithReasoning(id: string, text: string): UIMessage {
+  return {
+    id,
+    role: "assistant",
+    parts: [
+      { type: "reasoning", text: `thinking about ${text}` },
+      { type: "text", text },
+    ],
+  } as UIMessage;
+}
+
+function reasoningPartCount(msgs: UIMessage[]): number {
+  let n = 0;
+  for (const m of msgs) {
+    for (const p of (m.parts ?? []) as Array<Record<string, unknown>>) {
+      if (p.type === "reasoning") n += 1;
+    }
+  }
+  return n;
+}
+
+t("strips ALL reasoning when the last message is a fresh user turn", () => {
+  const msgs: UIMessage[] = [
+    userMsg("u0", "q0"),
+    assistantWithReasoning("a0", "answer 0"),
+    userMsg("u1", "q1"),
+    assistantWithReasoning("a1", "answer 1"),
+    userMsg("u2", "q2"), // fresh user turn → no continuation
+  ];
+  assert.equal(reasoningPartCount(msgs), 2);
+  const res = stripReplayedReasoning(msgs);
+  assert.equal(res.changed, true);
+  assert.equal(res.strippedCount, 2);
+  assert.equal(reasoningPartCount(res.messages), 0);
+});
+
+t("preserves reasoning on the last assistant msg during a continuation", () => {
+  // Last message is an assistant message (e.g. a client tool result was folded
+  // back into it) → Anthropic interleaved thinking may require its thinking.
+  const msgs: UIMessage[] = [
+    userMsg("u0", "q0"),
+    assistantWithReasoning("a0", "answer 0"),
+    userMsg("u1", "q1"),
+    assistantWithReasoning("a1", "answer 1"), // last assistant, continuation
+  ];
+  const res = stripReplayedReasoning(msgs);
+  assert.equal(res.changed, true);
+  // a0 stripped, a1 preserved
+  assert.equal(res.strippedCount, 1);
+  const a1 = res.messages.find(m => m.id === "a1");
+  assert.ok(a1);
+  assert.equal(
+    (a1.parts as Array<Record<string, unknown>>).some(
+      p => p.type === "reasoning",
+    ),
+    true,
+  );
+  const a0 = res.messages.find(m => m.id === "a0");
+  assert.ok(a0);
+  assert.equal(
+    (a0.parts as Array<Record<string, unknown>>).some(
+      p => p.type === "reasoning",
+    ),
+    false,
+  );
+});
+
+t("never empties a reasoning-only assistant message", () => {
+  const msgs: UIMessage[] = [
+    userMsg("u0", "q0"),
+    {
+      id: "a0",
+      role: "assistant",
+      parts: [{ type: "reasoning", text: "only thinking, no answer" }],
+    } as UIMessage,
+    userMsg("u1", "q1"),
+  ];
+  const res = stripReplayedReasoning(msgs);
+  // Stripping would empty a0 → left untouched.
+  assert.equal(res.changed, false);
+  assert.equal(reasoningPartCount(res.messages), 1);
+});
+
+t("no-op when there is no reasoning to strip", () => {
+  const msgs = conversation(3);
+  const res = stripReplayedReasoning(msgs);
+  assert.equal(res.changed, false);
+  assert.equal(res.strippedCount, 0);
+});
+
+process.stdout.write("\nAll compaction tests passed.\n");

--- a/api/src/agent-lib/context/compaction.ts
+++ b/api/src/agent-lib/context/compaction.ts
@@ -264,6 +264,69 @@ export function elideOldToolOutputs(
 }
 
 // ---------------------------------------------------------------------------
+// Replayed reasoning / thinking stripping (cost control, budget-independent)
+// ---------------------------------------------------------------------------
+
+export interface StripReasoningResult {
+  messages: UIMessage[];
+  changed: boolean;
+  strippedCount: number;
+}
+
+/**
+ * Drop replayed `reasoning` (extended-thinking) parts from the model input.
+ *
+ * `sendReasoning: true` streams the model's thinking to the UI and persists it,
+ * so the client replays every prior turn's thinking trace on every request.
+ * That is pure waste: a model never needs to re-read its own past thinking — the
+ * conclusions already live in the assistant text/tool calls that follow — and
+ * the blocks are re-billed as input tokens each turn.
+ *
+ * The one exception is provider-mandated: with Anthropic interleaved thinking +
+ * tool use, the thinking block of the assistant turn that is being *continued*
+ * with tool results must be preserved (signature verification). That turn is the
+ * LAST assistant message, and only when the latest message is NOT a fresh user
+ * message (i.e. we're mid tool-continuation). In every other case we strip all
+ * reasoning. We never empty a message (guards a reasoning-only assistant turn).
+ */
+export function stripReplayedReasoning(
+  messages: UIMessage[],
+): StripReasoningResult {
+  if (messages.length === 0) {
+    return { messages, changed: false, strippedCount: 0 };
+  }
+
+  const lastMessage = messages[messages.length - 1];
+  const isContinuation = lastMessage.role !== "user";
+  let preserveIdx = -1;
+  if (isContinuation) {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === "assistant") {
+        preserveIdx = i;
+        break;
+      }
+    }
+  }
+
+  let changed = false;
+  let strippedCount = 0;
+  const next = messages.map((msg, idx) => {
+    if (msg.role !== "assistant" || idx === preserveIdx) return msg;
+    const parts = (msg.parts ?? []) as Array<Record<string, unknown>>;
+    const filtered = parts.filter(part => part.type !== "reasoning");
+    const removed = parts.length - filtered.length;
+    // Nothing to strip, or stripping would leave the message empty (which
+    // `convertToModelMessages` rejects) — leave it untouched.
+    if (removed === 0 || filtered.length === 0) return msg;
+    changed = true;
+    strippedCount += removed;
+    return { ...msg, parts: filtered as UIMessage["parts"] };
+  });
+
+  return { messages: next, changed, strippedCount };
+}
+
+// ---------------------------------------------------------------------------
 // Summarization (agnostic — cheapest curated tool-use model)
 // ---------------------------------------------------------------------------
 

--- a/api/src/agent-lib/context/compaction.ts
+++ b/api/src/agent-lib/context/compaction.ts
@@ -46,6 +46,19 @@ const logger = loggers.agent();
 /** Turns kept verbatim at the tail of the conversation. */
 const DEFAULT_KEEP_RECENT_TURNS = 6;
 
+/**
+ * Turns kept verbatim by the ALWAYS-ON elision pass (cost control).
+ *
+ * Distinct from `DEFAULT_KEEP_RECENT_TURNS` (used by the budget-driven path):
+ * even when the prompt comfortably fits the context window, replaying every
+ * prior turn's full tool outputs on every request is the dominant driver of
+ * token spend in long agent chats. We keep only the most recent few turns
+ * verbatim and elide large tool outputs from everything older — regardless of
+ * the budget. Smaller than the budget window because this runs every turn and
+ * we want aggressive savings while preserving recent, actionable context.
+ */
+const ALWAYS_ELIDE_KEEP_RECENT_TURNS = 2;
+
 /** Fraction of the context window reserved as a safety margin. */
 const SAFETY_MARGIN_RATIO = 0.1;
 
@@ -131,12 +144,16 @@ function groupIntoTurns(messages: UIMessage[]): Turn[] {
 // Tool-output elision (lossless-ish)
 // ---------------------------------------------------------------------------
 
-function elideToolOutputsInMessage(message: UIMessage): {
+function elideToolOutputsInMessage(
+  message: UIMessage,
+  minTokens: number = ELIDE_TOOL_OUTPUT_TOKENS,
+): {
   message: UIMessage;
   changed: boolean;
+  count: number;
 } {
   const parts = (message.parts ?? []) as Array<Record<string, unknown>>;
-  let changed = false;
+  let count = 0;
   const nextParts = parts.map(part => {
     const type = typeof part.type === "string" ? part.type : "";
     const isTool = type.startsWith("tool-") || type === "dynamic-tool";
@@ -148,32 +165,102 @@ function elideToolOutputsInMessage(message: UIMessage): {
     ) {
       return part;
     }
-    if (estimateTokensFromValue(part.output) < ELIDE_TOOL_OUTPUT_TOKENS) {
+    if (estimateTokensFromValue(part.output) < minTokens) {
       return part;
     }
-    changed = true;
+    count += 1;
     return { ...part, output: ELIDED_OUTPUT_PLACEHOLDER };
   });
-  if (!changed) return { message, changed: false };
+  if (count === 0) return { message, changed: false, count: 0 };
   return {
     message: { ...message, parts: nextParts as UIMessage["parts"] },
     changed: true,
+    count,
   };
 }
 
 function elideToolOutputs(
   messages: UIMessage[],
   range: { from: number; to: number },
-): { messages: UIMessage[]; changed: boolean } {
+  minTokens: number = ELIDE_TOOL_OUTPUT_TOKENS,
+): { messages: UIMessage[]; changed: boolean; count: number } {
   let changed = false;
+  let count = 0;
   const next = messages.map((msg, idx) => {
     if (idx < range.from || idx >= range.to) return msg;
     if (msg.role !== "assistant") return msg;
-    const res = elideToolOutputsInMessage(msg);
-    if (res.changed) changed = true;
+    const res = elideToolOutputsInMessage(msg, minTokens);
+    if (res.changed) {
+      changed = true;
+      count += res.count;
+    }
     return res.message;
   });
-  return { messages: next, changed };
+  return { messages: next, changed, count };
+}
+
+// ---------------------------------------------------------------------------
+// Always-on old tool-output elision (cost control, budget-independent)
+// ---------------------------------------------------------------------------
+
+export interface ElideOldToolOutputsOptions {
+  /** Turns kept fully verbatim at the tail. */
+  keepRecentTurns?: number;
+  /** Only elide tool outputs estimated at or above this many tokens. */
+  minTokens?: number;
+}
+
+export interface ElideOldToolOutputsResult {
+  messages: UIMessage[];
+  changed: boolean;
+  elidedCount: number;
+}
+
+/**
+ * Elide large tool outputs from OLDER turns, independent of any token budget.
+ *
+ * This is the primary cost lever for long agent chats: the client replays the
+ * entire `messages[]` every turn, so a session that ran 50 large SQL/schema
+ * tool calls re-sends all of them on every subsequent request — even when the
+ * total still fits the context window. Those bytes are re-billed as input
+ * tokens (and re-processed) every single turn.
+ *
+ * We keep the most recent `keepRecentTurns` turns verbatim (the model's active
+ * working set) and replace large tool outputs in everything older with a short
+ * placeholder. Tool call↔result pairing is preserved because we only swap the
+ * `output` field of a tool part; the tool call itself remains.
+ */
+export function elideOldToolOutputs(
+  messages: UIMessage[],
+  opts?: ElideOldToolOutputsOptions,
+): ElideOldToolOutputsResult {
+  const keepRecentTurns =
+    opts?.keepRecentTurns ?? ALWAYS_ELIDE_KEEP_RECENT_TURNS;
+  const minTokens = opts?.minTokens ?? ELIDE_TOOL_OUTPUT_TOKENS;
+  if (messages.length === 0) {
+    return { messages, changed: false, elidedCount: 0 };
+  }
+
+  const turns = groupIntoTurns(messages);
+  if (turns.length <= keepRecentTurns) {
+    return { messages, changed: false, elidedCount: 0 };
+  }
+  const recentStartTurn = Math.max(0, turns.length - keepRecentTurns);
+  const recentStartIdx = turns[recentStartTurn].start;
+  if (recentStartIdx <= 0) {
+    return { messages, changed: false, elidedCount: 0 };
+  }
+
+  const res = elideToolOutputs(
+    messages,
+    { from: 0, to: recentStartIdx },
+    minTokens,
+  );
+  return {
+    messages: res.messages,
+    changed: res.changed,
+    elidedCount: res.count,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -21,6 +21,7 @@ import { withContextOverflowSelfHeal } from "../agent-lib/context-overflow-self-
 import {
   computeInputBudget,
   compactUiMessagesForBudget,
+  elideOldToolOutputs,
 } from "../agent-lib/context/compaction";
 import { unifiedAuthMiddleware } from "../auth/unified-auth.middleware";
 import { AuthenticatedContext } from "../middleware/workspace.middleware";
@@ -896,6 +897,23 @@ agentRoutes.openapi(
       const sanitizedMessages = sanitizeMessagesForModel(
         messagesWithAttachments,
       );
+      // Always-on cost control (budget-independent): the client replays the
+      // entire `messages[]` every turn, so a long session re-sends every prior
+      // turn's full tool outputs on every request — re-billed as input tokens
+      // each time, even when the prompt comfortably fits the context window.
+      // Elide large tool outputs from older turns (keeping the most recent
+      // turns verbatim) before any budget math. This is the main lever against
+      // runaway spend on long chats. Runs even when `contextWindow` is unknown.
+      const elision = elideOldToolOutputs(sanitizedMessages);
+      let messagesForModel = elision.messages;
+      if (elision.changed) {
+        logger.info("Elided old tool outputs before generation", {
+          chatId,
+          workspaceId,
+          modelId: resolvedModelId,
+          elidedCount: elision.elidedCount,
+        });
+      }
       // Proactively keep the prompt under the model's context window. Budget is
       // derived from the catalog `contextWindow` (provider-agnostic — every
       // gateway model reports it); when unknown we skip this and rely on the
@@ -907,10 +925,9 @@ agentRoutes.openapi(
         systemText: systemPrompt,
         thinkingBudgetTokens: modelDef?.thinkingBudgetTokens,
       });
-      let messagesForModel = sanitizedMessages;
       if (inputBudget !== null) {
         const compaction = await compactUiMessagesForBudget({
-          messages: sanitizedMessages,
+          messages: messagesForModel,
           budgetTokens: inputBudget,
           summarize: true,
           abortSignal: turnSignal,

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -22,6 +22,7 @@ import {
   computeInputBudget,
   compactUiMessagesForBudget,
   elideOldToolOutputs,
+  stripReplayedReasoning,
 } from "../agent-lib/context/compaction";
 import { unifiedAuthMiddleware } from "../auth/unified-auth.middleware";
 import { AuthenticatedContext } from "../middleware/workspace.middleware";
@@ -912,6 +913,21 @@ agentRoutes.openapi(
           workspaceId,
           modelId: resolvedModelId,
           elidedCount: elision.elidedCount,
+        });
+      }
+      // Strip replayed thinking/reasoning traces. `sendReasoning: true` persists
+      // the model's thinking and the client replays it every turn; a model never
+      // needs to re-read its own past thinking, and those blocks are re-billed as
+      // input tokens each request. Kept only on the assistant turn being
+      // continued with tool results (Anthropic interleaved-thinking requirement).
+      const reasoningStrip = stripReplayedReasoning(messagesForModel);
+      messagesForModel = reasoningStrip.messages;
+      if (reasoningStrip.changed) {
+        logger.info("Stripped replayed reasoning before generation", {
+          chatId,
+          workspaceId,
+          modelId: resolvedModelId,
+          strippedCount: reasoningStrip.strippedCount,
         });
       }
       // Proactively keep the prompt under the model's context window. Budget is

--- a/app/package.json
+++ b/app/package.json
@@ -53,6 +53,7 @@
     "react-resizable-panels": "^3.0.2",
     "react-router-dom": "^6.29.2",
     "react-syntax-highlighter": "^15.6.1",
+    "react-virtuoso": "^4.18.7",
     "streamdown": "^2.5.0",
     "use-stick-to-bottom": "^1.1.3",
     "vega": "^6.2.0",

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -14,7 +14,6 @@ import {
   Button,
   Chip,
   IconButton,
-  List,
   ListItem,
   ListItemText,
   MenuItem,
@@ -56,7 +55,7 @@ import {
 } from "lucide-react";
 import { useTheme as useMuiTheme, keyframes } from "@mui/material/styles";
 import { useChat } from "@ai-sdk/react";
-import { useStickToBottom } from "use-stick-to-bottom";
+import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import {
   DefaultChatTransport,
   lastAssistantMessageIsCompleteWithToolCalls,
@@ -721,6 +720,31 @@ const assistantMessageSx = {
   "& pre": { margin: 0, overflow: "hidden" },
 } as const;
 const listItemSx = { p: 0 } as const;
+
+// react-virtuoso slot components. The previous (non-virtualized) list got its
+// 8px gutters from the scroll container's `p: 1`; Virtuoso owns the scroller now
+// so we re-add the horizontal gutters per item and top/bottom spacers via the
+// Header/Footer slots. Defined at module scope so their identity is stable
+// (re-creating them each render would remount every row).
+const ChatListHeader = () => <div style={{ height: 8 }} />;
+const ChatListFooter = () => <div style={{ height: 8 }} />;
+const ChatListItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(function ChatListItem(props, ref) {
+  return (
+    <div
+      {...props}
+      ref={ref}
+      style={{ ...props.style, paddingLeft: 8, paddingRight: 8 }}
+    />
+  );
+});
+const virtuosoComponents = {
+  Header: ChatListHeader,
+  Footer: ChatListFooter,
+  Item: ChatListItem,
+};
 
 /**
  * Lightweight, dependency-free image lightbox. Shows the full (uncropped) image
@@ -1890,13 +1914,18 @@ const Chat: React.FC<ChatProps> = ({
   const [historyMenuAnchor, setHistoryMenuAnchor] =
     useState<null | HTMLElement>(null);
   const historyMenuOpen = Boolean(historyMenuAnchor);
-  const messagesEndRef = useRef<HTMLDivElement>(null);
-  const {
-    scrollRef: scrollContainerRef,
-    contentRef: scrollContentRef,
-    isAtBottom,
-    scrollToBottom,
-  } = useStickToBottom();
+  // Virtualized message list (react-virtuoso). Owns its own scroll container
+  // and the stick-to-bottom behavior; off-screen messages are unmounted, which
+  // keeps the DOM small in long chats (mobile Safari struggles otherwise).
+  const virtuosoRef = useRef<VirtuosoHandle>(null);
+  const [isAtBottom, setIsAtBottom] = useState(true);
+  const scrollToBottom = useCallback(() => {
+    virtuosoRef.current?.scrollToIndex({
+      index: "LAST",
+      behavior: "smooth",
+      align: "end",
+    });
+  }, []);
 
   // Track if we're viewing an existing chat from history (vs a new chat)
   // Moved before useChat so onFinish callback can access it
@@ -4035,13 +4064,11 @@ const Chat: React.FC<ChatProps> = ({
         </Box>
       )}
 
-      {/* Messages */}
+      {/* Messages — virtualized so only on-screen rows live in the DOM. */}
       <Box
-        ref={scrollContainerRef}
         sx={{
           flex: 1,
-          overflow: "auto",
-          p: 1,
+          minHeight: 0,
           position: "relative",
         }}
       >
@@ -4106,32 +4133,42 @@ const Chat: React.FC<ChatProps> = ({
           </Box>
         )}
 
-        <div ref={scrollContentRef}>
+        {messages.length > 0 && (
           <React.Profiler id="Chat.message-list" onRender={onRenderDebug}>
-            <List dense>
-              {messages.map((message, msgIdx) => (
+            <Virtuoso
+              key={chatId}
+              ref={virtuosoRef}
+              data={messages}
+              style={{ height: "100%" }}
+              className="chat-message-virtuoso"
+              computeItemKey={(_index, message) => message.id}
+              initialTopMostItemIndex={Math.max(0, messages.length - 1)}
+              followOutput="auto"
+              atBottomStateChange={setIsAtBottom}
+              atBottomThreshold={120}
+              increaseViewportBy={{ top: 800, bottom: 800 }}
+              components={virtuosoComponents}
+              itemContent={(index, message) => (
                 <ChatMessageRow
-                  key={message.id}
                   message={message}
-                  isLastMessage={msgIdx === messages.length - 1}
+                  isLastMessage={index === messages.length - 1}
                   isStreaming={status === "streaming"}
                   onToolClick={handleToolClick}
                   onConsoleTitleClick={handleConsoleTitleClick}
                   connectionIconById={connectionIconById}
                   paletteMode={paletteMode}
                 />
-              ))}
-            </List>
+              )}
+            />
           </React.Profiler>
-          <div ref={messagesEndRef} />
-        </div>
+        )}
 
-        {!isAtBottom && (
+        {messages.length > 0 && !isAtBottom && (
           <IconButton
             onClick={() => scrollToBottom()}
             size="small"
             sx={{
-              position: "sticky",
+              position: "absolute",
               bottom: 8,
               left: "50%",
               transform: "translateX(-50%)",

--- a/app/src/components/StreamingToolCard.tsx
+++ b/app/src/components/StreamingToolCard.tsx
@@ -217,6 +217,59 @@ function formatOutputForDisplay(output: unknown): string {
   return JSON.stringify(o, null, 2);
 }
 
+// Inline display caps. Tool results are already size-bounded server-side, but a
+// single 50k-char JSON blob still expands into thousands of DOM nodes once
+// syntax-highlighted — and many such cards in a long chat make mobile Safari
+// crawl. We never feed more than this to the highlighter; the full payload is
+// still available via the tool-details dialog.
+const MAX_INLINE_CHARS = 8_000;
+const MAX_INLINE_LINES = 200;
+
+function capForDisplay(text: string): string {
+  if (!text) return text;
+  let capped = text;
+  let truncated = false;
+  if (capped.length > MAX_INLINE_CHARS) {
+    capped = capped.slice(0, MAX_INLINE_CHARS);
+    truncated = true;
+  }
+  const newlineCount = (capped.match(/\n/g) ?? []).length;
+  if (newlineCount + 1 > MAX_INLINE_LINES) {
+    let idx = -1;
+    for (let i = 0; i < MAX_INLINE_LINES; i++) {
+      const next = capped.indexOf("\n", idx + 1);
+      if (next === -1) break;
+      idx = next;
+    }
+    if (idx !== -1) capped = capped.slice(0, idx);
+    truncated = true;
+  }
+  if (truncated) {
+    capped +=
+      "\n\n… truncated for display — open the tool details to view the full result.";
+  }
+  return capped;
+}
+
+/**
+ * Cheap check (no full serialization) for whether an output has anything worth
+ * showing in the expandable body. Used to decide `canExpand` without paying the
+ * cost of `formatOutputForDisplay` for collapsed cards.
+ */
+function hasDisplayableOutput(output: unknown): boolean {
+  if (output === null || output === undefined) return false;
+  if (typeof output === "string") return output.length > 0;
+  if (Array.isArray(output)) return output.length > 0;
+  if (typeof output === "object") {
+    const o = output as Record<string, unknown>;
+    const keys = Object.keys(o).filter(
+      k => !(k === "success" && o.success === true),
+    );
+    return keys.length > 0;
+  }
+  return false;
+}
+
 // ── Animations ───────────────────────────────────────────────
 
 const pulseKf = keyframes`
@@ -319,15 +372,39 @@ export const StreamingToolCard = React.memo(
     const rawContent = config.preview
       ? inputObj?.[config.preview.field]
       : undefined;
-    const defaultCode =
-      typeof rawContent === "string"
-        ? rawContent
-        : rawContent && typeof rawContent === "object"
-          ? JSON.stringify(rawContent, null, 2)
-          : "";
-    const code = bodyPreview?.content ?? defaultCode;
     const codeLanguage =
       bodyPreview?.language ?? config.preview?.language ?? "text";
+
+    // Cheap presence checks (no serialization) so we can decide expandability
+    // for collapsed cards without building the (potentially huge) body strings.
+    const hasCode = Boolean(
+      bodyPreview?.content ||
+        (typeof rawContent === "string"
+          ? rawContent.length > 0
+          : rawContent != null),
+    );
+    const hasOutput = (isDone || isError) && hasDisplayableOutput(output);
+
+    const hasVisibleBody = hasCode || hasOutput;
+    const canExpand = hasVisibleBody;
+
+    // Only build the heavy body strings when they will actually be rendered:
+    // while the card is active (streaming the preview) or after the user
+    // expands it. Collapsed history cards never pay this cost. The body itself
+    // is unmounted (Collapse `unmountOnExit`) so its DOM is gone too.
+    const shouldRenderBody = (expanded || isActive) && hasVisibleBody;
+
+    const code = useMemo(() => {
+      if (!shouldRenderBody || !hasCode) return "";
+      const raw =
+        bodyPreview?.content ??
+        (typeof rawContent === "string"
+          ? rawContent
+          : rawContent && typeof rawContent === "object"
+            ? JSON.stringify(rawContent, null, 2)
+            : "");
+      return capForDisplay(raw);
+    }, [shouldRenderBody, hasCode, bodyPreview?.content, rawContent]);
 
     useEffect(() => {
       if (isStreaming && !userScrolled && codeContainerRef.current) {
@@ -351,18 +428,16 @@ export const StreamingToolCard = React.memo(
     );
 
     const formattedOutput = useMemo(
-      () => (isDone || isError ? formatOutputForDisplay(output) : ""),
-      [isDone, isError, output],
+      () =>
+        shouldRenderBody && (isDone || isError)
+          ? capForDisplay(formatOutputForDisplay(output))
+          : "",
+      [shouldRenderBody, isDone, isError, output],
     );
     const outputLang =
       formattedOutput.startsWith("{") || formattedOutput.startsWith("[")
         ? "json"
         : "text";
-
-    const hasVisibleBody =
-      code.length > 0 || ((isDone || isError) && formattedOutput.length > 0);
-
-    const canExpand = hasVisibleBody;
 
     const statusText = isStreaming
       ? "Generating…"
@@ -565,8 +640,11 @@ export const StreamingToolCard = React.memo(
           </Box>
         </Box>
 
-        {/* Expandable body: code preview + output */}
-        <Collapse in={expanded && hasVisibleBody} timeout={300}>
+        {/* Expandable body: code preview + output.
+            `unmountOnExit` removes the syntax-highlighted DOM (and its many
+            nodes) entirely when collapsed — critical for keeping the DOM small
+            in long chats on mobile Safari. */}
+        <Collapse in={expanded && hasVisibleBody} timeout={300} unmountOnExit>
           {/* Code preview */}
           {code.length > 0 && (
             <Box

--- a/app/src/components/__tests__/Chat.perf.test.ts
+++ b/app/src/components/__tests__/Chat.perf.test.ts
@@ -304,8 +304,23 @@ describe("Chat.tsx structural guards", () => {
     expect(chatSource).toMatch(/experimental_throttle\s*:\s*\d+/);
   });
 
-  it("uses use-stick-to-bottom for scroll management", () => {
-    expect(chatSource).toContain("useStickToBottom");
+  it("virtualizes the message list with react-virtuoso", () => {
+    // Off-screen messages must be unmounted so the DOM stays small in long
+    // chats (mobile Safari struggles with thousands of nodes). Virtuoso owns
+    // the scroller + stick-to-bottom behavior.
+    expect(chatSource).toContain("react-virtuoso");
+    expect(chatSource).toMatch(/<Virtuoso\b/);
+  });
+
+  it("keys virtualized rows by message.id", () => {
+    // Stable keys prevent Virtuoso from remounting rows (which would drop
+    // tool-card expand state and cause flicker) as the range shifts.
+    expect(chatSource).toMatch(/computeItemKey=\{[^}]*message\.id/);
+  });
+
+  it("follows streaming output and tracks bottom state", () => {
+    expect(chatSource).toMatch(/followOutput=/);
+    expect(chatSource).toMatch(/atBottomStateChange=\{setIsAtBottom\}/);
   });
 
   it("does NOT have a DIY useEffect([messages]) auto-scroll", () => {
@@ -328,6 +343,29 @@ describe("Chat.tsx structural guards", () => {
     // toolCallId keeps identity stable across reorders/inserts.
     expect(chatSource).toMatch(/key=\{\s*key\s*\}/);
     expect(chatSource).toMatch(/`tool-\$\{toolCallId\}`/);
+  });
+});
+
+describe("StreamingToolCard structural guards", () => {
+  const cardSource = fs.readFileSync(
+    path.resolve(__dirname, "../StreamingToolCard.tsx"),
+    "utf-8",
+  );
+
+  it("unmounts the collapsed body (Collapse unmountOnExit)", () => {
+    // Collapsed tool cards must not keep their syntax-highlighted JSON/code in
+    // the DOM — that's the dominant DOM-node source in long chats on mobile.
+    expect(cardSource).toMatch(/<Collapse[^>]*unmountOnExit/s);
+  });
+
+  it("caps inline output/code size before highlighting", () => {
+    // Never feed a 10k-line JSON blob to the syntax highlighter inline.
+    expect(cardSource).toContain("capForDisplay");
+    expect(cardSource).toMatch(/MAX_INLINE_(CHARS|LINES)/);
+  });
+
+  it("defers building the heavy body strings until the body renders", () => {
+    expect(cardSource).toMatch(/shouldRenderBody/);
   });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -442,6 +442,9 @@ importers:
       react-syntax-highlighter:
         specifier: ^15.6.1
         version: 15.6.1(react@18.3.1)
+      react-virtuoso:
+        specifier: ^4.18.7
+        version: 4.18.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       streamdown:
         specifier: ^2.5.0
         version: 2.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9413,6 +9416,12 @@ packages:
     peerDependencies:
       react: '>=16.6.0'
       react-dom: '>=16.6.0'
+
+  react-virtuoso@4.18.7:
+    resolution: {integrity: sha512-xNF5zDGEEIMB7cKwcen/pLig0YDf6OnfFrVgKFa7sHPf9fRem0CaLshyObbBcP88jzn0enavL39EgplgdyT21g==}
+    peerDependencies:
+      react: '>=16 || >=17 || >= 18 || >= 19'
+      react-dom: '>=16 || >=17 || >= 18 || >=19'
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -22291,6 +22300,11 @@ snapshots:
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  react-virtuoso@4.18.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

1. **Cost** — long agent chats replay the entire `messages[]` every turn, so prior turns' full tool outputs (SQL results, schema dumps, etc.) are re-sent and re-billed as input tokens on *every* request, even when the prompt comfortably fits the model's context window. Existing compaction only kicked in near the context-window limit, so large-context models could rack up huge per-turn spend (a $1.3k Sunday).
2. **Mobile rendering** — chat rendering crawls on mobile Safari after enough messages, because the whole history is in the DOM (no virtualization) and collapsed tool cards keep their syntax-highlighted JSON mounted (just hidden), often thousands of nodes each.

## Changes

### Backend — always-on elision of old tool outputs (`api`)
- New `elideOldToolOutputs()` in `agent-lib/context/compaction.ts`: a **budget-independent** pass that replaces large tool outputs in older turns with a short placeholder while keeping the most recent turns verbatim. Tool call↔result pairing is preserved (only the `output` field is swapped).
- Wired into `buildSegmentModelMessages` in `agent.routes.ts` **before** the existing budget-driven compaction, so it runs every turn — even when the model's `contextWindow` is unknown.

### Frontend — virtualization + smaller tool-card DOM (`app`)
- **Virtualize** the message list with `react-virtuoso` so only on-screen rows are mounted (Virtuoso owns the scroller + stick-to-bottom via `followOutput`, replacing `use-stick-to-bottom`).
- **Unmount collapsed tool-card bodies** (`Collapse unmountOnExit`), defer building the heavy code/JSON strings until the body renders, and **cap inline output/code size** (`capForDisplay`) so a huge tool result never expands into thousands of nodes. Full payload stays available via the tool-details dialog.

## Evidence

Smooth virtualized scrolling of a 40-message chat on a mobile viewport:

[chat_virtualization_mobile_demo.mp4](https://cursor.com/agents/bc-0015df55-468b-47f8-8028-2190ce2678ba/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchat_virtualization_mobile_demo.mp4)

Virtualization windowing — only 3–4 of 40 rows mounted; the window shifts with scroll (bottom = indices 37–39, top = 0–3):

[Console: VIRT_BOTTOM indices 37-39 vs VIRT_TOP indices 0-3](https://cursor.com/agents/bc-0015df55-468b-47f8-8028-2190ce2678ba/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvirtualization_windowing_console.webp)

Collapsed tool cards are unmounted, not hidden — expanding one adds ~229 DOM nodes:

[Console: NODES_BEFORE_EXPAND vs NODES_AFTER_EXPAND](https://cursor.com/agents/bc-0015df55-468b-47f8-8028-2190ce2678ba/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftoolcard_unmount_console.webp)

Backend cost lever firing in a real agent run (dev DB), eliding older tool outputs each subsequent turn:

```
[agent] Elided old tool outputs before generation { chatId: ..., modelId: "openai/gpt-4o-mini", elidedCount: 1 }
[agent] Elided old tool outputs before generation { chatId: ..., modelId: "openai/gpt-4o-mini", elidedCount: 2 }
```

## Testing
- ✅ `pnpm --filter api exec tsx src/agent-lib/context/compaction.test.ts` (new unit tests; added to api `test` script)
- ✅ `pnpm --filter api run build` (lint + typecheck)
- ✅ `pnpm --filter app run typecheck && pnpm --filter app run lint`
- ✅ `pnpm --filter app exec vitest run src/components/__tests__/Chat.perf.test.ts` (32 tests, incl. new virtualization + tool-card guards)
- ✅ Manual end-to-end on mobile viewport (see evidence above)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0015df55-468b-47f8-8028-2190ce2678ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0015df55-468b-47f8-8028-2190ce2678ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

