### PR TITLE
fix(apps): allow links + downloads in sandboxed app preview iframes

### DIFF
--- a/app/src/app-runtime/preview.ts
+++ b/app/src/app-runtime/preview.ts
@@ -194,6 +194,10 @@ export function buildPreviewHtml(
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- The frame is an opaque origin (no allow-same-origin), so a plain
+         <a href> can't navigate the top frame. Default every link to a new
+         tab so app links open externally instead of silently no-opping. -->
+    <base target="_blank" />
     <script type="importmap">${importMap}</script>
     <script src="https://unpkg.com/@babel/standalone@7.25.6/babel.min.js"></script>
     <style>

--- a/app/src/components/AppRenderer.tsx
+++ b/app/src/components/AppRenderer.tsx
@@ -321,7 +321,7 @@ export default function AppRenderer({ appId }: { appId: string }) {
           title={`app-preview-${appId}`}
           data-mako-app-preview={appId}
           srcDoc={srcDoc}
-          sandbox="allow-scripts"
+          sandbox="allow-scripts allow-downloads allow-popups allow-popups-to-escape-sandbox"
           style={{ width: "100%", height: "100%", border: "none" }}
         />
         {booting && errors.length === 0 && (

--- a/app/src/components/public/PublicAppViewer.tsx
+++ b/app/src/components/public/PublicAppViewer.tsx
@@ -278,7 +278,7 @@ export default function PublicAppViewer({ token, content }: Props) {
           ref={iframeRef}
           title={`public-app-${token}`}
           srcDoc={srcDoc}
-          sandbox="allow-scripts"
+          sandbox="allow-scripts allow-downloads allow-popups allow-popups-to-escape-sandbox"
           style={{ width: "100%", height: "100%", border: "none" }}
         />
         {booting && !previewError && (

--- a/app/src/components/widgets/CodeWidget.tsx
+++ b/app/src/components/widgets/CodeWidget.tsx
@@ -41,6 +41,7 @@ const CodeWidget: React.FC<CodeWidgetProps> = ({
       <!DOCTYPE html>
       <html>
       <head>
+        <base target="_blank" />
         <style>
           body { margin: 0; padding: 8px; font-family: system-ui, sans-serif; }
           * { box-sizing: border-box; }
@@ -122,7 +123,7 @@ const CodeWidget: React.FC<CodeWidgetProps> = ({
       )}
       <iframe
         ref={iframeRef}
-        sandbox="allow-scripts"
+        sandbox="allow-scripts allow-downloads allow-popups allow-popups-to-escape-sandbox"
         style={{
           width: "100%",
           height: "100%",


### PR DESCRIPTION
## Summary

App preview iframes were sandboxed with only `allow-scripts`. `sandbox` is deny-by-default, so the browser actively blocked **downloads** (`<a download>`, blob exports, programmatic clicks), **`window.open`**, and **`target="_blank"` links** — download buttons and links in generated apps silently no-opped.

This PR:

- Adds `allow-downloads allow-popups allow-popups-to-escape-sandbox` to the three app iframes:
  - `app/src/components/AppRenderer.tsx`
  - `app/src/components/public/PublicAppViewer.tsx`
  - `app/src/components/widgets/CodeWidget.tsx`
- Injects `<base target="_blank">` so plain `<a href>` links (no explicit target) escape the opaque-origin frame into a new tab:
  - `buildPreviewHtml` in `app/src/app-runtime/preview.ts` (covers `AppRenderer` + `PublicAppViewer`)
  - the inline HTML head in `CodeWidget.tsx`

## Security / invariants preserved

- **`allow-same-origin` stays off** — apps remain on an opaque origin, so app JS still can't reach the parent DOM/cookies/`localStorage`.
- The opaque origin is load-bearing for the self-capture screenshot path (`preview.ts`), which keeps working.
- `allow-popups-to-escape-sandbox` means opened tabs are normal tabs (linked sites actually load) rather than crippled sandboxes.
- Deliberately did **not** add `allow-top-navigation*` — links open in a new tab instead of replacing the whole Mako tab/session.

## Desktop

No change needed: Electron already routes external-origin popups to `shell.openExternal` via `setWindowOpenHandler` in `packages/desktop/src/main.ts`.

## Test plan

- [ ] In an app preview, a download button (blob/`<a download>`) downloads a file.
- [ ] `target="_blank"` / `window.open` links open in a new browser tab.
- [ ] Plain `<a href>` links open in a new tab (via `<base>`).
- [ ] Public share viewer (`/share/:token`) links/downloads work.
- [ ] CodeWidget links/downloads work.
- [ ] Desktop build: external links open in the system browser.
- [ ] Self-capture screenshot of an app still works.

Made with [Cursor](https://cursor.com)