### PR TITLE
fix(dbt): make repo-bound git ops race-free and non-destructive

### DIFF
--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -48,12 +48,17 @@ import {
 } from "../../dbt/commands";
 import {
   commitAndPush,
+  commitToNewBranch,
   createProjectBranch,
+  deleteProjectBranch,
   getGitStatus,
   listProjectBranches,
+  listRecoverableFiles,
   openProjectPullRequest,
+  restoreDeletedFile,
   switchProjectBranch,
 } from "../../dbt/dbt-github-git.service";
+import { syncProjectFromRepo } from "../../dbt/dbt-github-sync.service";
 import { generateDbtCommitMessage } from "../../dbt/dbt-commit-message.service";
 import {
   DBT_COMPATIBLE_CONNECTION_TYPES,
@@ -978,6 +983,109 @@ export const createDbtServerTools = (
       },
     }),
 
+    dbt_sync_from_repo: tool({
+      description:
+        "Re-pull the latest commits from the project's tracked branch into the " +
+        "working tree (Mongo), the same as the IDE 'Sync/Pull' action. Use this " +
+        "when the project is building from a stale checkout — e.g. files were " +
+        "merged on the remote (a PR landed on main) but the project hasn't " +
+        "picked them up, so a run finds fewer models/sources than the branch " +
+        "actually has. SAFE BY DEFAULT: files you've edited locally but not yet " +
+        "committed are preserved (reported in `preservedLocal`), never " +
+        "overwritten — only non-conflicting files fast-forward to the remote. " +
+        "Pass discardLocalChanges:true to make the remote win and overwrite " +
+        "local edits (only after the user confirms). To pull a DIFFERENT " +
+        "branch, use dbt_switch_branch instead.",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        discardLocalChanges: z
+          .boolean()
+          .optional()
+          .describe(
+            "Set true to let the remote overwrite uncommitted local edits. " +
+              "Default false keeps local edits and only fast-forwards the rest.",
+          ),
+      }),
+      execute: async ({ projectId, discardLocalChanges }) => {
+        try {
+          const project = await assertRepoProject(projectId);
+          const result = await syncProjectFromRepo(project, userId ?? "agent", {
+            preserveLocalEdits: !(discardLocalChanges ?? false),
+          });
+          return {
+            success: true,
+            branch: project.repo?.branch,
+            sha: result.sha,
+            added: result.added,
+            updated: result.updated,
+            deleted: result.deleted,
+            skippedLarge: result.skippedLarge,
+            preservedLocal: result.preservedLocal,
+          };
+        } catch (error) {
+          return toolError(error, "Failed to sync from repo");
+        }
+      },
+    }),
+
+    dbt_list_recoverable_files: tool({
+      description:
+        "List soft-deleted dbt files whose content is still retained and can be " +
+        "restored. Use this to RECOVER work that disappeared — e.g. models that " +
+        "vanished after a branch switch/sync before the non-destructive guards " +
+        "existed. These files are not in the normal project tree. Returns each " +
+        "path with its retained content and when it was last edited; restore " +
+        "the ones you want with dbt_restore_file.",
+      inputSchema: z.object({ projectId: projectIdField }),
+      execute: async ({ projectId }) => {
+        try {
+          const project = await assertRepoProject(projectId);
+          const files = await listRecoverableFiles(project);
+          return {
+            success: true,
+            count: files.length,
+            files: files.map(f => ({
+              path: f.path,
+              updatedAt: f.updatedAt,
+              updatedBy: f.updatedBy,
+              contentPreview: f.content.slice(0, 2000),
+              truncated: f.content.length > 2000,
+            })),
+          };
+        } catch (error) {
+          return toolError(error, "Failed to list recoverable files");
+        }
+      },
+    }),
+
+    dbt_restore_file: tool({
+      description:
+        "Restore a soft-deleted dbt file (from dbt_list_recoverable_files) back " +
+        "into the working tree. It returns as a pending 'added' change you can " +
+        "review with dbt_git_status and then commit. Use to recover work lost " +
+        "to a destructive branch switch/sync.",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        path: z
+          .string()
+          .min(1)
+          .describe("Project-relative path, e.g. models/staging/stg_x.sql"),
+      }),
+      execute: async ({ projectId, path }) => {
+        try {
+          const project = await assertRepoProject(projectId);
+          const result = await restoreDeletedFile(
+            project,
+            path.trim(),
+            userId ?? "agent",
+          );
+          return { success: true, path: result.path };
+        } catch (error) {
+          return toolError(error, "Failed to restore file");
+        }
+      },
+    }),
+
     dbt_git_status: tool({
       description:
         "Show the working-tree git status of a repo-bound dbt project: which " +
@@ -1075,11 +1183,81 @@ export const createDbtServerTools = (
       },
     }),
 
