### PR TITLE
feat(apps): link data bindings to dbt projects from the binding editor UI

### DIFF
--- a/app/src/app-runtime/binding-preview.ts
+++ b/app/src/app-runtime/binding-preview.ts
@@ -14,7 +14,19 @@
 
 import { containsDbtSchemaToken, type AppDataBinding } from "@mako/schemas";
 import { useAppStore, prodLikeDbtEnvironment } from "../store/appStore";
-import { ensureBindingLoaded, loadBindingRowsTable } from "./duckdb";
+import {
+  ensureBindingLoaded,
+  loadBindingRowsTable,
+  dropBindingTableByRevisionPrefix,
+} from "./duckdb";
+
+/**
+ * Revision prefix for DuckDB tables loaded from a live preview-env run
+ * (`dbt-preview:<env>`) rather than the prod Parquet artifact. Marks the
+ * table as override data so resetting the override can evict it when no prod
+ * artifact is available to reload.
+ */
+const DBT_PREVIEW_REVISION_PREFIX = "dbt-preview:";
 
 /**
  * The active preview env override for a binding, or null when the binding
@@ -55,12 +67,25 @@ export async function ensureBindingLoadedForPreview(
   if (binding.materialization !== "parquet") return false;
 
   const override = await getBindingPreviewOverride(workspaceId, appId, binding);
-  if (!override) return ensureBindingLoaded(appId, binding, signal);
+  if (!override) {
+    const loaded = await ensureBindingLoaded(appId, binding, signal);
+    if (!loaded) {
+      // No ready prod artifact to reload (never materialized / build failed):
+      // evict rows a previous override run left behind so prod reads fail
+      // loudly instead of silently serving the other environment's data.
+      await dropBindingTableByRevisionPrefix(
+        appId,
+        binding.name,
+        DBT_PREVIEW_REVISION_PREFIX,
+      );
+    }
+    return loaded;
+  }
 
   return loadBindingRowsTable(
     appId,
     binding,
-    `dbt-preview:${override.environment}`,
+    `${DBT_PREVIEW_REVISION_PREFIX}${override.environment}`,
     async () => {
       const result = await useAppStore
         .getState()

--- a/app/src/app-runtime/duckdb.test.ts
+++ b/app/src/app-runtime/duckdb.test.ts
@@ -2,18 +2,26 @@ import { describe, expect, it, vi } from "vitest";
 
 // duckdb.ts imports the DuckDB-WASM helpers at module scope; stub them so the
 // pure sandbox-cap helpers can be tested in a node environment.
+const connQuery = vi.fn();
+const connClose = vi.fn();
 vi.mock("../lib/duckdb", () => ({
-  createDuckDBInstance: vi.fn(),
+  createDuckDBInstance: vi.fn(async () => ({
+    connect: async () => ({ query: connQuery, close: connClose }),
+  })),
   loadParquetTable: vi.fn(),
+  loadJsonTable: vi.fn(),
   queryDuckDB: vi.fn(),
   collectStreamBytes: vi.fn(),
   terminateTrackedDuckDBInstance: vi.fn(),
 }));
 
+import type { AppDataBinding } from "@mako/schemas";
 import {
   SANDBOX_DUCKDB_ROW_LIMIT,
   resolveSandboxRowLimit,
   applySandboxRowLimit,
+  loadBindingRowsTable,
+  dropBindingTableByRevisionPrefix,
 } from "./duckdb";
 
 describe("resolveSandboxRowLimit", () => {
@@ -68,5 +76,72 @@ describe("applySandboxRowLimit", () => {
       rows,
       truncated: false,
     });
+  });
+});
+
+describe("dropBindingTableByRevisionPrefix", () => {
+  const binding = (name: string): AppDataBinding =>
+    ({
+      id: name,
+      name,
+      connectionId: "conn1",
+      language: "sql",
+      code: "SELECT 1",
+      materialization: "parquet",
+    }) as AppDataBinding;
+
+  it("no-ops when the app has no DuckDB instance", async () => {
+    await expect(
+      dropBindingTableByRevisionPrefix("no-such-app", "orders", "dbt-preview:"),
+    ).resolves.toBeUndefined();
+    expect(connQuery).not.toHaveBeenCalled();
+  });
+
+  it("evicts a table loaded under a matching override revision", async () => {
+    const fetchRows = vi.fn(async () => [{ a: 1 }]);
+    await loadBindingRowsTable(
+      "app-a",
+      binding("orders"),
+      "dbt-preview:dev",
+      fetchRows,
+    );
+    expect(fetchRows).toHaveBeenCalledTimes(1);
+
+    await dropBindingTableByRevisionPrefix("app-a", "orders", "dbt-preview:");
+    expect(connQuery).toHaveBeenCalledWith('DROP TABLE IF EXISTS "orders"');
+    expect(connClose).toHaveBeenCalled();
+
+    // The revision was cleared, so re-loading the same snapshot fetches again
+    // instead of hitting the "already loaded" fast path.
+    await loadBindingRowsTable(
+      "app-a",
+      binding("orders"),
+      "dbt-preview:dev",
+      fetchRows,
+    );
+    expect(fetchRows).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves tables alone when the revision does not match the prefix", async () => {
+    const fetchRows = vi.fn(async () => [{ a: 1 }]);
+    await loadBindingRowsTable(
+      "app-b",
+      binding("orders"),
+      "artifact-rev-1",
+      fetchRows,
+    );
+    connQuery.mockClear();
+
+    await dropBindingTableByRevisionPrefix("app-b", "orders", "dbt-preview:");
+    expect(connQuery).not.toHaveBeenCalled();
+
+    // Still loaded: the same revision short-circuits without re-fetching.
+    await loadBindingRowsTable(
+      "app-b",
+      binding("orders"),
+      "artifact-rev-1",
+      fetchRows,
+    );
+    expect(fetchRows).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/src/app-runtime/duckdb.ts
+++ b/app/src/app-runtime/duckdb.ts
@@ -165,6 +165,48 @@ export async function loadBindingRowsTable(
   });
 }
 
+/**
+ * Drop a binding's table when its loaded revision starts with
+ * `revisionPrefix`. Used when a preview-env override resets but the prod
+ * artifact cannot be (re)loaded (not materialized yet / build failed): rows
+ * loaded for the override must not keep serving under prod, so the table is
+ * removed and reads fail loudly ("table does not exist") instead. No-ops when
+ * nothing matching is loaded. Serializes with in-flight loads of the table so
+ * a concurrent (re)load is never dropped mid-swap.
+ */
+export async function dropBindingTableByRevisionPrefix(
+  appId: string,
+  bindingName: string,
+  revisionPrefix: string,
+): Promise<void> {
+  const inst = instances.get(appId);
+  if (!inst) return;
+  const table = bindingTableName(bindingName);
+  if (!inst.loaded.get(table)?.startsWith(revisionPrefix)) return;
+
+  const prior = inst.loading.get(table) ?? Promise.resolve();
+  const result = prior.then(async () => {
+    // Re-check after waiting: an in-flight load may have replaced the table
+    // with a revision this drop no longer applies to.
+    if (!inst.loaded.get(table)?.startsWith(revisionPrefix)) return;
+    const conn = await inst.db.connect();
+    try {
+      await conn.query(`DROP TABLE IF EXISTS "${table}"`);
+    } finally {
+      await conn.close();
+    }
+    inst.loaded.delete(table);
+  });
+  inst.loading.set(
+    table,
+    result.then(
+      () => undefined,
+      () => undefined,
+    ),
+  );
+  return result;
+}
+
 /** Run analytical SQL against the app's loaded tables. */
 export async function queryAppDuckDB(
   appId: string,

--- a/app/src/components/AppBindingEditor.tsx
+++ b/app/src/components/AppBindingEditor.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
 import {
   Box,
+  Chip,
+  MenuItem,
+  Select,
   Typography,
   ToggleButtonGroup,
   ToggleButton,
@@ -8,9 +11,11 @@ import {
 } from "@mui/material";
 import { Info as InfoIcon } from "lucide-react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
+import { containsDbtSchemaToken } from "@mako/schemas";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useAppStore } from "../store/appStore";
 import { useConsoleStore } from "../store/consoleStore";
+import { useDbtStore } from "../store/dbtStore";
 import { previewParquetArtifact } from "../lib/parquet-preview";
 import Console from "./Console";
 import ResultsTable from "./ResultsTable";
@@ -83,6 +88,29 @@ export default function AppBindingEditor({
 
   const resolveDbtCodeForPreview = useAppStore(s => s.resolveDbtCodeForPreview);
   const bindingDbtProjectId = binding?.dbtProjectId;
+
+  // dbt link: lets the user connect this binding to a workspace dbt project
+  // from the UI (previously agent-tool only). Linking enables the
+  // {{ dbt_schema }} token in the query and, with it, the app preview's
+  // environment (schema) switcher — including for materialized (parquet)
+  // bindings, which serve a live row-capped run while an override is active.
+  const dbtProjects = useDbtStore(s => s.projects);
+  const dbtProjectsLoaded = useDbtStore(s => s.projectsLoaded);
+  const fetchDbtProjects = useDbtStore(s => s.fetchProjects);
+  useEffect(() => {
+    if (workspaceId && !dbtProjectsLoaded) void fetchDbtProjects(workspaceId);
+  }, [workspaceId, dbtProjectsLoaded, fetchDbtProjects]);
+
+  const handleDbtLinkChange = useCallback(
+    (projectId: string) => {
+      if (!workspaceId) return;
+      updateBinding(appId, bindingId, {
+        dbtProjectId: projectId || undefined,
+      });
+      void persistApp(workspaceId, appId);
+    },
+    [workspaceId, appId, bindingId, updateBinding, persistApp],
+  );
 
   const handleExecute = useCallback(
     async (content: string, connectionId?: string, databaseId?: string) => {
@@ -224,6 +252,19 @@ export default function AppBindingEditor({
 
   const isParquet = binding.materialization === "parquet";
 
+  // Show the dbt link picker when the workspace has dbt projects, or when the
+  // binding is already linked (so the link stays visible/unlinkable even if
+  // its project was deleted).
+  const showDbtLink = dbtProjects.length > 0 || Boolean(binding.dbtProjectId);
+  const linkedDbtProjectMissing = Boolean(
+    binding.dbtProjectId &&
+      dbtProjectsLoaded &&
+      !dbtProjects.some(p => p._id === binding.dbtProjectId),
+  );
+  const dbtLinkedWithoutToken = Boolean(
+    binding.dbtProjectId && !containsDbtSchemaToken(binding.code),
+  );
+
   const leadingControls = (
     <>
       <Typography variant="caption" color="text.secondary">
@@ -265,6 +306,76 @@ export default function AppBindingEditor({
           style={{ opacity: 0.6, cursor: "help" }}
         />
       </Tooltip>
+      {showDbtLink && (
+        <>
+          <Typography variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+            dbt
+          </Typography>
+          <Select
+            size="small"
+            variant="outlined"
+            displayEmpty
+            value={binding.dbtProjectId ?? ""}
+            onChange={e => handleDbtLinkChange(e.target.value)}
+            sx={{ fontSize: "0.72rem", height: 26, minWidth: 110 }}
+            renderValue={value => {
+              if (!value) return "Not linked";
+              return (
+                dbtProjects.find(p => p._id === value)?.name ??
+                (linkedDbtProjectMissing ? "Deleted project" : "…")
+              );
+            }}
+          >
+            <MenuItem value="">Not linked</MenuItem>
+            {dbtProjects.map(p => (
+              <MenuItem key={p._id} value={p._id}>
+                {p.name}
+              </MenuItem>
+            ))}
+          </Select>
+          <Tooltip
+            title={
+              <Box sx={{ p: 0.5 }}>
+                <Typography variant="caption" display="block" sx={{ mb: 0.5 }}>
+                  Link this data source to a dbt project to write
+                  environment-agnostic SQL: use the{" "}
+                  <code>{"{{ dbt_schema }}"}</code> token instead of hardcoding
+                  a schema (e.g.{" "}
+                  <code>{"SELECT * FROM {{ dbt_schema }}.fct_orders"}</code>).
+                </Typography>
+                <Typography variant="caption" display="block">
+                  The token resolves to the project&apos;s prod environment for
+                  published apps and materialized snapshots, and the app preview
+                  gains an environment switcher to point the draft (including
+                  materialized bindings) at a dev schema.
+                </Typography>
+              </Box>
+            }
+          >
+            <InfoIcon
+              size={15}
+              strokeWidth={1.5}
+              style={{ opacity: 0.6, cursor: "help" }}
+            />
+          </Tooltip>
+          {dbtLinkedWithoutToken && (
+            <Tooltip
+              title={
+                'Add the {{ dbt_schema }} token to the query (e.g. "FROM ' +
+                '{{ dbt_schema }}.my_model") to enable the schema switcher ' +
+                "in the app preview."
+              }
+            >
+              <Chip
+                size="small"
+                color="warning"
+                variant="outlined"
+                label="No {{ dbt_schema }} token"
+              />
+            </Tooltip>
+          )}
+        </>
+      )}
     </>
   );
 

--- a/app/src/components/AppRenderer.tsx
+++ b/app/src/components/AppRenderer.tsx
@@ -300,10 +300,12 @@ export default function AppRenderer({
           dbtOverrideActive &&
           Boolean(binding?.dbtProjectId) &&
           containsDbtSchemaToken(binding?.code ?? "");
-        // Materialized binding -> read its table from DuckDB-WASM.
+        // Materialized binding -> read its table from DuckDB-WASM. The
+        // preview-aware loader also evicts rows a previous env override left
+        // behind when no prod artifact exists to reload (stale-data guard).
         if (binding?.materialization === "parquet" && !dbtLiveOverride) {
           const rowLimit = resolveSandboxRowLimit(data.rowLimit);
-          void ensureBindingLoaded(appId, binding)
+          void ensureBindingLoadedForPreview(workspaceId, appId, binding)
             .then(() =>
               queryAppDuckDB(
                 appId,

--- a/app/src/components/AppRenderer.tsx
+++ b/app/src/components/AppRenderer.tsx
@@ -83,6 +83,7 @@ export default function AppRenderer({
   const bumpPreview = useAppStore(s => s.bumpPreview);
   const setPreviewErrors = useAppStore(s => s.setPreviewErrors);
   const runBinding = useAppStore(s => s.runBinding);
+  const materializeBinding = useAppStore(s => s.materializeBinding);
   const materializeAllBindings = useAppStore(s => s.materializeAllBindings);
   const persistApp = useAppStore(s => s.persistApp);
   const generateSaveComment = useAppStore(s => s.generateSaveComment);
@@ -266,6 +267,48 @@ export default function AppRenderer({
       }
     }
   }, [appId, appEntity, workspaceId, effectiveDbtEnv]);
+
+  // Auto-materialize: when a parquet binding's reads are about to hit the
+  // artifact path but no artifact exists (never materialized, or the cache
+  // was lost), queue its build automatically instead of leaving the app on a
+  // "table does not exist" error — e.g. switching the dbt preview env back to
+  // prod before the first build. Scoped tightly:
+  // - dbt-linked bindings serving a LIVE override run are skipped (building
+  //   would be pointless there: artifacts always hold prod data);
+  // - an errored build is NOT retried (no rebuild loops for broken queries —
+  //   the binding editor surfaces the error);
+  // - one attempt per binding per mount; the server-side per-binding claim
+  //   dedupes against builds already in flight.
+  const autoMaterializeAttempted = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    if (!appEntity || !workspaceId) return;
+    for (const binding of appEntity.dataBindings) {
+      if (binding.materialization !== "parquet") continue;
+      const servesLiveOverride =
+        dbtOverrideActive &&
+        Boolean(binding.dbtProjectId) &&
+        containsDbtSchemaToken(binding.code);
+      if (servesLiveOverride) continue;
+      const status = binding.cache?.parquetBuildStatus;
+      const hasArtifact =
+        status === "ready" && Boolean(binding.cache?.parquetUrl);
+      if (hasArtifact || status === "error") continue;
+      if (autoMaterializeAttempted.current.has(binding.id)) continue;
+      autoMaterializeAttempted.current.add(binding.id);
+      setPublishedNotice(`Building data for "${binding.name}"…`);
+      void materializeBinding(workspaceId, appId, binding.id).then(result => {
+        if (result.status === "ready") {
+          // materializeBinding already refetched the app and bumped the
+          // preview, so the fresh artifact loads on the rebuilt preview.
+          setPublishedNotice(`Data for "${binding.name}" is ready.`);
+        } else if (result.status === "error") {
+          setPublishedNotice(
+            `Failed to build "${binding.name}": ${result.error ?? "unknown error"}`,
+          );
+        }
+      });
+    }
+  }, [appId, appEntity, workspaceId, dbtOverrideActive, materializeBinding]);
 
   // Dispose the DuckDB instance when the tab unmounts.
   useEffect(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The schema switcher (dbt preview-environment picker in the app preview toolbar) only appears when a data binding has a `dbtProjectId` AND uses the `{{ dbt_schema }}` token — but `dbtProjectId` could only be set through agent tools (`app_create_data_binding` / `app_upsert_data_binding`). A user hand-editing a materialized (parquet) binding had no way to link it to a dbt project, so the schema switcher was unreachable for them.

## Changes

### 1. dbt link UI in the binding editor

- `AppBindingEditor` toolbar gains a **dbt** Select that links/unlinks the binding to any workspace dbt project (persisted via the existing `updateBinding` + `persistApp` path; the server already validates the project id).
- Info tooltip explains the `{{ dbt_schema }}` token and what linking enables (prod resolution for published apps + materialized snapshots, preview env switcher for drafts — including parquet bindings, which serve a live row-capped run while an override is active).
- A warning chip appears when a binding is linked but its query lacks the `{{ dbt_schema }}` token, since the switcher stays hidden without it.
- The picker stays visible for already-linked bindings even if the project was deleted, so the stale link can be removed.

### 2. Stale-data fix: evict override-loaded tables when the prod artifact is missing

Pre-existing edge case (from #663) found while testing: when a parquet binding had **never been materialized** (or its build failed), switching the preview env to dev loaded live rows into the binding's DuckDB table — and switching back to prod left them there, so `useQuery`/`useDuckDB` silently served **dev data labeled as prod**.

- `ensureBindingLoadedForPreview` now drops tables whose revision carries the `dbt-preview:` prefix when the prod artifact cannot be reloaded, so reads fail loudly ("table does not exist") instead.
- Tables loaded from a real artifact revision are untouched — the keep-serving-old-snapshot behavior during rebuilds is preserved.
- The `useQuery` read path in `AppRenderer` now uses the preview-aware loader so it gets the same guard.
- Unit tests for the new `dropBindingTableByRevisionPrefix` helper (evicts matching revisions, no-ops otherwise, serializes with in-flight loads).

### 3. Auto-materialize missing artifacts in the preview

On top of the loud-error guard, the preview now self-heals: when a parquet binding's reads are about to hit the artifact path but no artifact exists (never materialized / cache lost — e.g. switching the schema switcher back to prod before the first build), the build is queued automatically and the preview refreshes when it lands.

Scoped tightly:
- dbt-linked bindings serving a **live override run** are skipped — building there would be pointless (artifacts always hold prod data);
- **errored builds are not retried** (no rebuild loops for broken queries; the binding editor surfaces the error);
- one attempt per binding per mount; the server-side per-binding claim dedupes builds already in flight; `force: false` so the definition-hash cache still applies.

## Demo

[schema_switcher_dbt_parquet_binding_demo.mp4](https://cursor.com/agents/bc-4db592d5-6b5a-45b6-9c70-73889ed0101e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fschema_switcher_dbt_parquet_binding_demo.mp4)

Schema switcher on an app whose only binding is a dbt-linked **parquet** binding: prod artifact by default, live dev-schema rows while the override is active, back to prod on reset.

[auto_materialize_missing_artifact_demo.mp4](https://cursor.com/agents/bc-4db592d5-6b5a-45b6-9c70-73889ed0101e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fauto_materialize_missing_artifact_demo.mp4)

Auto-materialize with the binding cache wiped (never-materialized): the preview builds the artifact by itself and renders prod data with no Materialize click, then dev ⇄ prod switching works as usual.

[stale_override_data_fix_demo.mp4](https://cursor.com/agents/bc-4db592d5-6b5a-45b6-9c70-73889ed0101e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstale_override_data_fix_demo.mp4)

Stale-data guard verified in isolation (recorded before auto-materialize landed): prod fails loudly instead of serving dev rows, and Materialize recovers.

[Bug repro (pre-fix): dev rows still shown after switching back to prod](https://cursor.com/agents/bc-4db592d5-6b5a-45b6-9c70-73889ed0101e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbug_repro_stale_dev_rows_shown_as_prod.webp)
[Fixed: prod fails loudly after override reset when no artifact exists](https://cursor.com/agents/bc-4db592d5-6b5a-45b6-9c70-73889ed0101e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffixed_prod_errors_loudly_after_override_reset.webp)
[Binding editor with the new dbt link select (Not linked)](https://cursor.com/agents/bc-4db592d5-6b5a-45b6-9c70-73889ed0101e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbinding_editor_dbt_not_linked.webp)
[dbt project select menu](https://cursor.com/agents/bc-4db592d5-6b5a-45b6-9c70-73889ed0101e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbinding_editor_dbt_select_menu.webp)
[Materialized prod snapshot preview (5 rows, env=prod)](https://cursor.com/agents/bc-4db592d5-6b5a-45b6-9c70-73889ed0101e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmaterialized_prod_snapshot_preview.webp)
[App preview reading the dev schema while the override is active](https://cursor.com/agents/bc-4db592d5-6b5a-45b6-9c70-73889ed0101e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_preview_dev_override.webp)

## Testing

- ✅ `pnpm --filter app run typecheck`
- ✅ `pnpm --filter app run lint`
- ✅ `pnpm --filter app run test:unit src/app-runtime/duckdb.test.ts` (10 tests)
- ✅ Manual end-to-end (feature): created a dbt project (prod → `dbt_prod`, dev → `dbt_dev` on the demo Postgres) and an app with an un-linked parquet binding using `{{ dbt_schema }}`; linked it from the new toolbar select, materialized (5 rows, prod data), then used the schema switcher in the app preview to flip prod → dev → prod and verified the table data swapped both ways.
- ✅ Manual end-to-end (stale-data fix): wiped the binding cache to simulate never-materialized, reproduced the stale dev-rows-as-prod bug pre-fix, then verified post-fix that resetting the override fails loudly.
- ✅ Manual end-to-end (auto-materialize): wiped the cache again and confirmed the preview auto-queued the build (API log: `Queued app binding materialization` with `force:false`) and rendered prod data with zero manual clicks; dev ⇄ prod switching unaffected.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4db592d5-6b5a-45b6-9c70-73889ed0101e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4db592d5-6b5a-45b6-9c70-73889ed0101e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

