### PR TITLE
fix(public-share): force re-query on public dashboard refresh

### DIFF
--- a/api/src/routes/public-share.ts
+++ b/api/src/routes/public-share.ts
@@ -530,9 +530,15 @@ app.openapi(
         );
       }
 
+      // force: true re-queries the owner-defined source queries even when the
+      // dashboard definition is unchanged. Without it, the rebuild service
+      // reuses the cached parquet (no new parquetBuiltAt), so the viewer's
+      // "data changed?" poll never observes a fresh snapshot and times out.
+      // The 5-minute cooldown above guards against abusive/expensive re-runs.
       const queueResult = await queueDashboardArtifactRefresh({
         dashboardId: dashboard._id.toString(),
         workspaceId: dashboard.workspaceId.toString(),
+        force: true,
         triggerType: "manual",
       });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Public (anonymous) dashboards already expose a **"Refresh data"** button (`PublicDashboardViewer.tsx` → `POST /api/share/:token/refresh`). But it didn't actually force a re-query of the underlying source data.

The endpoint called `queueDashboardArtifactRefresh({ triggerType: "manual" })` **without `force: true`**. In `dashboard-artifact-rebuild.service.ts`, the `cachedReady` guard reuses the existing Parquet whenever the dashboard *definition* is unchanged. So:

- `parquetBuiltAt` never advances
- the viewer's poll loop (which waits for `materializedAt` to change) never observes a fresh snapshot
- the refresh appears to time out (*"taking longer than expected"*) — even though the user clicked it specifically to pick up new rows in the source DB

The authenticated path (`POST /dashboards/:id/refresh`) already passes `force: true`; the public path was simply missing it.

## Fix

Pass `force: true` from the public refresh endpoint so the owner-defined source queries are genuinely re-executed and a new snapshot is built. The existing **5-minute server-side cooldown** (`PUBLIC_REFRESH_COOLDOWN_MS`, claimed atomically) still guards against abusive/expensive re-runs. One-line behavioral change plus an explanatory comment; no schema or UI changes.

## Walkthrough

Clicking "Refresh data" on a public dashboard now advances the "Data as of" timestamp (a real re-materialization), with no timeout.

[public_dashboard_refresh_force_rebuild.mp4](https://cursor.com/agents/bc-5ba25735-66c3-443a-9eee-1914cd1043b1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpublic_dashboard_refresh_force_rebuild.mp4)

Before vs. after (timestamp advances `1:44:27 PM` → `1:48:26 PM`):

[Before refresh: Data as of 1:44:27 PM](https://cursor.com/agents/bc-5ba25735-66c3-443a-9eee-1914cd1043b1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpublic_dashboard_before_refresh.webp)
[After refresh: Data as of 1:48:26 PM](https://cursor.com/agents/bc-5ba25735-66c3-443a-9eee-1914cd1043b1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpublic_dashboard_refreshed_state.webp)

## Testing

- **End-to-end (real route + Inngest pipeline)** against a live public dashboard backed by the Chinook demo Postgres:
  - Initial materialization → `parquetBuiltAt = t1`
  - Rebuild **without** force (old behavior) → `reused = true`, `parquetBuiltAt` **unchanged** (reproduces the bug)
  - Real `POST /api/share/:token/refresh` (new behavior) → HTTP 200, server log shows `dashboard.refresh` published with `"force":true`, `parquetBuiltAt` **advanced to t2** → forced rebuild confirmed
- **Manual UI**: clicked "Refresh data" on `/share/:token`; "Refreshing data…" appeared then cleared, "Data as of" timestamp advanced, no error (see walkthrough).
- ✅ `pnpm --filter api run lint`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ba25735-66c3-443a-9eee-1914cd1043b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ba25735-66c3-443a-9eee-1914cd1043b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

