### PR TITLE
feat(apps): shareable, reload-safe URL state (paths + query params) for sandboxed apps

### DIFF
--- a/app/src/app-runtime/app-location.test.ts
+++ b/app/src/app-runtime/app-location.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  appLocationFromHostSearch,
+  appLocationToHostSearch,
+  formatAppLocation,
+  parseAppLocation,
+  resolveAppLocation,
+} from "./app-location";
+
+describe("app-location", () => {
+  it("parses relative URLs into pathname + search (dropping hash)", () => {
+    expect(parseAppLocation("/customers/1?tab=open#frag")).toEqual({
+      pathname: "/customers/1",
+      search: "?tab=open",
+    });
+    expect(parseAppLocation("")).toEqual({ pathname: "/", search: "" });
+    expect(parseAppLocation(undefined)).toEqual({ pathname: "/", search: "" });
+  });
+
+  it("round-trips an app location through the host query string", () => {
+    const cases = [
+      "/",
+      "/?tab=customers",
+      "/customers/123",
+      "/customers/123?sort=asc&dir=up",
+      // Comma is re-encoded as %2C on the way out but decodes to the same
+      // value, so compare parsed semantics rather than the raw string.
+      "/?c=ES,FR&s=vis&q=fuentes",
+    ];
+    const norm = (rel: string) => {
+      const { pathname, search } = parseAppLocation(rel);
+      const params = [...new URLSearchParams(search)].sort();
+      return { pathname, params };
+    };
+    for (const rel of cases) {
+      const host = appLocationToHostSearch(rel);
+      expect(norm(appLocationFromHostSearch(host))).toEqual(norm(rel));
+    }
+  });
+
+  it("keeps app query params readable and stows the path in _path", () => {
+    expect(appLocationToHostSearch("/customers/123?tab=open&c=ES")).toBe(
+      "?tab=open&c=ES&_path=%2Fcustomers%2F123",
+    );
+    // Root path emits no _path param at all.
+    expect(appLocationToHostSearch("/?tab=open")).toBe("?tab=open");
+    expect(appLocationToHostSearch("/")).toBe("");
+  });
+
+  it("decodes a host query string back into an app location", () => {
+    expect(
+      appLocationFromHostSearch("?tab=open&c=ES&_path=%2Fcustomers%2F123"),
+    ).toBe("/customers/123?tab=open&c=ES");
+    expect(appLocationFromHostSearch("")).toBe("/");
+    expect(appLocationFromHostSearch("?tab=open")).toBe("/?tab=open");
+  });
+
+  it("resolves absolute, relative and query-only navigation targets", () => {
+    expect(resolveAppLocation("/customers", "/orders")).toBe("/orders");
+    expect(resolveAppLocation("/customers/1", "?tab=open")).toBe(
+      "/customers/1?tab=open",
+    );
+    expect(resolveAppLocation("/customers/1", "../orders")).toBe("/orders");
+    expect(resolveAppLocation("/a/b", "c")).toBe("/a/c");
+  });
+
+  it("formats locations with a guaranteed leading slash", () => {
+    expect(formatAppLocation({ pathname: "x/y", search: "?q=1" })).toBe(
+      "/x/y?q=1",
+    );
+  });
+});

