### PR TITLE
MCP OAuth: return to server modal and auto-run tool discovery after connect

### DIFF
--- a/api/src/routes/mcp.routes.ts
+++ b/api/src/routes/mcp.routes.ts
@@ -34,6 +34,7 @@ import {
 } from "../services/mcp-client.service";
 import {
   completeMcpOAuthFlow,
+  findMcpOAuthFlowServerId,
   startMcpOAuthFlow,
 } from "../services/mcp-oauth.service";
 
@@ -82,36 +83,45 @@ mcpPresetRoutes.openapi(
   async c => {
     const { code, state, error, error_description } = c.req.query();
     const settingsUrl = "/settings/mcp";
+    // Carry the server id back so the UI can reopen that server's modal and
+    // auto-run discovery. Best-effort on errors (the flow may be gone).
+    const redirectWith = (params: Record<string, string>) => {
+      const query = new URLSearchParams(params).toString();
+      return c.redirect(`${settingsUrl}?${query}`);
+    };
+    const flowServerId = state
+      ? await findMcpOAuthFlowServerId(state).catch(() => null)
+      : null;
+    const serverParam = flowServerId ? { oauth_server: flowServerId } : {};
     if (error) {
       logger.warn("MCP OAuth callback returned an error", {
         error,
         error_description,
       });
-      return c.redirect(
-        `${settingsUrl}?oauth_error=${encodeURIComponent(error_description || error)}`,
-      );
+      return redirectWith({
+        oauth_error: error_description || error,
+        ...serverParam,
+      });
     }
     if (!code || !state) {
-      return c.redirect(`${settingsUrl}?oauth_error=Missing+code+or+state`);
+      return redirectWith({ oauth_error: "Missing code or state" });
     }
     const user = (c as AuthenticatedContext).get("user");
     if (!user) {
       return c.json({ success: false, error: "Unauthorized" }, 401);
     }
     try {
-      await completeMcpOAuthFlow({
+      const { serverId } = await completeMcpOAuthFlow({
         state,
         code,
         sessionUserId: user.id,
       });
-      return c.redirect(`${settingsUrl}?oauth_connected=1`);
+      return redirectWith({ oauth_connected: "1", oauth_server: serverId });
     } catch (err) {
       logger.error("MCP OAuth callback failed", { error: err });
       const message =
         err instanceof Error ? err.message : "OAuth connection failed";
-      return c.redirect(
-        `${settingsUrl}?oauth_error=${encodeURIComponent(message)}`,
-      );
+      return redirectWith({ oauth_error: message, ...serverParam });
     }
   },
 );

--- a/api/src/services/mcp-oauth.service.ts
+++ b/api/src/services/mcp-oauth.service.ts
@@ -226,6 +226,17 @@ export async function startMcpOAuthFlow(params: {
 }
 
 /**
+ * Server id of a pending flow (by `state`), so the OAuth callback can send
+ * the browser back to that server's settings modal even when the flow fails.
+ */
+export async function findMcpOAuthFlowServerId(
+  state: string,
+): Promise<string | null> {
+  const flow = await McpOAuthFlow.findOne({ state }).select("serverId").lean();
+  return flow?.serverId ? flow.serverId.toString() : null;
+}
+
+/**
  * Complete the flow from the OAuth callback: validate state, exchange the
  * authorization code (PKCE), persist tokens on the connection config.
  * Returns the workspace/server the flow belonged to for the UI redirect.

--- a/app/src/components/McpServersSection.tsx
+++ b/app/src/components/McpServersSection.tsx
@@ -3,7 +3,7 @@
  * any custom Streamable-HTTP server), save credentials, test the connection,
  * curate the exposed tool list, and review per-user approval grants.
  */
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Alert,
   Box,
@@ -391,9 +391,12 @@ function RestrictionControl({
 function OAuthConnectSection({
   server,
   onNotify,
+  onAlreadyAuthorized,
 }: {
   server: McpServerInfo;
   onNotify: (message: string, severity: "success" | "error") => void;
+  /** Called when no redirect is needed (valid tokens already stored). */
+  onAlreadyAuthorized?: () => void;
 }) {
   const { currentWorkspace } = useWorkspace();
   const startOAuth = useMcpStore(s => s.startOAuth);
@@ -415,6 +418,7 @@ function OAuthConnectSection({
       if (alreadyAuthorized) {
         onNotify("Account already connected", "success");
         setConnecting(false);
+        onAlreadyAuthorized?.();
         return;
       }
       // Hand the browser to the provider's consent screen; it redirects
@@ -710,11 +714,16 @@ function ServerDetail({
   server,
   preset,
   isAdmin,
+  autoDiscover,
+  onAutoDiscoverConsumed,
   onNotify,
 }: {
   server: McpServerInfo;
   preset: McpPresetInfo | undefined;
   isAdmin: boolean;
+  /** Run discovery automatically on mount (set after an OAuth return). */
+  autoDiscover?: boolean;
+  onAutoDiscoverConsumed?: () => void;
   onNotify: (message: string, severity: "success" | "error") => void;
 }) {
   const { currentWorkspace } = useWorkspace();
@@ -756,6 +765,18 @@ function ServerDetail({
       result.ok ? "success" : "error",
     );
   };
+
+  // After an OAuth return, kick off discovery without the extra click. The
+  // ref guards StrictMode double-invocation; the parent clears the flag so
+  // reopening the modal later doesn't re-trigger.
+  const autoDiscoverRan = useRef(false);
+  useEffect(() => {
+    if (!autoDiscover || autoDiscoverRan.current || !currentWorkspace) return;
+    autoDiscoverRan.current = true;
+    onAutoDiscoverConsumed?.();
+    void handleTest();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoDiscover, currentWorkspace]);
 
   const handleSetRestriction = async (
     toolName: string,
@@ -831,7 +852,11 @@ function ServerDetail({
       )}
 
       {server.authType === "oauth" ? (
-        <OAuthConnectSection server={server} onNotify={onNotify} />
+        <OAuthConnectSection
+          server={server}
+          onNotify={onNotify}
+          onAlreadyAuthorized={() => void handleTest()}
+        />
       ) : server.authType === "api_key" ? (
         <CredentialsForm
           server={server}
@@ -1211,11 +1236,20 @@ export function McpServersSection() {
   const { currentWorkspace, loading: workspaceLoading } = useWorkspace();
   const muiTheme = useTheme();
   const fullScreenDialog = useMediaQuery(muiTheme.breakpoints.down("sm"));
-  const { servers, presets, loading, error, fetchServers, fetchPresets } =
-    useMcpStore();
+  const {
+    servers,
+    presets,
+    loading,
+    error,
+    fetchServers,
+    fetchPresets,
+    oauthReturn,
+    clearOAuthReturn,
+  } = useMcpStore();
   const [addOpen, setAddOpen] = useState(false);
   const [addPreset, setAddPreset] = useState<string | undefined>(undefined);
   const [detailId, setDetailId] = useState<string | null>(null);
+  const [autoDiscoverId, setAutoDiscoverId] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [snackbar, setSnackbar] = useState<{
     open: boolean;
@@ -1236,28 +1270,34 @@ export function McpServersSection() {
   const notify = (message: string, severity: "success" | "error") =>
     setSnackbar({ open: true, message, severity });
 
-  // Surface the OAuth callback outcome (we land back here with a query flag).
+  // Fallback capture for entry paths that skip UrlSync hydration — normally
+  // UrlSync already moved the query flags into the store on page load.
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const oauthError = params.get("oauth_error");
-    const oauthConnected = params.get("oauth_connected");
-    if (!oauthError && !oauthConnected) return;
-    setSnackbar({
-      open: true,
-      message: oauthError
-        ? `OAuth connection failed: ${oauthError}`
-        : "Account connected — test the connection to load tools",
-      severity: oauthError ? "error" : "success",
-    });
-    params.delete("oauth_error");
-    params.delete("oauth_connected");
-    const query = params.toString();
-    window.history.replaceState(
-      null,
-      "",
-      window.location.pathname + (query ? `?${query}` : ""),
-    );
+    useMcpStore.getState().captureOAuthReturn();
   }, []);
+
+  // Surface the OAuth callback outcome: reopen the server's modal and, on
+  // success, auto-run discovery so tools load without another click.
+  useEffect(() => {
+    if (!oauthReturn) return;
+    clearOAuthReturn();
+    const { connected, error: oauthError, serverId } = oauthReturn;
+    if (serverId) setDetailId(serverId);
+    if (oauthError) {
+      notify(`OAuth connection failed: ${oauthError}`, "error");
+      return;
+    }
+    if (!connected) return;
+    if (serverId) {
+      setAutoDiscoverId(serverId);
+      notify("Account connected — loading tools…", "success");
+    } else {
+      notify(
+        "Account connected — test the connection to load tools",
+        "success",
+      );
+    }
+  }, [oauthReturn, clearOAuthReturn]);
 
   const effectivePresets: McpPresetInfo[] =
     presets.length > 0
@@ -1465,6 +1505,8 @@ export function McpServersSection() {
                 server={detailServer}
                 preset={presetByType(detailServer.connectorType)}
                 isAdmin={isAdmin}
+                autoDiscover={autoDiscoverId === detailServer.id}
+                onAutoDiscoverConsumed={() => setAutoDiscoverId(null)}
                 onNotify={notify}
               />
             </DialogContent>

--- a/app/src/components/UrlSync.tsx
+++ b/app/src/components/UrlSync.tsx
@@ -21,6 +21,7 @@ import {
   focusDbtRunsTab,
 } from "../dbt-runtime/shell";
 import { useDbtStore } from "../store/dbtStore";
+import { useMcpStore } from "../store/mcpStore";
 import { focusDashboardDataSourceTab } from "../dashboard-runtime/shell";
 import {
   TAB_DEEP_LINK_PATTERNS,
@@ -74,6 +75,13 @@ export function UrlSync() {
       isHydrated.current = false;
     }
   }, [user]);
+
+  // Capture MCP OAuth callback flags (?oauth_connected / ?oauth_error) into
+  // the store before the URL-sync effect below rewrites the address bar and
+  // strips them. The MCP settings section consumes the captured outcome.
+  useEffect(() => {
+    useMcpStore.getState().captureOAuthReturn();
+  }, []);
 
   // --- Hydration: Restore state from URL on mount ---
   useEffect(() => {

--- a/app/src/store/mcpStore.ts
+++ b/app/src/store/mcpStore.ts
@@ -84,6 +84,14 @@ export interface McpGrant {
   createdAt: string;
 }
 
+/** Outcome of an OAuth redirect back into the app (from URL query flags). */
+export interface McpOAuthReturn {
+  connected: boolean;
+  error: string | null;
+  /** Server the flow belonged to — lets the UI reopen its settings modal. */
+  serverId: string | null;
+}
+
 interface McpState {
   servers: McpServerInfo[];
   presets: McpPresetInfo[];
@@ -92,6 +100,8 @@ interface McpState {
   grants: Record<string, McpGrant[]>; // serverId → my grants
   loading: boolean;
   error: string | null;
+  /** Pending OAuth-callback outcome awaiting the MCP settings UI. */
+  oauthReturn: McpOAuthReturn | null;
 }
 
 interface McpActions {
@@ -141,6 +151,15 @@ interface McpActions {
     serverId: string,
     grantId: string,
   ) => Promise<void>;
+  /**
+   * Read the OAuth callback flags (`oauth_connected` / `oauth_error` /
+   * `oauth_server`) off the current URL into `oauthReturn`, and strip them
+   * from the address bar. Must run before UrlSync rewrites the URL, so it is
+   * called from UrlSync hydration (and again by the settings section as a
+   * fallback for direct loads). No-op when the flags are absent.
+   */
+  captureOAuthReturn: () => void;
+  clearOAuthReturn: () => void;
 }
 
 type McpStore = McpState & McpActions;
@@ -153,6 +172,7 @@ export const useMcpStore = create<McpStore>()(
     grants: {},
     loading: false,
     error: null,
+    oauthReturn: null,
 
     fetchServers: async workspaceId => {
       set(state => {
@@ -319,5 +339,30 @@ export const useMcpStore = create<McpStore>()(
       );
       await get().fetchGrants(workspaceId, serverId);
     },
+
+    captureOAuthReturn: () => {
+      const params = new URLSearchParams(window.location.search);
+      const error = params.get("oauth_error");
+      const connected = params.get("oauth_connected");
+      const serverId = params.get("oauth_server");
+      if (!error && !connected) return;
+      params.delete("oauth_error");
+      params.delete("oauth_connected");
+      params.delete("oauth_server");
+      const query = params.toString();
+      window.history.replaceState(
+        null,
+        "",
+        window.location.pathname + (query ? `?${query}` : ""),
+      );
+      set(state => {
+        state.oauthReturn = { connected: Boolean(connected), error, serverId };
+      });
+    },
+
+    clearOAuthReturn: () =>
+      set(state => {
+        state.oauthReturn = null;
+      }),
   })),
 );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After completing the MCP OAuth consent flow, the browser landed back on `/settings/mcp` with only a snackbar ("test the connection to load tools"). The server's settings modal did not reopen, and the user had to find the server card, reopen it, and click "Test connection" manually. The `?oauth_connected` query flag could also be stripped by `UrlSync`'s URL rewriting before the MCP settings section mounted, so sometimes not even the snackbar appeared.

## Changes

- **API** (`mcp.routes.ts`, `mcp-oauth.service.ts`): the OAuth callback redirect now carries `oauth_server=<serverId>` alongside `oauth_connected`/`oauth_error` (looked up from the pending flow by `state`, so error redirects carry it too when possible).
- **`mcpStore`**: new `oauthReturn` state plus `captureOAuthReturn()`/`clearOAuthReturn()` — the callback query flags are captured into the store and stripped from the URL.
- **`UrlSync`**: calls `captureOAuthReturn()` on mount, before URL hydration/sync can rewrite the address bar, fixing the lost-flag race.
- **`McpServersSection`**: consumes `oauthReturn` — reopens the manage modal for the connected server and auto-runs tool discovery (`testServer`), so tools load with no extra clicks. The `alreadyAuthorized` short-circuit in `OAuthConnectSection` also triggers discovery now.

## Demo

End-to-end test against a local mock OAuth-protected MCP server (spec-compliant: protected-resource metadata discovery, DCR, PKCE S256, consent page). After clicking Approve on the consent page, the app returns to Settings → MCP Servers, reopens the Mock CRM modal by itself, runs discovery automatically, and shows the two tools with the Connected chip — zero extra clicks:

[mcp_oauth_auto_reopen_and_discovery_demo.mp4](https://cursor.com/agents/bc-8361d9e4-b6a8-476a-b579-527e523c949e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp_oauth_auto_reopen_and_discovery_demo.mp4)

[Modal reopened automatically with discovered tools and Connected status](https://cursor.com/agents/bc-8361d9e4-b6a8-476a-b579-527e523c949e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_mcp_modal_connected_tools.webp)

## Testing

- ✅ `pnpm --filter app run typecheck`
- ✅ `pnpm --filter app run lint`
- ✅ `pnpm --filter api run lint`
- ✅ Manual E2E via browser: add custom OAuth server → consent → auto-reopen + auto-discovery verified (video above)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8361d9e4-b6a8-476a-b579-527e523c949e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8361d9e4-b6a8-476a-b579-527e523c949e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

