### PR TITLE
feat(dbt): branch-scoped drafts — iterate on multiple branches with independent uncommitted state

### DIFF
--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -1552,19 +1552,22 @@ export const createDbtServerTools = (
         "committed base tree, the same as the IDE 'Sync/Pull' action. Use this " +
         "when the project is building from a stale checkout — e.g. files were " +
         "merged on the remote (a PR landed on main) but the project hasn't " +
-        "picked them up. ALWAYS SAFE: uncommitted edits live in a per-user " +
-        "draft overlay that a sync never touches. Pass discardLocalChanges:" +
-        "true to ALSO drop the user's uncommitted drafts before pulling (a " +
-        "`git checkout -- .`; only after the user confirms). To pull a " +
-        "DIFFERENT branch, use dbt_switch_branch instead.",
+        "picked them up. ALWAYS SAFE: uncommitted edits live in a per-user, " +
+        "per-branch draft overlay that a sync never touches. Pass " +
+        "discardLocalChanges:true to ALSO drop the user's uncommitted drafts " +
+        "on the current branch before pulling (a `git checkout -- .`; only " +
+        "after the user confirms; drafts stashed on other branches are " +
+        "untouched). To pull a DIFFERENT branch, use dbt_switch_branch " +
+        "instead.",
       inputSchema: z.object({
         projectId: projectIdField,
         discardLocalChanges: z
           .boolean()
           .optional()
           .describe(
-            "Set true to also discard the user's uncommitted draft edits. " +
-              "Default false keeps drafts (they overlay the pulled tree).",
+            "Set true to also discard the user's uncommitted draft edits on " +
+              "the current branch. Default false keeps drafts (they overlay " +
+              "the pulled tree).",
           ),
       }),
       execute: async ({ projectId, discardLocalChanges }) => {
@@ -1660,9 +1663,12 @@ export const createDbtServerTools = (
     dbt_git_status: tool({
       description:
         "Show the working-tree git status of a repo-bound dbt project: which " +
-        "files are added/modified/deleted relative to the tracked branch, " +
-        "and the branch name. Call this before dbt_commit_and_push to confirm " +
-        "what will be committed, and to summarize pending changes for the user.",
+        "files are added/modified/deleted relative to the committed base of " +
+        "the USER's checked-out branch, and that branch's name. Drafts are " +
+        "per-branch, so this only shows the current branch's pending changes " +
+        "— work stashed on other branches does not appear (switch to see it). " +
+        "Call this before dbt_commit_and_push to confirm what will be " +
+        "committed, and to summarize pending changes for the user.",
       inputSchema: z.object({ projectId: projectIdField }),
       execute: async ({ projectId }) => {
         try {
@@ -1851,12 +1857,14 @@ export const createDbtServerTools = (
 
     dbt_create_branch: tool({
       description:
-        "Create a new branch off the project's current branch head and check " +
-        "it out (track it). NOTE: to put pending working-tree changes on a new " +
-        "branch, prefer dbt_commit_to_branch (atomic) — calling this then " +
-        "dbt_commit_and_push separately can race a concurrent commit. Use this " +
-        "only to branch with no pending changes. Branch content is " +
-        "identical to the current branch — no re-sync needed.",
+        "Create a new branch off the user's current branch head and check " +
+        "it out — `git checkout -b`: the user's uncommitted drafts MOVE to " +
+        "the new branch with them (the diff is unchanged since both bases " +
+        "are identical). NOTE: to branch AND commit pending changes in one " +
+        "step, prefer dbt_commit_to_branch (atomic) — calling this then " +
+        "dbt_commit_and_push separately can race a concurrent commit. " +
+        "Branch content is identical to the current branch — no re-sync " +
+        "needed.",
       inputSchema: z.object({
         projectId: projectIdField,
         name: z
@@ -1963,7 +1971,10 @@ export const createDbtServerTools = (
         "a stray/merged feature branch (e.g. after its PR is merged, or an " +
         "abandoned branch from a failed promote). Refuses to delete the branch " +
         "the project currently tracks (switch away first with dbt_switch_branch) " +
-        "and the repo's default branch. Idempotent: deleting an already-gone " +
+        "and the repo's default branch. DESTRUCTIVE for stashed work: any " +
+        "uncommitted drafts saved on that branch are permanently dropped with " +
+        "it — check for pending work there before deleting if in doubt. " +
+        "Idempotent: deleting an already-gone " +
         "branch succeeds. ONLY call after the user confirms the branch name.",
       inputSchema: z.object({
         projectId: projectIdField,
@@ -2030,14 +2041,17 @@ export const createDbtServerTools = (
     dbt_merge_pull_request: tool({
       description:
         "Merge a GitHub pull request that was opened with dbt_open_pull_request, " +
-        "optionally delete its source branch, then switch the project back to " +
-        "the repo's default branch and sync the merged state into the working " +
-        "tree. Use when the user asks to promote/merge a PR — completes the " +
-        "full ship loop without manual GitHub UI steps. Refuses before merging " +
-        "if the working tree has uncommitted changes that must be committed or " +
-        "moved first. Returns the merge " +
-        "commit SHA, whether the branch was deleted, and confirmation the " +
-        "working tree is clean on the default branch.",
+        "optionally delete its source branch, then switch the user's checkout " +
+        "back to the repo's default branch and sync the merged state into its " +
+        "base tree. Use when the user asks to promote/merge a PR — completes " +
+        "the full ship loop without manual GitHub UI steps. Uncommitted drafts " +
+        "on the deleted head branch are NOT lost: they move to the default " +
+        "branch with the user (workingTreeClean:false in the result means such " +
+        "pending changes exist — tell the user). WARNING: the merge itself only " +
+        "includes COMMITTED work; commit pending changes that belong in the PR " +
+        "first (dbt_git_status → dbt_commit_and_push). Returns the merge " +
+        "commit SHA, whether the branch was deleted, and whether the working " +
+        "tree is clean on the default branch.",
       inputSchema: z.object({
         projectId: projectIdField,
         prNumber: z

--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -1570,13 +1570,13 @@ export const createDbtServerTools = (
       execute: async ({ projectId, discardLocalChanges }) => {
         try {
           const project = await assertRepoProject(projectId);
-          if (discardLocalChanges) {
-            await discardUserDrafts(project, actingUserId);
-          }
           const branch = (await getCheckoutBranch(
             project,
             actingUserId,
           )) as string;
+          if (discardLocalChanges) {
+            await discardUserDrafts(project, actingUserId, branch);
+          }
           const result = await syncProjectBranchFromRepo(
             project,
             branch,
@@ -1889,10 +1889,13 @@ export const createDbtServerTools = (
       description:
         "Switch the USER's checked-out branch and pull its committed contents " +
         "into the base tree. Only the acting user's checkout moves — other " +
-        "collaborators keep their own branches. Uncommitted draft edits carry " +
-        "over as an overlay (like `git checkout` with a dirty tree), so " +
-        "nothing is lost; pass discardLocalChanges:true to drop the user's " +
-        "drafts instead (only after the user explicitly confirms).",
+        "collaborators keep their own branches. ALWAYS SAFE: uncommitted " +
+        "draft edits STAY WITH THE BRANCH they were made on (git-worktree " +
+        "semantics), so the user can iterate on several branches and find " +
+        "each branch's work-in-progress intact when they switch back — " +
+        "nothing mixes across branches. Pass discardLocalChanges:true to " +
+        "drop the user's drafts on the branch being left (only after the " +
+        "user explicitly confirms).",
       inputSchema: z.object({
         projectId: projectIdField,
         branch: z.string().min(1).max(255).describe("Existing branch to track"),
@@ -1900,8 +1903,8 @@ export const createDbtServerTools = (
           .boolean()
           .optional()
           .describe(
-            "Set true to throw away the user's uncommitted draft changes " +
-              "before switching. Only after the user explicitly confirms.",
+            "Set true to throw away the user's uncommitted draft changes on " +
+              "the branch being left. Only after the user explicitly confirms.",
           ),
       }),
       execute: async ({ projectId, branch, discardLocalChanges }) => {
@@ -1918,7 +1921,9 @@ export const createDbtServerTools = (
           return {
             success: true,
             branch: result.branch,
-            carriedChanges: result.carriedChanges,
+            // Uncommitted changes the user had previously stashed on the
+            // target branch, now visible again in their working tree.
+            pendingChangesOnBranch: result.pendingChanges,
             discardedChanges: result.discarded?.changes,
           };
         } catch (error) {

--- a/api/src/agent-skills/dbt/SKILL.md
+++ b/api/src/agent-skills/dbt/SKILL.md
@@ -154,11 +154,26 @@ AND its tests — always add at least `unique` + `not_null` on the primary key.
   - MULTI-USER workspace: each user tests against their OWN environment.
     `dbt_run_model` auto-provisions a personal one (schema `dbt_<user>`) on
     the first build so teammates never build over each other's schemas.
+- **Drafts are per user AND per branch (git-worktree semantics)**:
+  uncommitted edits stay with the branch they were made on. Switching
+  branches (`dbt_switch_branch`) is always safe — each branch's
+  work-in-progress is intact when you switch back, and nothing mixes across
+  branches. This means the user can iterate on several branches in parallel.
+  Consequences to keep straight:
+  - `dbt_git_status` shows ONLY the current branch's pending changes; work
+    stashed on another branch is invisible until you switch to it.
+  - `dbt_create_branch` is `git checkout -b`: the current dirty tree moves to
+    the new branch.
+  - Deleting a branch (`dbt_delete_branch`, or `deleteBranch` on close/merge
+    of a PR) drops the drafts stashed on it — except a PR merge, which moves
+    them to the default branch with the user.
+  - `discardLocalChanges` (on switch/sync) only discards the branch being
+    left / the current branch — never other branches' stashes.
 - **Which git tree a run builds (repo-bound projects)** — never mix these up:
   - Ad-hoc tools (`dbt_parse`, `dbt_compile_model`, `dbt_show`,
     `dbt_run_model`) build YOUR working tree: your checkout branch + your
-    uncommitted drafts. This is the ONLY way to verify uncommitted or
-    feature-branch work.
+    uncommitted drafts on that branch. This is the ONLY way to verify
+    uncommitted or feature-branch work.
   - Jobs (`dbt_run_job`, schedules) build the COMMITTED tracked branch only —
     never your checkout or drafts. Triggering a job to test a draft silently
     runs the OLD code; do not do it, and do not "fix" it by committing — the

--- a/api/src/agents/dbt/prompt.ts
+++ b/api/src/agents/dbt/prompt.ts
@@ -51,10 +51,12 @@ runs execute against the project's warehouse environments (dev/prod).
 - To promote working-tree changes onto a new branch, always use the atomic \`dbt_commit_to_branch\`
   instead of separate branch + commit calls — the two-step flow is racy. Pass \`paths\` if only
   some pending files belong in the commit.
-- Switching branches OVERWRITES the working tree. \`dbt_switch_branch\` refuses when there are
-  uncommitted changes; commit them first, or pass \`discardLocalChanges\` only after the user
-  explicitly confirms abandoning them. If a user reports missing/lost files, recover them with
-  \`dbt_list_recoverable_files\` then \`dbt_restore_file\` before doing anything else.
+- Switching branches is always safe: uncommitted edits stay with the branch they were made on
+  (git-worktree semantics), so \`dbt_switch_branch\` never mixes or loses work — the user finds
+  each branch's pending changes intact when they switch back. Pass \`discardLocalChanges\` only
+  when the user explicitly confirms abandoning the branch's pending changes. If a user reports
+  missing/lost files, recover them with \`dbt_list_recoverable_files\` then \`dbt_restore_file\`
+  before doing anything else.
 
 - Load the \`dbt\` system skill for materializations, incremental strategies, snapshots, and
   adapter quirks before writing non-trivial models.

--- a/api/src/agents/dbt/prompt.ts
+++ b/api/src/agents/dbt/prompt.ts
@@ -34,8 +34,10 @@ runs execute against the project's warehouse environments (dev/prod).
    \`dbt_commit_and_push\`, which can race a concurrent commit and strand the changes on the wrong
    branch. Then \`dbt_open_pull_request\`; when the user asks to promote/merge, call
    \`dbt_merge_pull_request\` with the PR number to merge on GitHub, delete the feature branch,
-   and sync the default branch into the working tree; it refuses before merging when there are
-   uncommitted working-tree changes. Use \`dbt_list_pull_requests\` to look up PR numbers and
+   and sync the default branch into the working tree. A merge only ships COMMITTED work —
+   check \`dbt_git_status\` first and commit pending changes that belong in the PR (uncommitted
+   drafts on the merged branch are not lost; they move to the default branch with the user).
+   Use \`dbt_list_pull_requests\` to look up PR numbers and
    status, \`dbt_update_pull_request\` to retitle/redescribe/retarget an open PR, and
    \`dbt_close_pull_request\` to abandon a PR without merging (only after the user confirms).
    If a build runs against a stale checkout (fewer models/sources

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -187,7 +187,8 @@ want to validate output, not just that it compiles.
 
 Which git tree a run builds (repo-bound projects) — never mix these up:
 - Ad-hoc tools (\`dbt_parse\` / \`dbt_compile_model\` / \`dbt_show\` / \`dbt_run_model\`) build YOUR
-  working tree: your checkout branch plus your uncommitted drafts. This is the only way to
+  working tree: your checkout branch plus your uncommitted drafts on that branch (drafts are
+  per-branch — each branch keeps its own work-in-progress). This is the only way to
   verify uncommitted or feature-branch work; \`dbt_run_model\` supports \`fullRefresh: true\` for
   incremental rebuilds, so never fall back to a job for that.
 - Jobs (\`dbt_run_job\`, schedules) build the COMMITTED tracked branch only — they never see your
@@ -209,8 +210,10 @@ changes on a NEW branch for review, use \`dbt_commit_to_branch\` (atomic branch+
 \`dbt_create_branch\` + \`dbt_commit_and_push\` — the two-step version can race a concurrent commit and
 strand the changes on the wrong branch. Then \`dbt_open_pull_request\`; when the user asks to
 promote/merge, call \`dbt_merge_pull_request\` with the PR number to merge on GitHub, delete the
-feature branch, and sync the default branch into the working tree; it refuses before merging when
-there are uncommitted working-tree changes. Use \`dbt_list_pull_requests\` to look up PR numbers
+feature branch, and sync the default branch into the working tree. A merge only ships COMMITTED
+work — check \`dbt_git_status\` first and commit pending changes that belong in the PR (uncommitted
+drafts on the merged branch are not lost; they move to the default branch with the user).
+Use \`dbt_list_pull_requests\` to look up PR numbers
 and status, \`dbt_update_pull_request\` to retitle/redescribe/retarget an open PR, and
 \`dbt_close_pull_request\` to abandon a PR without merging (only after the user confirms). If a run
 builds from a stale checkout (fewer models/sources than the branch actually has, e.g. a merged PR

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -216,9 +216,10 @@ and status, \`dbt_update_pull_request\` to retitle/redescribe/retarget an open P
 builds from a stale checkout (fewer models/sources than the branch actually has, e.g. a merged PR
 not picked up), call
 \`dbt_sync_from_repo\` to re-pull the tracked branch. Use \`dbt_delete_branch\` to clean up merged or
-stray branches. Switching branches OVERWRITES the working tree: \`dbt_switch_branch\` refuses when
-there are uncommitted changes — commit them first, or pass \`discardLocalChanges\` only after the
-user confirms abandoning them. If a user reports lost/missing files, use
+stray branches. Switching branches is always safe: uncommitted edits stay with the branch they
+were made on (git-worktree semantics), so \`dbt_switch_branch\` never mixes or loses work — pass
+\`discardLocalChanges\` only after the user confirms abandoning that branch's pending changes.
+If a user reports lost/missing files, use
 \`dbt_list_recoverable_files\` + \`dbt_restore_file\` to recover soft-deleted work. Never commit, push,
 switch branches, sync, or open a PR proactively.
 

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -4428,11 +4428,13 @@ DbtFileSchema.index({ workspaceId: 1, projectId: 1, is_deleted: 1 });
 export const DbtFile = mongoose.model<IDbtFile>("DbtFile", DbtFileSchema);
 
 /**
- * Per-user uncommitted edit to a dbt file (the draft overlay). Reads for a
- * user merge draft-over-base: other workspace members never see a draft, so
- * collaborators only observe committed changes — like separate git working
- * trees. Drafts follow the user across branch switches (a dirty git tree
- * carried through `git checkout`) and are cleared when committed.
+ * Per-user, per-branch uncommitted edit to a dbt file (the draft overlay).
+ * Reads for a user merge draft-over-base: other workspace members never see a
+ * draft, so collaborators only observe committed changes — like separate git
+ * working trees. Drafts are keyed to the branch they were made on, so
+ * switching branches leaves each branch's uncommitted work exactly where it
+ * was (git-worktree semantics: no carrying dirty state onto another branch's
+ * base). Drafts are cleared when committed.
  */
 export interface IDbtFileDraft extends Document {
   _id: Types.ObjectId;
@@ -4440,6 +4442,8 @@ export interface IDbtFileDraft extends Document {
   projectId: Types.ObjectId;
   /** Owning user id (or "agent" for agent edits outside a user session). */
   userId: string;
+  /** Branch the draft was made on (drafts only exist for repo projects). */
+  branch: string;
   path: string;
   content: string;
   /** Pending deletion of the base file (a staged `git rm`). */
@@ -4463,6 +4467,7 @@ const DbtFileDraftSchema = new Schema<IDbtFileDraft>(
       required: true,
     },
     userId: { type: String, required: true },
+    branch: { type: String, required: true },
     path: { type: String, required: true, trim: true },
     content: { type: String, default: "" },
     is_deleted: { type: Boolean, default: false },
@@ -4471,11 +4476,15 @@ const DbtFileDraftSchema = new Schema<IDbtFileDraft>(
   { collection: "dbt_file_drafts", timestamps: true },
 );
 
+// One draft per (project, user, branch, path): each branch keeps its own
+// uncommitted overlay per user.
 DbtFileDraftSchema.index(
-  { projectId: 1, userId: 1, path: 1 },
+  { projectId: 1, userId: 1, branch: 1, path: 1 },
   { unique: true },
 );
 DbtFileDraftSchema.index({ workspaceId: 1, projectId: 1, userId: 1 });
+// Branch-wide draft ops (relocate on PR merge, drop on branch delete).
+DbtFileDraftSchema.index({ projectId: 1, branch: 1 });
 
 export const DbtFileDraft = mongoose.model<IDbtFileDraft>(
   "DbtFileDraft",

--- a/api/src/dbt/dbt-github-git.integration.test.ts
+++ b/api/src/dbt/dbt-github-git.integration.test.ts
@@ -6,12 +6,15 @@
  * their actual code paths. Verifies the collaboration model end-to-end:
  *
  *  - drafts are per user (uncommitted edits invisible to other users)
+ *  - drafts are per branch (each branch keeps its own uncommitted overlay;
+ *    switching never mixes dirty state across bases — git-worktree semantics)
  *  - syncs never touch drafts
  *  - commits push drafts, advance the branch base tree, and clear drafts
  *  - protected branches refuse direct commits; commit-to-branch is the
- *    escape hatch
+ *    escape hatch (and takes the dirty tree with it)
  *  - checkouts (branch pointers) are per user
  *  - PR merge updates the default branch and relocates stranded checkouts
+ *    together with their uncommitted drafts
  */
 import {
   afterAll,
@@ -472,7 +475,7 @@ describe("branch protection", () => {
 });
 
 describe("per-user checkouts", () => {
-  it("switching branches moves only the caller's checkout and carries drafts", async () => {
+  it("switching branches moves only the caller's checkout; drafts stay with their branch", async () => {
     const project = await seedProject();
     remote.setBranch("feature/x", {
       "dbt_project.yml": "name: analytics",
@@ -487,23 +490,73 @@ describe("per-user checkouts", () => {
       "alice",
     );
     expect(result.branch).toBe("feature/x");
-    expect(result.carriedChanges).toBe(1);
+    // Nothing pending on feature/x: the main draft stayed on main.
+    expect(result.pendingChanges).toBe(0);
 
-    // Alice sees feature/x base + her carried draft.
+    // Alice sees the feature/x base, WITHOUT her main work-in-progress.
     expect(
       (await readWorkingFile(project, "alice", "models/a.sql"))?.content,
     ).toBe("select 100");
     expect(
-      (await readWorkingFile(project, "alice", "models/wip.sql"))?.content,
-    ).toBe("select 42");
+      await readWorkingFile(project, "alice", "models/wip.sql"),
+    ).toBeNull();
+    expect((await getGitStatus(project, "alice")).hasChanges).toBe(false);
     // Bob is untouched on main.
     expect(await getCheckoutBranch(project, "bob")).toBe("main");
     expect(
       (await readWorkingFile(project, "bob", "models/a.sql"))?.content,
     ).toBe("select 1");
+
+    // Switching back restores the main draft exactly where it was.
+    const back = await switchProjectBranch(project, "alice", "main", "alice");
+    expect(back.pendingChanges).toBe(1);
+    expect(
+      (await readWorkingFile(project, "alice", "models/wip.sql"))?.content,
+    ).toBe("select 42");
   });
 
-  it("discardLocalChanges drops the caller's drafts on switch", async () => {
+  it("a user iterates on two branches with independent uncommitted state", async () => {
+    const project = await seedProject();
+    remote.setBranch("feature/x", {
+      "dbt_project.yml": "name: analytics",
+      "models/a.sql": "select 1",
+    });
+
+    // Dirty main, switch, dirty feature/x differently — same path.
+    await writeWorkingFile(project, "alice", "models/a.sql", "select 2 -- main");
+    await switchProjectBranch(project, "alice", "feature/x", "alice");
+    await writeWorkingFile(project, "alice", "models/a.sql", "select 3 -- feat");
+
+    // Each branch shows only its own draft.
+    expect(
+      (await readWorkingFile(project, "alice", "models/a.sql"))?.content,
+    ).toBe("select 3 -- feat");
+    await switchProjectBranch(project, "alice", "main", "alice");
+    expect(
+      (await readWorkingFile(project, "alice", "models/a.sql"))?.content,
+    ).toBe("select 2 -- main");
+
+    // Committing on main pushes ONLY main's draft; feature/x keeps its own.
+    const result = await commitAndPush(project, {
+      userId: "alice",
+      message: "fix: main only",
+      updatedBy: "alice",
+    });
+    expect(result.pushed).toEqual({ added: 0, modified: 1, deleted: 0 });
+    expect(remote.branch("main").files.get("models/a.sql")).toBe(
+      "select 2 -- main",
+    );
+    expect(remote.branch("feature/x").files.get("models/a.sql")).toBe(
+      "select 1",
+    );
+    await switchProjectBranch(project, "alice", "feature/x", "alice");
+    expect(
+      (await readWorkingFile(project, "alice", "models/a.sql"))?.content,
+    ).toBe("select 3 -- feat");
+    expect((await getGitStatus(project, "alice")).modified).toBe(1);
+  });
+
+  it("discardLocalChanges drops the caller's drafts on the branch they leave", async () => {
     const project = await seedProject();
     remote.setBranch("feature/x", { "dbt_project.yml": "name: analytics" });
     await writeWorkingFile(project, "alice", "models/wip.sql", "select 42");
@@ -521,6 +574,12 @@ describe("per-user checkouts", () => {
     expect(
       await readWorkingFile(project, "alice", "models/wip.sql"),
     ).toBeNull();
+    // Gone for good: switching back to main finds a clean tree.
+    await switchProjectBranch(project, "alice", "main", "alice");
+    expect(
+      await readWorkingFile(project, "alice", "models/wip.sql"),
+    ).toBeNull();
+    expect((await getGitStatus(project, "alice")).hasChanges).toBe(false);
   });
 
   it("create branch clones the base tree locally and checks it out for the caller", async () => {
@@ -538,6 +597,22 @@ describe("per-user checkouts", () => {
     // Working tree contents come from the cloned branch.
     const files = await loadWorkingTreeContents(project, { userId: "alice" });
     expect(files.map(f => f.path)).toEqual(["dbt_project.yml", "models/a.sql"]);
+  });
+
+  it("deleting a branch drops the drafts stashed on it", async () => {
+    const project = await seedProject();
+    remote.setBranch("feature/x", { "dbt_project.yml": "name: analytics" });
+    await switchProjectBranch(project, "alice", "feature/x", "alice");
+    await writeWorkingFile(project, "alice", "models/wip.sql", "select 42");
+    await switchProjectBranch(project, "alice", "main", "alice");
+
+    await deleteProjectBranch(project, "alice", "feature/x");
+    expect(
+      await DbtFileDraft.countDocuments({
+        projectId: project._id,
+        branch: "feature/x",
+      }),
+    ).toBe(0);
   });
 
   it("refuses to delete a branch that any user has checked out", async () => {
@@ -600,6 +675,44 @@ describe("pull request merge", () => {
     ).toBe(0);
     expect(
       await DbtCheckout.countDocuments({
+        projectId: project._id,
+        branch: "feat/a",
+      }),
+    ).toBe(0);
+  });
+
+  it("relocates uncommitted drafts on the deleted head branch to the default branch", async () => {
+    const project = await seedProject();
+    await writeWorkingFile(project, "alice", "models/a.sql", "select 2");
+    await commitToNewBranch(project, {
+      userId: "alice",
+      branchName: "feat/a",
+      message: "feat: change a",
+      updatedBy: "alice",
+    });
+    // More work on feat/a that is NOT committed before the PR merges.
+    await writeWorkingFile(project, "alice", "models/followup.sql", "select 9");
+    remote.state.pulls.set(8, {
+      headRef: "feat/a",
+      baseRef: "main",
+      state: "open",
+    });
+
+    const result = await mergeProjectPullRequest(project, {
+      userId: "alice",
+      prNumber: 8,
+      updatedBy: "alice",
+    });
+    expect(result.branchDeleted).toBe(true);
+    // Alice is back on main and her uncommitted follow-up moved with her
+    // instead of orphaning on the deleted branch.
+    expect(result.workingTreeClean).toBe(false);
+    expect(await getCheckoutBranch(project, "alice")).toBe("main");
+    expect(
+      (await readWorkingFile(project, "alice", "models/followup.sql"))?.content,
+    ).toBe("select 9");
+    expect(
+      await DbtFileDraft.countDocuments({
         projectId: project._id,
         branch: "feat/a",
       }),

--- a/api/src/dbt/dbt-github-git.integration.test.ts
+++ b/api/src/dbt/dbt-github-git.integration.test.ts
@@ -582,6 +582,24 @@ describe("per-user checkouts", () => {
     expect((await getGitStatus(project, "alice")).hasChanges).toBe(false);
   });
 
+  it("create branch takes the caller's dirty tree with it (git checkout -b)", async () => {
+    const project = await seedProject();
+    await writeWorkingFile(project, "alice", "models/a.sql", "select 2");
+
+    await createProjectBranch(project, "alice", "feat/b");
+    // The pending change followed alice onto the new branch...
+    expect((await getGitStatus(project, "alice")).modified).toBe(1);
+    expect(
+      (await readWorkingFile(project, "alice", "models/a.sql"))?.content,
+    ).toBe("select 2");
+    // ...and main is clean when she switches back.
+    await switchProjectBranch(project, "alice", "main", "alice");
+    expect((await getGitStatus(project, "alice")).hasChanges).toBe(false);
+    expect(
+      (await readWorkingFile(project, "alice", "models/a.sql"))?.content,
+    ).toBe("select 1");
+  });
+
   it("create branch clones the base tree locally and checks it out for the caller", async () => {
     const project = await seedProject();
     const result = await createProjectBranch(project, "alice", "feat/clone");

--- a/api/src/dbt/dbt-github-git.service.ts
+++ b/api/src/dbt/dbt-github-git.service.ts
@@ -608,7 +608,10 @@ export async function listProjectBranches(
 /**
  * Create a new branch off the caller's checkout HEAD and check it out for
  * them (only their checkout moves — other users are unaffected). Content is
- * identical to the source branch, so the base tree is cloned locally.
+ * identical to the source branch, so the base tree is cloned locally. The
+ * caller's uncommitted drafts move to the new branch (`git checkout -b`
+ * takes the dirty tree with it — the "started on main, need a branch" flow);
+ * the bases are identical so the diff is unchanged.
  */
 export async function createProjectBranch(
   project: IDbtProject,
@@ -623,6 +626,7 @@ export async function createProjectBranch(
     const { commitSha } = await getRefCommit(owner, repo, fromBranch, token);
     await createBranch(owner, repo, branchName, commitSha, token);
     await cloneBranchBaseTree(fresh, fromBranch, branchName);
+    await moveUserDrafts(fresh, userId, fromBranch, branchName);
     await setCheckoutBranch(fresh, userId, branchName, {
       lastSyncedSha: commitSha,
     });

--- a/api/src/dbt/dbt-github-git.service.ts
+++ b/api/src/dbt/dbt-github-git.service.ts
@@ -3,12 +3,14 @@
  * status, commit & push, branch create/switch, and pull requests — the in-IDE
  * git surface that mirrors dbt Cloud.
  *
- * The working tree is per user: DbtFile rows are the COMMITTED base tree of a
- * branch, DbtFileDraft rows are the caller's uncommitted overlay, and
- * DbtCheckout points each user at their own branch. Status/commit therefore
- * only ever see the acting user's drafts. Pushing builds a single commit via
- * the Git Data API, updates the branch's base tree, and clears the committed
- * drafts.
+ * The working tree is per user AND per branch: DbtFile rows are the COMMITTED
+ * base tree of a branch, DbtFileDraft rows are the caller's uncommitted
+ * overlay keyed to the branch they were made on, and DbtCheckout points each
+ * user at their own branch. Status/commit therefore only ever see the acting
+ * user's drafts for their checked-out branch — switching branches leaves each
+ * branch's dirty state in place (git-worktree semantics). Pushing builds a
+ * single commit via the Git Data API, updates the branch's base tree, and
+ * clears the committed drafts.
  *
  * Branch protection: branches listed in `project.protectedBranches` refuse
  * direct commits — changes reach them only through a PR (commit-to-branch →
@@ -46,8 +48,11 @@ import {
   baseTreeFilter,
   cloneBranchBaseTree,
   deleteBranchBaseTree,
+  deleteBranchDrafts,
   discardUserDrafts,
   getCheckoutBranch,
+  moveBranchDrafts,
+  moveUserDrafts,
   setCheckoutBranch,
 } from "./dbt-working-tree.service";
 
@@ -257,7 +262,7 @@ async function loadStatusInputs(
   }
   const branch = (await getCheckoutBranch(project, userId)) as string;
   const [drafts, baseRows] = await Promise.all([
-    DbtFileDraft.find({ projectId: project._id, userId })
+    DbtFileDraft.find({ projectId: project._id, userId, branch })
       .select("path content is_deleted")
       .lean(),
     DbtFile.find({
@@ -317,7 +322,7 @@ export async function getProjectFileDiff(
   }
   const branch = await getCheckoutBranch(project, userId);
   const [draft, baseRow] = await Promise.all([
-    DbtFileDraft.findOne({ projectId: project._id, userId, path })
+    DbtFileDraft.findOne({ projectId: project._id, userId, branch, path })
       .select("content is_deleted")
       .lean(),
     DbtFile.findOne({
@@ -400,7 +405,11 @@ async function pushWorkingTree(
   const token = await resolveRepoToken(project.repo.installationId);
   const { owner, repo } = project.repo;
 
-  const drafts = await DbtFileDraft.find({ projectId: project._id, userId })
+  const drafts = await DbtFileDraft.find({
+    projectId: project._id,
+    userId,
+    branch,
+  })
     .select("path content is_deleted")
     .lean();
   const draftByPath = new Map(drafts.map(d => [d.path, d]));
@@ -443,6 +452,7 @@ async function pushWorkingTree(
       DbtFileDraft.deleteOne({
         projectId: project._id,
         userId,
+        branch,
         path: change.path,
       }).exec(),
     );
@@ -565,11 +575,13 @@ export async function commitToNewBranch(
     const { owner, repo } = fresh.repo;
 
     // Fork the new branch from the branch the user currently tracks, clone
-    // its committed base tree, and point the user's checkout at it BEFORE
-    // committing so pushWorkingTree targets the new branch.
+    // its committed base tree, move the user's drafts onto the new branch
+    // (the promote takes their dirty tree with it), and point their checkout
+    // at it BEFORE committing so pushWorkingTree targets the new branch.
     const { commitSha } = await getRefCommit(owner, repo, fromBranch, token);
     await createBranch(owner, repo, params.branchName, commitSha, token);
     await cloneBranchBaseTree(fresh, fromBranch, params.branchName);
+    await moveUserDrafts(fresh, params.userId, fromBranch, params.branchName);
     await setCheckoutBranch(fresh, params.userId, params.branchName);
 
     const result = await pushWorkingTree(
@@ -620,10 +632,14 @@ export async function createProjectBranch(
 
 /**
  * Switch the caller's checkout to another branch. Only their branch pointer
- * moves; their drafts carry over as an overlay (like `git checkout` with a
- * dirty tree), so nothing is lost. Pass `discardLocalChanges` to drop the
- * caller's drafts instead. The target branch's committed base tree is synced
- * from GitHub.
+ * moves; their drafts STAY WITH THE BRANCH they were made on (git-worktree
+ * semantics), so uncommitted work on the old branch is waiting untouched
+ * when they switch back, and never re-bases onto the target branch. Pass
+ * `discardLocalChanges` to drop the caller's drafts on the branch they are
+ * leaving. The target branch's committed base tree is synced from GitHub.
+ *
+ * `pendingChanges` reports the caller's uncommitted changes already stashed
+ * on the TARGET branch (from a previous session there).
  */
 export async function switchProjectBranch(
   project: IDbtProject,
@@ -631,15 +647,16 @@ export async function switchProjectBranch(
   branchName: string,
   updatedBy: string,
   options: { discardLocalChanges?: boolean } = {},
-): Promise<{ branch: string; discarded?: GitStatus; carriedChanges: number }> {
+): Promise<{ branch: string; discarded?: GitStatus; pendingChanges: number }> {
   return withProjectGitLock(project._id.toString(), async () => {
     const fresh = await reloadRepoProject(project);
 
     let discarded: GitStatus | undefined;
     if (options.discardLocalChanges) {
+      const fromBranch = (await getCheckoutBranch(fresh, userId)) as string;
       const status = await getGitStatus(fresh, userId);
       if (status.hasChanges) discarded = status;
-      await discardUserDrafts(fresh, userId);
+      await discardUserDrafts(fresh, userId, fromBranch);
     }
 
     // Materialize/refresh the target branch's committed base tree.
@@ -648,19 +665,18 @@ export async function switchProjectBranch(
       lastSyncedSha: sync.sha,
     });
 
-    const carried = discarded
-      ? 0
-      : (await getGitStatus(fresh, userId)).changes.length;
+    const pendingChanges = (await getGitStatus(fresh, userId)).changes.length;
     return discarded?.hasChanges
-      ? { branch: branchName, discarded, carriedChanges: carried }
-      : { branch: branchName, carriedChanges: carried };
+      ? { branch: branchName, discarded, pendingChanges }
+      : { branch: branchName, pendingChanges };
   });
 }
 
 /**
  * Delete a remote branch. Refuses to delete the caller's checked-out branch,
  * any branch another user has checked out, the project default branch, and
- * the repo default branch. Cleans up the branch's local base tree.
+ * the repo default branch. Cleans up the branch's local base tree and any
+ * drafts stashed on it (deleting a branch abandons its uncommitted work).
  */
 export async function deleteProjectBranch(
   project: IDbtProject,
@@ -703,6 +719,7 @@ export async function deleteProjectBranch(
     }
     await deleteBranch(owner, repo, branchName, token);
     await deleteBranchBaseTree(fresh, branchName);
+    await deleteBranchDrafts(fresh, branchName);
     return { deleted: branchName };
   });
 }
@@ -761,8 +778,9 @@ export async function restoreDeletedFile(
     if (!file) {
       throw new Error(`No recoverable file at "${path}".`);
     }
+    const branch = (await getCheckoutBranch(project, userId)) as string;
     await DbtFileDraft.updateOne(
-      { projectId: project._id, userId, path },
+      { projectId: project._id, userId, branch, path },
       {
         $set: {
           content: file.content ?? "",
@@ -923,6 +941,7 @@ export async function closeProjectPullRequest(
         branchDeleteWarning = deleteResult.warning;
         if (branchDeleted) {
           await deleteBranchBaseTree(fresh, headRef);
+          await deleteBranchDrafts(fresh, headRef);
         }
       }
     }
@@ -942,9 +961,10 @@ export interface MergePullRequestResult {
 /**
  * Merge a GitHub pull request, optionally delete its head branch, then switch
  * the caller's checkout back to the repo default branch and sync the merged
- * state into that branch's base tree. The caller's drafts (if any) carry over
- * as an overlay. Users checked out on the deleted head branch are moved back
- * to the default branch.
+ * state into that branch's base tree. Users checked out on the deleted head
+ * branch are moved back to the default branch, and uncommitted drafts on the
+ * deleted branch move with them (they would otherwise be orphaned on a
+ * branch that no longer exists).
  */
 export async function mergeProjectPullRequest(
   project: IDbtProject,
@@ -1014,6 +1034,7 @@ export async function mergeProjectPullRequest(
         branchDeleteWarning = deleteResult.warning;
         if (branchDeleted) {
           await deleteBranchBaseTree(fresh, pr.headRef);
+          await moveBranchDrafts(fresh, pr.headRef, defaultBranch);
           await DbtCheckout.updateMany(
             { projectId: fresh._id, branch: pr.headRef },
             {

--- a/api/src/dbt/dbt-working-tree.service.ts
+++ b/api/src/dbt/dbt-working-tree.service.ts
@@ -1,12 +1,15 @@
 /**
- * Per-user dbt working trees.
+ * Per-user, per-branch dbt working trees.
  *
  * Repo-bound projects keep one COMMITTED base tree per checked-out branch in
- * DbtFile (content mirrors the branch head) and a per-user draft overlay in
- * DbtFileDraft. A user's working tree is draft-over-base for the branch their
- * DbtCheckout points at, so uncommitted work is only ever visible to its
- * author — collaborators see changes when they are committed, like separate
- * git clones.
+ * DbtFile (content mirrors the branch head) and a per-user, per-branch draft
+ * overlay in DbtFileDraft. A user's working tree is draft-over-base for the
+ * branch their DbtCheckout points at, so uncommitted work is only ever
+ * visible to its author — collaborators see changes when they are committed,
+ * like separate git clones. Drafts are keyed to the branch they were made
+ * on, so switching branches leaves each branch's uncommitted work exactly
+ * where it was (git-worktree semantics) — a user can iterate on several
+ * branches without their dirty state mixing across bases.
  *
  * Blank (non-repo) projects keep the original shared model: DbtFile rows with
  * no `branch` are the single working tree every member edits directly.
@@ -168,8 +171,10 @@ async function loadBaseRows(
 async function loadDrafts(
   project: IDbtProject,
   userId: string,
+  branch: string | undefined,
 ): Promise<DraftLean[]> {
-  return DbtFileDraft.find({ projectId: project._id, userId })
+  if (!branch) return [];
+  return DbtFileDraft.find({ projectId: project._id, userId, branch })
     .select("path content is_deleted updatedAt")
     .lean();
 }
@@ -189,7 +194,7 @@ export async function listWorkingFiles(
   const branch = await getCheckoutBranch(project, userId);
   const [baseRows, drafts] = await Promise.all([
     loadBaseRows(project, branch),
-    loadDrafts(project, userId),
+    loadDrafts(project, userId, branch),
   ]);
   const merged = new Map<string, WorkingFileMeta>();
   for (const row of baseRows) {
@@ -219,10 +224,14 @@ export async function readWorkingFile(
   userId: string,
   path: string,
 ): Promise<WorkingFile | null> {
-  if (project.repo) {
+  const branch = project.repo
+    ? await getCheckoutBranch(project, userId)
+    : undefined;
+  if (project.repo && branch) {
     const draft = await DbtFileDraft.findOne({
       projectId: project._id,
       userId,
+      branch,
       path,
     }).lean();
     if (draft) {
@@ -235,9 +244,6 @@ export async function readWorkingFile(
       };
     }
   }
-  const branch = project.repo
-    ? await getCheckoutBranch(project, userId)
-    : undefined;
   const base = await DbtFile.findOne({
     ...baseTreeFilter(project, branch),
     path,
@@ -285,7 +291,7 @@ export async function writeWorkingFile(
     return { versionEntityId: file._id };
   }
 
-  const branch = await getCheckoutBranch(project, userId);
+  const branch = (await getCheckoutBranch(project, userId)) as string;
   const base = await DbtFile.findOne({
     ...baseTreeFilter(project, branch),
     path,
@@ -299,13 +305,14 @@ export async function writeWorkingFile(
     const existing = await DbtFileDraft.findOneAndDelete({
       projectId: project._id,
       userId,
+      branch,
       path,
     });
     return { versionEntityId: existing?._id ?? new Types.ObjectId() };
   }
 
   const draft = await DbtFileDraft.findOneAndUpdate(
-    { projectId: project._id, userId, path },
+    { projectId: project._id, userId, branch, path },
     {
       $set: {
         content,
@@ -339,21 +346,21 @@ export async function deleteWorkingFile(
     return result.matchedCount > 0;
   }
 
-  const branch = await getCheckoutBranch(project, userId);
+  const branch = (await getCheckoutBranch(project, userId)) as string;
   const [base, draft] = await Promise.all([
     DbtFile.exists({
       ...baseTreeFilter(project, branch),
       path,
       is_deleted: { $ne: true },
     }),
-    DbtFileDraft.findOne({ projectId: project._id, userId, path })
+    DbtFileDraft.findOne({ projectId: project._id, userId, branch, path })
       .select("is_deleted")
       .lean(),
   ]);
 
   if (base) {
     await DbtFileDraft.updateOne(
-      { projectId: project._id, userId, path },
+      { projectId: project._id, userId, branch, path },
       {
         $set: {
           content: "",
@@ -371,6 +378,7 @@ export async function deleteWorkingFile(
     await DbtFileDraft.deleteOne({
       projectId: project._id,
       userId,
+      branch,
       path,
     }).exec();
     return true;
@@ -415,14 +423,93 @@ export async function renameWorkingFile(
   return null;
 }
 
-/** Discard all of a user's drafts for a project (`git checkout -- .`). */
+/**
+ * Discard a user's drafts on one branch (`git checkout -- .` on that
+ * branch). Drafts the user stashed on other branches are untouched.
+ */
 export async function discardUserDrafts(
   project: IDbtProject,
   userId: string,
+  branch: string,
 ): Promise<number> {
   const result = await DbtFileDraft.deleteMany({
     projectId: project._id,
     userId,
+    branch,
+  }).exec();
+  return result.deletedCount ?? 0;
+}
+
+/**
+ * Re-key a user's drafts from one branch to another (an atomic promote moves
+ * the dirty tree onto the just-created branch). Orphaned same-path drafts
+ * already keyed to the target (relics of a deleted branch with the same
+ * name) are dropped so the unique index can't reject the move.
+ */
+export async function moveUserDrafts(
+  project: IDbtProject,
+  userId: string,
+  fromBranch: string,
+  toBranch: string,
+): Promise<void> {
+  const moving = await DbtFileDraft.find({
+    projectId: project._id,
+    userId,
+    branch: fromBranch,
+  })
+    .select("path")
+    .lean();
+  if (moving.length === 0) return;
+  await DbtFileDraft.deleteMany({
+    projectId: project._id,
+    userId,
+    branch: toBranch,
+    path: { $in: moving.map(d => d.path) },
+  }).exec();
+  await DbtFileDraft.updateMany(
+    { projectId: project._id, userId, branch: fromBranch },
+    { $set: { branch: toBranch } },
+  ).exec();
+}
+
+/**
+ * Re-key EVERY user's drafts from one branch to another (a merged-and-deleted
+ * PR head: users stranded on the branch move to the default branch, and their
+ * uncommitted work must move with them instead of orphaning). On a same-path
+ * collision the moved draft wins — it is the user's latest work on the
+ * branch that just merged.
+ */
+export async function moveBranchDrafts(
+  project: IDbtProject,
+  fromBranch: string,
+  toBranch: string,
+): Promise<void> {
+  const moving = await DbtFileDraft.find({
+    projectId: project._id,
+    branch: fromBranch,
+  })
+    .select("userId path")
+    .lean();
+  if (moving.length === 0) return;
+  await DbtFileDraft.deleteMany({
+    projectId: project._id,
+    branch: toBranch,
+    $or: moving.map(d => ({ userId: d.userId, path: d.path })),
+  }).exec();
+  await DbtFileDraft.updateMany(
+    { projectId: project._id, branch: fromBranch },
+    { $set: { branch: toBranch } },
+  ).exec();
+}
+
+/** Drop every user's drafts on a branch (the branch itself was deleted). */
+export async function deleteBranchDrafts(
+  project: IDbtProject,
+  branch: string,
+): Promise<number> {
+  const result = await DbtFileDraft.deleteMany({
+    projectId: project._id,
+    branch,
   }).exec();
   return result.deletedCount ?? 0;
 }
@@ -454,7 +541,7 @@ export async function loadWorkingTreeContents(
     baseRows.map(row => [row.path, row.content ?? ""]),
   );
   if (opts.userId) {
-    const drafts = await loadDrafts(project, opts.userId);
+    const drafts = await loadDrafts(project, opts.userId, branch);
     for (const draft of drafts) {
       if (draft.is_deleted) files.delete(draft.path);
       else files.set(draft.path, draft.content ?? "");

--- a/api/src/migrations/2026-07-06-130000_branch_scoped_dbt_file_drafts.ts
+++ b/api/src/migrations/2026-07-06-130000_branch_scoped_dbt_file_drafts.ts
@@ -73,7 +73,15 @@ export async function up(db: Db): Promise<void> {
   }
 
   // --- 2: re-key the unique index ---
-  const indexes = await drafts.indexes();
+  // On a fresh database the collection may not exist yet (indexes() throws
+  // "ns does not exist"); createIndex below creates it implicitly.
+  const collectionExists =
+    (
+      await db
+        .listCollections({ name: "dbt_file_drafts" }, { nameOnly: true })
+        .toArray()
+    ).length > 0;
+  const indexes = collectionExists ? await drafts.indexes() : [];
   const oldUnique = indexes.find(
     idx =>
       JSON.stringify(idx.key) ===

--- a/api/src/migrations/2026-07-06-130000_branch_scoped_dbt_file_drafts.ts
+++ b/api/src/migrations/2026-07-06-130000_branch_scoped_dbt_file_drafts.ts
@@ -1,0 +1,99 @@
+import { Db } from "mongodb";
+
+export const description =
+  "Branch-scoped dbt drafts: stamp dbt_file_drafts with the owner's checked-out branch and re-key the unique index to (projectId, userId, branch, path)";
+
+/**
+ * Before: dbt_file_drafts was one uncommitted overlay per (project, user) that
+ * silently followed the user across branch switches — edits made "on main"
+ * re-based onto whatever branch was checked out next. After: every draft is
+ * keyed to the branch it was made on (git-worktree semantics), so a user can
+ * iterate on several branches with independent uncommitted state.
+ *
+ * This migration:
+ *  1. stamps existing draft rows with `branch` = the owner's dbt_checkouts
+ *     branch for the project (absent row = the project's tracked branch),
+ *     which is exactly the branch those drafts overlay today;
+ *  2. re-keys the unique index from (projectId, userId, path) to
+ *     (projectId, userId, branch, path) and adds a (projectId, branch)
+ *     index for branch-wide draft operations.
+ *
+ * Blank (non-repo) projects never create drafts, so any draft whose project
+ * lost its repo binding is left unstamped (unreachable either way, and the
+ * old unique index already guaranteed such rows cannot collide under the new
+ * key). Idempotent throughout.
+ */
+
+interface RawDraft {
+  _id: unknown;
+  projectId: unknown;
+  userId: string;
+  branch?: string;
+}
+
+function hasIndexOnKeys(
+  indexes: Array<{ key?: Record<string, unknown>; name?: string }>,
+  keyPattern: Record<string, number>,
+): boolean {
+  return indexes.some(
+    idx => JSON.stringify(idx.key) === JSON.stringify(keyPattern),
+  );
+}
+
+export async function up(db: Db): Promise<void> {
+  const projects = db.collection("dbt_projects");
+  const checkouts = db.collection("dbt_checkouts");
+  const drafts = db.collection<RawDraft>("dbt_file_drafts");
+
+  // --- 1: stamp unbranched drafts with their owner's checkout branch ---
+  const projectIds = await drafts.distinct("projectId", {
+    branch: { $exists: false },
+  });
+  for (const projectId of projectIds) {
+    const project = await projects.findOne({ _id: projectId as never });
+    const trackedBranch = (project?.repo as { branch?: string } | undefined)
+      ?.branch;
+    if (!trackedBranch) continue;
+
+    const userIds = await drafts.distinct("userId", {
+      projectId,
+      branch: { $exists: false },
+    });
+    for (const userId of userIds) {
+      const checkout = await checkouts.findOne({ projectId, userId });
+      const branch =
+        typeof checkout?.branch === "string" && checkout.branch
+          ? checkout.branch
+          : trackedBranch;
+      await drafts.updateMany(
+        { projectId, userId, branch: { $exists: false } },
+        { $set: { branch } },
+      );
+    }
+  }
+
+  // --- 2: re-key the unique index ---
+  const indexes = await drafts.indexes();
+  const oldUnique = indexes.find(
+    idx =>
+      JSON.stringify(idx.key) ===
+      JSON.stringify({ projectId: 1, userId: 1, path: 1 }),
+  );
+  if (oldUnique?.name) {
+    await drafts.dropIndex(oldUnique.name);
+  }
+  if (
+    !hasIndexOnKeys(indexes, { projectId: 1, userId: 1, branch: 1, path: 1 })
+  ) {
+    await drafts.createIndex(
+      { projectId: 1, userId: 1, branch: 1, path: 1 },
+      { unique: true, name: "dbt_file_drafts_project_user_branch_path" },
+    );
+  }
+  if (!hasIndexOnKeys(indexes, { projectId: 1, branch: 1 })) {
+    await drafts.createIndex(
+      { projectId: 1, branch: 1 },
+      { name: "dbt_file_drafts_project_branch" },
+    );
+  }
+}

--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -1044,10 +1044,10 @@ dbtRoutes.post("/projects/:projectId/sync", async (c: AuthenticatedContext) => {
       return badRequest(c, "Project is not connected to a repository");
     }
     const userId = getUserId(c);
-    if (c.req.query("discard") === "true") {
-      await discardUserDrafts(project, userId);
-    }
     const branch = (await getCheckoutBranch(project, userId)) as string;
+    if (c.req.query("discard") === "true") {
+      await discardUserDrafts(project, userId, branch);
+    }
     const result = await syncProjectBranchFromRepo(project, branch, userId);
     publishDbtEvent(c, {
       type: "dbt.git.updated",
@@ -1358,8 +1358,9 @@ dbtRoutes.delete(
 );
 
 // POST /projects/:projectId/git/switch-branch — move the CALLER's checkout to
-// another branch. Their drafts carry over as an overlay (nothing is lost);
-// discardLocalChanges drops the caller's drafts instead.
+// another branch. Their drafts stay with the branch they were made on
+// (git-worktree semantics — nothing mixes across branches, nothing is lost);
+// discardLocalChanges drops the caller's drafts on the branch they leave.
 dbtRoutes.post(
   "/projects/:projectId/git/switch-branch",
   async (c: AuthenticatedContext) => {

--- a/app/src/components/DbtExplorer.tsx
+++ b/app/src/components/DbtExplorer.tsx
@@ -23,7 +23,9 @@ import {
   TextField,
   Button,
   Select,
+  Checkbox,
   FormControl,
+  FormControlLabel,
   InputLabel,
   Menu,
   Chip,
@@ -386,6 +388,7 @@ export function DbtExplorer() {
   const [switchTarget, setSwitchTarget] = useState<string | null>(null);
   const [switchBranches, setSwitchBranches] = useState<string[]>([]);
   const [switchValue, setSwitchValue] = useState("");
+  const [switchDiscard, setSwitchDiscard] = useState(false);
   const [prTarget, setPrTarget] = useState<string | null>(null);
   const [prTitle, setPrTitle] = useState("");
   const [prBody, setPrBody] = useState("");
@@ -796,6 +799,7 @@ export function DbtExplorer() {
       if (!workspaceId) return;
       setSwitchTarget(projectId);
       setSwitchBranches([]);
+      setSwitchDiscard(false);
       const result = await listBranches(workspaceId, projectId);
       if (result) {
         setSwitchBranches(result.branches);
@@ -808,7 +812,9 @@ export function DbtExplorer() {
   const handleSwitchBranch = useCallback(async () => {
     if (!workspaceId || !switchTarget || !switchValue) return;
     setGitBusy(true);
-    const updated = await switchBranch(workspaceId, switchTarget, switchValue);
+    const updated = await switchBranch(workspaceId, switchTarget, switchValue, {
+      discardLocalChanges: switchDiscard,
+    });
     setGitBusy(false);
     if (updated) {
       await fetchFiles(workspaceId, switchTarget);
@@ -819,6 +825,7 @@ export function DbtExplorer() {
     workspaceId,
     switchTarget,
     switchValue,
+    switchDiscard,
     switchBranch,
     fetchFiles,
     fetchGitStatus,
@@ -2475,8 +2482,31 @@ export function DbtExplorer() {
             sx={{ mt: 1 }}
           >
             Switching pulls the selected branch for you only — teammates keep
-            their own checkout, and your uncommitted changes carry over.
+            their own checkout. Your uncommitted changes stay with the branch
+            they were made on, waiting for you when you switch back.
           </Typography>
+          {switchTarget && gitStatusByProject[switchTarget]?.hasChanges && (
+            <FormControlLabel
+              sx={{ mt: 0.5 }}
+              control={
+                <Checkbox
+                  size="small"
+                  checked={switchDiscard}
+                  onChange={e => setSwitchDiscard(e.target.checked)}
+                />
+              }
+              label={
+                <Typography variant="caption">
+                  Discard my uncommitted changes on{" "}
+                  <strong>
+                    {checkoutBranchByProject[switchTarget] ??
+                      gitStatusByProject[switchTarget]?.branch}
+                  </strong>{" "}
+                  instead of keeping them there
+                </Typography>
+              }
+            />
+          )}
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setSwitchTarget(null)}>Cancel</Button>

--- a/app/src/store/dbtStore.ts
+++ b/app/src/store/dbtStore.ts
@@ -474,6 +474,7 @@ interface DbtActions {
     workspaceId: string,
     projectId: string,
     branch: string,
+    opts?: { discardLocalChanges?: boolean },
   ) => Promise<DbtProjectItem | null>;
   openPullRequest: (
     workspaceId: string,
@@ -1151,7 +1152,7 @@ export const useDbtStore = create<DbtStore>()(
       }
     },
 
-    switchBranch: async (workspaceId, projectId, branch) => {
+    switchBranch: async (workspaceId, projectId, branch, opts) => {
       try {
         const response = await apiClient.post<{
           success: boolean;
@@ -1159,7 +1160,10 @@ export const useDbtStore = create<DbtStore>()(
           project: DbtProjectItem;
         }>(
           `/workspaces/${workspaceId}/dbt/projects/${projectId}/git/switch-branch`,
-          { branch },
+          {
+            branch,
+            ...(opts?.discardLocalChanges ? { discardLocalChanges: true } : {}),
+          },
         );
         set(state => {
           state.checkoutBranchByProject[projectId] = response.branch;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Branch-scoped dbt drafts (git-worktree semantics)

## Problem

`dbt_file_drafts` was keyed per `(project, user)` only, so a user's uncommitted edits silently followed them across branch switches — work started "on main" re-based onto whatever branch was checked out next. Iterating on two branches meant mixing/overwriting dirty state.

## Change

Drafts are now keyed to the branch they were made on (unique index `(projectId, userId, branch, path)`). Switching branches leaves each branch's uncommitted work exactly where it was, like separate git worktrees:

- **Working tree service** — all draft reads/writes/discards scoped to the caller's checkout branch; new `moveUserDrafts` / `moveBranchDrafts` / `deleteBranchDrafts` helpers.
- **Git service** — status/diff/commit scoped per branch; `createProjectBranch` and `commitToNewBranch` move the dirty tree onto the new branch (`git checkout -b` semantics); PR merge relocates uncommitted drafts off the deleted head branch alongside stranded checkouts; explicit branch deletion drops that branch's stashed drafts; `switchProjectBranch` now reports `pendingChanges` stashed on the target branch (replaces `carriedChanges`).
- **Migration** — stamps existing drafts with their owner's `dbt_checkouts` branch (fallback: project tracked branch) and re-keys the unique index. Idempotent, handles fresh DBs.
- **UI** — switch-branch dialog explains per-branch drafts and exposes an optional "discard my uncommitted changes on \<branch\>" checkbox (previously API-only).
- **AI agent surfaces** — the new semantics are made explicit everywhere the agent learns about dbt git:
  - `dbt` system skill: dedicated "drafts are per user AND per branch" section covering the four consequences (per-branch `dbt_git_status` scope, `checkout -b` moving the dirty tree, branch deletion dropping stashes vs PR merge relocating them, `discardLocalChanges` scope).
  - Tool descriptions rewritten: `dbt_switch_branch` (always safe, per-branch stashes, returns `pendingChangesOnBranch`), `dbt_git_status`, `dbt_create_branch`, `dbt_delete_branch` (destructive-for-stashes warning), `dbt_merge_pull_request` (removed a false "refuses on uncommitted changes" claim; documents draft relocation + `workingTreeClean`), `dbt_sync_from_repo`.
  - Both agent prompts (`agents/dbt/prompt.ts`, `agents/modes/prompts.ts`) corrected — they previously claimed switching refuses/overwrites on a dirty tree.

## Demo

[dbt_two_branch_independent_drafts_demo.mp4](https://cursor.com/agents/bc-ee6be134-f903-4515-9eda-f365c2b0b80d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdbt_two_branch_independent_drafts_demo.mp4)

Same file (`stg_artists.sql`) edited differently on `feature/ordering` and `main`; each branch keeps its own pending change and editor content across repeated switches, with zero leakage.

[Switch dialog with keep/discard choice](https://cursor.com/agents/bc-ee6be134-f903-4515-9eda-f365c2b0b80d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_switch_dialog_keep_or_discard.webp)
[Feature branch draft restored after switching back](https://cursor.com/agents/bc-ee6be134-f903-4515-9eda-f365c2b0b80d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_feature_branch_draft_restored.webp)

## Testing

- `pnpm --filter api run test:dbt` — 221 passed (new integration tests: two-branch independent iteration, switch round-trip, per-branch discard, `checkout -b` dirty-tree move, PR-merge draft relocation, branch-delete draft cleanup)
- `pnpm --filter api run lint`, `pnpm --filter app run typecheck && lint`, `pnpm --filter app run test:unit` — all green
- Migration run against local Mongo (index re-key verified) + manual E2E in the browser against the fake GitHub server (video above)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee6be134-f903-4515-9eda-f365c2b0b80d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee6be134-f903-4515-9eda-f365c2b0b80d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

