### PR TITLE
feat(dbt): sortable + collapsible run nodes table, mobile-friendly run history

### DIFF
--- a/app/src/components/DbtJobView.tsx
+++ b/app/src/components/DbtJobView.tsx
@@ -32,6 +32,7 @@ import {
 import { CronExpressionParser } from "cron-parser";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useDbtStore, type DbtJobItem } from "../store/dbtStore";
+import { useIsMobile } from "../hooks/useIsMobile";
 import DbtRunHistory from "./DbtRunHistory";
 
 // Fast cadence while a run is active; slower idle cadence so scheduled runs
@@ -78,6 +79,7 @@ export default function DbtJobView({
 }) {
   const { currentWorkspace } = useWorkspace();
   const workspaceId = currentWorkspace?.id;
+  const isMobile = useIsMobile();
 
   const project = useDbtStore(s => s.projects.find(p => p._id === projectId));
   const jobs = useDbtStore(s => s.jobsByProject[projectId]);
@@ -301,11 +303,14 @@ export default function DbtJobView({
         backgroundColor: "background.paper",
       }}
     >
-      {/* Line 1 — identity + actions */}
+      {/* Line 1 — identity + actions. Wraps on mobile so the action buttons
+          stay reachable instead of overflowing a narrow viewport. */}
       <Box
         sx={{
           display: "flex",
           alignItems: "center",
+          flexWrap: isMobile ? "wrap" : "nowrap",
+          rowGap: 0.5,
           gap: 1,
           px: 1.5,
           pt: 0.75,

--- a/app/src/components/DbtRunCard.tsx
+++ b/app/src/components/DbtRunCard.tsx
@@ -135,7 +135,10 @@ export function DbtRunCard({ runId, projectId, label }: DbtRunCardProps) {
     [workspaceId, projectId, runId, cancelling, cancelRun, fetchRunDetails],
   );
 
-  const steps = run?.stepResults ?? [];
+  // Slowest nodes first — surfaces the bottlenecks at the top of the card.
+  const steps = [...(run?.stepResults ?? [])].sort(
+    (a, b) => b.executionTimeMs - a.executionTimeMs,
+  );
   const logs = run?.logs ?? [];
   const visibleLogs = logs.slice(-MAX_VISIBLE_LOGS);
   const hasBody = steps.length > 0 || logs.length > 0;

--- a/app/src/components/DbtRunHistory.tsx
+++ b/app/src/components/DbtRunHistory.tsx
@@ -29,14 +29,20 @@ import {
   Download as DownloadIcon,
   Search as SearchIcon,
   Square as StopIcon,
+  ChevronDown as ChevronDownIcon,
+  ChevronRight as ChevronRightIcon,
+  ArrowUp as ArrowUpIcon,
+  ArrowDown as ArrowDownIcon,
 } from "lucide-react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import {
   useDbtStore,
   type DbtRunItem,
   type DbtArtifactKind,
+  type DbtStepResult,
 } from "../store/dbtStore";
 import { focusDbtFileTab } from "../dbt-runtime/shell";
+import { useIsMobile } from "../hooks/useIsMobile";
 
 const ARTIFACT_LABELS: Record<DbtArtifactKind, string> = {
   manifest: "manifest.json",
@@ -108,6 +114,44 @@ function runSourceLabel(
   return commandSummary(run);
 }
 
+/** Sortable columns of the node-results table. */
+type NodeSortKey =
+  | "name"
+  | "resourceType"
+  | "status"
+  | "executionTimeMs"
+  | "rowsAffected";
+type SortDir = "asc" | "desc";
+
+const NODE_COLUMNS: { key: NodeSortKey; label: string }[] = [
+  { key: "name", label: "Node" },
+  { key: "resourceType", label: "Type" },
+  { key: "status", label: "Status" },
+  { key: "executionTimeMs", label: "Time" },
+  { key: "rowsAffected", label: "Rows" },
+];
+
+// Numeric columns default to descending (largest first); text columns ascending.
+const NUMERIC_SORT_KEYS = new Set<NodeSortKey>([
+  "executionTimeMs",
+  "rowsAffected",
+]);
+
+function compareSteps(
+  a: DbtStepResult,
+  b: DbtStepResult,
+  key: NodeSortKey,
+): number {
+  switch (key) {
+    case "executionTimeMs":
+      return a.executionTimeMs - b.executionTimeMs;
+    case "rowsAffected":
+      return (a.rowsAffected ?? -1) - (b.rowsAffected ?? -1);
+    default:
+      return String(a[key] ?? "").localeCompare(String(b[key] ?? ""));
+  }
+}
+
 export interface DbtRunHistoryProps {
   workspaceId: string | undefined;
   projectId: string;
@@ -138,10 +182,15 @@ export default function DbtRunHistory({
   const cancelRun = useDbtStore(s => s.cancelRun);
   const downloadRunArtifact = useDbtStore(s => s.downloadRunArtifact);
 
+  const isMobile = useIsMobile();
   const logScrollRef = useRef<HTMLDivElement | null>(null);
   const [statusFilter, setStatusFilter] = useState<string>("all");
   const [logQuery, setLogQuery] = useState("");
   const [cancelling, setCancelling] = useState(false);
+  // Nodes table: default sort by execution time, slowest first.
+  const [sortKey, setSortKey] = useState<NodeSortKey>("executionTimeMs");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+  const [nodesCollapsed, setNodesCollapsed] = useState(false);
 
   const selectedRun = selectedRunId ? runDetails[selectedRunId] : undefined;
   const selectedRunListItem = runs.find(run => run._id === selectedRunId);
@@ -150,12 +199,26 @@ export default function DbtRunHistory({
   const isActiveSelection =
     selectedStatus === "running" || selectedStatus === "queued";
 
-  // Reset filters + cancel state when switching runs.
+  // Reset filters, sort + cancel state when switching runs.
   useEffect(() => {
     setStatusFilter("all");
     setLogQuery("");
     setCancelling(false);
+    setSortKey("executionTimeMs");
+    setSortDir("desc");
+    setNodesCollapsed(false);
   }, [selectedRunId]);
+
+  const handleSort = useCallback((key: NodeSortKey) => {
+    setSortKey(prevKey => {
+      if (prevKey === key) {
+        setSortDir(prevDir => (prevDir === "asc" ? "desc" : "asc"));
+        return prevKey;
+      }
+      setSortDir(NUMERIC_SORT_KEYS.has(key) ? "desc" : "asc");
+      return key;
+    });
+  }, []);
 
   const stepResults = useMemo(
     () => selectedRun?.stepResults ?? [],
@@ -172,6 +235,15 @@ export default function DbtRunHistory({
         : stepResults.filter(s => s.status === statusFilter),
     [stepResults, statusFilter],
   );
+  const sortedSteps = useMemo(() => {
+    const dir = sortDir === "asc" ? 1 : -1;
+    return [...filteredSteps].sort((a, b) => {
+      const primary = compareSteps(a, b, sortKey);
+      // Stable tie-break by node name so equal values keep a deterministic order.
+      const cmp = primary !== 0 ? primary : a.name.localeCompare(b.name);
+      return cmp * dir;
+    });
+  }, [filteredSteps, sortKey, sortDir]);
   const visibleLogs = useMemo(() => {
     const logs = selectedRun?.logs ?? [];
     const query = logQuery.trim().toLowerCase();
@@ -274,14 +346,17 @@ export default function DbtRunHistory({
 
   return (
     <Box sx={{ height: "100%", minHeight: 0 }}>
-      <PanelGroup direction="horizontal">
+      {/* Desktop: side-by-side list + detail. Mobile: stacked vertically so the
+          run list and its details are both readable on a narrow screen. */}
+      <PanelGroup direction={isMobile ? "vertical" : "horizontal"}>
         {/* Run history list */}
-        <Panel defaultSize={showSource ? 32 : 25} minSize={15}>
+        <Panel defaultSize={isMobile ? 30 : showSource ? 32 : 25} minSize={15}>
           <Box
             sx={{
               height: "100%",
               overflow: "auto",
-              borderRight: "1px solid",
+              borderRight: isMobile ? "none" : "1px solid",
+              borderBottom: isMobile ? "1px solid" : "none",
               borderColor: "divider",
             }}
           >
@@ -421,10 +496,14 @@ export default function DbtRunHistory({
           </Box>
         </Panel>
         <PanelResizeHandle
-          style={{ width: 4, background: "var(--mui-palette-divider)" }}
+          style={
+            isMobile
+              ? { height: 4, background: "var(--mui-palette-divider)" }
+              : { width: 4, background: "var(--mui-palette-divider)" }
+          }
         />
         {/* Run details */}
-        <Panel defaultSize={showSource ? 68 : 75} minSize={30}>
+        <Panel defaultSize={isMobile ? 70 : showSource ? 68 : 75} minSize={30}>
           {!selectedRun && !selectedRunListItem ? (
             <Box sx={{ p: 2 }}>
               <Typography variant="caption" color="text.secondary">
@@ -616,11 +695,14 @@ export default function DbtRunHistory({
                 );
               })()}
 
-              {/* Node results table + status filter (screenshot 46). */}
+              {/* Node results table + status filter (screenshot 46). Sortable
+                  headers (default: slowest first) and a collapse toggle so the
+                  table can be tucked away to give the logs more room. */}
               {stepResults.length > 0 && (
                 <Box
                   sx={{
-                    maxHeight: "45%",
+                    maxHeight: nodesCollapsed ? "none" : "45%",
+                    flexShrink: 0,
                     display: "flex",
                     flexDirection: "column",
                     borderBottom: "1px solid",
@@ -636,6 +718,24 @@ export default function DbtRunHistory({
                       py: 0.5,
                     }}
                   >
+                    <Tooltip
+                      title={nodesCollapsed ? "Expand nodes" : "Collapse nodes"}
+                    >
+                      <IconButton
+                        size="small"
+                        onClick={() => setNodesCollapsed(prev => !prev)}
+                        aria-label={
+                          nodesCollapsed ? "Expand nodes" : "Collapse nodes"
+                        }
+                        aria-expanded={!nodesCollapsed}
+                      >
+                        {nodesCollapsed ? (
+                          <ChevronRightIcon size={14} />
+                        ) : (
+                          <ChevronDownIcon size={14} />
+                        )}
+                      </IconButton>
+                    </Tooltip>
                     <Select
                       size="small"
                       value={statusFilter}
@@ -661,82 +761,125 @@ export default function DbtRunHistory({
                       {filteredSteps.length === 1 ? "" : "s"}
                     </Typography>
                   </Box>
-                  <Box sx={{ flex: 1, minHeight: 0, overflow: "auto" }}>
-                    <Box
-                      component="table"
-                      sx={{
-                        width: "100%",
-                        fontSize: "0.75rem",
-                        borderCollapse: "collapse",
-                        "& td, & th": {
-                          borderBottom: "1px solid",
-                          borderColor: "divider",
-                          p: 0.5,
-                          textAlign: "left",
-                        },
-                      }}
-                    >
-                      <thead>
-                        <tr>
-                          <th>Node</th>
-                          <th>Type</th>
-                          <th>Status</th>
-                          <th>Time</th>
-                          <th>Rows</th>
-                          <th></th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {filteredSteps.map(step => (
-                          <Box
-                            component="tr"
-                            key={step.uniqueId}
-                            sx={{
-                              color:
-                                step.status === "error" ||
-                                step.status === "fail"
-                                  ? "error.main"
-                                  : step.status === "warn"
-                                    ? "warning.main"
-                                    : "inherit",
-                            }}
-                          >
-                            <td>{step.name}</td>
-                            <td>{step.resourceType}</td>
-                            <td>
-                              {step.status}
-                              {step.message &&
-                              (step.status === "error" ||
-                                step.status === "fail" ||
-                                step.status === "warn" ||
-                                step.resourceType === "source")
-                                ? ` — ${step.message}`
-                                : ""}
-                            </td>
-                            <td>{(step.executionTimeMs / 1000).toFixed(2)}s</td>
-                            <td>{step.rowsAffected ?? ""}</td>
-                            <td>
-                              {step.resourceType === "model" && (
-                                <Tooltip title="Open model">
-                                  <IconButton
-                                    size="small"
-                                    onClick={() =>
-                                      focusDbtFileTab(
-                                        projectId,
-                                        `models/${step.name}.sql`,
-                                      )
-                                    }
+                  {!nodesCollapsed && (
+                    <Box sx={{ flex: 1, minHeight: 0, overflow: "auto" }}>
+                      <Box
+                        component="table"
+                        sx={{
+                          width: "100%",
+                          fontSize: "0.75rem",
+                          borderCollapse: "collapse",
+                          "& td, & th": {
+                            borderBottom: "1px solid",
+                            borderColor: "divider",
+                            p: 0.5,
+                            textAlign: "left",
+                          },
+                        }}
+                      >
+                        <thead>
+                          <tr>
+                            {NODE_COLUMNS.map(col => {
+                              const active = sortKey === col.key;
+                              return (
+                                <Box
+                                  component="th"
+                                  key={col.key}
+                                  onClick={() => handleSort(col.key)}
+                                  role="button"
+                                  aria-sort={
+                                    active
+                                      ? sortDir === "asc"
+                                        ? "ascending"
+                                        : "descending"
+                                      : "none"
+                                  }
+                                  sx={{
+                                    cursor: "pointer",
+                                    userSelect: "none",
+                                    whiteSpace: "nowrap",
+                                    fontWeight: active ? 700 : 600,
+                                    color: active
+                                      ? "text.primary"
+                                      : "text.secondary",
+                                    "&:hover": { color: "text.primary" },
+                                  }}
+                                >
+                                  <Box
+                                    sx={{
+                                      display: "inline-flex",
+                                      alignItems: "center",
+                                      gap: 0.25,
+                                    }}
                                   >
-                                    <ModelIcon size={12} />
-                                  </IconButton>
-                                </Tooltip>
-                              )}
-                            </td>
-                          </Box>
-                        ))}
-                      </tbody>
+                                    {col.label}
+                                    {active &&
+                                      (sortDir === "asc" ? (
+                                        <ArrowUpIcon size={11} />
+                                      ) : (
+                                        <ArrowDownIcon size={11} />
+                                      ))}
+                                  </Box>
+                                </Box>
+                              );
+                            })}
+                            <th></th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {sortedSteps.map(step => (
+                            <Box
+                              component="tr"
+                              key={step.uniqueId}
+                              sx={{
+                                color:
+                                  step.status === "error" ||
+                                  step.status === "fail"
+                                    ? "error.main"
+                                    : step.status === "warn"
+                                      ? "warning.main"
+                                      : "inherit",
+                              }}
+                            >
+                              <td>{step.name}</td>
+                              <td>{step.resourceType}</td>
+                              <td>
+                                {step.status}
+                                {step.message &&
+                                (step.status === "error" ||
+                                  step.status === "fail" ||
+                                  step.status === "warn" ||
+                                  step.resourceType === "source")
+                                  ? ` — ${step.message}`
+                                  : ""}
+                              </td>
+                              <td>
+                                {(step.executionTimeMs / 1000).toFixed(2)}s
+                              </td>
+                              <td>{step.rowsAffected ?? ""}</td>
+                              <td>
+                                {step.resourceType === "model" && (
+                                  <Tooltip title="Open model">
+                                    <IconButton
+                                      size="small"
+                                      onClick={() =>
+                                        focusDbtFileTab(
+                                          projectId,
+                                          `models/${step.name}.sql`,
+                                        )
+                                      }
+                                    >
+                                      <ModelIcon size={12} />
+                                    </IconButton>
+                                  </Tooltip>
+                                )}
+                              </td>
+                            </Box>
+                          ))}
+                        </tbody>
+                      </Box>
                     </Box>
-                  </Box>
+                  )}
                 </Box>
               )}
 

--- a/app/src/components/DbtRunHistory.tsx
+++ b/app/src/components/DbtRunHistory.tsx
@@ -33,6 +33,7 @@ import {
   ChevronRight as ChevronRightIcon,
   ArrowUp as ArrowUpIcon,
   ArrowDown as ArrowDownIcon,
+  ArrowLeft as BackIcon,
 } from "lucide-react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import {
@@ -191,6 +192,12 @@ export default function DbtRunHistory({
   const [sortKey, setSortKey] = useState<NodeSortKey>("executionTimeMs");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
   const [nodesCollapsed, setNodesCollapsed] = useState(false);
+  // Mobile master/detail: land on the run list (full screen) and only show the
+  // detail once a run is tapped, with a "Runs" back button to return. Start on
+  // detail only when a run is already focused at mount (e.g. a chat deep-link).
+  const [mobileView, setMobileView] = useState<"list" | "detail">(
+    selectedRunId ? "detail" : "list",
+  );
 
   const selectedRun = selectedRunId ? runDetails[selectedRunId] : undefined;
   const selectedRunListItem = runs.find(run => run._id === selectedRunId);
@@ -344,619 +351,637 @@ export default function DbtRunHistory({
       ? "Cancelling…"
       : (selectedStatus ?? "queued");
 
-  return (
-    <Box sx={{ height: "100%", minHeight: 0 }}>
-      {/* Desktop: side-by-side list + detail. Mobile: stacked vertically so the
-          run list and its details are both readable on a narrow screen. */}
-      <PanelGroup direction={isMobile ? "vertical" : "horizontal"}>
-        {/* Run history list */}
-        <Panel defaultSize={isMobile ? 30 : showSource ? 32 : 25} minSize={15}>
-          <Box
-            sx={{
-              height: "100%",
-              overflow: "auto",
-              borderRight: isMobile ? "none" : "1px solid",
-              borderBottom: isMobile ? "1px solid" : "none",
-              borderColor: "divider",
-            }}
-          >
-            {runs.length === 0 ? (
-              <Box sx={{ p: 2 }}>
-                <Typography variant="caption" color="text.secondary">
-                  {emptyHint}
-                </Typography>
-              </Box>
-            ) : (
-              runs.map(run => {
-                const isSelected = run._id === selectedRunId;
-                const isActive =
-                  run.status === "running" || run.status === "queued";
-                const select = () => onSelectRun(run._id);
-                return (
-                  <Box
-                    key={run._id}
-                    role="button"
-                    tabIndex={0}
-                    onClick={select}
-                    onKeyDown={e => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault();
-                        select();
-                      }
-                    }}
-                    title={absoluteTime(run.createdAt)}
-                    sx={{
-                      px: 1.5,
-                      py: 0.75,
-                      cursor: "pointer",
-                      borderBottom: "1px solid",
-                      borderColor: "divider",
-                      backgroundColor: isSelected
-                        ? "action.selected"
-                        : "transparent",
-                      "&:hover": { backgroundColor: "action.hover" },
-                      "&:focus-visible": {
-                        outline: "2px solid",
-                        outlineColor: "primary.main",
-                        outlineOffset: "-2px",
-                      },
-                    }}
-                  >
-                    <Box
-                      sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 0.75,
-                      }}
-                    >
-                      <Box
-                        sx={{
-                          width: 8,
-                          height: 8,
-                          borderRadius: "50%",
-                          backgroundColor: statusColor(run.status),
-                          flexShrink: 0,
-                        }}
-                      />
-                      <Typography
-                        variant="caption"
-                        sx={{
-                          flex: 1,
-                          fontWeight: 600,
-                          color: statusColor(run.status),
-                          textTransform: "capitalize",
-                          display: "flex",
-                          alignItems: "center",
-                          gap: 0.5,
-                        }}
-                      >
-                        {run.status}
-                        {isActive && <CircularProgress size={9} />}
-                      </Typography>
-                      {run.durationMs !== undefined && (
-                        <Typography variant="caption" color="text.secondary">
-                          {formatDuration(run.durationMs)}
-                        </Typography>
-                      )}
-                    </Box>
-                    {showSource && (
-                      <Typography
-                        variant="caption"
-                        sx={{
-                          display: "block",
-                          mt: 0.25,
-                          fontFamily: "monospace",
-                          fontSize: "0.68rem",
-                          whiteSpace: "nowrap",
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          color: "text.primary",
-                        }}
-                        title={runSourceLabel(run, jobNameById)}
-                      >
-                        {runSourceLabel(run, jobNameById)}
-                      </Typography>
-                    )}
-                    <Box
-                      sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 0.5,
-                        mt: 0.25,
-                      }}
-                    >
-                      <Typography
-                        variant="caption"
-                        color="text.secondary"
-                        sx={{ flex: 1 }}
-                      >
-                        {relativeTime(run.createdAt)}
-                      </Typography>
-                      {run.ci ? (
-                        <Typography
-                          variant="caption"
-                          sx={{ fontSize: "0.65rem", color: "primary.main" }}
-                        >
-                          CI · PR #{run.ci.prNumber}
-                        </Typography>
-                      ) : (
-                        <Typography
-                          variant="caption"
-                          color="text.secondary"
-                          sx={{ fontSize: "0.65rem" }}
-                        >
-                          {run.trigger}
-                        </Typography>
-                      )}
-                    </Box>
-                  </Box>
-                );
-              })
-            )}
-          </Box>
-        </Panel>
-        <PanelResizeHandle
-          style={
-            isMobile
-              ? { height: 4, background: "var(--mui-palette-divider)" }
-              : { width: 4, background: "var(--mui-palette-divider)" }
-          }
-        />
-        {/* Run details */}
-        <Panel defaultSize={isMobile ? 70 : showSource ? 68 : 75} minSize={30}>
-          {!selectedRun && !selectedRunListItem ? (
-            <Box sx={{ p: 2 }}>
-              <Typography variant="caption" color="text.secondary">
-                Select a run to see details.
-              </Typography>
-            </Box>
-          ) : (
+  const listContent = (
+    <Box sx={{ height: "100%", overflow: "auto" }}>
+      {runs.length === 0 ? (
+        <Box sx={{ p: 2 }}>
+          <Typography variant="caption" color="text.secondary">
+            {emptyHint}
+          </Typography>
+        </Box>
+      ) : (
+        runs.map(run => {
+          const isSelected = run._id === selectedRunId;
+          const isActive = run.status === "running" || run.status === "queued";
+          const select = () => {
+            onSelectRun(run._id);
+            setMobileView("detail");
+          };
+          return (
             <Box
+              key={run._id}
+              role="button"
+              tabIndex={0}
+              onClick={select}
+              onKeyDown={e => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  select();
+                }
+              }}
+              title={absoluteTime(run.createdAt)}
               sx={{
-                height: "100%",
-                display: "flex",
-                flexDirection: "column",
+                px: 1.5,
+                py: 0.75,
+                cursor: "pointer",
+                borderBottom: "1px solid",
+                borderColor: "divider",
+                backgroundColor: isSelected ? "action.selected" : "transparent",
+                "&:hover": { backgroundColor: "action.hover" },
+                "&:focus-visible": {
+                  outline: "2px solid",
+                  outlineColor: "primary.main",
+                  outlineOffset: "-2px",
+                },
               }}
             >
-              {/* Summary strip */}
               <Box
                 sx={{
                   display: "flex",
-                  gap: 2,
                   alignItems: "center",
-                  px: 1.5,
-                  py: 0.75,
-                  borderBottom: "1px solid",
-                  borderColor: "divider",
-                  flexWrap: "wrap",
+                  gap: 0.75,
                 }}
               >
-                <Chip
-                  size="small"
-                  variant="outlined"
-                  icon={
-                    isActiveSelection ? (
-                      <CircularProgress size={10} />
-                    ) : undefined
-                  }
-                  label={cancelChipLabel}
+                <Box
                   sx={{
-                    height: 20,
-                    textTransform: "capitalize",
-                    fontWeight: 600,
-                    color: statusColor(
-                      (selectedStatus ?? "queued") as DbtRunItem["status"],
-                    ),
-                    borderColor: statusColor(
-                      (selectedStatus ?? "queued") as DbtRunItem["status"],
-                    ),
+                    width: 8,
+                    height: 8,
+                    borderRadius: "50%",
+                    backgroundColor: statusColor(run.status),
+                    flexShrink: 0,
                   }}
                 />
                 <Typography
                   variant="caption"
-                  color="text.secondary"
-                  title={absoluteTime(
-                    (selectedRun ?? selectedRunListItem)?.createdAt,
-                  )}
+                  sx={{
+                    flex: 1,
+                    fontWeight: 600,
+                    color: statusColor(run.status),
+                    textTransform: "capitalize",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 0.5,
+                  }}
                 >
-                  {relativeTime(
-                    (selectedRun ?? selectedRunListItem)?.createdAt,
-                  )}
+                  {run.status}
+                  {isActive && <CircularProgress size={9} />}
                 </Typography>
+                {run.durationMs !== undefined && (
+                  <Typography variant="caption" color="text.secondary">
+                    {formatDuration(run.durationMs)}
+                  </Typography>
+                )}
+              </Box>
+              {showSource && (
                 <Typography
                   variant="caption"
-                  color="text.secondary"
                   sx={{
+                    display: "block",
+                    mt: 0.25,
                     fontFamily: "monospace",
-                    maxWidth: 360,
+                    fontSize: "0.68rem",
                     whiteSpace: "nowrap",
                     overflow: "hidden",
                     textOverflow: "ellipsis",
+                    color: "text.primary",
                   }}
-                  title={(selectedRun ?? selectedRunListItem)?.commands
-                    .map(command => `dbt ${command}`)
-                    .join(" → ")}
+                  title={runSourceLabel(run, jobNameById)}
                 >
-                  {(selectedRun ?? selectedRunListItem)?.commands
-                    .map(command => `dbt ${command}`)
-                    .join(" → ")}
+                  {runSourceLabel(run, jobNameById)}
                 </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  {formatDuration(
-                    (selectedRun ?? selectedRunListItem)?.durationMs,
-                  )}
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  {(selectedRun ?? selectedRunListItem)?.trigger} ·{" "}
-                  {(selectedRun ?? selectedRunListItem)?.triggeredBy}
-                </Typography>
-                {selectedStatus === "cancelled" &&
-                  selectedDetail?.cancelledBy && (
-                    <Typography
-                      variant="caption"
-                      sx={{ color: "warning.main" }}
-                      title={absoluteTime(selectedDetail.cancelledAt)}
-                    >
-                      cancelled by {selectedDetail.cancelledBy}
-                      {selectedDetail.cancelledAt
-                        ? ` · ${relativeTime(selectedDetail.cancelledAt)}`
-                        : ""}
-                    </Typography>
-                  )}
-                {(selectedRun ?? selectedRunListItem)?.error && (
-                  <Typography variant="caption" color="error">
-                    {(selectedRun ?? selectedRunListItem)?.error}
-                  </Typography>
-                )}
-                {isActiveSelection && (
-                  <Tooltip title="Stop this run (terminates the dbt process)">
-                    <span style={{ marginLeft: "auto" }}>
-                      <Button
-                        size="small"
-                        color="warning"
-                        variant="outlined"
-                        startIcon={<StopIcon size={14} />}
-                        onClick={handleCancel}
-                        disabled={cancelling}
-                      >
-                        {cancelling ? "Cancelling…" : "Cancel"}
-                      </Button>
-                    </span>
-                  </Tooltip>
-                )}
-                {selectedStatus === "error" && (
-                  <Tooltip title="Re-run only the failed/skipped nodes">
-                    <Button
-                      size="small"
-                      variant="outlined"
-                      startIcon={<RetryIcon size={14} />}
-                      onClick={handleRetry}
-                      sx={{ ml: "auto" }}
-                    >
-                      Retry from failure
-                    </Button>
-                  </Tooltip>
-                )}
-              </Box>
-
-              {/* Artifacts (manifest/run_results/catalog/sources). Screenshot 45. */}
-              {(() => {
-                const available = ARTIFACT_ORDER.filter(
-                  kind => selectedRun?.artifactKeys?.[kind],
-                );
-                if (available.length === 0) return null;
-                return (
-                  <Box
-                    sx={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 0.75,
-                      px: 1.5,
-                      py: 0.5,
-                      borderBottom: "1px solid",
-                      borderColor: "divider",
-                      flexWrap: "wrap",
-                    }}
-                  >
-                    <Typography
-                      variant="caption"
-                      color="text.secondary"
-                      sx={{ fontWeight: 600 }}
-                    >
-                      Artifacts
-                    </Typography>
-                    {available.map(kind => (
-                      <Button
-                        key={kind}
-                        size="small"
-                        variant="outlined"
-                        startIcon={<DownloadIcon size={12} />}
-                        onClick={() => {
-                          if (workspaceId && selectedRunId) {
-                            void downloadRunArtifact(
-                              workspaceId,
-                              projectId,
-                              selectedRunId,
-                              kind,
-                            );
-                          }
-                        }}
-                        sx={{
-                          py: 0,
-                          minHeight: 22,
-                          fontSize: "0.68rem",
-                          textTransform: "none",
-                        }}
-                      >
-                        {ARTIFACT_LABELS[kind]}
-                      </Button>
-                    ))}
-                  </Box>
-                );
-              })()}
-
-              {/* Node results table + status filter (screenshot 46). Sortable
-                  headers (default: slowest first) and a collapse toggle so the
-                  table can be tucked away to give the logs more room. */}
-              {stepResults.length > 0 && (
-                <Box
-                  sx={{
-                    maxHeight: nodesCollapsed ? "none" : "45%",
-                    flexShrink: 0,
-                    display: "flex",
-                    flexDirection: "column",
-                    borderBottom: "1px solid",
-                    borderColor: "divider",
-                  }}
-                >
-                  <Box
-                    sx={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 1,
-                      px: 1.5,
-                      py: 0.5,
-                    }}
-                  >
-                    <Tooltip
-                      title={nodesCollapsed ? "Expand nodes" : "Collapse nodes"}
-                    >
-                      <IconButton
-                        size="small"
-                        onClick={() => setNodesCollapsed(prev => !prev)}
-                        aria-label={
-                          nodesCollapsed ? "Expand nodes" : "Collapse nodes"
-                        }
-                        aria-expanded={!nodesCollapsed}
-                      >
-                        {nodesCollapsed ? (
-                          <ChevronRightIcon size={14} />
-                        ) : (
-                          <ChevronDownIcon size={14} />
-                        )}
-                      </IconButton>
-                    </Tooltip>
-                    <Select
-                      size="small"
-                      value={statusFilter}
-                      onChange={e => setStatusFilter(e.target.value)}
-                      sx={{ fontSize: "0.72rem", minHeight: 28 }}
-                    >
-                      <MenuItem value="all">
-                        All ({stepResults.length})
-                      </MenuItem>
-                      {stepStatuses.map(status => (
-                        <MenuItem
-                          key={status}
-                          value={status}
-                          sx={{ textTransform: "capitalize" }}
-                        >
-                          {status} (
-                          {stepResults.filter(s => s.status === status).length})
-                        </MenuItem>
-                      ))}
-                    </Select>
-                    <Typography variant="caption" color="text.secondary">
-                      {filteredSteps.length} node
-                      {filteredSteps.length === 1 ? "" : "s"}
-                    </Typography>
-                  </Box>
-                  {!nodesCollapsed && (
-                    <Box sx={{ flex: 1, minHeight: 0, overflow: "auto" }}>
-                      <Box
-                        component="table"
-                        sx={{
-                          width: "100%",
-                          fontSize: "0.75rem",
-                          borderCollapse: "collapse",
-                          "& td, & th": {
-                            borderBottom: "1px solid",
-                            borderColor: "divider",
-                            p: 0.5,
-                            textAlign: "left",
-                          },
-                        }}
-                      >
-                        <thead>
-                          <tr>
-                            {NODE_COLUMNS.map(col => {
-                              const active = sortKey === col.key;
-                              return (
-                                <Box
-                                  component="th"
-                                  key={col.key}
-                                  onClick={() => handleSort(col.key)}
-                                  role="button"
-                                  aria-sort={
-                                    active
-                                      ? sortDir === "asc"
-                                        ? "ascending"
-                                        : "descending"
-                                      : "none"
-                                  }
-                                  sx={{
-                                    cursor: "pointer",
-                                    userSelect: "none",
-                                    whiteSpace: "nowrap",
-                                    fontWeight: active ? 700 : 600,
-                                    color: active
-                                      ? "text.primary"
-                                      : "text.secondary",
-                                    "&:hover": { color: "text.primary" },
-                                  }}
-                                >
-                                  <Box
-                                    sx={{
-                                      display: "inline-flex",
-                                      alignItems: "center",
-                                      gap: 0.25,
-                                    }}
-                                  >
-                                    {col.label}
-                                    {active &&
-                                      (sortDir === "asc" ? (
-                                        <ArrowUpIcon size={11} />
-                                      ) : (
-                                        <ArrowDownIcon size={11} />
-                                      ))}
-                                  </Box>
-                                </Box>
-                              );
-                            })}
-                            <th></th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          {sortedSteps.map(step => (
-                            <Box
-                              component="tr"
-                              key={step.uniqueId}
-                              sx={{
-                                color:
-                                  step.status === "error" ||
-                                  step.status === "fail"
-                                    ? "error.main"
-                                    : step.status === "warn"
-                                      ? "warning.main"
-                                      : "inherit",
-                              }}
-                            >
-                              <td>{step.name}</td>
-                              <td>{step.resourceType}</td>
-                              <td>
-                                {step.status}
-                                {step.message &&
-                                (step.status === "error" ||
-                                  step.status === "fail" ||
-                                  step.status === "warn" ||
-                                  step.resourceType === "source")
-                                  ? ` — ${step.message}`
-                                  : ""}
-                              </td>
-                              <td>
-                                {(step.executionTimeMs / 1000).toFixed(2)}s
-                              </td>
-                              <td>{step.rowsAffected ?? ""}</td>
-                              <td>
-                                {step.resourceType === "model" && (
-                                  <Tooltip title="Open model">
-                                    <IconButton
-                                      size="small"
-                                      onClick={() =>
-                                        focusDbtFileTab(
-                                          projectId,
-                                          `models/${step.name}.sql`,
-                                        )
-                                      }
-                                    >
-                                      <ModelIcon size={12} />
-                                    </IconButton>
-                                  </Tooltip>
-                                )}
-                              </td>
-                            </Box>
-                          ))}
-                        </tbody>
-                      </Box>
-                    </Box>
-                  )}
-                </Box>
-              )}
-
-              {/* Logs + search */}
-              {(selectedRun?.logs ?? []).length > 0 && (
-                <Box
-                  sx={{
-                    px: 1.5,
-                    py: 0.5,
-                    borderBottom: "1px solid",
-                    borderColor: "divider",
-                  }}
-                >
-                  <TextField
-                    size="small"
-                    fullWidth
-                    placeholder="Search logs…"
-                    value={logQuery}
-                    onChange={e => setLogQuery(e.target.value)}
-                    InputProps={{
-                      startAdornment: (
-                        <InputAdornment position="start">
-                          <SearchIcon size={14} />
-                        </InputAdornment>
-                      ),
-                    }}
-                    sx={{ "& .MuiInputBase-input": { fontSize: "0.72rem" } }}
-                  />
-                </Box>
               )}
               <Box
-                ref={logScrollRef}
                 sx={{
-                  flex: 1,
-                  minHeight: 0,
-                  overflow: "auto",
-                  fontFamily: "monospace",
-                  fontSize: "0.72rem",
-                  p: 1,
-                  whiteSpace: "pre-wrap",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 0.5,
+                  mt: 0.25,
                 }}
               >
-                {(selectedRun?.logs ?? []).length === 0 ? (
-                  <Typography variant="caption" color="text.secondary">
-                    {selectedStatus === "queued" ? "Run queued…" : "No logs."}
-                  </Typography>
-                ) : visibleLogs.length === 0 ? (
-                  <Typography variant="caption" color="text.secondary">
-                    No log lines match “{logQuery}”.
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ flex: 1 }}
+                >
+                  {relativeTime(run.createdAt)}
+                </Typography>
+                {run.ci ? (
+                  <Typography
+                    variant="caption"
+                    sx={{ fontSize: "0.65rem", color: "primary.main" }}
+                  >
+                    CI · PR #{run.ci.prNumber}
                   </Typography>
                 ) : (
-                  visibleLogs.map((log, index) => (
-                    <Box
-                      key={index}
-                      component="div"
-                      sx={{
-                        color:
-                          log.level === "error"
-                            ? "error.main"
-                            : log.level === "warn"
-                              ? "warning.main"
-                              : "text.primary",
-                      }}
-                    >
-                      <Box
-                        component="span"
-                        sx={{ color: "text.secondary", mr: 1 }}
-                      >
-                        {new Date(log.ts).toLocaleTimeString()}
-                      </Box>
-                      {log.line}
-                    </Box>
-                  ))
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ fontSize: "0.65rem" }}
+                  >
+                    {run.trigger}
+                  </Typography>
                 )}
               </Box>
             </Box>
+          );
+        })
+      )}
+    </Box>
+  );
+
+  const detailContent =
+    !selectedRun && !selectedRunListItem ? (
+      <Box sx={{ p: 2 }}>
+        <Typography variant="caption" color="text.secondary">
+          Select a run to see details.
+        </Typography>
+      </Box>
+    ) : (
+      <Box
+        sx={{
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        {/* Mobile: return to the (full-screen) run list. */}
+        {isMobile && (
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              px: 0.5,
+              py: 0.25,
+              borderBottom: "1px solid",
+              borderColor: "divider",
+            }}
+          >
+            <Button
+              size="small"
+              startIcon={<BackIcon size={16} />}
+              onClick={() => setMobileView("list")}
+            >
+              Runs
+            </Button>
+          </Box>
+        )}
+        {/* Summary strip */}
+        <Box
+          sx={{
+            display: "flex",
+            gap: 2,
+            alignItems: "center",
+            px: 1.5,
+            py: 0.75,
+            borderBottom: "1px solid",
+            borderColor: "divider",
+            flexWrap: "wrap",
+          }}
+        >
+          <Chip
+            size="small"
+            variant="outlined"
+            icon={
+              isActiveSelection ? <CircularProgress size={10} /> : undefined
+            }
+            label={cancelChipLabel}
+            sx={{
+              height: 20,
+              textTransform: "capitalize",
+              fontWeight: 600,
+              color: statusColor(
+                (selectedStatus ?? "queued") as DbtRunItem["status"],
+              ),
+              borderColor: statusColor(
+                (selectedStatus ?? "queued") as DbtRunItem["status"],
+              ),
+            }}
+          />
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            title={absoluteTime(
+              (selectedRun ?? selectedRunListItem)?.createdAt,
+            )}
+          >
+            {relativeTime((selectedRun ?? selectedRunListItem)?.createdAt)}
+          </Typography>
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{
+              fontFamily: "monospace",
+              maxWidth: 360,
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+            title={(selectedRun ?? selectedRunListItem)?.commands
+              .map(command => `dbt ${command}`)
+              .join(" → ")}
+          >
+            {(selectedRun ?? selectedRunListItem)?.commands
+              .map(command => `dbt ${command}`)
+              .join(" → ")}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            {formatDuration((selectedRun ?? selectedRunListItem)?.durationMs)}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            {(selectedRun ?? selectedRunListItem)?.trigger} ·{" "}
+            {(selectedRun ?? selectedRunListItem)?.triggeredBy}
+          </Typography>
+          {selectedStatus === "cancelled" && selectedDetail?.cancelledBy && (
+            <Typography
+              variant="caption"
+              sx={{ color: "warning.main" }}
+              title={absoluteTime(selectedDetail.cancelledAt)}
+            >
+              cancelled by {selectedDetail.cancelledBy}
+              {selectedDetail.cancelledAt
+                ? ` · ${relativeTime(selectedDetail.cancelledAt)}`
+                : ""}
+            </Typography>
           )}
+          {(selectedRun ?? selectedRunListItem)?.error && (
+            <Typography variant="caption" color="error">
+              {(selectedRun ?? selectedRunListItem)?.error}
+            </Typography>
+          )}
+          {isActiveSelection && (
+            <Tooltip title="Stop this run (terminates the dbt process)">
+              <span style={{ marginLeft: "auto" }}>
+                <Button
+                  size="small"
+                  color="warning"
+                  variant="outlined"
+                  startIcon={<StopIcon size={14} />}
+                  onClick={handleCancel}
+                  disabled={cancelling}
+                >
+                  {cancelling ? "Cancelling…" : "Cancel"}
+                </Button>
+              </span>
+            </Tooltip>
+          )}
+          {selectedStatus === "error" && (
+            <Tooltip title="Re-run only the failed/skipped nodes">
+              <Button
+                size="small"
+                variant="outlined"
+                startIcon={<RetryIcon size={14} />}
+                onClick={handleRetry}
+                sx={{ ml: "auto" }}
+              >
+                Retry from failure
+              </Button>
+            </Tooltip>
+          )}
+        </Box>
+
+        {/* Artifacts (manifest/run_results/catalog/sources). Screenshot 45. */}
+        {(() => {
+          const available = ARTIFACT_ORDER.filter(
+            kind => selectedRun?.artifactKeys?.[kind],
+          );
+          if (available.length === 0) return null;
+          return (
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 0.75,
+                px: 1.5,
+                py: 0.5,
+                borderBottom: "1px solid",
+                borderColor: "divider",
+                flexWrap: "wrap",
+              }}
+            >
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ fontWeight: 600 }}
+              >
+                Artifacts
+              </Typography>
+              {available.map(kind => (
+                <Button
+                  key={kind}
+                  size="small"
+                  variant="outlined"
+                  startIcon={<DownloadIcon size={12} />}
+                  onClick={() => {
+                    if (workspaceId && selectedRunId) {
+                      void downloadRunArtifact(
+                        workspaceId,
+                        projectId,
+                        selectedRunId,
+                        kind,
+                      );
+                    }
+                  }}
+                  sx={{
+                    py: 0,
+                    minHeight: 22,
+                    fontSize: "0.68rem",
+                    textTransform: "none",
+                  }}
+                >
+                  {ARTIFACT_LABELS[kind]}
+                </Button>
+              ))}
+            </Box>
+          );
+        })()}
+
+        {/* Node results table + status filter (screenshot 46). Sortable
+                  headers (default: slowest first) and a collapse toggle so the
+                  table can be tucked away to give the logs more room. */}
+        {stepResults.length > 0 && (
+          <Box
+            sx={{
+              maxHeight: nodesCollapsed ? "none" : "45%",
+              flexShrink: 0,
+              display: "flex",
+              flexDirection: "column",
+              borderBottom: "1px solid",
+              borderColor: "divider",
+            }}
+          >
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1,
+                px: 1.5,
+                py: 0.5,
+              }}
+            >
+              <Tooltip
+                title={nodesCollapsed ? "Expand nodes" : "Collapse nodes"}
+              >
+                <IconButton
+                  size="small"
+                  onClick={() => setNodesCollapsed(prev => !prev)}
+                  aria-label={
+                    nodesCollapsed ? "Expand nodes" : "Collapse nodes"
+                  }
+                  aria-expanded={!nodesCollapsed}
+                >
+                  {nodesCollapsed ? (
+                    <ChevronRightIcon size={14} />
+                  ) : (
+                    <ChevronDownIcon size={14} />
+                  )}
+                </IconButton>
+              </Tooltip>
+              <Select
+                size="small"
+                value={statusFilter}
+                onChange={e => setStatusFilter(e.target.value)}
+                sx={{ fontSize: "0.72rem", minHeight: 28 }}
+              >
+                <MenuItem value="all">All ({stepResults.length})</MenuItem>
+                {stepStatuses.map(status => (
+                  <MenuItem
+                    key={status}
+                    value={status}
+                    sx={{ textTransform: "capitalize" }}
+                  >
+                    {status} (
+                    {stepResults.filter(s => s.status === status).length})
+                  </MenuItem>
+                ))}
+              </Select>
+              <Typography variant="caption" color="text.secondary">
+                {filteredSteps.length} node
+                {filteredSteps.length === 1 ? "" : "s"}
+              </Typography>
+            </Box>
+            {!nodesCollapsed && (
+              <Box sx={{ flex: 1, minHeight: 0, overflow: "auto" }}>
+                <Box
+                  component="table"
+                  sx={{
+                    width: "100%",
+                    fontSize: "0.75rem",
+                    borderCollapse: "collapse",
+                    "& td, & th": {
+                      borderBottom: "1px solid",
+                      borderColor: "divider",
+                      p: 0.5,
+                      textAlign: "left",
+                    },
+                  }}
+                >
+                  <thead>
+                    <tr>
+                      {NODE_COLUMNS.map(col => {
+                        const active = sortKey === col.key;
+                        return (
+                          <Box
+                            component="th"
+                            key={col.key}
+                            onClick={() => handleSort(col.key)}
+                            role="button"
+                            aria-sort={
+                              active
+                                ? sortDir === "asc"
+                                  ? "ascending"
+                                  : "descending"
+                                : "none"
+                            }
+                            sx={{
+                              cursor: "pointer",
+                              userSelect: "none",
+                              whiteSpace: "nowrap",
+                              fontWeight: active ? 700 : 600,
+                              color: active ? "text.primary" : "text.secondary",
+                              "&:hover": { color: "text.primary" },
+                            }}
+                          >
+                            <Box
+                              sx={{
+                                display: "inline-flex",
+                                alignItems: "center",
+                                gap: 0.25,
+                              }}
+                            >
+                              {col.label}
+                              {active &&
+                                (sortDir === "asc" ? (
+                                  <ArrowUpIcon size={11} />
+                                ) : (
+                                  <ArrowDownIcon size={11} />
+                                ))}
+                            </Box>
+                          </Box>
+                        );
+                      })}
+                      <th></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {sortedSteps.map(step => (
+                      <Box
+                        component="tr"
+                        key={step.uniqueId}
+                        sx={{
+                          color:
+                            step.status === "error" || step.status === "fail"
+                              ? "error.main"
+                              : step.status === "warn"
+                                ? "warning.main"
+                                : "inherit",
+                        }}
+                      >
+                        <td>{step.name}</td>
+                        <td>{step.resourceType}</td>
+                        <td>
+                          {step.status}
+                          {step.message &&
+                          (step.status === "error" ||
+                            step.status === "fail" ||
+                            step.status === "warn" ||
+                            step.resourceType === "source")
+                            ? ` — ${step.message}`
+                            : ""}
+                        </td>
+                        <td>{(step.executionTimeMs / 1000).toFixed(2)}s</td>
+                        <td>{step.rowsAffected ?? ""}</td>
+                        <td>
+                          {step.resourceType === "model" && (
+                            <Tooltip title="Open model">
+                              <IconButton
+                                size="small"
+                                onClick={() =>
+                                  focusDbtFileTab(
+                                    projectId,
+                                    `models/${step.name}.sql`,
+                                  )
+                                }
+                              >
+                                <ModelIcon size={12} />
+                              </IconButton>
+                            </Tooltip>
+                          )}
+                        </td>
+                      </Box>
+                    ))}
+                  </tbody>
+                </Box>
+              </Box>
+            )}
+          </Box>
+        )}
+
+        {/* Logs + search */}
+        {(selectedRun?.logs ?? []).length > 0 && (
+          <Box
+            sx={{
+              px: 1.5,
+              py: 0.5,
+              borderBottom: "1px solid",
+              borderColor: "divider",
+            }}
+          >
+            <TextField
+              size="small"
+              fullWidth
+              placeholder="Search logs…"
+              value={logQuery}
+              onChange={e => setLogQuery(e.target.value)}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon size={14} />
+                  </InputAdornment>
+                ),
+              }}
+              sx={{ "& .MuiInputBase-input": { fontSize: "0.72rem" } }}
+            />
+          </Box>
+        )}
+        <Box
+          ref={logScrollRef}
+          sx={{
+            flex: 1,
+            minHeight: 0,
+            overflow: "auto",
+            fontFamily: "monospace",
+            fontSize: "0.72rem",
+            p: 1,
+            whiteSpace: "pre-wrap",
+          }}
+        >
+          {(selectedRun?.logs ?? []).length === 0 ? (
+            <Typography variant="caption" color="text.secondary">
+              {selectedStatus === "queued" ? "Run queued…" : "No logs."}
+            </Typography>
+          ) : visibleLogs.length === 0 ? (
+            <Typography variant="caption" color="text.secondary">
+              No log lines match “{logQuery}”.
+            </Typography>
+          ) : (
+            visibleLogs.map((log, index) => (
+              <Box
+                key={index}
+                component="div"
+                sx={{
+                  color:
+                    log.level === "error"
+                      ? "error.main"
+                      : log.level === "warn"
+                        ? "warning.main"
+                        : "text.primary",
+                }}
+              >
+                <Box component="span" sx={{ color: "text.secondary", mr: 1 }}>
+                  {new Date(log.ts).toLocaleTimeString()}
+                </Box>
+                {log.line}
+              </Box>
+            ))
+          )}
+        </Box>
+      </Box>
+    );
+
+  // Mobile: full-screen master/detail so neither pane is squeezed into a
+  // sliver. Land on the run list; tapping a run opens the detail (which has a
+  // "Runs" back button). Desktop keeps the side-by-side resizable split.
+  if (isMobile) {
+    return (
+      <Box sx={{ height: "100%", minHeight: 0 }}>
+        {mobileView === "detail" && (selectedRun || selectedRunListItem)
+          ? detailContent
+          : listContent}
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ height: "100%", minHeight: 0 }}>
+      <PanelGroup direction="horizontal">
+        {/* Run history list */}
+        <Panel defaultSize={showSource ? 32 : 25} minSize={15}>
+          <Box
+            sx={{
+              height: "100%",
+              borderRight: "1px solid",
+              borderColor: "divider",
+            }}
+          >
+            {listContent}
+          </Box>
+        </Panel>
+        <PanelResizeHandle
+          style={{ width: 4, background: "var(--mui-palette-divider)" }}
+        />
+        {/* Run details */}
+        <Panel defaultSize={showSource ? 68 : 75} minSize={30}>
+          {detailContent}
         </Panel>
       </PanelGroup>
     </Box>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

The dbt job run **nodes table** (`DbtRunHistory`, used by the Job view and the project-wide Runs view) had a fixed row order, no way to hide it, and a layout that was unusable on a phone. This PR addresses all three, and reworks the mobile run-history into a proper master/detail flow with clear back navigation.

### Changes
- **Sortable nodes table** — column headers (`Node`, `Type`, `Status`, `Time`, `Rows`) are clickable and toggle sort direction, with an arrow on the active column. Defaults to **Time descending** so the slowest nodes surface first. Numeric columns default to descending, text to ascending; ties break by node name.
- **Collapse toggle** — a chevron next to the status filter collapses/expands the nodes table so the logs pane can take the full height.
- **Mobile master/detail** — below the `md` breakpoint the run history is now a **full-screen master/detail**: you land on the full-screen run list, tap a run to open its detail full-screen, and use a new **"← Runs"** back button to return. This replaces the earlier cramped side-by-side/stacked split and answers "how do I get back to the run list?". Desktop keeps the side-by-side resizable split unchanged.
- **`DbtJobView`** header action row wraps on mobile so `Run now` / `Edit` / refresh stay reachable.
- **`DbtRunCard` (chat)** — its inline nodes table now default-sorts by time descending for parity.

## Walkthrough

### Desktop — sortable + collapsible nodes table
[dbt_nodes_table_sort_and_collapse.mp4](https://cursor.com/agents/bc-e34ad56c-8660-4f8e-93f6-df89ae7911a8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdbt_nodes_table_sort_and_collapse.mp4)

[Nodes table default-sorted by Time descending](https://cursor.com/agents/bc-e34ad56c-8660-4f8e-93f6-df89ae7911a8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdbt_nodes_table_desktop_sorted.webp)

### Mobile — full-screen master/detail with back navigation
[dbt_mobile_master_detail_back_nav-2.mp4](https://cursor.com/agents/bc-e34ad56c-8660-4f8e-93f6-df89ae7911a8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdbt_mobile_master_detail_back_nav-2.mp4)

[Full-screen run list on mobile](https://cursor.com/agents/bc-e34ad56c-8660-4f8e-93f6-df89ae7911a8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdbt_mobile_run_list_fullscreen.webp)
[Full-screen run detail with Runs back button](https://cursor.com/agents/bc-e34ad56c-8660-4f8e-93f6-df89ae7911a8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdbt_mobile_run_detail_back_button.webp)

## Testing
- `pnpm --filter app run typecheck` — pass
- `pnpm --filter app run lint` — pass
- Manual (seeded a dbt project/job/run with varied node times): verified column sorting (Time asc/desc, Node, Status), collapse/expand, mobile list→detail→back navigation, and desktop side-by-side layout unchanged.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e34ad56c-8660-4f8e-93f6-df89ae7911a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e34ad56c-8660-4f8e-93f6-df89ae7911a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

