### PR TITLE
fix(console): reliable live sync + one canonical source of truth for console names

### DIFF
--- a/api/src/agent-lib/tools/server-console-tools.ts
+++ b/api/src/agent-lib/tools/server-console-tools.ts
@@ -278,6 +278,15 @@ export function createServerConsoleTools({
               // Mark agent origin so a reconnecting client surfaces this as a
               // reviewable diff even if it missed the realtime poke.
               lastDraftOrigin: "agent",
+              // Set the next revision explicitly (instead of $inc) so the bump
+              // is null-safe. Legacy consoles have no draftRevision field; the
+              // Mongoose schema default reports it as 1, but `$inc` on the
+              // absent DB field also yields 1 — colliding with the value the
+              // client already holds, so revisions-sync saw "no change" and the
+              // first agent edit/rename never reached the open tab. currentRevision
+              // is the schema-defaulted value (1 for legacy), so +1 always
+              // exceeds what the client has.
+              draftRevision: currentRevision + 1,
             };
             if (title) setFields.name = title;
 
@@ -288,7 +297,7 @@ export function createServerConsoleTools({
                 draftRevision:
                   currentRevision === 1 ? { $in: [1, null] } : currentRevision,
               },
-              { $set: setFields, $inc: { draftRevision: 1 } },
+              { $set: setFields },
               { new: true },
             );
 
@@ -454,8 +463,11 @@ export function createServerConsoleTools({
                 databaseId,
                 databaseName,
                 updatedAt: new Date(),
+                // Null-safe bump (see modify_console): the schema default
+                // reports a legacy console's revision as 1 while `$inc` on the
+                // absent field also yields 1, so set the next value explicitly.
+                draftRevision: (doc.draftRevision ?? 1) + 1,
               },
-              $inc: { draftRevision: 1 },
             },
             { new: true },
           );

--- a/api/src/routes/realtime.ts
+++ b/api/src/routes/realtime.ts
@@ -30,8 +30,14 @@ import { OPEN_RESPONSES, createRouter } from "../openapi/core";
 
 const logger = loggers.api("realtime");
 
