### PR TITLE
fix(dbt): keep branch + changes panel in sync across windows

### DIFF
--- a/api/src/routes/dbt.routes.integration.test.ts
+++ b/api/src/routes/dbt.routes.integration.test.ts
@@ -123,7 +123,9 @@ import {
   requestDbtRunCancel,
   triggerDbtRunRetry,
 } from "../dbt/dbt-run.service";
+import { publishRealtimeEvent } from "../services/realtime.service";
 
+const publishMock = publishRealtimeEvent as unknown as ReturnType<typeof vi.fn>;
 const adhocMock = runAdhocDbtCommand as unknown as ReturnType<typeof vi.fn>;
 const cancelMock = requestDbtRunCancel as unknown as ReturnType<typeof vi.fn>;
 const retryMock = triggerDbtRunRetry as unknown as ReturnType<typeof vi.fn>;
@@ -323,6 +325,39 @@ describe("file CRUD", () => {
       { content: "x".repeat(1_000_001) },
     );
     expect(res.status).toBe(400);
+  });
+
+  it("rename pokes both paths over the realtime channel", async () => {
+    const projectId = await createProjectAsOwner();
+    await req("PUT", `/projects/${projectId}/files/models/old.sql`, {
+      content: "select 1",
+    });
+    publishMock.mockClear();
+
+    const res = await req("POST", `/projects/${projectId}/files/rename`, {
+      from: "models/old.sql",
+      to: "models/new.sql",
+      clientId: "tab-1",
+    });
+    expect(res.status).toBe(200);
+
+    // Other windows express the rename as delete(from) + add(to).
+    const events = publishMock.mock.calls.map(call => call[1]);
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "dbt.file.updated",
+        path: "models/old.sql",
+        deleted: true,
+        clientId: "tab-1",
+        origin: "save",
+      }),
+      expect.objectContaining({
+        type: "dbt.file.updated",
+        path: "models/new.sql",
+        clientId: "tab-1",
+        origin: "save",
+      }),
+    ]);
   });
 });
 

--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -1530,7 +1530,11 @@ dbtRoutes.post(
       if (!project) {
         return c.json({ success: false, error: "dbt project not found" }, 404);
       }
-      const body = (await c.req.json()) as { from?: unknown; to?: unknown };
+      const body = (await c.req.json()) as {
+        from?: unknown;
+        to?: unknown;
+        clientId?: unknown;
+      };
       const from = typeof body.from === "string" ? body.from : "";
       const to = typeof body.to === "string" ? body.to : "";
       if (!isSafeDbtPath(from) || !isSafeDbtPath(to)) {
@@ -1542,6 +1546,31 @@ dbtRoutes.post(
         return c.json({ success: false, error: renameError }, 404);
       }
       if (renameError) return badRequest(c, renameError);
+      // The working tree expresses a rename as delete(from) + add(to) — poke
+      // both paths so the acting user's other windows (and, for blank
+      // projects, the whole workspace) move the file and refresh git status.
+      const clientId =
+        typeof body.clientId === "string" ? body.clientId : undefined;
+      const forUserId = project.repo ? userId : undefined;
+      publishDbtEvent(c, {
+        type: "dbt.file.updated",
+        projectId: project._id.toString(),
+        path: from,
+        deleted: true,
+        updatedBy: userId,
+        clientId,
+        origin: "save",
+        forUserId,
+      });
+      publishDbtEvent(c, {
+        type: "dbt.file.updated",
+        projectId: project._id.toString(),
+        path: to,
+        updatedBy: userId,
+        clientId,
+        origin: "save",
+        forUserId,
+      });
       return c.json({ success: true });
     } catch (error) {
       return serverError(c, error, "Failed to rename dbt file");

--- a/app/src/store/dbtStore.test.ts
+++ b/app/src/store/dbtStore.test.ts
@@ -300,7 +300,12 @@ describe("project update + file list/delete/rename", () => {
     );
     expect(api.post).toHaveBeenCalledWith(
       `/workspaces/${WS}/dbt/projects/p1/files/rename`,
-      { from: "models/a.sql", to: "models/b.sql" },
+      // clientId (per-tab echo suppression) rides along with every rename.
+      {
+        from: "models/a.sql",
+        to: "models/b.sql",
+        clientId: expect.any(String),
+      },
     );
   });
 });
@@ -365,7 +370,10 @@ describe("runs lifecycle", () => {
       runs: [{ _id: "r1", status: "success" }],
     });
     await useDbtStore.getState().fetchRuns(WS, "p1", "j1");
