### PR TITLE
feat(dbt): cancel queued/running dbt runs end-to-end

### DIFF
--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -39,6 +39,7 @@ import { runAdhocDbtCommand } from "../../dbt/dbt-project.service";
 import {
   applyJobScheduleChange,
   reconcileStaleQueuedRun,
+  requestDbtRunCancel,
   triggerDbtJobRun,
   triggerDbtRun,
 } from "../../dbt/dbt-run.service";
@@ -655,6 +656,48 @@ export const createDbtServerTools = (
           };
         } catch (error) {
           return toolError(error, "Failed to trigger job");
+        }
+      },
+    }),
+
+    dbt_cancel_run: tool({
+      description:
+        "Cancel a queued or running dbt run by runId. A queued run is " +
+        "cancelled before it starts (freeing the queue); a running run has " +
+        "its dbt subprocess terminated and any in-flight BigQuery jobs " +
+        "best-effort cancelled. Idempotent: cancelling an already-finished " +
+        "run is a no-op that returns its current status. Use after " +
+        "dbt_run_model / dbt_run_job (with the returned runId) when the user " +
+        "asks to stop a build.",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        runId: z.string().describe("dbt run ID (from dbt_run_model / dbt_run_job)"),
+      }),
+      execute: async ({ projectId, runId }) => {
+        try {
+          await assertProject(projectId);
+          if (!Types.ObjectId.isValid(runId)) {
+            return { success: false, error: "Invalid run id" };
+          }
+          const result = await requestDbtRunCancel({
+            workspaceId,
+            runId,
+            cancelledBy: userId ?? "agent",
+          });
+          if (!result) return { success: false, error: "Run not found" };
+          return {
+            success: true,
+            runId,
+            status: result.status,
+            cancelledAt: result.cancelledAt,
+            cancelledBy: result.cancelledBy,
+            message:
+              result.status === "cancelled"
+                ? "Run cancelled."
+                : `Run is already ${result.status}; nothing to cancel.`,
+          };
+        } catch (error) {
+          return toolError(error, "Failed to cancel run");
         }
       },
     }),

