### PR TITLE
fix(chat): collapse thinking/tool blocks on finish to stop stream jumping

### DIFF
--- a/.cursor/rules/75-chat-performance.mdc
+++ b/.cursor/rules/75-chat-performance.mdc
@@ -64,56 +64,61 @@ DOM size, memory, paint, and scroll, especially on mobile. Memoization stops
 *re-renders* but does nothing about *mount cost / DOM size*; virtualization is
 the only thing that does.
 
-**Tool cards must NOT shrink mid-turn (the load-bearing anti-bounce rule).** A
-whole assistant turn streams into a **single** Virtuoso item. If that item's
-height ever **decreases** while the bottom-pin is engaged, the view snaps
-upward to the new (higher) bottom — a visible scroll bounce. The original
-culprit was `StreamingToolCard` auto-collapsing a finished card 800ms after it
-resolved *while the rest of the turn kept streaming*: every tool call produced a
-shrink → a snap (with the default 300ms `Collapse` animation it was worse — the
-shrink spanned ~18 frames and `totalListHeightChanged` doesn't fire on every
-sub-pixel frame, so Virtuoso's resize anchoring drifted `scrollTop` up on the
-frames the pin missed → oscillating jitter).
+**Anti-bounce rule: a finished block's height must never change AFTER a later
+block starts rendering below it.** A whole assistant turn streams into a
+**single** Virtuoso item. The bounce/blink happens when an *already-finished*
+block (a resolved tool card, a completed thinking block) changes height while
+content below it is streaming — the shrink/grow shoves everything under it, and
+Virtuoso's resize anchoring fights the bottom-pin. The original culprit was
+`StreamingToolCard` auto-collapsing a finished card **800ms after** it resolved
+*while the rest of the turn kept streaming below it*: by then the collapse
+shifted content that already existed underneath → a snap per tool call (an
+*animated* 300ms `Collapse` made it worse — the shrink spanned ~18 frames and
+`totalListHeightChanged` doesn't fire on every sub-pixel frame, so the pin
+drifted → oscillating jitter).
 
-The fix has two parts, both keyed off a `turnStreaming` prop
-(`isStreaming && isLastMessage`) threaded from `ChatMessageRow`:
+The fix is **collapse-on-finish + latch**, applied per block (NOT deferred to
+turn end):
 
