### PR TITLE
feat(apps): AI-suggested commit message when publishing app versions

### DIFF
--- a/api/src/routes/apps.ts
+++ b/api/src/routes/apps.ts
@@ -17,6 +17,7 @@ import {
   MakoApp,
   DatabaseConnection,
   DbtProject,
+  EntityVersion,
   type IMakoApp,
 } from "../database/workspace-schema";
 import { loggers, enrichContextWithWorkspace } from "../logging";
@@ -48,6 +49,8 @@ import {
   getVersion,
   getUserDisplayName,
 } from "../services/entity-version.service";
+import { generateAppVersionComment } from "../services/version-comment.service";
+import { getEntityChatPrompts } from "../services/entity-version-context.service";
 import { publishRealtimeEvent } from "../services/realtime.service";
 import {
   canReadResource,
@@ -1041,6 +1044,83 @@ app.openapi(
     } catch (error) {
       logger.error("Error saving app version", { error });
       return c.json({ success: false, error: "Failed to save version" }, 500);
+    }
+  },
+);
+
+// POST /{id}/version-comment — AI-suggested commit message for the pending
+// draft. Diffs the current (autosaved) draft against the latest saved version
+// snapshot and folds in any chat prompts that drove the changes. The client
+// should flush pending edits (PUT the draft) before calling this.
+app.openapi(
+  createRoute({
+    method: "post",
+    path: "/{id}/version-comment",
+    tags: ["Apps"],
+    summary: "Suggest a version comment for pending app changes",
+    security: AUTH_SECURITY,
+    request: { params: AppIdParam },
+    responses: { ...OPEN_RESPONSES },
+  }),
+  async c => {
+    try {
+      const workspaceId = c.req.param("workspaceId") as string;
+      const id = c.req.param("id");
+      const userId = c.get("user")?.id;
+      if (!Types.ObjectId.isValid(id)) {
+        return c.json({ success: false, error: "Invalid app ID" }, 400);
+      }
+      const doc = await MakoApp.findOne({
+        _id: new Types.ObjectId(id),
+        workspaceId: new Types.ObjectId(workspaceId),
+      });
+      if (!doc) return c.json({ success: false, error: "App not found" }, 404);
+      if (!canManage(doc, userId, c.get("memberRole"))) {
+        return c.json({ success: false, error: "Access denied" }, 403);
+      }
+
+      const newSnapshot = buildAppSnapshot(doc) as unknown as Record<
+        string,
+        unknown
+      >;
+
+      const latestVersion = await EntityVersion.findOne(
+        {
+          entityId: doc._id,
+          entityType: "app",
+        },
+        { snapshot: 1, version: 1 },
+      )
+        .sort({ version: -1 })
+        .lean();
+
+      const previousSnapshot =
+        (latestVersion?.snapshot as Record<string, unknown> | undefined) ??
+        (doc.published as Record<string, unknown> | undefined) ??
+        null;
+
+      const chatPrompts = userId
+        ? await getEntityChatPrompts(workspaceId, userId, id, ["appId"])
+        : [];
+
+      const result = await generateAppVersionComment(
+        { previousSnapshot, newSnapshot, chatPrompts },
+        userId
+          ? { workspaceId, userId, userEmail: c.get("user")?.email }
+          : undefined,
+      );
+
+      return c.json({
+        success: true,
+        comment: result.comment,
+        diff: result.diff,
+      });
+    } catch (error) {
+      logger.error("Error generating app version comment", { error });
+      return c.json(
+        { success: false, error: "Failed to generate version comment" },
+        500,
+      );
     }
   },
 );

--- a/api/src/routes/dashboards.ts
+++ b/api/src/routes/dashboards.ts
@@ -36,7 +36,7 @@ import {
   getUserDisplayName,
 } from "../services/entity-version.service";
 import { generateDashboardVersionComment } from "../services/version-comment.service";
