### PR TITLE
fix(dbt): stale tracked-branch recovery + warm-dir poisoning guards

### DIFF
--- a/api/src/dbt/dbt-github-git.integration.test.ts
+++ b/api/src/dbt/dbt-github-git.integration.test.ts
@@ -194,7 +194,10 @@ import {
   DbtProject,
   type IDbtProject,
 } from "../database/workspace-schema";
-import { syncProjectBranchFromRepo } from "./dbt-github-sync.service";
+import {
+  loadRunnableWorkingTree,
+  syncProjectBranchFromRepo,
+} from "./dbt-github-sync.service";
 import {
   commitAndPush,
   commitToNewBranch,
@@ -624,5 +627,148 @@ describe("pull request merge", () => {
         updatedBy: "alice",
       }),
     ).rejects.toThrow("Pull request #5 is closed");
+  });
+
+  it("never deletes the project's tracked branch (or its base tree) on merge", async () => {
+    const project = await seedProject();
+    // Stale pointer left behind by the pre-per-user-working-trees model: the
+    // project tracks the PR head branch itself.
+    remote.setBranch("feat/stale", {
+      "dbt_project.yml": "name: analytics",
+      "models/a.sql": "select 2",
+    });
+    await syncProjectBranchFromRepo(project, "feat/stale", "seed");
+    await DbtProject.updateOne(
+      { _id: project._id },
+      { $set: { "repo.branch": "feat/stale" } },
+    );
+    remote.state.pulls.set(9, {
+      headRef: "feat/stale",
+      baseRef: "main",
+      state: "open",
+    });
+
+    const result = await mergeProjectPullRequest(project, {
+      userId: "alice",
+      prNumber: 9,
+      updatedBy: "alice",
+    });
+
+    expect(result.branchDeleted).toBe(false);
+    expect(result.branchDeleteWarning).toMatch(/tracked branch/);
+    // Remote branch and its committed base tree both survive — deploy runs
+    // building the tracked branch keep their files.
+    expect(remote.state.branches.has("feat/stale")).toBe(true);
+    expect(
+      await DbtFile.countDocuments({
+        projectId: project._id,
+        branch: "feat/stale",
+        is_deleted: { $ne: true },
+      }),
+    ).toBeGreaterThan(0);
+  });
+});
+
+describe("loadRunnableWorkingTree — self-healing run snapshots", () => {
+  it("returns the working tree as-is when dbt_project.yml is present", async () => {
+    const project = await seedProject();
+    const files = await loadRunnableWorkingTree(project);
+    expect(files.map(f => f.path)).toEqual(["dbt_project.yml", "models/a.sql"]);
+  });
+
+  it("re-syncs a branch whose committed base tree is missing in Mongo", async () => {
+    const project = await seedProject();
+    // Simulate the incident: the tracked branch's base tree was dropped
+    // (e.g. deleteBranchBaseTree ran for it).
+    await DbtFile.deleteMany({ projectId: project._id, branch: "main" });
+
+    const files = await loadRunnableWorkingTree(project);
+    expect(files.map(f => f.path)).toContain("dbt_project.yml");
+    expect(
+      await DbtFile.countDocuments({
+        projectId: project._id,
+        branch: "main",
+        is_deleted: { $ne: true },
+      }),
+    ).toBe(2);
+  });
+
+  it("re-anchors a tracked branch that no longer exists on the remote", async () => {
+    const project = await seedProject();
+    // Stale tracked pointer at a branch that was merged + deleted upstream.
+    await DbtProject.updateOne(
+      { _id: project._id },
+      { $set: { "repo.branch": "feat/gone" } },
+    );
+    const stale = await DbtProject.findById(project._id);
+    if (!stale) throw new Error("project not found");
+
+    const files = await loadRunnableWorkingTree(stale);
+    expect(files.map(f => f.path)).toContain("dbt_project.yml");
+
+    const healed = await DbtProject.findById(project._id).lean();
+    expect(healed?.repo?.branch).toBe("main");
+  });
+
+  it("does not re-anchor when the tracked branch still exists on the remote", async () => {
+    const project = await seedProject();
+    remote.setBranch("feat/alive", {
+      "dbt_project.yml": "name: analytics",
+      "models/z.sql": "select 9",
+    });
+    await DbtProject.updateOne(
+      { _id: project._id },
+      { $set: { "repo.branch": "feat/alive" } },
+    );
+    const tracked = await DbtProject.findById(project._id);
+    if (!tracked) throw new Error("project not found");
+
+    // No base tree yet for feat/alive → the heal path syncs the branch
+    // itself (it exists), never touching the tracked pointer.
+    const files = await loadRunnableWorkingTree(tracked);
+    expect(files.map(f => f.path)).toContain("models/z.sql");
+
+    const after = await DbtProject.findById(project._id).lean();
+    expect(after?.repo?.branch).toBe("feat/alive");
+  });
+
+  it("rethrows when the tracked branch IS the repo default and the sync fails", async () => {
+    const project = await seedProject();
+    await DbtFile.deleteMany({ projectId: project._id, branch: "main" });
+    // Remote is unreachable/branch gone AND main is the repo default — there
+    // is nothing safe to re-anchor to, so the sync error surfaces.
+    remote.state.branches.delete("main");
+
+    await expect(loadRunnableWorkingTree(project)).rejects.toThrow(/404/);
+    const after = await DbtProject.findById(project._id).lean();
+    expect(after?.repo?.branch).toBe("main");
+  });
+
+  it("throws an actionable error for a blank project without dbt_project.yml", async () => {
+    const blank = await DbtProject.create({
+      workspaceId: WS,
+      name: `Blank-${new Types.ObjectId().toString()}`,
+      environments: [
+        {
+          name: "dev",
+          connectionId: new Types.ObjectId(),
+          targetSchema: "analytics",
+          threads: 4,
+        },
+      ],
+      defaultEnvironment: "dev",
+      createdBy: "tester",
+    });
+    await DbtFile.create({
+      workspaceId: WS,
+      projectId: blank._id,
+      path: "models/a.sql",
+      content: "select 1",
+      updatedBy: "tester",
+    });
+
+    await expect(loadRunnableWorkingTree(blank)).rejects.toThrow(
+      /has no dbt_project\.yml/,
+    );
   });
 });

