### PR TITLE
guides: PHP connection guides — mariadb + mssql (PHP axis complete)

### DIFF
--- a/content/guides/mariadb/connect-from-php.mdx
+++ b/content/guides/mariadb/connect-from-php.mdx
@@ -1,0 +1,179 @@
+---
+title: "How to Connect to MariaDB from PHP"
+description: "Connect to MariaDB from PHP with PDO and mysqli: why the MySQL drivers work, the utf8mb4 charset trap, the ed25519 authentication gotcha, RETURNING, transactions, SSL, and the errors you actually hit."
+database: "mariadb"
+category: "how-to"
+tags: ["mariadb", "php", "pdo", "mysqli", "pdo-mysql", "connection"]
+date: "2026-06-30"
+---
+
+PHP has no MariaDB-specific extension, and it does not need one. MariaDB began as a fork of MySQL and kept the wire protocol compatible, so the same two built-in extensions that talk to MySQL talk to MariaDB: the database-agnostic PDO layer with its `pdo_mysql` driver, and the MySQL-specific `mysqli` extension. For new code, PDO with `pdo_mysql` is the right default. It gives you a portable API, real prepared statements, and a clean exception model. This guide covers both supported extensions, the charset that trips everyone up, the one authentication method that genuinely does not work from PHP, prepared statements, transactions, SSL, and the errors you will meet. It is written against PHP 8.5 (8.5.7 as of June 2026) and MariaDB 11, but everything except the driver-subclass note works on PHP 8.1+.
+
+## Which extension to use
+
+Two extensions ship with PHP, and both connect to MariaDB without modification:
+
+- **PDO with `pdo_mysql`** is the portable, object-oriented choice. The same interface works across databases, errors raise exceptions, and you get named or positional placeholders. Use this unless you have a specific reason not to.
+- **`mysqli`** is the MySQL-and-MariaDB-specific extension. It exposes a few protocol-level features such as multiple-statement execution and asynchronous queries. Reach for it only when you actually need those.
+
+There is no `pdo_mariadb` and no `mariadb` extension in core PHP. The `pdo_mysql` driver name in the DSN stays `mysql` even when the server is MariaDB. The old `mysql_*` functions were removed in PHP 7.0; if you find them in a codebase, that code is overdue for a rewrite.
+
+Check that the driver is loaded:
+
+```bash
+php -m | grep mysql
+# expect: pdo_mysql  (and/or mysqli)
+```
+
+On Debian/Ubuntu, `apt install php-mysql` provides both.
+
+## Connecting with PDO
+
+The most common mistake connecting to MariaDB (and MySQL) from PHP is leaving the charset out of the DSN, or setting it to `utf8`. MariaDB's `utf8` is a three-byte encoding that cannot store emoji or many CJK characters. You almost always want `utf8mb4`. Put it in the DSN so the connection negotiates it from the first byte:
+
+```php
+<?php
+$dsn = 'mysql:host=127.0.0.1;port=3306;dbname=shop;charset=utf8mb4';
+
+$pdo = new PDO($dsn, 'appuser', 'secret', [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES   => false,
+]);
+```
+
+Those three options matter:
+
+- `ERRMODE_EXCEPTION` makes failures throw `PDOException` instead of returning `false`. Without it, a broken query silently returns nothing and you debug a `null` three layers up.
+- `FETCH_ASSOC` returns rows as associative arrays instead of the default duplicated numeric-plus-named arrays.
+- `ATTR_EMULATE_PREPARES => false` turns off PDO's client-side prepare emulation, which is **on by default for MySQL and MariaDB**. With emulation off, the server does the parameter binding, integers come back typed instead of as strings, and the query plan is cached on the server.
+
+### Prepared statements
+
+Never interpolate user input into SQL. Use placeholders:
+
+```php
+$stmt = $pdo->prepare('SELECT id, name, price FROM products WHERE price > :min');
+$stmt->execute([':min' => 100]);
+
+foreach ($stmt as $row) {
+    echo "{$row['id']}: {$row['name']} ({$row['price']})\n";
+}
+```
+
+PDO supports named (`:min`) and positional (`?`) placeholders, but you cannot mix the two styles in one statement. Placeholders stand in for values only, never for table or column names.
+
+## The ed25519 authentication gotcha
+
+This is the one MariaDB-specific trap, and it is easy to lose hours to. MariaDB ships its own authentication plugins. The default for new installs is usually `mysql_native_password` (still supported and fine), but many MariaDB deployments use `ed25519`, MariaDB's own strong password plugin. **PHP's `pdo_mysql` and `mysqli` clients do not implement the ed25519 client handshake.** If a user is defined with `IDENTIFIED VIA ed25519`, a connection from PHP fails with an authentication-plugin error no matter how correct the password is.
+
+You have two honest options:
+
+1. Authenticate the PHP application's user with `mysql_native_password` (or, on MariaDB 11.6+, the newer `parsec` plugin only if your client library supports it):
+
+   ```sql
+   ALTER USER 'appuser'@'%' IDENTIFIED VIA mysql_native_password USING PASSWORD('secret');
+   ```
+
+2. Use a connector that bundles ed25519 support. PHP core does not, so this means stepping outside the built-in extensions, which most teams avoid.
+
+Note the difference from MySQL here: MySQL 8 defaults to `caching_sha2_password`, which PHP's drivers do support (over TLS or with the server public key). MariaDB does **not** use `caching_sha2_password` at all, so that particular MySQL headache does not apply. The MariaDB-specific headache is ed25519. Check what a user is using:
+
+```sql
+SELECT user, host, plugin FROM mysql.user WHERE user = 'appuser';
+```
+
+## RETURNING for generated keys
+
+MariaDB added `INSERT ... RETURNING` in 10.5, years before MySQL had anything equivalent. If you target MariaDB specifically, you can read generated columns straight back from the insert instead of a second round trip to `lastInsertId()`:
+
+```php
+$stmt = $pdo->prepare(
+    'INSERT INTO products (name, price) VALUES (:name, :price) RETURNING id'
+);
+$stmt->execute([':name' => 'Wrench', ':price' => 19.90]);
+$id = $stmt->fetchColumn();
+```
+
+`RETURNING` runs as a result-set query, so fetch from the statement rather than calling `execute()` and discarding it. If you need code that runs against both MariaDB and MySQL, stick with `lastInsertId()`, which works on both:
+
+```php
+$pdo->prepare('INSERT INTO products (name, price) VALUES (?, ?)')
+    ->execute(['Wrench', 19.90]);
+$id = $pdo->lastInsertId();
+```
+
+## Transactions
+
+Wrap multi-statement work so a failure rolls everything back. This requires InnoDB (the default storage engine on modern MariaDB); the legacy MyISAM and Aria engines ignore transactions and silently commit each statement:
+
+```php
+$pdo->beginTransaction();
+try {
+    $pdo->prepare('UPDATE accounts SET balance = balance - ? WHERE id = ?')
+        ->execute([100, 1]);
+    $pdo->prepare('UPDATE accounts SET balance = balance + ? WHERE id = ?')
+        ->execute([100, 2]);
+    $pdo->commit();
+} catch (\Throwable $e) {
+    $pdo->rollBack();
+    throw $e;
+}
+```
+
+DDL statements such as `CREATE TABLE` and `ALTER TABLE` cause an implicit commit in MariaDB; you cannot roll them back as part of a transaction. Keep schema changes out of transactional code paths.
+
+## TLS connections
+
+For connections that cross a network, require TLS and verify the server certificate. Passing the CA tells the client to encrypt; you also want to confirm the server's identity rather than accept any certificate:
+
+```php
+$pdo = new PDO($dsn, 'appuser', 'secret', [
+    PDO::ATTR_ERRMODE                  => PDO::ERRMODE_EXCEPTION,
+    PDO::MYSQL_ATTR_SSL_CA             => '/etc/ssl/certs/mariadb-ca.pem',
+    PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => true,
+]);
+```
+
+Setting `MYSQL_ATTR_SSL_VERIFY_SERVER_CERT` to `false` encrypts the traffic but accepts any certificate, which leaves you open to a man-in-the-middle. Only do that for local debugging, never in production.
+
+## Connecting with mysqli
+
+If you need a `mysqli`-only feature, the interface is there. Enable exceptions first; otherwise `mysqli` reports errors through return values:
+
+```php
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$mysqli = new mysqli('127.0.0.1', 'appuser', 'secret', 'shop', 3306);
+$mysqli->set_charset('utf8mb4');
+
+$stmt = $mysqli->prepare('SELECT id, name FROM products WHERE price > ?');
+$stmt->bind_param('d', $minPrice);  // 'd' = double
+$minPrice = 100;
+$stmt->execute();
+$result = $stmt->get_result();
+
+while ($row = $result->fetch_assoc()) {
+    echo "{$row['id']}: {$row['name']}\n";
+}
+```
+
+`mysqli` uses `?` positional placeholders only, and `bind_param` requires a type string (`i` integer, `d` double, `s` string, `b` blob). Set the charset with `set_charset('utf8mb4')` rather than running a `SET NAMES` query, because `set_charset` also updates the client's idea of the encoding used for escaping.
+
+## Connection pooling
+
+PHP's request-per-process model means a normal connection opens and closes within one request, so there is no application-level pool the way there is in a long-running Node or Java service. PDO offers `ATTR_PERSISTENT` to reuse connections across requests, but it has sharp edges: a connection left mid-transaction or holding a table lock can be handed to the next request in that state. For production, the reliable answer is a connection proxy such as MaxScale or ProxySQL in front of MariaDB, which pools connections independently of PHP's lifecycle.
+
+## Errors you actually hit
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `could not find driver` | `pdo_mysql` is not installed or enabled | Install `php-mysql`; confirm with `php -m \| grep mysql` |
+| `Authentication plugin 'ed25519' cannot be loaded` | The user authenticates via MariaDB's ed25519 plugin, which PHP's drivers don't implement | Switch the user to `mysql_native_password`, or use a connector that bundles ed25519 |
+| `Incorrect string value: '\xF0\x9F...'` | Column or connection is `utf8` (3-byte), not `utf8mb4` | Add `charset=utf8mb4` to the DSN and convert the column to `utf8mb4` |
+| `SQLSTATE[HY000] [2002] Connection refused` | Wrong host/port or server not listening | Use `127.0.0.1`, check port 3306 and `bind-address` |
+| `Access denied for user ... (using password: YES)` | Wrong credentials or host not granted | Verify the password and the user's host grant |
+| Numbers come back as strings | Emulated prepares are on (the MariaDB/MySQL default) | Set `ATTR_EMULATE_PREPARES => false` |
+| `RETURNING` throws a syntax error | Server is MySQL, or MariaDB older than 10.5 | Use `lastInsertId()` instead for portable code |
+
+For exploring MariaDB data and drafting queries before they go into PHP, Mako connects to MariaDB with AI-powered autocomplete. Try it free at mako.ai.

