### PR TITLE
fix(chat): stick to streaming tail without scroll bounce

### DIFF
--- a/.cursor/rules/75-chat-performance.mdc
+++ b/.cursor/rules/75-chat-performance.mdc
@@ -79,25 +79,50 @@ Key pieces (in `Chat.tsx`):
 **Never revert to `messages.map(...)` over the full array.** That reintroduces
 the unbounded DOM that lags long chats on mobile.
 
-## Auto-scroll contract (Virtuoso `followOutput`)
+## Auto-scroll contract (rAF `scrollTo` follow)
 
-Bottom-anchoring is owned by Virtuoso, **not** `use-stick-to-bottom` (removed),
-and **not** a DIY `useEffect([messages])` → `scrollIntoView` (which fires on
-every chunk and causes scroll jank + broken hover/click events).
+Bottom-anchoring is owned by a **coalesced rAF follow effect**, **not**
+`use-stick-to-bottom` (removed), **not** a DIY `useEffect([messages])` →
+`scrollIntoView` (fires every chunk → jank + broken hover/click), and **not**
+Virtuoso's `followOutput`.
+
+**Why `followOutput` is OFF.** Virtuoso's `followOutput` only fires when the
+item **count** changes, and its resize re-stick (`notAtBottomBecause ===
+"SIZE_INCREASED"`) is only armed for ~100ms after a list refresh. But an entire
+assistant turn — thinking blocks, every tool card, and the final text — streams
+into a **single** message, growing one item without changing the count. So
+`followOutput` never fires mid-turn (thinking/tool cards stream in below the
+fold and the view never follows). Worse, when it *does* fire it runs
+`scrollToIndex({ align: "end" })`, which re-derives its target from the last
+item's current measured size — racing our per-frame pin while that item is being
+re-measured makes the view bounce between the item's top and bottom (visible as
+"jumping/blinking"). So `followOutput={false}`.
 
 Key pieces:
-- `followOutput={isAtBottom ? "smooth" : false}` — auto-sticks to the streaming
-  tail, but **only when the user is already at the bottom**, so scrolling up to
-  read history doesn't yank them back down.
+- **Streaming follow (the load-bearing piece):** a `useEffect` keyed on
+  `[messages, isLoading, isAtBottom]` schedules ONE coalesced
+  `requestAnimationFrame` per frame that calls
+  `virtuosoRef.current?.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "auto" })`.
+  - Use `scrollTo({ top })` (raw scroll-position set), **never**
+    `scrollToIndex({ align: "end" })` here — pinning the raw position to the
+    bottom each frame is self-correcting and never bounces upward, whereas an
+    index scroll bounces while the last item grows.
+  - Gated on `isAtBottom` so scrolling up to read history is never yanked down.
+  - `behavior: "auto"` (instant) — never `"smooth"`, which kicks off competing
+    animations on rapid streaming growth.
+  - rAF coalescing (a `followRafRef` guard) is the sanctioned exception to the
+    "no `messages`-dep DOM effect" rule; a separate unmount-only effect cancels
+    any pending frame.
 - `initialTopMostItemIndex={Math.max(0, messages.length - 1)}` — lands at the
   newest message on mount / chat switch.
 - `atBottomStateChange={setIsAtBottom}` + `atBottomThreshold={120}` — drives the
   `isAtBottom` state (note: this only flips when crossing the threshold, so it
   does **not** re-render per streaming chunk).
 - `virtuosoRef.current?.scrollToIndex({ index: messages.length - 1, align: "end" })`
-  — imperative scroll for the "scroll to bottom" button's `onClick`. The button
-  is `position: absolute` inside the relative parent `Box` (a sibling of
-  `<Virtuoso>`), since Virtuoso owns the scroller.
+  — imperative scroll for the "scroll to bottom" button's `onClick` (a one-shot
+  jump, so the bounce doesn't apply). The button is `position: absolute` inside
+  the relative parent `Box` (a sibling of `<Virtuoso>`), since Virtuoso owns the
+  scroller.
 - Opening an existing chat does an explicit `scrollToIndex({ index: "LAST" })`
   after the bulk `setMessages`, because Virtuoso keeps one instance across chat
   switches so `initialTopMostItemIndex` (mount-only) won't re-apply.
