### PR TITLE
feat(transforms): make dbt tabs deep-linkable with shareable URLs

### DIFF
--- a/app/src/components/DbtExplorer.tsx
+++ b/app/src/components/DbtExplorer.tsx
@@ -76,6 +76,16 @@ import {
   DBT_JINJA_LANGUAGE_ID,
   registerDbtJinjaLanguage,
 } from "../lib/dbt-monaco";
+import {
+  useExplorerRevealStore,
+  selectRevealFor,
+} from "../store/explorerRevealStore";
+import {
+  DBT_FILE_SEP,
+  DBT_DIR_SEP,
+  DBT_JOB_SEP,
+  DBT_RUNS_SEP,
+} from "../lib/explorer-reveal";
 
 function dbtDiffLanguage(path: string): string {
   if (path.endsWith(".sql")) return DBT_JINJA_LANGUAGE_ID;
@@ -91,10 +101,12 @@ import ExplorerShell from "./ExplorerShell";
 // Folder node:  "<projectId>::dir::<dirPath>"
 // File node:    "<projectId>::file::<filePath>"
 // Job node:     "<projectId>::job::<jobId>"
-const FILE_SEP = "::file::";
-const DIR_SEP = "::dir::";
-const JOB_SEP = "::job::";
-const RUNS_SEP = "::runs::";
+// Separators are sourced from explorer-reveal.ts so reveal ids never drift
+// from the ids this explorer builds (see 71-tab-entities rule).
+const FILE_SEP = DBT_FILE_SEP;
+const DIR_SEP = DBT_DIR_SEP;
+const JOB_SEP = DBT_JOB_SEP;
+const RUNS_SEP = DBT_RUNS_SEP;
 const JOBS_DIR = "__jobs";
 
 function dirname(path: string): string {
@@ -324,6 +336,8 @@ export function DbtExplorer() {
     }
     return null;
   }, [activeTab]);
+
+  const reveal = useExplorerRevealStore(selectRevealFor("dbt"));
 
   const expandedFolders = useExplorerStore(s => s.dbt.expandedFolders);
   const toggleDbtFolder = useExplorerStore(s => s.toggleDbtFolder);
