### PR TITLE
fix: allow selected dbt git commits

### DIFF
--- a/api/src/agent-lib/tools/dbt-job-tools.test.ts
+++ b/api/src/agent-lib/tools/dbt-job-tools.test.ts
@@ -41,6 +41,7 @@ vi.mock("../../dbt/dbt-run.service", () => ({
 }));
 vi.mock("../../dbt/dbt-github-git.service", () => ({
   commitAndPush: vi.fn(),
+  commitToNewBranch: vi.fn(),
   createProjectBranch: vi.fn(),
   getGitStatus: vi.fn(),
   listProjectBranches: vi.fn(),
@@ -58,6 +59,12 @@ vi.mock("../../services/scheduled-query-schedule.service", () => ({
 // Imported after the mocks are registered.
 import { createDbtServerTools } from "./dbt-tools";
 import { DbtJob, DbtProject } from "../../database/workspace-schema";
+import {
+  commitAndPush,
+  commitToNewBranch,
+  getGitStatus,
+} from "../../dbt/dbt-github-git.service";
+import { generateDbtCommitMessage } from "../../dbt/dbt-commit-message.service";
 
 let mongo: MongoMemoryServer;
 const WS = new Types.ObjectId().toString();
@@ -69,6 +76,8 @@ type ToolResult = {
   error?: string;
   jobId?: string;
   name?: string;
+  branch?: string;
+  sha?: string;
 };
 
 const tools = createDbtServerTools(WS, "u1", { chatId: "chat1" });
@@ -77,6 +86,36 @@ function deleteJob(input: DeleteJobInput): Promise<ToolResult> {
   // The AI SDK tool() wraps execute; call it the way the SDK does at runtime.
   return (
     tools.dbt_delete_job.execute as (i: DeleteJobInput) => Promise<ToolResult>
+  )(input);
+}
+
+function commitAndPushTool(input: {
+  projectId: string;
+  message?: string;
+  paths?: string[];
+}): Promise<ToolResult> {
+  return (
+    tools.dbt_commit_and_push.execute as (i: {
+      projectId: string;
+      message?: string;
+      paths?: string[];
+    }) => Promise<ToolResult>
+  )(input);
+}
+
+function commitToBranchTool(input: {
+  projectId: string;
+  name: string;
+  message?: string;
+  paths?: string[];
+}): Promise<ToolResult> {
+  return (
+    tools.dbt_commit_to_branch.execute as (i: {
+      projectId: string;
+      name: string;
+      message?: string;
+      paths?: string[];
+    }) => Promise<ToolResult>
   )(input);
 }
 
@@ -94,6 +133,30 @@ async function seedProject(): Promise<string> {
     ],
     defaultEnvironment: "dev",
     createdBy: "tester",
+  });
+  return project._id.toString();
+}
+
+async function seedRepoProject(): Promise<string> {
+  const project = await DbtProject.create({
+    workspaceId: new Types.ObjectId(WS),
+    name: "Analytics",
+    environments: [
+      {
+        name: "dev",
+        connectionId: new Types.ObjectId(CONN),
+        targetSchema: "analytics",
+        threads: 4,
+      },
+    ],
+    defaultEnvironment: "dev",
+    createdBy: "tester",
+    repo: {
+      owner: "acme",
+      repo: "analytics",
+      branch: "main",
+      installationId: 123,
+    },
   });
   return project._id.toString();
 }
@@ -196,5 +259,94 @@ describe("dbt_delete_job", () => {
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/not found|access denied/i);
     expect(await DbtJob.countDocuments({ _id: job._id })).toBe(1);
+  });
+});
+
+describe("dbt git commit tools", () => {
+  it("passes selected paths through generated-message commit and push", async () => {
+    const projectId = await seedRepoProject();
+    const paths = ["models/marts/dim_account.sql"];
+    vi.mocked(getGitStatus).mockResolvedValue({
+      branch: "main",
+      hasChanges: true,
+      added: 0,
+      modified: 2,
+      deleted: 0,
+      changes: [
+        { path: "models/marts/dim_account.sql", status: "modified" },
+        { path: "models/marts/fct_orders.sql", status: "modified" },
+      ],
+    });
+    vi.mocked(generateDbtCommitMessage).mockResolvedValue(
+      "fix: update account mart",
+    );
+    vi.mocked(commitAndPush).mockResolvedValue({
+      committed: true,
+      sha: "abc123",
+      branch: "main",
+      pushed: { added: 0, modified: 1, deleted: 0 },
+    });
+
+    const result = await commitAndPushTool({ projectId, paths });
+
+    expect(result.success).toBe(true);
+    expect(generateDbtCommitMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repo: expect.objectContaining({ branch: "main" }),
+      }),
+      { workspaceId: WS, userId: "u1" },
+      { paths },
+    );
+    expect(commitAndPush).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repo: expect.objectContaining({ branch: "main" }),
+      }),
+      {
+        message: "fix: update account mart",
+        updatedBy: "u1",
+        paths,
+      },
+    );
+  });
+
+  it("passes selected paths through commit-to-branch", async () => {
+    const projectId = await seedRepoProject();
+    const paths = ["models/staging/stg_crm_activity.sql"];
+    vi.mocked(generateDbtCommitMessage).mockResolvedValue(
+      "feat: add activity staging",
+    );
+    vi.mocked(commitToNewBranch).mockResolvedValue({
+      committed: true,
+      sha: "def456",
+      branch: "feat/activity",
+      fromBranch: "main",
+      pushed: { added: 1, modified: 0, deleted: 0 },
+    });
+
+    const result = await commitToBranchTool({
+      projectId,
+      name: "feat/activity",
+      paths,
+    });
+
+    expect(result.success).toBe(true);
+    expect(generateDbtCommitMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repo: expect.objectContaining({ branch: "main" }),
+      }),
+      { workspaceId: WS, userId: "u1" },
+      { paths },
+    );
+    expect(commitToNewBranch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repo: expect.objectContaining({ branch: "main" }),
+      }),
+      {
+        branchName: "feat/activity",
+        message: "feat: add activity staging",
+        updatedBy: "u1",
+        paths,
+      },
+    );
   });
 });

