### PR TITLE
guides: C#/.NET connection guides (Batch 12) — ClickHouse, BigQuery, Snowflake, MariaDB

### DIFF
--- a/content/guides/bigquery/connect-from-csharp.mdx
+++ b/content/guides/bigquery/connect-from-csharp.mdx
@@ -1,0 +1,157 @@
+---
+title: "How to Connect to BigQuery from C# (.NET)"
+description: "Connect to BigQuery from C# with Google.Cloud.BigQuery.V2: ADC and service-account auth, running queries, named and positional parameters, reading results, cost controls, and the errors you actually hit."
+database: "bigquery"
+category: "how-to"
+tags: ["bigquery", "csharp", "dotnet", "google-cloud", "connection"]
+date: "2026-06-24"
+---
+
+Connecting to BigQuery from C# is unlike connecting to PostgreSQL or SQL Server: there is no host, no port, and no connection string. BigQuery is an API, so "connecting" means authenticating with Google Cloud credentials and pointing a client at a project. The auth setup is the real work; the query code is a few lines.
+
+There is one client that matters: `Google.Cloud.BigQuery.V2`, maintained by Google as part of the Google Cloud .NET libraries. Current version is 3.12.0 (as of June 2026). There is no ADO.NET provider in the usual sense, so Dapper and EF Core do not apply here -- you use the typed client directly.
+
+```bash
+dotnet add package Google.Cloud.BigQuery.V2
+```
+
+## Step 0: authentication
+
+The client uses Application Default Credentials (ADC), the same resolution every Google Cloud library uses. It looks for credentials in this order:
+
+1. The `GOOGLE_APPLICATION_CREDENTIALS` environment variable pointing at a service-account JSON key file.
+2. Credentials from `gcloud auth application-default login` (local development).
+3. The service account attached to the runtime (Cloud Run, GCE, GKE, Cloud Functions) when running inside Google Cloud.
+
+For local development, the cleanest path is a service-account key referenced by environment variable:
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/key.json"
+```
+
+Treat that JSON file like a password: keep it out of source control, rotate it, and prefer workload identity federation over long-lived keys where your platform supports it. Inside Google Cloud, do not ship a key file at all -- attach a service account to the workload and ADC picks it up automatically.
+
+You can also load a credential explicitly in code, which is occasionally useful in scripts but should not be your default:
+
+```csharp
+using Google.Apis.Auth.OAuth2;
+using Google.Cloud.BigQuery.V2;
+
+var credential = GoogleCredential.FromFile("/path/to/key.json");
+var client = BigQueryClient.Create("your-project-id", credential);
+```
+
+## Connecting and querying
+
+With ADC in place, creating the client is one line. The "project" here is the **billing project** -- the one that pays for and runs the query, which is not necessarily where the data lives.
+
+```csharp
+using Google.Cloud.BigQuery.V2;
+
+var client = BigQueryClient.Create("your-billing-project-id");
+
+var sql = @"
+    SELECT name, SUM(number) AS total
+    FROM `bigquery-public-data.usa_names.usa_1910_2013`
+    WHERE state = 'TX'
+    GROUP BY name
+    ORDER BY total DESC
+    LIMIT 10";
+
+var results = await client.ExecuteQueryAsync(sql, parameters: null);
+
+foreach (var row in results)
+{
+    Console.WriteLine($"{row["name"]}: {row["total"]}");
+}
+```
+
+`ExecuteQueryAsync` runs the job, waits for completion, and returns the rows. Each `BigQueryRow` is indexed by column name or position. The values come back as boxed CLR types (`string`, `long`, `double`, `DateTime`), so cast as needed: `(long)row["total"]`.
+
+`BigQueryClient.Create` resolves credentials synchronously. There is also `CreateAsync` if you want to avoid any blocking during startup.
+
+## Parameters: never concatenate
+
+BigQuery supports both named (`@name`) and positional (`?`) parameters. Use them rather than interpolating values into the SQL string.
+
+```csharp
+var sql = @"
+    SELECT name, number
+    FROM `bigquery-public-data.usa_names.usa_1910_2013`
+    WHERE state = @state AND number > @min
+    ORDER BY number DESC
+    LIMIT 100";
+
+var parameters = new[]
+{
+    new BigQueryParameter("state", BigQueryDbType.String, "TX"),
+    new BigQueryParameter("min", BigQueryDbType.Int64, 5000L)
+};
+
+var results = await client.ExecuteQueryAsync(sql, parameters);
+```
+
+Pass `BigQueryDbType` explicitly. It is required when the value could be `null` (BigQuery cannot infer the type of a null) and removes ambiguity for numeric types. For positional parameters, build the query with `?` placeholders and set `BigQueryParameterMode.Positional` on the query options.
+
+## Cost controls: this is real money
+
+Unlike a database you provision, BigQuery's on-demand pricing bills by bytes scanned. A `SELECT *` over a large table is an expensive mistake you only notice on the invoice. Two guardrails belong in any non-trivial client.
+
+A **dry run** estimates bytes scanned without running the query or incurring cost:
+
+```csharp
+var job = await client.CreateQueryJobAsync(
+    sql,
+    parameters: null,
+    options: new QueryOptions { DryRun = true });
+
+var bytes = job.Resource.Statistics.Query.TotalBytesProcessed;
+Console.WriteLine($"This query would scan {bytes} bytes");
+```
+
+A **maximum bytes billed** cap makes BigQuery refuse a query that would scan more than a threshold, rather than letting it run up the bill:
+
+```csharp
+var options = new QueryOptions
+{
+    MaximumBytesBilled = 1_000_000_000 // 1 GB ceiling
+};
+var results = await client.ExecuteQueryAsync(sql, parameters: null, options: options);
+```
+
+If the query would exceed the cap, it fails fast with a billing error instead of scanning. Set this on anything user-facing.
+
+## The location trap
+
+BigQuery datasets live in a location (a region or multi-region like `US` or `EU`). If your dataset is in `EU` and you run a query without specifying the location, you can get a "Not found: Dataset" error that looks like a permissions or typo problem but is actually a location mismatch. Set the location on the query options when your data is not in the default multi-region:
+
+```csharp
+var options = new QueryOptions { /* ... */ };
+// for jobs, specify the location via the job creation options / dataset reference
+var job = await client.CreateQueryJobAsync(sql, parameters: null, options: options);
+```
+
+When a "table exists but BigQuery says it doesn't" error appears, check the dataset's location before anything else.
+
+## Billing project versus data project
+
+The project you pass to `BigQueryClient.Create` is the billing/compute project. The data you query can live in a different project -- you reference it with the fully qualified `` `project.dataset.table` `` syntax in the SQL. This split matters in larger organizations: you might run queries billed to your team's project against tables owned by a central data project. The service account needs read access (`bigquery.dataViewer`) on the data and job-creation rights (`bigquery.jobUser`) on the billing project.
+
+## Reading large result sets
+
+`ExecuteQueryAsync` is fine for results that fit comfortably in memory. For very large result sets, iterate the returned `BigQueryResults` lazily -- it pages through results rather than materializing everything at once -- and consider writing the query output to a destination table, then exporting, rather than streaming millions of rows through the client.
+
+## Errors you will actually hit
+
+| Error | Cause | Fix |
+|---|---|---|
+| `Could not load the default credentials` | ADC found no credentials | Set `GOOGLE_APPLICATION_CREDENTIALS`, run `gcloud auth application-default login`, or attach a service account |
+| `Not found: Dataset project:dataset` | Dataset is in a different location than the query, or a typo | Set the query location (`EU`, `asia-...`); verify the dataset name and project |
+| `Access Denied: ... permission bigquery.jobs.create` | Service account lacks job-creation rights on the billing project | Grant `roles/bigquery.jobUser` on the billing project |
+| `Access Denied: ... permission bigquery.tables.getData` | No read access to the data | Grant `roles/bigquery.dataViewer` on the dataset/table |
+| `Query exceeded limit for bytes billed` | `MaximumBytesBilled` cap hit (working as intended) | Narrow the query (select fewer columns, filter on partition/cluster keys) or raise the cap deliberately |
+| Boxed-cast `InvalidCastException` | Casting a `BigQueryRow` value to the wrong CLR type | Match the cast to the column type (`long` for INT64, `double` for FLOAT64, `DateTime` for TIMESTAMP) |
+
+## Where Mako fits
+
+Mako connects to BigQuery with AI-assisted SQL autocomplete, which helps when you are exploring datasets and figuring out which columns and partitions to query before you wire up `Google.Cloud.BigQuery.V2` and add cost controls. It is a read and query tool, not a connection library: you still use the Google client in your application code, and you still set your own `MaximumBytesBilled` caps. Try it free at mako.ai.

--- a/content/guides/clickhouse/connect-from-csharp.mdx
+++ b/content/guides/clickhouse/connect-from-csharp.mdx
@@ -1,0 +1,167 @@
+---
+title: "How to Connect to ClickHouse from C# (.NET)"
+description: "Connect to ClickHouse from C# with the ADO.NET drivers: ClickHouse.Driver, ClickHouse.Client, and Octonica. Ports, parameters, bulk inserts, Dapper, the too-many-parts trap, and the errors you actually hit."
+database: "clickhouse"
+category: "how-to"
+tags: ["clickhouse", "csharp", "dotnet", "ado-net", "dapper", "connection"]
+date: "2026-06-24"
+---
+
+ClickHouse from C# is a different decision than PostgreSQL or MySQL: there is no single obvious driver, and the choice you make affects which port you connect to and how inserts perform. There are three serious ADO.NET providers, and they split along the protocol ClickHouse exposes. This guide covers picking one, the port trap that catches almost everyone, parameters, bulk inserts, Dapper, and the errors you will hit.
+
+## The protocol decision comes first
+
+ClickHouse exposes two interfaces: the **HTTP interface on port 8123** and the **native binary protocol on port 9000** (8443 and 9440 respectively for TLS). The driver you pick is, in practice, a choice of which one you talk to.
+
+| Library | NuGet ID | Protocol / port | Maintainer | Notes |
+|---|---|---|---|---|
+| ClickHouse.Driver | `ClickHouse.Driver` | Binary over HTTP (8123/8443) | ClickHouse (official) | Official ADO.NET driver, current as of June 2026. The default recommendation for new code. |
+| ClickHouse.Client | `ClickHouse.Client` | Binary over HTTP (8123/8443) | Oleg Kozlyuk (community) | Mature, widely used, full ADO.NET surface. Predates the official driver and is still actively maintained. |
+| Octonica.ClickHouseClient | `Octonica.ClickHouseClient` | Native TCP (9000/9440) | Octonica (community) | Native-protocol ADO.NET provider. Use when you specifically want native-protocol features or TCP. |
+
+The official `ClickHouse.Driver` (1.2.0 as of June 2026) is the right starting point for new projects: it is maintained by ClickHouse, implements ADO.NET so Dapper and Linq2db work on top of it, and uses binary-over-HTTP, which is firewall-friendly and load-balancer-friendly. `ClickHouse.Client` (7.14.0) is the long-standing community option and remains a solid choice, particularly if you already depend on it. `Octonica.ClickHouseClient` (4.1.4) is the one to reach for when you want the native TCP protocol specifically.
+
+The examples below use the official `ClickHouse.Driver`. The ADO.NET surface is close enough that `ClickHouse.Client` code looks almost identical; only the connection class names differ.
+
+```bash
+dotnet add package ClickHouse.Driver
+```
+
+## The port trap
+
+The single most common ClickHouse connection mistake across every language is pointing an HTTP client at port 9000. Port 9000 speaks the native binary protocol; the HTTP-based drivers (`ClickHouse.Driver`, `ClickHouse.Client`) need **8123**. If you give an HTTP driver port 9000 you get a confusing protocol or parse error, not a clean "wrong port" message. The reverse is also true: Octonica's native driver wants 9000, not 8123.
+
+On ClickHouse Cloud, the HTTP interface is **8443 over TLS**. There is no plain-HTTP option there.
+
+## A first connection
+
+```csharp
+using ClickHouse.Driver.ADO;
+
+var connString =
+    "Host=localhost;Port=8123;Username=default;Password=;Database=default";
+
+await using var conn = new ClickHouseConnection(connString);
+await conn.OpenAsync();
+
+await using var cmd = conn.CreateCommand();
+cmd.CommandText = "SELECT number, number * 2 AS doubled FROM system.numbers LIMIT 5";
+
+await using var reader = await cmd.ExecuteReaderAsync();
+while (await reader.ReadAsync())
+{
+    var n = reader.GetUInt64(0);
+    var doubled = reader.GetUInt64(1);
+    Console.WriteLine($"{n} -> {doubled}");
+}
+```
+
+Use the async methods in any server application. ClickHouse maps `UInt64` (its default integer width for `system.numbers` and many counters) to .NET `ulong`, so read it with `GetUInt64`, not `GetInt32`. Reading the wrong width is a frequent source of `InvalidCastException`.
+
+## Parameters: never concatenate
+
+Bind values rather than building SQL strings. The drivers use named parameters:
+
+```csharp
+await using var cmd = conn.CreateCommand();
+cmd.CommandText =
+    "SELECT count() FROM events WHERE event_type = {type:String} AND ts >= {since:DateTime}";
+
+cmd.Parameters.Add(new ClickHouseDbParameter
+{
+    ParameterName = "type",
+    Value = "purchase"
+});
+cmd.Parameters.Add(new ClickHouseDbParameter
+{
+    ParameterName = "since",
+    Value = new DateTime(2026, 1, 1)
+});
+
+var count = (ulong)(await cmd.ExecuteScalarAsync())!;
+```
+
+ClickHouse's server-side parameter syntax is `{name:Type}`, where the type is a ClickHouse type name (`String`, `UInt64`, `DateTime`, `Array(String)`, and so on). This is different from the `@name` style of SQL Server or the `$1` of PostgreSQL, and the type annotation is required. Getting the type wrong (for example `{id:Int32}` for a `UInt64` column) produces a type-mismatch error from the server.
+
+## Inserting data: batch, do not loop
+
+This is where ClickHouse differs most from a row-oriented database. ClickHouse is a columnar store built for large, infrequent inserts. Inserting rows one at a time creates a storage part per insert, and parts have to be merged in the background. Flood it with single-row inserts and you hit the famous error:
+
+```
+DB::Exception: Too many parts (300). Merges are processing significantly slower than inserts.
+```
+
+The fix is to batch. Insert thousands to hundreds of thousands of rows per statement. The official driver exposes a bulk-copy helper for this:
+
+```csharp
+using ClickHouse.Driver.Copy;
+
+await using var bulkCopy = new ClickHouseBulkCopy(conn)
+{
+    DestinationTable = "events",
+    ColumnNames = new[] { "event_type", "user_id", "ts" },
+    BatchSize = 100_000
+};
+await bulkCopy.InitAsync();
+
+var rows = data.Select(d => new object[] { d.Type, d.UserId, d.Timestamp });
+await bulkCopy.WriteToServerAsync(rows);
+```
+
+If your data genuinely arrives one row at a time (per-request inserts in a web service, for example), use ClickHouse's **asynchronous inserts** instead of batching in your application. Set the server-side setting and let ClickHouse buffer and batch on its side:
+
+```csharp
+await using var cmd = conn.CreateCommand();
+cmd.CommandText = "INSERT INTO events (event_type, user_id, ts) VALUES ({t:String}, {u:UInt64}, now())";
+// enable async inserts so the server batches small inserts
+cmd.CommandText = "SET async_insert = 1, wait_for_async_insert = 1; " + cmd.CommandText;
+```
+
+`wait_for_async_insert = 1` keeps the call durable (it returns once the data is committed); setting it to 0 returns sooner but risks losing buffered rows on a crash. Either way, never solve high insert rates by raising the parts limit -- fix the insert pattern.
+
+## Dapper
+
+Because these are ADO.NET providers, Dapper works without anything ClickHouse-specific:
+
+```csharp
+using Dapper;
+
+await using var conn = new ClickHouseConnection(connString);
+var topTypes = await conn.QueryAsync<EventCount>(
+    "SELECT event_type AS Type, count() AS Total FROM events GROUP BY event_type ORDER BY Total DESC LIMIT 10");
+```
+
+Dapper 2.1.79 is current as of June 2026. Note that Dapper's parameter handling (`@name`) does not map onto ClickHouse's `{name:Type}` server-side syntax, so for parameterized queries through Dapper, check your driver's documentation on how it translates parameters -- the drivers handle the common cases, but the type-annotated server syntax is the native form.
+
+## Connection lifetime and pooling
+
+ClickHouse connections are cheaper to think about than transactional databases, but the HTTP drivers still pool underlying HTTP connections. Create one `ClickHouseConnection` per unit of work (or use a connection factory / DI registration) rather than sharing a single connection across threads. For analytical workloads -- a handful of large queries rather than thousands of tiny transactions -- you do not need a large pool. A small number of connections per process is usually right, because each query scans a lot of data and you are bound by the server's CPU and IO, not by connection count.
+
+ClickHouse has no multi-statement transactions in the OLTP sense, so there is no `BeginTransaction` pattern to manage across your reads. Inserts are atomic per part.
+
+## TLS and ClickHouse Cloud
+
+For ClickHouse Cloud or any networked deployment, use TLS. With the HTTP drivers that means the `https` interface on 8443:
+
+```csharp
+var connString =
+    "Host=your-instance.clickhouse.cloud;Port=8443;Username=default;Password=...;Database=default;Protocol=https";
+```
+
+Cloud instances also idle-sleep: the first query after an idle period can be slow while the instance wakes. Build a short retry or a generous command timeout into health checks so a cold start does not read as an outage.
+
+## Errors you will actually hit
+
+| Error | Cause | Fix |
+|---|---|---|
+| Protocol / unexpected-packet error on connect | HTTP driver pointed at native port 9000 (or native driver at 8123) | Use 8123/8443 for `ClickHouse.Driver`/`ClickHouse.Client`; 9000/9440 for Octonica |
+| `Too many parts (N)` | Single-row or tiny inserts creating too many storage parts | Batch inserts (bulk copy) or enable `async_insert` -- do not raise the parts limit |
+| `Authentication failed` | Wrong user/password, or user not allowed from your host | Check credentials; review `users.xml` / access control host rules |
+| `Code: 60. Table ... does not exist` | Wrong database in the connection string, or unqualified table name | Set `Database=` correctly or qualify as `db.table` |
+| `InvalidCastException` reading a column | Reading a `UInt64`/`Int64` column with `GetInt32`, or wrong .NET type | Match the read method to the ClickHouse column type (`GetUInt64` for `UInt64`) |
+| Type mismatch on a parameter | `{name:Type}` annotation does not match the column type | Use the exact ClickHouse type in the parameter (e.g. `{id:UInt64}`) |
+| Timeout on the first Cloud query | ClickHouse Cloud instance waking from idle | Increase command timeout / add a retry for cold starts |
+
+## Where Mako fits
+
+Mako connects to ClickHouse with AI-assisted SQL autocomplete, which helps when you are exploring tables and column types before you decide which driver to wire in and how to shape your inserts. It is a read and query tool, not a connection library or an ingestion pipeline: you still use `ClickHouse.Driver`, `ClickHouse.Client`, or Octonica in your application code, and you still batch your inserts. Try it free at mako.ai.

--- a/content/guides/mariadb/connect-from-csharp.mdx
+++ b/content/guides/mariadb/connect-from-csharp.mdx
@@ -1,0 +1,149 @@
+---
+title: "How to Connect to MariaDB from C# (.NET)"
+description: "Connect to MariaDB from C# with MySqlConnector: ADO.NET basics, async queries, parameters, connection pooling, Dapper and EF Core, SSL, and the auth and encoding traps that actually bite."
+database: "mariadb"
+category: "how-to"
+tags: ["mariadb", "csharp", "dotnet", "ado-net", "connection"]
+date: "2026-06-25"
+---
+
+MariaDB speaks the MySQL wire protocol, so connecting from C# uses the same drivers you would use for MySQL. There is no separate "MariaDB .NET driver" worth reaching for; the practical choice is between two MySQL-compatible ADO.NET drivers, and one of them is the clear default for new code.
+
+## Driver choice
+
+`MySqlConnector` (2.6.1 as of June 2026) is the recommended driver. It is a clean-room, async-first ADO.NET implementation under the MIT license, and it explicitly supports MariaDB alongside MySQL, Aurora, Azure Database for MySQL, and Percona. Its async methods are genuinely asynchronous, which matters under load.
+
+`MySql.Data` (Oracle's official Connector/NET, 9.7.0 as of June 2026) also connects to MariaDB, but its history of sync-over-async implementations makes it a weaker pick for high-concurrency services. If you are starting fresh, use `MySqlConnector`. The two share most of the API but live in different namespaces, so you cannot mix them in the same file without aliasing.
+
+```bash
+dotnet add package MySqlConnector
+```
+
+## A basic connection
+
+```csharp
+using MySqlConnector;
+
+var connString =
+    "Server=localhost;Port=3306;Database=shop;" +
+    "User ID=appuser;Password=secret;";
+
+await using var conn = new MySqlConnection(connString);
+await conn.OpenAsync();
+```
+
+`await using` ensures the connection is returned to the pool when the scope exits. Do not hold one connection open for the life of the app; open per unit of work and let pooling do its job (more below).
+
+## Running a query
+
+```csharp
+await using var cmd = conn.CreateCommand();
+cmd.CommandText = "SELECT id, name FROM products WHERE price > @minPrice";
+cmd.Parameters.AddWithValue("@minPrice", 100);
+
+await using var reader = await cmd.ExecuteReaderAsync();
+while (await reader.ReadAsync())
+{
+    var id = reader.GetInt32(0);
+    var name = reader.GetString(1);
+    Console.WriteLine($"{id}: {name}");
+}
+```
+
+Always parameterize. String-concatenating user input into SQL is the classic injection hole, and the driver's parameters also handle quoting and type conversion for you.
+
+## Getting a generated key
+
+MariaDB does not have SQL Server's `OUTPUT` clause or PostgreSQL's `RETURNING` in the same form (MariaDB does support `RETURNING` on `INSERT` since 10.5, which is a genuine option). The ADO.NET-portable way is `LastInsertedId`:
+
+```csharp
+await using var cmd = conn.CreateCommand();
+cmd.CommandText = "INSERT INTO products (name, price) VALUES (@name, @price)";
+cmd.Parameters.AddWithValue("@name", "Widget");
+cmd.Parameters.AddWithValue("@price", 9.99m);
+await cmd.ExecuteNonQueryAsync();
+
+long newId = cmd.LastInsertedId;
+```
+
+If you prefer `RETURNING`, run it as a normal query and read the result set back, but be aware it ties your code to MariaDB 10.5+ and breaks portability to MySQL.
+
+## The utf8mb4 trap
+
+MariaDB's legacy `utf8` is a three-byte encoding that cannot store emoji or some CJK characters. Use `utf8mb4` for the column charset, and the driver handles the rest. If you see `Incorrect string value` on insert, this is almost always the cause:
+
+```sql
+ALTER TABLE products MODIFY name VARCHAR(255)
+  CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+```
+
+## Authentication differences from MySQL
+
+This is where MariaDB and MySQL diverge in a way that matters. MySQL 8 defaults to the `caching_sha2_password` auth plugin; MariaDB does not use it. MariaDB sticks with `mysql_native_password` and adds its own `ed25519` plugin for stronger auth. So the `caching_sha2_password` and "Public Key Retrieval" headaches that plague MySQL 8 connections do not apply to MariaDB. If you want stronger-than-native auth on MariaDB, `ed25519` is the path, and `MySqlConnector` supports it.
+
+## Connection pooling
+
+Pooling is on by default and keyed by the connection string. The defaults worth knowing:
+
+- `Maximum Pool Size` defaults to 100.
+- `Minimum Pool Size` defaults to 0.
+- `Connection Idle Timeout` defaults to 180 seconds.
+
+The number you actually need to coordinate is total pool size across all app instances versus MariaDB's `max_connections` (default 151). Five app instances each with a 100-connection pool can demand 500 connections against a server that allows 151, and you get `Too many connections` under load. Size pools to fit the server, or raise `max_connections` deliberately.
+
+## Dapper
+
+`MySqlConnector` is a standard ADO.NET provider, so Dapper (2.1.79 as of June 2026) works directly:
+
+```csharp
+using Dapper;
+
+var products = await conn.QueryAsync<Product>(
+    "SELECT id, name, price FROM products WHERE price > @minPrice",
+    new { minPrice = 100 });
+```
+
+## Entity Framework Core
+
+For EF Core, use the Pomelo provider, `Pomelo.EntityFrameworkCore.MySql` (9.0.0 as of June 2026), which targets both MySQL and MariaDB and builds on `MySqlConnector`. Declare the server version so the provider enables the right feature set:
+
+```csharp
+var serverVersion = ServerVersion.AutoDetect(connString);
+
+builder.Services.AddDbContext<AppDb>(options =>
+    options.UseMySql(connString, serverVersion));
+```
+
+`ServerVersion.AutoDetect` opens a connection at startup to read the server version; if you want to avoid that round trip, pass an explicit `MariaDbServerVersion(new Version(11, 4, 0))`.
+
+## SSL
+
+For connections over an untrusted network, set the SSL mode:
+
+| SSL Mode | Behavior |
+| --- | --- |
+| `None` | No encryption |
+| `Preferred` | Encrypt if the server supports it (default) |
+| `Required` | Encrypt, but do not validate the server certificate |
+| `VerifyCA` | Encrypt and validate the CA |
+| `VerifyFull` | Encrypt, validate CA and hostname |
+
+Use `VerifyFull` for production connections over a public network. `Required` encrypts but leaves you open to man-in-the-middle, so it is not enough on its own.
+
+```csharp
+var connString =
+    "Server=db.example.com;Database=shop;User ID=appuser;Password=secret;" +
+    "SSL Mode=VerifyFull;";
+```
+
+## Errors you actually hit
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `Too many connections` | Combined pool size exceeds `max_connections` | Reduce `Maximum Pool Size` or raise server `max_connections` |
+| `Incorrect string value` | Column is legacy `utf8`, not `utf8mb4` | Convert column/table charset to `utf8mb4` |
+| `Access denied for user` | Wrong host pattern on the grant | MariaDB grants are user@host; check the host part matches your client |
+| `Unable to connect to any of the specified hosts` | Wrong host/port or server not listening | Verify `bind-address`, port 3306, firewall |
+| Time values off by hours | Server and client time zones differ | Store UTC; convert in app code, not in SQL |
+
+For exploring MariaDB data and drafting queries before they go into C#, Mako connects to MariaDB with AI-powered autocomplete. Try it free at mako.ai.

--- a/content/guides/snowflake/connect-from-csharp.mdx
+++ b/content/guides/snowflake/connect-from-csharp.mdx
@@ -1,0 +1,140 @@
+---
+title: "How to Connect to Snowflake from C# (.NET)"
+description: "Connect to Snowflake from C# with Snowflake.Data: account identifiers, key-pair auth after the password block, running queries, parameters, reading results, and the errors you actually hit."
+database: "snowflake"
+category: "how-to"
+tags: ["snowflake", "csharp", "dotnet", "ado-net", "connection"]
+date: "2026-06-25"
+---
+
+Snowflake is a cloud data warehouse, so connecting from C# looks a bit different from a local PostgreSQL or SQL Server connection: there is no host or port in the usual sense, the "server" is an account identifier, and as of late 2025 you can no longer log in with a single-factor password from a driver. The connection code itself is plain ADO.NET; the work is in the account identifier and the auth.
+
+There is one driver that matters: `Snowflake.Data`, the official .NET connector maintained by Snowflake. Current version is 5.7.0 (as of June 2026). It implements the ADO.NET interfaces (`SnowflakeDbConnection`, `SnowflakeDbCommand`, `SnowflakeDbDataReader`), so Dapper works on top of it. There is no Entity Framework Core provider from Snowflake, and there is no second serious community driver, so the choice is made for you.
+
+```bash
+dotnet add package Snowflake.Data
+```
+
+## The account identifier
+
+The first thing that trips people up is the `account` value. The recommended format is the organization-account name, `myorg-myaccount`, not the legacy account locator (`xy12345.eu-central-1`). You can find both in the Snowflake UI under Admin -> Accounts. The org-account form is the one to use in new code; the locator form still works but is being phased out and behaves differently across regions.
+
+You do not put a region in the connection string when you use the org-account identifier. That is a common mistake carried over from the old locator format.
+
+## Authentication after the November 2025 password block
+
+Snowflake began blocking single-factor password sign-ins for programmatic connections in November 2025. A bare `password=...` connection that worked in 2024 will now fail for human-owned accounts. For service connections the supported path is key-pair (JWT) authentication.
+
+Generate an unencrypted PKCS#8 private key and the matching public key:
+
+```bash
+openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out rsa_key.p8 -nocrypt
+openssl rsa -in rsa_key.p8 -pubout -out rsa_key.pub
+```
+
+Register the public key on the Snowflake user (strip the header, footer, and newlines from `rsa_key.pub`):
+
+```sql
+ALTER USER my_service_user SET RSA_PUBLIC_KEY='MIIBIjANBgkqh...';
+```
+
+Then connect with `authenticator=snowflake_jwt` and point the driver at the private key file:
+
+```csharp
+using Snowflake.Data.Client;
+
+var connString =
+    "account=myorg-myaccount;" +
+    "user=my_service_user;" +
+    "authenticator=snowflake_jwt;" +
+    "private_key_file=/secure/path/rsa_key.p8;" +
+    "db=ANALYTICS;schema=PUBLIC;warehouse=COMPUTE_WH;role=ANALYST";
+
+await using var conn = new SnowflakeDbConnection(connString);
+await conn.OpenAsync();
+```
+
+If the key is encrypted, add `private_key_pwd=...`. For interactive local development, `authenticator=externalbrowser` opens your SSO login in a browser instead, which avoids handling keys at all.
+
+## Why warehouse, db, schema, and role belong in the connection string
+
+Snowflake will happily connect you without a warehouse and then fail the first query with `No active warehouse selected in the current session`. Likewise, omitting `role` leaves you on your default role, which may not see the objects you expect, producing confusing "object does not exist" errors that are really permission errors. Set all four (`warehouse`, `db`, `schema`, `role`) up front so the session is fully scoped before you run anything.
+
+## Running a query
+
+`Snowflake.Data` implements `DbDataReader`, so the pattern is standard ADO.NET:
+
+```csharp
+await using var cmd = conn.CreateCommand();
+cmd.CommandText = "SELECT id, name FROM customers LIMIT 10";
+
+await using var reader = await cmd.ExecuteReaderAsync();
+while (await reader.ReadAsync())
+{
+    var id = reader.GetInt64(0);
+    var name = reader.GetString(1);
+    Console.WriteLine($"{id}: {name}");
+}
+```
+
+One thing to watch: Snowflake returns unquoted identifiers in uppercase. A column you wrote as `select name` comes back as `NAME` when you read it by name (`reader["NAME"]`). Reading by ordinal, as above, sidesteps the issue entirely.
+
+## Parameters
+
+The connector uses positional parameters with `?` placeholders, and you must set the Snowflake type via `SnowflakeDbParameter`:
+
+```csharp
+using Snowflake.Data.Core;
+
+await using var cmd = conn.CreateCommand();
+cmd.CommandText = "SELECT id, name FROM customers WHERE country = ? AND created_at > ?";
+
+var p1 = (SnowflakeDbParameter)cmd.CreateParameter();
+p1.ParameterName = "1";
+p1.SFDataType = SFDataType.TEXT;
+p1.Value = "CH";
+cmd.Parameters.Add(p1);
+
+var p2 = (SnowflakeDbParameter)cmd.CreateParameter();
+p2.ParameterName = "2";
+p2.SFDataType = SFDataType.TIMESTAMP_NTZ;
+p2.Value = new DateTime(2026, 1, 1);
+cmd.Parameters.Add(p2);
+
+await using var reader = await cmd.ExecuteReaderAsync();
+```
+
+Setting `SFDataType` matters most when the value can be null, since the driver cannot infer the type from a null `Value`.
+
+## Dapper
+
+Because the connector is a real ADO.NET provider, Dapper (2.1.79 as of June 2026) works without anything Snowflake-specific:
+
+```csharp
+using Dapper;
+
+var rows = await conn.QueryAsync<Customer>(
+    "SELECT id, name FROM customers WHERE country = ?",
+    new { country = "CH" });
+```
+
+Note that Dapper's named-parameter convenience maps onto Snowflake's positional `?` placeholders, so parameter order is what counts, not the property name.
+
+## Sessions, not pools
+
+Snowflake connections are sessions against a remote warehouse, and they are relatively heavy to establish. The connector supports connection pooling, which is on by default and keyed by connection string; reuse the same connection string so pooled sessions are actually reused. For long-lived services, `CLIENT_SESSION_KEEP_ALIVE=true` (set as a connection parameter) keeps a session from expiring during idle periods. Do not hold a single connection open across an entire app and share it between threads; let the pool hand out sessions per unit of work.
+
+## Errors you actually hit
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `JWT token is invalid` | Public key not registered, or wrong private key | Re-run `ALTER USER ... SET RSA_PUBLIC_KEY`, confirm the key pair matches |
+| `No active warehouse selected in the current session` | No `warehouse` in connection string | Add `warehouse=...` (and confirm the role can use it) |
+| `Object does not exist or not authorized` | Wrong `role` or `db`/`schema` | Set `role`, `db`, `schema` explicitly; verify grants |
+| `Incorrect username or password` on a human account | Single-factor password blocked (Nov 2025) | Switch to `snowflake_jwt` or `externalbrowser` |
+| Account identifier not found | Using locator format or wrong region | Use `myorg-myaccount`; no region suffix needed |
+| Column read by name returns null | Identifier case mismatch | Read by ordinal, or match Snowflake's uppercase |
+
+Snowflake's compute is billed by warehouse runtime, so an idle warehouse left running from a forgotten connection costs money. Set `AUTO_SUSPEND` on the warehouse and let sessions close cleanly.
+
+For exploring Snowflake data and shaping queries before you wire them into C#, Mako connects to Snowflake with AI-powered autocomplete. Try it free at mako.ai.


### PR DESCRIPTION
C#/.NET connection guides, continuing Batch 12.

- ClickHouse (ClickHouse.Driver 1.2.0 / ClickHouse.Client 7.14.0)
- BigQuery (Google.Cloud.BigQuery.V2 3.12.0)
- Snowflake (Snowflake.Data 5.7.0, key-pair auth after Nov 2025 password block)
- MariaDB (MySqlConnector 2.6.1)

All versions verified live via NuGet. Em-dash and banned-word clean. C# series now 8/9 (MS SQL remaining).