@@ -1503,6 +1517,8 @@ export function DbtExplorer() {
                     mode="sidebar"
                     searchQuery={searchQuery}
                     activeItemId={activeItemId}
+                    revealNodeId={reveal?.nodeId}
+                    revealNonce={reveal?.nonce}
                     getItemIcon={getItemIcon}
                     getContextMenuItems={getContextMenuItems}
                     getRightAdornment={getRightAdornment}

--- a/app/src/components/UrlSync.tsx
+++ b/app/src/components/UrlSync.tsx
@@ -14,6 +14,13 @@ import {
   focusAppFileTab,
   focusAppTab,
 } from "../app-runtime/shell";
+import {
+  focusDbtConsoleTab,
+  focusDbtFileTab,
+  focusDbtJobTab,
+  focusDbtRunsTab,
+} from "../dbt-runtime/shell";
+import { useDbtStore } from "../store/dbtStore";
 import { focusDashboardDataSourceTab } from "../dashboard-runtime/shell";
 import {
   TAB_DEEP_LINK_PATTERNS,
@@ -87,6 +94,10 @@ export function UrlSync() {
     const appFileMatch = path.match(TAB_DEEP_LINK_PATTERNS["app-file"]);
     const appBindingMatch = path.match(TAB_DEEP_LINK_PATTERNS["app-binding"]);
     const appMatch = path.match(TAB_DEEP_LINK_PATTERNS.app);
+    const dbtFileMatch = path.match(TAB_DEEP_LINK_PATTERNS["dbt-file"]);
+    const dbtJobMatch = path.match(TAB_DEEP_LINK_PATTERNS["dbt-job"]);
+    const dbtRunsMatch = path.match(TAB_DEEP_LINK_PATTERNS["dbt-runs"]);
+    const dbtConsoleMatch = path.match(TAB_DEEP_LINK_PATTERNS["dbt-console"]);
     const planMatch = path.match(TAB_DEEP_LINK_PATTERNS.plan);
     const settingsSectionMatch = path.match(TAB_DEEP_LINK_PATTERNS.settings);
     const settingsMatch = path.match(/^\/settings\/?$/);
@@ -246,6 +257,51 @@ export function UrlSync() {
             focusAppTab(appId, app?.title || "App");
           });
       }
+    } else if (dbtFileMatch) {
+      // /x/:projectId/file/:path
+      const projectId = dbtFileMatch[1];
+      const filePath = decodePathSegments(dbtFileMatch[2]);
+      setLeftPane("dbt");
+      // Helper dedupes against an existing tab and sets the active project.
+      focusDbtFileTab(projectId, filePath);
+    } else if (dbtJobMatch) {
+      // /x/:projectId/job/:jobId
+      const projectId = dbtJobMatch[1];
+      const jobId = dbtJobMatch[2];
+      setLeftPane("dbt");
+
+      const existingTab = Object.values(useConsoleStore.getState().tabs).find(
+        t =>
+          t.kind === "dbt-job" &&
+          t.metadata?.projectId === projectId &&
+          t.metadata?.jobId === jobId,
+      );
+
+      if (existingTab) {
+        setActiveTab(existingTab.id);
+      } else {
+        // Fetch jobs to resolve the title, then open the tab (placeholder
+        // title until then). focusDbtJobTab dedupes if a tab already exists.
+        useDbtStore
+          .getState()
+          .fetchJobs(currentWorkspace.id, projectId)
+          .then(() => {
+            const job = useDbtStore
+              .getState()
+              .jobsByProject[projectId]?.find(j => j._id === jobId);
+            focusDbtJobTab(projectId, jobId, job?.name || "Job");
+          });
+      }
+    } else if (dbtRunsMatch) {
+      // /x/:projectId/runs
+      const projectId = dbtRunsMatch[1];
+      setLeftPane("dbt");
+      focusDbtRunsTab(projectId, "Runs");
+    } else if (dbtConsoleMatch) {
+      // /x/:projectId — the project Console is the project home.
+      const projectId = dbtConsoleMatch[1];
+      setLeftPane("dbt");
+      focusDbtConsoleTab(projectId, "Console");
     } else if (planMatch) {
       // /p/:chatId — plans only exist within a chat session, so we can only
       // focus a plan tab that is already present in this browser's state.

--- a/app/src/dbt-runtime/shell.ts
+++ b/app/src/dbt-runtime/shell.ts
@@ -6,6 +6,7 @@
 
 import { useConsoleStore } from "../store/consoleStore";
 import { useUIStore } from "../store/uiStore";
+import { useDbtStore } from "../store/dbtStore";
 
 export function getCurrentWorkspaceId(): string | null {
   return useUIStore.getState().currentWorkspaceId ?? null;
@@ -41,6 +42,7 @@ export function focusDbtFileTab(projectId: string, path: string): string {
       { replacePristine: false },
     );
 
+  useDbtStore.getState().setActiveProject(projectId);
   consoleStore.setActiveTab(tabId);
   return tabId;
 }
@@ -65,6 +67,7 @@ export function focusDbtConsoleTab(projectId: string, title: string): string {
       { replacePristine: false },
     );
 
+  useDbtStore.getState().setActiveProject(projectId);
   consoleStore.setActiveTab(tabId);
   return tabId;
 }
@@ -104,6 +107,7 @@ export function focusDbtRunsTab(
     consoleStore.updateMetadata(tabId, { projectId, focusRunId: runId });
   }
 
+  useDbtStore.getState().setActiveProject(projectId);
   consoleStore.setActiveTab(tabId);
   return tabId;
 }
@@ -142,6 +146,7 @@ export function focusDbtJobTab(
       { replacePristine: false },
     );
 
+  useDbtStore.getState().setActiveProject(projectId);
   consoleStore.setActiveTab(tabId);
   return tabId;
 }

--- a/app/src/lib/explorer-reveal.ts
+++ b/app/src/lib/explorer-reveal.ts
@@ -21,13 +21,23 @@ export const APP_FILE_SEP = "::file::";
 export const APP_DIR_SEP = "::dir::";
 export const APP_BINDING_SEP = "::binding::";
 
+// dbt (Transforms) ResourceTree node-id encoding (kept in sync with
+// DbtExplorer, which imports these). Project node: "<projectId>";
+// dir: "<projectId>::dir::<path>"; file: "<projectId>::file::<path>";
+// job: "<projectId>::job::<jobId>"; runs: "<projectId>::runs::".
+export const DBT_FILE_SEP = "::file::";
+export const DBT_DIR_SEP = "::dir::";
+export const DBT_JOB_SEP = "::job::";
+export const DBT_RUNS_SEP = "::runs::";
+
 /** Left-pane explorers that support reveal/scroll-to-row. */
 export type RevealExplorer =
   | "consoles"
   | "dashboards"
   | "apps"
   | "connectors"