--- a/app/src/app-runtime/app-location.ts
+++ b/app/src/app-runtime/app-location.ts
@@ -1,0 +1,121 @@
+/**
+ * App runtime location <-> host URL projection.
+ *
+ * A Mako app runs inside a sandboxed `srcdoc` iframe (an opaque origin with no
+ * `allow-same-origin`), so it cannot read or write the real browser URL itself
+ * — inside the frame `window.location` is `about:srcdoc`. Instead the app
+ * reports its desired location over the `postMessage` bridge and the host
+ * projects that location onto its own shareable URL (`/a/:appId` in the Mako
+ * shell, `/share/:token` in the public viewer), then seeds it back into the
+ * iframe on load. This module is the single source of truth for that mapping,
+ * so the embedded and public hosts stay in lockstep.
+ *
+ * The app "location" is a normal relative URL — a pathname (always starting
+ * with "/") plus an optional query string, e.g. `/customers/123?tab=open`.
+ *
+ * Projection keeps the app's *query params as real, editable params* on the
+ * address bar and stows the app's *pathname* in a single reserved param
+ * (`_path`), so a shared link round-trips exactly:
+ *
+ *   app    /customers/123?tab=open&c=ES
+ *   host   /a/<id>?tab=open&c=ES&_path=%2Fcustomers%2F123
+ *
+ * The host's own path (`/a/:appId`, `/share/:token`) is left untouched, so
+ * this never collides with Mako's deep-link route patterns (which are
+ * exhaustive over tab kinds — see `tab-routing.ts`).
+ */
+
+/**
+ * Reserved host query param that carries the app's pathname. Apps should avoid
+ * using a top-level query param with this exact name (it is stripped on the way
+ * in and re-applied on the way out).
+ */
+export const RESERVED_PATH_PARAM = "_path";
+
+/** A dummy absolute base so we can reuse the platform URL parser for relatives. */
+const DUMMY_ORIGIN = "http://mako.app.local";
+
+export interface AppLocation {
+  /** Always starts with "/". */
+  pathname: string;
+  /** Empty string or a value beginning with "?". */
+  search: string;
+}
+
+/** Split a relative URL string into its pathname + search parts (hash dropped). */
+export function parseAppLocation(
+  relativeUrl: string | null | undefined,
+): AppLocation {
+  const raw = relativeUrl && relativeUrl.length > 0 ? relativeUrl : "/";
+  try {
+    const url = new URL(raw, DUMMY_ORIGIN);
+    return { pathname: url.pathname || "/", search: url.search };
+  } catch {
+    return { pathname: "/", search: "" };
+  }
+}
+
+/** Serialize an {@link AppLocation} back to a relative URL string. */
+export function formatAppLocation(loc: AppLocation): string {
+  const pathname = loc.pathname.startsWith("/")
+    ? loc.pathname
+    : `/${loc.pathname}`;
+  return `${pathname}${loc.search || ""}`;
+}
+
+/**
+ * Resolve a (possibly relative) navigation target against the current app
+ * location and return a normalized relative URL string. Supports absolute
+ * paths ("/x"), relative paths ("x", "./x", "../x") and query-only ("?q=1").
+ */
+export function resolveAppLocation(current: string, to: string): string {
+  try {
+    const base = new URL(
+      formatAppLocation(parseAppLocation(current)),
+      DUMMY_ORIGIN,
+    );
+    const next = new URL(to, base);
+    return formatAppLocation({
+      pathname: next.pathname || "/",
+      search: next.search,
+    });
+  } catch {
+    return formatAppLocation(parseAppLocation(current));
+  }
+}
+
+/**
+ * Encode an app location into a host query string. Returns the string with a
+ * leading "?", or "" when the app is at its root with no query.
+ */
+export function appLocationToHostSearch(
+  relativeUrl: string | null | undefined,
+): string {
+  const { pathname, search } = parseAppLocation(relativeUrl);
+  const out = new URLSearchParams();
+  for (const [key, value] of new URLSearchParams(search)) {
+    if (key === RESERVED_PATH_PARAM) continue; // reserved by the host
+    out.append(key, value);
+  }
+  if (pathname && pathname !== "/") out.set(RESERVED_PATH_PARAM, pathname);
+  const qs = out.toString();
+  return qs ? `?${qs}` : "";
+}
+
+/**
+ * Decode an app location (a relative URL string) out of a host query string.
+ * The inverse of {@link appLocationToHostSearch}; always returns a value that
+ * starts with "/".
+ */
+export function appLocationFromHostSearch(hostSearch: string): string {
+  const params = new URLSearchParams(hostSearch || "");
+  const rawPath = params.get(RESERVED_PATH_PARAM) || "/";
+  const pathname = rawPath.startsWith("/") ? rawPath : `/${rawPath}`;
+  const appParams = new URLSearchParams();
+  for (const [key, value] of params) {
+    if (key === RESERVED_PATH_PARAM) continue;
+    appParams.append(key, value);
+  }
+  const qs = appParams.toString();
+  return formatAppLocation({ pathname, search: qs ? `?${qs}` : "" });
+}

