### PR TITLE
fix(api): retry MongoDB connect with backoff on startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,14 @@ BCRYPT_ROUNDS=10
 MONGODB_MAX_POOL_SIZE=10
 MONGODB_MIN_POOL_SIZE=2
 
+# Optional: startup DB connection retry/backoff. The initial connect runs
+# before the server listens, so these let a transient Atlas blip (e.g.
+# ReplicaSetNoPrimary during a failover) be retried instead of aborting boot.
+# Defaults: 5 attempts, 1000ms base delay, 5000ms max delay (exponential).
+DB_CONNECT_MAX_ATTEMPTS=5
+DB_CONNECT_BASE_DELAY_MS=1000
+DB_CONNECT_MAX_DELAY_MS=5000
+
 # Port Configuration
 WEB_API_PORT=8080
 

--- a/api/src/database/schema.ts
+++ b/api/src/database/schema.ts
@@ -19,6 +19,35 @@ const mongooseConnectOptions: ConnectOptions = {
   serverMonitoringMode: "poll",
 };
 
+// Startup connection retry/backoff.
+//
+// The initial `connectDatabase()` runs before the server starts listening, so
+// a single failed attempt aborts the whole boot. A brief, transient Atlas
+// condition — most commonly `ReplicaSetNoPrimary` during a failover/maintenance
+// window — would otherwise kill the process and fail a Cloud Run rollout even
+// though the cluster recovers seconds later. Retrying with bounded exponential
+// backoff rides through those blips. Kept modest so the port still opens within
+// Cloud Run's startup-probe window; a genuinely-unreachable DB (bad URI, not
+// whitelisted) still fails fast after the attempts are exhausted. All knobs are
+// env-tunable so ops can widen the window without a code change (pair with a
+// longer Cloud Run startup-probe timeout if a failover routinely runs long).
+function positiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+const DB_CONNECT_MAX_ATTEMPTS = positiveIntEnv("DB_CONNECT_MAX_ATTEMPTS", 5);
+const DB_CONNECT_BASE_DELAY_MS = positiveIntEnv(
+  "DB_CONNECT_BASE_DELAY_MS",
+  1000,
+);
+const DB_CONNECT_MAX_DELAY_MS = positiveIntEnv("DB_CONNECT_MAX_DELAY_MS", 5000);
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise(resolve => setTimeout(resolve, ms));
+
 let mongooseListenersRegistered = false;
 
 function registerMongooseConnectionListeners(): void {
@@ -503,20 +532,44 @@ export async function connectDatabase(): Promise<void> {
     return;
   }
 
-  try {
-    await mongoose.connect(mongoUri, mongooseConnectOptions);
-    mongooseLogger.info("Connected to MongoDB", {
-      readyState: mongoose.connection.readyState,
-      maxPoolSize: mongooseConnectOptions.maxPoolSize,
-      maxIdleTimeMS: mongooseConnectOptions.maxIdleTimeMS,
-      serverSelectionTimeoutMS: mongooseConnectOptions.serverSelectionTimeoutMS,
-      serverMonitoringMode: mongooseConnectOptions.serverMonitoringMode,
-    });
-  } catch (error) {
-    mongooseLogger.error("MongoDB connection error", {
-      error,
-      readyState: mongoose.connection.readyState,
-    });
-    throw error;
+  for (let attempt = 1; attempt <= DB_CONNECT_MAX_ATTEMPTS; attempt++) {
+    try {
+      await mongoose.connect(mongoUri, mongooseConnectOptions);
+      mongooseLogger.info("Connected to MongoDB", {
+        attempt,
+        readyState: mongoose.connection.readyState,
+        maxPoolSize: mongooseConnectOptions.maxPoolSize,
+        maxIdleTimeMS: mongooseConnectOptions.maxIdleTimeMS,
+        serverSelectionTimeoutMS:
+          mongooseConnectOptions.serverSelectionTimeoutMS,
+        serverMonitoringMode: mongooseConnectOptions.serverMonitoringMode,
+      });
+      return;
+    } catch (error) {
+      const isLastAttempt = attempt >= DB_CONNECT_MAX_ATTEMPTS;
+      if (isLastAttempt) {
+        mongooseLogger.error("MongoDB connection error", {
+          error,
+          attempt,
+          maxAttempts: DB_CONNECT_MAX_ATTEMPTS,
+          readyState: mongoose.connection.readyState,
+        });
+        throw error;
+      }
+      // Exponential backoff, capped. Transient (e.g. ReplicaSetNoPrimary during
+      // an Atlas failover) — retry rather than aborting the whole boot.
+      const delayMs = Math.min(
+        DB_CONNECT_BASE_DELAY_MS * 2 ** (attempt - 1),
+        DB_CONNECT_MAX_DELAY_MS,
+      );
+      mongooseLogger.warn("MongoDB connection attempt failed, retrying", {
+        error: error instanceof Error ? error.message : String(error),
+        attempt,
+        maxAttempts: DB_CONNECT_MAX_ATTEMPTS,
+        retryInMs: delayMs,
+        readyState: mongoose.connection.readyState,
+      });
+      await sleep(delayMs);
+    }
   }
 }


### PR DESCRIPTION
## Summary

Production deploy #629 failed at **Cloud Run container startup** — not build/lint/type (all passed). The API awaits `connectDatabase()` *before* it starts listening on port 8080, and rethrows on failure, so a **transient** Atlas `ReplicaSetNoPrimary` (a failover/maintenance blip during the deploy window) killed the process before the port opened → the rollout aborted even though the cluster recovered seconds later. (Prod stayed up on the previous revision; the failed revision never took traffic.)

Observed in the failed revision's logs:

```
Fatal error during startup: MongooseServerSelectionError: Could not connect to any
servers in your MongoDB Atlas cluster...
    at connectDatabase (/app/api/dist/database/schema.js)
  reason: TopologyDescription { type: 'ReplicaSetNoPrimary', ... }
```

## Change

Wrap the startup connect in **bounded exponential backoff** so a brief blip is retried instead of aborting boot:

- Default **5 attempts**, **1s** base delay, **5s** cap (exponential: 1s → 2s → 4s → 5s between attempts).
- A genuinely unreachable DB (bad URI, not IP-whitelisted, missing `DATABASE_URL`) **still fails fast** after attempts are exhausted — `DATABASE_URL` missing throws before the loop.
- Each attempt keeps the existing `serverSelectionTimeoutMS: 10000`, so a primary elected mid-failover is picked up on the next try.
- All knobs are **env-tunable** — `DB_CONNECT_MAX_ATTEMPTS`, `DB_CONNECT_BASE_DELAY_MS`, `DB_CONNECT_MAX_DELAY_MS` — documented in `.env.example`, so ops can widen the window without a code change (pair with a longer Cloud Run startup-probe timeout if a failover routinely runs long).

Scope: `connectDatabase()` is only called from `api/src/index.ts` (server boot), so this affects the startup path only.

## Why option 1 (retry) and not listen-first

Minimal, low-risk change that preserves the existing "don't serve traffic without a DB" invariant. A follow-up could go further (listen first, connect in background, `/health` green immediately, DB routes 503 until connected) if transient Atlas windows turn out to exceed the retry budget.

## Test plan

- [x] `pnpm --filter api run lint` — clean
- [x] `pnpm --filter api run build` (typecheck) — clean
- [ ] Deploy to prod and confirm a normal rollout still succeeds.
- [ ] (Optional) Simulate a slow/unavailable DB at boot (temporarily point `DATABASE_URL` at an unreachable host, or lower `DB_CONNECT_MAX_ATTEMPTS=1`) and confirm the retry logs appear and it eventually fails fast when truly unreachable.

Made with [Cursor](https://cursor.com)