### PR TITLE
Add persistent per-app storage (useStorage) for user-editable values in apps

### DIFF
--- a/api/src/agent-skills/apps/SKILL.md
+++ b/api/src/agent-skills/apps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: apps
-description: Load when building, editing, or debugging Mako React apps — app files, npm dependencies, data bindings, the @mako/app-sdk hooks (useQuery / useDuckDB / useLocation / useSearchParams / navigate), URL state and shareable deep links, materialized Parquet/DuckDB bindings, and the live preview runtime.
+description: Load when building, editing, or debugging Mako React apps — app files, npm dependencies, data bindings, the @mako/app-sdk hooks (useQuery / useDuckDB / useStorage / useLocation / useSearchParams / navigate), URL state and shareable deep links, persistent app storage for user-editable values (targets, notes, overrides), materialized Parquet/DuckDB bindings, and the live preview runtime.
 entities:
   - app
   - apps
@@ -11,6 +11,10 @@ entities:
   - app-sdk
   - usequery
   - useduckdb
+  - usestorage
+  - storage
+  - targets
+  - edit in place
   - uselocation
   - usesearchparams
   - navigate
@@ -293,6 +297,36 @@ Guidance: reach for this whenever the app has tabs, filters, or master→detail
 navigation a user would expect to bookmark or share. Use distinct **paths** for
 separate views (`/`, `/customers/42`) and **query params** for filters/sort within a
 view. Hashes (`#…`) are not carried across the bridge — keep state in the path/query.
