### PR TITLE
fix(chat): pin streaming tail in totalListHeightChanged to stop scroll bounce

### DIFF
--- a/.cursor/rules/75-chat-performance.mdc
+++ b/.cursor/rules/75-chat-performance.mdc
@@ -79,40 +79,53 @@ Key pieces (in `Chat.tsx`):
 **Never revert to `messages.map(...)` over the full array.** That reintroduces
 the unbounded DOM that lags long chats on mobile.
 
-## Auto-scroll contract (rAF `scrollTo` follow)
+## Auto-scroll contract (`totalListHeightChanged` bottom-pin)
 
-Bottom-anchoring is owned by a **coalesced rAF follow effect**, **not**
-`use-stick-to-bottom` (removed), **not** a DIY `useEffect([messages])` →
-`scrollIntoView` (fires every chunk → jank + broken hover/click), and **not**
-Virtuoso's `followOutput`.
+Bottom-anchoring is owned by a **bottom-pin inside Virtuoso's
+`totalListHeightChanged` callback**, **not** `use-stick-to-bottom` (removed),
+**not** a DIY `useEffect([messages])` → `scrollIntoView` (fires every chunk →
+jank + broken hover/click), **not** a per-`messages`-tick rAF `scrollTo`
+(superseded — see below), and **not** Virtuoso's `followOutput`.
 
 **Why `followOutput` is OFF.** Virtuoso's `followOutput` only fires when the
-item **count** changes, and its resize re-stick (`notAtBottomBecause ===
-"SIZE_INCREASED"`) is only armed for ~100ms after a list refresh. But an entire
-assistant turn — thinking blocks, every tool card, and the final text — streams
-into a **single** message, growing one item without changing the count. So
-`followOutput` never fires mid-turn (thinking/tool cards stream in below the
-fold and the view never follows). Worse, when it *does* fire it runs
-`scrollToIndex({ align: "end" })`, which re-derives its target from the last
-item's current measured size — racing our per-frame pin while that item is being
-re-measured makes the view bounce between the item's top and bottom (visible as
-"jumping/blinking"). So `followOutput={false}`.
+item **count** changes, but an entire assistant turn — thinking blocks, every
+tool card, and the final text — streams into a **single** message, growing one
+item without changing the count. So `followOutput` never fires mid-turn
+(thinking/tool cards stream in below the fold and the view never follows), and
+when it *does* fire its `scrollToIndex({ align: "end" })` races the pin and
+bounces the view ("jumping/blinking"). So `followOutput={false}`.
+
+**Why not a per-`messages`-tick rAF.** The previous fix pinned the bottom in a
+one-shot `requestAnimationFrame` scheduled on each (throttled, ~50ms) `messages`
+tick. That only covers ~1 of every 3 frames. The interior blocks that change
+height asynchronously and non-monotonically — MUI `Collapse` on the thinking
+block + tool cards, and the `modify_console` diff re-render — animate over
+~300ms on frames where `messages` does **not** tick. On those frames Virtuoso's
+resize anchoring nudges `scrollTop` **up** (toward the message top) to keep
+content stable, and with no pin to counter it the view paints partway up — then
+the next `messages` tick pins it back down. That alternation **is** the
+top/bottom bounce. (`requestAnimationFrame` callbacks also run *before*
+ResizeObserver in the frame, so an rAF pin can't out-write Virtuoso's
+compensation on a resize frame anyway.) Plain-text turns never bounced because
+their growth is append-only at the bottom (monotonic), so anchor and pin agree.
 
 Key pieces:
