### PR TITLE
feat(plan): Cursor-style plan feedback — show feedback as a chat user message

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -13,7 +13,7 @@
     "worker:dev": "tsx watch --include \"src/**/*\" src/worker.ts",
     "migrate:workspaces": "tsx src/migrations/migrate-to-workspaces.ts",
     "openapi:generate": "tsx src/openapi/generate-cli.ts",
-    "test": "tsx src/openapi/core.test.ts && tsx src/openapi/openapi.test.ts && tsx src/dbt/warm-dir-cache.test.ts && tsx src/connectors/stripe/connector.test.ts && tsx src/connectors/close/connector.test.ts && tsx src/connectors/pandadoc/connector.test.ts && tsx src/connectors/claap/connector.test.ts && tsx src/sync-cdc/idempotency.test.ts && tsx src/agent-lib/context/compaction.test.ts && tsx src/services/safe-fetch.service.test.ts && tsx src/agent-lib/tools/check-query-status-poll.test.ts && tsx src/agent-lib/tools/str-replace.test.ts",
+    "test": "tsx src/openapi/core.test.ts && tsx src/openapi/openapi.test.ts && tsx src/dbt/warm-dir-cache.test.ts && tsx src/connectors/stripe/connector.test.ts && tsx src/connectors/close/connector.test.ts && tsx src/connectors/pandadoc/connector.test.ts && tsx src/connectors/claap/connector.test.ts && tsx src/sync-cdc/idempotency.test.ts && tsx src/agent-lib/context/compaction.test.ts && tsx src/services/safe-fetch.service.test.ts && tsx src/agent-lib/tools/check-query-status-poll.test.ts && tsx src/agent-lib/tools/str-replace.test.ts && tsx src/agents/modes/derive-mode-state.test.ts",
     "test:dbt": "vitest run",
     "test:dbt:watch": "vitest",
     "test:destinations": "vitest run --config vitest.destinations.config.ts",