--- a/api/src/dbt/dbt-github-git.service.ts
+++ b/api/src/dbt/dbt-github-git.service.ts
@@ -993,26 +993,38 @@ export async function mergeProjectPullRequest(
     let branchDeleted = false;
     let branchDeleteWarning: string | undefined;
     if (params.deleteBranch !== false) {
-      const deleteResult = await tryDeleteBranch(
-        owner,
-        repo,
-        pr.headRef,
-        token,
-      );
-      branchDeleted = deleteResult.deleted;
-      branchDeleteWarning = deleteResult.warning;
-      if (branchDeleted) {
-        await deleteBranchBaseTree(fresh, pr.headRef);
-        await DbtCheckout.updateMany(
-          { projectId: fresh._id, branch: pr.headRef },
-          {
-            $set: {
-              branch: defaultBranch,
-              lastSyncedSha: syncResult.sha,
-              lastSyncedAt: new Date(),
+      if (pr.headRef === fresh.repo.branch) {
+        // Never delete the project's tracked branch (or its base tree) — that
+        // is what deploy/job runs build. A stale tracked pointer (left behind
+        // by the pre-per-user-working-trees model) would otherwise take the
+        // whole committed tree with it and break every scheduled run with
+        // "No dbt_project.yml found". Mirrors closeProjectPullRequest.
+        branchDeleteWarning =
+          `Branch "${pr.headRef}" was not deleted — it is the project's ` +
+          "tracked branch. Change the project's branch in settings first if " +
+          "you want to remove it.";
+      } else {
+        const deleteResult = await tryDeleteBranch(
+          owner,
+          repo,
+          pr.headRef,
+          token,
+        );
+        branchDeleted = deleteResult.deleted;
+        branchDeleteWarning = deleteResult.warning;
+        if (branchDeleted) {
+          await deleteBranchBaseTree(fresh, pr.headRef);
+          await DbtCheckout.updateMany(
+            { projectId: fresh._id, branch: pr.headRef },
+            {
+              $set: {
+                branch: defaultBranch,
+                lastSyncedSha: syncResult.sha,
+                lastSyncedAt: new Date(),
+              },
             },
-          },
-        ).exec();
+          ).exec();
+        }
       }
     }
 

--- a/api/src/dbt/dbt-github-sync.service.ts
+++ b/api/src/dbt/dbt-github-sync.service.ts
@@ -28,6 +28,7 @@ import {
   getCheckoutBranch,
   loadWorkingTreeContents,
 } from "./dbt-working-tree.service";
+import { publishRealtimeEvent } from "../services/realtime.service";
 import { loggers } from "../logging";
 
 const logger = loggers.app();
@@ -330,6 +331,11 @@ async function reanchorTrackedBranch(
   project.markModified("repo");
   await project.save();
   await syncProjectBranchFromRepo(project, info.defaultBranch, updatedBy);
+  // Let open clients refetch the project so settings show the healed branch.
+  publishRealtimeEvent(project.workspaceId.toString(), {
+    type: "dbt.project.updated",
+    projectId: project._id.toString(),
+  });
 }
 
 /**

--- a/api/src/dbt/dbt-github-sync.service.ts
+++ b/api/src/dbt/dbt-github-sync.service.ts
@@ -21,8 +21,16 @@ import { resolveRepoToken } from "../integrations/github/app-auth";
 import {
   getBlobContent,
   getBranchHeadSha,
+  getRepoInfo,
   getRepoTree,
 } from "../integrations/github/github-api";
+import {
+  getCheckoutBranch,
+  loadWorkingTreeContents,
+} from "./dbt-working-tree.service";
+import { loggers } from "../logging";
+
+const logger = loggers.app();
 
 /** Per-file cap (matches the PUT /files content limit). */
 const MAX_FILE_BYTES = 1_000_000;
@@ -279,6 +287,108 @@ export async function syncProjectBranchFromRepo(
   ).exec();
 
   return { sha, added, updated, deleted, skippedLarge };
+}
+
+/** True when a file tree contains the root dbt_project.yml dbt requires. */
+export function hasRootDbtProjectYml(files: Array<{ path: string }>): boolean {
+  return files.some(file => file.path === "dbt_project.yml");
+}
+
+/**
+ * The project's tracked branch no longer exists on the remote (a stale
+ * pointer from the pre-per-user-working-trees model, deleted after its PR
+ * merged): re-anchor `repo.branch` to the repository's default branch and
+ * pull that branch's tree. Only fires when the branch is verifiably gone —
+ * a transient sync failure must never rewrite project config.
+ */
+async function reanchorTrackedBranch(
+  project: IDbtProject,
+  branch: string,
+  syncError: unknown,
+  updatedBy: string,
+): Promise<void> {
+  if (!project.repo || branch !== project.repo.branch) throw syncError;
+  const token = await resolveRepoToken(project.repo.installationId);
+  const { owner, repo } = project.repo;
+  const info = await getRepoInfo(owner, repo, token);
+  if (info.defaultBranch === branch) throw syncError;
+  const stillExists = await getBranchHeadSha(owner, repo, branch, token).then(
+    () => true,
+    () => false,
+  );
+  if (stillExists) throw syncError;
+
+  logger.warn(
+    "dbt tracked branch is gone on the remote; re-anchoring to repo default",
+    {
+      projectId: project._id.toString(),
+      staleBranch: branch,
+      defaultBranch: info.defaultBranch,
+    },
+  );
+  project.repo.branch = info.defaultBranch;
+  project.markModified("repo");
+  await project.save();
+  await syncProjectBranchFromRepo(project, info.defaultBranch, updatedBy);
+}
+
+/**
+ * Load a project's working-tree contents for a dbt run, self-healing the two
+ * states that would otherwise reach dbt as the confusing
+ * "No dbt_project.yml found at expected path <dir>/dbt_project.yml" (and, in
+ * a warm dir, reconcile the previously-good tree away):
+ *
+ *  1. the branch's committed base tree is missing/incomplete in Mongo (e.g.
+ *     dropped when its branch was deleted) → re-pull the branch;
+ *  2. the tracked branch itself no longer exists on the remote → re-anchor
+ *     `repo.branch` to the repo default branch and pull that.
+ *
+ * Throws an actionable error when the tree still has no dbt_project.yml.
+ */
+export async function loadRunnableWorkingTree(
+  project: IDbtProject,
+  opts: { userId?: string; branch?: string } = {},
+): Promise<Array<{ path: string; content: string }>> {
+  let files = await loadWorkingTreeContents(project, opts);
+  if (hasRootDbtProjectYml(files)) return files;
+
+  let branch: string | undefined;
+  if (project.repo) {
+    branch =
+      opts.branch ??
+      (opts.userId
+        ? await getCheckoutBranch(project, opts.userId)
+        : project.repo.branch);
+    const updatedBy = opts.userId ?? "system";
+    logger.warn("dbt working tree has no dbt_project.yml; re-syncing branch", {
+      projectId: project._id.toString(),
+      branch,
+    });
+    try {
+      await syncProjectBranchFromRepo(project, branch as string, updatedBy);
+    } catch (syncError) {
+      await reanchorTrackedBranch(
+        project,
+        branch as string,
+        syncError,
+        updatedBy,
+      );
+    }
+    files = await loadWorkingTreeContents(project, opts);
+  }
+
+  if (!hasRootDbtProjectYml(files)) {
+    const where = branch ? ` on branch "${branch}"` : "";
+    throw new Error(
+      `dbt project "${project.name}" has no dbt_project.yml in its working ` +
+        `tree${where} — the project files are missing or not synced. ` +
+        (project.repo
+          ? "Check the repository/subdirectory binding and run a sync " +
+            "(Version control → Sync, or dbt_sync_from_repo)."
+          : "Create a dbt_project.yml at the project root first."),
+    );
+  }
+  return files;
 }
 
 /** Sync the project's default branch (backwards-compatible entry point). */

--- a/api/src/dbt/dbt-project.service.ts
+++ b/api/src/dbt/dbt-project.service.ts
@@ -15,7 +15,7 @@ import {
   type IDbtEnvironment,
   type IDbtProject,
 } from "../database/workspace-schema";
-import { loadWorkingTreeContents } from "./dbt-working-tree.service";
+import { loadRunnableWorkingTree } from "./dbt-github-sync.service";
 import { renderDbtProfile, type RenderedProfile } from "./adapter-map";
 import { parseDbtCommand, type ParsedDbtCommand } from "./commands";
 import {
@@ -93,7 +93,10 @@ export async function loadDbtProjectSnapshot(params: {
 
   const profile = renderDbtProfile(connection, environment);
 
-  const files = await loadWorkingTreeContents(project, {
+  // Self-healing load: re-syncs a missing branch base tree (and re-anchors a
+  // tracked branch that no longer exists on the remote) rather than handing
+  // dbt a tree without dbt_project.yml.
+  const files = await loadRunnableWorkingTree(project, {
     userId: params.userId,
     branch: params.branch,
   });

--- a/api/src/dbt/runner-materialize.test.ts
+++ b/api/src/dbt/runner-materialize.test.ts
@@ -1,0 +1,114 @@
+/**
+ * materializeDbtProject / pruneStaleRunArtifacts — warm-dir safety.
+ *
+ * Regression tests for the "No dbt_project.yml found at expected path
+ * <warm-dir>/dbt_project.yml" incident: a broken (empty) snapshot must never
+ * reconcile a previously-good warm directory away, and per-run result
+ * artifacts must not leak across runs in a reused warm dir.
+ */
+import { access, mkdir, mkdtemp, readFile, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { describe, expect, it } from "vitest";
+import { materializeDbtProject, pruneStaleRunArtifacts } from "./runner.service";
+import type { RenderedProfile } from "./adapter-map";
+
+const profile: RenderedProfile = {
+  adapterPackage: "dbt-duckdb",
+  secretEnv: {},
+  keyfiles: [],
+  profilesYml: "mako:\n  target: dev\n",
+};
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("materializeDbtProject — dbt_project.yml guard", () => {
+  it("materializes a valid snapshot", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "mako-dbt-materialize-"));
+    const { changed } = await materializeDbtProject(dir, {
+      files: [
+        { path: "dbt_project.yml", content: "name: probe" },
+        { path: "models/a.sql", content: "select 1" },
+      ],
+      profile,
+      reconcile: true,
+    });
+    expect(changed).toBe(true);
+    expect(await readFile(join(dir, "dbt_project.yml"), "utf8")).toBe(
+      "name: probe",
+    );
+    expect(await readFile(join(dir, "models", "a.sql"), "utf8")).toBe(
+      "select 1",
+    );
+  });
+
+  it("refuses a snapshot without dbt_project.yml and leaves the warm dir intact", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "mako-dbt-materialize-"));
+    await materializeDbtProject(dir, {
+      files: [
+        { path: "dbt_project.yml", content: "name: probe" },
+        { path: "models/a.sql", content: "select 1" },
+      ],
+      profile,
+      reconcile: true,
+    });
+
+    // A broken snapshot (e.g. a branch whose base tree is missing) must throw
+    // BEFORE writing or reconciling anything.
+    await expect(
+      materializeDbtProject(dir, {
+        files: [{ path: "models/b.sql", content: "select 2" }],
+        profile,
+        reconcile: true,
+      }),
+    ).rejects.toThrow(/dbt_project\.yml/);
+
+    // The previously-good tree was not reconciled away.
+    expect(await readFile(join(dir, "dbt_project.yml"), "utf8")).toBe(
+      "name: probe",
+    );
+    expect(await readFile(join(dir, "models", "a.sql"), "utf8")).toBe(
+      "select 1",
+    );
+    expect(await exists(join(dir, "models", "b.sql"))).toBe(false);
+  });
+});
+
+describe("pruneStaleRunArtifacts", () => {
+  it("removes per-run result artifacts but keeps the parse cache and manifest", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "mako-dbt-prune-"));
+    await mkdir(join(dir, "target"), { recursive: true });
+    const all = [
+      "run_results.json",
+      "sources.json",
+      "catalog.json",
+      "partial_parse.msgpack",
+      "manifest.json",
+    ];
+    for (const name of all) {
+      await writeFile(join(dir, "target", name), "stale");
+    }
+
+    await pruneStaleRunArtifacts(dir);
+
+    expect(await exists(join(dir, "target", "run_results.json"))).toBe(false);
+    expect(await exists(join(dir, "target", "sources.json"))).toBe(false);
+    expect(await exists(join(dir, "target", "catalog.json"))).toBe(false);
+    expect(await exists(join(dir, "target", "partial_parse.msgpack"))).toBe(
+      true,
+    );
+    expect(await exists(join(dir, "target", "manifest.json"))).toBe(true);
+  });
+
+  it("is a no-op on a dir without target/", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "mako-dbt-prune-"));
+    await expect(pruneStaleRunArtifacts(dir)).resolves.toBeUndefined();
+  });
+});

