### PR TITLE
feat(analytics): distinguish web and desktop usage

### DIFF
--- a/app/src/lib/analytics.test.ts
+++ b/app/src/lib/analytics.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { trackEvent } from "./analytics";
+import { getAnalyticsContext, trackEvent } from "./analytics";
 
 describe("trackEvent", () => {
   beforeEach(() => {
@@ -33,6 +33,61 @@ describe("trackEvent", () => {
     expect(window.dataLayer[0]).toMatchObject({
       event_id: "existing-event-id",
       event_properties: { event_id: "existing-event-id" },
+    });
+  });
+
+  it("adds a stable web surface and session id", () => {
+    const values = new Map<string, string>();
+    vi.stubGlobal("window", {
+      dataLayer: [],
+      sessionStorage: {
+        getItem: (key: string) => values.get(key) ?? null,
+        setItem: (key: string, value: string) => values.set(key, value),
+      },
+    });
+
+    const first = getAnalyticsContext();
+    const second = getAnalyticsContext();
+
+    expect(first).toMatchObject({
+      app_surface: "web",
+      app_session_id: "generated-event-id",
+    });
+    expect(second.app_session_id).toBe(first.app_session_id);
+  });
+
+  it("adds persistent desktop installation and binary metadata", () => {
+    const session = new Map<string, string>();
+    const local = new Map<string, string>();
+    vi.stubGlobal("window", {
+      dataLayer: [],
+      makoDesktop: {
+        version: "0.3.0",
+        platform: "darwin",
+        arch: "arm64",
+      },
+      sessionStorage: {
+        getItem: (key: string) => session.get(key) ?? null,
+        setItem: (key: string, value: string) => session.set(key, value),
+      },
+      localStorage: {
+        getItem: (key: string) => local.get(key) ?? null,
+        setItem: (key: string, value: string) => local.set(key, value),
+      },
+    });
+
+    trackEvent("app_session_started");
+
+    expect(window.dataLayer[0]).toMatchObject({
+      app_surface: "desktop",
+      desktop_installation_id: "generated-event-id",
+      app_version: "0.3.0",
+      app_os: "darwin",
+      app_arch: "arm64",
+      event_properties: {
+        app_surface: "desktop",
+        desktop_installation_id: "generated-event-id",
+      },
     });
   });
 });

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -3,6 +3,7 @@
  * All events are pushed to window.dataLayer for GTM to handle distribution
  * to GA4, PostHog, and other configured destinations.
  */
+import { isMakoDesktop } from "./desktop";
 
 // Marketing events - sent to GA4 + Google Ads for attribution and conversions
 type MarketingEvent =
@@ -57,6 +58,65 @@ export interface QueryEventProperties {
 
 export type AnalyticsEvent = MarketingEvent | ProductEvent;
 
+const SESSION_ID_KEY = "mako_analytics_session_id";
+const DESKTOP_INSTALLATION_ID_KEY = "mako_desktop_installation_id";
+let fallbackSessionId: string | null = null;
+let fallbackInstallationId: string | null = null;
+
+function newId(): string {
+  return typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function storedId(
+  storage: Storage,
+  key: string,
+  fallback: string | null,
+): string {
+  try {
+    const existing = storage.getItem(key);
+    if (existing) return existing;
+    const created = newId();
+    storage.setItem(key, created);
+    return created;
+  } catch {
+    return fallback ?? newId();
+  }
+}
+
+export function getAnalyticsContext(): Record<string, unknown> {
+  if (typeof window === "undefined") return {};
+  const desktop = isMakoDesktop();
+  fallbackSessionId ??= newId();
+  const appSessionId = storedId(
+    window.sessionStorage,
+    SESSION_ID_KEY,
+    fallbackSessionId,
+  );
+  if (!desktop) {
+    return {
+      app_surface: "web",
+      app_session_id: appSessionId,
+    };
+  }
+
+  fallbackInstallationId ??= newId();
+  const installationId = storedId(
+    window.localStorage,
+    DESKTOP_INSTALLATION_ID_KEY,
+    fallbackInstallationId,
+  );
+  return {
+    app_surface: "desktop",
+    app_session_id: appSessionId,
+    desktop_installation_id: installationId,
+    app_version: window.makoDesktop?.version,
+    app_os: window.makoDesktop?.platform,
+    app_arch: window.makoDesktop?.arch,
+  };
+}
+
 /**
  * Push an event to the GTM dataLayer.
  * GTM will handle routing to appropriate destinations (GA4, PostHog, etc.)
@@ -76,11 +136,8 @@ export function trackEvent(
 
   const eventProps = {
     ...properties,
-    event_id:
-      properties?.event_id ??
-      (typeof crypto !== "undefined" && "randomUUID" in crypto
-        ? crypto.randomUUID()
-        : `${Date.now()}-${Math.random().toString(36).slice(2)}`),
+    ...getAnalyticsContext(),
+    event_id: properties?.event_id ?? newId(),
     event_timestamp: new Date().toISOString(),
   };
 
@@ -123,14 +180,18 @@ export function identify(
   window.dataLayer = window.dataLayer || [];
 
   const userTraits = traits || {};
+  const context = getAnalyticsContext();
 
   window.dataLayer.push({
     event: "identify",
     user_id: userId,
+    event_id: newId(),
+    event_timestamp: new Date().toISOString(),
     // Flat traits for GA4 user properties
     ...userTraits,
+    ...context,
     // Nested object for PostHog
-    user_traits: userTraits,
+    user_traits: { ...userTraits, ...context },
   });
 }
 
@@ -145,5 +206,8 @@ export function resetIdentity(): void {
   window.dataLayer.push({
     event: "reset_identity",
     user_id: null,
+    event_id: newId(),
+    event_timestamp: new Date().toISOString(),
+    ...getAnalyticsContext(),
   });
 }

--- a/app/src/lib/desktop.ts
+++ b/app/src/lib/desktop.ts
@@ -11,6 +11,7 @@
 export interface MakoDesktopBridge {
   version: string;
   platform: string;
+  arch: string;
   /**
    * Ask the desktop main process to start the browser-based sign-in flow:
    * it generates a PKCE pair and opens the system browser at

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -328,6 +328,13 @@ if (!hasSingleInstanceLock) {
   ipcMain.handle("mako:start-browser-auth", () => {
     startBrowserAuth();
   });
+  ipcMain.on("mako:get-app-metadata", event => {
+    event.returnValue = {
+      version: app.getVersion(),
+      platform: process.platform,
+      arch: process.arch,
+    };
+  });
 
   app.whenReady().then(async () => {
     setupAutoUpdater();

--- a/packages/desktop/src/preload.ts
+++ b/packages/desktop/src/preload.ts
@@ -5,9 +5,14 @@
  */
 import { contextBridge, ipcRenderer } from "electron";
 
+const metadata = ipcRenderer.sendSync("mako:get-app-metadata") as {
+  version: string;
+  platform: string;
+  arch: string;
+};
+
 contextBridge.exposeInMainWorld("makoDesktop", {
-  version: process.env.npm_package_version || "0.1.0",
-  platform: process.platform,
+  ...metadata,
   /**
    * Ask the main process to open the system browser at /desktop-auth with a
    * fresh PKCE challenge. The session comes back via a mako:// deep link.


### PR DESCRIPTION
## Summary
- enrich every analytics event with explicit `app_surface` and stable app session context
- add persistent Electron installation IDs plus binary version, OS, and architecture
- expose accurate packaged app metadata through the existing preload bridge without adding marketing or attribution logic

## Test plan
- [x] `pnpm --filter app exec vitest run src/lib/analytics.test.ts`
- [x] `pnpm --filter app run typecheck`
- [x] `pnpm --filter app run lint`
- [x] `pnpm --filter @mako/desktop run typecheck`
- [x] `pnpm --filter @mako/desktop run build`

Made with [Cursor](https://cursor.com)