+    dbt_commit_to_branch: tool({
+      description:
+        "ATOMIC PROMOTE: create a new feature branch off the current branch and " +
+        "commit ALL working-tree changes onto it in a single, race-free step. " +
+        "PREFER THIS over dbt_create_branch + dbt_commit_and_push when the user " +
+        "wants their changes on a new branch for review: those two separate " +
+        "calls can race a concurrent commit and leave the changes on the wrong " +
+        "branch (e.g. main) with an empty feature branch. This tool does branch+" +
+        "commit under one lock so that cannot happen. Afterwards the project " +
+        "tracks the new branch with a clean tree — call dbt_open_pull_request " +
+        "to raise the PR. ONLY call after the user has asked you to commit/push.",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        name: z
+          .string()
+          .min(1)
+          .max(255)
+          .describe("New branch name, e.g. 'feat/crm-conversation-mart'"),
+        message: z
+          .string()
+          .min(1)
+          .max(500)
+          .optional()
+          .describe("Commit message. Omit to auto-generate one from the diff."),
+      }),
+      execute: async ({ projectId, name, message }) => {
+        try {
+          const project = await assertRepoProject(projectId);
+          let commitMessage = message?.trim();
+          let generated = false;
+          if (!commitMessage) {
+            const ai = await generateDbtCommitMessage(project, {
+              workspaceId,
+              userId: userId ?? "agent",
+            });
+            if (ai) {
+              commitMessage = ai;
+              generated = true;
+            }
+          }
+          if (!commitMessage) {
+            return {
+              success: false,
+              error:
+                "Could not generate a commit message — provide `message` " +
+                "explicitly and retry.",
+            };
+          }
+          const result = await commitToNewBranch(project, {
+            branchName: name.trim(),
+            message: commitMessage,
+            updatedBy: userId ?? "agent",
+          });
+          return {
+            success: result.committed,
+            sha: result.sha,
+            branch: result.branch,
+            fromBranch: result.fromBranch,
+            message: commitMessage,
+            messageGenerated: generated,
+            pushed: result.pushed,
+          };
+        } catch (error) {
+          return toolError(error, "Failed to commit to new branch");
+        }
+      },
+    }),
+
     dbt_create_branch: tool({
       description:
         "Create a new branch off the project's current branch head and check " +
-        "it out (track it). Use before dbt_commit_and_push when the user " +
-        "wants changes isolated on a feature branch. Branch content is " +
+        "it out (track it). NOTE: to put pending working-tree changes on a new " +
+        "branch, prefer dbt_commit_to_branch (atomic) — calling this then " +
+        "dbt_commit_and_push separately can race a concurrent commit. Use this " +
+        "only to branch with no pending changes. Branch content is " +
         "identical to the current branch — no re-sync needed.",
       inputSchema: z.object({
         projectId: projectIdField,
@@ -1103,22 +1281,37 @@ export const createDbtServerTools = (
     dbt_switch_branch: tool({
       description:
         "Switch the project's tracked branch and pull its contents into the " +
-        "working tree. This OVERWRITES local working-tree files with the " +
-        "target branch — only call when the user confirms, and after any " +
-        "pending changes are committed (check dbt_git_status first).",
+        "working tree. This OVERWRITES the working tree with the target branch. " +
+        "For safety it REFUSES if there are uncommitted changes (so a branch " +
+        "move can't silently destroy un-pushed work) — commit them first " +
+        "(dbt_commit_and_push or dbt_commit_to_branch), or pass " +
+        "discardLocalChanges:true to abandon them on purpose. Always run " +
+        "dbt_git_status before switching.",
       inputSchema: z.object({
         projectId: projectIdField,
         branch: z.string().min(1).max(255).describe("Existing branch to track"),
+        discardLocalChanges: z
+          .boolean()
+          .optional()
+          .describe(
+            "Set true to throw away uncommitted working-tree changes and force " +
+              "the switch. Only after the user explicitly confirms discarding.",
+          ),
       }),
-      execute: async ({ projectId, branch }) => {
+      execute: async ({ projectId, branch, discardLocalChanges }) => {
         try {
           const project = await assertRepoProject(projectId);
           const result = await switchProjectBranch(
             project,
             branch.trim(),
             userId ?? "agent",
+            { discardLocalChanges: discardLocalChanges ?? false },
           );
-          return { success: true, branch: result.branch };
+          return {
+            success: true,
+            branch: result.branch,
+            discardedChanges: result.discarded?.changes,
+          };
         } catch (error) {
           return toolError(error, "Failed to switch branch");
         }
@@ -1142,6 +1335,29 @@ export const createDbtServerTools = (
           };
         } catch (error) {
           return toolError(error, "Failed to list branches");
+        }
+      },
+    }),
+
+    dbt_delete_branch: tool({
+      description:
+        "Delete a remote branch from the project's repository — use to clean up " +
+        "a stray/merged feature branch (e.g. after its PR is merged, or an " +
+        "abandoned branch from a failed promote). Refuses to delete the branch " +
+        "the project currently tracks (switch away first with dbt_switch_branch) " +
+        "and the repo's default branch. Idempotent: deleting an already-gone " +
+        "branch succeeds. ONLY call after the user confirms the branch name.",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        name: z.string().min(1).max(255).describe("Branch to delete"),
+      }),
+      execute: async ({ projectId, name }) => {
+        try {
+          const project = await assertRepoProject(projectId);
+          const result = await deleteProjectBranch(project, name.trim());
+          return { success: true, deleted: result.deleted };
+        } catch (error) {
+          return toolError(error, "Failed to delete branch");
         }
       },
     }),

--- a/api/src/agents/dbt/prompt.ts
+++ b/api/src/agents/dbt/prompt.ts
@@ -27,15 +27,25 @@ runs execute against the project's warehouse environments (dev/prod).
 6. **Ship (git)** — for repo-bound projects, your file edits land in the working tree but are
    NOT pushed automatically. Only commit after the user explicitly asks. Then call
    \`dbt_git_status\` to confirm what changed, and \`dbt_commit_and_push\` (omit \`message\` to
-   auto-generate one) to push to the tracked branch. Use \`dbt_create_branch\` first when the
-   user wants an isolated branch, and \`dbt_open_pull_request\` when they want review instead of
-   a direct push.
+   auto-generate one) to push to the tracked branch. When the user wants changes on a NEW branch
+   for review, use \`dbt_commit_to_branch\` (atomic branch+commit) — NOT \`dbt_create_branch\` then
+   \`dbt_commit_and_push\`, which can race a concurrent commit and strand the changes on the wrong
+   branch. Then \`dbt_open_pull_request\`. If a build runs against a stale checkout (fewer
+   models/sources than the branch has, e.g. a merged PR not yet picked up), call
+   \`dbt_sync_from_repo\` to re-pull the tracked branch. Clean up merged/stray branches with
+   \`dbt_delete_branch\`.
 
 ## Rules
 
 - Never commit or push proactively — file edits stay in the working tree until the user asks
   you to commit. Prefer pushing to the tracked branch (mirrors the IDE button); only branch or
   open a PR when the user asks for it.
+- To promote working-tree changes onto a new branch, always use the atomic \`dbt_commit_to_branch\`
+  instead of separate branch + commit calls — the two-step flow is racy.
+- Switching branches OVERWRITES the working tree. \`dbt_switch_branch\` refuses when there are
+  uncommitted changes; commit them first, or pass \`discardLocalChanges\` only after the user
+  explicitly confirms abandoning them. If a user reports missing/lost files, recover them with
+  \`dbt_list_recoverable_files\` then \`dbt_restore_file\` before doing anything else.
 
 - Load the \`dbt\` system skill for materializations, incremental strategies, snapshots, and
   adapter quirks before writing non-trivial models.

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -157,9 +157,17 @@ run; always follow up with \`dbt_get_run\` to report whether it actually passed 
 
 Git (repo-bound projects): your edits land in the working tree but are NOT pushed automatically.
 Only commit when the user asks. Check \`dbt_git_status\`, then \`dbt_commit_and_push\` (omit
-\`message\` to auto-generate one) to push to the tracked branch — same as the IDE button. Use
-\`dbt_create_branch\` first for an isolated branch, and \`dbt_open_pull_request\` only when the user
-wants review instead of a direct push. Never commit, push, switch branches, or open a PR proactively.
+\`message\` to auto-generate one) to push to the tracked branch — same as the IDE button. To put
+changes on a NEW branch for review, use \`dbt_commit_to_branch\` (atomic branch+commit) rather than
+\`dbt_create_branch\` + \`dbt_commit_and_push\` — the two-step version can race a concurrent commit and
+strand the changes on the wrong branch. Then \`dbt_open_pull_request\`. If a run builds from a stale
+checkout (fewer models/sources than the branch actually has, e.g. a merged PR not picked up), call
+\`dbt_sync_from_repo\` to re-pull the tracked branch. Use \`dbt_delete_branch\` to clean up merged or
+stray branches. Switching branches OVERWRITES the working tree: \`dbt_switch_branch\` refuses when
+there are uncommitted changes — commit them first, or pass \`discardLocalChanges\` only after the
+user confirms abandoning them. If a user reports lost/missing files, use
+\`dbt_list_recoverable_files\` + \`dbt_restore_file\` to recover soft-deleted work. Never commit, push,
+switch branches, sync, or open a PR proactively.
 
 For conventions (staging/marts layout, ref()/source(), materializations, incremental models,
 snapshots, schema.yml tests), load the \`dbt\` system skill.`;

--- a/api/src/agents/modes/registry.ts
+++ b/api/src/agents/modes/registry.ts
@@ -175,11 +175,17 @@ const TRANSFORM_MODE_TOOL_NAMES: string[] = [
   "dbt_update_job",
   // Git: commit/push edits to the connected repo (only when the user asks).
   "dbt_git_status",
+  "dbt_sync_from_repo",
   "dbt_commit_and_push",
+  "dbt_commit_to_branch",
   "dbt_create_branch",
   "dbt_switch_branch",
   "dbt_list_branches",
+  "dbt_delete_branch",
   "dbt_open_pull_request",
+  // Recovery: surface + restore work hidden by a destructive switch/sync.
+  "dbt_list_recoverable_files",
+  "dbt_restore_file",
   // Discovery: inspect sources before writing staging models; preview built
   // tables after dbt_run_model.
   "list_connections",

--- a/api/src/dbt/dbt-ci.service.ts
+++ b/api/src/dbt/dbt-ci.service.ts
@@ -69,7 +69,11 @@ export async function handlePushEvent(params: {
   let synced = 0;
   for (const project of projects) {
     try {
-      await syncProjectFromRepo(project, "github-webhook");
+      // preserveLocalEdits: a push to the tracked branch must never wipe a
+      // user's uncommitted working-tree changes (they'd be unrecoverable).
+      await syncProjectFromRepo(project, "github-webhook", {
+        preserveLocalEdits: true,
+      });
       synced++;
     } catch (error) {
       logger.warn("push auto-sync failed", {
@@ -147,7 +151,11 @@ export async function handlePullRequestEvent(
     if (!project.ci?.enabled) continue;
     try {
       // Pull the head into the working tree so the run reflects the PR.
-      await syncProjectFromRepo(project, "github-webhook");
+      // preserveLocalEdits: a background sync must never destroy a user's
+      // uncommitted working-tree changes.
+      await syncProjectFromRepo(project, "github-webhook", {
+        preserveLocalEdits: true,
+      });
 
       // Slim CI selection: state:modified+ when a prod manifest exists,
       // otherwise the downstream closure of the PR's changed models.

--- a/api/src/dbt/dbt-github-git.service.ts
+++ b/api/src/dbt/dbt-github-git.service.ts
@@ -7,13 +7,18 @@
  * blob SHA at the last import/sync/push, so the diff against the branch is a
  * pure local computation. Pushing builds a single commit via the Git Data API.
  */
-import { DbtFile, type IDbtProject } from "../database/workspace-schema";
+import {
+  DbtFile,
+  DbtProject,
+  type IDbtProject,
+} from "../database/workspace-schema";
 import { resolveRepoToken } from "../integrations/github/app-auth";
 import { gitBlobSha } from "../integrations/github/git-blob";
 import {
   commitChanges,
   createBranch,
   createPullRequest,
+  deleteBranch,
   getBlobContent,
   getRefCommit,
   getRepoInfo,
@@ -22,6 +27,59 @@ import {
   type TreeChange,
 } from "../integrations/github/github-api";
 import { syncProjectFromRepo } from "./dbt-github-sync.service";
+
+/**
+ * Per-project promise-chain lock. Every git mutation (commit, branch create,
+ * branch switch, atomic promote) runs through this so they can't interleave on
+ * stale in-memory copies of `project.repo.branch`. Mirrors the warm-dir lock in
+ * workspace-dir.service.ts: each acquirer waits on the previous holder.
+ *
+ * This is what closes the race that committed working-tree changes to `main`
+ * while a branch-create was mid-flight: concurrent callers are now serialized,
+ * and each re-reads `repo.branch` from Mongo inside the critical section instead
+ * of trusting whatever branch its caller loaded.
+ */
+const gitLocks = new Map<string, Promise<void>>();
+
+async function withProjectGitLock<T>(
+  projectId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const previous = gitLocks.get(projectId) ?? Promise.resolve();
+  let release: () => void = () => {};
+  const gate = new Promise<void>(resolve => {
+    release = resolve;
+  });
+  const chained = previous.then(() => gate);
+  gitLocks.set(projectId, chained);
+
+  await previous;
+  try {
+    return await fn();
+  } finally {
+    release();
+    if (gitLocks.get(projectId) === chained) gitLocks.delete(projectId);
+  }
+}
+
+/**
+ * Re-load the project document fresh from Mongo inside a locked section so we
+ * act on the current `repo.branch`/`lastSyncedSha`, not a stale copy the caller
+ * loaded before the lock was acquired.
+ */
+type RepoBoundProject = IDbtProject & {
+  repo: NonNullable<IDbtProject["repo"]>;
+};
+
+async function reloadRepoProject(
+  project: IDbtProject,
+): Promise<RepoBoundProject> {
+  const fresh = await DbtProject.findById(project._id);
+  if (!fresh?.repo) {
+    throw new Error("Project is not connected to a repository");
+  }
+  return fresh as RepoBoundProject;
+}
 
 export interface GitFileStatus {
   path: string;
@@ -139,23 +197,43 @@ export interface CommitResult {
  * Commit all working-tree changes and push them to the tracked branch in a
  * single commit. Updates each file's recorded blob SHA and hard-deletes files
  * that were removed (so they don't linger as ghost deletions).
+ *
+ * Runs under the per-project git lock and re-reads the project inside it, so
+ * the commit always targets the branch that is actually current in Mongo — not
+ * a stale `repo.branch` from before a concurrent branch-create/switch.
  */
 export async function commitAndPush(
   project: IDbtProject,
   params: { message: string; updatedBy: string },
 ): Promise<CommitResult> {
+  return withProjectGitLock(project._id.toString(), async () => {
+    const fresh = await reloadRepoProject(project);
+    const status = await getGitStatus(fresh);
+    if (!status.hasChanges) {
+      return {
+        committed: false,
+        branch: fresh.repo.branch,
+        pushed: { added: 0, modified: 0, deleted: 0 },
+      };
+    }
+    return pushWorkingTree(fresh, status, params.message);
+  });
+}
+
+/**
+ * Build a single commit from the working tree and push it to the project's
+ * currently tracked branch (`project.repo.branch`). Updates each file's blob
+ * SHA and hard-deletes removed files. The caller MUST hold the project git lock
+ * and pass a freshly loaded `project` plus its computed `status`.
+ */
+async function pushWorkingTree(
+  project: IDbtProject,
+  status: GitStatus,
+  message: string,
+): Promise<CommitResult> {
   if (!project.repo) {
     throw new Error("Project is not connected to a repository");
   }
-  const status = await getGitStatus(project);
-  if (!status.hasChanges) {
-    return {
-      committed: false,
-      branch: status.branch,
-      pushed: { added: 0, modified: 0, deleted: 0 },
-    };
-  }
-
   const token = await resolveRepoToken(project.repo.installationId);
   const { owner, repo, branch } = project.repo;
 
@@ -230,7 +308,7 @@ export async function commitAndPush(
       branch,
       parentSha: commitSha,
       baseTreeSha: treeSha,
-      message: params.message,
+      message,
       changes: treeChanges,
     },
     token,
@@ -255,6 +333,53 @@ export async function commitAndPush(
   };
 }
 
+export interface PromoteResult extends CommitResult {
+  /** Branch the new branch was forked from (the previously tracked branch). */
+  fromBranch: string;
+}
+
+/**
+ * Atomic "promote": create a feature branch off the currently tracked branch's
+ * HEAD and commit the working tree onto it — in one locked critical section, so
+ * no concurrent commit can land the changes on the wrong branch (e.g. main).
+ *
+ * This replaces the racy three-step branch → commit → PR dance: the branch and
+ * its commit are now inseparable. After this, the project tracks the new branch
+ * with a clean working tree; open a PR with `openProjectPullRequest`.
+ */
+export async function commitToNewBranch(
+  project: IDbtProject,
+  params: { branchName: string; message: string; updatedBy: string },
+): Promise<PromoteResult> {
+  return withProjectGitLock(project._id.toString(), async () => {
+    const fresh = await reloadRepoProject(project);
+    const status = await getGitStatus(fresh);
+    if (!status.hasChanges) {
+      throw new Error(
+        "No working-tree changes to promote — nothing to put on a new branch. " +
+          "The changes may already be committed (check dbt_git_status).",
+      );
+    }
+
+    const token = await resolveRepoToken(fresh.repo.installationId);
+    const { owner, repo } = fresh.repo;
+    const fromBranch = fresh.repo.branch;
+
+    // Fork the new branch from the branch we're currently tracking, then point
+    // the project at it BEFORE committing so pushWorkingTree targets the new
+    // branch. The commit's parent is the fork point, so the branch contains
+    // exactly the working-tree delta.
+    const { commitSha } = await getRefCommit(owner, repo, fromBranch, token);
+    await createBranch(owner, repo, params.branchName, commitSha, token);
+    fresh.repo.branch = params.branchName;
+    fresh.markModified("repo");
+    await fresh.save();
+
+    const result = await pushWorkingTree(fresh, status, params.message);
+    return { ...result, fromBranch };
+  });
+}
+
 export async function listProjectBranches(
   project: IDbtProject,
 ): Promise<string[]> {
@@ -273,38 +398,159 @@ export async function createProjectBranch(
   project: IDbtProject,
   branchName: string,
 ): Promise<{ branch: string }> {
-  if (!project.repo) {
-    throw new Error("Project is not connected to a repository");
-  }
-  const token = await resolveRepoToken(project.repo.installationId);
-  const { owner, repo } = project.repo;
-  const { commitSha } = await getRefCommit(
-    owner,
-    repo,
-    project.repo.branch,
-    token,
-  );
-  await createBranch(owner, repo, branchName, commitSha, token);
-  project.repo.branch = branchName;
-  project.markModified("repo");
-  await project.save();
-  return { branch: branchName };
+  return withProjectGitLock(project._id.toString(), async () => {
+    const fresh = await reloadRepoProject(project);
+    const token = await resolveRepoToken(fresh.repo.installationId);
+    const { owner, repo } = fresh.repo;
+    const { commitSha } = await getRefCommit(
+      owner,
+      repo,
+      fresh.repo.branch,
+      token,
+    );
+    await createBranch(owner, repo, branchName, commitSha, token);
+    fresh.repo.branch = branchName;
+    fresh.markModified("repo");
+    await fresh.save();
+    return { branch: branchName };
+  });
 }
 
-/** Switch the tracked branch and pull its contents into the working tree. */
+/**
+ * Switch the tracked branch and pull its contents into the working tree.
+ *
+ * This OVERWRITES the working tree with the target branch. To prevent silent
+ * data loss it REFUSES when there are uncommitted working-tree changes, unless
+ * the caller explicitly passes `discardLocalChanges`. (This is the guard that
+ * stops a branch move from eating un-pushed models, as happened before.)
+ */
 export async function switchProjectBranch(
   project: IDbtProject,
   branchName: string,
   updatedBy: string,
-): Promise<{ branch: string }> {
-  if (!project.repo) {
-    throw new Error("Project is not connected to a repository");
-  }
-  project.repo.branch = branchName;
-  project.markModified("repo");
-  await project.save();
-  await syncProjectFromRepo(project, updatedBy);
-  return { branch: branchName };
+  options: { discardLocalChanges?: boolean } = {},
+): Promise<{ branch: string; discarded?: GitStatus }> {
+  return withProjectGitLock(project._id.toString(), async () => {
+    const fresh = await reloadRepoProject(project);
+
+    let discarded: GitStatus | undefined;
+    if (!options.discardLocalChanges) {
+      const status = await getGitStatus(fresh);
+      if (status.hasChanges) {
+        const summary = `${status.added} added, ${status.modified} modified, ${status.deleted} deleted`;
+        throw new Error(
+          `Refusing to switch from "${fresh.repo.branch}" to "${branchName}": ` +
+            `${status.changes.length} uncommitted working-tree change(s) (${summary}) ` +
+            "would be lost. Commit them first (dbt_commit_and_push to push to the " +
+            "current branch, or dbt_commit_to_branch to move them to a new branch), " +
+            "or call again with discardLocalChanges to abandon them on purpose.",
+        );
+      }
+    } else {
+      // Record what we're discarding so the caller can surface/inspect it.
+      discarded = await getGitStatus(fresh);
+    }
+
+    fresh.repo.branch = branchName;
+    fresh.markModified("repo");
+    await fresh.save();
+    // Explicit, confirmed switch: remote is the source of truth.
+    await syncProjectFromRepo(fresh, updatedBy);
+    return discarded?.hasChanges
+      ? { branch: branchName, discarded }
+      : { branch: branchName };
+  });
+}
+
+/**
+ * Delete a remote branch. Refuses to delete the branch the project currently
+ * tracks (switch away first) and the repo's default branch. Idempotent: a
+ * branch that is already gone resolves successfully.
+ */
+export async function deleteProjectBranch(
+  project: IDbtProject,
+  branchName: string,
+): Promise<{ deleted: string }> {
+  return withProjectGitLock(project._id.toString(), async () => {
+    const fresh = await reloadRepoProject(project);
+    const token = await resolveRepoToken(fresh.repo.installationId);
+    const { owner, repo } = fresh.repo;
+    if (branchName === fresh.repo.branch) {
+      throw new Error(
+        `Cannot delete "${branchName}" — it is the project's currently tracked ` +
+          "branch. Switch to another branch first (dbt_switch_branch).",
+      );
+    }
+    const info = await getRepoInfo(owner, repo, token);
+    if (branchName === info.defaultBranch) {
+      throw new Error(
+        `Refusing to delete the repository's default branch "${branchName}".`,
+      );
+    }
+    await deleteBranch(owner, repo, branchName, token);
+    return { deleted: branchName };
+  });
+}
+
+export interface RecoverableFile {
+  path: string;
+  content: string;
+  updatedAt: Date;
+  updatedBy: string;
+}
+
+/**
+ * Soft-deleted files whose content is still retained in Mongo and can be
+ * restored — e.g. work hidden by a destructive branch switch/sync before the
+ * non-destructive guards landed. These don't appear in the normal file tree.
+ */
+export async function listRecoverableFiles(
+  project: IDbtProject,
+): Promise<RecoverableFile[]> {
+  const files = await DbtFile.find({
+    projectId: project._id,
+    is_deleted: true,
+  })
+    .select("path content updatedAt updatedBy")
+    .sort({ updatedAt: -1 })
+    .lean();
+  return files
+    .filter(f => (f.content ?? "").length > 0)
+    .map(f => ({
+      path: f.path,
+      content: f.content ?? "",
+      updatedAt: f.updatedAt,
+      updatedBy: f.updatedBy,
+    }));
+}
+
+/**
+ * Restore a soft-deleted file back into the working tree. It comes back as a
+ * pending "added" change (no recorded blob), so the user can review and commit
+ * it. Returns the restored content for confirmation.
+ */
+export async function restoreDeletedFile(
+  project: IDbtProject,
+  path: string,
+  updatedBy: string,
+): Promise<{ path: string; content: string }> {
+  return withProjectGitLock(project._id.toString(), async () => {
+    const file = await DbtFile.findOne({ projectId: project._id, path })
+      .select("content is_deleted")
+      .lean();
+    if (!file) {
+      throw new Error(`No file (recoverable or otherwise) at "${path}".`);
+    }
+    if (!file.is_deleted) {
+      // Already present in the working tree — nothing to restore.
+      return { path, content: file.content ?? "" };
+    }
+    await DbtFile.updateOne(
+      { projectId: project._id, path },
+      { $set: { is_deleted: false, updatedBy }, $unset: { repoBlobSha: "" } },
+    ).exec();
+    return { path, content: file.content ?? "" };
+  });
 }
 
 export async function openProjectPullRequest(

--- a/api/src/dbt/dbt-github-sync.service.ts
+++ b/api/src/dbt/dbt-github-sync.service.ts
@@ -16,6 +16,7 @@ import {
   type IDbtRepoBinding,
 } from "../database/workspace-schema";
 import { resolveRepoToken } from "../integrations/github/app-auth";
+import { gitBlobSha } from "../integrations/github/git-blob";
 import {
   getBlobContent,
   getBranchHeadSha,
@@ -160,20 +161,58 @@ export interface SyncResult {
   updated: number;
   deleted: number;
   skippedLarge: string[];
+  /**
+   * Paths skipped because they had uncommitted local edits and
+   * `preserveLocalEdits` was set — left untouched so the work isn't lost.
+   */
+  preservedLocal: string[];
+}
+
+export interface SyncOptions {
+  /**
+   * When true, never overwrite or soft-delete a file that has uncommitted local
+   * changes (locally added, or content diverged from its last-synced blob).
+   * Non-conflicting files still fast-forward to the remote. This makes a sync
+   * safe like `git pull` (which refuses to clobber a dirty working tree) and is
+   * used for background/automatic syncs (push webhooks, branch switches that
+   * the caller hasn't explicitly told to discard). Defaults to false, where the
+   * remote is the source of truth (an explicit, user-confirmed overwrite).
+   */
+  preserveLocalEdits?: boolean;
+}
+
+/** A file is locally modified if its current content no longer matches the
+ * blob recorded at the last sync/push — or it was added locally and never
+ * synced (no recorded blob). Soft-deleted rows are handled separately. */
+function isLocallyModified(prev: {
+  content?: string;
+  is_deleted?: boolean;
+  repoBlobSha?: string;
+}): boolean {
+  if (prev.is_deleted) return false;
+  if (!prev.repoBlobSha) return true; // locally added, never pushed
+  return gitBlobSha(prev.content ?? "") !== prev.repoBlobSha;
 }
 
 /**
  * Pull the latest repo state into an existing repo-bound project: upsert
  * changed files, soft-delete files no longer on the branch, and stamp the
  * project's lastSyncedSha/At.
+ *
+ * By default the remote wins (use only for explicit, user-confirmed pulls). For
+ * background syncs pass `{ preserveLocalEdits: true }` so a remote push or a
+ * branch switch can never silently destroy a user's uncommitted working-tree
+ * changes — those files are left exactly as-is and reported in `preservedLocal`.
  */
 export async function syncProjectFromRepo(
   project: IDbtProject,
   updatedBy: string,
+  options: SyncOptions = {},
 ): Promise<SyncResult> {
   if (!project.repo) {
     throw new Error("Project is not connected to a repository");
   }
+  const preserveLocalEdits = options.preserveLocalEdits ?? false;
   const { sha, files, skippedLarge } = await fetchRepoDbtFiles(project.repo);
 
   const existing = await DbtFile.find({ projectId: project._id })
@@ -185,10 +224,20 @@ export async function syncProjectFromRepo(
   let added = 0;
   let updated = 0;
   let deleted = 0;
+  const preservedLocal: string[] = [];
 
   const ops: Array<Promise<unknown>> = [];
   for (const file of files) {
     const prev = existingByPath.get(file.path);
+
+    // Don't clobber a file the user is actively editing locally. Leave it
+    // untouched (and keep its old base blob) so it still shows as a pending
+    // change the user can review/commit, rather than vanishing.
+    if (preserveLocalEdits && prev && isLocallyModified(prev)) {
+      preservedLocal.push(file.path);
+      continue;
+    }
+
     if (!prev || prev.is_deleted) {
       added++;
     } else if (prev.content !== file.content) {
@@ -228,6 +277,15 @@ export async function syncProjectFromRepo(
   // nor discarded (the next pull would re-create it).
   for (const prev of existing) {
     if (remotePaths.has(prev.path)) continue;
+
+    // A locally-added file (never on this branch) is unsaved work, not a
+    // deletion. Under preserveLocalEdits, keep it instead of soft-deleting it —
+    // this is the exact case that used to wipe new models on a branch switch.
+    if (preserveLocalEdits && !prev.is_deleted && !prev.repoBlobSha) {
+      preservedLocal.push(prev.path);
+      continue;
+    }
+
     if (!prev.is_deleted) {
       deleted++;
       ops.push(
@@ -258,7 +316,7 @@ export async function syncProjectFromRepo(
   project.markModified("repo");
   await project.save();
 
-  return { sha, added, updated, deleted, skippedLarge };
+  return { sha, added, updated, deleted, skippedLarge, preservedLocal };
 }
 
 /** Build a DbtFile insert payload from fetched repo files (first import). */

--- a/api/src/integrations/github/github-api.ts
+++ b/api/src/integrations/github/github-api.ts
@@ -355,6 +355,32 @@ export async function createBranch(
   });
 }
 
+/**
+ * Delete a branch ref. Treats "already gone" (404/422) as success so cleanup
+ * is idempotent; any other failure (e.g. protected branch, no permission) is
+ * surfaced.
+ */
+export async function deleteBranch(
+  owner: string,
+  repo: string,
+  branch: string,
+  token?: string,
+): Promise<void> {
+  try {
+    await ghFetch(
+      `/repos/${owner}/${repo}/git/refs/heads/${encodeURIComponent(branch)}`,
+      token,
+      { method: "DELETE" },
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes("GitHub 404") || message.includes("GitHub 422")) {
+      return; // ref already deleted — nothing to do
+    }
+    throw error;
+  }
+}
+
 /** Post a commit status (the GitHub "check" dot) on a SHA. context = "mako/ci". */
 export async function postCommitStatus(
   owner: string,

--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -46,7 +46,9 @@ import {
 } from "../dbt/dbt-github-sync.service";
 import {
   commitAndPush,
+  commitToNewBranch,
   createProjectBranch,
+  deleteProjectBranch,
   getGitStatus,
   getProjectFileDiff,
   listProjectBranches,
@@ -769,7 +771,12 @@ dbtRoutes.post("/projects/:projectId/sync", async (c: AuthenticatedContext) => {
     if (!project.repo) {
       return badRequest(c, "Project is not connected to a repository");
     }
-    const result = await syncProjectFromRepo(project, getUserId(c));
+    // Safe by default: preserve uncommitted local edits unless the caller
+    // explicitly opts into letting the remote overwrite them (?discard=true).
+    const discard = c.req.query("discard") === "true";
+    const result = await syncProjectFromRepo(project, getUserId(c), {
+      preserveLocalEdits: !discard,
+    });
     return c.json({ success: true, ...result, project });
   } catch (error) {
     return serverError(c, error, "Failed to sync dbt project from GitHub");
@@ -781,14 +788,20 @@ dbtRoutes.post("/projects/:projectId/sync", async (c: AuthenticatedContext) => {
 // ---------------------------------------------------------------------------
 
 const commitSchema = z.object({ message: z.string().min(1).max(500) });
-const branchSchema = z.object({
-  name: z
-    .string()
-    .min(1)
-    .max(255)
-    .regex(/^[^\s~^:?*[\\]+$/, "Invalid branch name"),
+const branchNameField = z
+  .string()
+  .min(1)
+  .max(255)
+  .regex(/^[^\s~^:?*[\\]+$/, "Invalid branch name");
+const branchSchema = z.object({ name: branchNameField });
+const commitToBranchSchema = z.object({
+  name: branchNameField,
+  message: z.string().min(1).max(500),
 });
-const switchBranchSchema = z.object({ branch: z.string().min(1).max(255) });
+const switchBranchSchema = z.object({
+  branch: z.string().min(1).max(255),
+  discardLocalChanges: z.boolean().optional(),
+});
 const pullRequestSchema = z.object({
   title: z.string().min(1).max(255),
   body: z.string().max(10_000).optional(),
@@ -937,6 +950,62 @@ dbtRoutes.post(
   },
 );
 
+// POST /projects/:projectId/git/commit-to-branch — atomic create-branch +
+// commit the working tree onto it (race-free promote).
+dbtRoutes.post(
+  "/projects/:projectId/git/commit-to-branch",
+  async (c: AuthenticatedContext) => {
+    try {
+      const project = await findProject(c);
+      if (!project) {
+        return c.json({ success: false, error: "dbt project not found" }, 404);
+      }
+      if (!project.repo) {
+        return badRequest(c, "Project is not connected to a repository");
+      }
+      const parsed = commitToBranchSchema.safeParse(await c.req.json());
+      if (!parsed.success) {
+        return badRequest(c, parsed.error.issues[0]?.message ?? "Invalid body");
+      }
+      const result = await commitToNewBranch(project, {
+        branchName: parsed.data.name,
+        message: parsed.data.message,
+        updatedBy: getUserId(c),
+      });
+      return c.json({ success: true, ...result });
+    } catch (error) {
+      return serverError(c, error, "Failed to commit to new branch");
+    }
+  },
+);
+
+// DELETE /projects/:projectId/git/branch/:name — delete a remote branch.
+dbtRoutes.delete(
+  "/projects/:projectId/git/branch/:name",
+  async (c: AuthenticatedContext) => {
+    try {
+      const project = await findProject(c);
+      if (!project) {
+        return c.json({ success: false, error: "dbt project not found" }, 404);
+      }
+      if (!project.repo) {
+        return badRequest(c, "Project is not connected to a repository");
+      }
+      const name = c.req.param("name");
+      if (!name) {
+        return badRequest(c, "Branch name is required");
+      }
+      const result = await deleteProjectBranch(
+        project,
+        decodeURIComponent(name),
+      );
+      return c.json({ success: true, ...result });
+    } catch (error) {
+      return serverError(c, error, "Failed to delete branch");
+    }
+  },
+);
+
 // POST /projects/:projectId/git/switch-branch — track + pull another branch.
 dbtRoutes.post(
   "/projects/:projectId/git/switch-branch",
@@ -957,6 +1026,7 @@ dbtRoutes.post(
         project,
         parsed.data.branch,
         getUserId(c),
+        { discardLocalChanges: parsed.data.discardLocalChanges ?? false },
       );
       return c.json({ success: true, ...result, project });
     } catch (error) {

--- a/app/src/components/DbtExplorer.tsx
+++ b/app/src/components/DbtExplorer.tsx
@@ -29,6 +29,8 @@ import {
   Chip,
   CircularProgress,
   Divider,
+  Snackbar,
+  Alert,
   useTheme,
 } from "@mui/material";
 import { DiffEditor } from "@monaco-editor/react";
@@ -375,6 +377,12 @@ export function DbtExplorer() {
   const [generatingMessage, setGeneratingMessage] = useState(false);
   const [gitBusy, setGitBusy] = useState(false);
   const [gitResult, setGitResult] = useState<string | null>(null);
+  const [syncSnack, setSyncSnack] = useState<{
+    severity: "success" | "info" | "warning" | "error";
+    message: string;
+    /** When set, the snackbar offers an "Overwrite local" re-pull action. */
+    projectId?: string;
+  } | null>(null);
   const [diffData, setDiffData] = useState<GitFileDiff | null>(null);
   const [diffLoading, setDiffLoading] = useState(false);
   const [branchTarget, setBranchTarget] = useState<string | null>(null);
@@ -604,14 +612,44 @@ export function DbtExplorer() {
   }, []);
 
   const handleSyncProject = useCallback(
-    async (projectId: string) => {
+    async (projectId: string, discard = false) => {
       if (!workspaceId) return;
       setSyncingProjectId(projectId);
-      const result = await syncProjectFromGitHub(workspaceId, projectId);
+      const result = await syncProjectFromGitHub(workspaceId, projectId, {
+        discard,
+      });
       setSyncingProjectId(null);
-      if (result) {
-        await fetchFiles(workspaceId, projectId);
-        await fetchGitStatus(workspaceId, projectId);
+      if (!result) {
+        setSyncSnack({
+          severity: "error",
+          message:
+            useDbtStore.getState().error.projects ?? "Pull from remote failed.",
+        });
+        return;
+      }
+      await fetchFiles(workspaceId, projectId);
+      await fetchGitStatus(workspaceId, projectId);
+
+      const ref = result.branch ?? "remote";
+      const changed = result.added + result.updated + result.deleted;
+      const kept = result.preservedLocal.length;
+      if (changed === 0 && kept === 0) {
+        setSyncSnack({
+          severity: "info",
+          message: `Already up to date with ${ref}.`,
+        });
+      } else {
+        const parts = `+${result.added} ~${result.updated} −${result.deleted}`;
+        setSyncSnack({
+          severity: kept > 0 ? "warning" : "success",
+          message:
+            `Pulled ${ref}: ${parts}` +
+            (kept > 0
+              ? ` · kept ${kept} file${kept === 1 ? "" : "s"} with uncommitted ` +
+                "local edits. Commit them, or overwrite with the remote."
+              : ""),
+          projectId: kept > 0 ? projectId : undefined,
+        });
       }
     },
     [workspaceId, syncProjectFromGitHub, fetchFiles, fetchGitStatus],
@@ -2296,6 +2334,39 @@ export function DbtExplorer() {
           </Button>
         </DialogActions>
       </Dialog>
+
+      <Snackbar
+        open={!!syncSnack}
+        autoHideDuration={syncSnack?.severity === "warning" ? 10000 : 6000}
+        onClose={() => setSyncSnack(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      >
+        {syncSnack ? (
+          <Alert
+            severity={syncSnack.severity}
+            variant="filled"
+            onClose={() => setSyncSnack(null)}
+            sx={{ maxWidth: 520 }}
+            action={
+              syncSnack.projectId ? (
+                <Button
+                  color="inherit"
+                  size="small"
+                  onClick={() => {
+                    const pid = syncSnack.projectId;
+                    setSyncSnack(null);
+                    if (pid) void handleSyncProject(pid, true);
+                  }}
+                >
+                  Overwrite local
+                </Button>
+              ) : undefined
+            }
+          >
+            {syncSnack.message}
+          </Alert>
+        ) : undefined}
+      </Snackbar>
     </>
   );
 }

--- a/app/src/store/dbtStore.ts
+++ b/app/src/store/dbtStore.ts
@@ -103,6 +103,10 @@ export interface SyncResult {
   updated: number;
   deleted: number;
   skippedLarge: string[];
+  /** Files left untouched because they had uncommitted local edits. */
+  preservedLocal: string[];
+  /** The branch that was pulled (for user-facing feedback). */
+  branch?: string;
 }
 
 export interface GitFileStatus {
@@ -345,6 +349,7 @@ interface DbtActions {
   syncProjectFromGitHub: (
     workspaceId: string,
     projectId: string,
+    options?: { discard?: boolean },
   ) => Promise<SyncResult | null>;
   fetchGitStatus: (
     workspaceId: string,
@@ -762,11 +767,15 @@ export const useDbtStore = create<DbtStore>()(
       }
     },
 
-    syncProjectFromGitHub: async (workspaceId, projectId) => {
+    syncProjectFromGitHub: async (workspaceId, projectId, options) => {
       try {
+        const query = options?.discard ? "?discard=true" : "";
         const response = await apiClient.post<
           { success: boolean; project: DbtProjectItem } & SyncResult
-        >(`/workspaces/${workspaceId}/dbt/projects/${projectId}/sync`, {});
+        >(
+          `/workspaces/${workspaceId}/dbt/projects/${projectId}/sync${query}`,
+          {},
+        );
         set(state => {
           const idx = state.projects.findIndex(p => p._id === projectId);
           if (idx >= 0) state.projects[idx] = response.project;
@@ -779,6 +788,8 @@ export const useDbtStore = create<DbtStore>()(
           updated: response.updated,
           deleted: response.deleted,
           skippedLarge: response.skippedLarge ?? [],
+          preservedLocal: response.preservedLocal ?? [],
+          branch: response.project.repo?.branch,
         };
       } catch (error) {
         set(state => {

--- a/packages/agent-tools/src/read-only-tools.ts
+++ b/packages/agent-tools/src/read-only-tools.ts
@@ -55,6 +55,7 @@ export const READ_ONLY_TOOL_NAMES: ReadonlySet<string> = new Set<string>([
   // dbt git reads (status + branch listing never mutate the repo)
   "dbt_git_status",
   "dbt_list_branches",
+  "dbt_list_recoverable_files",
   // Surface-scoped data-source reads (apps + dashboards, local DuckDB only)
   "list_data_sources",
   "inspect_data_source",


### PR DESCRIPTION
## Summary

The dbt project "working tree" is MongoDB (`DbtFile`), with `repo.branch` as the single tracked ref. Three classes of bug let an agent or the IDE silently lose a user's work during git operations. This PR makes every repo-bound git mutation **serialized, branch-correct, and non-destructive**, and adds recovery + feedback.

### Root causes fixed

1. **Promote race** — `dbt_create_branch` + `dbt_commit_and_push` were separate, unlocked operations, each reading its own stale copy of `repo.branch`. A concurrent commit (e.g. the IDE "Commit & push" button) could land the changes on `main` while the new feature branch stayed empty → "No changes to commit" / "No commits between main and feat".
2. **Destructive sync** — `switchProjectBranch` and the push-webhook sync treated the remote as the source of truth and overwrote / soft-deleted working-tree files **with no guard**, silently destroying uncommitted work on a branch move or a teammate's push.
3. **Silent pull** — "Pull from remote" surfaced no feedback, and (after the safe-sync change) could skip locally-edited files with no explanation, looking like "nothing happened".

### Changes

- **Per-project git lock** (`withProjectGitLock`); every mutation reloads the project inside the lock so a commit always targets the branch that is actually current.
- **Atomic `commitToNewBranch()`** (+ `dbt_commit_to_branch` tool & `POST /git/commit-to-branch`) — creates the branch and commits the tree in one locked step.
- **`syncProjectFromRepo` gains `preserveLocalEdits`** (default for the push webhook, branch switches, and the IDE pull) so a sync never clobbers uncommitted work; conflicting files are reported in `preservedLocal`.
- **`switchProjectBranch` refuses** when there are pending changes unless `discardLocalChanges` is set.
- **Recovery**: `listRecoverableFiles` / `restoreDeletedFile` (+ `dbt_list_recoverable_files`, `dbt_restore_file`) to bring back soft-deleted work.
- **New tools**: `dbt_sync_from_repo`, `dbt_commit_to_branch`, `dbt_delete_branch` (+ `deleteBranch` GitHub API helper, `DELETE /git/branch/:name`). Registered in the mode registry; read-only allowlist updated for the read-only ones.
- **Frontend**: pull now shows a snackbar with counts + preserved-local files and an **"Overwrite local"** action; agent prompts updated to prefer the atomic promote flow and the recovery tools.

## Test plan

- [x] `pnpm --filter api run lint` — clean
- [x] `tsc -p tsconfig.build.json --noEmit` (api) — clean
- [x] `vitest run` dbt route integration + sync-service tests — pass
- [x] App: `DbtExplorer.tsx` / `dbtStore.ts` lint + typecheck clean (note: pre-existing unrelated `AppBindingEditor.tsx` errors exist on `master`)
- [ ] Manual: promote via `dbt_commit_to_branch` → PR; switch branch with pending changes is refused; pull shows feedback + "Overwrite local"; recover a soft-deleted file

Made with [Cursor](https://cursor.com)