-/** Keep-alive interval — defeats proxy idle timeouts (Cloud Run, nginx). */
-const HEARTBEAT_INTERVAL_MS = 25_000;
+/**
+ * Keep-alive interval — defeats proxy idle timeouts (Cloud Run, nginx) AND
+ * acts as the liveness signal the client's watchdog measures against: a more
+ * frequent beat lets a silently-dead stream (NAT/proxy half-close) be detected
+ * and self-healed sooner. Keep in sync with the client's WATCHDOG_STALE_MS
+ * (app/src/store/realtimeStore.ts), which tolerates ~2 missed beats.
+ */
+const HEARTBEAT_INTERVAL_MS = 15_000;
 
 export const realtimeRoutes = createRouter();
 

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -3078,8 +3078,16 @@ const Chat: React.FC<ChatProps> = ({
             : undefined;
       const opensTab =
         toolName === "create_console" || toolName === "open_console";
+      // Server console writes whose only client delivery is the realtime poke.
+      // run_console bumps the draft revision AND persists a run artifact
+      // (tab.lastRun); the revision sync refreshes both, and Editor.tsx
+      // reactively renders lastRun into the results panel — so reconciling
+      // here surfaces agent run RESULTS even when the run.completed poke was
+      // missed (dead/half-closed SSE), matching modify/set-connection.
       const editsConsole =
-        toolName === "modify_console" || toolName === "set_console_connection";
+        toolName === "modify_console" ||
+        toolName === "set_console_connection" ||
+        toolName === "run_console";
       if (!opensTab && !editsConsole) continue;
       if (p.state !== "output-available") continue;
       if (!p.toolCallId || !p.output?.success) continue;

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -3089,9 +3089,17 @@ const Chat: React.FC<ChatProps> = ({
       if (handledConsoleOpenToolCallIdsRef.current.has(p.toolCallId)) continue;
       handledConsoleOpenToolCallIdsRef.current.add(p.toolCallId);
       if (opensTab) {
-        void useConsoleStore
-          .getState()
-          .openConsoleFromServer(workspaceId, p.output.consoleId as string);
+        const consoleId = p.output.consoleId as string;
+        void (async () => {
+          await useConsoleStore
+            .getState()
+            .openConsoleFromServer(workspaceId, consoleId);
+          // A create followed immediately by a modify can drop the modify's
+          // workspace poke while the tab is still opening; reconcile once the
+          // tab carries a revision base so it never sticks on create-time
+          // content.
+          void useRealtimeStore.getState().syncRevisions();
+        })();
       } else {
         void useRealtimeStore.getState().syncRevisions();
       }

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -3034,14 +3034,25 @@ const Chat: React.FC<ChatProps> = ({
     };
   }, [chatId, currentWorkspace?.id]);
 
-  // In-band console opening: when a create_console / open_console tool
-  // result streams in (state "output-available"), open the console tab in
-  // THIS window. The chat stream is resumable, so unlike the legacy
-  // chat.ui-intent realtime poke this survives SSE drops, reconnects and
-  // page refreshes — the replayed part triggers the same idempotent open.
+  // In-band console sync: when a server-side console tool result streams in
+  // (state "output-available"), reconcile THIS window against the server
+  // draft. The chat stream is resumable, so unlike the workspace realtime
+  // poke channel this survives SSE drops, half-closes, frozen background
+  // tabs, reconnects and page refreshes — the replayed part triggers the
+  // same idempotent reconciliation.
+  //
+  //   - create_console / open_console -> open the tab here.
+  //   - modify_console / set_console_connection -> pull the authoritative
+  //     draft for open tabs (revision sync). Without this, an agent EDIT
+  //     reached the editor ONLY via the realtime poke; a missed poke (dead
+  //     SSE, or a poke that raced the tab open) left the editor stale until
+  //     the next focus/reconnect/watchdog/refresh — the reported "modify did
+  //     nothing until I refreshed" bug. create_console never had this problem
+  //     because it already rode the chat stream (asymmetry, issue #475).
+  //
   // Tool call ids seen in RESTORED history are pre-seeded into this set by
-  // loadSession (reopening a chat must not re-open every console it ever
-  // touched — the dedicated consoles-restore payload handles that).
+  // loadSession (reopening a chat must not re-open/re-sync every console it
+  // ever touched — the dedicated consoles-restore payload handles that).
   const handledConsoleOpenToolCallIdsRef = useRef<Set<string>>(new Set());
   useEffect(() => {
     handledConsoleOpenToolCallIdsRef.current = new Set();
@@ -3065,17 +3076,25 @@ const Chat: React.FC<ChatProps> = ({
           : p.type?.startsWith("tool-")
             ? p.type.slice("tool-".length)
             : undefined;
-      if (toolName !== "create_console" && toolName !== "open_console") {
-        continue;
-      }
+      const opensTab =
+        toolName === "create_console" || toolName === "open_console";
+      const editsConsole =
+        toolName === "modify_console" || toolName === "set_console_connection";
+      if (!opensTab && !editsConsole) continue;
       if (p.state !== "output-available") continue;
-      const consoleId = p.output?.consoleId;
-      if (!p.toolCallId || !p.output?.success || !consoleId) continue;
+      if (!p.toolCallId || !p.output?.success) continue;
+      // Opening needs a consoleId; an edit reconciles all open tabs so it
+      // does not. Don't burn the dedupe slot on an opener that lacks an id.
+      if (opensTab && !p.output?.consoleId) continue;
       if (handledConsoleOpenToolCallIdsRef.current.has(p.toolCallId)) continue;
       handledConsoleOpenToolCallIdsRef.current.add(p.toolCallId);
-      void useConsoleStore
-        .getState()
-        .openConsoleFromServer(workspaceId, consoleId);
+      if (opensTab) {
+        void useConsoleStore
+          .getState()
+          .openConsoleFromServer(workspaceId, p.output.consoleId as string);
+      } else {
+        void useRealtimeStore.getState().syncRevisions();
+      }
     }
   }, [messages, currentWorkspace?.id]);
 

--- a/app/src/components/EntityBreadcrumbs.tsx
+++ b/app/src/components/EntityBreadcrumbs.tsx
@@ -63,11 +63,14 @@ function segmentsForTab(
         ];
       }
       const group = tab.access === "workspace" ? "Workspace" : "My Consoles";
-      return plain([
-        "Consoles",
-        group,
-        ...tab.filePath.split("/").filter(Boolean),
-      ]);
+      // The folder trail comes from the stored path, but the LEAF is the
+      // console's live display name (tab.title). An agent rename updates the
+      // name/title but not the stored path, so reading the leaf from filePath
+      // showed a stale name in the breadcrumb while the tab strip was correct.
+      const pathParts = tab.filePath.split("/").filter(Boolean);
+      const folderParts = pathParts.slice(0, -1);
+      const leaf = tab.title || pathParts[pathParts.length - 1];
+      return plain(["Consoles", group, ...folderParts, leaf]);
     }
     case "table-data":
       return plain([

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -689,8 +689,16 @@ export const useConsoleStore = create<ConsoleStore>()(
         if (!tab) return;
         const existing = pendingAgentReviews.get(entry.id);
         // Nothing to review: the proposed content already matches the tab
-        // (e.g. a stale re-sync after the user just accepted, or an echo).
-        if (!existing && tab.content === entry.content) return;
+        // (e.g. a run-artifact/metadata-only bump, an echo, or a stale
+        // re-sync after the user just accepted). Still FAST-FORWARD the
+        // revision/metadata to the server's current base — otherwise the tab
+        // keeps reporting its old draftRevision, so every later sync re-pulls
+        // this same "changed" entry and revision-checked writes use a stale
+        // base. (Returning without fast-forwarding was a real churn bug.)
+        if (!existing && tab.content === entry.content) {
+          get().fastForwardRemoteConsoleEntry(entry);
+          return;
+        }
         // Idempotent: same proposal already on screen — don't re-dispatch
         // (avoids resetting the diff scroll on every unrelated poke).
         if (

--- a/app/src/store/consoleTreeStore.ts
+++ b/app/src/store/consoleTreeStore.ts
@@ -160,6 +160,18 @@ interface TreeState {
     newName: string,
     isDirectory: boolean,
   ) => Promise<boolean>;
+  /**
+   * Surgically rename a tree node by id from a REMOTE signal (agent edit or
+   * another window) — in place, WITHOUT an API call and WITHOUT a full
+   * refetch. This keeps the sidebar update Apollo-like (patch the entity by
+   * id) so there are no loading skeletons or layout shift. No-op if the node
+   * is not in the tree (e.g. an unsaved draft) or already has the new name.
+   */
+  applyRemoteRename: (
+    workspaceId: string,
+    itemId: string,
+    newName: string,
+  ) => void;
   deleteItem: (
     workspaceId: string,
     itemId: string,
@@ -482,6 +494,25 @@ export const useConsoleTreeStore = create<TreeState>()(
         await _get().refresh(workspaceId);
         return false;
       }
+    },
+
+    applyRemoteRename: (workspaceId, itemId, newName) => {
+      set(state => {
+        for (const section of allSections(state, workspaceId)) {
+          const parent = findParentArray(section, itemId);
+          if (!parent) continue;
+          const idx = parent.findIndex(n => n.id === itemId);
+          if (idx === -1) continue;
+          if (parent[idx].name === newName) return; // already current — no-op
+          // Splice + re-insert so the row lands in its sorted position, exactly
+          // like the optimistic renameItem path. Only this node's parent array
+          // changes, so React re-renders just that branch (no skeleton/refetch).
+          const [node] = parent.splice(idx, 1);
+          node.name = newName;
+          insertAlphabetically(parent, node);
+          return;
+        }
+      });
     },
 
     deleteItem: async (workspaceId, itemId, isDirectory) => {

--- a/app/src/store/realtimeStore.ts
+++ b/app/src/store/realtimeStore.ts
@@ -95,12 +95,16 @@ const RECONNECT_MAX_MS = 30_000;
 /** Batch bursts of pokes (e.g. agent patching repeatedly) into one pull. */
 const SYNC_DEBOUNCE_MS = 250;
 /**
- * Liveness watchdog: the server heartbeats every 25s, so a stream that has
- * been silent longer than this is dead even though no `error` event fired
- * (NAT/proxy half-close, sleeping machine). 70s tolerates two missed beats.
+ * Liveness watchdog: the server heartbeats every 15s (realtime.ts
+ * HEARTBEAT_INTERVAL_MS), so a stream that has been silent longer than this
+ * is dead even though no `error` event fired (NAT/proxy half-close, sleeping
+ * machine). 35s tolerates two missed beats. This bounds how long a MISSED
+ * poke can leave a window stale with no user interaction: the reconnect's
+ * `onopen` runs syncRevisions, so lowering this directly shrinks the
+ * worst-case "edited elsewhere but not shown here" window (≈35s + one sweep).
  */
-const WATCHDOG_STALE_MS = 70_000;
-const WATCHDOG_INTERVAL_MS = 15_000;
+const WATCHDOG_STALE_MS = 35_000;
+const WATCHDOG_INTERVAL_MS = 8_000;
 /**
  * Wake-trigger staleness: when the user comes back to this window (focus /
  * visibility / pageshow), a stream that hasn't produced a frame within ~1.5
@@ -109,7 +113,7 @@ const WATCHDOG_INTERVAL_MS = 15_000;
  * their sockets without firing an `error` event, so `status === "open"`
  * cannot be trusted on wake.
  */
-const WAKE_STALE_MS = 40_000;
+const WAKE_STALE_MS = 25_000;
 /** Collapse the burst of focus+visibility events one window switch fires. */
 const WAKE_THROTTLE_MS = 1_000;
 /**

--- a/app/src/store/realtimeStore.ts
+++ b/app/src/store/realtimeStore.ts
@@ -556,15 +556,18 @@ export const useRealtimeStore = create<RealtimeStore>()(
           if (!res.success) return;
 
           const store = useConsoleStore.getState();
-          // An agent edit can also RENAME the console (modify_console title).
-          // The tree only auto-refreshes on save-origin pokes, so detect a
-          // name change here (before applying mutates the tab) and refresh the
-          // sidebar tree once after the loop.
-          let treeNeedsRefresh = false;
           for (const entry of res.changed) {
             const tab = store.tabs[entry.id];
+
+            // An agent edit can also RENAME the console (modify_console title).
+            // Patch the sidebar tree node by id IN PLACE (no full refetch, so
+            // no loading skeletons or layout shift) — the Apollo-style
+            // "update entity by id" pattern. tab.title here is the pre-apply
+            // value, so a real rename is detected before it is applied below.
             if (entry.name && tab && entry.name !== tab.title) {
-              treeNeedsRefresh = true;
+              useConsoleTreeStore
+                .getState()
+                .applyRemoteRename(workspaceId, entry.id, entry.name);
             }
 
             // Agent (modify_console) edits surface as a Monaco Accept/Reject
@@ -632,9 +635,6 @@ export const useRealtimeStore = create<RealtimeStore>()(
                 store.applyRemoteConsoleEntry(entry);
                 break;
             }
-          }
-          if (treeNeedsRefresh) {
-            void useConsoleTreeStore.getState().fetchTree(workspaceId);
           }
           for (const deletedId of res.deleted) {
             const tab = store.tabs[deletedId];

--- a/app/src/store/realtimeStore.ts
+++ b/app/src/store/realtimeStore.ts
@@ -556,8 +556,16 @@ export const useRealtimeStore = create<RealtimeStore>()(
           if (!res.success) return;
 
           const store = useConsoleStore.getState();
+          // An agent edit can also RENAME the console (modify_console title).
+          // The tree only auto-refreshes on save-origin pokes, so detect a
+          // name change here (before applying mutates the tab) and refresh the
+          // sidebar tree once after the loop.
+          let treeNeedsRefresh = false;
           for (const entry of res.changed) {
             const tab = store.tabs[entry.id];
+            if (entry.name && tab && entry.name !== tab.title) {
+              treeNeedsRefresh = true;
+            }
 
             // Agent (modify_console) edits surface as a Monaco Accept/Reject
             // diff instead of being applied silently. Route the pulled copy
@@ -624,6 +632,9 @@ export const useRealtimeStore = create<RealtimeStore>()(
                 store.applyRemoteConsoleEntry(entry);
                 break;
             }
+          }
+          if (treeNeedsRefresh) {
+            void useConsoleTreeStore.getState().fetchTree(workspaceId);
           }
           for (const deletedId of res.deleted) {
             const tab = store.tabs[deletedId];

--- a/app/src/store/realtimeStore.ts
+++ b/app/src/store/realtimeStore.ts
@@ -202,14 +202,17 @@ export const useRealtimeStore = create<RealtimeStore>()(
         }
       }
 
-      const tab = useConsoleStore.getState().tabs[event.consoleId];
-      if (!tab) return; // not open in this window — nothing to update
-
-      // Remember agent-origin edits on OPEN consoles so the pull routes them
-      // into the diff review (editor keeps the baseline until accept/reject).
+      // Remember agent-origin edits even when the tab is NOT open yet (the
+      // common create_console → immediate modify_console race: the modify
+      // poke can land while openConsoleFromServer is still fetching). The
+      // reconcile after the tab opens uses this + lastDraftOrigin to route
+      // the pulled copy into the diff review instead of a silent apply.
       if (event.origin === "agent") {
         agentOriginConsoles.add(event.consoleId);
       }
+
+      const tab = useConsoleStore.getState().tabs[event.consoleId];
+      if (!tab) return; // not open yet — openConsoleFromServer reconciles
 
       // A tab that never synced (no draftRevision) counts as revision 0 so
       // even the server's first revision is pulled.
@@ -297,11 +300,21 @@ export const useRealtimeStore = create<RealtimeStore>()(
       if (!workspaceId || event.intent !== "open_console") return;
 
       const consoleStore = useConsoleStore.getState();
-      if (consoleStore.tabs[event.consoleId]) {
-        consoleStore.setActiveTab(event.consoleId);
-        return;
-      }
-      void consoleStore.openConsoleFromServer(workspaceId, event.consoleId);
+      void (async () => {
+        if (consoleStore.tabs[event.consoleId]) {
+          consoleStore.setActiveTab(event.consoleId);
+        } else {
+          await consoleStore.openConsoleFromServer(
+            workspaceId,
+            event.consoleId,
+          );
+        }
+        // Pokes for this console may have arrived before the tab existed
+        // (create → immediate modify). Reconcile against the server now so a
+        // dropped poke does not leave the freshly opened tab on stale
+        // create-time content.
+        void get().syncRevisions();
+      })();
     };
 
     const handleEvent = (event: RealtimeEvent) => {
@@ -322,6 +335,13 @@ export const useRealtimeStore = create<RealtimeStore>()(
           set(state => {
             state.chatActivity[event.chatId] = event.state;
           });
+          // Agent turn finished: reconcile open consoles. Tool-agnostic
+          // catch-all for any console.updated poke missed during the turn
+          // (SSE blip, poke-before-tab-open race) and for detached
+          // server-side runs that completed while this window was attached.
+          if (event.state === "idle" && event.chatId === get().activeChatId) {
+            scheduleSync();
+          }
           break;
       }
     };

--- a/scripts/realtime-e2e/07-create-modify-same-turn.mjs
+++ b/scripts/realtime-e2e/07-create-modify-same-turn.mjs
@@ -1,0 +1,75 @@
+/**
+ * Scenario 07 — create_console + modify_console in ONE agent turn WITH a
+ * delayed content fetch to force the poke-before-tab-open race.
+ *
+ * Without post-open revisions-sync the client sticks on create-time content.
+ */
+import * as h from "./helpers.mjs";
+
+h.requireConfig();
+const b = await h.launch();
+const A = await h.newWindow(b);
+const chat = await h.getActiveChat(A.page);
+
+const uniqueContent = `SELECT 'race-${Date.now()}' AS marker`;
+
+// Slow the initial openConsoleFromServer fetch so modify's poke lands while
+// the tab is still absent from the store (the deterministic race).
+await A.page.route("**/consoles/content?id=*", async route => {
+  await new Promise(r => setTimeout(r, 1500));
+  await route.continue();
+});
+
+await h.apiAgentChat(chat.chatId, [
+  {
+    tool: "create_console",
+    input: {
+      title: h.uniqueName("RaceCreate"),
+      content: "SELECT 1",
+      connectionId: h.CONN_ID,
+    },
+  },
+  {
+    tool: "modify_console",
+    input: {
+      consoleId: "$prev.consoleId",
+      action: "replace",
+      content: uniqueContent,
+    },
+  },
+]);
+
+const created = await h.waitFor(async () => {
+  const tabs = await h.getTabs(A.page);
+  return Object.values(tabs).find(t =>
+    (t.title || "").startsWith("RaceCreate"),
+  );
+});
+h.check("create+modify opened a tab", Boolean(created));
+const id = created?.id;
+
+// Give sync a moment without requiring a page refresh.
+await h.waitMs(500);
+
+const editorText = await h.getEditorTextByTabId(A.page, id);
+const storeContent = id ? (await h.getTabs(A.page))[id]?.content : null;
+const srv = id ? await h.apiGetConsole(id) : null;
+
+h.check(
+  "Monaco shows the modified query without a page refresh",
+  Boolean(editorText?.includes(uniqueContent)),
+  editorText,
+);
+h.check(
+  "store content matches the server (not stuck on SELECT 1)",
+  storeContent?.includes(uniqueContent),
+  storeContent,
+);
+h.check(
+  "server holds the modified content",
+  srv?.content?.includes(uniqueContent),
+  srv?.content,
+);
+
+await b.close();
+h.finish("07-create-modify-same-turn");

--- a/scripts/realtime-e2e/10-run-dead-sse.mjs
+++ b/scripts/realtime-e2e/10-run-dead-sse.mjs
@@ -1,0 +1,87 @@
+/**
+ * Repro/regression — agent run_console RESULTS surface under a dead SSE.
+ *
+ * run_console executes server-side and persists a run artifact (tab.lastRun)
+ * + bumps the draft revision. Its only realtime delivery is the
+ * console.run.completed poke; if that is missed (silently-dead SSE) the
+ * results panel stayed empty until focus/reconnect. The in-band chat-stream
+ * reconcile (syncRevisions on the run_console tool result) refreshes
+ * tab.lastRun, which Editor.tsx renders reactively — so results appear live.
+ *
+ * Runs `SELECT '<marker>'` against the workspace's SQL connection, so it works
+ * on the demo Postgres without mongo sample data.
+ */
+import * as h from "./helpers.mjs";
+
+h.requireConfig();
+const b = await h.launch();
+const A = await h.newWindow(b);
+
+const marker = `runheal-${Date.now()}`;
+
+// Turn 1: create the console (SSE alive).
+await h.uiAgentChat(A.page, [
+  {
+    tool: "create_console",
+    input: {
+      title: "RunHeal",
+      content: `SELECT '${marker}' AS marker`,
+      connectionId: h.CONN_ID,
+    },
+  },
+]);
+const created = await h.waitFor(
+  async () => {
+    const tabs = await h.getTabs(A.page);
+    return Object.values(tabs).find(t => t.title === "RunHeal");
+  },
+  { timeoutMs: 20_000 },
+);
+h.check("create_console opened the tab", Boolean(created));
+const id = created?.id;
+if (!id) {
+  await b.close();
+  h.finish("10-run-dead-sse");
+  process.exit(0);
+}
+
+// The realtime stream goes silently dead.
+await h.killRealtimeSilently(A.page);
+await A.page.waitForTimeout(500);
+
+// Turn 2: agent runs the query (run.completed poke will be lost).
+await h.uiAgentChat(A.page, [
+  { tool: "run_console", input: { consoleId: id } },
+]);
+
+// Server ran it.
+const ranOnServer = await h.waitFor(
+  async () => {
+    const srv = await h.apiGetConsole(id);
+    return srv?.lastRun?.status === "success" ? srv : null;
+  },
+  { timeoutMs: 20_000 },
+);
+h.check("server executed the query (lastRun success)", Boolean(ranOnServer));
+
+// Client: the results panel must render the row WITHOUT a refresh, driven by
+// the in-band reconcile (not the dead poke).
+const resultsShown = await h.waitFor(
+  async () =>
+    (await A.page
+      .locator(`[data-mako-tab-id="${id}"]`)
+      .locator(`text=/${marker}/`)
+      .count()
+      .catch(() => 0)) > 0
+      ? true
+      : null,
+  { timeoutMs: 12_000, stepMs: 1000 },
+);
+h.check(
+  "agent run results surfaced LIVE under a dead SSE (no refresh)",
+  Boolean(resultsShown),
+);
+await h.screenshot(A.page, "10-run-dead-sse");
+
+await b.close();
+h.finish("10-run-dead-sse");

--- a/scripts/realtime-e2e/11-rename-legacy-console.mjs
+++ b/scripts/realtime-e2e/11-rename-legacy-console.mjs
@@ -1,0 +1,109 @@
+/**
+ * Repro/regression — agent rename of a LEGACY console (no draftRevision field)
+ * must update the open tab title + breadcrumbs.
+ *
+ * Legacy consoles (created before the draftRevision field) have draftRevision
+ * absent. The client read it as `?? 1`; the server's first write `$inc` on a
+ * null field also yields 1 — so revisions-sync sees serverRevision === clientRevision
+ * and returns NOTHING. The rename (a name-only modify_console) therefore never
+ * reaches the open tab/breadcrumbs, even after a refresh (the tree updates only
+ * because it is a full fetch).
+ *
+ * Simulates the legacy state by $unset-ing draftRevision via mongosh.
+ */
+import { execSync } from "node:child_process";
+import * as h from "./helpers.mjs";
+
+const MONGO_URL = process.env.E2E_MONGO_URL || "mongodb://127.0.0.1:27017/mako";
+
+h.requireConfig();
+const b = await h.launch();
+const A = await h.newWindow(b);
+
+const id = h.oid();
+const newName = `RenamedCute-${Date.now()}`;
+const headers = {
+  "content-type": "application/json",
+  cookie: `auth_session=${h.SESSION}`,
+};
+
+// Seed a draft console (this gives it draftRevision: 1).
+await fetch(`${h.API}/api/workspaces/${h.WS_ID}/consoles/${id}`, {
+  method: "PUT",
+  headers,
+  body: JSON.stringify({ content: "SELECT 1", clientId: "seed", language: "sql" }),
+}).then(r => r.json());
+
+// Make it LEGACY: remove the draftRevision field entirely.
+execSync(
+  `mongosh --quiet "${MONGO_URL}" --eval 'db.savedconsoles.updateOne({_id:ObjectId("${id}")},{$unset:{draftRevision:""}})'`,
+);
+// Sanity: confirm it is now absent.
+const check = execSync(
+  `mongosh --quiet "${MONGO_URL}" --eval 'db.savedconsoles.findOne({_id:ObjectId("${id}")}).draftRevision'`,
+)
+  .toString()
+  .trim();
+h.check("console is legacy (draftRevision absent)", check === "null" || check === "", check);
+
+// Open it in window A through the agent.
+await h.uiAgentChat(A.page, [{ tool: "open_console", input: { consoleId: id } }]);
+const opened = await h.waitFor(async () => {
+  const t = (await h.getTabs(A.page))[id];
+  return t ? t : null;
+});
+h.check("legacy console opened as a tab", Boolean(opened));
+
+// Rename via the agent: a name-only modify_console (no-op patch of line 1).
+await h.uiAgentChat(A.page, [
+  {
+    tool: "modify_console",
+    input: {
+      consoleId: id,
+      action: "patch",
+      startLine: 1,
+      endLine: 1,
+      content: "SELECT 1",
+      title: newName,
+    },
+  },
+]);
+
+// Server applied the rename.
+const ranOnServer = await h.waitFor(
+  async () => {
+    const srv = await h.apiGetConsole(id);
+    return srv?.name === newName ? srv : null;
+  },
+  { timeoutMs: 15_000 },
+);
+h.check("server renamed the console", Boolean(ranOnServer), ranOnServer?.name);
+
+// The OPEN TAB title must reflect the rename without a refresh.
+const tabRenamed = await h.waitFor(
+  async () => {
+    const t = (await h.getTabs(A.page))[id];
+    return t?.title === newName ? t : null;
+  },
+  { timeoutMs: 12_000, stepMs: 1000 },
+);
+h.check(
+  "open tab title updated to the new name (drives breadcrumbs/page title)",
+  Boolean(tabRenamed),
+  ((await h.getTabs(A.page))[id] || {}).title,
+);
+
+// The editor tab strip (driven by the same tab.title) should show the new
+// name — scoped to a [role="tab"] so it can't false-positive on the agent's
+// chat reply text.
+const tabStripShown =
+  (await A.page
+    .locator(`[role="tab"]:has-text("${newName}")`)
+    .count()
+    .catch(() => 0)) > 0;
+h.check("editor tab strip shows the new name", tabStripShown);
+
+await h.screenshot(A.page, "11-rename-legacy");
+
+await b.close();
+h.finish("11-rename-legacy-console");

--- a/scripts/realtime-e2e/12-rename-saved-surgical.mjs
+++ b/scripts/realtime-e2e/12-rename-saved-surgical.mjs
@@ -1,0 +1,130 @@
+/**
+ * Acid test — agent renames a SAVED console; the tab, breadcrumbs AND sidebar
+ * tree all update surgically (by id), with no full tree refetch (no skeletons
+ * / layout shift) and no stale copy left anywhere.
+ *
+ * A saved console has a filePath (so it shows in the tree and the breadcrumb
+ * renders its path). Made legacy ($unset draftRevision) so it also exercises
+ * the revision-collision fix.
+ */
+import { execSync } from "node:child_process";
+import * as h from "./helpers.mjs";
+
+const MONGO_URL = process.env.E2E_MONGO_URL || "mongodb://127.0.0.1:27017/mako";
+
+h.requireConfig();
+const b = await h.launch();
+
+const id = h.oid();
+const ts = Date.now();
+const oldName = `ReproSaved-${ts}`;
+const newName = `RenamedSaved-${ts}`;
+const headers = {
+  "content-type": "application/json",
+  cookie: `auth_session=${h.SESSION}`,
+};
+
+// Create a SAVED console (path ⇒ shows in the tree + breadcrumb), then make it
+// legacy by removing draftRevision.
+const created = await fetch(`${h.API}/api/workspaces/${h.WS_ID}/consoles`, {
+  method: "POST",
+  headers,
+  body: JSON.stringify({
+    id,
+    path: oldName,
+    content: "SELECT 1",
+    language: "sql",
+    access: "private",
+  }),
+}).then(r => r.json());
+h.check("saved console created", created?.success !== false, created?.error);
+execSync(
+  `mongosh --quiet "${MONGO_URL}" --eval 'db.savedconsoles.updateOne({_id:ObjectId("${id}")},{$unset:{draftRevision:""}})'`,
+);
+
+// Count text occurrences in the LEFT SIDEBAR only (x < 280px), so the chat
+// panel on the right (which legitimately references the old name in a tool
+// card) cannot pollute tree assertions.
+const sidebarCount = async (page, text) => {
+  const loc = page.locator(`text=/${text}/`);
+  const n = await loc.count().catch(() => 0);
+  let count = 0;
+  for (let i = 0; i < n; i++) {
+    const box = await loc
+      .nth(i)
+      .boundingBox()
+      .catch(() => null);
+    if (box && box.x < 280) count++;
+  }
+  return count;
+};
+
+// Now open the window (its tree fetch will include the saved console).
+const A = await h.newWindow(b);
+
+// Open it via the agent, then reveal it in the Consoles explorer by clicking
+// the breadcrumb (the window defaults to the Databases explorer).
+await h.uiAgentChat(A.page, [{ tool: "open_console", input: { consoleId: id } }]);
+await h.waitFor(async () => (await h.getTabs(A.page))[id] || null);
+await A.page
+  .getByRole("button", { name: "Consoles", exact: true })
+  .first()
+  .click()
+  .catch(() => undefined);
+const treeHasOld = await h.waitFor(
+  async () => ((await sidebarCount(A.page, oldName)) > 0 ? true : null),
+  { timeoutMs: 15_000 },
+);
+h.check("sidebar tree shows the old name before rename", Boolean(treeHasOld));
+
+// Rename via the agent (name-only modify_console: no-op patch + title).
+await h.uiAgentChat(A.page, [
+  {
+    tool: "modify_console",
+    input: {
+      consoleId: id,
+      action: "patch",
+      startLine: 1,
+      endLine: 1,
+      content: "SELECT 1",
+      title: newName,
+    },
+  },
+]);
+
+await h.waitFor(
+  async () => ((await h.apiGetConsole(id))?.name === newName ? true : null),
+  { timeoutMs: 15_000 },
+);
+
+// Tab: store title updated (drives the tab strip).
+const tabUpdated = await h.waitFor(
+  async () => ((await h.getTabs(A.page))[id]?.title === newName ? true : null),
+  { timeoutMs: 12_000, stepMs: 1000 },
+);
+h.check("tab title updated to the new name", Boolean(tabUpdated));
+
+// Breadcrumb / page title: document.title derives from the active tab title.
+const docTitle = await A.page.title();
+h.check(
+  "page title (breadcrumb source) reflects the new name",
+  docTitle.includes(newName),
+  docTitle,
+);
+
+// Surgical tree update: the sidebar now shows the NEW name and NO LONGER the
+// old one — patched in place by id (no full refetch / skeleton).
+const treeNew = await h.waitFor(
+  async () => ((await sidebarCount(A.page, newName)) > 0 ? true : null),
+  { timeoutMs: 12_000, stepMs: 1000 },
+);
+h.check("sidebar tree shows the new name (surgical, no refetch)", Boolean(treeNew));
+const oldInSidebar = await sidebarCount(A.page, oldName);
+h.check("old name is gone from the sidebar tree", oldInSidebar === 0, {
+  oldInSidebar,
+});
+
+await h.screenshot(A.page, "12-rename-saved-surgical");
+
+await b.close();
+h.finish("12-rename-saved-surgical");

--- a/scripts/realtime-e2e/99-modify-dead-sse-repro.mjs
+++ b/scripts/realtime-e2e/99-modify-dead-sse-repro.mjs
@@ -1,0 +1,132 @@
+/**
+ * Repro — "agent create shows instantly, agent modify does not until refresh".
+ *
+ * Models the user's exact report:
+ *   1. user asks agent to CREATE a console  -> tab opens instantly
+ *   2. realtime SSE silently dies (NAT/proxy half-close, frozen tab, ...)
+ *   3. user asks agent to MODIFY the same console -> NOTHING happens in the
+ *      editor (create rode the resumable chat stream; modify relies ONLY on
+ *      the realtime poke, which is now dead)
+ *   4. reload the page -> the edit finally shows (onopen revision sync)
+ *
+ * Both turns are driven through the BROWSER chat UI (uiAgentChat), so create
+ * uses the in-band chat-stream open path and modify uses the realtime poke
+ * path — the asymmetry under test.
+ */
+import * as h from "./helpers.mjs";
+
+h.requireConfig();
+const b = await h.launch();
+const A = await h.newWindow(b);
+
+// Turn 1: CREATE (realtime SSE still alive)
+await h.uiAgentChat(A.page, [
+  {
+    tool: "create_console",
+    input: {
+      title: "ModifyRepro",
+      content: "SELECT 1",
+      connectionId: h.CONN_ID,
+    },
+  },
+]);
+const created = await h.waitFor(
+  async () => {
+    const tabs = await h.getTabs(A.page);
+    return Object.values(tabs).find(t => t.title === "ModifyRepro");
+  },
+  { timeoutMs: 20_000 },
+);
+h.check("create_console opened the tab in the chat's window", Boolean(created));
+const id = created?.id;
+if (!id) {
+  await b.close();
+  h.finish("99-modify-dead-sse-repro");
+  process.exit(0);
+}
+const createdText = await h.getEditorTextByTabId(A.page, id);
+h.check("editor shows the created content (SELECT 1)", createdText === "SELECT 1", createdText);
+
+// Kill the realtime SSE silently (no error event — looks alive to the store).
+await h.killRealtimeSilently(A.page);
+await A.page.waitForTimeout(500);
+
+// Turn 2: MODIFY (realtime SSE is dead; chat stream still works)
+await h.uiAgentChat(A.page, [
+  {
+    tool: "modify_console",
+    input: { consoleId: id, action: "replace", content: "SELECT 2" },
+  },
+]);
+
+// Give the agent turn time to finish + any (dead) poke to NOT arrive.
+await A.page.waitForTimeout(10_000);
+
+// Server ground truth: the modify committed.
+const srv = await h.apiGetConsole(id);
+h.check("server draft has the modified content (SELECT 2)", srv.content === "SELECT 2", srv.content);
+
+// Client: did the agent edit surface LIVE (no refresh)? The edit is shown as
+// a Monaco Accept/Reject diff, so detect either the diff banner or the new
+// content anywhere in the tab DOM (getValue() returns the baseline in a diff).
+// PRE-FIX: stays stale (nothing) until refresh. POST-FIX: surfaces live via
+// the resumable chat-stream reconciliation even though the SSE poke is dead.
+const surfacedLive = await h.waitFor(
+  async () => {
+    const banner =
+      (await A.page
+        .locator(`[data-mako-tab-id="${id}"]`)
+        .locator("text=/AI suggested changes/i")
+        .count()
+        .catch(() => 0)) > 0;
+    const newContent =
+      (await A.page
+        .locator(`[data-mako-tab-id="${id}"]`)
+        .locator("text=/SELECT 2/")
+        .count()
+        .catch(() => 0)) > 0;
+    return banner || newContent ? true : null;
+  },
+  { timeoutMs: 6000, stepMs: 1000 },
+);
+const editorAfterModify = await h.getEditorTextByTabId(A.page, id);
+const storeAfterModify = (await h.getTabs(A.page))[id]?.content;
+h.check(
+  "agent modify surfaces LIVE with a dead SSE (no refresh needed)",
+  Boolean(surfacedLive),
+  { surfacedLive, editor: editorAfterModify, store: storeAfterModify },
+);
+
+await h.screenshot(A.page, "99-after-modify-dead-sse");
+
+// Now refresh — the user's workaround. The agent edit surfaces as a Monaco
+// Accept/Reject diff, so look for the new content anywhere in the tab DOM
+// (the diff's modified side) rather than via the buffer getValue().
+await A.page.reload({ waitUntil: "domcontentloaded" });
+await A.page.waitForTimeout(5000);
+const afterReload = await h.waitFor(
+  async () => {
+    const inBuffer = (await h.getEditorTextByTabId(A.page, id))?.includes(
+      "SELECT 2",
+    );
+    const inDom =
+      (
+        await A.page
+          .locator(`[data-mako-tab-id="${id}"]`)
+          .locator("text=/SELECT 2|AI suggested changes/i")
+          .count()
+          .catch(() => 0)
+      ) > 0;
+    return inBuffer || inDom ? true : null;
+  },
+  { timeoutMs: 15_000, stepMs: 1000 },
+);
+h.check(
+  "after a manual page refresh the modify is visible",
+  Boolean(afterReload),
+  afterReload,
+);
+await h.screenshot(A.page, "99-after-reload");
+
+await b.close();
+h.finish("99-modify-dead-sse-repro");

--- a/scripts/realtime-e2e/README.md
+++ b/scripts/realtime-e2e/README.md
@@ -23,6 +23,7 @@ hide divergence. Run it whenever the sync layer changes:
 | `03-agent-modalities` | create/modify/run/set-connection/open: Monaco shows agent edits, results render, user↔agent edits interleave without loss, tab stays a draft |
 | `04-dead-sse` | consoles created during a silently-dead SSE still appear (in-band chat stream); liveness watchdog reconnects ≲85s and repairs missed pokes (~2 min, real time) |
 | `05-stale-save-dual-guard` | agent edits (draftRevision-only) can't be silently reverted by a stale Cmd+S (dual version+draftRevision guard) |
+| `07-create-modify-same-turn` | create + modify in ONE turn with a delayed content fetch (forces the poke-before-tab-open race): the editor shows the modified query without a refresh (reconcile-after-open) |
 | `99-modify-dead-sse-repro` | agent `modify_console` surfaces LIVE even when the realtime poke channel is dead — the chat stream drives an in-band revision sync (regression for "create showed instantly, modify did nothing until refresh") |
 
 ## One-time setup

--- a/scripts/realtime-e2e/README.md
+++ b/scripts/realtime-e2e/README.md
@@ -24,6 +24,7 @@ hide divergence. Run it whenever the sync layer changes:
 | `04-dead-sse` | consoles created during a silently-dead SSE still appear (in-band chat stream); liveness watchdog reconnects ≲85s and repairs missed pokes (~2 min, real time) |
 | `05-stale-save-dual-guard` | agent edits (draftRevision-only) can't be silently reverted by a stale Cmd+S (dual version+draftRevision guard) |
 | `07-create-modify-same-turn` | create + modify in ONE turn with a delayed content fetch (forces the poke-before-tab-open race): the editor shows the modified query without a refresh (reconcile-after-open) |
+| `10-run-dead-sse` | agent `run_console` RESULTS render under a silently-dead SSE via the in-band reconcile (the run.completed poke is missed) |
 | `99-modify-dead-sse-repro` | agent `modify_console` surfaces LIVE even when the realtime poke channel is dead — the chat stream drives an in-band revision sync (regression for "create showed instantly, modify did nothing until refresh") |
 
 ## One-time setup

--- a/scripts/realtime-e2e/README.md
+++ b/scripts/realtime-e2e/README.md
@@ -26,6 +26,7 @@ hide divergence. Run it whenever the sync layer changes:
 | `07-create-modify-same-turn` | create + modify in ONE turn with a delayed content fetch (forces the poke-before-tab-open race): the editor shows the modified query without a refresh (reconcile-after-open) |
 | `10-run-dead-sse` | agent `run_console` RESULTS render under a silently-dead SSE via the in-band reconcile (the run.completed poke is missed) |
 | `11-rename-legacy-console` | agent rename of a LEGACY console (no `draftRevision` field) updates the open tab title + breadcrumbs + tree (revision-base `?? 0` fix; simulates legacy via mongosh `$unset`) |
+| `12-rename-saved-surgical` | agent rename of a SAVED console updates tab + breadcrumb + sidebar tree surgically (by id, no full refetch/skeleton); old name gone everywhere |
 | `99-modify-dead-sse-repro` | agent `modify_console` surfaces LIVE even when the realtime poke channel is dead — the chat stream drives an in-band revision sync (regression for "create showed instantly, modify did nothing until refresh") |
 
 ## One-time setup

--- a/scripts/realtime-e2e/README.md
+++ b/scripts/realtime-e2e/README.md
@@ -25,6 +25,7 @@ hide divergence. Run it whenever the sync layer changes:
 | `05-stale-save-dual-guard` | agent edits (draftRevision-only) can't be silently reverted by a stale Cmd+S (dual version+draftRevision guard) |
 | `07-create-modify-same-turn` | create + modify in ONE turn with a delayed content fetch (forces the poke-before-tab-open race): the editor shows the modified query without a refresh (reconcile-after-open) |
 | `10-run-dead-sse` | agent `run_console` RESULTS render under a silently-dead SSE via the in-band reconcile (the run.completed poke is missed) |
+| `11-rename-legacy-console` | agent rename of a LEGACY console (no `draftRevision` field) updates the open tab title + breadcrumbs + tree (revision-base `?? 0` fix; simulates legacy via mongosh `$unset`) |
 | `99-modify-dead-sse-repro` | agent `modify_console` surfaces LIVE even when the realtime poke channel is dead — the chat stream drives an in-band revision sync (regression for "create showed instantly, modify did nothing until refresh") |
 
 ## One-time setup

--- a/scripts/realtime-e2e/README.md
+++ b/scripts/realtime-e2e/README.md
@@ -23,6 +23,7 @@ hide divergence. Run it whenever the sync layer changes:
 | `03-agent-modalities` | create/modify/run/set-connection/open: Monaco shows agent edits, results render, user↔agent edits interleave without loss, tab stays a draft |
 | `04-dead-sse` | consoles created during a silently-dead SSE still appear (in-band chat stream); liveness watchdog reconnects ≲85s and repairs missed pokes (~2 min, real time) |
 | `05-stale-save-dual-guard` | agent edits (draftRevision-only) can't be silently reverted by a stale Cmd+S (dual version+draftRevision guard) |
+| `99-modify-dead-sse-repro` | agent `modify_console` surfaces LIVE even when the realtime poke channel is dead — the chat stream drives an in-band revision sync (regression for "create showed instantly, modify did nothing until refresh") |
 
 ## One-time setup
 

--- a/scripts/realtime-e2e/helpers.mjs
+++ b/scripts/realtime-e2e/helpers.mjs
@@ -117,13 +117,15 @@ export async function getTabs(page) {
 export async function getEditorTextByTabId(page, tabId) {
   return page.evaluate(tid => {
     const editors = window.monaco?.editor?.getEditors?.() || [];
-    for (const ed of editors) {
+    const inTab = editors.filter(ed => {
       const node = ed.getContainerDomNode?.();
-      if (node && node.closest(`[data-mako-tab-id="${tid}"]`)) {
-        return ed.getValue();
-      }
-    }
-    return null;
+      return node && node.closest(`[data-mako-tab-id="${tid}"]`);
+    });
+    if (inTab.length === 0) return null;
+    // An agent review renders a Monaco diff (original + proposed editors); the
+    // proposed (modified) side is mounted last, so read that one — otherwise a
+    // diff under review reads back as the stale baseline.
+    return inTab.at(-1)?.getValue() ?? null;
   }, tabId);
 }
 

--- a/scripts/realtime-e2e/run-all.mjs
+++ b/scripts/realtime-e2e/run-all.mjs
@@ -15,6 +15,7 @@ const scenarios = [
   "04-dead-sse.mjs",
   "05-stale-save-dual-guard.mjs",
   "06-wake-triggers.mjs",
+  "07-create-modify-same-turn.mjs",
   "99-modify-dead-sse-repro.mjs",
 ];
 

--- a/scripts/realtime-e2e/run-all.mjs
+++ b/scripts/realtime-e2e/run-all.mjs
@@ -15,6 +15,7 @@ const scenarios = [
   "04-dead-sse.mjs",
   "05-stale-save-dual-guard.mjs",
   "06-wake-triggers.mjs",
+  "99-modify-dead-sse-repro.mjs",
 ];
 
 const results = [];

--- a/scripts/realtime-e2e/run-all.mjs
+++ b/scripts/realtime-e2e/run-all.mjs
@@ -16,6 +16,7 @@ const scenarios = [
   "05-stale-save-dual-guard.mjs",
   "06-wake-triggers.mjs",
   "07-create-modify-same-turn.mjs",
+  "10-run-dead-sse.mjs",
   "99-modify-dead-sse-repro.mjs",
 ];
 

--- a/scripts/realtime-e2e/run-all.mjs
+++ b/scripts/realtime-e2e/run-all.mjs
@@ -18,6 +18,7 @@ const scenarios = [
   "07-create-modify-same-turn.mjs",
   "10-run-dead-sse.mjs",
   "11-rename-legacy-console.mjs",
+  "12-rename-saved-surgical.mjs",
   "99-modify-dead-sse-repro.mjs",
 ];
 

--- a/scripts/realtime-e2e/run-all.mjs
+++ b/scripts/realtime-e2e/run-all.mjs
@@ -17,6 +17,7 @@ const scenarios = [
   "06-wake-triggers.mjs",
   "07-create-modify-same-turn.mjs",
   "10-run-dead-sse.mjs",
+  "11-rename-legacy-console.mjs",
   "99-modify-dead-sse-repro.mjs",
 ];
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes server-authored console changes reflect reliably and consistently in the client, and establishes a single canonical source of truth for a console's name. Seven commits across three themes.

## A. Live propagation of agent console edits (the original bug)

`create_console`/`open_console` rode the **resumable in-band chat stream**; the other server console tools relied **solely** on the best-effort workspace realtime SSE poke, so a missed poke (dead/half-closed SSE, or a poke racing the tab open) left the open view stale until focus/reconnect/watchdog(~85s)/refresh.

[modify_after_fix_live_diff.png](https://cursor.com/agents/bc-158aaaaa-8976-42e6-a747-b5859493b8b1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmodify_after_fix_live_diff.png)

- **`reflect agent modify_console live via the resumable chat stream`** — `modify_console`/`set_console_connection` reaching `output-available` trigger `syncRevisions()`.
- **`halve the missed-poke self-heal window`** — heartbeat 25s→15s; watchdog 70s→35s / 8s sweep / 25s wake.
- **`harden realtime sync`** (from sibling branches `…-4abc`/`…-ee9d`) — `beginAgentReview` fast-forwards revision/metadata on the content-match no-op (re-pull churn); seed `agentOriginConsoles` before the `!tab` return + reconcile-after-open (create→modify race); `chat.activity: idle` catch-all; e2e helper reads the diff's modified side.
- **`surface agent run_console results live under a dead SSE`** — `run_console` added to the in-band reconcile.

## B. Legacy `draftRevision` collision

Legacy consoles have no `draftRevision`; the Mongoose `default: 1` reports 1 while `$inc` on the absent field also yields 1, so the first agent write equalled the client's value and `revisions-sync` returned no change. **`agent rename/edits propagate to legacy consoles`** — the agent edit tools set the next revision explicitly (`current + 1`), so a legacy console's first write goes 1→2.

## C. Surgical, canonical console name (the latest issues)

**`surgical (by-id) UI update on agent rename`** — the sidebar tree was refetched (`fetchTree` → skeletons/layout shift). Added `consoleTreeStore.applyRemoteRename(id, name)` (in-place, no refetch); breadcrumb leaf now follows the live name. Acid test (no skeletons/blink):

[agent_rename_surgical_no_blink.mp4](https://cursor.com/agents/bc-158aaaaa-8976-42e6-a747-b5859493b8b1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_rename_surgical_no_blink.mp4)

**`one canonical source of truth for a console's name (leaf), not the path`** — `tab.title` was the **leaf** in some open paths and the **full slash path** in others (sidebar click → `node.path`, save → `savePath`, move → `nextPath`); the tab strip masked it with `.split("/").pop()`. PR #565 removed that mask and stored the full path *as* the name → `fr/csm/customer_list` shown as the tab title/breadcrumb leaf.

Canonical model (confirmed by the schema + `console-manager.buildTree`): **folders are real (`folderId`→`parentId`); `SavedConsole.name` is the LEAF; the slash path is DERIVED.** So:
- **Client**: `tab.title` is always the leaf — `fetchConsoleContent` reconciles it to `res.name`; sidebar/save/move set the leaf; new `lib/console-name.ts` (`consoleLeafName` + `consoleFolderTrail`); breadcrumb derives the folder trail by stripping the leaf (robust to slashy legacy names); tab strip renders the title verbatim.
- **Server**: `create_console`/`modify_console` store the leaf (slashes can no longer leak a path into `name`). `saveConsole`/`renameConsole` already produced leaves.
- **Migration** `2026-06-23-163424_fold_slash_console_names_into_folders`: idempotently folds any `SavedConsole` whose `name` still contains "/" into the real folder hierarchy (ensures the folder chain, sets `name`=leaf + `folderId`=deepest; inherits access/owner). Tested locally (folder creation, idempotency, access inheritance, edge cases).

A console inside a folder, opened from the sidebar, now shows the leaf in the tab and a proper folder trail in the breadcrumb:

[console_name_canonical_leaf_title_breadcrumb.mp4](https://cursor.com/agents/bc-158aaaaa-8976-42e6-a747-b5859493b8b1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconsole_name_canonical_leaf_title_breadcrumb.mp4)

This **supersedes PR #565's display approach** (which conflated name with path); recommend closing #565 in favor of this.

## Testing

- ✅ realtime-e2e: `99-modify-dead-sse-repro`, `10-run-dead-sse`, `07-create-modify-same-turn`, `11-rename-legacy-console`, `12-rename-saved-surgical`.
- ✅ Migration unit-tested locally against Mongo (fold + idempotent + edge cases).
- ✅ Foldered console opened from the sidebar: leaf tab title + folder-trail breadcrumb (video, video-reviewed).
- ✅ `pnpm --filter app run typecheck` · `pnpm --filter app run lint` · `pnpm --filter api run lint`.

## Out of scope / follow-ups

- Dashboard/app/dbt/flow agent edits run client-side with no realtime channel — they only affect the driving window (separate multi-user gap).
- The same legacy-`draftRevision` collision affects user-driven single writes propagating to *other* windows (those paths keep `$inc`).
- `03-agent-modalities.mjs` fails on `master` independently (asserts pre-diff-review behavior).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-158aaaaa-8976-42e6-a747-b5859493b8b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-158aaaaa-8976-42e6-a747-b5859493b8b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

