### PR TITLE
feat(dbt): markdown preview switch in dbt file editor

### DIFF
--- a/app/src/components/DbtFileEditor.test.tsx
+++ b/app/src/components/DbtFileEditor.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import type React from "react";
 import {
   afterEach,
   beforeAll,
@@ -23,6 +24,19 @@ vi.mock("../contexts/workspace-context", () => ({
   useWorkspace: () => ({ currentWorkspace: { id: "ws1" } }),
 }));
 vi.mock("../dbt-runtime/shell", () => ({ focusDbtFileTab: vi.fn() }));
+// Streamdown pulls heavy ESM (shiki) that jsdom can't load — render children raw.
+vi.mock("./StreamingMarkdown", () => ({
+  default: ({ children }: { children: string }) => (
+    <div data-testid="markdown-preview">{children}</div>
+  ),
+}));
+// EntityBreadcrumbs returns null without a matching console tab; surface its
+// `trailing` slot so the markdown Preview switch is testable in isolation.
+vi.mock("./EntityBreadcrumbs", () => ({
+  default: ({ trailing }: { trailing?: React.ReactNode }) => (
+    <div data-testid="breadcrumbs">{trailing}</div>
+  ),
+}));
 
 import DbtFileEditor from "./DbtFileEditor";
 import { useDbtStore } from "../store/dbtStore";
@@ -132,6 +146,39 @@ describe("DbtFileEditor", () => {
         "dev",
         false,
       ),
+    );
+  });
+
+  it("renders a markdown preview by default for .md files and toggles to the editor", async () => {
+    const user = userEvent.setup();
+    useDbtStore.setState({
+      filesByProject: {
+        p1: {
+          "models/README.md": {
+            content: "# Hello docs",
+            dirty: false,
+            loaded: true,
+          },
+        },
+      } as never,
+      filePathsByProject: { p1: ["models/README.md"] } as never,
+    });
+
+    render(<DbtFileEditor tabId="t1" projectId="p1" path="models/README.md" />);
+
+    // Preview is on by default → markdown content is rendered.
+    const preview = await screen.findByTestId("markdown-preview");
+    expect(preview.textContent).toBe("# Hello docs");
+
+    // Flipping the Preview switch off swaps to the (Monaco) editor pane.
+    const previewSwitch = screen.getByRole("checkbox", {
+      name: /preview/i,
+    }) as HTMLInputElement;
+    expect(previewSwitch.checked).toBe(true);
+    await user.click(previewSwitch);
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("markdown-preview")).toBeNull(),
     );
   });
 });

