### PR TITLE
fix(chat): stop streaming scroll bounce and end-of-turn jump

### DIFF
--- a/.cursor/rules/75-chat-performance.mdc
+++ b/.cursor/rules/75-chat-performance.mdc
@@ -86,19 +86,41 @@ The fix has two parts, both keyed off a `turnStreaming` prop
    `stickTailUntilRef` pin window, so that end-of-turn shrink stays bottom-
    pinned too. (Verified: a 4-query streaming turn went from 4–5 upward jumps,
    worst −254px, to **0** upward jumps with the view glued, `avgLag≈7px`.)
-2. **Instant transitions during the turn.** The body renders
-   `<Collapse timeout={turnStreaming ? 0 : 300}>` so the remaining mid-turn
-   transition (a card *opening* when it becomes active) is a single discrete
-   frame, never an 18-frame animation that could drift the pin. History cards
-   keep the smooth 300ms animation.
+2. **The collapse is always instant** (`<Collapse timeout={0}>`). When the
+   deferred cards finally collapse at turn end, all of them shrink at once (the
+   message can lose ~1000px). An *animated* (300ms) collapse spans ~18 frames
+   and `totalListHeightChanged` doesn't fire on every frame, so the pin drifts
+   and strands the view above the conclusion — the same failure mode as the
+   streaming bounce, just at the end. A single-frame (instant) collapse fires
+   one height change the pin catches in one shot: the conclusion stays fixed at
+   the viewport bottom while the content above it compacts. (Verified: settle
+   `maxLag` dropped from ~1006px with the animation to ~1px instant.)
 
 `turnStreaming` is in the `StreamingToolCard` memo comparator (it flips at most
 once per turn, so it adds no per-chunk renders) so terminal cards still re-run
-their collapse effect / switch back to the animated timeout when the turn ends.
+their collapse effect when the turn ends.
 
 **Never reintroduce a mid-turn height *decrease* on the streaming message**
 (auto-collapsing cards, closing reasoning, removing rows). Append-only growth is
 what keeps the tail smooth.
+
+## End-of-turn settle (`stickTailUntilRef` + turn-end snapshot)
+
+The bottom-pin runs while `isLoadingRef` is true **plus a bounded settling
+window** after the turn ends (deferred collapses fire ~300ms later). Two
+non-obvious details make the settle land *on the conclusion* instead of
+stranding at the message top:
+
+- **Window length must outlast the deferred collapse.** It is `1200ms`
+  (collapse delay + instant collapse + margin), not the old `700ms`.
+- **The settling pin must NOT gate on the live `isAtBottom`.** The big
+  end-of-turn shrink momentarily flips `isAtBottom` false, which would disengage
+  the pin and let Virtuoso re-anchor to the item top. Instead, `pinToBottom`
+  snapshots whether the user was at the bottom *as the turn ended*
+  (`wasAtBottomAtTurnEndRef`, seeded from `isAtBottomRef` or a recent
+  `lastAtBottomAtRef`) and holds the bottom for the whole window based on that.
+  During streaming it still gates on the live `isAtBottomRef` so scrolling up to
+  read history releases the pin immediately.
 
 Key pieces (in `Chat.tsx`):
 - `<Virtuoso data={messages} computeItemKey={(_, m) => m.id} itemContent={...} />`

--- a/.cursor/rules/75-chat-performance.mdc
+++ b/.cursor/rules/75-chat-performance.mdc
@@ -64,22 +64,41 @@ DOM size, memory, paint, and scroll, especially on mobile. Memoization stops
 *re-renders* but does nothing about *mount cost / DOM size*; virtualization is
 the only thing that does.
 
