### PR TITLE
guides: SQL Server C# (Batch 12 close) + PHP connection guides (Batch 13)

### DIFF
--- a/content/guides/clickhouse/connect-from-php.mdx
+++ b/content/guides/clickhouse/connect-from-php.mdx
@@ -1,0 +1,144 @@
+---
+title: "How to Connect to ClickHouse from PHP"
+description: "Connect to ClickHouse from PHP over the HTTP interface: the smi2/phpClickHouse client, raw cURL, the 8123-not-9000 port trap, parameter binding, batch inserts, async_insert, TLS on 8443, and the errors you actually hit."
+database: "clickhouse"
+category: "how-to"
+tags: ["clickhouse", "php", "phpclickhouse", "http-interface", "olap", "connection"]
+date: "2026-06-28"
+---
+
+ClickHouse from PHP works differently from the relational databases. There is no PDO driver and no native-protocol PHP extension worth using. PHP talks to ClickHouse over its **HTTP interface**, either with raw cURL or, more commonly, through the `smi2/phpClickHouse` library, which wraps that HTTP interface in a sane API. ClickHouse Inc. does not maintain an official PHP client, so the community `smi2` package is the de facto standard. This guide covers the port that trips everyone up, the client, raw HTTP, parameter binding, batch inserts, async inserts, TLS, and the errors you will meet.
+
+## The port trap
+
+ClickHouse listens on two different ports for two different protocols:
+
+- **8123** is the HTTP interface. This is the one PHP uses.
+- **9000** is the native TCP protocol, used by `clickhouse-client` and native drivers in other languages.
+
+PHP connects over HTTP, so you want **8123** (or **8443** for HTTPS, including ClickHouse Cloud). Pointing a PHP client at 9000 produces confusing connection or parse errors because it is speaking HTTP to a port expecting the binary native protocol. This is the single most common ClickHouse-from-PHP mistake. When something refuses to connect, check the port first.
+
+## The client
+
+```bash
+composer require smi2/phpclickhouse
+```
+
+`smi2/phpClickHouse` 1.26.610 is current as of June 2026. It requires `ext-curl`. Basic connection and a query:
+
+```php
+<?php
+require 'vendor/autoload.php';
+
+$db = new ClickHouseDB\Client([
+    'host'     => '127.0.0.1',
+    'port'     => 8123,
+    'username' => 'default',
+    'password' => '',
+]);
+
+$db->database('default');
+$db->setTimeout(10);
+
+$rows = $db->select('SELECT id, name FROM products WHERE price > 100')->rows();
+foreach ($rows as $row) {
+    echo "{$row['id']}: {$row['name']}\n";
+}
+```
+
+`select()` returns a `Statement` object; call `rows()` for all rows as arrays, `fetchOne()` for a single scalar, or `rowsAsTree()` to group by a column. The client connects lazily, so a wrong host or port surfaces on the first query.
+
+## Parameter binding
+
+Pass parameters as a second argument and reference them with ClickHouse's `{name:Type}` placeholder syntax. The type is part of the placeholder and is required:
+
+```php
+$rows = $db->select(
+    'SELECT id, name FROM products WHERE price > {min_price:Float64} AND category = {cat:String}',
+    ['min_price' => 100, 'cat' => 'hardware']
+)->rows();
+```
+
+Binding parameters this way lets ClickHouse handle escaping, which is both safer and clearer than concatenating values into the SQL string. Note the placeholder syntax is ClickHouse-specific and unlike PDO's `?` or `:name`.
+
+## Inserting data
+
+For a handful of rows, `insert()` takes the column list and an array of row arrays:
+
+```php
+$db->insert('events', [
+    [1, 'click',   '2026-06-28 10:00:00'],
+    [2, 'view',    '2026-06-28 10:00:01'],
+], ['id', 'type', 'ts']);
+```
+
+The thing to internalize about ClickHouse is that **it is built for large batch inserts, not row-at-a-time writes.** Each `INSERT` creates a new data part on disk, and parts are merged in the background. Thousands of tiny inserts create thousands of tiny parts and trigger the dreaded `Too many parts` error, at which point ClickHouse starts rejecting writes. The fix is to buffer rows in your application and insert them in big batches (tens of thousands of rows at a time), not one HTTP request per row.
+
+For bulk loading a file, the client supports streaming inserts that avoid building a giant PHP array in memory:
+
+```php
+$db->insertBatchFiles('events', ['/path/to/events.csv'], ['id', 'type', 'ts']);
+```
+
+## Async inserts for high-frequency writes
+
+If you genuinely cannot batch on the client side (many independent processes each writing a few rows), let ClickHouse do the batching with async inserts:
+
+```php
+$db->settings()->set('async_insert', 1);
+$db->settings()->set('wait_for_async_insert', 1);
+```
+
+With `async_insert` enabled, the server buffers incoming rows and flushes them as one part. `wait_for_async_insert=1` makes the insert call return only after the buffer is flushed and persisted, which is the safe default; setting it to 0 returns immediately but means an acknowledged insert can still be lost if the server crashes before the flush. Choose based on whether you can tolerate that window.
+
+## TLS and ClickHouse Cloud
+
+ClickHouse Cloud and any TLS-secured server use HTTPS on port **8443**:
+
+```php
+$db = new ClickHouseDB\Client([
+    'host'     => 'abc123.clickhouse.cloud',
+    'port'     => 8443,
+    'username' => 'default',
+    'password' => $secret,
+    'https'    => true,
+]);
+```
+
+Two Cloud-specific notes. First, the port is 8443, not 8123, when TLS is on. Second, Cloud services idle down to save resources; the first query after an idle period can take several seconds while the service wakes, so set a generous `setConnectTimeOut()` and timeout to avoid spurious failures on a cold service.
+
+## Raw cURL without the library
+
+If you want zero dependencies, the HTTP interface is just a POST with SQL in the body:
+
+```php
+$ch = curl_init('http://127.0.0.1:8123/?database=default');
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_POST           => true,
+    CURLOPT_POSTFIELDS     => 'SELECT id, name FROM products FORMAT JSONEachRow',
+    CURLOPT_HTTPHEADER     => ['X-ClickHouse-User: default', 'X-ClickHouse-Key: '],
+]);
+$response = curl_exec($ch);
+// each line is a JSON object
+foreach (explode("\n", trim($response)) as $line) {
+    if ($line !== '') { $row = json_decode($line, true); /* ... */ }
+}
+```
+
+Append `FORMAT JSONEachRow` (or `JSON`, `TabSeparated`, etc.) to control the response shape. This works fine for simple scripts, but you give up parameter binding, batching helpers, and error parsing, which is exactly what the library provides.
+
+## Errors you actually hit
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Connection refused / garbled response | Pointed at native port 9000 | Use HTTP port 8123 (or 8443 for TLS) |
+| `Class "ClickHouseDB\Client" not found` | Library not installed or autoloader not required | `composer require smi2/phpclickhouse`; `require 'vendor/autoload.php'` |
+| `Too many parts` | Many small inserts creating too many parts | Batch rows; or enable `async_insert` |
+| `Authentication failed` | Wrong user/password, or password on wrong header | Check credentials; with raw cURL use `X-ClickHouse-User`/`X-ClickHouse-Key` |
+| Timeout on first Cloud query | Service was idle and is waking | Raise connect timeout; retry once |
+| Cannot parse parameter | Wrong type in `{name:Type}` placeholder | Match the placeholder type to the column |
+
+For working with data once connected, see [ClickHouse aggregate functions](/guides/clickhouse/aggregate-functions), [the MergeTree engines](/guides/clickhouse/mergetree-engines), and [partitioning](/guides/clickhouse/partitioning).
+
+Mako connects to ClickHouse, PostgreSQL, MySQL, and more with AI-powered autocomplete for writing and exploring queries. Try it free at mako.ai.