--- a/content/guides/mssql/connect-from-php.mdx
+++ b/content/guides/mssql/connect-from-php.mdx
@@ -1,0 +1,181 @@
+---
+title: "How to Connect to SQL Server from PHP"
+description: "Connect to Microsoft SQL Server from PHP with the official sqlsrv and pdo_sqlsrv drivers: ODBC Driver 18, the Encrypt-defaults-on TLS trap, prepared statements, transactions, the OUTPUT clause for generated keys, and the errors you actually hit."
+database: "mssql"
+category: "how-to"
+tags: ["mssql", "sql-server", "php", "pdo", "sqlsrv", "pdo-sqlsrv", "connection"]
+date: "2026-06-30"
+---
+
+Connecting to Microsoft SQL Server from PHP means installing an extension that does not ship with PHP itself. Microsoft maintains the Drivers for PHP for SQL Server: a pair of extensions, `sqlsrv` (a procedural API specific to SQL Server) and `pdo_sqlsrv` (a PDO driver). Both sit on top of the Microsoft ODBC Driver for SQL Server, which is a separate system package you must install first. The current release is 5.13.1 (as of June 2026), with day-one support for PHP 8.3, 8.4, and 8.5. For new code, `pdo_sqlsrv` is the right default because it gives you the same portable PDO API you would use for any other database. This guide covers the install chain, the TLS default that breaks local connections, prepared statements, transactions, reading generated keys, and the errors you will meet.
+
+## The install chain
+
+Three layers have to line up, in order:
+
+1. **The Microsoft ODBC Driver for SQL Server** (Driver 18 is current). This is an OS package, not a PHP one. On Debian/Ubuntu you add Microsoft's apt repository and install `msodbcsql18` plus `unixodbc-dev`. On Windows you download the MSI.
+2. **The PHP extensions**, installed through PECL:
+
+   ```bash
+   pecl install sqlsrv pdo_sqlsrv
+   ```
+
+   On Windows you download the prebuilt DLLs from Microsoft instead and drop them into the extension directory.
+3. **The `php.ini` entries** that load them:
+
+   ```ini
+   extension=sqlsrv
+   extension=pdo_sqlsrv
+   ```
+
+Confirm both the ODBC driver and the PHP extension are present:
+
+```bash
+php -m | grep -i sqlsrv
+# expect: pdo_sqlsrv  sqlsrv
+odbcinst -q -d
+# expect a section like: [ODBC Driver 18 for SQL Server]
+```
+
+The single most common failure here is `could not find driver`, which almost always means the ODBC system driver is missing even though the PHP extension loaded. The PHP extension is a thin layer; without the ODBC driver underneath it, there is nothing to connect with.
+
+## Connecting with PDO
+
+`pdo_sqlsrv` uses a `sqlsrv:` DSN. The server goes in `Server`, the database in `Database`. Note that SQL Server uses a backslash for named instances, which must be escaped in a PHP string:
+
+```php
+<?php
+$dsn = 'sqlsrv:Server=127.0.0.1,1433;Database=shop';
+
+$pdo = new PDO($dsn, 'appuser', 'secret', [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+]);
+```
+
+`ERRMODE_EXCEPTION` makes failures throw `PDOException` instead of returning `false`. `FETCH_ASSOC` returns rows as associative arrays.
+
+### Prepared statements
+
+`pdo_sqlsrv` supports both named and positional placeholders. Positional `?` is the most portable:
+
+```php
+$stmt = $pdo->prepare('SELECT id, name, price FROM products WHERE price > ?');
+$stmt->execute([100]);
+
+foreach ($stmt as $row) {
+    echo "{$row['id']}: {$row['name']}\n";
+}
+```
+
+Placeholders stand in for values only, never for table or column names.
+
+## The Encrypt-defaults-on TLS trap
+
+This is the trap that catches almost everyone the first time, and it changed with the driver generation. **ODBC Driver 18 defaults `Encrypt` to `yes`.** Earlier drivers defaulted to `no`. So code that connected fine against an older driver, or a tutorial written before Driver 18, suddenly fails against a local SQL Server with a self-signed certificate:
+
+```
+SQLSTATE[08001]: ... SSL Provider: The certificate chain was issued by an
+authority that is not trusted.
+```
+
+The connection is now encrypted by default and the client is correctly refusing to trust an untrusted certificate. The wrong fix is to disable encryption. The right fixes, in order of preference:
+
+- **Production:** install a certificate the client trusts and leave `Encrypt=yes`. Verify the server name matches the certificate.
+- **Local development only:** keep encryption on but skip certificate validation with `TrustServerCertificate=yes`:
+
+  ```php
+  $dsn = 'sqlsrv:Server=127.0.0.1,1433;Database=shop;Encrypt=yes;TrustServerCertificate=yes';
+  ```
+
+Resist the reflex of `Encrypt=no`. That sends credentials and data in clear text, and it is the opposite of what the new default is trying to protect you from.
+
+## Transactions
+
+Wrap multi-statement work so a failure rolls everything back:
+
+```php
+$pdo->beginTransaction();
+try {
+    $pdo->prepare('UPDATE accounts SET balance = balance - ? WHERE id = ?')
+        ->execute([100, 1]);
+    $pdo->prepare('UPDATE accounts SET balance = balance + ? WHERE id = ?')
+        ->execute([100, 2]);
+    $pdo->commit();
+} catch (\Throwable $e) {
+    $pdo->rollBack();
+    throw $e;
+}
+```
+
+## Reading generated keys
+
+SQL Server has no `RETURNING` clause and no reliable `lastInsertId()` story across all cases. The idiomatic approach is the `OUTPUT` clause, which returns inserted values as a result set directly from the `INSERT`:
+
+```php
+$stmt = $pdo->prepare(
+    'INSERT INTO products (name, price) OUTPUT INSERTED.id VALUES (?, ?)'
+);
+$stmt->execute(['Wrench', 19.90]);
+$id = $stmt->fetchColumn();
+```
+
+`OUTPUT INSERTED.id` is more robust than the older `SCOPE_IDENTITY()` pattern because it returns directly from the statement and works correctly when multiple rows are inserted at once. Avoid `@@IDENTITY`, which can return the wrong value if a trigger inserts into another table with its own identity column.
+
+## Connecting with the sqlsrv procedural API
+
+If you prefer or inherit the SQL Server-specific API, `sqlsrv` is procedural. Connection options are passed as an array, and parameters are bound positionally as a separate array:
+
+```php
+$conn = sqlsrv_connect('127.0.0.1,1433', [
+    'Database'             => 'shop',
+    'Uid'                  => 'appuser',
+    'PWD'                  => 'secret',
+    'Encrypt'              => true,
+    'TrustServerCertificate' => true, // dev only
+]);
+
+if ($conn === false) {
+    die(print_r(sqlsrv_errors(), true));
+}
+
+$sql = 'SELECT id, name FROM products WHERE price > ?';
+$stmt = sqlsrv_query($conn, $sql, [100]);
+
+while ($row = sqlsrv_fetch_array($stmt, SQLSRV_FETCH_ASSOC)) {
+    echo "{$row['id']}: {$row['name']}\n";
+}
+```
+
+`sqlsrv_connect` returns `false` on failure rather than throwing, so check the return value and read `sqlsrv_errors()`. This is the same trap PDO's exception mode removes, which is one reason `pdo_sqlsrv` is the friendlier default.
+
+## Named instances and Azure SQL
+
+For a named instance, give the instance after a backslash and let SQL Server Browser (UDP 1434) resolve the port, or specify the port directly:
+
+```php
+// Named instance, resolved by SQL Server Browser
+$dsn = 'sqlsrv:Server=dbhost\\SQLEXPRESS;Database=shop';
+
+// Explicit host and port (no Browser dependency)
+$dsn = 'sqlsrv:Server=dbhost,1433;Database=shop';
+```
+
+The explicit `host,port` form is more reliable in containerized and firewalled environments because it does not depend on the Browser service being reachable. Azure SQL Database always uses TLS, so `Encrypt=yes` is correct there by default; just make sure the server's firewall allows your client IP.
+
+## Connection pooling
+
+PHP's request-per-process model closes connections at the end of each request, so there is no application-level pool the way a long-running service has. On Linux, the unixODBC driver manager can pool ODBC connections at the system level, configured in `odbcinst.ini`. PDO also offers `ATTR_PERSISTENT`, which reuses the underlying connection across requests, but persistent connections can be handed to the next request mid-transaction, so use them with care and never while holding locks.
+
+## Errors you actually hit
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `could not find driver` | The Microsoft ODBC Driver is missing, even if the PHP extension loaded | Install `msodbcsql18`; confirm with `odbcinst -q -d` |
+| `SSL Provider: The certificate chain ... is not trusted` | Driver 18 defaults `Encrypt=yes` and the cert isn't trusted | Install a trusted cert (prod) or add `TrustServerCertificate=yes` (dev only) |
+| `SQLSTATE[08001] ... Login timeout expired` | Wrong host/port, server not listening, or firewall | Use explicit `Server=host,1433`; check the port and firewall |
+| `Login failed for user 'appuser'` | Wrong credentials, or SQL Server is in Windows-auth-only mode | Verify the password; enable Mixed Mode authentication on the server |
+| `The specified network name is no longer available` | Named instance can't be resolved (SQL Server Browser unreachable) | Use explicit `host,port` instead of `host\instance` |
+| `sqlsrv_query` returns `false` silently | The procedural API reports errors via return values, not exceptions | Check the return value and read `sqlsrv_errors()`; or use `pdo_sqlsrv` |
+
+For exploring SQL Server data and drafting queries before they go into PHP, Mako connects to SQL Server with AI-powered autocomplete. Try it free at mako.ai.


### PR DESCRIPTION
Finishes the PHP connection-guide series (PHP × 9 DBs complete) and closes the entire connection axis: Python/Node/Go/Java/C#/PHP × 9 databases.

## Articles
- `mariadb/connect-from-php` — PDO + mysqli reuse the MySQL drivers; utf8mb4 trap, the **ed25519 authentication gotcha** (PHP's drivers don't implement it; the genuinely MariaDB-specific failure), `INSERT ... RETURNING` (10.5+) vs `lastInsertId()`, transactions (InnoDB), TLS verify, error table.
- `mssql/connect-from-php` — Microsoft Drivers for PHP 5.13.1 (sqlsrv + pdo_sqlsrv on ODBC Driver 18, PHP 8.3/8.4/8.5), the three-layer install chain, the **Encrypt-defaults-yes TLS trap** on Driver 18, `OUTPUT INSERTED` for generated keys, named instances, Azure SQL, error table.

## Checks
- Versions verified live (MS Drivers 5.13.1 via Microsoft release notes/GitHub; MariaDB ed25519 + RETURNING behavior confirmed).
- Em-dash clean, banned-word clean, single CTA, frontmatter complete.
- Each article committed individually.