### PR TITLE
Fix Close MCP replay 400 (tool_use.input must be a dictionary) + ground agent in current date

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -13,7 +13,7 @@
     "worker:dev": "tsx watch --include \"src/**/*\" src/worker.ts",
     "migrate:workspaces": "tsx src/migrations/migrate-to-workspaces.ts",
     "openapi:generate": "tsx src/openapi/generate-cli.ts",
-    "test": "tsx src/openapi/core.test.ts && tsx src/openapi/openapi.test.ts && tsx src/dbt/warm-dir-cache.test.ts && tsx src/connectors/stripe/connector.test.ts && tsx src/connectors/close/connector.test.ts && tsx src/connectors/pandadoc/connector.test.ts && tsx src/connectors/claap/connector.test.ts && tsx src/sync-cdc/idempotency.test.ts && tsx src/agent-lib/context/compaction.test.ts && tsx src/services/safe-fetch.service.test.ts && tsx src/services/mcp-client.service.test.ts && tsx src/agent-lib/tools/check-query-status-poll.test.ts && tsx src/agent-lib/tools/str-replace.test.ts && tsx src/agents/modes/derive-mode-state.test.ts",
+    "test": "tsx src/openapi/core.test.ts && tsx src/openapi/openapi.test.ts && tsx src/dbt/warm-dir-cache.test.ts && tsx src/connectors/stripe/connector.test.ts && tsx src/connectors/close/connector.test.ts && tsx src/connectors/pandadoc/connector.test.ts && tsx src/connectors/claap/connector.test.ts && tsx src/sync-cdc/idempotency.test.ts && tsx src/agent-lib/context/compaction.test.ts && tsx src/services/safe-fetch.service.test.ts && tsx src/services/mcp-client.service.test.ts && tsx src/utils/message-sanitizer.test.ts && tsx src/agent-lib/tools/check-query-status-poll.test.ts && tsx src/agent-lib/tools/str-replace.test.ts && tsx src/agents/modes/derive-mode-state.test.ts",
     "test:dbt": "vitest run",
     "test:dbt:watch": "vitest",
     "test:destinations": "vitest run --config vitest.destinations.config.ts",

