### PR TITLE
fix(apps): dbt preview env override now applies to parquet bindings' DuckDB reads

### DIFF
--- a/api/src/agent-skills/apps/SKILL.md
+++ b/api/src/agent-skills/apps/SKILL.md
@@ -142,9 +142,13 @@ errors); `open_app` just focuses a UI tab.
    (e.g. to a personal `dbt_<user>` schema) to verify an app against
    freshly-built dev models WITHOUT affecting other editors or viewers —
    pass `environment: null` to reset to prod. While an override is active,
-   dbt-linked parquet bindings run live (row-capped) in the preview so the
-   prod artifact is never rebuilt from dev data. See the `dbt` skill for the
-   full model-iteration → preview → promote loop.
+   dbt-linked parquet bindings serve a live (row-capped) run against the
+   override schema instead of their prod artifact — `useQuery`, `useDuckDB`,
+   and `query_duckdb` all read the override data, and the prod artifact is
+   never rebuilt from dev data. Do NOT call `materialize_binding` to preview
+   dev data: materialization ALWAYS builds from the prod schema regardless of
+   the override (re-running it just refreshes the prod artifact). See the
+   `dbt` skill for the full model-iteration → preview → promote loop.
 
    **Result row cap:** rows delivered to the app are capped per query/binding read
    (default 500,000 — the bridge into the sandboxed iframe). Both hooks return

--- a/app/src/agent-runtime/data-source-tools.ts
+++ b/app/src/agent-runtime/data-source-tools.ts
@@ -15,6 +15,7 @@ import {
   queryAppDuckDB,
   bindingTableName,
 } from "../app-runtime/duckdb";
+import { ensureBindingLoadedForPreview } from "../app-runtime/binding-preview";
 import { queryDashboardRuntime } from "../dashboard-runtime/gateway";
 import { previewDashboardQuery } from "../dashboard-runtime/commands";
 import { getCurrentWorkspaceId } from "../app-runtime/shell";
