### PR TITLE
Unify app + dashboard data sources: persist schedules, agent scheduling, shared materialization UI

### DIFF
--- a/api/src/agent-lib/tools/server-app-tools.ts
+++ b/api/src/agent-lib/tools/server-app-tools.ts
@@ -38,8 +38,10 @@ import {
   getAppStateSchema,
   appReadFileSchema,
   materializeBindingSchema,
+  setBindingScheduleSchema,
 } from "@mako/agent-tools";
 import { normalizeAppFiles, createAppScaffold } from "@mako/schemas";
+import { validateDashboardMaterializationSchedule } from "../../services/dashboard-materialization-schedule.service";
 import {
   MakoApp,
   DatabaseConnection,
@@ -549,6 +551,26 @@ export function createServerAppTools({
           if (!connCheck.ok) return { success: false, error: connCheck.error };
           const materialization =
             input.materialization === "parquet" ? "parquet" : "live";
+          // Validate the optional schedule (cron) the same way the HTTP routes
+          // do. Live bindings can't be scheduled, so force it disabled.
+          let materializationSchedule;
+          if (input.materializationSchedule) {
+            try {
+              materializationSchedule = validateDashboardMaterializationSchedule(
+                materialization === "parquet"
+                  ? input.materializationSchedule
+                  : { ...input.materializationSchedule, enabled: false },
+              );
+            } catch (error) {
+              return {
+                success: false,
+                error:
+                  error instanceof Error
+                    ? error.message
+                    : "Invalid materialization schedule",
+              };
+            }
+          }
           const created = {
             id: nanoid(10),
             name: input.name,
@@ -558,6 +580,7 @@ export function createServerAppTools({
             databaseId: input.databaseId,
             databaseName: input.databaseName,
             materialization,
+            materializationSchedule,
             cache: undefined,
           };
           // Replace any existing binding with the same name (mirrors the client
@@ -575,6 +598,64 @@ export function createServerAppTools({
               materialization === "parquet"
                 ? `Call materialize_binding for "${created.name}", then read it with useQuery("${created.name}") or run analytics with useDuckDB(sql) from '@mako/app-sdk'.`
                 : `Read it in app code with useQuery("${created.name}") from '@mako/app-sdk'.`,
+          };
+        }),
+    }),
+
+    app_set_binding_schedule: tool({
+      description:
+        "Set or clear the materialization schedule on an existing 'parquet' " +
+        "data binding so its artifact auto-refreshes on a cron. Use this when " +
+        "the user wants a data source to refresh periodically (e.g. hourly or " +
+        "daily) instead of only on demand. Pass enabled:false to turn the " +
+        "schedule off. The binding must be 'parquet' (live bindings always run " +
+        "fresh and can't be scheduled). Confirm the name with list_data_sources.",
+      inputSchema: setBindingScheduleSchema,
+      execute: async ({ appId, name, enabled, cron, timezone, dataFreshnessTtlMs }) =>
+        wrap("app_set_binding_schedule", async () => {
+          const loaded = await loadApp(appId);
+          if (isLoadError(loaded)) return { success: false, ...loaded };
+          const { doc } = loaded;
+          if (!(await canWrite(doc))) return denied(appId);
+          const binding = (doc.dataBindings ?? []).find(b => b.name === name);
+          if (!binding) {
+            return { success: false, error: `No data binding named "${name}"` };
+          }
+          if (binding.materialization !== "parquet") {
+            return {
+              success: false,
+              error:
+                `Binding "${name}" is 'live'. Switch it to 'parquet' ` +
+                "materialization before scheduling refreshes.",
+            };
+          }
+          let schedule;
+          try {
+            schedule = validateDashboardMaterializationSchedule({
+              enabled,
+              cron: cron ?? null,
+              timezone,
+              dataFreshnessTtlMs,
+            });
+          } catch (error) {
+            return {
+              success: false,
+              error:
+                error instanceof Error
+                  ? error.message
+                  : "Invalid materialization schedule",
+            };
+          }
+          binding.materializationSchedule = schedule;
+          doc.markModified("dataBindings");
+          const version = await saveAndPublish(doc);
+          return {
+            success: true,
+            binding: { name, materializationSchedule: schedule },
+            version,
+            hint: schedule.enabled
+              ? `"${name}" will auto-refresh on schedule (${schedule.cron}, ${schedule.timezone}). Scheduled refresh runs in production; in local dev trigger it with materialize_binding.`
+              : `Scheduled refresh for "${name}" is now off.`,
           };
         }),
     }),

--- a/api/src/agent-skills/apps/SKILL.md
+++ b/api/src/agent-skills/apps/SKILL.md
@@ -84,6 +84,15 @@ errors); `open_app` just focuses a UI tab.
    Prefer parquet + useDuckDB for dashboards/aggregations over larger result sets; prefer
    live useQuery for small, always-fresh lookups.
 
+   **Scheduled refresh:** a parquet binding can auto-refresh on a cron — set
+   `materializationSchedule` when creating it, or call `app_set_binding_schedule`
+   (e.g. `{ enabled: true, cron: "0 * * * *" }` for hourly, `"0 0 * * *"` for
+   daily) on an existing one. This mirrors dashboard data-source schedules. Only
+   parquet bindings can be scheduled (live bindings always run fresh). Scheduled
+   refresh runs in production; in local dev trigger a build with
+   `materialize_binding`. An explicit `materialize_binding` always rebuilds from
+   current upstream data (it force-refreshes past the query-definition cache).
+
    **Result row cap:** rows delivered to the app are capped per query/binding read
    (default 500,000 — the bridge into the sandboxed iframe). Both hooks return
    `truncated: true` when rows beyond the cap were dropped, and `useDuckDB` also

--- a/api/src/agent-skills/dashboards/SKILL.md
+++ b/api/src/agent-skills/dashboards/SKILL.md
@@ -19,7 +19,7 @@ When working with dashboards, you help users create interactive data dashboards 
 ### Core Capabilities
 
 You can create, modify, and manage dashboards using structured tool calls. Dashboards consist of:
-- **Data sources** — dashboard-local query definitions materialized into an in-browser DuckDB instance
+- **Data sources** — dashboard-local query definitions loaded into an in-browser DuckDB instance. Each has a `materialization` mode (mirrors app data bindings): `parquet` (default) snapshots the query to a cached artifact (fast for aggregation, served to public shares); `live` streams the query server-side into DuckDB on every dashboard load (always fresh, but not shown in anonymous public shares). Set it on `create_data_source` or switch it later with `update_data_source_query`. Only parquet sources are materialized/scheduled/refreshed.
 - **Widgets** — charts (Vega-Lite), KPI cards, and data tables that query the local DuckDB data
 - **Cross-filtering** — clicking a bar or slice in one chart filters all other charts automatically
 - **Global filters** — dashboard-level date range pickers, dropdowns, and search fields

--- a/api/src/agents/modes/registry.ts
+++ b/api/src/agents/modes/registry.ts
@@ -134,6 +134,7 @@ const APP_MODE_TOOL_NAMES: string[] = [
   "app_remove_dependency",
   "app_create_data_binding",
   "app_delete_data_binding",
+  "app_set_binding_schedule",
   "app_save_version",
   "app_restore_version",
   "materialize_binding",

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -3225,6 +3225,11 @@ export interface IDashboardDataSource {
   origin?: IDashboardDataSourceOrigin;
   timeDimension?: string;
   rowLimit?: number;
+  /**
+   * How the data reaches widgets. `parquet` (default) materializes to a cached
+   * artifact; `live` streams the query server-side into DuckDB on every load.
+   */
+  materialization: "live" | "parquet";
   computedColumns?: Array<{
     name: string;
     expression: string;
@@ -3308,6 +3313,11 @@ const DashboardSchema = new Schema<IDashboard>(
         },
         timeDimension: { type: String },
         rowLimit: { type: Number },
+        materialization: {
+          type: String,
+          enum: ["live", "parquet"],
+          default: "parquet",
+        },
         computedColumns: [
           {
             name: { type: String, required: true },

--- a/api/src/routes/apps.ts
+++ b/api/src/routes/apps.ts
@@ -26,9 +26,14 @@ import { AppDefinitionSchema, normalizeAppFiles } from "@mako/schemas";
 import {
   queueAppBindingMaterialization,
   buildAppBindingMaterializationStatus,
+  buildAppBindingDefinitionHash,
   hydrateAppBindingUrls,
   getBindingArtifactInfo,
 } from "../services/app-binding-materialization.service";
+import {
+  validateDashboardMaterializationSchedule,
+  isDashboardMaterializationEnabled,
+} from "../services/dashboard-materialization-schedule.service";
 import { getDashboardArtifactStore } from "../services/dashboard-artifact-store.service";
 import {
   buildAppSnapshot,
@@ -362,6 +367,30 @@ app.openapi(
       if (!bindingCheck.ok) {
         return c.json({ success: false, error: bindingCheck.error }, 400);
       }
+      // Validate each binding's materialization schedule cron (parity with the
+      // dashboard create path), normalizing live bindings to a disabled schedule.
+      try {
+        for (const binding of def.dataBindings) {
+          if (!binding.materializationSchedule) continue;
+          binding.materializationSchedule =
+            validateDashboardMaterializationSchedule(
+              binding.materialization === "parquet"
+                ? binding.materializationSchedule
+                : { ...binding.materializationSchedule, enabled: false },
+            );
+        }
+      } catch (error) {
+        return c.json(
+          {
+            success: false,
+            error:
+              error instanceof Error
+                ? error.message
+                : "Invalid materialization schedule",
+          },
+          400,
+        );
+      }
 
       const created = await MakoApp.create({
         workspaceId: new Types.ObjectId(workspaceId),
@@ -484,6 +513,12 @@ app.openapi(
 
       const body = (await c.req.json()) as Record<string, unknown>;
 
+      // Snapshot of bindings before the update, keyed by id — used after save
+      // to detect which scheduled parquet bindings changed definition so we
+      // can proactively rebuild them (parity with dashboard auto-refresh).
+      let priorBindingsById: Map<string, IMakoApp["dataBindings"][number]> | null =
+        null;
+
       if (typeof body.title === "string" && body.title.trim()) {
         doc.title = body.title.trim();
       }
@@ -516,22 +551,51 @@ app.openapi(
         // Cache is server-owned: preserve the existing materialized cache by id;
         // never trust client-provided cache. Take only the query definition.
         const existingById = new Map(doc.dataBindings.map(b => [b.id, b]));
-        doc.dataBindings = bindings.map(b => {
-          const id = b.id || nanoid(10);
-          const prior = existingById.get(id);
-          return {
-            id,
-            name: b.name,
-            connectionId: b.connectionId,
-            language: b.language || "sql",
-            code: b.code ?? "",
-            databaseId: b.databaseId,
-            databaseName: b.databaseName,
-            materialization:
-              b.materialization === "parquet" ? "parquet" : "live",
-            cache: prior?.cache,
-          };
-        }) as IMakoApp["dataBindings"];
+        priorBindingsById = existingById;
+        try {
+          doc.dataBindings = bindings.map(b => {
+            const id = b.id || nanoid(10);
+            const prior = existingById.get(id);
+            const materialization =
+              b.materialization === "parquet" ? "parquet" : "live";
+            // Validate + persist the per-binding schedule (mirrors how
+            // dashboards validate `materializationSchedule` on save). Only
+            // parquet bindings can be scheduled, so a live binding keeps any
+            // prior schedule but is forced disabled.
+            const rawSchedule =
+              b.materializationSchedule ?? prior?.materializationSchedule;
+            const materializationSchedule = rawSchedule
+              ? validateDashboardMaterializationSchedule(
+                  materialization === "parquet"
+                    ? rawSchedule
+                    : { ...rawSchedule, enabled: false },
+                )
+              : undefined;
+            return {
+              id,
+              name: b.name,
+              connectionId: b.connectionId,
+              language: b.language || "sql",
+              code: b.code ?? "",
+              databaseId: b.databaseId,
+              databaseName: b.databaseName,
+              materialization,
+              materializationSchedule,
+              cache: prior?.cache,
+            };
+          }) as IMakoApp["dataBindings"];
+        } catch (error) {
+          return c.json(
+            {
+              success: false,
+              error:
+                error instanceof Error
+                  ? error.message
+                  : "Invalid materialization schedule",
+            },
+            400,
+          );
+        }
       }
       const wantsAccessChange =
         (body.access === "private" || body.access === "workspace") &&
@@ -559,6 +623,32 @@ app.openapi(
 
       doc.version += 1;
       await doc.save();
+
+      // Mechanism parity with dashboards: when a scheduled parquet binding's
+      // query definition changes, proactively rebuild its artifact so the
+      // materialized data stays in sync without a manual materialize. Gated on
+      // the binding's own schedule being enabled (apps schedule per-binding).
+      if (priorBindingsById) {
+        for (const binding of doc.dataBindings) {
+          if (binding.materialization !== "parquet") continue;
+          if (!isDashboardMaterializationEnabled(binding.materializationSchedule)) {
+            continue;
+          }
+          const prior = priorBindingsById.get(binding.id);
+          const changed =
+            !prior ||
+            buildAppBindingDefinitionHash(prior) !==
+              buildAppBindingDefinitionHash(binding);
+          if (changed) {
+            void queueAppBindingMaterialization({
+              workspaceId,
+              appId: id,
+              bindingId: binding.id,
+              force: true,
+            }).catch(() => undefined);
+          }
+        }
+      }
 
       return c.json({ success: true, app: serializeApp(doc) });
     } catch (error) {

--- a/api/src/routes/dashboards.ts
+++ b/api/src/routes/dashboards.ts
@@ -89,6 +89,7 @@ const DashboardDataSourceSchema = z.object({
   id: z.string(),
   name: z.string(),
   tableRef: z.string(),
+  materialization: z.enum(["live", "parquet"]).default("parquet"),
   query: DashboardQuerySchema,
   origin: z
     .object({
@@ -442,6 +443,7 @@ async function normalizeDashboardDataSources(
             : undefined,
           timeDimension: ds.timeDimension,
           rowLimit: ds.rowLimit,
+          materialization: ds.materialization === "live" ? "live" : "parquet",
           computedColumns: ds.computedColumns || [],
           cache: existingCacheById.get(String(id)),
         };

--- a/api/src/routes/public-share.ts
+++ b/api/src/routes/public-share.ts
@@ -189,6 +189,27 @@ async function buildDashboardContent(token: string, dashboard: IDashboard) {
   const dataSources = await Promise.all(
     ((def.dataSources as Array<Record<string, any>>) || []).map(async ds => {
       const liveDs = liveDsById.get(String(ds.id)) ?? ds;
+      const materialization =
+        (liveDs as { materialization?: string }).materialization === "live"
+          ? "live"
+          : "parquet";
+      // Live data sources execute server-side per viewer; anonymous public
+      // viewers never get live execution, so expose them as not-ready with no
+      // artifact (mirrors the public app viewer refusing live bindings).
+      if (materialization === "live") {
+        return {
+          id: ds.id,
+          name: ds.name,
+          tableRef: ds.tableRef,
+          timeDimension: ds.timeDimension,
+          computedColumns: ds.computedColumns,
+          materialization,
+          ready: false,
+          rowCount: null,
+          materializedAt: null,
+          artifactUrl: null,
+        };
+      }
       const status = await buildDataSourceMaterializationStatus({
         workspaceId,
         dashboardId,
@@ -201,6 +222,7 @@ async function buildDashboardContent(token: string, dashboard: IDashboard) {
         tableRef: ds.tableRef,
         timeDimension: ds.timeDimension,
         computedColumns: ds.computedColumns,
+        materialization,
         ready,
         rowCount: status.rowCount,
         materializedAt: status.builtAt || status.lastMaterializedAt,
@@ -528,6 +550,21 @@ app.openapi(
             {
               success: false,
               error: "No materialized app data sources to refresh",
+            },
+            400,
+          );
+        }
+      } else if (resource.type === "dashboard") {
+        const dashboardDoc = resource.doc;
+        if (
+          !(dashboardDoc.dataSources || []).some(
+            ds => ds.materialization !== "live",
+          )
+        ) {
+          return c.json(
+            {
+              success: false,
+              error: "No materialized dashboard data sources to refresh",
             },
             400,
           );

--- a/api/src/services/dashboard-artifact-rebuild.service.ts
+++ b/api/src/services/dashboard-artifact-rebuild.service.ts
@@ -130,8 +130,11 @@ export async function rebuildDashboardArtifacts(
       `Dashboard ${input.dashboardId} does not belong to workspace ${input.workspaceId}`,
     );
   }
-  const filteredDataSources = dashboard.dataSources.filter(ds =>
-    input.dataSourceIds?.length ? input.dataSourceIds.includes(ds.id) : true,
+  const filteredDataSources = dashboard.dataSources.filter(
+    ds =>
+      // Live sources stream on read and have no artifact to build.
+      ds.materialization !== "live" &&
+      (input.dataSourceIds?.length ? input.dataSourceIds.includes(ds.id) : true),
   );
 
   const results: RebuildDashboardArtifactsResult["results"] = [];

--- a/api/src/services/dashboard-refresh-runner.service.ts
+++ b/api/src/services/dashboard-refresh-runner.service.ts
@@ -45,8 +45,14 @@ export async function queueDashboardArtifactRefresh(input: {
     input.dataSourceIds?.length && dashboard.dataSources.length > 0
       ? input.dataSourceIds
       : dashboard.dataSources.map(dataSource => dataSource.id);
+  // Only parquet data sources have artifacts to (re)build; live sources stream
+  // server-side on every load and are never materialized.
   const dataSourceIds = requestedIds.filter(dataSourceId =>
-    dashboard.dataSources.some(dataSource => dataSource.id === dataSourceId),
+    dashboard.dataSources.some(
+      dataSource =>
+        dataSource.id === dataSourceId &&
+        dataSource.materialization !== "live",
+    ),
   );
 
   if (dataSourceIds.length === 0) {

--- a/api/src/services/resource-data-source.service.ts
+++ b/api/src/services/resource-data-source.service.ts
@@ -165,7 +165,7 @@ async function serializeDashboardDataSource(input: {
     code: input.dataSource.query.code,
     databaseId: input.dataSource.query.databaseId,
     databaseName: input.dataSource.query.databaseName,
-    materialization: "parquet",
+    materialization: input.dataSource.materialization ?? "parquet",
     materializationSchedule: schedule,
     scheduleScope: "resource",
     status: {
@@ -306,20 +306,23 @@ export async function updateResourceDataSourceSettings(input: {
   if (input.resourceType === "dashboard") {
     const dashboard = await getDashboardOrThrow(input);
     requireDashboardWrite(dashboard, input.userId, input.memberRole);
-    if (input.settings.materialization === "live") {
-      throw new Error("Dashboard data sources are always materialized");
-    }
-    if (
-      !dashboard.dataSources.some(dataSource => dataSource.id === input.dataSourceId)
-    ) {
+    const dataSource = dashboard.dataSources.find(
+      ds => ds.id === input.dataSourceId,
+    );
+    if (!dataSource) {
       throw new Error("Data source not found");
+    }
+    // Per-data-source live/parquet toggle (parity with app bindings).
+    if (input.settings.materialization) {
+      dataSource.materialization = input.settings.materialization;
+      dashboard.markModified("dataSources");
     }
     if (input.settings.schedule !== undefined) {
       dashboard.materializationSchedule = validateDashboardMaterializationSchedule(
         input.settings.schedule,
       );
-      await dashboard.save();
     }
+    await dashboard.save();
     return await getResourceDataSource(input);
   }
 
@@ -357,11 +360,16 @@ export async function refreshResourceDataSources(input: {
   if (input.resourceType === "dashboard") {
     const dashboard = await getDashboardOrThrow(input);
     requireDashboardWrite(dashboard, input.userId, input.memberRole);
-    if (
-      input.dataSourceId &&
-      !dashboard.dataSources.some(dataSource => dataSource.id === input.dataSourceId)
-    ) {
-      throw new Error("Data source not found");
+    if (input.dataSourceId) {
+      const target = dashboard.dataSources.find(
+        ds => ds.id === input.dataSourceId,
+      );
+      if (!target) {
+        throw new Error("Data source not found");
+      }
+      if (target.materialization === "live") {
+        throw new Error("Live data sources always run fresh; nothing to refresh");
+      }
     }
     const result = await queueDashboardArtifactRefresh({
       workspaceId: input.workspaceId,

--- a/app/src/api/schema.d.ts
+++ b/app/src/api/schema.d.ts
@@ -3871,6 +3871,11 @@ export interface components {
                 id: string;
                 name: string;
                 tableRef: string;
+                /**
+                 * @default parquet
+                 * @enum {string}
+                 */
+                materialization: "live" | "parquet";
                 query: {
                     /** @example 507f1f77bcf86cd799439011 */
                     connectionId?: string;

--- a/app/src/components/AppBindingEditor.tsx
+++ b/app/src/components/AppBindingEditor.tsx
@@ -2,24 +2,11 @@ import { useCallback, useEffect, useState } from "react";
 import {
   Box,
   Typography,
-  Button,
   ToggleButtonGroup,
   ToggleButton,
-  Chip,
   Tooltip,
-  IconButton,
-  Popover,
-  Divider,
 } from "@mui/material";
-import {
-  Database as MaterializeIcon,
-  CalendarClock as ScheduleIcon,
-  Info as InfoIcon,
-  History as HistoryIcon,
-  Eye as PreviewIcon,
-  CheckCircle2 as SuccessIcon,
-  XCircle as ErrorIcon,
-} from "lucide-react";
+import { Info as InfoIcon } from "lucide-react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useAppStore } from "../store/appStore";
@@ -28,7 +15,9 @@ import { previewParquetArtifact } from "../lib/parquet-preview";
 import Console from "./Console";
 import ResultsTable from "./ResultsTable";
 import EntityBreadcrumbs from "./EntityBreadcrumbs";
-import MaterializationScheduleControls from "./MaterializationScheduleControls";
+import DataSourceMaterializationControls, {
+  type MaterializationHistoryItem,
+} from "./DataSourceMaterializationControls";
 import {
   defaultMaterializationSchedule,
   type MaterializationScheduleValue,
@@ -78,10 +67,6 @@ export default function AppBindingEditor({
   const [running, setRunning] = useState(false);
   const [materializing, setMaterializing] = useState(false);
   const [previewingSnapshot, setPreviewingSnapshot] = useState(false);
-  const [historyAnchor, setHistoryAnchor] = useState<HTMLElement | null>(null);
-  const [scheduleAnchor, setScheduleAnchor] = useState<HTMLElement | null>(
-    null,
-  );
 
   useEffect(() => {
     if (!appEntity && workspaceId) void fetchApp(workspaceId, appId);
@@ -140,7 +125,10 @@ export default function AppBindingEditor({
   const handleMaterialize = useCallback(async () => {
     if (!workspaceId) return;
     setMaterializing(true);
-    await materializeBinding(workspaceId, appId, bindingId);
+    // Explicit user action = rebuild now. Force past the definition-hash cache
+    // so a rematerialize picks up new upstream data even when the query text is
+    // unchanged (parity with the dashboard data source Materialize button).
+    await materializeBinding(workspaceId, appId, bindingId, { force: true });
     setMaterializing(false);
   }, [workspaceId, appId, bindingId, materializeBinding]);
 
@@ -205,10 +193,21 @@ export default function AppBindingEditor({
 
   const cache = binding.cache;
 
-  const history = cache?.history ?? [];
+  const historyItems: MaterializationHistoryItem[] = (cache?.history ?? []).map(
+    (run, i) => ({
+      id: `${run.at}-${i}`,
+      status: run.status === "ready" ? "ready" : "error",
+      at: run.at,
+      rowCount: run.rowCount ?? null,
+      durationMs: run.durationMs ?? null,
+      error: run.error ?? null,
+    }),
+  );
 
-  const headerExtras = (
-    <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, ml: 1 }}>
+  const isParquet = binding.materialization === "parquet";
+
+  const leadingControls = (
+    <>
       <Typography variant="caption" color="text.secondary">
         Data
       </Typography>
@@ -248,71 +247,33 @@ export default function AppBindingEditor({
           style={{ opacity: 0.6, cursor: "help" }}
         />
       </Tooltip>
+    </>
+  );
 
-      {binding.materialization === "parquet" && (
-        <>
-          <Button
-            size="small"
-            variant="outlined"
-            startIcon={<MaterializeIcon size={16} strokeWidth={1.5} />}
-            onClick={handleMaterialize}
-            disabled={materializing}
-          >
-            {materializing ? "Materializing…" : "Materialize"}
-          </Button>
-          {cache?.parquetBuildStatus && (
-            <Chip
-              size="small"
-              variant="outlined"
-              color={
-                cache.parquetBuildStatus === "ready"
-                  ? "success"
-                  : cache.parquetBuildStatus === "error"
-                    ? "error"
-                    : "default"
-              }
-              label={
-                cache.parquetBuildStatus === "ready" && cache.rowCount != null
-                  ? `${cache.rowCount.toLocaleString()} rows`
-                  : cache.parquetBuildStatus
-              }
-            />
-          )}
-          {cache?.parquetBuildStatus === "ready" && cache?.parquetUrl && (
-            <Tooltip title="Preview the materialized data">
-              <span>
-                <IconButton
-                  size="small"
-                  onClick={() => void handlePreviewSnapshot()}
-                  disabled={previewingSnapshot}
-                >
-                  <PreviewIcon size={18} strokeWidth={1.5} />
-                </IconButton>
-              </span>
-            </Tooltip>
-          )}
-          <Tooltip title="Materialization schedule">
-            <IconButton
-              size="small"
-              onClick={e => setScheduleAnchor(e.currentTarget)}
-            >
-              <ScheduleIcon size={18} strokeWidth={1.5} />
-            </IconButton>
-          </Tooltip>
-          <Tooltip title="Materialization history">
-            <span>
-              <IconButton
-                size="small"
-                onClick={e => setHistoryAnchor(e.currentTarget)}
-                disabled={history.length === 0}
-              >
-                <HistoryIcon size={18} strokeWidth={1.5} />
-              </IconButton>
-            </span>
-          </Tooltip>
-        </>
-      )}
-    </Box>
+  const headerExtras = (
+    <DataSourceMaterializationControls
+      leadingControls={leadingControls}
+      showMaterializeControls={isParquet}
+      buildStatus={cache?.parquetBuildStatus ?? null}
+      rowCount={cache?.rowCount ?? null}
+      builtAtMs={
+        cache?.parquetBuiltAt ? Date.parse(cache.parquetBuiltAt) : null
+      }
+      dataFreshnessTtlMs={
+        binding.materializationSchedule?.dataFreshnessTtlMs ?? null
+      }
+      onMaterialize={() => void handleMaterialize()}
+      materializing={materializing}
+      canPreview={cache?.parquetBuildStatus === "ready" && !!cache?.parquetUrl}
+      onPreviewSnapshot={() => void handlePreviewSnapshot()}
+      previewing={previewingSnapshot}
+      schedule={
+        binding.materializationSchedule ?? defaultMaterializationSchedule(false)
+      }
+      onScheduleChange={handleScheduleChange}
+      scheduleCaption="This schedule refreshes only this app data source."
+      history={historyItems}
+    />
   );
 
   return (
@@ -363,98 +324,6 @@ export default function AppBindingEditor({
           </Panel>
         </PanelGroup>
       </Box>
-
-      {/* Materialization history */}
-      <Popover
-        open={Boolean(historyAnchor)}
-        anchorEl={historyAnchor}
-        onClose={() => setHistoryAnchor(null)}
-        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
-      >
-        <Box sx={{ p: 1.5, minWidth: 320, maxWidth: 460 }}>
-          <Typography variant="subtitle2" sx={{ mb: 1 }}>
-            Materialization history
-          </Typography>
-          {history.length === 0 ? (
-            <Typography variant="caption" color="text.secondary">
-              No runs yet.
-            </Typography>
-          ) : (
-            history.map((run, i) => (
-              <Box key={i}>
-                {i > 0 && <Divider sx={{ my: 0.5 }} />}
-                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                  {run.status === "ready" ? (
-                    <SuccessIcon
-                      size={16}
-                      strokeWidth={1.5}
-                      style={{
-                        color: "var(--mui-palette-success-main, green)",
-                      }}
-                    />
-                  ) : (
-                    <ErrorIcon
-                      size={16}
-                      strokeWidth={1.5}
-                      style={{
-                        color: "var(--mui-palette-error-main, crimson)",
-                      }}
-                    />
-                  )}
-                  <Typography variant="caption" sx={{ flex: 1 }}>
-                    {new Date(run.at).toLocaleString()}
-                  </Typography>
-                  {run.status === "ready" && run.rowCount != null && (
-                    <Typography variant="caption" color="text.secondary">
-                      {run.rowCount.toLocaleString()} rows
-                    </Typography>
-                  )}
-                  {run.durationMs != null && (
-                    <Typography variant="caption" color="text.secondary">
-                      {(run.durationMs / 1000).toFixed(1)}s
-                    </Typography>
-                  )}
-                </Box>
-                {run.error && (
-                  <Typography
-                    variant="caption"
-                    color="error"
-                    sx={{ display: "block", pl: 3, whiteSpace: "pre-wrap" }}
-                  >
-                    {run.error}
-                  </Typography>
-                )}
-              </Box>
-            ))
-          )}
-        </Box>
-      </Popover>
-
-      <Popover
-        open={Boolean(scheduleAnchor)}
-        anchorEl={scheduleAnchor}
-        onClose={() => setScheduleAnchor(null)}
-        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
-      >
-        <Box sx={{ p: 1.5, width: 360 }}>
-          <Typography variant="subtitle2" sx={{ mb: 1 }}>
-            Materialization settings
-          </Typography>
-          <MaterializationScheduleControls
-            value={
-              binding.materializationSchedule ??
-              defaultMaterializationSchedule(false)
-            }
-            onChange={handleScheduleChange}
-            disabled={binding.materialization !== "parquet"}
-            caption={
-              binding.materialization === "parquet"
-                ? "This schedule refreshes only this app data source."
-                : "Switch this data source to Materialized before scheduling refreshes."
-            }
-          />
-        </Box>
-      </Popover>
     </Box>
   );
 }

--- a/app/src/components/DashboardDataSourceEditor.tsx
+++ b/app/src/components/DashboardDataSourceEditor.tsx
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
-import { Box, Typography } from "@mui/material";
+import {
+  Box,
+  Typography,
+  ToggleButtonGroup,
+  ToggleButton,
+  Tooltip,
+} from "@mui/material";
+import { Info as InfoIcon } from "lucide-react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { useWorkspace } from "../contexts/workspace-context";
 import {
@@ -277,8 +284,58 @@ export default function DashboardDataSourceEditor({
     };
   });
 
+  const isParquet = (dataSource.materialization ?? "parquet") === "parquet";
+
+  const leadingControls = (
+    <>
+      <Typography variant="caption" color="text.secondary">
+        Data
+      </Typography>
+      <ToggleButtonGroup
+        size="small"
+        exclusive
+        value={dataSource.materialization ?? "parquet"}
+        disabled={dashboard.readOnly}
+        onChange={(_e, value) => {
+          if (value && workspaceId) {
+            updateDataSource(dashboardId, dataSourceId, {
+              materialization: value,
+            });
+            void saveDashboard(workspaceId, dashboardId);
+          }
+        }}
+      >
+        <ToggleButton value="live">Live</ToggleButton>
+        <ToggleButton value="parquet">Materialized</ToggleButton>
+      </ToggleButtonGroup>
+      <Tooltip
+        title={
+          <Box sx={{ p: 0.5 }}>
+            <Typography variant="caption" display="block" sx={{ mb: 0.5 }}>
+              <b>Live</b> — the query streams from the connection each time the
+              dashboard loads. Always fresh; not shown in public shares.
+            </Typography>
+            <Typography variant="caption" display="block">
+              <b>Materialized</b> — the query is snapshotted to a Parquet file
+              and loaded into DuckDB, so widgets render fast and public viewers
+              get a cached snapshot. Click <b>Materialize</b> to build/refresh.
+            </Typography>
+          </Box>
+        }
+      >
+        <InfoIcon
+          size={15}
+          strokeWidth={1.5}
+          style={{ opacity: 0.6, cursor: "help" }}
+        />
+      </Tooltip>
+    </>
+  );
+
   const headerExtras = (
     <DataSourceMaterializationControls
+      leadingControls={leadingControls}
+      showMaterializeControls={isParquet}
       buildStatus={cache?.parquetBuildStatus ?? null}
       rowCount={cache?.rowCount ?? null}
       builtAtMs={
@@ -295,7 +352,7 @@ export default function DashboardDataSourceEditor({
       schedule={dashboard.materializationSchedule}
       onScheduleChange={handleScheduleChange}
       scheduleDisabled={dashboard.readOnly}
-      scheduleCaption="Dashboard schedules apply to every data source in this dashboard."
+      scheduleCaption="Dashboard schedules apply to every materialized data source in this dashboard."
       history={historyItems}
       onOpenHistory={loadHistory}
     />

--- a/app/src/components/DashboardDataSourceEditor.tsx
+++ b/app/src/components/DashboardDataSourceEditor.tsx
@@ -1,22 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import {
-  Box,
-  Typography,
-  Button,
-  Chip,
-  Tooltip,
-  IconButton,
-  Popover,
-  Divider,
-} from "@mui/material";
-import {
-  Database as MaterializeIcon,
-  CalendarClock as ScheduleIcon,
-  History as HistoryIcon,
-  Eye as PreviewIcon,
-  CheckCircle2 as SuccessIcon,
-  XCircle as ErrorIcon,
-} from "lucide-react";
+import { Box, Typography } from "@mui/material";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { useWorkspace } from "../contexts/workspace-context";
 import {
@@ -28,7 +11,9 @@ import { previewParquetArtifact } from "../lib/parquet-preview";
 import Console from "./Console";
 import ResultsTable from "./ResultsTable";
 import EntityBreadcrumbs from "./EntityBreadcrumbs";
-import MaterializationScheduleControls from "./MaterializationScheduleControls";
+import DataSourceMaterializationControls, {
+  type MaterializationHistoryItem,
+} from "./DataSourceMaterializationControls";
 import type { MaterializationScheduleValue } from "../lib/materializationSchedule";
 
 interface PreviewResult {
@@ -84,10 +69,6 @@ export default function DashboardDataSourceEditor({
   const [running, setRunning] = useState(false);
   const [materializing, setMaterializing] = useState(false);
   const [previewingSnapshot, setPreviewingSnapshot] = useState(false);
-  const [historyAnchor, setHistoryAnchor] = useState<HTMLElement | null>(null);
-  const [scheduleAnchor, setScheduleAnchor] = useState<HTMLElement | null>(
-    null,
-  );
   const [historyRuns, setHistoryRuns] = useState<MaterializationRunRecord[]>(
     [],
   );
@@ -250,19 +231,15 @@ export default function DashboardDataSourceEditor({
     }
   }, [workspaceId, dashboardId, dataSourceId, cache]);
 
-  const openHistory = useCallback(
-    async (anchor: HTMLElement) => {
-      setHistoryAnchor(anchor);
-      if (!workspaceId) return;
-      const runs = await fetchMaterializationRuns(
-        workspaceId,
-        dashboardId,
-        dataSourceId,
-      );
-      setHistoryRuns(runs);
-    },
-    [workspaceId, dashboardId, dataSourceId, fetchMaterializationRuns],
-  );
+  const loadHistory = useCallback(async () => {
+    if (!workspaceId) return;
+    const runs = await fetchMaterializationRuns(
+      workspaceId,
+      dashboardId,
+      dataSourceId,
+    );
+    setHistoryRuns(runs);
+  }, [workspaceId, dashboardId, dataSourceId, fetchMaterializationRuns]);
 
   if (!dashboard) {
     return (
@@ -281,65 +258,47 @@ export default function DashboardDataSourceEditor({
     );
   }
 
+  const historyItems: MaterializationHistoryItem[] = historyRuns.map(run => {
+    const finishedAt = run.finishedAt ? new Date(run.finishedAt) : null;
+    const startedAt = run.startedAt
+      ? new Date(run.startedAt)
+      : new Date(run.requestedAt);
+    const durationMs =
+      finishedAt && startedAt
+        ? finishedAt.getTime() - startedAt.getTime()
+        : null;
+    return {
+      id: run.runId,
+      status: run.status === "ready" ? "ready" : "error",
+      at: run.requestedAt,
+      rowCount: run.rowCount ?? null,
+      durationMs,
+      error: run.error ?? null,
+    };
+  });
+
   const headerExtras = (
-    <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, ml: 1 }}>
-      <Button
-        size="small"
-        variant="outlined"
-        startIcon={<MaterializeIcon size={16} strokeWidth={1.5} />}
-        onClick={() => void handleMaterialize()}
-        disabled={materializing}
-      >
-        {materializing ? "Materializing…" : "Materialize"}
-      </Button>
-      {cache?.parquetBuildStatus && (
-        <Chip
-          size="small"
-          variant="outlined"
-          color={
-            cache.parquetBuildStatus === "ready"
-              ? "success"
-              : cache.parquetBuildStatus === "error"
-                ? "error"
-                : "default"
-          }
-          label={
-            cache.parquetBuildStatus === "ready" && cache.rowCount != null
-              ? `${cache.rowCount.toLocaleString()} rows`
-              : cache.parquetBuildStatus
-          }
-        />
-      )}
-      {cache?.parquetBuildStatus === "ready" && (
-        <Tooltip title="Preview the materialized data">
-          <span>
-            <IconButton
-              size="small"
-              onClick={() => void handlePreviewSnapshot()}
-              disabled={previewingSnapshot}
-            >
-              <PreviewIcon size={18} strokeWidth={1.5} />
-            </IconButton>
-          </span>
-        </Tooltip>
-      )}
-      <Tooltip title="Materialization schedule">
-        <IconButton
-          size="small"
-          onClick={e => setScheduleAnchor(e.currentTarget)}
-        >
-          <ScheduleIcon size={18} strokeWidth={1.5} />
-        </IconButton>
-      </Tooltip>
-      <Tooltip title="Materialization history">
-        <IconButton
-          size="small"
-          onClick={e => void openHistory(e.currentTarget)}
-        >
-          <HistoryIcon size={18} strokeWidth={1.5} />
-        </IconButton>
-      </Tooltip>
-    </Box>
+    <DataSourceMaterializationControls
+      buildStatus={cache?.parquetBuildStatus ?? null}
+      rowCount={cache?.rowCount ?? null}
+      builtAtMs={
+        cache?.parquetBuiltAt ? Date.parse(cache.parquetBuiltAt) : null
+      }
+      dataFreshnessTtlMs={
+        dashboard.materializationSchedule?.dataFreshnessTtlMs ?? null
+      }
+      onMaterialize={() => void handleMaterialize()}
+      materializing={materializing}
+      canPreview={cache?.parquetBuildStatus === "ready"}
+      onPreviewSnapshot={() => void handlePreviewSnapshot()}
+      previewing={previewingSnapshot}
+      schedule={dashboard.materializationSchedule}
+      onScheduleChange={handleScheduleChange}
+      scheduleDisabled={dashboard.readOnly}
+      scheduleCaption="Dashboard schedules apply to every data source in this dashboard."
+      history={historyItems}
+      onOpenHistory={loadHistory}
+    />
   );
 
   return (
@@ -394,103 +353,6 @@ export default function DashboardDataSourceEditor({
           </Panel>
         </PanelGroup>
       </Box>
-
-      {/* Materialization history */}
-      <Popover
-        open={Boolean(historyAnchor)}
-        anchorEl={historyAnchor}
-        onClose={() => setHistoryAnchor(null)}
-        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
-      >
-        <Box sx={{ p: 1.5, minWidth: 320, maxWidth: 460 }}>
-          <Typography variant="subtitle2" sx={{ mb: 1 }}>
-            Materialization history
-          </Typography>
-          {historyRuns.length === 0 ? (
-            <Typography variant="caption" color="text.secondary">
-              No runs yet.
-            </Typography>
-          ) : (
-            historyRuns.map((run, i) => {
-              const finishedAt = run.finishedAt
-                ? new Date(run.finishedAt)
-                : null;
-              const startedAt = run.startedAt
-                ? new Date(run.startedAt)
-                : new Date(run.requestedAt);
-              const durationMs =
-                finishedAt && startedAt
-                  ? finishedAt.getTime() - startedAt.getTime()
-                  : null;
-              return (
-                <Box key={run.runId}>
-                  {i > 0 && <Divider sx={{ my: 0.5 }} />}
-                  <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                    {run.status === "ready" ? (
-                      <SuccessIcon
-                        size={16}
-                        strokeWidth={1.5}
-                        style={{
-                          color: "var(--mui-palette-success-main, green)",
-                        }}
-                      />
-                    ) : (
-                      <ErrorIcon
-                        size={16}
-                        strokeWidth={1.5}
-                        style={{
-                          color: "var(--mui-palette-error-main, crimson)",
-                        }}
-                      />
-                    )}
-                    <Typography variant="caption" sx={{ flex: 1 }}>
-                      {new Date(run.requestedAt).toLocaleString()}
-                    </Typography>
-                    {run.status === "ready" && run.rowCount != null && (
-                      <Typography variant="caption" color="text.secondary">
-                        {run.rowCount.toLocaleString()} rows
-                      </Typography>
-                    )}
-                    {durationMs != null && durationMs >= 0 && (
-                      <Typography variant="caption" color="text.secondary">
-                        {(durationMs / 1000).toFixed(1)}s
-                      </Typography>
-                    )}
-                  </Box>
-                  {run.error && (
-                    <Typography
-                      variant="caption"
-                      color="error"
-                      sx={{ display: "block", pl: 3, whiteSpace: "pre-wrap" }}
-                    >
-                      {run.error}
-                    </Typography>
-                  )}
-                </Box>
-              );
-            })
-          )}
-        </Box>
-      </Popover>
-
-      <Popover
-        open={Boolean(scheduleAnchor)}
-        anchorEl={scheduleAnchor}
-        onClose={() => setScheduleAnchor(null)}
-        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
-      >
-        <Box sx={{ p: 1.5, width: 360 }}>
-          <Typography variant="subtitle2" sx={{ mb: 1 }}>
-            Materialization settings
-          </Typography>
-          <MaterializationScheduleControls
-            value={dashboard.materializationSchedule}
-            onChange={handleScheduleChange}
-            disabled={dashboard.readOnly}
-            caption="Dashboard schedules apply to every data source in this dashboard."
-          />
-        </Box>
-      </Popover>
     </Box>
   );
 }

--- a/app/src/components/DataSourceMaterializationControls.tsx
+++ b/app/src/components/DataSourceMaterializationControls.tsx
@@ -1,0 +1,319 @@
+import { useCallback, useState, type ReactNode } from "react";
+import {
+  Box,
+  Typography,
+  Button,
+  Chip,
+  Tooltip,
+  IconButton,
+  Popover,
+  Divider,
+} from "@mui/material";
+import {
+  Database as MaterializeIcon,
+  CalendarClock as ScheduleIcon,
+  History as HistoryIcon,
+  Eye as PreviewIcon,
+  CheckCircle2 as SuccessIcon,
+  XCircle as ErrorIcon,
+} from "lucide-react";
+import MaterializationScheduleControls from "./MaterializationScheduleControls";
+import type { MaterializationScheduleValue } from "../lib/materializationSchedule";
+
+/**
+ * Shared materialization toolbar for app data bindings and dashboard data
+ * sources. Both surfaces present the same controls — Materialize button, build
+ * status chip, freshness badge, snapshot preview, schedule popover, and history
+ * popover — so the two editors look and behave identically. Surface-specific
+ * wiring (where the schedule/cache live, how history is loaded) is passed in.
+ */
+
+export type MaterializationBuildStatus =
+  | "missing"
+  | "queued"
+  | "building"
+  | "ready"
+  | "error";
+
+/** Normalized history entry rendered in the history popover. */
+export interface MaterializationHistoryItem {
+  id: string;
+  status: "ready" | "error";
+  /** ISO timestamp the run was requested/finished. */
+  at: string;
+  rowCount?: number | null;
+  durationMs?: number | null;
+  error?: string | null;
+}
+
+interface Props {
+  /** Optional leading controls (e.g. the app's Live/Materialized toggle). */
+  leadingControls?: ReactNode;
+  /**
+   * When false, the materialize cluster (button, chip, preview, history) is
+   * hidden — used by app live bindings, which have nothing to materialize. The
+   * schedule control is always hidden in that case too.
+   */
+  showMaterializeControls?: boolean;
+
+  buildStatus?: MaterializationBuildStatus | null;
+  rowCount?: number | null;
+  /** Epoch ms the artifact was last built — drives the freshness badge. */
+  builtAtMs?: number | null;
+  /** Freshness window in ms; when older than this the badge turns "Stale". */
+  dataFreshnessTtlMs?: number | null;
+
+  onMaterialize: () => void;
+  materializing: boolean;
+
+  canPreview?: boolean;
+  onPreviewSnapshot?: () => void;
+  previewing?: boolean;
+
+  schedule: MaterializationScheduleValue;
+  onScheduleChange: (next: MaterializationScheduleValue) => void;
+  scheduleDisabled?: boolean;
+  scheduleCaption: string;
+
+  /** History rows to render. May be loaded lazily via `onOpenHistory`. */
+  history: MaterializationHistoryItem[];
+  /** Invoked when the history popover opens (e.g. to fetch runs). */
+  onOpenHistory?: () => void | Promise<void>;
+  /** Hide the history control entirely (e.g. nothing to show). */
+  showHistory?: boolean;
+}
+
+const DEFAULT_FRESHNESS_TTL_MS = 24 * 60 * 60 * 1000;
+
+function formatRelative(ms: number): string {
+  const sec = Math.round(ms / 1000);
+  if (sec < 60) return "just now";
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  return `${Math.round(hr / 24)}d ago`;
+}
+
+export default function DataSourceMaterializationControls({
+  leadingControls,
+  showMaterializeControls = true,
+  buildStatus,
+  rowCount,
+  builtAtMs,
+  dataFreshnessTtlMs,
+  onMaterialize,
+  materializing,
+  canPreview,
+  onPreviewSnapshot,
+  previewing,
+  schedule,
+  onScheduleChange,
+  scheduleDisabled,
+  scheduleCaption,
+  history,
+  onOpenHistory,
+  showHistory = true,
+}: Props) {
+  const [scheduleAnchor, setScheduleAnchor] = useState<HTMLElement | null>(
+    null,
+  );
+  const [historyAnchor, setHistoryAnchor] = useState<HTMLElement | null>(null);
+
+  const openHistory = useCallback(
+    (anchor: HTMLElement) => {
+      setHistoryAnchor(anchor);
+      void onOpenHistory?.();
+    },
+    [onOpenHistory],
+  );
+
+  // Freshness badge: only meaningful once a snapshot exists. Stale when the
+  // artifact is older than the freshness window (default 24h, matching the
+  // dashboard canvas badge).
+  let freshness: { label: string; stale: boolean } | null = null;
+  if (buildStatus === "ready" && builtAtMs) {
+    const ageMs = Date.now() - builtAtMs;
+    const ttl = dataFreshnessTtlMs ?? DEFAULT_FRESHNESS_TTL_MS;
+    freshness = { label: formatRelative(ageMs), stale: ageMs > ttl };
+  }
+
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, ml: 1 }}>
+      {leadingControls}
+
+      {showMaterializeControls && (
+        <>
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={<MaterializeIcon size={16} strokeWidth={1.5} />}
+            onClick={onMaterialize}
+            disabled={materializing}
+          >
+            {materializing ? "Materializing…" : "Materialize"}
+          </Button>
+          {buildStatus && (
+            <Chip
+              size="small"
+              variant="outlined"
+              color={
+                buildStatus === "ready"
+                  ? "success"
+                  : buildStatus === "error"
+                    ? "error"
+                    : "default"
+              }
+              label={
+                buildStatus === "ready" && rowCount != null
+                  ? `${rowCount.toLocaleString()} rows`
+                  : buildStatus
+              }
+            />
+          )}
+          {freshness && (
+            <Tooltip
+              title={
+                freshness.stale
+                  ? "The snapshot is older than its freshness window — click Materialize to refresh."
+                  : "The snapshot is up to date."
+              }
+            >
+              <Chip
+                size="small"
+                variant="outlined"
+                color={freshness.stale ? "warning" : "default"}
+                label={
+                  freshness.stale
+                    ? `Stale · ${freshness.label}`
+                    : `Updated ${freshness.label}`
+                }
+              />
+            </Tooltip>
+          )}
+          {canPreview && onPreviewSnapshot && (
+            <Tooltip title="Preview the materialized data">
+              <span>
+                <IconButton
+                  size="small"
+                  onClick={() => onPreviewSnapshot()}
+                  disabled={previewing}
+                >
+                  <PreviewIcon size={18} strokeWidth={1.5} />
+                </IconButton>
+              </span>
+            </Tooltip>
+          )}
+          <Tooltip title="Materialization schedule">
+            <IconButton
+              size="small"
+              onClick={e => setScheduleAnchor(e.currentTarget)}
+            >
+              <ScheduleIcon size={18} strokeWidth={1.5} />
+            </IconButton>
+          </Tooltip>
+          {showHistory && (
+            <Tooltip title="Materialization history">
+              <span>
+                <IconButton
+                  size="small"
+                  onClick={e => openHistory(e.currentTarget)}
+                  disabled={history.length === 0 && !onOpenHistory}
+                >
+                  <HistoryIcon size={18} strokeWidth={1.5} />
+                </IconButton>
+              </span>
+            </Tooltip>
+          )}
+        </>
+      )}
+
+      <Popover
+        open={Boolean(scheduleAnchor)}
+        anchorEl={scheduleAnchor}
+        onClose={() => setScheduleAnchor(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+      >
+        <Box sx={{ p: 1.5, width: 360 }}>
+          <Typography variant="subtitle2" sx={{ mb: 1 }}>
+            Materialization settings
+          </Typography>
+          <MaterializationScheduleControls
+            value={schedule}
+            onChange={onScheduleChange}
+            disabled={scheduleDisabled}
+            caption={scheduleCaption}
+          />
+        </Box>
+      </Popover>
+
+      <Popover
+        open={Boolean(historyAnchor)}
+        anchorEl={historyAnchor}
+        onClose={() => setHistoryAnchor(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+      >
+        <Box sx={{ p: 1.5, minWidth: 320, maxWidth: 460 }}>
+          <Typography variant="subtitle2" sx={{ mb: 1 }}>
+            Materialization history
+          </Typography>
+          {history.length === 0 ? (
+            <Typography variant="caption" color="text.secondary">
+              No runs yet.
+            </Typography>
+          ) : (
+            history.map((run, i) => {
+              const durationMs = run.durationMs;
+              return (
+                <Box key={run.id}>
+                  {i > 0 && <Divider sx={{ my: 0.5 }} />}
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                    {run.status === "ready" ? (
+                      <SuccessIcon
+                        size={16}
+                        strokeWidth={1.5}
+                        style={{
+                          color: "var(--mui-palette-success-main, green)",
+                        }}
+                      />
+                    ) : (
+                      <ErrorIcon
+                        size={16}
+                        strokeWidth={1.5}
+                        style={{
+                          color: "var(--mui-palette-error-main, crimson)",
+                        }}
+                      />
+                    )}
+                    <Typography variant="caption" sx={{ flex: 1 }}>
+                      {new Date(run.at).toLocaleString()}
+                    </Typography>
+                    {run.status === "ready" && run.rowCount != null && (
+                      <Typography variant="caption" color="text.secondary">
+                        {run.rowCount.toLocaleString()} rows
+                      </Typography>
+                    )}
+                    {durationMs != null && durationMs >= 0 && (
+                      <Typography variant="caption" color="text.secondary">
+                        {(durationMs / 1000).toFixed(1)}s
+                      </Typography>
+                    )}
+                  </Box>
+                  {run.error && (
+                    <Typography
+                      variant="caption"
+                      color="error"
+                      sx={{ display: "block", pl: 3, whiteSpace: "pre-wrap" }}
+                    >
+                      {run.error}
+                    </Typography>
+                  )}
+                </Box>
+              );
+            })
+          )}
+        </Box>
+      </Popover>
+    </Box>
+  );
+}

--- a/app/src/components/public/PublicDashboardViewer.tsx
+++ b/app/src/components/public/PublicDashboardViewer.tsx
@@ -67,6 +67,10 @@ export interface PublicDashboardContent {
     id: string;
     name: string;
     tableRef: string;
+    // Live data sources are never served to anonymous public viewers (they'd
+    // require server-side query execution per view); they arrive as not-ready
+    // with no artifact and are skipped when loading tables.
+    materialization?: "live" | "parquet";
     ready: boolean;
     rowCount: number | null;
     materializedAt: string | null;

--- a/app/src/dashboard-runtime/agent-tools.ts
+++ b/app/src/dashboard-runtime/agent-tools.ts
@@ -483,6 +483,7 @@ export async function executeDashboardAgentTool(
             : undefined,
         rowLimit:
           typeof input.rowLimit === "number" ? input.rowLimit : undefined,
+        materialization: input.materialization === "live" ? "live" : "parquet",
         dashboardId: ctx.dashboardId,
         query: {
           connectionId: input.connectionId,
@@ -632,6 +633,11 @@ export async function executeDashboardAgentTool(
             typeof input.rowLimit === "number"
               ? input.rowLimit
               : existing.rowLimit,
+          materialization:
+            input.materialization === "live" ||
+            input.materialization === "parquet"
+              ? input.materialization
+              : existing.materialization,
           query: {
             ...existing.query,
             connectionId:

--- a/app/src/dashboard-runtime/commands.ts
+++ b/app/src/dashboard-runtime/commands.ts
@@ -247,6 +247,7 @@ export function buildDashboardDataSource(input: {
   timeDimension?: string;
   rowLimit?: number;
   origin?: DashboardDataSourceOrigin;
+  materialization?: "live" | "parquet";
 }): DashboardDataSource {
   return {
     id: nanoid(),
@@ -256,6 +257,7 @@ export function buildDashboardDataSource(input: {
     origin: input.origin,
     timeDimension: input.timeDimension,
     rowLimit: input.rowLimit,
+    materialization: input.materialization ?? "parquet",
     computedColumns: [],
   };
 }
@@ -266,6 +268,7 @@ export async function createDashboardDataSource(options: {
   query: DashboardQueryDefinition;
   timeDimension?: string;
   rowLimit?: number;
+  materialization?: "live" | "parquet";
   dashboardId?: string;
   signal?: AbortSignal;
 }): Promise<DashboardDataSource> {
@@ -276,6 +279,7 @@ export async function createDashboardDataSource(options: {
     query: options.query,
     timeDimension: options.timeDimension,
     rowLimit: options.rowLimit,
+    materialization: options.materialization,
     origin: { type: "local" },
   });
 

--- a/app/src/dashboard-runtime/gateway.ts
+++ b/app/src/dashboard-runtime/gateway.ts
@@ -35,6 +35,10 @@ function hashString(value: string): string {
   return String(hash >>> 0);
 }
 
+function isLiveDataSource(dataSource: DashboardDataSource): boolean {
+  return dataSource.materialization === "live";
+}
+
 function buildDataSourceDefinitionVersion(
   dataSource: DashboardDataSource,
 ): string {
@@ -43,6 +47,8 @@ function buildDataSourceDefinitionVersion(
     rowLimit: dataSource.rowLimit ?? null,
     query: dataSource.query,
     computedColumns: dataSource.computedColumns ?? [],
+    // Toggling live<->parquet must invalidate any cached DuckDB load.
+    materialization: dataSource.materialization ?? "parquet",
   };
   return hashString(JSON.stringify(payload));
 }
@@ -73,7 +79,13 @@ type DashboardRuntimeContext = "builder" | "viewer";
 
 export function resolveActiveSource(options: {
   skipParquet: boolean;
+  dataSource?: DashboardDataSource;
 }): DashboardDataSourceActiveSource {
+  // A persistent live data source streams the query on every load, distinct
+  // from a draft edit-preview stream of an otherwise-materialized source.
+  if (options.dataSource && isLiveDataSource(options.dataSource)) {
+    return "live_stream";
+  }
   if (options.skipParquet) {
     return "draft_stream";
   }
@@ -109,6 +121,9 @@ export function buildDataSourceLoadVersion(options: {
 }): string {
   const definitionHash = buildDataSourceDefinitionVersion(options.dataSource);
   const activeSource = resolveActiveSource(options);
+  if (activeSource === "live_stream") {
+    return `live:${definitionHash}`;
+  }
   if (activeSource === "draft_stream") {
     return `draft:${definitionHash}`;
   }
@@ -528,7 +543,11 @@ async function loadDashboardDataSourceWithFallback(options: {
       return {
         rowCount: totalRows ?? loadedRowCount,
         loadPath: "arrow_stream",
-        activeSource: skipParquet ? "draft_stream" : "live_stream",
+        activeSource: isLiveDataSource(dataSource)
+          ? "live_stream"
+          : skipParquet
+            ? "draft_stream"
+            : "live_stream",
       };
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
@@ -630,7 +649,11 @@ async function loadDashboardDataSourceWithFallback(options: {
         },
       ),
       loadPath: "ndjson_stream",
-      activeSource: skipParquet ? "draft_stream" : "live_stream",
+      activeSource: isLiveDataSource(dataSource)
+        ? "live_stream"
+        : skipParquet
+          ? "draft_stream"
+          : "live_stream",
     };
   };
 
@@ -848,16 +871,21 @@ export async function materializeDashboardDataSource(options: {
     dataSource,
     force = false,
     runtimeContext = "builder",
-    skipParquet = false,
     signal,
   } = options;
+  // Live data sources always stream the query server-side (there is no
+  // artifact), exactly like the draft-preview stream path. Parquet sources use
+  // the published artifact unless the caller explicitly requests a draft stream
+  // (e.g. an edit-mode preview before the artifact is rebuilt).
+  const skipParquet =
+    options.skipParquet === true || isLiveDataSource(dataSource);
   const session = await ensureDashboardSession(dashboard._id);
   const runtimeStore = useDashboardRuntimeStore.getState();
   const loadVersion = buildDataSourceLoadVersion({
     dataSource,
     skipParquet,
   });
-  const requestedSource = resolveActiveSource({ skipParquet });
+  const requestedSource = resolveActiveSource({ skipParquet, dataSource });
   const cachedVersion = session.dataSourceVersions.get(dataSource.id);
   const cache = (dataSource.cache || {}) as {
     definitionHash?: string;

--- a/app/src/dashboard-runtime/runtime-contract.test.ts
+++ b/app/src/dashboard-runtime/runtime-contract.test.ts
@@ -123,6 +123,39 @@ describe("dashboard runtime contract", () => {
     expect(draftV2).toBe(draftV1);
   });
 
+  it("streams persistent live data sources instead of loading an artifact", () => {
+    const liveDataSource = {
+      ...baseDashboard.dataSources[0],
+      materialization: "live" as const,
+    };
+
+    // A live source resolves to live_stream even when not skipping parquet
+    // (viewer load), unlike a parquet source which uses the published artifact.
+    expect(
+      resolveActiveSource({ skipParquet: false, dataSource: liveDataSource }),
+    ).toBe("live_stream");
+    expect(
+      resolveActiveSource({
+        skipParquet: false,
+        dataSource: baseDashboard.dataSources[0],
+      }),
+    ).toBe("published_artifact");
+
+    // Live load version is prefixed live: and ignores artifact revision.
+    const liveVersion = buildDataSourceLoadVersion({
+      dataSource: liveDataSource,
+      skipParquet: false,
+    });
+    expect(liveVersion.startsWith("live:")).toBe(true);
+
+    // Toggling materialization must invalidate the cached load.
+    const parquetVersion = buildDataSourceLoadVersion({
+      dataSource: baseDashboard.dataSources[0],
+      skipParquet: false,
+    });
+    expect(liveVersion).not.toBe(parquetVersion);
+  });
+
   it("prefers a newer parquet build timestamp over a stale artifact revision", () => {
     const viewerBefore = buildDataSourceLoadVersion({
       dataSource: {

--- a/app/src/utils/stateHash.ts
+++ b/app/src/utils/stateHash.ts
@@ -46,6 +46,7 @@ export function computeDashboardStateHash(dashboard: {
     computedColumns?: unknown[];
     timeDimension?: string;
     rowLimit?: number;
+    materialization?: "live" | "parquet";
   }>;
   relationships: unknown[];
   globalFilters: unknown[];
@@ -76,6 +77,7 @@ export function computeDashboardStateHash(dashboard: {
       computedColumns: ds.computedColumns,
       timeDimension: ds.timeDimension,
       rowLimit: ds.rowLimit,
+      materialization: ds.materialization,
     })),
     relationships: dashboard.relationships,
     globalFilters: dashboard.globalFilters,

--- a/docs/src/openapi/mako-api.json
+++ b/docs/src/openapi/mako-api.json
@@ -229,6 +229,14 @@
                 "tableRef": {
                   "type": "string"
                 },
+                "materialization": {
+                  "type": "string",
+                  "enum": [
+                    "live",
+                    "parquet"
+                  ],
+                  "default": "parquet"
+                },
                 "query": {
                   "type": "object",
                   "properties": {

--- a/packages/agent-tools/src/app-tools.ts
+++ b/packages/agent-tools/src/app-tools.ts
@@ -59,6 +59,31 @@ export const removeDependencySchema = z.object({
   name: z.string().describe("npm package name to remove"),
 });
 
+/**
+ * Per-binding materialization schedule. Mirrors
+ * `AppBindingMaterializationScheduleSchema` in `@mako/schemas`; kept as a local
+ * zod object so the agent-tools package stays dependency-light.
+ */
+export const bindingMaterializationScheduleSchema = z.object({
+  enabled: z.boolean().describe("Whether scheduled auto-refresh is enabled"),
+  cron: z
+    .string()
+    .nullable()
+    .describe(
+      "5-field cron expression (e.g. '0 * * * *' = hourly, '0 0 * * *' = " +
+        "daily). Required when enabled; pass null when disabled.",
+    ),
+  timezone: z
+    .string()
+    .optional()
+    .describe("IANA timezone for the cron (defaults to UTC)"),
+  dataFreshnessTtlMs: z
+    .number()
+    .nullable()
+    .optional()
+    .describe("Optional freshness window in ms used for staleness badges"),
+});
+
 export const createDataBindingSchema = z.object({
   appId: appIdField,
   name: z
@@ -80,6 +105,14 @@ export const createDataBindingSchema = z.object({
         "enabling fast client-side analytical SQL via useDuckDB(sql). " +
         "Use 'parquet' for analytics/aggregation over larger result sets; after " +
         "creating a parquet binding, call materialize_binding to build it.",
+    ),
+  materializationSchedule: bindingMaterializationScheduleSchema
+    .optional()
+    .describe(
+      "Optional cron schedule that auto-refreshes a 'parquet' binding. Only " +
+        "applies when materialization is 'parquet' (ignored/disabled for " +
+        "'live'). You can also set or change this later with " +
+        "app_set_binding_schedule.",
     ),
 });
 
@@ -129,6 +162,33 @@ export const createAppSchema = z.object({
 export const getAppStateSchema = z.object({ appId: appIdField });
 
 export { readFileSchema as appReadFileSchema };
+
+export const setBindingScheduleSchema = z.object({
+  appId: appIdField,
+  name: z
+    .string()
+    .describe(
+      "Name of the parquet binding to schedule (from list_data_sources)",
+    ),
+  enabled: z.boolean().describe("Turn the scheduled auto-refresh on or off"),
+  cron: z
+    .string()
+    .nullable()
+    .optional()
+    .describe(
+      "5-field cron expression. Required when enabling. E.g. '0 * * * *' = " +
+        "hourly, '0 */6 * * *' = every 6h, '0 0 * * *' = daily.",
+    ),
+  timezone: z
+    .string()
+    .optional()
+    .describe("IANA timezone for the cron (defaults to UTC)"),
+  dataFreshnessTtlMs: z
+    .number()
+    .nullable()
+    .optional()
+    .describe("Optional freshness window in ms used for staleness badges"),
+});
 
 export const materializeBindingSchema = z.object({
   appId: appIdField,

--- a/packages/agent-tools/src/dashboard-tools.ts
+++ b/packages/agent-tools/src/dashboard-tools.ts
@@ -208,6 +208,16 @@ const createDataSourceSchema = z.object({
     .number()
     .optional()
     .describe("Optional row limit for materialization"),
+  materialization: z
+    .enum(["live", "parquet"])
+    .default("parquet")
+    .describe(
+      "'parquet' (default) materializes the query to a cached artifact loaded " +
+        "into DuckDB — fast for aggregation and served to public shares. " +
+        "'live' streams the query server-side into DuckDB on every dashboard " +
+        "load (always fresh, not shown in anonymous public shares). Mirrors " +
+        "app data binding materialization.",
+    ),
 });
 
 const updateDataSourceQuerySchema = z.object({
@@ -236,6 +246,13 @@ const updateDataSourceQuerySchema = z.object({
   databaseName: z.string().optional().describe("Updated database name"),
   timeDimension: z.string().optional().describe("Updated default time column"),
   rowLimit: z.number().optional().describe("Updated row limit"),
+  materialization: z
+    .enum(["live", "parquet"])
+    .optional()
+    .describe(
+      "Switch this data source between 'live' (stream on every load) and " +
+        "'parquet' (cached materialized artifact).",
+    ),
   startLine: z
     .number()
     .optional()

--- a/packages/agent-tools/src/index.ts
+++ b/packages/agent-tools/src/index.ts
@@ -74,6 +74,8 @@ export {
   getAppStateSchema,
   appReadFileSchema,
   materializeBindingSchema,
+  setBindingScheduleSchema,
+  bindingMaterializationScheduleSchema,
 } from "./app-tools";
 export type { AppWriteFileInput, AppCreateDataBindingInput } from "./app-tools";
 

--- a/packages/schemas/src/dashboard.schema.ts
+++ b/packages/schemas/src/dashboard.schema.ts
@@ -38,6 +38,22 @@ export const DashboardDataSourceOriginSchema = z.object({
   importedAt: z.string().optional(),
 });
 
+/**
+ * How a dashboard data source's data reaches the widgets — mirrors app data
+ * bindings:
+ * - `parquet` (default): the query is materialized to a Parquet artifact and
+ *   loaded into DuckDB-WASM. Fast for aggregation; served to public shares.
+ * - `live`: the query is streamed server-side into the DuckDB table on every
+ *   load (no cache). Always fresh; not available in anonymous public shares.
+ */
+export const DashboardDataSourceMaterializationSchema = z.enum([
+  "live",
+  "parquet",
+]);
+export type DashboardDataSourceMaterialization = z.infer<
+  typeof DashboardDataSourceMaterializationSchema
+>;
+
 export const DashboardMaterializationScheduleSchema = z.object({
   enabled: z.boolean(),
   cron: z.string().nullable(),
@@ -53,6 +69,7 @@ export const DashboardDataSourceSchema = z.object({
   origin: DashboardDataSourceOriginSchema.optional(),
   timeDimension: z.string().optional(),
   rowLimit: z.number().optional(),
+  materialization: DashboardDataSourceMaterializationSchema.default("parquet"),
   cache: z
     .object({
       lastRefreshedAt: z.string().optional(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Brings app and dashboard **data sources to full parity** — unified mechanism, appearance, scheduling, agent tooling, and now a shared `live | parquet` materialization mode — and fixes two real bugs along the way.

## Walkthrough

Dashboards now support a **live** materialization mode like apps. A live dashboard data source streams its query into DuckDB on every load — here the KPI updates `20 → 25` after 5 rows were added to the source, on a plain reload with no Materialize click:

[dashboard_live_mode_refresh.mp4](https://cursor.com/agents/bc-4df8fd62-21c7-4602-b496-b39b4a18d028/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_live_mode_refresh.mp4)
[Live dashboard KPI 20](https://cursor.com/agents/bc-4df8fd62-21c7-4602-b496-b39b4a18d028/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_live_kpi_20.webp)
[Live dashboard KPI 25 after reload](https://cursor.com/agents/bc-4df8fd62-21c7-4602-b496-b39b4a18d028/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_live_kpi_25.webp)

The dashboard data source editor gains the same Live/Materialized toggle as app bindings (materialize controls hide in Live mode):

[Dashboard Live/Materialized toggle](https://cursor.com/agents/bc-4df8fd62-21c7-4602-b496-b39b4a18d028/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_live_toggle.webp)

Shared materialization toolbar across both surfaces (Materialize, status chip, freshness badge, schedule, history):

[Unified toolbar app binding](https://cursor.com/agents/bc-4df8fd62-21c7-4602-b496-b39b4a18d028/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Funified_toolbar_app_binding.webp)
[Unified toolbar dashboard source](https://cursor.com/agents/bc-4df8fd62-21c7-4602-b496-b39b4a18d028/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Funified_toolbar_dashboard_source.webp)

App binding schedule now persists across reload (Fix 1):

[app_binding_schedule_persists.mp4](https://cursor.com/agents/bc-4df8fd62-21c7-4602-b496-b39b4a18d028/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_binding_schedule_persists.mp4)

## What's included

**Fix 1 — app binding schedule persists.** `PUT /apps/:id` (and create) dropped per-binding `materializationSchedule`; now validated + persisted like dashboards. Live bindings keep a disabled schedule.

**Mechanism parity — auto-refresh on edit.** Editing a scheduled parquet binding's query auto-queues a forced rebuild (mirrors dashboards).

**Fix 2 — agent can schedule app data sources.** Optional `materializationSchedule` on `app_create_data_binding` + new `app_set_binding_schedule` tool (validated, allowlisted, documented).

**Appearance unification.** New shared `DataSourceMaterializationControls` component used by both editors (Materialize button, status chip, freshness badge, snapshot preview, schedule + history popovers); apps gain a freshness badge; the app Materialize button forces a rebuild.

**Live mode for dashboards (full parity).**
- schema: `materialization: "live" | "parquet"` (default `parquet`) on dashboard data sources (zod + mongoose + OpenAPI + normalize). Missing == parquet, so no migration needed.
- runtime: live sources stream into DuckDB on every load (`live_stream`) instead of loading an artifact; `materializeDashboardDataSource` forces the stream path for live (single choke point); materialization is part of the load-version + dashboard state hash.
- pipeline: live sources excluded from artifact rebuild, refresh runner, scheduled/auto refresh, and unified refresh.
- public share: live sources serialized as not-ready with no artifact (anonymous viewers never get live execution, mirroring public apps); refresh guarded when no parquet sources.
- UI: Live/Materialized toggle in the dashboard data source editor.
- agent: `create_data_source` / `update_data_source_query` accept `materialization`; documented in the dashboards SKILL.

## Testing

- ✅ `pnpm --filter app run typecheck` / `lint`
- ✅ `pnpm --filter api run lint` / `build`
- ✅ `vitest run src/dashboard-runtime/runtime-contract.test.ts` (added live-mode contract test: live → `live_stream` + `live:` version)
- ✅ API contract: app schedule persists (invalid cron → 400); editing a scheduled binding auto-rebuilds (20→3, no manual materialize); agent `app_set_binding_schedule` (enable/invalid/unknown/disable)
- ✅ API contract (dashboards): toggle data source to `live` persists; refreshing a live source rejected; public content gates live (`ready:false`, no artifact); public refresh of a live-only dashboard → 400
- ✅ Manual GUI: unified toolbar on both surfaces; app schedule persists across reload; **dashboard live data source renders and refreshes on reload (20→25) with no materialize**; dashboard Live/Materialized toggle

Note: Fix 0 (force on editor/explorer/agent materialize) ships in #610; this branch independently forces the unified app Materialize action.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4df8fd62-21c7-4602-b496-b39b4a18d028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4df8fd62-21c7-4602-b496-b39b4a18d028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