-- **Streaming follow (the load-bearing piece):** a `useEffect` keyed on
-  `[messages, isLoading, isAtBottom]` schedules ONE coalesced
-  `requestAnimationFrame` per frame that calls
-  `virtuosoRef.current?.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "auto" })`.
-  - Use `scrollTo({ top })` (raw scroll-position set), **never**
-    `scrollToIndex({ align: "end" })` here — pinning the raw position to the
-    bottom each frame is self-correcting and never bounces upward, whereas an
-    index scroll bounces while the last item grows.
-  - Gated on `isAtBottom` so scrolling up to read history is never yanked down.
-  - `behavior: "auto"` (instant) — never `"smooth"`, which kicks off competing
-    animations on rapid streaming growth.
-  - rAF coalescing (a `followRafRef` guard) is the sanctioned exception to the
-    "no `messages`-dep DOM effect" rule; a separate unmount-only effect cancels
-    any pending frame.
+- **Streaming follow (the load-bearing piece):** Virtuoso's
+  `totalListHeightChanged={handleListHeightChanged}` callback fires as part of
+  Virtuoso's resize processing, **after** it applies its scroll compensation, so
+  setting `scroller.scrollTop = scroller.scrollHeight` there is the *last write
+  before paint on exactly the frames that resize* — the frames the old rAF pin
+  lost.
+  - Capture the scroller via `scrollerRef={el => { scrollerElRef.current = el }}`
+    and write its `scrollTop` directly (raw position set) — never
+    `scrollToIndex({ align: "end" })` (re-derives its target from the growing
+    last item and bounces).
+  - Gated on a **live `isAtBottomRef`** (read each call, not a stale closure) so
+    scrolling up to read history releases the pin immediately.
+  - Pin only while `isLoadingRef.current` is true **plus a bounded ~700ms
+    settling window** (`stickTailUntilRef`) after the turn ends, so the closing
+    Collapse animations / results panel don't strand the view at the message
+    top. Outside that window the pin no-ops (it never hijacks normal scrolling).
 - `initialTopMostItemIndex={Math.max(0, messages.length - 1)}` — lands at the
   newest message on mount / chat switch.
 - `atBottomStateChange={setIsAtBottom}` + `atBottomThreshold={120}` — drives the
@@ -186,9 +199,10 @@ callback, not via a selector subscription.
 - [ ] No new `useEffect` depending on `messages` that touches the DOM
 - [ ] `experimental_throttle: 50` is present on `useChat`
 - [ ] Message list stays virtualized (`<Virtuoso data={messages}>`), never `messages.map`
