### PR TITLE
fix(console): keep Save enabled after accepting agent edits on saved consoles

### DIFF
--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -85,6 +85,68 @@ function buildConsoleSnapshot(doc: ISavedConsole): Record<string, unknown> {
   };
 }
 
+// IMPORTANT: this MUST stay byte-for-byte compatible with the client hash so
+// the server-computed baseline equals what the client would compute for the
+// same snapshot. Mirror of `hashContent` in `app/src/utils/hash.ts` and
+// `computeConsoleStateHash` in `app/src/utils/stateHash.ts`. The two packages
+// can't share code (no common import path), so any change to the algorithm
+// here must be made in lockstep with those files or Save will misdetect dirt.
+function hashContent(content: string): string {
+  let hash = 0;
+  if (content.length === 0) return "0";
+
+  for (let i = 0; i < content.length; i++) {
+    const char = content.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash = hash & hash;
+  }
+
+  return Math.abs(hash).toString(16);
+}
+
+function computeConsoleStateHash(
+  content: string,
+  connectionId?: string,
+  databaseId?: string,
+  databaseName?: string,
+): string {
+  return hashContent(
+    `${content}|${connectionId || ""}|${databaseId || ""}|${databaseName || ""}`,
+  );
+}
+
+function computeConsoleStateHashFromSnapshot(
+  snapshot: Record<string, unknown> | undefined,
+): string | undefined {
+  if (!snapshot || typeof snapshot.code !== "string") return undefined;
+  return computeConsoleStateHash(
+    snapshot.code,
+    typeof snapshot.connectionId === "string"
+      ? snapshot.connectionId
+      : undefined,
+    typeof snapshot.databaseId === "string" ? snapshot.databaseId : undefined,
+    typeof snapshot.databaseName === "string"
+      ? snapshot.databaseName
+      : undefined,
+  );
+}
+
+async function getLatestConsoleSavedStateHash(
+  entityId: Types.ObjectId,
+  workspaceId: Types.ObjectId,
+): Promise<string | undefined> {
+  const latestVersion = await EntityVersion.findOne(
+    { entityId, entityType: "console", workspaceId },
+    { snapshot: 1 },
+  )
+    .sort({ version: -1 })
+    .lean();
+
+  return computeConsoleStateHashFromSnapshot(
+    latestVersion?.snapshot as Record<string, unknown> | undefined,
+  );
+}
+
 function sanitizeDownloadFilename(value: string): string {
   return value.replace(/[^a-zA-Z0-9._-]+/g, "_");
 }
@@ -339,6 +401,14 @@ consoleRoutes.openapi(
         ownerDisplayName = ownerUser?.email;
       }
 
