### PR TITLE
feat(app): Cmd+K command palette + entity-icons single source of truth

### DIFF
--- a/.cursor/rules/17-entity-icons.mdc
+++ b/.cursor/rules/17-entity-icons.mdc
@@ -1,0 +1,46 @@
+---
+globs: app/src/lib/entity-icons.ts,app/src/components/Sidebar.tsx,app/src/components/Editor.tsx,app/src/components/CommandPalette.tsx,app/src/lib/command-palette/*.ts,app/src/components/*Explorer.tsx,app/src/components/ConsoleTree.tsx
+description: Entity icons single source of truth — never pick lucide icons ad hoc for explorers, tab kinds, or settings sections
+---
+
+# Entity icons: single source of truth
+
+Every icon that represents an *entity concept* — an explorer section
+(Consoles, Dashboards, Apps, ...), a tab kind, or a settings section — MUST
+come from [app/src/lib/entity-icons.ts](mdc:app/src/lib/entity-icons.ts):
+
+- `EXPLORER_ICONS: Record<LeftPaneView, LucideIcon>` — sidebar rail, "Go to
+  ..." commands, and anywhere a section is referenced.
+- `TAB_KIND_ICONS: Record<TabKind, LucideIcon>` / `tabKindIcon(kind)` — the
+  Editor tab bar, explorer entity rows, and command-palette results.
+- `SETTINGS_SECTION_ICONS: Record<SettingsSection, LucideIcon>` — the
+  settings explorer and settings commands.
+- `CHAT_ICON` — the chat pane toggle.
+
+Both records are exhaustive (`satisfies Record<...>`), so adding a
+`LeftPaneView`, `TabKind`, or `SettingsSection` without deciding its icon is
+a **compile error** — same regression-guard pattern as `tab-routing.ts`.
+
+## Rules
+
+1. Do NOT import an icon directly from `lucide-react` to represent one of
+   these concepts in a new surface. Import the map and index it. This is how
+   the sidebar and the command palette drifted apart in the first place
+   (three different "console" icons in three files).
+2. When a component needs a local alias for readability, derive it from the
+   map: `const AppIcon = TAB_KIND_ICONS.app;` — never re-pick from lucide.
+3. State-dependent icon *overrides* stay with their owners and are the only
+   exceptions: connector/connection favicon images (`tab.icon`,
+   `connectionIconUrl` in `Editor.tsx`) and flow-editor subtype icons
+   (webhook / paused / scheduled in `Editor.tsx` + `FlowsExplorer.tsx`).
+   The generic kind icon must still come from the map.
+4. Changing what an entity looks like = editing `entity-icons.ts` once. If
+   you find yourself changing an entity icon in a component file, stop and
+   move it to the map.
+
+## Adding a new tab kind or explorer
+
+Follow the checklist in
+[71-tab-entities.mdc](mdc:.cursor/rules/71-tab-entities.mdc); the icon step
+means adding one entry to `TAB_KIND_ICONS` (and `EXPLORER_ICONS` if it gets
+a sidebar rail entry). The compiler will remind you.

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -137,6 +137,7 @@ function InvitePage() {
 }
 
 import { UrlSync } from "./components/UrlSync";
+import CommandPalette from "./components/CommandPalette";
 
 // Main application component (extracted from original App)
 
@@ -640,6 +641,7 @@ function MainApp() {
     return (
       <AuthWrapper>
         <UrlSync />
+        <CommandPalette />
         <Box
           data-mako-app-shell="true"
           data-mako-mobile="true"
@@ -778,6 +780,7 @@ function MainApp() {
   return (
     <AuthWrapper>
       <UrlSync />
+      <CommandPalette />
       <Box
         data-mako-app-shell="true"
         sx={{

--- a/app/src/components/AppsExplorer.tsx
+++ b/app/src/components/AppsExplorer.tsx
@@ -17,7 +17,6 @@ import {
 import {
   Plus as AddIcon,
   RefreshCw as RefreshIcon,
-  AppWindow as AppIcon,
   FileCode as CodeFileIcon,
   FileText as TextFileIcon,
   File as PlainFileIcon,
@@ -37,7 +36,10 @@ import {
 } from "lucide-react";
 import { useAuth } from "../contexts/auth-context";
 import { useWorkspace } from "../contexts/workspace-context";
+import { TAB_KIND_ICONS } from "../lib/entity-icons";
 import { useConsoleStore } from "../store/consoleStore";
+
+const AppIcon = TAB_KIND_ICONS.app;
 import { useExplorerStore } from "../store/explorerStore";
 import {
   useExplorerRevealStore,

--- a/app/src/components/CommandPalette.tsx
+++ b/app/src/components/CommandPalette.tsx
@@ -1,0 +1,333 @@
+/**
+ * Command palette (Cmd/Ctrl+K).
+ *
+ * Default mode searches navigable entities (open tabs, consoles via the
+ * server search endpoint, dashboards, apps, dbt projects, flows) plus the
+ * top-matching commands. Typing `>` switches to commands-only mode
+ * (VS Code style). Built on MUI primitives — no extra dependencies.
+ */
+
+import {
+  Box,
+  CircularProgress,
+  Dialog,
+  InputBase,
+  Typography,
+} from "@mui/material";
+import { ChevronRight, Search } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useAuth } from "../contexts/auth-context";
+import { useTheme as useAppTheme } from "../contexts/ThemeContext";
+import { buildCommands } from "../lib/command-palette/commands";
+import {
+  consoleResultItems,
+  searchApps,
+  searchDashboards,
+  searchDbtProjects,
+  searchFlows,
+  searchOpenTabs,
+} from "../lib/command-palette/entity-search";
+import {
+  scoreItem,
+  type PaletteItem,
+  type PaletteRunContext,
+} from "../lib/command-palette/types";
+import { useAppStore } from "../store/appStore";
+import { useCommandPaletteStore } from "../store/commandPaletteStore";
+import { useDashboardTreeStore } from "../store/dashboardTreeStore";
+import { useDbtStore } from "../store/dbtStore";
+import { useFlowStore } from "../store/flowStore";
+import { useUIStore } from "../store/uiStore";
+
+const SEARCH_DEBOUNCE_MS = 200;
+
+type Row =
+  | { type: "header"; label: string }
+  | { type: "item"; item: PaletteItem; index: number };
+
+function groupIntoRows(items: PaletteItem[]): Row[] {
+  const rows: Row[] = [];
+  let lastSection: string | null = null;
+  items.forEach((item, index) => {
+    if (item.section !== lastSection) {
+      rows.push({ type: "header", label: item.section });
+      lastSection = item.section;
+    }
+    rows.push({ type: "item", item, index });
+  });
+  return rows;
+}
+
+export default function CommandPalette() {
+  const open = useCommandPaletteStore(state => state.open);
+  const consoleResults = useCommandPaletteStore(state => state.consoleResults);
+  const searching = useCommandPaletteStore(state => state.searching);
+  const workspaceId = useUIStore(state => state.currentWorkspaceId);
+  const { user } = useAuth();
+  const { setMode } = useAppTheme();
+
+  const [query, setQuery] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  // Last pointer position — selection follows the mouse only when it really
+  // moves, not when items re-render underneath a stationary cursor (the
+  // cmdk behavior). Null until the first move after opening.
+  const pointerRef = useRef<{ x: number; y: number } | null>(null);
+
+  const isSuperAdmin = Boolean(
+    (user as { isSuperAdmin?: boolean } | null | undefined)?.isSuperAdmin,
+  );
+  const commandMode = query.startsWith(">");
+  const effectiveQuery = (commandMode ? query.slice(1) : query).trim();
+
+  // Global Cmd/Ctrl+K binding (capture phase so it wins over Monaco).
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        event.stopPropagation();
+        useCommandPaletteStore.getState().togglePalette();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, []);
+
+  // Reset transient state and warm entity lists whenever the palette opens.
+  useEffect(() => {
+    if (!open || !workspaceId) return;
+    setQuery("");
+    setSelectedIndex(0);
+    pointerRef.current = null;
+    const swallow = () => undefined;
+    void useDashboardTreeStore.getState().fetchTree(workspaceId).catch(swallow);
+    void useAppStore.getState().fetchList(workspaceId).catch(swallow);
+    void useDbtStore.getState().fetchProjects(workspaceId).catch(swallow);
+    void useFlowStore.getState().fetchFlows(workspaceId).catch(swallow);
+  }, [open, workspaceId]);
+
+  // Debounced server-side console search (default mode only).
+  useEffect(() => {
+    if (!open || !workspaceId) return;
+    if (commandMode || effectiveQuery.length < 2) {
+      useCommandPaletteStore.getState().clearConsoleResults();
+      return;
+    }
+    const timeout = setTimeout(() => {
+      void useCommandPaletteStore
+        .getState()
+        .searchConsoles(workspaceId, effectiveQuery);
+    }, SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timeout);
+  }, [open, workspaceId, commandMode, effectiveQuery]);
+
+  const items = useMemo<PaletteItem[]>(() => {
+    if (!open || !workspaceId) return [];
+
+    const commands = buildCommands({ isSuperAdmin });
+    const scoredCommands = commands
+      .map(command => ({
+        command,
+        score: scoreItem(effectiveQuery, command.title, command.keywords),
+      }))
+      .filter(entry => entry.score > 0)
+      .sort((a, b) => b.score - a.score);
+
+    if (commandMode) {
+      return scoredCommands.map(entry => entry.command);
+    }
+
+    return [
+      ...searchOpenTabs(effectiveQuery),
+      // Surface a few command hits in default mode for discoverability.
+      ...scoredCommands
+        .slice(0, effectiveQuery ? 3 : 4)
+        .map(entry => entry.command),
+      ...(effectiveQuery.length >= 2
+        ? consoleResultItems(workspaceId, consoleResults)
+        : []),
+      ...searchDashboards(workspaceId, effectiveQuery),
+      ...searchApps(workspaceId, effectiveQuery),
+      ...searchDbtProjects(effectiveQuery),
+      ...searchFlows(workspaceId, effectiveQuery),
+    ];
+  }, [
+    open,
+    workspaceId,
+    commandMode,
+    effectiveQuery,
+    consoleResults,
+    isSuperAdmin,
+  ]);
+
+  const rows = useMemo(() => groupIntoRows(items), [items]);
+
+  // Clamp selection when the result set shrinks.
+  useEffect(() => {
+    setSelectedIndex(index => Math.min(index, Math.max(items.length - 1, 0)));
+  }, [items.length]);
+
+  // Keep the selected row visible.
+  useEffect(() => {
+    const el = listRef.current?.querySelector(
+      `[data-palette-index="${selectedIndex}"]`,
+    );
+    el?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
+
+  const runItem = useCallback(
+    (item: PaletteItem) => {
+      if (!workspaceId) return;
+      const ctx: PaletteRunContext = { workspaceId, setThemeMode: setMode };
+      useCommandPaletteStore.getState().closePalette();
+      item.run(ctx);
+    },
+    [workspaceId, setMode],
+  );
+
+  // Bound at the dialog level (not the input) so navigation works no matter
+  // where focus ends up. Supports the cmdk staples: arrows (with wrap),
+  // Home/End, and emacs-style Ctrl+N/P.
+  const onDialogKeyDown = (event: React.KeyboardEvent) => {
+    const count = items.length;
+    if (count === 0) return;
+    const isCtrl = (key: string) => event.ctrlKey && event.key === key;
+
+    if (event.key === "ArrowDown" || isCtrl("n")) {
+      event.preventDefault();
+      setSelectedIndex(index => (index + 1) % count);
+    } else if (event.key === "ArrowUp" || isCtrl("p")) {
+      event.preventDefault();
+      setSelectedIndex(index => (index - 1 + count) % count);
+    } else if (event.key === "Home" && !query) {
+      event.preventDefault();
+      setSelectedIndex(0);
+    } else if (event.key === "End" && !query) {
+      event.preventDefault();
+      setSelectedIndex(count - 1);
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      const item = items[selectedIndex];
+      if (item) runItem(item);
+    }
+  };
+
+  if (!workspaceId) return null;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={() => useCommandPaletteStore.getState().closePalette()}
+      fullWidth
+      maxWidth="sm"
+      // Without this, MUI restores focus to the previously focused element
+      // (e.g. Monaco) when the dialog opens, defeating the input autofocus.
+      disableRestoreFocus
+      TransitionProps={{ onEntered: () => inputRef.current?.focus() }}
+      onKeyDown={onDialogKeyDown}
+      sx={{ "& .MuiDialog-container": { alignItems: "flex-start" } }}
+      PaperProps={{ sx: { mt: "12vh", overflow: "hidden" } }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1,
+          px: 2,
+          py: 1.25,
+          borderBottom: 1,
+          borderColor: "divider",
+        }}
+      >
+        {commandMode ? <ChevronRight size={16} /> : <Search size={16} />}
+        <InputBase
+          autoFocus
+          fullWidth
+          inputRef={inputRef}
+          value={query}
+          placeholder="Search consoles, dashboards, apps… type > for commands"
+          onChange={event => {
+            setQuery(event.target.value);
+            setSelectedIndex(0);
+          }}
+          sx={{ fontSize: 14 }}
+        />
+        {searching && <CircularProgress size={14} />}
+      </Box>
+
+      <Box ref={listRef} sx={{ maxHeight: 400, overflowY: "auto", py: 0.5 }}>
+        {rows.length === 0 && (
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{ px: 2, py: 2, textAlign: "center" }}
+          >
+            {effectiveQuery ? "No results" : "Start typing to search"}
+          </Typography>
+        )}
+        {rows.map(row =>
+          row.type === "header" ? (
+            <Typography
+              key={`header-${row.label}`}
+              variant="caption"
+              color="text.secondary"
+              sx={{
+                display: "block",
+                px: 2,
+                pt: 1,
+                pb: 0.25,
+                textTransform: "uppercase",
+                letterSpacing: 0.5,
+              }}
+            >
+              {row.label}
+            </Typography>
+          ) : (
+            <Box
+              key={row.item.id}
+              data-palette-index={row.index}
+              onClick={() => runItem(row.item)}
+              // preventDefault keeps the search input focused through clicks.
+              onMouseDown={event => event.preventDefault()}
+              onMouseMove={event => {
+                const prev = pointerRef.current;
+                pointerRef.current = { x: event.clientX, y: event.clientY };
+                if (
+                  prev &&
+                  prev.x === event.clientX &&
+                  prev.y === event.clientY
+                ) {
+                  return;
+                }
+                if (prev) setSelectedIndex(row.index);
+              }}
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1.25,
+                px: 2,
+                py: 0.75,
+                cursor: "pointer",
+                bgcolor:
+                  row.index === selectedIndex
+                    ? "action.selected"
+                    : "transparent",
+              }}
+            >
+              <row.item.icon size={15} />
+              <Typography variant="body2" noWrap sx={{ flex: 1 }}>
+                {row.item.title}
+              </Typography>
+              {"subtitle" in row.item && row.item.subtitle && (
+                <Typography variant="caption" color="text.secondary" noWrap>
+                  {row.item.subtitle}
+                </Typography>
+              )}
+            </Box>
+          ),
+        )}
+      </Box>
+    </Dialog>
+  );
+}

