### PR TITLE
docs: reflect v1 'App created' baseline on app creation (#601)

### DIFF
--- a/docs/src/content/docs/apps.md
+++ b/docs/src/content/docs/apps.md
@@ -76,7 +76,7 @@ Use distinct **paths** for separate views (`/`, `/customers/42`) and **query par
 
 ## Versioning & Publishing
 
-Apps autosave every edit, so what you (or the AI agent) work on is a **draft**. To create an immutable checkpoint, **save a version** — this snapshots the current draft into version history *and* **publishes** it.
+Apps autosave every edit, so what you (or the AI agent) work on is a **draft**. Every app starts with a v1 `App created` checkpoint (also its first published version), so version history is never empty. To create a further immutable checkpoint, **save a version** — this snapshots the current draft into version history *and* **publishes** it.
 
 - Public and shared links render the **published** version, never the live draft, so viewers never see a half-finished edit.
 - **Restoring** a past version reverts the draft (snapshotting the current draft first, so it's never lossy) but does **not** auto-publish — save a version afterward to push the restored state live.

--- a/docs/src/content/docs/version-history.md
+++ b/docs/src/content/docs/version-history.md
@@ -36,7 +36,7 @@ All endpoints live under the workspace path and require workspace membership.
 
 ### Apps
 
-Apps autosave every edit, so versions are explicit **checkpoints** rather than per-save snapshots. Saving a version also **publishes** it (see [Drafts & publishing](#drafts--publishing-apps) below).
+Apps autosave every edit, so versions are explicit **checkpoints** rather than per-save snapshots. Saving a version also **publishes** it (see [Drafts & publishing](#drafts--publishing-apps) below). Unlike older builds, every app now seeds a v1 `App created` published baseline at creation time (both the REST `POST /apps` and the agent `create_app` tool), so an app's version history is never empty.
 
 | Method | Endpoint                                                  | Description                              |
 | ------ | --------------------------------------------------------- | ---------------------------------------- |
@@ -111,6 +111,7 @@ Optional body on restore: `{ "comment": "Reverting because X" }`. If omitted, th
 Apps use a **draft → published** split:
 
 - The files, dependencies, and bindings you edit are the working **draft**, autosaved on every edit. Editors (and the AI agent) always see the draft in the live preview.
+- A freshly created app starts with a v1 `App created` checkpoint that is also the initial published version, so version history exists from the first moment (no explicit save required).
 - **Saving a version** snapshots the current draft into history *and* sets it as the **published** definition — the one that public/shared links and viewers render. A half-finished or in-progress draft is therefore never shown to viewers until you save a version.
 - The app document tracks `publishedVersion`, `publishedAt`, and a `hasUnpublishedChanges` flag so the UI can show when the draft has drifted from what viewers see.
 - **Restoring** reverts the *draft* to a past checkpoint (snapshotting the current draft first, so it is never lossy). Restore does **not** auto-publish — save a version afterward to push the restored state live. Binding materialization caches are preserved by binding id across restore.
@@ -123,7 +124,7 @@ Open the **version history panel** from any saved console, dashboard, or app. It
 - Restore any past version with one click
 - Optionally add a commit comment when saving via the save dialog
 
-Unsaved drafts have no version history yet; the history button is disabled until the first save.
+For **consoles and dashboards**, an unsaved draft has no version history yet, so the history button stays disabled until the first explicit save. **Apps** always have at least a v1 `App created` checkpoint, so their history is available immediately — and the app preview toolbar carries a **Version History** button that opens the panel for the open app.
 
 ## AI Agent Tools
 
@@ -148,3 +149,4 @@ Both tools are workspace-scoped: the assistant can only browse entities inside t
 - Version history is enabled by default for every workspace; no configuration needed.
 - The `EntityVersion` collection was introduced in migration `2026-04-05-075746_add_entity_versions_collection`.
 - History is append-only — there is no hard delete, even on restore.
+- Apps created before the initial-version fix were backfilled with a v1 snapshot by migration `2026-06-27-145356_backfill_initial_app_version` (idempotent — apps that already had a version are skipped).


### PR DESCRIPTION
## What

PR #601 changed app creation to seed a **v1 `App created`** published version (both REST `POST /apps` and the agent `create_app` tool), added a backfill migration for existing apps, and added a **Version History** button to the app preview toolbar. The docs weren't updated to match.

### P0 — factually wrong
- `version-history.md` said *"Unsaved drafts have no version history yet; the history button is disabled until the first save."* — now wrong for apps, which always have a v1 checkpoint.

### Fixes
- **apps.md** — Versioning & Publishing: note every app starts with a v1 `App created` checkpoint.
- **version-history.md**:
  - Apps REST section: v1-on-create from REST + agent.
  - Drafts & publishing (apps): added the v1-on-create bullet.
  - UI section: split behavior — consoles/dashboards stay disabled until first save; apps have history immediately + the new toolbar button.
  - Notes: documented backfill migration `2026-06-27-145356_backfill_initial_app_version`.

Docs-only. No code changes.

🤖 Daily mako-docs-maintenance run.