### PR TITLE
fix(apps): seed initial version on create + backfill existing apps (empty version history)

### DIFF
--- a/api/src/agent-lib/tools/server-app-tools.ts
+++ b/api/src/agent-lib/tools/server-app-tools.ts
@@ -258,6 +258,26 @@ export function createServerAppTools({
             createdBy: userId ?? "agent",
             version: 1,
           });
+          // Seed an initial published version (v1) so the app has version
+          // history from creation (mirrors consoles/dashboards + the REST route).
+          const initialSnapshot = buildAppSnapshot(created);
+          const initialVersion = await createVersion({
+            entityType: "app",
+            entityId: created._id,
+            workspaceId: new Types.ObjectId(workspaceId),
+            snapshot: initialSnapshot as unknown as Record<string, unknown>,
+            savedBy: userId ?? "agent",
+            savedByName: await savedByName(),
+            comment: "App created",
+          });
+          created.published = initialSnapshot as unknown as Record<
+            string,
+            unknown
+          >;
+          created.markModified("published");
+          created.publishedVersion = initialVersion.version;
+          created.publishedAt = new Date();
+          await created.save();
           // Poke the workspace so an attached browser's Apps explorer picks up
           // the new app without a manual reload (browser follows the server).
           publishRealtimeEvent(workspaceId, {

--- a/api/src/migrations/2026-06-27-145356_backfill_initial_app_version.ts
+++ b/api/src/migrations/2026-06-27-145356_backfill_initial_app_version.ts
@@ -1,0 +1,114 @@
+import { Db } from "mongodb";
+
+export const description =
+  "Backfill an initial published version (v1) for every MakoApp that has no version history";
+
+/**
+ * Apps shipped without creating an initial EntityVersion on creation (unlike
+ * consoles/dashboards), so apps created before that fix show an empty Version
+ * History panel. This backfills a v1 snapshot + `published` baseline for every
+ * app that has no "app" EntityVersion yet, so version history appears for
+ * existing apps. Idempotent: apps that already have a version are skipped.
+ */
+
+interface RawBinding {
+  id?: string;
+  name?: string;
+  connectionId?: string;
+  language?: string;
+  code?: string;
+  databaseId?: string;
+  databaseName?: string;
+  materialization?: string;
+  materializationSchedule?: unknown;
+}
+
+interface RawApp {
+  _id: unknown;
+  workspaceId: unknown;
+  title?: string;
+  description?: string;
+  template?: string;
+  runtime?: string;
+  entrypoint?: string;
+  files?: Array<{ path?: string; contents?: string }>;
+  dependencies?: Record<string, string>;
+  dataBindings?: RawBinding[];
+  published?: unknown;
+  createdBy?: string;
+}
+
+/** Mirror of services/app-version.service buildAppSnapshot (raw form). */
+function buildSnapshot(app: RawApp): Record<string, unknown> {
+  return {
+    title: app.title,
+    description: app.description,
+    template: app.template,
+    runtime: app.runtime,
+    entrypoint: app.entrypoint,
+    files: (app.files ?? []).map(f => ({
+      path: f.path,
+      contents: f.contents,
+    })),
+    dependencies: { ...(app.dependencies ?? {}) },
+    dataBindings: (app.dataBindings ?? []).map(b => ({
+      id: b.id,
+      name: b.name,
+      connectionId: b.connectionId,
+      language: b.language,
+      code: b.code,
+      databaseId: b.databaseId,
+      databaseName: b.databaseName,
+      materialization: b.materialization ?? "live",
+      materializationSchedule: b.materializationSchedule,
+    })),
+  };
+}
+
+export async function up(db: Db): Promise<void> {
+  const apps = db.collection<RawApp>("makoapps");
+  // EntityVersion model maps to the "entity_versions" collection (see
+  // EntityVersionSchema in workspace-schema.ts) — NOT Mongoose's default
+  // "entityversions".
+  const versions = db.collection("entity_versions");
+
+  const cursor = apps.find({});
+  for await (const app of cursor) {
+    // Idempotent: skip apps that already have any version history.
+    const existing = await versions.findOne({
+      entityType: "app",
+      entityId: app._id,
+    });
+    if (existing) continue;
+
+    const snapshot = buildSnapshot(app);
+    const now = new Date();
+
+    await versions.insertOne({
+      workspaceId: app.workspaceId,
+      entityType: "app",
+      entityId: app._id,
+      version: 1,
+      snapshot,
+      savedBy: app.createdBy || "system",
+      savedByName: "System",
+      comment: "Backfilled initial version",
+      createdAt: now,
+    });
+
+    // Only set the published baseline if the app was never published, so we
+    // never clobber an existing published snapshot.
+    if (app.published === undefined || app.published === null) {
+      await apps.updateOne(
+        { _id: app._id },
+        {
+          $set: {
+            published: snapshot,
+            publishedVersion: 1,
+            publishedAt: now,
+          },
+        },
+      );
+    }
+  }
+}

--- a/api/src/routes/apps.ts
+++ b/api/src/routes/apps.ts
@@ -379,6 +379,27 @@ app.openapi(
         version: 1,
       });
 
+      // Seed an initial published version (v1) so every app has version history
+      // from creation — mirroring consoles/dashboards. Without this, an app only
+      // gets versions after an explicit "Publish version", so freshly-created
+      // apps showed an empty history.
+      const displayName = await getUserDisplayName(userId ?? "system");
+      const initialSnapshot = buildAppSnapshot(created);
+      const initialVersion = await createVersion({
+        entityType: "app",
+        entityId: created._id,
+        workspaceId: new Types.ObjectId(workspaceId),
+        snapshot: initialSnapshot as unknown as Record<string, unknown>,
+        savedBy: userId ?? "system",
+        savedByName: displayName,
+        comment: "App created",
+      });
+      created.published = initialSnapshot as unknown as Record<string, unknown>;
+      created.markModified("published");
+      created.publishedVersion = initialVersion.version;
+      created.publishedAt = new Date();
+      await created.save();
+
       return c.json({ success: true, app: serializeApp(created) }, 201);
     } catch (error) {
       logger.error("Error creating app", { error });

--- a/app/src/components/AppRenderer.tsx
+++ b/app/src/components/AppRenderer.tsx
@@ -8,7 +8,11 @@ import {
   Chip,
   Alert,
 } from "@mui/material";
-import { RefreshCw as RefreshIcon, Share2 as ShareIcon } from "lucide-react";
+import {
+  RefreshCw as RefreshIcon,
+  Share2 as ShareIcon,
+  History as HistoryIcon,
+} from "lucide-react";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useAuth } from "../contexts/auth-context";
 import { useTheme } from "../contexts/ThemeContext";