-    expect(useDbtStore.getState().runsByProject.p1).toHaveLength(1);
+    // Job-scoped fetches land in runsByJob (runsByProject is the unfiltered
+    // project-wide list — the two views never clobber each other).
+    expect(useDbtStore.getState().runsByJob.j1).toHaveLength(1);
+    expect(useDbtStore.getState().runsByProject.p1).toBeUndefined();
     expect(api.get).toHaveBeenCalledWith(
       `/workspaces/${WS}/dbt/projects/p1/runs`,
       { jobId: "j1", limit: "100" },
@@ -445,6 +453,76 @@ describe("git / github actions", () => {
     await useDbtStore.getState().switchBranch(WS, "p1", "feature");
     expect(useDbtStore.getState().filesByProject.p1).toBeUndefined();
     expect(useDbtStore.getState().checkoutBranchByProject.p1).toBe("feature");
+  });
+
+  it("reconcileRemoteGitState refetches status only for loaded repo projects", async () => {
+    api.get.mockResolvedValueOnce({
+      success: true,
+      projects: [
+        { ...project("p1"), repo: { owner: "o", repo: "r", branch: "main" } },
+        { ...project("p2"), repo: { owner: "o", repo: "r2", branch: "main" } },
+        project("p3"), // blank project — no git surface
+      ],
+    });
+    await useDbtStore.getState().fetchProjects(WS);
+    // Only p1 has pulled git state in this window.
+    api.get.mockResolvedValueOnce({
+      success: true,
+      status: { branch: "main", changes: [], hasChanges: false },
+    });
+    await useDbtStore.getState().fetchGitStatus(WS, "p1");
+    api.get.mockClear();
+
+    api.get.mockResolvedValue({
+      success: true,
+      status: {
+        branch: "main",
+        changes: [{ path: "models/a.sql", status: "modified" }],
+        hasChanges: true,
+      },
+    });
+    await useDbtStore.getState().reconcileRemoteGitState(WS);
+    expect(api.get).toHaveBeenCalledTimes(1);
+    expect(api.get).toHaveBeenCalledWith(
+      `/workspaces/${WS}/dbt/projects/p1/git/status`,
+    );
+    expect(useDbtStore.getState().gitStatusByProject.p1.changes).toHaveLength(
+      1,
+    );
+  });
+
+  it("reconcileRemoteGitState reloads the tree when the branch moved", async () => {
+    api.get.mockResolvedValueOnce({
+      success: true,
+      projects: [
+        { ...project("p1"), repo: { owner: "o", repo: "r", branch: "main" } },
+      ],
+    });
+    await useDbtStore.getState().fetchProjects(WS);
+    api.get.mockResolvedValueOnce({
+      success: true,
+      status: { branch: "main", changes: [], hasChanges: false },
+    });
+    await useDbtStore.getState().fetchGitStatus(WS, "p1");
+    useDbtStore.getState().writeFile("p1", "models/a.sql", "old branch");
+    api.get.mockClear();
+
+    // The server says the checkout now points at "feature" (missed poke).
+    api.get.mockImplementation(async (url: string) => {
+      if (url.endsWith("/git/status")) {
+        return {
+          success: true,
+          status: { branch: "feature", changes: [], hasChanges: false },
+        };
+      }
+      return { success: true, files: [{ path: "models/b.sql" }] };
+    });
+    await useDbtStore.getState().reconcileRemoteGitState(WS);
+    const s = useDbtStore.getState();
+    expect(s.checkoutBranchByProject.p1).toBe("feature");
+    // Stale old-branch buffers were dropped and the tree reloaded.
+    expect(s.filesByProject.p1).toBeUndefined();
+    expect(s.filePathsByProject.p1).toEqual(["models/b.sql"]);
   });
 
   it("openPullRequest returns the PR number + url", async () => {

--- a/app/src/store/dbtStore.ts
+++ b/app/src/store/dbtStore.ts
@@ -501,6 +501,13 @@ interface DbtActions {
     projectId: string,
     branch: string,
   ) => Promise<void>;
+  /**
+   * Focus/reconnect backstop (same role syncRevisions plays for consoles):
+   * re-pull the working-tree git status for every repo-bound project this
+   * window has loaded, so missed SSE pokes (backgrounded tab, dropped
+   * stream) cannot leave the branch label or change list stale.
+   */
+  reconcileRemoteGitState: (workspaceId: string) => Promise<void>;
 
   fetchJobs: (workspaceId: string, projectId: string) => Promise<void>;
   saveJob: (
@@ -1335,6 +1342,37 @@ export const useDbtStore = create<DbtStore>()(
       ]);
     },
 
+    reconcileRemoteGitState: async workspaceId => {
+      const state = get();
+      // Only repo-bound projects this window already pulled state for — a
+      // window that never opened the dbt surface has nothing to reconcile
+      // (DbtExplorer fetches fresh state on mount).
+      const projectIds = state.projects
+        .filter(
+          project =>
+            project.repo &&
+            (state.gitStatusByProject[project._id] ||
+              state.filePathsByProject[project._id]),
+        )
+        .map(project => project._id);
+      await Promise.all(
+        projectIds.map(async projectId => {
+          const previousBranch = get().checkoutBranchByProject[projectId];
+          const status = await get().fetchGitStatus(workspaceId, projectId);
+          if (!status) return;
+          if (previousBranch && status.branch !== previousBranch) {
+            // The checkout moved while this window missed the poke (e.g.
+            // branch switched in another window during a dropped stream):
+            // the cached tree/contents belong to the old branch.
+            set(draft => {
+              delete draft.filesByProject[projectId];
+            });
+            await get().fetchFiles(workspaceId, projectId);
+          }
+        }),
+      );
+    },
+
     deleteFile: async (workspaceId, projectId, path) => {
       try {
         await apiClient.delete(
@@ -1364,7 +1402,8 @@ export const useDbtStore = create<DbtStore>()(
       try {
         await apiClient.post(
           `/workspaces/${workspaceId}/dbt/projects/${projectId}/files/rename`,
-          { from, to },
+          // clientId lets this tab suppress the echo of its own rename pokes.
+          { from, to, clientId: realtimeClientId },
         );
         set(state => {
           const files = state.filesByProject[projectId];

--- a/app/src/store/realtimeStore.ts
+++ b/app/src/store/realtimeStore.ts
@@ -230,6 +230,18 @@ export const useRealtimeStore = create<RealtimeStore>()(
     };
 
     /**
+     * Reconnect/focus reconciliation for the dbt surface (the counterpart of
+     * syncRevisions for consoles): pokes missed while a window was
+     * backgrounded or its stream was dead would otherwise leave the branch
+     * label / change list stale until a manual refresh.
+     */
+    const syncDbtGitState = () => {
+      const workspaceId = get().workspaceId;
+      if (!workspaceId) return;
+      void useDbtStore.getState().reconcileRemoteGitState(workspaceId);
+    };
+
+    /**
      * A remote update was deferred (banner) only because the user was
      * mid-typing — re-run the sync once the recency window has passed so a
      * now-quiescent tab converges on its own. Without this, a single remote
@@ -420,16 +432,27 @@ export const useRealtimeStore = create<RealtimeStore>()(
       if (isForAnotherUser(event.forUserId)) return;
       const workspaceId = get().workspaceId;
       if (!workspaceId) return;
-      // Only touch projects this window has loaded.
-      if (!useDbtStore.getState().filePathsByProject[event.projectId]) return;
-      void useDbtStore
-        .getState()
-        .applyRemoteFileUpdate(
+      const dbt = useDbtStore.getState();
+      // Only touch projects this window has loaded (file tree OR the
+      // version-control panel's git status — they load independently).
+      const hasFiles = Boolean(dbt.filePathsByProject[event.projectId]);
+      const hasStatus = Boolean(dbt.gitStatusByProject[event.projectId]);
+      if (!hasFiles && !hasStatus) return;
+      if (hasFiles) {
+        void dbt.applyRemoteFileUpdate(
           workspaceId,
           event.projectId,
           event.path,
           event.deleted,
         );
+      }
+      // A draft save/delete/rename changes the working-tree status too —
+      // refresh so the branch panel's change list and A/M/D badges stay in
+      // sync across the user's windows (not just the one that edited).
+      const project = dbt.projects.find(p => p._id === event.projectId);
+      if (project?.repo) {
+        void dbt.fetchGitStatus(workspaceId, event.projectId);
+      }
     };
 
     // Git surface changed (commit/sync/merge/branch delete — human or agent):
@@ -443,7 +466,15 @@ export const useRealtimeStore = create<RealtimeStore>()(
       const workspaceId = get().workspaceId;
       if (!workspaceId) return;
       const dbt = useDbtStore.getState();
-      if (!dbt.filePathsByProject[event.projectId]) return;
+      // React when this window holds ANY state for the project: the
+      // version-control panel loads git status for every repo project, even
+      // ones whose file tree was never expanded.
+      if (
+        !dbt.filePathsByProject[event.projectId] &&
+        !dbt.gitStatusByProject[event.projectId]
+      ) {
+        return;
+      }
       void dbt.applyRemoteGitUpdate(workspaceId, event.projectId);
     };
 
@@ -650,6 +681,7 @@ export const useRealtimeStore = create<RealtimeStore>()(
         // Reconnect is a refetch, not a replay: reconcile everything the
         // window has open against current server revisions.
         void get().syncRevisions();
+        syncDbtGitState();
       };
 
       source.addEventListener("message", (e: MessageEvent) => {
@@ -702,6 +734,7 @@ export const useRealtimeStore = create<RealtimeStore>()(
         // Connection looks healthy; revisions may still have moved while we
         // were backgrounded (throttled timers) — reconcile.
         void get().syncRevisions();
+        syncDbtGitState();
       } else {
         // Stream missing, mid-backoff, or silent past ~1.5 heartbeats.
         // `status === "open"` is NOT trustworthy here: Chrome freezes


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The dbt left panel's Version control section (current branch + change list) diverged between browser windows of the same user session. Opening a second window showed stale branch/changes until a manual refresh.

## Root causes

1. `dbt.file.updated` pokes pulled fresh file content in other windows but never refreshed the working-tree git status, so the change list / A-M-D badges stayed stale after every draft save in another window.
2. Wake/reconnect reconciliation (`syncRevisions`) only covered consoles — pokes missed while a window was backgrounded or its SSE stream was dead left dbt branch/changes permanently stale.
3. Realtime handlers were gated on the file tree being loaded, dropping events for repo projects whose git status was loaded but tree never expanded.
4. `POST .../files/rename` published no realtime event at all.

## Fix

- `realtimeStore.handleDbtFileUpdated` also refetches git status for repo-bound projects (echo-suppressed by clientId; scoped to the acting user via `forUserId`).
- New `dbtStore.reconcileRemoteGitState` — the dbt counterpart of console `syncRevisions` — runs on wake and SSE reconnect: re-pulls git status for every repo project the window loaded, and when the checkout branch moved (missed poke) drops the stale tree cache and reloads it.
- Softened load gates in `handleDbtFileUpdated` / `handleDbtGitUpdated` to react when either the file tree or the git status is loaded.
- Rename route now publishes `dbt.file.updated` for both paths (delete `from` + add `to`), with clientId echo suppression from the client.
- Fixed a stale `fetchRuns` unit test asserting pre-`runsByJob` behavior.

## Demos (two side-by-side windows, same user)

Live sync: edit + rename in the left window; the right window's Version control panel updates by itself within ~1–2s:

[dbt_panel_cross_window_live_sync_edit_and_rename.mp4](https://cursor.com/agents/bc-2ecf46f4-6245-4543-86d1-b9eda7d21491/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdbt_panel_cross_window_live_sync_edit_and_rename.mp4)

Wake reconciliation: the checkout was moved server-side with the SSE poke suppressed (simulated missed event); merely focusing each window flips it from `main` to `feature/wake-test` and loads the new branch's tree:

[dbt_panel_wake_reconcile_branch_switch_on_focus.mp4](https://cursor.com/agents/bc-2ecf46f4-6245-4543-86d1-b9eda7d21491/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdbt_panel_wake_reconcile_branch_switch_on_focus.mp4)

[Right window auto-shows the left window](https://cursor.com/agents/bc-2ecf46f4-6245-4543-86d1-b9eda7d21491/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_right_window_auto_shows_edit.webp)
[Both windows show the rename as M/A/D changes](https://cursor.com/agents/bc-2ecf46f4-6245-4543-86d1-b9eda7d21491/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_both_windows_after_rename_3_changes.webp)

## Testing

- ✅ `pnpm --filter app exec vitest run src/store/dbtStore.test.ts` (33 tests, incl. 2 new reconcile tests + rename clientId)
- ✅ `pnpm --filter api exec vitest run src/routes/dbt.routes.integration.test.ts` (23 tests, incl. new rename-poke test)
- ✅ `pnpm --filter app run typecheck && pnpm --filter app run lint`
- ✅ `pnpm --filter api run lint`
- ✅ Manual two-window GUI test (videos above)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ecf46f4-6245-4543-86d1-b9eda7d21491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ecf46f4-6245-4543-86d1-b9eda7d21491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

