### PR TITLE
feat(dbt): PR update/close tools + Pull requests dialog in the IDE

### DIFF
--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -51,17 +51,20 @@ import {
   parseDbtCommands,
 } from "../../dbt/commands";
 import {
+  closeProjectPullRequest,
   commitAndPush,
   commitToNewBranch,
   createProjectBranch,
   deleteProjectBranch,
   getGitStatus,
   listProjectBranches,
+  listProjectPullRequests,
   listRecoverableFiles,
   mergeProjectPullRequest,
   openProjectPullRequest,
   restoreDeletedFile,
   switchProjectBranch,
+  updateProjectPullRequest,
 } from "../../dbt/dbt-github-git.service";
 import { syncProjectBranchFromRepo } from "../../dbt/dbt-github-sync.service";
 import {
@@ -1772,6 +1775,154 @@ export const createDbtServerTools = (
           };
         } catch (error) {
           return toolError(error, "Failed to merge pull request");
+        }
+      },
+    }),
+
+    dbt_list_pull_requests: tool({
+      description:
+        "List the pull requests of the project's connected repository " +
+        "(defaults to open PRs; pass state to include closed/merged ones). " +
+        "Returns number, title, state, merged flag, head/base branches, and " +
+        "URL for each PR. Use to find a PR number before " +
+        "dbt_update_pull_request, dbt_close_pull_request, or " +
+        "dbt_merge_pull_request, or to report PR status to the user.",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        state: z
+          .enum(["open", "closed", "all"])
+          .optional()
+          .describe('Which PRs to list; defaults to "open"'),
+      }),
+      execute: async ({ projectId, state }) => {
+        try {
+          const project = await assertRepoProject(projectId);
+          const pullRequests = await listProjectPullRequests(project, {
+            state,
+          });
+          return {
+            success: true,
+            // Bodies can be huge (up to 10k chars each) — truncate so a long
+            // PR list doesn't blow up the chat context.
+            pullRequests: pullRequests.map(pr => ({
+              ...pr,
+              body:
+                pr.body.length > 500 ? `${pr.body.slice(0, 500)}…` : pr.body,
+            })),
+          };
+        } catch (error) {
+          return toolError(error, "Failed to list pull requests");
+        }
+      },
+    }),
+
+    dbt_update_pull_request: tool({
+      description:
+        "Update an open GitHub pull request's title, description, and/or base " +
+        "branch. Provide at least one field. Use when the user wants to " +
+        "retitle a PR, rewrite its description, or retarget it at a different " +
+        "base branch. Returns the updated PR summary.",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        prNumber: z
+          .number()
+          .int()
+          .positive()
+          .describe("Pull request number (see dbt_list_pull_requests)"),
+        title: z
+          .string()
+          .min(1)
+          .max(255)
+          .optional()
+          .describe("New pull request title"),
+        body: z
+          .string()
+          .max(10_000)
+          .optional()
+          .describe("New pull request description (Markdown)"),
+        base: z
+          .string()
+          .min(1)
+          .max(255)
+          .optional()
+          .describe("New base branch to retarget the PR at"),
+      }),
+      execute: async ({ projectId, prNumber, title, body, base }) => {
+        try {
+          const project = await assertRepoProject(projectId);
+          // Editing a PR is repo-level administration (like merge/close) —
+          // gate on the admin/owner role, mirroring the HTTP route RBAC.
+          if (userId && !(await workspaceService.isAdmin(workspaceId, userId))) {
+            return {
+              success: false,
+              error:
+                "Updating a pull request requires the admin or owner " +
+                "workspace role. Ask a workspace admin to update it.",
+            };
+          }
+          const pr = await updateProjectPullRequest(project, {
+            prNumber,
+            title: title?.trim(),
+            body,
+            base,
+          });
+          return { success: true, pr };
+        } catch (error) {
+          return toolError(error, "Failed to update pull request");
+        }
+      },
+    }),
+
+    dbt_close_pull_request: tool({
+      description:
+        "Close a GitHub pull request WITHOUT merging it — use when the user " +
+        "wants to abandon or withdraw a PR. Optionally delete its source " +
+        "branch (defaults to false so the work is preserved; it refuses to " +
+        "delete the project default branch or any branch a user has checked " +
+        "out). To land a PR's changes instead, use dbt_merge_pull_request. " +
+        "ONLY call after the user confirms the PR number.",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        prNumber: z
+          .number()
+          .int()
+          .positive()
+          .describe("Pull request number (see dbt_list_pull_requests)"),
+        deleteBranch: z
+          .boolean()
+          .optional()
+          .describe(
+            "Also delete the PR's source branch; defaults to false",
+          ),
+      }),
+      execute: async ({ projectId, prNumber, deleteBranch }) => {
+        try {
+          const project = await assertRepoProject(projectId);
+          // Closing a PR is repo-level administration (like merge) — gate on
+          // the admin/owner role, mirroring the HTTP route RBAC.
+          if (userId && !(await workspaceService.isAdmin(workspaceId, userId))) {
+            return {
+              success: false,
+              error:
+                "Closing a pull request requires the admin or owner " +
+                "workspace role. Ask a workspace admin to close it.",
+            };
+          }
+          const result = await closeProjectPullRequest(project, {
+            prNumber,
+            deleteBranch,
+          });
+          if (result.branchDeleted) publishGitUpdated(projectId);
+          return {
+            success: true,
+            pr: result.pr,
+            branchDeleted: result.branchDeleted,
+            ...(result.branchDeleteWarning
+              ? { branchDeleteWarning: result.branchDeleteWarning }
+              : {}),
+          };
+        } catch (error) {
+          return toolError(error, "Failed to close pull request");
         }
       },
     }),

