### PR TITLE
docs: cover Jul 9 merges — dbt-linked bindings, always-on web tools, verify-before-save, desktop auth

### DIFF
--- a/docs/src/content/docs/ai-agent.md
+++ b/docs/src/content/docs/ai-agent.md
@@ -87,7 +87,7 @@ Every turn, Mako injects a compact index of every skill plus the top-3 auto-retr
 
 ## Expertise Modes
 
-Mako runs a **single unified agent**, not a fleet of separate agents. Capability is loaded dynamically: the agent switches *expertise modes* mid-conversation via the `enable_mode` tool, and each mode unlocks a domain-specific toolset plus guidance. A set of core tools (memory, skills, search, version history, planning, mode-switching) is always available regardless of mode.
+Mako runs a **single unified agent**, not a fleet of separate agents. Capability is loaded dynamically: the agent switches *expertise modes* mid-conversation via the `enable_mode` tool, and each mode unlocks a domain-specific toolset plus guidance. A set of core tools (memory, skills, search, web access, version history, planning, mode-switching) is always available regardless of mode.
 
 On a fresh request the default mode is picked from what you're looking at — a dashboard view opens in **Dashboard**, the flow editor in **Sync Flow**, an app in **React App**, a dbt file/job in **Transforms** — otherwise **Query**. The agent then switches as the task demands.
 