--- a/app/src/app-runtime/preview.ts
+++ b/app/src/app-runtime/preview.ts
@@ -32,6 +32,11 @@ export const PREVIEW_MESSAGE = {
   capture: "mako-app:capture",
   captureResult: "mako-app:capture-result",
   setTheme: "mako-app:set-theme",
+  // iframe -> host: the app wants to change its (host-projected) URL.
+  navigate: "mako-app:navigate",
+  // host -> iframe: the app's location changed outside the app (deep link on
+  // load, browser back/forward). The app updates without echoing back.
+  location: "mako-app:location",
   error: "mako-app:error",
 } as const;
 
@@ -169,6 +174,13 @@ export function buildPreviewHtml(
      * omitted/null the iframe follows `prefers-color-scheme` (standalone).
      */
     theme?: PreviewTheme | null;
+    /**
+     * App location (relative URL, e.g. `/customers/1?tab=open`) to boot with.
+     * The host derives this from its own shareable URL so reload + share
+     * restore the app's view; later changes flow over the message bridge
+     * (`mako-app:navigate` / `mako-app:location`), never a srcdoc rebuild.
+     */
+    location?: string | null;
   },
 ): string {
   const scriptFiles: Record<string, string> = {};
@@ -187,6 +199,7 @@ export function buildPreviewHtml(
     bareDeps,
     entrypoint,
     theme: options?.theme ?? null,
+    location: options?.location ?? null,
   });
 
   return `<!DOCTYPE html>
@@ -287,6 +300,70 @@ window.addEventListener("message", (event) => {
   if (data.type === "mako-app:set-theme") setExplicitTheme(data.theme);
 });
 
+// --- Location: the app's URL relative to its mount point. The sandboxed frame
+// can't touch the real (shareable) browser URL, so the app reads/writes this
+// virtual location via useLocation()/useSearchParams()/navigate() from
+// "@mako/app-sdk"; the host projects it onto its own URL and seeds it back on
+// load (payload.location) or on browser back/forward ("mako-app:location"). ---
+const LOCATION_BASE = "http://mako.app.local";
+let currentLocation = "/";
+const locationListeners = new Set();
+
+function resolveLocation(to) {
+  try {
+    const base = new URL(currentLocation, LOCATION_BASE);
+    const next = new URL(String(to), base);
+    return (next.pathname || "/") + (next.search || "");
+  } catch (_) {
+    return currentLocation;
+  }
+}
+function notifyLocation() {
+  locationListeners.forEach((listener) => {
+    try {
+      listener(currentLocation);
+    } catch (_) {
+      /* listener errors must not break routing */
+    }
+  });
+}
+// Apply an external location change (host -> iframe). Does not post back.
+function applyLocation(next) {
+  const normalized = resolveLocation(next);
+  if (normalized === currentLocation) return;
+  currentLocation = normalized;
+  notifyLocation();
+}
+// Apply an app-initiated change and report it to the host so the real URL
+// (and any shared link) tracks the app's view.
+function navigateTo(to, opts) {
+  const normalized = resolveLocation(to);
+  const changed = normalized !== currentLocation;
+  currentLocation = normalized;
+  if (changed) notifyLocation();
+  POST({
+    type: "mako-app:navigate",
+    location: currentLocation,
+    replace: !!(opts && opts.replace),
+  });
+}
+function parseLocation(loc) {
+  const url = new URL(loc, LOCATION_BASE);
+  return {
+    pathname: url.pathname || "/",
+    search: url.search,
+    hash: url.hash,
+    href: (url.pathname || "/") + url.search + url.hash,
+    searchParams: url.searchParams,
+  };
+}
+window.addEventListener("message", (event) => {
+  const data = event.data || {};
+  if (data.type === "mako-app:location" && typeof data.location === "string") {
+    applyLocation(data.location);
+  }
+});
+
 async function waitForBabel(timeoutMs = 10000) {
   const start = Date.now();
   while (!window.Babel) {
@@ -384,6 +461,12 @@ async function main() {
   // renders so the first paint already uses the right tokens.
   setExplicitTheme(payload.theme);
 
+  // Seed the location the host derived from its shareable URL so the very
+  // first render already reflects a deep link / reloaded view.
+  if (typeof payload.location === "string" && payload.location) {
+    currentLocation = payload.location;
+  }
+
   const Babel = await waitForBabel();
 
   // Pre-import bare npm dependencies as ESM (via the import map).
@@ -472,6 +555,48 @@ async function main() {
         return () => { themeListeners.delete(listener); };
       }, []);
       return { theme: theme };
+    },
+    // The app's current location, projected onto (and shareable via) the host
+    // URL. Returns { pathname, search, hash, href, searchParams } and
+    // re-renders on every navigate() or external (back/forward) change.
+    useLocation() {
+      const [loc, setLoc] = React.useState(() => parseLocation(currentLocation));
+      React.useEffect(() => {
+        const listener = (next) => setLoc(parseLocation(next));
+        locationListeners.add(listener);
+        // Re-sync in case the location changed between render and subscribe.
+        setLoc(parseLocation(currentLocation));
+        return () => { locationListeners.delete(listener); };
+      }, []);
+      return loc;
+    },
+    // React-Router-style query param access: [URLSearchParams, setSearchParams].
+    // setSearchParams(next, { replace }) keeps the current pathname and updates
+    // only the query string (next may be a URLSearchParams, object, or string).
+    useSearchParams() {
+      const read = () => new URL(currentLocation, LOCATION_BASE).search;
+      const [search, setSearch] = React.useState(read);
+      React.useEffect(() => {
+        const listener = () => setSearch(read());
+        locationListeners.add(listener);
+        setSearch(read());
+        return () => { locationListeners.delete(listener); };
+      }, []);
+      const setSearchParams = (next, opts) => {
+        const sp =
+          next instanceof URLSearchParams ? next : new URLSearchParams(next);
+        const qs = sp.toString();
+        const pathname = new URL(currentLocation, LOCATION_BASE).pathname || "/";
+        navigateTo(pathname + (qs ? "?" + qs : ""), opts);
+      };
+      return [new URLSearchParams(search), setSearchParams];
+    },
+    // Imperatively change the app's location. The target may be absolute
+    // ("/x"), relative ("x", "../x") or query-only ("?q=1"). Pass
+    // { replace: true } to overwrite the current history entry (use it for
+    // transient filter tweaks so back/forward isn't flooded); default pushes.
+    navigate(to, opts) {
+      navigateTo(to, opts);
     },
   };
 

--- a/app/src/app-runtime/shell.ts
+++ b/app/src/app-runtime/shell.ts
@@ -6,22 +6,45 @@ export function getCurrentWorkspaceId(): string | null {
   return useUIStore.getState().currentWorkspaceId ?? null;
 }
 
-/** Open (or focus) the full-screen preview tab for a React app. */
-export function focusAppTab(appId: string, title: string): string {
+/**
+ * Open (or focus) the full-screen preview tab for a React app.
+ *
+ * `appLocation` (a relative URL the app understands, e.g. `/customers?tab=1`)
+ * seeds the in-app router from a deep link. It is only applied when provided,
+ * so opening the app from the explorer never clobbers an already-navigated
+ * sub-location.
+ */
+export function focusAppTab(
+  appId: string,
+  title: string,
+  appLocation?: string,
+): string {
   const consoleStore = useConsoleStore.getState();
   const existingTab = Object.values(consoleStore.tabs).find(
     (tab: { kind?: string; metadata?: { appId?: string } }) =>
       tab.kind === "app" && tab.metadata?.appId === appId,
   );
 
-  const tabId =
-    existingTab?.id ??
-    consoleStore.openTab({
-      title,
-      content: "",
-      kind: "app",
-      metadata: { appId },
-    });
+  if (existingTab) {
+    if (typeof appLocation === "string") {
+      consoleStore.updateMetadata(existingTab.id, {
+        ...(existingTab.metadata ?? {}),
+        appId,
+        appLocation,
+      });
+    }
+    consoleStore.setActiveTab(existingTab.id);
+    useAppStore.getState().setActiveApp(appId);
+    return existingTab.id;
+  }
+
+  const tabId = consoleStore.openTab({
+    title,
+    content: "",
+    kind: "app",
+    metadata:
+      typeof appLocation === "string" ? { appId, appLocation } : { appId },
+  });
 
   consoleStore.setActiveTab(tabId);
   useAppStore.getState().setActiveApp(appId);

--- a/app/src/components/AppRenderer.tsx
+++ b/app/src/components/AppRenderer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Box,
   CircularProgress,
@@ -14,8 +14,10 @@ import { useAuth } from "../contexts/auth-context";
 import { useTheme } from "../contexts/ThemeContext";
 import { useIsWorkspaceAdmin } from "../hooks/useIsWorkspaceAdmin";
 import { useAppStore } from "../store/appStore";
+import { useConsoleStore } from "../store/consoleStore";
 import ShareDialog from "./ShareDialog";
 import { buildPreviewHtml, PREVIEW_MESSAGE } from "../app-runtime/preview";
+import { appLocationFromHostSearch } from "../app-runtime/app-location";
 import {
   ensureBindingLoaded,
   queryAppDuckDB,
@@ -31,7 +33,13 @@ import {
  * `app-file` tabs (opened from the sidebar explorer); this tab only renders the
  * sandboxed preview and bridges data-binding requests to the workspace.
  */
-export default function AppRenderer({ appId }: { appId: string }) {
+export default function AppRenderer({
+  appId,
+  tabId,
+}: {
+  appId: string;
+  tabId?: string;
+}) {
   const { currentWorkspace } = useWorkspace();
   const { user } = useAuth();
   const isWorkspaceAdmin = useIsWorkspaceAdmin();
@@ -54,6 +62,34 @@ export default function AppRenderer({ appId }: { appId: string }) {
   const runBinding = useAppStore(s => s.runBinding);
 
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
+
+  // App router state lives on the owning tab's metadata (`appLocation`), so the
+  // single source of truth for the URL stays UrlSync (which derives the address
+  // bar from the active tab). Seeding the iframe reads it once, on boot; later
+  // navigations flow over postMessage and must never bump the srcdoc.
+  const initialAppLocationRef = useRef<string | null>(
+    tabId
+      ? ((useConsoleStore.getState().tabs[tabId]?.metadata?.appLocation as
+          | string
+          | undefined) ?? null)
+      : null,
+  );
+
+  // Persist an app-initiated location change onto the tab. UrlSync then writes
+  // it to the shareable URL; this is a no-op when nothing changed.
+  const applyAppLocation = useCallback(
+    (location: string) => {
+      if (!tabId) return;
+      const store = useConsoleStore.getState();
+      const tab = store.tabs[tabId];
+      if (!tab || tab.metadata?.appLocation === location) return;
+      store.updateMetadata(tabId, {
+        ...(tab.metadata ?? {}),
+        appLocation: location,
+      });
+    },
+    [tabId],
+  );
 
   // True from the moment a (re)built srcdoc is handed to the iframe until the
   // bootstrap posts ready/error. Loading deps from the CDN and transpiling
@@ -191,6 +227,8 @@ export default function AppRenderer({ appId }: { appId: string }) {
               error: err instanceof Error ? err.message : "DuckDB query failed",
             }),
           );
+      } else if (data.type === PREVIEW_MESSAGE.navigate) {
+        if (typeof data.location === "string") applyAppLocation(data.location);
       } else if (data.type === PREVIEW_MESSAGE.error) {
         setBooting(false);
         setPreviewErrors(appId, [
@@ -208,7 +246,29 @@ export default function AppRenderer({ appId }: { appId: string }) {
     };
     window.addEventListener("message", handler);
     return () => window.removeEventListener("message", handler);
-  }, [appId, workspaceId, appEntity, runBinding, setPreviewErrors]);
+  }, [
+    appId,
+    workspaceId,
+    appEntity,
+    runBinding,
+    setPreviewErrors,
+    applyAppLocation,
+  ]);
+
+  // Browser back/forward changes the host URL without a reload; mirror the new
+  // app location into the tab and push it to the (already-booted) iframe.
+  useEffect(() => {
+    const onPopState = () => {
+      const location = appLocationFromHostSearch(window.location.search);
+      applyAppLocation(location);
+      iframeRef.current?.contentWindow?.postMessage(
+        { type: PREVIEW_MESSAGE.location, location },
+        "*",
+      );
+    };
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, [applyAppLocation]);
 
   // Keep the booted preview's theme in sync with the host toggle.
   useEffect(() => {
@@ -223,7 +283,10 @@ export default function AppRenderer({ appId }: { appId: string }) {
   // must not trigger an expensive rebuild on toggle (set-theme handles that).
   const srcDoc = useMemo(() => {
     if (!appEntity) return "";
-    return buildPreviewHtml(appEntity, { theme: effectiveModeRef.current });
+    return buildPreviewHtml(appEntity, {
+      theme: effectiveModeRef.current,
+      location: initialAppLocationRef.current,
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [appEntity?._id, previewNonce]);
 

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -2732,7 +2732,10 @@ function Editor({
                       }}
                     />
                   ) : tab.kind === "app" ? (
-                    <AppRenderer appId={tab.metadata?.appId as string} />
+                    <AppRenderer
+                      appId={tab.metadata?.appId as string}
+                      tabId={tab.id}
+                    />
                   ) : tab.kind === "app-file" ? (
                     <AppFileEditor
                       tabId={tab.id}

--- a/app/src/components/UrlSync.tsx
+++ b/app/src/components/UrlSync.tsx
@@ -27,6 +27,7 @@ import {
   decodePathSegments,
   tabUrlPath,
 } from "../lib/tab-routing";
+import { appLocationFromHostSearch } from "../app-runtime/app-location";
 
 /**
  * UrlSync component
@@ -238,23 +239,26 @@ export function UrlSync() {
       // tab once the app loads.
       focusAppBindingTab(appId, bindingId, "Data source");
     } else if (appMatch) {
-      // /a/:appId
+      // /a/:appId (+ the running app's own location: readable query params and
+      // its pathname carried in the reserved `_path` param).
       const appId = appMatch[1];
       setLeftPane("apps");
+
+      const appLocation = appLocationFromHostSearch(window.location.search);
 
       const existingTab = Object.values(useConsoleStore.getState().tabs).find(
         t => t.kind === "app" && t.metadata?.appId === appId,
       );
 
       if (existingTab) {
-        setActiveTab(existingTab.id);
+        focusAppTab(appId, existingTab.title, appLocation);
       } else {
         // Fetch the app to get its title, then open the tab
         useAppStore
           .getState()
           .fetchApp(currentWorkspace.id, appId)
           .then(app => {
-            focusAppTab(appId, app?.title || "App");
+            focusAppTab(appId, app?.title || "App", appLocation);
           });
       }
     } else if (dbtFileMatch) {

--- a/app/src/components/public/PublicAppViewer.tsx
+++ b/app/src/components/public/PublicAppViewer.tsx
@@ -1,7 +1,11 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box, CircularProgress, Typography, Alert } from "@mui/material";
 import { useTheme } from "../../contexts/ThemeContext";
 import { buildPreviewHtml, PREVIEW_MESSAGE } from "../../app-runtime/preview";
+import {
+  appLocationFromHostSearch,
+  appLocationToHostSearch,
+} from "../../app-runtime/app-location";
 import {
   ensureBindingLoaded,
   queryAppDuckDB,
@@ -79,6 +83,20 @@ export default function PublicAppViewer({ token, content }: Props) {
   effectiveModeRef.current = effectiveMode;
 
   const duckAppId = `share-${token}`;
+
+  // The public viewer owns its `/share/:token` URL directly (no tab system),
+  // so it seeds the app's location from the address bar on load and writes it
+  // back on navigate — making deep links + reloads restore the same view.
+  const initialAppLocationRef = useRef<string>(
+    appLocationFromHostSearch(window.location.search),
+  );
+
+  const writeAppLocation = useCallback((location: string, replace: boolean) => {
+    const next = window.location.pathname + appLocationToHostSearch(location);
+    if (next === window.location.pathname + window.location.search) return;
+    if (replace) window.history.replaceState(null, "", next);
+    else window.history.pushState(null, "", next);
+  }, []);
 
   // Preload all ready parquet bindings.
   useEffect(() => {
@@ -194,6 +212,10 @@ export default function PublicAppViewer({ token, content }: Props) {
               error: err instanceof Error ? err.message : "DuckDB query failed",
             }),
           );
+      } else if (data.type === PREVIEW_MESSAGE.navigate) {
+        if (typeof data.location === "string") {
+          writeAppLocation(data.location, !!data.replace);
+        }
       } else if (data.type === PREVIEW_MESSAGE.error) {
         setBooting(false);
         setPreviewError(String(data.message || "App failed to load"));
@@ -209,7 +231,22 @@ export default function PublicAppViewer({ token, content }: Props) {
     };
     window.addEventListener("message", handler);
     return () => window.removeEventListener("message", handler);
-  }, [duckAppId, content]);
+  }, [duckAppId, content, writeAppLocation]);
+
+  // Reflect browser back/forward into the booted iframe.
+  useEffect(() => {
+    const onPopState = () => {
+      iframeRef.current?.contentWindow?.postMessage(
+        {
+          type: PREVIEW_MESSAGE.location,
+          location: appLocationFromHostSearch(window.location.search),
+        },
+        "*",
+      );
+    };
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, []);
 
   // Keep the booted preview's theme in sync with system/theme changes.
   useEffect(() => {
@@ -229,7 +266,10 @@ export default function PublicAppViewer({ token, content }: Props) {
           dependencies: content.dependencies,
           entrypoint: content.entrypoint,
         } as Parameters<typeof buildPreviewHtml>[0],
-        { theme: effectiveModeRef.current },
+        {
+          theme: effectiveModeRef.current,
+          location: initialAppLocationRef.current,
+        },
       ),
     [content],
   );

--- a/app/src/lib/tab-routing.test.ts
+++ b/app/src/lib/tab-routing.test.ts
@@ -142,4 +142,15 @@ describe("tab-routing", () => {
     const url = tabUrlPath("t", FIXTURES["table-data"]) as string;
     expect(url).toBe("/t/651234567890abcdef1234/public/users?db=mydb");
   });
+
+  it("projects a running app's sub-location onto its /a/:id URL", () => {
+    const tab = baseTab({
+      kind: "app",
+      metadata: { appId: "app-1", appLocation: "/customers/9?tab=open&c=ES" },
+    });
+    const url = tabUrlPath("t", tab) as string;
+    expect(url).toBe("/a/app-1?tab=open&c=ES&_path=%2Fcustomers%2F9");
+    // The pathname (what hydration matches on) still resolves to the bare app.
+    expect(url.split("?")[0]).toMatch(TAB_DEEP_LINK_PATTERNS.app);
+  });
 });

--- a/app/src/lib/tab-routing.ts
+++ b/app/src/lib/tab-routing.ts
@@ -15,6 +15,7 @@
  * test in `tab-routing.test.ts` keeps the two directions in sync.
  */
 import type { ConsoleTab, TabKind } from "../store/lib/types";
+import { appLocationToHostSearch } from "../app-runtime/app-location";
 
 /** Encode a path that may contain slashes, keeping the slashes readable. */
 export function encodePathSegments(path: string): string {
@@ -96,7 +97,13 @@ export function tabUrlPath(tabId: string, tab: ConsoleTab): string | null {
     }
     case "app": {
       const appId = tab.metadata?.appId as string | undefined;
-      return appId ? `/a/${appId}` : null;
+      if (!appId) return null;
+      // The running app projects its own location (path + query) onto the
+      // host URL: query params stay readable, the app pathname rides in the
+      // reserved `_path` param. The bare `/a/:appId` pathname is unchanged, so
+      // the deep-link pattern still matches.
+      const appLocation = tab.metadata?.appLocation as string | undefined;
+      return `/a/${appId}${appLocationToHostSearch(appLocation)}`;
     }
     case "app-file": {
       const appId = tab.metadata?.appId as string | undefined;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Walkthrough

Public share view (no login) — a shared deep link restores the exact view; tab clicks update the URL; a path route survives reload; browser Back works:

[public_share_url_state_demo.mp4](https://cursor.com/agents/bc-73c40c54-7d80-44bc-9fb7-1c3989569d4a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpublic_share_url_state_demo.mp4)

[Shared deep link restored customers tab + ES,FR filter](https://cursor.com/agents/bc-73c40c54-7d80-44bc-9fb7-1c3989569d4a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpublic_share_deeplink_restored.webp)
[Embedded /a/:appId view with app path carried in _path param](https://cursor.com/agents/bc-73c40c54-7d80-44bc-9fb7-1c3989569d4a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fembedded_path_route.webp)

## What & why

Mako apps run inside a `srcdoc` iframe sandboxed **without** `allow-same-origin`, so inside the app `window.location` is `about:srcdoc` — the app can't read or write the real browser URL. This adds a tiny router shim over the **existing `postMessage` bridge** so an app's location (path + query) is:

- **projected onto the host's shareable URL** in both the Mako shell (`/a/:appId`) and the public viewer (`/share/:token`), and
- **seeded back into the iframe on load** (same mechanism already used for `theme`),

so reload keeps your place and the URL is shareable in **both** contexts.

## Projection scheme

App query params stay **readable/editable** on the address bar; the app pathname rides in a single reserved `_path` param. The host's own path is untouched, so this never collides with Mako's exhaustive deep-link route patterns.

```
app    /customers/123?tab=open&c=ES
host   /a/<id>?tab=open&c=ES&_path=%2Fcustomers%2F123
       /share/<token>?tab=open&c=ES&_path=%2Fcustomers%2F123