@@ -161,7 +186,9 @@ callback, not via a selector subscription.
 - [ ] No new `useEffect` depending on `messages` that touches the DOM
 - [ ] `experimental_throttle: 50` is present on `useChat`
 - [ ] Message list stays virtualized (`<Virtuoso data={messages}>`), never `messages.map`
-- [ ] Auto-scroll uses Virtuoso `followOutput`, not a DIY `useEffect`
+- [ ] Auto-scroll uses the coalesced rAF `scrollTo({ top })` follow effect
+      (gated on `isAtBottom`), **not** Virtuoso `followOutput` and **not**
+      a per-chunk `scrollToIndex`/`scrollIntoView`
 - [ ] Collapsed `StreamingToolCard` bodies unmount (`Collapse unmountOnExit`)
 - [ ] Any new child component inside `ChatMessageRow` is `React.memo`-wrapped
 - [ ] Zustand selectors return primitives, not object references

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -2980,6 +2980,51 @@ const Chat: React.FC<ChatProps> = ({
     activeClientToolCallCount > 0;
   isLoadingRef.current = isLoading;
 
+  // Stick to the streaming tail while a turn is generating.
+  //
+  // Virtuoso's `followOutput` only fires when the item COUNT changes, and its
+  // resize re-stick (`notAtBottomBecause === "SIZE_INCREASED"`) is only armed
+  // for ~100ms after a list refresh. But an entire assistant turn — thinking
+  // blocks, every tool card, and the final text — streams into a SINGLE
+  // message, growing one item without ever changing the count. So neither
+  // built-in mechanism keeps us pinned mid-turn: thinking blocks and tool
+  // cards stream in below the fold and the view never follows them down.
+  //
+  // Drive the follow ourselves: on each (throttled) `messages` tick while
+  // streaming, coalesce a single rAF that pins the scroller to the bottom.
+  // We use the handle's `scrollTo({ top })` (a direct scroll-position set on
+  // Virtuoso's scroller) rather than `scrollToIndex({ align: "end" })`: an
+  // index scroll re-derives its target from the last item's *current* measured
+  // size, so firing it every frame while that item is still growing/being
+  // re-measured makes the view bounce between the item's top and bottom (the
+  // "jumping/blinking"). Pinning the raw scroll position to the bottom each
+  // frame is self-correcting and never bounces upward. Gated on `isAtBottom`
+  // so scrolling up to read history is never yanked back down. This is the
+  // rAF-coalesced exception to the "no messages-dep DOM effect" rule
+  // (see .cursor/rules/75-chat-performance.mdc).
+  const followRafRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!isLoading || !isAtBottom) return;
+    if (followRafRef.current !== null) return; // coalesce: one pin per frame
+    followRafRef.current = requestAnimationFrame(() => {
+      followRafRef.current = null;
+      virtuosoRef.current?.scrollTo({
+        top: Number.MAX_SAFE_INTEGER,
+        behavior: "auto",
+      });
+    });
+  }, [messages, isLoading, isAtBottom]);
+
+  useEffect(
+    () => () => {
+      if (followRafRef.current !== null) {
+        cancelAnimationFrame(followRafRef.current);
+        followRafRef.current = null;
+      }
+    },
+    [],
+  );
+
   // Rescue tool cards orphaned by a clean stream end.
   //
   // A tool card's "Running…" status is derived purely from the AI SDK tool
