### PR TITLE
Add dbt_compare_branches agent tool for branch-vs-base comparison

### DIFF
--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -2015,6 +2015,22 @@ export const createDbtServerTools = (
           });
           const MAX_COMMITS = 20;
           const MAX_FILES = 100;
+          // Spell the verdict out — "aheadBy > 0 but fully merged" (squash
+          // merge) is easy to misread as unmerged work.
+          const mergedPr = result.pullRequests.find(
+            pr => pr.merged && pr.baseRef === result.base,
+          );
+          const hint = result.fullyMergedIntoBase
+            ? result.aheadBy === 0
+              ? `Every commit on "${result.head}" is already on ` +
+                `"${result.base}" — the branch is safe to delete.`
+              : `aheadBy is ${result.aheadBy} only because the branch was ` +
+                `squash/rebase-merged${mergedPr ? ` (PR #${mergedPr.number}` : " (PR"} ` +
+                `merged after its last commit), so its original SHAs never ` +
+                `landed on "${result.base}". Its CONTENT is already in ` +
+                `"${result.base}" — the branch is safe to delete.`
+            : `"${result.head}" carries commits whose content is NOT in ` +
+              `"${result.base}" — deleting it would lose that work.`;
           return {
             success: true,
             base: result.base,
@@ -2023,6 +2039,7 @@ export const createDbtServerTools = (
             aheadBy: result.aheadBy,
             behindBy: result.behindBy,
             fullyMergedIntoBase: result.fullyMergedIntoBase,
+            hint,
             // Newest commits are the most informative — keep the tail.
             commits: result.commits.slice(-MAX_COMMITS).map(c => ({
               sha: c.sha.slice(0, 7),

--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -67,6 +67,7 @@ import {
   closeProjectPullRequest,
   commitAndPush,
   commitToNewBranch,
+  compareProjectRefs,
   createProjectBranch,
   deleteProjectBranch,
   getGitStatus,
@@ -1971,11 +1972,89 @@ export const createDbtServerTools = (
       },
     }),
 
+    dbt_compare_branches: tool({
+      description:
+        "Compare a branch (or any ref) against a base branch WITHOUT " +
+        "switching checkouts — GitHub's base...head compare (head vs the " +
+        "merge base, like a PR diff). Returns ahead/behind commit counts, " +
+        "the changed files, the PRs opened from that branch, and " +
+        "fullyMergedIntoBase — true when the branch's content is already in " +
+        "the base (directly merged, or squash/rebase-merged via a PR after " +
+        "its last commit). ALWAYS check this before dbt_delete_branch when " +
+        "cleaning up branches: fullyMergedIntoBase true → safe to delete; " +
+        "false → the branch still carries unmerged work.",
+      inputSchema: z.object({
+        projectId: projectIdField,
+        head: z
+          .string()
+          .min(1)
+          .max(255)
+          .optional()
+          .describe(
+            "Branch/ref to inspect; defaults to the user's checked-out branch",
+          ),
+        base: z
+          .string()
+          .min(1)
+          .max(255)
+          .optional()
+          .describe(
+            "Branch/ref to compare against; defaults to the repo's default " +
+              "branch",
+          ),
+      }),
+      execute: async ({ projectId, head, base }) => {
+        try {
+          const project = await assertRepoProject(projectId);
+          const headRef =
+            head?.trim() ||
+            ((await getCheckoutBranch(project, actingUserId)) as string);
+          const result = await compareProjectRefs(project, {
+            head: headRef,
+            base: base?.trim() || undefined,
+          });
+          const MAX_COMMITS = 20;
+          const MAX_FILES = 100;
+          return {
+            success: true,
+            base: result.base,
+            head: result.head,
+            status: result.status,
+            aheadBy: result.aheadBy,
+            behindBy: result.behindBy,
+            fullyMergedIntoBase: result.fullyMergedIntoBase,
+            // Newest commits are the most informative — keep the tail.
+            commits: result.commits.slice(-MAX_COMMITS).map(c => ({
+              sha: c.sha.slice(0, 7),
+              message: c.message.split("\n", 1)[0],
+              date: c.date,
+            })),
+            commitsTruncated: result.commits.length > MAX_COMMITS,
+            files: result.files.slice(0, MAX_FILES),
+            filesTruncated: result.files.length > MAX_FILES,
+            pullRequests: result.pullRequests.map(pr => ({
+              number: pr.number,
+              title: pr.title,
+              state: pr.state,
+              merged: pr.merged,
+              mergedAt: pr.mergedAt,
+              baseRef: pr.baseRef,
+              url: pr.htmlUrl,
+            })),
+          };
+        } catch (error) {
+          return toolError(error, "Failed to compare branches");
+        }
+      },
+    }),
+
     dbt_delete_branch: tool({
       description:
         "Delete a remote branch from the project's repository — use to clean up " +
         "a stray/merged feature branch (e.g. after its PR is merged, or an " +
-        "abandoned branch from a failed promote). Refuses to delete the branch " +
+        "abandoned branch from a failed promote). If unsure whether the " +
+        "branch's work has landed, check dbt_compare_branches first " +
+        "(fullyMergedIntoBase). Refuses to delete the branch " +
         "the project currently tracks (switch away first with dbt_switch_branch) " +
         "and the repo's default branch. DESTRUCTIVE for stashed work: any " +
         "uncommitted drafts saved on that branch are permanently dropped with " +

--- a/api/src/agent-skills/dbt/SKILL.md
+++ b/api/src/agent-skills/dbt/SKILL.md
@@ -167,6 +167,10 @@ AND its tests — always add at least `unique` + `not_null` on the primary key.
   - Deleting a branch (`dbt_delete_branch`, or `deleteBranch` on close/merge
     of a PR) drops the drafts stashed on it — except a PR merge, which moves
     them to the default branch with the user.
+  - `dbt_compare_branches` diffs any branch against a base without switching
+    checkouts (ahead/behind, changed files, that branch's PRs). Its
+    `fullyMergedIntoBase` flag detects squash/rebase merges too — check it
+    before deleting a branch during cleanup.
   - `discardLocalChanges` (on switch/sync) only discards the branch being
     left / the current branch — never other branches' stashes.
 - **Which git tree a run builds (repo-bound projects)** — never mix these up:

--- a/api/src/agents/dbt/prompt.ts
+++ b/api/src/agents/dbt/prompt.ts
@@ -43,7 +43,9 @@ runs execute against the project's warehouse environments (dev/prod).
    If a build runs against a stale checkout (fewer models/sources
    than the branch has, e.g. a merged PR not yet picked up), call
    \`dbt_sync_from_repo\` to re-pull the tracked branch. Clean up merged/stray branches with
-   \`dbt_delete_branch\`.
+   \`dbt_delete_branch\`; when unsure whether a branch's work has landed, check it with
+   \`dbt_compare_branches\` first — \`fullyMergedIntoBase: true\` (handles squash merges) means the
+   branch is safe to delete, \`false\` means it still carries unmerged work.
 
 ## Rules
 

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -219,7 +219,9 @@ and status, \`dbt_update_pull_request\` to retitle/redescribe/retarget an open P
 builds from a stale checkout (fewer models/sources than the branch actually has, e.g. a merged PR
 not picked up), call
 \`dbt_sync_from_repo\` to re-pull the tracked branch. Use \`dbt_delete_branch\` to clean up merged or
-stray branches. Switching branches is always safe: uncommitted edits stay with the branch they
+stray branches; when unsure whether a branch's work has landed, check \`dbt_compare_branches\` first —
+\`fullyMergedIntoBase: true\` (handles squash merges) means safe to delete, \`false\` means unmerged
+work. Switching branches is always safe: uncommitted edits stay with the branch they
 were made on (git-worktree semantics), so \`dbt_switch_branch\` never mixes or loses work — pass
 \`discardLocalChanges\` only after the user confirms abandoning that branch's pending changes.
 If a user reports lost/missing files, use

--- a/api/src/agents/modes/registry.ts
+++ b/api/src/agents/modes/registry.ts
@@ -195,6 +195,7 @@ const TRANSFORM_MODE_TOOL_NAMES: string[] = [
   "dbt_create_branch",
   "dbt_switch_branch",
   "dbt_list_branches",
+  "dbt_compare_branches",
   "dbt_delete_branch",
   "dbt_open_pull_request",
   "dbt_merge_pull_request",

--- a/api/src/dbt/dbt-github-git.compare.test.ts
+++ b/api/src/dbt/dbt-github-git.compare.test.ts
@@ -1,0 +1,202 @@
+/**
+ * compareProjectRefs — branch-vs-base comparison verdicts, incl. the
+ * squash-merge detection that plain ahead/behind counts can't answer.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { IDbtProject } from "../database/workspace-schema";
+
+vi.mock("../integrations/github/app-auth", () => ({
+  resolveRepoToken: vi.fn(async () => "token"),
+}));
+
+const github = vi.hoisted(() => ({
+  compareRefs: vi.fn(),
+  listPullRequests: vi.fn(),
+  getRepoInfo: vi.fn(),
+}));
+
+vi.mock("../integrations/github/github-api", async importOriginal => ({
+  ...(await importOriginal<
+    typeof import("../integrations/github/github-api")
+  >()),
+  compareRefs: github.compareRefs,
+  listPullRequests: github.listPullRequests,
+  getRepoInfo: github.getRepoInfo,
+}));
+
+import { compareProjectRefs } from "./dbt-github-git.service";
+
+const project = {
+  repo: {
+    provider: "github",
+    owner: "acme",
+    repo: "analytics",
+    branch: "dev",
+    installationId: 123,
+  },
+} as unknown as IDbtProject;
+
+function compareResult(
+  overrides: Partial<{
+    status: string;
+    aheadBy: number;
+    behindBy: number;
+    commits: Array<{ sha: string; message: string; date?: string }>;
+    files: Array<{
+      filename: string;
+      status: string;
+      additions: number;
+      deletions: number;
+    }>;
+  }> = {},
+) {
+  return {
+    status: "ahead",
+    aheadBy: 1,
+    behindBy: 0,
+    commits: [
+      { sha: "abc", message: "feat: x", date: "2026-06-01T00:00:00Z" },
+    ],
+    files: [
+      { filename: "models/x.sql", status: "added", additions: 5, deletions: 0 },
+    ],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  github.getRepoInfo.mockResolvedValue({
+    fullName: "acme/analytics",
+    owner: "acme",
+    name: "analytics",
+    defaultBranch: "dev",
+    private: true,
+  });
+  github.listPullRequests.mockResolvedValue([]);
+});
+
+describe("compareProjectRefs", () => {
+  it("defaults base to the repo default branch and filters PRs by head", async () => {
+    github.compareRefs.mockResolvedValue(compareResult());
+
+    const result = await compareProjectRefs(project, { head: "feat/x" });
+
+    expect(result.base).toBe("dev");
+    expect(result.head).toBe("feat/x");
+    expect(github.compareRefs).toHaveBeenCalledWith(
+      "acme",
+      "analytics",
+      "dev",
+      "feat/x",
+      "token",
+    );
+    expect(github.listPullRequests).toHaveBeenCalledWith(
+      "acme",
+      "analytics",
+      { state: "all", head: "acme:feat/x" },
+      "token",
+    );
+  });
+
+  it("skips the default-branch lookup when base is given", async () => {
+    github.compareRefs.mockResolvedValue(compareResult());
+
+    const result = await compareProjectRefs(project, {
+      head: "feat/x",
+      base: "staging",
+    });
+
+    expect(result.base).toBe("staging");
+    expect(github.getRepoInfo).not.toHaveBeenCalled();
+  });
+
+  it("aheadBy 0 → fully merged (regular merge)", async () => {
+    github.compareRefs.mockResolvedValue(
+      compareResult({ status: "behind", aheadBy: 0, commits: [], files: [] }),
+    );
+
+    const result = await compareProjectRefs(project, { head: "feat/merged" });
+    expect(result.fullyMergedIntoBase).toBe(true);
+  });
+
+  it("aheadBy > 0 with a PR into base merged after the last commit → fully merged (squash)", async () => {
+    github.compareRefs.mockResolvedValue(
+      compareResult({
+        aheadBy: 2,
+        commits: [
+          { sha: "a", message: "feat", date: "2026-06-01T00:00:00Z" },
+          { sha: "b", message: "fix", date: "2026-06-02T00:00:00Z" },
+        ],
+      }),
+    );
+    github.listPullRequests.mockResolvedValue([
+      {
+        number: 15,
+        state: "closed",
+        merged: true,
+        mergedAt: "2026-06-03T00:00:00Z",
+        baseRef: "dev",
+      },
+    ]);
+
+    const result = await compareProjectRefs(project, { head: "feat/docs" });
+    expect(result.fullyMergedIntoBase).toBe(true);
+    expect(result.pullRequests).toHaveLength(1);
+  });
+
+  it("commits pushed AFTER the merged PR → NOT fully merged", async () => {
+    github.compareRefs.mockResolvedValue(
+      compareResult({
+        aheadBy: 2,
+        commits: [
+          { sha: "a", message: "feat", date: "2026-06-01T00:00:00Z" },
+          { sha: "b", message: "post-merge fix", date: "2026-06-05T00:00:00Z" },
+        ],
+      }),
+    );
+    github.listPullRequests.mockResolvedValue([
+      {
+        number: 15,
+        state: "closed",
+        merged: true,
+        mergedAt: "2026-06-03T00:00:00Z",
+        baseRef: "dev",
+      },
+    ]);
+
+    const result = await compareProjectRefs(project, { head: "feat/docs" });
+    expect(result.fullyMergedIntoBase).toBe(false);
+  });
+
+  it("merged PR into a DIFFERENT base → NOT fully merged", async () => {
+    github.compareRefs.mockResolvedValue(compareResult({ aheadBy: 1 }));
+    github.listPullRequests.mockResolvedValue([
+      {
+        number: 9,
+        state: "closed",
+        merged: true,
+        mergedAt: "2026-06-03T00:00:00Z",
+        baseRef: "main",
+      },
+    ]);
+
+    const result = await compareProjectRefs(project, { head: "feat/x" });
+    expect(result.fullyMergedIntoBase).toBe(false);
+  });
+
+  it("ahead with no merged PR → NOT fully merged (unmerged work)", async () => {
+    github.compareRefs.mockResolvedValue(
+      compareResult({ status: "diverged", aheadBy: 3, behindBy: 4 }),
+    );
+
+    const result = await compareProjectRefs(project, { head: "wip/experiment" });
+    expect(result.fullyMergedIntoBase).toBe(false);
+  });
+
+  it("throws for projects without a connected repo", async () => {
+    await expect(
+      compareProjectRefs({} as IDbtProject, { head: "feat/x" }),
+    ).rejects.toThrow("not connected to a repository");
+  });
+});

--- a/api/src/dbt/dbt-github-git.service.ts
+++ b/api/src/dbt/dbt-github-git.service.ts
@@ -27,6 +27,7 @@ import { resolveRepoToken } from "../integrations/github/app-auth";
 import { gitBlobSha } from "../integrations/github/git-blob";
 import {
   commitChanges,
+  compareRefs,
   createBranch,
   createPullRequest,
   deleteBranch,
@@ -39,6 +40,7 @@ import {
   mergePullRequest,
   tryDeleteBranch,
   updatePullRequest,
+  type CompareRefsResult,
   type MergeMethod,
   type PullRequestSummary,
   type TreeChange,
@@ -845,6 +847,76 @@ export async function listProjectPullRequests(
     { state: params.state ?? "open" },
     token,
   );
+}
+
+export interface BranchComparison extends CompareRefsResult {
+  base: string;
+  head: string;
+  /** PRs (any state) whose head is the compared branch. */
+  pullRequests: PullRequestSummary[];
+  /**
+   * True when head's content is already in base: either every head commit is
+   * on base (`aheadBy === 0`), or a PR from head into base was merged after
+   * head's last commit (squash/rebase merges keep aheadBy > 0 even though the
+   * content landed).
+   */
+  fullyMergedIntoBase: boolean;
+}
+
+/**
+ * Compare a branch (or any ref) against a base ref — GitHub's
+ * `base...head` three-dot compare (head vs the merge base, like a PR diff) —
+ * plus the PRs opened from that branch. Purely a GitHub read — no git lock.
+ * `base` defaults to the repo's default branch.
+ */
+export async function compareProjectRefs(
+  project: IDbtProject,
+  params: { head: string; base?: string },
+): Promise<BranchComparison> {
+  if (!project.repo) {
+    throw new Error("Project is not connected to a repository");
+  }
+  const token = await resolveRepoToken(project.repo.installationId);
+  const { owner, repo } = project.repo;
+
+  let base = params.base;
+  if (!base) {
+    const info = await getRepoInfo(owner, repo, token);
+    base = info.defaultBranch;
+  }
+
+  const [compare, pullRequests] = await Promise.all([
+    compareRefs(owner, repo, base, params.head, token),
+    listPullRequests(
+      owner,
+      repo,
+      { state: "all", head: `${owner}:${params.head}` },
+      token,
+    ),
+  ]);
+
+  // Squash/rebase merges never put head's SHAs on base, so aheadBy stays > 0.
+  // A PR into base merged AFTER head's last commit proves the content landed.
+  const lastCommitAt = compare.commits.reduce<string | undefined>(
+    (latest, c) => (c.date && (!latest || c.date > latest) ? c.date : latest),
+    undefined,
+  );
+  const mergedViaPr = pullRequests.some(
+    pr =>
+      pr.merged &&
+      pr.baseRef === base &&
+      lastCommitAt !== undefined &&
+      pr.mergedAt !== undefined &&
+      pr.mergedAt >= lastCommitAt,
+  );
+
+  return {
+    ...compare,
+    base,
+    head: params.head,
+    pullRequests,
+    fullyMergedIntoBase: compare.aheadBy === 0 || mergedViaPr,
+  };
 }
 
 /**

--- a/api/src/dbt/test-support/fake-github-server.mjs
+++ b/api/src/dbt/test-support/fake-github-server.mjs
@@ -41,11 +41,11 @@ function sha1(value) {
 const trees = new Map();
 /** blobSha -> content */
 const blobs = new Map();
-/** commitSha -> { treeSha, parents, message } */
+/** commitSha -> { treeSha, parents, message, date } */
 const commits = new Map();
 /** branch -> head commit sha */
 const branches = new Map();
-/** number -> { headRef, baseRef, state, title, body } */
+/** number -> { headRef, baseRef, state, title, body, createdAt, mergedAt } */
 const pulls = new Map();
 let pullCounter = 0;
 
@@ -61,8 +61,27 @@ function storeTree(files) {
 
 function storeCommit(treeSha, parents, message) {
   const sha = sha1(`${treeSha}|${parents.join(",")}|${message}|${Date.now()}|${Math.random()}`);
-  commits.set(sha, { treeSha, parents, message });
+  commits.set(sha, {
+    treeSha,
+    parents,
+    message,
+    date: new Date().toISOString(),
+  });
   return sha;
+}
+
+/** All commit SHAs reachable from `sha` (inclusive). */
+function ancestors(sha) {
+  const seen = new Set();
+  const stack = [sha];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current || seen.has(current)) continue;
+    seen.add(current);
+    const commit = commits.get(current);
+    if (commit) stack.push(...commit.parents);
+  }
+  return seen;
 }
 
 function branchFiles(branch) {
@@ -313,7 +332,85 @@ const server = createServer(async (req, res) => {
       }
     }
 
+    // GET /compare/:base...:head — three-dot ref comparison
+    if (req.method === "GET" && sub.startsWith("/compare/")) {
+      const basehead = sub.slice("/compare/".length);
+      const [baseRef, headRef] = basehead.split("...");
+      const resolveHead = ref =>
+        branches.get(ref) ?? (commits.has(ref) ? ref : null);
+      const baseSha = resolveHead(baseRef);
+      const headSha = resolveHead(headRef);
+      if (!baseSha || !headSha) return notFound(res);
+      const baseAncestors = ancestors(baseSha);
+      const headAncestors = ancestors(headSha);
+      const aheadShas = [...headAncestors].filter(s => !baseAncestors.has(s));
+      const behindBy = [...baseAncestors].filter(
+        s => !headAncestors.has(s),
+      ).length;
+      const status =
+        aheadShas.length === 0
+          ? behindBy === 0
+            ? "identical"
+            : "behind"
+          : behindBy === 0
+            ? "ahead"
+            : "diverged";
+      const baseFiles = trees.get(commits.get(baseSha).treeSha);
+      const headFiles = trees.get(commits.get(headSha).treeSha);
+      const files = [];
+      for (const [p, c] of headFiles) {
+        if (!baseFiles.has(p)) {
+          files.push({ filename: p, status: "added", additions: 1, deletions: 0 });
+        } else if (baseFiles.get(p) !== c) {
+          files.push({ filename: p, status: "modified", additions: 1, deletions: 1 });
+        }
+      }
+      for (const p of baseFiles.keys()) {
+        if (!headFiles.has(p)) {
+          files.push({ filename: p, status: "removed", additions: 0, deletions: 1 });
+        }
+      }
+      return json(res, 200, {
+        status,
+        ahead_by: aheadShas.length,
+        behind_by: behindBy,
+        total_commits: aheadShas.length,
+        commits: aheadShas.map(sha => ({
+          sha,
+          commit: {
+            message: commits.get(sha).message,
+            committer: { date: commits.get(sha).date },
+          },
+        })),
+        files,
+      });
+    }
+
     // Pull requests
+    if (req.method === "GET" && sub === "/pulls") {
+      const state = url.searchParams.get("state") ?? "open";
+      const headFilter = url.searchParams.get("head"); // "owner:branch"
+      const headBranch = headFilter ? headFilter.split(":").pop() : null;
+      const list = [...pulls.entries()]
+        .filter(([, pr]) => state === "all" || pr.state === state)
+        .filter(([, pr]) => !headBranch || pr.headRef === headBranch)
+        .sort(([a], [b]) => b - a)
+        .map(([number, pr]) => ({
+          number,
+          title: pr.title,
+          state: pr.state,
+          merged_at: pr.mergedAt ?? null,
+          draft: false,
+          head: { ref: pr.headRef },
+          base: { ref: pr.baseRef },
+          html_url: `http://127.0.0.1:${PORT}/${OWNER}/${REPO}/pull/${number}`,
+          user: { login: "fake-user" },
+          body: pr.body ?? "",
+          created_at: pr.createdAt,
+          updated_at: pr.mergedAt ?? pr.createdAt,
+        }));
+      return json(res, 200, list);
+    }
     if (req.method === "POST" && sub === "/pulls") {
       const body = await readBody(req);
       pullCounter += 1;
@@ -323,6 +420,7 @@ const server = createServer(async (req, res) => {
         state: "open",
         title: body.title,
         body: body.body ?? "",
+        createdAt: new Date().toISOString(),
       });
       return json(res, 201, {
         number: pullCounter,
@@ -358,16 +456,27 @@ const server = createServer(async (req, res) => {
         const headFiles = branchFiles(pr.headRef);
         const baseFiles = branchFiles(pr.baseRef);
         if (!headFiles || !baseFiles) return notFound(res);
+        const mergeBody = await readBody(req);
         const merged = new Map(baseFiles);
         for (const [p, c] of headFiles) merged.set(p, c);
         const treeSha = storeTree(merged);
+        // Squash (Mako's default) keeps a single parent: the head branch's
+        // SHAs never become ancestors of the base, so /compare keeps
+        // reporting them "ahead" — exactly what dbt_compare_branches'
+        // merged-PR fallback exists to detect. A "merge" commit gets both
+        // parents, making the head reachable from base (ahead_by drops to 0).
+        const parents =
+          mergeBody.merge_method === "merge"
+            ? [branches.get(pr.baseRef), branches.get(pr.headRef)]
+            : [branches.get(pr.baseRef)];
         const sha = storeCommit(
           treeSha,
-          [branches.get(pr.baseRef)],
+          parents,
           `Merge pull request #${number}`,
         );
         branches.set(pr.baseRef, sha);
         pr.state = "closed";
+        pr.mergedAt = new Date().toISOString();
         return json(res, 200, { sha, merged: true });
       }
     }

--- a/api/src/integrations/github/github-api.compare.test.ts
+++ b/api/src/integrations/github/github-api.compare.test.ts
@@ -1,0 +1,125 @@
+/**
+ * compareRefs + listPullRequests head filter — GitHub REST mapping.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { compareRefs, listPullRequests } from "./github-api";
+
+describe("compareRefs", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("maps the compare payload and encodes refs", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        status: "ahead",
+        ahead_by: 2,
+        behind_by: 1,
+        commits: [
+          {
+            sha: "abc1234def",
+            commit: {
+              message: "feat: add model\n\nlong body",
+              committer: { date: "2026-07-01T10:00:00Z" },
+            },
+          },
+          {
+            sha: "def5678abc",
+            commit: { message: "fix: tweak", committer: null },
+          },
+        ],
+        files: [
+          {
+            filename: "models/stg_orders.sql",
+            status: "modified",
+            additions: 3,
+            deletions: 1,
+          },
+        ],
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await compareRefs("o", "r", "dev", "feat/csm-owner");
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/repos/o/r/compare/dev...feat%2Fcsm-owner"),
+      expect.anything(),
+    );
+    expect(result.status).toBe("ahead");
+    expect(result.aheadBy).toBe(2);
+    expect(result.behindBy).toBe(1);
+    expect(result.commits).toEqual([
+      {
+        sha: "abc1234def",
+        message: "feat: add model\n\nlong body",
+        date: "2026-07-01T10:00:00Z",
+      },
+      { sha: "def5678abc", message: "fix: tweak", date: undefined },
+    ]);
+    expect(result.files).toEqual([
+      {
+        filename: "models/stg_orders.sql",
+        status: "modified",
+        additions: 3,
+        deletions: 1,
+      },
+    ]);
+  });
+
+  it("surfaces GitHub errors (unknown ref)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: false,
+        status: 404,
+        headers: { get: () => null },
+        text: async () => '{"message":"Not Found"}',
+      })),
+    );
+
+    await expect(compareRefs("o", "r", "dev", "gone")).rejects.toThrow(
+      "GitHub 404",
+    );
+  });
+});
+
+describe("listPullRequests head filter", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes head=owner:branch and maps mergedAt", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => [
+        {
+          number: 15,
+          title: "Docs contract",
+          state: "closed",
+          merged_at: "2026-06-30T12:00:00Z",
+          head: { ref: "feat/docs" },
+          base: { ref: "dev" },
+          html_url: "https://github.com/o/r/pull/15",
+          user: { login: "alice" },
+          body: null,
+          created_at: "2026-06-29T09:00:00Z",
+          updated_at: "2026-06-30T12:00:00Z",
+        },
+      ],
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const prs = await listPullRequests("o", "r", {
+      state: "all",
+      head: "o:feat/docs",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("&head=o%3Afeat%2Fdocs"),
+      expect.anything(),
+    );
+    expect(prs).toHaveLength(1);
+    expect(prs[0].merged).toBe(true);
+    expect(prs[0].mergedAt).toBe("2026-06-30T12:00:00Z");
+  });
+});

--- a/api/src/integrations/github/github-api.ts
+++ b/api/src/integrations/github/github-api.ts
@@ -413,6 +413,76 @@ export async function postCommitStatus(
   });
 }
 
+export interface CompareRefsResult {
+  /** How `head` relates to `base`: "identical" | "ahead" | "behind" | "diverged". */
+  status: string;
+  /** Commits on `head` that are not on `base` (by SHA). */
+  aheadBy: number;
+  /** Commits on `base` that are not on `head` (by SHA). */
+  behindBy: number;
+  /** The `aheadBy` commits, oldest first (first page, up to 100). */
+  commits: Array<{ sha: string; message: string; date?: string }>;
+  /** Files that differ between the merge base and `head` (up to 300). */
+  files: Array<{
+    filename: string;
+    status: string;
+    additions: number;
+    deletions: number;
+  }>;
+}
+
+/**
+ * Compare two refs (branches, tags, or SHAs) via GitHub's compare API —
+ * `base...head` (three-dot: head vs the merge base, like a PR diff).
+ * `aheadBy === 0` means every commit on head is already on base. Note that a
+ * SQUASH-merged branch still shows ahead (its original SHAs never land on
+ * base) — cross-check merged PRs for the head branch in that case.
+ */
+export async function compareRefs(
+  owner: string,
+  repo: string,
+  base: string,
+  head: string,
+  token?: string,
+): Promise<CompareRefsResult> {
+  const basehead = `${encodeURIComponent(base)}...${encodeURIComponent(head)}`;
+  const res = await ghFetch(
+    `/repos/${owner}/${repo}/compare/${basehead}?per_page=100`,
+    token,
+  );
+  const json = (await res.json()) as {
+    status: string;
+    ahead_by: number;
+    behind_by: number;
+    commits: Array<{
+      sha: string;
+      commit: { message: string; committer?: { date?: string } | null };
+    }>;
+    files?: Array<{
+      filename: string;
+      status: string;
+      additions: number;
+      deletions: number;
+    }>;
+  };
+  return {
+    status: json.status,
+    aheadBy: json.ahead_by,
+    behindBy: json.behind_by,
+    commits: json.commits.map(c => ({
+      sha: c.sha,
+      message: c.commit.message,
+      date: c.commit.committer?.date,
+    })),
+    files: (json.files ?? []).map(f => ({
+      filename: f.filename,
+      status: f.status,
+      additions: f.additions,
+      deletions: f.deletions,
+    })),
+  };
+}
+
 /** Filenames changed by a pull request (paginated). */
 export async function getPullRequestFiles(
   owner: string,
@@ -466,6 +536,8 @@ export interface PullRequestSummary {
   /** "open" or "closed" (merged PRs are "closed" with `merged: true`). */
   state: string;
   merged: boolean;
+  /** ISO timestamp of the merge, when merged. */
+  mergedAt?: string;
   draft: boolean;
   headRef: string;
   baseRef: string;
@@ -497,6 +569,7 @@ function toPullRequestSummary(json: RawPullRequest): PullRequestSummary {
     title: json.title,
     state: json.state,
     merged: json.merged_at !== null,
+    mergedAt: json.merged_at ?? undefined,
     draft: json.draft ?? false,
     headRef: json.head.ref,
     baseRef: json.base.ref,
@@ -508,17 +581,23 @@ function toPullRequestSummary(json: RawPullRequest): PullRequestSummary {
   };
 }
 
-/** Pull requests of a repo, newest first (paginated up to ~1000). */
+/**
+ * Pull requests of a repo, newest first (paginated up to ~1000). Pass `head`
+ * as `"owner:branch"` to only return PRs whose head is that branch.
+ */
 export async function listPullRequests(
   owner: string,
   repo: string,
-  params: { state: "open" | "closed" | "all" },
+  params: { state: "open" | "closed" | "all"; head?: string },
   token?: string,
 ): Promise<PullRequestSummary[]> {
+  const headFilter = params.head
+    ? `&head=${encodeURIComponent(params.head)}`
+    : "";
   const prs: PullRequestSummary[] = [];
   for (let page = 1; page <= 10; page++) {
     const res = await ghFetch(
-      `/repos/${owner}/${repo}/pulls?state=${params.state}&sort=created&direction=desc&per_page=100&page=${page}`,
+      `/repos/${owner}/${repo}/pulls?state=${params.state}${headFilter}&sort=created&direction=desc&per_page=100&page=${page}`,
       token,
     );
     const json = (await res.json()) as RawPullRequest[];

--- a/app/src/agent-runtime/client-tool-manifest.ts
+++ b/app/src/agent-runtime/client-tool-manifest.ts
@@ -883,6 +883,19 @@ export const AGENT_TOOL_MANIFEST = {
     getLabel: () => "Listing branches",
     icon: "list",
   },
+  dbt_compare_branches: {
+    domain: "dbt",
+    execution: "server",
+    getLabel: input => {
+      const params = input as Record<string, unknown> | undefined;
+      const head = params?.head;
+      const base = params?.base;
+      if (head && base) return `Comparing ${head} against ${base}`;
+      if (head) return `Comparing ${head} against the default branch`;
+      return "Comparing branches";
+    },
+    icon: "eye",
+  },
   dbt_delete_branch: {
     domain: "dbt",
     execution: "server",

--- a/packages/agent-tools/src/read-only-tools.ts
+++ b/packages/agent-tools/src/read-only-tools.ts
@@ -52,9 +52,10 @@ export const READ_ONLY_TOOL_NAMES: ReadonlySet<string> = new Set<string>([
   "dbt_compile_model",
   "dbt_get_run",
   "dbt_show",
-  // dbt git reads (status + branch listing never mutate the repo)
+  // dbt git reads (status + branch listing/compare never mutate the repo)
   "dbt_git_status",
   "dbt_list_branches",
+  "dbt_compare_branches",
   "dbt_list_recoverable_files",
   // Surface-scoped data-source reads (apps + dashboards, local DuckDB only)
   "list_data_sources",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The agent's git surface can list and delete branches but cannot answer "does branch X differ from dev?". During branch cleanup it had to tell the user to check GitHub's branch list manually — and worse, ahead/behind counts alone can't tell whether a squash-merged branch is safe to delete.

## Solution

New read-only `dbt_compare_branches` server tool, layered like the existing git tools:

- `compareRefs()` in `api/src/integrations/github/github-api.ts` — GitHub `base...head` three-dot compare (ahead/behind, commits, files). `listPullRequests()` gains an optional `head` filter and the PR summary now carries `mergedAt`.
- `compareProjectRefs()` in `api/src/dbt/dbt-github-git.service.ts` — pure GitHub read (no git lock), defaults base to the repo default branch, and computes `fullyMergedIntoBase`: true when `aheadBy === 0` (regular merge) **or** a PR from the branch into the base was merged after the branch's last commit (squash/rebase merges keep `aheadBy > 0` even though the content landed).
- `dbt_compare_branches` tool in `api/src/agent-lib/tools/dbt-tools.ts` — head defaults to the user's checkout; output caps commits (20) and files (100) and includes a plain-language `hint` spelling out the verdict (the squash-merge case is easy to misread).

Registered in the transform-mode tool list, read-only tool list (plan gate), client tool manifest (UI label), both git prompts, and the dbt skill. `dbt_delete_branch`'s description now points at the compare tool.

The fake GitHub server (`api/src/dbt/test-support/fake-github-server.mjs`) gained `/compare/` and `GET /pulls` (with `head`/`state` filters) endpoints; its PR merge honors `merge_method` (squash keeps one parent so compare still reports the branch "ahead" — the exact case the merged-PR fallback detects).

## Demo

Agent chat in the Transforms IDE, asked to decide which of three branches are safe to delete vs `main` — it compares all three and correctly flags the squash-merged branch as safe and the WIP branch as unmerged:

[dbt_compare_branches_chat_demo.mp4](https://cursor.com/agents/bc-afb0281d-9ce8-4aa0-a130-e7ba847f7a58/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdbt_compare_branches_chat_demo.mp4)

[Per-branch verdicts in chat](https://cursor.com/agents/bc-afb0281d-9ce8-4aa0-a130-e7ba847f7a58/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_agent_branch_cleanup_verdicts.webp)

## Testing

- `github-api.compare.test.ts` — REST payload mapping, ref encoding, head filter, `mergedAt`.
- `dbt-github-git.compare.test.ts` — verdict matrix: regular merge, squash merge, commits pushed after merge, PR into a different base, unmerged WIP branch, default-base resolution.
- Full `test:dbt` suite, api/app/agent-tools lint + typecheck + build all green.
- Manual E2E on the VM against the fake GitHub server: harness exercising the real tool path (squash-merged → `fullyMergedIntoBase: true`, WIP → `false`, merge-commit → `aheadBy: 0`), then GUI chat test (video above).


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afb0281d-9ce8-4aa0-a130-e7ba847f7a58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afb0281d-9ce8-4aa0-a130-e7ba847f7a58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