+      const savedStateHash =
+        fullConsole && (consoleData.isSaved ?? true)
+          ? await getLatestConsoleSavedStateHash(
+              fullConsole._id,
+              new Types.ObjectId(workspaceId),
+            )
+          : undefined;
+
       return c.json({
         success: true,
         content: consoleData.content,
@@ -350,6 +420,8 @@ consoleRoutes.openapi(
         name: consoleData.name,
         path: consoleData.path,
         isSaved: consoleData.isSaved,
+        savedStateHash,
+        lastDraftOrigin: fullConsole?.lastDraftOrigin,
         chartSpec: consoleData.chartSpec,
         resultsViewMode: consoleData.resultsViewMode,
         access: consoleAccess,
@@ -453,6 +525,7 @@ consoleRoutes.openapi(
         workspaceId: new Types.ObjectId(workspaceId),
       });
       const docsById = new Map(docs.map(d => [d._id.toString(), d]));
+      const workspaceObjectId = new Types.ObjectId(workspaceId);
 
       const changed: Array<Record<string, unknown>> = [];
       const deleted: string[] = [];
@@ -469,6 +542,10 @@ consoleRoutes.openapi(
         }
         const serverRevision = doc.draftRevision ?? 1;
         if (serverRevision === clientRevision) continue;
+        const isSaved = doc.isSaved ?? true;
+        const savedStateHash = isSaved
+          ? await getLatestConsoleSavedStateHash(doc._id, workspaceObjectId)
+          : undefined;
         changed.push({
           id,
           draftRevision: serverRevision,
@@ -481,7 +558,8 @@ consoleRoutes.openapi(
           // Server truth for draft-vs-saved: clients use this to keep the
           // tab's autosave eligibility correct (drafts autosave, saved
           // consoles don't). Missing on legacy docs ⇒ treated as saved.
-          isSaved: doc.isSaved ?? true,
+          isSaved,
+          savedStateHash,
           // Lets the client route an agent edit into the diff-review flow even
           // when the live poke was missed (reconnect/reload). Undefined ⇒ user.
           lastDraftOrigin: doc.lastDraftOrigin,

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -3743,21 +3743,13 @@ const Chat: React.FC<ChatProps> = ({
           // and fetches those consoles from the database
           if (data.consoles && data.consoles.length > 0) {
             const store = useConsoleStore.getState();
-            const existingTabs = Object.values(store.tabs);
+            const workspaceId = workspaceIdRef.current;
 
             for (const console of data.consoles) {
               // Check if console already exists in tabs (by ID)
-              const exists = existingTabs.some((t: any) => t.id === console.id);
-              if (!exists) {
-                // Add the console tab
-                store.openTab({
-                  id: console.id,
-                  title: console.title || "Untitled",
-                  content: console.content || "",
-                  connectionId: console.connectionId,
-                  databaseId: console.databaseId,
-                  databaseName: console.databaseName,
-                });
+              const exists = Boolean(store.tabs[console.id]);
+              if (!exists && workspaceId) {
+                await store.openConsoleFromServer(workspaceId, console.id);
               }
             }
 
@@ -3986,21 +3978,7 @@ const Chat: React.FC<ChatProps> = ({
     if (!workspaceId) return;
 
     try {
-      const data = await store.fetchConsoleContent(workspaceId, consoleId);
-      if (!data) return;
-
-      const currentStore = useConsoleStore.getState();
-      currentStore.openTab({
-        id: consoleId,
-        title: data.name || data.path || "Untitled",
-        content: data.content || "",
-        connectionId: data.connectionId,
-        databaseId: data.databaseId,
-        databaseName: data.databaseName,
-        filePath: data.path,
-        isSaved: true,
-      });
-      currentStore.setActiveTab(consoleId);
+      await store.openConsoleFromServer(workspaceId, consoleId);
     } catch {
       /* ignore focus failures */
     }

--- a/app/src/components/ConsoleExplorer.tsx
+++ b/app/src/components/ConsoleExplorer.tsx
@@ -192,13 +192,17 @@ function ConsoleExplorer(
           const { computeConsoleStateHash } = await import(
             "../utils/stateHash"
           );
-          const hash = computeConsoleStateHash(
-            data.content,
-            data.connectionId,
-            data.databaseId,
-            data.databaseName,
-          );
-          updateSavedState(result.id, true, hash);
+          const savedStateHash =
+            data.savedStateHash ??
+            (data.lastDraftOrigin === "agent"
+              ? undefined
+              : computeConsoleStateHash(
+                  data.content,
+                  data.connectionId,
+                  data.databaseId,
+                  data.databaseName,
+                ));
+          updateSavedState(result.id, true, savedStateHash);
         }
       } catch (e) {
         console.error("Failed to load search result console", e);
@@ -259,12 +263,16 @@ function ConsoleExplorer(
           const { computeConsoleStateHash } = await import(
             "../utils/stateHash"
           );
-          const savedStateHash = computeConsoleStateHash(
-            data.content,
-            data.connectionId,
-            data.databaseId,
-            data.databaseName,
-          );
+          const savedStateHash =
+            data.savedStateHash ??
+            (data.lastDraftOrigin === "agent"
+              ? undefined
+              : computeConsoleStateHash(
+                  data.content,
+                  data.connectionId,
+                  data.databaseId,
+                  data.databaseName,
+                ));
           updateSavedState(consoleId, true, savedStateHash);
         }
       } catch (e) {

--- a/app/src/lib/api-types.ts
+++ b/app/src/lib/api-types.ts
@@ -33,6 +33,10 @@ export interface ConsoleContentResponse {
   path?: string;
   name?: string;
   isSaved?: boolean;
+  /** Hash of the latest explicit-save snapshot, not the mutable draft. */
+  savedStateHash?: string;
+  /** Latest draft writer; agent drafts without a saved hash must stay dirty. */
+  lastDraftOrigin?: "user" | "agent";
   chartSpec?: Record<string, unknown>;
   resultsViewMode?: "table" | "json" | "chart";
   access?: "private" | "workspace";
@@ -114,6 +118,8 @@ export interface ConsoleRevisionSyncEntry {
   version?: number;
   /** Server truth for draft-vs-saved (drives autosave eligibility). */
   isSaved?: boolean;
+  /** Hash of the latest explicit-save snapshot, not the mutable draft. */
+  savedStateHash?: string;
   /**
    * Who produced the latest draft write ("agent" | "user"). Lets the client
    * surface an agent edit as a reviewable diff on reconnect/reload even when

--- a/app/src/store/consoleStore.test.ts
+++ b/app/src/store/consoleStore.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The store module pulls in the network clients at import time. None of them
+// are exercised by the agent-review ACCEPT path under test (it returns before
+// any PUT), but they must resolve for the module to load.
+vi.mock("../lib/api-client", () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    put: vi.fn(),
+    putWithStatus: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("../api", () => ({
+  api: {
+    GET: vi.fn(),
+    POST: vi.fn(),
+    PUT: vi.fn(),
+    DELETE: vi.fn(),
+  },
+  unwrapBody: (x: unknown) => x,
+}));
+
+vi.mock("../lib/local-agent-client", () => ({
+  isLocalConnectionId: () => false,
+  localAgentClient: {},
+}));
+
+vi.mock("../lib/realtime-client-id", () => ({
+  realtimeClientId: "test-client",
+}));
+
+import {
+  useConsoleStore,
+  hasUnsavedLocalEdits,
+  hasPendingAgentReview,
+} from "./consoleStore";
+import { computeConsoleStateHash } from "../utils/stateHash";
+import type { ConsoleRevisionSyncEntry } from "../lib/api-types";
+
+const WS = "workspace-1";
+
+function openSavedConsole(id: string, content: string) {
+  useConsoleStore.getState().openTab({
+    id,
+    title: "report.sql",
+    content,
+    isSaved: true,
+    filePath: "report.sql",
+    connectionId: "conn-1",
+    databaseId: "db-1",
+    databaseName: "main",
+    draftRevision: 1,
+    version: 1,
+  });
+}
+
+function agentEntry(
+  id: string,
+  content: string,
+  draftRevision: number,
+): ConsoleRevisionSyncEntry {
+  return {
+    id,
+    content,
+    draftRevision,
+    connectionId: "conn-1",
+    databaseId: "db-1",
+    databaseName: "main",
+    isSaved: true,
+    lastDraftOrigin: "agent",
+  };
+}
+
+beforeEach(() => {
+  useConsoleStore.getState().clearAllConsoles();
+  vi.clearAllMocks();
+});
+
+describe("resolveAgentReview('accept') — explicit-save baseline", () => {
+  it("keeps the Save button enabled after accepting an agent edit on a saved console", async () => {
+    const id = "65b000000000000000000001";
+    const baseSql = "SELECT 1;";
+    const agentSql = "SELECT 2;";
+
+    openSavedConsole(id, baseSql);
+    const baselineHash = useConsoleStore.getState().tabs[id].savedStateHash;
+    expect(baselineHash).toBe(
+      computeConsoleStateHash(baseSql, "conn-1", "db-1", "main"),
+    );
+    // Clean tab at rest: nothing to save yet.
+    expect(hasUnsavedLocalEdits(id)).toBe(false);
+
+    // Agent (modify_console) edit arrives as a reviewable diff. The store
+    // content stays on the baseline until the user resolves the review.
+    useConsoleStore.getState().beginAgentReview(agentEntry(id, agentSql, 2));
+    expect(hasPendingAgentReview(id)).toBe(true);
+    expect(useConsoleStore.getState().tabs[id].content).toBe(baseSql);
+
+    // User accepts the agent's change.
+    await useConsoleStore.getState().resolveAgentReview(WS, id, "accept");
+
+    const tab = useConsoleStore.getState().tabs[id];
+    // The accepted content is adopted...
+    expect(tab.content).toBe(agentSql);
+    expect(tab.draftRevision).toBe(2);
+    // ...but the explicit-save baseline is NOT advanced to the agent draft.
+    // (Regression guard: this used to be set to hash(agentSql), which made
+    // hasUnsavedChanges false → Save disabled → no way to checkpoint into
+    // version history.)
+    expect(tab.savedStateHash).toBe(baselineHash);
+    expect(tab.savedStateHash).not.toBe(
+      computeConsoleStateHash(agentSql, "conn-1", "db-1", "main"),
+    );
+    // Net effect the Save button reads: there ARE unsaved changes to checkpoint.
+    expect(hasUnsavedLocalEdits(id)).toBe(true);
+  });
+
+  it("clears the pending review on accept", async () => {
+    const id = "65b000000000000000000002";
+    openSavedConsole(id, "SELECT 1;");
+    useConsoleStore.getState().beginAgentReview(agentEntry(id, "SELECT 2;", 2));
+    expect(hasPendingAgentReview(id)).toBe(true);
+
+    await useConsoleStore.getState().resolveAgentReview(WS, id, "accept");
+    expect(hasPendingAgentReview(id)).toBe(false);
+  });
+});

--- a/app/src/store/consoleStore.test.ts
+++ b/app/src/store/consoleStore.test.ts
@@ -1,132 +1,174 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
-// The store module pulls in the network clients at import time. None of them
-// are exercised by the agent-review ACCEPT path under test (it returns before
-// any PUT), but they must resolve for the module to load.
-vi.mock("../lib/api-client", () => ({
-  apiClient: {
-    get: vi.fn(),
-    post: vi.fn(),
-    patch: vi.fn(),
-    put: vi.fn(),
-    putWithStatus: vi.fn(),
-    delete: vi.fn(),
-  },
-}));
-
-vi.mock("../api", () => ({
-  api: {
-    GET: vi.fn(),
-    POST: vi.fn(),
-    PUT: vi.fn(),
-    DELETE: vi.fn(),
-  },
-  unwrapBody: (x: unknown) => x,
-}));
-
-vi.mock("../lib/local-agent-client", () => ({
-  isLocalConnectionId: () => false,
-  localAgentClient: {},
-}));
-
-vi.mock("../lib/realtime-client-id", () => ({
-  realtimeClientId: "test-client",
-}));
-
-import {
-  useConsoleStore,
-  hasUnsavedLocalEdits,
-  hasPendingAgentReview,
-} from "./consoleStore";
-import { computeConsoleStateHash } from "../utils/stateHash";
+import { beforeEach, describe, expect, it } from "vitest";
 import type { ConsoleRevisionSyncEntry } from "../lib/api-types";
+import { computeConsoleStateHash } from "../utils/stateHash";
+import {
+  hasPendingAgentReview,
+  hasUnsavedLocalEdits,
+  useConsoleStore,
+} from "./consoleStore";
 
-const WS = "workspace-1";
+function resetConsoleStore(): void {
+  useConsoleStore.setState({
+    tabs: {},
+    tabOrder: [],
+    activeTabId: null,
+    loading: {},
+    error: {},
+  });
+  localStorage.clear();
+}
 
-function openSavedConsole(id: string, content: string) {
+function openSavedConsole(params: {
+  id: string;
+  content: string;
+  savedStateHash?: string;
+  draftRevision?: number;
+  version?: number;
+}): void {
   useConsoleStore.getState().openTab({
-    id,
-    title: "report.sql",
-    content,
+    id: params.id,
+    title: "Saved console",
+    content: params.content,
     isSaved: true,
-    filePath: "report.sql",
-    connectionId: "conn-1",
-    databaseId: "db-1",
-    databaseName: "main",
-    draftRevision: 1,
-    version: 1,
+    filePath: "Saved console",
+    savedStateHash: params.savedStateHash,
+    draftRevision: params.draftRevision ?? 1,
+    version: params.version ?? 1,
+    kind: "console",
   });
 }
 
 function agentEntry(
   id: string,
   content: string,
-  draftRevision: number,
+  overrides: Partial<ConsoleRevisionSyncEntry> = {},
 ): ConsoleRevisionSyncEntry {
   return {
     id,
     content,
-    draftRevision,
-    connectionId: "conn-1",
-    databaseId: "db-1",
-    databaseName: "main",
+    draftRevision: 2,
     isSaved: true,
+    version: 1,
     lastDraftOrigin: "agent",
+    ...overrides,
   };
 }
 
-beforeEach(() => {
-  useConsoleStore.getState().clearAllConsoles();
-  vi.clearAllMocks();
-});
+describe("consoleStore saved baseline reconciliation", () => {
+  beforeEach(() => {
+    resetConsoleStore();
+  });
 
-describe("resolveAgentReview('accept') — explicit-save baseline", () => {
-  it("keeps the Save button enabled after accepting an agent edit on a saved console", async () => {
-    const id = "65b000000000000000000001";
-    const baseSql = "SELECT 1;";
-    const agentSql = "SELECT 2;";
+  it("keeps Save enabled after accepting an agent draft for a saved console", async () => {
+    const id = "agent-accept-console";
+    const baseContent = "select 1;";
+    const agentContent = "select 2;";
+    const savedStateHash = computeConsoleStateHash(baseContent);
+    openSavedConsole({ id, content: baseContent, savedStateHash });
 
-    openSavedConsole(id, baseSql);
-    const baselineHash = useConsoleStore.getState().tabs[id].savedStateHash;
-    expect(baselineHash).toBe(
-      computeConsoleStateHash(baseSql, "conn-1", "db-1", "main"),
-    );
-    // Clean tab at rest: nothing to save yet.
-    expect(hasUnsavedLocalEdits(id)).toBe(false);
-
-    // Agent (modify_console) edit arrives as a reviewable diff. The store
-    // content stays on the baseline until the user resolves the review.
-    useConsoleStore.getState().beginAgentReview(agentEntry(id, agentSql, 2));
-    expect(hasPendingAgentReview(id)).toBe(true);
-    expect(useConsoleStore.getState().tabs[id].content).toBe(baseSql);
-
-    // User accepts the agent's change.
-    await useConsoleStore.getState().resolveAgentReview(WS, id, "accept");
+    useConsoleStore
+      .getState()
+      .beginAgentReview(agentEntry(id, agentContent, { savedStateHash }));
+    await useConsoleStore
+      .getState()
+      .resolveAgentReview("workspace", id, "accept");
 
     const tab = useConsoleStore.getState().tabs[id];
-    // The accepted content is adopted...
-    expect(tab.content).toBe(agentSql);
+    // The accepted content is adopted as the working draft...
+    expect(tab.content).toBe(agentContent);
     expect(tab.draftRevision).toBe(2);
     // ...but the explicit-save baseline is NOT advanced to the agent draft.
-    // (Regression guard: this used to be set to hash(agentSql), which made
+    // (Regression guard: this used to be set to hash(agentContent), which made
     // hasUnsavedChanges false → Save disabled → no way to checkpoint into
     // version history.)
-    expect(tab.savedStateHash).toBe(baselineHash);
-    expect(tab.savedStateHash).not.toBe(
-      computeConsoleStateHash(agentSql, "conn-1", "db-1", "main"),
-    );
-    // Net effect the Save button reads: there ARE unsaved changes to checkpoint.
+    expect(tab.savedStateHash).toBe(savedStateHash);
+    expect(computeConsoleStateHash(tab.content)).not.toBe(savedStateHash);
     expect(hasUnsavedLocalEdits(id)).toBe(true);
   });
 
-  it("clears the pending review on accept", async () => {
-    const id = "65b000000000000000000002";
-    openSavedConsole(id, "SELECT 1;");
-    useConsoleStore.getState().beginAgentReview(agentEntry(id, "SELECT 2;", 2));
+  it("clears the pending agent review on accept", async () => {
+    const id = "agent-accept-clears-review";
+    const savedStateHash = computeConsoleStateHash("select 1;");
+    openSavedConsole({ id, content: "select 1;", savedStateHash });
+
+    useConsoleStore
+      .getState()
+      .beginAgentReview(agentEntry(id, "select 2;", { savedStateHash }));
     expect(hasPendingAgentReview(id)).toBe(true);
 
-    await useConsoleStore.getState().resolveAgentReview(WS, id, "accept");
+    await useConsoleStore
+      .getState()
+      .resolveAgentReview("workspace", id, "accept");
     expect(hasPendingAgentReview(id)).toBe(false);
+  });
+
+  it("does not advance the saved baseline on a same-content agent sync echo", () => {
+    const id = "agent-echo-console";
+    const savedContent = "select 1;";
+    const agentContent = "select 2;";
+    const savedStateHash = computeConsoleStateHash(savedContent);
+    openSavedConsole({ id, content: agentContent, savedStateHash });
+
+    useConsoleStore.getState().beginAgentReview(agentEntry(id, agentContent));
+
+    const tab = useConsoleStore.getState().tabs[id];
+    expect(tab.draftRevision).toBe(2);
+    expect(tab.savedStateHash).toBe(savedStateHash);
+    expect(hasUnsavedLocalEdits(id)).toBe(true);
+  });
+
+  it("keeps legacy agent drafts dirty when no saved baseline hash exists", () => {
+    const id = "agent-legacy-console";
+    const agentContent = "select 2;";
+    openSavedConsole({
+      id,
+      content: agentContent,
+    });
+    useConsoleStore.getState().updateSavedState(id, true, undefined);
+
+    useConsoleStore.getState().beginAgentReview(agentEntry(id, agentContent));
+
+    const tab = useConsoleStore.getState().tabs[id];
+    expect(tab.draftRevision).toBe(2);
+    expect(tab.savedStateHash).toBeUndefined();
+    expect(hasUnsavedLocalEdits(id)).toBe(true);
+  });
+
+  it("preserves a server-provided saved baseline when opening a saved console", () => {
+    // Reload / re-open: the server returns the LAST EXPLICIT-SAVE hash, not the
+    // mutable draft. An agent draft sitting on top of it must read dirty.
+    const id = "agent-reload-console";
+    const savedContent = "select 1;";
+    const agentDraftContent = "select 2;";
+    const savedStateHash = computeConsoleStateHash(savedContent);
+
+    openSavedConsole({ id, content: agentDraftContent, savedStateHash });
+
+    const tab = useConsoleStore.getState().tabs[id];
+    expect(tab.savedStateHash).toBe(savedStateHash);
+    expect(computeConsoleStateHash(tab.content)).not.toBe(savedStateHash);
+    expect(hasUnsavedLocalEdits(id)).toBe(true);
+  });
+
+  it("does not synthesize a saved baseline for server-loaded legacy agent drafts", () => {
+    const id = "agent-server-open-console";
+    useConsoleStore.getState().openTab(
+      {
+        id,
+        title: "Legacy agent draft",
+        content: "select 2;",
+        isSaved: true,
+        filePath: "Legacy agent draft",
+        draftRevision: 2,
+        version: 1,
+        kind: "console",
+      },
+      { preserveMissingSavedStateHash: true },
+    );
+
+    const tab = useConsoleStore.getState().tabs[id];
+    expect(tab.savedStateHash).toBeUndefined();
+    expect(hasUnsavedLocalEdits(id)).toBe(true);
   });
 });

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -751,8 +751,8 @@ export const useConsoleStore = create<ConsoleStore>()(
 
         if (action === "accept") {
           // The server already holds the proposed content at proposedRevision;
-          // adopt it locally so the tab mirrors the server and autosave stays
-          // quiet. The editor buffer is set to the proposal by Console.
+          // adopt it locally so the tab mirrors the server's DRAFT and autosave
+          // stays quiet. The editor buffer is set to the proposal by Console.
           const newStateHash = computeConsoleStateHash(
             review.proposedContent,
             tab.connectionId,
@@ -764,10 +764,22 @@ export const useConsoleStore = create<ConsoleStore>()(
             if (!t) return;
             t.content = review.proposedContent;
             t.draftRevision = review.proposedRevision;
-            if (t.isSaved) t.savedStateHash = newStateHash;
+            // Deliberately DO NOT advance `savedStateHash` here. An agent
+            // modify_console is a DRAFT write: it bumps `draftRevision` only,
+            // never the explicit-save `version` that creates a version-history
+            // checkpoint. Treating the accepted draft as the explicit-save
+            // baseline made `hasUnsavedChanges` false, so the Save button went
+            // disabled even though the agent had changed the SQL — and because
+            // the agent never created a version, the user was left with no way
+            // to checkpoint the change into save history. Leaving the baseline
+            // on the last EXPLICIT save keeps the tab dirty (Save enabled) so a
+            // deliberate Save snapshots the agent's edit into version history.
             t.remoteUpdate = null;
           });
           blockedDraftSaves.delete(consoleId);
+          // The autosave-dedup baseline tracks the PERSISTED draft (now the
+          // agent content on the server), independent of the explicit-save
+          // baseline above — keep it current so a no-op autosave can't 409.
           lastSavedContentHash.set(consoleId, newStateHash);
           return;
         }

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -56,6 +56,11 @@ interface ConsoleActions {
        * one it opens.
        */
       replacePristine?: boolean;
+      /**
+       * Server-loaded agent drafts may have no EntityVersion baseline. In that
+       * case an unknown savedStateHash is intentional: Save must stay enabled.
+       */
+      preserveMissingSavedStateHash?: boolean;
     },
   ) => string;
   closeTab: (id: string) => void;
@@ -81,7 +86,7 @@ interface ConsoleActions {
   updateSavedState: (
     id: string,
     isSaved: boolean,
-    savedStateHash: string,
+    savedStateHash: string | undefined,
   ) => void;
   updateChartSpec: (
     id: string,
@@ -435,6 +440,19 @@ const shouldAutoSave = (getState: () => ConsoleState, consoleId: string) => {
   return tab ? !tab.isSaved : true;
 };
 
+function savedStateHashForRemoteEntry(
+  entry: Pick<ConsoleRevisionSyncEntry, "lastDraftOrigin" | "savedStateHash">,
+  currentSavedStateHash: string | undefined,
+  entryStateHash: string,
+): string | undefined {
+  if (entry.savedStateHash !== undefined) return entry.savedStateHash;
+  if (entry.lastDraftOrigin === "agent" && currentSavedStateHash) {
+    return currentSavedStateHash;
+  }
+  if (entry.lastDraftOrigin === "agent") return undefined;
+  return entryStateHash;
+}
+
 function normalizeScheduledRunSnapshotForTab(
   scheduledRun: ConsoleContentResponse["scheduledRun"],
 ): ConsoleTab["scheduledRun"] {
@@ -477,14 +495,16 @@ export const useConsoleStore = create<ConsoleStore>()(
           versionManagers.set(id, new ConsoleVersionManager(id));
         }
 
-        const savedStateHash = tab.filePath
-          ? computeConsoleStateHash(
-              content,
-              tab.connectionId,
-              tab.databaseId,
-              tab.databaseName,
-            )
-          : tab.savedStateHash;
+        const savedStateHash =
+          tab.savedStateHash ??
+          (tab.filePath && !options?.preserveMissingSavedStateHash
+            ? computeConsoleStateHash(
+                content,
+                tab.connectionId,
+                tab.databaseId,
+                tab.databaseName,
+              )
+            : undefined);
 
         set(state => {
           if (pristineTabId && pristineTabId !== id) {
@@ -636,10 +656,16 @@ export const useConsoleStore = create<ConsoleStore>()(
           t.draftRevision = entry.draftRevision;
           if (typeof entry.version === "number") t.version = entry.version;
           if (typeof entry.isSaved === "boolean") t.isSaved = entry.isSaved;
-          // The applied copy IS the persisted state: refresh the explicit-
-          // save baseline so hasUnsavedLocalEdits doesn't misread the tab as
-          // locally edited from now on.
-          if (t.isSaved) t.savedStateHash = newStateHash;
+          // Refresh the explicit-save baseline from the server when available.
+          // Agent drafts are not history versions, so they must not become the
+          // baseline that disables Save.
+          if (t.isSaved) {
+            t.savedStateHash = savedStateHashForRemoteEntry(
+              entry,
+              tab.savedStateHash,
+              newStateHash,
+            );
+          }
           t.remoteUpdate = null;
           t.lastRun = entry.lastRun ?? t.lastRun;
         });
@@ -675,7 +701,13 @@ export const useConsoleStore = create<ConsoleStore>()(
           t.draftRevision = entry.draftRevision;
           if (typeof entry.version === "number") t.version = entry.version;
           if (typeof entry.isSaved === "boolean") t.isSaved = entry.isSaved;
-          if (t.isSaved) t.savedStateHash = newStateHash;
+          if (t.isSaved) {
+            t.savedStateHash = savedStateHashForRemoteEntry(
+              entry,
+              tab.savedStateHash,
+              newStateHash,
+            );
+          }
           // Server matches local content: any conflict affordance is moot.
           t.remoteUpdate = null;
           t.lastRun = entry.lastRun ?? t.lastRun;
@@ -751,8 +783,9 @@ export const useConsoleStore = create<ConsoleStore>()(
 
         if (action === "accept") {
           // The server already holds the proposed content at proposedRevision;
-          // adopt it locally so the tab mirrors the server's DRAFT and autosave
-          // stays quiet. The editor buffer is set to the proposal by Console.
+          // adopt it locally so the tab mirrors the server. Do not advance
+          // savedStateHash: only explicit saves create history versions, and
+          // the Save button must stay enabled until the user saves this draft.
           const newStateHash = computeConsoleStateHash(
             review.proposedContent,
             tab.connectionId,
@@ -764,22 +797,9 @@ export const useConsoleStore = create<ConsoleStore>()(
             if (!t) return;
             t.content = review.proposedContent;
             t.draftRevision = review.proposedRevision;
-            // Deliberately DO NOT advance `savedStateHash` here. An agent
-            // modify_console is a DRAFT write: it bumps `draftRevision` only,
-            // never the explicit-save `version` that creates a version-history
-            // checkpoint. Treating the accepted draft as the explicit-save
-            // baseline made `hasUnsavedChanges` false, so the Save button went
-            // disabled even though the agent had changed the SQL — and because
-            // the agent never created a version, the user was left with no way
-            // to checkpoint the change into save history. Leaving the baseline
-            // on the last EXPLICIT save keeps the tab dirty (Save enabled) so a
-            // deliberate Save snapshots the agent's edit into version history.
             t.remoteUpdate = null;
           });
           blockedDraftSaves.delete(consoleId);
-          // The autosave-dedup baseline tracks the PERSISTED draft (now the
-          // agent content on the server), independent of the explicit-save
-          // baseline above — keep it current so a no-op autosave can't 409.
           lastSavedContentHash.set(consoleId, newStateHash);
           return;
         }
@@ -1074,28 +1094,36 @@ export const useConsoleStore = create<ConsoleStore>()(
             const content = res.content || "";
             const filePath = res.path || res.name;
 
-            get().openTab({
-              id: res.id,
-              title: res.name || res.path || "Console",
-              content,
-              isSaved: res.isSaved ?? !!filePath,
-              connectionId: res.connectionId,
-              databaseId: res.databaseId,
-              databaseName: res.databaseName,
-              filePath,
-              kind: "console",
-              chartSpec: res.chartSpec,
-              resultsViewMode: res.resultsViewMode,
-              schedule: res.schedule,
-              scheduledRun: res.scheduledRun,
-              access: res.access,
-              workspaceRole: res.workspaceRole,
-              owner_id: res.owner_id,
-              readOnly: res.readOnly,
-              metadata: options?.openScheduledRuns
-                ? { openScheduledRuns: true }
-                : undefined,
-            });
+            get().openTab(
+              {
+                id: res.id,
+                title: res.name || res.path || "Console",
+                content,
+                isSaved: res.isSaved ?? !!filePath,
+                savedStateHash: res.savedStateHash,
+                connectionId: res.connectionId,
+                databaseId: res.databaseId,
+                databaseName: res.databaseName,
+                filePath,
+                kind: "console",
+                chartSpec: res.chartSpec,
+                resultsViewMode: res.resultsViewMode,
+                schedule: res.schedule,
+                scheduledRun: res.scheduledRun,
+                access: res.access,
+                workspaceRole: res.workspaceRole,
+                owner_id: res.owner_id,
+                readOnly: res.readOnly,
+                metadata: options?.openScheduledRuns
+                  ? { openScheduledRuns: true }
+                  : undefined,
+              },
+              {
+                preserveMissingSavedStateHash:
+                  res.lastDraftOrigin === "agent" &&
+                  res.savedStateHash === undefined,
+              },
+            );
             get().setActiveTab(res.id);
           } else {
             set(state => {
@@ -1127,19 +1155,27 @@ export const useConsoleStore = create<ConsoleStore>()(
             const content = res.content || "";
             const filePath = res.path || res.name;
 
-            get().openTab({
-              id: res.id,
-              title: res.name || res.path || "Console",
-              content,
-              isSaved: res.isSaved ?? !!filePath,
-              connectionId: res.connectionId,
-              databaseId: res.databaseId,
-              databaseName: res.databaseName,
-              filePath,
-              kind: "console",
-              chartSpec: res.chartSpec,
-              resultsViewMode: res.resultsViewMode,
-            });
+            get().openTab(
+              {
+                id: res.id,
+                title: res.name || res.path || "Console",
+                content,
+                isSaved: res.isSaved ?? !!filePath,
+                savedStateHash: res.savedStateHash,
+                connectionId: res.connectionId,
+                databaseId: res.databaseId,
+                databaseName: res.databaseName,
+                filePath,
+                kind: "console",
+                chartSpec: res.chartSpec,
+                resultsViewMode: res.resultsViewMode,
+              },
+              {
+                preserveMissingSavedStateHash:
+                  res.lastDraftOrigin === "agent" &&
+                  res.savedStateHash === undefined,
+              },
+            );
             get().setActiveTab(res.id);
           }
         } catch {
@@ -1189,12 +1225,16 @@ export const useConsoleStore = create<ConsoleStore>()(
               }
             });
 
-            const savedStateHash = computeConsoleStateHash(
-              res.content || "",
-              res.connectionId,
-              res.databaseId,
-              res.databaseName,
-            );
+            const savedStateHash =
+              res.savedStateHash ??
+              (isSaved && res.lastDraftOrigin === "agent"
+                ? undefined
+                : computeConsoleStateHash(
+                    res.content || "",
+                    res.connectionId,
+                    res.databaseId,
+                    res.databaseName,
+                  ));
             get().updateSavedState(consoleId, isSaved, savedStateHash);
           }
 
@@ -1236,6 +1276,7 @@ export const useConsoleStore = create<ConsoleStore>()(
               databaseId: res.databaseId,
               databaseName: res.databaseName,
               isSaved,
+              savedStateHash: res.savedStateHash,
               filePath: isSaved ? res.path || res.name : undefined,
               access: res.access,
               workspaceRole: res.workspaceRole,
@@ -1246,7 +1287,12 @@ export const useConsoleStore = create<ConsoleStore>()(
               lastRun: res.lastRun,
               kind: "console",
             },
-            { replacePristine: false },
+            {
+              replacePristine: false,
+              preserveMissingSavedStateHash:
+                res.lastDraftOrigin === "agent" &&
+                res.savedStateHash === undefined,
+            },
           );
           get().setActiveTab(consoleId);
         } catch (e) {
@@ -1816,18 +1862,6 @@ export const useConsoleStore = create<ConsoleStore>()(
                 }
                 if (tab.isSaved === undefined) {
                   tab.isSaved = !!tab.filePath;
-                }
-                if (tab.savedStateHash === undefined && tab.filePath) {
-                  const savedContent = tab.initialContent ?? tab.content ?? "";
-                  const savedConnId = tab.savedConnectionId ?? tab.connectionId;
-                  const savedDbId = tab.savedDatabaseId ?? tab.databaseId;
-                  const savedDbName = tab.savedDatabaseName ?? tab.databaseName;
-                  tab.savedStateHash = computeConsoleStateHash(
-                    savedContent,
-                    savedConnId,
-                    savedDbId,
-                    savedDbName,
-                  );
                 }
                 delete tab.initialContent;
                 delete tab.dbContentHash;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Walkthrough

Agent edits a saved console → Accept → Save stays enabled **even after a full page reload (F5)** → saving creates a new version-history entry.

[console_agent_edit_save_survives_reload_demo.mp4](https://cursor.com/agents/bc-e5ac9a82-a76c-4c04-9774-a1f1cd34052c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconsole_agent_edit_save_survives_reload_demo.mp4)

[After reloading, the Save button is still enabled and the editor still shows the agent](https://cursor.com/agents/bc-e5ac9a82-a76c-4c04-9774-a1f1cd34052c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freload_save_enabled_after_reload.webp)
[Saving after reload creates a new version in history](https://cursor.com/agents/bc-e5ac9a82-a76c-4c04-9774-a1f1cd34052c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freload_version_history.webp)

Earlier in-session demo (accept → Save enabled → version created):
[console_agent_edit_save_enabled_demo.mp4](https://cursor.com/agents/bc-e5ac9a82-a76c-4c04-9774-a1f1cd34052c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconsole_agent_edit_save_enabled_demo.mp4)
[Agent modify_console diff with Accept/Reject](https://cursor.com/agents/bc-e5ac9a82-a76c-4c04-9774-a1f1cd34052c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_diff_accept_reject.webp)

## Problem

When the AI agent modifies a **saved** console (via `modify_console`), the Save button became disabled (the dirty-state hash comparison reported "no changes"), yet **no new version appeared in save history** — leaving the user with no way to checkpoint the agent's change.

## Root cause

The two console counters are intentionally split (`api/src/services/console-save-guards.ts`):

- `version` — bumped by **explicit saves only**; creates a version-history (`EntityVersion`) checkpoint.
- `draftRevision` — bumped by every draft write, including agent `modify_console`.

So an agent edit only bumps `draftRevision` and never creates a version snapshot (by design). The bug was on the client: the Save button compares the current content against `savedStateHash` (the "last explicit save" baseline), but several paths overwrote that baseline with the **mutable draft** content:

1. `resolveAgentReview("accept")` set `savedStateHash` to the accepted agent draft for saved consoles.
2. `fetchConsoleContent` / `openTab` / the explorer / persist-rehydrate all hashed the draft `code` as the baseline.
3. `applyRemoteConsoleEntry` / `fastForwardRemoteConsoleEntry` advanced the baseline on agent draft writes.

Any of these made `hasUnsavedChanges` return `false` → Save disabled, with the change living only as a draft and no path to checkpoint it.

## Fix

Make the explicit-save baseline authoritative on the **server** (the latest `EntityVersion` snapshot) instead of inferring it from the mutable draft, and stop the client from ever adopting a draft as the baseline:

- **API** — `GET /content` and `revisions-sync` now return `savedStateHash` (hash of the latest `EntityVersion` snapshot — the real checkpoint) plus `lastDraftOrigin`. The server hash mirrors `app/src/utils/hash.ts` + `stateHash.ts` byte-for-byte (with a sync-warning comment, since the packages can't share an import path).
- **Client** — trust the server `savedStateHash` everywhere (`openTab`, `fetchConsoleContent`, `openConsoleFromServer`, explorer opens, remote-apply) instead of hashing the draft. `resolveAgentReview("accept")` no longer advances the baseline; `savedStateHashForRemoteEntry` keeps agent draft writes from clobbering it; `preserveMissingSavedStateHash` + `updateSavedState(undefined)` keep legacy agent drafts (no version snapshot yet) dirty so Save stays enabled. Removed the persist-rehydrate recompute that re-derived the baseline from draft content.
- **Chat / ConsoleExplorer** — route console opens through `openConsoleFromServer` / the server-provided hash so the baseline is consistent on every entry path.

Net effect: an accepted (or pending) agent draft now reads dirty across accept, page refresh, tab re-open, and remote sync — so the user can always Save to checkpoint the agent's edit into version history.

## Testing

- `app/src/store/consoleStore.test.ts` (6 tests): accept keeps Save enabled, accept clears the pending review, same-content agent echo doesn't advance the baseline, legacy agent drafts with no baseline stay dirty, a server-provided baseline survives re-open, and server-loaded legacy drafts aren't given a synthetic baseline.
- ✅ `pnpm --filter app exec vitest run src/store/consoleStore.test.ts` (6 passed)
- ✅ `pnpm --filter app run typecheck`
- ✅ `pnpm --filter app run lint`
- ✅ `pnpm --filter api run build` (includes API typecheck + lint)
- ✅ Manual E2E: agent `modify_console` on a saved console → Accept → Save enabled → **reload (F5)** → Save still enabled, content preserved → Save → new version in history (see walkthrough).

The robust server-baseline approach was adapted from the parallel branch `cursor/fix-console-agent-save-history-1aab` and combined with this branch's surgical accept fix and tests.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5ac9a82-a76c-4c04-9774-a1f1cd34052c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5ac9a82-a76c-4c04-9774-a1f1cd34052c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

