### PR TITLE
feat(agent): add dbt_delete_job tool for deleting saved dbt jobs

### DIFF
--- a/api/src/agent-lib/tools/dbt-job-tools.test.ts
+++ b/api/src/agent-lib/tools/dbt-job-tools.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Agent dbt job tools — in-process integration tests.
+ *
+ * Boots `createDbtServerTools` against an ephemeral mongodb-memory-server and
+ * exercises the `dbt_delete_job` tool end-to-end through real Mongoose
+ * persistence. Heavy collaborators (runner, run scheduler, GitHub git, realtime
+ * bus, entity versioning) are mocked so the test stays deterministic and
+ * offline — it only verifies the tool's workspace scoping, validation, and
+ * delete behavior.
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import mongoose, { Types } from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+
+// Heavy collaborators pulled in transitively by the tools module — stubbed so
+// imports resolve and side-effects are inert.
+vi.mock("../../services/realtime.service", () => ({
+  publishRealtimeEvent: vi.fn(),
+}));
+vi.mock("../../services/entity-version.service", () => ({
+  createVersion: vi.fn(async () => ({})),
+  getLatestVersionNumber: vi.fn(async () => 0),
+  getUserDisplayName: vi.fn(async () => "Tester"),
+}));
+vi.mock("../../dbt/dbt-project.service", () => ({
+  runAdhocDbtCommand: vi.fn(),
+}));
+vi.mock("../../dbt/dbt-run.service", () => ({
+  applyJobScheduleChange: vi.fn(async () => undefined),
+  reconcileStaleQueuedRun: vi.fn(async (r: unknown) => r),
+  triggerDbtJobRun: vi.fn(async () => ({ _id: new Types.ObjectId() })),
+  triggerDbtRun: vi.fn(async () => ({ _id: new Types.ObjectId() })),
+}));
+vi.mock("../../dbt/dbt-github-git.service", () => ({
+  commitAndPush: vi.fn(),
+  createProjectBranch: vi.fn(),
+  getGitStatus: vi.fn(),
+  listProjectBranches: vi.fn(),
+  openProjectPullRequest: vi.fn(),
+  switchProjectBranch: vi.fn(),
+}));
+vi.mock("../../dbt/dbt-commit-message.service", () => ({
+  generateDbtCommitMessage: vi.fn(),
+}));
+vi.mock("../../services/scheduled-query-schedule.service", () => ({
+  validateScheduledConsoleSchedule: vi.fn(() => null),
+}));
+
+// Imported after the mocks are registered.
+import { createDbtServerTools } from "./dbt-tools";
+import { DbtJob, DbtProject } from "../../database/workspace-schema";
+
+let mongo: MongoMemoryServer;
+const WS = new Types.ObjectId().toString();
+const CONN = new Types.ObjectId().toString();
+
+type DeleteJobInput = { projectId: string; jobId: string };
+type ToolResult = {
+  success: boolean;
+  error?: string;
+  jobId?: string;
+  name?: string;
+};
+
+const tools = createDbtServerTools(WS, "u1", { chatId: "chat1" });
+
+function deleteJob(input: DeleteJobInput): Promise<ToolResult> {
+  // The AI SDK tool() wraps execute; call it the way the SDK does at runtime.
+  return (
+    tools.dbt_delete_job.execute as (i: DeleteJobInput) => Promise<ToolResult>
+  )(input);
+}
+
+async function seedProject(): Promise<string> {
+  const project = await DbtProject.create({
+    workspaceId: new Types.ObjectId(WS),
+    name: "Analytics",
+    environments: [
+      {
+        name: "dev",
+        connectionId: new Types.ObjectId(CONN),
+        targetSchema: "analytics",
+        threads: 4,
+      },
+    ],
+    defaultEnvironment: "dev",
+    createdBy: "tester",
+  });
+  return project._id.toString();
+}
+
+async function seedJob(projectId: string): Promise<string> {
+  const job = await DbtJob.create({
+    workspaceId: new Types.ObjectId(WS),
+    projectId: new Types.ObjectId(projectId),
+    name: "nightly",
+    environment: "dev",
+    commands: ["build"],
+    enabled: true,
+    deferToProduction: false,
+    createdBy: "tester",
+  });
+  return job._id.toString();
+}
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  await Promise.all([
+    mongoose.connection.collection("dbt_projects").deleteMany({}),
+    mongoose.connection.collection("dbt_jobs").deleteMany({}),
+  ]);
+});
+
+describe("dbt_delete_job", () => {
+  it("deletes an existing job and removes it from the collection", async () => {
+    const projectId = await seedProject();
+    const jobId = await seedJob(projectId);
+
+    const result = await deleteJob({ projectId, jobId });
+
+    expect(result.success).toBe(true);
+    expect(result.jobId).toBe(jobId);
+    expect(result.name).toBe("nightly");
+    expect(await DbtJob.countDocuments({})).toBe(0);
+  });
+
+  it("returns an error for an unknown job id", async () => {
+    const projectId = await seedProject();
+    const result = await deleteJob({
+      projectId,
+      jobId: new Types.ObjectId().toString(),
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not found/i);
+  });
+
+  it("rejects a malformed job id", async () => {
+    const projectId = await seedProject();
+    const result = await deleteJob({ projectId, jobId: "not-an-objectid" });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/invalid job id/i);
+  });
+
+  it("does not delete a job that belongs to another workspace's project", async () => {
+    // Project + job exist, but under a different workspace than the tool's WS.
+    const otherWs = new Types.ObjectId();
+    const project = await DbtProject.create({
+      workspaceId: otherWs,
+      name: "Other",
+      environments: [
+        {
+          name: "dev",
+          connectionId: new Types.ObjectId(CONN),
+          targetSchema: "analytics",
+          threads: 4,
+        },
+      ],
+      defaultEnvironment: "dev",
+      createdBy: "tester",
+    });
+    const job = await DbtJob.create({
+      workspaceId: otherWs,
+      projectId: project._id,
+      name: "foreign",
+      environment: "dev",
+      commands: ["build"],
+      enabled: true,
+      deferToProduction: false,
+      createdBy: "tester",
+    });
+
+    const result = await deleteJob({
+      projectId: project._id.toString(),
+      jobId: job._id.toString(),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not found|access denied/i);
+    expect(await DbtJob.countDocuments({ _id: job._id })).toBe(1);
+  });
+});

--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -978,6 +978,36 @@ export const createDbtServerTools = (
       },
     }),
 
