### PR TITLE
Show target environment in dbt run history

### DIFF
--- a/app/src/components/DbtExplorer.tsx
+++ b/app/src/components/DbtExplorer.tsx
@@ -83,6 +83,7 @@ import {
   DBT_JINJA_LANGUAGE_ID,
   registerDbtJinjaLanguage,
 } from "../lib/dbt-monaco";
+import { envBadgeColor } from "../lib/dbt-env";
 import {
   useExplorerRevealStore,
   selectRevealFor,
@@ -223,27 +224,6 @@ function buildFileNodes(
 function scheduleSummary(job: DbtJobItem): string {
   if (!job.schedule?.cron) return "manual";
   return `${job.schedule.cron} ${job.schedule.timezone ?? "UTC"}`;
-}
-
-/**
- * MUI Chip color for a job's environment badge. Prod-like envs are flagged
- * `warning` so destructive/scheduled prod runs stand out; the project default
- * and dev-like envs get `info`, everything else stays neutral.
- */
-function envBadgeColor(
-  envName: string,
-  defaultEnvironment?: string,
-): "warning" | "info" | "default" {
-  const lower = envName.trim().toLowerCase();
-  if (lower === "prod" || lower === "production") return "warning";
-  if (
-    lower === "dev" ||
-    lower === "development" ||
-    (defaultEnvironment != null && envName === defaultEnvironment)
-  ) {
-    return "info";
-  }
-  return "default";
 }
 
 /** Collapsible section header (dbt Studio "Version control" / "File explorer"). */

--- a/app/src/components/DbtRunHistory.tsx
+++ b/app/src/components/DbtRunHistory.tsx
@@ -42,7 +42,9 @@ import {
   type DbtArtifactKind,
   type DbtStepResult,
 } from "../store/dbtStore";
+import { useSchemaStore } from "../store/schemaStore";
 import { focusDbtFileTab } from "../dbt-runtime/shell";
+import { envBadgeColor } from "../lib/dbt-env";
 import { useIsMobile } from "../hooks/useIsMobile";
 
 const ARTIFACT_LABELS: Record<DbtArtifactKind, string> = {
@@ -182,6 +184,25 @@ export default function DbtRunHistory({
   const retryRun = useDbtStore(s => s.retryRun);
   const cancelRun = useDbtStore(s => s.cancelRun);
   const downloadRunArtifact = useDbtStore(s => s.downloadRunArtifact);
+  const project = useDbtStore(s => s.projects.find(p => p._id === projectId));
+  const connections = useSchemaStore(s =>
+    workspaceId ? s.connections[workspaceId] : undefined,
+  );
+
+  // Tooltip resolving what an environment actually targets (connection +
+  // schema). Falls back to the bare env name for envs removed from the project
+  // config after the run happened.
+  const envTooltip = useCallback(
+    (envName: string): string => {
+      const env = project?.environments.find(e => e.name === envName);
+      if (!env) return `Environment: ${envName}`;
+      const connectionName = connections?.find(
+        c => c.id === env.connectionId,
+      )?.name;
+      return `Environment: ${envName} · ${connectionName ?? "connection"} · schema ${env.targetSchema}`;
+    },
+    [project?.environments, connections],
+  );
 
   const isMobile = useIsMobile();
   const logScrollRef = useRef<HTMLDivElement | null>(null);
@@ -426,6 +447,25 @@ export default function DbtRunHistory({
                   {run.status}
                   {isActive && <CircularProgress size={9} />}
                 </Typography>
+                {run.environment && (
+                  <Tooltip title={envTooltip(run.environment)}>
+                    <Chip
+                      label={run.environment}
+                      size="small"
+                      variant="outlined"
+                      color={envBadgeColor(
+                        run.environment,
+                        project?.defaultEnvironment,
+                      )}
+                      sx={{
+                        height: 16,
+                        fontSize: "0.62rem",
+                        flexShrink: 0,
+                        "& .MuiChip-label": { px: 0.5 },
+                      }}
+                    />
+                  </Tooltip>
+                )}
                 {run.durationMs !== undefined && (
                   <Typography variant="caption" color="text.secondary">
                     {formatDuration(run.durationMs)}
@@ -557,6 +597,20 @@ export default function DbtRunHistory({
               ),
             }}
           />
+          {selectedDetail?.environment && (
+            <Tooltip title={envTooltip(selectedDetail.environment)}>
+              <Chip
+                label={selectedDetail.environment}
+                size="small"
+                variant="outlined"
+                color={envBadgeColor(
+                  selectedDetail.environment,
+                  project?.defaultEnvironment,
+                )}
+                sx={{ height: 20 }}
+              />
+            </Tooltip>
+          )}
           <Typography
             variant="caption"
             color="text.secondary"

--- a/app/src/lib/dbt-env.ts
+++ b/app/src/lib/dbt-env.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared helpers for dbt environment badges (jobs list, run history).
+ */
+
+/**
+ * MUI Chip color for a dbt environment badge. Prod-like envs are flagged
+ * `warning` so destructive/scheduled prod runs stand out; the project default
+ * and dev-like envs get `info`, everything else stays neutral.
+ */
+export function envBadgeColor(
+  envName: string,
+  defaultEnvironment?: string,
+): "warning" | "info" | "default" {
+  const lower = envName.trim().toLowerCase();
+  if (lower === "prod" || lower === "production") return "warning";
+  if (
+    lower === "dev" ||
+    lower === "development" ||
+    (defaultEnvironment != null && envName === defaultEnvironment)
+  ) {
+    return "info";
+  }
+  return "default";
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In the dbt Transforms run history (project-wide **Runs** tab and job-scoped history), each run record stores the dbt `environment` it targeted, but the UI never displayed it. The project-wide Runs view mixes agent, manual, scheduled, and CI runs that can target different environments (e.g. `dev` vs `prod`), so you couldn't tell which environment a run hit.

## Changes

- `app/src/components/DbtRunHistory.tsx`: each run row and the detail summary strip now show an environment chip, colored via the shared `envBadgeColor` helper (prod-like envs `warning`, dev/default `info`). The chip tooltip resolves what the environment targets — connection name + target schema — from the project's environment config, falling back to the bare env name for environments removed from the config after the run.
- `app/src/lib/dbt-env.ts` (new): `envBadgeColor` extracted from `DbtExplorer.tsx` so the jobs list and run history share the same badge colors.
- `app/src/components/DbtExplorer.tsx`: imports the shared helper instead of a local copy.

## Demo

[dbt_runs_history_environment_chips_demo.mp4](https://cursor.com/agents/bc-43522459-deb7-4f2d-b11d-c4a6e1d63c36/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdbt_runs_history_environment_chips_demo.mp4)

[Runs list with env chips](https://cursor.com/agents/bc-43522459-deb7-4f2d-b11d-c4a6e1d63c36/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fruns_list_with_env_chips.webp)
[Prod run detail with env tooltip](https://cursor.com/agents/bc-43522459-deb7-4f2d-b11d-c4a6e1d63c36/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprod_run_detail_env_tooltip.webp)

## Testing

- `pnpm --filter app run typecheck`
- `pnpm --filter app run lint`
- Manual GUI verification of the Runs tab against seeded runs across `dev`/`prod` environments (chips, colors, tooltips) — see video above.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43522459-deb7-4f2d-b11d-c4a6e1d63c36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43522459-deb7-4f2d-b11d-c4a6e1d63c36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

