### PR TITLE
fix(console): one canonical source of truth for a console's name (lea…

### DIFF
--- a/api/src/agent-lib/tools/server-console-tools.ts
+++ b/api/src/agent-lib/tools/server-console-tools.ts
@@ -52,6 +52,18 @@ const logger = loggers.agent();
 
 const RUN_PREVIEW_MAX_ROWS = 50;
 
+/**
+ * A console's `name` is the canonical LEAF display name (folder placement is
+ * `folderId`, never the name). Keep agent-set names as leaves so the agent
+ * cannot reintroduce slash-delimited "paths" into the name field — the UI
+ * shows `name` verbatim as the title/breadcrumb leaf/tree row.
+ */
+function leafConsoleName(raw: string | undefined): string {
+  const value = raw ?? "";
+  const parts = value.split("/").filter(Boolean);
+  return parts.length > 0 ? parts[parts.length - 1] : value;
+}
+
 /** First poll backoff hint surfaced to the agent (seconds). */
 const FIRST_POLL_BACKOFF_S = Math.round(
   (QUERY_POLL_BACKOFF_MS[0] ?? 30_000) / 1000,
@@ -288,7 +300,7 @@ export function createServerConsoleTools({
               // exceeds what the client has.
               draftRevision: currentRevision + 1,
             };
-            if (title) setFields.name = title;
+            if (title) setFields.name = leafConsoleName(title) || title;
 
             const updated = await SavedConsole.findOneAndUpdate(
               {
@@ -371,7 +383,7 @@ export function createServerConsoleTools({
 
           const doc = await SavedConsole.create({
             workspaceId: new Types.ObjectId(workspaceId),
-            name: title || "Untitled",
+            name: leafConsoleName(title) || "Untitled",
             code: content || "",
             language,
             connectionId: connectionId

--- a/api/src/migrations/2026-06-23-163424_fold_slash_console_names_into_folders.ts
+++ b/api/src/migrations/2026-06-23-163424_fold_slash_console_names_into_folders.ts
@@ -1,0 +1,117 @@
+import { Db, ObjectId } from "mongodb";
+
+export const description =
+  "Fold slash-delimited console names into the folder hierarchy (name becomes the leaf, placement becomes folderId)";
+
+/**
+ * Canonical console model: `SavedConsole.name` is the LEAF display name and
+ * folder placement is `folderId` → `ConsoleFolder.parentId`. The slash path is
+ * always DERIVED. Some consoles (legacy data, or agent `create_console` calls
+ * that put a path in the title) stored a slash-delimited PATH in `name` with
+ * no `folderId`, which the UI then rendered as a flat "fr/csm/customer_list"
+ * title/breadcrumb. Convert those to the canonical form: ensure the folder
+ * chain exists (under the console's current folder, or root) and set
+ * `name` = leaf, `folderId` = deepest folder.
+ *
+ * Idempotent: only touches consoles whose `name` still contains "/"; after
+ * conversion the name has no "/", so a re-run is a no-op. Folder creation is
+ * find-or-create.
+ */
+export async function up(db: Db): Promise<void> {
+  const consoles = db.collection("savedconsoles");
+  const folders = db.collection("consolefolders");
+
+  // (workspaceId|parent|segmentName) -> folder _id, to dedupe within a run.
+  const folderCache = new Map<string, ObjectId>();
+
+  const resolveFolder = async (
+    workspaceId: ObjectId,
+    parentId: ObjectId | null,
+    name: string,
+    access: string,
+    isPrivate: boolean,
+    ownerId: string | undefined,
+  ): Promise<ObjectId> => {
+    const cacheKey = `${workspaceId.toString()}|${
+      parentId ? parentId.toString() : "root"
+    }|${name}`;
+    const cached = folderCache.get(cacheKey);
+    if (cached) return cached;
+
+    const parentMatch = parentId
+      ? { parentId }
+      : { $or: [{ parentId: null }, { parentId: { $exists: false } }] };
+    const existing = await folders.findOne({
+      workspaceId,
+      name,
+      ...parentMatch,
+    });
+
+    let id: ObjectId;
+    if (existing) {
+      id = existing._id as ObjectId;
+    } else {
+      const res = await folders.insertOne({
+        workspaceId,
+        name,
+        ...(parentId ? { parentId } : {}),
+        isPrivate,
+        ownerId,
+        access,
+        createdAt: new Date(),
+      });
+      id = res.insertedId;
+    }
+    folderCache.set(cacheKey, id);
+    return id;
+  };
+
+  const cursor = consoles.find({ name: { $regex: "/" } });
+  for await (const doc of cursor) {
+    const rawName: string = typeof doc.name === "string" ? doc.name : "";
+    const segments = rawName.split("/").filter(Boolean);
+
+    // A name like "report/" or "/report" has a single real segment — just
+    // clean the stray slashes off the leaf, no folders.
+    if (segments.length <= 1) {
+      const leaf = segments[0] ?? rawName;
+      if (leaf !== rawName) {
+        await consoles.updateOne({ _id: doc._id }, { $set: { name: leaf } });
+      }
+      continue;
+    }
+
+    const leaf = segments[segments.length - 1];
+    const folderParts = segments.slice(0, -1);
+
+    const workspaceId = doc.workspaceId as ObjectId;
+    const access: string =
+      typeof doc.access === "string"
+        ? doc.access
+        : doc.isPrivate === false
+          ? "workspace"
+          : "private";
+    const isPrivate = access !== "workspace";
+    const ownerId: string | undefined =
+      (typeof doc.owner_id === "string" && doc.owner_id) ||
+      (typeof doc.createdBy === "string" && doc.createdBy) ||
+      undefined;
+
+    let parentId: ObjectId | null = (doc.folderId as ObjectId) ?? null;
+    for (const segment of folderParts) {
+      parentId = await resolveFolder(
+        workspaceId,
+        parentId,
+        segment,
+        access,
+        isPrivate,
+        ownerId,
+      );
+    }
+
+    await consoles.updateOne(
+      { _id: doc._id },
+      { $set: { name: leaf, folderId: parentId } },
+    );
+  }
+}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -49,6 +49,7 @@ import {
 import { useConsoleStore } from "./store/consoleStore";
 import { useExplorerRevealStore } from "./store/explorerRevealStore";
 import { tabRevealTarget } from "./lib/explorer-reveal";
+import { consoleLeafName } from "./lib/console-name";
 import Chat from "./components/Chat";
 import DatabaseExplorer, {
   type CollectionInfo,
@@ -495,7 +496,9 @@ function MainApp() {
       databaseName?: string,
     ) => {
       openOrFocusConsoleTab(
-        path,
+        // Title is the LEAF name (canonical display name); the full path is
+        // kept as filePath for the breadcrumb folder trail + deep link.
+        consoleLeafName(path),
         content,
         connectionId,
         path,

--- a/app/src/components/ConsoleExplorer.tsx
+++ b/app/src/components/ConsoleExplorer.tsx
@@ -390,7 +390,8 @@ function ConsoleExplorer(
           nextName,
         );
         updateTabFilePath(selectedItem.id, nextPath);
-        updateTabTitle(selectedItem.id, nextPath);
+        // Title is the canonical leaf name; the path drives the breadcrumb.
+        updateTabTitle(selectedItem.id, nextName);
         updateTabAccess(
           selectedItem.id,
           section === "workspace" ? "workspace" : "private",

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -103,6 +103,7 @@ import { useSqlAutocomplete } from "../hooks/useSqlAutocomplete";
 import { useIsMobile } from "../hooks/useIsMobile";
 import { trackEvent } from "../lib/analytics";
 import { getApiBasePath } from "../lib/api-base-path";
+import { consoleLeafName } from "../lib/console-name";
 import { generateObjectId } from "../utils/objectId";
 import {
   computeConsoleStateHash,
@@ -1401,9 +1402,9 @@ function Editor({
       }
 
       if (result.success) {
-        // Update file path and title
+        // Update file path and title (title = canonical leaf name)
         updateFilePath(tabId, savePath);
-        updateTitle(tabId, savePath);
+        updateTitle(tabId, consoleLeafName(savePath));
         updateAccess(tabId, currentTab?.access);
         updateDirty(tabId, true);
 
@@ -1715,7 +1716,7 @@ function Editor({
 
         // Update the tab properties
         updateFilePath(tabId, pendingSaveData.path);
-        updateTitle(tabId, pendingSaveData.path);
+        updateTitle(tabId, consoleLeafName(pendingSaveData.path));
         updateAccess(tabId, pendingSaveData.access);
         updateDirty(tabId, true);
 
@@ -1814,7 +1815,7 @@ function Editor({
 
         if (result.success) {
           updateFilePath(targetId, savePath);
-          updateTitle(targetId, savePath);
+          updateTitle(targetId, consoleLeafName(savePath));
           updateAccess(
             targetId,
             section === "workspace" ? "workspace" : "private",
@@ -1905,7 +1906,7 @@ function Editor({
         } else {
           // "new" — first-time save of a draft; update the originating tab.
           updateFilePath(targetId, savePath);
-          updateTitle(targetId, savePath);
+          updateTitle(targetId, consoleLeafName(savePath));
           updateAccess(
             targetId,
             section === "workspace" ? "workspace" : "private",
@@ -2289,8 +2290,7 @@ function Editor({
                                 }}
                                 title={tab.title}
                               >
-                                {tab.title?.split("/").filter(Boolean).pop() ||
-                                  tab.title}
+                                {tab.title}
                               </span>
                               <IconButton
                                 component="span"

--- a/app/src/components/EntityBreadcrumbs.tsx
+++ b/app/src/components/EntityBreadcrumbs.tsx
@@ -12,6 +12,7 @@ import { tabRevealTarget } from "../lib/explorer-reveal";
 import { useWorkspace } from "../contexts/workspace-context";
 import { SECTION_LABELS } from "../pages/settings/sections";
 import type { ConsoleTab, TabKind } from "../store/lib/types";
+import { consoleFolderTrail, consoleLeafName } from "../lib/console-name";
 
 interface BreadcrumbSegment {
   label: string;
@@ -63,13 +64,11 @@ function segmentsForTab(
         ];
       }
       const group = tab.access === "workspace" ? "Workspace" : "My Consoles";
-      // The folder trail comes from the stored path, but the LEAF is the
-      // console's live display name (tab.title). An agent rename updates the
-      // name/title but not the stored path, so reading the leaf from filePath
-      // showed a stale name in the breadcrumb while the tab strip was correct.
-      const pathParts = tab.filePath.split("/").filter(Boolean);
-      const folderParts = pathParts.slice(0, -1);
-      const leaf = tab.title || pathParts[pathParts.length - 1];
+      // Single source of truth: the leaf is the live display name (tab.title);
+      // the folder trail is derived from the full path by stripping that leaf
+      // (robust to a leaf name that itself contains slashes — legacy data).
+      const leaf = tab.title || consoleLeafName(tab.filePath);
+      const folderParts = consoleFolderTrail(tab.filePath, leaf);
       return plain(["Consoles", group, ...folderParts, leaf]);
     }
     case "table-data":

--- a/app/src/lib/console-name.ts
+++ b/app/src/lib/console-name.ts
@@ -1,0 +1,42 @@
+/**
+ * Canonical console name/path helpers.
+ *
+ * SINGLE SOURCE OF TRUTH: a console's display name is its LEAF name
+ * (`SavedConsole.name` on the server). Its location is the folder hierarchy
+ * (`folderId` → `ConsoleFolder.parentId`). The slash-delimited `path` is a
+ * DERIVED convenience (folder ancestry joined with the leaf), used only for
+ * the breadcrumb folder trail and deep links — it is never the display name.
+ *
+ * Historically the client set `tab.title` to the full path in some open paths
+ * (sidebar click, explicit save, move) and to the leaf in others (server /
+ * agent opens), then masked the difference by splitting on "/" in the tab
+ * strip. That made the same value mean two different things. These helpers +
+ * the "title is always the leaf" rule remove the ambiguity.
+ */
+
+/** The leaf (last non-empty segment) of a console path, or the value itself. */
+export function consoleLeafName(pathOrName: string | undefined | null): string {
+  if (!pathOrName) return "";
+  const parts = pathOrName.split("/").filter(Boolean);
+  return parts.length > 0 ? parts[parts.length - 1] : pathOrName;
+}
+
+/**
+ * The folder trail (ancestor folder names) for a console, derived from its
+ * full derived `filePath` by stripping the trailing leaf `name`. Robust to a
+ * leaf name that itself contains slashes (legacy data): we strip the exact
+ * trailing `/<name>` rather than blindly dropping the last "/" segment.
+ */
+export function consoleFolderTrail(
+  filePath: string | undefined | null,
+  leafName: string | undefined | null,
+): string[] {
+  if (!filePath) return [];
+  const leaf = leafName ?? "";
+  if (!leaf || filePath === leaf) return [];
+  const suffix = `/${leaf}`;
+  const folderPath = filePath.endsWith(suffix)
+    ? filePath.slice(0, -suffix.length)
+    : filePath;
+  return folderPath.split("/").filter(Boolean);
+}

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -1159,6 +1159,11 @@ export const useConsoleStore = create<ConsoleStore>()(
                 tab.connectionId = res.connectionId;
                 tab.databaseId = res.databaseId;
                 tab.databaseName = res.databaseName;
+                // Canonical: the title is ALWAYS the leaf name from the server.
+                // Sidebar/search opens seed the tab with a placeholder (often
+                // the full path); reconcile it to the authoritative leaf so the
+                // tab strip, breadcrumb and document.title agree.
+                if (res.name) tab.title = res.name;
                 tab.filePath = filePath;
                 tab.access = res.access;
                 tab.owner_id = res.owner_id;


### PR DESCRIPTION
…f), not the path

A console's display name was the LEAF (SavedConsole.name) in some open paths (server/agent opens, search, agent rename) but the FULL slash-delimited PATH in others (sidebar click -> node.path, explicit save -> savePath, move -> nextPath). The desktop tab strip masked this by doing tab.title.split('/').pop(); breadcrumbs, document.title and the mobile menu did not. (PR #565 removed that mask and stored the full path AS the name, exposing 'fr/csm/customer_list' as the tab title and breadcrumb leaf — a regression.)

Canonical model (confirmed by the schema + console-manager.buildTree): folders are real (SavedConsole.folderId -> ConsoleFolder.parentId); SavedConsole.name is the LEAF; the slash path is DERIVED. So the single source of truth for the display name is the leaf name; placement is folderId; path is derived for the breadcrumb folder trail + deep links only.

Client — tab.title is ALWAYS the leaf:
- new app/src/lib/console-name.ts: consoleLeafName() + consoleFolderTrail() (the latter strips the trailing leaf from the derived path, robust to legacy leaf names that themselves contain slashes).
- fetchConsoleContent reconciles tab.title to res.name (leaf) — any open path's title self-corrects.
- sidebar open (App.handleConsoleSelect), explicit save + move (Editor / ConsoleExplorer) now set the title to the leaf, not the full path.
- EntityBreadcrumbs derives the folder trail via consoleFolderTrail(filePath, leaf) and the leaf from tab.title.
- Editor tab strip renders tab.title verbatim (no more split — it's always a leaf).

Server — stop generating new slash names:
- create_console / modify_console store the LEAF name (slashes can no longer leak a 'path' into the name field). saveConsole/renameConsole already produced leaves.

Migration — fix existing data:
- 2026-06-23-163424_fold_slash_console_names_into_folders: idempotently folds any SavedConsole whose name still contains '/' into the real folder hierarchy (ensures the folder chain, sets name=leaf + folderId=deepest). Inherits the console's access/owner; find-or-create folders; safe to re-run.

This supersedes PR #565's display approach (which conflated name with path).