### PR TITLE
fix(agent): make fetch_url and web_search available in every expertise mode

### DIFF
--- a/api/src/agents/modes/registry.ts
+++ b/api/src/agents/modes/registry.ts
@@ -32,6 +32,9 @@ export const CORE_ALWAYS_TOOL_NAMES: readonly string[] = [
   // Cross-surface search (parity: both are discovery, not modality work)
   "search_consoles",
   "search_dashboards",
+  // Public web access (useful in every modality, not modality-specific)
+  "fetch_url",
+  "web_search",
   // Version history
   "browse_version_history",
   "get_version_snapshot",
@@ -160,8 +163,6 @@ const APP_MODE_TOOL_NAMES: string[] = [
   "mongo_list_collections",
   "mongo_inspect_collection",
   "mongo_execute_query",
-  "fetch_url",
-  "web_search",
 ];
 
 const TRANSFORM_MODE_TOOL_NAMES: string[] = [
@@ -232,8 +233,6 @@ const EXPLORE_MODE_TOOL_NAMES: string[] = [
   "list_open_dashboards",
   "get_dashboard_state",
   "capture_screenshot",
-  "fetch_url",
-  "web_search",
 ];
 
 export const modeRegistry: Record<ExpertiseModeId, AgentMode> = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Problem

`fetch_url` and `web_search` (#562) were only added to the `app` and `explore` expertise-mode tool allowlists in `api/src/agents/modes/registry.ts`. The unified agent's `prepareStep` (`computeActiveTools` in `api/src/agents/modes/runtime.ts`) filters the tools sent to the model down to the *currently enabled* expertise mode(s) — and `defaultExpertiseMode()` resolves to `"query"` for the large majority of chats (any console/SQL work, which is the app's primary use case). `query` mode's allowlist never included these tools, so in a fresh chat the model never even saw that `fetch_url`/`web_search` existed — they were effectively invisible outside of `App`/`Explore` mode. This matches "we had a web search and fetch tool but it's not working" — it works exactly where it was tested, and silently doesn't exist everywhere else.

### Fix

Move `fetch_url` and `web_search` into `CORE_ALWAYS_TOOL_NAMES`, so they're active regardless of the enabled expertise mode(s) — consistent with how they're already classified as cross-cutting, always-safe tools in `READ_ONLY_TOOL_NAMES` (`packages/agent-tools/src/read-only-tools.ts`). Removed the now-redundant entries from `app`/`explore`.

### Testing

- Reproduced the bug directly: computed `computeActiveTools` for a fresh chat in the default (`query`) mode before the fix — `fetch_url`/`web_search` were absent. After the fix, they're present in every mode (`query`, `dashboard`, `flow`, `app`, `transform`, `explore`).
- Ran the real `fetch_url` tool end-to-end through the Vercel AI SDK tool-call loop (`generateText` with a live Anthropic model via the AI Gateway) against `https://example.com` — verified on both Node 22 (matches this dev sandbox) and Node 20.20 (matches the production `Dockerfile`'s `node:20` base image) to rule out a Node-version-specific regression in `safeFetch`'s SSRF-hardened DNS pinning.
- Also exercised `safeFetch` against several real-world redirect-heavy domains (`google.com`, `github.com`, `en.wikipedia.org`, `news.ycombinator.com`) on both Node versions — all succeeded.
- ✅ `pnpm --filter api run lint`
- ✅ `pnpm --filter api run test` (includes `derive-mode-state.test.ts`, which exercises the file changed here)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3af2-4085-789c-9f80-9fbb37460d16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3af2-4085-789c-9f80-9fbb37460d16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

