### PR TITLE
docs(agent): teach the apps agent the URL-state SDK (useLocation / useSearchParams / navigate)

### DIFF
--- a/api/src/agent-skills/apps/SKILL.md
+++ b/api/src/agent-skills/apps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: apps
-description: Load when building, editing, or debugging Mako React apps — app files, npm dependencies, data bindings, the @mako/app-sdk hooks (useQuery / useDuckDB), materialized Parquet/DuckDB bindings, and the live preview runtime.
+description: Load when building, editing, or debugging Mako React apps — app files, npm dependencies, data bindings, the @mako/app-sdk hooks (useQuery / useDuckDB / useLocation / useSearchParams / navigate), URL state and shareable deep links, materialized Parquet/DuckDB bindings, and the live preview runtime.
 entities:
   - app
   - apps
@@ -11,6 +11,15 @@ entities:
   - app-sdk
   - usequery
   - useduckdb
+  - uselocation
+  - usesearchparams
+  - navigate
+  - url state
+  - query params
+  - routing
+  - tabs
+  - deep link
+  - share link
   - parquet
   - preview
   - theme
@@ -115,6 +124,42 @@ const { theme } = useTheme(); // "light" | "dark", updates live on toggle
 
 Brand colors are fine for accents — just keep backgrounds, text, and borders on the
 tokens so both modes stay readable.
+
+### URL state & routing (shareable, reload-safe views)
+
+Persist view state — the open tab, active filters, a selected record, a sub-page —
+in the URL so a reload restores it and the link is shareable. The runtime projects
+the app's location onto the host's real URL in **both** contexts: embedded in Mako
+(`/a/:appId`) and the public share view (`/share/:token`). App query params stay
+readable on the address bar; the app's pathname rides in a reserved `_path` param.
+
+Use the injected hooks — do **not** reach for `window.history`, `window.location`,
+the URL hash, or a `react-router` `BrowserRouter`. The app runs in a sandboxed
+`about:srcdoc` iframe, so those can't write the real address bar and won't survive a
+reload or share; only these hooks bridge to the host:
+
+```tsx
+import { useLocation, useSearchParams, navigate } from "@mako/app-sdk";
+
+// Read the current location (re-renders on every change, incl. back/forward).
+const loc = useLocation(); // { pathname, search, hash, href, searchParams }
+
+// React-Router-style query params for tabs / filters.
+const [params, setParams] = useSearchParams();
+const tab = params.get("tab") ?? "overview";
+// Pass { replace: true } for high-frequency updates (typing in a filter, sliders)
+// so back/forward isn't flooded; the default pushes a new history entry.
+setParams(new URLSearchParams({ tab: "customers", c: "ES,FR" }), { replace: true });
+
+// Path-style routing for distinct views / detail pages.
+navigate("/customers/42");          // push a new entry (Back returns to the list)
+navigate("/", { replace: true });   // replace the current entry
+```
+
+Guidance: reach for this whenever the app has tabs, filters, or master→detail
+navigation a user would expect to bookmark or share. Use distinct **paths** for
+separate views (`/`, `/customers/42`) and **query params** for filters/sort within a
+view. Hashes (`#…`) are not carried across the bridge — keep state in the path/query.
 
 ### Constraints
 

--- a/packages/schemas/src/app-scaffold.ts
+++ b/packages/schemas/src/app-scaffold.ts
@@ -16,6 +16,12 @@ const APP_TSX = `// Read workspace data with the injected SDK once a data bindin
 //
 // Create bindings from the chat ("bind the revenue query") or the data panel.
 //
+// Keep view state (tabs, filters, selected record) in the URL so reloads
+// restore it and links are shareable — use the SDK, not window.history:
+//
+//   import { useSearchParams, navigate } from "@mako/app-sdk";
+//   const [params, setParams] = useSearchParams();
+//
 // Theming: the runtime provides CSS variables (--background, --foreground,
 // --card, --border, --muted-foreground, --primary, --chart-1..5, --radius, …)
 // that switch with light/dark automatically — use var(--token) instead of
@@ -86,6 +92,28 @@ import { useTheme } from "@mako/app-sdk";
 
 const { theme } = useTheme(); // "light" | "dark"
 \`\`\`
+
+## URL state (shareable, reload-safe)
+
+Keep view state — the open tab, active filters, a selected record — in the URL
+so reloads restore it and links are shareable. This works both inside Mako
+(\`/a/:appId\`) and in the public share view (\`/share/:token\`). Use the SDK
+hooks, not \`window.history\`/\`location\` (the app is sandboxed and those won't
+persist or share):
+
+\`\`\`tsx
+import { useLocation, useSearchParams, navigate } from "@mako/app-sdk";
+
+const loc = useLocation();              // { pathname, search, hash, href, searchParams }
+const [params, setParams] = useSearchParams();
+const tab = params.get("tab") ?? "overview";
+
+setParams({ tab: "customers" }, { replace: true }); // filters within a view
+navigate("/customers/42");                            // distinct view / detail page
+\`\`\`
+
+Use \`{ replace: true }\` for high-frequency updates (filter typing) so
+back/forward isn't flooded; the default pushes a new history entry.
 `;
 
 export const DEFAULT_APP_SCAFFOLD_FILES: AppFile[] = [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The Mako app builder is **AI-driven**, so the URL-state SDK hooks are only useful if the agent knows they exist. Per `.cursor/rules/35-agent-prompts.mdc`, this durable guidance belongs in the on-demand **system skill** and the **scaffold**, not in always-on base-prompt literals (keeps the prompt-size budget intact).

## Changes

- **`api/src/agent-skills/apps/SKILL.md`** — adds a `URL state & routing` section: how to keep view state (tabs, filters, selected record) in the URL so reloads restore it and links are shareable, working both embedded (`/a/:appId`) and in the public share view (`/share/:token`); use `useLocation` / `useSearchParams` / `navigate` and **not** `window.history` / `location` / hash / `BrowserRouter` (the app is sandboxed `about:srcdoc`). Also expands the frontmatter `description` + `entities` so retrieval triggers on `url state`, `query params`, `routing`, `tabs`, `deep link`, `navigate`, etc.
- **`packages/schemas/src/app-scaffold.ts`** — surfaces the routing hooks in every new app's entry-file comment and README.

## Relationship to the runtime PR

This documents the SDK shipped in **#568** (the `app-runtime` implementation + `preview.test.ts` guard). These docs are standalone and green on `master`; #568 carries the runtime + its test guard.

## Testing

- `pnpm --filter @mako/schemas run build` ✅
- Loaded the `apps` system skill (`getSystemSkillFullText("apps")`) and confirmed the new routing content + triggers resolve ✅

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73c40c54-7d80-44bc-9fb7-1c3989569d4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73c40c54-7d80-44bc-9fb7-1c3989569d4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