--- a/api/src/dbt/runner.service.ts
+++ b/api/src/dbt/runner.service.ts
@@ -480,6 +480,18 @@ export async function materializeDbtProject(
     reconcile?: boolean;
   },
 ): Promise<{ keyfileEnv: Record<string, string>; changed: boolean }> {
+  // Refuse to materialize a tree that cannot be a dbt project. Without this
+  // guard an empty/broken snapshot (e.g. a branch whose committed base tree
+  // is missing) would reconcile-delete dbt_project.yml and every model out of
+  // a shared warm dir, and dbt would fail with the far more confusing
+  // "No dbt_project.yml found at expected path <dir>/dbt_project.yml".
+  if (!params.files.some(file => file.path === "dbt_project.yml")) {
+    throw new Error(
+      "dbt project snapshot has no dbt_project.yml — refusing to materialize " +
+        "(the project's file tree is empty or not synced)",
+    );
+  }
+
   // Preserve list for reconciliation (profiles.yml + every snapshot file +
   // keyfiles get added below).
   const keep = new Set<string>(["profiles.yml"]);
@@ -523,6 +535,21 @@ export async function materializeDbtProject(
     changed = true;
   }
   return { keyfileEnv, changed };
+}
+
+/**
+ * Remove per-run result artifacts from a (warm) project dir's target/.
+ * Warm dirs keep target/ across runs so partial parsing stays warm, but a
+ * command that fails before writing its own run_results.json would otherwise
+ * have the PREVIOUS run's file collected and misattributed to it (an errored
+ * run "showing" passing node results). The parse cache and manifest stay.
+ */
+export async function pruneStaleRunArtifacts(projectDir: string): Promise<void> {
+  for (const name of ["run_results.json", "sources.json", "catalog.json"]) {
+    await rm(join(projectDir, "target", name), { force: true }).catch(
+      () => {},
+    );
+  }
 }
 
 /**
@@ -576,6 +603,17 @@ export async function runDbt(request: DbtRunRequest): Promise<DbtRunResult> {
         reconcile: !ownsDir,
       },
     );
+
+    // Warm dirs: drop the previous run's result artifacts so a command that
+    // fails early can never have stale run_results/sources/catalog collected
+    // and misattributed to it. `retry` is the exception — it resumes FROM the
+    // prior run_results (re-seeded via restoreTarget below).
+    const isRetryRun = request.commands.some(
+      command => command.subcommand === "retry",
+    );
+    if (!ownsDir && !isRetryRun) {
+      await pruneStaleRunArtifacts(projectDir);
+    }
 
     // Seed prior artifacts into target/ for `dbt retry` (run_results.json is
     // what dbt reads to resume at the failed/skipped nodes).

--- a/api/src/inngest/functions/dbt-run.ts
+++ b/api/src/inngest/functions/dbt-run.ts
@@ -361,7 +361,15 @@ export const dbtRunExecutorFunction = inngest.createFunction(
             if (warmDirsEnabled()) {
               try {
                 result = await withProjectDir(
-                  { ...cacheScope, role: "run" },
+                  {
+                    ...cacheScope,
+                    role: "run",
+                    // Working-tree (agent verification) builds materialize a
+                    // user's draft overlay — isolate them in a per-user dir so
+                    // they can never reconcile the shared committed-deploy dir
+                    // into a draft state.
+                    userId: runInfo.workingTreeUserId ?? undefined,
+                  },
                   dir => runOnce(dir),
                 );
                 // Positive signal so warm-dir engagement on the executor is

--- a/api/src/routes/dbt.routes.integration.test.ts
+++ b/api/src/routes/dbt.routes.integration.test.ts
@@ -77,6 +77,7 @@ vi.mock("../integrations/github/config", () => ({
 }));
 vi.mock("../integrations/github/github-api", () => ({
   fileExistsAtRef: vi.fn(),
+  getBranchHeadSha: vi.fn(),
   getRepoInfo: vi.fn(),
   listBranches: vi.fn(),
   listDbtProjectSubdirectories: vi.fn(),
@@ -123,10 +124,16 @@ import {
   requestDbtRunCancel,
   triggerDbtRunRetry,
 } from "../dbt/dbt-run.service";
+import { getBranchHeadSha } from "../integrations/github/github-api";
+import { syncProjectBranchFromRepo } from "../dbt/dbt-github-sync.service";
 
 const adhocMock = runAdhocDbtCommand as unknown as ReturnType<typeof vi.fn>;
 const cancelMock = requestDbtRunCancel as unknown as ReturnType<typeof vi.fn>;
 const retryMock = triggerDbtRunRetry as unknown as ReturnType<typeof vi.fn>;
+const branchHeadMock = getBranchHeadSha as unknown as ReturnType<typeof vi.fn>;
+const syncBranchMock = syncProjectBranchFromRepo as unknown as ReturnType<
+  typeof vi.fn
+>;
 
 let mongo: MongoMemoryServer;
 const WS = new Types.ObjectId().toString();
@@ -265,6 +272,76 @@ describe("project CRUD", () => {
     expect(
       (await (await req("GET", "/projects")).json()).projects,
     ).toHaveLength(0);
+  });
+
+  it("changes the tracked branch after verifying it exists on the remote", async () => {
+    const projectId = await createProjectAsOwner();
+    await mongoose.connection.collection("dbt_projects").updateOne(
+      { _id: new Types.ObjectId(projectId) },
+      {
+        $set: {
+          repo: {
+            provider: "github",
+            owner: "acme",
+            repo: "analytics",
+            branch: "fix/stale-feature",
+            installationId: 1,
+          },
+        },
+      },
+    );
+    branchHeadMock.mockResolvedValueOnce("sha-main");
+
+    const res = await req("PATCH", `/projects/${projectId}`, {
+      repoBranch: "main",
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).project.repo.branch).toBe("main");
+    // The new tracked branch's base tree is materialized right away.
+    expect(syncBranchMock).toHaveBeenCalledTimes(1);
+    const [projArg, branchArg, userArg] = syncBranchMock.mock.calls[0] as [
+      { _id: Types.ObjectId },
+      string,
+      string,
+    ];
+    expect(projArg._id.toString()).toBe(projectId);
+    expect(branchArg).toBe("main");
+    expect(userArg).toBe("u1");
+  });
+
+  it("rejects a tracked branch that does not exist on the remote", async () => {
+    const projectId = await createProjectAsOwner();
+    await mongoose.connection.collection("dbt_projects").updateOne(
+      { _id: new Types.ObjectId(projectId) },
+      {
+        $set: {
+          repo: {
+            provider: "github",
+            owner: "acme",
+            repo: "analytics",
+            branch: "main",
+            installationId: 1,
+          },
+        },
+      },
+    );
+    branchHeadMock.mockRejectedValueOnce(new Error("GitHub 404"));
+
+    const res = await req("PATCH", `/projects/${projectId}`, {
+      repoBranch: "typo/branch",
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/not found/);
+    expect(syncBranchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects repoBranch on a project without a repo binding", async () => {
+    const projectId = await createProjectAsOwner();
+    const res = await req("PATCH", `/projects/${projectId}`, {
+      repoBranch: "main",
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/connected repository/);
   });
 
   it("rejects an environment bound to a non-dbt-compatible connection", async () => {

--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -36,6 +36,7 @@ import {
 } from "../integrations/github/config";
 import {
   fileExistsAtRef,
+  getBranchHeadSha,
   getRepoInfo,
   listBranches,
   listDbtProjectSubdirectories,
@@ -278,6 +279,12 @@ const patchProjectSchema = z.object({
     .array(z.string().min(1).max(255))
     .max(20)
     .optional(),
+  /**
+   * Tracked branch of the repo binding — what deploy/job runs build and what
+   * syncs target by default. Must exist on the remote; its base tree is
+   * synced on change.
+   */
+  repoBranch: z.string().min(1).max(255).optional(),
 });
 
 async function validateEnvironments(
@@ -479,7 +486,43 @@ dbtRoutes.patch("/projects/:projectId", async (c: AuthenticatedContext) => {
       project.protectedBranches = [...new Set(body.protectedBranches)];
       project.markModified("protectedBranches");
     }
+    let trackedBranchChanged = false;
+    if (body.repoBranch) {
+      if (!project.repo) {
+        return badRequest(
+          c,
+          "Changing the tracked branch requires a connected repository",
+        );
+      }
+      if (body.repoBranch !== project.repo.branch) {
+        // The tracked branch is what deploy/job runs build — verify it exists
+        // on the remote before re-pointing the project at it.
+        const token = await resolveRepoToken(project.repo.installationId);
+        try {
+          await getBranchHeadSha(
+            project.repo.owner,
+            project.repo.repo,
+            body.repoBranch,
+            token,
+          );
+        } catch {
+          return badRequest(
+            c,
+            `Branch "${body.repoBranch}" was not found on ` +
+              `${project.repo.owner}/${project.repo.repo}`,
+          );
+        }
+        project.repo.branch = body.repoBranch;
+        project.markModified("repo");
+        trackedBranchChanged = true;
+      }
+    }
     await project.save();
+    if (trackedBranchChanged && project.repo) {
+      // Materialize the new tracked branch's committed base tree so deploy
+      // runs and fresh checkouts have files to build immediately.
+      await syncProjectBranchFromRepo(project, project.repo.branch, getUserId(c));
+    }
     publishDbtEvent(c, {
       type: "dbt.project.updated",
       projectId: project._id.toString(),

--- a/app/src/components/DbtProjectSettingsDrawer.tsx
+++ b/app/src/components/DbtProjectSettingsDrawer.tsx
@@ -183,6 +183,7 @@ export default function DbtProjectSettingsDrawer({
 }: DbtProjectSettingsDrawerProps) {
   const projects = useDbtStore(s => s.projects);
   const updateProject = useDbtStore(s => s.updateProject);
+  const listBranches = useDbtStore(s => s.listBranches);
 
   const project = useMemo(
     () => projects.find(p => p._id === projectId) ?? null,
@@ -202,6 +203,13 @@ export default function DbtProjectSettingsDrawer({
   // add/remove PATCHes the project) — independent of the drawer's Edit mode.
   const [newProtectedBranch, setNewProtectedBranch] = useState("");
   const [savingProtection, setSavingProtection] = useState(false);
+  // Tracked branch (what deploy/job runs build): applies immediately, like
+  // branch protection. Remote branches populate the picker.
+  const [remoteBranches, setRemoteBranches] = useState<string[]>([]);
+  const [savingTrackedBranch, setSavingTrackedBranch] = useState(false);
+  const [trackedBranchError, setTrackedBranchError] = useState<string | null>(
+    null,
+  );
   // Per-environment variable rows, parallel to editEnvs (same index). Kept as
   // an ordered array (not a record) so typing keys never reorders or collides.
   const [editVarRows, setEditVarRows] = useState<
@@ -260,6 +268,33 @@ export default function DbtProjectSettingsDrawer({
   }, [project, resetFromProject]);
 
   const isRepoBound = project?.repo != null;
+
+  useEffect(() => {
+    if (!open || !projectId || !isRepoBound) return;
+    setTrackedBranchError(null);
+    void listBranches(workspaceId, projectId).then(result => {
+      if (result) setRemoteBranches(result.branches);
+    });
+  }, [open, projectId, workspaceId, isRepoBound, listBranches]);
+
+  const handleTrackedBranchChange = useCallback(
+    async (branch: string) => {
+      if (!project || !projectId || branch === project.repo?.branch) return;
+      setSavingTrackedBranch(true);
+      setTrackedBranchError(null);
+      const updated = await updateProject(workspaceId, projectId, {
+        repoBranch: branch,
+      });
+      if (!updated) {
+        setTrackedBranchError(
+          useDbtStore.getState().error.projects ?? "Failed to update branch",
+        );
+      }
+      setSavingTrackedBranch(false);
+    },
+    [project, projectId, workspaceId, updateProject],
+  );
+
   const selectedEnv = useMemo(() => {
     if (!selectedEnvName) return null;
     if (isEditing) {
@@ -1032,7 +1067,51 @@ export default function DbtProjectSettingsDrawer({
 
             {isRepoBound && project.repo && (
               <SettingsSection title="Git">
-                <ReadOnlyField label="Branch" value={project.repo.branch} />
+                <Box sx={{ mb: 1.5 }}>
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    display="block"
+                  >
+                    Branch
+                  </Typography>
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    display="block"
+                    sx={{ mb: 0.5 }}
+                  >
+                    Deploy jobs, CI, and syncs build this branch. Your editor
+                    checkout is independent (Version control panel).
+                  </Typography>
+                  <Select
+                    size="small"
+                    value={project.repo.branch}
+                    disabled={savingTrackedBranch}
+                    onChange={e =>
+                      void handleTrackedBranchChange(e.target.value)
+                    }
+                    sx={{ minWidth: 260, maxWidth: "100%" }}
+                  >
+                    {[...new Set([project.repo.branch, ...remoteBranches])].map(
+                      branch => (
+                        <MenuItem key={branch} value={branch}>
+                          {branch}
+                        </MenuItem>
+                      ),
+                    )}
+                  </Select>
+                  {trackedBranchError && (
+                    <Typography
+                      variant="caption"
+                      color="error"
+                      display="block"
+                      sx={{ mt: 0.5 }}
+                    >
+                      {trackedBranchError}
+                    </Typography>
+                  )}
+                </Box>
                 <ReadOnlyField
                   label="Last synced"
                   value={

--- a/app/src/store/dbtStore.ts
+++ b/app/src/store/dbtStore.ts
@@ -346,6 +346,8 @@ interface DbtActions {
       dbtVersion?: string;
       ci?: DbtCiConfig;
       protectedBranches?: string[];
+      /** Tracked branch of the repo binding (what deploy/job runs build). */
+      repoBranch?: string;
     },
   ) => Promise<DbtProjectItem | null>;
   deleteProject: (workspaceId: string, projectId: string) => Promise<boolean>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Incident

Two production reports, one root cause:

1. Prod dbt job runs dying in seconds with `Runtime Error: No dbt_project.yml found at expected path /tmp/mako-dbt-warm/<ws>/<proj>/prod__run/dbt_project.yml`.
2. Project settings showing a feature branch (`fix/meet-close-external-participant-merge`) as the project's Git branch while the editor sidebar shows `main`.

Before #637 (per-user working trees), `project.repo.branch` was the *shared current-branch pointer* and was mutated on every branch create/switch/merge. #637 repurposed it as the project's fixed **tracked branch** (what deploy/job runs build) but kept whatever stale value was in it. From there:

- Deploy runs build the stale feature branch's committed base tree.
- `mergeProjectPullRequest` had **no guard** against the PR head being the tracked branch — merging that PR deletes the head branch **and its base tree**, leaving the tracked branch with an empty tree.
- The runner then materializes the empty snapshot into the shared `prod__run` warm dir with reconciliation enabled, which **deletes `dbt_project.yml` and every model from the warm dir**, producing dbt's confusing error — and the stale `target/run_results.json` from the previous successful run gets misattributed to the failed run (errored runs "showing" passing nodes).

## Fixes

- **Merge guard** — `mergeProjectPullRequest` refuses to delete the PR head branch (and its base tree) when it is the project's tracked branch (mirrors `closeProjectPullRequest` / `deleteProjectBranch`).
- **Self-healing run snapshots** — new `loadRunnableWorkingTree` (used by `loadDbtProjectSnapshot`, i.e. every dbt run/compile): re-syncs a branch whose committed base tree is missing in Mongo; re-anchors a tracked branch that verifiably no longer exists on the remote to the repo default branch (and publishes `dbt.project.updated` so open clients refresh); otherwise throws an actionable error instead of handing dbt a broken tree. Existing broken projects heal on their next run.
- **Warm-dir guards** — `materializeDbtProject` refuses snapshots without `dbt_project.yml` (an empty tree can never reconcile a warm dir away); `runDbt` prunes stale `run_results.json`/`sources.json`/`catalog.json` from warm dirs before commands (except `retry`) so failed commands can't inherit the previous run's results.
- **Per-user warm run dirs** — agent working-tree verification builds no longer share the committed-deploy `prod__run` warm dir.
- **Tracked branch is now fixable from the UI** — `PATCH /projects/:id` accepts `repoBranch` (validated against the remote via `getBranchHeadSha`, new branch's base tree synced immediately); the project settings drawer's Git "Branch" field is an editable select of remote branches.

## Demos (local repro against a fake GitHub remote + Chinook Postgres)

Run-time self-heal — settings show the broken tracked branch, a manual job run succeeds (previously: `No dbt_project.yml found`), and the tracked branch is re-anchored to `main`, live, without a reload:

[dbt_run_self_heal_final_demo.mp4](https://cursor.com/agents/bc-8bbaced5-61a7-426d-a193-68d39c2ae458/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdbt_run_self_heal_final_demo.mp4)

Editable tracked branch in project settings (stale branch → `main`, synced immediately):

[settings_tracked_branch_select_fix.mp4](https://cursor.com/agents/bc-8bbaced5-61a7-426d-a193-68d39c2ae458/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsettings_tracked_branch_select_fix.mp4)

[Before: settings show stale tracked branch while checkout is main](https://cursor.com/agents/bc-8bbaced5-61a7-426d-a193-68d39c2ae458/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsettings_git_branch_before_stale.webp)
[Job run succeeds after self-heal (PASS=2)](https://cursor.com/agents/bc-8bbaced5-61a7-426d-a193-68d39c2ae458/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frun_success_after_self_heal.webp)

## Immediate remediation for the affected project

Open RealAdvisor DBT → Project settings → Git → Branch and switch it back to `main` (the new select) — or just let the next deploy run self-heal it once this ships.

## Testing

- ✅ `pnpm --filter api run test:dbt` — 167 passed (new: merge guard, 6 `loadRunnableWorkingTree` self-heal cases, 3 PATCH `repoBranch` route cases, 4 warm-dir guard/prune unit tests)
- ✅ `pnpm --filter api run build` (lint + tsc)
- ✅ `pnpm --filter app run typecheck && pnpm --filter app run lint`
- ✅ Manual E2E in the running app (fake GitHub remote, real dbt-core 1.9.10 + dbt-postgres via uvx against the Chinook demo Postgres) — videos above

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8bbaced5-61a7-426d-a193-68d39c2ae458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bbaced5-61a7-426d-a193-68d39c2ae458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

