### PR TITLE
fix(app): explicit not-found/no-access states for every tab entity + workspace-scoped tab persistence

### DIFF
--- a/app/src/api/index.ts
+++ b/app/src/api/index.ts
@@ -1,3 +1,10 @@
 export { api, createApiClient } from "./client";
-export { unwrap, unwrapBody, type ApiResult } from "./result";
+export {
+  ApiError,
+  toLoadError,
+  unwrap,
+  unwrapBody,
+  type ApiResult,
+  type LoadError,
+} from "./result";
 export type { paths, components, operations } from "./schema";

--- a/app/src/api/result.ts
+++ b/app/src/api/result.ts
@@ -84,13 +84,49 @@ function errorMessage(res: ApiResult): string {
 }
 
 /**
+ * Error thrown by `unwrap`/`unwrapBody` on non-2xx responses. Carries the HTTP
+ * status so callers can distinguish "not found" (404) from "no access" (403)
+ * without parsing the message string.
+ */
+export class ApiError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+  }
+}
+
+/**
+ * Structured load failure for a single entity (app, dashboard, ...) kept in
+ * store state so views can render "not found" / "access denied" instead of an
+ * infinite loading placeholder.
+ */
+export interface LoadError {
+  status?: number;
+  message: string;
+}
+
+/** Normalize any thrown value into a `LoadError` for store error state. */
+export function toLoadError(e: unknown, fallbackMessage: string): LoadError {
+  if (e instanceof ApiError) {
+    return { status: e.status, message: e.message };
+  }
+  if (e instanceof Error && e.message.trim()) {
+    return { message: e.message };
+  }
+  return { message: fallbackMessage };
+}
+
+/**
  * Throws on transport/HTTP error; otherwise returns the parsed body as the
  * `{ success, data }` envelope with `data` typed as `unknown` (callers assert
  * their domain type — the API DTO is a structural subset).
  */
 export function unwrap(res: ApiResult): { data?: unknown } {
   if (res.error || !res.response.ok) {
-    throw new Error(errorMessage(res));
+    throw new ApiError(errorMessage(res), res.response.status);
   }
   return (res.data ?? {}) as { data?: unknown };
 }