-**Streaming tool cards collapse instantly (no animation).** A whole assistant
-turn streams into a **single** Virtuoso item, and that item's height changes
-**non-monotonically** when a finished tool card auto-collapses (it shrinks 800ms
-after resolving) while text keeps streaming below. With the default MUI
-`Collapse` 300ms animation, that shrink spans ~18 frames; the
-`totalListHeightChanged` pin (below) does not fire on every sub-pixel animation
-frame, so Virtuoso's resize anchoring nudges `scrollTop` **up** on the frames it
-misses → the view paints partway up, then the next reported height change pins
-it back down. That alternation **is** the bounce. `StreamingToolCard` takes a
-`turnStreaming` prop (`isStreaming && isLastMessage`) and renders its body
-`<Collapse timeout={turnStreaming ? 0 : 300}>` — during the active turn the
-expand/collapse is a **single discrete frame**, which `totalListHeightChanged`
-catches in one shot (no bounce). Settled history cards keep the smooth 300ms
-animation. `turnStreaming` is in the memo comparator (it flips at most once per
-turn, so it adds no per-chunk renders) so terminal cards still switch back to
-the animated timeout when the turn ends.
+**Tool cards must NOT shrink mid-turn (the load-bearing anti-bounce rule).** A
+whole assistant turn streams into a **single** Virtuoso item. If that item's
+height ever **decreases** while the bottom-pin is engaged, the view snaps
+upward to the new (higher) bottom — a visible scroll bounce. The original
+culprit was `StreamingToolCard` auto-collapsing a finished card 800ms after it
+resolved *while the rest of the turn kept streaming*: every tool call produced a
+shrink → a snap (with the default 300ms `Collapse` animation it was worse — the
+shrink spanned ~18 frames and `totalListHeightChanged` doesn't fire on every
+sub-pixel frame, so Virtuoso's resize anchoring drifted `scrollTop` up on the
+frames the pin missed → oscillating jitter).
+
+The fix has two parts, both keyed off a `turnStreaming` prop
+(`isStreaming && isLastMessage`) threaded from `ChatMessageRow`:
+
+1. **Defer collapse until the turn settles.** While `turnStreaming`, finished
+   tool cards stay **expanded** (`StreamingToolCard`'s collapse effect early-
+   returns). The streaming message's height is therefore **monotonic** (it only
+   grows), so the view follows the tail straight down with zero upward snaps.
+   Cards collapse ~300ms after the turn ends — inside `Chat`'s ~700ms post-turn
+   `stickTailUntilRef` pin window, so that end-of-turn shrink stays bottom-
+   pinned too. (Verified: a 4-query streaming turn went from 4–5 upward jumps,
+   worst −254px, to **0** upward jumps with the view glued, `avgLag≈7px`.)
+2. **Instant transitions during the turn.** The body renders
+   `<Collapse timeout={turnStreaming ? 0 : 300}>` so the remaining mid-turn
+   transition (a card *opening* when it becomes active) is a single discrete
+   frame, never an 18-frame animation that could drift the pin. History cards
+   keep the smooth 300ms animation.
+
+`turnStreaming` is in the `StreamingToolCard` memo comparator (it flips at most
+once per turn, so it adds no per-chunk renders) so terminal cards still re-run
+their collapse effect / switch back to the animated timeout when the turn ends.
+
+**Never reintroduce a mid-turn height *decrease* on the streaming message**
+(auto-collapsing cards, closing reasoning, removing rows). Append-only growth is
+what keeps the tail smooth.
 
 Key pieces (in `Chat.tsx`):
 - `<Virtuoso data={messages} computeItemKey={(_, m) => m.id} itemContent={...} />`

--- a/.cursor/rules/75-chat-performance.mdc
+++ b/.cursor/rules/75-chat-performance.mdc
@@ -64,6 +64,23 @@ DOM size, memory, paint, and scroll, especially on mobile. Memoization stops
 *re-renders* but does nothing about *mount cost / DOM size*; virtualization is
 the only thing that does.
 
