### PR TITLE
feat(agent): run query_duckdb / inspect_data_source / list_data_sources on the server

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -13,7 +13,7 @@
     "worker:dev": "tsx watch src/worker.ts",
     "migrate:workspaces": "tsx src/migrations/migrate-to-workspaces.ts",
     "openapi:generate": "tsx src/openapi/generate-cli.ts",
-    "test": "tsx src/openapi/core.test.ts && tsx src/openapi/openapi.test.ts && tsx src/dbt/warm-dir-cache.test.ts && tsx src/connectors/stripe/connector.test.ts && tsx src/connectors/close/connector.test.ts && tsx src/connectors/pandadoc/connector.test.ts && tsx src/sync-cdc/idempotency.test.ts && tsx src/agent-lib/context/compaction.test.ts && tsx src/services/safe-fetch.service.test.ts && tsx src/agent-lib/tools/check-query-status-poll.test.ts",
+    "test": "tsx src/openapi/core.test.ts && tsx src/openapi/openapi.test.ts && tsx src/dbt/warm-dir-cache.test.ts && tsx src/connectors/stripe/connector.test.ts && tsx src/connectors/close/connector.test.ts && tsx src/connectors/pandadoc/connector.test.ts && tsx src/sync-cdc/idempotency.test.ts && tsx src/agent-lib/context/compaction.test.ts && tsx src/services/safe-fetch.service.test.ts && tsx src/agent-lib/tools/check-query-status-poll.test.ts && tsx src/services/server-data-source.service.test.ts",
     "test:dbt": "vitest run",
     "test:dbt:watch": "vitest",
     "test:destinations": "vitest run --config vitest.destinations.config.ts",

--- a/api/src/agent-lib/tools/server-data-source-tools.ts
+++ b/api/src/agent-lib/tools/server-data-source-tools.ts
@@ -1,0 +1,97 @@
+/**
+ * Server-side data-source tools (issue #475 pattern, extended to data sources)
+ *
+ * `list_data_sources`, `inspect_data_source`, and `query_duckdb` execute on the
+ * API instead of in the browser. They read the authoritative MakoApp / Dashboard
+ * document and query the SAME materialized Parquet artifacts the browser loads
+ * into DuckDB-WASM — via node DuckDB (`@duckdb/node-api`). This makes analytical
+ * validation work end-to-end with no attached browser (mobile lock, headless
+ * runs, stranded turns).
+ *
+ * Read-only by construction: no Mongo writes, no realtime events. SQL is gated
+ * to a single read-only SELECT/WITH statement with external access disabled.
+ *
+ * Tool schemas live in @mako/agent-tools (shared with the app's tool cards).
+ */
+import { tool } from "ai";
+import {
+  listDataSourcesSchema,
+  inspectDataSourceSchema,
+  queryDuckdbSchema,
+} from "@mako/agent-tools";
+import {
+  listSurfaceDataSources,
+  inspectSurfaceDataSource,
+  querySurfaceDuckDB,
+} from "../../services/server-data-source.service";
+import { loggers } from "../../logging";
+
+const logger = loggers.agent();
+
+export interface ServerDataSourceToolsOptions {
+  workspaceId: string;
+}
+
+export function createServerDataSourceTools({
+  workspaceId,
+}: ServerDataSourceToolsOptions) {
+  const wrap = async <T>(
+    label: string,
+    fn: () => Promise<T>,
+  ): Promise<T | { success: false; error: string }> => {
+    try {
+      return await fn();
+    } catch (error) {
+      logger.warn(`Server data-source tool failed: ${label}`, {
+        error,
+        workspaceId,
+      });
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : `Failed: ${label}`,
+      };
+    }
+  };
+
+  return {
+    list_data_sources: tool({
+      description:
+        "List the data sources of an app or dashboard: name, connection, query, " +
+        "materialization mode, build status, and row counts. Works for both " +
+        "surfaces — pass surface.kind and surface.id. Use this to understand what " +
+        "data is available and how it was built.",
+      inputSchema: listDataSourcesSchema,
+      execute: async ({ surface }) =>
+        wrap("list_data_sources", () =>
+          listSurfaceDataSources(workspaceId, surface),
+        ),
+    }),
+
+    inspect_data_source: tool({
+      description:
+        "Inspect one data source: its connection, query, column schema, and a few " +
+        "sample rows (from the materialized Parquet artifact when available, " +
+        "otherwise a live preview). Works for apps and dashboards.",
+      inputSchema: inspectDataSourceSchema,
+      execute: async ({ surface, dataSource }) =>
+        wrap("inspect_data_source", () =>
+          inspectSurfaceDataSource(workspaceId, surface, dataSource),
+        ),
+    }),
+
+    query_duckdb: tool({
+      description:
+        "Run analytical DuckDB SQL against a surface's materialized tables and " +
+        "return the rows. Table names are the data source names (apps) or " +
+        "tableRefs (dashboards). Only read-only SELECT / WITH queries are allowed. " +
+        "Tables must be materialized to Parquet first (call materialize_binding " +
+        "for app bindings). Use to validate aggregations before writing them into " +
+        "app `useDuckDB` calls or dashboard widget SQL.",
+      inputSchema: queryDuckdbSchema,
+      execute: async ({ surface, sql }) =>
+        wrap("query_duckdb", () =>
+          querySurfaceDuckDB(workspaceId, surface, sql),
+        ),
+    }),
+  };
+}

--- a/api/src/agents/unified/index.ts
+++ b/api/src/agents/unified/index.ts
@@ -8,6 +8,7 @@ import {
 } from "@mako/agent-tools";
 import { createDbtServerTools } from "../../agent-lib/tools/dbt-tools";
 import { createServerAppTools } from "../../agent-lib/tools/server-app-tools";
+import { createServerDataSourceTools } from "../../agent-lib/tools/server-data-source-tools";
 import { createSelfDirectiveTools } from "../../agent-lib/tools/self-directive-tool";
 import { createSkillTools } from "../../agent-lib/tools/skill-tools";
 import { createConsoleSearchTools } from "../../agent-lib/tools/console-search-tools";
