### PR TITLE
fix(chat): survive mobile lock / computer sleep — resume on wake + serverize mutation tools

### DIFF
--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -18,12 +18,23 @@ import { tool } from "ai";
 import { z } from "zod";
 import { Types } from "mongoose";
 import {
+  createDbtFileSchema,
+  modifyDbtFileSchema,
+  deleteDbtFileSchema,
+} from "@mako/agent-tools";
+import {
   DatabaseConnection,
   DbtFile,
   DbtJob,
   DbtProject,
   DbtRun,
 } from "../../database/workspace-schema";
+import { publishRealtimeEvent } from "../../services/realtime.service";
+import {
+  createVersion,
+  getLatestVersionNumber,
+  getUserDisplayName,
+} from "../../services/entity-version.service";
 import { runAdhocDbtCommand } from "../../dbt/dbt-project.service";
 import {
   applyJobScheduleChange,
@@ -108,7 +119,43 @@ function summarizeLogs(logs: DbtLogLine[], maxLines = 30): string[] {
   return selected.map(log => `[${log.level}] ${log.line}`);
 }
 
-export const createDbtServerTools = (workspaceId: string, userId?: string) => {
+/** Mirror of dbt.routes.ts isSafeDbtPath — block traversal / absolute paths. */
+function isSafeDbtPath(path: string): boolean {
+  return (
+    typeof path === "string" &&
+    path.length > 0 &&
+    path.length < 1024 &&
+    !path.startsWith("/") &&
+    !path.split("/").includes("..") &&
+    !path.includes("\\")
+  );
+}
+
+export const createDbtServerTools = (
+  workspaceId: string,
+  userId?: string,
+  options?: { chatId?: string },
+) => {
+  const agentClientId = `agent:${options?.chatId ?? "unknown"}`;
+
+  // Poke open dbt-file tabs to pull the new content (poke-then-pull, mirrors
+  // the console #475 realtime sync).
+  const publishFileUpdated = (
+    projectId: string,
+    path: string,
+    deleted?: boolean,
+  ) => {
+    publishRealtimeEvent(workspaceId, {
+      type: "dbt.file.updated",
+      projectId,
+      path,
+      deleted,
+      updatedBy: userId ?? "agent",
+      clientId: agentClientId,
+      origin: "agent",
+    });
+  };
+
   const assertProject = async (projectId: string) => {
     if (!Types.ObjectId.isValid(projectId)) {
       throw new Error("Invalid dbt project id");
@@ -164,7 +211,155 @@ export const createDbtServerTools = (workspaceId: string, userId?: string) => {
     return null;
   };
 
+  // Snapshot a dbt file version (entity-version pattern, mirrors the route).
+  const snapshotVersion = async (
+    fileId: Types.ObjectId,
+    projectId: Types.ObjectId,
+    wsId: Types.ObjectId,
+    path: string,
+    content: string,
+  ) => {
+    try {
+      const latest = await getLatestVersionNumber(fileId, "dbt-file");
+      const savedBy = userId ?? "agent";
+      await createVersion({
+        entityType: "dbt-file",
+        entityId: fileId,
+        workspaceId: wsId,
+        snapshot: { path, content },
+        savedBy,
+        savedByName: userId ? await getUserDisplayName(userId) : "Agent",
+        comment: `Save ${path} (v${latest + 1})`,
+      });
+    } catch {
+      /* version history is best-effort */
+    }
+    void projectId;
+  };
+
   return {
+    create_dbt_file: tool({
+      description:
+        "Create a new file in a dbt project (e.g. a staging model + its " +
+        "schema.yml entry). Fails if the file already exists — use " +
+        "modify_dbt_file to change existing files. After writing models, " +
+        "verify with dbt_parse and dbt_compile_model.",
+      inputSchema: createDbtFileSchema,
+      execute: async ({ projectId, path, contents }) => {
+        try {
+          const project = await assertProject(projectId);
+          if (!isSafeDbtPath(path)) {
+            return { success: false, error: "Invalid file path" };
+          }
+          const existing = await DbtFile.findOne({
+            projectId: project._id,
+            path,
+            is_deleted: { $ne: true },
+          });
+          if (existing) {
+            return {
+              success: false,
+              error: `File already exists: ${path}. Use modify_dbt_file to change it.`,
+            };
+          }
+          const file = await DbtFile.findOneAndUpdate(
+            { projectId: project._id, path },
+            {
+              $set: {
+                content: contents ?? "",
+                updatedBy: userId,
+                is_deleted: false,
+                workspaceId: project.workspaceId,
+              },
+            },
+            { upsert: true, new: true, setDefaultsOnInsert: true },
+          );
+          await snapshotVersion(
+            file._id,
+            project._id,
+            project.workspaceId,
+            path,
+            contents ?? "",
+          );
+          await DbtProject.updateOne(
+            { _id: project._id },
+            { $currentDate: { updatedAt: true } },
+          );
+          publishFileUpdated(projectId, path);
+          return { success: true, path };
+        } catch (error) {
+          return toolError(error, "Failed to create dbt file");
+        }
+      },
+    }),
+
+    modify_dbt_file: tool({
+      description:
+        "Overwrite an existing dbt project file with full contents. The open " +
+        "editor tab updates live; every save snapshots a version for undo. " +
+        "After editing, verify with dbt_parse / dbt_compile_model.",
+      inputSchema: modifyDbtFileSchema,
+      execute: async ({ projectId, path, contents }) => {
+        try {
+          const project = await assertProject(projectId);
+          if (!isSafeDbtPath(path)) {
+            return { success: false, error: "Invalid file path" };
+          }
+          if ((contents ?? "").length > 1_000_000) {
+            return { success: false, error: "File too large (max 1MB)" };
+          }
+          const file = await DbtFile.findOneAndUpdate(
+            { projectId: project._id, path },
+            {
+              $set: {
+                content: contents ?? "",
+                updatedBy: userId,
+                is_deleted: false,
+                workspaceId: project.workspaceId,
+              },
+            },
+            { upsert: true, new: true, setDefaultsOnInsert: true },
+          );
+          await snapshotVersion(
+            file._id,
+            project._id,
+            project.workspaceId,
+            path,
+            contents ?? "",
+          );
+          await DbtProject.updateOne(
+            { _id: project._id },
+            { $currentDate: { updatedAt: true } },
+          );
+          publishFileUpdated(projectId, path);
+          return { success: true, path };
+        } catch (error) {
+          return toolError(error, "Failed to save dbt file");
+        }
+      },
+    }),
+
+    delete_dbt_file: tool({
+      description: "Delete a file from a dbt project.",
+      inputSchema: deleteDbtFileSchema,
+      execute: async ({ projectId, path }) => {
+        try {
+          const project = await assertProject(projectId);
+          const result = await DbtFile.updateOne(
+            { projectId: project._id, path },
+            { $set: { is_deleted: true, updatedBy: userId } },
+          );
+          if (result.matchedCount === 0) {
+            return { success: false, error: `File not found: ${path}` };
+          }
+          publishFileUpdated(projectId, path, true);
+          return { success: true, path };
+        } catch (error) {
+          return toolError(error, "Failed to delete dbt file");
+        }
+      },
+    }),
+
     dbt_create_project: tool({
       description:
         "Initialize a new dbt project in this workspace. Use this when " +

--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -214,7 +214,6 @@ export const createDbtServerTools = (
   // Snapshot a dbt file version (entity-version pattern, mirrors the route).
   const snapshotVersion = async (
     fileId: Types.ObjectId,
-    projectId: Types.ObjectId,
     wsId: Types.ObjectId,
     path: string,
     content: string,
@@ -234,7 +233,6 @@ export const createDbtServerTools = (
     } catch {
       /* version history is best-effort */
     }
-    void projectId;
   };
 
   return {
@@ -276,7 +274,6 @@ export const createDbtServerTools = (
           );
           await snapshotVersion(
             file._id,
-            project._id,
             project.workspaceId,
             path,
             contents ?? "",
@@ -322,7 +319,6 @@ export const createDbtServerTools = (
           );
           await snapshotVersion(
             file._id,
-            project._id,
             project.workspaceId,
             path,
             contents ?? "",

--- a/api/src/agent-lib/tools/server-app-tools.ts
+++ b/api/src/agent-lib/tools/server-app-tools.ts
@@ -1,0 +1,336 @@
+/**
+ * Server-side React App tools (issue #475 pattern, extended to apps)
+ *
+ * App mutation tools (write/delete/rename file, add/remove dependency,
+ * create/delete data binding) execute on the API against the authoritative
+ * MakoApp document instead of in the browser. Like the console server tools,
+ * the agent becomes "just another writer": every mutation persists to Mongo and
+ * pokes the workspace realtime channel so open tabs refresh live — and a
+ * detached chat (mobile lock / computer sleep) keeps working end-to-end because
+ * the write no longer depends on a connected browser.
+ *
+ * Browser-only legs stay client-side: `run_app` (preview rebuild) and
+ * `materialize_binding` (DuckDB-WASM materialization), plus the cheap reads
+ * `list_open_apps` / `open_app` / `get_app_state` / `app_read_file`.
+ *
+ * Tool schemas live in @mako/agent-tools (shared with the app's tool cards).
+ */
+import { tool } from "ai";
+import { Types } from "mongoose";
+import { nanoid } from "nanoid";
+import {
+  writeFileSchema,
+  deleteFileSchema,
+  renameFileSchema,
+  addDependencySchema,
+  removeDependencySchema,
+  createDataBindingSchema,
+  deleteDataBindingSchema,
+} from "@mako/agent-tools";
+import { normalizeAppFiles } from "@mako/schemas";
+import {
+  MakoApp,
+  DatabaseConnection,
+  type IMakoApp,
+} from "../../database/workspace-schema";
+import { workspaceService } from "../../services/workspace.service";
+import { publishRealtimeEvent } from "../../services/realtime.service";
+import { canReadResource, canWriteResource } from "../../utils/resource-acl";
+import { loggers } from "../../logging";
+
+const logger = loggers.agent();
+
+export interface ServerAppToolsOptions {
+  workspaceId: string;
+  /** Acting user (session user id, or API-key creator). */
+  userId?: string;
+  /** Chat driving this turn — used as the realtime echo-suppression id. */
+  chatId?: string;
+}
+
+type LoadResult = { doc: IMakoApp } | { error: string };
+
+function isLoadError(r: LoadResult): r is { error: string } {
+  return (r as { error?: string }).error !== undefined;
+}
+
+export function createServerAppTools({
+  workspaceId,
+  userId,
+  chatId,
+}: ServerAppToolsOptions) {
+  const agentClientId = `agent:${chatId ?? "unknown"}`;
+
+  const loadApp = async (appId: string): Promise<LoadResult> => {
+    if (!appId) {
+      return {
+        error: "appId is required. Use list_open_apps to find app IDs.",
+      };
+    }
+    if (!Types.ObjectId.isValid(appId)) {
+      return { error: `Invalid app ID: ${appId}` };
+    }
+    const doc = await MakoApp.findOne({
+      _id: new Types.ObjectId(appId),
+      workspaceId: new Types.ObjectId(workspaceId),
+    });
+    if (!doc) {
+      return {
+        error: `App ${appId} not found. Use list_open_apps to see available apps.`,
+      };
+    }
+    if (userId && !canReadResource(doc, userId, await memberRole())) {
+      return {
+        error: `App ${appId} not found. Use list_open_apps to see available apps.`,
+      };
+    }
+    return { doc };
+  };
+
+  let cachedRole: string | undefined | null = null;
+  const memberRole = async (): Promise<string | undefined> => {
+    if (cachedRole !== null) return cachedRole;
+    if (!userId) {
+      cachedRole = undefined;
+      return undefined;
+    }
+    try {
+      const member = await workspaceService.getMember(workspaceId, userId);
+      cachedRole = member?.role;
+    } catch {
+      cachedRole = undefined;
+    }
+    return cachedRole ?? undefined;
+  };
+
+  const canWrite = async (doc: IMakoApp): Promise<boolean> => {
+    if (!userId) return true; // workspace-scoped API-key automation
+    return canWriteResource(doc, userId, await memberRole());
+  };
+
+  // Persist a mutated app doc, then poke the workspace channel so open tabs
+  // pull the new definition and rebuild their preview.
+  const saveAndPublish = async (doc: IMakoApp): Promise<number> => {
+    doc.version += 1;
+    await doc.save();
+    publishRealtimeEvent(workspaceId, {
+      type: "app.updated",
+      appId: doc._id.toString(),
+      version: doc.version,
+      updatedBy: userId ?? "agent",
+      clientId: agentClientId,
+      origin: "agent",
+    });
+    return doc.version;
+  };
+
+  // Validate that a data-binding connection belongs to this workspace.
+  const validateConnection = async (
+    connectionId: string | undefined,
+  ): Promise<{ ok: true } | { ok: false; error: string }> => {
+    if (!connectionId) return { ok: true };
+    if (!Types.ObjectId.isValid(connectionId)) {
+      return { ok: false, error: `Invalid connectionId: ${connectionId}` };
+    }
+    const found = await DatabaseConnection.countDocuments({
+      _id: new Types.ObjectId(connectionId),
+      workspaceId: new Types.ObjectId(workspaceId),
+    });
+    return found > 0
+      ? { ok: true }
+      : { ok: false, error: "Data binding connection is invalid" };
+  };
+
+  const denied = (appId: string) => ({
+    success: false as const,
+    error: `You do not have write access to app ${appId}.`,
+  });
+
+  const wrap = async <T>(
+    label: string,
+    fn: () => Promise<T>,
+  ): Promise<T | { success: false; error: string }> => {
+    try {
+      return await fn();
+    } catch (error) {
+      logger.warn(`Server app tool failed: ${label}`, { error, workspaceId });
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : `Failed: ${label}`,
+      };
+    }
+  };
+
+  return {
+    app_write_file: tool({
+      description:
+        "Create or overwrite a file with full contents. This is the primary " +
+        "editing tool — write the complete file, not a diff. Writing the " +
+        "entrypoint or any imported file refreshes the live preview.",
+      inputSchema: writeFileSchema,
+      execute: async ({ appId, path, contents }) =>
+        wrap("app_write_file", async () => {
+          const loaded = await loadApp(appId);
+          if (isLoadError(loaded)) return { success: false, ...loaded };
+          const { doc } = loaded;
+          if (!(await canWrite(doc))) return denied(appId);
+          doc.files = normalizeAppFiles([
+            ...(doc.files ?? []).filter(f => f.path !== path),
+            { path, contents: contents ?? "" },
+          ]) as IMakoApp["files"];
+          const version = await saveAndPublish(doc);
+          return { success: true, path, version };
+        }),
+    }),
+
+    app_delete_file: tool({
+      description: "Delete a file from the app.",
+      inputSchema: deleteFileSchema,
+      execute: async ({ appId, path }) =>
+        wrap("app_delete_file", async () => {
+          const loaded = await loadApp(appId);
+          if (isLoadError(loaded)) return { success: false, ...loaded };
+          const { doc } = loaded;
+          if (!(await canWrite(doc))) return denied(appId);
+          doc.files = (doc.files ?? []).filter(
+            f => f.path !== path,
+          ) as IMakoApp["files"];
+          const version = await saveAndPublish(doc);
+          return { success: true, path, version };
+        }),
+    }),
+
+    app_rename_file: tool({
+      description: "Rename/move a file within the app.",
+      inputSchema: renameFileSchema,
+      execute: async ({ appId, from, to }) =>
+        wrap("app_rename_file", async () => {
+          const loaded = await loadApp(appId);
+          if (isLoadError(loaded)) return { success: false, ...loaded };
+          const { doc } = loaded;
+          if (!(await canWrite(doc))) return denied(appId);
+          const file = (doc.files ?? []).find(f => f.path === from);
+          if (!file)
+            return { success: false, error: `File not found: ${from}` };
+          doc.files = normalizeAppFiles([
+            ...(doc.files ?? []).filter(f => f.path !== from && f.path !== to),
+            { path: to, contents: file.contents },
+          ]) as IMakoApp["files"];
+          if (doc.entrypoint === from) doc.entrypoint = to;
+          const version = await saveAndPublish(doc);
+          return { success: true, from, to, version };
+        }),
+    }),
+
+    app_add_dependency: tool({
+      description:
+        "Add an npm dependency to the app (e.g. d3, framer-motion, recharts). " +
+        "The dependency becomes importable from app code on the next preview build.",
+      inputSchema: addDependencySchema,
+      execute: async ({ appId, name, version: depVersion }) =>
+        wrap("app_add_dependency", async () => {
+          const loaded = await loadApp(appId);
+          if (isLoadError(loaded)) return { success: false, ...loaded };
+          const { doc } = loaded;
+          if (!(await canWrite(doc))) return denied(appId);
+          doc.dependencies = {
+            ...(doc.dependencies ?? {}),
+            [name]: depVersion || "latest",
+          };
+          const version = await saveAndPublish(doc);
+          return { success: true, name, version };
+        }),
+    }),
+
+    app_remove_dependency: tool({
+      description: "Remove an npm dependency from the app.",
+      inputSchema: removeDependencySchema,
+      execute: async ({ appId, name }) =>
+        wrap("app_remove_dependency", async () => {
+          const loaded = await loadApp(appId);
+          if (isLoadError(loaded)) return { success: false, ...loaded };
+          const { doc } = loaded;
+          if (!(await canWrite(doc))) return denied(appId);
+          const next = { ...(doc.dependencies ?? {}) };
+          delete next[name];
+          doc.dependencies = next;
+          const version = await saveAndPublish(doc);
+          return { success: true, name, version };
+        }),
+    }),
+
+    app_create_data_binding: tool({
+      description:
+        "Create a named data binding that the app can read via useQuery(name) " +
+        "from '@mako/app-sdk'. The query runs server-side, scoped to the " +
+        "workspace — the app never sees credentials. Set materialization to " +
+        "'parquet' for DuckDB-WASM-backed analytics (then call materialize_binding). " +
+        "Use the SQL connections/tools to inspect schema and validate the query first.",
+      inputSchema: createDataBindingSchema,
+      execute: async input =>
+        wrap("app_create_data_binding", async () => {
+          const loaded = await loadApp(input.appId);
+          if (isLoadError(loaded)) return { success: false, ...loaded };
+          const { doc } = loaded;
+          if (!(await canWrite(doc))) return denied(input.appId);
+          const connCheck = await validateConnection(input.connectionId);
+          if (!connCheck.ok) return { success: false, error: connCheck.error };
+          const materialization =
+            input.materialization === "parquet" ? "parquet" : "live";
+          const created = {
+            id: nanoid(10),
+            name: input.name,
+            connectionId: input.connectionId,
+            language: input.language || "sql",
+            code: input.code,
+            databaseId: input.databaseId,
+            databaseName: input.databaseName,
+            materialization,
+            cache: undefined,
+          };
+          // Replace any existing binding with the same name (mirrors the client
+          // addDataBinding semantics).
+          doc.dataBindings = [
+            ...(doc.dataBindings ?? []).filter(b => b.name !== created.name),
+            created,
+          ] as IMakoApp["dataBindings"];
+          const version = await saveAndPublish(doc);
+          return {
+            success: true,
+            binding: { name: created.name, materialization },
+            version,
+            hint:
+              materialization === "parquet"
+                ? `Call materialize_binding for "${created.name}", then read it with useQuery("${created.name}") or run analytics with useDuckDB(sql) from '@mako/app-sdk'.`
+                : `Read it in app code with useQuery("${created.name}") from '@mako/app-sdk'.`,
+          };
+        }),
+    }),
+
+    app_delete_data_binding: tool({
+      description:
+        "Delete a named data binding (data source) from the app. Use this to " +
+        "clean up orphaned or superseded bindings. Removes the binding from the " +
+        "app definition and persists the change. Confirm the binding name with " +
+        "list_data_sources first; the change is reflected there afterward.",
+      inputSchema: deleteDataBindingSchema,
+      execute: async ({ appId, name }) =>
+        wrap("app_delete_data_binding", async () => {
+          const loaded = await loadApp(appId);
+          if (isLoadError(loaded)) return { success: false, ...loaded };
+          const { doc } = loaded;
+          if (!(await canWrite(doc))) return denied(appId);
+          const exists = (doc.dataBindings ?? []).some(b => b.name === name);
+          if (!exists) {
+            return { success: false, error: `No data binding named "${name}"` };
+          }
+          doc.dataBindings = (doc.dataBindings ?? []).filter(
+            b => b.name !== name,
+          ) as IMakoApp["dataBindings"];
+          const version = await saveAndPublish(doc);
+          const remaining = (doc.dataBindings ?? []).map(b => b.name);
+          return { success: true, deleted: name, remaining, version };
+        }),
+    }),
+  };
+}

--- a/api/src/agent-lib/tools/server-app-tools.ts
+++ b/api/src/agent-lib/tools/server-app-tools.ts
@@ -210,8 +210,9 @@ export function createServerAppTools({
           const { doc } = loaded;
           if (!(await canWrite(doc))) return denied(appId);
           const file = (doc.files ?? []).find(f => f.path === from);
-          if (!file)
+          if (!file) {
             return { success: false, error: `File not found: ${from}` };
+          }
           doc.files = normalizeAppFiles([
             ...(doc.files ?? []).filter(f => f.path !== from && f.path !== to),
             { path: to, contents: file.contents },

--- a/api/src/agents/unified/index.ts
+++ b/api/src/agents/unified/index.ts
@@ -7,6 +7,7 @@ import {
   clientDataSourceTools,
 } from "@mako/agent-tools";
 import { createDbtServerTools } from "../../agent-lib/tools/dbt-tools";
+import { createServerAppTools } from "../../agent-lib/tools/server-app-tools";
 import { createSelfDirectiveTools } from "../../agent-lib/tools/self-directive-tool";
 import { createSkillTools } from "../../agent-lib/tools/skill-tools";
 import { createConsoleSearchTools } from "../../agent-lib/tools/console-search-tools";
@@ -49,6 +50,11 @@ export function unifiedAgentFactory(context: AgentContext): AgentConfig {
   const versionHistoryTools = createVersionHistoryTools(workspaceId);
   const dbtServerTools = createDbtServerTools(workspaceId, userId);
   const webTools = createWebTools(context.toolExecutionContext);
+  const serverAppTools = createServerAppTools({
+    workspaceId,
+    userId,
+    chatId: context.chatId,
+  });
 
   const {
     list_connections: _flowListConnections,
@@ -76,6 +82,7 @@ export function unifiedAgentFactory(context: AgentContext): AgentConfig {
       ...universalTools,
       ...clientDashboardTools,
       ...clientAppTools,
+      ...serverAppTools,
       ...clientDbtTools,
       ...dbtServerTools,
       ...clientDataSourceTools,

--- a/api/src/agents/unified/index.ts
+++ b/api/src/agents/unified/index.ts
@@ -48,7 +48,9 @@ export function unifiedAgentFactory(context: AgentContext): AgentConfig {
     context.toolExecutionContext,
   );
   const versionHistoryTools = createVersionHistoryTools(workspaceId);
-  const dbtServerTools = createDbtServerTools(workspaceId, userId);
+  const dbtServerTools = createDbtServerTools(workspaceId, userId, {
+    chatId: context.chatId,
+  });
   const webTools = createWebTools(context.toolExecutionContext);
   const serverAppTools = createServerAppTools({
     workspaceId,

--- a/api/src/services/realtime.service.ts
+++ b/api/src/services/realtime.service.ts
@@ -58,6 +58,36 @@ export type RealtimeEvent =
       type: "chat.activity";
       chatId: string;
       state: "streaming" | "idle";
+    }
+  // Agent-driven mutation pokes for server-executed app/dbt/dashboard tools
+  // (the app/dbt/dashboard analogue of console.updated). Open tabs pull the
+  // authoritative document over normal HTTP when the carried version/path is
+  // newer than what they hold (poke-then-pull). `clientId` lets a tab suppress
+  // its own echoes; agent writes carry `agent:<chatId>`.
+  | {
+      type: "app.updated";
+      appId: string;
+      version: number;
+      updatedBy: string;
+      clientId?: string;
+      origin: "agent" | "save";
+    }
+  | {
+      type: "dbt.file.updated";
+      projectId: string;
+      path: string;
+      deleted?: boolean;
+      updatedBy: string;
+      clientId?: string;
+      origin: "agent" | "save";
+    }
+  | {
+      type: "dashboard.updated";
+      dashboardId: string;
+      version: number;
+      updatedBy: string;
+      clientId?: string;
+      origin: "agent" | "save";
     };
 
 function channelFor(workspaceId: string): string {

--- a/app/src/agent-runtime/client-tool-manifest.ts
+++ b/app/src/agent-runtime/client-tool-manifest.ts
@@ -562,10 +562,12 @@ export const AGENT_TOOL_MANIFEST = {
     },
     icon: "eye",
   },
+  // dbt file mutation tools execute SERVER-SIDE (issue #475 pattern; see
+  // createDbtServerTools in api/src/agent-lib/tools/dbt-tools.ts). Open editor
+  // tabs follow along via the realtime channel (dbt.file.updated).
   create_dbt_file: {
     domain: "dbt",
-    execution: "client",
-    clientExecutor: "dbt",
+    execution: "server",
     longRunning: true,
     getLabel: input => {
       const path = (input as Record<string, unknown>)?.path;
@@ -576,8 +578,7 @@ export const AGENT_TOOL_MANIFEST = {
   },
   modify_dbt_file: {
     domain: "dbt",
-    execution: "client",
-    clientExecutor: "dbt",
+    execution: "server",
     longRunning: true,
     getLabel: input => {
       const path = (input as Record<string, unknown>)?.path;
@@ -588,8 +589,7 @@ export const AGENT_TOOL_MANIFEST = {
   },
   delete_dbt_file: {
     domain: "dbt",
-    execution: "client",
-    clientExecutor: "dbt",
+    execution: "server",
     getLabel: input => {
       const path = (input as Record<string, unknown>)?.path;
       return path ? `Deleting ${path}` : "Deleting dbt file";

--- a/app/src/agent-runtime/client-tool-manifest.ts
+++ b/app/src/agent-runtime/client-tool-manifest.ts
@@ -431,10 +431,12 @@ export const AGENT_TOOL_MANIFEST = {
     },
     icon: "eye",
   },
+  // App mutation tools execute SERVER-SIDE (issue #475 pattern; see
+  // api/src/agent-lib/tools/server-app-tools.ts). Open tabs follow along via
+  // the realtime channel (app.updated). Entries kept for tool-card UI.
   app_write_file: {
     domain: "app",
-    execution: "client",
-    clientExecutor: "app",
+    execution: "server",
     longRunning: true,
     getLabel: input => {
       const path = (input as Record<string, unknown>)?.path;
@@ -445,8 +447,7 @@ export const AGENT_TOOL_MANIFEST = {
   },
   app_delete_file: {
     domain: "app",
-    execution: "client",
-    clientExecutor: "app",
+    execution: "server",
     getLabel: input => {
       const path = (input as Record<string, unknown>)?.path;
       return path ? `Deleting ${path}` : "Deleting file";
@@ -455,15 +456,13 @@ export const AGENT_TOOL_MANIFEST = {
   },
   app_rename_file: {
     domain: "app",
-    execution: "client",
-    clientExecutor: "app",
+    execution: "server",
     getLabel: () => "Renaming file",
     icon: "pencil",
   },
   app_add_dependency: {
     domain: "app",
-    execution: "client",
-    clientExecutor: "app",
+    execution: "server",
     longRunning: true,
     getLabel: input => {
       const name = (input as Record<string, unknown>)?.name;
@@ -473,8 +472,7 @@ export const AGENT_TOOL_MANIFEST = {
   },
   app_remove_dependency: {
     domain: "app",
-    execution: "client",
-    clientExecutor: "app",
+    execution: "server",
     getLabel: input => {
       const name = (input as Record<string, unknown>)?.name;
       return name ? `Removing dependency ${name}` : "Removing dependency";
@@ -483,8 +481,7 @@ export const AGENT_TOOL_MANIFEST = {
   },
   app_create_data_binding: {
     domain: "app",
-    execution: "client",
-    clientExecutor: "app",
+    execution: "server",
     longRunning: true,
     getLabel: input => {
       const name = (input as Record<string, unknown>)?.name;
@@ -495,8 +492,7 @@ export const AGENT_TOOL_MANIFEST = {
   },
   app_delete_data_binding: {
     domain: "app",
-    execution: "client",
-    clientExecutor: "app",
+    execution: "server",
     getLabel: input => {
       const name = (input as Record<string, unknown>)?.name;
       return name ? `Deleting data binding "${name}"` : "Deleting data binding";

--- a/app/src/agent-runtime/screenshot-agent-tools.ts
+++ b/app/src/agent-runtime/screenshot-agent-tools.ts
@@ -518,7 +518,13 @@ async function analyzeImageQuality(
  * composite the returned PNGs over the parent capture at the iframe rects.
  */
 const APP_PREVIEW_IFRAME_SELECTOR = "iframe[data-mako-app-preview]";
-const APP_PREVIEW_CAPTURE_TIMEOUT_MS = 8000;
+// Per-iframe self-capture cap. Kept deliberately short: capture_screenshot is a
+// client-only, long-running tool, so the longer it runs the wider the window in
+// which a mobile lock / computer sleep / proxy idle timeout can interrupt the
+// turn and strand the card. Iframes are captured in parallel (Promise.all), so
+// this bounds the whole composite, not each iframe serially. A timed-out iframe
+// degrades gracefully (its region is reported as a capture failure).
+const APP_PREVIEW_CAPTURE_TIMEOUT_MS = 4000;
 let captureSeq = 0;
 
 function findAppPreviewIframes(target: HTMLElement): HTMLIFrameElement[] {

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -1999,12 +1999,15 @@ const Chat: React.FC<ChatProps> = ({
     new Map<string, ActiveClientToolCall>(),
   );
   const cancelledClientToolCallIdsRef = useRef(new Set<string>());
-  // Bounds onError → resume retries so a genuinely-offline client can't spin in
-  // a clearError()/resumeStream() loop. Resets after a quiet window.
-  const errorResumeRef = useRef<{ at: number; count: number }>({
-    at: 0,
-    count: 0,
-  });
+  // Spaces + bounds onError → resume retries. A failed resume re-fires onError,
+  // so retrying instantly would burst; instead we schedule one delayed attempt
+  // (giving a brief network blip time to recover) and cap attempts per window
+  // before falling back to poisoning the tool cards.
+  const errorResumeRef = useRef<{
+    count: number;
+    windowStart: number;
+    timer: ReturnType<typeof setTimeout> | null;
+  }>({ count: 0, windowStart: 0, timer: null });
   const [activeClientToolCallCount, setActiveClientToolCallCount] = useState(0);
   const [queuedPrompts, setQueuedPrompts] = useState<QueuedPrompt[]>([]);
   const queuedPromptsRef = useRef(queuedPrompts);
@@ -2601,10 +2604,19 @@ const Chat: React.FC<ChatProps> = ({
         document.visibilityState !== "visible" ||
         stalledToolNames.length > 0;
 
+      const RESUME_RETRY_DELAY_MS = 1500;
+      const RESUME_RETRY_WINDOW_MS = 30_000;
+      const RESUME_MAX_RETRIES = 4;
       const now = Date.now();
       const resumeState = errorResumeRef.current;
-      if (now - resumeState.at > 15_000) resumeState.count = 0;
-      const canRetryResume = resumeState.count < 3;
+      if (now - resumeState.windowStart > RESUME_RETRY_WINDOW_MS) {
+        resumeState.windowStart = now;
+        resumeState.count = 0;
+      }
+      // Keep taking the resume branch while a retry is still scheduled, so we
+      // never poison the cards out from under a pending reattach.
+      const canRetryResume =
+        resumeState.count < RESUME_MAX_RETRIES || resumeState.timer !== null;
 
       if (
         !isStructuredServerError &&
@@ -2612,8 +2624,6 @@ const Chat: React.FC<ChatProps> = ({
         canRetryResume &&
         !manualStopRequestedRef.current
       ) {
-        resumeState.at = now;
-        resumeState.count += 1;
         reportStreamInterruption({
           path: "stream-error",
           chatId,
@@ -2623,10 +2633,18 @@ const Chat: React.FC<ChatProps> = ({
           resumed: true,
         });
         // Clear the SDK error so the hook can stream again, then reattach to
-        // the buffered turn. A finished turn answers 204 (cheap no-op) and the
-        // orphan-rescue effect handles any genuinely stranded tool card.
+        // the buffered turn after a short delay. The delay coalesces the burst
+        // of onError calls a failing reconnect produces and gives a brief
+        // network blip time to recover. A finished turn answers 204 (cheap
+        // no-op) and the orphan-rescue effect handles any stranded card.
         clearError();
-        void resumeStreamRef.current?.();
+        if (!resumeState.timer) {
+          resumeState.count += 1;
+          resumeState.timer = setTimeout(() => {
+            resumeState.timer = null;
+            void resumeStreamRef.current?.();
+          }, RESUME_RETRY_DELAY_MS);
+        }
         return;
       }
 
@@ -2676,6 +2694,8 @@ const Chat: React.FC<ChatProps> = ({
       );
     },
     onFinish: () => {
+      // The turn settled cleanly — reset the resume-retry budget.
+      errorResumeRef.current.count = 0;
       if (!isExistingChatRef.current) {
         fetchSessionsRef.current?.();
       }
@@ -3072,6 +3092,9 @@ const Chat: React.FC<ChatProps> = ({
   useEffect(() => {
     const WAKE_THROTTLE_MS = 2000;
     let lastWakeAt = 0;
+    // Stable across the component's life (useRef object identity never changes);
+    // captured for the cleanup to read the latest pending resume timer.
+    const resumeState = errorResumeRef.current;
 
     const hasResumableTurn = (): boolean => {
       if (manualStopRequestedRef.current) return false;
@@ -3128,6 +3151,10 @@ const Chat: React.FC<ChatProps> = ({
       window.removeEventListener("focus", wake);
       window.removeEventListener("pageshow", wake);
       document.removeEventListener("resume", wake);
+      if (resumeState.timer) {
+        clearTimeout(resumeState.timer);
+        resumeState.timer = null;
+      }
     };
   }, []);
 

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -156,15 +156,20 @@ function toolNameFromPartType(partType: string): string {
     : partType;
 }
 
-// Diagnostics for the two *live* stream-disconnect signatures so they can be
+// Diagnostics for the *live* stream-disconnect signatures so they can be
 // investigated after the fact:
 //   - "orphan-rescue": a turn settled to `ready` while non-interactive tool
 //     cards were still pending (the silent SSE drop → 204 reconnect path).
-//   - "stream-error":  the SDK surfaced a thrown stream error (e.g. a 524).
+//   - "stream-error":  the SDK surfaced a thrown stream error (e.g. a 524 or a
+//     network drop when the tab is frozen by a mobile lock / computer sleep).
+//   - "wake-resume":   the tab woke (visibility/focus/pageshow/resume) with an
+//     in-flight turn, so we proactively reattached to the buffered stream.
+// `resumed` records whether we attempted a resume (reattach) rather than
+// poisoning the tool cards — the recovery path we want to confirm in prod.
 // Emits a structured console line for live debugging and a PostHog product
 // event so frequency / affected tools are queryable. Correlate with the
 // server's `mako.agent` logs (and the resume-endpoint 204 reasons) via chatId.
-type StreamInterruptionPath = "orphan-rescue" | "stream-error";
+type StreamInterruptionPath = "orphan-rescue" | "stream-error" | "wake-resume";
 
 function reportStreamInterruption(detail: {
   path: StreamInterruptionPath;
@@ -173,6 +178,7 @@ function reportStreamInterruption(detail: {
   toolNames: string[];
   recoveredToolNames?: string[];
   errorMessage?: string;
+  resumed?: boolean;
 }): void {
   console.warn("[Chat][stream-interrupted]", detail);
   trackEvent("ai_chat_stream_interrupted", {
@@ -184,6 +190,7 @@ function reportStreamInterruption(detail: {
     recovered_tool_names: detail.recoveredToolNames?.join(",") || "(none)",
     recovered_count: detail.recoveredToolNames?.length ?? 0,
     error_message: detail.errorMessage,
+    resumed: detail.resumed ?? false,
   });
 }
 
@@ -1992,6 +1999,12 @@ const Chat: React.FC<ChatProps> = ({
     new Map<string, ActiveClientToolCall>(),
   );
   const cancelledClientToolCallIdsRef = useRef(new Set<string>());
+  // Bounds onError → resume retries so a genuinely-offline client can't spin in
+  // a clearError()/resumeStream() loop. Resets after a quiet window.
+  const errorResumeRef = useRef<{ at: number; count: number }>({
+    at: 0,
+    count: 0,
+  });
   const [activeClientToolCallCount, setActiveClientToolCallCount] = useState(0);
   const [queuedPrompts, setQueuedPrompts] = useState<QueuedPrompt[]>([]);
   const queuedPromptsRef = useRef(queuedPrompts);
@@ -2544,7 +2557,7 @@ const Chat: React.FC<ChatProps> = ({
 
     onError: err => {
       console.error("[Chat] Error:", err);
-      cancelActiveClientToolCalls("stream-error");
+      const errorMessage = err instanceof Error ? err.message : String(err);
       const lastMessage = messagesRef.current.at(-1);
       const stalledToolNames =
         lastMessage?.role === "assistant"
@@ -2560,12 +2573,74 @@ const Chat: React.FC<ChatProps> = ({
               })
               .map(p => toolNameFromPartType(p.type as string))
           : [];
+
+      // Structured server errors (billing / model availability) arrive as JSON
+      // with a `code` — those are genuine and must NOT be resumed.
+      let isStructuredServerError = false;
+      try {
+        const parsed = JSON.parse(errorMessage);
+        isStructuredServerError = !!parsed && typeof parsed.code === "string";
+      } catch {
+        /* not JSON → network / stream drop */
+      }
+
+      // The turn's lifetime is decoupled from the HTTP connection: the server
+      // keeps generating and buffers a resumable stream after a client
+      // disconnect. A mobile lock / computer sleep freezes the tab and the OS
+      // kills the SSE socket; on wake the dead read surfaces here as a
+      // non-structured network/stream error (the user-reported "network error"
+      // / "Stream disconnected"). When the turn still looks live, reattach
+      // instead of poisoning the cards — the replay re-emits the tool outputs,
+      // and any in-flight client tool (e.g. a slow capture_screenshot) is left
+      // running so it can settle on its own.
+      const turnLooksLive =
+        statusRef.current === "streaming" ||
+        statusRef.current === "submitted" ||
+        useRealtimeStore.getState().chatActivity[chatIdRef.current] ===
+          "streaming" ||
+        document.visibilityState !== "visible" ||
+        stalledToolNames.length > 0;
+
+      const now = Date.now();
+      const resumeState = errorResumeRef.current;
+      if (now - resumeState.at > 15_000) resumeState.count = 0;
+      const canRetryResume = resumeState.count < 3;
+
+      if (
+        !isStructuredServerError &&
+        turnLooksLive &&
+        canRetryResume &&
+        !manualStopRequestedRef.current
+      ) {
+        resumeState.at = now;
+        resumeState.count += 1;
+        reportStreamInterruption({
+          path: "stream-error",
+          chatId,
+          status,
+          toolNames: stalledToolNames,
+          errorMessage,
+          resumed: true,
+        });
+        // Clear the SDK error so the hook can stream again, then reattach to
+        // the buffered turn. A finished turn answers 204 (cheap no-op) and the
+        // orphan-rescue effect handles any genuinely stranded tool card.
+        clearError();
+        void resumeStreamRef.current?.();
+        return;
+      }
+
+      // Genuine / fatal error (or too many resume retries): fall back to the
+      // original behavior — cancel in-flight client tools and poison pending
+      // tool parts so the AI SDK unblocks the next sendMessage.
+      cancelActiveClientToolCalls("stream-error");
       reportStreamInterruption({
         path: "stream-error",
         chatId,
         status,
         toolNames: stalledToolNames,
-        errorMessage: err instanceof Error ? err.message : String(err),
+        errorMessage,
+        resumed: false,
       });
       // When the stream disconnects (e.g. 524 timeout), tool calls may be
       // stuck in "input-available" state. The AI SDK blocks sendMessage until
@@ -2614,6 +2689,11 @@ const Chat: React.FC<ChatProps> = ({
   // re-bound to a fresh Chat instance whenever chatId changes.
   const resumeStreamRef = useRef(resumeStream);
   resumeStreamRef.current = resumeStream;
+
+  // Latest status for use inside stable event-listener / callback closures
+  // (the wake handler and onError) without re-installing listeners every turn.
+  const statusRef = useRef(status);
+  statusRef.current = status;
 
   const createCancellationOutput = useCallback(
     (toolName: string): Record<string, unknown> => ({
@@ -2979,6 +3059,77 @@ const Chat: React.FC<ChatProps> = ({
     recoverOrphanedClientToolCall,
     setMessages,
   ]);
+
+  // Reattach the chat stream when the tab wakes. A mobile lock / computer sleep
+  // freezes the page and the OS silently kills the SSE socket; on wake the AI
+  // SDK does not re-reconnect on its own, so an in-flight turn would otherwise
+  // surface as a "stream error" (or strand a tool card). The server keeps
+  // generating and buffers the turn as a resumable stream, so resumeStream()
+  // replays the buffered + live chunks; a finished turn answers 204 (cheap
+  // no-op). Mirrors realtimeStore.wake() (visibilitychange + focus + pageshow +
+  // resume), throttled so a single wake burst fires the work once. Listeners
+  // are installed once (stable closure over refs) and never re-installed.
+  useEffect(() => {
+    const WAKE_THROTTLE_MS = 2000;
+    let lastWakeAt = 0;
+
+    const hasResumableTurn = (): boolean => {
+      if (manualStopRequestedRef.current) return false;
+      const s = statusRef.current;
+      if (s === "streaming" || s === "submitted") return true;
+      if (
+        useRealtimeStore.getState().chatActivity[chatIdRef.current] ===
+        "streaming"
+      ) {
+        return true;
+      }
+      // A tool card frozen mid-turn (non-terminal, non-HITL) means the turn was
+      // interrupted while we were away — worth a reattach.
+      const last = messagesRef.current.at(-1);
+      if (!last || last.role !== "assistant") return false;
+      return (last.parts ?? []).some(p => {
+        const pt = p.type as string;
+        if (!pt?.startsWith("tool-") && pt !== "dynamic-tool") return false;
+        if (isHumanInTheLoopToolPartType(pt)) return false;
+        const st = (p as Record<string, unknown>).state as string;
+        return (
+          st !== "output-available" && st !== "output-error" && st !== "error"
+        );
+      });
+    };
+
+    const wake = () => {
+      const now = Date.now();
+      // A window switch fires a burst (focus + visibilitychange); the first one
+      // does the work.
+      if (now - lastWakeAt < WAKE_THROTTLE_MS) return;
+      lastWakeAt = now;
+      if (!hasResumableTurn()) return;
+      reportStreamInterruption({
+        path: "wake-resume",
+        chatId: chatIdRef.current,
+        status: statusRef.current,
+        toolNames: [],
+        resumed: true,
+      });
+      void resumeStreamRef.current?.();
+    };
+
+    const onVisible = () => {
+      if (document.visibilityState === "visible") wake();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    window.addEventListener("focus", wake);
+    window.addEventListener("pageshow", wake);
+    // Page Lifecycle API: fired when the browser unfreezes a frozen tab.
+    document.addEventListener("resume", wake);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("focus", wake);
+      window.removeEventListener("pageshow", wake);
+      document.removeEventListener("resume", wake);
+    };
+  }, []);
 
   const lastMessage = messages.at(-1);
   const lastMessageParts = lastMessage?.parts ?? [];

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -71,6 +71,8 @@ import { useSettingsStore } from "../store/settingsStore";
 import { useSchemaStore } from "../store/schemaStore";
 import { selectActiveExplorer, useUIStore } from "../store/uiStore";
 import { useRealtimeStore } from "../store/realtimeStore";
+import { useAppStore } from "../store/appStore";
+import { useDbtStore } from "../store/dbtStore";
 import { useIsMobile } from "../hooks/useIsMobile";
 import { ModelSelector } from "./ModelSelector";
 import { generateObjectId } from "../utils/objectId";
@@ -155,6 +157,25 @@ function toolNameFromPartType(partType: string): string {
     ? partType.slice("tool-".length)
     : partType;
 }
+
+// Server-executed mutation tools (issue #475 pattern) whose open-tab sync we
+// ALSO reconcile off the resumable chat stream — in addition to the workspace
+// realtime poke (app.updated / dbt.file.updated) — so an open app / dbt tab
+// converges even when the workspace SSE is dead (mobile lock / laptop sleep).
+const APP_SERVER_MUTATION_TOOLS = new Set<string>([
+  "app_write_file",
+  "app_delete_file",
+  "app_rename_file",
+  "app_add_dependency",
+  "app_remove_dependency",
+  "app_create_data_binding",
+  "app_delete_data_binding",
+]);
+const DBT_SERVER_MUTATION_TOOLS = new Set<string>([
+  "create_dbt_file",
+  "modify_dbt_file",
+  "delete_dbt_file",
+]);
 
 // Diagnostics for the *live* stream-disconnect signatures so they can be
 // investigated after the fact:
@@ -3288,6 +3309,87 @@ const Chat: React.FC<ChatProps> = ({
         })();
       } else {
         void useRealtimeStore.getState().syncRevisions();
+      }
+    }
+  }, [messages, currentWorkspace?.id]);
+
+  // In-band app/dbt sync — the app/dbt analogue of the console reconcile above.
+  // The app_* and dbt file mutation tools execute SERVER-SIDE, so an OPEN app /
+  // dbt tab learns about the agent's write via the workspace realtime poke
+  // (app.updated / dbt.file.updated). That poke rides the workspace SSE, which
+  // a mobile lock / laptop sleep / proxy half-close can kill — so reconcile
+  // off the RESUMABLE CHAT STREAM too: when the tool result streams in (or is
+  // replayed after a wake reattach), refetch the open app / dbt file. This
+  // makes the open tab converge even under a dead workspace SSE (poke = fast
+  // path, this = robust backstop). Mirrors the console pattern (issue #475).
+  const handledEntitySyncToolCallIdsRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    handledEntitySyncToolCallIdsRef.current = new Set();
+  }, [chatId]);
+  useEffect(() => {
+    const workspaceId = currentWorkspace?.id;
+    if (!workspaceId) return;
+    const last = messages.at(-1);
+    if (!last || last.role !== "assistant") return;
+    for (const part of last.parts ?? []) {
+      const p = part as {
+        type?: string;
+        toolName?: string;
+        state?: string;
+        toolCallId?: string;
+        input?: { appId?: string; projectId?: string; path?: string };
+        output?: { success?: boolean };
+      };
+      const toolName =
+        p.type === "dynamic-tool"
+          ? p.toolName
+          : p.type?.startsWith("tool-")
+            ? p.type.slice("tool-".length)
+            : undefined;
+      if (!toolName) continue;
+      const isAppEdit = APP_SERVER_MUTATION_TOOLS.has(toolName);
+      const isDbtEdit = DBT_SERVER_MUTATION_TOOLS.has(toolName);
+      if (!isAppEdit && !isDbtEdit) continue;
+      if (
+        p.state !== "output-available" ||
+        !p.toolCallId ||
+        !p.output?.success
+      ) {
+        continue;
+      }
+      if (handledEntitySyncToolCallIdsRef.current.has(p.toolCallId)) continue;
+      handledEntitySyncToolCallIdsRef.current.add(p.toolCallId);
+
+      if (isAppEdit) {
+        const appId = p.input?.appId;
+        // Only reconcile a tab that is actually open here (mirrors the
+        // realtime handler); fetchApp + bumpPreview rebuilds the preview.
+        if (appId && useAppStore.getState().openApps[appId]) {
+          void (async () => {
+            const fresh = await useAppStore
+              .getState()
+              .fetchApp(workspaceId, appId);
+            if (fresh) useAppStore.getState().bumpPreview(appId);
+          })();
+        }
+      } else {
+        const projectId = p.input?.projectId;
+        const path = p.input?.path;
+        // Only touch projects this window has loaded.
+        if (
+          projectId &&
+          path &&
+          useDbtStore.getState().filePathsByProject[projectId]
+        ) {
+          void useDbtStore
+            .getState()
+            .applyRemoteFileUpdate(
+              workspaceId,
+              projectId,
+              path,
+              toolName === "delete_dbt_file",
+            );
+        }
       }
     }
   }, [messages, currentWorkspace?.id]);

--- a/app/src/store/dbtStore.ts
+++ b/app/src/store/dbtStore.ts
@@ -413,6 +413,17 @@ interface DbtActions {
     from: string,
     to: string,
   ) => Promise<boolean>;
+  /**
+   * Apply a server-originated file change (agent server tools poke the realtime
+   * channel). Pulls fresh content for an open file, or drops a deleted file.
+   * Skips files with unsaved local edits to avoid clobbering the user's buffer.
+   */
+  applyRemoteFileUpdate: (
+    workspaceId: string,
+    projectId: string,
+    path: string,
+    deleted?: boolean,
+  ) => Promise<void>;
 
   fetchJobs: (workspaceId: string, projectId: string) => Promise<void>;
   saveJob: (
@@ -1045,6 +1056,48 @@ export const useDbtStore = create<DbtStore>()(
     createFile: async (workspaceId, projectId, path, content = "") => {
       get().writeFile(projectId, path, content);
       return get().persistFile(workspaceId, projectId, path);
+    },
+
+    applyRemoteFileUpdate: async (workspaceId, projectId, path, deleted) => {
+      if (deleted) {
+        set(state => {
+          delete state.filesByProject[projectId]?.[path];
+          const paths = state.filePathsByProject[projectId];
+          if (paths) {
+            state.filePathsByProject[projectId] = paths.filter(p => p !== path);
+          }
+        });
+        return;
+      }
+      // Don't clobber a dirty buffer the user is editing.
+      const entry = get().filesByProject[projectId]?.[path];
+      if (entry?.dirty) return;
+      try {
+        const response = await apiClient.get<{
+          success: boolean;
+          file: { path: string; content: string };
+        }>(
+          `/workspaces/${workspaceId}/dbt/projects/${projectId}/files/${encodeDbtPath(path)}`,
+        );
+        const content = response.file?.content ?? "";
+        set(state => {
+          if (!state.filesByProject[projectId]) {
+            state.filesByProject[projectId] = {};
+          }
+          state.filesByProject[projectId][path] = {
+            content,
+            dirty: false,
+            loaded: true,
+          };
+          const paths = state.filePathsByProject[projectId];
+          if (paths && !paths.includes(path)) {
+            paths.push(path);
+            paths.sort();
+          }
+        });
+      } catch {
+        /* best-effort live refresh */
+      }
     },
 
     deleteFile: async (workspaceId, projectId, path) => {

--- a/app/src/store/realtimeStore.ts
+++ b/app/src/store/realtimeStore.ts
@@ -23,6 +23,7 @@ import {
   hasBlockedDraftSave,
   hasPendingAgentReview,
 } from "./consoleStore";
+import { useAppStore } from "./appStore";
 import { decideRemoteApply } from "./lib/remoteApplyGate";
 import { useConsoleTreeStore } from "./consoleTreeStore";
 import type { ConsoleRevisionsSyncResponse } from "../lib/api-types";
@@ -53,7 +54,32 @@ export type RealtimeEvent =
       intent: "open_console";
       consoleId: string;
     }
-  | { type: "chat.activity"; chatId: string; state: "streaming" | "idle" };
+  | { type: "chat.activity"; chatId: string; state: "streaming" | "idle" }
+  | {
+      type: "app.updated";
+      appId: string;
+      version: number;
+      updatedBy: string;
+      clientId?: string;
+      origin: "agent" | "save";
+    }
+  | {
+      type: "dbt.file.updated";
+      projectId: string;
+      path: string;
+      deleted?: boolean;
+      updatedBy: string;
+      clientId?: string;
+      origin: "agent" | "save";
+    }
+  | {
+      type: "dashboard.updated";
+      dashboardId: string;
+      version: number;
+      updatedBy: string;
+      clientId?: string;
+      origin: "agent" | "save";
+    };
 
 export type RealtimeStatus = "idle" | "connecting" | "open" | "reconnecting";
 
@@ -317,10 +343,36 @@ export const useRealtimeStore = create<RealtimeStore>()(
       })();
     };
 
+    // Server-executed app mutation tools (issue #475 pattern for apps): pull the
+    // authoritative app over HTTP and rebuild its preview when an OPEN app's
+    // version advances. Echo-suppressed by clientId; agent writes carry
+    // `agent:<chatId>` so they are applied (this tab did not make the edit).
+    const handleAppUpdated = (
+      event: Extract<RealtimeEvent, { type: "app.updated" }>,
+    ) => {
+      if (event.clientId && event.clientId === realtimeClientId) return;
+      const workspaceId = get().workspaceId;
+      if (!workspaceId) return;
+      const appStore = useAppStore.getState();
+      const open = appStore.openApps[event.appId];
+      if (!open) return; // not open in this window — explorer refreshes lazily
+      if ((open.version ?? 0) >= event.version) return; // stale / own echo
+      void (async () => {
+        const fresh = await useAppStore
+          .getState()
+          .fetchApp(workspaceId, event.appId);
+        // Rebuild the preview iframe so server-applied file edits render.
+        if (fresh) useAppStore.getState().bumpPreview(event.appId);
+      })();
+    };
+
     const handleEvent = (event: RealtimeEvent) => {
       switch (event.type) {
         case "console.updated":
           handleConsoleUpdated(event);
+          break;
+        case "app.updated":
+          handleAppUpdated(event);
           break;
         case "console.deleted":
           handleConsoleDeleted(event);

--- a/app/src/store/realtimeStore.ts
+++ b/app/src/store/realtimeStore.ts
@@ -24,6 +24,7 @@ import {
   hasPendingAgentReview,
 } from "./consoleStore";
 import { useAppStore } from "./appStore";
+import { useDbtStore } from "./dbtStore";
 import { decideRemoteApply } from "./lib/remoteApplyGate";
 import { useConsoleTreeStore } from "./consoleTreeStore";
 import type { ConsoleRevisionsSyncResponse } from "../lib/api-types";
@@ -366,6 +367,26 @@ export const useRealtimeStore = create<RealtimeStore>()(
       })();
     };
 
+    // Server-executed dbt file mutation tools: pull the fresh file content (or
+    // drop a deleted file) for OPEN dbt projects. Echo-suppressed by clientId.
+    const handleDbtFileUpdated = (
+      event: Extract<RealtimeEvent, { type: "dbt.file.updated" }>,
+    ) => {
+      if (event.clientId && event.clientId === realtimeClientId) return;
+      const workspaceId = get().workspaceId;
+      if (!workspaceId) return;
+      // Only touch projects this window has loaded.
+      if (!useDbtStore.getState().filePathsByProject[event.projectId]) return;
+      void useDbtStore
+        .getState()
+        .applyRemoteFileUpdate(
+          workspaceId,
+          event.projectId,
+          event.path,
+          event.deleted,
+        );
+    };
+
     const handleEvent = (event: RealtimeEvent) => {
       switch (event.type) {
         case "console.updated":
@@ -373,6 +394,9 @@ export const useRealtimeStore = create<RealtimeStore>()(
           break;
         case "app.updated":
           handleAppUpdated(event);
+          break;
+        case "dbt.file.updated":
+          handleDbtFileUpdated(event);
           break;
         case "console.deleted":
           handleConsoleDeleted(event);

--- a/packages/agent-tools/src/app-tools.ts
+++ b/packages/agent-tools/src/app-tools.ts
@@ -16,7 +16,12 @@ import { z } from "zod";
 
 const appIdField = z.string().describe("App ID (from list_open_apps)");
 
-const writeFileSchema = z.object({
+// NOTE: the mutation tools below (write/delete/rename file, add/remove
+// dependency, create/delete data binding) execute SERVER-SIDE (mirroring the
+// console #475 pattern) — see api/src/agent-lib/tools/server-app-tools.ts. Their
+// schemas are exported here so the server tools and the app's tool cards share
+// a single source of truth. They are intentionally NOT in `clientAppTools`.
+export const writeFileSchema = z.object({
   appId: appIdField,
   path: z
     .string()
@@ -24,12 +29,12 @@ const writeFileSchema = z.object({
   contents: z.string().describe("Full UTF-8 file contents to write"),
 });
 
-const deleteFileSchema = z.object({
+export const deleteFileSchema = z.object({
   appId: appIdField,
   path: z.string().describe("File path to delete"),
 });
 
-const renameFileSchema = z.object({
+export const renameFileSchema = z.object({
   appId: appIdField,
   from: z.string().describe("Existing file path"),
   to: z.string().describe("New file path"),
@@ -40,7 +45,7 @@ const readFileSchema = z.object({
   path: z.string().describe("File path to read"),
 });
 
-const addDependencySchema = z.object({
+export const addDependencySchema = z.object({
   appId: appIdField,
   name: z.string().describe("npm package name, e.g. d3"),
   version: z
@@ -49,12 +54,12 @@ const addDependencySchema = z.object({
     .describe("Semver range. Defaults to 'latest' when omitted."),
 });
 
-const removeDependencySchema = z.object({
+export const removeDependencySchema = z.object({
   appId: appIdField,
   name: z.string().describe("npm package name to remove"),
 });
 
-const createDataBindingSchema = z.object({
+export const createDataBindingSchema = z.object({
   appId: appIdField,
   name: z
     .string()
@@ -78,7 +83,7 @@ const createDataBindingSchema = z.object({
     ),
 });
 
-const deleteDataBindingSchema = z.object({
+export const deleteDataBindingSchema = z.object({
   appId: appIdField,
   name: z
     .string()
@@ -137,48 +142,6 @@ export const clientAppTools = {
   app_read_file: tool({
     description: "Read the full contents of a single file in the app.",
     inputSchema: readFileSchema,
-  }),
-  app_write_file: tool({
-    description:
-      "Create or overwrite a file with full contents. This is the primary " +
-      "editing tool — write the complete file, not a diff. Writing the " +
-      "entrypoint or any imported file refreshes the live preview.",
-    inputSchema: writeFileSchema,
-  }),
-  app_delete_file: tool({
-    description: "Delete a file from the app.",
-    inputSchema: deleteFileSchema,
-  }),
-  app_rename_file: tool({
-    description: "Rename/move a file within the app.",
-    inputSchema: renameFileSchema,
-  }),
-  app_add_dependency: tool({
-    description:
-      "Add an npm dependency to the app (e.g. d3, framer-motion, recharts). " +
-      "The dependency becomes importable from app code on the next preview build.",
-    inputSchema: addDependencySchema,
-  }),
-  app_remove_dependency: tool({
-    description: "Remove an npm dependency from the app.",
-    inputSchema: removeDependencySchema,
-  }),
-  app_create_data_binding: tool({
-    description:
-      "Create a named data binding that the app can read via useQuery(name) " +
-      "from '@mako/app-sdk'. The query runs server-side, scoped to the " +
-      "workspace — the app never sees credentials. Set materialization to " +
-      "'parquet' for DuckDB-WASM-backed analytics (then call materialize_binding). " +
-      "Use the SQL connections/tools to inspect schema and validate the query first.",
-    inputSchema: createDataBindingSchema,
-  }),
-  app_delete_data_binding: tool({
-    description:
-      "Delete a named data binding (data source) from the app. Use this to " +
-      "clean up orphaned or superseded bindings. Removes the binding from the " +
-      "app definition and persists the change. Confirm the binding name with " +
-      "list_data_sources first; the change is reflected there afterward.",
-    inputSchema: deleteDataBindingSchema,
   }),
   materialize_binding: tool({
     description:

--- a/packages/agent-tools/src/dbt-tools.ts
+++ b/packages/agent-tools/src/dbt-tools.ts
@@ -38,13 +38,17 @@ const readFileSchema = z.object({
   path: dbtPathField,
 });
 
-const createFileSchema = z.object({
+// NOTE: the file mutation tools (create/modify/delete) execute SERVER-SIDE
+// (issue #475 pattern) — see api/src/agent-lib/tools/dbt-tools.ts. Their schemas
+// are exported here so the server tools and the dbt IDE tool cards share a
+// single source of truth. They are intentionally NOT in `clientDbtTools`.
+export const createDbtFileSchema = z.object({
   projectId: projectIdField,
   path: dbtPathField,
   contents: z.string().describe("Full UTF-8 file contents"),
 });
 
-const modifyFileSchema = z.object({
+export const modifyDbtFileSchema = z.object({
   projectId: projectIdField,
   path: dbtPathField,
   contents: z
@@ -54,7 +58,7 @@ const modifyFileSchema = z.object({
     ),
 });
 
-const deleteFileSchema = z.object({
+export const deleteDbtFileSchema = z.object({
   projectId: projectIdField,
   path: dbtPathField,
 });
@@ -73,26 +77,7 @@ export const clientDbtTools = {
       "(models, schema.yml, dbt_project.yml, seeds, macros...).",
     inputSchema: readFileSchema,
   }),
-  create_dbt_file: tool({
-    description:
-      "Create a new file in a dbt project (e.g. a staging model + its " +
-      "schema.yml entry). Fails if the file already exists — use " +
-      "modify_dbt_file to change existing files. After writing models, " +
-      "verify with dbt_parse and dbt_compile_model.",
-    inputSchema: createFileSchema,
-  }),
-  modify_dbt_file: tool({
-    description:
-      "Overwrite an existing dbt project file with full contents. The open " +
-      "editor tab updates live; every save snapshots a version for undo. " +
-      "After editing, verify with dbt_parse / dbt_compile_model.",
-    inputSchema: modifyFileSchema,
-  }),
-  delete_dbt_file: tool({
-    description: "Delete a file from a dbt project.",
-    inputSchema: deleteFileSchema,
-  }),
 };
 
-export type DbtCreateFileInput = z.infer<typeof createFileSchema>;
-export type DbtModifyFileInput = z.infer<typeof modifyFileSchema>;
+export type DbtCreateFileInput = z.infer<typeof createDbtFileSchema>;
+export type DbtModifyFileInput = z.infer<typeof modifyDbtFileSchema>;

--- a/packages/agent-tools/src/index.ts
+++ b/packages/agent-tools/src/index.ts
@@ -56,6 +56,17 @@ export { clientDashboardTools } from "./dashboard-tools";
 export { clientFlowTools } from "./flow-tools";
 
 export { clientAppTools } from "./app-tools";
+export {
+  // Schemas for the server-executed app mutation tools (registered with execute
+  // functions in api/src/agent-lib/tools/server-app-tools.ts).
+  writeFileSchema,
+  deleteFileSchema,
+  renameFileSchema,
+  addDependencySchema,
+  removeDependencySchema,
+  createDataBindingSchema,
+  deleteDataBindingSchema,
+} from "./app-tools";
 export type { AppWriteFileInput, AppCreateDataBindingInput } from "./app-tools";
 
 export { clientDbtTools } from "./dbt-tools";

--- a/packages/agent-tools/src/index.ts
+++ b/packages/agent-tools/src/index.ts
@@ -70,6 +70,13 @@ export {
 export type { AppWriteFileInput, AppCreateDataBindingInput } from "./app-tools";
 
 export { clientDbtTools } from "./dbt-tools";
+export {
+  // Schemas for the server-executed dbt file tools (registered with execute
+  // functions in api/src/agent-lib/tools/dbt-tools.ts).
+  createDbtFileSchema,
+  modifyDbtFileSchema,
+  deleteDbtFileSchema,
+} from "./dbt-tools";
 export type { DbtCreateFileInput, DbtModifyFileInput } from "./dbt-tools";
 
 export { clientDataSourceTools } from "./data-source-tools";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When a phone locks or a laptop sleeps mid-chat, the OS freezes the tab and kills the SSE socket. On wake the dead read surfaced as a `network error` and poisoned in-flight tool cards (`Stream disconnected` / `Interrupted — stream disconnected before tool completed`). The server actually keeps generating and buffers the turn as a resumable stream — the client just never reattached, and browser-only mutation tools (e.g. `app_write_file`, the "Writing src/…" cards) were lost on disconnect.

Rebased onto `master` (incl. #563) and combined with it — see "Relationship to #563" below.

## What changed

### Phase A — client resilience (`app/src/components/Chat.tsx`)
- **Wake handler** (`visibilitychange`/`focus`/`pageshow`/`resume`, throttled): calls `resumeStream()` when the chat has an in-flight/recoverable turn, so a woken tab reattaches to the buffered turn.
- **`onError` is resume-first** on transient network drops: `clearError()` + a spaced, bounded `resumeStream()` retry instead of cancelling in-flight client tools and poisoning tool parts. Structured server errors (billing / model availability) and manual stop keep the original poison path.
- New `wake-resume` `StreamInterruptionPath` + `resumed` telemetry field.

### Phase B — serverize mutation tools (issue #475 pattern)
Moved mutations to the API so a write issued while asleep still lands; each tool persists to the authoritative Mongo doc + pokes the workspace realtime channel.
- **B1 apps:** `app_write_file`, `app_delete_file`, `app_rename_file`, `app_add_dependency`, `app_remove_dependency`, `app_create_data_binding`, `app_delete_data_binding` (`server-app-tools.ts`; `app.updated` event; `run_app`/`materialize_binding`/reads stay client-side).
- **B2 dbt:** `create_dbt_file`, `modify_dbt_file`, `delete_dbt_file` (in `createDbtServerTools`, same version snapshots as the IDE routes; `dbt.file.updated` event).
- **B3 dashboards — intentionally NOT serverized** (edit-mode/in-memory/versioned-save + DuckDB-WASM render; needs a separate dashboard-draft subsystem). Covered by Phase A + the stranded-turn fallback.

### Phase C — screenshot resilience
`capture_screenshot` stays client-only; no longer cancelled/poisoned on a transient disconnect, and the per-iframe app-preview composite timeout is trimmed 8s → 4s.

## Relationship to #563 (combined)
#563 made the already-serverized **console** tools reconcile **in-band off the resumable chat stream** (rather than trusting the fragile workspace poke). My serverized **app/dbt** tools had the same weakness (open-tab sync rode only `app.updated`/`dbt.file.updated`). This PR **generalizes #563's pattern to app/dbt**: when an `app_*` / dbt file tool result streams in — or replays after a wake reattach — `Chat.tsx` refetches the open app (`fetchApp` + `bumpPreview`) / dbt file (`applyRemoteFileUpdate`). The workspace poke stays as the fast path; the in-band reconcile is the dead-SSE backstop, and it rides Phase A's wake reattach. Net: each PR supplies the half the other lacked — #563's in-band reconcile + #561's chat-stream reattach = edits land in the open tab even after sleep.

## Verification

**Phase A — wake reattach (conclusive):** backgrounding/refocusing the tab twice during a live streaming turn produced two `GET /api/agent/chat/:id/stream 200` reattaches in the server log, no errors, answer completed.
[phase_a_wake_reattach_on_tab_refocus.mp4](https://cursor.com/agents/bc-3b1e0d69-1b48-432b-9074-ec0cebed80a6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphase_a_wake_reattach_on_tab_refocus.mp4)
[phase_a_reattach_server_log.txt](https://cursor.com/agents/bc-3b1e0d69-1b48-432b-9074-ec0cebed80a6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphase_a_reattach_server_log.txt)

**B1 — `app_write_file` executes server-side, preview updates live (persisted to Mongo, version bumped):**
[b1_app_write_file_server_executed.mp4](https://cursor.com/agents/bc-3b1e0d69-1b48-432b-9074-ec0cebed80a6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fb1_app_write_file_server_executed.mp4)

**Combined in-band reconcile — agent edits an open app, live preview converges (post-rebase regression):**
[combined_inband_app_edit_live_sync.mp4](https://cursor.com/agents/bc-3b1e0d69-1b48-432b-9074-ec0cebed80a6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcombined_inband_app_edit_live_sync.mp4)

- ✅ `pnpm run lint:all` (app + api + connector-agnosticism)
- ✅ `pnpm --filter app run typecheck`
- ✅ `api` `tsc -p tsconfig.build.json --noEmit`
- ✅ `client-tool-manifest.test.ts`
- ✅ B2 dbt tools verified end-to-end against Mongo (create/modify/delete persist + version snapshots)
- ✅ Rebased onto `master` (incl. #563) — conflicts resolved in `unified/index.ts`; `Chat.tsx`/`realtimeStore.ts` carry both PRs' logic.

Note: a brief DevTools "Offline" toggle does not close an established SSE through the Vite proxy, so the conclusive Phase A proof uses the wake (visibility/focus) path, which is the primary mechanism for lock/sleep.

Follow-up (optional): extend #563's `scripts/realtime-e2e` harness with app/dbt dead-SSE scenarios (mirroring `10-run-dead-sse.mjs`) for automated coverage of B1/B2.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b1e0d69-1b48-432b-9074-ec0cebed80a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b1e0d69-1b48-432b-9074-ec0cebed80a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

