### PR TITLE
Fix dbt Project settings drawer not opening on mobile

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -773,6 +773,7 @@ function MainApp() {
             </BottomNavigation>
           </Paper>
         </Box>
+        <DbtProjectDrawersHost />
       </AuthWrapper>
     );
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The dbt "Project settings" drawer (and "New dbt project" drawer) was completely inaccessible on mobile — tapping "Project settings" from the project menu did nothing.

Root cause: `DbtProjectDrawersHost` (which mounts both drawers at the app root) was only rendered in the desktop branch of `App.tsx`. The mobile layout branch returns early with its own `<AuthWrapper>` and never mounted the host, so the drawers had no chance to render regardless of viewport size.

## Fix

Mount `<DbtProjectDrawersHost />` inside the mobile layout's `AuthWrapper` as well, mirroring the desktop branch.

## Testing

[dbt_project_settings_mobile_fixed.mp4](https://cursor.com/agents/bc-019f27c5-9066-7a1d-a0ec-17ab068ad157/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdbt_project_settings_mobile_fixed.mp4)

Manually tested at a 390x844 mobile viewport: opened a dbt project's Project settings drawer, entered edit mode, viewed the Environments editor, opened an environment's detail view, and closed the drawer via the back/close buttons — all worked with no horizontal overflow or cut-off content.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f27c5-9066-7a1d-a0ec-17ab068ad157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f27c5-9066-7a1d-a0ec-17ab068ad157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

