### PR TITLE
feat(connectors): add PandaDoc CDC connector

### DIFF
--- a/api/src/connectors/base/BaseConnector.ts
+++ b/api/src/connectors/base/BaseConnector.ts
@@ -73,6 +73,12 @@ export interface WebhookHandlerOptions {
   payload: any;
   headers: Record<string, string | string[] | undefined>;
   secret?: string;
+  /**
+   * Inbound request query parameters. Some providers (e.g. PandaDoc) deliver
+   * their HMAC signature as a query parameter rather than a header, so the
+   * generic webhook receiver forwards them here for verification.
+   */
+  query?: Record<string, string | string[] | undefined>;
 }
 
 export interface ProvisionWebhookOptions {
@@ -456,6 +462,7 @@ export abstract class BaseConnector {
       payload?.date_updated,
       payload?.updated_at,
       payload?.updatedAt,
+      payload?.date_modified,
       payload?.date_created,
       payload?.created_at,
       payload?.createdAt,

--- a/api/src/connectors/pandadoc/connector.test.ts
+++ b/api/src/connectors/pandadoc/connector.test.ts
@@ -1,0 +1,308 @@
+import crypto from "node:crypto";
+import assert from "node:assert/strict";
+import { PandaDocConnector } from "./connector";
+
+function createConnector(config: Record<string, unknown> = {}) {
+  return new PandaDocConnector({
+    id: "ds_pandadoc",
+    name: "PandaDoc",
+    type: "pandadoc",
+    config: {
+      api_key: "test-api-key",
+      api_base_url: "https://api.pandadoc.com",
+      ...config,
+    },
+  } as any);
+}
+
+function testConfigValidationRequiresApiKey() {
+  const connector = createConnector({ api_key: "" });
+  const result = connector.validateConfig();
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some(error => error.includes("API key")));
+}
+
+function testSupportsResumableAndWebhooks() {
+  const connector = createConnector();
+  assert.equal(connector.supportsResumableFetching(), true);
+  assert.equal(connector.supportsWebhooks(), true);
+  assert.equal(connector.supportsWebhookProvisioning(), true);
+}
+
+function testAvailableEntities() {
+  const connector = createConnector();
+  assert.deepEqual(connector.getAvailableEntities(), [
+    "documents",
+    "templates",
+    "contacts",
+    "members",
+  ]);
+}
+
+function testWebhookEventsForEntities() {
+  const connector = createConnector();
+
+  assert.deepEqual(connector.getWebhookEventsForEntities(["documents"]).sort(), [
+    "document_completed_pdf_ready",
+    "document_creation_failed",
+    "document_deleted",
+    "document_section_added",
+    "document_state_changed",
+    "document_updated",
+    "quote_updated",
+    "recipient_completed",
+  ]);
+
+  assert.deepEqual(connector.getWebhookEventsForEntities(["templates"]).sort(), [
+    "template_created",
+    "template_deleted",
+    "template_updated",
+  ]);
+
+  assert.deepEqual(connector.getWebhookEventsForEntities(["contacts"]), []);
+
+  // Empty selection falls back to all supported events.
+  assert.equal(
+    connector.getWebhookEventsForEntities([]).length,
+    connector.getSupportedWebhookEvents().length,
+  );
+}
+
+function testWebhookEventMapping() {
+  const connector = createConnector();
+  assert.deepEqual(connector.getWebhookEventMapping("document_state_changed"), {
+    entity: "documents",
+    operation: "upsert",
+  });
+  assert.deepEqual(connector.getWebhookEventMapping("recipient_completed"), {
+    entity: "documents",
+    operation: "upsert",
+  });
+  assert.deepEqual(connector.getWebhookEventMapping("document_deleted"), {
+    entity: "documents",
+    operation: "delete",
+  });
+  assert.deepEqual(connector.getWebhookEventMapping("template_updated"), {
+    entity: "templates",
+    operation: "upsert",
+  });
+  assert.deepEqual(connector.getWebhookEventMapping("template_deleted"), {
+    entity: "templates",
+    operation: "delete",
+  });
+  assert.equal(connector.getWebhookEventMapping("unknown_event"), null);
+}
+
+const DOCUMENT_WEBHOOK_PAYLOAD = [
+  {
+    event: "document_state_changed",
+    data: {
+      id: "eHCjisfdtzJnbqnBbv2T9V",
+      name: "My document for webhooks testing",
+      date_created: "2024-03-18T16:26:43.090372Z",
+      date_modified: "2024-03-18T16:26:46.286951Z",
+      status: "document.completed",
+      recipients: [{ email: "john.doe@example.com", has_completed: true }],
+    },
+  },
+];
+
+function signQuery(secret: string, body: string): string {
+  return crypto.createHmac("sha256", secret).update(body, "utf8").digest("hex");
+}
+
+async function testWebhookVerificationAcceptsQuerySignature() {
+  const connector = createConnector();
+  const secret = "shared_key_test";
+  const body = JSON.stringify(DOCUMENT_WEBHOOK_PAYLOAD);
+  const signature = signQuery(secret, body);
+
+  const result = await connector.verifyWebhook({
+    payload: body,
+    headers: {},
+    secret,
+    query: { signature },
+  });
+
+  assert.equal(result.valid, true);
+  assert.equal(result.event?.type, "document_state_changed");
+  assert.ok(typeof result.event?.id === "string" && result.event.id.length > 0);
+  assert.equal(result.event?.events?.length, 1);
+}
+
+async function testWebhookVerificationAcceptsHeaderSignature() {
+  const connector = createConnector();
+  const secret = "shared_key_test";
+  const body = JSON.stringify(DOCUMENT_WEBHOOK_PAYLOAD);
+  const signature = signQuery(secret, body);
+
+  const result = await connector.verifyWebhook({
+    payload: body,
+    headers: { signature },
+    secret,
+  });
+
+  assert.equal(result.valid, true);
+}
+
+async function testWebhookVerificationRejectsBadSignature() {
+  const connector = createConnector();
+  const result = await connector.verifyWebhook({
+    payload: JSON.stringify(DOCUMENT_WEBHOOK_PAYLOAD),
+    headers: {},
+    secret: "shared_key_test",
+    query: {
+      signature:
+        "deadbeef00000000000000000000000000000000000000000000000000000000",
+    },
+  });
+  assert.equal(result.valid, false);
+  assert.match(result.error || "", /Invalid signature/);
+}
+
+async function testWebhookVerificationRejectsMissingSignature() {
+  const connector = createConnector();
+  const result = await connector.verifyWebhook({
+    payload: "[]",
+    headers: {},
+    secret: "shared_key_test",
+  });
+  assert.equal(result.valid, false);
+  assert.match(result.error || "", /Missing PandaDoc signature/);
+}
+
+async function testWebhookVerificationRejectsMissingSecret() {
+  const connector = createConnector();
+  const result = await connector.verifyWebhook({
+    payload: "[]",
+    headers: {},
+    query: { signature: "abcd" },
+  });
+  assert.equal(result.valid, false);
+  assert.match(result.error || "", /Missing webhook shared key/);
+}
+
+function testExtractWebhookData() {
+  const connector = createConnector();
+  const extracted = connector.extractWebhookData(DOCUMENT_WEBHOOK_PAYLOAD);
+  assert.ok(extracted);
+  assert.equal(extracted?.id, "eHCjisfdtzJnbqnBbv2T9V");
+  assert.equal(extracted?.data.status, "document.completed");
+}
+
+function testExtractWebhookCdcRecordsFromArray() {
+  const connector = createConnector();
+  const records = connector.extractWebhookCdcRecords(
+    DOCUMENT_WEBHOOK_PAYLOAD,
+    "document_state_changed",
+  );
+
+  assert.equal(records.length, 1);
+  assert.equal(records[0].entity, "documents");
+  assert.equal(records[0].recordId, "eHCjisfdtzJnbqnBbv2T9V");
+  assert.equal(records[0].operation, "upsert");
+  assert.equal(records[0].source, "webhook");
+  assert.ok(records[0].sourceTs instanceof Date);
+  // sourceTs derives from date_modified.
+  assert.equal(records[0].sourceTs.toISOString(), "2024-03-18T16:26:46.286Z");
+}
+
+function testExtractWebhookCdcRecordsFromWrappedShape() {
+  const connector = createConnector();
+  // verifyWebhook stores a wrapped { type, id, events } object as rawPayload.
+  const wrapped = {
+    type: "document_deleted",
+    id: "abc",
+    events: [
+      { event: "document_deleted", data: { id: "doc_1" } },
+      { event: "template_updated", data: { id: "tmpl_1" } },
+    ],
+  };
+  const records = connector.extractWebhookCdcRecords(wrapped);
+
+  assert.equal(records.length, 2);
+  const doc = records.find(r => r.entity === "documents");
+  const tmpl = records.find(r => r.entity === "templates");
+  assert.equal(doc?.recordId, "doc_1");
+  assert.equal(doc?.operation, "delete");
+  assert.equal(tmpl?.recordId, "tmpl_1");
+  assert.equal(tmpl?.operation, "upsert");
+}
+
+function testNormalizeBackfillRecordDerivesMemberId() {
+  const connector = createConnector();
+  const normalized = connector.normalizeBackfillRecord("members", {
+    membership_id: "RyMNXBjBPRppw56TfYBrrr",
+    email: "josh@example.com",
+    date_modified: "2024-07-11T20:36:43.362526Z",
+  });
+  assert.ok(normalized);
+  assert.equal(normalized?.recordId, "RyMNXBjBPRppw56TfYBrrr");
+  assert.equal(normalized?.payload?.id, "RyMNXBjBPRppw56TfYBrrr");
+}
+
+function testNormalizeBackfillRecordDocument() {
+  const connector = createConnector();
+  const normalized = connector.normalizeBackfillRecord("documents", {
+    id: "doc_99",
+    name: "Sample",
+    date_modified: "2024-03-18T16:26:46.286951Z",
+  });
+  assert.ok(normalized);
+  assert.equal(normalized?.recordId, "doc_99");
+  assert.equal(normalized?.operation, "upsert");
+  assert.equal(normalized?.source, "backfill");
+}
+
+async function testResolveSchema() {
+  const connector = createConnector();
+  for (const entity of ["documents", "templates", "contacts", "members"]) {
+    const schema = await connector.resolveSchema(entity);
+    assert.ok(schema, `expected schema for ${entity}`);
+    assert.equal(schema?.entity, entity);
+    assert.equal(schema?.unknownFieldPolicy, "string");
+    assert.deepEqual(schema?.keyColumns, ["id"]);
+    assert.ok(schema?.fields.id);
+  }
+  assert.equal(await connector.resolveSchema("not_real"), null);
+}
+
+function testEntityMetadataIncludesLayoutSuggestion() {
+  const connector = createConnector();
+  const metadata = connector.getEntityMetadata();
+  const documents = metadata.find(m => m.name === "documents");
+  assert.equal(documents?.layoutSuggestion?.partitionField, "date_created");
+  const contacts = metadata.find(m => m.name === "contacts");
+  assert.equal(contacts?.layoutSuggestion?.partitionField, "_syncedAt");
+}
+
+function testConfigSchemaWiresAllFields() {
+  const schema = PandaDocConnector.getConfigSchema();
+  const names = schema.fields.map(f => f.name);
+  assert.deepEqual(names, ["api_key", "api_base_url"]);
+}
+
+async function main() {
+  testConfigValidationRequiresApiKey();
+  testSupportsResumableAndWebhooks();
+  testAvailableEntities();
+  testWebhookEventsForEntities();
+  testWebhookEventMapping();
+  await testWebhookVerificationAcceptsQuerySignature();
+  await testWebhookVerificationAcceptsHeaderSignature();
+  await testWebhookVerificationRejectsBadSignature();
+  await testWebhookVerificationRejectsMissingSignature();
+  await testWebhookVerificationRejectsMissingSecret();
+  testExtractWebhookData();
+  testExtractWebhookCdcRecordsFromArray();
+  testExtractWebhookCdcRecordsFromWrappedShape();
+  testNormalizeBackfillRecordDerivesMemberId();
+  testNormalizeBackfillRecordDocument();
+  await testResolveSchema();
+  testEntityMetadataIncludesLayoutSuggestion();
+  testConfigSchemaWiresAllFields();
+}
+
+main().catch((error: unknown) => {
+  throw error;
+});

--- a/api/src/connectors/pandadoc/connector.ts
+++ b/api/src/connectors/pandadoc/connector.ts
@@ -1,0 +1,781 @@
+import crypto from "node:crypto";
+import axios, { AxiosError, AxiosInstance } from "axios";
+import {
+  BaseConnector,
+  ConnectionTestResult,
+  FetchOptions,
+  ResumableFetchOptions,
+  FetchState,
+  WebhookVerificationResult,
+  WebhookHandlerOptions,
+  WebhookEventMapping,
+  EntityMetadata,
+  NormalizedCdcRecord,
+  ProvisionWebhookOptions,
+  ProvisionWebhookResult,
+  type WebhookCapabilities,
+  type ConnectorEntitySchema,
+} from "../base/BaseConnector";
+import { resolvePandaDocEntitySchema } from "./schema";
+import { loggers } from "../../logging";
+
+const logger = loggers.connector("pandadoc");
+
+const DEFAULT_BASE_URL = "https://api.pandadoc.com";
+const MAX_PAGE_LIMIT = 100;
+
+const SUPPORTED_ENTITIES = [
+  "documents",
+  "templates",
+  "contacts",
+  "members",
+] as const;
+
+type SupportedEntity = (typeof SUPPORTED_ENTITIES)[number];
+
+// Entities that paginate via ?count=&page=. Contacts/members return the whole
+// collection in a single response (no pagination params).
+const PAGINATED_ENTITIES: Record<SupportedEntity, boolean> = {
+  documents: true,
+  templates: true,
+  contacts: false,
+  members: false,
+};
+
+const ENTITY_LIST_PATH: Record<SupportedEntity, string> = {
+  documents: "/public/v1/documents",
+  templates: "/public/v1/templates",
+  contacts: "/public/v1/contacts",
+  members: "/public/v1/members",
+};
+
+// All PandaDoc webhook triggers. document_deleted/template_deleted map to a
+// CDC delete; everything else is an upsert.
+const DOCUMENT_TRIGGERS = [
+  "document_state_changed",
+  "document_updated",
+  "document_creation_failed",
+  "document_completed_pdf_ready",
+  "document_section_added",
+  "recipient_completed",
+  "quote_updated",
+  "document_deleted",
+] as const;
+
+const TEMPLATE_TRIGGERS = [
+  "template_created",
+  "template_updated",
+  "template_deleted",
+] as const;
+
+const SUPPORTED_WEBHOOK_EVENTS = [
+  ...DOCUMENT_TRIGGERS,
+  ...TEMPLATE_TRIGGERS,
+] as const;
+
+type PandaDocListResponse<T = Record<string, unknown>> = {
+  results?: T[];
+};
+
+type PandaDocWebhookItem = {
+  event?: string;
+  data?: Record<string, unknown>;
+};
+
+/**
+ * PandaDoc members have no `id`; their stable identifier is `membership_id`.
+ * Mirror it onto `id` so the key column is uniform across entities.
+ */
+function withId(
+  entity: string,
+  record: Record<string, unknown>,
+): Record<string, unknown> {
+  if (record == null) return record;
+  if (typeof record.id === "string" && record.id.length > 0) return record;
+  if (entity === "members" && typeof record.membership_id === "string") {
+    return { ...record, id: record.membership_id };
+  }
+  return record;
+}
+
+function formatPandaDocApiError(error: unknown): string {
+  if (axios.isAxiosError(error)) {
+    const status = error.response?.status;
+    const data = error.response?.data as
+      | {
+          detail?: unknown;
+          message?: string;
+          type?: string;
+        }
+      | string
+      | undefined;
+
+    const direct =
+      typeof data === "string"
+        ? data
+        : typeof data?.message === "string"
+          ? data.message
+          : typeof data?.detail === "string"
+            ? data.detail
+            : data?.detail && typeof data.detail === "object"
+              ? JSON.stringify(data.detail)
+              : undefined;
+
+    const detail = direct || error.message;
+    return status ? `HTTP ${status}: ${detail}` : detail;
+  }
+
+  return error instanceof Error ? error.message : String(error);
+}
+
+export class PandaDocConnector extends BaseConnector {
+  private pandaDocApi: AxiosInstance | null = null;
+
+  static getConfigSchema() {
+    return {
+      fields: [
+        {
+          name: "api_key",
+          label: "API Key",
+          type: "password",
+          required: true,
+          helperText:
+            "PandaDoc API Key (generate in the Developer Dashboard). Used as `Authorization: API-Key <key>`.",
+        },
+        {
+          name: "api_base_url",
+          label: "API Base URL",
+          type: "string",
+          required: false,
+          default: DEFAULT_BASE_URL,
+        },
+      ],
+    };
+  }
+
+  getMetadata() {
+    return {
+      name: "PandaDoc",
+      version: "1.0.0",
+      description:
+        "Connector for PandaDoc documents, templates, contacts, and members. Real-time document + template webhooks (CDC); scheduled backfill covers contacts and members.",
+      supportedEntities: [...SUPPORTED_ENTITIES],
+    };
+  }
+
+  validateConfig() {
+    const base = super.validateConfig();
+    const errors = [...base.errors];
+
+    if (!this.dataSource.config.api_key) {
+      errors.push("PandaDoc API key is required");
+    }
+
+    return { valid: errors.length === 0, errors };
+  }
+
+  private getBaseUrl(): string {
+    const configured = this.dataSource.config.api_base_url;
+    if (typeof configured === "string" && configured.trim().length > 0) {
+      return configured.trim().replace(/\/+$/, "");
+    }
+    return DEFAULT_BASE_URL;
+  }
+
+  private getClient(): AxiosInstance {
+    if (!this.pandaDocApi) {
+      if (!this.dataSource.config.api_key) {
+        throw new Error("PandaDoc API key not configured");
+      }
+
+      this.pandaDocApi = axios.create({
+        baseURL: this.getBaseUrl(),
+        headers: {
+          Authorization: `API-Key ${this.dataSource.config.api_key}`,
+          "Content-Type": "application/json",
+        },
+      });
+    }
+    return this.pandaDocApi;
+  }
+
+  private headerValue(
+    headers: Record<string, string | string[] | undefined>,
+    name: string,
+  ): string | undefined {
+    const lower = name.toLowerCase();
+    for (const [key, value] of Object.entries(headers)) {
+      if (key.toLowerCase() !== lower) continue;
+      return Array.isArray(value) ? value[0] : value;
+    }
+    return undefined;
+  }
+
+  private async executeWithRetry<T>(
+    fn: () => Promise<T>,
+    maxRetries = 5,
+  ): Promise<T> {
+    let attempt = 0;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      try {
+        return await fn();
+      } catch (error) {
+        const axiosError = error as AxiosError;
+        const status = axiosError.response?.status;
+        const retryable =
+          status === 429 ||
+          (status !== undefined && status >= 500 && status < 600);
+
+        if (!retryable || attempt >= maxRetries) {
+          if (axios.isAxiosError(error)) {
+            error.message = formatPandaDocApiError(error);
+          }
+          throw error;
+        }
+
+        const retryAfterHeader = axiosError.response?.headers?.["retry-after"];
+        const retryAfterSeconds = parseInt(String(retryAfterHeader ?? ""), 10);
+        const delayMs = Number.isFinite(retryAfterSeconds)
+          ? retryAfterSeconds * 1000
+          : Math.min(1000 * 2 ** attempt, 60_000);
+
+        logger.warn("PandaDoc API rate limited or server error, retrying", {
+          status,
+          attempt: attempt + 1,
+          delayMs,
+        });
+        await this.sleep(delayMs);
+        attempt++;
+      }
+    }
+  }
+
+  private resolvePageCount(batchSize?: number): number {
+    const requested =
+      typeof batchSize === "number" && batchSize > 0
+        ? batchSize
+        : this.getBatchSize();
+    return Math.min(Math.max(requested, 1), MAX_PAGE_LIMIT);
+  }
+
+  async testConnection(): Promise<ConnectionTestResult> {
+    try {
+      const validation = this.validateConfig();
+      if (!validation.valid) {
+        return {
+          success: false,
+          message: "Invalid configuration",
+          details: validation.errors,
+        };
+      }
+
+      const api = this.getClient();
+      // Lightweight authenticated call: list a single document.
+      await this.executeWithRetry(() =>
+        api.get(ENTITY_LIST_PATH.documents, { params: { count: 1, page: 1 } }),
+      );
+
+      return {
+        success: true,
+        message: "Successfully connected to PandaDoc API",
+      };
+    } catch (error) {
+      return {
+        success: false,
+        message: "Failed to connect to PandaDoc API",
+        details: formatPandaDocApiError(error),
+      };
+    }
+  }
+
+  getAvailableEntities(): string[] {
+    return [...SUPPORTED_ENTITIES];
+  }
+
+  getEntityMetadata(): EntityMetadata[] {
+    const layout = (partitionField: string) => ({
+      partitionField,
+      partitionGranularity: "day" as const,
+      clusterFields: ["_dataSourceId", "id"],
+    });
+
+    return [
+      {
+        name: "documents",
+        label: "Documents",
+        description: "PandaDoc documents with status, recipients, and pricing",
+        layoutSuggestion: layout("date_created"),
+      },
+      {
+        name: "templates",
+        label: "Templates",
+        description: "Document templates",
+        layoutSuggestion: layout("date_created"),
+      },
+      {
+        name: "contacts",
+        label: "Contacts",
+        description: "Workspace contacts directory",
+        layoutSuggestion: {
+          partitionField: "_syncedAt",
+          partitionGranularity: "day",
+          clusterFields: ["_dataSourceId", "id"],
+        },
+      },
+      {
+        name: "members",
+        label: "Members",
+        description: "Workspace members (users)",
+        layoutSuggestion: layout("date_created"),
+      },
+    ];
+  }
+
+  async resolveSchema(entity: string): Promise<ConnectorEntitySchema | null> {
+    return resolvePandaDocEntitySchema(entity);
+  }
+
+  supportsResumableFetching(): boolean {
+    return true;
+  }
+
+  async fetchEntityChunk(options: ResumableFetchOptions): Promise<FetchState> {
+    const { entity } = options;
+
+    if (!(SUPPORTED_ENTITIES as readonly string[]).includes(entity)) {
+      throw new Error(`Unsupported entity for PandaDoc connector: ${entity}`);
+    }
+
+    const typedEntity = entity as SupportedEntity;
+    return PAGINATED_ENTITIES[typedEntity]
+      ? this.fetchPaginatedChunk(options, typedEntity)
+      : this.fetchSingleShotChunk(options, typedEntity);
+  }
+
+  private buildListParams(
+    entity: SupportedEntity,
+    page: number,
+    count: number,
+    since?: Date,
+  ): Record<string, string | number> {
+    const params: Record<string, string | number> = { count, page };
+
+    if (entity === "documents") {
+      params.order_by = "date_modified";
+      if (since instanceof Date) {
+        params.modified_from = since.toISOString();
+      }
+    }
+
+    return params;
+  }
+
+  private mapRecords(
+    entity: SupportedEntity,
+    rawResults: Record<string, unknown>[],
+    since?: Date,
+  ): Record<string, unknown>[] {
+    let records = rawResults.map(item => withId(entity, item));
+
+    // Documents are filtered server-side via modified_from. Templates and
+    // members expose date_modified but no incremental query param, so filter
+    // client-side. Contacts carry no timestamp — always full sync.
+    if (
+      since instanceof Date &&
+      (entity === "templates" || entity === "members")
+    ) {
+      const sinceMs = since.getTime();
+      records = records.filter(item => {
+        const modified =
+          typeof item.date_modified === "string"
+            ? new Date(item.date_modified).getTime()
+            : NaN;
+        return Number.isFinite(modified) ? modified >= sinceMs : true;
+      });
+    }
+
+    return records;
+  }
+
+  private async fetchPaginatedChunk(
+    options: ResumableFetchOptions,
+    entity: SupportedEntity,
+  ): Promise<FetchState> {
+    const { onBatch, onProgress, since, state, batchSize } = options;
+    const maxIterations = options.maxIterations ?? 10;
+    const api = this.getClient();
+    const path = ENTITY_LIST_PATH[entity];
+    const count = this.resolvePageCount(batchSize);
+
+    let page = (state?.page as number | undefined) ?? 1;
+    let recordCount = state?.totalProcessed ?? 0;
+    let iterations = 0;
+
+    while (iterations < maxIterations) {
+      const params = this.buildListParams(entity, page, count, since);
+      const response = await this.executeWithRetry(() =>
+        api.get<PandaDocListResponse>(path, { params }),
+      );
+      const results = Array.isArray(response.data?.results)
+        ? response.data.results
+        : [];
+
+      const records = this.mapRecords(
+        entity,
+        results as Record<string, unknown>[],
+        since,
+      );
+
+      if (records.length > 0) {
+        await onBatch(records);
+        recordCount += records.length;
+        onProgress?.(recordCount, undefined);
+      }
+
+      iterations++;
+
+      // A short page means the dataset is exhausted.
+      if (results.length < count) {
+        return {
+          page,
+          totalProcessed: recordCount,
+          hasMore: false,
+          iterationsInChunk: iterations,
+        };
+      }
+
+      page++;
+      await this.sleep(options.rateLimitDelay ?? this.getRateLimitDelay());
+    }
+
+    return {
+      page,
+      totalProcessed: recordCount,
+      hasMore: true,
+      iterationsInChunk: iterations,
+    };
+  }
+
+  private async fetchSingleShotChunk(
+    options: ResumableFetchOptions,
+    entity: SupportedEntity,
+  ): Promise<FetchState> {
+    const { onBatch, onProgress, since, state } = options;
+
+    // Non-paginated endpoints return everything at once, so a resumed chunk has
+    // nothing left to do.
+    if (state && state.totalProcessed !== 0) {
+      return {
+        totalProcessed: state.totalProcessed,
+        hasMore: false,
+        iterationsInChunk: 0,
+      };
+    }
+
+    const api = this.getClient();
+    const path = ENTITY_LIST_PATH[entity];
+    const response = await this.executeWithRetry(() =>
+      api.get<PandaDocListResponse>(path),
+    );
+    const results = Array.isArray(response.data?.results)
+      ? response.data.results
+      : [];
+
+    const records = this.mapRecords(
+      entity,
+      results as Record<string, unknown>[],
+      since,
+    );
+
+    if (records.length > 0) {
+      await onBatch(records);
+      onProgress?.(records.length, records.length);
+    }
+
+    return {
+      totalProcessed: records.length,
+      hasMore: false,
+      iterationsInChunk: 1,
+    };
+  }
+
+  async fetchEntity(options: FetchOptions): Promise<void> {
+    await this.fetchEntityChunk({
+      ...options,
+      maxIterations: Number.MAX_SAFE_INTEGER,
+    });
+  }
+
+  supportsWebhooks(): boolean {
+    return true;
+  }
+
+  supportsWebhookProvisioning(): boolean {
+    return true;
+  }
+
+  getWebhookCapabilities(): WebhookCapabilities {
+    return {
+      supported: true,
+      provisioning: {
+        supported: true,
+        providerLabel: "PandaDoc",
+        storesSecretAutomatically: true,
+      },
+      secretHelpText:
+        "Enter the webhook subscription Shared Key from the PandaDoc Developer Dashboard (used to verify the HMAC signature).",
+    };
+  }
+
+  async createWebhookSubscription(
+    options: ProvisionWebhookOptions,
+  ): Promise<ProvisionWebhookResult> {
+    const api = this.getClient();
+
+    const requestedEvents = Array.isArray(options.events)
+      ? options.events.map(event => event.trim()).filter(Boolean)
+      : [];
+
+    const effectiveEvents =
+      requestedEvents.length > 0
+        ? requestedEvents
+        : this.getWebhookEventsForEntities(options.enabledEntities ?? []);
+
+    const triggers = effectiveEvents.filter(event =>
+      (SUPPORTED_WEBHOOK_EVENTS as readonly string[]).includes(event),
+    );
+
+    if (triggers.length === 0) {
+      throw new Error(
+        requestedEvents.length > 0
+          ? `No valid PandaDoc webhook events configured. Supported: ${SUPPORTED_WEBHOOK_EVENTS.join(", ")}`
+          : "No webhook events resolved for the selected entities",
+      );
+    }
+
+    const payload = {
+      name: "Mako",
+      url: options.endpointUrl,
+      active: true,
+      // Include the rich payload sections so document rows carry pricing,
+      // fields, products, tokens, and metadata.
+      payload: ["fields", "products", "tokens", "metadata", "pricing"],
+      triggers,
+    };
+
+    try {
+      const response = await this.executeWithRetry(() =>
+        api.post("/public/v1/webhook-subscriptions", payload),
+      );
+      const data = (response.data ?? {}) as {
+        uuid?: string;
+        shared_key?: string;
+      };
+      const providerWebhookId = data.uuid;
+      if (!providerWebhookId) {
+        throw new Error(
+          "PandaDoc webhook created but no subscription uuid returned by API",
+        );
+      }
+      return {
+        providerWebhookId: String(providerWebhookId),
+        endpointUrl: options.endpointUrl,
+        signingSecret:
+          typeof data.shared_key === "string" && data.shared_key.length > 0
+            ? data.shared_key
+            : undefined,
+      };
+    } catch (error) {
+      throw new Error(
+        `Failed to create PandaDoc webhook subscription: ${formatPandaDocApiError(error)}`,
+      );
+    }
+  }
+
+  async verifyWebhook(
+    options: WebhookHandlerOptions,
+  ): Promise<WebhookVerificationResult> {
+    const { payload, headers, secret, query } = options;
+
+    if (!secret) {
+      return { valid: false, error: "Missing webhook shared key on flow" };
+    }
+
+    // PandaDoc appends the HMAC signature as a `signature` query parameter; some
+    // setups also surface it via a header.
+    const querySignature = query?.signature;
+    const signature =
+      (Array.isArray(querySignature) ? querySignature[0] : querySignature) ||
+      this.headerValue(headers, "signature");
+
+    if (!signature || typeof signature !== "string") {
+      return { valid: false, error: "Missing PandaDoc signature parameter" };
+    }
+
+    try {
+      const body =
+        typeof payload === "string" ? payload : JSON.stringify(payload);
+      const expected = crypto
+        .createHmac("sha256", secret)
+        .update(body, "utf8")
+        .digest("hex");
+
+      const expectedBuf = Buffer.from(expected, "hex");
+      const providedBuf = Buffer.from(signature, "hex");
+      if (
+        expectedBuf.length !== providedBuf.length ||
+        !crypto.timingSafeEqual(expectedBuf, providedBuf)
+      ) {
+        return { valid: false, error: "Invalid signature" };
+      }
+
+      const parsed =
+        typeof payload === "string" ? JSON.parse(payload) : payload;
+      const items = this.toWebhookItems(parsed);
+      const firstTrigger = items.find(item => item.event)?.event;
+
+      // PandaDoc deliveries have no event id; derive a stable one from the body
+      // so genuine re-deliveries dedupe on the (flowId, eventId) index.
+      const deliveryId = crypto
+        .createHash("sha1")
+        .update(body, "utf8")
+        .digest("hex");
+
+      return {
+        valid: true,
+        event: {
+          type: firstTrigger,
+          id: deliveryId,
+          events: items,
+        },
+      };
+    } catch (err) {
+      return {
+        valid: false,
+        error: err instanceof Error ? err.message : "Failed to verify webhook",
+      };
+    }
+  }
+
+  getWebhookEventMapping(eventType: string): WebhookEventMapping | null {
+    if ((DOCUMENT_TRIGGERS as readonly string[]).includes(eventType)) {
+      return {
+        entity: "documents",
+        operation: eventType === "document_deleted" ? "delete" : "upsert",
+      };
+    }
+    if ((TEMPLATE_TRIGGERS as readonly string[]).includes(eventType)) {
+      return {
+        entity: "templates",
+        operation: eventType === "template_deleted" ? "delete" : "upsert",
+      };
+    }
+    return null;
+  }
+
+  getSupportedWebhookEvents(): string[] {
+    return [...SUPPORTED_WEBHOOK_EVENTS];
+  }
+
+  getWebhookEventsForEntities(entities: string[]): string[] {
+    if (entities.length === 0) return this.getSupportedWebhookEvents();
+    const normalized = new Set(entities.map(e => e.toLowerCase()));
+    const events: string[] = [];
+
+    if (normalized.has("documents")) {
+      events.push(...DOCUMENT_TRIGGERS);
+    }
+    if (normalized.has("templates")) {
+      events.push(...TEMPLATE_TRIGGERS);
+    }
+
+    return events;
+  }
+
+  /**
+   * Normalize a PandaDoc webhook body into an array of `{ event, data }` items.
+   * Accepts the raw provider array, the wrapped shape produced by
+   * verifyWebhook (`{ events: [...] }`), or a single item.
+   */
+  private toWebhookItems(event: unknown): PandaDocWebhookItem[] {
+    if (Array.isArray(event)) {
+      return event as PandaDocWebhookItem[];
+    }
+    if (event && typeof event === "object") {
+      const wrapped = (event as { events?: unknown }).events;
+      if (Array.isArray(wrapped)) {
+        return wrapped as PandaDocWebhookItem[];
+      }
+      if ("data" in (event as Record<string, unknown>)) {
+        return [event as PandaDocWebhookItem];
+      }
+    }
+    return [];
+  }
+
+  extractWebhookData(
+    event: unknown,
+  ): { id: string; data: Record<string, unknown> } | null {
+    const items = this.toWebhookItems(event);
+    for (const item of items) {
+      const data = item?.data;
+      if (data && typeof data === "object") {
+        const id = typeof data.id === "string" ? data.id : "";
+        if (id) return { id, data };
+      }
+    }
+    return null;
+  }
+
+  extractWebhookCdcRecords(
+    event: unknown,
+    eventType?: string,
+  ): NormalizedCdcRecord[] {
+    const items = this.toWebhookItems(event);
+    const records: NormalizedCdcRecord[] = [];
+
+    for (const item of items) {
+      const trigger = item?.event || eventType;
+      const data = item?.data;
+      if (!trigger || !data || typeof data !== "object") continue;
+
+      const mapping = this.getWebhookEventMapping(trigger);
+      if (!mapping) continue;
+
+      const recordId = typeof data.id === "string" ? data.id : "";
+      if (!recordId) continue;
+
+      const sourceTs = this.resolveRecordTimestamp(data);
+      records.push({
+        entity: mapping.entity,
+        recordId,
+        operation: mapping.operation,
+        payload: data,
+        sourceTs,
+        source: "webhook",
+        changeId: `${trigger}:${recordId}:${sourceTs.toISOString()}`,
+      });
+    }
+
+    return records;
+  }
+
+  normalizeBackfillRecord(
+    entity: string,
+    record: Record<string, unknown>,
+  ): NormalizedCdcRecord | null {
+    const enriched = withId(entity, record);
+    const recordId = String(enriched.id ?? "");
+    if (!recordId) return null;
+
+    return {
+      entity,
+      recordId,
+      operation: "upsert",
+      payload: enriched,
+      sourceTs: this.resolveRecordTimestamp(enriched),
+      source: "backfill",
+    };
+  }
+}

