### PR TITLE
fix(agent): long-poll check_query_status to stop rapid-fire polling near query timeout

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -13,7 +13,7 @@
     "worker:dev": "tsx watch src/worker.ts",
     "migrate:workspaces": "tsx src/migrations/migrate-to-workspaces.ts",
     "openapi:generate": "tsx src/openapi/generate-cli.ts",
-    "test": "tsx src/openapi/core.test.ts && tsx src/openapi/openapi.test.ts && tsx src/dbt/warm-dir-cache.test.ts && tsx src/connectors/stripe/connector.test.ts && tsx src/connectors/close/connector.test.ts && tsx src/sync-cdc/idempotency.test.ts && tsx src/agent-lib/context/compaction.test.ts && tsx src/services/safe-fetch.service.test.ts",
+    "test": "tsx src/openapi/core.test.ts && tsx src/openapi/openapi.test.ts && tsx src/dbt/warm-dir-cache.test.ts && tsx src/connectors/stripe/connector.test.ts && tsx src/connectors/close/connector.test.ts && tsx src/sync-cdc/idempotency.test.ts && tsx src/agent-lib/context/compaction.test.ts && tsx src/services/safe-fetch.service.test.ts && tsx src/agent-lib/tools/check-query-status-poll.test.ts",
     "test:dbt": "vitest run",
     "test:dbt:watch": "vitest",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives",

