### PR TITLE
feat(sync-cdc): run CDC repartition as an observable background job

### DIFF
--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -1054,6 +1054,13 @@ export interface ICdcEntityState extends Document {
   consecutiveFailures: number;
   lastFailedAt?: Date;
   lastFailureError?: string;
+  // Progress of an in-place destination-table repartition (layout change).
+  repartition?: {
+    status: "pending" | "running" | "done" | "failed";
+    startedAt?: Date;
+    completedAt?: Date;
+    error?: string;
+  };
 }
 
 export type IBigQueryChangeEvent = ICdcChangeEvent;
@@ -2654,6 +2661,15 @@ const CdcEntityStateSchema = new Schema<ICdcEntityState>(
     consecutiveFailures: { type: Number, default: 0 },
     lastFailedAt: Date,
     lastFailureError: String,
+    repartition: {
+      status: {
+        type: String,
+        enum: ["pending", "running", "done", "failed"],
+      },
+      startedAt: Date,
+      completedAt: Date,
+      error: String,
+    },
   },
   {
     collection: "cdc_entity_state",

--- a/api/src/inngest/functions/cdc-repartition.ts
+++ b/api/src/inngest/functions/cdc-repartition.ts
@@ -1,0 +1,126 @@
+import { inngest } from "../client";
+import { cdcBackfillService } from "../../sync-cdc/backfill";
+import { loggers } from "../../logging";
+
+const log = loggers.inngest();
+
+interface RepartitionEventData {
+  workspaceId: string;
+  flowId: string;
+  entities: string[];
+  deleteDestination?: boolean;
+}
+
+/**
+ * Background, observable in-place repartition of CDC destination tables.
+ *
+ * Triggered by a layout change (partition/cluster). Each entity is rewritten as
+ * its own durable `step.run`, so a long copy on a large table can't time out the
+ * request or block the others, and a transient failure retries that step alone.
+ *
+ * Flow:
+ *  1. pause the flow stream (consumer holds events while tables swap),
+ *  2. repartition each entity in place (copy + swap) — per-entity status is
+ *     persisted on `CdcEntityState.repartition` for the UI,
+ *  3. resume the stream,
+ *  4. re-trigger materialization for repartitioned entities (queued events apply
+ *     to the new table; merge is idempotent), and backfill any entity that had
+ *     no existing table.
+ *
+ * `onFailure` resumes the stream and marks still-running entities failed so a
+ * crash can never leave the flow stuck paused.
+ */
+export const cdcRepartitionFunction = inngest.createFunction(
+  {
+    id: "cdc-repartition",
+    name: "CDC Repartition",
+    retries: 2,
+    timeouts: { finish: "2h" },
+    concurrency: [{ scope: "fn", key: "event.data.flowId", limit: 1 }],
+    singleton: { key: "event.data.flowId", mode: "skip" },
+    onFailure: async ({ event }) => {
+      const data = ((event as { data?: { event?: { data?: RepartitionEventData } } })
+        ?.data?.event?.data ?? {}) as Partial<RepartitionEventData>;
+      if (data.workspaceId && data.flowId) {
+        await cdcBackfillService.recoverRepartition(
+          data.workspaceId,
+          data.flowId,
+        );
+      }
+      log.error(
+        "cdc-repartition failed; resumed stream + marked entities failed",
+        { flowId: data.flowId },
+      );
+    },
+  },
+  { event: "cdc/repartition" },
+  async ({ event, step }) => {
+    const { workspaceId, flowId, deleteDestination } =
+      event.data as RepartitionEventData;
+    const entities = Array.isArray(event.data?.entities)
+      ? (event.data.entities as unknown[]).filter(
+          (e): e is string => typeof e === "string" && e.length > 0,
+        )
+      : [];
+    if (entities.length === 0) {
+      return { repartitioned: [], missing: [], failed: [] };
+    }
+
+    const { previousStreamState } = (await step.run("pause-stream", () =>
+      cdcBackfillService.pauseStreamForRepartition(workspaceId, flowId),
+    )) as { previousStreamState: string };
+
+    const repartitioned: string[] = [];
+    const missing: string[] = [];
+    const failed: string[] = [];
+
+    for (const entity of entities) {
+      const safeId = entity.replace(/[^a-zA-Z0-9_-]/g, "_");
+      const result = (await step.run(`repartition-${safeId}`, () =>
+        cdcBackfillService.repartitionEntity({ workspaceId, flowId, entity }),
+      )) as { outcome: "repartitioned" | "missing" | "failed" };
+      if (result.outcome === "repartitioned") repartitioned.push(entity);
+      else if (result.outcome === "missing") missing.push(entity);
+      else failed.push(entity);
+    }
+
+    // Resume before follow-ups so live materialization isn't held longer than
+    // the swaps themselves.
+    await step.run("resume-stream", () =>
+      cdcBackfillService.resumeStreamForRepartition(
+        workspaceId,
+        flowId,
+        previousStreamState,
+      ),
+    );
+
+    if (repartitioned.length > 0) {
+      await step.run("materialize-repartitioned", () =>
+        cdcBackfillService.triggerEntityMaterialization(
+          workspaceId,
+          flowId,
+          repartitioned,
+        ),
+      );
+    }
+
+    if (missing.length > 0) {
+      await step.run("backfill-missing", () =>
+        cdcBackfillService.backfillMissingEntities(
+          workspaceId,
+          flowId,
+          missing,
+          deleteDestination,
+        ),
+      );
+    }
+
+    log.info("cdc-repartition complete", {
+      flowId,
+      repartitioned,
+      missing,
+      failed,
+    });
+    return { repartitioned, missing, failed };
+  },
+);

--- a/api/src/inngest/functions/webhook-flow.ts
+++ b/api/src/inngest/functions/webhook-flow.ts
@@ -17,6 +17,7 @@ import {
 } from "../../sync-cdc/normalization";
 import { cdcIngestService } from "../../sync-cdc/ingest";
 import { cdcConsumerService } from "../../sync-cdc/consumer";
+import { cdcBackfillService } from "../../sync-cdc/backfill";
 import { cleanupStalePendingCdcEvents } from "../../sync-cdc/cdc-stale-pending-cleanup";
 import { reconcileOrphanedWebhookApplyStatus } from "../../sync-cdc/cdc-orphan-applystatus";
 
@@ -840,6 +841,12 @@ export const cdcMaterializeSchedulerFunction = inngest.createFunction(
       "reconcile-orphaned-applystatus",
       reconcileOrphanedWebhookApplyStatus,
     )) as Awaited<ReturnType<typeof reconcileOrphanedWebhookApplyStatus>>;
