### PR TITLE
fix(chat): dedupe replayed tool executions + decompose Chat.tsx into chat/ module

### DIFF
--- a/api/src/agent-lib/context/compaction.test.ts
+++ b/api/src/agent-lib/context/compaction.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import type { UIMessage } from "ai";
 import {
   dedupeAssistantReasoning,
+  dedupeAssistantStreamArtifacts,
   elideOldToolOutputs,
   stripReplayedReasoning,
 } from "./compaction";
@@ -264,9 +265,7 @@ function reasoningPart(
   return {
     type: "reasoning",
     text,
-    ...(signature
-      ? { providerMetadata: { anthropic: { signature } } }
-      : {}),
+    ...(signature ? { providerMetadata: { anthropic: { signature } } } : {}),
   };
 }
 
@@ -381,6 +380,114 @@ t("dedupe: ignores user messages and empty/whitespace reasoning", () => {
   const res = dedupeAssistantReasoning(msgs);
   assert.equal(res.changed, false);
   assert.equal(res.removedCount, 0);
+});
+
+// --- dedupeAssistantStreamArtifacts -----------------------------------------
+
+const LONG_A =
+  "I'll reconcile submit_valuation_form across your CRM database, GA4, and the ad platforms.";
+const LONG_B =
+  "The full reconciliation works. Let me put it in a console and run it there.";
+
+t(
+  "artifacts: removes replay-duplicated text parts and step-start bursts",
+  () => {
+    // Mirrors the triplicate-consumer incident: each extra stream consumer
+    // appended a byte-identical copy of every text part plus step-start bursts.
+    const msgs: UIMessage[] = [
+      userMsg("u0", "reconcile my funnel"),
+      assistantParts([
+        { type: "step-start" },
+        { type: "text", text: LONG_A },
+        {
+          type: "tool-create_dashboard",
+          toolCallId: "c1",
+          toolName: "create_dashboard",
+          input: { title: "Recon" },
+          output: { success: true },
+          state: "output-available",
+        },
+        { type: "text", text: LONG_B },
+        // consumer #2 replay append
+        { type: "step-start" },
+        { type: "step-start" },
+        { type: "text", text: LONG_A },
+        { type: "step-start" },
+        { type: "text", text: LONG_B },
+        // consumer #3 replay append
+        { type: "step-start" },
+        { type: "text", text: LONG_A },
+        { type: "step-start" },
+        { type: "step-start" },
+        { type: "text", text: LONG_B },
+      ]),
+    ];
+    const res = dedupeAssistantStreamArtifacts(msgs);
+    assert.equal(res.changed, true);
+    const a = res.messages.find(m => m.id === "a");
+    assert.ok(a);
+    const parts = a.parts as Array<Record<string, unknown>>;
+    const texts = parts.filter(p => p.type === "text");
+    // Each long text survives exactly once, in original order.
+    assert.equal(texts.length, 2);
+    assert.equal(texts[0].text, LONG_A);
+    assert.equal(texts[1].text, LONG_B);
+    // No two step-start parts remain adjacent.
+    for (let i = 1; i < parts.length; i++) {
+      assert.ok(
+        !(parts[i].type === "step-start" && parts[i - 1].type === "step-start"),
+        "consecutive step-start survived",
+      );
+    }
+    // The tool part is untouched.
+    assert.equal(
+      parts.filter(p => p.type === "tool-create_dashboard").length,
+      1,
+    );
+  },
+);
+
+t("artifacts: keeps short repeated texts and non-adjacent step-starts", () => {
+  const msgs: UIMessage[] = [
+    userMsg("u0", "q"),
+    assistantParts([
+      { type: "step-start" },
+      { type: "text", text: "Done." }, // short — legitimate repeat possible
+      { type: "step-start" },
+      { type: "text", text: "Done." },
+    ]),
+  ];
+  const res = dedupeAssistantStreamArtifacts(msgs);
+  assert.equal(res.changed, false);
+  assert.equal(res.removedCount, 0);
+});
+
+t("artifacts: no-op on clean messages and ignores user messages", () => {
+  const msgs: UIMessage[] = [
+    userMsg("u0", LONG_A),
+    assistantParts([
+      { type: "step-start" },
+      { type: "text", text: LONG_A },
+      { type: "step-start" },
+      { type: "text", text: LONG_B },
+    ]),
+  ];
+  const res = dedupeAssistantStreamArtifacts(msgs);
+  assert.equal(res.changed, false);
+  assert.equal(res.removedCount, 0);
+  assert.equal(res.messages[1], msgs[1]); // untouched reference
+});
+
+t("artifacts: whitespace-only texts are never collapsed together", () => {
+  const msgs: UIMessage[] = [
+    userMsg("u0", "q"),
+    assistantParts([
+      { type: "text", text: "   " },
+      { type: "text", text: "   " },
+    ]),
+  ];
+  const res = dedupeAssistantStreamArtifacts(msgs);
+  assert.equal(res.changed, false);
 });
 
 process.stdout.write("\nAll compaction tests passed.\n");

--- a/api/src/agent-lib/context/compaction.ts
+++ b/api/src/agent-lib/context/compaction.ts
@@ -421,6 +421,94 @@ export function dedupeAssistantReasoning(
   return { messages: next, changed, removedCount };
 }
 
+/**
+ * Minimum trimmed length for a text part to participate in duplicate removal.
+ * Short affirmations ("Done.", "Yes.") can legitimately repeat inside one
+ * assistant message; the replay corruption this cleans up duplicates whole
+ * paragraphs, so a modest threshold removes the corruption without ever
+ * touching plausible legitimate repeats.
+ */
+const TEXT_DEDUPE_MIN_LENGTH = 24;
+
+/**
+ * Remove stream-replay artifacts from assistant messages: duplicated `text`
+ * parts and bursts of consecutive `step-start` parts.
+ *
+ * WHY THIS EXISTS — resumable-stream replay corruption:
+ * When a client attaches additional consumers to a turn's resumable stream
+ * (resumeStream() after a wake/refresh/error — historically without any
+ * single-flight guard), every consumer re-processes every chunk. Tool and
+ * reasoning chunks MERGE into existing parts (by toolCallId / signature), but
+ * `text-start` and `start-step` chunks unconditionally APPEND — so each extra
+ * consumer appended a byte-identical copy of every text part plus a burst of
+ * step-start parts. Later live chunks then interleave with the appended
+ * copies, so the duplicates are NOT a clean suffix; they are byte-identical
+ * repeats scattered through the tail of the message.
+ *
+ * The client-side fixes (tool dispatch gate + single-flight resume) stop new
+ * corruption; this persist-time pass repairs messages that already carry it
+ * (and acts as a backstop). Mirrors `dedupeAssistantReasoning`: first
+ * occurrence and order are preserved.
+ *
+ * Conservative by construction:
+ *  - only assistant messages;
+ *  - only text parts whose trimmed content is at least
+ *    TEXT_DEDUPE_MIN_LENGTH chars AND byte-identical (trimmed) to an earlier
+ *    text part in the same message;
+ *  - step-start parts are only dropped when DIRECTLY consecutive (possible
+ *    only via replay appends — a real step boundary always carries content).
+ */
+export function dedupeAssistantStreamArtifacts(
+  messages: UIMessage[],
+): DedupeReasoningResult {
+  let changed = false;
+  let removedCount = 0;
+
+  const next = messages.map(msg => {
+    if (msg.role !== "assistant") return msg;
+    const parts = (msg.parts ?? []) as Array<Record<string, unknown>>;
+    const seenTexts = new Set<string>();
+    let removedHere = 0;
+    let previousKeptType: string | null = null;
+
+    const filtered = parts.filter(part => {
+      const type = part.type;
+
+      if (type === "step-start") {
+        if (previousKeptType === "step-start") {
+          removedHere += 1;
+          return false;
+        }
+        previousKeptType = "step-start";
+        return true;
+      }
+
+      if (type === "text") {
+        const trimmed = String((part.text as string) ?? "").trim();
+        if (trimmed.length >= TEXT_DEDUPE_MIN_LENGTH) {
+          if (seenTexts.has(trimmed)) {
+            removedHere += 1;
+            return false;
+          }
+          seenTexts.add(trimmed);
+        }
+        previousKeptType = "text";
+        return true;
+      }
+
+      previousKeptType = typeof type === "string" ? type : null;
+      return true;
+    });
+
+    if (removedHere === 0) return msg;
+    changed = true;
+    removedCount += removedHere;
+    return { ...msg, parts: filtered as UIMessage["parts"] };
+  });
+
+  return { messages: next, changed, removedCount };
+}
+
 // ---------------------------------------------------------------------------
 // Summarization (agnostic — cheapest curated tool-use model)
 // ---------------------------------------------------------------------------

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -3092,6 +3092,14 @@ export interface IDashboard extends Document {
   workspaceId: Types.ObjectId;
   title: string;
   description?: string;
+  /**
+   * Client-supplied creation idempotency key (the agent toolCallId). Multiple
+   * windows attached to the same chat stream each dispatch the same
+   * create_dashboard call; the unique partial index on
+   * { workspaceId, creationIdempotencyKey } makes the second insert a
+   * duplicate, and the create route returns the existing dashboard instead.
+   */
+  creationIdempotencyKey?: string;
 
   dataSources: IDashboardDataSource[];
 
@@ -3280,6 +3288,8 @@ export interface IDashboardDataSourceOrigin {
   consoleId?: Types.ObjectId;
   consoleName?: string;
   importedAt?: Date;
+  /** Agent toolCallId that created this data source (creation idempotency). */
+  createdByToolCallId?: string;
 }
 
 export interface IDashboardDataSource {
@@ -3327,6 +3337,7 @@ const DashboardSchema = new Schema<IDashboard>(
     },
     title: { type: String, required: true },
     description: { type: String },
+    creationIdempotencyKey: { type: String },
 
     dataSources: [
       {
@@ -3375,6 +3386,7 @@ const DashboardSchema = new Schema<IDashboard>(
           },
           consoleName: { type: String },
           importedAt: { type: Date },
+          createdByToolCallId: { type: String },
         },
         timeDimension: { type: String },
         rowLimit: { type: Number },
@@ -3608,6 +3620,16 @@ DashboardSchema.index({ workspaceId: 1, "sharedWith.userId": 1 });
 DashboardSchema.index(
   { "publicShare.token": 1 },
   { unique: true, sparse: true },
+);
+// Creation idempotency (see IDashboard.creationIdempotencyKey). Partial (not
+// sparse): a sparse COMPOUND index still indexes docs that have workspaceId
+// but no key, which would make every keyless dashboard collide.
+DashboardSchema.index(
+  { workspaceId: 1, creationIdempotencyKey: 1 },
+  {
+    unique: true,
+    partialFilterExpression: { creationIdempotencyKey: { $type: "string" } },
+  },
 );
 
 /**

--- a/api/src/migrations/2026-07-02-131500_dashboard_creation_idempotency_index.ts
+++ b/api/src/migrations/2026-07-02-131500_dashboard_creation_idempotency_index.ts
@@ -1,0 +1,71 @@
+import { Db } from "mongodb";
+import { loggers } from "../logging";
+
+const log = loggers.migration();
+
+const COLLECTION = "dashboards";
+const INDEX_NAME = "workspaceId_1_creationIdempotencyKey_1";
+
+type IndexInfo = {
+  name: string;
+  key?: Record<string, unknown>;
+};
+
+/**
+ * Dashboard creation idempotency: the agent's create_dashboard tool executes
+ * client-side, and multiple browser windows attached to the same resumable
+ * chat stream each dispatch the same tool call — producing duplicate
+ * dashboards. The create route now accepts the toolCallId as an idempotency
+ * key (persisted as `creationIdempotencyKey`); this unique PARTIAL index
+ * makes the concurrent second insert a duplicate-key error the route turns
+ * into "return the existing dashboard".
+ *
+ * Partial (not sparse) on purpose: a sparse COMPOUND index still indexes
+ * documents that have `workspaceId` but no key, so every keyless dashboard
+ * in a workspace would collide with the next one.
+ */
+export const description =
+  "Add unique partial { workspaceId, creationIdempotencyKey } index on dashboards for create idempotency";
+
+function hasIndexOnKeys(
+  indexes: IndexInfo[],
+  keyPattern: Record<string, number>,
+): boolean {
+  const target = JSON.stringify(keyPattern);
+  return indexes.some(idx => JSON.stringify(idx.key) === target);
+}
+
+export async function up(db: Db): Promise<void> {
+  const names = new Set(
+    (await db.listCollections().toArray()).map(c => c.name),
+  );
+  if (!names.has(COLLECTION)) {
+    log.info("dashboards collection not found, skipping", {
+      collection: COLLECTION,
+    });
+    return;
+  }
+
+  const col = db.collection(COLLECTION);
+  const indexes = (await col.indexes()) as IndexInfo[];
+
+  if (hasIndexOnKeys(indexes, { workspaceId: 1, creationIdempotencyKey: 1 })) {
+    log.info("creation idempotency index already present, skipping", {
+      collection: COLLECTION,
+    });
+    return;
+  }
+
+  await col.createIndex(
+    { workspaceId: 1, creationIdempotencyKey: 1 },
+    {
+      name: INDEX_NAME,
+      unique: true,
+      partialFilterExpression: { creationIdempotencyKey: { $type: "string" } },
+    },
+  );
+  log.info("Created dashboards creation idempotency index", {
+    collection: COLLECTION,
+    name: INDEX_NAME,
+  });
+}

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -10,7 +10,6 @@ import {
   streamText,
   convertToModelMessages,
   stepCountIs,
-  UI_MESSAGE_STREAM_HEADERS,
   type UIMessage,
 } from "ai";
 import { getModel, buildProviderOptions } from "../agent-lib/ai-gateway";
@@ -26,7 +25,6 @@ import {
   stripReplayedReasoning,
 } from "../agent-lib/context/compaction";
 import { unifiedAuthMiddleware } from "../auth/unified-auth.middleware";
-import { AuthenticatedContext } from "../middleware/workspace.middleware";
 import { workspaceService } from "../services/workspace.service";
 import type { ConsoleDataV2 } from "../agent-lib/types";
 import {
@@ -78,12 +76,18 @@ import { scheduleChatFinalization } from "./chat-finalization-queue";
 import {
   getResumableStreamContext,
   registerActiveGeneration,
-  stopActiveGeneration,
   clearActiveGeneration,
 } from "../services/resumable-stream.service";
 import { hasAttachedClients } from "../services/realtime-presence.service";
 import { publishRealtimeEvent } from "../services/realtime.service";
 import { AUTH_SECURITY, OPEN_RESPONSES, createRouter } from "../openapi/core";
+import {
+  buildScreenshotVisionModelMessage,
+  resumeChatStream,
+  stopChatGeneration,
+  withSseKeepAlive,
+  type ScreenshotVisionAttachment,
+} from "../services/agent-stream.service";
 
 const logger = loggers.agent();
 
@@ -99,154 +103,6 @@ const StreamResponses = {
     content: { "text/event-stream": { schema: z.string() } },
   },
 };
-
-interface ScreenshotVisionAttachment {
-  renderer?: string;
-  filename?: string;
-  mediaType?: string;
-  dataUrl?: string;
-  outputBytes?: number;
-  targetLabel?: string;
-}
-
-const MAX_SCREENSHOT_VISION_ATTACHMENTS = 6;
-const MAX_SCREENSHOT_VISION_BYTES = 2_000_000;
-
-// Keep the SSE connection warm during long silent gaps.
-//
-// While a server-side tool runs (e.g. a multi-minute `dbt build`) the AI SDK
-// emits the `tool-input-available` chunk and then sends nothing on the wire
-// until the tool resolves. Edge proxies (Cloudflare's origin idle timeout is
-// ~100s with no bytes) terminate a connection that goes quiet for too long —
-// which drops the live stream and strands the in-flight tool card on
-// "Running…" in the browser. Emitting an SSE comment line on a fixed interval
-// keeps bytes flowing without affecting the protocol: lines beginning with
-// `:` are comments per the SSE spec and are ignored by the AI SDK's stream
-// parser. We wrap only the live client-facing branch; the tee'd
-// resumable-stream copy is untouched, so keepalives are never buffered or
-// replayed on reconnect.
-const SSE_KEEPALIVE_INTERVAL_MS = 15_000;
-
-function withSseKeepAlive(
-  response: Response,
-  intervalMs = SSE_KEEPALIVE_INTERVAL_MS,
-): Response {
-  if (!response.body) return response;
-
-  const encoder = new TextEncoder();
-  const reader = response.body.getReader();
-  let keepAlive: ReturnType<typeof setInterval> | null = null;
-
-  const stopKeepAlive = () => {
-    if (keepAlive) {
-      clearInterval(keepAlive);
-      keepAlive = null;
-    }
-  };
-
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      keepAlive = setInterval(() => {
-        try {
-          controller.enqueue(encoder.encode(": keep-alive\n\n"));
-        } catch {
-          // Controller already closed/errored — stop pinging.
-          stopKeepAlive();
-        }
-      }, intervalMs);
-    },
-    async pull(controller) {
-      try {
-        const { done, value } = await reader.read();
-        if (done) {
-          stopKeepAlive();
-          controller.close();
-          return;
-        }
-        controller.enqueue(value);
-      } catch (error) {
-        stopKeepAlive();
-        controller.error(error);
-      }
-    },
-    cancel(reason) {
-      stopKeepAlive();
-      void reader.cancel(reason);
-    },
-  });
-
-  return new Response(stream, {
-    status: response.status,
-    statusText: response.statusText,
-    headers: response.headers,
-  });
-}
-
-function estimateDataUrlBytes(dataUrl: string): number {
-  const commaIndex = dataUrl.indexOf(",");
-  if (commaIndex === -1) return dataUrl.length;
-  return Math.floor(((dataUrl.length - commaIndex - 1) * 3) / 4);
-}
-
-function buildScreenshotVisionModelMessage(
-  attachments: ScreenshotVisionAttachment[] | undefined,
-) {
-  if (!Array.isArray(attachments) || attachments.length === 0) {
-    return null;
-  }
-
-  const accepted = attachments
-    .filter(attachment => {
-      if (
-        typeof attachment.dataUrl !== "string" ||
-        !attachment.dataUrl.startsWith("data:image/")
-      ) {
-        return false;
-      }
-      const byteCount =
-        typeof attachment.outputBytes === "number"
-          ? attachment.outputBytes
-          : estimateDataUrlBytes(attachment.dataUrl);
-      return byteCount <= MAX_SCREENSHOT_VISION_BYTES;
-    })
-    .slice(0, MAX_SCREENSHOT_VISION_ATTACHMENTS);
-
-  if (accepted.length === 0) {
-    return null;
-  }
-
-  const content: Array<
-    | { type: "text"; text: string }
-    | { type: "file"; mediaType: string; filename?: string; data: string }
-  > = [
-    {
-      type: "text",
-      text:
-        "The previous screenshot tool call captured these PNG images for visual inspection. " +
-        "Look at the actual images, describe what is visible, and use them as visual evidence when answering.",
-    },
-  ];
-
-  accepted.forEach((attachment, index) => {
-    const renderer = attachment.renderer || `renderer-${index + 1}`;
-    const filename = attachment.filename || `${renderer}.png`;
-    content.push({
-      type: "text",
-      text: `Screenshot ${index + 1}: ${renderer} (${filename})`,
-    });
-    content.push({
-      type: "file",
-      mediaType: attachment.mediaType || "image/png",
-      filename,
-      data: attachment.dataUrl as string,
-    });
-  });
-
-  return {
-    role: "user" as const,
-    content,
-  };
-}
 
 // Apply unified auth middleware to all routes
 agentRoutes.use("*", unifiedAuthMiddleware);
@@ -1637,51 +1493,6 @@ agentRoutes.openapi(
  * auth model of POST /chat: session users need workspace membership, API
  * keys must belong to the chat's workspace.
  */
-async function authorizeChatStreamAccess(
-  c: AuthenticatedContext,
-  chatId: string,
-): Promise<
-  | {
-      ok: true;
-      chat: { activeStreamId?: string | null; workspaceId: string };
-    }
-  | { ok: false; status: 400 | 401 | 403 | 404 }
-> {
-  const user = c.get("user");
-  const apiKeyWorkspace = c.get("workspace");
-
-  if (!ObjectId.isValid(chatId)) {
-    return { ok: false, status: 400 };
-  }
-
-  const chat = await Chat.findById(chatId).select("workspaceId activeStreamId");
-  if (!chat) {
-    return { ok: false, status: 404 };
-  }
-
-  const chatWorkspaceId = chat.workspaceId.toString();
-  if (apiKeyWorkspace) {
-    if (apiKeyWorkspace._id.toString() !== chatWorkspaceId) {
-      return { ok: false, status: 403 };
-    }
-  } else if (user) {
-    const hasAccess = await workspaceService.hasAccess(
-      chatWorkspaceId,
-      user.id,
-    );
-    if (!hasAccess) {
-      return { ok: false, status: 403 };
-    }
-  } else {
-    return { ok: false, status: 401 };
-  }
-
-  return {
-    ok: true,
-    chat: { activeStreamId: chat.activeStreamId, workspaceId: chatWorkspaceId },
-  };
-}
-
 /**
  * GET /api/agent/chat/:chatId/stream
  *
@@ -1703,67 +1514,12 @@ agentRoutes.openapi(
   }),
   async c => {
     const chatId = c.req.param("chatId");
-    const access = await authorizeChatStreamAccess(c, chatId);
-    if (!access.ok) {
-      // A not-yet-created chat (client-minted chatId, no turn sent) is a normal
-      // "nothing to resume" case, not an error.
-      if (access.status === 404) {
-        // `reason` discriminates the three distinct 204 outcomes below so a
-        // benign "nothing to resume" can be told apart from a lost stream when
-        // investigating client-side disconnect reports.
-        logger.debug("Stream resume: nothing to resume", {
-          chatId,
-          reason: "chat-not-found",
-        });
-        return c.body(null, 204);
-      }
-      return c.json({ error: "Cannot access chat stream" }, access.status);
+    const result = await resumeChatStream(c, chatId);
+    if (result.kind === "no-content") return c.body(null, 204);
+    if (result.kind === "forbidden") {
+      return c.json({ error: "Cannot access chat stream" }, result.status);
     }
-
-    const { activeStreamId } = access.chat;
-    if (!activeStreamId) {
-      logger.debug("Stream resume: nothing to resume", {
-        chatId,
-        reason: "no-active-stream",
-      });
-      return c.body(null, 204);
-    }
-
-    const stream =
-      await getResumableStreamContext().resumeExistingStream(activeStreamId);
-    if (!stream) {
-      // Stale pointer: stream expired or was lost (e.g. process restart with
-      // the in-memory backend, or a `/stop` handled by another instance). The
-      // client minted a turn but we can no longer reattach — this is the
-      // server-side counterpart of the client's silent-disconnect rescue.
-      logger.info("Stream resume: stale pointer, cannot reattach", {
-        chatId,
-        streamId: activeStreamId,
-        reason: "stale-pointer",
-      });
-      // Clear it so future mounts short-circuit.
-      void Chat.updateOne(
-        { _id: new ObjectId(chatId), activeStreamId },
-        { $set: { activeStreamId: null } },
-      ).catch(error =>
-        logger.warn("Failed to clear stale activeStreamId", { error, chatId }),
-      );
-      return c.body(null, 204);
-    }
-
-    logger.info("Client reattached to chat stream", {
-      chatId,
-      streamId: activeStreamId,
-    });
-    // Keep the reattached connection warm during long silent tool gaps, same
-    // as the live POST branch. Without this, a client that resumes mid-turn is
-    // dropped by the edge proxy's idle timeout (~100s with no bytes) whenever a
-    // server-side tool runs quietly, stranding the resumed turn.
-    return withSseKeepAlive(
-      new Response(stream.pipeThrough(new TextEncoderStream()), {
-        headers: UI_MESSAGE_STREAM_HEADERS,
-      }),
-    );
+    return result.response;
   },
 );
 
@@ -1788,28 +1544,11 @@ agentRoutes.openapi(
   }),
   async c => {
     const chatId = c.req.param("chatId");
-    const access = await authorizeChatStreamAccess(c, chatId);
-    if (!access.ok) {
-      if (access.status === 404) return c.json({ stopped: false });
-      return c.json({ error: "Cannot access chat" }, access.status);
+    const result = await stopChatGeneration(c, chatId);
+    if (result.kind === "not-found") return c.json({ stopped: false });
+    if (result.kind === "forbidden") {
+      return c.json({ error: "Cannot access chat" }, result.status);
     }
-
-    const stopped = stopActiveGeneration(chatId);
-
-    // Clear the pointer immediately so reconnecting clients don't reattach to
-    // the aborted stream. Finalization also clears it, but only on the
-    // instance that owns the generation.
-    await Chat.updateOne(
-      { _id: new ObjectId(chatId) },
-      { $set: { activeStreamId: null } },
-    );
-    publishRealtimeEvent(access.chat.workspaceId, {
-      type: "chat.activity",
-      chatId,
-      state: "idle",
-    });
-
-    logger.info("Chat generation stop requested", { chatId, stopped });
-    return c.json({ stopped });
+    return c.json({ stopped: result.stopped });
   },
 );

--- a/api/src/routes/dashboards.ts
+++ b/api/src/routes/dashboards.ts
@@ -688,6 +688,7 @@ app.openapi(
       const {
         cache: _ignoredCache,
         snapshots: _ignoredSnapshots,
+        idempotencyKey: rawIdempotencyKey,
         ...dashboardInput
       } = body as Record<string, unknown>;
 
@@ -697,6 +698,33 @@ app.openapi(
         !dashboardInput.title.trim()
       ) {
         return c.json({ success: false, error: "title is required" }, 400);
+      }
+
+      // Creation idempotency: agent-driven creates send the toolCallId as the
+      // key. Multiple windows attached to the same chat stream dispatch the
+      // same create_dashboard call; the first insert wins and every other
+      // request gets the SAME dashboard back instead of creating a duplicate.
+      const idempotencyKey =
+        typeof rawIdempotencyKey === "string" && rawIdempotencyKey.trim()
+          ? rawIdempotencyKey.trim()
+          : undefined;
+      const findExistingByIdempotencyKey = () =>
+        idempotencyKey
+          ? Dashboard.findOne({
+              workspaceId: new Types.ObjectId(workspaceId),
+              creationIdempotencyKey: idempotencyKey,
+            })
+          : null;
+
+      const preExisting = await findExistingByIdempotencyKey();
+      if (preExisting) {
+        return c.json({
+          success: true,
+          idempotentReplay: true,
+          data: sanitizeDashboardResponse(
+            await hydrateDashboardArtifactUrls(preExisting.toObject() as any),
+          ),
+        });
       }
 
       if (
@@ -748,9 +776,30 @@ app.openapi(
         createdBy: userId,
         owner_id: userId,
         materializationSchedule,
+        ...(idempotencyKey ? { creationIdempotencyKey: idempotencyKey } : {}),
       });
 
-      await dashboard.save();
+      try {
+        await dashboard.save();
+      } catch (saveError) {
+        // E11000 on the { workspaceId, creationIdempotencyKey } unique index:
+        // a concurrent duplicate request won the race — return its dashboard.
+        const isDuplicateKey =
+          (saveError as { code?: number } | null)?.code === 11000;
+        if (isDuplicateKey && idempotencyKey) {
+          const winner = await findExistingByIdempotencyKey();
+          if (winner) {
+            return c.json({
+              success: true,
+              idempotentReplay: true,
+              data: sanitizeDashboardResponse(
+                await hydrateDashboardArtifactUrls(winner.toObject() as any),
+              ),
+            });
+          }
+        }
+        throw saveError;
+      }
 
       // Create version 1 for the new dashboard and publish it.
       const displayName = await getUserDisplayName(userId);
@@ -1084,8 +1133,7 @@ app.openapi(
         dashboardId: updated._id.toString(),
         version: updated.version,
         updatedBy: userId,
-        clientId:
-          typeof body.clientId === "string" ? body.clientId : undefined,
+        clientId: typeof body.clientId === "string" ? body.clientId : undefined,
         origin: "save",
       });
 
@@ -1331,8 +1379,7 @@ app.openapi(
         dashboardId: dashboard._id.toString(),
         version: dashboard.version,
         updatedBy: userId,
-        clientId:
-          typeof body.clientId === "string" ? body.clientId : undefined,
+        clientId: typeof body.clientId === "string" ? body.clientId : undefined,
         origin: "save",
       });
 

--- a/api/src/services/agent-stream.service.ts
+++ b/api/src/services/agent-stream.service.ts
@@ -1,0 +1,347 @@
+/**
+ * Agent chat stream lifecycle: SSE keep-alive wrapping, screenshot-vision
+ * message assembly, and the resume/stop endpoints' logic. Extracted from
+ * agent.routes.ts so the route file stays a thin spec + handler layer.
+ */
+import { ObjectId } from "mongodb";
+import { UI_MESSAGE_STREAM_HEADERS } from "ai";
+import { Chat } from "../database/workspace-schema";
+import { workspaceService } from "./workspace.service";
+import {
+  getResumableStreamContext,
+  stopActiveGeneration,
+} from "./resumable-stream.service";
+import { publishRealtimeEvent } from "./realtime.service";
+import type { AuthenticatedContext } from "../middleware/workspace.middleware";
+import { loggers } from "../logging";
+
+const logger = loggers.agent();
+
+// ── Screenshot vision attachments ────────────────────────────────
+
+export interface ScreenshotVisionAttachment {
+  renderer?: string;
+  filename?: string;
+  mediaType?: string;
+  dataUrl?: string;
+  outputBytes?: number;
+  targetLabel?: string;
+}
+
+const MAX_SCREENSHOT_VISION_ATTACHMENTS = 6;
+const MAX_SCREENSHOT_VISION_BYTES = 2_000_000;
+
+function estimateDataUrlBytes(dataUrl: string): number {
+  const commaIndex = dataUrl.indexOf(",");
+  if (commaIndex === -1) return dataUrl.length;
+  return Math.floor(((dataUrl.length - commaIndex - 1) * 3) / 4);
+}
+
+export function buildScreenshotVisionModelMessage(
+  attachments: ScreenshotVisionAttachment[] | undefined,
+) {
+  if (!Array.isArray(attachments) || attachments.length === 0) {
+    return null;
+  }
+
+  const accepted = attachments
+    .filter(attachment => {
+      if (
+        typeof attachment.dataUrl !== "string" ||
+        !attachment.dataUrl.startsWith("data:image/")
+      ) {
+        return false;
+      }
+      const byteCount =
+        typeof attachment.outputBytes === "number"
+          ? attachment.outputBytes
+          : estimateDataUrlBytes(attachment.dataUrl);
+      return byteCount <= MAX_SCREENSHOT_VISION_BYTES;
+    })
+    .slice(0, MAX_SCREENSHOT_VISION_ATTACHMENTS);
+
+  if (accepted.length === 0) {
+    return null;
+  }
+
+  const content: Array<
+    | { type: "text"; text: string }
+    | { type: "file"; mediaType: string; filename?: string; data: string }
+  > = [
+    {
+      type: "text",
+      text:
+        "The previous screenshot tool call captured these PNG images for visual inspection. " +
+        "Look at the actual images, describe what is visible, and use them as visual evidence when answering.",
+    },
+  ];
+
+  accepted.forEach((attachment, index) => {
+    const renderer = attachment.renderer || `renderer-${index + 1}`;
+    const filename = attachment.filename || `${renderer}.png`;
+    content.push({
+      type: "text",
+      text: `Screenshot ${index + 1}: ${renderer} (${filename})`,
+    });
+    content.push({
+      type: "file",
+      mediaType: attachment.mediaType || "image/png",
+      filename,
+      data: attachment.dataUrl as string,
+    });
+  });
+
+  return {
+    role: "user" as const,
+    content,
+  };
+}
+
+// ── SSE keep-alive ────────────────────────────────────────────────
+
+// Keep the SSE connection warm during long silent gaps.
+//
+// While a server-side tool runs (e.g. a multi-minute `dbt build`) the AI SDK
+// emits the `tool-input-available` chunk and then sends nothing on the wire
+// until the tool resolves. Edge proxies (Cloudflare's origin idle timeout is
+// ~100s with no bytes) terminate a connection that goes quiet for too long —
+// which drops the live stream and strands the in-flight tool card on
+// "Running…" in the browser. Emitting an SSE comment line on a fixed interval
+// keeps bytes flowing without affecting the protocol: lines beginning with
+// `:` are comments per the SSE spec and are ignored by the AI SDK's stream
+// parser. We wrap only the live client-facing branch; the tee'd
+// resumable-stream copy is untouched, so keepalives are never buffered or
+// replayed on reconnect.
+const SSE_KEEPALIVE_INTERVAL_MS = 15_000;
+
+export function withSseKeepAlive(
+  response: Response,
+  intervalMs = SSE_KEEPALIVE_INTERVAL_MS,
+): Response {
+  if (!response.body) return response;
+
+  const encoder = new TextEncoder();
+  const reader = response.body.getReader();
+  let keepAlive: ReturnType<typeof setInterval> | null = null;
+
+  const stopKeepAlive = () => {
+    if (keepAlive) {
+      clearInterval(keepAlive);
+      keepAlive = null;
+    }
+  };
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      keepAlive = setInterval(() => {
+        try {
+          controller.enqueue(encoder.encode(": keep-alive\n\n"));
+        } catch {
+          // Controller already closed/errored — stop pinging.
+          stopKeepAlive();
+        }
+      }, intervalMs);
+    },
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          stopKeepAlive();
+          controller.close();
+          return;
+        }
+        controller.enqueue(value);
+      } catch (error) {
+        stopKeepAlive();
+        controller.error(error);
+      }
+    },
+    cancel(reason) {
+      stopKeepAlive();
+      void reader.cancel(reason);
+    },
+  });
+
+  return new Response(stream, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
+// ── Stream access authorization ───────────────────────────────────
+
+/**
+ * Shared guard for the resume/stop endpoints: the caller must be an
+ * authenticated user with access to the chat's workspace, or an API key
+ * scoped to that workspace.
+ */
+export async function authorizeChatStreamAccess(
+  c: AuthenticatedContext,
+  chatId: string,
+): Promise<
+  | {
+      ok: true;
+      chat: { activeStreamId?: string | null; workspaceId: string };
+    }
+  | { ok: false; status: 400 | 401 | 403 | 404 }
+> {
+  const user = c.get("user");
+  const apiKeyWorkspace = c.get("workspace");
+
+  if (!ObjectId.isValid(chatId)) {
+    return { ok: false, status: 400 };
+  }
+
+  const chat = await Chat.findById(chatId).select("workspaceId activeStreamId");
+  if (!chat) {
+    return { ok: false, status: 404 };
+  }
+
+  const chatWorkspaceId = chat.workspaceId.toString();
+  if (apiKeyWorkspace) {
+    if (apiKeyWorkspace._id.toString() !== chatWorkspaceId) {
+      return { ok: false, status: 403 };
+    }
+  } else if (user) {
+    const hasAccess = await workspaceService.hasAccess(
+      chatWorkspaceId,
+      user.id,
+    );
+    if (!hasAccess) {
+      return { ok: false, status: 403 };
+    }
+  } else {
+    return { ok: false, status: 401 };
+  }
+
+  return {
+    ok: true,
+    chat: { activeStreamId: chat.activeStreamId, workspaceId: chatWorkspaceId },
+  };
+}
+
+// ── Resume / stop lifecycle ───────────────────────────────────────
+
+export type ResumeChatStreamResult =
+  /** Nothing to resume — respond 204. `reason` discriminates the outcomes. */
+  | {
+      kind: "no-content";
+      reason: "chat-not-found" | "no-active-stream" | "stale-pointer";
+    }
+  | { kind: "forbidden"; status: 400 | 401 | 403 }
+  /** Reattached — pipe this SSE response to the client. */
+  | { kind: "stream"; response: Response };
+
+/**
+ * Reattach the caller to the chat's in-flight turn: buffered chunks are
+ * replayed, then live chunks follow. Multiple clients may attach to the same
+ * stream concurrently.
+ */
+export async function resumeChatStream(
+  c: AuthenticatedContext,
+  chatId: string,
+): Promise<ResumeChatStreamResult> {
+  const access = await authorizeChatStreamAccess(c, chatId);
+  if (!access.ok) {
+    // A not-yet-created chat (client-minted chatId, no turn sent) is a normal
+    // "nothing to resume" case, not an error.
+    if (access.status === 404) {
+      logger.debug("Stream resume: nothing to resume", {
+        chatId,
+        reason: "chat-not-found",
+      });
+      return { kind: "no-content", reason: "chat-not-found" };
+    }
+    return { kind: "forbidden", status: access.status };
+  }
+
+  const { activeStreamId } = access.chat;
+  if (!activeStreamId) {
+    logger.debug("Stream resume: nothing to resume", {
+      chatId,
+      reason: "no-active-stream",
+    });
+    return { kind: "no-content", reason: "no-active-stream" };
+  }
+
+  const stream =
+    await getResumableStreamContext().resumeExistingStream(activeStreamId);
+  if (!stream) {
+    // Stale pointer: stream expired or was lost (e.g. process restart with
+    // the in-memory backend, or a `/stop` handled by another instance). The
+    // client minted a turn but we can no longer reattach — this is the
+    // server-side counterpart of the client's silent-disconnect rescue.
+    logger.info("Stream resume: stale pointer, cannot reattach", {
+      chatId,
+      streamId: activeStreamId,
+      reason: "stale-pointer",
+    });
+    // Clear it so future mounts short-circuit.
+    void Chat.updateOne(
+      { _id: new ObjectId(chatId), activeStreamId },
+      { $set: { activeStreamId: null } },
+    ).catch(error =>
+      logger.warn("Failed to clear stale activeStreamId", { error, chatId }),
+    );
+    return { kind: "no-content", reason: "stale-pointer" };
+  }
+
+  logger.info("Client reattached to chat stream", {
+    chatId,
+    streamId: activeStreamId,
+  });
+  // Keep the reattached connection warm during long silent tool gaps, same
+  // as the live POST branch. Without this, a client that resumes mid-turn is
+  // dropped by the edge proxy's idle timeout (~100s with no bytes) whenever a
+  // server-side tool runs quietly, stranding the resumed turn.
+  return {
+    kind: "stream",
+    response: withSseKeepAlive(
+      new Response(stream.pipeThrough(new TextEncoderStream()), {
+        headers: UI_MESSAGE_STREAM_HEADERS,
+      }),
+    ),
+  };
+}
+
+export type StopChatGenerationResult =
+  | { kind: "stopped"; stopped: boolean }
+  | { kind: "not-found" }
+  | { kind: "forbidden"; status: 400 | 401 | 403 };
+
+/**
+ * Explicitly abort the chat's in-flight generation. With resumable streams a
+ * client disconnect (refresh, tab close) intentionally no longer cancels the
+ * turn, so the Stop button calls this. Aborting triggers the normal
+ * onFinish(isAborted) path, which persists the partial assistant message and
+ * clears the resume pointer.
+ */
+export async function stopChatGeneration(
+  c: AuthenticatedContext,
+  chatId: string,
+): Promise<StopChatGenerationResult> {
+  const access = await authorizeChatStreamAccess(c, chatId);
+  if (!access.ok) {
+    if (access.status === 404) return { kind: "not-found" };
+    return { kind: "forbidden", status: access.status };
+  }
+
+  const stopped = stopActiveGeneration(chatId);
+
+  // Clear the pointer immediately so reconnecting clients don't reattach to
+  // the aborted stream. Finalization also clears it, but only on the
+  // instance that owns the generation.
+  await Chat.updateOne(
+    { _id: new ObjectId(chatId) },
+    { $set: { activeStreamId: null } },
+  );
+  publishRealtimeEvent(access.chat.workspaceId, {
+    type: "chat.activity",
+    chatId,
+    state: "idle",
+  });
+
+  logger.info("Chat generation stop requested", { chatId, stopped });
+  return { kind: "stopped", stopped };
+}

--- a/api/src/services/agent-thread.service.ts
+++ b/api/src/services/agent-thread.service.ts
@@ -5,7 +5,10 @@ import { Chat, SavedConsole } from "../database/workspace-schema";
 import type { AgentKind } from "../agent-lib";
 import { loggers } from "../logging";
 import { isModelReadyFilePart } from "../utils/message-sanitizer";
-import { dedupeAssistantReasoning } from "../agent-lib/context/compaction";
+import {
+  dedupeAssistantReasoning,
+  dedupeAssistantStreamArtifacts,
+} from "../agent-lib/context/compaction";
 import { externalizeChatAttachments } from "./chat-attachment.service";
 
 const logger = loggers.agent();
@@ -721,7 +724,21 @@ export const saveChat = async (
     });
   }
 
-  const storedMessages = reasoningDedupe.messages.map(
+  // Same lifecycle, different part kinds: resumable-stream replays append
+  // duplicate text/step-start parts (they have no id to merge on, unlike tool
+  // and reasoning parts). Strip byte-identical repeats before persisting so a
+  // corrupted in-flight turn doesn't poison the chat for every later load.
+  const artifactDedupe = dedupeAssistantStreamArtifacts(
+    reasoningDedupe.messages,
+  );
+  if (artifactDedupe.changed) {
+    logger.warn("Removed replayed text/step-start parts before persistence", {
+      chatId,
+      removedCount: artifactDedupe.removedCount,
+    });
+  }
+
+  const storedMessages = artifactDedupe.messages.map(
     convertUIMessageToStoredFormat,
   );
 

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -5,85 +5,48 @@
 import React, {
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useState,
   useRef,
 } from "react";
 import {
   Box,
-  Button,
   Chip,
   IconButton,
-  List,
-  ListItem,
-  ListItemText,
-  MenuItem,
-  Paper,
-  TextField,
   Typography,
-  Menu,
-  ListItemIcon,
   Alert,
   Collapse,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
   Tooltip,
 } from "@mui/material";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import {
-  prism,
-  tomorrow,
-} from "react-syntax-highlighter/dist/esm/styles/prism";
-import { StreamingMarkdown } from "./StreamingMarkdown";
-import {
-  ArrowUp,
   ChevronDown,
-  ChevronRight,
-  ChevronUp,
-  Circle,
   Copy,
   Check,
   History,
-  ImagePlus,
   Menu as MenuIcon,
-  Pencil,
   Plus,
-  MessageSquare,
-  Trash2,
-  X,
 } from "lucide-react";
-import { useTheme as useMuiTheme, keyframes } from "@mui/material/styles";
+import { useTheme as useMuiTheme } from "@mui/material/styles";
 import { useChat } from "@ai-sdk/react";
 import { Virtuoso, type VirtuosoHandle, type Components } from "react-virtuoso";
 import {
   DefaultChatTransport,
   lastAssistantMessageIsCompleteWithToolCalls,
-  type FileUIPart,
 } from "ai";
+import { api } from "../api/client";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useConsoleStore } from "../store/consoleStore";
-import { executeDashboardAgentTool } from "../dashboard-runtime/agent-tools";
 import type { ConsoleTab } from "../store/lib/types";
 import { useDatabaseCatalogStore } from "../store/databaseCatalogStore";
 import { useSettingsStore } from "../store/settingsStore";
 import { useSchemaStore } from "../store/schemaStore";
 import { selectActiveExplorer, useUIStore } from "../store/uiStore";
 import { useRealtimeStore } from "../store/realtimeStore";
-import { useAppStore } from "../store/appStore";
-import { useDbtStore } from "../store/dbtStore";
 import { useIsMobile } from "../hooks/useIsMobile";
-import { ModelSelector } from "./ModelSelector";
 import { generateObjectId } from "../utils/objectId";
-import type { ConsoleModification } from "../hooks/useMonacoConsole";
-import { trackEvent } from "../lib/analytics";
 import { DbFlowFormRef } from "./DbFlowForm";
 import { safeStringify, toJsonSafe } from "../lib/json-safe";
-import { StreamingToolCard, type ToolPartState } from "./StreamingToolCard";
 import { ClarifyingQuestionsCard } from "./ClarifyingQuestionsCard";
-import { DbtRunCard } from "./DbtRunCard";
 import { PlanCard } from "./PlanCard";
 import {
   focusPlanTab,
@@ -93,1148 +56,48 @@ import {
 } from "../store/planStore";
 import type {
   AskClarifyingQuestionsInput,
-  AskClarifyingQuestionsOutput,
   SubmitPlanInput,
-  SubmitPlanOutput,
 } from "@mako/agent-tools";
-import {
-  computeReasoningGroups,
-  getStreamingReasoningGroupStart,
-} from "./reasoning-groups";
-import {
-  chatMessageRowArePropsEqual,
-  type ChatMessageRowProps,
-} from "./chat-message-comparator";
+import { type ChatMessageRowProps } from "./chat-message-comparator";
 import {
   buildChatRequestBody,
   type ActiveConsoleResultsContext,
 } from "../agent-runtime/request-context";
-import { executeConsoleAgentTool } from "../agent-runtime/console-agent-tools";
 import { consumePendingScreenshotVisionAttachments } from "../agent-runtime/screenshot-agent-tools";
-import { buildModificationDiff } from "../utils/consoleModification";
-import {
-  DASHBOARD_EXECUTOR_TOOL_NAMES,
-  APP_EXECUTOR_TOOL_NAMES,
-  DBT_EXECUTOR_TOOL_NAMES,
-  DATA_SOURCE_EXECUTOR_TOOL_NAMES,
-  getAgentToolManifestEntry,
-  type AgentToolName,
-} from "../agent-runtime/client-tool-manifest";
-import { executeAppAgentTool } from "../app-runtime/agent-tools";
-import { executeDbtAgentTool } from "../dbt-runtime/agent-tools";
-import { executeDataSourceTool } from "../agent-runtime/data-source-tools";
 import { UpgradePrompt } from "./UpgradePrompt";
+import {
+  readStoredChatSession,
+  writeStoredChatSession,
+  type StoredChatSession,
+} from "./chat/session-storage";
+import {
+  type AutoSendPredicateArgs,
+  type ToolInvocationInfo,
+} from "./chat/tool-presentation";
+import {
+  useClientToolRegistry,
+  type AddToolOutputFn,
+} from "./chat/hooks/useClientToolRegistry";
+import {
+  useClientToolDispatch,
+  type DispatchableToolCall,
+} from "./chat/hooks/useClientToolDispatch";
+import { useStreamResume } from "./chat/hooks/useStreamResume";
+import { useServerToolSync } from "./chat/hooks/useServerToolSync";
+import { useChatSessions } from "./chat/hooks/useChatSessions";
+import { ChatHistoryMenu } from "./chat/ChatHistoryMenu";
+import { ToolDetailsDialog } from "./chat/ToolDetailsDialog";
+import { useChatSessionLoader } from "./chat/hooks/useChatSessionLoader";
+import { useQueuedPrompts } from "./chat/hooks/useQueuedPrompts";
+import { useChatScroll } from "./chat/hooks/useChatScroll";
+import { ChatMessageRow, MessageVirtuosoList } from "./chat/ChatMessageRow";
+import { QueuedPromptList } from "./chat/QueuedPrompts";
+import { ChatInputArea } from "./chat/ChatInputArea";
 import {
   onRenderDebug,
   useRenderCount,
   useWhyChanged,
 } from "../utils/renderDebug";
-
-interface ChatSessionMeta {
-  _id: string;
-  title: string;
-  createdAt?: string;
-  updatedAt?: string;
-  /** Resume pointer set while a turn is generating server-side. */
-  activeStreamId?: string | null;
-}
-
-// Human-in-the-loop tools resolve via an interactive card (the user answers /
-// approves), not via an `execute` result. They legitimately stay pending at
-// `input-available` with no output until the user acts, so any "settle the
-// dangling tool" cleanup must skip them — otherwise the card is torn down
-// before it can be answered. Part types are `tool-<toolName>`.
-const HUMAN_IN_THE_LOOP_TOOL_PART_TYPES = new Set([
-  "tool-ask_clarifying_questions",
-  "tool-submit_plan",
-]);
-
-function isHumanInTheLoopToolPartType(partType: string): boolean {
-  return HUMAN_IN_THE_LOOP_TOOL_PART_TYPES.has(partType);
-}
-
-function toolNameFromPartType(partType: string): string {
-  return partType.startsWith("tool-")
-    ? partType.slice("tool-".length)
-    : partType;
-}
-
-// Server-executed mutation tools (issue #475 pattern) whose open-tab sync we
-// ALSO reconcile off the resumable chat stream — in addition to the workspace
-// realtime poke (app.updated / dbt.file.updated) — so an open app / dbt tab
-// converges even when the workspace SSE is dead (mobile lock / laptop sleep).
-const APP_SERVER_MUTATION_TOOLS = new Set<string>([
-  "app_write_file",
-  "app_delete_file",
-  "app_rename_file",
-  "app_add_dependency",
-  "app_remove_dependency",
-  "app_create_data_binding",
-  "app_delete_data_binding",
-]);
-const DBT_SERVER_MUTATION_TOOLS = new Set<string>([
-  "create_dbt_file",
-  "modify_dbt_file",
-  "delete_dbt_file",
-]);
-
-// Diagnostics for the *live* stream-disconnect signatures so they can be
-// investigated after the fact:
-//   - "orphan-rescue": a turn settled to `ready` while non-interactive tool
-//     cards were still pending (the silent SSE drop → 204 reconnect path).
-//   - "stream-error":  the SDK surfaced a thrown stream error (e.g. a 524 or a
-//     network drop when the tab is frozen by a mobile lock / computer sleep).
-//   - "wake-resume":   the tab woke (visibility/focus/pageshow/resume) with an
-//     in-flight turn, so we proactively reattached to the buffered stream.
-// `resumed` records whether we attempted a resume (reattach) rather than
-// poisoning the tool cards — the recovery path we want to confirm in prod.
-// Emits a structured console line for live debugging and a PostHog product
-// event so frequency / affected tools are queryable. Correlate with the
-// server's `mako.agent` logs (and the resume-endpoint 204 reasons) via chatId.
-type StreamInterruptionPath = "orphan-rescue" | "stream-error" | "wake-resume";
-
-function reportStreamInterruption(detail: {
-  path: StreamInterruptionPath;
-  chatId: string;
-  status: string;
-  toolNames: string[];
-  recoveredToolNames?: string[];
-  errorMessage?: string;
-  resumed?: boolean;
-}): void {
-  console.warn("[Chat][stream-interrupted]", detail);
-  trackEvent("ai_chat_stream_interrupted", {
-    interruption_path: detail.path,
-    chat_id: detail.chatId,
-    chat_status: detail.status,
-    tool_names: detail.toolNames.join(",") || "(none)",
-    tool_count: detail.toolNames.length,
-    recovered_tool_names: detail.recoveredToolNames?.join(",") || "(none)",
-    recovered_count: detail.recoveredToolNames?.length ?? 0,
-    error_message: detail.errorMessage,
-    resumed: detail.resumed ?? false,
-  });
-}
-
-// ── Per-tab chat session persistence ─────────────────────────────
-// sessionStorage scopes the active chat to the browser tab: a refresh
-// restores (and reattaches to) the same chat, while new tabs start blank.
-
-const CHAT_SESSION_STORAGE_KEY = "mako:active-chat";
-
-interface StoredChatSession {
-  chatId: string;
-  workspaceId: string;
-}
-
-function readStoredChatSession(): StoredChatSession | null {
-  try {
-    const raw = sessionStorage.getItem(CHAT_SESSION_STORAGE_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as Partial<StoredChatSession>;
-    if (
-      typeof parsed.chatId === "string" &&
-      /^[0-9a-fA-F]{24}$/.test(parsed.chatId) &&
-      typeof parsed.workspaceId === "string"
-    ) {
-      return { chatId: parsed.chatId, workspaceId: parsed.workspaceId };
-    }
-  } catch {
-    /* sessionStorage unavailable or corrupted entry */
-  }
-  return null;
-}
-
-function writeStoredChatSession(session: StoredChatSession): void {
-  try {
-    sessionStorage.setItem(CHAT_SESSION_STORAGE_KEY, JSON.stringify(session));
-  } catch {
-    /* ignore storage failures (private mode, quota) */
-  }
-}
-
-// CodeBlock component for syntax highlighting
-const CodeBlock = React.memo(
-  ({
-    language,
-    children,
-    isGenerating,
-    scrollable,
-    paletteMode,
-  }: {
-    language: string;
-    children: string;
-    isGenerating: boolean;
-    scrollable?: boolean;
-    /** Included so memo re-renders when the app theme toggles */
-    paletteMode: "light" | "dark";
-  }) => {
-    const effectiveMode = paletteMode;
-    const syntaxTheme = effectiveMode === "dark" ? tomorrow : prism;
-    const [isExpanded, setIsExpanded] = React.useState(false);
-    const [isCopied, setIsCopied] = React.useState(false);
-
-    const lines = children.split("\n");
-    const needsExpansion = lines.length > 12;
-
-    const isScrollable = !!scrollable;
-    const displayedCode = isScrollable
-      ? children
-      : needsExpansion && !isExpanded
-        ? lines.slice(0, 12).join("\n")
-        : children;
-
-    const handleCopy = async () => {
-      try {
-        await navigator.clipboard.writeText(children);
-        setIsCopied(true);
-        setTimeout(() => setIsCopied(false), 2000);
-      } catch (err) {
-        console.error("Failed to copy code:", err);
-      }
-    };
-
-    return (
-      <Box
-        sx={{
-          overflow: "hidden",
-          borderRadius: 1,
-          my: 1,
-          position: "relative",
-        }}
-      >
-        {isGenerating && (
-          <Box
-            sx={{
-              position: "absolute",
-              top: 0,
-              left: 0,
-              right: 0,
-              bottom: 0,
-              zIndex: 1,
-            }}
-          >
-            <Typography variant="body2" color="text.primary">
-              Generating...
-            </Typography>
-          </Box>
-        )}
-        <Box
-          sx={{
-            position: "absolute",
-            top: 8,
-            right: 8,
-            zIndex: 1,
-          }}
-        >
-          <IconButton
-            size="small"
-            onClick={handleCopy}
-            sx={{
-              backgroundColor:
-                effectiveMode === "dark"
-                  ? "rgba(255,255,255,0.1)"
-                  : "rgba(0,0,0,0.1)",
-              "&:hover": {
-                backgroundColor:
-                  effectiveMode === "dark"
-                    ? "rgba(255,255,255,0.2)"
-                    : "rgba(0,0,0,0.2)",
-              },
-              transition: "all 0.2s",
-            }}
-          >
-            {isCopied ? (
-              <Check
-                size={16}
-                style={{ color: "var(--mui-palette-success-main, #4caf50)" }}
-              />
-            ) : (
-              <Copy size={16} />
-            )}
-          </IconButton>
-        </Box>
-
-        <SyntaxHighlighter
-          style={syntaxTheme}
-          language={language}
-          PreTag="div"
-          customStyle={{
-            fontSize: "0.8rem",
-            margin: 0,
-            overflow: "auto",
-            maxWidth: "100%",
-            maxHeight: isScrollable ? "50vh" : undefined,
-            paddingBottom: needsExpansion && !isScrollable ? "2rem" : "0.75rem",
-            paddingTop: "0.75rem",
-          }}
-        >
-          {displayedCode}
-        </SyntaxHighlighter>
-
-        {needsExpansion && !isScrollable && (
-          <Box
-            sx={{
-              position: "absolute",
-              bottom: 0,
-              left: 0,
-              right: 0,
-              display: "flex",
-              justifyContent: "center",
-            }}
-          >
-            <Button
-              size="small"
-              onClick={() => setIsExpanded(!isExpanded)}
-              sx={{
-                borderRadius: 0,
-                flexGrow: 1,
-                color: "text.primary",
-                backgroundColor:
-                  effectiveMode === "dark"
-                    ? "rgba(0, 0, 0, 0.3)"
-                    : "rgba(255, 255, 255, 0.3)",
-                "&:hover": {
-                  backgroundColor:
-                    effectiveMode === "dark"
-                      ? "rgba(0, 0, 0, 0.1)"
-                      : "rgba(255, 255, 255, 0.1)",
-                },
-              }}
-            >
-              {isExpanded ? <ChevronUp size={20} /> : <ChevronDown size={20} />}
-            </Button>
-          </Box>
-        )}
-      </Box>
-    );
-  },
-);
-
-CodeBlock.displayName = "CodeBlock";
-
-// Tool part structure - tool type is "tool-{toolName}" with state/input/output
-interface ToolInvocationInfo {
-  toolCallId: string;
-  toolName: string;
-  state:
-    | "input-streaming"
-    | "input-available"
-    | "output-streaming"
-    | "output-available"
-    | "error";
-  input?: unknown;
-  output?: unknown;
-}
-
-type AutoSendPredicateArgs = Parameters<
-  typeof lastAssistantMessageIsCompleteWithToolCalls
->[0];
-
-function hasPendingAssistantToolCalls(
-  messages: AutoSendPredicateArgs["messages"],
-): boolean {
-  const last = messages.at(-1);
-  if (!last?.parts || last.role !== "assistant") return false;
-
-  return last.parts.some(part => {
-    const partType = part.type as string;
-    if (!partType.startsWith("tool-") && partType !== "dynamic-tool") {
-      return false;
-    }
-    const state = (part as { state?: string }).state;
-    return (
-      state !== "output-available" &&
-      state !== "output-error" &&
-      state !== "error"
-    );
-  });
-}
-
-interface ActiveClientToolCall {
-  toolCallId: string;
-  toolName: string;
-  executionId: string;
-  abortController: AbortController;
-  cancel: () => void | Promise<void>;
-  cancellationOutput: Record<string, unknown>;
-  settled: boolean;
-}
-
-function asToolPayload(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object"
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
-
-function getConsoleIdFromToolPayload(
-  input: unknown,
-  output: unknown,
-): string | null {
-  const inputObj = asToolPayload(input);
-  const outputObj = asToolPayload(output);
-  const consoleId = inputObj?.consoleId ?? outputObj?.consoleId;
-  return typeof consoleId === "string" && consoleId.length > 0
-    ? consoleId
-    : null;
-}
-
-interface ConsoleToolPresentation {
-  consoleId: string;
-  title: string;
-  iconUrl?: string;
-  diff?: string;
-}
-
-function getConsoleToolPresentation(
-  toolName: string,
-  input: unknown,
-  output: unknown,
-  connectionIconById: ReadonlyMap<string, string>,
-  state: ToolPartState,
-): ConsoleToolPresentation | null {
-  if (toolName !== "modify_console") return null;
-
-  const store = useConsoleStore.getState();
-  const inputObj = asToolPayload(input);
-  const outputObj = asToolPayload(output);
-  const consoleId = getConsoleIdFromToolPayload(input, output);
-  if (!consoleId) return null;
-
-  const consoleTab = store.tabs[consoleId];
-  const inputTitle = inputObj?.title;
-  const outputTitle = outputObj?.title;
-  const title =
-    consoleTab?.title ??
-    (typeof inputTitle === "string" ? inputTitle : undefined) ??
-    (typeof outputTitle === "string" ? outputTitle : undefined) ??
-    "Untitled console";
-
-  // While the input is still streaming, the `content` field is partial, so a
-  // line-diff against the existing console re-aligns its +/- groupings on every
-  // token (interleaved → grouped as more text arrives) — the modify_console
-  // "blink like mad" the diff card showed under Virtuoso. Skip the live diff
-  // while streaming: with no diff, the card falls back to rendering the raw
-  // `content` as plain SQL, which grows append-only and streams smoothly
-  // (exactly the token-by-token write users want, same path as create_console).
-  // Once the content is complete (`input-available`/`output-available`) the diff
-  // is stable, so we show the proper red/green diff again — preferring the final
-  // server `outputDiff` when present.
-  const outputDiff = outputObj?.diff;
-  const diff =
-    typeof outputDiff === "string" && outputDiff.length > 0
-      ? outputDiff
-      : state === "input-streaming"
-        ? undefined
-        : buildStreamingModificationDiff(inputObj, consoleTab);
-
-  return {
-    consoleId,
-    title,
-    iconUrl: consoleTab?.connectionId
-      ? connectionIconById.get(consoleTab.connectionId)
-      : undefined,
-    diff,
-  };
-}
-
-function buildStreamingModificationDiff(
-  input: Record<string, unknown> | undefined,
-  consoleTab: ConsoleTab | undefined,
-): string | undefined {
-  const action = input?.action;
-  const content = input?.content;
-  if (
-    !input ||
-    !consoleTab ||
-    typeof action !== "string" ||
-    typeof content !== "string" ||
-    content.length === 0
-  ) {
-    return undefined;
-  }
-
-  const position = input.position;
-  const startLine = input.startLine;
-  const endLine = input.endLine;
-  const modification: ConsoleModification = {
-    action: action as ConsoleModification["action"],
-    content,
-    position:
-      typeof position === "number" ? { line: position, column: 1 } : undefined,
-    startLine: typeof startLine === "number" ? startLine : undefined,
-    endLine: typeof endLine === "number" ? endLine : undefined,
-  };
-
-  return buildModificationDiff(consoleTab.content || "", modification);
-}
-
-// ReasoningDisplay for showing reasoning/thinking parts inline.
-// - Auto-opens while streaming, auto-collapses when done.
-// - Shows elapsed thinking time ("Thought for Xs").
-// - Scrollable container with max height, auto-scrolls during streaming.
-const ReasoningDisplay = React.memo(
-  ({
-    reasoningText,
-    isStreaming,
-    paletteMode: _paletteMode,
-  }: {
-    reasoningText: string;
-    isStreaming: boolean;
-    paletteMode: "light" | "dark";
-  }) => {
-    const [userToggled, setUserToggled] = React.useState(false);
-    const [userOpen, setUserOpen] = React.useState(false);
-    const [elapsedSeconds, setElapsedSeconds] = React.useState(0);
-    // Latches true once this block has streamed and then stopped. A finished
-    // thinking block must NEVER auto-reopen: reopening it would grow a block
-    // sitting ABOVE the currently-streaming one, shifting everything below and
-    // making the chat jump. Once done it stays collapsed unless the user opens
-    // it. (A given reasoning group streams exactly once, so latching is safe.)
-    const [finished, setFinished] = React.useState(false);
-    // Track whether this component was live-streamed (vs loaded from history)
-    const wasLiveRef = React.useRef(false);
-    const startTimeRef = React.useRef<number | null>(null);
-    const scrollRef = React.useRef<HTMLDivElement>(null);
-
-    // Auto-open only while THIS block is actively streaming and not yet
-    // finished; auto-close the moment it finishes. If the user manually
-    // toggled, respect their choice.
-    const isOpen = userToggled ? userOpen : isStreaming && !finished;
-
-    const handleToggle = () => {
-      setUserToggled(true);
-      setUserOpen(!isOpen);
-    };
-
-    // Timer: start counting when streaming begins, freeze when it stops
-    React.useEffect(() => {
-      // Never restart a block that already finished (guards against a spurious
-      // `isStreaming` flip re-opening / re-timing a completed block).
-      if (isStreaming && !finished) {
-        // Mark that this component saw a live session
-        wasLiveRef.current = true;
-        // Reset for new streaming session
-        setUserToggled(false);
-        startTimeRef.current = Date.now();
-        setElapsedSeconds(0);
-
-        const interval = setInterval(() => {
-          if (startTimeRef.current) {
-            setElapsedSeconds(
-              Math.round((Date.now() - startTimeRef.current) / 1000),
-            );
-          }
-        }, 1000);
-
-        return () => clearInterval(interval);
-      }
-      // Streaming just stopped — freeze the elapsed time
-      // (elapsedSeconds already holds the last value) and latch this block as
-      // done so it can never auto-reopen.
-      startTimeRef.current = null;
-      if (wasLiveRef.current) setFinished(true);
-    }, [isStreaming, finished]);
-
-    // Auto-scroll the reasoning container to the bottom while streaming
-    React.useEffect(() => {
-      if (isStreaming && isOpen && scrollRef.current) {
-        scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-      }
-    }, [reasoningText, isStreaming, isOpen]);
-
-    // Build the label text
-    let label: string;
-    if (isStreaming) {
-      label = `Thinking${elapsedSeconds > 0 ? ` for ${elapsedSeconds}s` : ""}...`;
-    } else if (wasLiveRef.current) {
-      label = `Thought for ${elapsedSeconds || "<1"}s`;
-    } else {
-      label = "Thinking process";
-    }
-
-    return (
-      <Box sx={{ my: 0.5 }}>
-        <Button
-          size="small"
-          onClick={handleToggle}
-          endIcon={
-            isOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />
-          }
-          sx={{
-            color: "text.secondary",
-            textTransform: "none",
-            fontSize: "0.8rem",
-            p: 0,
-            minWidth: "auto",
-            "& .MuiButton-endIcon": {
-              opacity: isOpen ? 1 : 0,
-              transition: "opacity 0.15s ease",
-            },
-            "&:hover .MuiButton-endIcon": {
-              opacity: 1,
-            },
-            "&:hover": {
-              backgroundColor: "transparent",
-            },
-          }}
-          disableRipple
-        >
-          {label}
-        </Button>
-        {isOpen && (
-          <Box
-            ref={scrollRef}
-            sx={{
-              mt: 0.5,
-              pl: 2,
-              borderLeft: 2,
-              borderColor: "divider",
-              color: "text.secondary",
-              fontSize: "0.85rem",
-              maxHeight: 300,
-              overflowY: "auto",
-              "& p": { my: 0.5 },
-            }}
-          >
-            <StreamingMarkdown>{reasoningText}</StreamingMarkdown>
-          </Box>
-        )}
-      </Box>
-    );
-  },
-);
-
-ReasoningDisplay.displayName = "ReasoningDisplay";
-
-// Stable keyframes animation defined outside component to prevent re-renders
-const pulseAnimation = keyframes`
-  0%, 100% { opacity: 0.4; transform: scale(1); }
-  50% { opacity: 1; transform: scale(1.35); }
-`;
-
-// Queue card slides up from behind the chat input as it reveals
-const queueSlideUp = keyframes`
-  from { opacity: 0; transform: translateY(100%); }
-  to { opacity: 1; transform: translateY(0); }
-`;
-
-// Stable style objects to prevent re-renders
-const streamingIndicatorContainerSx = {
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  width: 14,
-  height: 14,
-  overflow: "visible",
-  lineHeight: 0,
-  flexShrink: 0,
-  mt: 0.5,
-} as const;
-
-const streamingIndicatorDotSx = {
-  width: 8,
-  height: 8,
-  borderRadius: "50%",
-  backgroundColor: "primary.main",
-  animation: `${pulseAnimation} 1s infinite ease-in-out`,
-} as const;
-
-// StreamingIndicator - Shows pulsing dot while content is being streamed
-// (not memoized) so it picks up theme updates when the parent palette changes
-function StreamingIndicator() {
-  return (
-    <Box component="span" sx={streamingIndicatorContainerSx}>
-      <Box sx={streamingIndicatorDotSx} />
-    </Box>
-  );
-}
-
-// ── Memoized message row ─────────────────────────────────────────
-// Prevents completed messages from re-rendering on every streaming chunk.
-
-const userMessageSx = { flex: 1, mt: 2, minWidth: 0 } as const;
-const userMessagePaperSx = {
-  p: 1,
-  borderRadius: 1,
-  backgroundColor: "background.paper",
-  overflow: "hidden",
-} as const;
-const userMessageTextSx = {
-  maxWidth: "100%",
-  whiteSpace: "pre-wrap",
-  wordBreak: "break-word",
-  overflowWrap: "break-word",
-} as const;
-const assistantMessageSx = {
-  flex: 1,
-  overflow: "hidden",
-  fontSize: "0.875rem",
-  mt: 1,
-  "& pre": { margin: 0, overflow: "hidden" },
-} as const;
-const listItemSx = { p: 0 } as const;
-
-// Sent user messages are collapsed in the history so a long prompt doesn't
-// dominate the transcript. Show at most this many lines before clamping.
-const USER_MESSAGE_COLLAPSED_LINES = 3;
-
-const userMessageToggleSx = {
-  display: "inline-block",
-  mt: 0.5,
-  border: "none",
-  background: "none",
-  p: 0,
-  cursor: "pointer",
-  color: "text.secondary",
-  fontWeight: 600,
-  "&:hover": { color: "text.primary", textDecoration: "underline" },
-} as const;
-
-/**
- * Renders a sent user message's text, collapsed to a few lines with an ellipsis
- * when it's long. Clicking the text (or the Show more/less toggle) expands and
- * re-collapses it. The toggle only appears when the text actually overflows the
- * collapsed clamp, so short messages render unchanged.
- */
-function CollapsibleUserText({ text }: { text: string }) {
-  const [expanded, setExpanded] = useState(false);
-  const [isOverflowing, setIsOverflowing] = useState(false);
-  const textRef = useRef<HTMLDivElement | null>(null);
-
-  // Measure whether the clamped text overflows. Only meaningful while
-  // collapsed, where the clamp limits height; comparing the full content
-  // height (scrollHeight) against the visible height (clientHeight) tells us
-  // if there's hidden content worth a toggle.
-  useLayoutEffect(() => {
-    if (expanded) return;
-    const el = textRef.current;
-    if (!el) return;
-    setIsOverflowing(el.scrollHeight > el.clientHeight + 1);
-  }, [text, expanded]);
-
-  const canToggle = isOverflowing || expanded;
-  const toggle = useCallback(() => setExpanded(prev => !prev), []);
-
-  return (
-    <Box>
-      <Typography
-        ref={textRef}
-        variant="body2"
-        color="text.primary"
-        onClick={canToggle ? toggle : undefined}
-        sx={{
-          ...userMessageTextSx,
-          ...(canToggle && { cursor: "pointer" }),
-          ...(!expanded && {
-            display: "-webkit-box",
-            WebkitBoxOrient: "vertical",
-            WebkitLineClamp: USER_MESSAGE_COLLAPSED_LINES,
-            overflow: "hidden",
-          }),
-        }}
-      >
-        {text}
-      </Typography>
-      {canToggle && (
-        <Typography
-          component="button"
-          type="button"
-          onClick={toggle}
-          variant="caption"
-          sx={userMessageToggleSx}
-        >
-          {expanded ? "Show less" : "Show more"}
-        </Typography>
-      )}
-    </Box>
-  );
-}
-
-/**
- * Lightweight, dependency-free image lightbox. Shows the full (uncropped) image
- * centered over a dimmed backdrop; closes on backdrop click, the X button, or
- * Escape (handled by MUI Dialog).
- */
-function ImagePreviewDialog({
-  src,
-  onClose,
-}: {
-  src: string | null;
-  onClose: () => void;
-}) {
-  return (
-    <Dialog
-      open={Boolean(src)}
-      onClose={onClose}
-      maxWidth="lg"
-      slotProps={{
-        paper: {
-          sx: {
-            backgroundColor: "transparent",
-            boxShadow: "none",
-            m: 2,
-            overflow: "visible",
-          },
-        },
-      }}
-    >
-      <Box sx={{ position: "relative", display: "flex" }}>
-        <IconButton
-          onClick={onClose}
-          aria-label="Close preview"
-          size="small"
-          sx={{
-            position: "absolute",
-            top: 8,
-            right: 8,
-            color: "common.white",
-            backgroundColor: "rgba(0, 0, 0, 0.6)",
-            "&:hover": { backgroundColor: "rgba(0, 0, 0, 0.8)" },
-          }}
-        >
-          <X size={18} />
-        </IconButton>
-        {src && (
-          <Box
-            component="img"
-            src={src}
-            alt="Image preview"
-            sx={{
-              maxWidth: "90vw",
-              maxHeight: "85vh",
-              borderRadius: 1,
-              objectFit: "contain",
-              display: "block",
-            }}
-          />
-        )}
-      </Box>
-    </Dialog>
-  );
-}
-
-const ChatMessageRow = React.memo(function ChatMessageRow({
-  message,
-  isLastMessage,
-  isStreaming,
-  onToolClick,
-  onConsoleTitleClick,
-  connectionIconById,
-  paletteMode,
-}: ChatMessageRowProps) {
-  const parts = (message.parts || []) as Array<Record<string, unknown>>;
-  useRenderCount(`ChatMessageRow:${message.id}`, {
-    role: message.role,
-    partCount: parts.length,
-  });
-  useWhyChanged(`ChatMessageRow:${message.id}`, {
-    messageRef: message,
-    partsRef: message.parts,
-    partCount: parts.length,
-    isLastMessage,
-    isStreaming,
-    onToolClick,
-    onConsoleTitleClick,
-    connectionIconById,
-    paletteMode,
-  });
-
-  // Lightbox state for clicking an attached image to preview it full-size.
-  const [previewSrc, setPreviewSrc] = useState<string | null>(null);
-
-  if (message.role === "user") {
-    const fileParts = (message.parts || []).filter(
-      (p): p is { type: "file"; url: string; mediaType: string } =>
-        p.type === "file" && "url" in p,
-    );
-    const textContent =
-      (message.parts || [])
-        .filter(
-          (p): p is { type: "text"; text: string } =>
-            p.type === "text" && "text" in p,
-        )
-        .map(p => p.text)
-        .join("") || "";
-
-    return (
-      <ListItem alignItems="flex-start" sx={listItemSx}>
-        <Box sx={userMessageSx}>
-          <Paper variant="outlined" sx={userMessagePaperSx}>
-            {fileParts.length > 0 && (
-              <Box
-                sx={{
-                  display: "flex",
-                  flexWrap: "wrap",
-                  gap: 1,
-                  mb: textContent ? 1 : 0,
-                }}
-              >
-                {fileParts.map((fp, i) => (
-                  <Box
-                    key={i}
-                    component="img"
-                    src={fp.url}
-                    alt="Attached image"
-                    loading="lazy"
-                    decoding="async"
-                    onClick={() => setPreviewSrc(fp.url)}
-                    sx={{
-                      width: 56,
-                      height: 56,
-                      borderRadius: 1.5,
-                      objectFit: "cover",
-                      cursor: "pointer",
-                      border: 1,
-                      borderColor: "divider",
-                      display: "block",
-                    }}
-                  />
-                ))}
-              </Box>
-            )}
-            {textContent && <CollapsibleUserText text={textContent} />}
-          </Paper>
-        </Box>
-        <ImagePreviewDialog
-          src={previewSrc}
-          onClose={() => setPreviewSrc(null)}
-        />
-      </ListItem>
-    );
-  }
-
-  const isStreamingNow = isStreaming;
-
-  const reasoningGroups = computeReasoningGroups(parts);
-
-  // Stable identity for each reasoning block: its ordinal position among the
-  // message's reasoning groups (0, 1, 2…). Keying by this instead of the raw
-  // part index means an inserted `step-start`/tool/text part shifting the array
-  // can't remount an existing block — a remount would reset its `finished`
-  // latch and make it re-expand (flicker). Reasoning groups only ever append,
-  // so ordinals are stable for the lifetime of a block.
-  const reasoningGroupOrdinals = new Map<number, number>();
-  {
-    let ordinal = 0;
-    for (const start of reasoningGroups.keys()) {
-      reasoningGroupOrdinals.set(start, ordinal++);
-    }
-  }
-
-  const lastPartIndex = parts.length - 1;
-  const lastPart = parts.at(-1);
-  const isLastPartText =
-    isLastMessage && isStreamingNow && lastPart?.type === "text";
-
-  // The single reasoning group (if any) that should stay expanded because it
-  // owns the streaming last part. `null` when not streaming or the last part
-  // isn't reasoning, so previously-collapsed blocks are never re-opened.
-  const streamingReasoningGroupStart =
-    isLastMessage && isStreamingNow
-      ? getStreamingReasoningGroupStart(parts, reasoningGroups)
-      : null;
-
-  return (
-    <ListItem alignItems="flex-start" sx={listItemSx}>
-      <Box sx={assistantMessageSx}>
-        {parts.map((part, partIndex) => {
-          const partType = part.type as string;
-
-          if (partType?.startsWith("tool-") || partType === "dynamic-tool") {
-            const toolName =
-              partType === "dynamic-tool"
-                ? (part.toolName as string)
-                : partType.split("-").slice(1).join("-");
-            const rawState = part.state as string;
-            const cardState: ToolPartState =
-              rawState === "output-error"
-                ? "error"
-                : (part.state as ToolPartState);
-            const cardOutput =
-              rawState === "output-error"
-                ? {
-                    success: false,
-                    error:
-                      (part.errorText as string | undefined) ?? "Tool failed",
-                  }
-                : part.output;
-            const toolCallId = (part.toolCallId as string) || "";
-            const consoleToolPresentation = getConsoleToolPresentation(
-              toolName,
-              part.input,
-              cardOutput,
-              connectionIconById,
-              cardState,
-            );
-            // Key by toolCallId when available so reordering/insertion in the
-            // parts array doesn't remount completed tool cards. Falls back to
-            // a type+index tag for the (rare) case where toolCallId is missing.
-            const key = toolCallId
-              ? `tool-${toolCallId}`
-              : `tool-idx-${partIndex}`;
-
-            // Interactive plan-lifecycle tools: while pending they render in
-            // the docked panel above the composer (Cursor-style), NOT in the
-            // chat. Once resolved, a read-only summary appears inline here.
-            // Errors fall through to the generic tool card.
-            if (
-              toolName === "ask_clarifying_questions" ||
-              toolName === "submit_plan"
-            ) {
-              if (rawState === "output-available") {
-                if (toolName === "ask_clarifying_questions") {
-                  return (
-                    <ClarifyingQuestionsCard
-                      key={key}
-                      input={part.input as AskClarifyingQuestionsInput}
-                      output={part.output as AskClarifyingQuestionsOutput}
-                    />
-                  );
-                }
-                return (
-                  <PlanCard
-                    key={key}
-                    toolCallId={toolCallId}
-                    input={part.input as SubmitPlanInput}
-                    output={part.output as SubmitPlanOutput}
-                  />
-                );
-              }
-              if (rawState !== "output-error") {
-                return null;
-              }
-            }
-
-            // Async dbt builds: once dbt_run_model has dispatched a run (output
-            // carries a runId), render a live run card that self-polls the run
-            // — decoupled from the agent turn, so it keeps updating after the
-            // turn ends and resumes on chat reload. While the dispatch is still
-            // in flight, or if it errored without a runId, fall through to the
-            // generic card.
-            if (
-              toolName === "dbt_run_model" &&
-              rawState === "output-available"
-            ) {
-              const dbtOutput = cardOutput as { runId?: string } | undefined;
-              const dbtInput = part.input as
-                | { projectId?: string; model?: string }
-                | undefined;
-              if (dbtOutput?.runId && dbtInput?.projectId) {
-                return (
-                  <DbtRunCard
-                    key={key}
-                    runId={dbtOutput.runId}
-                    projectId={dbtInput.projectId}
-                    label={dbtInput.model}
-                  />
-                );
-              }
-            }
-            return (
-              <StreamingToolCard
-                key={key}
-                toolCallId={toolCallId}
-                toolName={toolName}
-                state={cardState}
-                input={part.input}
-                output={cardOutput}
-                labelOverride={consoleToolPresentation?.title}
-                leadingIconUrl={consoleToolPresentation?.iconUrl}
-                leadingIconAlt={
-                  consoleToolPresentation ? "Database" : undefined
-                }
-                bodyPreview={
-                  consoleToolPresentation?.diff
-                    ? {
-                        content: consoleToolPresentation.diff,
-                        language: "diff",
-                      }
-                    : undefined
-                }
-                onTitleClick={
-                  consoleToolPresentation
-                    ? () =>
-                        onConsoleTitleClick(consoleToolPresentation.consoleId)
-                    : undefined
-                }
-                onDetailClick={() =>
-                  onToolClick({
-                    toolCallId,
-                    toolName: toolName || "",
-                    state: part.state as ToolInvocationInfo["state"],
-                    input: part.input,
-                    output: cardOutput,
-                  })
-                }
-              />
-            );
-          }
-
-          if (partType === "reasoning") {
-            const group = reasoningGroups.get(partIndex);
-            if (!group) return null;
-            const isGroupStreaming = partIndex === streamingReasoningGroupStart;
-            // Skip empty reasoning groups unless they're the block currently
-            // streaming (a brand-new thinking block whose text hasn't arrived
-            // yet). This avoids rendering blank "Thinking process" blocks for
-            // empty reasoning parts loaded from history.
-            if (!group.text && !isGroupStreaming) return null;
-            return (
-              <ReasoningDisplay
-                key={`reasoning-group-${reasoningGroupOrdinals.get(partIndex) ?? partIndex}`}
-                reasoningText={group.text}
-                isStreaming={isGroupStreaming}
-                paletteMode={paletteMode}
-              />
-            );
-          }
-
-          if (partType === "text" && (part as { text?: string }).text) {
-            // Only the trailing text block of the actively streaming
-            // message is still growing — flag it so Streamdown knows to
-            // treat its last markdown block as incomplete. All earlier
-            // text blocks are static and can skip animation entirely.
-            const isTrailingStreamingText =
-              isLastPartText && partIndex === lastPartIndex;
-            return (
-              <StreamingMarkdown
-                key={`text-${partIndex}`}
-                isStreaming={isTrailingStreamingText}
-              >
-                {(part as { text: string }).text}
-              </StreamingMarkdown>
-            );
-          }
-
-          return null;
-        })}
-        {isStreaming && isLastMessage && <StreamingIndicator />}
-      </Box>
-    </ListItem>
-  );
-}, chatMessageRowArePropsEqual);
-
-ChatMessageRow.displayName = "ChatMessageRow";
-
-// List element Virtuoso renders the (windowed) message rows into. Rendered as
-// a MUI `<List dense component="div">` so the `dense` ListContext still reaches
-// each `ChatMessageRow`'s `<ListItem>` (context flows through Virtuoso's div
-// Item wrappers regardless of DOM nesting) while avoiding `<ul>` DOM-nesting
-// warnings. Virtuoso owns the inline `style` (it sets paddingTop/Bottom to
-// offset windowed items) so we must forward it onto the list element.
-const MessageVirtuosoList = React.memo(
-  React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-    function MessageVirtuosoList({ style, children }, ref) {
-      return (
-        <List dense component="div" ref={ref} style={style} sx={{ px: 1 }}>
-          {children}
-        </List>
-      );
-    },
-  ),
-);
-MessageVirtuosoList.displayName = "MessageVirtuosoList";
 
 // Virtuoso's `Components['List']` types `ref` as a `LegacyRef` (string refs
 // allowed), which is contravariant with forwardRef's `Ref`. The component is
@@ -1244,709 +107,6 @@ const messageVirtuosoComponents: Components<ChatMessageRowProps["message"]> = {
     ChatMessageRowProps["message"]
   >["List"],
 };
-
-// Isolated input component — owns its own `input` state so keystrokes
-// never re-render the (expensive) message list above it.
-
-interface ImageAttachment {
-  id: string;
-  file: File;
-  previewUrl: string;
-}
-
-interface QueuedPrompt {
-  id: string;
-  text: string;
-  files?: FileUIPart[];
-  consoleId: string | null;
-  dashboardId: string | null;
-}
-
-interface QueuedPromptListProps {
-  prompts: QueuedPrompt[];
-  editingId: string | null;
-  onStartEdit: (id: string) => void;
-  onSendNow: (id: string) => void;
-  onRemove: (id: string) => void;
-}
-
-interface QueuedPromptRowProps {
-  prompt: QueuedPrompt;
-  isEditing: boolean;
-  onStartEdit: (id: string) => void;
-  onSendNow: (id: string) => void;
-  onRemove: (id: string) => void;
-}
-
-const QUEUED_ROW_ACTION_BTN_SX = {
-  width: 22,
-  height: 22,
-  flexShrink: 0,
-  color: "text.secondary",
-  "&:hover": { color: "text.primary" },
-} as const;
-
-// One queued prompt. Editing happens in the main composer (Cursor-style), so
-// the row itself only renders the prompt + hover actions.
-const QueuedPromptRow = React.memo(
-  ({
-    prompt,
-    isEditing,
-    onStartEdit,
-    onSendNow,
-    onRemove,
-  }: QueuedPromptRowProps) => {
-    const imageCount = prompt.files?.length ?? 0;
-    const display = prompt.text || (imageCount > 0 ? "Image attachment" : "");
-
-    return (
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          gap: 1,
-          px: 1,
-          py: 0.5,
-          borderRadius: 1,
-          minHeight: 32,
-          backgroundColor: isEditing ? "action.selected" : "transparent",
-          "&:hover": {
-            backgroundColor: isEditing ? "action.selected" : "action.hover",
-          },
-          "&:hover .queued-prompt-actions": { opacity: 1 },
-        }}
-      >
-        <Box
-          sx={{
-            display: "flex",
-            alignItems: "center",
-            color: "text.secondary",
-            flexShrink: 0,
-          }}
-        >
-          <Circle size={10} />
-        </Box>
-
-        <Typography
-          variant="body2"
-          sx={{
-            flex: 1,
-            minWidth: 0,
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-            fontSize: 13,
-            color: "text.primary",
-          }}
-        >
-          {display}
-        </Typography>
-
-        {imageCount > 0 && (
-          <Typography
-            variant="caption"
-            sx={{ color: "text.secondary", flexShrink: 0 }}
-          >
-            {imageCount} {imageCount === 1 ? "image" : "images"}
-          </Typography>
-        )}
-
-        <Box
-          className="queued-prompt-actions"
-          sx={{
-            display: "flex",
-            alignItems: "center",
-            gap: 0.25,
-            flexShrink: 0,
-            opacity: 0,
-            transition: "opacity 120ms ease",
-          }}
-        >
-          <IconButton
-            type="button"
-            aria-label="Edit queued prompt"
-            onClick={() => onStartEdit(prompt.id)}
-            size="small"
-            sx={QUEUED_ROW_ACTION_BTN_SX}
-          >
-            <Pencil size={14} />
-          </IconButton>
-          <Tooltip title="Send now (interrupts the running chat)">
-            <IconButton
-              type="button"
-              aria-label="Send now (interrupts the running chat)"
-              onClick={() => onSendNow(prompt.id)}
-              size="small"
-              sx={QUEUED_ROW_ACTION_BTN_SX}
-            >
-              <ArrowUp size={14} />
-            </IconButton>
-          </Tooltip>
-          <IconButton
-            type="button"
-            aria-label="Remove queued prompt"
-            onClick={() => onRemove(prompt.id)}
-            size="small"
-            sx={QUEUED_ROW_ACTION_BTN_SX}
-          >
-            <Trash2 size={14} />
-          </IconButton>
-        </Box>
-      </Box>
-    );
-  },
-);
-QueuedPromptRow.displayName = "QueuedPromptRow";
-
-const QueuedPromptList = React.memo(
-  ({
-    prompts,
-    editingId,
-    onStartEdit,
-    onSendNow,
-    onRemove,
-  }: QueuedPromptListProps) => {
-    const [expanded, setExpanded] = useState(true);
-
-    if (prompts.length === 0) return null;
-
-    return (
-      <Box
-        sx={{
-          mx: 2.25,
-          mb: 0,
-          border: 1,
-          borderBottom: 0,
-          borderColor: "divider",
-          borderRadius: 2.5,
-          borderBottomLeftRadius: 0,
-          borderBottomRightRadius: 0,
-          p: 0.5,
-          transformOrigin: "bottom",
-          animation: `${queueSlideUp} 220ms cubic-bezier(0.4, 0, 0.2, 1)`,
-        }}
-      >
-        <Box
-          role="button"
-          tabIndex={0}
-          aria-expanded={expanded}
-          onClick={() => setExpanded(prev => !prev)}
-          onKeyDown={e => {
-            if (e.key === "Enter" || e.key === " ") {
-              e.preventDefault();
-              setExpanded(prev => !prev);
-            }
-          }}
-          sx={{
-            display: "flex",
-            alignItems: "center",
-            gap: 0.5,
-            px: 1,
-            py: 0.5,
-            cursor: "pointer",
-            color: "text.secondary",
-            borderRadius: 1,
-            "&:hover": { color: "text.primary" },
-          }}
-        >
-          {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-          <Typography
-            variant="caption"
-            sx={{ fontWeight: 600, letterSpacing: 0.2 }}
-          >
-            {prompts.length} Queued
-          </Typography>
-        </Box>
-
-        {expanded && (
-          <Box sx={{ display: "flex", flexDirection: "column" }}>
-            {prompts.map(prompt => (
-              <QueuedPromptRow
-                key={prompt.id}
-                prompt={prompt}
-                isEditing={prompt.id === editingId}
-                onStartEdit={onStartEdit}
-                onSendNow={onSendNow}
-                onRemove={onRemove}
-              />
-            ))}
-          </Box>
-        )}
-      </Box>
-    );
-  },
-);
-QueuedPromptList.displayName = "QueuedPromptList";
-
-interface ChatInputAreaProps {
-  onSubmit: (text: string, files?: FileUIPart[]) => void;
-  onStop: () => void;
-  isLoading: boolean;
-  disabled: boolean;
-  focusKey: string | number;
-  paletteMode: "light" | "dark";
-  editingPrompt: QueuedPrompt | null;
-  onCancelEdit: () => void;
-}
-
-function readFileAsDataUrl(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(reader.result as string);
-    reader.onerror = reject;
-    reader.readAsDataURL(file);
-  });
-}
-
-const ChatInputArea = React.memo(
-  ({
-    onSubmit,
-    onStop,
-    isLoading,
-    disabled,
-    focusKey,
-    paletteMode: _paletteMode,
-    editingPrompt,
-    onCancelEdit,
-  }: ChatInputAreaProps) => {
-    const [input, setInput] = useState("");
-    const [images, setImages] = useState<ImageAttachment[]>([]);
-    const [previewSrc, setPreviewSrc] = useState<string | null>(null);
-    const [isPreparingSubmission, setIsPreparingSubmission] = useState(false);
-    const inputRef = useRef<HTMLInputElement>(null);
-    const fileInputRef = useRef<HTMLInputElement>(null);
-    const imagesRef = useRef<ImageAttachment[]>([]);
-    // When entering edit mode, load the queued prompt's text into the composer
-    // and stash whatever the user was drafting so Cancel/commit can restore it.
-    const inputValueRef = useRef(input);
-    inputValueRef.current = input;
-    const preEditDraftRef = useRef("");
-    const prevEditingIdRef = useRef<string | null>(null);
-    useRenderCount("ChatInputArea", {
-      isLoading,
-      disabled,
-      imageCount: images.length,
-    });
-    useWhyChanged("ChatInputArea", {
-      onSubmit,
-      onStop,
-      isLoading,
-      disabled,
-      focusKey,
-      imageCount: images.length,
-    });
-    imagesRef.current = images;
-
-    useEffect(() => {
-      const timer = setTimeout(() => inputRef.current?.focus(), 100);
-      return () => clearTimeout(timer);
-    }, [focusKey]);
-
-    useEffect(() => {
-      const prevId = prevEditingIdRef.current;
-      const currId = editingPrompt?.id ?? null;
-      if (currId === prevId) return;
-      if (currId) {
-        if (!prevId) preEditDraftRef.current = inputValueRef.current;
-        setInput(editingPrompt?.text ?? "");
-        setTimeout(() => inputRef.current?.focus(), 0);
-      } else {
-        setInput(preEditDraftRef.current);
-        preEditDraftRef.current = "";
-      }
-      prevEditingIdRef.current = currId;
-    }, [editingPrompt]);
-
-    useEffect(() => {
-      return () => {
-        imagesRef.current.forEach(img => URL.revokeObjectURL(img.previewUrl));
-      };
-    }, []);
-
-    const addImages = useCallback((files: File[]) => {
-      const imageFiles = files.filter(f => f.type.startsWith("image/"));
-      if (imageFiles.length === 0) return;
-      setImages(prev => [
-        ...prev,
-        ...imageFiles.map(file => ({
-          id: crypto.randomUUID(),
-          file,
-          previewUrl: URL.createObjectURL(file),
-        })),
-      ]);
-    }, []);
-
-    const removeImage = useCallback((id: string) => {
-      setImages(prev => {
-        const img = prev.find(i => i.id === id);
-        if (img) URL.revokeObjectURL(img.previewUrl);
-        return prev.filter(i => i.id !== id);
-      });
-    }, []);
-
-    const handlePaste = useCallback(
-      (e: React.ClipboardEvent) => {
-        const items = e.clipboardData?.items;
-        if (!items) return;
-        const files: File[] = [];
-        for (const item of items) {
-          if (item.kind === "file" && item.type.startsWith("image/")) {
-            const file = item.getAsFile();
-            if (file) files.push(file);
-          }
-        }
-        if (files.length > 0) {
-          e.preventDefault();
-          addImages(files);
-        }
-      },
-      [addImages],
-    );
-
-    const submitMessage = useCallback(async () => {
-      const trimmedInput = input.trim();
-      const currentImages = images;
-      const hasText = trimmedInput.length > 0;
-      const hasImages = currentImages.length > 0;
-      if ((!hasText && !hasImages) || isPreparingSubmission) {
-        return;
-      }
-
-      setIsPreparingSubmission(true);
-      let fileParts: FileUIPart[] | undefined;
-      try {
-        if (hasImages) {
-          fileParts = await Promise.all(
-            currentImages.map(async img => ({
-              type: "file" as const,
-              url: await readFileAsDataUrl(img.file),
-              mediaType: img.file.type,
-            })),
-          );
-          currentImages.forEach(img => URL.revokeObjectURL(img.previewUrl));
-        }
-
-        onSubmit(input, fileParts);
-        setInput("");
-        setImages([]);
-      } finally {
-        setIsPreparingSubmission(false);
-      }
-    }, [images, input, isPreparingSubmission, onSubmit]);
-
-    const hasContent = input.trim() || images.length > 0;
-    const isSubmitDisabled = !hasContent || disabled || isPreparingSubmission;
-
-    return (
-      <Paper
-        elevation={0}
-        sx={{
-          border: 1,
-          borderColor: "divider",
-          borderRadius: 2.5,
-          p: 1,
-          m: 1,
-          display: "flex",
-          flexDirection: "column",
-          gap: 1,
-        }}
-      >
-        {editingPrompt && (
-          <Box
-            sx={{
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "space-between",
-              px: 0.5,
-              pb: 0.5,
-              mb: 0.5,
-              borderBottom: 1,
-              borderColor: "divider",
-            }}
-          >
-            <Typography
-              variant="caption"
-              sx={{ fontWeight: 600, color: "text.secondary" }}
-            >
-              Editing queued message
-            </Typography>
-            <Typography
-              component="button"
-              type="button"
-              onClick={onCancelEdit}
-              variant="caption"
-              sx={{
-                border: "none",
-                background: "none",
-                cursor: "pointer",
-                color: "primary.main",
-                fontWeight: 600,
-                p: 0,
-                "&:hover": { textDecoration: "underline" },
-              }}
-            >
-              Cancel
-            </Typography>
-          </Box>
-        )}
-
-        <form
-          onSubmit={e => {
-            e.preventDefault();
-            submitMessage();
-          }}
-          onPaste={handlePaste}
-        >
-          {images.length > 0 && (
-            <Box
-              sx={{
-                display: "flex",
-                flexWrap: "wrap",
-                gap: 1,
-                px: 0.5,
-                pt: 0.5,
-              }}
-            >
-              {images.map(img => (
-                <Box
-                  key={img.id}
-                  sx={{
-                    position: "relative",
-                    width: 56,
-                    height: 56,
-                    borderRadius: 1.5,
-                    overflow: "hidden",
-                    flexShrink: 0,
-                    "&:hover .remove-btn": {
-                      opacity: 1,
-                    },
-                  }}
-                >
-                  <Box
-                    component="img"
-                    src={img.previewUrl}
-                    alt="Attachment"
-                    onClick={() => setPreviewSrc(img.previewUrl)}
-                    sx={{
-                      width: 56,
-                      height: 56,
-                      borderRadius: 1.5,
-                      objectFit: "cover",
-                      cursor: "pointer",
-                      border: 1,
-                      borderColor: "divider",
-                      display: "block",
-                    }}
-                  />
-                  <IconButton
-                    type="button"
-                    className="remove-btn"
-                    aria-label="Remove image"
-                    onClick={e => {
-                      e.stopPropagation();
-                      removeImage(img.id);
-                    }}
-                    size="small"
-                    disabled={isPreparingSubmission}
-                    sx={{
-                      position: "absolute",
-                      top: 4,
-                      right: 4,
-                      width: 18,
-                      height: 18,
-                      p: 0,
-                      opacity: 0,
-                      transition: "opacity 0.15s",
-                      color: "common.white",
-                      backgroundColor: "rgba(0, 0, 0, 0.6)",
-                      "&:hover": {
-                        backgroundColor: "rgba(0, 0, 0, 0.8)",
-                      },
-                    }}
-                  >
-                    <X size={11} />
-                  </IconButton>
-                </Box>
-              ))}
-            </Box>
-          )}
-
-          <ImagePreviewDialog
-            src={previewSrc}
-            onClose={() => setPreviewSrc(null)}
-          />
-
-          <TextField
-            fullWidth
-            autoFocus
-            multiline
-            minRows={1}
-            maxRows={24}
-            placeholder={
-              editingPrompt ? "Edit queued message..." : "Ask Chat..."
-            }
-            value={input}
-            onChange={e => setInput(e.target.value)}
-            onKeyDown={e => {
-              if (e.key === "Enter" && !e.shiftKey) {
-                e.preventDefault();
-                submitMessage();
-              }
-              if (e.key === "Escape" && editingPrompt) {
-                e.preventDefault();
-                onCancelEdit();
-              }
-              if (e.key === "Backspace" && !input && images.length > 0) {
-                e.preventDefault();
-                const last = images[images.length - 1];
-                if (last) removeImage(last.id);
-              }
-            }}
-            variant="outlined"
-            inputRef={inputRef}
-            sx={{
-              m: 0.5,
-              maxHeight: "60vh",
-              overflowY: "auto",
-              "& .MuiInputBase-input": {
-                fontSize: { xs: 16, sm: 14 },
-              },
-              "& .MuiInputBase-root": {
-                p: 0,
-                fontSize: { xs: 16, sm: 14 },
-              },
-              "& .MuiOutlinedInput-notchedOutline": {
-                border: "none",
-              },
-              "& .MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline":
-                {
-                  border: "none",
-                },
-              "& .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline":
-                {
-                  border: "none",
-                },
-            }}
-          />
-
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept="image/*"
-            multiple
-            style={{ display: "none" }}
-            onChange={e => {
-              if (e.target.files) {
-                addImages(Array.from(e.target.files));
-                e.target.value = "";
-              }
-            }}
-          />
-
-          <Box
-            sx={{
-              display: "flex",
-              alignItems: "center",
-              gap: 0.5,
-              minWidth: 0,
-            }}
-          >
-            <Box
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                gap: 0.5,
-                flex: "1 1 auto",
-                minWidth: 0,
-              }}
-            >
-              <ModelSelector />
-            </Box>
-
-            <Tooltip title="Attach image" placement="top">
-              <IconButton
-                type="button"
-                onClick={() => fileInputRef.current?.click()}
-                size="small"
-                disabled={isPreparingSubmission || disabled || isLoading}
-                sx={{
-                  width: 28,
-                  height: 28,
-                  flexShrink: 0,
-                  color: "text.secondary",
-                  "&:hover": { color: "text.primary" },
-                }}
-              >
-                <ImagePlus size={16} />
-              </IconButton>
-            </Tooltip>
-
-            {isLoading ? (
-              <IconButton
-                type="button"
-                aria-label="Stop generating"
-                onClick={onStop}
-                size="small"
-                sx={{
-                  width: 28,
-                  height: 28,
-                  borderRadius: "50%",
-                  backgroundColor: "action.hover",
-                  border: 1,
-                  borderColor: "divider",
-                  "&:hover": {
-                    backgroundColor: "action.selected",
-                  },
-                  flexShrink: 0,
-                }}
-              >
-                <Box
-                  sx={{
-                    width: 10,
-                    height: 10,
-                    backgroundColor: "text.primary",
-                    borderRadius: 0.5,
-                  }}
-                />
-              </IconButton>
-            ) : (
-              <IconButton
-                type="submit"
-                aria-label="Send message"
-                disabled={isSubmitDisabled}
-                size="small"
-                sx={{
-                  width: 28,
-                  height: 28,
-                  borderRadius: "50%",
-                  backgroundColor: !isSubmitDisabled
-                    ? "primary.main"
-                    : "action.disabledBackground",
-                  color: !isSubmitDisabled
-                    ? "primary.contrastText"
-                    : "text.disabled",
-                  "&:hover": {
-                    backgroundColor: !isSubmitDisabled
-                      ? "primary.dark"
-                      : "action.disabledBackground",
-                  },
-                  "&.Mui-disabled": {
-                    backgroundColor: "action.disabledBackground",
-                    color: "text.disabled",
-                  },
-                  flexShrink: 0,
-                }}
-              >
-                <ArrowUp size={18} />
-              </IconButton>
-            )}
-          </Box>
-        </form>
-      </Paper>
-    );
-  },
-);
-ChatInputArea.displayName = "ChatInputArea";
 
 // DbFlowFormRef is imported from ./DbFlowForm
 
@@ -2038,7 +198,6 @@ const Chat: React.FC<ChatProps> = ({
     return iconByConnectionId;
   }, [dbTypes, workspaceConnections]);
 
-  const [sessions, setSessions] = useState<ChatSessionMeta[]>([]);
   // The chat persisted for this tab (if any), read once per mount. Restoring
   // it means a page refresh reopens — and reattaches to — the same chat.
   const initialStoredSessionRef = useRef<StoredChatSession | null | undefined>(
@@ -2051,16 +210,12 @@ const Chat: React.FC<ChatProps> = ({
   const [chatId, setChatId] = useState<string>(
     () => initialStoredSessionRef.current?.chatId ?? generateObjectId(),
   );
-  const [historyMenuAnchor, setHistoryMenuAnchor] =
-    useState<null | HTMLElement>(null);
-  const historyMenuOpen = Boolean(historyMenuAnchor);
   // Virtualized message list (react-virtuoso). Replaces use-stick-to-bottom:
   // Virtuoso owns its own scroller and bottom-anchoring (`followOutput`), and
   // only mounts visible rows + overscan so long chats stay light on
   // DOM/memory/paint — critical on mobile. `isAtBottom` drives both the
   // "scroll to bottom" button and whether streaming auto-follows the tail.
   const virtuosoRef = useRef<VirtuosoHandle>(null);
-  const [isAtBottom, setIsAtBottom] = useState(true);
 
   // Track if we're viewing an existing chat from history (vs a new chat)
   // Moved before useChat so onFinish callback can access it
@@ -2086,21 +241,18 @@ const Chat: React.FC<ChatProps> = ({
   // doesn't cause the agent to read context from a different dashboard
   const capturedDashboardIdRef = useRef<string | null>(null);
 
-  // Function to fetch sessions - defined before useChat so it can be used in onFinish
-  // Using a ref-based pattern to always access the current workspace
-  const fetchSessionsRef = useRef<() => Promise<void>>();
-  fetchSessionsRef.current = async () => {
-    if (!currentWorkspace) return;
-    try {
-      const res = await fetch(`/api/workspaces/${currentWorkspace.id}/chats`);
-      if (res.ok) {
-        const data = await res.json();
-        setSessions(data);
-      }
-    } catch {
-      /* ignore */
-    }
-  };
+  // Session list / history menu state (fetch, delete, streaming indicator).
+  // Called before useChat so onFinish can refresh the list via the ref.
+  const {
+    sessions,
+    fetchSessionsRef,
+    isSessionStreaming,
+    deleteSession,
+    historyMenuAnchor,
+    historyMenuOpen,
+    handleHistoryMenuOpen,
+    handleHistoryMenuClose,
+  } = useChatSessions({ workspaceId: currentWorkspace?.id });
 
   // Tool debug dialog
   const [toolDialogOpen, setToolDialogOpen] = useState(false);
@@ -2124,50 +276,63 @@ const Chat: React.FC<ChatProps> = ({
   const chatIdRef = useRef(chatId);
   const manualStopRequestedRef = useRef(false);
   const drainQueuedPromptAfterTurnRef = useRef<(() => void) | null>(null);
-  const activeClientToolCallsRef = useRef(
-    new Map<string, ActiveClientToolCall>(),
-  );
-  const cancelledClientToolCallIdsRef = useRef(new Set<string>());
-  // Spaces + bounds onError → resume retries. A failed resume re-fires onError,
-  // so retrying instantly would burst; instead we schedule one delayed attempt
-  // (giving a brief network blip time to recover) and cap attempts per window
-  // before falling back to poisoning the tool cards.
+  // Client-tool registry: in-flight executions, cancel/interrupt plumbing,
+  // and the per-chat toolCallId dispatch dedupe gate (the triplicate-tool
+  // fix). Created before useChat — its register/settle callbacks are wired
+  // into onToolCall; addToolOutputRef is assigned right after useChat.
+  const addToolOutputRef = useRef<AddToolOutputFn>();
+  const {
+    activeClientToolCallsRef,
+    toolDispatchGateRef,
+    activeClientToolCallCount,
+    registerActiveClientToolCall,
+    settleActiveClientToolCall,
+    cancelActiveClientToolCalls,
+    interruptActiveClientToolCalls,
+  } = useClientToolRegistry({
+    addToolOutputRef,
+    manualStopRequestedRef,
+    chatId,
+  });
+  // onError's resume-retry budget/timer — owned by useStreamResume; declared
+  // here because useChat's onFinish (built before that hook runs) resets it.
   const errorResumeRef = useRef<{
     count: number;
     windowStart: number;
     timer: ReturnType<typeof setTimeout> | null;
   }>({ count: 0, windowStart: 0, timer: null });
-  const [activeClientToolCallCount, setActiveClientToolCallCount] = useState(0);
-  const [queuedPrompts, setQueuedPrompts] = useState<QueuedPrompt[]>([]);
-  const queuedPromptsRef = useRef(queuedPrompts);
+  // Stream-error handling lives in useStreamResume (which needs useChat's
+  // state, so it runs after useChat); useChat's onError — captured once per
+  // Chat instance — delegates through this ref.
+  const onStreamErrorImplRef = useRef<(error: unknown) => void>();
+  const clearErrorRef = useRef<(() => void) | undefined>();
+  // Single-flight resume manager (assigned after useChat — it needs stop /
+  // resumeStream). ALL reattach triggers (loadSession, wake, error retry) go
+  // through requestResumeRef: calling the SDK's resumeStream directly attaches
+  // an ADDITIONAL stream consumer without tearing down the previous one, and
+  // every consumer re-processes every chunk — the root cause of the
+  // triplicated tool executions and message parts.
+  const requestResumeRef =
+    useRef<(opts?: { skipReload?: boolean }) => Promise<void>>();
+  // Refetch persisted messages + reset chat state; assigned by
+  // useChatSessionLoader (shares the history-load conversion logic).
+  const loadPersistedMessagesRef =
+    useRef<(opts?: { forHistoryLoad?: boolean }) => Promise<boolean>>();
+  // Client tool dispatch lives in useClientToolDispatch (which needs useChat's
+  // state, so it runs after useChat); useChat's onToolCall — captured once at
+  // Chat-instance creation — delegates through this ref so it always invokes
+  // the latest implementation.
+  const onToolCallImplRef =
+    useRef<(toolCall: DispatchableToolCall) => Promise<void>>();
   const isLoadingRef = useRef(false);
-  queuedPromptsRef.current = queuedPrompts;
-  // Id of the queued prompt currently being edited in the composer (Cursor-style).
-  const [editingPromptId, setEditingPromptId] = useState<string | null>(null);
-  const editingPromptIdRef = useRef<string | null>(null);
-  editingPromptIdRef.current = editingPromptId;
-  // Id of a prompt the user force-sent (top arrow). Once the interrupted turn
-  // settles, the drain sends it immediately, bypassing the normal busy guards.
-  const pendingForcePromptIdRef = useRef<string | null>(null);
-  const editingPrompt = useMemo(
-    () => queuedPrompts.find(prompt => prompt.id === editingPromptId) ?? null,
-    [queuedPrompts, editingPromptId],
-  );
+  // While a submit_plan awaits review, the composer routes sent messages to
+  // the plan as request_changes feedback. Assigned below (after the
+  // pendingInteractiveTool memo); declared here so useQueuedPrompts can close
+  // over it.
+  const pendingPlanToolCallIdRef = useRef<string | null>(null);
   workspaceIdRef.current = currentWorkspace?.id;
   modelIdRef.current = selectedModelId;
   chatIdRef.current = chatId;
-
-  const cancelActiveClientToolCalls = useCallback((reason: string): void => {
-    for (const activeToolCall of activeClientToolCallsRef.current.values()) {
-      cancelledClientToolCallIdsRef.current.add(activeToolCall.toolCallId);
-      activeToolCall.abortController.abort(reason);
-      activeToolCall.settled = true;
-      void Promise.resolve(activeToolCall.cancel()).catch(() => undefined);
-    }
-
-    activeClientToolCallsRef.current.clear();
-    setActiveClientToolCallCount(0);
-  }, []);
 
   const autoSendWhenComplete = useCallback((options: AutoSendPredicateArgs) => {
     if (manualStopRequestedRef.current) {
@@ -2281,548 +446,27 @@ const Chat: React.FC<ChatProps> = ({
     // Automatically submit when all tool results are available
     sendAutomaticallyWhen: autoSendWhenComplete,
 
-    // Handle client-side tools (console operations)
+    // Handle client-side tools (console operations). The implementation
+    // lives in useClientToolDispatch (it needs useChat state for its
+    // orphan-rescue effect, so it runs after this hook); the SDK captures
+    // this closure once per Chat instance, so delegate through a ref.
     async onToolCall({ toolCall }) {
-      // Skip dynamic tools (not our console tools)
-      if ((toolCall as { dynamic?: boolean }).dynamic) {
-        return;
-      }
-
-      const toolName = toolCall.toolName;
-      const input = toolCall.input as Record<string, unknown>;
-
-      // Deferred plan-lifecycle tools: do NOT settle here. The interactive
-      // card rendered in the message list resolves them via addToolOutput once
-      // the user answers / approves. Returning without output keeps the tool
-      // call pending (human-in-the-loop) until then.
-      if (
-        toolName === "ask_clarifying_questions" ||
-        toolName === "submit_plan"
-      ) {
-        return;
-      }
-
-      try {
-        if (
-          await executeConsoleAgentTool({
-            toolCall: {
-              toolName,
-              toolCallId: toolCall.toolCallId,
-            },
-            input,
-            workspaceId: workspaceIdRef.current,
-            onChartSpecChange: onChartSpecChangeRef?.current,
-            addToolOutput,
-            registerActiveClientToolCall,
-            settleActiveClientToolCall,
-          })
-        ) {
-          return;
-        }
-
-        // --- Dashboard tools (client-side) ---
-        if (DASHBOARD_EXECUTOR_TOOL_NAMES.has(toolName as AgentToolName)) {
-          const activeDashboardTool = registerActiveClientToolCall(
-            toolName,
-            toolCall.toolCallId,
-          );
-
-          // Fire-and-forget for ALL dashboard client work, never await it here.
-          // The AI SDK awaits onToolCall while reading the SSE stream, and only
-          // sends the follow-up request with the tool output once the stream
-          // reaches its finish chunk. Awaiting any client work inside
-          // onToolCall blocks the reader from processing that finish chunk, so
-          // the continuation hangs until the HTTP/proxy stream times out — even
-          // for tools that resolve in milliseconds (e.g. remove_widget,
-          // get_dashboard_state). Settling asynchronously lets the finish chunk
-          // be read immediately and the stream close cleanly.
-          void (async () => {
-            try {
-              const dashboardToolOutput = await executeDashboardAgentTool(
-                toolName,
-                input,
-                {
-                  executionId: activeDashboardTool.executionId,
-                  signal: activeDashboardTool.abortController.signal,
-                },
-              );
-
-              if (activeDashboardTool.abortController.signal.aborted) {
-                return;
-              }
-
-              settleActiveClientToolCall(
-                toolName,
-                toolCall.toolCallId,
-                dashboardToolOutput ?? {
-                  success: false,
-                  error: `Dashboard tool "${toolName}" did not return a result.`,
-                },
-              );
-            } catch (dashboardError) {
-              if (
-                manualStopRequestedRef.current ||
-                activeDashboardTool.abortController.signal.aborted
-              ) {
-                return;
-              }
-              settleActiveClientToolCall(toolName, toolCall.toolCallId, {
-                success: false,
-                error:
-                  dashboardError instanceof Error
-                    ? dashboardError.message
-                    : "Dashboard tool execution failed",
-              });
-            }
-          })();
-          return;
-        }
-
-        // --- React App tools (client-side) ---
-        if (APP_EXECUTOR_TOOL_NAMES.has(toolName as AgentToolName)) {
-          const activeAppTool = registerActiveClientToolCall(
-            toolName,
-            toolCall.toolCallId,
-          );
-
-          // Fire-and-forget, same rationale as dashboard tools above: never
-          // await client work inside onToolCall or the SSE finish chunk stalls.
-          void (async () => {
-            try {
-              const appToolOutput = await executeAppAgentTool(toolName, input, {
-                executionId: activeAppTool.executionId,
-                signal: activeAppTool.abortController.signal,
-              });
-
-              if (activeAppTool.abortController.signal.aborted) return;
-
-              settleActiveClientToolCall(
-                toolName,
-                toolCall.toolCallId,
-                appToolOutput ?? {
-                  success: false,
-                  error: `App tool "${toolName}" did not return a result.`,
-                },
-              );
-            } catch (appError) {
-              if (
-                manualStopRequestedRef.current ||
-                activeAppTool.abortController.signal.aborted
-              ) {
-                return;
-              }
-              settleActiveClientToolCall(toolName, toolCall.toolCallId, {
-                success: false,
-                error:
-                  appError instanceof Error
-                    ? appError.message
-                    : "App tool execution failed",
-              });
-            }
-          })();
-          return;
-        }
-
-        // --- dbt tools (client-side) ---
-        if (DBT_EXECUTOR_TOOL_NAMES.has(toolName as AgentToolName)) {
-          const activeDbtTool = registerActiveClientToolCall(
-            toolName,
-            toolCall.toolCallId,
-          );
-          // Fire-and-forget, same rationale as app tools above.
-          void (async () => {
-            try {
-              const dbtToolOutput = await executeDbtAgentTool(toolName, input);
-              if (activeDbtTool.abortController.signal.aborted) return;
-              settleActiveClientToolCall(
-                toolName,
-                toolCall.toolCallId,
-                dbtToolOutput ?? {
-                  success: false,
-                  error: `dbt tool "${toolName}" did not return a result.`,
-                },
-              );
-            } catch (dbtError) {
-              if (
-                manualStopRequestedRef.current ||
-                activeDbtTool.abortController.signal.aborted
-              ) {
-                return;
-              }
-              settleActiveClientToolCall(toolName, toolCall.toolCallId, {
-                success: false,
-                error:
-                  dbtError instanceof Error
-                    ? dbtError.message
-                    : "dbt tool execution failed",
-              });
-            }
-          })();
-          return;
-        }
-
-        // --- Shared data source tools (apps + dashboards) ---
-        if (DATA_SOURCE_EXECUTOR_TOOL_NAMES.has(toolName as AgentToolName)) {
-          const activeDataTool = registerActiveClientToolCall(
-            toolName,
-            toolCall.toolCallId,
-          );
-          void (async () => {
-            try {
-              const output = await executeDataSourceTool(toolName, input);
-              if (activeDataTool.abortController.signal.aborted) return;
-              settleActiveClientToolCall(
-                toolName,
-                toolCall.toolCallId,
-                output ?? {
-                  success: false,
-                  error: `Data source tool "${toolName}" did not return a result.`,
-                },
-              );
-            } catch (dataError) {
-              if (
-                manualStopRequestedRef.current ||
-                activeDataTool.abortController.signal.aborted
-              ) {
-                return;
-              }
-              settleActiveClientToolCall(toolName, toolCall.toolCallId, {
-                success: false,
-                error:
-                  dataError instanceof Error
-                    ? dataError.message
-                    : "Data source tool execution failed",
-              });
-            }
-          })();
-          return;
-        }
-
-        // Handle flow agent client-side tools
-        // get_form_state - Return current form configuration
-        if (toolName === "get_form_state") {
-          const formRef = dbFlowFormRefCurrent.current?.current;
-          if (!formRef) {
-            addToolOutput({
-              tool: "get_form_state",
-              toolCallId: toolCall.toolCallId,
-              output: {
-                success: false,
-                error:
-                  "Form is not available. Make sure you're in the flow editor.",
-              },
-            });
-            return;
-          }
-
-          const formState = formRef.getFormState();
-          addToolOutput({
-            tool: "get_form_state",
-            toolCallId: toolCall.toolCallId,
-            output: {
-              success: true,
-              formState,
-            },
-          });
-          return;
-        }
-
-        // set_form_field - Update a single form field
-        if (toolName === "set_form_field") {
-          const formRef = dbFlowFormRefCurrent.current?.current;
-          if (!formRef) {
-            addToolOutput({
-              tool: "set_form_field",
-              toolCallId: toolCall.toolCallId,
-              output: {
-                success: false,
-                error:
-                  "Form is not available. Make sure you're in the flow editor.",
-              },
-            });
-            return;
-          }
-
-          const { fieldName, value } = input as {
-            fieldName: string;
-            value: unknown;
-          };
-
-          // The tool schema uses a structured z.union() instead of z.any(),
-          // so the LLM returns proper typed values (arrays as arrays, not strings).
-          // See: TYPE_COERCION_SCHEMA in db-flow-form.schema.ts
-          formRef.setField(fieldName, value);
-          addToolOutput({
-            tool: "set_form_field",
-            toolCallId: toolCall.toolCallId,
-            output: {
-              success: true,
-              fieldName,
-              value,
-              message: `Updated ${fieldName} successfully`,
-            },
-          });
-          return;
-        }
-
-        // set_multiple_fields - Update multiple fields at once
-        if (toolName === "set_multiple_fields") {
-          const formRef = dbFlowFormRefCurrent.current?.current;
-          if (!formRef) {
-            addToolOutput({
-              tool: "set_multiple_fields",
-              toolCallId: toolCall.toolCallId,
-              output: {
-                success: false,
-                error:
-                  "Form is not available. Make sure you're in the flow editor.",
-              },
-            });
-            return;
-          }
-
-          const { fields } = input as { fields: Record<string, unknown> };
-          formRef.setMultipleFields(fields);
-          addToolOutput({
-            tool: "set_multiple_fields",
-            toolCallId: toolCall.toolCallId,
-            output: {
-              success: true,
-              fields: Object.keys(fields),
-              message: `Updated ${Object.keys(fields).length} field(s) successfully`,
-            },
-          });
-          return;
-        }
-
-        // NOTE: set_column_mappings has been removed
-        // Use set_form_field with fieldName="typeCoercions" instead
-
-        // create_flow_tab - Create a new db-scheduled flow tab
-        if (toolName === "create_flow_tab") {
-          const currentStore = useConsoleStore.getState();
-          const title = (input.title as string) || "New Database Sync";
-
-          // Generate a new ID and create the flow tab
-          const newTabId = generateObjectId();
-          currentStore.openTab({
-            id: newTabId,
-            title,
-            content: "",
-            kind: "flow-editor",
-            metadata: { isNew: true, flowType: "db-scheduled" },
-          });
-          currentStore.setActiveTab(newTabId);
-
-          addToolOutput({
-            tool: "create_flow_tab",
-            toolCallId: toolCall.toolCallId,
-            output: {
-              success: true,
-              tabId: newTabId,
-              title,
-              message: `Created new flow tab "${title}"`,
-            },
-          });
-          return;
-        }
-
-        // list_flow_tabs - List all open flow editor tabs
-        if (toolName === "list_flow_tabs") {
-          const currentStore = useConsoleStore.getState();
-          const currentTabs = Object.values(currentStore.tabs);
-          const currentActiveId = currentStore.activeTabId;
-
-          const flowTabs = currentTabs
-            .filter((tab: any) => tab?.kind === "flow-editor")
-            .map((tab: any) => ({
-              id: tab.id,
-              title: tab.title || "Untitled Flow",
-              flowType: tab.metadata?.flowType || "unknown",
-              flowId: tab.metadata?.flowId,
-              isNew: tab.metadata?.isNew || false,
-              isActive: tab.id === currentActiveId,
-            }));
-
-          addToolOutput({
-            tool: "list_flow_tabs",
-            toolCallId: toolCall.toolCallId,
-            output: {
-              success: true,
-              flowTabs,
-              message: `Found ${flowTabs.length} open flow tab(s)`,
-            },
-          });
-          return;
-        }
-
-        const manifestEntry = getAgentToolManifestEntry(toolName);
-        if (manifestEntry?.execution === "client") {
-          addToolOutput({
-            tool: toolName,
-            toolCallId: toolCall.toolCallId,
-            output: {
-              success: false,
-              error: `Client-side tool "${toolName}" is registered but has no browser handler.`,
-            },
-          });
-          return;
-        }
-
-        // Unknown tool - not a client-side tool, let it be handled server-side
-      } catch (toolError) {
-        // Safety net: if any client-side tool throws an uncaught error,
-        // return the error to the LLM so the conversation doesn't hang.
-        addToolOutput({
-          tool: toolName,
-          toolCallId: toolCall.toolCallId,
-          output: {
-            success: false,
-            error:
-              toolError instanceof Error
-                ? toolError.message
-                : "Client-side tool execution failed unexpectedly",
-          },
-        });
-      }
+      await onToolCallImplRef.current?.(toolCall as DispatchableToolCall);
     },
 
+    // Stream-error handling (resume retry budget / poison fallback) lives in
+    // useStreamResume; the SDK captures this closure once per Chat instance,
+    // so delegate through a ref.
     onError: err => {
-      console.error("[Chat] Error:", err);
-      const errorMessage = err instanceof Error ? err.message : String(err);
-      const lastMessage = messagesRef.current.at(-1);
-      const stalledToolNames =
-        lastMessage?.role === "assistant"
-          ? (lastMessage.parts ?? [])
-              .filter(p => {
-                const pt = p.type as string;
-                if (!pt?.startsWith("tool-") && pt !== "dynamic-tool") {
-                  return false;
-                }
-                if (isHumanInTheLoopToolPartType(pt)) return false;
-                const s = (p as Record<string, unknown>).state as string;
-                return s !== "output-available" && s !== "error";
-              })
-              .map(p => toolNameFromPartType(p.type as string))
-          : [];
-
-      // Structured server errors (billing / model availability) arrive as JSON
-      // with a `code` — those are genuine and must NOT be resumed.
-      let isStructuredServerError = false;
-      try {
-        const parsed = JSON.parse(errorMessage);
-        isStructuredServerError = !!parsed && typeof parsed.code === "string";
-      } catch {
-        /* not JSON → network / stream drop */
-      }
-
-      // The turn's lifetime is decoupled from the HTTP connection: the server
-      // keeps generating and buffers a resumable stream after a client
-      // disconnect. A mobile lock / computer sleep freezes the tab and the OS
-      // kills the SSE socket; on wake the dead read surfaces here as a
-      // non-structured network/stream error (the user-reported "network error"
-      // / "Stream disconnected"). When the turn still looks live, reattach
-      // instead of poisoning the cards — the replay re-emits the tool outputs,
-      // and any in-flight client tool (e.g. a slow capture_screenshot) is left
-      // running so it can settle on its own.
-      const turnLooksLive =
-        statusRef.current === "streaming" ||
-        statusRef.current === "submitted" ||
-        useRealtimeStore.getState().chatActivity[chatIdRef.current] ===
-          "streaming" ||
-        document.visibilityState !== "visible" ||
-        stalledToolNames.length > 0;
-
-      const RESUME_RETRY_DELAY_MS = 1500;
-      const RESUME_RETRY_WINDOW_MS = 30_000;
-      const RESUME_MAX_RETRIES = 4;
-      const now = Date.now();
-      const resumeState = errorResumeRef.current;
-      if (now - resumeState.windowStart > RESUME_RETRY_WINDOW_MS) {
-        resumeState.windowStart = now;
-        resumeState.count = 0;
-      }
-      // Keep taking the resume branch while a retry is still scheduled, so we
-      // never poison the cards out from under a pending reattach.
-      const canRetryResume =
-        resumeState.count < RESUME_MAX_RETRIES || resumeState.timer !== null;
-
-      if (
-        !isStructuredServerError &&
-        turnLooksLive &&
-        canRetryResume &&
-        !manualStopRequestedRef.current
-      ) {
-        reportStreamInterruption({
-          path: "stream-error",
-          chatId,
-          status,
-          toolNames: stalledToolNames,
-          errorMessage,
-          resumed: true,
-        });
-        // Clear the SDK error so the hook can stream again, then reattach to
-        // the buffered turn after a short delay. The delay coalesces the burst
-        // of onError calls a failing reconnect produces and gives a brief
-        // network blip time to recover. A finished turn answers 204 (cheap
-        // no-op) and the orphan-rescue effect handles any stranded card.
-        clearError();
-        if (!resumeState.timer) {
-          resumeState.count += 1;
-          resumeState.timer = setTimeout(() => {
-            resumeState.timer = null;
-            void resumeStreamRef.current?.();
-          }, RESUME_RETRY_DELAY_MS);
-        }
-        return;
-      }
-
-      // Genuine / fatal error (or too many resume retries): fall back to the
-      // original behavior — cancel in-flight client tools and poison pending
-      // tool parts so the AI SDK unblocks the next sendMessage.
-      cancelActiveClientToolCalls("stream-error");
-      reportStreamInterruption({
-        path: "stream-error",
-        chatId,
-        status,
-        toolNames: stalledToolNames,
-        errorMessage,
-        resumed: false,
-      });
-      // When the stream disconnects (e.g. 524 timeout), tool calls may be
-      // stuck in "input-available" state. The AI SDK blocks sendMessage until
-      // all tool calls are settled. Patch them to "error" so the chat remains
-      // usable.
-      setMessages(prev =>
-        prev.map(msg => {
-          if (msg.role !== "assistant") return msg;
-          const hasPending = msg.parts?.some(p => {
-            const pt = p.type as string;
-            if (!pt?.startsWith("tool-") && pt !== "dynamic-tool") return false;
-            if (isHumanInTheLoopToolPartType(pt)) return false;
-            const s = (p as Record<string, unknown>).state as string;
-            return s !== "output-available" && s !== "error";
-          });
-          if (!hasPending) return msg;
-          return {
-            ...msg,
-            parts: msg.parts.map(p => {
-              const pt = p.type as string;
-              if (!pt?.startsWith("tool-") && pt !== "dynamic-tool") return p;
-              if (isHumanInTheLoopToolPartType(pt)) return p;
-              const s = (p as Record<string, unknown>).state as string;
-              if (s === "output-available" || s === "error") return p;
-              return {
-                ...p,
-                state: "error" as const,
-                output: { success: false, error: "Stream disconnected" },
-              };
-            }) as any,
-          };
-        }),
-      );
+      onStreamErrorImplRef.current?.(err);
     },
-    onFinish: () => {
+    onFinish: ({ isAbort }) => {
+      // A teardown abort — the resume manager stopping a stale consumer
+      // before reattaching, or the user's Stop — is not a completed turn:
+      // don't reset the retry budget, refetch sessions, or drain queued
+      // prompts off it. (A force-send drains via the status-transition
+      // effect once the interrupted turn settles.)
+      if (isAbort) return;
       // The turn settled cleanly — reset the resume-retry budget.
       errorResumeRef.current.count = 0;
       if (!isExistingChatRef.current) {
@@ -2844,166 +488,65 @@ const Chat: React.FC<ChatProps> = ({
   const statusRef = useRef(status);
   statusRef.current = status;
 
-  const createCancellationOutput = useCallback(
-    (toolName: string): Record<string, unknown> => ({
-      success: false,
-      error:
-        toolName === "run_console"
-          ? "Query cancelled because the chat stopped."
-          : "Tool cancelled because the chat stopped.",
-    }),
-    [],
-  );
+  // Latest stop() for the resume manager (client-side abort only — it never
+  // hits the server /stop endpoint, so the generation keeps running for the
+  // replacement consumer to reattach to).
+  const stopRef = useRef(stop);
+  stopRef.current = stop;
 
-  const registerActiveClientToolCall = useCallback(
-    (
-      toolName: string,
-      toolCallId: string,
-      options?: {
-        executionId?: string;
-        cancel?: () => void | Promise<void>;
-        cancellationOutput?: Record<string, unknown>;
-      },
-    ) => {
-      const abortController = new AbortController();
-      const executionId =
-        options?.executionId ?? `chat-tool-${generateObjectId()}`;
+  // Latest messages / sendMessage for stable closures (drain, wake handler).
+  const messagesRef = useRef(messages);
+  messagesRef.current = messages;
+  const sendMessageRef = useRef(sendMessage);
+  sendMessageRef.current = sendMessage;
 
-      cancelledClientToolCallIdsRef.current.delete(toolCallId);
-      activeClientToolCallsRef.current.set(toolCallId, {
-        toolCallId,
-        toolName,
-        executionId,
-        abortController,
-        cancel: options?.cancel ?? (() => {}),
-        cancellationOutput:
-          options?.cancellationOutput ?? createCancellationOutput(toolName),
-        settled: false,
-      });
-      setActiveClientToolCallCount(activeClientToolCallsRef.current.size);
+  // Give the registry (created before useChat) the live addToolOutput.
+  addToolOutputRef.current = addToolOutput;
+  clearErrorRef.current = clearError;
 
-      return { abortController, executionId };
+  // Single-flight + liveness-gated resume manager, tab-wake reattach, and the
+  // stream-error handler — assigns requestResumeRef / onStreamErrorImplRef
+  // and installs the wake listeners.
+  useStreamResume({
+    status,
+    messages,
+    statusRef,
+    messagesRef,
+    chatIdRef,
+    manualStopRequestedRef,
+    activeClientToolCallsRef,
+    stopRef,
+    resumeStreamRef,
+    loadPersistedMessagesRef,
+    requestResumeRef,
+    errorResumeRef,
+    onStreamErrorImplRef,
+    clearErrorRef,
+    setMessages,
+    cancelActiveClientToolCalls,
+  });
+
+  // Client-tool dispatch (onToolCall body, orphan recovery + rescue effect).
+  const { onToolCall: dispatchClientToolCall } = useClientToolDispatch({
+    registry: {
+      activeClientToolCallsRef,
+      toolDispatchGateRef,
+      activeClientToolCallCount,
+      registerActiveClientToolCall,
+      settleActiveClientToolCall,
     },
-    [createCancellationOutput],
-  );
-
-  const settleActiveClientToolCall = useCallback(
-    async (
-      toolName: string,
-      toolCallId: string,
-      output: Record<string, unknown>,
-    ): Promise<void> => {
-      if (cancelledClientToolCallIdsRef.current.delete(toolCallId)) {
-        return;
-      }
-
-      const activeToolCall = activeClientToolCallsRef.current.get(toolCallId);
-      if (!activeToolCall) {
-        if (!manualStopRequestedRef.current) {
-          await addToolOutput({ tool: toolName, toolCallId, output });
-        }
-        return;
-      }
-
-      try {
-        if (!activeToolCall.settled) {
-          activeToolCall.settled = true;
-          await addToolOutput({
-            tool: activeToolCall.toolName,
-            toolCallId,
-            output,
-          });
-        }
-      } finally {
-        activeClientToolCallsRef.current.delete(toolCallId);
-        setActiveClientToolCallCount(activeClientToolCallsRef.current.size);
-      }
-    },
-    [addToolOutput],
-  );
-
-  // Self-heal a client tool call that the live stream delivered but never got
-  // to dispatch (the SSE dropped, the SDK reconnected to a 204, and `status`
-  // settled to "ready" with the tool frozen at "input-available"). Because a
-  // completed run would be "output-available", a tool stuck at "input-available"
-  // provably never executed — so we can safely re-dispatch it through the exact
-  // same executor `onToolCall` would have used. Its result settles via
-  // `addToolOutput`, and `sendAutomaticallyWhen` resumes the turn, recovering
-  // transparently instead of poisoning the card with "Interrupted".
-  //
-  // Returns true if it took ownership of the call (recovering), false if the
-  // tool is not a client-executable family we can safely re-run (those still
-  // get the terminal error patch).
-  const recoveredToolCallIdsRef = useRef<Set<string>>(new Set());
-  const recoverOrphanedClientToolCall = useCallback(
-    (
-      toolName: string,
-      toolCallId: string,
-      input: Record<string, unknown>,
-    ): boolean => {
-      const name = toolName as AgentToolName;
-      let run:
-        | ((ctx: {
-            executionId: string;
-            signal: AbortSignal;
-          }) => Promise<Record<string, unknown> | null | undefined>)
-        | null = null;
-      if (APP_EXECUTOR_TOOL_NAMES.has(name)) {
-        run = ({ executionId, signal }) =>
-          executeAppAgentTool(toolName, input, { executionId, signal });
-      } else if (DASHBOARD_EXECUTOR_TOOL_NAMES.has(name)) {
-        run = ({ executionId, signal }) =>
-          executeDashboardAgentTool(toolName, input, { executionId, signal });
-      } else if (DBT_EXECUTOR_TOOL_NAMES.has(name)) {
-        run = () => executeDbtAgentTool(toolName, input);
-      } else if (DATA_SOURCE_EXECUTOR_TOOL_NAMES.has(name)) {
-        run = () => executeDataSourceTool(toolName, input);
-      }
-      if (!run) return false;
-
-      // Already recovering this exact call (effect re-ran before it settled):
-      // keep ownership so it isn't poisoned, but don't dispatch twice.
-      if (recoveredToolCallIdsRef.current.has(toolCallId)) return true;
-      recoveredToolCallIdsRef.current.add(toolCallId);
-
-      const active = registerActiveClientToolCall(toolName, toolCallId);
-      void (async () => {
-        try {
-          const output = await run({
-            executionId: active.executionId,
-            signal: active.abortController.signal,
-          });
-          if (active.abortController.signal.aborted) return;
-          await settleActiveClientToolCall(
-            toolName,
-            toolCallId,
-            output ?? {
-              success: false,
-              error: `Recovered tool "${toolName}" did not return a result.`,
-            },
-          );
-        } catch (recoverError) {
-          if (
-            manualStopRequestedRef.current ||
-            active.abortController.signal.aborted
-          ) {
-            return;
-          }
-          await settleActiveClientToolCall(toolName, toolCallId, {
-            success: false,
-            error:
-              recoverError instanceof Error
-                ? recoverError.message
-                : "Recovered tool execution failed",
-          });
-        } finally {
-          recoveredToolCallIdsRef.current.delete(toolCallId);
-        }
-      })();
-      return true;
-    },
-    [registerActiveClientToolCall, settleActiveClientToolCall],
-  );
+    addToolOutputRef,
+    manualStopRequestedRef,
+    workspaceIdRef,
+    onChartSpecChangeRef,
+    dbFlowFormRefCurrent,
+    status,
+    messages,
+    chatId,
+    setMessages,
+    loadPersistedMessagesRef,
+  });
+  onToolCallImplRef.current = dispatchClientToolCall;
 
   // Aborting mid-stream can leave assistant tool calls stuck in
   // "input-available"/"input-streaming" (their output never arrives). The AI
@@ -3048,39 +591,20 @@ const Chat: React.FC<ChatProps> = ({
   const interruptActiveTurn = useCallback(() => {
     manualStopRequestedRef.current = true;
 
-    for (const activeToolCall of activeClientToolCallsRef.current.values()) {
-      cancelledClientToolCallIdsRef.current.add(activeToolCall.toolCallId);
-      activeToolCall.abortController.abort("chat-stop");
-      void Promise.resolve(activeToolCall.cancel()).catch(() => undefined);
-
-      if (!activeToolCall.settled) {
-        activeToolCall.settled = true;
-        addToolOutput({
-          tool: activeToolCall.toolName,
-          toolCallId: activeToolCall.toolCallId,
-          output: activeToolCall.cancellationOutput,
-        });
-      }
-    }
-
-    activeClientToolCallsRef.current.clear();
-    setActiveClientToolCallCount(0);
+    interruptActiveClientToolCalls();
     // With resumable streams, disconnecting no longer cancels the turn — the
     // server keeps generating for reconnecting clients. Stop must be explicit:
     // this aborts the server-side generation and clears the resume pointer.
     if (chatIdRef.current) {
-      void fetch(`/api/agent/chat/${chatIdRef.current}/stop`, {
-        method: "POST",
-      }).catch(() => undefined);
+      void api
+        .POST("/api/agent/chat/{chatId}/stop", {
+          params: { path: { chatId: chatIdRef.current } },
+        })
+        .catch(() => undefined);
     }
     stop();
     settleDanglingAssistantToolCalls();
-  }, [addToolOutput, stop, settleDanglingAssistantToolCalls]);
-
-  const handleStop = useCallback(() => {
-    interruptActiveTurn();
-    setQueuedPrompts([]);
-  }, [interruptActiveTurn]);
+  }, [interruptActiveClientToolCalls, stop, settleDanglingAssistantToolCalls]);
 
   const isLoading =
     status === "streaming" ||
@@ -3088,304 +612,9 @@ const Chat: React.FC<ChatProps> = ({
     activeClientToolCallCount > 0;
   isLoadingRef.current = isLoading;
 
-  // Stick to the streaming tail while a turn is generating.
-  //
-  // Virtuoso's `followOutput` only fires when the item COUNT changes, but an
-  // entire assistant turn — thinking blocks, every tool card, and the final
-  // text — streams into a SINGLE message, growing one item without ever
-  // changing the count. So `followOutput` never fires mid-turn and the view
-  // doesn't follow the streaming content (it stays OFF on `<Virtuoso>`).
-  //
-  // We instead pin the bottom inside Virtuoso's own `totalListHeightChanged`
-  // callback (`handleListHeightChanged`). The earlier approach pinned on each
-  // throttled `messages` tick via a one-shot rAF, but that only covers ~1 of
-  // every 3 frames: the interior blocks that change height asynchronously and
-  // non-monotonically (MUI `Collapse` on the thinking block + tool cards, and
-  // the `modify_console` diff re-render) animate over ~300ms on frames where
-  // `messages` does NOT tick. On those frames Virtuoso's resize anchoring
-  // nudges `scrollTop` UP (toward the message top) to keep content stable, and
-  // with no pin to counter it the view paints partway up — then the next
-  // `messages` tick pins it back down. That alternation is the top/bottom
-  // "jumping/blinking". Plain-text turns never bounced because their growth is
-  // append-only at the bottom (monotonic), so the anchor and the pin agree.
-  //
-  // `totalListHeightChanged` fires as part of Virtuoso's resize processing,
-  // AFTER it applies that compensation, so writing `scrollTop = scrollHeight`
-  // here is the last write before paint on exactly the frames that resize —
-  // the frames the old pin lost. Reading `isAtBottom` from a ref keeps history
-  // reading un-yanked the instant the user scrolls up.
-  const scrollerElRef = useRef<HTMLElement | Window | null>(null);
-  const isAtBottomRef = useRef(isAtBottom);
-  isAtBottomRef.current = isAtBottom;
-
-  // Track the last time the view was at the bottom (updated in render). Used to
-  // decide whether to hold the bottom through the post-turn settling window
-  // even after the big end-of-turn collapse momentarily flips `isAtBottom`.
-  const lastAtBottomAtRef = useRef(0);
-  if (isAtBottom) lastAtBottomAtRef.current = Date.now();
-
-  // Bounded settling window after a turn ends. Tool cards and thinking blocks
-  // now collapse per-block the instant each one finishes (see
-  // `StreamingToolCard` / `ReasoningDisplay`), so there is no longer a single
-  // mass collapse deferred to turn end. What still shrinks at turn end is the
-  // LAST live block: the final thinking block (or a trailing tool card) closes
-  // when `status` leaves "streaming". Virtuoso reacts to that shrink by
-  // re-anchoring to the (now shorter) item's TOP, which can strand the view at
-  // the top of the response unless we keep pinning the bottom through it.
-  //
-  // The live `isAtBottom` can't gate this pin: the very shrink we're countering
-  // flips `isAtBottom` to false for a few frames, which would disengage the pin
-  // and let the strand happen. Instead we snapshot whether the user was at the
-  // bottom *as the turn ended* (`wasAtBottomAtTurnEndRef`) and hold the bottom
-  // for the whole window based on that — so the final collapse stays pinned,
-  // but a user who had scrolled up to read history is never yanked back down.
-  const stickTailUntilRef = useRef(0);
-  const wasAtBottomAtTurnEndRef = useRef(false);
-  const wasLoadingRef = useRef(isLoading);
-  useEffect(() => {
-    if (wasLoadingRef.current && !isLoading) {
-      // Hold the bottom briefly so the final block's collapse at turn end
-      // stays pinned instead of stranding the view at the message top.
-      stickTailUntilRef.current = Date.now() + 1200;
-      wasAtBottomAtTurnEndRef.current =
-        isAtBottomRef.current || Date.now() - lastAtBottomAtRef.current < 800;
-    }
-    wasLoadingRef.current = isLoading;
-  }, [isLoading]);
-
-  // Streaming follow: a raw `scrollTop = scrollHeight` write on the captured
-  // scroller. This is the smoothest way to track append-only growth — released
-  // the instant the user scrolls up (live `isAtBottomRef`) so reading history
-  // isn't yanked down.
-  const pinToBottom = useCallback(() => {
-    if (!isAtBottomRef.current) return;
-    const el = scrollerElRef.current;
-    if (el && el instanceof HTMLElement) el.scrollTop = el.scrollHeight;
-  }, []);
-
-  const handleListHeightChanged = useCallback(() => {
-    if (isLoadingRef.current) {
-      pinToBottom();
-      return;
-    }
-    // Post-turn settle. The final block's collapse at turn end shrinks the
-    // streaming message; a raw `scrollTop` write can lose the race to Virtuoso
-    // re-anchoring the (now shorter) item to its TOP, which strands the view at
-    // the top of the response. Virtuoso's own
-    // `scrollToIndex` is authoritative — it re-targets the last item's end and
-    // survives the re-measure — so use it to hold the conclusion at the bottom
-    // through the collapse. Gated on the turn-end snapshot (not the live
-    // `isAtBottom`, which the collapse transiently flips false) and the bounded
-    // window, so a user who scrolled up to read history is never yanked back.
-    // `scrollToIndex` is only safe here because the last item is no longer
-    // growing (during streaming it would re-derive a moving target and bounce —
-    // that path uses the raw `scrollTop` pin above).
-    if (
-      Date.now() <= stickTailUntilRef.current &&
-      wasAtBottomAtTurnEndRef.current
-    ) {
-      virtuosoRef.current?.scrollToIndex({ index: "LAST", align: "end" });
-    }
-  }, [pinToBottom]);
-
-  // Rescue tool cards orphaned by a clean stream end.
-  //
-  // A tool card's "Running…" status is derived purely from the AI SDK tool
-  // part `state` — it only resolves once a terminal `output-available` /
-  // `output-error` chunk arrives. `onError` patches stuck parts when the
-  // stream *throws* (e.g. a 524), and the history-load path rewrites them when
-  // a chat is reopened. But with resumable streams a long server-side tool can
-  // outlive the edge proxy's idle timeout: the SSE connection is closed, the
-  // SDK silently reconnects, the reconnect returns 204 ("nothing streaming"),
-  // and `status` settles back to "ready" without any error ever surfacing. The
-  // live in-memory message then keeps a tool part frozen at "input-available"
-  // → a permanent "Running…" card that also blocks the composer (the SDK won't
-  // accept a new message until every tool call is settled).
-  //
-  // Once the turn has settled (`status === "ready"`) and no client-side tool is
-  // still executing, any non-terminal tool part on the last assistant message
-  // is orphaned. Patch it to an error so the card resolves and input unblocks.
-  // Mirrors the `onError` rescue; uses `setMessages` (not `addToolOutput`) so
-  // it does not feed back into `sendAutomaticallyWhen` and kick off a new turn.
-  useEffect(() => {
-    if (status !== "ready" || activeClientToolCallCount > 0) return;
-    if (activeClientToolCallsRef.current.size > 0) return;
-    const last = messages.at(-1);
-    if (!last || last.role !== "assistant") return;
-    // Human-in-the-loop tools (clarifying questions / plan review) are *meant*
-    // to sit at "input-available" with no output until the user answers via
-    // their docked card — that is not an orphan. Patching them here would tear
-    // the card down before it can be answered (it surfaces as "Interrupted —
-    // stream disconnected"). Leave them pending.
-    const pendingToolParts = (last.parts ?? []).filter(p => {
-      const pt = p.type as string;
-      if (!pt?.startsWith("tool-") && pt !== "dynamic-tool") return false;
-      if (isHumanInTheLoopToolPartType(pt)) return false;
-      const s = (p as Record<string, unknown>).state as string;
-      return s !== "output-available" && s !== "output-error" && s !== "error";
-    });
-    if (pendingToolParts.length === 0) return;
-
-    // Try to self-heal first: re-dispatch any client-executable tool stuck at
-    // "input-available". The IDs we recover keep their card alive (the
-    // re-dispatch registers an active client tool call) and must NOT be
-    // poisoned below.
-    const recoveredCallIds = new Set<string>();
-    const recoveredToolNames: string[] = [];
-    const orphanedToolNames: string[] = [];
-    for (const part of pendingToolParts) {
-      const record = part as Record<string, unknown>;
-      const pt = part.type as string;
-      const toolName =
-        pt === "dynamic-tool"
-          ? ((record.toolName as string) ?? "")
-          : toolNameFromPartType(pt);
-      const toolCallId = record.toolCallId as string | undefined;
-      const input = (record.input ?? {}) as Record<string, unknown>;
-      if (
-        record.state === "input-available" &&
-        toolCallId &&
-        recoverOrphanedClientToolCall(toolName, toolCallId, input)
-      ) {
-        recoveredCallIds.add(toolCallId);
-        recoveredToolNames.push(toolName);
-      } else {
-        orphanedToolNames.push(toolName);
-      }
-    }
-
-    reportStreamInterruption({
-      path: "orphan-rescue",
-      chatId,
-      status,
-      toolNames: orphanedToolNames,
-      recoveredToolNames,
-    });
-
-    // Nothing left to poison — everything is being recovered.
-    if (orphanedToolNames.length === 0) return;
-    setMessages(prev => {
-      const lastIndex = prev.length - 1;
-      const lastMsg = prev[lastIndex];
-      if (!lastMsg || lastMsg.role !== "assistant") return prev;
-      return prev.map((msg, i) => {
-        if (i !== lastIndex) return msg;
-        return {
-          ...msg,
-          parts: msg.parts.map(p => {
-            const record = p as Record<string, unknown>;
-            const pt = p.type as string;
-            if (!pt?.startsWith("tool-") && pt !== "dynamic-tool") return p;
-            if (isHumanInTheLoopToolPartType(pt)) return p;
-            // Leave parts we just handed to recovery untouched.
-            if (recoveredCallIds.has(record.toolCallId as string)) return p;
-            const s = record.state as string;
-            if (
-              s === "output-available" ||
-              s === "output-error" ||
-              s === "error"
-            ) {
-              return p;
-            }
-            return {
-              ...p,
-              state: "error" as const,
-              output: {
-                success: false,
-                error:
-                  "Interrupted — stream disconnected before tool completed",
-              },
-            };
-          }) as any,
-        };
-      });
-    });
-  }, [
-    status,
-    activeClientToolCallCount,
-    messages,
-    chatId,
-    recoverOrphanedClientToolCall,
-    setMessages,
-  ]);
-
-  // Reattach the chat stream when the tab wakes. A mobile lock / computer sleep
-  // freezes the page and the OS silently kills the SSE socket; on wake the AI
-  // SDK does not re-reconnect on its own, so an in-flight turn would otherwise
-  // surface as a "stream error" (or strand a tool card). The server keeps
-  // generating and buffers the turn as a resumable stream, so resumeStream()
-  // replays the buffered + live chunks; a finished turn answers 204 (cheap
-  // no-op). Mirrors realtimeStore.wake() (visibilitychange + focus + pageshow +
-  // resume), throttled so a single wake burst fires the work once. Listeners
-  // are installed once (stable closure over refs) and never re-installed.
-  useEffect(() => {
-    const WAKE_THROTTLE_MS = 2000;
-    let lastWakeAt = 0;
-    // Stable across the component's life (useRef object identity never changes);
-    // captured for the cleanup to read the latest pending resume timer.
-    const resumeState = errorResumeRef.current;
-
-    const hasResumableTurn = (): boolean => {
-      if (manualStopRequestedRef.current) return false;
-      const s = statusRef.current;
-      if (s === "streaming" || s === "submitted") return true;
-      if (
-        useRealtimeStore.getState().chatActivity[chatIdRef.current] ===
-        "streaming"
-      ) {
-        return true;
-      }
-      // A tool card frozen mid-turn (non-terminal, non-HITL) means the turn was
-      // interrupted while we were away — worth a reattach.
-      const last = messagesRef.current.at(-1);
-      if (!last || last.role !== "assistant") return false;
-      return (last.parts ?? []).some(p => {
-        const pt = p.type as string;
-        if (!pt?.startsWith("tool-") && pt !== "dynamic-tool") return false;
-        if (isHumanInTheLoopToolPartType(pt)) return false;
-        const st = (p as Record<string, unknown>).state as string;
-        return (
-          st !== "output-available" && st !== "output-error" && st !== "error"
-        );
-      });
-    };
-
-    const wake = () => {
-      const now = Date.now();
-      // A window switch fires a burst (focus + visibilitychange); the first one
-      // does the work.
-      if (now - lastWakeAt < WAKE_THROTTLE_MS) return;
-      lastWakeAt = now;
-      if (!hasResumableTurn()) return;
-      reportStreamInterruption({
-        path: "wake-resume",
-        chatId: chatIdRef.current,
-        status: statusRef.current,
-        toolNames: [],
-        resumed: true,
-      });
-      void resumeStreamRef.current?.();
-    };
-
-    const onVisible = () => {
-      if (document.visibilityState === "visible") wake();
-    };
-    document.addEventListener("visibilitychange", onVisible);
-    window.addEventListener("focus", wake);
-    window.addEventListener("pageshow", wake);
-    // Page Lifecycle API: fired when the browser unfreezes a frozen tab.
-    document.addEventListener("resume", wake);
-    return () => {
-      document.removeEventListener("visibilitychange", onVisible);
-      window.removeEventListener("focus", wake);
-      window.removeEventListener("pageshow", wake);
-      document.removeEventListener("resume", wake);
-      if (resumeState.timer) {
-        clearTimeout(resumeState.timer);
-        resumeState.timer = null;
-      }
-    };
-  }, []);
+  // Bottom-pin / streaming-follow machinery (see useChatScroll).
+  const { isAtBottom, setIsAtBottom, scrollerElRef, handleListHeightChanged } =
+    useChatScroll({ isLoading, isLoadingRef, virtuosoRef });
 
   const lastMessage = messages.at(-1);
   const lastMessageParts = lastMessage?.parts ?? [];
@@ -3406,11 +635,6 @@ const Chat: React.FC<ChatProps> = ({
     isLoading,
     connectionIconById,
   });
-
-  // Session management - fetch available chat sessions for history menu
-  useEffect(() => {
-    fetchSessionsRef.current?.();
-  }, [currentWorkspace]);
 
   // Validate the restored per-tab chat once the workspace resolves: a chat
   // persisted for a different workspace must not leak into this one.
@@ -3441,456 +665,48 @@ const Chat: React.FC<ChatProps> = ({
     };
   }, [chatId, currentWorkspace?.id]);
 
-  // In-band console sync: when a server-side console tool result streams in
-  // (state "output-available"), reconcile THIS window against the server
-  // draft. The chat stream is resumable, so unlike the workspace realtime
-  // poke channel this survives SSE drops, half-closes, frozen background
-  // tabs, reconnects and page refreshes — the replayed part triggers the
-  // same idempotent reconciliation.
-  //
-  //   - create_console / open_console -> open the tab here.
-  //   - modify_console / set_console_connection -> pull the authoritative
-  //     draft for open tabs (revision sync). Without this, an agent EDIT
-  //     reached the editor ONLY via the realtime poke; a missed poke (dead
-  //     SSE, or a poke that raced the tab open) left the editor stale until
-  //     the next focus/reconnect/watchdog/refresh — the reported "modify did
-  //     nothing until I refreshed" bug. create_console never had this problem
-  //     because it already rode the chat stream (asymmetry, issue #475).
-  //
-  // Tool call ids seen in RESTORED history are pre-seeded into this set by
-  // loadSession (reopening a chat must not re-open/re-sync every console it
-  // ever touched — the dedicated consoles-restore payload handles that).
-  const handledConsoleOpenToolCallIdsRef = useRef<Set<string>>(new Set());
-  useEffect(() => {
-    handledConsoleOpenToolCallIdsRef.current = new Set();
-  }, [chatId]);
-  useEffect(() => {
-    const workspaceId = currentWorkspace?.id;
-    if (!workspaceId) return;
-    const last = messages.at(-1);
-    if (!last || last.role !== "assistant") return;
-    for (const part of last.parts ?? []) {
-      const p = part as {
-        type?: string;
-        toolName?: string;
-        state?: string;
-        toolCallId?: string;
-        output?: { success?: boolean; consoleId?: string };
-      };
-      const toolName =
-        p.type === "dynamic-tool"
-          ? p.toolName
-          : p.type?.startsWith("tool-")
-            ? p.type.slice("tool-".length)
-            : undefined;
-      const opensTab =
-        toolName === "create_console" || toolName === "open_console";
-      // Server console writes whose only client delivery is the realtime poke.
-      // run_console bumps the draft revision AND persists a run artifact
-      // (tab.lastRun); the revision sync refreshes both, and Editor.tsx
-      // reactively renders lastRun into the results panel — so reconciling
-      // here surfaces agent run RESULTS even when the run.completed poke was
-      // missed (dead/half-closed SSE), matching modify/set-connection.
-      const editsConsole =
-        toolName === "modify_console" ||
-        toolName === "set_console_connection" ||
-        toolName === "run_console";
-      if (!opensTab && !editsConsole) continue;
-      if (p.state !== "output-available") continue;
-      if (!p.toolCallId || !p.output?.success) continue;
-      // Opening needs a consoleId; an edit reconciles all open tabs so it
-      // does not. Don't burn the dedupe slot on an opener that lacks an id.
-      if (opensTab && !p.output?.consoleId) continue;
-      if (handledConsoleOpenToolCallIdsRef.current.has(p.toolCallId)) continue;
-      handledConsoleOpenToolCallIdsRef.current.add(p.toolCallId);
-      if (opensTab) {
-        const consoleId = p.output.consoleId as string;
-        void (async () => {
-          await useConsoleStore
-            .getState()
-            .openConsoleFromServer(workspaceId, consoleId);
-          // A create followed immediately by a modify can drop the modify's
-          // workspace poke while the tab is still opening; reconcile once the
-          // tab carries a revision base so it never sticks on create-time
-          // content.
-          void useRealtimeStore.getState().syncRevisions();
-        })();
-      } else {
-        void useRealtimeStore.getState().syncRevisions();
-      }
-    }
-  }, [messages, currentWorkspace?.id]);
+  // In-band reconciliation of server-executed tool results (console open /
+  // revision sync + app/dbt refetch) — see useServerToolSync. The returned
+  // ref is seeded by the session loader so restored history doesn't re-open
+  // every console the chat ever touched.
+  const { handledConsoleOpenToolCallIdsRef } = useServerToolSync({
+    chatId,
+    workspaceId: currentWorkspace?.id,
+    messages,
+  });
 
-  // In-band app/dbt sync — the app/dbt analogue of the console reconcile above.
-  // The app_* and dbt file mutation tools execute SERVER-SIDE, so an OPEN app /
-  // dbt tab learns about the agent's write via the workspace realtime poke
-  // (app.updated / dbt.file.updated). That poke rides the workspace SSE, which
-  // a mobile lock / laptop sleep / proxy half-close can kill — so reconcile
-  // off the RESUMABLE CHAT STREAM too: when the tool result streams in (or is
-  // replayed after a wake reattach), refetch the open app / dbt file. This
-  // makes the open tab converge even under a dead workspace SSE (poke = fast
-  // path, this = robust backstop). Mirrors the console pattern (issue #475).
-  const handledEntitySyncToolCallIdsRef = useRef<Set<string>>(new Set());
-  useEffect(() => {
-    handledEntitySyncToolCallIdsRef.current = new Set();
-  }, [chatId]);
-  useEffect(() => {
-    const workspaceId = currentWorkspace?.id;
-    if (!workspaceId) return;
-    const last = messages.at(-1);
-    if (!last || last.role !== "assistant") return;
-    for (const part of last.parts ?? []) {
-      const p = part as {
-        type?: string;
-        toolName?: string;
-        state?: string;
-        toolCallId?: string;
-        input?: { appId?: string; projectId?: string; path?: string };
-        output?: { success?: boolean };
-      };
-      const toolName =
-        p.type === "dynamic-tool"
-          ? p.toolName
-          : p.type?.startsWith("tool-")
-            ? p.type.slice("tool-".length)
-            : undefined;
-      if (!toolName) continue;
-      const isAppEdit = APP_SERVER_MUTATION_TOOLS.has(toolName);
-      const isDbtEdit = DBT_SERVER_MUTATION_TOOLS.has(toolName);
-      if (!isAppEdit && !isDbtEdit) continue;
-      if (
-        p.state !== "output-available" ||
-        !p.toolCallId ||
-        !p.output?.success
-      ) {
-        continue;
-      }
-      if (handledEntitySyncToolCallIdsRef.current.has(p.toolCallId)) continue;
-      handledEntitySyncToolCallIdsRef.current.add(p.toolCallId);
-
-      if (isAppEdit) {
-        const appId = p.input?.appId;
-        // Only reconcile a tab that is actually open here (mirrors the
-        // realtime handler); fetchApp + bumpPreview rebuilds the preview.
-        if (appId && useAppStore.getState().openApps[appId]) {
-          void (async () => {
-            const fresh = await useAppStore
-              .getState()
-              .fetchApp(workspaceId, appId);
-            if (fresh) useAppStore.getState().bumpPreview(appId);
-          })();
-        }
-      } else {
-        const projectId = p.input?.projectId;
-        const path = p.input?.path;
-        // Only touch projects this window has loaded.
-        if (
-          projectId &&
-          path &&
-          useDbtStore.getState().filePathsByProject[projectId]
-        ) {
-          void useDbtStore
-            .getState()
-            .applyRemoteFileUpdate(
-              workspaceId,
-              projectId,
-              path,
-              toolName === "delete_dbt_file",
-            );
-        }
-      }
-    }
-  }, [messages, currentWorkspace?.id]);
-
-  // Load messages when selecting an existing chat from history
-  useEffect(() => {
-    // Flipped when this effect is superseded (chat switched / unmount) so a
-    // slow fetch can't clobber the next chat's state or resume the wrong one.
-    let cancelled = false;
-    const loadSession = async () => {
-      if (!isExistingChat || !currentWorkspace) {
-        return;
-      }
-      try {
-        const res = await fetch(
-          `/api/workspaces/${currentWorkspace.id}/chats/${chatId}`,
-        );
-        if (cancelled) return;
-        if (res.ok) {
-          const data = await res.json();
-          // Convert stored messages to AI SDK format with parts including tool calls
-          // Tool calls are included for UI display (shows what tools were used).
-          // The backend sanitizes these before sending to the AI to avoid
-          // "tool_use without tool_result" errors.
-          const convertedMessages =
-            data.messages?.map((msg: any) => {
-              // NEW: If parts are stored, use them directly (preserves chronological order)
-              if (
-                msg.parts &&
-                Array.isArray(msg.parts) &&
-                msg.parts.length > 0
-              ) {
-                return {
-                  id:
-                    msg.id ||
-                    msg._id?.toString() ||
-                    `${Date.now()}-${Math.random()}`,
-                  role: msg.role,
-                  parts: msg.parts.map((p: any) => {
-                    // Convert stored part to UI format
-                    if (p.type === "text") {
-                      return { type: "text", text: p.text || "" };
-                    }
-                    if (p.type === "reasoning") {
-                      // Handle both 'reasoning' and 'text' fields for reasoning parts.
-                      // Carry providerMetadata back (Anthropic extended-thinking
-                      // `signature`) so a continuation replays the thinking block
-                      // byte-for-byte; without it Anthropic rejects the turn with
-                      // "thinking ... blocks in the latest assistant message cannot
-                      // be modified".
-                      return {
-                        type: "reasoning",
-                        text: p.reasoning || p.text || "",
-                        ...(p.providerMetadata != null
-                          ? { providerMetadata: p.providerMetadata }
-                          : {}),
-                      };
-                    }
-                    // Tool parts: ensure state is set for UI rendering
-                    // AI SDK v6 uses output-error (not "error") so convertToModelMessages
-                    // emits a matching tool-result for Anthropic.
-                    if (
-                      p.type?.startsWith("tool-") ||
-                      p.type === "dynamic-tool"
-                    ) {
-                      const toolState = p.state as string | undefined;
-                      const interruptedText =
-                        "Interrupted — stream disconnected before tool completed";
-                      if (toolState === "error") {
-                        const output = p.output as
-                          | { error?: unknown }
-                          | null
-                          | undefined;
-                        const errorText =
-                          typeof p.errorText === "string"
-                            ? p.errorText
-                            : typeof output?.error === "string"
-                              ? output.error
-                              : output?.error != null
-                                ? String(output.error)
-                                : "Tool failed";
-                        return {
-                          ...p,
-                          state: "output-error",
-                          input: p.input ?? {},
-                          output: undefined,
-                          errorText,
-                        };
-                      }
-                      const isComplete =
-                        toolState === "output-available" ||
-                        toolState === "output-error" ||
-                        toolState === "output-denied";
-                      if (isComplete) {
-                        return {
-                          ...p,
-                          input: p.input ?? {},
-                        };
-                      }
-                      // A persisted, unanswered human-in-the-loop tool
-                      // (clarifying questions / plan review) is not an
-                      // interrupted tool: re-render its interactive card so the
-                      // user can still answer it. Answering sends the tool
-                      // result, which continues the turn from persisted
-                      // history. Keep it pending instead of marking it errored.
-                      if (
-                        typeof p.type === "string" &&
-                        isHumanInTheLoopToolPartType(p.type) &&
-                        toolState === "input-available"
-                      ) {
-                        return {
-                          ...p,
-                          input: p.input ?? {},
-                        };
-                      }
-                      return {
-                        ...p,
-                        state: "output-error",
-                        input: p.input ?? {},
-                        output: undefined,
-                        errorText: interruptedText,
-                      };
-                    }
-                    // Unknown part type - pass through as-is
-                    return p;
-                  }),
-                };
-              }
-
-              // TODO: Remove this fallback once we're OK with losing the ability to show old chats
-              // that were created before the parts array migration.
-              // LEGACY FALLBACK: Reconstruct parts from legacy fields (for existing chats without parts)
-              // Note: Order cannot be perfectly restored, use best-effort: tools -> reasoning -> text
-              const parts: Array<Record<string, unknown>> = [];
-
-              // Add tool call parts (for UI display - shows tool history)
-              // IMPORTANT: input must always be defined (at least {}) for OpenAI API compatibility
-              if (msg.toolCalls && msg.toolCalls.length > 0) {
-                for (const tc of msg.toolCalls) {
-                  if (!tc.toolName) continue;
-                  parts.push({
-                    type: `tool-${tc.toolName}`,
-                    toolCallId:
-                      tc.toolCallId ||
-                      tc._id?.toString() ||
-                      `saved-${tc.toolName}-${Date.now()}-${Math.random()}`,
-                    toolName: tc.toolName,
-                    state: "output-available",
-                    input: tc.input ?? {},
-                    output: tc.result ?? null,
-                  });
-                }
-              }
-
-              // Add reasoning parts (if any)
-              if (msg.reasoning && Array.isArray(msg.reasoning)) {
-                for (const reasoningText of msg.reasoning) {
-                  parts.push({
-                    type: "reasoning",
-                    text: reasoningText,
-                  });
-                }
-              }
-
-              // Add text content part
-              if (msg.content) {
-                parts.push({ type: "text", text: msg.content });
-              }
-
-              return {
-                id:
-                  msg._id?.toString() ||
-                  msg.id ||
-                  `${Date.now()}-${Math.random()}`,
-                role: msg.role,
-                parts,
-              };
-            }) || [];
-
-          // Restored tool parts must not re-trigger the in-band console
-          // opener (only LIVE streamed results should); the consoles-restore
-          // payload below already reopens what matters.
-          for (const msg of convertedMessages) {
-            for (const part of msg.parts ?? []) {
-              const toolCallId = (part as { toolCallId?: string }).toolCallId;
-              if (toolCallId) {
-                handledConsoleOpenToolCallIdsRef.current.add(toolCallId);
-              }
-            }
-          }
-
-          setMessages(convertedMessages);
-
-          // Virtuoso keeps ONE instance across chat switches (Chat isn't keyed
-          // by chatId), so its `initialTopMostItemIndex` — read once at mount —
-          // never re-applies when we bulk-load a different chat's history here.
-          // Without this, opening an existing chat from history can land
-          // mid-list or at the top. Pin to the newest message on the next
-          // frame (after the new data has rendered) so it deterministically
-          // opens at the bottom, matching the old stick-to-bottom behavior.
-          if (convertedMessages.length > 0) {
-            requestAnimationFrame(() => {
-              if (cancelled) return;
-              virtuosoRef.current?.scrollToIndex({
-                index: "LAST",
-                align: "end",
-              });
-            });
-          }
-
-          // Restore consoles that were modified by the agent in this chat
-          // The backend extracts console IDs from modify_console tool calls in the messages
-          // and fetches those consoles from the database
-          if (data.consoles && data.consoles.length > 0) {
-            const store = useConsoleStore.getState();
-            const workspaceId = workspaceIdRef.current;
-
-            for (const console of data.consoles) {
-              // Check if console already exists in tabs (by ID)
-              const exists = Boolean(store.tabs[console.id]);
-              if (!exists && workspaceId) {
-                await store.openConsoleFromServer(workspaceId, console.id);
-              }
-            }
-
-            // Set the first restored console as active and capture it for this chat
-            const firstConsole = data.consoles[0];
-            if (firstConsole) {
-              store.setActiveTab(firstConsole.id);
-              capturedConsoleIdRef.current = firstConsole.id;
-            }
-          }
-        }
-      } catch {
-        /* ignore */
-      }
-
-      // Reattach to a still-generating turn AFTER the persisted messages are
-      // in place: the resumable SSE replay only contains this turn's
-      // assistant chunks, so loading first yields the full conversation and
-      // avoids setMessages clobbering an in-flight replay. The server answers
-      // 204 when the chat is idle (or unknown), making this a cheap no-op.
-      if (!cancelled) {
-        void resumeStreamRef.current?.();
-      }
-    };
-    loadSession();
-    return () => {
-      cancelled = true;
-    };
-  }, [chatId, isExistingChat, currentWorkspace, setMessages]);
+  // History load (chat selection / tab restore) + the shared persisted-message
+  // reload used by the resume manager.
+  useChatSessionLoader({
+    chatId,
+    isExistingChat,
+    workspaceId: currentWorkspace?.id,
+    setMessages,
+    messagesRef,
+    workspaceIdRef,
+    chatIdRef,
+    virtuosoRef,
+    capturedConsoleIdRef,
+    handledConsoleOpenToolCallIdsRef,
+    toolDispatchGateRef,
+    loadPersistedMessagesRef,
+    requestResumeRef,
+  });
 
   // Create new chat session - just generate a new ID locally (no API call needed)
   const createNewSession = () => {
     cancelActiveClientToolCalls("session-change");
     manualStopRequestedRef.current = false;
-    setQueuedPrompts([]);
+    clearQueuedPrompts();
     setChatId(generateObjectId());
     setMessages([]);
     setIsExistingChat(false);
   };
 
-  // Live per-chat activity from the realtime channel. The server-fetched
-  // activeStreamId is the initial value (correct on cold open); chat.activity
-  // events keep it current while the menu is open — including turns started
-  // by other windows or continuing server-side after a detach.
-  const chatActivity = useRealtimeStore(s => s.chatActivity);
-  const isSessionStreaming = useCallback(
-    (session: ChatSessionMeta): boolean => {
-      const live = chatActivity[session._id];
-      if (live === "streaming") return true;
-      if (live === "idle") return false;
-      return Boolean(session.activeStreamId);
-    },
-    [chatActivity],
-  );
-
-  const handleHistoryMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
-    setHistoryMenuAnchor(event.currentTarget);
-    // The list goes stale the moment a new chat starts a turn (the doc is
-    // created server-side at turn start) — refresh it on every open so
-    // in-flight chats appear immediately with their streaming indicator.
-    void fetchSessionsRef.current?.();
-  };
-
-  const handleHistoryMenuClose = () => {
-    setHistoryMenuAnchor(null);
-  };
-
   const handleSelectSession = (id: string) => {
     cancelActiveClientToolCalls("session-change");
     manualStopRequestedRef.current = false;
-    setQueuedPrompts([]);
+    clearQueuedPrompts();
     setChatId(id);
     setMessages([]);
     setIsExistingChat(true);
@@ -3899,22 +715,10 @@ const Chat: React.FC<ChatProps> = ({
 
   const handleDeleteSession = async (id: string, e: React.MouseEvent) => {
     e.stopPropagation();
-    if (!currentWorkspace) return;
-    try {
-      const res = await fetch(
-        `/api/workspaces/${currentWorkspace.id}/chats/${id}`,
-        { method: "DELETE" },
-      );
-      if (res.ok) {
-        const newSessions = sessions.filter(s => s._id !== id);
-        setSessions(newSessions);
-        if (chatId === id) {
-          // If we deleted the current chat, start a new one
-          createNewSession();
-        }
-      }
-    } catch {
-      /* ignore */
+    const deleted = await deleteSession(id);
+    // If we deleted the current chat, start a new one.
+    if (deleted && chatId === id) {
+      createNewSession();
     }
   };
 
@@ -3975,8 +779,8 @@ const Chat: React.FC<ChatProps> = ({
   // While a submit_plan awaits review (input fully available, unresolved),
   // the chat composer becomes the plan-iteration channel: a sent message is
   // routed to the tool output as request_changes feedback instead of a normal
-  // user message. Ref keeps handleChatSubmit's identity stable (perf rules).
-  const pendingPlanToolCallIdRef = useRef<string | null>(null);
+  // user message. Ref (declared above useChat) keeps handleChatSubmit's
+  // identity stable (perf rules).
   pendingPlanToolCallIdRef.current =
     pendingInteractiveTool?.toolName === "submit_plan" &&
     !pendingInteractiveTool.streaming
@@ -4059,266 +863,41 @@ const Chat: React.FC<ChatProps> = ({
     setSelectedTool(null);
   };
 
-  // Stable submit handler — reads store state at call time via getState() and refs
-  // to keep the callback identity stable during streaming.
-  const sendMessageRef = useRef(sendMessage);
-  sendMessageRef.current = sendMessage;
-  const messagesRef = useRef(messages);
-  messagesRef.current = messages;
+  // Prompt queue: queue-while-busy, drain-on-settle, in-composer editing,
+  // and force-send. Owns handleChatSubmit.
+  const {
+    queuedPrompts,
+    editingPromptId,
+    editingPrompt,
+    handleChatSubmit,
+    handleRemoveQueuedPrompt,
+    handleStartEditQueuedPrompt,
+    handleCancelEditQueuedPrompt,
+    handleSendQueuedPromptNow,
+    clearQueuedPrompts,
+  } = useQueuedPrompts({
+    chatId,
+    status,
+    isLoading,
+    activeClientToolCallCount,
+    isLoadingRef,
+    manualStopRequestedRef,
+    messagesRef,
+    sendMessageRef,
+    modelIdRef,
+    capturedConsoleIdRef,
+    capturedDashboardIdRef,
+    activeConsoleIdRef,
+    pendingPlanToolCallIdRef,
+    autoSendWhenComplete,
+    interruptActiveTurn,
+    drainQueuedPromptAfterTurnRef,
+  });
 
-  // When a turn ends on a completed client-side tool call (e.g. a data
-  // binding), `lastAssistantMessageIsCompleteWithToolCalls` stays true and the
-  // SDK *may* auto-continue the agent loop in a microtask after onFinish. We
-  // must not drain into that gap, but we also must not stall forever when the
-  // SDK is actually idle and won't resume (e.g. the tool settled while the
-  // stream was still streaming, so the SDK's auto-continue condition was
-  // missed). When that predicate is the *only* thing blocking the drain, defer
-  // one macrotask and re-check: if the SDK resumed, `status` is now
-  // submitted/streaming and the loading guard bails; if it stayed idle, force
-  // the drain past the (now-stale) predicate so the queue can't hang.
-  const drainRecheckScheduledRef = useRef(false);
-  const forceDrainPastAutoContinueRef = useRef(false);
-
-  const tryDrainQueuedPromptRef = useRef<() => void>(() => {});
-  tryDrainQueuedPromptRef.current = () => {
-    // Force-send (top arrow): the user interrupted the running turn to push
-    // this prompt now. Wait only until the aborted turn has fully settled
-    // (no in-flight stream / unanswered tool calls), then send it past every
-    // other guard — including the manual-stop flag the interrupt just set.
-    const forcedId = pendingForcePromptIdRef.current;
-    if (forcedId) {
-      const forced = queuedPromptsRef.current.find(p => p.id === forcedId);
-      if (!forced) {
-        pendingForcePromptIdRef.current = null;
-      } else {
-        if (
-          isLoadingRef.current ||
-          hasPendingAssistantToolCalls(messagesRef.current)
-        ) {
-          return;
-        }
-        pendingForcePromptIdRef.current = null;
-        const remaining = queuedPromptsRef.current.filter(
-          p => p.id !== forcedId,
-        );
-        queuedPromptsRef.current = remaining;
-        isLoadingRef.current = true;
-        setQueuedPrompts(remaining);
-        capturedConsoleIdRef.current = forced.consoleId;
-        capturedDashboardIdRef.current = forced.dashboardId;
-        manualStopRequestedRef.current = false;
-        trackEvent("ai_chat_message_sent", {
-          model: modelIdRef.current,
-          has_context: false,
-          has_images: (forced.files?.length ?? 0) > 0,
-        });
-        sendMessageRef.current({ text: forced.text, files: forced.files });
-        return;
-      }
-    }
-
-    if (
-      manualStopRequestedRef.current ||
-      // Don't auto-fire the next queued prompt into a failed turn. The error
-      // (e.g. usage_limit_exceeded) stays on screen; dismissing it via
-      // clearError flips status back to "ready" and re-triggers this drain.
-      status === "error" ||
-      queuedPromptsRef.current.length === 0 ||
-      // Don't drain the head item while the user is editing it in the composer.
-      queuedPromptsRef.current[0]?.id === editingPromptIdRef.current
-    ) {
-      forceDrainPastAutoContinueRef.current = false;
-      return;
-    }
-
-    // Hard blocks: the agent is genuinely mid-turn (streaming, running a
-    // client tool, or has an unanswered tool call). Sending now would race the
-    // loop or break the SDK's "all tool calls must be settled" invariant.
-    if (
-      isLoadingRef.current ||
-      hasPendingAssistantToolCalls(messagesRef.current)
-    ) {
-      forceDrainPastAutoContinueRef.current = false;
-      return;
-    }
-
-    // Soft block: the turn ended on completed tool calls and the SDK might
-    // auto-continue in a microtask. Give it one macrotask before draining.
-    if (
-      autoSendWhenComplete({ messages: messagesRef.current }) &&
-      !forceDrainPastAutoContinueRef.current
-    ) {
-      if (!drainRecheckScheduledRef.current) {
-        drainRecheckScheduledRef.current = true;
-        setTimeout(() => {
-          drainRecheckScheduledRef.current = false;
-          forceDrainPastAutoContinueRef.current = true;
-          tryDrainQueuedPromptRef.current();
-        }, 80);
-      }
-      return;
-    }
-
-    forceDrainPastAutoContinueRef.current = false;
-
-    const [next, ...rest] = queuedPromptsRef.current;
-    // Synchronously advance the queue and mark loading BEFORE sending so a
-    // second drain trigger firing in the same tick (the [isLoading,status]
-    // effect and the onFinish microtask can both run before React re-renders)
-    // bails out at the guards above instead of re-sending the same prompt.
-    queuedPromptsRef.current = rest;
-    isLoadingRef.current = true;
-    setQueuedPrompts(rest);
-    capturedConsoleIdRef.current = next.consoleId;
-    capturedDashboardIdRef.current = next.dashboardId;
-    manualStopRequestedRef.current = false;
-    trackEvent("ai_chat_message_sent", {
-      model: modelIdRef.current,
-      has_context: false,
-      has_images: (next.files?.length ?? 0) > 0,
-    });
-    sendMessageRef.current({ text: next.text, files: next.files });
-  };
-  drainQueuedPromptAfterTurnRef.current = () =>
-    tryDrainQueuedPromptRef.current();
-
-  const handleChatSubmit = useCallback((text: string, files?: FileUIPart[]) => {
-    // Committing an edit of a queued prompt: update the queue entry in place
-    // instead of sending/queuing a new message.
-    if (editingPromptIdRef.current) {
-      const id = editingPromptIdRef.current;
-      const trimmed = text.trim();
-      setEditingPromptId(null);
-      if (trimmed) {
-        setQueuedPrompts(prev =>
-          prev.map(prompt =>
-            prompt.id === id ? { ...prompt, text: trimmed } : prompt,
-          ),
-        );
-      }
-      return;
-    }
-
-    // Conversational plan iteration (Cursor-style): while a submitted plan is
-    // awaiting review, the typed message becomes request_changes feedback on
-    // the plan — including the current draft, so manual edits made in the
-    // plan tab flow back — instead of a normal user message.
-    const pendingPlanToolCallId = pendingPlanToolCallIdRef.current;
-    if (pendingPlanToolCallId) {
-      const planStore = usePlanStore.getState();
-      const planEntry = planStore.plans[pendingPlanToolCallId];
-      const feedback = text.trim();
-      if (planEntry?.status === "pending" && feedback) {
-        trackEvent("ai_plan_feedback_sent", { model: modelIdRef.current });
-        planStore.resolvePlan(
-          pendingPlanToolCallId,
-          "request_changes",
-          feedback,
-        );
-        return;
-      }
-    }
-
-    capturedConsoleIdRef.current = activeConsoleIdRef.current;
-    const store = useConsoleStore.getState();
-    const currentTab = store.tabs[store.activeTabId || ""] as
-      | (ConsoleTab & { metadata?: Record<string, unknown> })
-      | undefined;
-    const dashboardId =
-      currentTab?.kind === "dashboard"
-        ? ((currentTab.metadata?.dashboardId as string | undefined) ?? null)
-        : null;
-    capturedDashboardIdRef.current = dashboardId;
-    const consoleId = capturedConsoleIdRef.current;
-
-    if (isLoadingRef.current) {
-      trackEvent("ai_chat_message_queued", {
-        model: modelIdRef.current,
-        has_images: (files?.length ?? 0) > 0,
-      });
-      setQueuedPrompts(prev => [
-        ...prev,
-        {
-          id: generateObjectId(),
-          text,
-          files,
-          consoleId,
-          dashboardId,
-        },
-      ]);
-      return;
-    }
-
-    manualStopRequestedRef.current = false;
-    const activeConsole = store.tabs[store.activeTabId || ""];
-    trackEvent("ai_chat_message_sent", {
-      model: modelIdRef.current,
-      has_context: !!activeConsole?.content,
-      has_images: (files?.length ?? 0) > 0,
-    });
-    sendMessageRef.current({ text, files });
-  }, []);
-
-  useEffect(() => {
-    tryDrainQueuedPromptRef.current();
-  }, [isLoading, status, activeClientToolCallCount]);
-
-  // Belt-and-suspenders: useChat `id` resets hook state on chatId change.
-  useEffect(() => {
-    setQueuedPrompts([]);
-  }, [chatId]);
-
-  const handleRemoveQueuedPrompt = useCallback((id: string) => {
-    setQueuedPrompts(prev => prev.filter(prompt => prompt.id !== id));
-  }, []);
-
-  const handleStartEditQueuedPrompt = useCallback((id: string) => {
-    setEditingPromptId(id);
-  }, []);
-
-  const handleCancelEditQueuedPrompt = useCallback(() => {
-    setEditingPromptId(null);
-  }, []);
-
-  // If the edited prompt leaves the queue (drained, removed, or cleared), exit
-  // edit mode so a stale id can't swallow the next real submit.
-  useEffect(() => {
-    if (
-      editingPromptId &&
-      !queuedPrompts.some(prompt => prompt.id === editingPromptId)
-    ) {
-      setEditingPromptId(null);
-    }
-  }, [queuedPrompts, editingPromptId]);
-
-  // Force-send (top arrow): send this prompt right now. If the agent is still
-  // running, interrupt the current turn first, then push it. If idle, just
-  // send it immediately (ahead of any other queued items).
-  const handleSendQueuedPromptNow = useCallback(
-    (id: string) => {
-      if (!queuedPromptsRef.current.some(p => p.id === id)) return;
-      if (editingPromptIdRef.current === id) setEditingPromptId(null);
-
-      // Move to the front for immediate visual feedback.
-      setQueuedPrompts(prev => {
-        const index = prev.findIndex(prompt => prompt.id === id);
-        if (index <= 0) return prev;
-        const next = [...prev];
-        const [item] = next.splice(index, 1);
-        next.unshift(item);
-        return next;
-      });
-
-      pendingForcePromptIdRef.current = id;
-      if (isLoadingRef.current) {
-        interruptActiveTurn();
-      }
-      // Drain now if already idle; otherwise the status→ready transition from
-      // the interrupt re-fires the drain effect, which sends the forced prompt.
-      queueMicrotask(() => tryDrainQueuedPromptRef.current());
-    },
-    [interruptActiveTurn],
-  );
+  const handleStop = useCallback(() => {
+    interruptActiveTurn();
+    clearQueuedPrompts();
+  }, [interruptActiveTurn, clearQueuedPrompts]);
 
   // Copy chat history handler
   const [copiedChat, setCopiedChat] = useState(false);
@@ -4467,84 +1046,16 @@ const Chat: React.FC<ChatProps> = ({
       </Box>
 
       {/* History Menu */}
-      <Menu
+      <ChatHistoryMenu
         anchorEl={historyMenuAnchor}
         open={historyMenuOpen}
         onClose={handleHistoryMenuClose}
-        PaperProps={{
-          sx: { maxHeight: 400, width: 300 },
-        }}
-      >
-        {sessions
-          .filter(
-            session =>
-              session._id === chatId ||
-              isSessionStreaming(session) ||
-              (session.title && session.title.length > 0),
-          )
-          .map(session => (
-            <MenuItem
-              key={session._id}
-              onClick={() => handleSelectSession(session._id)}
-              selected={session._id === chatId}
-              sx={{ display: "flex", justifyContent: "space-between" }}
-            >
-              <Box sx={{ display: "flex", alignItems: "center", flex: 1 }}>
-                <ListItemIcon>
-                  {isSessionStreaming(session) ? (
-                    // Turn in flight server-side — pulsing indicator instead
-                    // of the static chat icon.
-                    <Box
-                      sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                        width: 18,
-                        height: 18,
-                      }}
-                    >
-                      <Box sx={streamingIndicatorDotSx} />
-                    </Box>
-                  ) : (
-                    <MessageSquare size={18} />
-                  )}
-                </ListItemIcon>
-                <Box>
-                  <ListItemText
-                    primary={session.title || session._id.substring(0, 8)}
-                    secondary={
-                      session.updatedAt
-                        ? new Date(session.updatedAt).toLocaleString()
-                        : session.createdAt
-                          ? new Date(session.createdAt).toLocaleString()
-                          : ""
-                    }
-                    primaryTypographyProps={{
-                      noWrap: true,
-                      sx: { maxWidth: 200 },
-                    }}
-                  />
-                </Box>
-              </Box>
-              {sessions.length > 1 && (
-                <IconButton
-                  size="small"
-                  onClick={e => handleDeleteSession(session._id, e)}
-                  sx={{ ml: 1 }}
-                >
-                  <Trash2 size={18} />
-                </IconButton>
-              )}
-            </MenuItem>
-          ))}
-        {sessions.length === 0 && (
-          <MenuItem disabled>
-            <Typography variant="body2" color="text.secondary">
-              No chat history yet
-            </Typography>
-          </MenuItem>
-        )}
-      </Menu>
+        sessions={sessions}
+        currentChatId={chatId}
+        isSessionStreaming={isSessionStreaming}
+        onSelect={handleSelectSession}
+        onDelete={handleDeleteSession}
+      />
 
       {/* Error display — billing errors get an upgrade prompt */}
       {error && (
@@ -4811,55 +1322,12 @@ const Chat: React.FC<ChatProps> = ({
       />
 
       {/* Tool Debug Dialog */}
-      <Dialog
+      <ToolDetailsDialog
         open={toolDialogOpen}
+        tool={selectedTool}
         onClose={handleCloseToolDialog}
-        fullWidth
-        maxWidth="md"
-      >
-        <DialogTitle>
-          {selectedTool ? `Tool: ${selectedTool.toolName}` : "Tool Details"}
-        </DialogTitle>
-        <DialogContent dividers>
-          <Box sx={{ mb: 2 }}>
-            <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
-              Input
-            </Typography>
-            <CodeBlock
-              language="json"
-              isGenerating={false}
-              scrollable
-              paletteMode={paletteMode}
-            >
-              {selectedTool && selectedTool.input !== undefined
-                ? typeof selectedTool.input === "string"
-                  ? selectedTool.input
-                  : safeStringify(selectedTool.input, 2)
-                : "No input captured"}
-            </CodeBlock>
-          </Box>
-          <Box>
-            <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
-              Output
-            </Typography>
-            <CodeBlock
-              language="json"
-              isGenerating={false}
-              scrollable
-              paletteMode={paletteMode}
-            >
-              {selectedTool && selectedTool.output !== undefined
-                ? typeof selectedTool.output === "string"
-                  ? selectedTool.output
-                  : safeStringify(selectedTool.output, 2)
-                : "No output captured"}
-            </CodeBlock>
-          </Box>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleCloseToolDialog}>Close</Button>
-        </DialogActions>
-      </Dialog>
+        paletteMode={paletteMode}
+      />
     </Box>
   );
 };

--- a/app/src/components/StreamingToolCard.tsx
+++ b/app/src/components/StreamingToolCard.tsx
@@ -168,38 +168,80 @@ function formatOutputForDisplay(output: unknown): string {
   return JSON.stringify(o, null, 2);
 }
 
-// Inline display caps. Tool results are already size-bounded server-side, but a
-// single 50k-char JSON blob still expands into thousands of DOM nodes once
-// syntax-highlighted — and many such cards in a long chat make mobile Safari
-// crawl. We never feed more than this to the highlighter; the full payload is
-// still available via the tool-details dialog.
-const MAX_INLINE_CHARS = 8_000;
-const MAX_INLINE_LINES = 200;
+// The tool body always renders the FULL content — never truncated. What we DO
+// bound is the *highlighter*: Prism expands every token into a DOM node and
+// re-parses the whole string on each streaming tick, so an unbounded payload
+// would explode into tens of thousands of nodes and make long chats (and
+// mobile Safari) crawl. Past this budget the body falls back to a plain
+// monospace <pre> — a single text node, cheap at any size — trading syntax
+// colors for completeness. The scroll container bounds what's on screen.
+const MAX_HIGHLIGHT_CHARS = 20_000;
+const MAX_HIGHLIGHT_LINES = 500;
 
-function capForDisplay(text: string): string {
-  if (!text) return text;
-  let capped = text;
-  let truncated = false;
-  if (capped.length > MAX_INLINE_CHARS) {
-    capped = capped.slice(0, MAX_INLINE_CHARS);
-    truncated = true;
+function isWithinHighlightBudget(text: string): boolean {
+  if (text.length > MAX_HIGHLIGHT_CHARS) return false;
+  let lines = 1;
+  let idx = -1;
+  while ((idx = text.indexOf("\n", idx + 1)) !== -1) {
+    if (++lines > MAX_HIGHLIGHT_LINES) return false;
   }
-  const newlineCount = (capped.match(/\n/g) ?? []).length;
-  if (newlineCount + 1 > MAX_INLINE_LINES) {
-    let idx = -1;
-    for (let i = 0; i < MAX_INLINE_LINES; i++) {
-      const next = capped.indexOf("\n", idx + 1);
-      if (next === -1) break;
-      idx = next;
-    }
-    if (idx !== -1) capped = capped.slice(0, idx);
-    truncated = true;
+  return true;
+}
+
+// Matches SyntaxHighlighter's Prism theme typography so the plain fallback is
+// visually identical apart from colorization.
+const PLAIN_CODE_FONT_FAMILY =
+  'Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace';
+
+/**
+ * Code body renderer: syntax-highlighted while the content fits the budget,
+ * plain monospace beyond it. Either way the full text is rendered.
+ */
+function ToolCardCode({
+  text,
+  language,
+  syntaxTheme,
+  fontSize,
+}: {
+  text: string;
+  language: string;
+  syntaxTheme: Record<string, React.CSSProperties>;
+  fontSize: string;
+}) {
+  if (isWithinHighlightBudget(text)) {
+    return (
+      <SyntaxHighlighter
+        style={syntaxTheme}
+        language={language}
+        PreTag="div"
+        customStyle={{
+          fontSize,
+          margin: 0,
+          padding: "0.75rem",
+          background: "transparent",
+          overflow: "visible",
+        }}
+      >
+        {text}
+      </SyntaxHighlighter>
+    );
   }
-  if (truncated) {
-    capped +=
-      "\n\n… truncated for display — open the tool details to view the full result.";
-  }
-  return capped;
+  return (
+    <Box
+      component="pre"
+      sx={{
+        fontSize,
+        m: 0,
+        p: "0.75rem",
+        fontFamily: PLAIN_CODE_FONT_FAMILY,
+        whiteSpace: "pre",
+        overflow: "visible",
+        color: "text.primary",
+      }}
+    >
+      {text}
+    </Box>
+  );
 }
 
 /**
@@ -362,14 +404,14 @@ export const StreamingToolCard = React.memo(
 
     const code = useMemo(() => {
       if (!shouldRenderBody || !hasCode) return "";
-      const raw =
+      return (
         bodyPreview?.content ??
         (typeof rawContent === "string"
           ? rawContent
           : rawContent && typeof rawContent === "object"
             ? JSON.stringify(rawContent, null, 2)
-            : "");
-      return capForDisplay(raw);
+            : "")
+      );
     }, [shouldRenderBody, hasCode, bodyPreview?.content, rawContent]);
 
     useEffect(() => {
@@ -396,7 +438,7 @@ export const StreamingToolCard = React.memo(
     const formattedOutput = useMemo(
       () =>
         shouldRenderBody && (isDone || isError)
-          ? capForDisplay(formatOutputForDisplay(output))
+          ? formatOutputForDisplay(output)
           : "",
       [shouldRenderBody, isDone, isError, output],
     );
@@ -623,20 +665,12 @@ export const StreamingToolCard = React.memo(
                 borderColor: "divider",
               }}
             >
-              <SyntaxHighlighter
-                style={syntaxTheme}
+              <ToolCardCode
+                text={code || " "}
                 language={codeLanguage}
-                PreTag="div"
-                customStyle={{
-                  fontSize: "0.78rem",
-                  margin: 0,
-                  padding: "0.75rem",
-                  background: "transparent",
-                  overflow: "visible",
-                }}
-              >
-                {code || " "}
-              </SyntaxHighlighter>
+                syntaxTheme={syntaxTheme}
+                fontSize="0.78rem"
+              />
             </Box>
           )}
 
@@ -655,20 +689,12 @@ export const StreamingToolCard = React.memo(
                 }),
               }}
             >
-              <SyntaxHighlighter
-                style={syntaxTheme}
+              <ToolCardCode
+                text={formattedOutput}
                 language={outputLang}
-                PreTag="div"
-                customStyle={{
-                  fontSize: "0.75rem",
-                  margin: 0,
-                  padding: "0.75rem",
-                  background: "transparent",
-                  overflow: "visible",
-                }}
-              >
-                {formattedOutput}
-              </SyntaxHighlighter>
+                syntaxTheme={syntaxTheme}
+                fontSize="0.75rem"
+              />
             </Box>
           )}
         </Collapse>

--- a/app/src/components/__tests__/Chat.perf.test.ts
+++ b/app/src/components/__tests__/Chat.perf.test.ts
@@ -330,6 +330,7 @@ describe("Chat.tsx structural guards", () => {
     expect(chatSource).toMatch(
       /totalListHeightChanged=\{handleListHeightChanged\}/,
     );
+    expect(chatSource).toMatch(/scrollerRef=\{/);
     // While streaming, the pin writes scrollTop on the captured scroller, gated
     // on the live isAtBottom ref (so scrolling up to read history isn't yanked
     // down). While settling after the turn ends, it instead uses Virtuoso's
@@ -338,46 +339,69 @@ describe("Chat.tsx structural guards", () => {
     // the item top), gated on a snapshot of whether the user was at the bottom
     // AS the turn ended (`wasAtBottomAtTurnEndRef`) — the live ref can't gate
     // that because the collapse momentarily flips isAtBottom false.
-    expect(chatSource).toMatch(/scrollerRef=\{/);
-    expect(chatSource).toMatch(/el\.scrollTop = el\.scrollHeight/);
-    expect(chatSource).toMatch(/if \(!isAtBottomRef\.current\) return;/);
-    expect(chatSource).toMatch(/wasAtBottomAtTurnEndRef/);
+    // (The pin machinery lives in chat/hooks/useChatScroll.ts.)
+    const scrollHookSource = fs.readFileSync(
+      path.resolve(__dirname, "../chat/hooks/useChatScroll.ts"),
+      "utf-8",
+    );
+    expect(scrollHookSource).toMatch(/el\.scrollTop = el\.scrollHeight/);
+    expect(scrollHookSource).toMatch(/if \(!isAtBottomRef\.current\) return;/);
+    expect(scrollHookSource).toMatch(/wasAtBottomAtTurnEndRef/);
     // Settle uses the authoritative scrollToIndex, not a raw scrollTop write,
     // so the end-of-turn collapse can't strand the view at the message top.
-    expect(chatSource).toMatch(
+    expect(scrollHookSource).toMatch(
       /Date\.now\(\) <= stickTailUntilRef\.current &&[\s\S]*?scrollToIndex\(\{ index: "LAST", align: "end" \}\)/,
     );
   });
+
+  const scrollHookSourceForNegativeGuards = fs.readFileSync(
+    path.resolve(__dirname, "../chat/hooks/useChatScroll.ts"),
+    "utf-8",
+  );
 
   it("does NOT have a DIY useEffect([messages]) scrollIntoView auto-scroll", () => {
     // The follow pin sets scrollTop on Virtuoso's captured scroller inside its
     // height-change callback, never a raw per-chunk `scrollIntoView` on a DOM
     // node, which fired every chunk and broke hover/click + caused jank.
     expect(chatSource).not.toMatch(/scrollIntoView/);
+    expect(scrollHookSourceForNegativeGuards).not.toMatch(/scrollIntoView/);
   });
 
   it("does NOT have isNearBottomRef (old DIY scroll state)", () => {
     expect(chatSource).not.toContain("isNearBottomRef");
+    expect(scrollHookSourceForNegativeGuards).not.toContain("isNearBottomRef");
   });
 
   it("does NOT have rafIdRef (old DIY scroll coalescing)", () => {
     expect(chatSource).not.toContain("rafIdRef");
+    expect(scrollHookSourceForNegativeGuards).not.toContain("rafIdRef");
   });
 
   it("does NOT build a live modify_console diff while input is still streaming", () => {
     // A line-diff of partial streamed content re-aligns its +/- groupings on
     // every token (the modify_console "blink"). While input-streaming we show
     // the raw SQL (append-only, smooth) and only render the diff once content
-    // is complete.
-    expect(chatSource).toMatch(/state === "input-streaming"\s*\?\s*undefined/);
+    // is complete. (Lives in chat/tool-presentation.ts.)
+    const presentationSource = fs.readFileSync(
+      path.resolve(__dirname, "../chat/tool-presentation.ts"),
+      "utf-8",
+    );
+    expect(presentationSource).toMatch(
+      /state === "input-streaming"\s*\?\s*undefined/,
+    );
   });
 
   it("keys tool parts by toolCallId so completed cards don't remount", () => {
     // Remounting a finished tool card on every parts-array mutation drops
     // its internal expand/scroll state and causes a flicker. Keying by
     // toolCallId keeps identity stable across reorders/inserts.
-    expect(chatSource).toMatch(/key=\{\s*key\s*\}/);
-    expect(chatSource).toMatch(/`tool-\$\{toolCallId\}`/);
+    // (Lives in chat/ChatMessageRow.tsx.)
+    const rowSource = fs.readFileSync(
+      path.resolve(__dirname, "../chat/ChatMessageRow.tsx"),
+      "utf-8",
+    );
+    expect(rowSource).toMatch(/key=\{\s*key\s*\}/);
+    expect(rowSource).toMatch(/`tool-\$\{toolCallId\}`/);
   });
 });
 
@@ -393,10 +417,15 @@ describe("StreamingToolCard structural guards", () => {
     expect(cardSource).toMatch(/<Collapse[^>]*unmountOnExit/s);
   });
 
-  it("caps inline output/code size before highlighting", () => {
-    // Never feed a 10k-line JSON blob to the syntax highlighter inline.
-    expect(cardSource).toContain("capForDisplay");
-    expect(cardSource).toMatch(/MAX_INLINE_(CHARS|LINES)/);
+  it("renders full tool content but budget-gates the syntax highlighter", () => {
+    // The body must NEVER truncate tool content (users need the full streamed
+    // SQL/code inline) — but Prism explodes big payloads into tens of
+    // thousands of DOM nodes, so past a size budget the body falls back to a
+    // plain monospace <pre> (single text node) instead of highlighting.
+    expect(cardSource).toContain("isWithinHighlightBudget");
+    expect(cardSource).toMatch(/MAX_HIGHLIGHT_(CHARS|LINES)/);
+    expect(cardSource).not.toContain("truncated for display");
+    expect(cardSource).not.toContain("capForDisplay");
   });
 
   it("defers building the heavy body strings until the body renders", () => {

--- a/app/src/components/chat/ChatHistoryMenu.tsx
+++ b/app/src/components/chat/ChatHistoryMenu.tsx
@@ -1,0 +1,117 @@
+import React from "react";
+import {
+  Box,
+  IconButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  Typography,
+} from "@mui/material";
+import { MessageSquare, Trash2 } from "lucide-react";
+import { streamingIndicatorDotSx } from "./streaming-indicator-styles";
+import type { ChatSessionMeta } from "./hooks/useChatSessions";
+
+interface ChatHistoryMenuProps {
+  anchorEl: HTMLElement | null;
+  open: boolean;
+  onClose: () => void;
+  sessions: ChatSessionMeta[];
+  currentChatId: string;
+  isSessionStreaming: (session: ChatSessionMeta) => boolean;
+  onSelect: (id: string) => void;
+  onDelete: (id: string, e: React.MouseEvent) => void;
+}
+
+/** Chat history dropdown: session list with live streaming indicators. */
+export function ChatHistoryMenu({
+  anchorEl,
+  open,
+  onClose,
+  sessions,
+  currentChatId,
+  isSessionStreaming,
+  onSelect,
+  onDelete,
+}: ChatHistoryMenuProps) {
+  return (
+    <Menu
+      anchorEl={anchorEl}
+      open={open}
+      onClose={onClose}
+      PaperProps={{
+        sx: { maxHeight: 400, width: 300 },
+      }}
+    >
+      {sessions
+        .filter(
+          session =>
+            session._id === currentChatId ||
+            isSessionStreaming(session) ||
+            (session.title && session.title.length > 0),
+        )
+        .map(session => (
+          <MenuItem
+            key={session._id}
+            onClick={() => onSelect(session._id)}
+            selected={session._id === currentChatId}
+            sx={{ display: "flex", justifyContent: "space-between" }}
+          >
+            <Box sx={{ display: "flex", alignItems: "center", flex: 1 }}>
+              <ListItemIcon>
+                {isSessionStreaming(session) ? (
+                  // Turn in flight server-side — pulsing indicator instead
+                  // of the static chat icon.
+                  <Box
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      width: 18,
+                      height: 18,
+                    }}
+                  >
+                    <Box sx={streamingIndicatorDotSx} />
+                  </Box>
+                ) : (
+                  <MessageSquare size={18} />
+                )}
+              </ListItemIcon>
+              <Box>
+                <ListItemText
+                  primary={session.title || session._id.substring(0, 8)}
+                  secondary={
+                    session.updatedAt
+                      ? new Date(session.updatedAt).toLocaleString()
+                      : session.createdAt
+                        ? new Date(session.createdAt).toLocaleString()
+                        : ""
+                  }
+                  primaryTypographyProps={{
+                    noWrap: true,
+                    sx: { maxWidth: 200 },
+                  }}
+                />
+              </Box>
+            </Box>
+            {sessions.length > 1 && (
+              <IconButton
+                size="small"
+                onClick={e => onDelete(session._id, e)}
+                sx={{ ml: 1 }}
+              >
+                <Trash2 size={18} />
+              </IconButton>
+            )}
+          </MenuItem>
+        ))}
+      {sessions.length === 0 && (
+        <MenuItem disabled>
+          <Typography variant="body2" color="text.secondary">
+            No chat history yet
+          </Typography>
+        </MenuItem>
+      )}
+    </Menu>
+  );
+}

--- a/app/src/components/chat/ChatInputArea.tsx
+++ b/app/src/components/chat/ChatInputArea.tsx
@@ -1,0 +1,494 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Box,
+  IconButton,
+  Paper,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { ArrowUp, ImagePlus, X } from "lucide-react";
+import type { FileUIPart } from "ai";
+import { ModelSelector } from "../ModelSelector";
+import { useRenderCount, useWhyChanged } from "../../utils/renderDebug";
+import { ImagePreviewDialog } from "./ImagePreviewDialog";
+import type { QueuedPrompt } from "./QueuedPrompts";
+
+// Isolated input component — owns its own `input` state so keystrokes
+// never re-render the (expensive) message list above it.
+
+interface ImageAttachment {
+  id: string;
+  file: File;
+  previewUrl: string;
+}
+
+interface ChatInputAreaProps {
+  onSubmit: (text: string, files?: FileUIPart[]) => void;
+  onStop: () => void;
+  isLoading: boolean;
+  disabled: boolean;
+  focusKey: string | number;
+  paletteMode: "light" | "dark";
+  editingPrompt: QueuedPrompt | null;
+  onCancelEdit: () => void;
+}
+
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+
+export const ChatInputArea = React.memo(
+  ({
+    onSubmit,
+    onStop,
+    isLoading,
+    disabled,
+    focusKey,
+    paletteMode: _paletteMode,
+    editingPrompt,
+    onCancelEdit,
+  }: ChatInputAreaProps) => {
+    const [input, setInput] = useState("");
+    const [images, setImages] = useState<ImageAttachment[]>([]);
+    const [previewSrc, setPreviewSrc] = useState<string | null>(null);
+    const [isPreparingSubmission, setIsPreparingSubmission] = useState(false);
+    const inputRef = useRef<HTMLInputElement>(null);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const imagesRef = useRef<ImageAttachment[]>([]);
+    // When entering edit mode, load the queued prompt's text into the composer
+    // and stash whatever the user was drafting so Cancel/commit can restore it.
+    const inputValueRef = useRef(input);
+    inputValueRef.current = input;
+    const preEditDraftRef = useRef("");
+    const prevEditingIdRef = useRef<string | null>(null);
+    useRenderCount("ChatInputArea", {
+      isLoading,
+      disabled,
+      imageCount: images.length,
+    });
+    useWhyChanged("ChatInputArea", {
+      onSubmit,
+      onStop,
+      isLoading,
+      disabled,
+      focusKey,
+      imageCount: images.length,
+    });
+    imagesRef.current = images;
+
+    useEffect(() => {
+      const timer = setTimeout(() => inputRef.current?.focus(), 100);
+      return () => clearTimeout(timer);
+    }, [focusKey]);
+
+    useEffect(() => {
+      const prevId = prevEditingIdRef.current;
+      const currId = editingPrompt?.id ?? null;
+      if (currId === prevId) return;
+      if (currId) {
+        if (!prevId) preEditDraftRef.current = inputValueRef.current;
+        setInput(editingPrompt?.text ?? "");
+        setTimeout(() => inputRef.current?.focus(), 0);
+      } else {
+        setInput(preEditDraftRef.current);
+        preEditDraftRef.current = "";
+      }
+      prevEditingIdRef.current = currId;
+    }, [editingPrompt]);
+
+    useEffect(() => {
+      return () => {
+        imagesRef.current.forEach(img => URL.revokeObjectURL(img.previewUrl));
+      };
+    }, []);
+
+    const addImages = useCallback((files: File[]) => {
+      const imageFiles = files.filter(f => f.type.startsWith("image/"));
+      if (imageFiles.length === 0) return;
+      setImages(prev => [
+        ...prev,
+        ...imageFiles.map(file => ({
+          id: crypto.randomUUID(),
+          file,
+          previewUrl: URL.createObjectURL(file),
+        })),
+      ]);
+    }, []);
+
+    const removeImage = useCallback((id: string) => {
+      setImages(prev => {
+        const img = prev.find(i => i.id === id);
+        if (img) URL.revokeObjectURL(img.previewUrl);
+        return prev.filter(i => i.id !== id);
+      });
+    }, []);
+
+    const handlePaste = useCallback(
+      (e: React.ClipboardEvent) => {
+        const items = e.clipboardData?.items;
+        if (!items) return;
+        const files: File[] = [];
+        for (const item of items) {
+          if (item.kind === "file" && item.type.startsWith("image/")) {
+            const file = item.getAsFile();
+            if (file) files.push(file);
+          }
+        }
+        if (files.length > 0) {
+          e.preventDefault();
+          addImages(files);
+        }
+      },
+      [addImages],
+    );
+
+    const submitMessage = useCallback(async () => {
+      const trimmedInput = input.trim();
+      const currentImages = images;
+      const hasText = trimmedInput.length > 0;
+      const hasImages = currentImages.length > 0;
+      if ((!hasText && !hasImages) || isPreparingSubmission) {
+        return;
+      }
+
+      setIsPreparingSubmission(true);
+      let fileParts: FileUIPart[] | undefined;
+      try {
+        if (hasImages) {
+          fileParts = await Promise.all(
+            currentImages.map(async img => ({
+              type: "file" as const,
+              url: await readFileAsDataUrl(img.file),
+              mediaType: img.file.type,
+            })),
+          );
+          currentImages.forEach(img => URL.revokeObjectURL(img.previewUrl));
+        }
+
+        onSubmit(input, fileParts);
+        setInput("");
+        setImages([]);
+      } finally {
+        setIsPreparingSubmission(false);
+      }
+    }, [images, input, isPreparingSubmission, onSubmit]);
+
+    const hasContent = input.trim() || images.length > 0;
+    const isSubmitDisabled = !hasContent || disabled || isPreparingSubmission;
+
+    return (
+      <Paper
+        elevation={0}
+        sx={{
+          border: 1,
+          borderColor: "divider",
+          borderRadius: 2.5,
+          p: 1,
+          m: 1,
+          display: "flex",
+          flexDirection: "column",
+          gap: 1,
+        }}
+      >
+        {editingPrompt && (
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              px: 0.5,
+              pb: 0.5,
+              mb: 0.5,
+              borderBottom: 1,
+              borderColor: "divider",
+            }}
+          >
+            <Typography
+              variant="caption"
+              sx={{ fontWeight: 600, color: "text.secondary" }}
+            >
+              Editing queued message
+            </Typography>
+            <Typography
+              component="button"
+              type="button"
+              onClick={onCancelEdit}
+              variant="caption"
+              sx={{
+                border: "none",
+                background: "none",
+                cursor: "pointer",
+                color: "primary.main",
+                fontWeight: 600,
+                p: 0,
+                "&:hover": { textDecoration: "underline" },
+              }}
+            >
+              Cancel
+            </Typography>
+          </Box>
+        )}
+
+        <form
+          onSubmit={e => {
+            e.preventDefault();
+            submitMessage();
+          }}
+          onPaste={handlePaste}
+        >
+          {images.length > 0 && (
+            <Box
+              sx={{
+                display: "flex",
+                flexWrap: "wrap",
+                gap: 1,
+                px: 0.5,
+                pt: 0.5,
+              }}
+            >
+              {images.map(img => (
+                <Box
+                  key={img.id}
+                  sx={{
+                    position: "relative",
+                    width: 56,
+                    height: 56,
+                    borderRadius: 1.5,
+                    overflow: "hidden",
+                    flexShrink: 0,
+                    "&:hover .remove-btn": {
+                      opacity: 1,
+                    },
+                  }}
+                >
+                  <Box
+                    component="img"
+                    src={img.previewUrl}
+                    alt="Attachment"
+                    onClick={() => setPreviewSrc(img.previewUrl)}
+                    sx={{
+                      width: 56,
+                      height: 56,
+                      borderRadius: 1.5,
+                      objectFit: "cover",
+                      cursor: "pointer",
+                      border: 1,
+                      borderColor: "divider",
+                      display: "block",
+                    }}
+                  />
+                  <IconButton
+                    type="button"
+                    className="remove-btn"
+                    aria-label="Remove image"
+                    onClick={e => {
+                      e.stopPropagation();
+                      removeImage(img.id);
+                    }}
+                    size="small"
+                    disabled={isPreparingSubmission}
+                    sx={{
+                      position: "absolute",
+                      top: 4,
+                      right: 4,
+                      width: 18,
+                      height: 18,
+                      p: 0,
+                      opacity: 0,
+                      transition: "opacity 0.15s",
+                      color: "common.white",
+                      backgroundColor: "rgba(0, 0, 0, 0.6)",
+                      "&:hover": {
+                        backgroundColor: "rgba(0, 0, 0, 0.8)",
+                      },
+                    }}
+                  >
+                    <X size={11} />
+                  </IconButton>
+                </Box>
+              ))}
+            </Box>
+          )}
+
+          <ImagePreviewDialog
+            src={previewSrc}
+            onClose={() => setPreviewSrc(null)}
+          />
+
+          <TextField
+            fullWidth
+            autoFocus
+            multiline
+            minRows={1}
+            maxRows={24}
+            placeholder={
+              editingPrompt ? "Edit queued message..." : "Ask Chat..."
+            }
+            value={input}
+            onChange={e => setInput(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                submitMessage();
+              }
+              if (e.key === "Escape" && editingPrompt) {
+                e.preventDefault();
+                onCancelEdit();
+              }
+              if (e.key === "Backspace" && !input && images.length > 0) {
+                e.preventDefault();
+                const last = images[images.length - 1];
+                if (last) removeImage(last.id);
+              }
+            }}
+            variant="outlined"
+            inputRef={inputRef}
+            sx={{
+              m: 0.5,
+              maxHeight: "60vh",
+              overflowY: "auto",
+              "& .MuiInputBase-input": {
+                fontSize: { xs: 16, sm: 14 },
+              },
+              "& .MuiInputBase-root": {
+                p: 0,
+                fontSize: { xs: 16, sm: 14 },
+              },
+              "& .MuiOutlinedInput-notchedOutline": {
+                border: "none",
+              },
+              "& .MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline":
+                {
+                  border: "none",
+                },
+              "& .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline":
+                {
+                  border: "none",
+                },
+            }}
+          />
+
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            multiple
+            style={{ display: "none" }}
+            onChange={e => {
+              if (e.target.files) {
+                addImages(Array.from(e.target.files));
+                e.target.value = "";
+              }
+            }}
+          />
+
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 0.5,
+              minWidth: 0,
+            }}
+          >
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 0.5,
+                flex: "1 1 auto",
+                minWidth: 0,
+              }}
+            >
+              <ModelSelector />
+            </Box>
+
+            <Tooltip title="Attach image" placement="top">
+              <IconButton
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                size="small"
+                disabled={isPreparingSubmission || disabled || isLoading}
+                sx={{
+                  width: 28,
+                  height: 28,
+                  flexShrink: 0,
+                  color: "text.secondary",
+                  "&:hover": { color: "text.primary" },
+                }}
+              >
+                <ImagePlus size={16} />
+              </IconButton>
+            </Tooltip>
+
+            {isLoading ? (
+              <IconButton
+                type="button"
+                aria-label="Stop generating"
+                onClick={onStop}
+                size="small"
+                sx={{
+                  width: 28,
+                  height: 28,
+                  borderRadius: "50%",
+                  backgroundColor: "action.hover",
+                  border: 1,
+                  borderColor: "divider",
+                  "&:hover": {
+                    backgroundColor: "action.selected",
+                  },
+                  flexShrink: 0,
+                }}
+              >
+                <Box
+                  sx={{
+                    width: 10,
+                    height: 10,
+                    backgroundColor: "text.primary",
+                    borderRadius: 0.5,
+                  }}
+                />
+              </IconButton>
+            ) : (
+              <IconButton
+                type="submit"
+                aria-label="Send message"
+                disabled={isSubmitDisabled}
+                size="small"
+                sx={{
+                  width: 28,
+                  height: 28,
+                  borderRadius: "50%",
+                  backgroundColor: !isSubmitDisabled
+                    ? "primary.main"
+                    : "action.disabledBackground",
+                  color: !isSubmitDisabled
+                    ? "primary.contrastText"
+                    : "text.disabled",
+                  "&:hover": {
+                    backgroundColor: !isSubmitDisabled
+                      ? "primary.dark"
+                      : "action.disabledBackground",
+                  },
+                  "&.Mui-disabled": {
+                    backgroundColor: "action.disabledBackground",
+                    color: "text.disabled",
+                  },
+                  flexShrink: 0,
+                }}
+              >
+                <ArrowUp size={18} />
+              </IconButton>
+            )}
+          </Box>
+        </form>
+      </Paper>
+    );
+  },
+);
+ChatInputArea.displayName = "ChatInputArea";

--- a/app/src/components/chat/ChatMessageRow.tsx
+++ b/app/src/components/chat/ChatMessageRow.tsx
@@ -1,0 +1,371 @@
+import React, { useState } from "react";
+import { Box, List, ListItem, Paper } from "@mui/material";
+import { StreamingMarkdown } from "../StreamingMarkdown";
+import { StreamingToolCard, type ToolPartState } from "../StreamingToolCard";
+import { ClarifyingQuestionsCard } from "../ClarifyingQuestionsCard";
+import { DbtRunCard } from "../DbtRunCard";
+import { PlanCard } from "../PlanCard";
+import type {
+  AskClarifyingQuestionsInput,
+  AskClarifyingQuestionsOutput,
+  SubmitPlanInput,
+  SubmitPlanOutput,
+} from "@mako/agent-tools";
+import {
+  computeReasoningGroups,
+  getStreamingReasoningGroupStart,
+} from "../reasoning-groups";
+import {
+  chatMessageRowArePropsEqual,
+  type ChatMessageRowProps,
+} from "../chat-message-comparator";
+import { useRenderCount, useWhyChanged } from "../../utils/renderDebug";
+import {
+  getConsoleToolPresentation,
+  type ToolInvocationInfo,
+} from "./tool-presentation";
+import { ReasoningDisplay } from "./ReasoningDisplay";
+import { StreamingIndicator } from "./StreamingIndicator";
+import { CollapsibleUserText } from "./CollapsibleUserText";
+import { ImagePreviewDialog } from "./ImagePreviewDialog";
+
+// ── Memoized message row ─────────────────────────────────────────
+// Prevents completed messages from re-rendering on every streaming chunk.
+
+const userMessageSx = { flex: 1, mt: 2, minWidth: 0 } as const;
+const userMessagePaperSx = {
+  p: 1,
+  borderRadius: 1,
+  backgroundColor: "background.paper",
+  overflow: "hidden",
+} as const;
+const assistantMessageSx = {
+  flex: 1,
+  overflow: "hidden",
+  fontSize: "0.875rem",
+  mt: 1,
+  "& pre": { margin: 0, overflow: "hidden" },
+} as const;
+const listItemSx = { p: 0 } as const;
+
+export const ChatMessageRow = React.memo(function ChatMessageRow({
+  message,
+  isLastMessage,
+  isStreaming,
+  onToolClick,
+  onConsoleTitleClick,
+  connectionIconById,
+  paletteMode,
+}: ChatMessageRowProps) {
+  const parts = (message.parts || []) as Array<Record<string, unknown>>;
+  useRenderCount(`ChatMessageRow:${message.id}`, {
+    role: message.role,
+    partCount: parts.length,
+  });
+  useWhyChanged(`ChatMessageRow:${message.id}`, {
+    messageRef: message,
+    partsRef: message.parts,
+    partCount: parts.length,
+    isLastMessage,
+    isStreaming,
+    onToolClick,
+    onConsoleTitleClick,
+    connectionIconById,
+    paletteMode,
+  });
+
+  // Lightbox state for clicking an attached image to preview it full-size.
+  const [previewSrc, setPreviewSrc] = useState<string | null>(null);
+
+  if (message.role === "user") {
+    const fileParts = (message.parts || []).filter(
+      (p): p is { type: "file"; url: string; mediaType: string } =>
+        p.type === "file" && "url" in p,
+    );
+    const textContent =
+      (message.parts || [])
+        .filter(
+          (p): p is { type: "text"; text: string } =>
+            p.type === "text" && "text" in p,
+        )
+        .map(p => p.text)
+        .join("") || "";
+
+    return (
+      <ListItem alignItems="flex-start" sx={listItemSx}>
+        <Box sx={userMessageSx}>
+          <Paper variant="outlined" sx={userMessagePaperSx}>
+            {fileParts.length > 0 && (
+              <Box
+                sx={{
+                  display: "flex",
+                  flexWrap: "wrap",
+                  gap: 1,
+                  mb: textContent ? 1 : 0,
+                }}
+              >
+                {fileParts.map((fp, i) => (
+                  <Box
+                    key={i}
+                    component="img"
+                    src={fp.url}
+                    alt="Attached image"
+                    loading="lazy"
+                    decoding="async"
+                    onClick={() => setPreviewSrc(fp.url)}
+                    sx={{
+                      width: 56,
+                      height: 56,
+                      borderRadius: 1.5,
+                      objectFit: "cover",
+                      cursor: "pointer",
+                      border: 1,
+                      borderColor: "divider",
+                      display: "block",
+                    }}
+                  />
+                ))}
+              </Box>
+            )}
+            {textContent && <CollapsibleUserText text={textContent} />}
+          </Paper>
+        </Box>
+        <ImagePreviewDialog
+          src={previewSrc}
+          onClose={() => setPreviewSrc(null)}
+        />
+      </ListItem>
+    );
+  }
+
+  const isStreamingNow = isStreaming;
+
+  const reasoningGroups = computeReasoningGroups(parts);
+
+  // Stable identity for each reasoning block: its ordinal position among the
+  // message's reasoning groups (0, 1, 2…). Keying by this instead of the raw
+  // part index means an inserted `step-start`/tool/text part shifting the array
+  // can't remount an existing block — a remount would reset its `finished`
+  // latch and make it re-expand (flicker). Reasoning groups only ever append,
+  // so ordinals are stable for the lifetime of a block.
+  const reasoningGroupOrdinals = new Map<number, number>();
+  {
+    let ordinal = 0;
+    for (const start of reasoningGroups.keys()) {
+      reasoningGroupOrdinals.set(start, ordinal++);
+    }
+  }
+
+  const lastPartIndex = parts.length - 1;
+  const lastPart = parts.at(-1);
+  const isLastPartText =
+    isLastMessage && isStreamingNow && lastPart?.type === "text";
+
+  // The single reasoning group (if any) that should stay expanded because it
+  // owns the streaming last part. `null` when not streaming or the last part
+  // isn't reasoning, so previously-collapsed blocks are never re-opened.
+  const streamingReasoningGroupStart =
+    isLastMessage && isStreamingNow
+      ? getStreamingReasoningGroupStart(parts, reasoningGroups)
+      : null;
+
+  return (
+    <ListItem alignItems="flex-start" sx={listItemSx}>
+      <Box sx={assistantMessageSx}>
+        {parts.map((part, partIndex) => {
+          const partType = part.type as string;
+
+          if (partType?.startsWith("tool-") || partType === "dynamic-tool") {
+            const toolName =
+              partType === "dynamic-tool"
+                ? (part.toolName as string)
+                : partType.split("-").slice(1).join("-");
+            const rawState = part.state as string;
+            const cardState: ToolPartState =
+              rawState === "output-error"
+                ? "error"
+                : (part.state as ToolPartState);
+            const cardOutput =
+              rawState === "output-error"
+                ? {
+                    success: false,
+                    error:
+                      (part.errorText as string | undefined) ?? "Tool failed",
+                  }
+                : part.output;
+            const toolCallId = (part.toolCallId as string) || "";
+            const consoleToolPresentation = getConsoleToolPresentation(
+              toolName,
+              part.input,
+              cardOutput,
+              connectionIconById,
+              cardState,
+            );
+            // Key by toolCallId when available so reordering/insertion in the
+            // parts array doesn't remount completed tool cards. Falls back to
+            // a type+index tag for the (rare) case where toolCallId is missing.
+            const key = toolCallId
+              ? `tool-${toolCallId}`
+              : `tool-idx-${partIndex}`;
+
+            // Interactive plan-lifecycle tools: while pending they render in
+            // the docked panel above the composer (Cursor-style), NOT in the
+            // chat. Once resolved, a read-only summary appears inline here.
+            // Errors fall through to the generic tool card.
+            if (
+              toolName === "ask_clarifying_questions" ||
+              toolName === "submit_plan"
+            ) {
+              if (rawState === "output-available") {
+                if (toolName === "ask_clarifying_questions") {
+                  return (
+                    <ClarifyingQuestionsCard
+                      key={key}
+                      input={part.input as AskClarifyingQuestionsInput}
+                      output={part.output as AskClarifyingQuestionsOutput}
+                    />
+                  );
+                }
+                return (
+                  <PlanCard
+                    key={key}
+                    toolCallId={toolCallId}
+                    input={part.input as SubmitPlanInput}
+                    output={part.output as SubmitPlanOutput}
+                  />
+                );
+              }
+              if (rawState !== "output-error") {
+                return null;
+              }
+            }
+
+            // Async dbt builds: once dbt_run_model has dispatched a run (output
+            // carries a runId), render a live run card that self-polls the run
+            // — decoupled from the agent turn, so it keeps updating after the
+            // turn ends and resumes on chat reload. While the dispatch is still
+            // in flight, or if it errored without a runId, fall through to the
+            // generic card.
+            if (
+              toolName === "dbt_run_model" &&
+              rawState === "output-available"
+            ) {
+              const dbtOutput = cardOutput as { runId?: string } | undefined;
+              const dbtInput = part.input as
+                | { projectId?: string; model?: string }
+                | undefined;
+              if (dbtOutput?.runId && dbtInput?.projectId) {
+                return (
+                  <DbtRunCard
+                    key={key}
+                    runId={dbtOutput.runId}
+                    projectId={dbtInput.projectId}
+                    label={dbtInput.model}
+                  />
+                );
+              }
+            }
+            return (
+              <StreamingToolCard
+                key={key}
+                toolCallId={toolCallId}
+                toolName={toolName}
+                state={cardState}
+                input={part.input}
+                output={cardOutput}
+                labelOverride={consoleToolPresentation?.title}
+                leadingIconUrl={consoleToolPresentation?.iconUrl}
+                leadingIconAlt={
+                  consoleToolPresentation ? "Database" : undefined
+                }
+                bodyPreview={
+                  consoleToolPresentation?.diff
+                    ? {
+                        content: consoleToolPresentation.diff,
+                        language: "diff",
+                      }
+                    : undefined
+                }
+                onTitleClick={
+                  consoleToolPresentation
+                    ? () =>
+                        onConsoleTitleClick(consoleToolPresentation.consoleId)
+                    : undefined
+                }
+                onDetailClick={() =>
+                  onToolClick({
+                    toolCallId,
+                    toolName: toolName || "",
+                    state: part.state as ToolInvocationInfo["state"],
+                    input: part.input,
+                    output: cardOutput,
+                  })
+                }
+              />
+            );
+          }
+
+          if (partType === "reasoning") {
+            const group = reasoningGroups.get(partIndex);
+            if (!group) return null;
+            const isGroupStreaming = partIndex === streamingReasoningGroupStart;
+            // Skip empty reasoning groups unless they're the block currently
+            // streaming (a brand-new thinking block whose text hasn't arrived
+            // yet). This avoids rendering blank "Thinking process" blocks for
+            // empty reasoning parts loaded from history.
+            if (!group.text && !isGroupStreaming) return null;
+            return (
+              <ReasoningDisplay
+                key={`reasoning-group-${reasoningGroupOrdinals.get(partIndex) ?? partIndex}`}
+                reasoningText={group.text}
+                isStreaming={isGroupStreaming}
+                paletteMode={paletteMode}
+              />
+            );
+          }
+
+          if (partType === "text" && (part as { text?: string }).text) {
+            // Only the trailing text block of the actively streaming
+            // message is still growing — flag it so Streamdown knows to
+            // treat its last markdown block as incomplete. All earlier
+            // text blocks are static and can skip animation entirely.
+            const isTrailingStreamingText =
+              isLastPartText && partIndex === lastPartIndex;
+            return (
+              <StreamingMarkdown
+                key={`text-${partIndex}`}
+                isStreaming={isTrailingStreamingText}
+              >
+                {(part as { text: string }).text}
+              </StreamingMarkdown>
+            );
+          }
+
+          return null;
+        })}
+        {isStreaming && isLastMessage && <StreamingIndicator />}
+      </Box>
+    </ListItem>
+  );
+}, chatMessageRowArePropsEqual);
+
+ChatMessageRow.displayName = "ChatMessageRow";
+
+// List element Virtuoso renders the (windowed) message rows into. Rendered as
+// a MUI `<List dense component="div">` so the `dense` ListContext still reaches
+// each `ChatMessageRow`'s `<ListItem>` (context flows through Virtuoso's div
+// Item wrappers regardless of DOM nesting) while avoiding `<ul>` DOM-nesting
+// warnings. Virtuoso owns the inline `style` (it sets paddingTop/Bottom to
+// offset windowed items) so we must forward it onto the list element.
+export const MessageVirtuosoList = React.memo(
+  React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+    function MessageVirtuosoList({ style, children }, ref) {
+      return (
+        <List dense component="div" ref={ref} style={style} sx={{ px: 1 }}>
+          {children}
+        </List>
+      );
+    },
+  ),
+);
+MessageVirtuosoList.displayName = "MessageVirtuosoList";

--- a/app/src/components/chat/CodeBlock.tsx
+++ b/app/src/components/chat/CodeBlock.tsx
@@ -1,0 +1,168 @@
+import React from "react";
+import { Box, Button, IconButton, Typography } from "@mui/material";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import {
+  prism,
+  tomorrow,
+} from "react-syntax-highlighter/dist/esm/styles/prism";
+import { Check, ChevronDown, ChevronUp, Copy } from "lucide-react";
+
+// CodeBlock component for syntax highlighting
+export const CodeBlock = React.memo(
+  ({
+    language,
+    children,
+    isGenerating,
+    scrollable,
+    paletteMode,
+  }: {
+    language: string;
+    children: string;
+    isGenerating: boolean;
+    scrollable?: boolean;
+    /** Included so memo re-renders when the app theme toggles */
+    paletteMode: "light" | "dark";
+  }) => {
+    const effectiveMode = paletteMode;
+    const syntaxTheme = effectiveMode === "dark" ? tomorrow : prism;
+    const [isExpanded, setIsExpanded] = React.useState(false);
+    const [isCopied, setIsCopied] = React.useState(false);
+
+    const lines = children.split("\n");
+    const needsExpansion = lines.length > 12;
+
+    const isScrollable = !!scrollable;
+    const displayedCode = isScrollable
+      ? children
+      : needsExpansion && !isExpanded
+        ? lines.slice(0, 12).join("\n")
+        : children;
+
+    const handleCopy = async () => {
+      try {
+        await navigator.clipboard.writeText(children);
+        setIsCopied(true);
+        setTimeout(() => setIsCopied(false), 2000);
+      } catch (err) {
+        console.error("Failed to copy code:", err);
+      }
+    };
+
+    return (
+      <Box
+        sx={{
+          overflow: "hidden",
+          borderRadius: 1,
+          my: 1,
+          position: "relative",
+        }}
+      >
+        {isGenerating && (
+          <Box
+            sx={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              zIndex: 1,
+            }}
+          >
+            <Typography variant="body2" color="text.primary">
+              Generating...
+            </Typography>
+          </Box>
+        )}
+        <Box
+          sx={{
+            position: "absolute",
+            top: 8,
+            right: 8,
+            zIndex: 1,
+          }}
+        >
+          <IconButton
+            size="small"
+            onClick={handleCopy}
+            sx={{
+              backgroundColor:
+                effectiveMode === "dark"
+                  ? "rgba(255,255,255,0.1)"
+                  : "rgba(0,0,0,0.1)",
+              "&:hover": {
+                backgroundColor:
+                  effectiveMode === "dark"
+                    ? "rgba(255,255,255,0.2)"
+                    : "rgba(0,0,0,0.2)",
+              },
+              transition: "all 0.2s",
+            }}
+          >
+            {isCopied ? (
+              <Check
+                size={16}
+                style={{ color: "var(--mui-palette-success-main, #4caf50)" }}
+              />
+            ) : (
+              <Copy size={16} />
+            )}
+          </IconButton>
+        </Box>
+
+        <SyntaxHighlighter
+          style={syntaxTheme}
+          language={language}
+          PreTag="div"
+          customStyle={{
+            fontSize: "0.8rem",
+            margin: 0,
+            overflow: "auto",
+            maxWidth: "100%",
+            maxHeight: isScrollable ? "50vh" : undefined,
+            paddingBottom: needsExpansion && !isScrollable ? "2rem" : "0.75rem",
+            paddingTop: "0.75rem",
+          }}
+        >
+          {displayedCode}
+        </SyntaxHighlighter>
+
+        {needsExpansion && !isScrollable && (
+          <Box
+            sx={{
+              position: "absolute",
+              bottom: 0,
+              left: 0,
+              right: 0,
+              display: "flex",
+              justifyContent: "center",
+            }}
+          >
+            <Button
+              size="small"
+              onClick={() => setIsExpanded(!isExpanded)}
+              sx={{
+                borderRadius: 0,
+                flexGrow: 1,
+                color: "text.primary",
+                backgroundColor:
+                  effectiveMode === "dark"
+                    ? "rgba(0, 0, 0, 0.3)"
+                    : "rgba(255, 255, 255, 0.3)",
+                "&:hover": {
+                  backgroundColor:
+                    effectiveMode === "dark"
+                      ? "rgba(0, 0, 0, 0.1)"
+                      : "rgba(255, 255, 255, 0.1)",
+                },
+              }}
+            >
+              {isExpanded ? <ChevronUp size={20} /> : <ChevronDown size={20} />}
+            </Button>
+          </Box>
+        )}
+      </Box>
+    );
+  },
+);
+
+CodeBlock.displayName = "CodeBlock";

--- a/app/src/components/chat/CollapsibleUserText.tsx
+++ b/app/src/components/chat/CollapsibleUserText.tsx
@@ -1,0 +1,85 @@
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import { Box, Typography } from "@mui/material";
+
+const userMessageTextSx = {
+  maxWidth: "100%",
+  whiteSpace: "pre-wrap",
+  wordBreak: "break-word",
+  overflowWrap: "break-word",
+} as const;
+
+// Sent user messages are collapsed in the history so a long prompt doesn't
+// dominate the transcript. Show at most this many lines before clamping.
+const USER_MESSAGE_COLLAPSED_LINES = 3;
+
+const userMessageToggleSx = {
+  display: "inline-block",
+  mt: 0.5,
+  border: "none",
+  background: "none",
+  p: 0,
+  cursor: "pointer",
+  color: "text.secondary",
+  fontWeight: 600,
+  "&:hover": { color: "text.primary", textDecoration: "underline" },
+} as const;
+
+/**
+ * Renders a sent user message's text, collapsed to a few lines with an ellipsis
+ * when it's long. Clicking the text (or the Show more/less toggle) expands and
+ * re-collapses it. The toggle only appears when the text actually overflows the
+ * collapsed clamp, so short messages render unchanged.
+ */
+export function CollapsibleUserText({ text }: { text: string }) {
+  const [expanded, setExpanded] = useState(false);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+  const textRef = useRef<HTMLDivElement | null>(null);
+
+  // Measure whether the clamped text overflows. Only meaningful while
+  // collapsed, where the clamp limits height; comparing the full content
+  // height (scrollHeight) against the visible height (clientHeight) tells us
+  // if there's hidden content worth a toggle.
+  useLayoutEffect(() => {
+    if (expanded) return;
+    const el = textRef.current;
+    if (!el) return;
+    setIsOverflowing(el.scrollHeight > el.clientHeight + 1);
+  }, [text, expanded]);
+
+  const canToggle = isOverflowing || expanded;
+  const toggle = useCallback(() => setExpanded(prev => !prev), []);
+
+  return (
+    <Box>
+      <Typography
+        ref={textRef}
+        variant="body2"
+        color="text.primary"
+        onClick={canToggle ? toggle : undefined}
+        sx={{
+          ...userMessageTextSx,
+          ...(canToggle && { cursor: "pointer" }),
+          ...(!expanded && {
+            display: "-webkit-box",
+            WebkitBoxOrient: "vertical",
+            WebkitLineClamp: USER_MESSAGE_COLLAPSED_LINES,
+            overflow: "hidden",
+          }),
+        }}
+      >
+        {text}
+      </Typography>
+      {canToggle && (
+        <Typography
+          component="button"
+          type="button"
+          onClick={toggle}
+          variant="caption"
+          sx={userMessageToggleSx}
+        >
+          {expanded ? "Show less" : "Show more"}
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/app/src/components/chat/ImagePreviewDialog.tsx
+++ b/app/src/components/chat/ImagePreviewDialog.tsx
@@ -1,0 +1,65 @@
+import { Box, Dialog, IconButton } from "@mui/material";
+import { X } from "lucide-react";
+
+/**
+ * Lightweight, dependency-free image lightbox. Shows the full (uncropped) image
+ * centered over a dimmed backdrop; closes on backdrop click, the X button, or
+ * Escape (handled by MUI Dialog).
+ */
+export function ImagePreviewDialog({
+  src,
+  onClose,
+}: {
+  src: string | null;
+  onClose: () => void;
+}) {
+  return (
+    <Dialog
+      open={Boolean(src)}
+      onClose={onClose}
+      maxWidth="lg"
+      slotProps={{
+        paper: {
+          sx: {
+            backgroundColor: "transparent",
+            boxShadow: "none",
+            m: 2,
+            overflow: "visible",
+          },
+        },
+      }}
+    >
+      <Box sx={{ position: "relative", display: "flex" }}>
+        <IconButton
+          onClick={onClose}
+          aria-label="Close preview"
+          size="small"
+          sx={{
+            position: "absolute",
+            top: 8,
+            right: 8,
+            color: "common.white",
+            backgroundColor: "rgba(0, 0, 0, 0.6)",
+            "&:hover": { backgroundColor: "rgba(0, 0, 0, 0.8)" },
+          }}
+        >
+          <X size={18} />
+        </IconButton>
+        {src && (
+          <Box
+            component="img"
+            src={src}
+            alt="Image preview"
+            sx={{
+              maxWidth: "90vw",
+              maxHeight: "85vh",
+              borderRadius: 1,
+              objectFit: "contain",
+              display: "block",
+            }}
+          />
+        )}
+      </Box>
+    </Dialog>
+  );
+}

--- a/app/src/components/chat/QueuedPrompts.tsx
+++ b/app/src/components/chat/QueuedPrompts.tsx
@@ -1,0 +1,242 @@
+import React, { useState } from "react";
+import { Box, IconButton, Tooltip, Typography } from "@mui/material";
+import { keyframes } from "@mui/material/styles";
+import {
+  ArrowUp,
+  ChevronDown,
+  ChevronRight,
+  Circle,
+  Pencil,
+  Trash2,
+} from "lucide-react";
+import type { FileUIPart } from "ai";
+
+// Queue card slides up from behind the chat input as it reveals
+const queueSlideUp = keyframes`
+  from { opacity: 0; transform: translateY(100%); }
+  to { opacity: 1; transform: translateY(0); }
+`;
+
+export interface QueuedPrompt {
+  id: string;
+  text: string;
+  files?: FileUIPart[];
+  consoleId: string | null;
+  dashboardId: string | null;
+}
+
+interface QueuedPromptListProps {
+  prompts: QueuedPrompt[];
+  editingId: string | null;
+  onStartEdit: (id: string) => void;
+  onSendNow: (id: string) => void;
+  onRemove: (id: string) => void;
+}
+
+interface QueuedPromptRowProps {
+  prompt: QueuedPrompt;
+  isEditing: boolean;
+  onStartEdit: (id: string) => void;
+  onSendNow: (id: string) => void;
+  onRemove: (id: string) => void;
+}
+
+const QUEUED_ROW_ACTION_BTN_SX = {
+  width: 22,
+  height: 22,
+  flexShrink: 0,
+  color: "text.secondary",
+  "&:hover": { color: "text.primary" },
+} as const;
+
+// One queued prompt. Editing happens in the main composer (Cursor-style), so
+// the row itself only renders the prompt + hover actions.
+const QueuedPromptRow = React.memo(
+  ({
+    prompt,
+    isEditing,
+    onStartEdit,
+    onSendNow,
+    onRemove,
+  }: QueuedPromptRowProps) => {
+    const imageCount = prompt.files?.length ?? 0;
+    const display = prompt.text || (imageCount > 0 ? "Image attachment" : "");
+
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1,
+          px: 1,
+          py: 0.5,
+          borderRadius: 1,
+          minHeight: 32,
+          backgroundColor: isEditing ? "action.selected" : "transparent",
+          "&:hover": {
+            backgroundColor: isEditing ? "action.selected" : "action.hover",
+          },
+          "&:hover .queued-prompt-actions": { opacity: 1 },
+        }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            color: "text.secondary",
+            flexShrink: 0,
+          }}
+        >
+          <Circle size={10} />
+        </Box>
+
+        <Typography
+          variant="body2"
+          sx={{
+            flex: 1,
+            minWidth: 0,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            fontSize: 13,
+            color: "text.primary",
+          }}
+        >
+          {display}
+        </Typography>
+
+        {imageCount > 0 && (
+          <Typography
+            variant="caption"
+            sx={{ color: "text.secondary", flexShrink: 0 }}
+          >
+            {imageCount} {imageCount === 1 ? "image" : "images"}
+          </Typography>
+        )}
+
+        <Box
+          className="queued-prompt-actions"
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: 0.25,
+            flexShrink: 0,
+            opacity: 0,
+            transition: "opacity 120ms ease",
+          }}
+        >
+          <IconButton
+            type="button"
+            aria-label="Edit queued prompt"
+            onClick={() => onStartEdit(prompt.id)}
+            size="small"
+            sx={QUEUED_ROW_ACTION_BTN_SX}
+          >
+            <Pencil size={14} />
+          </IconButton>
+          <Tooltip title="Send now (interrupts the running chat)">
+            <IconButton
+              type="button"
+              aria-label="Send now (interrupts the running chat)"
+              onClick={() => onSendNow(prompt.id)}
+              size="small"
+              sx={QUEUED_ROW_ACTION_BTN_SX}
+            >
+              <ArrowUp size={14} />
+            </IconButton>
+          </Tooltip>
+          <IconButton
+            type="button"
+            aria-label="Remove queued prompt"
+            onClick={() => onRemove(prompt.id)}
+            size="small"
+            sx={QUEUED_ROW_ACTION_BTN_SX}
+          >
+            <Trash2 size={14} />
+          </IconButton>
+        </Box>
+      </Box>
+    );
+  },
+);
+QueuedPromptRow.displayName = "QueuedPromptRow";
+
+export const QueuedPromptList = React.memo(
+  ({
+    prompts,
+    editingId,
+    onStartEdit,
+    onSendNow,
+    onRemove,
+  }: QueuedPromptListProps) => {
+    const [expanded, setExpanded] = useState(true);
+
+    if (prompts.length === 0) return null;
+
+    return (
+      <Box
+        sx={{
+          mx: 2.25,
+          mb: 0,
+          border: 1,
+          borderBottom: 0,
+          borderColor: "divider",
+          borderRadius: 2.5,
+          borderBottomLeftRadius: 0,
+          borderBottomRightRadius: 0,
+          p: 0.5,
+          transformOrigin: "bottom",
+          animation: `${queueSlideUp} 220ms cubic-bezier(0.4, 0, 0.2, 1)`,
+        }}
+      >
+        <Box
+          role="button"
+          tabIndex={0}
+          aria-expanded={expanded}
+          onClick={() => setExpanded(prev => !prev)}
+          onKeyDown={e => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              setExpanded(prev => !prev);
+            }
+          }}
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: 0.5,
+            px: 1,
+            py: 0.5,
+            cursor: "pointer",
+            color: "text.secondary",
+            borderRadius: 1,
+            "&:hover": { color: "text.primary" },
+          }}
+        >
+          {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+          <Typography
+            variant="caption"
+            sx={{ fontWeight: 600, letterSpacing: 0.2 }}
+          >
+            {prompts.length} Queued
+          </Typography>
+        </Box>
+
+        {expanded && (
+          <Box sx={{ display: "flex", flexDirection: "column" }}>
+            {prompts.map(prompt => (
+              <QueuedPromptRow
+                key={prompt.id}
+                prompt={prompt}
+                isEditing={prompt.id === editingId}
+                onStartEdit={onStartEdit}
+                onSendNow={onSendNow}
+                onRemove={onRemove}
+              />
+            ))}
+          </Box>
+        )}
+      </Box>
+    );
+  },
+);
+QueuedPromptList.displayName = "QueuedPromptList";

--- a/app/src/components/chat/ReasoningDisplay.tsx
+++ b/app/src/components/chat/ReasoningDisplay.tsx
@@ -1,0 +1,142 @@
+import React from "react";
+import { Box, Button } from "@mui/material";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { StreamingMarkdown } from "../StreamingMarkdown";
+
+// ReasoningDisplay for showing reasoning/thinking parts inline.
+// - Auto-opens while streaming, auto-collapses when done.
+// - Shows elapsed thinking time ("Thought for Xs").
+// - Scrollable container with max height, auto-scrolls during streaming.
+export const ReasoningDisplay = React.memo(
+  ({
+    reasoningText,
+    isStreaming,
+    paletteMode: _paletteMode,
+  }: {
+    reasoningText: string;
+    isStreaming: boolean;
+    paletteMode: "light" | "dark";
+  }) => {
+    const [userToggled, setUserToggled] = React.useState(false);
+    const [userOpen, setUserOpen] = React.useState(false);
+    const [elapsedSeconds, setElapsedSeconds] = React.useState(0);
+    // Latches true once this block has streamed and then stopped. A finished
+    // thinking block must NEVER auto-reopen: reopening it would grow a block
+    // sitting ABOVE the currently-streaming one, shifting everything below and
+    // making the chat jump. Once done it stays collapsed unless the user opens
+    // it. (A given reasoning group streams exactly once, so latching is safe.)
+    const [finished, setFinished] = React.useState(false);
+    // Track whether this component was live-streamed (vs loaded from history)
+    const wasLiveRef = React.useRef(false);
+    const startTimeRef = React.useRef<number | null>(null);
+    const scrollRef = React.useRef<HTMLDivElement>(null);
+
+    // Auto-open only while THIS block is actively streaming and not yet
+    // finished; auto-close the moment it finishes. If the user manually
+    // toggled, respect their choice.
+    const isOpen = userToggled ? userOpen : isStreaming && !finished;
+
+    const handleToggle = () => {
+      setUserToggled(true);
+      setUserOpen(!isOpen);
+    };
+
+    // Timer: start counting when streaming begins, freeze when it stops
+    React.useEffect(() => {
+      // Never restart a block that already finished (guards against a spurious
+      // `isStreaming` flip re-opening / re-timing a completed block).
+      if (isStreaming && !finished) {
+        // Mark that this component saw a live session
+        wasLiveRef.current = true;
+        // Reset for new streaming session
+        setUserToggled(false);
+        startTimeRef.current = Date.now();
+        setElapsedSeconds(0);
+
+        const interval = setInterval(() => {
+          if (startTimeRef.current) {
+            setElapsedSeconds(
+              Math.round((Date.now() - startTimeRef.current) / 1000),
+            );
+          }
+        }, 1000);
+
+        return () => clearInterval(interval);
+      }
+      // Streaming just stopped — freeze the elapsed time
+      // (elapsedSeconds already holds the last value) and latch this block as
+      // done so it can never auto-reopen.
+      startTimeRef.current = null;
+      if (wasLiveRef.current) setFinished(true);
+    }, [isStreaming, finished]);
+
+    // Auto-scroll the reasoning container to the bottom while streaming
+    React.useEffect(() => {
+      if (isStreaming && isOpen && scrollRef.current) {
+        scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+      }
+    }, [reasoningText, isStreaming, isOpen]);
+
+    // Build the label text
+    let label: string;
+    if (isStreaming) {
+      label = `Thinking${elapsedSeconds > 0 ? ` for ${elapsedSeconds}s` : ""}...`;
+    } else if (wasLiveRef.current) {
+      label = `Thought for ${elapsedSeconds || "<1"}s`;
+    } else {
+      label = "Thinking process";
+    }
+
+    return (
+      <Box sx={{ my: 0.5 }}>
+        <Button
+          size="small"
+          onClick={handleToggle}
+          endIcon={
+            isOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />
+          }
+          sx={{
+            color: "text.secondary",
+            textTransform: "none",
+            fontSize: "0.8rem",
+            p: 0,
+            minWidth: "auto",
+            "& .MuiButton-endIcon": {
+              opacity: isOpen ? 1 : 0,
+              transition: "opacity 0.15s ease",
+            },
+            "&:hover .MuiButton-endIcon": {
+              opacity: 1,
+            },
+            "&:hover": {
+              backgroundColor: "transparent",
+            },
+          }}
+          disableRipple
+        >
+          {label}
+        </Button>
+        {isOpen && (
+          <Box
+            ref={scrollRef}
+            sx={{
+              mt: 0.5,
+              pl: 2,
+              borderLeft: 2,
+              borderColor: "divider",
+              color: "text.secondary",
+              fontSize: "0.85rem",
+              maxHeight: 300,
+              overflowY: "auto",
+              "& p": { my: 0.5 },
+            }}
+          >
+            <StreamingMarkdown>{reasoningText}</StreamingMarkdown>
+          </Box>
+        )}
+      </Box>
+    );
+  },
+);
+
+ReasoningDisplay.displayName = "ReasoningDisplay";

--- a/app/src/components/chat/StreamingIndicator.tsx
+++ b/app/src/components/chat/StreamingIndicator.tsx
@@ -1,0 +1,15 @@
+import { Box } from "@mui/material";
+import {
+  streamingIndicatorContainerSx,
+  streamingIndicatorDotSx,
+} from "./streaming-indicator-styles";
+
+// StreamingIndicator - Shows pulsing dot while content is being streamed
+// (not memoized) so it picks up theme updates when the parent palette changes
+export function StreamingIndicator() {
+  return (
+    <Box component="span" sx={streamingIndicatorContainerSx}>
+      <Box sx={streamingIndicatorDotSx} />
+    </Box>
+  );
+}

--- a/app/src/components/chat/ToolDetailsDialog.tsx
+++ b/app/src/components/chat/ToolDetailsDialog.tsx
@@ -1,0 +1,74 @@
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from "@mui/material";
+import { safeStringify } from "../../lib/json-safe";
+import { CodeBlock } from "./CodeBlock";
+import type { ToolInvocationInfo } from "./tool-presentation";
+
+interface ToolDetailsDialogProps {
+  open: boolean;
+  tool: ToolInvocationInfo | null;
+  onClose: () => void;
+  paletteMode: "light" | "dark";
+}
+
+/** Tool debug dialog: raw input/output of a tool call as scrollable JSON. */
+export function ToolDetailsDialog({
+  open,
+  tool,
+  onClose,
+  paletteMode,
+}: ToolDetailsDialogProps) {
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+      <DialogTitle>
+        {tool ? `Tool: ${tool.toolName}` : "Tool Details"}
+      </DialogTitle>
+      <DialogContent dividers>
+        <Box sx={{ mb: 2 }}>
+          <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+            Input
+          </Typography>
+          <CodeBlock
+            language="json"
+            isGenerating={false}
+            scrollable
+            paletteMode={paletteMode}
+          >
+            {tool && tool.input !== undefined
+              ? typeof tool.input === "string"
+                ? tool.input
+                : safeStringify(tool.input, 2)
+              : "No input captured"}
+          </CodeBlock>
+        </Box>
+        <Box>
+          <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+            Output
+          </Typography>
+          <CodeBlock
+            language="json"
+            isGenerating={false}
+            scrollable
+            paletteMode={paletteMode}
+          >
+            {tool && tool.output !== undefined
+              ? typeof tool.output === "string"
+                ? tool.output
+                : safeStringify(tool.output, 2)
+              : "No output captured"}
+          </CodeBlock>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/app/src/components/chat/__tests__/convert-stored-messages.test.ts
+++ b/app/src/components/chat/__tests__/convert-stored-messages.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect } from "vitest";
+import { convertStoredMessages } from "../convert-stored-messages";
+
+const INTERRUPTED = "Interrupted — stream disconnected before tool completed";
+
+describe("convertStoredMessages", () => {
+  it("returns [] for null/undefined/empty input", () => {
+    expect(convertStoredMessages(null)).toEqual([]);
+    expect(convertStoredMessages(undefined)).toEqual([]);
+    expect(convertStoredMessages([])).toEqual([]);
+  });
+
+  it("passes through text parts and preserves message id/role", () => {
+    const [msg] = convertStoredMessages([
+      {
+        id: "m1",
+        role: "user",
+        parts: [{ type: "text", text: "hello" }],
+      },
+    ]);
+    expect(msg.id).toBe("m1");
+    expect(msg.role).toBe("user");
+    expect(msg.parts).toEqual([{ type: "text", text: "hello" }]);
+  });
+
+  it("falls back to _id and generates an id when both are missing", () => {
+    const [withUnderscore, generated] = convertStoredMessages([
+      { _id: "mongo-1", role: "user", parts: [{ type: "text", text: "a" }] },
+      { role: "user", parts: [{ type: "text", text: "b" }] },
+    ]);
+    expect(withUnderscore.id).toBe("mongo-1");
+    expect(typeof generated.id).toBe("string");
+    expect(generated.id.length).toBeGreaterThan(0);
+  });
+
+  it("carries reasoning providerMetadata (Anthropic thinking signature)", () => {
+    // Without the signature round-tripping, Anthropic rejects the next turn
+    // with "thinking blocks ... cannot be modified".
+    const meta = { anthropic: { signature: "sig-abc" } };
+    const [msg] = convertStoredMessages([
+      {
+        id: "m1",
+        role: "assistant",
+        parts: [
+          { type: "reasoning", reasoning: "thought A", providerMetadata: meta },
+          { type: "reasoning", text: "thought B" },
+        ],
+      },
+    ]);
+    expect(msg.parts[0]).toEqual({
+      type: "reasoning",
+      text: "thought A",
+      providerMetadata: meta,
+    });
+    // No providerMetadata key at all when the stored part had none.
+    expect(msg.parts[1]).toEqual({ type: "reasoning", text: "thought B" });
+  });
+
+  it('rewrites legacy "error" tool state to output-error with errorText fallback chain', () => {
+    const [msg] = convertStoredMessages([
+      {
+        id: "m1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-run_console",
+            toolCallId: "c1",
+            state: "error",
+            errorText: "explicit text",
+            output: { error: "output error" },
+          },
+          {
+            type: "tool-run_console",
+            toolCallId: "c2",
+            state: "error",
+            output: { error: "output error" },
+          },
+          {
+            type: "tool-run_console",
+            toolCallId: "c3",
+            state: "error",
+            output: { error: 42 },
+          },
+          { type: "tool-run_console", toolCallId: "c4", state: "error" },
+        ],
+      },
+    ]);
+    const states = msg.parts.map(p => p.state);
+    expect(states).toEqual(Array(4).fill("output-error"));
+    expect(msg.parts.map(p => p.errorText)).toEqual([
+      "explicit text",
+      "output error",
+      "42",
+      "Tool failed",
+    ]);
+    // Output is cleared and input defaulted so the SDK/model input stays valid.
+    expect(msg.parts[0].output).toBeUndefined();
+    expect(msg.parts[3].input).toEqual({});
+  });
+
+  it("keeps terminal tool parts as-is (with input defaulted to {})", () => {
+    const [msg] = convertStoredMessages([
+      {
+        id: "m1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-create_dashboard",
+            toolCallId: "c1",
+            state: "output-available",
+            output: { success: true },
+          },
+        ],
+      },
+    ]);
+    expect(msg.parts[0].state).toBe("output-available");
+    expect(msg.parts[0].input).toEqual({});
+    expect(msg.parts[0].output).toEqual({ success: true });
+  });
+
+  it("patches interrupted (non-terminal) tool parts to output-error", () => {
+    const [msg] = convertStoredMessages([
+      {
+        id: "m1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-create_data_source",
+            toolCallId: "c1",
+            state: "input-available",
+            input: { name: "x" },
+          },
+          {
+            type: "dynamic-tool",
+            toolName: "custom_tool",
+            toolCallId: "c2",
+            state: "input-streaming",
+          },
+        ],
+      },
+    ]);
+    for (const part of msg.parts) {
+      expect(part.state).toBe("output-error");
+      expect(part.errorText).toBe(INTERRUPTED);
+      expect(part.output).toBeUndefined();
+    }
+    expect(msg.parts[0].input).toEqual({ name: "x" });
+  });
+
+  it("leaves non-terminal tool parts PENDING while the turn is still active server-side", () => {
+    // Mid-turn reload: persistence is per-segment and async, so a settled
+    // client tool can still read input-available in the snapshot. Patching it
+    // to "Interrupted" while activeStreamId is set poisoned settled tools and
+    // the next send persisted the poison — leave pending; resume replay /
+    // orphan rescue settles it.
+    const [msg] = convertStoredMessages(
+      [
+        {
+          id: "m1",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-create_dashboard",
+              toolCallId: "c1",
+              state: "input-available",
+              input: { title: "X" },
+            },
+          ],
+        },
+      ],
+      { turnActive: true },
+    );
+    expect(msg.parts[0].state).toBe("input-available");
+    expect(msg.parts[0].errorText).toBeUndefined();
+  });
+
+  it("keeps unanswered human-in-the-loop tools pending (interactive card must survive reload)", () => {
+    const [msg] = convertStoredMessages([
+      {
+        id: "m1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-ask_clarifying_questions",
+            toolCallId: "c1",
+            state: "input-available",
+            input: { questions: [] },
+          },
+          {
+            type: "tool-submit_plan",
+            toolCallId: "c2",
+            state: "input-available",
+            input: { title: "Plan" },
+          },
+        ],
+      },
+    ]);
+    for (const part of msg.parts) {
+      expect(part.state).toBe("input-available");
+      expect(part.errorText).toBeUndefined();
+    }
+  });
+
+  it("passes through unknown part types untouched", () => {
+    const part = { type: "step-start" };
+    const [msg] = convertStoredMessages([
+      { id: "m1", role: "assistant", parts: [part] },
+    ]);
+    expect(msg.parts[0]).toEqual(part);
+  });
+
+  it("reconstructs parts from legacy fields (toolCalls -> reasoning -> text)", () => {
+    const [msg] = convertStoredMessages([
+      {
+        _id: "legacy-1",
+        role: "assistant",
+        content: "final answer",
+        reasoning: ["thought 1", "thought 2"],
+        toolCalls: [
+          {
+            toolName: "run_console",
+            toolCallId: "tc1",
+            input: { sql: "SELECT 1" },
+            result: { rows: 1 },
+          },
+          // toolName missing -> skipped entirely
+          { toolCallId: "tc2" },
+        ],
+      },
+    ]);
+    expect(msg.parts.map(p => p.type)).toEqual([
+      "tool-run_console",
+      "reasoning",
+      "reasoning",
+      "text",
+    ]);
+    expect(msg.parts[0]).toMatchObject({
+      toolCallId: "tc1",
+      toolName: "run_console",
+      state: "output-available",
+      input: { sql: "SELECT 1" },
+      output: { rows: 1 },
+    });
+    expect(msg.parts[3]).toEqual({ type: "text", text: "final answer" });
+  });
+
+  it("legacy fallback generates a toolCallId when missing", () => {
+    const [msg] = convertStoredMessages([
+      {
+        id: "legacy-2",
+        role: "assistant",
+        toolCalls: [{ toolName: "run_console" }],
+      },
+    ]);
+    const id = msg.parts[0].toolCallId as string;
+    expect(id.startsWith("saved-run_console-")).toBe(true);
+  });
+});

--- a/app/src/components/chat/__tests__/session-loader-staleness.test.ts
+++ b/app/src/components/chat/__tests__/session-loader-staleness.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import type { UIMessage } from "ai";
+import { isPersistedSnapshotStale } from "../hooks/useChatSessionLoader";
+
+type RawMessages = Parameters<typeof isPersistedSnapshotStale>[0];
+
+function user(text: string) {
+  return { role: "user", parts: [{ type: "text", text }] };
+}
+
+function assistant(parts: Array<Record<string, unknown>>) {
+  return { role: "assistant", parts };
+}
+
+function tool(state: string, toolCallId = "call-1") {
+  return {
+    type: "tool-create_dashboard",
+    toolCallId,
+    state,
+    input: { title: "X" },
+  };
+}
+
+const asUi = (msgs: RawMessages) => msgs as unknown as UIMessage[];
+
+describe("isPersistedSnapshotStale (reload-before-replay guard)", () => {
+  it("not stale when memory is empty (cold open)", () => {
+    expect(isPersistedSnapshotStale([user("hi")], asUi([]))).toBe(false);
+  });
+
+  it("stale when the snapshot has fewer messages than memory", () => {
+    const memory = [user("hi"), assistant([tool("output-available")])];
+    expect(isPersistedSnapshotStale([user("hi")], asUi(memory))).toBe(true);
+  });
+
+  it("not stale when the snapshot has more messages (server ahead)", () => {
+    const persisted = [user("hi"), assistant([tool("output-available")])];
+    expect(isPersistedSnapshotStale(persisted, asUi([user("hi")]))).toBe(false);
+  });
+
+  it("stale when a tool settled in memory is still pending in the snapshot", () => {
+    // The segment-boundary race: create_dashboard settled locally via
+    // addToolOutput, but the continuation save hasn't landed server-side.
+    const persisted = [user("hi"), assistant([tool("input-available")])];
+    const memory = [user("hi"), assistant([tool("output-available")])];
+    expect(isPersistedSnapshotStale(persisted, asUi(memory))).toBe(true);
+  });
+
+  it("stale when the snapshot is missing trailing parts of the last message", () => {
+    const persisted = [user("hi"), assistant([tool("output-available")])];
+    const memory = [
+      user("hi"),
+      assistant([
+        tool("output-available"),
+        { type: "text", text: "All done." },
+      ]),
+    ];
+    expect(isPersistedSnapshotStale(persisted, asUi(memory))).toBe(true);
+  });
+
+  it("not stale when snapshot and memory agree", () => {
+    const parts = [tool("output-available"), { type: "text", text: "Done." }];
+    expect(
+      isPersistedSnapshotStale(
+        [user("hi"), assistant(parts)],
+        asUi([user("hi"), assistant(parts)]),
+      ),
+    ).toBe(false);
+  });
+
+  it("not stale when the snapshot has MORE parts (server ahead mid-replay)", () => {
+    const persisted = [
+      user("hi"),
+      assistant([tool("output-available"), { type: "text", text: "Done." }]),
+    ];
+    const memory = [user("hi"), assistant([tool("output-available")])];
+    expect(isPersistedSnapshotStale(persisted, asUi(memory))).toBe(false);
+  });
+});

--- a/app/src/components/chat/__tests__/tool-dispatch-gate.test.ts
+++ b/app/src/components/chat/__tests__/tool-dispatch-gate.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from "vitest";
+import { ToolDispatchGate } from "../tool-dispatch-gate";
+
+describe("ToolDispatchGate", () => {
+  it("allows the first dispatch and blocks replays of the same toolCallId", () => {
+    const gate = new ToolDispatchGate();
+    const execute = vi.fn();
+
+    // Simulates the incident: the same tool-input-available chunk delivered to
+    // multiple stream consumers / replayed by a resume reattach.
+    for (let i = 0; i < 3; i++) {
+      if (gate.markDispatched("call-1")) execute();
+    }
+
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("tracks distinct toolCallIds independently", () => {
+    const gate = new ToolDispatchGate();
+    expect(gate.markDispatched("call-1")).toBe(true);
+    expect(gate.markDispatched("call-2")).toBe(true);
+    expect(gate.markDispatched("call-1")).toBe(false);
+    expect(gate.markDispatched("call-2")).toBe(false);
+  });
+
+  it("always allows calls without a toolCallId (cannot dedupe)", () => {
+    const gate = new ToolDispatchGate();
+    expect(gate.markDispatched("")).toBe(true);
+    expect(gate.markDispatched(undefined)).toBe(true);
+    expect(gate.markDispatched(null)).toBe(true);
+  });
+
+  it("reset() forgets dispatched ids (chat switch)", () => {
+    const gate = new ToolDispatchGate();
+    gate.markDispatched("call-1");
+    gate.reset();
+    expect(gate.markDispatched("call-1")).toBe(true);
+  });
+
+  describe("seedFromPersistedMessages", () => {
+    it("blocks ids persisted in a terminal state", () => {
+      const gate = new ToolDispatchGate();
+      gate.seedFromPersistedMessages([
+        {
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-create_dashboard",
+              toolCallId: "done-1",
+              state: "output-available",
+            },
+            {
+              type: "dynamic-tool",
+              toolName: "create_data_source",
+              toolCallId: "done-2",
+              state: "output-error",
+            },
+            { type: "tool-run_console", toolCallId: "err-1", state: "error" },
+          ],
+        },
+      ]);
+      expect(gate.markDispatched("done-1")).toBe(false);
+      expect(gate.markDispatched("done-2")).toBe(false);
+      expect(gate.markDispatched("err-1")).toBe(false);
+    });
+
+    it("keeps non-terminal (interrupted) ids dispatchable for post-refresh recovery", () => {
+      const gate = new ToolDispatchGate();
+      gate.seedFromPersistedMessages([
+        {
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-create_dashboard",
+              toolCallId: "pending-1",
+              state: "input-available",
+            },
+            {
+              type: "tool-add_widget",
+              toolCallId: "pending-2",
+              state: "input-streaming",
+            },
+          ],
+        },
+      ]);
+      // First (replay-driven) dispatch is allowed, subsequent ones are blocked.
+      expect(gate.markDispatched("pending-1")).toBe(true);
+      expect(gate.markDispatched("pending-1")).toBe(false);
+      expect(gate.markDispatched("pending-2")).toBe(true);
+    });
+
+    it("ignores non-tool parts and parts without ids", () => {
+      const gate = new ToolDispatchGate();
+      gate.seedFromPersistedMessages([
+        {
+          role: "assistant",
+          parts: [
+            { type: "text", text: "hello" },
+            { type: "step-start" },
+            { type: "tool-run_console", state: "output-available" },
+            { type: "reasoning", reasoning: "hmm" },
+          ],
+        },
+        { role: "user", parts: [{ type: "text", text: "hi" }] },
+        { role: "assistant", parts: null },
+      ]);
+      expect(gate.markDispatched("anything")).toBe(true);
+    });
+  });
+});

--- a/app/src/components/chat/convert-stored-messages.ts
+++ b/app/src/components/chat/convert-stored-messages.ts
@@ -1,0 +1,206 @@
+/**
+ * Conversion of persisted chat messages (the MongoDB shape returned by
+ * GET /api/workspaces/:id/chats/:chatId) into AI SDK UIMessage-compatible
+ * objects for `setMessages`.
+ *
+ * Extracted from Chat.tsx's loadSession so it is unit-testable and shared by
+ * the history loader and the resume manager's reload-before-replay path.
+ */
+
+/** Loose UIMessage shape accepted by useChat's setMessages. */
+export interface ConvertedUiMessage {
+  id: string;
+  role: string;
+  parts: Array<Record<string, unknown>>;
+}
+
+const INTERRUPTED_TEXT =
+  "Interrupted — stream disconnected before tool completed";
+
+// Human-in-the-loop tools resolve via an interactive card, so a persisted
+// unanswered one must be re-rendered pending rather than patched to an error.
+const HUMAN_IN_THE_LOOP_TOOL_PART_TYPES = new Set([
+  "tool-ask_clarifying_questions",
+  "tool-submit_plan",
+]);
+
+export interface ConvertStoredMessagesOptions {
+  /**
+   * True when the chat has an in-flight turn server-side (activeStreamId
+   * set). Non-terminal tool parts are then left PENDING instead of being
+   * patched to "Interrupted": persistence is per-segment and asynchronous,
+   * so mid-turn the snapshot can lag the live state (a client tool that
+   * already settled may still read `input-available` here). Poisoning it
+   * corrupts history — the resumed segment's replay only appends new chunks
+   * and never re-delivers the settled tool, so the poison survives in memory
+   * and the NEXT send persists it over the server's correct finalization.
+   * Pending parts self-heal instead: the resume replay re-delivers/settles
+   * them, and the orphan-rescue effect recovers or patches anything
+   * genuinely stuck once the turn goes quiet.
+   */
+  turnActive?: boolean;
+}
+
+function convertStoredPart(
+  p: any,
+  opts?: ConvertStoredMessagesOptions,
+): Record<string, unknown> {
+  // Convert stored part to UI format
+  if (p.type === "text") {
+    return { type: "text", text: p.text || "" };
+  }
+  if (p.type === "reasoning") {
+    // Handle both 'reasoning' and 'text' fields for reasoning parts.
+    // Carry providerMetadata back (Anthropic extended-thinking
+    // `signature`) so a continuation replays the thinking block
+    // byte-for-byte; without it Anthropic rejects the turn with
+    // "thinking ... blocks in the latest assistant message cannot
+    // be modified".
+    return {
+      type: "reasoning",
+      text: p.reasoning || p.text || "",
+      ...(p.providerMetadata != null
+        ? { providerMetadata: p.providerMetadata }
+        : {}),
+    };
+  }
+  // Tool parts: ensure state is set for UI rendering
+  // AI SDK v6 uses output-error (not "error") so convertToModelMessages
+  // emits a matching tool-result for Anthropic.
+  if (p.type?.startsWith("tool-") || p.type === "dynamic-tool") {
+    const toolState = p.state as string | undefined;
+    if (toolState === "error") {
+      const output = p.output as { error?: unknown } | null | undefined;
+      const errorText =
+        typeof p.errorText === "string"
+          ? p.errorText
+          : typeof output?.error === "string"
+            ? output.error
+            : output?.error != null
+              ? String(output.error)
+              : "Tool failed";
+      return {
+        ...p,
+        state: "output-error",
+        input: p.input ?? {},
+        output: undefined,
+        errorText,
+      };
+    }
+    const isComplete =
+      toolState === "output-available" ||
+      toolState === "output-error" ||
+      toolState === "output-denied";
+    if (isComplete) {
+      return {
+        ...p,
+        input: p.input ?? {},
+      };
+    }
+    // A persisted, unanswered human-in-the-loop tool
+    // (clarifying questions / plan review) is not an
+    // interrupted tool: re-render its interactive card so the
+    // user can still answer it. Answering sends the tool
+    // result, which continues the turn from persisted
+    // history. Keep it pending instead of marking it errored.
+    if (
+      typeof p.type === "string" &&
+      HUMAN_IN_THE_LOOP_TOOL_PART_TYPES.has(p.type) &&
+      toolState === "input-available"
+    ) {
+      return {
+        ...p,
+        input: p.input ?? {},
+      };
+    }
+    // Turn still in flight server-side: the snapshot may simply lag the live
+    // state — leave the part pending so the resume replay / orphan rescue can
+    // settle it (see ConvertStoredMessagesOptions.turnActive).
+    if (opts?.turnActive) {
+      return {
+        ...p,
+        state: toolState ?? "input-available",
+        input: p.input ?? {},
+      };
+    }
+    return {
+      ...p,
+      state: "output-error",
+      input: p.input ?? {},
+      output: undefined,
+      errorText: INTERRUPTED_TEXT,
+    };
+  }
+  // Unknown part type - pass through as-is
+  return p;
+}
+
+/**
+ * Convert stored messages to AI SDK format with parts including tool calls.
+ * Tool calls are included for UI display (shows what tools were used).
+ * The backend sanitizes these before sending to the AI to avoid
+ * "tool_use without tool_result" errors.
+ */
+export function convertStoredMessages(
+  rawMessages: unknown[] | null | undefined,
+  opts?: ConvertStoredMessagesOptions,
+): ConvertedUiMessage[] {
+  return (
+    (rawMessages as any[] | null | undefined)?.map((msg: any) => {
+      // NEW: If parts are stored, use them directly (preserves chronological order)
+      if (msg.parts && Array.isArray(msg.parts) && msg.parts.length > 0) {
+        return {
+          id: msg.id || msg._id?.toString() || `${Date.now()}-${Math.random()}`,
+          role: msg.role,
+          parts: msg.parts.map((p: any) => convertStoredPart(p, opts)),
+        };
+      }
+
+      // TODO: Remove this fallback once we're OK with losing the ability to show old chats
+      // that were created before the parts array migration.
+      // LEGACY FALLBACK: Reconstruct parts from legacy fields (for existing chats without parts)
+      // Note: Order cannot be perfectly restored, use best-effort: tools -> reasoning -> text
+      const parts: Array<Record<string, unknown>> = [];
+
+      // Add tool call parts (for UI display - shows tool history)
+      // IMPORTANT: input must always be defined (at least {}) for OpenAI API compatibility
+      if (msg.toolCalls && msg.toolCalls.length > 0) {
+        for (const tc of msg.toolCalls) {
+          if (!tc.toolName) continue;
+          parts.push({
+            type: `tool-${tc.toolName}`,
+            toolCallId:
+              tc.toolCallId ||
+              tc._id?.toString() ||
+              `saved-${tc.toolName}-${Date.now()}-${Math.random()}`,
+            toolName: tc.toolName,
+            state: "output-available",
+            input: tc.input ?? {},
+            output: tc.result ?? null,
+          });
+        }
+      }
+
+      // Add reasoning parts (if any)
+      if (msg.reasoning && Array.isArray(msg.reasoning)) {
+        for (const reasoningText of msg.reasoning) {
+          parts.push({
+            type: "reasoning",
+            text: reasoningText,
+          });
+        }
+      }
+
+      // Add text content part
+      if (msg.content) {
+        parts.push({ type: "text", text: msg.content });
+      }
+
+      return {
+        id: msg._id?.toString() || msg.id || `${Date.now()}-${Math.random()}`,
+        role: msg.role,
+        parts,
+      };
+    }) || []
+  );
+}

--- a/app/src/components/chat/hooks/useChatScroll.ts
+++ b/app/src/components/chat/hooks/useChatScroll.ts
@@ -1,0 +1,133 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type MutableRefObject,
+  type RefObject,
+} from "react";
+import type { VirtuosoHandle } from "react-virtuoso";
+
+export interface UseChatScrollArgs {
+  isLoading: boolean;
+  isLoadingRef: MutableRefObject<boolean>;
+  virtuosoRef: RefObject<VirtuosoHandle>;
+}
+
+/**
+ * Stick to the streaming tail while a turn is generating.
+ *
+ * Virtuoso's `followOutput` only fires when the item COUNT changes, but an
+ * entire assistant turn — thinking blocks, every tool card, and the final
+ * text — streams into a SINGLE message, growing one item without ever
+ * changing the count. So `followOutput` never fires mid-turn and the view
+ * doesn't follow the streaming content (it stays OFF on `<Virtuoso>`).
+ *
+ * We instead pin the bottom inside Virtuoso's own `totalListHeightChanged`
+ * callback (`handleListHeightChanged`). The earlier approach pinned on each
+ * throttled `messages` tick via a one-shot rAF, but that only covers ~1 of
+ * every 3 frames: the interior blocks that change height asynchronously and
+ * non-monotonically (MUI `Collapse` on the thinking block + tool cards, and
+ * the `modify_console` diff re-render) animate over ~300ms on frames where
+ * `messages` does NOT tick. On those frames Virtuoso's resize anchoring
+ * nudges `scrollTop` UP (toward the message top) to keep content stable, and
+ * with no pin to counter it the view paints partway up — then the next
+ * `messages` tick pins it back down. That alternation is the top/bottom
+ * "jumping/blinking". Plain-text turns never bounced because their growth is
+ * append-only at the bottom (monotonic), so the anchor and the pin agree.
+ *
+ * `totalListHeightChanged` fires as part of Virtuoso's resize processing,
+ * AFTER it applies that compensation, so writing `scrollTop = scrollHeight`
+ * here is the last write before paint on exactly the frames that resize —
+ * the frames the old pin lost. Reading `isAtBottom` from a ref keeps history
+ * reading un-yanked the instant the user scrolls up.
+ */
+export function useChatScroll({
+  isLoading,
+  isLoadingRef,
+  virtuosoRef,
+}: UseChatScrollArgs) {
+  // `isAtBottom` drives both the "scroll to bottom" button and whether
+  // streaming auto-follows the tail.
+  const [isAtBottom, setIsAtBottom] = useState(true);
+  const scrollerElRef = useRef<HTMLElement | Window | null>(null);
+  const isAtBottomRef = useRef(isAtBottom);
+  isAtBottomRef.current = isAtBottom;
+
+  // Track the last time the view was at the bottom (updated in render). Used to
+  // decide whether to hold the bottom through the post-turn settling window
+  // even after the big end-of-turn collapse momentarily flips `isAtBottom`.
+  const lastAtBottomAtRef = useRef(0);
+  if (isAtBottom) lastAtBottomAtRef.current = Date.now();
+
+  // Bounded settling window after a turn ends. Tool cards and thinking blocks
+  // now collapse per-block the instant each one finishes (see
+  // `StreamingToolCard` / `ReasoningDisplay`), so there is no longer a single
+  // mass collapse deferred to turn end. What still shrinks at turn end is the
+  // LAST live block: the final thinking block (or a trailing tool card) closes
+  // when `status` leaves "streaming". Virtuoso reacts to that shrink by
+  // re-anchoring to the (now shorter) item's TOP, which can strand the view at
+  // the top of the response unless we keep pinning the bottom through it.
+  //
+  // The live `isAtBottom` can't gate this pin: the very shrink we're countering
+  // flips `isAtBottom` to false for a few frames, which would disengage the pin
+  // and let the strand happen. Instead we snapshot whether the user was at the
+  // bottom *as the turn ended* (`wasAtBottomAtTurnEndRef`) and hold the bottom
+  // for the whole window based on that — so the final collapse stays pinned,
+  // but a user who had scrolled up to read history is never yanked back down.
+  const stickTailUntilRef = useRef(0);
+  const wasAtBottomAtTurnEndRef = useRef(false);
+  const wasLoadingRef = useRef(isLoading);
+  useEffect(() => {
+    if (wasLoadingRef.current && !isLoading) {
+      // Hold the bottom briefly so the final block's collapse at turn end
+      // stays pinned instead of stranding the view at the message top.
+      stickTailUntilRef.current = Date.now() + 1200;
+      wasAtBottomAtTurnEndRef.current =
+        isAtBottomRef.current || Date.now() - lastAtBottomAtRef.current < 800;
+    }
+    wasLoadingRef.current = isLoading;
+  }, [isLoading]);
+
+  // Streaming follow: a raw `scrollTop = scrollHeight` write on the captured
+  // scroller. This is the smoothest way to track append-only growth — released
+  // the instant the user scrolls up (live `isAtBottomRef`) so reading history
+  // isn't yanked down.
+  const pinToBottom = useCallback(() => {
+    if (!isAtBottomRef.current) return;
+    const el = scrollerElRef.current;
+    if (el && el instanceof HTMLElement) el.scrollTop = el.scrollHeight;
+  }, []);
+
+  const handleListHeightChanged = useCallback(() => {
+    if (isLoadingRef.current) {
+      pinToBottom();
+      return;
+    }
+    // Post-turn settle. The final block's collapse at turn end shrinks the
+    // streaming message; a raw `scrollTop` write can lose the race to Virtuoso
+    // re-anchoring the (now shorter) item to its TOP, which strands the view at
+    // the top of the response. Virtuoso's own
+    // `scrollToIndex` is authoritative — it re-targets the last item's end and
+    // survives the re-measure — so use it to hold the conclusion at the bottom
+    // through the collapse. Gated on the turn-end snapshot (not the live
+    // `isAtBottom`, which the collapse transiently flips false) and the bounded
+    // window, so a user who scrolled up to read history is never yanked back.
+    // `scrollToIndex` is only safe here because the last item is no longer
+    // growing (during streaming it would re-derive a moving target and bounce —
+    // that path uses the raw `scrollTop` pin above).
+    if (
+      Date.now() <= stickTailUntilRef.current &&
+      wasAtBottomAtTurnEndRef.current
+    ) {
+      virtuosoRef.current?.scrollToIndex({ index: "LAST", align: "end" });
+    }
+  }, [isLoadingRef, pinToBottom, virtuosoRef]);
+
+  return {
+    isAtBottom,
+    setIsAtBottom,
+    scrollerElRef,
+    handleListHeightChanged,
+  };
+}

--- a/app/src/components/chat/hooks/useChatSessionLoader.ts
+++ b/app/src/components/chat/hooks/useChatSessionLoader.ts
@@ -1,0 +1,298 @@
+import { useEffect, type MutableRefObject, type RefObject } from "react";
+import type { UseChatHelpers } from "@ai-sdk/react";
+import type { UIMessage } from "ai";
+import type { VirtuosoHandle } from "react-virtuoso";
+import { api } from "../../../api/client";
+import { useConsoleStore } from "../../../store/consoleStore";
+import { convertStoredMessages } from "../convert-stored-messages";
+import type { ToolDispatchGate } from "../tool-dispatch-gate";
+
+type ChatHelpers = UseChatHelpers<UIMessage>;
+
+const TERMINAL_TOOL_STATES = new Set([
+  "output-available",
+  "output-error",
+  "output-denied",
+  "error",
+]);
+
+function isToolPart(part: Record<string, unknown>): boolean {
+  const type = part.type;
+  return (
+    typeof type === "string" &&
+    (type.startsWith("tool-") || type === "dynamic-tool")
+  );
+}
+
+/**
+ * True when the fetched persisted snapshot is BEHIND the live in-memory
+ * state. Persistence is asynchronous and per-segment, so around a segment
+ * boundary (a client tool just settled, the continuation hasn't saved yet)
+ * the server may still hold the segment-END snapshot where that tool is
+ * `input-available`. Swapping that in would clobber the settled output, the
+ * history converter would poison the "pending" tool to Interrupted, and the
+ * next send would persist the corrupted turn — history rewritten backwards.
+ */
+export function isPersistedSnapshotStale(
+  rawPersisted: Array<{
+    role?: string;
+    parts?: Array<Record<string, unknown>> | null;
+  }>,
+  inMemory: ChatHelpers["messages"],
+): boolean {
+  if (inMemory.length === 0) return false;
+  if (rawPersisted.length < inMemory.length) return true;
+  if (rawPersisted.length > inMemory.length) return false;
+
+  const persistedLast = rawPersisted[rawPersisted.length - 1];
+  const memoryLast = inMemory[inMemory.length - 1];
+  if (memoryLast.role !== "assistant") return false;
+  if (persistedLast.role !== memoryLast.role) return true;
+
+  const persistedParts = (persistedLast.parts ?? []) as Array<
+    Record<string, unknown>
+  >;
+  const memoryParts = (memoryLast.parts ?? []) as Array<
+    Record<string, unknown>
+  >;
+  if (persistedParts.length < memoryParts.length) return true;
+
+  // Tool-output regression: a call settled in memory but still pending in
+  // the snapshot means the snapshot predates the settle.
+  const persistedToolStates = new Map<string, string>();
+  for (const part of persistedParts) {
+    if (!isToolPart(part)) continue;
+    const id = part.toolCallId;
+    if (typeof id === "string" && id) {
+      persistedToolStates.set(id, String(part.state ?? ""));
+    }
+  }
+  for (const part of memoryParts) {
+    if (!isToolPart(part)) continue;
+    const id = part.toolCallId;
+    if (typeof id !== "string" || !id) continue;
+    const memoryState = String(part.state ?? "");
+    if (!TERMINAL_TOOL_STATES.has(memoryState)) continue;
+    const persistedState = persistedToolStates.get(id);
+    if (
+      persistedState !== undefined &&
+      !TERMINAL_TOOL_STATES.has(persistedState)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export interface UseChatSessionLoaderArgs {
+  chatId: string;
+  isExistingChat: boolean;
+  /** Current workspace id — reruns the history load when it resolves/changes. */
+  workspaceId: string | undefined;
+  setMessages: ChatHelpers["setMessages"];
+  /** Live in-memory messages — the reload path must never step them backwards. */
+  messagesRef: MutableRefObject<ChatHelpers["messages"]>;
+  workspaceIdRef: MutableRefObject<string | undefined>;
+  chatIdRef: MutableRefObject<string>;
+  virtuosoRef: RefObject<VirtuosoHandle>;
+  capturedConsoleIdRef: MutableRefObject<string | null>;
+  handledConsoleOpenToolCallIdsRef: MutableRefObject<Set<string>>;
+  toolDispatchGateRef: MutableRefObject<ToolDispatchGate>;
+  /** Wired by this hook; used by the resume manager's reload-before-replay. */
+  loadPersistedMessagesRef: MutableRefObject<
+    ((opts?: { forHistoryLoad?: boolean }) => Promise<boolean>) | undefined
+  >;
+  requestResumeRef: MutableRefObject<
+    ((opts?: { skipReload?: boolean }) => Promise<void>) | undefined
+  >;
+}
+
+/**
+ * Loads persisted chat messages (history selection / tab restore) and exposes
+ * the same fetch+convert+set pipeline to the resume manager via
+ * `loadPersistedMessagesRef`.
+ */
+export function useChatSessionLoader({
+  chatId,
+  isExistingChat,
+  workspaceId,
+  setMessages,
+  messagesRef,
+  workspaceIdRef,
+  chatIdRef,
+  virtuosoRef,
+  capturedConsoleIdRef,
+  handledConsoleOpenToolCallIdsRef,
+  toolDispatchGateRef,
+  loadPersistedMessagesRef,
+  requestResumeRef,
+}: UseChatSessionLoaderArgs): void {
+  // Fetch the persisted chat and swap it into the hook state. Shared by the
+  // history-load effect below and the resume manager's reload-before-replay
+  // path (which must reset the in-memory assistant message before a replay
+  // appends onto it). Reads chatId/workspaceId from refs at call time and
+  // re-checks after every await so a slow fetch can never clobber a
+  // different chat's state.
+  loadPersistedMessagesRef.current = async (opts?: {
+    forHistoryLoad?: boolean;
+  }): Promise<boolean> => {
+    const currentWorkspaceId = workspaceIdRef.current;
+    const targetChatId = chatIdRef.current;
+    if (!currentWorkspaceId || !targetChatId) return false;
+    try {
+      const { data: payload, response } = await api.GET(
+        "/api/workspaces/{workspaceId}/chats/{id}",
+        {
+          params: {
+            path: { workspaceId: currentWorkspaceId, id: targetChatId },
+          },
+        },
+      );
+      if (chatIdRef.current !== targetChatId) return false;
+      if (!response.ok || !payload) return false;
+      // The chat payload (messages/consoles) is spec-typed as a generic JSON
+      // envelope; keep the loose shape the converter expects.
+      const data = payload as {
+        messages?: unknown[];
+        consoles?: Array<{ id: string }>;
+        activeStreamId?: string | null;
+      };
+      if (chatIdRef.current !== targetChatId) return false;
+
+      const rawMessages = (data.messages ?? []) as Array<{
+        role?: string;
+        parts?: Array<Record<string, unknown>> | null;
+      }>;
+
+      // Reload-before-replay only: never step the live in-memory state
+      // backwards to a stale snapshot (persistence is per-segment and async;
+      // around a segment boundary the server can lag the client). The resume
+      // replay is still safe without the reload — the dispatch gate blocks
+      // re-execution and the persist-time dedupe strips duplicate text.
+      if (
+        !opts?.forHistoryLoad &&
+        isPersistedSnapshotStale(rawMessages, messagesRef.current)
+      ) {
+        return false;
+      }
+
+      // Convert stored messages to AI SDK format with parts including tool
+      // calls (for UI display — the backend sanitizes them before sending to
+      // the AI to avoid "tool_use without tool_result" errors). While the
+      // turn is still generating server-side (activeStreamId set), the
+      // snapshot can lag the live state, so non-terminal tool parts are left
+      // PENDING for the resume replay / orphan rescue to settle — patching
+      // them to "Interrupted" here poisoned settled tools and the next send
+      // persisted the poison over the server's correct finalization.
+      const convertedMessages = convertStoredMessages(
+        data.messages as unknown[],
+        { turnActive: Boolean(data.activeStreamId) },
+      );
+
+      // Restored tool parts must not re-trigger the in-band console
+      // opener (only LIVE streamed results should); the consoles-restore
+      // payload below already reopens what matters.
+      for (const msg of convertedMessages) {
+        for (const part of msg.parts ?? []) {
+          const toolCallId = (part as { toolCallId?: string }).toolCallId;
+          if (toolCallId) {
+            handledConsoleOpenToolCallIdsRef.current.add(toolCallId);
+          }
+        }
+      }
+
+      // Seed the dispatch gate from the RAW persisted parts: tool calls that
+      // completed in a previous page instance must not be re-executed by a
+      // resumed-stream replay. Raw states on purpose — the converter rewrites
+      // interrupted parts to output-error, and seeding those would block the
+      // legitimate post-refresh re-dispatch of a tool that never got to run.
+      toolDispatchGateRef.current.seedFromPersistedMessages(
+        (data.messages ?? []) as Array<{
+          role?: string;
+          parts?: Array<Record<string, unknown>> | null;
+        }>,
+      );
+
+      setMessages(convertedMessages as unknown as UIMessage[]);
+
+      if (opts?.forHistoryLoad) {
+        // Virtuoso keeps ONE instance across chat switches (Chat isn't keyed
+        // by chatId), so its `initialTopMostItemIndex` — read once at mount —
+        // never re-applies when we bulk-load a different chat's history here.
+        // Without this, opening an existing chat from history can land
+        // mid-list or at the top. Pin to the newest message on the next
+        // frame (after the new data has rendered) so it deterministically
+        // opens at the bottom, matching the old stick-to-bottom behavior.
+        if (convertedMessages.length > 0) {
+          requestAnimationFrame(() => {
+            if (chatIdRef.current !== targetChatId) return;
+            virtuosoRef.current?.scrollToIndex({
+              index: "LAST",
+              align: "end",
+            });
+          });
+        }
+
+        // Restore consoles that were modified by the agent in this chat
+        // The backend extracts console IDs from modify_console tool calls in
+        // the messages and fetches those consoles from the database
+        if (data.consoles && data.consoles.length > 0) {
+          const store = useConsoleStore.getState();
+          for (const console of data.consoles) {
+            // Check if console already exists in tabs (by ID)
+            const exists = Boolean(store.tabs[console.id]);
+            if (!exists) {
+              await store.openConsoleFromServer(currentWorkspaceId, console.id);
+            }
+          }
+
+          // Set the first restored console as active and capture it for this chat
+          const firstConsole = data.consoles[0];
+          if (firstConsole) {
+            store.setActiveTab(firstConsole.id);
+            capturedConsoleIdRef.current = firstConsole.id;
+          }
+        }
+      }
+
+      return true;
+    } catch {
+      /* ignore */
+      return false;
+    }
+  };
+
+  // Load messages when selecting an existing chat from history
+  useEffect(() => {
+    // Flipped when this effect is superseded (chat switched / unmount) so a
+    // slow load can't resume the wrong chat. (State staleness is handled
+    // inside loadPersistedMessages via chatId re-checks.)
+    let cancelled = false;
+    const loadSession = async () => {
+      if (!isExistingChat || !workspaceId) {
+        return;
+      }
+      await loadPersistedMessagesRef.current?.({ forHistoryLoad: true });
+
+      // Reattach to a still-generating turn AFTER the persisted messages are
+      // in place: the resumable SSE replay only contains this turn's
+      // assistant chunks, so loading first yields the full conversation and
+      // avoids setMessages clobbering an in-flight replay (skipReload — this
+      // effect just loaded). The server answers 204 when the chat is idle
+      // (or unknown), making this a cheap no-op.
+      if (!cancelled) {
+        void requestResumeRef.current?.({ skipReload: true });
+      }
+    };
+    loadSession();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    chatId,
+    isExistingChat,
+    workspaceId,
+    loadPersistedMessagesRef,
+    requestResumeRef,
+  ]);
+}

--- a/app/src/components/chat/hooks/useChatSessions.ts
+++ b/app/src/components/chat/hooks/useChatSessions.ts
@@ -1,0 +1,129 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type MutableRefObject,
+} from "react";
+import { api } from "../../../api/client";
+import { useRealtimeStore } from "../../../store/realtimeStore";
+
+export interface ChatSessionMeta {
+  _id: string;
+  title: string;
+  createdAt?: string;
+  updatedAt?: string;
+  /** Resume pointer set while a turn is generating server-side. */
+  activeStreamId?: string | null;
+}
+
+export interface UseChatSessionsArgs {
+  workspaceId: string | undefined;
+}
+
+/**
+ * Chat session list for the history menu: fetch, live streaming indicator,
+ * delete, and the menu anchor state. Selecting/creating a session is
+ * cross-cutting orchestration (queue, gate, messages) and stays in Chat.tsx.
+ */
+export function useChatSessions({ workspaceId }: UseChatSessionsArgs): {
+  sessions: ChatSessionMeta[];
+  /** Latest fetch — useChat's onFinish refreshes the list through this ref. */
+  fetchSessionsRef: MutableRefObject<(() => Promise<void>) | undefined>;
+  isSessionStreaming: (session: ChatSessionMeta) => boolean;
+  /** Deletes the session server-side; resolves true on success. */
+  deleteSession: (id: string) => Promise<boolean>;
+  historyMenuAnchor: HTMLElement | null;
+  historyMenuOpen: boolean;
+  handleHistoryMenuOpen: (event: React.MouseEvent<HTMLElement>) => void;
+  handleHistoryMenuClose: () => void;
+} {
+  const [sessions, setSessions] = useState<ChatSessionMeta[]>([]);
+  const [historyMenuAnchor, setHistoryMenuAnchor] =
+    useState<null | HTMLElement>(null);
+  const historyMenuOpen = Boolean(historyMenuAnchor);
+
+  // Ref-based so useChat's onFinish (declared before this hook's consumers
+  // re-render) always reaches the current workspace.
+  const fetchSessionsRef = useRef<() => Promise<void>>();
+  fetchSessionsRef.current = async () => {
+    if (!workspaceId) return;
+    try {
+      const { data, response } = await api.GET(
+        "/api/workspaces/{workspaceId}/chats",
+        { params: { path: { workspaceId } } },
+      );
+      if (response.ok && Array.isArray(data)) {
+        setSessions(data as ChatSessionMeta[]);
+      }
+    } catch {
+      /* ignore */
+    }
+  };
+
+  // Fetch available chat sessions when the workspace resolves/changes.
+  useEffect(() => {
+    void fetchSessionsRef.current?.();
+  }, [workspaceId]);
+
+  // Live per-chat activity from the realtime channel. The server-fetched
+  // activeStreamId is the initial value (correct on cold open); chat.activity
+  // events keep it current while the menu is open — including turns started
+  // by other windows or continuing server-side after a detach.
+  const chatActivity = useRealtimeStore(s => s.chatActivity);
+  const isSessionStreaming = useCallback(
+    (session: ChatSessionMeta): boolean => {
+      const live = chatActivity[session._id];
+      if (live === "streaming") return true;
+      if (live === "idle") return false;
+      return Boolean(session.activeStreamId);
+    },
+    [chatActivity],
+  );
+
+  const deleteSession = useCallback(
+    async (id: string): Promise<boolean> => {
+      if (!workspaceId) return false;
+      try {
+        const { response } = await api.DELETE(
+          "/api/workspaces/{workspaceId}/chats/{id}",
+          { params: { path: { workspaceId, id } } },
+        );
+        if (response.ok) {
+          setSessions(prev => prev.filter(s => s._id !== id));
+          return true;
+        }
+      } catch {
+        /* ignore */
+      }
+      return false;
+    },
+    [workspaceId],
+  );
+
+  const handleHistoryMenuOpen = useCallback(
+    (event: React.MouseEvent<HTMLElement>) => {
+      setHistoryMenuAnchor(event.currentTarget);
+      // The list goes stale the moment a new chat starts a turn (the doc is
+      // created server-side at turn start) — refresh it on every open so
+      // in-flight chats appear immediately with their streaming indicator.
+      void fetchSessionsRef.current?.();
+    },
+    [],
+  );
+
+  const handleHistoryMenuClose = useCallback(() => {
+    setHistoryMenuAnchor(null);
+  }, []);
+
+  return {
+    sessions,
+    fetchSessionsRef,
+    isSessionStreaming,
+    deleteSession,
+    historyMenuAnchor,
+    historyMenuOpen,
+    handleHistoryMenuOpen,
+    handleHistoryMenuClose,
+  };
+}

--- a/app/src/components/chat/hooks/useClientToolDispatch.ts
+++ b/app/src/components/chat/hooks/useClientToolDispatch.ts
@@ -1,0 +1,809 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type MutableRefObject,
+  type RefObject,
+} from "react";
+import type { UseChatHelpers } from "@ai-sdk/react";
+import type { UIMessage } from "ai";
+import { useConsoleStore } from "../../../store/consoleStore";
+import { generateObjectId } from "../../../utils/objectId";
+import { executeConsoleAgentTool } from "../../../agent-runtime/console-agent-tools";
+import { executeDashboardAgentTool } from "../../../dashboard-runtime/agent-tools";
+import { executeAppAgentTool } from "../../../app-runtime/agent-tools";
+import { executeDbtAgentTool } from "../../../dbt-runtime/agent-tools";
+import { executeDataSourceTool } from "../../../agent-runtime/data-source-tools";
+import {
+  DASHBOARD_EXECUTOR_TOOL_NAMES,
+  APP_EXECUTOR_TOOL_NAMES,
+  DBT_EXECUTOR_TOOL_NAMES,
+  DATA_SOURCE_EXECUTOR_TOOL_NAMES,
+  getAgentToolManifestEntry,
+  type AgentToolName,
+} from "../../../agent-runtime/client-tool-manifest";
+import {
+  isHumanInTheLoopToolPartType,
+  reportStreamInterruption,
+  toolNameFromPartType,
+} from "../tool-presentation";
+import type { DbFlowFormRef } from "../../DbFlowForm";
+import type {
+  ClientToolRegistry,
+  AddToolOutputFn,
+} from "./useClientToolRegistry";
+
+type ChatHelpers = UseChatHelpers<UIMessage>;
+
+/** The fields of the SDK's onToolCall payload the dispatcher reads. */
+export interface DispatchableToolCall {
+  toolCallId: string;
+  toolName: string;
+  input?: unknown;
+  dynamic?: boolean;
+}
+
+export interface UseClientToolDispatchArgs {
+  registry: Pick<
+    ClientToolRegistry,
+    | "activeClientToolCallsRef"
+    | "toolDispatchGateRef"
+    | "activeClientToolCallCount"
+    | "registerActiveClientToolCall"
+    | "settleActiveClientToolCall"
+  >;
+  addToolOutputRef: MutableRefObject<AddToolOutputFn | undefined>;
+  manualStopRequestedRef: MutableRefObject<boolean>;
+  workspaceIdRef: MutableRefObject<string | undefined>;
+  onChartSpecChangeRef?: MutableRefObject<
+    | ((payload: import("../../Editor").ChartSpecChangePayload) => void)
+    | undefined
+  >;
+  dbFlowFormRefCurrent: MutableRefObject<
+    RefObject<DbFlowFormRef | null> | undefined
+  >;
+  // Reactive values for the orphan-rescue effect.
+  status: ChatHelpers["status"];
+  messages: ChatHelpers["messages"];
+  chatId: string;
+  setMessages: ChatHelpers["setMessages"];
+  /**
+   * Refetch persisted messages (session loader's shared pipeline). The
+   * orphan-rescue effect tries this FIRST for stuck tool parts: a pending
+   * part is often just a lagging local copy of a tool that already settled
+   * (mid-turn reload raced the per-segment persistence), and the server's
+   * finalization holds the correct terminal state.
+   */
+  loadPersistedMessagesRef: MutableRefObject<
+    ((opts?: { forHistoryLoad?: boolean }) => Promise<boolean>) | undefined
+  >;
+}
+
+/**
+ * Client-side tool dispatch: the `onToolCall` body (executor routing for
+ * console/dashboard/app/dbt/data-source/flow tools), the orphan recovery
+ * re-dispatch, and the orphan-rescue effect. All dispatch flows through the
+ * registry's ToolDispatchGate so a replayed or re-delivered tool call can
+ * never execute twice.
+ */
+export function useClientToolDispatch({
+  registry,
+  addToolOutputRef,
+  manualStopRequestedRef,
+  workspaceIdRef,
+  onChartSpecChangeRef,
+  dbFlowFormRefCurrent,
+  status,
+  messages,
+  chatId,
+  setMessages,
+  loadPersistedMessagesRef,
+}: UseClientToolDispatchArgs) {
+  const {
+    activeClientToolCallsRef,
+    toolDispatchGateRef,
+    activeClientToolCallCount,
+    registerActiveClientToolCall,
+    settleActiveClientToolCall,
+  } = registry;
+
+  const onToolCall = useCallback(
+    async (toolCall: DispatchableToolCall): Promise<void> => {
+      // Latest addToolOutput (assigned by Chat.tsx right after useChat).
+      const addToolOutput: AddToolOutputFn = payload => {
+        void addToolOutputRef.current?.(payload);
+      };
+
+      // Skip dynamic tools (not our console tools)
+      if (toolCall.dynamic) {
+        return;
+      }
+
+      const toolName = toolCall.toolName;
+      const input = toolCall.input as Record<string, unknown>;
+
+      // Deferred plan-lifecycle tools: do NOT settle here. The interactive
+      // card rendered in the message list resolves them via addToolOutput once
+      // the user answers / approves. Returning without output keeps the tool
+      // call pending (human-in-the-loop) until then.
+      if (
+        toolName === "ask_clarifying_questions" ||
+        toolName === "submit_plan"
+      ) {
+        return;
+      }
+
+      // Dedupe by toolCallId: resumable-stream replays (resumeStream after a
+      // wake/refresh/error) and additional concurrent stream consumers
+      // re-deliver `tool-input-available` chunks for calls this page already
+      // dispatched. The tool PART merges by id so the transcript looks fine,
+      // but re-dispatching re-runs the side effect — one create_dashboard call
+      // must never create two dashboards.
+      if (!toolDispatchGateRef.current.markDispatched(toolCall.toolCallId)) {
+        return;
+      }
+
+      try {
+        if (
+          await executeConsoleAgentTool({
+            toolCall: {
+              toolName,
+              toolCallId: toolCall.toolCallId,
+            },
+            input,
+            workspaceId: workspaceIdRef.current,
+            onChartSpecChange: onChartSpecChangeRef?.current,
+            addToolOutput,
+            registerActiveClientToolCall,
+            settleActiveClientToolCall,
+          })
+        ) {
+          return;
+        }
+
+        // --- Dashboard tools (client-side) ---
+        if (DASHBOARD_EXECUTOR_TOOL_NAMES.has(toolName as AgentToolName)) {
+          const activeDashboardTool = registerActiveClientToolCall(
+            toolName,
+            toolCall.toolCallId,
+          );
+
+          // Fire-and-forget for ALL dashboard client work, never await it here.
+          // The AI SDK awaits onToolCall while reading the SSE stream, and only
+          // sends the follow-up request with the tool output once the stream
+          // reaches its finish chunk. Awaiting any client work inside
+          // onToolCall blocks the reader from processing that finish chunk, so
+          // the continuation hangs until the HTTP/proxy stream times out — even
+          // for tools that resolve in milliseconds (e.g. remove_widget,
+          // get_dashboard_state). Settling asynchronously lets the finish chunk
+          // be read immediately and the stream close cleanly.
+          void (async () => {
+            try {
+              const dashboardToolOutput = await executeDashboardAgentTool(
+                toolName,
+                input,
+                {
+                  executionId: activeDashboardTool.executionId,
+                  signal: activeDashboardTool.abortController.signal,
+                  // Server-side idempotency: another window attached to the
+                  // same stream may execute this exact call too.
+                  toolCallId: toolCall.toolCallId,
+                },
+              );
+
+              if (activeDashboardTool.abortController.signal.aborted) {
+                return;
+              }
+
+              void settleActiveClientToolCall(
+                toolName,
+                toolCall.toolCallId,
+                dashboardToolOutput ?? {
+                  success: false,
+                  error: `Dashboard tool "${toolName}" did not return a result.`,
+                },
+              );
+            } catch (dashboardError) {
+              if (
+                manualStopRequestedRef.current ||
+                activeDashboardTool.abortController.signal.aborted
+              ) {
+                return;
+              }
+              void settleActiveClientToolCall(toolName, toolCall.toolCallId, {
+                success: false,
+                error:
+                  dashboardError instanceof Error
+                    ? dashboardError.message
+                    : "Dashboard tool execution failed",
+              });
+            }
+          })();
+          return;
+        }
+
+        // --- React App tools (client-side) ---
+        if (APP_EXECUTOR_TOOL_NAMES.has(toolName as AgentToolName)) {
+          const activeAppTool = registerActiveClientToolCall(
+            toolName,
+            toolCall.toolCallId,
+          );
+
+          // Fire-and-forget, same rationale as dashboard tools above: never
+          // await client work inside onToolCall or the SSE finish chunk stalls.
+          void (async () => {
+            try {
+              const appToolOutput = await executeAppAgentTool(toolName, input, {
+                executionId: activeAppTool.executionId,
+                signal: activeAppTool.abortController.signal,
+              });
+
+              if (activeAppTool.abortController.signal.aborted) return;
+
+              void settleActiveClientToolCall(
+                toolName,
+                toolCall.toolCallId,
+                appToolOutput ?? {
+                  success: false,
+                  error: `App tool "${toolName}" did not return a result.`,
+                },
+              );
+            } catch (appError) {
+              if (
+                manualStopRequestedRef.current ||
+                activeAppTool.abortController.signal.aborted
+              ) {
+                return;
+              }
+              void settleActiveClientToolCall(toolName, toolCall.toolCallId, {
+                success: false,
+                error:
+                  appError instanceof Error
+                    ? appError.message
+                    : "App tool execution failed",
+              });
+            }
+          })();
+          return;
+        }
+
+        // --- dbt tools (client-side) ---
+        if (DBT_EXECUTOR_TOOL_NAMES.has(toolName as AgentToolName)) {
+          const activeDbtTool = registerActiveClientToolCall(
+            toolName,
+            toolCall.toolCallId,
+          );
+          // Fire-and-forget, same rationale as app tools above.
+          void (async () => {
+            try {
+              const dbtToolOutput = await executeDbtAgentTool(toolName, input);
+              if (activeDbtTool.abortController.signal.aborted) return;
+              void settleActiveClientToolCall(
+                toolName,
+                toolCall.toolCallId,
+                dbtToolOutput ?? {
+                  success: false,
+                  error: `dbt tool "${toolName}" did not return a result.`,
+                },
+              );
+            } catch (dbtError) {
+              if (
+                manualStopRequestedRef.current ||
+                activeDbtTool.abortController.signal.aborted
+              ) {
+                return;
+              }
+              void settleActiveClientToolCall(toolName, toolCall.toolCallId, {
+                success: false,
+                error:
+                  dbtError instanceof Error
+                    ? dbtError.message
+                    : "dbt tool execution failed",
+              });
+            }
+          })();
+          return;
+        }
+
+        // --- Shared data source tools (apps + dashboards) ---
+        if (DATA_SOURCE_EXECUTOR_TOOL_NAMES.has(toolName as AgentToolName)) {
+          const activeDataTool = registerActiveClientToolCall(
+            toolName,
+            toolCall.toolCallId,
+          );
+          void (async () => {
+            try {
+              const output = await executeDataSourceTool(toolName, input);
+              if (activeDataTool.abortController.signal.aborted) return;
+              void settleActiveClientToolCall(
+                toolName,
+                toolCall.toolCallId,
+                output ?? {
+                  success: false,
+                  error: `Data source tool "${toolName}" did not return a result.`,
+                },
+              );
+            } catch (dataError) {
+              if (
+                manualStopRequestedRef.current ||
+                activeDataTool.abortController.signal.aborted
+              ) {
+                return;
+              }
+              void settleActiveClientToolCall(toolName, toolCall.toolCallId, {
+                success: false,
+                error:
+                  dataError instanceof Error
+                    ? dataError.message
+                    : "Data source tool execution failed",
+              });
+            }
+          })();
+          return;
+        }
+
+        // Handle flow agent client-side tools
+        // get_form_state - Return current form configuration
+        if (toolName === "get_form_state") {
+          const formRef = dbFlowFormRefCurrent.current?.current;
+          if (!formRef) {
+            addToolOutput({
+              tool: "get_form_state",
+              toolCallId: toolCall.toolCallId,
+              output: {
+                success: false,
+                error:
+                  "Form is not available. Make sure you're in the flow editor.",
+              },
+            });
+            return;
+          }
+
+          const formState = formRef.getFormState();
+          addToolOutput({
+            tool: "get_form_state",
+            toolCallId: toolCall.toolCallId,
+            output: {
+              success: true,
+              formState,
+            },
+          });
+          return;
+        }
+
+        // set_form_field - Update a single form field
+        if (toolName === "set_form_field") {
+          const formRef = dbFlowFormRefCurrent.current?.current;
+          if (!formRef) {
+            addToolOutput({
+              tool: "set_form_field",
+              toolCallId: toolCall.toolCallId,
+              output: {
+                success: false,
+                error:
+                  "Form is not available. Make sure you're in the flow editor.",
+              },
+            });
+            return;
+          }
+
+          const { fieldName, value } = input as {
+            fieldName: string;
+            value: unknown;
+          };
+
+          // The tool schema uses a structured z.union() instead of z.any(),
+          // so the LLM returns proper typed values (arrays as arrays, not strings).
+          // See: TYPE_COERCION_SCHEMA in db-flow-form.schema.ts
+          formRef.setField(fieldName, value);
+          addToolOutput({
+            tool: "set_form_field",
+            toolCallId: toolCall.toolCallId,
+            output: {
+              success: true,
+              fieldName,
+              value,
+              message: `Updated ${fieldName} successfully`,
+            },
+          });
+          return;
+        }
+
+        // set_multiple_fields - Update multiple fields at once
+        if (toolName === "set_multiple_fields") {
+          const formRef = dbFlowFormRefCurrent.current?.current;
+          if (!formRef) {
+            addToolOutput({
+              tool: "set_multiple_fields",
+              toolCallId: toolCall.toolCallId,
+              output: {
+                success: false,
+                error:
+                  "Form is not available. Make sure you're in the flow editor.",
+              },
+            });
+            return;
+          }
+
+          const { fields } = input as { fields: Record<string, unknown> };
+          formRef.setMultipleFields(fields);
+          addToolOutput({
+            tool: "set_multiple_fields",
+            toolCallId: toolCall.toolCallId,
+            output: {
+              success: true,
+              fields: Object.keys(fields),
+              message: `Updated ${Object.keys(fields).length} field(s) successfully`,
+            },
+          });
+          return;
+        }
+
+        // NOTE: set_column_mappings has been removed
+        // Use set_form_field with fieldName="typeCoercions" instead
+
+        // create_flow_tab - Create a new db-scheduled flow tab
+        if (toolName === "create_flow_tab") {
+          const currentStore = useConsoleStore.getState();
+          const title = (input.title as string) || "New Database Sync";
+
+          // Generate a new ID and create the flow tab
+          const newTabId = generateObjectId();
+          currentStore.openTab({
+            id: newTabId,
+            title,
+            content: "",
+            kind: "flow-editor",
+            metadata: { isNew: true, flowType: "db-scheduled" },
+          });
+          currentStore.setActiveTab(newTabId);
+
+          addToolOutput({
+            tool: "create_flow_tab",
+            toolCallId: toolCall.toolCallId,
+            output: {
+              success: true,
+              tabId: newTabId,
+              title,
+              message: `Created new flow tab "${title}"`,
+            },
+          });
+          return;
+        }
+
+        // list_flow_tabs - List all open flow editor tabs
+        if (toolName === "list_flow_tabs") {
+          const currentStore = useConsoleStore.getState();
+          const currentTabs = Object.values(currentStore.tabs);
+          const currentActiveId = currentStore.activeTabId;
+
+          const flowTabs = currentTabs
+            .filter((tab: any) => tab?.kind === "flow-editor")
+            .map((tab: any) => ({
+              id: tab.id,
+              title: tab.title || "Untitled Flow",
+              flowType: tab.metadata?.flowType || "unknown",
+              flowId: tab.metadata?.flowId,
+              isNew: tab.metadata?.isNew || false,
+              isActive: tab.id === currentActiveId,
+            }));
+
+          addToolOutput({
+            tool: "list_flow_tabs",
+            toolCallId: toolCall.toolCallId,
+            output: {
+              success: true,
+              flowTabs,
+              message: `Found ${flowTabs.length} open flow tab(s)`,
+            },
+          });
+          return;
+        }
+
+        const manifestEntry = getAgentToolManifestEntry(toolName);
+        if (manifestEntry?.execution === "client") {
+          addToolOutput({
+            tool: toolName,
+            toolCallId: toolCall.toolCallId,
+            output: {
+              success: false,
+              error: `Client-side tool "${toolName}" is registered but has no browser handler.`,
+            },
+          });
+          return;
+        }
+
+        // Unknown tool - not a client-side tool, let it be handled server-side
+      } catch (toolError) {
+        // Safety net: if any client-side tool throws an uncaught error,
+        // return the error to the LLM so the conversation doesn't hang.
+        addToolOutput({
+          tool: toolName,
+          toolCallId: toolCall.toolCallId,
+          output: {
+            success: false,
+            error:
+              toolError instanceof Error
+                ? toolError.message
+                : "Client-side tool execution failed unexpectedly",
+          },
+        });
+      }
+    },
+    [
+      addToolOutputRef,
+      manualStopRequestedRef,
+      workspaceIdRef,
+      onChartSpecChangeRef,
+      dbFlowFormRefCurrent,
+      toolDispatchGateRef,
+      registerActiveClientToolCall,
+      settleActiveClientToolCall,
+    ],
+  );
+
+  // Self-heal a client tool call that the live stream delivered but never got
+  // to dispatch (the SSE dropped, the SDK reconnected to a 204, and `status`
+  // settled to "ready" with the tool frozen at "input-available"). Because a
+  // completed run would be "output-available", a tool stuck at "input-available"
+  // provably never executed — so we can safely re-dispatch it through the exact
+  // same executor `onToolCall` would have used. Its result settles via
+  // `addToolOutput`, and `sendAutomaticallyWhen` resumes the turn, recovering
+  // transparently instead of poisoning the card with "Interrupted".
+  //
+  // Returns true if it took ownership of the call (recovering), false if the
+  // tool is not a client-executable family we can safely re-run (those still
+  // get the terminal error patch).
+  const recoveredToolCallIdsRef = useRef<Set<string>>(new Set());
+  const recoverOrphanedClientToolCall = useCallback(
+    (
+      toolName: string,
+      toolCallId: string,
+      input: Record<string, unknown>,
+    ): boolean => {
+      const name = toolName as AgentToolName;
+      let run:
+        | ((ctx: {
+            executionId: string;
+            signal: AbortSignal;
+          }) => Promise<Record<string, unknown> | null | undefined>)
+        | null = null;
+      if (APP_EXECUTOR_TOOL_NAMES.has(name)) {
+        run = ({ executionId, signal }) =>
+          executeAppAgentTool(toolName, input, { executionId, signal });
+      } else if (DASHBOARD_EXECUTOR_TOOL_NAMES.has(name)) {
+        run = ({ executionId, signal }) =>
+          executeDashboardAgentTool(toolName, input, {
+            executionId,
+            signal,
+            toolCallId,
+          });
+      } else if (DBT_EXECUTOR_TOOL_NAMES.has(name)) {
+        run = () => executeDbtAgentTool(toolName, input);
+      } else if (DATA_SOURCE_EXECUTOR_TOOL_NAMES.has(name)) {
+        run = () => executeDataSourceTool(toolName, input);
+      }
+      if (!run) return false;
+
+      // Already recovering this exact call (effect re-ran before it settled):
+      // keep ownership so it isn't poisoned, but don't dispatch twice.
+      if (recoveredToolCallIdsRef.current.has(toolCallId)) return true;
+
+      // A call this page instance already dispatched must NOT be re-run — its
+      // side effects may have landed even though the part looks stuck. Decline
+      // ownership so the poison path settles it instead.
+      if (toolDispatchGateRef.current.wasDispatched(toolCallId)) return false;
+
+      recoveredToolCallIdsRef.current.add(toolCallId);
+      // Recovery IS a dispatch: claim the id so a later stream replay of the
+      // same call can't run it a second time.
+      toolDispatchGateRef.current.markDispatched(toolCallId);
+
+      const active = registerActiveClientToolCall(toolName, toolCallId);
+      void (async () => {
+        try {
+          const output = await run({
+            executionId: active.executionId,
+            signal: active.abortController.signal,
+          });
+          if (active.abortController.signal.aborted) return;
+          await settleActiveClientToolCall(
+            toolName,
+            toolCallId,
+            output ?? {
+              success: false,
+              error: `Recovered tool "${toolName}" did not return a result.`,
+            },
+          );
+        } catch (recoverError) {
+          if (
+            manualStopRequestedRef.current ||
+            active.abortController.signal.aborted
+          ) {
+            return;
+          }
+          await settleActiveClientToolCall(toolName, toolCallId, {
+            success: false,
+            error:
+              recoverError instanceof Error
+                ? recoverError.message
+                : "Recovered tool execution failed",
+          });
+        } finally {
+          recoveredToolCallIdsRef.current.delete(toolCallId);
+        }
+      })();
+      return true;
+    },
+    [
+      manualStopRequestedRef,
+      toolDispatchGateRef,
+      registerActiveClientToolCall,
+      settleActiveClientToolCall,
+    ],
+  );
+
+  // Rescue tool cards orphaned by a clean stream end.
+  //
+  // A tool card's "Running…" status is derived purely from the AI SDK tool
+  // part `state` — it only resolves once a terminal `output-available` /
+  // `output-error` chunk arrives. `onError` patches stuck parts when the
+  // stream *throws* (e.g. a 524), and the history-load path rewrites them when
+  // a chat is reopened. But with resumable streams a long server-side tool can
+  // outlive the edge proxy's idle timeout: the SSE connection is closed, the
+  // SDK silently reconnects, the reconnect returns 204 ("nothing streaming"),
+  // and `status` settles back to "ready" without any error ever surfacing. The
+  // live in-memory message then keeps a tool part frozen at "input-available"
+  // → a permanent "Running…" card that also blocks the composer (the SDK won't
+  // accept a new message until every tool call is settled).
+  //
+  // Once the turn has settled (`status === "ready"`) and no client-side tool is
+  // still executing, any non-terminal tool part on the last assistant message
+  // is orphaned. Patch it to an error so the card resolves and input unblocks.
+  // Mirrors the `onError` rescue; uses `setMessages` (not `addToolOutput`) so
+  // it does not feed back into `sendAutomaticallyWhen` and kick off a new turn.
+  //
+  // Server-reconcile first: a pending part is often just a LAGGING LOCAL COPY
+  // of a tool that already settled (a mid-turn reload can load a per-segment
+  // snapshot older than the settle), while the server's finalization holds the
+  // correct terminal state. Refetch once per toolCallId before recovering /
+  // poisoning; only parts still pending after the refetch are treated as
+  // genuine orphans.
+  const reconcileAttemptedToolCallIdsRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    reconcileAttemptedToolCallIdsRef.current = new Set();
+  }, [chatId]);
+  const [rescueTick, setRescueTick] = useState(0);
+  useEffect(() => {
+    if (status !== "ready" || activeClientToolCallCount > 0) return;
+    if (activeClientToolCallsRef.current.size > 0) return;
+    const last = messages.at(-1);
+    if (!last || last.role !== "assistant") return;
+    // Human-in-the-loop tools (clarifying questions / plan review) are *meant*
+    // to sit at "input-available" with no output until the user answers via
+    // their docked card — that is not an orphan. Patching them here would tear
+    // the card down before it can be answered (it surfaces as "Interrupted —
+    // stream disconnected"). Leave them pending.
+    const pendingToolParts = (last.parts ?? []).filter(p => {
+      const pt = p.type as string;
+      if (!pt?.startsWith("tool-") && pt !== "dynamic-tool") return false;
+      if (isHumanInTheLoopToolPartType(pt)) return false;
+      const s = (p as Record<string, unknown>).state as string;
+      return s !== "output-available" && s !== "output-error" && s !== "error";
+    });
+    if (pendingToolParts.length === 0) return;
+
+    const unreconciled = pendingToolParts.filter(p => {
+      const id = (p as Record<string, unknown>).toolCallId;
+      return (
+        typeof id === "string" &&
+        id &&
+        !reconcileAttemptedToolCallIdsRef.current.has(id)
+      );
+    });
+    if (unreconciled.length > 0) {
+      for (const p of unreconciled) {
+        reconcileAttemptedToolCallIdsRef.current.add(
+          (p as Record<string, unknown>).toolCallId as string,
+        );
+      }
+      void (async () => {
+        const reloaded = await loadPersistedMessagesRef.current?.();
+        // A successful reload replaces `messages` and re-runs this effect
+        // (now past the reconcile step). When the reload was skipped (stale
+        // snapshot / fetch failure), nothing re-triggers the effect — bump a
+        // tick so the rescue below still runs for the genuine-orphan case.
+        if (!reloaded) setRescueTick(t => t + 1);
+      })();
+      return;
+    }
+
+    // Try to self-heal first: re-dispatch any client-executable tool stuck at
+    // "input-available". The IDs we recover keep their card alive (the
+    // re-dispatch registers an active client tool call) and must NOT be
+    // poisoned below.
+    const recoveredCallIds = new Set<string>();
+    const recoveredToolNames: string[] = [];
+    const orphanedToolNames: string[] = [];
+    for (const part of pendingToolParts) {
+      const record = part as Record<string, unknown>;
+      const pt = part.type as string;
+      const toolName =
+        pt === "dynamic-tool"
+          ? ((record.toolName as string) ?? "")
+          : toolNameFromPartType(pt);
+      const toolCallId = record.toolCallId as string | undefined;
+      const input = (record.input ?? {}) as Record<string, unknown>;
+      if (
+        record.state === "input-available" &&
+        toolCallId &&
+        recoverOrphanedClientToolCall(toolName, toolCallId, input)
+      ) {
+        recoveredCallIds.add(toolCallId);
+        recoveredToolNames.push(toolName);
+      } else {
+        orphanedToolNames.push(toolName);
+      }
+    }
+
+    reportStreamInterruption({
+      path: "orphan-rescue",
+      chatId,
+      status,
+      toolNames: orphanedToolNames,
+      recoveredToolNames,
+    });
+
+    // Nothing left to poison — everything is being recovered.
+    if (orphanedToolNames.length === 0) return;
+    setMessages(prev => {
+      const lastIndex = prev.length - 1;
+      const lastMsg = prev[lastIndex];
+      if (!lastMsg || lastMsg.role !== "assistant") return prev;
+      return prev.map((msg, i) => {
+        if (i !== lastIndex) return msg;
+        return {
+          ...msg,
+          parts: msg.parts.map(p => {
+            const record = p as Record<string, unknown>;
+            const pt = p.type as string;
+            if (!pt?.startsWith("tool-") && pt !== "dynamic-tool") return p;
+            if (isHumanInTheLoopToolPartType(pt)) return p;
+            // Leave parts we just handed to recovery untouched.
+            if (recoveredCallIds.has(record.toolCallId as string)) return p;
+            const s = record.state as string;
+            if (
+              s === "output-available" ||
+              s === "output-error" ||
+              s === "error"
+            ) {
+              return p;
+            }
+            return {
+              ...p,
+              state: "error" as const,
+              output: {
+                success: false,
+                error:
+                  "Interrupted — stream disconnected before tool completed",
+              },
+            };
+          }) as any,
+        };
+      });
+    });
+  }, [
+    status,
+    activeClientToolCallCount,
+    activeClientToolCallsRef,
+    messages,
+    chatId,
+    recoverOrphanedClientToolCall,
+    setMessages,
+    loadPersistedMessagesRef,
+    rescueTick,
+  ]);
+
+  return { onToolCall, recoverOrphanedClientToolCall };
+}

--- a/app/src/components/chat/hooks/useClientToolRegistry.ts
+++ b/app/src/components/chat/hooks/useClientToolRegistry.ts
@@ -1,0 +1,188 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type MutableRefObject,
+} from "react";
+import { generateObjectId } from "../../../utils/objectId";
+import { ToolDispatchGate } from "../tool-dispatch-gate";
+import type { ActiveClientToolCall } from "../tool-presentation";
+
+/** Matches useChat's addToolOutput for the fields the registry uses. */
+export type AddToolOutputFn = (payload: {
+  tool: string;
+  toolCallId: string;
+  output: Record<string, unknown>;
+}) => void | PromiseLike<void>;
+
+export interface UseClientToolRegistryArgs {
+  /**
+   * Latest useChat addToolOutput. A ref because the registry is created
+   * BEFORE useChat (its register/settle callbacks are captured by the
+   * onToolCall config); Chat.tsx assigns `.current` right after useChat.
+   */
+  addToolOutputRef: MutableRefObject<AddToolOutputFn | undefined>;
+  manualStopRequestedRef: MutableRefObject<boolean>;
+  /** Active chat — the dispatch gate resets when it changes. */
+  chatId: string;
+}
+
+/**
+ * Tracks client-side tool executions in flight (abort/cancel plumbing +
+ * "is anything running" count) and owns the per-chat dispatch dedupe gate.
+ */
+export function useClientToolRegistry({
+  addToolOutputRef,
+  manualStopRequestedRef,
+  chatId,
+}: UseClientToolRegistryArgs) {
+  const activeClientToolCallsRef = useRef(
+    new Map<string, ActiveClientToolCall>(),
+  );
+  const cancelledClientToolCallIdsRef = useRef(new Set<string>());
+  // Dispatch dedupe by toolCallId (see ToolDispatchGate). Resumable-stream
+  // replays and concurrent stream consumers re-deliver `tool-input-available`
+  // chunks for calls this page already dispatched — without this gate a single
+  // create_dashboard call executed once per consumer (the triplicate-dashboard
+  // incident). Reset on chat switch; the session loader seeds it from raw
+  // history.
+  const toolDispatchGateRef = useRef(new ToolDispatchGate());
+  useEffect(() => {
+    toolDispatchGateRef.current.reset();
+  }, [chatId]);
+
+  const [activeClientToolCallCount, setActiveClientToolCallCount] = useState(0);
+
+  const createCancellationOutput = useCallback(
+    (toolName: string): Record<string, unknown> => ({
+      success: false,
+      error:
+        toolName === "run_console"
+          ? "Query cancelled because the chat stopped."
+          : "Tool cancelled because the chat stopped.",
+    }),
+    [],
+  );
+
+  const registerActiveClientToolCall = useCallback(
+    (
+      toolName: string,
+      toolCallId: string,
+      options?: {
+        executionId?: string;
+        cancel?: () => void | Promise<void>;
+        cancellationOutput?: Record<string, unknown>;
+      },
+    ) => {
+      const abortController = new AbortController();
+      const executionId =
+        options?.executionId ?? `chat-tool-${generateObjectId()}`;
+
+      cancelledClientToolCallIdsRef.current.delete(toolCallId);
+      activeClientToolCallsRef.current.set(toolCallId, {
+        toolCallId,
+        toolName,
+        executionId,
+        abortController,
+        cancel: options?.cancel ?? (() => {}),
+        cancellationOutput:
+          options?.cancellationOutput ?? createCancellationOutput(toolName),
+        settled: false,
+      });
+      setActiveClientToolCallCount(activeClientToolCallsRef.current.size);
+
+      return { abortController, executionId };
+    },
+    [createCancellationOutput],
+  );
+
+  const settleActiveClientToolCall = useCallback(
+    async (
+      toolName: string,
+      toolCallId: string,
+      output: Record<string, unknown>,
+    ): Promise<void> => {
+      if (cancelledClientToolCallIdsRef.current.delete(toolCallId)) {
+        return;
+      }
+
+      const activeToolCall = activeClientToolCallsRef.current.get(toolCallId);
+      if (!activeToolCall) {
+        if (!manualStopRequestedRef.current) {
+          await addToolOutputRef.current?.({
+            tool: toolName,
+            toolCallId,
+            output,
+          });
+        }
+        return;
+      }
+
+      try {
+        if (!activeToolCall.settled) {
+          activeToolCall.settled = true;
+          await addToolOutputRef.current?.({
+            tool: activeToolCall.toolName,
+            toolCallId,
+            output,
+          });
+        }
+      } finally {
+        activeClientToolCallsRef.current.delete(toolCallId);
+        setActiveClientToolCallCount(activeClientToolCallsRef.current.size);
+      }
+    },
+    [addToolOutputRef, manualStopRequestedRef],
+  );
+
+  const cancelActiveClientToolCalls = useCallback((reason: string): void => {
+    for (const activeToolCall of activeClientToolCallsRef.current.values()) {
+      cancelledClientToolCallIdsRef.current.add(activeToolCall.toolCallId);
+      activeToolCall.abortController.abort(reason);
+      activeToolCall.settled = true;
+      void Promise.resolve(activeToolCall.cancel()).catch(() => undefined);
+    }
+
+    activeClientToolCallsRef.current.clear();
+    setActiveClientToolCallCount(0);
+  }, []);
+
+  /**
+   * Interrupt path (manual stop / force-send): abort every in-flight client
+   * tool AND settle it with its cancellation output so the SDK's "all tool
+   * calls answered" invariant holds for the next sendMessage.
+   */
+  const interruptActiveClientToolCalls = useCallback((): void => {
+    for (const activeToolCall of activeClientToolCallsRef.current.values()) {
+      cancelledClientToolCallIdsRef.current.add(activeToolCall.toolCallId);
+      activeToolCall.abortController.abort("chat-stop");
+      void Promise.resolve(activeToolCall.cancel()).catch(() => undefined);
+
+      if (!activeToolCall.settled) {
+        activeToolCall.settled = true;
+        void addToolOutputRef.current?.({
+          tool: activeToolCall.toolName,
+          toolCallId: activeToolCall.toolCallId,
+          output: activeToolCall.cancellationOutput,
+        });
+      }
+    }
+
+    activeClientToolCallsRef.current.clear();
+    setActiveClientToolCallCount(0);
+  }, [addToolOutputRef]);
+
+  return {
+    activeClientToolCallsRef,
+    cancelledClientToolCallIdsRef,
+    toolDispatchGateRef,
+    activeClientToolCallCount,
+    registerActiveClientToolCall,
+    settleActiveClientToolCall,
+    cancelActiveClientToolCalls,
+    interruptActiveClientToolCalls,
+  };
+}
+
+export type ClientToolRegistry = ReturnType<typeof useClientToolRegistry>;

--- a/app/src/components/chat/hooks/useQueuedPrompts.ts
+++ b/app/src/components/chat/hooks/useQueuedPrompts.ts
@@ -1,0 +1,366 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MutableRefObject,
+} from "react";
+import type { UseChatHelpers } from "@ai-sdk/react";
+import type { FileUIPart, UIMessage } from "ai";
+import { useConsoleStore } from "../../../store/consoleStore";
+import type { ConsoleTab } from "../../../store/lib/types";
+import { usePlanStore } from "../../../store/planStore";
+import { generateObjectId } from "../../../utils/objectId";
+import { trackEvent } from "../../../lib/analytics";
+import {
+  hasPendingAssistantToolCalls,
+  type AutoSendPredicateArgs,
+} from "../tool-presentation";
+import type { QueuedPrompt } from "../QueuedPrompts";
+
+type ChatHelpers = UseChatHelpers<UIMessage>;
+
+export interface UseQueuedPromptsArgs {
+  chatId: string;
+  status: ChatHelpers["status"];
+  isLoading: boolean;
+  activeClientToolCallCount: number;
+  isLoadingRef: MutableRefObject<boolean>;
+  manualStopRequestedRef: MutableRefObject<boolean>;
+  messagesRef: MutableRefObject<ChatHelpers["messages"]>;
+  sendMessageRef: MutableRefObject<ChatHelpers["sendMessage"] | undefined>;
+  modelIdRef: MutableRefObject<string | undefined>;
+  capturedConsoleIdRef: MutableRefObject<string | null>;
+  capturedDashboardIdRef: MutableRefObject<string | null>;
+  activeConsoleIdRef: MutableRefObject<string | null>;
+  pendingPlanToolCallIdRef: MutableRefObject<string | null>;
+  autoSendWhenComplete: (options: AutoSendPredicateArgs) => boolean;
+  interruptActiveTurn: () => void;
+  /**
+   * Declared in Chat.tsx (useChat's onFinish drains through it before this
+   * hook runs); this hook assigns the implementation.
+   */
+  drainQueuedPromptAfterTurnRef: MutableRefObject<(() => void) | null>;
+}
+
+/**
+ * Prompt queue (Cursor-style): prompts typed while the agent is busy queue up
+ * and drain one at a time when the turn settles, with in-composer editing and
+ * force-send (interrupt + send now).
+ */
+export function useQueuedPrompts({
+  chatId,
+  status,
+  isLoading,
+  activeClientToolCallCount,
+  isLoadingRef,
+  manualStopRequestedRef,
+  messagesRef,
+  sendMessageRef,
+  modelIdRef,
+  capturedConsoleIdRef,
+  capturedDashboardIdRef,
+  activeConsoleIdRef,
+  pendingPlanToolCallIdRef,
+  autoSendWhenComplete,
+  interruptActiveTurn,
+  drainQueuedPromptAfterTurnRef,
+}: UseQueuedPromptsArgs) {
+  const [queuedPrompts, setQueuedPrompts] = useState<QueuedPrompt[]>([]);
+  const queuedPromptsRef = useRef(queuedPrompts);
+  queuedPromptsRef.current = queuedPrompts;
+  // Id of the queued prompt currently being edited in the composer (Cursor-style).
+  const [editingPromptId, setEditingPromptId] = useState<string | null>(null);
+  const editingPromptIdRef = useRef<string | null>(null);
+  editingPromptIdRef.current = editingPromptId;
+  // Id of a prompt the user force-sent (top arrow). Once the interrupted turn
+  // settles, the drain sends it immediately, bypassing the normal busy guards.
+  const pendingForcePromptIdRef = useRef<string | null>(null);
+  const editingPrompt = useMemo(
+    () => queuedPrompts.find(prompt => prompt.id === editingPromptId) ?? null,
+    [queuedPrompts, editingPromptId],
+  );
+
+  // When a turn ends on a completed client-side tool call (e.g. a data
+  // binding), `lastAssistantMessageIsCompleteWithToolCalls` stays true and the
+  // SDK *may* auto-continue the agent loop in a microtask after onFinish. We
+  // must not drain into that gap, but we also must not stall forever when the
+  // SDK is actually idle and won't resume (e.g. the tool settled while the
+  // stream was still streaming, so the SDK's auto-continue condition was
+  // missed). When that predicate is the *only* thing blocking the drain, defer
+  // one macrotask and re-check: if the SDK resumed, `status` is now
+  // submitted/streaming and the loading guard bails; if it stayed idle, force
+  // the drain past the (now-stale) predicate so the queue can't hang.
+  const drainRecheckScheduledRef = useRef(false);
+  const forceDrainPastAutoContinueRef = useRef(false);
+
+  const tryDrainQueuedPromptRef = useRef<() => void>(() => {});
+  tryDrainQueuedPromptRef.current = () => {
+    // Force-send (top arrow): the user interrupted the running turn to push
+    // this prompt now. Wait only until the aborted turn has fully settled
+    // (no in-flight stream / unanswered tool calls), then send it past every
+    // other guard — including the manual-stop flag the interrupt just set.
+    const forcedId = pendingForcePromptIdRef.current;
+    if (forcedId) {
+      const forced = queuedPromptsRef.current.find(p => p.id === forcedId);
+      if (!forced) {
+        pendingForcePromptIdRef.current = null;
+      } else {
+        if (
+          isLoadingRef.current ||
+          hasPendingAssistantToolCalls(messagesRef.current)
+        ) {
+          return;
+        }
+        pendingForcePromptIdRef.current = null;
+        const remaining = queuedPromptsRef.current.filter(
+          p => p.id !== forcedId,
+        );
+        queuedPromptsRef.current = remaining;
+        isLoadingRef.current = true;
+        setQueuedPrompts(remaining);
+        capturedConsoleIdRef.current = forced.consoleId;
+        capturedDashboardIdRef.current = forced.dashboardId;
+        manualStopRequestedRef.current = false;
+        trackEvent("ai_chat_message_sent", {
+          model: modelIdRef.current,
+          has_context: false,
+          has_images: (forced.files?.length ?? 0) > 0,
+        });
+        sendMessageRef.current?.({ text: forced.text, files: forced.files });
+        return;
+      }
+    }
+
+    if (
+      manualStopRequestedRef.current ||
+      // Don't auto-fire the next queued prompt into a failed turn. The error
+      // (e.g. usage_limit_exceeded) stays on screen; dismissing it via
+      // clearError flips status back to "ready" and re-triggers this drain.
+      status === "error" ||
+      queuedPromptsRef.current.length === 0 ||
+      // Don't drain the head item while the user is editing it in the composer.
+      queuedPromptsRef.current[0]?.id === editingPromptIdRef.current
+    ) {
+      forceDrainPastAutoContinueRef.current = false;
+      return;
+    }
+
+    // Hard blocks: the agent is genuinely mid-turn (streaming, running a
+    // client tool, or has an unanswered tool call). Sending now would race the
+    // loop or break the SDK's "all tool calls must be settled" invariant.
+    if (
+      isLoadingRef.current ||
+      hasPendingAssistantToolCalls(messagesRef.current)
+    ) {
+      forceDrainPastAutoContinueRef.current = false;
+      return;
+    }
+
+    // Soft block: the turn ended on completed tool calls and the SDK might
+    // auto-continue in a microtask. Give it one macrotask before draining.
+    if (
+      autoSendWhenComplete({ messages: messagesRef.current }) &&
+      !forceDrainPastAutoContinueRef.current
+    ) {
+      if (!drainRecheckScheduledRef.current) {
+        drainRecheckScheduledRef.current = true;
+        setTimeout(() => {
+          drainRecheckScheduledRef.current = false;
+          forceDrainPastAutoContinueRef.current = true;
+          tryDrainQueuedPromptRef.current();
+        }, 80);
+      }
+      return;
+    }
+
+    forceDrainPastAutoContinueRef.current = false;
+
+    const [next, ...rest] = queuedPromptsRef.current;
+    // Synchronously advance the queue and mark loading BEFORE sending so a
+    // second drain trigger firing in the same tick (the [isLoading,status]
+    // effect and the onFinish microtask can both run before React re-renders)
+    // bails out at the guards above instead of re-sending the same prompt.
+    queuedPromptsRef.current = rest;
+    isLoadingRef.current = true;
+    setQueuedPrompts(rest);
+    capturedConsoleIdRef.current = next.consoleId;
+    capturedDashboardIdRef.current = next.dashboardId;
+    manualStopRequestedRef.current = false;
+    trackEvent("ai_chat_message_sent", {
+      model: modelIdRef.current,
+      has_context: false,
+      has_images: (next.files?.length ?? 0) > 0,
+    });
+    sendMessageRef.current?.({ text: next.text, files: next.files });
+  };
+  drainQueuedPromptAfterTurnRef.current = () =>
+    tryDrainQueuedPromptRef.current();
+
+  const handleChatSubmit = useCallback(
+    (text: string, files?: FileUIPart[]) => {
+      // Committing an edit of a queued prompt: update the queue entry in place
+      // instead of sending/queuing a new message.
+      if (editingPromptIdRef.current) {
+        const id = editingPromptIdRef.current;
+        const trimmed = text.trim();
+        setEditingPromptId(null);
+        if (trimmed) {
+          setQueuedPrompts(prev =>
+            prev.map(prompt =>
+              prompt.id === id ? { ...prompt, text: trimmed } : prompt,
+            ),
+          );
+        }
+        return;
+      }
+
+      // Conversational plan iteration (Cursor-style): while a submitted plan is
+      // awaiting review, the typed message becomes request_changes feedback on
+      // the plan — including the current draft, so manual edits made in the
+      // plan tab flow back — instead of a normal user message.
+      const pendingPlanToolCallId = pendingPlanToolCallIdRef.current;
+      if (pendingPlanToolCallId) {
+        const planStore = usePlanStore.getState();
+        const planEntry = planStore.plans[pendingPlanToolCallId];
+        const feedback = text.trim();
+        if (planEntry?.status === "pending" && feedback) {
+          trackEvent("ai_plan_feedback_sent", { model: modelIdRef.current });
+          planStore.resolvePlan(
+            pendingPlanToolCallId,
+            "request_changes",
+            feedback,
+          );
+          return;
+        }
+      }
+
+      capturedConsoleIdRef.current = activeConsoleIdRef.current;
+      const store = useConsoleStore.getState();
+      const currentTab = store.tabs[store.activeTabId || ""] as
+        | (ConsoleTab & { metadata?: Record<string, unknown> })
+        | undefined;
+      const dashboardId =
+        currentTab?.kind === "dashboard"
+          ? ((currentTab.metadata?.dashboardId as string | undefined) ?? null)
+          : null;
+      capturedDashboardIdRef.current = dashboardId;
+      const consoleId = capturedConsoleIdRef.current;
+
+      if (isLoadingRef.current) {
+        trackEvent("ai_chat_message_queued", {
+          model: modelIdRef.current,
+          has_images: (files?.length ?? 0) > 0,
+        });
+        setQueuedPrompts(prev => [
+          ...prev,
+          {
+            id: generateObjectId(),
+            text,
+            files,
+            consoleId,
+            dashboardId,
+          },
+        ]);
+        return;
+      }
+
+      manualStopRequestedRef.current = false;
+      const activeConsole = store.tabs[store.activeTabId || ""];
+      trackEvent("ai_chat_message_sent", {
+        model: modelIdRef.current,
+        has_context: !!activeConsole?.content,
+        has_images: (files?.length ?? 0) > 0,
+      });
+      sendMessageRef.current?.({ text, files });
+    },
+    [
+      activeConsoleIdRef,
+      capturedConsoleIdRef,
+      capturedDashboardIdRef,
+      isLoadingRef,
+      manualStopRequestedRef,
+      modelIdRef,
+      pendingPlanToolCallIdRef,
+      sendMessageRef,
+    ],
+  );
+
+  useEffect(() => {
+    tryDrainQueuedPromptRef.current();
+  }, [isLoading, status, activeClientToolCallCount]);
+
+  // Belt-and-suspenders: useChat `id` resets hook state on chatId change.
+  useEffect(() => {
+    setQueuedPrompts([]);
+  }, [chatId]);
+
+  const handleRemoveQueuedPrompt = useCallback((id: string) => {
+    setQueuedPrompts(prev => prev.filter(prompt => prompt.id !== id));
+  }, []);
+
+  const handleStartEditQueuedPrompt = useCallback((id: string) => {
+    setEditingPromptId(id);
+  }, []);
+
+  const handleCancelEditQueuedPrompt = useCallback(() => {
+    setEditingPromptId(null);
+  }, []);
+
+  // If the edited prompt leaves the queue (drained, removed, or cleared), exit
+  // edit mode so a stale id can't swallow the next real submit.
+  useEffect(() => {
+    if (
+      editingPromptId &&
+      !queuedPrompts.some(prompt => prompt.id === editingPromptId)
+    ) {
+      setEditingPromptId(null);
+    }
+  }, [queuedPrompts, editingPromptId]);
+
+  // Force-send (top arrow): send this prompt right now. If the agent is still
+  // running, interrupt the current turn first, then push it. If idle, just
+  // send it immediately (ahead of any other queued items).
+  const handleSendQueuedPromptNow = useCallback(
+    (id: string) => {
+      if (!queuedPromptsRef.current.some(p => p.id === id)) return;
+      if (editingPromptIdRef.current === id) setEditingPromptId(null);
+
+      // Move to the front for immediate visual feedback.
+      setQueuedPrompts(prev => {
+        const index = prev.findIndex(prompt => prompt.id === id);
+        if (index <= 0) return prev;
+        const next = [...prev];
+        const [item] = next.splice(index, 1);
+        next.unshift(item);
+        return next;
+      });
+
+      pendingForcePromptIdRef.current = id;
+      if (isLoadingRef.current) {
+        interruptActiveTurn();
+      }
+      // Drain now if already idle; otherwise the status→ready transition from
+      // the interrupt re-fires the drain effect, which sends the forced prompt.
+      queueMicrotask(() => tryDrainQueuedPromptRef.current());
+    },
+    [interruptActiveTurn, isLoadingRef],
+  );
+
+  const clearQueuedPrompts = useCallback(() => {
+    setQueuedPrompts([]);
+  }, []);
+
+  return {
+    queuedPrompts,
+    editingPromptId,
+    editingPrompt,
+    handleChatSubmit,
+    handleRemoveQueuedPrompt,
+    handleStartEditQueuedPrompt,
+    handleCancelEditQueuedPrompt,
+    handleSendQueuedPromptNow,
+    clearQueuedPrompts,
+  };
+}

--- a/app/src/components/chat/hooks/useServerToolSync.ts
+++ b/app/src/components/chat/hooks/useServerToolSync.ts
@@ -1,0 +1,192 @@
+import { useEffect, useRef, type MutableRefObject } from "react";
+import type { UseChatHelpers } from "@ai-sdk/react";
+import type { UIMessage } from "ai";
+import { useConsoleStore } from "../../../store/consoleStore";
+import { useRealtimeStore } from "../../../store/realtimeStore";
+import { useAppStore } from "../../../store/appStore";
+import { useDbtStore } from "../../../store/dbtStore";
+import {
+  APP_SERVER_MUTATION_TOOLS,
+  DBT_SERVER_MUTATION_TOOLS,
+} from "../tool-presentation";
+
+type ChatHelpers = UseChatHelpers<UIMessage>;
+
+export interface UseServerToolSyncArgs {
+  chatId: string;
+  workspaceId: string | undefined;
+  messages: ChatHelpers["messages"];
+}
+
+/**
+ * In-band reconciliation of SERVER-executed tool results against this
+ * window's open tabs, riding the resumable chat stream (issue #475 pattern).
+ *
+ * Console sync: when a server-side console tool result streams in (state
+ * "output-available"), reconcile THIS window against the server draft. The
+ * chat stream is resumable, so unlike the workspace realtime poke channel
+ * this survives SSE drops, half-closes, frozen background tabs, reconnects
+ * and page refreshes — the replayed part triggers the same idempotent
+ * reconciliation.
+ *
+ *   - create_console / open_console -> open the tab here.
+ *   - modify_console / set_console_connection -> pull the authoritative
+ *     draft for open tabs (revision sync). Without this, an agent EDIT
+ *     reached the editor ONLY via the realtime poke; a missed poke (dead
+ *     SSE, or a poke that raced the tab open) left the editor stale until
+ *     the next focus/reconnect/watchdog/refresh — the reported "modify did
+ *     nothing until I refreshed" bug. create_console never had this problem
+ *     because it already rode the chat stream (asymmetry, issue #475).
+ *
+ * App/dbt sync: the app_* and dbt file mutation tools execute SERVER-SIDE,
+ * so an OPEN app / dbt tab learns about the agent's write via the workspace
+ * realtime poke (app.updated / dbt.file.updated). That poke rides the
+ * workspace SSE, which a mobile lock / laptop sleep / proxy half-close can
+ * kill — so reconcile off the RESUMABLE CHAT STREAM too: when the tool
+ * result streams in (or is replayed after a wake reattach), refetch the open
+ * app / dbt file (poke = fast path, this = robust backstop).
+ *
+ * Returns `handledConsoleOpenToolCallIdsRef` so the session loader can seed
+ * it: tool call ids seen in RESTORED history must not re-trigger the console
+ * opener (the dedicated consoles-restore payload handles reopening).
+ */
+export function useServerToolSync({
+  chatId,
+  workspaceId,
+  messages,
+}: UseServerToolSyncArgs): {
+  handledConsoleOpenToolCallIdsRef: MutableRefObject<Set<string>>;
+} {
+  const handledConsoleOpenToolCallIdsRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    handledConsoleOpenToolCallIdsRef.current = new Set();
+  }, [chatId]);
+  useEffect(() => {
+    if (!workspaceId) return;
+    const last = messages.at(-1);
+    if (!last || last.role !== "assistant") return;
+    for (const part of last.parts ?? []) {
+      const p = part as {
+        type?: string;
+        toolName?: string;
+        state?: string;
+        toolCallId?: string;
+        output?: { success?: boolean; consoleId?: string };
+      };
+      const toolName =
+        p.type === "dynamic-tool"
+          ? p.toolName
+          : p.type?.startsWith("tool-")
+            ? p.type.slice("tool-".length)
+            : undefined;
+      const opensTab =
+        toolName === "create_console" || toolName === "open_console";
+      // Server console writes whose only client delivery is the realtime poke.
+      // run_console bumps the draft revision AND persists a run artifact
+      // (tab.lastRun); the revision sync refreshes both, and Editor.tsx
+      // reactively renders lastRun into the results panel — so reconciling
+      // here surfaces agent run RESULTS even when the run.completed poke was
+      // missed (dead/half-closed SSE), matching modify/set-connection.
+      const editsConsole =
+        toolName === "modify_console" ||
+        toolName === "set_console_connection" ||
+        toolName === "run_console";
+      if (!opensTab && !editsConsole) continue;
+      if (p.state !== "output-available") continue;
+      if (!p.toolCallId || !p.output?.success) continue;
+      // Opening needs a consoleId; an edit reconciles all open tabs so it
+      // does not. Don't burn the dedupe slot on an opener that lacks an id.
+      if (opensTab && !p.output?.consoleId) continue;
+      if (handledConsoleOpenToolCallIdsRef.current.has(p.toolCallId)) continue;
+      handledConsoleOpenToolCallIdsRef.current.add(p.toolCallId);
+      if (opensTab) {
+        const consoleId = p.output.consoleId as string;
+        void (async () => {
+          await useConsoleStore
+            .getState()
+            .openConsoleFromServer(workspaceId, consoleId);
+          // A create followed immediately by a modify can drop the modify's
+          // workspace poke while the tab is still opening; reconcile once the
+          // tab carries a revision base so it never sticks on create-time
+          // content.
+          void useRealtimeStore.getState().syncRevisions();
+        })();
+      } else {
+        void useRealtimeStore.getState().syncRevisions();
+      }
+    }
+  }, [messages, workspaceId]);
+
+  const handledEntitySyncToolCallIdsRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    handledEntitySyncToolCallIdsRef.current = new Set();
+  }, [chatId]);
+  useEffect(() => {
+    if (!workspaceId) return;
+    const last = messages.at(-1);
+    if (!last || last.role !== "assistant") return;
+    for (const part of last.parts ?? []) {
+      const p = part as {
+        type?: string;
+        toolName?: string;
+        state?: string;
+        toolCallId?: string;
+        input?: { appId?: string; projectId?: string; path?: string };
+        output?: { success?: boolean };
+      };
+      const toolName =
+        p.type === "dynamic-tool"
+          ? p.toolName
+          : p.type?.startsWith("tool-")
+            ? p.type.slice("tool-".length)
+            : undefined;
+      if (!toolName) continue;
+      const isAppEdit = APP_SERVER_MUTATION_TOOLS.has(toolName);
+      const isDbtEdit = DBT_SERVER_MUTATION_TOOLS.has(toolName);
+      if (!isAppEdit && !isDbtEdit) continue;
+      if (
+        p.state !== "output-available" ||
+        !p.toolCallId ||
+        !p.output?.success
+      ) {
+        continue;
+      }
+      if (handledEntitySyncToolCallIdsRef.current.has(p.toolCallId)) continue;
+      handledEntitySyncToolCallIdsRef.current.add(p.toolCallId);
+
+      if (isAppEdit) {
+        const appId = p.input?.appId;
+        // Only reconcile a tab that is actually open here (mirrors the
+        // realtime handler); fetchApp + bumpPreview rebuilds the preview.
+        if (appId && useAppStore.getState().openApps[appId]) {
+          void (async () => {
+            const fresh = await useAppStore
+              .getState()
+              .fetchApp(workspaceId, appId);
+            if (fresh) useAppStore.getState().bumpPreview(appId);
+          })();
+        }
+      } else {
+        const projectId = p.input?.projectId;
+        const path = p.input?.path;
+        // Only touch projects this window has loaded.
+        if (
+          projectId &&
+          path &&
+          useDbtStore.getState().filePathsByProject[projectId]
+        ) {
+          void useDbtStore
+            .getState()
+            .applyRemoteFileUpdate(
+              workspaceId,
+              projectId,
+              path,
+              toolName === "delete_dbt_file",
+            );
+        }
+      }
+    }
+  }, [messages, workspaceId]);
+
+  return { handledConsoleOpenToolCallIdsRef };
+}

--- a/app/src/components/chat/hooks/useStreamResume.ts
+++ b/app/src/components/chat/hooks/useStreamResume.ts
@@ -1,0 +1,394 @@
+import { useEffect, useRef, type MutableRefObject } from "react";
+import type { UseChatHelpers } from "@ai-sdk/react";
+import type { UIMessage } from "ai";
+import { useRealtimeStore } from "../../../store/realtimeStore";
+import {
+  isHumanInTheLoopToolPartType,
+  reportStreamInterruption,
+  toolNameFromPartType,
+  type ActiveClientToolCall,
+} from "../tool-presentation";
+
+type ChatHelpers = UseChatHelpers<UIMessage>;
+
+export interface ErrorResumeState {
+  count: number;
+  windowStart: number;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+// Spacing/budget for onError → resume retries. A failed resume re-fires
+// onError, so retrying instantly would burst; instead we schedule one delayed
+// attempt (giving a brief network blip time to recover) and cap attempts per
+// window before falling back to poisoning the tool cards.
+const RESUME_RETRY_DELAY_MS = 1500;
+const RESUME_RETRY_WINDOW_MS = 30_000;
+const RESUME_MAX_RETRIES = 4;
+
+export interface UseStreamResumeArgs {
+  // Reactive values (drive the liveness effect).
+  status: ChatHelpers["status"];
+  messages: ChatHelpers["messages"];
+  // Latest-value refs (assigned by Chat.tsx each render / after useChat).
+  statusRef: MutableRefObject<ChatHelpers["status"]>;
+  messagesRef: MutableRefObject<ChatHelpers["messages"]>;
+  chatIdRef: MutableRefObject<string>;
+  manualStopRequestedRef: MutableRefObject<boolean>;
+  activeClientToolCallsRef: MutableRefObject<Map<string, ActiveClientToolCall>>;
+  stopRef: MutableRefObject<ChatHelpers["stop"] | undefined>;
+  resumeStreamRef: MutableRefObject<ChatHelpers["resumeStream"] | undefined>;
+  loadPersistedMessagesRef: MutableRefObject<
+    ((opts?: { forHistoryLoad?: boolean }) => Promise<boolean>) | undefined
+  >;
+  /**
+   * Wired by this hook; declared in Chat.tsx because useChat's onError (built
+   * before this hook runs) schedules retries through it.
+   */
+  requestResumeRef: MutableRefObject<
+    ((opts?: { skipReload?: boolean }) => Promise<void>) | undefined
+  >;
+  /** onError's retry budget/timer — the wake effect's cleanup clears it. */
+  errorResumeRef: MutableRefObject<ErrorResumeState>;
+  /**
+   * Wired by this hook; declared in Chat.tsx because useChat's onError —
+   * captured once per Chat instance — delegates through it.
+   */
+  onStreamErrorImplRef: MutableRefObject<
+    ((error: unknown) => void) | undefined
+  >;
+  /** Latest clearError (re-bound per Chat instance). */
+  clearErrorRef: MutableRefObject<ChatHelpers["clearError"] | undefined>;
+  setMessages: ChatHelpers["setMessages"];
+  cancelActiveClientToolCalls: (reason: string) => void;
+}
+
+/**
+ * Single-flight, liveness-gated stream resume manager + tab-wake reattach.
+ *
+ * The SDK's resumeStream() has no guard of its own: each call attaches a NEW
+ * consumer to the resumable stream (replaying the segment buffer from
+ * position 0) WITHOUT aborting the previous consumer — so concurrent triggers
+ * (loadSession + wake burst + error retry) stacked N consumers on one turn,
+ * and every consumer re-processed every chunk: client tools executed N times
+ * and text/step-start parts were appended N times.
+ */
+export function useStreamResume({
+  status,
+  messages,
+  statusRef,
+  messagesRef,
+  chatIdRef,
+  manualStopRequestedRef,
+  activeClientToolCallsRef,
+  stopRef,
+  resumeStreamRef,
+  loadPersistedMessagesRef,
+  requestResumeRef,
+  errorResumeRef,
+  onStreamErrorImplRef,
+  clearErrorRef,
+  setMessages,
+  cancelActiveClientToolCalls,
+}: UseStreamResumeArgs): void {
+  // Stream liveness: the moment chunks last arrived. `messages` mutates on
+  // every processed chunk while a consumer is attached, so a recent timestamp
+  // while status reports an active stream means the consumer is healthy.
+  const lastStreamActivityAtRef = useRef(0);
+  useEffect(() => {
+    if (status === "streaming" || status === "submitted") {
+      lastStreamActivityAtRef.current = Date.now();
+    }
+  }, [messages, status]);
+
+  // This wrapper makes a resume:
+  //   1. a no-op while another resume is in flight or the attached consumer
+  //      is demonstrably alive (chunk activity within the liveness window);
+  //   2. tear down a stale consumer via stop() before reattaching;
+  //   3. reset to the persisted turn snapshot before replaying (when safe),
+  //      so the replay never appends onto parts this page already received.
+  const resumeInFlightRef = useRef(false);
+  requestResumeRef.current = async (opts?: {
+    skipReload?: boolean;
+  }): Promise<void> => {
+    const STREAM_LIVENESS_WINDOW_MS = 10_000;
+    if (resumeInFlightRef.current) return;
+    if (manualStopRequestedRef.current) return;
+
+    const currentStatus = statusRef.current;
+    const consuming =
+      currentStatus === "streaming" || currentStatus === "submitted";
+    if (consuming) {
+      // "submitted" = a POST is in flight and no chunk has arrived yet. That
+      // is NOT staleness: thinking models routinely take >10s before the
+      // first token, and a segment continuation (right after a client tool
+      // settles) sits in this state too. Tearing it down here reloaded a
+      // mid-segment persisted snapshot where the just-settled client tool was
+      // still input-available — the history converter then poisoned it to
+      // "Interrupted" and the turn's tail was lost. If the request is truly
+      // dead (frozen tab), its fetch errors on wake and the onError retry
+      // path resumes; never stale-kill a submitted request from here.
+      if (currentStatus === "submitted") return;
+      if (
+        Date.now() - lastStreamActivityAtRef.current <
+        STREAM_LIVENESS_WINDOW_MS
+      ) {
+        // A healthy consumer is attached and receiving chunks — resuming now
+        // would add a SECOND consumer of the same stream.
+        return;
+      }
+    }
+
+    resumeInFlightRef.current = true;
+    try {
+      if (consuming) {
+        // Stale consumer (status says streaming but no chunks for a while —
+        // the socket is likely dead, or a long silent server-side tool is
+        // running): abort it before attaching the replacement. Aborting a
+        // healthy-but-quiet consumer is safe — the replay rebuilds the same
+        // state and the dispatch gate blocks tool re-execution.
+        await stopRef.current?.();
+      }
+      // Reset to the persisted turn snapshot before replaying when safe. The
+      // replay clones the last in-memory assistant message and APPENDS every
+      // replayed text/step-start part onto it — resuming on top of parts this
+      // page already received is what duplicated message content. Skipped
+      // while a client tool is mid-flight (the reload would tear its live
+      // card down) and by loadSession (which just loaded).
+      if (!opts?.skipReload && activeClientToolCallsRef.current.size === 0) {
+        await loadPersistedMessagesRef.current?.();
+      }
+      if (manualStopRequestedRef.current) return;
+      await resumeStreamRef.current?.();
+    } finally {
+      resumeInFlightRef.current = false;
+    }
+  };
+
+  // Stream-error handler (useChat's onError delegates here). The turn's
+  // lifetime is decoupled from the HTTP connection: the server keeps
+  // generating and buffers a resumable stream after a client disconnect. A
+  // mobile lock / computer sleep freezes the tab and the OS kills the SSE
+  // socket; on wake the dead read surfaces here as a non-structured
+  // network/stream error (the user-reported "network error" / "Stream
+  // disconnected"). When the turn still looks live, reattach instead of
+  // poisoning the cards — the replay re-emits the tool outputs, and any
+  // in-flight client tool (e.g. a slow capture_screenshot) is left running so
+  // it can settle on its own.
+  onStreamErrorImplRef.current = (err: unknown): void => {
+    console.error("[Chat] Error:", err);
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    const lastMessage = messagesRef.current.at(-1);
+    const stalledToolNames =
+      lastMessage?.role === "assistant"
+        ? (lastMessage.parts ?? [])
+            .filter(p => {
+              const pt = p.type as string;
+              if (!pt?.startsWith("tool-") && pt !== "dynamic-tool") {
+                return false;
+              }
+              if (isHumanInTheLoopToolPartType(pt)) return false;
+              const s = (p as Record<string, unknown>).state as string;
+              return s !== "output-available" && s !== "error";
+            })
+            .map(p => toolNameFromPartType(p.type as string))
+        : [];
+
+    // Structured server errors (billing / model availability) arrive as JSON
+    // with a `code` — those are genuine and must NOT be resumed.
+    let isStructuredServerError = false;
+    try {
+      const parsed = JSON.parse(errorMessage);
+      isStructuredServerError = !!parsed && typeof parsed.code === "string";
+    } catch {
+      /* not JSON → network / stream drop */
+    }
+
+    const turnLooksLive =
+      statusRef.current === "streaming" ||
+      statusRef.current === "submitted" ||
+      useRealtimeStore.getState().chatActivity[chatIdRef.current] ===
+        "streaming" ||
+      document.visibilityState !== "visible" ||
+      stalledToolNames.length > 0;
+
+    const now = Date.now();
+    const resumeState = errorResumeRef.current;
+    if (now - resumeState.windowStart > RESUME_RETRY_WINDOW_MS) {
+      resumeState.windowStart = now;
+      resumeState.count = 0;
+    }
+    // Keep taking the resume branch while a retry is still scheduled, so we
+    // never poison the cards out from under a pending reattach.
+    const canRetryResume =
+      resumeState.count < RESUME_MAX_RETRIES || resumeState.timer !== null;
+
+    if (
+      !isStructuredServerError &&
+      turnLooksLive &&
+      canRetryResume &&
+      !manualStopRequestedRef.current
+    ) {
+      reportStreamInterruption({
+        path: "stream-error",
+        chatId: chatIdRef.current,
+        status: statusRef.current,
+        toolNames: stalledToolNames,
+        errorMessage,
+        resumed: true,
+      });
+      // Clear the SDK error so the hook can stream again, then reattach to
+      // the buffered turn after a short delay. The delay coalesces the burst
+      // of onError calls a failing reconnect produces and gives a brief
+      // network blip time to recover. A finished turn answers 204 (cheap
+      // no-op) and the orphan-rescue effect handles any stranded card.
+      clearErrorRef.current?.();
+      if (!resumeState.timer) {
+        resumeState.count += 1;
+        resumeState.timer = setTimeout(() => {
+          resumeState.timer = null;
+          void requestResumeRef.current?.();
+        }, RESUME_RETRY_DELAY_MS);
+      }
+      return;
+    }
+
+    // Genuine / fatal error (or too many resume retries): fall back to the
+    // original behavior — cancel in-flight client tools and poison pending
+    // tool parts so the AI SDK unblocks the next sendMessage.
+    cancelActiveClientToolCalls("stream-error");
+    reportStreamInterruption({
+      path: "stream-error",
+      chatId: chatIdRef.current,
+      status: statusRef.current,
+      toolNames: stalledToolNames,
+      errorMessage,
+      resumed: false,
+    });
+    // When the stream disconnects (e.g. 524 timeout), tool calls may be
+    // stuck in "input-available" state. The AI SDK blocks sendMessage until
+    // all tool calls are settled. Patch them to "error" so the chat remains
+    // usable.
+    setMessages(prev =>
+      prev.map(msg => {
+        if (msg.role !== "assistant") return msg;
+        const hasPending = msg.parts?.some(p => {
+          const pt = p.type as string;
+          if (!pt?.startsWith("tool-") && pt !== "dynamic-tool") return false;
+          if (isHumanInTheLoopToolPartType(pt)) return false;
+          const s = (p as Record<string, unknown>).state as string;
+          return s !== "output-available" && s !== "error";
+        });
+        if (!hasPending) return msg;
+        return {
+          ...msg,
+          parts: msg.parts.map(p => {
+            const pt = p.type as string;
+            if (!pt?.startsWith("tool-") && pt !== "dynamic-tool") return p;
+            if (isHumanInTheLoopToolPartType(pt)) return p;
+            const s = (p as Record<string, unknown>).state as string;
+            if (s === "output-available" || s === "error") return p;
+            return {
+              ...p,
+              state: "error" as const,
+              output: { success: false, error: "Stream disconnected" },
+            };
+          }) as any,
+        };
+      }),
+    );
+  };
+
+  // Reattach the chat stream when the tab wakes. A mobile lock / computer sleep
+  // freezes the page and the OS silently kills the SSE socket; on wake the AI
+  // SDK does not re-reconnect on its own, so an in-flight turn would otherwise
+  // surface as a "stream error" (or strand a tool card). The server keeps
+  // generating and buffers the turn as a resumable stream, so resumeStream()
+  // replays the buffered + live chunks; a finished turn answers 204 (cheap
+  // no-op). Mirrors realtimeStore.wake() (visibilitychange + focus + pageshow +
+  // resume), throttled so a single wake burst fires the work once. Listeners
+  // are installed once (stable closure over refs) and never re-installed.
+  useEffect(() => {
+    const WAKE_THROTTLE_MS = 2000;
+    let lastWakeAt = 0;
+    // Stable across the component's life (useRef object identity never changes);
+    // captured for the cleanup to read the latest pending resume timer.
+    const resumeState = errorResumeRef.current;
+
+    const hasResumableTurn = (): boolean => {
+      if (manualStopRequestedRef.current) return false;
+      // A client tool executing locally is NOT a stranded turn: the segment's
+      // stream already ended (dashboard/app tools dispatch fire-and-forget)
+      // and the turn resumes via sendAutomaticallyWhen once the tool settles.
+      // Reattaching here would replay the finished segment for nothing — and
+      // long tools (a 2-3 min create_data_source materialization) kept this
+      // window open for minutes, turning every tab switch into a replay.
+      if (activeClientToolCallsRef.current.size > 0) return false;
+      const s = statusRef.current;
+      if (s === "streaming" || s === "submitted") return true;
+      if (
+        useRealtimeStore.getState().chatActivity[chatIdRef.current] ===
+        "streaming"
+      ) {
+        return true;
+      }
+      // A tool card frozen mid-turn (non-terminal, non-HITL) means the turn was
+      // interrupted while we were away — worth a reattach.
+      const last = messagesRef.current.at(-1);
+      if (!last || last.role !== "assistant") return false;
+      return (last.parts ?? []).some(p => {
+        const pt = p.type as string;
+        if (!pt?.startsWith("tool-") && pt !== "dynamic-tool") return false;
+        if (isHumanInTheLoopToolPartType(pt)) return false;
+        const st = (p as Record<string, unknown>).state as string;
+        return (
+          st !== "output-available" && st !== "output-error" && st !== "error"
+        );
+      });
+    };
+
+    const wake = () => {
+      const now = Date.now();
+      // A window switch fires a burst (focus + visibilitychange); the first one
+      // does the work.
+      if (now - lastWakeAt < WAKE_THROTTLE_MS) return;
+      lastWakeAt = now;
+      if (!hasResumableTurn()) return;
+      reportStreamInterruption({
+        path: "wake-resume",
+        chatId: chatIdRef.current,
+        status: statusRef.current,
+        toolNames: [],
+        resumed: true,
+      });
+      void requestResumeRef.current?.();
+    };
+
+    const onVisible = () => {
+      if (document.visibilityState === "visible") wake();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    window.addEventListener("focus", wake);
+    window.addEventListener("pageshow", wake);
+    // Page Lifecycle API: fired when the browser unfreezes a frozen tab.
+    document.addEventListener("resume", wake);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("focus", wake);
+      window.removeEventListener("pageshow", wake);
+      document.removeEventListener("resume", wake);
+      if (resumeState.timer) {
+        clearTimeout(resumeState.timer);
+        resumeState.timer = null;
+      }
+    };
+    // Deps are all stable ref objects — the listeners install exactly once.
+  }, [
+    activeClientToolCallsRef,
+    chatIdRef,
+    errorResumeRef,
+    manualStopRequestedRef,
+    messagesRef,
+    requestResumeRef,
+    statusRef,
+  ]);
+}

--- a/app/src/components/chat/session-storage.ts
+++ b/app/src/components/chat/session-storage.ts
@@ -1,0 +1,36 @@
+// ── Per-tab chat session persistence ─────────────────────────────
+// sessionStorage scopes the active chat to the browser tab: a refresh
+// restores (and reattaches to) the same chat, while new tabs start blank.
+
+const CHAT_SESSION_STORAGE_KEY = "mako:active-chat";
+
+export interface StoredChatSession {
+  chatId: string;
+  workspaceId: string;
+}
+
+export function readStoredChatSession(): StoredChatSession | null {
+  try {
+    const raw = sessionStorage.getItem(CHAT_SESSION_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<StoredChatSession>;
+    if (
+      typeof parsed.chatId === "string" &&
+      /^[0-9a-fA-F]{24}$/.test(parsed.chatId) &&
+      typeof parsed.workspaceId === "string"
+    ) {
+      return { chatId: parsed.chatId, workspaceId: parsed.workspaceId };
+    }
+  } catch {
+    /* sessionStorage unavailable or corrupted entry */
+  }
+  return null;
+}
+
+export function writeStoredChatSession(session: StoredChatSession): void {
+  try {
+    sessionStorage.setItem(CHAT_SESSION_STORAGE_KEY, JSON.stringify(session));
+  } catch {
+    /* ignore storage failures (private mode, quota) */
+  }
+}

--- a/app/src/components/chat/streaming-indicator-styles.ts
+++ b/app/src/components/chat/streaming-indicator-styles.ts
@@ -1,0 +1,29 @@
+import { keyframes } from "@mui/material/styles";
+
+// Stable keyframes animation defined outside components to prevent re-renders
+const pulseAnimation = keyframes`
+  0%, 100% { opacity: 0.4; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.35); }
+`;
+
+// Stable style objects to prevent re-renders. The dot is shared by the
+// streaming indicator and the history menu's in-flight session marker.
+export const streamingIndicatorContainerSx = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: 14,
+  height: 14,
+  overflow: "visible",
+  lineHeight: 0,
+  flexShrink: 0,
+  mt: 0.5,
+} as const;
+
+export const streamingIndicatorDotSx = {
+  width: 8,
+  height: 8,
+  borderRadius: "50%",
+  backgroundColor: "primary.main",
+  animation: `${pulseAnimation} 1s infinite ease-in-out`,
+} as const;

--- a/app/src/components/chat/tool-dispatch-gate.ts
+++ b/app/src/components/chat/tool-dispatch-gate.ts
@@ -1,0 +1,92 @@
+/**
+ * Dedupe gate for client-side tool dispatch.
+ *
+ * The AI SDK fires `onToolCall` for EVERY `tool-input-available` chunk a
+ * stream consumer processes — including chunks replayed from position 0 by a
+ * resumable-stream reattach (`resumeStream()`), and chunks broadcast to
+ * additional concurrent consumers (the SDK never aborts the previous
+ * `activeResponse` when a resume attaches). Tool PARTS merge by `toolCallId`
+ * so the duplication is invisible in the transcript, but the dispatch is not
+ * deduped anywhere — one `create_dashboard` call executed N times (the
+ * "3 dashboards / 3 data sources from a single tool call" incident).
+ *
+ * The gate is scoped to a chat and a page instance:
+ *  - `markDispatched` returns false when this page instance already dispatched
+ *    the id, blocking same-instance replays and concurrent consumers.
+ *  - `seedFromPersistedMessages` blocks ids whose PERSISTED state is terminal:
+ *    they completed in a previous page instance, so a post-refresh replay must
+ *    not re-run them.
+ *  - Non-terminal persisted ids stay dispatchable ON PURPOSE: a refresh
+ *    mid-execution relies on the resumed stream re-dispatching the call (the
+ *    previous page died before the tool could settle).
+ */
+
+/** Tool part states that mean the call already ran to completion. */
+const TERMINAL_TOOL_STATES = new Set([
+  "output-available",
+  "output-error",
+  "output-denied",
+  "error",
+]);
+
+export interface PersistedMessageLike {
+  role?: string;
+  parts?: Array<Record<string, unknown>> | null;
+}
+
+function isToolPartType(type: unknown): type is string {
+  return (
+    typeof type === "string" &&
+    (type.startsWith("tool-") || type === "dynamic-tool")
+  );
+}
+
+export class ToolDispatchGate {
+  private dispatched = new Set<string>();
+
+  /** Forget everything (call when the active chat changes). */
+  reset(): void {
+    this.dispatched.clear();
+  }
+
+  /** True if this toolCallId was already dispatched (or seeded as terminal). */
+  wasDispatched(toolCallId: string): boolean {
+    return this.dispatched.has(toolCallId);
+  }
+
+  /**
+   * Claim a toolCallId for dispatch. Returns true exactly once per id — a
+   * false return means the call was already dispatched and the caller must
+   * NOT execute it again. Ids without a value cannot be deduped and are always
+   * allowed through.
+   */
+  markDispatched(toolCallId: string | undefined | null): boolean {
+    if (!toolCallId) return true;
+    if (this.dispatched.has(toolCallId)) return false;
+    this.dispatched.add(toolCallId);
+    return true;
+  }
+
+  /**
+   * Seed from the RAW persisted messages (server shape, before any client
+   * normalization). Only tool parts persisted in a TERMINAL state block
+   * re-dispatch; the history loader rewrites interrupted parts to
+   * `output-error` for display, so seeding must happen from the raw data or
+   * legitimate post-refresh recovery of interrupted tools would be blocked.
+   */
+  seedFromPersistedMessages(messages: PersistedMessageLike[]): void {
+    for (const message of messages) {
+      for (const part of message.parts ?? []) {
+        if (!isToolPartType(part.type)) continue;
+        const toolCallId = part.toolCallId;
+        if (typeof toolCallId !== "string" || toolCallId.length === 0) {
+          continue;
+        }
+        const state = part.state;
+        if (typeof state === "string" && TERMINAL_TOOL_STATES.has(state)) {
+          this.dispatched.add(toolCallId);
+        }
+      }
+    }
+  }
+}

--- a/app/src/components/chat/tool-presentation.ts
+++ b/app/src/components/chat/tool-presentation.ts
@@ -1,0 +1,248 @@
+/**
+ * Pure helpers around agent tool parts: naming, pending-state predicates,
+ * console tool-card presentation, and stream-interruption diagnostics.
+ * Extracted from Chat.tsx (no React — unit-testable).
+ */
+import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
+import { useConsoleStore } from "../../store/consoleStore";
+import type { ConsoleTab } from "../../store/lib/types";
+import type { ConsoleModification } from "../../hooks/useMonacoConsole";
+import { buildModificationDiff } from "../../utils/consoleModification";
+import { trackEvent } from "../../lib/analytics";
+import type { ToolPartState } from "../StreamingToolCard";
+
+// Human-in-the-loop tools resolve via an interactive card (the user answers /
+// approves), not via an `execute` result. They legitimately stay pending at
+// `input-available` with no output until the user acts, so any "settle the
+// dangling tool" cleanup must skip them — otherwise the card is torn down
+// before it can be answered. Part types are `tool-<toolName>`.
+const HUMAN_IN_THE_LOOP_TOOL_PART_TYPES = new Set([
+  "tool-ask_clarifying_questions",
+  "tool-submit_plan",
+]);
+
+export function isHumanInTheLoopToolPartType(partType: string): boolean {
+  return HUMAN_IN_THE_LOOP_TOOL_PART_TYPES.has(partType);
+}
+
+export function toolNameFromPartType(partType: string): string {
+  return partType.startsWith("tool-")
+    ? partType.slice("tool-".length)
+    : partType;
+}
+
+// Server-executed mutation tools (issue #475 pattern) whose open-tab sync we
+// ALSO reconcile off the resumable chat stream — in addition to the workspace
+// realtime poke (app.updated / dbt.file.updated) — so an open app / dbt tab
+// converges even when the workspace SSE is dead (mobile lock / laptop sleep).
+export const APP_SERVER_MUTATION_TOOLS = new Set<string>([
+  "app_write_file",
+  "app_delete_file",
+  "app_rename_file",
+  "app_add_dependency",
+  "app_remove_dependency",
+  "app_create_data_binding",
+  "app_delete_data_binding",
+]);
+export const DBT_SERVER_MUTATION_TOOLS = new Set<string>([
+  "create_dbt_file",
+  "modify_dbt_file",
+  "delete_dbt_file",
+]);
+
+// Diagnostics for the *live* stream-disconnect signatures so they can be
+// investigated after the fact:
+//   - "orphan-rescue": a turn settled to `ready` while non-interactive tool
+//     cards were still pending (the silent SSE drop → 204 reconnect path).
+//   - "stream-error":  the SDK surfaced a thrown stream error (e.g. a 524 or a
+//     network drop when the tab is frozen by a mobile lock / computer sleep).
+//   - "wake-resume":   the tab woke (visibility/focus/pageshow/resume) with an
+//     in-flight turn, so we proactively reattached to the buffered stream.
+// `resumed` records whether we attempted a resume (reattach) rather than
+// poisoning the tool cards — the recovery path we want to confirm in prod.
+// Emits a structured console line for live debugging and a PostHog product
+// event so frequency / affected tools are queryable. Correlate with the
+// server's `mako.agent` logs (and the resume-endpoint 204 reasons) via chatId.
+export type StreamInterruptionPath =
+  | "orphan-rescue"
+  | "stream-error"
+  | "wake-resume";
+
+export function reportStreamInterruption(detail: {
+  path: StreamInterruptionPath;
+  chatId: string;
+  status: string;
+  toolNames: string[];
+  recoveredToolNames?: string[];
+  errorMessage?: string;
+  resumed?: boolean;
+}): void {
+  console.warn("[Chat][stream-interrupted]", detail);
+  trackEvent("ai_chat_stream_interrupted", {
+    interruption_path: detail.path,
+    chat_id: detail.chatId,
+    chat_status: detail.status,
+    tool_names: detail.toolNames.join(",") || "(none)",
+    tool_count: detail.toolNames.length,
+    recovered_tool_names: detail.recoveredToolNames?.join(",") || "(none)",
+    recovered_count: detail.recoveredToolNames?.length ?? 0,
+    error_message: detail.errorMessage,
+    resumed: detail.resumed ?? false,
+  });
+}
+
+// Tool part structure - tool type is "tool-{toolName}" with state/input/output
+export interface ToolInvocationInfo {
+  toolCallId: string;
+  toolName: string;
+  state:
+    | "input-streaming"
+    | "input-available"
+    | "output-streaming"
+    | "output-available"
+    | "error";
+  input?: unknown;
+  output?: unknown;
+}
+
+export type AutoSendPredicateArgs = Parameters<
+  typeof lastAssistantMessageIsCompleteWithToolCalls
+>[0];
+
+export function hasPendingAssistantToolCalls(
+  messages: AutoSendPredicateArgs["messages"],
+): boolean {
+  const last = messages.at(-1);
+  if (!last?.parts || last.role !== "assistant") return false;
+
+  return last.parts.some(part => {
+    const partType = part.type as string;
+    if (!partType.startsWith("tool-") && partType !== "dynamic-tool") {
+      return false;
+    }
+    const state = (part as { state?: string }).state;
+    return (
+      state !== "output-available" &&
+      state !== "output-error" &&
+      state !== "error"
+    );
+  });
+}
+
+export interface ActiveClientToolCall {
+  toolCallId: string;
+  toolName: string;
+  executionId: string;
+  abortController: AbortController;
+  cancel: () => void | Promise<void>;
+  cancellationOutput: Record<string, unknown>;
+  settled: boolean;
+}
+
+function asToolPayload(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function getConsoleIdFromToolPayload(
+  input: unknown,
+  output: unknown,
+): string | null {
+  const inputObj = asToolPayload(input);
+  const outputObj = asToolPayload(output);
+  const consoleId = inputObj?.consoleId ?? outputObj?.consoleId;
+  return typeof consoleId === "string" && consoleId.length > 0
+    ? consoleId
+    : null;
+}
+
+export interface ConsoleToolPresentation {
+  consoleId: string;
+  title: string;
+  iconUrl?: string;
+  diff?: string;
+}
+
+export function getConsoleToolPresentation(
+  toolName: string,
+  input: unknown,
+  output: unknown,
+  connectionIconById: ReadonlyMap<string, string>,
+  state: ToolPartState,
+): ConsoleToolPresentation | null {
+  if (toolName !== "modify_console") return null;
+
+  const store = useConsoleStore.getState();
+  const inputObj = asToolPayload(input);
+  const outputObj = asToolPayload(output);
+  const consoleId = getConsoleIdFromToolPayload(input, output);
+  if (!consoleId) return null;
+
+  const consoleTab = store.tabs[consoleId];
+  const inputTitle = inputObj?.title;
+  const outputTitle = outputObj?.title;
+  const title =
+    consoleTab?.title ??
+    (typeof inputTitle === "string" ? inputTitle : undefined) ??
+    (typeof outputTitle === "string" ? outputTitle : undefined) ??
+    "Untitled console";
+
+  // While the input is still streaming, the `content` field is partial, so a
+  // line-diff against the existing console re-aligns its +/- groupings on every
+  // token (interleaved → grouped as more text arrives) — the modify_console
+  // "blink like mad" the diff card showed under Virtuoso. Skip the live diff
+  // while streaming: with no diff, the card falls back to rendering the raw
+  // `content` as plain SQL, which grows append-only and streams smoothly
+  // (exactly the token-by-token write users want, same path as create_console).
+  // Once the content is complete (`input-available`/`output-available`) the diff
+  // is stable, so we show the proper red/green diff again — preferring the final
+  // server `outputDiff` when present.
+  const outputDiff = outputObj?.diff;
+  const diff =
+    typeof outputDiff === "string" && outputDiff.length > 0
+      ? outputDiff
+      : state === "input-streaming"
+        ? undefined
+        : buildStreamingModificationDiff(inputObj, consoleTab);
+
+  return {
+    consoleId,
+    title,
+    iconUrl: consoleTab?.connectionId
+      ? connectionIconById.get(consoleTab.connectionId)
+      : undefined,
+    diff,
+  };
+}
+
+function buildStreamingModificationDiff(
+  input: Record<string, unknown> | undefined,
+  consoleTab: ConsoleTab | undefined,
+): string | undefined {
+  const action = input?.action;
+  const content = input?.content;
+  if (
+    !input ||
+    !consoleTab ||
+    typeof action !== "string" ||
+    typeof content !== "string" ||
+    content.length === 0
+  ) {
+    return undefined;
+  }
+
+  const position = input.position;
+  const startLine = input.startLine;
+  const endLine = input.endLine;
+  const modification: ConsoleModification = {
+    action: action as ConsoleModification["action"],
+    content,
+    position:
+      typeof position === "number" ? { line: position, column: 1 } : undefined,
+    startLine: typeof startLine === "number" ? startLine : undefined,
+    endLine: typeof endLine === "number" ? endLine : undefined,
+  };
+
+  return buildModificationDiff(consoleTab.content || "", modification);
+}

--- a/app/src/dashboard-runtime/agent-tools.ts
+++ b/app/src/dashboard-runtime/agent-tools.ts
@@ -103,7 +103,17 @@ const EDIT_MODE_EXEMPT_TOOLS = new Set([
 export async function executeDashboardAgentTool(
   toolName: string,
   input: Record<string, unknown>,
-  options?: { executionId?: string; signal?: AbortSignal },
+  options?: {
+    executionId?: string;
+    signal?: AbortSignal;
+    /**
+     * The agent toolCallId driving this execution. Forwarded to creation
+     * commands as an idempotency key: multiple windows attached to the same
+     * chat stream each dispatch the same call, and the server (or the
+     * dashboard doc) dedupes by this id so the side effect lands once.
+     */
+    toolCallId?: string;
+  },
 ): Promise<Record<string, unknown> | null> {
   if (!DASHBOARD_EXECUTOR_TOOL_NAMES.has(toolName as AgentToolName)) {
     return null;
@@ -269,6 +279,12 @@ export async function executeDashboardAgentTool(
             typeof input.description === "string"
               ? input.description
               : undefined,
+          // Server-side create idempotency: another window attached to the
+          // same chat stream dispatching this exact tool call gets the same
+          // dashboard back instead of creating a duplicate.
+          ...(options?.toolCallId
+            ? { idempotencyKey: options.toolCallId }
+            : {}),
         } as any,
         { signal },
       );
@@ -425,6 +441,7 @@ export async function executeDashboardAgentTool(
               : undefined,
           dashboardId: ctx.dashboardId,
           signal,
+          toolCallId: options?.toolCallId,
         });
         throwIfAborted(signal);
         const snapshot = getDashboardStateSnapshot(ctx.dashboardId);
@@ -499,6 +516,7 @@ export async function executeDashboardAgentTool(
               : undefined,
         },
         signal,
+        toolCallId: options?.toolCallId,
       });
       throwIfAborted(signal);
       const snapshot = getDashboardStateSnapshot(ctx.dashboardId);

--- a/app/src/dashboard-runtime/commands.ts
+++ b/app/src/dashboard-runtime/commands.ts
@@ -262,6 +262,28 @@ export function buildDashboardDataSource(input: {
   };
 }
 
+/**
+ * Creation idempotency for agent-created data sources: when the dashboard
+ * already holds a data source stamped with this toolCallId, return it instead
+ * of adding another. Covers a second window attached to the same chat stream
+ * dispatching the same create call after the first window's save landed.
+ * (Cross-window last-write-wins on concurrent dashboard saves is a separate
+ * consistency problem, out of scope here — the stamp at least makes the
+ * duplicate detectable and the common sequential case idempotent.)
+ */
+function findDataSourceByToolCallId(
+  dashboardId: string | undefined,
+  toolCallId: string | undefined,
+): DashboardDataSource | null {
+  if (!toolCallId) return null;
+  const dashboard = getDashboardOrThrow(dashboardId);
+  return (
+    dashboard.dataSources.find(
+      ds => ds.origin?.createdByToolCallId === toolCallId,
+    ) ?? null
+  );
+}
+
 export async function createDashboardDataSource(options: {
   workspaceId: string;
   name: string;
@@ -271,7 +293,15 @@ export async function createDashboardDataSource(options: {
   materialization?: "live" | "parquet";
   dashboardId?: string;
   signal?: AbortSignal;
+  /** Agent toolCallId — creation idempotency stamp (see above). */
+  toolCallId?: string;
 }): Promise<DashboardDataSource> {
+  const existing = findDataSourceByToolCallId(
+    options.dashboardId,
+    options.toolCallId,
+  );
+  if (existing) return existing;
+
   const store = useDashboardStore.getState();
   const dashboard = getDashboardOrThrow(options.dashboardId);
   const dataSource = buildDashboardDataSource({
@@ -280,7 +310,7 @@ export async function createDashboardDataSource(options: {
     timeDimension: options.timeDimension,
     rowLimit: options.rowLimit,
     materialization: options.materialization,
-    origin: { type: "local" },
+    origin: { type: "local", createdByToolCallId: options.toolCallId },
   });
 
   store.addDataSource(dashboard._id, dataSource);
@@ -304,7 +334,15 @@ export async function importConsoleAsDashboardDataSource(options: {
   timeDimension?: string;
   dashboardId?: string;
   signal?: AbortSignal;
+  /** Agent toolCallId — creation idempotency stamp (see above). */
+  toolCallId?: string;
 }): Promise<DashboardDataSource> {
+  const preExisting = findDataSourceByToolCallId(
+    options.dashboardId,
+    options.toolCallId,
+  );
+  if (preExisting) return preExisting;
+
   const response = await apiClient.get<ConsoleContentResponse>(
     `/workspaces/${options.workspaceId}/consoles/content`,
     { id: options.consoleId },
@@ -337,6 +375,7 @@ export async function importConsoleAsDashboardDataSource(options: {
       consoleId: response.id,
       consoleName: response.name,
       importedAt: new Date().toISOString(),
+      createdByToolCallId: options.toolCallId,
     },
   });
 

--- a/packages/schemas/src/dashboard.schema.ts
+++ b/packages/schemas/src/dashboard.schema.ts
@@ -36,6 +36,13 @@ export const DashboardDataSourceOriginSchema = z.object({
   consoleId: z.string().optional(),
   consoleName: z.string().optional(),
   importedAt: z.string().optional(),
+  /**
+   * The agent toolCallId that created this data source (creation idempotency:
+   * multiple windows attached to the same chat stream dispatch the same
+   * create call; the duplicate finds this stamp and returns the existing
+   * data source instead of adding another).
+   */
+  createdByToolCallId: z.string().optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary

Fixes the triplicate tool-execution incident (one `create_dashboard` call → 3 dashboards, 3 data sources) and decomposes the 4,869-line `Chat.tsx` into a `components/chat/` module (now 1,333 lines).

### Root cause

The AI SDK fires `onToolCall` for **every** `tool-input-available` chunk seen by **every** attached stream consumer, and `resumeStream()` (called from `loadSession`, the tab-wake handler, and the `onError` retry) attached **additional** consumers that replay the segment buffer from position 0 — with no `toolCallId` dedupe anywhere. N consumers = N executions; the same replay-append triplicated text/step-start parts in persisted messages.

### Bug fixes

- **`ToolDispatchGate`** — per-chat `toolCallId` dispatch dedupe in `onToolCall` + the orphan-recovery path, seeded from raw persisted history (terminal states only, so refresh-mid-execution recovery still works)
- **Single-flight, liveness-gated `requestResume()`** replacing the 3 raw `resumeStream()` call sites — `stop()`s a stale consumer before reattaching, never stale-kills a `submitted` request (thinking models sit chunkless legitimately), reloads the persisted snapshot before replaying (with a staleness guard so a lagging snapshot can't step the live state backwards); `onFinish` guarded on `isAbort`
- **Wake guard** — an executing local client tool is not a stranded turn; a 2–3 min `create_data_source` no longer turns every tab switch into a full-segment replay
- **Mid-turn reload no longer corrupts history** — while a turn is active server-side (`activeStreamId`), non-terminal persisted tool parts are left pending instead of poisoned to "Interrupted", and orphan-rescue reconciles from the server's finalization before recovering/poisoning
- **Persist-time repair** — `dedupeAssistantStreamArtifacts` strips replay-duplicated text/step-start parts in `saveChat` (fixes already-corrupted chats)
- **Multi-window duplicate protection** — `create_dashboard` sends its `toolCallId` as an idempotency key (unique partial index on `{workspaceId, creationIdempotencyKey}` + migration; POST returns the existing dashboard on replay/race); data sources are stamped with `origin.createdByToolCallId` and creation returns the existing one
- **Tool cards never truncate** — full streamed SQL/code always renders; past a size budget the body falls back to plain monospace instead of cutting content

### Refactor (mechanical, no behavior change)

- `Chat.tsx` → `components/chat/`: pure modules (`tool-dispatch-gate`, `convert-stored-messages`, `tool-presentation`, `session-storage`), presentational components (`ChatMessageRow`, `ChatInputArea`, `QueuedPrompts`, `ChatHistoryMenu`, `ToolDetailsDialog`, …), and hooks (`useClientToolRegistry`, `useClientToolDispatch`, `useStreamResume`, `useChatSessionLoader`, `useChatSessions`, `useServerToolSync`, `useQueuedPrompts`, `useChatScroll`)
- `agent.routes.ts` stream lifecycle (SSE keep-alive, screenshot-vision assembly, authorize/resume/stop) → `agent-stream.service.ts`; route handlers stay thin with identical OpenAPI specs
- Chat's raw `fetch` calls migrated to the spec-typed openapi client
- `Chat.perf.test.ts` structural guards updated to read the relocated files; memoization contracts (`chatMessageRowArePropsEqual`, throttle, Virtuoso pin) preserved

## Test plan

- [x] `pnpm --filter app run typecheck && lint`, `pnpm --filter api run lint && build`, api test script — all green
- [x] New unit tests: dispatch gate (7), stored-message converter (12), snapshot-staleness guard (7), persist-time artifact dedupe (4)
- [x] Live browser smoke on dev: dashboard-creation turn with wake bursts every 2.6s **and** a hard reload mid-turn → exactly one dashboard, persisted transcript clean (`create_dashboard: output-available`, no duplicated text)
- [x] Idempotency: 4 concurrent POSTs with one key → one document, 3 flagged `idempotentReplay`
- [x] Stop button mid-stream → clean settle, composer unblocks, next send streams normally
- [x] History menu switching, heavy-chat restore (13 tool cards), queued-prompt drain
- [ ] `pnpm migrate` on deploy applies `2026-07-02-131500_dashboard_creation_idempotency_index` (already applied to dev)

Made with [Cursor](https://cursor.com)