--- a/content/guides/mongodb/connect-from-php.mdx
+++ b/content/guides/mongodb/connect-from-php.mdx
@@ -1,0 +1,171 @@
+---
+title: "How to Connect to MongoDB from PHP"
+description: "Connect to MongoDB from PHP with the ext-mongodb extension and the mongodb/mongodb library: the Client lifetime rule, CRUD, SRV strings, Atlas, authSource, pooling, transactions, and the errors you actually hit."
+database: "mongodb"
+category: "how-to"
+tags: ["mongodb", "php", "ext-mongodb", "mongodb-library", "atlas", "connection"]
+date: "2026-06-28"
+---
+
+MongoDB from PHP is built in two layers. At the bottom is `ext-mongodb`, a C extension that does the actual wire protocol, BSON encoding, and connection management. On top of it sits `mongodb/mongodb`, a Composer library that gives you the friendly `MongoDB\Client`, `Collection`, and helper APIs most code uses. You need both: the extension does the work, the library makes it pleasant. This guide covers installing both, the one lifetime rule people get wrong, CRUD, connection strings and Atlas, pooling, transactions, and the errors you will meet.
+
+## The two pieces
+
+```bash
+# 1. the C extension (does the real work)
+pecl install mongodb
+
+# 2. the high-level library (what your code calls)
+composer require mongodb/mongodb
+```
+
+As of June 2026 the extension is `ext-mongodb` 2.3.3 and the library is `mongodb/mongodb` 2.3.0, which requires PHP 8.1+ and `ext-mongodb` ^2.3. The two version lines track each other; keep them in step. The old `ext-mongo` extension (the one with the `Mongo` and `MongoClient` classes, no namespace) was abandoned years ago and does not work with modern MongoDB or PHP. If a tutorial uses `new MongoClient()` without a namespace, it is for the dead driver.
+
+Confirm the extension is loaded:
+
+```bash
+php -m | grep mongodb
+# expect: mongodb
+```
+
+This guide is written against PHP 8.5 (8.5.7 as of June 2026), but everything works on 8.1+.
+
+## Client: create one, reuse it
+
+The single most important rule: **`MongoDB\Client` is meant to be created once and reused for the lifetime of your request or process.** The underlying extension manages a connection pool per client. Constructing a new `Client` on every operation throws away that pool, opens fresh sockets each time, and will exhaust connections under load.
+
+```php
+<?php
+require 'vendor/autoload.php';
+
+$client = new MongoDB\Client('mongodb://localhost:27017');
+// reuse $client everywhere
+```
+
+In a long-running worker (Swoole, RoadRunner, a queue consumer) build the client once at boot and hand it around. In classic request-per-process PHP-FPM, one client per request is the natural unit; the connection itself is established lazily and reused within that request.
+
+Construction does not connect. The client connects lazily on the first real operation, so a wrong host or a down server surfaces as a timeout on your first query, not on `new Client()`. To fail fast at startup, ping:
+
+```php
+$client->getDatabase('admin')->command(['ping' => 1]);
+```
+
+## Basic CRUD
+
+The library exposes databases and collections you call methods on. Filters and documents are plain PHP arrays (or `BSON` objects).
+
+```php
+$collection = $client->shop->products; // database "shop", collection "products"
+
+// insert
+$result = $collection->insertOne([
+    'name'  => 'Widget',
+    'price' => 19.99,
+    'tags'  => ['hardware', 'new'],
+]);
+echo $result->getInsertedId(); // an ObjectId
+
+// find one
+$doc = $collection->findOne(['name' => 'Widget']);
+echo $doc['price']; // 19.99
+
+// find many (returns a cursor; iterate it)
+foreach ($collection->find(['price' => ['$gt' => 10]]) as $doc) {
+    echo "{$doc['name']}: {$doc['price']}\n";
+}
+
+// update
+$collection->updateOne(
+    ['name' => 'Widget'],
+    ['$set' => ['price' => 24.99]]
+);
+
+// delete
+$collection->deleteOne(['name' => 'Widget']);
+```
+
+By default documents come back as `MongoDB\Model\BSONDocument` objects that behave like arrays. If you would rather get plain PHP arrays or your own classes, pass a `typeMap`:
+
+```php
+$doc = $collection->findOne(
+    ['name' => 'Widget'],
+    ['typeMap' => ['root' => 'array', 'document' => 'array', 'array' => 'array']]
+);
+```
+
+## Update, not replace
+
+`updateOne` with `$set` changes only the fields you name. `replaceOne` swaps the entire document for the one you pass, dropping any field you forgot to include. The replacement is occasionally what you want, but it is the classic source of silent data loss. Default to `updateOne` with update operators (`$set`, `$inc`, `$push`) unless you genuinely mean "overwrite this whole document."
+
+## Connection strings, SRV, and Atlas
+
+The connection string carries host, credentials, and options:
+
+```php
+// standard
+$client = new MongoDB\Client('mongodb://appuser:secret@localhost:27017/?authSource=admin');
+
+// SRV (Atlas and most managed clusters)
+$client = new MongoDB\Client('mongodb+srv://appuser:secret@cluster0.abcde.mongodb.net/?retryWrites=true&w=majority');
+```
+
+Three things bite people here:
+
+- **`authSource`.** Authentication runs against the database where the user was created, not the one you query. If the user lives in `admin` but you connect to `shop`, you must pass `?authSource=admin` or authentication fails even with the correct password.
+- **Percent-encode credentials.** A password containing `@`, `:`, `/`, or `?` will corrupt the URI. Run it through `rawurlencode()` before building the string.
+- **`mongodb+srv://` implies TLS** and resolves the host list from DNS SRV records. If your network blocks SRV lookups, the connection fails before it starts. For Atlas you also must allowlist your server's egress IP, or every connection times out regardless of credentials.
+
+Pass credentials separately to keep them out of the URI:
+
+```php
+$client = new MongoDB\Client(
+    'mongodb://localhost:27017',
+    ['username' => 'appuser', 'password' => $secret, 'authSource' => 'admin']
+);
+```
+
+## Pooling and concurrency
+
+The extension maintains the pool for you; there is no separate pool object to configure as in some other ecosystems. The lever is `maxPoolSize` (default 100) in the connection options. Each PHP-FPM worker is its own process with its own client and its own pool, so your real ceiling is `maxPoolSize` × number of workers × instances. Keep that product under the connection limit of your server or Atlas tier, or you will hit connection-limit errors under load even though each individual worker looks fine.
+
+## Transactions
+
+Multi-document transactions require a replica set or sharded cluster (a standalone `mongod` cannot do them) and a session:
+
+```php
+$session = $client->startSession();
+$session->startTransaction();
+
+try {
+    $client->bank->accounts->updateOne(
+        ['_id' => 'a'], ['$inc' => ['balance' => -100]],
+        ['session' => $session]
+    );
+    $client->bank->accounts->updateOne(
+        ['_id' => 'b'], ['$inc' => ['balance' => 100]],
+        ['session' => $session]
+    );
+    $session->commitTransaction();
+} catch (\Throwable $e) {
+    $session->abortTransaction();
+    throw $e;
+}
+```
+
+You must pass the `session` to every operation that should be part of the transaction. Forgetting it on one write silently runs that write outside the transaction. Most single-document updates are already atomic on their own and need no transaction; reach for one only when you have to change multiple documents together.
+
+## Errors you actually hit
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `Class "MongoDB\Client" not found` | Library not installed or autoloader not required | `composer require mongodb/mongodb`; `require 'vendor/autoload.php'` |
+| `no suitable servers found` / timeout on first op | Wrong host/port, server down, or SRV DNS blocked | Ping at startup; check host; confirm SRV lookups resolve |
+| Authentication failed with correct password | Wrong `authSource` | Add `?authSource=admin` (or wherever the user was created) |
+| Connection refused on `localhost` | Resolved to IPv6 `::1`, server on IPv4 | Use `127.0.0.1` explicitly |
+| Atlas connection times out | Egress IP not allowlisted | Allowlist your server IP in Atlas Network Access |
+| Fields silently gone after update | Used `replaceOne` | Use `updateOne` with `$set` and other operators |
+| `Transaction numbers are only allowed on a replica set` | Transactions on a standalone server | Use a replica set or sharded cluster |
+
+For working with documents once connected, see [the MongoDB aggregation pipeline](/guides/mongodb/aggregation-pipeline), [query operators](/guides/mongodb/query-operators), and [indexes explained](/guides/mongodb/indexes-explained).
+
+Mako connects to MongoDB, PostgreSQL, MySQL, and more with AI-powered autocomplete for writing and exploring queries. Try it free at mako.ai.

