### PR TITLE
dbt: Cursor-IDE dev loop — draft runs everywhere with provenance, full-refresh, personal envs by default, prod via jobs only

### DIFF
--- a/api/src/agent-lib/tools/dbt-job-tools.test.ts
+++ b/api/src/agent-lib/tools/dbt-job-tools.test.ts
@@ -68,6 +68,7 @@ import {
   getGitStatus,
 } from "../../dbt/dbt-github-git.service";
 import { generateDbtCommitMessage } from "../../dbt/dbt-commit-message.service";
+import { triggerDbtRun } from "../../dbt/dbt-run.service";
 
 let mongo: MongoMemoryServer;
 const WS = new Types.ObjectId().toString();
@@ -262,6 +263,63 @@ describe("dbt_delete_job", () => {
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/not found|access denied/i);
     expect(await DbtJob.countDocuments({ _id: job._id })).toBe(1);
+  });
+});
+
+describe("dbt_run_model — personal environment auto-provisioning", () => {
+  function runModel(input: {
+    projectId: string;
+    model: string;
+    environment?: string;
+  }): Promise<ToolResult & { environment?: string }> {
+    return (
+      tools.dbt_run_model.execute as (
+        i: typeof input,
+      ) => Promise<ToolResult & { environment?: string }>
+    )(input);
+  }
+
+  it("provisions the caller's personal environment on the first build", async () => {
+    const projectId = await seedProject();
+
+    const result = await runModel({ projectId, model: "stg_orders" });
+    expect(result.success).toBe(true);
+
+    // Personal env exists now (slug from the mocked display name "Tester").
+    const project = await DbtProject.findById(projectId).lean();
+    const personal = project?.environments.find(e => e.ownerUserId === "u1");
+    expect(personal?.name).toBe("tester");
+    expect(personal?.targetSchema).toBe("dbt_tester");
+
+    // The queued run targets it, not the shared default.
+    expect(vi.mocked(triggerDbtRun)).toHaveBeenCalledWith(
+      expect.objectContaining({ environment: "tester" }),
+    );
+
+    // Idempotent: a second build reuses it without adding another env.
+    await runModel({ projectId, model: "stg_orders" });
+    const after = await DbtProject.findById(projectId).lean();
+    expect(
+      after?.environments.filter(e => e.ownerUserId === "u1"),
+    ).toHaveLength(1);
+  });
+
+  it("an explicit environment always wins (no auto-provisioning)", async () => {
+    const projectId = await seedProject();
+
+    const result = await runModel({
+      projectId,
+      model: "stg_orders",
+      environment: "dev",
+    });
+    expect(result.success).toBe(true);
+    expect(vi.mocked(triggerDbtRun)).toHaveBeenCalledWith(
+      expect.objectContaining({ environment: "dev" }),
+    );
+    const project = await DbtProject.findById(projectId).lean();
+    expect(
+      project?.environments.some(e => e.ownerUserId === "u1"),
+    ).toBe(false);
   });
 });
 

