### PR TITLE
feat: unified versioning + full-server apps/dbt agent tools (draft/published, realtime)

### DIFF
--- a/UNIFIED_VERSIONING_DESIGN.md
+++ b/UNIFIED_VERSIONING_DESIGN.md
@@ -110,17 +110,29 @@ Two operations:
 
 - **Phase 0 — DONE (PR #595).** App `versionHistory` + restore + server agent
   tools (`app_save_version`, `app_restore_version`) + `browse_version_history`
-  extended to apps + file-aware history UI. This is the `versionHistory[]` layer
-  and is independent of the published split.
-- **Phase 1 — Apps draft/published split.** Add `MakoApp.published`; add a
-  Publish action (draft → published + snapshot); make public-share / viewers
-  render `published` (fallback to draft); restore targets the draft. Contained to
-  apps + public-share.
-- **Phase 2 — Dashboard unification.** Generalize a shared
-  draft/published/publish/restore service; migrate the dashboard draft off
-  Zustand to the server doc; port `clientDashboardTools` → server tools; add
-  `editLock`; wire `dashboard.updated` realtime refetch. Bigger and riskier;
-  unblocks the server-side dashboard agent.
+  extended to apps + file-aware history UI.
+- **Phase 1 — DONE (PR #595).** Apps draft/published split: `MakoApp.published`
+  + `publishedVersion`/`publishedAt`; saving a version publishes it
+  (draft → published + snapshot); public-share / viewers render `published`
+  (fallback to draft); restore targets the draft only; `hasUnpublishedChanges`
+  surfaced; UI relabelled to "Publish version".
+- **Phase 2 — DONE (PR #595), except the headless editing-tool port.**
+  Dashboards adopt the identical model: `Dashboard.published` +
+  `publishedVersion`/`publishedAt`; every explicit save (PATCH/PUT/create)
+  publishes; restore reverts the draft only; public-share renders `published`;
+  `dashboard.updated` realtime is now emitted on save/restore and consumed by
+  `handleDashboardUpdated` (poke-then-pull, guarded so it never clobbers a user
+  mid-edit or with unsaved changes); `hasUnpublishedChanges` surfaced;
+  `editLock` retained. `browse_version_history` / `get_version_snapshot` already
+  cover dashboards.
+  - **Remaining (Phase 2c, follow-up):** port the ~15 client dashboard editing
+    tools (`add_widget`, `modify_widget`, `create_data_source`, …) to
+    server-side `execute` tools (mirroring `server-app-tools`) so a fully
+    headless agent can mutate a dashboard's server draft without a browser. The
+    server-persisted draft + realtime now make this a mechanical port; it is
+    deliberately staged separately because it is large and touches the live
+    dashboard agent surface (each tool needs server-side layout/spec logic and
+    its own tests).
 
 ## Open product decision
 

--- a/UNIFIED_VERSIONING_DESIGN.md
+++ b/UNIFIED_VERSIONING_DESIGN.md
@@ -1,0 +1,133 @@
+# Unified Draft / Published / Version-History Model (Apps + Dashboards)
+
+Status: proposal · Owner: TBD · Relates to PR #595 (app version history)
+
+## TL;DR
+
+Once an entity has version history, it has three things: **committed versions**
+(immutable snapshots), a **working draft** (what's being edited), and a
+**published** definition (what viewers / public links render). The only
+architecturally load-bearing decision is **where the working draft lives**, and
+the answer — forced by the server-side + background-agent direction — is: **the
+draft must be server-persisted, never client-only.**
+
+Apps already embody this (the doc *is* the server draft, autosaved; the agent
+mutates it server-side). The work is therefore:
+
+1. Add an explicit **draft → published** split (so shares/viewers see a stable
+   version while the editor + agent iterate).
+2. Reuse `entity-version.service` for the immutable history (apps already do
+   after PR #595).
+3. Apply the **identical** model to dashboards — which also moves the dashboard
+   draft off the client and unblocks **server-side dashboard agent tools**.
+
+## Current state
+
+| Concern | Apps (today) | Dashboards (today) |
+| --- | --- | --- |
+| Working def | `MakoApp` doc, **server-persisted**, autosaved via `persistApp` (PUT) | `dashboardStore` (**Zustand, client-only**) |
+| Agent edits | **Server** tools (`server-app-tools.ts`) mutate the doc | **Client** tools (`clientDashboardTools` via `onToolCall`) — needs a browser |
+| Realtime resync | `app.updated` → open tabs refetch | `dashboard.updated` exists (partial) |
+| History | `EntityVersion` (PR #595) + restore | `EntityVersion` + legacy embedded `versionHistory[]` |
+| Published/served | none — public share renders the **live** doc | none — renders live def |
+
+Takeaway: **apps are ~80% of the model already.** The only missing piece for
+apps is the published split. Dashboards are the real lift: their draft is in the
+browser, which is exactly why their agent tools are client-side and a headless
+agent "needs a browser."
+
+## Target model (one shape for both entities)
+
+```text
+Entity {
+  // working draft — the current editable definition. Autosaved server-side
+  // (debounced PATCH; the app persistApp mechanism). User editor AND agent
+  // both mutate this.
+  draft: Definition
+
+  // last committed/served definition. Viewers, public/shared links, and
+  // snapshots render THIS, never the draft.
+  published?: Definition
+
+  // immutable committed snapshots (generic infra: entity-version.service
+  // createVersion({ entityType })). Apps reuse it directly.
+  versionHistory: EntityVersion[]   // separate collection, not embedded
+}
+```
+
+Two operations:
+
+- **Publish a version** = copy `draft → published`, append a snapshot to
+  `versionHistory`, bump the committed version.
+- **Restore** = copy `versionHistory[n] → draft` (then optionally publish).
+
+## Preview & sharing semantics
+
+- **Editor's open tab** renders `draft` and re-renders on the realtime
+  `*.updated` event (the `handleAppUpdated` pattern). So when the background
+  agent edits the draft, the user opens the tab and previews the working draft.
+- **Viewers / public links / snapshots** render `published`. A half-edited or
+  agent-in-progress draft is never exposed on a public share.
+
+## Agent implications
+
+- A server-side / background agent can only edit a **server-persisted draft**.
+  Apps already satisfy this; dashboards do not. Moving the dashboard draft to the
+  doc lets us port the dashboard tools to **server tools** (the issue-#475
+  pattern), which is what makes the headless dashboard agent possible.
+- The agent writes the shared server draft directly — the same thing apps do
+  today — so the "dashboard concurrency" problem dissolves into the app model.
+
+## Concurrency
+
+- **v1:** single shared draft per entity, **last-writer-wins + realtime
+  refetch** (the current app model).
+- **Multi-editor surfaces (dashboards):** add an `editLock` to serialize human
+  editors; the agent **respects/holds** the lock so a background run doesn't
+  stomp someone actively editing.
+- **Out of scope:** per-user draft branches / true merge / CRDT. One shared
+  server draft is the right v1.
+
+## Implementation refinements (important)
+
+1. **Do not physically rename app top-level fields to `draft.*`.** The blast
+   radius (routes, `serializeApp`, agent tools, store, UI, generated OpenAPI
+   types) is huge. Treat the **existing top-level fields as the draft in place**
+   and add a single `published` snapshot object. Backward compatible: if
+   `published` is absent, fall back to the live def (today's behavior).
+2. **Checkpoint vs publish.** PR #595 ships "Save version" = snapshot only (a WIP
+   restore point) with **no** publish. The target model conflates save = publish.
+   Decide whether we want a WIP-checkpoint action distinct from publish:
+   - Simplest (user's model): every saved version is a publish.
+   - Safer for WIP: keep "Save checkpoint" (snapshot only) **and** add an explicit
+     "Publish" (draft → published + snapshot). Recommended once shares matter.
+3. **Public-share behavior change.** Switching shares to render `published` is a
+   real, user-visible change (today shares reflect live edits). It is the right
+   call, but it is a product decision (see below) and should ship behind the
+   published-fallback so un-published apps keep working.
+
+## Phasing
+
+- **Phase 0 — DONE (PR #595).** App `versionHistory` + restore + server agent
+  tools (`app_save_version`, `app_restore_version`) + `browse_version_history`
+  extended to apps + file-aware history UI. This is the `versionHistory[]` layer
+  and is independent of the published split.
+- **Phase 1 — Apps draft/published split.** Add `MakoApp.published`; add a
+  Publish action (draft → published + snapshot); make public-share / viewers
+  render `published` (fallback to draft); restore targets the draft. Contained to
+  apps + public-share.
+- **Phase 2 — Dashboard unification.** Generalize a shared
+  draft/published/publish/restore service; migrate the dashboard draft off
+  Zustand to the server doc; port `clientDashboardTools` → server tools; add
+  `editLock`; wire `dashboard.updated` realtime refetch. Bigger and riskier;
+  unblocks the server-side dashboard agent.
+
+## Open product decision
+
+**Do viewers / public links need a stable `published` version while the editor +
+agent iterate on the draft?**
+
+- **Yes (recommended):** implement the draft/published split above. You don't
+  want a half-edited or agent-in-progress app/dashboard shown on a public share.
+- **No:** skip `published`; the doc is just `draft` + history. Simpler, but public
+  shares reflect in-progress edits (today's behavior).

--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -21,6 +21,8 @@ import {
   createDbtFileSchema,
   modifyDbtFileSchema,
   deleteDbtFileSchema,
+  readDbtTreeSchema,
+  readDbtFileSchema,
 } from "@mako/agent-tools";
 import {
   DatabaseConnection,
@@ -236,6 +238,96 @@ export const createDbtServerTools = (
   };
 
   return {
+    read_dbt_project_tree: tool({
+      description:
+        "List dbt projects in the workspace, or the file tree + jobs of one " +
+        "project when projectId is given. Call this FIRST to get project IDs " +
+        "and file paths before using any other dbt tool.",
+      inputSchema: readDbtTreeSchema,
+      execute: async ({ projectId }) => {
+        try {
+          if (!projectId) {
+            const projects = await DbtProject.find({
+              workspaceId: new Types.ObjectId(workspaceId),
+            })
+              .sort({ updatedAt: -1 })
+              .lean();
+            return {
+              success: true as const,
+              projects: projects.map(p => ({
+                id: p._id.toString(),
+                name: p.name,
+                defaultEnvironment: p.defaultEnvironment,
+                environments: (p.environments ?? []).map(env => ({
+                  name: env.name,
+                  targetSchema: env.targetSchema,
+                  connectionId: env.connectionId?.toString(),
+                })),
+              })),
+            };
+          }
+          const project = await assertProject(projectId);
+          const [files, jobs] = await Promise.all([
+            DbtFile.find({
+              projectId: project._id,
+              is_deleted: { $ne: true },
+            })
+              .select("path")
+              .sort({ path: 1 })
+              .lean(),
+            DbtJob.find({ projectId: project._id }).lean(),
+          ]);
+          return {
+            success: true as const,
+            projectId,
+            name: project.name,
+            defaultEnvironment: project.defaultEnvironment,
+            environments: project.environments,
+            files: files.map(f => f.path),
+            jobs: jobs.map(job => ({
+              id: job._id.toString(),
+              name: job.name,
+              environment: job.environment,
+              commands: job.commands,
+              schedule: job.schedule ?? null,
+              enabled: job.enabled,
+            })),
+          };
+        } catch (error) {
+          return toolError(error, "Failed to read dbt project tree");
+        }
+      },
+    }),
+
+    read_dbt_file: tool({
+      description:
+        "Read the full contents of a single file in a dbt project " +
+        "(models, schema.yml, dbt_project.yml, seeds, macros...).",
+      inputSchema: readDbtFileSchema,
+      execute: async ({ projectId, path }) => {
+        try {
+          const project = await assertProject(projectId);
+          const file = await DbtFile.findOne({
+            projectId: project._id,
+            path,
+            is_deleted: { $ne: true },
+          })
+            .select("path content")
+            .lean();
+          if (!file) {
+            return { success: false as const, error: `File not found: ${path}` };
+          }
+          return {
+            success: true as const,
+            path: file.path,
+            contents: file.content ?? "",
+          };
+        } catch (error) {
+          return toolError(error, "Failed to read dbt file");
+        }
+      },
+    }),
+
     create_dbt_file: tool({
       description:
         "Create a new file in a dbt project (e.g. a staging model + its " +

--- a/api/src/agent-lib/tools/server-app-tools.ts
+++ b/api/src/agent-lib/tools/server-app-tools.ts
@@ -26,6 +26,8 @@ import {
   removeDependencySchema,
   createDataBindingSchema,
   deleteDataBindingSchema,
+  saveAppVersionSchema,
+  restoreAppVersionSchema,
 } from "@mako/agent-tools";
 import { normalizeAppFiles } from "@mako/schemas";
 import {
@@ -35,6 +37,16 @@ import {
 } from "../../database/workspace-schema";
 import { workspaceService } from "../../services/workspace.service";
 import { publishRealtimeEvent } from "../../services/realtime.service";
+import {
+  createVersion,
+  getVersion,
+  getUserDisplayName,
+} from "../../services/entity-version.service";
+import {
+  buildAppSnapshot,
+  applyAppSnapshot,
+  type AppSnapshot,
+} from "../../services/app-version.service";
 import { canReadResource, canWriteResource } from "../../utils/resource-acl";
 import { loggers } from "../../logging";
 
@@ -107,6 +119,10 @@ export function createServerAppTools({
     if (!userId) return true; // workspace-scoped API-key automation
     return canWriteResource(doc, userId, await memberRole());
   };
+
+  // Display name stamped on version checkpoints the agent creates.
+  const savedByName = async (): Promise<string> =>
+    userId ? await getUserDisplayName(userId) : "Agent";
 
   // Persist a mutated app doc, then poke the workspace channel so open tabs
   // pull the new definition and rebuild their preview.
@@ -331,6 +347,87 @@ export function createServerAppTools({
           const version = await saveAndPublish(doc);
           const remaining = (doc.dataBindings ?? []).map(b => b.name);
           return { success: true, deleted: name, remaining, version };
+        }),
+    }),
+
+    app_save_version: tool({
+      description:
+        "Save a named checkpoint of the app's current state to its version " +
+        "history. Apps autosave on every edit, so use this to mark meaningful " +
+        "milestones (before a risky refactor, after finishing a feature) that " +
+        "the user can review or restore later. Returns the new version number.",
+      inputSchema: saveAppVersionSchema,
+      execute: async ({ appId, comment }) =>
+        wrap("app_save_version", async () => {
+          const loaded = await loadApp(appId);
+          if (isLoadError(loaded)) return { success: false, ...loaded };
+          const { doc } = loaded;
+          if (!(await canWrite(doc))) return denied(appId);
+          const created = await createVersion({
+            entityType: "app",
+            entityId: doc._id,
+            workspaceId: new Types.ObjectId(workspaceId),
+            snapshot: buildAppSnapshot(doc) as unknown as Record<
+              string,
+              unknown
+            >,
+            savedBy: userId ?? "agent",
+            savedByName: await savedByName(),
+            comment: (comment ?? "").slice(0, 500),
+          });
+          return {
+            success: true,
+            version: created.version,
+            createdAt: created.createdAt,
+          };
+        }),
+    }),
+
+    app_restore_version: tool({
+      description:
+        "Restore the app to a previous version from its history (get the " +
+        "version number from browse_version_history). The current state is " +
+        "first preserved as a new checkpoint, so restoring is never lossy. " +
+        "Open tabs reload the reverted app automatically.",
+      inputSchema: restoreAppVersionSchema,
+      execute: async ({ appId, version, comment }) =>
+        wrap("app_restore_version", async () => {
+          const loaded = await loadApp(appId);
+          if (isLoadError(loaded)) return { success: false, ...loaded };
+          const { doc } = loaded;
+          if (!(await canWrite(doc))) return denied(appId);
+          const old = await getVersion(
+            appId,
+            "app",
+            version,
+            new Types.ObjectId(workspaceId),
+          );
+          if (!old) {
+            return { success: false, error: `Version ${version} not found` };
+          }
+          applyAppSnapshot(doc, old.snapshot as unknown as AppSnapshot);
+          const newVersion = await saveAndPublish(doc);
+          await createVersion({
+            entityType: "app",
+            entityId: doc._id,
+            workspaceId: new Types.ObjectId(workspaceId),
+            snapshot: buildAppSnapshot(doc) as unknown as Record<
+              string,
+              unknown
+            >,
+            savedBy: userId ?? "agent",
+            savedByName: await savedByName(),
+            comment: (comment ?? `Restored from version ${version}`).slice(
+              0,
+              500,
+            ),
+            restoredFrom: version,
+          });
+          return {
+            success: true,
+            restoredFrom: version,
+            version: newVersion,
+          };
         }),
     }),
   };

--- a/api/src/agent-lib/tools/server-app-tools.ts
+++ b/api/src/agent-lib/tools/server-app-tools.ts
@@ -9,9 +9,14 @@
  * detached chat (mobile lock / computer sleep) keeps working end-to-end because
  * the write no longer depends on a connected browser.
  *
- * Browser-only legs stay client-side: `run_app` (preview rebuild) and
- * `materialize_binding` (DuckDB-WASM materialization), plus the cheap reads
- * `list_open_apps` / `open_app` / `get_app_state` / `app_read_file`.
+ * Apps are now FULLY server-authoritative: not just the writes, but listing,
+ * creating, reading/inspecting, and materializing bindings all run against the
+ * MakoApp document here, so a headless / detached agent can build and operate
+ * an app end-to-end with no browser.
+ *
+ * The only browser-only leg is `run_app` (rebuild the sandboxed-iframe preview
+ * and read render/build errors); `open_app` is a pure UI tab-focus convenience.
+ * A headless agent skips both and works on the appId directly.
  *
  * Tool schemas live in @mako/agent-tools (shared with the app's tool cards).
  */
@@ -28,13 +33,22 @@ import {
   deleteDataBindingSchema,
   saveAppVersionSchema,
   restoreAppVersionSchema,
+  listAppsSchema,
+  createAppSchema,
+  getAppStateSchema,
+  appReadFileSchema,
+  materializeBindingSchema,
 } from "@mako/agent-tools";
-import { normalizeAppFiles } from "@mako/schemas";
+import { normalizeAppFiles, createAppScaffold } from "@mako/schemas";
 import {
   MakoApp,
   DatabaseConnection,
   type IMakoApp,
 } from "../../database/workspace-schema";
+import {
+  queueAppBindingMaterialization,
+  buildAppBindingMaterializationStatus,
+} from "../../services/app-binding-materialization.service";
 import { workspaceService } from "../../services/workspace.service";
 import { publishRealtimeEvent } from "../../services/realtime.service";
 import {
@@ -177,7 +191,218 @@ export function createServerAppTools({
     }
   };
 
+  const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
+
   return {
+    list_open_apps: tool({
+      description:
+        "List the apps in this workspace (id, title, file count, and data " +
+        "binding names). Call this FIRST to discover app IDs before using other " +
+        "app tools. Returns all apps you can access — not just ones open in a UI " +
+        "tab — so it works headlessly.",
+      inputSchema: listAppsSchema,
+      execute: async () =>
+        wrap("list_open_apps", async () => {
+          const filter: Record<string, unknown> = {
+            workspaceId: new Types.ObjectId(workspaceId),
+          };
+          if (userId) {
+            filter.$or = [
+              { owner_id: userId },
+              { access: "workspace" },
+              { "sharedWith.userId": userId },
+            ];
+          }
+          const docs = await MakoApp.find(filter)
+            .sort({ updatedAt: -1 })
+            .limit(100)
+            .lean<IMakoApp[]>();
+          return {
+            success: true,
+            apps: docs.map(d => ({
+              id: d._id.toString(),
+              title: d.title,
+              fileCount: Array.isArray(d.files) ? d.files.length : 0,
+              dataBindings: (d.dataBindings ?? []).map(b => ({
+                name: b.name,
+                language: b.language,
+                materialization: b.materialization ?? "live",
+              })),
+            })),
+          };
+        }),
+    }),
+
+    create_app: tool({
+      description:
+        "Create a new React app from the default scaffold (React + TypeScript) " +
+        "and return its appId. Then use app_write_file to build features and " +
+        "app_add_dependency to add libraries. (In an attached browser, call " +
+        "open_app afterward to focus the new app's tab.)",
+      inputSchema: createAppSchema,
+      execute: async ({ title, description }) =>
+        wrap("create_app", async () => {
+          const scaffold = createAppScaffold(title || "Untitled App");
+          const created = await MakoApp.create({
+            workspaceId: new Types.ObjectId(workspaceId),
+            title: scaffold.title,
+            description: description ?? scaffold.description,
+            template: scaffold.template,
+            runtime: scaffold.runtime,
+            entrypoint: scaffold.entrypoint,
+            files: normalizeAppFiles(scaffold.files),
+            dependencies: scaffold.dependencies,
+            dataBindings: [],
+            access: "private",
+            owner_id: userId,
+            createdBy: userId ?? "agent",
+            version: 1,
+          });
+          return {
+            success: true,
+            appId: created._id.toString(),
+            title: created.title,
+            files: created.files.map(f => f.path),
+          };
+        }),
+    }),
+
+    get_app_state: tool({
+      description:
+        "Get the app definition from the server: file list (paths), dependencies, " +
+        "data bindings, entrypoint, runtime, and version/publish state. Use this " +
+        "to understand the project before editing. NOTE: live preview build/" +
+        "runtime errors are only available in an attached browser via run_app.",
+      inputSchema: getAppStateSchema,
+      execute: async ({ appId }) =>
+        wrap("get_app_state", async () => {
+          const loaded = await loadApp(appId);
+          if (isLoadError(loaded)) return { success: false, ...loaded };
+          const { doc } = loaded;
+          return {
+            success: true,
+            appId,
+            title: doc.title,
+            runtime: doc.runtime,
+            entrypoint: doc.entrypoint,
+            version: doc.version,
+            publishedVersion: doc.publishedVersion,
+            files: (doc.files ?? []).map(f => f.path),
+            dependencies: doc.dependencies ?? {},
+            dataBindings: (doc.dataBindings ?? []).map(b => ({
+              name: b.name,
+              connectionId: b.connectionId,
+              language: b.language,
+              code: b.code,
+              materialization: b.materialization ?? "live",
+            })),
+          };
+        }),
+    }),
+
+    app_read_file: tool({
+      description: "Read the full contents of a single file in the app.",
+      inputSchema: appReadFileSchema,
+      execute: async ({ appId, path }) =>
+        wrap("app_read_file", async () => {
+          const loaded = await loadApp(appId);
+          if (isLoadError(loaded)) return { success: false, ...loaded };
+          const file = (loaded.doc.files ?? []).find(f => f.path === path);
+          if (!file) return { success: false, error: `File not found: ${path}` };
+          return { success: true, path: file.path, contents: file.contents };
+        }),
+    }),
+
+    materialize_binding: tool({
+      description:
+        "Build (or rebuild) the Parquet artifact for a 'parquet' data binding. " +
+        "The build runs server-side in the background; this tool waits up to " +
+        "waitSeconds (default 120, max 600) and returns status 'building' if it " +
+        "is still running — call again to keep waiting, or use waitSeconds: 0 " +
+        "for an instant status check. Apps with an attached browser refresh " +
+        "automatically when the build is ready.",
+      inputSchema: materializeBindingSchema,
+      execute: async ({ appId, name, waitSeconds }) =>
+        wrap("materialize_binding", async () => {
+          const loaded = await loadApp(appId);
+          if (isLoadError(loaded)) return { success: false, ...loaded };
+          if (!(await canWrite(loaded.doc))) return denied(appId);
+          const binding = (loaded.doc.dataBindings ?? []).find(
+            b => b.name === name,
+          );
+          if (!binding) {
+            return { success: false, error: `No data binding named "${name}"` };
+          }
+          if (binding.materialization !== "parquet") {
+            return {
+              success: false,
+              error: `Binding "${name}" is 'live', not 'parquet' — nothing to materialize.`,
+            };
+          }
+          const queued = await queueAppBindingMaterialization({
+            workspaceId,
+            appId,
+            bindingId: binding.id,
+          });
+          const waitMs =
+            Math.min(Math.max(waitSeconds ?? 120, 0), 600) * 1000;
+          const deadline = Date.now() + waitMs;
+          let status: string = queued.status;
+          // Poll the doc until the background build terminates or the wait
+          // elapses (the build keeps running server-side either way).
+          while (
+            (status === "queued" || status === "building") &&
+            Date.now() < deadline
+          ) {
+            await sleep(2500);
+            const fresh = await MakoApp.findById(loaded.doc._id);
+            const st = fresh
+              ? buildAppBindingMaterializationStatus(fresh, binding.id)
+              : null;
+            if (!st) break;
+            status = st.status;
+          }
+          if (status === "ready") {
+            // Bump version + poke so an attached browser reloads the artifact
+            // into its DuckDB instance (headless callers ignore this).
+            const bumped = await MakoApp.findByIdAndUpdate(
+              loaded.doc._id,
+              { $inc: { version: 1 } },
+              { new: true },
+            );
+            publishRealtimeEvent(workspaceId, {
+              type: "app.updated",
+              appId,
+              version: bumped?.version ?? loaded.doc.version + 1,
+              updatedBy: userId ?? "agent",
+              clientId: agentClientId,
+              origin: "agent",
+            });
+            return {
+              success: true,
+              binding: { name, status: "ready" },
+              hint: `Materialized. Read it with useQuery("${name}") or useDuckDB(sql).`,
+            };
+          }
+          if (status === "error") {
+            return {
+              success: false,
+              binding: { name },
+              status: "error",
+              error: "Materialization failed. Check the binding query.",
+            };
+          }
+          return {
+            success: true,
+            binding: { name },
+            status: "building",
+            hint:
+              `Materialization of "${name}" is still running in the background. ` +
+              "Call materialize_binding again to keep waiting.",
+          };
+        }),
+    }),
+
     app_write_file: tool({
       description:
         "Create or overwrite a file with full contents. This is the primary " +

--- a/api/src/agent-lib/tools/server-app-tools.ts
+++ b/api/src/agent-lib/tools/server-app-tools.ts
@@ -258,6 +258,16 @@ export function createServerAppTools({
             createdBy: userId ?? "agent",
             version: 1,
           });
+          // Poke the workspace so an attached browser's Apps explorer picks up
+          // the new app without a manual reload (browser follows the server).
+          publishRealtimeEvent(workspaceId, {
+            type: "app.updated",
+            appId: created._id.toString(),
+            version: created.version,
+            updatedBy: userId ?? "agent",
+            clientId: agentClientId,
+            origin: "agent",
+          });
           return {
             success: true,
             appId: created._id.toString(),

--- a/api/src/agent-lib/tools/server-app-tools.ts
+++ b/api/src/agent-lib/tools/server-app-tools.ts
@@ -352,10 +352,12 @@ export function createServerAppTools({
 
     app_save_version: tool({
       description:
-        "Save a named checkpoint of the app's current state to its version " +
-        "history. Apps autosave on every edit, so use this to mark meaningful " +
-        "milestones (before a risky refactor, after finishing a feature) that " +
-        "the user can review or restore later. Returns the new version number.",
+        "Save AND publish a version of the app's current state. Apps autosave " +
+        "the working draft on every edit; saving a version snapshots it into " +
+        "version history AND publishes that snapshot — it becomes the definition " +
+        "public/shared viewers render. Use it to mark meaningful milestones " +
+        "(after finishing a feature, before a risky refactor) and to push work " +
+        "live to viewers. Returns the new version number.",
       inputSchema: saveAppVersionSchema,
       execute: async ({ appId, comment }) =>
         wrap("app_save_version", async () => {
@@ -363,21 +365,26 @@ export function createServerAppTools({
           if (isLoadError(loaded)) return { success: false, ...loaded };
           const { doc } = loaded;
           if (!(await canWrite(doc))) return denied(appId);
+          const snapshot = buildAppSnapshot(doc);
           const created = await createVersion({
             entityType: "app",
             entityId: doc._id,
             workspaceId: new Types.ObjectId(workspaceId),
-            snapshot: buildAppSnapshot(doc) as unknown as Record<
-              string,
-              unknown
-            >,
+            snapshot: snapshot as unknown as Record<string, unknown>,
             savedBy: userId ?? "agent",
             savedByName: await savedByName(),
             comment: (comment ?? "").slice(0, 500),
           });
+          // Publish: the snapshot becomes the viewer-facing definition.
+          doc.published = snapshot as unknown as Record<string, unknown>;
+          doc.markModified("published"); // Mixed: assignment isn't auto-tracked
+          doc.publishedVersion = created.version;
+          doc.publishedAt = new Date();
+          await doc.save();
           return {
             success: true,
             version: created.version,
+            publishedVersion: created.version,
             createdAt: created.createdAt,
           };
         }),

--- a/api/src/agent-lib/tools/version-history-tools.ts
+++ b/api/src/agent-lib/tools/version-history-tools.ts
@@ -8,16 +8,19 @@ import {
 export const createVersionHistoryTools = (workspaceId: string) => ({
   browse_version_history: tool({
     description:
-      "Browse the version history of a saved console or dashboard. " +
+      "Browse the version history of a saved console, dashboard, or app. " +
       "Returns a list of past versions with who saved them, when, and their commit comment. " +
-      "Use after search_consoles or search_dashboards to inspect change history, " +
-      "understand who changed what, or help the user decide which version to restore. " +
-      "Pass the entityId from a search result.",
+      "Use after search_consoles, search_dashboards, or list_open_apps to inspect change history, " +
+      "understand who changed what, or help the user decide which version to restore " +
+      "(restore consoles/dashboards via their own flows; restore apps with app_restore_version). " +
+      "Pass the entityId from a search result (for apps, the appId).",
     inputSchema: z.object({
       entityType: z
-        .enum(["console", "dashboard"])
-        .describe("Whether this is a console or dashboard"),
-      entityId: z.string().describe("The ID of the console or dashboard"),
+        .enum(["console", "dashboard", "app"])
+        .describe("Whether this is a console, dashboard, or app"),
+      entityId: z
+        .string()
+        .describe("The ID of the console, dashboard, or app"),
       limit: z
         .number()
         .optional()
@@ -58,15 +61,18 @@ export const createVersionHistoryTools = (workspaceId: string) => ({
 
   get_version_snapshot: tool({
     description:
-      "Get the full snapshot of a specific version of a console or dashboard. " +
+      "Get the full snapshot of a specific version of a console, dashboard, or app. " +
       "Use this to show the user what a past version looked like, or to compare " +
       "with the current state. For consoles, the snapshot includes the code; " +
-      "for dashboards, it includes widgets, data sources, and layout.",
+      "for dashboards, it includes widgets, data sources, and layout; for apps, " +
+      "it includes the files, dependencies, and data binding queries.",
     inputSchema: z.object({
       entityType: z
-        .enum(["console", "dashboard"])
-        .describe("Whether this is a console or dashboard"),
-      entityId: z.string().describe("The ID of the console or dashboard"),
+        .enum(["console", "dashboard", "app"])
+        .describe("Whether this is a console, dashboard, or app"),
+      entityId: z
+        .string()
+        .describe("The ID of the console, dashboard, or app"),
       version: z.number().describe("The version number to retrieve"),
     }),
     execute: async ({ entityType, entityId, version }) => {

--- a/api/src/agent-skills/apps/SKILL.md
+++ b/api/src/agent-skills/apps/SKILL.md
@@ -28,12 +28,21 @@ entities:
 
 Apps are React projects rendered live in a tab. You build them by editing files.
 
+All app tools run server-side except the live preview: `list_open_apps`,
+`create_app`, `get_app_state`, `app_read_file`, the file/dependency/binding
+edits, `materialize_binding`, and versioning all operate on the server document,
+so you can build and operate an app with no browser attached. The only
+browser-only tool is `run_app` (rebuild the preview and read render/build
+errors); `open_app` just focuses a UI tab.
+
 ### Workflow
 
-1. Call `list_open_apps` to find the active app and its `appId`. If none is open,
-   use `create_app` (it scaffolds a React + TypeScript starter and opens a tab).
-2. Use `get_app_state` to see the file list, dependencies, data bindings, and any
-   current build/runtime errors before editing.
+1. Call `list_open_apps` to find the target app and its `appId`. If none exists,
+   use `create_app` (it scaffolds a React + TypeScript starter; in an attached
+   browser, call `open_app` afterward to focus its tab).
+2. Use `get_app_state` to see the file list, dependencies, data bindings,
+   entrypoint, and version before editing. (Live preview build/runtime errors are
+   only available in an attached browser via `run_app`.)
 3. Edit with `app_write_file` — always write the COMPLETE file contents, not a diff.
    The entrypoint defaults to `src/App.tsx` (default export is rendered).
 4. Add libraries with `app_add_dependency` (e.g. d3, recharts, framer-motion) before
@@ -85,8 +94,10 @@ Apps are React projects rendered live in a tab. You build them by editing files.
    you genuinely need more rows, pass `useDuckDB(sql, { rowLimit: 2_000_000 })` or
    `{ rowLimit: null }` to disable the cap (costs memory + serialization time), and
    surface `truncated` in the UI whenever you render row-level data.
-6. After a batch of edits, if something looks wrong, call `get_app_state` (or `run_app`)
-   to read build/runtime errors and fix them. Iterate until the preview is error-free.
+6. After a batch of edits, in an attached browser call `run_app` to rebuild the
+   preview and read build/runtime errors, then fix them. Iterate until the preview
+   is error-free. (Headless, with no browser, you cannot render — rely on
+   `get_app_state` and careful editing.)
 7. Understand and validate data before coding against it using the shared data-source
    primitives (they work for apps and dashboards — pass `surface: { kind: "app", id: appId }`):
    `list_data_sources` shows every data source (connection, query, materialization, status);

--- a/api/src/agent-skills/apps/SKILL.md
+++ b/api/src/agent-skills/apps/SKILL.md
@@ -95,6 +95,27 @@ Apps are React projects rendered live in a tab. You build them by editing files.
    `useDuckDB` calls. Data sources are also visible to the user under "Data sources" in the
    app's explorer tree.
 
+### Version history & checkpoints
+
+Apps autosave on every edit, so the running `version` counter is not a restore
+point. To create restorable history, save **explicit checkpoints**:
+
+- `app_save_version` — freeze the app's current files, dependencies, and data
+  binding queries into an immutable checkpoint with a short `comment`. Do this
+  at meaningful milestones: before a risky refactor, after finishing a feature,
+  or whenever the user asks to "save"/"snapshot"/"checkpoint" the app.
+- `browse_version_history` with `entityType: "app"` and the `appId` — list past
+  checkpoints (who, when, comment, and `restoredFrom`). Use `get_version_snapshot`
+  to inspect a specific version's files before restoring.
+- `app_restore_version` — revert the app to a checkpoint by version number. The
+  current state is preserved as a new checkpoint first, so restoring is never
+  lossy. Open tabs reload the reverted app automatically. Binding materialization
+  artifacts are kept (the snapshot stores query definitions, not parquet caches).
+
+Good habit: call `app_save_version` with a descriptive comment right before
+making sweeping edits the user might want to undo, so there is always a clean
+point to roll back to.
+
 ### Theming & dark mode
 
 Apps are themed by the runtime — do not build a theme system. The preview injects

--- a/api/src/agent-skills/apps/SKILL.md
+++ b/api/src/agent-skills/apps/SKILL.md
@@ -95,26 +95,35 @@ Apps are React projects rendered live in a tab. You build them by editing files.
    `useDuckDB` calls. Data sources are also visible to the user under "Data sources" in the
    app's explorer tree.
 
-### Version history & checkpoints
+### Version history, drafts & publishing
 
-Apps autosave on every edit, so the running `version` counter is not a restore
-point. To create restorable history, save **explicit checkpoints**:
+Apps use a **draft → published** split:
 
-- `app_save_version` — freeze the app's current files, dependencies, and data
-  binding queries into an immutable checkpoint with a short `comment`. Do this
-  at meaningful milestones: before a risky refactor, after finishing a feature,
-  or whenever the user asks to "save"/"snapshot"/"checkpoint" the app.
+- The files/dependencies/bindings you edit are the working **draft**, autosaved
+  on every edit. Editors (and you) always see the draft in the preview.
+- **Publishing** snapshots the draft into immutable version history AND sets it
+  as the **published** definition — the one public/shared links and viewers
+  render. So a half-finished or in-progress draft is never shown to viewers
+  until you publish.
+
+Tools:
+
+- `app_save_version` — snapshot the current draft into history **and publish it**
+  (it becomes the viewer-facing version). Use at meaningful milestones (after
+  finishing a feature, before a risky refactor) and whenever the user asks to
+  "save"/"publish"/"snapshot" the app. Give a short `comment`.
 - `browse_version_history` with `entityType: "app"` and the `appId` — list past
-  checkpoints (who, when, comment, and `restoredFrom`). Use `get_version_snapshot`
-  to inspect a specific version's files before restoring.
-- `app_restore_version` — revert the app to a checkpoint by version number. The
-  current state is preserved as a new checkpoint first, so restoring is never
-  lossy. Open tabs reload the reverted app automatically. Binding materialization
-  artifacts are kept (the snapshot stores query definitions, not parquet caches).
+  versions (who, when, comment, `restoredFrom`). Use `get_version_snapshot` to
+  inspect a version's files before restoring.
+- `app_restore_version` — revert the **draft** to a past version by number. The
+  current draft is snapshotted first, so restoring is never lossy; it does NOT
+  auto-publish (publish afterward to push the restored state live). Open tabs
+  reload automatically. Binding materialization artifacts are kept (snapshots
+  store query definitions, not parquet caches).
 
-Good habit: call `app_save_version` with a descriptive comment right before
-making sweeping edits the user might want to undo, so there is always a clean
-point to roll back to.
+Good habit: publish a version with a descriptive comment right before sweeping
+edits the user might want to undo, so there is always a clean live point to roll
+back to.
 
 ### Theming & dark mode
 

--- a/api/src/agent-skills/dashboards/SKILL.md
+++ b/api/src/agent-skills/dashboards/SKILL.md
@@ -40,15 +40,15 @@ Before making any changes to a dashboard, you MUST call `enter_edit_mode` with t
 - If `enter_edit_mode` fails because the dashboard is read-only, inform the user that modifications are not possible.
 - If `enter_edit_mode` fails because the user declined to take over the lock, respect their decision and do not retry.
 - After making changes, do NOT auto-save or ask the user to save — they will save when ready. The dashboard remains in edit mode for the user to review your changes.
-- EXCEPTION: when the user explicitly asks to save / publish / snapshot the dashboard, call `save_dashboard_version` (with a short `comment`). This persists the working draft, creates a version, and publishes it — the published snapshot is what viewers and shared/public links render.
+- EXCEPTION: when the user explicitly asks to save / publish / snapshot the dashboard, call `dashboard_save_version` (with a short `comment`). This persists the working draft, creates a version, and publishes it — the published snapshot is what viewers and shared/public links render.
 
 ### Versioning & publishing (draft → published)
 
 Dashboards use a draft → published split:
 - The widgets/data sources/layout you edit are the working **draft**. Editors see the draft; viewers and shared/public links see the **published** version.
-- `save_dashboard_version` (requires edit mode) saves the draft to the server, snapshots it into history, AND publishes it. Use only when the user asks to save/publish.
+- `dashboard_save_version` (requires edit mode) saves the draft to the server, snapshots it into history, AND publishes it. Use only when the user asks to save/publish.
 - `browse_version_history` with `entityType: "dashboard"` and the `dashboardId` lists past versions (who, when, comment, `restoredFrom`); `get_version_snapshot` shows a version's full definition.
-- `restore_dashboard_version` reverts the draft to a past version and reloads the dashboard (never lossy — the current state is snapshotted first). It does NOT publish; call `save_dashboard_version` afterward to push the restored state live. It replaces unsaved edits in the open tab, so confirm with the user before restoring over unsaved work.
+- `dashboard_restore_version` reverts the draft to a past version and reloads the dashboard (never lossy — the current state is snapshotted first). It does NOT publish; call `dashboard_save_version` afterward to push the restored state live. It replaces unsaved edits in the open tab, so confirm with the user before restoring over unsaved work.
 
 ### Available Tools
 

--- a/api/src/agent-skills/dashboards/SKILL.md
+++ b/api/src/agent-skills/dashboards/SKILL.md
@@ -39,7 +39,16 @@ Before making any changes to a dashboard, you MUST call `enter_edit_mode` with t
 - If another user holds the lock, a confirmation dialog is shown to the user automatically — you do not need to handle this yourself.
 - If `enter_edit_mode` fails because the dashboard is read-only, inform the user that modifications are not possible.
 - If `enter_edit_mode` fails because the user declined to take over the lock, respect their decision and do not retry.
-- After making changes, do NOT ask the user to save — they will save when ready. The dashboard remains in edit mode for the user to review your changes.
+- After making changes, do NOT auto-save or ask the user to save — they will save when ready. The dashboard remains in edit mode for the user to review your changes.
+- EXCEPTION: when the user explicitly asks to save / publish / snapshot the dashboard, call `save_dashboard_version` (with a short `comment`). This persists the working draft, creates a version, and publishes it — the published snapshot is what viewers and shared/public links render.
+
+### Versioning & publishing (draft → published)
+
+Dashboards use a draft → published split:
+- The widgets/data sources/layout you edit are the working **draft**. Editors see the draft; viewers and shared/public links see the **published** version.
+- `save_dashboard_version` (requires edit mode) saves the draft to the server, snapshots it into history, AND publishes it. Use only when the user asks to save/publish.
+- `browse_version_history` with `entityType: "dashboard"` and the `dashboardId` lists past versions (who, when, comment, `restoredFrom`); `get_version_snapshot` shows a version's full definition.
+- `restore_dashboard_version` reverts the draft to a past version and reloads the dashboard (never lossy — the current state is snapshotted first). It does NOT publish; call `save_dashboard_version` afterward to push the restored state live. It replaces unsaved edits in the open tab, so confirm with the user before restoring over unsaved work.
 
 ### Available Tools
 

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -120,9 +120,10 @@ if none is open. Edit with \`app_write_file\` (always write the COMPLETE file co
 diff). Read workspace data through named data bindings (\`app_create_data_binding\`), never by
 embedding credentials in app code.
 
-Apps autosave on every edit. Mark restorable milestones with \`app_save_version\` (before risky
-refactors or when the user asks to save/snapshot), browse them via \`browse_version_history\`
-(\`entityType: "app"\`), and revert with \`app_restore_version\` — restoring is never lossy.
+Apps use a draft→published split: edits autosave to the draft; \`app_save_version\` snapshots the
+draft into history AND publishes it (what viewers/shared links render). Browse via
+\`browse_version_history\` (\`entityType: "app"\`); revert the draft with \`app_restore_version\`
+(never lossy; publish afterward to push the restored state live).
 
 For the full app-building workflow (data bindings, \`@mako/app-sdk\` hooks, materialized
 Parquet/DuckDB bindings, preview debugging, and runtime constraints), load the \`apps\`

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -120,6 +120,10 @@ if none is open. Edit with \`app_write_file\` (always write the COMPLETE file co
 diff). Read workspace data through named data bindings (\`app_create_data_binding\`), never by
 embedding credentials in app code.
 
+Apps autosave on every edit. Mark restorable milestones with \`app_save_version\` (before risky
+refactors or when the user asks to save/snapshot), browse them via \`browse_version_history\`
+(\`entityType: "app"\`), and revert with \`app_restore_version\` — restoring is never lossy.
+
 For the full app-building workflow (data bindings, \`@mako/app-sdk\` hooks, materialized
 Parquet/DuckDB bindings, preview debugging, and runtime constraints), load the \`apps\`
 system skill.`;

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -103,9 +103,9 @@ current IDs and pass that ID on every dashboard tool call. If no dashboard is op
 
 Dashboards use a draft→published split: edits stay in the working draft for the user to
 review (don't auto-save). Only when the user asks to save/publish, call
-\`save_dashboard_version\` (publishes the draft + snapshots it for viewers). Browse history
+\`dashboard_save_version\` (publishes the draft + snapshots it for viewers). Browse history
 with \`browse_version_history\` (\`entityType: "dashboard"\`) and revert with
-\`restore_dashboard_version\` (reverts the draft; publish afterward to push live).
+\`dashboard_restore_version\` (reverts the draft; publish afterward to push live).
 
 For dashboard creation, editing, widget SQL, Vega-Lite specs, layout, and cross-filtering
 guidance, load the \`dashboards\` system skill. If that skill points to a needed

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -101,6 +101,12 @@ Dashboard tools require an explicit \`dashboardId\`; use \`list_open_dashboards\
 current IDs and pass that ID on every dashboard tool call. If no dashboard is open, use
 \`create_dashboard\` or \`open_dashboard\` first. Widget \`localSql\` always runs in DuckDB.
 
+Dashboards use a draft→published split: edits stay in the working draft for the user to
+review (don't auto-save). Only when the user asks to save/publish, call
+\`save_dashboard_version\` (publishes the draft + snapshots it for viewers). Browse history
+with \`browse_version_history\` (\`entityType: "dashboard"\`) and revert with
+\`restore_dashboard_version\` (reverts the draft; publish afterward to push live).
+
 For dashboard creation, editing, widget SQL, Vega-Lite specs, layout, and cross-filtering
 guidance, load the \`dashboards\` system skill. If that skill points to a needed
 \`references/*.md\` file, use \`read_skill_resource\`.`;

--- a/api/src/agents/modes/registry.ts
+++ b/api/src/agents/modes/registry.ts
@@ -132,6 +132,8 @@ const APP_MODE_TOOL_NAMES: string[] = [
   "app_remove_dependency",
   "app_create_data_binding",
   "app_delete_data_binding",
+  "app_save_version",
+  "app_restore_version",
   "materialize_binding",
   "run_app",
   // Shared surface-scoped data-source primitives (apps + dashboards)

--- a/api/src/agents/modes/registry.ts
+++ b/api/src/agents/modes/registry.ts
@@ -90,8 +90,8 @@ const DASHBOARD_MODE_TOOL_NAMES: string[] = [
   "set_time_dimension",
   "get_chart_templates",
   "get_chart_template",
-  "save_dashboard_version",
-  "restore_dashboard_version",
+  "dashboard_save_version",
+  "dashboard_restore_version",
   "capture_screenshot",
   // Search + discovery for building data sources
   "search_dashboards",

--- a/api/src/agents/modes/registry.ts
+++ b/api/src/agents/modes/registry.ts
@@ -90,6 +90,8 @@ const DASHBOARD_MODE_TOOL_NAMES: string[] = [
   "set_time_dimension",
   "get_chart_templates",
   "get_chart_template",
+  "save_dashboard_version",
+  "restore_dashboard_version",
   "capture_screenshot",
   // Search + discovery for building data sources
   "search_dashboards",

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -3541,7 +3541,11 @@ export const Connector = mongoose.model<IConnector>(
  * EntityVersion — immutable append-only version snapshots for consoles and dashboards.
  * Every explicit save creates a new version record; history is never rewritten.
  */
-export type VersionableEntityType = "console" | "dashboard" | "dbt-file";
+export type VersionableEntityType =
+  | "console"
+  | "dashboard"
+  | "dbt-file"
+  | "app";
 
 export interface IEntityVersion extends Document {
   _id: Types.ObjectId;
@@ -3566,7 +3570,7 @@ const EntityVersionSchema = new Schema<IEntityVersion>(
     },
     entityType: {
       type: String,
-      enum: ["console", "dashboard", "dbt-file"],
+      enum: ["console", "dashboard", "dbt-file", "app"],
       required: true,
     },
     entityId: {

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -3763,6 +3763,17 @@ export interface IMakoApp extends Document {
   dependencies: Record<string, string>;
   dataBindings: IMakoAppDataBinding[];
   version: number;
+  /**
+   * Last published definition snapshot (draft/published split). The top-level
+   * fields above are the working DRAFT (autosaved on every edit); `published`
+   * is the committed definition that public/shared viewers render. Absent until
+   * the app is first published — readers fall back to the draft for back-compat.
+   * Shape matches `buildAppSnapshot` (no server-owned binding `cache`).
+   */
+  published?: Record<string, unknown>;
+  /** EntityVersion number that was published into `published`. */
+  publishedVersion?: number;
+  publishedAt?: Date;
   access: "private" | "workspace";
   /** Role granted to workspace members when access is "workspace". */
   workspaceRole?: ResourceShareRole;
@@ -3871,6 +3882,12 @@ const MakoAppSchema = new Schema<IMakoApp>(
     dependencies: { type: Schema.Types.Mixed, default: {} },
     dataBindings: { type: [MakoAppDataBindingSchema], default: [] },
     version: { type: Number, default: 1 },
+    // Draft/published split: `published` holds the last committed definition
+    // snapshot (Mixed — same shape as buildAppSnapshot). Public/shared viewers
+    // render this; the top-level fields are the working draft.
+    published: { type: Schema.Types.Mixed, default: undefined },
+    publishedVersion: { type: Number },
+    publishedAt: { type: Date },
     access: {
       type: String,
       enum: ["private", "workspace"],

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -3110,6 +3110,19 @@ export interface IDashboard extends Document {
     expiresAt: Date;
   };
 
+  /**
+   * Last published definition snapshot (draft/published split, mirrors
+   * MakoApp). The top-level definition fields are the working draft; `published`
+   * is what public/shared viewers render. Set on every explicit save (which
+   * also creates a version); a restore reverts the draft only, leaving
+   * `published` until the next save. Absent until first save — readers fall
+   * back to the live definition for back-compat. Shape = buildDashboardSnapshot.
+   */
+  published?: Record<string, unknown>;
+  /** EntityVersion number that was published into `published`. */
+  publishedVersion?: number;
+  publishedAt?: Date;
+
   folderId?: Types.ObjectId;
   access: "private" | "workspace";
   /** Role granted to workspace members when access is "workspace". */
@@ -3440,6 +3453,13 @@ const DashboardSchema = new Schema<IDashboard>(
       lockedAt: { type: Date },
       expiresAt: { type: Date },
     },
+
+    // Draft/published split (mirrors MakoApp): `published` holds the last
+    // committed definition snapshot (Mixed — same shape as
+    // buildDashboardSnapshot). Public/shared viewers render this.
+    published: { type: Schema.Types.Mixed, default: undefined },
+    publishedVersion: { type: Number },
+    publishedAt: { type: Date },
 
     folderId: {
       type: Schema.Types.ObjectId,

--- a/api/src/routes/apps.ts
+++ b/api/src/routes/apps.ts
@@ -33,6 +33,7 @@ import { getDashboardArtifactStore } from "../services/dashboard-artifact-store.
 import {
   buildAppSnapshot,
   applyAppSnapshot,
+  appHasUnpublishedChanges,
   type AppSnapshot,
 } from "../services/app-version.service";
 import {
@@ -161,6 +162,9 @@ function serializeApp(doc: IMakoApp) {
         : undefined,
     })) as Array<Record<string, any>>,
     version: doc.version,
+    publishedVersion: doc.publishedVersion,
+    publishedAt: doc.publishedAt,
+    hasUnpublishedChanges: appHasUnpublishedChanges(doc),
     access: doc.access,
     workspaceRole: doc.workspaceRole ?? "viewer",
     sharedWith: (doc.sharedWith ?? []).map(s => ({
@@ -861,19 +865,30 @@ app.openapi(
         comment?: string;
       };
       const displayName = await getUserDisplayName(userId ?? "system");
+      const snapshot = buildAppSnapshot(doc);
       const created = await createVersion({
         entityType: "app",
         entityId: doc._id,
         workspaceId: new Types.ObjectId(workspaceId),
-        snapshot: buildAppSnapshot(doc) as unknown as Record<string, unknown>,
+        snapshot: snapshot as unknown as Record<string, unknown>,
         savedBy: userId ?? "system",
         savedByName: displayName,
         comment: (body.comment ?? "").slice(0, 500),
       });
 
+      // Saving a version publishes it: the snapshot becomes the definition that
+      // public/shared viewers render. The working draft (top-level fields) is
+      // unchanged; it simply now matches `published`.
+      doc.published = snapshot as unknown as Record<string, unknown>;
+      doc.markModified("published"); // Mixed type: assignment isn't auto-tracked
+      doc.publishedVersion = created.version;
+      doc.publishedAt = new Date();
+      await doc.save();
+
       return c.json({
         success: true,
         version: created.version,
+        publishedVersion: created.version,
         createdAt: created.createdAt,
       });
     } catch (error) {

--- a/api/src/routes/apps.ts
+++ b/api/src/routes/apps.ts
@@ -31,6 +31,18 @@ import {
 } from "../services/app-binding-materialization.service";
 import { getDashboardArtifactStore } from "../services/dashboard-artifact-store.service";
 import {
+  buildAppSnapshot,
+  applyAppSnapshot,
+  type AppSnapshot,
+} from "../services/app-version.service";
+import {
+  createVersion,
+  listVersions,
+  getVersion,
+  getUserDisplayName,
+} from "../services/entity-version.service";
+import { publishRealtimeEvent } from "../services/realtime.service";
+import {
   canReadResource,
   canWriteResource,
   canManageSharing,
@@ -756,6 +768,254 @@ app.openapi(
     } catch (error) {
       logger.error("Error serving app binding artifact", { error });
       return c.json({ success: false, error: "Failed to serve artifact" }, 500);
+    }
+  },
+);
+
+// ── Version history (explicit checkpoints) ──
+//
+// Apps autosave on every edit, so versions are explicit checkpoints rather
+// than per-save snapshots: POST creates one, restore reverts to one (and
+// records a fresh checkpoint with `restoredFrom`). Snapshots freeze the
+// editable definition (files + deps + binding queries); the server-owned
+// materialization cache is preserved by binding id on restore.
+
+// GET /{id}/versions — list checkpoints (newest first)
+app.openapi(
+  createRoute({
+    method: "get",
+    path: "/{id}/versions",
+    tags: ["Apps"],
+    summary: "List app versions",
+    security: AUTH_SECURITY,
+    request: {
+      params: AppIdParam,
+      query: z.object({
+        limit: z.string().optional(),
+        offset: z.string().optional(),
+      }),
+    },
+    responses: { ...OPEN_RESPONSES },
+  }),
+  async c => {
+    try {
+      const workspaceId = c.req.param("workspaceId") as string;
+      const id = c.req.param("id");
+      const userId = c.get("user")?.id;
+      if (!Types.ObjectId.isValid(id)) {
+        return c.json({ success: false, error: "Invalid app ID" }, 400);
+      }
+      const doc = await MakoApp.findOne({
+        _id: new Types.ObjectId(id),
+        workspaceId: new Types.ObjectId(workspaceId),
+      });
+      if (!doc) return c.json({ success: false, error: "App not found" }, 404);
+      if (!canRead(doc, userId, c.get("memberRole"))) {
+        return c.json({ success: false, error: "Access denied" }, 403);
+      }
+
+      const limit = Math.min(parseInt(c.req.query("limit") ?? "50", 10) || 50, 100);
+      const offset = parseInt(c.req.query("offset") ?? "0", 10) || 0;
+      const result = await listVersions(new Types.ObjectId(id), "app", {
+        limit,
+        offset,
+        workspaceId: new Types.ObjectId(workspaceId),
+      });
+      return c.json({ success: true, ...result });
+    } catch (error) {
+      logger.error("Error listing app versions", { error });
+      return c.json({ success: false, error: "Failed to list versions" }, 500);
+    }
+  },
+);
+
+// POST /{id}/versions — create a checkpoint of the current app state
+app.openapi(
+  createRoute({
+    method: "post",
+    path: "/{id}/versions",
+    tags: ["Apps"],
+    summary: "Save an app version checkpoint",
+    security: AUTH_SECURITY,
+    request: { params: AppIdParam, body: AppBody },
+    responses: { ...OPEN_RESPONSES },
+  }),
+  async c => {
+    try {
+      const workspaceId = c.req.param("workspaceId") as string;
+      const id = c.req.param("id");
+      const userId = c.get("user")?.id;
+      if (!Types.ObjectId.isValid(id)) {
+        return c.json({ success: false, error: "Invalid app ID" }, 400);
+      }
+      const doc = await MakoApp.findOne({
+        _id: new Types.ObjectId(id),
+        workspaceId: new Types.ObjectId(workspaceId),
+      });
+      if (!doc) return c.json({ success: false, error: "App not found" }, 404);
+      if (!canManage(doc, userId, c.get("memberRole"))) {
+        return c.json({ success: false, error: "Access denied" }, 403);
+      }
+
+      const body = (await c.req.json().catch(() => ({}))) as {
+        comment?: string;
+      };
+      const displayName = await getUserDisplayName(userId ?? "system");
+      const created = await createVersion({
+        entityType: "app",
+        entityId: doc._id,
+        workspaceId: new Types.ObjectId(workspaceId),
+        snapshot: buildAppSnapshot(doc) as unknown as Record<string, unknown>,
+        savedBy: userId ?? "system",
+        savedByName: displayName,
+        comment: (body.comment ?? "").slice(0, 500),
+      });
+
+      return c.json({
+        success: true,
+        version: created.version,
+        createdAt: created.createdAt,
+      });
+    } catch (error) {
+      logger.error("Error saving app version", { error });
+      return c.json({ success: false, error: "Failed to save version" }, 500);
+    }
+  },
+);
+
+// GET /{id}/versions/{version} — full snapshot of one checkpoint
+app.openapi(
+  createRoute({
+    method: "get",
+    path: "/{id}/versions/{version}",
+    tags: ["Apps"],
+    summary: "Get an app version snapshot",
+    security: AUTH_SECURITY,
+    request: {
+      params: AppIdParam.extend({
+        version: z.string().openapi({ param: { name: "version", in: "path" } }),
+      }),
+    },
+    responses: { ...OPEN_RESPONSES },
+  }),
+  async c => {
+    try {
+      const workspaceId = c.req.param("workspaceId") as string;
+      const id = c.req.param("id");
+      const versionNum = parseInt(c.req.param("version"), 10);
+      const userId = c.get("user")?.id;
+      if (!Types.ObjectId.isValid(id) || Number.isNaN(versionNum)) {
+        return c.json({ success: false, error: "Invalid request" }, 400);
+      }
+      const doc = await MakoApp.findOne({
+        _id: new Types.ObjectId(id),
+        workspaceId: new Types.ObjectId(workspaceId),
+      });
+      if (!doc) return c.json({ success: false, error: "App not found" }, 404);
+      if (!canRead(doc, userId, c.get("memberRole"))) {
+        return c.json({ success: false, error: "Access denied" }, 403);
+      }
+      const version = await getVersion(
+        id,
+        "app",
+        versionNum,
+        new Types.ObjectId(workspaceId),
+      );
+      if (!version) {
+        return c.json({ success: false, error: "Version not found" }, 404);
+      }
+      return c.json({ success: true, version });
+    } catch (error) {
+      logger.error("Error fetching app version", { error });
+      return c.json({ success: false, error: "Failed to fetch version" }, 500);
+    }
+  },
+);
+
+// POST /{id}/versions/{version}/restore — revert the app to a checkpoint
+app.openapi(
+  createRoute({
+    method: "post",
+    path: "/{id}/versions/{version}/restore",
+    tags: ["Apps"],
+    summary: "Restore an app version",
+    security: AUTH_SECURITY,
+    request: {
+      params: AppIdParam.extend({
+        version: z.string().openapi({ param: { name: "version", in: "path" } }),
+      }),
+      body: AppBody,
+    },
+    responses: { ...OPEN_RESPONSES },
+  }),
+  async c => {
+    try {
+      const workspaceId = c.req.param("workspaceId") as string;
+      const id = c.req.param("id");
+      const versionNum = parseInt(c.req.param("version"), 10);
+      const userId = c.get("user")?.id;
+      if (!Types.ObjectId.isValid(id) || Number.isNaN(versionNum)) {
+        return c.json({ success: false, error: "Invalid request" }, 400);
+      }
+      const doc = await MakoApp.findOne({
+        _id: new Types.ObjectId(id),
+        workspaceId: new Types.ObjectId(workspaceId),
+      });
+      if (!doc) return c.json({ success: false, error: "App not found" }, 404);
+      if (!canManage(doc, userId, c.get("memberRole"))) {
+        return c.json({ success: false, error: "Access denied" }, 403);
+      }
+      const old = await getVersion(
+        id,
+        "app",
+        versionNum,
+        new Types.ObjectId(workspaceId),
+      );
+      if (!old) {
+        return c.json({ success: false, error: "Version not found" }, 404);
+      }
+
+      applyAppSnapshot(doc, old.snapshot as unknown as AppSnapshot);
+      doc.version += 1;
+      await doc.save();
+
+      // Record the restore as a fresh checkpoint so history stays append-only.
+      const body = (await c.req.json().catch(() => ({}))) as {
+        comment?: string;
+      };
+      const displayName = await getUserDisplayName(userId ?? "system");
+      await createVersion({
+        entityType: "app",
+        entityId: doc._id,
+        workspaceId: new Types.ObjectId(workspaceId),
+        snapshot: buildAppSnapshot(doc) as unknown as Record<string, unknown>,
+        savedBy: userId ?? "system",
+        savedByName: displayName,
+        comment:
+          (body.comment ?? `Restored from version ${versionNum}`).slice(0, 500),
+        restoredFrom: versionNum,
+      });
+
+      // Poke open tabs so they pull the reverted definition and rebuild preview.
+      publishRealtimeEvent(workspaceId, {
+        type: "app.updated",
+        appId: doc._id.toString(),
+        version: doc.version,
+        updatedBy: userId ?? "system",
+        origin: "save",
+      });
+
+      return c.json({
+        success: true,
+        message: `Restored to version ${versionNum}`,
+        app: serializeApp(doc),
+      });
+    } catch (error) {
+      logger.error("Error restoring app version", { error });
+      return c.json(
+        { success: false, error: "Failed to restore version" },
+        500,
+      );
     }
   },
 );

--- a/api/src/routes/dashboards.ts
+++ b/api/src/routes/dashboards.ts
@@ -19,6 +19,8 @@ import {
   buildTableRef,
 } from "@mako/schemas";
 import { hydrateDashboardArtifactUrls } from "../services/dashboard-cache.service";
+import { snapshotsEqual } from "../services/snapshot-diff";
+import { publishRealtimeEvent } from "../services/realtime.service";
 import { buildDashboardDataSourceDefinitionHash } from "../services/dashboard-artifact-rebuild.service";
 import {
   isDashboardMaterializationEnabled,
@@ -292,6 +294,35 @@ function buildDashboardSnapshot(
   };
 }
 
+/**
+ * True when the working definition differs from the last published snapshot
+ * (or the dashboard was never published). Drives the "unpublished changes" hint
+ * so editors know the live/shared version is behind the working draft (e.g.
+ * after a restore, which reverts the draft without publishing).
+ */
+function dashboardHasUnpublishedChanges(
+  doc: IDashboard | Record<string, any>,
+): boolean {
+  if (!doc.published) return true;
+  return !snapshotsEqual(buildDashboardSnapshot(doc), doc.published);
+}
+
+/**
+ * Publish the current definition: stamp it onto a (Mongoose) dashboard doc as
+ * the viewer-facing `published` snapshot at the given version, and persist.
+ * Call after createVersion on every explicit save.
+ */
+async function publishDashboard(
+  doc: IDashboard,
+  version: number,
+): Promise<void> {
+  doc.published = buildDashboardSnapshot(doc.toObject());
+  doc.markModified("published"); // Mixed: assignment isn't auto-tracked
+  doc.publishedVersion = version;
+  doc.publishedAt = new Date();
+  await doc.save();
+}
+
 async function normalizeDashboardDataSources(
   workspaceId: string,
   inputDataSources: unknown,
@@ -445,6 +476,10 @@ function sanitizeDashboardResponse<
   delete dashboard.materializationMode;
   // Never leak the password hash; expose only safe public-share metadata.
   const loose = dashboard as Record<string, any>;
+  // Draft/published: expose a cheap dirty flag, then drop the (large) published
+  // snapshot from the editor payload — editors render the live draft fields.
+  loose.hasUnpublishedChanges = dashboardHasUnpublishedChanges(loose);
+  delete loose.published;
   if (loose.publicShare && typeof loose.publicShare === "object") {
     const ps = loose.publicShare as Record<string, unknown>;
     if (ps.enabled && ps.token) {
@@ -715,9 +750,9 @@ app.openapi(
 
       await dashboard.save();
 
-      // Create version 1 for the new dashboard
+      // Create version 1 for the new dashboard and publish it.
       const displayName = await getUserDisplayName(userId);
-      await createVersion({
+      const createdVersion = await createVersion({
         entityType: "dashboard",
         entityId: dashboard._id,
         workspaceId: new Types.ObjectId(workspaceId),
@@ -726,6 +761,7 @@ app.openapi(
         savedByName: displayName,
         comment: body.comment ?? "",
       });
+      await publishDashboard(dashboard, createdVersion.version);
 
       if (
         (dashboard.dataSources || []).length > 0 &&
@@ -1029,7 +1065,7 @@ app.openapi(
 
       // Create version record for the new state
       const putDisplayName = await getUserDisplayName(userId);
-      await createVersion({
+      const putVersion = await createVersion({
         entityType: "dashboard",
         entityId: updated._id,
         workspaceId: new Types.ObjectId(workspaceId),
@@ -1037,6 +1073,18 @@ app.openapi(
         savedBy: userId,
         savedByName: putDisplayName,
         comment: body.comment ?? "",
+      });
+      // A full update is a publish.
+      await publishDashboard(updated, putVersion.version);
+
+      publishRealtimeEvent(workspaceId, {
+        type: "dashboard.updated",
+        dashboardId: updated._id.toString(),
+        version: updated.version,
+        updatedBy: userId,
+        clientId:
+          typeof body.clientId === "string" ? body.clientId : undefined,
+        origin: "save",
       });
 
       if (
@@ -1262,7 +1310,7 @@ app.openapi(
 
       if (typeof body.comment === "string") {
         const patchDisplayName = await getUserDisplayName(userId);
-        await createVersion({
+        const createdVersion = await createVersion({
           entityType: "dashboard",
           entityId: dashboard._id,
           workspaceId: new Types.ObjectId(workspaceId),
@@ -1271,7 +1319,20 @@ app.openapi(
           savedByName: patchDisplayName,
           comment: body.comment,
         });
+        // Explicit save publishes: the snapshot becomes the viewer-facing def.
+        await publishDashboard(dashboard, createdVersion.version);
       }
+
+      // Poke open tabs (poke-then-pull) so other viewers reload the saved def.
+      publishRealtimeEvent(workspaceId, {
+        type: "dashboard.updated",
+        dashboardId: dashboard._id.toString(),
+        version: dashboard.version,
+        updatedBy: userId,
+        clientId:
+          typeof body.clientId === "string" ? body.clientId : undefined,
+        origin: "save",
+      });
 
       if (
         didDashboardArtifactInputsChange(
@@ -2567,6 +2628,17 @@ app.openapi(
         savedByName: displayName,
         comment,
         restoredFrom: versionNum,
+      });
+
+      // Restore reverts the working draft only (no publish): public/shared
+      // viewers keep seeing the published version until the next explicit save.
+      // Poke open editor tabs so they reload the reverted draft.
+      publishRealtimeEvent(workspaceId, {
+        type: "dashboard.updated",
+        dashboardId: restored._id.toString(),
+        version: restored.version,
+        updatedBy: userId,
+        origin: "save",
       });
 
       return c.json({

--- a/api/src/routes/public-share.ts
+++ b/api/src/routes/public-share.ts
@@ -166,12 +166,33 @@ async function buildDashboardContent(token: string, dashboard: IDashboard) {
   const workspaceId = dashboard.workspaceId.toString();
   const dashboardId = dashboard._id.toString();
 
+  // Render the PUBLISHED definition (draft/published split) so a public viewer
+  // never sees a half-edited or restored-but-unpublished draft. Fall back to
+  // the live definition for dashboards that were never published (back-compat).
+  const def = (dashboard.published as Record<string, any> | undefined) ?? {
+    title: dashboard.title,
+    description: dashboard.description,
+    widgets: dashboard.widgets,
+    globalFilters: dashboard.globalFilters,
+    relationships: dashboard.relationships,
+    crossFilter: dashboard.crossFilter,
+    layout: dashboard.layout,
+    dataSources: dashboard.dataSources,
+  };
+
+  // Materialization artifacts are server-owned and keyed by data-source id, so
+  // compute status from the LIVE data source when present (freshest), falling
+  // back to the published snapshot's definition.
+  const liveDsById = new Map(
+    (dashboard.dataSources || []).map(ds => [String(ds.id), ds]),
+  );
   const dataSources = await Promise.all(
-    (dashboard.dataSources || []).map(async ds => {
+    ((def.dataSources as Array<Record<string, any>>) || []).map(async ds => {
+      const liveDs = liveDsById.get(String(ds.id)) ?? ds;
       const status = await buildDataSourceMaterializationStatus({
         workspaceId,
         dashboardId,
-        dataSource: ds,
+        dataSource: liveDs as any,
       });
       const ready = status.status === "ready" && !!status.artifactKey;
       return {
@@ -184,7 +205,7 @@ async function buildDashboardContent(token: string, dashboard: IDashboard) {
         rowCount: status.rowCount,
         materializedAt: status.builtAt || status.lastMaterializedAt,
         artifactUrl: ready
-          ? `/api/share/${token}/artifacts/${encodeURIComponent(ds.id)}?rev=${encodeURIComponent(status.artifactRevision || "")}`
+          ? `/api/share/${token}/artifacts/${encodeURIComponent(String(ds.id))}?rev=${encodeURIComponent(status.artifactRevision || "")}`
           : null,
       };
     }),
@@ -192,13 +213,13 @@ async function buildDashboardContent(token: string, dashboard: IDashboard) {
 
   return {
     type: "dashboard" as const,
-    title: dashboard.title,
-    description: dashboard.description,
-    widgets: dashboard.widgets,
-    globalFilters: dashboard.globalFilters,
-    relationships: dashboard.relationships,
-    crossFilter: dashboard.crossFilter,
-    layout: dashboard.layout,
+    title: def.title,
+    description: def.description,
+    widgets: def.widgets,
+    globalFilters: def.globalFilters,
+    relationships: def.relationships,
+    crossFilter: def.crossFilter,
+    layout: def.layout,
     dataSources,
     refresh: {
       cooldownMs: PUBLIC_REFRESH_COOLDOWN_MS,

--- a/api/src/routes/public-share.ts
+++ b/api/src/routes/public-share.ts
@@ -27,6 +27,10 @@ import {
   type IMakoApp,
 } from "../database/workspace-schema";
 import { loggers } from "../logging";
+import {
+  buildAppSnapshot,
+  type AppSnapshot,
+} from "../services/app-version.service";
 import { buildDataSourceMaterializationStatus } from "../services/dashboard-materialization.service";
 import { queueDashboardArtifactRefresh } from "../services/dashboard-refresh-runner.service";
 import { getDashboardArtifactStore } from "../services/dashboard-artifact-store.service";
@@ -205,30 +209,42 @@ async function buildDashboardContent(token: string, dashboard: IDashboard) {
 }
 
 function buildAppContent(token: string, makoApp: IMakoApp) {
+  // Render the PUBLISHED definition (draft/published split) so a public viewer
+  // never sees half-edited or agent-in-progress work. Fall back to the live
+  // draft for apps that were never published (back-compat).
+  const def = (makoApp.published as AppSnapshot | undefined) ??
+    buildAppSnapshot(makoApp);
+  // Materialization artifacts are server-owned and keyed by binding id, so we
+  // hydrate artifact URLs from the LIVE binding caches (the published snapshot
+  // intentionally excludes `cache`).
+  const liveCacheById = new Map(
+    (makoApp.dataBindings || []).map(b => [b.id, b.cache]),
+  );
   return {
     type: "app" as const,
-    title: makoApp.title,
-    description: makoApp.description,
-    entrypoint: makoApp.entrypoint,
-    files: (makoApp.files || []).map(f => ({
+    title: def.title,
+    description: def.description,
+    entrypoint: def.entrypoint,
+    files: (def.files || []).map(f => ({
       path: f.path,
       contents: f.contents,
     })),
-    dependencies: makoApp.dependencies || {},
-    dataBindings: (makoApp.dataBindings || []).map(b => {
+    dependencies: def.dependencies || {},
+    dataBindings: (def.dataBindings || []).map(b => {
+      const cache = liveCacheById.get(b.id as string);
       const ready =
         b.materialization === "parquet" &&
-        b.cache?.parquetBuildStatus === "ready" &&
-        !!b.cache?.parquetArtifactKey;
+        cache?.parquetBuildStatus === "ready" &&
+        !!cache?.parquetArtifactKey;
       return {
         id: b.id,
         name: b.name,
         materialization: b.materialization ?? "live",
         ready,
-        rowCount: b.cache?.rowCount ?? null,
-        materializedAt: b.cache?.parquetBuiltAt ?? null,
+        rowCount: cache?.rowCount ?? null,
+        materializedAt: cache?.parquetBuiltAt ?? null,
         artifactUrl: ready
-          ? `/api/share/${token}/artifacts/${encodeURIComponent(b.id)}?rev=${encodeURIComponent(b.cache?.artifactRevision || "")}`
+          ? `/api/share/${token}/artifacts/${encodeURIComponent(String(b.id))}?rev=${encodeURIComponent(cache?.artifactRevision || "")}`
           : null,
       };
     }),

--- a/api/src/services/app-version.service.ts
+++ b/api/src/services/app-version.service.ts
@@ -1,0 +1,89 @@
+/**
+ * App version snapshots.
+ *
+ * React Apps autosave on every edit (each PUT bumps `MakoApp.version`), so
+ * unlike consoles we do NOT snapshot on every write — that would bury real
+ * checkpoints under hundreds of keystroke-level versions. Instead, app
+ * versions are *explicit checkpoints*: a user clicks "Save version" or the
+ * agent calls `app_save_version`, and we freeze the editable app definition
+ * into an immutable `EntityVersion` (entityType "app").
+ *
+ * `buildAppSnapshot` captures the editable definition only. `applyAppSnapshot`
+ * reverts a doc to a snapshot while preserving the server-owned binding
+ * materialization `cache` by id (mirrors the PUT /apps/:id contract), so a
+ * restore never resurrects a stale parquet artifact pointer or drops a fresh
+ * one.
+ */
+import type { IMakoApp } from "../database/workspace-schema";
+
+/** The editable body of an app, frozen into a version snapshot (no caches). */
+export interface AppSnapshot {
+  title: string;
+  description?: string;
+  template: string;
+  runtime: "cdn" | "webcontainer";
+  entrypoint: string;
+  files: Array<{ path: string; contents: string }>;
+  dependencies: Record<string, string>;
+  dataBindings: Array<Record<string, unknown>>;
+}
+
+/** Freeze the current editable definition of an app into a snapshot. */
+export function buildAppSnapshot(doc: IMakoApp): AppSnapshot {
+  return {
+    title: doc.title,
+    description: doc.description,
+    template: doc.template,
+    runtime: doc.runtime,
+    entrypoint: doc.entrypoint,
+    files: (doc.files ?? []).map(f => ({ path: f.path, contents: f.contents })),
+    dependencies: { ...(doc.dependencies ?? {}) },
+    // Binding query definitions only — `cache` is server-owned and excluded.
+    dataBindings: (doc.dataBindings ?? []).map(b => ({
+      id: b.id,
+      name: b.name,
+      connectionId: b.connectionId,
+      language: b.language,
+      code: b.code,
+      databaseId: b.databaseId,
+      databaseName: b.databaseName,
+      materialization: b.materialization ?? "live",
+      materializationSchedule: b.materializationSchedule,
+    })),
+  };
+}
+
+/**
+ * Revert `doc` to `snapshot` in place. Binding materialization caches are
+ * preserved by binding id so a restore re-points at the same artifacts the
+ * server already built (and a binding that did not exist before simply has no
+ * cache). The caller is responsible for bumping `version` and saving.
+ */
+export function applyAppSnapshot(doc: IMakoApp, snapshot: AppSnapshot): void {
+  doc.title = snapshot.title;
+  doc.description = snapshot.description;
+  doc.template = snapshot.template;
+  doc.runtime = snapshot.runtime;
+  doc.entrypoint = snapshot.entrypoint;
+  doc.files = (snapshot.files ?? []).map(f => ({
+    path: f.path,
+    contents: f.contents,
+  })) as IMakoApp["files"];
+  doc.dependencies = { ...(snapshot.dependencies ?? {}) };
+
+  const cacheById = new Map(
+    (doc.dataBindings ?? []).map(b => [b.id, b.cache]),
+  );
+  doc.dataBindings = (snapshot.dataBindings ?? []).map(b => ({
+    id: b.id as string,
+    name: b.name as string,
+    connectionId: b.connectionId as string,
+    language: (b.language as "sql" | "javascript" | "mongodb") || "sql",
+    code: (b.code as string) ?? "",
+    databaseId: b.databaseId as string | undefined,
+    databaseName: b.databaseName as string | undefined,
+    materialization: b.materialization === "parquet" ? "parquet" : "live",
+    materializationSchedule: b.materializationSchedule,
+    cache: cacheById.get(b.id as string),
+  })) as IMakoApp["dataBindings"];
+}

--- a/api/src/services/app-version.service.ts
+++ b/api/src/services/app-version.service.ts
@@ -28,6 +28,49 @@ export interface AppSnapshot {
   dataBindings: Array<Record<string, unknown>>;
 }
 
+/**
+ * Canonicalize a snapshot for comparison. Mongoose `minimize` (on by default)
+ * strips empty objects (e.g. `dependencies: {}`) when persisting the Mixed
+ * `published` field, so a naive JSON compare against a freshly-built draft
+ * snapshot reports phantom differences. Recursively drop `undefined` and empty
+ * objects and sort object keys so both sides normalize identically.
+ */
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      const v = canonicalize((value as Record<string, unknown>)[key]);
+      if (v === undefined) continue;
+      if (v && typeof v === "object" && !Array.isArray(v) &&
+        Object.keys(v).length === 0) {
+        continue; // drop empty objects (Mongoose minimize parity)
+      }
+      out[key] = v;
+    }
+    return out;
+  }
+  return value;
+}
+
+/** Stable JSON used to compare a draft against its published snapshot. */
+function stableSnapshotJson(snapshot: unknown): string {
+  return JSON.stringify(canonicalize(snapshot ?? null));
+}
+
+/**
+ * True when the working draft differs from the last published snapshot (or the
+ * app has never been published). Drives the "unpublished changes" hint in the
+ * editor so users know the live/shared version is behind the draft.
+ */
+export function appHasUnpublishedChanges(doc: IMakoApp): boolean {
+  if (!doc.published) return true;
+  return (
+    stableSnapshotJson(buildAppSnapshot(doc)) !==
+    stableSnapshotJson(doc.published)
+  );
+}
+
 /** Freeze the current editable definition of an app into a snapshot. */
 export function buildAppSnapshot(doc: IMakoApp): AppSnapshot {
   return {
@@ -86,4 +129,6 @@ export function applyAppSnapshot(doc: IMakoApp, snapshot: AppSnapshot): void {
     materializationSchedule: b.materializationSchedule,
     cache: cacheById.get(b.id as string),
   })) as IMakoApp["dataBindings"];
+  // `dependencies` is a Mixed path — assignment isn't auto-tracked by Mongoose.
+  doc.markModified("dependencies");
 }

--- a/api/src/services/app-version.service.ts
+++ b/api/src/services/app-version.service.ts
@@ -15,6 +15,7 @@
  * one.
  */
 import type { IMakoApp } from "../database/workspace-schema";
+import { snapshotsEqual } from "./snapshot-diff";
 
 /** The editable body of an app, frozen into a version snapshot (no caches). */
 export interface AppSnapshot {
@@ -29,46 +30,13 @@ export interface AppSnapshot {
 }
 
 /**
- * Canonicalize a snapshot for comparison. Mongoose `minimize` (on by default)
- * strips empty objects (e.g. `dependencies: {}`) when persisting the Mixed
- * `published` field, so a naive JSON compare against a freshly-built draft
- * snapshot reports phantom differences. Recursively drop `undefined` and empty
- * objects and sort object keys so both sides normalize identically.
- */
-function canonicalize(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(canonicalize);
-  if (value && typeof value === "object") {
-    const out: Record<string, unknown> = {};
-    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
-      const v = canonicalize((value as Record<string, unknown>)[key]);
-      if (v === undefined) continue;
-      if (v && typeof v === "object" && !Array.isArray(v) &&
-        Object.keys(v).length === 0) {
-        continue; // drop empty objects (Mongoose minimize parity)
-      }
-      out[key] = v;
-    }
-    return out;
-  }
-  return value;
-}
-
-/** Stable JSON used to compare a draft against its published snapshot. */
-function stableSnapshotJson(snapshot: unknown): string {
-  return JSON.stringify(canonicalize(snapshot ?? null));
-}
-
-/**
  * True when the working draft differs from the last published snapshot (or the
  * app has never been published). Drives the "unpublished changes" hint in the
  * editor so users know the live/shared version is behind the draft.
  */
 export function appHasUnpublishedChanges(doc: IMakoApp): boolean {
   if (!doc.published) return true;
-  return (
-    stableSnapshotJson(buildAppSnapshot(doc)) !==
-    stableSnapshotJson(doc.published)
-  );
+  return !snapshotsEqual(buildAppSnapshot(doc), doc.published);
 }
 
 /** Freeze the current editable definition of an app into a snapshot. */

--- a/api/src/services/snapshot-diff.ts
+++ b/api/src/services/snapshot-diff.ts
@@ -1,0 +1,40 @@
+/**
+ * Snapshot comparison helper shared by the apps and dashboards draft/published
+ * splits.
+ *
+ * Mongoose `minimize` (on by default) strips empty objects (e.g.
+ * `dependencies: {}`) when persisting a Mixed `published` field, so a naive
+ * JSON compare against a freshly-built draft snapshot reports phantom
+ * differences. `canonicalizeSnapshot` recursively drops `undefined`/`null` and
+ * empty objects and sorts object keys so both sides normalize identically.
+ */
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      const v = canonicalize((value as Record<string, unknown>)[key]);
+      if (v === undefined || v === null) continue;
+      if (
+        v &&
+        typeof v === "object" &&
+        !Array.isArray(v) &&
+        Object.keys(v).length === 0
+      ) {
+        continue; // drop empty objects (Mongoose minimize parity)
+      }
+      out[key] = v;
+    }
+    return out;
+  }
+  return value;
+}
+
+export function canonicalizeSnapshot(snapshot: unknown): string {
+  return JSON.stringify(canonicalize(snapshot ?? null));
+}
+
+/** True when two snapshots are equal after canonicalization. */
+export function snapshotsEqual(a: unknown, b: unknown): boolean {
+  return canonicalizeSnapshot(a) === canonicalizeSnapshot(b);
+}

--- a/app/src/agent-runtime/client-tool-manifest.ts
+++ b/app/src/agent-runtime/client-tool-manifest.ts
@@ -388,6 +388,32 @@ export const AGENT_TOOL_MANIFEST = {
     getLabel: () => "Reading chart template",
     icon: "eye",
   },
+  save_dashboard_version: {
+    domain: "dashboard",
+    execution: "client",
+    clientExecutor: "dashboard",
+    longRunning: true,
+    getLabel: input => {
+      const comment = (input as Record<string, unknown>)?.comment;
+      return comment
+        ? `Publishing version: "${comment}"`
+        : "Publishing dashboard version";
+    },
+    icon: "clock",
+  },
+  restore_dashboard_version: {
+    domain: "dashboard",
+    execution: "client",
+    clientExecutor: "dashboard",
+    longRunning: true,
+    getLabel: input => {
+      const version = (input as Record<string, unknown>)?.version;
+      return version
+        ? `Restoring version ${version}`
+        : "Restoring dashboard version";
+    },
+    icon: "clock",
+  },
   list_open_apps: {
     domain: "app",
     execution: "client",

--- a/app/src/agent-runtime/client-tool-manifest.ts
+++ b/app/src/agent-runtime/client-tool-manifest.ts
@@ -588,17 +588,19 @@ export const AGENT_TOOL_MANIFEST = {
     getLabel: () => "Rebuilding app preview",
     icon: "play",
   },
+  // dbt reads execute SERVER-SIDE (issue #475) — reading the authoritative
+  // DbtProject/DbtFile docs avoids a pending client tool tearing down the SSE
+  // turn ("stream disconnected before tool completed") when the tab is slow or
+  // detached. See api/src/agent-lib/tools/dbt-tools.ts.
   read_dbt_project_tree: {
     domain: "dbt",
-    execution: "client",
-    clientExecutor: "dbt",
+    execution: "server",
     getLabel: () => "Reading dbt project tree",
     icon: "list",
   },
   read_dbt_file: {
     domain: "dbt",
-    execution: "client",
-    clientExecutor: "dbt",
+    execution: "server",
     getLabel: input => {
       const path = (input as Record<string, unknown>)?.path;
       return path ? `Reading ${path}` : "Reading dbt file";

--- a/app/src/agent-runtime/client-tool-manifest.ts
+++ b/app/src/agent-runtime/client-tool-manifest.ts
@@ -499,6 +499,25 @@ export const AGENT_TOOL_MANIFEST = {
     },
     icon: "trash",
   },
+  app_save_version: {
+    domain: "app",
+    execution: "server",
+    getLabel: input => {
+      const comment = (input as Record<string, unknown>)?.comment;
+      return comment ? `Saving version: "${comment}"` : "Saving app version";
+    },
+    icon: "clock",
+  },
+  app_restore_version: {
+    domain: "app",
+    execution: "server",
+    longRunning: true,
+    getLabel: input => {
+      const version = (input as Record<string, unknown>)?.version;
+      return version ? `Restoring version ${version}` : "Restoring app version";
+    },
+    icon: "clock",
+  },
   materialize_binding: {
     domain: "app",
     execution: "client",

--- a/app/src/agent-runtime/client-tool-manifest.ts
+++ b/app/src/agent-runtime/client-tool-manifest.ts
@@ -388,7 +388,7 @@ export const AGENT_TOOL_MANIFEST = {
     getLabel: () => "Reading chart template",
     icon: "eye",
   },
-  save_dashboard_version: {
+  dashboard_save_version: {
     domain: "dashboard",
     execution: "client",
     clientExecutor: "dashboard",
@@ -401,7 +401,7 @@ export const AGENT_TOOL_MANIFEST = {
     },
     icon: "clock",
   },
-  restore_dashboard_version: {
+  dashboard_restore_version: {
     domain: "dashboard",
     execution: "client",
     clientExecutor: "dashboard",

--- a/app/src/agent-runtime/client-tool-manifest.ts
+++ b/app/src/agent-runtime/client-tool-manifest.ts
@@ -414,11 +414,13 @@ export const AGENT_TOOL_MANIFEST = {
     },
     icon: "clock",
   },
+  // Full-server apps: list/create/read/inspect/materialize execute SERVER-SIDE
+  // (see api/src/agent-lib/tools/server-app-tools.ts). Entries kept for tool-card
+  // labels/icons. Only open_app and run_app remain browser-executed.
   list_open_apps: {
     domain: "app",
-    execution: "client",
-    clientExecutor: "app",
-    getLabel: () => "Listing open apps",
+    execution: "server",
+    getLabel: () => "Listing apps",
     icon: "list",
   },
   open_app: {
@@ -431,8 +433,7 @@ export const AGENT_TOOL_MANIFEST = {
   },
   create_app: {
     domain: "app",
-    execution: "client",
-    clientExecutor: "app",
+    execution: "server",
     longRunning: true,
     getLabel: input => {
       const title = (input as Record<string, unknown>)?.title;
@@ -442,15 +443,13 @@ export const AGENT_TOOL_MANIFEST = {
   },
   get_app_state: {
     domain: "app",
-    execution: "client",
-    clientExecutor: "app",
+    execution: "server",
     getLabel: () => "Reading app state",
     icon: "eye",
   },
   app_read_file: {
     domain: "app",
-    execution: "client",
-    clientExecutor: "app",
+    execution: "server",
     getLabel: input => {
       const path = (input as Record<string, unknown>)?.path;
       return path ? `Reading ${path}` : "Reading file";
@@ -546,8 +545,7 @@ export const AGENT_TOOL_MANIFEST = {
   },
   materialize_binding: {
     domain: "app",
-    execution: "client",
-    clientExecutor: "app",
+    execution: "server",
     longRunning: true,
     getLabel: input => {
       const name = (input as Record<string, unknown>)?.name;

--- a/app/src/api/schema.d.ts
+++ b/app/src/api/schema.d.ts
@@ -2922,6 +2922,58 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/workspaces/{workspaceId}/apps/{id}/versions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List app versions */
+        get: operations["get_api_workspaces_workspaceId_apps_id_versions"];
+        put?: never;
+        /** Save an app version checkpoint */
+        post: operations["post_api_workspaces_workspaceId_apps_id_versions"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspaces/{workspaceId}/apps/{id}/versions/{version}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get an app version snapshot */
+        get: operations["get_api_workspaces_workspaceId_apps_id_versions_version"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspaces/{workspaceId}/apps/{id}/versions/{version}/restore": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Restore an app version */
+        post: operations["post_api_workspaces_workspaceId_apps_id_versions_version_restore"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/workspaces/{workspaceId}/apps/{id}/collaborators": {
         parameters: {
             query?: never;
@@ -13835,6 +13887,187 @@ export interface operations {
                 };
                 content: {
                     "application/vnd.apache.parquet": string;
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    get_api_workspaces_workspaceId_apps_id_versions: {
+        parameters: {
+            query?: {
+                limit?: string;
+                offset?: string;
+            };
+            header?: never;
+            path: {
+                workspaceId: string;
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    post_api_workspaces_workspaceId_apps_id_versions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    [key: string]: unknown;
+                };
+            };
+        };
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    get_api_workspaces_workspaceId_apps_id_versions_version: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+                id: string;
+                version: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    post_api_workspaces_workspaceId_apps_id_versions_version_restore: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+                id: string;
+                version: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    [key: string]: unknown;
+                };
+            };
+        };
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
                 };
             };
             /** @description Invalid request */

--- a/app/src/components/AppsExplorer.tsx
+++ b/app/src/components/AppsExplorer.tsx
@@ -517,7 +517,7 @@ export function AppsExplorer() {
               <ListItemIcon>
                 <SaveVersionIcon size={16} strokeWidth={1.5} />
               </ListItemIcon>
-              Save version
+              Publish version
             </MenuItem>,
           );
         }
@@ -783,11 +783,11 @@ export function AppsExplorer() {
         maxWidth="sm"
         fullWidth
       >
-        <DialogTitle>Save version of {saveVersionApp?.name}</DialogTitle>
+        <DialogTitle>Publish version of {saveVersionApp?.name}</DialogTitle>
         <DialogContent>
           <DialogContentText sx={{ mb: 2 }}>
-            Saves a restorable checkpoint of the app&apos;s current files,
-            dependencies, and data binding queries.
+            Snapshots the current draft into version history and publishes it as
+            the live version that shared links and viewers see.
           </DialogContentText>
           <TextField
             autoFocus
@@ -814,7 +814,7 @@ export function AppsExplorer() {
             variant="contained"
             disabled={savingVersion}
           >
-            {savingVersion ? "Saving..." : "Save version"}
+            {savingVersion ? "Publishing..." : "Publish version"}
           </Button>
         </DialogActions>
       </Dialog>

--- a/app/src/components/AppsExplorer.tsx
+++ b/app/src/components/AppsExplorer.tsx
@@ -32,6 +32,8 @@ import {
   Pencil as RenameIcon,
   Trash2 as DeleteIcon,
   Database as MaterializeIcon,
+  History as HistoryIcon,
+  Save as SaveVersionIcon,
 } from "lucide-react";
 import { useAuth } from "../contexts/auth-context";
 import { useWorkspace } from "../contexts/workspace-context";
@@ -42,6 +44,8 @@ import {
   selectRevealFor,
 } from "../store/explorerRevealStore";
 import { useAppStore, type AppListItem } from "../store/appStore";
+import { useVersionStore } from "../store/versionStore";
+import { VersionHistoryPanel } from "./VersionHistoryPanel";
 import {
   APP_FILE_SEP as FILE_SEP,
   APP_DIR_SEP as DIR_SEP,
@@ -192,6 +196,8 @@ export function AppsExplorer() {
   const materializeBinding = useAppStore(s => s.materializeBinding);
   const persistApp = useAppStore(s => s.persistApp);
   const setAppAccess = useAppStore(s => s.setAppAccess);
+  const bumpPreview = useAppStore(s => s.bumpPreview);
+  const saveVersion = useVersionStore(s => s.saveVersion);
 
   const activeTabId = useConsoleStore(s => s.activeTabId);
   const tabs = useConsoleStore(s => s.tabs);
@@ -222,6 +228,18 @@ export function AppsExplorer() {
     parsed: ParsedNode;
     name: string;
   } | null>(null);
+  // Version history: which app's history drawer is open.
+  const [historyApp, setHistoryApp] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+  // Save-version dialog state.
+  const [saveVersionApp, setSaveVersionApp] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+  const [saveVersionComment, setSaveVersionComment] = useState("");
+  const [savingVersion, setSavingVersion] = useState(false);
 
   useEffect(() => {
     if (workspaceId) void fetchList(workspaceId);
@@ -470,6 +488,41 @@ export function AppsExplorer() {
         );
       }
 
+      // Version history (read) + save checkpoint (write) for apps.
+      if (parsed.kind === "app") {
+        items.push(
+          <MenuItem
+            key="history"
+            onClick={() => {
+              setHistoryApp({ id: parsed.appId, name: node.name });
+              helpers.closeMenu();
+            }}
+          >
+            <ListItemIcon>
+              <HistoryIcon size={16} strokeWidth={1.5} />
+            </ListItemIcon>
+            Version history
+          </MenuItem>,
+        );
+        if (canManageNode(node)) {
+          items.push(
+            <MenuItem
+              key="save-version"
+              onClick={() => {
+                setSaveVersionApp({ id: parsed.appId, name: node.name });
+                setSaveVersionComment("");
+                helpers.closeMenu();
+              }}
+            >
+              <ListItemIcon>
+                <SaveVersionIcon size={16} strokeWidth={1.5} />
+              </ListItemIcon>
+              Save version
+            </MenuItem>,
+          );
+        }
+      }
+
       // Materialize action for parquet bindings.
       if (parsed.kind === "binding" && workspaceId) {
         const appEntity = openApps[parsed.appId];
@@ -573,6 +626,30 @@ export function AppsExplorer() {
     deleteFile,
     removeDataBinding,
     persistApp,
+  ]);
+
+  const handleSaveVersionConfirm = useCallback(async () => {
+    if (!saveVersionApp || !workspaceId) return;
+    setSavingVersion(true);
+    // Flush any pending local edits so the checkpoint matches what's on screen.
+    if (openApps[saveVersionApp.id]) {
+      await persistApp(workspaceId, saveVersionApp.id);
+    }
+    await saveVersion(
+      workspaceId,
+      "app",
+      saveVersionApp.id,
+      saveVersionComment.trim(),
+    );
+    setSavingVersion(false);
+    setSaveVersionApp(null);
+  }, [
+    saveVersionApp,
+    workspaceId,
+    openApps,
+    persistApp,
+    saveVersion,
+    saveVersionComment,
   ]);
 
   const actions = (
@@ -698,6 +775,66 @@ export function AppsExplorer() {
           </Button>
         </DialogActions>
       </Dialog>
+
+      {/* Save version dialog */}
+      <Dialog
+        open={!!saveVersionApp}
+        onClose={() => !savingVersion && setSaveVersionApp(null)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>Save version of {saveVersionApp?.name}</DialogTitle>
+        <DialogContent>
+          <DialogContentText sx={{ mb: 2 }}>
+            Saves a restorable checkpoint of the app&apos;s current files,
+            dependencies, and data binding queries.
+          </DialogContentText>
+          <TextField
+            autoFocus
+            fullWidth
+            size="small"
+            label="Comment (optional)"
+            placeholder="e.g. Add revenue chart"
+            value={saveVersionComment}
+            onChange={e => setSaveVersionComment(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === "Enter") void handleSaveVersionConfirm();
+            }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => setSaveVersionApp(null)}
+            disabled={savingVersion}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSaveVersionConfirm}
+            variant="contained"
+            disabled={savingVersion}
+          >
+            {savingVersion ? "Saving..." : "Save version"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Version history drawer */}
+      {historyApp && (
+        <VersionHistoryPanel
+          open={!!historyApp}
+          onClose={() => setHistoryApp(null)}
+          entityType="app"
+          entityId={historyApp.id}
+          onRestore={() => {
+            if (workspaceId && historyApp) {
+              void fetchApp(workspaceId, historyApp.id).then(() =>
+                bumpPreview(historyApp.id),
+              );
+            }
+          }}
+        />
+      )}
     </>
   );
 }

--- a/app/src/components/VersionHistoryPanel.tsx
+++ b/app/src/components/VersionHistoryPanel.tsx
@@ -18,6 +18,8 @@ import {
   TextField,
   Avatar,
   Stack,
+  Select,
+  MenuItem,
 } from "@mui/material";
 import { X, RotateCcw } from "lucide-react";
 import Editor from "@monaco-editor/react";
@@ -25,6 +27,7 @@ import {
   useVersionStore,
   type VersionListItem,
   type VersionDetail,
+  type VersionEntityType,
 } from "../store/versionStore";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useTheme } from "../contexts/ThemeContext";
@@ -32,7 +35,7 @@ import { useTheme } from "../contexts/ThemeContext";
 interface VersionHistoryPanelProps {
   open: boolean;
   onClose: () => void;
-  entityType: "console" | "dashboard";
+  entityType: VersionEntityType;
   entityId: string;
   currentCode?: string;
   onRestore?: () => void;
@@ -40,6 +43,26 @@ interface VersionHistoryPanelProps {
 
 const LIST_WIDTH = 380;
 const PREVIEW_WIDTH = 640;
+
+interface AppSnapshotFile {
+  path: string;
+  contents: string;
+}
+
+/** Synthetic selector entries (after the real files) for app snapshots. */
+const APP_DEPS_KEY = "::dependencies";
+const APP_BINDINGS_KEY = "::dataBindings";
+
+function monacoLanguageForPath(path: string): string {
+  const ext = path.split(".").pop()?.toLowerCase() ?? "";
+  if (ext === "ts" || ext === "tsx") return "typescript";
+  if (ext === "js" || ext === "jsx") return "javascript";
+  if (ext === "css" || ext === "scss") return "css";
+  if (ext === "html") return "html";
+  if (ext === "json") return "json";
+  if (ext === "md" || ext === "mdx") return "markdown";
+  return "plaintext";
+}
 
 function formatDate(dateStr: string): string {
   const d = new Date(dateStr);
@@ -96,12 +119,30 @@ export function VersionHistoryPanel({
   );
   const [restoreComment, setRestoreComment] = useState("");
   const [restoring, setRestoring] = useState(false);
+  // For app snapshots: which file (or synthetic deps/bindings view) is shown.
+  const [appFilePath, setAppFilePath] = useState<string | null>(null);
 
   useEffect(() => {
     if (!open) {
       setSelectedVersion(null);
     }
   }, [open]);
+
+  // When an app version loads, default the preview to its entrypoint.
+  useEffect(() => {
+    if (entityType !== "app" || !selectedVersion) return;
+    const files =
+      (selectedVersion.snapshot.files as AppSnapshotFile[] | undefined) ?? [];
+    const entrypoint = selectedVersion.snapshot.entrypoint as
+      | string
+      | undefined;
+    const fallback = files[0]?.path ?? APP_DEPS_KEY;
+    setAppFilePath(
+      entrypoint && files.some(f => f.path === entrypoint)
+        ? entrypoint
+        : fallback,
+    );
+  }, [entityType, selectedVersion]);
 
   useEffect(() => {
     if (open && workspaceId && entityId) {
@@ -169,12 +210,44 @@ export function VersionHistoryPanel({
   };
 
   const monacoTheme = effectiveMode === "dark" ? "vs-dark" : "light";
-  const snapshotValue =
-    selectedVersion == null
-      ? ""
-      : entityType === "console"
-        ? ((selectedVersion.snapshot.code as string) ?? "")
-        : JSON.stringify(selectedVersion.snapshot ?? {}, null, 2);
+
+  const appFiles: AppSnapshotFile[] =
+    entityType === "app" && selectedVersion
+      ? ((selectedVersion.snapshot.files as AppSnapshotFile[] | undefined) ??
+        [])
+      : [];
+
+  let snapshotValue = "";
+  let previewLanguage = "json";
+  if (selectedVersion != null) {
+    if (entityType === "console") {
+      snapshotValue = (selectedVersion.snapshot.code as string) ?? "";
+      previewLanguage = "sql";
+    } else if (entityType === "app") {
+      if (appFilePath === APP_DEPS_KEY) {
+        snapshotValue = JSON.stringify(
+          selectedVersion.snapshot.dependencies ?? {},
+          null,
+          2,
+        );
+        previewLanguage = "json";
+      } else if (appFilePath === APP_BINDINGS_KEY) {
+        snapshotValue = JSON.stringify(
+          selectedVersion.snapshot.dataBindings ?? [],
+          null,
+          2,
+        );
+        previewLanguage = "json";
+      } else {
+        const file = appFiles.find(f => f.path === appFilePath);
+        snapshotValue = file?.contents ?? "";
+        previewLanguage = monacoLanguageForPath(appFilePath ?? "");
+      }
+    } else {
+      snapshotValue = JSON.stringify(selectedVersion.snapshot ?? {}, null, 2);
+      previewLanguage = "json";
+    }
+  }
 
   return (
     <>
@@ -260,6 +333,41 @@ export function VersionHistoryPanel({
               </Stack>
             </Box>
 
+            {entityType === "app" && !loadingDetail && (
+              <Box
+                sx={{
+                  px: 2,
+                  py: 1,
+                  borderBottom: 1,
+                  borderColor: "divider",
+                  flexShrink: 0,
+                }}
+              >
+                <Select
+                  size="small"
+                  fullWidth
+                  value={appFilePath ?? ""}
+                  onChange={e => setAppFilePath(e.target.value)}
+                  sx={{
+                    fontSize: "0.8rem",
+                    "& .MuiSelect-select": { py: 0.5 },
+                  }}
+                >
+                  {appFiles.map(f => (
+                    <MenuItem key={f.path} value={f.path}>
+                      {f.path}
+                    </MenuItem>
+                  ))}
+                  <MenuItem value={APP_DEPS_KEY}>
+                    · dependencies (JSON)
+                  </MenuItem>
+                  <MenuItem value={APP_BINDINGS_KEY}>
+                    · data bindings (JSON)
+                  </MenuItem>
+                </Select>
+              </Box>
+            )}
+
             <Box sx={{ flex: 1, minHeight: 0, position: "relative" }}>
               {loadingDetail ? (
                 <Box
@@ -275,7 +383,7 @@ export function VersionHistoryPanel({
               ) : (
                 <Editor
                   height="100%"
-                  language={entityType === "console" ? "sql" : "json"}
+                  language={previewLanguage}
                   theme={monacoTheme}
                   value={snapshotValue}
                   options={{
@@ -342,7 +450,9 @@ export function VersionHistoryPanel({
         ) : !versions?.length ? (
           <Box sx={{ px: 2, py: 4, textAlign: "center" }}>
             <Typography variant="body2" color="text.secondary">
-              No version history yet. Versions are created each time you save.
+              {entityType === "app"
+                ? "No saved versions yet. Use \u201CSave version\u201D to create a restorable checkpoint."
+                : "No version history yet. Versions are created each time you save."}
             </Typography>
           </Box>
         ) : (

--- a/app/src/components/VersionHistoryPanel.tsx
+++ b/app/src/components/VersionHistoryPanel.tsx
@@ -451,7 +451,7 @@ export function VersionHistoryPanel({
           <Box sx={{ px: 2, py: 4, textAlign: "center" }}>
             <Typography variant="body2" color="text.secondary">
               {entityType === "app"
-                ? "No saved versions yet. Use \u201CSave version\u201D to create a restorable checkpoint."
+                ? "No published versions yet. Use \u201CPublish version\u201D to snapshot and publish the current draft."
                 : "No version history yet. Versions are created each time you save."}
             </Typography>
           </Box>

--- a/app/src/dashboard-runtime/agent-tools.ts
+++ b/app/src/dashboard-runtime/agent-tools.ts
@@ -11,6 +11,7 @@ import {
   updateDashboardWidget,
 } from "./commands";
 import { useDashboardStore } from "../store/dashboardStore";
+import { useVersionStore } from "../store/versionStore";
 import type { DashboardDataSource, DashboardWidget } from "./types";
 import { classifyDuckDBError, classifySourceError } from "./error-kinds";
 import { computeDashboardStateHash } from "../utils/stateHash";
@@ -94,6 +95,9 @@ const EDIT_MODE_EXEMPT_TOOLS = new Set([
   "create_dashboard",
   "list_open_dashboards",
   "open_dashboard",
+  // Restore is a server-side revert + reload; it does not require holding the
+  // edit lock (it replaces the open tab's state with the restored draft).
+  "restore_dashboard_version",
 ]);
 
 export async function executeDashboardAgentTool(
@@ -178,6 +182,69 @@ export async function executeDashboardAgentTool(
         error instanceof Error ? error.message : "Failed to open dashboard";
       return { success: false, error: message };
     }
+  }
+
+  if (toolName === "restore_dashboard_version") {
+    const ctx = requireDashboardId(input);
+    if (!ctx) return { success: false, error: DASHBOARD_ID_REQUIRED_ERROR };
+    const version =
+      typeof input.version === "number" ? input.version : Number(input.version);
+    if (!Number.isFinite(version)) {
+      return { success: false, error: "version (number) is required" };
+    }
+    const comment =
+      typeof input.comment === "string" ? input.comment : undefined;
+    const res = await useVersionStore
+      .getState()
+      .restoreVersion(
+        ctx.workspaceId,
+        "dashboard",
+        ctx.dashboardId,
+        version,
+        comment,
+      );
+    if (!res.success) {
+      return { success: false, error: res.error || "Restore failed" };
+    }
+    await useDashboardStore
+      .getState()
+      .reloadDashboard(ctx.workspaceId, ctx.dashboardId);
+    throwIfAborted(signal);
+    const d = useDashboardStore.getState().openDashboards[ctx.dashboardId];
+    return {
+      success: true,
+      restoredFrom: version,
+      title: (d as any)?.title,
+      message:
+        `Restored the dashboard draft to version ${version}. This is not yet ` +
+        "published — call save_dashboard_version to push it live to viewers.",
+    };
+  }
+
+  if (toolName === "save_dashboard_version") {
+    const ctx = requireDashboardId(input);
+    if (!ctx) return { success: false, error: DASHBOARD_ID_REQUIRED_ERROR };
+    const comment = typeof input.comment === "string" ? input.comment : "";
+    const result = await useDashboardStore
+      .getState()
+      .saveDashboard(ctx.workspaceId, ctx.dashboardId, comment);
+    if (!result.ok) {
+      return {
+        success: false,
+        error:
+          result.error ||
+          "Save failed (the dashboard may have been modified elsewhere; reload and retry).",
+      };
+    }
+    const d = useDashboardStore.getState().openDashboards[ctx.dashboardId] as
+      | (Record<string, any> & { version?: number; publishedVersion?: number })
+      | undefined;
+    return {
+      success: true,
+      version: d?.version,
+      publishedVersion: d?.publishedVersion,
+      message: `Saved and published "${d?.title ?? "dashboard"}" as version ${d?.publishedVersion ?? d?.version}.`,
+    };
   }
 
   if (toolName === "capture_screenshot") {

--- a/app/src/dashboard-runtime/agent-tools.ts
+++ b/app/src/dashboard-runtime/agent-tools.ts
@@ -97,7 +97,7 @@ const EDIT_MODE_EXEMPT_TOOLS = new Set([
   "open_dashboard",
   // Restore is a server-side revert + reload; it does not require holding the
   // edit lock (it replaces the open tab's state with the restored draft).
-  "restore_dashboard_version",
+  "dashboard_restore_version",
 ]);
 
 export async function executeDashboardAgentTool(
@@ -184,7 +184,7 @@ export async function executeDashboardAgentTool(
     }
   }
 
-  if (toolName === "restore_dashboard_version") {
+  if (toolName === "dashboard_restore_version") {
     const ctx = requireDashboardId(input);
     if (!ctx) return { success: false, error: DASHBOARD_ID_REQUIRED_ERROR };
     const version =
@@ -217,11 +217,11 @@ export async function executeDashboardAgentTool(
       title: (d as any)?.title,
       message:
         `Restored the dashboard draft to version ${version}. This is not yet ` +
-        "published — call save_dashboard_version to push it live to viewers.",
+        "published — call dashboard_save_version to push it live to viewers.",
     };
   }
 
-  if (toolName === "save_dashboard_version") {
+  if (toolName === "dashboard_save_version") {
     const ctx = requireDashboardId(input);
     if (!ctx) return { success: false, error: DASHBOARD_ID_REQUIRED_ERROR };
     const comment = typeof input.comment === "string" ? input.comment : "";

--- a/app/src/dashboard-runtime/types.ts
+++ b/app/src/dashboard-runtime/types.ts
@@ -352,6 +352,10 @@ const DASHBOARD_METADATA_KEYS: ReadonlySet<string> = new Set([
   "editLock",
   "cache",
   "snapshots",
+  "published",
+  "publishedVersion",
+  "publishedAt",
+  "hasUnpublishedChanges",
 ]);
 
 function stripDataSourceServerState(dataSource: Record<string, unknown>) {

--- a/app/src/store/appStore.ts
+++ b/app/src/store/appStore.ts
@@ -33,6 +33,11 @@ export interface AppEntity {
   dependencies: Record<string, string>;
   dataBindings: AppDataBinding[];
   version: number;
+  /** EntityVersion number last published (draft/published split). */
+  publishedVersion?: number;
+  publishedAt?: string;
+  /** True when the working draft differs from the published version. */
+  hasUnpublishedChanges?: boolean;
   access: "private" | "workspace";
   /** Role granted to workspace members when access is "workspace". */
   workspaceRole?: "viewer" | "editor";

--- a/app/src/store/dashboardStore.ts
+++ b/app/src/store/dashboardStore.ts
@@ -7,6 +7,7 @@ import {
   normalizeWidgetLayouts,
 } from "@mako/schemas";
 import { computeDashboardStateHash } from "../utils/stateHash";
+import { realtimeClientId } from "../lib/realtime-client-id";
 import { disposeDashboardRuntime } from "../dashboard-runtime/gateway";
 import {
   sanitizeEditableDashboardDefinition,
@@ -552,6 +553,9 @@ export const useDashboardStore = create<DashboardStoreState>()(
             ...editableDefinition,
             version: dashboard.version,
             comment: comment ?? "",
+            // Echo-suppression for the realtime dashboard.updated poke so this
+            // saving tab doesn't reload itself (draft/published model).
+            clientId: realtimeClientId,
           };
           // Read the raw result instead of unwrapping: a 409 carries a
           // structured VERSION_CONFLICT body that drives the conflict UI.

--- a/app/src/store/realtimeStore.ts
+++ b/app/src/store/realtimeStore.ts
@@ -24,7 +24,9 @@ import {
   hasPendingAgentReview,
 } from "./consoleStore";
 import { useAppStore } from "./appStore";
+import { useDashboardStore } from "./dashboardStore";
 import { useDbtStore } from "./dbtStore";
+import { computeDashboardStateHash } from "../utils/stateHash";
 import { decideRemoteApply } from "./lib/remoteApplyGate";
 import { useConsoleTreeStore } from "./consoleTreeStore";
 import type { ConsoleRevisionsSyncResponse } from "../lib/api-types";
@@ -387,6 +389,32 @@ export const useRealtimeStore = create<RealtimeStore>()(
         );
     };
 
+    // Server-persisted dashboard saves/restores (draft/published model): pull
+    // the authoritative dashboard for an OPEN dashboard when its version
+    // advances — but NEVER clobber a user mid-edit. Skips the reload if this
+    // tab is editing or holds unsaved local changes (their work wins until they
+    // save/discard); echo-suppressed by clientId; stale events ignored.
+    const handleDashboardUpdated = (
+      event: Extract<RealtimeEvent, { type: "dashboard.updated" }>,
+    ) => {
+      if (event.clientId && event.clientId === realtimeClientId) return;
+      const workspaceId = get().workspaceId;
+      if (!workspaceId) return;
+      const ds = useDashboardStore.getState();
+      const open = ds.openDashboards[event.dashboardId];
+      if (!open) return; // not open here — explorer/canvas refreshes lazily
+      if ((open.version ?? 0) >= event.version) return; // stale / own echo
+      if (ds.editingDashboards[event.dashboardId]) return; // don't stomp editor
+      const savedHash = ds.savedStateHashes[event.dashboardId];
+      if (
+        savedHash !== undefined &&
+        computeDashboardStateHash(open) !== savedHash
+      ) {
+        return; // unsaved local changes — preserve them
+      }
+      void ds.reloadDashboard(workspaceId, event.dashboardId);
+    };
+
     const handleEvent = (event: RealtimeEvent) => {
       switch (event.type) {
         case "console.updated":
@@ -394,6 +422,9 @@ export const useRealtimeStore = create<RealtimeStore>()(
           break;
         case "app.updated":
           handleAppUpdated(event);
+          break;
+        case "dashboard.updated":
+          handleDashboardUpdated(event);
           break;
         case "dbt.file.updated":
           handleDbtFileUpdated(event);

--- a/app/src/store/realtimeStore.ts
+++ b/app/src/store/realtimeStore.ts
@@ -358,7 +358,13 @@ export const useRealtimeStore = create<RealtimeStore>()(
       if (!workspaceId) return;
       const appStore = useAppStore.getState();
       const open = appStore.openApps[event.appId];
-      if (!open) return; // not open in this window — explorer refreshes lazily
+      if (!open) {
+        // Not open in this window — but the app list may have changed (e.g. the
+        // agent created/edited an app server-side). Refresh the explorer so new
+        // apps appear without a manual reload (browser follows the server).
+        void appStore.fetchList(workspaceId);
+        return;
+      }
       if ((open.version ?? 0) >= event.version) return; // stale / own echo
       void (async () => {
         const fresh = await useAppStore

--- a/app/src/store/versionStore.ts
+++ b/app/src/store/versionStore.ts
@@ -5,7 +5,10 @@ import { api, unwrap } from "../api";
 const VERSION_BASE = {
   console: "/api/workspaces/{workspaceId}/consoles/{id}/versions",
   dashboard: "/api/workspaces/{workspaceId}/dashboards/{id}/versions",
+  app: "/api/workspaces/{workspaceId}/apps/{id}/versions",
 } as const;
+
+export type VersionEntityType = keyof typeof VERSION_BASE;
 
 export interface VersionListItem {
   version: number;
@@ -27,25 +30,37 @@ interface VersionStoreState {
 
   fetchVersionHistory: (
     workspaceId: string,
-    entityType: "console" | "dashboard",
+    entityType: VersionEntityType,
     entityId: string,
     opts?: { limit?: number; offset?: number },
   ) => Promise<void>;
 
   fetchVersion: (
     workspaceId: string,
-    entityType: "console" | "dashboard",
+    entityType: VersionEntityType,
     entityId: string,
     version: number,
   ) => Promise<VersionDetail | null>;
 
   restoreVersion: (
     workspaceId: string,
-    entityType: "console" | "dashboard",
+    entityType: VersionEntityType,
     entityId: string,
     version: number,
     comment?: string,
   ) => Promise<{ success: boolean; error?: string }>;
+
+  /**
+   * Create an explicit checkpoint of the entity's current state. Only apps use
+   * this today (consoles/dashboards version implicitly on save); the base path
+   * map gates which entity types support it.
+   */
+  saveVersion: (
+    workspaceId: string,
+    entityType: VersionEntityType,
+    entityId: string,
+    comment?: string,
+  ) => Promise<{ success: boolean; version?: number; error?: string }>;
 
   clearHistory: (entityId: string) => void;
 }
@@ -126,6 +141,32 @@ export const useVersionStore = create<VersionStoreState>((set, get) => ({
       return {
         success: false,
         error: err instanceof Error ? err.message : "Restore failed",
+      };
+    }
+  },
+
+  saveVersion: async (workspaceId, entityType, entityId, comment) => {
+    // Only apps support explicit checkpoint creation today; consoles and
+    // dashboards version implicitly on save (no POST /versions endpoint).
+    if (entityType !== "app") {
+      return {
+        success: false,
+        error: `Explicit versions are not supported for ${entityType}`,
+      };
+    }
+    try {
+      const data = unwrap(
+        await api.POST("/api/workspaces/{workspaceId}/apps/{id}/versions", {
+          params: { path: { workspaceId, id: entityId } },
+          body: { comment: comment ?? "" },
+        }),
+      ) as { version?: number };
+      await get().fetchVersionHistory(workspaceId, entityType, entityId);
+      return { success: true, version: data.version };
+    } catch (err) {
+      return {
+        success: false,
+        error: err instanceof Error ? err.message : "Failed to save version",
       };
     }
   },

--- a/docs/src/openapi/mako-api.json
+++ b/docs/src/openapi/mako-api.json
@@ -18645,6 +18645,366 @@
         "operationId": "get_api_workspaces_workspaceId_apps_id_bindings_bindingId_materialization_artifact"
       }
     },
+    "/api/workspaces/{workspaceId}/apps/{id}/versions": {
+      "get": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "List app versions",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "offset",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get_api_workspaces_workspaceId_apps_id_versions"
+      },
+      "post": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "Save an app version checkpoint",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": {}
+              }
+            }
+          }
+        },
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "post_api_workspaces_workspaceId_apps_id_versions"
+      }
+    },
+    "/api/workspaces/{workspaceId}/apps/{id}/versions/{version}": {
+      "get": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "Get an app version snapshot",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "version",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get_api_workspaces_workspaceId_apps_id_versions_version"
+      }
+    },
+    "/api/workspaces/{workspaceId}/apps/{id}/versions/{version}/restore": {
+      "post": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "Restore an app version",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "version",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": {}
+              }
+            }
+          }
+        },
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "post_api_workspaces_workspaceId_apps_id_versions_version_restore"
+      }
+    },
     "/api/workspaces/{workspaceId}/apps/{id}/collaborators": {
       "get": {
         "tags": [

--- a/packages/agent-tools/src/app-tools.ts
+++ b/packages/agent-tools/src/app-tools.ts
@@ -115,7 +115,22 @@ export const restoreAppVersionSchema = z.object({
     .describe("Optional note explaining why this version was restored."),
 });
 
-const materializeBindingSchema = z.object({
+// Schemas for the server-executed app tools (registered with execute functions
+// in api/src/agent-lib/tools/server-app-tools.ts). Apps are fully
+// server-authoritative: list/create/read/inspect/materialize all run against
+// the MakoApp document so a headless / detached agent never needs a browser.
+export const listAppsSchema = z.object({});
+
+export const createAppSchema = z.object({
+  title: z.string().describe("App title"),
+  description: z.string().optional().describe("Brief description"),
+});
+
+export const getAppStateSchema = z.object({ appId: appIdField });
+
+export { readFileSchema as appReadFileSchema };
+
+export const materializeBindingSchema = z.object({
   appId: appIdField,
   name: z.string().describe("Name of the parquet binding to (re)materialize"),
   waitSeconds: z
@@ -131,60 +146,23 @@ const materializeBindingSchema = z.object({
     ),
 });
 
-const createAppSchema = z.object({
-  title: z.string().describe("App title"),
-  description: z.string().optional().describe("Brief description"),
-});
-
+// Client-executed legs only: these depend on the browser preview (sandboxed
+// iframe) and the live UI tabs, so they cannot run server-side. A headless
+// agent simply does not call them — it operates on `appId` directly.
 export const clientAppTools = {
-  list_open_apps: tool({
-    description:
-      "List all open React App tabs. Returns each app's id, title, file count, " +
-      "dependency list, data bindings, and isActive flag. " +
-      "Call this FIRST to get app IDs before using any other app tool.",
-    inputSchema: z.object({}),
-  }),
   open_app: tool({
     description:
-      "Open a saved app by its ID into a tab and load its files. " +
-      "Returns the appId to use with other tools.",
+      "Open a saved app by its ID into a tab in the UI and load its files. " +
+      "UI convenience for an attached browser; headless flows can skip this and " +
+      "pass the appId directly to other tools.",
     inputSchema: z.object({ appId: z.string().describe("App ID to open") }),
-  }),
-  create_app: tool({
-    description:
-      "Create a new React app from the default scaffold (React + TypeScript). " +
-      "Opens it in a tab and returns the new appId. After creating, use " +
-      "app_write_file to build features and app_add_dependency to add libraries.",
-    inputSchema: createAppSchema,
-  }),
-  get_app_state: tool({
-    description:
-      "Get the app definition: file list (paths), dependencies, data bindings, " +
-      "entrypoint, runtime, and the latest preview build/runtime errors. " +
-      "Use this to understand the project and to read build errors before fixing them.",
-    inputSchema: z.object({ appId: appIdField }),
-  }),
-  app_read_file: tool({
-    description: "Read the full contents of a single file in the app.",
-    inputSchema: readFileSchema,
-  }),
-  materialize_binding: tool({
-    description:
-      "Build (or rebuild) the Parquet artifact for a 'parquet' data binding and " +
-      "load it into the app's DuckDB-WASM instance. Run this after creating or " +
-      "editing a parquet binding so useQuery/useDuckDB return fresh data. " +
-      "The build runs server-side in the background: the tool waits up to " +
-      "waitSeconds (default 120) and returns status 'building' if it is still " +
-      "running — that is not an error; the app picks up the data automatically " +
-      "when ready. To block until completion, call this tool again (it resumes " +
-      "waiting on the in-flight build); use waitSeconds: 0 for an instant " +
-      "status check.",
-    inputSchema: materializeBindingSchema,
   }),
   run_app: tool({
     description:
-      "Rebuild and reload the app preview. Use after a batch of edits, or to " +
-      "recover from a stuck preview. Returns any build/runtime errors.",
+      "Rebuild and reload the app's LIVE PREVIEW in the browser and return any " +
+      "build/runtime errors. This is the only browser-only app tool — use it to " +
+      "validate that edits render and to read preview errors. Requires an " +
+      "attached browser tab; it is not needed to author or persist an app.",
     inputSchema: z.object({ appId: appIdField }),
   }),
 };

--- a/packages/agent-tools/src/app-tools.ts
+++ b/packages/agent-tools/src/app-tools.ts
@@ -90,6 +90,31 @@ export const deleteDataBindingSchema = z.object({
     .describe("Name of the data binding to delete (from list_data_sources)"),
 });
 
+export const saveAppVersionSchema = z.object({
+  appId: appIdField,
+  comment: z
+    .string()
+    .optional()
+    .describe(
+      "Short message describing this checkpoint, e.g. 'Add revenue chart'. " +
+        "Shown in the version history list.",
+    ),
+});
+
+export const restoreAppVersionSchema = z.object({
+  appId: appIdField,
+  version: z
+    .number()
+    .describe(
+      "Version number to restore (from browse_version_history). The current " +
+        "state is preserved as a new checkpoint, so a restore is never lossy.",
+    ),
+  comment: z
+    .string()
+    .optional()
+    .describe("Optional note explaining why this version was restored."),
+});
+
 const materializeBindingSchema = z.object({
   appId: appIdField,
   name: z.string().describe("Name of the parquet binding to (re)materialize"),

--- a/packages/agent-tools/src/dashboard-tools.ts
+++ b/packages/agent-tools/src/dashboard-tools.ts
@@ -404,7 +404,7 @@ export const clientDashboardTools = {
       templateId: z.string().describe("Template ID from get_chart_templates"),
     }),
   }),
-  save_dashboard_version: tool({
+  dashboard_save_version: tool({
     description:
       "Save AND publish the dashboard's current edits as a new version. Persists " +
       "the working draft to the server, creates an immutable version snapshot in " +
@@ -414,13 +414,13 @@ export const clientDashboardTools = {
       "edit mode for the user to review. Give a short `comment`.",
     inputSchema: saveDashboardVersionSchema,
   }),
-  restore_dashboard_version: tool({
+  dashboard_restore_version: tool({
     description:
       "Restore the dashboard to a previous version (get the number from " +
       "browse_version_history with entityType:'dashboard'). Reverts the working " +
       "draft to that snapshot and reloads the dashboard; the current state is " +
       "preserved as a new version first, so it is never lossy. Restoring does " +
-      "NOT publish — call save_dashboard_version afterward to push the restored " +
+      "NOT publish — call dashboard_save_version afterward to push the restored " +
       "state live to viewers. This replaces any unsaved edits in the open tab.",
     inputSchema: restoreDashboardVersionSchema,
   }),

--- a/packages/agent-tools/src/dashboard-tools.ts
+++ b/packages/agent-tools/src/dashboard-tools.ts
@@ -29,6 +29,31 @@ const vegaLiteSpecField = z
       "If the spec is invalid or fails to render, the tool returns the error/hint so you can fix it with modify_widget.",
   );
 
+const saveDashboardVersionSchema = z.object({
+  dashboardId: z.string().describe("Dashboard ID (from list_open_dashboards)"),
+  comment: z
+    .string()
+    .optional()
+    .describe(
+      "Short message describing this version, e.g. 'Add revenue KPI'. Shown in " +
+        "the version history list.",
+    ),
+});
+
+const restoreDashboardVersionSchema = z.object({
+  dashboardId: z.string().describe("Dashboard ID (from list_open_dashboards)"),
+  version: z
+    .number()
+    .describe(
+      "Version number to restore (from browse_version_history). The current " +
+        "state is preserved as a new version first, so restoring is never lossy.",
+    ),
+  comment: z
+    .string()
+    .optional()
+    .describe("Optional note explaining why this version was restored."),
+});
+
 const addWidgetSchema = z.object({
   dashboardId: z.string().describe("Dashboard ID"),
   type: z.enum(["chart", "kpi", "table"]).describe("Widget type"),
@@ -378,5 +403,25 @@ export const clientDashboardTools = {
     inputSchema: z.object({
       templateId: z.string().describe("Template ID from get_chart_templates"),
     }),
+  }),
+  save_dashboard_version: tool({
+    description:
+      "Save AND publish the dashboard's current edits as a new version. Persists " +
+      "the working draft to the server, creates an immutable version snapshot in " +
+      "history, and publishes it — the published snapshot is what viewers and " +
+      "shared/public links render. Call enter_edit_mode first. Only call this " +
+      "when the user asks to save/publish/snapshot; otherwise leave changes in " +
+      "edit mode for the user to review. Give a short `comment`.",
+    inputSchema: saveDashboardVersionSchema,
+  }),
+  restore_dashboard_version: tool({
+    description:
+      "Restore the dashboard to a previous version (get the number from " +
+      "browse_version_history with entityType:'dashboard'). Reverts the working " +
+      "draft to that snapshot and reloads the dashboard; the current state is " +
+      "preserved as a new version first, so it is never lossy. Restoring does " +
+      "NOT publish — call save_dashboard_version afterward to push the restored " +
+      "state live to viewers. This replaces any unsaved edits in the open tab.",
+    inputSchema: restoreDashboardVersionSchema,
   }),
 };

--- a/packages/agent-tools/src/dbt-tools.ts
+++ b/packages/agent-tools/src/dbt-tools.ts
@@ -1,17 +1,21 @@
 /**
- * Client-Side dbt Tools
+ * dbt tool schemas (shared source of truth for the dbt IDE tool cards).
  *
- * File-editing tools for the dbt IDE ("dbt Cloud replica"). Like the app
- * tools these have no `execute` function, so the AI SDK routes them to the
- * browser via `onToolCall`, where `executeDbtAgentTool` applies them to the
- * dbtStore (the same writeFile path the editor uses) and persists them.
+ * ALL dbt agent tools now execute SERVER-SIDE against the authoritative
+ * DbtProject/DbtFile/DbtJob documents (issue #475 pattern) — both the file
+ * mutations (create/modify/delete) AND the reads (read_dbt_project_tree /
+ * read_dbt_file). Reads moved server-side because a client-executed read leaves
+ * a tool call pending in the browser; if the tab is slow/backgrounded/detached
+ * the SSE turn tears down with "stream disconnected before tool completed".
+ * Reading the docs on the server keeps the turn entirely server-driven.
  *
- * Server-side verification tools (dbt_parse / dbt_compile_model /
- * dbt_run_model / dbt_run_job) live in api/src/agent-lib/tools/dbt-tools.ts
- * because they invoke the dbt runner.
+ * Verification tools (dbt_parse / dbt_compile_model / dbt_run_model /
+ * dbt_run_job) also live server-side because they invoke the dbt runner.
+ *
+ * `clientDbtTools` is therefore intentionally empty — no dbt tool is browser
+ * executed anymore.
  */
 
-import { tool } from "ai";
 import { z } from "zod";
 
 const projectIdField = z
@@ -24,7 +28,7 @@ const dbtPathField = z
     "POSIX file path relative to the project root, e.g. models/staging/stg_orders.sql",
   );
 
-const readTreeSchema = z.object({
+export const readDbtTreeSchema = z.object({
   projectId: z
     .string()
     .optional()
@@ -33,15 +37,14 @@ const readTreeSchema = z.object({
     ),
 });
 
-const readFileSchema = z.object({
+export const readDbtFileSchema = z.object({
   projectId: projectIdField,
   path: dbtPathField,
 });
 
-// NOTE: the file mutation tools (create/modify/delete) execute SERVER-SIDE
-// (issue #475 pattern) — see api/src/agent-lib/tools/dbt-tools.ts. Their schemas
-// are exported here so the server tools and the dbt IDE tool cards share a
-// single source of truth. They are intentionally NOT in `clientDbtTools`.
+// All dbt tools execute SERVER-SIDE (see api/src/agent-lib/tools/dbt-tools.ts).
+// Schemas are exported here so the server tools and the dbt IDE tool cards share
+// a single source of truth.
 export const createDbtFileSchema = z.object({
   projectId: projectIdField,
   path: dbtPathField,
@@ -63,21 +66,9 @@ export const deleteDbtFileSchema = z.object({
   path: dbtPathField,
 });
 
-export const clientDbtTools = {
-  read_dbt_project_tree: tool({
-    description:
-      "List dbt projects in the workspace, or the file tree + jobs of one " +
-      "project when projectId is given. Call this FIRST to get project IDs " +
-      "and file paths before using any other dbt tool.",
-    inputSchema: readTreeSchema,
-  }),
-  read_dbt_file: tool({
-    description:
-      "Read the full contents of a single file in a dbt project " +
-      "(models, schema.yml, dbt_project.yml, seeds, macros...).",
-    inputSchema: readFileSchema,
-  }),
-};
+// No dbt tools are browser-executed anymore — reads and writes alike run on the
+// server. Kept as an (empty) export so the agent wiring/types stay stable.
+export const clientDbtTools = {};
 
 export type DbtCreateFileInput = z.infer<typeof createDbtFileSchema>;
 export type DbtModifyFileInput = z.infer<typeof modifyDbtFileSchema>;

--- a/packages/agent-tools/src/index.ts
+++ b/packages/agent-tools/src/index.ts
@@ -84,6 +84,8 @@ export {
   createDbtFileSchema,
   modifyDbtFileSchema,
   deleteDbtFileSchema,
+  readDbtTreeSchema,
+  readDbtFileSchema,
 } from "./dbt-tools";
 export type { DbtCreateFileInput, DbtModifyFileInput } from "./dbt-tools";
 

--- a/packages/agent-tools/src/index.ts
+++ b/packages/agent-tools/src/index.ts
@@ -66,6 +66,8 @@ export {
   removeDependencySchema,
   createDataBindingSchema,
   deleteDataBindingSchema,
+  saveAppVersionSchema,
+  restoreAppVersionSchema,
 } from "./app-tools";
 export type { AppWriteFileInput, AppCreateDataBindingInput } from "./app-tools";
 

--- a/packages/agent-tools/src/index.ts
+++ b/packages/agent-tools/src/index.ts
@@ -68,6 +68,12 @@ export {
   deleteDataBindingSchema,
   saveAppVersionSchema,
   restoreAppVersionSchema,
+  // Server-executed read/create/materialize tools (full-server apps).
+  listAppsSchema,
+  createAppSchema,
+  getAppStateSchema,
+  appReadFileSchema,
+  materializeBindingSchema,
 } from "./app-tools";
 export type { AppWriteFileInput, AppCreateDataBindingInput } from "./app-tools";
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Unified **draft → published → version-history** model across **apps and dashboards** (server-persisted state, realtime sync, agent versioning tools), made **apps fully server-authoritative**, and moved the remaining **client-side dbt reads server-side** (fixing a "stream disconnected on dbt file read" class of bug).

### Apps — full server
- All app agent tools now run server-side against the `MakoApp` doc: writes + versioning (already), plus **`list_open_apps`, `create_app`, `get_app_state`, `app_read_file`, `materialize_binding`**. Only `run_app` (sandboxed-iframe preview) and `open_app` (UI tab focus) remain browser legs.
- Server-side create/edit pokes `app.updated`; the Apps explorer follows (auto-refresh, no reload).
- Draft/published split: `MakoApp.published`/`publishedVersion`/`publishedAt`; saving a version publishes it; restore reverts draft only; shares render `published`.

### Dashboards
- Same draft/published/version model + `dashboard.updated` realtime (guarded so it never clobbers a mid-edit user).
- Agent version tools `dashboard_save_version` / `dashboard_restore_version` (client-executed to compose with the browser-only DuckDB editing runtime); browse/get cover dashboards.

### dbt — reads moved server-side (bug fix)
- `read_dbt_project_tree` + `read_dbt_file` were the last **client-executed** dbt tools (writes were already server-side). A pending client read tool tears down the SSE turn ("Interrupted — stream disconnected before tool completed") when the tab is slow/backgrounded/detached.
- Both now execute server-side against `DbtProject`/`DbtFile`/`DbtJob`, so the turn is fully server-driven. **All dbt agent tools are now server-executed** (`clientDbtTools` is empty).

### Agent tool naming (aligned)
`app_save_version`/`app_restore_version` ↔ `dashboard_save_version`/`dashboard_restore_version`; `browse_version_history`/`get_version_snapshot` take `entityType`.

## Walkthrough

Agent reads dbt files **server-side**, no stream disconnect (create project → read tree → read `dbt_project.yml`):
[agent_dbt_read_server_side_no_disconnect.mp4](https://cursor.com/agents/bc-b6f67baf-48f5-431a-8cf7-88bf90851629/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_dbt_read_server_side_no_disconnect.mp4)

Agent builds an app **fully server-side** (no preview); explorer auto-refreshes on server create:
[agent_builds_app_fully_server.mp4](https://cursor.com/agents/bc-b6f67baf-48f5-431a-8cf7-88bf90851629/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_builds_app_fully_server.mp4)
[apps_explorer_autorefresh_on_server_create.mp4](https://cursor.com/agents/bc-b6f67baf-48f5-431a-8cf7-88bf90851629/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapps_explorer_autorefresh_on_server_create.mp4)

Agent versions an app + a dashboard via chat:
[agent_publishes_app_version.mp4](https://cursor.com/agents/bc-b6f67baf-48f5-431a-8cf7-88bf90851629/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_publishes_app_version.mp4)
[agent_versions_dashboard.mp4](https://cursor.com/agents/bc-b6f67baf-48f5-431a-8cf7-88bf90851629/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_versions_dashboard.mp4)

## Testing
- ✅ `pnpm --filter app run typecheck` / `lint`; `pnpm --filter api run lint`; `api` `tsc -p tsconfig.build.json --noEmit`
- ✅ `vitest run client-tool-manifest.test.ts` (drift guard incl. server app + dbt reads + dashboard version tools)
- ✅ Apps + Dashboards API e2e: publish/restore/draft transitions; shares render published while draft differs.
- ✅ Agent e2e (Claude Sonnet 4.6): headless-style app build (server tools); app+dashboard versioning; explorer auto-refresh; **dbt create+read entirely server-side with no stream disconnect** — all verified on video, UI intact.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6f67baf-48f5-431a-8cf7-88bf90851629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6f67baf-48f5-431a-8cf7-88bf90851629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