--- a/app/src/components/ConsoleTree.tsx
+++ b/app/src/components/ConsoleTree.tsx
@@ -7,7 +7,9 @@ import {
   useRef,
   useState,
 } from "react";
-import { SquareTerminal as ConsoleIcon } from "lucide-react";
+import { TAB_KIND_ICONS } from "../lib/entity-icons";
+
+const ConsoleIcon = TAB_KIND_ICONS.console;
 import { Box } from "@mui/material";
 import { useExplorerStore } from "../store/explorerStore";
 import {

--- a/app/src/components/DashboardsExplorer.tsx
+++ b/app/src/components/DashboardsExplorer.tsx
@@ -19,8 +19,10 @@ import {
   Globe as GlobeIcon,
   User as UserIcon,
   Database as DataSourceIcon,
-  ChartPie as DashboardIcon,
 } from "lucide-react";
+import { TAB_KIND_ICONS } from "../lib/entity-icons";
+
+const DashboardIcon = TAB_KIND_ICONS.dashboard;
 import { useWorkspace } from "../contexts/workspace-context";
 import { useAuth } from "../contexts/auth-context";
 import { useConsoleStore } from "../store/consoleStore";

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -42,23 +42,22 @@ import {
 } from "@mui/material";
 import { Close as CloseIcon } from "@mui/icons-material";
 import {
-  SquareTerminal as ConsoleIcon,
-  Settings as SettingsIcon,
-  CloudUpload as DataSourceIcon,
   Clock as ScheduleIcon,
   Webhook as WebhookIcon,
   CirclePause as PauseIcon,
-  ChartPie as DashboardIcon,
-  AppWindow as AppIcon,
-  FileCode as AppFileIcon,
-  Database as DatabaseIcon,
-  Table as TableDataIcon,
-  ClipboardList as PlanIcon,
   Menu as MenuIcon,
   ChevronDown as ChevronDownIcon,
   Plus as PlusIcon,
   X as CloseTabIcon,
 } from "lucide-react";
+import { tabKindIcon } from "../lib/entity-icons";
+import type { TabKind } from "../store/lib/types";
+
+/** Renders the canonical icon for a tab kind (see lib/entity-icons.ts). */
+function TabKindGlyph({ kind }: { kind: TabKind | undefined }) {
+  const Icon = tabKindIcon(kind);
+  return <Icon size={18} strokeWidth={1.5} />;
+}
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { loader } from "@monaco-editor/react";
 import Console, { ConsoleRef } from "./Console";
@@ -2183,6 +2182,10 @@ function Editor({
                       const connectionIconUrl = tab.connectionId
                         ? connectionIconById.get(tab.connectionId)
                         : undefined;
+                      // Canonical per-kind icon (see lib/entity-icons.ts);
+                      // overridden below by connector favicons, connection
+                      // icons, and flow-editor subtype icons.
+                      const KindIcon = tabKindIcon(tab.kind);
                       const nextTab = consoleTabs[index + 1];
                       const isLastTab = index === consoleTabs.length - 1;
                       // Cursor-style separator: thin vertical rule on the trailing
@@ -2238,10 +2241,6 @@ function Editor({
                                   alt="tab icon"
                                   sx={{ width: 18, height: 18 }}
                                 />
-                              ) : tab.kind === "settings" ? (
-                                <SettingsIcon size={18} strokeWidth={1.5} />
-                              ) : tab.kind === "connectors" ? (
-                                <DataSourceIcon size={18} strokeWidth={1.5} />
                               ) : tab.kind === "flow-editor" ? (
                                 tab.metadata?.flowType === "webhook" ? (
                                   <WebhookIcon size={18} strokeWidth={1.5} />
@@ -2250,20 +2249,8 @@ function Editor({
                                 ) : (
                                   <ScheduleIcon size={18} strokeWidth={1.5} />
                                 )
-                              ) : tab.kind === "dashboard" ? (
-                                <DashboardIcon size={18} strokeWidth={1.5} />
-                              ) : tab.kind === "app" ? (
-                                <AppIcon size={18} strokeWidth={1.5} />
-                              ) : tab.kind === "app-file" ? (
-                                <AppFileIcon size={18} strokeWidth={1.5} />
-                              ) : tab.kind === "app-binding" ||
-                                tab.kind === "dashboard-data-source" ? (
-                                <DatabaseIcon size={18} strokeWidth={1.5} />
-                              ) : tab.kind === "table-data" ? (
-                                <TableDataIcon size={18} strokeWidth={1.5} />
-                              ) : tab.kind === "plan" ? (
-                                <PlanIcon size={18} strokeWidth={1.5} />
-                              ) : connectionIconUrl ? (
+                              ) : (tab.kind ?? "console") === "console" &&
+                                connectionIconUrl ? (
                                 <Box
                                   component="img"
                                   src={connectionIconUrl}
@@ -2275,7 +2262,7 @@ function Editor({
                                   }}
                                 />
                               ) : (
-                                <ConsoleIcon size={18} strokeWidth={1.5} />
+                                <KindIcon size={18} strokeWidth={1.5} />
                               )}
                               <span
                                 style={{
@@ -2350,7 +2337,7 @@ function Editor({
                       sx={{ width: 18, height: 18 }}
                     />
                   ) : (
-                    <ConsoleIcon size={18} strokeWidth={1.5} />
+                    <TabKindGlyph kind={tab.kind} />
                   )}
                 </ListItemIcon>
                 <ListItemText

--- a/app/src/components/SettingsExplorer.tsx
+++ b/app/src/components/SettingsExplorer.tsx
@@ -1,38 +1,13 @@
 import { Box, Typography } from "@mui/material";
-import {
-  Sparkles as ModelsIcon,
-  MessageSquareText as PromptIcon,
-  BookOpen as SkillsIcon,
-  Plug as McpIcon,
-  Wallet as BillingIcon,
-  Users as MembersIcon,
-  KeySquare as ApiKeyIcon,
-  Palette as AppearanceIcon,
-  ShieldCheck as AdminIcon,
-} from "lucide-react";
 import ExplorerShell from "./ExplorerShell";
 import { useAuth } from "../contexts/auth-context";
 import {
   selectTabBySettingsSection,
   useConsoleStore,
 } from "../store/consoleStore";
+import { SETTINGS_SECTION_ICONS } from "../lib/entity-icons";
 import type { SettingsSection } from "../store/lib/types";
 import { SECTION_LABELS, SECTION_ORDER } from "../pages/settings/sections";
-
-const SECTION_ICONS: Record<
-  SettingsSection,
-  (props: { size?: number; strokeWidth?: number }) => JSX.Element
-> = {
-  prompt: props => <PromptIcon {...props} />,
-  skills: props => <SkillsIcon {...props} />,
-  mcp: props => <McpIcon {...props} />,
-  models: props => <ModelsIcon {...props} />,
-  billing: props => <BillingIcon {...props} />,
-  members: props => <MembersIcon {...props} />,
-  "api-keys": props => <ApiKeyIcon {...props} />,
-  appearance: props => <AppearanceIcon {...props} />,
-  admin: props => <AdminIcon {...props} />,
-};
 
 export default function SettingsExplorer() {
   const { user } = useAuth();
@@ -65,7 +40,7 @@ export default function SettingsExplorer() {
       {() => (
         <Box sx={{ py: 0.5 }}>
           {sections.map(section => {
-            const Icon = SECTION_ICONS[section];
+            const Icon = SETTINGS_SECTION_ICONS[section];
             const isActive =
               activeTab?.kind === "settings" &&
               activeTab.settingsSection === section;

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -9,18 +9,8 @@ import {
   Divider,
 } from "@mui/material";
 import { Logout as LogoutIcon } from "@mui/icons-material";
-import {
-  Settings as SettingsIcon,
-  SquareChevronRight as ConsoleIcon,
-  Database as DatabaseIcon,
-  Plug as DataSourceIcon,
-  ArrowLeftRight as FlowsIcon,
-  ChartPie as DashboardIcon,
-  AppWindow as AppsIcon,
-  GitBranch as TransformsIcon,
-  CircleUserRound as UserIcon,
-  MessageCircleMore as ChatIcon,
-} from "lucide-react";
+import { CircleUserRound as UserIcon } from "lucide-react";
+import { CHAT_ICON as ChatIcon, EXPLORER_ICONS } from "../lib/entity-icons";
 import { selectActiveExplorer, useUIStore } from "../store/uiStore";
 import { useConsoleStore } from "../store/consoleStore";
 import { useAuth } from "../contexts/auth-context";
@@ -71,20 +61,20 @@ const topNavigationItems: {
   icon: any;
   label: string;
 }[] = [
-  { view: "databases", icon: DatabaseIcon, label: "Databases" },
-  { view: "consoles", icon: ConsoleIcon, label: "Consoles" },
-  { view: "flows", icon: FlowsIcon, label: "Flows" },
-  { view: "dbt", icon: TransformsIcon, label: "Transforms" },
-  { view: "connectors", icon: DataSourceIcon, label: "Connectors" },
-  { view: "dashboards", icon: DashboardIcon, label: "Dashboards" },
-  { view: "apps", icon: AppsIcon, label: "Apps" },
+  { view: "databases", icon: EXPLORER_ICONS.databases, label: "Databases" },
+  { view: "consoles", icon: EXPLORER_ICONS.consoles, label: "Consoles" },
+  { view: "flows", icon: EXPLORER_ICONS.flows, label: "Flows" },
+  { view: "dbt", icon: EXPLORER_ICONS.dbt, label: "Transforms" },
+  { view: "connectors", icon: EXPLORER_ICONS.connectors, label: "Connectors" },
+  { view: "dashboards", icon: EXPLORER_ICONS.dashboards, label: "Dashboards" },
+  { view: "apps", icon: EXPLORER_ICONS.apps, label: "Apps" },
 ];
 
 const bottomNavigationItems: {
   view: NavigationView;
   icon: any;
   label: string;
-}[] = [{ view: "settings", icon: SettingsIcon, label: "Settings" }];
+}[] = [{ view: "settings", icon: EXPLORER_ICONS.settings, label: "Settings" }];
 
 const preloadDashboardsExplorer = () => {
   void import("./DashboardsExplorer");

--- a/app/src/lib/command-palette/commands.ts
+++ b/app/src/lib/command-palette/commands.ts
@@ -1,0 +1,215 @@
+/**
+ * Command palette — static command registry.
+ *
+ * Commands are rebuilt on every palette render via `buildCommands()` so
+ * availability can be derived from current store state (active tab kind,
+ * open tabs, ...) without a reactive `when`-clause system. Keep entries
+ * here in sync with what the underlying stores actually support.
+ */
+
+import {
+  Copy,
+  Monitor,
+  Moon,
+  PanelLeft,
+  Plus,
+  Sun,
+  X,
+  XCircle,
+} from "lucide-react";
+import { SECTION_LABELS, SECTION_ORDER } from "../../pages/settings/sections";
+import {
+  CHAT_ICON,
+  EXPLORER_ICONS,
+  SETTINGS_SECTION_ICONS,
+} from "../entity-icons";
+import {
+  selectTabBySettingsSection,
+  useConsoleStore,
+} from "../../store/consoleStore";
+import type { LeftPaneView, SettingsSection } from "../../store/lib/types";
+import { useUIStore } from "../../store/uiStore";
+import { tabUrlPath } from "../tab-routing";
+import type { PaletteCommand } from "./types";
+
+// Icons come from the shared EXPLORER_ICONS map so the palette always
+// matches the sidebar rail (see lib/entity-icons.ts).
+const EXPLORER_VIEWS: Array<{ view: LeftPaneView; label: string }> = [
+  { view: "databases", label: "Databases" },
+  { view: "consoles", label: "Consoles" },
+  { view: "dashboards", label: "Dashboards" },
+  { view: "apps", label: "Apps" },
+  { view: "dbt", label: "Transforms" },
+  { view: "flows", label: "Flows" },
+  { view: "connectors", label: "Connectors" },
+  { view: "settings", label: "Settings" },
+];
+
+function openSettingsSection(section: SettingsSection): void {
+  const state = useConsoleStore.getState();
+  const existing = selectTabBySettingsSection(section)(state);
+  if (existing) {
+    state.setActiveTab(existing.id);
+    return;
+  }
+  const id = state.openTab({
+    title: SECTION_LABELS[section],
+    content: "",
+    kind: "settings",
+    settingsSection: section,
+  });
+  state.setActiveTab(id);
+}
+
+export function buildCommands(options: {
+  isSuperAdmin: boolean;
+}): PaletteCommand[] {
+  const consoleState = useConsoleStore.getState();
+  const activeTab = consoleState.activeTabId
+    ? consoleState.tabs[consoleState.activeTabId]
+    : null;
+  const tabCount = consoleState.tabOrder.length;
+
+  const commands: PaletteCommand[] = [];
+
+  commands.push({
+    id: "create.console",
+    title: "New console",
+    section: "Create",
+    keywords: ["query", "sql", "editor"],
+    icon: Plus,
+    run: () => {
+      const state = useConsoleStore.getState();
+      const id = state.openTab({ title: "New Console", content: "" });
+      state.setActiveTab(id);
+    },
+  });
+
+  for (const { view, label } of EXPLORER_VIEWS) {
+    commands.push({
+      id: `view.explorer.${view}`,
+      title: `Go to ${label}`,
+      section: "Navigate",
+      keywords: ["explorer", "sidebar", label.toLowerCase()],
+      icon: EXPLORER_ICONS[view],
+      run: () => {
+        const ui = useUIStore.getState();
+        ui.navigateToView(view);
+        ui.openLeftPane();
+      },
+    });
+  }
+
+  commands.push(
+    {
+      id: "view.toggleSidebar",
+      title: "Toggle sidebar",
+      section: "View",
+      keywords: ["explorer", "left", "pane", "panel"],
+      icon: PanelLeft,
+      run: () => {
+        const ui = useUIStore.getState();
+        ui.setLeftPaneOpen(!ui.leftPaneOpen);
+      },
+    },
+    {
+      id: "view.toggleChat",
+      title: "Toggle chat panel",
+      section: "View",
+      keywords: ["ask", "ai", "right", "pane", "assistant"],
+      icon: CHAT_ICON,
+      run: () => {
+        const ui = useUIStore.getState();
+        ui.setRightPaneOpen(!ui.rightPaneOpen);
+      },
+    },
+  );
+
+  commands.push(
+    {
+      id: "theme.light",
+      title: "Theme: Light",
+      section: "Appearance",
+      keywords: ["color", "mode"],
+      icon: Sun,
+      run: ctx => ctx.setThemeMode("light"),
+    },
+    {
+      id: "theme.dark",
+      title: "Theme: Dark",
+      section: "Appearance",
+      keywords: ["color", "mode"],
+      icon: Moon,
+      run: ctx => ctx.setThemeMode("dark"),
+    },
+    {
+      id: "theme.system",
+      title: "Theme: System",
+      section: "Appearance",
+      keywords: ["color", "mode", "auto"],
+      icon: Monitor,
+      run: ctx => ctx.setThemeMode("system"),
+    },
+  );
+
+  const settingsSections = SECTION_ORDER.filter(
+    section => section !== "admin" || options.isSuperAdmin,
+  );
+  for (const section of settingsSections) {
+    commands.push({
+      id: `settings.${section}`,
+      title: `Settings: ${SECTION_LABELS[section]}`,
+      section: "Settings",
+      keywords: ["preferences", "configure"],
+      icon: SETTINGS_SECTION_ICONS[section],
+      run: () => openSettingsSection(section),
+    });
+  }
+
+  if (activeTab) {
+    commands.push({
+      id: "tab.close",
+      title: "Close tab",
+      section: "Tabs",
+      keywords: ["current"],
+      icon: X,
+      run: () => {
+        const state = useConsoleStore.getState();
+        if (state.activeTabId) state.closeTab(state.activeTabId);
+      },
+    });
+
+    const url = tabUrlPath(activeTab.id, activeTab);
+    if (url) {
+      commands.push({
+        id: "tab.copyLink",
+        title: "Copy link to tab",
+        section: "Tabs",
+        keywords: ["url", "share", "deep link"],
+        icon: Copy,
+        run: () => {
+          void navigator.clipboard.writeText(`${window.location.origin}${url}`);
+        },
+      });
+    }
+  }
+
+  if (tabCount > 1) {
+    commands.push({
+      id: "tab.closeOthers",
+      title: "Close other tabs",
+      section: "Tabs",
+      keywords: ["all"],
+      icon: XCircle,
+      run: () => {
+        const state = useConsoleStore.getState();
+        const keep = state.activeTabId;
+        for (const id of [...state.tabOrder]) {
+          if (id !== keep) state.closeTab(id);
+        }
+      },
+    });
+  }
+
+  return commands;
+}

--- a/app/src/lib/command-palette/entity-search.ts
+++ b/app/src/lib/command-palette/entity-search.ts
@@ -1,0 +1,234 @@
+/**
+ * Command palette — entity search providers (default mode).
+ *
+ * Each provider reads the owning domain store synchronously and returns
+ * scored, ready-to-run items. The only async source is the server-side
+ * console search, which lives in commandPaletteStore; its results are
+ * converted to items here.
+ */
+
+import { focusAppTab } from "../../app-runtime/shell";
+import { focusDashboardTab } from "../../dashboard-runtime/shell";
+import { focusDbtConsoleTab } from "../../dbt-runtime/shell";
+import { useAppStore } from "../../store/appStore";
+import type { ConsoleSearchResult } from "../../store/commandPaletteStore";
+import { useConsoleStore } from "../../store/consoleStore";
+import {
+  useDashboardTreeStore,
+  type DashboardEntry,
+} from "../../store/dashboardTreeStore";
+import { useDbtStore } from "../../store/dbtStore";
+import { useFlowStore, type Flow } from "../../store/flowStore";
+import { EXPLORER_ICONS, TAB_KIND_ICONS, tabKindIcon } from "../entity-icons";
+import { matchScore, type PaletteEntityItem } from "./types";
+
+interface Scored {
+  item: PaletteEntityItem;
+  score: number;
+}
+
+function sorted(scored: Scored[], limit: number): PaletteEntityItem[] {
+  return scored
+    .filter(s => s.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map(s => s.item);
+}
+
+/** Open editor tabs — instant switch. Listed first, even for empty queries. */
+export function searchOpenTabs(query: string): PaletteEntityItem[] {
+  const state = useConsoleStore.getState();
+  const scored: Scored[] = state.tabOrder
+    .filter(id => id !== state.activeTabId && state.tabs[id])
+    .map(id => {
+      const tab = state.tabs[id];
+      return {
+        score: matchScore(query, tab.title),
+        item: {
+          id: `tab:${id}`,
+          title: tab.title,
+          subtitle: "Open tab",
+          section: "Open Tabs",
+          icon: tabKindIcon(tab.kind),
+          run: () => useConsoleStore.getState().setActiveTab(id),
+        },
+      };
+    });
+  return sorted(scored, query ? 6 : 5);
+}
+
+/** Server console search results (already query-filtered by the API). */
+export function consoleResultItems(
+  workspaceId: string,
+  results: ConsoleSearchResult[],
+): PaletteEntityItem[] {
+  const openTabs = useConsoleStore.getState().tabs;
+  return results
+    .filter(result => !openTabs[result.id])
+    .map(result => ({
+      id: `console:${result.id}`,
+      title: result.title,
+      subtitle: [result.connectionName, result.databaseName]
+        .filter(Boolean)
+        .join(" · "),
+      section: "Consoles",
+      icon: TAB_KIND_ICONS.console,
+      run: () => {
+        void useConsoleStore.getState().loadConsole(workspaceId, result.id);
+      },
+    }));
+}
+
+function flattenDashboards(entries: DashboardEntry[]): DashboardEntry[] {
+  const out: DashboardEntry[] = [];
+  for (const entry of entries) {
+    if (entry.isDirectory) {
+      out.push(...flattenDashboards(entry.children ?? []));
+    } else {
+      out.push(entry);
+    }
+  }
+  return out;
+}
+
+export function searchDashboards(
+  workspaceId: string,
+  query: string,
+): PaletteEntityItem[] {
+  const state = useDashboardTreeStore.getState();
+  const entries = [
+    ...flattenDashboards(state.myDashboards[workspaceId] ?? []),
+    ...flattenDashboards(state.workspaceDashboards[workspaceId] ?? []),
+  ];
+  const seen = new Set<string>();
+  const scored: Scored[] = [];
+  for (const entry of entries) {
+    if (seen.has(entry.id)) continue;
+    seen.add(entry.id);
+    scored.push({
+      score: matchScore(query, entry.name),
+      item: {
+        id: `dashboard:${entry.id}`,
+        title: entry.name,
+        section: "Dashboards",
+        icon: TAB_KIND_ICONS.dashboard,
+        run: () => {
+          focusDashboardTab(entry.id, entry.name);
+        },
+      },
+    });
+  }
+  return sorted(scored, 5);
+}
+
+export function searchApps(
+  workspaceId: string,
+  query: string,
+): PaletteEntityItem[] {
+  const state = useAppStore.getState();
+  const apps = [
+    ...(state.myApps[workspaceId] ?? []),
+    ...(state.workspaceApps[workspaceId] ?? []),
+  ];
+  const seen = new Set<string>();
+  const scored: Scored[] = [];
+  for (const app of apps) {
+    if (seen.has(app.id)) continue;
+    seen.add(app.id);
+    scored.push({
+      score: matchScore(query, app.name),
+      item: {
+        id: `app:${app.id}`,
+        title: app.name,
+        section: "Apps",
+        icon: TAB_KIND_ICONS.app,
+        run: () => {
+          focusAppTab(app.id, app.name);
+        },
+      },
+    });
+  }
+  return sorted(scored, 5);
+}
+
+export function searchDbtProjects(query: string): PaletteEntityItem[] {
+  const scored: Scored[] = useDbtStore.getState().projects.map(project => ({
+    score: matchScore(query, project.name),
+    item: {
+      id: `dbt:${project._id}`,
+      title: project.name,
+      subtitle: "dbt project",
+      section: "Transforms",
+      icon: EXPLORER_ICONS.dbt,
+      run: () => {
+        focusDbtConsoleTab(project._id, project.name);
+      },
+    },
+  }));
+  return sorted(scored, 4);
+}
+
+/** Mirrors FlowsExplorer's title derivation for a flow row. */
+function flowTitle(flow: Flow): string {
+  const f = flow as Flow & {
+    sourceType?: string;
+    tableDestination?: { tableName?: string };
+  };
+  if (f.sourceType === "database") {
+    return `Query -> ${f.tableDestination?.tableName || "Table"}`;
+  }
+  const sourceName =
+    (flow.dataSourceId as { name?: string } | undefined)?.name || "Source";
+  const destName =
+    (flow.destinationDatabaseId as { name?: string } | undefined)?.name ||
+    "Destination";
+  return `${sourceName} -> ${destName}`;
+}
+
+export function searchFlows(
+  workspaceId: string,
+  query: string,
+): PaletteEntityItem[] {
+  const flows = useFlowStore.getState().flows[workspaceId] ?? [];
+  const scored: Scored[] = flows.map(flow => {
+    const title = flowTitle(flow);
+    return {
+      score: matchScore(query, title),
+      item: {
+        id: `flow:${flow._id}`,
+        title,
+        section: "Flows",
+        icon: EXPLORER_ICONS.flows,
+        run: () => {
+          const consoleStore = useConsoleStore.getState();
+          useFlowStore.getState().selectFlow(flow._id);
+          const existing = Object.values(consoleStore.tabs).find(
+            tab => tab.metadata?.flowId === flow._id,
+          );
+          if (existing) {
+            consoleStore.setActiveTab(existing.id);
+            return;
+          }
+          const f = flow as Flow & { sourceType?: string };
+          const id = consoleStore.openTab({
+            title,
+            content: "",
+            kind: "flow-editor",
+            metadata: {
+              flowId: flow._id,
+              isNew: false,
+              flowType:
+                f.sourceType === "database" ? "db-scheduled" : flow.type,
+              enabled:
+                flow.type === "webhook"
+                  ? flow.webhookConfig?.enabled
+                  : flow.schedule?.enabled,
+            },
+          });
+          consoleStore.setActiveTab(id);
+        },
+      },
+    };
+  });
+  return sorted(scored, 4);
+}

--- a/app/src/lib/command-palette/types.ts
+++ b/app/src/lib/command-palette/types.ts
@@ -1,0 +1,95 @@
+import type { LucideIcon } from "lucide-react";
+import type { ThemeMode } from "../../contexts/ThemeContext";
+
+/**
+ * Context handed to commands when they run. Built by the CommandPalette
+ * component so commands can reach values that live in React context
+ * (theme mode, auth) as well as the current workspace.
+ */
+export interface PaletteRunContext {
+  workspaceId: string;
+  setThemeMode: (mode: ThemeMode) => void;
+}
+
+/** A user-invokable command shown in `>` mode (and mixed into default mode). */
+export interface PaletteCommand {
+  id: string;
+  title: string;
+  /** Section header the command is grouped under. */
+  section: string;
+  /** Extra match terms beyond the title. */
+  keywords?: string[];
+  icon: LucideIcon;
+  run: (ctx: PaletteRunContext) => void;
+}
+
+/** A navigable entity (open tab, console, dashboard, ...) in default mode. */
+export interface PaletteEntityItem {
+  id: string;
+  title: string;
+  subtitle?: string;
+  section: string;
+  icon: LucideIcon;
+  run: (ctx: PaletteRunContext) => void;
+}
+
+export type PaletteItem = PaletteCommand | PaletteEntityItem;
+
+/** Score of one lowercase token against one lowercase text. 0 = no match. */
+function tokenScore(token: string, text: string): number {
+  if (text === token) return 4;
+  if (text.startsWith(token)) return 3;
+  // Word-boundary match ("con" matching "New Console")
+  if (text.split(/[\s/_:-]+/).some(word => word.startsWith(token))) return 2;
+  if (text.includes(token)) return 1;
+  return 0;
+}
+
+function tokenize(query: string): string[] {
+  return query.toLowerCase().split(/\s+/).filter(Boolean);
+}
+
+/**
+ * Simple relevance score: 0 = no match. Higher is better. Case-insensitive
+ * and token-based — every word of the query must match somewhere in the
+ * text ("theme light" matches "Theme: Light"). An empty query matches
+ * everything (score 1) so default mode can list items.
+ */
+export function matchScore(query: string, text: string): number {
+  const tokens = tokenize(query);
+  if (tokens.length === 0) return 1;
+  const t = text.toLowerCase();
+  let total = 0;
+  for (const token of tokens) {
+    const score = tokenScore(token, t);
+    if (score === 0) return 0;
+    total += score;
+  }
+  return total;
+}
+
+/**
+ * Score against a title plus optional keywords. Each query token may match
+ * either the title or a keyword (keyword hits are capped so title matches
+ * always rank higher); tokens that match nothing disqualify the item.
+ */
+export function scoreItem(
+  query: string,
+  title: string,
+  keywords?: string[],
+): number {
+  const tokens = tokenize(query);
+  if (tokens.length === 0) return 1;
+  const t = title.toLowerCase();
+  const kws = (keywords ?? []).map(keyword => keyword.toLowerCase());
+  let total = 0;
+  for (const token of tokens) {
+    let best = tokenScore(token, t);
+    for (const keyword of kws) {
+      best = Math.max(best, Math.min(tokenScore(token, keyword), 2));
+    }
+    if (best === 0) return 0;
+    total += best;
+  }
+  return total;
+}

--- a/app/src/lib/entity-icons.ts
+++ b/app/src/lib/entity-icons.ts
@@ -1,0 +1,106 @@
+/**
+ * Entity icons — single source of truth.
+ *
+ * Every surface that renders an icon for an explorer section, a tab kind,
+ * or a settings section MUST import it from here instead of picking a
+ * lucide icon ad hoc. Consumers: Sidebar rail, Editor tab bar, command
+ * palette, SettingsExplorer. Both maps are exhaustive over their key
+ * unions (`satisfies Record<...>`), so adding a `LeftPaneView` or
+ * `TabKind` without deciding its icon is a compile error — the same
+ * regression guard pattern as `tab-routing.ts`.
+ *
+ * Special cases that stay with their owners (they depend on runtime
+ * state, not the kind): connector/connection favicon images (`tab.icon`,
+ * `connectionIconUrl`) and flow-editor subtype icons (webhook/paused/
+ * scheduled) in Editor.tsx and FlowsExplorer.
+ */
+
+import {
+  AppWindow,
+  ArrowLeftRight,
+  BookOpen,
+  CalendarClock,
+  ChartPie,
+  ClipboardList,
+  CloudUpload,
+  Database,
+  FileCode,
+  GitBranch,
+  History,
+  KeySquare,
+  MessageCircleMore,
+  MessageSquareText,
+  Palette,
+  Plug,
+  Settings,
+  ShieldCheck,
+  Sparkles,
+  SquareChevronRight,
+  SquareTerminal,
+  Table,
+  Terminal,
+  Users,
+  Wallet,
+  type LucideIcon,
+} from "lucide-react";
+import type {
+  LeftPaneView,
+  SettingsSection,
+  TabKind,
+} from "../store/lib/types";
+
+/** Sidebar rail / "Go to ..." icons, one per explorer section. */
+export const EXPLORER_ICONS = {
+  databases: Database,
+  consoles: SquareChevronRight,
+  flows: ArrowLeftRight,
+  dbt: GitBranch,
+  connectors: Plug,
+  dashboards: ChartPie,
+  apps: AppWindow,
+  settings: Settings,
+} as const satisfies Record<LeftPaneView, LucideIcon>;
+
+/** Chat pane icon (sidebar rail + palette command). */
+export const CHAT_ICON: LucideIcon = MessageCircleMore;
+
+/**
+ * Icon per tab kind, as rendered in the Editor tab bar. Entity rows in
+ * explorers and palette results use the same map so a dashboard looks the
+ * same everywhere it appears.
+ */
+export const TAB_KIND_ICONS = {
+  console: SquareTerminal,
+  settings: Settings,
+  connectors: CloudUpload,
+  members: Users,
+  "flow-editor": ArrowLeftRight,
+  dashboard: ChartPie,
+  "dashboard-data-source": Database,
+  "table-data": Table,
+  app: AppWindow,
+  "app-file": FileCode,
+  "app-binding": Database,
+  plan: ClipboardList,
+  "dbt-file": FileCode,
+  "dbt-job": CalendarClock,
+  "dbt-console": Terminal,
+  "dbt-runs": History,
+} as const satisfies Record<NonNullable<TabKind>, LucideIcon>;
+
+export function tabKindIcon(kind: TabKind | undefined): LucideIcon {
+  return TAB_KIND_ICONS[kind ?? "console"];
+}
+
+/** Settings explorer / settings command icons, one per section. */
+export const SETTINGS_SECTION_ICONS = {
+  prompt: MessageSquareText,
+  skills: BookOpen,
+  mcp: Plug,
+  models: Sparkles,
+  billing: Wallet,
+  members: Users,
+  "api-keys": KeySquare,
+  appearance: Palette,
+  admin: ShieldCheck,
+} as const satisfies Record<SettingsSection, LucideIcon>;

--- a/app/src/store/commandPaletteStore.ts
+++ b/app/src/store/commandPaletteStore.ts
@@ -1,0 +1,120 @@
+/**
+ * Command Palette Store
+ *
+ * Owns the palette open/closed state and the server-backed console search
+ * (network calls live in stores per the frontend guidelines). Everything
+ * else the palette shows (open tabs, dashboards, apps, ...) is read from
+ * the owning domain stores at render time.
+ */
+
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+import { apiClient } from "../lib/api-client";
+
+export interface ConsoleSearchResult {
+  id: string;
+  title: string;
+  description: string;
+  connectionName?: string;
+  databaseName?: string;
+  language: string;
+  isSaved: boolean;
+  score: number;
+}
+
+interface CommandPaletteState {
+  open: boolean;
+  consoleResults: ConsoleSearchResult[];
+  searching: boolean;
+}
+
+interface CommandPaletteActions {
+  openPalette: () => void;
+  closePalette: () => void;
+  togglePalette: () => void;
+  /** Server-side console search (vector + text). Aborts in-flight requests. */
+  searchConsoles: (workspaceId: string, query: string) => Promise<void>;
+  clearConsoleResults: () => void;
+}
+
+type CommandPaletteStore = CommandPaletteState & CommandPaletteActions;
+
+let inFlightSearch: AbortController | null = null;
+
+export const useCommandPaletteStore = create<CommandPaletteStore>()(
+  immer((set, get) => ({
+    open: false,
+    consoleResults: [],
+    searching: false,
+
+    openPalette: () =>
+      set(state => {
+        state.open = true;
+      }),
+
+    closePalette: () => {
+      inFlightSearch?.abort();
+      inFlightSearch = null;
+      set(state => {
+        state.open = false;
+        state.consoleResults = [];
+        state.searching = false;
+      });
+    },
+
+    togglePalette: () => {
+      if (get().open) {
+        get().closePalette();
+      } else {
+        get().openPalette();
+      }
+    },
+
+    searchConsoles: async (workspaceId, query) => {
+      inFlightSearch?.abort();
+      if (query.trim().length < 2) {
+        set(state => {
+          state.consoleResults = [];
+          state.searching = false;
+        });
+        return;
+      }
+
+      const controller = new AbortController();
+      inFlightSearch = controller;
+      set(state => {
+        state.searching = true;
+      });
+
+      try {
+        const res = await apiClient.get<{ results?: ConsoleSearchResult[] }>(
+          `/workspaces/${workspaceId}/consoles/search`,
+          { q: query.trim(), limit: "8" },
+          { signal: controller.signal },
+        );
+        if (controller.signal.aborted) return;
+        set(state => {
+          state.consoleResults = res.results ?? [];
+          state.searching = false;
+        });
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        // Search is best-effort UI sugar; swallow errors and show nothing.
+        set(state => {
+          state.consoleResults = [];
+          state.searching = false;
+        });
+      } finally {
+        if (inFlightSearch === controller) {
+          inFlightSearch = null;
+        }
+      }
+    },
+
+    clearConsoleResults: () =>
+      set(state => {
+        state.consoleResults = [];
+        state.searching = false;
+      }),
+  })),
+);


### PR DESCRIPTION
## Summary

- **Cmd/Ctrl+K command palette** built on MUI primitives (no new dependencies). Default mode is navigation: open tabs (instant switch), consoles via the existing `/consoles/search` endpoint (vector + text, debounced), dashboards, apps, dbt projects, and flows — all deduped against already-open tabs and opened through the existing `focus*Tab` / `loadConsole` helpers so URL sync and sidebar reveal behave exactly like the explorers. Typing `>` switches to commands-only mode (VS Code style): new console, go-to for each explorer, sidebar/chat pane toggles, theme light/dark/system, every settings section (admin gated by `isSuperAdmin`), close tab / close others, copy deep link to tab.
- **Keyboard/pointer behavior follows cmdk staples:** input autofocus (works around MUI Dialog focus restore with `disableRestoreFocus` + `onEntered`), dialog-level key handling (arrows with wrap, Enter, Ctrl+N/P, Home/End), selection resets to first item on open/filter, selected row scrolls into view, and hover only moves the selection on real pointer movement — items rendering under a stationary cursor can't steal the highlight.
- **Entity icons: single source of truth.** The sidebar, editor tab bar, explorers, and palette had drifted (three different console icons, two dashboard icons, ...). New `app/src/lib/entity-icons.ts` exports `EXPLORER_ICONS`, `TAB_KIND_ICONS`, and `SETTINGS_SECTION_ICONS`, exhaustive over their unions via `satisfies` (same guard pattern as `tab-routing.ts`) — adding a `TabKind`/`LeftPaneView`/`SettingsSection` without an icon is now a compile error. All surfaces consume the maps; the 45-line tab-icon ternary in `Editor.tsx` collapsed to a lookup (connection favicons and flow subtype icons remain deliberate state-dependent overrides). Side effect: dbt tabs now get proper per-kind icons instead of the generic console fallback.
- Adds `.cursor/rules/17-entity-icons.mdc` so future agents/reviewers keep icons in the shared map.

Architecture notes: network calls live in `commandPaletteStore` per the frontend store rule; the palette store owns only palette state + the console search call, everything else reads existing domain stores.

## Test plan

- [x] `pnpm --filter app run typecheck` and `lint` green
- [x] `pnpm --filter app run test:unit` — 285 tests pass
- [x] Browser-verified: Cmd+K opens with input focused; arrows/Ctrl+N/P navigate with wrap + scroll-into-view; Enter executes (theme switch, sidebar toggle) and closes; `>` filters to commands; multi-word queries (`>theme light`) match; entity search returns live consoles/dashboards/apps/flows; icons match the sidebar
- [ ] Manual: verify on a second workspace (entity search + deep links)
- [ ] Manual: confirm Cmd+K while Monaco is focused feels right (it intentionally shadows Monaco's Cmd+K chord prefix)

Made with [Cursor](https://cursor.com)