### PR TITLE
feat(agent): let clarifying questions recommend a default option

### DIFF
--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -66,8 +66,10 @@ YOU decide when these make sense:
   lists in your reply — ALWAYS call \`ask_clarifying_questions\` instead so the user gets an
   interactive form. Give each question concrete \`options\` when you can enumerate them, set
   \`allowMultiple\` when several answers are valid, and set \`allowOther: false\` only when the
-  listed options are exhaustive. NEVER include an "Other" / "Something else" option yourself —
-  the form automatically appends a free-text "Other" choice unless \`allowOther\` is false.
+  listed options are exhaustive. When one option is the best default, set \`recommendedOption\`
+  to its exact label so the form badges it as "Recommended". NEVER include an "Other" /
+  "Something else" option yourself — the form automatically appends a free-text "Other" choice
+  unless \`allowOther\` is false.
 - \`submit_plan\` — use BEFORE acting when the work is large, destructive, or spans multiple
   artifacts (e.g. building a dashboard from scratch, modifying many consoles, deleting or
   overwriting data, reconfiguring a sync flow), or when the user explicitly asks for a plan.

--- a/app/src/components/ClarifyingQuestionsCard.tsx
+++ b/app/src/components/ClarifyingQuestionsCard.tsx
@@ -113,6 +113,8 @@ interface OptionRowProps {
   multiple: boolean;
   icon?: React.ReactNode;
   role?: "radio" | "checkbox";
+  /** Show a subtle "Recommended" badge after the label. */
+  recommended?: boolean;
   onToggle: () => void;
 }
 
@@ -123,6 +125,7 @@ const OptionRow: React.FC<OptionRowProps> = ({
   multiple,
   icon,
   role,
+  recommended,
   onToggle,
 }) => {
   const indicator =
@@ -172,6 +175,20 @@ const OptionRow: React.FC<OptionRowProps> = ({
       <Typography sx={{ fontSize: 13, flex: 1, minWidth: 0 }}>
         {label}
       </Typography>
+      {recommended && (
+        <Chip
+          size="small"
+          label="Recommended"
+          color="primary"
+          variant="outlined"
+          sx={{
+            flexShrink: 0,
+            height: 18,
+            fontSize: 10,
+            "& .MuiChip-label": { px: 0.75 },
+          }}
+        />
+      )}
     </Box>
   );
 };
@@ -444,6 +461,10 @@ export const ClarifyingQuestionsCard: React.FC<
                       label={option}
                       selected={answer.selected.includes(option)}
                       multiple={Boolean(question.allowMultiple)}
+                      recommended={
+                        !question.allowMultiple &&
+                        question.recommendedOption === option
+                      }
                       onToggle={() => toggleOption(question, option)}
                     />
                   ))}

--- a/packages/agent-tools/src/plan-tools.ts
+++ b/packages/agent-tools/src/plan-tools.ts
@@ -45,6 +45,14 @@ export const clarifyingQuestionSchema = z.object({
       "For 'choice' questions, append an 'Other' free-text option (defaults to true). " +
         "Set false when the listed options are exhaustive.",
     ),
+  recommendedOption: z
+    .string()
+    .optional()
+    .describe(
+      "For single-choice questions, the exact label of the option you recommend as the " +
+        "best default. The form badges it with 'Recommended'. Must match one entry in " +
+        "'options' verbatim. Omit when you have no clear recommendation or when 'allowMultiple' is set.",
+    ),
 });
 
 export const askClarifyingQuestionsSchema = z.object({
@@ -89,6 +97,8 @@ export const clientPlanTools = {
       "which dashboard, scope, etc.). The user answers in an inline form; their answers are returned to you. " +
       "This is the ONLY way to ask the user questions — never present questions or option lists " +
       "as plain text in a reply. Prefer 'choice' questions with concrete options over free text. " +
+      "When one option is the best default, set 'recommendedOption' to its exact label so the form " +
+      "badges it as 'Recommended'. " +
       "Only ask what you genuinely need — do not ask questions you can answer with read-only tools.",
     inputSchema: askClarifyingQuestionsSchema,
     // No execute function - resolved by the client via an interactive form.


### PR DESCRIPTION
## Summary
- Add optional `recommendedOption` to the clarifying-question schema (`packages/agent-tools/src/plan-tools.ts`), scoped to single-choice questions and requiring an exact-label match against `options`.
- Badge the matching option with a subtle outlined **"Recommended"** chip in `ClarifyingQuestionsCard.tsx`. No pre-selection — the user still chooses explicitly. Ignored when `allowMultiple` is set.
- Update the tool `description` and the **Clarify & Plan** prompt guidance (`api/src/agents/modes/prompts.ts`) so the model knows to set `recommendedOption` when one option is the best default.

## Notes
- Exact-label match is fail-safe: a mismatch simply renders no badge (no crash).
- `@mako/agent-tools` `dist/` is gitignored; CI rebuilds it so `app` picks up the new type.

## Test plan
- [ ] Trigger a single-choice clarifying question with `recommendedOption` set → the matching row shows the "Recommended" chip and nothing is pre-selected.
- [ ] `allowMultiple` question with `recommendedOption` → no badge rendered.
- [ ] Mismatched `recommendedOption` label → no badge, form still works.
- [ ] `pnpm --filter app run typecheck && lint`, `pnpm --filter api run lint` green.

Made with [Cursor](https://cursor.com)