### PR TITLE
fix(public-share): clicking Refresh no longer breaks shared apps

### DIFF
--- a/app/src/components/public/PublicAppViewer.tsx
+++ b/app/src/components/public/PublicAppViewer.tsx
@@ -122,7 +122,21 @@ export default function PublicAppViewer({
     else window.history.pushState(null, "", next);
   }, []);
 
-  // Preload all ready parquet bindings.
+  // Tear down the app's DuckDB instance only when the viewer unmounts. This
+  // MUST NOT depend on `content`: the refresh poll calls reloadContent() (and
+  // thus setContent) on every attempt, so a content-keyed cleanup would
+  // dispose + recreate the instance every few seconds — wiping every loaded
+  // table out from under the running app and breaking its queries mid-refresh.
+  useEffect(() => {
+    return () => {
+      void disposeAppDuckDB(duckAppId);
+    };
+  }, [duckAppId]);
+
+  // (Re)load ready parquet bindings whenever content changes. ensureBindingLoaded
+  // is revision-cached (no-op when unchanged) and reloads in place when a new
+  // snapshot is ready, so bindings still mid-rematerialization keep their
+  // previously-loaded table instead of being dropped.
   useEffect(() => {
     for (const binding of content.dataBindings) {
       const loadable = toLoadableBinding(binding);
@@ -132,9 +146,6 @@ export default function PublicAppViewer({
         });
       }
     }
-    return () => {
-      void disposeAppDuckDB(duckAppId);
-    };
   }, [duckAppId, content]);
 
   // Bridge: serve binding + DuckDB requests from snapshot data only.
@@ -280,23 +291,34 @@ export default function PublicAppViewer({
     );
   }, [effectiveMode]);
 
-  // Theme comes from a ref on purpose: it only seeds the boot paint and must
-  // not rebuild the (slow, Babel-compiled) preview — set-theme handles toggles.
-  const srcDoc = useMemo(
+  // Rebuild the (slow, Babel-compiled) preview only when the app's *code*
+  // changes — never on data-only refreshes. The refresh poll swaps in a fresh
+  // `content` object every few seconds; keying the srcdoc on the whole object
+  // would reboot the iframe each time and reset the running app's UI state.
+  // Data bindings reach the app over the message bridge, not the srcdoc, so
+  // they're deliberately excluded from this signature.
+  const codeSignature = useMemo(
     () =>
-      buildPreviewHtml(
-        {
-          files: content.files,
-          dependencies: content.dependencies,
-          entrypoint: content.entrypoint,
-        } as Parameters<typeof buildPreviewHtml>[0],
-        {
-          theme: effectiveModeRef.current,
-          location: initialAppLocationRef.current,
-        },
-      ),
+      JSON.stringify({
+        entrypoint: content.entrypoint,
+        dependencies: content.dependencies,
+        files: content.files,
+      }),
     [content],
   );
+
+  // Theme comes from a ref on purpose: it only seeds the boot paint and must
+  // not rebuild the preview — set-theme handles toggles. The app code is parsed
+  // back from `codeSignature` so the memo recomputes only when the code changes.
+  const srcDoc = useMemo(() => {
+    const code = JSON.parse(codeSignature) as Parameters<
+      typeof buildPreviewHtml
+    >[0];
+    return buildPreviewHtml(code, {
+      theme: effectiveModeRef.current,
+      location: initialAppLocationRef.current,
+    });
+  }, [codeSignature]);
 
   const hasMaterializedBindings = content.dataBindings.some(
     binding => binding.materialization === "parquet",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Clicking **Refresh data** on a public, shared **app** (`/share/:token`) breaks the running app with a DuckDB catalog error such as:

> `Catalog Error: Table with name cohort_v3 does not exist! Did you mean 'icp_v3'?`

## Root cause

In `app/src/components/public/PublicAppViewer.tsx`, the effect that preloads parquet bindings was keyed on `content` **and** its cleanup called `disposeAppDuckDB(duckAppId)`. The refresh flow polls `reloadContent()` — which calls `setContent(next)` with a fresh object on **every** attempt (~every 8s for up to 2 minutes). Each new `content` reference re-ran the effect, so React first ran the cleanup, **tearing down the whole DuckDB instance and wiping every loaded table**, then reloaded only the bindings that were `ready` at that instant.

Server-side, `POST /api/share/:token/refresh` re-materializes all bindings with `force: true`. While a binding is rebuilding it reports `ready: false`, so the viewer dropped its table and never reloaded it. The next time the app re-queried that binding (e.g. on a tab/filter change) it hit a now-missing table and errored — persistently.

## Fix

- Dispose the app's DuckDB instance **only on unmount** (`deps: [duckAppId]`).
- Load ready bindings on `content` change **without** tearing down the instance. `ensureBindingLoaded` is revision-cached and reloads each table in place when a new snapshot is ready, so bindings still mid-rematerialization keep their previously-loaded snapshot instead of being dropped.
- Stabilize `srcDoc` on a code-only signature (`files`/`dependencies`/`entrypoint`) so data-only refreshes no longer rebuild the srcdoc. Data bindings reach the app over the message bridge, not the srcdoc.

## Evidence

Reproduced with a shared app whose "albums" binding re-materializes slowly, leaving it mid-rebuild during the refresh poll while "artists" finishes instantly.

**Before (bug) — Albums panel errors after Refresh, mirroring the reported screenshot:**

[Before: Catalog Error after refresh](https://cursor.com/agents/bc-28e3d2bd-7033-4523-909b-6ddb11a2924a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbefore_refresh_catalog_error.webp)

**After (fixed) — both panels keep rendering valid data through the refresh, even while re-querying every 2s:**

[After: panels stay valid through refresh](https://cursor.com/agents/bc-28e3d2bd-7033-4523-909b-6ddb11a2924a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_refresh_fixed.webp)

## Testing

- ✅ `pnpm --filter app run typecheck`
- ✅ `pnpm --filter app run lint`
- Manual repro of the exact `Catalog Error: Table ... does not exist` on the pre-fix code, and confirmation it no longer occurs with the fix.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28e3d2bd-7033-4523-909b-6ddb11a2924a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28e3d2bd-7033-4523-909b-6ddb11a2924a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