-1. **Defer collapse until the turn settles.** While `turnStreaming`, finished
-   tool cards stay **expanded** (`StreamingToolCard`'s collapse effect early-
-   returns). The streaming message's height is therefore **monotonic** (it only
-   grows), so the view follows the tail straight down with zero upward snaps.
-   Cards collapse ~300ms after the turn ends — inside `Chat`'s ~700ms post-turn
-   `stickTailUntilRef` pin window, so that end-of-turn shrink stays bottom-
-   pinned too. (Verified: a 4-query streaming turn went from 4–5 upward jumps,
-   worst −254px, to **0** upward jumps with the view glued, `avgLag≈7px`.)
-2. **The collapse is always instant** (`<Collapse timeout={0}>`). When the
-   deferred cards finally collapse at turn end, all of them shrink at once (the
-   message can lose ~1000px). An *animated* (300ms) collapse spans ~18 frames
-   and `totalListHeightChanged` doesn't fire on every frame, so the pin drifts
-   and strands the view above the conclusion — the same failure mode as the
-   streaming bounce, just at the end. A single-frame (instant) collapse fires
-   one height change the pin catches in one shot: the conclusion stays fixed at
-   the viewport bottom while the content above it compacts. (Verified: settle
-   `maxLag` dropped from ~1006px with the animation to ~1px instant.)
+1. **Each block collapses the instant *it* finishes** — at its own finish
+   transition, while it is still the streaming *tail* and before the next
+   reasoning/tool/text part appends below it. Collapsing at the tail is
+   absorbed by the bottom-pin (you're watching the bottom); the block is then
+   fixed for the rest of the turn. `StreamingToolCard` collapses when it reaches
+   a terminal state (`output-available`/`error`); `ReasoningDisplay` collapses
+   when its group stops being the streaming group.
+2. **The collapse is a single discrete frame.** `StreamingToolCard`'s body uses
+   `<Collapse timeout={0}>` and `ReasoningDisplay` collapses via conditional
+   render (no MUI `Collapse`). One height change → one `totalListHeightChanged`
+   → the pin catches it in one shot. Never use an *animated* collapse on a
+   streaming turn (multi-frame shrink drifts the pin between resize callbacks).
+3. **Finished blocks latch — never auto-reopen or re-collapse.** A resolved tool
+   card's `isDone`/`isError`/`isActive` are monotonic and the memo comparator
+   freezes terminal cards, so its collapse effect runs once. `ReasoningDisplay`
+   holds a `finished` latch (`isOpen = userToggled ? userOpen : isStreaming &&
+   !finished`) so a spurious `isStreaming` flip can never re-expand a completed
+   thinking block. Only a **user** toggle may change a finished block after it
+   collapses.
 
-`turnStreaming` is in the `StreamingToolCard` memo comparator (it flips at most
-once per turn, so it adds no per-chunk renders) so terminal cards still re-run
-their collapse effect when the turn ends.
-
-**Never reintroduce a mid-turn height *decrease* on the streaming message**
-(auto-collapsing cards, closing reasoning, removing rows). Append-only growth is
-what keeps the tail smooth.
+**Never touch a finished (non-tail) block's height mid-turn** — no re-opening a
+collapsed thinking block, no deferring a tool-card collapse until after later
+content rendered, no auto-collapse *timer* that fires once content already sits
+below the block. Collapse exactly once, at the block's own finish, then leave it
+alone.
 
 ## End-of-turn settle (`stickTailUntilRef` + turn-end snapshot)
 
 The bottom-pin runs while `isLoadingRef` is true **plus a bounded settling
-window** after the turn ends (deferred collapses fire ~300ms later). Two
-non-obvious details make the settle land *on the conclusion* instead of
-stranding at the message top:
+window** after the turn ends. Blocks now collapse per-block *during* the turn,
+so there is no mass collapse deferred to turn end — but the **last live block**
+(the final thinking block or a trailing tool card) still collapses as `status`
+leaves "streaming", and that final shrink needs the pin. Two non-obvious details
+make the settle land *on the conclusion* instead of stranding at the message
+top:
 
-- **Window length must outlast the deferred collapse.** It is `1200ms`
-  (collapse delay + instant collapse + margin), not the old `700ms`.
-- **The settling pin must NOT gate on the live `isAtBottom`.** The big
+- **Window length is `1200ms`** (comfortable margin around the final block's
+  single-frame collapse), not the old `700ms`.
+- **The settling pin must NOT gate on the live `isAtBottom`.** The
   end-of-turn shrink momentarily flips `isAtBottom` false, which would disengage
   the pin and let Virtuoso re-anchor to the item top. Instead, `pinToBottom`
   snapshots whether the user was at the bottom *as the turn ended*
@@ -155,10 +160,10 @@ bounces the view ("jumping/blinking"). So `followOutput={false}`.
 
 **Why not a per-`messages`-tick rAF.** The previous fix pinned the bottom in a
 one-shot `requestAnimationFrame` scheduled on each (throttled, ~50ms) `messages`
-tick. That only covers ~1 of every 3 frames. The interior blocks that change
-height asynchronously and non-monotonically — MUI `Collapse` on the thinking
-block + tool cards, and the `modify_console` diff re-render — animate over
-~300ms on frames where `messages` does **not** tick. On those frames Virtuoso's
+tick. That only covers ~1 of every 3 frames. Interior blocks that change
+height asynchronously on frames where `messages` does **not** tick — a
+single-frame collapse when a block finishes, the `modify_console` diff
+re-render, late image/table layout — race the pin. On those frames Virtuoso's
 resize anchoring nudges `scrollTop` **up** (toward the message top) to keep
 content stable, and with no pin to counter it the view paints partway up — then
 the next `messages` tick pins it back down. That alternation **is** the

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -586,14 +586,21 @@ const ReasoningDisplay = React.memo(
     const [userToggled, setUserToggled] = React.useState(false);
     const [userOpen, setUserOpen] = React.useState(false);
     const [elapsedSeconds, setElapsedSeconds] = React.useState(0);
+    // Latches true once this block has streamed and then stopped. A finished
+    // thinking block must NEVER auto-reopen: reopening it would grow a block
+    // sitting ABOVE the currently-streaming one, shifting everything below and
+    // making the chat jump. Once done it stays collapsed unless the user opens
+    // it. (A given reasoning group streams exactly once, so latching is safe.)
+    const [finished, setFinished] = React.useState(false);
     // Track whether this component was live-streamed (vs loaded from history)
     const wasLiveRef = React.useRef(false);
     const startTimeRef = React.useRef<number | null>(null);
     const scrollRef = React.useRef<HTMLDivElement>(null);
 
-    // Auto-open while streaming, auto-close when done.
-    // If the user manually toggled, respect their choice.
-    const isOpen = userToggled ? userOpen : isStreaming;
+    // Auto-open only while THIS block is actively streaming and not yet
+    // finished; auto-close the moment it finishes. If the user manually
+    // toggled, respect their choice.
+    const isOpen = userToggled ? userOpen : isStreaming && !finished;
 
     const handleToggle = () => {
       setUserToggled(true);
@@ -602,7 +609,9 @@ const ReasoningDisplay = React.memo(
 
     // Timer: start counting when streaming begins, freeze when it stops
     React.useEffect(() => {
-      if (isStreaming) {
+      // Never restart a block that already finished (guards against a spurious
+      // `isStreaming` flip re-opening / re-timing a completed block).
+      if (isStreaming && !finished) {
         // Mark that this component saw a live session
         wasLiveRef.current = true;
         // Reset for new streaming session
@@ -621,9 +630,11 @@ const ReasoningDisplay = React.memo(
         return () => clearInterval(interval);
       }
       // Streaming just stopped — freeze the elapsed time
-      // (elapsedSeconds already holds the last value)
+      // (elapsedSeconds already holds the last value) and latch this block as
+      // done so it can never auto-reopen.
       startTimeRef.current = null;
-    }, [isStreaming]);
+      if (wasLiveRef.current) setFinished(true);
+    }, [isStreaming, finished]);
 
     // Auto-scroll the reasoning container to the bottom while streaming
     React.useEffect(() => {
@@ -1127,7 +1138,6 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
                       }
                     : undefined
                 }
-                turnStreaming={isStreaming && isLastMessage}
                 onTitleClick={
                   consoleToolPresentation
                     ? () =>
@@ -3100,26 +3110,28 @@ const Chat: React.FC<ChatProps> = ({
   const lastAtBottomAtRef = useRef(0);
   if (isAtBottom) lastAtBottomAtRef.current = Date.now();
 
-  // Bounded settling window after a turn ends. The end-of-turn collapse — the
-  // thinking blocks closing AND every finished tool card collapsing (deferred
-  // to here, see `StreamingToolCard`) — shrinks the single streaming message by
-  // a lot, all at once. Virtuoso reacts by re-anchoring to the (now much
-  // shorter) item's TOP, which strands the view at the top of the response
-  // unless we keep pinning the bottom through the shrink.
+  // Bounded settling window after a turn ends. Tool cards and thinking blocks
+  // now collapse per-block the instant each one finishes (see
+  // `StreamingToolCard` / `ReasoningDisplay`), so there is no longer a single
+  // mass collapse deferred to turn end. What still shrinks at turn end is the
+  // LAST live block: the final thinking block (or a trailing tool card) closes
+  // when `status` leaves "streaming". Virtuoso reacts to that shrink by
+  // re-anchoring to the (now shorter) item's TOP, which can strand the view at
+  // the top of the response unless we keep pinning the bottom through it.
   //
   // The live `isAtBottom` can't gate this pin: the very shrink we're countering
   // flips `isAtBottom` to false for a few frames, which would disengage the pin
   // and let the strand happen. Instead we snapshot whether the user was at the
   // bottom *as the turn ended* (`wasAtBottomAtTurnEndRef`) and hold the bottom
-  // for the whole window based on that — so a big collapse stays pinned, but a
-  // user who had scrolled up to read history is never yanked back down.
+  // for the whole window based on that — so the final collapse stays pinned,
+  // but a user who had scrolled up to read history is never yanked back down.
   const stickTailUntilRef = useRef(0);
   const wasAtBottomAtTurnEndRef = useRef(false);
   const wasLoadingRef = useRef(isLoading);
   useEffect(() => {
     if (wasLoadingRef.current && !isLoading) {
-      // Window must outlast the deferred tool-card collapse (~300ms delay +
-      // ~300ms animation) plus margin.
+      // Hold the bottom briefly so the final block's collapse at turn end
+      // stays pinned instead of stranding the view at the message top.
       stickTailUntilRef.current = Date.now() + 1200;
       wasAtBottomAtTurnEndRef.current =
         isAtBottomRef.current || Date.now() - lastAtBottomAtRef.current < 800;
@@ -3142,10 +3154,10 @@ const Chat: React.FC<ChatProps> = ({
       pinToBottom();
       return;
     }
-    // Post-turn settle. The deferred tool-card collapse shrinks the single
-    // streaming message all at once; a raw `scrollTop` write can lose the race
-    // to Virtuoso re-anchoring the (now much shorter) item to its TOP, which
-    // strands the view at the top of the response. Virtuoso's own
+    // Post-turn settle. The final block's collapse at turn end shrinks the
+    // streaming message; a raw `scrollTop` write can lose the race to Virtuoso
+    // re-anchoring the (now shorter) item to its TOP, which strands the view at
+    // the top of the response. Virtuoso's own
     // `scrollToIndex` is authoritative — it re-targets the last item's end and
     // survives the re-measure — so use it to hold the conclusion at the bottom
     // through the collapse. Gated on the turn-end snapshot (not the live

--- a/app/src/components/StreamingToolCard.tsx
+++ b/app/src/components/StreamingToolCard.tsx
@@ -65,20 +65,6 @@ interface StreamingToolCardProps {
   onTitleClick?: () => void;
   onDetailClick?: () => void;
   /**
-   * True while the assistant turn this card belongs to is still streaming
-   * (`isStreaming && isLastMessage`). While set, a finished card is NOT
-   * auto-collapsed — it stays expanded until the turn ends. A whole turn
-   * streams into a SINGLE Virtuoso item; collapsing a card mid-turn shrinks
-   * that item, which yanks the chat's bottom-pin upward (a visible scroll
-   * snap/bounce that repeats per tool call). Deferring the collapse keeps the
-   * streaming message's height monotonic (append-only), so the view follows
-   * the tail straight down with no snap. (The body `<Collapse>` also always
-   * uses `timeout={0}` so the eventual collapse is a single discrete frame the
-   * `totalListHeightChanged` pin catches in one shot — an animated multi-frame
-   * collapse drifts the pin between resize callbacks.)
-   */
-  turnStreaming?: boolean;
-  /**
    * Optional — used as a defensive check in the memo comparator so that
    * React re-renders if the underlying tool call identity actually changed.
    * In practice parents also use this as the React key, so unmount/remount
@@ -287,7 +273,6 @@ export const StreamingToolCard = React.memo(
     bodyPreview,
     onTitleClick,
     onDetailClick,
-    turnStreaming,
   }: StreamingToolCardProps) {
     const config = getToolConfig(toolName);
     const muiTheme = useMuiTheme();
@@ -325,29 +310,28 @@ export const StreamingToolCard = React.memo(
     useEffect(() => {
       if (!hasCodePreview) return;
       if (isActive) {
+        // Auto-expand while the tool is actively streaming/executing so its
+        // query/preview builds live in view.
         setExpanded(true);
         setUserScrolled(false);
         return;
       }
       if (isDone || isError) {
-        // While the assistant turn is still streaming, keep finished cards
-        // expanded instead of auto-collapsing them. A whole turn streams into
-        // a SINGLE Virtuoso item; collapsing a card mid-turn shrinks that item
-        // (by up to a few hundred px), which yanks the bottom-pinned view
-        // upward to the new bottom — a visible scroll "snap"/bounce that
-        // repeats for every tool call. Deferring the collapse keeps the
-        // streaming message's height monotonic (it only grows), so the view
-        // follows the tail straight down with no snap. The cards collapse once
-        // the turn settles (below), inside `Chat`'s post-turn pin window so
-        // that end-of-turn shrink stays bottom-pinned too.
-        if (turnStreaming) {
-          setExpanded(true);
-          return;
-        }
-        const timer = setTimeout(() => setExpanded(false), 300);
-        return () => clearTimeout(timer);
+        // Collapse the instant THIS card finishes — not deferred to the end of
+        // the turn. The anti-bounce invariant is "a finished block's height
+        // must never change AFTER a later block has started rendering below
+        // it": collapsing right at the finish transition (while this card is
+        // still the streaming tail, before the next reasoning/tool/text part
+        // appends) keeps the finished card fixed from then on. Because the body
+        // `<Collapse>` uses `timeout={0}`, the shrink is a single discrete
+        // frame that Virtuoso's bottom-pin (`totalListHeightChanged`) catches
+        // in one shot. `isDone`/`isError`/`isActive` are monotonic (a terminal
+        // card never goes back to active) and the memo comparator freezes
+        // terminal cards, so this runs exactly once and never fights a manual
+        // re-expand.
+        setExpanded(false);
       }
-    }, [isDone, isError, isActive, hasCodePreview, turnStreaming]);
+    }, [isDone, isError, isActive, hasCodePreview]);
 
     // Resolve code preview content (supports both string and object fields)
     const inputObj = input as Record<string, unknown> | undefined;
@@ -703,11 +687,6 @@ export const StreamingToolCard = React.memo(
     if (prev.leadingIconAlt !== next.leadingIconAlt) return false;
     if (prev.bodyPreview?.content !== next.bodyPreview?.content) return false;
     if (prev.bodyPreview?.language !== next.bodyPreview?.language) return false;
-    // `turnStreaming` flips at most once per turn (true→false when the turn
-    // ends), so re-rendering on it does not add per-chunk renders, but it must
-    // be honored even for terminal cards so the collapse transition switches
-    // from instant (streaming) back to the smooth 300ms animation (history).
-    if (prev.turnStreaming !== next.turnStreaming) return false;
 
     // Terminal states are immutable. Even if useChat handed us new cloned
     // references for `input` / `output` this tick, the contents are the


### PR DESCRIPTION
## Summary

Fixes the chat "jumping / blinking / layout shift" during streaming assistant turns. The root cause was **already-finished blocks changing height after later blocks had started rendering below them** — every such shrink/grow shoved the content underneath, and Virtuoso's resize anchoring fought the bottom-pin, producing the up/down bounce.

Two offenders:

- **Tool cards deferred their collapse to the *end of the turn*** (`turnStreaming`) and then collapsed on a 300ms timer — shrinking a card long after content had already streamed in beneath it.
- **Thinking blocks tied their open state directly to `isStreaming`**, so a completed block could re-open on a spurious re-render ("collapsing and reopening").

**Fix: collapse each block the instant *it* finishes** — while it's still the streaming *tail*, before the next reasoning/tool/text part appends below it — as a single discrete frame, then **latch** it so it's never auto-touched again. Collapsing at the tail is absorbed by the bottom-pin; from then on the block's height is fixed, so nothing above the live block ever moves.

## Changes

- **`StreamingToolCard.tsx`** — removed the `turnStreaming` deferral entirely (prop, JSDoc, memo comparator, and the `Chat.tsx` call site). Now collapses on transition to `output-available`/`error`. `isDone`/`isError`/`isActive` are monotonic and the memo comparator freezes terminal cards, so the collapse effect runs **once** and never fights a manual re-expand. Body `<Collapse>` stays `timeout={0}` (single-frame).
- **`ReasoningDisplay` (in `Chat.tsx`)** — added a `finished` latch: `isOpen = userToggled ? userOpen : isStreaming && !finished`. A completed thinking block can never auto-reopen; only a user toggle can change it after it collapses. Timer effect also guarded with `!finished`.
- **`.cursor/rules/75-chat-performance.mdc`** — rewrote the anti-bounce rule to the per-block **collapse-on-finish + single-frame + latch** contract and fixed the now-stale "defer to turn end" / end-of-turn mass-collapse comments. The `stickTailUntilRef` settle window stays (it still catches the *last* live block collapsing when `status` leaves streaming).

## Behavior

- Tool call finishes → its card collapses immediately.
- Thinking block finishes → it collapses immediately.
- Finished blocks are never auto-reopened or re-collapsed. Users can still expand any block manually.

## Test plan

- [x] `pnpm --filter app exec vitest run` for `reasoning-groups.test.ts` + `Chat.perf.test.ts` — **41 passed**
- [x] `pnpm --filter app run typecheck && pnpm --filter app run lint` — clean
- [ ] Manual: drive an interleaved *think → run query → think again* turn and confirm no scroll bounce/blink; verify each block collapses on finish and stays put; verify manual expand/collapse still works.

Made with [Cursor](https://cursor.com)