--- a/api/src/agents/modes/registry.ts
+++ b/api/src/agents/modes/registry.ts
@@ -169,6 +169,7 @@ const TRANSFORM_MODE_TOOL_NAMES: string[] = [
   "dbt_compile_model",
   "dbt_run_model",
   "dbt_run_job",
+  "dbt_cancel_run",
   "dbt_get_run",
   "dbt_show",
   "dbt_create_job",

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -4383,6 +4383,10 @@ export interface IDbtRun extends Document {
   startedAt?: Date;
   completedAt?: Date;
   durationMs?: number;
+  /** When a cancel was requested / finalized (status === "cancelled"). */
+  cancelledAt?: Date;
+  /** User id that cancelled the run, or "agent" for automated cancels. */
+  cancelledBy?: string;
   /** Capped, batch-written log lines (parsed from --log-format json). */
   logs: IDbtRunLogLine[];
   /** Parsed from run_results.json after each command. */
@@ -4454,6 +4458,8 @@ const DbtRunSchema = new Schema<IDbtRun>(
     startedAt: { type: Date },
     completedAt: { type: Date },
     durationMs: { type: Number },
+    cancelledAt: { type: Date },
+    cancelledBy: { type: String },
     logs: {
       type: [
         new Schema<IDbtRunLogLine>(

--- a/api/src/dbt/bigquery-cancel.service.ts
+++ b/api/src/dbt/bigquery-cancel.service.ts
@@ -1,0 +1,118 @@
+/**
+ * Best-effort cancellation of in-flight BigQuery jobs spawned by a dbt run.
+ *
+ * Killing the dbt subprocess stops the local process, but a BigQuery query it
+ * already submitted keeps running (and billing) on the warehouse until it
+ * finishes. dbt-bigquery prints the job id for each query it runs, so we scrape
+ * the streamed logs for job ids and call `jobs.cancel` on them when the run is
+ * cancelled.
+ *
+ * This is intentionally best-effort: the job id may not have been logged yet at
+ * cancel time, the SDK call may race the job's natural completion, and the
+ * cancel is fire-and-forget. None of these should block or fail the cancel.
+ */
+
+import { BigQuery } from "@google-cloud/bigquery";
+import { loggers } from "../logging";
+import type { DbtLogLine } from "./runner.service";
+
+const logger = loggers.app();
+
+export interface ParsedBigQueryJob {
+  jobId: string;
+  location?: string;
+}
+
+// BigQuery job ids are alphanumerics plus `_` and `-` (e.g. UUID-ish strings or
+// `script_job_*`). Kept conservative so we never grab trailing punctuation.
+const JOB_ID_CHARS = "[A-Za-z0-9_-]+";
+
+const JOB_ID_PATTERNS: RegExp[] = [
+  // Console URL dbt prints per node: ...&j=bq:US:JOBID&page=queryresults
+  new RegExp(`[?&]j=bq:([A-Za-z0-9_-]+):(${JOB_ID_CHARS})`, "g"),
+  // REST job path: .../projects/PROJECT/jobs/JOBID
+  new RegExp(`/jobs/(${JOB_ID_CHARS})`, "g"),
+  // Structured / plain mentions: "job_id": "JOBID", job_id=JOBID, Job ID: JOBID
+  new RegExp(`job[_ ]?id["']?\\s*[:=]\\s*["']?(${JOB_ID_CHARS})`, "gi"),
+];
+
+/**
+ * Extract BigQuery job ids (and locations, when present) from a single log
+ * line. Pure + exported so the patterns can be unit-tested without spawning
+ * dbt. De-duplicates within the line.
+ */
+export function extractBigQueryJobIds(line: string): ParsedBigQueryJob[] {
+  if (!line) return [];
+  const found = new Map<string, ParsedBigQueryJob>();
+
+  // Console URL carries the location explicitly: j=bq:<location>:<jobId>.
+  const urlPattern = JOB_ID_PATTERNS[0];
+  urlPattern.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = urlPattern.exec(line)) !== null) {
+    const [, location, jobId] = match;
+    if (jobId) found.set(jobId, { jobId, location });
+  }
+
+  for (const pattern of JOB_ID_PATTERNS.slice(1)) {
+    pattern.lastIndex = 0;
+    while ((match = pattern.exec(line)) !== null) {
+      const jobId = match[1];
+      // Ignore obvious non-job tokens and anything already captured w/ location.
+      if (!jobId || jobId.length < 4) continue;
+      if (!found.has(jobId)) found.set(jobId, { jobId });
+    }
+  }
+
+  return [...found.values()];
+}
+
+/**
+ * Cancel the given BigQuery jobs. Builds one client from the service-account
+ * credentials (the same shape dbt's keyfile uses) and issues `cancel()` per
+ * job, swallowing per-job errors. No-op when there are no jobs or no
+ * credentials.
+ */
+export async function cancelBigQueryJobs(params: {
+  credentials: Record<string, unknown> | undefined;
+  projectId?: string;
+  defaultLocation?: string;
+  jobs: ParsedBigQueryJob[];
+  onLog?: (line: DbtLogLine) => void;
+}): Promise<void> {
+  if (!params.credentials || params.jobs.length === 0) return;
+
+  const projectId =
+    params.projectId ?? (params.credentials.project_id as string | undefined);
+
+  let bq: BigQuery;
+  try {
+    bq = new BigQuery({
+      projectId,
+      credentials: params.credentials as Record<string, string>,
+    });
+  } catch (error) {
+    logger.warn("Failed to build BigQuery client for job cancel", { error });
+    return;
+  }
+
+  await Promise.all(
+    params.jobs.map(async ({ jobId, location }) => {
+      try {
+        await bq.job(jobId, { location: location ?? params.defaultLocation }).cancel();
+        params.onLog?.({
+          ts: new Date(),
+          level: "warn",
+          line: `Requested BigQuery job cancel: ${jobId}`,
+        });
+        logger.info("Cancelled BigQuery job for cancelled dbt run", {
+          jobId,
+          location: location ?? params.defaultLocation,
+        });
+      } catch (error) {
+        // Already done / unknown id / transient — best-effort only.
+        logger.warn("BigQuery job cancel failed", { error, jobId });
+      }
+    }),
+  );
+}

--- a/api/src/dbt/bigquery-cancel.test.ts
+++ b/api/src/dbt/bigquery-cancel.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { extractBigQueryJobIds } from "./bigquery-cancel.service";
+
+describe("extractBigQueryJobIds", () => {
+  it("parses the console URL dbt prints per node (with location)", () => {
+    const line =
+      "View job in the BigQuery console: " +
+      "https://console.cloud.google.com/bigquery?project=my-proj&j=bq:US:abc123-def456&page=queryresults";
+    expect(extractBigQueryJobIds(line)).toEqual([
+      { jobId: "abc123-def456", location: "US" },
+    ]);
+  });
+
+  it("parses a REST job path", () => {
+    const line =
+      "POST https://bigquery.googleapis.com/bigquery/v2/projects/p/jobs/job_AbC-123";
+    expect(extractBigQueryJobIds(line)).toEqual([{ jobId: "job_AbC-123" }]);
+  });
+
+  it("parses a structured job_id mention", () => {
+    expect(extractBigQueryJobIds('{"job_id": "script_job_99"}')).toEqual([
+      { jobId: "script_job_99" },
+    ]);
+    expect(extractBigQueryJobIds("Job ID: dbt-run-7788")).toEqual([
+      { jobId: "dbt-run-7788" },
+    ]);
+  });
+
+  it("prefers the location-bearing console URL when a job id appears twice", () => {
+    const line =
+      "url?x=1&j=bq:EU:dup-job-1 ... later mentions job_id=dup-job-1 again";
+    expect(extractBigQueryJobIds(line)).toEqual([
+      { jobId: "dup-job-1", location: "EU" },
+    ]);
+  });
+
+  it("returns nothing for unrelated log lines", () => {
+    expect(extractBigQueryJobIds("Running with dbt=1.8.0")).toEqual([]);
+    expect(extractBigQueryJobIds("")).toEqual([]);
+  });
+});

--- a/api/src/dbt/dbt-run-cancel.test.ts
+++ b/api/src/dbt/dbt-run-cancel.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { isTerminalDbtRunStatus } from "./dbt-run.service";
+import type { DbtRunStatus } from "../database/workspace-schema";
+
+describe("isTerminalDbtRunStatus", () => {
+  it("treats success/error/cancelled as terminal", () => {
+    for (const status of ["success", "error", "cancelled"] as DbtRunStatus[]) {
+      expect(isTerminalDbtRunStatus(status)).toBe(true);
+    }
+  });
+
+  it("treats queued/running as non-terminal (cancellable)", () => {
+    for (const status of ["queued", "running"] as DbtRunStatus[]) {
+      expect(isTerminalDbtRunStatus(status)).toBe(false);
+    }
+  });
+});

--- a/api/src/dbt/dbt-run-registry.ts
+++ b/api/src/dbt/dbt-run-registry.ts
@@ -1,0 +1,79 @@
+/**
+ * In-process registry of dbt runs that are actively executing on THIS node.
+ *
+ * The Inngest `cancelOn: "dbt/run.cancel"` only stops the executor function
+ * from scheduling further steps — it cannot interrupt the dbt subprocess that
+ * is already running inside a `step.run` on the worker. Without a way to reach
+ * that child process, cancelling a stuck build (e.g. a model running >18 min)
+ * would still leave it consuming warehouse compute until it finished on its
+ * own. This registry bridges that gap: the executor registers a control handle
+ * keyed by runId while a command is in flight, and {@link cancelLocalRun}
+ * (called from the cancel API path, which runs in the same process as the
+ * Inngest worker) aborts the subprocess and best-effort-cancels any BigQuery
+ * jobs the run has spawned.
+ *
+ * It is intentionally process-local: in a multi-instance deployment the cancel
+ * may land on a different instance than the one running the subprocess, in
+ * which case the `dbt/run.cancel` event still frees the Inngest concurrency
+ * slot and finalizes the run. The registry is the fast path that also reclaims
+ * warehouse compute when the cancel and the worker share a process (the common
+ * single-instance / dev case).
+ */
+
+import { loggers } from "../logging";
+
+const logger = loggers.app();
+
+export interface ActiveRunControl {
+  /** Abort the in-flight dbt subprocess (SIGTERM, then SIGKILL after grace). */
+  abort: (reason: string) => void;
+  /** Best-effort cancel of any BigQuery jobs discovered for this run. */
+  cancelWarehouseJobs: () => Promise<void>;
+}
+
+const activeRuns = new Map<string, ActiveRunControl>();
+
+/** Register the control handle for a run that is starting execution here. */
+export function registerActiveRun(
+  runId: string,
+  control: ActiveRunControl,
+): void {
+  activeRuns.set(runId, control);
+}
+
+/**
+ * Remove a run's control handle. Pass the same `control` reference registered
+ * earlier so a stale teardown (from a re-invoked executor) never clobbers a
+ * newer registration for the same runId.
+ */
+export function unregisterActiveRun(
+  runId: string,
+  control?: ActiveRunControl,
+): void {
+  if (control && activeRuns.get(runId) !== control) return;
+  activeRuns.delete(runId);
+}
+
+/** True when this process is currently executing the given run. */
+export function isRunActiveLocally(runId: string): boolean {
+  return activeRuns.has(runId);
+}
+
+/**
+ * Abort a run executing on this process: SIGTERM/SIGKILL the dbt subprocess and
+ * fire-and-forget a BigQuery job cancel. Returns whether a local handle existed
+ * (false means the run is running elsewhere or already finished here).
+ */
+export function cancelLocalRun(runId: string, reason: string): boolean {
+  const control = activeRuns.get(runId);
+  if (!control) return false;
+  try {
+    control.abort(reason);
+  } catch (error) {
+    logger.warn("dbt local run abort failed", { error, runId });
+  }
+  void control.cancelWarehouseJobs().catch(error => {
+    logger.warn("dbt warehouse job cancel failed", { error, runId });
+  });
+  return true;
+}

--- a/api/src/dbt/dbt-run.service.ts
+++ b/api/src/dbt/dbt-run.service.ts
@@ -10,11 +10,23 @@ import { inngest } from "../inngest/client";
 import {
   DbtJob,
   DbtRun,
+  type DbtRunStatus,
   type IDbtJob,
   type IDbtRun,
 } from "../database/workspace-schema";
 import { parseDbtCommands } from "./commands";
+import { cancelLocalRun } from "./dbt-run-registry";
 import { loggers } from "../logging";
+
+const TERMINAL_DBT_RUN_STATUSES: ReadonlySet<DbtRunStatus> = new Set([
+  "success",
+  "error",
+  "cancelled",
+]);
+
+export function isTerminalDbtRunStatus(status: DbtRunStatus): boolean {
+  return TERMINAL_DBT_RUN_STATUSES.has(status);
+}
 
 const logger = loggers.api("dbt-run");
 
@@ -292,34 +304,155 @@ export async function triggerDbtRunRetry(params: {
   return run;
 }
 
+/**
+ * Flip a run that is still queued/running to the terminal "cancelled" status.
+ * Shared by the executor (when its subprocess was aborted) and the
+ * `dbt/run.cancel` finalizer so a cancel always lands exactly one terminal
+ * write. Idempotent (guarded on a non-terminal status) and an aggregation
+ * pipeline so it can preserve an already-staged cancelledBy/cancelledAt and
+ * compute durationMs from startedAt in a single atomic update.
+ */
+export async function finalizeCancelledDbtRun(
+  runId: Types.ObjectId | string,
+  fallbackCancelledBy?: string,
+): Promise<void> {
+  const _id = typeof runId === "string" ? new Types.ObjectId(runId) : runId;
+  await DbtRun.updateOne({ _id, status: { $in: ["queued", "running"] } }, [
+    {
+      $set: {
+        status: "cancelled",
+        completedAt: "$$NOW",
+        cancelledAt: { $ifNull: ["$cancelledAt", "$$NOW"] },
+        cancelledBy: {
+          $ifNull: ["$cancelledBy", fallbackCancelledBy ?? "user"],
+        },
+        error: { $ifNull: ["$error", "Cancelled"] },
+        durationMs: {
+          $cond: [
+            { $ifNull: ["$startedAt", false] },
+            {
+              $dateDiff: {
+                startDate: "$startedAt",
+                endDate: "$$NOW",
+                unit: "millisecond",
+              },
+            },
+            "$durationMs",
+          ],
+        },
+      },
+    },
+  ]);
+}
+
+export interface DbtRunCancelResult {
+  /** The run's status after the cancel attempt (may already be terminal). */
+  status: DbtRunStatus;
+  cancelledAt?: Date;
+  cancelledBy?: string;
+}
+
+/**
+ * Cancel a queued or running dbt run.
+ *
+ *  - **queued** → finalized to `cancelled` immediately (guarded on `queued`),
+ *    so the executor's `mark-running` claim no-ops and it never executes.
+ *  - **running** → stage the cancel attribution on the doc, then (a) abort the
+ *    local subprocess + best-effort cancel its BigQuery jobs via the in-process
+ *    registry and (b) emit `dbt/run.cancel` so Inngest `cancelOn` frees the
+ *    concurrency slot and the finalizer flips the status (covers the
+ *    cross-instance case where the worker runs elsewhere).
+ *  - **terminal** (success/error/cancelled) → idempotent no-op; returns the
+ *    current status with no side effects.
+ *
+ * Returns `null` only when the run does not exist. Otherwise returns the
+ * run's status; in the race where the run finishes just as cancel arrives, the
+ * real terminal status (e.g. `success`) is returned rather than an error.
+ */
 export async function requestDbtRunCancel(params: {
   workspaceId: string;
   runId: string;
-}): Promise<boolean> {
+  /** User id, or "agent" for automated cancels. */
+  cancelledBy?: string;
+}): Promise<DbtRunCancelResult | null> {
   const run = await DbtRun.findOne({
     _id: new Types.ObjectId(params.runId),
     workspaceId: new Types.ObjectId(params.workspaceId),
-  });
-  if (!run) return false;
-  // Only active runs can be cancelled; terminal runs (success/error/cancelled)
-  // are a no-op. The boolean return means "cancellation was initiated", which
-  // is true for both branches below (a queued run finalized here, or a running
-  // run signaled via cancelOn) — including the queued→running race, where the
-  // guarded update no-ops but the executor still honors the cancel event.
-  if (run.status !== "queued" && run.status !== "running") return false;
+  })
+    .select("status cancelledAt cancelledBy")
+    .lean();
+  if (!run) return null;
 
-  // cancelOn match in the executor; queued runs are finalized directly since
-  // the executor may not have started yet.
-  await inngest.send({
-    name: "dbt/run.cancel",
-    data: { runId: params.runId },
-  });
+  // Idempotent: a terminal run is a no-op that echoes the current status.
+  if (isTerminalDbtRunStatus(run.status)) {
+    return {
+      status: run.status,
+      cancelledAt: run.cancelledAt,
+      cancelledBy: run.cancelledBy,
+    };
+  }
 
-  await DbtRun.updateOne(
+  const cancelledBy = params.cancelledBy ?? "user";
+  const now = new Date();
+
+  // Queued runs are finalized synchronously (never start). Guarded on "queued"
+  // so a last-moment executor pickup (queued→running race) is never clobbered.
+  const queued = await DbtRun.findOneAndUpdate(
     { _id: run._id, status: "queued" },
-    { $set: { status: "cancelled", completedAt: new Date() } },
+    {
+      $set: {
+        status: "cancelled",
+        completedAt: now,
+        cancelledAt: now,
+        cancelledBy,
+      },
+    },
+    { new: true },
+  )
+    .select("status cancelledAt cancelledBy")
+    .lean();
+
+  // Always emit the cancel event: frees the Inngest concurrency slot (cancelOn)
+  // so the next queued run starts, and runs the finalizer as a cross-instance
+  // backstop. Carries cancelledBy so the finalizer can attribute it.
+  await inngest
+    .send({
+      name: "dbt/run.cancel",
+      data: { runId: params.runId, cancelledBy },
+    })
+    .catch(error => {
+      logger.warn("Failed to emit dbt/run.cancel event", {
+        error,
+        runId: params.runId,
+      });
+    });
+
+  if (queued) {
+    return {
+      status: "cancelled",
+      cancelledAt: queued.cancelledAt ?? now,
+      cancelledBy: queued.cancelledBy ?? cancelledBy,
+    };
+  }
+
+  // Not queued anymore → running (or it just finished). Stage attribution so
+  // the finalizer + UI can show who/when, then kill the local subprocess.
+  await DbtRun.updateOne(
+    { _id: run._id, status: "running" },
+    { $set: { cancelledAt: now, cancelledBy } },
   );
-  return true;
+  cancelLocalRun(params.runId, `Cancelled by ${cancelledBy}`);
+
+  // Re-read for the authoritative current status (handles the finish-just-as-
+  // cancel-arrives race: return the real terminal status, not an error).
+  const fresh = await DbtRun.findById(run._id)
+    .select("status cancelledAt cancelledBy")
+    .lean();
+  return {
+    status: fresh?.status ?? "running",
+    cancelledAt: fresh?.cancelledAt,
+    cancelledBy: fresh?.cancelledBy,
+  };
 }
 
 /** Recompute a job's next scheduled run after a schedule edit. */

--- a/api/src/dbt/runner-cancel.integration.test.ts
+++ b/api/src/dbt/runner-cancel.integration.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Runner cancellation integration test — exercises the REAL runDbt /
+ * execDbtCommand subprocess path (no Inngest, no DB) using a fake "dbt" binary
+ * pointed at via DBT_VENV_BIN. Verifies that an AbortSignal stops an in-flight
+ * dbt subprocess promptly, and that a process which ignores SIGTERM is escalated
+ * to SIGKILL after the (env-shortened) grace window.
+ */
+import { tmpdir } from "os";
+import { join } from "path";
+import { randomUUID } from "crypto";
+import { mkdtemp, writeFile, chmod, rm } from "fs/promises";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parseDbtCommand } from "./commands";
+import { runDbt } from "./runner.service";
+import type { RenderedProfile } from "./adapter-map";
+
+const profile: RenderedProfile = {
+  adapterPackage: "dbt-postgres",
+  secretEnv: {},
+  keyfiles: [],
+  profilesYml: "mako:\n  target: dev\n  outputs:\n    dev:\n      type: postgres\n",
+};
+
+const files = [{ path: "dbt_project.yml", content: "name: probe\n" }];
+
+let scriptDir: string;
+const prevVenv = process.env.DBT_VENV_BIN;
+const prevGrace = process.env.DBT_KILL_GRACE_MS;
+
+beforeEach(async () => {
+  scriptDir = await mkdtemp(join(tmpdir(), `dbt-fake-${randomUUID()}-`));
+});
+
+afterEach(async () => {
+  process.env.DBT_VENV_BIN = prevVenv;
+  process.env.DBT_KILL_GRACE_MS = prevGrace;
+  await rm(scriptDir, { recursive: true, force: true });
+});
+
+async function installFakeDbt(body: string): Promise<void> {
+  const bin = join(scriptDir, "dbt");
+  await writeFile(bin, `#!/usr/bin/env bash\n${body}\n`, "utf8");
+  await chmod(bin, 0o755);
+  process.env.DBT_VENV_BIN = bin;
+}
+
+describe("runDbt cancellation", () => {
+  it(
+    "SIGTERM stops a subprocess that exits cleanly on the signal",
+    async () => {
+      // Honors SIGTERM — emit a log line then `exec sleep` so the signal hits
+      // the sleeping process directly (a bare `sleep` under bash would defer it,
+      // unlike real dbt's Python process which handles SIGTERM itself).
+      await installFakeDbt(
+        'echo \'{"info":{"ts":"2026-01-01T00:00:00Z","level":"info","msg":"fake dbt started"}}\'\n' +
+          "exec sleep 120\n",
+      );
+
+      const controller = new AbortController();
+      const logs: string[] = [];
+      const started = Date.now();
+      setTimeout(() => controller.abort("test cancel"), 500);
+
+      const result = await runDbt({
+        files,
+        profile,
+        commands: [parseDbtCommand("run --select x")],
+        signal: controller.signal,
+        onLog: line => logs.push(line.line),
+      });
+
+      const elapsed = Date.now() - started;
+      expect(result.success).toBe(false);
+      // Aborted well before the fake's 120s sleep.
+      expect(elapsed).toBeLessThan(10_000);
+      expect(logs.some(l => l.includes("fake dbt started"))).toBe(true);
+      expect(logs.some(l => l.includes("SIGTERM"))).toBe(true);
+    },
+    20_000,
+  );
+
+  it(
+    "escalates to SIGKILL when the subprocess ignores SIGTERM",
+    async () => {
+      process.env.DBT_KILL_GRACE_MS = "500";
+      // Traps + ignores SIGTERM, so only SIGKILL can stop it.
+      await installFakeDbt(
+        "trap '' TERM\n" +
+          'echo \'{"info":{"ts":"2026-01-01T00:00:00Z","level":"info","msg":"ignoring sigterm"}}\'\n' +
+          "while true; do sleep 1; done\n",
+      );
+
+      const controller = new AbortController();
+      const logs: string[] = [];
+      const started = Date.now();
+      setTimeout(() => controller.abort("test cancel"), 300);
+
+      const result = await runDbt({
+        files,
+        profile,
+        commands: [parseDbtCommand("run --select x")],
+        signal: controller.signal,
+        onLog: line => logs.push(line.line),
+      });
+
+      const elapsed = Date.now() - started;
+      expect(result.success).toBe(false);
+      // SIGTERM (~300ms) + 500ms grace + reap → comfortably under 8s.
+      expect(elapsed).toBeLessThan(8_000);
+      expect(logs.some(l => l.includes("SIGKILL"))).toBe(true);
+    },
+    20_000,
+  );
+});

--- a/api/src/dbt/runner.service.ts
+++ b/api/src/dbt/runner.service.ts
@@ -344,6 +344,14 @@ async function reconcileWarmDir(
   return deleted;
 }
 
+/**
+ * How long a dbt subprocess gets to exit after SIGTERM before we escalate to
+ * SIGKILL. dbt traps SIGTERM to flush partial run_results.json / logs, so we
+ * give it a window to shut down cleanly, then force-kill so a cancel always
+ * frees the slot promptly even if dbt is wedged.
+ */
+const KILL_GRACE_MS = 15_000;
+
 function execDbtCommand(params: {
   bin: string;
   args: string[];
@@ -362,18 +370,43 @@ function execDbtCommand(params: {
 
     let stdoutBuffer = "";
     let settled = false;
+    let killTimer: ReturnType<typeof setTimeout> | null = null;
 
-    const timeout = setTimeout(() => {
+    // Graceful stop: SIGTERM, then SIGKILL if the process is still alive after
+    // KILL_GRACE_MS. Used by both the per-command timeout and an external abort
+    // (run cancellation). Idempotent — the close handler clears killTimer.
+    const terminate = (cause: string) => {
       params.onLog({
         ts: new Date(),
         level: "error",
-        line: `Command timed out after ${Math.round(params.timeoutMs / 1000)}s — sending SIGTERM`,
+        line: `${cause} — sending SIGTERM`,
       });
       child.kill("SIGTERM");
+      if (killTimer) return;
+      killTimer = setTimeout(() => {
+        if (settled) return;
+        params.onLog({
+          ts: new Date(),
+          level: "error",
+          line: `Process did not exit ${Math.round(KILL_GRACE_MS / 1000)}s after SIGTERM — sending SIGKILL`,
+        });
+        child.kill("SIGKILL");
+      }, KILL_GRACE_MS);
+    };
+
+    const timeout = setTimeout(() => {
+      terminate(
+        `Command timed out after ${Math.round(params.timeoutMs / 1000)}s`,
+      );
     }, params.timeoutMs);
 
-    const onAbort = () => child.kill("SIGTERM");
-    params.signal?.addEventListener("abort", onAbort, { once: true });
+    const onAbort = () => terminate("Run cancellation requested");
+    if (params.signal?.aborted) {
+      // Already aborted before spawn settled — stop the child immediately.
+      onAbort();
+    } else {
+      params.signal?.addEventListener("abort", onAbort, { once: true });
+    }
 
     const flushLines = (chunk: string, isStderr: boolean) => {
       if (isStderr) {
@@ -405,6 +438,7 @@ function execDbtCommand(params: {
       if (settled) return;
       settled = true;
       clearTimeout(timeout);
+      if (killTimer) clearTimeout(killTimer);
       params.signal?.removeEventListener("abort", onAbort);
       reject(error);
     });
@@ -413,6 +447,7 @@ function execDbtCommand(params: {
       if (settled) return;
       settled = true;
       clearTimeout(timeout);
+      if (killTimer) clearTimeout(killTimer);
       params.signal?.removeEventListener("abort", onAbort);
       if (stdoutBuffer.trim()) params.onLog(parseLogLine(stdoutBuffer.trim()));
       resolve(code ?? 1);

--- a/api/src/dbt/runner.service.ts
+++ b/api/src/dbt/runner.service.ts
@@ -348,9 +348,12 @@ async function reconcileWarmDir(
  * How long a dbt subprocess gets to exit after SIGTERM before we escalate to
  * SIGKILL. dbt traps SIGTERM to flush partial run_results.json / logs, so we
  * give it a window to shut down cleanly, then force-kill so a cancel always
- * frees the slot promptly even if dbt is wedged.
+ * frees the slot promptly even if dbt is wedged. Read per-call (not at module
+ * load) so DBT_KILL_GRACE_MS can be shortened in tests without import ordering.
  */
-const KILL_GRACE_MS = 15_000;
+function killGraceMs(): number {
+  return Number(process.env.DBT_KILL_GRACE_MS) || 15_000;
+}
 
 function execDbtCommand(params: {
   bin: string;
@@ -371,6 +374,7 @@ function execDbtCommand(params: {
     let stdoutBuffer = "";
     let settled = false;
     let killTimer: ReturnType<typeof setTimeout> | null = null;
+    const graceMs = killGraceMs();
 
     // Graceful stop: SIGTERM, then SIGKILL if the process is still alive after
     // KILL_GRACE_MS. Used by both the per-command timeout and an external abort
@@ -388,10 +392,10 @@ function execDbtCommand(params: {
         params.onLog({
           ts: new Date(),
           level: "error",
-          line: `Process did not exit ${Math.round(KILL_GRACE_MS / 1000)}s after SIGTERM — sending SIGKILL`,
+          line: `Process did not exit ${Math.round(graceMs / 1000)}s after SIGTERM — sending SIGKILL`,
         });
         child.kill("SIGKILL");
-      }, KILL_GRACE_MS);
+      }, graceMs);
     };
 
     const timeout = setTimeout(() => {

--- a/api/src/inngest/functions/dbt-run.ts
+++ b/api/src/inngest/functions/dbt-run.ts
@@ -490,19 +490,25 @@ export const dbtRunExecutorFunction = inngest.createFunction(
       unregisterActiveRun(data.runId, runControl);
     }
 
-    // A triggered abort means this run was cancelled (subprocess SIGTERM/
-    // SIGKILL'd by the registry), not a genuine dbt failure — finalize it as
-    // "cancelled" with attribution rather than "error".
-    const wasCancelled = controller.signal.aborted;
-
     await step.run("finalize-run", async () => {
-      if (wasCancelled) {
-        await finalizeCancelledDbtRun(runObjectId);
+      const completedAt = new Date();
+      const run = await DbtRun.findById(runObjectId)
+        .select("startedAt status cancelledAt cancelledBy")
+        .lean();
+
+      // Detect cancellation from the PERSISTED marker, not the in-memory
+      // AbortController: Inngest replays the function body (and recreates the
+      // controller) on each step, so `controller.signal.aborted` is only true
+      // in the invocation that ran the subprocess — not in the later
+      // finalize-run replay. requestDbtRunCancel stages cancelledAt/cancelledBy
+      // (or flips status to "cancelled") before aborting, so the marker is
+      // durable. Without this a cancelled run would finalize as "error".
+      if (run?.status === "cancelled" || run?.cancelledAt) {
+        await finalizeCancelledDbtRun(runObjectId, run?.cancelledBy);
         logger.info("dbt run cancelled; finalized", { runId: data.runId });
         return;
       }
-      const completedAt = new Date();
-      const run = await DbtRun.findById(runObjectId).select("startedAt").lean();
+
       const durationMs = run?.startedAt
         ? completedAt.getTime() - new Date(run.startedAt).getTime()
         : undefined;

--- a/api/src/inngest/functions/dbt-run.ts
+++ b/api/src/inngest/functions/dbt-run.ts
@@ -28,7 +28,20 @@ import {
   runDbt,
   type DbtLogLine,
 } from "../../dbt/runner.service";
-import { triggerDbtJobRun } from "../../dbt/dbt-run.service";
+import {
+  finalizeCancelledDbtRun,
+  triggerDbtJobRun,
+} from "../../dbt/dbt-run.service";
+import {
+  registerActiveRun,
+  unregisterActiveRun,
+  type ActiveRunControl,
+} from "../../dbt/dbt-run-registry";
+import {
+  cancelBigQueryJobs,
+  extractBigQueryJobIds,
+  type ParsedBigQueryJob,
+} from "../../dbt/bigquery-cancel.service";
 import {
   computePackagesHash,
   loadDbtCaches,
@@ -104,6 +117,28 @@ interface DbtRunRequestedEvent {
   projectId: string;
   runId: string;
   jobId?: string;
+}
+
+/**
+ * Mutable, process-local state backing a run's {@link ActiveRunControl}. The
+ * BigQuery credentials are filled in lazily once the executor loads the project
+ * snapshot inside the command step (so the registry can cancel warehouse jobs
+ * even though the registration happens before the snapshot is available).
+ */
+interface DbtRunCancelState {
+  bqJobs: Map<string, ParsedBigQueryJob>;
+  bqCredentials?: Record<string, unknown>;
+  bqLocation?: string;
+}
+
+/**
+ * Scan a streamed dbt log line for BigQuery job ids and remember them so a
+ * cancel can stop the warehouse query, not just the local subprocess.
+ */
+function captureBigQueryJobs(state: DbtRunCancelState, line: string): void {
+  for (const job of extractBigQueryJobIds(line)) {
+    state.bqJobs.set(job.jobId, job);
+  }
 }
 
 /** Read an artifact key into a Buffer, or undefined if missing/unreadable. */
@@ -206,6 +241,25 @@ export const dbtRunExecutorFunction = inngest.createFunction(
     let unexpectedError: unknown;
     const allStepResults: ReturnType<typeof parseStepResults> = [];
 
+    // Cancellation plumbing: an AbortController whose signal is passed into
+    // every runDbt call so a cancel can SIGTERM/SIGKILL the dbt subprocess, and
+    // a registry handle the cancel API path uses to reach this process. The
+    // BigQuery credentials are populated lazily from the snapshot below.
+    const controller = new AbortController();
+    const cancelState: DbtRunCancelState = { bqJobs: new Map() };
+    const runControl: ActiveRunControl = {
+      abort: reason => controller.abort(reason),
+      cancelWarehouseJobs: async () => {
+        if (!cancelState.bqCredentials || cancelState.bqJobs.size === 0) return;
+        await cancelBigQueryJobs({
+          credentials: cancelState.bqCredentials,
+          defaultLocation: cancelState.bqLocation,
+          jobs: [...cancelState.bqJobs.values()],
+        });
+      },
+    };
+    registerActiveRun(data.runId, runControl);
+
     try {
       for (let i = 0; i < runInfo.commands.length; i++) {
         const commandText = runInfo.commands[i];
@@ -218,10 +272,30 @@ export const dbtRunExecutorFunction = inngest.createFunction(
             projectId: data.projectId,
             environmentName: runInfo.environment,
           });
+          // Stash BigQuery credentials so a cancel can stop in-flight warehouse
+          // jobs (best-effort; no-op for non-BigQuery adapters).
+          if (snapshot.profile.adapterPackage === "dbt-bigquery") {
+            const keyfile = snapshot.profile.keyfiles[0]?.content;
+            if (keyfile) {
+              try {
+                cancelState.bqCredentials = JSON.parse(keyfile) as Record<
+                  string,
+                  unknown
+                >;
+              } catch {
+                /* malformed keyfile — dbt surfaces its own error */
+              }
+            }
+          }
           const parsed = parseDbtCommand(commandText);
           const logWriter = createLogWriter(runObjectId);
+          // Tee the log stream to both the DB writer and the BQ job scraper.
+          const onLog = (line: DbtLogLine) => {
+            captureBigQueryJobs(cancelState, line.line);
+            logWriter.onLog(line);
+          };
 
-          logWriter.onLog({
+          onLog({
             ts: new Date(),
             level: "info",
             line: `$ dbt ${parsed.argv.join(" ")}`,
@@ -272,7 +346,8 @@ export const dbtRunExecutorFunction = inngest.createFunction(
                 skipDeps: caches.packagesFresh,
                 packagesHash,
                 workingDir,
-                onLog: logWriter.onLog,
+                signal: controller.signal,
+                onLog,
               });
 
             let result: Awaited<ReturnType<typeof runDbt>> | undefined;
@@ -411,9 +486,21 @@ export const dbtRunExecutorFunction = inngest.createFunction(
         runId: data.runId,
         error,
       });
+    } finally {
+      unregisterActiveRun(data.runId, runControl);
     }
 
+    // A triggered abort means this run was cancelled (subprocess SIGTERM/
+    // SIGKILL'd by the registry), not a genuine dbt failure — finalize it as
+    // "cancelled" with attribution rather than "error".
+    const wasCancelled = controller.signal.aborted;
+
     await step.run("finalize-run", async () => {
+      if (wasCancelled) {
+        await finalizeCancelledDbtRun(runObjectId);
+        logger.info("dbt run cancelled; finalized", { runId: data.runId });
+        return;
+      }
       const completedAt = new Date();
       const run = await DbtRun.findById(runObjectId).select("startedAt").lean();
       const durationMs = run?.startedAt
@@ -546,22 +633,13 @@ export const dbtRunCancelFunction = inngest.createFunction(
   },
   { event: "dbt/run.cancel" },
   async ({ event, step }) => {
-    const runId = (event.data as { runId: string }).runId;
+    const { runId, cancelledBy } = event.data as {
+      runId: string;
+      cancelledBy?: string;
+    };
     await step.sleep("allow-executor-teardown", "10s");
     await step.run("finalize-cancelled", async () => {
-      await DbtRun.updateOne(
-        {
-          _id: new Types.ObjectId(runId),
-          status: { $in: ["queued", "running"] },
-        },
-        {
-          $set: {
-            status: "cancelled",
-            completedAt: new Date(),
-            error: "Cancelled by user",
-          },
-        },
-      );
+      await finalizeCancelledDbtRun(new Types.ObjectId(runId), cancelledBy);
     });
     return { runId };
   },

--- a/api/src/routes/dbt.routes.integration.test.ts
+++ b/api/src/routes/dbt.routes.integration.test.ts
@@ -61,7 +61,7 @@ vi.mock("../dbt/dbt-project.service", () => ({
 vi.mock("../dbt/dbt-run.service", () => ({
   triggerDbtJobRun: vi.fn(async () => ({ _id: new Types.ObjectId() })),
   triggerDbtRunRetry: vi.fn(async () => ({ _id: new Types.ObjectId() })),
-  requestDbtRunCancel: vi.fn(async () => true),
+  requestDbtRunCancel: vi.fn(async () => ({ status: "cancelled" })),
   applyJobScheduleChange: vi.fn(async () => undefined),
   reconcileStaleQueuedRun: vi.fn(async (r: unknown) => r),
   reconcileStaleQueuedRuns: vi.fn(async (r: unknown) => r),
@@ -399,19 +399,36 @@ describe("runs lifecycle", () => {
     expect(res.run.logCursor).toBe(3);
   });
 
-  it("cancel returns 200 when cancellable, 400 otherwise", async () => {
+  it("cancel returns 200 with status, 404 when the run is unknown", async () => {
     const projectId = await createProjectAsOwner();
     const runId = await insertRun(projectId, { status: "running" });
 
-    cancelMock.mockResolvedValueOnce(true);
-    expect(
-      (await req("POST", `/projects/${projectId}/runs/${runId}/cancel`)).status,
-    ).toBe(200);
+    const cancelledAt = new Date();
+    cancelMock.mockResolvedValueOnce({
+      status: "cancelled",
+      cancelledAt,
+      cancelledBy: "user-1",
+    });
+    const ok = await req("POST", `/projects/${projectId}/runs/${runId}/cancel`);
+    expect(ok.status).toBe(200);
+    const body = await ok.json();
+    expect(body.status).toBe("cancelled");
+    expect(body.cancelledBy).toBe("user-1");
 
-    cancelMock.mockResolvedValueOnce(false);
+    // Idempotent: an already-terminal run echoes its status with a 200.
+    cancelMock.mockResolvedValueOnce({ status: "success" });
+    const idempotent = await req(
+      "POST",
+      `/projects/${projectId}/runs/${runId}/cancel`,
+    );
+    expect(idempotent.status).toBe(200);
+    expect((await idempotent.json()).status).toBe("success");
+
+    // Unknown run → null → 404.
+    cancelMock.mockResolvedValueOnce(null);
     expect(
       (await req("POST", `/projects/${projectId}/runs/${runId}/cancel`)).status,
-    ).toBe(400);
+    ).toBe(404);
   });
 
   it("retry returns the new runId when retriable, 400 otherwise", async () => {

--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -1522,14 +1522,23 @@ dbtRoutes.post(
       if (!Types.ObjectId.isValid(runId)) {
         return badRequest(c, "Invalid run id");
       }
-      const cancelled = await requestDbtRunCancel({
+      const result = await requestDbtRunCancel({
         workspaceId: project.workspaceId.toString(),
         runId,
+        cancelledBy: getUserId(c),
       });
-      if (!cancelled) {
-        return badRequest(c, "Run is not cancellable (already finished?)");
+      if (!result) {
+        return c.json({ success: false, error: "Run not found" }, 404);
       }
-      return c.json({ success: true });
+      // Idempotent: an already-terminal run echoes its current status (no
+      // error), and the queued→running / finished-during-cancel races return
+      // the real status rather than failing.
+      return c.json({
+        success: true,
+        status: result.status,
+        cancelledAt: result.cancelledAt,
+        cancelledBy: result.cancelledBy,
+      });
     } catch (error) {
       return serverError(c, error, "Failed to cancel dbt run");
     }

--- a/app/src/agent-runtime/client-tool-manifest.ts
+++ b/app/src/agent-runtime/client-tool-manifest.ts
@@ -18,6 +18,7 @@ export type ToolIconKey =
   | "clock"
   | "brain"
   | "shield-check"
+  | "square"
   | "help-circle";
 
 export type AgentToolDomain =
@@ -632,6 +633,12 @@ export const AGENT_TOOL_MANIFEST = {
       return jobName ? `Running job "${jobName}"` : "Running dbt job";
     },
     icon: "play",
+  },
+  dbt_cancel_run: {
+    domain: "dbt",
+    execution: "server",
+    getLabel: () => "Cancelling dbt run",
+    icon: "square",
   },
   search_consoles: {
     domain: "search",

--- a/app/src/components/DbtRunCard.tsx
+++ b/app/src/components/DbtRunCard.tsx
@@ -147,7 +147,8 @@ export function DbtRunCard({ runId, projectId, label }: DbtRunCardProps) {
       ? `dbt ${command}`
       : "dbt build";
 
-  const statusLabel = status ?? "queued";
+  const statusLabel =
+    cancelling && isActive ? "Cancelling…" : (status ?? "queued");
 
   return (
     <Box

--- a/app/src/components/DbtRunHistory.tsx
+++ b/app/src/components/DbtRunHistory.tsx
@@ -28,6 +28,7 @@ import {
   RotateCcw as RetryIcon,
   Download as DownloadIcon,
   Search as SearchIcon,
+  Square as StopIcon,
 } from "lucide-react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import {
@@ -134,20 +135,26 @@ export default function DbtRunHistory({
   const runDetails = useDbtStore(s => s.runDetails);
   const fetchRunDetails = useDbtStore(s => s.fetchRunDetails);
   const retryRun = useDbtStore(s => s.retryRun);
+  const cancelRun = useDbtStore(s => s.cancelRun);
   const downloadRunArtifact = useDbtStore(s => s.downloadRunArtifact);
 
   const logScrollRef = useRef<HTMLDivElement | null>(null);
   const [statusFilter, setStatusFilter] = useState<string>("all");
   const [logQuery, setLogQuery] = useState("");
+  const [cancelling, setCancelling] = useState(false);
 
   const selectedRun = selectedRunId ? runDetails[selectedRunId] : undefined;
   const selectedRunListItem = runs.find(run => run._id === selectedRunId);
   const selectedStatus = selectedRun?.status ?? selectedRunListItem?.status;
+  const selectedDetail = selectedRun ?? selectedRunListItem;
+  const isActiveSelection =
+    selectedStatus === "running" || selectedStatus === "queued";
 
-  // Reset filters when switching runs.
+  // Reset filters + cancel state when switching runs.
   useEffect(() => {
     setStatusFilter("all");
     setLogQuery("");
+    setCancelling(false);
   }, [selectedRunId]);
 
   const stepResults = useMemo(
@@ -235,6 +242,35 @@ export default function DbtRunHistory({
     retryRun,
     onSelectRun,
   ]);
+
+  const handleCancel = useCallback(async () => {
+    if (!workspaceId || !selectedRunId || cancelling) return;
+    // Optimistically flip to "Cancelling…"; the poll/refetch reconciles it to
+    // "Cancelled" once the runner finalizes.
+    setCancelling(true);
+    await cancelRun(workspaceId, projectId, selectedRunId);
+    await fetchRunDetails(workspaceId, projectId, selectedRunId);
+  }, [
+    workspaceId,
+    projectId,
+    selectedRunId,
+    cancelling,
+    cancelRun,
+    fetchRunDetails,
+  ]);
+
+  // Clear the optimistic "Cancelling…" label once the run reaches a terminal
+  // status (cancelled/success/error) — the poll keeps fetching until then.
+  useEffect(() => {
+    if (cancelling && selectedStatus && !isActiveSelection) {
+      setCancelling(false);
+    }
+  }, [cancelling, selectedStatus, isActiveSelection]);
+
+  const cancelChipLabel =
+    cancelling && isActiveSelection
+      ? "Cancelling…"
+      : (selectedStatus ?? "queued");
 
   return (
     <Box sx={{ height: "100%", minHeight: 0 }}>
@@ -420,12 +456,11 @@ export default function DbtRunHistory({
                   size="small"
                   variant="outlined"
                   icon={
-                    selectedStatus === "running" ||
-                    selectedStatus === "queued" ? (
+                    isActiveSelection ? (
                       <CircularProgress size={10} />
                     ) : undefined
                   }
-                  label={selectedStatus ?? "queued"}
+                  label={cancelChipLabel}
                   sx={{
                     height: 20,
                     textTransform: "capitalize",
@@ -476,10 +511,39 @@ export default function DbtRunHistory({
                   {(selectedRun ?? selectedRunListItem)?.trigger} ·{" "}
                   {(selectedRun ?? selectedRunListItem)?.triggeredBy}
                 </Typography>
+                {selectedStatus === "cancelled" &&
+                  selectedDetail?.cancelledBy && (
+                    <Typography
+                      variant="caption"
+                      sx={{ color: "warning.main" }}
+                      title={absoluteTime(selectedDetail.cancelledAt)}
+                    >
+                      cancelled by {selectedDetail.cancelledBy}
+                      {selectedDetail.cancelledAt
+                        ? ` · ${relativeTime(selectedDetail.cancelledAt)}`
+                        : ""}
+                    </Typography>
+                  )}
                 {(selectedRun ?? selectedRunListItem)?.error && (
                   <Typography variant="caption" color="error">
                     {(selectedRun ?? selectedRunListItem)?.error}
                   </Typography>
+                )}
+                {isActiveSelection && (
+                  <Tooltip title="Stop this run (terminates the dbt process)">
+                    <span style={{ marginLeft: "auto" }}>
+                      <Button
+                        size="small"
+                        color="warning"
+                        variant="outlined"
+                        startIcon={<StopIcon size={14} />}
+                        onClick={handleCancel}
+                        disabled={cancelling}
+                      >
+                        {cancelling ? "Cancelling…" : "Cancel"}
+                      </Button>
+                    </span>
+                  </Tooltip>
                 )}
                 {selectedStatus === "error" && (
                   <Tooltip title="Re-run only the failed/skipped nodes">

--- a/app/src/components/StreamingToolCard.tsx
+++ b/app/src/components/StreamingToolCard.tsx
@@ -31,6 +31,7 @@ import {
   Plus,
   Search,
   ShieldCheck,
+  Square,
   Table2,
   Trash2,
   Wrench,
@@ -116,6 +117,8 @@ function renderToolIcon(iconKey: ToolIconKey): React.ReactNode {
       return <Brain size={ICON_SIZE} />;
     case "shield-check":
       return <ShieldCheck size={ICON_SIZE} />;
+    case "square":
+      return <Square size={ICON_SIZE} />;
     case "help-circle":
       return <HelpCircle size={ICON_SIZE} />;
     default:

--- a/app/src/store/dbtStore.ts
+++ b/app/src/store/dbtStore.ts
@@ -192,6 +192,10 @@ export interface DbtRunItem {
   startedAt?: string;
   completedAt?: string;
   durationMs?: number;
+  /** Set when the run was cancelled. */
+  cancelledAt?: string;
+  /** User id (or "agent") that cancelled the run. */
+  cancelledBy?: string;
   stepResults?: DbtStepResult[];
   error?: string;
   createdAt: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Today a long-running dbt build (e.g. a model stuck >18 min) can only be waited out — there is no stop control. The pre-existing `cancelOn` only stopped Inngest from scheduling further steps; it never killed the dbt subprocess, so warehouse compute kept running. This PR adds real, end-to-end cancellation from the Runs tab and the agent API.

## Walkthrough

[dbt_cancel_running_run_and_queue_advance.mp4](https://cursor.com/agents/bc-dc7be728-7f3a-4c64-9078-b22bdac8acb4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdbt_cancel_running_run_and_queue_advance.mp4)

Cancelling a running run from the Runs tab: the status flips **Running → Cancelling… → Cancelled** with attribution.

[Cancelled run with attribution](https://cursor.com/agents/bc-dc7be728-7f3a-4c64-9078-b22bdac8acb4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdbt_run_cancelled_with_attribution.webp)

[Cancelled run detail showing partial logs incl. SIGTERM, plus the queued run advanced to Running](https://cursor.com/agents/bc-dc7be728-7f3a-4c64-9078-b22bdac8acb4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdbt_queue_advanced_after_cancel.webp)

The detail panel shows the **Cancelled** chip, the `cancelled by <user> · just now` attribution, the **partial logs captured up to the cancel point** (including `Run cancellation requested — sending SIGTERM` and the BigQuery job console URL the scraper parses), and the left list's previously-queued run now **Running** — the queue advanced.

## Runner / backend

- **Actually kill the subprocess.** New in-process active-run registry (`api/src/dbt/dbt-run-registry.ts`). The Inngest executor registers an `AbortController` per run and passes its signal into `runDbt`; `execDbtCommand` now escalates SIGTERM → SIGKILL after a 15s grace (env-tunable for tests). `cancelLocalRun(runId)` (called from the cancel API path, same process as the worker) aborts the child.
- **BigQuery `jobs.cancel`.** Best-effort: the executor scrapes streamed dbt logs for BigQuery job ids (`api/src/dbt/bigquery-cancel.service.ts`, unit-tested extractor) and cancels them so we stop warehouse compute, not just the local process.
- **Terminal `cancelled` status** with `cancelledAt` + `cancelledBy` (userId or `"agent"`) and partial step results/logs. Shared `finalizeCancelledDbtRun` keeps the write idempotent and frees the Inngest concurrency slot so the next queued run starts.
- **`requestDbtRunCancel` is idempotent** and returns `{ status, cancelledAt, cancelledBy }`. queued → cancelled before it starts; running → abort + event; terminal → no-op echoing current status; finish-just-as-cancel race → returns the real terminal status.

## API & agent

- `POST /dbt/projects/:projectId/runs/:runId/cancel` returns `{ status, cancelledAt, cancelledBy }` (404 unknown, 200 incl. idempotent terminal).
- New agent tool `dbt_cancel_run(projectId, runId)`, registered in the transform mode allowlist + client tool manifest.

## UI (Runs tab)

- Cancel button on `queued`/`running` runs in `DbtRunHistory`, optimistically flips to **Cancelling…** then **Cancelled**, and shows who cancelled it and when. Partial logs surface. Chat run card label also reflects Cancelling….

## Notable fix found during testing

The first manual test exposed a real bug: Inngest **replays the executor function body per step and recreates the `AbortController` each time**, so `controller.signal.aborted` was only true in the invocation that ran the subprocess — by the time `finalize-run` executed in a later replay it read a fresh (un-aborted) controller and finalized a cancelled run as `error`. Fixed by detecting cancellation from the **durable DB marker** (`status === cancelled || cancelledAt`), which `requestDbtRunCancel` stages before aborting. Re-tested: cancel now reliably lands on `cancelled`.

## Edge cases handled

- Race (cancel as run finishes) → return actual terminal status, no error.
- Multi-step runs → abort stops the whole run, not just the current step.
- BigQuery job id unknown at cancel time → kill subprocess + best-effort-cancel any ids found in logs.

## Merge

Merged latest `master`; the only conflict (`client-tool-manifest.ts`) was a both-sides-added-adjacent-entry conflict — kept both `dbt_cancel_run` (this branch) and `dbt_delete_job` (master). The corresponding `registry.ts` / `dbt-tools.ts` entries auto-merged and contain both tools.

## Testing

- ✅ `pnpm --filter api exec vitest run src/dbt src/routes/dbt.routes.integration.test.ts` (110 passed, incl. new BQ extraction, idempotency, and a runner SIGTERM/SIGKILL integration test that drives real `runDbt` with a fake dbt bin)
- ✅ `pnpm --filter api run build` (lint + tsc)
- ✅ `pnpm --filter app run typecheck && pnpm --filter app run lint && pnpm --filter app run build`
- ✅ Manual end-to-end via UI + API: queued cancel never executes; running cancel kills the subprocess instantly and lands `cancelled` with attribution; idempotent cancel on a terminal run echoes status with no side effects; queue advances (A→cancelled, B→running).

> Note: BigQuery `jobs.cancel` cannot be exercised here (demo source is local Postgres, no BigQuery credentials). The job-id extraction is unit-tested and the cancel call is best-effort/fire-and-forget; the demo's fake dbt emits a BigQuery console URL to exercise the scraping path.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc7be728-7f3a-4c64-9078-b22bdac8acb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc7be728-7f3a-4c64-9078-b22bdac8acb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

