### PR TITLE
feat(dbt): add dbt_merge_pull_request agent tool

### DIFF
--- a/api/src/agent-lib/tools/dbt-job-tools.test.ts
+++ b/api/src/agent-lib/tools/dbt-job-tools.test.ts
@@ -44,6 +44,7 @@ vi.mock("../../dbt/dbt-github-git.service", () => ({
   createProjectBranch: vi.fn(),
   getGitStatus: vi.fn(),
   listProjectBranches: vi.fn(),
+  mergeProjectPullRequest: vi.fn(),
   openProjectPullRequest: vi.fn(),
   switchProjectBranch: vi.fn(),
 }));

--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -55,6 +55,7 @@ import {
   getGitStatus,
   listProjectBranches,
   listRecoverableFiles,
+  mergeProjectPullRequest,
   openProjectPullRequest,
   restoreDeletedFile,
   switchProjectBranch,
@@ -1473,6 +1474,63 @@ export const createDbtServerTools = (
           };
         } catch (error) {
           return toolError(error, "Failed to open pull request");
+        }
+      },
+    }),
+
+    dbt_merge_pull_request: tool({
+      description:
+        "Merge a GitHub pull request that was opened with dbt_open_pull_request, " +
+        "optionally delete its source branch, then switch the project back to " +
+        "the repo's default branch and sync the merged state into the working " +
+        "tree. Use when the user asks to promote/merge a PR — completes the " +
+        "full ship loop without manual GitHub UI steps. Returns the merge " +
+        "commit SHA, whether the branch was deleted, and confirmation the " +
+        "working tree is clean on the default branch.",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        prNumber: z
+          .number()
+          .int()
+          .positive()
+          .describe("Pull request number returned by dbt_open_pull_request"),
+        mergeMethod: z
+          .enum(["merge", "squash", "rebase"])
+          .optional()
+          .describe('How to merge; defaults to "squash"'),
+        deleteBranch: z
+          .boolean()
+          .optional()
+          .describe(
+            "Delete the PR's source branch after merge; defaults to true",
+          ),
+      }),
+      execute: async ({
+        projectId,
+        prNumber,
+        mergeMethod,
+        deleteBranch,
+      }) => {
+        try {
+          const project = await assertRepoProject(projectId);
+          const result = await mergeProjectPullRequest(project, {
+            prNumber,
+            mergeMethod,
+            deleteBranch,
+            updatedBy: userId ?? "agent",
+          });
+          return {
+            success: true,
+            sha: result.sha,
+            branchDeleted: result.branchDeleted,
+            ...(result.branchDeleteWarning
+              ? { branchDeleteWarning: result.branchDeleteWarning }
+              : {}),
+            branch: result.branch,
+            workingTreeClean: result.workingTreeClean,
+          };
+        } catch (error) {
+          return toolError(error, "Failed to merge pull request");
         }
       },
     }),

