### PR TITLE
guides: T-SQL how-tos — JSON queries, indexes explained (Batch 15)

### DIFF
--- a/content/guides/mssql/indexes-explained.mdx
+++ b/content/guides/mssql/indexes-explained.mdx
@@ -1,0 +1,153 @@
+---
+title: "SQL Server Indexes Explained"
+description: "Clustered vs nonclustered indexes, included columns, key lookups, filtered indexes, and columnstore, with execution plan checks to verify indexes are used."
+database: "mssql"
+category: "how-to"
+tags: ["sql-server", "t-sql", "indexes", "performance", "execution-plans"]
+date: "2026-07-07"
+---
+
+Indexes in SQL Server follow the same B-tree fundamentals as every other relational database, but the clustered/nonclustered split shapes everything: how tables are physically stored, how lookups work, and why an innocent-looking `SELECT *` can turn a good index useless. If you're coming from PostgreSQL, where all indexes are secondary and the table is a heap, this is the main mental adjustment.
+
+## Clustered indexes: the table IS the index
+
+A clustered index defines the physical storage order of the table. The leaf level of a clustered index doesn't point at the data -- it *is* the data. Consequently a table can have exactly one clustered index.
+
+By default, a primary key creates a clustered index:
+
+```sql
+CREATE TABLE orders (
+    id INT IDENTITY PRIMARY KEY,      -- clustered index on id
+    customer_id INT NOT NULL,
+    status NVARCHAR(20) NOT NULL,
+    total DECIMAL(10,2) NOT NULL,
+    created_at DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME()
+);
+```
+
+You can decouple the two -- `PRIMARY KEY NONCLUSTERED` plus a separate `CREATE CLUSTERED INDEX` on another column -- but for most OLTP tables an ever-increasing integer or sequential key as the clustered key is the right default. It keeps inserts appending at the end instead of splitting pages mid-table, and it keeps the clustered key narrow, which matters for the next section.
+
+A table without any clustered index is a *heap*. Heaps are legitimate for staging tables you bulk-load and truncate, but as a permanent home for queried data they invite forwarded-record problems and slow scans. If you find one in the wild (`SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID('dbo.orders') AND type = 0`), it usually wasn't a deliberate choice.
+
+## Nonclustered indexes and the key lookup
+
+A nonclustered index is a separate structure: its leaf level contains the index key columns plus a *row locator* pointing back to the table. On a clustered table, that locator is the clustered key. This has two consequences:
+
+1. **A fat clustered key makes every nonclustered index fat.** A `UNIQUEIDENTIFIER` or wide composite clustered key gets silently copied into every other index on the table.
+2. **Queries that need columns beyond the index must go fetch them.** That fetch is the *key lookup*, and it's the most common performance surprise in SQL Server.
+
+```sql
+CREATE INDEX ix_orders_customer ON orders (customer_id);
+
+-- Uses the index... plus one key lookup per matching row
+SELECT customer_id, status, total
+FROM orders
+WHERE customer_id = 42;
+```
+
+The index seek finds the matching rows fast, but `status` and `total` aren't in the index, so SQL Server does a lookup into the clustered index for each row. For a handful of rows, fine. For 100,000 rows, the optimizer will often decide the lookups cost more than just scanning the whole table -- and your index gets ignored entirely. This "tipping point" is why an index that worked in testing gets abandoned in production once data volumes grow.
+
+## Included columns: covering the query
+
+The fix is to put the extra columns in the index leaf level without making them key columns:
+
+```sql
+CREATE INDEX ix_orders_customer
+ON orders (customer_id)
+INCLUDE (status, total)
+WITH (DROP_EXISTING = ON);
+```
+
+Now the query above is *covered*: everything it needs is in the index, no lookups. Key columns versus included columns:
+
+- **Key columns** order the B-tree. Use them for columns you filter or sort on.
+- **INCLUDE columns** exist only at the leaf level. They can't help a `WHERE` or `ORDER BY`, but they satisfy the `SELECT` list, don't count against key size limits (key max is 1,700 bytes for nonclustered indexes), and allow types like `NVARCHAR(MAX)` that can't be keys at all.
+
+The habit that makes covering indexes viable: select only the columns you need. `SELECT *` is effectively a request to never be covered.
+
+For composite keys, order matters. An index on `(customer_id, created_at)` supports `WHERE customer_id = 42` and `WHERE customer_id = 42 AND created_at > '2026-01-01'`, but not `WHERE created_at > '2026-01-01'` alone -- the leading column must be constrained. Put equality-filtered columns before range-filtered ones.
+
+## Filtered indexes
+
+A filtered index is a nonclustered index with a `WHERE` clause -- it only indexes rows matching the predicate:
+
+```sql
+CREATE INDEX ix_orders_pending
+ON orders (created_at)
+INCLUDE (customer_id, total)
+WHERE status = 'pending';
+```
+
+If 2% of orders are pending and your dashboard only ever queries pending orders, this index is 50x smaller than a full one, cheaper to maintain, and its statistics are more precise. The classic use cases: soft-delete flags (`WHERE deleted = 0`), sparse columns (`WHERE email IS NOT NULL`), and hot-status subsets like the above.
+
+Caveat: the query's predicate must match the filter closely enough for the optimizer to prove the index applies, and parameterized queries (`WHERE status = @status`) generally can't use a filtered index, because the plan must work for every parameter value.
+
+## Unique indexes and constraints
+
+`UNIQUE` constraints are enforced by unique indexes; creating either gives you both. Unique indexes also help the optimizer -- knowing at most one row matches enables cheaper plans:
+
+```sql
+CREATE UNIQUE INDEX ux_customers_email ON customers (email);
+```
+
+One SQL Server quirk versus PostgreSQL and MySQL: a unique index treats `NULL` as a value, so only *one* NULL is allowed. The workaround is a filtered unique index: `CREATE UNIQUE INDEX ux ON customers (email) WHERE email IS NOT NULL;`.
+
+## Columnstore: the analytics option
+
+Rowstore B-trees are built for finding few rows fast. For analytical scans over millions of rows, SQL Server has columnstore indexes -- data stored per-column, heavily compressed, processed in batches:
+
+```sql
+CREATE NONCLUSTERED COLUMNSTORE INDEX ncci_orders
+ON orders (customer_id, status, total, created_at);
+```
+
+A nonclustered columnstore on an OLTP table enables real-time analytics without moving data; a *clustered* columnstore makes the whole table columnar, the usual choice for fact tables in a warehouse. Aggregation queries (`SUM(total) GROUP BY customer_id` over the full table) can run an order of magnitude faster. Don't reach for it below a few million rows; segment elimination and batch mode need volume to pay off.
+
+## Verifying with execution plans
+
+The only way to know whether indexes are used is the execution plan. In SSMS press Ctrl+M (actual plan) before running, or use `SET STATISTICS IO ON` to see logical reads. What to look for:
+
+- **Index Seek** -- the B-tree navigated to matching rows. What you want for selective predicates.
+- **Index Scan / Clustered Index Scan** -- reading the whole index or table. Expected for unselective queries; a red flag when you thought you had a usable index.
+- **Key Lookup** -- the per-row fetch described above. A key lookup next to a nested loops join, repeated many times, is the signature of a non-covering index.
+
+The most common reason a seek silently becomes a scan is a *non-sargable* predicate -- wrapping the indexed column in a function or implicit conversion:
+
+```sql
+-- Scan: the column is inside a function
+WHERE YEAR(created_at) = 2026
+-- Seek: range on the bare column
+WHERE created_at >= '2026-01-01' AND created_at < '2027-01-01'
+
+-- Scan: NVARCHAR parameter vs VARCHAR column forces CONVERT_IMPLICIT on the column
+WHERE varchar_col = @nvarchar_param
+```
+
+Implicit conversions are sneaky because the query still returns correct results; the plan XML shows `CONVERT_IMPLICIT` on the column side. Match parameter types to column types.
+
+## Maintenance basics
+
+- **Unused indexes cost writes.** Every INSERT/UPDATE/DELETE maintains every index. Check `sys.dm_db_index_usage_stats` for indexes with high `user_updates` and zero `user_seeks`/`user_scans`, and drop them (the DMV resets on instance restart, so check uptime first).
+- **Statistics matter more than fragmentation.** On modern SSDs, obsessing over fragmentation percentages is mostly wasted effort; out-of-date statistics causing bad row estimates is the real plan-killer. `UPDATE STATISTICS` or leave auto-update on.
+- **Missing index DMVs are suggestions, not orders.** `sys.dm_db_missing_index_details` over-suggests wide INCLUDE lists and never accounts for overlap with existing indexes. Read them as hints, consolidate, and never create all of them blindly.
+
+## Common mistakes
+
+- Indexing every column individually. Five single-column indexes rarely help; one well-ordered composite usually does.
+- `SELECT *` defeating covering indexes.
+- Functions or type mismatches on the filtered column (non-sargable predicates).
+- Wide clustered keys (GUIDs) inflating every nonclustered index.
+- Creating every missing-index suggestion the DMV emits.
+
+Reading execution plans takes practice; Mako's AI assistant can explain why a specific query scans instead of seeks and suggest the index or rewrite.
+
+## See also
+
+- [Window functions in SQL Server](/guides/mssql/window-functions)
+- [Working with JSON in SQL Server](/guides/mssql/json-queries)
+- [MySQL indexes explained](/guides/mysql/indexes-explained)
+- [PostgreSQL indexes explained](/guides/postgresql/indexes-explained)
+
+---
+
+Mako connects to SQL Server with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).

