### PR TITLE
feat(dbt): environment badge on job rows in Jobs & runs explorer

### DIFF
--- a/app/src/components/DbtExplorer.tsx
+++ b/app/src/components/DbtExplorer.tsx
@@ -218,6 +218,27 @@ function scheduleSummary(job: DbtJobItem): string {
   return `${job.schedule.cron} ${job.schedule.timezone ?? "UTC"}`;
 }
 
+/**
+ * MUI Chip color for a job's environment badge. Prod-like envs are flagged
+ * `warning` so destructive/scheduled prod runs stand out; the project default
+ * and dev-like envs get `info`, everything else stays neutral.
+ */
+function envBadgeColor(
+  envName: string,
+  defaultEnvironment?: string,
+): "warning" | "info" | "default" {
+  const lower = envName.trim().toLowerCase();
+  if (lower === "prod" || lower === "production") return "warning";
+  if (
+    lower === "dev" ||
+    lower === "development" ||
+    (defaultEnvironment != null && envName === defaultEnvironment)
+  ) {
+    return "info";
+  }
+  return "default";
+}
+
 /** Collapsible section header (dbt Studio "Version control" / "File explorer"). */
 function SectionHeader({
   label,
@@ -1688,6 +1709,28 @@ export function DbtExplorer() {
                               {scheduleSummary(job)}
                             </Box>
                           </Box>
+                          {job.environment && (
+                            <Tooltip title={`Environment: ${job.environment}`}>
+                              <Chip
+                                label={job.environment}
+                                size="small"
+                                variant="outlined"
+                                color={envBadgeColor(
+                                  job.environment,
+                                  activeProject.defaultEnvironment,
+                                )}
+                                sx={{
+                                  flexShrink: 0,
+                                  height: 18,
+                                  maxWidth: 90,
+                                  fontSize: 10,
+                                  fontWeight: 600,
+                                  textTransform: "uppercase",
+                                  "& .MuiChip-label": { px: 0.625 },
+                                }}
+                              />
+                            </Tooltip>
+                          )}
                           <IconButton
                             size="small"
                             aria-label="Job actions"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a color-coded **environment badge** to each dbt job row in the `JOBS & RUNS` section of the dbt explorer (`DbtExplorer.tsx`). Previously the sidebar only showed the job name + schedule, with no indication of which environment a job runs against — so prod and dev jobs looked identical.

## Why

The job's target environment is the most safety-relevant attribute of a scheduled dbt job. Surfacing it inline lets you tell at a glance whether a row runs against `prod`, `dev`, or `staging` without opening the job detail tab.

## How

- New `envBadgeColor()` helper maps an env name to a MUI Chip color:
  - `prod` / `production` → `warning` (orange) so destructive/scheduled prod runs stand out
  - `dev` / `development` / the project's `defaultEnvironment` → `info` (blue)
  - everything else → `default` (neutral)
- Renders a compact outlined `Chip` (`job.environment`) between the name/schedule block and the kebab menu, with a `Environment: <name>` tooltip. Reuses the existing chip pattern from `DbtJobView`.

## Testing

- `pnpm --filter app run typecheck` ✅
- `pnpm --filter app run lint` ✅
- Manually verified against seeded `Analytics` project with `dev`/`staging`/`prod` jobs: badges render with correct colors and tooltips (`Environment: prod` / `staging` / `dev`).

[dbt Jobs & runs with environment badges](https://cursor.com/agents/bc-45ba8449-815c-4306-ae02-e3b1b091f0f9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdbt_jobs_env_badges.webp)
[prod badge tooltip: Environment: prod](https://cursor.com/agents/bc-45ba8449-815c-4306-ae02-e3b1b091f0f9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdbt_badge_prod_tooltip.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45ba8449-815c-4306-ae02-e3b1b091f0f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45ba8449-815c-4306-ae02-e3b1b091f0f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