+
+### Persistent app storage (user-editable values)
+
+For values users EDIT in the app UI — per-entity targets, notes, manual
+overrides, checklist state — use the persistent key-value storage hook. Data is
+stored server-side per app (MongoDB, independent of the app definition), shared
+by everyone who uses the app, and survives reloads, publishes, and restores. Do
+NOT use it for view state (URL hooks) or for caching query data (bindings).
+
+```tsx
+import { useStorage } from "@mako/app-sdk";
+
+const { value: targets, setValue, loading, saving, error, readOnly } =
+  useStorage("csm-targets", {} as Record<string, number>);
+
+// Optimistic write-through; functional updates are supported.
+setValue(prev => ({ ...prev, [repId]: newTarget }));
+```
+
+- `value` is the stored JSON (any shape) or `defaultValue` while unset.
+- Writes need workspace access: anyone who can open the app in Mako can edit.
+  Public share viewers (`/share/:token`) get `readOnly: true` and writes fail —
+  hide or disable edit affordances when `readOnly` is set.
+- Values sync live across users and windows (realtime poke → refetch).
+- Prefer ONE key per logical document (e.g. a `{ id → number }` map under
+  `"csm-targets"`) over hundreds of tiny keys; a value can hold up to 256 KB of
+  JSON, max 500 keys per app.
+- Typical edit-in-place pattern: render the stored value; on click swap in an
+  `<input>` seeded with it; on blur/Enter call `setValue`; show a subtle
+  "Saving…" indicator while `saving` is true and surface `error` readably.
 
 ### Constraints
 

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -4100,6 +4100,54 @@ MakoAppSchema.index({ "publicShare.token": 1 }, { unique: true, sparse: true });
 export const MakoApp = mongoose.model<IMakoApp>("MakoApp", MakoAppSchema);
 
 /**
+ * MakoAppStorageEntry — per-app key-value storage for RUNTIME app data (user
+ * inputs like targets, notes, manual overrides). Written by app code through
+ * the `useStorage` hook in `@mako/app-sdk`; independent of the app definition
+ * and its draft/published split, so values survive publishes and restores.
+ *
+ * Values are arbitrary JSON documents, shared by everyone who uses the app
+ * (workspace-visible data, not per-user preferences).
+ */
+export interface IMakoAppStorageEntry extends Document {
+  _id: Types.ObjectId;
+  workspaceId: Types.ObjectId;
+  appId: Types.ObjectId;
+  key: string;
+  value: unknown;
+  updatedBy?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const MakoAppStorageEntrySchema = new Schema<IMakoAppStorageEntry>(
+  {
+    workspaceId: {
+      type: Schema.Types.ObjectId,
+      ref: "Workspace",
+      required: true,
+      index: true,
+    },
+    appId: {
+      type: Schema.Types.ObjectId,
+      ref: "MakoApp",
+      required: true,
+      index: true,
+    },
+    key: { type: String, required: true },
+    value: { type: Schema.Types.Mixed, default: null },
+    updatedBy: { type: String },
+  },
+  { timestamps: true, collection: "makoapp_storage" },
+);
+
+MakoAppStorageEntrySchema.index({ appId: 1, key: 1 }, { unique: true });
+
+export const MakoAppStorageEntry = mongoose.model<IMakoAppStorageEntry>(
+  "MakoAppStorageEntry",
+  MakoAppStorageEntrySchema,
+);
+
+/**
  * Skill — workspace-scoped knowledge + procedure primitive.
  *
  * See GitHub issue #365. A skill is a named, conditional playbook with:

--- a/api/src/routes/apps.ts
+++ b/api/src/routes/apps.ts
@@ -15,6 +15,7 @@ import { Readable } from "node:stream";
 import { nanoid } from "nanoid";
 import {
   MakoApp,
+  MakoAppStorageEntry,
   DatabaseConnection,
   DbtProject,
   EntityVersion,
@@ -725,6 +726,9 @@ app.openapi(
       }
 
       await doc.deleteOne();
+      await MakoAppStorageEntry.deleteMany({ appId: doc._id }).catch(
+        () => undefined,
+      );
       return c.json({ success: true });
     } catch (error) {
       logger.error("Error deleting app", { error });
@@ -919,6 +923,263 @@ app.openapi(
     } catch (error) {
       logger.error("Error serving app binding artifact", { error });
       return c.json({ success: false, error: "Failed to serve artifact" }, 500);
+    }
+  },
+);
+
+// ── App storage (runtime key-value data) ──
+//
+// Per-app KV store for data the RUNNING app persists (user inputs like
+// per-CSM targets, notes, manual overrides) via the `useStorage` SDK hook.
+// Values live in their own collection (`makoapp_storage`), independent of the
+// app definition — publishing, restoring, or editing the app never touches
+// them. Anyone who can READ the app can read and write storage: storage
+// writes are "using the app" (filling in a form), not "editing the app".
+// Public (anonymous) share viewers get read-only access via /api/share.
+
+/** Storage keys: sane identifier charset, bounded length. */
+const STORAGE_KEY_RE = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,199}$/;
+/** Serialized JSON size cap per value (256 KB). */
+const STORAGE_VALUE_MAX_BYTES = 256 * 1024;
+/** Max distinct keys per app. */
+const STORAGE_MAX_KEYS = 500;
+
+const StorageKeyParam = AppIdParam.extend({
+  key: z.string().openapi({ param: { name: "key", in: "path" } }),
+});
+
+// GET /{id}/storage — every entry for the app, as { key: value }
+app.openapi(
+  createRoute({
+    method: "get",
+    path: "/{id}/storage",
+    tags: ["Apps"],
+    summary: "List app storage entries",
+    security: AUTH_SECURITY,
+    request: { params: AppIdParam },
+    responses: { ...OPEN_RESPONSES },
+  }),
+  async c => {
+    try {
+      const workspaceId = c.req.param("workspaceId") as string;
+      const id = c.req.param("id");
+      const userId = c.get("user")?.id;
+      if (!Types.ObjectId.isValid(id)) {
+        return c.json({ success: false, error: "Invalid app ID" }, 400);
+      }
+      const doc = await MakoApp.findOne({
+        _id: new Types.ObjectId(id),
+        workspaceId: new Types.ObjectId(workspaceId),
+      });
+      if (!doc) return c.json({ success: false, error: "App not found" }, 404);
+      if (!canRead(doc, userId, c.get("memberRole"))) {
+        return c.json({ success: false, error: "Access denied" }, 403);
+      }
+
+      const entries = await MakoAppStorageEntry.find({
+        appId: doc._id,
+      }).lean();
+      const values: Record<string, unknown> = {};
+      for (const entry of entries) values[entry.key] = entry.value;
+      return c.json({ success: true, values });
+    } catch (error) {
+      logger.error("Error listing app storage", { error });
+      return c.json({ success: false, error: "Failed to load storage" }, 500);
+    }
+  },
+);
+
+// GET /{id}/storage/{key} — one entry
+app.openapi(
+  createRoute({
+    method: "get",
+    path: "/{id}/storage/{key}",
+    tags: ["Apps"],
+    summary: "Get an app storage entry",
+    security: AUTH_SECURITY,
+    request: { params: StorageKeyParam },
+    responses: { ...OPEN_RESPONSES },
+  }),
+  async c => {
+    try {
+      const workspaceId = c.req.param("workspaceId") as string;
+      const id = c.req.param("id");
+      const key = c.req.param("key");
+      const userId = c.get("user")?.id;
+      if (!Types.ObjectId.isValid(id)) {
+        return c.json({ success: false, error: "Invalid app ID" }, 400);
+      }
+      const doc = await MakoApp.findOne({
+        _id: new Types.ObjectId(id),
+        workspaceId: new Types.ObjectId(workspaceId),
+      });
+      if (!doc) return c.json({ success: false, error: "App not found" }, 404);
+      if (!canRead(doc, userId, c.get("memberRole"))) {
+        return c.json({ success: false, error: "Access denied" }, 403);
+      }
+
+      const entry = await MakoAppStorageEntry.findOne({
+        appId: doc._id,
+        key,
+      }).lean();
+      return c.json({
+        success: true,
+        key,
+        value: entry ? entry.value : null,
+        exists: !!entry,
+        updatedAt: entry?.updatedAt,
+        updatedBy: entry?.updatedBy,
+      });
+    } catch (error) {
+      logger.error("Error reading app storage entry", { error });
+      return c.json({ success: false, error: "Failed to read storage" }, 500);
+    }
+  },
+);
+
+// PUT /{id}/storage/{key} — upsert one entry ({ value: <json> })
+app.openapi(
+  createRoute({
+    method: "put",
+    path: "/{id}/storage/{key}",
+    tags: ["Apps"],
+    summary: "Set an app storage entry",
+    security: AUTH_SECURITY,
+    request: { params: StorageKeyParam, body: AppBody },
+    responses: { ...OPEN_RESPONSES },
+  }),
+  async c => {
+    try {
+      const workspaceId = c.req.param("workspaceId") as string;
+      const id = c.req.param("id");
+      const key = c.req.param("key");
+      const userId = c.get("user")?.id;
+      if (!Types.ObjectId.isValid(id)) {
+        return c.json({ success: false, error: "Invalid app ID" }, 400);
+      }
+      if (!STORAGE_KEY_RE.test(key)) {
+        return c.json(
+          {
+            success: false,
+            error:
+              "Invalid storage key: use letters, digits, '.', '_', ':' or '-' (max 200 chars)",
+          },
+          400,
+        );
+      }
+      const doc = await MakoApp.findOne({
+        _id: new Types.ObjectId(id),
+        workspaceId: new Types.ObjectId(workspaceId),
+      });
+      if (!doc) return c.json({ success: false, error: "App not found" }, 404);
+      // Read access is enough: writing storage is USING the app (submitting a
+      // form the app renders), not editing its definition.
+      if (!canRead(doc, userId, c.get("memberRole"))) {
+        return c.json({ success: false, error: "Access denied" }, 403);
+      }
+
+      const body = (await c.req.json().catch(() => null)) as {
+        value?: unknown;
+      } | null;
+      if (!body || !("value" in body)) {
+        return c.json(
+          { success: false, error: "Body must be { value: <json> }" },
+          400,
+        );
+      }
+      const serialized = JSON.stringify(body.value ?? null);
+      if (serialized.length > STORAGE_VALUE_MAX_BYTES) {
+        return c.json(
+          {
+            success: false,
+            error: `Value too large (max ${STORAGE_VALUE_MAX_BYTES / 1024} KB)`,
+          },
+          400,
+        );
+      }
+
+      const existing = await MakoAppStorageEntry.exists({
+        appId: doc._id,
+        key,
+      });
+      if (!existing) {
+        const count = await MakoAppStorageEntry.countDocuments({
+          appId: doc._id,
+        });
+        if (count >= STORAGE_MAX_KEYS) {
+          return c.json(
+            {
+              success: false,
+              error: `Storage limit reached (max ${STORAGE_MAX_KEYS} keys per app)`,
+            },
+            400,
+          );
+        }
+      }
+
+      const entry = await MakoAppStorageEntry.findOneAndUpdate(
+        { appId: doc._id, key },
+        {
+          $set: { value: body.value ?? null, updatedBy: userId },
+          $setOnInsert: { workspaceId: doc.workspaceId },
+        },
+        { new: true, upsert: true },
+      );
+
+      publishRealtimeEvent(workspaceId, {
+        type: "app.storage.updated",
+        appId: doc._id.toString(),
+        key,
+        updatedBy: userId ?? "system",
+      });
+
+      return c.json({
+        success: true,
+        key,
+        value: entry.value,
+        updatedAt: entry.updatedAt,
+      });
+    } catch (error) {
+      logger.error("Error writing app storage entry", { error });
+      return c.json({ success: false, error: "Failed to write storage" }, 500);
+    }
+  },
+);
+
+// DELETE /{id}/storage/{key} — remove one entry
+app.openapi(
+  createRoute({
+    method: "delete",
+    path: "/{id}/storage/{key}",
+    tags: ["Apps"],
+    summary: "Delete an app storage entry",
+    security: AUTH_SECURITY,
+    request: { params: StorageKeyParam },
+    responses: { ...OPEN_RESPONSES },
+  }),
+  async c => {
+    try {
+      const workspaceId = c.req.param("workspaceId") as string;
+      const id = c.req.param("id");
+      const key = c.req.param("key");
+      const userId = c.get("user")?.id;
+      if (!Types.ObjectId.isValid(id)) {
+        return c.json({ success: false, error: "Invalid app ID" }, 400);
+      }
+      const doc = await MakoApp.findOne({
+        _id: new Types.ObjectId(id),
+        workspaceId: new Types.ObjectId(workspaceId),
+      });
+      if (!doc) return c.json({ success: false, error: "App not found" }, 404);
+      if (!canRead(doc, userId, c.get("memberRole"))) {
+        return c.json({ success: false, error: "Access denied" }, 403);
+      }
+
+      await MakoAppStorageEntry.deleteOne({ appId: doc._id, key });
+      return c.json({ success: true, key });
+    } catch (error) {
+      logger.error("Error deleting app storage entry", { error });
+      return c.json({ success: false, error: "Failed to delete storage" }, 500);
     }
   },
 );