--- a/content/guides/mssql/connect-from-csharp.mdx
+++ b/content/guides/mssql/connect-from-csharp.mdx
@@ -1,0 +1,205 @@
+---
+title: "How to Connect to SQL Server from C# (.NET)"
+description: "Connect to Microsoft SQL Server from C# with Microsoft.Data.SqlClient: ADO.NET basics, async queries, parameters, the Encrypt-by-default TLS change that breaks local connections, pooling, Dapper and EF Core, and the errors you actually hit."
+database: "mssql"
+category: "how-to"
+tags: ["mssql", "sql-server", "csharp", "dotnet", "ado-net", "connection"]
+date: "2026-06-26"
+---
+
+SQL Server is a Microsoft product and C# is a Microsoft language, so the connection story here is the most first-party of any database. There is one driver worth using, it is maintained by the same team that builds the server, and it is the foundation Dapper and EF Core sit on. This guide covers the driver, the connection string, the one default that breaks almost every fresh local setup, parameters, pooling, the higher-level options, and the errors you will meet.
+
+## The one driver you need
+
+`Microsoft.Data.SqlClient` (7.0.2 as of June 2026) is the current ADO.NET provider for SQL Server and Azure SQL. It replaced the older `System.Data.SqlClient`, which still exists in the box but no longer receives feature work. Any tutorial that has you `using System.Data.SqlClient;` is out of date; the API is nearly identical, so the only change for most code is the namespace and the NuGet reference.
+
+```bash
+dotnet add package Microsoft.Data.SqlClient
+```
+
+```csharp
+using Microsoft.Data.SqlClient;
+```
+
+There is no second serious contender. The community has consolidated on this one package because it ships the newest TLS, authentication, and Azure features first.
+
+## A basic connection
+
+```csharp
+using Microsoft.Data.SqlClient;
+
+var connString =
+    "Server=localhost;Database=shop;" +
+    "User ID=appuser;Password=secret;" +
+    "Encrypt=True;TrustServerCertificate=True;";
+
+await using var conn = new SqlConnection(connString);
+await conn.OpenAsync();
+```
+
+`await using` returns the connection to the pool when the scope exits. Open one per unit of work rather than holding a single connection for the life of the app; pooling makes that cheap (more below). The `Encrypt` and `TrustServerCertificate` settings are doing real work here, and they are the single biggest source of "it worked on the old driver, now it fails" reports.
+
+## The Encrypt default that breaks local setups
+
+Starting with `Microsoft.Data.SqlClient` 4.0, the default for `Encrypt` flipped from `False` to `True`. The driver now tries to establish an encrypted TLS connection by default and validates the server's certificate. A default local SQL Server install presents a self-signed certificate that your machine does not trust, so the connection fails before you ever run a query:
+
+```
+A connection was successfully established with the server, but then an error
+occurred during the login process. (provider: SSL Provider, error: 0 -
+The certificate chain was issued by an authority that is not trusted.)
+```
+
+You have three ways to handle this, in order of preference:
+
+1. **Production / Azure:** install a certificate the client trusts (Azure SQL already presents a valid one) and leave `Encrypt=True` with `TrustServerCertificate=False`. This is the only combination that actually protects you from a man-in-the-middle.
+2. **Local development:** set `TrustServerCertificate=True`. This keeps the connection encrypted but skips certificate validation. It is fine on your own machine and dangerous over a real network, because anyone who can intercept the connection can present any certificate.
+3. **Reflex you should resist:** `Encrypt=False`. This turns encryption off entirely. It "works," but it sends credentials and data in clear text. Do not reach for it just to silence the error; use `TrustServerCertificate=True` for local work instead.
+
+The short rule: `Encrypt=True;TrustServerCertificate=True` for local, `Encrypt=True;TrustServerCertificate=False` (the default) for anything across a network.
+
+## Running a query
+
+```csharp
+await using var cmd = conn.CreateCommand();
+cmd.CommandText = "SELECT id, name FROM products WHERE price > @minPrice";
+cmd.Parameters.AddWithValue("@minPrice", 100);
+
+await using var reader = await cmd.ExecuteReaderAsync();
+while (await reader.ReadAsync())
+{
+    var id = reader.GetInt32(0);
+    var name = reader.GetString(1);
+    Console.WriteLine($"{id}: {name}");
+}
+```
+
+Always parameterize. String-concatenating user input into SQL is the classic injection hole, and the driver's parameters also handle quoting and type conversion. SQL Server uses `@name` for parameter markers, both in the SQL text and in the `Parameters` collection.
+
+`AddWithValue` is convenient but infers the type from the .NET value, which can produce surprising plans (for example, a .NET `string` maps to `nvarchar`, and comparing it to a `varchar` column can defeat an index). For hot paths, declare the type explicitly:
+
+```csharp
+cmd.Parameters.Add("@code", SqlDbType.VarChar, 20).Value = code;
+```
+
+## Getting a generated key
+
+SQL Server's portable way to read back an identity value is the `OUTPUT` clause, which is safe under concurrency in a way that `SELECT SCOPE_IDENTITY()` as a second statement is not:
+
+```csharp
+await using var cmd = conn.CreateCommand();
+cmd.CommandText = @"
+    INSERT INTO products (name, price)
+    OUTPUT INSERTED.id
+    VALUES (@name, @price)";
+cmd.Parameters.AddWithValue("@name", "Widget");
+cmd.Parameters.AddWithValue("@price", 9.99m);
+
+var newId = (int)(await cmd.ExecuteScalarAsync())!;
+```
+
+`OUTPUT INSERTED.id` returns the generated key as part of the same statement, so there is no race window and no need for a separate `SCOPE_IDENTITY()` round trip.
+
+## Transactions
+
+```csharp
+await using var tx = await conn.BeginTransactionAsync();
+try
+{
+    await using var cmd = conn.CreateCommand();
+    cmd.Transaction = (SqlTransaction)tx;
+    cmd.CommandText = "UPDATE accounts SET balance = balance - @amt WHERE id = @from";
+    cmd.Parameters.AddWithValue("@amt", 50m);
+    cmd.Parameters.AddWithValue("@from", 1);
+    await cmd.ExecuteNonQueryAsync();
+
+    await tx.CommitAsync();
+}
+catch
+{
+    await tx.RollbackAsync();
+    throw;
+}
+```
+
+Every command that should run inside the transaction must have its `Transaction` property set; the driver does not infer it from the connection. Forgetting this on one command is a common cause of "the rollback didn't undo everything."
+
+## Connection pooling
+
+`Microsoft.Data.SqlClient` pools connections per unique connection string. The default `Max Pool Size` is 100. When the pool is exhausted, `OpenAsync` blocks until a connection frees up or times out:
+
+```
+Timeout expired. The timeout period elapsed prior to obtaining a connection
+from the pool. This may have occurred because all pooled connections were in
+use and max pool size was reached.
+```
+
+That message almost always means leaked connections, not a too-small pool. Look for a code path that opens a connection (or a reader) and never disposes it; `await using` on both the connection and the reader is the fix. Raising `Max Pool Size` only delays the same failure.
+
+If you run multiple app instances, size the pool against the server's connection limit: instances times `Max Pool Size` should stay comfortably under what SQL Server can handle.
+
+## Named instances and ports
+
+If SQL Server runs as a named instance (`SQLEXPRESS` is the common one), connect via the instance name and let the SQL Server Browser service resolve the dynamic port:
+
+```csharp
+var connString = @"Server=localhost\SQLEXPRESS;Database=shop;Integrated Security=True;Encrypt=True;TrustServerCertificate=True;";
+```
+
+The Browser service listens on UDP 1434 and tells the client which TCP port the instance uses. If it is disabled (common in locked-down environments), name resolution fails and you must specify the port directly: `Server=localhost,1433`. Note the comma before the port, not a colon.
+
+## Windows / integrated authentication
+
+On Windows, you can skip username and password and authenticate as the current Windows user:
+
+```csharp
+var connString = "Server=localhost;Database=shop;Integrated Security=True;Encrypt=True;TrustServerCertificate=True;";
+```
+
+For Azure SQL with Microsoft Entra ID, the driver supports several `Authentication` modes (for example `Active Directory Default`, which walks the standard credential chain including managed identity). This is the recommended path for Azure-hosted apps because it avoids storing passwords:
+
+```csharp
+var connString = "Server=tcp:myserver.database.windows.net;Database=shop;Authentication=Active Directory Default;Encrypt=True;";
+```
+
+## Dapper
+
+Dapper (2.1.79 as of June 2026) layers convenient mapping over the same `SqlConnection`. It does not replace the driver; it calls it:
+
+```csharp
+using Dapper;
+using Microsoft.Data.SqlClient;
+
+await using var conn = new SqlConnection(connString);
+var products = await conn.QueryAsync<Product>(
+    "SELECT id, name, price FROM products WHERE price > @minPrice",
+    new { minPrice = 100 });
+```
+
+Dapper passes parameters as `@name` bound from the anonymous object's property names, so the SQL Server marker style works unchanged. It is a good fit when you want hand-written SQL with object mapping and no change tracking.
+
+## EF Core
+
+For a full ORM with migrations, change tracking, and LINQ, use the `Microsoft.EntityFrameworkCore.SqlServer` provider (10.0.9 as of June 2026). Match the provider's major version to your EF Core version:
+
+```bash
+dotnet add package Microsoft.EntityFrameworkCore.SqlServer
+```
+
+```csharp
+builder.Services.AddDbContext<AppDb>(options =>
+    options.UseSqlServer(connString));
+```
+
+The provider depends on `Microsoft.Data.SqlClient`, so the same `Encrypt` and `TrustServerCertificate` rules apply to the connection string you hand it. EF Core is the productive default for new applications; reach for Dapper or raw ADO.NET when a specific query needs hand-tuning.
+
+## Errors you actually hit
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `The certificate chain was issued by an authority that is not trusted` | `Encrypt=True` (the default) against a self-signed local cert | `TrustServerCertificate=True` for local; a trusted cert for production |
+| `Timeout expired ... max pool size was reached` | Leaked connections or readers not disposed | `await using` every connection and reader; do not just raise the pool size |
+| `A network-related or instance-specific error` | Wrong server/instance, Browser service off, or firewall | Verify instance name, enable SQL Server Browser (UDP 1434) or specify the port |
+| `Login failed for user` | Wrong credentials or SQL auth disabled | Check the password; confirm the server allows SQL (mixed-mode) auth |
+| `Cannot open database requested by the login` | The login lacks access to that database | Grant the login a user mapping in the target database |
+
+For exploring SQL Server data and drafting queries before they go into C#, Mako connects to SQL Server with AI-powered autocomplete. Try it free at mako.ai.

