### PR TITLE
fix(app): verify session before redirecting to /login on 401

### DIFF
--- a/app/src/api/client.ts
+++ b/app/src/api/client.ts
@@ -16,9 +16,8 @@
  */
 import createClient, { type Client, type Middleware } from "openapi-fetch";
 
+import { handleUnauthorized } from "../lib/auth-redirect";
 import type { paths } from "./schema";
-
-let isRedirectingToLogin = false;
 
 function activeWorkspaceId(): string | null {
   if (typeof localStorage === "undefined") return null;
@@ -35,18 +34,10 @@ const authMiddleware: Middleware = {
     return request;
   },
   onResponse({ response }) {
-    if (response.status === 401 && typeof window !== "undefined") {
-      try {
-        localStorage.removeItem("activeWorkspaceId");
-      } catch {
-        // ignore storage failures
-      }
-      const path = window.location.pathname;
-      const isAuthPage = path === "/login" || path === "/register";
-      if (!isAuthPage && !isRedirectingToLogin) {
-        isRedirectingToLogin = true;
-        window.location.href = "/login";
-      }
+    // Verify the session before redirecting so a transient 401 during a
+    // deploy doesn't bounce the user to /login (see lib/auth-redirect.ts).
+    if (response.status === 401) {
+      void handleUnauthorized();
     }
     return response;
   },

--- a/app/src/lib/api-client.ts
+++ b/app/src/lib/api-client.ts
@@ -2,13 +2,11 @@
  * General API client that handles authentication and error responses
  */
 import { getApiBasePath } from "./api-base-path";
+import { handleUnauthorized } from "./auth-redirect";
 
 interface ApiRequestOptions extends RequestInit {
   params?: Record<string, string>;
 }
-
-// Flag to prevent multiple 401 redirects
-let isRedirectingToLogin = false;
 
 class ApiClient {
   private basePath: string;
@@ -48,20 +46,10 @@ class ApiClient {
    * Handle API response and errors
    */
   private async handleResponse<T>(response: Response): Promise<T> {
-    // Handle 401 Unauthorized - redirect to login (but avoid redirect loop)
+    // Handle 401 Unauthorized - verify the session before redirecting so a
+    // transient 401 during a deploy doesn't bounce the user to /login.
     if (response.status === 401) {
-      // Clear any stored auth state
-      localStorage.removeItem("activeWorkspaceId");
-
-      // Only redirect if not already redirecting and not on login/register page
-      const currentPath = window.location.pathname;
-      const isAuthPage =
-        currentPath === "/login" || currentPath === "/register";
-
-      if (!isAuthPage && !isRedirectingToLogin) {
-        isRedirectingToLogin = true;
-        window.location.href = "/login";
-      }
+      void handleUnauthorized();
       throw new Error("Unauthorized");
     }
 
@@ -176,14 +164,7 @@ class ApiClient {
     });
 
     if (response.status === 401) {
-      localStorage.removeItem("activeWorkspaceId");
-      const currentPath = window.location.pathname;
-      const isAuthPage =
-        currentPath === "/login" || currentPath === "/register";
-      if (!isAuthPage && !isRedirectingToLogin) {
-        isRedirectingToLogin = true;
-        window.location.href = "/login";
-      }
+      void handleUnauthorized();
       throw new Error("Unauthorized");
     }
 
@@ -238,14 +219,7 @@ class ApiClient {
     });
 
     if (response.status === 401) {
-      localStorage.removeItem("activeWorkspaceId");
-      const currentPath = window.location.pathname;
-      const isAuthPage =
-        currentPath === "/login" || currentPath === "/register";
-      if (!isAuthPage && !isRedirectingToLogin) {
-        isRedirectingToLogin = true;
-        window.location.href = "/login";
-      }
+      void handleUnauthorized();
       throw new Error("Unauthorized");
     }
 

--- a/app/src/lib/auth-redirect.test.ts
+++ b/app/src/lib/auth-redirect.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { __resetAuthRedirectState, handleUnauthorized } from "./auth-redirect";
+
+/**
+ * The deploy-resilient 401 handler: it must only redirect to /login when
+ * `/auth/me` returns a definitive 401, and must stay put for transient
+ * failures (network / 5xx) that happen during a rolling deploy.
+ */
+
+interface FakeLocation {
+  pathname: string;
+  href: string;
+}
+
+function stubBrowser(pathname = "/dashboard"): FakeLocation {
+  const location: FakeLocation = { pathname, href: pathname };
+  vi.stubGlobal("window", { location });
+  vi.stubGlobal("localStorage", {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+    clear: vi.fn(),
+    key: vi.fn(),
+    length: 0,
+  } as unknown as Storage);
+  return location;
+}
+
+function meResponse(status: number): Response {
+  return new Response(status === 200 ? JSON.stringify({ user: {} }) : null, {
+    status,
+  });
+}
+
+describe("handleUnauthorized", () => {
+  beforeEach(() => {
+    __resetAuthRedirectState();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("redirects to /login when /auth/me confirms a dead session (401)", async () => {
+    const location = stubBrowser();
+    const fetchMock = vi.fn(async () => meResponse(401));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await handleUnauthorized();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(location.href).toBe("/login");
+  });
+
+  it("does NOT redirect when /auth/me says the session is still alive", async () => {
+    const location = stubBrowser();
+    const fetchMock = vi.fn(async () => meResponse(200));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await handleUnauthorized();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(location.href).toBe("/dashboard");
+  });
+
+  it("retries transient failures and stays put when undetermined (deploy blip)", async () => {
+    const location = stubBrowser();
+    // Network error, then 503, then 503 → never a definitive 401.
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("network"))
+      .mockResolvedValueOnce(meResponse(503))
+      .mockResolvedValueOnce(meResponse(503));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const done = handleUnauthorized();
+    await vi.runAllTimersAsync();
+    await done;
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(location.href).toBe("/dashboard");
+  });
+
+  it("recovers via a later attempt: 503 then alive → no redirect", async () => {
+    const location = stubBrowser();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(meResponse(503))
+      .mockResolvedValueOnce(meResponse(200));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const done = handleUnauthorized();
+    await vi.runAllTimersAsync();
+    await done;
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(location.href).toBe("/dashboard");
+  });
+
+  it("dedupes concurrent 401s into a single /auth/me probe", async () => {
+    stubBrowser();
+    const fetchMock = vi.fn(async () => meResponse(401));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const a = handleUnauthorized();
+    const b = handleUnauthorized();
+    await Promise.all([a, b]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when already on the /login page", async () => {
+    stubBrowser("/login");
+    const fetchMock = vi.fn(async () => meResponse(401));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await handleUnauthorized();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/lib/auth-redirect.ts
+++ b/app/src/lib/auth-redirect.ts
@@ -1,0 +1,115 @@
+/**
+ * Centralized handling for `401 Unauthorized` responses from the API.
+ *
+ * A naive client redirects to `/login` on the first 401 it sees. During a
+ * rolling deploy, in-flight requests can briefly hit a starting/draining
+ * instance (or a momentarily unreachable database) and come back 401/5xx even
+ * though the user's session is still valid. That bounced users to `/login` on
+ * essentially every deploy.
+ *
+ * Instead we verify the session against `/auth/me` (with a short retry/backoff
+ * to ride out the deploy window) before deciding. We only redirect when the
+ * server gives a definitive 401 for `/auth/me` — a genuinely dead session.
+ * Transient/indeterminate failures are swallowed so the user stays put and the
+ * next request succeeds once the new revision is serving.
+ */
+import { getApiBasePath } from "./api-base-path";
+
+const LOGIN_PATH = "/login";
+const AUTH_PAGES = new Set([LOGIN_PATH, "/register"]);
+
+/** Total `/auth/me` probe attempts before giving up (treating as transient). */
+const VERIFY_MAX_ATTEMPTS = 3;
+/** Backoff between probe attempts; index N is the wait after attempt N. */
+const VERIFY_BACKOFF_MS = [300, 800];
+
+let isRedirectingToLogin = false;
+let inFlightVerification: Promise<void> | null = null;
+
+function authMeUrl(): string {
+  const basePath = getApiBasePath(import.meta.env.VITE_API_URL);
+  const path = "/auth/me";
+  return basePath === "/" ? path : `${basePath}${path}`;
+}
+
+function onAuthPage(): boolean {
+  if (typeof window === "undefined") return false;
+  return AUTH_PAGES.has(window.location.pathname);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function clearActiveWorkspace(): void {
+  try {
+    localStorage.removeItem("activeWorkspaceId");
+  } catch {
+    // ignore storage failures (private mode / SSR)
+  }
+}
+
+function redirectToLogin(): void {
+  if (typeof window === "undefined" || isRedirectingToLogin || onAuthPage()) {
+    return;
+  }
+  isRedirectingToLogin = true;
+  clearActiveWorkspace();
+  window.location.href = LOGIN_PATH;
+}
+
+/**
+ * Probe `/auth/me` to decide whether the session is actually gone.
+ *
+ * @returns `true` when alive, `false` when the server returns a definitive
+ *   401, `null` when undetermined after retries (network/5xx — treated as a
+ *   transient deploy blip, so we do not log the user out).
+ */
+async function probeSession(): Promise<boolean | null> {
+  for (let attempt = 0; attempt < VERIFY_MAX_ATTEMPTS; attempt++) {
+    try {
+      const res = await fetch(authMeUrl(), {
+        method: "GET",
+        credentials: "include",
+        cache: "no-store",
+      });
+      if (res.status === 401) return false;
+      if (res.ok) return true;
+      // Other statuses (502/503/504/etc.) are likely a deploy blip — retry.
+    } catch {
+      // Network error — likely a deploy blip — retry.
+    }
+    const backoff = VERIFY_BACKOFF_MS[attempt];
+    if (backoff !== undefined) await delay(backoff);
+  }
+  return null;
+}
+
+/**
+ * Call when an authenticated request returns `401`. Verifies the session via
+ * `/auth/me` before redirecting to `/login`; concurrent 401s share a single
+ * verification so we never fire more than one probe at a time. Returns a
+ * promise that resolves once the decision (redirect or stay) has been made.
+ */
+export function handleUnauthorized(): Promise<void> {
+  if (typeof window === "undefined" || isRedirectingToLogin || onAuthPage()) {
+    return Promise.resolve();
+  }
+  if (inFlightVerification) return inFlightVerification;
+
+  inFlightVerification = probeSession()
+    .then(alive => {
+      if (alive === false) redirectToLogin();
+    })
+    .finally(() => {
+      inFlightVerification = null;
+    });
+
+  return inFlightVerification;
+}
+
+/** Test-only: reset module-level state between cases. */
+export function __resetAuthRedirectState(): void {
+  isRedirectingToLogin = false;
+  inFlightVerification = null;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

After a new deployment Mako often bounces logged-in users to `/login`. The session itself is fine — Mako sessions are **server-side, DB-backed**; the `auth_session` cookie is an opaque MongoDB id and is **not** signed with `SESSION_SECRET`, so secret rotation on deploy doesn't invalidate it.

The real cause is the **frontend over-reacting to a transient 401**. During a rolling deploy, a few in-flight requests hit a starting/draining instance (or a momentarily unreachable DB) and come back `401`/`5xx`. Both API clients reacted to *any* 401 by clearing workspace state and hard-redirecting to `/login` — no retry, no check whether the session was actually dead.

## What

Add `app/src/lib/auth-redirect.ts` with a single `handleUnauthorized()` entry point:

- On a 401, **probe `GET /auth/me`** (with short retry/backoff: ~300ms, ~800ms) to ride out the deploy window before deciding.
- Redirect to `/login` **only** when `/auth/me` returns a definitive `401` (genuinely dead session).
- Transient/indeterminate failures (network / `5xx`) are swallowed — the user stays put and the next request succeeds once the new revision is serving.
- Concurrent 401s share a **single** in-flight probe (dedupe).
- `activeWorkspaceId` is cleared only when we actually decide to log out (not on every blip).

Both clients now route 401s through this helper:
- `app/src/lib/api-client.ts` (`handleResponse`, `postWithStatus`, `putWithStatus`)
- `app/src/api/client.ts` (openapi-fetch `onResponse` middleware)

## Testing

- `pnpm --filter app run typecheck` ✅
- `pnpm --filter app run lint` ✅
- `pnpm --filter app exec vitest run` — new `auth-redirect.test.ts` (6 cases) + existing `client.test.ts` (7) all pass ✅
- Manual end-to-end (videos below):
  - **Transient 401** (data API 401 but `/auth/me` healthy) → app stays on the current route, user NOT logged out.
  - **Genuine dead session** (real `auth_session` cookie deleted) → app redirects to `/login` and stays there.

### Transient 401 no longer logs the user out
[transient_401_does_not_logout.mp4](https://cursor.com/agents/bc-f16ac239-f8c0-4ece-bf5c-180fb2331ccd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftransient_401_does_not_logout.mp4)

### A genuinely dead session still redirects to /login
[genuine_dead_session_redirects_to_login.mp4](https://cursor.com/agents/bc-f16ac239-f8c0-4ece-bf5c-180fb2331ccd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgenuine_dead_session_redirects_to_login.mp4)

## Follow-ups (not in this PR)
- `Session.expiresAt` is a plain index, not a TTL index.
- `SESSION_DURATION` is set in deploy env but unread (code hard-codes 24h).
- PR previews drop+restore their ephemeral Mongo DB, which genuinely deletes sessions (re-login expected there).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f16ac239-f8c0-4ece-bf5c-180fb2331ccd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f16ac239-f8c0-4ece-bf5c-180fb2331ccd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