@@ -57,6 +58,7 @@ export function unifiedAgentFactory(context: AgentContext): AgentConfig {
     userId,
     chatId: context.chatId,
   });
+  const serverDataSourceTools = createServerDataSourceTools({ workspaceId });
 
   const {
     list_connections: _flowListConnections,
@@ -88,6 +90,10 @@ export function unifiedAgentFactory(context: AgentContext): AgentConfig {
       ...clientDbtTools,
       ...dbtServerTools,
       ...clientDataSourceTools,
+      // Server-executed data-source tools override the client (no-execute)
+      // versions of the same names so analytical queries run on the API with
+      // no attached browser. Must come after clientDataSourceTools.
+      ...serverDataSourceTools,
       ...flowUniqueTools,
       ...selfDirectiveTools,
       ...skillTools,

--- a/api/src/services/server-data-source.service.test.ts
+++ b/api/src/services/server-data-source.service.test.ts
@@ -1,0 +1,217 @@
+/* eslint-disable no-console */
+/**
+ * Tests for the server-side data-source tools.
+ *
+ * - `checkServerDuckDbSql` gate: pure, always runs.
+ * - End-to-end query/inspect/list: builds a real Parquet artifact, stores it,
+ *   attaches it to a MakoApp binding, and runs the server tools against node
+ *   DuckDB. Self-skips when MongoDB is unreachable (so it is safe in CI without
+ *   a database), mirroring seed-dev-admin's soft-fail.
+ */
+import assert from "node:assert/strict";
+import { Types } from "mongoose";
+import mongoose from "mongoose";
+import { buildParquetFromBatches } from "../utils/streaming-parquet-builder";
+import {
+  storeArtifact,
+  deleteArtifact,
+  getArtifactPrefix,
+} from "./dashboard-cache.service";
+import {
+  checkServerDuckDbSql,
+  querySurfaceDuckDB,
+  listSurfaceDataSources,
+  inspectSurfaceDataSource,
+} from "./server-data-source.service";
+
+function testSqlGate() {
+  console.log("  checkServerDuckDbSql: read-only single-statement gate");
+
+  // Accepts read-only SELECT / WITH.
+  assert.equal(checkServerDuckDbSql("SELECT 1").ok, true);
+  assert.equal(
+    checkServerDuckDbSql("  -- comment\n SELECT * FROM foo").ok,
+    true,
+  );
+  assert.equal(
+    checkServerDuckDbSql("WITH x AS (SELECT 1 AS a) SELECT * FROM x").ok,
+    true,
+  );
+  const trailing = checkServerDuckDbSql("SELECT 1;");
+  assert.equal(trailing.ok, true);
+  assert.equal(trailing.ok && trailing.statement, "SELECT 1");
+
+  // Rejects non-read-only.
+  assert.equal(checkServerDuckDbSql("DELETE FROM foo").ok, false);
+  assert.equal(checkServerDuckDbSql("INSERT INTO foo VALUES (1)").ok, false);
+  assert.equal(checkServerDuckDbSql("CREATE TABLE x (a INT)").ok, false);
+  assert.equal(checkServerDuckDbSql("PRAGMA database_list").ok, false);
+  assert.equal(checkServerDuckDbSql("").ok, false);
+
+  // Rejects file / extension / network access.
+  assert.equal(
+    checkServerDuckDbSql("SELECT * FROM read_parquet('/etc/passwd')").ok,
+    false,
+  );
+  assert.equal(
+    checkServerDuckDbSql("SELECT * FROM read_csv_auto('/etc/passwd')").ok,
+    false,
+  );
+  assert.equal(checkServerDuckDbSql("ATTACH 'x.db' AS y").ok, false);
+  assert.equal(
+    checkServerDuckDbSql("COPY (SELECT 1) TO '/tmp/x.csv'").ok,
+    false,
+  );
+  assert.equal(checkServerDuckDbSql("INSTALL httpfs").ok, false);
+
+  // Rejects multi-statement.
+  assert.equal(checkServerDuckDbSql("SELECT 1; DROP TABLE foo").ok, false);
+  // Semicolon inside a string literal is fine.
+  assert.equal(checkServerDuckDbSql("SELECT ';' AS s").ok, true);
+
+  console.log("    ✓ gate accepts/rejects as expected");
+}
+
+async function buildArtifact(
+  key: string,
+  rows: Record<string, unknown>[],
+): Promise<void> {
+  const built = await buildParquetFromBatches({
+    filenameBase: "test-server-ds",
+    fields: [
+      { name: "genre", type: "VARCHAR" },
+      { name: "amount", type: "DOUBLE" },
+    ],
+    streamBatches: async insert => {
+      await insert(rows);
+    },
+  });
+  await storeArtifact(built.filePath, key);
+}
+
+async function testEndToEnd() {
+  console.log("  end-to-end: materialized binding -> node DuckDB query");
+
+  const workspaceId = new Types.ObjectId();
+  const appId = new Types.ObjectId();
+  const bindingId = "bind_test";
+  const artifactKey = `${getArtifactPrefix()}/test/${appId.toString()}/${bindingId}.parquet`;
+
+  await buildArtifact(artifactKey, [
+    { genre: "Rock", amount: 10 },
+    { genre: "Rock", amount: 5 },
+    { genre: "Jazz", amount: 7 },
+  ]);
+
+  const MakoApp = mongoose.model("MakoApp");
+  await MakoApp.create({
+    _id: appId,
+    workspaceId,
+    title: "Test App",
+    template: "blank",
+    runtime: "cdn",
+    entrypoint: "App.tsx",
+    files: [{ path: "App.tsx", contents: "" }],
+    dependencies: {},
+    dataBindings: [
+      {
+        id: bindingId,
+        name: "sales",
+        connectionId: new Types.ObjectId().toString(),
+        language: "sql",
+        code: "SELECT genre, amount FROM sales",
+        materialization: "parquet",
+        cache: {
+          parquetArtifactKey: artifactKey,
+          parquetBuildStatus: "ready",
+          rowCount: 3,
+          artifactRevision: "1",
+        },
+      },
+    ],
+    version: 1,
+    access: "private",
+    createdBy: "test",
+  });
+
+  const surface = { kind: "app" as const, id: appId.toString() };
+  const wsId = workspaceId.toString();
+
+  try {
+    // list_data_sources
+    const list = await listSurfaceDataSources(wsId, surface);
+    assert.equal(list.success, true);
+    assert.equal((list.dataSources as unknown[]).length, 1);
+    assert.equal((list.dataSources as { name: string }[])[0].name, "sales");
+    console.log("    ✓ list_data_sources returns the binding");
+
+    // query_duckdb — aggregation against the materialized table.
+    const q = await querySurfaceDuckDB(
+      wsId,
+      surface,
+      'SELECT genre, SUM(amount) AS total FROM "sales" GROUP BY genre ORDER BY genre',
+    );
+    assert.equal(q.success, true, `query failed: ${q.error}`);
+    const rows = q.rows as { genre: string; total: number }[];
+    assert.equal(rows.length, 2);
+    assert.equal(rows[0].genre, "Jazz");
+    assert.equal(Number(rows[0].total), 7);
+    assert.equal(rows[1].genre, "Rock");
+    assert.equal(Number(rows[1].total), 15);
+    assert.deepEqual(q.tables, ["sales"]);
+    console.log("    ✓ query_duckdb returns correct aggregation");
+
+    // query_duckdb — file access is blocked even though we loaded a parquet.
+    const blocked = await querySurfaceDuckDB(
+      wsId,
+      surface,
+      "SELECT * FROM read_parquet('/etc/hostname')",
+    );
+    assert.equal(blocked.success, false);
+    console.log("    ✓ query_duckdb blocks file access");
+
+    // inspect_data_source — samples rows from the materialized table.
+    const inspect = await inspectSurfaceDataSource(wsId, surface, "sales");
+    assert.equal(inspect.success, true);
+    const ds = inspect.dataSource as {
+      columns: string[];
+      sampleRows: unknown[];
+    };
+    assert.ok(ds.columns.includes("genre"));
+    assert.ok(ds.columns.includes("amount"));
+    assert.equal(ds.sampleRows.length, 3);
+    console.log("    ✓ inspect_data_source samples the materialized table");
+  } finally {
+    await MakoApp.deleteOne({ _id: appId }).catch(() => undefined);
+    await deleteArtifact(artifactKey).catch(() => undefined);
+  }
+}
+
+async function main() {
+  console.log("server-data-source.service tests");
+  testSqlGate();
+
+  const uri = process.env.DATABASE_URL || "mongodb://127.0.0.1:27017/mako";
+  try {
+    await mongoose.connect(uri, { serverSelectionTimeoutMS: 2500 });
+  } catch {
+    console.log("  end-to-end: SKIPPED (MongoDB unreachable)");
+    console.log("✓ server-data-source.service tests passed (gate only)");
+    return;
+  }
+
+  try {
+    await testEndToEnd();
+  } finally {
+    await mongoose.disconnect().catch(() => undefined);
+  }
+
+  console.log("✓ server-data-source.service tests passed");
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch(err => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/api/src/services/server-data-source.service.test.ts
+++ b/api/src/services/server-data-source.service.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-console */
+/* eslint-disable no-console, no-process-exit */
 /**
  * Tests for the server-side data-source tools.
  *
@@ -9,8 +9,7 @@
  *   a database), mirroring seed-dev-admin's soft-fail.
  */
 import assert from "node:assert/strict";
-import { Types } from "mongoose";
-import mongoose from "mongoose";
+import mongoose, { Types } from "mongoose";
 import { buildParquetFromBatches } from "../utils/streaming-parquet-builder";
 import {
   storeArtifact,

--- a/api/src/services/server-data-source.service.ts
+++ b/api/src/services/server-data-source.service.ts
@@ -1,0 +1,620 @@
+/**
+ * Server-side data-source execution (surface-agnostic).
+ *
+ * Mirrors the browser data-source tools (`list_data_sources`,
+ * `inspect_data_source`, `query_duckdb`) on the API so the agent can run them
+ * with NO attached browser. Materialized Parquet artifacts — built by the SAME
+ * pipeline the browser loads into DuckDB-WASM (see
+ * app-binding-materialization.service.ts / parquet-build.service.ts) — are
+ * streamed from the artifact store into a node DuckDB instance
+ * (`@duckdb/node-api`) and queried with identical SQL. The browser's WASM tables
+ * and the server's node tables are loaded from the same artifacts, so results
+ * match.
+ *
+ * Safety: the agent's SQL is gated to a single read-only SELECT/WITH statement
+ * with no file/extension access (DuckDB external access is disabled before the
+ * query runs, and a denylist rejects file table-functions). The instance only
+ * holds this workspace's own materialized data, which the caller can already
+ * read.
+ */
+
+import os from "os";
+import path from "path";
+import { promises as fsPromises, createWriteStream } from "fs";
+import { pipeline } from "stream/promises";
+import { Types } from "mongoose";
+import { DuckDBInstance } from "@duckdb/node-api";
+import {
+  MakoApp,
+  Dashboard,
+  DatabaseConnection,
+} from "../database/workspace-schema";
+import { getArtifactStore } from "./dashboard-cache.service";
+import { databaseConnectionService } from "./database-connection.service";
+import { loggers } from "../logging";
+
+const logger = loggers.api("server-data-source");
+
+const DEFAULT_DUCKDB_MEMORY_LIMIT_MB = 512;
+/** Rows returned to the model (matches the browser tool's `slice(100)`). */
+const RESULT_ROW_CAP = 100;
+/** Hard cap on rows materialized from the agent query to bound API heap. */
+const READ_ROW_CAP = 10_000;
+/** Sample rows for inspect_data_source (matches the browser tool). */
+const INSPECT_SAMPLE_ROWS = 5;
+
+export interface DataSourceSurface {
+  kind: "app" | "dashboard";
+  id: string;
+}
+
+export interface ServerDataSourceResult {
+  success: boolean;
+  error?: string;
+  [key: string]: unknown;
+}
+
+/** DuckDB-safe table name derived from a binding name (mirrors the client). */
+function bindingTableName(name: string): string {
+  const safe = name.replace(/[^a-zA-Z0-9_]/g, "_");
+  return /^[a-zA-Z_]/.test(safe) ? safe : `t_${safe}`;
+}
+
+function fail(error: string): ServerDataSourceResult {
+  return { success: false, error };
+}
+
+const LEADING_SQL_COMMENTS = /^(\s*(--[^\n]*(\n|$)|\/\*[\s\S]*?\*\/))*\s*/;
+// Table functions / statements that reach the host filesystem, network, or
+// extension loader. Rejected even though external access is also disabled at
+// the DuckDB level (defense in depth).
+const FILE_ACCESS_DENYLIST =
+  /\b(read_csv|read_csv_auto|read_parquet|read_json|read_json_auto|read_text|read_blob|read_ndjson|parquet_scan|glob|attach|detach|copy|install|load|sniff_csv)\b/i;
+
+/**
+ * Gate agent-supplied DuckDB SQL: a single read-only SELECT/WITH statement with
+ * no file/extension access. Mirrors `checkSandboxDuckDbSql` on the client and
+ * adds the file-access denylist for the (more sensitive) server context.
+ */
+export function checkServerDuckDbSql(
+  sql: string,
+): { ok: true; statement: string } | { ok: false; error: string } {
+  const stripped = sql.replace(LEADING_SQL_COMMENTS, "").trim();
+  if (!stripped) return { ok: false, error: "Empty SQL." };
+  if (!/^(SELECT|WITH)\b/i.test(stripped)) {
+    return {
+      ok: false,
+      error: "Only read-only SELECT / WITH queries are allowed.",
+    };
+  }
+  if (FILE_ACCESS_DENYLIST.test(stripped)) {
+    return {
+      ok: false,
+      error:
+        "File, network, and extension access (read_parquet, read_csv, ATTACH, COPY, INSTALL, …) is not allowed.",
+    };
+  }
+  // Reject anything after a top-level semicolon (multi-statement).
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < stripped.length; i++) {
+    const ch = stripped[i];
+    if (inSingle) {
+      if (ch === "'") {
+        if (stripped[i + 1] === "'") i++;
+        else inSingle = false;
+      }
+      continue;
+    }
+    if (inDouble) {
+      if (ch === '"') {
+        if (stripped[i + 1] === '"') i++;
+        else inDouble = false;
+      }
+      continue;
+    }
+    if (ch === "'") inSingle = true;
+    else if (ch === '"') inDouble = true;
+    else if (ch === ";" && stripped.slice(i + 1).trim().length > 0) {
+      return { ok: false, error: "Only a single SQL statement is allowed." };
+    }
+  }
+  return { ok: true, statement: stripped.replace(/;\s*$/, "") };
+}
+
+interface SurfaceTable {
+  /** Data source name (apps) or display name (dashboards). */
+  name: string;
+  /** DuckDB table name the SQL references. */
+  table: string;
+  artifactKey?: string;
+  status?: string | null;
+  rowCount?: number | null;
+}
+
+interface ResolvedSurface {
+  tables: SurfaceTable[];
+}
+
+/** Resolve a surface's materialized (Parquet) tables from MongoDB. */
+async function resolveSurfaceTables(
+  workspaceId: string,
+  surface: DataSourceSurface,
+): Promise<ResolvedSurface | { error: string }> {
+  if (!Types.ObjectId.isValid(surface.id)) {
+    return { error: `Invalid ${surface.kind} id: ${surface.id}` };
+  }
+  const wsId = new Types.ObjectId(workspaceId);
+
+  if (surface.kind === "app") {
+    const app = await MakoApp.findOne({
+      _id: new Types.ObjectId(surface.id),
+      workspaceId: wsId,
+    });
+    if (!app) return { error: "App not found" };
+    const tables = (app.dataBindings ?? [])
+      .filter(b => b.materialization === "parquet")
+      .map(b => ({
+        name: b.name,
+        table: bindingTableName(b.name),
+        artifactKey: b.cache?.parquetArtifactKey,
+        status: b.cache?.parquetBuildStatus ?? null,
+        rowCount: b.cache?.rowCount ?? null,
+      }));
+    return { tables };
+  }
+
+  const dashboard = await Dashboard.findOne({
+    _id: new Types.ObjectId(surface.id),
+    workspaceId: wsId,
+  });
+  if (!dashboard) return { error: "Dashboard not found" };
+  const tables = (dashboard.dataSources ?? [])
+    .filter(ds => ds.cache?.parquetArtifactKey)
+    .map(ds => ({
+      name: ds.name,
+      table: ds.tableRef,
+      artifactKey: ds.cache?.parquetArtifactKey,
+      status: ds.cache?.parquetBuildStatus ?? null,
+      rowCount: ds.cache?.rowCount ?? null,
+    }));
+  return { tables };
+}
+
+/** Stream a Parquet artifact from the store into a local temp file. */
+async function fetchArtifactToTemp(
+  artifactKey: string,
+  base: string,
+): Promise<string> {
+  const stream = await getArtifactStore().openReadStream(artifactKey);
+  if (!stream) throw new Error(`Artifact not available: ${artifactKey}`);
+  const tmpPath = path.join(
+    os.tmpdir(),
+    `mako-duckdb-${base}-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2, 8)}.parquet`,
+  );
+  await pipeline(stream, createWriteStream(tmpPath));
+  return tmpPath;
+}
+
+interface DuckDBField {
+  name: string;
+  type?: string;
+}
+
+function extractFields(result: {
+  columnNames?: () => string[];
+  columnTypes?: () => unknown[];
+}): DuckDBField[] {
+  try {
+    const names = result.columnNames?.() ?? [];
+    let types: unknown[] = [];
+    try {
+      types = result.columnTypes?.() ?? [];
+    } catch {
+      types = [];
+    }
+    return names.map((name, i) => ({
+      name,
+      type: types[i] != null ? String(types[i]) : undefined,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+interface LoadedDuckDB {
+  query: (sql: string) => Promise<{
+    rows: Record<string, unknown>[];
+    fields: DuckDBField[];
+  }>;
+  loaded: SurfaceTable[];
+  skipped: { name: string; reason: string }[];
+  cleanup: () => Promise<void>;
+}
+
+/**
+ * Create an in-memory node DuckDB instance with this surface's ready Parquet
+ * tables materialized into it. External file/extension access is disabled
+ * before any caller query runs.
+ */
+async function loadSurfaceDuckDB(
+  surface: DataSourceSurface,
+  tables: SurfaceTable[],
+): Promise<LoadedDuckDB> {
+  const instance = await DuckDBInstance.create(":memory:");
+  const connection = await instance.connect();
+  const tempFiles: string[] = [];
+  const loaded: SurfaceTable[] = [];
+  const skipped: { name: string; reason: string }[] = [];
+
+  const cleanup = async (): Promise<void> => {
+    try {
+      connection.closeSync();
+    } catch {
+      /* best-effort */
+    }
+    try {
+      instance.closeSync();
+    } catch {
+      /* best-effort */
+    }
+    await Promise.all(
+      tempFiles.map(f => fsPromises.rm(f, { force: true }).catch(() => undefined)),
+    );
+  };
+
+  try {
+    await connection.run(
+      `PRAGMA memory_limit='${DEFAULT_DUCKDB_MEMORY_LIMIT_MB}MB'`,
+    );
+    await connection.run(
+      `PRAGMA temp_directory='${os.tmpdir().replace(/'/g, "''")}'`,
+    );
+
+    for (const t of tables) {
+      if (!t.artifactKey || t.status !== "ready") {
+        skipped.push({
+          name: t.name,
+          reason:
+            t.status === "ready"
+              ? "no artifact"
+              : `not materialized (status: ${t.status ?? "missing"})`,
+        });
+        continue;
+      }
+      try {
+        const tmp = await fetchArtifactToTemp(
+          t.artifactKey,
+          `${surface.kind}-${surface.id}`,
+        );
+        tempFiles.push(tmp);
+        // CREATE TABLE (not VIEW): copies rows into DuckDB so the query never
+        // needs file access — which lets us disable external access below.
+        await connection.run(
+          `CREATE TABLE "${t.table.replace(/"/g, '""')}" AS SELECT * FROM read_parquet('${tmp.replace(/'/g, "''")}')`,
+        );
+        loaded.push(t);
+      } catch (error) {
+        skipped.push({
+          name: t.name,
+          reason: error instanceof Error ? error.message : "load failed",
+        });
+      }
+    }
+
+    // Lock down the host: after this, the agent's query can only touch the
+    // tables loaded above. Best-effort — the SQL gate is the primary defense.
+    try {
+      await connection.run(`SET enable_external_access=false`);
+    } catch (error) {
+      logger.warn("Could not disable DuckDB external access", { error });
+    }
+
+    const query = async (sql: string) => {
+      const result = await connection.run(sql);
+      const rows = (await result.getRowObjectsJson()) as Record<
+        string,
+        unknown
+      >[];
+      return { rows, fields: extractFields(result as never) };
+    };
+
+    return { query, loaded, skipped, cleanup };
+  } catch (error) {
+    await cleanup();
+    throw error;
+  }
+}
+
+/**
+ * list_data_sources — pure MongoDB read. Lists a surface's data sources with
+ * connection, query, materialization mode, build status, and row counts.
+ */
+export async function listSurfaceDataSources(
+  workspaceId: string,
+  surface: DataSourceSurface,
+): Promise<ServerDataSourceResult> {
+  if (!Types.ObjectId.isValid(surface.id)) {
+    return fail(`Invalid ${surface.kind} id: ${surface.id}`);
+  }
+  const wsId = new Types.ObjectId(workspaceId);
+
+  if (surface.kind === "app") {
+    const app = await MakoApp.findOne({
+      _id: new Types.ObjectId(surface.id),
+      workspaceId: wsId,
+    });
+    if (!app) return fail("App not found");
+    return {
+      success: true,
+      dataSources: (app.dataBindings ?? []).map(b => ({
+        name: b.name,
+        connectionId: b.connectionId,
+        language: b.language,
+        materialization: b.materialization,
+        code: b.code,
+        status: b.cache?.parquetBuildStatus ?? null,
+        rowCount: b.cache?.rowCount ?? null,
+        table:
+          b.materialization === "parquet"
+            ? bindingTableName(b.name)
+            : undefined,
+      })),
+    };
+  }
+
+  const dashboard = await Dashboard.findOne({
+    _id: new Types.ObjectId(surface.id),
+    workspaceId: wsId,
+  });
+  if (!dashboard) return fail("Dashboard not found");
+  return {
+    success: true,
+    dataSources: (dashboard.dataSources ?? []).map(ds => ({
+      id: ds.id,
+      name: ds.name,
+      table: ds.tableRef,
+      connectionId: ds.query?.connectionId,
+      language: ds.query?.language,
+      code: ds.query?.code,
+      status: ds.cache?.parquetBuildStatus ?? null,
+      rowCount: ds.cache?.rowCount ?? null,
+    })),
+  };
+}
+
+/**
+ * query_duckdb — run read-only analytical SQL against a surface's materialized
+ * tables in node DuckDB and return the rows.
+ */
+export async function querySurfaceDuckDB(
+  workspaceId: string,
+  surface: DataSourceSurface,
+  sql: string,
+): Promise<ServerDataSourceResult> {
+  const gate = checkServerDuckDbSql(sql);
+  if (!gate.ok) return fail(gate.error);
+
+  const resolved = await resolveSurfaceTables(workspaceId, surface);
+  if ("error" in resolved) return fail(resolved.error);
+
+  let db: LoadedDuckDB | undefined;
+  try {
+    db = await loadSurfaceDuckDB(surface, resolved.tables);
+    if (db.loaded.length === 0) {
+      const detail =
+        db.skipped.length > 0
+          ? ` (${db.skipped.map(s => `${s.name}: ${s.reason}`).join("; ")})`
+          : "";
+      return fail(
+        `No materialized tables available to query${detail}. ${
+          surface.kind === "app"
+            ? "Call materialize_binding for the app's parquet bindings first."
+            : "Materialize the dashboard's data sources first."
+        }`,
+      );
+    }
+
+    // Cap rows read into the API process; +1 detects truncation.
+    const capped = `SELECT * FROM (${gate.statement}) AS _mako_q LIMIT ${READ_ROW_CAP + 1}`;
+    const { rows, fields } = await db.query(capped);
+    const truncated = rows.length > READ_ROW_CAP;
+    const effectiveRows = truncated ? rows.slice(0, READ_ROW_CAP) : rows;
+
+    return {
+      success: true,
+      rows: effectiveRows.slice(0, RESULT_ROW_CAP),
+      fields,
+      rowCount: effectiveRows.length,
+      truncated,
+      tables: db.loaded.map(t => t.table),
+      ...(db.skipped.length > 0
+        ? {
+            skippedTables: db.skipped.map(s => `${s.name} (${s.reason})`),
+          }
+        : {}),
+    };
+  } catch (error) {
+    return fail(error instanceof Error ? error.message : "DuckDB query failed");
+  } finally {
+    await db?.cleanup();
+  }
+}
+
+/**
+ * inspect_data_source — connection, query, column schema, and a few sample
+ * rows. Uses the materialized Parquet artifact when ready, otherwise a live
+ * read-only preview against the source connection.
+ */
+export async function inspectSurfaceDataSource(
+  workspaceId: string,
+  surface: DataSourceSurface,
+  dataSourceRef: string,
+): Promise<ServerDataSourceResult> {
+  if (!Types.ObjectId.isValid(surface.id)) {
+    return fail(`Invalid ${surface.kind} id: ${surface.id}`);
+  }
+  const wsId = new Types.ObjectId(workspaceId);
+
+  if (surface.kind === "app") {
+    const app = await MakoApp.findOne({
+      _id: new Types.ObjectId(surface.id),
+      workspaceId: wsId,
+    });
+    if (!app) return fail("App not found");
+    const binding = (app.dataBindings ?? []).find(
+      b => b.name === dataSourceRef,
+    );
+    if (!binding) return fail(`No data source named "${dataSourceRef}"`);
+
+    let columns: string[] = [];
+    let sampleRows: Record<string, unknown>[] = [];
+    let note: string | undefined;
+
+    if (binding.materialization === "parquet") {
+      if (binding.cache?.parquetBuildStatus === "ready") {
+        const sample = await querySurfaceDuckDB(
+          workspaceId,
+          surface,
+          `SELECT * FROM "${bindingTableName(binding.name)}" LIMIT ${INSPECT_SAMPLE_ROWS}`,
+        );
+        if (sample.success) {
+          sampleRows = (sample.rows as Record<string, unknown>[]) ?? [];
+          columns = ((sample.fields as DuckDBField[]) ?? []).map(f => f.name);
+        } else {
+          note = sample.error as string;
+        }
+      } else {
+        note = "Parquet not built yet — call materialize_binding first.";
+      }
+    } else {
+      const live = await runLivePreview(
+        binding.connectionId,
+        binding.code,
+        binding.databaseId,
+        binding.databaseName,
+      );
+      sampleRows = live.rows;
+      columns = live.columns;
+      note = live.note;
+    }
+
+    return {
+      success: true,
+      dataSource: {
+        name: binding.name,
+        connectionId: binding.connectionId,
+        language: binding.language,
+        materialization: binding.materialization,
+        code: binding.code,
+        table:
+          binding.materialization === "parquet"
+            ? bindingTableName(binding.name)
+            : undefined,
+        status: binding.cache?.parquetBuildStatus ?? null,
+        rowCount: binding.cache?.rowCount ?? null,
+        columns,
+        sampleRows,
+      },
+      note,
+    };
+  }
+
+  const dashboard = await Dashboard.findOne({
+    _id: new Types.ObjectId(surface.id),
+    workspaceId: wsId,
+  });
+  if (!dashboard) return fail("Dashboard not found");
+  const ds =
+    (dashboard.dataSources ?? []).find(d => d.id === dataSourceRef) ||
+    (dashboard.dataSources ?? []).find(d => d.name === dataSourceRef);
+  if (!ds) return fail(`No data source "${dataSourceRef}" on this dashboard`);
+
+  let columns: string[] = [];
+  let sampleRows: Record<string, unknown>[] = [];
+  let note: string | undefined;
+
+  if (ds.cache?.parquetArtifactKey && ds.cache?.parquetBuildStatus === "ready") {
+    const sample = await querySurfaceDuckDB(
+      workspaceId,
+      surface,
+      `SELECT * FROM "${ds.tableRef.replace(/"/g, '""')}" LIMIT ${INSPECT_SAMPLE_ROWS}`,
+    );
+    if (sample.success) {
+      sampleRows = (sample.rows as Record<string, unknown>[]) ?? [];
+      columns = ((sample.fields as DuckDBField[]) ?? []).map(f => f.name);
+    } else {
+      note = sample.error as string;
+    }
+  } else if (ds.query?.connectionId && typeof ds.query.code === "string") {
+    const live = await runLivePreview(
+      ds.query.connectionId,
+      ds.query.code,
+      undefined,
+      undefined,
+    );
+    sampleRows = live.rows;
+    columns = live.columns;
+    note = live.note;
+  } else {
+    note = "Data source not materialized yet.";
+  }
+
+  return {
+    success: true,
+    dataSource: {
+      id: ds.id,
+      name: ds.name,
+      table: ds.tableRef,
+      connectionId: ds.query?.connectionId,
+      language: ds.query?.language,
+      code: ds.query?.code,
+      status: ds.cache?.parquetBuildStatus ?? null,
+      rowCount: ds.cache?.rowCount ?? null,
+      columns,
+      sampleRows,
+    },
+    note,
+  };
+}
+
+/** Run a binding/data-source query live (read-only) and return a small sample. */
+async function runLivePreview(
+  connectionId: string | Types.ObjectId,
+  code: string,
+  databaseId: string | undefined,
+  databaseName: string | undefined,
+): Promise<{ rows: Record<string, unknown>[]; columns: string[]; note?: string }> {
+  try {
+    const connectionIdStr = String(connectionId);
+    if (!Types.ObjectId.isValid(connectionIdStr)) {
+      return { rows: [], columns: [], note: "Invalid connection" };
+    }
+    const connection = await DatabaseConnection.findById(connectionIdStr);
+    if (!connection) {
+      return { rows: [], columns: [], note: "Connection not found" };
+    }
+    const result = await databaseConnectionService.executeQuery(
+      connection,
+      code,
+      { databaseId, databaseName },
+    );
+    if (!result.success) {
+      return { rows: [], columns: [], note: result.error };
+    }
+    const rows = (Array.isArray(result.data) ? result.data : []).slice(
+      0,
+      INSPECT_SAMPLE_ROWS,
+    ) as Record<string, unknown>[];
+    const columns = rows.length > 0 ? Object.keys(rows[0]) : [];
+    return { rows, columns };
+  } catch (error) {
+    return {
+      rows: [],
+      columns: [],
+      note: error instanceof Error ? error.message : "Live preview failed",
+    };
+  }
+}

--- a/app/src/agent-runtime/client-tool-manifest.ts
+++ b/app/src/agent-runtime/client-tool-manifest.ts
@@ -510,17 +510,19 @@ export const AGENT_TOOL_MANIFEST = {
     },
     icon: "database",
   },
+  // Data-source tools execute SERVER-SIDE (issue #475 pattern; see
+  // api/src/agent-lib/tools/server-data-source-tools.ts). They query the same
+  // materialized Parquet artifacts via node DuckDB, so they work with no
+  // attached browser. Entries kept for tool-card labels/icons/previews.
   list_data_sources: {
     domain: "database",
-    execution: "client",
-    clientExecutor: "data",
+    execution: "server",
     getLabel: () => "Listing data sources",
     icon: "list",
   },
   inspect_data_source: {
     domain: "database",
-    execution: "client",
-    clientExecutor: "data",
+    execution: "server",
     longRunning: true,
     getLabel: input => {
       const ds = (input as Record<string, unknown>)?.dataSource;
@@ -530,8 +532,7 @@ export const AGENT_TOOL_MANIFEST = {
   },
   query_duckdb: {
     domain: "database",
-    execution: "client",
-    clientExecutor: "data",
+    execution: "server",
     longRunning: true,
     getLabel: () => "Running DuckDB query",
     icon: "play",

--- a/packages/agent-tools/src/data-source-tools.ts
+++ b/packages/agent-tools/src/data-source-tools.ts
@@ -29,6 +29,27 @@ const surfaceSchema = z
   })
   .describe("Target surface that owns the data source(s)");
 
+// Input schemas are shared verbatim with the server-executed versions
+// (api/src/agent-lib/tools/server-data-source-tools.ts) so the tool surface
+// cannot drift between the client tool cards and the server `execute`.
+export const listDataSourcesSchema = z.object({ surface: surfaceSchema });
+
+export const inspectDataSourceSchema = z.object({
+  surface: surfaceSchema,
+  dataSource: z
+    .string()
+    .describe("Data source name (apps) or data source id (dashboards)"),
+});
+
+export const queryDuckdbSchema = z.object({
+  surface: surfaceSchema,
+  sql: z.string().describe("DuckDB SQL to execute"),
+});
+
+export type ListDataSourcesInput = z.infer<typeof listDataSourcesSchema>;
+export type InspectDataSourceInput = z.infer<typeof inspectDataSourceSchema>;
+export type QueryDuckdbInput = z.infer<typeof queryDuckdbSchema>;
+
 export const clientDataSourceTools = {
   list_data_sources: tool({
     description:
@@ -36,29 +57,23 @@ export const clientDataSourceTools = {
       "materialization mode, build status, and row counts. Works for both " +
       "surfaces — pass surface.kind and surface.id. Use this to understand what " +
       "data is available and how it was built.",
-    inputSchema: z.object({ surface: surfaceSchema }),
+    inputSchema: listDataSourcesSchema,
   }),
   inspect_data_source: tool({
     description:
       "Inspect one data source: its connection, query, column schema, and a few " +
-      "sample rows (from in-browser DuckDB when materialized, otherwise a live " +
-      "preview). Works for apps and dashboards.",
-    inputSchema: z.object({
-      surface: surfaceSchema,
-      dataSource: z
-        .string()
-        .describe("Data source name (apps) or data source id (dashboards)"),
-    }),
+      "sample rows (from the materialized Parquet artifact when available, " +
+      "otherwise a live preview). Works for apps and dashboards.",
+    inputSchema: inspectDataSourceSchema,
   }),
   query_duckdb: tool({
     description:
-      "Run analytical DuckDB SQL in the browser against a surface's in-memory " +
-      "tables and return the rows. Table names are the data source names (apps) " +
-      "or tableRefs (dashboards). Use to validate aggregations before writing " +
-      "them into app `useDuckDB` calls or dashboard widget SQL.",
-    inputSchema: z.object({
-      surface: surfaceSchema,
-      sql: z.string().describe("DuckDB SQL to execute"),
-    }),
+      "Run analytical DuckDB SQL against a surface's materialized tables and " +
+      "return the rows. Table names are the data source names (apps) or " +
+      "tableRefs (dashboards). Only read-only SELECT / WITH queries are allowed. " +
+      "Tables must be materialized to Parquet first (call materialize_binding " +
+      "for app bindings). Use to validate aggregations before writing them into " +
+      "app `useDuckDB` calls or dashboard widget SQL.",
+    inputSchema: queryDuckdbSchema,
   }),
 };

--- a/packages/agent-tools/src/index.ts
+++ b/packages/agent-tools/src/index.ts
@@ -80,6 +80,18 @@ export {
 export type { DbtCreateFileInput, DbtModifyFileInput } from "./dbt-tools";
 
 export { clientDataSourceTools } from "./data-source-tools";
+export {
+  // Schemas for the server-executed data-source tools (registered with execute
+  // functions in api/src/agent-lib/tools/server-data-source-tools.ts).
+  listDataSourcesSchema,
+  inspectDataSourceSchema,
+  queryDuckdbSchema,
+} from "./data-source-tools";
+export type {
+  ListDataSourcesInput,
+  InspectDataSourceInput,
+  QueryDuckdbInput,
+} from "./data-source-tools";
 
 export { clientScreenshotTools } from "./screenshot-tools";
 export type { CaptureScreenshotInput } from "./screenshot-tools";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The surface-agnostic data-source tools (`query_duckdb`, `inspect_data_source`, `list_data_sources`) were **browser-only** — they had no server `execute`, so the AI SDK forwarded them to the browser's `onToolCall`. When no browser tab is actively driving the chat (mobile lock, tab backgrounded, headless/stranded turns), they never run and the tool card ends up stuck/"Interrupted — stream disconnected". `query_duckdb` is one of the tools seen failing in that state.

## Change

Make these three tools **server-executable** (the established #475 pattern, extended to data sources). The server `execute` queries the **same materialized Parquet artifacts the browser loads into DuckDB-WASM** — built by `app-binding-materialization` / `parquet-build` — but via **node DuckDB** (`@duckdb/node-api`, already a dependency). Identical SQL, identical data, no browser required.

- **`api/src/services/server-data-source.service.ts`** (new) — streams a surface's ready Parquet artifacts from the artifact store into an in-memory node DuckDB instance and runs read-only SQL. Handles both app bindings (`bindingTableName`) and dashboard data sources (`tableRef`). Live (non-parquet) sources fall back to a read-only sample query for `inspect_data_source`.
- **`api/src/agent-lib/tools/server-data-source-tools.ts`** (new) — registers the three tools with `execute`.
- **`api/src/agents/unified/index.ts`** — spreads `serverDataSourceTools` after `clientDataSourceTools` so the server (execute) versions override the client (no-execute) ones.
- **`app/src/agent-runtime/client-tool-manifest.ts`** — flips the three entries to `execution: "server"` (labels/icons/previews kept for the tool cards).
- **`packages/agent-tools/src/data-source-tools.ts`** + barrel — exports `listDataSourcesSchema` / `inspectDataSourceSchema` / `queryDuckdbSchema` so the client cards and server `execute` share one schema and can't drift.

### Safety
Agent SQL is gated to a **single read-only SELECT/WITH** statement; file/network/extension access is denied (`read_parquet`, `read_csv`, `ATTACH`, `COPY`, `INSTALL`, …) and DuckDB `enable_external_access=false` is set before the query runs. Tables are `CREATE TABLE` (materialized in-memory) so the gated query needs no file access. Rows read into the API are capped (10k, `truncated` flag); 100 returned to the model — matching the browser tool. The instance only ever holds this workspace's own already-readable data.

## Testing (run in a live env: local Mongo + local Chinook Postgres + `pnpm dev`)

**End-to-end through the agent UI** — sent a chat asking the agent to run DuckDB SQL against an app; the agent invoked `query_duckdb` (server-side) twice; both tool cards completed (✓, no "Interrupted"); correct results rendered:

[agent_query_duckdb_server_side.mp4](https://cursor.com/agents/bc-a09778bb-6cf2-45c5-a26d-bb8686be12e3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_query_duckdb_server_side.mp4)

[Agent ran query_duckdb server-side: count=5, tables=\[artists\], first 3 artists AC/DC / Aerosmith / Led Zeppelin](https://cursor.com/agents/bc-a09778bb-6cf2-45c5-a26d-bb8686be12e3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_duckdb_answer.webp)

The tool-card JSON shows `"tables":["artists"]`, `"rowCount":1` (count=5) and `"rowCount":3` (sample) — executed on the API (`POST /api/agent/chat 200` with tool calls + "Stream finished" in the server log), not the browser.

**Real-pipeline integration** — created an app with a Parquet binding (`SELECT artist_id, name FROM artist`) against the live Chinook Postgres, ran the real materialization (Postgres → Parquet artifact → artifact store), then queried it server-side:
- `query_duckdb` `SELECT COUNT(*)` → `n=5`
- `query_duckdb` sample → `AC/DC, Aerosmith, Led Zeppelin`
- `query_duckdb` `read_csv_auto('/etc/hostname')` → rejected by the gate
- `inspect_data_source` → columns `[artist_id, name]` + 5 sample rows
[realpipe_server_duckdb.log](https://cursor.com/agents/bc-a09778bb-6cf2-45c5-a26d-bb8686be12e3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frealpipe_server_duckdb.log)

**Automated + checks**
- `tsx src/services/server-data-source.service.test.ts` — gate unit tests + end-to-end (real Parquet artifact → node DuckDB): aggregation, blocked file access, sampled rows. Added to the api `test` script; self-skips without Mongo.
- Verified the unified agent registers all three tools with `execute=true`.
- `pnpm run build` (root: lint:fix:all + schemas + agent-tools + app:build + api:build + connector check) passes.

## Follow-up (separate PR)
Tighten the stranded-turn gate to be chat-stream-consumer-scoped (not coarse workspace presence) and broaden frontend orphan recovery for idempotent client tools — addresses the remaining browser-bound tools (e.g. `run_app`).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a09778bb-6cf2-45c5-a26d-bb8686be12e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a09778bb-6cf2-45c5-a26d-bb8686be12e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

