### PR TITLE
fix(close): sync opportunity/contact custom fields to destination columns

### DIFF
--- a/api/src/connectors/close/connector.test.ts
+++ b/api/src/connectors/close/connector.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { CloseConnector } from "./connector";
+import { buildCloseSearchFieldSelection } from "./schema";
 
 function createConnector() {
   return new CloseConnector({
@@ -201,6 +202,210 @@ async function testGroupSchemaResolves() {
   );
 }
 
+// Regression: opportunity custom fields must be flattened into `custom_cf_*`
+// columns on the backfill path. Previously only leads and custom_objects were
+// flattened, so opportunity custom fields stayed buried in the nested `custom`
+// JSON blob and never materialized as destination columns.
+function testOpportunityBackfillFlattensCustomFields() {
+  const connector = createConnector();
+
+  const normalized = connector.normalizeBackfillRecord("opportunities", {
+    id: "oppo_123",
+    lead_id: "lead_abc",
+    status_label: "Active",
+    date_updated: "2026-06-21T17:19:39.000Z",
+    // Nested blob (Search API `custom` field)
+    custom: { cf_renewal: "2027-01-01", cf_amount: 42 },
+    // Flat dotted key (explicit `_fields=custom.cf_<id>` selector)
+    "custom.cf_owner": "user_1",
+  });
+
+  assert.ok(normalized);
+  if (!normalized) return;
+  const payload = normalized.payload as Record<string, unknown>;
+  assert.equal(payload.custom_cf_renewal, "2027-01-01");
+  assert.equal(payload.custom_cf_amount, 42);
+  assert.equal(payload.custom_cf_owner, "user_1");
+  assert.ok(
+    !("custom.cf_owner" in payload),
+    "dotted key should be renamed, not duplicated",
+  );
+  assert.deepEqual(
+    payload.custom,
+    { cf_renewal: "2027-01-01", cf_amount: 42 },
+    "nested custom blob should be preserved as JSON fallback",
+  );
+}
+
+// Same regression for the webhook path: opportunity.updated payloads carry a
+// nested `custom` object which must land in `custom_cf_*` columns.
+function testOpportunityWebhookFlattensCustomFields() {
+  const connector = createConnector();
+
+  const records = connector.extractWebhookCdcRecords(
+    {
+      event: {
+        id: "ev_oppo_1",
+        object_type: "opportunity",
+        action: "updated",
+        object_id: "oppo_123",
+        date_updated: "2026-06-21T17:19:39.000Z",
+        data: {
+          id: "oppo_123",
+          status_label: "Active",
+          date_updated: "2026-06-21T17:19:39.000Z",
+          custom: { cf_renewal: "2027-01-01" },
+        },
+      },
+    },
+    "opportunity.updated",
+  );
+
+  assert.equal(records.length, 1);
+  assert.equal(records[0].entity, "opportunities");
+  const payload = records[0].payload as Record<string, unknown>;
+  assert.equal(payload.custom_cf_renewal, "2027-01-01");
+}
+
+// Contacts share the same custom-field mechanics as opportunities.
+function testContactBackfillFlattensCustomFields() {
+  const connector = createConnector();
+
+  const normalized = connector.normalizeBackfillRecord("contacts", {
+    id: "cont_123",
+    lead_id: "lead_abc",
+    date_updated: "2026-06-21T17:19:39.000Z",
+    custom: { cf_linkedin: "https://linkedin.com/in/x" },
+  });
+
+  assert.ok(normalized);
+  if (!normalized) return;
+  const payload = normalized.payload as Record<string, unknown>;
+  assert.equal(payload.custom_cf_linkedin, "https://linkedin.com/in/x");
+}
+
+// The Search API field selection must enumerate every custom field as an
+// explicit `custom.cf_<id>` selector (plus keep the `custom` blob fallback),
+// so no field is silently missing from backfill payloads.
+function testSearchFieldSelectionIncludesCustomFieldSelectors() {
+  const selection = buildCloseSearchFieldSelection(
+    ["id", "lead_id", "custom"],
+    [
+      {
+        id: "cf_renewal",
+        name: "Renewal Date",
+        type: "date",
+        appliesTo: "opportunity",
+      },
+      {
+        id: "cf_amount",
+        name: "Amount",
+        type: "number",
+        appliesTo: "opportunity",
+      },
+      { id: "", name: "bogus", type: "text", appliesTo: "opportunity" },
+    ],
+  );
+
+  assert.deepEqual(selection, [
+    "id",
+    "lead_id",
+    "custom",
+    "custom.cf_renewal",
+    "custom.cf_amount",
+  ]);
+}
+
+// End-to-end contract for the opportunity backfill path with a stubbed Close
+// client: the Search API request must enumerate `custom.cf_<id>` selectors,
+// and records handed to onBatch must arrive with flattened `custom_cf_*` keys.
+async function testOpportunitySearchBackfillRequestsAndFlattensCustomFields() {
+  const connector = createConnector();
+
+  const searchBodies: any[] = [];
+  let servedPage = false;
+
+  const opportunityRow = {
+    id: "oppo_1",
+    lead_id: "lead_1",
+    status_label: "Active",
+    date_created: "2026-01-01T00:00:01.000Z",
+    date_updated: "2026-01-02T00:00:00.000Z",
+    "custom.cf_renewal": "2027-01-01",
+    custom: { cf_renewal: "2027-01-01", cf_amount: 42 },
+  };
+
+  (connector as any).closeApi = {
+    get: async (url: string) => {
+      if (url === "/custom_field_schema/opportunity/") {
+        return {
+          data: {
+            fields: [
+              { id: "cf_renewal", name: "Renewal Date", type: "date" },
+              { id: "cf_amount", name: "Amount", type: "number" },
+            ],
+          },
+        };
+      }
+      return { data: {} };
+    },
+    post: async (_url: string, body: any) => {
+      if (body?.include_counts) {
+        return { data: { count: { total: 1 }, data: [] } };
+      }
+      if (body?._limit === 1 && Array.isArray(body?.sort)) {
+        // Oldest-record probe used to seed the date window
+        return {
+          data: {
+            data: [{ id: "oppo_1", date_created: "2026-01-01T00:00:00.000Z" }],
+          },
+        };
+      }
+      if (body?._limit === 1) {
+        // Gap probe after the window is exhausted — no more data
+        return { data: { data: [] } };
+      }
+      searchBodies.push(body);
+      if (!servedPage) {
+        servedPage = true;
+        return { data: { data: [opportunityRow], cursor: null } };
+      }
+      return { data: { data: [], cursor: null } };
+    },
+  };
+
+  const batches: Record<string, unknown>[][] = [];
+  const state = await connector.fetchEntityChunk({
+    entity: "opportunities",
+    onBatch: async batch => {
+      batches.push(batch);
+    },
+    onProgress: () => {},
+    rateLimitDelay: 1,
+  } as any);
+
+  assert.equal(state.hasMore, false);
+  assert.ok(searchBodies.length >= 1, "should issue a paged search request");
+  const requestedFields: string[] = searchBodies[0]?._fields?.opportunity ?? [];
+  assert.ok(
+    requestedFields.includes("custom.cf_renewal"),
+    `_fields should include custom.cf_renewal, got: ${requestedFields.join(",")}`,
+  );
+  assert.ok(
+    requestedFields.includes("custom"),
+    "_fields should keep the custom blob fallback",
+  );
+
+  assert.equal(batches.length, 1);
+  const record = batches[0][0];
+  assert.equal(record.custom_cf_renewal, "2027-01-01");
+  assert.equal(record.custom_cf_amount, 42);
+  assert.ok(
+    !("custom.cf_renewal" in record),
+    "dotted key should be renamed in emitted records",
+  );
+}
+
 async function main() {
   testUserWebhookEventsAreSupported();
   testUserWebhookEventsAreMapped();
@@ -212,6 +417,11 @@ async function main() {
   testGroupWebhookEventsAreScopedToGroups();
   testGroupWebhookEventsAreMapped();
   await testGroupSchemaResolves();
+  testOpportunityBackfillFlattensCustomFields();
+  testOpportunityWebhookFlattensCustomFields();
+  testContactBackfillFlattensCustomFields();
+  testSearchFieldSelectionIncludesCustomFieldSelectors();
+  await testOpportunitySearchBackfillRequestsAndFlattensCustomFields();
 }
 
 main().catch(error => {

--- a/api/src/connectors/close/connector.ts
+++ b/api/src/connectors/close/connector.ts
@@ -14,7 +14,11 @@ import {
   type WebhookCapabilities,
   type ConnectorEntitySchema,
 } from "../base/BaseConnector";
-import { resolveCloseEntitySchema, type CloseCustomField } from "./schema";
+import {
+  resolveCloseEntitySchema,
+  buildCloseSearchFieldSelection,
+  type CloseCustomField,
+} from "./schema";
 import axios, { AxiosInstance } from "axios";
 import * as crypto from "crypto";
 import { loggers } from "../../logging";
@@ -464,11 +468,22 @@ export class CloseConnector extends BaseConnector {
   }
 
   /**
-   * Flatten nested `custom` object into `custom_<cfId>` columns so that
-   * webhook payloads (nested object) match backfill payloads (flat keys via
-   * `_fields=custom.cf_xxx`).
+   * Flatten custom fields into `custom_<cfId>` columns so that webhook
+   * payloads (nested `custom` object) and backfill payloads (flat dotted keys
+   * via `_fields=custom.cf_xxx`) both land in the schema-declared columns.
    */
   private static flattenCustomFields(record: Record<string, unknown>): void {
+    // Flat dotted keys from explicit `_fields` selectors: custom.cf_x → custom_cf_x
+    for (const rawKey of Object.keys(record)) {
+      if (!/^custom\.cf_[A-Za-z0-9]+$/.test(rawKey)) continue;
+      const flatKey = rawKey.replace(/\./g, "_");
+      if (!(flatKey in record)) {
+        record[flatKey] = record[rawKey];
+      }
+      delete record[rawKey];
+    }
+
+    // Nested `custom` object (webhook payloads, Search API `custom` blob)
     if (
       record.custom &&
       typeof record.custom === "object" &&
@@ -484,6 +499,13 @@ export class CloseConnector extends BaseConnector {
       }
     }
   }
+
+  /** Entities whose payloads carry Close custom fields that must be flattened. */
+  private static readonly CUSTOM_FIELD_FLATTEN_ENTITIES = new Set([
+    "opportunities",
+    "contacts",
+    "custom_objects",
+  ]);
 
   private normalizeLeadRecord(
     record: Record<string, unknown>,
@@ -1232,6 +1254,24 @@ export class CloseConnector extends BaseConnector {
       fieldsMap[objectType] = activityFields;
     }
 
+    // Core objects: enumerate every custom field as an explicit
+    // `custom.cf_<id>` selector so values come back as flat keys (matching the
+    // schema's `custom_cf_*` columns) instead of relying solely on the
+    // aggregate `custom` blob. Resolved once per chunk; the custom-field
+    // schema lookup is cached per connector instance.
+    let coreFieldSelection: string[] | null = null;
+    if (
+      objectType === "lead" ||
+      objectType === "contact" ||
+      objectType === "opportunity"
+    ) {
+      const customFields = await this.fetchCustomFieldsViaSchema(objectType);
+      coreFieldSelection = buildCloseSearchFieldSelection(
+        fieldsMap[objectType] || [],
+        customFields,
+      );
+    }
+
     // Forward-scanning ASC date windows avoid the non-deterministic row drops
     // that occur with DESC sort + cursor resets.  Close's Search API cursor is
     // unstable under DESC sort: resetting the cursor mid-window can silently
@@ -1387,15 +1427,8 @@ export class CloseConnector extends BaseConnector {
           ],
         };
 
-        if (
-          objectType === "lead" ||
-          objectType === "contact" ||
-          objectType === "opportunity"
-        ) {
-          const baseFields = fieldsMap[objectType] || [];
-          body._fields = {
-            [objectType]: Array.from(new Set([...baseFields, "custom"])),
-          };
+        if (coreFieldSelection) {
+          body._fields = { [objectType]: coreFieldSelection };
         } else if (fieldsMap[objectType]) {
           body._fields = { [objectType]: fieldsMap[objectType] };
         }
@@ -1409,7 +1442,17 @@ export class CloseConnector extends BaseConnector {
 
         if (data.length > 0) {
           const records =
-            entity === "leads" ? this.normalizeLeadBatch(data) : data;
+            entity === "leads"
+              ? this.normalizeLeadBatch(data)
+              : CloseConnector.CUSTOM_FIELD_FLATTEN_ENTITIES.has(entity)
+                ? data.map((record: any) => {
+                    const normalized = {
+                      ...(record || {}),
+                    } as Record<string, unknown>;
+                    CloseConnector.flattenCustomFields(normalized);
+                    return normalized;
+                  })
+                : data;
           await onBatch(records);
           recordCount += records.length;
           if (onProgress) onProgress(recordCount, undefined);
@@ -2596,7 +2639,10 @@ export class CloseConnector extends BaseConnector {
       let payload = (record.payload || {}) as Record<string, unknown>;
       if (record.entity === "leads") {
         payload = this.normalizeLeadRecord(payload);
-      } else if (record.entity === "custom_objects") {
+      } else if (
+        CloseConnector.CUSTOM_FIELD_FLATTEN_ENTITIES.has(record.entity)
+      ) {
+        payload = { ...payload };
         CloseConnector.flattenCustomFields(payload);
       }
       return {
@@ -2628,7 +2674,8 @@ export class CloseConnector extends BaseConnector {
     let payload = (normalized.payload || {}) as Record<string, unknown>;
     if (entity === "leads") {
       payload = this.normalizeLeadRecord(payload);
-    } else if (entity === "custom_objects") {
+    } else if (CloseConnector.CUSTOM_FIELD_FLATTEN_ENTITIES.has(entity)) {
+      payload = { ...payload };
       CloseConnector.flattenCustomFields(payload);
     }
 

--- a/api/src/connectors/close/schema.ts
+++ b/api/src/connectors/close/schema.ts
@@ -551,6 +551,27 @@ export interface CloseCustomField {
   acceptsMultipleValues?: boolean;
 }
 
+/**
+ * Build the Search API `_fields` selection for a core object type.
+ *
+ * Requests every custom field explicitly (`custom.cf_<id>`) in addition to
+ * the aggregate `custom` blob. The explicit selectors guarantee each field is
+ * returned as a flat key even if the blob omits it; the blob is kept as a
+ * fallback (and lands as a JSON column) in case the Search API ignores the
+ * dotted selectors.
+ */
+export function buildCloseSearchFieldSelection(
+  baseFields: readonly string[],
+  customFields: CloseCustomField[],
+): string[] {
+  const fields = new Set<string>([...baseFields, "custom"]);
+  for (const field of customFields) {
+    if (!field.id) continue;
+    fields.add(`custom.${field.id}`);
+  }
+  return Array.from(fields);
+}
+
 export function resolveCloseEntitySchema(
   entity: string,
   customFields: CloseCustomField[],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Close opportunity (and contact) custom fields never landed as columns in BigQuery — only ~9 base columns materialized, none of the custom (e.g. renewal) fields. Root cause chain:

1. `resolveCloseEntitySchema` declares `custom_cf_*` columns for opportunities/contacts, so Mako "knows" about them.
2. But `flattenCustomFields` only ran for `leads` and `custom_objects` — opportunity/contact payloads kept their custom values buried (nested `custom` object on webhooks, dotted `custom.cf_*` keys on the Search API) on both the backfill (`normalizeBackfillRecord`, `fetchViaSearchApi`) and webhook (`extractWebhookCdcRecords`) paths.
3. The BigQuery adapter creates live-table columns from **actual staging payload keys** (`ensureLiveTableFromSchema`), not the declared schema — so declared-but-never-populated `custom_cf_*` columns never got created.

## Fix

- Wire `flattenCustomFields` for `opportunities` and `contacts` on all three paths: backfill record normalization, Search API batch emission, and webhook CDC extraction.
- Extend `flattenCustomFields` to also normalize flat dotted keys (`custom.cf_x` → `custom_cf_x`) coming from `_fields` selectors.
- The Search API `_fields` for lead/contact/opportunity now enumerates every custom field explicitly as `custom.cf_<id>` (new `buildCloseSearchFieldSelection`, sourced from the cached `/custom_field_schema/<type>/` lookup — same source as the declared schema, so selectors and columns stay consistent). The aggregate `custom` blob is kept as a fallback.

Existing destination rows won't retro-fill; re-run a backfill for `opportunities`/`contacts` after deploying — the BigQuery adapter auto-adds the new `custom_cf_*` columns via `ALTER TABLE … ADD COLUMN IF NOT EXISTS`.

## Verified against the real Close API ✔

Using the `Mako Demo Org` Close trial account (`mako-close-demo@agentmail.to`): created two opportunity custom fields (`Renewal Date` date, `ARR Tier` choices), set values on both seeded opportunities, then ran the real `fetchEntityChunk("opportunities")` end-to-end against the live Search API.

**Pre-fix code** (master): records emit dotted `custom.cf_<id>` keys that don't match the schema's declared `custom_cf_*` columns — and notably, the Search API returns **no `custom` blob at all** even when requested, so the old blob-only `_fields` never had a safety net on this path:

[close_real_api_backfill_test_OLD_CODE.log](https://cursor.com/agents/bc-e3cbfa78-d050-4053-9e39-69981af82ee5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclose_real_api_backfill_test_OLD_CODE.log)

**With this fix**: records emit flat `custom_cf_*` keys matching the resolved schema (typed `timestamp`/`string`), values intact ("2027-03-15"/"Gold", "2026-12-01"/"Silver"):

[close_real_api_backfill_test.log](https://cursor.com/agents/bc-e3cbfa78-d050-4053-9e39-69981af82ee5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclose_real_api_backfill_test.log)

## Tests

- Real Close API end-to-end backfill contract (above): pre-fix FAILS, post-fix PASSES
- `custom_cf_*` flattening for opportunity backfill records (nested blob + dotted keys, blob preserved as fallback)
- Flattening on the opportunity webhook path (nested `custom` object per Close webhook payload shape)
- Contact backfill flattening
- `buildCloseSearchFieldSelection` selector construction (dedupe, skips empty ids)
- Stubbed end-to-end opportunity backfill contract (offline CI-safe variant of the real-API test)

✅ `pnpm --filter api exec tsx src/connectors/close/connector.test.ts`
✅ `pnpm --filter api run test`
✅ `pnpm --filter api run test:destinations` (151 tests)
✅ `pnpm --filter api run lint`
⚠️ `pnpm --filter api run build` — fails on pre-existing `src/routes/mcp.routes.ts` type errors also present on `master` (verified via stash); no type errors in changed files.

Real BigQuery round-trip not run here (needs Docker for the gated `RUN_DB_INTEGRATION=1` suite; runs nightly via `destination-integration.yml`).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3cbfa78-d050-4053-9e39-69981af82ee5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3cbfa78-d050-4053-9e39-69981af82ee5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

