### PR TITLE
fix(dbt agent): label dbt tool cards, surface run status, harden against leaked tool-call text

### DIFF
--- a/api/src/agent-skills/dbt/SKILL.md
+++ b/api/src/agent-skills/dbt/SKILL.md
@@ -129,6 +129,13 @@ AND its tests — always add at least `unique` + `not_null` on the primary key.
    (`select * from <dev_schema>.<model> limit 100`) — only after the run
    reaches `success`.
 
+> ALWAYS invoke these as real tool calls. NEVER write a tool name or its
+> arguments (`projectId`, `runId`, `waitMs`, etc.) as message text — e.g. do
+> not type `dbt_get_run <projectId> <runId> 60000` into your reply. If you want
+> to check a run, emit a `dbt_get_run` tool call; the user already sees live
+> progress in the run card. After a run finishes, reply with a short
+> human-readable summary, not raw IDs.
+
 ## Environments and jobs
 
 - Projects have environments (dev/prod) mapping to a workspace connection +

--- a/api/src/services/dashboard-artifact-store.service.ts
+++ b/api/src/services/dashboard-artifact-store.service.ts
@@ -275,7 +275,6 @@ class S3DashboardArtifactStore implements DashboardArtifactStore {
   private readonly secretAccessKey = process.env.S3_SECRET_ACCESS_KEY || "";
   private readonly sessionToken = process.env.S3_SESSION_TOKEN || "";
   private readonly forcePathStyle = process.env.S3_FORCE_PATH_STYLE === "true";
-  private readonly publicBaseUrl = process.env.S3_PUBLIC_BASE_URL || "";
 
   private requireBucket(): string {
     if (!this.bucket) {

--- a/app/src/agent-runtime/client-tool-manifest.test.ts
+++ b/app/src/agent-runtime/client-tool-manifest.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@mako/agent-tools";
 import { UNIVERSAL_PROMPT_V2 } from "../../../api/src/agent-lib/prompts/universal";
 import { buildCurrentScreenContext } from "../../../api/src/agents/unified/prompt";
+import { createDbtServerTools } from "../../../api/src/agent-lib/tools/dbt-tools";
 import {
   AGENT_TOOL_MANIFEST,
   type AgentToolName,
@@ -79,6 +80,44 @@ describe("client tool manifest contracts", () => {
     expect(context).toContain("### Open Dashboards");
     expect(context).toContain("Revenue Dashboard");
     expect(context).toContain("dash_1");
+  });
+
+  // Server-side dbt tools have no compile-time drift guard (unlike client
+  // tools), so a new dbt tool can ship without a manifest entry and render the
+  // ugly humanizeToolName fallback ("Dbt Get Run"). This is exactly what leaked
+  // into an agent transcript. Assert every dbt server tool has an entry.
+  it("covers every dbt server tool with a manifest entry", () => {
+    const dbtServerToolNames = Object.keys(
+      createDbtServerTools("000000000000000000000000"),
+    ).sort();
+
+    const missing = dbtServerToolNames.filter(
+      name => getAgentToolManifestEntry(name) === undefined,
+    );
+    expect(missing).toEqual([]);
+
+    for (const name of dbtServerToolNames) {
+      expect(getAgentToolManifestEntry(name)?.domain).toBe("dbt");
+    }
+  });
+
+  it("gives dbt status/preview tools human labels (no humanize fallback)", () => {
+    expect(getAgentToolManifestEntry("dbt_get_run")?.getLabel()).toBe(
+      "Checking dbt run status",
+    );
+    expect(
+      getAgentToolManifestEntry("dbt_show")?.getLabel({ model: "stg_orders" }),
+    ).toBe("Previewing stg_orders");
+    expect(
+      getAgentToolManifestEntry("dbt_create_project")?.getLabel({
+        name: "analytics",
+      }),
+    ).toBe('Creating dbt project "analytics"');
+    expect(
+      getAgentToolManifestEntry("dbt_open_pull_request")?.getLabel({
+        title: "Add orders mart",
+      }),
+    ).toBe("Opening PR: Add orders mart");
   });
 
   it("registers web tools for chat tool cards", () => {

--- a/app/src/agent-runtime/client-tool-manifest.ts
+++ b/app/src/agent-runtime/client-tool-manifest.ts
@@ -679,17 +679,163 @@ export const AGENT_TOOL_MANIFEST = {
     },
     icon: "play",
   },
+  // dbt_get_run polls the runner for a run's status. Without an explicit entry
+  // it fell back to humanizeToolName ("Dbt Get Run"), which is what surfaced in
+  // the agent transcript after a build. Give it a human label + a clock icon.
+  dbt_get_run: {
+    domain: "dbt",
+    execution: "server",
+    getLabel: () => "Checking dbt run status",
+    icon: "clock",
+  },
+  dbt_show: {
+    domain: "dbt",
+    execution: "server",
+    longRunning: true,
+    getLabel: input => {
+      const model = (input as Record<string, unknown>)?.model;
+      return model ? `Previewing ${model}` : "Previewing model";
+    },
+    icon: "eye",
+  },
+  dbt_create_project: {
+    domain: "dbt",
+    execution: "server",
+    longRunning: true,
+    getLabel: input => {
+      const name = (input as Record<string, unknown>)?.name;
+      return name ? `Creating dbt project "${name}"` : "Creating dbt project";
+    },
+    icon: "plus",
+  },
   dbt_cancel_run: {
     domain: "dbt",
     execution: "server",
     getLabel: () => "Cancelling dbt run",
     icon: "square",
   },
+  dbt_create_job: {
+    domain: "dbt",
+    execution: "server",
+    getLabel: input => {
+      const name = (input as Record<string, unknown>)?.name;
+      return name ? `Creating job "${name}"` : "Creating dbt job";
+    },
+    icon: "plus",
+  },
+  dbt_update_job: {
+    domain: "dbt",
+    execution: "server",
+    getLabel: input => {
+      const name = (input as Record<string, unknown>)?.name;
+      return name ? `Updating job "${name}"` : "Updating dbt job";
+    },
+    icon: "pencil",
+  },
   dbt_delete_job: {
     domain: "dbt",
     execution: "server",
     getLabel: () => "Deleting dbt job",
     icon: "trash",
+  },
+  dbt_sync_from_repo: {
+    domain: "dbt",
+    execution: "server",
+    longRunning: true,
+    getLabel: () => "Syncing from repo",
+    icon: "download",
+  },
+  dbt_list_recoverable_files: {
+    domain: "dbt",
+    execution: "server",
+    getLabel: () => "Listing recoverable files",
+    icon: "list",
+  },
+  dbt_restore_file: {
+    domain: "dbt",
+    execution: "server",
+    getLabel: input => {
+      const path = (input as Record<string, unknown>)?.path;
+      return path ? `Restoring ${path}` : "Restoring file";
+    },
+    icon: "plus",
+  },
+  dbt_git_status: {
+    domain: "dbt",
+    execution: "server",
+    getLabel: () => "Checking git status",
+    icon: "eye",
+  },
+  dbt_commit_and_push: {
+    domain: "dbt",
+    execution: "server",
+    longRunning: true,
+    getLabel: () => "Committing & pushing",
+    icon: "external-link",
+  },
+  dbt_commit_to_branch: {
+    domain: "dbt",
+    execution: "server",
+    longRunning: true,
+    getLabel: input => {
+      const name = (input as Record<string, unknown>)?.name;
+      return name ? `Committing to ${name}` : "Committing to new branch";
+    },
+    icon: "external-link",
+  },
+  dbt_create_branch: {
+    domain: "dbt",
+    execution: "server",
+    getLabel: input => {
+      const name = (input as Record<string, unknown>)?.name;
+      return name ? `Creating branch ${name}` : "Creating branch";
+    },
+    icon: "plus",
+  },
+  dbt_switch_branch: {
+    domain: "dbt",
+    execution: "server",
+    longRunning: true,
+    getLabel: input => {
+      const branch = (input as Record<string, unknown>)?.branch;
+      return branch ? `Switching to ${branch}` : "Switching branch";
+    },
+    icon: "link",
+  },
+  dbt_list_branches: {
+    domain: "dbt",
+    execution: "server",
+    getLabel: () => "Listing branches",
+    icon: "list",
+  },
+  dbt_delete_branch: {
+    domain: "dbt",
+    execution: "server",
+    getLabel: input => {
+      const name = (input as Record<string, unknown>)?.name;
+      return name ? `Deleting branch ${name}` : "Deleting branch";
+    },
+    icon: "trash",
+  },
+  dbt_open_pull_request: {
+    domain: "dbt",
+    execution: "server",
+    longRunning: true,
+    getLabel: input => {
+      const title = (input as Record<string, unknown>)?.title;
+      return title ? `Opening PR: ${title}` : "Opening pull request";
+    },
+    icon: "external-link",
+  },
+  dbt_merge_pull_request: {
+    domain: "dbt",
+    execution: "server",
+    longRunning: true,
+    getLabel: input => {
+      const prNumber = (input as Record<string, unknown>)?.prNumber;
+      return prNumber ? `Merging PR #${prNumber}` : "Merging pull request";
+    },
+    icon: "external-link",
   },
   search_consoles: {
     domain: "search",

--- a/app/src/components/StreamingToolCard.tsx
+++ b/app/src/components/StreamingToolCard.tsx
@@ -44,6 +44,7 @@ import {
   type ToolIconKey,
   type ToolUiConfig,
 } from "../agent-runtime/client-tool-manifest";
+import { getOutputSummary } from "./streaming-tool-card-summary";
 
 export type ToolPartState =
   | "input-streaming"
@@ -134,59 +135,6 @@ function getToolConfig(toolName: string): ToolUiConfig {
       icon: "help-circle",
     }
   );
-}
-
-function getOutputSummary(output: unknown): string | null {
-  if (output === null || output === undefined) return null;
-
-  const o = output as Record<string, unknown>;
-
-  if (o.success === false || o.error) {
-    const raw = o.error;
-    const err =
-      typeof raw === "string"
-        ? raw
-        : raw && typeof raw === "object" && "message" in raw
-          ? String((raw as { message: unknown }).message)
-          : "Failed";
-    return err.length > 50 ? err.slice(0, 50) + "…" : err;
-  }
-
-  if (o.state === "definition_updated") {
-    return "Definition saved only";
-  }
-  if (o.state === "loaded") {
-    if (typeof o.rowCount === "number") {
-      return `${o.rowCount} row${o.rowCount !== 1 ? "s" : ""}`;
-    }
-    return "Fresh data loaded";
-  }
-
-  if (Array.isArray(o.data)) {
-    return `${o.data.length} row${o.data.length !== 1 ? "s" : ""}`;
-  }
-  if (typeof o.rowCount === "number") {
-    return `${o.rowCount} row${o.rowCount !== 1 ? "s" : ""}`;
-  }
-
-  if (Array.isArray(output)) {
-    return `${output.length} result${output.length !== 1 ? "s" : ""}`;
-  }
-
-  if (Array.isArray(o.fields)) {
-    return `${o.fields.length} field${o.fields.length !== 1 ? "s" : ""}`;
-  }
-  if (Array.isArray(o.columns)) {
-    return `${o.columns.length} column${o.columns.length !== 1 ? "s" : ""}`;
-  }
-  if (Array.isArray(o.databases)) {
-    return `${o.databases.length} database${o.databases.length !== 1 ? "s" : ""}`;
-  }
-  if (Array.isArray(o.tables)) {
-    return `${o.tables.length} table${o.tables.length !== 1 ? "s" : ""}`;
-  }
-
-  return null;
 }
 
 function formatOutputForDisplay(output: unknown): string {

--- a/app/src/components/streaming-tool-card-summary.test.ts
+++ b/app/src/components/streaming-tool-card-summary.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { getOutputSummary } from "./streaming-tool-card-summary";
+
+describe("StreamingToolCard getOutputSummary", () => {
+  it("summarizes a dbt run-status output with its lifecycle status", () => {
+    expect(
+      getOutputSummary({
+        success: true,
+        runId: "6a425cd21f3df656858dd1ff",
+        status: "success",
+      }),
+    ).toBe("success");
+  });
+
+  it("includes step count when the dbt run reports step results", () => {
+    expect(
+      getOutputSummary({
+        success: true,
+        runId: "6a425cd21f3df656858dd1ff",
+        status: "error",
+        stepResults: [{ name: "a" }, { name: "b" }],
+      }),
+    ).toBe("error · 2 steps");
+  });
+
+  it("prefers the error message over the run status when the tool failed", () => {
+    expect(
+      getOutputSummary({
+        success: false,
+        error: "boom",
+        runId: "6a425cd21f3df656858dd1ff",
+        status: "error",
+      }),
+    ).toBe("boom");
+  });
+
+  it("falls back to row counts for non-dbt outputs", () => {
+    expect(getOutputSummary({ data: [1, 2, 3] })).toBe("3 rows");
+    expect(getOutputSummary(null)).toBeNull();
+  });
+});

--- a/app/src/components/streaming-tool-card-summary.ts
+++ b/app/src/components/streaming-tool-card-summary.ts
@@ -1,0 +1,68 @@
+/**
+ * Builds the short status line shown in a tool card header once the tool
+ * finishes (e.g. "3 rows", "success"). Kept in its own module so it can be
+ * unit-tested without importing the React component graph, and so the
+ * component file keeps a Fast-Refresh-friendly component-only export surface.
+ */
+export function getOutputSummary(output: unknown): string | null {
+  if (output === null || output === undefined) return null;
+
+  const o = output as Record<string, unknown>;
+
+  if (o.success === false || o.error) {
+    const raw = o.error;
+    const err =
+      typeof raw === "string"
+        ? raw
+        : raw && typeof raw === "object" && "message" in raw
+          ? String((raw as { message: unknown }).message)
+          : "Failed";
+    return err.length > 50 ? err.slice(0, 50) + "…" : err;
+  }
+
+  // dbt run-status tools (dbt_get_run / dbt_run_job / dbt_cancel_run) return a
+  // run id plus the run's lifecycle status. Surface the status so the card
+  // header reads "success" / "running" instead of a bare "Done".
+  if (typeof o.runId === "string" && typeof o.status === "string") {
+    const steps = Array.isArray(o.stepResults) ? o.stepResults.length : 0;
+    return steps > 0
+      ? `${o.status} · ${steps} step${steps !== 1 ? "s" : ""}`
+      : o.status;
+  }
+
+  if (o.state === "definition_updated") {
+    return "Definition saved only";
+  }
+  if (o.state === "loaded") {
+    if (typeof o.rowCount === "number") {
+      return `${o.rowCount} row${o.rowCount !== 1 ? "s" : ""}`;
+    }
+    return "Fresh data loaded";
+  }
+
+  if (Array.isArray(o.data)) {
+    return `${o.data.length} row${o.data.length !== 1 ? "s" : ""}`;
+  }
+  if (typeof o.rowCount === "number") {
+    return `${o.rowCount} row${o.rowCount !== 1 ? "s" : ""}`;
+  }
+
+  if (Array.isArray(output)) {
+    return `${output.length} result${output.length !== 1 ? "s" : ""}`;
+  }
+
+  if (Array.isArray(o.fields)) {
+    return `${o.fields.length} field${o.fields.length !== 1 ? "s" : ""}`;
+  }
+  if (Array.isArray(o.columns)) {
+    return `${o.columns.length} column${o.columns.length !== 1 ? "s" : ""}`;
+  }
+  if (Array.isArray(o.databases)) {
+    return `${o.databases.length} database${o.databases.length !== 1 ? "s" : ""}`;
+  }
+  if (Array.isArray(o.tables)) {
+    return `${o.tables.length} table${o.tables.length !== 1 ? "s" : ""}`;
+  }
+
+  return null;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What happened

A dbt agent chat "stopped and posted something weird": after `Build int_demo__booking+` (Success) and a `Dbt Get Run` card (Done), the assistant emitted a garbage line of raw IDs:

```
court 6a379d6014cf36380f79d5fe
6a425cd21f3df656858dd1ff 60000
```

Those tokens are `dbt_get_run`'s arguments — `projectId`, `runId`, and `waitMs: 60000`. A weaker model (GLM 5.2 in the screenshot) typed the intended tool call as prose instead of invoking it. Two problems surfaced:

1. **Tool cards were under-labeled.** `dbt_get_run` (and ~16 other dbt server tools) were missing from `AGENT_TOOL_MANIFEST`, so they fell back to `humanizeToolName` → the bare `"Dbt Get Run"` with no status, just `"Done"`.
2. **Nothing discouraged the model** from writing tool calls / IDs as text.

## Changes

- **`client-tool-manifest.ts`** — register every dbt server tool that was missing (`dbt_get_run`, `dbt_show`, `dbt_create_project`, `dbt_create_job`, `dbt_update_job`, sync/restore/git/branch/PR tools) with human labels + icons. `dbt_get_run` now reads **"Checking dbt run status"**.
- **`streaming-tool-card-summary.ts`** (extracted from `StreamingToolCard.tsx`) — a finished dbt run card now shows its lifecycle status (`success` / `error` / `running`, plus step count) instead of a bare `"Done"`. Extraction keeps the component Fast-Refresh-friendly and makes the helper unit-testable.
- **`api/src/agent-skills/dbt/SKILL.md`** — explicit rule: always invoke dbt tools as real tool calls; never type a tool name or its `projectId`/`runId`/`waitMs` as message text; reply with a human summary, not raw IDs.
- **`dashboard-artifact-store.service.ts`** — drop a dead `publicBaseUrl` private field (never read) that the new manifest drift test pulled into the app type graph.

The leaked-text itself is model behaviour we can't fully fix client-side; the skill guardrail reduces recurrence, while the manifest/summary work makes the surrounding cards clear instead of cryptic.

## Testing

- ✅ `pnpm --filter app exec vitest run client-tool-manifest.test.ts streaming-tool-card-summary.test.ts` — 12 tests, incl. a drift guard that **every** dbt server tool has a manifest entry, label assertions (`dbt_get_run` → "Checking dbt run status"), and run-status summary cases (`success`, `error · 2 steps`, error-precedence).
- ✅ `pnpm --filter app run typecheck`
- ✅ `pnpm --filter app run lint`
- ✅ `pnpm --filter api run lint`

A live UI demo of the exact failure isn't deterministically reproducible (it depends on a weaker model mis-emitting a tool call), so the presentation-mapping logic is covered by deterministic unit tests instead.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97fba702-48c3-4d42-89c9-c8d55cd7efcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97fba702-48c3-4d42-89c9-c8d55cd7efcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

