### PR TITLE
fix(connectors): add UI feedback when creating/updating connectors

### DIFF
--- a/app/src/components/ConnectorForm.tsx
+++ b/app/src/components/ConnectorForm.tsx
@@ -68,7 +68,9 @@ interface ConnectorFormProps {
   variant?: "dialog" | "inline";
   open?: boolean;
   onClose?: () => void;
-  onSubmit: (data: any) => void;
+  onSubmit: (
+    data: any,
+  ) => void | Promise<{ success: boolean; isNew?: boolean } | void>;
   connector?: any | null;
   connectorTypes?: Array<{
     type: string;
@@ -124,6 +126,8 @@ function ConnectorForm({
     Record<string, boolean>
   >({});
   const [snackbarMessage, setSnackbarMessage] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const draftRef = useRef<Record<string, any> | undefined>(
     tabId ? useConnectorStore.getState().drafts[tabId]?.values : undefined,
@@ -321,7 +325,7 @@ function ConnectorForm({
     return decryptedValues[fieldName];
   };
 
-  const onSubmitInternal = (values: Record<string, unknown>) => {
+  const onSubmitInternal = async (values: Record<string, unknown>) => {
     // form submitted
     const { dirtyFields } = form.formState;
     // Validate object_array required items before proceeding
@@ -439,15 +443,28 @@ function ConnectorForm({
     }
 
     if (!isNewConnector && Object.keys(payload).length === 0) {
-      console.warn("[ConnectorForm] no changes detected; skipping submit");
+      setSnackbarMessage("No changes to save");
       return;
     }
 
     // submitting payload
+    setIsSubmitting(true);
     try {
-      onSubmit(payload);
+      const result = await onSubmit(payload);
+      // A `void` return is treated as success (legacy callers); only an explicit
+      // `{ success: false }` suppresses the success toast.
+      const succeeded = !result || result.success !== false;
+      if (succeeded) {
+        setSuccessMessage(
+          isNewConnector
+            ? "Connector created successfully"
+            : "Connector updated successfully",
+        );
+      }
     } catch (err) {
       console.error("[ConnectorForm] onSubmit threw", err);
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -1105,9 +1122,27 @@ function ConnectorForm({
           <Box
             sx={{ display: "flex", justifyContent: "flex-end", gap: 1, mt: 2 }}
           >
-            <Button onClick={onClose}>Cancel</Button>
-            <Button type="submit" variant="contained" disableElevation>
-              {connector ? "Update" : "Create"}
+            <Button onClick={onClose} disabled={isSubmitting}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="contained"
+              disableElevation
+              disabled={isSubmitting}
+              startIcon={
+                isSubmitting ? (
+                  <CircularProgress size={16} color="inherit" />
+                ) : undefined
+              }
+            >
+              {isSubmitting
+                ? connector
+                  ? "Updating…"
+                  : "Creating…"
+                : connector
+                  ? "Update"
+                  : "Create"}
             </Button>
           </Box>
         </>
@@ -1141,6 +1176,22 @@ function ConnectorForm({
         message={snackbarMessage}
         anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
       />
+
+      <Snackbar
+        open={!!successMessage}
+        autoHideDuration={4000}
+        onClose={() => setSuccessMessage(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+      >
+        <Alert
+          onClose={() => setSuccessMessage(null)}
+          severity="success"
+          variant="filled"
+          sx={{ width: "100%" }}
+        >
+          {successMessage}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 }

--- a/app/src/components/ConnectorTab.tsx
+++ b/app/src/components/ConnectorTab.tsx
@@ -5,6 +5,7 @@ import { useWorkspace } from "../contexts/workspace-context";
 import { useConsoleStore } from "../store/consoleStore";
 import { useConnectorCatalogStore } from "../store/connectorCatalogStore";
 import { useConnectorEntitiesStore } from "../store/connectorEntitiesStore";
+import { useDataSourceEntitiesStore } from "../store/dataSourceEntitiesStore";
 import { useConnectorStore } from "../store/connectorStore";
 import { trackEvent } from "../lib/analytics";
 
@@ -47,6 +48,11 @@ const ConnectorTab: React.FC<ConnectorTabProps> = ({
     upsert: upsertConnector,
     entities,
   } = useConnectorEntitiesStore();
+
+  // The sidebar list (ConnectorExplorer) reads from a separate entity cache.
+  // Upsert into it too so a newly created/updated connector appears without a
+  // manual refresh.
+  const upsertDataSource = useDataSourceEntitiesStore(state => state.upsert);
 
   const [localSourceId, setLocalSourceId] = useState<string | undefined>(
     initialSourceId,
@@ -120,8 +126,11 @@ const ConnectorTab: React.FC<ConnectorTabProps> = ({
     closeTab(tabId);
   };
 
-  const handleSubmit = async (formData: any) => {
-    if (!currentWorkspace) return;
+  const handleSubmit = async (
+    formData: any,
+  ): Promise<{ success: boolean; isNew: boolean }> => {
+    const isNew = !effectiveSourceId;
+    if (!currentWorkspace) return { success: false, isNew };
 
     try {
       const url = effectiveSourceId
@@ -136,10 +145,11 @@ const ConnectorTab: React.FC<ConnectorTabProps> = ({
       });
       const data = await response.json();
       if (data.success) {
-        // update entity cache
-        if (currentWorkspace) {
-          upsertConnector({ ...data.data, workspaceId: currentWorkspace.id });
-        }
+        const entity = { ...data.data, workspaceId: currentWorkspace.id };
+        // Update the tab's entity cache and the sidebar list's cache so the
+        // connector shows/updates immediately without a manual refresh.
+        upsertConnector(entity);
+        upsertDataSource(entity);
         setError(null);
         updateTabIcon(data.data.type);
         // Update the tab title once after a successful save
@@ -149,7 +159,7 @@ const ConnectorTab: React.FC<ConnectorTabProps> = ({
         deleteDraft(tabId);
 
         const newId = data.data._id;
-        if (!effectiveSourceId && newId) {
+        if (isNew && newId) {
           // Track connector creation
           trackEvent("connector_created", {
             connector_type: data.data.type,
@@ -160,13 +170,16 @@ const ConnectorTab: React.FC<ConnectorTabProps> = ({
           updateContent(tabId, newId);
           setLocalSourceId(newId);
         }
+        return { success: true, isNew };
       } else {
         const serverError = data.error || data.message || JSON.stringify(data);
         setError(serverError);
+        return { success: false, isNew };
       }
     } catch (err: any) {
       console.error("Error saving connector", err);
       setError(err.message || "Failed to save connector");
+      return { success: false, isNew };
     }
   };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Creating and updating connectors had no UI feedback:
- No button animation while the save request was in flight.
- Nothing clearly indicated the connector was saved.
- The connector sidebar list required a manual refresh before a newly created connector appeared.

## Root cause

- `ConnectorForm`'s submit button never disabled or showed a spinner, and `ConnectorTab.handleSubmit` (async) was fired without `await`, so the form had no notion of "in flight" or "succeeded".
- There was no success toast on save.
- `ConnectorTab` upserted the saved connector into `connectorEntitiesStore`, but the sidebar list (`ConnectorExplorer`) reads from a **different** cache, `dataSourceEntitiesStore` — so the list stayed stale until a manual refresh.

## Fix

- `ConnectorTab.handleSubmit` now upserts the saved entity into **both** entity stores and returns `{ success, isNew }`.
- `ConnectorForm` awaits `onSubmit`, tracks `isSubmitting` to disable the buttons and show a spinner ("Creating…" / "Updating…"), and shows a success `Snackbar`/`Alert` on save ("Connector created/updated successfully").
- "No changes" edits now surface a small info snackbar instead of silently doing nothing.

## Walkthrough

Create flow — success toast + connector appears in the previously-empty sidebar list with no manual refresh:
[connector_create_success_toast_and_live_list.mp4](https://cursor.com/agents/bc-a0ce3bc7-f1b0-4291-b77d-907c28722145/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconnector_create_success_toast_and_live_list.mp4)

Button in-flight state — the Update button is disabled and shows a spinner while saving (temporary ~1.8s delay added only for the recording, not committed):
[connector_update_button_spinner_demo.mp4](https://cursor.com/agents/bc-a0ce3bc7-f1b0-4291-b77d-907c28722145/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconnector_update_button_spinner_demo.mp4)

Rename reflects live in the sidebar:
[Renamed connector shown live in sidebar](https://cursor.com/agents/bc-a0ce3bc7-f1b0-4291-b77d-907c28722145/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconnector_rename_in_sidebar.webp)

## Testing

- `pnpm --filter app run typecheck`
- `pnpm --filter app run lint`
- Manual end-to-end: created a REST connector and renamed it; confirmed success toast, in-flight button spinner, and live sidebar updates without refresh.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0ce3bc7-f1b0-4291-b77d-907c28722145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0ce3bc7-f1b0-4291-b77d-907c28722145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

