### PR TITLE
Fix slash handling in console names

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -13,7 +13,7 @@
     "worker:dev": "tsx watch src/worker.ts",
     "migrate:workspaces": "tsx src/migrations/migrate-to-workspaces.ts",
     "openapi:generate": "tsx src/openapi/generate-cli.ts",
-    "test": "tsx src/openapi/core.test.ts && tsx src/openapi/openapi.test.ts && tsx src/dbt/warm-dir-cache.test.ts && tsx src/connectors/stripe/connector.test.ts && tsx src/connectors/close/connector.test.ts && tsx src/sync-cdc/idempotency.test.ts && tsx src/agent-lib/context/compaction.test.ts",
+    "test": "tsx src/openapi/core.test.ts && tsx src/openapi/openapi.test.ts && tsx src/dbt/warm-dir-cache.test.ts && tsx src/connectors/stripe/connector.test.ts && tsx src/connectors/close/connector.test.ts && tsx src/sync-cdc/idempotency.test.ts && tsx src/agent-lib/context/compaction.test.ts && tsx src/utils/console-manager.test.ts",
     "test:dbt": "vitest run",
     "test:dbt:watch": "vitest",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives",

--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -924,6 +924,10 @@ consoleRoutes.openapi(
           400,
         );
       }
+      const targetFolderId =
+        typeof folderId === "string" && Types.ObjectId.isValid(folderId)
+          ? folderId
+          : undefined;
 
       // connectionId is optional - consoles can be saved without being associated with a specific database
       let targetConnectionId = connectionId;
