### PR TITLE
Fix queued prompts hanging behind a pending plan review

### DIFF
--- a/app/src/components/chat/hooks/useQueuedPrompts.test.ts
+++ b/app/src/components/chat/hooks/useQueuedPrompts.test.ts
@@ -1,0 +1,245 @@
+// @vitest-environment jsdom
+/**
+ * useQueuedPrompts — queued-prompt drain vs a pending submit_plan.
+ *
+ * Regression coverage for "queued message never sends after the agent builds
+ * a plan": a turn that ends on an unresolved submit_plan (human-in-the-loop
+ * review) left `hasPendingAssistantToolCalls` true forever, hard-blocking
+ * both the auto-drain and the force-send (top arrow). The drain now settles
+ * a pending plan itself by resolving it as request_changes with the queued
+ * prompt as feedback — the same conversational plan-iteration path as typing
+ * in the composer while the plan awaits review.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import type { MutableRefObject } from "react";
+import type { UIMessage } from "ai";
+import type { SubmitPlanOutput } from "@mako/agent-tools";
+
+vi.mock("../../../store/consoleStore", () => ({
+  useConsoleStore: { getState: () => ({ tabs: {}, activeTabId: null }) },
+}));
+vi.mock("../../../lib/analytics", () => ({ trackEvent: vi.fn() }));
+
+import { usePlanStore } from "../../../store/planStore";
+import {
+  useQueuedPrompts,
+  type UseQueuedPromptsArgs,
+} from "./useQueuedPrompts";
+
+const PLAN_TOOL_CALL_ID = "plan-tc-1";
+const CHAT_ID = "chat-1";
+
+const PLAN_INPUT = {
+  title: "My plan",
+  planMarkdown: "1. do things",
+  todos: [{ content: "step one", status: "pending" as const }],
+};
+
+function assistantMessageWithTool(
+  toolType: string,
+  state: string,
+  toolCallId = PLAN_TOOL_CALL_ID,
+): UIMessage[] {
+  return [
+    {
+      id: "m1",
+      role: "assistant",
+      parts: [{ type: toolType, state, toolCallId, input: PLAN_INPUT }],
+    } as unknown as UIMessage,
+  ];
+}
+
+function makeRef<T>(value: T): MutableRefObject<T> {
+  return { current: value };
+}
+
+interface Harness {
+  args: UseQueuedPromptsArgs;
+  sendMessage: ReturnType<typeof vi.fn>;
+  interruptActiveTurn: ReturnType<typeof vi.fn>;
+}
+
+function buildArgs(overrides: Partial<UseQueuedPromptsArgs> = {}): Harness {
+  const sendMessage = vi.fn();
+  const interruptActiveTurn = vi.fn();
+  const args: UseQueuedPromptsArgs = {
+    chatId: CHAT_ID,
+    status: "ready",
+    isLoading: false,
+    activeClientToolCallCount: 0,
+    isLoadingRef: makeRef(false),
+    manualStopRequestedRef: makeRef(false),
+    messagesRef: makeRef<UIMessage[]>([]),
+    sendMessageRef: makeRef(
+      sendMessage,
+    ) as unknown as UseQueuedPromptsArgs["sendMessageRef"],
+    modelIdRef: makeRef<string | undefined>("model-x"),
+    capturedConsoleIdRef: makeRef<string | null>(null),
+    capturedDashboardIdRef: makeRef<string | null>(null),
+    activeConsoleIdRef: makeRef<string | null>(null),
+    pendingPlanToolCallIdRef: makeRef<string | null>(null),
+    suppressNextAutoSendRef: makeRef(false),
+    autoSendWhenComplete: () => false,
+    interruptActiveTurn,
+    drainQueuedPromptAfterTurnRef: makeRef<(() => void) | null>(null),
+    ...overrides,
+  };
+  return { args, sendMessage, interruptActiveTurn };
+}
+
+/** Queue a prompt through the real submit path (isLoading forces queueing). */
+function queuePrompt(
+  harness: Harness,
+  result: { current: ReturnType<typeof useQueuedPrompts> },
+  text: string,
+) {
+  const wasLoading = harness.args.isLoadingRef.current;
+  harness.args.isLoadingRef.current = true;
+  act(() => {
+    result.current.handleChatSubmit(text);
+  });
+  harness.args.isLoadingRef.current = wasLoading;
+}
+
+/** Register a pending plan (with resolver) and point the ref at it. */
+function registerPendingPlan(harness: Harness) {
+  const resolver = vi.fn<(output: SubmitPlanOutput) => void>();
+  usePlanStore.getState().registerPlan(PLAN_TOOL_CALL_ID, CHAT_ID, PLAN_INPUT);
+  usePlanStore.getState().registerResolver(PLAN_TOOL_CALL_ID, resolver);
+  harness.args.pendingPlanToolCallIdRef.current = PLAN_TOOL_CALL_ID;
+  harness.args.messagesRef.current = assistantMessageWithTool(
+    "tool-submit_plan",
+    "input-available",
+  );
+  return resolver;
+}
+
+beforeEach(() => {
+  usePlanStore.setState({ plans: {} });
+});
+
+describe("useQueuedPrompts × pending submit_plan", () => {
+  it("auto-drains a queued prompt as request_changes plan feedback", () => {
+    const harness = buildArgs();
+    const { result } = renderHook(() => useQueuedPrompts(harness.args));
+
+    queuePrompt(harness, result, "also include churn by region");
+    expect(result.current.queuedPrompts).toHaveLength(1);
+
+    const resolver = registerPendingPlan(harness);
+
+    // The onFinish drain (post-turn) fires with the plan awaiting review.
+    act(() => {
+      harness.args.drainQueuedPromptAfterTurnRef.current?.();
+    });
+
+    expect(resolver).toHaveBeenCalledTimes(1);
+    const output = resolver.mock.calls[0][0];
+    expect(output.decision).toBe("request_changes");
+    expect(output.feedback).toBe("also include churn by region");
+    expect(output.editedPlan?.title).toBe("My plan");
+    // Latch set so addToolOutput's auto-send is suppressed (consumed by the
+    // SDK predicate in the real flow).
+    expect(harness.args.suppressNextAutoSendRef.current).toBe(true);
+    expect(harness.sendMessage).toHaveBeenCalledWith({
+      text: "also include churn by region",
+      files: undefined,
+    });
+    expect(result.current.queuedPrompts).toHaveLength(0);
+    expect(usePlanStore.getState().plans[PLAN_TOOL_CALL_ID]?.status).toBe(
+      "request_changes",
+    );
+  });
+
+  it("force-send (top arrow) resolves the pending plan and sends now", async () => {
+    const harness = buildArgs();
+    const { result } = renderHook(() => useQueuedPrompts(harness.args));
+
+    queuePrompt(harness, result, "first queued");
+    queuePrompt(harness, result, "use monthly granularity instead");
+    const forced = result.current.queuedPrompts[1];
+
+    const resolver = registerPendingPlan(harness);
+
+    // Idle (plan awaiting review) — force-send must not need an interrupt.
+    await act(async () => {
+      result.current.handleSendQueuedPromptNow(forced.id);
+    });
+
+    expect(harness.interruptActiveTurn).not.toHaveBeenCalled();
+    expect(resolver).toHaveBeenCalledTimes(1);
+    expect(resolver.mock.calls[0][0].feedback).toBe(
+      "use monthly granularity instead",
+    );
+    expect(harness.sendMessage).toHaveBeenCalledWith({
+      text: "use monthly granularity instead",
+      files: undefined,
+    });
+    // The other prompt stays queued.
+    expect(result.current.queuedPrompts.map(p => p.text)).toEqual([
+      "first queued",
+    ]);
+  });
+
+  it("stays blocked on a non-plan unanswered tool call", () => {
+    const harness = buildArgs();
+    const { result } = renderHook(() => useQueuedPrompts(harness.args));
+
+    queuePrompt(harness, result, "queued text");
+    harness.args.messagesRef.current = assistantMessageWithTool(
+      "tool-run_query",
+      "input-available",
+      "other-tc",
+    );
+
+    act(() => {
+      harness.args.drainQueuedPromptAfterTurnRef.current?.();
+    });
+
+    expect(harness.sendMessage).not.toHaveBeenCalled();
+    expect(result.current.queuedPrompts).toHaveLength(1);
+    expect(harness.args.suppressNextAutoSendRef.current).toBe(false);
+  });
+
+  it("stays blocked (latch released) when the plan has no live resolver", () => {
+    const harness = buildArgs();
+    const { result } = renderHook(() => useQueuedPrompts(harness.args));
+
+    queuePrompt(harness, result, "queued text");
+    // Plan registered as pending, but no resolver (e.g. pre-rehydration).
+    usePlanStore
+      .getState()
+      .registerPlan(PLAN_TOOL_CALL_ID, CHAT_ID, PLAN_INPUT);
+    harness.args.pendingPlanToolCallIdRef.current = PLAN_TOOL_CALL_ID;
+    harness.args.messagesRef.current = assistantMessageWithTool(
+      "tool-submit_plan",
+      "input-available",
+    );
+
+    act(() => {
+      harness.args.drainQueuedPromptAfterTurnRef.current?.();
+    });
+
+    expect(harness.sendMessage).not.toHaveBeenCalled();
+    expect(result.current.queuedPrompts).toHaveLength(1);
+    expect(harness.args.suppressNextAutoSendRef.current).toBe(false);
+  });
+
+  it("drains normally when no tool calls are pending", () => {
+    const harness = buildArgs();
+    const { result } = renderHook(() => useQueuedPrompts(harness.args));
+
+    queuePrompt(harness, result, "plain queued prompt");
+
+    act(() => {
+      harness.args.drainQueuedPromptAfterTurnRef.current?.();
+    });
+
+    expect(harness.sendMessage).toHaveBeenCalledWith({
+      text: "plain queued prompt",
+      files: undefined,
+    });
+    expect(result.current.queuedPrompts).toHaveLength(0);
+  });
+});

