### PR TITLE
fix(apps): force rebuild on explicit binding rematerialize

### DIFF
--- a/api/src/agent-lib/tools/server-app-tools.ts
+++ b/api/src/agent-lib/tools/server-app-tools.ts
@@ -369,10 +369,15 @@ export function createServerAppTools({
               error: `Binding "${name}" is 'live', not 'parquet' — nothing to materialize.`,
             };
           }
+          // Explicit "rebuild" request: force past the definition-hash cache
+          // so the artifact is rebuilt from the current upstream data even when
+          // the binding query is unchanged. Without this, a rematerialize over
+          // an unchanged query is a no-op cache hit.
           const queued = await queueAppBindingMaterialization({
             workspaceId,
             appId,
             bindingId: binding.id,
+            force: true,
           });
           const waitMs =
             Math.min(Math.max(waitSeconds ?? 120, 0), 600) * 1000;

--- a/app/src/app-runtime/agent-tools.ts
+++ b/app/src/app-runtime/agent-tools.ts
@@ -239,7 +239,7 @@ export async function executeAppAgentTool(
         workspaceId,
         appId,
         binding.id,
-        { signal: options?.signal, timeoutMs },
+        { force: true, signal: options?.signal, timeoutMs },
       );
       if (result.status === "building") {
         // Not an error: the build continues server-side. Return so the agent

--- a/app/src/components/AppBindingEditor.tsx
+++ b/app/src/components/AppBindingEditor.tsx
@@ -140,7 +140,10 @@ export default function AppBindingEditor({
   const handleMaterialize = useCallback(async () => {
     if (!workspaceId) return;
     setMaterializing(true);
-    await materializeBinding(workspaceId, appId, bindingId);
+    // Explicit user action = rebuild now. Force past the definition-hash cache
+    // so a rematerialize picks up new upstream data even when the query text
+    // is unchanged.
+    await materializeBinding(workspaceId, appId, bindingId, { force: true });
     setMaterializing(false);
   }, [workspaceId, appId, bindingId, materializeBinding]);
 

--- a/app/src/components/AppsExplorer.tsx
+++ b/app/src/components/AppsExplorer.tsx
@@ -532,7 +532,12 @@ export function AppsExplorer() {
             <MenuItem
               key="materialize"
               onClick={() => {
-                void materializeBinding(workspaceId, parsed.appId, parsed.path);
+                void materializeBinding(
+                  workspaceId,
+                  parsed.appId,
+                  parsed.path,
+                  { force: true },
+                );
                 helpers.closeMenu();
               }}
             >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Re-materializing a parquet app data binding from the UI or the agent does **not** actually rebuild the artifact when the binding's query is unchanged — so the app's data stays frozen even though the upstream source changed.

### Root cause

The parquet artifact cache is keyed by the binding's **definition hash** (query code + connection/db), not by the underlying data. `queueAppBindingMaterialization` / `materializeAppBinding` short-circuit with a "cache hit" and return `ready` **without rebuilding** when the query text is unchanged and `force` is not set:

```ts
if (!force &&
    binding.cache?.parquetArtifactKey === artifactKey &&
    binding.cache?.definitionHash === definitionHash &&
    binding.cache?.parquetBuildStatus === "ready" &&
    (await artifactExists(artifactKey))) {
  return { status: "ready", queued: false }; // no rebuild
}
```

The unified refresh API (`refreshResourceDataSources`) and the scheduled cron (`appBindingSchedulerFunction`) already pass `force: true`, so they work. But every **explicit** "rebuild now" entry point omitted it, making them silent no-ops over an unchanged query.

## Fix

Pass `force: true` from every explicit user/agent rebuild action (intent = pick up new upstream data):

- `app/src/components/AppBindingEditor.tsx` — "Materialize" button
- `app/src/components/AppsExplorer.tsx` — context-menu "Materialize"
- `app/src/app-runtime/agent-tools.ts` — client agent `materialize_binding` leg
- `api/src/agent-lib/tools/server-app-tools.ts` — server agent tool `materialize_binding`

The read side already cache-busts correctly (`buildAppBindingArtifactPath(..., revision: cache.artifactRevision)` + browser dedup by revision), so once a real rebuild happens the app picks it up.

## Testing

- `pnpm --filter app run typecheck`
- `pnpm --filter app run lint`
- `pnpm --filter api run lint`
- Manual end-to-end: materialize a parquet binding, mutate the source data, rematerialize, confirm `rowCount`/`artifactRevision` change (no-op before this fix).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4df8fd62-21c7-4602-b496-b39b4a18d028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4df8fd62-21c7-4602-b496-b39b4a18d028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