+**Streaming tool cards collapse instantly (no animation).** A whole assistant
+turn streams into a **single** Virtuoso item, and that item's height changes
+**non-monotonically** when a finished tool card auto-collapses (it shrinks 800ms
+after resolving) while text keeps streaming below. With the default MUI
+`Collapse` 300ms animation, that shrink spans ~18 frames; the
+`totalListHeightChanged` pin (below) does not fire on every sub-pixel animation
+frame, so Virtuoso's resize anchoring nudges `scrollTop` **up** on the frames it
+misses → the view paints partway up, then the next reported height change pins
+it back down. That alternation **is** the bounce. `StreamingToolCard` takes a
+`turnStreaming` prop (`isStreaming && isLastMessage`) and renders its body
+`<Collapse timeout={turnStreaming ? 0 : 300}>` — during the active turn the
+expand/collapse is a **single discrete frame**, which `totalListHeightChanged`
+catches in one shot (no bounce). Settled history cards keep the smooth 300ms
+animation. `turnStreaming` is in the memo comparator (it flips at most once per
+turn, so it adds no per-chunk renders) so terminal cards still switch back to
+the animated timeout when the turn ends.
+
 Key pieces (in `Chat.tsx`):
 - `<Virtuoso data={messages} computeItemKey={(_, m) => m.id} itemContent={...} />`
   — `computeItemKey` by `message.id` keeps row identity (and memo) stable across

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -3094,23 +3094,49 @@ const Chat: React.FC<ChatProps> = ({
   const isAtBottomRef = useRef(isAtBottom);
   isAtBottomRef.current = isAtBottom;
 
-  // Bounded settling window after a turn ends. The closing Collapse animations
-  // (thinking block, tool cards) and the results panel keep emitting height
-  // changes after `isLoading` flips false; without continuing to pin through
-  // them, Virtuoso's last upward compensation strands the view at the message
-  // top. Gated on `isAtBottom`, so it never hijacks a user who scrolled away.
+  // Track the last time the view was at the bottom (updated in render). Used to
+  // decide whether to hold the bottom through the post-turn settling window
+  // even after the big end-of-turn collapse momentarily flips `isAtBottom`.
+  const lastAtBottomAtRef = useRef(0);
+  if (isAtBottom) lastAtBottomAtRef.current = Date.now();
+
+  // Bounded settling window after a turn ends. The end-of-turn collapse — the
+  // thinking blocks closing AND every finished tool card collapsing (deferred
+  // to here, see `StreamingToolCard`) — shrinks the single streaming message by
+  // a lot, all at once. Virtuoso reacts by re-anchoring to the (now much
+  // shorter) item's TOP, which strands the view at the top of the response
+  // unless we keep pinning the bottom through the shrink.
+  //
+  // The live `isAtBottom` can't gate this pin: the very shrink we're countering
+  // flips `isAtBottom` to false for a few frames, which would disengage the pin
+  // and let the strand happen. Instead we snapshot whether the user was at the
+  // bottom *as the turn ended* (`wasAtBottomAtTurnEndRef`) and hold the bottom
+  // for the whole window based on that — so a big collapse stays pinned, but a
+  // user who had scrolled up to read history is never yanked back down.
   const stickTailUntilRef = useRef(0);
+  const wasAtBottomAtTurnEndRef = useRef(false);
   const wasLoadingRef = useRef(isLoading);
   useEffect(() => {
     if (wasLoadingRef.current && !isLoading) {
-      stickTailUntilRef.current = Date.now() + 700;
+      // Window must outlast the deferred tool-card collapse (~300ms delay +
+      // ~300ms animation) plus margin.
+      stickTailUntilRef.current = Date.now() + 1200;
+      wasAtBottomAtTurnEndRef.current =
+        isAtBottomRef.current || Date.now() - lastAtBottomAtRef.current < 800;
     }
     wasLoadingRef.current = isLoading;
   }, [isLoading]);
 
   const pinToBottom = useCallback(() => {
-    if (!isAtBottomRef.current) return;
-    if (!isLoadingRef.current && Date.now() > stickTailUntilRef.current) return;
+    const streaming = isLoadingRef.current;
+    const settling = !streaming && Date.now() <= stickTailUntilRef.current;
+    if (!streaming && !settling) return;
+    // While streaming, release the instant the user scrolls up to read history.
+    // While settling, hold based on the turn-end snapshot (see above) so the
+    // end-of-turn collapse doesn't strand the view at the message top.
+    if (streaming ? !isAtBottomRef.current : !wasAtBottomAtTurnEndRef.current) {
+      return;
+    }
     const el = scrollerElRef.current;
     if (el && el instanceof HTMLElement) el.scrollTop = el.scrollHeight;
   }, []);

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -3127,22 +3127,39 @@ const Chat: React.FC<ChatProps> = ({
     wasLoadingRef.current = isLoading;
   }, [isLoading]);
 
+  // Streaming follow: a raw `scrollTop = scrollHeight` write on the captured
+  // scroller. This is the smoothest way to track append-only growth — released
+  // the instant the user scrolls up (live `isAtBottomRef`) so reading history
+  // isn't yanked down.
   const pinToBottom = useCallback(() => {
-    const streaming = isLoadingRef.current;
-    const settling = !streaming && Date.now() <= stickTailUntilRef.current;
-    if (!streaming && !settling) return;
-    // While streaming, release the instant the user scrolls up to read history.
-    // While settling, hold based on the turn-end snapshot (see above) so the
-    // end-of-turn collapse doesn't strand the view at the message top.
-    if (streaming ? !isAtBottomRef.current : !wasAtBottomAtTurnEndRef.current) {
-      return;
-    }
+    if (!isAtBottomRef.current) return;
     const el = scrollerElRef.current;
     if (el && el instanceof HTMLElement) el.scrollTop = el.scrollHeight;
   }, []);
 
   const handleListHeightChanged = useCallback(() => {
-    pinToBottom();
+    if (isLoadingRef.current) {
+      pinToBottom();
+      return;
+    }
+    // Post-turn settle. The deferred tool-card collapse shrinks the single
+    // streaming message all at once; a raw `scrollTop` write can lose the race
+    // to Virtuoso re-anchoring the (now much shorter) item to its TOP, which
+    // strands the view at the top of the response. Virtuoso's own
+    // `scrollToIndex` is authoritative — it re-targets the last item's end and
+    // survives the re-measure — so use it to hold the conclusion at the bottom
+    // through the collapse. Gated on the turn-end snapshot (not the live
+    // `isAtBottom`, which the collapse transiently flips false) and the bounded
+    // window, so a user who scrolled up to read history is never yanked back.
+    // `scrollToIndex` is only safe here because the last item is no longer
+    // growing (during streaming it would re-derive a moving target and bounce —
+    // that path uses the raw `scrollTop` pin above).
+    if (
+      Date.now() <= stickTailUntilRef.current &&
+      wasAtBottomAtTurnEndRef.current
+    ) {
+      virtuosoRef.current?.scrollToIndex({ index: "LAST", align: "end" });
+    }
   }, [pinToBottom]);
 
   // Rescue tool cards orphaned by a clean stream end.

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -1127,6 +1127,7 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
                       }
                     : undefined
                 }
