### PR TITLE
fix(api): Redis failure ERROR logging + Memorystore migration + preview sweep

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -3,6 +3,11 @@ name: Cleanup PR Preview
 on:
   pull_request:
     types: [closed]
+  # Nightly sweep: catches previews the close-event cleanup missed (workflow
+  # failures, PRs closed before the workflow existed, manual deploys, etc.)
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
 
 env:
   GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
@@ -16,6 +21,7 @@ permissions:
 jobs:
   cleanup:
     name: Cleanup PR #${{ github.event.pull_request.number }}
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -139,3 +145,90 @@ jobs:
               issue_number: prNumber,
               body: body,
             });
+
+  # Nightly sweep of orphaned preview resources. The per-PR cleanup job above
+  # handles the happy path; this catches anything it missed.
+  sweep:
+    name: Sweep stale PR previews
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCP_DEV_SERVICE_ACCOUNT }}
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v3
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: List open PRs
+        run: |
+          gh pr list --repo "${{ github.repository }}" --state open --limit 500 \
+            --json number --jq '.[].number' | sort > /tmp/open_prs.txt
+          echo "Open PRs: $(wc -l < /tmp/open_prs.txt)"
+
+      - name: Delete Cloud Run services for closed PRs
+        run: |
+          gcloud run services list --region "${GCP_REGION}" \
+            --format='value(metadata.name)' \
+            | grep '^mako-pr-' | sed 's/^mako-pr-//' | sort > /tmp/service_prs.txt || true
+
+          comm -23 /tmp/service_prs.txt /tmp/open_prs.txt > /tmp/stale_service_prs.txt
+          echo "Stale services: $(wc -l < /tmp/stale_service_prs.txt)"
+
+          while read -r pr; do
+            [ -z "$pr" ] && continue
+            echo "Deleting Cloud Run service mako-pr-${pr}"
+            gcloud run services delete "mako-pr-${pr}" \
+              --region "${GCP_REGION}" --quiet \
+              || echo "::warning::Failed to delete service mako-pr-${pr}"
+          done < /tmp/stale_service_prs.txt
+
+      - name: Delete Artifact Registry images for closed PRs
+        run: |
+          gcloud artifacts docker images list \
+            "${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${{ vars.GCP_ARTIFACT_REPOSITORY }}" \
+            --format='value(package)' 2>/dev/null \
+            | sort -u | grep '/mako-pr-' | sed 's|.*/mako-pr-||' | sort > /tmp/image_prs.txt || true
+
+          comm -23 /tmp/image_prs.txt /tmp/open_prs.txt > /tmp/stale_image_prs.txt
+          echo "Stale image packages: $(wc -l < /tmp/stale_image_prs.txt)"
+
+          while read -r pr; do
+            [ -z "$pr" ] && continue
+            echo "Deleting image package mako-pr-${pr}"
+            gcloud artifacts packages delete "mako-pr-${pr}" \
+              --repository="${{ vars.GCP_ARTIFACT_REPOSITORY }}" \
+              --location="${GCP_REGION}" --quiet \
+              || echo "::warning::Failed to delete image package mako-pr-${pr}"
+          done < /tmp/stale_image_prs.txt
+
+      - name: Delete ephemeral databases for closed PRs
+        continue-on-error: true
+        env:
+          STAGING_DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+        run: |
+          wget -qO- https://www.mongodb.org/static/pgp/server-7.0.asc | sudo gpg --dearmor -o /usr/share/keyrings/mongodb.gpg
+          echo "deb [signed-by=/usr/share/keyrings/mongodb.gpg] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-7.0.list
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq mongodb-mongosh
+
+          mongosh "$STAGING_DATABASE_URL" --quiet --eval "
+            const dbs = db.adminCommand({ listDatabases: 1 }).databases;
+            dbs.filter(d => d.name.startsWith('staging_pr_')).forEach(d => print(d.name));
+          " | sed 's/^staging_pr_//' | sort > /tmp/db_prs.txt || true
+
+          comm -23 /tmp/db_prs.txt /tmp/open_prs.txt > /tmp/stale_db_prs.txt
+          echo "Stale ephemeral DBs: $(wc -l < /tmp/stale_db_prs.txt)"
+
+          while read -r pr; do
+            [ -z "$pr" ] && continue
+            echo "Dropping database staging_pr_${pr}"
+            mongosh "$STAGING_DATABASE_URL" --quiet \
+              --eval "db.getSiblingDB('staging_pr_${pr}').dropDatabase()" \
+              || echo "::warning::Failed to drop database staging_pr_${pr}"
+          done < /tmp/stale_db_prs.txt

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -26,6 +26,7 @@ import mongoose from "mongoose";
 import { databaseConnectionService } from "./services/database-connection.service";
 import { sshTunnelManager } from "./services/ssh-tunnel.service";
 import { loggers, loggingMiddleware } from "./logging";