--- a/api/src/routes/public-share.ts
+++ b/api/src/routes/public-share.ts
@@ -23,6 +23,7 @@ import { OPEN_RESPONSES, createRouter } from "../openapi/core";
 import {
   Dashboard,
   MakoApp,
+  MakoAppStorageEntry,
   type IDashboard,
   type IMakoApp,
 } from "../database/workspace-schema";
@@ -519,6 +520,51 @@ app.openapi(
     } catch (error) {
       logger.error("Error streaming share artifact", { error });
       return c.json({ success: false, error: "Failed to serve artifact" }, 500);
+    }
+  },
+);
+
+// GET /:token/storage — read-only app storage (post-unlock).
+// Apps only. Anonymous viewers can READ runtime values the app persisted
+// (targets, notes, …) so the shared view renders complete; writes are only
+// possible for authenticated workspace users via /api/workspaces/.../storage.
+app.openapi(
+  createRoute({
+    method: "get",
+    path: "/{token}/storage",
+    tags: ["Public Shares"],
+    summary: "Read a shared app's storage values",
+    security: [],
+    request: { params: TokenParam },
+    responses: { ...OPEN_RESPONSES },
+  }),
+  async c => {
+    try {
+      const token = c.req.param("token");
+      const resource = await findByToken(token);
+      if (!resource) {
+        return c.json({ success: false, error: "Share link not found" }, 404);
+      }
+      if (resource.type !== "app") {
+        return c.json(
+          { success: false, error: "Storage is only supported for apps" },
+          400,
+        );
+      }
+      const gate = requireUnlock(c, token, resource);
+      if (gate) return gate;
+
+      const entries = await MakoAppStorageEntry.find({
+        appId: resource.doc._id,
+      }).lean();
+      const values: Record<string, unknown> = {};
+      for (const entry of entries) values[entry.key] = entry.value;
+      return c.json({ success: true, values }, 200, {
+        "Cache-Control": "private, no-store",
+      });
+    } catch (error) {
+      logger.error("Error reading public app storage", { error });
+      return c.json({ success: false, error: "Failed to load storage" }, 500);
     }
   },
 );