@@ -98,7 +134,7 @@ export function unwrap(res: ApiResult): { data?: unknown } {
 /** Throws on error; returns the raw response body as `unknown` (no envelope). */
 export function unwrapBody(res: ApiResult): unknown {
   if (res.error || !res.response.ok) {
-    throw new Error(errorMessage(res));
+    throw new ApiError(errorMessage(res), res.response.status);
   }
   return res.data;
 }

--- a/app/src/components/AppBindingEditor.tsx
+++ b/app/src/components/AppBindingEditor.tsx
@@ -15,6 +15,10 @@ import { previewParquetArtifact } from "../lib/parquet-preview";
 import Console from "./Console";
 import ResultsTable from "./ResultsTable";
 import EntityBreadcrumbs from "./EntityBreadcrumbs";
+import EntityLoadErrorState, {
+  EntityLoadingState,
+} from "./EntityLoadErrorState";
+import { missingEntityError } from "../lib/entity-labels";
 import DataSourceMaterializationControls, {
   type MaterializationHistoryItem,
 } from "./DataSourceMaterializationControls";
@@ -55,6 +59,7 @@ export default function AppBindingEditor({
   const workspaceId = currentWorkspace?.id;
 
   const appEntity = useAppStore(s => s.openApps[appId]);
+  const appLoadError = useAppStore(s => s.openAppErrors[appId]);
   const fetchApp = useAppStore(s => s.fetchApp);
   const updateBinding = useAppStore(s => s.updateBinding);
   const persistApp = useAppStore(s => s.persistApp);
@@ -193,19 +198,26 @@ export default function AppBindingEditor({
   }, [bindingCache?.parquetUrl]);
 
   if (!appEntity) {
-    return (
-      <Box sx={{ p: 3, color: "text.secondary" }}>
-        <Typography variant="body2">Loading…</Typography>
-      </Box>
-    );
+    if (appLoadError) {
+      return (
+        <EntityLoadErrorState
+          error={appLoadError}
+          entityLabel="app"
+          onRetry={() => {
+            if (workspaceId) void fetchApp(workspaceId, appId);
+          }}
+        />
+      );
+    }
+    return <EntityLoadingState label="Loading data source…" />;
   }
   if (!binding) {
     return (
-      <Box sx={{ p: 3, color: "text.secondary" }}>
-        <Typography variant="body2">
-          This data source no longer exists.
-        </Typography>
-      </Box>
+      <EntityLoadErrorState
+        error={missingEntityError("data source")}
+        entityLabel="data source"
+        detail="This data source no longer exists in this app."
+      />
     );
   }
 

--- a/app/src/components/AppFileEditor.tsx
+++ b/app/src/components/AppFileEditor.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from "react";
-import { Box, Typography, useTheme } from "@mui/material";
+import { Box, useTheme } from "@mui/material";
 import MonacoEditor from "@monaco-editor/react";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useAppStore } from "../store/appStore";
@@ -8,6 +8,10 @@ import {
   languageForPath,
 } from "../app-runtime/monaco-jsx";
 import EntityBreadcrumbs from "./EntityBreadcrumbs";
+import EntityLoadErrorState, {
+  EntityLoadingState,
+} from "./EntityLoadErrorState";
+import { missingEntityError } from "../lib/entity-labels";
 
 /**
  * Full-screen editor for a single file within an app. Opened as its own tab
@@ -28,6 +32,7 @@ export default function AppFileEditor({
   const monacoTheme = useTheme().palette.mode === "dark" ? "vs-dark" : "vs";
 
   const appEntity = useAppStore(s => s.openApps[appId]);
+  const appLoadError = useAppStore(s => s.openAppErrors[appId]);
   const fetchApp = useAppStore(s => s.fetchApp);
   const writeFile = useAppStore(s => s.writeFile);
   const persistApp = useAppStore(s => s.persistApp);
@@ -51,21 +56,28 @@ export default function AppFileEditor({
   );
 
   if (!appEntity) {
-    return (
-      <Box sx={{ p: 3, color: "text.secondary" }}>
-        <Typography variant="body2">Loading file…</Typography>
-      </Box>
-    );
+    if (appLoadError) {
+      return (
+        <EntityLoadErrorState
+          error={appLoadError}
+          entityLabel="app"
+          onRetry={() => {
+            if (workspaceId) void fetchApp(workspaceId, appId);
+          }}
+        />
+      );
+    }
+    return <EntityLoadingState label="Loading file…" />;
   }
 
   const file = appEntity.files.find(f => f.path === path);
   if (!file) {
     return (
-      <Box sx={{ p: 3, color: "text.secondary" }}>
-        <Typography variant="body2">
-          {path} no longer exists in this app.
-        </Typography>
-      </Box>
+      <EntityLoadErrorState
+        error={missingEntityError("file")}
+        entityLabel="file"
+        detail={`${path} no longer exists in this app.`}
+      />
     );
   }
 

--- a/app/src/components/AppRenderer.tsx
+++ b/app/src/components/AppRenderer.tsx
@@ -23,6 +23,9 @@ import {
 import { containsDbtSchemaToken } from "@mako/schemas";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useAuth } from "../contexts/auth-context";
+import EntityLoadErrorState, {
+  EntityLoadingState,
+} from "./EntityLoadErrorState";
 import { useTheme } from "../contexts/ThemeContext";
 import { useIsWorkspaceAdmin } from "../hooks/useIsWorkspaceAdmin";
 import { useAppStore } from "../store/appStore";
@@ -77,6 +80,7 @@ export default function AppRenderer({
   effectiveModeRef.current = effectiveMode;
 
   const appEntity = useAppStore(s => s.openApps[appId]);
+  const appLoadError = useAppStore(s => s.openAppErrors[appId]);
   const previewNonce = useAppStore(s => s.previewNonce[appId] ?? 0);
   const previewErrors = useAppStore(s => s.previewErrors[appId]);
   const fetchApp = useAppStore(s => s.fetchApp);
@@ -483,11 +487,18 @@ export default function AppRenderer({
   }, [srcDoc, previewNonce]);
 
   if (!appEntity) {
-    return (
-      <Box sx={{ p: 3, color: "text.secondary" }}>
-        <Typography variant="body2">Loading app…</Typography>
-      </Box>
-    );
+    if (appLoadError) {
+      return (
+        <EntityLoadErrorState
+          error={appLoadError}
+          entityLabel="app"
+          onRetry={() => {
+            if (workspaceId) void fetchApp(workspaceId, appId);
+          }}
+        />
+      );
+    }
+    return <EntityLoadingState label="Loading app…" />;
   }
 
   const errors = previewErrors || [];

--- a/app/src/components/AppsExplorer.tsx
+++ b/app/src/components/AppsExplorer.tsx
@@ -185,6 +185,7 @@ export function AppsExplorer() {
     s => (workspaceId ? s.workspaceApps[workspaceId] : undefined) || EMPTY_LIST,
   );
   const openApps = useAppStore(s => s.openApps);
+  const openAppErrors = useAppStore(s => s.openAppErrors);
   const loading = useAppStore(s =>
     workspaceId ? !!s.loading[workspaceId] : false,
   );
@@ -257,7 +258,11 @@ export function AppsExplorer() {
     (items: AppListItem[]): ResourceTreeNode[] =>
       items.map(item => {
         const loaded = openApps[item.id];
-        let children: ResourceTreeNode[] | undefined;
+        // A failed fetch (deleted app, lost access) must not leave the row on
+        // a perpetual loading skeleton — resolve to an empty child list; the
+        // tab view carries the detailed error.
+        let children: ResourceTreeNode[] | undefined =
+          !loaded && openAppErrors[item.id] ? [] : undefined;
         if (loaded) {
           // buildAppFileNodes already returns folders-first, files-last. Insert
           // the synthetic "Data sources" folder alongside the real folders so
@@ -299,7 +304,7 @@ export function AppsExplorer() {
           children,
         };
       }),
-    [openApps],
+    [openApps, openAppErrors],
   );
 
   const sections = useMemo(

--- a/app/src/components/DashboardCanvas.tsx
+++ b/app/src/components/DashboardCanvas.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Box,
-  Typography,
   IconButton,
   Tooltip,
   Chip,
@@ -55,6 +54,9 @@ import DataSourcePanel from "./dashboard/DataSourcePanel";
 import AddWidgetDialog from "./dashboard/AddWidgetDialog";
 import DashboardSettingsDialog from "./dashboard/DashboardSettingsDialog";
 import ShareDialog from "./ShareDialog";
+import EntityLoadErrorState, {
+  EntityLoadingState,
+} from "./EntityLoadErrorState";
 import { useIsWorkspaceAdmin } from "../hooks/useIsWorkspaceAdmin";
 import WidgetInspector from "./dashboard/WidgetInspector";
 import { SaveCommentDialog } from "./SaveCommentDialog";
@@ -115,6 +117,10 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
   } = useDashboardEditSession({ dashboardId, workspaceId });
 
   const isWorkspaceAdmin = useIsWorkspaceAdmin();
+
+  const dashboardLoadError = useDashboardStore(state =>
+    dashboardId ? state.openDashboardErrors[dashboardId] : undefined,
+  );
 
   const tabId = useConsoleStore(state =>
     Object.keys(state.tabs).find(id => {
@@ -275,19 +281,22 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
   );
 
   if (!dashboard) {
-    return (
-      <Box
-        sx={{
-          height: "100%",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          color: "text.secondary",
-        }}
-      >
-        <Typography>Loading dashboard...</Typography>
-      </Box>
-    );
+    if (dashboardLoadError && dashboardId) {
+      return (
+        <EntityLoadErrorState
+          error={dashboardLoadError}
+          entityLabel="dashboard"
+          onRetry={() => {
+            if (workspaceId) {
+              void useDashboardStore
+                .getState()
+                .reloadDashboard(workspaceId, dashboardId);
+            }
+          }}
+        />
+      );
+    }
+    return <EntityLoadingState label="Loading dashboard…" />;
   }
 
   const isDashboardOwner =

--- a/app/src/components/DashboardDataSourceEditor.tsx
+++ b/app/src/components/DashboardDataSourceEditor.tsx
@@ -18,6 +18,10 @@ import { previewParquetArtifact } from "../lib/parquet-preview";
 import Console from "./Console";
 import ResultsTable from "./ResultsTable";
 import EntityBreadcrumbs from "./EntityBreadcrumbs";
+import EntityLoadErrorState, {
+  EntityLoadingState,
+} from "./EntityLoadErrorState";
+import { missingEntityError } from "../lib/entity-labels";
 import DataSourceMaterializationControls, {
   type MaterializationHistoryItem,
 } from "./DataSourceMaterializationControls";
@@ -56,6 +60,9 @@ export default function DashboardDataSourceEditor({
   const workspaceId = currentWorkspace?.id;
 
   const dashboard = useDashboardStore(s => s.openDashboards[dashboardId]);
+  const dashboardLoadError = useDashboardStore(
+    s => s.openDashboardErrors[dashboardId],
+  );
   const openDashboard = useDashboardStore(s => s.openDashboard);
   const updateDataSource = useDashboardStore(s => s.updateDataSource);
   const saveDashboard = useDashboardStore(s => s.saveDashboard);
@@ -249,19 +256,26 @@ export default function DashboardDataSourceEditor({
   }, [workspaceId, dashboardId, dataSourceId, fetchMaterializationRuns]);
 
   if (!dashboard) {
-    return (
-      <Box sx={{ p: 3, color: "text.secondary" }}>
-        <Typography variant="body2">Loading…</Typography>
-      </Box>
-    );
+    if (dashboardLoadError) {
+      return (
+        <EntityLoadErrorState
+          error={dashboardLoadError}
+          entityLabel="dashboard"
+          onRetry={() => {
+            if (workspaceId) void openDashboard(workspaceId, dashboardId);
+          }}
+        />
+      );
+    }
+    return <EntityLoadingState label="Loading data source…" />;
   }
   if (!dataSource) {
     return (
-      <Box sx={{ p: 3, color: "text.secondary" }}>
-        <Typography variant="body2">
-          This data source no longer exists.
-        </Typography>
-      </Box>
+      <EntityLoadErrorState
+        error={missingEntityError("data source")}
+        entityLabel="data source"
+        detail="This data source no longer exists in this dashboard."
+      />
     );
   }
 

--- a/app/src/components/DbtConsoleView.tsx
+++ b/app/src/components/DbtConsoleView.tsx
@@ -46,6 +46,10 @@ import {
 } from "../store/dbtStore";
 import { focusDbtFileTab } from "../dbt-runtime/shell";
 import { resolveDevEnvName, resolveProdLikeEnvName } from "../lib/dbt-env";
+import EntityLoadErrorState, {
+  EntityLoadingState,
+} from "./EntityLoadErrorState";
+import { missingEntityError } from "../lib/entity-labels";
 
 const DbtLineageView = lazy(() => import("./DbtLineageView"));
 
@@ -125,6 +129,8 @@ export default function DbtConsoleView({ projectId }: { projectId: string }) {
   const workspaceId = currentWorkspace?.id;
 
   const project = useDbtStore(s => s.projects.find(p => p._id === projectId));
+  const projectsLoaded = useDbtStore(s => s.projectsLoaded);
+  const projectsLoadError = useDbtStore(s => s.loadErrors.projects);
   const fetchProjects = useDbtStore(s => s.fetchProjects);
   const compileModel = useDbtStore(s => s.compileModel);
   const runCommand = useDbtStore(s => s.runCommand);
@@ -215,11 +221,27 @@ export default function DbtConsoleView({ projectId }: { projectId: string }) {
   );
 
   if (!project) {
-    return (
-      <Box sx={{ p: 3, color: "text.secondary" }}>
-        <Typography variant="body2">Loading project…</Typography>
-      </Box>
-    );
+    if (projectsLoadError) {
+      return (
+        <EntityLoadErrorState
+          error={projectsLoadError}
+          entityLabel="project"
+          onRetry={() => {
+            if (workspaceId) void fetchProjects(workspaceId);
+          }}
+        />
+      );
+    }
+    // The workspace's project list loaded but this project isn't in it.
+    if (projectsLoaded) {
+      return (
+        <EntityLoadErrorState
+          error={missingEntityError("project")}
+          entityLabel="project"
+        />
+      );
+    }
+    return <EntityLoadingState label="Loading project…" />;
   }
 
   return (

--- a/app/src/components/DbtFileEditor.tsx
+++ b/app/src/components/DbtFileEditor.tsx
@@ -75,6 +75,9 @@ import {
 import { resolveDevEnvName, resolveProdLikeEnvName } from "../lib/dbt-env";
 import { focusDbtFileTab } from "../dbt-runtime/shell";
 import EntityBreadcrumbs from "./EntityBreadcrumbs";
+import EntityLoadErrorState, {
+  EntityLoadingState,
+} from "./EntityLoadErrorState";
 import StreamingMarkdown from "./StreamingMarkdown";
 
 const DbtLineageView = lazy(() => import("./DbtLineageView"));
@@ -283,6 +286,9 @@ export default function DbtFileEditor({
 
   const project = useDbtStore(s => s.projects.find(p => p._id === projectId));
   const file = useDbtStore(s => s.filesByProject[projectId]?.[path]);
+  const fileLoadError = useDbtStore(
+    s => s.loadErrors[`file:${projectId}:${path}`],
+  );
   const filePaths = useDbtStore(s => s.filePathsByProject[projectId]);
   const fetchProjects = useDbtStore(s => s.fetchProjects);
   const readFile = useDbtStore(s => s.readFile);
@@ -602,11 +608,18 @@ export default function DbtFileEditor({
               : { label: "Ready", tone: "idle" };
 
   if (!file?.loaded) {
-    return (
-      <Box sx={{ p: 3, color: "text.secondary" }}>
-        <Typography variant="body2">Loading file…</Typography>
-      </Box>
-    );
+    if (fileLoadError) {
+      return (
+        <EntityLoadErrorState
+          error={fileLoadError}
+          entityLabel="file"
+          onRetry={() => {
+            if (workspaceId) void readFile(workspaceId, projectId, path);
+          }}
+        />
+      );
+    }
+    return <EntityLoadingState label="Loading file…" />;
   }
 
   const editorPane = showMarkdownPreview ? (

--- a/app/src/components/DbtJobView.tsx
+++ b/app/src/components/DbtJobView.tsx
@@ -34,6 +34,10 @@ import { useWorkspace } from "../contexts/workspace-context";
 import { useDbtStore, type DbtJobItem } from "../store/dbtStore";
 import { useIsMobile } from "../hooks/useIsMobile";
 import DbtRunHistory from "./DbtRunHistory";
+import EntityLoadErrorState, {
+  EntityLoadingState,
+} from "./EntityLoadErrorState";
+import { missingEntityError } from "../lib/entity-labels";
 
 // Fast cadence while a run is active; slower idle cadence so scheduled runs
 // that fire (and progress updates) surface without a manual refresh.
@@ -83,6 +87,7 @@ export default function DbtJobView({
 
   const project = useDbtStore(s => s.projects.find(p => p._id === projectId));
   const jobs = useDbtStore(s => s.jobsByProject[projectId]);
+  const jobsLoadError = useDbtStore(s => s.loadErrors[`jobs:${projectId}`]);
   const runs = useDbtStore(s => s.runsByJob[jobId]);
   const fetchProjects = useDbtStore(s => s.fetchProjects);
   const fetchJobs = useDbtStore(s => s.fetchJobs);
@@ -281,11 +286,27 @@ export default function DbtJobView({
   ]);
 
   if (!job) {
-    return (
-      <Box sx={{ p: 3, color: "text.secondary" }}>
-        <Typography variant="body2">Loading job…</Typography>
-      </Box>
-    );
+    if (jobsLoadError) {
+      return (
+        <EntityLoadErrorState
+          error={jobsLoadError}
+          entityLabel="job"
+          onRetry={() => {
+            if (workspaceId) void fetchJobs(workspaceId, projectId);
+          }}
+        />
+      );
+    }
+    // The jobs list for this project loaded but this job isn't in it.
+    if (jobs !== undefined) {
+      return (
+        <EntityLoadErrorState
+          error={missingEntityError("job")}
+          entityLabel="job"
+        />
+      );
+    }
+    return <EntityLoadingState label="Loading job…" />;
   }
 
   const commandSummary = job.commands

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -78,6 +78,9 @@ import DbtRunsView from "./DbtRunsView";
 import DashboardDataSourceEditor from "./DashboardDataSourceEditor";
 import TableDataView from "./TableDataView";
 import EntityBreadcrumbs from "./EntityBreadcrumbs";
+import EntityLoadErrorState from "./EntityLoadErrorState";
+import { tabKindEntityLabel } from "../lib/entity-labels";
+import type { LoadError } from "../api";
 import ScheduleConsoleModal from "./ScheduleConsoleModal";
 import ConsoleRemoteUpdateBanner from "./ConsoleRemoteUpdateBanner";
 import ScheduledRunsPanel from "./ScheduledRunsPanel";
@@ -2655,6 +2658,28 @@ function Editor({
                         full experience.
                       </Alert>
                     </Box>
+                  ) : tab.metadata?.loadError ? (
+                    /* Placeholder tab for an entity that failed to load (e.g.
+                       a /c/:id deep link into a workspace that doesn't have
+                       that console): explicit not-found / no-access copy
+                       instead of a silent redirect. Any tab kind may carry
+                       `metadata.loadError`; the label comes from the shared
+                       entity-label map. */
+                    <EntityLoadErrorState
+                      error={tab.metadata.loadError as LoadError}
+                      entityLabel={tabKindEntityLabel(tab.kind)}
+                      onRetry={
+                        (tab.kind ?? "console") === "console"
+                          ? () => {
+                              if (currentWorkspace?.id) {
+                                void useConsoleStore
+                                  .getState()
+                                  .loadConsole(currentWorkspace.id, tab.id);
+                              }
+                            }
+                          : undefined
+                      }
+                    />
                   ) : tab.kind === "settings" ? (
                     <Settings section={tab.settingsSection} />
                   ) : tab.kind === "members" ? (

--- a/app/src/components/EntityLoadErrorState.tsx
+++ b/app/src/components/EntityLoadErrorState.tsx
@@ -1,0 +1,95 @@
+import { Box, Button, Typography } from "@mui/material";
+import { SearchX, Lock, AlertTriangle } from "lucide-react";
+import type { LoadError } from "../api";
+
+/**
+ * Shared load states for any entity opened in a tab (app, dashboard, console,
+ * flow, dbt project, file, data source, ...). Every tab view should render one
+ * of these instead of a bespoke placeholder so a 404/403/transport failure is
+ * always explicit and never an infinite "Loading…".
+ *
+ *  - `EntityLoadErrorState` — fetch failed: "not found" / "no access" copy
+ *    from the HTTP status, or the server message with a Retry affordance.
+ *  - `EntityLoadingState`   — the standardized loading placeholder.
+ *
+ * For a sub-entity that vanished from an already-loaded parent (file removed
+ * from an app, data source removed from a dashboard, ...), synthesize the 404
+ * with `missingEntityError` from lib/entity-labels.
+ */
+export default function EntityLoadErrorState({
+  error,
+  entityLabel,
+  detail,
+  onRetry,
+}: {
+  error: LoadError;
+  /** Lowercase noun for the copy, e.g. "app", "dashboard", "file". */
+  entityLabel: string;
+  /** Overrides the default body copy (title stays status-derived). */
+  detail?: string;
+  onRetry?: () => void;
+}) {
+  const notFound = error.status === 404;
+  const forbidden = error.status === 403;
+
+  const Icon = notFound ? SearchX : forbidden ? Lock : AlertTriangle;
+  const title = notFound
+    ? `${capitalize(entityLabel)} not found`
+    : forbidden
+      ? `You don't have access to this ${entityLabel}`
+      : `Failed to load ${entityLabel}`;
+  const detailText =
+    detail ??
+    (notFound
+      ? `This ${entityLabel} may have been deleted, or it belongs to a different workspace.`
+      : forbidden
+        ? `Ask the owner to share this ${entityLabel} with you.`
+        : error.message);
+
+  return (
+    <Box
+      sx={{
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 1,
+        p: 3,
+        textAlign: "center",
+        color: "text.secondary",
+      }}
+    >
+      <Icon size={28} strokeWidth={1.5} />
+      <Typography variant="subtitle1" color="text.primary">
+        {title}
+      </Typography>
+      <Typography variant="body2" sx={{ maxWidth: 420 }}>
+        {detailText}
+      </Typography>
+      {onRetry && !notFound && !forbidden && (
+        <Button
+          size="small"
+          variant="outlined"
+          onClick={onRetry}
+          sx={{ mt: 1 }}
+        >
+          Retry
+        </Button>
+      )}
+    </Box>
+  );
+}
+
+/** Standardized "Loading <entity>…" placeholder for tab views. */
+export function EntityLoadingState({ label }: { label: string }) {
+  return (
+    <Box sx={{ p: 3, color: "text.secondary" }}>
+      <Typography variant="body2">{label}</Typography>
+    </Box>
+  );
+}
+
+function capitalize(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}

--- a/app/src/components/FlowEditor.tsx
+++ b/app/src/components/FlowEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, type RefObject } from "react";
+import { useEffect, useState, type RefObject } from "react";
 import { Alert, Box, Tab, Tabs } from "@mui/material";
 import { SyncFlowForm } from "./SyncFlowForm";
 import { DbFlowForm, type DbFlowFormRef } from "./DbFlowForm";
@@ -6,6 +6,10 @@ import { FlowLogs } from "./FlowLogs";
 import { BackfillPanel } from "./BackfillPanel";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useFlowStore } from "../store/flowStore";