--- a/api/src/agents/dbt/prompt.ts
+++ b/api/src/agents/dbt/prompt.ts
@@ -30,7 +30,9 @@ runs execute against the project's warehouse environments (dev/prod).
    auto-generate one) to push to the tracked branch. When the user wants changes on a NEW branch
    for review, use \`dbt_commit_to_branch\` (atomic branch+commit) — NOT \`dbt_create_branch\` then
    \`dbt_commit_and_push\`, which can race a concurrent commit and strand the changes on the wrong
-   branch. Then \`dbt_open_pull_request\`. If a build runs against a stale checkout (fewer
+   branch. Then \`dbt_open_pull_request\`; when the user asks to promote/merge, call
+   \`dbt_merge_pull_request\` with the PR number to merge on GitHub, delete the feature branch,
+   and sync the default branch into the working tree. If a build runs against a stale checkout (fewer
    models/sources than the branch has, e.g. a merged PR not yet picked up), call
    \`dbt_sync_from_repo\` to re-pull the tracked branch. Clean up merged/stray branches with
    \`dbt_delete_branch\`.

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -161,7 +161,9 @@ Only commit when the user asks. Check \`dbt_git_status\`, then \`dbt_commit_and_
 \`message\` to auto-generate one) to push to the tracked branch — same as the IDE button. To put
 changes on a NEW branch for review, use \`dbt_commit_to_branch\` (atomic branch+commit) rather than
 \`dbt_create_branch\` + \`dbt_commit_and_push\` — the two-step version can race a concurrent commit and
-strand the changes on the wrong branch. Then \`dbt_open_pull_request\`. If a run builds from a stale
+strand the changes on the wrong branch. Then \`dbt_open_pull_request\`; when the user asks to
+promote/merge, call \`dbt_merge_pull_request\` with the PR number to merge on GitHub, delete the
+feature branch, and sync the default branch into the working tree. If a run builds from a stale
 checkout (fewer models/sources than the branch actually has, e.g. a merged PR not picked up), call
 \`dbt_sync_from_repo\` to re-pull the tracked branch. Use \`dbt_delete_branch\` to clean up merged or
 stray branches. Switching branches OVERWRITES the working tree: \`dbt_switch_branch\` refuses when

--- a/api/src/agents/modes/registry.ts
+++ b/api/src/agents/modes/registry.ts
@@ -185,6 +185,7 @@ const TRANSFORM_MODE_TOOL_NAMES: string[] = [
   "dbt_list_branches",
   "dbt_delete_branch",
   "dbt_open_pull_request",
+  "dbt_merge_pull_request",
   // Recovery: surface + restore work hidden by a destructive switch/sync.
   "dbt_list_recoverable_files",
   "dbt_restore_file",

--- a/api/src/dbt/dbt-github-git.merge.test.ts
+++ b/api/src/dbt/dbt-github-git.merge.test.ts
@@ -1,0 +1,221 @@
+/**
+ * mergeProjectPullRequest — unit tests with mocked GitHub API + sync.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Types } from "mongoose";
+import type { IDbtProject } from "../database/workspace-schema";
+
+vi.mock("../integrations/github/app-auth", () => ({
+  resolveRepoToken: vi.fn(async () => "token"),
+}));
+
+vi.mock("../integrations/github/github-api", () => ({
+  getPullRequest: vi.fn(),
+  mergePullRequest: vi.fn(),
+  getRepoInfo: vi.fn(),
+  tryDeleteBranch: vi.fn(),
+}));
+
+vi.mock("./dbt-github-sync.service", () => ({
+  syncProjectFromRepo: vi.fn(async () => undefined),
+}));
+
+const mockFindById = vi.fn();
+const mockSave = vi.fn(async () => undefined);
+
+vi.mock("../database/workspace-schema", () => ({
+  DbtFile: {
+    find: vi.fn(() => ({
+      select: () => ({
+        lean: async () => [],
+      }),
+    })),
+    findOne: vi.fn(),
+  },
+  DbtProject: {
+    findById: (...args: unknown[]) => mockFindById(...args),
+  },
+}));
+
+import {
+  getPullRequest,
+  mergePullRequest,
+  getRepoInfo,
+  tryDeleteBranch,
+} from "../integrations/github/github-api";
+import { syncProjectFromRepo } from "./dbt-github-sync.service";
+import { mergeProjectPullRequest } from "./dbt-github-git.service";
+
+const projectId = new Types.ObjectId();
+
+function makeProject(overrides: Partial<IDbtProject> = {}): IDbtProject {
+  return {
+    _id: projectId,
+    repo: {
+      owner: "acme",
+      repo: "dbt",
+      branch: "feature/add-model",
+      installationId: "inst-1",
+    },
+    markModified: vi.fn(),
+    save: mockSave,
+    ...overrides,
+  } as unknown as IDbtProject;
+}
+
+describe("mergeProjectPullRequest", () => {
+  let storedProject: IDbtProject;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storedProject = makeProject();
+    mockFindById.mockImplementation(async () => storedProject);
+  });
+
+  it("merges PR, deletes branch, switches to default, and syncs", async () => {
+    vi.mocked(getPullRequest).mockResolvedValue({
+      number: 42,
+      headRef: "feature/add-model",
+      baseRef: "main",
+      mergeable: true,
+      state: "open",
+    });
+    vi.mocked(mergePullRequest).mockResolvedValue({ sha: "abc123" });
+    vi.mocked(getRepoInfo).mockResolvedValue({
+      fullName: "acme/dbt",
+      owner: "acme",
+      name: "dbt",
+      defaultBranch: "main",
+      private: false,
+    });
+    vi.mocked(tryDeleteBranch).mockResolvedValue({ deleted: true });
+
+    const project = storedProject;
+    const result = await mergeProjectPullRequest(project, {
+      prNumber: 42,
+      updatedBy: "agent",
+    });
+
+    expect(mergePullRequest).toHaveBeenCalledWith(
+      "acme",
+      "dbt",
+      42,
+      { mergeMethod: "squash" },
+      "token",
+    );
+    expect(project.repo?.branch).toBe("main");
+    expect(mockSave).toHaveBeenCalled();
+    expect(syncProjectFromRepo).toHaveBeenCalledWith(project, "agent");
+    expect(tryDeleteBranch).toHaveBeenCalledWith(
+      "acme",
+      "dbt",
+      "feature/add-model",
+      "token",
+    );
+    expect(result).toEqual({
+      sha: "abc123",
+      branchDeleted: true,
+      branchDeleteWarning: undefined,
+      branch: "main",
+      workingTreeClean: true,
+    });
+  });
+
+  it("returns branch delete warning when deletion fails", async () => {
+    vi.mocked(getPullRequest).mockResolvedValue({
+      number: 7,
+      headRef: "feature/x",
+      baseRef: "main",
+      mergeable: true,
+      state: "open",
+    });
+    vi.mocked(mergePullRequest).mockResolvedValue({ sha: "def456" });
+    vi.mocked(getRepoInfo).mockResolvedValue({
+      fullName: "acme/dbt",
+      owner: "acme",
+      name: "dbt",
+      defaultBranch: "main",
+      private: false,
+    });
+    vi.mocked(tryDeleteBranch).mockResolvedValue({
+      deleted: false,
+      warning: "GitHub 403 on ...: protected branch",
+    });
+
+    const result = await mergeProjectPullRequest(storedProject, {
+      prNumber: 7,
+      mergeMethod: "merge",
+      deleteBranch: true,
+      updatedBy: "u1",
+    });
+
+    expect(result.sha).toBe("def456");
+    expect(result.branchDeleted).toBe(false);
+    expect(result.branchDeleteWarning).toContain("protected branch");
+  });
+
+  it("skips branch deletion when deleteBranch is false", async () => {
+    vi.mocked(getPullRequest).mockResolvedValue({
+      number: 3,
+      headRef: "feature/y",
+      baseRef: "main",
+      mergeable: true,
+      state: "open",
+    });
+    vi.mocked(mergePullRequest).mockResolvedValue({ sha: "ghi789" });
+    vi.mocked(getRepoInfo).mockResolvedValue({
+      fullName: "acme/dbt",
+      owner: "acme",
+      name: "dbt",
+      defaultBranch: "main",
+      private: false,
+    });
+
+    const result = await mergeProjectPullRequest(storedProject, {
+      prNumber: 3,
+      deleteBranch: false,
+      updatedBy: "u1",
+    });
+
+    expect(tryDeleteBranch).not.toHaveBeenCalled();
+    expect(result.branchDeleted).toBe(false);
+  });
+
+  it("surfaces GitHub merge errors verbatim", async () => {
+    vi.mocked(getPullRequest).mockResolvedValue({
+      number: 99,
+      headRef: "feature/conflict",
+      baseRef: "main",
+      mergeable: false,
+      state: "open",
+    });
+    vi.mocked(mergePullRequest).mockRejectedValue(
+      new Error("Pull Request is not mergeable"),
+    );
+
+    await expect(
+      mergeProjectPullRequest(storedProject, {
+        prNumber: 99,
+        updatedBy: "u1",
+      }),
+    ).rejects.toThrow("Pull Request is not mergeable");
+  });
+
+  it("rejects closed pull requests", async () => {
+    vi.mocked(getPullRequest).mockResolvedValue({
+      number: 5,
+      headRef: "feature/done",
+      baseRef: "main",
+      mergeable: null,
+      state: "closed",
+    });
+
+    await expect(
+      mergeProjectPullRequest(storedProject, {
+        prNumber: 5,
+        updatedBy: "u1",
+      }),
+    ).rejects.toThrow("Pull request #5 is closed");
+    expect(mergePullRequest).not.toHaveBeenCalled();
+  });
+});

--- a/api/src/dbt/dbt-github-git.service.ts
+++ b/api/src/dbt/dbt-github-git.service.ts
@@ -20,10 +20,14 @@ import {
   createPullRequest,
   deleteBranch,
   getBlobContent,
+  getPullRequest,
   getRefCommit,
   getRepoInfo,
   getRepoTree,
   listBranches,
+  mergePullRequest,
+  tryDeleteBranch,
+  type MergeMethod,
   type TreeChange,
 } from "../integrations/github/github-api";
 import { syncProjectFromRepo } from "./dbt-github-sync.service";
@@ -578,4 +582,78 @@ export async function openProjectPullRequest(
     { title: params.title, head: branch, base, body: params.body },
     token,
   );
+}
+
+export interface MergePullRequestResult {
+  sha: string;
+  branchDeleted: boolean;
+  branchDeleteWarning?: string;
+  branch: string;
+  workingTreeClean: boolean;
+}
+
+/**
+ * Merge a GitHub pull request, optionally delete its head branch, then switch
+ * the project back to the repo default branch and sync the merged state into
+ * the working tree.
+ */
+export async function mergeProjectPullRequest(
+  project: IDbtProject,
+  params: {
+    prNumber: number;
+    mergeMethod?: MergeMethod;
+    deleteBranch?: boolean;
+    updatedBy: string;
+  },
+): Promise<MergePullRequestResult> {
+  return withProjectGitLock(project._id.toString(), async () => {
+    const fresh = await reloadRepoProject(project);
+    const token = await resolveRepoToken(fresh.repo.installationId);
+    const { owner, repo } = fresh.repo;
+
+    const pr = await getPullRequest(owner, repo, params.prNumber, token);
+    if (pr.state !== "open") {
+      throw new Error(
+        `Pull request #${params.prNumber} is ${pr.state} — only open PRs can be merged`,
+      );
+    }
+
+    const { sha } = await mergePullRequest(
+      owner,
+      repo,
+      params.prNumber,
+      { mergeMethod: params.mergeMethod ?? "squash" },
+      token,
+    );
+
+    const info = await getRepoInfo(owner, repo, token);
+    const defaultBranch = info.defaultBranch;
+
+    fresh.repo.branch = defaultBranch;
+    fresh.markModified("repo");
+    await fresh.save();
+    await syncProjectFromRepo(fresh, params.updatedBy);
+
+    let branchDeleted = false;
+    let branchDeleteWarning: string | undefined;
+    if (params.deleteBranch !== false) {
+      const deleteResult = await tryDeleteBranch(
+        owner,
+        repo,
+        pr.headRef,
+        token,
+      );
+      branchDeleted = deleteResult.deleted;
+      branchDeleteWarning = deleteResult.warning;
+    }
+
+    const status = await getGitStatus(fresh);
+    return {
+      sha,
+      branchDeleted,
+      branchDeleteWarning,
+      branch: defaultBranch,
+      workingTreeClean: !status.hasChanges,
+    };
+  });
 }

