### PR TITLE
fix(chat): grow chat input to ~24 lines + collapse long sent messages in history

### DIFF
--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -5,6 +5,7 @@
 import React, {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useState,
   useRef,
@@ -750,6 +751,82 @@ const assistantMessageSx = {
 } as const;
 const listItemSx = { p: 0 } as const;
 
+// Sent user messages are collapsed in the history so a long prompt doesn't
+// dominate the transcript. Show at most this many lines before clamping.
+const USER_MESSAGE_COLLAPSED_LINES = 3;
+
+const userMessageToggleSx = {
+  display: "inline-block",
+  mt: 0.5,
+  border: "none",
+  background: "none",
+  p: 0,
+  cursor: "pointer",
+  color: "text.secondary",
+  fontWeight: 600,
+  "&:hover": { color: "text.primary", textDecoration: "underline" },
+} as const;
+
+/**
+ * Renders a sent user message's text, collapsed to a few lines with an ellipsis
+ * when it's long. Clicking the text (or the Show more/less toggle) expands and
+ * re-collapses it. The toggle only appears when the text actually overflows the
+ * collapsed clamp, so short messages render unchanged.
+ */
+function CollapsibleUserText({ text }: { text: string }) {
+  const [expanded, setExpanded] = useState(false);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+  const textRef = useRef<HTMLDivElement | null>(null);
+
+  // Measure whether the clamped text overflows. Only meaningful while
+  // collapsed, where the clamp limits height; comparing the full content
+  // height (scrollHeight) against the visible height (clientHeight) tells us
+  // if there's hidden content worth a toggle.
+  useLayoutEffect(() => {
+    if (expanded) return;
+    const el = textRef.current;
+    if (!el) return;
+    setIsOverflowing(el.scrollHeight > el.clientHeight + 1);
+  }, [text, expanded]);
+
+  const canToggle = isOverflowing || expanded;
+  const toggle = useCallback(() => setExpanded(prev => !prev), []);
+
+  return (
+    <Box>
+      <Typography
+        ref={textRef}
+        variant="body2"
+        color="text.primary"
+        onClick={canToggle ? toggle : undefined}
+        sx={{
+          ...userMessageTextSx,
+          ...(canToggle && { cursor: "pointer" }),
+          ...(!expanded && {
+            display: "-webkit-box",
+            WebkitBoxOrient: "vertical",
+            WebkitLineClamp: USER_MESSAGE_COLLAPSED_LINES,
+            overflow: "hidden",
+          }),
+        }}
+      >
+        {text}
+      </Typography>
+      {canToggle && (
+        <Typography
+          component="button"
+          type="button"
+          onClick={toggle}
+          variant="caption"
+          sx={userMessageToggleSx}
+        >
+          {expanded ? "Show less" : "Show more"}
+        </Typography>
+      )}
+    </Box>
+  );
+}
+
 /**
  * Lightweight, dependency-free image lightbox. Shows the full (uncropped) image
  * centered over a dimmed backdrop; closes on backdrop click, the X button, or
@@ -892,15 +969,7 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
                 ))}
               </Box>
             )}
-            {textContent && (
-              <Typography
-                variant="body2"
-                color="text.primary"
-                sx={userMessageTextSx}
-              >
-                {textContent}
-              </Typography>
-            )}
+            {textContent && <CollapsibleUserText text={textContent} />}
           </Paper>
         </Box>
         <ImagePreviewDialog

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -1673,7 +1673,7 @@ const ChatInputArea = React.memo(
             autoFocus
             multiline
             minRows={1}
-            maxRows={6}
+            maxRows={24}
             placeholder={
               editingPrompt ? "Edit queued message..." : "Ask Chat..."
             }
@@ -1698,7 +1698,7 @@ const ChatInputArea = React.memo(
             inputRef={inputRef}
             sx={{
               m: 0.5,
-              maxHeight: "50vh",
+              maxHeight: "60vh",
               overflowY: "auto",
               "& .MuiInputBase-input": {
                 fontSize: { xs: 16, sm: 14 },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two related chat composer/history UX fixes in `app/src/components/Chat.tsx`:

### 1. Chat input grows with content again
The chat input only expanded to **6 lines** (`maxRows={6}`) before scrolling, so it felt like it stopped growing.
- Raised `maxRows` `6` → `24` (grows up to ~24 lines, within the requested 20–30 range) before scrolling.
- Raised the viewport safety cap `maxHeight: 50vh` → `60vh` so the taller input isn't clipped below ~20 lines on standard laptop viewports.

### 2. Long sent messages are collapsed in the history
A long prompt used to render in full in the transcript, dominating the history.
- Added a `CollapsibleUserText` component that clamps a sent user message to **3 lines with an ellipsis** when it overflows, with a **Show more / Show less** toggle (clicking the text or the link expands/collapses).
- The toggle only appears when the text actually overflows the 3-line clamp (overflow is measured via `scrollHeight` vs `clientHeight`), so short messages render unchanged.

## Walkthrough

Input auto-grows as content is added:
[chat_input_autogrows_with_text.mp4](https://cursor.com/agents/bc-d03591de-298b-4583-9e48-2e9bbc057ed0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchat_input_autogrows_with_text.mp4)

Input before vs. after (15+ lines typed in):
[Before: input capped at 6 lines](https://cursor.com/agents/bc-d03591de-298b-4583-9e48-2e9bbc057ed0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchat_input_before_6line_cap.webp)
[After: input grows to ~24 lines](https://cursor.com/agents/bc-d03591de-298b-4583-9e48-2e9bbc057ed0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchat_input_after_24_lines.webp)

Sent long message collapses to 3 lines and expands on click:
[sent_message_collapse_expand.mp4](https://cursor.com/agents/bc-d03591de-298b-4583-9e48-2e9bbc057ed0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsent_message_collapse_expand.mp4)
[Collapsed: sent message clamped to 3 lines with Show more](https://cursor.com/agents/bc-d03591de-298b-4583-9e48-2e9bbc057ed0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsent_message_collapsed_3lines.webp)
[Expanded: full sent message with Show less](https://cursor.com/agents/bc-d03591de-298b-4583-9e48-2e9bbc057ed0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsent_message_expanded.webp)

## Testing

Manually tested in the running app (Vite + Hono + local Mongo):
- Input: capped at 6 lines before, grows to ~24 then scrolls after.
- Sent message: long message renders collapsed to 3 lines + ellipsis + "Show more"; clicking expands to full text + "Show less"; clicking collapses again. Short messages are unaffected.
- ✅ `pnpm --filter app run typecheck`
- ✅ `pnpm --filter app run lint`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d03591de-298b-4583-9e48-2e9bbc057ed0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d03591de-298b-4583-9e48-2e9bbc057ed0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

