### PR TITLE
docs(connectors): document PandaDoc CDC connector (#571)

### DIFF
--- a/docs/src/content/docs/connectors.md
+++ b/docs/src/content/docs/connectors.md
@@ -1,6 +1,6 @@
 ---
 title: SaaS Sync (Connectors)
-description: Pull data from SaaS tools like Stripe, Close CRM, Claap, Calendly, PostHog, and more into your data warehouse.
+description: Pull data from SaaS tools like Stripe, Close CRM, Claap, Calendly, PandaDoc, PostHog, and more into your data warehouse.
 ---
 
 :::caution[Experimental]
@@ -17,6 +17,7 @@ Connectors pull data from external services and sync it into your connected data
 | **Close CRM** | Close API       | Leads, Opportunities, Activities (10+ sub-types), Contacts, Users, Custom Fields. *Webhooks are automatically scoped to synced entities only.* |
 | **Claap**     | Claap API       | Recordings, Workspace. *Supports backfill and CDC webhooks (auto-provisioning via "Create in Claap").* |
 | **Calendly**  | Calendly API    | Organizations, Users, Groups, Event Types, Scheduled Events, Invitees, Contacts. *Real-time invitee + event-type webhooks (auto-provisioned); scheduled backfill covers the rest.* |
+| **PandaDoc**  | PandaDoc API    | Documents, Templates, Contacts, Members. *Document + template webhooks (CDC, auto-provisioned); scheduled backfill covers contacts and members. Documents are hydrated with full detail (fields, tokens, pricing, products, recipients) during backfill.* |
 | **PostHog**   | PostHog HogQL   | Dynamic — each configured HogQL query becomes an entity                          |
 | **GraphQL**   | Any GraphQL API | Dynamic — each configured query becomes an entity                                |
 | **BigQuery**  | Google BigQuery | Dynamic — each configured query becomes an entity                                |


### PR DESCRIPTION
## What

Adds **PandaDoc** to the Available Connectors table in `connectors.md` (and the page description). The connector shipped in #571 but had zero docs.

## Details (verified against `api/src/connectors/pandadoc/`)
- **Entities:** Documents, Templates, Contacts, Members
- **CDC webhooks (auto-provisioned):** documents + templates
- **Scheduled backfill:** contacts + members (these endpoints return full lists, no pagination)
- **Document hydration:** during backfill each document is enriched via `/public/v1/documents/{id}/details` (fields, tokens, pricing, products, recipients)

## Out of scope (logged for next run)
`fetch_url` / `web_search` agent tools (#562) are also undocumented — deferring to keep this to one PR.

🤖 Generated by the mako-docs-maintenance job