### PR TITLE
Guard dbt PR merge against dirty working tree

### DIFF
--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -1612,7 +1612,9 @@ export const createDbtServerTools = (
         "optionally delete its source branch, then switch the project back to " +
         "the repo's default branch and sync the merged state into the working " +
         "tree. Use when the user asks to promote/merge a PR — completes the " +
-        "full ship loop without manual GitHub UI steps. Returns the merge " +
+        "full ship loop without manual GitHub UI steps. Refuses before merging " +
+        "if the working tree has uncommitted changes that must be committed or " +
+        "moved first. Returns the merge " +
         "commit SHA, whether the branch was deleted, and confirmation the " +
         "working tree is clean on the default branch.",
       inputSchema: z.object({
@@ -1656,6 +1658,7 @@ export const createDbtServerTools = (
               : {}),
             branch: result.branch,
             workingTreeClean: result.workingTreeClean,
+            preservedLocal: result.preservedLocal,
           };
         } catch (error) {
           return toolError(error, "Failed to merge pull request");

--- a/api/src/agents/dbt/prompt.ts
+++ b/api/src/agents/dbt/prompt.ts
@@ -33,8 +33,9 @@ runs execute against the project's warehouse environments (dev/prod).
    \`dbt_commit_and_push\`, which can race a concurrent commit and strand the changes on the wrong
    branch. Then \`dbt_open_pull_request\`; when the user asks to promote/merge, call
    \`dbt_merge_pull_request\` with the PR number to merge on GitHub, delete the feature branch,
-   and sync the default branch into the working tree. If a build runs against a stale checkout (fewer
-   models/sources than the branch has, e.g. a merged PR not yet picked up), call
+   and sync the default branch into the working tree; it refuses before merging when there are
+   uncommitted working-tree changes. If a build runs against a stale checkout (fewer models/sources
+   than the branch has, e.g. a merged PR not yet picked up), call
    \`dbt_sync_from_repo\` to re-pull the tracked branch. Clean up merged/stray branches with
    \`dbt_delete_branch\`.
 

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -175,8 +175,9 @@ changes on a NEW branch for review, use \`dbt_commit_to_branch\` (atomic branch+
 \`dbt_create_branch\` + \`dbt_commit_and_push\` — the two-step version can race a concurrent commit and
 strand the changes on the wrong branch. Then \`dbt_open_pull_request\`; when the user asks to
 promote/merge, call \`dbt_merge_pull_request\` with the PR number to merge on GitHub, delete the
-feature branch, and sync the default branch into the working tree. If a run builds from a stale
-checkout (fewer models/sources than the branch actually has, e.g. a merged PR not picked up), call
+feature branch, and sync the default branch into the working tree; it refuses before merging when
+there are uncommitted working-tree changes. If a run builds from a stale checkout (fewer
+models/sources than the branch actually has, e.g. a merged PR not picked up), call
 \`dbt_sync_from_repo\` to re-pull the tracked branch. Use \`dbt_delete_branch\` to clean up merged or
 stray branches. Switching branches OVERWRITES the working tree: \`dbt_switch_branch\` refuses when
 there are uncommitted changes — commit them first, or pass \`discardLocalChanges\` only after the

--- a/api/src/dbt/dbt-github-git.merge.test.ts
+++ b/api/src/dbt/dbt-github-git.merge.test.ts
@@ -4,6 +4,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Types } from "mongoose";
 import type { IDbtProject } from "../database/workspace-schema";
+import { gitBlobSha } from "../integrations/github/git-blob";
 
 vi.mock("../integrations/github/app-auth", () => ({
   resolveRepoToken: vi.fn(async () => "token"),
@@ -17,19 +18,23 @@ vi.mock("../integrations/github/github-api", () => ({
 }));
 
 vi.mock("./dbt-github-sync.service", () => ({
-  syncProjectFromRepo: vi.fn(async () => undefined),
+  syncProjectFromRepo: vi.fn(async () => ({
+    sha: "synced-sha",
+    added: 0,
+    updated: 0,
+    deleted: 0,
+    skippedLarge: [],
+    preservedLocal: [],
+  })),
 }));
 
 const mockFindById = vi.fn();
+const mockFindFiles = vi.fn();
 const mockSave = vi.fn(async () => undefined);
 
 vi.mock("../database/workspace-schema", () => ({
   DbtFile: {
-    find: vi.fn(() => ({
-      select: () => ({
-        lean: async () => [],
-      }),
-    })),
+    find: (...args: unknown[]) => mockFindFiles(...args),
     findOne: vi.fn(),
   },
   DbtProject: {
@@ -63,11 +68,27 @@ function makeProject(overrides: Partial<IDbtProject> = {}): IDbtProject {
   } as unknown as IDbtProject;
 }
 
+function mockFiles(
+  files: Array<{
+    path: string;
+    content?: string;
+    is_deleted?: boolean;
+    repoBlobSha?: string;
+  }> = [],
+) {
+  mockFindFiles.mockReturnValue({
+    select: () => ({
+      lean: async () => files,
+    }),
+  });
+}
+
 describe("mergeProjectPullRequest", () => {
   let storedProject: IDbtProject;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockFiles();
     storedProject = makeProject();
     mockFindById.mockImplementation(async () => storedProject);
   });
@@ -105,7 +126,9 @@ describe("mergeProjectPullRequest", () => {
     );
     expect(project.repo?.branch).toBe("main");
     expect(mockSave).toHaveBeenCalled();
-    expect(syncProjectFromRepo).toHaveBeenCalledWith(project, "agent");
+    expect(syncProjectFromRepo).toHaveBeenCalledWith(project, "agent", {
+      preserveLocalEdits: true,
+    });
     expect(tryDeleteBranch).toHaveBeenCalledWith(
       "acme",
       "dbt",
@@ -118,7 +141,57 @@ describe("mergeProjectPullRequest", () => {
       branchDeleteWarning: undefined,
       branch: "main",
       workingTreeClean: true,
+      preservedLocal: [],
     });
+  });
+
+  it("refuses before merging when switching back would discard local work", async () => {
+    vi.mocked(getPullRequest).mockResolvedValue({
+      number: 42,
+      headRef: "feature/add-model",
+      baseRef: "main",
+      mergeable: true,
+      state: "open",
+    });
+    vi.mocked(getRepoInfo).mockResolvedValue({
+      fullName: "acme/dbt",
+      owner: "acme",
+      name: "dbt",
+      defaultBranch: "main",
+      private: false,
+    });
+    mockFiles([
+      {
+        path: "models/_crm__sources.yml",
+        content: "version: 2\n",
+        is_deleted: false,
+      },
+      {
+        path: "models/int_crm__activity_account.sql",
+        content: "select 'email' as match_key",
+        is_deleted: false,
+        repoBlobSha: gitBlobSha("select 'name' as match_key"),
+      },
+      {
+        path: "models/old_name_match.sql",
+        is_deleted: true,
+        repoBlobSha: gitBlobSha("select 'name'"),
+      },
+    ]);
+
+    await expect(
+      mergeProjectPullRequest(storedProject, {
+        prNumber: 42,
+        updatedBy: "agent",
+      }),
+    ).rejects.toThrow(
+      'Refusing to merge pull request and switch from "feature/add-model" to "main": 3 uncommitted working-tree change(s)',
+    );
+
+    expect(mergePullRequest).not.toHaveBeenCalled();
+    expect(syncProjectFromRepo).not.toHaveBeenCalled();
+    expect(tryDeleteBranch).not.toHaveBeenCalled();
+    expect(storedProject.repo?.branch).toBe("feature/add-model");
   });
 
   it("returns branch delete warning when deletion fails", async () => {

--- a/api/src/dbt/dbt-github-git.service.ts
+++ b/api/src/dbt/dbt-github-git.service.ts
@@ -166,6 +166,22 @@ function filterGitStatus(status: GitStatus, paths?: string[]): GitStatus {
   return summarizeChanges(status.branch, selectedChanges);
 }
 
+function dirtyBranchMoveMessage(params: {
+  action: string;
+  fromBranch: string;
+  toBranch: string;
+  status: GitStatus;
+}): string {
+  const summary = `${params.status.added} added, ${params.status.modified} modified, ${params.status.deleted} deleted`;
+  return (
+    `Refusing to ${params.action} from "${params.fromBranch}" to "${params.toBranch}": ` +
+    `${params.status.changes.length} uncommitted working-tree change(s) (${summary}) ` +
+    "would be lost. Commit them first (dbt_commit_and_push to push to the " +
+    "current branch, or dbt_commit_to_branch to move them to a new branch), " +
+    "or explicitly discard them only after the user confirms abandoning that work."
+  );
+}
+
 /** Compute the working-tree status of a repo-bound project. */
 export async function getGitStatus(
   project: IDbtProject,
@@ -504,13 +520,13 @@ export async function switchProjectBranch(
     if (!options.discardLocalChanges) {
       const status = await getGitStatus(fresh);
       if (status.hasChanges) {
-        const summary = `${status.added} added, ${status.modified} modified, ${status.deleted} deleted`;
         throw new Error(
-          `Refusing to switch from "${fresh.repo.branch}" to "${branchName}": ` +
-            `${status.changes.length} uncommitted working-tree change(s) (${summary}) ` +
-            "would be lost. Commit them first (dbt_commit_and_push to push to the " +
-            "current branch, or dbt_commit_to_branch to move them to a new branch), " +
-            "or call again with discardLocalChanges to abandon them on purpose.",
+          dirtyBranchMoveMessage({
+            action: "switch",
+            fromBranch: fresh.repo.branch,
+            toBranch: branchName,
+            status,
+          }),
         );
       }
     } else {
@@ -653,6 +669,7 @@ export interface MergePullRequestResult {
   branchDeleteWarning?: string;
   branch: string;
   workingTreeClean: boolean;
+  preservedLocal: string[];
 }
 
 /**
@@ -681,6 +698,20 @@ export async function mergeProjectPullRequest(
       );
     }
 
+    const info = await getRepoInfo(owner, repo, token);
+    const defaultBranch = info.defaultBranch;
+    const preMergeStatus = await getGitStatus(fresh);
+    if (preMergeStatus.hasChanges) {
+      throw new Error(
+        dirtyBranchMoveMessage({
+          action: "merge pull request and switch",
+          fromBranch: fresh.repo.branch,
+          toBranch: defaultBranch,
+          status: preMergeStatus,
+        }),
+      );
+    }
+
     const { sha } = await mergePullRequest(
       owner,
       repo,
@@ -689,13 +720,12 @@ export async function mergeProjectPullRequest(
       token,
     );
 
-    const info = await getRepoInfo(owner, repo, token);
-    const defaultBranch = info.defaultBranch;
-
     fresh.repo.branch = defaultBranch;
     fresh.markModified("repo");
     await fresh.save();
-    await syncProjectFromRepo(fresh, params.updatedBy);
+    const syncResult = await syncProjectFromRepo(fresh, params.updatedBy, {
+      preserveLocalEdits: true,
+    });
 
     let branchDeleted = false;
     let branchDeleteWarning: string | undefined;
@@ -717,6 +747,7 @@ export async function mergeProjectPullRequest(
       branchDeleteWarning,
       branch: defaultBranch,
       workingTreeClean: !status.hasChanges,
+      preservedLocal: syncResult.preservedLocal,
     };
   });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add a pre-merge dirty working-tree check to `mergeProjectPullRequest` so `dbt_merge_pull_request` refuses before mutating GitHub when local dbt edits would be overwritten by switching back to the default branch.
- Sync the merged default branch with `preserveLocalEdits: true` as a second safety net for edits that appear mid-operation.
- Add regression coverage for locally added, modified, and deleted dbt files and update dbt agent guidance/tool output.

### Testing
- `pnpm --filter api run test:dbt -- src/dbt/dbt-github-git.merge.test.ts`
- `pnpm --filter api run lint`
- `pnpm --filter api run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1b4477d-7cf2-4b43-9471-93804ad306ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1b4477d-7cf2-4b43-9471-93804ad306ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

