### PR TITLE
guides: Ruby connection guides — clickhouse/bigquery (Batch 14)

### DIFF
--- a/content/guides/bigquery/connect-from-ruby.mdx
+++ b/content/guides/bigquery/connect-from-ruby.mdx
@@ -1,0 +1,168 @@
+---
+title: "How to Connect to BigQuery from Ruby"
+description: "Connect to Google BigQuery from Ruby with the official google-cloud-bigquery gem. Covers Application Default Credentials, the billing-vs-data project split, named and positional query parameters, the dataset location trap, and dry-run cost caps."
+database: "bigquery"
+category: "how-to"
+tags: ["bigquery", "ruby", "rails", "google-cloud-bigquery", "connection"]
+date: "2026-07-03"
+---
+
+BigQuery has no host, port, or connection string. It is a REST API you authenticate against with a Google Cloud identity, so "connecting" from Ruby means installing the client library and getting credentials right. There is one official gem, `google-cloud-bigquery`, and it handles auth, query execution, and result streaming. This guide covers the credential ladder, the two project fields people confuse, parameterized queries, and the cost controls you should set before running anything against real data.
+
+## The library
+
+| Library | Layer | When to use it | Version (as of July 2026) |
+|---|---|---|---|
+| `google-cloud-bigquery` | Official Google client | Everything: queries, loads, exports, table management | 1.64.0 |
+
+There is no ActiveRecord adapter worth recommending and no low-level driver to choose between. BigQuery is an API, not a wire-protocol database, so unlike PostgreSQL or MySQL there is no ecosystem of competing drivers. Use the official gem.
+
+## Installing
+
+```bash
+gem install google-cloud-bigquery
+```
+
+Or in a Gemfile:
+
+```ruby
+gem "google-cloud-bigquery", "~> 1.64"
+```
+
+No native extension, no client library to install. Authentication is the only setup step that takes any thought.
+
+## Authentication: the credential ladder
+
+The gem uses Application Default Credentials (ADC), the same mechanism every Google Cloud client library uses. It looks for credentials in this order:
+
+1. **`GOOGLE_APPLICATION_CREDENTIALS`** environment variable pointing at a service account JSON key file.
+2. **`gcloud auth application-default login`** credentials, for local development.
+3. **The attached service account**, when running on Google Cloud (GCE, Cloud Run, GKE). No key file needed, which is the recommended production setup.
+
+The simplest local path:
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+```
+
+Then in Ruby:
+
+```ruby
+require "google/cloud/bigquery"
+
+bigquery = Google::Cloud::Bigquery.new(project_id: "my-billing-project")
+
+results = bigquery.query "SELECT name, count FROM `my-data-project.census.names` LIMIT 10"
+results.each { |row| puts "#{row[:name]}: #{row[:count]}" }
+```
+
+You can also pass credentials explicitly instead of relying on the environment:
+
+```ruby
+bigquery = Google::Cloud::Bigquery.new(
+  project_id:  "my-billing-project",
+  credentials: "/path/to/service-account.json"
+)
+```
+
+On Google Cloud infrastructure, attach a service account to the workload and drop the key file entirely. Long-lived JSON keys are a security liability; avoid them where the platform can inject identity for you.
+
+## The billing project vs data project split
+
+This trips up almost everyone the first time. There are two separate project concepts:
+
+- **The billing project** is where the query runs and where the compute cost is charged. This is the `project_id` you pass when creating the client.
+- **The data project** is where the tables live. It appears in the fully qualified table name: `` `project.dataset.table` ``.
+
+They are often the same project, but they do not have to be. You can run a query billed to your project against a public dataset in `bigquery-public-data`. If you get a permissions error, check which project the failure refers to: you need `bigquery.jobs.create` on the billing project (the `roles/bigquery.jobUser` role) and `bigquery.tables.getData` on the data project (`roles/bigquery.dataViewer`). Missing either produces a permission denied that looks identical at first glance.
+
+## Parameterized queries
+
+BigQuery supports both named and positional parameters. Always parameterize user input; string interpolation into SQL is an injection risk here as everywhere.
+
+Named parameters:
+
+```ruby
+results = bigquery.query(
+  "SELECT name, count
+   FROM `bigquery-public-data.usa_names.usa_1910_2013`
+   WHERE state = @state AND number >= @min
+   ORDER BY count DESC LIMIT 20",
+  params: { state: "CA", min: 100 }
+)
+```
+
+Positional parameters use `?` and an array:
+
+```ruby
+results = bigquery.query(
+  "SELECT name FROM `proj.ds.people` WHERE age >= ? AND city = ?",
+  params: [21, "Zurich"]
+)
+```
+
+For a NULL value where BigQuery cannot infer the type, pass the type explicitly with the `types` option so the parameter binds correctly rather than erroring on ambiguous type.
+
+## The dataset location trap
+
+BigQuery datasets are created in a specific location (`US`, `EU`, `asia-northeast1`, and so on), and a query only sees datasets in the location it runs in. If your dataset is in `EU` and your query runs in the default `US`, BigQuery reports that the table was **not found**, which reads like a typo or a permissions problem but is actually a location mismatch.
+
+Set the location explicitly when it is not the default:
+
+```ruby
+results = bigquery.query(
+  "SELECT * FROM `proj.eu_dataset.sales` LIMIT 100",
+  location: "EU"
+)
+```
+
+If a table you know exists returns "not found," check the dataset location before anything else.
+
+## Controlling cost: dry run and byte caps
+
+BigQuery bills by bytes scanned, and a careless `SELECT *` on a large partitioned table can scan terabytes. Two controls prevent surprise bills.
+
+A dry run estimates bytes scanned without running the query or incurring cost:
+
+```ruby
+job = bigquery.query_job(
+  "SELECT * FROM `proj.ds.events`",
+  dryrun: true
+)
+puts "Would scan #{job.bytes_processed} bytes"
+```
+
+A byte cap makes the query fail rather than run if it would scan more than a limit you set:
+
+```ruby
+results = bigquery.query(
+  "SELECT * FROM `proj.ds.events` WHERE event_date = '2026-07-03'",
+  maximum_bytes_billed: 10 * 1024**3   # fail if it would scan more than 10 GB
+)
+```
+
+Setting `maximum_bytes_billed` on queries that run against user-controlled input or large tables is cheap insurance. Combine it with partition filters so you scan only the days you need.
+
+## Large result sets
+
+`bigquery.query` loads results into memory. For large results, page through them or read from the destination table. The gem returns a paginated data object, so iterate with `results.all` (which fetches subsequent pages automatically) rather than assuming a single page holds everything:
+
+```ruby
+results.all do |row|
+  process(row)
+end
+```
+
+## Common errors
+
+| Error / symptom | Likely cause |
+|---|---|
+| Table "not found" but it exists | Dataset is in a different location than the query is running in |
+| Permission denied on `jobs.create` | Missing `bigquery.jobUser` on the billing project |
+| Permission denied reading a table | Missing `bigquery.dataViewer` on the data project |
+| Could not load default credentials | No `GOOGLE_APPLICATION_CREDENTIALS`, no `gcloud` ADC login, no attached service account |
+| Query cost far higher than expected | No partition filter and no `maximum_bytes_billed` cap |
+
+For loading data into BigQuery, see our guides on [importing CSV to BigQuery](/guides/import-csv-to-bigquery) and [importing JSON to BigQuery](/guides/import-json-to-bigquery).
+
+Mako connects to BigQuery, PostgreSQL, ClickHouse, and more with AI-powered autocomplete. Try it free at mako.ai.

--- a/content/guides/clickhouse/connect-from-ruby.mdx
+++ b/content/guides/clickhouse/connect-from-ruby.mdx
@@ -1,0 +1,155 @@
+---
+title: "How to Connect to ClickHouse from Ruby"
+description: "Connect to ClickHouse from Ruby over the HTTP interface with click_house, the clickhouse gem, or clickhouse-activerecord for Rails. Covers the 8123-vs-9000 port trap, parameterized queries, batch inserts, and async_insert durability."
+database: "clickhouse"
+category: "how-to"
+tags: ["clickhouse", "ruby", "rails", "click_house", "clickhouse-activerecord", "connection"]
+date: "2026-07-03"
+---
+
+Ruby talks to ClickHouse over the HTTP interface, not a native binary protocol. There is no libpq-style C driver here, so every Ruby option is a wrapper around HTTP requests to the ClickHouse server. That single fact explains the most common connection failure, the way parameters are passed, and why inserts need batching. This guide covers the three libraries worth knowing, the port trap that catches almost everyone, and the settings that matter in production.
+
+## The options
+
+| Library | Layer | When to use it | Version (as of July 2026) |
+|---|---|---|---|
+| `click_house` | HTTP client with type casting | Scripts and services wanting typed results and a clean query API | 2.1.2 |
+| `clickhouse` | HTTP client (bundles a CLI and web UI) | Direct HTTP querying, plus optional tooling | 0.1.10 |
+| `clickhouse-activerecord` | ActiveRecord adapter | Rails apps (Rails >= 7.1, ClickHouse 22.0 LTS and later) | 1.6.7 |
+
+`click_house` (from `github.com/shlima/click_house`) is a focused HTTP client that maps ClickHouse types to Ruby types for you, which is the part you would otherwise write by hand. `clickhouse-activerecord` (from PNixx) lets Rails models, migrations, and queries target ClickHouse, at the cost of the usual ORM abstraction over an analytical database that does not behave like PostgreSQL. GitLab also maintains a `ClickHouse::Client` gem used internally, if you prefer their HTTP wrapper.
+
+Whichever you pick, you are sending SQL over HTTP. The driver-level concerns below apply to all of them.
+
+## Installing the driver
+
+```bash
+gem install click_house
+```
+
+Or in a Gemfile:
+
+```ruby
+gem "click_house", "~> 2.1"
+```
+
+There is no native extension to compile and no ClickHouse client library to install, because everything goes over HTTP. That makes ClickHouse one of the easier databases to reach from Ruby.
+
+## The port trap (read this first)
+
+This is the single most common ClickHouse connection mistake, in every language, and Ruby is no exception.
+
+ClickHouse listens on two different ports for two different protocols:
+
+- **8123** is the HTTP interface. This is what Ruby drivers use.
+- **9000** is the native TCP protocol, used by `clickhouse-client` (the command-line tool) and native drivers in other languages.
+
+If you point a Ruby HTTP client at 9000, the connection either hangs or returns an unreadable error, because you are speaking HTTP to a socket expecting the native binary protocol. Always use **8123** for plaintext HTTP and **8443** for HTTPS (which is what ClickHouse Cloud requires). If a connection "just won't work" and the credentials are right, check the port before anything else.
+
+## Connecting
+
+```ruby
+require "click_house"
+
+client = ClickHouse::Connection.new(
+  ClickHouse::Config.new.tap do |c|
+    c.scheme   = "http"
+    c.host     = "localhost"
+    c.port     = 8123          # HTTP interface, not 9000
+    c.database = "analytics"
+    c.username = "default"
+    c.password = ENV.fetch("CLICKHOUSE_PASSWORD")
+  end
+)
+
+rows = client.select_all("SELECT version()")
+puts rows.to_a
+```
+
+The client does not open a persistent socket the way a PostgreSQL driver does. Each query is an HTTP request, so there is no long-lived connection to keep alive or pool in the traditional sense. Reuse the client object across requests to benefit from keep-alive on the underlying HTTP connection.
+
+For ClickHouse Cloud or any TLS endpoint:
+
+```ruby
+c.scheme = "https"
+c.port   = 8443
+```
+
+## Parameterized queries
+
+ClickHouse supports server-side query parameters using its own `{name:Type}` syntax, where the type is part of the placeholder. This is not the `?` or `$1` style you see in other databases, and getting the type wrong produces a parse error rather than a silent coercion.
+
+```ruby
+rows = client.select_all(
+  "SELECT event, count() AS c
+   FROM events
+   WHERE user_id = {uid:UInt64}
+     AND event_date >= {since:Date}
+   GROUP BY event",
+  params: { uid: 42, since: "2026-01-01" }
+)
+```
+
+Always parameterize values that come from user input. String interpolation into ClickHouse SQL is an injection risk just as it is anywhere else, and it also loses the type checking that the `{name:Type}` form gives you.
+
+## Inserting data: batch, do not drip
+
+ClickHouse is built around large, infrequent inserts. Its MergeTree storage engine creates a new data "part" on disk for every insert statement, and merges parts in the background. If you insert one row at a time in a loop, you generate thousands of tiny parts and quickly hit the `TOO_MANY_PARTS` error, which blocks further inserts until merges catch up.
+
+Insert in batches instead:
+
+```ruby
+rows = [
+  { user_id: 1, event: "click", event_date: "2026-07-03" },
+  { user_id: 2, event: "view",  event_date: "2026-07-03" },
+  # ... thousands more
+]
+
+client.insert("events", columns: %i[user_id event event_date], values: rows.map(&:values))
+```
+
+Aim for batches of thousands to tens of thousands of rows per insert, not single rows. If your data arrives one row at a time, buffer it in the application and flush periodically.
+
+### async_insert for high-frequency writes
+
+If batching in the application is impractical, ClickHouse can buffer small inserts server-side with `async_insert`:
+
+```ruby
+client.execute(
+  "INSERT INTO events (user_id, event, event_date) VALUES",
+  body: payload,
+  settings: { async_insert: 1, wait_for_async_insert: 1 }
+)
+```
+
+`async_insert: 1` lets the server accumulate rows from many small inserts into larger parts. The `wait_for_async_insert` setting is the durability tradeoff: set to `1` and the call waits until the buffer is flushed to disk (safer, slower); set to `0` and the call returns as soon as the row is buffered in memory (faster, but a crash before flush loses the row). Choose based on whether you can tolerate losing recent rows.
+
+## Rails with clickhouse-activerecord
+
+For Rails, `clickhouse-activerecord` adds a `clickhouse` adapter. Configure it in `config/database.yml`:
+
+```yaml
+production:
+  adapter: clickhouse
+  host: <%= ENV["CLICKHOUSE_HOST"] %>
+  port: 8123
+  database: analytics
+  username: default
+  password: <%= ENV["CLICKHOUSE_PASSWORD"] %>
+```
+
+Treat this adapter with realistic expectations. ClickHouse is a columnar analytical database with no row-level updates or deletes in the transactional sense, no foreign keys, and eventual consistency on merges. ActiveRecord conventions that assume an OLTP database (per-row `save`, `update`, associations that fan out into many small queries) map poorly onto it. The adapter works well for defining tables via migrations and running analytical reads through ActiveRecord's query interface. It is not a drop-in replacement for a PostgreSQL model layer, and you should not try to use it as one.
+
+## Common errors
+
+| Error / symptom | Likely cause |
+|---|---|
+| Connection hangs or "unexpected response" | Pointing an HTTP client at port 9000 (native) instead of 8123 |
+| `TOO_MANY_PARTS` | Inserting row-by-row; batch inserts or enable `async_insert` |
+| `Code: 62. Syntax error` on a parameter | Wrong type in `{name:Type}`, or using `?` / `$1` placeholder style |
+| TLS handshake failure against Cloud | Using `http`/8123 instead of `https`/8443 |
+| Slow first query after idle (Cloud) | Idle instance waking up; the request that triggers the wake is slow, retries are fast |
+
+For getting data into ClickHouse in the first place, see our guides on [importing CSV to ClickHouse](/guides/import-csv-to-clickhouse) and [importing JSON to ClickHouse](/guides/import-json-to-clickhouse).
+
+Mako connects to ClickHouse, PostgreSQL, MySQL, and more with AI-powered autocomplete. Try it free at mako.ai.


### PR DESCRIPTION
Continues Batch 14 (Ruby connection guides). Adds 2 more DBs, bringing Ruby to 6/9.

- `clickhouse/connect-from-ruby` — click_house 2.1.2 / clickhouse 0.1.10 / clickhouse-activerecord 1.6.7. HTTP-interface model, 8123-vs-9000 port trap, {name:Type} params, batch-insert + TOO_MANY_PARTS, async_insert durability tradeoff, Rails adapter with honest OLAP caveats.
- `bigquery/connect-from-ruby` — google-cloud-bigquery 1.64.0 (only official gem). ADC credential ladder, billing-vs-data project split, named + positional params, dataset-location "not found" trap, dry-run + maximum_bytes_billed cost caps.

Versions verified live via RubyGems API Jul 3. Content-only (2 .mdx files). Em-dash + banned-word clean.