### PR TITLE
fix(pandadoc): hydrate documents with full detail during backfill

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -13,7 +13,7 @@
     "worker:dev": "tsx watch src/worker.ts",
     "migrate:workspaces": "tsx src/migrations/migrate-to-workspaces.ts",
     "openapi:generate": "tsx src/openapi/generate-cli.ts",
-    "test": "tsx src/openapi/core.test.ts && tsx src/openapi/openapi.test.ts && tsx src/dbt/warm-dir-cache.test.ts && tsx src/connectors/stripe/connector.test.ts && tsx src/connectors/close/connector.test.ts && tsx src/sync-cdc/idempotency.test.ts && tsx src/agent-lib/context/compaction.test.ts && tsx src/services/safe-fetch.service.test.ts && tsx src/agent-lib/tools/check-query-status-poll.test.ts",
+    "test": "tsx src/openapi/core.test.ts && tsx src/openapi/openapi.test.ts && tsx src/dbt/warm-dir-cache.test.ts && tsx src/connectors/stripe/connector.test.ts && tsx src/connectors/close/connector.test.ts && tsx src/connectors/pandadoc/connector.test.ts && tsx src/sync-cdc/idempotency.test.ts && tsx src/agent-lib/context/compaction.test.ts && tsx src/services/safe-fetch.service.test.ts && tsx src/agent-lib/tools/check-query-status-poll.test.ts",
     "test:dbt": "vitest run",
     "test:dbt:watch": "vitest",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives",

--- a/api/src/connectors/pandadoc/connector.test.ts
+++ b/api/src/connectors/pandadoc/connector.test.ts
@@ -2,7 +2,10 @@ import crypto from "node:crypto";
 import assert from "node:assert/strict";
 import { PandaDocConnector } from "./connector";
 