```

## App SDK (`@mako/app-sdk`)

```ts
const loc = useLocation();                  // { pathname, search, hash, href, searchParams }
const [params, setParams] = useSearchParams(); // React-Router-style
navigate("/customers/123?tab=open");        // push
navigate("?tab=open", { replace: true });   // replace (transient filter tweaks)
```

## Changes

- `app-runtime/app-location.ts` — central relative-URL ⇄ host-search mapping (+ unit tests).
- `app-runtime/preview.ts` — `mako-app:navigate` / `mako-app:location` messages, `payload.location` seed, and `useLocation`/`useSearchParams`/`navigate` on the injected SDK.
- `AppRenderer` (embedded) — seeds from + persists to the owning tab's `appLocation` metadata so `UrlSync` writes the address bar; mirrors browser back/forward into the iframe.
- `PublicAppViewer` — owns the `/share` URL directly (seed, push/replace, popstate).
- `tab-routing.ts` + `UrlSync.tsx` + `focusAppTab` — project `appLocation` onto `/a/:appId` and hydrate it from a deep link.
- **Agent awareness** — `agent-skills/apps/SKILL.md` gains a "URL state & routing" section + retrieval triggers, and the app scaffold (comment + README) hints at the hooks, so the AI app builder actually uses them.

## Testing

- `pnpm --filter app run test:unit` (app-location, tab-routing round-trip, preview bootstrap/location plumbing) ✅
- `pnpm --filter app run typecheck` / `lint`, `pnpm --filter api run lint`, `@mako/schemas` build ✅
- Loaded the `apps` system skill and confirmed the new routing content + triggers resolve ✅
- Manual end-to-end in the embedded Mako view **and** the public share view, incl. deep link, reload, and browser back/forward (video above) ✅


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73c40c54-7d80-44bc-9fb7-1c3989569d4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73c40c54-7d80-44bc-9fb7-1c3989569d4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