--- a/api/src/agents/modes/derive-mode-state.test.ts
+++ b/api/src/agents/modes/derive-mode-state.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for `deriveModeState` — the stateless plan-gate / expertise-mode
+ * scan over the chat history. Focus: the conversational plan-iteration rule
+ * (a user message following a `request_changes` decision keeps the gate
+ * engaged, Cursor-style, because that message IS the plan feedback).
+ *
+ * Run: tsx src/agents/modes/derive-mode-state.test.ts
+ */
+import assert from "node:assert/strict";
+import type { UIMessage } from "ai";
+import { deriveModeState } from "./runtime";
+
+type Part = Record<string, unknown>;
+
+let idCounter = 0;
+const msg = (role: "user" | "assistant", parts: Part[]): UIMessage =>
+  ({ id: `m${idCounter++}`, role, parts }) as unknown as UIMessage;
+
+const user = (text: string) => msg("user", [{ type: "text", text }]);
+
+const submitPlan = (decision?: "approve" | "request_changes" | "cancel") =>
+  msg("assistant", [
+    {
+      type: "tool-submit_plan",
+      toolCallId: `c${idCounter}`,
+      state: decision ? "output-available" : "input-available",
+      input: { title: "Plan", planMarkdown: "…", todos: [] },
+      ...(decision ? { output: { success: true, decision } } : {}),
+    },
+  ]);
+
+// --- pending submission stays gated -----------------------------------------
+{
+  const state = deriveModeState([user("do it"), submitPlan()], "query");
+  assert.equal(state.planSubmitted, true);
+  assert.equal(state.planApproved, false);
+}
+
+// --- approval unlocks writes -------------------------------------------------
+{
+  const state = deriveModeState(
+    [user("do it"), submitPlan("approve")],
+    "query",
+  );
+  assert.equal(state.planSubmitted, true);
+  assert.equal(state.planApproved, true);
+}
+
+// --- feedback user message after request_changes KEEPS the gate engaged ------
+{
+  const state = deriveModeState(
+    [user("do it"), submitPlan("request_changes"), user("also add a chart")],
+    "query",
+  );
+  assert.equal(
+    state.planSubmitted,
+    true,
+    "plan iteration feedback must not lift the gate",
+  );
+  assert.equal(state.planApproved, false);
+}
+
+// --- iteration loop: revised plan approved after feedback --------------------
+{
+  const state = deriveModeState(
+    [
+      user("do it"),
+      submitPlan("request_changes"),
+      user("also add a chart"),
+      submitPlan("approve"),
+    ],
+    "query",
+  );
+  assert.equal(state.planSubmitted, true);
+  assert.equal(state.planApproved, true);
+}
+
+// --- a user message after APPROVAL starts a fresh cycle ----------------------
+{
+  const state = deriveModeState(
+    [user("do it"), submitPlan("approve"), user("now something else")],
+    "query",
+  );
+  assert.equal(state.planSubmitted, false);
+  assert.equal(state.planApproved, false);
+}
+
+// --- a user message after CANCEL starts a fresh cycle ------------------------
+{
+  const state = deriveModeState(
+    [user("do it"), submitPlan("cancel"), user("never mind, just query X")],
+    "query",
+  );
+  assert.equal(state.planSubmitted, false);
+  assert.equal(state.planApproved, false);
+}
+
+// --- multi-round iteration keeps the gate through every feedback message -----
+{
+  const state = deriveModeState(
+    [
+      user("do it"),
+      submitPlan("request_changes"),
+      user("feedback 1"),
+      submitPlan("request_changes"),
+      user("feedback 2"),
+    ],
+    "query",
+  );
+  assert.equal(state.planSubmitted, true);
+  assert.equal(state.planApproved, false);
+}
+
+// --- no plan at all ----------------------------------------------------------
+{
+  const state = deriveModeState([user("hello")], "query");
+  assert.equal(state.planSubmitted, false);
+  assert.equal(state.planApproved, false);
+}
+
+// eslint-disable-next-line no-console
+console.log("derive-mode-state.test.ts: all assertions passed");
+
+// runtime.ts transitively imports the full agent stack (loggers, mongoose
+// schemas), which keeps the event loop alive — exit explicitly like
+// openapi/core.test.ts does.
+// eslint-disable-next-line no-process-exit
+process.exit(0);

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -218,7 +218,8 @@ You submitted a plan for this request and the user has NOT approved it yet. Writ
 (creating/modifying consoles or dashboards, running or executing queries, setting form fields,
 writing memory) are DISABLED until the user approves.
 
-- If the user **requested changes**, revise the plan using their feedback and call
+- If the user **requested changes**, their feedback arrives as their latest chat message
+  (it may also be echoed in the tool result). Revise the plan accordingly and call
   \`submit_plan\` again. Use read-only tools if you need more context for the revision.
 - If the user **cancelled**, stop and ask how they would like to proceed instead.
 - NEVER attempt a mutating tool before approval — it will be rejected.`;