--- a/api/src/agent-lib/tools/dbt-job-tools.test.ts
+++ b/api/src/agent-lib/tools/dbt-job-tools.test.ts
@@ -26,7 +26,11 @@ vi.mock("../../services/realtime.service", () => ({
   publishRealtimeEvent: vi.fn(),
 }));
 vi.mock("../../services/workspace.service", () => ({
-  workspaceService: { isAdmin: vi.fn(async () => true) },
+  workspaceService: {
+    isAdmin: vi.fn(async () => true),
+    // Default: multi-user workspace; solo tests override per-call.
+    getMembers: vi.fn(async () => [{ userId: "u1" }, { userId: "u2" }]),
+  },
 }));
 vi.mock("../../services/entity-version.service", () => ({
   createVersion: vi.fn(async () => ({})),
@@ -61,7 +65,12 @@ vi.mock("../../services/scheduled-query-schedule.service", () => ({
 
 // Imported after the mocks are registered.
 import { createDbtServerTools } from "./dbt-tools";
-import { DbtJob, DbtProject } from "../../database/workspace-schema";
+import {
+  DbtEnvPreference,
+  DbtJob,
+  DbtProject,
+} from "../../database/workspace-schema";
+import { workspaceService } from "../../services/workspace.service";
 import {
   commitAndPush,
   commitToNewBranch,
@@ -191,9 +200,16 @@ afterAll(async () => {
 
 beforeEach(async () => {
   vi.clearAllMocks();
+  // vi.clearAllMocks wipes mock implementations' return queues but keeps the
+  // factory defaults; re-assert the multi-user default explicitly.
+  vi.mocked(workspaceService.getMembers).mockResolvedValue([
+    { userId: "u1" },
+    { userId: "u2" },
+  ] as never);
   await Promise.all([
     mongoose.connection.collection("dbt_projects").deleteMany({}),
     mongoose.connection.collection("dbt_jobs").deleteMany({}),
+    mongoose.connection.collection("dbt_env_preferences").deleteMany({}),
   ]);
 });
 
@@ -266,7 +282,7 @@ describe("dbt_delete_job", () => {
   });
 });
 
-describe("dbt_run_model — personal environment auto-provisioning", () => {
+describe("dbt_run_model — per-user environment resolution", () => {
   function runModel(input: {
     projectId: string;
     model: string;
@@ -279,7 +295,7 @@ describe("dbt_run_model — personal environment auto-provisioning", () => {
     )(input);
   }
 
-  it("provisions the caller's personal environment on the first build", async () => {
+  it("multi-user workspace: provisions the caller's personal environment on the first build", async () => {
     const projectId = await seedProject();
 
     const result = await runModel({ projectId, model: "stg_orders" });
@@ -302,6 +318,44 @@ describe("dbt_run_model — personal environment auto-provisioning", () => {
     expect(
       after?.environments.filter(e => e.ownerUserId === "u1"),
     ).toHaveLength(1);
+  });
+
+  it("single-user workspace: dev IS the personal target — no auto-provisioning", async () => {
+    vi.mocked(workspaceService.getMembers).mockResolvedValue([
+      { userId: "u1" },
+    ] as never);
+    const projectId = await seedProject();
+
+    const result = await runModel({ projectId, model: "stg_orders" });
+    expect(result.success).toBe(true);
+    expect(vi.mocked(triggerDbtRun)).toHaveBeenCalledWith(
+      expect.objectContaining({ environment: "dev" }),
+    );
+    const project = await DbtProject.findById(projectId).lean();
+    expect(project?.environments.some(e => e.ownerUserId === "u1")).toBe(
+      false,
+    );
+  });
+
+  it("a saved per-user dev environment wins and suppresses auto-provisioning", async () => {
+    const projectId = await seedProject();
+    await DbtEnvPreference.create({
+      workspaceId: new Types.ObjectId(WS),
+      projectId: new Types.ObjectId(projectId),
+      userId: "u1",
+      environment: "dev",
+    });
+
+    const result = await runModel({ projectId, model: "stg_orders" });
+    expect(result.success).toBe(true);
+    expect(vi.mocked(triggerDbtRun)).toHaveBeenCalledWith(
+      expect.objectContaining({ environment: "dev" }),
+    );
+    // Even in a multi-user workspace the explicit choice stops provisioning.
+    const project = await DbtProject.findById(projectId).lean();
+    expect(project?.environments.some(e => e.ownerUserId === "u1")).toBe(
+      false,
+    );
   });
 
   it("an explicit environment always wins (no auto-provisioning)", async () => {

--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -924,6 +924,11 @@ export const createDbtServerTools = (
         "This WRITES to the warehouse target schema. `model` accepts a node " +
         "name (stg_orders) or a dbt selector with graph operators/methods " +
         "(stg_orders+, +marts.orders, tag:nightly, state:modified+). " +
+        "On repo-connected projects this builds YOUR working tree — your " +
+        "checkout branch plus your uncommitted drafts — so it is the ONLY " +
+        "run tool that verifies uncommitted or feature-branch work (jobs " +
+        "always build the committed tracked branch instead). Pass " +
+        "`fullRefresh: true` to rebuild incremental models from scratch. " +
         "Runs ASYNCHRONOUSLY in the runner and returns a `runId` immediately " +
         "(it does NOT block until the build finishes). Poll `dbt_get_run` " +
         "with that `runId` (pass `waitMs`) to get per-node status, timing, " +
@@ -941,12 +946,28 @@ export const createDbtServerTools = (
           .optional()
           .describe(
             "Environment name; defaults to your personal environment when " +
-              "provisioned, else the project default (dev). Only use prod " +
-              "when the user explicitly asks.",
+              "provisioned, else the project default (dev). The prod-like " +
+              "environment refuses ad-hoc builds — deploys go through jobs.",
+          ),
+        fullRefresh: z
+          .boolean()
+          .optional()
+          .describe(
+            "Run with --full-refresh: drop and rebuild the selected " +
+              "incremental models from scratch. Use after changing an " +
+              "incremental model's schema or logic — do NOT trigger a " +
+              "full-refresh JOB for this (jobs build the committed tracked " +
+              "branch, not your working tree).",
           ),
         defer: deferField,
       }),
-      execute: async ({ projectId, model, environment, defer }) => {
+      execute: async ({
+        projectId,
+        model,
+        environment,
+        fullRefresh,
+        defer,
+      }) => {
         try {
           if (!SELECTOR_PATTERN.test(model)) {
             return { success: false, error: "Invalid model selector" };
@@ -955,6 +976,12 @@ export const createDbtServerTools = (
           const environmentName = resolveEnvironment(project, environment);
           const wantsDefer =
             defer ?? shouldDeferByDefault(project, environmentName);
+          // The source tree this run builds: the acting user's checkout
+          // branch + drafts (repo projects) — surfaced in the result so the
+          // agent never has to guess which git state was verified.
+          const sourceBranch = project.repo
+            ? await getCheckoutBranch(project, actingUserId)
+            : undefined;
           // Dispatch to the async runner instead of blocking the chat turn for
           // the full build. The build executes in the Inngest worker
           // (decoupled from this SSE connection), so it survives proxy idle
@@ -964,7 +991,9 @@ export const createDbtServerTools = (
             workspaceId,
             projectId,
             environment: environmentName,
-            commands: [`build --select ${model}`],
+            commands: [
+              `build --select ${model}${fullRefresh ? " --full-refresh" : ""}`,
+            ],
             trigger: "agent",
             triggeredBy: "agent",
             // Build the acting user's working tree (checkout + drafts) so
@@ -980,10 +1009,15 @@ export const createDbtServerTools = (
             environment: run.environment,
             defer: wantsDefer,
             commands: run.commands,
+            ...(sourceBranch ? { sourceBranch } : {}),
             message:
               "Build started in the runner. Poll dbt_get_run with this runId " +
               "(pass waitMs) until status is success/error. The user sees " +
               "live progress in the run card." +
+              (sourceBranch
+                ? ` Building your working tree on "${sourceBranch}" ` +
+                  "(committed base + your uncommitted drafts)."
+                : "") +
               (wantsDefer
                 ? " Running with --defer: unselected refs resolve to the " +
                   "last prod build."
@@ -998,6 +1032,10 @@ export const createDbtServerTools = (
     dbt_run_job: tool({
       description:
         "Trigger a saved dbt job (full command list, possibly against prod). " +
+        "Jobs ALWAYS build the project's tracked branch as COMMITTED to git " +
+        "— NEVER your checkout branch or uncommitted drafts. Do not use a " +
+        "job to verify draft or feature-branch work (it would silently run " +
+        "the old code); use dbt_run_model (supports fullRefresh) instead. " +
         "Runs asynchronously via the job runner; returns the runId to share " +
         "with the user. Only call after the user explicitly confirms which " +
         "job to run — never trigger prod jobs proactively.",
@@ -1026,14 +1064,22 @@ export const createDbtServerTools = (
             runId: run._id.toString(),
             jobId: job._id.toString(),
           });
+          const trackedBranch = project.repo?.branch;
           return {
             success: true,
             runId: run._id.toString(),
             jobName: job.name,
             environment: job.environment,
             commands: job.commands,
+            ...(trackedBranch ? { sourceBranch: trackedBranch } : {}),
             message:
-              "Run queued. The user can watch live logs in the job tab " +
+              "Run queued. " +
+              (trackedBranch
+                ? `This job builds the COMMITTED "${trackedBranch}" branch — ` +
+                  "your checkout and uncommitted drafts are NOT included. " +
+                  "To verify working-tree changes use dbt_run_model instead. "
+                : "") +
+              "The user can watch live logs in the job tab " +
               "(Transforms → Jobs).",
           };
         } catch (error) {

--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -786,9 +786,10 @@ export const createDbtServerTools = (
         "warehouse connection as prod, private schema `dbt_<user>`. Once it " +
         "exists, dbt_parse / dbt_compile_model / dbt_run_model / dbt_show " +
         "default to it automatically, so iteration never writes to shared " +
-        "dev/prod schemas. Call this before building models when the user " +
-        "wants to iterate safely (or when read_dbt_project_tree shows no " +
-        "personal environment). Safe to call repeatedly.",
+        "dev/prod schemas. NOTE: dbt_run_model auto-provisions this on the " +
+        "first build, so you rarely need to call it explicitly — use it only " +
+        "to provision ahead of time (e.g. before dbt_show against a fresh " +
+        "schema). Safe to call repeatedly.",
       inputSchema: z.object({ projectId: projectIdField }),
       execute: async ({ projectId }) => {
         try {
@@ -945,9 +946,11 @@ export const createDbtServerTools = (
           .string()
           .optional()
           .describe(
-            "Environment name; defaults to your personal environment when " +
-              "provisioned, else the project default (dev). The prod-like " +
-              "environment refuses ad-hoc builds — deploys go through jobs.",
+            "Environment name. Omit it: builds default to your PERSONAL " +
+              "environment (auto-provisioned on first build — schema " +
+              "dbt_<user>), so iteration never touches shared schemas. The " +
+              "prod-like environment refuses ad-hoc builds — deploys go " +
+              "through jobs.",
           ),
         fullRefresh: z
           .boolean()
@@ -973,7 +976,34 @@ export const createDbtServerTools = (
             return { success: false, error: "Invalid model selector" };
           }
           const project = await assertProject(projectId);
-          const environmentName = resolveEnvironment(project, environment);
+          let environmentName = resolveEnvironment(project, environment);
+          // Smart default: builds land in the caller's PERSONAL environment.
+          // When none exists yet (and no explicit environment was requested),
+          // provision it idempotently so iteration never writes to the shared
+          // dev schema. Explicit `environment` always wins; best-effort — a
+          // provisioning failure falls back to the project default.
+          let autoProvisionedEnv: string | undefined;
+          if (
+            !environment &&
+            userId &&
+            project.environments.length > 0 &&
+            !findPersonalEnvironment(project, userId)
+          ) {
+            try {
+              const ensured = await ensurePersonalDbtEnvironment({
+                workspaceId,
+                projectId,
+                userId,
+              });
+              environmentName = ensured.environment.name;
+              if (ensured.created) {
+                autoProvisionedEnv = ensured.environment.targetSchema;
+                publishProjectUpdated(projectId);
+              }
+            } catch {
+              /* fall back to the project default environment */
+            }
+          }
           const wantsDefer =
             defer ?? shouldDeferByDefault(project, environmentName);
           // The source tree this run builds: the acting user's checkout
@@ -1014,6 +1044,11 @@ export const createDbtServerTools = (
               "Build started in the runner. Poll dbt_get_run with this runId " +
               "(pass waitMs) until status is success/error. The user sees " +
               "live progress in the run card." +
+              (autoProvisionedEnv
+                ? ` Provisioned your personal environment "${run.environment}" ` +
+                  `(schema ${autoProvisionedEnv}) — ad-hoc builds now default ` +
+                  "to it."
+                : "") +
               (sourceBranch
                 ? ` Building your working tree on "${sourceBranch}" ` +
                   "(committed base + your uncommitted drafts)."

--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -48,7 +48,8 @@ import {
 import {
   ensurePersonalDbtEnvironment,
   findPersonalEnvironment,
-  resolveEnvironmentNameForUser,
+  getUserDevEnvPreference,
+  resolveDevEnvironmentForUser,
   resolveProdLikeEnvironmentName,
 } from "../../dbt/dbt-environments.service";
 import {
@@ -322,19 +323,22 @@ export const createDbtServerTools = (
     return null;
   };
 
-  type EnvProject = Parameters<typeof resolveEnvironmentNameForUser>[0] & {
+  type EnvProject = Parameters<typeof resolveDevEnvironmentForUser>[0] & {
     lastProdManifestKey?: string;
   };
 
   /**
-   * Environment an ad-hoc action targets when the agent passed none: the
-   * acting user's personal environment when provisioned, else the project
-   * default. Explicit names always win.
+   * Environment an ad-hoc action targets when the agent passed none:
+   * explicit > the acting user's saved per-user dev environment > their
+   * personal environment when provisioned > the project default. Single
+   * player: dev IS the personal target; teams: per-user envs/choices keep
+   * builds out of teammates' schemas.
    */
   const resolveEnvironment = (
     project: EnvProject,
     requested?: string,
-  ): string => resolveEnvironmentNameForUser(project, actingUserId, requested);
+  ): Promise<string> =>
+    resolveDevEnvironmentForUser(project, actingUserId, requested);
 
   /**
    * Default defer decision for ad-hoc builds/previews: defer to the last prod
@@ -785,11 +789,11 @@ export const createDbtServerTools = (
         "on a project (dbt Cloud-style development credentials): same " +
         "warehouse connection as prod, private schema `dbt_<user>`. Once it " +
         "exists, dbt_parse / dbt_compile_model / dbt_run_model / dbt_show " +
-        "default to it automatically, so iteration never writes to shared " +
-        "dev/prod schemas. NOTE: dbt_run_model auto-provisions this on the " +
-        "first build, so you rarely need to call it explicitly — use it only " +
-        "to provision ahead of time (e.g. before dbt_show against a fresh " +
-        "schema). Safe to call repeatedly.",
+        "default to it automatically. Intended for MULTI-USER workspaces " +
+        "(dbt_run_model auto-provisions it there on the first build); solo " +
+        "workspaces normally keep building the shared dev environment — only " +
+        "provision explicitly when the user asks for an isolated schema. " +
+        "Safe to call repeatedly.",
       inputSchema: z.object({ projectId: projectIdField }),
       execute: async ({ projectId }) => {
         try {
@@ -850,7 +854,7 @@ export const createDbtServerTools = (
           const result = await runAdhocDbtCommand({
             workspaceId,
             projectId,
-            environmentName: resolveEnvironment(project, environment),
+            environmentName: await resolveEnvironment(project, environment),
             userId: actingUserId,
             command: "parse",
             timeoutMs: 2 * 60 * 1000,
@@ -891,7 +895,7 @@ export const createDbtServerTools = (
             return { success: false, error: "Invalid model selector" };
           }
           const project = await assertProject(projectId);
-          const environmentName = resolveEnvironment(project, environment);
+          const environmentName = await resolveEnvironment(project, environment);
           const wantsDefer =
             defer ?? shouldDeferByDefault(project, environmentName);
           const result = await runAdhocDbtCommand({
@@ -946,11 +950,13 @@ export const createDbtServerTools = (
           .string()
           .optional()
           .describe(
-            "Environment name. Omit it: builds default to your PERSONAL " +
-              "environment (auto-provisioned on first build — schema " +
-              "dbt_<user>), so iteration never touches shared schemas. The " +
-              "prod-like environment refuses ad-hoc builds — deploys go " +
-              "through jobs.",
+            "Environment name. Omit it: builds default to the user's saved " +
+              "dev environment, else their personal environment. Solo " +
+              "workspaces default to the shared dev environment (dev IS the " +
+              "personal target); multi-user workspaces auto-provision a " +
+              "personal environment (schema dbt_<user>) on first build so " +
+              "teammates never build over each other. The prod-like " +
+              "environment refuses ad-hoc builds — deploys go through jobs.",
           ),
         fullRefresh: z
           .boolean()
@@ -976,32 +982,39 @@ export const createDbtServerTools = (
             return { success: false, error: "Invalid model selector" };
           }
           const project = await assertProject(projectId);
-          let environmentName = resolveEnvironment(project, environment);
-          // Smart default: builds land in the caller's PERSONAL environment.
-          // When none exists yet (and no explicit environment was requested),
-          // provision it idempotently so iteration never writes to the shared
-          // dev schema. Explicit `environment` always wins; best-effort — a
-          // provisioning failure falls back to the project default.
+          let environmentName = await resolveEnvironment(project, environment);
+          // Smart default, following the single/multi-player model:
+          //  - SINGLE player (sole workspace member): the shared dev default
+          //    IS their personal target — never invent a `dbt_<user>` schema.
+          //  - MULTIPLE players: auto-provision the caller's PERSONAL
+          //    environment on first build so teammates never build over each
+          //    other's schemas.
+          // An explicit `environment` or a saved per-user choice always wins;
+          // best-effort — a provisioning failure falls back to the default.
           let autoProvisionedEnv: string | undefined;
           if (
             !environment &&
             userId &&
             project.environments.length > 0 &&
-            !findPersonalEnvironment(project, userId)
+            !findPersonalEnvironment(project, userId) &&
+            !(await getUserDevEnvPreference(project, userId))
           ) {
             try {
-              const ensured = await ensurePersonalDbtEnvironment({
-                workspaceId,
-                projectId,
-                userId,
-              });
-              environmentName = ensured.environment.name;
-              if (ensured.created) {
-                autoProvisionedEnv = ensured.environment.targetSchema;
-                publishProjectUpdated(projectId);
+              const members = await workspaceService.getMembers(workspaceId);
+              if (members.length > 1) {
+                const ensured = await ensurePersonalDbtEnvironment({
+                  workspaceId,
+                  projectId,
+                  userId,
+                });
+                environmentName = ensured.environment.name;
+                if (ensured.created) {
+                  autoProvisionedEnv = ensured.environment.targetSchema;
+                  publishProjectUpdated(projectId);
+                }
               }
             } catch {
-              /* fall back to the project default environment */
+              /* fall back to the resolved default environment */
             }
           }
           const wantsDefer =
@@ -1310,7 +1323,7 @@ export const createDbtServerTools = (
             return { success: false, error: "Invalid model selector" };
           }
           const project = await assertProject(projectId);
-          const environmentName = resolveEnvironment(project, environment);
+          const environmentName = await resolveEnvironment(project, environment);
           const wantsDefer =
             defer ?? shouldDeferByDefault(project, environmentName);
           const result = await runAdhocDbtCommand({

--- a/api/src/agent-skills/dbt/SKILL.md
+++ b/api/src/agent-skills/dbt/SKILL.md
@@ -143,9 +143,17 @@ AND its tests — always add at least `unique` + `not_null` on the primary key.
 ## Environments and jobs
 
 - Projects have environments (dev/prod) mapping to a workspace connection +
-  target schema. Ad-hoc agent builds default to the acting user's PERSONAL
-  environment; `dbt_run_model` auto-provisions it on the first build (schema
-  `dbt_<user>`), so omit `environment` unless the user explicitly picks one.
+  target schema. Ad-hoc agent builds resolve their environment PER USER:
+  saved per-user dev environment (the UI env pickers persist this setting) >
+  personal environment > project default. Omit `environment` unless the user
+  explicitly picks one.
+- **Single vs multi player — keep this clear:**
+  - SINGLE-USER workspace: the shared dev environment IS the user's personal
+    target. Drafts and branch verification build against dev; do NOT
+    provision `dbt_<user>` schemas unless the user asks for isolation.
+  - MULTI-USER workspace: each user tests against their OWN environment.
+    `dbt_run_model` auto-provisions a personal one (schema `dbt_<user>`) on
+    the first build so teammates never build over each other's schemas.
 - **Which git tree a run builds (repo-bound projects)** — never mix these up:
   - Ad-hoc tools (`dbt_parse`, `dbt_compile_model`, `dbt_show`,
     `dbt_run_model`) build YOUR working tree: your checkout branch + your
@@ -164,12 +172,13 @@ AND its tests — always add at least `unique` + `not_null` on the primary key.
   merged into the tracked branch. Read-only commands (parse/compile/show)
   still work against any environment.
 - **Personal environments**: per-user environments (schema `dbt_<user>`, same
-  connection as prod). `dbt_run_model` auto-provisions the caller's on its
-  first build; `dbt_ensure_dev_environment` provisions it explicitly ahead of
-  time. Once it exists, `dbt_parse` / `dbt_compile_model` / `dbt_run_model` /
-  `dbt_show` default to it — iteration never touches shared dev/prod schemas.
-  When verifying feature-branch work, build it into the personal environment
-  (the default) rather than shared dev; prod stays a jobs-only deploy target.
+  connection as prod). In MULTI-USER workspaces `dbt_run_model`
+  auto-provisions the caller's on its first build;
+  `dbt_ensure_dev_environment` provisions it explicitly ahead of time. Once
+  it exists, `dbt_parse` / `dbt_compile_model` / `dbt_run_model` / `dbt_show`
+  default to it. Feature-branch verification builds into the user's dev
+  environment (dev itself when solo, personal when in a team); prod stays a
+  jobs-only deploy target.
 - **Defer (fast iteration)**: ad-hoc builds default to
   `--defer --state <last prod manifest>` when targeting a non-prod environment
   and a prod build exists — unselected `ref()`s resolve to prod relations, so
@@ -194,8 +203,9 @@ draft preview can be switched.
 The full safe-iteration loop:
 
 1. Edit models; verify with `dbt_parse` → `dbt_compile_model` →
-   `dbt_run_model` (defaults: personal env — auto-provisioned on first
-   build, e.g. `dbt_jonas` — + defer to prod manifest).
+   `dbt_run_model` (defaults: the user's dev environment — dev itself when
+   solo, personal `dbt_<user>` in teams (auto-provisioned on first build) —
+   + defer to prod manifest).
 2. `app_set_preview_environment` with the personal environment — the app's
    DRAFT preview now reads the freshly built schema. This is per-user view
    state: other editors, the published app, and shared links keep reading

--- a/api/src/agent-skills/dbt/SKILL.md
+++ b/api/src/agent-skills/dbt/SKILL.md
@@ -144,7 +144,8 @@ AND its tests — always add at least `unique` + `not_null` on the primary key.
 
 - Projects have environments (dev/prod) mapping to a workspace connection +
   target schema. Ad-hoc agent builds default to the acting user's PERSONAL
-  environment when provisioned, else dev.
+  environment; `dbt_run_model` auto-provisions it on the first build (schema
+  `dbt_<user>`), so omit `environment` unless the user explicitly picks one.
 - **Which git tree a run builds (repo-bound projects)** — never mix these up:
   - Ad-hoc tools (`dbt_parse`, `dbt_compile_model`, `dbt_show`,
     `dbt_run_model`) build YOUR working tree: your checkout branch + your
@@ -162,11 +163,13 @@ AND its tests — always add at least `unique` + `not_null` on the primary key.
   `seed`/`snapshot`). Deploys go through jobs or CI after the change is
   merged into the tracked branch. Read-only commands (parse/compile/show)
   still work against any environment.
-- **Personal environments**: `dbt_ensure_dev_environment` idempotently
-  provisions a per-user environment (schema `dbt_<user>`, same connection as
-  prod). Once it exists, `dbt_parse` / `dbt_compile_model` / `dbt_run_model` /
+- **Personal environments**: per-user environments (schema `dbt_<user>`, same
+  connection as prod). `dbt_run_model` auto-provisions the caller's on its
+  first build; `dbt_ensure_dev_environment` provisions it explicitly ahead of
+  time. Once it exists, `dbt_parse` / `dbt_compile_model` / `dbt_run_model` /
   `dbt_show` default to it — iteration never touches shared dev/prod schemas.
-  Provision it before building models when the user wants safe iteration.
+  When verifying feature-branch work, build it into the personal environment
+  (the default) rather than shared dev; prod stays a jobs-only deploy target.
 - **Defer (fast iteration)**: ad-hoc builds default to
   `--defer --state <last prod manifest>` when targeting a non-prod environment
   and a prod build exists — unselected `ref()`s resolve to prod relations, so
@@ -190,17 +193,17 @@ draft preview can be switched.
 
 The full safe-iteration loop:
 
-1. `dbt_ensure_dev_environment` — get a personal schema (e.g. `dbt_jonas`).
-2. Edit models; verify with `dbt_parse` → `dbt_compile_model` →
-   `dbt_run_model` (defaults: personal env + defer to prod manifest).
-3. `app_set_preview_environment` with the personal environment — the app's
+1. Edit models; verify with `dbt_parse` → `dbt_compile_model` →
+   `dbt_run_model` (defaults: personal env — auto-provisioned on first
+   build, e.g. `dbt_jonas` — + defer to prod manifest).
+2. `app_set_preview_environment` with the personal environment — the app's
    DRAFT preview now reads the freshly built schema. This is per-user view
    state: other editors, the published app, and shared links keep reading
    prod. Verify visually (screenshot) if useful.
-4. Promote the dbt change: `dbt_commit_to_branch` → `dbt_open_pull_request` →
+3. Promote the dbt change: `dbt_commit_to_branch` → `dbt_open_pull_request` →
    (after review) `dbt_merge_pull_request`; then run the prod job via
    `dbt_run_job` — ONLY with explicit user confirmation.
-5. After the prod build succeeds, reset the preview
+4. After the prod build succeeds, reset the preview
    (`app_set_preview_environment` with `environment: null`) and, if app code
    changed, publish with `app_save_version`.
 

--- a/api/src/agent-skills/dbt/SKILL.md
+++ b/api/src/agent-skills/dbt/SKILL.md
@@ -144,8 +144,24 @@ AND its tests — always add at least `unique` + `not_null` on the primary key.
 
 - Projects have environments (dev/prod) mapping to a workspace connection +
   target schema. Ad-hoc agent builds default to the acting user's PERSONAL
-  environment when provisioned, else dev. Never target prod unless the user
-  explicitly asks.
+  environment when provisioned, else dev.
+- **Which git tree a run builds (repo-bound projects)** — never mix these up:
+  - Ad-hoc tools (`dbt_parse`, `dbt_compile_model`, `dbt_show`,
+    `dbt_run_model`) build YOUR working tree: your checkout branch + your
+    uncommitted drafts. This is the ONLY way to verify uncommitted or
+    feature-branch work.
+  - Jobs (`dbt_run_job`, schedules) build the COMMITTED tracked branch only —
+    never your checkout or drafts. Triggering a job to test a draft silently
+    runs the OLD code; do not do it, and do not "fix" it by committing — the
+    job still builds the tracked branch, not your feature branch.
+  - **Full refresh of a draft**: pass `fullRefresh: true` to `dbt_run_model`
+    (adds `--full-refresh`). Never reach for a full-refresh job to rebuild an
+    incremental model you just edited.
+- **Prod is protected from ad-hoc runs**: on repo-connected projects the
+  prod-like environment refuses ad-hoc warehouse writes (`run`/`build`/
+  `seed`/`snapshot`). Deploys go through jobs or CI after the change is
+  merged into the tracked branch. Read-only commands (parse/compile/show)
+  still work against any environment.
 - **Personal environments**: `dbt_ensure_dev_environment` idempotently
   provisions a per-user environment (schema `dbt_<user>`, same connection as
   prod). Once it exists, `dbt_parse` / `dbt_compile_model` / `dbt_run_model` /
@@ -161,7 +177,8 @@ AND its tests — always add at least `unique` + `not_null` on the primary key.
 - Jobs are saved command lists (`build`, `test`, `seed`, `snapshot`,
   `source freshness`, `docs generate` + `--select/--exclude/--full-refresh`
   flags) with optional cron schedules. Trigger via `dbt_run_job` only after
-  explicit user confirmation.
+  explicit user confirmation, and only for committed work — never to verify
+  drafts.
 
 ## Iterating on models that feed apps (dev → prod loop)
 

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -164,9 +164,10 @@ The verification loop is mandatory after edits:
 3. \`dbt_run_model\` — build the model + its tests and report row counts and test
    results to the user
 
-Ad-hoc builds default to the acting user's PERSONAL environment when one exists
-(provision with \`dbt_ensure_dev_environment\`), else the project default — and
-default to \`--defer\` against the last prod manifest when targeting a non-prod
+Ad-hoc builds default to the acting user's PERSONAL environment —
+\`dbt_run_model\` auto-provisions it on the first build (schema \`dbt_<user>\`),
+so omit \`environment\` unless the user explicitly picks one — and default to
+\`--defer\` against the last prod manifest when targeting a non-prod
 environment, so one model can be rebuilt without its whole upstream DAG. Load
 the \`dbt\` system skill for the full dev → app preview → prod promotion loop.
 

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -177,6 +177,16 @@ use graph operators and methods like \`+stg_orders\` (upstream), \`stg_orders+\`
 Use \`dbt_show\` to preview the rows a model would return (bounded SELECT, no writes) when you
 want to validate output, not just that it compiles.
 
+Which git tree a run builds (repo-bound projects) — never mix these up:
+- Ad-hoc tools (\`dbt_parse\` / \`dbt_compile_model\` / \`dbt_show\` / \`dbt_run_model\`) build YOUR
+  working tree: your checkout branch plus your uncommitted drafts. This is the only way to
+  verify uncommitted or feature-branch work; \`dbt_run_model\` supports \`fullRefresh: true\` for
+  incremental rebuilds, so never fall back to a job for that.
+- Jobs (\`dbt_run_job\`, schedules) build the COMMITTED tracked branch only — they never see your
+  checkout or drafts. Running a job to test a draft silently executes the old code.
+- The prod-like environment refuses ad-hoc warehouse writes: deploys go through jobs (or CI)
+  after the change is merged into the tracked branch.
+
 Jobs: create or edit saved jobs with \`dbt_create_job\` / \`dbt_update_job\` (add a cron schedule
 only when the user asks for a recurring run), and remove one with \`dbt_delete_job\` — only delete
 a job when the user explicitly asks. Trigger a saved job with \`dbt_run_job\` — never run

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -164,9 +164,16 @@ The verification loop is mandatory after edits:
 3. \`dbt_run_model\` — build the model + its tests and report row counts and test
    results to the user
 
-Ad-hoc builds default to the acting user's PERSONAL environment —
-\`dbt_run_model\` auto-provisions it on the first build (schema \`dbt_<user>\`),
-so omit \`environment\` unless the user explicitly picks one — and default to
+Ad-hoc builds resolve their environment per USER: the user's saved dev
+environment (a per-user setting the UI env pickers persist) > their personal
+environment > the project default. The working model — keep it clear:
+- SINGLE-USER workspace: the shared dev environment IS the user's personal
+  target; drafts and branch verification build against dev. Do NOT provision
+  \`dbt_<user>\` schemas unless asked.
+- MULTI-USER workspace: each user tests against their OWN environment;
+  \`dbt_run_model\` auto-provisions a personal one (schema \`dbt_<user>\`) on the
+  first build so teammates never build over each other.
+Omit \`environment\` unless the user explicitly picks one. Builds default to
 \`--defer\` against the last prod manifest when targeting a non-prod
 environment, so one model can be rebuilt without its whole upstream DAG. Load
 the \`dbt\` system skill for the full dev → app preview → prod promotion loop.

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -4263,6 +4263,15 @@ export interface IDbtProject extends Document {
   environments: IDbtEnvironment[];
   defaultEnvironment: string;
   /**
+   * Explicit PRODUCTION environment (the defer target). Drives which
+   * environment's successful runs update `lastProdManifestKey` (what ad-hoc
+   * `--defer` resolves against), what `{{ dbt_schema }}` resolves to for
+   * published apps, and which environment refuses ad-hoc warehouse writes.
+   * Unset → convention: the environment literally named "prod" when one
+   * exists, else the project default.
+   */
+  prodEnvironment?: string;
+  /**
    * Artifact-store key of the last successful prod manifest.json. This is
    * the state artifact for --defer / state:modified+ (Slim CI, later phase).
    */
@@ -4335,6 +4344,7 @@ const DbtProjectSchema = new Schema<IDbtProject>(
     dbtVersion: { type: String, default: "1.9" },
     environments: { type: [DbtEnvironmentSchema], default: [] },
     defaultEnvironment: { type: String, default: "dev" },
+    prodEnvironment: { type: String },
     lastProdManifestKey: { type: String },
     repo: { type: DbtRepoBindingSchema },
     protectedBranches: { type: [String], default: undefined },

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -4521,6 +4521,56 @@ const DbtCheckoutSchema = new Schema<IDbtCheckout>(
 DbtCheckoutSchema.index({ projectId: 1, userId: 1 }, { unique: true });
 DbtCheckoutSchema.index({ projectId: 1, branch: 1 });
 
+/**
+ * Per-user DEVELOPMENT environment choice for a dbt project — which
+ * environment this user's ad-hoc work (editor runs, agent builds, previews)
+ * targets by default.
+ *
+ * The working model this encodes:
+ *  - Single player: the shared dev environment IS your personal target —
+ *    drafts and branch verification build against dev. No row needed.
+ *  - Multiple players: each user points at their own personal environment
+ *    (schema `dbt_<user>`), so nobody stomps a teammate's schema.
+ *
+ * Absent row → resolution falls back to the user's personal environment when
+ * one exists, else the project default. Explicit requests always win.
+ */
+export interface IDbtEnvPreference extends Document {
+  _id: Types.ObjectId;
+  workspaceId: Types.ObjectId;
+  projectId: Types.ObjectId;
+  userId: string;
+  /** Environment name from the project's environments list. */
+  environment: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const DbtEnvPreferenceSchema = new Schema<IDbtEnvPreference>(
+  {
+    workspaceId: {
+      type: Schema.Types.ObjectId,
+      ref: "Workspace",
+      required: true,
+    },
+    projectId: {
+      type: Schema.Types.ObjectId,
+      ref: "DbtProject",
+      required: true,
+    },
+    userId: { type: String, required: true },
+    environment: { type: String, required: true, trim: true },
+  },
+  { collection: "dbt_env_preferences", timestamps: true },
+);
+
+DbtEnvPreferenceSchema.index({ projectId: 1, userId: 1 }, { unique: true });
+
+export const DbtEnvPreference = mongoose.model<IDbtEnvPreference>(
+  "DbtEnvPreference",
+  DbtEnvPreferenceSchema,
+);
+
 export const DbtCheckout = mongoose.model<IDbtCheckout>(
   "DbtCheckout",
   DbtCheckoutSchema,

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -4690,6 +4690,14 @@ export interface IDbtRun extends Document {
    */
   workingTreeUserId?: string;
   /**
+   * DISPLAY-ONLY: the git branch this run's source tree came from, stamped
+   * at trigger time so the Runs UI can say what was built without re-deriving
+   * it. Working-tree runs record the caller's checkout branch; job/deploy
+   * runs record the tracked branch; CI runs record the PR head. The executor
+   * never reads this — `gitBranch` / `workingTreeUserId` stay authoritative.
+   */
+  sourceBranch?: string;
+  /**
    * Ad-hoc/agent runs only: run with `--defer --state <prod manifest>` so
    * unselected refs resolve to the last production build instead of
    * rebuilding the whole upstream DAG in the target schema. Job runs read
@@ -4772,6 +4780,7 @@ const DbtRunSchema = new Schema<IDbtRun>(
     triggeredBy: { type: String, required: true },
     gitBranch: { type: String },
     workingTreeUserId: { type: String },
+    sourceBranch: { type: String },
     deferToProduction: { type: Boolean },
     ci: {
       type: new Schema(

--- a/api/src/dbt/commands.test.ts
+++ b/api/src/dbt/commands.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   DbtCommandValidationError,
+  isWarehouseWriteCommand,
   parseDbtCommand,
   parseDbtCommands,
 } from "./commands";
@@ -93,5 +94,43 @@ describe("parseDbtCommand", () => {
   it("rejects empty commands", () => {
     expect(() => parseDbtCommand("")).toThrow(DbtCommandValidationError);
     expect(() => parseDbtCommands([])).toThrow(DbtCommandValidationError);
+  });
+});
+
+describe("isWarehouseWriteCommand", () => {
+  it("classifies run/build/seed/snapshot/retry as warehouse writes", () => {
+    for (const command of [
+      "run --select stg_orders",
+      "build --select stg_orders+ --full-refresh",
+      "seed",
+      "snapshot",
+      "retry",
+    ]) {
+      expect(isWarehouseWriteCommand(parseDbtCommand(command))).toBe(true);
+    }
+  });
+
+  it("classifies parse/compile/show/docs/deps/source freshness as read-only", () => {
+    for (const command of [
+      "parse",
+      "compile --select stg_orders",
+      "show --select stg_orders --limit 5",
+      "docs generate",
+      "deps",
+      "source freshness",
+    ]) {
+      expect(isWarehouseWriteCommand(parseDbtCommand(command))).toBe(false);
+    }
+  });
+
+  it("treats test as read-only unless --store-failures persists tables", () => {
+    expect(
+      isWarehouseWriteCommand(parseDbtCommand("test --select stg_orders")),
+    ).toBe(false);
+    expect(
+      isWarehouseWriteCommand(
+        parseDbtCommand("test --select stg_orders --store-failures"),
+      ),
+    ).toBe(true);
   });
 });

--- a/api/src/dbt/commands.ts
+++ b/api/src/dbt/commands.ts
@@ -52,6 +52,27 @@ export interface ParsedDbtCommand {
   subcommand: string;
 }
 
+/**
+ * Subcommands that write into the warehouse target schema. `test` is
+ * read-only unless `--store-failures` persists audit tables; `retry` resumes
+ * whatever (possibly writing) command originally failed.
+ */
+const WAREHOUSE_WRITE_SUBCOMMANDS = new Set([
+  "run",
+  "build",
+  "seed",
+  "snapshot",
+  "retry",
+]);
+
+/** Whether a validated command writes to the warehouse target schema. */
+export function isWarehouseWriteCommand(parsed: ParsedDbtCommand): boolean {
+  if (WAREHOUSE_WRITE_SUBCOMMANDS.has(parsed.subcommand)) return true;
+  return (
+    parsed.subcommand === "test" && parsed.argv.includes("--store-failures")
+  );
+}
+
 export class DbtCommandValidationError extends Error {}
 
 function tokenize(command: string): string[] {

--- a/api/src/dbt/dbt-environments.service.test.ts
+++ b/api/src/dbt/dbt-environments.service.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it } from "vitest";
 import { Types } from "mongoose";
 import { containsDbtSchemaToken, resolveDbtSchemaToken } from "@mako/schemas";
 import {
+  DbtProtectedEnvironmentError,
+  assertAdhocDbtRunAllowed,
   findPersonalEnvironment,
   resolveEnvironmentNameForUser,
   resolveProdLikeEnvironmentName,
   sanitizePersonalSlug,
 } from "./dbt-environments.service";
+import { parseDbtCommand } from "./commands";
 
 function env(name: string, ownerUserId?: string) {
   return {
@@ -82,6 +85,83 @@ describe("sanitizePersonalSlug", () => {
 
   it("falls back to 'user' when nothing survives", () => {
     expect(sanitizePersonalSlug("@@@")).toBe("user");
+  });
+});
+
+describe("assertAdhocDbtRunAllowed", () => {
+  const repoProject = {
+    environments: [env("dev"), env("prod")],
+    defaultEnvironment: "dev",
+    repo: { branch: "main" },
+  };
+  const commands = (...cmds: string[]) => cmds.map(parseDbtCommand);
+
+  it("refuses warehouse writes into the prod-like environment", () => {
+    for (const cmd of [
+      "build --select stg_orders",
+      "run --select stg_orders",
+      "seed",
+      "snapshot",
+      "test --select stg_orders --store-failures",
+    ]) {
+      expect(() =>
+        assertAdhocDbtRunAllowed(repoProject, "prod", commands(cmd)),
+      ).toThrow(DbtProtectedEnvironmentError);
+    }
+  });
+
+  it("names the protected environment and tracked branch in the error", () => {
+    expect(() =>
+      assertAdhocDbtRunAllowed(
+        repoProject,
+        "prod",
+        commands("build --select stg_orders --full-refresh"),
+      ),
+    ).toThrow(/"prod".*"main"/s);
+  });
+
+  it("allows warehouse writes into non-prod environments", () => {
+    expect(() =>
+      assertAdhocDbtRunAllowed(
+        repoProject,
+        "dev",
+        commands("build --select stg_orders --full-refresh"),
+      ),
+    ).not.toThrow();
+  });
+
+  it("allows read-only commands against the prod-like environment", () => {
+    expect(() =>
+      assertAdhocDbtRunAllowed(
+        repoProject,
+        "prod",
+        commands("parse", "compile --select stg_orders", "docs generate"),
+      ),
+    ).not.toThrow();
+  });
+
+  it("uses the project default as prod-like when no 'prod' env exists", () => {
+    const project = {
+      environments: [env("main_env"), env("staging")],
+      defaultEnvironment: "main_env",
+      repo: { branch: "main" },
+    };
+    expect(() =>
+      assertAdhocDbtRunAllowed(project, "main_env", commands("build")),
+    ).toThrow(DbtProtectedEnvironmentError);
+    expect(() =>
+      assertAdhocDbtRunAllowed(project, "staging", commands("build")),
+    ).not.toThrow();
+  });
+
+  it("exempts projects without a repo binding (no committed tree to bypass)", () => {
+    const blankProject = {
+      environments: [env("dev"), env("prod")],
+      defaultEnvironment: "dev",
+    };
+    expect(() =>
+      assertAdhocDbtRunAllowed(blankProject, "prod", commands("build")),
+    ).not.toThrow();
   });
 });
 

--- a/api/src/dbt/dbt-environments.service.test.ts
+++ b/api/src/dbt/dbt-environments.service.test.ts
@@ -39,6 +39,26 @@ describe("resolveProdLikeEnvironmentName", () => {
       }),
     ).toBe("main");
   });
+
+  it("an explicit prodEnvironment setting beats the convention", () => {
+    expect(
+      resolveProdLikeEnvironmentName({
+        environments: [env("dev"), env("prod"), env("release")],
+        defaultEnvironment: "dev",
+        prodEnvironment: "release",
+      }),
+    ).toBe("release");
+  });
+
+  it("ignores a stale prodEnvironment pointing at a removed env", () => {
+    expect(
+      resolveProdLikeEnvironmentName({
+        environments: [env("dev"), env("prod")],
+        defaultEnvironment: "dev",
+        prodEnvironment: "release",
+      }),
+    ).toBe("prod");
+  });
 });
 
 describe("findPersonalEnvironment / resolveEnvironmentNameForUser", () => {
@@ -161,6 +181,22 @@ describe("assertAdhocDbtRunAllowed", () => {
     };
     expect(() =>
       assertAdhocDbtRunAllowed(blankProject, "prod", commands("build")),
+    ).not.toThrow();
+  });
+
+  it("follows an explicit prodEnvironment setting", () => {
+    const project = {
+      environments: [env("dev"), env("prod"), env("release")],
+      defaultEnvironment: "dev",
+      prodEnvironment: "release",
+      repo: { branch: "main" },
+    };
+    expect(() =>
+      assertAdhocDbtRunAllowed(project, "release", commands("build")),
+    ).toThrow(DbtProtectedEnvironmentError);
+    // The env named "prod" is no longer the protected target.
+    expect(() =>
+      assertAdhocDbtRunAllowed(project, "prod", commands("build")),
     ).not.toThrow();
   });
 });

--- a/api/src/dbt/dbt-environments.service.ts
+++ b/api/src/dbt/dbt-environments.service.ts
@@ -27,6 +27,10 @@ import {
   type IDbtProject,
 } from "../database/workspace-schema";
 import { getUserDisplayName } from "../services/entity-version.service";
+import {
+  isWarehouseWriteCommand,
+  type ParsedDbtCommand,
+} from "./commands";
 
 type ProjectEnvFields = Pick<
   IDbtProject,
@@ -44,6 +48,48 @@ export function resolveProdLikeEnvironmentName(
   return project.environments.some(env => env.name === "prod")
     ? "prod"
     : project.defaultEnvironment;
+}
+
+/**
+ * Thrown when an ad-hoc run would write into the protected (prod-like)
+ * environment. Mapped to HTTP 400 by the dbt routes.
+ */
+export class DbtProtectedEnvironmentError extends Error {
+  constructor(environmentName: string, trackedBranch?: string) {
+    super(
+      `Ad-hoc dbt runs build your working tree (checkout branch + ` +
+        `uncommitted drafts) and are not allowed to write to the protected ` +
+        `"${environmentName}" environment. Deploys to "${environmentName}" ` +
+        `must go through a saved job or CI, which build the committed` +
+        `${trackedBranch ? ` "${trackedBranch}"` : ""} branch — merge your ` +
+        `changes first, then trigger the job.`,
+    );
+    this.name = "DbtProtectedEnvironmentError";
+  }
+}
+
+/**
+ * Guard for ad-hoc (working-tree) runs on repo-connected projects: they build
+ * the CALLER's checkout + uncommitted drafts, so letting one write into the
+ * prod-like environment would deploy unreviewed code and bypass the
+ * protected-branch → PR → job pipeline. Jobs and CI are the only paths that
+ * build the prod-like environment (they always build a committed tree).
+ *
+ * Read-only commands (parse / compile / show / test without
+ * --store-failures) stay allowed against any environment, and projects
+ * without a repo binding are exempt (jobs and ad-hoc runs there build the
+ * same shared tree, so there is nothing to bypass).
+ */
+export function assertAdhocDbtRunAllowed(
+  project: ProjectEnvFields & { repo?: { branch?: string } | null },
+  environmentName: string,
+  commands: ParsedDbtCommand[],
+): void {
+  if (!project.repo) return;
+  if (!commands.some(isWarehouseWriteCommand)) return;
+  const prodLike = resolveProdLikeEnvironmentName(project);
+  if (environmentName !== prodLike) return;
+  throw new DbtProtectedEnvironmentError(prodLike, project.repo.branch);
 }
 
 /** The acting user's personal environment on this project, if provisioned. */

--- a/api/src/dbt/dbt-environments.service.ts
+++ b/api/src/dbt/dbt-environments.service.ts
@@ -35,16 +35,27 @@ import {
 type ProjectEnvFields = Pick<
   IDbtProject,
   "environments" | "defaultEnvironment"
->;
+> & { prodEnvironment?: string };
 
 /**
- * The environment treated as "production" for defer state and app-binding
- * schema resolution: `prod` when it exists, else the project default. Mirrors
- * the executor's `lastProdManifestKey` promotion rule (dbt-run.ts).
+ * The environment treated as "production": the defer-state source
+ * (`lastProdManifestKey` promotion), the `{{ dbt_schema }}` target for
+ * app bindings, and the environment protected from ad-hoc warehouse writes.
+ *
+ * An explicit `project.prodEnvironment` wins (set in project settings, shown
+ * in the UI); a stale value pointing at a removed environment is ignored.
+ * Convention fallback: the environment literally named "prod" when one
+ * exists, else the project default.
  */
 export function resolveProdLikeEnvironmentName(
   project: ProjectEnvFields,
 ): string {
+  if (
+    project.prodEnvironment &&
+    project.environments.some(env => env.name === project.prodEnvironment)
+  ) {
+    return project.prodEnvironment;
+  }
   return project.environments.some(env => env.name === "prod")
     ? "prod"
     : project.defaultEnvironment;
@@ -218,7 +229,7 @@ export async function resolveDbtSchemaForBinding(params: {
     _id: new Types.ObjectId(params.dbtProjectId),
     workspaceId: new Types.ObjectId(params.workspaceId.toString()),
   })
-    .select("environments defaultEnvironment")
+    .select("environments defaultEnvironment prodEnvironment")
     .lean();
   if (!project) return null;
 

--- a/api/src/dbt/dbt-environments.service.ts
+++ b/api/src/dbt/dbt-environments.service.ts
@@ -22,6 +22,7 @@
 import { Types } from "mongoose";
 import { containsDbtSchemaToken, resolveDbtSchemaToken } from "@mako/schemas";
 import {
+  DbtEnvPreference,
   DbtProject,
   type IDbtEnvironment,
   type IDbtProject,
@@ -116,6 +117,10 @@ export function findPersonalEnvironment(
  * Environment an agent/user action targets when none is given explicitly:
  * the caller's personal environment when provisioned, else the project
  * default. Explicit names always win (validated downstream).
+ *
+ * Pure fallback used when the per-user preference is unavailable — most
+ * callers should use {@link resolveDevEnvironmentForUser}, which also
+ * consults the persisted per-user choice.
  */
 export function resolveEnvironmentNameForUser(
   project: ProjectEnvFields,
@@ -127,6 +132,76 @@ export function resolveEnvironmentNameForUser(
     findPersonalEnvironment(project, userId)?.name ??
     project.defaultEnvironment
   );
+}
+
+type ProjectIdEnvFields = ProjectEnvFields & Pick<IDbtProject, "_id">;
+
+/**
+ * The user's saved DEVELOPMENT environment for a project, or undefined when
+ * unset / stale (env no longer exists).
+ */
+export async function getUserDevEnvPreference(
+  project: ProjectIdEnvFields,
+  userId: string | undefined,
+): Promise<string | undefined> {
+  if (!userId) return undefined;
+  const pref = await DbtEnvPreference.findOne({
+    projectId: project._id,
+    userId,
+  })
+    .select("environment")
+    .lean();
+  if (!pref) return undefined;
+  return project.environments.some(env => env.name === pref.environment)
+    ? pref.environment
+    : undefined;
+}
+
+/** Persist (or clear, with null) the user's dev environment for a project. */
+export async function setUserDevEnvPreference(params: {
+  workspaceId: Types.ObjectId | string;
+  projectId: Types.ObjectId | string;
+  userId: string;
+  environment: string | null;
+}): Promise<void> {
+  const projectId = new Types.ObjectId(params.projectId.toString());
+  if (params.environment === null) {
+    await DbtEnvPreference.deleteOne({ projectId, userId: params.userId });
+    return;
+  }
+  await DbtEnvPreference.updateOne(
+    { projectId, userId: params.userId },
+    {
+      $set: {
+        workspaceId: new Types.ObjectId(params.workspaceId.toString()),
+        environment: params.environment,
+      },
+    },
+    { upsert: true },
+  );
+}
+
+/**
+ * THE per-user development-environment resolution — the environment a user's
+ * ad-hoc work (editor runs, agent builds, previews) targets when none is
+ * requested explicitly:
+ *
+ *   explicit request > the user's saved per-user choice > their personal
+ *   environment (when provisioned) > the project default.
+ *
+ * Single player: no choice + no personal env → the shared dev default (dev IS
+ * their personal target). Multiple players: each user's choice / personal
+ * env keeps their work out of teammates' schemas.
+ */
+export async function resolveDevEnvironmentForUser(
+  project: ProjectIdEnvFields,
+  userId: string | undefined,
+  requested?: string,
+): Promise<string> {
+  if (requested) return requested;
+  const preferred = await getUserDevEnvPreference(project, userId);
+  if (preferred) return preferred;
+  return resolveEnvironmentNameForUser(project, userId);
 }
 
 /**

--- a/api/src/dbt/dbt-project.service.ts
+++ b/api/src/dbt/dbt-project.service.ts
@@ -1,7 +1,7 @@
 /**
  * dbt project snapshot loading + ad-hoc execution helpers.
  *
- * Shared by the routes (compile / run-select endpoints), the Inngest
+ * Shared by the routes (compile / command endpoints), the Inngest
  * executor, and the agent's server-side verification tools so they all go
  * through identical validation: workspace scoping, environment resolution,
  * connection decryption, and command allowlisting.

--- a/api/src/dbt/dbt-project.service.ts
+++ b/api/src/dbt/dbt-project.service.ts
@@ -17,6 +17,7 @@ import {
 } from "../database/workspace-schema";
 import { loadRunnableWorkingTree } from "./dbt-github-sync.service";
 import { renderDbtProfile, type RenderedProfile } from "./adapter-map";
+import { assertAdhocDbtRunAllowed } from "./dbt-environments.service";
 import { parseDbtCommand, type ParsedDbtCommand } from "./commands";
 import {
   materializeDbtProject,
@@ -198,6 +199,13 @@ export async function runAdhocDbtCommand(params: {
     environmentName: params.environmentName,
     userId: params.userId,
   });
+
+  // Ad-hoc commands build the caller's working tree (checkout + drafts);
+  // refuse warehouse writes into the protected prod-like environment —
+  // deploys there go through jobs/CI, which build a committed tree.
+  assertAdhocDbtRunAllowed(snapshot.project, snapshot.environment.name, [
+    parsed,
+  ]);
 
   // Warm caches so parse/compile/show/build don't re-parse the whole project
   // (and skip `dbt deps` when packages are unchanged). Best-effort. The

--- a/api/src/dbt/dbt-run-guard.integration.test.ts
+++ b/api/src/dbt/dbt-run-guard.integration.test.ts
@@ -245,7 +245,11 @@ describe("recordCompletedAdhocDbtRun", () => {
       result: {
         success: true,
         exitCode: 0,
-        logs: [{ ts: new Date(), level: "info", line: "Done. PASS=1" }],
+        logs: [
+          { ts: new Date(), level: "info", line: "Done. PASS=1" },
+          // dbt emits blank spacer lines — must not fail `create` validation.
+          { ts: new Date(), level: "info", line: "" },
+        ],
         stepResults: [
           {
             uniqueId: "model.p.stg_orders",
@@ -266,7 +270,7 @@ describe("recordCompletedAdhocDbtRun", () => {
     expect(doc?.sourceBranch).toBe("main");
     expect(doc?.workingTreeUserId).toBe("u1");
     expect(doc?.durationMs).toBeGreaterThanOrEqual(1500);
-    expect(doc?.logs).toHaveLength(1);
+    expect(doc?.logs).toHaveLength(2);
     expect(doc?.stepResults?.[0]?.name).toBe("stg_orders");
     expect(doc?.completedAt).toBeDefined();
   });

--- a/api/src/dbt/dbt-run-guard.integration.test.ts
+++ b/api/src/dbt/dbt-run-guard.integration.test.ts
@@ -27,9 +27,19 @@ vi.mock("../inngest/client", () => ({
 }));
 
 import { inngest } from "../inngest/client";
-import { triggerDbtRun, triggerDbtJobRun } from "./dbt-run.service";
+import {
+  recordCompletedAdhocDbtRun,
+  triggerDbtRun,
+  triggerDbtJobRun,
+} from "./dbt-run.service";
 import { DbtProtectedEnvironmentError } from "./dbt-environments.service";
-import { DbtJob, DbtProject, DbtRun } from "../database/workspace-schema";
+import { setCheckoutBranch } from "./dbt-working-tree.service";
+import {
+  DbtCheckout,
+  DbtJob,
+  DbtProject,
+  DbtRun,
+} from "../database/workspace-schema";
 
 const sendMock = inngest.send as unknown as ReturnType<typeof vi.fn>;
 
@@ -52,6 +62,7 @@ beforeEach(async () => {
     DbtProject.deleteMany({}),
     DbtRun.deleteMany({}),
     DbtJob.deleteMany({}),
+    DbtCheckout.deleteMany({}),
   ]);
 });
 
@@ -154,5 +165,124 @@ describe("triggerDbtRun protected-environment guard", () => {
       workingTreeUserId: undefined,
     });
     expect(run.status).toBe("queued");
+  });
+});
+
+describe("sourceBranch provenance stamping", () => {
+  it("working-tree runs record the caller's checkout branch", async () => {
+    const project = await seedProject();
+    // Implicit checkout (no row) → tracked branch.
+    const tracked = await triggerDbtRun(
+      adhocParams(project._id.toString(), "dev"),
+    );
+    expect(tracked.sourceBranch).toBe("main");
+    expect(tracked.workingTreeUserId).toBe("u1");
+
+    // Explicit checkout → that branch.
+    await setCheckoutBranch(project, "u1", "feat/leads-rollup");
+    const feature = await triggerDbtRun(
+      adhocParams(project._id.toString(), "dev"),
+    );
+    expect(feature.sourceBranch).toBe("feat/leads-rollup");
+  });
+
+  it("job runs record the committed tracked branch (no working tree)", async () => {
+    const project = await seedProject();
+    const job = await DbtJob.create({
+      workspaceId: WS,
+      projectId: project._id,
+      name: "Nightly",
+      environment: "prod",
+      commands: ["build"],
+      enabled: true,
+      createdBy: "u1",
+    });
+    const run = await triggerDbtJobRun({
+      workspaceId: WS.toString(),
+      job,
+      trigger: "manual",
+      triggeredBy: "u1",
+    });
+    expect(run.sourceBranch).toBe("main");
+    expect(run.workingTreeUserId).toBeUndefined();
+  });
+
+  it("explicit gitBranch (CI) wins and repo-less projects stay unstamped", async () => {
+    const repoProject = await seedProject();
+    const ci = await triggerDbtRun({
+      workspaceId: WS.toString(),
+      projectId: repoProject._id.toString(),
+      environment: "dev",
+      commands: ["build"],
+      trigger: "ci",
+      triggeredBy: "ci-webhook",
+      gitBranch: "pr-head-branch",
+    });
+    expect(ci.sourceBranch).toBe("pr-head-branch");
+
+    const blank = await seedProject({ repo: false });
+    const run = await triggerDbtRun({
+      ...adhocParams(blank._id.toString(), "dev"),
+      workingTreeUserId: undefined,
+    });
+    expect(run.sourceBranch).toBeUndefined();
+  });
+});
+
+describe("recordCompletedAdhocDbtRun", () => {
+  it("persists a terminal run doc with logs, steps, and provenance", async () => {
+    const project = await seedProject();
+    const startedAt = new Date(Date.now() - 1500);
+    const recorded = await recordCompletedAdhocDbtRun({
+      workspaceId: WS.toString(),
+      projectId: project._id.toString(),
+      environment: "dev",
+      command: "build --select stg_orders --full-refresh",
+      triggeredBy: "u1",
+      workingTreeUserId: "u1",
+      sourceBranch: "main",
+      startedAt,
+      result: {
+        success: true,
+        exitCode: 0,
+        logs: [{ ts: new Date(), level: "info", line: "Done. PASS=1" }],
+        stepResults: [
+          {
+            uniqueId: "model.p.stg_orders",
+            name: "stg_orders",
+            resourceType: "model",
+            status: "success",
+            executionTimeMs: 42,
+          },
+        ],
+      },
+    });
+
+    expect(recorded).not.toBeNull();
+    const doc = await DbtRun.findById(recorded?._id).lean();
+    expect(doc?.status).toBe("success");
+    expect(doc?.trigger).toBe("manual");
+    expect(doc?.commands).toEqual(["build --select stg_orders --full-refresh"]);
+    expect(doc?.sourceBranch).toBe("main");
+    expect(doc?.workingTreeUserId).toBe("u1");
+    expect(doc?.durationMs).toBeGreaterThanOrEqual(1500);
+    expect(doc?.logs).toHaveLength(1);
+    expect(doc?.stepResults?.[0]?.name).toBe("stg_orders");
+    expect(doc?.completedAt).toBeDefined();
+  });
+
+  it("marks failed commands as error with the exit code", async () => {
+    const project = await seedProject();
+    const recorded = await recordCompletedAdhocDbtRun({
+      workspaceId: WS.toString(),
+      projectId: project._id.toString(),
+      environment: "dev",
+      command: "build",
+      triggeredBy: "u1",
+      startedAt: new Date(),
+      result: { success: false, exitCode: 2, logs: [], stepResults: [] },
+    });
+    expect(recorded?.status).toBe("error");
+    expect(recorded?.error).toMatch(/exited with code 2/);
   });
 });

--- a/api/src/dbt/dbt-run-guard.integration.test.ts
+++ b/api/src/dbt/dbt-run-guard.integration.test.ts
@@ -32,10 +32,15 @@ import {
   triggerDbtRun,
   triggerDbtJobRun,
 } from "./dbt-run.service";
-import { DbtProtectedEnvironmentError } from "./dbt-environments.service";
+import {
+  DbtProtectedEnvironmentError,
+  resolveDevEnvironmentForUser,
+  setUserDevEnvPreference,
+} from "./dbt-environments.service";
 import { setCheckoutBranch } from "./dbt-working-tree.service";
 import {
   DbtCheckout,
+  DbtEnvPreference,
   DbtJob,
   DbtProject,
   DbtRun,
@@ -63,6 +68,7 @@ beforeEach(async () => {
     DbtRun.deleteMany({}),
     DbtJob.deleteMany({}),
     DbtCheckout.deleteMany({}),
+    DbtEnvPreference.deleteMany({}),
   ]);
 });
 
@@ -226,6 +232,73 @@ describe("sourceBranch provenance stamping", () => {
       workingTreeUserId: undefined,
     });
     expect(run.sourceBranch).toBeUndefined();
+  });
+});
+
+describe("resolveDevEnvironmentForUser — per-user dev environment", () => {
+  it("resolves explicit > saved choice > personal env > project default", async () => {
+    const project = await seedProject();
+
+    // No choice, no personal env → the project default (single-player: dev
+    // IS the personal target).
+    expect(await resolveDevEnvironmentForUser(project, "u1")).toBe("dev");
+
+    // Personal env provisioned → it wins over the default.
+    project.environments.push({
+      name: "alice",
+      connectionId: new Types.ObjectId(),
+      targetSchema: "dbt_alice",
+      threads: 4,
+      ownerUserId: "u1",
+    });
+    await project.save();
+    expect(await resolveDevEnvironmentForUser(project, "u1")).toBe("alice");
+
+    // A saved per-user choice beats the personal env.
+    await setUserDevEnvPreference({
+      workspaceId: WS,
+      projectId: project._id,
+      userId: "u1",
+      environment: "dev",
+    });
+    expect(await resolveDevEnvironmentForUser(project, "u1")).toBe("dev");
+
+    // Explicit request always wins.
+    expect(await resolveDevEnvironmentForUser(project, "u1", "prod")).toBe(
+      "prod",
+    );
+
+    // Clearing the choice falls back to the personal env.
+    await setUserDevEnvPreference({
+      workspaceId: WS,
+      projectId: project._id,
+      userId: "u1",
+      environment: null,
+    });
+    expect(await resolveDevEnvironmentForUser(project, "u1")).toBe("alice");
+  });
+
+  it("ignores a stale saved choice pointing at a removed environment", async () => {
+    const project = await seedProject();
+    await DbtEnvPreference.create({
+      workspaceId: WS,
+      projectId: project._id,
+      userId: "u1",
+      environment: "gone",
+    });
+    expect(await resolveDevEnvironmentForUser(project, "u1")).toBe("dev");
+  });
+
+  it("is scoped per user", async () => {
+    const project = await seedProject();
+    await setUserDevEnvPreference({
+      workspaceId: WS,
+      projectId: project._id,
+      userId: "u1",
+      environment: "prod",
+    });
+    expect(await resolveDevEnvironmentForUser(project, "u1")).toBe("prod");
+    expect(await resolveDevEnvironmentForUser(project, "u2")).toBe("dev");
   });
 });
 

--- a/api/src/dbt/dbt-run-guard.integration.test.ts
+++ b/api/src/dbt/dbt-run-guard.integration.test.ts
@@ -1,0 +1,158 @@
+/**
+ * triggerDbtRun protected-environment guard — integration.
+ *
+ * Real service + real Mongoose models against mongodb-memory-server; only
+ * Inngest is mocked. Verifies the ad-hoc/job asymmetry end-to-end:
+ *
+ *  - ad-hoc (agent/manual, no jobId) warehouse writes into the prod-like
+ *    environment of a repo-connected project are refused BEFORE a run doc is
+ *    created or an event is sent (uncommitted drafts can never deploy prod);
+ *  - job runs, read-only ad-hoc commands, non-prod targets, and blank
+ *    (repo-less) projects keep working.
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import mongoose, { Types } from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+
+vi.mock("../inngest/client", () => ({
+  inngest: { send: vi.fn(async () => ({ ids: [] })) },
+}));
+
+import { inngest } from "../inngest/client";
+import { triggerDbtRun, triggerDbtJobRun } from "./dbt-run.service";
+import { DbtProtectedEnvironmentError } from "./dbt-environments.service";
+import { DbtJob, DbtProject, DbtRun } from "../database/workspace-schema";
+
+const sendMock = inngest.send as unknown as ReturnType<typeof vi.fn>;
+
+let mongo: MongoMemoryServer;
+const WS = new Types.ObjectId();
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  await Promise.all([
+    DbtProject.deleteMany({}),
+    DbtRun.deleteMany({}),
+    DbtJob.deleteMany({}),
+  ]);
+});
+
+function envs() {
+  return [
+    {
+      name: "dev",
+      connectionId: new Types.ObjectId(),
+      targetSchema: "dbt_dev",
+      threads: 4,
+    },
+    {
+      name: "prod",
+      connectionId: new Types.ObjectId(),
+      targetSchema: "dbt_prod",
+      threads: 4,
+    },
+  ];
+}
+
+async function seedProject(opts: { repo?: boolean } = {}) {
+  return DbtProject.create({
+    workspaceId: WS,
+    name: `p-${new Types.ObjectId().toString()}`,
+    environments: envs(),
+    defaultEnvironment: "dev",
+    createdBy: "u1",
+    ...(opts.repo === false
+      ? {}
+      : { repo: { owner: "acme", repo: "analytics", branch: "main" } }),
+  });
+}
+
+function adhocParams(projectId: string, environment: string) {
+  return {
+    workspaceId: WS.toString(),
+    projectId,
+    environment,
+    commands: ["build --select stg_orders --full-refresh"],
+    trigger: "agent" as const,
+    triggeredBy: "agent",
+    workingTreeUserId: "u1",
+  };
+}
+
+describe("triggerDbtRun protected-environment guard", () => {
+  it("refuses an ad-hoc warehouse write into prod on a repo project", async () => {
+    const project = await seedProject();
+    await expect(
+      triggerDbtRun(adhocParams(project._id.toString(), "prod")),
+    ).rejects.toThrow(DbtProtectedEnvironmentError);
+    // Nothing persisted, nothing enqueued.
+    expect(await DbtRun.countDocuments({})).toBe(0);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("allows the same ad-hoc build against a non-prod environment", async () => {
+    const project = await seedProject();
+    const run = await triggerDbtRun(adhocParams(project._id.toString(), "dev"));
+    expect(run.status).toBe("queued");
+    expect(run.commands).toEqual(["build --select stg_orders --full-refresh"]);
+    expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows read-only ad-hoc commands against prod", async () => {
+    const project = await seedProject();
+    const run = await triggerDbtRun({
+      ...adhocParams(project._id.toString(), "prod"),
+      commands: ["compile --select stg_orders"],
+    });
+    expect(run.status).toBe("queued");
+  });
+
+  it("allows prod runs through a saved job (the sanctioned deploy path)", async () => {
+    const project = await seedProject();
+    const job = await DbtJob.create({
+      workspaceId: WS,
+      projectId: project._id,
+      name: "Deploy prod",
+      environment: "prod",
+      commands: ["build --full-refresh"],
+      enabled: true,
+      createdBy: "u1",
+    });
+    const run = await triggerDbtJobRun({
+      workspaceId: WS.toString(),
+      job,
+      trigger: "manual",
+      triggeredBy: "u1",
+    });
+    expect(run.status).toBe("queued");
+    expect(run.jobId?.toString()).toBe(job._id.toString());
+    expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("exempts projects without a repo binding", async () => {
+    const project = await seedProject({ repo: false });
+    const run = await triggerDbtRun({
+      ...adhocParams(project._id.toString(), "prod"),
+      workingTreeUserId: undefined,
+    });
+    expect(run.status).toBe("queued");
+  });
+});

--- a/api/src/dbt/dbt-run.service.ts
+++ b/api/src/dbt/dbt-run.service.ts
@@ -16,8 +16,10 @@ import {
   type IDbtRun,
 } from "../database/workspace-schema";
 import { assertAdhocDbtRunAllowed } from "./dbt-environments.service";
+import { getCheckoutBranch } from "./dbt-working-tree.service";
 import { parseDbtCommands } from "./commands";
 import { cancelLocalRun } from "./dbt-run-registry";
+import type { AdhocDbtResult } from "./dbt-project.service";
 import { loggers } from "../logging";
 
 const TERMINAL_DBT_RUN_STATUSES: ReadonlySet<DbtRunStatus> = new Set([
@@ -214,23 +216,33 @@ export async function triggerDbtRun(params: {
   // Validate before persisting anything — bad commands never reach a run doc.
   const parsedCommands = parseDbtCommands(params.commands);
 
+  const project = await DbtProject.findOne({
+    _id: new Types.ObjectId(params.projectId),
+    workspaceId: new Types.ObjectId(params.workspaceId),
+  })
+    .select("environments defaultEnvironment repo")
+    .lean();
+
   // Ad-hoc (non-job, non-CI) runs on repo-connected projects build a
   // working tree — refuse warehouse writes into the protected prod-like
   // environment so uncommitted drafts can never deploy to prod. Jobs and CI
   // (which build committed trees) are the only paths allowed to write there.
   const isAdhocRun =
     !params.jobId && params.trigger !== "ci" && params.trigger !== "schedule";
-  if (isAdhocRun) {
-    const project = await DbtProject.findOne({
-      _id: new Types.ObjectId(params.projectId),
-      workspaceId: new Types.ObjectId(params.workspaceId),
-    })
-      .select("environments defaultEnvironment repo")
-      .lean();
-    if (project) {
-      assertAdhocDbtRunAllowed(project, params.environment, parsedCommands);
-    }
+  if (isAdhocRun && project) {
+    assertAdhocDbtRunAllowed(project, params.environment, parsedCommands);
   }
+
+  // Display-only provenance: which git branch this run's source tree comes
+  // from. Working-tree runs (workingTreeUserId) record that user's checkout;
+  // explicit-branch runs (CI) record it directly; everything else (jobs,
+  // deploys) builds the committed tracked branch.
+  const sourceBranch = !project?.repo
+    ? undefined
+    : (params.gitBranch ??
+      (params.workingTreeUserId
+        ? await getCheckoutBranch(project, params.workingTreeUserId)
+        : project.repo.branch));
 
   if (params.skipIfActive && params.jobId) {
     const active = await DbtRun.findOne({
@@ -251,6 +263,7 @@ export async function triggerDbtRun(params: {
     triggeredBy: params.triggeredBy,
     gitBranch: params.gitBranch,
     workingTreeUserId: params.workingTreeUserId,
+    sourceBranch,
     deferToProduction: params.deferToProduction,
     ci: params.ci,
   });
@@ -271,6 +284,69 @@ export async function triggerDbtRun(params: {
   }
 
   return run;
+}
+
+/** Log lines kept when persisting a completed sync ad-hoc run (mirrors the
+ * executor's MAX_LOG_LINES cap in inngest/functions/dbt-run.ts). */
+const ADHOC_RECORD_MAX_LOG_LINES = 5000;
+
+/**
+ * Persist a COMPLETED synchronous ad-hoc command (IDE Run button / command
+ * bar) into dbt_runs so editor runs share the same history, run detail, and
+ * provenance UI as agent/job runs. Written post-hoc with a terminal status —
+ * it never goes through the executor, so there is no queued/running state,
+ * no cancel plumbing, and no sweeper interaction. Best-effort: a write
+ * failure must never fail the run the user already got results for.
+ */
+export async function recordCompletedAdhocDbtRun(params: {
+  workspaceId: string;
+  projectId: string;
+  environment: string;
+  command: string;
+  triggeredBy: string;
+  /** Caller whose working tree the command built (repo-bound projects). */
+  workingTreeUserId?: string;
+  /** Caller's checkout branch at run time (display-only provenance). */
+  sourceBranch?: string;
+  deferToProduction?: boolean;
+  startedAt: Date;
+  result: Pick<AdhocDbtResult, "success" | "exitCode" | "logs" | "stepResults">;
+}): Promise<IDbtRun | null> {
+  try {
+    const completedAt = new Date();
+    return await DbtRun.create({
+      workspaceId: new Types.ObjectId(params.workspaceId),
+      projectId: new Types.ObjectId(params.projectId),
+      environment: params.environment,
+      commands: [params.command],
+      status: params.result.success ? "success" : "error",
+      trigger: "manual",
+      triggeredBy: params.triggeredBy,
+      workingTreeUserId: params.workingTreeUserId,
+      sourceBranch: params.sourceBranch,
+      deferToProduction: params.deferToProduction,
+      startedAt: params.startedAt,
+      completedAt,
+      durationMs: completedAt.getTime() - params.startedAt.getTime(),
+      ...(params.result.success
+        ? {}
+        : {
+            error: `dbt command "${params.command}" exited with code ${params.result.exitCode}`,
+          }),
+      logs: params.result.logs.slice(-ADHOC_RECORD_MAX_LOG_LINES).map(line => ({
+        ts: line.ts,
+        level: line.level,
+        line: line.line.slice(0, 2000),
+      })),
+      stepResults: params.result.stepResults,
+    });
+  } catch (error) {
+    logger.warn("Failed to record completed ad-hoc dbt run", {
+      error,
+      projectId: params.projectId,
+    });
+    return null;
+  }
 }
 
 export async function triggerDbtJobRun(params: {
@@ -320,6 +396,11 @@ export async function triggerDbtRunRetry(params: {
     status: "queued",
     trigger: "manual",
     triggeredBy: params.triggeredBy,
+    // Resume the same source tree the failed run built.
+    gitBranch: source.gitBranch,
+    workingTreeUserId: source.workingTreeUserId,
+    sourceBranch: source.sourceBranch,
+    deferToProduction: source.deferToProduction,
     retryOfRunId: source._id,
     restoreArtifactKeys: {
       runResults: source.artifactKeys.runResults,

--- a/api/src/dbt/dbt-run.service.ts
+++ b/api/src/dbt/dbt-run.service.ts
@@ -336,7 +336,9 @@ export async function recordCompletedAdhocDbtRun(params: {
       logs: params.result.logs.slice(-ADHOC_RECORD_MAX_LOG_LINES).map(line => ({
         ts: line.ts,
         level: line.level,
-        line: line.line.slice(0, 2000),
+        // dbt emits blank spacer lines; `create` runs full validation (unlike
+        // the executor's $push), and a required String path rejects "".
+        line: line.line.slice(0, 2000) || " ",
       })),
       stepResults: params.result.stepResults,
     });

--- a/api/src/dbt/dbt-run.service.ts
+++ b/api/src/dbt/dbt-run.service.ts
@@ -9,11 +9,13 @@ import { Types } from "mongoose";
 import { inngest } from "../inngest/client";
 import {
   DbtJob,
+  DbtProject,
   DbtRun,
   type DbtRunStatus,
   type IDbtJob,
   type IDbtRun,
 } from "../database/workspace-schema";
+import { assertAdhocDbtRunAllowed } from "./dbt-environments.service";
 import { parseDbtCommands } from "./commands";
 import { cancelLocalRun } from "./dbt-run-registry";
 import { loggers } from "../logging";
@@ -210,7 +212,25 @@ export async function triggerDbtRun(params: {
   skipIfActive?: boolean;
 }): Promise<IDbtRun> {
   // Validate before persisting anything — bad commands never reach a run doc.
-  parseDbtCommands(params.commands);
+  const parsedCommands = parseDbtCommands(params.commands);
+
+  // Ad-hoc (non-job, non-CI) runs on repo-connected projects build a
+  // working tree — refuse warehouse writes into the protected prod-like
+  // environment so uncommitted drafts can never deploy to prod. Jobs and CI
+  // (which build committed trees) are the only paths allowed to write there.
+  const isAdhocRun =
+    !params.jobId && params.trigger !== "ci" && params.trigger !== "schedule";
+  if (isAdhocRun) {
+    const project = await DbtProject.findOne({
+      _id: new Types.ObjectId(params.projectId),
+      workspaceId: new Types.ObjectId(params.workspaceId),
+    })
+      .select("environments defaultEnvironment repo")
+      .lean();
+    if (project) {
+      assertAdhocDbtRunAllowed(project, params.environment, parsedCommands);
+    }
+  }
 
   if (params.skipIfActive && params.jobId) {
     const active = await DbtRun.findOne({

--- a/api/src/dbt/dbt-run.service.ts
+++ b/api/src/dbt/dbt-run.service.ts
@@ -220,7 +220,7 @@ export async function triggerDbtRun(params: {
     _id: new Types.ObjectId(params.projectId),
     workspaceId: new Types.ObjectId(params.workspaceId),
   })
-    .select("environments defaultEnvironment repo")
+    .select("environments defaultEnvironment prodEnvironment repo")
     .lean();
 
   // Ad-hoc (non-job, non-CI) runs on repo-connected projects build a

--- a/api/src/dbt/dbt-working-tree.service.ts
+++ b/api/src/dbt/dbt-working-tree.service.ts
@@ -41,7 +41,7 @@ export function isRepoProject(project: IDbtProject): boolean {
  * blank projects (no git surface).
  */
 export async function getCheckoutBranch(
-  project: IDbtProject,
+  project: Pick<IDbtProject, "_id" | "repo">,
   userId: string | undefined,
 ): Promise<string | undefined> {
   if (!project.repo) return undefined;

--- a/api/src/dbt/rbac.test.ts
+++ b/api/src/dbt/rbac.test.ts
@@ -70,7 +70,6 @@ describe("resolveDbtAccess", () => {
       { method: "DELETE", path: `${WS}/projects/abc/files/models%2Ffoo.sql` },
       { method: "POST", path: `${WS}/projects/abc/files/rename` },
       { method: "POST", path: `${WS}/projects/abc/compile` },
-      { method: "POST", path: `${WS}/projects/abc/run-select` },
       { method: "POST", path: `${WS}/projects/abc/command` },
       { method: "POST", path: `${WS}/projects/abc/jobs/j1/trigger` },
       { method: "POST", path: `${WS}/projects/abc/runs/r1/cancel` },

--- a/api/src/inngest/functions/dbt-run.ts
+++ b/api/src/inngest/functions/dbt-run.ts
@@ -32,6 +32,7 @@ import {
   finalizeCancelledDbtRun,
   triggerDbtJobRun,
 } from "../../dbt/dbt-run.service";
+import { resolveProdLikeEnvironmentName } from "../../dbt/dbt-environments.service";
 import {
   registerActiveRun,
   unregisterActiveRun,
@@ -609,10 +610,14 @@ export const dbtRunExecutorFunction = inngest.createFunction(
         if (finishedRun?.artifactKeys?.manifest) {
           const project = await DbtProject.findById(
             new Types.ObjectId(data.projectId),
-          ).select("defaultEnvironment");
+          )
+            .select("environments defaultEnvironment prodEnvironment")
+            .lean();
+          // Single source of truth for what counts as production (explicit
+          // prodEnvironment setting > "prod" by name > project default).
           const prodLike =
-            finishedRun.environment === "prod" ||
-            finishedRun.environment === project?.defaultEnvironment;
+            project != null &&
+            finishedRun.environment === resolveProdLikeEnvironmentName(project);
           if (prodLike) {
             await DbtProject.updateOne(
               { _id: new Types.ObjectId(data.projectId) },

--- a/api/src/routes/dbt.routes.integration.test.ts
+++ b/api/src/routes/dbt.routes.integration.test.ts
@@ -356,6 +356,31 @@ describe("project CRUD", () => {
     expect((await res.json()).error).toMatch(/connected repository/);
   });
 
+  it("sets, validates, and clears the production (defer) environment", async () => {
+    const projectId = await createProjectAsOwner();
+
+    // Unknown env name → 400.
+    const bad = await req("PATCH", `/projects/${projectId}`, {
+      prodEnvironment: "release",
+    });
+    expect(bad.status).toBe(400);
+    expect((await bad.json()).error).toMatch(/not in environments/);
+
+    // Valid env → persisted.
+    const set = await req("PATCH", `/projects/${projectId}`, {
+      prodEnvironment: "dev",
+    });
+    expect(set.status).toBe(200);
+    expect((await set.json()).project.prodEnvironment).toBe("dev");
+
+    // Empty string clears the override back to Auto.
+    const cleared = await req("PATCH", `/projects/${projectId}`, {
+      prodEnvironment: "",
+    });
+    expect(cleared.status).toBe(200);
+    expect((await cleared.json()).project.prodEnvironment).toBeUndefined();
+  });
+
   it("rejects an environment bound to a non-dbt-compatible connection", async () => {
     await mongoose.connection
       .collection("databaseconnections")

--- a/api/src/routes/dbt.routes.integration.test.ts
+++ b/api/src/routes/dbt.routes.integration.test.ts
@@ -356,6 +356,44 @@ describe("project CRUD", () => {
     expect((await res.json()).error).toMatch(/connected repository/);
   });
 
+  it("saves, validates, clears, and surfaces the caller's dev environment", async () => {
+    const projectId = await createProjectAsOwner();
+
+    // Unknown env → 400.
+    const bad = await req("PUT", `/projects/${projectId}/my-environment`, {
+      environment: "nope",
+    });
+    expect(bad.status).toBe(400);
+
+    // Save a valid choice → surfaced on the project list for this caller.
+    const set = await req("PUT", `/projects/${projectId}/my-environment`, {
+      environment: "dev",
+    });
+    expect(set.status).toBe(200);
+    expect((await set.json()).myDevEnvironment).toBe("dev");
+
+    const list = await req("GET", "/projects");
+    const listed = ((await list.json()).projects as Array<{
+      _id: string;
+      myDevEnvironment?: string;
+    }>).find(p => p._id === projectId);
+    expect(listed?.myDevEnvironment).toBe("dev");
+
+    // "" clears back to Auto.
+    const cleared = await req("PUT", `/projects/${projectId}/my-environment`, {
+      environment: "",
+    });
+    expect(cleared.status).toBe(200);
+    expect((await cleared.json()).myDevEnvironment).toBeUndefined();
+
+    const list2 = await req("GET", "/projects");
+    const listed2 = ((await list2.json()).projects as Array<{
+      _id: string;
+      myDevEnvironment?: string;
+    }>).find(p => p._id === projectId);
+    expect(listed2?.myDevEnvironment).toBeUndefined();
+  });
+
   it("sets, validates, and clears the production (defer) environment", async () => {
     const projectId = await createProjectAsOwner();
 

--- a/api/src/routes/dbt.routes.integration.test.ts
+++ b/api/src/routes/dbt.routes.integration.test.ts
@@ -66,6 +66,9 @@ vi.mock("../dbt/dbt-run.service", () => ({
   triggerDbtRunRetry: vi.fn(async () => ({ _id: new Types.ObjectId() })),
   requestDbtRunCancel: vi.fn(async () => ({ status: "cancelled" })),
   applyJobScheduleChange: vi.fn(async () => undefined),
+  recordCompletedAdhocDbtRun: vi.fn(async () => ({
+    _id: new Types.ObjectId(),
+  })),
   reconcileStaleQueuedRun: vi.fn(async (r: unknown) => r),
   reconcileStaleQueuedRuns: vi.fn(async (r: unknown) => r),
 }));
@@ -124,6 +127,7 @@ import { dbtRoutes } from "./dbt.routes";
 import { DatabaseConnection } from "../database/workspace-schema";
 import { runAdhocDbtCommand } from "../dbt/dbt-project.service";
 import {
+  recordCompletedAdhocDbtRun,
   requestDbtRunCancel,
   triggerDbtRunRetry,
 } from "../dbt/dbt-run.service";
@@ -133,6 +137,9 @@ import { publishRealtimeEvent } from "../services/realtime.service";
 
 const publishMock = publishRealtimeEvent as unknown as ReturnType<typeof vi.fn>;
 const adhocMock = runAdhocDbtCommand as unknown as ReturnType<typeof vi.fn>;
+const recordAdhocMock = recordCompletedAdhocDbtRun as unknown as ReturnType<
+  typeof vi.fn
+>;
 const cancelMock = requestDbtRunCancel as unknown as ReturnType<typeof vi.fn>;
 const retryMock = triggerDbtRunRetry as unknown as ReturnType<typeof vi.fn>;
 const branchHeadMock = getBranchHeadSha as unknown as ReturnType<typeof vi.fn>;
@@ -603,19 +610,6 @@ describe("ad-hoc runner routes", () => {
     expect(res.status).toBe(400);
   });
 
-  it("run-select requires a select and returns step results", async () => {
-    const projectId = await createProjectAsOwner();
-    expect(
-      (await req("POST", `/projects/${projectId}/run-select`, {})).status,
-    ).toBe(400);
-
-    const res = await req("POST", `/projects/${projectId}/run-select`, {
-      select: "customers+",
-    });
-    expect(res.status).toBe(200);
-    expect((await res.json()).run.stepResults).toHaveLength(1);
-  });
-
   it("command validates against the allowlist (strips leading `dbt`)", async () => {
     const projectId = await createProjectAsOwner();
     const ok = await req("POST", `/projects/${projectId}/command`, {
@@ -631,6 +625,28 @@ describe("ad-hoc runner routes", () => {
       command: "clean",
     });
     expect(bad.status).toBe(400);
+  });
+
+  it("records warehouse-writing commands into run history, not read-only ones", async () => {
+    const projectId = await createProjectAsOwner();
+
+    await req("POST", `/projects/${projectId}/command`, {
+      command: "build --select customers --full-refresh",
+    });
+    expect(recordAdhocMock).toHaveBeenCalledTimes(1);
+    expect(recordAdhocMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: "build --select customers --full-refresh",
+        environment: "dev",
+        triggeredBy: "u1",
+      }),
+    );
+
+    recordAdhocMock.mockClear();
+    await req("POST", `/projects/${projectId}/command`, {
+      command: "compile --select customers",
+    });
+    expect(recordAdhocMock).not.toHaveBeenCalled();
   });
 
   it("lineage returns an empty DAG when no manifest exists yet", async () => {

--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -89,7 +89,10 @@ import {
   loadDbtDeferState,
   runAdhocDbtCommand,
 } from "../dbt/dbt-project.service";
-import { ensurePersonalDbtEnvironment } from "../dbt/dbt-environments.service";
+import {
+  DbtProtectedEnvironmentError,
+  ensurePersonalDbtEnvironment,
+} from "../dbt/dbt-environments.service";
 import {
   applyJobScheduleChange,
   reconcileStaleQueuedRun,
@@ -184,7 +187,10 @@ function serverError(
   error: unknown,
   fallback: string,
 ) {
-  if (error instanceof ProtectedBranchError) {
+  if (
+    error instanceof ProtectedBranchError ||
+    error instanceof DbtProtectedEnvironmentError
+  ) {
     return c.json({ success: false, error: error.message }, 400);
   }
   logger.error(fallback, { error });

--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -16,6 +16,7 @@ import { workspaceService } from "../services/workspace.service";
 import { AuthenticatedContext } from "../middleware/workspace.middleware";
 import {
   DbtCheckout,
+  DbtEnvPreference,
   DbtFile,
   DbtFileDraft,
   DbtJob,
@@ -93,6 +94,7 @@ import {
 import {
   DbtProtectedEnvironmentError,
   ensurePersonalDbtEnvironment,
+  setUserDevEnvPreference,
 } from "../dbt/dbt-environments.service";
 import {
   applyJobScheduleChange,
@@ -339,7 +341,9 @@ async function validateEnvironments(
 // Projects
 // ---------------------------------------------------------------------------
 
-// GET / — list projects with job/run rollups for the explorer
+// GET / — list projects with job/run rollups for the explorer. Each project
+// carries `myDevEnvironment`: the CALLER's saved per-user dev environment
+// (single player: unset → the shared default; teams: each user's own).
 dbtRoutes.get("/projects", async (c: AuthenticatedContext) => {
   try {
     const workspaceId = c.req.param("workspaceId");
@@ -351,7 +355,27 @@ dbtRoutes.get("/projects", async (c: AuthenticatedContext) => {
     })
       .sort({ updatedAt: -1 })
       .lean();
-    return c.json({ success: true, projects });
+    const userId = getUserId(c);
+    const prefs = await DbtEnvPreference.find({
+      projectId: { $in: projects.map(p => p._id) },
+      userId,
+    })
+      .select("projectId environment")
+      .lean();
+    const prefByProject = new Map(
+      prefs.map(pref => [pref.projectId.toString(), pref.environment]),
+    );
+    const enriched = projects.map(project => {
+      const preferred = prefByProject.get(project._id.toString());
+      // Stale choices (env renamed/removed) are dropped, not surfaced.
+      const valid =
+        preferred &&
+        project.environments.some(env => env.name === preferred)
+          ? preferred
+          : undefined;
+      return { ...project, myDevEnvironment: valid };
+    });
+    return c.json({ success: true, projects: enriched });
   } catch (error) {
     return serverError(c, error, "Failed to list dbt projects");
   }
@@ -619,6 +643,52 @@ dbtRoutes.post(
   },
 );
 
+// PUT /projects/:projectId/my-environment — the CALLER's default DEVELOPMENT
+// environment for this project (a per-user setting: the editor/console env
+// pickers persist here, and agent builds default to it). Body:
+// { environment } — "" clears back to Auto (personal env when provisioned,
+// else the project default). Member+ (only affects the caller's own target).
+dbtRoutes.put(
+  "/projects/:projectId/my-environment",
+  async (c: AuthenticatedContext) => {
+    try {
+      const project = await findProject(c);
+      if (!project) {
+        return c.json({ success: false, error: "dbt project not found" }, 404);
+      }
+      const parsed = z
+        .object({ environment: z.string().max(64) })
+        .safeParse(await c.req.json().catch(() => ({})));
+      if (!parsed.success) {
+        return badRequest(c, "environment (string) is required");
+      }
+      const environment = parsed.data.environment;
+      if (
+        environment !== "" &&
+        !project.environments.some(env => env.name === environment)
+      ) {
+        return badRequest(
+          c,
+          `Environment "${environment}" is not in the project`,
+        );
+      }
+      const userId = getUserId(c);
+      await setUserDevEnvPreference({
+        workspaceId: project.workspaceId,
+        projectId: project._id,
+        userId,
+        environment: environment === "" ? null : environment,
+      });
+      return c.json({
+        success: true,
+        myDevEnvironment: environment === "" ? undefined : environment,
+      });
+    } catch (error) {
+      return serverError(c, error, "Failed to save your dev environment");
+    }
+  },
+);
+
 dbtRoutes.delete("/projects/:projectId", async (c: AuthenticatedContext) => {
   try {
     const project = await findProject(c);
@@ -629,6 +699,7 @@ dbtRoutes.delete("/projects/:projectId", async (c: AuthenticatedContext) => {
       DbtFile.deleteMany({ projectId: project._id }),
       DbtFileDraft.deleteMany({ projectId: project._id }),
       DbtCheckout.deleteMany({ projectId: project._id }),
+      DbtEnvPreference.deleteMany({ projectId: project._id }),
       DbtJob.deleteMany({ projectId: project._id }),
       DbtRun.deleteMany({ projectId: project._id }),
     ]);

--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -285,6 +285,11 @@ const patchProjectSchema = z.object({
   dbtVersion: z.string().max(16).optional(),
   environments: z.array(environmentSchema).min(1).optional(),
   defaultEnvironment: z.string().min(1).optional(),
+  /**
+   * Explicit production (defer target) environment; empty string clears the
+   * override back to the convention (env named "prod", else the default).
+   */
+  prodEnvironment: z.string().max(64).optional(),
   ci: z
     .object({
       enabled: z.boolean(),
@@ -476,6 +481,21 @@ dbtRoutes.patch("/projects/:projectId", async (c: AuthenticatedContext) => {
         c,
         `Default environment "${project.defaultEnvironment}" is not in environments`,
       );
+    }
+    if (body.prodEnvironment !== undefined) {
+      if (body.prodEnvironment === "") {
+        project.prodEnvironment = undefined;
+      } else {
+        if (
+          !project.environments.some(env => env.name === body.prodEnvironment)
+        ) {
+          return badRequest(
+            c,
+            `Production environment "${body.prodEnvironment}" is not in environments`,
+          );
+        }
+        project.prodEnvironment = body.prodEnvironment;
+      }
     }
     if (body.ci) {
       if (

--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -81,6 +81,7 @@ import {
 import { resolveDbtAccess } from "../dbt/rbac";
 import {
   DbtCommandValidationError,
+  isWarehouseWriteCommand,
   parseDbtCommand,
   parseDbtCommands,
 } from "../dbt/commands";
@@ -95,6 +96,7 @@ import {
 } from "../dbt/dbt-environments.service";
 import {
   applyJobScheduleChange,
+  recordCompletedAdhocDbtRun,
   reconcileStaleQueuedRun,
   reconcileStaleQueuedRuns,
   requestDbtRunCancel,
@@ -2104,7 +2106,7 @@ dbtRoutes.get(
 );
 
 // ---------------------------------------------------------------------------
-// Ad-hoc compile / run-select (synchronous runner invocations)
+// Ad-hoc compile / command (synchronous runner invocations)
 // ---------------------------------------------------------------------------
 
 const adhocSchema = z.object({
@@ -2188,51 +2190,12 @@ dbtRoutes.post(
   },
 );
 
-dbtRoutes.post(
-  "/projects/:projectId/run-select",
-  async (c: AuthenticatedContext) => {
-    try {
-      const project = await findProject(c);
-      if (!project) {
-        return c.json({ success: false, error: "dbt project not found" }, 404);
-      }
-      const parsed = adhocSchema.safeParse(await c.req.json());
-      if (!parsed.success || !parsed.data.select) {
-        return badRequest(c, "select is required");
-      }
-      const { select, environment, defer } = parsed.data;
-      if (!SELECT_PATTERN.test(select)) {
-        return badRequest(c, "Invalid --select value");
-      }
-      const deferState = defer ? await loadDeferState(project) : undefined;
-      const result = await runAdhocDbtCommand({
-        workspaceId: project.workspaceId.toString(),
-        projectId: project._id.toString(),
-        environmentName: environment,
-        userId: getUserId(c),
-        command: `build --select ${select}`,
-        select,
-        deferState,
-        timeoutMs: 5 * 60 * 1000,
-      });
-      return c.json({
-        success: true,
-        run: {
-          ok: result.success,
-          exitCode: result.exitCode,
-          stepResults: result.stepResults,
-          logs: noteDeferUnavailable(result.logs, !!defer, deferState),
-        },
-      });
-    } catch (error) {
-      return serverError(c, error, "Failed to run dbt model");
-    }
-  },
-);
-
-// Free-form command bar (dbt Cloud parity). The command is tokenized and
-// validated against the same allowlist as stored jobs before it reaches the
-// runner, so no extra CLI surface (--profiles-dir, shell metachars) leaks in.
+// Free-form command bar + editor Run menu (dbt Cloud parity). The command is
+// tokenized and validated against the same allowlist as stored jobs before it
+// reaches the runner, so no extra CLI surface (--profiles-dir, shell
+// metachars) leaks in. Runs synchronously against the CALLER's working tree
+// (checkout + drafts); warehouse-writing commands are recorded post-hoc into
+// dbt_runs so editor runs appear in the Runs history with provenance.
 dbtRoutes.post(
   "/projects/:projectId/command",
   async (c: AuthenticatedContext) => {
@@ -2259,16 +2222,44 @@ dbtRoutes.post(
         }
         throw error;
       }
+      const userId = getUserId(c);
+      const startedAt = new Date();
       const deferState = defer ? await loadDeferState(project) : undefined;
       const result = await runAdhocDbtCommand({
         workspaceId: project.workspaceId.toString(),
         projectId: project._id.toString(),
         environmentName: environment,
-        userId: getUserId(c),
+        userId,
         command: normalized,
         deferState,
         timeoutMs: 9 * 60 * 1000,
       });
+
+      // Editor/console runs that WROTE to the warehouse join the same run
+      // history as agent/job runs. Read-only commands (parse/compile/show)
+      // stay ephemeral — recording every live compile would flood the list.
+      if (isWarehouseWriteCommand(validated)) {
+        const recorded = await recordCompletedAdhocDbtRun({
+          workspaceId: project.workspaceId.toString(),
+          projectId: project._id.toString(),
+          environment: environment ?? project.defaultEnvironment,
+          command: normalized,
+          triggeredBy: userId,
+          workingTreeUserId: project.repo ? userId : undefined,
+          sourceBranch: await getCheckoutBranch(project, userId),
+          deferToProduction: Boolean(defer && deferState),
+          startedAt,
+          result,
+        });
+        if (recorded) {
+          publishDbtEvent(c, {
+            type: "dbt.run.updated",
+            projectId: project._id.toString(),
+            runId: recorded._id.toString(),
+          });
+        }
+      }
+
       return c.json({
         success: true,
         result: {

--- a/app/src/components/DbtConsoleView.tsx
+++ b/app/src/components/DbtConsoleView.tsx
@@ -45,7 +45,7 @@ import {
   type DbtRunLogLine,
 } from "../store/dbtStore";
 import { focusDbtFileTab } from "../dbt-runtime/shell";
-import { resolveProdLikeEnvName } from "../lib/dbt-env";
+import { resolveDevEnvName, resolveProdLikeEnvName } from "../lib/dbt-env";
 
 const DbtLineageView = lazy(() => import("./DbtLineageView"));
 
@@ -128,6 +128,7 @@ export default function DbtConsoleView({ projectId }: { projectId: string }) {
   const fetchProjects = useDbtStore(s => s.fetchProjects);
   const compileModel = useDbtStore(s => s.compileModel);
   const runCommand = useDbtStore(s => s.runCommand);
+  const setMyEnvironment = useDbtStore(s => s.setMyEnvironment);
 
   const [view, setView] = useState<"console" | "lineage">("console");
   const [environment, setEnvironment] = useState("");
@@ -142,16 +143,25 @@ export default function DbtConsoleView({ projectId }: { projectId: string }) {
     if (!project && workspaceId) void fetchProjects(workspaceId);
   }, [project, workspaceId, fetchProjects]);
 
-  // Default to the user's PERSONAL environment when provisioned (safe fast
-  // iteration in their own schema), else the project default.
+  // Default to the user's saved dev environment (per-user setting), else
+  // their personal environment, else the project default.
   useEffect(() => {
     if (project && !environment) {
-      const personal = project.environments?.find(
-        env => env.ownerUserId && env.ownerUserId === user?.id,
+      setEnvironment(
+        resolveDevEnvName(project, user?.id) ?? project.defaultEnvironment,
       );
-      setEnvironment(personal?.name ?? project.defaultEnvironment);
     }
   }, [project, environment, user?.id]);
+
+  // Picking an environment is a per-user setting shared with the editor and
+  // agent builds — persist it.
+  const handleEnvironmentChange = useCallback(
+    (name: string) => {
+      setEnvironment(name);
+      if (workspaceId) void setMyEnvironment(workspaceId, projectId, name);
+    },
+    [workspaceId, projectId, setMyEnvironment],
+  );
 
   const runParse = useCallback(async () => {
     if (!workspaceId) return;
@@ -263,7 +273,7 @@ export default function DbtConsoleView({ projectId }: { projectId: string }) {
             <Select
               size="small"
               value={environment}
-              onChange={e => setEnvironment(e.target.value)}
+              onChange={e => handleEnvironmentChange(e.target.value)}
               sx={{ fontSize: "0.8rem", minWidth: 90 }}
             >
               {visibleDbtEnvironments(project.environments, user?.id).map(

--- a/app/src/components/DbtConsoleView.tsx
+++ b/app/src/components/DbtConsoleView.tsx
@@ -28,6 +28,7 @@ import {
   Tab,
   Tabs,
   TextField,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import {
@@ -44,6 +45,7 @@ import {
   type DbtRunLogLine,
 } from "../store/dbtStore";
 import { focusDbtFileTab } from "../dbt-runtime/shell";
+import { resolveProdLikeEnvName } from "../lib/dbt-env";
 
 const DbtLineageView = lazy(() => import("./DbtLineageView"));
 
@@ -285,21 +287,29 @@ export default function DbtConsoleView({ projectId }: { projectId: string }) {
                 sx: { fontFamily: "monospace", fontSize: "0.8rem" },
               }}
             />
-            <FormControlLabel
-              control={
-                <Checkbox
-                  size="small"
-                  checked={defer}
-                  onChange={e => setDefer(e.target.checked)}
-                />
+            <Tooltip
+              title={
+                `Resolve unselected refs against the last ` +
+                `"${resolveProdLikeEnvName(project) ?? "prod"}" build ` +
+                "(dbt --defer). Change the defer target in Project settings."
               }
-              label={
-                <Typography variant="caption" sx={{ whiteSpace: "nowrap" }}>
-                  Defer to prod
-                </Typography>
-              }
-              sx={{ mr: 0 }}
-            />
+            >
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    size="small"
+                    checked={defer}
+                    onChange={e => setDefer(e.target.checked)}
+                  />
+                }
+                label={
+                  <Typography variant="caption" sx={{ whiteSpace: "nowrap" }}>
+                    Defer to {resolveProdLikeEnvName(project) ?? "prod"}
+                  </Typography>
+                }
+                sx={{ mr: 0 }}
+              />
+            </Tooltip>
             <Button
               size="small"
               variant="contained"

--- a/app/src/components/DbtFileEditor.tsx
+++ b/app/src/components/DbtFileEditor.tsx
@@ -52,7 +52,6 @@ import {
   visibleDbtEnvironments,
   type DbtCompileResult,
   type DbtCommandRunResult,
-  type DbtRunModelResult,
   type DbtRunLogLine,
 } from "../store/dbtStore";
 import {
@@ -128,7 +127,7 @@ function LogLines({ logs }: { logs: DbtRunLogLine[] }) {
 function StepResultsTable({
   steps,
 }: {
-  steps: DbtRunModelResult["stepResults"];
+  steps: DbtCommandRunResult["stepResults"];
 }) {
   return (
     <Box
@@ -294,6 +293,9 @@ export default function DbtFileEditor({
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [environment, setEnvironment] = useState<string>("");
   const [defer, setDefer] = useState(false);
+  // Run menu builds/runs with --full-refresh (rebuild incremental models
+  // from scratch). Sticky per editor instance, like the Defer checkbox.
+  const [fullRefresh, setFullRefresh] = useState(false);
   const [panelOpen, setPanelOpen] = useState(true);
   const [panelTab, setPanelTab] = useState<PanelTab>("compiled");
   const [busy, setBusy] = useState<
@@ -476,7 +478,7 @@ export default function DbtFileEditor({
   const runNodeSelection = useCallback(
     async (verb: DbtRunVerb, scope: DbtSelectScope) => {
       if (!workspaceId || !modelName) return;
-      const cmd = buildDbtNodeCommand(verb, modelName, scope);
+      const cmd = buildDbtNodeCommand(verb, modelName, scope, { fullRefresh });
       if (
         environment === "prod" &&
         !window.confirm(`Run "dbt ${cmd}" against the prod environment?`)
@@ -506,6 +508,7 @@ export default function DbtFileEditor({
       modelName,
       environment,
       defer,
+      fullRefresh,
       runCommand,
       saveNow,
     ],
@@ -863,7 +866,25 @@ export default function DbtFileEditor({
         </Tooltip>
       )}
 
-      {/* Defer / environment */}
+      {/* Full refresh / defer / environment */}
+      <Tooltip title="Rebuild incremental models from scratch (dbt --full-refresh) — applies to the Build/Run menu">
+        <FormControlLabel
+          control={
+            <Checkbox
+              size="small"
+              checked={fullRefresh}
+              onChange={e => setFullRefresh(e.target.checked)}
+              sx={{ p: 0.25 }}
+            />
+          }
+          label={
+            <Typography variant="caption" sx={{ whiteSpace: "nowrap" }}>
+              Full refresh
+            </Typography>
+          }
+          sx={{ mr: 0, ml: 0.5 }}
+        />
+      </Tooltip>
       <Tooltip title="Resolve unselected refs against the last prod build (dbt --defer)">
         <FormControlLabel
           control={

--- a/app/src/components/DbtFileEditor.tsx
+++ b/app/src/components/DbtFileEditor.tsx
@@ -72,7 +72,7 @@ import {
   modelNamesFromPaths,
   type Problem,
 } from "../lib/dbt-editor-logic";
-import { resolveProdLikeEnvName } from "../lib/dbt-env";
+import { resolveDevEnvName, resolveProdLikeEnvName } from "../lib/dbt-env";
 import { focusDbtFileTab } from "../dbt-runtime/shell";
 import EntityBreadcrumbs from "./EntityBreadcrumbs";
 import StreamingMarkdown from "./StreamingMarkdown";
@@ -290,6 +290,7 @@ export default function DbtFileEditor({
   const persistFile = useDbtStore(s => s.persistFile);
   const compileModel = useDbtStore(s => s.compileModel);
   const runCommand = useDbtStore(s => s.runCommand);
+  const setMyEnvironment = useDbtStore(s => s.setMyEnvironment);
 
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [environment, setEnvironment] = useState<string>("");
@@ -354,16 +355,26 @@ export default function DbtFileEditor({
     }
   }, [workspaceId, projectId, path, file?.loaded, readFile]);
 
-  // Default to the user's PERSONAL environment when provisioned (safe fast
-  // iteration in their own schema), else the project default.
+  // Default to the user's saved dev environment (per-user setting), else
+  // their personal environment, else the project default. Single player:
+  // the shared dev default IS the personal target.
   useEffect(() => {
     if (project && !environment) {
-      const personal = project.environments?.find(
-        env => env.ownerUserId && env.ownerUserId === user?.id,
+      setEnvironment(
+        resolveDevEnvName(project, user?.id) ?? project.defaultEnvironment,
       );
-      setEnvironment(personal?.name ?? project.defaultEnvironment);
     }
   }, [project, environment, user?.id]);
+
+  // Picking an environment is a per-user setting: persist it so the console,
+  // the agent's builds, and other windows follow the same choice.
+  const handleEnvironmentChange = useCallback(
+    (name: string) => {
+      setEnvironment(name);
+      if (workspaceId) void setMyEnvironment(workspaceId, projectId, name);
+    },
+    [workspaceId, projectId, setMyEnvironment],
+  );
 
   const handleChange = useCallback(
     (value: string | undefined) => {
@@ -919,7 +930,7 @@ export default function DbtFileEditor({
         variant="standard"
         disableUnderline
         value={environment}
-        onChange={e => setEnvironment(e.target.value)}
+        onChange={e => handleEnvironmentChange(e.target.value)}
         sx={{ fontSize: "0.72rem", textTransform: "uppercase" }}
       >
         {visibleDbtEnvironments(project?.environments, user?.id).map(env => (

--- a/app/src/components/DbtFileEditor.tsx
+++ b/app/src/components/DbtFileEditor.tsx
@@ -72,6 +72,7 @@ import {
   modelNamesFromPaths,
   type Problem,
 } from "../lib/dbt-editor-logic";
+import { resolveProdLikeEnvName } from "../lib/dbt-env";
 import { focusDbtFileTab } from "../dbt-runtime/shell";
 import EntityBreadcrumbs from "./EntityBreadcrumbs";
 import StreamingMarkdown from "./StreamingMarkdown";
@@ -314,6 +315,11 @@ export default function DbtFileEditor({
   const [markdownPreview, setMarkdownPreview] = useState(true);
 
   const modelName = useMemo(() => modelNameForPath(path), [path]);
+  // Defer target for display: the project's production-like environment.
+  const prodEnvName = useMemo(
+    () => (project ? (resolveProdLikeEnvName(project) ?? "prod") : "prod"),
+    [project],
+  );
   const isMarkdown = useMemo(() => isMarkdownDbtPath(path), [path]);
   const showMarkdownPreview = isMarkdown && markdownPreview;
 
@@ -885,7 +891,12 @@ export default function DbtFileEditor({
           sx={{ mr: 0, ml: 0.5 }}
         />
       </Tooltip>
-      <Tooltip title="Resolve unselected refs against the last prod build (dbt --defer)">
+      <Tooltip
+        title={
+          `Resolve unselected refs against the last "${prodEnvName}" build ` +
+          "(dbt --defer). Change the defer target in Project settings."
+        }
+      >
         <FormControlLabel
           control={
             <Checkbox
@@ -897,7 +908,7 @@ export default function DbtFileEditor({
           }
           label={
             <Typography variant="caption" sx={{ whiteSpace: "nowrap" }}>
-              Defer to
+              Defer to {prodEnvName}
             </Typography>
           }
           sx={{ mr: 0, ml: 0.5 }}

--- a/app/src/components/DbtProjectSettingsDrawer.tsx
+++ b/app/src/components/DbtProjectSettingsDrawer.tsx
@@ -52,6 +52,7 @@ import {
 } from "../store/dbtStore";
 import type { Connection } from "../store/schemaStore";
 import { dbtVersionLabel, normalizeDbtVersion } from "../lib/dbt-versions";
+import { resolveProdLikeEnvName } from "../lib/dbt-env";
 import DbtVersionSelect from "./DbtVersionSelect";
 
 const DRAWER_WIDTH = 540;
@@ -73,7 +74,13 @@ function envBadge(envName: string, project: DbtProjectItem): string {
   ) {
     return "DEV";
   }
-  if (envName === "prod" || envName === "production") return "PROD";
+  if (
+    envName === resolveProdLikeEnvName(project) ||
+    envName === "prod" ||
+    envName === "production"
+  ) {
+    return "PROD";
+  }
   return "General";
 }
 
@@ -204,6 +211,9 @@ export default function DbtProjectSettingsDrawer({
   const [editName, setEditName] = useState("");
   const [editDbtVersion, setEditDbtVersion] = useState("");
   const [editDefaultEnv, setEditDefaultEnv] = useState("");
+  // Production/defer environment override; "" = Auto (env named "prod",
+  // else the project default).
+  const [editProdEnv, setEditProdEnv] = useState("");
   const [editEnvs, setEditEnvs] = useState<DbtEnvironment[]>([]);
   // Branch protection (repo-bound projects): edits apply immediately (each
   // add/remove PATCHes the project) — independent of the drawer's Edit mode.
@@ -236,6 +246,7 @@ export default function DbtProjectSettingsDrawer({
     setEditName(p.name);
     setEditDbtVersion(normalizeDbtVersion(p.dbtVersion));
     setEditDefaultEnv(p.defaultEnvironment);
+    setEditProdEnv(p.prodEnvironment ?? "");
     setEditEnvs(p.environments.map(env => ({ ...env })));
     setEditVarRows(
       p.environments.map(env =>
@@ -503,6 +514,9 @@ export default function DbtProjectSettingsDrawer({
     if (!editEnvs.some(e => e.name.trim() === editDefaultEnv)) {
       return "Default environment must match one of the environment names.";
     }
+    if (editProdEnv && !editEnvs.some(e => e.name.trim() === editProdEnv)) {
+      return "Production environment must match one of the environment names.";
+    }
     for (const env of editEnvs) {
       if (!env.connectionId) return `Connection is required for "${env.name}".`;
       if (!env.targetSchema.trim()) {
@@ -513,7 +527,7 @@ export default function DbtProjectSettingsDrawer({
       return "Add a database connection before saving environments.";
     }
     return null;
-  }, [editName, editEnvs, editDefaultEnv, connections.length]);
+  }, [editName, editEnvs, editDefaultEnv, editProdEnv, connections.length]);
 
   const handleSave = useCallback(async () => {
     if (!workspaceId || !projectId) return;
@@ -542,6 +556,8 @@ export default function DbtProjectSettingsDrawer({
       name: editName.trim(),
       environments: normalizedEnvs,
       defaultEnvironment: editDefaultEnv,
+      // "" clears the override back to Auto (prod by name, else default).
+      prodEnvironment: editProdEnv,
       dbtVersion: editDbtVersion,
     });
     setSaving(false);
@@ -565,6 +581,7 @@ export default function DbtProjectSettingsDrawer({
     editVarRows,
     editName,
     editDefaultEnv,
+    editProdEnv,
     editDbtVersion,
     updateProject,
     resetFromProject,
@@ -925,7 +942,7 @@ export default function DbtProjectSettingsDrawer({
                   labelId="dbt-settings-version"
                 />
               </Box>
-              <FormControl fullWidth size="small">
+              <FormControl fullWidth size="small" sx={{ mb: 1.5 }}>
                 <InputLabel id="dbt-settings-default-env">
                   Default environment
                 </InputLabel>
@@ -941,6 +958,37 @@ export default function DbtProjectSettingsDrawer({
                     </MenuItem>
                   ))}
                 </Select>
+              </FormControl>
+              <FormControl fullWidth size="small">
+                <InputLabel id="dbt-settings-prod-env">
+                  Production environment (defer target)
+                </InputLabel>
+                <Select
+                  labelId="dbt-settings-prod-env"
+                  label="Production environment (defer target)"
+                  value={editProdEnv}
+                  onChange={e => setEditProdEnv(e.target.value)}
+                >
+                  <MenuItem value="">
+                    Auto — “prod” when it exists, else the default
+                  </MenuItem>
+                  {editEnvs
+                    .filter(env => !env.ownerUserId)
+                    .map(env => (
+                      <MenuItem key={env.name} value={env.name}>
+                        {env.name}
+                      </MenuItem>
+                    ))}
+                </Select>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ mt: 0.5, display: "block" }}
+                >
+                  Ad-hoc builds defer to this environment’s last manifest, apps
+                  resolve {"{{ dbt_schema }}"} against it, and it refuses ad-hoc
+                  writes (deploys go through jobs).
+                </Typography>
               </FormControl>
             </SettingsSection>
 
@@ -989,6 +1037,14 @@ export default function DbtProjectSettingsDrawer({
               <ReadOnlyField
                 label="Default environment"
                 value={project.defaultEnvironment}
+              />
+              <ReadOnlyField
+                label="Production environment (defer target)"
+                value={
+                  project.prodEnvironment
+                    ? project.prodEnvironment
+                    : `${resolveProdLikeEnvName(project) ?? "—"} (auto)`
+                }
               />
               <ReadOnlyField
                 label="dbt version"

--- a/app/src/components/DbtProjectSettingsDrawer.tsx
+++ b/app/src/components/DbtProjectSettingsDrawer.tsx
@@ -47,12 +47,13 @@ import {
 import { useAuth } from "../contexts/auth-context";
 import {
   useDbtStore,
+  visibleDbtEnvironments,
   type DbtEnvironment,
   type DbtProjectItem,
 } from "../store/dbtStore";
 import type { Connection } from "../store/schemaStore";
 import { dbtVersionLabel, normalizeDbtVersion } from "../lib/dbt-versions";
-import { resolveProdLikeEnvName } from "../lib/dbt-env";
+import { resolveDevEnvName, resolveProdLikeEnvName } from "../lib/dbt-env";
 import DbtVersionSelect from "./DbtVersionSelect";
 
 const DRAWER_WIDTH = 540;
@@ -196,6 +197,7 @@ export default function DbtProjectSettingsDrawer({
   const ensurePersonalEnvironment = useDbtStore(
     s => s.ensurePersonalEnvironment,
   );
+  const setMyEnvironment = useDbtStore(s => s.setMyEnvironment);
   const [creatingPersonalEnv, setCreatingPersonalEnv] = useState(false);
 
   const project = useMemo(
@@ -1050,6 +1052,56 @@ export default function DbtProjectSettingsDrawer({
                 label="dbt version"
                 value={dbtVersionLabel(project.dbtVersion)}
               />
+              {/* Per-USER setting (not project config): which environment
+                  this user's drafts/builds target. Solo: the shared dev
+                  default; teams: your personal environment. */}
+              <Box sx={{ mt: 1.5 }}>
+                <FormControl fullWidth size="small">
+                  <InputLabel id="dbt-settings-my-env">
+                    My development environment (per-user)
+                  </InputLabel>
+                  <Select
+                    labelId="dbt-settings-my-env"
+                    label="My development environment (per-user)"
+                    value={project.myDevEnvironment ?? ""}
+                    onChange={e => {
+                      if (!projectId) return;
+                      void setMyEnvironment(
+                        workspaceId,
+                        projectId,
+                        e.target.value,
+                      );
+                    }}
+                  >
+                    <MenuItem value="">
+                      Auto —{" "}
+                      {resolveDevEnvName(
+                        { ...project, myDevEnvironment: undefined },
+                        user?.id,
+                      ) ?? "default"}
+                      {" (your personal env, else the default)"}
+                    </MenuItem>
+                    {visibleDbtEnvironments(project.environments, user?.id).map(
+                      env => (
+                        <MenuItem key={env.name} value={env.name}>
+                          {env.ownerUserId
+                            ? `${env.name} (personal)`
+                            : env.name}
+                        </MenuItem>
+                      ),
+                    )}
+                  </Select>
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ mt: 0.5, display: "block" }}
+                  >
+                    Where YOUR drafts and agent builds run. Solo workspaces: dev
+                    is your personal target. Teams: pick (or provision) your
+                    personal environment so builds never collide.
+                  </Typography>
+                </FormControl>
+              </Box>
             </SettingsSection>
 
             <SettingsSection

--- a/app/src/components/DbtRunCard.tsx
+++ b/app/src/components/DbtRunCard.tsx
@@ -170,13 +170,14 @@ export function DbtRunCard({ runId, projectId, label }: DbtRunCardProps) {
     <Box
       sx={{
         my: 0.75,
+        maxWidth: 560,
         borderRadius: 1.5,
         border: 1,
-        borderColor: isActive
-          ? "primary.main"
-          : status === "error"
-            ? "error.main"
-            : "divider",
+        borderColor: isActive ? "primary.main" : "divider",
+        // Status accent: a slim colored edge reads at a glance without a
+        // heavy full border.
+        borderLeft: 3,
+        borderLeftColor: statusColor(status),
         overflow: "hidden",
         transition: "border-color 0.3s",
         backgroundColor: theme =>
@@ -185,107 +186,133 @@ export function DbtRunCard({ runId, projectId, label }: DbtRunCardProps) {
             : "rgba(0,0,0,0.015)",
       }}
     >
-      {/* Header */}
+      {/* Header: title + status, then a meta row (env / branch / duration /
+          actions) — two lines so the command stays readable in a narrow
+          chat panel instead of being squeezed out by the chips. */}
       <Box
         onClick={() => hasBody && setExpanded(prev => !prev)}
         sx={{
-          display: "flex",
-          alignItems: "center",
-          gap: 1,
           px: 1.25,
           py: 0.75,
           cursor: hasBody ? "pointer" : "default",
           "&:hover": hasBody ? { backgroundColor: "action.hover" } : undefined,
         }}
       >
-        {hasBody ? (
-          expanded ? (
-            <ChevronDownIcon size={14} />
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+          {hasBody ? (
+            expanded ? (
+              <ChevronDownIcon size={14} style={{ flexShrink: 0 }} />
+            ) : (
+              <ChevronRightIcon size={14} style={{ flexShrink: 0 }} />
+            )
           ) : (
-            <ChevronRightIcon size={14} />
-          )
-        ) : (
-          <Box sx={{ width: 14 }} />
-        )}
-        <Box
-          component="span"
-          sx={{
-            fontFamily: "monospace",
-            fontSize: "0.8rem",
-            fontWeight: 600,
-            flex: 1,
-            whiteSpace: "nowrap",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-          }}
-          title={title}
-        >
-          {title}
-        </Box>
-        {run?.environment && (
+            <Box sx={{ width: 14, flexShrink: 0 }} />
+          )}
+          <Box
+            component="span"
+            sx={{
+              fontFamily: "monospace",
+              fontSize: "0.8rem",
+              fontWeight: 600,
+              flex: 1,
+              minWidth: 0,
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+            title={title}
+          >
+            {title}
+          </Box>
           <Chip
             size="small"
             variant="outlined"
-            label={run.environment}
-            sx={{ height: 18, fontSize: "0.66rem" }}
+            icon={isActive ? <CircularProgress size={10} /> : undefined}
+            label={statusLabel}
+            sx={{
+              height: 20,
+              flexShrink: 0,
+              textTransform: "capitalize",
+              fontWeight: 600,
+              color: statusColor(status),
+              borderColor: statusColor(status),
+            }}
           />
-        )}
-        {treeChip && (
-          <Tooltip title={treeChip.tooltip}>
+        </Box>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: 0.75,
+            mt: 0.5,
+            ml: "22px",
+            flexWrap: "wrap",
+          }}
+        >
+          {run?.environment && (
             <Chip
               size="small"
               variant="outlined"
-              color={run?.workingTreeUserId ? "info" : "default"}
-              label={treeChip.label}
-              sx={{ height: 18, fontSize: "0.66rem", fontFamily: "monospace" }}
+              label={run.environment}
+              sx={{
+                height: 18,
+                fontSize: "0.64rem",
+                "& .MuiChip-label": { px: 0.75 },
+              }}
             />
-          </Tooltip>
-        )}
-        {run?.durationMs !== undefined && (
-          <Box
-            component="span"
-            sx={{ fontSize: "0.72rem", color: "text.secondary" }}
-          >
-            {formatDuration(run.durationMs)}
-          </Box>
-        )}
-        <Tooltip title="Open in Transforms → Runs">
-          <IconButton
-            size="small"
-            onClick={event => {
-              event.stopPropagation();
-              focusDbtRunsTab(projectId, "Runs", runId);
-            }}
-          >
-            <OpenIcon size={13} />
-          </IconButton>
-        </Tooltip>
-        <Chip
-          size="small"
-          variant="outlined"
-          icon={isActive ? <CircularProgress size={10} /> : undefined}
-          label={statusLabel}
-          sx={{
-            height: 20,
-            textTransform: "capitalize",
-            fontWeight: 600,
-            color: statusColor(status),
-            borderColor: statusColor(status),
-          }}
-        />
-        {isActive && (
-          <Tooltip title="Cancel build">
-            <span>
-              <IconButton
+          )}
+          {treeChip && (
+            <Tooltip title={treeChip.tooltip}>
+              <Chip
                 size="small"
-                onClick={handleCancel}
-                disabled={cancelling}
-              >
-                <StopIcon size={13} />
-              </IconButton>
-            </span>
+                variant="outlined"
+                color={run?.workingTreeUserId ? "info" : "default"}
+                label={treeChip.label}
+                sx={{
+                  height: 18,
+                  fontSize: "0.64rem",
+                  fontFamily: "monospace",
+                  "& .MuiChip-label": { px: 0.75 },
+                }}
+              />
+            </Tooltip>
+          )}
+          {run?.durationMs !== undefined && (
+            <Box
+              component="span"
+              sx={{ fontSize: "0.7rem", color: "text.secondary" }}
+            >
+              {formatDuration(run.durationMs)}
+            </Box>
+          )}
+          <Box sx={{ flex: 1 }} />
+          {isActive && (
+            <Tooltip title="Cancel build">
+              <span>
+                <IconButton
+                  size="small"
+                  sx={{ p: 0.25 }}
+                  onClick={handleCancel}
+                  disabled={cancelling}
+                >
+                  <StopIcon size={13} />
+                </IconButton>
+              </span>
+            </Tooltip>
+          )}
+          <Tooltip title="Open in Transforms → Runs">
+            <IconButton
+              size="small"
+              sx={{ p: 0.25 }}
+              onClick={event => {
+                event.stopPropagation();
+                focusDbtRunsTab(projectId, "Runs", runId);
+              }}
+            >
+              <OpenIcon size={13} />
+            </IconButton>
           </Tooltip>
-        )}
+        </Box>
       </Box>
 
       {/* Error summary (always visible when failed) */}

--- a/app/src/components/DbtRunCard.tsx
+++ b/app/src/components/DbtRunCard.tsx
@@ -153,6 +153,19 @@ export function DbtRunCard({ runId, projectId, label }: DbtRunCardProps) {
   const statusLabel =
     cancelling && isActive ? "Cancelling…" : (status ?? "queued");
 
+  // Git provenance: which source tree the build ran (working tree = the
+  // caller's checkout + uncommitted drafts; otherwise a committed branch).
+  const treeChip = run?.sourceBranch
+    ? {
+        label: run.workingTreeUserId
+          ? `${run.sourceBranch} · draft`
+          : run.sourceBranch,
+        tooltip: run.workingTreeUserId
+          ? `Built your working tree: branch "${run.sourceBranch}" plus your uncommitted drafts.`
+          : `Built the committed "${run.sourceBranch}" branch.`,
+      }
+    : null;
+
   return (
     <Box
       sx={{
@@ -209,6 +222,25 @@ export function DbtRunCard({ runId, projectId, label }: DbtRunCardProps) {
         >
           {title}
         </Box>
+        {run?.environment && (
+          <Chip
+            size="small"
+            variant="outlined"
+            label={run.environment}
+            sx={{ height: 18, fontSize: "0.66rem" }}
+          />
+        )}
+        {treeChip && (
+          <Tooltip title={treeChip.tooltip}>
+            <Chip
+              size="small"
+              variant="outlined"
+              color={run?.workingTreeUserId ? "info" : "default"}
+              label={treeChip.label}
+              sx={{ height: 18, fontSize: "0.66rem", fontFamily: "monospace" }}
+            />
+          </Tooltip>
+        )}
         {run?.durationMs !== undefined && (
           <Box
             component="span"

--- a/app/src/components/DbtRunHistory.tsx
+++ b/app/src/components/DbtRunHistory.tsx
@@ -117,6 +117,33 @@ function runSourceLabel(
   return commandSummary(run);
 }
 
+/**
+ * Git provenance chip: which source tree the run built. Working-tree runs
+ * (editor / chat ad-hoc) include the caller's uncommitted drafts; everything
+ * else builds a committed branch (jobs, deploys, CI).
+ */
+function runTreeChip(
+  run: Pick<DbtRunItem, "sourceBranch" | "workingTreeUserId" | "ci">,
+): { label: string; tooltip: string; draft: boolean } | null {
+  if (!run.sourceBranch) return null;
+  if (run.workingTreeUserId) {
+    return {
+      label: `${run.sourceBranch} · draft`,
+      tooltip:
+        `Built a working tree: branch "${run.sourceBranch}" plus the ` +
+        "runner's uncommitted drafts at run time.",
+      draft: true,
+    };
+  }
+  return {
+    label: run.sourceBranch,
+    tooltip: `Built the committed "${run.sourceBranch}" branch${
+      run.ci ? ` (PR #${run.ci.prNumber} head)` : ""
+    }.`,
+    draft: false,
+  };
+}
+
 /** Sortable columns of the node-results table. */
 type NodeSortKey =
   | "name"
@@ -466,6 +493,27 @@ export default function DbtRunHistory({
                     />
                   </Tooltip>
                 )}
+                {(() => {
+                  const tree = runTreeChip(run);
+                  if (!tree) return null;
+                  return (
+                    <Tooltip title={tree.tooltip}>
+                      <Chip
+                        label={tree.label}
+                        size="small"
+                        variant="outlined"
+                        color={tree.draft ? "info" : "default"}
+                        sx={{
+                          height: 16,
+                          fontSize: "0.62rem",
+                          flexShrink: 0,
+                          fontFamily: "monospace",
+                          "& .MuiChip-label": { px: 0.5 },
+                        }}
+                      />
+                    </Tooltip>
+                  );
+                })()}
                 {run.durationMs !== undefined && (
                   <Typography variant="caption" color="text.secondary">
                     {formatDuration(run.durationMs)}
@@ -611,6 +659,21 @@ export default function DbtRunHistory({
               />
             </Tooltip>
           )}
+          {(() => {
+            const tree = selectedDetail ? runTreeChip(selectedDetail) : null;
+            if (!tree) return null;
+            return (
+              <Tooltip title={tree.tooltip}>
+                <Chip
+                  label={tree.label}
+                  size="small"
+                  variant="outlined"
+                  color={tree.draft ? "info" : "default"}
+                  sx={{ height: 20, fontFamily: "monospace" }}
+                />
+              </Tooltip>
+            );
+          })()}
           <Typography
             variant="caption"
             color="text.secondary"

--- a/app/src/lib/dbt-env.test.ts
+++ b/app/src/lib/dbt-env.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { resolveProdLikeEnvName } from "./dbt-env";
+
+const envs = (...names: string[]) => names.map(name => ({ name }));
+
+describe("resolveProdLikeEnvName", () => {
+  it("prefers an explicit prodEnvironment setting", () => {
+    expect(
+      resolveProdLikeEnvName({
+        environments: envs("dev", "prod", "release"),
+        defaultEnvironment: "dev",
+        prodEnvironment: "release",
+      }),
+    ).toBe("release");
+  });
+
+  it("ignores a stale prodEnvironment and falls back to 'prod'", () => {
+    expect(
+      resolveProdLikeEnvName({
+        environments: envs("dev", "prod"),
+        defaultEnvironment: "dev",
+        prodEnvironment: "gone",
+      }),
+    ).toBe("prod");
+  });
+
+  it("falls back to the default when no 'prod' env exists", () => {
+    expect(
+      resolveProdLikeEnvName({
+        environments: envs("main", "staging"),
+        defaultEnvironment: "main",
+      }),
+    ).toBe("main");
+  });
+});

--- a/app/src/lib/dbt-env.ts
+++ b/app/src/lib/dbt-env.ts
@@ -26,6 +26,35 @@ export function resolveProdLikeEnvName(project: {
 }
 
 /**
+ * The environment a user's ad-hoc work targets by default — mirrors the
+ * server's resolveDevEnvironmentForUser:
+ *   saved per-user choice (`myDevEnvironment`) > the user's personal
+ *   environment > the project default.
+ * Single player: the shared dev default IS the personal target; teams: each
+ * user's own environment keeps builds out of teammates' schemas.
+ */
+export function resolveDevEnvName(
+  project: {
+    environments?: Array<{ name: string; ownerUserId?: string }>;
+    defaultEnvironment?: string;
+    myDevEnvironment?: string;
+  },
+  userId: string | undefined,
+): string | undefined {
+  const environments = project.environments ?? [];
+  if (
+    project.myDevEnvironment &&
+    environments.some(env => env.name === project.myDevEnvironment)
+  ) {
+    return project.myDevEnvironment;
+  }
+  const personal = userId
+    ? environments.find(env => env.ownerUserId === userId)
+    : undefined;
+  return personal?.name ?? project.defaultEnvironment;
+}
+
+/**
  * MUI Chip color for a dbt environment badge. Prod-like envs are flagged
  * `warning` so destructive/scheduled prod runs stand out; the project default
  * and dev-like envs get `info`, everything else stays neutral.

--- a/app/src/lib/dbt-env.ts
+++ b/app/src/lib/dbt-env.ts
@@ -1,6 +1,29 @@
 /**
- * Shared helpers for dbt environment badges (jobs list, run history).
+ * Shared helpers for dbt environment badges (jobs list, run history) and
+ * prod-like environment resolution.
  */
+
+/**
+ * The environment treated as "production" (the defer target). Mirrors the
+ * server's resolveProdLikeEnvironmentName: an explicit `prodEnvironment`
+ * setting wins when it still exists, else the env literally named "prod",
+ * else the project default.
+ */
+export function resolveProdLikeEnvName(project: {
+  environments?: Array<{ name: string }>;
+  defaultEnvironment?: string;
+  prodEnvironment?: string;
+}): string | undefined {
+  const environments = project.environments ?? [];
+  if (
+    project.prodEnvironment &&
+    environments.some(env => env.name === project.prodEnvironment)
+  ) {
+    return project.prodEnvironment;
+  }
+  if (environments.some(env => env.name === "prod")) return "prod";
+  return project.defaultEnvironment;
+}
 
 /**
  * MUI Chip color for a dbt environment badge. Prod-like envs are flagged

--- a/app/src/lib/dbt-node-selection.test.ts
+++ b/app/src/lib/dbt-node-selection.test.ts
@@ -29,4 +29,19 @@ describe("buildDbtNodeCommand", () => {
       "test --select dim_users",
     );
   });
+
+  it("appends --full-refresh for build/run but never for test", () => {
+    expect(
+      buildDbtNodeCommand("build", "fct_orders", "", { fullRefresh: true }),
+    ).toBe("build --select fct_orders --full-refresh");
+    expect(
+      buildDbtNodeCommand("run", "fct_orders", "down", { fullRefresh: true }),
+    ).toBe("run --select fct_orders+ --full-refresh");
+    expect(
+      buildDbtNodeCommand("test", "fct_orders", "", { fullRefresh: true }),
+    ).toBe("test --select fct_orders");
+    expect(
+      buildDbtNodeCommand("build", "fct_orders", "", { fullRefresh: false }),
+    ).toBe("build --select fct_orders");
+  });
 });

--- a/app/src/lib/dbt-node-selection.ts
+++ b/app/src/lib/dbt-node-selection.ts
@@ -28,6 +28,11 @@ export function buildDbtNodeCommand(
   verb: DbtRunVerb,
   modelName: string,
   scope: DbtSelectScope,
+  options?: { fullRefresh?: boolean },
 ): string {
-  return `${verb} --select ${buildDbtSelectArg(modelName, scope)}`;
+  // --full-refresh only applies to commands that (re)build tables; `test`
+  // rejects the flag.
+  const fullRefresh =
+    options?.fullRefresh && verb !== "test" ? " --full-refresh" : "";
+  return `${verb} --select ${buildDbtSelectArg(modelName, scope)}${fullRefresh}`;
 }

--- a/app/src/store/dbtStore.test.ts
+++ b/app/src/store/dbtStore.test.ts
@@ -213,21 +213,6 @@ describe("ad-hoc runner passthrough", () => {
     );
   });
 
-  it("runModel posts the select and returns the run result", async () => {
-    api.post.mockResolvedValue({
-      success: true,
-      run: { ok: true, exitCode: 0, stepResults: [], logs: [] },
-    });
-    const res = await useDbtStore
-      .getState()
-      .runModel(WS, "p1", "customers+", "dev", true);
-    expect(res?.ok).toBe(true);
-    expect(api.post).toHaveBeenCalledWith(
-      `/workspaces/${WS}/dbt/projects/p1/run-select`,
-      { select: "customers+", environment: "dev", defer: true },
-    );
-  });
-
   it("fetchLineage returns the lineage payload", async () => {
     api.get.mockResolvedValue({
       success: true,

--- a/app/src/store/dbtStore.ts
+++ b/app/src/store/dbtStore.ts
@@ -62,6 +62,11 @@ export interface DbtProjectItem {
   dbtVersion: string;
   environments: DbtEnvironment[];
   defaultEnvironment: string;
+  /**
+   * Explicit production (defer target) environment. Unset → convention:
+   * the env named "prod" when one exists, else the project default.
+   */
+  prodEnvironment?: string;
   updatedAt?: string;
   /** Set when the project is imported/synced from a Git repository. */
   repo?: DbtRepoBinding;
@@ -363,6 +368,8 @@ interface DbtActions {
       name?: string;
       environments?: DbtEnvironment[];
       defaultEnvironment?: string;
+      /** Production/defer env override; "" clears back to the convention. */
+      prodEnvironment?: string;
       dbtVersion?: string;
       ci?: DbtCiConfig;
       protectedBranches?: string[];

--- a/app/src/store/dbtStore.ts
+++ b/app/src/store/dbtStore.ts
@@ -67,6 +67,13 @@ export interface DbtProjectItem {
    * the env named "prod" when one exists, else the project default.
    */
   prodEnvironment?: string;
+  /**
+   * The CALLER's saved development environment for this project (per-user
+   * setting, persisted by the env pickers). Unset → auto: their personal
+   * environment when provisioned, else the project default. Single player:
+   * the shared dev default IS the personal target; teams: each user's own.
+   */
+  myDevEnvironment?: string;
   updatedAt?: string;
   /** Set when the project is imported/synced from a Git repository. */
   repo?: DbtRepoBinding;
@@ -387,6 +394,15 @@ interface DbtActions {
     workspaceId: string,
     projectId: string,
   ) => Promise<DbtEnvironment | null>;
+  /**
+   * Persist the caller's per-user dev environment for a project ("" clears
+   * back to Auto). Updates `myDevEnvironment` on the cached project.
+   */
+  setMyEnvironment: (
+    workspaceId: string,
+    projectId: string,
+    environment: string,
+  ) => Promise<boolean>;
   fetchGitHubStatus: (workspaceId: string) => Promise<GitHubStatus | null>;
   fetchGitHubRepos: (
     workspaceId: string,
@@ -742,7 +758,14 @@ export const useDbtStore = create<DbtStore>()(
         const project = response.project;
         set(state => {
           const idx = state.projects.findIndex(p => p._id === projectId);
-          if (idx >= 0) state.projects[idx] = project;
+          if (idx >= 0) {
+            // PATCH responses don't carry the caller's per-user dev env
+            // (list enrichment does) — keep the cached value.
+            state.projects[idx] = {
+              ...project,
+              myDevEnvironment: state.projects[idx].myDevEnvironment,
+            };
+          }
         });
         return project;
       } catch (error) {
@@ -774,6 +797,33 @@ export const useDbtStore = create<DbtStore>()(
           );
         });
         return null;
+      }
+    },
+
+    setMyEnvironment: async (workspaceId, projectId, environment) => {
+      try {
+        const response = await apiClient.put<{
+          success: boolean;
+          myDevEnvironment?: string;
+        }>(
+          `/workspaces/${workspaceId}/dbt/projects/${projectId}/my-environment`,
+          { environment },
+        );
+        set(state => {
+          const idx = state.projects.findIndex(p => p._id === projectId);
+          if (idx >= 0) {
+            state.projects[idx].myDevEnvironment = response.myDevEnvironment;
+          }
+        });
+        return true;
+      } catch (error) {
+        set(state => {
+          state.error.projects = errMessage(
+            error,
+            "Failed to save your dev environment",
+          );
+        });
+        return false;
       }
     },
 

--- a/app/src/store/dbtStore.ts
+++ b/app/src/store/dbtStore.ts
@@ -240,6 +240,14 @@ export interface DbtRunItem {
   stepResults?: DbtStepResult[];
   error?: string;
   createdAt: string;
+  /**
+   * Git branch the run's source tree came from (repo-bound projects).
+   * Combined with `workingTreeUserId` it tells WHAT was built: a user's
+   * working tree (checkout + uncommitted drafts) vs the committed branch.
+   */
+  sourceBranch?: string;
+  /** Set when the run built this user's working tree (drafts included). */
+  workingTreeUserId?: string;
   /** PR context for CI runs (trigger === "ci"). */
   ci?: {
     prNumber: number;
@@ -271,13 +279,6 @@ export interface DbtCompileResult {
   ok: boolean;
   exitCode: number;
   compiledSql?: string;
-  logs: DbtRunLogLine[];
-}
-
-export interface DbtRunModelResult {
-  ok: boolean;
-  exitCode: number;
-  stepResults: DbtStepResult[];
   logs: DbtRunLogLine[];
 }
 
@@ -593,13 +594,6 @@ interface DbtActions {
     environment?: string,
     defer?: boolean,
   ) => Promise<DbtCompileResult | null>;
-  runModel: (
-    workspaceId: string,
-    projectId: string,
-    select: string,
-    environment?: string,
-    defer?: boolean,
-  ) => Promise<DbtRunModelResult | null>;
   runCommand: (
     workspaceId: string,
     projectId: string,
@@ -1756,33 +1750,6 @@ export const useDbtStore = create<DbtStore>()(
               ts: new Date().toISOString(),
               level: "error",
               line: errMessage(error, "Compile failed"),
-            },
-          ],
-        };
-      }
-    },
-
-    runModel: async (workspaceId, projectId, select, environment, defer) => {
-      try {
-        const response = await apiClient.post<{
-          success: boolean;
-          run: DbtRunModelResult;
-        }>(`/workspaces/${workspaceId}/dbt/projects/${projectId}/run-select`, {
-          select,
-          ...(environment ? { environment } : {}),
-          ...(defer ? { defer } : {}),
-        });
-        return response.run ?? null;
-      } catch (error) {
-        return {
-          ok: false,
-          exitCode: 1,
-          stepResults: [],
-          logs: [
-            {
-              ts: new Date().toISOString(),
-              level: "error",
-              line: errMessage(error, "Run failed"),
             },
           ],
         };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Goal

Make the git / dbt / agent loop feel like developing from the Cursor IDE, with an explicit single/multi-player model:

- **Single player:** the shared `dev` environment IS your personal target — drafts and branch verification build against dev. No surprise `dbt_<user>` schemas.
- **Multiple players:** each user tests against their OWN environment (personal env, auto-provisioned on first build).
- **The development default is a per-user setting** — resolution is: explicit request > saved per-user choice > personal env > project default.
- Every run says which git tree it built; prod is a jobs/CI-only deploy target and the prod/defer environment is an explicit, visible setting.

## Wave 1 — fix the agent loop + protect prod

- `dbt_run_model` gains `fullRefresh` (`--full-refresh`) so incremental rebuilds of drafts never require a saved job (jobs build the committed tracked branch and silently ran OLD code — the original loop).
- `dbt_run_job` is explicit that it ALWAYS builds the committed tracked branch; result includes `sourceBranch` + warning.
- New `assertAdhocDbtRunAllowed` guard: ad-hoc warehouse writes cannot target the prod-like environment on repo-connected projects (HTTP 400); jobs/CI only.

## Wave 2 — one run pipeline with provenance

- Every `DbtRun` stamps a display-only `sourceBranch`; Runs list, run detail, and the chat run card show `main · draft` vs committed-branch chips plus the environment.
- Editor/console warehouse-writing `/command` runs are recorded post-hoc into `dbt_runs` — IDE draft runs share the same history as agent/job runs.
- "Full refresh" checkbox in the editor status bar (Build/Run menu appends `--full-refresh`, never for `test`).
- Removed the redundant `/run-select` route + unused store `runModel`.

## Wave 3 — explicit prod/defer environment + run card polish

- `project.prodEnvironment` (settable in Project settings, Auto fallback: env named "prod", else default) drives defer-manifest promotion, `{{ dbt_schema }}` resolution, and the ad-hoc write guard through one resolver. Fixes an OR-bug where both `prod` and the default env promoted the defer manifest.
- Editor/console defer checkboxes name the actual target ("Defer to prod").
- `DbtRunCard` redesign: two-line header, status-colored left accent, capped width.

## Wave 4 — per-user dev environment (single vs multi player)

- New `dbt_env_preferences` collection (unique per project+user): the caller's saved development environment. `resolveDevEnvironmentForUser` is the single server-side resolution (explicit > saved choice > personal env > default) used by all agent dbt tools.
- **Auto-provisioning is now gated on workspace member count > 1**: solo workspaces keep building shared `dev` (dev IS the personal target); multi-user workspaces auto-provision `dbt_<user>` on the first build. A saved choice or explicit env always suppresses it.
- `PUT /projects/:id/my-environment` saves/clears the choice; the project list carries `myDevEnvironment` per caller; the editor + console env pickers initialize from it and persist changes; Project settings gains a per-user "My development environment" selector with an Auto option.
- Prompts + `dbt` skill state the single/multi-player contract verbatim so agents keep it clear.

## Demos (live app, real dbt runner)

**Single player: agent build defaults to `dev` (no personal schema invented) + the per-user env setting**
[single_player_builds_dev_and_per_user_env_setting.mp4](https://cursor.com/agents/bc-2019eb89-2e2e-49be-bec5-895111ad5b88/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsingle_player_builds_dev_and_per_user_env_setting.mp4)
[Solo workspace: run card env chip = dev](https://cursor.com/agents/bc-2019eb89-2e2e-49be-bec5-895111ad5b88/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsolo_build_defaults_to_dev.webp)
[Per-user My development environment selector with Auto option](https://cursor.com/agents/bc-2019eb89-2e2e-49be-bec5-895111ad5b88/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmy_dev_environment_per_user_setting.webp)

**Multi player: same request after adding a second member → personal env `cloud_agent` auto-provisioned**
[multiplayer_auto_provisions_personal_env.mp4](https://cursor.com/agents/bc-2019eb89-2e2e-49be-bec5-895111ad5b88/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmultiplayer_auto_provisions_personal_env.mp4)
[Multiplayer: run card env chip = cloud_agent](https://cursor.com/agents/bc-2019eb89-2e2e-49be-bec5-895111ad5b88/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmultiplayer_personal_env_run_card.webp)

**Prod/defer env setting + redesigned run card**
[prod_defer_env_setting_and_redesigned_run_card.mp4](https://cursor.com/agents/bc-2019eb89-2e2e-49be-bec5-895111ad5b88/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprod_defer_env_setting_and_redesigned_run_card.mp4)

**Editor: one-click full-refresh draft build + provenance chips in Runs**
[editor_full_refresh_button_and_run_provenance_chips.mp4](https://cursor.com/agents/bc-2019eb89-2e2e-49be-bec5-895111ad5b88/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Feditor_full_refresh_button_and_run_provenance_chips.mp4)

**Wave 1 demo (agent full-refresh on dev + prod refusal)**
[agent_full_refresh_dev_success_and_prod_guard_refusal.mp4](https://cursor.com/agents/bc-2019eb89-2e2e-49be-bec5-895111ad5b88/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_full_refresh_dev_success_and_prod_guard_refusal.mp4)

## Testing

- ✅ `pnpm --filter api run test:dbt` (219 tests: 217 passed, 2 skipped)
- ✅ `pnpm --filter api run lint` / `pnpm --filter api run build`
- ✅ `pnpm --filter app run typecheck` / `pnpm --filter app run lint`
- ✅ App unit tests (`dbt-env`, `dbt-node-selection`, `dbtStore`, `DbtFileEditor`, 95 tests)
- ✅ Terminal E2E: `PUT my-environment` set/validate/clear + list enrichment; DB verified after each GUI step (no personal env in solo; pref rows; `cloud_agent` provisioned only in multiplayer)
- ✅ GUI E2E: solo→dev and multiplayer→personal-env demos above, verified with video review

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2019eb89-2e2e-49be-bec5-895111ad5b88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2019eb89-2e2e-49be-bec5-895111ad5b88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

