### PR TITLE
Unify dashboard and app data source UX

### DIFF
--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -3725,6 +3725,12 @@ export interface IMakoAppDataBinding {
   databaseId?: string;
   databaseName?: string;
   materialization: "live" | "parquet";
+  materializationSchedule?: {
+    enabled: boolean;
+    cron: string | null;
+    timezone?: string;
+    dataFreshnessTtlMs?: number | null;
+  };
   cache?: IMakoAppBindingCache;
 }
 
@@ -3815,6 +3821,12 @@ const MakoAppDataBindingSchema = new Schema<IMakoAppDataBinding>(
       type: String,
       enum: ["live", "parquet"],
       default: "live",
+    },
+    materializationSchedule: {
+      enabled: { type: Boolean, default: false },
+      cron: { type: String, default: null },
+      timezone: { type: String, default: "UTC" },
+      dataFreshnessTtlMs: { type: Number, default: null },
     },
     cache: { type: MakoAppBindingCacheSchema, default: undefined },
   },

--- a/api/src/inngest/functions/app-binding-materialize.ts
+++ b/api/src/inngest/functions/app-binding-materialize.ts
@@ -7,7 +7,12 @@
  * tool) returns immediately and the build survives client disconnects.
  */
 import { inngest } from "../client";
-import { materializeAppBinding } from "../../services/app-binding-materialization.service";
+import { MakoApp } from "../../database/workspace-schema";
+import {
+  materializeAppBinding,
+  queueAppBindingMaterialization,
+} from "../../services/app-binding-materialization.service";
+import { isDashboardMaterializationDue } from "../../services/dashboard-materialization-schedule.service";
 import { loggers } from "../../logging";
 
 const log = loggers.inngest();
@@ -62,5 +67,73 @@ export const appBindingMaterializeFunction = inngest.createFunction(
     }
 
     return result;
+  },
+);
+
+export const appBindingSchedulerFunction = inngest.createFunction(
+  {
+    id: "scheduled-app-binding-refresh",
+    name: "Scheduled App Data Source Refresh",
+  },
+  { cron: "* * * * *" },
+  async ({ step }) => {
+    const apps = (await step.run("find-stale-app-bindings", async () => {
+      return MakoApp.find({
+        dataBindings: {
+          $elemMatch: {
+            materialization: "parquet",
+            "materializationSchedule.enabled": true,
+            "materializationSchedule.cron": { $type: "string", $ne: "" },
+          },
+        },
+      }).select("_id workspaceId dataBindings");
+    })) as any[];
+
+    let triggered = 0;
+
+    for (const app of apps) {
+      for (const binding of app.dataBindings || []) {
+        if (binding.materialization !== "parquet") continue;
+        const schedule = binding.materializationSchedule;
+        if (!schedule?.enabled || !schedule.cron) continue;
+
+        let isDue = false;
+        try {
+          isDue = isDashboardMaterializationDue({
+            schedule,
+            lastRefreshedAt:
+              binding.cache?.lastRefreshedAt ??
+              binding.cache?.parquetBuiltAt ??
+              null,
+          });
+        } catch (error) {
+          log.warn("Skipping app binding with invalid materialization schedule", {
+            error,
+            appId: app._id.toString(),
+            bindingId: binding.id,
+          });
+          continue;
+        }
+
+        if (!isDue) continue;
+
+        await step.run(`queue-binding-${app._id.toString()}-${binding.id}`, () =>
+          queueAppBindingMaterialization({
+            workspaceId: app.workspaceId.toString(),
+            appId: app._id.toString(),
+            bindingId: binding.id,
+            force: true,
+          }),
+        );
+        triggered++;
+      }
+    }
+
+    log.info("App binding scheduler run", {
+      total: apps.length,
+      triggered,
+    });
+
+    return { total: apps.length, triggered };
   },
 );

--- a/api/src/inngest/index.ts
+++ b/api/src/inngest/index.ts
@@ -18,7 +18,10 @@ import {
   dashboardSchedulerFunction,
   cleanupAbandonedMaterializationRunsFunction,
 } from "./functions/dashboard-refresh";
-import { appBindingMaterializeFunction } from "./functions/app-binding-materialize";
+import {
+  appBindingMaterializeFunction,
+  appBindingSchedulerFunction,
+} from "./functions/app-binding-materialize";
 import { syncBackfillEntityFunction } from "./functions/sync-entity";
 import { usageReportingFunction } from "./functions/usage-reporting";
 import { modelCatalogRefreshFunction } from "./functions/model-catalog-refresh";
@@ -89,6 +92,7 @@ export function getFunctions() {
         ...webhookFunctions,
         flowSchedulerFunction,
         dashboardSchedulerFunction,
+        appBindingSchedulerFunction,
         scheduledQuerySchedulerFunction,
         dbtSchedulerFunction,
       ];
