### PR TITLE
fix(apps): refresh public share app view in place

### DIFF
--- a/app/src/app-runtime/duckdb.ts
+++ b/app/src/app-runtime/duckdb.ts
@@ -21,6 +21,8 @@ interface AppDuckDB {
   db: AsyncDuckDB;
   /** tableName -> loaded artifact revision (skip reload when unchanged). */
   loaded: Map<string, string>;
+  /** tableName -> in-flight load, so concurrent callers serialize per table. */
+  loading: Map<string, Promise<void>>;
 }
 
 const instances = new Map<string, AppDuckDB>();
@@ -40,7 +42,7 @@ async function getInstance(appId: string): Promise<AppDuckDB> {
 
   const promise = (async () => {
     const db = await createDuckDBInstance();
-    const inst: AppDuckDB = { db, loaded: new Map() };
+    const inst: AppDuckDB = { db, loaded: new Map(), loading: new Map() };
     instances.set(appId, inst);
     initializing.delete(appId);
     return inst;
@@ -70,19 +72,43 @@ export async function ensureBindingLoaded(
   const inst = await getInstance(appId);
   const table = bindingTableName(binding.name);
   const revision = cache.artifactRevision || cache.definitionHash || "";
+  const parquetUrl = cache.parquetUrl;
+
+  // Fast path: this exact snapshot is already loaded.
   if (inst.loaded.get(table) === revision) return true;
 
-  const response = await fetch(cache.parquetUrl, {
-    credentials: "include",
-    signal,
+  // Serialize loads for a table. The viewer preloads bindings in an effect at
+  // the same time the booted app issues on-demand reads (and several widgets
+  // can read the same binding at once); without this, two callers would
+  // DROP/CREATE the same table from separate connections concurrently, leaving
+  // it missing mid-rebuild — which surfaces as "data source not ready" until
+  // the user retries. Each load waits for the in-flight one, then re-checks the
+  // revision so it no-ops when the snapshot it needs already landed.
+  const prior = inst.loading.get(table) ?? Promise.resolve();
+  const result = prior.then(async () => {
+    if (inst.loaded.get(table) === revision) return true;
+    const response = await fetch(parquetUrl, {
+      credentials: "include",
+      signal,
+    });
+    if (!response.ok || !response.body) {
+      throw new Error(`Failed to fetch parquet for "${binding.name}"`);
+    }
+    const buffer = await collectStreamBytes(response.body);
+    await loadParquetTable(inst.db, table, buffer);
+    inst.loaded.set(table, revision);
+    return true;
   });
-  if (!response.ok || !response.body) {
-    throw new Error(`Failed to fetch parquet for "${binding.name}"`);
-  }
-  const buffer = await collectStreamBytes(response.body);
-  await loadParquetTable(inst.db, table, buffer);
-  inst.loaded.set(table, revision);
-  return true;
+
+  // Keep the per-table chain alive for the next caller even if this load fails.
+  inst.loading.set(
+    table,
+    result.then(
+      () => undefined,
+      () => undefined,
+    ),
+  );
+  return result;
 }
 
 /** Run analytical SQL against the app's loaded tables. */

--- a/app/src/app-runtime/preview.ts
+++ b/app/src/app-runtime/preview.ts
@@ -29,6 +29,10 @@ export const PREVIEW_MESSAGE = {
   bindingResult: "mako-app:binding-result",
   runDuckDb: "mako-app:run-duckdb",
   duckDbResult: "mako-app:duckdb-result",
+  // host -> iframe: the app's materialized data changed (a refresh landed new
+  // parquet snapshots in the parent's DuckDB). The booted app re-runs its data
+  // hooks without a srcdoc rebuild, so the view updates while keeping UI state.
+  dataRefresh: "mako-app:data-refresh",
   capture: "mako-app:capture",
   captureResult: "mako-app:capture-result",
   setTheme: "mako-app:set-theme",
@@ -388,6 +392,25 @@ window.addEventListener("message", (event) => {
     resolve(data);
   }
 });
+
+// --- Data epoch: bumps when the host swaps in a fresh materialized snapshot
+// ("mako-app:data-refresh"). Data hooks depend on it, so they re-fetch when the
+// underlying parquet changes without rebuilding the (slow) srcdoc or losing the
+// running app's UI state. ---
+const dataListeners = new Set();
+let dataEpoch = 0;
+window.addEventListener("message", (event) => {
+  const data = event.data || {};
+  if (data.type !== "mako-app:data-refresh") return;
+  dataEpoch++;
+  dataListeners.forEach((listener) => {
+    try {
+      listener(dataEpoch);
+    } catch (_) {
+      /* listener errors must not break other subscribers */
+    }
+  });
+});
 function runBinding(name, rowLimit) {
   return new Promise((resolve) => {
     const requestId = "req_" + ++reqSeq;
@@ -492,6 +515,14 @@ async function main() {
     useQuery(name, opts) {
       const rowLimit = opts ? opts.rowLimit : undefined;
       const [state, setState] = React.useState({ data: null, error: null, loading: true, truncated: false });
+      const [epoch, setEpoch] = React.useState(dataEpoch);
+      React.useEffect(() => {
+        const listener = (next) => setEpoch(next);
+        dataListeners.add(listener);
+        // Re-sync in case a refresh landed between render and subscribe.
+        setEpoch(dataEpoch);
+        return () => { dataListeners.delete(listener); };
+      }, []);
       React.useEffect(() => {
         let active = true;
         setState({ data: null, error: null, loading: true, truncated: false });
@@ -505,7 +536,7 @@ async function main() {
           }
         });
         return () => { active = false; };
-      }, [name, rowLimit]);
+      }, [name, rowLimit, epoch]);
       return state;
     },
     // Run analytical SQL over the app's materialized (parquet) tables in
@@ -517,6 +548,14 @@ async function main() {
     useDuckDB(sql, opts) {
       const rowLimit = opts ? opts.rowLimit : undefined;
       const [state, setState] = React.useState({ data: null, fields: null, error: null, loading: true, truncated: false, rowCount: null });
+      const [epoch, setEpoch] = React.useState(dataEpoch);
+      React.useEffect(() => {
+        const listener = (next) => setEpoch(next);
+        dataListeners.add(listener);
+        // Re-sync in case a refresh landed between render and subscribe.
+        setEpoch(dataEpoch);
+        return () => { dataListeners.delete(listener); };
+      }, []);
       React.useEffect(() => {
         let active = true;
         setState({ data: null, fields: null, error: null, loading: true, truncated: false, rowCount: null });
@@ -537,7 +576,7 @@ async function main() {
           }
         });
         return () => { active = false; };
-      }, [sql, rowLimit]);
+      }, [sql, rowLimit, epoch]);
       return state;
     },
     // Effective color mode: { theme: "light" | "dark" }. Tracks the host app

--- a/app/src/components/public/PublicAppViewer.tsx
+++ b/app/src/components/public/PublicAppViewer.tsx
@@ -351,6 +351,22 @@ export default function PublicAppViewer({
         await new Promise(resolve => setTimeout(resolve, 8000));
         const fresh = await reloadContent();
         if (fresh && latestMaterializedAt(fresh) !== before) {
+          // Pull the new snapshots into DuckDB *before* telling the booted app
+          // to re-query — otherwise its hooks could read the previous table.
+          // ensureBindingLoaded reloads in place (revision changed), and the
+          // shared per-table lock dedupes this with the content-change effect.
+          await Promise.all(
+            fresh.dataBindings.map(binding => {
+              const loadable = toLoadableBinding(binding);
+              return loadable
+                ? ensureBindingLoaded(duckAppId, loadable).catch(() => false)
+                : Promise.resolve(false);
+            }),
+          );
+          iframeRef.current?.contentWindow?.postMessage(
+            { type: PREVIEW_MESSAGE.dataRefresh },
+            "*",
+          );
           setRefreshNote(null);
           return;
         }

--- a/app/src/lib/duckdb.ts
+++ b/app/src/lib/duckdb.ts
@@ -581,12 +581,29 @@ export async function loadParquetTable(
   tableName: string,
   buffer: Uint8Array,
 ): Promise<number> {
-  await db.registerFileBuffer(`${tableName}.parquet`, buffer);
+  const fileName = `${tableName}.parquet`;
+  // Drop the table that references the previous buffer, then replace the
+  // registered file before re-registering. Re-registering a duckdb-wasm file
+  // buffer under an existing name without dropping it first leaves a stale
+  // handle, so a later read_parquet fails with "Invalid data" — this surfaces
+  // when an app reloads a refreshed snapshot in place (same table name, new
+  // bytes). On the first load dropTable/dropFile are harmless no-ops.
+  const dropConn = await db.connect();
+  try {
+    await dropConn.query(`DROP TABLE IF EXISTS "${tableName}"`);
+  } finally {
+    await dropConn.close();
+  }
+  try {
+    await db.dropFile(fileName);
+  } catch {
+    // File was not registered yet (first load) — nothing to drop.
+  }
+  await db.registerFileBuffer(fileName, buffer);
   const conn = await db.connect();
   try {
-    await conn.query(`DROP TABLE IF EXISTS "${tableName}"`);
     await conn.query(
-      `CREATE TABLE "${tableName}" AS SELECT * FROM read_parquet('${tableName}.parquet')`,
+      `CREATE TABLE "${tableName}" AS SELECT * FROM read_parquet('${fileName}')`,
     );
     const result = await conn.query(
       `SELECT count(*) as cnt FROM "${tableName}"`,

--- a/app/src/lib/duckdb.ts
+++ b/app/src/lib/duckdb.ts
@@ -576,28 +576,28 @@ export async function loadNdjsonStreamTable(
   }
 }
 
+let parquetFileSeq = 0;
+
 export async function loadParquetTable(
   db: AsyncDuckDB,
   tableName: string,
   buffer: Uint8Array,
 ): Promise<number> {
-  const fileName = `${tableName}.parquet`;
-  // Drop the table that references the previous buffer, then replace the
-  // registered file before re-registering. Re-registering a duckdb-wasm file
-  // buffer under an existing name without dropping it first leaves a stale
-  // handle, so a later read_parquet fails with "Invalid data" — this surfaces
-  // when an app reloads a refreshed snapshot in place (same table name, new
-  // bytes). On the first load dropTable/dropFile are harmless no-ops.
+  // Register each buffer under a UNIQUE virtual filename. duckdb-wasm's
+  // registerFileBuffer/dropFile operate on the DB-global WASM virtual
+  // filesystem; repeatedly dropping + re-registering the SAME name (what an
+  // in-place snapshot reload did, since the name was derived only from the
+  // table) eventually leaves a stale handle, so a later read_parquet reads
+  // garbage and fails with "Invalid data: TProtocolException". A fresh name per
+  // load means we never re-register an existing name; the unique file is then
+  // dropped in `finally` to free worker memory. The table itself is still
+  // replaced under its stable name via DROP TABLE + CREATE TABLE.
+  const fileName = `${tableName}__${Date.now()}_${++parquetFileSeq}.parquet`;
   const dropConn = await db.connect();
   try {
     await dropConn.query(`DROP TABLE IF EXISTS "${tableName}"`);
   } finally {
     await dropConn.close();
-  }
-  try {
-    await db.dropFile(fileName);
-  } catch {
-    // File was not registered yet (first load) — nothing to drop.
   }
   await db.registerFileBuffer(fileName, buffer);
   const conn = await db.connect();
@@ -611,6 +611,13 @@ export async function loadParquetTable(
     return Number(result.getChild("cnt")?.get(0) ?? 0);
   } finally {
     await conn.close();
+    // Free the unique virtual file now that the table is materialized; a
+    // failure here is non-fatal (best-effort memory cleanup).
+    try {
+      await db.dropFile(fileName);
+    } catch {
+      // Best-effort cleanup; the file may already be gone.
+    }
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On the public shared-app viewer (`/share/:workspaceSlug/:token`), the **Refresh data** button has two issues:

1. **When the refresh finishes, the app view doesn't update.** The poll detected the new snapshot and reloaded the parquet into the parent DuckDB, but the booted iframe app never re-ran its `useQuery` / `useDuckDB` hooks, so it kept showing stale data until a full page reload.
2. **After a refresh, the data source isn't "ready"/bound and needs several manual reloads.** Two root causes here:
   - The viewer preloads bindings in an effect while the booted app also issues on-demand reads (and several widgets can read the same binding), with no serialization — concurrent `DROP`/`CREATE` of the same DuckDB table.
   - More importantly, every in-place reload re-registered the parquet under the **same** duckdb-wasm virtual filename (`<table>.parquet`). `registerFileBuffer`/`dropFile` act on the DB-global WASM virtual filesystem; repeatedly dropping + re-registering the same name eventually leaves a stale handle, so a later `read_parquet` fails with `TProtocolException: Invalid data`. A fresh full page reload always worked (first-ever registration), which masked the bug.

## Fix

- **`app/src/lib/duckdb.ts`** — `loadParquetTable` now registers each buffer under a **unique per-call virtual filename** (`<table>__<ts>_<seq>.parquet`) and drops it after the table is materialized. The stale-handle path can no longer occur. (This replaced an earlier drop-before-register attempt that did not help — see commit history.)
- **`app/src/app-runtime/duckdb.ts`** — serialize `ensureBindingLoaded` per table via an in-flight promise map, so the preload effect, the refresh handler, and the iframe re-query don't redundantly reload the same table.
- **`app/src/app-runtime/preview.ts`** — add a `mako-app:data-refresh` host→iframe message + a data-epoch counter the `useQuery` / `useDuckDB` hooks depend on, so the booted app re-fetches when fresh parquet lands, without a srcdoc rebuild (UI state preserved).
- **`app/src/components/public/PublicAppViewer.tsx`** — after the refresh poll observes a new snapshot, load it into DuckDB and then post `data-refresh` so the running app updates automatically.

## Root cause investigation

Root cause was confirmed with runtime instrumentation in the browser: `concurrentActiveForTable` was always 1 (serialization worked), yet repeated sequential reloads that reused the same virtual filename eventually threw `Invalid data` on a valid `PAR1` buffer — isolating the stale-handle cause and ruling out concurrency / buffer-detachment / corrupt-bytes hypotheses. The instrumentation was removed after verification.

## Testing

End-to-end manual test on the actual `/share/realadvisor/test-share-app` page (parquet binding bound to the demo Postgres): with the snapshot stale vs. the source, clicking **Refresh data** now updates the view automatically with no error and no manual reload.

[Before: Album count 19](https://cursor.com/agents/bc-4935e109-5242-4cf9-865c-cd559e51ae07/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshare_refresh_before_19.webp)
[Refreshing state](https://cursor.com/agents/bc-4935e109-5242-4cf9-865c-cd559e51ae07/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshare_refresh_refreshing.webp)
[After: Album count auto-updated to 22, no error, no reload](https://cursor.com/agents/bc-4935e109-5242-4cf9-865c-cd559e51ae07/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshare_refresh_after_22.webp)

Before/after the source gained rows: the heading auto-updated from `Album count: 19` to `Album count: 22` without a page reload and without the previous `TProtocolException` error.

- ✅ `pnpm --filter app run typecheck`
- ✅ `pnpm --filter app run lint`
- ✅ Manual end-to-end share refresh (auto-updates in place, no error)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4935e109-5242-4cf9-865c-cd559e51ae07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4935e109-5242-4cf9-865c-cd559e51ae07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