--- a/content/guides/mysql/connect-from-php.mdx
+++ b/content/guides/mysql/connect-from-php.mdx
@@ -1,0 +1,177 @@
+---
+title: "How to Connect to MySQL from PHP"
+description: "Connect to MySQL from PHP with PDO and mysqli: the utf8mb4 charset, real prepared statements, the EMULATE_PREPARES tradeoff, transactions, SSL, caching_sha2_password, and the errors you actually hit."
+database: "mysql"
+category: "how-to"
+tags: ["mysql", "php", "pdo", "mysqli", "pdo-mysql", "connection"]
+date: "2026-06-27"
+---
+
+PHP has two built-in ways to reach MySQL: the database-agnostic PDO layer and the MySQL-specific `mysqli` extension. For new code, PDO with the `pdo_mysql` driver is the right default. It gives you a portable API, real prepared statements, and a clean exception model. `mysqli` is still maintained and exposes a few MySQL-only features, but most applications never need it. The old `mysql_*` functions were removed in PHP 7.0 years ago; if you find them in a codebase, that code is overdue for a rewrite. This guide covers both supported extensions, the charset that trips everyone up, prepared statements, transactions, SSL, and the errors you will meet. It is written against PHP 8.5 (8.5.7 as of June 2026), but everything except the driver-subclass note works on 8.1+.
+
+## Which extension to use
+
+Two extensions ship with PHP:
+
+- **PDO with `pdo_mysql`** is the portable, object-oriented choice. Same interface across databases, exceptions on error, and named or positional placeholders. Use this unless you have a specific reason not to.
+- **`mysqli`** (the functions and classes starting with `mysqli`) is the MySQL-specific extension. It exposes a few MySQL-only features such as multiple-statement execution and asynchronous queries. Reach for it only when you actually need those features.
+
+Check that the driver is loaded:
+
+```bash
+php -m | grep mysql
+# expect: pdo_mysql  (and/or mysqli)
+```
+
+On Debian/Ubuntu, `apt install php-mysql` provides both.
+
+## Connecting with PDO
+
+The single most common MySQL-from-PHP mistake is leaving the charset out of the DSN. Set it to `utf8mb4`, not `utf8`. MySQL's legacy `utf8` is a three-byte encoding that cannot store emoji or many CJK characters, and inserting one silently truncates the row or throws an `Incorrect string value` error. `utf8mb4` is the real, full Unicode encoding.
+
+```php
+<?php
+$dsn = 'mysql:host=127.0.0.1;port=3306;dbname=shop;charset=utf8mb4';
+
+try {
+    $pdo = new PDO($dsn, 'appuser', 'secret', [
+        PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        PDO::ATTR_EMULATE_PREPARES   => false,
+    ]);
+} catch (PDOException $e) {
+    // Do not echo $e->getMessage() to users; it can leak the DSN
+    error_log('DB connection failed: ' . $e->getMessage());
+    throw $e;
+}
+```
+
+Three options are worth setting on every connection:
+
+- `ERRMODE_EXCEPTION` makes PDO throw on errors instead of returning `false`. Without it, a failed query looks like success until you check a return value, which almost nobody does consistently.
+- `FETCH_ASSOC` returns rows as associative arrays instead of the default duplicated numeric-and-associative array.
+- `ATTR_EMULATE_PREPARES => false` switches off PDO's client-side statement emulation, which is **on by default for MySQL**. This is the one default worth changing. See the next section for why.
+
+Use `127.0.0.1` rather than `localhost` in the DSN unless you specifically want a Unix socket. On many systems `localhost` makes the MySQL client try the socket and ignore the `port`, which produces confusing connection errors when the socket path is non-standard.
+
+## Emulated vs real prepared statements
+
+For MySQL, PDO emulates prepared statements by default: it interpolates the bound values into the SQL string itself (with correct escaping) and sends one round trip. Setting `ATTR_EMULATE_PREPARES => false` tells PDO to send the parameterized statement to the server and bind values server-side, the way most people assume prepared statements always work.
+
+The practical differences:
+
+- With emulation **off**, numeric columns come back typed as integers/floats instead of every value being a string. This alone is reason enough to disable it.
+- With emulation **off**, the server caches the query plan, which helps when you run the same statement in a loop.
+- With emulation **on**, you can run multiple statements in one `query()` call, which the server protocol does not allow for a single real prepared statement.
+
+Disable emulation unless you have a concrete reason to keep it. Either way, always bind values rather than concatenating them.
+
+## Prepared statements
+
+Never interpolate user input into SQL. Use placeholders and let the driver bind them:
+
+```php
+$stmt = $pdo->prepare('SELECT id, name FROM products WHERE price > :minPrice');
+$stmt->execute(['minPrice' => 100]);
+
+foreach ($stmt as $row) {
+    echo "{$row['id']}: {$row['name']}\n";
+}
+```
+
+PDO supports named placeholders (`:minPrice`) and positional ones (`?`). Pick one style per statement; you cannot mix them. Named placeholders are easier to read and reorder once a query has more than two or three parameters.
+
+## Getting a generated key
+
+After an `INSERT` into a table with an `AUTO_INCREMENT` column, read the value with `lastInsertId()`:
+
+```php
+$stmt = $pdo->prepare('INSERT INTO products (name, price) VALUES (:name, :price)');
+$stmt->execute(['name' => 'Widget', 'price' => 9.99]);
+$newId = $pdo->lastInsertId();
+```
+
+Unlike PostgreSQL, MySQL has no `RETURNING` clause in stable releases, so `lastInsertId()` is the standard approach. It returns the ID generated by the most recent insert on that connection, so read it immediately after the `execute()`.
+
+## The PDO driver subclasses (PHP 8.4+)
+
+PHP 8.4 added driver-specific PDO subclasses: `Pdo\Mysql`, `Pdo\Pgsql`, `Pdo\Sqlite`, and others. Constructing through `Pdo\Mysql::connect()` gives you a typed object that exposes MySQL-only helpers such as `getWarningCount()` as first-class methods:
+
+```php
+// PHP 8.4+
+$pdo = Pdo\Mysql::connect($dsn, 'appuser', 'secret');
+```
+
+If you only run portable SQL, plain `PDO` is still fine. The subclass matters when you want MySQL-specific methods without dropping to `mysqli`.
+
+## Transactions
+
+```php
+$pdo->beginTransaction();
+try {
+    $pdo->prepare('UPDATE accounts SET balance = balance - :amt WHERE id = :id')
+        ->execute(['amt' => 50, 'id' => 1]);
+    $pdo->prepare('UPDATE accounts SET balance = balance + :amt WHERE id = :id')
+        ->execute(['amt' => 50, 'id' => 2]);
+    $pdo->commit();
+} catch (Throwable $e) {
+    $pdo->rollBack();
+    throw $e;
+}
+```
+
+Transactions only work on transactional storage engines. InnoDB, the default since MySQL 5.5, is transactional. The legacy MyISAM engine is not: `beginTransaction()` and `rollBack()` silently do nothing on a MyISAM table, so a half-finished multi-row change stays half-finished. Confirm your tables are InnoDB before relying on rollback. Also note that DDL statements such as `CREATE TABLE` and `ALTER TABLE` cause an implicit commit, so you cannot roll them back.
+
+## SSL/TLS
+
+For connections crossing a network, encrypt and verify the server certificate. With PDO you pass the certificate paths as driver options:
+
+```php
+$pdo = new PDO($dsn, 'appuser', 'secret', [
+    PDO::ATTR_ERRMODE          => PDO::ERRMODE_EXCEPTION,
+    PDO::MYSQL_ATTR_SSL_CA     => '/etc/ssl/certs/mysql-ca.pem',
+    PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => true,
+]);
+```
+
+Setting only `MYSQL_ATTR_SSL_CA` encrypts the connection and validates the CA. Leaving `SSL_VERIFY_SERVER_CERT` off means the certificate's hostname is not checked, which leaves you open to a man-in-the-middle on an otherwise encrypted connection. Turn it on for anything public-facing.
+
+## A note on authentication
+
+MySQL 8.0 made `caching_sha2_password` the default authentication plugin. Over a non-TLS connection, the first authentication for a user needs either an encrypted channel or RSA key exchange, which is why some apps that worked against MySQL 5.7 fail to connect to 8.0 with an authentication error until TLS is enabled. MySQL 9.0 removed the older `mysql_native_password` plugin entirely. The fix is almost always to connect over TLS rather than to downgrade the auth plugin.
+
+## Using mysqli directly
+
+If you need a MySQL-only feature, the `mysqli` object interface is there. Enable exceptions first; otherwise `mysqli` reports errors through return values, the same trap PDO's `ERRMODE_EXCEPTION` avoids:
+
+```php
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$mysqli = new mysqli('127.0.0.1', 'appuser', 'secret', 'shop', 3306);
+$mysqli->set_charset('utf8mb4');
+
+$stmt = $mysqli->prepare('SELECT id, name FROM products WHERE price > ?');
+$stmt->bind_param('d', $minPrice);  // 'd' = double
+$minPrice = 100;
+$stmt->execute();
+$result = $stmt->get_result();
+
+while ($row = $result->fetch_assoc()) {
+    echo "{$row['id']}: {$row['name']}\n";
+}
+```
+
+`mysqli` uses `?` positional placeholders only, and `bind_param` requires a type string (`i` integer, `d` double, `s` string, `b` blob). Set the charset with `set_charset('utf8mb4')` rather than running a `SET NAMES` query, because `set_charset` also updates the client's idea of the encoding for escaping.
+
+## Errors you actually hit
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `could not find driver` | `pdo_mysql` is not installed or enabled | Install `php-mysql`; confirm with `php -m \| grep mysql` |
+| `Incorrect string value: '\xF0\x9F...'` | Column or connection is `utf8` (3-byte), not `utf8mb4` | Add `charset=utf8mb4` to the DSN and convert the column to `utf8mb4` |
+| `SQLSTATE[HY000] [2002] Connection refused` | Wrong host/port or server not listening | Use `127.0.0.1`, check port 3306 and `bind-address` |
+| `Access denied for user ... (using password: YES)` | Wrong credentials or host not granted | Verify the password and the user's host grant |
+| `The server requested authentication method unknown` | `caching_sha2_password` over a non-TLS connection | Connect over TLS, or supply the server's public key |
+| Numbers come back as strings | Emulated prepares are on (the MySQL default) | Set `ATTR_EMULATE_PREPARES => false` |
+
+For exploring MySQL data and drafting queries before they go into PHP, Mako connects to MySQL with AI-powered autocomplete. Try it free at mako.ai.