@@ -4476,10 +4521,16 @@ const Chat: React.FC<ChatProps> = ({
             // survives streaming ticks and history inserts — mirrors the old
             // `key={message.id}`.
             computeItemKey={(_index, message) => message.id}
-            // Auto-stick to the tail while streaming, but only when the user is
-            // already at the bottom (don't yank them down if they scrolled up
-            // to read history). This preserves the old use-stick-to-bottom UX.
-            followOutput={isAtBottom ? "smooth" : false}
+            // Auto-scroll during streaming is owned entirely by the rAF
+            // `scrollTo({ top })` follow effect above (it covers BOTH new-
+            // message appends and intra-message growth, since `messages`
+            // changes in both cases). `followOutput` is left OFF: Virtuoso's
+            // built-in follow does a `scrollToIndex({ align: "end" })` on every
+            // count change, which — racing our per-frame pin while the last
+            // item is being re-measured — reintroduces the top/bottom bounce
+            // ("jumping/blinking"). Mount/history-load anchoring is handled by
+            // `initialTopMostItemIndex` and the explicit post-load scroll.
+            followOutput={false}
             initialTopMostItemIndex={Math.max(0, messages.length - 1)}
             atBottomStateChange={setIsAtBottom}
             atBottomThreshold={120}

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -490,6 +490,7 @@ function getConsoleToolPresentation(
   input: unknown,
   output: unknown,
   connectionIconById: ReadonlyMap<string, string>,
+  state: ToolPartState,
 ): ConsoleToolPresentation | null {
   if (toolName !== "modify_console") return null;
 
@@ -508,11 +509,23 @@ function getConsoleToolPresentation(
     (typeof outputTitle === "string" ? outputTitle : undefined) ??
     "Untitled console";
 
+  // While the input is still streaming, the `content` field is partial, so a
+  // line-diff against the existing console re-aligns its +/- groupings on every
+  // token (interleaved → grouped as more text arrives) — the modify_console
+  // "blink like mad" the diff card showed under Virtuoso. Skip the live diff
+  // while streaming: with no diff, the card falls back to rendering the raw
+  // `content` as plain SQL, which grows append-only and streams smoothly
+  // (exactly the token-by-token write users want, same path as create_console).
+  // Once the content is complete (`input-available`/`output-available`) the diff
+  // is stable, so we show the proper red/green diff again — preferring the final
+  // server `outputDiff` when present.
   const outputDiff = outputObj?.diff;
   const diff =
     typeof outputDiff === "string" && outputDiff.length > 0
       ? outputDiff
-      : buildStreamingModificationDiff(inputObj, consoleTab);
+      : state === "input-streaming"
+        ? undefined
+        : buildStreamingModificationDiff(inputObj, consoleTab);
 
   return {
     consoleId,
@@ -958,6 +971,7 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
               part.input,
               cardOutput,
               connectionIconById,
+              cardState,
             );
             // Key by toolCallId when available so reordering/insertion in the
             // parts array doesn't remount completed tool cards. Falls back to

--- a/app/src/components/StreamingToolCard.tsx
+++ b/app/src/components/StreamingToolCard.tsx
@@ -352,19 +352,6 @@ export const StreamingToolCard = React.memo(
 
     const hasCodePreview = Boolean(config.preview);
 
-    // While a `modify_console` edit is still streaming its input, the SQL is
-    // also being written live into the actual console tab — so re-highlighting
-    // a duplicate diff preview inside the card on every token is pure churn
-    // (the "re-render each token / blink" the user hit on the edit-console
-    // card). Suppress the card's streaming body until the edit settles; the
-    // final diff still renders once `state` leaves `input-streaming`. The memo
-    // comparator below also bails out of these per-token re-renders entirely.
-    const suppressModifyConsoleStreamingPreview =
-      toolName === "modify_console" && isStreaming;
-    const visibleBodyPreview = suppressModifyConsoleStreamingPreview
-      ? undefined
-      : bodyPreview;
-
     const [expanded, setExpanded] = useState(
       hasCodePreview ? !isDone && !isError : false,
     );
@@ -382,17 +369,16 @@ export const StreamingToolCard = React.memo(
 
     // Resolve code preview content (supports both string and object fields)
     const inputObj = input as Record<string, unknown> | undefined;
-    const rawContent =
-      config.preview && !suppressModifyConsoleStreamingPreview
-        ? inputObj?.[config.preview.field]
-        : undefined;
+    const rawContent = config.preview
+      ? inputObj?.[config.preview.field]
+      : undefined;
     const codeLanguage =
-      visibleBodyPreview?.language ?? config.preview?.language ?? "text";
+      bodyPreview?.language ?? config.preview?.language ?? "text";
 
     // Cheap presence checks (no serialization) so we can decide expandability
     // for collapsed cards without building the (potentially huge) body strings.
     const hasCode = Boolean(
-      visibleBodyPreview?.content ||
+      bodyPreview?.content ||
         (typeof rawContent === "string"
           ? rawContent.length > 0
           : rawContent != null),
@@ -411,14 +397,14 @@ export const StreamingToolCard = React.memo(
     const code = useMemo(() => {
       if (!shouldRenderBody || !hasCode) return "";
       const raw =
-        visibleBodyPreview?.content ??
+        bodyPreview?.content ??
         (typeof rawContent === "string"
           ? rawContent
           : rawContent && typeof rawContent === "object"
             ? JSON.stringify(rawContent, null, 2)
             : "");
       return capForDisplay(raw);
-    }, [shouldRenderBody, hasCode, visibleBodyPreview?.content, rawContent]);
+    }, [shouldRenderBody, hasCode, bodyPreview?.content, rawContent]);
 
     useEffect(() => {
       if (isStreaming && !userScrolled && codeContainerRef.current) {
@@ -733,17 +719,6 @@ export const StreamingToolCard = React.memo(
     if (prev.labelOverride !== next.labelOverride) return false;
     if (prev.leadingIconUrl !== next.leadingIconUrl) return false;
     if (prev.leadingIconAlt !== next.leadingIconAlt) return false;
-    // `modify_console` suppresses its streaming body preview (rendered live in
-    // the console tab instead), so its `input`/`bodyPreview` growing per token
-    // is invisible — skip those re-renders entirely. The `state` change out of
-    // `input-streaming` is still caught by the `prev.state !== next.state`
-    // check above, so the settled diff renders.
-    if (
-      next.toolName === "modify_console" &&
-      next.state === "input-streaming"
-    ) {
-      return true;
-    }
     if (prev.bodyPreview?.content !== next.bodyPreview?.content) return false;
     if (prev.bodyPreview?.language !== next.bodyPreview?.language) return false;
 

--- a/app/src/components/StreamingToolCard.tsx
+++ b/app/src/components/StreamingToolCard.tsx
@@ -352,6 +352,19 @@ export const StreamingToolCard = React.memo(
 
     const hasCodePreview = Boolean(config.preview);
 
+    // While a `modify_console` edit is still streaming its input, the SQL is
+    // also being written live into the actual console tab — so re-highlighting
+    // a duplicate diff preview inside the card on every token is pure churn
+    // (the "re-render each token / blink" the user hit on the edit-console
+    // card). Suppress the card's streaming body until the edit settles; the
+    // final diff still renders once `state` leaves `input-streaming`. The memo
+    // comparator below also bails out of these per-token re-renders entirely.
+    const suppressModifyConsoleStreamingPreview =
+      toolName === "modify_console" && isStreaming;
+    const visibleBodyPreview = suppressModifyConsoleStreamingPreview
+      ? undefined
+      : bodyPreview;
+
     const [expanded, setExpanded] = useState(
       hasCodePreview ? !isDone && !isError : false,
     );
@@ -369,16 +382,17 @@ export const StreamingToolCard = React.memo(
 
     // Resolve code preview content (supports both string and object fields)
     const inputObj = input as Record<string, unknown> | undefined;
-    const rawContent = config.preview
-      ? inputObj?.[config.preview.field]
-      : undefined;
+    const rawContent =
+      config.preview && !suppressModifyConsoleStreamingPreview
+        ? inputObj?.[config.preview.field]
+        : undefined;
     const codeLanguage =
-      bodyPreview?.language ?? config.preview?.language ?? "text";
+      visibleBodyPreview?.language ?? config.preview?.language ?? "text";
 
     // Cheap presence checks (no serialization) so we can decide expandability
     // for collapsed cards without building the (potentially huge) body strings.
     const hasCode = Boolean(
-      bodyPreview?.content ||
+      visibleBodyPreview?.content ||
         (typeof rawContent === "string"
           ? rawContent.length > 0
           : rawContent != null),
@@ -397,14 +411,14 @@ export const StreamingToolCard = React.memo(
     const code = useMemo(() => {
       if (!shouldRenderBody || !hasCode) return "";
       const raw =
-        bodyPreview?.content ??
+        visibleBodyPreview?.content ??
         (typeof rawContent === "string"
           ? rawContent
           : rawContent && typeof rawContent === "object"
             ? JSON.stringify(rawContent, null, 2)
             : "");
       return capForDisplay(raw);
-    }, [shouldRenderBody, hasCode, bodyPreview?.content, rawContent]);
+    }, [shouldRenderBody, hasCode, visibleBodyPreview?.content, rawContent]);
 
     useEffect(() => {
       if (isStreaming && !userScrolled && codeContainerRef.current) {
@@ -719,6 +733,17 @@ export const StreamingToolCard = React.memo(
     if (prev.labelOverride !== next.labelOverride) return false;
     if (prev.leadingIconUrl !== next.leadingIconUrl) return false;
     if (prev.leadingIconAlt !== next.leadingIconAlt) return false;
+    // `modify_console` suppresses its streaming body preview (rendered live in
+    // the console tab instead), so its `input`/`bodyPreview` growing per token
+    // is invisible — skip those re-renders entirely. The `state` change out of
+    // `input-streaming` is still caught by the `prev.state !== next.state`
+    // check above, so the settled diff renders.
+    if (
+      next.toolName === "modify_console" &&
+      next.state === "input-streaming"
+    ) {
+      return true;
+    }
     if (prev.bodyPreview?.content !== next.bodyPreview?.content) return false;
     if (prev.bodyPreview?.language !== next.bodyPreview?.language) return false;
 

--- a/app/src/components/__tests__/Chat.perf.test.ts
+++ b/app/src/components/__tests__/Chat.perf.test.ts
@@ -255,24 +255,6 @@ describe("StreamingToolCard memo comparator", () => {
     expect(compare(prev, next)).toBe(false);
   });
 
-  it("skips re-render while a modify_console edit streams its input (body shown in the console tab, not the card)", () => {
-    const prev = baseProps({
-      toolName: "modify_console",
-      state: "input-streaming",
-      input: { action: "replace", content: "SELECT" },
-      output: undefined,
-      labelOverride: "Revenue console",
-    });
-    const next = baseProps({
-      toolName: "modify_console",
-      state: "input-streaming",
-      input: { action: "replace", content: "SELECT 1" },
-      output: undefined,
-      labelOverride: "Revenue console",
-    });
-    expect(compare(prev, next)).toBe(true);
-  });
-
   it("re-renders when state transitions (e.g. input-streaming → output-available)", () => {
     const prev = baseProps({
       state: "input-streaming",
@@ -394,15 +376,6 @@ describe("StreamingToolCard structural guards", () => {
 
   it("defers building the heavy body strings until the body renders", () => {
     expect(cardSource).toMatch(/shouldRenderBody/);
-  });
-
-  it("suppresses modify_console body churn while input is still streaming", () => {
-    // The streaming SQL is shown live in the console tab, so re-highlighting a
-    // duplicate diff preview in the card on every token is pure churn.
-    expect(cardSource).toContain("suppressModifyConsoleStreamingPreview");
-    expect(cardSource).toMatch(
-      /next\.toolName === "modify_console" &&\s+next\.state === "input-streaming"/,
-    );
   });
 });
 

--- a/app/src/components/__tests__/Chat.perf.test.ts
+++ b/app/src/components/__tests__/Chat.perf.test.ts
@@ -315,17 +315,28 @@ describe("Chat.tsx structural guards", () => {
     expect(chatSource).toMatch(/computeItemKey=/);
   });
 
-  it("auto-follows the streaming tail only when at bottom", () => {
-    // followOutput pins to the newest message while streaming, but is disabled
-    // when the user has scrolled up to read history (so they're not yanked
-    // down). This replaces use-stick-to-bottom's equivalent behavior.
-    expect(chatSource).toMatch(/followOutput=\{isAtBottom \? .* : false\}/);
+  it("auto-follows the streaming tail via a coalesced rAF scrollTo, gated on isAtBottom", () => {
+    // Auto-scroll is owned by a coalesced requestAnimationFrame follow effect
+    // that pins the scroller to the bottom (`scrollTo({ top })`) on each
+    // streaming tick — NOT Virtuoso's `followOutput`. `followOutput` only fires
+    // on item-COUNT change (a whole turn streams into ONE message, so it never
+    // fires mid-turn) and, when it does, its `scrollToIndex({ align: "end" })`
+    // races our per-frame pin and bounces the view. So it must stay OFF.
+    expect(chatSource).toMatch(/followOutput=\{false\}/);
+    // The follow effect must coalesce with rAF, pin to the bottom, and be gated
+    // on isAtBottom (so scrolling up to read history isn't yanked down).
+    expect(chatSource).toMatch(/requestAnimationFrame/);
+    expect(chatSource).toMatch(
+      /scrollTo\(\{\s*top:\s*Number\.MAX_SAFE_INTEGER/,
+    );
+    expect(chatSource).toMatch(/if \(!isLoading \|\| !isAtBottom\) return;/);
   });
 
-  it("does NOT have a DIY useEffect([messages]) auto-scroll", () => {
-    const diyScrollPattern =
-      /useEffect\(\s*\(\)\s*=>\s*\{[^}]*scrollIntoView[^}]*\}\s*,\s*\[messages\]\)/s;
-    expect(chatSource).not.toMatch(diyScrollPattern);
+  it("does NOT have a DIY useEffect([messages]) scrollIntoView auto-scroll", () => {
+    // The follow effect uses Virtuoso's `scrollTo` handle (gated + rAF
+    // coalesced), never a raw per-chunk `scrollIntoView` on a DOM node, which
+    // fired every chunk and broke hover/click + caused jank.
+    expect(chatSource).not.toMatch(/scrollIntoView/);
   });
 
   it("does NOT have isNearBottomRef (old DIY scroll state)", () => {

--- a/app/src/components/__tests__/Chat.perf.test.ts
+++ b/app/src/components/__tests__/Chat.perf.test.ts
@@ -347,6 +347,14 @@ describe("Chat.tsx structural guards", () => {
     expect(chatSource).not.toContain("rafIdRef");
   });
 
+  it("does NOT build a live modify_console diff while input is still streaming", () => {
+    // A line-diff of partial streamed content re-aligns its +/- groupings on
+    // every token (the modify_console "blink"). While input-streaming we show
+    // the raw SQL (append-only, smooth) and only render the diff once content
+    // is complete.
+    expect(chatSource).toMatch(/state === "input-streaming"\s*\?\s*undefined/);
+  });
+
   it("keys tool parts by toolCallId so completed cards don't remount", () => {
     // Remounting a finished tool card on every parts-array mutation drops
     // its internal expand/scroll state and causes a flicker. Keying by

--- a/app/src/components/__tests__/Chat.perf.test.ts
+++ b/app/src/components/__tests__/Chat.perf.test.ts
@@ -255,6 +255,24 @@ describe("StreamingToolCard memo comparator", () => {
     expect(compare(prev, next)).toBe(false);
   });
 
+  it("skips re-render while a modify_console edit streams its input (body shown in the console tab, not the card)", () => {
+    const prev = baseProps({
+      toolName: "modify_console",
+      state: "input-streaming",
+      input: { action: "replace", content: "SELECT" },
+      output: undefined,
+      labelOverride: "Revenue console",
+    });
+    const next = baseProps({
+      toolName: "modify_console",
+      state: "input-streaming",
+      input: { action: "replace", content: "SELECT 1" },
+      output: undefined,
+      labelOverride: "Revenue console",
+    });
+    expect(compare(prev, next)).toBe(true);
+  });
+
   it("re-renders when state transitions (e.g. input-streaming → output-available)", () => {
     const prev = baseProps({
       state: "input-streaming",
@@ -376,6 +394,15 @@ describe("StreamingToolCard structural guards", () => {
 
   it("defers building the heavy body strings until the body renders", () => {
     expect(cardSource).toMatch(/shouldRenderBody/);
+  });
+
+  it("suppresses modify_console body churn while input is still streaming", () => {
+    // The streaming SQL is shown live in the console tab, so re-highlighting a
+    // duplicate diff preview in the card on every token is pure churn.
+    expect(cardSource).toContain("suppressModifyConsoleStreamingPreview");
+    expect(cardSource).toMatch(
+      /next\.toolName === "modify_console" &&\s+next\.state === "input-streaming"/,
+    );
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Ever since the chat virtualization + tool-card unmount work (#557), the chat behaved erratically during streaming:

- **Thinking/reasoning blocks didn't scroll the chat to the bottom** while generating.
- **The "edit console" (`modify_console`) tool card re-rendered every token and blinked/jumped like mad.**
- Overall the chat "jumped around" and flickered.

## Root causes & fixes

### 1. Auto-scroll never followed mid-turn growth
A whole assistant turn (thinking + every tool card + final text) streams into a **single** message. Virtuoso's `followOutput` only fires on item-**count** change, and its resize re-stick is armed for only ~100ms after a list refresh — so mid-turn the last item just grows in height and nothing follows it; content streamed in below the fold. (Switching `followOutput` `"smooth" → "auto"` alone does **not** fix this — verified by running the alternative branch.)

**Fix:** a coalesced `requestAnimationFrame` effect pins the scroller to the bottom via the Virtuoso handle's `scrollTo({ top })` on each streaming tick (gated on `isAtBottom`, instant behavior). `scrollTo` of the raw position is self-correcting and never bounces, unlike `scrollToIndex({ align: "end" })`. `followOutput` is turned **off** so it can't race the per-frame pin.

### 2. `modify_console` diff churned on every token
The edit-console card built a **line-diff** of the *streaming* (partial) `content` against the existing console on every token. With partial content, the diff re-aligns its `+`/`-` groupings (interleaved → grouped) as more text arrives; under Virtuoso that restructuring also jumps the card height and jitters the scroll — the "edit console blinks like mad."

**Fix:** while `state === "input-streaming"`, skip the live diff. With no diff, the card falls back to rendering the raw `content` as **plain SQL**, which grows append-only and streams smoothly (same path as `create_console`) — preserving the intentional, Cursor-style token-by-token write. Once the content is complete (`input-available`/`output-available`) the diff is stable, so the red/green diff renders again (server `outputDiff` preferred). The live preview is **kept**, only the unstable partial-diff frames are replaced with smooth SQL.

Updates `.cursor/rules/75-chat-performance.mdc` (auto-scroll contract) and `Chat.perf.test.ts` guards.

## Testing

Reproduced and verified end-to-end in the running app (local Mongo + AI gateway), with a video model scrutinizing each iteration frame-by-frame.

**`modify_console` after the fix** — SQL streams in token-by-token, smoothly, no diff churn / height jitter / scroll jitter (chat card on the right; the main editor still shows the diff):

[verify_modify_console_live_sql_no_blink_after_fix.mp4](https://cursor.com/agents/bc-9dfe32e3-96ba-4f4e-90e2-d9fd86254ad3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fverify_modify_console_live_sql_no_blink_after_fix.mp4)

**Auto-scroll after the fix** — view stays pinned to thinking blocks + tool cards with no bounce:

[chat_streaming_smooth_pinned_no_bounce_after_fix.mp4](https://cursor.com/agents/bc-9dfe32e3-96ba-4f4e-90e2-d9fd86254ad3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchat_streaming_smooth_pinned_no_bounce_after_fix.mp4)

Before the fix, streamed content (thinking + tool cards) landed below the fold and the view didn't follow:

[Before fix: streamed content off-screen below the fold](https://cursor.com/agents/bc-9dfe32e3-96ba-4f4e-90e2-d9fd86254ad3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchat_before_fix_content_off_screen.webp)

- ✅ `pnpm --filter app exec vitest run src/components/__tests__/Chat.perf.test.ts` (32 passed)
- ✅ `pnpm --filter app run typecheck`
- ✅ `pnpm --filter app run lint`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9dfe32e3-96ba-4f4e-90e2-d9fd86254ad3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9dfe32e3-96ba-4f4e-90e2-d9fd86254ad3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