+
+    // Safety net: resume any flow stuck in a repartition pause (e.g. the
+    // repartition job's process died before its resume step ran).
+    await step.run("recover-stale-repartition-pauses", () =>
+      cdcBackfillService.recoverStaleRepartitionPauses(),
+    );
 
     const staleEntities = (await step.run(
       "find-stale-entities",

--- a/api/src/inngest/index.ts
+++ b/api/src/inngest/index.ts
@@ -22,6 +22,7 @@ import {
   appBindingSchedulerFunction,
 } from "./functions/app-binding-materialize";
 import { syncBackfillEntityFunction } from "./functions/sync-entity";
+import { cdcRepartitionFunction } from "./functions/cdc-repartition";
 import { usageReportingFunction } from "./functions/usage-reporting";
 import { modelCatalogRefreshFunction } from "./functions/model-catalog-refresh";
 import {
@@ -46,6 +47,7 @@ const baseFunctions = [
   cancelFlowFunction,
   cleanupAbandonedFlowsFunction,
   syncBackfillEntityFunction,
+  cdcRepartitionFunction,
   dashboardRefreshFunction,
   cleanupAbandonedMaterializationRunsFunction,
   appBindingMaterializeFunction,

--- a/api/src/routes/flows.ts
+++ b/api/src/routes/flows.ts
@@ -3329,6 +3329,16 @@ flowRoutes.openapi(
           failedCount: failedByEntity.get(entity)?.count || 0,
           lastFailedAt: failedByEntity.get(entity)?.latestAt || null,
           lastFailedError: failedByEntity.get(entity)?.latestError || null,
+          repartition: (state as any)?.repartition?.status
+            ? {
+                status: (state as any).repartition.status as
+                  | "pending"
+                  | "running"
+                  | "done"
+                  | "failed",
+                error: (state as any).repartition.error ?? null,
+              }
+            : null,
         };
       });
 

--- a/api/src/sync-cdc/backfill.ts
+++ b/api/src/sync-cdc/backfill.ts
@@ -531,7 +531,7 @@ export class CdcBackfillService {
     flowId: string;
     entities: string[];
     deleteDestination?: boolean;
-  }): Promise<{ repartitioned: string[]; backfilled: string[] }> {
+  }): Promise<{ queued: string[] }> {
     const { workspaceId, flowId, deleteDestination } = params;
     const entities = normalizeEntities(params.entities);
     if (entities.length === 0) {
@@ -551,129 +551,284 @@ export class CdcBackfillService {
 
     await assertCanStartBackfill(workspaceId, flowId);
 
-    // Preferred path: rewrite the partitioning/clustering in place by copying
-    // existing destination rows into a new-layout table and swapping — no
-    // source re-fetch. Entities whose table can't be repartitioned (missing,
-    // unsupported destination, or copy failure) fall back to drop + backfill.
-    const { repartitioned, fallback } = await this.repartitionEntitiesInPlace(
-      flow,
-      workspaceId,
-      flowId,
-      entities,
+    // Mark the target entities pending so the UI shows progress immediately,
+    // then hand off to the background `cdc/repartition` job. The job rewrites
+    // the partitioning/clustering in place (copy + swap, no source re-fetch)
+    // per entity as durable steps — so a long copy on a large table can't time
+    // out the request or leave the others unprocessed.
+    await CdcEntityState.updateMany(
+      { flowId: flow._id, entity: { $in: entities } },
+      {
+        $set: {
+          "repartition.status": "pending",
+          "repartition.startedAt": new Date(),
+        },
+        $unset: { "repartition.completedAt": "", "repartition.error": "" },
+      },
     );
 
-    if (fallback.length > 0) {
-      await this.backfillEntitiesFallback(
-        flow,
+    await inngest.send({
+      name: "cdc/repartition",
+      data: {
         workspaceId,
         flowId,
-        fallback,
-        deleteDestination,
-      );
-    }
-
-    log.info("resyncEntities complete", {
-      flowId,
-      repartitioned,
-      backfilled: fallback,
-    });
-    return { repartitioned, backfilled: fallback };
-  }
-
-  /**
-   * Build the destination adapter for a flow and, for each entity, attempt an
-   * in-place repartition (copy + swap). The flow's stream is paused for the
-   * duration so the consumer holds incoming events (they materialize into the
-   * freshly-laid-out table once we resume + re-trigger). Returns which entities
-   * were repartitioned vs. which need a drop + backfill fallback.
-   */
-  private async repartitionEntitiesInPlace(
-    flow: IFlow,
-    workspaceId: string,
-    flowId: string,
-    entities: string[],
-  ): Promise<{ repartitioned: string[]; fallback: string[] }> {
-    if (!flow.tableDestination?.connectionId || !flow.tableDestination?.schema) {
-      return { repartitioned: [], fallback: entities };
-    }
-    const destination = await DatabaseConnection.findById(
-      flow.tableDestination.connectionId,
-    ).lean();
-    if (!destination) {
-      return { repartitioned: [], fallback: entities };
-    }
-
-    const adapter = resolveCdcDestinationAdapter({
-      destinationType: destination.type,
-      destinationDatabaseId: String(flow.destinationDatabaseId),
-      destinationDatabaseName: flow.destinationDatabaseName,
-      tableDestination: {
-        connectionId: String(flow.tableDestination.connectionId),
-        schema: flow.tableDestination.schema,
-        tableName: flow.tableDestination.tableName || "",
+        entities,
+        deleteDestination: Boolean(deleteDestination),
       },
     });
 
-    // Destination doesn't support in-place repartition (e.g. PostgreSQL/Mongo).
-    if (!adapter.repartitionLiveTable) {
-      return { repartitioned: [], fallback: entities };
-    }
+    log.info("Enqueued cdc/repartition job", { flowId, entities });
+    return { queued: entities };
+  }
 
-    const repartitioned: string[] = [];
-    const fallback: string[] = [];
+  /** Resolve the in-place-repartition-capable adapter for a flow (or null). */
+  private resolveRepartitionAdapter(flow: IFlow, destinationType: string) {
+    const adapter = resolveCdcDestinationAdapter({
+      destinationType,
+      destinationDatabaseId: String(flow.destinationDatabaseId),
+      destinationDatabaseName: flow.destinationDatabaseName,
+      tableDestination: {
+        connectionId: String(flow.tableDestination?.connectionId),
+        schema: flow.tableDestination?.schema || "public",
+        tableName: flow.tableDestination?.tableName || "",
+      },
+    });
+    return adapter.repartitionLiveTable ? adapter : null;
+  }
 
-    // Pause materialization so no writes land on the live table mid-swap.
-    const previousStreamState = flow.streamState;
+  private async setEntityRepartitionStatus(
+    workspaceId: Types.ObjectId,
+    flowId: Types.ObjectId,
+    entity: string,
+    repartition: {
+      status: "pending" | "running" | "done" | "failed";
+      startedAt?: Date;
+      completedAt?: Date;
+      error?: string;
+    },
+  ): Promise<void> {
+    await CdcEntityState.updateOne(
+      { flowId, entity },
+      { $set: { repartition }, $setOnInsert: { workspaceId, mode: "steady" } },
+      { upsert: true },
+    );
+  }
+
+  /**
+   * Pause the flow stream for an in-place repartition. Returns the prior stream
+   * state so the resume step can restore it. Tags the pause with a
+   * `REPARTITION_PAUSE` marker so a stuck pause can be auto-recovered.
+   */
+  async pauseStreamForRepartition(
+    workspaceId: string,
+    flowId: string,
+  ): Promise<{ previousStreamState: string }> {
+    const flow = await Flow.findOne({
+      _id: new Types.ObjectId(flowId),
+      workspaceId: new Types.ObjectId(workspaceId),
+    });
+    if (!flow) throw new Error("Flow not found");
+    const previous =
+      flow.streamState && flow.streamState !== "paused"
+        ? flow.streamState
+        : "idle";
     flow.streamState = "paused";
+    flow.syncStateMeta = {
+      ...(flow.syncStateMeta || {}),
+      lastEvent: "REPARTITION_PAUSE",
+      lastReason: "Paused for in-place repartition",
+    };
     flow.syncStateUpdatedAt = new Date();
     await flow.save();
-    log.info("Paused flow stream for in-place repartition", {
-      flowId,
-      entities,
-      previousStreamState,
-    });
+    log.info("Paused flow stream for repartition", { flowId, previous });
+    return { previousStreamState: previous };
+  }
 
-    try {
-      for (const entity of entities) {
-        const layout = await this.buildEntityLayout(flow, entity);
-        try {
-          const result = await adapter.repartitionLiveTable(layout);
-          if (result.repartitioned) {
-            repartitioned.push(entity);
-          } else {
-            // No existing table — let the backfill path create it fresh.
-            fallback.push(entity);
-          }
-        } catch (error) {
-          log.warn("In-place repartition failed; falling back to backfill", {
-            flowId,
-            entity,
-            error: error instanceof Error ? error.message : String(error),
-          });
-          fallback.push(entity);
-        }
-      }
-    } finally {
-      // Always restore the stream state, even if a repartition threw.
-      flow.streamState = previousStreamState || "idle";
+  /** Resume the stream after repartition, restoring the prior state. */
+  async resumeStreamForRepartition(
+    workspaceId: string,
+    flowId: string,
+    previousStreamState: string,
+  ): Promise<void> {
+    const flow = await Flow.findOne({
+      _id: new Types.ObjectId(flowId),
+      workspaceId: new Types.ObjectId(workspaceId),
+    });
+    if (!flow) return;
+    // Only resume our own pause — never clobber a pause set elsewhere.
+    if (
+      flow.streamState === "paused" &&
+      flow.syncStateMeta?.lastEvent === "REPARTITION_PAUSE"
+    ) {
+      flow.streamState = (previousStreamState as IFlow["streamState"]) || "idle";
+      flow.syncStateMeta = {
+        ...(flow.syncStateMeta || {}),
+        lastEvent: "REPARTITION_RESUME",
+        lastReason: "Resumed after in-place repartition",
+      };
       flow.syncStateUpdatedAt = new Date();
       await flow.save();
-      log.info("Resumed flow stream after in-place repartition", {
+      log.info("Resumed flow stream after repartition", {
         flowId,
         restoredStreamState: flow.streamState,
       });
     }
+  }
 
-    // Re-trigger materialization for repartitioned entities so any events that
-    // queued during the pause are applied to the new table (idempotent merge).
-    for (const entity of repartitioned) {
+  /**
+   * Repartition a single entity's destination table in place (copy + swap).
+   * Updates the entity's `repartition` status. Returns the outcome so the job
+   * can decide follow-up: `repartitioned` (done), `missing` (no table → create
+   * via backfill), or `failed` (left as-is, surfaced for operator retry).
+   */
+  async repartitionEntity(params: {
+    workspaceId: string;
+    flowId: string;
+    entity: string;
+  }): Promise<{ outcome: "repartitioned" | "missing" | "failed"; error?: string }> {
+    const { workspaceId, flowId, entity } = params;
+    const flow = await Flow.findOne({
+      _id: new Types.ObjectId(flowId),
+      workspaceId: new Types.ObjectId(workspaceId),
+    });
+    if (!flow) throw new Error("Flow not found");
+
+    if (!flow.tableDestination?.connectionId) {
+      return { outcome: "missing" };
+    }
+    const destination = await DatabaseConnection.findById(
+      flow.tableDestination.connectionId,
+    ).lean();
+    const adapter = destination
+      ? this.resolveRepartitionAdapter(flow, destination.type)
+      : null;
+    if (!adapter?.repartitionLiveTable) {
+      // Unsupported destination (PostgreSQL/Mongo) — fall back to backfill.
+      return { outcome: "missing" };
+    }
+
+    await this.setEntityRepartitionStatus(flow.workspaceId, flow._id, entity, {
+      status: "running",
+      startedAt: new Date(),
+    });
+    try {
+      const layout = await this.buildEntityLayout(flow, entity);
+      const result = await adapter.repartitionLiveTable(layout);
+      if (result.repartitioned) {
+        await this.setEntityRepartitionStatus(
+          flow.workspaceId,
+          flow._id,
+          entity,
+          { status: "done", completedAt: new Date() },
+        );
+        return { outcome: "repartitioned" };
+      }
+      // No existing table — clear status; the backfill path will create it.
+      await CdcEntityState.updateOne(
+        { flowId: flow._id, entity },
+        { $unset: { repartition: "" } },
+      );
+      return { outcome: "missing" };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log.error("In-place repartition failed for entity", {
+        flowId,
+        entity,
+        error: message,
+      });
+      await this.setEntityRepartitionStatus(flow.workspaceId, flow._id, entity, {
+        status: "failed",
+        completedAt: new Date(),
+        error: message.slice(0, 500),
+      });
+      return { outcome: "failed", error: message };
+    }
+  }
+
+  /** Fan out materialization for entities that were repartitioned in place. */
+  async triggerEntityMaterialization(
+    workspaceId: string,
+    flowId: string,
+    entities: string[],
+  ): Promise<void> {
+    for (const entity of entities) {
       await inngest.send({
         name: "cdc/materialize",
         data: { workspaceId, flowId, entity, force: true },
       });
     }
+  }
 
-    return { repartitioned, fallback };
+  /**
+   * Safety net: clear any repartition pause / running state for a flow (used by
+   * the job's onFailure handler and the stale-pause sweeper). Marks still-running
+   * entities as failed and resumes the stream.
+   */
+  async recoverRepartition(workspaceId: string, flowId: string): Promise<void> {
+    await CdcEntityState.updateMany(
+      {
+        flowId: new Types.ObjectId(flowId),
+        "repartition.status": { $in: ["pending", "running"] },
+      },
+      {
+        $set: {
+          "repartition.status": "failed",
+          "repartition.completedAt": new Date(),
+          "repartition.error": "Repartition job did not complete",
+        },
+      },
+    );
+    await this.resumeStreamForRepartition(workspaceId, flowId, "idle");
+  }
+
+  /**
+   * Resume flows stuck in a repartition pause for longer than the threshold
+   * (e.g. the job's process died before its resume step ran). Called from the
+   * CDC materialize scheduler.
+   */
+  async recoverStaleRepartitionPauses(
+    olderThanMs = 30 * 60 * 1000,
+  ): Promise<number> {
+    const cutoff = new Date(Date.now() - olderThanMs);
+    const stuck = await Flow.find({
+      streamState: "paused",
+      "syncStateMeta.lastEvent": "REPARTITION_PAUSE",
+      syncStateUpdatedAt: { $lt: cutoff },
+    })
+      .select({ _id: 1, workspaceId: 1 })
+      .lean();
+    for (const flow of stuck) {
+      await this.recoverRepartition(
+        String(flow.workspaceId),
+        String(flow._id),
+      );
+    }
+    if (stuck.length > 0) {
+      log.warn("Recovered stale repartition pauses", { count: stuck.length });
+    }
+    return stuck.length;
+  }
+
+  /** Public entry: load the flow and backfill entities lacking a live table. */
+  async backfillMissingEntities(
+    workspaceId: string,
+    flowId: string,
+    entities: string[],
+    deleteDestination?: boolean,
+  ): Promise<void> {
+    if (entities.length === 0) return;
+    const flow = await Flow.findOne({
+      _id: new Types.ObjectId(flowId),
+      workspaceId: new Types.ObjectId(workspaceId),
+    });
+    if (!flow) throw new Error("Flow not found");
+    await this.backfillEntitiesFallback(
+      flow,
+      workspaceId,
+      flowId,
+      entities,
+      deleteDestination,
+    );
   }
 
   /** Drop + clear + subset backfill for entities that can't be repartitioned. */

--- a/app/src/components/BackfillPanel.tsx
+++ b/app/src/components/BackfillPanel.tsx
@@ -842,6 +842,7 @@ export function BackfillPanel({
         typeof s?.lifetimeRowsApplied === "number" ? s.lifetimeRowsApplied : 0,
       backfillDone: s?.backfillDone === true,
       failedCount: (s as any)?.failedCount || 0,
+      repartition: (s as any)?.repartition ?? null,
       execRows: execStats[name] || 0,
       execStatus: execStatus[name] || null,
     };
@@ -1315,6 +1316,22 @@ export function BackfillPanel({
                   <TableBody>
                     {entities.map(e => {
                       const sc = entityStreamChip(e);
+                      // A repartition (layout change) in progress/failed takes
+                      // precedence over the normal stream chip.
+                      const repart = e.repartition as {
+                        status?: "pending" | "running" | "done" | "failed";
+                        error?: string | null;
+                      } | null;
+                      const streamChip: {
+                        label: string;
+                        color: "success" | "info" | "default" | "error";
+                      } =
+                        repart?.status === "pending" ||
+                        repart?.status === "running"
+                          ? { label: "Repartitioning…", color: "info" }
+                          : repart?.status === "failed"
+                            ? { label: "Repartition failed", color: "error" }
+                            : sc;
                       const bc = entityBackfillChip(e);
                       const backfillChip =
                         e.execStatus === "syncing"
@@ -1396,17 +1413,25 @@ export function BackfillPanel({
                               </Box>
                             </TableCell>
                             <TableCell>
-                              <Chip
-                                label={sc.label}
-                                color={sc.color}
-                                size="small"
-                                variant="outlined"
-                                sx={{
-                                  height: 22,
-                                  fontSize: "0.68rem",
-                                  fontWeight: 500,
-                                }}
-                              />
+                              <Tooltip
+                                title={
+                                  repart?.status === "failed" && repart?.error
+                                    ? `Repartition failed: ${repart.error}`
+                                    : ""
+                                }
+                              >
+                                <Chip
+                                  label={streamChip.label}
+                                  color={streamChip.color}
+                                  size="small"
+                                  variant="outlined"
+                                  sx={{
+                                    height: 22,
+                                    fontSize: "0.68rem",
+                                    fontWeight: 500,
+                                  }}
+                                />
+                              </Tooltip>
                             </TableCell>
                             <TableCell>
                               <Box

--- a/app/src/store/flowStore.ts
+++ b/app/src/store/flowStore.ts
@@ -303,6 +303,10 @@ export interface CdcStatus {
     lifetimeEventsProcessed?: number;
     lifetimeRowsApplied?: number;
     backfillDone?: boolean;
+    repartition?: {
+      status: "pending" | "running" | "done" | "failed";
+      error: string | null;
+    } | null;
   }>;
   pipeline: {
     cdcEventsByStatus: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #619 (merged). The in-place repartition currently runs **synchronously inside the `POST /sync-cdc/resync` request**, which doesn't scale: rebuilding several large BigQuery tables in one request times out the client, so only the smallest table finishes, there's no per-entity progress, and a killed request can leave the stream stuck paused.

## What
- **Background job (`cdc/repartition`)**: the resync route now marks entities pending and enqueues an Inngest job, returning immediately. Each entity is its own durable `step.run`, so a long copy can't time out the request or starve the others, and a transient failure retries just that step.
- **Per-entity progress**: persisted on `CdcEntityState.repartition` (`pending|running|done|failed`, with error), surfaced in `GET .../sync-cdc/status` and shown in the `BackfillPanel` STREAM column ("Repartitioning…" / "Repartition failed" with the error in a tooltip).
- **Crash-safe pause**: pause/resume are durable steps; `onFailure` resumes the stream + marks running entities failed; a sweeper in the CDC materialize scheduler auto-resumes any flow stuck in a repartition pause > 30 min.
- **Safer fallbacks**: a *failed* repartition leaves the existing table intact (no silent drop) and surfaces the error; a *missing* table falls back to a scoped backfill that creates it.

## Files
- `api/src/inngest/functions/cdc-repartition.ts` (new) + `inngest/index.ts` registration
- `api/src/sync-cdc/backfill.ts` — enqueue job; `repartitionEntity`, pause/resume + recovery helpers
- `api/src/inngest/functions/webhook-flow.ts` — stale-pause sweeper in the scheduler
- `api/src/database/workspace-schema.ts` — `CdcEntityState.repartition`
- `api/src/routes/flows.ts` — repartition status in `/sync-cdc/status`
- `app/src/store/flowStore.ts`, `app/src/components/BackfillPanel.tsx` — progress chip

## Testing
- ✅ `pnpm --filter api run build` (lint + `tsc -p tsconfig.build.json`)
- ✅ `pnpm --filter app run typecheck` + `lint`
- ✅ `pnpm --filter api run test:destinations` — 92 offline tests
- ✅ **ClickHouse validated end-to-end** against a real server: `repartitionEntity` swapped the partition key (`toYYYYMMDD(date_created)` → `toYYYYMMDD(_syncedAt)`), preserved rows, and recorded `repartition.status="done"`

### Caveats
- The full Inngest job loop isn't exercised end-to-end in this VM (no Inngest dev + event loop), but its core per-entity step (`repartitionEntity`) is validated against real ClickHouse and the job is thin orchestration over validated service methods.
- BigQuery copy-swap remains validated by the offline SQL builder test + a manual run (no BQ emulator/Docker here); a failed swap leaves the table intact.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f2a4aaa-0dc9-4e60-881a-feb2c521ca7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f2a4aaa-0dc9-4e60-881a-feb2c521ca7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