--- a/app/src/components/DbtFileEditor.tsx
+++ b/app/src/components/DbtFileEditor.tsx
@@ -26,6 +26,7 @@ import {
   Menu,
   MenuItem,
   Select,
+  Switch,
   Tab,
   Tabs,
   Tooltip,
@@ -63,6 +64,7 @@ import {
   type DbtSelectScope,
 } from "../lib/dbt-node-selection";
 import {
+  isMarkdownDbtPath,
   languageForDbtPath,
   logsToProblems,
   modelNameForPath,
@@ -71,6 +73,7 @@ import {
 } from "../lib/dbt-editor-logic";
 import { focusDbtFileTab } from "../dbt-runtime/shell";
 import EntityBreadcrumbs from "./EntityBreadcrumbs";
+import StreamingMarkdown from "./StreamingMarkdown";
 
 const DbtLineageView = lazy(() => import("./DbtLineageView"));
 
@@ -301,8 +304,13 @@ export default function DbtFileEditor({
     useState<DbtCommandRunResult | null>(null);
   const [problems, setProblems] = useState<Problem[] | null>(null);
   const [runMenuAnchor, setRunMenuAnchor] = useState<HTMLElement | null>(null);
+  // Markdown docs (.md/.markdown) open in a rendered preview by default; the
+  // header switch flips back to the raw Monaco editor for editing.
+  const [markdownPreview, setMarkdownPreview] = useState(true);
 
   const modelName = useMemo(() => modelNameForPath(path), [path]);
+  const isMarkdown = useMemo(() => isMarkdownDbtPath(path), [path]);
+  const showMarkdownPreview = isMarkdown && markdownPreview;
 
   // Live-compile plumbing: refs let the debounced save callback re-compile
   // without re-creating the timer on every keystroke. `manualBusyRef` is set
@@ -571,7 +579,13 @@ export default function DbtFileEditor({
     );
   }
 
-  const editorPane = (
+  const editorPane = showMarkdownPreview ? (
+    <Box sx={{ height: "100%", minHeight: 0, overflow: "auto" }}>
+      <Box sx={{ maxWidth: 820, mx: "auto", px: 3, py: 3 }}>
+        <StreamingMarkdown>{file.content}</StreamingMarkdown>
+      </Box>
+    </Box>
+  ) : (
     <Box sx={{ height: "100%", minHeight: 0 }}>
       <MonacoEditor
         height="100%"
@@ -587,10 +601,29 @@ export default function DbtFileEditor({
           fontSize: 13,
           automaticLayout: true,
           scrollBeyondLastLine: false,
+          wordWrap: isMarkdown ? "on" : "off",
         }}
       />
     </Box>
   );
+
+  const markdownPreviewToggle = isMarkdown ? (
+    <FormControlLabel
+      control={
+        <Switch
+          size="small"
+          checked={markdownPreview}
+          onChange={e => setMarkdownPreview(e.target.checked)}
+        />
+      }
+      label={
+        <Typography variant="caption" sx={{ whiteSpace: "nowrap" }}>
+          Preview
+        </Typography>
+      }
+      sx={{ mr: 0, ml: 0 }}
+    />
+  ) : null;
 
   const panelHeader = (
     <Box
@@ -973,7 +1006,7 @@ export default function DbtFileEditor({
     <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
       {/* Breadcrumb (workspace › Transforms › project › path). Compile is live
           and runs go through the command bar, mirroring dbt Studio. */}
-      <EntityBreadcrumbs tabId={tabId} />
+      <EntityBreadcrumbs tabId={tabId} trailing={markdownPreviewToggle} />
 
       <Box sx={{ flex: 1, minHeight: 0 }}>
         {panelOpen ? (

--- a/app/src/lib/dbt-editor-logic.test.ts
+++ b/app/src/lib/dbt-editor-logic.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   extractFilePath,
+  isMarkdownDbtPath,
   languageForDbtPath,
   logsToProblems,
   modelNameForPath,
@@ -63,6 +64,15 @@ describe("languageForDbtPath", () => {
     expect(languageForDbtPath("models/schema.yaml")).toBe("yaml");
     expect(languageForDbtPath("README.md")).toBe("markdown");
     expect(languageForDbtPath("Makefile")).toBe("plaintext");
+  });
+});
+
+describe("isMarkdownDbtPath", () => {
+  it("detects markdown files case-insensitively", () => {
+    expect(isMarkdownDbtPath("models/README.md")).toBe(true);
+    expect(isMarkdownDbtPath("docs/overview.MARKDOWN")).toBe(true);
+    expect(isMarkdownDbtPath("models/a.sql")).toBe(false);
+    expect(isMarkdownDbtPath("models/schema.yml")).toBe(false);
   });
 });
 

--- a/app/src/lib/dbt-editor-logic.ts
+++ b/app/src/lib/dbt-editor-logic.ts
@@ -39,8 +39,14 @@ export function logsToProblems(logs: DbtRunLogLine[]): Problem[] {
 export function languageForDbtPath(path: string): string {
   if (path.endsWith(".sql")) return DBT_JINJA_LANGUAGE_ID;
   if (path.endsWith(".yml") || path.endsWith(".yaml")) return "yaml";
-  if (path.endsWith(".md")) return "markdown";
+  if (isMarkdownDbtPath(path)) return "markdown";
   return "plaintext";
+}
+
+/** True for dbt docs files that can be rendered as markdown (.md / .markdown). */
+export function isMarkdownDbtPath(path: string): boolean {
+  const lower = path.toLowerCase();
+  return lower.endsWith(".md") || lower.endsWith(".markdown");
 }
 
 /** Model names (basename without .sql) under models/ for ref() completions. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a rendered **Markdown viewer** to the dbt file editor, toggled by a **Preview switch** in the tab header (breadcrumb bar). When a `.md` / `.markdown` file is open, it renders formatted markdown by default; flip the switch off to edit the raw source in Monaco.

## Why

dbt docs (`README.md`, model docs) were only viewable as raw source in Monaco. A preview makes them readable without leaving the editor.

## Changes

- `app/src/lib/dbt-editor-logic.ts`: new `isMarkdownDbtPath()` helper (`.md`/`.markdown`, case-insensitive); `languageForDbtPath` reuses it.
- `app/src/components/DbtFileEditor.tsx`:
  - `markdownPreview` state (default on for markdown files).
  - MUI `Switch` labeled "Preview" placed in the `EntityBreadcrumbs` `trailing` slot, shown only for markdown files.
  - Editor pane swaps between `StreamingMarkdown` (rendered) and Monaco (raw, with word-wrap for markdown).
- Tests: `isMarkdownDbtPath` unit tests + a `DbtFileEditor` test asserting the preview renders by default and the switch flips back to the editor.

## Testing

- `pnpm --filter app exec vitest run` (dbt editor logic + component) — pass
- `pnpm --filter app run typecheck` — pass
- `pnpm --filter app run lint` — pass
- Manual UI test (see walkthrough).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c175e35-cd57-4500-bb6b-baaf8ae56f0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c175e35-cd57-4500-bb6b-baaf8ae56f0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