--- a/content/guides/mssql/json-queries.mdx
+++ b/content/guides/mssql/json-queries.mdx
@@ -1,0 +1,223 @@
+---
+title: "Working with JSON in SQL Server"
+description: "A practical guide to T-SQL JSON functions: JSON_VALUE, JSON_QUERY, OPENJSON, FOR JSON, JSON_MODIFY, plus the native json type and JSON indexes in SQL Server 2025."
+database: "mssql"
+category: "how-to"
+tags: ["sql-server", "t-sql", "json", "openjson", "for-json"]
+date: "2026-07-07"
+---
+
+SQL Server has supported JSON since SQL Server 2016, but with a design choice that surprises people coming from PostgreSQL or MySQL: for most of its history there was no JSON data type. You stored JSON as plain `NVARCHAR(MAX)` and used functions to parse it. That changed in SQL Server 2025, which shipped a native `json` type and a JSON index, but the function-based model is still what you'll encounter in nearly every existing database.
+
+This guide covers both: the function toolkit that works from 2016 onward, and what the 2025 native type changes.
+
+## Storing JSON: NVARCHAR plus a constraint
+
+On SQL Server 2016 through 2022, the standard pattern is an `NVARCHAR(MAX)` column with an `ISJSON` check constraint so invalid documents are rejected at insert time:
+
+```sql
+CREATE TABLE orders (
+    id INT IDENTITY PRIMARY KEY,
+    customer NVARCHAR(100),
+    details NVARCHAR(MAX),
+    CONSTRAINT chk_details_json CHECK (ISJSON(details) = 1)
+);
+
+INSERT INTO orders (customer, details) VALUES
+('Acme', N'{"status": "shipped", "items": [{"sku": "A-100", "qty": 2}, {"sku": "B-200", "qty": 1}], "priority": true}'),
+('Globex', N'{"status": "pending", "items": [{"sku": "A-100", "qty": 5}], "priority": false}');
+```
+
+Without the constraint, nothing stops `'not json at all'` from landing in the column and blowing up your queries later. Use `NVARCHAR`, not `VARCHAR`: JSON is Unicode by definition, and the JSON functions expect it.
+
+## Extracting scalars: JSON_VALUE
+
+`JSON_VALUE` pulls a single scalar (string, number, boolean) out of a document using a JSON path:
+
+```sql
+SELECT
+    id,
+    customer,
+    JSON_VALUE(details, '$.status') AS status,
+    JSON_VALUE(details, '$.items[0].sku') AS first_sku
+FROM orders;
+```
+
+Paths start at `$` (the document root), use `.key` for object properties and `[n]` for array elements. Array indexing is zero-based, matching JSON convention (note that this differs from T-SQL strings, where `SUBSTRING` is 1-based).
+
+Two behaviors to know:
+
+- `JSON_VALUE` returns `NVARCHAR(4000)`. If you need a number or date, cast it: `CAST(JSON_VALUE(details, '$.total') AS DECIMAL(10,2))`.
+- In *lax mode* (the default), a missing path returns `NULL`. In *strict mode* it raises an error: `JSON_VALUE(details, 'strict $.missing')`. Lax is forgiving during exploration; strict catches typos in production code.
+
+## Extracting objects and arrays: JSON_QUERY
+
+`JSON_VALUE` returns `NULL` (lax mode) if the path points at an object or array rather than a scalar. That silent `NULL` is the most common JSON gotcha in SQL Server. To extract a fragment, use `JSON_QUERY`:
+
+```sql
+SELECT
+    JSON_VALUE(details, '$.items') AS items_wrong,   -- NULL, it's an array
+    JSON_QUERY(details, '$.items') AS items_right    -- [{"sku":"A-100",...}]
+FROM orders
+WHERE id = 1;
+```
+
+Rule of thumb: scalar → `JSON_VALUE`, object or array → `JSON_QUERY`. If a query keeps returning `NULL` and you're sure the path is right, you've probably used the wrong one.
+
+## Shredding JSON into rows: OPENJSON
+
+`OPENJSON` is a table-valued function that turns JSON into a rowset, which makes it the workhorse for anything relational: joins, aggregation, filtering on array elements. It appears in the `FROM` clause like a table.
+
+Without a schema, it returns key/value/type triples:
+
+```sql
+SELECT j.[key], j.value, j.type
+FROM orders
+CROSS APPLY OPENJSON(details) AS j
+WHERE id = 1;
+```
+
+The far more useful form specifies an explicit schema with `WITH`:
+
+```sql
+SELECT o.id, o.customer, i.sku, i.qty
+FROM orders AS o
+CROSS APPLY OPENJSON(o.details, '$.items')
+    WITH (
+        sku NVARCHAR(20) '$.sku',
+        qty INT          '$.qty'
+    ) AS i
+WHERE i.qty >= 2;
+```
+
+This unnests the `items` array into one row per element, with typed columns. `CROSS APPLY` is the T-SQL idiom for "call this table-valued function once per outer row" (use `OUTER APPLY` to keep rows whose array is empty or missing, analogous to a left join).
+
+Aggregating over array elements works the way you'd expect once the data is rows:
+
+```sql
+SELECT i.sku, SUM(i.qty) AS total_qty
+FROM orders AS o
+CROSS APPLY OPENJSON(o.details, '$.items')
+    WITH (sku NVARCHAR(20), qty INT) AS i
+GROUP BY i.sku
+ORDER BY total_qty DESC;
+```
+
+When the `WITH` column name matches the JSON key, you can omit the path, as above. To grab a nested object as raw JSON inside a `WITH` schema, add `AS JSON`: `items NVARCHAR(MAX) '$.items' AS JSON`.
+
+`OPENJSON` requires database compatibility level 130 or higher. If you get "Invalid object name 'OPENJSON'", check `SELECT compatibility_level FROM sys.databases WHERE name = DB_NAME();` -- databases restored from old instances often sit at a lower level than the server supports.
+
+## Producing JSON: FOR JSON
+
+Going the other direction, `FOR JSON` serializes query results to JSON. `FOR JSON PATH` gives you control over nesting via column aliases:
+
+```sql
+SELECT
+    id,
+    customer AS [info.name],
+    JSON_VALUE(details, '$.status') AS [info.status]
+FROM orders
+FOR JSON PATH;
+```
+
+Dots in aliases become nested objects: `[{"id":1,"info":{"name":"Acme","status":"shipped"}}, ...]`.
+
+Useful modifiers:
+
+- `ROOT('orders')` wraps the array in a named root object.
+- `WITHOUT_ARRAY_WRAPPER` drops the outer `[...]` for single-row results (careful: the result is no longer valid JSON if more than one row comes back, they get comma-joined).
+- `INCLUDE_NULL_VALUES` emits `"key": null` instead of omitting NULL columns, which is the default.
+
+Correlated subqueries with `FOR JSON PATH` build nested arrays, the standard pattern for parent/child shapes:
+
+```sql
+SELECT c.name,
+    (SELECT o.id, JSON_VALUE(o.details, '$.status') AS status
+     FROM orders AS o WHERE o.customer = c.name
+     FOR JSON PATH) AS orders
+FROM customers AS c
+FOR JSON PATH;
+```
+
+## Modifying JSON: JSON_MODIFY
+
+`JSON_MODIFY` returns a new document with one path changed; combine it with `UPDATE` to persist:
+
+```sql
+UPDATE orders
+SET details = JSON_MODIFY(details, '$.status', 'delivered')
+WHERE id = 1;
+
+-- Append to an array
+UPDATE orders
+SET details = JSON_MODIFY(details, 'append $.items',
+    JSON_QUERY(N'{"sku": "C-300", "qty": 4}'))
+WHERE id = 1;
+
+-- Delete a key by setting it to NULL (lax mode)
+UPDATE orders
+SET details = JSON_MODIFY(details, '$.priority', NULL)
+WHERE id = 1;
+```
+
+The `JSON_QUERY` wrapper in the append example matters: without it, the new value is inserted as an escaped string rather than an object. Each `JSON_MODIFY` call changes one path; chain calls to change several: `JSON_MODIFY(JSON_MODIFY(details, '$.a', 1), '$.b', 2)`.
+
+## Indexing JSON queries (2016-2022)
+
+Since JSON lives in an `NVARCHAR` column, `JSON_VALUE` in a `WHERE` clause means a full scan by default. The classic fix is a computed column plus a regular index:
+
+```sql
+ALTER TABLE orders
+ADD status AS JSON_VALUE(details, '$.status');
+
+CREATE INDEX ix_orders_status ON orders (status);
+```
+
+The computed column doesn't have to be `PERSISTED` for the index to work. Queries that filter on the same expression, `WHERE JSON_VALUE(details, '$.status') = 'shipped'`, will use the index automatically as long as the expression matches exactly.
+
+## SQL Server 2025: the native json type
+
+SQL Server 2025 (GA November 2025) finally added a native `json` data type, aligned with what Azure SQL Database has had since 2024:
+
+```sql
+CREATE TABLE events (
+    id INT IDENTITY PRIMARY KEY,
+    payload JSON
+);
+```
+
+What it buys you (as of mid-2026):
+
+- **Binary storage.** Documents are stored in a parsed binary format rather than text, so reads skip re-parsing and storage is more compact.
+- **Validation built in.** No `ISJSON` constraint needed; invalid JSON is rejected on insert.
+- **JSON indexes.** A new index type for path queries inside documents: `CREATE JSON INDEX ix_payload ON events (payload);` -- this replaces the computed-column workaround for many cases.
+- **ANSI aggregate functions.** `JSON_OBJECTAGG` and `JSON_ARRAYAGG` build objects/arrays from grouped rows, closing a long-standing gap with PostgreSQL and MySQL:
+
+```sql
+SELECT customer, JSON_ARRAYAGG(JSON_VALUE(details, '$.status')) AS statuses
+FROM orders
+GROUP BY customer;
+```
+
+All the existing functions (`JSON_VALUE`, `OPENJSON`, etc.) work against the new type unchanged. If you're on 2025 or Azure SQL, prefer `json` over `NVARCHAR(MAX)` for new tables; for 2016-2022 the NVARCHAR-plus-functions model remains the only option.
+
+## Common mistakes
+
+- **Using JSON_VALUE on an array/object.** Returns `NULL` in lax mode with no error. Use `JSON_QUERY`, or strict mode to fail loudly.
+- **Forgetting the N prefix.** `'{"k":"v"}'` is VARCHAR; non-ASCII characters get mangled before the JSON functions ever see them. Write `N'{"k":"v"}'`.
+- **Comparing JSON_VALUE output as the wrong type.** It returns NVARCHAR, so `JSON_VALUE(d, '$.qty') > 9` does a string comparison ('10' < '9'). Cast first.
+- **OPENJSON missing.** Compatibility level below 130. Fix with `ALTER DATABASE ... SET COMPATIBILITY_LEVEL = 160;` after testing.
+- **WITHOUT_ARRAY_WRAPPER on multi-row results.** Produces comma-separated objects that aren't a valid JSON document.
+
+When exploring an unfamiliar JSON column, an AI-assisted editor like Mako's helps generate the `OPENJSON ... WITH` schema from a sample document instead of hand-typing every path.
+
+## See also
+
+- [Window functions in SQL Server](/guides/mssql/window-functions)
+- [CTEs in SQL Server](/guides/mssql/cte)
+- [Import JSON to SQL Server](/guides/import-json-to-mssql)
+- [Working with JSON in MySQL](/guides/mysql/json-queries)
+
+---
+
+Mako connects to SQL Server with AI-powered autocomplete. Try it free at [mako.ai](https://mako.ai).


### PR DESCRIPTION
Two more Batch 15 (MS SQL / T-SQL how-to) guides:

- **mssql/json-queries** — JSON_VALUE vs JSON_QUERY (the lax-mode NULL trap), OPENJSON WITH schemas + CROSS APPLY, FOR JSON PATH, JSON_MODIFY (append + JSON_QUERY wrapper), computed-column indexing for 2016-2022, and the SQL Server 2025 native json type + JSON index + JSON_ARRAYAGG/OBJECTAGG (GA Nov 18 2025, verified).
- **mssql/indexes-explained** — clustered vs nonclustered (table-is-the-index model), key lookups + the tipping point, INCLUDE covering indexes, filtered indexes (incl. the single-NULL unique quirk), columnstore, sargability/implicit-conversion traps, DMV caveats.

Content-only (2 new .mdx files). Researched fresh Jul 7; follows editorial guidelines (honest limitations, no hype, single CTA).