-function createConnector(config: Record<string, unknown> = {}) {
+function createConnector(
+  config: Record<string, unknown> = {},
+  settings: Record<string, unknown> = {},
+) {
   return new PandaDocConnector({
     id: "ds_pandadoc",
     name: "PandaDoc",
@@ -12,6 +15,7 @@ function createConnector(config: Record<string, unknown> = {}) {
       api_base_url: "https://api.pandadoc.com",
       ...config,
     },
+    settings,
   } as any);
 }
 
@@ -279,7 +283,173 @@ function testEntityMetadataIncludesLayoutSuggestion() {
 function testConfigSchemaWiresAllFields() {
   const schema = PandaDocConnector.getConfigSchema();
   const names = schema.fields.map(f => f.name);
-  assert.deepEqual(names, ["api_key", "api_base_url"]);
+  assert.deepEqual(names, [
+    "api_key",
+    "api_base_url",
+    "fetch_document_details",
+  ]);
+  const detailField = schema.fields.find(
+    f => f.name === "fetch_document_details",
+  );
+  assert.equal(detailField?.type, "boolean");
+  assert.equal(detailField?.default, true);
+}
+
+type FakeGet = (url: string, config?: { params?: unknown }) => Promise<unknown>;
+
+function injectFakeClient(connector: PandaDocConnector, get: FakeGet) {
+  (connector as unknown as { pandaDocApi: { get: FakeGet } }).pandaDocApi = {
+    get,
+  };
+}
+
+const DOCUMENT_LIST_RESPONSE = {
+  data: {
+    results: [
+      { id: "doc_1", name: "List Doc One", status: "document.completed" },
+      { id: "doc_2", name: "List Doc Two", status: "document.draft" },
+    ],
+  },
+};
+
+async function collectDocuments(
+  connector: PandaDocConnector,
+): Promise<Record<string, unknown>[]> {
+  const records: Record<string, unknown>[] = [];
+  await connector.fetchEntity({
+    entity: "documents",
+    onBatch: async batch => {
+      records.push(...(batch as Record<string, unknown>[]));
+    },
+  });
+  return records;
+}
+
+async function testBackfillHydratesDocumentDetails() {
+  const connector = createConnector();
+  const detailCalls: string[] = [];
+
+  injectFakeClient(connector, async url => {
+    if (url === "/public/v1/documents") {
+      return DOCUMENT_LIST_RESPONSE;
+    }
+    const match = url.match(/^\/public\/v1\/documents\/(.+)\/details$/);
+    if (match) {
+      const id = decodeURIComponent(match[1]);
+      detailCalls.push(id);
+      return {
+        data: {
+          id,
+          name: `Detail ${id}`,
+          fields: [{ name: "contract_start", value: "2024-01-01" }],
+          tokens: [{ name: "Client.Company", value: "Acme" }],
+          metadata: { contract_id: `c-${id}` },
+          pricing: { tables: [] },
+        },
+      };
+    }
+    throw new Error(`Unexpected URL ${url}`);
+  });
+
+  const records = await collectDocuments(connector);
+
+  assert.equal(records.length, 2);
+  assert.deepEqual(detailCalls.sort(), ["doc_1", "doc_2"]);
+
+  const doc1 = records.find(r => r.id === "doc_1");
+  assert.ok(doc1, "expected doc_1 in results");
+  // Rich nested objects only available from the details endpoint.
+  assert.ok(Array.isArray(doc1?.fields));
+  assert.ok(Array.isArray(doc1?.tokens));
+  assert.ok(doc1?.metadata && typeof doc1.metadata === "object");
+  // Detail values take precedence over the shallow list projection.
+  assert.equal(doc1?.name, "Detail doc_1");
+  // List-only fields still survive the merge.
+  assert.equal(doc1?.status, "document.completed");
+}
+
+async function testDetailHydrationCanBeDisabled() {
+  const connector = createConnector({ fetch_document_details: false });
+  let detailCalled = false;
+
+  injectFakeClient(connector, async url => {
+    if (url.includes("/details")) {
+      detailCalled = true;
+      return { data: {} };
+    }
+    return DOCUMENT_LIST_RESPONSE;
+  });
+
+  const records = await collectDocuments(connector);
+
+  assert.equal(detailCalled, false);
+  assert.equal(records.length, 2);
+  assert.equal(records[0].fields, undefined);
+  assert.equal(records[0].metadata, undefined);
+}
+
+async function testBackfillPaginatesAndHydratesAcrossChunks() {
+  // sync_batch_size 2 makes a "full page" two records, so the dataset spans
+  // multiple pages and multiple resumable chunks (the detail-hydration cap is 2
+  // pages/chunk). rate_limit_delay_ms 0 keeps the test fast.
+  const connector = createConnector(
+    {},
+    { sync_batch_size: 2, rate_limit_delay_ms: 0 },
+  );
+
+  const pages: Record<number, { id: string }[]> = {
+    1: [{ id: "d1" }, { id: "d2" }],
+    2: [{ id: "d3" }, { id: "d4" }],
+    3: [{ id: "d5" }],
+  };
+  const detailCalls: string[] = [];
+
+  injectFakeClient(connector, async (url, config) => {
+    if (url === "/public/v1/documents") {
+      const page = Number(
+        (config?.params as { page?: number } | undefined)?.page ?? 1,
+      );
+      return { data: { results: pages[page] ?? [] } };
+    }
+    const match = url.match(/^\/public\/v1\/documents\/(.+)\/details$/);
+    if (match) {
+      const id = decodeURIComponent(match[1]);
+      detailCalls.push(id);
+      return { data: { id, metadata: { hydrated: true } } };
+    }
+    throw new Error(`Unexpected URL ${url}`);
+  });
+
+  const records = await collectDocuments(connector);
+
+  assert.equal(records.length, 5);
+  assert.deepEqual(detailCalls.sort(), ["d1", "d2", "d3", "d4", "d5"]);
+  assert.ok(
+    records.every(
+      r => (r.metadata as { hydrated?: boolean } | undefined)?.hydrated === true,
+    ),
+    "every document should be hydrated across chunk boundaries",
+  );
+}
+
+async function testDetailFetchFailureKeepsListProjection() {
+  const connector = createConnector();
+
+  injectFakeClient(connector, async url => {
+    if (url.includes("/details")) {
+      throw new Error("HTTP 500: boom");
+    }
+    return DOCUMENT_LIST_RESPONSE;
+  });
+
+  const records = await collectDocuments(connector);
+
+  // A per-document detail failure must not fail the whole backfill; the list
+  // projection is retained instead.
+  assert.equal(records.length, 2);
+  const doc1 = records.find(r => r.id === "doc_1");
+  assert.equal(doc1?.name, "List Doc One");
+  assert.equal(doc1?.fields, undefined);
 }
 
 async function main() {
@@ -301,6 +471,10 @@ async function main() {
   await testResolveSchema();
   testEntityMetadataIncludesLayoutSuggestion();
   testConfigSchemaWiresAllFields();
+  await testBackfillHydratesDocumentDetails();
+  await testDetailHydrationCanBeDisabled();
+  await testBackfillPaginatesAndHydratesAcrossChunks();
+  await testDetailFetchFailureKeepsListProjection();
 }
 
 main().catch((error: unknown) => {

--- a/api/src/connectors/pandadoc/connector.ts
+++ b/api/src/connectors/pandadoc/connector.ts
@@ -49,6 +49,24 @@ const ENTITY_LIST_PATH: Record<SupportedEntity, string> = {
   members: "/public/v1/members",
 };
 
+// The document LIST endpoint only returns a shallow projection. The rich nested
+// objects (fields, tokens, metadata, pricing, products, grand_total,
+// recipients, ...) live exclusively on the per-document DETAILS endpoint, so
+// backfill must hydrate each listed document from here.
+const documentDetailPath = (documentId: string): string =>
+  `/public/v1/documents/${encodeURIComponent(documentId)}/details`;
+
+// How many document-detail requests to run concurrently while hydrating a list
+// page. Kept small so a backfill stays well under PandaDoc's rate limits while
+// still being meaningfully faster than a fully sequential loop.
+const DOCUMENT_DETAIL_CONCURRENCY = 5;
+
+// When detail hydration is on, every list page fans out into up to
+// `pageCount` extra detail requests. Cap the pages processed per resumable
+// chunk so a single chunk's wall-clock stays bounded; the resume cursor picks
+// up the remaining pages on the next chunk.
+const DETAIL_HYDRATION_MAX_PAGES_PER_CHUNK = 2;
+
 // All PandaDoc webhook triggers. document_deleted/template_deleted map to a
 // CDC delete; everything else is an upsert.
 const DOCUMENT_TRIGGERS = [
@@ -148,6 +166,15 @@ export class PandaDocConnector extends BaseConnector {
           type: "string",
           required: false,
           default: DEFAULT_BASE_URL,
+        },
+        {
+          name: "fetch_document_details",
+          label: "Fetch full document details",
+          type: "boolean",
+          required: false,
+          default: true,
+          helperText:
+            "Hydrate each document with its full detail (fields, tokens, metadata, pricing, products, recipients) during backfill. The document list endpoint omits these. Disable to reduce API calls if you hit rate limits.",
         },
       ],
     };
@@ -257,6 +284,76 @@ export class PandaDocConnector extends BaseConnector {
         ? batchSize
         : this.getBatchSize();
     return Math.min(Math.max(requested, 1), MAX_PAGE_LIMIT);
+  }
+
+  /**
+   * Whether to hydrate listed documents from the per-document details endpoint.
+   * Defaults to ON; the `fetch_document_details` config flag can disable it for
+   * rate-limit-constrained workspaces.
+   */
+  private shouldFetchDocumentDetails(): boolean {
+    const configured = this.dataSource.config.fetch_document_details;
+    return configured !== false && configured !== "false";
+  }
+
+  /**
+   * Hydrate each document from `GET /public/v1/documents/{id}/details`, merging
+   * the rich nested objects (fields, tokens, metadata, pricing, products,
+   * grand_total, recipients, ...) over the shallow list projection. Detail
+   * fetches run in small concurrent batches and a per-document failure falls
+   * back to the list projection rather than failing the whole backfill.
+   */
+  private async enrichDocumentsWithDetails(
+    records: Record<string, unknown>[],
+    rateLimitDelay: number,
+  ): Promise<Record<string, unknown>[]> {
+    if (records.length === 0 || !this.shouldFetchDocumentDetails()) {
+      return records;
+    }
+
+    const api = this.getClient();
+    const enriched = [...records];
+
+    for (let start = 0; start < enriched.length; start += DOCUMENT_DETAIL_CONCURRENCY) {
+      const batch = enriched.slice(start, start + DOCUMENT_DETAIL_CONCURRENCY);
+
+      await Promise.all(
+        batch.map(async (record, offset) => {
+          const documentId =
+            typeof record.id === "string" && record.id.length > 0
+              ? record.id
+              : undefined;
+          if (!documentId) return;
+
+          try {
+            const response = await this.executeWithRetry(() =>
+              api.get<Record<string, unknown>>(documentDetailPath(documentId)),
+            );
+            const detail = response.data;
+            if (detail && typeof detail === "object") {
+              enriched[start + offset] = withId("documents", {
+                ...record,
+                ...detail,
+              });
+            }
+          } catch (error) {
+            logger.warn(
+              "Failed to fetch PandaDoc document details; keeping list projection",
+              {
+                documentId,
+                error: formatPandaDocApiError(error),
+              },
+            );
+          }
+        }),
+      );
+
+      if (start + DOCUMENT_DETAIL_CONCURRENCY < enriched.length) {
+        await this.sleep(rateLimitDelay);
+      }
+    }
+
+    return enriched;
   }
 
   async testConnection(): Promise<ConnectionTestResult> {
@@ -403,10 +500,19 @@ export class PandaDocConnector extends BaseConnector {
     entity: SupportedEntity,
   ): Promise<FetchState> {
     const { onBatch, onProgress, since, state, batchSize } = options;
-    const maxIterations = options.maxIterations ?? 10;
     const api = this.getClient();
     const path = ENTITY_LIST_PATH[entity];
     const count = this.resolvePageCount(batchSize);
+    const rateLimitDelay = options.rateLimitDelay ?? this.getRateLimitDelay();
+
+    // Hydrating documents fans each page out into many detail requests, so cap
+    // the pages handled per chunk to keep the chunk's runtime bounded.
+    const hydrateDocuments =
+      entity === "documents" && this.shouldFetchDocumentDetails();
+    const maxIterations = Math.min(
+      options.maxIterations ?? 10,
+      hydrateDocuments ? DETAIL_HYDRATION_MAX_PAGES_PER_CHUNK : Number.MAX_SAFE_INTEGER,
+    );
 
     let page = (state?.page as number | undefined) ?? 1;
     let recordCount = state?.totalProcessed ?? 0;
@@ -421,11 +527,15 @@ export class PandaDocConnector extends BaseConnector {
         ? response.data.results
         : [];
 
-      const records = this.mapRecords(
+      let records = this.mapRecords(
         entity,
         results as Record<string, unknown>[],
         since,
       );
+
+      if (hydrateDocuments) {
+        records = await this.enrichDocumentsWithDetails(records, rateLimitDelay);
+      }
 
       if (records.length > 0) {
         await onBatch(records);
@@ -446,7 +556,7 @@ export class PandaDocConnector extends BaseConnector {
       }
 
       page++;
-      await this.sleep(options.rateLimitDelay ?? this.getRateLimitDelay());
+      await this.sleep(rateLimitDelay);
     }
 
     return {
@@ -501,10 +611,13 @@ export class PandaDocConnector extends BaseConnector {
   }
 
   async fetchEntity(options: FetchOptions): Promise<void> {
-    await this.fetchEntityChunk({
-      ...options,
-      maxIterations: Number.MAX_SAFE_INTEGER,
-    });
+    // Drain every chunk. Looping (rather than one giant maxIterations) keeps the
+    // internal per-chunk caps used for detail hydration from truncating a full,
+    // non-resumable fetch.
+    let state: FetchState | undefined;
+    do {
+      state = await this.fetchEntityChunk({ ...options, state });
+    } while (state.hasMore);
   }
 
   supportsWebhooks(): boolean {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

PandaDoc's document **list** endpoint (`GET /public/v1/documents`) only returns a shallow projection. The rich nested objects — `fields`, `tokens`, `metadata`, `pricing`, `products`, `grand_total`, `recipients`, etc. — are returned **only** by the per-document **details** endpoint (`GET /public/v1/documents/{id}/details`).

Webhooks already received those sections (the subscription requests `payload: ["fields","products","tokens","metadata","pricing"]`), but **backfill never called the details endpoint**, so after a backfill those JSON columns existed but were 100% empty. Any custom contract dates living in `fields`/`tokens`/`metadata` were therefore missing.

## Fix

- Hydrate each listed document from `GET /public/v1/documents/{id}/details`, merging the rich detail over the shallow list projection (detail wins, list-only fields preserved).
- Detail fetches run in small concurrent batches (`DOCUMENT_DETAIL_CONCURRENCY = 5`) with the existing 429/5xx retry + rate-limit-delay handling.
- A per-document detail failure soft-falls back to the list projection (with a warning log) instead of failing the whole backfill.
- Added a `fetch_document_details` boolean config flag (default **on**) so rate-limit-constrained workspaces can opt out. Schema-driven, so no UI changes required.
- Bounded detail-hydration work per resumable chunk (`DETAIL_HYDRATION_MAX_PAGES_PER_CHUNK = 2`) to keep chunk runtime in check, and reworked `fetchEntity` to drain via a chunk loop so the per-chunk cap never truncates a full fetch.

## Testing

- Added connector tests with a mocked client: detail hydration, disable flag, multi-page/multi-chunk drain, and per-document failure fallback.
- Wired the previously-unreferenced `pandadoc/connector.test.ts` into the `api` `test` script.

- ✅ `pnpm --filter api exec tsx src/connectors/pandadoc/connector.test.ts`
- ✅ `pnpm --filter api run lint`
- ✅ `tsc -p tsconfig.build.json --noEmit`

This is a backend connector change with no real PandaDoc credentials available in the environment, so end-to-end evidence is the mocked-client unit tests, which exercise the full `fetchEntity` → list → detail-hydration → merge flow.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9cccbbde-91d3-45c2-9858-7acec7009879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9cccbbde-91d3-45c2-9858-7acec7009879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

