### PR TITLE
fix(dbt): anchored edit_dbt_file writes the draft overlay + UI follows agent git tools

### DIFF
--- a/api/src/agent-lib/tools/dbt-file-tools.test.ts
+++ b/api/src/agent-lib/tools/dbt-file-tools.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Agent dbt file tools — draft/dirty-tracking integration tests.
+ *
+ * Boots `createDbtServerTools` against an ephemeral mongodb-memory-server and
+ * exercises the file mutation tools through the REAL working-tree + git-status
+ * services (only GitHub network calls and heavy collaborators are mocked).
+ *
+ * Regression coverage for "anchored edit_dbt_file edits were invisible to
+ * dbt_git_status / the Version Control UI": edit_dbt_file used to write the
+ * committed base tree (DbtFile) directly instead of the per-user draft
+ * overlay (DbtFileDraft), so after a dbt_sync_from_repo stamped base blob
+ * SHAs the working tree reported clean and dbt_commit_and_push refused with
+ * "No changes to commit" — while modify_dbt_file (full rewrite) worked.
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import mongoose, { Types } from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+
+// Heavy collaborators pulled in transitively by the tools module — stubbed so
+// imports resolve and side-effects are inert. dbt-github-git.service and
+// dbt-working-tree.service stay REAL (they are the code under test).
+vi.mock("../../services/realtime.service", () => ({
+  publishRealtimeEvent: vi.fn(),
+}));
+vi.mock("../../services/workspace.service", () => ({
+  workspaceService: { isAdmin: vi.fn(async () => true) },
+}));
+vi.mock("../../services/entity-version.service", () => ({
+  createVersion: vi.fn(async () => ({})),
+  getLatestVersionNumber: vi.fn(async () => 0),
+  getUserDisplayName: vi.fn(async () => "Tester"),
+}));
+vi.mock("../../dbt/dbt-project.service", () => ({
+  runAdhocDbtCommand: vi.fn(),
+}));
+vi.mock("../../dbt/dbt-run.service", () => ({
+  applyJobScheduleChange: vi.fn(async () => undefined),
+  reconcileStaleQueuedRun: vi.fn(async (r: unknown) => r),
+  requestDbtRunCancel: vi.fn(),
+  triggerDbtJobRun: vi.fn(async () => ({ _id: new Types.ObjectId() })),
+  triggerDbtRun: vi.fn(async () => ({ _id: new Types.ObjectId() })),
+}));
+vi.mock("../../dbt/dbt-commit-message.service", () => ({
+  generateDbtCommitMessage: vi.fn(),
+}));
+vi.mock("../../services/scheduled-query-schedule.service", () => ({
+  validateScheduledConsoleSchedule: vi.fn(() => null),
+}));
+// GitHub network surface only — the local git services run for real.
+vi.mock("../../integrations/github/app-auth", () => ({
+  resolveRepoToken: vi.fn(async () => "token"),
+}));
+vi.mock("../../integrations/github/github-api", () => ({
+  commitChanges: vi.fn(),
+  createBranch: vi.fn(),
+  createPullRequest: vi.fn(),
+  deleteBranch: vi.fn(),
+  getBlobContent: vi.fn(),
+  getBranchHeadSha: vi.fn(),
+  getPullRequest: vi.fn(),
+  getRefCommit: vi.fn(),
+  getRepoInfo: vi.fn(),
+  getRepoTree: vi.fn(),
+  listBranches: vi.fn(),
+  listPullRequests: vi.fn(),
+  mergePullRequest: vi.fn(),
+  tryDeleteBranch: vi.fn(),
+  updatePullRequest: vi.fn(),
+}));
+
+// Imported after the mocks are registered.
+import { createDbtServerTools } from "./dbt-tools";
+import {
+  DbtFile,
+  DbtFileDraft,
+  DbtProject,
+} from "../../database/workspace-schema";
+import { publishRealtimeEvent } from "../../services/realtime.service";
+import { gitBlobSha } from "../../integrations/github/git-blob";
+
+let mongo: MongoMemoryServer;
+const WS = new Types.ObjectId().toString();
+const CONN = new Types.ObjectId();
+const USER = "u1";
+
+const tools = createDbtServerTools(WS, USER, { chatId: "chat1" });
+
+type EditInput = {
+  projectId: string;
+  path: string;
+  oldString: string;
+  newString: string;
+  replaceAll?: boolean;
+};
+type EditResult = {
+  success: boolean;
+  error?: string;
+  path?: string;
+  replacements?: number;
+};
+type StatusResult = {
+  success: boolean;
+  branch?: string;
+  hasChanges?: boolean;
+  added?: number;
+  modified?: number;
+  deleted?: number;
+  changes?: Array<{ path: string; status: string }>;
+};
+type ReadResult = { success: boolean; contents?: string };
+
+function editFile(input: EditInput): Promise<EditResult> {
+  return (tools.edit_dbt_file.execute as (i: EditInput) => Promise<EditResult>)(
+    input,
+  );
+}
+
+function gitStatus(projectId: string): Promise<StatusResult> {
+  return (
+    tools.dbt_git_status.execute as (i: {
+      projectId: string;
+    }) => Promise<StatusResult>
+  )({ projectId });
+}
+
+function readFile(projectId: string, path: string): Promise<ReadResult> {
+  return (
+    tools.read_dbt_file.execute as (i: {
+      projectId: string;
+      path: string;
+    }) => Promise<ReadResult>
+  )({ projectId, path });
+}
+
+async function seedRepoProject(): Promise<string> {
+  const project = await DbtProject.create({
+    workspaceId: new Types.ObjectId(WS),
+    name: "Analytics",
+    environments: [
+      { name: "dev", connectionId: CONN, targetSchema: "analytics", threads: 4 },
+    ],
+    defaultEnvironment: "dev",
+    createdBy: "tester",
+    repo: {
+      provider: "github",
+      owner: "acme",
+      repo: "analytics",
+      branch: "main",
+      installationId: 123,
+    },
+  });
+  // Committed base tree of `main`, as a dbt_sync_from_repo leaves it: content
+  // mirrors the branch head and repoBlobSha is stamped for diffing.
+  await DbtFile.insertMany(
+    [
+      { path: "dbt_project.yml", content: "name: analytics" },
+      { path: "models/a.sql", content: "select 1" },
+    ].map(file => ({
+      workspaceId: project.workspaceId,
+      projectId: project._id,
+      branch: "main",
+      path: file.path,
+      content: file.content,
+      updatedBy: "sync",
+      repoBlobSha: gitBlobSha(file.content),
+    })),
+  );
+  return project._id.toString();
+}
+
+async function seedBlankProject(): Promise<string> {
+  const project = await DbtProject.create({
+    workspaceId: new Types.ObjectId(WS),
+    name: "Blank",
+    environments: [
+      { name: "dev", connectionId: CONN, targetSchema: "analytics", threads: 4 },
+    ],
+    defaultEnvironment: "dev",
+    createdBy: "tester",
+  });
+  await DbtFile.create({
+    workspaceId: project.workspaceId,
+    projectId: project._id,
+    path: "models/a.sql",
+    content: "select 1",
+    updatedBy: "tester",
+  });
+  return project._id.toString();
+}
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  await Promise.all([
+    mongoose.connection.collection("dbt_projects").deleteMany({}),
+    mongoose.connection.collection("dbt_files").deleteMany({}),
+    mongoose.connection.collection("dbt_file_drafts").deleteMany({}),
+    mongoose.connection.collection("dbt_checkouts").deleteMany({}),
+  ]);
+});
+
+describe("edit_dbt_file on a repo-bound project", () => {
+  it("writes a draft overlay, never the committed base tree", async () => {
+    const projectId = await seedRepoProject();
+
+    const result = await editFile({
+      projectId,
+      path: "models/a.sql",
+      oldString: "select 1",
+      newString: "select 2",
+    });
+    expect(result.success).toBe(true);
+    expect(result.replacements).toBe(1);
+
+    // The edit lives in the acting user's draft overlay...
+    const draft = await DbtFileDraft.findOne({ userId: USER }).lean();
+    expect(draft?.path).toBe("models/a.sql");
+    expect(draft?.content).toBe("select 2");
+    // ...and the committed base tree is untouched (other users see HEAD).
+    const base = await DbtFile.findOne({
+      branch: "main",
+      path: "models/a.sql",
+    }).lean();
+    expect(base?.content).toBe("select 1");
+    expect(base?.repoBlobSha).toBe(gitBlobSha("select 1"));
+  });
+
+  it("shows the anchored edit as a pending change in dbt_git_status", async () => {
+    // The reported bug: after a sync stamped base blob SHAs, an anchored
+    // edit succeeded (readable/compilable) but git status reported a clean
+    // tree, so commit tools refused with "No changes to commit".
+    const projectId = await seedRepoProject();
+
+    await editFile({
+      projectId,
+      path: "models/a.sql",
+      oldString: "select 1",
+      newString: "select 2",
+    });
+
+    const status = await gitStatus(projectId);
+    expect(status.success).toBe(true);
+    expect(status.hasChanges).toBe(true);
+    expect(status.modified).toBe(1);
+    expect(status.changes).toEqual([
+      { path: "models/a.sql", status: "modified" },
+    ]);
+  });
+
+  it("edits are visible to the working-tree read path and stack across calls", async () => {
+    const projectId = await seedRepoProject();
+
+    await editFile({
+      projectId,
+      path: "models/a.sql",
+      oldString: "select 1",
+      newString: "select 2",
+    });
+    // Second anchored edit must read the DRAFT content, not the base.
+    const second = await editFile({
+      projectId,
+      path: "models/a.sql",
+      oldString: "select 2",
+      newString: "select 3",
+    });
+    expect(second.success).toBe(true);
+
+    const read = await readFile(projectId, "models/a.sql");
+    expect(read.contents).toBe("select 3");
+    expect((await gitStatus(projectId)).modified).toBe(1);
+  });
+
+  it("reverting back to the committed content clears the pending change", async () => {
+    const projectId = await seedRepoProject();
+
+    await editFile({
+      projectId,
+      path: "models/a.sql",
+      oldString: "select 1",
+      newString: "select 2",
+    });
+    await editFile({
+      projectId,
+      path: "models/a.sql",
+      oldString: "select 2",
+      newString: "select 1",
+    });
+
+    expect(await DbtFileDraft.countDocuments({})).toBe(0);
+    expect((await gitStatus(projectId)).hasChanges).toBe(false);
+  });
+
+  it("publishes a user-scoped draft poke so only the author's windows react", async () => {
+    const projectId = await seedRepoProject();
+
+    await editFile({
+      projectId,
+      path: "models/a.sql",
+      oldString: "select 1",
+      newString: "select 2",
+    });
+
+    expect(publishRealtimeEvent).toHaveBeenCalledWith(
+      WS,
+      expect.objectContaining({
+        type: "dbt.file.updated",
+        path: "models/a.sql",
+        forUserId: USER,
+      }),
+    );
+  });
+
+  it("returns an error for a missing file without creating a draft", async () => {
+    const projectId = await seedRepoProject();
+    const result = await editFile({
+      projectId,
+      path: "models/missing.sql",
+      oldString: "x",
+      newString: "y",
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not found/i);
+    expect(await DbtFileDraft.countDocuments({})).toBe(0);
+  });
+});
+
+describe("edit_dbt_file on a blank (non-repo) project", () => {
+  it("updates the shared working tree directly (no draft overlay)", async () => {
+    const projectId = await seedBlankProject();
+
+    const result = await editFile({
+      projectId,
+      path: "models/a.sql",
+      oldString: "select 1",
+      newString: "select 2",
+    });
+    expect(result.success).toBe(true);
+
+    const file = await DbtFile.findOne({ path: "models/a.sql" }).lean();
+    expect(file?.content).toBe("select 2");
+    expect(await DbtFileDraft.countDocuments({})).toBe(0);
+  });
+});

--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -530,11 +530,12 @@ export const createDbtServerTools = (
           if (!isSafeDbtPath(path)) {
             return { success: false, error: "Invalid file path" };
           }
-          const file = await DbtFile.findOne({
-            projectId: project._id,
-            path,
-            is_deleted: { $ne: true },
-          });
+          // Read + write through the working-tree service (same as
+          // modify_dbt_file): repo projects edit the caller's DRAFT overlay
+          // on their checkout branch — never the committed base tree — so
+          // the edit shows up in dbt_git_status / the Version Control UI and
+          // stays invisible to other users until committed.
+          const file = await readWorkingFile(project, actingUserId, path);
           if (!file) {
             return {
               success: false,
@@ -560,11 +561,14 @@ export const createDbtServerTools = (
             newString,
             result.replacements,
           );
-          file.content = result.contents;
-          if (userId) file.updatedBy = userId;
-          await file.save();
+          const { versionEntityId } = await writeWorkingFile(
+            project,
+            actingUserId,
+            path,
+            result.contents,
+          );
           await snapshotVersion(
-            file._id,
+            versionEntityId,
             project.workspaceId,
             path,
             result.contents,
@@ -573,7 +577,9 @@ export const createDbtServerTools = (
             { _id: project._id },
             { $currentDate: { updatedAt: true } },
           );
-          publishFileUpdated(projectId, path);
+          publishFileUpdated(projectId, path, {
+            draft: Boolean(project.repo),
+          });
           return {
             success: true,
             path,

--- a/api/vitest.config.ts
+++ b/api/vitest.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
       "src/dbt/**/*.test.ts",
       "src/integrations/github/**/*.test.ts",
       "src/routes/dbt.routes.integration.test.ts",
-      "src/agent-lib/tools/dbt-job-tools.test.ts",
+      "src/agent-lib/tools/dbt-*.test.ts",
     ],
     exclude: [
       "**/node_modules/**",

--- a/app/src/components/chat/hooks/useServerToolSync.test.ts
+++ b/app/src/components/chat/hooks/useServerToolSync.test.ts
@@ -1,0 +1,208 @@
+// @vitest-environment jsdom
+/**
+ * useServerToolSync — dbt git/checkout chat-stream backstop.
+ *
+ * Regression coverage for "the UI doesn't follow the agent's branch": a
+ * server-side dbt_switch_branch only reached open tabs via the workspace SSE
+ * poke (dbt.checkout.updated), so a dead/dropped stream left the tab
+ * rendering the old branch/tree until a manual reload. The hook now also
+ * reconciles off the resumable chat stream when git tool results arrive.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { UIMessage } from "ai";
+
+const stores = vi.hoisted(() => {
+  const dbtState = {
+    projects: [] as Array<{ _id: string; repo?: { owner: string } }>,
+    filePathsByProject: {} as Record<string, string[]>,
+    gitStatusByProject: {} as Record<string, unknown>,
+    applyRemoteFileUpdate: vi.fn(),
+    applyRemoteGitUpdate: vi.fn(),
+    applyRemoteCheckoutUpdate: vi.fn(),
+    fetchGitStatus: vi.fn(),
+  };
+  return {
+    dbtState,
+    consoleState: { tabs: {}, openConsoleFromServer: vi.fn() },
+    realtimeState: { syncRevisions: vi.fn() },
+    appState: { openApps: {}, fetchApp: vi.fn(), bumpPreview: vi.fn() },
+  };
+});
+
+vi.mock("../../../store/dbtStore", () => ({
+  useDbtStore: { getState: () => stores.dbtState },
+}));
+vi.mock("../../../store/consoleStore", () => ({
+  useConsoleStore: { getState: () => stores.consoleState },
+}));
+vi.mock("../../../store/realtimeStore", () => ({
+  useRealtimeStore: { getState: () => stores.realtimeState },
+}));
+vi.mock("../../../store/appStore", () => ({
+  useAppStore: { getState: () => stores.appState },
+}));
+
+import { useServerToolSync } from "./useServerToolSync";
+
+const WS = "ws1";
+const PROJECT = "p1";
+
+function toolMessage(
+  toolName: string,
+  output: Record<string, unknown>,
+  opts: { toolCallId?: string; input?: Record<string, unknown> } = {},
+): UIMessage[] {
+  return [
+    {
+      id: "m1",
+      role: "assistant",
+      parts: [
+        {
+          type: `tool-${toolName}`,
+          state: "output-available",
+          toolCallId: opts.toolCallId ?? "call-1",
+          input: { projectId: PROJECT, ...opts.input },
+          output,
+        },
+      ],
+    },
+  ] as unknown as UIMessage[];
+}
+
+function render(messages: UIMessage[]) {
+  return renderHook(
+    props =>
+      useServerToolSync({
+        chatId: "chat1",
+        workspaceId: WS,
+        messages: props.messages,
+      }),
+    { initialProps: { messages } },
+  );
+}
+
+function markProjectLoaded(withRepo = true) {
+  stores.dbtState.projects = [
+    { _id: PROJECT, ...(withRepo ? { repo: { owner: "acme" } } : {}) },
+  ];
+  stores.dbtState.filePathsByProject = { [PROJECT]: ["models/a.sql"] };
+  stores.dbtState.gitStatusByProject = { [PROJECT]: { branch: "main" } };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  stores.dbtState.projects = [];
+  stores.dbtState.filePathsByProject = {};
+  stores.dbtState.gitStatusByProject = {};
+});
+
+describe("dbt checkout-moving tools (branch follow)", () => {
+  it("follows a dbt_switch_branch result onto the new branch", () => {
+    markProjectLoaded();
+    render(
+      toolMessage("dbt_switch_branch", { success: true, branch: "feat/x" }),
+    );
+    expect(stores.dbtState.applyRemoteCheckoutUpdate).toHaveBeenCalledWith(
+      WS,
+      PROJECT,
+      "feat/x",
+    );
+  });
+
+  it("follows dbt_commit_to_branch onto the promoted branch", () => {
+    markProjectLoaded();
+    render(
+      toolMessage("dbt_commit_to_branch", { success: true, branch: "feat/y" }),
+    );
+    expect(stores.dbtState.applyRemoteCheckoutUpdate).toHaveBeenCalledWith(
+      WS,
+      PROJECT,
+      "feat/y",
+    );
+  });
+
+  it("handles each tool call once across re-renders (dedupe)", () => {
+    markProjectLoaded();
+    const messages = toolMessage("dbt_switch_branch", {
+      success: true,
+      branch: "feat/x",
+    });
+    const { rerender } = render(messages);
+    rerender({ messages: [...messages] });
+    expect(stores.dbtState.applyRemoteCheckoutUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores results for projects this window never loaded", () => {
+    render(
+      toolMessage("dbt_switch_branch", { success: true, branch: "feat/x" }),
+    );
+    expect(stores.dbtState.applyRemoteCheckoutUpdate).not.toHaveBeenCalled();
+  });
+
+  it("ignores failed tool results", () => {
+    markProjectLoaded();
+    render(toolMessage("dbt_switch_branch", { success: false }));
+    expect(stores.dbtState.applyRemoteCheckoutUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("dbt git-surface tools (no checkout move)", () => {
+  it("refetches tree + status after dbt_sync_from_repo", () => {
+    markProjectLoaded();
+    render(
+      toolMessage("dbt_sync_from_repo", { success: true, branch: "main" }),
+    );
+    // Sync carries `branch` in its output but does NOT move the checkout —
+    // it must reconcile via the git-update path, not the checkout path.
+    expect(stores.dbtState.applyRemoteGitUpdate).toHaveBeenCalledWith(
+      WS,
+      PROJECT,
+    );
+    expect(stores.dbtState.applyRemoteCheckoutUpdate).not.toHaveBeenCalled();
+  });
+
+  it("refetches tree + status after dbt_commit_and_push", () => {
+    markProjectLoaded();
+    render(
+      toolMessage("dbt_commit_and_push", { success: true, branch: "main" }),
+    );
+    expect(stores.dbtState.applyRemoteGitUpdate).toHaveBeenCalledWith(
+      WS,
+      PROJECT,
+    );
+  });
+});
+
+describe("dbt file mutation tools", () => {
+  it("pulls the file AND refreshes git status after edit_dbt_file", () => {
+    markProjectLoaded();
+    render(
+      toolMessage(
+        "edit_dbt_file",
+        { success: true },
+        { input: { path: "models/a.sql" } },
+      ),
+    );
+    expect(stores.dbtState.applyRemoteFileUpdate).toHaveBeenCalledWith(
+      WS,
+      PROJECT,
+      "models/a.sql",
+      false,
+    );
+    expect(stores.dbtState.fetchGitStatus).toHaveBeenCalledWith(WS, PROJECT);
+  });
+
+  it("skips the git-status refresh for non-repo projects", () => {
+    markProjectLoaded(false);
+    render(
+      toolMessage(
+        "modify_dbt_file",
+        { success: true },
+        { input: { path: "models/a.sql" } },
+      ),
+    );
+    expect(stores.dbtState.applyRemoteFileUpdate).toHaveBeenCalled();
+    expect(stores.dbtState.fetchGitStatus).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/components/chat/hooks/useServerToolSync.ts
+++ b/app/src/components/chat/hooks/useServerToolSync.ts
@@ -7,6 +7,8 @@ import { useAppStore } from "../../../store/appStore";
 import { useDbtStore } from "../../../store/dbtStore";
 import {
   APP_SERVER_MUTATION_TOOLS,
+  DBT_CHECKOUT_MUTATION_TOOLS,
+  DBT_GIT_MUTATION_TOOLS,
   DBT_SERVER_MUTATION_TOOLS,
 } from "../tool-presentation";
 
@@ -38,13 +40,15 @@ export interface UseServerToolSyncArgs {
  *     nothing until I refreshed" bug. create_console never had this problem
  *     because it already rode the chat stream (asymmetry, issue #475).
  *
- * App/dbt sync: the app_* and dbt file mutation tools execute SERVER-SIDE,
- * so an OPEN app / dbt tab learns about the agent's write via the workspace
- * realtime poke (app.updated / dbt.file.updated). That poke rides the
- * workspace SSE, which a mobile lock / laptop sleep / proxy half-close can
- * kill — so reconcile off the RESUMABLE CHAT STREAM too: when the tool
- * result streams in (or is replayed after a wake reattach), refetch the open
- * app / dbt file (poke = fast path, this = robust backstop).
+ * App/dbt sync: the app_* and dbt file/git mutation tools execute
+ * SERVER-SIDE, so an OPEN app / dbt tab learns about the agent's write via
+ * the workspace realtime poke (app.updated / dbt.file.updated /
+ * dbt.git.updated / dbt.checkout.updated). That poke rides the workspace
+ * SSE, which a mobile lock / laptop sleep / proxy half-close can kill — so
+ * reconcile off the RESUMABLE CHAT STREAM too: when the tool result streams
+ * in (or is replayed after a wake reattach), refetch the open app / dbt
+ * file, git status, and — for branch-moving tools — follow the agent's
+ * checkout onto its new branch (poke = fast path, this = robust backstop).
  *
  * Returns `handledConsoleOpenToolCallIdsRef` so the session loader can seed
  * it: tool call ids seen in RESTORED history must not re-trigger the console
@@ -132,7 +136,7 @@ export function useServerToolSync({
         state?: string;
         toolCallId?: string;
         input?: { appId?: string; projectId?: string; path?: string };
-        output?: { success?: boolean };
+        output?: { success?: boolean; branch?: string };
       };
       const toolName =
         p.type === "dynamic-tool"
@@ -143,7 +147,11 @@ export function useServerToolSync({
       if (!toolName) continue;
       const isAppEdit = APP_SERVER_MUTATION_TOOLS.has(toolName);
       const isDbtEdit = DBT_SERVER_MUTATION_TOOLS.has(toolName);
-      if (!isAppEdit && !isDbtEdit) continue;
+      const isDbtCheckoutMove = DBT_CHECKOUT_MUTATION_TOOLS.has(toolName);
+      const isDbtGitMutation = DBT_GIT_MUTATION_TOOLS.has(toolName);
+      if (!isAppEdit && !isDbtEdit && !isDbtCheckoutMove && !isDbtGitMutation) {
+        continue;
+      }
       if (
         p.state !== "output-available" ||
         !p.toolCallId ||
@@ -166,23 +174,56 @@ export function useServerToolSync({
             if (fresh) useAppStore.getState().bumpPreview(appId);
           })();
         }
-      } else {
+      } else if (isDbtEdit) {
         const projectId = p.input?.projectId;
         const path = p.input?.path;
-        // Only touch projects this window has loaded.
+        if (!projectId || !path) continue;
+        const dbt = useDbtStore.getState();
+        // Only touch projects this window has loaded (file tree OR the
+        // version-control panel's git status — they load independently).
+        if (dbt.filePathsByProject[projectId]) {
+          void dbt.applyRemoteFileUpdate(
+            workspaceId,
+            projectId,
+            path,
+            toolName === "delete_dbt_file",
+          );
+        }
+        // A draft write also changes the working-tree status — refresh so
+        // the Version Control panel's change list / A-M-D badges converge
+        // even when the dbt.file.updated poke was missed (dead SSE).
+        const project = dbt.projects.find(proj => proj._id === projectId);
         if (
-          projectId &&
-          path &&
-          useDbtStore.getState().filePathsByProject[projectId]
+          project?.repo &&
+          (dbt.filePathsByProject[projectId] ||
+            dbt.gitStatusByProject[projectId])
         ) {
-          void useDbtStore
-            .getState()
-            .applyRemoteFileUpdate(
-              workspaceId,
-              projectId,
-              path,
-              toolName === "delete_dbt_file",
-            );
+          void dbt.fetchGitStatus(workspaceId, projectId);
+        }
+      } else {
+        const projectId = p.input?.projectId;
+        if (!projectId) continue;
+        const dbt = useDbtStore.getState();
+        if (
+          !dbt.filePathsByProject[projectId] &&
+          !dbt.gitStatusByProject[projectId]
+        ) {
+          continue;
+        }
+        if (isDbtCheckoutMove && p.output.branch) {
+          // The agent moved this user's checkout (branch create/switch/
+          // promote/merge): follow it — update the branch label and reload
+          // tree + status. Chat-stream counterpart of dbt.checkout.updated.
+          void dbt.applyRemoteCheckoutUpdate(
+            workspaceId,
+            projectId,
+            p.output.branch,
+          );
+        } else {
+          // Git surface changed without a checkout move (sync/commit/branch
+          // delete/restore): refetch tree + status + clean open buffers.
+          // Chat-stream counterpart of dbt.git.updated.
+          void dbt.applyRemoteGitUpdate(workspaceId, projectId);
         }
       }
     }

--- a/app/src/components/chat/tool-presentation.ts
+++ b/app/src/components/chat/tool-presentation.ts
@@ -53,6 +53,27 @@ export const DBT_SERVER_MUTATION_TOOLS = new Set<string>([
   "delete_dbt_file",
 ]);
 
+// Server-executed dbt git tools that MOVE the acting user's checkout (their
+// tool output carries the new `branch`). Reconciled off the resumable chat
+// stream so the open dbt tab follows the agent onto the new branch even when
+// the workspace SSE poke (dbt.checkout.updated) was missed.
+export const DBT_CHECKOUT_MUTATION_TOOLS = new Set<string>([
+  "dbt_switch_branch",
+  "dbt_create_branch",
+  "dbt_commit_to_branch",
+  "dbt_merge_pull_request",
+]);
+
+// Server-executed dbt git tools that change the git surface (base tree /
+// pending changes) WITHOUT moving the checkout. Chat-stream counterpart of
+// the dbt.git.updated poke: refetch tree + git status.
+export const DBT_GIT_MUTATION_TOOLS = new Set<string>([
+  "dbt_sync_from_repo",
+  "dbt_commit_and_push",
+  "dbt_delete_branch",
+  "dbt_restore_file",
+]);
+
 // Diagnostics for the *live* stream-disconnect signatures so they can be
 // investigated after the fact:
 //   - "orphan-rescue": a turn settled to `ready` while non-interactive tool


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Two field-reported bugs in the dbt git flow:

1. **Anchored `edit_dbt_file` edits were invisible to draft/diff tracking.** After a `dbt_sync_from_repo`, anchored edits succeeded (readable, compilable, runnable) but `dbt_git_status` reported a clean tree, the Version Control UI showed no draft files, and `dbt_commit_and_push` / `dbt_commit_to_branch` refused with "No changes to commit". Full-file rewrites via `modify_dbt_file` worked (the workaround that landed the user's PR).
2. **The open tab didn't follow the agent's `dbt_switch_branch`** — the branch/tree kept rendering the old state until a manual reload.

## Root causes

1. `edit_dbt_file` did a raw `DbtFile.findOne` + `file.save()`, writing the **committed base tree** directly — bypassing the per-user `DbtFileDraft` overlay that `dbt_git_status` / the Version Control panel diff against (and skipping the branch filter, so it could even hit the wrong branch's base row). `modify_dbt_file` goes through `writeWorkingFile()` which creates the draft — that's why full rewrites re-marked the file dirty.
2. Branch switches only reached open tabs via the workspace SSE poke (`dbt.checkout.updated`). When that stream is dead/dropped (mobile lock, laptop sleep, proxy half-close), nothing else told the tab the checkout moved — unlike file edits, which already have a resumable-chat-stream backstop in `useServerToolSync`.

## Fixes

- `edit_dbt_file` now reads via `readWorkingFile` (draft-over-base, so sequential edits stack) and writes via `writeWorkingFile` (draft overlay for repo projects, shared row for blank projects), snapshots the right version entity, and publishes a user-scoped `draft` poke — exactly mirroring `modify_dbt_file`.
- `useServerToolSync` gains a chat-stream backstop for dbt git tools:
  - checkout-moving tools (`dbt_switch_branch`, `dbt_create_branch`, `dbt_commit_to_branch`, `dbt_merge_pull_request`) → `applyRemoteCheckoutUpdate` (branch label + tree + status follow the agent);
  - git-surface tools (`dbt_sync_from_repo`, `dbt_commit_and_push`, `dbt_delete_branch`, `dbt_restore_file`) → `applyRemoteGitUpdate`;
  - file mutation tools additionally refresh git status (previously only the SSE poke did).

## Demo (manual E2E in the Cloud Agent VM)

Imported the public `dbt-labs/jaffle-shop-classic` repo, then drove the real unified agent from the chat panel — no page reloads anywhere:

[dbt_agent_edit_draft_tracking_and_branch_follow_demo.mp4](https://cursor.com/agents/bc-8faab0bd-72e1-4569-add4-4fac632d2010/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdbt_agent_edit_draft_tracking_and_branch_follow_demo.mp4)

Agent `edit_dbt_file` → Version Control panel live-updates to "Commit & push (1)" with `M models/customers.sql`, and `dbt_git_status` reports `hasChanges: true, modified: 1` (previously: clean tree / "No changes to commit"):

[Pending change appears after anchored edit](https://cursor.com/agents/bc-8faab0bd-72e1-4569-add4-4fac632d2010/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_edit_shows_pending_change.webp)

Agent `dbt_switch_branch` to `core-v1.0.0` → the branch label follows live and the draft carries over (`carriedChanges: 1`):

[Branch label follows the agent to core-v1.0.0 with the draft carried over](https://cursor.com/agents/bc-8faab0bd-72e1-4569-add4-4fac632d2010/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_branch_followed_to_core_v1_with_carried_draft.webp)

(Also verified live: reverting the edit back to the committed content auto-clears the pending change.)

> Note: manual verification surfaced a stale `{projectId, path}` unique index in the dev DB that made branch switches fail with E11000 — running the existing `2026-07-02-100000_per_user_dbt_working_trees` migration (`pnpm migrate`) drops it. No code change needed, but environments that haven't run that migration will hit the same error.

## Tests

- New `api/src/agent-lib/tools/dbt-file-tools.test.ts` (7 tests, real working-tree + git-status services on mongodb-memory-server): draft overlay written, base tree untouched, pending change visible in `dbt_git_status`, edits stack, revert clears the draft, user-scoped poke, blank-project path.
- New `app/src/components/chat/hooks/useServerToolSync.test.ts` (9 tests): branch follow, promote follow, dedupe across re-renders, unloaded-project/failed-result guards, sync/commit git refetch, file-edit git-status refresh.
- ✅ `pnpm --filter api run test:dbt` (175 passed) · ✅ `pnpm --filter app run test:unit` (282 passed) · ✅ `pnpm --filter api run lint` · ✅ `pnpm --filter app run typecheck && lint`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8faab0bd-72e1-4569-add4-4fac632d2010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8faab0bd-72e1-4569-add4-4fac632d2010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

