### PR TITLE
chore(cursor): durable MCP allowlists via permissions.json

### DIFF
--- a/.cursor/cli.json
+++ b/.cursor/cli.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Mcp(playwright:*)",
+      "Mcp(*playwright:*)"
+    ]
+  }
+}

--- a/.cursor/permissions.json
+++ b/.cursor/permissions.json
@@ -1,0 +1,25 @@
+{
+  // Source of truth for MCP auto-approval in this repo.
+  // Prefer this file over clicking "Always allow" in chat — UI entries are
+  // per exact server:tool and break when Cursor's internal server ID format
+  // changes (e.g. playwright vs project-0-playwright).
+  //
+  // Docs: https://cursor.com/docs/reference/permissions.md
+  // Requires Run Mode = Auto-review or Allowlist (Settings > Agents > Approvals).
+  //
+  // When this key is set, the in-app MCP allowlist editor becomes read-only.
+  // Personal servers belong in ~/.cursor/permissions.json (arrays merge).
+
+  "mcpAllowlist": [
+    // Repo MCP from .cursor/mcp.json
+    "playwright:*",
+    // Tolerate Cursor's project-prefixed server IDs (known allowlist mismatch)
+    "*playwright:*"
+  ],
+
+  "autoRun": {
+    "allow_instructions": [
+      "Playwright MCP browser automation tools configured in this repo are trusted and should auto-run without prompting."
+    ]
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Clicking **Always allow** on MCP tool prompts is brittle: Cursor stores exact `server:tool` entries, and the internal server ID can change between sessions (e.g. `playwright` vs `project-0-playwright`). That makes UI allowlist clicks silently stop matching, so prompts keep coming back.

## Approach

Treat allowlists as **config-as-code** next to `.cursor/mcp.json`, using wildcards that survive ID-format churn:

| File | Scope |
| --- | --- |
| `.cursor/permissions.json` | IDE / Agent Window MCP allowlist + Auto-review steering |
| `.cursor/cli.json` | Cursor CLI `Mcp(...)` permissions (separate system) |

Patterns used:

- `playwright:*` — all tools from the repo Playwright MCP
- `*playwright:*` — same tools when Cursor prefixes the server ID

Personal / cloud MCP servers (ClickHouse, PostHog, cursor-cloud) belong in `~/.cursor/permissions.json` (not committed); arrays merge with the repo file.

## What you need locally

1. **Settings → Agents → Approvals & Execution** → Run Mode = **Auto-review** (or Allowlist)
2. Update Cursor if "Always allow" was never sticking (server-ID mismatch fixes shipped early Feb 2026)
3. Optional personal file: `~/.cursor/permissions.json` with your trusted servers as `"myserver:*"`

Once `mcpAllowlist` is defined in `permissions.json`, the in-app MCP allowlist editor becomes read-only — manage entries in the file going forward.

## Docs

- https://cursor.com/docs/reference/permissions.md
- https://cursor.com/docs/agent/security/run-modes.md
- https://cursor.com/docs/cli/reference/permissions.md
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35752433-6127-4efb-8392-d3f112508c5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35752433-6127-4efb-8392-d3f112508c5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

