### PR TITLE
feat(analytics): add stable event IDs

### DIFF
--- a/app/src/lib/analytics.test.ts
+++ b/app/src/lib/analytics.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { trackEvent } from "./analytics";
+
+describe("trackEvent", () => {
+  beforeEach(() => {
+    vi.stubGlobal("window", { dataLayer: [] });
+    vi.stubGlobal("crypto", { randomUUID: () => "generated-event-id" });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("adds one stable event_id to flat and nested properties", () => {
+    trackEvent("query_executed", { database_type: "postgresql" });
+
+    expect(window.dataLayer).toHaveLength(1);
+    expect(window.dataLayer[0]).toMatchObject({
+      event: "query_executed",
+      event_id: "generated-event-id",
+      event_properties: {
+        event_id: "generated-event-id",
+        database_type: "postgresql",
+      },
+    });
+  });
+
+  it("preserves a server-provided event_id for retry deduplication", () => {
+    trackEvent("database_connection_verified", {
+      event_id: "existing-event-id",
+    });
+
+    expect(window.dataLayer[0]).toMatchObject({
+      event_id: "existing-event-id",
+      event_properties: { event_id: "existing-event-id" },
+    });
+  });
+});

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -76,6 +76,11 @@ export function trackEvent(
 
   const eventProps = {
     ...properties,
+    event_id:
+      properties?.event_id ??
+      (typeof crypto !== "undefined" && "randomUUID" in crypto
+        ? crypto.randomUUID()
+        : `${Date.now()}-${Math.random().toString(36).slice(2)}`),
     event_timestamp: new Date().toISOString(),
   };
 


### PR DESCRIPTION
## Summary
- generate one UUID-style `event_id` for every dataLayer event
- preserve an existing ID so retries stay deduplicated
- expose the same ID in flat GA4/GTM parameters and nested PostHog properties

## Why
Server-side delivery, GA4 identity linking, and Google Ads offline uploads need a shared idempotency key without embedding vendor-specific logic in the app.

## Test plan
- [x] focused Vitest coverage
- [x] app TypeScript check
- [x] app ESLint

Made with [Cursor](https://cursor.com)