--- a/content/guides/postgresql/connect-from-php.mdx
+++ b/content/guides/postgresql/connect-from-php.mdx
@@ -1,0 +1,161 @@
+---
+title: "How to Connect to PostgreSQL from PHP"
+description: "Connect to PostgreSQL from PHP with PDO and the pgsql extension: prepared statements, the PDO driver subclasses added in 8.4, persistent connections, transactions, SSL, and the errors you actually hit."
+database: "postgresql"
+category: "how-to"
+tags: ["postgresql", "php", "pdo", "pgsql", "pdo-pgsql", "connection"]
+date: "2026-06-26"
+---
+
+PHP has two built-in ways to reach PostgreSQL: the database-agnostic PDO layer and the PostgreSQL-specific `pgsql` extension. For new code, PDO with the `pdo_pgsql` driver is the right default. It gives you the same API you would use for MySQL or SQLite, real prepared statements, and a clean exception model. The `pgsql` extension is still maintained and exposes a few Postgres-only features, but most applications never need it. This guide covers both, the connection string, prepared statements, pooling realities, transactions, SSL, and the errors you will meet.
+
+## Which extension to use
+
+Two extensions ship with PHP:
+
+- **PDO with `pdo_pgsql`** is the portable, object-oriented choice. Same interface across databases, exceptions on error, and named or positional placeholders. Use this unless you have a specific reason not to.
+- **`pgsql`** (the functions starting with `pg_`, like `pg_connect` and `pg_query`) is the PostgreSQL-specific extension. It is marginally faster and exposes Postgres-only features such as `COPY` streaming and asynchronous queries. Reach for it only when you actually need those features.
+
+Check that the driver is loaded:
+
+```bash
+php -m | grep pgsql
+# expect: pdo_pgsql  (and/or pgsql)
+```
+
+On Debian/Ubuntu, `apt install php-pgsql` provides both. This guide is written against PHP 8.5 (8.5.7 as of June 2026), but everything except the driver-subclass note below works on 8.1+.
+
+## Connecting with PDO
+
+```php
+<?php
+$dsn = 'pgsql:host=localhost;port=5432;dbname=shop';
+
+try {
+    $pdo = new PDO($dsn, 'appuser', 'secret', [
+        PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        PDO::ATTR_EMULATE_PREPARES   => false,
+    ]);
+} catch (PDOException $e) {
+    // Do not echo $e->getMessage() to users; it can leak the DSN
+    error_log('DB connection failed: ' . $e->getMessage());
+    throw $e;
+}
+```
+
+Three options are worth setting on every connection:
+
+- `ERRMODE_EXCEPTION` makes PDO throw on errors instead of returning `false`. Without it, a failed query looks like success until you check a return value, which almost nobody does consistently.
+- `FETCH_ASSOC` returns rows as associative arrays instead of the default duplicated numeric-and-associative array.
+- `ATTR_EMULATE_PREPARES => false` tells PDO to use real server-side prepared statements. For `pdo_pgsql` this is the honest default behavior; setting it explicitly documents intent and avoids client-side emulation surprises.
+
+## Prepared statements
+
+Never interpolate user input into SQL. Use placeholders and let the driver bind them:
+
+```php
+$stmt = $pdo->prepare('SELECT id, name FROM products WHERE price > :minPrice');
+$stmt->execute(['minPrice' => 100]);
+
+foreach ($stmt as $row) {
+    echo "{$row['id']}: {$row['name']}\n";
+}
+```
+
+PDO supports named placeholders (`:minPrice`) and positional ones (`?`). Pick one style per statement; you cannot mix them. Named placeholders are easier to read and reorder, which matters once a query has more than two or three parameters.
+
+## Getting a generated key
+
+PostgreSQL identity and serial columns do not return their value automatically. The clean way is `RETURNING`:
+
+```php
+$stmt = $pdo->prepare(
+    'INSERT INTO products (name, price) VALUES (:name, :price) RETURNING id'
+);
+$stmt->execute(['name' => 'Widget', 'price' => 9.99]);
+$newId = $stmt->fetchColumn();
+```
+
+`PDO::lastInsertId()` also works but relies on sequence naming conventions and is less explicit. `RETURNING` is portable across PostgreSQL versions and lets you read back any column the insert generated, not just the key.
+
+## The PDO driver subclasses (PHP 8.4+)
+
+PHP 8.4 added driver-specific PDO subclasses: `Pdo\Pgsql`, `Pdo\Mysql`, `Pdo\Sqlite`, and others. Constructing a connection through `Pdo\Pgsql::connect()` gives you a typed object that exposes Postgres-only helpers such as `pgsqlCopyFromArray()` and `pgsqlGetNotify()` as first-class methods:
+
+```php
+// PHP 8.4+
+$pdo = Pdo\Pgsql::connect($dsn, 'appuser', 'secret');
+```
+
+In PHP 8.5, calling those Postgres-specific methods on a plain `PDO` instance is deprecated in favor of the subclass. If you are on 8.4 or later and use any Postgres-specific PDO method, switch to `Pdo\Pgsql`. If you only run portable SQL, plain `PDO` is still fine.
+
+## Transactions
+
+```php
+$pdo->beginTransaction();
+try {
+    $pdo->prepare('UPDATE accounts SET balance = balance - :amt WHERE id = :id')
+        ->execute(['amt' => 50, 'id' => 1]);
+    $pdo->prepare('UPDATE accounts SET balance = balance + :amt WHERE id = :id')
+        ->execute(['amt' => 50, 'id' => 2]);
+    $pdo->commit();
+} catch (Throwable $e) {
+    $pdo->rollBack();
+    throw $e;
+}
+```
+
+PostgreSQL wraps each statement in an implicit transaction by default, so an explicit transaction is only needed when several statements must succeed or fail together. One trap: after any error inside a transaction, PostgreSQL aborts the whole transaction and rejects further statements with `current transaction is aborted`. You must `rollBack()` (or roll back to a savepoint) before the connection is usable again.
+
+## Connection pooling
+
+PHP's request-per-process model means a fresh connection is opened and torn down on most requests, which is wasteful under load. There are two answers, and the better one is not in PHP:
+
+- **`PDO::ATTR_PERSISTENT => true`** keeps the connection open across requests within the same PHP worker. It helps, but it has sharp edges: a connection left in a bad state (open transaction, temp tables, session settings) is reused by the next request. Use it with care, and never leave transactions open.
+- **An external pooler such as PgBouncer** is the production-grade answer. It sits between PHP and PostgreSQL and multiplexes many short PHP connections onto a small pool of real backend connections. In transaction pooling mode, disable server-side prepared statement caching concerns by keeping statements short-lived, and avoid session-level features that span transactions.
+
+For most real deployments, PgBouncer in front of PostgreSQL beats `ATTR_PERSISTENT` and is the standard pattern.
+
+## SSL
+
+For connections over an untrusted network, request encryption and verify the server certificate via the DSN:
+
+```php
+$dsn = 'pgsql:host=db.example.com;port=5432;dbname=shop;'
+     . 'sslmode=verify-full;sslrootcert=/etc/ssl/certs/pg-ca.pem';
+```
+
+`sslmode` accepts the standard PostgreSQL values. `require` encrypts but does not validate the certificate, leaving you open to a man-in-the-middle. `verify-full` encrypts, validates the CA, and checks the hostname; use it for anything crossing a public network.
+
+## Using the pgsql extension directly
+
+If you need Postgres-only features, the `pg_*` functions are there:
+
+```php
+$conn = pg_connect('host=localhost dbname=shop user=appuser password=secret');
+
+$result = pg_query_params(
+    $conn,
+    'SELECT id, name FROM products WHERE price > $1',
+    [100]
+);
+
+while ($row = pg_fetch_assoc($result)) {
+    echo "{$row['id']}: {$row['name']}\n";
+}
+```
+
+Note the `$1` positional placeholders, which differ from PDO's `?` and `:name`. Always use `pg_query_params` rather than building SQL with `pg_query` and string concatenation, for the same injection-safety reason.
+
+## Errors you actually hit
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `could not find driver` | `pdo_pgsql` is not installed or enabled | Install `php-pgsql`; confirm with `php -m \| grep pgsql` |
+| `SQLSTATE[08006] ... Connection refused` | Wrong host/port or server not listening | Check `listen_addresses`, port 5432, firewall |
+| `password authentication failed for user` | Wrong credentials or `pg_hba.conf` rule | Verify the password and the `pg_hba.conf` auth method for that host |
+| `current transaction is aborted` | An error happened inside an open transaction | `rollBack()` before issuing more statements; use savepoints to recover partially |
+| `no pg_hba.conf entry for host` | Server has no rule allowing your client IP | Add a matching `pg_hba.conf` line and reload PostgreSQL |
+
+For exploring PostgreSQL data and drafting queries before they go into PHP, Mako connects to PostgreSQL with AI-powered autocomplete. Try it free at mako.ai.

