### PR TITLE
fix(chat): stop thinking-block flicker from duplicated/mis-grouped reasoning parts

### DIFF
--- a/.cursor/rules/75-chat-performance.mdc
+++ b/.cursor/rules/75-chat-performance.mdc
@@ -106,6 +106,35 @@ content rendered, no auto-collapse *timer* that fires once content already sits
 below the block. Collapse exactly once, at the block's own finish, then leave it
 alone.
 
+## Reasoning-block identity & dedup (`reasoning-groups.ts`)
+
+The latch above only holds if a thinking block keeps a **stable identity** and a
+**stable streaming flag**. The AI SDK's `ReasoningUIPart` has **no `id`**, only
+`state: 'streaming' | 'done'`. Three rules keep blocks stable:
+
+1. **Drive the streaming flag off `part.state`, not an index heuristic.**
+   `getStreamingReasoningGroupStart` force-expands the **last** reasoning group
+   only while its trailing part is `state === 'streaming'`. `state` flips to
+   `'done'` exactly once (at reasoning-end), so it does not thrash per token the
+   way "the group owning the last array part" did (empty reasoning parts and
+   `step-start` markers arriving at the tail used to flip it every chunk →
+   expand/collapse blinking). Parts rebuilt from history carry no `state`, so a
+   last-part fallback is used there (and the render gates on `isStreamingNow`).
+2. **A `step-start` marker does NOT break a reasoning run.** Multi-step loops and
+   resume/continuation replay interleave `step-start` between thinking segments
+   (and between a partial reasoning part and its replayed copy). `step-start`
+   bridges the run; only a real tool/text part starts a new block.
+3. **Dedupe overlapping reasoning within a run.** Continuation-merge and
+   resumable-stream replay inject duplicate reasoning parts (a partial `"ABC"`
+   next to the replayed `"ABC more…"`). `computeReasoningGroups` collapses them
+   by Anthropic `signature`, then exact text, then prefix-superset (keep the
+   longest) — the same keys the backend's `dedupeAssistantReasoning` uses. Never
+   `join("\n\n")` raw parts: that renders the same thinking twice.
+
+Blocks are keyed **`reasoning-group-<ordinal>`** (position among reasoning
+groups), never `reasoning-<partIndex>` — a shifting array index would remount
+the block, resetting its `finished` latch and re-expanding it.
+
 ## End-of-turn settle (`stickTailUntilRef` + turn-end snapshot)
 
 The bottom-pin runs while `isLoadingRef` is true **plus a bounded settling

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -1008,6 +1008,20 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
 
   const reasoningGroups = computeReasoningGroups(parts);
 
+  // Stable identity for each reasoning block: its ordinal position among the
+  // message's reasoning groups (0, 1, 2…). Keying by this instead of the raw
+  // part index means an inserted `step-start`/tool/text part shifting the array
+  // can't remount an existing block — a remount would reset its `finished`
+  // latch and make it re-expand (flicker). Reasoning groups only ever append,
+  // so ordinals are stable for the lifetime of a block.
+  const reasoningGroupOrdinals = new Map<number, number>();
+  {
+    let ordinal = 0;
+    for (const start of reasoningGroups.keys()) {
+      reasoningGroupOrdinals.set(start, ordinal++);
+    }
+  }
+
   const lastPartIndex = parts.length - 1;
   const lastPart = parts.at(-1);
   const isLastPartText =