--- a/api/src/connectors/pandadoc/icon.svg
+++ b/api/src/connectors/pandadoc/icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="6.5" fill="#23A35C"/>
+  <path
+    d="M9 8h7.6c3.7 0 6.4 2.4 6.4 5.9 0 3.5-2.7 5.9-6.4 5.9h-3.7V24H9V8zm3.9 8.6h3.3c1.7 0 2.8-1 2.8-2.7 0-1.7-1.1-2.7-2.8-2.7h-3.3v5.4z"
+    fill="#FFFFFF"
+  />
+</svg>

--- a/api/src/connectors/pandadoc/index.ts
+++ b/api/src/connectors/pandadoc/index.ts
@@ -1,0 +1,1 @@
+export { PandaDocConnector } from "./connector";

--- a/api/src/connectors/pandadoc/schema.ts
+++ b/api/src/connectors/pandadoc/schema.ts
@@ -1,0 +1,132 @@
+import {
+  type ConnectorEntitySchema,
+  type ConnectorFieldSchema,
+  MAKO_SYSTEM_FIELDS,
+} from "../base/BaseConnector";
+
+const s = (nullable = true): ConnectorFieldSchema => ({
+  type: "string",
+  nullable,
+});
+const ts = (nullable = true): ConnectorFieldSchema => ({
+  type: "timestamp",
+  nullable,
+});
+const b = (nullable = true): ConnectorFieldSchema => ({
+  type: "boolean",
+  nullable,
+});
+const j = (nullable = true): ConnectorFieldSchema => ({
+  type: "json",
+  nullable,
+});
+
+// ---------------------------------------------------------------------------
+// Entity schemas
+//
+// PandaDoc list endpoints return a shallow projection; webhooks (and the
+// document details endpoint) deliver the richer nested objects. We declare the
+// union of fields seen across both and lean on `unknownFieldPolicy: "string"`
+// for anything the API adds later, so backfill rows and webhook rows converge
+// on the same table.
+// ---------------------------------------------------------------------------
+
+export const DOCUMENT_SCHEMA: Record<string, ConnectorFieldSchema> = {
+  id: { type: "string", required: true },
+  name: s(),
+  status: s(),
+  version: s(),
+  autonumbering_sequence_name: s(),
+  date_created: ts(),
+  date_modified: ts(),
+  date_completed: ts(),
+  date_status_changed: ts(),
+  date_sent: ts(),
+  expiration_date: ts(),
+  created_by: j(),
+  sent_by: j(),
+  template: j(),
+  metadata: j(),
+  tokens: j(),
+  fields: j(),
+  products: j(),
+  pricing: j(),
+  grand_total: j(),
+  total: s(),
+  tags: j(),
+  recipients: j(),
+  approvers: j(),
+  linked_objects: j(),
+  ...MAKO_SYSTEM_FIELDS,
+};
+
+export const TEMPLATE_SCHEMA: Record<string, ConnectorFieldSchema> = {
+  id: { type: "string", required: true },
+  name: s(),
+  version: s(),
+  date_created: ts(),
+  date_modified: ts(),
+  content_date_modified: ts(),
+  ...MAKO_SYSTEM_FIELDS,
+};
+
+export const CONTACT_SCHEMA: Record<string, ConnectorFieldSchema> = {
+  id: { type: "string", required: true },
+  email: s(),
+  first_name: s(),
+  last_name: s(),
+  company: s(),
+  job_title: s(),
+  phone: s(),
+  country: s(),
+  state: s(),
+  street_address: s(),
+  city: s(),
+  postal_code: s(),
+  ...MAKO_SYSTEM_FIELDS,
+};
+
+export const MEMBER_SCHEMA: Record<string, ConnectorFieldSchema> = {
+  // PandaDoc members carry no `id`; the connector derives one from
+  // `membership_id` so the key column stays consistent across entities.
+  id: { type: "string", required: true },
+  user_id: s(),
+  membership_id: s(),
+  email: s(),
+  first_name: s(),
+  last_name: s(),
+  is_active: b(),
+  workspace: s(),
+  workspace_name: s(),
+  emails_verified: b(),
+  email_verified: b(),
+  role: s(),
+  user_license: s(),
+  date_created: ts(),
+  date_modified: ts(),
+  ...MAKO_SYSTEM_FIELDS,
+};
+
+export const ENTITY_SCHEMA_MAP: Record<
+  string,
+  Record<string, ConnectorFieldSchema>
+> = {
+  documents: DOCUMENT_SCHEMA,
+  templates: TEMPLATE_SCHEMA,
+  contacts: CONTACT_SCHEMA,
+  members: MEMBER_SCHEMA,
+};
+
+export function resolvePandaDocEntitySchema(
+  entity: string,
+): ConnectorEntitySchema | null {
+  const fields = ENTITY_SCHEMA_MAP[entity];
+  if (!fields) return null;
+
+  return {
+    entity,
+    fields: { ...fields },
+    unknownFieldPolicy: "string",
+    keyColumns: ["id"],
+  };
+}

