### PR TITLE
guides: Ruby connection guides — postgresql/mysql/sqlite/mongodb (Batch 14)

### DIFF
--- a/content/guides/mongodb/connect-from-ruby.mdx
+++ b/content/guides/mongodb/connect-from-ruby.mdx
@@ -1,0 +1,182 @@
+---
+title: "How to Connect to MongoDB from Ruby"
+description: "Connect to MongoDB from Ruby with the official mongo driver or Mongoid. Working code for connections, one-client reuse, CRUD, the replaceOne data-loss trap, SRV URIs, authSource, and connection pooling."
+database: "mongodb"
+category: "how-to"
+tags: ["mongodb", "ruby", "rails", "mongo", "mongoid", "connection"]
+date: "2026-07-02"
+---
+
+MongoDB is not a SQL database and there is no ADO.NET-style layer here: Ruby talks to it through one official driver, the `mongo` gem, a pure-Ruby client. Mongoid, the popular ODM (object-document mapper) used in Rails, sits on top of that same driver. This guide shows the raw `mongo` interface first, then where Mongoid fits, and covers the things that actually cause MongoDB-from-Ruby incidents: client reuse, lazy connections, the whole-document replace trap, SRV URIs, `authSource`, and pool sizing.
+
+## The options
+
+| Library | Layer | When to use it | Version (as of July 2026) |
+|---|---|---|---|
+| `mongo` | Official driver (pure Ruby) | Scripts, services, or when you want direct collection access | 2.24.1 |
+| Mongoid | ODM built on the driver | Rails apps, or when you want models, validations, and associations | 9.1.0 |
+
+Mongoid depends on the `mongo` gem, so the driver-level concerns below apply whether you write against the driver directly or through Mongoid.
+
+## Installing the driver
+
+```bash
+gem install mongo
+```
+
+The `mongo` gem is pure Ruby with no C extension, so there are no system headers to install and no compile step. For DNS `SRV` connection strings (the `mongodb+srv://` form Atlas hands you), you also need a DNS resolver gem; add `resolv` if your environment does not already provide it.
+
+## A minimal connection
+
+```ruby
+require 'mongo'
+
+client = Mongo::Client.new(
+  ['localhost:27017'],
+  database: 'shop'
+)
+
+puts client.database.command(ping: 1).documents.first
+
+client.close
+```
+
+`Mongo::Client.new` takes either an array of host strings plus options (above) or a single connection URI:
+
+```ruby
+client = Mongo::Client.new('mongodb://app:secret@localhost:27017/shop')
+```
+
+## Reuse one client -- do not create per request
+
+A `Mongo::Client` owns a connection pool and background monitoring threads. Create it **once** at process startup and reuse it for the life of the app. Building a new client per web request exhausts connections and adds handshake latency on every call. In Rails this is what the Mongoid initializer or a global constant is for; in a plain service, store it in a constant or a container.
+
+Close it on shutdown:
+
+```ruby
+CLIENT = Mongo::Client.new(ENV['MONGODB_URI'])
+at_exit { CLIENT.close }
+```
+
+## Connections are lazy
+
+`Mongo::Client.new` does **not** connect. It returns immediately and the first real network contact happens on your first operation. That means a wrong host or bad credentials surfaces as a `Mongo::Error::NoServerAvailable` on your first query, not at client creation. To fail fast at startup, ping explicitly:
+
+```ruby
+client.database.command(ping: 1)
+```
+
+## CRUD basics
+
+Collections come off the client and documents are plain Ruby hashes:
+
+```ruby
+customers = client[:customers]
+
+# insert
+customers.insert_one(name: 'Acme', region: 'EMEA', active: true)
+
+# find
+customers.find(region: 'EMEA').each do |doc|
+  puts doc['name']
+end
+
+# update a subset of fields
+customers.update_one({ name: 'Acme' }, { '$set' => { active: false } })
+
+# delete
+customers.delete_one(name: 'Acme')
+```
+
+Query filters are hashes; there is no SQL string and therefore no SQL-injection surface in the usual sense. Do still be careful passing raw user input as operators (for example letting a user supply a `$where`), which is the MongoDB equivalent risk.
+
+## The replace-vs-update data-loss trap
+
+`replace_one` swaps the **entire** document for the one you pass. If you meant to change one field and used `replace_one` with just that field, every other field is gone:
+
+```ruby
+# WRONG -- this wipes every field except status
+customers.replace_one({ name: 'Acme' }, { status: 'inactive' })
+
+# RIGHT -- change only the field you name
+customers.update_one({ name: 'Acme' }, { '$set' => { status: 'inactive' } })
+```
+
+Reach for `update_one`/`update_many` with `$set` (and the other update operators) for partial changes. Use `replace_one` only when you genuinely want to overwrite the whole document.
+
+## Connecting to Atlas: SRV URIs and gotchas
+
+Atlas gives you a `mongodb+srv://` connection string:
+
+```ruby
+client = Mongo::Client.new(
+  'mongodb+srv://app:secret@cluster0.abcde.mongodb.net/shop?retryWrites=true&w=majority'
+)
+```
+
+Three things trip people up:
+
+- **`mongodb+srv://` implies TLS.** The SRV scheme turns on TLS by default and resolves the seed list from DNS, so you do not list hosts yourself.
+- **Percent-encode credentials.** A password containing `@`, `/`, `:`, or `#` must be URL-encoded in the URI, or parsing breaks in confusing ways.
+- **`authSource`.** By default the driver authenticates against the database in the URI path. If your user was created in `admin` (the common case), you need `authSource=admin`, or authentication fails even with correct credentials.
+
+For Atlas specifically, the client's public IP must be on the project's **IP access list**, or the connection times out with no clear auth error.
+
+## Connection pooling
+
+Each client keeps a pool per server it knows about. The size is controlled by `max_pool_size` (default 20):
+
+```ruby
+client = Mongo::Client.new(
+  ENV['MONGODB_URI'],
+  max_pool_size: 20,
+  min_pool_size: 5
+)
+```
+
+The number that matters is **max_pool_size × number of app processes × number of instances** against the server's connection limit. A handful of Puma workers each with a 20-connection pool adds up quickly on a small cluster. Size the pool to your real concurrency, not to a big round number.
+
+## Mongoid
+
+Mongoid configures the same driver through `config/mongoid.yml`:
+
+```yaml
+production:
+  clients:
+    default:
+      uri: <%= ENV['MONGODB_URI'] %>
+      options:
+        max_pool_size: 20
+```
+
+Models then map to collections:
+
+```ruby
+class Customer
+  include Mongoid::Document
+  field :name, type: String
+  field :region, type: String
+  field :active, type: Boolean
+end
+
+Customer.where(region: 'EMEA').to_a
+```
+
+Mongoid gives you validations, associations, and query composition; underneath, every call goes through the `mongo` driver, so the pooling and `authSource` notes above still apply.
+
+## Common errors
+
+| Error | Cause |
+|---|---|
+| `Mongo::Error::NoServerAvailable` | Wrong host/port, server down, or Atlas IP not allow-listed (surfaces on first op, not on client create) |
+| `Mongo::Auth::Unauthorized` | Wrong credentials, or missing `authSource=admin` for an admin-created user |
+| Connection to `localhost` refused | Client resolving to IPv6 `::1` while `mongod` listens on IPv4; use `127.0.0.1` |
+| URI parse errors | Special characters in the password not percent-encoded |
+| Every field but one disappeared after an update | `replace_one` used where `update_one` + `$set` was meant |
+| Connections exhausted under load | A new client per request instead of one reused client; or pool size × processes over the server cap |
+
+## Querying without writing connection code
+
+If your goal is to explore a MongoDB database rather than build a service, a GUI client skips all of the above. Mako connects to MongoDB with AI-assisted queries -- see our [MongoDB GUI client guide](/guides/mongodb-gui-client) for how it compares to Compass and Studio 3T. Connecting from another language? See [How to Connect to MongoDB from Python](/guides/mongodb/connect-from-python) and [from Node.js](/guides/mongodb/connect-from-node).
+
+Mako connects to MongoDB with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/mysql/connect-from-ruby.mdx
+++ b/content/guides/mysql/connect-from-ruby.mdx
@@ -1,0 +1,182 @@
+---
+title: "How to Connect to MySQL from Ruby"
+description: "Connect to MySQL from Ruby with mysql2 or trilogy, plus Sequel and ActiveRecord. Working code for connections, pooling, parameterized queries, the utf8mb4 trap, and the caching_sha2_password authentication problem on MySQL 8."
+database: "mysql"
+category: "how-to"
+tags: ["mysql", "ruby", "rails", "mysql2", "trilogy", "sequel", "activerecord", "connection"]
+date: "2026-07-01"
+---
+
+Ruby has two serious MySQL drivers today. `mysql2` is the long-standing default, a C binding to libmysqlclient. `trilogy` is a newer client, written from scratch with no libmysqlclient dependency, open-sourced by GitHub and now natively supported by Rails. This guide shows both, explains when each makes sense, and covers the two configuration issues that cause the most MySQL-from-Ruby incidents: the `utf8mb4` charset trap and `caching_sha2_password` authentication on MySQL 8.
+
+## The options
+
+| Library | Native dependency | Notes | Version (as of July 2026) |
+|---|---|---|---|
+| `mysql2` | libmysqlclient / libmariadb | Mature, widely deployed default | 0.5.7 |
+| `trilogy` | None (pure protocol implementation) | No client-lib to install; Rails-native adapter | 2.12.6 |
+| Sequel | via mysql2 or trilogy | Toolkit/ORM, not a driver itself | 5.105.0 |
+| ActiveRecord | via mysql2 or trilogy | Full ORM (Rails) | ships with Rails |
+
+The practical decision:
+
+- **`mysql2`** if you want the established, battle-tested option and don't mind installing MySQL client libraries at build time.
+- **`trilogy`** if you want to avoid the libmysqlclient build dependency entirely (a common source of CI and Docker friction) or you're on a recent Rails and want the natively supported adapter.
+
+Sequel and ActiveRecord are layers on top; they use one of these two drivers underneath.
+
+## Installing mysql2
+
+The gem compiles against a MySQL client library, so install the headers first:
+
+- **Debian/Ubuntu:** `sudo apt-get install libmysqlclient-dev` (or `libmariadb-dev`)
+- **macOS (Homebrew):** `brew install mysql-client` then `gem install mysql2 -- --with-mysql-dir=$(brew --prefix mysql-client)`
+- **RHEL/Fedora:** `sudo dnf install mysql-devel`
+
+```bash
+gem install mysql2
+```
+
+If the build cannot find `mysql.h` or `libmysqlclient`, the dev package is missing or the `--with-mysql-dir` path is wrong. This is the most common mysql2 install failure and the exact friction trilogy avoids.
+
+## A minimal connection with mysql2
+
+```ruby
+require 'mysql2'
+
+client = Mysql2::Client.new(
+  host:     'localhost',
+  port:     3306,
+  username: 'app',
+  password: ENV['DB_PASSWORD'],
+  database: 'shop',
+  encoding: 'utf8mb4'
+)
+
+client.query('SELECT VERSION()').each do |row|
+  puts row['VERSION()']
+end
+
+client.close
+```
+
+`Mysql2::Result` yields each row as a hash keyed by column name, and mysql2 casts to native Ruby types (Integer, Float, Time) by default.
+
+## The utf8mb4 charset trap
+
+Set `encoding: 'utf8mb4'`. MySQL's historic `utf8` is a **3-byte** encoding that cannot store 4-byte characters like emoji or many CJK characters, and inserting them raises `Incorrect string value`. The name is a long-standing MySQL misnomer; `utf8mb4` is real, full UTF-8. Match this to your table and column charset (`CHARACTER SET utf8mb4`), or you get silent truncation or errors that only appear once a user pastes an emoji.
+
+## Parameterized queries
+
+mysql2 supports prepared statements with positional `?` placeholders (MySQL's placeholder syntax, unlike PostgreSQL's `$1`):
+
+```ruby
+stmt = client.prepare('SELECT id, name FROM customers WHERE region = ? AND active = ?')
+result = stmt.execute('EMEA', 1)
+result.each { |row| puts row['name'] }
+```
+
+Do not build SQL by interpolating user input. If you must use `client.query` with dynamic values, escape them with `client.escape`, but prepared statements are the safer default.
+
+## trilogy
+
+trilogy speaks the MySQL protocol directly, so there is no client library to install:
+
+```bash
+gem install trilogy
+```
+
+```ruby
+require 'trilogy'
+
+client = Trilogy.new(
+  host:     'localhost',
+  port:     3306,
+  username: 'app',
+  password: ENV['DB_PASSWORD'],
+  database: 'shop',
+  ssl_mode: Trilogy::SSL_PREFERRED
+)
+
+result = client.query('SELECT id, name FROM customers WHERE region = "EMEA"')
+result.each { |row| puts row[1] }
+
+client.close
+```
+
+trilogy returns rows as arrays by default (index by column position) and exposes `result.fields` for the column names. Its main appeal is operational: no libmysqlclient, which removes a whole class of build and deployment problems.
+
+## The caching_sha2_password problem on MySQL 8
+
+MySQL 8.0 changed the default authentication plugin from `mysql_native_password` to `caching_sha2_password`. This plugin transmits credentials in a way that requires either a secure connection (TLS) or an RSA key exchange. The practical consequences:
+
+- **mysql2:** works with `caching_sha2_password` as long as your libmysqlclient/libmariadb is recent enough. An old client library produces `Authentication plugin 'caching_sha2_password' cannot be loaded`.
+- **trilogy:** supports `caching_sha2_password`, but you must set `ssl_mode` (for example `Trilogy::SSL_PREFERRED` or stricter) so the secure-transport requirement is met. Connecting without TLS to a `caching_sha2_password` account fails.
+
+If you hit an auth-plugin error, the fix is one of: upgrade the client library, connect over TLS, or (last resort, and weaker) alter the account to `mysql_native_password`. Note that MySQL 9 removed `mysql_native_password` entirely, so the long-term answer is TLS plus a current client, not downgrading the auth method.
+
+## Connection pooling
+
+A single client object is not safe to share across threads. In threaded servers (Puma, Sidekiq) you need one connection per thread. mysql2 and trilogy do not ship pools, so use the `connection_pool` gem, or let Sequel/ActiveRecord manage it:
+
+```ruby
+require 'mysql2'
+require 'connection_pool'
+
+DB = ConnectionPool.new(size: 5, timeout: 5) do
+  Mysql2::Client.new(host: 'localhost', username: 'app',
+                     password: ENV['DB_PASSWORD'], database: 'shop',
+                     encoding: 'utf8mb4')
+end
+
+DB.with { |c| c.query('SELECT count(*) FROM orders').first }
+```
+
+Size the pool so that **pool size × process count stays under the server's `max_connections`** (default 151). Exceeding it produces `Too many connections`.
+
+## Sequel and ActiveRecord
+
+Sequel picks the driver from the URL scheme:
+
+```ruby
+require 'sequel'
+
+# mysql2 driver
+DB = Sequel.connect('mysql2://app:secret@localhost/shop?encoding=utf8mb4', max_connections: 5)
+# or trilogy
+# DB = Sequel.connect('trilogy://app:secret@localhost/shop')
+
+DB[:customers].where(region: 'EMEA').each { |row| puts row[:name] }
+```
+
+In Rails, `config/database.yml` selects the adapter:
+
+```yaml
+production:
+  adapter: mysql2        # or: trilogy
+  host: <%= ENV['DB_HOST'] %>
+  database: shop
+  username: app
+  password: <%= ENV['DB_PASSWORD'] %>
+  encoding: utf8mb4
+  pool: 5
+```
+
+The `pool` value is per process; the same `pool × processes < max_connections` rule applies.
+
+## Common errors
+
+| Error | Cause |
+|---|---|
+| Cannot find `mysql.h` / `libmysqlclient` at install | MySQL client dev package missing (mysql2 only; trilogy avoids this) |
+| `Can't connect to MySQL server` | Wrong host/port, or server not listening on TCP |
+| `Access denied for user` | Wrong credentials, or host-pattern account mismatch |
+| `Authentication plugin 'caching_sha2_password' cannot be loaded` | Old client lib, or non-TLS connection to a MySQL 8 default account |
+| `Incorrect string value` | 4-byte character into a `utf8` (3-byte) column; use `utf8mb4` end to end |
+| `Too many connections` | Pool size × process count exceeds `max_connections` |
+
+## Querying without writing connection code
+
+If your goal is to explore a MySQL database rather than build a service, a GUI client skips all of the above. Mako connects to MySQL with AI-assisted SQL -- see our [MySQL GUI client guide](/guides/mysql-gui-client) for how it compares to MySQL Workbench, DBeaver, and TablePlus. Connecting from another language? See [How to Connect to MySQL from Python](/guides/mysql/connect-from-python) and [from Node.js](/guides/mysql/connect-from-node).
+
+Mako connects to MySQL with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/postgresql/connect-from-ruby.mdx
+++ b/content/guides/postgresql/connect-from-ruby.mdx
@@ -1,0 +1,198 @@
+---
+title: "How to Connect to PostgreSQL from Ruby"
+description: "Connect to PostgreSQL from Ruby with the pg gem, Sequel, or ActiveRecord. Working code for connections, connection pools, parameterized queries, prepared statements, and the sslmode and PostgreSQL 18 cancel-key traps."
+database: "postgresql"
+category: "how-to"
+tags: ["postgresql", "ruby", "rails", "pg", "sequel", "activerecord", "connection"]
+date: "2026-07-01"
+---
+
+Ruby has one low-level PostgreSQL driver that everything else builds on: the `pg` gem. ActiveRecord (Rails), Sequel, and most query builders use it underneath. This guide shows the raw `pg` interface first, then where Sequel and ActiveRecord fit, and covers the configuration that actually causes production incidents: pooling, parameterized queries, TLS, and a version trap specific to PostgreSQL 18.
+
+## The options
+
+| Library | Layer | When to use it | Version (as of July 2026) |
+|---|---|---|---|
+| `pg` | Raw driver (libpq wrapper) | Scripts, services, or when you want SQL and nothing else | 1.6.3 |
+| Sequel | Database toolkit + ORM | Non-Rails apps wanting a dataset API without full ActiveRecord | 5.105.0 |
+| ActiveRecord | Full ORM | Rails apps, or when you want migrations and models | ships with Rails |
+
+`pg` is the interface to libpq, PostgreSQL's official C client library. It works with PostgreSQL 10 and later. Sequel and ActiveRecord both depend on `pg` for PostgreSQL connectivity, so the driver-level concerns below apply no matter which layer you write against.
+
+## Installing the driver
+
+```bash
+gem install pg
+```
+
+The gem compiles a native extension against libpq, so you need the PostgreSQL client development headers first:
+
+- **Debian/Ubuntu:** `sudo apt-get install libpq-dev`
+- **macOS (Homebrew):** `brew install libpq` (you may need `gem install pg -- --with-pg-config=$(brew --prefix libpq)/bin/pg_config`)
+- **RHEL/Fedora:** `sudo dnf install libpq-devel`
+
+If the build fails with `Can't find the 'libpq-fe.h' header`, the dev package is missing or `pg_config` isn't on your `PATH`. That is the single most common install failure.
+
+## A minimal connection
+
+```ruby
+require 'pg'
+
+conn = PG.connect(
+  host:     'localhost',
+  port:     5432,
+  dbname:   'shop',
+  user:     'app',
+  password: ENV['PGPASSWORD']
+)
+
+result = conn.exec('SELECT version()')
+puts result.getvalue(0, 0)
+
+conn.close
+```
+
+`PG.connect` accepts either a keyword hash (above) or a libpq connection string / URI:
+
+```ruby
+conn = PG.connect('postgres://app:secret@localhost:5432/shop')
+```
+
+The gem also reads standard libpq environment variables (`PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`, `PGSSLMODE`). Anything you omit from the hash falls back to those, which is a clean way to keep credentials out of source.
+
+## Parameterized queries -- do not interpolate
+
+Never build SQL with string interpolation. Pass parameters separately and let the server bind them:
+
+```ruby
+conn.exec_params(
+  'SELECT id, name FROM customers WHERE region = $1 AND active = $2',
+  ['EMEA', true]
+)
+```
+
+PostgreSQL uses positional `$1, $2, ...` placeholders, not `?`. Parameters are passed as an array; `exec_params` sends them out-of-band, which closes off SQL injection and handles quoting and type conversion for you.
+
+For a statement you run repeatedly, prepare it once:
+
+```ruby
+conn.prepare('find_customer', 'SELECT id, name FROM customers WHERE region = $1')
+conn.exec_prepared('find_customer', ['EMEA'])
+```
+
+## Reading results
+
+`PG::Result` is enumerable and yields each row as a hash keyed by column name:
+
+```ruby
+conn.exec_params('SELECT id, name FROM customers WHERE region = $1', ['EMEA']).each do |row|
+  puts "#{row['id']}: #{row['name']}"
+end
+```
+
+One thing to know: by default `pg` returns every column value as a **string**. An `integer` column comes back as `"42"`. To get native Ruby types (Integer, Float, Time, boolean, arrays), enable type mapping:
+
+```ruby
+conn.type_map_for_results = PG::BasicTypeMapForResults.new(conn)
+```
+
+Sequel and ActiveRecord do this for you. If you are using raw `pg` and wondering why numeric comparisons behave oddly, this is almost always the reason.
+
+## Connection pooling
+
+A `PG::Connection` is **not** safe to share across threads. In any concurrent app (Puma, Sidekiq, a threaded script) you need one connection per thread, which means a pool. The `pg` gem does not ship a pool, so use the `connection_pool` gem:
+
+```ruby
+require 'pg'
+require 'connection_pool'
+
+DB = ConnectionPool.new(size: 5, timeout: 5) do
+  PG.connect(ENV['DATABASE_URL'])
+end
+
+DB.with do |conn|
+  conn.exec_params('SELECT count(*) FROM orders WHERE status = $1', ['open'])
+end
+```
+
+Size the pool deliberately. **Pool size × number of processes must stay under the server's `max_connections`** (default 100). Four Puma workers with a pool of 5 each is 20 connections from one machine; multiply across machines and you can exhaust the server, which surfaces as `FATAL: sorry, too many clients already`. If you have many processes, put PgBouncer in front and point the pool at it. In PgBouncer transaction-pooling mode, disable server-side prepared statements or you will hit `prepared statement "..." does not exist`.
+
+Sequel and ActiveRecord manage their own pools; you configure the size rather than wiring `connection_pool` yourself.
+
+## Sequel
+
+Sequel gives you a dataset API and connection pool without adopting Rails:
+
+```ruby
+require 'sequel'
+
+DB = Sequel.connect('postgres://app:secret@localhost:5432/shop', max_connections: 5)
+
+DB[:customers].where(region: 'EMEA').each do |row|
+  puts row[:name]
+end
+
+# Raw SQL with placeholders when you need it
+DB.fetch('SELECT count(*) FROM orders WHERE status = ?', 'open').first
+```
+
+Sequel returns native Ruby types and symbol-keyed rows out of the box, and handles pooling through `max_connections`.
+
+## ActiveRecord / Rails
+
+In a Rails app you rarely call `pg` directly. Configure `config/database.yml`:
+
+```yaml
+production:
+  adapter: postgresql
+  host: <%= ENV['DB_HOST'] %>
+  database: shop
+  username: app
+  password: <%= ENV['DB_PASSWORD'] %>
+  pool: 5
+  sslmode: require
+```
+
+The `pool` value is per process. The same `pool × processes < max_connections` rule applies. Rails uses the `pg` gem underneath, so a build failure on `bundle install` is the same libpq-dev problem described above.
+
+## TLS / sslmode
+
+For any connection crossing a network, set `sslmode`. The values, weakest to strongest:
+
+| `sslmode` | Encrypted? | Server cert verified? |
+|---|---|---|
+| `disable` | No | No |
+| `require` | Yes | No |
+| `verify-ca` | Yes | Yes (chain only) |
+| `verify-full` | Yes | Yes (chain + hostname) |
+
+`require` encrypts traffic but does not stop a man-in-the-middle presenting any certificate. For production against a managed provider, use `verify-full` and point `sslrootcert` at the provider's CA:
+
+```ruby
+conn = PG.connect(
+  'postgres://app:secret@db.example.com:5432/shop' \
+  '?sslmode=verify-full&sslrootcert=/etc/ssl/certs/provider-ca.pem'
+)
+```
+
+## The PostgreSQL 18 cancel-key trap
+
+PostgreSQL 18 introduced longer cancel keys. Older versions of the `pg` gem assumed a fixed-size key and break when connecting to PG 18, sometimes only when a query cancellation is attempted. The fix landed in **pg 1.6.0**. If you are targeting PostgreSQL 18, make sure your `Gemfile.lock` pins `pg` at 1.6.0 or newer -- an old `pg` against a new server is a subtle failure that passes basic connectivity tests and fails under load.
+
+## Common errors
+
+| Error | Cause |
+|---|---|
+| `Can't find the 'libpq-fe.h' header` | `libpq-dev` / `libpq-devel` missing at gem-install time |
+| `could not connect to server: Connection refused` | Wrong host/port, or PostgreSQL not listening on TCP (`listen_addresses`) |
+| `password authentication failed for user` | Wrong credentials, or `pg_hba.conf` auth method mismatch |
+| `FATAL: sorry, too many clients already` | Pool size × process count exceeds `max_connections` |
+| `SSL error` / `certificate verify failed` | `verify-full` without a correct `sslrootcert` |
+| `prepared statement "..." does not exist` | PgBouncer transaction pooling with server-side prepares still on |
+| Numeric column behaves like a string | Result type mapping not enabled on raw `pg` |
+
+## Querying without writing connection code
+
+If your goal is to explore a PostgreSQL database rather than build a service, a GUI client skips all of the above. Mako connects to PostgreSQL with AI-assisted SQL -- see our [PostgreSQL GUI client guide](/guides/postgresql-gui-client) for how it compares to pgAdmin, DBeaver, and TablePlus. Connecting from another language? See [How to Connect to PostgreSQL from Python](/guides/postgresql/connect-from-python) and [from Node.js](/guides/postgresql/connect-from-node).
+
+Mako connects to PostgreSQL with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/sqlite/connect-from-ruby.mdx
+++ b/content/guides/sqlite/connect-from-ruby.mdx
@@ -1,0 +1,201 @@
+---
+title: "How to Connect to SQLite from Ruby"
+description: "Connect to SQLite from Ruby with the sqlite3 gem, Sequel, or ActiveRecord. Working code for connections, parameterized queries, WAL mode, the busy_timeout lock fix, and the accidental-file-creation trap."
+database: "sqlite"
+category: "how-to"
+tags: ["sqlite", "ruby", "rails", "sqlite3", "sequel", "activerecord", "connection"]
+date: "2026-07-02"
+---
+
+SQLite is a library, not a server. There is no host, port, or password: you open a file (or an in-memory database) and talk to it in-process. In Ruby that file is handled by one gem, `sqlite3`, which everything else builds on. This guide shows the raw `sqlite3` interface first, then where Sequel and ActiveRecord fit, and covers the configuration that actually matters for a single-file embedded database: transactions, WAL mode, the `database is locked` problem, and a file-handling trap that silently hides bugs.
+
+## The options
+
+| Library | Layer | When to use it | Version (as of July 2026) |
+|---|---|---|---|
+| `sqlite3` | Raw driver (bindings to the SQLite C library) | Scripts, services, or when you want SQL and nothing else | 2.9.5 |
+| Sequel | Database toolkit + ORM | Non-Rails apps wanting a dataset API without full ActiveRecord | 5.105.0 |
+| ActiveRecord | Full ORM | Rails apps, or when you want migrations and models | ships with Rails |
+
+The `sqlite3` gem is the interface to the SQLite C library. Sequel and ActiveRecord both depend on it for SQLite connectivity, so the driver-level concerns below apply no matter which layer you write against.
+
+## Installing the driver
+
+```bash
+gem install sqlite3
+```
+
+Since version 2.0, the gem ships **precompiled native binaries with the SQLite library bundled** for common platforms (Linux, macOS, Windows on supported Ruby versions). For those platforms you do not need system SQLite headers, and you get a known, recent SQLite version regardless of what the OS provides.
+
+If your platform has no precompiled binary, the gem falls back to compiling against a bundled SQLite source, or you can force it to build against the system library:
+
+```bash
+gem install sqlite3 --platform=ruby -- --enable-system-libraries
+```
+
+That path needs the SQLite development headers (`libsqlite3-dev` on Debian/Ubuntu, `sqlite-devel` on RHEL/Fedora). Most people never touch this: the precompiled gem is the default and the simplest choice.
+
+## A minimal connection
+
+```ruby
+require 'sqlite3'
+
+db = SQLite3::Database.new('shop.db')
+
+db.execute('SELECT sqlite_version()') do |row|
+  puts row.first
+end
+
+db.close
+```
+
+`SQLite3::Database.new` opens `shop.db` relative to the working directory. Use an absolute path in anything long-lived so the location does not depend on where the process was started. For a throwaway database that lives only in RAM:
+
+```ruby
+db = SQLite3::Database.new(':memory:')
+```
+
+An in-memory database exists only for the life of that one connection. Open a second connection to `:memory:` and you get a *different*, empty database, not a shared one.
+
+## The accidental-file-creation trap
+
+By default, opening a database that does not exist **creates an empty one**. Mistype the path and you get a brand-new empty database instead of an error, then spend an afternoon wondering why every query returns nothing.
+
+To fail loudly when the file is missing, open read-only or read-write without create:
+
+```ruby
+db = SQLite3::Database.new('shop.db', readonly: true)
+```
+
+For read-write-but-must-exist, use a URI filename with the `mode` parameter:
+
+```ruby
+db = SQLite3::Database.new('file:shop.db?mode=rw')
+```
+
+`mode=rw` opens for read and write but does **not** create the file, so a wrong path raises `SQLite3::CantOpenException` instead of silently making a new database.
+
+## Parameterized queries -- do not interpolate
+
+Never build SQL with string interpolation. Pass parameters separately and let SQLite bind them:
+
+```ruby
+db.execute(
+  'SELECT id, name FROM customers WHERE region = ? AND active = ?',
+  ['EMEA', 1]
+)
+```
+
+SQLite uses `?` positional placeholders. It also supports named placeholders, which are clearer in longer statements:
+
+```ruby
+db.execute(
+  'SELECT id, name FROM customers WHERE region = :region',
+  region: 'EMEA'
+)
+```
+
+For a statement you run repeatedly, prepare it once and reuse the handle:
+
+```ruby
+stmt = db.prepare('SELECT id, name FROM customers WHERE region = ?')
+stmt.execute('EMEA').each { |row| p row }
+stmt.close
+```
+
+One SQLite-specific note on types: SQLite stores booleans as integers (`0`/`1`), so bind `1` and `0` rather than `true`/`false` and expect integers back.
+
+## Reading results as hashes
+
+By default `execute` yields each row as an array. To get rows keyed by column name, set `results_as_hash`:
+
+```ruby
+db.results_as_hash = true
+db.execute('SELECT id, name FROM customers').each do |row|
+  puts "#{row['id']}: #{row['name']}"
+end
+```
+
+Sequel and ActiveRecord return hash-like or model objects by default; this setting only matters for the raw gem.
+
+## Connection-scoped PRAGMAs: WAL and busy_timeout
+
+Two PRAGMAs solve the most common SQLite-from-Ruby problems, and both are set per connection right after opening:
+
+```ruby
+db = SQLite3::Database.new('shop.db')
+db.execute('PRAGMA journal_mode = WAL')
+db.busy_timeout = 5000   # milliseconds
+db.execute('PRAGMA foreign_keys = ON')
+```
+
+- **`journal_mode = WAL`** (write-ahead logging) lets one writer and multiple readers work at the same time instead of readers and writers blocking each other. This is the single biggest concurrency improvement for a web app. WAL is a persistent property of the database file, but it is worth setting on connect so a fresh file gets it too.
+- **`foreign_keys = ON`** must be set on every connection: SQLite ships with foreign-key enforcement *off* by default for backward compatibility.
+
+## The "database is locked" problem
+
+`SQLite3::BusyException: database is locked` is the error people hit most. SQLite allows only one writer at a time; when two connections try to write at once, one gets rejected immediately unless you tell it to wait.
+
+The fix is `busy_timeout`, which makes a blocked connection retry for up to N milliseconds before giving up:
+
+```ruby
+db.busy_timeout = 5000
+```
+
+Combined with WAL mode, a 5-second busy timeout eliminates the large majority of lock errors in typical web workloads. If you still see them under heavy write concurrency, the honest answer is that SQLite's single-writer model has a ceiling: at that point you either serialize writes through one connection or move to a client/server database.
+
+## Transactions are a performance feature
+
+Every `INSERT` outside an explicit transaction is its own transaction, each with a disk sync. Wrapping a bulk load in one transaction can turn thousands of tiny commits into a single one and speed up inserts by orders of magnitude:
+
+```ruby
+db.transaction do
+  1000.times do |i|
+    db.execute('INSERT INTO events (name) VALUES (?)', ["event_#{i}"])
+  end
+end
+```
+
+If the block raises, the gem rolls the transaction back automatically.
+
+## No connection pooling -- it is in-process
+
+Because SQLite is a library and not a server, there is no network pool to size. Each `SQLite3::Database` object is one handle to the file. The `sqlite3` gem's own objects are not thread-safe to share across threads, so the usual pattern is one connection per thread, and WAL mode plus `busy_timeout` to coordinate writers. In Rails, ActiveRecord's connection pool handles this for you; with the raw gem in a threaded server, open a connection per thread rather than sharing one.
+
+## Sequel and ActiveRecord
+
+Sequel connects with a `sqlite://` URL and applies sensible defaults:
+
+```ruby
+require 'sequel'
+DB = Sequel.sqlite('shop.db')
+DB[:customers].where(region: 'EMEA').all
+```
+
+ActiveRecord (Rails) uses the `sqlite3` adapter in `database.yml`:
+
+```yaml
+production:
+  adapter: sqlite3
+  database: storage/production.sqlite3
+  timeout: 5000
+```
+
+Recent Rails versions ship a production-tuned SQLite setup (WAL, a busy timeout, and other PRAGMAs) out of the box, reflecting that SQLite is now a supported choice for small-to-medium production apps, not just development.
+
+## Common errors
+
+| Error | Cause |
+|---|---|
+| `SQLite3::CantOpenException` | Wrong path, no write permission on the directory, or `mode=rw` on a missing file |
+| Queries return nothing on a "working" DB | Typo in the path created a new empty database (the file-creation trap) |
+| `SQLite3::BusyException: database is locked` | Concurrent writers without `busy_timeout`; set it and enable WAL |
+| `SQLite3::SQLException: no such table` | Connected to the wrong file, or the schema was never created |
+| `cannot load such file -- sqlite3` | Gem not installed in the active Ruby / bundle |
+| Foreign keys not enforced | `PRAGMA foreign_keys = ON` not set on this connection |
+
+## Querying without writing connection code
+
+If your goal is to explore a SQLite database rather than build a service, a GUI client skips all of the above. Mako opens SQLite files with AI-assisted SQL -- see our [SQLite GUI client guide](/guides/sqlite-gui-client) for how it compares to DB Browser for SQLite and DBeaver. Connecting from another language? See [How to Connect to SQLite from Python](/guides/sqlite/connect-from-python) and [from Node.js](/guides/sqlite/connect-from-node).
+
+Mako connects to SQLite with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).


### PR DESCRIPTION
Batch 14 — Ruby connection guides. 4 of 9 DBs:
- postgresql (pg/Sequel/ActiveRecord, PG18 cancel-key trap)
- mysql (mysql2/trilogy, utf8mb4 + caching_sha2_password)
- sqlite (sqlite3/Sequel/ActiveRecord, WAL + busy_timeout + file-creation trap)
- mongodb (mongo driver/Mongoid, replace-vs-update trap, SRV/authSource)

Content-only. Versions verified live via RubyGems Jul 1-2 2026. No em dashes, no banned words. Remaining Ruby: clickhouse, bigquery, snowflake, mariadb, mssql (5).