+import { checkPubSubBackendHealth } from "./services/pubsub.service";
 import { warmPricingCache } from "./services/gateway-pricing.service";
 import { warmCatalog } from "./services/model-catalog.service";
 import { discoverSystemSkills } from "./agent-lib/skills/system-skills";
@@ -311,6 +312,16 @@ async function main(): Promise<void> {
         "Generate a key at: Vercel Dashboard > AI Gateway settings.",
     );
   }
+
+  // Redis pub/sub health (resumable chat streams + workspace realtime).
+  // Logs an ERROR when REDIS_URL is set but the backend is unusable
+  // (connectivity, auth, or provider quota) so the degradation is visible
+  // from boot instead of hiding behind per-turn warnings.
+  checkPubSubBackendHealth().catch(err => {
+    logger.warn("Pub/sub health check failed to run", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
 
   warmPricingCache().catch(err => {
     logger.warn("Startup pricing cache warm failed", {

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -80,6 +80,7 @@ import {
 } from "../services/resumable-stream.service";
 import { hasAttachedClients } from "../services/realtime-presence.service";
 import { publishRealtimeEvent } from "../services/realtime.service";
+import { reportPubSubFailure } from "../services/pubsub.service";
 import { AUTH_SECURITY, OPEN_RESPONSES, createRouter } from "../openapi/core";
 import {
   buildScreenshotVisionModelMessage,
@@ -1049,13 +1050,18 @@ agentRoutes.openapi(
                   state: "streaming",
                 });
               } catch (error) {
-                // Resumability is best-effort: the direct response stream to the
-                // originating client is unaffected by failures here.
-                logger.warn("Failed to set up resumable stream", {
+                // Resumability is best-effort: the direct response stream to
+                // the originating client is unaffected by failures here. But
+                // it failing means reload/second-device reattach is silently
+                // broken for this turn — log at ERROR so Error Reporting
+                // alerts (the Upstash quota exhaustion hid behind a warn),
+                // and feed the throttled backend-level reporter.
+                logger.error("Failed to set up resumable stream", {
                   error,
                   chatId,
                   streamId,
                 });
+                reportPubSubFailure("resumable-stream-setup", error);
               }
             },
             onFinish: ({ messages: allMessages, isAborted }) => {

--- a/api/src/services/pubsub.service.ts
+++ b/api/src/services/pubsub.service.ts
@@ -29,8 +29,50 @@
 import { EventEmitter } from "node:events";
 import { Redis } from "ioredis";
 import type { Publisher, Subscriber } from "resumable-stream/generic";
+import { loggers } from "../logging";
 
 export type { Publisher, Subscriber } from "resumable-stream/generic";
+
+const logger = loggers.api("pubsub");
+
+// ── Failure reporting ─────────────────────────────────────────────
+//
+// A broken Redis backend silently downgrades two headline features at once:
+// resumable chat streams (reload/second-device reattach) and the workspace
+// realtime channel. That must surface as an ERROR (Cloud Error Reporting
+// alerts on it), not a per-event warn buried in the noise — the July 2026
+// Upstash max_requests quota exhaustion ran for hours as swallowed warns.
+//
+// Throttled: an outage emits failures per chunk/event/turn, so unthrottled
+// error logs would flood Error Reporting without adding signal.
+const FAILURE_LOG_INTERVAL_MS = 60_000;
+let lastFailureLogAt = 0;
+
+/**
+ * Report a Redis pub/sub failure. Logs at ERROR level at most once per
+ * minute (per process); other calls in the window log at debug so the full
+ * failure rate stays reconstructable from debug logs.
+ */
+export function reportPubSubFailure(context: string, error: unknown): void {
+  const now = Date.now();
+  if (now - lastFailureLogAt >= FAILURE_LOG_INTERVAL_MS) {
+    lastFailureLogAt = now;
+    logger.error(
+      "Redis pub/sub backend failing — resumable chat streams and workspace realtime events are degraded until it recovers",
+      { context, error },
+    );
+  } else {
+    logger.debug("Redis pub/sub failure (throttled)", { context, error });
+  }
+}
+
+/** Attach a structured error listener to an ioredis connection. */
+function attachRedisErrorListener(redis: Redis, context: string): Redis {
+  redis.on("error", (error: unknown) => {
+    reportPubSubFailure(context, error);
+  });
+  return redis;
+}
 
 // Mirrors the 24h TTL resumable-stream applies to its own keys; only used
 // for keys the library creates via INCR (no explicit expiry).
@@ -146,7 +188,10 @@ export function getPubSubBackendKind(): "redis" | "memory" {
 export function createPubSubPublisher(): Publisher {
   const redisUrl = process.env.REDIS_URL;
   if (redisUrl) {
-    return new Redis(redisUrl) as unknown as Publisher;
+    return attachRedisErrorListener(
+      new Redis(redisUrl),
+      "publisher",
+    ) as unknown as Publisher;
   }
   return getInMemoryPubSub().createPublisher();
 }
@@ -159,7 +204,54 @@ export function createPubSubPublisher(): Publisher {
 export function createPubSubSubscriber(): Subscriber {
   const redisUrl = process.env.REDIS_URL;
   if (redisUrl) {
-    return new Redis(redisUrl) as unknown as Subscriber;
+    return attachRedisErrorListener(
+      new Redis(redisUrl),
+      "subscriber",
+    ) as unknown as Subscriber;
   }
   return getInMemoryPubSub().createSubscriber();
+}
+
+/**
+ * Startup health check: when Redis is configured, verify it actually answers
+ * (connectivity, auth, AND quota — Upstash returns errors on commands once
+ * `max_requests` is exhausted, so a bare TCP connect is not enough). Logs an
+ * ERROR when the backend is configured but unusable; the server still starts
+ * (streaming to the originating client works without Redis, and Redis may
+ * recover), but the degradation is loud from minute zero.
+ */
+export async function checkPubSubBackendHealth(): Promise<void> {
+  const redisUrl = process.env.REDIS_URL;
+  if (!redisUrl) {
+    logger.info(
+      "Pub/sub backend: in-process (single instance only — set REDIS_URL when scaling out)",
+    );
+    return;
+  }
+
+  const probe = new Redis(redisUrl, {
+    connectTimeout: 5_000,
+    maxRetriesPerRequest: 1,
+    // The probe owns its own error reporting below; a listener stops ioredis
+    // from spamming "[ioredis] Unhandled error event" during the check.
+    lazyConnect: true,
+  });
+  probe.on("error", () => {
+    /* surfaced via the ping result below */
+  });
+  try {
+    await probe.connect();
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("PING timed out after 5s")), 5_000),
+    );
+    await Promise.race([probe.ping(), timeout]);
+    logger.info("Pub/sub backend: Redis healthy");
+  } catch (error) {
+    logger.error(
+      "REDIS_URL is set but Redis is unusable (connectivity/auth/quota) — resumable chat streams and workspace realtime events will be degraded",
+      { error },
+    );
+  } finally {
+    probe.disconnect();
+  }
 }

--- a/api/src/services/realtime.service.ts
+++ b/api/src/services/realtime.service.ts
@@ -15,6 +15,7 @@
 import {
   createPubSubPublisher,
   createPubSubSubscriber,
+  reportPubSubFailure,
   type Publisher,
   type Subscriber,
 } from "./pubsub.service";
@@ -178,6 +179,9 @@ export function publishRealtimeEvent(
         workspaceId,
         eventType: event.type,
       });
+      // Escalates to a throttled ERROR: a failing publish means the Redis
+      // backend is down/over quota and realtime + stream resume are degraded.
+      reportPubSubFailure("realtime-publish", error);
     }
   })();
 }


### PR DESCRIPTION
## Summary

Bundles three things from today's Redis incident follow-up:

### 1. Redis failures now log ERRORs (was: silent warns)

The Upstash `max_requests` quota exhaustion silently broke resumable chat streams (mid-turn reload → 204, stream lost) and degraded the workspace realtime channel for hours — every failure was a per-turn `logger.warn`.

- `pubsub.service`: `reportPubSubFailure()` — ERROR at most once/min per process (alerts via Cloud Error Reporting without flooding), debug otherwise; ioredis connections carry structured error listeners
- `checkPubSubBackendHealth()` at boot: PING probe (5s timeout) that logs an ERROR when `REDIS_URL` is set but unusable — connectivity, auth, **or provider quota** (Upstash over quota accepts TCP but errors on commands, so PING is the real test)
- `agent.routes` "Failed to set up resumable stream": warn → **error** + throttled reporter; `realtime.service` publish failures feed the reporter

### 2. Redis migration: Upstash → GCP Memorystore

Provisioned `mako-redis` (Memorystore for Redis, Basic 1 GB, redis 7.2, `europe-west1`, `mako-vpc` direct peering, AUTH enabled, host `10.67.253.179`). The `REDIS_URL` repo secret now points at it — **this PR's preview deploy is the validation** (previews use the same secret; the new boot health check logs "Pub/sub backend: Redis healthy" or an ERROR). Production switches over when this merges and deploys.

- Why: flat ~$35/mo, no per-request pricing or quota cliffs, private VPC latency instead of public internet
- Rollback: set the `REDIS_URL` secret back to the Upstash URL (kept alive on pay-as-you-go) and redeploy
- Note: Basic tier has no replication — an instance restart drops in-flight resumable streams (same as any Redis blip; clients fall back to persisted chats, and the new logging makes it visible)

### 3. Nightly sweep of orphaned PR preview resources

The close-event cleanup misses previews (failed runs, PRs closed before the workflow existed, manual deploys). New scheduled (03:17 UTC) + `workflow_dispatch` job diffs live resources against open PRs and deletes stale `mako-pr-*` Cloud Run services, Artifact Registry packages, and `staging_pr_*` ephemeral DBs.

## Test plan

- [x] `pnpm --filter api run build` (lint + typecheck) green
- [x] Health check exercised: no `REDIS_URL` → info; dead `REDIS_URL` → single ERROR
- [x] Prod verified on Upstash PAYG: mid-turn `activeStreamId` set, resume 200 + replay, reload mid-stream resumes
- [x] Preview deploy of this PR boots with "Pub/sub backend: Redis healthy" (validates Memorystore reachability from Cloud Run over the VPC — confirmed in mako-pr-643 logs at 16:45Z)
- [ ] Mid-turn reload resumes on the preview URL
- [ ] After merge: same check on prod, then downgrade/retire the Upstash database
