### PR TITLE
Improve repartition save feedback

### DIFF
--- a/app/src/components/FlowEditor.tsx
+++ b/app/src/components/FlowEditor.tsx
@@ -1,5 +1,5 @@
 import { useState, type RefObject } from "react";
-import { Box } from "@mui/material";
+import { Alert, Box } from "@mui/material";
 import { ScheduledFlowForm } from "./ScheduledFlowForm";
 import { WebhookFlowForm } from "./WebhookFlowForm";
 import { DbFlowForm, type DbFlowFormRef } from "./DbFlowForm";
@@ -17,6 +17,11 @@ interface FlowEditorProps {
   dbFlowFormRef?: RefObject<DbFlowFormRef | null>;
 }
 
+interface FlowSavedOptions {
+  showBackfillPanel?: boolean;
+  notice?: string;
+}
+
 export function FlowEditor({
   flowId,
   isNew = false,
@@ -29,6 +34,7 @@ export function FlowEditor({
   const [currentFlowId, setCurrentFlowId] = useState<string | undefined>(
     flowId,
   );
+  const [backfillNotice, setBackfillNotice] = useState<string | null>(null);
 
   const { currentWorkspace } = useWorkspace();
   const { flows: flowsMap, runFlow } = useFlowStore();
@@ -50,8 +56,16 @@ export function FlowEditor({
     currentFlow?.sourceType === "database" ||
     (!currentFlow && flowType === "db-scheduled");
 
-  const handleSaved = (newFlowId: string) => {
+  const handleSaved = (newFlowId: string, options?: FlowSavedOptions) => {
     setCurrentFlowId(newFlowId);
+    if (options?.showBackfillPanel) {
+      setBackfillNotice(options.notice ?? null);
+      setIsEditing(false);
+      onSave?.();
+      return;
+    }
+
+    setBackfillNotice(null);
     // Webhook flows stay in editing mode after first save so the user
     // can see the generated webhook URL and finish setup in Step 5.
     if (!isWebhookFlow) {
@@ -67,6 +81,7 @@ export function FlowEditor({
   };
 
   const handleEditClick = () => {
+    setBackfillNotice(null);
     setIsEditing(true);
   };
 
@@ -127,11 +142,22 @@ export function FlowEditor({
             />
           )}
           {currentFlowId && isWebhookFlow && currentWorkspace && (
-            <BackfillPanel
-              workspaceId={currentWorkspace.id}
-              flowId={currentFlowId}
-              onEdit={handleEditClick}
-            />
+            <>
+              {backfillNotice && (
+                <Alert
+                  severity="success"
+                  onClose={() => setBackfillNotice(null)}
+                  sx={{ m: 2, mb: 0 }}
+                >
+                  {backfillNotice}
+                </Alert>
+              )}
+              <BackfillPanel
+                workspaceId={currentWorkspace.id}
+                flowId={currentFlowId}
+                onEdit={handleEditClick}
+              />
+            </>
           )}
         </>
       )}

--- a/app/src/components/WebhookFlowForm.test.tsx
+++ b/app/src/components/WebhookFlowForm.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WebhookFlowForm } from "./WebhookFlowForm";
+import { useFlowStore } from "../store/flowStore";
+import { useSchemaStore } from "../store/schemaStore";
+import { useConnectorCatalogStore } from "../store/connectorCatalogStore";
+import { useAvailableEntitiesStore } from "../store/availableEntitiesStore";
+
+vi.mock("idb-keyval", () => ({
+  get: vi.fn(async () => null),
+  set: vi.fn(async () => undefined),
+  del: vi.fn(async () => undefined),
+}));
+
+vi.mock("../contexts/workspace-context", () => ({
+  useWorkspace: () => ({
+    currentWorkspace: { id: "ws_1", role: "admin" },
+  }),
+}));
+
+const baseFlow = {
+  _id: "6a449f90718eeb15279df8a4",
+  workspaceId: "ws_1",
+  dataSourceId: { _id: "src_1", name: "Stripe", type: "stripe" },
+  destinationDatabaseId: { _id: "dest_1", name: "BigQuery", type: "bigquery" },
+  type: "webhook",
+  schedule: {},
+  webhookConfig: {
+    endpoint: "https://example.test/webhook",
+    secret: "redacted",
+    enabled: true,
+  },
+  syncMode: "incremental",
+  syncEngine: "cdc",
+  runCount: 0,
+  createdBy: "user_1",
+  createdAt: "2026-07-01T00:00:00.000Z",
+  updatedAt: "2026-07-01T00:00:00.000Z",
+  deleteMode: "soft",
+  entityLayouts: [
+    {
+      entity: "customers",
+      label: "Customers",
+      partitionField: "_syncedAt",
+      partitionGranularity: "day",
+      clusterFields: [],
+      enabled: true,
+    },
+  ],
+};
+
+interface UpdateFlowPayload {
+  tableDestination?: {
+    connectionId?: string;
+    schema?: string;
+    tableName?: string;
+  };
+}
+
+type UpdateFlowMock = ReturnType<
+  typeof vi.fn<
+    (
+      workspaceId: string,
+      flowId: string,
+      payload: UpdateFlowPayload,
+    ) => Promise<void>
+  >
+>;
+
+const setupStores = (updateFlow: UpdateFlowMock) => {
+  useFlowStore.setState({
+    flows: {
+      ws_1: [
+        {
+          ...baseFlow,
+          tableDestination: {
+            connectionId: "dest_1",
+            database: "my_dataset",
+            tableName: "stripe_",
+            createIfNotExists: true,
+          },
+        } as any,
+      ],
+    },
+    loading: {},
+    error: {},
+    fetchConnectors: vi.fn(async () => [
+      { _id: "src_1", name: "Stripe", type: "stripe" },
+    ]),
+    updateFlow,
+    setSyncEngine: vi.fn(async () => true),
+    fetchFlows: vi.fn(async () => []),
+    resyncCdcFlow: vi.fn(async () => true),
+    clearError: vi.fn(),
+  } as any);
+  useSchemaStore.setState({
+    connections: {
+      ws_1: [
+        {
+          id: "dest_1",
+          name: "BigQuery",
+          description: "",
+          database: "",
+          type: "bigquery",
+          active: true,
+          displayName: "BigQuery",
+          hostKey: "bigquery",
+          hostName: "bigquery",
+        },
+      ],
+    },
+    ensureConnections: vi.fn(async () => []),
+  } as any);
+  useConnectorCatalogStore.setState({
+    types: [
+      {
+        type: "stripe",
+        name: "Stripe",
+        version: "1",
+        description: "",
+        supportedEntities: ["customers"],
+        webhook: {
+          supported: true,
+          provisioning: {
+            supported: false,
+            providerLabel: "Stripe",
+            storesSecretAutomatically: false,
+          },
+        },
+      },
+    ],
+    fetchCatalog: vi.fn(async () => undefined),
+  } as any);
+  useAvailableEntitiesStore.setState({
+    byConnector: {
+      "ws_1:src_1": [
+        {
+          name: "customers",
+          label: "Customers",
+          layoutSuggestion: {
+            partitionField: "_syncedAt",
+            partitionGranularity: "day",
+            clusterFields: [],
+          },
+          fields: [{ name: "_syncedAt", type: "timestamp" }],
+        },
+      ],
+    },
+  } as any);
+};
+
+describe("WebhookFlowForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("hydrates BigQuery dataset from legacy database field and submits it as schema", async () => {
+    const updateFlow = vi.fn(
+      async (
+        _workspaceId: string,
+        _flowId: string,
+        _payload: UpdateFlowPayload,
+      ) => undefined,
+    );
+    setupStores(updateFlow);
+
+    render(<WebhookFlowForm flowId="6a449f90718eeb15279df8a4" />);
+
+    await screen.findByDisplayValue("my_dataset");
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => expect(updateFlow).toHaveBeenCalled());
+    expect(updateFlow.mock.calls[0]?.[2].tableDestination).toMatchObject({
+      connectionId: "dest_1",
+      schema: "my_dataset",
+      tableName: "stripe_",
+    });
+  });
+});

--- a/app/src/components/WebhookFlowForm.tsx
+++ b/app/src/components/WebhookFlowForm.tsx
@@ -54,7 +54,10 @@ interface WebhookFlowFormProps {
   flowId?: string;
   isNew?: boolean;
   onSave?: () => void;
-  onSaved?: (flowId: string) => void;
+  onSaved?: (
+    flowId: string,
+    options?: { showBackfillPanel?: boolean; notice?: string },
+  ) => void;
   onCancel?: () => void;
 }
 
@@ -598,8 +601,6 @@ export function WebhookFlowForm({
         // Refresh the flows list
         await useFlowStore.getState().fetchFlows(currentWorkspace.id);
 
-        onSaved?.(currentFlowId);
-
         if (!syncEngineOk) {
           setError(SYNC_ENGINE_PERMISSION_ERROR);
           return;
@@ -613,6 +614,18 @@ export function WebhookFlowForm({
             deleteDestination: true,
             entities: opts.resetEntities,
           });
+        }
+
+        const queuedRepartitionEntities = opts.resetEntities ?? [];
+        if (queuedRepartitionEntities.length > 0) {
+          onSaved?.(currentFlowId, {
+            showBackfillPanel: true,
+            notice: `Repartition job queued for ${queuedRepartitionEntities.join(
+              ", ",
+            )}. Watch the Stream column for progress.`,
+          });
+        } else {
+          onSaved?.(currentFlowId);
         }
 
         // Reset form to mark it as pristine

--- a/app/src/components/WebhookFlowForm.tsx
+++ b/app/src/components/WebhookFlowForm.tsx
@@ -406,7 +406,12 @@ export function WebhookFlowForm({
         if (flow.tableDestination) {
           formData.tableDestination = {
             tablePrefix: flow.tableDestination.tableName || "",
-            schema: flow.tableDestination.schema || "",
+            // Legacy/stale BigQuery CDC flows may have stored the dataset under
+            // `database`; the CDC writer and form validation use `schema`.
+            schema:
+              flow.tableDestination.schema ||
+              flow.tableDestination.database ||
+              "",
           };
         }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Redirect webhook layout rebuild saves back to the backfill panel after the repartition job is queued.
- Show a dismissible success alert that tells users to watch the Stream column for repartition progress.
- Hydrate legacy BigQuery dataset values from `tableDestination.database` into the form `schema` field so saves are not blocked by a false "Schema/dataset is required" error.

## Walkthrough
[repartition_save_redirect_feedback.mp4](https://cursor.com/agents/bc-537ffc47-d6be-4030-b5bc-7c404bf6a351/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frepartition_save_redirect_feedback.mp4)

## Testing
- `pnpm --filter app exec vitest run src/components/WebhookFlowForm.test.tsx`
- `pnpm --filter app run typecheck`
- `pnpm --filter app run lint`
- Manual browser walkthrough against local Mongo/Postgres/Vite/API fixture: changed `stripe_customers` granularity, confirmed rebuild, verified redirect to backfill/status panel, queued alert, and Stream repartition status.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-537ffc47-d6be-4030-b5bc-7c404bf6a351"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-537ffc47-d6be-4030-b5bc-7c404bf6a351"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