@@ -139,6 +143,7 @@ export {
   dashboardSchedulerFunction,
   cleanupAbandonedMaterializationRunsFunction,
   appBindingMaterializeFunction,
+  appBindingSchedulerFunction,
   usageReportingFunction,
   modelCatalogRefreshFunction,
   scheduledQueryExecutorFunction,

--- a/api/src/routes/apps.ts
+++ b/api/src/routes/apps.ts
@@ -125,6 +125,7 @@ function serializeApp(doc: IMakoApp) {
       databaseId: b.databaseId,
       databaseName: b.databaseName,
       materialization: b.materialization ?? "live",
+      materializationSchedule: b.materializationSchedule,
       cache: b.cache
         ? {
             parquetArtifactKey: b.cache.parquetArtifactKey,

--- a/api/src/routes/public-share.ts
+++ b/api/src/routes/public-share.ts
@@ -10,7 +10,7 @@
  *   POST /api/share/:token/unlock     — verify password, set signed cookie
  *   GET  /api/share/:token/content    — sanitized dashboard/app definition
  *   GET  /api/share/:token/artifacts/:artifactId — stream snapshot parquet
- *   POST /api/share/:token/refresh    — throttled re-materialization (dash)
+ *   POST /api/share/:token/refresh    — throttled snapshot re-materialization
  */
 
 import crypto from "node:crypto";
@@ -30,7 +30,10 @@ import { loggers } from "../logging";
 import { buildDataSourceMaterializationStatus } from "../services/dashboard-materialization.service";
 import { queueDashboardArtifactRefresh } from "../services/dashboard-refresh-runner.service";
 import { getDashboardArtifactStore } from "../services/dashboard-artifact-store.service";
-import { getBindingArtifactInfo } from "../services/app-binding-materialization.service";
+import {
+  getBindingArtifactInfo,
+  queueAppBindingMaterialization,
+} from "../services/app-binding-materialization.service";
 
 const logger = loggers.api("public-share");
 
@@ -455,7 +458,7 @@ app.openapi(
   },
 );
 
-// POST /:token/refresh — throttled snapshot refresh (dashboards only).
+// POST /:token/refresh — throttled snapshot refresh.
 // Only re-runs the owner-defined data source queries; anonymous viewers can
 // never execute arbitrary queries.
 app.openapi(
@@ -463,7 +466,7 @@ app.openapi(
     method: "post",
     path: "/{token}/refresh",
     tags: ["Public Shares"],
-    summary: "Refresh a dashboard share snapshot",
+    summary: "Refresh a public share snapshot",
     security: [],
     request: { params: TokenParam },
     responses: { ...OPEN_RESPONSES },
@@ -477,15 +480,20 @@ app.openapi(
       }
       const gate = requireUnlock(c, token, resource);
       if (gate) return gate;
-      if (resource.type !== "dashboard") {
+      const doc = resource.doc;
+      if (
+        resource.type === "app" &&
+        !doc.dataBindings.some(binding => binding.materialization === "parquet")
+      ) {
         return c.json(
-          { success: false, error: "Refresh is only available for dashboards" },
+          {
+            success: false,
+            error: "No materialized app data sources to refresh",
+          },
           400,
         );
       }
-
-      const dashboard = resource.doc;
-      const last = dashboard.publicShare?.lastPublicRefreshAt?.getTime() ?? 0;
+      const last = doc.publicShare?.lastPublicRefreshAt?.getTime() ?? 0;
       const elapsed = Date.now() - last;
       if (elapsed < PUBLIC_REFRESH_COOLDOWN_MS) {
         const retryAfterMs = PUBLIC_REFRESH_COOLDOWN_MS - elapsed;
@@ -502,9 +510,10 @@ app.openapi(
 
       // Claim the cooldown slot atomically so concurrent anonymous viewers
       // can't queue duplicate refreshes.
-      const claimed = await Dashboard.findOneAndUpdate(
+      const model = resource.type === "dashboard" ? Dashboard : MakoApp;
+      const claimed = await model.findOneAndUpdate(
         {
-          _id: dashboard._id,
+          _id: doc._id,
           "publicShare.enabled": true,
           $or: [
             { "publicShare.lastPublicRefreshAt": { $exists: false } },
@@ -530,22 +539,49 @@ app.openapi(
         );
       }
 
-      // force: true re-queries the owner-defined source queries even when the
-      // dashboard definition is unchanged. Without it, the rebuild service
-      // reuses the cached parquet (no new parquetBuiltAt), so the viewer's
-      // "data changed?" poll never observes a fresh snapshot and times out.
-      // The 5-minute cooldown above guards against abusive/expensive re-runs.
-      const queueResult = await queueDashboardArtifactRefresh({
-        dashboardId: dashboard._id.toString(),
-        workspaceId: dashboard.workspaceId.toString(),
-        force: true,
-        triggerType: "manual",
-      });
+      let queued = false;
+      let alreadyRunning = false;
+      let dataSourceIds: string[] = [];
+
+      if (resource.type === "dashboard") {
+        // force: true re-queries the owner-defined source queries even when the
+        // dashboard definition is unchanged. Without it, the rebuild service
+        // reuses the cached parquet (no new parquetBuiltAt), so the viewer's
+        // "data changed?" poll never observes a fresh snapshot and times out.
+        // The 5-minute cooldown above guards against abusive/expensive re-runs.
+        const queueResult = await queueDashboardArtifactRefresh({
+          dashboardId: doc._id.toString(),
+          workspaceId: doc.workspaceId.toString(),
+          force: true,
+          triggerType: "manual",
+        });
+        queued = queueResult.queued;
+        alreadyRunning = !queueResult.queued;
+        dataSourceIds = queueResult.dataSourceIds;
+      } else {
+        const materializedBindings = doc.dataBindings.filter(
+          binding => binding.materialization === "parquet",
+        );
+        const results = await Promise.all(
+          materializedBindings.map(binding =>
+            queueAppBindingMaterialization({
+              workspaceId: doc.workspaceId.toString(),
+              appId: doc._id.toString(),
+              bindingId: binding.id,
+              force: true,
+            }),
+          ),
+        );
+        queued = results.some(result => result.queued);
+        alreadyRunning = results.some(result => result.alreadyRunning);
+        dataSourceIds = results.map(result => result.bindingId);
+      }
 
       return c.json({
         success: true,
-        queued: queueResult.queued,
-        alreadyRunning: !queueResult.queued,
+        queued,
+        alreadyRunning,
+        dataSourceIds,
         cooldownMs: PUBLIC_REFRESH_COOLDOWN_MS,
       });
     } catch (error) {

--- a/api/src/routes/public-share.ts
+++ b/api/src/routes/public-share.ts
@@ -480,20 +480,25 @@ app.openapi(
       }
       const gate = requireUnlock(c, token, resource);
       if (gate) return gate;
-      const doc = resource.doc;
-      if (
-        resource.type === "app" &&
-        !doc.dataBindings.some(binding => binding.materialization === "parquet")
-      ) {
-        return c.json(
-          {
-            success: false,
-            error: "No materialized app data sources to refresh",
-          },
-          400,
-        );
+      if (resource.type === "app") {
+        const appDoc = resource.doc;
+        if (
+          !appDoc.dataBindings.some(
+            binding => binding.materialization === "parquet",
+          )
+        ) {
+          return c.json(
+            {
+              success: false,
+              error: "No materialized app data sources to refresh",
+            },
+            400,
+          );
+        }
       }
-      const last = doc.publicShare?.lastPublicRefreshAt?.getTime() ?? 0;
+
+      const last =
+        resource.doc.publicShare?.lastPublicRefreshAt?.getTime() ?? 0;
       const elapsed = Date.now() - last;
       if (elapsed < PUBLIC_REFRESH_COOLDOWN_MS) {
         const retryAfterMs = PUBLIC_REFRESH_COOLDOWN_MS - elapsed;
@@ -510,23 +515,40 @@ app.openapi(
 
       // Claim the cooldown slot atomically so concurrent anonymous viewers
       // can't queue duplicate refreshes.
-      const model = resource.type === "dashboard" ? Dashboard : MakoApp;
-      const claimed = await model.findOneAndUpdate(
-        {
-          _id: doc._id,
-          "publicShare.enabled": true,
-          $or: [
-            { "publicShare.lastPublicRefreshAt": { $exists: false } },
-            {
-              "publicShare.lastPublicRefreshAt": {
-                $lte: new Date(Date.now() - PUBLIC_REFRESH_COOLDOWN_MS),
+      const claimed =
+        resource.type === "dashboard"
+          ? await Dashboard.findOneAndUpdate(
+              {
+                _id: resource.doc._id,
+                "publicShare.enabled": true,
+                $or: [
+                  { "publicShare.lastPublicRefreshAt": { $exists: false } },
+                  {
+                    "publicShare.lastPublicRefreshAt": {
+                      $lte: new Date(Date.now() - PUBLIC_REFRESH_COOLDOWN_MS),
+                    },
+                  },
+                ],
               },
-            },
-          ],
-        },
-        { $set: { "publicShare.lastPublicRefreshAt": new Date() } },
-        { new: true },
-      );
+              { $set: { "publicShare.lastPublicRefreshAt": new Date() } },
+              { new: true },
+            )
+          : await MakoApp.findOneAndUpdate(
+              {
+                _id: resource.doc._id,
+                "publicShare.enabled": true,
+                $or: [
+                  { "publicShare.lastPublicRefreshAt": { $exists: false } },
+                  {
+                    "publicShare.lastPublicRefreshAt": {
+                      $lte: new Date(Date.now() - PUBLIC_REFRESH_COOLDOWN_MS),
+                    },
+                  },
+                ],
+              },
+              { $set: { "publicShare.lastPublicRefreshAt": new Date() } },
+              { new: true },
+            );
       if (!claimed) {
         return c.json(
           {
@@ -544,14 +566,15 @@ app.openapi(
       let dataSourceIds: string[] = [];
 
       if (resource.type === "dashboard") {
+        const dashboard = resource.doc;
         // force: true re-queries the owner-defined source queries even when the
         // dashboard definition is unchanged. Without it, the rebuild service
         // reuses the cached parquet (no new parquetBuiltAt), so the viewer's
         // "data changed?" poll never observes a fresh snapshot and times out.
         // The 5-minute cooldown above guards against abusive/expensive re-runs.
         const queueResult = await queueDashboardArtifactRefresh({
-          dashboardId: doc._id.toString(),
-          workspaceId: doc.workspaceId.toString(),
+          dashboardId: dashboard._id.toString(),
+          workspaceId: dashboard.workspaceId.toString(),
           force: true,
           triggerType: "manual",
         });
@@ -559,14 +582,15 @@ app.openapi(
         alreadyRunning = !queueResult.queued;
         dataSourceIds = queueResult.dataSourceIds;
       } else {
-        const materializedBindings = doc.dataBindings.filter(
+        const appDoc = resource.doc;
+        const materializedBindings = appDoc.dataBindings.filter(
           binding => binding.materialization === "parquet",
         );
         const results = await Promise.all(
           materializedBindings.map(binding =>
             queueAppBindingMaterialization({
-              workspaceId: doc.workspaceId.toString(),
-              appId: doc._id.toString(),
+              workspaceId: appDoc.workspaceId.toString(),
+              appId: appDoc._id.toString(),
               bindingId: binding.id,
               force: true,
             }),

--- a/api/src/routes/register-routes.ts
+++ b/api/src/routes/register-routes.ts
@@ -29,6 +29,7 @@ import { dashboardRoutes } from "./dashboards";
 import { appRoutes } from "./apps";
 import { publicShareRoutes } from "./public-share";
 import { dashboardMaterializationRoutes } from "./dashboard-materialization";
+import { resourceDataSourceRoutes } from "./resource-data-sources";
 import { scheduledQueryRoutes } from "./scheduled-queries";
 import { notificationRulesRoutes } from "./notification-rules";
 import { devEmailPreviewRoutes } from "./dev-email-preview.routes";
@@ -79,6 +80,10 @@ export function registerApiRoutes(app: OpenAPIHono<AuthEnv>): void {
   app.route("/api/workspaces/:workspaceId/billing", billingRoutes);
   app.route("/api/workspaces/:workspaceId/dashboards", dashboardRoutes);
   app.route("/api/workspaces/:workspaceId/apps", appRoutes);
+  app.route(
+    "/api/workspaces/:workspaceId/data-sources",
+    resourceDataSourceRoutes,
+  );
   app.route(
     "/api/workspaces/:workspaceId/dashboards/:dashboardId",
     dashboardMaterializationRoutes,

--- a/api/src/routes/resource-data-sources.ts
+++ b/api/src/routes/resource-data-sources.ts
@@ -127,16 +127,19 @@ app.openapi(
   async c => {
     try {
       const dataSources = await listResourceDataSources({
-        workspaceId: c.req.param("workspaceId"),
+        workspaceId: c.req.param("workspaceId") as string,
         resourceType: c.req.param("resourceType") as "dashboard" | "app",
-        resourceId: c.req.param("resourceId"),
+        resourceId: c.req.param("resourceId") as string,
         userId: c.get("user")?.id,
         memberRole: c.get("memberRole"),
       });
       return c.json({ success: true, data: { dataSources } });
     } catch (error) {
       logger.error("Error listing resource data sources", { error });
-      return c.json({ success: false, error: errorMessage(error) }, errorStatus(error));
+      return c.json(
+        { success: false, error: errorMessage(error) },
+        errorStatus(error),
+      );
     }
   },
 );
@@ -154,17 +157,20 @@ app.openapi(
   async c => {
     try {
       const dataSource = await getResourceDataSource({
-        workspaceId: c.req.param("workspaceId"),
+        workspaceId: c.req.param("workspaceId") as string,
         resourceType: c.req.param("resourceType") as "dashboard" | "app",
-        resourceId: c.req.param("resourceId"),
-        dataSourceId: c.req.param("dataSourceId"),
+        resourceId: c.req.param("resourceId") as string,
+        dataSourceId: c.req.param("dataSourceId") as string,
         userId: c.get("user")?.id,
         memberRole: c.get("memberRole"),
       });
       return c.json({ success: true, data: { dataSource } });
     } catch (error) {
       logger.error("Error getting resource data source", { error });
-      return c.json({ success: false, error: errorMessage(error) }, errorStatus(error));
+      return c.json(
+        { success: false, error: errorMessage(error) },
+        errorStatus(error),
+      );
     }
   },
 );
@@ -183,10 +189,10 @@ app.openapi(
     try {
       const body = await c.req.json().catch(() => ({}));
       const dataSource = await updateResourceDataSourceSettings({
-        workspaceId: c.req.param("workspaceId"),
+        workspaceId: c.req.param("workspaceId") as string,
         resourceType: c.req.param("resourceType") as "dashboard" | "app",
-        resourceId: c.req.param("resourceId"),
-        dataSourceId: c.req.param("dataSourceId"),
+        resourceId: c.req.param("resourceId") as string,
+        dataSourceId: c.req.param("dataSourceId") as string,
         settings: body,
         userId: c.get("user")?.id,
         memberRole: c.get("memberRole"),
@@ -194,7 +200,10 @@ app.openapi(
       return c.json({ success: true, data: { dataSource } });
     } catch (error) {
       logger.error("Error updating resource data source settings", { error });
-      return c.json({ success: false, error: errorMessage(error) }, errorStatus(error));
+      return c.json(
+        { success: false, error: errorMessage(error) },
+        errorStatus(error),
+      );
     }
   },
 );
@@ -212,16 +221,19 @@ app.openapi(
   async c => {
     try {
       const result = await refreshResourceDataSources({
-        workspaceId: c.req.param("workspaceId"),
+        workspaceId: c.req.param("workspaceId") as string,
         resourceType: c.req.param("resourceType") as "dashboard" | "app",
-        resourceId: c.req.param("resourceId"),
+        resourceId: c.req.param("resourceId") as string,
         userId: c.get("user")?.id,
         memberRole: c.get("memberRole"),
       });
       return c.json({ success: true, data: result });
     } catch (error) {
       logger.error("Error refreshing resource data sources", { error });
-      return c.json({ success: false, error: errorMessage(error) }, errorStatus(error));
+      return c.json(
+        { success: false, error: errorMessage(error) },
+        errorStatus(error),
+      );
     }
   },
 );
@@ -239,17 +251,20 @@ app.openapi(
   async c => {
     try {
       const result = await refreshResourceDataSources({
-        workspaceId: c.req.param("workspaceId"),
+        workspaceId: c.req.param("workspaceId") as string,
         resourceType: c.req.param("resourceType") as "dashboard" | "app",
-        resourceId: c.req.param("resourceId"),
-        dataSourceId: c.req.param("dataSourceId"),
+        resourceId: c.req.param("resourceId") as string,
+        dataSourceId: c.req.param("dataSourceId") as string,
         userId: c.get("user")?.id,
         memberRole: c.get("memberRole"),
       });
       return c.json({ success: true, data: result });
     } catch (error) {
       logger.error("Error refreshing resource data source", { error });
-      return c.json({ success: false, error: errorMessage(error) }, errorStatus(error));
+      return c.json(
+        { success: false, error: errorMessage(error) },
+        errorStatus(error),
+      );
     }
   },
 );

--- a/api/src/routes/resource-data-sources.ts
+++ b/api/src/routes/resource-data-sources.ts
@@ -1,0 +1,257 @@
+/**
+ * Unified data-source routes for dashboard data sources and app data bindings.
+ *
+ * Classification: Authenticated + workspace-scoped
+ * (`unifiedAuthMiddleware` + workspace verification).
+ */
+
+import { createRoute, z } from "@hono/zod-openapi";
+import { Types } from "mongoose";
+import { unifiedAuthMiddleware } from "../auth/unified-auth.middleware";
+import { AuthenticatedContext } from "../middleware/workspace.middleware";
+import { loggers, enrichContextWithWorkspace } from "../logging";
+import { workspaceService } from "../services/workspace.service";
+import {
+  getResourceDataSource,
+  listResourceDataSources,
+  refreshResourceDataSources,
+  updateResourceDataSourceSettings,
+} from "../services/resource-data-source.service";
+import { AUTH_SECURITY, OPEN_RESPONSES, createRouter } from "../openapi/core";
+
+const logger = loggers.api("resource-data-sources");
+const app = createRouter();
+
+const ResourceTypeSchema = z.enum(["dashboard", "app"]);
+const ScheduleSchema = z.object({
+  enabled: z.boolean(),
+  cron: z.string().nullable(),
+  timezone: z.string().optional(),
+  dataFreshnessTtlMs: z.number().nullable().optional(),
+});
+
+const ResourceParam = z.object({
+  workspaceId: z
+    .string()
+    .openapi({ param: { name: "workspaceId", in: "path" } }),
+  resourceType: ResourceTypeSchema.openapi({
+    param: { name: "resourceType", in: "path" },
+  }),
+  resourceId: z
+    .string()
+    .openapi({ param: { name: "resourceId", in: "path" } }),
+});
+
+const DataSourceParam = ResourceParam.extend({
+  dataSourceId: z
+    .string()
+    .openapi({ param: { name: "dataSourceId", in: "path" } }),
+});
+
+const SettingsBody = {
+  required: false,
+  content: {
+    "application/json": {
+      schema: z.object({
+        materialization: z.enum(["live", "parquet"]).optional(),
+        schedule: ScheduleSchema.nullable().optional(),
+      }),
+    },
+  },
+};
+
+function errorStatus(error: unknown): 400 | 403 | 404 | 500 {
+  const message = error instanceof Error ? error.message : "";
+  if (message === "Access denied") return 403;
+  if (message.includes("not found")) return 404;
+  if (message.startsWith("Invalid") || message.includes("always")) return 400;
+  if (message.includes("No materialized")) return 400;
+  return 500;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Request failed";
+}
+
+app.use("*", unifiedAuthMiddleware);
+
+app.use("*", async (c: AuthenticatedContext, next) => {
+  const workspaceId = c.req.param("workspaceId") as string;
+  if (!Types.ObjectId.isValid(workspaceId)) {
+    return c.json(
+      { success: false, error: "Invalid workspace ID format" },
+      400,
+    );
+  }
+
+  const user = c.get("user");
+  const workspace = c.get("workspace");
+  if (workspace) {
+    if (workspace._id.toString() !== workspaceId) {
+      return c.json(
+        {
+          success: false,
+          error: "API key not authorized for this workspace",
+        },
+        403,
+      );
+    }
+    c.set("memberRole", "admin");
+  } else if (user) {
+    const member = await workspaceService.getMember(workspaceId, user.id);
+    if (!member) {
+      return c.json(
+        { success: false, error: "Access denied to workspace" },
+        403,
+      );
+    }
+    c.set("memberRole", member.role);
+  } else {
+    return c.json({ success: false, error: "Unauthorized" }, 401);
+  }
+
+  enrichContextWithWorkspace(workspaceId);
+  await next();
+});
+
+app.openapi(
+  createRoute({
+    method: "get",
+    path: "/{resourceType}/{resourceId}",
+    tags: ["Data Sources"],
+    summary: "List data sources for a dashboard or app",
+    security: AUTH_SECURITY,
+    request: { params: ResourceParam },
+    responses: { ...OPEN_RESPONSES },
+  }),
+  async c => {
+    try {
+      const dataSources = await listResourceDataSources({
+        workspaceId: c.req.param("workspaceId"),
+        resourceType: c.req.param("resourceType") as "dashboard" | "app",
+        resourceId: c.req.param("resourceId"),
+        userId: c.get("user")?.id,
+        memberRole: c.get("memberRole"),
+      });
+      return c.json({ success: true, data: { dataSources } });
+    } catch (error) {
+      logger.error("Error listing resource data sources", { error });
+      return c.json({ success: false, error: errorMessage(error) }, errorStatus(error));
+    }
+  },
+);
+
+app.openapi(
+  createRoute({
+    method: "get",
+    path: "/{resourceType}/{resourceId}/{dataSourceId}",
+    tags: ["Data Sources"],
+    summary: "Get one dashboard/app data source",
+    security: AUTH_SECURITY,
+    request: { params: DataSourceParam },
+    responses: { ...OPEN_RESPONSES },
+  }),
+  async c => {
+    try {
+      const dataSource = await getResourceDataSource({
+        workspaceId: c.req.param("workspaceId"),
+        resourceType: c.req.param("resourceType") as "dashboard" | "app",
+        resourceId: c.req.param("resourceId"),
+        dataSourceId: c.req.param("dataSourceId"),
+        userId: c.get("user")?.id,
+        memberRole: c.get("memberRole"),
+      });
+      return c.json({ success: true, data: { dataSource } });
+    } catch (error) {
+      logger.error("Error getting resource data source", { error });
+      return c.json({ success: false, error: errorMessage(error) }, errorStatus(error));
+    }
+  },
+);
+
+app.openapi(
+  createRoute({
+    method: "patch",
+    path: "/{resourceType}/{resourceId}/{dataSourceId}/settings",
+    tags: ["Data Sources"],
+    summary: "Update materialization settings for a data source",
+    security: AUTH_SECURITY,
+    request: { params: DataSourceParam, body: SettingsBody },
+    responses: { ...OPEN_RESPONSES },
+  }),
+  async c => {
+    try {
+      const body = await c.req.json().catch(() => ({}));
+      const dataSource = await updateResourceDataSourceSettings({
+        workspaceId: c.req.param("workspaceId"),
+        resourceType: c.req.param("resourceType") as "dashboard" | "app",
+        resourceId: c.req.param("resourceId"),
+        dataSourceId: c.req.param("dataSourceId"),
+        settings: body,
+        userId: c.get("user")?.id,
+        memberRole: c.get("memberRole"),
+      });
+      return c.json({ success: true, data: { dataSource } });
+    } catch (error) {
+      logger.error("Error updating resource data source settings", { error });
+      return c.json({ success: false, error: errorMessage(error) }, errorStatus(error));
+    }
+  },
+);
+
+app.openapi(
+  createRoute({
+    method: "post",
+    path: "/{resourceType}/{resourceId}/refresh",
+    tags: ["Data Sources"],
+    summary: "Refresh all materialized data sources for a dashboard or app",
+    security: AUTH_SECURITY,
+    request: { params: ResourceParam },
+    responses: { ...OPEN_RESPONSES },
+  }),
+  async c => {
+    try {
+      const result = await refreshResourceDataSources({
+        workspaceId: c.req.param("workspaceId"),
+        resourceType: c.req.param("resourceType") as "dashboard" | "app",
+        resourceId: c.req.param("resourceId"),
+        userId: c.get("user")?.id,
+        memberRole: c.get("memberRole"),
+      });
+      return c.json({ success: true, data: result });
+    } catch (error) {
+      logger.error("Error refreshing resource data sources", { error });
+      return c.json({ success: false, error: errorMessage(error) }, errorStatus(error));
+    }
+  },
+);
+
+app.openapi(
+  createRoute({
+    method: "post",
+    path: "/{resourceType}/{resourceId}/{dataSourceId}/refresh",
+    tags: ["Data Sources"],
+    summary: "Refresh one materialized data source for a dashboard or app",
+    security: AUTH_SECURITY,
+    request: { params: DataSourceParam },
+    responses: { ...OPEN_RESPONSES },
+  }),
+  async c => {
+    try {
+      const result = await refreshResourceDataSources({
+        workspaceId: c.req.param("workspaceId"),
+        resourceType: c.req.param("resourceType") as "dashboard" | "app",
+        resourceId: c.req.param("resourceId"),
+        dataSourceId: c.req.param("dataSourceId"),
+        userId: c.get("user")?.id,
+        memberRole: c.get("memberRole"),
+      });
+      return c.json({ success: true, data: result });
+    } catch (error) {
+      logger.error("Error refreshing resource data source", { error });
+      return c.json({ success: false, error: errorMessage(error) }, errorStatus(error));
+    }
+  },
+);
+
+export const resourceDataSourceRoutes = app;

--- a/api/src/services/resource-data-source.service.ts
+++ b/api/src/services/resource-data-source.service.ts
@@ -1,0 +1,414 @@
+import { Types } from "mongoose";
+import {
+  Dashboard,
+  MakoApp,
+  type IDashboard,
+  type IDashboardDataSource,
+  type IMakoApp,
+  type IMakoAppDataBinding,
+} from "../database/workspace-schema";
+import { DashboardManager } from "../utils/dashboard-manager";
+import { canReadResource, canWriteResource } from "../utils/resource-acl";
+import {
+  buildDataSourceMaterializationStatus,
+  type MaterializationStatusValue,
+} from "./dashboard-materialization.service";
+import { queueDashboardArtifactRefresh } from "./dashboard-refresh-runner.service";
+import {
+  buildAppBindingMaterializationStatus,
+  queueAppBindingMaterialization,
+} from "./app-binding-materialization.service";
+import {
+  normalizeDashboardMaterializationSchedule,
+  validateDashboardMaterializationSchedule,
+  type DashboardMaterializationScheduleInput,
+} from "./dashboard-materialization-schedule.service";
+
+export type ResourceDataSourceType = "dashboard" | "app";
+export type ResourceDataSourceMaterialization = "live" | "parquet";
+
+export interface ResourceDataSourceSettingsInput {
+  materialization?: ResourceDataSourceMaterialization;
+  schedule?: DashboardMaterializationScheduleInput | null;
+}
+
+export interface ResourceDataSourceStatus {
+  status: MaterializationStatusValue;
+  rowCount: number | null;
+  byteSize: number | null;
+  artifactRevision: string | null;
+  materializedAt: string | null;
+  readUrl: string | null;
+  lastError: string | null;
+}
+
+export interface UnifiedResourceDataSource {
+  id: string;
+  name: string;
+  resourceType: ResourceDataSourceType;
+  resourceId: string;
+  sourceKind: "dashboard-data-source" | "app-binding";
+  tableRef?: string;
+  connectionId: string;
+  language: "sql" | "javascript" | "mongodb";
+  code: string;
+  databaseId?: string;
+  databaseName?: string;
+  materialization: ResourceDataSourceMaterialization;
+  materializationSchedule: {
+    enabled: boolean;
+    cron: string | null;
+    timezone: string;
+    dataFreshnessTtlMs?: number | null;
+  };
+  scheduleScope: "resource" | "data-source";
+  status: ResourceDataSourceStatus;
+}
+
+export interface ResourceDataSourceRefreshResult {
+  resourceType: ResourceDataSourceType;
+  resourceId: string;
+  dataSourceIds: string[];
+  queued: boolean;
+  alreadyRunning?: boolean;
+}
+
+function assertObjectId(id: string, label: string): void {
+  if (!Types.ObjectId.isValid(id)) {
+    throw new Error(`Invalid ${label}`);
+  }
+}
+
+function requireDashboardRead(
+  dashboard: IDashboard,
+  userId: string | undefined,
+  memberRole?: string,
+): void {
+  if (!userId || !DashboardManager.canRead(dashboard, userId, memberRole)) {
+    throw new Error("Access denied");
+  }
+}
+
+function requireDashboardWrite(
+  dashboard: IDashboard,
+  userId: string | undefined,
+  memberRole?: string,
+): void {
+  const isAdmin = memberRole === "owner" || memberRole === "admin";
+  if (
+    !userId ||
+    !DashboardManager.canWrite(dashboard, userId, isAdmin, memberRole)
+  ) {
+    throw new Error("Access denied");
+  }
+}
+
+function requireAppRead(
+  app: IMakoApp,
+  userId: string | undefined,
+  memberRole?: string,
+): void {
+  if (!canReadResource(app, userId, memberRole)) {
+    throw new Error("Access denied");
+  }
+}
+
+function requireAppWrite(
+  app: IMakoApp,
+  userId: string | undefined,
+  memberRole?: string,
+): void {
+  if (!canWriteResource(app, userId, memberRole)) {
+    throw new Error("Access denied");
+  }
+}
+
+function serializeAppStatus(
+  status: NonNullable<ReturnType<typeof buildAppBindingMaterializationStatus>>,
+): ResourceDataSourceStatus {
+  return {
+    status: status.status,
+    rowCount: status.rowCount ?? null,
+    byteSize: status.byteSize ?? null,
+    artifactRevision: status.artifactRevision ?? null,
+    materializedAt:
+      status.parquetBuiltAt?.toISOString() ??
+      status.lastRefreshedAt?.toISOString() ??
+      null,
+    readUrl: null,
+    lastError: status.error ?? null,
+  };
+}
+
+async function serializeDashboardDataSource(input: {
+  workspaceId: string;
+  dashboard: IDashboard;
+  dataSource: IDashboardDataSource;
+}): Promise<UnifiedResourceDataSource> {
+  const status = await buildDataSourceMaterializationStatus({
+    workspaceId: input.workspaceId,
+    dashboardId: input.dashboard._id.toString(),
+    dataSource: input.dataSource,
+  });
+  const schedule = normalizeDashboardMaterializationSchedule(
+    input.dashboard.materializationSchedule,
+  );
+  return {
+    id: input.dataSource.id,
+    name: input.dataSource.name,
+    resourceType: "dashboard",
+    resourceId: input.dashboard._id.toString(),
+    sourceKind: "dashboard-data-source",
+    tableRef: input.dataSource.tableRef,
+    connectionId: input.dataSource.query.connectionId.toString(),
+    language: input.dataSource.query.language,
+    code: input.dataSource.query.code,
+    databaseId: input.dataSource.query.databaseId,
+    databaseName: input.dataSource.query.databaseName,
+    materialization: "parquet",
+    materializationSchedule: schedule,
+    scheduleScope: "resource",
+    status: {
+      status: status.status,
+      rowCount: status.rowCount,
+      byteSize: status.byteSize,
+      artifactRevision: status.artifactRevision,
+      materializedAt: status.builtAt ?? status.lastMaterializedAt,
+      readUrl: status.readUrl,
+      lastError: status.lastError,
+    },
+  };
+}
+
+function serializeAppBinding(input: {
+  app: IMakoApp;
+  binding: IMakoAppDataBinding;
+}): UnifiedResourceDataSource {
+  const status = buildAppBindingMaterializationStatus(
+    input.app,
+    input.binding.id,
+  );
+  return {
+    id: input.binding.id,
+    name: input.binding.name,
+    resourceType: "app",
+    resourceId: input.app._id.toString(),
+    sourceKind: "app-binding",
+    connectionId: input.binding.connectionId.toString(),
+    language: input.binding.language,
+    code: input.binding.code,
+    databaseId: input.binding.databaseId,
+    databaseName: input.binding.databaseName,
+    materialization: input.binding.materialization,
+    materializationSchedule: normalizeDashboardMaterializationSchedule(
+      input.binding.materializationSchedule ?? {
+        enabled: false,
+        cron: null,
+        timezone: "UTC",
+      },
+    ),
+    scheduleScope: "data-source",
+    status: status
+      ? serializeAppStatus(status)
+      : {
+          status: "missing",
+          rowCount: null,
+          byteSize: null,
+          artifactRevision: null,
+          materializedAt: null,
+          readUrl: null,
+          lastError: "Binding not found",
+        },
+  };
+}
+
+async function getDashboardOrThrow(input: {
+  workspaceId: string;
+  resourceId: string;
+}): Promise<IDashboard> {
+  assertObjectId(input.resourceId, "dashboard ID");
+  const dashboard = await Dashboard.findOne({
+    _id: new Types.ObjectId(input.resourceId),
+    workspaceId: new Types.ObjectId(input.workspaceId),
+  });
+  if (!dashboard) {
+    throw new Error("Dashboard not found");
+  }
+  return dashboard;
+}
+
+async function getAppOrThrow(input: {
+  workspaceId: string;
+  resourceId: string;
+}): Promise<IMakoApp> {
+  assertObjectId(input.resourceId, "app ID");
+  const app = await MakoApp.findOne({
+    _id: new Types.ObjectId(input.resourceId),
+    workspaceId: new Types.ObjectId(input.workspaceId),
+  });
+  if (!app) {
+    throw new Error("App not found");
+  }
+  return app;
+}
+
+export async function listResourceDataSources(input: {
+  workspaceId: string;
+  resourceType: ResourceDataSourceType;
+  resourceId: string;
+  userId?: string;
+  memberRole?: string;
+}): Promise<UnifiedResourceDataSource[]> {
+  if (input.resourceType === "dashboard") {
+    const dashboard = await getDashboardOrThrow(input);
+    requireDashboardRead(dashboard, input.userId, input.memberRole);
+    return await Promise.all(
+      dashboard.dataSources.map(dataSource =>
+        serializeDashboardDataSource({
+          workspaceId: input.workspaceId,
+          dashboard,
+          dataSource,
+        }),
+      ),
+    );
+  }
+
+  const app = await getAppOrThrow(input);
+  requireAppRead(app, input.userId, input.memberRole);
+  return app.dataBindings.map(binding => serializeAppBinding({ app, binding }));
+}
+
+export async function getResourceDataSource(input: {
+  workspaceId: string;
+  resourceType: ResourceDataSourceType;
+  resourceId: string;
+  dataSourceId: string;
+  userId?: string;
+  memberRole?: string;
+}): Promise<UnifiedResourceDataSource> {
+  const dataSources = await listResourceDataSources(input);
+  const dataSource = dataSources.find(source => source.id === input.dataSourceId);
+  if (!dataSource) {
+    throw new Error("Data source not found");
+  }
+  return dataSource;
+}
+
+export async function updateResourceDataSourceSettings(input: {
+  workspaceId: string;
+  resourceType: ResourceDataSourceType;
+  resourceId: string;
+  dataSourceId: string;
+  settings: ResourceDataSourceSettingsInput;
+  userId?: string;
+  memberRole?: string;
+}): Promise<UnifiedResourceDataSource> {
+  if (input.resourceType === "dashboard") {
+    const dashboard = await getDashboardOrThrow(input);
+    requireDashboardWrite(dashboard, input.userId, input.memberRole);
+    if (input.settings.materialization === "live") {
+      throw new Error("Dashboard data sources are always materialized");
+    }
+    if (
+      !dashboard.dataSources.some(dataSource => dataSource.id === input.dataSourceId)
+    ) {
+      throw new Error("Data source not found");
+    }
+    if (input.settings.schedule !== undefined) {
+      dashboard.materializationSchedule = validateDashboardMaterializationSchedule(
+        input.settings.schedule,
+      );
+      await dashboard.save();
+    }
+    return await getResourceDataSource(input);
+  }
+
+  const app = await getAppOrThrow(input);
+  requireAppWrite(app, input.userId, input.memberRole);
+  const bindingIndex = app.dataBindings.findIndex(
+    binding => binding.id === input.dataSourceId,
+  );
+  if (bindingIndex < 0) {
+    throw new Error("Data source not found");
+  }
+
+  const binding = app.dataBindings[bindingIndex];
+  if (input.settings.materialization) {
+    binding.materialization = input.settings.materialization;
+  }
+  if (input.settings.schedule !== undefined) {
+    binding.materializationSchedule = validateDashboardMaterializationSchedule(
+      input.settings.schedule,
+    );
+  }
+  app.markModified("dataBindings");
+  await app.save();
+  return await getResourceDataSource(input);
+}
+
+export async function refreshResourceDataSources(input: {
+  workspaceId: string;
+  resourceType: ResourceDataSourceType;
+  resourceId: string;
+  dataSourceId?: string;
+  userId?: string;
+  memberRole?: string;
+}): Promise<ResourceDataSourceRefreshResult> {
+  if (input.resourceType === "dashboard") {
+    const dashboard = await getDashboardOrThrow(input);
+    requireDashboardWrite(dashboard, input.userId, input.memberRole);
+    if (
+      input.dataSourceId &&
+      !dashboard.dataSources.some(dataSource => dataSource.id === input.dataSourceId)
+    ) {
+      throw new Error("Data source not found");
+    }
+    const result = await queueDashboardArtifactRefresh({
+      workspaceId: input.workspaceId,
+      dashboardId: input.resourceId,
+      dataSourceIds: input.dataSourceId ? [input.dataSourceId] : undefined,
+      force: true,
+      triggerType: "manual",
+    });
+    return {
+      resourceType: "dashboard",
+      resourceId: input.resourceId,
+      dataSourceIds: result.dataSourceIds,
+      queued: result.queued,
+      alreadyRunning: result.activeRunIds
+        ? result.activeRunIds.length > 0
+        : undefined,
+    };
+  }
+
+  const app = await getAppOrThrow(input);
+  requireAppWrite(app, input.userId, input.memberRole);
+  const targetBindings = input.dataSourceId
+    ? app.dataBindings.filter(binding => binding.id === input.dataSourceId)
+    : app.dataBindings.filter(binding => binding.materialization === "parquet");
+  if (targetBindings.length === 0) {
+    throw new Error(
+      input.dataSourceId
+        ? "Data source not found or not materialized"
+        : "No materialized app data sources to refresh",
+    );
+  }
+
+  const results = await Promise.all(
+    targetBindings.map(binding =>
+      queueAppBindingMaterialization({
+        workspaceId: input.workspaceId,
+        appId: input.resourceId,
+        bindingId: binding.id,
+        force: true,
+      }),
+    ),
+  );
+  return {
+    resourceType: "app",
+    resourceId: input.resourceId,
+    dataSourceIds: results.map(result => result.bindingId),
+    queued: results.some(result => result.queued),
+    alreadyRunning: results.some(result => result.alreadyRunning),
+  };
+}

--- a/app/src/api/schema.d.ts
+++ b/app/src/api/schema.d.ts
@@ -3011,6 +3011,91 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/workspaces/{workspaceId}/data-sources/{resourceType}/{resourceId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List data sources for a dashboard or app */
+        get: operations["get_api_workspaces_workspaceId_data_sources_resourceType_resourceId"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspaces/{workspaceId}/data-sources/{resourceType}/{resourceId}/{dataSourceId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get one dashboard/app data source */
+        get: operations["get_api_workspaces_workspaceId_data_sources_resourceType_resourceId_dataSourceId"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspaces/{workspaceId}/data-sources/{resourceType}/{resourceId}/{dataSourceId}/settings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update materialization settings for a data source */
+        patch: operations["patch_api_workspaces_workspaceId_data_sources_resourceType_resourceId_dataSourceId_settings"];
+        trace?: never;
+    };
+    "/api/workspaces/{workspaceId}/data-sources/{resourceType}/{resourceId}/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Refresh all materialized data sources for a dashboard or app */
+        post: operations["post_api_workspaces_workspaceId_data_sources_resourceType_resourceId_refresh"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspaces/{workspaceId}/data-sources/{resourceType}/{resourceId}/{dataSourceId}/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Refresh one materialized data source for a dashboard or app */
+        post: operations["post_api_workspaces_workspaceId_data_sources_resourceType_resourceId_dataSourceId_refresh"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/workspaces/{workspaceId}/dashboards/{dashboardId}/materialization": {
         parameters: {
             query?: never;
@@ -3224,7 +3309,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Refresh a dashboard share snapshot */
+        /** Refresh a public share snapshot */
         post: operations["post_api_share_token_refresh"];
         delete?: never;
         options?: never;
@@ -14147,6 +14232,232 @@ export interface operations {
             path: {
                 workspaceId: string;
                 id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    get_api_workspaces_workspaceId_data_sources_resourceType_resourceId: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+                resourceType: "dashboard" | "app";
+                resourceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    get_api_workspaces_workspaceId_data_sources_resourceType_resourceId_dataSourceId: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+                resourceType: "dashboard" | "app";
+                resourceId: string;
+                dataSourceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    patch_api_workspaces_workspaceId_data_sources_resourceType_resourceId_dataSourceId_settings: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+                resourceType: "dashboard" | "app";
+                resourceId: string;
+                dataSourceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    /** @enum {string} */
+                    materialization?: "live" | "parquet";
+                    schedule?: {
+                        enabled: boolean;
+                        cron: string | null;
+                        timezone?: string;
+                        dataFreshnessTtlMs?: number | null;
+                    } | null;
+                };
+            };
+        };
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    post_api_workspaces_workspaceId_data_sources_resourceType_resourceId_refresh: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+                resourceType: "dashboard" | "app";
+                resourceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    post_api_workspaces_workspaceId_data_sources_resourceType_resourceId_dataSourceId_refresh: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+                resourceType: "dashboard" | "app";
+                resourceId: string;
+                dataSourceId: string;
             };
             cookie?: never;
         };

--- a/app/src/components/AppBindingEditor.tsx
+++ b/app/src/components/AppBindingEditor.tsx
@@ -13,6 +13,7 @@ import {
 } from "@mui/material";
 import {
   Database as MaterializeIcon,
+  CalendarClock as ScheduleIcon,
   Info as InfoIcon,
   History as HistoryIcon,
   Eye as PreviewIcon,
@@ -27,6 +28,11 @@ import { previewParquetArtifact } from "../lib/parquet-preview";
 import Console from "./Console";
 import ResultsTable from "./ResultsTable";
 import EntityBreadcrumbs from "./EntityBreadcrumbs";
+import MaterializationScheduleControls from "./MaterializationScheduleControls";
+import {
+  defaultMaterializationSchedule,
+  type MaterializationScheduleValue,
+} from "../lib/materializationSchedule";
 
 interface PreviewResult {
   results: Record<string, unknown>[];
@@ -73,6 +79,9 @@ export default function AppBindingEditor({
   const [materializing, setMaterializing] = useState(false);
   const [previewingSnapshot, setPreviewingSnapshot] = useState(false);
   const [historyAnchor, setHistoryAnchor] = useState<HTMLElement | null>(null);
+  const [scheduleAnchor, setScheduleAnchor] = useState<HTMLElement | null>(
+    null,
+  );
 
   useEffect(() => {
     if (!appEntity && workspaceId) void fetchApp(workspaceId, appId);
@@ -136,6 +145,15 @@ export default function AppBindingEditor({
   }, [workspaceId, appId, bindingId, materializeBinding]);
 
   const bindingCache = binding?.cache;
+  const handleScheduleChange = useCallback(
+    (schedule: MaterializationScheduleValue) => {
+      if (!workspaceId) return;
+      updateBinding(appId, bindingId, { materializationSchedule: schedule });
+      void persistApp(workspaceId, appId);
+    },
+    [workspaceId, appId, bindingId, updateBinding, persistApp],
+  );
+
   const handlePreviewSnapshot = useCallback(async () => {
     if (!bindingCache?.parquetUrl) return;
     setPreviewingSnapshot(true);
@@ -273,6 +291,14 @@ export default function AppBindingEditor({
               </span>
             </Tooltip>
           )}
+          <Tooltip title="Materialization schedule">
+            <IconButton
+              size="small"
+              onClick={e => setScheduleAnchor(e.currentTarget)}
+            >
+              <ScheduleIcon size={18} strokeWidth={1.5} />
+            </IconButton>
+          </Tooltip>
           <Tooltip title="Materialization history">
             <span>
               <IconButton
@@ -401,6 +427,32 @@ export default function AppBindingEditor({
               </Box>
             ))
           )}
+        </Box>
+      </Popover>
+
+      <Popover
+        open={Boolean(scheduleAnchor)}
+        anchorEl={scheduleAnchor}
+        onClose={() => setScheduleAnchor(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+      >
+        <Box sx={{ p: 1.5, width: 360 }}>
+          <Typography variant="subtitle2" sx={{ mb: 1 }}>
+            Materialization settings
+          </Typography>
+          <MaterializationScheduleControls
+            value={
+              binding.materializationSchedule ??
+              defaultMaterializationSchedule(false)
+            }
+            onChange={handleScheduleChange}
+            disabled={binding.materialization !== "parquet"}
+            caption={
+              binding.materialization === "parquet"
+                ? "This schedule refreshes only this app data source."
+                : "Switch this data source to Materialized before scheduling refreshes."
+            }
+          />
         </Box>
       </Popover>
     </Box>

--- a/app/src/components/AppsExplorer.tsx
+++ b/app/src/components/AppsExplorer.tsx
@@ -237,20 +237,20 @@ export function AppsExplorer() {
         let children: ResourceTreeNode[] | undefined;
         if (loaded) {
           children = buildAppFileNodes(item.id, loaded.files);
-          if (loaded.dataBindings.length > 0) {
-            children.push({
-              id: `${item.id}${DIR_SEP}${DATA_SOURCES_DIR}`,
-              name: "Data sources",
-              path: DATA_SOURCES_DIR,
-              isDirectory: true,
-              children: loaded.dataBindings.map(b => ({
-                id: `${item.id}${BINDING_SEP}${b.id}`,
-                name: b.name,
-                path: `binding/${b.id}`,
-                isDirectory: false,
-              })),
-            });
-          }
+          children.push({
+            id: `${item.id}${DIR_SEP}${DATA_SOURCES_DIR}`,
+            name: "Data sources",
+            path: DATA_SOURCES_DIR,
+            isDirectory: true,
+            entityType: "data-source-folder",
+            children: loaded.dataBindings.map(b => ({
+              id: `${item.id}${BINDING_SEP}${b.id}`,
+              name: b.name,
+              path: `binding/${b.id}`,
+              isDirectory: false,
+              entityType: "data-source",
+            })),
+          });
         }
         return {
           id: item.id,

--- a/app/src/components/DashboardDataSourceEditor.tsx
+++ b/app/src/components/DashboardDataSourceEditor.tsx
@@ -11,6 +11,7 @@ import {
 } from "@mui/material";
 import {
   Database as MaterializeIcon,
+  CalendarClock as ScheduleIcon,
   History as HistoryIcon,
   Eye as PreviewIcon,
   CheckCircle2 as SuccessIcon,
@@ -27,6 +28,8 @@ import { previewParquetArtifact } from "../lib/parquet-preview";
 import Console from "./Console";
 import ResultsTable from "./ResultsTable";
 import EntityBreadcrumbs from "./EntityBreadcrumbs";
+import MaterializationScheduleControls from "./MaterializationScheduleControls";
+import type { MaterializationScheduleValue } from "../lib/materializationSchedule";
 
 interface PreviewResult {
   results: Record<string, unknown>[];
@@ -82,6 +85,9 @@ export default function DashboardDataSourceEditor({
   const [materializing, setMaterializing] = useState(false);
   const [previewingSnapshot, setPreviewingSnapshot] = useState(false);
   const [historyAnchor, setHistoryAnchor] = useState<HTMLElement | null>(null);
+  const [scheduleAnchor, setScheduleAnchor] = useState<HTMLElement | null>(
+    null,
+  );
   const [historyRuns, setHistoryRuns] = useState<MaterializationRunRecord[]>(
     [],
   );
@@ -192,6 +198,19 @@ export default function DashboardDataSourceEditor({
   ]);
 
   const cache = dataSource?.cache;
+
+  const handleScheduleChange = useCallback(
+    (schedule: MaterializationScheduleValue) => {
+      if (!workspaceId || !dashboard) return;
+      useDashboardStore.setState(state => {
+        if (state.openDashboards[dashboardId]) {
+          state.openDashboards[dashboardId].materializationSchedule = schedule;
+        }
+      });
+      void saveDashboard(workspaceId, dashboardId);
+    },
+    [workspaceId, dashboard, dashboardId, saveDashboard],
+  );
 
   const handlePreviewSnapshot = useCallback(async () => {
     if (!workspaceId) return;
@@ -304,6 +323,14 @@ export default function DashboardDataSourceEditor({
           </span>
         </Tooltip>
       )}
+      <Tooltip title="Materialization schedule">
+        <IconButton
+          size="small"
+          onClick={e => setScheduleAnchor(e.currentTarget)}
+        >
+          <ScheduleIcon size={18} strokeWidth={1.5} />
+        </IconButton>
+      </Tooltip>
       <Tooltip title="Materialization history">
         <IconButton
           size="small"
@@ -443,6 +470,25 @@ export default function DashboardDataSourceEditor({
               );
             })
           )}
+        </Box>
+      </Popover>
+
+      <Popover
+        open={Boolean(scheduleAnchor)}
+        anchorEl={scheduleAnchor}
+        onClose={() => setScheduleAnchor(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+      >
+        <Box sx={{ p: 1.5, width: 360 }}>
+          <Typography variant="subtitle2" sx={{ mb: 1 }}>
+            Materialization settings
+          </Typography>
+          <MaterializationScheduleControls
+            value={dashboard.materializationSchedule}
+            onChange={handleScheduleChange}
+            disabled={dashboard.readOnly}
+            caption="Dashboard schedules apply to every data source in this dashboard."
+          />
         </Box>
       </Popover>
     </Box>

--- a/app/src/components/DashboardsExplorer.tsx
+++ b/app/src/components/DashboardsExplorer.tsx
@@ -20,6 +20,8 @@ import {
   Globe as GlobeIcon,
   User as UserIcon,
   Database as DataSourceIcon,
+  Folder as FolderIcon,
+  FolderOpen as FolderOpenIcon,
 } from "lucide-react";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useAuth } from "../contexts/auth-context";
@@ -312,18 +314,25 @@ export function DashboardsExplorer() {
     setInfoTarget(node);
   }, []);
 
-  const getItemIcon = useCallback((node: ResourceTreeNode) => {
-    if (
-      node.id.includes(DASHBOARD_DATA_SOURCE_SEP) ||
-      node.id.includes(DASHBOARD_DATA_SOURCE_DIR_SEP)
-    ) {
-      return <DataSourceIcon size={16} strokeWidth={1.5} />;
-    }
-    if (node.access === "workspace") {
-      return <GlobeIcon size={16} strokeWidth={1.5} />;
-    }
-    return <LockIcon size={16} strokeWidth={1.5} />;
-  }, []);
+  const getItemIcon = useCallback(
+    (node: ResourceTreeNode, ctx?: { isExpanded: boolean }) => {
+      if (node.id.includes(DASHBOARD_DATA_SOURCE_SEP)) {
+        return <DataSourceIcon size={16} strokeWidth={1.5} />;
+      }
+      if (node.id.includes(DASHBOARD_DATA_SOURCE_DIR_SEP)) {
+        return ctx?.isExpanded ? (
+          <FolderOpenIcon size={16} strokeWidth={1.5} />
+        ) : (
+          <FolderIcon size={16} strokeWidth={1.5} />
+        );
+      }
+      if (node.access === "workspace") {
+        return <GlobeIcon size={16} strokeWidth={1.5} />;
+      }
+      return <LockIcon size={16} strokeWidth={1.5} />;
+    },
+    [],
+  );
 
   const withDataSourceNodes = useCallback(
     (nodes: ResourceTreeNode[]): ResourceTreeNode[] =>

--- a/app/src/components/DashboardsExplorer.tsx
+++ b/app/src/components/DashboardsExplorer.tsx
@@ -19,6 +19,7 @@ import {
   Lock as LockIcon,
   Globe as GlobeIcon,
   User as UserIcon,
+  Database as DataSourceIcon,
 } from "lucide-react";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useAuth } from "../contexts/auth-context";
@@ -30,13 +31,19 @@ import {
   useExplorerRevealStore,
   selectRevealFor,
 } from "../store/explorerRevealStore";
-import { focusDashboardTab } from "../dashboard-runtime/shell";
+import {
+  focusDashboardDataSourceTab,
+  focusDashboardTab,
+} from "../dashboard-runtime/shell";
+import { DASHBOARD_DATA_SOURCE_SEP } from "../lib/explorer-reveal";
 import type { Dashboard } from "../dashboard-runtime/types";
 import { computeDashboardStateHash } from "../utils/stateHash";
 import ResourceTree, { type ResourceTreeNode } from "./ResourceTree";
 import ExplorerShell from "./ExplorerShell";
 
 const EMPTY_TREE: ResourceTreeNode[] = [];
+const DATA_SOURCES_DIR = "__datasources";
+const DASHBOARD_DATA_SOURCE_DIR_SEP = "::dashboard-data-sources::";
 const NEW_DASHBOARD_TEMPLATE = {
   title: "Untitled Dashboard",
   dataSources: [],
@@ -86,6 +93,8 @@ export function DashboardsExplorer() {
   const resortItem = useDashboardTreeStore(s => s.resortItem);
   const createDashboard = useDashboardStore(s => s.createDashboard);
   const duplicateDashboard = useDashboardStore(s => s.duplicateDashboard);
+  const openDashboard = useDashboardStore(s => s.openDashboard);
+  const openDashboards = useDashboardStore(s => s.openDashboards);
 
   const dashboardExpandedFolders = useExplorerStore(
     s => s.dashboard.expandedFolders,
@@ -107,6 +116,9 @@ export function DashboardsExplorer() {
   );
   const [moveTarget, setMoveTarget] = useState<ResourceTreeNode | null>(null);
   const [infoTarget, setInfoTarget] = useState<ResourceTreeNode | null>(null);
+  const [loadingDashboards, setLoadingDashboards] = useState<
+    Record<string, boolean>
+  >({});
 
   useEffect(() => {
     if (workspaceId) {
@@ -137,6 +149,15 @@ export function DashboardsExplorer() {
 
   const handleItemClick = useCallback(
     (node: ResourceTreeNode) => {
+      if (node.id.includes(DASHBOARD_DATA_SOURCE_SEP)) {
+        const [dashboardId, dataSourceId] = node.id.split(
+          DASHBOARD_DATA_SOURCE_SEP,
+        );
+        focusDashboardDataSourceTab(dashboardId, dataSourceId, node.name);
+        return;
+      }
+      if (node.id.includes(DASHBOARD_DATA_SOURCE_DIR_SEP)) return;
+
       const existingTab = Object.values(tabs).find(
         (tab: any) =>
           tab.kind === "dashboard" && tab.metadata?.dashboardId === node.id,
@@ -160,11 +181,26 @@ export function DashboardsExplorer() {
     setDeleteTarget(node);
   }, []);
 
+  const isDashboardEntryId = useCallback(
+    (id: string) =>
+      [...myDashboards, ...workspaceDashboards].some(function visit(
+        node: ResourceTreeNode,
+      ): boolean {
+        if (node.id === id) return !node.isDirectory;
+        return node.children?.some(visit) ?? false;
+      }),
+    [myDashboards, workspaceDashboards],
+  );
+
   const handleDeleteConfirm = useCallback(async () => {
     if (!deleteTarget || !workspaceId) return;
-    await deleteItem(workspaceId, deleteTarget.id, deleteTarget.isDirectory);
+    await deleteItem(
+      workspaceId,
+      deleteTarget.id,
+      deleteTarget.isDirectory && !isDashboardEntryId(deleteTarget.id),
+    );
     setDeleteTarget(null);
-  }, [deleteTarget, workspaceId, deleteItem]);
+  }, [deleteTarget, workspaceId, deleteItem, isDashboardEntryId]);
 
   const handleDuplicate = useCallback(
     async (node: ResourceTreeNode) => {
@@ -217,6 +253,16 @@ export function DashboardsExplorer() {
   const handleMoveFolder = useCallback(
     (folderId: string, parentId: string | null, access?: string) => {
       if (!workspaceId) return;
+      const isDashboard = isDashboardEntryId(folderId);
+      if (isDashboard) {
+        moveItem(
+          workspaceId,
+          folderId,
+          parentId,
+          (access as "private" | "workspace") || undefined,
+        );
+        return;
+      }
       moveFolder(
         workspaceId,
         folderId,
@@ -224,15 +270,15 @@ export function DashboardsExplorer() {
         (access as "private" | "workspace") || undefined,
       );
     },
-    [workspaceId, moveFolder],
+    [workspaceId, isDashboardEntryId, moveItem, moveFolder],
   );
 
   const handleRenameItem = useCallback(
     (id: string, name: string, isDirectory: boolean) => {
       if (!workspaceId) return;
-      renameItem(workspaceId, id, name, isDirectory);
+      renameItem(workspaceId, id, name, isDirectory && !isDashboardEntryId(id));
     },
-    [workspaceId, renameItem],
+    [workspaceId, renameItem, isDashboardEntryId],
   );
 
   const handleResortItem = useCallback(
@@ -245,6 +291,12 @@ export function DashboardsExplorer() {
 
   const canManageItem = useCallback(
     (node: ResourceTreeNode) => {
+      if (
+        node.id.includes(DASHBOARD_DATA_SOURCE_SEP) ||
+        node.id.includes(DASHBOARD_DATA_SOURCE_DIR_SEP)
+      ) {
+        return false;
+      }
       if (isAdmin) return true;
       if (node.owner_id === user?.id) return true;
       return false;
@@ -261,11 +313,82 @@ export function DashboardsExplorer() {
   }, []);
 
   const getItemIcon = useCallback((node: ResourceTreeNode) => {
+    if (
+      node.id.includes(DASHBOARD_DATA_SOURCE_SEP) ||
+      node.id.includes(DASHBOARD_DATA_SOURCE_DIR_SEP)
+    ) {
+      return <DataSourceIcon size={16} strokeWidth={1.5} />;
+    }
     if (node.access === "workspace") {
       return <GlobeIcon size={16} strokeWidth={1.5} />;
     }
     return <LockIcon size={16} strokeWidth={1.5} />;
   }, []);
+
+  const withDataSourceNodes = useCallback(
+    (nodes: ResourceTreeNode[]): ResourceTreeNode[] =>
+      nodes.map(node => {
+        if (node.isDirectory) {
+          return {
+            ...node,
+            entityType: "dashboard-folder",
+            children: node.children ? withDataSourceNodes(node.children) : [],
+          };
+        }
+
+        const loaded = openDashboards[node.id];
+        return {
+          ...node,
+          isDirectory: true,
+          entityType: "dashboard",
+          children: loaded
+            ? [
+                {
+                  id: `${node.id}${DASHBOARD_DATA_SOURCE_DIR_SEP}${DATA_SOURCES_DIR}`,
+                  name: "Data sources",
+                  path: DATA_SOURCES_DIR,
+                  isDirectory: true,
+                  entityType: "data-source-folder",
+                  children: loaded.dataSources.map(dataSource => ({
+                    id: `${node.id}${DASHBOARD_DATA_SOURCE_SEP}${dataSource.id}`,
+                    name: dataSource.name,
+                    path: `data-source/${dataSource.id}`,
+                    isDirectory: false,
+                    entityType: "data-source",
+                  })),
+                },
+              ]
+            : undefined,
+        };
+      }),
+    [openDashboards],
+  );
+
+  const handleLoadChildren = useCallback(
+    async (node: ResourceTreeNode) => {
+      if (!workspaceId) return;
+      if (
+        node.id.includes(DASHBOARD_DATA_SOURCE_SEP) ||
+        node.id.includes(DASHBOARD_DATA_SOURCE_DIR_SEP) ||
+        node.entityType !== "dashboard" ||
+        openDashboards[node.id] ||
+        loadingDashboards[node.id]
+      ) {
+        return;
+      }
+      setLoadingDashboards(state => ({ ...state, [node.id]: true }));
+      try {
+        await openDashboard(workspaceId, node.id);
+      } finally {
+        setLoadingDashboards(state => {
+          const next = { ...state };
+          delete next[node.id];
+          return next;
+        });
+      }
+    },
+    [workspaceId, openDashboard, openDashboards, loadingDashboards],
+  );
 
   const sectionsDef = useMemo(
     () => [
@@ -273,7 +396,7 @@ export function DashboardsExplorer() {
         key: "my",
         label: "My Dashboards",
         icon: <UserIcon size={16} strokeWidth={1.5} />,
-        nodes: myDashboards as ResourceTreeNode[],
+        nodes: withDataSourceNodes(myDashboards as ResourceTreeNode[]),
         droppableId: "__section_my",
         defaultAccess: "private" as const,
       },
@@ -281,12 +404,45 @@ export function DashboardsExplorer() {
         key: "workspace",
         label: "Workspace",
         icon: <GlobeIcon size={16} strokeWidth={1.5} />,
-        nodes: workspaceDashboards as ResourceTreeNode[],
+        nodes: withDataSourceNodes(workspaceDashboards as ResourceTreeNode[]),
         droppableId: "__section_workspace",
         defaultAccess: "workspace" as const,
       },
     ],
-    [myDashboards, workspaceDashboards],
+    [myDashboards, workspaceDashboards, withDataSourceNodes],
+  );
+
+  const folderOnlyNodes = useCallback(function onlyFolders(
+    nodes: ResourceTreeNode[],
+  ): ResourceTreeNode[] {
+    return nodes
+      .filter(node => node.isDirectory)
+      .map(node => ({
+        ...node,
+        children: node.children ? onlyFolders(node.children) : [],
+      }));
+  }, []);
+
+  const pickerSectionsDef = useMemo(
+    () => [
+      {
+        key: "my",
+        label: "My Dashboards",
+        icon: <UserIcon size={16} strokeWidth={1.5} />,
+        nodes: folderOnlyNodes(myDashboards as ResourceTreeNode[]),
+        droppableId: "__section_my",
+        defaultAccess: "private" as const,
+      },
+      {
+        key: "workspace",
+        label: "Workspace",
+        icon: <GlobeIcon size={16} strokeWidth={1.5} />,
+        nodes: folderOnlyNodes(workspaceDashboards as ResourceTreeNode[]),
+        droppableId: "__section_workspace",
+        defaultAccess: "workspace" as const,
+      },
+    ],
+    [myDashboards, workspaceDashboards, folderOnlyNodes],
   );
 
   const activeDashboardTabId = (() => {
@@ -294,6 +450,9 @@ export function DashboardsExplorer() {
     const tab = tabs[activeTabId];
     if (tab?.kind === "dashboard" && tab.metadata?.dashboardId) {
       return tab.metadata.dashboardId as string;
+    }
+    if (tab?.kind === "dashboard-data-source") {
+      return `${tab.metadata?.dashboardId}${DASHBOARD_DATA_SOURCE_SEP}${tab.metadata?.dataSourceId}`;
     }
     return null;
   })();
@@ -339,7 +498,7 @@ export function DashboardsExplorer() {
       >
         {({ searchQuery }) => (
           <ResourceTree
-            sections={sectionsDef}
+            sections={pickerSectionsDef}
             mode="sidebar"
             searchQuery={searchQuery}
             activeItemId={activeDashboardTabId}
@@ -352,6 +511,9 @@ export function DashboardsExplorer() {
             enableDelete
             enableNewFolder
             onItemClick={handleItemClick}
+            shouldFolderClickActivate={node => node.entityType === "dashboard"}
+            onLoadChildren={handleLoadChildren}
+            isLoadingChildren={node => !!loadingDashboards[node.id]}
             onMoveItem={handleMoveItem}
             onMoveFolder={handleMoveFolder}
             onRenameItem={handleRenameItem}
@@ -376,12 +538,15 @@ export function DashboardsExplorer() {
       {/* Delete Confirmation Dialog */}
       <Dialog open={!!deleteTarget} onClose={() => setDeleteTarget(null)}>
         <DialogTitle>
-          Delete {deleteTarget?.isDirectory ? "Folder" : "Dashboard"}
+          Delete{" "}
+          {deleteTarget?.isDirectory && !isDashboardEntryId(deleteTarget.id)
+            ? "Folder"
+            : "Dashboard"}
         </DialogTitle>
         <DialogContent>
           <DialogContentText>
             Are you sure you want to delete &quot;{deleteTarget?.name}&quot;?
-            {deleteTarget?.isDirectory
+            {deleteTarget?.isDirectory && !isDashboardEntryId(deleteTarget.id)
               ? " All dashboards inside will be moved to the root level."
               : " This action cannot be undone."}
           </DialogContentText>
@@ -402,7 +567,10 @@ export function DashboardsExplorer() {
         fullWidth
       >
         <DialogTitle>
-          Move {moveTarget?.isDirectory ? "Folder" : "Dashboard"}
+          Move{" "}
+          {moveTarget?.isDirectory && !isDashboardEntryId(moveTarget.id)
+            ? "Folder"
+            : "Dashboard"}
         </DialogTitle>
         <DialogContent sx={{ p: 0, height: 320 }}>
           <ResourceTree
@@ -418,7 +586,10 @@ export function DashboardsExplorer() {
               if (!moveTarget || !workspaceId) return;
               const access =
                 sectionKey === "workspace" ? "workspace" : "private";
-              if (moveTarget.isDirectory) {
+              if (
+                moveTarget.isDirectory &&
+                !isDashboardEntryId(moveTarget.id)
+              ) {
                 moveFolder(workspaceId, moveTarget.id, folderId, access);
               } else {
                 moveItem(workspaceId, moveTarget.id, folderId, access);
@@ -481,7 +652,10 @@ function DashboardInfoDialog({
   return (
     <Dialog open={!!item} onClose={onClose} maxWidth="sm" fullWidth>
       <DialogTitle sx={{ pb: 1 }}>
-        {item?.isDirectory ? "Folder" : "Dashboard"} Information
+        {item?.isDirectory && item.entityType !== "dashboard"
+          ? "Folder"
+          : "Dashboard"}{" "}
+        Information
       </DialogTitle>
       <DialogContent sx={{ pt: 1 }}>
         <Stack spacing={2}>

--- a/app/src/components/DashboardsExplorer.tsx
+++ b/app/src/components/DashboardsExplorer.tsx
@@ -498,7 +498,7 @@ export function DashboardsExplorer() {
       >
         {({ searchQuery }) => (
           <ResourceTree
-            sections={pickerSectionsDef}
+            sections={sectionsDef}
             mode="sidebar"
             searchQuery={searchQuery}
             activeItemId={activeDashboardTabId}
@@ -574,7 +574,7 @@ export function DashboardsExplorer() {
         </DialogTitle>
         <DialogContent sx={{ p: 0, height: 320 }}>
           <ResourceTree
-            sections={sectionsDef}
+            sections={pickerSectionsDef}
             mode="picker"
             showFiles={false}
             getItemIcon={getItemIcon}

--- a/app/src/components/MaterializationScheduleControls.tsx
+++ b/app/src/components/MaterializationScheduleControls.tsx
@@ -1,0 +1,115 @@
+import {
+  Box,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Select,
+  Switch,
+  TextField,
+  Typography,
+} from "@mui/material";
+import {
+  describeMaterializationSchedule,
+  MATERIALIZATION_SCHEDULE_PRESETS,
+  type MaterializationScheduleValue,
+} from "../lib/materializationSchedule";
+
+function resolveSchedulePresetKey(cron: string | null | undefined): string {
+  const preset = MATERIALIZATION_SCHEDULE_PRESETS.find(
+    item => item.cron === cron,
+  );
+  return preset?.key ?? "custom";
+}
+
+export default function MaterializationScheduleControls({
+  value,
+  onChange,
+  disabled = false,
+  title = "Automatic materialization",
+  caption,
+}: {
+  value: MaterializationScheduleValue;
+  onChange: (value: MaterializationScheduleValue) => void;
+  disabled?: boolean;
+  title?: string;
+  caption?: string;
+}) {
+  const cron = value.cron ?? "0 0 * * *";
+  const presetKey = resolveSchedulePresetKey(value.cron);
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+      <FormControlLabel
+        control={
+          <Switch
+            checked={value.enabled}
+            onChange={e =>
+              onChange({
+                ...value,
+                enabled: e.target.checked,
+                cron: e.target.checked ? cron : null,
+                timezone: value.timezone || "UTC",
+              })
+            }
+            disabled={disabled}
+          />
+        }
+        label={title}
+      />
+      {caption && (
+        <Typography variant="caption" color="text.secondary" sx={{ mt: -1 }}>
+          {caption}
+        </Typography>
+      )}
+
+      {value.enabled && (
+        <>
+          <FormControl size="small" fullWidth disabled={disabled}>
+            <InputLabel>Materialization Schedule</InputLabel>
+            <Select
+              value={presetKey}
+              label="Materialization Schedule"
+              onChange={e => {
+                const nextPreset = e.target.value;
+                const preset = MATERIALIZATION_SCHEDULE_PRESETS.find(
+                  item => item.key === nextPreset,
+                );
+                onChange({
+                  ...value,
+                  enabled: true,
+                  cron: preset ? preset.cron : cron,
+                  timezone: value.timezone || "UTC",
+                });
+              }}
+            >
+              {MATERIALIZATION_SCHEDULE_PRESETS.map(preset => (
+                <MenuItem key={preset.key} value={preset.key}>
+                  {preset.label}
+                </MenuItem>
+              ))}
+              <MenuItem value="custom">Custom</MenuItem>
+            </Select>
+          </FormControl>
+
+          <TextField
+            label="Cron Expression"
+            value={cron}
+            onChange={e =>
+              onChange({
+                ...value,
+                enabled: true,
+                cron: e.target.value,
+                timezone: value.timezone || "UTC",
+              })
+            }
+            fullWidth
+            size="small"
+            disabled={disabled}
+            helperText={describeMaterializationSchedule(value.enabled, cron)}
+          />
+        </>
+      )}
+    </Box>
+  );
+}

--- a/app/src/components/ResourceTree.tsx
+++ b/app/src/components/ResourceTree.tsx
@@ -81,6 +81,7 @@ export interface ResourceTreeNode {
   name: string;
   path: string;
   isDirectory: boolean;
+  entityType?: string;
   children?: ResourceTreeNode[];
   access?: "private" | "workspace";
   owner_id?: string;
@@ -821,7 +822,7 @@ function ResourceTreeInner(
         event.key.toLowerCase() === "d" &&
         focusItem &&
         enableDuplicate &&
-        !focusItem.isDirectory
+        (!focusItem.isDirectory || focusItem.entityType === "dashboard")
       ) {
         event.preventDefault();
         onDuplicateItem?.(focusItem);
@@ -1609,31 +1610,35 @@ function ResourceTreeInner(
                   Rename
                 </MenuItem>
               ),
-              enableDuplicate && !item.isDirectory && (
-                <MenuItem
-                  key="duplicate"
-                  onClick={() => {
-                    setContextMenu(null);
-                    onDuplicateItem?.(item);
-                  }}
-                >
-                  <Copy size={14} style={{ marginRight: 8 }} />
-                  Duplicate
-                </MenuItem>
-              ),
-              enableNewFolder && item.isDirectory && canManage && (
-                <MenuItem
-                  key="subfolder"
-                  onClick={async () => {
-                    setContextMenu(null);
-                    onExpandFolder(getExpansionKey(item));
-                    await triggerCreateFolder(item.id, item.access);
-                  }}
-                >
-                  <FolderPlus size={14} style={{ marginRight: 8 }} />
-                  New Subfolder
-                </MenuItem>
-              ),
+              enableDuplicate &&
+                (!item.isDirectory || item.entityType === "dashboard") && (
+                  <MenuItem
+                    key="duplicate"
+                    onClick={() => {
+                      setContextMenu(null);
+                      onDuplicateItem?.(item);
+                    }}
+                  >
+                    <Copy size={14} style={{ marginRight: 8 }} />
+                    Duplicate
+                  </MenuItem>
+                ),
+              enableNewFolder &&
+                item.isDirectory &&
+                item.entityType !== "dashboard" &&
+                canManage && (
+                  <MenuItem
+                    key="subfolder"
+                    onClick={async () => {
+                      setContextMenu(null);
+                      onExpandFolder(getExpansionKey(item));
+                      await triggerCreateFolder(item.id, item.access);
+                    }}
+                  >
+                    <FolderPlus size={14} style={{ marginRight: 8 }} />
+                    New Subfolder
+                  </MenuItem>
+                ),
               enableMove && canManage && onMoveRequest && (
                 <MenuItem
                   key="move"

--- a/app/src/components/dashboard/DashboardSettingsDialog.tsx
+++ b/app/src/components/dashboard/DashboardSettingsDialog.tsx
@@ -21,45 +21,13 @@ import { Copy, RotateCcw, Trash2 } from "lucide-react";
 import { useDashboardStore } from "../../store/dashboardStore";
 import { useWorkspace } from "../../contexts/workspace-context";
 import { useConsoleStore } from "../../store/consoleStore";
+import MaterializationScheduleControls from "../MaterializationScheduleControls";
+import type { MaterializationScheduleValue } from "../../lib/materializationSchedule";
 
 interface DashboardSettingsDialogProps {
   open: boolean;
   onClose: () => void;
   dashboardId?: string;
-}
-
-const MATERIALIZATION_SCHEDULE_PRESETS = [
-  { key: "hourly", label: "Every hour", cron: "0 * * * *" },
-  { key: "every-6-hours", label: "Every 6 hours", cron: "0 */6 * * *" },
-  { key: "daily", label: "Daily", cron: "0 0 * * *" },
-  { key: "weekly", label: "Weekly", cron: "0 0 * * 0" },
-] as const;
-
-function resolveSchedulePresetKey(cron: string | null | undefined): string {
-  const preset = MATERIALIZATION_SCHEDULE_PRESETS.find(
-    item => item.cron === cron,
-  );
-  return preset?.key ?? "custom";
-}
-
-function describeMaterializationSchedule(
-  enabled: boolean,
-  cron: string,
-): string {
-  if (!enabled) {
-    return "Automatic materialization is disabled. Refresh manually when needed.";
-  }
-
-  const preset = MATERIALIZATION_SCHEDULE_PRESETS.find(
-    item => item.cron === cron,
-  );
-  if (preset) {
-    return `${preset.label} in UTC.`;
-  }
-
-  return cron.trim()
-    ? `Runs on cron "${cron}" in UTC.`
-    : "Enter a cron expression in UTC.";
 }
 
 export default function DashboardSettingsDialog({
@@ -78,9 +46,12 @@ export default function DashboardSettingsDialog({
   const [access, setAccess] = useState<"private" | "workspace">("private");
   const [gridColumns, setGridColumns] = useState(12);
   const [rowHeight, setRowHeight] = useState(80);
-  const [materializationEnabled, setMaterializationEnabled] = useState(true);
-  const [materializationPreset, setMaterializationPreset] = useState("daily");
-  const [materializationCron, setMaterializationCron] = useState("0 0 * * *");
+  const [materializationSchedule, setMaterializationSchedule] =
+    useState<MaterializationScheduleValue>({
+      enabled: true,
+      cron: "0 0 * * *",
+      timezone: "UTC",
+    });
   const [crossFilterEnabled, setCrossFilterEnabled] = useState(false);
   const [crossFilterResolution, setCrossFilterResolution] = useState<
     "intersect" | "union"
@@ -103,9 +74,12 @@ export default function DashboardSettingsDialog({
         cron: "0 0 * * *",
         timezone: "UTC",
       };
-      setMaterializationEnabled(schedule.enabled);
-      setMaterializationCron(schedule.cron ?? "0 0 * * *");
-      setMaterializationPreset(resolveSchedulePresetKey(schedule.cron));
+      setMaterializationSchedule({
+        enabled: schedule.enabled,
+        cron: schedule.cron,
+        timezone: schedule.timezone ?? "UTC",
+        dataFreshnessTtlMs: schedule.dataFreshnessTtlMs ?? null,
+      });
       setCrossFilterEnabled(dashboard.crossFilter.enabled);
       setCrossFilterResolution(dashboard.crossFilter.resolution);
       setCrossFilterEngine(dashboard.crossFilter.engine ?? "mosaic");
@@ -123,9 +97,13 @@ export default function DashboardSettingsDialog({
         access,
         layout: { columns: gridColumns, rowHeight },
         materializationSchedule: {
-          enabled: materializationEnabled,
-          cron: materializationEnabled ? materializationCron.trim() : null,
-          timezone: "UTC",
+          enabled: materializationSchedule.enabled,
+          cron: materializationSchedule.enabled
+            ? materializationSchedule.cron?.trim() || null
+            : null,
+          timezone: materializationSchedule.timezone ?? "UTC",
+          dataFreshnessTtlMs:
+            materializationSchedule.dataFreshnessTtlMs ?? null,
         },
         crossFilter: {
           enabled: crossFilterEnabled,
@@ -141,9 +119,13 @@ export default function DashboardSettingsDialog({
           access,
           layout: { columns: gridColumns, rowHeight },
           materializationSchedule: {
-            enabled: materializationEnabled,
-            cron: materializationEnabled ? materializationCron.trim() : null,
-            timezone: "UTC",
+            enabled: materializationSchedule.enabled,
+            cron: materializationSchedule.enabled
+              ? materializationSchedule.cron?.trim() || null
+              : null,
+            timezone: materializationSchedule.timezone ?? "UTC",
+            dataFreshnessTtlMs:
+              materializationSchedule.dataFreshnessTtlMs ?? null,
           },
           crossFilter: {
             enabled: crossFilterEnabled,
@@ -278,60 +260,13 @@ export default function DashboardSettingsDialog({
           </Box>
         )}
 
-        <FormControlLabel
-          control={
-            <Switch
-              checked={materializationEnabled}
-              onChange={e => setMaterializationEnabled(e.target.checked)}
-              disabled={isReadOnly}
-            />
-          }
-          label="Automatic materialization"
+        <MaterializationScheduleControls
+          value={materializationSchedule}
+          onChange={setMaterializationSchedule}
+          disabled={isReadOnly}
+          title="Automatic materialization"
+          caption="Applies to every data source in this dashboard."
         />
-
-        {materializationEnabled && (
-          <>
-            <FormControl size="small" fullWidth>
-              <InputLabel>Materialization Schedule</InputLabel>
-              <Select
-                value={materializationPreset}
-                label="Materialization Schedule"
-                onChange={e => {
-                  const nextPreset = e.target.value;
-                  setMaterializationPreset(nextPreset);
-                  const preset = MATERIALIZATION_SCHEDULE_PRESETS.find(
-                    item => item.key === nextPreset,
-                  );
-                  if (preset) {
-                    setMaterializationCron(preset.cron);
-                  }
-                }}
-              >
-                {MATERIALIZATION_SCHEDULE_PRESETS.map(preset => (
-                  <MenuItem key={preset.key} value={preset.key}>
-                    {preset.label}
-                  </MenuItem>
-                ))}
-                <MenuItem value="custom">Custom</MenuItem>
-              </Select>
-            </FormControl>
-
-            <TextField
-              label="Cron Expression"
-              value={materializationCron}
-              onChange={e => {
-                setMaterializationPreset("custom");
-                setMaterializationCron(e.target.value);
-              }}
-              fullWidth
-              size="small"
-              helperText={describeMaterializationSchedule(
-                materializationEnabled,
-                materializationCron,
-              )}
-            />
-          </>
-        )}
 
         <FormControlLabel
           control={

--- a/app/src/components/public/PublicAppViewer.tsx
+++ b/app/src/components/public/PublicAppViewer.tsx
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Box, CircularProgress, Typography, Alert } from "@mui/material";
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Typography,
+} from "@mui/material";
+import { RefreshCw } from "lucide-react";
 import { useTheme } from "../../contexts/ThemeContext";
 import { buildPreviewHtml, PREVIEW_MESSAGE } from "../../app-runtime/preview";
 import {
@@ -47,6 +54,7 @@ export interface PublicAppContent {
 interface Props {
   token: string;
   content: PublicAppContent;
+  reloadContent: () => Promise<PublicAppContent | null>;
 }
 
 /** Adapt a public binding to the shape the app DuckDB loader expects. */
@@ -69,10 +77,26 @@ function toLoadableBinding(
   } as AppDataBinding;
 }
 
-export default function PublicAppViewer({ token, content }: Props) {
+function latestMaterializedAt(content: PublicAppContent): string | null {
+  const timestamps = content.dataBindings
+    .map(binding => binding.materializedAt)
+    .filter((value): value is string => !!value)
+    .sort();
+  return timestamps[timestamps.length - 1] ?? null;
+}
+
+export default function PublicAppViewer({
+  token,
+  content,
+  reloadContent,
+}: Props) {
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const [booting, setBooting] = useState(true);
   const [previewError, setPreviewError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [refreshNote, setRefreshNote] = useState<string | null>(null);
+  const contentRef = useRef(content);
+  contentRef.current = content;
 
   // Anonymous visitors have no saved theme preference, so the ThemeProvider
   // default ("system") makes effectiveMode track the OS preference — exactly
@@ -274,6 +298,53 @@ export default function PublicAppViewer({ token, content }: Props) {
     [content],
   );
 
+  const hasMaterializedBindings = content.dataBindings.some(
+    binding => binding.materialization === "parquet",
+  );
+
+  const handleRefresh = async () => {
+    if (!hasMaterializedBindings) return;
+    setRefreshing(true);
+    setRefreshNote(null);
+    try {
+      const res = await fetch(`/api/share/${token}/refresh`, {
+        method: "POST",
+        credentials: "include",
+      });
+      const json = await res.json().catch(() => null);
+      if (res.status === 429) {
+        const retryMin = Math.ceil((json?.retryAfterMs ?? 60000) / 60000);
+        setRefreshNote(
+          `Data was refreshed recently — try again in ~${retryMin} min.`,
+        );
+        return;
+      }
+      if (!res.ok || !json?.success) {
+        throw new Error(json?.error || "Failed to refresh");
+      }
+
+      setRefreshNote("Refreshing data…");
+      const before = latestMaterializedAt(contentRef.current);
+      for (let attempt = 0; attempt < 15; attempt++) {
+        await new Promise(resolve => setTimeout(resolve, 8000));
+        const fresh = await reloadContent();
+        if (fresh && latestMaterializedAt(fresh) !== before) {
+          setRefreshNote(null);
+          return;
+        }
+      }
+      setRefreshNote(
+        "Refresh is still running. Reload in a moment to see the latest snapshot.",
+      );
+    } catch (error) {
+      setRefreshNote(
+        error instanceof Error ? error.message : "Failed to refresh data.",
+      );
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
   return (
     <Box sx={{ height: "100vh", display: "flex", flexDirection: "column" }}>
       <Box
@@ -293,6 +364,27 @@ export default function PublicAppViewer({ token, content }: Props) {
         <Typography variant="caption" color="text.secondary">
           Shared read-only view
         </Typography>
+        <Box sx={{ flex: 1 }} />
+        {refreshNote && (
+          <Typography variant="caption" color="text.secondary">
+            {refreshNote}
+          </Typography>
+        )}
+        <Button
+          size="small"
+          variant="outlined"
+          startIcon={
+            refreshing ? (
+              <CircularProgress size={14} />
+            ) : (
+              <RefreshCw size={14} />
+            )
+          }
+          onClick={() => void handleRefresh()}
+          disabled={!hasMaterializedBindings || refreshing}
+        >
+          {refreshing ? "Refreshing…" : "Refresh data"}
+        </Button>
       </Box>
 
       {previewError && (

--- a/app/src/lib/explorer-reveal.test.ts
+++ b/app/src/lib/explorer-reveal.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   APP_BINDING_SEP,
   APP_FILE_SEP,
+  DASHBOARD_DATA_SOURCE_SEP,
   tabRevealTarget,
 } from "./explorer-reveal";
 import type { ConsoleTab } from "../store/lib/types";
@@ -31,7 +32,7 @@ describe("tabRevealTarget", () => {
     });
   });
 
-  it("maps dashboards (and their data sources) to the dashboard row", () => {
+  it("maps dashboards and dashboard data sources to dashboard explorer rows", () => {
     expect(
       tabRevealTarget(
         makeTab({ kind: "dashboard", metadata: { dashboardId: "d1" } }),
@@ -44,7 +45,10 @@ describe("tabRevealTarget", () => {
           metadata: { dashboardId: "d1", dataSourceId: "ds1" },
         }),
       ),
-    ).toEqual({ explorer: "dashboards", nodeId: "d1" });
+    ).toEqual({
+      explorer: "dashboards",
+      nodeId: `d1${DASHBOARD_DATA_SOURCE_SEP}ds1`,
+    });
   });
 
   it("maps apps, app files and bindings using the shared separators", () => {

--- a/app/src/lib/explorer-reveal.ts
+++ b/app/src/lib/explorer-reveal.ts
@@ -20,6 +20,7 @@ import type { ConsoleTab, TabKind } from "../store/lib/types";
 export const APP_FILE_SEP = "::file::";
 export const APP_DIR_SEP = "::dir::";
 export const APP_BINDING_SEP = "::binding::";
+export const DASHBOARD_DATA_SOURCE_SEP = "::dashboard-data-source::";
 
 // dbt (Transforms) ResourceTree node-id encoding (kept in sync with
 // DbtExplorer, which imports these). Project node: "<projectId>";
@@ -68,9 +69,14 @@ export function tabRevealTarget(
       return id ? { explorer: "dashboards", nodeId: id } : null;
     }
     case "dashboard-data-source": {
-      // Data-source tabs live under their dashboard — reveal the dashboard row.
-      const id = meta.dashboardId as string | undefined;
-      return id ? { explorer: "dashboards", nodeId: id } : null;
+      const dashboardId = meta.dashboardId as string | undefined;
+      const dataSourceId = meta.dataSourceId as string | undefined;
+      return dashboardId && dataSourceId
+        ? {
+            explorer: "dashboards",
+            nodeId: `${dashboardId}${DASHBOARD_DATA_SOURCE_SEP}${dataSourceId}`,
+          }
+        : null;
     }
     case "app": {
       const appId = meta.appId as string | undefined;

--- a/app/src/lib/materializationSchedule.ts
+++ b/app/src/lib/materializationSchedule.ts
@@ -1,0 +1,43 @@
+export interface MaterializationScheduleValue {
+  enabled: boolean;
+  cron: string | null;
+  timezone?: string;
+  dataFreshnessTtlMs?: number | null;
+}
+
+export const MATERIALIZATION_SCHEDULE_PRESETS = [
+  { key: "hourly", label: "Every hour", cron: "0 * * * *" },
+  { key: "every-6-hours", label: "Every 6 hours", cron: "0 */6 * * *" },
+  { key: "daily", label: "Daily", cron: "0 0 * * *" },
+  { key: "weekly", label: "Weekly", cron: "0 0 * * 0" },
+] as const;
+
+export function defaultMaterializationSchedule(
+  enabled = false,
+): MaterializationScheduleValue {
+  return {
+    enabled,
+    cron: enabled ? "0 0 * * *" : null,
+    timezone: "UTC",
+  };
+}
+
+export function describeMaterializationSchedule(
+  enabled: boolean,
+  cron: string | null | undefined,
+): string {
+  if (!enabled) {
+    return "Automatic materialization is disabled. Refresh manually when needed.";
+  }
+
+  const preset = MATERIALIZATION_SCHEDULE_PRESETS.find(
+    item => item.cron === cron,
+  );
+  if (preset) {
+    return `${preset.label} in UTC.`;
+  }
+
+  return cron?.trim()
+    ? `Runs on cron "${cron}" in UTC.`
+    : "Enter a cron expression in UTC.";
+}

--- a/app/src/lib/tab-routing.test.ts
+++ b/app/src/lib/tab-routing.test.ts
@@ -36,7 +36,7 @@ const FIXTURES: Record<NonNullable<TabKind>, ConsoleTab> = {
   }),
   "dashboard-data-source": baseTab({
     kind: "dashboard-data-source",
-    metadata: { dashboardId: "dash-1", dataSourceId: "ds-1" },
+    metadata: { dashboardId: "dash-1", dataSourceId: "ds_1" },
   }),
   "table-data": baseTab({
     kind: "table-data",
@@ -51,7 +51,7 @@ const FIXTURES: Record<NonNullable<TabKind>, ConsoleTab> = {
   }),
   "app-binding": baseTab({
     kind: "app-binding",
-    metadata: { appId: "app-1", bindingId: "binding-1" },
+    metadata: { appId: "app-1", bindingId: "binding_1" },
   }),
   plan: baseTab({ kind: "plan", metadata: { chatId: "chat-1" } }),
   settings: baseTab({ kind: "settings", settingsSection: "models" }),

--- a/app/src/lib/tab-routing.ts
+++ b/app/src/lib/tab-routing.ts
@@ -39,11 +39,11 @@ export const TAB_DEEP_LINK_PATTERNS = {
   connectors: /^\/cx\/([a-zA-Z0-9-]+)/,
   "flow-editor": /^\/f\/([a-zA-Z0-9-]+)/,
   dashboard: /^\/d\/([a-zA-Z0-9-]+)\/?$/,
-  "dashboard-data-source": /^\/d\/([a-zA-Z0-9-]+)\/data\/([a-zA-Z0-9-]+)/,
+  "dashboard-data-source": /^\/d\/([a-zA-Z0-9-]+)\/data\/([a-zA-Z0-9_-]+)/,
   "table-data": /^\/t\/([a-zA-Z0-9-]+)\/([^/]+)\/([^/]+)\/?$/,
   app: /^\/a\/([a-zA-Z0-9-]+)\/?$/,
   "app-file": /^\/a\/([a-zA-Z0-9-]+)\/file\/(.+)$/,
-  "app-binding": /^\/a\/([a-zA-Z0-9-]+)\/data\/([a-zA-Z0-9-]+)/,
+  "app-binding": /^\/a\/([a-zA-Z0-9-]+)\/data\/([a-zA-Z0-9_-]+)/,
   plan: /^\/p\/([a-zA-Z0-9-]+)/,
   settings: /^\/settings\/([a-z-]+)$/,
   // Legacy tab kind superseded by the settings "members" section.

--- a/app/src/pages/PublicSharePage.tsx
+++ b/app/src/pages/PublicSharePage.tsx
@@ -230,5 +230,18 @@ export default function PublicSharePage() {
     );
   }
 
-  return <PublicAppViewer token={token} content={content} />;
+  return (
+    <PublicAppViewer
+      token={token}
+      content={content}
+      reloadContent={async () => {
+        const next = await loadContent();
+        if (next && next.type === "app") {
+          setContent(next);
+          return next;
+        }
+        return null;
+      }}
+    />
+  );
 }

--- a/docs/src/openapi/mako-api.json
+++ b/docs/src/openapi/mako-api.json
@@ -19455,6 +19455,524 @@
         "operationId": "get_api_workspaces_workspaceId_apps_id_public_share_password"
       }
     },
+    "/api/workspaces/{workspaceId}/data-sources/{resourceType}/{resourceId}": {
+      "get": {
+        "tags": [
+          "Data Sources"
+        ],
+        "summary": "List data sources for a dashboard or app",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "dashboard",
+                "app"
+              ]
+            },
+            "required": true,
+            "name": "resourceType",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "resourceId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get_api_workspaces_workspaceId_data_sources_resourceType_resourceId"
+      }
+    },
+    "/api/workspaces/{workspaceId}/data-sources/{resourceType}/{resourceId}/{dataSourceId}": {
+      "get": {
+        "tags": [
+          "Data Sources"
+        ],
+        "summary": "Get one dashboard/app data source",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "dashboard",
+                "app"
+              ]
+            },
+            "required": true,
+            "name": "resourceType",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "resourceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "dataSourceId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get_api_workspaces_workspaceId_data_sources_resourceType_resourceId_dataSourceId"
+      }
+    },
+    "/api/workspaces/{workspaceId}/data-sources/{resourceType}/{resourceId}/{dataSourceId}/settings": {
+      "patch": {
+        "tags": [
+          "Data Sources"
+        ],
+        "summary": "Update materialization settings for a data source",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "dashboard",
+                "app"
+              ]
+            },
+            "required": true,
+            "name": "resourceType",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "resourceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "dataSourceId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "materialization": {
+                    "type": "string",
+                    "enum": [
+                      "live",
+                      "parquet"
+                    ]
+                  },
+                  "schedule": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "cron": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "timezone": {
+                        "type": "string"
+                      },
+                      "dataFreshnessTtlMs": {
+                        "type": [
+                          "number",
+                          "null"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "enabled",
+                      "cron"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "patch_api_workspaces_workspaceId_data_sources_resourceType_resourceId_dataSourceId_settings"
+      }
+    },
+    "/api/workspaces/{workspaceId}/data-sources/{resourceType}/{resourceId}/refresh": {
+      "post": {
+        "tags": [
+          "Data Sources"
+        ],
+        "summary": "Refresh all materialized data sources for a dashboard or app",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "dashboard",
+                "app"
+              ]
+            },
+            "required": true,
+            "name": "resourceType",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "resourceId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "post_api_workspaces_workspaceId_data_sources_resourceType_resourceId_refresh"
+      }
+    },
+    "/api/workspaces/{workspaceId}/data-sources/{resourceType}/{resourceId}/{dataSourceId}/refresh": {
+      "post": {
+        "tags": [
+          "Data Sources"
+        ],
+        "summary": "Refresh one materialized data source for a dashboard or app",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "dashboard",
+                "app"
+              ]
+            },
+            "required": true,
+            "name": "resourceType",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "resourceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "dataSourceId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "post_api_workspaces_workspaceId_data_sources_resourceType_resourceId_dataSourceId_refresh"
+      }
+    },
     "/api/workspaces/{workspaceId}/dashboards/{dashboardId}/materialization": {
       "get": {
         "tags": [
@@ -20419,7 +20937,7 @@
         "tags": [
           "Public Shares"
         ],
-        "summary": "Refresh a dashboard share snapshot",
+        "summary": "Refresh a public share snapshot",
         "security": [],
         "parameters": [
           {

--- a/packages/schemas/src/app.schema.ts
+++ b/packages/schemas/src/app.schema.ts
@@ -50,6 +50,16 @@ export type AppBindingMaterialization = z.infer<
   typeof AppBindingMaterializationSchema
 >;
 
+export const AppBindingMaterializationScheduleSchema = z.object({
+  enabled: z.boolean(),
+  cron: z.string().nullable(),
+  timezone: z.string().optional(),
+  dataFreshnessTtlMs: z.number().nullable().optional(),
+});
+export type AppBindingMaterializationSchedule = z.infer<
+  typeof AppBindingMaterializationScheduleSchema
+>;
+
 export const AppBindingParquetStatusSchema = z.enum([
   "missing",
   "queued",
@@ -117,6 +127,7 @@ export const AppDataBindingSchema = z.object({
   databaseId: z.string().optional().describe("Optional sub-database id"),
   databaseName: z.string().optional().describe("Optional database name"),
   materialization: AppBindingMaterializationSchema.default("live"),
+  materializationSchedule: AppBindingMaterializationScheduleSchema.optional(),
   cache: AppBindingCacheSchema.optional(),
 });
 export type AppDataBinding = z.infer<typeof AppDataBindingSchema>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add a unified workspace data-source API for dashboards and apps.
- Show dashboard data sources in the dashboard explorer tree and align app explorer data-source folders.
- Move materialization schedule controls into data-source editor surfaces.
- Allow public app shares to refresh materialized parquet data sources with cooldown protection.
- Fix dashboard/app data-source deep links to accept underscore ids.
- Rebase onto latest `master` and resolve the `PublicAppViewer` conflict while preserving public app location sync and refresh controls.
- Sync generated OpenAPI spec and frontend API types for the new data-source routes.

### Walkthrough
[dashboard_data_sources_folder_ui_stable.mp4](https://cursor.com/agents/bc-a11c7e96-bc90-4a73-9f86-a75c0fa0ff20/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_data_sources_folder_ui_stable.mp4)
[dashboard_data_source_schedule_popover.mp4](https://cursor.com/agents/bc-a11c7e96-bc90-4a73-9f86-a75c0fa0ff20/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_data_source_schedule_popover.mp4)
[unified_data_sources_final_walkthrough.mp4](https://cursor.com/agents/bc-a11c7e96-bc90-4a73-9f86-a75c0fa0ff20/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Funified_data_sources_final_walkthrough.mp4)

### Testing
- ✅ `pnpm run openapi:sync`
- ✅ `pnpm --filter @mako/schemas run build`
- ✅ `pnpm --filter app run typecheck`
- ✅ `pnpm --filter app run lint`
- ✅ `pnpm --filter api run lint`
- ✅ `pnpm --filter api run build`
- ✅ `cd app && pnpm exec vitest run src/lib/tab-routing.test.ts src/lib/explorer-reveal.test.ts src/components/resource-tree/utils.test.ts`
- ✅ Manual UI smoke: dashboard `Data sources` folder collapses/expands like Apps, source row remains nested under the folder, schedule popovers open, and public app refresh button responds.
- ⚠️ `pnpm --filter app run test:unit -- src/lib/explorer-reveal.test.ts` ran the full app suite and hit an unrelated pre-existing `src/store/dbtStore.test.ts` failure while `src/lib/explorer-reveal.test.ts` passed.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a11c7e96-bc90-4a73-9f86-a75c0fa0ff20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a11c7e96-bc90-4a73-9f86-a75c0fa0ff20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