@@ -1168,7 +1182,7 @@ const ChatMessageRow = React.memo(function ChatMessageRow({
             if (!group.text && !isGroupStreaming) return null;
             return (
               <ReasoningDisplay
-                key={`reasoning-${partIndex}`}
+                key={`reasoning-group-${reasoningGroupOrdinals.get(partIndex) ?? partIndex}`}
                 reasoningText={group.text}
                 isStreaming={isGroupStreaming}
                 paletteMode={paletteMode}

--- a/app/src/components/__tests__/reasoning-groups.test.ts
+++ b/app/src/components/__tests__/reasoning-groups.test.ts
@@ -58,6 +58,87 @@ describe("computeReasoningGroups", () => {
     const groups = computeReasoningGroups(parts);
     expect(groups.get(0)?.text).toBe("from history");
   });
+
+  it("bridges a reasoning run across a step-start marker", () => {
+    // Multi-step tool loops (and resume replay) insert a step-start between
+    // thinking segments; it must not split the block.
+    const parts: Part[] = [
+      { type: "reasoning", text: "part one" },
+      { type: "step-start" },
+      { type: "reasoning", text: "part two" },
+    ];
+    const groups = computeReasoningGroups(parts);
+    expect([...groups.keys()]).toEqual([0]);
+    expect(groups.get(0)).toEqual({
+      text: "part one\n\npart two",
+      lastIndex: 2,
+    });
+  });
+
+  it("still splits reasoning across a tool part even after a step-start", () => {
+    const parts: Part[] = [
+      { type: "reasoning", text: "block A" },
+      { type: "step-start" },
+      { type: "tool-run_console", state: "output-available" },
+      { type: "reasoning", text: "block B" },
+    ];
+    const groups = computeReasoningGroups(parts);
+    expect([...groups.keys()]).toEqual([0, 3]);
+    expect(groups.get(0)?.text).toBe("block A");
+    expect(groups.get(3)?.text).toBe("block B");
+  });
+
+  it("dedupes an exact duplicate reasoning part (replay artifact)", () => {
+    const parts: Part[] = [
+      { type: "reasoning", text: "thinking hard" },
+      { type: "reasoning", text: "thinking hard" },
+    ];
+    expect(computeReasoningGroups(parts).get(0)?.text).toBe("thinking hard");
+  });
+
+  it("collapses a partial copy into its extended copy (prefix-superset)", () => {
+    // The classic symptom: a prematurely-collapsed partial block ("ABC")
+    // followed by the replayed, still-streaming extended copy ("ABC more…").
+    const parts: Part[] = [
+      { type: "reasoning", text: "ABC" },
+      { type: "step-start" },
+      { type: "reasoning", text: "ABC more thinking" },
+    ];
+    expect(computeReasoningGroups(parts).get(0)?.text).toBe(
+      "ABC more thinking",
+    );
+  });
+
+  it("dedupes by Anthropic signature, keeping the longest copy", () => {
+    const sigMeta = { anthropic: { signature: "sig-1" } };
+    const parts: Part[] = [
+      { type: "reasoning", text: "short", providerMetadata: sigMeta },
+      {
+        type: "reasoning",
+        text: "short but longer",
+        providerMetadata: sigMeta,
+      },
+    ];
+    expect(computeReasoningGroups(parts).get(0)?.text).toBe("short but longer");
+  });
+
+  it("keeps distinct signatured blocks separate even if text overlaps", () => {
+    const parts: Part[] = [
+      {
+        type: "reasoning",
+        text: "Let me look",
+        providerMetadata: { anthropic: { signature: "sig-a" } },
+      },
+      {
+        type: "reasoning",
+        text: "Let me look at the schema",
+        providerMetadata: { anthropic: { signature: "sig-b" } },
+      },
+    ];
+    expect(computeReasoningGroups(parts).get(0)?.text).toBe(
+      "Let me look\n\nLet me look at the schema",
+    );
+  });
 });
 
 describe("getStreamingReasoningGroupStart (re-expand regression)", () => {
@@ -106,5 +187,43 @@ describe("getStreamingReasoningGroupStart (re-expand regression)", () => {
       { type: "text", text: "final answer" },
     ];
     expect(getStreamingReasoningGroupStart(parts)).toBeNull();
+  });
+});
+
+describe("getStreamingReasoningGroupStart (state-driven)", () => {
+  it("flags the last block while its trailing part is streaming", () => {
+    const parts: Part[] = [
+      { type: "reasoning", text: "done block", state: "done" },
+      { type: "tool-run_console", state: "output-available" },
+      { type: "reasoning", text: "live block", state: "streaming" },
+    ];
+    expect(getStreamingReasoningGroupStart(parts)).toBe(2);
+  });
+
+  it("flags no block once the last reasoning part is done", () => {
+    const parts: Part[] = [
+      { type: "reasoning", text: "first", state: "done" },
+      { type: "reasoning", text: "second", state: "done" },
+    ];
+    expect(getStreamingReasoningGroupStart(parts)).toBeNull();
+  });
+
+  it("does not re-open an earlier block left streaming by a missing end", () => {
+    // An earlier block never got its reasoning-end (stuck 'streaming'), but the
+    // active block below it is done — nothing should be force-expanded.
+    const parts: Part[] = [
+      { type: "reasoning", text: "stale", state: "streaming" },
+      { type: "text", text: "answer" },
+      { type: "reasoning", text: "final", state: "done" },
+    ];
+    expect(getStreamingReasoningGroupStart(parts)).toBeNull();
+  });
+
+  it("ignores a trailing step-start when reading the streaming state", () => {
+    const parts: Part[] = [
+      { type: "reasoning", text: "live", state: "streaming" },
+      { type: "step-start" },
+    ];
+    expect(getStreamingReasoningGroupStart(parts)).toBe(0);
   });
 });

--- a/app/src/components/reasoning-groups.ts
+++ b/app/src/components/reasoning-groups.ts
@@ -6,13 +6,99 @@
 
 export interface ReasoningGroup {
   text: string;
+  // Index of the LAST reasoning part in this run (used both to decide which
+  // block owns the trailing stream and to read that part's live `state`).
   lastIndex: number;
+}
+
+type Part = Record<string, unknown>;
+
+// Live-streamed parts use `text`; persisted/history parts may use `reasoning`.
+// Accept either so grouping is consistent across both.
+function partText(p: Part): string {
+  if (typeof p.text === "string") return p.text;
+  if (typeof p.reasoning === "string") return p.reasoning as string;
+  return "";
+}
+
+// Anthropic extended-thinking blocks carry a unique per-block `signature` at
+// `providerMetadata.anthropic.signature`. Two reasoning parts sharing a
+// signature are unambiguously the SAME block (see the backend's
+// `dedupeAssistantReasoning`), so we use it as the primary dedupe key.
+function partSignature(p: Part): string | null {
+  const meta = p.providerMetadata as Record<string, unknown> | undefined | null;
+  const anthropic = meta?.anthropic as
+    | Record<string, unknown>
+    | undefined
+    | null;
+  const sig = anthropic?.signature;
+  return typeof sig === "string" && sig.length > 0 ? sig : null;
+}
+
+// True for the AI SDK step boundary marker. A `step-start` sits between the
+// thinking segments of a multi-step tool loop; it must NOT break a reasoning
+// run (see `computeReasoningGroups`).
+function isStepStart(p: Part): boolean {
+  return p.type === "step-start";
+}
+
+// Collapses a run's reasoning parts into a single de-duplicated text.
+//
+// WHY: continuation mode (streamed parts merged with `originalMessages`) and
+// resumable-stream replay can inject DUPLICATE reasoning parts into a single
+// assistant message — most visibly a partial copy ("ABC") sitting right next to
+// the replayed, extended copy ("ABC more…"). Naively joining every part then
+// renders the same thinking twice ("ABC\n\nABC more"). We dedupe the same way
+// the backend does before it hits the model: by Anthropic signature, then exact
+// text, then prefix-superset (the streaming-grow / replay shape). We only ever
+// DROP redundant copies and keep the longest surviving text — never alter the
+// underlying thinking.
+function dedupeRunText(items: Array<{ text: string; sig: string | null }>) {
+  const kept: Array<{ text: string; sig: string | null }> = [];
+
+  for (const item of items) {
+    const t = item.text;
+
+    // Same signature → same block: keep whichever copy is longer.
+    if (item.sig) {
+      const existing = kept.find(k => k.sig === item.sig);
+      if (existing) {
+        if (t.length > existing.text.length) existing.text = t;
+        continue;
+      }
+    }
+
+    // Exact duplicate anywhere in the run.
+    if (kept.some(k => k.text === t)) continue;
+
+    // Streaming-grow / replay: the trailing kept copy is a prefix of this one
+    // (or vice versa). Only applied to signature-less parts — signatured blocks
+    // are authoritative and distinct even if their prose overlaps.
+    const last = kept[kept.length - 1];
+    if (last && !last.sig && !item.sig) {
+      if (t.startsWith(last.text)) {
+        last.text = t;
+        continue;
+      }
+      if (last.text.startsWith(t)) continue;
+    }
+
+    kept.push({ text: t, sig: item.sig });
+  }
+
+  return kept.map(k => k.text).join("\n\n");
 }
 
 // Groups consecutive `reasoning` parts into a single display block. A run of
 // adjacent reasoning parts (regardless of whether each chunk has text yet) is
-// one "thinking" session; any non-reasoning part (tool call, text) ends the
-// run, so the next reasoning part starts a fresh group.
+// one "thinking" session. A `step-start` marker between reasoning parts does
+// NOT end the run — multi-step tool loops interleave `step-start` between
+// thinking segments, and (critically) resume/continuation replay re-emits a
+// `step-start` between a partial reasoning part and its replayed copy. Keeping
+// the run intact lets `dedupeRunText` collapse those copies into one block
+// instead of rendering the same thinking twice. Any OTHER non-reasoning part
+// (tool call, text) genuinely ends the run, so the next reasoning part starts a
+// fresh group.
 //
 // Grouping by contiguous runs — rather than only indexing parts that already
 // have text — is important: when a new thinking block begins, its first
@@ -21,7 +107,7 @@ export interface ReasoningGroup {
 // the "last group start" pointing at a previous, already-collapsed block
 // (which would make that old block re-expand when the new one starts).
 export function computeReasoningGroups(
-  parts: Array<Record<string, unknown>>,
+  parts: Array<Part>,
 ): Map<number, ReasoningGroup> {
   const groups = new Map<number, ReasoningGroup>();
 
@@ -33,45 +119,71 @@ export function computeReasoningGroups(
     }
 
     const start = i;
-    const texts: string[] = [];
+    const items: Array<{ text: string; sig: string | null }> = [];
     let lastIndex = i;
-    while (i < parts.length && parts[i].type === "reasoning") {
-      const p = parts[i];
-      // Live-streamed parts use `text`; persisted/history parts may use
-      // `reasoning`. Accept either so grouping is consistent across both.
-      const raw =
-        typeof p.text === "string"
-          ? p.text
-          : typeof p.reasoning === "string"
-            ? (p.reasoning as string)
-            : "";
-      const trimmed = raw.trim();
-      if (trimmed) texts.push(trimmed);
-      lastIndex = i;
-      i++;
+
+    let j = i;
+    while (j < parts.length) {
+      const p = parts[j];
+      if (p.type === "reasoning") {
+        const trimmed = partText(p).trim();
+        if (trimmed) items.push({ text: trimmed, sig: partSignature(p) });
+        lastIndex = j;
+        j++;
+      } else if (isStepStart(p)) {
+        // Bridge the run across the step boundary without extending lastIndex
+        // (which must stay on a real reasoning part so its `state` is readable).
+        j++;
+      } else {
+        break;
+      }
     }
 
-    groups.set(start, { text: texts.join("\n\n"), lastIndex });
+    groups.set(start, { text: dedupeRunText(items), lastIndex });
+    i = j;
   }
 
   return groups;
 }
 
-// The start index of the reasoning group that is currently streaming, i.e. the
-// group that owns the message's last part. Returns null when the last part is
-// not a reasoning part (so no block should be force-expanded), or when the last
-// part somehow belongs to no group.
+// Does any reasoning part carry a live `state` field? Streamed parts do
+// (`'streaming'` → `'done'`); parts rebuilt from persisted history do not.
+function hasReasoningState(parts: Array<Part>): boolean {
+  return parts.some(p => p.type === "reasoning" && typeof p.state === "string");
+}
+
+// The start index of the reasoning group that is currently streaming — i.e. the
+// block that should stay force-expanded. Returns null when nothing is streaming,
+// so previously-collapsed blocks are never re-opened.
 //
-// Selecting by `lastIndex === lastPartIndex` (rather than "the highest group
-// start") ties the streaming flag to the group the trailing part actually
-// belongs to. Combined with contiguous-run grouping above, a just-started empty
-// block forms its own group whose lastIndex is the last part — so it's selected
-// here and shows its "Thinking…" indicator immediately, while every earlier,
-// already-collapsed block stays closed.
+// PRIMARY PATH (live streaming): the AI SDK stamps each reasoning part with
+// `state: 'streaming' | 'done'`, flipping to `'done'` exactly once at
+// reasoning-end. We key the streaming flag off the LAST group's trailing part
+// state. This is stable per-token (unlike an index heuristic, which flips as
+// empty reasoning parts / step-start markers arrive at the tail) and only ever
+// points at the final block — an earlier block left `'streaming'` by a missing
+// reasoning-end can never re-open something above the active stream.
+//
+// FALLBACK PATH (no `state`, e.g. unit fixtures / providers that don't emit it):
+// select the group that owns the message's trailing part, and only when that
+// trailing part is itself a reasoning part.
 export function getStreamingReasoningGroupStart(
-  parts: Array<Record<string, unknown>>,
+  parts: Array<Part>,
   groups: Map<number, ReasoningGroup> = computeReasoningGroups(parts),
 ): number | null {
+  if (groups.size === 0) return null;
+
+  if (hasReasoningState(parts)) {
+    let lastStart: number | null = null;
+    let lastGroup: ReasoningGroup | null = null;
+    for (const [start, group] of groups) {
+      lastStart = start;
+      lastGroup = group;
+    }
+    if (lastStart === null || lastGroup === null) return null;
+    return parts[lastGroup.lastIndex]?.state === "streaming" ? lastStart : null;
+  }
+
   const lastPartIndex = parts.length - 1;
   const lastPart = parts[lastPartIndex];
   if (lastPart?.type !== "reasoning") return null;


### PR DESCRIPTION
## Summary

Follow-up to #629. Thinking blocks were **90% stable** but could still flicker: a block would prematurely collapse, a **second block with the same text duplicated** (plus more streaming text) would appear underneath, and blocks would **expand/collapse on every token**.

Root cause is in how we group assistant `reasoning` parts for display:

- The AI SDK's `ReasoningUIPart` carries **no stable `id`**, only `state: 'streaming' | 'done'` — which we ignored. We instead decided "which block is streaming" by *which array index owns the last part*, so the flag thrashed every time an empty reasoning part or `step-start` marker arrived at the tail.
- On **resume-reconnect / continuation replay**, the client message ends up with **duplicate reasoning parts** (a partial `"ABC"` next to the replayed `"ABC more…"`). The backend's `dedupeAssistantReasoning` only cleans the **model input**, never the client display, so our `texts.join("\n\n")` rendered the same thinking twice — split into two blocks when a `step-start` sat between the copies.
- Blocks were keyed by `reasoning-${partIndex}`; an index shift remounted the block and reset its `finished` latch → re-expand.

This is a **display-layer only** fix — no backend/stream/persistence changes.

## Changes

- **Streaming flag from `part.state`** — force-expand the last reasoning group only while its trailing part is `state === 'streaming'` (flips once, at reasoning-end). Falls back to the old last-part heuristic for history parts that carry no `state` (gated on `isStreamingNow`).
- **`step-start` no longer breaks a reasoning run** — so a partial part and its replayed copy group together instead of splitting.
- **Dedupe reasoning within a run** — by Anthropic `signature`, then exact text, then prefix-superset (keep longest), mirroring the backend's proven `dedupeAssistantReasoning`.
- **Stable block keys** — `reasoning-group-<ordinal>` instead of the part index, so an index shift can't remount a block and reset its `finished` latch.
- Documented the identity/dedup contract in `.cursor/rules/75-chat-performance.mdc`.

## Test plan

- [x] `pnpm --filter app exec vitest run src/components/__tests__/reasoning-groups.test.ts` — 19/19 pass (added regression tests for step-start bridging, exact/prefix/signature dedup, and state-driven streaming)
- [x] `pnpm --filter app run typecheck` — clean
- [x] `pnpm --filter app run lint` — clean
- [ ] Manual: stream a long multi-step turn (thinking → tool calls → thinking); confirm no duplicated thinking blocks, no per-token expand/collapse, no re-expanding of finished blocks. Reload mid-turn (resume) and confirm no duplicate blocks appear.

> Note: separate from #630 (MongoDB connect-retry deploy fix), which is still open.

Made with [Cursor](https://cursor.com)