--- a/api/src/agents/modes/runtime.ts
+++ b/api/src/agents/modes/runtime.ts
@@ -67,13 +67,22 @@ export function deriveModeState(
   const enabledModes = new Set<ExpertiseModeId>([defaultMode]);
   let planSubmitted = false;
   let planApproved = false;
+  let lastPlanDecision: unknown;
 
   for (const message of messages) {
-    // A new user turn starts a fresh plan cycle: any previous submission or
-    // approval is stale for the new request. Enabled expertise modes are
-    // intentionally NOT reset (they accumulate across the conversation).
+    // A new user turn normally starts a fresh plan cycle: any previous
+    // submission or approval is stale for the new request. Exception
+    // (conversational plan iteration, Cursor-style): when the latest plan was
+    // resolved with request_changes, the following user message IS the
+    // feedback — the gate stays engaged so the model revises and re-submits
+    // instead of mutating. Enabled expertise modes are intentionally NOT
+    // reset (they accumulate across the conversation).
     if (message.role === "user") {
-      planSubmitted = false;
+      const isPlanIterationFeedback =
+        planSubmitted && !planApproved && lastPlanDecision === "request_changes";
+      if (!isPlanIterationFeedback) {
+        planSubmitted = false;
+      }
       planApproved = false;
     }
 
@@ -90,6 +99,7 @@ export function deriveModeState(
         planSubmitted = true;
         const decision = (part.output as { decision?: unknown } | undefined)
           ?.decision;
+        lastPlanDecision = decision;
         // The latest decision in this turn wins; only an explicit approval
         // unlocks writes. A pending submission (no output yet) stays gated.
         planApproved = decision === "approve";

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -330,6 +330,14 @@ const Chat: React.FC<ChatProps> = ({
   // pendingInteractiveTool memo); declared here so useQueuedPrompts can close
   // over it.
   const pendingPlanToolCallIdRef = useRef<string | null>(null);
+  // One-shot latch: suppress the SDK auto-send triggered by `addToolOutput`
+  // when plan feedback resolves the tool — the feedback is then sent as a
+  // real user message (visible in the chat), carrying the resolved tool
+  // output and the message in a single request. Consumed by the
+  // `sendAutomaticallyWhen` predicate below; reset in onFinish as a leak
+  // guard (e.g. the SDK skipped the predicate because a request was already
+  // in flight).
+  const suppressNextAutoSendRef = useRef(false);
   workspaceIdRef.current = currentWorkspace?.id;
   modelIdRef.current = selectedModelId;
   chatIdRef.current = chatId;
@@ -340,6 +348,20 @@ const Chat: React.FC<ChatProps> = ({
     }
     return lastAssistantMessageIsCompleteWithToolCalls(options);
   }, []);
+
+  // The predicate handed to useChat. Split from `autoSendWhenComplete` (also
+  // used by the queued-prompt drain as a soft-block mirror) so the one-shot
+  // plan-feedback latch is only ever consumed by the SDK's own check.
+  const sdkAutoSendWhen = useCallback(
+    (options: AutoSendPredicateArgs) => {
+      if (suppressNextAutoSendRef.current) {
+        suppressNextAutoSendRef.current = false;
+        return false;
+      }
+      return autoSendWhenComplete(options);
+    },
+    [autoSendWhenComplete],
+  );
 
   // Create transport once — prepareSendMessagesRequest reads all dynamic
   // values from getState() / refs at request time, so the transport identity
@@ -444,7 +466,7 @@ const Chat: React.FC<ChatProps> = ({
     experimental_throttle: 50,
 
     // Automatically submit when all tool results are available
-    sendAutomaticallyWhen: autoSendWhenComplete,
+    sendAutomaticallyWhen: sdkAutoSendWhen,
 
     // Handle client-side tools (console operations). The implementation
     // lives in useClientToolDispatch (it needs useChat state for its
@@ -467,8 +489,10 @@ const Chat: React.FC<ChatProps> = ({
       // prompts off it. (A force-send drains via the status-transition
       // effect once the interrupted turn settles.)
       if (isAbort) return;
-      // The turn settled cleanly — reset the resume-retry budget.
+      // The turn settled cleanly — reset the resume-retry budget and release
+      // a plan-feedback auto-send latch that was never consumed (leak guard).
       errorResumeRef.current.count = 0;
+      suppressNextAutoSendRef.current = false;
       if (!isExistingChatRef.current) {
         fetchSessionsRef.current?.();
       }
@@ -781,11 +805,12 @@ const Chat: React.FC<ChatProps> = ({
   // routed to the tool output as request_changes feedback instead of a normal
   // user message. Ref (declared above useChat) keeps handleChatSubmit's
   // identity stable (perf rules).
-  pendingPlanToolCallIdRef.current =
+  const isPlanAwaitingFeedback =
     pendingInteractiveTool?.toolName === "submit_plan" &&
-    !pendingInteractiveTool.streaming
-      ? pendingInteractiveTool.toolCallId
-      : null;
+    !pendingInteractiveTool.streaming;
+  pendingPlanToolCallIdRef.current = isPlanAwaitingFeedback
+    ? pendingInteractiveTool.toolCallId
+    : null;
 
   // Pending submit_plan: register the plan + its resolver in planStore and
   // auto-open the main-view plan tab (once per toolCallId, as soon as
@@ -889,6 +914,7 @@ const Chat: React.FC<ChatProps> = ({
     capturedDashboardIdRef,
     activeConsoleIdRef,
     pendingPlanToolCallIdRef,
+    suppressNextAutoSendRef,
     autoSendWhenComplete,
     interruptActiveTurn,
     drainQueuedPromptAfterTurnRef,
@@ -1319,6 +1345,7 @@ const Chat: React.FC<ChatProps> = ({
         paletteMode={paletteMode}
         editingPrompt={editingPrompt}
         onCancelEdit={handleCancelEditQueuedPrompt}
+        planFeedbackMode={isPlanAwaitingFeedback}
       />
 
       {/* Tool Debug Dialog */}

--- a/app/src/components/PlanCard.tsx
+++ b/app/src/components/PlanCard.tsx
@@ -4,12 +4,15 @@ import {
   Button,
   Chip,
   CircularProgress,
+  IconButton,
   Stack,
+  Tooltip,
   Typography,
 } from "@mui/material";
-import { ClipboardList } from "lucide-react";
+import { ClipboardList, X } from "lucide-react";
 import type { SubmitPlanInput, SubmitPlanOutput } from "@mako/agent-tools";
 import {
+  closePlanTab,
   DECISION_COLOR,
   DECISION_LABEL,
   focusPlanTab,
@@ -82,6 +85,16 @@ export const PlanCard: React.FC<PlanCardProps> = ({
     focusPlanTab(toolCallId, chatId ?? plan?.chatId ?? "", title);
   };
 
+  // Discard (Cursor-style "not now"): resolves the deferred tool with a
+  // cancel decision — the agent stops without executing — and closes the
+  // plan tab. The summary card stays in the chat with a "Cancelled" chip.
+  const discardPlan = () => {
+    if (!toolCallId) return;
+    if (resolvePlan(toolCallId, "cancel")) {
+      closePlanTab(toolCallId, chatId ?? plan?.chatId ?? "");
+    }
+  };
+
   return (
     <Box
       onClick={openTab}
@@ -146,16 +159,30 @@ export const PlanCard: React.FC<PlanCardProps> = ({
           />
         )}
         {pending && (
-          <Button
-            size="small"
-            variant="contained"
-            onClick={e => {
-              e.stopPropagation();
-              resolvePlan(toolCallId, "approve");
-            }}
-          >
-            Approve &amp; run
-          </Button>
+          <>
+            <Tooltip title="Discard plan" placement="top">
+              <IconButton
+                size="small"
+                aria-label="Discard plan"
+                onClick={e => {
+                  e.stopPropagation();
+                  discardPlan();
+                }}
+              >
+                <X size={15} />
+              </IconButton>
+            </Tooltip>
+            <Button
+              size="small"
+              variant="contained"
+              onClick={e => {
+                e.stopPropagation();
+                resolvePlan(toolCallId, "approve");
+              }}
+            >
+              Approve &amp; run
+            </Button>
+          </>
         )}
       </Stack>
     </Box>

--- a/app/src/components/PlanDocumentTab.tsx
+++ b/app/src/components/PlanDocumentTab.tsx
@@ -26,6 +26,7 @@ import {
 } from "lucide-react";
 import type { PlanTodo } from "@mako/agent-tools";
 import {
+  closePlanTab,
   DECISION_COLOR,
   DECISION_LABEL,
   usePlanStore,
@@ -295,6 +296,19 @@ export default function PlanDocumentTab({
             <Typography variant="caption" color="text.secondary">
               or reply in chat to iterate on the plan
             </Typography>
+            <Button
+              size="small"
+              color="inherit"
+              onClick={() => {
+                // Cancel decision → the agent stops without executing; the
+                // tab closes and the chat card keeps a "Cancelled" summary.
+                if (resolvePlan(toolCallId, "cancel")) {
+                  closePlanTab(toolCallId, plan.chatId);
+                }
+              }}
+            >
+              Discard
+            </Button>
             <Button
               size="small"
               variant="contained"

--- a/app/src/components/PlanDocumentTab.tsx
+++ b/app/src/components/PlanDocumentTab.tsx
@@ -269,12 +269,6 @@ export default function PlanDocumentTab({
                 )}
               </Box>
             )}
-
-            {!pending && plan.output?.feedback && (
-              <Typography variant="body2" color="warning.main" mt={2}>
-                Feedback: {plan.output.feedback}
-              </Typography>
-            )}
           </Box>
         )}
       </Box>

--- a/app/src/components/chat/ChatInputArea.tsx
+++ b/app/src/components/chat/ChatInputArea.tsx
@@ -32,6 +32,9 @@ interface ChatInputAreaProps {
   paletteMode: "light" | "dark";
   editingPrompt: QueuedPrompt | null;
   onCancelEdit: () => void;
+  /** A submitted plan is awaiting review — sent messages become plan
+   * feedback (Cursor-style), so the placeholder reflects that. */
+  planFeedbackMode?: boolean;
 }
 
 function readFileAsDataUrl(file: File): Promise<string> {
@@ -53,6 +56,7 @@ export const ChatInputArea = React.memo(
     paletteMode: _paletteMode,
     editingPrompt,
     onCancelEdit,
+    planFeedbackMode = false,
   }: ChatInputAreaProps) => {
     const [input, setInput] = useState("");
     const [images, setImages] = useState<ImageAttachment[]>([]);
@@ -328,7 +332,11 @@ export const ChatInputArea = React.memo(
             minRows={1}
             maxRows={24}
             placeholder={
-              editingPrompt ? "Edit queued message..." : "Ask Chat..."
+              editingPrompt
+                ? "Edit queued message..."
+                : planFeedbackMode
+                  ? "Suggest changes to the plan..."
+                  : "Ask Chat..."
             }
             value={input}
             onChange={e => setInput(e.target.value)}

--- a/app/src/components/chat/hooks/useQueuedPrompts.ts
+++ b/app/src/components/chat/hooks/useQueuedPrompts.ts
@@ -35,6 +35,11 @@ export interface UseQueuedPromptsArgs {
   capturedDashboardIdRef: MutableRefObject<string | null>;
   activeConsoleIdRef: MutableRefObject<string | null>;
   pendingPlanToolCallIdRef: MutableRefObject<string | null>;
+  /** One-shot latch consumed by the SDK's `sendAutomaticallyWhen` predicate.
+   * Set right before resolving a plan with feedback so `addToolOutput` does
+   * not auto-send — the feedback `sendMessage` below carries the resolved
+   * tool output AND the user message in a single request. */
+  suppressNextAutoSendRef: MutableRefObject<boolean>;
   autoSendWhenComplete: (options: AutoSendPredicateArgs) => boolean;
   interruptActiveTurn: () => void;
   /**
@@ -63,6 +68,7 @@ export function useQueuedPrompts({
   capturedDashboardIdRef,
   activeConsoleIdRef,
   pendingPlanToolCallIdRef,
+  suppressNextAutoSendRef,
   autoSendWhenComplete,
   interruptActiveTurn,
   drainQueuedPromptAfterTurnRef,
@@ -216,23 +222,41 @@ export function useQueuedPrompts({
         return;
       }
 
-      // Conversational plan iteration (Cursor-style): while a submitted plan is
-      // awaiting review, the typed message becomes request_changes feedback on
-      // the plan — including the current draft, so manual edits made in the
-      // plan tab flow back — instead of a normal user message.
+      // Conversational plan iteration (Cursor-style): while a submitted plan
+      // is awaiting review, the typed message resolves the plan as
+      // request_changes (carrying the current draft, so manual edits made in
+      // the plan tab flow back) AND is sent as a real user message so the
+      // feedback stays visible in the chat transcript. The suppress latch
+      // stops `addToolOutput`'s auto-send; the `sendMessage` below ships the
+      // resolved tool output and the feedback in one request.
       const pendingPlanToolCallId = pendingPlanToolCallIdRef.current;
       if (pendingPlanToolCallId) {
         const planStore = usePlanStore.getState();
         const planEntry = planStore.plans[pendingPlanToolCallId];
         const feedback = text.trim();
         if (planEntry?.status === "pending" && feedback) {
-          trackEvent("ai_plan_feedback_sent", { model: modelIdRef.current });
-          planStore.resolvePlan(
+          suppressNextAutoSendRef.current = true;
+          // The latch is consumed (one-shot) inside the SDK's
+          // sendAutomaticallyWhen predicate, normally synchronously via the
+          // resolver → addToolOutput → predicate chain.
+          const resolved = planStore.resolvePlan(
             pendingPlanToolCallId,
             "request_changes",
             feedback,
           );
-          return;
+          if (resolved) {
+            trackEvent("ai_plan_feedback_sent", { model: modelIdRef.current });
+            capturedConsoleIdRef.current = activeConsoleIdRef.current;
+            isLoadingRef.current = true;
+            manualStopRequestedRef.current = false;
+            sendMessageRef.current?.({ text: feedback, files });
+            return;
+          }
+          // No live resolver (should not happen while the plan is pending in
+          // the live messages) — release the unconsumed latch and fall
+          // through to the normal send path so the user's message is never
+          // silently swallowed.
+          suppressNextAutoSendRef.current = false;
         }
       }
 
@@ -284,6 +308,7 @@ export function useQueuedPrompts({
       modelIdRef,
       pendingPlanToolCallIdRef,
       sendMessageRef,
+      suppressNextAutoSendRef,
     ],
   );
 

--- a/app/src/store/planStore.ts
+++ b/app/src/store/planStore.ts
@@ -327,6 +327,18 @@ export function focusPlanTab(
   return id;
 }
 
+/** Close the plan's main-view tab (no-op when it is not open or has been
+ * re-pointed to a different toolCallId). Used when the user discards a
+ * pending plan — the inline summary card in the chat history can re-open it
+ * read-only. */
+export function closePlanTab(toolCallId: string, chatId: string): void {
+  const consoleStore = useConsoleStore.getState();
+  const id = planTabId(toolCallId, chatId);
+  const tab = consoleStore.tabs[id];
+  if (!tab || tab.metadata?.toolCallId !== toolCallId) return;
+  consoleStore.closeTab(id);
+}
+
 /** Keep the plan tab's title in sync as it streams/finalizes (no-op when the
  * tab is closed or the title is unchanged — cheap to call per delta). */
 export function syncPlanTabTitle(

--- a/app/src/store/planStore.ts
+++ b/app/src/store/planStore.ts
@@ -97,12 +97,13 @@ interface PlanActions {
   removeTodo: (toolCallId: string, index: number) => void;
   registerResolver: (toolCallId: string, resolver: PlanResolver) => void;
   /** Resolve the deferred tool with the current draft as `editedPlan`
-   * (omitted on cancel, matching the original PlanCard behavior). */
+   * (omitted on cancel, matching the original PlanCard behavior). Returns
+   * false when the plan is not pending or no live resolver is registered. */
   resolvePlan: (
     toolCallId: string,
     decision: PlanDecision,
     feedback?: string,
-  ) => void;
+  ) => boolean;
   /** Hydrate an already-resolved plan from message history (reload / old
    * chats). Idempotent and safe to call from effects. */
   markResolved: (toolCallId: string, output: SubmitPlanOutput) => void;
@@ -212,9 +213,9 @@ export const usePlanStore = create<PlanStore>()(
 
       resolvePlan: (toolCallId, decision, feedback) => {
         const plan = get().plans[toolCallId];
-        if (!plan || plan.status !== "pending") return;
+        if (!plan || plan.status !== "pending") return false;
         const resolver = resolvers.get(toolCallId);
-        if (!resolver) return;
+        if (!resolver) return false;
 
         const output: SubmitPlanOutput = {
           success: true,
@@ -242,6 +243,7 @@ export const usePlanStore = create<PlanStore>()(
           entry.status = decision;
           entry.output = output;
         });
+        return true;
       },
 
       markResolved: (toolCallId, output) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When a submitted plan is awaiting review, typing feedback in the chat composer resolved the `submit_plan` tool with `request_changes` and swallowed the message: it never appeared in the chat transcript, only as a `Feedback: ...` line at the bottom of the plan document (which then vanished when the revision re-pointed the tab). There was also no way to discard a pending plan — the `"cancel"` decision existed in the schema but had no UI trigger.

## Fix (Cursor-like UX)

- Plan feedback typed in the composer now resolves the plan (`request_changes` + the current edited draft) **and** is sent as a real user message, so the feedback stays visible in the chat between the old and revised plan cards.
- A one-shot suppress latch stops `addToolOutput`'s SDK auto-send so the resolved tool output and the feedback message ride a **single** request (no double turn).
- `deriveModeState` keeps the plan gate engaged across the feedback user message: iteration keeps mutating tools blocked so the model revises and re-submits the plan instead of executing.
- Removed the `Feedback: ...` line at the bottom of `PlanDocumentTab`.
- **Discard a pending plan**: X icon on the docked plan card and a `Discard` button in the plan tab's action bar resolve the tool with `decision: "cancel"` — the agent stops without executing, the plan tab closes, and the chat card keeps a "Cancelled" chip.

## Additional improvements

- Composer placeholder switches to `Suggest changes to the plan...` while a plan awaits review.
- Feedback messages now carry image attachments (previously silently dropped).
- If no live resolver is registered (edge case), the message falls through to the normal send path instead of being silently swallowed (`resolvePlan` now returns a boolean).
- New unit test `api/src/agents/modes/derive-mode-state.test.ts` wired into the api `test` script.

## Demo

Feedback cycle — feedback typed in the composer shows up as a user message, the old plan flips to "Changes requested", the agent revises the plan, approval unlocks execution and the query runs:

[plan_feedback_full_cycle_feedback_revise_approve_execute.mp4](https://cursor.com/agents/bc-a05698ce-c1a9-4ec5-99e8-0c83916796d1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fplan_feedback_full_cycle_feedback_revise_approve_execute.mp4)

Discard — from the plan tab's action bar and from the docked card's X icon; the agent acknowledges and nothing executes:

[plan_discard_from_tab_and_docked_card_demo.mp4](https://cursor.com/agents/bc-a05698ce-c1a9-4ec5-99e8-0c83916796d1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fplan_discard_from_tab_and_docked_card_demo.mp4)

[Feedback visible as a user message between the old (Changes requested) and revised plan cards](https://cursor.com/agents/bc-a05698ce-c1a9-4ec5-99e8-0c83916796d1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffeedback_as_user_message_in_chat.webp)
[Discarded plans show Cancelled chips; agent asks how to proceed](https://cursor.com/agents/bc-a05698ce-c1a9-4ec5-99e8-0c83916796d1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdiscarded_plans_cancelled_chips.webp)
[Plan document bottom — no Feedback line anymore](https://cursor.com/agents/bc-a05698ce-c1a9-4ec5-99e8-0c83916796d1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fplan_document_no_feedback_line.webp)

## Testing

- ✅ `pnpm --filter api exec tsx src/agents/modes/derive-mode-state.test.ts`
- ✅ `pnpm --filter app run typecheck` / `pnpm --filter app run lint`
- ✅ `pnpm --filter api run lint` / `pnpm --filter api run build`
- ⚠️ `pnpm --filter app run test:unit` — 268/269 pass; the one failure (`dbtStore.test.ts` fetchRuns) is pre-existing on master.
- ✅ Manual E2E (videos): plan → feedback in chat → revision → approve → execute; discard from both the plan tab and the docked card.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a05698ce-c1a9-4ec5-99e8-0c83916796d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a05698ce-c1a9-4ec5-99e8-0c83916796d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

