### PR TITLE
guides: PHP connection guides — bigquery + snowflake

### DIFF
--- a/content/guides/bigquery/connect-from-php.mdx
+++ b/content/guides/bigquery/connect-from-php.mdx
@@ -1,0 +1,122 @@
+---
+title: "How to Connect to BigQuery from PHP"
+description: "Connect to Google BigQuery from PHP with the google/cloud-bigquery client: composer install, ADC authentication, running queries with parameters, the location trap, dry-run cost controls, and the errors you actually hit."
+database: "bigquery"
+category: "how-to"
+tags: ["bigquery", "php", "google-cloud", "data-warehouse", "connection"]
+date: "2026-06-29"
+---
+
+BigQuery is a query API, not a database you open a socket to. There is no host, no port, and no PDO driver. PHP talks to it through the `google/cloud-bigquery` client, which authenticates with Application Default Credentials and submits jobs over HTTPS. If you have connected PHP to PostgreSQL or MySQL, almost none of that knowledge carries over. This guide covers install, auth, queries with parameters, the cost controls that keep a runaway query from costing real money, the location mistake that looks like a permissions error, and the failures you will actually see.
+
+## Install
+
+```bash
+composer require google/cloud-bigquery
+```
+
+`google/cloud-bigquery` 1.38 is current as of June 2026 and runs on PHP 8.1+. It pulls in the gRPC or REST transport plus the gax (Google API extensions) layer. For heavy result sets, install the `grpc` and `protobuf` PECL extensions; the pure-REST path works without them but is slower on large reads.
+
+## Authentication
+
+There is no username and password. BigQuery uses **Application Default Credentials (ADC)**, resolved in a ladder:
+
+1. The `GOOGLE_APPLICATION_CREDENTIALS` env var pointing at a service-account JSON key file.
+2. Credentials from `gcloud auth application-default login` (local dev).
+3. The attached service account when running on GCP (Cloud Run, GCE, App Engine).
+
+Local development:
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/service-account.json"
+```
+
+```php
+<?php
+require 'vendor/autoload.php';
+
+use Google\Cloud\BigQuery\BigQueryClient;
+
+$bigQuery = new BigQueryClient([
+    'projectId' => 'my-billing-project',
+]);
+```
+
+The `projectId` here is the **billing** project, the one charged for the query. The data you read can live in another project entirely; you reference it as `project.dataset.table` in SQL. Conflating the two is a common source of "where did this bill come from" confusion.
+
+## Run a query
+
+```php
+$query = 'SELECT name, total FROM `bigquery-public-data.usa_names.usa_1910_2013` LIMIT 10';
+
+$queryJobConfig = $bigQuery->query($query);
+$results = $bigQuery->runQuery($queryJobConfig);
+
+foreach ($results as $row) {
+    printf("%s: %d\n", $row['name'], $row['total']);
+}
+```
+
+`runQuery` blocks until the job finishes and pages results automatically as you iterate. For long jobs, `startQuery` returns immediately and you poll `$job->reload()` / `$job->isComplete()` yourself.
+
+## Parameters
+
+Never build SQL with string concatenation. Use named parameters:
+
+```php
+$query = 'SELECT name, total FROM `bigquery-public-data.usa_names.usa_1910_2013`
+          WHERE state = @state AND gender = @gender
+          LIMIT 100';
+
+$jobConfig = $bigQuery->query($query)
+    ->parameters([
+        'state'  => 'CA',
+        'gender' => 'F',
+    ]);
+
+$results = $bigQuery->runQuery($jobConfig);
+```
+
+For NULLs or types the client cannot infer, pass `types()` alongside `parameters()` so BigQuery binds the right column type instead of guessing.
+
+## The location trap
+
+A BigQuery dataset lives in a region (US, EU, asia-northeast1, ...). A query has to run in the same location as the data it touches. If you query an EU dataset without telling the client, you get **"Not found: Dataset ... was not found in location US"**, which reads like a permissions or typo problem but is purely geographic:
+
+```php
+$jobConfig = $bigQuery->query($query)->location('EU');
+```
+
+Set the location whenever your data is outside the multi-region US default. This is the single most common BigQuery-from-PHP mistake.
+
+## Cost controls
+
+BigQuery bills by bytes scanned, so a careless `SELECT *` on a large table is a real invoice. Two guards:
+
+```php
+// Dry run: returns the byte estimate, scans nothing, costs nothing.
+$jobConfig = $bigQuery->query($query)->dryRun(true);
+$job = $bigQuery->startQuery($jobConfig);
+$bytes = $job->info()['statistics']['totalBytesProcessed'];
+
+// Hard cap: kill the query if it would exceed the limit.
+$jobConfig = $bigQuery->query($query)->maximumBytesBilled(1_000_000_000);
+```
+
+Dry-run before any query against unfamiliar tables, and set `maximumBytesBilled` in production so one bad query cannot run away.
+
+## Errors you will actually hit
+
+| Symptom | Cause |
+| --- | --- |
+| `Could not load the default credentials` | No `GOOGLE_APPLICATION_CREDENTIALS`, no `gcloud` login, not on GCP. ADC found nothing. |
+| `Not found: Dataset ... in location US` | Data is in EU/asia; set `->location()`. |
+| `Access Denied: ... bigquery.jobs.create` | Service account lacks `roles/bigquery.jobUser` on the billing project. |
+| `Access Denied: ... on table` | Lacks `roles/bigquery.dataViewer` on the dataset. Job and data roles are separate. |
+| `Quota exceeded: bytes billed` | `maximumBytesBilled` cap hit. The guard worked. |
+
+Two roles, two projects: `jobUser` on billing, `dataViewer` on data. Granting one and not the other is the usual permission snag.
+
+## Where Mako fits
+
+Mako connects to BigQuery and gives you AI-assisted autocomplete for exploring tables and writing SQL, with the byte-scan estimate shown before you run, so you can validate a query interactively before wiring it into PHP. It is read and query only: no dataset administration. Try it free at mako.ai.

--- a/content/guides/snowflake/connect-from-php.mdx
+++ b/content/guides/snowflake/connect-from-php.mdx
@@ -1,0 +1,103 @@
+---
+title: "How to Connect to Snowflake from PHP"
+description: "Connect to Snowflake from PHP with the official pdo_snowflake driver: building the C extension, the account-identifier DSN trap, key-pair auth after the 2025 password block, parameter binding, warehouse setup, uppercase identifiers, and the errors you actually hit."
+database: "snowflake"
+category: "how-to"
+tags: ["snowflake", "php", "pdo", "data-warehouse", "connection"]
+date: "2026-06-29"
+---
+
+Snowflake ships an official PHP PDO driver, `pdo_snowflake`, so the API feels familiar: `new PDO(...)`, prepared statements, `fetch()`. What is not familiar is the install. It is a C extension built from source, not a `composer require`, and the account identifier and authentication rules trip up nearly everyone on the first attempt. This guide covers building the driver, the DSN format, key-pair auth (which became mandatory for most accounts in late 2025), parameters, warehouses, identifier casing, and the failures you will hit.
+
+## Install: build from source
+
+`pdo_snowflake` is a PHP extension distributed as source. There is no Packagist package and no pure-PHP fallback. You clone, build, and load it. As of June 2026 the current release is 4.0.0, which supports PHP 8.5:
+
+```bash
+git clone https://github.com/snowflakedb/pdo_snowflake.git
+cd pdo_snowflake
+export PHP_HOME=/usr/bin
+/bin/bash ./scripts/build_pdo_snowflake.sh $PHP_HOME/php-config
+$PHP_HOME/php -dextension=modules/pdo_snowflake.so -m | grep pdo_snowflake
+```
+
+Then add `extension=pdo_snowflake.so` to `php.ini`. This is the biggest difference from PostgreSQL or MySQL, where the PDO driver ships with PHP. Budget time for build dependencies (gcc, cmake, libcurl) on the host.
+
+## Connect
+
+```php
+<?php
+$dsn = "snowflake:account=myorg-myaccount";
+$dbh = new PDO($dsn, "MY_USER", "MY_PASSWORD");
+$dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+```
+
+## The account-identifier trap
+
+The single most common failure is the account identifier. The modern format is `organization-account` (for example `myorg-myaccount`), not the legacy region locator like `xy12345.eu-central-1`. Mixing the two, or pasting the full `.snowflakecomputing.com` host into the `account=` field, produces connection failures that look like network errors. You can sidestep the parsing by giving the host directly:
+
+```php
+$dsn = "snowflake:host=myorg-myaccount.snowflakecomputing.com";
+```
+
+Find the exact identifier under Admin → Accounts in Snowsight. Get this right before debugging anything else.
+
+## Key-pair auth (the password block)
+
+In late 2025 Snowflake began blocking single-factor password sign-in for most accounts. Username and password alone will likely be rejected. The supported path for programmatic PHP is **key-pair auth**: generate an encrypted PKCS#8 key, register the public key on the user, then authenticate with JWT:
+
+```bash
+openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out rsa_key.p8
+openssl rsa -in rsa_key.p8 -pubout -out rsa_key.pub
+```
+
+```sql
+ALTER USER MY_USER SET RSA_PUBLIC_KEY='MIIB...';
+```
+
+```php
+$dsn = "snowflake:account=myorg-myaccount;authenticator=SNOWFLAKE_JWT;"
+     . "priv_key_file=/path/rsa_key.p8;priv_key_file_pwd=passphrase";
+$dbh = new PDO($dsn, "MY_USER", "");
+```
+
+The password argument is empty; the key does the work. For interactive users, `authenticator=externalbrowser` triggers SSO instead.
+
+## Query and parameters
+
+```php
+$stmt = $dbh->prepare("SELECT name, total FROM customers WHERE region = ? AND active = ?");
+$stmt->execute(['EMEA', true]);
+foreach ($stmt as $row) {
+    printf("%s: %d\n", $row['NAME'], $row['TOTAL']);
+}
+```
+
+Positional `?` binds are the safe path. Note `$row['NAME']`, not `$row['name']`: Snowflake folds unquoted identifiers to **uppercase**, so result columns come back uppercase unless you double-quoted them at creation. Reading lowercase keys returns nulls and confuses people for hours.
+
+## You need a warehouse
+
+A query needs a running virtual warehouse to compute. Without one set, you get **"No active warehouse selected in the current session"**. Set it on connect:
+
+```php
+$dbh->exec("USE WAREHOUSE MY_WH");
+$dbh->exec("USE DATABASE MY_DB");
+$dbh->exec("USE SCHEMA PUBLIC");
+```
+
+Set role too if your default role cannot see the objects, or you get object-not-found errors that are really permission errors.
+
+## Errors you will actually hit
+
+| Symptom | Cause |
+| --- | --- |
+| Connection fails, looks like network | Wrong account identifier; use `org-account`, not the region locator. |
+| `Incorrect username or password` despite correct creds | Single-factor password blocked; switch to key-pair auth. |
+| `JWT token is invalid` | Public key not registered, or clock skew on the host. |
+| `No active warehouse selected` | Run `USE WAREHOUSE` after connecting. |
+| Object does not exist | Wrong role, database, or schema in session. |
+| Null values reading `$row['name']` | Snowflake uppercases identifiers; read `$row['NAME']`. |
+
+## Where Mako fits
+
+Mako connects to Snowflake and gives you AI-assisted autocomplete for writing and exploring queries before you wire them into PHP, including warehouse and role selection so "no active warehouse" never surprises you. It is read and query only: no warehouse administration. Try it free at mako.ai.


### PR DESCRIPTION
Batch 13 PHP series (7/9). Two connection guides:
- bigquery/connect-from-php — google/cloud-bigquery 1.38, ADC auth, location trap, dry-run cost caps
- snowflake/connect-from-php — pdo_snowflake 4.0.0 (build-from-source), account-id trap, key-pair auth post-2025 block, uppercase identifiers

Versions verified live (Packagist/GitHub) Jun 29. Em-dash + banned-word clean. Remaining PHP: mariadb, mssql.