--- a/api/src/services/realtime.service.ts
+++ b/api/src/services/realtime.service.ts
@@ -73,6 +73,14 @@ export type RealtimeEvent =
       clientId?: string;
       origin: "agent" | "save";
     }
+  // A runtime storage value changed (useStorage SDK hook). Open previews of
+  // the same app refetch the key so collaborating editors stay in sync.
+  | {
+      type: "app.storage.updated";
+      appId: string;
+      key: string;
+      updatedBy: string;
+    }
   | {
       type: "dbt.file.updated";
       projectId: string;

--- a/app/src/api/schema.d.ts
+++ b/app/src/api/schema.d.ts
@@ -3095,6 +3095,42 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/workspaces/{workspaceId}/apps/{id}/storage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List app storage entries */
+        get: operations["get_api_workspaces_workspaceId_apps_id_storage"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspaces/{workspaceId}/apps/{id}/storage/{key}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get an app storage entry */
+        get: operations["get_api_workspaces_workspaceId_apps_id_storage_key"];
+        /** Set an app storage entry */
+        put: operations["put_api_workspaces_workspaceId_apps_id_storage_key"];
+        post?: never;
+        /** Delete an app storage entry */
+        delete: operations["delete_api_workspaces_workspaceId_apps_id_storage_key"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/workspaces/{workspaceId}/apps/{id}/versions": {
         parameters: {
             query?: never;
@@ -3534,6 +3570,23 @@ export interface paths {
         };
         /** Stream a share snapshot artifact */
         get: operations["get_api_share_token_artifacts_artifactId"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/share/{token}/storage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Read a shared app's storage values */
+        get: operations["get_api_share_token_storage"];
         put?: never;
         post?: never;
         delete?: never;
@@ -14709,6 +14762,179 @@ export interface operations {
             };
         };
     };
+    get_api_workspaces_workspaceId_apps_id_storage: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    get_api_workspaces_workspaceId_apps_id_storage_key: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+                id: string;
+                key: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    put_api_workspaces_workspaceId_apps_id_storage_key: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+                id: string;
+                key: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    [key: string]: unknown;
+                };
+            };
+        };
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    delete_api_workspaces_workspaceId_apps_id_storage_key: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+                id: string;
+                key: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
     get_api_workspaces_workspaceId_apps_id_versions: {
         parameters: {
             query?: {
@@ -16065,6 +16291,46 @@ export interface operations {
                 };
                 content: {
                     "application/vnd.apache.parquet": string;
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    get_api_share_token_storage: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
                 };
             };
             /** @description Invalid request */

--- a/app/src/app-runtime/preview.ts
+++ b/app/src/app-runtime/preview.ts
@@ -33,6 +33,13 @@ export const PREVIEW_MESSAGE = {
   // parquet snapshots in the parent's DuckDB). The booted app re-runs its data
   // hooks without a srcdoc rebuild, so the view updates while keeping UI state.
   dataRefresh: "mako-app:data-refresh",
+  // iframe -> host: read/write a persistent app storage value (useStorage).
+  storageGet: "mako-app:storage-get",
+  storageSet: "mako-app:storage-set",
+  storageResult: "mako-app:storage-result",
+  // host -> iframe: a storage value changed outside this frame (another user
+  // or window saved). Hooks bound to that key refetch.
+  storageChanged: "mako-app:storage-changed",
   capture: "mako-app:capture",
   captureResult: "mako-app:capture-result",
   setTheme: "mako-app:set-theme",
@@ -384,7 +391,8 @@ window.addEventListener("message", (event) => {
   const data = event.data || {};
   if (
     (data.type === "mako-app:binding-result" ||
-      data.type === "mako-app:duckdb-result") &&
+      data.type === "mako-app:duckdb-result" ||
+      data.type === "mako-app:storage-result") &&
     pending.has(data.requestId)
   ) {
     const resolve = pending.get(data.requestId);
@@ -423,6 +431,34 @@ function runDuckDb(sql, rowLimit) {
     const requestId = "duck_" + ++reqSeq;
     pending.set(requestId, resolve);
     POST({ type: "mako-app:run-duckdb", requestId, sql: sql, rowLimit: rowLimit });
+  });
+}
+
+// --- Storage bridge: useStorage(key) -> parent app-storage API ---
+const storageListeners = new Set();
+window.addEventListener("message", (event) => {
+  const data = event.data || {};
+  if (data.type !== "mako-app:storage-changed") return;
+  storageListeners.forEach((listener) => {
+    try {
+      listener(data.key);
+    } catch (_) {
+      /* listener errors must not break other subscribers */
+    }
+  });
+});
+function runStorageGet(key) {
+  return new Promise((resolve) => {
+    const requestId = "sto_" + ++reqSeq;
+    pending.set(requestId, resolve);
+    POST({ type: "mako-app:storage-get", requestId, key: key });
+  });
+}
+function runStorageSet(key, value) {
+  return new Promise((resolve) => {
+    const requestId = "sto_" + ++reqSeq;
+    pending.set(requestId, resolve);
+    POST({ type: "mako-app:storage-set", requestId, key: key, value: value });
   });
 }
 function warnTruncated(source, res) {
@@ -578,6 +614,90 @@ async function main() {
         return () => { active = false; };
       }, [sql, rowLimit, epoch]);
       return state;
+    },
+    // Persistent per-app key-value storage, shared by everyone who uses the
+    // app (server-side, survives reloads and publishes). Use it for values
+    // users EDIT in the app UI — targets, notes, manual overrides. Returns
+    // { value, setValue, loading, saving, error, readOnly }:
+    // - value: the stored JSON value, or defaultValue while missing.
+    // - setValue(next): optimistic write-through; accepts a value or an
+    //   updater function (prev => next). No-op in read-only contexts
+    //   (public share links), where readOnly is true.
+    // Values sync live across users/windows via the host realtime channel.
+    useStorage(key, defaultValue) {
+      const defaultRef = React.useRef(defaultValue);
+      defaultRef.current = defaultValue;
+      const [state, setState] = React.useState({
+        value: defaultValue,
+        loading: true,
+        saving: false,
+        error: null,
+        readOnly: false,
+      });
+      const savingRef = React.useRef(0);
+      const refetch = React.useCallback(() => {
+        runStorageGet(key).then((res) => {
+          // A save is in flight: its optimistic value is newer than this read.
+          if (savingRef.current > 0) return;
+          if (res.success) {
+            setState((prev) => ({
+              ...prev,
+              value: res.exists ? res.value : defaultRef.current,
+              loading: false,
+              error: null,
+              readOnly: !!res.readOnly,
+            }));
+          } else {
+            setState((prev) => ({
+              ...prev,
+              loading: false,
+              error: res.error || "Failed to load storage",
+              readOnly: !!res.readOnly,
+            }));
+          }
+        });
+      }, [key]);
+      React.useEffect(() => {
+        setState((prev) => ({ ...prev, loading: true, error: null }));
+        refetch();
+        const listener = (changedKey) => {
+          if (changedKey === key) refetch();
+        };
+        storageListeners.add(listener);
+        return () => { storageListeners.delete(listener); };
+      }, [key, refetch]);
+      const setValue = React.useCallback((next) => {
+        setState((prev) => {
+          const resolved = typeof next === "function" ? next(prev.value) : next;
+          savingRef.current++;
+          runStorageSet(key, resolved).then((res) => {
+            savingRef.current--;
+            if (res.success) {
+              if (savingRef.current === 0) {
+                setState((cur) => ({ ...cur, saving: false, error: null }));
+              }
+            } else {
+              setState((cur) => ({
+                ...cur,
+                saving: savingRef.current > 0,
+                error: res.error || "Failed to save",
+                readOnly: !!res.readOnly || cur.readOnly,
+              }));
+              // Re-sync with the server after a failed optimistic write.
+              if (savingRef.current === 0) refetch();
+            }
+          });
+          return { ...prev, value: resolved, saving: true };
+        });
+      }, [key, refetch]);
+      return {
+        value: state.value,
+        setValue: setValue,
+        loading: state.loading,
+        saving: state.saving,
+        error: state.error,
+        readOnly: state.readOnly,
+      };
     },
     // Effective color mode: { theme: "light" | "dark" }. Tracks the host app
     // theme when embedded in Mako and the OS preference when standalone. Use

--- a/app/src/components/AppRenderer.tsx
+++ b/app/src/components/AppRenderer.tsx
@@ -83,6 +83,9 @@ export default function AppRenderer({
   const bumpPreview = useAppStore(s => s.bumpPreview);
   const setPreviewErrors = useAppStore(s => s.setPreviewErrors);
   const runBinding = useAppStore(s => s.runBinding);
+  const getStorageValue = useAppStore(s => s.getStorageValue);
+  const setStorageValue = useAppStore(s => s.setStorageValue);
+  const storageChangeSignal = useAppStore(s => s.storageChangeSignal[appId]);
   const materializeAllBindings = useAppStore(s => s.materializeAllBindings);
   const persistApp = useAppStore(s => s.persistApp);
   const generateSaveComment = useAppStore(s => s.generateSaveComment);
@@ -395,6 +398,32 @@ export default function AppRenderer({
               error: err instanceof Error ? err.message : "DuckDB query failed",
             }),
           );
+      } else if (data.type === PREVIEW_MESSAGE.storageGet && workspaceId) {
+        void getStorageValue(workspaceId, appId, String(data.key ?? "")).then(
+          result =>
+            post({
+              type: PREVIEW_MESSAGE.storageResult,
+              requestId: data.requestId,
+              success: result.success,
+              value: result.value ?? null,
+              exists: result.exists === true,
+              error: result.error,
+            }),
+        );
+      } else if (data.type === PREVIEW_MESSAGE.storageSet && workspaceId) {
+        void setStorageValue(
+          workspaceId,
+          appId,
+          String(data.key ?? ""),
+          data.value,
+        ).then(result =>
+          post({
+            type: PREVIEW_MESSAGE.storageResult,
+            requestId: data.requestId,
+            success: result.success,
+            error: result.error,
+          }),
+        );
       } else if (data.type === PREVIEW_MESSAGE.navigate) {
         if (typeof data.location === "string") applyAppLocation(data.location);
       } else if (data.type === PREVIEW_MESSAGE.error) {
@@ -419,10 +448,25 @@ export default function AppRenderer({
     workspaceId,
     appEntity,
     runBinding,
+    getStorageValue,
+    setStorageValue,
     setPreviewErrors,
     applyAppLocation,
     dbtOverrideActive,
   ]);
+
+  // A storage value changed in another window/user session (realtime poke):
+  // tell the booted iframe so useStorage hooks bound to that key refetch.
+  useEffect(() => {
+    if (!storageChangeSignal) return;
+    iframeRef.current?.contentWindow?.postMessage(
+      {
+        type: PREVIEW_MESSAGE.storageChanged,
+        key: storageChangeSignal.key,
+      },
+      "*",
+    );
+  }, [storageChangeSignal]);
 
   // Browser back/forward changes the host URL without a reload; mirror the new
   // app location into the tab and push it to the (already-booted) iframe.

--- a/app/src/components/public/PublicAppViewer.tsx
+++ b/app/src/components/public/PublicAppViewer.tsx
@@ -294,6 +294,44 @@ export default function PublicAppViewer({
               error: err instanceof Error ? err.message : "DuckDB query failed",
             }),
           );
+      } else if (data.type === PREVIEW_MESSAGE.storageGet) {
+        // Anonymous viewers read the app's persisted values (targets, notes…)
+        // so the shared view renders complete — but can never write them.
+        void fetch(`/api/share/${token}/storage`, { credentials: "include" })
+          .then(async res => {
+            const json = await res.json().catch(() => null);
+            if (!res.ok || !json?.success) {
+              throw new Error(json?.error || "Failed to load storage");
+            }
+            const values = (json.values ?? {}) as Record<string, unknown>;
+            const key = String(data.key ?? "");
+            post({
+              type: PREVIEW_MESSAGE.storageResult,
+              requestId: data.requestId,
+              success: true,
+              value: key in values ? values[key] : null,
+              exists: key in values,
+              readOnly: true,
+            });
+          })
+          .catch(err =>
+            post({
+              type: PREVIEW_MESSAGE.storageResult,
+              requestId: data.requestId,
+              success: false,
+              error:
+                err instanceof Error ? err.message : "Failed to load storage",
+              readOnly: true,
+            }),
+          );
+      } else if (data.type === PREVIEW_MESSAGE.storageSet) {
+        post({
+          type: PREVIEW_MESSAGE.storageResult,
+          requestId: data.requestId,
+          success: false,
+          error: "Storage is read-only in the shared view",
+          readOnly: true,
+        });
       } else if (data.type === PREVIEW_MESSAGE.navigate) {
         if (typeof data.location === "string") {
           writeAppLocation(data.location, !!data.replace);

--- a/app/src/store/appStore.ts
+++ b/app/src/store/appStore.ts
@@ -136,6 +136,13 @@ interface AppState {
   previewDbtEnv: Record<string, string | null>;
   /** Cached dbt project environments for binding resolution (by projectId). */
   dbtEnvInfo: Record<string, AppDbtEnvInfo>;
+  /**
+   * Per-app signal that a storage value changed remotely (realtime
+   * `app.storage.updated`). AppRenderer watches it and forwards a
+   * storage-changed message into the booted iframe so `useStorage` hooks
+   * bound to that key refetch.
+   */
+  storageChangeSignal: Record<string, { key: string; nonce: number }>;
 }
 
 interface AppActions {
@@ -207,6 +214,29 @@ interface AppActions {
     appId: string,
     bindingName: string,
   ) => Promise<{ success: boolean; rows?: unknown[]; error?: string }>;
+
+  /** Read one app-storage value (runtime KV persisted by `useStorage`). */
+  getStorageValue: (
+    workspaceId: string,
+    appId: string,
+    key: string,
+  ) => Promise<{
+    success: boolean;
+    value?: unknown;
+    exists?: boolean;
+    error?: string;
+  }>;
+
+  /** Upsert one app-storage value. */
+  setStorageValue: (
+    workspaceId: string,
+    appId: string,
+    key: string,
+    value: unknown,
+  ) => Promise<{ success: boolean; error?: string }>;
+
+  /** Realtime poke: a storage key changed in another window/user session. */
+  signalStorageChange: (appId: string, key: string) => void;
 
   /**
    * Switch which dbt environment the app's draft preview reads (per-user view
@@ -284,6 +314,7 @@ const initialState: AppState = {
   previewErrors: {},
   previewDbtEnv: {},
   dbtEnvInfo: {},
+  storageChangeSignal: {},
 };
 
 function genId(): string {
@@ -795,6 +826,72 @@ export const useAppStore = create<AppStore>()(
         };
       }
     },
+
+    getStorageValue: async (workspaceId, appId, key) => {
+      try {
+        const res = unwrapBody(
+          await api.GET(
+            "/api/workspaces/{workspaceId}/apps/{id}/storage/{key}",
+            {
+              params: { path: { workspaceId, id: appId, key } },
+            },
+          ),
+        ) as {
+          success: boolean;
+          value?: unknown;
+          exists?: boolean;
+          error?: string;
+        };
+        if (!res.success) {
+          return {
+            success: false,
+            error: res.error || "Failed to load storage",
+          };
+        }
+        return { success: true, value: res.value, exists: !!res.exists };
+      } catch (e) {
+        return {
+          success: false,
+          error: e instanceof Error ? e.message : "Failed to load storage",
+        };
+      }
+    },
+
+    setStorageValue: async (workspaceId, appId, key, value) => {
+      try {
+        // 400/403 carry a structured error body (validation / permission), so
+        // read the parsed body regardless of HTTP status instead of throwing.
+        const result = await api.PUT(
+          "/api/workspaces/{workspaceId}/apps/{id}/storage/{key}",
+          {
+            params: { path: { workspaceId, id: appId, key } },
+            body: { value },
+          },
+        );
+        const body = (result.data ?? result.error) as {
+          success?: boolean;
+          error?: string;
+        };
+        if (!body?.success) {
+          return { success: false, error: body?.error || "Failed to save" };
+        }
+        return { success: true };
+      } catch (e) {
+        return {
+          success: false,
+          error: e instanceof Error ? e.message : "Failed to save",
+        };
+      }
+    },
+
+    signalStorageChange: (appId, key) =>
+      set(state => {
+        const prev = state.storageChangeSignal[appId];
+        state.storageChangeSignal[appId] = {
+          key,
+          nonce: (prev?.nonce ?? 0) + 1,
+        };
+      }),
 
     materializeBinding: async (workspaceId, appId, bindingId, options) => {
       const signal = options?.signal;

--- a/app/src/store/realtimeStore.ts
+++ b/app/src/store/realtimeStore.ts
@@ -67,6 +67,12 @@ export type RealtimeEvent =
       origin: "agent" | "save";
     }
   | {
+      type: "app.storage.updated";
+      appId: string;
+      key: string;
+      updatedBy: string;
+    }
+  | {
       type: "dbt.file.updated";
       projectId: string;
       path: string;
@@ -565,6 +571,14 @@ export const useRealtimeStore = create<RealtimeStore>()(
           break;
         case "app.updated":
           handleAppUpdated(event);
+          break;
+        case "app.storage.updated":
+          // Only open apps care; the forwarded poke makes their `useStorage`
+          // hooks refetch the changed key (own writes are already optimistic
+          // and guarded by the in-flight save counter in the SDK).
+          if (useAppStore.getState().openApps[event.appId]) {
+            useAppStore.getState().signalStorageChange(event.appId, event.key);
+          }
           break;
         case "dashboard.updated":
           handleDashboardUpdated(event);

--- a/docs/src/openapi/mako-api.json
+++ b/docs/src/openapi/mako-api.json
@@ -19799,6 +19799,345 @@
         "operationId": "get_api_workspaces_workspaceId_apps_id_bindings_bindingId_materialization_artifact"
       }
     },
+    "/api/workspaces/{workspaceId}/apps/{id}/storage": {
+      "get": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "List app storage entries",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get_api_workspaces_workspaceId_apps_id_storage"
+      }
+    },
+    "/api/workspaces/{workspaceId}/apps/{id}/storage/{key}": {
+      "get": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "Get an app storage entry",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "key",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get_api_workspaces_workspaceId_apps_id_storage_key"
+      },
+      "put": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "Set an app storage entry",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "key",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": {}
+              }
+            }
+          }
+        },
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "put_api_workspaces_workspaceId_apps_id_storage_key"
+      },
+      "delete": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "Delete an app storage entry",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "key",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "delete_api_workspaces_workspaceId_apps_id_storage_key"
+      }
+    },
     "/api/workspaces/{workspaceId}/apps/{id}/versions": {
       "get": {
         "tags": [
@@ -22524,6 +22863,68 @@
           }
         },
         "operationId": "get_api_share_token_artifacts_artifactId"
+      }
+    },
+    "/api/share/{token}/storage": {
+      "get": {
+        "tags": [
+          "Public Shares"
+        ],
+        "summary": "Read a shared app's storage values",
+        "security": [],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "token",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get_api_share_token_storage"
       }
     },
     "/api/share/{token}/binding/{bindingId}/execute": {

--- a/packages/schemas/src/app-scaffold.ts
+++ b/packages/schemas/src/app-scaffold.ts
@@ -22,6 +22,12 @@ const APP_TSX = `// Read workspace data with the injected SDK once a data bindin
 //   import { useSearchParams, navigate } from "@mako/app-sdk";
 //   const [params, setParams] = useSearchParams();
 //
+// Persist values users EDIT in the app (targets, notes, overrides) with the
+// storage hook — server-side, shared by everyone who uses the app:
+//
+//   import { useStorage } from "@mako/app-sdk";
+//   const { value, setValue, saving, readOnly } = useStorage("my-key", {});
+//
 // Theming: the runtime provides CSS variables (--background, --foreground,
 // --card, --border, --muted-foreground, --primary, --chart-1..5, --radius, …)
 // that switch with light/dark automatically — use var(--token) instead of
@@ -114,6 +120,22 @@ navigate("/customers/42");                            // distinct view / detail 
 
 Use \`{ replace: true }\` for high-frequency updates (filter typing) so
 back/forward isn't flooded; the default pushes a new history entry.
+
+## Persistent storage (user-editable values)
+
+For values users edit in the app UI — targets, notes, manual overrides — use
+the storage hook. Values are stored server-side per app, shared by everyone who
+uses the app, and survive reloads and publishes. Public share viewers get
+read-only access (\`readOnly: true\`).
+
+\`\`\`tsx
+import { useStorage } from "@mako/app-sdk";
+
+const { value, setValue, loading, saving, error, readOnly } =
+  useStorage("csm-targets", {} as Record<string, number>);
+
+setValue(prev => ({ ...prev, [repId]: 25 })); // optimistic write-through
+\`\`\`
 `;
 
 export const DEFAULT_APP_SCAFFOLD_FILES: AppFile[] = [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Apps could read workspace data (bindings) but had nowhere to persist values users edit **in** the app UI — e.g. monthly targets per CSM in the CSM Activity app. Bindings are read-only by design, and stuffing data into the app definition would entangle it with the draft/published split and version restores.

## What

**New per-app key-value storage**, written by app code through a new `useStorage` hook in `@mako/app-sdk`:

- **Persistence**: new `MakoAppStorageEntry` model (`makoapp_storage` collection), one doc per `{ appId, key }` with a free-form JSON `value`. Independent of the app definition, so values survive edits, publishes, and restores. Deleted with the app.
- **API** (`api/src/routes/apps.ts`): `GET /apps/:id/storage`, `GET|PUT|DELETE /apps/:id/storage/:key`. Anyone who can *read* the app can read and write storage (using the app ≠ editing the app). Caps: 256 KB/value, 500 keys/app, key charset validated.
- **SDK** (`app/src/app-runtime/preview.ts`): `useStorage(key, defaultValue)` → `{ value, setValue, loading, saving, error, readOnly }`. Optimistic write-through with functional updates; bridges over `postMessage` (the sandboxed iframe never talks to the API directly).
- **Host bridge**: `AppRenderer` handles `storage-get`/`storage-set` via new `appStore` actions.
- **Realtime sync**: new `app.storage.updated` event; other windows/users forward a `storage-changed` poke into booted iframes so hooks refetch the changed key.
- **Public shares**: read-only — `GET /api/share/:token/storage` (post-unlock) serves values so shared views render complete; writes return `readOnly: true` and the hook exposes it so apps can hide edit affordances.
- **Docs**: apps skill (`api/src/agent-skills/apps/SKILL.md`) + app scaffold README document the hook and the edit-in-place pattern, so agent-built apps (like CSM Activity targets) use it directly.

## Why Mongo (alternatives considered)

- **Writable warehouse table**: makes targets SQL/dbt-queryable, but requires opening a write path from sandboxed app code into customer warehouses (the runtime is deliberately read-only via `checkPreviewQuerySafety`), per-dialect UPSERT/DDL, and write credentials. A future "storage → warehouse table" scheduled sync (reusing `DestinationWriter`) can add SQL queryability without changing the `useStorage` API.
- **dbt seed CSV**: git-versioned and warehouse-native, but edit → commit → `dbt seed` → materialize is not edit-in-place.
- **App files / URL / localStorage**: entangled with publish lifecycle, or not shared/durable.

## Demo

[csm_target_edit_in_place_full_loop_final.mp4](https://cursor.com/agents/bc-52e18a9a-4ae8-4b7b-b7cd-fa74e058f8f0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcsm_target_edit_in_place_full_loop_final.mp4)

Edit-in-place on a demo CSM targets app: click target → inline input → Enter → optimistic save → F5 reload → value persisted (verified in `makoapp_storage`).

## Testing

- ✅ `pnpm --filter app run typecheck`, `pnpm --filter app run lint`, `pnpm --filter api run build` (includes lint + tsc)
- ✅ `pnpm run openapi:sync` (spec + generated types committed)
- ✅ API-level: upsert/read/list/delete, key validation, missing-body 400, anonymous 401, public-share read-only GET
- ✅ Manual end-to-end in the browser: edit-in-place, progress recompute, persistence across full page reload; stored doc verified in Mongo


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52e18a9a-4ae8-4b7b-b7cd-fa74e058f8f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52e18a9a-4ae8-4b7b-b7cd-fa74e058f8f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