@@ -144,7 +144,7 @@ This lets the agent verify dashboard rendering (chart legibility, overlap, layou
 
 ## Web Access
 
-When a request needs information from the public internet — a pasted URL, an online document, or fresh facts not in your data — the agent reaches for two web tools (loaded via the `web` skill):
+When a request needs information from the public internet — a pasted URL, an online document, or fresh facts not in your data — the agent reaches for two web tools. They are always active in every expertise mode (usage guidance lives in the `web` skill):
 
 | Tool | What It Does |
 |------|--------------|

--- a/docs/src/content/docs/api-reference.md
+++ b/docs/src/content/docs/api-reference.md
@@ -60,6 +60,8 @@ These endpoints manage connections to user databases (PostgreSQL, MySQL, MongoDB
 | `POST`   | `/api/workspaces/:wid/databases/:id/test`             | Test an existing connection                                                |
 | `POST`   | `/api/workspaces/:wid/databases/demo`                 | Provision the demo Chinook database (onboarding)                           |
 
+Create and update accept an optional `verifyBeforeSave: true` flag: the connection is tested before persisting, a failing test refuses the write with a structured `connection_test_failed` result, and a passing test stamps `lastConnectedAt`. Without the flag the legacy save-without-testing behavior is kept for programmatic callers. The app UI always sets it (with a "Save anyways" escape hatch).
+
 ### MongoDB Collections & Views
 
 For MongoDB connections, collection and view management is exposed under the same workspace-scoped database routes. The legacy unauthenticated `/api/database/*` routes were removed in [#408](https://github.com/mako-ai/mako/pull/408) — all callers must use the endpoints below.

--- a/docs/src/content/docs/apps.md
+++ b/docs/src/content/docs/apps.md
@@ -48,6 +48,14 @@ const { data: totals } = useDuckDB(
 
 Data sources are visible under **Data sources** in the app's explorer tree, with a Live/Materialized mode control and materialization run history.
 
+### dbt-linked bindings
+
+A binding can be linked to a workspace [dbt project](/transforms/) — from the **dbt** selector in the binding editor toolbar, or via agent tools. Linking enables environment-agnostic SQL:
+
+- Use the `{{ dbt_schema }}` token instead of hardcoding a schema (e.g. `SELECT * FROM {{ dbt_schema }}.fct_orders`). It resolves to the linked project's target schema.
+- Linking plus the token unlocks the app preview's **environment switcher** — preview the app's data against any dbt environment you can use (personal environments included). The override is per-user view state for *your* preview only; published and shared viewers always read prod. A linked binding whose query is missing the token gets a warning chip, and the switcher stays hidden for it.
+- Materialized (parquet) bindings participate too: while a non-prod override is active they serve a live, row-capped run (artifacts always hold prod data). Switching back to prod reloads the artifact — and a binding that was never materialized is built automatically instead of erroring.
+
 ## URL State & Routing
 
 Apps can keep view state — the active tab, applied filters, a selected record, a sub-page — in the URL, so a reload restores it and the link is shareable. This works both when the app is embedded in Mako (`/a/:appId`) and in the public share view (`/share/:token`).

--- a/docs/src/content/docs/databases/connect-databases.md
+++ b/docs/src/content/docs/databases/connect-databases.md
@@ -24,8 +24,10 @@ Mako connects to your databases directly — no data leaves your infrastructure.
 1. Go to **Settings → Databases** in your workspace
 2. Select the database type
 3. Enter your connection details (host, port, credentials, database name)
-4. Click **Test Connection** to verify
-5. Save — Mako will discover your schema automatically
+4. Click **Save** — Mako tests the connection first and only persists it if the test passes. If the test fails, you can fix the details or choose **Save anyways**.
+5. Once saved, Mako discovers your schema automatically
+
+You can also click **Test Connection** at any point to check reachability without saving.
 
 ## Local Databases (localhost)
 

--- a/docs/src/content/docs/desktop.md
+++ b/docs/src/content/docs/desktop.md
@@ -18,7 +18,7 @@ These links always serve the latest release. The app keeps itself up to date aut
 
 ## Signing in
 
-Mako Desktop never shows third-party login pages inside its own window. Clicking **Sign in** opens your **system browser** — where your password manager, Google/GitHub sessions, and the URL bar are available — and hands the session back to the app via a `mako://` deep link. The handoff uses one-time, PKCE-bound codes that expire after 60 seconds, so an intercepted link can't be replayed.
+Mako Desktop never asks for credentials inside its own window. Every sign-in and registration method — email/password included — runs in your **system browser**, where your password manager, Google/GitHub sessions, and the URL bar are available, and hands the session back to the app via a `mako://` deep link. The handoff uses one-time, PKCE-bound codes that expire after 60 seconds, so an intercepted link can't be replayed.
 
 ## Local databases (Mako Agent)
 


### PR DESCRIPTION
Daily docs maintenance. Covers everything doc-impacting that merged Jul 9:

## P1 — dbt-linked bindings had zero docs (carry-over + #673)
**apps.md**: new *dbt-linked bindings* subsection under Data Bindings — linking from the binding editor's dbt Select (#673), the `{{ dbt_schema }}` token, the app preview environment switcher (per-user view state; published/shared viewers always read prod), warning chip when the token is missing, and parquet binding behavior under overrides incl. auto-materialize (#663/#678).

## P0/P2 — stale claims fixed
- **ai-agent.md**: `fetch_url`/`web_search` moved to `CORE_ALWAYS_TOOL_NAMES` in #671 — docs still described them as loaded via the `web` skill and implicitly mode-gated. Now stated as always active in every expertise mode.
- **connect-databases.md**: the 'Test Connection then Save' steps predate #685 — Save now runs the connectivity test itself and refuses to persist on failure (with *Save anyways*). Steps rewritten.
- **api-reference.md**: documented `verifyBeforeSave` on database create/update, the `connection_test_failed` structured refusal, and the `lastConnectedAt` stamp (#685).
- **desktop.md**: 'never shows *third-party* login pages' is stale after #686 — email/password login and registration also go through the system browser now.

No doc surface: #684 (attribution cookie, internal), #687 (stable event IDs, internal analytics).

Source-verified against `api/src/agents/modes/registry.ts`, `api/src/routes/workspace-databases.ts`, `app/src/components/AppBindingEditor.tsx`, `app/src/components/AppRenderer.tsx`, `app/src/components/LoginPage.tsx`.