### PR TITLE
Allow claiming/releasing dbt personal environments from settings UI

### DIFF
--- a/api/src/routes/dbt.routes.ts
+++ b/api/src/routes/dbt.routes.ts
@@ -229,9 +229,10 @@ const environmentSchema = z.object({
   threads: z.number().int().min(1).max(16).default(4),
   vars: z.record(z.string(), z.unknown()).optional(),
   /**
-   * Personal environment owner (auto-provisioned per-developer target).
-   * Round-tripped by settings saves so admin edits never strip ownership;
-   * provisioning happens via POST .../environments/personal, not here.
+   * Personal environment owner (per-developer target). Auto-provisioned via
+   * POST .../environments/personal, and editable from environment settings
+   * (claim/release). Round-tripped by settings saves so admin edits never
+   * strip ownership.
    */
   ownerUserId: z.string().optional(),
 });
@@ -308,6 +309,40 @@ const patchProjectSchema = z.object({
    */
   repoBranch: z.string().min(1).max(255).optional(),
 });
+
+/**
+ * Personal environments are per-user build targets: at most one per user, and
+ * never the shared default or the production (defer target) environment —
+ * both are resolved for OTHER users too, so pointing them at a private
+ * schema would leak one developer's scratch data into everyone's builds.
+ */
+function validatePersonalEnvironments(
+  environments: Array<{ name: string; ownerUserId?: string }>,
+  defaultEnvironment: string | undefined,
+  prodEnvironment: string | undefined,
+): string | null {
+  const ownedNames = new Map<string, string>();
+  for (const env of environments) {
+    if (!env.ownerUserId) continue;
+    const prior = ownedNames.get(env.ownerUserId);
+    if (prior) {
+      return (
+        `"${prior}" and "${env.name}" are personal environments of the ` +
+        `same user — each user can own only one per project`
+      );
+    }
+    ownedNames.set(env.ownerUserId, env.name);
+  }
+  const isPersonal = (name: string | undefined) =>
+    Boolean(name) && environments.some(e => e.name === name && e.ownerUserId);
+  if (isPersonal(defaultEnvironment)) {
+    return `Default environment "${defaultEnvironment}" cannot be a personal environment`;
+  }
+  if (isPersonal(prodEnvironment)) {
+    return `Production environment "${prodEnvironment}" cannot be a personal environment`;
+  }
+  return null;
+}
 
 async function validateEnvironments(
   workspaceId: string,
@@ -399,6 +434,12 @@ dbtRoutes.post("/projects", async (c: AuthenticatedContext) => {
     }
     const envError = await validateEnvironments(workspaceId, body.environments);
     if (envError) return badRequest(c, envError);
+    const personalError = validatePersonalEnvironments(
+      body.environments,
+      body.defaultEnvironment,
+      undefined,
+    );
+    if (personalError) return badRequest(c, personalError);
 
     const userId = getUserId(c);
     const project = await DbtProject.create({
@@ -516,6 +557,14 @@ dbtRoutes.patch("/projects/:projectId", async (c: AuthenticatedContext) => {
         }
         project.prodEnvironment = body.prodEnvironment;
       }
+    }
+    {
+      const personalError = validatePersonalEnvironments(
+        project.environments,
+        project.defaultEnvironment,
+        project.prodEnvironment,
+      );
+      if (personalError) return badRequest(c, personalError);
     }
     if (body.ci) {
       if (
@@ -932,6 +981,12 @@ dbtRoutes.post("/projects/import-github", async (c: AuthenticatedContext) => {
     }
     const envError = await validateEnvironments(workspaceId, body.environments);
     if (envError) return badRequest(c, envError);
+    const personalError = validatePersonalEnvironments(
+      body.environments,
+      body.defaultEnvironment,
+      undefined,
+    );
+    if (personalError) return badRequest(c, personalError);
 
     // SECURITY: never mint an installation token for an installation that is
     // not bound to THIS workspace — otherwise an admin could read any private

--- a/app/src/components/DbtProjectSettingsDrawer.tsx
+++ b/app/src/components/DbtProjectSettingsDrawer.tsx
@@ -412,6 +412,18 @@ export default function DbtProjectSettingsDrawer({
       setEnvModalError(error);
       return;
     }
+    if (normalized.ownerUserId) {
+      const existingEnvs = isEditing ? editEnvs : (project?.environments ?? []);
+      const owned = existingEnvs.find(
+        e => e.ownerUserId === normalized.ownerUserId,
+      );
+      if (owned) {
+        setEnvModalError(
+          `You already own the personal environment "${owned.name}" — each user can own only one per project.`,
+        );
+        return;
+      }
+    }
 
     if (isEditing) {
       setEditEnvs(prev => [...prev, normalized]);
@@ -518,6 +530,26 @@ export default function DbtProjectSettingsDrawer({
     }
     if (editProdEnv && !editEnvs.some(e => e.name.trim() === editProdEnv)) {
       return "Production environment must match one of the environment names.";
+    }
+    // Personal (owned) environments are per-user build targets: at most one
+    // per user, and never the shared default / production environment.
+    const ownedNames = new Map<string, string>();
+    for (const env of editEnvs) {
+      if (!env.ownerUserId) continue;
+      const prior = ownedNames.get(env.ownerUserId);
+      if (prior) {
+        return `"${prior}" and "${env.name.trim()}" are personal environments of the same user — each user can own only one.`;
+      }
+      ownedNames.set(env.ownerUserId, env.name.trim());
+    }
+    if (editEnvs.find(e => e.name.trim() === editDefaultEnv)?.ownerUserId) {
+      return "The default environment cannot be a personal environment.";
+    }
+    if (
+      editProdEnv &&
+      editEnvs.find(e => e.name.trim() === editProdEnv)?.ownerUserId
+    ) {
+      return "The production environment cannot be a personal environment.";
     }
     for (const env of editEnvs) {
       if (!env.connectionId) return `Connection is required for "${env.name}".`;
@@ -720,6 +752,36 @@ export default function DbtProjectSettingsDrawer({
           inputProps={{ min: 1, max: 32 }}
           sx={{ mb: 1.5 }}
         />
+        <FormControl fullWidth size="small" sx={{ mb: 1.5 }}>
+          <InputLabel id={`dbt-settings-owner-${index}`}>Ownership</InputLabel>
+          <Select
+            labelId={`dbt-settings-owner-${index}`}
+            label="Ownership"
+            value={env.ownerUserId ?? ""}
+            onChange={e =>
+              updateEditEnv(index, { ownerUserId: e.target.value || undefined })
+            }
+          >
+            <MenuItem value="">Shared — whole team</MenuItem>
+            {user?.id && (
+              <MenuItem value={user.id}>Personal — only me</MenuItem>
+            )}
+            {env.ownerUserId && env.ownerUserId !== user?.id && (
+              <MenuItem value={env.ownerUserId}>
+                Personal — another user
+              </MenuItem>
+            )}
+          </Select>
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ mt: 0.5, display: "block" }}
+          >
+            Personal environments become the owner&apos;s default build target
+            and are hidden from teammates&apos; pickers. They can&apos;t be the
+            project default or the production environment.
+          </Typography>
+        </FormControl>
 
         <Typography
           variant="caption"
@@ -897,6 +959,16 @@ export default function DbtProjectSettingsDrawer({
               <ReadOnlyField
                 label="Threads"
                 value={String(selectedEnv.threads)}
+              />
+              <ReadOnlyField
+                label="Ownership"
+                value={
+                  selectedEnv.ownerUserId
+                    ? selectedEnv.ownerUserId === user?.id
+                      ? "Personal — only me"
+                      : "Personal — another user"
+                    : "Shared — whole team"
+                }
               />
               <Box sx={{ mb: 1.5 }}>
                 <Typography
@@ -1438,6 +1510,26 @@ export default function DbtProjectSettingsDrawer({
                 inputProps={{ min: 1, max: 32 }}
                 sx={{ mb: 1.5 }}
               />
+              <FormControl fullWidth size="small" sx={{ mb: 1.5 }}>
+                <InputLabel id="dbt-env-modal-owner">Ownership</InputLabel>
+                <Select
+                  labelId="dbt-env-modal-owner"
+                  label="Ownership"
+                  value={envModalDraft.ownerUserId ?? ""}
+                  onChange={e =>
+                    setEnvModalDraft(prev =>
+                      prev
+                        ? { ...prev, ownerUserId: e.target.value || undefined }
+                        : prev,
+                    )
+                  }
+                >
+                  <MenuItem value="">Shared — whole team</MenuItem>
+                  {user?.id && (
+                    <MenuItem value={user.id}>Personal — only me</MenuItem>
+                  )}
+                </Select>
+              </FormControl>
               <Typography
                 variant="caption"
                 color="text.secondary"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Personal dbt environments (`ownerUserId`) could only be created by the auto-provisioner or `POST .../environments/personal` — the settings UI showed the `personal` chip but offered no way to claim an existing environment as personal or release one back to shared. This PR exposes ownership as an editable field.

### App (`DbtProjectSettingsDrawer.tsx`)

- New **Ownership** select in the environment editor (edit mode + compact single-env edit): `Shared — whole team` / `Personal — only me` (and a `Personal — another user` option shown only when the env is owned by someone else, so admins can release it).
- Same Ownership select in the **Add environment** modal.
- Read-only environment detail view now shows an **Ownership** field.
- Client-side validation on save: at most one personal env per user, and the default / production (defer target) environment cannot be personal.

### API (`dbt.routes.ts`)

- New `validatePersonalEnvironments` guard wired into project create, PATCH, and GitHub import: rejects duplicate owners and personal default/prod environments (previously the API round-tripped `ownerUserId` with no validation).

## Demo

[dbt_env_ownership_claim_guard_release.mp4](https://cursor.com/agents/bc-f626a526-665a-432f-a50e-bef7e028f88e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdbt_env_ownership_claim_guard_release.mp4)

Claiming `jonas` as personal (chip appears), the one-personal-env-per-user guard blocking a second claim, and releasing back to shared.

[jonas env with personal chip after claiming](https://cursor.com/agents/bc-f626a526-665a-432f-a50e-bef7e028f88e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_jonas_personal_chip.webp)
[validation error when a user tries to own two personal envs](https://cursor.com/agents/bc-f626a526-665a-432f-a50e-bef7e028f88e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_one_personal_per_user_error.webp)

## Testing

- ✅ `pnpm --filter app run typecheck`
- ✅ `pnpm --filter app run lint`
- ✅ `pnpm --filter api run lint`
- ✅ `pnpm --filter api run test:dbt` (221 passed, 2 skipped)
- ✅ Manual GUI test (video above): claim → chip appears; guard error; release → chip gone.
- ✅ Server-side guards curl-tested directly against `PATCH /api/workspaces/:ws/dbt/projects/:id` (bypassing client validation): personal default env → 400, two envs same owner → 400, personal prod env → 400, valid claim/release → 200.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f626a526-665a-432f-a50e-bef7e028f88e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f626a526-665a-432f-a50e-bef7e028f88e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