-- [ ] Auto-scroll uses the coalesced rAF `scrollTo({ top })` follow effect
-      (gated on `isAtBottom`), **not** Virtuoso `followOutput` and **not**
-      a per-chunk `scrollToIndex`/`scrollIntoView`
+- [ ] Auto-scroll pins the bottom in Virtuoso's `totalListHeightChanged`
+      callback (gated on a live `isAtBottomRef`), **not** Virtuoso `followOutput`,
+      **not** a per-`messages`-tick rAF `scrollTo`, and **not** a per-chunk
+      `scrollToIndex`/`scrollIntoView`
 - [ ] Collapsed `StreamingToolCard` bodies unmount (`Collapse unmountOnExit`)
 - [ ] Any new child component inside `ChatMessageRow` is `React.memo`-wrapped
 - [ ] Zustand selectors return primitives, not object references

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -3065,48 +3065,58 @@ const Chat: React.FC<ChatProps> = ({
 
   // Stick to the streaming tail while a turn is generating.
   //
-  // Virtuoso's `followOutput` only fires when the item COUNT changes, and its
-  // resize re-stick (`notAtBottomBecause === "SIZE_INCREASED"`) is only armed
-  // for ~100ms after a list refresh. But an entire assistant turn — thinking
-  // blocks, every tool card, and the final text — streams into a SINGLE
-  // message, growing one item without ever changing the count. So neither
-  // built-in mechanism keeps us pinned mid-turn: thinking blocks and tool
-  // cards stream in below the fold and the view never follows them down.
+  // Virtuoso's `followOutput` only fires when the item COUNT changes, but an
+  // entire assistant turn — thinking blocks, every tool card, and the final
+  // text — streams into a SINGLE message, growing one item without ever
+  // changing the count. So `followOutput` never fires mid-turn and the view
+  // doesn't follow the streaming content (it stays OFF on `<Virtuoso>`).
   //
-  // Drive the follow ourselves: on each (throttled) `messages` tick while
-  // streaming, coalesce a single rAF that pins the scroller to the bottom.
-  // We use the handle's `scrollTo({ top })` (a direct scroll-position set on
-  // Virtuoso's scroller) rather than `scrollToIndex({ align: "end" })`: an
-  // index scroll re-derives its target from the last item's *current* measured
-  // size, so firing it every frame while that item is still growing/being
-  // re-measured makes the view bounce between the item's top and bottom (the
-  // "jumping/blinking"). Pinning the raw scroll position to the bottom each
-  // frame is self-correcting and never bounces upward. Gated on `isAtBottom`
-  // so scrolling up to read history is never yanked back down. This is the
-  // rAF-coalesced exception to the "no messages-dep DOM effect" rule
-  // (see .cursor/rules/75-chat-performance.mdc).
-  const followRafRef = useRef<number | null>(null);
-  useEffect(() => {
-    if (!isLoading || !isAtBottom) return;
-    if (followRafRef.current !== null) return; // coalesce: one pin per frame
-    followRafRef.current = requestAnimationFrame(() => {
-      followRafRef.current = null;
-      virtuosoRef.current?.scrollTo({
-        top: Number.MAX_SAFE_INTEGER,
-        behavior: "auto",
-      });
-    });
-  }, [messages, isLoading, isAtBottom]);
+  // We instead pin the bottom inside Virtuoso's own `totalListHeightChanged`
+  // callback (`handleListHeightChanged`). The earlier approach pinned on each
+  // throttled `messages` tick via a one-shot rAF, but that only covers ~1 of
+  // every 3 frames: the interior blocks that change height asynchronously and
+  // non-monotonically (MUI `Collapse` on the thinking block + tool cards, and
+  // the `modify_console` diff re-render) animate over ~300ms on frames where
+  // `messages` does NOT tick. On those frames Virtuoso's resize anchoring
+  // nudges `scrollTop` UP (toward the message top) to keep content stable, and
+  // with no pin to counter it the view paints partway up — then the next
+  // `messages` tick pins it back down. That alternation is the top/bottom
+  // "jumping/blinking". Plain-text turns never bounced because their growth is
+  // append-only at the bottom (monotonic), so the anchor and the pin agree.
+  //
+  // `totalListHeightChanged` fires as part of Virtuoso's resize processing,
+  // AFTER it applies that compensation, so writing `scrollTop = scrollHeight`
+  // here is the last write before paint on exactly the frames that resize —
+  // the frames the old pin lost. Reading `isAtBottom` from a ref keeps history
+  // reading un-yanked the instant the user scrolls up.
+  const scrollerElRef = useRef<HTMLElement | Window | null>(null);
+  const isAtBottomRef = useRef(isAtBottom);
+  isAtBottomRef.current = isAtBottom;
 
-  useEffect(
-    () => () => {
-      if (followRafRef.current !== null) {
-        cancelAnimationFrame(followRafRef.current);
-        followRafRef.current = null;
-      }
-    },
-    [],
-  );
+  // Bounded settling window after a turn ends. The closing Collapse animations
+  // (thinking block, tool cards) and the results panel keep emitting height
+  // changes after `isLoading` flips false; without continuing to pin through
+  // them, Virtuoso's last upward compensation strands the view at the message
+  // top. Gated on `isAtBottom`, so it never hijacks a user who scrolled away.
+  const stickTailUntilRef = useRef(0);
+  const wasLoadingRef = useRef(isLoading);
+  useEffect(() => {
+    if (wasLoadingRef.current && !isLoading) {
+      stickTailUntilRef.current = Date.now() + 700;
+    }
+    wasLoadingRef.current = isLoading;
+  }, [isLoading]);
+
+  const pinToBottom = useCallback(() => {
+    if (!isAtBottomRef.current) return;
+    if (!isLoadingRef.current && Date.now() > stickTailUntilRef.current) return;
+    const el = scrollerElRef.current;
+    if (el && el instanceof HTMLElement) el.scrollTop = el.scrollHeight;
+  }, []);
+
+  const handleListHeightChanged = useCallback(() => {
+    pinToBottom();
+  }, [pinToBottom]);
 
   // Rescue tool cards orphaned by a clean stream end.
   //
@@ -4612,16 +4622,25 @@ const Chat: React.FC<ChatProps> = ({
             // survives streaming ticks and history inserts — mirrors the old
             // `key={message.id}`.
             computeItemKey={(_index, message) => message.id}
-            // Auto-scroll during streaming is owned entirely by the rAF
-            // `scrollTo({ top })` follow effect above (it covers BOTH new-
-            // message appends and intra-message growth, since `messages`
-            // changes in both cases). `followOutput` is left OFF: Virtuoso's
-            // built-in follow does a `scrollToIndex({ align: "end" })` on every
-            // count change, which — racing our per-frame pin while the last
-            // item is being re-measured — reintroduces the top/bottom bounce
-            // ("jumping/blinking"). Mount/history-load anchoring is handled by
+            // Auto-scroll during streaming is owned by the bottom-pin in
+            // `handleListHeightChanged` (wired to `totalListHeightChanged`
+            // below), gated on `isAtBottom`. `followOutput` is left OFF:
+            // it only fires on item-COUNT change (a whole turn streams into ONE
+            // message, so it never fires mid-turn) and its
+            // `scrollToIndex({ align: "end" })` races the pin and bounces the
+            // view. Mount/history-load anchoring is handled by
             // `initialTopMostItemIndex` and the explicit post-load scroll.
             followOutput={false}
+            // Capture the scroller so the height-change pin can set its
+            // scrollTop directly (last write before paint on resize frames).
+            scrollerRef={el => {
+              scrollerElRef.current = el;
+            }}
+            // Pin the bottom on every total-height change while streaming (and
+            // through the bounded post-turn settling window) — see the
+            // `handleListHeightChanged` comment for why this beats a per-frame
+            // rAF for the Collapse/diff resize bounce.
+            totalListHeightChanged={handleListHeightChanged}
             initialTopMostItemIndex={Math.max(0, messages.length - 1)}
             atBottomStateChange={setIsAtBottom}
             atBottomThreshold={120}

--- a/app/src/components/__tests__/Chat.perf.test.ts
+++ b/app/src/components/__tests__/Chat.perf.test.ts
@@ -315,27 +315,32 @@ describe("Chat.tsx structural guards", () => {
     expect(chatSource).toMatch(/computeItemKey=/);
   });
 
-  it("auto-follows the streaming tail via a coalesced rAF scrollTo, gated on isAtBottom", () => {
-    // Auto-scroll is owned by a coalesced requestAnimationFrame follow effect
-    // that pins the scroller to the bottom (`scrollTo({ top })`) on each
-    // streaming tick — NOT Virtuoso's `followOutput`. `followOutput` only fires
-    // on item-COUNT change (a whole turn streams into ONE message, so it never
-    // fires mid-turn) and, when it does, its `scrollToIndex({ align: "end" })`
-    // races our per-frame pin and bounces the view. So it must stay OFF.
+  it("auto-follows the streaming tail by pinning in totalListHeightChanged, gated on isAtBottom", () => {
+    // Auto-scroll is owned by a bottom-pin inside Virtuoso's
+    // `totalListHeightChanged` callback — NOT Virtuoso's `followOutput` and NOT
+    // a per-`messages`-tick rAF. `followOutput` only fires on item-COUNT change
+    // (a whole turn streams into ONE message, so it never fires mid-turn) and
+    // its `scrollToIndex({ align: "end" })` races the pin and bounces the view,
+    // so it must stay OFF. The previous rAF-on-messages-tick pin only covered
+    // ~1 of every 3 frames, so the interior Collapse/diff resizes (which fire
+    // between ticks) let Virtuoso's anchoring pull the view up → top/bottom
+    // bounce. Pinning in `totalListHeightChanged` runs after Virtuoso's
+    // compensation on exactly the resize frames, which fixes the bounce.
     expect(chatSource).toMatch(/followOutput=\{false\}/);
-    // The follow effect must coalesce with rAF, pin to the bottom, and be gated
-    // on isAtBottom (so scrolling up to read history isn't yanked down).
-    expect(chatSource).toMatch(/requestAnimationFrame/);
     expect(chatSource).toMatch(
-      /scrollTo\(\{\s*top:\s*Number\.MAX_SAFE_INTEGER/,
+      /totalListHeightChanged=\{handleListHeightChanged\}/,
     );
-    expect(chatSource).toMatch(/if \(!isLoading \|\| !isAtBottom\) return;/);
+    // The pin writes scrollTop on the captured scroller and is gated on the
+    // live isAtBottom ref (so scrolling up to read history isn't yanked down).
+    expect(chatSource).toMatch(/scrollerRef=\{/);
+    expect(chatSource).toMatch(/el\.scrollTop = el\.scrollHeight/);
+    expect(chatSource).toMatch(/if \(!isAtBottomRef\.current\) return;/);
   });
 
   it("does NOT have a DIY useEffect([messages]) scrollIntoView auto-scroll", () => {
-    // The follow effect uses Virtuoso's `scrollTo` handle (gated + rAF
-    // coalesced), never a raw per-chunk `scrollIntoView` on a DOM node, which
-    // fired every chunk and broke hover/click + caused jank.
+    // The follow pin sets scrollTop on Virtuoso's captured scroller inside its
+    // height-change callback, never a raw per-chunk `scrollIntoView` on a DOM
+    // node, which fired every chunk and broke hover/click + caused jank.
     expect(chatSource).not.toMatch(/scrollIntoView/);
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Walkthrough

Fixed chat streaming auto-scroll: the view stays smoothly pinned to the newest content (no top/bottom bounce), ends at the bottom, and still lets you scroll up to read history mid-stream.

[chat_streaming_fixed_no_bounce.mp4](https://cursor.com/agents/bc-bb58dc52-3175-48e7-a74c-6a854b09badd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchat_streaming_fixed_no_bounce.mp4)

Before (the bug, for reference — view snaps between the top of the message and the bottom several times per second, then is stranded at the top):

[chat_streaming_current_behavior.mp4](https://cursor.com/agents/bc-bb58dc52-3175-48e7-a74c-6a854b09badd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchat_streaming_current_behavior.mp4)

## Problem

After #582, the chat still **bounces/flickers** during streaming: the message view violently snaps between the **top of the assistant message and the bottom several times per second**, and at the end of the turn it is left **stranded at the top** instead of the bottom.

A frame-by-frame video review confirmed it. The decisive clue from instrumentation: a **plain-text** response streams smoothly (no bounce), while turns with **thinking blocks + tool cards + a `modify_console` diff** bounce hard.

## Root cause

#582 pinned the bottom with a one-shot `requestAnimationFrame` (`scrollTo({ top: MAX })`) scheduled on each throttled (`~50ms`) `messages` tick — i.e. only ~1 of every 3 frames.

The interior blocks that change height **asynchronously and non-monotonically** — MUI `Collapse` on the thinking block + tool cards, and the `modify_console` diff re-render — animate over ~300ms on frames where `messages` does **not** tick. On those frames react-virtuoso's resize anchoring nudges `scrollTop` **up** (toward the message top) to keep content stable; with no pin to counter it on those frames, the view paints partway up, then the next `messages` tick pins it back down → the top/bottom oscillation. (`requestAnimationFrame` also runs *before* `ResizeObserver` in the frame, so an rAF pin can't out-write virtuoso's compensation on a resize frame regardless.) Plain text never bounced because its growth is append-only at the bottom (monotonic), so anchor and pin agree.

## Fix

Pin the bottom inside react-virtuoso's own `totalListHeightChanged` callback instead of a per-`messages`-tick rAF. That callback fires as part of virtuoso's resize processing, **after** it applies its compensation, so writing `scroller.scrollTop = scroller.scrollHeight` there is the **last write before paint on exactly the frames that resize** — the frames the old pin lost.

- Capture the scroller via `scrollerRef` and set its `scrollTop` directly.
- Gate on a **live `isAtBottomRef`** (read each call, not a stale closure) so scrolling up to read history releases the pin immediately.
- Keep pinning while loading **plus a bounded ~700ms settling window** after the turn ends, so the closing Collapse animations / results panel don't strand the view at the top.
- `followOutput` stays OFF.

Updates the chat-performance rule and the perf regression guards in `Chat.perf.test.ts`.

## Testing

- `pnpm --filter app run typecheck`
- `pnpm --filter app run lint`
- `pnpm --filter app exec vitest run src/components/__tests__/Chat.perf.test.ts` (32 passed)
- Manual before/after on the running app with the thinking + tool-card repro; frame-by-frame video review confirmed no bounce, final resting position at the bottom, and that scrolling up during streaming is respected.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb58dc52-3175-48e7-a74c-6a854b09badd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb58dc52-3175-48e7-a74c-6a854b09badd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