+    dbt_delete_job: tool({
+      description:
+        "Permanently delete a saved dbt job. Call read_dbt_project_tree first " +
+        "to confirm the job id and name. Only delete when the user explicitly " +
+        "asks — this removes the job definition and stops its schedule; past " +
+        "run history is kept.",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        jobId: z.string().describe("dbt job ID (from read_dbt_project_tree)"),
+      }),
+      execute: async ({ projectId, jobId }) => {
+        try {
+          const project = await assertProject(projectId);
+          if (!Types.ObjectId.isValid(jobId)) {
+            return { success: false, error: "Invalid job id" };
+          }
+          const job = await DbtJob.findOne({
+            _id: new Types.ObjectId(jobId),
+            projectId: project._id,
+          });
+          if (!job) return { success: false, error: "Job not found" };
+          const name = job.name;
+          await DbtJob.deleteOne({ _id: job._id, projectId: project._id });
+          return { success: true, jobId: job._id.toString(), name };
+        } catch (error) {
+          return toolError(error, "Failed to delete dbt job");
+        }
+      },
+    }),
+
     dbt_git_status: tool({
       description:
         "Show the working-tree git status of a repo-bound dbt project: which " +

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -151,7 +151,8 @@ Use \`dbt_show\` to preview the rows a model would return (bounded SELECT, no wr
 want to validate output, not just that it compiles.
 
 Jobs: create or edit saved jobs with \`dbt_create_job\` / \`dbt_update_job\` (add a cron schedule
-only when the user asks for a recurring run). Trigger a saved job with \`dbt_run_job\` — never run
+only when the user asks for a recurring run), and remove one with \`dbt_delete_job\` — only delete
+a job when the user explicitly asks. Trigger a saved job with \`dbt_run_job\` — never run
 a job (possibly prod) without the user explicitly confirming it. \`dbt_run_job\` only QUEUES the
 run; always follow up with \`dbt_get_run\` to report whether it actually passed or failed.
 

--- a/api/src/agents/modes/registry.ts
+++ b/api/src/agents/modes/registry.ts
@@ -173,6 +173,7 @@ const TRANSFORM_MODE_TOOL_NAMES: string[] = [
   "dbt_show",
   "dbt_create_job",
   "dbt_update_job",
+  "dbt_delete_job",
   // Git: commit/push edits to the connected repo (only when the user asks).
   "dbt_git_status",
   "dbt_commit_and_push",

--- a/api/vitest.config.ts
+++ b/api/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       "src/dbt/**/*.test.ts",
       "src/integrations/github/**/*.test.ts",
       "src/routes/dbt.routes.integration.test.ts",
+      "src/agent-lib/tools/dbt-job-tools.test.ts",
     ],
     exclude: [
       "**/node_modules/**",

--- a/app/src/agent-runtime/client-tool-manifest.ts
+++ b/app/src/agent-runtime/client-tool-manifest.ts
@@ -633,6 +633,12 @@ export const AGENT_TOOL_MANIFEST = {
     },
     icon: "play",
   },
+  dbt_delete_job: {
+    domain: "dbt",
+    execution: "server",
+    getLabel: () => "Deleting dbt job",
+    icon: "trash",
+  },
   search_consoles: {
     domain: "search",
     execution: "server",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a new server-side agent tool, `dbt_delete_job`, so the AI agent can permanently delete a saved dbt job ("db job"). Until now the agent could create (`dbt_create_job`), edit (`dbt_update_job`), and run (`dbt_run_job`) jobs, but had no way to delete one — the only delete path was the HTTP `DELETE .../jobs/:jobId` route.

## Changes

- `api/src/agent-lib/tools/dbt-tools.ts` — new `dbt_delete_job` tool. Mirrors the existing HTTP delete: workspace-scoped `assertProject`, validates the job id, looks the job up scoped to the project, then `DbtJob.deleteOne`. Returns `{ success, jobId, name }` or a `{ success: false, error }` envelope. Deleting the job document stops its schedule; past run history is preserved (matches the route).
- `api/src/agents/modes/registry.ts` — register `dbt_delete_job` in `TRANSFORM_MODE_TOOL_NAMES`.
- `api/src/agents/modes/prompts.ts` — extend the Jobs guidance to mention `dbt_delete_job` and require explicit user confirmation before deleting (same convention as `dbt_run_job`).
- `app/src/agent-runtime/client-tool-manifest.ts` — add a manifest entry (`trash` icon, "Deleting dbt job" label) so the streaming tool card renders nicely.
- `api/src/agent-lib/tools/dbt-job-tools.test.ts` — new integration test (mongodb-memory-server) covering delete success, unknown id, malformed id, and cross-workspace isolation.
- `api/vitest.config.ts` — include the new test file in the dbt suite.

## Testing

- `pnpm --filter api run lint` — pass
- `pnpm --filter app run typecheck && lint` — pass
- `pnpm --filter api run build` — pass
- `cd api && npx vitest run` — 118 passed / 2 skipped (includes the 4 new `dbt_delete_job` tests)
- Manual end-to-end: seeded a demo dbt project + `nightly-build` job, then in the chat asked the agent to delete it. The agent switched to transform mode, read the project tree, called `dbt_delete_job`, and confirmed deletion; verified the job was removed from MongoDB.

[agent_dbt_delete_job_demo.mp4](https://cursor.com/agents/bc-c957b95d-40a6-4f6c-90ce-2bcf55e46457/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_dbt_delete_job_demo.mp4)

[Agent confirms dbt job deletion](https://cursor.com/agents/bc-c957b95d-40a6-4f6c-90ce-2bcf55e46457/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_dbt_delete_job_confirmation.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c957b95d-40a6-4f6c-90ce-2bcf55e46457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c957b95d-40a6-4f6c-90ce-2bcf55e46457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

