### PR TITLE
feat(sync-cdc): in-place table repartition (copy + swap) for CDC layout changes

### DIFF
--- a/api/src/databases/test-support/README.md
+++ b/api/src/databases/test-support/README.md
@@ -24,10 +24,29 @@ CI: offline suite runs in `api-contract.yml`; the gated suites run nightly in
 | --- | --- | --- |
 | Dialect contract | `drivers/destination-contract.test.ts` | Table-driven over every destination driver |
 | CDC SQL builder | `sync-cdc/adapters/bigquery-merge.test.ts` | Inline-snapshot the MERGE |
+| CDC repartition SQL | `sync-cdc/adapters/repartition-sql.test.ts` | Copy+swap statements (BigQuery + ClickHouse) |
+| CDC `_syncedAt` stamp | `sync-cdc/adapters/synced-at.test.ts` | `withSyncedAt` contract |
 | Driver write-SQL | `drivers/{postgresql,bigquery}/write-sql.test.ts` | Stub `executeQuery`, assert SQL |
 | Orchestration | `services/destination-writer.service.test.ts` | Via `_injectForTest` seam |
 | Emulator seam | `utils/bigquery-emulator.test.ts` | Host detection / endpoint helpers |
-| Integration (gated) | `drivers/**/**.integration.test.ts` | testcontainers / bigquery-emulator |
+| Integration (gated) | `drivers/**/**.integration.test.ts`, `sync-cdc/adapters/clickhouse-repartition.integration.test.ts` | testcontainers / bigquery-emulator |
+
+### ClickHouse in-place repartition (gated)
+
+`sync-cdc/adapters/clickhouse-repartition.integration.test.ts` runs the real
+copy+`EXCHANGE TABLES` swap and asserts the partition key changes while rows are
+preserved. It uses an external server when `CLICKHOUSE_TEST_HTTP` is set,
+otherwise testcontainers:
+
+```bash
+# Against an already-running ClickHouse (no Docker):
+RUN_DB_INTEGRATION=1 CLICKHOUSE_TEST_HTTP=http://localhost:8123 \
+  pnpm --filter api exec vitest run --config vitest.destinations.config.ts \
+  src/sync-cdc/adapters/clickhouse-repartition.integration.test.ts
+
+# Via testcontainers (requires Docker):
+RUN_DB_INTEGRATION=1 pnpm --filter api run test:destinations
+```
 
 ## Helpers (this folder)
 

--- a/api/src/sync-cdc/adapters/bigquery.ts
+++ b/api/src/sync-cdc/adapters/bigquery.ts
@@ -319,6 +319,51 @@ export function buildMergeStatement(p: BuildMergeStatementParams): string {
     .join("\n");
 }
 
+/**
+ * BigQuery `PARTITION BY` clause for a CDC layout (empty when unpartitioned).
+ * Exported for contract testing.
+ */
+export function bigQueryPartitionClause(layout: CdcEntityLayout): string {
+  if (!layout.partitioning?.field) return "";
+  const gran = layout.partitioning.granularity?.toUpperCase() || "DAY";
+  return `PARTITION BY TIMESTAMP_TRUNC(${escId(layout.partitioning.field)}, ${gran})`;
+}
+
+export function bigQueryClusterClause(layout: CdcEntityLayout): string {
+  if (!layout.clustering?.fields?.length) return "";
+  return `CLUSTER BY ${layout.clustering.fields.map(escId).join(", ")}`;
+}
+
+export interface BigQueryRepartitionStatements {
+  createTmp: string;
+  dropLive: string;
+  rename: string;
+}
+
+/**
+ * Build the statements that rewrite a live table's partition/cluster layout in
+ * place: CTAS into a new-layout table, drop the old, rename the new. Exported
+ * for contract testing + reuse by the gated integration suite.
+ */
+export function buildBigQueryRepartitionStatements(params: {
+  fullLive: string;
+  fullTmp: string;
+  liveName: string;
+  layout: CdcEntityLayout;
+}): BigQueryRepartitionStatements {
+  const partitionClause = bigQueryPartitionClause(params.layout);
+  const clusterClause = bigQueryClusterClause(params.layout);
+  return {
+    createTmp:
+      `CREATE TABLE ${params.fullTmp} ${partitionClause} ${clusterClause} AS SELECT * FROM ${params.fullLive}`.replace(
+        /\s+/g,
+        " ",
+      ),
+    dropLive: `DROP TABLE ${params.fullLive}`,
+    rename: `ALTER TABLE ${params.fullTmp} RENAME TO ${escId(params.liveName)}`,
+  };
+}
+
 interface BigQueryAdapterConfig {
   destinationDatabaseId: string;
   destinationDatabaseName?: string;
@@ -397,17 +442,6 @@ export class BigQueryDestinationAdapter implements CdcDestinationAdapter {
     });
   }
 