--- a/api/src/integrations/github/github-api.merge.test.ts
+++ b/api/src/integrations/github/github-api.merge.test.ts
@@ -1,0 +1,81 @@
+/**
+ * mergePullRequest + tryDeleteBranch — GitHub REST error handling.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mergePullRequest, tryDeleteBranch } from "./github-api";
+
+describe("mergePullRequest", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns merge commit sha on success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        text: async () => JSON.stringify({ sha: "merged-sha", merged: true }),
+      })),
+    );
+
+    const result = await mergePullRequest("o", "r", 10, {
+      mergeMethod: "squash",
+    });
+    expect(result.sha).toBe("merged-sha");
+  });
+
+  it("throws GitHub message verbatim on merge failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: false,
+        text: async () =>
+          JSON.stringify({
+            message: "Pull Request is not mergeable",
+            documentation_url: "https://docs.github.com/rest",
+          }),
+      })),
+    );
+
+    await expect(
+      mergePullRequest("o", "r", 10, { mergeMethod: "squash" }),
+    ).rejects.toThrow("Pull Request is not mergeable");
+  });
+});
+
+describe("tryDeleteBranch", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("treats 404 as already deleted", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: false,
+        status: 404,
+        headers: { get: () => null },
+        text: async () => '{"message":"Reference does not exist"}',
+      })),
+    );
+
+    const result = await tryDeleteBranch("o", "r", "gone-branch");
+    expect(result).toEqual({ deleted: true });
+  });
+
+  it("returns warning on protected branch failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: false,
+        status: 403,
+        headers: { get: () => null },
+        text: async () => '{"message":"Resource not accessible"}',
+      })),
+    );
+
+    const result = await tryDeleteBranch("o", "r", "protected");
+    expect(result.deleted).toBe(false);
+    expect(result.warning).toContain("GitHub 403");
+  });
+});

--- a/api/src/integrations/github/github-api.ts
+++ b/api/src/integrations/github/github-api.ts
@@ -444,6 +444,101 @@ export async function createPullRequest(
   return { number: json.number, htmlUrl: json.html_url };
 }
 
+export interface PullRequestInfo {
+  number: number;
+  headRef: string;
+  baseRef: string;
+  mergeable: boolean | null;
+  state: string;
+}
+
+export async function getPullRequest(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  token?: string,
+): Promise<PullRequestInfo> {
+  const res = await ghFetch(`/repos/${owner}/${repo}/pulls/${prNumber}`, token);
+  const json = (await res.json()) as {
+    number: number;
+    head: { ref: string };
+    base: { ref: string };
+    mergeable: boolean | null;
+    state: string;
+  };
+  return {
+    number: json.number,
+    headRef: json.head.ref,
+    baseRef: json.base.ref,
+    mergeable: json.mergeable,
+    state: json.state,
+  };
+}
+
+export type MergeMethod = "merge" | "squash" | "rebase";
+
+function parseGitHubErrorMessage(body: string): string {
+  try {
+    const parsed = JSON.parse(body) as { message?: string };
+    if (parsed.message) return parsed.message;
+  } catch {
+    // fall through
+  }
+  return body.slice(0, 500);
+}
+
+/** Merge a pull request. Surfaces GitHub's error message verbatim on failure. */
+export async function mergePullRequest(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  params: { mergeMethod: MergeMethod },
+  token?: string,
+): Promise<{ sha: string }> {
+  const headers = authHeaders(token);
+  headers["Content-Type"] = "application/json";
+  const res = await fetch(
+    `${GITHUB_API}/repos/${owner}/${repo}/pulls/${prNumber}/merge`,
+    {
+      method: "PUT",
+      headers,
+      body: JSON.stringify({ merge_method: params.mergeMethod }),
+    },
+  );
+  const bodyText = await res.text();
+  if (!res.ok) {
+    throw new Error(parseGitHubErrorMessage(bodyText));
+  }
+  const json = JSON.parse(bodyText) as { sha: string };
+  return { sha: json.sha };
+}
+
+/**
+ * Delete a branch ref. Returns whether the ref is gone and an optional warning
+ * when deletion fails for a reason other than "already deleted".
+ */
+export async function tryDeleteBranch(
+  owner: string,
+  repo: string,
+  branch: string,
+  token?: string,
+): Promise<{ deleted: boolean; warning?: string }> {
+  try {
+    await ghFetch(
+      `/repos/${owner}/${repo}/git/refs/heads/${encodeURIComponent(branch)}`,
+      token,
+      { method: "DELETE" },
+    );
+    return { deleted: true };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes("GitHub 404") || message.includes("GitHub 422")) {
+      return { deleted: true };
+    }
+    return { deleted: false, warning: message };
+  }
+}
+
 /** Repos an App installation can access (requires an installation token). */
 export async function listInstallationRepos(
   token: string,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `dbt_merge_pull_request` so the dbt agent can complete the promote-to-prod loop after `dbt_open_pull_request` — no manual GitHub UI step, no re-applying files on main by hand.

## Tool signature

- `projectId` (required)
- `prNumber` (required) — from `dbt_open_pull_request`
- `mergeMethod` (optional, default `"squash"`) — `"merge"` | `"squash"` | `"rebase"`
- `deleteBranch` (optional, default `true`)

## Behavior

1. `PUT /repos/{owner}/{repo}/pulls/{pr_number}/merge` with the chosen merge method
2. Switches the project to the repo default branch and syncs the merged state into the working tree
3. Optionally deletes the PR head branch via `DELETE /repos/{owner}/{repo}/git/refs/heads/{branch}`
4. Returns merge commit SHA, branch deletion status, current branch, and whether the working tree is clean

## Error handling

- Merge conflicts / non-mergeable PRs: GitHub error message returned verbatim
- Branch deletion failures (protected branch, etc.): merge succeeds with a `branchDeleteWarning`; already-deleted branches are treated as success

## Changes

- `api/src/integrations/github/github-api.ts` — `getPullRequest`, `mergePullRequest`, `tryDeleteBranch`
- `api/src/dbt/dbt-github-git.service.ts` — `mergeProjectPullRequest` orchestration (git lock, branch switch, sync)
- `api/src/agent-lib/tools/dbt-tools.ts` — `dbt_merge_pull_request` tool
- Agent mode registry + dbt prompts updated
- Unit tests for API helpers and service layer

## Test plan

- [x] `pnpm --filter api exec vitest run src/dbt/dbt-github-git.merge.test.ts src/integrations/github/github-api.merge.test.ts`
- [x] `pnpm --filter api run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-206b8aa9-6aca-44e8-b4df-8de6a479f714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-206b8aa9-6aca-44e8-b4df-8de6a479f714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

