### PR TITLE
guides: T-SQL how-tos — window functions, CTEs (Batch 15, MS SQL)

### DIFF
--- a/content/guides/mssql/cte.mdx
+++ b/content/guides/mssql/cte.mdx
@@ -1,0 +1,180 @@
+---
+title: "CTEs in SQL Server: WITH Syntax, Recursive Queries, and MAXRECURSION"
+description: "How to use common table expressions in SQL Server. Covers WITH syntax, chaining CTEs, recursive CTEs for hierarchies, the MAXRECURSION 100 default, the semicolon quirk, and CTE vs temp table."
+database: "mssql"
+category: "sql-how-to"
+tags: ["sql-server", "t-sql", "sql", "cte", "recursive-queries"]
+date: "2026-07-06"
+---
+
+# CTEs in SQL Server
+
+A common table expression (CTE) is a named result set that exists only for the duration of a single statement. It replaces nested derived tables with readable, top-to-bottom logic, and it is the only way in T-SQL to write recursive queries.
+
+SQL Server has supported CTEs since 2005, so version compatibility is a non-issue.
+
+## Basic Syntax
+
+```sql
+WITH regional_totals AS (
+    SELECT region, SUM(amount) AS total
+    FROM sales
+    GROUP BY region
+)
+SELECT region, total
+FROM regional_totals
+WHERE total > 300;
+```
+
+The CTE is visible only to the statement immediately following it. Two CTEs with the same name in different statements are unrelated.
+
+### The Semicolon Quirk
+
+`WITH` also begins other T-SQL constructs (table hints, `WITH XMLNAMESPACES`), so if the previous statement in a batch is not terminated, the parser misreads it:
+
+```
+Incorrect syntax near the keyword 'with'. If this statement is a common
+table expression ... the previous statement must be terminated with a semicolon.
+```
+
+The fix is to terminate the preceding statement with `;`. You will see many scripts write `;WITH` as a defensive habit. It works, but the honest fix is terminating every statement -- Microsoft has deprecated non-semicolon-terminated statements for years.
+
+## Chaining Multiple CTEs
+
+One `WITH`, comma-separated definitions. Later CTEs can reference earlier ones:
+
+```sql
+WITH daily AS (
+    SELECT sale_date, SUM(amount) AS day_total
+    FROM sales
+    GROUP BY sale_date
+),
+ranked AS (
+    SELECT sale_date, day_total,
+           RANK() OVER (ORDER BY day_total DESC) AS rnk
+    FROM daily
+)
+SELECT sale_date, day_total
+FROM ranked
+WHERE rnk <= 3;
+```
+
+This CTE-then-window-function pattern is the standard workaround for T-SQL's lack of `QUALIFY`: window functions cannot appear in `WHERE`, so you name the intermediate result and filter one level up.
+
+## CTEs Are Inlined, Not Materialized
+
+SQL Server expands a CTE into the outer query like a macro. It does **not** compute the result once and cache it. Reference a CTE three times and its query can be evaluated three times, each potentially re-scanning the base tables.
+
+Consequences:
+
+- A cheap CTE referenced multiple times is fine -- the optimizer works with the expanded tree.
+- An expensive CTE referenced multiple times can silently multiply its cost. If you see the same heavy scan repeated in the execution plan, materialize the intermediate result yourself in a `#temp` table (which also gets statistics, unlike a CTE or table variable) and join to that.
+- Unlike PostgreSQL, there is no `AS MATERIALIZED` hint. The temp table *is* the materialization hint in T-SQL.
+
+CTE vs temp table in one line: CTE for readability and single-statement logic, `#temp` table for large intermediate results used more than once.
+
+## Recursive CTEs
+
+A recursive CTE has an anchor member, `UNION ALL`, and a recursive member that references the CTE itself:
+
+```sql
+CREATE TABLE employees (
+    id         int primary key,
+    name       varchar(50),
+    manager_id int NULL
+);
+
+INSERT INTO employees VALUES
+    (1, 'Ada',   NULL),
+    (2, 'Grace', 1),
+    (3, 'Edgar', 1),
+    (4, 'Linus', 2);
+
+WITH org AS (
+    -- anchor: the root(s)
+    SELECT id, name, manager_id, 0 AS depth,
+           CAST(name AS varchar(4000)) AS path
+    FROM employees
+    WHERE manager_id IS NULL
+
+    UNION ALL
+
+    -- recursive member: joins back to the CTE
+    SELECT e.id, e.name, e.manager_id, org.depth + 1,
+           CAST(org.path + ' > ' + e.name AS varchar(4000))
+    FROM employees e
+    JOIN org ON e.manager_id = org.id
+)
+SELECT * FROM org ORDER BY path;
+```
+
+Execution is iterative: the anchor produces level 0, then the recursive member runs against the previous level's rows until an iteration produces nothing.
+
+Two T-SQL-specific rules trip people up:
+
+1. **Column types must match exactly** between anchor and recursive member. The `CAST(... AS varchar(4000))` on both sides above is not decoration -- without it, string concatenation grows the type and you get "Types don't match between the anchor and the recursive part".
+2. **The recursive member is restricted**: no `GROUP BY`, no aggregates, no `TOP`, no outer join against the CTE, and the CTE may be referenced exactly once in it.
+
+### MAXRECURSION: the 100-Level Default
+
+SQL Server aborts a recursive CTE after 100 recursions by default:
+
+```
+The maximum recursion 100 has been exhausted before statement completion.
+```
+
+Override per query:
+
+```sql
+SELECT * FROM org
+OPTION (MAXRECURSION 1000);   -- up to 32767, or 0 for unlimited
+```
+
+Treat the error as a signal first and a limit second. Real org charts and BOM hierarchies are rarely 100 levels deep -- hitting the cap usually means a cycle in your data (a row that is its own ancestor). `MAXRECURSION 0` removes the safety net entirely; if there is a cycle, the query runs until you kill it. For cycle detection, carry a path string (as above) and add `WHERE org.path NOT LIKE '%' + e.name + '%'`-style guards, or better, use a numeric id path.
+
+One more gotcha: `MAXRECURSION` is a statement-level hint, so you cannot put it inside a view definition. Put the hint in the query that selects *from* the view.
+
+### Generating Sequences (and Why Not To)
+
+The number-series recursive CTE shows up in every tutorial:
+
+```sql
+WITH nums AS (
+    SELECT 1 AS n
+    UNION ALL
+    SELECT n + 1 FROM nums WHERE n < 1000
+)
+SELECT n FROM nums OPTION (MAXRECURSION 0);
+```
+
+It works, but it is row-by-row iteration. From SQL Server 2022, `GENERATE_SERIES(1, 1000)` does the same thing set-based and faster. On older versions, a tally table or cross-joined `VALUES` clauses beat recursion for large ranges.
+
+## Updating Through a CTE
+
+CTEs can be the target of `UPDATE`, `DELETE`, and `INSERT`, which makes "delete duplicates keeping one" a two-liner:
+
+```sql
+WITH dupes AS (
+    SELECT *, ROW_NUMBER() OVER (
+        PARTITION BY region, sale_date ORDER BY amount DESC
+    ) AS rn
+    FROM sales
+)
+DELETE FROM dupes WHERE rn > 1;
+```
+
+The delete applies to the underlying table. This works because the CTE is updatable (single base table, no aggregation) -- the same rules as updatable views.
+
+## Common Mistakes
+
+- **Assuming the CTE runs once.** It is inlined. Expensive CTE + multiple references = multiplied cost; use a `#temp` table.
+- **Missing semicolon before `WITH`** in multi-statement batches.
+- **Type mismatch between anchor and recursive member.** CAST both sides explicitly.
+- **`MAXRECURSION 0` as a reflex.** Find out *why* you exceeded 100 first -- it is usually a data cycle.
+- **`ORDER BY` inside a CTE.** Not allowed without `TOP`, and even with `TOP` it does not guarantee outer ordering. Order in the outer query.
+
+CTEs are also where AI-assisted editors earn their keep -- Mako's autocomplete can scaffold the anchor/recursive-member structure from a description of the hierarchy while you fill in the join logic.
+
+---
+
+Mako connects to SQL Server with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/mssql/window-functions.mdx
+++ b/content/guides/mssql/window-functions.mdx
@@ -1,0 +1,190 @@
+---
+title: "SQL Server Window Functions: ROW_NUMBER, RANK, LAG, Running Totals"
+description: "How to use window functions in SQL Server with OVER, PARTITION BY, and frame clauses. Covers ROW_NUMBER, RANK, LAG/LEAD, the RANGE default gotcha, and the 2022 WINDOW clause and IGNORE NULLS."
+database: "mssql"
+category: "sql-how-to"
+tags: ["sql-server", "t-sql", "sql", "window-functions", "analytics"]
+date: "2026-07-06"
+---
+
+# SQL Server Window Functions
+
+Window functions compute values across a set of rows related to the current row, without collapsing those rows into one. They are the standard way to express running totals, rankings, and row-to-row comparisons that would otherwise need self-joins or correlated subqueries.
+
+SQL Server has shipped the full set since SQL Server 2012: ranking functions, offset functions (LAG/LEAD, FIRST_VALUE/LAST_VALUE), and aggregate functions with frame support. SQL Server 2022 added two long-requested pieces: the WINDOW clause and NULL treatment (IGNORE NULLS). Both are covered below.
+
+## Sample Schema
+
+```sql
+CREATE TABLE sales (
+    region     varchar(10)  NOT NULL,
+    sale_date  date         NOT NULL,
+    amount     int          NOT NULL
+);
+
+INSERT INTO sales VALUES
+    ('north', '2026-01-01', 100),
+    ('north', '2026-01-02', 150),
+    ('north', '2026-01-03', 120),
+    ('south', '2026-01-01', 200),
+    ('south', '2026-01-02', 180);
+```
+
+## The Anatomy of a Window Function
+
+```sql
+SELECT
+    region,
+    sale_date,
+    amount,
+    SUM(amount) OVER (
+        PARTITION BY region       -- split rows into independent windows
+        ORDER BY sale_date        -- order rows within each window
+        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW  -- the frame
+    ) AS running_total
+FROM sales;
+```
+
+Three parts, all optional individually:
+
+- `PARTITION BY` splits the result set into independent groups. Without it, the whole result set is one window.
+- `ORDER BY` defines row order inside the window. Required for ranking and offset functions.
+- The frame clause (`ROWS`/`RANGE BETWEEN ...`) restricts which rows the function sees. Only aggregate and some analytic functions accept it.
+
+## Ranking: ROW_NUMBER, RANK, DENSE_RANK, NTILE
+
+```sql
+SELECT
+    region,
+    amount,
+    ROW_NUMBER() OVER (PARTITION BY region ORDER BY amount DESC) AS rn,
+    RANK()       OVER (PARTITION BY region ORDER BY amount DESC) AS rnk,
+    DENSE_RANK() OVER (PARTITION BY region ORDER BY amount DESC) AS drnk,
+    NTILE(2)     OVER (PARTITION BY region ORDER BY amount DESC) AS half
+FROM sales;
+```
+
+- `ROW_NUMBER()` numbers rows 1, 2, 3 with no ties -- ties are broken arbitrarily unless your `ORDER BY` is unique.
+- `RANK()` gives tied rows the same rank and skips the next values (1, 1, 3).
+- `DENSE_RANK()` gives tied rows the same rank without gaps (1, 1, 2).
+- `NTILE(n)` deals rows into n buckets as evenly as possible.
+
+The classic use is top-N per group. Window functions cannot appear in `WHERE`, so wrap the query:
+
+```sql
+SELECT region, sale_date, amount
+FROM (
+    SELECT *,
+        ROW_NUMBER() OVER (PARTITION BY region ORDER BY amount DESC) AS rn
+    FROM sales
+) ranked
+WHERE rn <= 2;
+```
+
+A derived table or CTE is required; T-SQL also has no `QUALIFY` clause (Snowflake and BigQuery users will miss it).
+
+## LAG and LEAD: Comparing to Neighboring Rows
+
+```sql
+SELECT
+    region,
+    sale_date,
+    amount,
+    LAG(amount)  OVER (PARTITION BY region ORDER BY sale_date) AS prev_amount,
+    amount - LAG(amount, 1, 0)
+        OVER (PARTITION BY region ORDER BY sale_date) AS change
+FROM sales;
+```
+
+`LAG(col, offset, default)` reads a previous row; `LEAD` reads a following one. The third argument replaces the NULL you would otherwise get at partition edges -- here `0` instead of NULL for the first row of each region.
+
+## Running Totals and the RANGE Default Gotcha
+
+The single most common window-function bug in SQL Server: when you write `ORDER BY` in an `OVER` clause but no frame, the default frame is `RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW` -- not `ROWS`.
+
+`RANGE` treats all rows with the same `ORDER BY` value as peers of the current row and includes all of them. If two rows share a date, both get the total *including each other*, so your "running total" jumps in steps instead of row by row. It is also slower: the `RANGE` implementation spools rows to tempdb (an on-disk worktable), while `ROWS` uses an in-memory spool.
+
+Be explicit:
+
+```sql
+SUM(amount) OVER (
+    PARTITION BY region
+    ORDER BY sale_date
+    ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+) AS running_total
+```
+
+For a moving average over the last 3 rows:
+
+```sql
+AVG(amount) OVER (
+    PARTITION BY region
+    ORDER BY sale_date
+    ROWS BETWEEN 2 PRECEDING AND CURRENT ROW
+) AS moving_avg_3
+```
+
+Note SQL Server's `RANGE` only supports `UNBOUNDED` and `CURRENT ROW` bounds -- interval-based frames like `RANGE INTERVAL '7' DAY PRECEDING` (PostgreSQL) do not exist in T-SQL.
+
+## FIRST_VALUE, LAST_VALUE, and IGNORE NULLS (2022+)
+
+`LAST_VALUE` with the default frame returns the current row's value, not the partition's last -- the frame ends at `CURRENT ROW`. Extend it:
+
+```sql
+LAST_VALUE(amount) OVER (
+    PARTITION BY region
+    ORDER BY sale_date
+    ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+) AS final_amount
+```
+
+SQL Server 2022 added NULL treatment for the offset functions, which makes "carry the last known value forward" expressible without workarounds:
+
+```sql
+LAST_VALUE(reading) IGNORE NULLS OVER (
+    ORDER BY reading_time
+    ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+) AS last_known_reading
+```
+
+`IGNORE NULLS` / `RESPECT NULLS` (the default) work on `FIRST_VALUE`, `LAST_VALUE`, `LAG`, and `LEAD`. On 2019 and earlier you need the two-step "grouping flag" workaround with a running MAX over a CASE expression.
+
+## The WINDOW Clause (2022+)
+
+Repeating the same `OVER (...)` spec across five columns is noisy. SQL Server 2022 (database compatibility level 160) lets you name it once:
+
+```sql
+SELECT
+    region,
+    sale_date,
+    amount,
+    SUM(amount)  OVER w AS running_total,
+    AVG(amount)  OVER w AS running_avg,
+    COUNT(*)     OVER w AS running_count
+FROM sales
+WINDOW w AS (
+    PARTITION BY region
+    ORDER BY sale_date
+    ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+);
+```
+
+Named windows can also be refined per-function: `OVER (w ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)`.
+
+## Common Mistakes
+
+- **Relying on the default frame.** You get `RANGE`, peer-row surprises with ties, and a tempdb worktable. Write `ROWS BETWEEN ... ` explicitly whenever `ORDER BY` is present.
+- **Filtering on a window function in WHERE.** Window functions are evaluated after `WHERE`. Wrap in a CTE or derived table.
+- **`LAST_VALUE` without extending the frame.** Returns the current row. Use `UNBOUNDED FOLLOWING` or flip to `FIRST_VALUE` with `ORDER BY ... DESC`.
+- **Non-deterministic `ROW_NUMBER` ties.** If the `ORDER BY` is not unique, row numbers can change between runs. Add a tiebreaker column.
+- **Expecting `QUALIFY`.** T-SQL does not have it (as of SQL Server 2025 previews it still does not). Derived table it is.
+
+Window functions are also a good fit for exploring data interactively -- Mako's AI autocomplete can draft the `OVER` clause and frame spec from a plain-language description while you iterate on a query.
+
+## Performance Notes
+
+A window function's `PARTITION BY` + `ORDER BY` combination wants a supporting index (`region, sale_date` in the examples above) to avoid a sort. Check the plan for Sort and Window Spool operators; a `ROWS` frame with a covering index is the fast path. Multiple different window specs in one query mean multiple sorts.
+
+---
+
+Mako connects to SQL Server with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).