--- a/api/src/routes/webhooks.ts
+++ b/api/src/routes/webhooks.ts
@@ -107,6 +107,7 @@ router.openapi(
     const rawBodyBuffer = Buffer.from(await c.req.arrayBuffer());
     const rawBodyText = rawBodyBuffer.toString("utf8");
     const headers = c.req.header();
+    const query = c.req.query();
 
     try {
       const flow = await Flow.findOne({
@@ -145,6 +146,7 @@ router.openapi(
           payload: rawBodyText,
           headers: headers,
           secret: flow.webhookConfig.secret,
+          query,
         });
 
         if (!verificationResult.valid) {

--- a/api/src/sync-cdc/normalization.ts
+++ b/api/src/sync-cdc/normalization.ts
@@ -31,6 +31,7 @@ export function resolveSourceTimestamp(
     payload?.date_updated,
     payload?.updated_at,
     payload?.updatedAt,
+    payload?.date_modified,
     payload?.date_created,
     payload?.created_at,
     payload?.createdAt,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a self-contained **PandaDoc** data source connector under `api/src/connectors/pandadoc/`, following the Close/Calendly CDC reference pattern. It supports resumable backfill and real-time CDC webhooks so PandaDoc documents/templates/contacts/members can be synced into warehouse destinations.

### What's included
- `connector.ts` — `PandaDocConnector extends BaseConnector`
  - API-Key auth (`Authorization: API-Key <key>`), configurable base URL (`https://api.pandadoc.com`)
  - Resumable backfill: `documents` + `templates` (page-based `count`/`page`), `contacts` + `members` (single-shot, no pagination params). Incremental `documents` via `modified_from`; `templates`/`members` filtered client-side by `date_modified`.
  - CDC webhooks: HMAC-SHA256 verification of the raw body against the subscription **Shared Key**, with the signature read from the `?signature=` query param (header fallback). Handles PandaDoc's **array** payload and fans out one delivery into multiple CDC records.
  - Auto-provisioning via `POST /public/v1/webhook-subscriptions` (stores returned `shared_key`).
  - `members` have no `id`; the connector derives one from `membership_id`.
- `schema.ts` — typed entity schemas + `keyColumns`, `unknownFieldPolicy: "string"`, BigQuery layout suggestions.
- `index.ts`, `icon.svg`, and mocked `connector.test.ts`.

### Generic enablers (separate commit)
- `WebhookHandlerOptions.query` added and forwarded from the webhook route (`c.req.query()`) so providers that sign via query param are supported connector-agnostically.
- `date_modified` added to the CDC source-timestamp precedence in **both** `BaseConnector.resolveRecordTimestamp` and `normalization.resolveSourceTimestamp` (kept in sync per CDC rules) so PandaDoc document state changes order correctly.

No UI changes are required — the connector is schema-driven and auto-discovered by the registry.

## Testing
- ✅ `pnpm --filter api exec tsx src/connectors/pandadoc/connector.test.ts`
- ✅ Close / Calendly / Claap / Stripe connector tests (no timestamp regressions)
- ✅ `pnpm --filter api run lint`
- ✅ `pnpm --filter api run build` (typecheck + compile, copies `icon.svg` to `dist`)
- ✅ `node scripts/check-connector-agnosticism.js`
- Manual: verified the connector registers and serves its schema via `GET /api/connectors/pandadoc/schema`.

> Note: live end-to-end backfill/webhook smoke against PandaDoc requires a real API key + webhook subscription, which isn't available in this environment; logic is covered by mocked unit tests and a local registration/schema check.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e119936b-2379-4b68-a0a9-c9e28b7d5d0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e119936b-2379-4b68-a0a9-c9e28b7d5d0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