@@ -16,6 +20,7 @@ import { useIsWorkspaceAdmin } from "../hooks/useIsWorkspaceAdmin";
 import { useAppStore } from "../store/appStore";
 import { useConsoleStore } from "../store/consoleStore";
 import ShareDialog from "./ShareDialog";
+import { VersionHistoryPanel } from "./VersionHistoryPanel";
 import { buildPreviewHtml, PREVIEW_MESSAGE } from "../app-runtime/preview";
 import { appLocationFromHostSearch } from "../app-runtime/app-location";
 import {
@@ -45,6 +50,7 @@ export default function AppRenderer({
   const isWorkspaceAdmin = useIsWorkspaceAdmin();
   const workspaceId = currentWorkspace?.id;
   const [shareOpen, setShareOpen] = useState(false);
+  const [historyOpen, setHistoryOpen] = useState(false);
 
   // The sandboxed preview inherits the host theme: the current mode seeds the
   // srcdoc, and later toggles are pushed via postMessage (rebuilding the
@@ -328,6 +334,11 @@ export default function AppRenderer({
           label={appEntity.runtime === "cdn" ? "CDN preview" : "WebContainer"}
         />
         <Box sx={{ flex: 1 }} />
+        <Tooltip title="Version history">
+          <IconButton size="small" onClick={() => setHistoryOpen(true)}>
+            <HistoryIcon size={18} strokeWidth={1.5} />
+          </IconButton>
+        </Tooltip>
         <Tooltip title="Share">
           <IconButton size="small" onClick={() => setShareOpen(true)}>
             <ShareIcon size={18} strokeWidth={1.5} />
@@ -339,6 +350,18 @@ export default function AppRenderer({
           </IconButton>
         </Tooltip>
       </Box>
+
+      <VersionHistoryPanel
+        open={historyOpen}
+        onClose={() => setHistoryOpen(false)}
+        entityType="app"
+        entityId={appId}
+        onRestore={() => {
+          if (workspaceId) {
+            void fetchApp(workspaceId, appId).then(() => bumpPreview(appId));
+          }
+        }}
+      />
 
       <ShareDialog
         open={shareOpen}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

App version history showed **no versions in prod**, and there was **no toolbar affordance** to open it from an open app — only the explorer right-click.

Root cause for the missing versions: apps never created an `EntityVersion` on creation — unlike consoles and dashboards, which both seed a v1. App versions were only created on an explicit **Publish version**, so any app that was just created/edited (never published) had an empty Version History panel.

## What changed

1. **Seed v1 on create.** Both `POST /apps` and the agent `create_app` tool now create an initial `EntityVersion` (`"App created"`) + `published` baseline right after `MakoApp.create`, mirroring consoles/dashboards. Every new app has version history from creation.
2. **Backfill migration** (`backfill_initial_app_version`): for every existing `MakoApp` with no `app` version, insert a v1 snapshot and (if never published) set the `published` baseline. Idempotent; targets the correct `entity_versions` collection.
3. **Version History toolbar button.** Added a clock/history icon to the app preview toolbar in `AppRenderer` (next to Share + Rebuild) that opens the Version History panel for the open app — so versions are reachable from the toolbar, not just the explorer context menu.

## Walkthrough

Version History button on the app preview toolbar opens the panel (v1..v12 listed):
[app_toolbar_version_history_button.mp4](https://cursor.com/agents/bc-b6f67baf-48f5-431a-8cf7-88bf90851629/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_toolbar_version_history_button.mp4)

Previously-empty apps now show a backfilled v1:
[app_versions_now_appear_after_backfill.mp4](https://cursor.com/agents/bc-b6f67baf-48f5-431a-8cf7-88bf90851629/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_versions_now_appear_after_backfill.mp4)

## Testing
- ✅ `pnpm --filter app run typecheck` / `lint`
- ✅ `api` `tsc -p tsconfig.build.json --noEmit`; `pnpm --filter api run lint`
- ✅ Migration locally: published apps skipped; never-published apps backfilled to v1; idempotent re-run.
- ✅ New-app API: returns `publishedVersion: 1`; `GET …/versions` returns `v1 "App created"` immediately.
- ✅ UI: toolbar Version History button opens the panel and lists versions; backfilled apps show v1 (videos).

_Note: the "Failed to load dependency 'react' from esm.sh" banner seen in the toolbar video is the sandboxed CDN preview being unable to reach esm.sh from this test VM (network limitation) — unrelated to this change; the version-history UI renders and works correctly._


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6f67baf-48f5-431a-8cf7-88bf90851629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6f67baf-48f5-431a-8cf7-88bf90851629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