### PR DESCRIPTION
New batch: **Batch 15 — SQL how-tos for MS SQL / T-SQL** (20-article series mirroring the PostgreSQL/MySQL/SQLite/ClickHouse how-to batches).

**Scoping rationale (challenge-before-building):** connection axis is fully closed (Py/Node/Go/Java/C#/PHP/Ruby × 9 = 63 guides, all merged). Remaining candidates were Rust connection guides (thin keyword volume), migration guides (new axis), and T-SQL how-tos. Picked T-SQL: genuinely distinct dialect (not a MySQL near-dup — RANGE default frame, MAXRECURSION, no QUALIFY, WINDOW clause 2022, IGNORE NULLS), large keyword surface, and the mssql GUI/import/connect guides already exist so the internal-link web is in place.

Articles in this PR:
- `mssql/window-functions` — ROW_NUMBER/RANK/DENSE_RANK/NTILE, LAG/LEAD, the RANGE-default-frame gotcha (peer rows + tempdb spool), FIRST_VALUE/LAST_VALUE frame trap, 2022 IGNORE NULLS + WINDOW clause, no-QUALIFY workaround
- `mssql/cte` — WITH syntax, semicolon quirk, chaining, inlined-not-materialized (vs #temp table), recursive CTEs (anchor type-match rule, restrictions), MAXRECURSION 100 default + cycle detection, GENERATE_SERIES (2022) over number-series recursion, updatable CTEs

Content-only, follows editorial guidelines (researched against current top results + MS docs, no banned words, honest limitations, single CTA).