--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -85,6 +85,25 @@ const projectIdField = z
   .string()
   .describe("dbt project ID (from read_dbt_project_tree)");
 
+const dbtCommitPathsField = z
+  .array(
+    z
+      .string()
+      .min(1)
+      .max(1000)
+      .describe(
+        "Project-relative changed file path, e.g. models/staging/stg_orders.sql",
+      ),
+  )
+  .min(1)
+  .max(100)
+  .optional()
+  .describe(
+    "Optional project-relative changed paths to commit. Omit to commit all " +
+      "working-tree changes; pass this when dbt_git_status shows unrelated " +
+      "pending files that should stay uncommitted.",
+  );
+
 function toolError(error: unknown, fallback: string) {
   return {
     success: false,
@@ -1280,10 +1299,12 @@ export const createDbtServerTools = (
 
     dbt_commit_and_push: tool({
       description:
-        "Commit ALL working-tree changes and push them to the project's " +
-        "currently tracked branch in a single commit — the same action as the " +
-        "IDE 'Commit & push' button. ONLY call this after the user has " +
-        "explicitly asked you to commit/push (or clearly confirmed it in the " +
+        "Commit working-tree changes and push them to the project's " +
+        "currently tracked branch in a single commit. By default this commits " +
+        "ALL pending changes (the same action as the IDE 'Commit & push' " +
+        "button); pass `paths` to commit only specific changed files when " +
+        "dbt_git_status shows unrelated pending work. ONLY call this after " +
+        "the user has explicitly asked you to commit/push (or clearly confirmed it in the " +
         "conversation); never commit proactively. If you omit `message`, a " +
         "Conventional Commits message is generated automatically from the " +
         "diff. Returns the new commit sha and per-type counts. To put changes " +
@@ -1297,8 +1318,9 @@ export const createDbtServerTools = (
           .max(500)
           .optional()
           .describe("Commit message. Omit to auto-generate one from the diff."),
+        paths: dbtCommitPathsField,
       }),
-      execute: async ({ projectId, message }) => {
+      execute: async ({ projectId, message, paths }) => {
         try {
           const project = await assertRepoProject(projectId);
           const status = await getGitStatus(project);
@@ -1313,10 +1335,14 @@ export const createDbtServerTools = (
           let commitMessage = message?.trim();
           let generated = false;
           if (!commitMessage) {
-            const ai = await generateDbtCommitMessage(project, {
-              workspaceId,
-              userId: userId ?? "agent",
-            });
+            const ai = await generateDbtCommitMessage(
+              project,
+              {
+                workspaceId,
+                userId: userId ?? "agent",
+              },
+              { paths },
+            );
             if (ai) {
               commitMessage = ai;
               generated = true;
@@ -1334,6 +1360,7 @@ export const createDbtServerTools = (
           const result = await commitAndPush(project, {
             message: commitMessage,
             updatedBy: userId ?? "agent",
+            paths,
           });
           return {
             success: result.committed,
@@ -1352,7 +1379,10 @@ export const createDbtServerTools = (
     dbt_commit_to_branch: tool({
       description:
         "ATOMIC PROMOTE: create a new feature branch off the current branch and " +
-        "commit ALL working-tree changes onto it in a single, race-free step. " +
+        "commit working-tree changes onto it in a single, race-free step. By " +
+        "default this commits ALL pending changes; pass `paths` to commit only " +
+        "specific changed files when unrelated pending work should stay " +
+        "uncommitted. " +
         "PREFER THIS over dbt_create_branch + dbt_commit_and_push when the user " +
         "wants their changes on a new branch for review: those two separate " +
         "calls can race a concurrent commit and leave the changes on the wrong " +
@@ -1373,17 +1403,22 @@ export const createDbtServerTools = (
           .max(500)
           .optional()
           .describe("Commit message. Omit to auto-generate one from the diff."),
+        paths: dbtCommitPathsField,
       }),
-      execute: async ({ projectId, name, message }) => {
+      execute: async ({ projectId, name, message, paths }) => {
         try {
           const project = await assertRepoProject(projectId);
           let commitMessage = message?.trim();
           let generated = false;
           if (!commitMessage) {
-            const ai = await generateDbtCommitMessage(project, {
-              workspaceId,
-              userId: userId ?? "agent",
-            });
+            const ai = await generateDbtCommitMessage(
+              project,
+              {
+                workspaceId,
+                userId: userId ?? "agent",
+              },
+              { paths },
+            );
             if (ai) {
               commitMessage = ai;
               generated = true;
@@ -1401,6 +1436,7 @@ export const createDbtServerTools = (
             branchName: name.trim(),
             message: commitMessage,
             updatedBy: userId ?? "agent",
+            paths,
           });
           return {
             success: result.committed,

--- a/api/src/agents/dbt/prompt.ts
+++ b/api/src/agents/dbt/prompt.ts
@@ -27,7 +27,8 @@ runs execute against the project's warehouse environments (dev/prod).
 6. **Ship (git)** — for repo-bound projects, your file edits land in the working tree but are
    NOT pushed automatically. Only commit after the user explicitly asks. Then call
    \`dbt_git_status\` to confirm what changed, and \`dbt_commit_and_push\` (omit \`message\` to
-   auto-generate one) to push to the tracked branch. When the user wants changes on a NEW branch
+   auto-generate one; pass \`paths\` when unrelated pending files should stay uncommitted) to
+   push to the tracked branch. When the user wants changes on a NEW branch
    for review, use \`dbt_commit_to_branch\` (atomic branch+commit) — NOT \`dbt_create_branch\` then
    \`dbt_commit_and_push\`, which can race a concurrent commit and strand the changes on the wrong
    branch. Then \`dbt_open_pull_request\`; when the user asks to promote/merge, call
@@ -43,7 +44,8 @@ runs execute against the project's warehouse environments (dev/prod).
   you to commit. Prefer pushing to the tracked branch (mirrors the IDE button); only branch or
   open a PR when the user asks for it.
 - To promote working-tree changes onto a new branch, always use the atomic \`dbt_commit_to_branch\`
-  instead of separate branch + commit calls — the two-step flow is racy.
+  instead of separate branch + commit calls — the two-step flow is racy. Pass \`paths\` if only
+  some pending files belong in the commit.
 - Switching branches OVERWRITES the working tree. \`dbt_switch_branch\` refuses when there are
   uncommitted changes; commit them first, or pass \`discardLocalChanges\` only after the user
   explicitly confirms abandoning them. If a user reports missing/lost files, recover them with

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -169,7 +169,8 @@ run; always follow up with \`dbt_get_run\` to report whether it actually passed 
 
 Git (repo-bound projects): your edits land in the working tree but are NOT pushed automatically.
 Only commit when the user asks. Check \`dbt_git_status\`, then \`dbt_commit_and_push\` (omit
-\`message\` to auto-generate one) to push to the tracked branch — same as the IDE button. To put
+\`message\` to auto-generate one; pass \`paths\` when unrelated pending files should stay
+uncommitted) to push to the tracked branch — same as the IDE button. To put
 changes on a NEW branch for review, use \`dbt_commit_to_branch\` (atomic branch+commit) rather than
 \`dbt_create_branch\` + \`dbt_commit_and_push\` — the two-step version can race a concurrent commit and
 strand the changes on the wrong branch. Then \`dbt_open_pull_request\`; when the user asks to

--- a/api/src/dbt/dbt-commit-message.service.ts
+++ b/api/src/dbt/dbt-commit-message.service.ts
@@ -50,6 +50,11 @@ export interface CommitMessageTrackingContext {
   userEmail?: string;
 }
 
+export interface CommitMessageOptions {
+  /** Project-relative paths to summarize; omitted means the full working tree. */
+  paths?: string[];
+}
+
 function truncate(value: string, max: number): string {
   return value.length > max ? `${value.slice(0, max)}\n…(truncated)…` : value;
 }
@@ -69,8 +74,22 @@ function patchBody(patch: string): string {
 async function buildWorkingTreeDiff(project: IDbtProject): Promise<{
   diff: string;
   fileCount: number;
+} | null>;
+async function buildWorkingTreeDiff(
+  project: IDbtProject,
+  options: CommitMessageOptions,
+): Promise<{
+  diff: string;
+  fileCount: number;
+} | null>;
+async function buildWorkingTreeDiff(
+  project: IDbtProject,
+  options: CommitMessageOptions = {},
+): Promise<{
+  diff: string;
+  fileCount: number;
 } | null> {
-  const status = await getGitStatus(project);
+  const status = await getGitStatus(project, { paths: options.paths });
   if (!status.hasChanges) return null;
 
   const changes = status.changes.slice(0, MAX_FILES);
@@ -127,9 +146,10 @@ async function buildWorkingTreeDiff(project: IDbtProject): Promise<{
 export async function generateDbtCommitMessage(
   project: IDbtProject,
   trackingCtx?: CommitMessageTrackingContext,
+  options: CommitMessageOptions = {},
 ): Promise<string | null> {
   try {
-    const built = await buildWorkingTreeDiff(project);
+    const built = await buildWorkingTreeDiff(project, options);
     if (!built) return null;
 
     const utilityModel = await getUtilityModelId();

--- a/api/src/dbt/dbt-github-git.commit.test.ts
+++ b/api/src/dbt/dbt-github-git.commit.test.ts
@@ -1,0 +1,189 @@
+/**
+ * commitAndPush / commitToNewBranch — selected-path git commit behavior.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Types } from "mongoose";
+import type { IDbtProject } from "../database/workspace-schema";
+import { gitBlobSha } from "../integrations/github/git-blob";
+
+vi.mock("../integrations/github/app-auth", () => ({
+  resolveRepoToken: vi.fn(async () => "token"),
+}));
+
+vi.mock("../integrations/github/github-api", () => ({
+  commitChanges: vi.fn(async () => "new-sha"),
+  createBranch: vi.fn(async () => undefined),
+  createPullRequest: vi.fn(),
+  deleteBranch: vi.fn(),
+  getBlobContent: vi.fn(),
+  getPullRequest: vi.fn(),
+  getRefCommit: vi.fn(async () => ({
+    commitSha: "parent-sha",
+    treeSha: "tree-sha",
+  })),
+  getRepoInfo: vi.fn(),
+  getRepoTree: vi.fn(async () => ({
+    sha: "tree-sha",
+    truncated: false,
+    entries: [
+      { path: "models/selected.sql", type: "blob", sha: "selected-old" },
+      { path: "models/unselected.sql", type: "blob", sha: "unselected-old" },
+    ],
+  })),
+  listBranches: vi.fn(),
+  mergePullRequest: vi.fn(),
+  tryDeleteBranch: vi.fn(),
+}));
+
+vi.mock("./dbt-github-sync.service", () => ({
+  syncProjectFromRepo: vi.fn(async () => undefined),
+}));
+
+const mockFindById = vi.fn();
+const mockFindFiles = vi.fn();
+const mockUpdateOne = vi.fn(() => ({ exec: vi.fn(async () => undefined) }));
+const mockDeleteOne = vi.fn(() => ({ exec: vi.fn(async () => undefined) }));
+const mockSave = vi.fn(async () => undefined);
+
+vi.mock("../database/workspace-schema", () => ({
+  DbtFile: {
+    find: (...args: unknown[]) => mockFindFiles(...args),
+    findOne: vi.fn(),
+    updateOne: (...args: unknown[]) => mockUpdateOne(...args),
+    deleteOne: (...args: unknown[]) => mockDeleteOne(...args),
+  },
+  DbtProject: {
+    findById: (...args: unknown[]) => mockFindById(...args),
+  },
+}));
+
+import { commitChanges, createBranch } from "../integrations/github/github-api";
+import { commitAndPush, commitToNewBranch } from "./dbt-github-git.service";
+
+const projectId = new Types.ObjectId();
+
+function makeProject(overrides: Partial<IDbtProject> = {}): IDbtProject {
+  return {
+    _id: projectId,
+    repo: {
+      owner: "acme",
+      repo: "analytics",
+      branch: "main",
+      installationId: "inst-1",
+    },
+    markModified: vi.fn(),
+    save: mockSave,
+    ...overrides,
+  } as unknown as IDbtProject;
+}
+
+function mockFiles() {
+  const files = [
+    {
+      path: "models/selected.sql",
+      content: "select 1 as selected",
+      is_deleted: false,
+      repoBlobSha: gitBlobSha("select 0 as selected"),
+    },
+    {
+      path: "models/unselected.sql",
+      content: "select 1 as unselected",
+      is_deleted: false,
+      repoBlobSha: gitBlobSha("select 0 as unselected"),
+    },
+  ];
+  mockFindFiles.mockReturnValue({
+    select: () => ({
+      lean: async () => files,
+    }),
+  });
+}
+
+describe("selected-path dbt git commits", () => {
+  let storedProject: IDbtProject;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFiles();
+    storedProject = makeProject();
+    mockFindById.mockResolvedValue(storedProject);
+  });
+
+  it("commits and reconciles only selected paths", async () => {
+    const result = await commitAndPush(storedProject, {
+      message: "fix: update selected model",
+      updatedBy: "agent",
+      paths: ["models/selected.sql"],
+    });
+
+    expect(result).toMatchObject({
+      committed: true,
+      sha: "new-sha",
+      branch: "main",
+      pushed: { added: 0, modified: 1, deleted: 0 },
+    });
+    expect(commitChanges).toHaveBeenCalledWith(
+      "acme",
+      "analytics",
+      expect.objectContaining({
+        branch: "main",
+        message: "fix: update selected model",
+        changes: [
+          { path: "models/selected.sql", content: "select 1 as selected" },
+        ],
+      }),
+      "token",
+    );
+    expect(mockUpdateOne).toHaveBeenCalledTimes(1);
+    expect(mockUpdateOne).toHaveBeenCalledWith(
+      { projectId, path: "models/selected.sql" },
+      { $set: { repoBlobSha: gitBlobSha("select 1 as selected") } },
+    );
+    expect(mockDeleteOne).not.toHaveBeenCalled();
+  });
+
+  it("creates a new branch and commits only selected paths", async () => {
+    const result = await commitToNewBranch(storedProject, {
+      branchName: "feat/selected",
+      message: "feat: add selected change",
+      updatedBy: "agent",
+      paths: ["models/selected.sql"],
+    });
+
+    expect(createBranch).toHaveBeenCalledWith(
+      "acme",
+      "analytics",
+      "feat/selected",
+      "parent-sha",
+      "token",
+    );
+    expect(commitChanges).toHaveBeenCalledWith(
+      "acme",
+      "analytics",
+      expect.objectContaining({
+        branch: "feat/selected",
+        changes: [
+          { path: "models/selected.sql", content: "select 1 as selected" },
+        ],
+      }),
+      "token",
+    );
+    expect(result).toMatchObject({
+      committed: true,
+      branch: "feat/selected",
+      fromBranch: "main",
+      pushed: { added: 0, modified: 1, deleted: 0 },
+    });
+  });
+
+  it("rejects a selected path without pending changes", async () => {
+    await expect(
+      commitAndPush(storedProject, {
+        message: "fix: update selected model",
+        updatedBy: "agent",
+        paths: ["models/missing.sql"],
+      }),
+    ).rejects.toThrow("Selected path(s) have no pending changes");
+    expect(commitChanges).not.toHaveBeenCalled();
+  });
+});

--- a/api/src/dbt/dbt-github-git.service.ts
+++ b/api/src/dbt/dbt-github-git.service.ts
@@ -99,13 +99,78 @@ export interface GitStatus {
   hasChanges: boolean;
 }
 
+export interface GitStatusOptions {
+  /** Project-relative paths to include; omitted means the full working tree. */
+  paths?: string[];
+}
+
 function repoPath(project: IDbtProject, path: string): string {
   const subdir = project.repo?.subdirectory?.replace(/^\/+|\/+$/g, "");
   return subdir ? `${subdir}/${path}` : path;
 }
 
+function normalizeCommitPaths(paths?: string[]): string[] | undefined {
+  if (!paths) return undefined;
+  const normalized = [
+    ...new Set(
+      paths.map(path =>
+        path
+          .trim()
+          .replace(/^\.\/+/, "")
+          .replace(/^\/+/, ""),
+      ),
+    ),
+  ].filter(Boolean);
+  if (normalized.length === 0) {
+    throw new Error("At least one project-relative path is required.");
+  }
+  return normalized;
+}
+
+function summarizeChanges(branch: string, changes: GitFileStatus[]): GitStatus {
+  const added = changes.filter(c => c.status === "added").length;
+  const modified = changes.filter(c => c.status === "modified").length;
+  const deleted = changes.filter(c => c.status === "deleted").length;
+  return {
+    branch,
+    changes,
+    added,
+    modified,
+    deleted,
+    hasChanges: changes.length > 0,
+  };
+}
+
+function filterGitStatus(status: GitStatus, paths?: string[]): GitStatus {
+  const normalized = normalizeCommitPaths(paths);
+  if (!normalized) return status;
+
+  const changesByPath = new Map(
+    status.changes.map(change => [change.path, change]),
+  );
+  const selectedChanges = normalized
+    .map(path => changesByPath.get(path))
+    .filter((change): change is GitFileStatus => change !== undefined);
+  const missing = normalized.filter(path => !changesByPath.has(path));
+
+  if (missing.length > 0) {
+    const available = status.changes.map(change => change.path).join(", ");
+    throw new Error(
+      `Selected path(s) have no pending changes: ${missing.join(", ")}.` +
+        (available
+          ? ` Pending changed paths are: ${available}.`
+          : " The working tree is clean."),
+    );
+  }
+
+  return summarizeChanges(status.branch, selectedChanges);
+}
+
 /** Compute the working-tree status of a repo-bound project. */
-export async function getGitStatus(project: IDbtProject): Promise<GitStatus> {
+export async function getGitStatus(
+  project: IDbtProject,
+  options: GitStatusOptions = {},
+): Promise<GitStatus> {
   if (!project.repo) {
     throw new Error("Project is not connected to a repository");
   }
@@ -130,17 +195,10 @@ export async function getGitStatus(project: IDbtProject): Promise<GitStatus> {
     }
   }
   changes.sort((a, b) => a.path.localeCompare(b.path));
-  const added = changes.filter(c => c.status === "added").length;
-  const modified = changes.filter(c => c.status === "modified").length;
-  const deleted = changes.filter(c => c.status === "deleted").length;
-  return {
-    branch: project.repo.branch,
-    changes,
-    added,
-    modified,
-    deleted,
-    hasChanges: changes.length > 0,
-  };
+  return filterGitStatus(
+    summarizeChanges(project.repo.branch, changes),
+    options.paths,
+  );
 }
 
 export interface GitFileDiff {
@@ -208,11 +266,11 @@ export interface CommitResult {
  */
 export async function commitAndPush(
   project: IDbtProject,
-  params: { message: string; updatedBy: string },
+  params: { message: string; updatedBy: string; paths?: string[] },
 ): Promise<CommitResult> {
   return withProjectGitLock(project._id.toString(), async () => {
     const fresh = await reloadRepoProject(project);
-    const status = await getGitStatus(fresh);
+    const status = await getGitStatus(fresh, { paths: params.paths });
     if (!status.hasChanges) {
       return {
         committed: false,
@@ -353,11 +411,16 @@ export interface PromoteResult extends CommitResult {
  */
 export async function commitToNewBranch(
   project: IDbtProject,
-  params: { branchName: string; message: string; updatedBy: string },
+  params: {
+    branchName: string;
+    message: string;
+    updatedBy: string;
+    paths?: string[];
+  },
 ): Promise<PromoteResult> {
   return withProjectGitLock(project._id.toString(), async () => {
     const fresh = await reloadRepoProject(project);
-    const status = await getGitStatus(fresh);
+    const status = await getGitStatus(fresh, { paths: params.paths });
     if (!status.hasChanges) {
       throw new Error(
         "No working-tree changes to promote — nothing to put on a new branch. " +

--- a/app/src/agent-runtime/client-tool-manifest.ts
+++ b/app/src/agent-runtime/client-tool-manifest.ts
@@ -770,7 +770,12 @@ export const AGENT_TOOL_MANIFEST = {
     domain: "dbt",
     execution: "server",
     longRunning: true,
-    getLabel: () => "Committing & pushing",
+    getLabel: input => {
+      const paths = (input as Record<string, unknown>)?.paths;
+      return Array.isArray(paths) && paths.length > 0
+        ? `Committing ${paths.length} file${paths.length === 1 ? "" : "s"} & pushing`
+        : "Committing & pushing";
+    },
     icon: "external-link",
   },
   dbt_commit_to_branch: {
@@ -779,6 +784,12 @@ export const AGENT_TOOL_MANIFEST = {
     longRunning: true,
     getLabel: input => {
       const name = (input as Record<string, unknown>)?.name;
+      const paths = (input as Record<string, unknown>)?.paths;
+      const count =
+        Array.isArray(paths) && paths.length > 0 ? paths.length : null;
+      if (name && count) {
+        return `Committing ${count} file${count === 1 ? "" : "s"} to ${name}`;
+      }
       return name ? `Committing to ${name}` : "Committing to new branch";
     },
     icon: "external-link",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add optional `paths` support to `dbt_commit_and_push` and `dbt_commit_to_branch` so agents can commit only selected dbt working-tree files.
- Scope generated dbt commit messages to the same selected paths.
- Update dbt agent guidance and tool labels for selected-file commits.
- Add service and tool tests covering selected-path commit behavior.

## Testing
- `pnpm --filter api exec vitest run src/dbt/dbt-github-git.commit.test.ts src/agent-lib/tools/dbt-job-tools.test.ts`
- `pnpm --filter api run build`
- `pnpm --filter app run typecheck`
- `pnpm --filter app run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01eee4a9-5a12-4f2a-90f6-4c66d1ae7e6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01eee4a9-5a12-4f2a-90f6-4c66d1ae7e6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

