### PR TITLE
fix(apps): "Rebuild preview" button was a no-op when code was unchanged

### DIFF
--- a/app/src/components/AppRenderer.tsx
+++ b/app/src/components/AppRenderer.tsx
@@ -475,9 +475,12 @@ export default function AppRenderer({
   }, [appEntity?._id, previewNonce]);
 
   // Every new srcdoc boots from scratch (deps re-import, Babel re-transpiles).
+  // Keyed on the nonce (not just the srcdoc string): a manual "Rebuild
+  // preview" with unchanged code regenerates an identical string, which
+  // Object.is-equal deps would ignore.
   useEffect(() => {
     if (srcDoc) setBooting(true);
-  }, [srcDoc]);
+  }, [srcDoc, previewNonce]);
 
   if (!appEntity) {
     return (
@@ -706,6 +709,10 @@ export default function AppRenderer({
         }}
       >
         <iframe
+          // Keyed on the nonce so "Rebuild preview" always reboots: with
+          // unchanged code the regenerated srcDoc string is identical, so a
+          // srcdoc-prop update alone would be skipped by React entirely.
+          key={previewNonce}
           ref={iframeRef}
           title={`app-preview-${appId}`}
           data-mako-app-preview={appId}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Clicking the refresh ("Rebuild preview") button on an app tab did nothing. `bumpPreview` incremented `previewNonce`, but with unchanged files/deps `buildPreviewHtml` regenerated a byte-identical `srcDoc` string — React sees an equal `srcdoc` prop and skips the DOM update entirely, so the iframe never reboots and no "Building preview…" overlay ever shows.

## Fix

In `AppRenderer.tsx`:

- Key the preview `<iframe>` on `previewNonce`, so every rebuild remounts the iframe and reboots the sandbox even when the generated srcdoc string is identical.
- Add `previewNonce` to the `setBooting(true)` effect deps, so the "Building preview…" overlay shows during nonce-only rebuilds too.

This also covers all other `bumpPreview` callers (file writes, dependency changes, binding edits) — those already changed the srcdoc string, and remounting on nonce is what the srcdoc rebuild always intended.

## Testing

Reproduced the no-op before the fix, verified after: clicking "Rebuild preview" now shows the "Building preview…" overlay and the sandbox reboots and re-renders.

[rebuild_preview_button_working.mp4](https://cursor.com/agents/bc-b38a4a5a-5a0d-48c6-9aa0-bdc6a90a0ea0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frebuild_preview_button_working.mp4)

Before fix (click did nothing):
[Before fix — no response to click](https://cursor.com/agents/bc-b38a4a5a-5a0d-48c6-9aa0-bdc6a90a0ea0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_before_fix_no_response.webp)

After fix (overlay during rebuild):
[After fix — Building preview overlay](https://cursor.com/agents/bc-b38a4a5a-5a0d-48c6-9aa0-bdc6a90a0ea0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_building_preview_overlay_after_fix.webp)

- ✅ `pnpm --filter app run typecheck`
- ✅ `pnpm --filter app run lint`
- ✅ `pnpm --filter app run test:unit` (289 passed)
- ✅ Manual end-to-end test via browser (video above)

Note: the explorer-panel refresh button (list refetch) was also checked — it works correctly (it refetches the app list; with an unchanged list there is simply nothing visible to update). The actionable bug was the preview toolbar button fixed here.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b38a4a5a-5a0d-48c6-9aa0-bdc6a90a0ea0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b38a4a5a-5a0d-48c6-9aa0-bdc6a90a0ea0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

