### PR TITLE
feat(app): add Publish button to app preview toolbar

### DIFF
--- a/app/src/components/AppRenderer.tsx
+++ b/app/src/components/AppRenderer.tsx
@@ -1,23 +1,34 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Box,
+  Button,
   CircularProgress,
   IconButton,
   Tooltip,
   Typography,
   Chip,
   Alert,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  TextField,
+  Snackbar,
 } from "@mui/material";
 import {
   RefreshCw as RefreshIcon,
   Share2 as ShareIcon,
   History as HistoryIcon,
+  UploadCloud as PublishIcon,
+  CheckCircle2 as PublishedIcon,
 } from "lucide-react";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useAuth } from "../contexts/auth-context";
 import { useTheme } from "../contexts/ThemeContext";
 import { useIsWorkspaceAdmin } from "../hooks/useIsWorkspaceAdmin";
 import { useAppStore } from "../store/appStore";
+import { useVersionStore } from "../store/versionStore";
 import { useConsoleStore } from "../store/consoleStore";
 import ShareDialog from "./ShareDialog";
 import { VersionHistoryPanel } from "./VersionHistoryPanel";
@@ -51,6 +62,10 @@ export default function AppRenderer({
   const workspaceId = currentWorkspace?.id;
   const [shareOpen, setShareOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
+  const [publishOpen, setPublishOpen] = useState(false);
+  const [publishComment, setPublishComment] = useState("");
+  const [publishing, setPublishing] = useState(false);
+  const [publishedNotice, setPublishedNotice] = useState<string | null>(null);
 
   // The sandboxed preview inherits the host theme: the current mode seeds the
   // srcdoc, and later toggles are pushed via postMessage (rebuilding the
@@ -66,6 +81,8 @@ export default function AppRenderer({
   const bumpPreview = useAppStore(s => s.bumpPreview);
   const setPreviewErrors = useAppStore(s => s.setPreviewErrors);
   const runBinding = useAppStore(s => s.runBinding);
+  const persistApp = useAppStore(s => s.persistApp);
+  const saveVersion = useVersionStore(s => s.saveVersion);
 
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
 
@@ -96,6 +113,41 @@ export default function AppRenderer({
     },
     [tabId],
   );
+
+  // Owner or workspace admin may publish (mirrors the Share dialog's canManage).
+  const canManage =
+    !!appEntity &&
+    ((appEntity.owner_id ?? appEntity.createdBy) === user?.id ||
+      isWorkspaceAdmin);
+
+  // Promote the current draft to the published definition that shared links and
+  // viewers render. Flush pending edits first so the checkpoint matches the
+  // preview, then refresh so the toolbar's published state stops being stale.
+  const handlePublishConfirm = useCallback(async () => {
+    if (!workspaceId) return;
+    setPublishing(true);
+    try {
+      await persistApp(workspaceId, appId);
+      const result = await saveVersion(
+        workspaceId,
+        "app",
+        appId,
+        publishComment.trim(),
+      );
+      await fetchApp(workspaceId, appId);
+      setPublishOpen(false);
+      setPublishComment("");
+      setPublishedNotice(
+        result.success
+          ? result.version
+            ? `Published version ${result.version}`
+            : "Published"
+          : (result.error ?? "Failed to publish"),
+      );
+    } finally {
+      setPublishing(false);
+    }
+  }, [workspaceId, appId, persistApp, saveVersion, publishComment, fetchApp]);
 
   // True from the moment a (re)built srcdoc is handed to the iframe until the
   // bootstrap posts ready/error. Loading deps from the CDN and transpiling
@@ -333,7 +385,40 @@ export default function AppRenderer({
           variant="outlined"
           label={appEntity.runtime === "cdn" ? "CDN preview" : "WebContainer"}
         />
+        {appEntity.hasUnpublishedChanges && (
+          <Chip
+            size="small"
+            color="warning"
+            variant="outlined"
+            label="Unpublished changes"
+          />
+        )}
         <Box sx={{ flex: 1 }} />
+        {canManage &&
+          (appEntity.hasUnpublishedChanges ? (
+            <Button
+              size="small"
+              variant="contained"
+              startIcon={<PublishIcon size={16} strokeWidth={1.5} />}
+              onClick={() => setPublishOpen(true)}
+            >
+              Publish
+            </Button>
+          ) : (
+            <Tooltip title="Draft matches the published version">
+              <span>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  color="inherit"
+                  disabled
+                  startIcon={<PublishedIcon size={16} strokeWidth={1.5} />}
+                >
+                  Published
+                </Button>
+              </span>
+            </Tooltip>
+          ))}
         <Tooltip title="Version history">
           <IconButton size="small" onClick={() => setHistoryOpen(true)}>
             <HistoryIcon size={18} strokeWidth={1.5} />
@@ -380,6 +465,53 @@ export default function AppRenderer({
         onSharingChanged={changes =>
           useAppStore.getState().applySharingChanges(appId, changes)
         }
+      />
+
+      <Dialog
+        open={publishOpen}
+        onClose={() => !publishing && setPublishOpen(false)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>Publish {appEntity.title}</DialogTitle>
+        <DialogContent>
+          <DialogContentText sx={{ mb: 2 }}>
+            Snapshots the current draft into version history and publishes it as
+            the live version that shared links and viewers see.
+          </DialogContentText>
+          <TextField
+            autoFocus
+            fullWidth
+            size="small"
+            label="Comment (optional)"
+            placeholder="e.g. Add revenue chart"
+            value={publishComment}
+            onChange={e => setPublishComment(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === "Enter") void handlePublishConfirm();
+            }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setPublishOpen(false)} disabled={publishing}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handlePublishConfirm}
+            variant="contained"
+            disabled={publishing}
+          >
+            {publishing ? "Publishing..." : "Publish"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar
+        open={!!publishedNotice}
+        autoHideDuration={4000}
+        onClose={() => setPublishedNotice(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+        message={publishedNotice ?? ""}
       />
 
       {errors.length > 0 && (

--- a/app/src/store/appStore.ts
+++ b/app/src/store/appStore.ts
@@ -335,7 +335,15 @@ export const useAppStore = create<AppStore>()(
         if (res.success && res.app) {
           set(state => {
             const current = state.openApps[appId];
-            if (current) current.version = res.app.version;
+            if (current) {
+              current.version = res.app.version;
+              // Autosave bumps the draft; mirror the server-computed publish
+              // state so the preview toolbar's Publish button reflects whether
+              // the draft now differs from the published version.
+              current.publishedVersion = res.app.publishedVersion;
+              current.publishedAt = res.app.publishedAt;
+              current.hasUnpublishedChanges = res.app.hasUnpublishedChanges;
+            }
           });
         }
       } catch {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Publish** action directly to the app preview toolbar (`AppRenderer`) so users can promote an app from where they're previewing it, instead of hunting for the "Publish version" item in the Apps explorer context menu.

The toolbar now reflects publish state at a glance:
- An orange **"Unpublished changes"** chip when the working draft differs from the published version.
- A contained **Publish** button (upload-cloud icon) when there are unpublished changes — opens a small dialog with an optional comment, then snapshots + publishes via the existing `POST /api/workspaces/:workspaceId/apps/:id/versions` endpoint.
- A disabled **Published** button (checkmark) when the draft already matches the published version.
- A success snackbar (e.g. `Published version 2`) after publishing.

The button is gated on manage permission (owner or workspace admin), mirroring the Share dialog's `canManage` check. After publishing, the app is re-fetched so the toolbar state updates immediately.

## Bug fix included

`persistApp` (autosave) received the freshly serialized app (which includes the server-computed `hasUnpublishedChanges`) but only copied `version` back into the store — so the publish-state indicator stayed stale after edits. It now also syncs `hasUnpublishedChanges`, `publishedVersion`, and `publishedAt`, so the toolbar reacts to draft edits in real time.

## Changes

- `app/src/components/AppRenderer.tsx` — Publish button, unpublished-changes chip, publish dialog, success snackbar, `canManage` gating, refresh-after-publish.
- `app/src/store/appStore.ts` — `persistApp` now mirrors server publish-state fields on autosave.

## Testing

- `pnpm --filter app run typecheck` ✅
- `pnpm --filter app run lint` ✅
- Manual end-to-end test (login → create app → edit file → Publish from toolbar) ✅

### Walkthrough

[publish_button_app_preview_demo.mp4](https://cursor.com/agents/bc-25ee733b-f6ba-4941-9860-30fd8f8bb887/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpublish_button_app_preview_demo.mp4)

Publishing from the preview toolbar: dialog opens, comment entered, toolbar transitions from "Unpublished changes" → "Published".

[Toolbar with Unpublished changes chip and Publish button](https://cursor.com/agents/bc-25ee733b-f6ba-4941-9860-30fd8f8bb887/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftoolbar_unpublished_changes.webp)
[Snackbar reading Published version 2](https://cursor.com/agents/bc-25ee733b-f6ba-4941-9860-30fd8f8bb887/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsnackbar_published_version.webp)
[Toolbar showing disabled Published state](https://cursor.com/agents/bc-25ee733b-f6ba-4941-9860-30fd8f8bb887/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftoolbar_published_state.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25ee733b-f6ba-4941-9860-30fd8f8bb887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25ee733b-f6ba-4941-9860-30fd8f8bb887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

