### PR TITLE
fix(app): restore four-arrow intersection resize between side panes and editor split

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2,9 +2,12 @@ import {
   Suspense,
   useCallback,
   useEffect,
+  useLayoutEffect,
+  useMemo,
   useRef,
   useState,
   lazy,
+  type CSSProperties,
 } from "react";
 import {
   Box,
@@ -31,7 +34,14 @@ import {
   useNavigate,
   useLocation,
 } from "react-router-dom";
+import {
+  Panel,
+  PanelGroup,
+  PanelResizeHandle,
+  type ImperativePanelGroupHandle,
+} from "react-resizable-panels";
 import { trackPageView } from "./lib/analytics";
+import { setIframeDragGuard } from "./lib/iframe-drag-guard";
 import Sidebar, {
   SidebarUserMenu,
   SidebarMobileExplorerNav,
@@ -41,7 +51,6 @@ import {
   CENTER_PANE_MIN_WIDTH_PX,
   DEFAULT_LEFT_PANE_WIDTH_PX,
   DEFAULT_RIGHT_PANE_WIDTH_PX,
-  SIDE_PANEL_COLLAPSE_THRESHOLD_PX,
   SIDE_PANEL_MAX_WIDTH_PX,
   SIDE_PANEL_MIN_WIDTH_PX,
   useUIStore,
@@ -84,21 +93,33 @@ import { useAuth } from "./contexts/auth-context";
 import { OnboardingFlow } from "./components/OnboardingFlow";
 import { UpdateNotification } from "./components/UpdateNotification";
 
-// Draggable divider between a fixed-width side pane and the flexible center.
-// Resizing changes the side pane's pixel width directly (not a percentage),
-// so side panes stay a fixed width and only the center pane flexes.
-const ResizeDivider = styled("div")(({ theme }) => ({
+// Draggable divider between a side pane and the flexible center. A real
+// react-resizable-panels handle so it participates in the library's global
+// handle registry: where it crosses a perpendicular handle (the editor/results
+// split), hovering shows the four-arrow "move" cursor and dragging resizes
+// both panes at once.
+const SideResizeHandle = styled(PanelResizeHandle)(({ theme }) => ({
   flex: "0 0 4px",
   width: "4px",
   alignSelf: "stretch",
   background: theme.palette.divider,
-  cursor: "col-resize",
   touchAction: "none",
   transition: "background-color 0.2s ease",
-  "&:hover": {
+  // The library flags hover/drag via a data attribute (it extends beyond the
+  // 4px strip through hit-area margins), so key the highlight off that.
+  "&[data-resize-handle-state='hover'], &[data-resize-handle-state='drag']": {
     backgroundColor: theme.palette.primary.main,
   },
 }));
+
+// Collapse a divider entirely while its side pane is closed.
+const HIDDEN_HANDLE_STYLE: CSSProperties = {
+  flex: "0 0 0px",
+  width: 0,
+  minWidth: 0,
+  opacity: 0,
+  pointerEvents: "none",
+};
 
 // Component for the invite page route
 function InvitePage() {
@@ -122,8 +143,6 @@ import { UrlSync } from "./components/UrlSync";
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
 }
-
-type SidePane = "left" | "right";
 
 /**
  * User identity + active workspace shown in the mobile explorer drawer header.
@@ -175,7 +194,9 @@ function MainApp() {
   const activeTabId = useConsoleStore(state => state.activeTabId);
   const requestReveal = useExplorerRevealStore(state => state.requestReveal);
   const rightPaneOpen = useUIStore(state => state.rightPaneOpen);
+  const openLeftPane = useUIStore(state => state.openLeftPane);
   const closeLeftPane = useUIStore(state => state.closeLeftPane);
+  const openRightPane = useUIStore(state => state.openRightPane);
   const closeRightPane = useUIStore(state => state.closeRightPane);
   const leftPaneWidthPx = useUIStore(state => state.leftPaneWidthPx);
   const rightPaneWidthPx = useUIStore(state => state.rightPaneWidthPx);
@@ -202,19 +223,20 @@ function MainApp() {
   }, [activeTabId, isMobile, setMobileTab, closeMobileDrawer]);
 
   const panelContainerRef = useRef<HTMLDivElement | null>(null);
-  const leftPaneElRef = useRef<HTMLDivElement | null>(null);
-  const rightPaneElRef = useRef<HTMLDivElement | null>(null);
+  const groupRef = useRef<ImperativePanelGroupHandle | null>(null);
 
   // Side panes have a FIXED pixel width. Only the center pane flexes to fill
   // the remaining space, so resizing the window never changes the side panes —
-  // it only grows/shrinks the center (Slack/Cursor behavior). The width is a
-  // local px value, seeded from (and persisted back to) the UI store.
-  const [leftWidth, setLeftWidth] = useState(() =>
+  // it only grows/shrinks the center (Slack/Cursor behavior). react-resizable-
+  // panels is percentage-based, so we keep the source of truth in px (refs +
+  // the UI store) and translate: px → % when (re)applying layout, % → px when
+  // the user drags a handle.
+  const leftWidthRef = useRef(
     leftPaneWidthPx && leftPaneWidthPx > 0
       ? clamp(leftPaneWidthPx, SIDE_PANEL_MIN_WIDTH_PX, SIDE_PANEL_MAX_WIDTH_PX)
       : DEFAULT_LEFT_PANE_WIDTH_PX,
   );
-  const [rightWidth, setRightWidth] = useState(() =>
+  const rightWidthRef = useRef(
     rightPaneWidthPx && rightPaneWidthPx > 0
       ? clamp(
           rightPaneWidthPx,
@@ -224,147 +246,141 @@ function MainApp() {
       : DEFAULT_RIGHT_PANE_WIDTH_PX,
   );
 
-  // Mirror widths into refs so the drag handler reads fresh values without
-  // being re-created on every width change.
-  const leftWidthRef = useRef(leftWidth);
-  const rightWidthRef = useRef(rightWidth);
-  leftWidthRef.current = leftWidth;
-  rightWidthRef.current = rightWidth;
-
-  // Keep local widths in sync if the persisted store value changes elsewhere.
-  useEffect(() => {
-    if (leftPaneWidthPx && leftPaneWidthPx > 0) {
-      setLeftWidth(
-        clamp(
-          leftPaneWidthPx,
-          SIDE_PANEL_MIN_WIDTH_PX,
-          SIDE_PANEL_MAX_WIDTH_PX,
-        ),
-      );
-    }
-  }, [leftPaneWidthPx]);
-  useEffect(() => {
-    if (rightPaneWidthPx && rightPaneWidthPx > 0) {
-      setRightWidth(
-        clamp(
-          rightPaneWidthPx,
-          SIDE_PANEL_MIN_WIDTH_PX,
-          SIDE_PANEL_MAX_WIDTH_PX,
-        ),
-      );
-    }
-  }, [rightPaneWidthPx]);
-
-  // Begin a manual drag-resize of a side pane. The new width is applied
-  // imperatively to the pane element during the drag (so heavy children like
-  // the editor/chat don't re-render on every pointer move), then committed to
-  // React state + the store on release.
-  const beginResize = useCallback(
-    (side: SidePane, e: React.PointerEvent<HTMLDivElement>) => {
-      e.preventDefault();
-
-      // Capture the pointer so move/up events keep flowing to the divider even
-      // when the cursor crosses an iframe (e.g. the app preview), which would
-      // otherwise swallow them and freeze the drag.
-      const divider = e.currentTarget;
-      try {
-        divider.setPointerCapture(e.pointerId);
-      } catch {
-        // Pointer may already be gone (e.g. released between events).
-      }
-
-      // Belt-and-suspenders for browsers with flaky pointer capture across
-      // (cross-origin) iframes: make iframes transparent to pointer events
-      // for the duration of the drag.
-      const iframes = Array.from(document.querySelectorAll("iframe"));
-      const savedPointerEvents = iframes.map(f => f.style.pointerEvents);
-      iframes.forEach(f => {
-        f.style.pointerEvents = "none";
-      });
-      const restoreIframes = () => {
-        iframes.forEach((f, i) => {
-          f.style.pointerEvents = savedPointerEvents[i];
-        });
-      };
-
-      const container = panelContainerRef.current;
-      const containerWidth = container
-        ? container.clientWidth
-        : window.innerWidth;
-      const startX = e.clientX;
-      const startWidth =
-        side === "left" ? leftWidthRef.current : rightWidthRef.current;
-      const otherWidth =
-        side === "left"
-          ? rightPaneOpen
-            ? rightWidthRef.current
-            : 0
-          : leftPaneOpen
-            ? leftWidthRef.current
-            : 0;
-
-      // Cap so the center pane keeps a usable minimum width.
-      const maxWidth = Math.max(
-        SIDE_PANEL_MIN_WIDTH_PX,
-        Math.min(
-          SIDE_PANEL_MAX_WIDTH_PX,
-          containerWidth - otherWidth - CENTER_PANE_MIN_WIDTH_PX - 8,
-        ),
-      );
-
-      const el =
-        side === "left" ? leftPaneElRef.current : rightPaneElRef.current;
-      let finalWidth = startWidth;
-      let shouldCollapse = false;
-
-      const onMove = (ev: PointerEvent) => {
-        const delta = ev.clientX - startX;
-        const raw = side === "left" ? startWidth + delta : startWidth - delta;
-        shouldCollapse = raw < SIDE_PANEL_COLLAPSE_THRESHOLD_PX;
-        if (shouldCollapse) {
-          finalWidth = 0;
-          if (el) el.style.width = "0px";
-          return;
-        }
-
-        finalWidth = clamp(raw, SIDE_PANEL_MIN_WIDTH_PX, maxWidth);
-        if (el) el.style.width = `${finalWidth}px`;
-      };
-
-      const onUp = () => {
-        window.removeEventListener("pointermove", onMove);
-        window.removeEventListener("pointerup", onUp);
-        window.removeEventListener("pointercancel", onUp);
-        restoreIframes();
-        document.body.style.cursor = "";
-        document.body.style.userSelect = "";
-
-        if (shouldCollapse) {
-          if (side === "left") {
-            closeLeftPane();
-          } else {
-            closeRightPane();
-          }
-          return;
-        }
-
-        if (side === "left") {
-          setLeftWidth(finalWidth);
-          setPaneWidths({ leftPaneWidthPx: finalWidth });
-        } else {
-          setRightWidth(finalWidth);
-          setPaneWidths({ rightPaneWidthPx: finalWidth });
-        }
-      };
-
-      document.body.style.cursor = "col-resize";
-      document.body.style.userSelect = "none";
-      window.addEventListener("pointermove", onMove);
-      window.addEventListener("pointerup", onUp);
-      window.addEventListener("pointercancel", onUp);
-    },
-    [closeLeftPane, closeRightPane, leftPaneOpen, rightPaneOpen, setPaneWidths],
+  // Container width drives all px↔% conversions. Seeded with an estimate so
+  // the first paint is close; the ResizeObserver below corrects it.
+  const [containerWidth, setContainerWidth] = useState(() =>
+    typeof window === "undefined" ? 1200 : Math.max(window.innerWidth - 52, 1),
   );
+  const containerWidthRef = useRef(containerWidth);
+  containerWidthRef.current = containerWidth;
+
+  const openFlagsRef = useRef({ left: leftPaneOpen, right: rightPaneOpen });
+  openFlagsRef.current = { left: leftPaneOpen, right: rightPaneOpen };
+
+  // Compute the full [left, center, right] percentage layout from the px
+  // widths, honoring closed (collapsed to 0) panes.
+  const computeLayoutPct = useCallback((width: number): number[] => {
+    const { left, right } = openFlagsRef.current;
+    const leftPct = left ? (leftWidthRef.current / width) * 100 : 0;
+    const rightPct = right ? (rightWidthRef.current / width) * 100 : 0;
+    return [leftPct, Math.max(100 - leftPct - rightPct, 0), rightPct];
+  }, []);
+
+  // Keep side panes at their fixed px width when the container resizes: the
+  // library would otherwise scale all panels proportionally. A callback ref
+  // (rather than a mount effect) attaches the observer, because AuthWrapper
+  // gates the children — the container div doesn't exist on first commit.
+  const containerObserverRef = useRef<ResizeObserver | null>(null);
+  const attachPanelContainer = useCallback((el: HTMLDivElement | null) => {
+    panelContainerRef.current = el;
+    containerObserverRef.current?.disconnect();
+    containerObserverRef.current = null;
+    if (!el) return;
+    const observer = new ResizeObserver(entries => {
+      const width = entries[0]?.contentRect.width ?? 0;
+      if (width > 0) setContainerWidth(width);
+    });
+    observer.observe(el);
+    containerObserverRef.current = observer;
+  }, []);
+  // Re-apply the px-derived layout after the width state commits, so the
+  // min/max percentage constraints derived from it are already up to date.
+  useLayoutEffect(() => {
+    if (containerWidth <= 0) return;
+    groupRef.current?.setLayout(computeLayoutPct(containerWidth));
+  }, [containerWidth, computeLayoutPct]);
+
+  // Persist px widths (debounced) as the user drags a handle.
+  const persistTimeoutRef = useRef<number | null>(null);
+  useEffect(() => {
+    return () => {
+      if (persistTimeoutRef.current) {
+        window.clearTimeout(persistTimeoutRef.current);
+      }
+    };
+  }, []);
+  const handleGroupLayout = useCallback(
+    (sizes: number[]) => {
+      const width = containerWidthRef.current;
+      if (width <= 0 || sizes.length !== 3) return;
+      const [leftPct, , rightPct] = sizes;
+      if (leftPct > 0) leftWidthRef.current = (leftPct * width) / 100;
+      if (rightPct > 0) rightWidthRef.current = (rightPct * width) / 100;
+
+      if (persistTimeoutRef.current) {
+        window.clearTimeout(persistTimeoutRef.current);
+      }
+      persistTimeoutRef.current = window.setTimeout(() => {
+        const updates: {
+          leftPaneWidthPx?: number;
+          rightPaneWidthPx?: number;
+        } = {};
+        if (leftPct > 0) updates.leftPaneWidthPx = leftWidthRef.current;
+        if (rightPct > 0) updates.rightPaneWidthPx = rightWidthRef.current;
+        if (Object.keys(updates).length > 0) {
+          setPaneWidths(updates);
+        }
+      }, 200);
+    },
+    [setPaneWidths],
+  );
+
+  // Re-apply the layout when the open flags change elsewhere (sidebar
+  // toggles, chat close button, ...): computeLayoutPct collapses closed panes
+  // to 0 and restores open ones to their remembered px width. Dragging a pane
+  // below the collapse threshold collapses it via the library, which flips
+  // the flag through onCollapse and keeps both in sync.
+  useEffect(() => {
+    groupRef.current?.setLayout(
+      computeLayoutPct(Math.max(containerWidthRef.current, 1)),
+    );
+  }, [leftPaneOpen, rightPaneOpen, computeLayoutPct]);
+
+  // While dragging, make iframes (e.g. the app preview) transparent to
+  // pointer events so they don't swallow the drag mid-flight. Also snapshot
+  // the pane widths so a drag-to-collapse can restore the pre-drag width
+  // (dragging past the minimum would otherwise leave the remembered width at
+  // the minimum, and the pane would reopen tiny).
+  const dragSnapshotRef = useRef<{ left: number; right: number } | null>(null);
+  const snapshotClearTimeoutRef = useRef<number | null>(null);
+  const handleDividerDragging = useCallback((isDragging: boolean) => {
+    setIframeDragGuard(isDragging);
+    if (snapshotClearTimeoutRef.current) {
+      window.clearTimeout(snapshotClearTimeoutRef.current);
+      snapshotClearTimeoutRef.current = null;
+    }
+    if (isDragging) {
+      dragSnapshotRef.current = {
+        left: leftWidthRef.current,
+        right: rightWidthRef.current,
+      };
+    } else {
+      // Clear on the next macrotask: the panel onCollapse callback fires from
+      // a React effect that may commit *after* the pointerup, and it needs
+      // the snapshot to restore the pre-drag width.
+      snapshotClearTimeoutRef.current = window.setTimeout(() => {
+        dragSnapshotRef.current = null;
+        snapshotClearTimeoutRef.current = null;
+      }, 0);
+    }
+  }, []);
+
+  const handleLeftCollapse = useCallback(() => {
+    const snapshot = dragSnapshotRef.current;
+    if (snapshot) leftWidthRef.current = snapshot.left;
+    closeLeftPane();
+  }, [closeLeftPane]);
+  const handleRightCollapse = useCallback(() => {
+    const snapshot = dragSnapshotRef.current;
+    if (snapshot) rightWidthRef.current = snapshot.right;
+    closeRightPane();
+  }, [closeRightPane]);
+
+  // px-based panel constraints expressed as percentages of the container.
+  const sideMinPct = (SIDE_PANEL_MIN_WIDTH_PX / containerWidth) * 100;
+  const sideMaxPct = (SIDE_PANEL_MAX_WIDTH_PX / containerWidth) * 100;
+  const centerMinPct = (CENTER_PANE_MIN_WIDTH_PX / containerWidth) * 100;
+  const defaultLayout = computeLayoutPct(containerWidth);
 
   // Ref for DbFlowForm - allows AI agent to manipulate form state
   const dbFlowFormRef = useRef<DbFlowFormRef | null>(null);
@@ -526,8 +542,10 @@ function MainApp() {
     }
   }, [activeTabId, requestReveal]);
 
-  // Left pane content renderer
-  const renderLeftPane = () => {
+  // Left pane content. Memoized (like the editor/chat elements below) so
+  // PanelGroup re-renders during a divider drag reuse the same element and
+  // React bails out of re-rendering the heavy explorer subtree.
+  const leftPaneContent = useMemo(() => {
     switch (activeView) {
       case "databases":
         return (
@@ -550,7 +568,31 @@ function MainApp() {
       default:
         return null;
     }
-  };
+  }, [activeView, handleDatabaseCollectionClick, handleConsoleSelect]);
+
+  // Stable elements for the heavy center/right panes. All props are refs, so
+  // these never need to be re-created; identical element references let React
+  // skip re-rendering Editor/Chat on every layout change while dragging.
+  const editorElement = useMemo(
+    () => (
+      <Editor
+        dbFlowFormRef={dbFlowFormRef}
+        onChartSpecChangeRef={onChartSpecChangeRef}
+        resultsContextRef={resultsContextRef}
+      />
+    ),
+    [],
+  );
+  const chatElement = useMemo(
+    () => (
+      <Chat
+        dbFlowFormRef={dbFlowFormRef}
+        onChartSpecChangeRef={onChartSpecChangeRef}
+        resultsContextRef={resultsContextRef}
+      />
+    ),
+    [],
+  );
 
   useEffect(() => {
     const win = window as Window & {
@@ -623,11 +665,7 @@ function MainApp() {
                 display: mobileTab === "ask" ? "block" : "none",
               }}
             >
-              <Chat
-                dbFlowFormRef={dbFlowFormRef}
-                onChartSpecChangeRef={onChartSpecChangeRef}
-                resultsContextRef={resultsContextRef}
-              />
+              {chatElement}
             </Box>
             <Box
               sx={{
@@ -639,11 +677,7 @@ function MainApp() {
                     : "none",
               }}
             >
-              <Editor
-                dbFlowFormRef={dbFlowFormRef}
-                onChartSpecChangeRef={onChartSpecChangeRef}
-                resultsContextRef={resultsContextRef}
-              />
+              {editorElement}
             </Box>
           </Box>
 
@@ -695,7 +729,7 @@ function MainApp() {
                     </Box>
                   }
                 >
-                  {renderLeftPane()}
+                  {leftPaneContent}
                 </Suspense>
               </Box>
             </Box>
@@ -758,28 +792,28 @@ function MainApp() {
         <Sidebar />
 
         <Box
-          ref={panelContainerRef}
-          sx={{
-            height: "100%",
-            flex: 1,
-            minWidth: 0,
-            display: "flex",
-            flexDirection: "row",
-          }}
+          ref={attachPanelContainer}
+          sx={{ height: "100%", flex: 1, minWidth: 0 }}
         >
-          {/* Left side pane — fixed pixel width, resizable by hand */}
-          {leftPaneOpen && (
-            <>
-              <Box
-                ref={leftPaneElRef}
-                style={{ width: leftWidth }}
-                sx={{
-                  flex: "0 0 auto",
-                  flexShrink: 0,
-                  height: "100%",
-                  overflow: "hidden",
-                }}
-              >
+          <PanelGroup
+            ref={groupRef}
+            direction="horizontal"
+            style={{ height: "100%", width: "100%" }}
+            onLayout={handleGroupLayout}
+          >
+            {/* Left side pane — fixed pixel width, resizable by hand */}
+            <Panel
+              id="left-pane"
+              order={1}
+              collapsible
+              collapsedSize={0}
+              defaultSize={leftPaneOpen ? defaultLayout[0] : 0}
+              minSize={sideMinPct}
+              maxSize={sideMaxPct}
+              onCollapse={handleLeftCollapse}
+              onExpand={openLeftPane}
+            >
+              <Box sx={{ height: "100%", overflow: "hidden" }}>
                 <Suspense
                   fallback={
                     <Box
@@ -794,49 +828,55 @@ function MainApp() {
                     </Box>
                   }
                 >
-                  {renderLeftPane()}
+                  {leftPaneContent}
                 </Suspense>
               </Box>
-              <ResizeDivider onPointerDown={e => beginResize("left", e)} />
-            </>
-          )}
+            </Panel>
 
-          {/* Center (main content) — flexes to fill remaining space */}
-          <Box
-            data-mako-main-content="true"
-            sx={{ flex: "1 1 0", minWidth: 0, height: "100%" }}
-          >
-            <Editor
-              dbFlowFormRef={dbFlowFormRef}
-              onChartSpecChangeRef={onChartSpecChangeRef}
-              resultsContextRef={resultsContextRef}
+            <SideResizeHandle
+              onDragging={handleDividerDragging}
+              style={leftPaneOpen ? undefined : HIDDEN_HANDLE_STYLE}
             />
-          </Box>
 
-          {/* Right side pane (chat) — fixed pixel width, resizable by hand */}
-          {rightPaneOpen && (
-            <>
-              <ResizeDivider onPointerDown={e => beginResize("right", e)} />
+            {/* Center (main content) — flexes to fill remaining space */}
+            <Panel id="center-pane" order={2} minSize={centerMinPct}>
               <Box
-                ref={rightPaneElRef}
-                style={{ width: rightWidth }}
+                data-mako-main-content="true"
+                sx={{ height: "100%", minWidth: 0 }}
+              >
+                {editorElement}
+              </Box>
+            </Panel>
+
+            <SideResizeHandle
+              onDragging={handleDividerDragging}
+              style={rightPaneOpen ? undefined : HIDDEN_HANDLE_STYLE}
+            />
+
+            {/* Right side pane (chat) — fixed pixel width, resizable by hand */}
+            <Panel
+              id="right-pane"
+              order={3}
+              collapsible
+              collapsedSize={0}
+              defaultSize={rightPaneOpen ? defaultLayout[2] : 0}
+              minSize={sideMinPct}
+              maxSize={sideMaxPct}
+              onCollapse={handleRightCollapse}
+              onExpand={openRightPane}
+            >
+              <Box
                 sx={{
-                  flex: "0 0 auto",
-                  flexShrink: 0,
                   height: "100%",
                   overflow: "hidden",
                   borderLeft: "1px solid",
                   borderColor: "divider",
                 }}
               >
-                <Chat
-                  dbFlowFormRef={dbFlowFormRef}
-                  onChartSpecChangeRef={onChartSpecChangeRef}
-                  resultsContextRef={resultsContextRef}
-                />
+                {chatElement}
               </Box>
-            </>
-          )}
+            </Panel>
+          </PanelGroup>
         </Box>
       </Box>
       <DbtProjectDrawersHost />

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -103,6 +103,7 @@ import { useSqlAutocomplete } from "../hooks/useSqlAutocomplete";
 import { useIsMobile } from "../hooks/useIsMobile";
 import { trackEvent } from "../lib/analytics";
 import { getApiBasePath } from "../lib/api-base-path";
+import { setIframeDragGuard } from "../lib/iframe-drag-guard";
 import { consoleLeafName } from "../lib/console-name";
 import { generateObjectId } from "../utils/objectId";
 import {
@@ -153,9 +154,10 @@ interface TabPaginationState {
 const StyledVerticalResizeHandle = styled(PanelResizeHandle)(({ theme }) => ({
   height: "4px",
   background: theme.palette.divider,
-  cursor: "row-resize",
   transition: "background-color 0.2s ease",
-  "&:hover": {
+  // The library flags hover/drag via a data attribute (its hit area extends
+  // beyond the 4px strip), so key the highlight off that instead of :hover.
+  "&[data-resize-handle-state='hover'], &[data-resize-handle-state='drag']": {
     backgroundColor: theme.palette.primary.main,
   },
 }));
@@ -2807,7 +2809,9 @@ function Editor({
                             {consolePane}
                           </Panel>
 
-                          <StyledVerticalResizeHandle />
+                          <StyledVerticalResizeHandle
+                            onDragging={setIframeDragGuard}
+                          />
 
                           <Panel defaultSize={40} minSize={1}>
                             {resultsPane}

--- a/app/src/lib/iframe-drag-guard.ts
+++ b/app/src/lib/iframe-drag-guard.ts
@@ -1,0 +1,34 @@
+/**
+ * While a pane divider drag is active, make every iframe transparent to
+ * pointer events. Cross-origin iframes (e.g. the sandboxed app preview)
+ * otherwise swallow pointermove/pointerup once the cursor crosses them,
+ * freezing the drag mid-flight.
+ *
+ * Reference-counted so overlapping drags (e.g. an intersection drag that
+ * activates a horizontal and a vertical handle at once) restore styles only
+ * after the last one ends.
+ */
+
+let activeDrags = 0;
+let savedStyles: Array<[HTMLIFrameElement, string]> = [];
+
+export function setIframeDragGuard(active: boolean): void {
+  if (active) {
+    activeDrags += 1;
+    if (activeDrags > 1) return;
+    savedStyles = Array.from(document.querySelectorAll("iframe")).map(frame => [
+      frame,
+      frame.style.pointerEvents,
+    ]);
+    for (const [frame] of savedStyles) {
+      frame.style.pointerEvents = "none";
+    }
+  } else {
+    activeDrags = Math.max(0, activeDrags - 1);
+    if (activeDrags > 0) return;
+    for (const [frame, previous] of savedStyles) {
+      frame.style.pointerEvents = previous;
+    }
+    savedStyles = [];
+  }
+}


### PR DESCRIPTION
## Summary

Hovering the T-junction where a side-pane divider meets the editor/results split used to show the four-arrow `move` cursor and let you resize both panes with one drag. That is a native `react-resizable-panels` feature that only works between the library's own handles — the flexbox rework in #426 replaced the horizontal `PanelGroup` in `App.tsx` with hand-rolled dividers, which dropped them from the library's global handle registry and silently killed the intersection behavior.

- Rebuild the desktop shell on a horizontal `PanelGroup` so the side dividers are real `PanelResizeHandle`s again; the intersection cursor + dual-axis drag work at both junctions (explorer ↔ editor/results and editor/results ↔ chat).
- Keep the fixed-pixel side-pane behavior from #426: px widths remain the source of truth (refs + persisted UI store), and a `ResizeObserver` re-applies the layout on container resize so side panes hold their width and only the center flexes.
- Open/close flags (`leftPaneOpen`/`rightPaneOpen`) sync both ways: sidebar toggles re-apply the layout via `setLayout`, drag-to-collapse flips the flag through `onCollapse`, and a drag-start width snapshot ensures a collapsed pane reopens at its pre-drag width instead of the minimum.
- Memoize the `Editor`, `Chat`, and explorer elements so the panel group re-rendering on every drag frame doesn't re-render those heavy subtrees (preserves the perf motivation behind #426).
- Move the iframe pointer-events guard (from 42be7c46, keeps drags alive over the app-preview iframe) to a shared `lib/iframe-drag-guard.ts` wired to all handles via `onDragging`, and switch handle hover highlights to the library's `data-resize-handle-state` attribute so the full hit area highlights.

## Test plan

- [x] Hovering either T-junction shows the `move` cursor; dragging there resizes the side pane and the editor/results split simultaneously (verified via injected pointer events: both handles enter the `drag` state and both layouts change)
- [x] Window resize keeps side panes at fixed px width; only the center flexes (verified at 1000/1250/1400/1600 px viewports)
- [x] Widths persist across reloads via the UI store
- [x] Drag-to-collapse closes a pane and syncs the store flag; reopening from the sidebar restores the pre-drag width
- [x] `pnpm --filter app run typecheck` and `pnpm --filter app run lint` pass
- [ ] Manual check: drag a divider across an open app-preview iframe

Made with [Cursor](https://cursor.com)