-import { getDashboardChatPrompts } from "../services/dashboard-version-context.service";
+import { getEntityChatPrompts } from "../services/entity-version-context.service";
 import {
   registerCollaboratorRoutes,
   registerSharingSettingsRoutes,
@@ -1480,10 +1480,11 @@ app.openapi(
         (latestVersion?.snapshot as Record<string, unknown> | undefined) ??
         null;
 
-      const chatPrompts = await getDashboardChatPrompts(
+      const chatPrompts = await getEntityChatPrompts(
         workspaceId,
         userId,
         dashboardId,
+        ["dashboardId"],
       );
 
       const result = await generateDashboardVersionComment(

--- a/api/src/services/entity-version-context.service.ts
+++ b/api/src/services/entity-version-context.service.ts
@@ -1,12 +1,12 @@
 /**
- * Dashboard version context
+ * Entity version context
  *
  * Best-effort extraction of the chat prompts that drove changes to a given
- * dashboard. There is no persisted FK from a chat to a dashboard, so we scan
- * the user's recent chats for tool calls that reference the dashboard id and
- * collect the user prompts that immediately preceded those edits. This covers
- * AI-driven dashboard changes; purely manual edits simply yield no prompts and
- * the comment generator falls back to the diff alone.
+ * entity (dashboard, app, ...). There is no persisted FK from a chat to an
+ * entity, so we scan the user's recent chats for tool calls that reference the
+ * entity id and collect the user prompts that immediately preceded those
+ * edits. This covers AI-driven changes; purely manual edits simply yield no
+ * prompts and the comment generator falls back to the diff alone.
  */
 
 import { Types } from "mongoose";
@@ -63,13 +63,16 @@ function extractToolInputs(msg: any): Array<Record<string, unknown>> {
   return inputs;
 }
 
-function messageTouchesDashboard(msg: any, dashboardId: string): boolean {
+function messageTouchesEntity(
+  msg: any,
+  entityId: string,
+  idFields: string[],
+): boolean {
   for (const input of extractToolInputs(msg)) {
-    if (
-      typeof input.dashboardId === "string" &&
-      input.dashboardId === dashboardId
-    ) {
-      return true;
+    for (const field of idFields) {
+      if (typeof input[field] === "string" && input[field] === entityId) {
+        return true;
+      }
     }
   }
   return false;
@@ -77,13 +80,16 @@ function messageTouchesDashboard(msg: any, dashboardId: string): boolean {
 
 /**
  * Returns the most recent user prompts (oldest → newest) that triggered AI
- * edits to the given dashboard, across the user's recent chats. Best effort:
- * returns an empty array on any error or when no chat touched the dashboard.
+ * edits to the given entity, across the user's recent chats. Tool calls are
+ * matched by the given id input fields (e.g. `["dashboardId"]`, `["appId"]`).
+ * Best effort: returns an empty array on any error or when no chat touched
+ * the entity.
  */
-export async function getDashboardChatPrompts(
+export async function getEntityChatPrompts(
   workspaceId: string,
   userId: string,
-  dashboardId: string,
+  entityId: string,
+  idFields: string[],
 ): Promise<string[]> {
   if (!Types.ObjectId.isValid(workspaceId)) return [];
 
@@ -113,7 +119,7 @@ export async function getDashboardChatPrompts(
           if (text) lastUserPrompt = text;
         } else if (
           msg?.role === "assistant" &&
-          messageTouchesDashboard(msg, dashboardId) &&
+          messageTouchesEntity(msg, entityId, idFields) &&
           lastUserPrompt
         ) {
           if (!prompts.includes(lastUserPrompt)) {
@@ -125,9 +131,9 @@ export async function getDashboardChatPrompts(
 
     return prompts.slice(-MAX_PROMPTS);
   } catch (err) {
-    logger.warn("Failed to gather dashboard chat prompts", {
+    logger.warn("Failed to gather entity chat prompts", {
       error: String(err),
-      dashboardId,
+      entityId,
     });
     return [];
   }

--- a/api/src/services/version-comment.service.ts
+++ b/api/src/services/version-comment.service.ts
@@ -272,44 +272,214 @@ export function computeSnapshotDiff(
   return computeDiff(prev, next);
 }
 
-export async function generateDashboardVersionComment(
-  context: DashboardVersionCommentContext,
-  trackingCtx?: VersionCommentTrackingContext,
-): Promise<VersionCommentResult> {
-  const diff = computeSnapshotDiff(
-    context.previousSnapshot,
-    context.newSnapshot,
-  );
+/**
+ * Shared "diff + chat prompts → single commit line" pipeline used by the
+ * dashboard and app version-comment generators. The caller supplies the
+ * entity-appropriate system prompt, precomputed diff and diff label; this
+ * folds in the chat prompts block and calls the utility model.
+ */
+async function generateSnapshotVersionComment(opts: {
+  systemPrompt: string;
+  diff: string | null;
+  diffLabel: string;
+  chatPrompts?: string[];
+  entityLabel: string;
+  trackingCtx?: VersionCommentTrackingContext;
+}): Promise<VersionCommentResult> {
+  const { diff } = opts;
   if (!diff) return { comment: null, diff: null };
 
   const parts: string[] = [];
 
-  const prompts = (context.chatPrompts ?? [])
+  const prompts = (opts.chatPrompts ?? [])
     .map(p => p.trim())
     .filter(Boolean)
     .slice(-6);
   if (prompts.length > 0) {
-    parts.push("Chat prompts that drove these dashboard changes:");
+    parts.push(`Chat prompts that drove these ${opts.entityLabel} changes:`);
     for (const p of prompts) {
       parts.push(`- ${p.substring(0, 300)}`);
     }
     parts.push("");
   }
 
-  parts.push("Dashboard definition diff:");
+  parts.push(`${opts.diffLabel}:`);
   parts.push(diff);
-
-  const prompt = parts.join("\n");
 
   try {
     const comment = await generateCommitMessage(
-      DASHBOARD_VERSION_COMMENT_SYSTEM_PROMPT,
-      prompt,
-      trackingCtx,
+      opts.systemPrompt,
+      parts.join("\n"),
+      opts.trackingCtx,
     );
     return { comment, diff };
   } catch (err) {
-    logger.error("Dashboard version comment generation failed", { error: err });
+    logger.error(`${opts.entityLabel} version comment generation failed`, {
+      error: err,
+    });
     return { comment: null, diff };
   }
+}
+
+export async function generateDashboardVersionComment(
+  context: DashboardVersionCommentContext,
+  trackingCtx?: VersionCommentTrackingContext,
+): Promise<VersionCommentResult> {
+  return generateSnapshotVersionComment({
+    systemPrompt: DASHBOARD_VERSION_COMMENT_SYSTEM_PROMPT,
+    diff: computeSnapshotDiff(context.previousSnapshot, context.newSnapshot),
+    diffLabel: "Dashboard definition diff",
+    chatPrompts: context.chatPrompts,
+    entityLabel: "dashboard",
+    trackingCtx,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// App version comments (multi-file)
+// ---------------------------------------------------------------------------
+
+const APP_VERSION_COMMENT_SYSTEM_PROMPT = `You are to act as an author of a version comment for a saved React app built in a BI tool.
+Your mission is to create a clean, specific commit message that explains WHAT changed in the app and WHY.
+I'll send you per-file diffs of the app's source files (plus a JSON diff of metadata like data bindings and dependencies) and, when available, the chat prompts the user gave the AI that produced the change. You convert this into a single commit message.
+
+Rules:
+- Use present tense, imperative mood (e.g. "Add revenue chart to overview page", "Wire orders table to live query")
+- Summarize the overall intent across all files — do not list file names one by one
+- Be specific: mention component names, features, data bindings, dependencies — not line numbers
+- Prefer the user's intent from the chat prompts when it clarifies the change
+- Maximum 72 characters
+- Do NOT wrap the message in quotes or backticks
+- Do NOT add a trailing period
+- Do NOT add any prefix like "feat:" or "fix:"
+- Do NOT add explanations beyond the single commit line
+- Respond with ONLY the commit message text, nothing else`;
+
+export interface AppVersionCommentContext {
+  previousSnapshot: Record<string, unknown> | null;
+  newSnapshot: Record<string, unknown>;
+  /** User prompts from chat sessions that contributed to the change, if any. */
+  chatPrompts?: string[];
+}
+
+interface SnapshotFileEntry {
+  path: string;
+  contents: string;
+}
+
+function asFileEntries(
+  snapshot: Record<string, unknown> | null,
+): SnapshotFileEntry[] {
+  if (!snapshot || !Array.isArray(snapshot.files)) return [];
+  return (snapshot.files as unknown[]).flatMap(f => {
+    if (!f || typeof f !== "object") return [];
+    const { path, contents } = f as Record<string, unknown>;
+    if (typeof path !== "string") return [];
+    return [{ path, contents: typeof contents === "string" ? contents : "" }];
+  });
+}
+
+function countDiffLines(diff: string): { added: number; removed: number } {
+  let added = 0;
+  let removed = 0;
+  for (const line of diff.split("\n")) {
+    if (line.startsWith("+") && !line.startsWith("+++")) added++;
+    else if (line.startsWith("-") && !line.startsWith("---")) removed++;
+  }
+  return { added, removed };
+}
+
+// Apps diff over many files, so the budget is larger than the single-query
+// console cap but still bounded for the utility model. Files that don't fit
+// degrade to one-line "+N/-M lines" stats instead of being dropped.
+const APP_DIFF_TOTAL_BUDGET = 9000;
+const APP_DIFF_PER_FILE_BUDGET = 1800;
+
+/**
+ * Diff two app snapshots as a git-style multi-file diff: a per-file unified
+ * diff for each added/removed/modified source file plus a JSON diff of the
+ * non-file metadata (title, data bindings, dependencies, ...). Once the total
+ * budget is spent, remaining files are summarized as line-count stats.
+ */
+export function computeAppMultiFileDiff(
+  previousSnapshot: Record<string, unknown> | null,
+  newSnapshot: Record<string, unknown>,
+): string | null {
+  const stripFiles = (s: Record<string, unknown> | null) => {
+    if (!s) return null;
+    const { files: _files, ...rest } = s;
+    return rest;
+  };
+
+  const metaDiff = computeSnapshotDiff(
+    stripFiles(previousSnapshot),
+    stripFiles(newSnapshot) ?? {},
+  );
+
+  const prevMap = new Map(
+    asFileEntries(previousSnapshot).map(f => [f.path, f.contents]),
+  );
+  const nextMap = new Map(
+    asFileEntries(newSnapshot).map(f => [f.path, f.contents]),
+  );
+  const paths = [...new Set([...prevMap.keys(), ...nextMap.keys()])].sort();
+
+  const sections: string[] = [];
+  let used = metaDiff?.length ?? 0;
+
+  for (const path of paths) {
+    const prev = prevMap.get(path);
+    const next = nextMap.get(path);
+    if (prev === next) continue;
+
+    let header: string;
+    let body: string | null;
+    if (prev === undefined) {
+      header = `Added file: ${path}`;
+      body = computeUnifiedDiff("", next ?? "");
+    } else if (next === undefined) {
+      header = `Deleted file: ${path}`;
+      body = null;
+    } else {
+      header = `Modified file: ${path}`;
+      body = computeUnifiedDiff(prev, next);
+      if (!body || !hasRealChanges(body)) continue;
+    }
+
+    let section = header;
+    if (body) {
+      const { added, removed } = countDiffLines(body);
+      const fits =
+        used + body.length <= APP_DIFF_TOTAL_BUDGET &&
+        body.length <= APP_DIFF_PER_FILE_BUDGET;
+      section = fits
+        ? `${header}\n${body}`
+        : `${header} (+${added}/-${removed} lines, diff omitted)`;
+    }
+    used += section.length;
+    sections.push(section);
+  }
+
+  const parts: string[] = [];
+  if (sections.length > 0) parts.push(sections.join("\n\n"));
+  if (metaDiff) parts.push(`App metadata diff (non-file fields):\n${metaDiff}`);
+  if (parts.length === 0) return null;
+  return parts.join("\n\n");
+}
+
+export async function generateAppVersionComment(
+  context: AppVersionCommentContext,
+  trackingCtx?: VersionCommentTrackingContext,
+): Promise<VersionCommentResult> {
+  return generateSnapshotVersionComment({
+    systemPrompt: APP_VERSION_COMMENT_SYSTEM_PROMPT,
+    diff: computeAppMultiFileDiff(
+      context.previousSnapshot,
+      context.newSnapshot,
+    ),
+    diffLabel: "App definition diff",
+    chatPrompts: context.chatPrompts,
+    entityLabel: "app",
+    trackingCtx,
+  });
 }

--- a/app/src/api/schema.d.ts
+++ b/app/src/api/schema.d.ts
@@ -3113,6 +3113,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/workspaces/{workspaceId}/apps/{id}/version-comment": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Suggest a version comment for pending app changes */
+        post: operations["post_api_workspaces_workspaceId_apps_id_version_comment"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/workspaces/{workspaceId}/apps/{id}/versions/{version}": {
         parameters: {
             query?: never;
@@ -14753,6 +14770,47 @@ export interface operations {
                 };
             };
         };
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    post_api_workspaces_workspaceId_apps_id_version_comment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
         responses: {
             /** @description Successful response */
             "2XX": {

--- a/app/src/components/AppRenderer.tsx
+++ b/app/src/components/AppRenderer.tsx
@@ -10,12 +10,6 @@ import {
   Typography,
   Chip,
   Alert,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogContentText,
-  DialogActions,
-  TextField,
   Snackbar,
 } from "@mui/material";
 import {
@@ -35,7 +29,9 @@ import { useAppStore } from "../store/appStore";
 import { useVersionStore } from "../store/versionStore";
 import { useConsoleStore } from "../store/consoleStore";
 import ShareDialog from "./ShareDialog";
+import { SaveCommentDialog } from "./SaveCommentDialog";
 import { VersionHistoryPanel } from "./VersionHistoryPanel";
+import { useSaveCommentSuggestion } from "../hooks/useSaveCommentSuggestion";
 import { buildPreviewHtml, PREVIEW_MESSAGE } from "../app-runtime/preview";
 import { appLocationFromHostSearch } from "../app-runtime/app-location";
 import {
@@ -67,8 +63,8 @@ export default function AppRenderer({
   const [shareOpen, setShareOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
   const [publishOpen, setPublishOpen] = useState(false);
-  const [publishComment, setPublishComment] = useState("");
   const [publishing, setPublishing] = useState(false);
+  const publishSuggestion = useSaveCommentSuggestion();
   const [publishedNotice, setPublishedNotice] = useState<string | null>(null);
   const [rematerializing, setRematerializing] = useState(false);
 
@@ -88,6 +84,7 @@ export default function AppRenderer({
   const runBinding = useAppStore(s => s.runBinding);
   const materializeAllBindings = useAppStore(s => s.materializeAllBindings);
   const persistApp = useAppStore(s => s.persistApp);
+  const generateSaveComment = useAppStore(s => s.generateSaveComment);
   const saveVersion = useVersionStore(s => s.saveVersion);
 
   // dbt preview environment override (per-user view state): only surfaced
@@ -158,34 +155,55 @@ export default function AppRenderer({
     ((appEntity.owner_id ?? appEntity.createdBy) === user?.id ||
       isWorkspaceAdmin);
 
+  // Open the publish dialog and kick off the AI commit-message suggestion.
+  // The draft is flushed first so the server-side diff (draft vs last saved
+  // version) matches what's on screen.
+  const openPublishDialog = useCallback(() => {
+    setPublishOpen(true);
+    if (!workspaceId) return;
+    publishSuggestion.begin(async signal => {
+      await persistApp(workspaceId, appId);
+      if (signal.aborted) return { comment: null, diff: null };
+      return generateSaveComment(workspaceId, appId, signal);
+    });
+  }, [workspaceId, appId, persistApp, generateSaveComment, publishSuggestion]);
+
+  const closePublishDialog = useCallback(() => {
+    publishSuggestion.cancel();
+    setPublishOpen(false);
+  }, [publishSuggestion]);
+
   // Promote the current draft to the published definition that shared links and
   // viewers render. Flush pending edits first so the checkpoint matches the
   // preview, then refresh so the toolbar's published state stops being stale.
-  const handlePublishConfirm = useCallback(async () => {
-    if (!workspaceId) return;
-    setPublishing(true);
-    try {
-      await persistApp(workspaceId, appId);
-      const result = await saveVersion(
-        workspaceId,
-        "app",
-        appId,
-        publishComment.trim(),
-      );
-      await fetchApp(workspaceId, appId);
-      setPublishOpen(false);
-      setPublishComment("");
-      setPublishedNotice(
-        result.success
-          ? result.version
-            ? `Published version ${result.version}`
-            : "Published"
-          : (result.error ?? "Failed to publish"),
-      );
-    } finally {
-      setPublishing(false);
-    }
-  }, [workspaceId, appId, persistApp, saveVersion, publishComment, fetchApp]);
+  const handlePublishConfirm = useCallback(
+    async (comment: string) => {
+      if (!workspaceId) return;
+      setPublishing(true);
+      try {
+        await persistApp(workspaceId, appId);
+        const result = await saveVersion(
+          workspaceId,
+          "app",
+          appId,
+          comment.trim(),
+        );
+        await fetchApp(workspaceId, appId);
+        publishSuggestion.cancel();
+        setPublishOpen(false);
+        setPublishedNotice(
+          result.success
+            ? result.version
+              ? `Published version ${result.version}`
+              : "Published"
+            : (result.error ?? "Failed to publish"),
+        );
+      } finally {
+        setPublishing(false);
+      }
+    },
+    [workspaceId, appId, persistApp, saveVersion, fetchApp, publishSuggestion],
+  );
 
   const hasParquetBindings = !!appEntity?.dataBindings.some(
     b => b.materialization === "parquet",
@@ -544,7 +562,7 @@ export default function AppRenderer({
               size="small"
               variant="contained"
               startIcon={<PublishIcon size={16} strokeWidth={1.5} />}
-              onClick={() => setPublishOpen(true)}
+              onClick={openPublishDialog}
             >
               Publish
             </Button>
@@ -633,44 +651,18 @@ export default function AppRenderer({
         }
       />
 
-      <Dialog
+      <SaveCommentDialog
         open={publishOpen}
-        onClose={() => !publishing && setPublishOpen(false)}
-        maxWidth="sm"
-        fullWidth
-      >
-        <DialogTitle>Publish {appEntity.title}</DialogTitle>
-        <DialogContent>
-          <DialogContentText sx={{ mb: 2 }}>
-            Snapshots the current draft into version history and publishes it as
-            the live version that shared links and viewers see.
-          </DialogContentText>
-          <TextField
-            autoFocus
-            fullWidth
-            size="small"
-            label="Comment (optional)"
-            placeholder="e.g. Add revenue chart"
-            value={publishComment}
-            onChange={e => setPublishComment(e.target.value)}
-            onKeyDown={e => {
-              if (e.key === "Enter") void handlePublishConfirm();
-            }}
-          />
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setPublishOpen(false)} disabled={publishing}>
-            Cancel
-          </Button>
-          <Button
-            onClick={handlePublishConfirm}
-            variant="contained"
-            disabled={publishing}
-          >
-            {publishing ? "Publishing..." : "Publish"}
-          </Button>
-        </DialogActions>
-      </Dialog>
+        title={`Publish ${appEntity.title}`}
+        description="Snapshots the current draft into version history and publishes it as the live version that shared links and viewers see."
+        confirmLabel={publishing ? "Publishing..." : "Publish"}
+        busy={publishing}
+        defaultComment={publishSuggestion.comment}
+        loading={publishSuggestion.loading}
+        diff={publishSuggestion.diff}
+        onCancel={closePublishDialog}
+        onSave={comment => void handlePublishConfirm(comment)}
+      />
 
       <Snackbar
         open={!!publishedNotice}

--- a/app/src/components/AppsExplorer.tsx
+++ b/app/src/components/AppsExplorer.tsx
@@ -47,6 +47,8 @@ import {
 } from "../store/explorerRevealStore";
 import { useAppStore, type AppListItem } from "../store/appStore";
 import { useVersionStore } from "../store/versionStore";
+import { useSaveCommentSuggestion } from "../hooks/useSaveCommentSuggestion";
+import { SaveCommentDialog } from "./SaveCommentDialog";
 import { VersionHistoryPanel } from "./VersionHistoryPanel";
 import {
   APP_FILE_SEP as FILE_SEP,
@@ -197,6 +199,7 @@ export function AppsExplorer() {
   const removeDataBinding = useAppStore(s => s.removeDataBinding);
   const materializeBinding = useAppStore(s => s.materializeBinding);
   const persistApp = useAppStore(s => s.persistApp);
+  const generateSaveComment = useAppStore(s => s.generateSaveComment);
   const setAppAccess = useAppStore(s => s.setAppAccess);
   const bumpPreview = useAppStore(s => s.bumpPreview);
   const saveVersion = useVersionStore(s => s.saveVersion);
@@ -240,8 +243,8 @@ export function AppsExplorer() {
     id: string;
     name: string;
   } | null>(null);
-  const [saveVersionComment, setSaveVersionComment] = useState("");
   const [savingVersion, setSavingVersion] = useState(false);
+  const saveVersionSuggestion = useSaveCommentSuggestion();
 
   useEffect(() => {
     if (workspaceId) void fetchList(workspaceId);
@@ -450,6 +453,57 @@ export function AppsExplorer() {
     [],
   );
 
+  const openSaveVersionDialog = useCallback(
+    (appId: string, name: string) => {
+      setSaveVersionApp({ id: appId, name });
+      if (!workspaceId) return;
+      saveVersionSuggestion.begin(async signal => {
+        // Flush any pending local edits so the server-side diff matches
+        // what's on screen.
+        if (openApps[appId]) {
+          await persistApp(workspaceId, appId);
+        }
+        if (signal.aborted) return { comment: null, diff: null };
+        return generateSaveComment(workspaceId, appId, signal);
+      });
+    },
+    [
+      workspaceId,
+      openApps,
+      persistApp,
+      generateSaveComment,
+      saveVersionSuggestion,
+    ],
+  );
+
+  const closeSaveVersionDialog = useCallback(() => {
+    saveVersionSuggestion.cancel();
+    setSaveVersionApp(null);
+  }, [saveVersionSuggestion]);
+
+  const handleSaveVersionConfirm = useCallback(
+    async (comment: string) => {
+      if (!saveVersionApp || !workspaceId) return;
+      setSavingVersion(true);
+      // Flush any pending local edits so the checkpoint matches what's on screen.
+      if (openApps[saveVersionApp.id]) {
+        await persistApp(workspaceId, saveVersionApp.id);
+      }
+      await saveVersion(workspaceId, "app", saveVersionApp.id, comment.trim());
+      setSavingVersion(false);
+      saveVersionSuggestion.cancel();
+      setSaveVersionApp(null);
+    },
+    [
+      saveVersionApp,
+      workspaceId,
+      openApps,
+      persistApp,
+      saveVersion,
+      saveVersionSuggestion,
+    ],
+  );
+
   const getContextMenuItems = useCallback(
     (node: ResourceTreeNode, helpers: { closeMenu: () => void }) => {
       const parsed = parseNodeId(node.id);
@@ -525,8 +579,7 @@ export function AppsExplorer() {
             <MenuItem
               key="save-version"
               onClick={() => {
-                setSaveVersionApp({ id: parsed.appId, name: node.name });
-                setSaveVersionComment("");
+                openSaveVersionDialog(parsed.appId, node.name);
                 helpers.closeMenu();
               }}
             >
@@ -595,7 +648,14 @@ export function AppsExplorer() {
       );
       return items;
     },
-    [workspaceId, openApps, materializeBinding, canManageNode, setAppAccess],
+    [
+      workspaceId,
+      openApps,
+      materializeBinding,
+      canManageNode,
+      setAppAccess,
+      openSaveVersionDialog,
+    ],
   );
 
   const handleRenameConfirm = useCallback(async () => {
@@ -642,30 +702,6 @@ export function AppsExplorer() {
     deleteFile,
     removeDataBinding,
     persistApp,
-  ]);
-
-  const handleSaveVersionConfirm = useCallback(async () => {
-    if (!saveVersionApp || !workspaceId) return;
-    setSavingVersion(true);
-    // Flush any pending local edits so the checkpoint matches what's on screen.
-    if (openApps[saveVersionApp.id]) {
-      await persistApp(workspaceId, saveVersionApp.id);
-    }
-    await saveVersion(
-      workspaceId,
-      "app",
-      saveVersionApp.id,
-      saveVersionComment.trim(),
-    );
-    setSavingVersion(false);
-    setSaveVersionApp(null);
-  }, [
-    saveVersionApp,
-    workspaceId,
-    openApps,
-    persistApp,
-    saveVersion,
-    saveVersionComment,
   ]);
 
   const actions = (
@@ -793,47 +829,18 @@ export function AppsExplorer() {
       </Dialog>
 
       {/* Save version dialog */}
-      <Dialog
+      <SaveCommentDialog
         open={!!saveVersionApp}
-        onClose={() => !savingVersion && setSaveVersionApp(null)}
-        maxWidth="sm"
-        fullWidth
-      >
-        <DialogTitle>Publish version of {saveVersionApp?.name}</DialogTitle>
-        <DialogContent>
-          <DialogContentText sx={{ mb: 2 }}>
-            Snapshots the current draft into version history and publishes it as
-            the live version that shared links and viewers see.
-          </DialogContentText>
-          <TextField
-            autoFocus
-            fullWidth
-            size="small"
-            label="Comment (optional)"
-            placeholder="e.g. Add revenue chart"
-            value={saveVersionComment}
-            onChange={e => setSaveVersionComment(e.target.value)}
-            onKeyDown={e => {
-              if (e.key === "Enter") void handleSaveVersionConfirm();
-            }}
-          />
-        </DialogContent>
-        <DialogActions>
-          <Button
-            onClick={() => setSaveVersionApp(null)}
-            disabled={savingVersion}
-          >
-            Cancel
-          </Button>
-          <Button
-            onClick={handleSaveVersionConfirm}
-            variant="contained"
-            disabled={savingVersion}
-          >
-            {savingVersion ? "Publishing..." : "Publish version"}
-          </Button>
-        </DialogActions>
-      </Dialog>
+        title={`Publish version of ${saveVersionApp?.name ?? ""}`}
+        description="Snapshots the current draft into version history and publishes it as the live version that shared links and viewers see."
+        confirmLabel={savingVersion ? "Publishing..." : "Publish version"}
+        busy={savingVersion}
+        defaultComment={saveVersionSuggestion.comment}
+        loading={saveVersionSuggestion.loading}
+        diff={saveVersionSuggestion.diff}
+        onCancel={closeSaveVersionDialog}
+        onSave={comment => void handleSaveVersionConfirm(comment)}
+      />
 
       {/* Version history drawer */}
       {historyApp && (

--- a/app/src/components/DashboardCanvas.tsx
+++ b/app/src/components/DashboardCanvas.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Box,
   Typography,
@@ -64,6 +58,7 @@ import ShareDialog from "./ShareDialog";
 import { useIsWorkspaceAdmin } from "../hooks/useIsWorkspaceAdmin";
 import WidgetInspector from "./dashboard/WidgetInspector";
 import { SaveCommentDialog } from "./SaveCommentDialog";
+import { useSaveCommentSuggestion } from "../hooks/useSaveCommentSuggestion";
 import { VersionHistoryPanel } from "./VersionHistoryPanel";
 
 type ViewMode = "canvas" | "code";
@@ -149,45 +144,27 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
     useState<DashboardWidget | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [commentDialogOpen, setCommentDialogOpen] = useState(false);
-  const [suggestedComment, setSuggestedComment] = useState<string | undefined>(
-    undefined,
-  );
-  const [suggestedCommentLoading, setSuggestedCommentLoading] = useState(false);
-  const [saveCommentDiff, setSaveCommentDiff] = useState<string | null>(null);
-  const saveCommentAbortRef = useRef<AbortController | null>(null);
+  const saveSuggestion = useSaveCommentSuggestion();
   const [versionHistoryOpen, setVersionHistoryOpen] = useState(false);
 
   const openSaveDialog = useCallback(() => {
-    setSuggestedComment(undefined);
-    setSaveCommentDiff(null);
-    setSuggestedCommentLoading(false);
     setCommentDialogOpen(true);
 
     // Only existing (persisted) dashboards can be diffed against a saved
     // version for an AI suggestion.
-    if (!workspaceId || !dashboardId || isNew) return;
-
-    saveCommentAbortRef.current?.abort();
-    const controller = new AbortController();
-    saveCommentAbortRef.current = controller;
-    setSuggestedCommentLoading(true);
-    void generateSaveCommentAction(
-      workspaceId,
-      dashboardId,
-      controller.signal,
-    ).then(result => {
-      if (controller.signal.aborted) return;
-      setSuggestedComment(result.comment ?? undefined);
-      setSaveCommentDiff(result.diff);
-      setSuggestedCommentLoading(false);
-    });
-  }, [workspaceId, dashboardId, isNew]);
+    if (!workspaceId || !dashboardId || isNew) {
+      saveSuggestion.begin();
+      return;
+    }
+    saveSuggestion.begin(signal =>
+      generateSaveCommentAction(workspaceId, dashboardId, signal),
+    );
+  }, [workspaceId, dashboardId, isNew, saveSuggestion]);
 
   const closeSaveDialog = useCallback(() => {
-    saveCommentAbortRef.current?.abort();
-    setSuggestedCommentLoading(false);
+    saveSuggestion.cancel();
     setCommentDialogOpen(false);
-  }, []);
+  }, [saveSuggestion]);
 
   const queryGeneration = runtimeSession?.queryGeneration ?? 0;
 
@@ -705,12 +682,12 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
       <SaveCommentDialog
         open={commentDialogOpen}
         title="Save dashboard version"
-        defaultComment={suggestedComment}
-        loading={suggestedCommentLoading}
-        diff={saveCommentDiff}
+        defaultComment={saveSuggestion.comment}
+        loading={saveSuggestion.loading}
+        diff={saveSuggestion.diff}
         onCancel={closeSaveDialog}
         onSave={async comment => {
-          saveCommentAbortRef.current?.abort();
+          saveSuggestion.cancel();
           setCommentDialogOpen(false);
           if (!workspaceId || !dashboardId) return;
           try {

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -87,6 +87,7 @@ import ConflictResolutionDialog, {
 } from "./ConflictResolutionDialog";
 import FileExplorerDialog from "./FileExplorerDialog";
 import { SaveCommentDialog } from "./SaveCommentDialog";
+import { useSaveCommentSuggestion } from "../hooks/useSaveCommentSuggestion";
 import { VersionHistoryPanel } from "./VersionHistoryPanel";
 import { useConsoleStore, selectConsoleTabs } from "../store/consoleStore";
 import { useShallow } from "zustand/react/shallow";
@@ -457,12 +458,7 @@ function Editor({
 
   // Save comment dialog state (version commit message)
   const [commentDialogOpen, setCommentDialogOpen] = useState(false);
-  const [suggestedComment, setSuggestedComment] = useState<string | undefined>(
-    undefined,
-  );
-  const [suggestedCommentLoading, setSuggestedCommentLoading] = useState(false);
-  const [saveCommentDiff, setSaveCommentDiff] = useState<string | null>(null);
-  const saveCommentAbortRef = useRef<AbortController | null>(null);
+  const saveSuggestion = useSaveCommentSuggestion();
   const [pendingCommentSave, setPendingCommentSave] = useState<{
     tabId: string;
     content: string;
@@ -1479,30 +1475,25 @@ function Editor({
       return false;
     }
 
+    // Comments already attached to recent AI edits win over a fresh
+    // AI-generated suggestion (they carry the user's intent directly).
     const vm = getVersionManager(tabId);
     const aiComments = vm?.getRecentAiComments() ?? [];
     const existingComment =
       aiComments.length > 0 ? aiComments.join("; ") : undefined;
-    setSuggestedComment(existingComment);
 
-    if (!existingComment && currentWorkspace?.id) {
-      saveCommentAbortRef.current?.abort();
-      const controller = new AbortController();
-      saveCommentAbortRef.current = controller;
-      setSuggestedCommentLoading(true);
-      generateSaveComment(
-        currentWorkspace.id,
-        tabId,
-        { newContent: contentToSave, source: "user" },
-        controller.signal,
-      ).then(result => {
-        if (!controller.signal.aborted) {
-          setSuggestedComment(result.comment ?? undefined);
-          setSaveCommentDiff(result.diff);
-          setSuggestedCommentLoading(false);
-        }
-      });
-    }
+    saveSuggestion.begin(
+      currentWorkspace?.id
+        ? signal =>
+            generateSaveComment(
+              currentWorkspace.id,
+              tabId,
+              { newContent: contentToSave, source: "user" },
+              signal,
+            )
+        : undefined,
+      existingComment,
+    );
 
     return new Promise<boolean>(resolve => {
       setPendingCommentSave({
@@ -1517,9 +1508,7 @@ function Editor({
 
   const handleCommentSaveConfirm = async (comment: string) => {
     setCommentDialogOpen(false);
-    saveCommentAbortRef.current?.abort();
-    setSuggestedCommentLoading(false);
-    setSaveCommentDiff(null);
+    saveSuggestion.cancel();
     const pending = pendingCommentSave;
     setPendingCommentSave(null);
     if (!pending) return;
@@ -1534,9 +1523,7 @@ function Editor({
 
   const handleCommentSaveCancel = () => {
     setCommentDialogOpen(false);
-    saveCommentAbortRef.current?.abort();
-    setSuggestedCommentLoading(false);
-    setSaveCommentDiff(null);
+    saveSuggestion.cancel();
     const pending = pendingCommentSave;
     setPendingCommentSave(null);
     pending?.resolve(false);
@@ -2989,9 +2976,9 @@ function Editor({
         onSave={handleCommentSaveConfirm}
         onCancel={handleCommentSaveCancel}
         title="Save console version"
-        defaultComment={suggestedComment}
-        loading={suggestedCommentLoading}
-        diff={saveCommentDiff}
+        defaultComment={saveSuggestion.comment}
+        loading={saveSuggestion.loading}
+        diff={saveSuggestion.diff}
       />
 
       {/* Version history panel */}

--- a/app/src/components/SaveCommentDialog.tsx
+++ b/app/src/components/SaveCommentDialog.tsx
@@ -19,6 +19,12 @@ interface SaveCommentDialogProps {
   onSave: (comment: string) => void;
   onCancel: () => void;
   title?: string;
+  /** Optional explanatory text shown above the comment field. */
+  description?: string;
+  /** Label for the confirm button (defaults to "Save version"). */
+  confirmLabel?: string;
+  /** Disables actions while the save/publish itself is running. */
+  busy?: boolean;
   defaultComment?: string;
   loading?: boolean;
   diff?: string | null;
@@ -29,6 +35,9 @@ export function SaveCommentDialog({
   onSave,
   onCancel,
   title = "Save version",
+  description,
+  confirmLabel = "Save version",
+  busy,
   defaultComment,
   loading,
   diff,
@@ -68,9 +77,19 @@ export function SaveCommentDialog({
   );
 
   return (
-    <Dialog open={open} onClose={onCancel} maxWidth="sm" fullWidth>
+    <Dialog
+      open={open}
+      onClose={busy ? undefined : onCancel}
+      maxWidth="sm"
+      fullWidth
+    >
       <DialogTitle>{title}</DialogTitle>
       <DialogContent>
+        {description && (
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+            {description}
+          </Typography>
+        )}
         <TextField
           autoFocus
           fullWidth
@@ -178,11 +197,16 @@ export function SaveCommentDialog({
         )}
       </DialogContent>
       <DialogActions>
-        <Button onClick={onCancel} size="small">
+        <Button onClick={onCancel} size="small" disabled={busy}>
           Cancel
         </Button>
-        <Button onClick={handleSave} variant="contained" size="small">
-          Save version
+        <Button
+          onClick={handleSave}
+          variant="contained"
+          size="small"
+          disabled={busy}
+        >
+          {confirmLabel}
         </Button>
       </DialogActions>
     </Dialog>

--- a/app/src/hooks/useSaveCommentSuggestion.ts
+++ b/app/src/hooks/useSaveCommentSuggestion.ts
@@ -1,0 +1,60 @@
+import { useCallback, useRef, useState } from "react";
+
+export interface SaveCommentSuggestionResult {
+  comment: string | null;
+  diff: string | null;
+}
+
+/**
+ * Shared state machine for the AI-suggested commit message in save-version
+ * dialogs (consoles, dashboards, apps). Encapsulates the abort-on-reopen
+ * controller, the loading flag, and the suggested comment + diff pair so each
+ * entity's save dialog only supplies a fetcher for its version-comment
+ * endpoint.
+ */
+export function useSaveCommentSuggestion() {
+  const [comment, setComment] = useState<string | undefined>(undefined);
+  const [diff, setDiff] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  /**
+   * Start a new suggestion cycle (call when the dialog opens). If
+   * `initialComment` is provided (e.g. comments already attached to recent AI
+   * edits), it is used directly and no request is made. Otherwise `fetcher`
+   * is invoked with an abort signal; a subsequent `begin`/`cancel` aborts it.
+   */
+  const begin = useCallback(
+    (
+      fetcher?: (signal: AbortSignal) => Promise<SaveCommentSuggestionResult>,
+      initialComment?: string,
+    ) => {
+      abortRef.current?.abort();
+      setComment(initialComment);
+      setDiff(null);
+      if (initialComment || !fetcher) {
+        setLoading(false);
+        return;
+      }
+      const controller = new AbortController();
+      abortRef.current = controller;
+      setLoading(true);
+      void fetcher(controller.signal).then(result => {
+        if (controller.signal.aborted) return;
+        setComment(result.comment ?? undefined);
+        setDiff(result.diff);
+        setLoading(false);
+      });
+    },
+    [],
+  );
+
+  /** Abort any in-flight request and reset (call on dialog close/confirm). */
+  const cancel = useCallback(() => {
+    abortRef.current?.abort();
+    setLoading(false);
+    setDiff(null);
+  }, []);
+
+  return { comment, diff, loading, begin, cancel };
+}

--- a/app/src/store/appStore.ts
+++ b/app/src/store/appStore.ts
@@ -144,6 +144,16 @@ interface AppActions {
   createApp: (workspaceId: string, title: string) => Promise<AppEntity | null>;
   deleteApp: (workspaceId: string, appId: string) => Promise<boolean>;
   persistApp: (workspaceId: string, appId: string) => Promise<void>;
+  /**
+   * Ask the server for an AI-suggested commit message for the app's pending
+   * draft changes (diffed against the last saved version). Callers should
+   * `persistApp` first so the server-side draft matches what's on screen.
+   */
+  generateSaveComment: (
+    workspaceId: string,
+    appId: string,
+    signal?: AbortSignal,
+  ) => Promise<{ comment: string | null; diff: string | null }>;
   renameApp: (
     workspaceId: string,
     appId: string,
@@ -455,6 +465,25 @@ export const useAppStore = create<AppStore>()(
             },
           ];
         });
+      }
+    },
+
+    generateSaveComment: async (workspaceId, appId, signal) => {
+      try {
+        const res = unwrapBody(
+          await api.POST(
+            "/api/workspaces/{workspaceId}/apps/{id}/version-comment",
+            {
+              params: { path: { workspaceId, id: appId } },
+              signal,
+            },
+          ),
+        ) as { success: boolean; comment: string | null; diff: string | null };
+        return res.success
+          ? { comment: res.comment ?? null, diff: res.diff ?? null }
+          : { comment: null, diff: null };
+      } catch {
+        return { comment: null, diff: null };
       }
     },
 

--- a/docs/src/openapi/mako-api.json
+++ b/docs/src/openapi/mako-api.json
@@ -19978,6 +19978,83 @@
         "operationId": "post_api_workspaces_workspaceId_apps_id_versions"
       }
     },
+    "/api/workspaces/{workspaceId}/apps/{id}/version-comment": {
+      "post": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "Suggest a version comment for pending app changes",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "post_api_workspaces_workspaceId_apps_id_version_comment"
+      }
+    },
     "/api/workspaces/{workspaceId}/apps/{id}/versions/{version}": {
       "get": {
         "tags": [


### PR DESCRIPTION
## Summary

- **Apps now get the AI-suggested commit message** that consoles and dashboards already have: a new `POST /apps/:id/version-comment` endpoint diffs the (autosaved) draft against the last saved version and asks the utility model for a single commit line. Both app publish flows — the toolbar **Publish** button in `AppRenderer` and the explorer context-menu **Publish version** — now use the shared `SaveCommentDialog`, with the sparkle loading state and the collapsible "changes since last save" diff.
- **Multi-file diff for apps**: `computeAppMultiFileDiff` produces a git-style diff — per-file unified diffs (`Added file:` / `Deleted file:` / `Modified file:` sections) plus a JSON diff of non-file metadata (data bindings, dependencies, entrypoint, ...). Bounded by a total budget with a per-file cap; files that don't fit degrade to one-line `(+N/-M lines, diff omitted)` stats instead of being dropped, so the model always sees the full shape of the change.
- **Context**: on top of the diff, the generator folds in user chat prompts recovered from recent AI sessions whose tool calls reference the app (same approach dashboards already used — no per-edit persistence needed).
- **Extracted shared logic**:
  - `generateSnapshotVersionComment` dedupes the dashboard/app comment pipelines in `version-comment.service.ts`.
  - `dashboard-version-context.service.ts` → `entity-version-context.service.ts`: `getEntityChatPrompts(workspaceId, userId, entityId, idFields)` matches tool calls by any id input field (`["dashboardId"]`, `["appId"]`, ...).
  - New `useSaveCommentSuggestion` hook replaces the copy-pasted abort-controller/loading/suggestion state in `Editor.tsx`, `DashboardCanvas.tsx` and the two app dialogs. `SaveCommentDialog` gains optional `description` / `confirmLabel` / `busy` props so it can serve the publish flows.

## Test plan

- [x] `pnpm --filter app run typecheck`, `pnpm --filter app run lint`, `pnpm --filter api run lint` all pass
- [x] Sanity-checked `computeAppMultiFileDiff` output (modified/added/deleted files + metadata diff; `null` when snapshots match)
- [x] Tested end-to-end against the local dev stack: made a draft edit to an app, opened both publish dialogs — suggestion generated in ~4–5s (e.g. "Add Power Users tab and update query materialization settings"), diff renders with per-file sections; endpoint returns `comment: null` when the draft matches the last saved version
- [ ] Verify console + dashboard save dialogs still behave the same after the shared-hook refactor

Made with [Cursor](https://cursor.com)