### PR TITLE
feat(agent): run agent read tools server-side (Phase 1 of server-side port)

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -13,7 +13,7 @@
     "worker:dev": "tsx watch src/worker.ts",
     "migrate:workspaces": "tsx src/migrations/migrate-to-workspaces.ts",
     "openapi:generate": "tsx src/openapi/generate-cli.ts",
-    "test": "tsx src/openapi/core.test.ts && tsx src/openapi/openapi.test.ts && tsx src/dbt/warm-dir-cache.test.ts && tsx src/connectors/stripe/connector.test.ts && tsx src/connectors/close/connector.test.ts && tsx src/connectors/pandadoc/connector.test.ts && tsx src/sync-cdc/idempotency.test.ts && tsx src/agent-lib/context/compaction.test.ts && tsx src/services/safe-fetch.service.test.ts && tsx src/agent-lib/tools/check-query-status-poll.test.ts",
+    "test": "tsx src/openapi/core.test.ts && tsx src/openapi/openapi.test.ts && tsx src/dbt/warm-dir-cache.test.ts && tsx src/connectors/stripe/connector.test.ts && tsx src/connectors/close/connector.test.ts && tsx src/connectors/pandadoc/connector.test.ts && tsx src/sync-cdc/idempotency.test.ts && tsx src/agent-lib/context/compaction.test.ts && tsx src/services/safe-fetch.service.test.ts && tsx src/agent-lib/tools/check-query-status-poll.test.ts && tsx src/agent-lib/tools/server-read-tools.test.ts",
     "test:dbt": "vitest run",
     "test:dbt:watch": "vitest",
     "test:destinations": "vitest run --config vitest.destinations.config.ts",