@@ -94,7 +95,11 @@ async function executeAppDataTool(
     let note: string | undefined;
     try {
       if (binding.materialization === "parquet") {
-        const loaded = await ensureBindingLoaded(appId, binding);
+        // Preview-env aware: while a dbt preview override is active the table
+        // holds a live run against the override schema, not the prod artifact.
+        const loaded = workspaceId
+          ? await ensureBindingLoadedForPreview(workspaceId, appId, binding)
+          : await ensureBindingLoaded(appId, binding);
         if (loaded) {
           const result = await queryAppDuckDB(
             appId,
@@ -139,10 +144,16 @@ async function executeAppDataTool(
 
   if (toolName === "query_duckdb") {
     try {
+      // Preview-env aware, matching what the app preview itself reads.
       await Promise.all(
         appEntity.dataBindings
           .filter(b => b.materialization === "parquet")
-          .map(b => ensureBindingLoaded(appId, b).catch(() => false)),
+          .map(b =>
+            (workspaceId
+              ? ensureBindingLoadedForPreview(workspaceId, appId, b)
+              : ensureBindingLoaded(appId, b)
+            ).catch(() => false),
+          ),
       );
       const result = await queryAppDuckDB(appId, input.sql as string);
       return {

--- a/app/src/app-runtime/binding-preview.ts
+++ b/app/src/app-runtime/binding-preview.ts
@@ -1,0 +1,77 @@
+/**
+ * dbt preview-environment support for materialized (parquet) app bindings.
+ *
+ * Parquet artifacts ALWAYS hold prod data (materialization resolves
+ * `{{ dbt_schema }}` against the prod-like environment server-side). When an
+ * editor activates a preview env override, dbt-linked parquet bindings must
+ * not read those prod artifacts: this module executes the binding live
+ * (row-capped) against the override schema and loads the rows into the app's
+ * DuckDB table under the same name, so BOTH read paths — `useQuery` and
+ * `useDuckDB` / `query_duckdb` — see the preview data. The prod artifact is
+ * never rebuilt or touched; resetting the override reloads the parquet
+ * snapshot (the table revision encodes the override).
+ */
+
+import { containsDbtSchemaToken, type AppDataBinding } from "@mako/schemas";
+import { useAppStore, prodLikeDbtEnvironment } from "../store/appStore";
+import { ensureBindingLoaded, loadBindingRowsTable } from "./duckdb";
+
+/**
+ * The active preview env override for a binding, or null when the binding
+ * reads prod (no override set, override invalid, or binding not dbt-linked).
+ */
+export async function getBindingPreviewOverride(
+  workspaceId: string,
+  appId: string,
+  binding: AppDataBinding,
+): Promise<{ environment: string } | null> {
+  if (!binding.dbtProjectId || !containsDbtSchemaToken(binding.code)) {
+    return null;
+  }
+  const store = useAppStore.getState();
+  const override = store.previewDbtEnv[appId];
+  if (!override) return null;
+  const info = await store.fetchDbtEnvInfo(workspaceId, binding.dbtProjectId);
+  if (!info || !info.environments.some(env => env.name === override)) {
+    return null;
+  }
+  if (override === prodLikeDbtEnvironment(info)) return null;
+  return { environment: override };
+}
+
+/**
+ * Ensure a parquet binding's DuckDB table holds the data the CURRENT preview
+ * environment should see: the prod Parquet artifact by default, or a live
+ * (row-capped) execution against the override schema while a dbt preview env
+ * override is active. Returns false when the table could not be loaded (e.g.
+ * artifact not built yet).
+ */
+export async function ensureBindingLoadedForPreview(
+  workspaceId: string,
+  appId: string,
+  binding: AppDataBinding,
+  signal?: AbortSignal,
+): Promise<boolean> {
+  if (binding.materialization !== "parquet") return false;
+
+  const override = await getBindingPreviewOverride(workspaceId, appId, binding);
+  if (!override) return ensureBindingLoaded(appId, binding, signal);
+
+  return loadBindingRowsTable(
+    appId,
+    binding,
+    `dbt-preview:${override.environment}`,
+    async () => {
+      const result = await useAppStore
+        .getState()
+        .runBinding(workspaceId, appId, binding.name);
+      if (!result.success) {
+        throw new Error(
+          result.error ||
+            `Failed to run "${binding.name}" against the preview environment`,
+        );
+      }
+      return (result.rows ?? []) as Record<string, unknown>[];
+    },
+  );
+}

--- a/app/src/app-runtime/duckdb.ts
+++ b/app/src/app-runtime/duckdb.ts
@@ -10,6 +10,7 @@ import type { AsyncDuckDB } from "@duckdb/duckdb-wasm";
 import {
   createDuckDBInstance,
   loadParquetTable,
+  loadJsonTable,
   queryDuckDB,
   collectStreamBytes,
   terminateTrackedDuckDBInstance,
@@ -52,6 +53,44 @@ async function getInstance(appId: string): Promise<AppDuckDB> {
 }
 
 /**
+ * Serialize (re)loads of a table and skip the load when the requested
+ * revision already landed. The viewer preloads bindings in an effect at
+ * the same time the booted app issues on-demand reads (and several widgets
+ * can read the same binding at once); without this, two callers would
+ * DROP/CREATE the same table from separate connections concurrently, leaving
+ * it missing mid-rebuild — which surfaces as "data source not ready" until
+ * the user retries. Each load waits for the in-flight one, then re-checks the
+ * revision so it no-ops when the snapshot it needs already landed.
+ */
+function loadTableSerialized(
+  inst: AppDuckDB,
+  table: string,
+  revision: string,
+  load: () => Promise<void>,
+): Promise<boolean> {
+  // Fast path: this exact snapshot is already loaded.
+  if (inst.loaded.get(table) === revision) return Promise.resolve(true);
+
+  const prior = inst.loading.get(table) ?? Promise.resolve();
+  const result = prior.then(async () => {
+    if (inst.loaded.get(table) === revision) return true;
+    await load();
+    inst.loaded.set(table, revision);
+    return true;
+  });
+
+  // Keep the per-table chain alive for the next caller even if this load fails.
+  inst.loading.set(
+    table,
+    result.then(
+      () => undefined,
+      () => undefined,
+    ),
+  );
+  return result;
+}
+
+/**
  * Ensure a binding's Parquet artifact is loaded into the app's DuckDB instance.
  * Returns false if the binding isn't a ready materialized artifact.
  */
@@ -74,19 +113,7 @@ export async function ensureBindingLoaded(
   const revision = cache.artifactRevision || cache.definitionHash || "";
   const parquetUrl = cache.parquetUrl;
 
-  // Fast path: this exact snapshot is already loaded.
-  if (inst.loaded.get(table) === revision) return true;
-
-  // Serialize loads for a table. The viewer preloads bindings in an effect at
-  // the same time the booted app issues on-demand reads (and several widgets
-  // can read the same binding at once); without this, two callers would
-  // DROP/CREATE the same table from separate connections concurrently, leaving
-  // it missing mid-rebuild — which surfaces as "data source not ready" until
-  // the user retries. Each load waits for the in-flight one, then re-checks the
-  // revision so it no-ops when the snapshot it needs already landed.
-  const prior = inst.loading.get(table) ?? Promise.resolve();
-  const result = prior.then(async () => {
-    if (inst.loaded.get(table) === revision) return true;
+  return loadTableSerialized(inst, table, revision, async () => {
     const response = await fetch(parquetUrl, {
       credentials: "include",
       signal,
@@ -96,19 +123,46 @@ export async function ensureBindingLoaded(
     }
     const buffer = await collectStreamBytes(response.body);
     await loadParquetTable(inst.db, table, buffer);
-    inst.loaded.set(table, revision);
-    return true;
   });
+}
 
-  // Keep the per-table chain alive for the next caller even if this load fails.
-  inst.loading.set(
-    table,
-    result.then(
-      () => undefined,
-      () => undefined,
-    ),
-  );
-  return result;
+/**
+ * Load a binding's table from in-memory rows instead of its Parquet artifact.
+ * Used by the dbt preview-environment override: the caller executes the
+ * binding live against the override schema and swaps the rows in under the
+ * SAME table name, so `useDuckDB` reads the preview data while the prod
+ * artifact stays untouched. `revision` must encode the override (e.g.
+ * `dbt-preview:<env>`) so switching environments — including back to prod —
+ * reloads the table.
+ */
+export async function loadBindingRowsTable(
+  appId: string,
+  binding: AppDataBinding,
+  revision: string,
+  fetchRows: () => Promise<Record<string, unknown>[]>,
+): Promise<boolean> {
+  const inst = await getInstance(appId);
+  const table = bindingTableName(binding.name);
+
+  return loadTableSerialized(inst, table, revision, async () => {
+    const rows = await fetchRows();
+    if (rows.length === 0) {
+      // Zero-row preview result: replace the table with an empty one (single
+      // placeholder column — JSON inference has no schema to work from) so
+      // reads see "no data" instead of silently serving the stale prod rows.
+      const conn = await inst.db.connect();
+      try {
+        await conn.query(`DROP TABLE IF EXISTS "${table}"`);
+        await conn.query(
+          `CREATE TABLE "${table}" AS SELECT NULL AS __empty WHERE false`,
+        );
+      } finally {
+        await conn.close();
+      }
+      return;
+    }
+    await loadJsonTable(inst.db, table, rows);
+  });
 }
 
 /** Run analytical SQL against the app's loaded tables. */

--- a/app/src/components/AppRenderer.tsx
+++ b/app/src/components/AppRenderer.tsx
@@ -43,6 +43,7 @@ import {
   resolveSandboxRowLimit,
   applySandboxRowLimit,
 } from "../app-runtime/duckdb";
+import { ensureBindingLoadedForPreview } from "../app-runtime/binding-preview";
 
 /**
  * Full-screen live preview of a React app. File editing happens in dedicated
@@ -248,16 +249,23 @@ export default function AppRenderer({
   }, [appEntity, workspaceId, appId, fetchApp]);
 
   // Preload materialized (parquet) bindings into the app's DuckDB instance.
+  // Preview-env aware: while a dbt override is active, dbt-linked bindings
+  // load a live (row-capped) run against the override schema instead of the
+  // prod Parquet artifact — re-runs when the effective env changes so the
+  // tables swap in both directions.
   useEffect(() => {
     if (!appEntity) return;
     for (const binding of appEntity.dataBindings) {
       if (binding.materialization === "parquet") {
-        void ensureBindingLoaded(appId, binding).catch(() => {
+        const load = workspaceId
+          ? ensureBindingLoadedForPreview(workspaceId, appId, binding)
+          : ensureBindingLoaded(appId, binding);
+        void load.catch(() => {
           /* surfaced when the app actually queries it */
         });
       }
     }
-  }, [appId, appEntity]);
+  }, [appId, appEntity, workspaceId, effectiveDbtEnv]);
 
   // Dispose the DuckDB instance when the tab unmounts.
   useEffect(() => {
@@ -354,9 +362,14 @@ export default function AppRenderer({
           b => b.materialization === "parquet",
         );
         const rowLimit = resolveSandboxRowLimit(data.rowLimit);
+        // Preview-env aware: dbt-linked tables hold override data while a
+        // preview env is active (see ensureBindingLoadedForPreview).
         void Promise.all(
           parquetBindings.map(b =>
-            ensureBindingLoaded(appId, b).catch(() => false),
+            (workspaceId
+              ? ensureBindingLoadedForPreview(workspaceId, appId, b)
+              : ensureBindingLoaded(appId, b)
+            ).catch(() => false),
           ),
         )
           .then(() => queryAppDuckDB(appId, data.sql))

--- a/packages/agent-tools/src/app-tools.ts
+++ b/packages/agent-tools/src/app-tools.ts
@@ -359,9 +359,13 @@ export const clientAppTools = {
       "(for dbt-linked bindings using the {{ dbt_schema }} token). This is " +
       "per-user VIEW state — it never changes the app definition, other " +
       "editors' previews, or what published/shared viewers see (those always " +
-      "read the prod environment). Pass environment: null to go back to the " +
-      "default (prod). Use it to verify an app against models you just built " +
-      "in a dev/personal schema before promoting them to prod.",
+      "read the prod environment). While an override is active, dbt-linked " +
+      "parquet bindings serve a live (row-capped) run against the override " +
+      "schema — useQuery, useDuckDB, and query_duckdb all read it; do NOT " +
+      "call materialize_binding to preview dev data (materialization always " +
+      "builds from prod). Pass environment: null to go back to the default " +
+      "(prod). Use it to verify an app against models you just built in a " +
+      "dev/personal schema before promoting them to prod.",
     inputSchema: z.object({
       appId: appIdField,
       environment: z


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The app preview dbt-environment switcher (`app_set_preview_environment` / the toolbar dropdown) only affected `useQuery` reads: `AppRenderer`'s `runBinding` bridge falls back to a live execution against the override schema for dbt-linked parquet bindings.

But `useDuckDB` — the read path the apps skill recommends for parquet-backed dashboard apps — and the agent's `query_duckdb` / `inspect_data_source` tools always loaded the **prod Parquet artifacts** into DuckDB-WASM and never consulted the override. Result: switching the preview env rendered the "Previewing dbt env" pill but changed **zero data** for any app that reads through DuckDB, which is essentially every parquet-materialized app. (Seen in the field: an agent burned a whole session re-materializing bindings trying to preview `dbt_jonas` data, concluding the switcher "can't preview this app".)

Bug reproduced on pre-fix code — pill renders, data stays prod:

[bug_repro_prefix_env_switch_no_data_change.mp4](https://cursor.com/agents/bc-2f2b40ab-7279-45fa-ae09-3a1fdddd38c8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbug_repro_prefix_env_switch_no_data_change.mp4)

## Fix

While a dbt preview env override is active, dbt-linked parquet bindings now load their DuckDB table from a **live (row-capped) run against the override schema** instead of the prod artifact:

- `app/src/app-runtime/binding-preview.ts` (new): `ensureBindingLoadedForPreview` resolves the active override (same validity + prod-like rules as the switcher) and swaps the rows in under the same table name. Table revisions are keyed `dbt-preview:<env>` so switching environments — including back to prod — reloads the table; the prod Parquet artifact is never rebuilt or touched.
- `app/src/app-runtime/duckdb.ts`: per-table serialized loading extracted into `loadTableSerialized`; new `loadBindingRowsTable` loads JSON rows (empty results replace the table with an empty placeholder so stale prod rows are never silently served).
- `AppRenderer.tsx`: the binding preload effect and the `runDuckDb` bridge use the preview-aware loader (preload re-runs on env change).
- `data-source-tools.ts`: `query_duckdb` and `inspect_data_source` on the app surface use the preview-aware loader, so agent validation sees the same data as the preview.
- `apps/SKILL.md` + `app_set_preview_environment` tool description: spell out that `useQuery`, `useDuckDB`, and `query_duckdb` all read the override, and that `materialize_binding` ALWAYS builds from prod (never call it to preview dev data).

## Demo (with fix)

Fixture: dbt project with `prod` → `dbt_prod` (CH 13.3 / ES 3.6 / FR 4.1 / IT 2.7) and `jonas` → `dbt_jonas` (CH 61.9 / ES 67.0 / FR 63.4 / IT 65.2); app with one parquet-materialized binding read via `useDuckDB`. Switching the dropdown swaps the data both ways; the parquet artifact is untouched:

[preview_env_switch_parquet_binding_demo.mp4](https://cursor.com/agents/bc-2f2b40ab-7279-45fa-ae09-3a1fdddd38c8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreview_env_switch_parquet_binding_demo.mp4)

[Preview env jonas shows dev data](https://cursor.com/agents/bc-2f2b40ab-7279-45fa-ae09-3a1fdddd38c8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_fix_previewing_jonas_env.webp)

## Testing

- ✅ `pnpm --filter @mako/agent-tools run build`
- ✅ `pnpm --filter app run typecheck`
- ✅ `pnpm --filter app run lint`
- ✅ Manual E2E (videos above): bug reproduced on pre-fix code, fix verified switching prod → jonas → prod with a parquet binding read through `useDuckDB`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f2b40ab-7279-45fa-ae09-3a1fdddd38c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f2b40ab-7279-45fa-ae09-3a1fdddd38c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

