### PR TITLE
fix(apps): keep rows visible during in-place data refresh (stop flicker)

### DIFF
--- a/app/src/app-runtime/preview.ts
+++ b/app/src/app-runtime/preview.ts
@@ -523,17 +523,31 @@ async function main() {
         setEpoch(dataEpoch);
         return () => { dataListeners.delete(listener); };
       }, []);
+      // Tell a brand-new query (name/rowLimit changed -> blanking to a loading
+      // state is expected) apart from an in-place data refresh (epoch bumped,
+      // same query). On a refresh we keep the rows already on screen and swap
+      // them only once the new ones land, so a periodic refresh never flickers
+      // through an empty/loading frame. Seeded to null so the first run counts
+      // as a new query and still surfaces an initial-load error.
+      const queryKey = name + "\u0000" + String(rowLimit);
+      const keyRef = React.useRef(null);
       React.useEffect(() => {
         let active = true;
-        setState({ data: null, error: null, loading: true, truncated: false });
+        const isNewQuery = keyRef.current !== queryKey;
+        keyRef.current = queryKey;
+        if (isNewQuery) {
+          setState({ data: null, error: null, loading: true, truncated: false });
+        }
         runBinding(name, rowLimit).then((res) => {
           if (!active) return;
           if (res.success) {
             if (res.truncated) warnTruncated('useQuery("' + name + '")', res);
             setState({ data: res.rows, error: null, loading: false, truncated: !!res.truncated });
-          } else {
+          } else if (isNewQuery) {
             setState({ data: null, error: res.error || "Query failed", loading: false, truncated: false });
           }
+          // In-place refresh failure: keep the rows already on screen rather
+          // than flashing an error/empty frame; a later refresh corrects it.
         });
         return () => { active = false; };
       }, [name, rowLimit, epoch]);
@@ -556,9 +570,18 @@ async function main() {
         setEpoch(dataEpoch);
         return () => { dataListeners.delete(listener); };
       }, []);
+      // See useQuery: distinguish a new query (sql/rowLimit changed) from an
+      // in-place refresh (epoch bumped) so a refresh keeps the current result
+      // visible and swaps it only when the new one lands — no loading flicker.
+      const queryKey = sql + "\u0000" + String(rowLimit);
+      const keyRef = React.useRef(null);
       React.useEffect(() => {
         let active = true;
-        setState({ data: null, fields: null, error: null, loading: true, truncated: false, rowCount: null });
+        const isNewQuery = keyRef.current !== queryKey;
+        keyRef.current = queryKey;
+        if (isNewQuery) {
+          setState({ data: null, fields: null, error: null, loading: true, truncated: false, rowCount: null });
+        }
         runDuckDb(sql, rowLimit).then((res) => {
           if (!active) return;
           if (res.success) {
@@ -571,9 +594,11 @@ async function main() {
               truncated: !!res.truncated,
               rowCount: typeof res.rowCount === "number" ? res.rowCount : (res.rows ? res.rows.length : null),
             });
-          } else {
+          } else if (isNewQuery) {
             setState({ data: null, fields: null, error: res.error || "DuckDB query failed", loading: false, truncated: false, rowCount: null });
           }
+          // In-place refresh failure: keep the current result rather than
+          // flashing an error/empty frame; a later refresh corrects it.
         });
         return () => { active = false; };
       }, [sql, rowLimit, epoch]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After #581 made public-share app refreshes happen "in place" (no srcdoc rebuild), there was still visible **flickering** on refresh.

Root cause is in the sandboxed app SDK data hooks (`useQuery` / `useDuckDB`) in `app/src/app-runtime/preview.ts`. When the host posts `mako-app:data-refresh`, the `dataEpoch` bumps and the data effect re-runs. That effect unconditionally reset state to `{ data: null, loading: true }`, blanking every widget (charts/tables fall back to their loading/empty state) until the freshly-materialized rows arrive — i.e. the flicker.

## Fix

Distinguish a **genuinely new query** (the `name`/`sql`/`rowLimit` changed → blanking to a loading frame is expected) from an **in-place data refresh** (only `epoch` bumped, same query):

- New query → reset to `loading` and surface load errors as before.
- In-place refresh → keep the rows already on screen, swap them atomically only when the new rows land, and on a transient refresh failure keep the existing rows instead of flashing an error/empty frame.

Implemented with a `keyRef` seeded to `null` so the first mount still counts as a new query (initial-load errors keep surfacing). Applied to both `useQuery` and `useDuckDB`.

## Testing

- `pnpm --filter app run typecheck`
- `pnpm --filter app run lint`
- Manual: public share view → Refresh data → confirmed widgets stay populated through the refresh (no blank/loading frame).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb58dc52-3175-48e7-a74c-6a854b09badd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb58dc52-3175-48e7-a74c-6a854b09badd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