--- a/api/src/agents/unified/prompt.ts
+++ b/api/src/agents/unified/prompt.ts
@@ -376,6 +376,22 @@ export function buildCurrentScreenContext(context: AgentContext): string {
   sections.push("## Current Workspace State");
   sections.push("");
 
+  // Ground relative-date reasoning ("next Friday", "last quarter") — without
+  // this the model guesses a date from its training cutoff, which produces
+  // silently wrong due dates in CRM tasks, SQL date filters, etc. Date-only
+  // (no clock time) so the block stays stable within a day.
+  const now = new Date();
+  sections.push(
+    `Current date: ${now.toLocaleDateString("en-US", {
+      weekday: "long",
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      timeZone: "UTC",
+    })} (UTC)`,
+  );
+  sections.push("");
+
   sections.push(...buildTabSummary(context));
   sections.push("");
 

--- a/api/src/utils/message-sanitizer.test.ts
+++ b/api/src/utils/message-sanitizer.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Message sanitizer tests.
+ *
+ * Focus: repairing persisted tool parts whose `input` is not a JSON object
+ * before they reach `convertToModelMessages`. Anthropic rejects a replayed
+ * `tool_use` whose input is a string/missing with
+ * "messages.N.content.M.tool_use.input: Input should be a valid dictionary"
+ * — reproduced live with the Close CRM MCP tools when the model emitted
+ * malformed tool-call JSON (AI SDK keeps the raw text on `rawInput`).
+ *
+ * Run: tsx src/utils/message-sanitizer.test.ts
+ */
+import assert from "node:assert/strict";
+import { convertToModelMessages, type UIMessage } from "ai";
+import { sanitizeMessagesForModel } from "./message-sanitizer";
+
+type LoosePart = Record<string, unknown>;
+
+function assistantMessage(parts: LoosePart[]): UIMessage {
+  return { id: "a1", role: "assistant", parts } as unknown as UIMessage;
+}
+
+function userMessage(text: string, id = "u1"): UIMessage {
+  return { id, role: "user", parts: [{ type: "text", text }] } as UIMessage;
+}
+
+function firstToolPart(msg: UIMessage): LoosePart {
+  const part = (msg.parts as unknown as LoosePart[]).find(
+    p => p.type === "dynamic-tool" || String(p.type).startsWith("tool-"),
+  );
+  assert.ok(part, "expected a tool part");
+  return part;
+}
+
+function testStringRawInputIsRepaired() {
+  // Invalid tool call: the model emitted truncated JSON. AI SDK leaves
+  // `input` undefined and stores the raw text on `rawInput` — which
+  // convertToModelMessages forwards verbatim for output-error parts.
+  const sanitized = sanitizeMessagesForModel([
+    userMessage("search leads"),
+    assistantMessage([
+      {
+        type: "dynamic-tool",
+        toolName: "mcp_close_crm_lead_search",
+        toolCallId: "call_1",
+        state: "output-error",
+        rawInput: '{"query": "name:Acme', // truncated → unparseable
+        errorText: "Invalid tool input",
+      },
+    ]),
+  ]);
+
+  const part = firstToolPart(sanitized[1]);
+  assert.deepEqual(part.input, {});
+  assert.equal(part.rawInput, undefined);
+}
+
+function testParseableStringInputIsRecovered() {
+  const sanitized = sanitizeMessagesForModel([
+    userMessage("fetch lead"),
+    assistantMessage([
+      {
+        type: "dynamic-tool",
+        toolName: "mcp_close_crm_fetch_lead",
+        toolCallId: "call_2",
+        state: "output-available",
+        input: '{"id":"lead_123"}', // stringified instead of parsed
+        output: "Lead: Acme Robotics",
+      },
+    ]),
+  ]);
+
+  const part = firstToolPart(sanitized[1]);
+  assert.deepEqual(part.input, { id: "lead_123" });
+}
+
+function testUndefinedInputBecomesEmptyObject() {
+  // Zero-argument tools (e.g. Close's org_info) can persist with no input.
+  const sanitized = sanitizeMessagesForModel([
+    userMessage("org info"),
+    assistantMessage([
+      {
+        type: "dynamic-tool",
+        toolName: "mcp_close_crm_org_info",
+        toolCallId: "call_3",
+        state: "output-available",
+        output: "Org: Mako Demo Org",
+      },
+    ]),
+  ]);
+
+  const part = firstToolPart(sanitized[1]);
+  assert.deepEqual(part.input, {});
+}
+
+function testObjectInputIsPreserved() {
+  const input = { id: "lead_123", description: "Robotics leader" };
+  const sanitized = sanitizeMessagesForModel([
+    userMessage("update lead"),
+    assistantMessage([
+      {
+        type: "dynamic-tool",
+        toolName: "mcp_close_crm_update_lead",
+        toolCallId: "call_4",
+        state: "output-available",
+        input,
+        output: "Updated",
+      },
+    ]),
+  ]);
+
+  const part = firstToolPart(sanitized[1]);
+  assert.deepEqual(part.input, input);
+}
+
+function testLegacyErrorStateStillRepairsInput() {
+  const sanitized = sanitizeMessagesForModel([
+    userMessage("create lead"),
+    assistantMessage([
+      {
+        type: "dynamic-tool",
+        toolName: "mcp_close_crm_create_lead",
+        toolCallId: "call_5",
+        state: "error", // legacy client normalization
+        input: "not json at all",
+        output: { success: false, error: "Interrupted" },
+      },
+    ]),
+  ]);
+
+  const part = firstToolPart(sanitized[1]);
+  assert.equal(part.state, "output-error");
+  assert.equal(part.errorText, "Interrupted");
+  assert.deepEqual(part.input, {});
+  assert.equal(part.output, undefined);
+}
+
+async function testConvertedToolCallsAlwaysHaveObjectInput() {
+  // End-to-end through the real AI SDK conversion: every tool-call the
+  // provider will see must carry a plain-object input.
+  const sanitized = sanitizeMessagesForModel([
+    userMessage("do things"),
+    assistantMessage([
+      { type: "step-start" },
+      {
+        type: "dynamic-tool",
+        toolName: "mcp_close_crm_lead_search",
+        toolCallId: "call_a",
+        state: "output-error",
+        rawInput: '{"query": "name:Acme',
+        errorText: "Invalid tool input",
+      },
+      {
+        type: "dynamic-tool",
+        toolName: "mcp_close_crm_org_info",
+        toolCallId: "call_b",
+        state: "output-available",
+        output: "Org info",
+      },
+    ]),
+    userMessage("continue", "u2"),
+  ]);
+
+  const modelMessages = await convertToModelMessages(sanitized);
+  const toolCalls = modelMessages
+    .flatMap(m => (Array.isArray(m.content) ? m.content : []))
+    .filter(
+      (c): c is { type: "tool-call"; input: unknown } =>
+        (c as { type?: string }).type === "tool-call",
+    );
+  assert.equal(toolCalls.length, 2);
+  for (const call of toolCalls) {
+    assert.equal(
+      typeof call.input === "object" &&
+        call.input !== null &&
+        !Array.isArray(call.input),
+      true,
+      `tool-call input must be a plain object, got: ${JSON.stringify(call.input)}`,
+    );
+  }
+}
+
+async function main() {
+  testStringRawInputIsRepaired();
+  testParseableStringInputIsRecovered();
+  testUndefinedInputBecomesEmptyObject();
+  testObjectInputIsPreserved();
+  testLegacyErrorStateStillRepairsInput();
+  await testConvertedToolCallsAlwaysHaveObjectInput();
+  // eslint-disable-next-line no-console
+  console.log("message-sanitizer tests passed");
+}
+
+void main();

--- a/api/src/utils/message-sanitizer.ts
+++ b/api/src/utils/message-sanitizer.ts
@@ -50,6 +50,41 @@ function dropMalformedFileParts(
 }
 
 /**
+ * Coerce a persisted tool-call input into the plain object shape providers
+ * require. Anthropic rejects any replayed `tool_use` whose `input` is not a
+ * JSON object ("Input should be a valid dictionary"), which happens when:
+ *
+ * - the model emitted malformed/truncated tool-call JSON (the AI SDK keeps
+ *   the raw text on `rawInput` and leaves `input` undefined), or
+ * - a stream was interrupted mid tool-input and the client persisted the
+ *   partial raw string.
+ *
+ * `convertToModelMessages` (v6) forwards `input ?? rawInput` verbatim for
+ * `output-error` parts, so a string leaks straight through to the provider.
+ * Strings that parse to an object are recovered; everything else falls back
+ * to `{}` (the tool-result/errorText still tells the model what happened).
+ */
+function coerceToolInputToObject(input: unknown, rawInput: unknown): unknown {
+  const candidates = [input, rawInput];
+  for (const candidate of candidates) {
+    if (isRecord(candidate) && !Array.isArray(candidate)) {
+      return candidate;
+    }
+    if (typeof candidate === "string") {
+      try {
+        const parsed: unknown = JSON.parse(candidate);
+        if (isRecord(parsed) && !Array.isArray(parsed)) {
+          return parsed;
+        }
+      } catch {
+        // Malformed JSON (e.g. truncated stream) — fall through.
+      }
+    }
+  }
+  return {};
+}
+
+/**
  * Sanitize UIMessages by removing incomplete tool parts.
  *
  * When a chat stream is interrupted (user closes browser, network failure, etc.),
@@ -117,6 +152,12 @@ export function sanitizeMessagesForModel(messages: UIMessage[]): UIMessage[] {
       }
 
       const p = part as Record<string, unknown>;
+      // Providers require tool_use.input to be a JSON object on replay; a
+      // string/undefined input (invalid tool call, interrupted stream) must
+      // be repaired here or the whole continuation request 400s. `rawInput`
+      // is dropped so `convertToModelMessages` cannot fall back to the raw
+      // (possibly malformed) string for output-error parts.
+      const input = coerceToolInputToObject(p.input, p.rawInput);
       if (p.state === "error") {
         const output = p.output as Record<string, unknown> | null | undefined;
         const errorText =
@@ -134,11 +175,17 @@ export function sanitizeMessagesForModel(messages: UIMessage[]): UIMessage[] {
         return {
           ...part,
           state: "output-error",
+          input,
+          rawInput: undefined,
           output: undefined,
           errorText,
         } as typeof part;
       }
-      return part;
+      return {
+        ...part,
+        input,
+        rawInput: undefined,
+      } as typeof part;
     });
 
     const sanitizedParts = partsNormalized.filter(part => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Fix Close MCP tool replay 400 + date grounding

## Bug 1: `messages.N.content.M.tool_use.input: Input should be a valid dictionary`

Reproduced live against the real Close MCP server (`https://mcp.close.com/mcp`, demo org + API key). When the model emits malformed/truncated tool-call JSON (or a stream dies mid tool-input), the AI SDK persists the raw string on `rawInput` with `input` undefined. On the next turn, `convertToModelMessages` forwards `input ?? rawInput` verbatim for `output-error` parts, so a raw string reaches Anthropic as `tool_use.input` and the whole continuation request 400s — every subsequent message in that chat fails.

**Fix:** `sanitizeMessagesForModel` now coerces every replayed tool-part input to a plain object (parse recoverable JSON strings, fall back to `{}`) and strips `rawInput`. Regression tests in `api/src/utils/message-sanitizer.test.ts` cover string `rawInput`, stringified inputs, undefined inputs (zero-arg tools like Close's `org_info`), legacy `state: "error"`, and an end-to-end assertion through the real `convertToModelMessages`.

Repro before/after through `POST /api/agent/chat`:
[Repro log](https://cursor.com/agents/bc-019f2ba9-75be-7e4a-850f-c4ffd6b12264/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frepro_before_after.log)

## Bug 2: agent has no idea what day it is

Found while testing Close write tools: "create a task due next Friday" produced a task due **2025-01-31** (model training-cutoff guess; today is 2026-07-06). The unified agent context now injects the current date into the dynamic (uncached) system block, so prompt caching is unaffected.

## End-to-end verification with real Close MCP

Set up a real Close trial org (via AgentMail inbox `mako-close-demo@agentmail.to`), connected it as an MCP server with API-key auth + `write_destructive` scope, discovered all 97 tools, and exercised read tools, the approval flow (allow + deny), denial recovery, and write tools — writes verified via the Close REST API.

[close_mcp_write_approval_flow_demo.mp4](https://cursor.com/agents/bc-019f2ba9-75be-7e4a-850f-c4ffd6b12264/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclose_mcp_write_approval_flow_demo.mp4)

[Approval cards for write tools](https://cursor.com/agents/bc-019f2ba9-75be-7e4a-850f-c4ffd6b12264/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclose_mcp_approval_cards.webp)
[Read tools listing leads](https://cursor.com/agents/bc-019f2ba9-75be-7e4a-850f-c4ffd6b12264/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclose_mcp_org_and_leads_answer.webp)

## Testing

- ✅ `pnpm --filter api run test` (incl. new `message-sanitizer.test.ts`)
- ✅ `pnpm --filter api run lint`
- ✅ `pnpm --filter api run build`
- ✅ Manual repro payload against `POST /api/agent/chat`: 400 before, streams normally after
- ✅ Manual UI testing of Close MCP read/write/approval/denial flows with Claude Sonnet 4.5

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2ba9-75be-7e4a-850f-c4ffd6b12264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2ba9-75be-7e4a-850f-c4ffd6b12264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

