### PR TITLE
MCP settings: allow renaming connections; stop showing a URL field for fixed-URL presets

### DIFF
--- a/app/src/components/McpServersSection.tsx
+++ b/app/src/components/McpServersSection.tsx
@@ -244,13 +244,17 @@ function AddServerDialog({
               helperText="Streamable HTTP endpoint of the MCP server"
             />
           ) : (
-            <TextField
-              label="Server URL"
-              size="small"
-              fullWidth
-              value={preset?.url ?? ""}
-              disabled
-            />
+            // Fixed-URL presets: a disabled input reads like an empty
+            // required field, so show the endpoint as plain info instead.
+            preset?.url && (
+              <Typography variant="caption" color="text.secondary">
+                Connects to{" "}
+                <Box component="code" sx={{ fontFamily: "monospace" }}>
+                  {preset.url}
+                </Box>{" "}
+                — the official {preset.label} MCP endpoint (not editable).
+              </Typography>
+            )
           )}
           {authOptions.length > 1 && (
             <FormControl fullWidth size="small">

--- a/app/src/components/McpServersSection.tsx
+++ b/app/src/components/McpServersSection.tsx
@@ -620,6 +620,88 @@ function CredentialsForm({
   );
 }
 
+/**
+ * Admin-only rename + description editor. Renaming is safe: credentials,
+ * grants, and tool policies are keyed by server ID — only the agent-facing
+ * tool prefix (derived from the name) changes.
+ */
+function ServerDetailsForm({
+  server,
+  onNotify,
+}: {
+  server: McpServerInfo;
+  onNotify: (message: string, severity: "success" | "error") => void;
+}) {
+  const { currentWorkspace } = useWorkspace();
+  const updateServer = useMcpStore(s => s.updateServer);
+  const [name, setName] = useState(server.name);
+  const [description, setDescription] = useState(server.description ?? "");
+  const [saving, setSaving] = useState(false);
+
+  // Re-sync when switching to a different server in the same dialog.
+  useEffect(() => {
+    setName(server.name);
+    setDescription(server.description ?? "");
+  }, [server.id, server.name, server.description]);
+
+  const dirty =
+    name.trim() !== server.name ||
+    description.trim() !== (server.description ?? "");
+
+  const handleSave = async () => {
+    if (!currentWorkspace) return;
+    setSaving(true);
+    try {
+      await updateServer(currentWorkspace.id, server.id, {
+        name: name.trim(),
+        description: description.trim() || undefined,
+      });
+      onNotify("Connection details saved", "success");
+    } catch (err) {
+      onNotify(
+        err instanceof Error ? err.message : "Failed to save details",
+        "error",
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Stack spacing={1.5}>
+      <Typography variant="subtitle2">Connection details</Typography>
+      <TextField
+        label="Name"
+        size="small"
+        fullWidth
+        value={name}
+        onChange={e => setName(e.target.value)}
+        helperText="Shown in tool names, e.g. mcp_close_crm_lead_search — renaming changes the tool prefix the agent sees"
+      />
+      <TextField
+        label="Description"
+        size="small"
+        fullWidth
+        multiline
+        minRows={2}
+        value={description}
+        onChange={e => setDescription(e.target.value)}
+        helperText="Optional — shown on the connection card"
+      />
+      <Button
+        variant="outlined"
+        size="small"
+        disabled={!dirty || name.trim().length === 0 || saving}
+        onClick={() => void handleSave()}
+        sx={{ alignSelf: "flex-start" }}
+        data-testid="mcp-save-details"
+      >
+        {saving ? "Saving…" : "Save details"}
+      </Button>
+    </Stack>
+  );
+}
+
 function ServerDetail({
   server,
   preset,
@@ -735,6 +817,13 @@ function ServerDetail({
     <Stack spacing={2.5}>
       {server.status === "error" && server.lastError && (
         <Alert severity="error">{server.lastError}</Alert>
+      )}
+
+      {isAdmin && (
+        <>
+          <ServerDetailsForm server={server} onNotify={onNotify} />
+          <Divider />
+        </>
       )}
 
       {server.authType === "oauth" ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two UX fixes to Settings → MCP Servers (`McpServersSection.tsx`):

### 1. Rename MCP connections
MCP servers could not be renamed from the UI even though the backend `PATCH /api/workspaces/:workspaceId/mcp-servers/:id` route has always accepted `name` and `description`. Adds an admin-only "Connection details" form to the server management dialog:

- editable **Name** (with a helper note that renaming changes the agent-facing tool prefix, e.g. `mcp_close_crm_*`)
- editable optional **Description** (shown on the connection card)
- Save button enabled only when dirty; duplicate-name conflicts surface the API's 409 message

Renaming is safe: credentials, grants, and tool policies are keyed by server ID, so only the derived tool prefix changes.

### 2. No more "Server URL" field for the Close preset
The "Add MCP server" dialog rendered a disabled `Server URL` TextField for fixed-URL presets like Close CRM, which read as the form asking the user for an MCP URL. Fixed-URL presets now show a plain caption ("Connects to `https://mcp.close.com/mcp` — the official Close CRM MCP endpoint (not editable).") instead; custom servers keep the editable URL input. The URL was never user-supplied for these presets anyway — the backend ignores it (`preset.urlEditable ? body.url : preset.url`).

## Demo

Rename flow ("Close US" → "Close EMEA", persisted to `mcp_servers`):

[rename_mcp_connection_demo.mp4](https://cursor.com/agents/bc-02dde757-4e94-4c38-b359-e2aefa27f441/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frename_mcp_connection_demo.mp4)

Close preset dialog now shows endpoint info text instead of a URL field (custom preset keeps the editable field):

[close_preset_url_info_text_demo.mp4](https://cursor.com/agents/bc-02dde757-4e94-4c38-b359-e2aefa27f441/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclose_preset_url_info_text_demo.mp4)

[Close dialog without URL field](https://cursor.com/agents/bc-02dde757-4e94-4c38-b359-e2aefa27f441/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclose_dialog_no_url_field.webp)
[Custom dialog keeps editable URL field](https://cursor.com/agents/bc-02dde757-4e94-4c38-b359-e2aefa27f441/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcustom_dialog_url_field_kept.webp)
[Settings card showing renamed connection](https://cursor.com/agents/bc-02dde757-4e94-4c38-b359-e2aefa27f441/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsettings_card_renamed.webp)

## Testing

- ✅ `pnpm --filter app run typecheck`
- ✅ `pnpm --filter app run lint`
- ✅ Manual GUI tests on the running dev stack: renamed a server end-to-end (dialog title, card, MongoDB document all updated); verified the Close preset dialog shows the info caption with no URL input while the custom preset retains the editable URL field.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02dde757-4e94-4c38-b359-e2aefa27f441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02dde757-4e94-4c38-b359-e2aefa27f441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

