### PR TITLE
feat(webhooks): tiered retention TTLs for processed webhook events

### DIFF
--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -2424,9 +2424,46 @@ WebhookEventSchema.index({ flowId: 1, applyStatus: 1, receivedAt: 1 });
 // index this query does a COLLSCAN + in-memory sort over the whole collection.
 WebhookEventSchema.index({ status: 1, receivedAt: 1 });
 WebhookEventSchema.index({ workspaceId: 1, receivedAt: -1 });
+// Tiered retention by applyStatus (anchored on receivedAt, which is required on
+// every doc so the four partial TTLs fully cover the collection). MongoDB allows
+// multiple TTL indexes on the same key when they differ by partialFilterExpression
+// (same pattern as cdc_change_events applied-vs-dropped). Successfully processed
+// events are purged quickly; errors are retained longer for debugging.
+/** Successfully processed -> short retention. */
 WebhookEventSchema.index(
   { receivedAt: 1 },
-  { expireAfterSeconds: 7 * 24 * 60 * 60 },
+  {
+    name: "webhookevents_applied_ttl_3d",
+    expireAfterSeconds: 3 * 24 * 60 * 60,
+    partialFilterExpression: { applyStatus: "applied" },
+  },
+);
+/** Awaiting destination apply -> safety net (matches prior flat behavior). */
+WebhookEventSchema.index(
+  { receivedAt: 1 },
+  {
+    name: "webhookevents_pending_ttl_7d",
+    expireAfterSeconds: 7 * 24 * 60 * 60,
+    partialFilterExpression: { applyStatus: "pending" },
+  },
+);
+/** Intentionally skipped -> keep longer for audit. */
+WebhookEventSchema.index(
+  { receivedAt: 1 },
+  {
+    name: "webhookevents_dropped_ttl_7d",
+    expireAfterSeconds: 7 * 24 * 60 * 60,
+    partialFilterExpression: { applyStatus: "dropped" },
+  },
+);
+/** Errors -> retained longest for debugging. */
+WebhookEventSchema.index(
+  { receivedAt: 1 },
+  {
+    name: "webhookevents_failed_ttl_30d",
+    expireAfterSeconds: 30 * 24 * 60 * 60,
+    partialFilterExpression: { applyStatus: "failed" },
+  },
 );
 
 /**

--- a/api/src/migrations/2026-06-29-063053_webhookevents_tiered_apply_ttl.ts
+++ b/api/src/migrations/2026-06-29-063053_webhookevents_tiered_apply_ttl.ts
@@ -1,0 +1,128 @@
+import { Db } from "mongodb";
+import { loggers } from "../logging";
+
+const log = loggers.migration();
+
+const COLLECTION = "webhookevents";
+
+const APPLIED_TTL_INDEX_NAME = "webhookevents_applied_ttl_3d";
+const PENDING_TTL_INDEX_NAME = "webhookevents_pending_ttl_7d";
+const DROPPED_TTL_INDEX_NAME = "webhookevents_dropped_ttl_7d";
+const FAILED_TTL_INDEX_NAME = "webhookevents_failed_ttl_30d";
+
+const THREE_DAYS = 3 * 24 * 60 * 60;
+const SEVEN_DAYS = 7 * 24 * 60 * 60;
+const THIRTY_DAYS = 30 * 24 * 60 * 60;
+
+type IndexInfo = {
+  name: string;
+  key?: Record<string, unknown>;
+  expireAfterSeconds?: number;
+  partialFilterExpression?: Record<string, unknown>;
+};
+
+type Tier = {
+  name: string;
+  expireAfterSeconds: number;
+  applyStatus: "applied" | "pending" | "dropped" | "failed";
+};
+
+const TIERS: Tier[] = [
+  { name: APPLIED_TTL_INDEX_NAME, expireAfterSeconds: THREE_DAYS, applyStatus: "applied" },
+  { name: PENDING_TTL_INDEX_NAME, expireAfterSeconds: SEVEN_DAYS, applyStatus: "pending" },
+  { name: DROPPED_TTL_INDEX_NAME, expireAfterSeconds: SEVEN_DAYS, applyStatus: "dropped" },
+  { name: FAILED_TTL_INDEX_NAME, expireAfterSeconds: THIRTY_DAYS, applyStatus: "failed" },
+];
+
+function isReceivedAtAscendingOnly(index: IndexInfo): boolean {
+  if (!index.key || typeof index.key !== "object") return false;
+  const keys = Object.entries(index.key);
+  return keys.length === 1 && keys[0][0] === "receivedAt" && keys[0][1] === 1;
+}
+
+function partialAppliesToStatus(
+  partial: Record<string, unknown> | undefined,
+  applyStatus: string,
+): boolean {
+  if (!partial || typeof partial !== "object") return false;
+  return partial.applyStatus === applyStatus;
+}
+
+function hasTierTtl(indexes: IndexInfo[], tier: Tier): boolean {
+  return indexes.some(
+    idx =>
+      isReceivedAtAscendingOnly(idx) &&
+      (idx.expireAfterSeconds || 0) === tier.expireAfterSeconds &&
+      partialAppliesToStatus(idx.partialFilterExpression, tier.applyStatus),
+  );
+}
+
+export const description =
+  "Replace flat webhookevents.receivedAt TTL with applyStatus-tiered partial TTL indexes (applied 3d, pending 7d, dropped 7d, failed 30d)";
+
+export async function up(db: Db): Promise<void> {
+  const names = new Set(
+    (await db.listCollections().toArray()).map(c => c.name),
+  );
+  if (!names.has(COLLECTION)) {
+    log.info("webhookevents collection not found, skipping", {
+      collection: COLLECTION,
+    });
+    return;
+  }
+
+  const col = db.collection(COLLECTION);
+  const indexes = (await col.indexes()) as IndexInfo[];
+
+  // Drop any legacy flat TTL on { receivedAt: 1 } (no applyStatus partial filter).
+  // Covers both Mongoose's auto name (receivedAt_1) and the migration-created
+  // webhookevents_receivedAt_ttl_7d.
+  for (const index of indexes) {
+    if (!isReceivedAtAscendingOnly(index)) continue;
+    if (typeof index.expireAfterSeconds !== "number") continue;
+    const partial = index.partialFilterExpression;
+    const isFlatTtl =
+      !partial || typeof partial !== "object" || partial.applyStatus == null;
+    if (!isFlatTtl) continue;
+
+    try {
+      await col.dropIndex(index.name);
+      log.info("Dropped legacy flat webhookevents receivedAt TTL index", {
+        collection: COLLECTION,
+        index: index.name,
+      });
+    } catch (error) {
+      log.warn("Failed to drop legacy flat webhookevents TTL index", {
+        collection: COLLECTION,
+        index: index.name,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  for (const tier of TIERS) {
+    const refreshed = (await col.indexes()) as IndexInfo[];
+    if (hasTierTtl(refreshed, tier)) {
+      log.info("webhookevents tiered TTL index already present, skipping", {
+        collection: COLLECTION,
+        name: tier.name,
+      });
+      continue;
+    }
+
+    await col.createIndex(
+      { receivedAt: 1 },
+      {
+        name: tier.name,
+        expireAfterSeconds: tier.expireAfterSeconds,
+        partialFilterExpression: { applyStatus: tier.applyStatus },
+      },
+    );
+    log.info("Created webhookevents tiered TTL index", {
+      collection: COLLECTION,
+      name: tier.name,
+      expireAfterSeconds: tier.expireAfterSeconds,
+      applyStatus: tier.applyStatus,
+    });
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Processed webhook events in the `webhookevents` collection (the Events table in the Flows UI) keep accumulating. Retention today is a single flat TTL: every event is deleted 7 days after `receivedAt` regardless of outcome, so successfully-applied events and errors are treated identically. There is no shorter purge for successes nor longer retention for errors.

The tiered "best practice" pattern already exists for the internal `cdc_change_events` log (36h applied / 7d dropped) but was never applied to the user-facing `webhookevents` table.

## Change

Replace the flat TTL with four `applyStatus`-partitioned partial TTL indexes on `webhookevents`, anchored on `receivedAt`. MongoDB allows multiple TTL indexes on the same key when they differ by `partialFilterExpression` (same approach `cdc_change_events` already uses). `applyStatus` is `required` on every doc, so the four tiers fully cover the collection.

| applyStatus | Retention | Rationale |
|---|---|---|
| `applied` | 3 days | Successfully processed — purge quickly |
| `pending` | 7 days | Safety net (matches prior flat behavior) |
| `dropped` | 7 days | Intentionally skipped — keep for audit |
| `failed` | 30 days | Errors — retained longest for debugging |

Files:
- `api/src/database/workspace-schema.ts` — replaces the flat `{ receivedAt: 1 }` TTL with four named partial TTL indexes.
- `api/src/migrations/2026-06-29-063053_webhookevents_tiered_apply_ttl.ts` — idempotent, up-only migration that drops any legacy flat `receivedAt` TTL (handles both the Mongoose auto name `receivedAt_1` and the migration-created `webhookevents_receivedAt_ttl_7d`) and creates the four tiered indexes.

## Testing

- `pnpm --filter api run lint` — pass
- `pnpm --filter api run build` (lint + typecheck) — pass
- `pnpm migrate` against local Mongo replica set — applies cleanly
- Direct migration test: seeded the collection with the legacy flat TTL + one doc per `applyStatus`, ran `up()` twice. Verified the flat TTL is dropped, exactly the four partial TTLs exist with correct `expireAfterSeconds` (259200 / 604800 / 604800 / 2592000) and partial filters, and the second run is a no-op (idempotent). Result: PASS.

## Notes / risks

- Index-definition change only; no data is migrated. Existing events are re-evaluated against the new TTLs on the next TTL-monitor pass, so some applied events older than 3 days will be purged shortly after deploy (expected).
- `receivedAt` (not `appliedAt`) anchors all tiers to guarantee field presence and complete coverage; the difference is negligible since events apply within minutes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a832a813-7e03-4b12-a1f7-c02a1b86f29b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a832a813-7e03-4b12-a1f7-c02a1b86f29b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

