### PR TITLE
fix(apps): 404 + self-heal for missing parquet artifacts; sync binding cache after server-side materialize

### DIFF
--- a/api/src/routes/apps.ts
+++ b/api/src/routes/apps.ts
@@ -902,6 +902,17 @@ app.openapi(
       const store = getDashboardArtifactStore();
       const stream = await store.openReadStream(info.artifactKey);
       if (!stream) {
+        // The binding cache says "ready" but the artifact bytes are gone
+        // (bucket cleanup, prod restore onto a machine without the files).
+        // Self-heal: queue a background rebuild — the atomic claim inside
+        // queueAppBindingMaterialization dedupes the concurrent 404s a page
+        // load produces — and return a clean 404 for this read. Open tabs
+        // pick the fresh artifact up via the post-build app.updated poke.
+        void queueAppBindingMaterialization({
+          workspaceId,
+          appId: id,
+          bindingId,
+        }).catch(() => undefined);
         return c.json({ success: false, error: "Artifact not found" }, 404);
       }
 

--- a/api/src/routes/mcp.routes.ts
+++ b/api/src/routes/mcp.routes.ts
@@ -92,7 +92,9 @@ mcpPresetRoutes.openapi(
     const flowServerId = state
       ? await findMcpOAuthFlowServerId(state).catch(() => null)
       : null;
-    const serverParam = flowServerId ? { oauth_server: flowServerId } : {};
+    const serverParam: Record<string, string> = flowServerId
+      ? { oauth_server: flowServerId }
+      : {};
     if (error) {
       logger.warn("MCP OAuth callback returned an error", {
         error,

--- a/api/src/services/app-binding-materialization.service.ts
+++ b/api/src/services/app-binding-materialization.service.ts
@@ -29,6 +29,7 @@ import {
   PARQUET_ROW_LIMIT,
 } from "./parquet-build.service";
 import { inngest } from "../inngest/client";
+import { publishRealtimeEvent } from "./realtime.service";
 import { loggers } from "../logging";
 
 const logger = loggers.api("app-materialization");
@@ -605,6 +606,24 @@ export async function materializeAppBinding(input: {
         status: "ready",
         rowCount: parquet.rowCount,
         byteSize: parquet.byteSize,
+      });
+
+      // Bump the doc version + poke so open tabs refetch and load the fresh
+      // artifact. Foreground callers (the agent tool, the browser's status
+      // poller) converge on their own, but background builds — scheduled
+      // refreshes and the serve route's missing-artifact self-heal — would
+      // otherwise complete silently, leaving open tabs on the broken state.
+      const bumped = await MakoApp.findByIdAndUpdate(
+        appDoc._id,
+        { $inc: { version: 1 } },
+        { new: true },
+      );
+      publishRealtimeEvent(workspaceId, {
+        type: "app.updated",
+        appId,
+        version: bumped?.version ?? appDoc.version + 1,
+        updatedBy: "system",
+        origin: "save",
       });
 
       logger.info("Materialized app binding", {

--- a/api/src/services/dashboard-artifact-store.service.ts
+++ b/api/src/services/dashboard-artifact-store.service.ts
@@ -1,4 +1,4 @@
-import fs, { promises as fsPromises } from "fs";
+import { promises as fsPromises } from "fs";
 import crypto from "crypto";
 import path from "path";
 import { Storage } from "@google-cloud/storage";
@@ -142,7 +142,17 @@ class FilesystemDashboardArtifactStore implements DashboardArtifactStore {
   }
 
   async openReadStream(key: string): Promise<NodeJS.ReadableStream | null> {
-    return fs.createReadStream(this.resolvePath(key));
+    // fs.createReadStream on a missing file only errors ASYNCHRONOUSLY —
+    // after the serve route has already sent 200 headers — which truncates
+    // direct responses and permanently hangs proxied ones (the Vite dev
+    // proxy never terminates the client request). Open the fd first so a
+    // missing artifact is a clean `null` (routes turn it into a 404).
+    try {
+      const handle = await fsPromises.open(this.resolvePath(key), "r");
+      return handle.createReadStream();
+    } catch {
+      return null;
+    }
   }
 
   async getSize(key: string): Promise<number | null> {
@@ -242,8 +252,14 @@ class GcsDashboardArtifactStore implements DashboardArtifactStore {
   }
 
   async openReadStream(key: string): Promise<NodeJS.ReadableStream | null> {
+    // Same lazy-error hazard as the filesystem store: a GCS read stream for a
+    // missing object only fails after headers are sent. Probe existence first
+    // so callers get `null` (→ 404) instead of a mid-stream abort.
     try {
-      return this.file(key).createReadStream();
+      const file = this.file(key);
+      const [exists] = await file.exists();
+      if (!exists) return null;
+      return file.createReadStream();
     } catch {
       return null;
     }

--- a/app/src/agent-runtime/data-source-tools.ts
+++ b/app/src/agent-runtime/data-source-tools.ts
@@ -50,6 +50,36 @@ export async function executeDataSourceTool(
 
 // ---- App surface ---------------------------------------------------------
 
+type AppEntityLike = ReturnType<
+  typeof useAppStore.getState
+>["openApps"][string];
+
+/**
+ * Server-side materialization completes with only a workspace poke as the
+ * fast-path delivery; a missed poke (dead SSE) leaves this window's copy of
+ * the binding cache stale — historically surfacing as "table does not exist"
+ * / "Parquet not built yet" loops even though the artifact was long ready.
+ * When a relevant parquet binding's local cache isn't "ready", pull the
+ * authoritative app once before trusting the stale copy.
+ */
+async function refreshAppIfParquetCacheStale(
+  workspaceId: string | null | undefined,
+  appId: string,
+  appEntity: AppEntityLike,
+  bindingName?: string,
+): Promise<AppEntityLike> {
+  if (!workspaceId) return appEntity;
+  const stale = appEntity.dataBindings.some(
+    b =>
+      b.materialization === "parquet" &&
+      (bindingName === undefined || b.name === bindingName) &&
+      b.cache?.parquetBuildStatus !== "ready",
+  );
+  if (!stale) return appEntity;
+  const fresh = await useAppStore.getState().fetchApp(workspaceId, appId);
+  return fresh ?? appEntity;
+}
+
 async function executeAppDataTool(
   toolName: string,
   appId: string,
@@ -87,6 +117,12 @@ async function executeAppDataTool(
 
   if (toolName === "inspect_data_source") {
     const name = input.dataSource as string;
+    appEntity = await refreshAppIfParquetCacheStale(
+      workspaceId,
+      appId,
+      appEntity,
+      name,
+    );
     const binding = appEntity.dataBindings.find(b => b.name === name);
     if (!binding) return fail(`No data source named "${name}"`);
 
@@ -144,6 +180,11 @@ async function executeAppDataTool(
 
   if (toolName === "query_duckdb") {
     try {
+      appEntity = await refreshAppIfParquetCacheStale(
+        workspaceId,
+        appId,
+        appEntity,
+      );
       // Preview-env aware, matching what the app preview itself reads.
       await Promise.all(
         appEntity.dataBindings

--- a/app/src/components/chat/tool-presentation.ts
+++ b/app/src/components/chat/tool-presentation.ts
@@ -55,6 +55,15 @@ export const APP_SERVER_MUTATION_TOOLS = new Set<string>([
   "app_create_data_binding",
   "app_update_data_binding",
   "app_delete_data_binding",
+  // Binding cache/schedule mutations and restores also happen server-side
+  // with only the workspace poke as delivery. materialize_binding especially:
+  // a missed poke left the open tab's binding cache stale (status null), so
+  // the client-side query_duckdb / inspect_data_source kept reporting the
+  // parquet table as missing even though the build was long done.
+  "materialize_binding",
+  "app_set_binding_materialization",
+  "app_set_binding_schedule",
+  "app_restore_version",
 ]);
 export const DBT_SERVER_MUTATION_TOOLS = new Set<string>([
   "create_dbt_file",


### PR DESCRIPTION
## Summary

Two related failure modes around materialized (parquet) app bindings, found while debugging a frozen Product Growth Dashboard after a prod DB restore:

### 1. Missing artifact bytes hung the whole app (and dev server proxy)

When a binding's cache said `ready` but the artifact file was gone (prod restore onto a machine without the files, cloud bucket cleanup), `openReadStream` returned a stream that only errored **after** the serve route had sent `200` headers:

- direct responses were truncated (`transfer closed with outstanding read data remaining`),
- **Vite-proxied responses hung forever** — the app preloads all parquet bindings at once, so ~7 hung requests exhausted Chrome's 6-connections-per-origin pool and froze the entire tab (only killing `pnpm dev` recovered it).

Fixes:
- `dashboard-artifact-store.service.ts`: detect the miss up front — filesystem opens the fd before streaming, GCS probes existence (same lazy-error hazard in prod). S3 already checked `response.ok`. All artifact routes (apps, dashboards, public shares, dbt) now return an instant, clean `404`.
- `apps.ts` artifact route: on a miss, fire-and-forget `queueAppBindingMaterialization` (atomic claim dedupes the concurrent 404s of a page load; a failed rebuild flips status away from `ready`, so hydrated `parquetUrl`s — and the retries — stop).
- `app-binding-materialization.service.ts`: successful builds bump the app version + publish `app.updated`, so background rebuilds (self-heal, scheduled refreshes) are picked up by open tabs instead of completing silently.

Verified end-to-end locally: deleting an artifact → instant 404 → auto-rebuilt ~12s later → next fetch 200, no user action needed. The public-share route intentionally does **not** auto-queue (unauthenticated traffic shouldn't trigger warehouse queries); anonymous viewers recover once the owner-side heal runs.

### 2. Server-side `materialize_binding` results never reconciled open tabs

`materialize_binding` executes server-side with only the workspace SSE poke as delivery; a missed poke left the open tab's binding cache stale (`status: null`), so the client-executed `query_duckdb` / `inspect_data_source` looped on "table does not exist" even though the build was long done (observed in an agent transcript, where it got superstitiously "fixed" by unrelated file writes — which happen to be in the reconcile set).

Fixes:
- `tool-presentation.ts`: added `materialize_binding`, `app_set_binding_materialization`, `app_set_binding_schedule`, `app_restore_version` to `APP_SERVER_MUTATION_TOOLS` so the resumable chat-stream backstop refetches the app when their results stream in.
- `data-source-tools.ts`: `query_duckdb` / `inspect_data_source` refetch the app once when a parquet binding's local cache isn't `ready` before declaring the table missing.

## Test plan

- [x] `pnpm --filter api run build` (lint + typecheck) green
- [x] `pnpm --filter app run typecheck && pnpm --filter app run lint` green
- [x] Repro harness: missing-file stream through a Vite proxy hung pre-fix; post-fix returns 404 in ~5ms, 200 when the file exists
- [x] Live: deleted a binding's parquet from the local store → 404 + background rebuild restored it in ~12s → 200 without any manual action
- [ ] Regression pass on dashboard data-source materialization (shares the store changes)

Made with [Cursor](https://cursor.com)