### PR TITLE
fix(claap): migrate recordings to aiFields, retain insightTemplates

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -13,7 +13,7 @@
     "worker:dev": "tsx watch src/worker.ts",
     "migrate:workspaces": "tsx src/migrations/migrate-to-workspaces.ts",
     "openapi:generate": "tsx src/openapi/generate-cli.ts",
-    "test": "tsx src/openapi/core.test.ts && tsx src/openapi/openapi.test.ts && tsx src/dbt/warm-dir-cache.test.ts && tsx src/connectors/stripe/connector.test.ts && tsx src/connectors/close/connector.test.ts && tsx src/connectors/pandadoc/connector.test.ts && tsx src/sync-cdc/idempotency.test.ts && tsx src/agent-lib/context/compaction.test.ts && tsx src/services/safe-fetch.service.test.ts && tsx src/agent-lib/tools/check-query-status-poll.test.ts",
+    "test": "tsx src/openapi/core.test.ts && tsx src/openapi/openapi.test.ts && tsx src/dbt/warm-dir-cache.test.ts && tsx src/connectors/stripe/connector.test.ts && tsx src/connectors/close/connector.test.ts && tsx src/connectors/pandadoc/connector.test.ts && tsx src/connectors/claap/connector.test.ts && tsx src/sync-cdc/idempotency.test.ts && tsx src/agent-lib/context/compaction.test.ts && tsx src/services/safe-fetch.service.test.ts && tsx src/agent-lib/tools/check-query-status-poll.test.ts",
     "test:dbt": "vitest run",
     "test:dbt:watch": "vitest",
     "test:destinations": "vitest run --config vitest.destinations.config.ts",

--- a/api/src/connectors/claap/connector.test.ts
+++ b/api/src/connectors/claap/connector.test.ts
@@ -140,7 +140,44 @@ function testResolveSchemaForRecordings() {
     assert.equal(schema?.unknownFieldPolicy, "string");
     assert.ok(schema?.fields.id);
     assert.ok(schema?.fields.createdAt);
+    assert.ok(schema?.fields.aiFields, "aiFields should be in recordings schema");
+    assert.ok(
+      schema?.fields.insightTemplates,
+      "legacy insightTemplates retained for historical rows",
+    );
   });
+}
+
+async function testRecordingsFetchRequestsAiFields() {
+  const connector = createConnector();
+  let capturedParams: Record<string, unknown> | undefined;
+
+  (connector as any).claapApi = {
+    get: (_path: string, options?: { params?: Record<string, unknown> }) => {
+      capturedParams = options?.params;
+      return Promise.resolve({
+        data: {
+          result: {
+            recordings: [{ id: "rec_1", title: "Demo" }],
+            pagination: { nextCursor: undefined, totalCount: 1 },
+          },
+        },
+      });
+    },
+  };
+
+  const batches: Record<string, unknown>[][] = [];
+  await connector.fetchEntityChunk({
+    entity: "recordings",
+    maxIterations: 1,
+    onBatch: async records => {
+      batches.push(records);
+    },
+  } as any);
+
+  assert.equal(capturedParams?.returnAiFields, true);
+  assert.equal(batches.length, 1);
+  assert.equal(batches[0][0].id, "rec_1");
 }
 
 function testSupportsResumableFetching() {
@@ -167,6 +204,7 @@ async function main() {
   testWebhookPayloadIsExtractedForProcessing();
   testWebhookCdcRecordUsesRecordingsEntity();
   await testResolveSchemaForRecordings();
+  await testRecordingsFetchRequestsAiFields();
   testSupportsResumableFetching();
   testEntityMetadataIncludesLayoutSuggestion();
 }

--- a/api/src/connectors/claap/connector.ts
+++ b/api/src/connectors/claap/connector.ts
@@ -370,9 +370,13 @@ export class ClaapConnector extends BaseConnector {
     limit?: number;
   }): Promise<ClaapListRecordingsResult> {
     const api = this.getClaapClient();
-    const params: Record<string, string | number> = {
+    const params: Record<string, string | number | boolean> = {
       limit: Math.min(options.limit ?? this.getBatchSize(), MAX_PAGE_LIMIT),
       sort: "created_asc",
+      // Opt into Claap's new AI output structure (`aiFields`). Without this the
+      // API returns the legacy `insightTemplates`, which stops being populated
+      // as of 2026-06-26.
+      returnAiFields: true,
     };
 
     if (options.cursor) {

--- a/api/src/connectors/claap/schema.ts
+++ b/api/src/connectors/claap/schema.ts
@@ -41,6 +41,10 @@ export const RECORDING_SCHEMA: Record<string, ConnectorFieldSchema> = {
   companies: j(),
   crmInfo: j(),
   deal: j(),
+  // Claap is migrating AI output from the nested `insightTemplates` shape to a
+  // flatter `aiFields` array. `insightTemplates` is retained so historical rows
+  // remain queryable, but it is no longer populated by the API as of 2026-06-26.
+  aiFields: j(),
   insightTemplates: j(),
   keyTakeaways: j(),
   outlines: j(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Claap is replacing the nested `insightTemplates` attribute with a flatter `aiFields` structure on the Get Recording endpoint and Recording webhook payloads. As of **2026-06-26**, `insightTemplates` is no longer populated. Our Claap connector was still mapping `insightTemplates` in its schema and never opted into the new format, so AI output would have gone silently null on new syncs.

## What changed

- **`schema.ts`** — Add `aiFields` (`json`) to `RECORDING_SCHEMA`. Keep `insightTemplates` so historical rows stay queryable; it's just no longer populated going forward.
- **`connector.ts`** — Add `returnAiFields: true` to the `/v1/recordings` list params, per Claap's API requirement to receive `aiFields` instead of the legacy field. Widened the params type to allow the boolean.
- **`connector.test.ts`** — Assert `aiFields` (and legacy `insightTemplates`) are present in the recordings schema, and a new test verifying the list fetch sends `returnAiFields: true`.
- **`package.json`** — Wire the Claap connector test into the `api` `test` script (it was previously not run alongside stripe/close/pandadoc).

### Webhooks
No code change needed: Claap states new webhook subscriptions default to the `aiFields` format, and our `createWebhookSubscription` provisions fresh subscriptions. Delivered `aiFields` now lands in the typed `json` column instead of the unknown-field bucket.

## Testing
- `pnpm --filter api exec tsx src/connectors/claap/connector.test.ts` — pass
- `pnpm --filter api run test` — pass (includes the newly-wired Claap suite)
- `pnpm --filter api run lint` — pass

Stays fully connector-agnostic; no UI/route/registry changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f2413ec-71ee-422c-8962-ab6389de616f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f2413ec-71ee-422c-8962-ab6389de616f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