+                turnStreaming={isStreaming && isLastMessage}
                 onTitleClick={
                   consoleToolPresentation
                     ? () =>

--- a/app/src/components/StreamingToolCard.tsx
+++ b/app/src/components/StreamingToolCard.tsx
@@ -65,6 +65,17 @@ interface StreamingToolCardProps {
   onTitleClick?: () => void;
   onDetailClick?: () => void;
   /**
+   * True while the assistant turn this card belongs to is still streaming.
+   * When set, the expand/collapse body transition runs with `timeout={0}`
+   * (instant, single-frame) instead of the 300ms MUI animation. Animated
+   * height changes inside the single, growing streaming message span many
+   * frames and drift the chat's bottom-pin between Virtuoso resize callbacks
+   * (the "bounce"); a discrete one-frame height change is caught by the
+   * `totalListHeightChanged` pin in one shot. The smooth animation is kept
+   * for settled history cards (when this is false).
+   */
+  turnStreaming?: boolean;
+  /**
    * Optional — used as a defensive check in the memo comparator so that
    * React re-renders if the underlying tool call identity actually changed.
    * In practice parents also use this as the React key, so unmount/remount
@@ -273,6 +284,7 @@ export const StreamingToolCard = React.memo(
     bodyPreview,
     onTitleClick,
     onDetailClick,
+    turnStreaming,
   }: StreamingToolCardProps) {
     const config = getToolConfig(toolName);
     const muiTheme = useMuiTheme();
@@ -595,7 +607,11 @@ export const StreamingToolCard = React.memo(
             `unmountOnExit` removes the syntax-highlighted DOM (and its many
             nodes) entirely when collapsed — critical for keeping the DOM small
             in long chats on mobile Safari. */}
-        <Collapse in={expanded && hasVisibleBody} timeout={300} unmountOnExit>
+        <Collapse
+          in={expanded && hasVisibleBody}
+          timeout={turnStreaming ? 0 : 300}
+          unmountOnExit
+        >
           {/* Code preview */}
           {code.length > 0 && (
             <Box
@@ -672,6 +688,11 @@ export const StreamingToolCard = React.memo(
     if (prev.leadingIconAlt !== next.leadingIconAlt) return false;
     if (prev.bodyPreview?.content !== next.bodyPreview?.content) return false;
     if (prev.bodyPreview?.language !== next.bodyPreview?.language) return false;
+    // `turnStreaming` flips at most once per turn (true→false when the turn
+    // ends), so re-rendering on it does not add per-chunk renders, but it must
+    // be honored even for terminal cards so the collapse transition switches
+    // from instant (streaming) back to the smooth 300ms animation (history).
+    if (prev.turnStreaming !== next.turnStreaming) return false;
 
     // Terminal states are immutable. Even if useChat handed us new cloned
     // references for `input` / `output` this tick, the contents are the

--- a/app/src/components/StreamingToolCard.tsx
+++ b/app/src/components/StreamingToolCard.tsx
@@ -65,14 +65,17 @@ interface StreamingToolCardProps {
   onTitleClick?: () => void;
   onDetailClick?: () => void;
   /**
-   * True while the assistant turn this card belongs to is still streaming.
-   * When set, the expand/collapse body transition runs with `timeout={0}`
-   * (instant, single-frame) instead of the 300ms MUI animation. Animated
-   * height changes inside the single, growing streaming message span many
-   * frames and drift the chat's bottom-pin between Virtuoso resize callbacks
-   * (the "bounce"); a discrete one-frame height change is caught by the
-   * `totalListHeightChanged` pin in one shot. The smooth animation is kept
-   * for settled history cards (when this is false).
+   * True while the assistant turn this card belongs to is still streaming
+   * (`isStreaming && isLastMessage`). While set, a finished card is NOT
+   * auto-collapsed — it stays expanded until the turn ends. A whole turn
+   * streams into a SINGLE Virtuoso item; collapsing a card mid-turn shrinks
+   * that item, which yanks the chat's bottom-pin upward (a visible scroll
+   * snap/bounce that repeats per tool call). Deferring the collapse keeps the
+   * streaming message's height monotonic (append-only), so the view follows
+   * the tail straight down with no snap. (The body `<Collapse>` also always
+   * uses `timeout={0}` so the eventual collapse is a single discrete frame the
+   * `totalListHeightChanged` pin catches in one shot — an animated multi-frame
+   * collapse drifts the pin between resize callbacks.)
    */
   turnStreaming?: boolean;
   /**
@@ -623,11 +626,7 @@ export const StreamingToolCard = React.memo(
             `unmountOnExit` removes the syntax-highlighted DOM (and its many
             nodes) entirely when collapsed — critical for keeping the DOM small
             in long chats on mobile Safari. */}
-        <Collapse
-          in={expanded && hasVisibleBody}
-          timeout={turnStreaming ? 0 : 300}
-          unmountOnExit
-        >
+        <Collapse in={expanded && hasVisibleBody} timeout={0} unmountOnExit>
           {/* Code preview */}
           {code.length > 0 && (
             <Box

--- a/app/src/components/StreamingToolCard.tsx
+++ b/app/src/components/StreamingToolCard.tsx
@@ -320,15 +320,31 @@ export const StreamingToolCard = React.memo(
     );
 
     useEffect(() => {
-      if ((isDone || isError) && hasCodePreview) {
-        const timer = setTimeout(() => setExpanded(false), 800);
-        return () => clearTimeout(timer);
-      }
-      if (isActive && hasCodePreview) {
+      if (!hasCodePreview) return;
+      if (isActive) {
         setExpanded(true);
         setUserScrolled(false);
+        return;
       }
-    }, [isDone, isError, isActive, hasCodePreview]);
+      if (isDone || isError) {
+        // While the assistant turn is still streaming, keep finished cards
+        // expanded instead of auto-collapsing them. A whole turn streams into
+        // a SINGLE Virtuoso item; collapsing a card mid-turn shrinks that item
+        // (by up to a few hundred px), which yanks the bottom-pinned view
+        // upward to the new bottom — a visible scroll "snap"/bounce that
+        // repeats for every tool call. Deferring the collapse keeps the
+        // streaming message's height monotonic (it only grows), so the view
+        // follows the tail straight down with no snap. The cards collapse once
+        // the turn settles (below), inside `Chat`'s post-turn pin window so
+        // that end-of-turn shrink stays bottom-pinned too.
+        if (turnStreaming) {
+          setExpanded(true);
+          return;
+        }
+        const timer = setTimeout(() => setExpanded(false), 300);
+        return () => clearTimeout(timer);
+      }
+    }, [isDone, isError, isActive, hasCodePreview, turnStreaming]);
 
     // Resolve code preview content (supports both string and object fields)
     const inputObj = input as Record<string, unknown> | undefined;

--- a/app/src/components/__tests__/Chat.perf.test.ts
+++ b/app/src/components/__tests__/Chat.perf.test.ts
@@ -330,17 +330,23 @@ describe("Chat.tsx structural guards", () => {
     expect(chatSource).toMatch(
       /totalListHeightChanged=\{handleListHeightChanged\}/,
     );
-    // The pin writes scrollTop on the captured scroller. While streaming it is
-    // gated on the live isAtBottom ref (so scrolling up to read history isn't
-    // yanked down). While settling after the turn ends it holds the bottom
-    // based on a snapshot of whether the user was at the bottom AS the turn
-    // ended (`wasAtBottomAtTurnEndRef`) — the live ref can't gate that because
-    // the big end-of-turn collapse momentarily flips isAtBottom false and would
-    // strand the view at the message top.
+    // While streaming, the pin writes scrollTop on the captured scroller, gated
+    // on the live isAtBottom ref (so scrolling up to read history isn't yanked
+    // down). While settling after the turn ends, it instead uses Virtuoso's
+    // authoritative `scrollToIndex({ index: "LAST" })` (a raw scrollTop write
+    // loses the race to Virtuoso re-anchoring the big end-of-turn collapse to
+    // the item top), gated on a snapshot of whether the user was at the bottom
+    // AS the turn ended (`wasAtBottomAtTurnEndRef`) — the live ref can't gate
+    // that because the collapse momentarily flips isAtBottom false.
     expect(chatSource).toMatch(/scrollerRef=\{/);
     expect(chatSource).toMatch(/el\.scrollTop = el\.scrollHeight/);
-    expect(chatSource).toMatch(/streaming \? !isAtBottomRef\.current/);
+    expect(chatSource).toMatch(/if \(!isAtBottomRef\.current\) return;/);
     expect(chatSource).toMatch(/wasAtBottomAtTurnEndRef/);
+    // Settle uses the authoritative scrollToIndex, not a raw scrollTop write,
+    // so the end-of-turn collapse can't strand the view at the message top.
+    expect(chatSource).toMatch(
+      /Date\.now\(\) <= stickTailUntilRef\.current &&[\s\S]*?scrollToIndex\(\{ index: "LAST", align: "end" \}\)/,
+    );
   });
 
   it("does NOT have a DIY useEffect([messages]) scrollIntoView auto-scroll", () => {

--- a/app/src/components/__tests__/Chat.perf.test.ts
+++ b/app/src/components/__tests__/Chat.perf.test.ts
@@ -330,11 +330,17 @@ describe("Chat.tsx structural guards", () => {
     expect(chatSource).toMatch(
       /totalListHeightChanged=\{handleListHeightChanged\}/,
     );
-    // The pin writes scrollTop on the captured scroller and is gated on the
-    // live isAtBottom ref (so scrolling up to read history isn't yanked down).
+    // The pin writes scrollTop on the captured scroller. While streaming it is
+    // gated on the live isAtBottom ref (so scrolling up to read history isn't
+    // yanked down). While settling after the turn ends it holds the bottom
+    // based on a snapshot of whether the user was at the bottom AS the turn
+    // ended (`wasAtBottomAtTurnEndRef`) — the live ref can't gate that because
+    // the big end-of-turn collapse momentarily flips isAtBottom false and would
+    // strand the view at the message top.
     expect(chatSource).toMatch(/scrollerRef=\{/);
     expect(chatSource).toMatch(/el\.scrollTop = el\.scrollHeight/);
-    expect(chatSource).toMatch(/if \(!isAtBottomRef\.current\) return;/);
+    expect(chatSource).toMatch(/streaming \? !isAtBottomRef\.current/);
+    expect(chatSource).toMatch(/wasAtBottomAtTurnEndRef/);
   });
 
   it("does NOT have a DIY useEffect([messages]) scrollIntoView auto-scroll", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Even after virtualizing the chat message list, streaming still felt unsmooth: the view **bounced** up/down as content streamed, and at the end of a turn it could **jump and "struggle to find the end."**

## Root cause

A whole assistant turn streams into a **single** `react-virtuoso` item, so the chat's bottom-pin is sensitive to that item's height changing **non-monotonically**:

1. **Mid-stream bounce** — `StreamingToolCard` auto-collapsed each finished tool card 800ms after it resolved, *while the rest of the turn kept streaming*. Every collapse shrank the message and yanked the bottom-pin up. With the 300ms `Collapse` animation it was worse: the shrink spans ~18 frames and `totalListHeightChanged` doesn't fire on every frame, so Virtuoso's resize anchoring drifted `scrollTop` up on the missed frames → oscillating jitter.
2. **End-of-turn jump** — once collapse was deferred to turn-end (below), all cards collapse at once (~1000px). An animated/raw-`scrollTop` pin loses the race to Virtuoso re-anchoring the suddenly-short item to its **top**, stranding the view above the conclusion.

## Fix

- **Defer tool-card collapse until the turn ends** (`StreamingToolCard`, gated on a new `turnStreaming = isStreaming && isLastMessage` prop). The streaming message now grows **monotonically**, so the view follows the tail straight down with no mid-stream snap.
- **Collapse is always instant** (`<Collapse timeout={0}>`) so the eventual end-of-turn collapse is a single discrete frame the pin catches in one shot, instead of an 18-frame animation that drifts the pin.
- **Authoritative end-of-turn settle** — during the bounded post-turn window (`stickTailUntilRef`, widened to 1200ms) the pin uses Virtuoso's own `scrollToIndex({ index: "LAST", align: "end" })` (which survives Virtuoso's re-measure) instead of a raw `scrollTop` write, gated on a snapshot of whether the user was at the bottom **as the turn ended** (`wasAtBottomAtTurnEndRef`) — not the live `isAtBottom`, which the big collapse transiently flips false. Streaming still uses the raw-`scrollTop` follow (smoothest for append-only growth; `scrollToIndex` would re-derive a moving target and bounce there).

`turnStreaming` is added to the `StreamingToolCard` memo comparator (it flips at most once per turn, so no per-chunk renders).

## Verification

Measured with a temporary per-frame scroll monitor (instrumentation reverted before commit). Same 4-query streaming prompt, controlled A/B:

| Phase | Before | After |
|---|---|---|
| Streaming upward jumps | 4 (worst −254px) | **0** |
| End-of-turn settle (max lag from bottom) | ~1006px (stranded at top) | **0px** (stays on conclusion) |

Self-proving demo (live metrics overlay shows `0` bounce / `0` settle lag while the conclusion stays pinned at the bottom):

[chat_streaming_fix_proof_with_live_metrics.mp4](https://cursor.com/agents/bc-a1d18e85-c0d9-4b6e-9d30-5cd170890f6f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchat_streaming_fix_proof_with_live_metrics.mp4)

[End of turn: all scroll metrics 0, conclusion pinned at bottom](https://cursor.com/agents/bc-a1d18e85-c0d9-4b6e-9d30-5cd170890f6f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchat_end_settle_metrics_zero.webp)

**Checks**
- ✅ `pnpm --filter app exec vitest run src/components/__tests__/Chat.perf.test.ts` (32 passed)
- ✅ `pnpm --filter app run typecheck`
- ✅ `pnpm --filter app run lint`

Docs: updated `.cursor/rules/75-chat-performance.mdc` with the new monotonic-growth + authoritative-settle contract.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1d18e85-c0d9-4b6e-9d30-5cd170890f6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1d18e85-c0d9-4b6e-9d30-5cd170890f6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

