### PR TITLE
feat(close): sync user groups (functional teams) via backfill + CDC webhooks

### DIFF
--- a/api/src/connectors/close/connector.test.ts
+++ b/api/src/connectors/close/connector.test.ts
@@ -147,13 +147,74 @@ function testWebhookChangeIdFallbackIncludesSourceTs() {
   assert.ok(records[0].changeId.includes("lead_xyz"));
 }
 
-function main() {
+function testGroupsEntityIsAvailable() {
+  const connector = createConnector();
+
+  assert.ok(
+    connector.getAvailableEntities().includes("groups"),
+    "groups should be an available entity",
+  );
+  assert.ok(
+    connector.getEntityMetadata().some(meta => meta.name === "groups"),
+    "groups should be present in entity metadata",
+  );
+}
+
+function testGroupWebhookEventsAreScopedToGroups() {
+  const connector = createConnector();
+
+  assert.deepEqual(connector.getWebhookEventsForEntities(["groups"]), [
+    "group.created",
+    "group.updated",
+    "group.deleted",
+  ]);
+}
+
+function testGroupWebhookEventsAreMapped() {
+  const connector = createConnector();
+
+  assert.deepEqual(connector.getWebhookEventMapping("group.created"), {
+    entity: "groups",
+    operation: "upsert",
+  });
+  assert.deepEqual(connector.getWebhookEventMapping("group.updated"), {
+    entity: "groups",
+    operation: "upsert",
+  });
+  assert.deepEqual(connector.getWebhookEventMapping("group.deleted"), {
+    entity: "groups",
+    operation: "delete",
+  });
+}
+
+async function testGroupSchemaResolves() {
+  const connector = createConnector();
+
+  const schema = await connector.resolveSchema("groups");
+  assert.ok(schema, "groups schema should resolve");
+  if (!schema) return;
+  assert.equal(schema.entity, "groups");
+  assert.ok(schema.fields.members, "groups schema should expose members");
+  assert.ok(
+    schema.fields.organization_id,
+    "groups schema should expose organization_id",
+  );
+}
+
+async function main() {
   testUserWebhookEventsAreSupported();
   testUserWebhookEventsAreMapped();
   testUserWebhookPayloadIsExtractedForProcessing();
   testUserWebhookCdcRecordUsesUsersEntity();
   testWebhookChangeIdUsesNestedEventId();
   testWebhookChangeIdFallbackIncludesSourceTs();
+  testGroupsEntityIsAvailable();
+  testGroupWebhookEventsAreScopedToGroups();
+  testGroupWebhookEventsAreMapped();
+  await testGroupSchemaResolves();
 }
 
-main();
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/api/src/connectors/close/connector.ts
+++ b/api/src/connectors/close/connector.ts
@@ -144,6 +144,9 @@ const CLOSE_SUPPORTED_WEBHOOK_SELECTORS: CloseWebhookSelector[] = [
   { object_type: "status.opportunity", action: "created" },
   { object_type: "status.opportunity", action: "updated" },
   { object_type: "status.opportunity", action: "deleted" },
+  { object_type: "group", action: "created" },
+  { object_type: "group", action: "updated" },
+  { object_type: "group", action: "deleted" },
 ];
 
 const CLOSE_SUPPORTED_WEBHOOK_SELECTOR_KEYS = new Set(
@@ -714,6 +717,7 @@ export class CloseConnector extends BaseConnector {
       "lead_statuses",
       "opportunity_statuses",
       "outcomes",
+      "groups",
     ];
 
     const activitySubEntities = CLOSE_ACTIVITY_TYPES.map(
@@ -797,6 +801,12 @@ export class CloseConnector extends BaseConnector {
         label: "Outcomes",
         layoutSuggestion: lookupLayout,
       },
+      {
+        name: "groups",
+        label: "Groups",
+        description: "User groups (functional teams, e.g. Sales / CSM)",
+        layoutSuggestion: lookupLayout,
+      },
     ];
   }
 
@@ -834,6 +844,10 @@ export class CloseConnector extends BaseConnector {
 
     if (entity === "users") {
       return await this.fetchUsersChunk(options);
+    }
+
+    if (entity === "groups") {
+      return await this.fetchGroupsChunk(options);
     }
 
     if (entity in CloseConnector.SIMPLE_ENTITY_ENDPOINTS) {
@@ -1635,6 +1649,15 @@ export class CloseConnector extends BaseConnector {
       return;
     }
 
+    // Groups expose functional-team membership; backfill all pages.
+    if (entity === "groups") {
+      await this.fetchGroupsChunk({
+        ...options,
+        maxIterations: Number.MAX_SAFE_INTEGER,
+      } as ResumableFetchOptions);
+      return;
+    }
+
     // Simple entities (statuses, types) — fetch all via pagination
     if (entity in CloseConnector.SIMPLE_ENTITY_ENDPOINTS) {
       await this.fetchSimpleEntityChunk(entity, options as any);
@@ -1874,6 +1897,82 @@ export class CloseConnector extends BaseConnector {
     custom_object_types: "/custom_object_type/",
     outcomes: "/outcome/",
   };
+
+  /**
+   * Fetch user groups (functional teams). Unlike the SIMPLE_ENTITY_ENDPOINTS,
+   * the `/group/` list endpoint only returns `name`/`members` when those
+   * fields are explicitly requested via `_fields`, so groups get their own
+   * fetcher that always sends the selector.
+   */
+  private async fetchGroupsChunk(
+    options: ResumableFetchOptions,
+  ): Promise<FetchState> {
+    const { onBatch, onProgress, state } = options;
+
+    if (state && !state.hasMore) {
+      return {
+        totalProcessed: state.totalProcessed,
+        hasMore: false,
+        iterationsInChunk: 0,
+      };
+    }
+
+    const api = this.getCloseClient();
+    const batchSize = options.batchSize || this.getBatchSize();
+    const rateLimitDelay = options.rateLimitDelay || this.getRateLimitDelay();
+    const maxIterations = options.maxIterations || 10;
+
+    let offset = state?.offset || 0;
+    let recordCount = state?.totalProcessed || 0;
+    let hasMore = true;
+    let iterations = 0;
+
+    while (hasMore && iterations < maxIterations) {
+      try {
+        const response = await api.get("/group/", {
+          params: {
+            _limit: batchSize,
+            _skip: offset,
+            // `/group/` omits name/members unless explicitly requested.
+            _fields: "id,name,members,organization_id",
+          },
+        });
+        const data = response.data.data || [];
+
+        if (data.length > 0) {
+          await onBatch(data);
+          recordCount += data.length;
+          if (onProgress) onProgress(recordCount, undefined);
+        }
+
+        hasMore = response.data.has_more || false;
+        if (hasMore) {
+          offset += batchSize;
+          iterations++;
+          await this.sleep(rateLimitDelay);
+        }
+      } catch (error) {
+        if (axios.isAxiosError(error) && error.response?.status === 429) {
+          const retryAfter = parseInt(
+            error.response.headers["retry-after"] || "60",
+          );
+          logger.warn("Rate limited, waiting", {
+            retryAfterSeconds: retryAfter,
+          });
+          await this.sleep(retryAfter * 1000);
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    return {
+      offset,
+      totalProcessed: recordCount,
+      hasMore,
+      iterationsInChunk: iterations,
+    };
+  }
 
   private async fetchSimpleEntityChunk(
     entity: string,
@@ -2283,6 +2382,11 @@ export class CloseConnector extends BaseConnector {
       "opportunity.created": { entity: "opportunities", operation: "upsert" },
       "opportunity.updated": { entity: "opportunities", operation: "upsert" },
       "opportunity.deleted": { entity: "opportunities", operation: "delete" },
+
+      // Groups (functional teams). `group.updated` also fires on member add/remove.
+      "group.created": { entity: "groups", operation: "upsert" },
+      "group.updated": { entity: "groups", operation: "upsert" },
+      "group.deleted": { entity: "groups", operation: "delete" },
     };
 
     if (mappings[eventType]) return mappings[eventType];
@@ -2415,6 +2519,7 @@ export class CloseConnector extends BaseConnector {
       custom_objects: ["custom_object"],
       lead_statuses: ["status.lead"],
       opportunity_statuses: ["status.opportunity"],
+      groups: ["group"],
     };
 
     const relevantObjectTypes = new Set<string>();

--- a/api/src/connectors/close/schema.ts
+++ b/api/src/connectors/close/schema.ts
@@ -478,6 +478,15 @@ export const OPPORTUNITY_STATUS_SCHEMA: Record<string, ConnectorFieldSchema> = {
   ...MAKO_SYSTEM_FIELDS,
 };
 
+export const GROUP_SCHEMA: Record<string, ConnectorFieldSchema> = {
+  id: { type: "string", required: true },
+  name: s(),
+  organization_id: s(),
+  // List of member user_ids (the actual team membership Close exposes).
+  members: j(),
+  ...MAKO_SYSTEM_FIELDS,
+};
+
 export const OUTCOME_SCHEMA: Record<string, ConnectorFieldSchema> = {
   id: { type: "string", required: true },
   name: s(),
@@ -527,6 +536,7 @@ export const CORE_ENTITY_SCHEMA_MAP: Record<
   lead_statuses: LEAD_STATUS_SCHEMA,
   opportunity_statuses: OPPORTUNITY_STATUS_SCHEMA,
   outcomes: OUTCOME_SCHEMA,
+  groups: GROUP_SCHEMA,
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

We wanted to distinguish **Sales vs CSM** in synced Close data and assumed functional team membership wasn't available in the API (only permission `role` tiers like admin/user, plus the org id under `user.organizations`). That assumption was wrong: Close exposes teams through the **Groups API** (`/group/`).

Per Close docs: *"Groups are named collections of Users… A group typically represents a team in your company. For example, you can have a Sales group and a Support group. A User can be a member of multiple Groups."*

So instead of inferring team from behavior (who owns new-business opportunities vs who only runs meetings), we sync the real membership natively.

## What

Adds a first-class `groups` entity to the Close connector:

- **schema** — `GROUP_SCHEMA` (`id`, `name`, `organization_id`, `members`) registered in `CORE_ENTITY_SCHEMA_MAP`. `members` is the list of member `user_id`s — the actual team membership.
- **backfill** — `fetchGroupsChunk` paginates `/group/` and always sends `_fields=id,name,members,organization_id` (the list endpoint omits `name`/`members` unless explicitly requested). Wired into both `fetchEntityChunk` (resumable CDC backfill) and `fetchEntity` (full-sync fallback). Honors `_skip`/`_limit`/`has_more` and 429 retry like the other fetchers.
- **entities** — `groups` added to `getAvailableEntities()` and `getEntityMetadata()` (lookup layout).
- **webhooks** — `group.created` / `group.updated` / `group.deleted` selectors, event mapping (`{ entity: "groups", operation }`), and entity scoping (`groups → ["group"]`). `group.updated` fires on member add/remove, so membership stays fresh incrementally.
- **tests** — entity availability, webhook scoping + mapping, and schema resolution.

## Testing

- `tsx api/src/connectors/close/connector.test.ts` — all assertions pass (incl. new group cases).
- `pnpm --filter api run lint` — clean.
- `pnpm --filter api run build` — typecheck/build passes.
- `node scripts/check-connector-agnosticism.js` — passes (change is fully self-contained in `connectors/close/`).
- Mocked end-to-end backfill of `fetchGroupsChunk`: confirmed it sends `_fields`, paginates (`_skip` 0 → 2), and emits all groups with `members` across pages.

## Downstream

Once synced, the warehouse has a `<base>_groups` table with `members`; a rep's team is `JOIN`/`UNNEST(members)` → `users`. No behavioral inference needed when Groups are populated in Close. (If a customer leaves Groups empty, the earlier derived classification remains a fallback.)

## Note

`fetchGroupsChunk` requests `organization_id` in `_fields`; if a given Close org rejects that selector, drop it to `id,name,members`. Verified the request shape via mocked client; not yet smoke-tested against a live Close org.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0687d5fa-d532-4b75-9107-9783933d4959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0687d5fa-d532-4b75-9107-9783933d4959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