-  | "flows";
+  | "flows"
+  | "dbt";
 
 export interface ExplorerRevealTarget {
   explorer: RevealExplorer;
@@ -98,13 +108,31 @@ export function tabRevealTarget(
     case "members":
       // No sidebar tree row.
       return null;
-    case "dbt-file":
-    case "dbt-job":
-    case "dbt-console":
-    case "dbt-runs":
-      // dbt tabs live in the Transforms explorer; no stable reveal id yet
-      // (mirrors tab-routing.ts — not deep-linkable yet).
-      return null;
+    case "dbt-file": {
+      const projectId = meta.projectId as string | undefined;
+      const path = meta.path as string | undefined;
+      return projectId && path
+        ? { explorer: "dbt", nodeId: `${projectId}${DBT_FILE_SEP}${path}` }
+        : null;
+    }
+    case "dbt-job": {
+      const projectId = meta.projectId as string | undefined;
+      const jobId = meta.jobId as string | undefined;
+      return projectId && jobId
+        ? { explorer: "dbt", nodeId: `${projectId}${DBT_JOB_SEP}${jobId}` }
+        : null;
+    }
+    case "dbt-runs": {
+      const projectId = meta.projectId as string | undefined;
+      return projectId
+        ? { explorer: "dbt", nodeId: `${projectId}${DBT_RUNS_SEP}` }
+        : null;
+    }
+    case "dbt-console": {
+      // The Console is the project home — reveal the project node itself.
+      const projectId = meta.projectId as string | undefined;
+      return projectId ? { explorer: "dbt", nodeId: projectId } : null;
+    }
     default: {
       // Compile-time exhaustiveness: a new TabKind must be handled above.
       const exhaustivenessCheck: never = kind;

--- a/app/src/lib/tab-routing.test.ts
+++ b/app/src/lib/tab-routing.test.ts
@@ -107,6 +107,19 @@ describe("tab-routing", () => {
     const bindingUrl = tabUrlPath("t", FIXTURES["app-binding"]) as string;
     expect(fileUrl).not.toMatch(TAB_DEEP_LINK_PATTERNS.app);
     expect(bindingUrl).not.toMatch(TAB_DEEP_LINK_PATTERNS.app);
+
+    // /x/:id/file|job|runs must not be captured by the bare console pattern.
+    const dbtFileUrl = tabUrlPath("t", FIXTURES["dbt-file"]) as string;
+    const dbtJobUrl = tabUrlPath("t", FIXTURES["dbt-job"]) as string;
+    const dbtRunsUrl = tabUrlPath("t", FIXTURES["dbt-runs"]) as string;
+    expect(dbtFileUrl).not.toMatch(TAB_DEEP_LINK_PATTERNS["dbt-console"]);
+    expect(dbtJobUrl).not.toMatch(TAB_DEEP_LINK_PATTERNS["dbt-console"]);
+    expect(dbtRunsUrl).not.toMatch(TAB_DEEP_LINK_PATTERNS["dbt-console"]);
+  });
+
+  it("encodes nested dbt file paths in their URL", () => {
+    const url = tabUrlPath("t", FIXTURES["dbt-file"]) as string;
+    expect(url).toBe("/x/proj-1/file/models/stg.sql");
   });
 
   it("tabs missing their identifiers produce no URL instead of a broken one", () => {

--- a/app/src/lib/tab-routing.ts
+++ b/app/src/lib/tab-routing.ts
@@ -47,11 +47,12 @@ export const TAB_DEEP_LINK_PATTERNS = {
   settings: /^\/settings\/([a-z-]+)$/,
   // Legacy tab kind superseded by the settings "members" section.
   members: null,
-  // dbt tabs are opened from the Transforms explorer; not deep-linkable yet.
-  "dbt-file": null,
-  "dbt-job": null,
-  "dbt-console": null,
-  "dbt-runs": null,
+  // dbt (Transforms) tabs are addressed under /x/:projectId. The bare project
+  // URL is the Console (project home); runs/file/job hang off it.
+  "dbt-file": /^\/x\/([a-zA-Z0-9-]+)\/file\/(.+)$/,
+  "dbt-job": /^\/x\/([a-zA-Z0-9-]+)\/job\/([a-zA-Z0-9-]+)/,
+  "dbt-runs": /^\/x\/([a-zA-Z0-9-]+)\/runs\/?$/,
+  "dbt-console": /^\/x\/([a-zA-Z0-9-]+)\/?$/,
 } as const satisfies Record<NonNullable<TabKind>, RegExp | null>;
 
 /**
@@ -119,11 +120,26 @@ export function tabUrlPath(tabId: string, tab: ConsoleTab): string | null {
         : "/settings";
     case "members":
       return null;
-    case "dbt-file":
-    case "dbt-job":
-    case "dbt-console":
-    case "dbt-runs":
-      return null;
+    case "dbt-file": {
+      const projectId = tab.metadata?.projectId as string | undefined;
+      const path = tab.metadata?.path as string | undefined;
+      return projectId && path
+        ? `/x/${projectId}/file/${encodePathSegments(path)}`
+        : null;
+    }
+    case "dbt-job": {
+      const projectId = tab.metadata?.projectId as string | undefined;
+      const jobId = tab.metadata?.jobId as string | undefined;
+      return projectId && jobId ? `/x/${projectId}/job/${jobId}` : null;
+    }
+    case "dbt-runs": {
+      const projectId = tab.metadata?.projectId as string | undefined;
+      return projectId ? `/x/${projectId}/runs` : null;
+    }
+    case "dbt-console": {
+      const projectId = tab.metadata?.projectId as string | undefined;
+      return projectId ? `/x/${projectId}` : null;
+    }
     default: {
       // Compile-time exhaustiveness: a new TabKind must be handled above.
       const exhaustivenessCheck: never = kind;


### PR DESCRIPTION
## Summary

dbt (Transforms) tabs were the only deep-linkable-eligible tab kinds stubbed to `null` everywhere (the recurring *"not deep-linkable yet"* comment). They now get stable, shareable URLs — opening one updates the address bar, and the URL restores the tab on a cold load — exactly like apps do.

URL scheme (under `/x/:projectId`):

| Tab | URL |
|---|---|
| Console (project home) | `/x/:projectId` |
| Runs | `/x/:projectId/runs` |
| File | `/x/:projectId/file/<path>` |
| Job | `/x/:projectId/job/:jobId` |

## Changes

- **`lib/tab-routing.ts`** — real `TAB_DEEP_LINK_PATTERNS` regexes + `tabUrlPath` builders for all four kinds (guarding on `projectId`/`path`/`jobId`).
- **`components/UrlSync.tsx`** — hydration branches (most-specific first: file → job → runs → console). The job branch fetches jobs to resolve the real title; others open via the dedupe-aware `focusDbt*` helpers.
- **`lib/explorer-reveal.ts`** — added `"dbt"` to `RevealExplorer`, exported the node-id separators, and mapped each kind to the exact tree-node id the explorer builds (console → project node).
- **`components/DbtExplorer.tsx`** — sources separators from `explorer-reveal.ts` (no drift), subscribes via `selectRevealFor("dbt")`, threads `revealNodeId`/`revealNonce` into the files `ResourceTree`.
- **`dbt-runtime/shell.ts`** — `focusDbt*` helpers now call `setActiveProject(projectId)` (mirrors `focusAppTab`'s `setActiveApp`), so deep-linking to a non-active project switches the explorer to it.
- **`lib/tab-routing.test.ts`** — round-trip guard auto-covers the new URLs; added assertions that `/x/:id/file|job|runs` aren't captured by the bare console pattern + a file-path encoding check.

Follows the `71-tab-entities.mdc` checklist; the exhaustiveness guards (`tabUrlPath`, `segmentsForTab`, `tabRevealTarget`) all stay satisfied.

## Test plan

- [x] `pnpm --filter app run test:unit` — tab-routing round-trip + nested-route guards pass (the pre-existing `dbtStore.test.ts > fetchRuns` failure is unrelated — confirmed it fails identically on a clean tree).
- [x] `pnpm --filter app run typecheck` — clean.
- [x] `pnpm --filter app run lint` — clean.
- [ ] Manual: open a dbt file/job/runs/console tab → address bar shows `/x/...`; paste the URL into a fresh tab → the correct project + tab restores and the sidebar row reveals/highlights.

Made with [Cursor](https://cursor.com)