--- a/content/guides/sqlite/connect-from-php.mdx
+++ b/content/guides/sqlite/connect-from-php.mdx
@@ -1,0 +1,156 @@
+---
+title: "How to Connect to SQLite from PHP"
+description: "Connect to SQLite from PHP with PDO and the SQLite3 class: opening files safely, WAL mode, the busy timeout for 'database is locked', transactions, prepared statements, and the errors you actually hit."
+database: "sqlite"
+category: "how-to"
+tags: ["sqlite", "php", "pdo", "sqlite3", "pdo-sqlite", "connection"]
+date: "2026-06-27"
+---
+
+SQLite is the easiest database to reach from PHP because there is no server, no host, and no port. You open a file. PHP ships two ways to do it: the database-agnostic PDO layer and the SQLite-specific `SQLite3` class. For most code, PDO with the `pdo_sqlite` driver is the right default; it gives you the same API you would use for MySQL or PostgreSQL, so switching databases later means changing a DSN rather than rewriting every query. The `SQLite3` class exposes a few SQLite-only features and is fine when you know you will only ever talk to SQLite. This guide covers both, the file-path gotcha that bites everyone, WAL mode, the busy timeout, transactions, and the errors you will meet. It is written against PHP 8.5 (8.5.7 as of June 2026).
+
+## Which extension to use
+
+Both extensions ship with PHP and are enabled by default in most builds:
+
+- **PDO with `pdo_sqlite`** is the portable, object-oriented choice. Same interface across databases, exceptions on error, named or positional placeholders. Use this unless you have a specific reason not to.
+- **`SQLite3`** is the SQLite-specific class. It exposes a few SQLite-only features such as `createFunction()` for user-defined functions and `loadExtension()`. Reach for it when you actually need those.
+
+Check that the driver is loaded:
+
+```bash
+php -m | grep sqlite
+# expect: pdo_sqlite  (and/or sqlite3)
+```
+
+## Connecting with PDO
+
+```php
+<?php
+$dsn = 'sqlite:/var/data/shop.db';
+
+try {
+    $pdo = new PDO($dsn, null, null, [
+        PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ]);
+} catch (PDOException $e) {
+    error_log('DB connection failed: ' . $e->getMessage());
+    throw $e;
+}
+```
+
+There is no username or password; SQLite has no authentication. The DSN is just `sqlite:` plus a path. Use an absolute path in production: a relative path is resolved against the process's current working directory, which is rarely what you expect under a web server. For a throwaway database that lives only in RAM, use `sqlite::memory:`.
+
+## The file-creation trap
+
+By default, opening a path that does not exist **creates an empty database there**. If you mistype the filename, you do not get an error; you get a brand-new empty database and a stream of "no such table" errors that look like data loss. This is the single most common SQLite-from-PHP confusion.
+
+PDO has no built-in read-write-but-do-not-create mode, but you can express it with a file URI:
+
+```php
+// Fail loudly if the file is missing, instead of creating it
+$dsn = 'sqlite:file:/var/data/shop.db?mode=rw';
+$pdo = new PDO($dsn);
+```
+
+The `mode=rw` flag opens the existing file read-write and throws if it is absent. `mode=ro` opens read-only. If you genuinely want to create a missing file, the default behavior is what you want, but be deliberate about it.
+
+## Set these PRAGMAs on every connection
+
+Three connection-scoped settings make SQLite behave well under PHP. They are not persisted in the file, so run them right after connecting:
+
+```php
+$pdo->exec('PRAGMA journal_mode = WAL');
+$pdo->exec('PRAGMA busy_timeout = 5000');   // milliseconds
+$pdo->exec('PRAGMA foreign_keys = ON');
+```
+
+- **WAL (write-ahead logging)** lets readers and a writer work at the same time instead of blocking each other. For any app with concurrent requests, this is the difference between smooth operation and constant lock errors. WAL is a persistent property of the file once set, but setting it per connection is harmless.
+- **`busy_timeout`** tells SQLite to wait up to N milliseconds for a lock to clear before giving up. Without it, the default is zero: the moment another connection holds a write lock, you get an immediate `database is locked` error. Setting 5000 ms eliminates the vast majority of those errors in practice.
+- **`foreign_keys = ON`** enforces foreign-key constraints, which SQLite leaves off by default for backward compatibility. This is per-connection and must be set every time.
+
+## Prepared statements
+
+Never interpolate user input into SQL. Use placeholders:
+
+```php
+$stmt = $pdo->prepare('SELECT id, name FROM products WHERE price > :minPrice');
+$stmt->execute(['minPrice' => 100]);
+
+foreach ($stmt as $row) {
+    echo "{$row['id']}: {$row['name']}\n";
+}
+```
+
+PDO supports named placeholders (`:minPrice`) and positional ones (`?`). Pick one style per statement; you cannot mix them.
+
+## Getting a generated key
+
+After an `INSERT` into a table with an `INTEGER PRIMARY KEY` (or explicit `AUTOINCREMENT`), read the row id with `lastInsertId()`:
+
+```php
+$stmt = $pdo->prepare('INSERT INTO products (name, price) VALUES (:name, :price)');
+$stmt->execute(['name' => 'Widget', 'price' => 9.99]);
+$newId = $pdo->lastInsertId();
+```
+
+Modern SQLite (3.35+) also supports `RETURNING`, so `INSERT ... RETURNING id` works if you prefer to read the value back as a column.
+
+## Transactions are also a performance tool
+
+In SQLite, every standalone `INSERT` or `UPDATE` is its own transaction, and each commit waits for the write to reach disk. Wrapping many writes in one transaction turns thousands of disk syncs into one and can make a bulk load orders of magnitude faster:
+
+```php
+$pdo->beginTransaction();
+try {
+    $stmt = $pdo->prepare('INSERT INTO events (name) VALUES (?)');
+    foreach ($names as $name) {
+        $stmt->execute([$name]);
+    }
+    $pdo->commit();
+} catch (Throwable $e) {
+    $pdo->rollBack();
+    throw $e;
+}
+```
+
+This is not only about correctness; it is the standard way to make batch inserts fast in SQLite.
+
+## Connection model: no pooling
+
+SQLite is an in-process library, not a server, so there is no connection pool to manage and no network round trip. Open one connection per request (or one long-lived connection for a CLI worker) and reuse it. Because writes are serialized at the file level, a single writer with WAL and a sensible `busy_timeout` handles typical web traffic well. If you find yourself fighting persistent lock errors under heavy write load, that is usually the signal to move to a client-server database rather than to add more connections.
+
+## Using the SQLite3 class directly
+
+If you need a SQLite-only feature, the `SQLite3` class is there. Note that its busy timeout is a method call, not a PRAGMA, and it must be set after opening:
+
+```php
+$db = new SQLite3('/var/data/shop.db', SQLITE3_OPEN_READWRITE);
+$db->enableExceptions(true);
+$db->busyTimeout(5000);
+$db->exec('PRAGMA journal_mode = WAL');
+
+$stmt = $db->prepare('SELECT id, name FROM products WHERE price > :min');
+$stmt->bindValue(':min', 100, SQLITE3_INTEGER);
+$result = $stmt->execute();
+
+while ($row = $result->fetchArray(SQLITE3_ASSOC)) {
+    echo "{$row['id']}: {$row['name']}\n";
+}
+```
+
+Call `enableExceptions(true)` for the same reason you set `ERRMODE_EXCEPTION` on PDO: otherwise errors surface as `false` return values you have to check by hand. Passing `SQLITE3_OPEN_READWRITE` without `SQLITE3_OPEN_CREATE` is the `SQLite3` equivalent of the `mode=rw` trick: it fails on a missing file instead of creating one.
+
+## Errors you actually hit
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `could not find driver` | `pdo_sqlite` is not installed or enabled | Install/enable the SQLite PDO driver; confirm with `php -m \| grep sqlite` |
+| "no such table" right after connecting | A typo in the path created a new empty database | Use an absolute path and `mode=rw` to fail loudly on a missing file |
+| `database is locked` | Another connection holds a write lock and there is no busy timeout | Enable WAL and set `PRAGMA busy_timeout` (e.g. 5000) |
+| `unable to open database file` | Directory missing, or the web-server user lacks write permission | Check the directory exists and is writable by the PHP process |
+| Foreign keys not enforced | `foreign_keys` defaults to off per connection | Run `PRAGMA foreign_keys = ON` after connecting |
+| `attempt to write a readonly database` | Opened `mode=ro`, or the file/directory is not writable | Open read-write and fix filesystem permissions |
+
+For exploring SQLite data and drafting queries before they go into PHP, Mako connects to SQLite with AI-powered autocomplete. Try it free at mako.ai.


### PR DESCRIPTION
Batch 12 close + Batch 13 PHP connection-guide series.

**Guides in this PR (6):**
- `mssql/connect-from-csharp` — closes Batch 12 (C#/.NET × 9)
- `postgresql/connect-from-php` — opens Batch 13 (PHP)
- `mysql/connect-from-php`
- `sqlite/connect-from-php`
- `mongodb/connect-from-php` — ext-mongodb 2.3.3 + mongodb/mongodb 2.3.0, Client lifetime, authSource trap, SRV/Atlas, transactions
- `clickhouse/connect-from-php` — smi2/phpClickHouse 1.26.610, 8123-not-9000 port trap, {name:Type} binding, batch/async inserts, 8443 TLS

PHP series now 5/9 (postgresql, mysql, sqlite, mongodb, clickhouse). Versions verified live. Em-dash clean, no banned words.