--- a/api/src/agent-lib/prompts/universal.ts
+++ b/api/src/agent-lib/prompts/universal.ts
@@ -86,7 +86,7 @@ For dialect syntax and worked examples, load the matching system skill: \`dialec
 
 1. **Finishes quickly** → you get \`status: "success"\` with the rows. Done.
 2. **Still running after the soft timeout** → you get \`status: "running"\` plus an \`executionId\`. The query KEEPS RUNNING server-side. Then:
-   - **Auto-poll \`check_query_status\`** (pass the same \`consoleId\` + \`executionId\`) with backoff — roughly 30s, then 60s, then 90s. Do this silently; don't narrate every poll.
+   - **Call \`check_query_status\`** (pass the same \`consoleId\` + \`executionId\`). It BLOCKS server-side and returns the moment the query settles, so you do NOT need to space out your polls — never add your own delay or call it in a rapid loop. If it returns \`status: "running"\` again, simply call it once more to keep waiting. Do this silently; don't narrate every poll.
    - When it reports \`status: "success"\`, use the returned preview/rowCount as the result. \`status: "error"\` / \`"cancelled"\` end the wait.
    - **Never re-run the same query** while one is running, and never call \`cancel_query\` just to retry — that throws away in-progress work.
    - The query is **automatically aborted server-side at a hard cap (~5 min)**; when that happens \`check_query_status\` returns \`status: "error"\`/\`"cancelled"\`. If a query is too slow to finish in time, rewrite it into narrower queries (add filters / date ranges / LIMIT) and run those.

--- a/api/src/agent-lib/tools/check-query-status-poll.test.ts
+++ b/api/src/agent-lib/tools/check-query-status-poll.test.ts
@@ -1,0 +1,221 @@
+import assert from "node:assert/strict";
+import {
+  pollRunStatus,
+  abortableSleep,
+  type ReadRunResult,
+  type PollRunArtifact,
+} from "./check-query-status-poll";
+
+/**
+ * Build a virtual clock + sleep pair so the long-poll loop can be driven
+ * deterministically without real timers. Every simulated sleep advances the
+ * clock by the requested amount.
+ */
+function virtualClock() {
+  let t = 0;
+  return {
+    now: () => t,
+    sleep: async (ms: number) => {
+      t += ms;
+    },
+    set: (v: number) => {
+      t = v;
+    },
+  };
+}
+
+const running: PollRunArtifact = {
+  at: new Date(0),
+  startedAt: new Date(0),
+  status: "running",
+  executionId: "exec-1",
+};
+const success: PollRunArtifact = {
+  at: new Date(0),
+  status: "success",
+  rowCount: 42,
+  durationMs: 1234,
+  sampleRows: [{ a: 1 }, { a: 2 }],
+  executionId: "exec-1",
+};
+
+/** A terminal status returns immediately without ever sleeping. */
+async function testTerminalReturnsImmediately() {
+  const clock = virtualClock();
+  let reads = 0;
+  let sleeps = 0;
+  const result = await pollRunStatus({
+    readRun: async (): Promise<ReadRunResult> => {
+      reads++;
+      return { ok: true, lastRun: success };
+    },
+    waitMs: 30_000,
+    intervalMs: 2_000,
+    now: clock.now,
+    sleep: async ms => {
+      sleeps++;
+      await clock.sleep(ms);
+    },
+  });
+
+  assert.equal(result.status, "success");
+  assert.equal(result.rowCount, 42);
+  assert.equal(result.durationMs, 1234);
+  assert.deepEqual(result.preview, [{ a: 1 }, { a: 2 }]);
+  assert.equal(reads, 1, "should read exactly once");
+  assert.equal(sleeps, 0, "should never sleep for a settled run");
+}
+
+/** While running, the poll blocks and returns the instant the run settles. */
+async function testBlocksThenReturnsOnSettle() {
+  const clock = virtualClock();
+  let reads = 0;
+  const result = await pollRunStatus({
+    readRun: async (): Promise<ReadRunResult> => {
+      reads++;
+      // Running for the first 3 reads, then finishes.
+      return { ok: true, lastRun: reads <= 3 ? running : success };
+    },
+    waitMs: 30_000,
+    intervalMs: 2_000,
+    now: clock.now,
+    sleep: clock.sleep,
+  });
+
+  assert.equal(result.status, "success");
+  assert.equal(reads, 4, "should keep polling until the run settles");
+  // 3 sleeps of 2s each before the 4th read saw success.
+  assert.equal(clock.now(), 6_000);
+}
+
+/**
+ * THE THROTTLE GUARANTEE: a run that never settles must NOT return on the first
+ * read. It blocks for the whole wait window, returns status:"running", and only
+ * polls a bounded number of times — so the agent can't rapid-fire the tool.
+ */
+async function testStillRunningThrottlesToOnePerWindow() {
+  const clock = virtualClock();
+  let reads = 0;
+  const result = await pollRunStatus({
+    readRun: async (): Promise<ReadRunResult> => {
+      reads++;
+      return { ok: true, lastRun: running };
+    },
+    executionId: "exec-1",
+    waitMs: 30_000,
+    intervalMs: 2_000,
+    now: clock.now,
+    sleep: clock.sleep,
+  });
+
+  assert.equal(result.status, "running");
+  assert.equal(result.executionId, "exec-1");
+  assert.ok(
+    typeof result.elapsedMs === "number" && result.elapsedMs >= 30_000,
+    "elapsedMs should reflect the full wait",
+  );
+  // Reads happen at t=0,2k,...,30k => 16 reads. The key point: it is bounded
+  // and small (NOT one-per-second-forever like the bug).
+  assert.equal(reads, 16, "bounded number of reads per blocking poll");
+  assert.equal(clock.now(), 30_000, "blocks for the full wait window");
+}
+
+/** A newer run on the same console is reported as superseded. */
+async function testSuperseded() {
+  const clock = virtualClock();
+  const result = await pollRunStatus({
+    readRun: async (): Promise<ReadRunResult> => ({
+      ok: true,
+      lastRun: { ...running, executionId: "exec-2" },
+    }),
+    executionId: "exec-1",
+    waitMs: 30_000,
+    intervalMs: 2_000,
+    now: clock.now,
+    sleep: clock.sleep,
+  });
+
+  assert.equal(result.status, "superseded");
+  assert.equal(result.latestExecutionId, "exec-2");
+}
+
+/** An aborted turn ends the wait immediately rather than blocking. */
+async function testAbortEndsWaitEarly() {
+  const clock = virtualClock();
+  const controller = new AbortController();
+  controller.abort();
+  let reads = 0;
+  const result = await pollRunStatus({
+    readRun: async (): Promise<ReadRunResult> => {
+      reads++;
+      return { ok: true, lastRun: running };
+    },
+    executionId: "exec-1",
+    waitMs: 30_000,
+    intervalMs: 2_000,
+    signal: controller.signal,
+    now: clock.now,
+    sleep: clock.sleep,
+  });
+
+  assert.equal(result.status, "running");
+  assert.equal(reads, 1, "aborted poll returns after a single read");
+  assert.equal(clock.now(), 0, "aborted poll does not sleep");
+}
+
+/** A read/load error surfaces as a failure result. */
+async function testReadErrorSurfaces() {
+  const result = await pollRunStatus({
+    readRun: async (): Promise<ReadRunResult> => ({
+      ok: false,
+      error: "Console not found",
+    }),
+    waitMs: 30_000,
+    intervalMs: 2_000,
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error, "Console not found");
+}
+
+/** No run yet → clear instruction to run the query first. */
+async function testNoRunYet() {
+  const result = await pollRunStatus({
+    readRun: async (): Promise<ReadRunResult> => ({ ok: true, lastRun: null }),
+    waitMs: 30_000,
+    intervalMs: 2_000,
+  });
+
+  assert.equal(result.success, false);
+  assert.match(String(result.error), /No run found/);
+}
+
+/** The real abortableSleep resolves promptly when the signal aborts. */
+async function testAbortableSleepResolvesOnAbort() {
+  const controller = new AbortController();
+  const started = Date.now();
+  const p = abortableSleep(10_000, controller.signal);
+  controller.abort();
+  await p;
+  assert.ok(
+    Date.now() - started < 1_000,
+    "abortableSleep should resolve right after abort, not after the full delay",
+  );
+}
+
+async function run() {
+  await testTerminalReturnsImmediately();
+  await testBlocksThenReturnsOnSettle();
+  await testStillRunningThrottlesToOnePerWindow();
+  await testSuperseded();
+  await testAbortEndsWaitEarly();
+  await testReadErrorSurfaces();
+  await testNoRunYet();
+  await testAbortableSleepResolvesOnAbort();
+  process.stdout.write("\ncheck-query-status-poll.test.ts: all tests passed\n");
+}
+
+run().catch((err: unknown) => {
+  process.stderr.write(`${err instanceof Error ? err.stack : String(err)}\n`);
+  process.exitCode = 1;
+});

--- a/api/src/agent-lib/tools/check-query-status-poll.ts
+++ b/api/src/agent-lib/tools/check-query-status-poll.ts
@@ -1,0 +1,182 @@
+/**
+ * Long-poll core for the `check_query_status` agent tool.
+ *
+ * WHY THIS EXISTS: an LLM cannot sleep between tool calls. When
+ * `check_query_status` returned instantly while a console run was still
+ * `running`, the model would re-invoke it every ~1s — producing dozens of
+ * back-to-back polls (observed: ~50 polls in ~100s near the 5-min cap) that
+ * flood the chat UI and make it jump around. The fix is to make each poll
+ * BLOCK server-side until the run settles or a bounded wait window elapses, so
+ * the agent only gets a turn back roughly once per interval no matter how
+ * eagerly it calls the tool. This does NOT change the hard execution cap — the
+ * query keeps running server-side and is still aborted at its own ceiling.
+ *
+ * The logic is kept dependency-free (no Mongoose / services) so it is unit
+ * testable in isolation with a fake run reader.
+ */
+
+/** Subset of the persisted `SavedConsole.lastRun` artifact this poll reads. */
+export interface PollRunArtifact {
+  status: "running" | "success" | "error" | "cancelled" | (string & {});
+  executionId?: string;
+  rowCount?: number;
+  durationMs?: number;
+  sampleRows?: unknown[];
+  error?: string;
+  startedAt?: Date | string;
+  at: Date | string;
+}
+
+/** What a single read of the latest run yields. */
+export type ReadRunResult =
+  | { ok: true; lastRun?: PollRunArtifact | null }
+  | { ok: false; error: string };
+
+export interface PollRunStatusOptions {
+  /** Re-reads the authoritative latest run each iteration. */
+  readRun: () => Promise<ReadRunResult>;
+  /** The executionId the caller pinned, if any (detects a superseding run). */
+  executionId?: string;
+  /** Max time to block before handing a "running" turn back (ms). */
+  waitMs: number;
+  /** How often to re-read while waiting (ms). */
+  intervalMs: number;
+  /** Turn abort signal: ends the wait early (explicit Stop / turn end). */
+  signal?: AbortSignal;
+  /** Max preview rows to surface on success. */
+  previewMaxRows?: number;
+  /** Injectable clock for tests. */
+  now?: () => number;
+  /** Injectable sleep for tests. */
+  sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+}
+
+const DEFAULT_PREVIEW_MAX_ROWS = 50;
+
+/**
+ * Sleep that resolves early if the turn is aborted. Exported so the tool and
+ * tests share one implementation.
+ */
+export function abortableSleep(
+  ms: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  return new Promise<void>(resolve => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    let onAbort: (() => void) | undefined;
+    const timer = setTimeout(() => {
+      if (onAbort) signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    (timer as { unref?: () => void }).unref?.();
+    if (signal) {
+      onAbort = () => {
+        clearTimeout(timer);
+        resolve();
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+  });
+}
+
+/**
+ * Block until the polled run settles (success/error/cancelled/superseded) or
+ * the wait window elapses, then return the tool result payload. Re-reads the
+ * run on every iteration so a status change is observed promptly.
+ */
+export async function pollRunStatus(
+  options: PollRunStatusOptions,
+): Promise<Record<string, unknown>> {
+  const {
+    readRun,
+    executionId,
+    waitMs,
+    intervalMs,
+    signal,
+    previewMaxRows = DEFAULT_PREVIEW_MAX_ROWS,
+    now = () => Date.now(),
+    sleep = abortableSleep,
+  } = options;
+
+  const deadline = now() + waitMs;
+
+  for (;;) {
+    const read = await readRun();
+    if (!read.ok) return { success: false, error: read.error };
+
+    const lastRun = read.lastRun;
+    if (!lastRun) {
+      return {
+        success: false,
+        error:
+          "No run found for this console yet. Use run_console to execute the query first.",
+      };
+    }
+
+    // A newer run on the same console supersedes the one being polled.
+    if (
+      executionId &&
+      lastRun.executionId &&
+      lastRun.executionId !== executionId
+    ) {
+      return {
+        success: true,
+        status: "superseded",
+        message:
+          "A newer run has started on this console; the execution you polled is no longer the latest. Re-run or check the latest run instead.",
+        latestExecutionId: lastRun.executionId,
+        latestStatus: lastRun.status,
+      };
+    }
+
+    if (lastRun.status === "success") {
+      return {
+        success: true,
+        status: "success",
+        rowCount: lastRun.rowCount ?? 0,
+        durationMs: lastRun.durationMs,
+        preview: (lastRun.sampleRows ?? []).slice(0, previewMaxRows),
+        message: `Query finished: ${lastRun.rowCount ?? 0} row(s).`,
+      };
+    }
+
+    if (lastRun.status === "cancelled") {
+      return {
+        success: true,
+        status: "cancelled",
+        error: lastRun.error || "Query was cancelled.",
+      };
+    }
+
+    if (lastRun.status !== "running") {
+      return {
+        success: false,
+        status: "error",
+        error: lastRun.error || "Query failed.",
+      };
+    }
+
+    // Still running: give up the wait once the window is exhausted or the turn
+    // is aborted; otherwise sleep a short interval and re-check.
+    const current = now();
+    if (current >= deadline || signal?.aborted) {
+      const startedAtMs = lastRun.startedAt
+        ? new Date(lastRun.startedAt).getTime()
+        : new Date(lastRun.at).getTime();
+      return {
+        success: true,
+        status: "running",
+        executionId: lastRun.executionId,
+        elapsedMs: Math.max(0, current - startedAtMs),
+        message:
+          "Still running. Call check_query_status again to keep waiting " +
+          "(each call already blocks server-side), or escalate to the user.",
+      };
+    }
+
+    await sleep(Math.min(intervalMs, deadline - current), signal);
+  }
+}

--- a/api/src/agent-lib/tools/server-console-tools.ts
+++ b/api/src/agent-lib/tools/server-console-tools.ts
@@ -43,9 +43,11 @@ import {
 import type { AgentToolExecutionContext } from "../../agents/types";
 import {
   QUERY_SOFT_TIMEOUT_MS,
-  QUERY_POLL_BACKOFF_MS,
   QUERY_HARD_MAX_EXECUTION_MS,
+  QUERY_STATUS_POLL_WAIT_MS,
+  QUERY_STATUS_POLL_INTERVAL_MS,
 } from "../../config/long-running-queries";
+import { pollRunStatus } from "./check-query-status-poll";
 import { loggers } from "../../logging";
 
 const logger = loggers.agent();
@@ -63,11 +65,6 @@ function leafConsoleName(raw: string | undefined): string {
   const parts = value.split("/").filter(Boolean);
   return parts.length > 0 ? parts[parts.length - 1] : value;
 }
-
-/** First poll backoff hint surfaced to the agent (seconds). */
-const FIRST_POLL_BACKOFF_S = Math.round(
-  (QUERY_POLL_BACKOFF_MS[0] ?? 30_000) / 1000,
-);
 
 const consoleManager = new ConsoleManager();
 
@@ -626,7 +623,7 @@ export function createServerConsoleTools({
               elapsedMs: QUERY_SOFT_TIMEOUT_MS,
               message:
                 `Query is still running after ${Math.round(QUERY_SOFT_TIMEOUT_MS / 1000)}s and keeps running server-side. ` +
-                `Poll check_query_status (consoleId="${consoleId}", executionId="${executionId}") after ~${FIRST_POLL_BACKOFF_S}s to get the result. Do not re-run the query.`,
+                `Call check_query_status (consoleId="${consoleId}", executionId="${executionId}") to get the result — it blocks server-side until the query finishes (no need to wait or poll rapidly yourself). Do not re-run the query.`,
             };
           }
 
@@ -663,80 +660,29 @@ export function createServerConsoleTools({
     check_query_status: tool({
       description:
         'Poll the status of a console query started with run_console (DB-backed, works across server instances). Returns { status: "running", elapsedMs } while it runs, { status: "success", rowCount, preview } when it finishes, { status: "error", error }, or { status: "cancelled" }. ' +
-        'After run_console returns status="running", auto-poll this with backoff (~' +
-        QUERY_POLL_BACKOFF_MS.map(ms => `${Math.round(ms / 1000)}s`).join("/") +
-        `) until it finishes. The query is automatically aborted server-side at a hard cap (~${Math.round(QUERY_HARD_MAX_EXECUTION_MS / 60_000)} min); if that happens, rewrite it into smaller/narrower queries rather than retrying as-is. Never silently re-run the query while it is still running.`,
+        `This call BLOCKS server-side for up to ~${Math.round(QUERY_STATUS_POLL_WAIT_MS / 1000)}s, returning the instant the query settles — so you do NOT need to (and must NOT) add your own delay or spam rapid calls. After run_console returns status="running", just call this again; if it returns status="running" again, call it once more to keep waiting. ` +
+        `The query is automatically aborted server-side at a hard cap (~${Math.round(QUERY_HARD_MAX_EXECUTION_MS / 60_000)} min); if that happens, rewrite it into smaller/narrower queries rather than retrying as-is. Never silently re-run the query while it is still running.`,
       inputSchema: checkQueryStatusSchema,
-      execute: async ({ consoleId, executionId }) => {
-        const loaded = await loadConsole(consoleId);
-        if (isLoadError(loaded)) return { success: false, ...loaded };
-        const { doc } = loaded;
-
-        const lastRun = doc.lastRun;
-        if (!lastRun) {
-          return {
-            success: false,
-            error:
-              "No run found for this console yet. Use run_console to execute the query first.",
-          };
-        }
-
-        // If the caller pinned an executionId, only report when it matches the
-        // console's latest run (a newer run supersedes the one being polled).
-        if (
-          executionId &&
-          lastRun.executionId &&
-          lastRun.executionId !== executionId
-        ) {
-          return {
-            success: true,
-            status: "superseded" as const,
-            message:
-              "A newer run has started on this console; the execution you polled is no longer the latest. Re-run or check the latest run instead.",
-            latestExecutionId: lastRun.executionId,
-            latestStatus: lastRun.status,
-          };
-        }
-
-        if (lastRun.status === "running") {
-          const startedAtMs = lastRun.startedAt
-            ? new Date(lastRun.startedAt).getTime()
-            : new Date(lastRun.at).getTime();
-          return {
-            success: true,
-            status: "running" as const,
-            executionId: lastRun.executionId,
-            elapsedMs: Math.max(0, Date.now() - startedAtMs),
-            message:
-              "Still running. Keep polling with backoff, or escalate to the user after the poll window.",
-          };
-        }
-
-        if (lastRun.status === "success") {
-          return {
-            success: true,
-            status: "success" as const,
-            rowCount: lastRun.rowCount ?? 0,
-            durationMs: lastRun.durationMs,
-            preview: (lastRun.sampleRows ?? []).slice(0, RUN_PREVIEW_MAX_ROWS),
-            message: `Query finished: ${lastRun.rowCount ?? 0} row(s).`,
-          };
-        }
-
-        if (lastRun.status === "cancelled") {
-          return {
-            success: true,
-            status: "cancelled" as const,
-            error: lastRun.error || "Query was cancelled.",
-          };
-        }
-
-        return {
-          success: false,
-          status: "error" as const,
-          error: lastRun.error || "Query failed.",
-        };
-      },
+      execute: async ({ consoleId, executionId }) =>
+        // Long-poll: an LLM cannot sleep between tool calls, so if this returned
+        // instantly while the query is "running" the model re-invokes it every
+        // ~1s — flooding the chat UI (see the rapid-poll incident this fixes).
+        // pollRunStatus blocks (re-reading the DB-backed run artifact) until the
+        // run settles or the wait window elapses. The query keeps running
+        // server-side either way (hard cap still applies); we only throttle how
+        // often the agent gets a turn back.
+        pollRunStatus({
+          readRun: async () => {
+            const loaded = await loadConsole(consoleId);
+            if (isLoadError(loaded)) return { ok: false, error: loaded.error };
+            return { ok: true, lastRun: loaded.doc.lastRun };
+          },
+          executionId,
+          waitMs: QUERY_STATUS_POLL_WAIT_MS,
+          intervalMs: QUERY_STATUS_POLL_INTERVAL_MS,
+          signal: executionContext?.signal,
+          previewMaxRows: RUN_PREVIEW_MAX_ROWS,
+        }),
     }),
 
     cancel_query: tool({

--- a/api/src/config/long-running-queries.ts
+++ b/api/src/config/long-running-queries.ts
@@ -57,6 +57,34 @@ export const QUERY_POLL_BACKOFF_MS = envIntList(
 );
 
 /**
+ * How long `check_query_status` BLOCKS server-side while a run is still
+ * `running` before returning `status: "running"`. The tool long-polls (re-reads
+ * the DB-backed run artifact every `QUERY_STATUS_POLL_INTERVAL_MS`) and returns
+ * early the moment the run settles.
+ *
+ * This is the throttle that fixes rapid-fire polling: an LLM cannot actually
+ * sleep between tool calls, so without a server-side wait it re-invokes
+ * `check_query_status` every ~1s (flooding the chat UI). Blocking here makes
+ * each poll naturally take ~one backoff interval regardless of how eagerly the
+ * model calls it. It does NOT change the hard execution cap — the query keeps
+ * running server-side and is still aborted at `QUERY_HARD_MAX_EXECUTION_MS`.
+ */
+export const QUERY_STATUS_POLL_WAIT_MS = envInt(
+  "QUERY_STATUS_POLL_WAIT_MS",
+  QUERY_POLL_BACKOFF_MS[0] ?? 30_000,
+);
+
+/**
+ * How often the blocking `check_query_status` long-poll re-reads the persisted
+ * run artifact while waiting for the run to settle. Small enough to surface a
+ * finished result promptly, large enough to avoid hammering the DB.
+ */
+export const QUERY_STATUS_POLL_INTERVAL_MS = envInt(
+  "QUERY_STATUS_POLL_INTERVAL_MS",
+  2_000,
+);
+
+/**
  * Server-side hard ceiling: a detached run is aborted (task + engine-native
  * cancel) once it exceeds this, so no query can run forever. This is an
  * absolute cap applied uniformly to every engine; it is also used as the

--- a/docs/src/content/docs/ai-agent.md
+++ b/docs/src/content/docs/ai-agent.md
@@ -189,7 +189,7 @@ Queries that take a while no longer fail at a fixed timeout. When the agent call
 - If it finishes within a short soft timeout (`QUERY_SOFT_TIMEOUT_MS`, ~90s default), the rows come back immediately, as before.
 - If it's still running after that, `run_console` returns `{ status: "running", executionId }` and the query **keeps running** server-side — nothing is cancelled.
 
-The agent then polls `check_query_status` (with backoff) to fetch the result, and can stop a run with `cancel_query`:
+The agent then calls `check_query_status` to fetch the result, and can stop a run with `cancel_query`. `check_query_status` **long-polls server-side** (`QUERY_STATUS_POLL_WAIT_MS`, ~30s default): it blocks until the run settles or the wait window elapses, then returns. This throttles the agent to roughly one poll per window — an LLM can't sleep between tool calls, so without server-side blocking it would re-poll every ~1s and flood the chat UI:
 
 | Tool                 | What It Does                                                                                          |
 | -------------------- | ---------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When a console query runs long (approaching the 5‑minute hard cap), the chat window misbehaves: it "jumps back and forth" and queries status roughly every second, making it impossible to follow.

Root cause confirmed from the reported Langfuse session (`5fbc576c...`, user `kirill.vakalov@realadvisor.com`): the agent fired `check_query_status` ~50 times in ~100s — bursts every ~3–4s (often two per turn), not the intended 30/60/90s backoff. Each tool call returns in ~0.003s.

The backoff is only *advice* in the prompt. An LLM cannot actually sleep between tool calls, so when `check_query_status` returns instantly while a run is still `running`, the model immediately re-invokes it — a tight loop that floods the chat with tool cards and churns the UI.

## Fix

Make `check_query_status` **block server-side**. It now long-polls the DB‑backed `lastRun` artifact for up to `QUERY_STATUS_POLL_WAIT_MS` (~30s default, env‑overridable), re-reading every `QUERY_STATUS_POLL_INTERVAL_MS` (~2s) and returning **the instant the run settles**. This throttles the agent to roughly one poll per window no matter how eagerly it calls the tool — without changing query semantics.

The **5‑minute hard execution cap (`QUERY_HARD_MAX_EXECUTION_MS`) is unchanged**; the query keeps running server-side and is still aborted at the same ceiling. The wait is abortable via the turn signal (explicit Stop / turn end), so a blocking poll never outlives its turn.

### Changes
- New dependency-free `pollRunStatus()` core + `abortableSleep()` in `api/src/agent-lib/tools/check-query-status-poll.ts`; the tool delegates to it.
- Add `QUERY_STATUS_POLL_WAIT_MS` / `QUERY_STATUS_POLL_INTERVAL_MS` to `long-running-queries.ts`.
- Update `check_query_status` / `run_console` tool messages, the universal agent prompt, and the AI‑agent doc to say the poll blocks (don't add your own delay / rapid loop).
- Unit tests: throttle (blocks full window, bounded reads), prompt-on-settle, supersede, abort-ends-early, read/no-run errors, real `abortableSleep`.

## Testing
- ✅ `pnpm --filter api run lint`
- ✅ `pnpm --filter api run build` (typecheck)
- ✅ `tsx src/agent-lib/tools/check-query-status-poll.test.ts` (added to `api` test script)
- ✅ Integration against the **real** `check_query_status` tool + real local Mongo (throwaway script, not committed): with a 4s wait window — run settling at ~1.5s returned at **1526ms** `status=success`; a never‑settling run returned at **4002ms** `status=running` (previously ~3ms instant). This is exactly the throttle that stops the ~1s rapid polling.

[check_query_status_longpoll_integration.log](https://cursor.com/agents/bc-bcb47b76-a806-455c-932c-51d57ad91663/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcheck_query_status_longpoll_integration.log)

A full GUI repro was not run because this VM snapshot lacks the documented setup (standalone Mongo without a replica set, no Postgres) and reproducing requires a non-deterministic AI driving a 2‑minute query; the integration test exercises the real tool path deterministically instead.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bcb47b76-a806-455c-932c-51d57ad91663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bcb47b76-a806-455c-932c-51d57ad91663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

