### PR TITLE
feat(analytics): track checkout_started and checkout_completed

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -40,7 +40,7 @@ import {
   PanelResizeHandle,
   type ImperativePanelGroupHandle,
 } from "react-resizable-panels";
-import { trackPageView } from "./lib/analytics";
+import { trackEvent, trackPageView } from "./lib/analytics";
 import { setIframeDragGuard } from "./lib/iframe-drag-guard";
 import Sidebar, {
   SidebarUserMenu,
@@ -1015,6 +1015,30 @@ function DesktopAuthResume() {
   return <Navigate to="/desktop-auth" replace />;
 }
 
+// Fire checkout_completed exactly once when Stripe redirects back with
+// ?billing=success (see api billing route's default successUrl). The param is
+// stripped via replaceState so refreshes/back-navigation don't re-fire it.
+function CheckoutSuccessTracker() {
+  const location = useLocation();
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    if (params.get("billing") !== "success") return;
+
+    trackEvent("checkout_completed");
+
+    params.delete("billing");
+    const query = params.toString();
+    window.history.replaceState(
+      window.history.state,
+      "",
+      `${location.pathname}${query ? `?${query}` : ""}${location.hash}`,
+    );
+  }, [location.search, location.pathname, location.hash]);
+
+  return null;
+}
+
 // Track page views on route changes for SPA
 function PageViewTracker() {
   const location = useLocation();
@@ -1046,6 +1070,7 @@ function App() {
   return (
     <>
       <PageViewTracker />
+      <CheckoutSuccessTracker />
       <DesktopAuthResume />
       <UpdateNotification />
       <Routes>

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -16,7 +16,9 @@ type MarketingEvent =
   | "workspace_created"
   | "onboarding_completed"
   | "email_verified"
-  | "demo_database_created";
+  | "demo_database_created"
+  | "checkout_started"
+  | "checkout_completed";
 
 // Product events - sent to PostHog via GTM for product analytics
 type ProductEvent =

--- a/app/src/store/billingStore.ts
+++ b/app/src/store/billingStore.ts
@@ -7,6 +7,7 @@
 
 import { create } from "zustand";
 import { api, unwrapBody } from "../api";
+import { trackEvent } from "../lib/analytics";
 
 export interface BillingStatus {
   billingEnabled: boolean;
@@ -86,6 +87,8 @@ export const useBillingStore = create<BillingState>()(set => ({
           body: { successUrl, cancelUrl },
         }),
       ) as { url: string };
+      // Marketing funnel event: the user is being handed to Stripe Checkout.
+      trackEvent("checkout_started", { workspace_id: workspaceId });
       return result.url;
     } catch (err) {
       set({


### PR DESCRIPTION
## Summary
- `checkout_started` fires when a Stripe Checkout session is created (`billingStore.createCheckoutSession`)
- `checkout_completed` fires exactly once when Stripe redirects back with `?billing=success`; the param is stripped via `replaceState` so refreshes/back-navigation don't re-fire it
- Both added to the marketing event union in `lib/analytics.ts` and flow through the existing dataLayer -> GTM routing like the rest of the funnel events

## Test plan
- [ ] Upgrade flow: click Upgrade to Pro -> `checkout_started` visible in dataLayer
- [ ] Complete a test checkout -> land on `/settings?billing=success` -> `checkout_completed` pushed once, URL param removed
- [ ] Refresh after redirect -> no duplicate event

Made with [Cursor](https://cursor.com)