+import EntityLoadErrorState, {
+  EntityLoadingState,
+} from "./EntityLoadErrorState";
+import { missingEntityError } from "../lib/entity-labels";
 
 interface FlowEditorProps {
   flowId?: string;
@@ -45,7 +49,10 @@ export function FlowEditor({
   const [viewTab, setViewTab] = useState<"cdc" | "runs">("cdc");
 
   const { currentWorkspace } = useWorkspace();
-  const { flows: flowsMap, runFlow } = useFlowStore();
+  const { flows: flowsMap, runFlow, fetchFlows } = useFlowStore();
+  const flowsError = useFlowStore(s =>
+    currentWorkspace ? s.error[currentWorkspace.id] : null,
+  );
 
   const flows = currentWorkspace ? flowsMap[currentWorkspace.id] || [] : [];
   const currentFlow = currentFlowId
@@ -53,6 +60,37 @@ export function FlowEditor({
     : null;
 
   const isNewMode = Boolean(isNew && !currentFlowId);
+
+  // Deep links can reference a flow that isn't in the (possibly stale) cached
+  // list — e.g. after a workspace switch. Refetch once before deciding the
+  // flow doesn't exist, so we never show "not found" for a merely-uncached
+  // flow, and never leave the tab empty for a truly missing one.
+  const [missingFlowVerified, setMissingFlowVerified] = useState(false);
+  useEffect(() => {
+    if (
+      !currentWorkspace?.id ||
+      isNewMode ||
+      !currentFlowId ||
+      currentFlow ||
+      missingFlowVerified
+    ) {
+      return;
+    }
+    let cancelled = false;
+    void fetchFlows(currentWorkspace.id).finally(() => {
+      if (!cancelled) setMissingFlowVerified(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    currentWorkspace?.id,
+    isNewMode,
+    currentFlowId,
+    currentFlow,
+    missingFlowVerified,
+    fetchFlows,
+  ]);
 
   // Database-query sources keep the dedicated DbFlowForm.
   const isDbFlow =
@@ -153,6 +191,30 @@ export function FlowEditor({
       </>
     );
   };
+
+  // Existing-flow tab whose flow can't be resolved: loading until the
+  // verification fetch settles, then an explicit error / not-found state
+  // (never a silently empty tab).
+  if (!isEditing && !isNewMode && currentFlowId && !currentFlow) {
+    if (!missingFlowVerified) {
+      return <EntityLoadingState label="Loading flow…" />;
+    }
+    if (flowsError) {
+      return (
+        <EntityLoadErrorState
+          error={{ message: flowsError }}
+          entityLabel="flow"
+          onRetry={() => setMissingFlowVerified(false)}
+        />
+      );
+    }
+    return (
+      <EntityLoadErrorState
+        error={missingEntityError("flow")}
+        entityLabel="flow"
+      />
+    );
+  }
 
   return (
     <Box

--- a/app/src/contexts/workspace-context.tsx
+++ b/app/src/contexts/workspace-context.tsx
@@ -17,9 +17,9 @@ import {
 } from "../lib/workspace-client";
 import { useAuth } from "./auth-context";
 import { useUIStore } from "../store/uiStore";
-import { useConsoleStore } from "../store/consoleStore";
 import { useExplorerStore } from "../store/explorerStore";
 import { useChatStore } from "../store/chatStore";
+import { useDashboardStore } from "../store/dashboardStore";
 
 import { useFlowStore } from "../store/flowStore";
 import { useSchemaStore } from "../store/schemaStore";
@@ -332,24 +332,28 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
           setCurrentWorkspace(workspace);
         }
 
-        // Clear local storage to reset app state for the new workspace.
-        // This is critical: persisted stores (console-store, flow-store-v2,
-        // explorer-store, chat-store, ui-store, …) must not leak tabs/state
-        // from the previous workspace into the new one. Preserve the
-        // activeWorkspaceId by setting it AFTER clear.
-        localStorage.clear();
-        localStorage.setItem("activeWorkspaceId", id);
-        setCurrentWorkspaceId(id);
-
-        // Also reset in-memory store state to prevent leaks if reload is delayed
-        useUIStore.getState().reset();
+        // Console tabs are persisted per workspace (`console-store:<id>`, see
+        // consoleStore's storage adapter), so they must NOT be cleared here:
+        // the post-switch reload rehydrates the new workspace's own tabs, and
+        // switching back later restores this workspace's tabs. The adapter
+        // freezes writes once `activeWorkspaceId` flips (workspaceClient set
+        // it above), so the old workspace's tabs can't leak into the new
+        // bucket before the reload.
+        //
+        // Reset only the persisted stores whose state is global and
+        // workspace-specific, so it can't leak into the new workspace.
         useExplorerStore.getState().reset();
         useChatStore.getState().reset();
-        useConsoleStore.getState().clearAllConsoles();
         useFlowStore.getState().reset();
+        useDashboardStore.setState({ activeDashboardId: null });
 
-        // Reload the page to refresh all data with new workspace context
-        window.location.reload();
+        setCurrentWorkspaceId(id);
+
+        // Reload from the root: keeping the current path would make UrlSync
+        // deep-link the previous workspace's resource (e.g. /a/<appId>) into
+        // the new workspace, where it 404s. The new workspace's own active
+        // tab is restored from its persisted bucket instead.
+        window.location.replace("/");
       } catch (err: any) {
         setError(err.message || "Failed to switch workspace");
         throw err;

--- a/app/src/lib/api-client.ts
+++ b/app/src/lib/api-client.ts
@@ -3,6 +3,7 @@
  */
 import { getApiBasePath } from "./api-base-path";
 import { handleUnauthorized } from "./auth-redirect";
+import { ApiError } from "../api/result";
 
 interface ApiRequestOptions extends RequestInit {
   params?: Record<string, string>;
@@ -50,14 +51,19 @@ class ApiClient {
     // transient 401 during a deploy doesn't bounce the user to /login.
     if (response.status === 401) {
       void handleUnauthorized();
-      throw new Error("Unauthorized");
+      throw new ApiError("Unauthorized", 401);
     }
 
     if (!response.ok) {
       const error = await response
         .json()
         .catch(() => ({ error: "An error occurred" }));
-      throw new Error(error.error || `HTTP error! status: ${response.status}`);
+      // ApiError (extends Error) carries the HTTP status so callers can
+      // distinguish "not found" from "no access" without string parsing.
+      throw new ApiError(
+        error.error || `HTTP error! status: ${response.status}`,
+        response.status,
+      );
     }
 
     // Handle empty responses

--- a/app/src/lib/entity-labels.ts
+++ b/app/src/lib/entity-labels.ts
@@ -1,0 +1,49 @@
+/**
+ * Entity labels: single source of truth for the human noun of each tab kind.
+ *
+ * Used by the shared entity load/error states ("App not found", "You don't
+ * have access to this dashboard", "Loading flow…") so the copy stays
+ * consistent everywhere a resource fails to load.
+ *
+ * REGRESSION GUARD: exhaustive over `TabKind` (same pattern as
+ * lib/tab-routing.ts) — adding a tab kind without deciding its label is a
+ * compile error.
+ */
+import type { TabKind } from "../store/lib/types";
+import type { LoadError } from "../api/result";
+
+export const TAB_KIND_ENTITY_LABELS = {
+  console: "console",
+  connectors: "connector",
+  "flow-editor": "flow",
+  dashboard: "dashboard",
+  "dashboard-data-source": "data source",
+  "table-data": "table",
+  app: "app",
+  "app-file": "file",
+  "app-binding": "data source",
+  plan: "plan",
+  settings: "settings section",
+  members: "members page",
+  "dbt-file": "file",
+  "dbt-job": "job",
+  "dbt-runs": "runs view",
+  "dbt-console": "project",
+} as const satisfies Record<NonNullable<TabKind>, string>;
+
+export function tabKindEntityLabel(kind: TabKind | undefined): string {
+  return TAB_KIND_ENTITY_LABELS[kind ?? "console"];
+}
+
+/**
+ * 404 `LoadError` for a sub-entity missing from a loaded parent (file removed
+ * from an app, data source removed from a dashboard, job deleted from a
+ * project, ...). Renders with the "not found" treatment in
+ * EntityLoadErrorState; pass `detail` there for context-specific copy.
+ */
+export function missingEntityError(entityLabel: string): LoadError {
+  return {
+    status: 404,
+    message: `${entityLabel.charAt(0).toUpperCase()}${entityLabel.slice(1)} not found`,
+  };
+}

--- a/app/src/store/appStore.ts
+++ b/app/src/store/appStore.ts
@@ -13,7 +13,7 @@
 
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
-import { api, unwrapBody } from "../api";
+import { api, toLoadError, unwrapBody, type LoadError } from "../api";
 import { apiClient } from "../lib/api-client";
 import {
   containsDbtSchemaToken,
@@ -121,6 +121,11 @@ interface AppState {
   error: Record<string, string | null>;
 
   openApps: Record<string, AppEntity>;
+  /**
+   * Per-app load failure (404 / 403 / transport) from `fetchApp`. Views use
+   * this to render "not found" / "no access" instead of loading forever.
+   */
+  openAppErrors: Record<string, LoadError>;
   activeAppId: string | null;
 
   /** Bumping the nonce forces the renderer to rebuild that app's preview. */
@@ -279,6 +284,7 @@ const initialState: AppState = {
   loading: {},
   error: {},
   openApps: {},
+  openAppErrors: {},
   activeAppId: null,
   previewNonce: {},
   previewErrors: {},
@@ -363,9 +369,15 @@ export const useAppStore = create<AppStore>()(
             params: { path: { workspaceId, id: appId } },
           }),
         ) as { success: boolean; app: AppEntity };
-        if (!res.success || !res.app) return null;
+        if (!res.success || !res.app) {
+          set(state => {
+            state.openAppErrors[appId] = { message: "Failed to load app" };
+          });
+          return null;
+        }
         set(state => {
           state.openApps[appId] = res.app;
+          delete state.openAppErrors[appId];
           if (state.previewNonce[appId] === undefined) {
             state.previewNonce[appId] = 0;
           }
@@ -376,7 +388,10 @@ export const useAppStore = create<AppStore>()(
           }
         });
         return res.app;
-      } catch {
+      } catch (e) {
+        set(state => {
+          state.openAppErrors[appId] = toLoadError(e, "Failed to load app");
+        });
         return null;
       }
     },
@@ -412,6 +427,7 @@ export const useAppStore = create<AppStore>()(
         );
         set(state => {
           delete state.openApps[appId];
+          delete state.openAppErrors[appId];
           delete state.previewNonce[appId];
           delete state.previewErrors[appId];
         });

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 import { apiClient } from "../lib/api-client";
-import { api, unwrapBody } from "../api";
+import { api, toLoadError, unwrapBody, type LoadError } from "../api";
 import {
   isLocalConnectionId,
   localAgentClient,
@@ -192,6 +192,8 @@ interface ConsoleActions {
     consoleId: string,
     options?: { openScheduledRuns?: boolean },
   ) => Promise<void>;
+  /** Open a placeholder tab surfacing a failed console load (see impl). */
+  openConsoleLoadErrorTab: (consoleId: string, loadError: LoadError) => void;
   reloadConsole: (workspaceId: string, consoleId: string) => Promise<void>;
   fetchConsoleContent: (
     workspaceId: string,
@@ -473,6 +475,65 @@ function normalizeScheduledRunSnapshotForTab(
     runCount: scheduledRun?.runCount ?? 0,
     consecutiveFailures: scheduledRun?.consecutiveFailures ?? 0,
   };
+}
+
+/**
+ * Tabs are persisted per workspace: `console-store:<workspaceId>`. The active
+ * workspace id lives in localStorage (`activeWorkspaceId`, written before the
+ * post-switch reload), so each boot rehydrates the bucket that belongs to the
+ * workspace being loaded — switching workspaces no longer leaks tabs from
+ * another workspace, and switching back restores that workspace's tabs.
+ */
+const CONSOLE_STORE_BASE_KEY = "console-store";
+
+function consoleStoreStorageKey(): string {
+  const workspaceId = localStorage.getItem("activeWorkspaceId");
+  return workspaceId
+    ? `${CONSOLE_STORE_BASE_KEY}:${workspaceId}`
+    : CONSOLE_STORE_BASE_KEY;
+}
+
+/**
+ * One-time migration: users upgrading from the global bucket keep the tabs of
+ * the workspace they are currently in; the legacy key is removed so it can't
+ * leak into other workspaces later.
+ */
+function readConsoleStoreItem(): string | null {
+  const key = consoleStoreStorageKey();
+  const scoped = localStorage.getItem(key);
+  if (scoped !== null) return scoped;
+  if (key === CONSOLE_STORE_BASE_KEY) return null;
+  const legacy = localStorage.getItem(CONSOLE_STORE_BASE_KEY);
+  if (legacy !== null) {
+    localStorage.setItem(key, legacy);
+    localStorage.removeItem(CONSOLE_STORE_BASE_KEY);
+  }
+  return legacy;
+}
+
+/** Bucket this session's in-memory tab state was rehydrated from. */
+let hydratedConsoleStoreKey: string | null = null;
+
+/**
+ * Resolve the bucket writes should target, or null to skip the write.
+ *
+ * When the active workspace changes mid-session (workspace switch, invite
+ * accept) the in-memory tabs still belong to the previous workspace, so
+ * persisting them under the new workspace's key would leak them across
+ * workspaces. Writes are frozen until the post-switch reload rehydrates the
+ * correct bucket. The one legitimate flip — booting with no workspace selected
+ * and resolving to one — adopts the new key instead.
+ */
+function consoleStoreWriteKey(): string | null {
+  const key = consoleStoreStorageKey();
+  if (hydratedConsoleStoreKey === null || hydratedConsoleStoreKey === key) {
+    return key;
+  }
+  if (hydratedConsoleStoreKey === CONSOLE_STORE_BASE_KEY) {
+    hydratedConsoleStoreKey = key;
+    return key;
+  }
+  return null;
 }
 
 export const useConsoleStore = create<ConsoleStore>()(
@@ -1065,12 +1126,14 @@ export const useConsoleStore = create<ConsoleStore>()(
 
       // API operations
       loadConsole: async (workspaceId, consoleId, options) => {
-        // Check if console is already loaded
-        if (get().tabs[consoleId]) {
+        // Check if console is already loaded. A load-error placeholder tab
+        // does not count: fall through and retry the fetch (access may have
+        // been granted since, or the failure was transient).
+        const existingTab = get().tabs[consoleId];
+        if (existingTab && !existingTab.metadata?.loadError) {
           if (options?.openScheduledRuns) {
-            const existingMetadata = get().tabs[consoleId].metadata;
             get().updateMetadata(consoleId, {
-              ...(existingMetadata || {}),
+              ...(existingTab.metadata || {}),
               openScheduledRuns: true,
             });
           }
@@ -1129,18 +1192,43 @@ export const useConsoleStore = create<ConsoleStore>()(
             set(state => {
               state.error[consoleId] = "Failed to load console";
             });
+            get().openConsoleLoadErrorTab(consoleId, {
+              message: "Failed to load console",
+            });
           }
         } catch (e) {
           console.error("Failed to load console", e);
+          const loadError = toLoadError(e, "Failed to load console");
           set(state => {
-            state.error[consoleId] =
-              e instanceof Error ? e.message : "Failed to load console";
+            state.error[consoleId] = loadError.message;
           });
+          get().openConsoleLoadErrorTab(consoleId, loadError);
         } finally {
           set(state => {
             delete state.loading[consoleId];
           });
         }
+      },
+
+      /**
+       * Deep links and palette opens must not fail silently: when the console
+       * can't be loaded (deleted, other workspace, no access), open a
+       * placeholder tab that renders the load error (Editor short-circuits on
+       * `metadata.loadError`). The tab reuses the console id so the /c/:id
+       * URL sticks and a successful retry replaces it in place.
+       */
+      openConsoleLoadErrorTab: (consoleId, loadError) => {
+        get().openTab(
+          {
+            id: consoleId,
+            title: "Console",
+            content: "",
+            kind: "console",
+            isSaved: false,
+            metadata: { loadError },
+          },
+          { replacePristine: false },
+        );
       },
 
       reloadConsole: async (workspaceId, consoleId) => {
@@ -1827,8 +1915,11 @@ export const useConsoleStore = create<ConsoleStore>()(
         activeTabId: state.activeTabId,
       }),
       storage: {
-        getItem: name => {
-          const str = localStorage.getItem(name);
+        // The `name` argument is ignored on purpose: reads and writes resolve
+        // the per-workspace key at call time (see consoleStoreStorageKey).
+        getItem: () => {
+          hydratedConsoleStoreKey = consoleStoreStorageKey();
+          const str = readConsoleStoreItem();
           if (str) {
             const data = JSON.parse(str);
             if (data.state?.tabs) {
@@ -1899,11 +1990,13 @@ export const useConsoleStore = create<ConsoleStore>()(
 
           return null;
         },
-        setItem: (name, value) => {
-          localStorage.setItem(name, JSON.stringify(value));
+        setItem: (_name, value) => {
+          const key = consoleStoreWriteKey();
+          if (key) localStorage.setItem(key, JSON.stringify(value));
         },
-        removeItem: name => {
-          localStorage.removeItem(name);
+        removeItem: () => {
+          const key = consoleStoreWriteKey();
+          if (key) localStorage.removeItem(key);
         },
       },
     },

--- a/app/src/store/dashboardStore.ts
+++ b/app/src/store/dashboardStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
-import { api, unwrap, unwrapBody } from "../api";
+import { api, toLoadError, unwrap, unwrapBody, type LoadError } from "../api";
 import {
   DashboardDefinitionSchema,
   normalizeWidgetLayouts,
@@ -139,6 +139,12 @@ interface DashboardStoreState {
   error: Record<string, string | null>;
 
   openDashboards: Record<string, Dashboard>;
+  /**
+   * Per-dashboard load failure (404 / 403 / transport) from `reloadDashboard`.
+   * Views use this to render "not found" / "no access" instead of loading
+   * forever.
+   */
+  openDashboardErrors: Record<string, LoadError>;
   editingDashboards: Record<string, boolean>;
   activeDashboardId: string | null;
   historyMap: Record<string, HistoryEntry>;
@@ -294,6 +300,7 @@ export const useDashboardStore = create<DashboardStoreState>()(
       loading: {},
       error: {},
       openDashboards: {},
+      openDashboardErrors: {},
       editingDashboards: {},
       activeDashboardId: null,
       historyMap: {},
@@ -507,14 +514,23 @@ export const useDashboardStore = create<DashboardStoreState>()(
             }
             set(state => {
               state.openDashboards[dashboardId] = dashboard;
+              delete state.openDashboardErrors[dashboardId];
               state.activeDashboardId = dashboardId;
               state.historyMap[dashboardId] = { stack: [], index: -1 };
               state.savedStateHashes[dashboardId] =
                 computeDashboardStateHash(dashboard);
             });
           }
-        } catch {
-          // silent
+        } catch (e) {
+          // An aborted request is not a load failure — the caller navigated
+          // away; don't paint the tab with an error.
+          if (e instanceof DOMException && e.name === "AbortError") return;
+          set(state => {
+            state.openDashboardErrors[dashboardId] = toLoadError(
+              e,
+              "Failed to load dashboard",
+            );
+          });
         }
       },
 
@@ -529,6 +545,7 @@ export const useDashboardStore = create<DashboardStoreState>()(
         set(state => {
           delete state.editingDashboards[dashboardId];
           delete state.openDashboards[dashboardId];
+          delete state.openDashboardErrors[dashboardId];
           delete state.historyMap[dashboardId];
           delete state.savedStateHashes[dashboardId];
           if (state.activeDashboardId === dashboardId) {

--- a/app/src/store/dbtStore.ts
+++ b/app/src/store/dbtStore.ts
@@ -10,6 +10,7 @@
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import { apiClient } from "../lib/api-client";
+import { toLoadError, type LoadError } from "../api/result";
 import { realtimeClientId } from "../lib/realtime-client-id";
 
 export interface DbtEnvironment {
@@ -354,6 +355,12 @@ interface DbtState {
   createProjectMode: "blank" | "github";
   loading: Record<string, boolean>;
   error: Record<string, string | null>;
+  /**
+   * Structured load failures (status + message) for the fetches that tab
+   * views gate on: `projects`, `jobs:<projectId>`, `file:<projectId>:<path>`.
+   * Lets views render "not found" / "no access" instead of loading forever.
+   */
+  loadErrors: Record<string, LoadError>;
 }
 
 interface DbtActions {
@@ -658,6 +665,7 @@ const initialState: DbtState = {
   createProjectMode: "blank",
   loading: {},
   error: {},
+  loadErrors: {},
 };
 
 function errMessage(error: unknown, fallback: string): string {
@@ -696,6 +704,7 @@ export const useDbtStore = create<DbtStore>()(
       set(state => {
         state.loading.projects = true;
         state.error.projects = null;
+        delete state.loadErrors.projects;
       });
       try {
         const response = await apiClient.get<{
@@ -720,6 +729,10 @@ export const useDbtStore = create<DbtStore>()(
         set(state => {
           state.loading.projects = false;
           state.error.projects = errMessage(error, "Failed to load projects");
+          state.loadErrors.projects = toLoadError(
+            error,
+            "Failed to load projects",
+          );
         });
       }
     },
@@ -1295,6 +1308,9 @@ export const useDbtStore = create<DbtStore>()(
     readFile: async (workspaceId, projectId, path) => {
       const existing = get().filesByProject[projectId]?.[path];
       if (existing?.loaded) return existing.content;
+      set(state => {
+        delete state.loadErrors[`file:${projectId}:${path}`];
+      });
       try {
         const response = await apiClient.get<{
           success: boolean;
@@ -1317,6 +1333,10 @@ export const useDbtStore = create<DbtStore>()(
       } catch (error) {
         set(state => {
           state.error[`file:${projectId}:${path}`] = errMessage(
+            error,
+            "Failed to read file",
+          );
+          state.loadErrors[`file:${projectId}:${path}`] = toLoadError(
             error,
             "Failed to read file",
           );
@@ -1541,6 +1561,9 @@ export const useDbtStore = create<DbtStore>()(
     },
 
     fetchJobs: async (workspaceId, projectId) => {
+      set(state => {
+        delete state.loadErrors[`jobs:${projectId}`];
+      });
       try {
         const response = await apiClient.get<{
           success: boolean;
@@ -1552,6 +1575,10 @@ export const useDbtStore = create<DbtStore>()(
       } catch (error) {
         set(state => {
           state.error[`jobs:${projectId}`] = errMessage(
+            error,
+            "Failed to load jobs",
+          );
+          state.loadErrors[`jobs:${projectId}`] = toLoadError(
             error,
             "Failed to load jobs",
           );

--- a/app/src/store/lib/storeVersion.ts
+++ b/app/src/store/lib/storeVersion.ts
@@ -24,6 +24,23 @@ const PERSISTED_STORE_KEYS = [
 ];
 
 /**
+ * Prefixes of workspace-scoped persisted stores (`<prefix>:<workspaceId>`).
+ * Every matching key is cleared on version change.
+ */
+const PERSISTED_STORE_KEY_PREFIXES = ["console-store:"];
+
+function removeKeysWithPrefixes(): void {
+  const toRemove: string[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key && PERSISTED_STORE_KEY_PREFIXES.some(p => key.startsWith(p))) {
+      toRemove.push(key);
+    }
+  }
+  toRemove.forEach(key => localStorage.removeItem(key));
+}
+
+/**
  * Legacy keys to always remove (from old store architecture).
  * These are cleared regardless of version to clean up old data.
  */
@@ -50,8 +67,9 @@ export function initializeStoreVersion(): void {
   if (storedVersion !== CURRENT_VERSION) {
     // Store version changed - clearing stored data for clean upgrade
 
-    // Clear all persisted stores
+    // Clear all persisted stores (including workspace-scoped buckets)
     PERSISTED_STORE_KEYS.forEach(key => localStorage.removeItem(key));
+    removeKeysWithPrefixes();
 
     // Set new version
     localStorage.setItem(STORE_VERSION_KEY, String(CURRENT_VERSION));
@@ -72,6 +90,7 @@ export function getStoreVersion(): number {
  */
 export function clearAllStoreData(): void {
   PERSISTED_STORE_KEYS.forEach(key => localStorage.removeItem(key));
+  removeKeysWithPrefixes();
   LEGACY_KEYS.forEach(key => localStorage.removeItem(key));
   localStorage.removeItem(STORE_VERSION_KEY);
 }


### PR DESCRIPTION
## Summary

Two related UX bugs around resource access and workspace switching:

1. **Resources that fail to load now say so.** Opening an app, dashboard, console, flow, dbt project/file/job, app file/data-binding, or dashboard data source that was deleted, belongs to another workspace, or isn't shared with you previously left the tab on "Loading…" forever — and console deep links (`/c/:id`) silently redirected to `/` with no message. Every tab view now renders a shared `EntityLoadErrorState`: **404 → "X not found"**, **403 → "You don't have access to this X"**, anything else → the server message with a Retry button.
2. **Tabs are persisted per workspace and rehydrate on switch.** `switchWorkspace` used to `localStorage.clear()` + close all tabs, and stale tabs could still leak into the new workspace via other paths. The console/tab store now persists into `console-store:<workspaceId>` buckets (with one-time migration from the legacy global key), so switching to workspace B restores B's own tabs and switching back restores A's exactly as left. A write-freeze guard prevents one workspace's in-memory tabs from being written under another workspace's key if `activeWorkspaceId` flips mid-session (e.g. invite accept). Post-switch reload now lands on `/` so UrlSync can't deep-link the previous workspace's resource into the new one.

### Generic building blocks

- `ApiError` (status-carrying) thrown by `unwrap`/`unwrapBody` **and** the legacy `apiClient`; `toLoadError()` normalizes any failure to `{ status?, message }`
- `EntityLoadErrorState` / `EntityLoadingState` shared components; `missingEntityError()` for sub-entities that vanished from a loaded parent
- `TAB_KIND_ENTITY_LABELS` exhaustive over `TabKind` (compile-time guard, same pattern as `tab-routing.ts`)
- Any tab kind can carry `metadata.loadError` and `Editor.tsx` renders the placeholder generically (used today by failed console deep links)

## Test plan

- [x] `pnpm --filter app run typecheck`, `lint`, `test:unit` (290 tests) all green
- [x] Browser-tested on localhost: deep links to nonexistent console (original repro URL), app, dashboard, flow, dbt project, dbt file each show the explicit not-found tab with the URL preserved
- [x] Missing file inside a real app shows "File not found — `<path>` no longer exists in this app"
- [x] Workspace switch round trip (Mako → RealAdvisor → Mako): each workspace restores its own tabs; localStorage buckets verified intact in both directions; real console with content/connection restored correctly
- [x] Regression: real app preview, tab closing, and URL-follows-active-tab all behave as before

Made with [Cursor](https://cursor.com)