--- a/app/src/components/chat/hooks/useQueuedPrompts.ts
+++ b/app/src/components/chat/hooks/useQueuedPrompts.ts
@@ -101,6 +101,40 @@ export function useQueuedPrompts({
   const drainRecheckScheduledRef = useRef(false);
   const forceDrainPastAutoContinueRef = useRef(false);
 
+  // A submit_plan awaiting review is the one unanswered tool call the queue
+  // can settle itself: the drained prompt resolves the plan as
+  // request_changes feedback (carrying the current draft, so manual edits
+  // made in the plan tab flow back) — the same conversational plan-iteration
+  // path as typing in the composer while the plan is pending. The suppress
+  // latch stops `addToolOutput`'s auto-send; the caller's `sendMessage`
+  // ships the resolved tool output AND the user message in one request.
+  // Returns false (and stays blocked) when no plan is pending or no live
+  // resolver is registered yet.
+  const resolvePendingPlanWithFeedback = (feedback: string): boolean => {
+    const pendingPlanToolCallId = pendingPlanToolCallIdRef.current;
+    if (!pendingPlanToolCallId) return false;
+    const planStore = usePlanStore.getState();
+    if (planStore.plans[pendingPlanToolCallId]?.status !== "pending") {
+      return false;
+    }
+    suppressNextAutoSendRef.current = true;
+    // The latch is consumed (one-shot) inside the SDK's sendAutomaticallyWhen
+    // predicate, normally synchronously via the resolver → addToolOutput →
+    // predicate chain.
+    const resolved = planStore.resolvePlan(
+      pendingPlanToolCallId,
+      "request_changes",
+      feedback.trim() || undefined,
+    );
+    if (!resolved) {
+      // No live resolver — release the unconsumed latch and stay blocked.
+      suppressNextAutoSendRef.current = false;
+      return false;
+    }
+    trackEvent("ai_plan_feedback_sent", { model: modelIdRef.current });
+    return true;
+  };
+
   const tryDrainQueuedPromptRef = useRef<() => void>(() => {});
   tryDrainQueuedPromptRef.current = () => {
     // Force-send (top arrow): the user interrupted the running turn to push
@@ -113,9 +147,15 @@ export function useQueuedPrompts({
       if (!forced) {
         pendingForcePromptIdRef.current = null;
       } else {
+        if (isLoadingRef.current) {
+          return;
+        }
+        // A pending submit_plan is not a hard block: force-sending delivers
+        // the prompt as plan feedback (request_changes), same as typing
+        // while the plan awaits review.
         if (
-          isLoadingRef.current ||
-          hasPendingAssistantToolCalls(messagesRef.current)
+          hasPendingAssistantToolCalls(messagesRef.current) &&
+          !resolvePendingPlanWithFeedback(forced.text)
         ) {
           return;
         }
@@ -153,20 +193,27 @@ export function useQueuedPrompts({
       return;
     }
 
-    // Hard blocks: the agent is genuinely mid-turn (streaming, running a
-    // client tool, or has an unanswered tool call). Sending now would race the
-    // loop or break the SDK's "all tool calls must be settled" invariant.
-    if (
-      isLoadingRef.current ||
-      hasPendingAssistantToolCalls(messagesRef.current)
-    ) {
+    // Hard block: the agent is genuinely mid-turn (streaming or running a
+    // client tool). Sending now would race the loop.
+    if (isLoadingRef.current) {
       forceDrainPastAutoContinueRef.current = false;
       return;
     }
 
-    // Soft block: the turn ended on completed tool calls and the SDK might
-    // auto-continue in a microtask. Give it one macrotask before draining.
-    if (
+    if (hasPendingAssistantToolCalls(messagesRef.current)) {
+      // An unanswered tool call usually hard-blocks the drain (sending would
+      // break the SDK's "all tool calls must be settled" invariant) — except
+      // a submit_plan awaiting review, which the head prompt settles itself
+      // as request_changes feedback. When the plan resolves, fall through to
+      // the send below (skipping the soft block: the feedback message MUST
+      // ship now to carry the resolved tool output back to the agent).
+      if (!resolvePendingPlanWithFeedback(queuedPromptsRef.current[0].text)) {
+        forceDrainPastAutoContinueRef.current = false;
+        return;
+      }
+    } else if (
+      // Soft block: the turn ended on completed tool calls and the SDK might
+      // auto-continue in a microtask. Give it one macrotask before draining.
       autoSendWhenComplete({ messages: messagesRef.current }) &&
       !forceDrainPastAutoContinueRef.current
     ) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When a prompt is queued while the agent is busy and the turn ends with the agent presenting a plan (`submit_plan` awaiting review), the queued message never auto-sends, and the force-send arrow silently no-ops. The queue hangs until the user manually resolves the plan.

**Root cause:** `submit_plan` is a deferred human-in-the-loop tool, so the turn settles with the tool call unresolved (`input-available`). Both the queued-prompt auto-drain and the force-send branch in `useQueuedPrompts` hard-block on `hasPendingAssistantToolCalls(...)`, which stays true forever — and nothing ever re-triggers the drain.

## Fix

A `submit_plan` awaiting review is the one unanswered tool call the queue can settle itself. The drain (and force-send) now routes the queued prompt through the existing conversational plan-iteration path — the same one used when typing in the composer while a plan is pending:

- resolve the plan as `request_changes` with the queued prompt text as feedback (carrying the current draft, so manual plan-tab edits flow back),
- set the `suppressNextAutoSend` latch so `addToolOutput` doesn't double-send,
- ship the prompt as a real user message carrying the resolved tool output in one request.

Any other unanswered tool call (or a plan with no live resolver) still hard-blocks the drain, and the suppress latch is released if resolution fails.

## Demo

[queued_prompt_auto_sends_as_plan_feedback.mp4](https://cursor.com/agents/bc-8bcc303d-e3e5-49a3-a567-1fad4d30dab7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fqueued_prompt_auto_sends_as_plan_feedback.mp4)

A message queued while the agent drafts a plan ("1 Queued" above the composer) auto-sends as `request_changes` feedback the moment the plan is presented; the plan flips to "Changes requested" and the agent revises it to include the queued request.

[Message queued while agent plans](https://cursor.com/agents/bc-8bcc303d-e3e5-49a3-a567-1fad4d30dab7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_message_queued_while_agent_plans.webp)
[Revised plan incorporating queued feedback](https://cursor.com/agents/bc-8bcc303d-e3e5-49a3-a567-1fad4d30dab7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_revised_plan_after_queued_feedback.webp)

## Testing

- New unit suite `useQueuedPrompts.test.ts` (5 tests): auto-drain as plan feedback, force-send while a plan is pending, hard block on non-plan pending tool calls, latch release when no resolver is registered, and the plain-drain path.
- `pnpm --filter app run typecheck`, `pnpm --filter app run lint`, `pnpm --filter app run test:unit` (290 tests) all pass.
- Live GUI verification (video above): queued while planning → plan presented → queued prompt auto-drained as feedback → plan revised.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8bcc303d-e3e5-49a3-a567-1fad4d30dab7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bcc303d-e3e5-49a3-a567-1fad4d30dab7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