-  private partitionClauseFor(layout: CdcEntityLayout): string {
-    if (!layout.partitioning?.field) return "";
-    const gran = layout.partitioning.granularity?.toUpperCase() || "DAY";
-    return `PARTITION BY TIMESTAMP_TRUNC(${escId(layout.partitioning.field)}, ${gran})`;
-  }
-
-  private clusterClauseFor(layout: CdcEntityLayout): string {
-    if (!layout.clustering?.fields?.length) return "";
-    return `CLUSTER BY ${layout.clustering.fields.map(escId).join(", ")}`;
-  }
-
   async repartitionLiveTable(
     layout: CdcEntityLayout,
   ): Promise<{ repartitioned: boolean }> {
@@ -421,8 +455,6 @@ export class BigQueryDestinationAdapter implements CdcDestinationAdapter {
     const tmp = `${live}__repart_${Date.now().toString(36)}`;
     const fullLive = `${escId(projectId)}.${escId(dataset)}.${escId(live)}`;
     const fullTmp = `${escId(projectId)}.${escId(dataset)}.${escId(tmp)}`;
-    const partitionClause = this.partitionClauseFor(layout);
-    const clusterClause = this.clusterClauseFor(layout);
 
     const run = async (sql: string) => {
       const r = await databaseConnectionService.executeQuery(destination, sql, {
@@ -435,12 +467,16 @@ export class BigQueryDestinationAdapter implements CdcDestinationAdapter {
     // Copy current rows into a new table laid out with the desired partitioning
     // / clustering, then swap (drop old, rename new). The caller pauses the
     // stream so no writes land on the old table during this window.
+    const stmts = buildBigQueryRepartitionStatements({
+      fullLive,
+      fullTmp,
+      liveName: live,
+      layout,
+    });
     await run(`DROP TABLE IF EXISTS ${fullTmp}`);
-    await run(
-      `CREATE TABLE ${fullTmp} ${partitionClause} ${clusterClause} AS SELECT * FROM ${fullLive}`,
-    );
-    await run(`DROP TABLE ${fullLive}`);
-    await run(`ALTER TABLE ${fullTmp} RENAME TO ${escId(live)}`);
+    await run(stmts.createTmp);
+    await run(stmts.dropLive);
+    await run(stmts.rename);
 
     invalidateCachedSchema(getSchemaCacheKey(projectId, dataset, live));
     log.info("Repartitioned live table in place", {

--- a/api/src/sync-cdc/adapters/bigquery.ts
+++ b/api/src/sync-cdc/adapters/bigquery.ts
@@ -397,6 +397,62 @@ export class BigQueryDestinationAdapter implements CdcDestinationAdapter {
     });
   }
 
+  private partitionClauseFor(layout: CdcEntityLayout): string {
+    if (!layout.partitioning?.field) return "";
+    const gran = layout.partitioning.granularity?.toUpperCase() || "DAY";
+    return `PARTITION BY TIMESTAMP_TRUNC(${escId(layout.partitioning.field)}, ${gran})`;
+  }
+
+  private clusterClauseFor(layout: CdcEntityLayout): string {
+    if (!layout.clustering?.fields?.length) return "";
+    return `CLUSTER BY ${layout.clustering.fields.map(escId).join(", ")}`;
+  }
+
+  async repartitionLiveTable(
+    layout: CdcEntityLayout,
+  ): Promise<{ repartitioned: boolean }> {
+    const { bq, projectId, dataset, destination, datasetLocation } =
+      await this.resolveBqClient();
+    const live = layout.tableName;
+
+    const [exists] = await bq.dataset(dataset).table(live).exists();
+    if (!exists) return { repartitioned: false };
+
+    const tmp = `${live}__repart_${Date.now().toString(36)}`;
+    const fullLive = `${escId(projectId)}.${escId(dataset)}.${escId(live)}`;
+    const fullTmp = `${escId(projectId)}.${escId(dataset)}.${escId(tmp)}`;
+    const partitionClause = this.partitionClauseFor(layout);
+    const clusterClause = this.clusterClauseFor(layout);
+
+    const run = async (sql: string) => {
+      const r = await databaseConnectionService.executeQuery(destination, sql, {
+        location: datasetLocation,
+        bigQueryJobMaxWaitMs: 15 * 60 * 1000,
+      });
+      if (!r.success) throw new Error(r.error || `BigQuery DDL failed: ${sql}`);
+    };
+
+    // Copy current rows into a new table laid out with the desired partitioning
+    // / clustering, then swap (drop old, rename new). The caller pauses the
+    // stream so no writes land on the old table during this window.
+    await run(`DROP TABLE IF EXISTS ${fullTmp}`);
+    await run(
+      `CREATE TABLE ${fullTmp} ${partitionClause} ${clusterClause} AS SELECT * FROM ${fullLive}`,
+    );
+    await run(`DROP TABLE ${fullLive}`);
+    await run(`ALTER TABLE ${fullTmp} RENAME TO ${escId(live)}`);
+
+    invalidateCachedSchema(getSchemaCacheKey(projectId, dataset, live));
+    log.info("Repartitioned live table in place", {
+      liveTable: live,
+      dataset,
+      partition: layout.partitioning?.field,
+      granularity: layout.partitioning?.granularity,
+      cluster: layout.clustering?.fields,
+    });
+    return { repartitioned: true };
+  }
+
   async applyEvents(params: {
     events: CdcStoredEvent[];
     layout: CdcEntityLayout;

--- a/api/src/sync-cdc/adapters/bigquery.ts
+++ b/api/src/sync-cdc/adapters/bigquery.ts
@@ -342,8 +342,11 @@ export interface BigQueryRepartitionStatements {
 
 /**
  * Build the statements that rewrite a live table's partition/cluster layout in
- * place: CTAS into a new-layout table, drop the old, rename the new. Exported
- * for contract testing + reuse by the gated integration suite.
+ * place: `CREATE OR REPLACE` a new-layout table from the current rows, drop the
+ * old table, then rename the new one into place. This is the swap BigQuery
+ * actually supports (no atomic EXCHANGE); the caller pauses the stream so the
+ * brief window where `live` is renamed is safe. Exported for contract testing +
+ * reuse by the gated integration suite.
  */
 export function buildBigQueryRepartitionStatements(params: {
   fullLive: string;
@@ -355,7 +358,7 @@ export function buildBigQueryRepartitionStatements(params: {
   const clusterClause = bigQueryClusterClause(params.layout);
   return {
     createTmp:
-      `CREATE TABLE ${params.fullTmp} ${partitionClause} ${clusterClause} AS SELECT * FROM ${params.fullLive}`.replace(
+      `CREATE OR REPLACE TABLE ${params.fullTmp} ${partitionClause} ${clusterClause} AS SELECT * FROM ${params.fullLive}`.replace(
         /\s+/g,
         " ",
       ),
@@ -464,16 +467,15 @@ export class BigQueryDestinationAdapter implements CdcDestinationAdapter {
       if (!r.success) throw new Error(r.error || `BigQuery DDL failed: ${sql}`);
     };
 
-    // Copy current rows into a new table laid out with the desired partitioning
-    // / clustering, then swap (drop old, rename new). The caller pauses the
-    // stream so no writes land on the old table during this window.
+    // CREATE OR REPLACE a new-layout table from the current rows, drop the old
+    // table, then rename the new one in. The caller pauses the stream so the
+    // brief window where `live` is renamed is safe.
     const stmts = buildBigQueryRepartitionStatements({
       fullLive,
       fullTmp,
       liveName: live,
       layout,
     });
-    await run(`DROP TABLE IF EXISTS ${fullTmp}`);
     await run(stmts.createTmp);
     await run(stmts.dropLive);
     await run(stmts.rename);

--- a/api/src/sync-cdc/adapters/clickhouse-repartition.integration.test.ts
+++ b/api/src/sync-cdc/adapters/clickhouse-repartition.integration.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  clickHousePartitionClause,
+  buildClickHouseRepartitionStatements,
+} from "./clickhouse";
+import { buildCdcEntityLayout } from "./registry";
+
+/**
+ * Gated integration test for the ClickHouse in-place repartition (copy + swap).
+ * Executes the SAME SQL the adapter runs (`buildClickHouseRepartitionStatements`)
+ * against a real ClickHouse and asserts the partition key changes while the
+ * existing rows are preserved — i.e. the layout is rewritten WITHOUT re-fetching
+ * from the source.
+ *
+ * Skipped unless RUN_DB_INTEGRATION=1. Uses an external server when
+ * CLICKHOUSE_TEST_HTTP is set (e.g. http://localhost:8123), otherwise spins one
+ * up via testcontainers (requires Docker). Runs in the nightly CI job.
+ */
+const RUN =
+  process.env.RUN_DB_INTEGRATION === "1" ||
+  process.env.RUN_DB_INTEGRATION === "true";
+
+describe.skipIf(!RUN)("ClickHouse in-place repartition", () => {
+  let container: { stop: () => Promise<unknown> } | undefined;
+  let baseUrl = "";
+
+  beforeAll(async () => {
+    const external = process.env.CLICKHOUSE_TEST_HTTP;
+    if (external) {
+      baseUrl = external.replace(/\/$/, "");
+      return;
+    }
+    // Import lazily so the offline suite never loads testcontainers.
+    const { GenericContainer } = await import("testcontainers");
+    const started = await new GenericContainer(
+      "clickhouse/clickhouse-server:24-alpine",
+    )
+      .withExposedPorts(8123)
+      .start();
+    container = started;
+    baseUrl = `http://${started.getHost()}:${started.getMappedPort(8123)}`;
+  }, 180_000);
+
+  afterAll(async () => {
+    if (container) await container.stop();
+  });
+
+  const ch = async (sql: string): Promise<Array<Record<string, string>>> => {
+    const isSelect = /^\s*select/i.test(sql);
+    const url = isSelect
+      ? `${baseUrl}/?default_format=JSONEachRow`
+      : `${baseUrl}/`;
+    const res = await fetch(url, { method: "POST", body: sql });
+    const text = await res.text();
+    if (!res.ok) throw new Error(`CH failed: ${sql} :: ${text}`);
+    if (!isSelect || !text.trim()) return [];
+    return text
+      .trim()
+      .split("\n")
+      .map(line => JSON.parse(line));
+  };
+
+  const partitionKey = async (db: string, table: string): Promise<string> => {
+    const rows = await ch(
+      `SELECT partition_key FROM system.tables WHERE database = '${db}' AND name = '${table}'`,
+    );
+    return String(rows[0]?.partition_key ?? "");
+  };
+
+  it("changes the partition key while preserving rows (copy + EXCHANGE)", async () => {
+    const db = "default";
+    const live = `repart_it_${Date.now().toString(36)}`;
+    const tmp = `${live}__repart_tmp`;
+    const fullLive = `\`${db}\`.\`${live}\``;
+    const fullTmp = `\`${db}\`.\`${tmp}\``;
+
+    // Seed a table with the OLD layout (partitioned by date_created).
+    await ch(
+      `CREATE TABLE ${fullLive} (
+         id String, _syncedAt DateTime64(3),
+         date_created DateTime64(3), _mako_source_ts DateTime64(3)
+       ) ENGINE = ReplacingMergeTree(_mako_source_ts)
+       PARTITION BY toYYYYMMDD(date_created) ORDER BY (id)`,
+    );
+    await ch(
+      `INSERT INTO ${fullLive} VALUES
+        ('a','2026-06-30 10:00:00','2026-01-01 00:00:00','2026-06-30 10:00:00'),
+        ('b','2026-06-30 11:00:00','2026-02-01 00:00:00','2026-06-30 11:00:00'),
+        ('c','2026-06-30 12:00:00','2026-03-01 00:00:00','2026-06-30 12:00:00')`,
+    );
+
+    expect(await partitionKey(db, live)).toBe("toYYYYMMDD(date_created)");
+
+    // NEW desired layout: partition by _syncedAt — the exact SQL the adapter runs.
+    const layout = buildCdcEntityLayout({
+      entity: "leads",
+      tableName: live,
+      keyColumns: ["id"],
+      partitioning: { type: "time", field: "_syncedAt", granularity: "day" },
+    });
+    const stmts = buildClickHouseRepartitionStatements({
+      fullLive,
+      fullTmp,
+      partitionClause: clickHousePartitionClause(layout),
+      orderByColumns: layout.keyColumns,
+    });
+    await ch(`DROP TABLE IF EXISTS ${fullTmp}`);
+    await ch(stmts.createTmp);
+    await ch(stmts.copy);
+    await ch(stmts.exchange);
+    await ch(`DROP TABLE IF EXISTS ${fullTmp}`);
+
+    // Partition key changed; rows preserved exactly (no re-fetch).
+    expect(await partitionKey(db, live)).toBe("toYYYYMMDD(_syncedAt)");
+    const ids = (await ch(`SELECT id FROM ${fullLive} ORDER BY id`)).map(
+      r => r.id,
+    );
+    expect(ids).toEqual(["a", "b", "c"]);
+
+    await ch(`DROP TABLE IF EXISTS ${fullLive}`);
+  }, 120_000);
+});

--- a/api/src/sync-cdc/adapters/clickhouse.ts
+++ b/api/src/sync-cdc/adapters/clickhouse.ts
@@ -67,6 +67,55 @@ const escId = (id: string) => `\`${id.replace(/`/g, "``")}\``;
 
 const escStr = (val: string) => val.replace(/'/g, "''");
 
+/**
+ * ClickHouse `PARTITION BY` clause for a CDC layout (empty when unpartitioned).
+ * Exported for contract testing — partition expression shape is correctness
+ * critical for in-place repartition.
+ */
+export function clickHousePartitionClause(layout: CdcEntityLayout): string {
+  if (!layout.partitioning?.field) return "";
+  const field = escId(layout.partitioning.field);
+  const gran = (layout.partitioning.granularity || "day").toLowerCase();
+  switch (gran) {
+    case "hour":
+      return `PARTITION BY toStartOfHour(${field})`;
+    case "month":
+      return `PARTITION BY toYYYYMM(${field})`;
+    case "year":
+      return `PARTITION BY toYear(${field})`;
+    default:
+      return `PARTITION BY toYYYYMMDD(${field})`;
+  }
+}
+
+export interface ClickHouseRepartitionStatements {
+  createTmp: string;
+  copy: string;
+  exchange: string;
+}
+
+/**
+ * Build the happy-path statements that rewrite a live table's partition/sort
+ * layout in place: create a sibling table with the new layout, copy the rows,
+ * then atomically swap. Exported for contract testing + reuse by the gated
+ * integration suite.
+ */
+export function buildClickHouseRepartitionStatements(params: {
+  fullLive: string;
+  fullTmp: string;
+  partitionClause: string;
+  orderByColumns: string[];
+  sourceTsColumn?: string;
+}): ClickHouseRepartitionStatements {
+  const orderBy = params.orderByColumns.map(escId).join(", ");
+  const versionCol = escId(params.sourceTsColumn || "_mako_source_ts");
+  return {
+    createTmp: `CREATE TABLE ${params.fullTmp} AS ${params.fullLive} ENGINE = ReplacingMergeTree(${versionCol}) ${params.partitionClause} ORDER BY (${orderBy})`,
+    copy: `INSERT INTO ${params.fullTmp} SELECT * FROM ${params.fullLive}`,
+    exchange: `EXCHANGE TABLES ${params.fullLive} AND ${params.fullTmp}`,
+  };
+}
+
 interface ClickHouseAdapterConfig {
   destinationDatabaseId: string;
   destinationDatabaseName?: string;
@@ -165,22 +214,6 @@ export class ClickHouseDestinationAdapter implements CdcDestinationAdapter {
     await this.executeQuery(ddl);
   }
 
-  private partitionClauseFor(layout: CdcEntityLayout): string {
-    if (!layout.partitioning?.field) return "";
-    const field = escId(layout.partitioning.field);
-    const gran = (layout.partitioning.granularity || "day").toLowerCase();
-    switch (gran) {
-      case "hour":
-        return `PARTITION BY toStartOfHour(${field})`;
-      case "month":
-        return `PARTITION BY toYYYYMM(${field})`;
-      case "year":
-        return `PARTITION BY toYear(${field})`;
-      default:
-        return `PARTITION BY toYYYYMMDD(${field})`;
-    }
-  }
-
   async repartitionLiveTable(
     layout: CdcEntityLayout,
   ): Promise<{ repartitioned: boolean }> {
@@ -196,21 +229,21 @@ export class ClickHouseDestinationAdapter implements CdcDestinationAdapter {
     const tmp = `${live}__repart_${Date.now().toString(36)}`;
     const fullLive = `${escId(db)}.${escId(live)}`;
     const fullTmp = `${escId(db)}.${escId(tmp)}`;
-    const partitionClause = this.partitionClauseFor(layout);
-    const keyColumns = layout.keyColumns.map(escId).join(", ");
 
     // Create a sibling table with the same columns but the new partitioning /
     // sort key, copy the current rows, then atomically swap. The caller pauses
     // the stream so no writes land on the old table during this window.
+    const stmts = buildClickHouseRepartitionStatements({
+      fullLive,
+      fullTmp,
+      partitionClause: clickHousePartitionClause(layout),
+      orderByColumns: layout.keyColumns,
+    });
     await this.executeQuery(`DROP TABLE IF EXISTS ${fullTmp}`);
-    await this.executeQuery(
-      `CREATE TABLE ${fullTmp} AS ${fullLive} ENGINE = ReplacingMergeTree(_mako_source_ts) ${partitionClause} ORDER BY (${keyColumns})`,
-    );
-    await this.executeQuery(
-      `INSERT INTO ${fullTmp} SELECT * FROM ${fullLive}`,
-    );
+    await this.executeQuery(stmts.createTmp);
+    await this.executeQuery(stmts.copy);
     try {
-      await this.executeQuery(`EXCHANGE TABLES ${fullLive} AND ${fullTmp}`);
+      await this.executeQuery(stmts.exchange);
       await this.executeQuery(`DROP TABLE IF EXISTS ${fullTmp}`);
     } catch (err) {
       // EXCHANGE TABLES requires the Atomic database engine; fall back to a

--- a/api/src/sync-cdc/adapters/clickhouse.ts
+++ b/api/src/sync-cdc/adapters/clickhouse.ts
@@ -165,6 +165,76 @@ export class ClickHouseDestinationAdapter implements CdcDestinationAdapter {
     await this.executeQuery(ddl);
   }
 
+  private partitionClauseFor(layout: CdcEntityLayout): string {
+    if (!layout.partitioning?.field) return "";
+    const field = escId(layout.partitioning.field);
+    const gran = (layout.partitioning.granularity || "day").toLowerCase();
+    switch (gran) {
+      case "hour":
+        return `PARTITION BY toStartOfHour(${field})`;
+      case "month":
+        return `PARTITION BY toYYYYMM(${field})`;
+      case "year":
+        return `PARTITION BY toYear(${field})`;
+      default:
+        return `PARTITION BY toYYYYMMDD(${field})`;
+    }
+  }
+
+  async repartitionLiveTable(
+    layout: CdcEntityLayout,
+  ): Promise<{ repartitioned: boolean }> {
+    const db = this.getDatabase();
+    const live = layout.tableName;
+
+    const existsResult = await this.executeQuery(
+      `SELECT count() AS c FROM system.tables WHERE database = '${escStr(db)}' AND name = '${escStr(live)}'`,
+    );
+    const exists = Number(existsResult?.data?.[0]?.c || 0) > 0;
+    if (!exists) return { repartitioned: false };
+
+    const tmp = `${live}__repart_${Date.now().toString(36)}`;
+    const fullLive = `${escId(db)}.${escId(live)}`;
+    const fullTmp = `${escId(db)}.${escId(tmp)}`;
+    const partitionClause = this.partitionClauseFor(layout);
+    const keyColumns = layout.keyColumns.map(escId).join(", ");
+
+    // Create a sibling table with the same columns but the new partitioning /
+    // sort key, copy the current rows, then atomically swap. The caller pauses
+    // the stream so no writes land on the old table during this window.
+    await this.executeQuery(`DROP TABLE IF EXISTS ${fullTmp}`);
+    await this.executeQuery(
+      `CREATE TABLE ${fullTmp} AS ${fullLive} ENGINE = ReplacingMergeTree(_mako_source_ts) ${partitionClause} ORDER BY (${keyColumns})`,
+    );
+    await this.executeQuery(
+      `INSERT INTO ${fullTmp} SELECT * FROM ${fullLive}`,
+    );
+    try {
+      await this.executeQuery(`EXCHANGE TABLES ${fullLive} AND ${fullTmp}`);
+      await this.executeQuery(`DROP TABLE IF EXISTS ${fullTmp}`);
+    } catch (err) {
+      // EXCHANGE TABLES requires the Atomic database engine; fall back to a
+      // (non-atomic) RENAME swap, which the paused stream makes safe.
+      log.warn("EXCHANGE TABLES failed, falling back to RENAME swap", {
+        live,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      const old = `${live}__repart_old_${Date.now().toString(36)}`;
+      await this.executeQuery(
+        `RENAME TABLE ${fullLive} TO ${escId(db)}.${escId(old)}, ${fullTmp} TO ${fullLive}`,
+      );
+      await this.executeQuery(`DROP TABLE IF EXISTS ${escId(db)}.${escId(old)}`);
+    }
+
+    log.info("Repartitioned live table in place", {
+      liveTable: live,
+      database: db,
+      partition: layout.partitioning?.field,
+      granularity: layout.partitioning?.granularity,
+    });
+    return { repartitioned: true };
+  }
+
   async applyEvents(params: {
     events: CdcStoredEvent[];
     layout: CdcEntityLayout;

--- a/api/src/sync-cdc/adapters/registry.ts
+++ b/api/src/sync-cdc/adapters/registry.ts
@@ -69,6 +69,19 @@ export interface CdcDestinationAdapter {
     flowId: string,
     options?: { stagingSuffix?: string },
   ): Promise<void>;
+
+  /**
+   * Rewrite an existing live table's partitioning/clustering in place by
+   * copying its current rows into a freshly-laid-out table and atomically
+   * swapping it in — avoiding a full re-fetch from the source. Returns
+   * `repartitioned: false` when the live table does not exist yet (the caller
+   * should fall back to a backfill). Throws on failure (caller falls back).
+   * Only implemented for warehouses where partitioning/clustering is fixed at
+   * CREATE (BigQuery, ClickHouse).
+   */
+  repartitionLiveTable?(layout: CdcEntityLayout): Promise<{
+    repartitioned: boolean;
+  }>;
 }
 
 export function resolveCdcDestinationAdapter(params: {

--- a/api/src/sync-cdc/adapters/repartition-sql.test.ts
+++ b/api/src/sync-cdc/adapters/repartition-sql.test.ts
@@ -109,7 +109,7 @@ describe("BigQuery repartition SQL", () => {
     );
   });
 
-  it("builds CTAS + drop + rename swap", () => {
+  it("builds CREATE OR REPLACE + drop + rename swap", () => {
     const stmts = buildBigQueryRepartitionStatements({
       fullLive: "`proj`.`ds`.`close_leads`",
       fullTmp: "`proj`.`ds`.`close_leads__repart_x`",
@@ -117,7 +117,7 @@ describe("BigQuery repartition SQL", () => {
       layout: layout(),
     });
     expect(stmts.createTmp).toBe(
-      "CREATE TABLE `proj`.`ds`.`close_leads__repart_x` " +
+      "CREATE OR REPLACE TABLE `proj`.`ds`.`close_leads__repart_x` " +
         "PARTITION BY TIMESTAMP_TRUNC(`_syncedAt`, DAY) " +
         "CLUSTER BY `_dataSourceId`, `id` AS SELECT * FROM `proj`.`ds`.`close_leads`",
     );
@@ -135,7 +135,7 @@ describe("BigQuery repartition SQL", () => {
       layout: layout({ partitioning: undefined, clustering: undefined }),
     });
     expect(stmts.createTmp).toBe(
-      "CREATE TABLE `p`.`d`.`t2` AS SELECT * FROM `p`.`d`.`t`",
+      "CREATE OR REPLACE TABLE `p`.`d`.`t2` AS SELECT * FROM `p`.`d`.`t`",
     );
   });
 });

--- a/api/src/sync-cdc/adapters/repartition-sql.test.ts
+++ b/api/src/sync-cdc/adapters/repartition-sql.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import {
+  bigQueryPartitionClause,
+  bigQueryClusterClause,
+  buildBigQueryRepartitionStatements,
+} from "./bigquery";
+import {
+  clickHousePartitionClause,
+  buildClickHouseRepartitionStatements,
+} from "./clickhouse";
+import type { CdcEntityLayout } from "./registry";
+
+/**
+ * Contract tests for the in-place repartition SQL (copy + swap). This SQL
+ * rewrites a live table's partition/clustering without re-fetching from the
+ * source, so its exact shape is correctness-critical. The gated ClickHouse
+ * integration test (`clickhouse/repartition.integration.test.ts`) executes the
+ * same builder against a real engine; these run offline in CI.
+ */
+
+function layout(overrides: Partial<CdcEntityLayout> = {}): CdcEntityLayout {
+  return {
+    entity: "leads",
+    tableName: "close_leads",
+    keyColumns: ["id"],
+    partitioning: { type: "time", field: "_syncedAt", granularity: "day" },
+    clustering: { fields: ["_dataSourceId", "id"] },
+    ...overrides,
+  };
+}
+
+describe("ClickHouse repartition SQL", () => {
+  it("maps granularity to the right partition function", () => {
+    expect(clickHousePartitionClause(layout({ partitioning: undefined }))).toBe(
+      "",
+    );
+    expect(
+      clickHousePartitionClause(
+        layout({ partitioning: { field: "_syncedAt", granularity: "day" } }),
+      ),
+    ).toBe("PARTITION BY toYYYYMMDD(`_syncedAt`)");
+    expect(
+      clickHousePartitionClause(
+        layout({ partitioning: { field: "date_created", granularity: "hour" } }),
+      ),
+    ).toBe("PARTITION BY toStartOfHour(`date_created`)");
+    expect(
+      clickHousePartitionClause(
+        layout({ partitioning: { field: "_syncedAt", granularity: "month" } }),
+      ),
+    ).toBe("PARTITION BY toYYYYMM(`_syncedAt`)");
+    expect(
+      clickHousePartitionClause(
+        layout({ partitioning: { field: "_syncedAt", granularity: "year" } }),
+      ),
+    ).toBe("PARTITION BY toYear(`_syncedAt`)");
+  });
+
+  it("builds create/copy/exchange that preserve columns + dedupe by source_ts", () => {
+    const stmts = buildClickHouseRepartitionStatements({
+      fullLive: "`mako_cdc`.`close_leads`",
+      fullTmp: "`mako_cdc`.`close_leads__repart_x`",
+      partitionClause: clickHousePartitionClause(layout()),
+      orderByColumns: ["id"],
+    });
+    // new table copies the live structure but overrides engine + partition + sort
+    expect(stmts.createTmp).toBe(
+      "CREATE TABLE `mako_cdc`.`close_leads__repart_x` AS `mako_cdc`.`close_leads` " +
+        "ENGINE = ReplacingMergeTree(`_mako_source_ts`) " +
+        "PARTITION BY toYYYYMMDD(`_syncedAt`) ORDER BY (`id`)",
+    );
+    // full-column copy (no projection) so existing data is preserved exactly
+    expect(stmts.copy).toBe(
+      "INSERT INTO `mako_cdc`.`close_leads__repart_x` SELECT * FROM `mako_cdc`.`close_leads`",
+    );
+    // atomic swap
+    expect(stmts.exchange).toBe(
+      "EXCHANGE TABLES `mako_cdc`.`close_leads` AND `mako_cdc`.`close_leads__repart_x`",
+    );
+  });
+
+  it("supports composite sort keys", () => {
+    const stmts = buildClickHouseRepartitionStatements({
+      fullLive: "`d`.`t`",
+      fullTmp: "`d`.`t2`",
+      partitionClause: "",
+      orderByColumns: ["tenant", "id"],
+    });
+    expect(stmts.createTmp).toContain("ORDER BY (`tenant`, `id`)");
+  });
+});
+
+describe("BigQuery repartition SQL", () => {
+  it("builds partition + cluster clauses", () => {
+    expect(bigQueryPartitionClause(layout({ partitioning: undefined }))).toBe(
+      "",
+    );
+    expect(bigQueryPartitionClause(layout())).toBe(
+      "PARTITION BY TIMESTAMP_TRUNC(`_syncedAt`, DAY)",
+    );
+    expect(
+      bigQueryPartitionClause(
+        layout({ partitioning: { field: "date_created", granularity: "month" } }),
+      ),
+    ).toBe("PARTITION BY TIMESTAMP_TRUNC(`date_created`, MONTH)");
+    expect(bigQueryClusterClause(layout({ clustering: undefined }))).toBe("");
+    expect(bigQueryClusterClause(layout())).toBe(
+      "CLUSTER BY `_dataSourceId`, `id`",
+    );
+  });
+
+  it("builds CTAS + drop + rename swap", () => {
+    const stmts = buildBigQueryRepartitionStatements({
+      fullLive: "`proj`.`ds`.`close_leads`",
+      fullTmp: "`proj`.`ds`.`close_leads__repart_x`",
+      liveName: "close_leads",
+      layout: layout(),
+    });
+    expect(stmts.createTmp).toBe(
+      "CREATE TABLE `proj`.`ds`.`close_leads__repart_x` " +
+        "PARTITION BY TIMESTAMP_TRUNC(`_syncedAt`, DAY) " +
+        "CLUSTER BY `_dataSourceId`, `id` AS SELECT * FROM `proj`.`ds`.`close_leads`",
+    );
+    expect(stmts.dropLive).toBe("DROP TABLE `proj`.`ds`.`close_leads`");
+    expect(stmts.rename).toBe(
+      "ALTER TABLE `proj`.`ds`.`close_leads__repart_x` RENAME TO `close_leads`",
+    );
+  });
+
+  it("omits clauses when no partitioning/clustering configured", () => {
+    const stmts = buildBigQueryRepartitionStatements({
+      fullLive: "`p`.`d`.`t`",
+      fullTmp: "`p`.`d`.`t2`",
+      liveName: "t",
+      layout: layout({ partitioning: undefined, clustering: undefined }),
+    });
+    expect(stmts.createTmp).toBe(
+      "CREATE TABLE `p`.`d`.`t2` AS SELECT * FROM `p`.`d`.`t`",
+    );
+  });
+});

--- a/api/src/sync-cdc/backfill.ts
+++ b/api/src/sync-cdc/backfill.ts
@@ -14,8 +14,16 @@ import {
 import { loggers } from "../logging";
 import { databaseRegistry } from "../databases/registry";
 import { resolveConfiguredEntities } from "./entity-selection";
-import { hasCdcDestinationAdapter } from "./adapters/registry";
+import {
+  hasCdcDestinationAdapter,
+  resolveCdcDestinationAdapter,
+  resolveEntityPartitioning,
+  resolveEntityClustering,
+  buildCdcEntityLayout,
+} from "./adapters/registry";
 import { cdcLiveTableName, cdcStageTableName } from "./normalization";
+import { syncConnectorRegistry } from "../sync/connector-registry";
+import { databaseDataSourceManager } from "../sync/database-data-source-manager";
 import { getCdcEventStore } from "./event-store";
 import { cdcSyncStateService } from "./sync-state";
 import { resolveOrphanedWebhookApplyStatusForFlow } from "./cdc-orphan-applystatus";
@@ -523,19 +531,16 @@ export class CdcBackfillService {
     flowId: string;
     entities: string[];
     deleteDestination?: boolean;
-  }) {
+  }): Promise<{ repartitioned: string[]; backfilled: string[] }> {
     const { workspaceId, flowId, deleteDestination } = params;
     const entities = normalizeEntities(params.entities);
     if (entities.length === 0) {
       throw new Error("resyncEntities requires at least one entity");
     }
 
-    const workspaceObjectId = new Types.ObjectId(workspaceId);
-    const flowObjectId = new Types.ObjectId(flowId);
-
     const flow = await Flow.findOne({
-      _id: flowObjectId,
-      workspaceId: workspaceObjectId,
+      _id: new Types.ObjectId(flowId),
+      workspaceId: new Types.ObjectId(workspaceId),
     });
     if (!flow) {
       throw new Error("Flow not found");
@@ -546,12 +551,143 @@ export class CdcBackfillService {
 
     await assertCanStartBackfill(workspaceId, flowId);
 
-    // Scope all destructive operations to the requested entities so unchanged
-    // entities keep their destination data and CDC state.
+    // Preferred path: rewrite the partitioning/clustering in place by copying
+    // existing destination rows into a new-layout table and swapping — no
+    // source re-fetch. Entities whose table can't be repartitioned (missing,
+    // unsupported destination, or copy failure) fall back to drop + backfill.
+    const { repartitioned, fallback } = await this.repartitionEntitiesInPlace(
+      flow,
+      workspaceId,
+      flowId,
+      entities,
+    );
+
+    if (fallback.length > 0) {
+      await this.backfillEntitiesFallback(
+        flow,
+        workspaceId,
+        flowId,
+        fallback,
+        deleteDestination,
+      );
+    }
+
+    log.info("resyncEntities complete", {
+      flowId,
+      repartitioned,
+      backfilled: fallback,
+    });
+    return { repartitioned, backfilled: fallback };
+  }
+
+  /**
+   * Build the destination adapter for a flow and, for each entity, attempt an
+   * in-place repartition (copy + swap). The flow's stream is paused for the
+   * duration so the consumer holds incoming events (they materialize into the
+   * freshly-laid-out table once we resume + re-trigger). Returns which entities
+   * were repartitioned vs. which need a drop + backfill fallback.
+   */
+  private async repartitionEntitiesInPlace(
+    flow: IFlow,
+    workspaceId: string,
+    flowId: string,
+    entities: string[],
+  ): Promise<{ repartitioned: string[]; fallback: string[] }> {
+    if (!flow.tableDestination?.connectionId || !flow.tableDestination?.schema) {
+      return { repartitioned: [], fallback: entities };
+    }
+    const destination = await DatabaseConnection.findById(
+      flow.tableDestination.connectionId,
+    ).lean();
+    if (!destination) {
+      return { repartitioned: [], fallback: entities };
+    }
+
+    const adapter = resolveCdcDestinationAdapter({
+      destinationType: destination.type,
+      destinationDatabaseId: String(flow.destinationDatabaseId),
+      destinationDatabaseName: flow.destinationDatabaseName,
+      tableDestination: {
+        connectionId: String(flow.tableDestination.connectionId),
+        schema: flow.tableDestination.schema,
+        tableName: flow.tableDestination.tableName || "",
+      },
+    });
+
+    // Destination doesn't support in-place repartition (e.g. PostgreSQL/Mongo).
+    if (!adapter.repartitionLiveTable) {
+      return { repartitioned: [], fallback: entities };
+    }
+
+    const repartitioned: string[] = [];
+    const fallback: string[] = [];
+
+    // Pause materialization so no writes land on the live table mid-swap.
+    const previousStreamState = flow.streamState;
+    flow.streamState = "paused";
+    flow.syncStateUpdatedAt = new Date();
+    await flow.save();
+    log.info("Paused flow stream for in-place repartition", {
+      flowId,
+      entities,
+      previousStreamState,
+    });
+
+    try {
+      for (const entity of entities) {
+        const layout = await this.buildEntityLayout(flow, entity);
+        try {
+          const result = await adapter.repartitionLiveTable(layout);
+          if (result.repartitioned) {
+            repartitioned.push(entity);
+          } else {
+            // No existing table — let the backfill path create it fresh.
+            fallback.push(entity);
+          }
+        } catch (error) {
+          log.warn("In-place repartition failed; falling back to backfill", {
+            flowId,
+            entity,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          fallback.push(entity);
+        }
+      }
+    } finally {
+      // Always restore the stream state, even if a repartition threw.
+      flow.streamState = previousStreamState || "idle";
+      flow.syncStateUpdatedAt = new Date();
+      await flow.save();
+      log.info("Resumed flow stream after in-place repartition", {
+        flowId,
+        restoredStreamState: flow.streamState,
+      });
+    }
+
+    // Re-trigger materialization for repartitioned entities so any events that
+    // queued during the pause are applied to the new table (idempotent merge).
+    for (const entity of repartitioned) {
+      await inngest.send({
+        name: "cdc/materialize",
+        data: { workspaceId, flowId, entity, force: true },
+      });
+    }
+
+    return { repartitioned, fallback };
+  }
+
+  /** Drop + clear + subset backfill for entities that can't be repartitioned. */
+  private async backfillEntitiesFallback(
+    flow: IFlow,
+    workspaceId: string,
+    flowId: string,
+    entities: string[],
+    deleteDestination?: boolean,
+  ): Promise<void> {
     await getCdcEventStore().deleteFlowEvents({ workspaceId, flowId, entities });
     await CdcEntityState.deleteMany({
-      workspaceId: workspaceObjectId,
-      flowId: flowObjectId,
+      workspaceId: new Types.ObjectId(workspaceId),
+      flowId: new Types.ObjectId(flowId),
       entity: { $in: entities },
     });
 
@@ -559,10 +695,54 @@ export class CdcBackfillService {
       await this.deleteDestinationTables(flow, entities);
     }
 
-    // Subset backfill — only the targeted entities are re-fetched + rebuilt.
     await this.startBackfill(workspaceId, flowId, {
       entities,
-      reason: `Layout-change resync for entities: ${entities.join(", ")}`,
+      reason: `Layout-change resync (backfill) for entities: ${entities.join(", ")}`,
+    });
+  }
+
+  /** Resolve the CDC layout (table name, key columns, new partitioning). */
+  private async buildEntityLayout(flow: IFlow, entity: string) {
+    const entityLayout = (flow.entityLayouts || []).find(
+      layout =>
+        layout.entity === entity || layout.entity === entity.split(":")[0],
+    );
+    const tableName = cdcLiveTableName(
+      flow.tableDestination?.tableName,
+      entity,
+      String(flow._id),
+    );
+
+    let keyColumns: string[] | undefined;
+    if (flow.dataSourceId) {
+      try {
+        const ds = await databaseDataSourceManager.getDataSource(
+          String(flow.dataSourceId),
+        );
+        const conn = ds ? await syncConnectorRegistry.getConnector(ds) : null;
+        const schema = conn ? await conn.resolveSchema(entity) : null;
+        keyColumns = schema?.keyColumns;
+      } catch {
+        log.warn("Schema resolution failed for repartition key columns", {
+          entity,
+          flowId: String(flow._id),
+        });
+      }
+    }
+
+    return buildCdcEntityLayout({
+      entity,
+      tableName,
+      keyColumns,
+      deleteMode: flow.deleteMode,
+      partitioning: resolveEntityPartitioning(
+        entityLayout,
+        flow.tableDestination?.partitioning,
+      ),
+      clustering: resolveEntityClustering(
+        entityLayout,
+        flow.tableDestination?.clustering,
+      ),
     });
   }
 

--- a/app/src/components/WebhookFlowForm.tsx
+++ b/app/src/components/WebhookFlowForm.tsx
@@ -745,18 +745,19 @@ export function WebhookFlowForm({
         open={pendingLayoutReset !== null}
         onClose={() => !isSubmitting && setPendingLayoutReset(null)}
       >
-        <DialogTitle>Reset destination tables?</DialogTitle>
+        <DialogTitle>Rebuild destination tables?</DialogTitle>
         <DialogContent>
           <DialogContentText component="div">
             You changed the partition or cluster layout for{" "}
             <strong>{pendingLayoutReset?.entities.join(", ")}</strong>. These
             settings are fixed when a destination table is created, so the
-            existing table(s) must be dropped and rebuilt for the change to take
-            effect.
-            <Alert severity="warning" sx={{ mt: 2 }}>
-              Saving will delete only those destination table(s) and re-sync
-              (backfill) just those entities from scratch. Other entities are
-              unaffected. This cannot be undone.
+            table(s) must be rebuilt for the change to take effect.
+            <Alert severity="info" sx={{ mt: 2 }}>
+              Saving rebuilds only those table(s) in place — the existing rows
+              are copied into a new table with the new layout and swapped in, so
+              no data is re-fetched from the source. If a table can&apos;t be
+              copied, it falls back to a full re-sync. Other entities are
+              unaffected.
             </Alert>
           </DialogContentText>
         </DialogContent>
@@ -780,7 +781,7 @@ export function WebhookFlowForm({
               });
             }}
           >
-            {isSubmitting ? "Resetting..." : "Save & reset tables"}
+            {isSubmitting ? "Rebuilding..." : "Save & rebuild tables"}
           </Button>
         </DialogActions>
       </Dialog>
@@ -1227,13 +1228,13 @@ export function WebhookFlowForm({
                           Entities & Table Configuration
                         </Typography>
                         {!isNewMode && (
-                          <Alert severity="warning" sx={{ mb: 1 }}>
+                          <Alert severity="info" sx={{ mb: 1 }}>
                             Changing the partition field, granularity, or
-                            cluster fields only affects how destination tables
-                            are created. Existing tables keep their current
-                            layout until you <strong>Reset sync</strong> with{" "}
-                            <strong>Delete destination tables</strong> enabled,
-                            which drops and rebuilds them with the new layout.
+                            cluster fields rebuilds the affected destination
+                            table(s) when you save: existing rows are copied
+                            into a new table with the new layout and swapped in
+                            (no re-sync from the source). You&apos;ll be asked
+                            to confirm.
                           </Alert>
                         )}
                         <Box


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #617 (merged). When a CDC flow's partition/cluster layout changes, rebuild the affected destination tables **in place** via an in-warehouse copy-swap instead of re-fetching from the source — now as an **observable background job**.

## What
- **`repartitionLiveTable()`** on the CDC destination adapter interface:
  - **BigQuery**: `CREATE OR REPLACE TABLE tmp PARTITION BY <new> CLUSTER BY <new> AS SELECT * FROM live`, `DROP TABLE live`, `ALTER TABLE tmp RENAME TO live`.
  - **ClickHouse**: `CREATE … ENGINE=ReplacingMergeTree PARTITION BY <new> ORDER BY (keys)`, `INSERT … SELECT`, atomic `EXCHANGE TABLES` (RENAME fallback).
- **Background job (`cdc/repartition`)** instead of running in the HTTP request:
  - Each entity is its own durable `step.run`, so a long copy on a large table can't time out the request or leave the others unprocessed (the original bug: only the smallest table finished).
  - **Per-entity progress** persisted on `CdcEntityState.repartition` (`pending|running|done|failed`), surfaced in `GET .../sync-cdc/status` and shown in the `BackfillPanel` STREAM column ("Repartitioning…" / "Repartition failed" with the error in a tooltip).
  - **Crash-safe pause**: pause/resume are durable steps; `onFailure` resumes the stream + marks running entities failed; a sweeper in the CDC materialize scheduler auto-resumes any flow stuck in a repartition pause > 30 min.
  - **Fallbacks**: a *missing* table → scoped backfill (creates it); a *failed* repartition leaves the existing table intact (no silent drop) and surfaces the error for retry.

## Files
- `api/src/sync-cdc/adapters/{bigquery,clickhouse,registry}.ts` — `repartitionLiveTable` + SQL builders
- `api/src/sync-cdc/backfill.ts` — enqueue job, per-entity `repartitionEntity`, pause/resume + recovery helpers
- `api/src/inngest/functions/cdc-repartition.ts` (new) + `inngest/index.ts` registration
- `api/src/inngest/functions/webhook-flow.ts` — stale-pause sweeper in the scheduler
- `api/src/database/workspace-schema.ts` — `CdcEntityState.repartition`
- `api/src/routes/flows.ts` — repartition status in `/sync-cdc/status`
- `app/src/store/flowStore.ts`, `app/src/components/BackfillPanel.tsx` — progress chip
- Tests: `repartition-sql.test.ts` (offline) + `clickhouse-repartition.integration.test.ts` (gated)

## Testing
- ✅ `pnpm --filter api run build` (lint + `tsc -p tsconfig.build.json`)
- ✅ `pnpm --filter app run typecheck` + `lint`
- ✅ `pnpm --filter api run test:destinations` — 92 offline tests
- ✅ **ClickHouse validated end-to-end** against a real server: `repartitionEntity` swapped the table (`toYYYYMMDD(date_created)` → `toYYYYMMDD(_syncedAt)`), preserved rows, and recorded `repartition.status="done"`
- ✅ `pnpm run openapi:sync` (no drift)

[repartition_clickhouse_verify.txt](https://cursor.com/agents/bc-9f2a4aaa-0dc9-4e60-881a-feb2c521ca7e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frepartition_clickhouse_verify.txt)

### Caveats
- **BigQuery copy-swap isn't end-to-end tested here** (no BQ emulator/Docker in the VM); the SQL matches a validated manual run + the offline builder test, and a failed swap leaves the table intact.
- The full Inngest job isn't exercised end-to-end in this environment (no Inngest dev + event loop here); the per-entity step logic (`repartitionEntity`) is validated against real ClickHouse, and the job is thin orchestration over validated service methods.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f2a4aaa-0dc9-4e60-881a-feb2c521ca7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f2a4aaa-0dc9-4e60-881a-feb2c521ca7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

