### PR TITLE
guides: Ruby connection guides — snowflake/mariadb (Batch 14)

### DIFF
--- a/content/guides/mariadb/connect-from-ruby.mdx
+++ b/content/guides/mariadb/connect-from-ruby.mdx
@@ -1,0 +1,192 @@
+---
+title: "How to Connect to MariaDB from Ruby"
+description: "Connect to MariaDB from Ruby with mysql2 or trilogy, plus Sequel and ActiveRecord. Working code for connections, pooling, parameterized queries, INSERT...RETURNING, the utf8mb4 trap, and the ed25519 authentication gotcha that is genuinely MariaDB-specific."
+database: "mariadb"
+category: "how-to"
+tags: ["mariadb", "ruby", "rails", "mysql2", "trilogy", "sequel", "activerecord", "connection"]
+date: "2026-07-04"
+---
+
+There is no MariaDB-specific Ruby driver, and you do not need one. MariaDB speaks the MySQL wire protocol, so the same Ruby drivers that connect to MySQL connect to MariaDB: `mysql2` and `trilogy`. This guide shows both, plus Sequel and ActiveRecord on top, and focuses on the two things that actually differ between MariaDB and MySQL from Ruby's point of view: the `ed25519` authentication plugin, and `INSERT ... RETURNING`.
+
+## The options
+
+| Library | Native dependency | Notes | Version (as of July 2026) |
+|---|---|---|---|
+| `mysql2` | libmysqlclient / libmariadb | Mature, widely deployed default | 0.5.7 |
+| `trilogy` | None (pure protocol implementation) | No client lib to build; Rails-native adapter | 2.12.6 |
+| Sequel | via mysql2 or trilogy | Toolkit/ORM, uses a driver underneath | 5.106.0 |
+| ActiveRecord | via mysql2 or trilogy | Full ORM (Rails) | ships with Rails 8.1.3 |
+
+The practical decision is the same as for MySQL:
+
+- **`mysql2`** if you want the established option and don't mind installing client libraries at build time. Installing the MariaDB client library (`libmariadb-dev`) satisfies its dependency perfectly well.
+- **`trilogy`** if you want to avoid the C client build dependency (a frequent source of CI and Docker friction) or you are on a recent Rails and want the natively supported adapter.
+
+## Installing mysql2 against MariaDB
+
+The gem compiles against a MySQL-compatible client library. The MariaDB Connector/C works and is often the cleaner install on modern systems:
+
+- **Debian/Ubuntu:** `sudo apt-get install libmariadb-dev`
+- **macOS (Homebrew):** `brew install mariadb-connector-c`
+- **RHEL/Fedora:** `sudo dnf install MariaDB-shared MariaDB-devel`
+
+```bash
+gem install mysql2
+```
+
+If the build cannot find the client headers, the dev package is missing. `trilogy` skips this entirely because it implements the protocol in Ruby with no C client to link against.
+
+## A minimal connection with mysql2
+
+```ruby
+require 'mysql2'
+
+client = Mysql2::Client.new(
+  host:     'localhost',
+  port:     3306,
+  username: 'app',
+  password: ENV['DB_PASSWORD'],
+  database: 'shop',
+  encoding: 'utf8mb4'
+)
+
+client.query('SELECT VERSION()').each do |row|
+  puts row['VERSION()']   # e.g. "11.4.2-MariaDB"
+end
+
+client.close
+```
+
+## The utf8mb4 trap
+
+This applies to MariaDB exactly as it does to MySQL. In this ecosystem `utf8` is a historical alias for a 3-byte encoding that cannot store 4-byte characters (emoji, some CJK characters, many symbols). Set `utf8mb4` everywhere: in the driver connection (`encoding: 'utf8mb4'`), and on the database, tables, and columns. Mismatched charsets produce `Incorrect string value` errors on insert, or silent data loss on older configurations. Use `utf8mb4` end to end and the problem disappears.
+
+## The ed25519 authentication gotcha (this is the MariaDB-specific one)
+
+Here is the genuine MariaDB difference. MariaDB does **not** use MySQL 8's `caching_sha2_password` plugin, so the whole "Authentication plugin caching_sha2_password cannot be loaded" / Public Key Retrieval headache from MySQL 8 simply does not exist here. Good news.
+
+The flip side: MariaDB has its own modern authentication plugin, `ed25519`, which many MariaDB deployments now use for accounts instead of the legacy `mysql_native_password`. And the Ruby drivers do not implement the client side of `ed25519`. If your account was created with:
+
+```sql
+CREATE USER 'app'@'%' IDENTIFIED VIA ed25519 USING PASSWORD('secret');
+```
+
+then a `mysql2` or `trilogy` connection will fail with a "plugin ... could not be loaded" or authentication error, because the driver cannot answer the ed25519 challenge. This is the failure mode that surprises people moving from MySQL: the driver is fine, the credentials are correct, but the auth plugin is one Ruby's clients don't speak.
+
+Your options:
+
+- **Use a `mysql_native_password` account for the Ruby app.** Create or alter the service account to use native password auth: `ALTER USER 'app'@'%' IDENTIFIED VIA mysql_native_password USING PASSWORD('secret');`. This is the pragmatic path today.
+- **Build `mysql2` against a MariaDB Connector/C that has the ed25519 client plugin available**, and ensure the plugin `.so` is discoverable. This works with the C client but adds deployment complexity, and `trilogy` (pure Ruby) still cannot do it.
+
+If a MariaDB connection that has correct credentials keeps failing, check the account's plugin with `SELECT user, plugin FROM mysql.user WHERE user='app';` before assuming a network or password problem.
+
+## Parameterized queries and prepared statements
+
+Use bound parameters rather than interpolating into SQL:
+
+```ruby
+stmt = client.prepare('SELECT name, plan FROM accounts WHERE region = ? AND active = ?')
+result = stmt.execute('EMEA', true)
+result.each { |row| puts "#{row['name']}: #{row['plan']}" }
+```
+
+`mysql2` uses `?` positional placeholders in prepared statements.
+
+## INSERT ... RETURNING (a real MariaDB advantage)
+
+MariaDB supports `INSERT ... RETURNING` (since 10.5), which MySQL does not. Instead of inserting and then reading `last_id`, you can get generated values back in one round trip:
+
+```ruby
+row = client.query(
+  "INSERT INTO accounts (name, region) VALUES ('Acme', 'EMEA') RETURNING id, created_at"
+).first
+
+puts row['id']
+puts row['created_at']
+```
+
+This is portable across MariaDB but not to MySQL, so if the same code must run against both, fall back to `client.last_id` after the insert instead.
+
+## Connection pooling
+
+Neither `mysql2` nor `trilogy` pools connections on its own. A `Mysql2::Client` is a single connection and is not thread-safe for concurrent queries. In a threaded server, use the `connection_pool` gem:
+
+```ruby
+require 'connection_pool'
+require 'mysql2'
+
+POOL = ConnectionPool.new(size: 5, timeout: 5) do
+  Mysql2::Client.new(
+    host: 'localhost', username: 'app',
+    password: ENV['DB_PASSWORD'], database: 'shop',
+    encoding: 'utf8mb4'
+  )
+end
+
+POOL.with do |client|
+  client.query('SELECT count(*) AS n FROM accounts').first['n']
+end
+```
+
+Size the pool so that `pool_size × process_count` stays under the server's `max_connections` (151 by default on MariaDB). For heavy connection churn, a proxy like MaxScale or ProxySQL in front of MariaDB does real connection pooling server-side.
+
+## Sequel and ActiveRecord
+
+Sequel picks the driver from the URL scheme:
+
+```ruby
+require 'sequel'
+
+# mysql2 driver against MariaDB
+DB = Sequel.connect('mysql2://app:secret@localhost/shop?encoding=utf8mb4', max_connections: 5)
+# or trilogy
+# DB = Sequel.connect('trilogy://app:secret@localhost/shop')
+
+DB[:customers].where(region: 'EMEA').each { |row| puts row[:name] }
+```
+
+In Rails, `config/database.yml` selects the adapter. There is no separate MariaDB adapter; use `mysql2` or `trilogy`:
+
+```yaml
+production:
+  adapter: mysql2        # or: trilogy
+  host: <%= ENV['DB_HOST'] %>
+  database: shop
+  username: app
+  password: <%= ENV['DB_PASSWORD'] %>
+  encoding: utf8mb4
+  pool: 5
+```
+
+## TLS connections
+
+To require an encrypted connection and verify the server certificate:
+
+```ruby
+client = Mysql2::Client.new(
+  host: 'db.internal', username: 'app', password: ENV['DB_PASSWORD'],
+  database: 'shop', encoding: 'utf8mb4',
+  sslca: '/etc/ssl/certs/ca.pem',
+  sslverify: true
+)
+```
+
+Setting `sslca` with verification is the meaningful step; enabling TLS without verifying the certificate protects against passive sniffing but not an active man-in-the-middle.
+
+## Common errors
+
+| Error | Cause |
+|---|---|
+| Cannot find client headers at install | MariaDB/MySQL client dev package missing (mysql2 only; trilogy avoids this) |
+| `Can't connect to MySQL server` | Wrong host/port, or server not listening on TCP |
+| `Access denied for user` | Wrong credentials, or host-pattern account mismatch |
+| Auth plugin could not be loaded / auth fails with correct password | Account uses MariaDB `ed25519`, which the Ruby drivers can't answer; switch the account to `mysql_native_password` |
+| `Incorrect string value` | 4-byte character into a `utf8` (3-byte) column; use `utf8mb4` end to end |
+| `Too many connections` | Pool size × process count exceeds `max_connections` (151 default) |
+
+## Querying without writing connection code
+
+If your goal is to explore a MariaDB database rather than build a service, a GUI client skips all of the above. Mako connects to MariaDB with AI-assisted SQL -- see our [MariaDB GUI client guide](/guides/mariadb-gui-client). Connecting from another language? See [How to Connect to MariaDB from Python](/guides/mariadb/connect-from-python) and [from Node.js](/guides/mariadb/connect-from-node).
+
+Mako connects to MariaDB with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/snowflake/connect-from-ruby.mdx
+++ b/content/guides/snowflake/connect-from-ruby.mdx
@@ -1,0 +1,176 @@
+---
+title: "How to Connect to Snowflake from Ruby"
+description: "Connect to Snowflake from Ruby. There is no official Ruby driver, so this covers the realistic paths: ODBC with ruby-odbc, sequel-snowflake, and the SQL REST API, plus the account-identifier trap and the 2025 key-pair authentication change."
+database: "snowflake"
+category: "how-to"
+tags: ["snowflake", "ruby", "rails", "odbc", "sequel", "connection"]
+date: "2026-07-04"
+---
+
+The first thing to know about connecting to Snowflake from Ruby: there is no official, Snowflake-maintained Ruby driver. Snowflake ships and supports native drivers for Python, Node.js, Go, Java, .NET, and PHP, but not Ruby. That single fact shapes every option below, so it is worth stating up front rather than letting you discover it after `gem install`.
+
+That does not mean Ruby cannot talk to Snowflake. It can, through three realistic paths, each with real tradeoffs.
+
+## The options
+
+| Approach | How it works | Native dependency | Notes |
+|---|---|---|---|
+| ODBC via `ruby-odbc` | Ruby ODBC binding talking to Snowflake's official ODBC driver | Snowflake ODBC driver + unixODBC | The most common path; supported driver, but ODBC round-trips are slow for large result sets |
+| `sequel-snowflake` | Sequel adapter layered on top of `ruby-odbc` | Same as above | Adds Sequel's query builder; still ODBC underneath (2.3.0 as of July 2026) |
+| SQL REST API | Plain HTTPS calls to Snowflake's SQL API | None (just an HTTP client) | No driver install; you manage auth tokens and result pagination yourself |
+
+The honest summary:
+
+- **ODBC** is the path most Ruby-plus-Snowflake deployments use. The Snowflake ODBC driver is officially supported and current (version 3.13.0 as of November 2025), and `ruby-odbc` is a thin binding to it.
+- **`sequel-snowflake`** is worth it if you already use Sequel and want its query builder and connection handling. It does not avoid ODBC; it wraps it.
+- **The SQL REST API** is the dependency-free option. It is a good fit for a small number of queries, serverless functions, or environments where installing an ODBC driver is painful. It is more work for anything involving many queries or large results.
+
+There is no ActiveRecord story worth recommending. Community ODBC-based adapters exist, but Snowflake is a columnar analytics warehouse, not an OLTP row store; driving it through an ORM built for transactional CRUD is usually the wrong shape. Query it directly.
+
+## The account identifier trap
+
+Before any code, get the account identifier right. This is the single most common reason a first connection fails, across every language.
+
+The modern format is `<orgname>-<account_name>` (organization name and account name joined by a hyphen), for example `myorg-prod_eu`. The account URL is then `myorg-prod_eu.snowflakecomputing.com`.
+
+The older format is a bare account locator (like `xy12345`) sometimes with a region and cloud suffix (`xy12345.eu-central-1`). Mixing these up, or dropping the region on a legacy locator, produces connection failures that look like network problems but are not. If you can, use the org-account form.
+
+## Authentication changed in 2025
+
+Snowflake began blocking single-factor password sign-in for programmatic connections, with enforcement rolling out through late 2025. A username and password alone is no longer a connection method you should build on. Use one of:
+
+- **Key-pair authentication** (recommended for services): generate an RSA key pair, register the public key on the user with `ALTER USER myuser SET RSA_PUBLIC_KEY='...'`, and point the driver at the private key.
+- **External browser SSO** for interactive/developer use.
+- **OAuth** for delegated access from an application.
+
+The ODBC driver supports key-pair auth through the `AUTHENTICATOR=SNOWFLAKE_JWT` option plus a `PRIV_KEY_FILE` path (and passphrase if the key is encrypted). Build for this now rather than retrofitting it after a password stops working.
+
+## ODBC setup
+
+Install unixODBC and the Snowflake ODBC driver, then the Ruby gem.
+
+- **Debian/Ubuntu:** `sudo apt-get install unixodbc unixodbc-dev`
+- **macOS (Homebrew):** `brew install unixodbc`
+
+Download the Snowflake ODBC driver from Snowflake's client download page and install it. Then register it in `odbcinst.ini` so unixODBC can find the driver library:
+
+```ini
+[SnowflakeDSIIDriver]
+Description = Snowflake ODBC Driver
+Driver = /opt/snowflake/snowflakeodbc/lib/universal/libSnowflake.dylib
+```
+
+The exact library path depends on your OS and install location. A wrong path here is the usual cause of "Can't open lib ... file not found" at connection time.
+
+Install the Ruby binding:
+
+```bash
+gem install ruby-odbc
+```
+
+## A minimal connection with ruby-odbc
+
+You can connect with a full connection string rather than a pre-configured DSN, which keeps configuration in your app:
+
+```ruby
+require 'odbc'
+
+conn_str = [
+  "Driver=SnowflakeDSIIDriver",
+  "server=myorg-prod_eu.snowflakecomputing.com",
+  "uid=SVC_ANALYTICS",
+  "authenticator=SNOWFLAKE_JWT",
+  "priv_key_file=/etc/secrets/snowflake_key.p8",
+  "warehouse=ANALYTICS_WH",
+  "database=ANALYTICS",
+  "schema=PUBLIC",
+  "role=ANALYST"
+].join(';')
+
+db = ODBC::Database.new
+conn = db.drvconnect(conn_str)
+
+stmt = conn.run('SELECT CURRENT_VERSION()')
+stmt.each { |row| puts row[0] }
+stmt.drop
+
+conn.disconnect
+```
+
+Two things that bite people:
+
+- **No active warehouse.** If you omit `warehouse` (or the role has no default warehouse), queries fail with a "no active warehouse selected" error even though the connection itself succeeded. Always set `warehouse`, `database`, `schema`, and `role` explicitly.
+- **Uppercase identifiers.** Snowflake folds unquoted identifiers to uppercase. A column written as `select id from users` comes back keyed as `ID`. Read result columns by their uppercase names or by ordinal position, not by the lowercase name you typed.
+
+## Parameterized queries
+
+Use bind parameters rather than string interpolation, both for safety and to let Snowflake cache the plan:
+
+```ruby
+stmt = conn.prepare('SELECT name, plan FROM accounts WHERE region = ? AND active = ?')
+stmt.execute('EMEA', true)
+stmt.each_hash { |row| puts "#{row['NAME']}: #{row['PLAN']}" }
+stmt.drop
+```
+
+Note the uppercase keys again when using `each_hash`.
+
+## Using sequel-snowflake
+
+If you use Sequel, `sequel-snowflake` gives you the query builder on top of the same ODBC driver:
+
+```ruby
+require 'sequel'
+require 'sequel-snowflake'
+
+DB = Sequel.connect(
+  adapter: 'snowflake',
+  drvconnect: [
+    "Driver=SnowflakeDSIIDriver",
+    "server=myorg-prod_eu.snowflakecomputing.com",
+    "uid=SVC_ANALYTICS",
+    "authenticator=SNOWFLAKE_JWT",
+    "priv_key_file=/etc/secrets/snowflake_key.p8",
+    "warehouse=ANALYTICS_WH",
+    "database=ANALYTICS",
+    "schema=PUBLIC"
+  ].join(';')
+)
+
+DB.fetch('SELECT region, count(*) AS n FROM accounts GROUP BY region') do |row|
+  puts "#{row[:region]}: #{row[:n]}"
+end
+```
+
+This is convenient, but it does not change the underlying transport. ODBC is still doing the work, so the performance characteristics below apply.
+
+## The performance reality
+
+ODBC round-trips to Snowflake are noticeably slower than the native drivers other languages get, especially when fetching many rows. Ruby teams have reported multi-second loads for result sets that a native connector would return quickly, because the ODBC layer materializes and marshals rows less efficiently than Snowflake's Arrow-based native fetch.
+
+Practical mitigations:
+
+- Aggregate in SQL. Return small result sets, not raw rows. This is good Snowflake practice regardless of language.
+- For large exports, `COPY INTO` a stage (S3/GCS/Azure) and read the files, rather than streaming millions of rows back through ODBC.
+- Suspend warehouses when idle. Ruby-side latency does not change your compute bill, but an always-on warehouse does.
+
+## The SQL REST API path
+
+If installing an ODBC driver is a problem (containers, serverless, locked-down CI), Snowflake's SQL REST API lets you run statements over plain HTTPS with no driver at all. You POST a statement to the `/api/v2/statements` endpoint with a JWT built from your key pair, and read JSON back. You are responsible for token generation, result pagination, and type handling, so it is more code than a driver for anything beyond a handful of queries, but it removes the entire ODBC install chain. It is the cleanest option for a Lambda-style function that runs one query and exits.
+
+## Common errors
+
+| Error | Cause |
+|---|---|
+| `Can't open lib ... file not found` | Wrong driver library path in `odbcinst.ini`, or the ODBC driver is not installed |
+| Connection hangs or "could not connect to server" | Wrong account identifier format (locator vs org-account), or region missing on a legacy locator |
+| `No active warehouse selected in the current session` | `warehouse` not set, or role has no default warehouse |
+| `JWT token is invalid` | Public key not registered with `ALTER USER`, wrong private key, or clock skew on the client |
+| Column key not found in row hash | Reading a lowercase name; Snowflake returns unquoted identifiers uppercased |
+| Very slow large-result queries | ODBC fetch overhead; aggregate in SQL or export via `COPY INTO` a stage |
+
+## Querying without the driver chain
+
+If your goal is to explore a Snowflake warehouse rather than build a service, the entire ODBC install chain is avoidable. Mako connects to Snowflake with AI-assisted SQL and no local driver setup -- see our [Snowflake GUI client guide](/guides/snowflake-gui-client). Connecting from another language with a native driver? See [How to Connect to Snowflake from Python](/guides/snowflake/connect-from-python) and [from Node.js](/guides/snowflake/connect-from-node).
+
+Mako connects to Snowflake with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).


### PR DESCRIPTION
Two more Ruby connection guides (Batch 14):

- `snowflake/connect-from-ruby` — no official Ruby driver; covers ODBC via ruby-odbc, sequel-snowflake, and SQL REST API. Account-identifier trap, 2025 key-pair auth change, ODBC perf reality. ODBC driver 3.13.0, sequel-snowflake 2.3.0 verified.
- `mariadb/connect-from-ruby` — mysql2/trilogy (MariaDB speaks MySQL wire protocol). Focus on the two genuine differences: the ed25519 auth gotcha (Ruby drivers can't answer it — the MariaDB-specific failure) and INSERT...RETURNING. Versions verified live via RubyGems.

Content-only. No em dashes, no banned words. Ruby now 8/9 (only mssql remains).