@@ -942,6 +946,7 @@ consoleRoutes.openapi(
       const existingConsole = await consoleManager.getConsoleByPath(
         consolePath,
         workspaceId,
+        targetFolderId,
       );
 
       // If console exists and has a different ID, check for conflict
@@ -990,7 +995,7 @@ consoleRoutes.openapi(
         databaseId,
         {
           id: consoleIdToUse, // Use existing console ID if overwriting placeholder, otherwise client ID
-          folderId,
+          folderId: targetFolderId,
           description,
           language,
           isPrivate,
@@ -1045,7 +1050,7 @@ consoleRoutes.openapi(
             } = await generateDescriptionAndEmbedding(
               {
                 code: content,
-                title: consolePath.split("/").pop() || consolePath,
+                title: consolePath,
                 connectionName: connDoc?.name,
                 databaseType: connDoc?.type,
                 databaseName,
@@ -1242,9 +1247,19 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
       // If this is an explicit save with a path, check for path conflicts
       if (isExplicitSave && body.path) {
         const consolePath = body.path;
+        const hasFolderId = Object.prototype.hasOwnProperty.call(
+          body,
+          "folderId",
+        );
+        const targetFolderId =
+          typeof body.folderId === "string" &&
+          Types.ObjectId.isValid(body.folderId)
+            ? body.folderId
+            : undefined;
         const existingConsole = await consoleManager.getConsoleByPath(
           consolePath,
           workspaceId,
+          targetFolderId,
         );
 
         // If a different console exists at this path, return conflict
@@ -1265,26 +1280,12 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
           );
         }
 
-        // Parse path to get folder and name
-        const parts = consolePath.split("/");
-        const consoleName = parts[parts.length - 1];
-        let folderId: string | undefined;
-        if (parts.length > 1) {
-          const folderPath = parts.slice(0, -1);
-          folderId = await consoleManager.findOrCreateFolderPath(
-            folderPath,
-            workspaceId,
-            user.id,
-          );
-        }
-
         const displayName = await getUserDisplayName(user.id);
 
-        // Update with path information (use upsert in case console hasn't been auto-saved yet)
+        // Update with explicit save information (use upsert in case console hasn't been auto-saved yet)
         const setFields: Record<string, any> = {
           code: body.content,
-          name: consoleName,
-          folderId: folderId ? new Types.ObjectId(folderId) : undefined,
+          name: consolePath,
           connectionId: body.connectionId
             ? new Types.ObjectId(body.connectionId)
             : undefined,
@@ -1296,6 +1297,11 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
           // reconnect doesn't re-surface this as an agent diff.
           lastDraftOrigin: "user",
         };
+        if (hasFolderId) {
+          setFields.folderId = targetFolderId
+            ? new Types.ObjectId(targetFolderId)
+            : null;
+        }
         if (body.chartSpec !== undefined) setFields.chartSpec = body.chartSpec;
         if (body.resultsViewMode !== undefined) {
           setFields.resultsViewMode = body.resultsViewMode;
@@ -1561,6 +1567,10 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
 
     // Path-based save (explicit user save to folder)
     const consolePath = pathOrId;
+    const targetFolderId =
+      typeof body.folderId === "string" && Types.ObjectId.isValid(body.folderId)
+        ? body.folderId
+        : undefined;
 
     // connectionId is optional - consoles can be saved without being associated with a specific database
     let targetConnectionId = body.connectionId;
@@ -1582,7 +1592,7 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
       body.databaseName,
       body.databaseId,
       {
-        folderId: body.folderId,
+        folderId: targetFolderId,
         description: body.description,
         language: body.language,
         isPrivate: body.isPrivate,
@@ -1623,7 +1633,7 @@ consoleRoutes.put("/:path{.+}", async (c: Context) => {
           } = await generateDescriptionAndEmbedding(
             {
               code: body.content,
-              title: consolePath.split("/").pop() || consolePath,
+              title: consolePath,
               connectionName: connDoc?.name,
               databaseType: connDoc?.type,
               databaseName: body.databaseName,

--- a/api/src/utils/console-manager.test.ts
+++ b/api/src/utils/console-manager.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import mongoose, { Types } from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { ConsoleFolder, SavedConsole } from "../database/workspace-schema";
+import { ConsoleManager } from "./console-manager";
+
+const WORKSPACE_ID = new Types.ObjectId().toString();
+const USER_ID = "user-1";
+
+async function resetCollections() {
+  await Promise.all([SavedConsole.deleteMany({}), ConsoleFolder.deleteMany({})]);
+}
+
+async function testSavePreservesSlashNames() {
+  await resetCollections();
+  const manager = new ConsoleManager();
+
+  const saved = await manager.saveConsole(
+    "finance/revenue",
+    "select 1",
+    WORKSPACE_ID,
+    USER_ID,
+    undefined,
+    undefined,
+    undefined,
+    { id: new Types.ObjectId().toString(), access: "private" },
+  );
+
+  const persisted = await SavedConsole.findById(saved._id).lean();
+  const exactMatch = await manager.getConsoleByPath(
+    "finance/revenue",
+    WORKSPACE_ID,
+  );
+
+  assert.equal(persisted?.name, "finance/revenue");
+  assert.equal(persisted?.folderId, undefined);
+  assert.equal(
+    await ConsoleFolder.countDocuments({ workspaceId: WORKSPACE_ID }),
+    0,
+  );
+  assert.equal(exactMatch?.name, "finance/revenue");
+  assert.equal(await manager.getConsoleByPath("revenue", WORKSPACE_ID), null);
+}
+
+async function testExplicitFolderIdControlsPlacement() {
+  await resetCollections();
+  const manager = new ConsoleManager();
+  const folder = await manager.createFolder("Finance", WORKSPACE_ID, USER_ID);
+
+  const saved = await manager.saveConsole(
+    "north/america",
+    "select 1",
+    WORKSPACE_ID,
+    USER_ID,
+    undefined,
+    undefined,
+    undefined,
+    { folderId: folder._id.toString(), access: "private" },
+  );
+
+  const persisted = await SavedConsole.findById(saved._id).lean();
+  const exactMatch = await manager.getConsoleByPath(
+    "north/america",
+    WORKSPACE_ID,
+    folder._id.toString(),
+  );
+
+  assert.equal(persisted?.name, "north/america");
+  assert.equal(persisted?.folderId?.toString(), folder._id.toString());
+  assert.equal(
+    await ConsoleFolder.countDocuments({ workspaceId: WORKSPACE_ID }),
+    1,
+  );
+  assert.equal(exactMatch?.name, "north/america");
+}
+
+async function testRenamePreservesSlashNames() {
+  await resetCollections();
+  const manager = new ConsoleManager();
+  const saved = await manager.saveConsole(
+    "initial",
+    "select 1",
+    WORKSPACE_ID,
+    USER_ID,
+    undefined,
+    undefined,
+    undefined,
+    { access: "private" },
+  );
+
+  const success = await manager.renameConsole(
+    saved._id.toString(),
+    "a/b/c",
+    WORKSPACE_ID,
+    USER_ID,
+  );
+  const persisted = await SavedConsole.findById(saved._id).lean();
+
+  assert.equal(success, true);
+  assert.equal(persisted?.name, "a/b/c");
+  assert.equal(persisted?.folderId, undefined);
+  assert.equal(
+    await ConsoleFolder.countDocuments({ workspaceId: WORKSPACE_ID }),
+    0,
+  );
+}
+
+async function main() {
+  const mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+  try {
+    await testSavePreservesSlashNames();
+    await testExplicitFolderIdControlsPlacement();
+    await testRenamePreservesSlashNames();
+  } finally {
+    await mongoose.disconnect();
+    await mongo.stop();
+  }
+}
+
+void main().then(() => {
+  // eslint-disable-next-line no-console -- self-running test, not API code
+  console.log("console-manager.test.ts: all assertions passed");
+});

--- a/api/src/utils/console-manager.ts
+++ b/api/src/utils/console-manager.ts
@@ -476,33 +476,11 @@ export class ConsoleManager {
             workspaceId: new Types.ObjectId(workspaceId),
           });
         } else {
-          // Try to find by path
-          const parts = consolePath.split("/");
-          const consoleName = parts[parts.length - 1];
-
-          if (parts.length > 1) {
-            // Console is in a folder - need to find the folder first
-            const folderParts = parts.slice(0, -1);
-            const folderId = await this.findFolderByPath(
-              folderParts,
-              workspaceId,
-            );
-
-            savedConsole = await SavedConsole.findOne({
-              name: consoleName,
-              workspaceId: new Types.ObjectId(workspaceId),
-              folderId: folderId
-                ? new Types.ObjectId(folderId)
-                : { $exists: false },
-            });
-          } else {
-            // Console is at root level
-            savedConsole = await SavedConsole.findOne({
-              name: consoleName,
-              workspaceId: new Types.ObjectId(workspaceId),
-              folderId: { $exists: false },
-            });
-          }
+          savedConsole = await SavedConsole.findOne({
+            name: consolePath,
+            workspaceId: new Types.ObjectId(workspaceId),
+            $or: [{ folderId: null }, { folderId: { $exists: false } }],
+          });
         }
 
         if (savedConsole) {
@@ -756,7 +734,7 @@ export class ConsoleManager {
     databaseId?: string,
     options?: {
       id?: string; // Optional client-provided ID
-      folderId?: string;
+      folderId?: string | null;
       description?: string;
       language?: "sql" | "javascript" | "mongodb";
       isPrivate?: boolean;
@@ -764,21 +742,8 @@ export class ConsoleManager {
     },
   ): Promise<ISavedConsole> {
     try {
-      const parts = consolePath.split("/");
-      const consoleName = parts[parts.length - 1];
-
-      // Handle folder path from consolePath if not provided in options
-      let folderId = options?.folderId;
-
-      if (!folderId && parts.length > 1) {
-        // Extract folder path and find/create the folder
-        const folderParts = parts.slice(0, -1);
-        folderId = await this.ensureFolderPath(
-          folderParts,
-          workspaceId,
-          userId,
-        );
-      }
+      const consoleName = consolePath;
+      const folderId = options?.folderId ?? undefined;
 
       // Look up existing console - try by ID first, then by name + folder
       // The POST route handles conflict detection for new consoles
@@ -793,7 +758,7 @@ export class ConsoleManager {
         });
       }
 
-      // Fallback: look up by name + folder for path-based PUT requests
+      // Fallback: look up by exact name + folder for legacy path-based PUT requests.
       // Only match saved consoles (isSaved: true), not drafts
       if (!savedConsole) {
         const query: any = {
@@ -822,10 +787,10 @@ export class ConsoleManager {
 
       if (savedConsole) {
         // Update existing console (draft -> saved)
-        savedConsole.name = consoleName; // Update name (may change if draft is being saved with a path)
+        savedConsole.name = consoleName;
         savedConsole.folderId = folderId
           ? new Types.ObjectId(folderId)
-          : undefined; // Update folder (draft -> saved with path)
+          : undefined;
         savedConsole.code = content;
         savedConsole.isSaved = true; // Mark as explicitly saved (no longer a draft)
         savedConsole.updatedAt = new Date();
@@ -949,34 +914,13 @@ export class ConsoleManager {
     consoleId: string,
     newName: string,
     workspaceId: string,
-    userId: string,
+    _userId: string,
   ): Promise<boolean> {
     try {
-      // Parse the new name for potential folder path
-      const parts = newName.split("/");
-      const consoleName = parts[parts.length - 1];
-
-      let folderId: string | undefined = undefined;
-
-      if (parts.length > 1) {
-        // Extract folder path and find/create the folder
-        const folderParts = parts.slice(0, -1);
-        folderId = await this.ensureFolderPath(
-          folderParts,
-          workspaceId,
-          userId,
-        );
-      }
-
       const updateFields: any = {
-        name: consoleName,
+        name: newName,
         updatedAt: new Date(),
       };
-
-      // Update folderId if we have a folder path
-      if (parts.length > 1) {
-        updateFields.folderId = folderId ? new Types.ObjectId(folderId) : null;
-      }
 
       const result = await SavedConsole.updateOne(
         {
@@ -1094,30 +1038,11 @@ export class ConsoleManager {
           });
           return !!savedConsole;
         } else {
-          const parts = consolePath.split("/");
-          const consoleName = parts[parts.length - 1];
-
-          // Get folder ID if there's a folder path
-          let folderId: string | undefined;
-          if (parts.length > 1) {
-            const folderParts = parts.slice(0, -1);
-            folderId = await this.findFolderByPath(folderParts, workspaceId);
-          }
-
-          // Check for console with same name in same folder (or root if no folder)
-          const query: any = {
-            name: consoleName,
+          const savedConsole = await SavedConsole.findOne({
+            name: consolePath,
             workspaceId: new Types.ObjectId(workspaceId),
-          };
-
-          if (folderId) {
-            query.folderId = new Types.ObjectId(folderId);
-          } else {
-            // For root level consoles, check that folderId is null/undefined
-            query.$or = [{ folderId: null }, { folderId: { $exists: false } }];
-          }
-
-          const savedConsole = await SavedConsole.findOne(query);
+            $or: [{ folderId: null }, { folderId: { $exists: false } }],
+          });
           return !!savedConsole;
         }
       }
@@ -1138,28 +1063,13 @@ export class ConsoleManager {
   async getConsoleByPath(
     consolePath: string,
     workspaceId: string,
+    folderId?: string | null,
   ): Promise<ISavedConsole | null> {
     try {
-      const parts = consolePath.split("/");
-      const consoleName = parts[parts.length - 1];
-
-      // Get folder ID if there's a folder path
-      let folderId: string | undefined;
-      const hasFolder = parts.length > 1;
-      if (hasFolder) {
-        const folderParts = parts.slice(0, -1);
-        folderId = await this.findFolderByPath(folderParts, workspaceId);
-
-        // If path specifies a folder but it doesn't exist, no console can exist at this path
-        if (!folderId) {
-          return null;
-        }
-      }
-
-      // Build query for console with same name in same folder (or root if no folder)
+      // Build query for console with same exact name in the selected folder (or root).
       // Only match explicitly saved consoles (isSaved: true) - not drafts
       const query: any = {
-        name: consoleName,
+        name: consolePath,
         workspaceId: new Types.ObjectId(workspaceId),
         isSaved: true, // Only match saved consoles, not drafts
       };
@@ -1175,7 +1085,7 @@ export class ConsoleManager {
       // in case there are duplicate entries
       return await SavedConsole.findOne(query).sort({ updatedAt: -1 });
     } catch (error) {
-      console.error("Error getting console by path:", error);
+      logger.error("Error getting console by path", { error });
       return null;
     }
   }

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -524,6 +524,7 @@ function Editor({
     databaseName?: string;
     comment?: string;
     access?: "private" | "workspace";
+    folderId?: string | null;
   } | null>(null);
 
   // Refs for query cancellation (per-tab to support parallel queries)
@@ -1431,7 +1432,13 @@ function Editor({
           );
           useConsoleTreeStore
             .getState()
-            .addConsole(currentWorkspace.id, savePath ?? "", tabId);
+            .addConsole(
+              currentWorkspace.id,
+              savePath ?? "",
+              tabId,
+              null,
+              currentTab?.access,
+            );
         }
 
         if (currentTab?.metadata?.openScheduleOnSave) {
@@ -1708,6 +1715,7 @@ function Editor({
         tabViewModes[pendingSaveData.tabId],
         pendingSaveData.comment,
         pendingSaveData.access,
+        pendingSaveData.folderId,
       );
 
       if (result.success) {
@@ -1734,7 +1742,13 @@ function Editor({
         );
         useConsoleTreeStore
           .getState()
-          .addConsole(currentWorkspace.id, pendingSaveData.path, tabId);
+          .addConsole(
+            currentWorkspace.id,
+            pendingSaveData.path,
+            tabId,
+            pendingSaveData.folderId,
+            pendingSaveData.access,
+          );
 
         setSnackbarMessage(`Console saved at '${pendingSaveData.path}.js'`);
         setSnackbarOpen(true);
@@ -1794,6 +1808,7 @@ function Editor({
           tabViewModes[saveDialogTabId],
           undefined,
           section === "workspace" ? "workspace" : "private",
+          folderId,
         );
 
         if (result.error === "conflict" && result.conflict) {
@@ -1805,6 +1820,7 @@ function Editor({
             databaseId,
             databaseName,
             access: section === "workspace" ? "workspace" : "private",
+            folderId,
           });
           setConflictData(result.conflict);
           setConflictDialogOpen(true);
@@ -1884,6 +1900,7 @@ function Editor({
           databaseId,
           databaseName,
           access: section === "workspace" ? "workspace" : "private",
+          folderId,
         });
         setConflictData(result.conflict);
         setConflictDialogOpen(true);
@@ -2289,8 +2306,7 @@ function Editor({
                                 }}
                                 title={tab.title}
                               >
-                                {tab.title?.split("/").filter(Boolean).pop() ||
-                                  tab.title}
+                                {tab.title}
                               </span>
                               <IconButton
                                 component="span"

--- a/app/src/components/EntityBreadcrumbs.tsx
+++ b/app/src/components/EntityBreadcrumbs.tsx
@@ -63,11 +63,7 @@ function segmentsForTab(
         ];
       }
       const group = tab.access === "workspace" ? "Workspace" : "My Consoles";
-      return plain([
-        "Consoles",
-        group,
-        ...tab.filePath.split("/").filter(Boolean),
-      ]);
+      return plain(["Consoles", group, tab.title || tab.filePath]);
     }
     case "table-data":
       return plain([

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -205,6 +205,7 @@ interface ConsoleActions {
     resultsViewMode?: string,
     comment?: string,
     access?: "private" | "workspace",
+    folderId?: string | null,
   ) => Promise<ConsoleSaveResponse>;
   deleteConsole: (
     workspaceId: string,
@@ -1264,6 +1265,7 @@ export const useConsoleStore = create<ConsoleStore>()(
         resultsViewMode,
         comment,
         access,
+        folderId,
       ) => {
         try {
           const cleanPath = path.endsWith(".js") ? path.slice(0, -3) : path;
@@ -1291,6 +1293,7 @@ export const useConsoleStore = create<ConsoleStore>()(
                 resultsViewMode,
                 comment: comment ?? "",
                 access,
+                folderId,
                 isPrivate:
                   access === undefined ? undefined : access === "private",
                 expectedVersion,

--- a/app/src/store/consoleTreeStore.test.ts
+++ b/app/src/store/consoleTreeStore.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useConsoleTreeStore, type ConsoleEntry } from "./consoleTreeStore";
+
+const WORKSPACE_ID = "workspace-1";
+
+function folderNode(): ConsoleEntry {
+  return {
+    id: "folder-1",
+    name: "Folder",
+    path: "Folder",
+    isDirectory: true,
+    children: [],
+  };
+}
+
+describe("consoleTreeStore", () => {
+  beforeEach(() => {
+    const myConsoles = [folderNode()];
+    useConsoleTreeStore.setState({
+      myConsoles: { [WORKSPACE_ID]: myConsoles },
+      sharedWithWorkspace: { [WORKSPACE_ID]: [] },
+      trees: { [WORKSPACE_ID]: myConsoles },
+      loading: {},
+      error: {},
+      searchQuery: "",
+      searchResults: [],
+      searchLoading: false,
+    });
+  });
+
+  it("adds slash-containing console names at root without splitting folders", () => {
+    useConsoleTreeStore
+      .getState()
+      .addConsole(WORKSPACE_ID, "finance/revenue", "console-1");
+
+    const tree = useConsoleTreeStore.getState().myConsoles[WORKSPACE_ID];
+    const added = tree.find(node => node.id === "console-1");
+
+    expect(added).toMatchObject({
+      name: "finance/revenue",
+      path: "finance/revenue",
+      isDirectory: false,
+    });
+    expect(tree.find(node => node.name === "finance")).toBeUndefined();
+  });
+
+  it("uses folder ids for placement without parsing slashes from names", () => {
+    useConsoleTreeStore
+      .getState()
+      .addConsole(WORKSPACE_ID, "north/america", "console-2", "folder-1");
+
+    const folder = useConsoleTreeStore
+      .getState()
+      .myConsoles[WORKSPACE_ID].find(node => node.id === "folder-1");
+
+    expect(folder?.children).toEqual([
+      expect.objectContaining({
+        id: "console-2",
+        name: "north/america",
+        path: "north/america",
+      }),
+    ]);
+  });
+});

--- a/app/src/store/consoleTreeStore.ts
+++ b/app/src/store/consoleTreeStore.ts
@@ -5,7 +5,6 @@ import { api, unwrapBody } from "../api";
 import {
   findById,
   findParentArray,
-  findTargetArray,
   insertAlphabetically,
   insertAtTop,
   removeById,
@@ -132,7 +131,13 @@ interface TreeState {
   refresh: (workspaceId: string) => Promise<ConsoleEntry[]>;
   init: (workspaceId: string) => Promise<void>;
   setTree: (workspaceId: string, tree: ConsoleEntry[]) => void;
-  addConsole: (workspaceId: string, path: string, id: string) => void;
+  addConsole: (
+    workspaceId: string,
+    name: string,
+    id: string,
+    folderId?: string | null,
+    access?: ConsoleAccessLevel,
+  ) => void;
   searchConsoles: (workspaceId: string, query: string) => Promise<void>;
   clearSearch: () => void;
 
@@ -280,25 +285,27 @@ export const useConsoleTreeStore = create<TreeState>()(
       });
     },
 
-    addConsole: (workspaceId, path, id) => {
+    addConsole: (workspaceId, name, id, folderId, access) => {
       set(state => {
-        const tree = state.myConsoles[workspaceId] || [];
-        const segments = path.split("/").filter(Boolean);
-        const fileName = segments[segments.length - 1];
-        const folderSegments = segments.slice(0, -1);
-        const existing = removeById(tree, id);
-        const targetArray = findTargetArray(tree, folderSegments);
+        const existing = removeFromAnySection(state, workspaceId, id);
         const newConsole: ConsoleEntry = {
           ...(existing || {}),
-          name: fileName,
-          path,
+          name,
+          path: name,
           isDirectory: false,
           id,
+          folderId: folderId ?? undefined,
+          access: access ?? existing?.access,
         };
-        const destination = targetArray || tree;
-        insertAlphabetically(destination, newConsole);
-        state.myConsoles[workspaceId] = tree;
-        state.trees[workspaceId] = tree;
+        const targetSection = access === "workspace" ? "workspace" : "my";
+        insertIntoFolder(
+          state,
+          workspaceId,
+          newConsole,
+          folderId ?? null,
+          targetSection,
+        );
+        state.trees[workspaceId] = state.myConsoles[workspaceId] || [];
       });
     },
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Preserve `/` characters in console names during saves, renames, conflict checks, breadcrumbs, and optimistic tree updates.
- Pass explicit `folderId` values through save flows so folder placement no longer depends on parsing names as paths.
- Add backend and frontend regression coverage for slash-containing console names.

### Walkthrough
[console_slash_name_save_walkthrough.mp4](https://cursor.com/agents/bc-315ab1cb-0181-449b-8735-0dcc96e45c9c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconsole_slash_name_save_walkthrough.mp4)

### Testing
- `pnpm --filter api exec tsx src/utils/console-manager.test.ts`
- `pnpm --filter app exec vitest run src/store/consoleTreeStore.test.ts`
- `pnpm --filter api run build`
- `pnpm --filter app run typecheck && pnpm --filter app run lint`
- `pnpm --filter api run test`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-315ab1cb-0181-449b-8735-0dcc96e45c9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-315ab1cb-0181-449b-8735-0dcc96e45c9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