--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -21,6 +21,8 @@ import {
   createDbtFileSchema,
   modifyDbtFileSchema,
   deleteDbtFileSchema,
+  readDbtProjectTreeSchema,
+  readDbtFileSchema,
 } from "@mako/agent-tools";
 import {
   DatabaseConnection,
@@ -236,6 +238,91 @@ export const createDbtServerTools = (
   };
 
   return {
+    read_dbt_project_tree: tool({
+      description:
+        "List dbt projects in the workspace, or the file tree + jobs of one " +
+        "project when projectId is given. Call this FIRST to get project IDs " +
+        "and file paths before using any other dbt tool.",
+      inputSchema: readDbtProjectTreeSchema,
+      execute: async ({ projectId }) => {
+        try {
+          if (!projectId) {
+            const projects = await DbtProject.find({
+              workspaceId: new Types.ObjectId(workspaceId),
+            });
+            return {
+              success: true,
+              projects: projects.map(project => ({
+                id: project._id.toString(),
+                name: project.name,
+                defaultEnvironment: project.defaultEnvironment,
+                environments: (project.environments ?? []).map(env => ({
+                  name: env.name,
+                  targetSchema: env.targetSchema,
+                  connectionId: env.connectionId?.toString(),
+                })),
+              })),
+            };
+          }
+          const project = await assertProject(projectId);
+          const [files, jobs] = await Promise.all([
+            DbtFile.find({
+              projectId: project._id,
+              is_deleted: { $ne: true },
+            }).select("path"),
+            DbtJob.find({ projectId: project._id }),
+          ]);
+          return {
+            success: true,
+            projectId,
+            name: project.name,
+            defaultEnvironment: project.defaultEnvironment,
+            environments: project.environments,
+            files: files.map(f => f.path),
+            jobs: jobs.map(job => ({
+              id: job._id.toString(),
+              name: job.name,
+              environment: job.environment,
+              commands: job.commands,
+              schedule: job.schedule ?? null,
+              enabled: job.enabled,
+            })),
+          };
+        } catch (error) {
+          return {
+            success: false,
+            error:
+              error instanceof Error ? error.message : "Failed to read dbt tree",
+          };
+        }
+      },
+    }),
+
+    read_dbt_file: tool({
+      description:
+        "Read the full contents of a single file in a dbt project " +
+        "(models, schema.yml, dbt_project.yml, seeds, macros...).",
+      inputSchema: readDbtFileSchema,
+      execute: async ({ projectId, path }) => {
+        try {
+          const project = await assertProject(projectId);
+          const file = await DbtFile.findOne({
+            projectId: project._id,
+            path,
+            is_deleted: { $ne: true },
+          }).select("path content");
+          if (!file) return { success: false, error: `File not found: ${path}` };
+          return { success: true, path: file.path, contents: file.content };
+        } catch (error) {
+          return {
+            success: false,
+            error:
+              error instanceof Error ? error.message : "Failed to read dbt file",
+          };
+        }
+      },
+    }),
+
     create_dbt_file: tool({
       description:
         "Create a new file in a dbt project (e.g. a staging model + its " +

--- a/api/src/agent-lib/tools/server-app-tools.ts
+++ b/api/src/agent-lib/tools/server-app-tools.ts
@@ -9,9 +9,10 @@
  * detached chat (mobile lock / computer sleep) keeps working end-to-end because
  * the write no longer depends on a connected browser.
  *
- * Browser-only legs stay client-side: `run_app` (preview rebuild) and
- * `materialize_binding` (DuckDB-WASM materialization), plus the cheap reads
- * `list_open_apps` / `open_app` / `get_app_state` / `app_read_file`.
+ * Reads (`get_app_state`, `app_read_file`) also execute here against the saved
+ * doc. Browser-only legs stay client-side: `run_app` (preview rebuild),
+ * `materialize_binding` (DuckDB-WASM materialization), and `list_open_apps` /
+ * `open_app` (open-tab UI state).
  *
  * Tool schemas live in @mako/agent-tools (shared with the app's tool cards).
  */
@@ -26,6 +27,8 @@ import {
   removeDependencySchema,
   createDataBindingSchema,
   deleteDataBindingSchema,
+  appReadFileSchema,
+  getAppStateSchema,
 } from "@mako/agent-tools";
 import { normalizeAppFiles } from "@mako/schemas";
 import {
@@ -162,6 +165,51 @@ export function createServerAppTools({
   };
 
   return {
+    get_app_state: tool({
+      description:
+        "Get the app definition: file list (paths), dependencies, data bindings, " +
+        "entrypoint, and runtime. Use this to understand the project. " +
+        "(Live preview build/runtime errors come from run_app in an open browser.)",
+      inputSchema: getAppStateSchema,
+      execute: async ({ appId }) =>
+        wrap("get_app_state", async () => {
+          const loaded = await loadApp(appId);
+          if (isLoadError(loaded)) return { success: false, ...loaded };
+          const { doc } = loaded;
+          return {
+            success: true,
+            appId,
+            title: doc.title,
+            runtime: doc.runtime,
+            entrypoint: doc.entrypoint,
+            files: (doc.files ?? []).map(f => f.path),
+            dependencies: doc.dependencies ?? {},
+            dataBindings: (doc.dataBindings ?? []).map(b => ({
+              name: b.name,
+              connectionId: b.connectionId,
+              language: b.language,
+              code: b.code,
+              materialization: b.materialization,
+            })),
+            version: doc.version,
+          };
+        }),
+    }),
+
+    app_read_file: tool({
+      description: "Read the full contents of a single file in the app.",
+      inputSchema: appReadFileSchema,
+      execute: async ({ appId, path }) =>
+        wrap("app_read_file", async () => {
+          const loaded = await loadApp(appId);
+          if (isLoadError(loaded)) return { success: false, ...loaded };
+          const { doc } = loaded;
+          const file = (doc.files ?? []).find(f => f.path === path);
+          if (!file) return { success: false, error: `File not found: ${path}` };
+          return { success: true, path: file.path, contents: file.contents };
+        }),
+    }),
+
     app_write_file: tool({
       description:
         "Create or overwrite a file with full contents. This is the primary " +

--- a/api/src/agent-lib/tools/server-chart-tools.ts
+++ b/api/src/agent-lib/tools/server-chart-tools.ts
@@ -1,0 +1,43 @@
+/**
+ * Server-side chart-template read tools (issue #475 pattern).
+ *
+ * `get_chart_templates` / `get_chart_template` are pure static lookups against
+ * the `@mako/schemas` template registry — no browser, no workspace state — so
+ * they execute on the API. This lets the agent discover/read chart templates
+ * with no attached browser. Schemas live in @mako/agent-tools (shared with the
+ * app's tool cards).
+ */
+import { tool } from "ai";
+import { getChartTemplateSchema, getChartTemplatesSchema } from "@mako/agent-tools";
+import { getAllTemplates, getTemplate } from "@mako/schemas";
+
+export function createServerChartTools() {
+  return {
+    get_chart_templates: tool({
+      description:
+        "List available best-practice chart templates with IDs and descriptions. " +
+        "Call before creating charts to discover proven simple patterns " +
+        "(e.g. multi-series line with hover rule, donut, stacked bar).",
+      inputSchema: getChartTemplatesSchema,
+      execute: async () => ({ success: true, templates: getAllTemplates() }),
+    }),
+
+    get_chart_template: tool({
+      description:
+        "Get a best-practice chart template with full vegaLiteSpec, SQL pattern, and implementation notes. " +
+        "Use for complex patterns (e.g. multi-series hover rule, stacked bar, donut) instead of inventing specs from scratch. " +
+        "Available IDs: multi-series-line-hover, time-series-area, grouped-bar, stacked-bar, horizontal-ranking, donut, kpi-sparkline.",
+      inputSchema: getChartTemplateSchema,
+      execute: async ({ templateId }) => {
+        const template = getTemplate(templateId);
+        if (!template) {
+          return {
+            success: false,
+            error: `No chart template with id "${templateId}".`,
+          };
+        }
+        return { success: true, template };
+      },
+    }),
+  };
+}

--- a/api/src/agent-lib/tools/server-read-tools.test.ts
+++ b/api/src/agent-lib/tools/server-read-tools.test.ts
@@ -10,8 +10,11 @@
  * chart tools are pure. Safe to run in CI.
  */
 import assert from "node:assert/strict";
-import { unifiedAgentFactory } from "../../agents/unified/index";
+import { getAgentFactory } from "../../agents/index";
 import { createServerChartTools } from "./server-chart-tools";
+
+// Every agent a chat turn can resolve to.
+const AGENT_IDS = ["unified", "console", "dashboard", "dbt", "flow"];
 
 const SERVER_READ_TOOLS = [
   "get_chart_templates",
@@ -34,19 +37,34 @@ function runTool(tool: ExecutableTool, args: unknown) {
 }
 
 function testWiring() {
-  console.log("  wiring: read tools registered server-side with execute");
-  const cfg = unifiedAgentFactory({
-    workspaceId: "000000000000000000000000",
-  } as never);
-  const tools = cfg.tools as Record<string, ExecutableTool | undefined>;
-  for (const name of SERVER_READ_TOOLS) {
-    assert.equal(
-      typeof tools[name]?.execute,
-      "function",
-      `${name} must have a server execute`,
-    );
+  console.log("  wiring: read tools never exposed as no-execute on any agent");
+  // The manifest marks these tools `execution: "server"` globally, so ANY
+  // agent that exposes one must also register a server `execute` — otherwise
+  // the client won't dispatch it and the turn hangs. Check every agent.
+  const ctx = { workspaceId: "000000000000000000000000" } as never;
+  let sawUnifiedAll = false;
+  for (const agentId of AGENT_IDS) {
+    const factory = getAgentFactory(agentId);
+    assert.ok(factory, `agent "${agentId}" must be registered`);
+    const cfg = factory(ctx);
+    const tools = cfg.tools as Record<string, ExecutableTool | undefined>;
+    let presentCount = 0;
+    for (const name of SERVER_READ_TOOLS) {
+      const def = tools[name];
+      if (!def) continue;
+      presentCount++;
+      assert.equal(
+        typeof def.execute,
+        "function",
+        `agent "${agentId}" exposes ${name} without a server execute`,
+      );
+    }
+    if (agentId === "unified") {
+      sawUnifiedAll = presentCount === SERVER_READ_TOOLS.length;
+    }
+    console.log(`    ✓ ${agentId}: ${presentCount} read tool(s), all server-executed`);
   }
-  console.log("    ✓ all 6 read tools are server-executed");
+  assert.ok(sawUnifiedAll, "unified agent must expose all 6 read tools");
 }
 
 async function testChartTools() {

--- a/api/src/agent-lib/tools/server-read-tools.test.ts
+++ b/api/src/agent-lib/tools/server-read-tools.test.ts
@@ -1,0 +1,86 @@
+/* eslint-disable no-console, no-process-exit */
+/**
+ * Tests for the server-side read tools (Phase 1 of the server-side port).
+ *
+ * - Wiring: the unified agent registers the 6 read tools with a server
+ *   `execute` (so the AI SDK runs them server-side, no browser).
+ * - Chart tools: pure static lookups against `@mako/schemas`.
+ *
+ * No DB required — `unifiedAgentFactory` only builds tool definitions, and the
+ * chart tools are pure. Safe to run in CI.
+ */
+import assert from "node:assert/strict";
+import { unifiedAgentFactory } from "../../agents/unified/index";
+import { createServerChartTools } from "./server-chart-tools";
+
+const SERVER_READ_TOOLS = [
+  "get_chart_templates",
+  "get_chart_template",
+  "get_app_state",
+  "app_read_file",
+  "read_dbt_project_tree",
+  "read_dbt_file",
+];
+
+type ExecutableTool = {
+  execute?: (args: unknown, opts: unknown) => Promise<Record<string, unknown>>;
+};
+
+function runTool(tool: ExecutableTool, args: unknown) {
+  if (typeof tool.execute !== "function") {
+    throw new Error("tool has no execute");
+  }
+  return tool.execute(args, { toolCallId: "t", messages: [] });
+}
+
+function testWiring() {
+  console.log("  wiring: read tools registered server-side with execute");
+  const cfg = unifiedAgentFactory({
+    workspaceId: "000000000000000000000000",
+  } as never);
+  const tools = cfg.tools as Record<string, ExecutableTool | undefined>;
+  for (const name of SERVER_READ_TOOLS) {
+    assert.equal(
+      typeof tools[name]?.execute,
+      "function",
+      `${name} must have a server execute`,
+    );
+  }
+  console.log("    ✓ all 6 read tools are server-executed");
+}
+
+async function testChartTools() {
+  console.log("  chart tools: static template lookups");
+  const chart = createServerChartTools() as Record<string, ExecutableTool>;
+
+  const list = await runTool(chart.get_chart_templates, {});
+  assert.equal(list.success, true);
+  assert.ok(
+    Array.isArray(list.templates) && list.templates.length > 0,
+    "expected at least one template",
+  );
+
+  const donut = await runTool(chart.get_chart_template, { templateId: "donut" });
+  assert.equal(donut.success, true);
+  assert.equal((donut.template as { id?: string })?.id, "donut");
+
+  const missing = await runTool(chart.get_chart_template, {
+    templateId: "does-not-exist",
+  });
+  assert.equal(missing.success, false);
+  console.log("    ✓ list + donut lookup + unknown-id rejection");
+}
+
+async function main() {
+  console.log("server-read-tools tests");
+  testWiring();
+  await testChartTools();
+  console.log("✓ server-read-tools tests passed");
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch(err => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/api/src/agents/console/index.ts
+++ b/api/src/agents/console/index.ts
@@ -13,6 +13,7 @@ import type {
 } from "../types";
 import { UNIVERSAL_PROMPT_V2 } from "../../agent-lib/prompts/universal";
 import { createUniversalTools } from "../../agent-lib/tools/universal-tools";
+import { createServerChartTools } from "../../agent-lib/tools/server-chart-tools";
 import { createSelfDirectiveTools } from "../../agent-lib/tools/self-directive-tool";
 import { createSkillTools } from "../../agent-lib/tools/skill-tools";
 import { createConsoleSearchTools } from "../../agent-lib/tools/console-search-tools";
@@ -248,6 +249,9 @@ export const consoleAgentFactory: AgentFactory = (
     ],
     tools: {
       ...tools,
+      // get_chart_template executes server-side; must come after the universal
+      // tools (which carry its no-execute version via clientChartTools).
+      ...createServerChartTools(),
       ...selfDirectiveTools,
       ...skillTools,
       ...consoleSearchTools,

--- a/api/src/agents/dashboard/index.ts
+++ b/api/src/agents/dashboard/index.ts
@@ -12,6 +12,7 @@ import {
   buildDashboardRuntimeContext,
 } from "./prompt";
 import { clientDashboardTools } from "@mako/agent-tools";
+import { createServerChartTools } from "../../agent-lib/tools/server-chart-tools";
 import { createSelfDirectiveTools } from "../../agent-lib/tools/self-directive-tool";
 import { createConsoleSearchTools } from "../../agent-lib/tools/console-search-tools";
 import { createDashboardSearchTools } from "../../agent-lib/tools/dashboard-search-tools";
@@ -65,6 +66,9 @@ export function dashboardAgentFactory(context: AgentContext): AgentConfig {
     ],
     tools: {
       ...clientDashboardTools,
+      // get_chart_templates/get_chart_template execute server-side; must come
+      // after clientDashboardTools (which carries their no-execute versions).
+      ...createServerChartTools(),
       ...selfDirectiveTools,
       ...consoleSearchTools,
       ...dashboardSearchTools,

--- a/api/src/agents/dbt/index.ts
+++ b/api/src/agents/dbt/index.ts
@@ -15,6 +15,7 @@ import type {
 } from "../types";
 import { clientDbtTools } from "@mako/agent-tools";
 import { createDbtServerTools } from "../../agent-lib/tools/dbt-tools";
+import { createServerChartTools } from "../../agent-lib/tools/server-chart-tools";
 import { createUniversalTools } from "../../agent-lib/tools/universal-tools";
 import { createSkillTools } from "../../agent-lib/tools/skill-tools";
 import { DBT_AGENT_PROMPT } from "./prompt";
@@ -99,6 +100,9 @@ export const dbtAgentFactory: AgentFactory = (
       ...universalTools,
       ...clientDbtTools,
       ...dbtServerTools,
+      // get_chart_template executes server-side; must come after the universal
+      // tools (which carry its no-execute version via clientChartTools).
+      ...createServerChartTools(),
       ...skillTools,
     },
   };

--- a/api/src/agents/unified/index.ts
+++ b/api/src/agents/unified/index.ts
@@ -8,6 +8,7 @@ import {
 } from "@mako/agent-tools";
 import { createDbtServerTools } from "../../agent-lib/tools/dbt-tools";
 import { createServerAppTools } from "../../agent-lib/tools/server-app-tools";
+import { createServerChartTools } from "../../agent-lib/tools/server-chart-tools";
 import { createSelfDirectiveTools } from "../../agent-lib/tools/self-directive-tool";
 import { createSkillTools } from "../../agent-lib/tools/skill-tools";
 import { createConsoleSearchTools } from "../../agent-lib/tools/console-search-tools";
@@ -57,6 +58,7 @@ export function unifiedAgentFactory(context: AgentContext): AgentConfig {
     userId,
     chatId: context.chatId,
   });
+  const serverChartTools = createServerChartTools();
 
   const {
     list_connections: _flowListConnections,
@@ -95,6 +97,9 @@ export function unifiedAgentFactory(context: AgentContext): AgentConfig {
       ...dashboardSearchTools,
       ...versionHistoryTools,
       ...webTools,
+      // Server-executed chart-template reads override the client (no-execute)
+      // versions of the same names; must come after the client tool spreads.
+      ...serverChartTools,
     },
   };
 }

--- a/app/src/agent-runtime/client-tool-manifest.ts
+++ b/app/src/agent-runtime/client-tool-manifest.ts
@@ -374,17 +374,17 @@ export const AGENT_TOOL_MANIFEST = {
     getLabel: () => "Setting time dimension",
     icon: "clock",
   },
+  // Chart-template reads execute SERVER-SIDE (static @mako/schemas lookup; see
+  // api/src/agent-lib/tools/server-chart-tools.ts).
   get_chart_templates: {
     domain: "dashboard",
-    execution: "client",
-    clientExecutor: "dashboard",
+    execution: "server",
     getLabel: () => "Listing chart templates",
     icon: "list",
   },
   get_chart_template: {
     domain: "chart",
-    execution: "client",
-    clientExecutor: "dashboard",
+    execution: "server",
     getLabel: () => "Reading chart template",
     icon: "eye",
   },
@@ -414,17 +414,17 @@ export const AGENT_TOOL_MANIFEST = {
     },
     icon: "plus",
   },
+  // App reads execute SERVER-SIDE against the saved doc (see
+  // api/src/agent-lib/tools/server-app-tools.ts).
   get_app_state: {
     domain: "app",
-    execution: "client",
-    clientExecutor: "app",
+    execution: "server",
     getLabel: () => "Reading app state",
     icon: "eye",
   },
   app_read_file: {
     domain: "app",
-    execution: "client",
-    clientExecutor: "app",
+    execution: "server",
     getLabel: input => {
       const path = (input as Record<string, unknown>)?.path;
       return path ? `Reading ${path}` : "Reading file";
@@ -545,17 +545,17 @@ export const AGENT_TOOL_MANIFEST = {
     getLabel: () => "Rebuilding app preview",
     icon: "play",
   },
+  // dbt reads execute SERVER-SIDE (DbtProject/DbtFile/DbtJob; see
+  // createDbtServerTools in api/src/agent-lib/tools/dbt-tools.ts).
   read_dbt_project_tree: {
     domain: "dbt",
-    execution: "client",
-    clientExecutor: "dbt",
+    execution: "server",
     getLabel: () => "Reading dbt project tree",
     icon: "list",
   },
   read_dbt_file: {
     domain: "dbt",
-    execution: "client",
-    clientExecutor: "dbt",
+    execution: "server",
     getLabel: input => {
       const path = (input as Record<string, unknown>)?.path;
       return path ? `Reading ${path}` : "Reading dbt file";

--- a/packages/agent-tools/src/app-tools.ts
+++ b/packages/agent-tools/src/app-tools.ts
@@ -40,10 +40,15 @@ export const renameFileSchema = z.object({
   to: z.string().describe("New file path"),
 });
 
-const readFileSchema = z.object({
+// Read tool schemas execute SERVER-SIDE (read the authoritative MakoApp doc) —
+// see api/src/agent-lib/tools/server-app-tools.ts. Exported for a single source
+// of truth with the app's tool cards.
+export const appReadFileSchema = z.object({
   appId: appIdField,
   path: z.string().describe("File path to read"),
 });
+
+export const getAppStateSchema = z.object({ appId: appIdField });
 
 export const addDependencySchema = z.object({
   appId: appIdField,
@@ -137,11 +142,11 @@ export const clientAppTools = {
       "Get the app definition: file list (paths), dependencies, data bindings, " +
       "entrypoint, runtime, and the latest preview build/runtime errors. " +
       "Use this to understand the project and to read build errors before fixing them.",
-    inputSchema: z.object({ appId: appIdField }),
+    inputSchema: getAppStateSchema,
   }),
   app_read_file: tool({
     description: "Read the full contents of a single file in the app.",
-    inputSchema: readFileSchema,
+    inputSchema: appReadFileSchema,
   }),
   materialize_binding: tool({
     description:

--- a/packages/agent-tools/src/chart-tools.ts
+++ b/packages/agent-tools/src/chart-tools.ts
@@ -38,6 +38,16 @@ export const modifyChartSpecSchema = z.object({
 
 export type ModifyChartSpecInput = z.infer<typeof modifyChartSpecSchema>;
 
+// Chart-template reads are pure static lookups (`@mako/schemas`) and execute
+// SERVER-SIDE — see api/src/agent-lib/tools/server-chart-tools.ts.
+export const getChartTemplateSchema = z.object({
+  templateId: z
+    .string()
+    .describe("Template ID (e.g. 'multi-series-line-hover', 'donut')"),
+});
+
+export const getChartTemplatesSchema = z.object({});
+
 export const clientChartTools = {
   modify_chart_spec: tool({
     description:
@@ -54,10 +64,6 @@ export const clientChartTools = {
       "Get a best-practice chart template with full vegaLiteSpec, SQL pattern, and implementation notes. " +
       "Use for complex patterns (e.g. multi-series hover rule, stacked bar, donut) instead of inventing specs from scratch. " +
       "Available IDs: multi-series-line-hover, time-series-area, grouped-bar, stacked-bar, horizontal-ranking, donut, kpi-sparkline.",
-    inputSchema: z.object({
-      templateId: z
-        .string()
-        .describe("Template ID (e.g. 'multi-series-line-hover', 'donut')"),
-    }),
+    inputSchema: getChartTemplateSchema,
   }),
 };

--- a/packages/agent-tools/src/dbt-tools.ts
+++ b/packages/agent-tools/src/dbt-tools.ts
@@ -24,7 +24,10 @@ const dbtPathField = z
     "POSIX file path relative to the project root, e.g. models/staging/stg_orders.sql",
   );
 
-const readTreeSchema = z.object({
+// Read tool schemas execute SERVER-SIDE (read DbtProject/DbtFile/DbtJob) —
+// see api/src/agent-lib/tools/dbt-tools.ts. Exported for a single source of
+// truth with the dbt IDE tool cards.
+export const readDbtProjectTreeSchema = z.object({
   projectId: z
     .string()
     .optional()
@@ -33,7 +36,7 @@ const readTreeSchema = z.object({
     ),
 });
 
-const readFileSchema = z.object({
+export const readDbtFileSchema = z.object({
   projectId: projectIdField,
   path: dbtPathField,
 });
@@ -69,13 +72,13 @@ export const clientDbtTools = {
       "List dbt projects in the workspace, or the file tree + jobs of one " +
       "project when projectId is given. Call this FIRST to get project IDs " +
       "and file paths before using any other dbt tool.",
-    inputSchema: readTreeSchema,
+    inputSchema: readDbtProjectTreeSchema,
   }),
   read_dbt_file: tool({
     description:
       "Read the full contents of a single file in a dbt project " +
       "(models, schema.yml, dbt_project.yml, seeds, macros...).",
-    inputSchema: readFileSchema,
+    inputSchema: readDbtFileSchema,
   }),
 };
 

--- a/packages/agent-tools/src/index.ts
+++ b/packages/agent-tools/src/index.ts
@@ -50,6 +50,11 @@ export type {
 } from "./console-tools";
 
 export { clientChartTools } from "./chart-tools";
+export {
+  // Schemas for the server-executed chart-template reads.
+  getChartTemplateSchema,
+  getChartTemplatesSchema,
+} from "./chart-tools";
 export type { ModifyChartSpecInput } from "./chart-tools";
 
 export { clientDashboardTools } from "./dashboard-tools";
@@ -66,6 +71,9 @@ export {
   removeDependencySchema,
   createDataBindingSchema,
   deleteDataBindingSchema,
+  // Schemas for the server-executed app read tools.
+  appReadFileSchema,
+  getAppStateSchema,
 } from "./app-tools";
 export type { AppWriteFileInput, AppCreateDataBindingInput } from "./app-tools";
 
@@ -76,6 +84,9 @@ export {
   createDbtFileSchema,
   modifyDbtFileSchema,
   deleteDbtFileSchema,
+  // Schemas for the server-executed dbt read tools.
+  readDbtProjectTreeSchema,
+  readDbtFileSchema,
 } from "./dbt-tools";
 export type { DbtCreateFileInput, DbtModifyFileInput } from "./dbt-tools";
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Part of moving agent tool execution server-side so the agent works with no attached browser (toward a background agent that only stops on HITL). This is **Phase 1: the clean read tools** — no semantic hazards, no product decisions.

Moves 6 read tools from client `onToolCall` to a server `execute` (the #475 pattern):

| Tool | Server source |
|---|---|
| `get_chart_templates`, `get_chart_template` | static `@mako/schemas` lookup (`server-chart-tools.ts`) |
| `get_app_state`, `app_read_file` | saved `MakoApp` doc (`server-app-tools.ts`) |
| `read_dbt_project_tree`, `read_dbt_file` | `DbtProject`/`DbtFile`/`DbtJob` (`createDbtServerTools`) |

## What

- **New** `api/src/agent-lib/tools/server-chart-tools.ts` (pure, no DB).
- `get_app_state`/`app_read_file` added to `createServerAppTools` (read the authoritative doc; `get_app_state` omits browser-only live preview errors — those come from `run_app`).
- `read_dbt_project_tree`/`read_dbt_file` added to `createDbtServerTools`, mirroring the client tree shape.
- Shared input schemas exported from `@mako/agent-tools` (single source of truth with the tool cards).
- Manifest entries flipped to `execution: "server"` (labels/icons kept) in `app/src/agent-runtime/client-tool-manifest.ts`.

## Agent coverage (important — the manifest flip is global)
Because the manifest marks these tools `execution: "server"` for **all** agents, every agent that exposes one must also register a server `execute` (otherwise the client won't dispatch it and the turn hangs). Verified + fixed for all 5 agents:

| Agent | Read tools exposed | All server-executed? |
|---|---|---|
| `unified` (production chat — all surfaces incl. dashboards/apps) | 6 | ✅ |
| `console` | 2 (chart) | ✅ (added `createServerChartTools`) |
| `dashboard` | 2 (chart) | ✅ (added `createServerChartTools`) |
| `dbt` | 4 (chart + dbt reads) | ✅ (added `createServerChartTools`) |
| `flow` | 0 | ✅ (n/a) |

Production chat always resolves to `unified` (frontend hardcodes `agentId: "unified"`; `detectAgentId` returns `unified` for every tab kind), which was already safe; the fix closes the latent hang for explicit `agentId` API calls to the standalone agents.

## Scope note (why only Phase 1)
Dashboard **doc CRUD / data-source** ops (Phase 2–3) only mutate *in-memory* state today and persist via a user-driven `PATCH` with an `editLock` + optimistic `version`, so porting them server-side is a real concurrency/UX decision (tracked separately, alongside the apps version-history / draft-vs-published work). Genuinely browser-bound tools (`run_app`, `capture_screenshot`, Vega render) need server render libs or a headless browser. `create_flow_tab`/`list_flow_tabs` are pure UI tabs with no Mongo entity.

## Testing (live env: local Mongo + seeded `Cloud Agent Dev`)
- ✅ `tsx src/agent-lib/tools/server-read-tools.test.ts` — asserts **all 5 agents** server-execute every read tool they expose + pure chart-tool lookups. Added to the api `test` script (no DB needed).
- ✅ Functional vs live Mongo: chart templates→7, `donut` lookup (+ unknown→fail), dbt tree→`projects:0` (valid), `get_app_state`→`DuckDB Server Test App`, `app_read_file(App.tsx)`→42 bytes (+ missing→fail).
- ✅ `pnpm --filter api run build`, `pnpm run build` (root), app `typecheck`/`lint`.

[phase1_read_tools_verify.log](https://cursor.com/agents/bc-a09778bb-6cf2-45c5-a26d-bb8686be12e3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphase1_read_tools_verify.log)

## Follow-up
Phase 2 (dashboard doc CRUD + realtime), Phase 3 (data ops via node DuckDB), draft/published + version-history model — see the server-side-agent epic.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a09778bb-6cf2-45c5-a26d-bb8686be12e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a09778bb-6cf2-45c5-a26d-bb8686be12e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