--- a/api/src/agents/dbt/prompt.ts
+++ b/api/src/agents/dbt/prompt.ts
@@ -34,7 +34,10 @@ runs execute against the project's warehouse environments (dev/prod).
    branch. Then \`dbt_open_pull_request\`; when the user asks to promote/merge, call
    \`dbt_merge_pull_request\` with the PR number to merge on GitHub, delete the feature branch,
    and sync the default branch into the working tree; it refuses before merging when there are
-   uncommitted working-tree changes. If a build runs against a stale checkout (fewer models/sources
+   uncommitted working-tree changes. Use \`dbt_list_pull_requests\` to look up PR numbers and
+   status, \`dbt_update_pull_request\` to retitle/redescribe/retarget an open PR, and
+   \`dbt_close_pull_request\` to abandon a PR without merging (only after the user confirms).
+   If a build runs against a stale checkout (fewer models/sources
    than the branch has, e.g. a merged PR not yet picked up), call
    \`dbt_sync_from_repo\` to re-pull the tracked branch. Clean up merged/stray branches with
    \`dbt_delete_branch\`.

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -176,8 +176,11 @@ changes on a NEW branch for review, use \`dbt_commit_to_branch\` (atomic branch+
 strand the changes on the wrong branch. Then \`dbt_open_pull_request\`; when the user asks to
 promote/merge, call \`dbt_merge_pull_request\` with the PR number to merge on GitHub, delete the
 feature branch, and sync the default branch into the working tree; it refuses before merging when
-there are uncommitted working-tree changes. If a run builds from a stale checkout (fewer
-models/sources than the branch actually has, e.g. a merged PR not picked up), call
+there are uncommitted working-tree changes. Use \`dbt_list_pull_requests\` to look up PR numbers
+and status, \`dbt_update_pull_request\` to retitle/redescribe/retarget an open PR, and
+\`dbt_close_pull_request\` to abandon a PR without merging (only after the user confirms). If a run
+builds from a stale checkout (fewer models/sources than the branch actually has, e.g. a merged PR
+not picked up), call
 \`dbt_sync_from_repo\` to re-pull the tracked branch. Use \`dbt_delete_branch\` to clean up merged or
 stray branches. Switching branches OVERWRITES the working tree: \`dbt_switch_branch\` refuses when
 there are uncommitted changes — commit them first, or pass \`discardLocalChanges\` only after the

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -36,8 +36,10 @@ based on what the user is currently looking at — you can switch or add modes a
   bindings. Enable ONLY when the user explicitly mentions building an app, a React app, a
   page/screen/component, installing a library, or references something visible in the active app.
 - \`transform\` — build and run dbt transformations: edit dbt project files (models, schema.yml,
-  sources), compile, test, and run models/jobs against the warehouse. Enable when the user
-  mentions dbt, transforms, models, staging/marts, \`ref()\`/\`source()\`, or running a dbt job.
+  sources), compile, test, and run models/jobs against the warehouse. Also manage the dbt
+  project's Git repo and GitHub pull requests (commit, branch, open/list/update/merge/close PRs).
+  Enable when the user mentions dbt, transforms, models, staging/marts, \`ref()\`/\`source()\`,
+  running a dbt job, or the project's branches / pull requests.
 - \`explore\` — read-only research across connections, consoles, dashboards, and memory. Enable
   when you need to investigate before committing to an action.
 

--- a/api/src/agents/modes/registry.ts
+++ b/api/src/agents/modes/registry.ts
@@ -286,7 +286,8 @@ export const modeRegistry: Record<ExpertiseModeId, AgentMode> = {
     id: "transform",
     name: "Transforms",
     routingPrompt:
-      "Build and run dbt transformations: edit project files, compile, test, and run models against the warehouse.",
+      "Build and run dbt transformations: edit project files, compile, test, and run models against the warehouse. " +
+      "Also manage the project's Git repo and GitHub pull requests: commit, branch, and open/list/update/merge/close PRs.",
     systemPrompt: TRANSFORM_MODE_SYSTEM_PROMPT,
     toolNames: TRANSFORM_MODE_TOOL_NAMES,
     trajectories: [

--- a/api/src/agents/modes/registry.ts
+++ b/api/src/agents/modes/registry.ts
@@ -192,6 +192,9 @@ const TRANSFORM_MODE_TOOL_NAMES: string[] = [
   "dbt_delete_branch",
   "dbt_open_pull_request",
   "dbt_merge_pull_request",
+  "dbt_list_pull_requests",
+  "dbt_update_pull_request",
+  "dbt_close_pull_request",
   // Recovery: surface + restore work hidden by a destructive switch/sync.
   "dbt_list_recoverable_files",
   "dbt_restore_file",

--- a/api/src/dbt/dbt-github-git.service.ts
+++ b/api/src/dbt/dbt-github-git.service.ts
@@ -33,9 +33,12 @@ import {
   getRepoInfo,
   getRepoTree,
   listBranches,
+  listPullRequests,
   mergePullRequest,
   tryDeleteBranch,
+  updatePullRequest,
   type MergeMethod,
+  type PullRequestSummary,
   type TreeChange,
 } from "../integrations/github/github-api";
 import { syncProjectBranchFromRepo } from "./dbt-github-sync.service";
@@ -800,6 +803,132 @@ export async function openProjectPullRequest(
     { title: params.title, head: branch, base, body: params.body },
     token,
   );
+}
+
+/**
+ * List the repository's pull requests (newest first). Purely a GitHub read —
+ * no git lock needed. `state` defaults to "open".
+ */
+export async function listProjectPullRequests(
+  project: IDbtProject,
+  params: { state?: "open" | "closed" | "all" } = {},
+): Promise<PullRequestSummary[]> {
+  if (!project.repo) {
+    throw new Error("Project is not connected to a repository");
+  }
+  const token = await resolveRepoToken(project.repo.installationId);
+  return listPullRequests(
+    project.repo.owner,
+    project.repo.repo,
+    { state: params.state ?? "open" },
+    token,
+  );
+}
+
+/**
+ * Update a pull request's title, body, and/or base branch. At least one field
+ * must be provided. Works on open PRs only — closed/merged PRs are immutable
+ * from Mako to avoid confusing GitHub history rewrites.
+ */
+export async function updateProjectPullRequest(
+  project: IDbtProject,
+  params: { prNumber: number; title?: string; body?: string; base?: string },
+): Promise<PullRequestSummary> {
+  if (!project.repo) {
+    throw new Error("Project is not connected to a repository");
+  }
+  if (
+    params.title === undefined &&
+    params.body === undefined &&
+    params.base === undefined
+  ) {
+    throw new Error(
+      "Nothing to update — provide at least one of title, body, or base",
+    );
+  }
+  const token = await resolveRepoToken(project.repo.installationId);
+  const { owner, repo } = project.repo;
+  const pr = await getPullRequest(owner, repo, params.prNumber, token);
+  if (pr.state !== "open") {
+    throw new Error(
+      `Pull request #${params.prNumber} is ${pr.state} — only open PRs can be updated`,
+    );
+  }
+  return updatePullRequest(
+    owner,
+    repo,
+    params.prNumber,
+    { title: params.title, body: params.body, base: params.base },
+    token,
+  );
+}
+
+export interface ClosePullRequestResult {
+  pr: PullRequestSummary;
+  branchDeleted: boolean;
+  branchDeleteWarning?: string;
+}
+
+/**
+ * Close a pull request WITHOUT merging it. Optionally delete its head branch
+ * afterwards (default false — closing shouldn't destroy the work). Branch
+ * deletion refuses when the branch is the project default or any user has it
+ * checked out; a deleted branch's local base tree is cleaned up.
+ */
+export async function closeProjectPullRequest(
+  project: IDbtProject,
+  params: { prNumber: number; deleteBranch?: boolean },
+): Promise<ClosePullRequestResult> {
+  return withProjectGitLock(project._id.toString(), async () => {
+    const fresh = await reloadRepoProject(project);
+    const token = await resolveRepoToken(fresh.repo.installationId);
+    const { owner, repo } = fresh.repo;
+
+    const existing = await getPullRequest(owner, repo, params.prNumber, token);
+    if (existing.state !== "open") {
+      throw new Error(
+        `Pull request #${params.prNumber} is already ${existing.state}`,
+      );
+    }
+
+    const pr = await updatePullRequest(
+      owner,
+      repo,
+      params.prNumber,
+      { state: "closed" },
+      token,
+    );
+
+    let branchDeleted = false;
+    let branchDeleteWarning: string | undefined;
+    if (params.deleteBranch) {
+      const headRef = existing.headRef;
+      const checkout = await DbtCheckout.findOne({
+        projectId: fresh._id,
+        branch: headRef,
+      })
+        .select("userId")
+        .lean();
+      if (headRef === fresh.repo.branch) {
+        branchDeleteWarning =
+          `Branch "${headRef}" was not deleted — it is the project's ` +
+          "default branch.";
+      } else if (checkout) {
+        branchDeleteWarning =
+          `Branch "${headRef}" was not deleted — a user has it checked out. ` +
+          "Delete it with dbt_delete_branch after they switch away.";
+      } else {
+        const deleteResult = await tryDeleteBranch(owner, repo, headRef, token);
+        branchDeleted = deleteResult.deleted;
+        branchDeleteWarning = deleteResult.warning;
+        if (branchDeleted) {
+          await deleteBranchBaseTree(fresh, headRef);
+        }
+      }
+    }
+
+    return { pr, branchDeleted, branchDeleteWarning };
+  });
 }
 
 export interface MergePullRequestResult {

--- a/api/src/dbt/rbac.test.ts
+++ b/api/src/dbt/rbac.test.ts
@@ -46,6 +46,10 @@ describe("resolveDbtAccess", () => {
       { method: "DELETE", path: `${WS}/projects/abc/jobs/j1` },
       // Merging a PR is the only write path into protected branches.
       { method: "POST", path: `${WS}/projects/abc/git/merge-pull-request` },
+      // Editing/closing PRs is repo-level administration, not own-checkout
+      // work — admin+ like merge.
+      { method: "PATCH", path: `${WS}/projects/abc/git/pull-request/12` },
+      { method: "POST", path: `${WS}/projects/abc/git/pull-request/12/close` },
     ];
 
     it.each(adminOnlyCases)(

--- a/api/src/dbt/rbac.ts
+++ b/api/src/dbt/rbac.ts
@@ -40,6 +40,14 @@ export const DBT_ADMIN_ONLY: Array<{ method: string; pattern: RegExp }> = [
     method: "POST",
     pattern: /\/dbt\/projects\/[^/]+\/git\/merge-pull-request$/,
   },
+  {
+    method: "PATCH",
+    pattern: /\/dbt\/projects\/[^/]+\/git\/pull-request\/\d+$/,
+  },
+  {
+    method: "POST",
+    pattern: /\/dbt\/projects\/[^/]+\/git\/pull-request\/\d+\/close$/,
+  },
 ];
 
 export interface DbtAccessDecision {

--- a/api/src/integrations/github/github-api.ts
+++ b/api/src/integrations/github/github-api.ts
@@ -457,6 +457,104 @@ export interface PullRequestInfo {
   state: string;
 }
 
+export interface PullRequestSummary {
+  number: number;
+  title: string;
+  /** "open" or "closed" (merged PRs are "closed" with `merged: true`). */
+  state: string;
+  merged: boolean;
+  draft: boolean;
+  headRef: string;
+  baseRef: string;
+  htmlUrl: string;
+  author?: string;
+  body: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface RawPullRequest {
+  number: number;
+  title: string;
+  state: string;
+  merged_at: string | null;
+  draft?: boolean;
+  head: { ref: string };
+  base: { ref: string };
+  html_url: string;
+  user?: { login: string } | null;
+  body: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+function toPullRequestSummary(json: RawPullRequest): PullRequestSummary {
+  return {
+    number: json.number,
+    title: json.title,
+    state: json.state,
+    merged: json.merged_at !== null,
+    draft: json.draft ?? false,
+    headRef: json.head.ref,
+    baseRef: json.base.ref,
+    htmlUrl: json.html_url,
+    author: json.user?.login,
+    body: json.body ?? "",
+    createdAt: json.created_at,
+    updatedAt: json.updated_at,
+  };
+}
+
+/** Pull requests of a repo, newest first (paginated up to ~1000). */
+export async function listPullRequests(
+  owner: string,
+  repo: string,
+  params: { state: "open" | "closed" | "all" },
+  token?: string,
+): Promise<PullRequestSummary[]> {
+  const prs: PullRequestSummary[] = [];
+  for (let page = 1; page <= 10; page++) {
+    const res = await ghFetch(
+      `/repos/${owner}/${repo}/pulls?state=${params.state}&sort=created&direction=desc&per_page=100&page=${page}`,
+      token,
+    );
+    const json = (await res.json()) as RawPullRequest[];
+    prs.push(...json.map(toPullRequestSummary));
+    if (json.length < 100) break;
+  }
+  return prs;
+}
+
+/**
+ * Update a pull request's title, body, base branch, and/or state. Passing
+ * `state: "closed"` closes the PR without merging; `state: "open"` reopens it.
+ */
+export async function updatePullRequest(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  params: {
+    title?: string;
+    body?: string;
+    base?: string;
+    state?: "open" | "closed";
+  },
+  token?: string,
+): Promise<PullRequestSummary> {
+  const body: Record<string, unknown> = {};
+  if (params.title !== undefined) body.title = params.title;
+  if (params.body !== undefined) body.body = params.body;
+  if (params.base !== undefined) body.base = params.base;
+  if (params.state !== undefined) body.state = params.state;
+  const res = await ghFetch(
+    `/repos/${owner}/${repo}/pulls/${prNumber}`,
+    token,
+    { method: "PATCH", body },
+  );
+  const json = (await res.json()) as RawPullRequest;
+  return toPullRequestSummary(json);
+}
+
 export async function getPullRequest(
   owner: string,
   repo: string,

--- a/api/src/integrations/github/github-api.ts
+++ b/api/src/integrations/github/github-api.ts
@@ -8,9 +8,12 @@
 /**
  * Overridable for local development / testing against a GitHub API emulator
  * (see api/src/dbt/test-support/fake-github-server.mjs). Real deployments
- * leave this unset.
+ * leave this unset. Read lazily so dotenv (loaded in index.ts) has run
+ * before the first request.
  */
-const GITHUB_API = process.env.GITHUB_API_BASE_URL ?? "https://api.github.com";
+function githubApiBase(): string {
+  return process.env.GITHUB_API_BASE_URL ?? "https://api.github.com";
+}
 
 export interface GitHubRepoInfo {
   fullName: string;
@@ -52,7 +55,7 @@ async function ghFetch(
 ): Promise<Response> {
   const headers = authHeaders(token);
   if (init?.body !== undefined) headers["Content-Type"] = "application/json";
-  const res = await fetch(`${GITHUB_API}${path}`, {
+  const res = await fetch(`${githubApiBase()}${path}`, {
     method: init?.method ?? "GET",
     headers,
     body: init?.body !== undefined ? JSON.stringify(init.body) : undefined,
@@ -119,7 +122,7 @@ export async function fileExistsAtRef(
 ): Promise<boolean> {
   const encoded = encodeRepoPath(path);
   const res = await fetch(
-    `${GITHUB_API}/repos/${owner}/${repo}/contents/${encoded}?ref=${encodeURIComponent(ref)}`,
+    `${githubApiBase()}/repos/${owner}/${repo}/contents/${encoded}?ref=${encodeURIComponent(ref)}`,
     { headers: authHeaders(token) },
   );
   return res.ok;
@@ -601,7 +604,7 @@ export async function mergePullRequest(
   const headers = authHeaders(token);
   headers["Content-Type"] = "application/json";
   const res = await fetch(
-    `${GITHUB_API}/repos/${owner}/${repo}/pulls/${prNumber}/merge`,
+    `${githubApiBase()}/repos/${owner}/${repo}/pulls/${prNumber}/merge`,
     {
       method: "PUT",
       headers,

--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -47,6 +47,7 @@ import {
   syncProjectBranchFromRepo,
 } from "../dbt/dbt-github-sync.service";
 import {
+  closeProjectPullRequest,
   commitAndPush,
   commitToNewBranch,
   createProjectBranch,
@@ -54,10 +55,12 @@ import {
   getGitStatus,
   getProjectFileDiff,
   listProjectBranches,
+  listProjectPullRequests,
   mergeProjectPullRequest,
   openProjectPullRequest,
   ProtectedBranchError,
   switchProjectBranch,
+  updateProjectPullRequest,
 } from "../dbt/dbt-github-git.service";
 import {
   deleteWorkingFile,
@@ -880,6 +883,25 @@ const pullRequestSchema = z.object({
   body: z.string().max(10_000).optional(),
   base: z.string().min(1).max(255).optional(),
 });
+const updatePullRequestSchema = z
+  .object({
+    title: z.string().min(1).max(255).optional(),
+    body: z.string().max(10_000).optional(),
+    base: z.string().min(1).max(255).optional(),
+  })
+  .refine(
+    data =>
+      data.title !== undefined ||
+      data.body !== undefined ||
+      data.base !== undefined,
+    { message: "Provide at least one of title, body, or base" },
+  );
+const closePullRequestSchema = z.object({
+  deleteBranch: z.boolean().optional(),
+});
+const listPullRequestsQuerySchema = z
+  .enum(["open", "closed", "all"])
+  .default("open");
 
 // GET /projects/:projectId/git/status — the CALLER's working-tree diff (their
 // drafts vs the committed base of their checked-out branch).
@@ -1242,6 +1264,106 @@ dbtRoutes.post(
       return c.json({ success: true, ...result });
     } catch (error) {
       return serverError(c, error, "Failed to merge pull request");
+    }
+  },
+);
+
+function parsePrNumber(raw: string | undefined): number | null {
+  if (!raw || !/^\d+$/.test(raw)) return null;
+  const num = Number(raw);
+  return num > 0 ? num : null;
+}
+
+// GET /projects/:projectId/git/pull-requests?state=open|closed|all — list the
+// repo's PRs (newest first).
+dbtRoutes.get(
+  "/projects/:projectId/git/pull-requests",
+  async (c: AuthenticatedContext) => {
+    try {
+      const project = await findProject(c);
+      if (!project) {
+        return c.json({ success: false, error: "dbt project not found" }, 404);
+      }
+      if (!project.repo) {
+        return badRequest(c, "Project is not connected to a repository");
+      }
+      const parsed = listPullRequestsQuerySchema.safeParse(
+        c.req.query("state") ?? undefined,
+      );
+      if (!parsed.success) {
+        return badRequest(c, "state must be one of open, closed, all");
+      }
+      const pullRequests = await listProjectPullRequests(project, {
+        state: parsed.data,
+      });
+      return c.json({ success: true, pullRequests });
+    } catch (error) {
+      return serverError(c, error, "Failed to list pull requests");
+    }
+  },
+);
+
+// PATCH /projects/:projectId/git/pull-request/:number — update an open PR's
+// title/body/base.
+dbtRoutes.patch(
+  "/projects/:projectId/git/pull-request/:number",
+  async (c: AuthenticatedContext) => {
+    try {
+      const project = await findProject(c);
+      if (!project) {
+        return c.json({ success: false, error: "dbt project not found" }, 404);
+      }
+      if (!project.repo) {
+        return badRequest(c, "Project is not connected to a repository");
+      }
+      const prNumber = parsePrNumber(c.req.param("number"));
+      if (!prNumber) {
+        return badRequest(c, "Invalid pull request number");
+      }
+      const parsed = updatePullRequestSchema.safeParse(await c.req.json());
+      if (!parsed.success) {
+        return badRequest(c, parsed.error.issues[0]?.message ?? "Invalid body");
+      }
+      const pr = await updateProjectPullRequest(project, {
+        prNumber,
+        ...parsed.data,
+      });
+      return c.json({ success: true, pr });
+    } catch (error) {
+      return serverError(c, error, "Failed to update pull request");
+    }
+  },
+);
+
+// POST /projects/:projectId/git/pull-request/:number/close — close a PR
+// without merging, optionally deleting its source branch.
+dbtRoutes.post(
+  "/projects/:projectId/git/pull-request/:number/close",
+  async (c: AuthenticatedContext) => {
+    try {
+      const project = await findProject(c);
+      if (!project) {
+        return c.json({ success: false, error: "dbt project not found" }, 404);
+      }
+      if (!project.repo) {
+        return badRequest(c, "Project is not connected to a repository");
+      }
+      const prNumber = parsePrNumber(c.req.param("number"));
+      if (!prNumber) {
+        return badRequest(c, "Invalid pull request number");
+      }
+      const body = await c.req.json().catch(() => ({}));
+      const parsed = closePullRequestSchema.safeParse(body);
+      if (!parsed.success) {
+        return badRequest(c, parsed.error.issues[0]?.message ?? "Invalid body");
+      }
+      const result = await closeProjectPullRequest(project, {
+        prNumber,
+        deleteBranch: parsed.data.deleteBranch,
+      });
+      return c.json({ success: true, ...result });
+    } catch (error) {
+      return serverError(c, error, "Failed to close pull request");
     }
   },
 );

--- a/app/src/agent-runtime/client-tool-manifest.ts
+++ b/app/src/agent-runtime/client-tool-manifest.ts
@@ -860,6 +860,35 @@ export const AGENT_TOOL_MANIFEST = {
     },
     icon: "external-link",
   },
+  dbt_list_pull_requests: {
+    domain: "dbt",
+    execution: "server",
+    getLabel: input => {
+      const state = (input as Record<string, unknown>)?.state;
+      return state && state !== "open"
+        ? `Listing ${state} pull requests`
+        : "Listing pull requests";
+    },
+    icon: "list",
+  },
+  dbt_update_pull_request: {
+    domain: "dbt",
+    execution: "server",
+    getLabel: input => {
+      const prNumber = (input as Record<string, unknown>)?.prNumber;
+      return prNumber ? `Updating PR #${prNumber}` : "Updating pull request";
+    },
+    icon: "external-link",
+  },
+  dbt_close_pull_request: {
+    domain: "dbt",
+    execution: "server",
+    getLabel: input => {
+      const prNumber = (input as Record<string, unknown>)?.prNumber;
+      return prNumber ? `Closing PR #${prNumber}` : "Closing pull request";
+    },
+    icon: "external-link",
+  },
   search_consoles: {
     domain: "search",
     execution: "server",

--- a/app/src/components/DbtExplorer.tsx
+++ b/app/src/components/DbtExplorer.tsx
@@ -29,6 +29,7 @@ import {
   Chip,
   CircularProgress,
   Divider,
+  Link,
   Snackbar,
   Alert,
   useTheme,
@@ -52,6 +53,8 @@ import {
   DownloadCloud as SyncIcon,
   GitCommitHorizontal as CommitIcon,
   GitPullRequest as PullRequestIcon,
+  GitPullRequestClosed as PullRequestClosedIcon,
+  GitMerge as MergedIcon,
   GitBranchPlus as NewBranchIcon,
   ArrowLeftRight as SwitchBranchIcon,
   ChevronDown as ChevronDownIcon,
@@ -68,6 +71,7 @@ import {
   useDbtStore,
   type DbtJobItem,
   type GitFileDiff,
+  type PullRequestItem,
 } from "../store/dbtStore";
 import {
   focusDbtConsoleTab,
@@ -313,7 +317,8 @@ const STATUS_META = {
 export function DbtExplorer() {
   const { currentWorkspace } = useWorkspace();
   const workspaceId = currentWorkspace?.id;
-  const monacoTheme = useTheme().palette.mode === "dark" ? "vs-dark" : "vs";
+  const theme = useTheme();
+  const monacoTheme = theme.palette.mode === "dark" ? "vs-dark" : "vs";
 
   const projects = useDbtStore(s => s.projects);
   const projectsLoaded = useDbtStore(s => s.projectsLoaded);
@@ -342,6 +347,9 @@ export function DbtExplorer() {
   const createBranch = useDbtStore(s => s.createBranch);
   const switchBranch = useDbtStore(s => s.switchBranch);
   const openPullRequest = useDbtStore(s => s.openPullRequest);
+  const listPullRequests = useDbtStore(s => s.listPullRequests);
+  const updatePullRequest = useDbtStore(s => s.updatePullRequest);
+  const closePullRequest = useDbtStore(s => s.closePullRequest);
   const createFile = useDbtStore(s => s.createFile);
   const deleteFile = useDbtStore(s => s.deleteFile);
   const renameFile = useDbtStore(s => s.renameFile);
@@ -401,6 +409,17 @@ export function DbtExplorer() {
   const [prTarget, setPrTarget] = useState<string | null>(null);
   const [prTitle, setPrTitle] = useState("");
   const [prBody, setPrBody] = useState("");
+  // Pull requests list dialog
+  const [prListTarget, setPrListTarget] = useState<string | null>(null);
+  const [prList, setPrList] = useState<PullRequestItem[] | null>(null);
+  const [prListState, setPrListState] = useState<"open" | "all">("open");
+  const [prEdit, setPrEdit] = useState<{
+    number: number;
+    title: string;
+    body: string;
+  } | null>(null);
+  const [prCloseConfirm, setPrCloseConfirm] = useState<number | null>(null);
+  const [prBusy, setPrBusy] = useState(false);
   const [newFileTarget, setNewFileTarget] = useState<{
     projectId: string;
     dir: string;
@@ -841,6 +860,86 @@ export function DbtExplorer() {
     }
   }, [workspaceId, prTarget, prTitle, prBody, openPullRequest]);
 
+  const refreshPrList = useCallback(
+    async (projectId: string, state: "open" | "all") => {
+      if (!workspaceId) return;
+      setPrList(null);
+      const result = await listPullRequests(workspaceId, projectId, state);
+      setPrList(result ?? []);
+    },
+    [workspaceId, listPullRequests],
+  );
+
+  const openPrListDialog = useCallback(
+    (projectId: string) => {
+      setPrListTarget(projectId);
+      setPrEdit(null);
+      setPrCloseConfirm(null);
+      setPrListState("open");
+      void refreshPrList(projectId, "open");
+    },
+    [refreshPrList],
+  );
+
+  const handlePrStateFilterChange = useCallback(
+    (state: "open" | "all") => {
+      setPrListState(state);
+      if (prListTarget) void refreshPrList(prListTarget, state);
+    },
+    [prListTarget, refreshPrList],
+  );
+
+  const handleUpdatePullRequest = useCallback(async () => {
+    if (!workspaceId || !prListTarget || !prEdit || !prEdit.title.trim()) {
+      return;
+    }
+    setPrBusy(true);
+    const updated = await updatePullRequest(
+      workspaceId,
+      prListTarget,
+      prEdit.number,
+      { title: prEdit.title.trim(), body: prEdit.body },
+    );
+    setPrBusy(false);
+    if (updated) {
+      setPrEdit(null);
+      setSyncSnack({
+        severity: "success",
+        message: `PR #${updated.number} updated`,
+      });
+      void refreshPrList(prListTarget, prListState);
+    }
+  }, [
+    workspaceId,
+    prListTarget,
+    prEdit,
+    prListState,
+    updatePullRequest,
+    refreshPrList,
+  ]);
+
+  const handleClosePullRequest = useCallback(
+    async (prNumber: number) => {
+      if (!workspaceId || !prListTarget) return;
+      setPrBusy(true);
+      const closed = await closePullRequest(
+        workspaceId,
+        prListTarget,
+        prNumber,
+      );
+      setPrBusy(false);
+      setPrCloseConfirm(null);
+      if (closed) {
+        setSyncSnack({
+          severity: "success",
+          message: `PR #${closed.number} closed without merging`,
+        });
+        void refreshPrList(prListTarget, prListState);
+      }
+    },
+    [workspaceId, prListTarget, prListState, closePullRequest, refreshPrList],
+  );
+
   const getContextMenuItems = useCallback(
     (node: ResourceTreeNode, helpers: { closeMenu: () => void }) => {
       const parsed = parseNodeId(node.id);
@@ -1008,6 +1107,18 @@ export function DbtExplorer() {
               </ListItemIcon>
               Open pull request
             </MenuItem>,
+            <MenuItem
+              key="git-pr-list"
+              onClick={() => {
+                openPrListDialog(parsed.projectId);
+                helpers.closeMenu();
+              }}
+            >
+              <ListItemIcon>
+                <PullRequestIcon size={16} strokeWidth={1.5} />
+              </ListItemIcon>
+              Pull requests
+            </MenuItem>,
             <Divider key="git-divider" />,
           );
         }
@@ -1076,6 +1187,7 @@ export function DbtExplorer() {
       gitStatusByProject,
       openCommitDialog,
       openSwitchDialog,
+      openPrListDialog,
       handleNewJob,
     ],
   );
@@ -1353,8 +1465,20 @@ export function DbtExplorer() {
         </ListItemIcon>
         Open pull request
       </MenuItem>,
+      <MenuItem
+        key="pr-list"
+        onClick={() => {
+          openPrListDialog(projectId);
+          close();
+        }}
+      >
+        <ListItemIcon>
+          <PullRequestIcon size={16} strokeWidth={1.5} />
+        </ListItemIcon>
+        Pull requests
+      </MenuItem>,
     ],
-    [syncingProjectId, handleSyncProject, openSwitchDialog],
+    [syncingProjectId, handleSyncProject, openSwitchDialog, openPrListDialog],
   );
 
   const projectSelector = (
@@ -2437,6 +2561,324 @@ export function DbtExplorer() {
           >
             {gitBusy ? "Opening…" : "Open PR"}
           </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Pull requests list dialog (view / edit / close) */}
+      <Dialog
+        open={!!prListTarget}
+        onClose={() => setPrListTarget(null)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 1,
+          }}
+        >
+          Pull requests
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+            <FormControl size="small" sx={{ minWidth: 90 }}>
+              <Select
+                value={prListState}
+                onChange={e =>
+                  handlePrStateFilterChange(e.target.value as "open" | "all")
+                }
+              >
+                <MenuItem value="open">Open</MenuItem>
+                <MenuItem value="all">All</MenuItem>
+              </Select>
+            </FormControl>
+            <Tooltip title="Refresh">
+              <IconButton
+                size="small"
+                onClick={() => {
+                  if (prListTarget) {
+                    void refreshPrList(prListTarget, prListState);
+                  }
+                }}
+              >
+                <RefreshIcon size={16} strokeWidth={2} />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        </DialogTitle>
+        <DialogContent dividers sx={{ p: 0, minHeight: 160 }}>
+          {prList === null ? (
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                py: 5,
+              }}
+            >
+              <CircularProgress size={20} />
+            </Box>
+          ) : prList.length === 0 ? (
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ px: 2.5, py: 4, textAlign: "center" }}
+            >
+              {prListState === "open"
+                ? "No open pull requests."
+                : "No pull requests."}
+            </Typography>
+          ) : (
+            prList.map(pr => {
+              const isEditing = prEdit?.number === pr.number;
+              const isConfirmingClose = prCloseConfirm === pr.number;
+              return (
+                <Box
+                  key={pr.number}
+                  sx={{
+                    px: 2,
+                    py: 1.25,
+                    borderBottom: 1,
+                    borderColor: "divider",
+                    "&:last-of-type": { borderBottom: 0 },
+                  }}
+                >
+                  <Box
+                    sx={{ display: "flex", alignItems: "flex-start", gap: 1 }}
+                  >
+                    <Box sx={{ mt: 0.25, flexShrink: 0, display: "flex" }}>
+                      {pr.merged ? (
+                        <MergedIcon
+                          size={16}
+                          strokeWidth={2}
+                          color={theme.palette.secondary.main}
+                        />
+                      ) : pr.state === "open" ? (
+                        <PullRequestIcon
+                          size={16}
+                          strokeWidth={2}
+                          color={theme.palette.success.main}
+                        />
+                      ) : (
+                        <PullRequestClosedIcon
+                          size={16}
+                          strokeWidth={2}
+                          color={theme.palette.error.main}
+                        />
+                      )}
+                    </Box>
+                    <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+                      <Link
+                        href={pr.htmlUrl}
+                        target="_blank"
+                        rel="noopener"
+                        underline="hover"
+                        color="text.primary"
+                        sx={{
+                          fontSize: "0.85rem",
+                          fontWeight: 500,
+                          display: "block",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        #{pr.number} {pr.title}
+                      </Link>
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{
+                          display: "block",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {pr.headRef} → {pr.baseRef}
+                        {pr.author ? ` · ${pr.author}` : ""}
+                        {" · "}
+                        {new Date(pr.updatedAt).toLocaleDateString()}
+                      </Typography>
+                    </Box>
+                    {pr.draft && (
+                      <Chip
+                        label="Draft"
+                        size="small"
+                        variant="outlined"
+                        sx={{ flexShrink: 0 }}
+                      />
+                    )}
+                    {pr.merged ? (
+                      <Chip
+                        label="Merged"
+                        size="small"
+                        color="secondary"
+                        variant="outlined"
+                        sx={{ flexShrink: 0 }}
+                      />
+                    ) : pr.state === "closed" ? (
+                      <Chip
+                        label="Closed"
+                        size="small"
+                        color="error"
+                        variant="outlined"
+                        sx={{ flexShrink: 0 }}
+                      />
+                    ) : (
+                      <Box
+                        sx={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 0.25,
+                          flexShrink: 0,
+                        }}
+                      >
+                        <Tooltip title="Edit title & description">
+                          <IconButton
+                            size="small"
+                            disabled={prBusy}
+                            onClick={() => {
+                              setPrCloseConfirm(null);
+                              setPrEdit(
+                                isEditing
+                                  ? null
+                                  : {
+                                      number: pr.number,
+                                      title: pr.title,
+                                      body: pr.body,
+                                    },
+                              );
+                            }}
+                          >
+                            <RenameIcon size={14} strokeWidth={1.75} />
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title="Close without merging">
+                          <IconButton
+                            size="small"
+                            disabled={prBusy}
+                            onClick={() => {
+                              setPrEdit(null);
+                              setPrCloseConfirm(
+                                isConfirmingClose ? null : pr.number,
+                              );
+                            }}
+                          >
+                            <PullRequestClosedIcon
+                              size={14}
+                              strokeWidth={1.75}
+                            />
+                          </IconButton>
+                        </Tooltip>
+                      </Box>
+                    )}
+                  </Box>
+                  {isEditing && (
+                    <Box sx={{ mt: 1.25, pl: 3 }}>
+                      <TextField
+                        autoFocus
+                        fullWidth
+                        size="small"
+                        label="Title"
+                        value={prEdit.title}
+                        onChange={e =>
+                          setPrEdit({ ...prEdit, title: e.target.value })
+                        }
+                        sx={{ mb: 1.5 }}
+                      />
+                      <TextField
+                        fullWidth
+                        multiline
+                        minRows={2}
+                        size="small"
+                        label="Description"
+                        value={prEdit.body}
+                        onChange={e =>
+                          setPrEdit({ ...prEdit, body: e.target.value })
+                        }
+                      />
+                      <Box
+                        sx={{
+                          display: "flex",
+                          justifyContent: "flex-end",
+                          gap: 1,
+                          mt: 1,
+                        }}
+                      >
+                        <Button size="small" onClick={() => setPrEdit(null)}>
+                          Cancel
+                        </Button>
+                        <Button
+                          size="small"
+                          variant="contained"
+                          onClick={handleUpdatePullRequest}
+                          disabled={prBusy || !prEdit.title.trim()}
+                          startIcon={
+                            prBusy ? <CircularProgress size={12} /> : undefined
+                          }
+                        >
+                          {prBusy ? "Saving…" : "Save"}
+                        </Button>
+                      </Box>
+                    </Box>
+                  )}
+                  {isConfirmingClose && (
+                    <Box
+                      sx={{
+                        mt: 1,
+                        pl: 3,
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "flex-end",
+                        gap: 1,
+                      }}
+                    >
+                      <Typography variant="caption" color="text.secondary">
+                        Close #{pr.number} without merging?
+                      </Typography>
+                      <Button
+                        size="small"
+                        onClick={() => setPrCloseConfirm(null)}
+                      >
+                        Cancel
+                      </Button>
+                      <Button
+                        size="small"
+                        color="error"
+                        variant="contained"
+                        onClick={() => void handleClosePullRequest(pr.number)}
+                        disabled={prBusy}
+                        startIcon={
+                          prBusy ? <CircularProgress size={12} /> : undefined
+                        }
+                      >
+                        {prBusy ? "Closing…" : "Close PR"}
+                      </Button>
+                    </Box>
+                  )}
+                </Box>
+              );
+            })
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button
+            startIcon={<PullRequestIcon size={15} strokeWidth={1.75} />}
+            onClick={() => {
+              const pid = prListTarget;
+              setPrListTarget(null);
+              if (pid) {
+                setPrTarget(pid);
+                setPrTitle("");
+                setPrBody("");
+              }
+            }}
+          >
+            New PR
+          </Button>
+          <Box sx={{ flexGrow: 1 }} />
+          <Button onClick={() => setPrListTarget(null)}>Close</Button>
         </DialogActions>
       </Dialog>
 

--- a/app/src/components/DbtExplorer.tsx
+++ b/app/src/components/DbtExplorer.tsx
@@ -2685,23 +2685,37 @@ export function DbtExplorer() {
                       >
                         #{pr.number} {pr.title}
                       </Link>
-                      <Typography
-                        variant="caption"
-                        color="text.secondary"
+                      <Box
                         sx={{
-                          display: "block",
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          whiteSpace: "nowrap",
+                          display: "flex",
+                          alignItems: "baseline",
+                          gap: 0.5,
+                          minWidth: 0,
                         }}
                       >
-                        {pr.headRef} → {pr.baseRef}
-                        {pr.author ? ` · ${pr.author}` : ""}
-                        {" · "}
-                        {new Date(pr.updatedAt).toLocaleDateString()}
-                      </Typography>
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                            minWidth: 0,
+                          }}
+                        >
+                          {pr.headRef} → {pr.baseRef}
+                          {pr.author ? ` · ${pr.author}` : ""}
+                        </Typography>
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{ flexShrink: 0 }}
+                        >
+                          · {new Date(pr.updatedAt).toLocaleDateString()}
+                        </Typography>
+                      </Box>
                     </Box>
-                    {pr.draft && (
+                    {pr.draft && pr.state === "open" && (
                       <Chip
                         label="Draft"
                         size="small"

--- a/app/src/store/dbtStore.ts
+++ b/app/src/store/dbtStore.ts
@@ -143,6 +143,22 @@ export interface PromoteResult extends CommitResult {
   fromBranch: string;
 }
 
+export interface PullRequestItem {
+  number: number;
+  title: string;
+  /** "open" or "closed" (merged PRs are "closed" with merged: true). */
+  state: string;
+  merged: boolean;
+  draft: boolean;
+  headRef: string;
+  baseRef: string;
+  htmlUrl: string;
+  author?: string;
+  body: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface DbtFileEntry {
   content: string;
   /** True while local edits have not been persisted yet. */
@@ -410,6 +426,23 @@ interface DbtActions {
     projectId: string,
     payload: { title: string; body?: string; base?: string },
   ) => Promise<{ number: number; htmlUrl: string } | null>;
+  listPullRequests: (
+    workspaceId: string,
+    projectId: string,
+    state?: "open" | "closed" | "all",
+  ) => Promise<PullRequestItem[] | null>;
+  updatePullRequest: (
+    workspaceId: string,
+    projectId: string,
+    prNumber: number,
+    payload: { title?: string; body?: string; base?: string },
+  ) => Promise<PullRequestItem | null>;
+  closePullRequest: (
+    workspaceId: string,
+    projectId: string,
+    prNumber: number,
+    options?: { deleteBranch?: boolean },
+  ) => Promise<PullRequestItem | null>;
 
   fetchFiles: (workspaceId: string, projectId: string) => Promise<void>;
   readFile: (
@@ -1049,6 +1082,68 @@ export const useDbtStore = create<DbtStore>()(
           state.error.projects = errMessage(
             error,
             "Failed to open pull request",
+          );
+        });
+        return null;
+      }
+    },
+
+    listPullRequests: async (workspaceId, projectId, state = "open") => {
+      try {
+        const response = await apiClient.get<{
+          success: boolean;
+          pullRequests: PullRequestItem[];
+        }>(
+          `/workspaces/${workspaceId}/dbt/projects/${projectId}/git/pull-requests?state=${state}`,
+        );
+        return response.pullRequests;
+      } catch (error) {
+        set(draft => {
+          draft.error.projects = errMessage(
+            error,
+            "Failed to list pull requests",
+          );
+        });
+        return null;
+      }
+    },
+
+    updatePullRequest: async (workspaceId, projectId, prNumber, payload) => {
+      try {
+        const response = await apiClient.patch<{
+          success: boolean;
+          pr: PullRequestItem;
+        }>(
+          `/workspaces/${workspaceId}/dbt/projects/${projectId}/git/pull-request/${prNumber}`,
+          payload,
+        );
+        return response.pr;
+      } catch (error) {
+        set(draft => {
+          draft.error.projects = errMessage(
+            error,
+            "Failed to update pull request",
+          );
+        });
+        return null;
+      }
+    },
+
+    closePullRequest: async (workspaceId, projectId, prNumber, options) => {
+      try {
+        const response = await apiClient.post<{
+          success: boolean;
+          pr: PullRequestItem;
+        }>(
+          `/workspaces/${workspaceId}/dbt/projects/${projectId}/git/pull-request/${prNumber}/close`,
+          options ?? {},
+        );
+        return response.pr;
+      } catch (error) {
+        set(draft => {
+          draft.error.projects = errMessage(
+            error,
+            "Failed to close pull request",
           );
         });
         return null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the missing pull-request lifecycle pieces around the existing `dbt_open_pull_request` / `dbt_merge_pull_request` flow, and surfaces PRs in the UI. **The chat agent can drive the entire PR lifecycle with tools** — see the demo below.

> Rebased onto `master` after #637 (per-user working trees, checkouts, protected branches) and adapted to it — see "Rebase notes".

### Agent tools (server-side, dbt domain)
- `dbt_list_pull_requests` — list repo PRs (open/closed/all) with number, title, state, merged flag, branches, URL (bodies truncated to 500 chars for context safety).
- `dbt_update_pull_request` — retitle / redescribe / retarget an **open** PR (admin+, like merge).
- `dbt_close_pull_request` — close a PR **without merging** (admin+), optionally deleting its head branch (refuses the project default branch or any branch a user has checked out; cleans up the branch's local base tree).
- Registered in the Transform-mode allowlist and referenced in the dbt + mode prompts.
- Routing fix: the base prompt's `transform` bullet and the `enable_mode` routing prompt now mention git/PR management, so PR requests route to transform mode even from a non-dbt tab (before this, the agent claimed it had no GitHub access).

### API
- `github-api.ts`: `listPullRequests`, `updatePullRequest` (PATCH, incl. `state`), PR summaries include `body`; the `GITHUB_API_BASE_URL` override from #637 is now read lazily so it also works when set via `.env` (dotenv loads after module import).
- `dbt-github-git.service.ts`: `listProjectPullRequests`, `updateProjectPullRequest`, `closeProjectPullRequest` (close runs under the per-project git lock and is checkout-aware).
- REST routes: `GET .../git/pull-requests?state=`, `PATCH .../git/pull-request/:number`, `POST .../git/pull-request/:number/close`.
- RBAC: update/close are admin-only alongside #637's merge rule; list is a normal read.

### UI
- New **Pull requests** dialog in `DbtExplorer` (Version control menu + project context menu): lists PRs with state icons/chips (open / merged / closed / draft), links out to GitHub, Open/All filter, refresh, inline edit of title & description, and close-without-merging with inline confirmation. "New PR" hands off to the existing open-PR dialog.
- `dbtStore`: `listPullRequests`, `updatePullRequest`, `closePullRequest`.
- Tool manifest entries so the new agent tools render human labels in chat.

### Rebase notes (adaptation to #637)
- RBAC: PR update/close stay admin+ (repo-level administration like merge), while #637 made commit/branch/switch/PR-open member+ (own-checkout work). Test cases moved accordingly.
- `closeProjectPullRequest` branch deletion is now checkout-aware: refuses the project default branch or any branch with an active `DbtCheckout`, and calls `deleteBranchBaseTree` after deleting.
- `dbt_update_pull_request` / `dbt_close_pull_request` gate on `workspaceService.isAdmin`, mirroring #637's merge tool; close publishes `dbt.git.updated` when a branch was deleted.
- Kept #637's `GITHUB_API_BASE_URL` override, converted to a lazy read (`githubApiBase()`).

## Demo — chat agent doing it all with tools

[chat_agent_pr_list_update_close_via_tools.mp4](https://cursor.com/agents/bc-7bbfdad9-3705-4aa1-b126-14986c2f02b2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchat_agent_pr_list_update_close_via_tools.mp4)

[Chat agent lists open PRs via dbt_list_pull_requests](https://cursor.com/agents/bc-7bbfdad9-3705-4aa1-b126-14986c2f02b2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchat_agent_lists_open_prs.webp)
[Chat agent closes PR #902 via dbt_close_pull_request](https://cursor.com/agents/bc-7bbfdad9-3705-4aa1-b126-14986c2f02b2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchat_agent_closes_pr902.webp)

## Demo — Pull requests dialog in the IDE

[pr_dialog_list_edit_close_demo_v2.mp4](https://cursor.com/agents/bc-7bbfdad9-3705-4aa1-b126-14986c2f02b2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr_dialog_list_edit_close_demo_v2.mp4)

## Testing
- ✅ `pnpm --filter api run lint`
- ✅ `pnpm --filter app run typecheck` + `pnpm --filter app run lint` (after rebuilding stale `@mako/schemas` dist)
- ✅ `vitest run src/dbt/rbac.test.ts` (34 tests incl. new admin-only cases) and `src/dbt/dbt-github-git.integration.test.ts` + `src/agent-lib/tools/dbt-job-tools.test.ts` (22 tests, #637's fake-GitHub harness)
- ✅ `vitest run src/agent-runtime/client-tool-manifest.test.ts` + `src/store/dbtStore.test.ts` (one pre-existing `fetchRuns` failure reproduces on pristine `master`, unrelated)
- ✅ Post-rebase runtime smoke: migrations applied (`per_user_dbt_working_trees`), REST list/update/close incl. checkout-aware `deleteBranch: true` path, double-close guard
- ✅ Post-rebase GUI check of the Pull requests dialog (list, edit + snackbar, close + snackbar)
- ✅ **Live chat-agent test** (Claude Sonnet 4.5 through the real chat endpoint): list → update → close → list-all (video above); routing also verified from a non-dbt console tab


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7bbfdad9-3705-4aa1-b126-14986c2f02b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7bbfdad9-3705-4aa1-b126-14986c2f02b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

