### PR TITLE
ci: deploy PR previews to the dedicated mako-ai-dev project

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -9,8 +9,11 @@ on:
     - cron: "17 3 * * *"
   workflow_dispatch:
 
+# Previews live in the dedicated DEV project (mako-ai-dev), so cleanup
+# targets that project. Production is never touched by this workflow.
 env:
-  GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+  GCP_PROJECT_ID: ${{ vars.GCP_DEV_PROJECT_ID }}
+  GCP_ARTIFACT_REPOSITORY: ${{ vars.GCP_DEV_ARTIFACT_REPOSITORY }}
   GCP_REGION: ${{ vars.GCP_REGION }}
 
 permissions:
@@ -58,7 +61,7 @@ jobs:
         continue-on-error: true
         run: |
           IMAGE_NAME="mako-pr-${PR_NUMBER}"
-          IMAGE_PATH="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${{ vars.GCP_ARTIFACT_REPOSITORY }}/${IMAGE_NAME}"
+          IMAGE_PATH="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/${IMAGE_NAME}"
 
           echo "Deleting Docker images: ${IMAGE_PATH}"
 
@@ -191,7 +194,7 @@ jobs:
       - name: Delete Artifact Registry images for closed PRs
         run: |
           gcloud artifacts docker images list \
-            "${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${{ vars.GCP_ARTIFACT_REPOSITORY }}" \
+            "${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}" \
             --format='value(package)' 2>/dev/null \
             | sort -u | grep '/mako-pr-' | sed 's|.*/mako-pr-||' | sort > /tmp/image_prs.txt || true
 
@@ -202,7 +205,7 @@ jobs:
             [ -z "$pr" ] && continue
             echo "Deleting image package mako-pr-${pr}"
             gcloud artifacts packages delete "mako-pr-${pr}" \
-              --repository="${{ vars.GCP_ARTIFACT_REPOSITORY }}" \
+              --repository="${GCP_ARTIFACT_REPOSITORY}" \
               --location="${GCP_REGION}" --quiet \
               || echo "::warning::Failed to delete image package mako-pr-${pr}"
           done < /tmp/stale_image_prs.txt

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -53,7 +53,7 @@ jobs:
         continue-on-error: true
         run: |
           echo "Deleting Cloud Run service: ${SERVICE_NAME}"
-          gcloud run services delete ${SERVICE_NAME} \
+          gcloud run services delete ${SERVICE_NAME} --project ${GCP_PROJECT_ID} \
             --region ${GCP_REGION} \
             --quiet || echo "Service ${SERVICE_NAME} not found or already deleted"
 
@@ -176,7 +176,7 @@ jobs:
 
       - name: Delete Cloud Run services for closed PRs
         run: |
-          gcloud run services list --region "${GCP_REGION}" \
+          gcloud run services list --project "${GCP_PROJECT_ID}" --region "${GCP_REGION}" \
             --format='value(metadata.name)' \
             | grep '^mako-pr-' | sed 's/^mako-pr-//' | sort > /tmp/service_prs.txt || true
 
@@ -187,6 +187,7 @@ jobs:
             [ -z "$pr" ] && continue
             echo "Deleting Cloud Run service mako-pr-${pr}"
             gcloud run services delete "mako-pr-${pr}" \
+              --project "${GCP_PROJECT_ID}" \
               --region "${GCP_REGION}" --quiet \
               || echo "::warning::Failed to delete service mako-pr-${pr}"
           done < /tmp/stale_service_prs.txt
@@ -205,6 +206,7 @@ jobs:
             [ -z "$pr" ] && continue
             echo "Deleting image package mako-pr-${pr}"
             gcloud artifacts packages delete "mako-pr-${pr}" \
+              --project="${GCP_PROJECT_ID}" \
               --repository="${GCP_ARTIFACT_REPOSITORY}" \
               --location="${GCP_REGION}" --quiet \
               || echo "::warning::Failed to delete image package mako-pr-${pr}"

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -553,7 +553,10 @@ jobs:
         env:
           SERVICE_NAME: ${{ steps.pr-vars.outputs.SERVICE_NAME }}
         run: |
+          # --project is explicit because the auth action exports CLOUDSDK_CORE_PROJECT
+          # from the SA key's home project, which overrides setup-gcloud's project_id.
           gcloud run deploy ${SERVICE_NAME} \
+            --project ${GCP_PROJECT_ID} \
             --image ${{ steps.image.outputs.sha_tag }} \
             --region ${GCP_REGION} \
             --timeout=3600 \
@@ -624,7 +627,7 @@ jobs:
             --quiet
 
           # Get the Cloud Run URL
-          CLOUD_RUN_URL=$(gcloud run services describe ${SERVICE_NAME} --region ${GCP_REGION} --format='value(status.url)')
+          CLOUD_RUN_URL=$(gcloud run services describe ${SERVICE_NAME} --project ${GCP_PROJECT_ID} --region ${GCP_REGION} --format='value(status.url)')
           echo "cloud_run_url=${CLOUD_RUN_URL}" >> "$GITHUB_OUTPUT"
 
       - name: Sync Inngest branch environment

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -22,11 +22,10 @@ concurrency:
   group: deploy-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || (github.event_name == 'workflow_dispatch' && inputs.pr_number != '' && format('pr-{0}', inputs.pr_number)) || github.ref_name }}
   cancel-in-progress: true
 
+# PR previews deploy to the dedicated DEV project (mako-ai-dev); production
+# stays in the prod project. Project-scoped values live on each deploy job.
 env:
-  GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
   GCP_REGION: ${{ vars.GCP_REGION }}
-  GCP_ARTIFACT_REPOSITORY: ${{ vars.GCP_ARTIFACT_REPOSITORY }}
-  GCS_DASHBOARD_BUCKET: revops-462013-dashboard-artifacts
 
 permissions:
   contents: read
@@ -147,6 +146,10 @@ jobs:
       name: pr-${{ needs.detect-changes.outputs.pr_number }}
       url: https://pr-${{ needs.detect-changes.outputs.pr_number }}.mako.ai
     env:
+      # Previews deploy to the dedicated DEV project, not production's.
+      GCP_PROJECT_ID: ${{ vars.GCP_DEV_PROJECT_ID }}
+      GCP_ARTIFACT_REPOSITORY: ${{ vars.GCP_DEV_ARTIFACT_REPOSITORY }}
+      GCS_DASHBOARD_BUCKET: ${{ vars.GCS_DEV_DASHBOARD_BUCKET }}
       PR_NUMBER: ${{ needs.detect-changes.outputs.pr_number }}
       BASE_URL: https://pr-${{ needs.detect-changes.outputs.pr_number }}.mako.ai
       CLIENT_URL: https://pr-${{ needs.detect-changes.outputs.pr_number }}.mako.ai
@@ -186,7 +189,9 @@ jobs:
       LANGFUSE_TRACING_ENVIRONMENT: pr-${{ needs.detect-changes.outputs.pr_number }}
       RATE_LIMIT_MAX_REQUESTS: ${{ vars.RATE_LIMIT_MAX_REQUESTS }}
       RATE_LIMIT_WINDOW_MS: ${{ vars.RATE_LIMIT_WINDOW_MS }}
-      REDIS_URL: ${{ secrets.REDIS_URL }}
+      # No REDIS_URL for previews: the prod Memorystore instance lives in the
+      # prod project's VPC and is unreachable from mako-ai-dev. The API falls
+      # back to in-process pub/sub when REDIS_URL is unset (fine for previews).
       SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
       SENDGRID_FROM_EMAIL: ${{ vars.SENDGRID_FROM_EMAIL }}
       SENDGRID_INVITATION_TEMPLATE_ID: ${{ vars.SENDGRID_INVITATION_TEMPLATE_ID }}
@@ -594,7 +599,6 @@ jobs:
             --set-env-vars SYNC_PARQUET_DUCKDB_THREADS=1 \
             --set-env-vars RATE_LIMIT_MAX_REQUESTS=${RATE_LIMIT_MAX_REQUESTS} \
             --set-env-vars RATE_LIMIT_WINDOW_MS=${RATE_LIMIT_WINDOW_MS} \
-            --set-env-vars REDIS_URL=${REDIS_URL} \
             --set-env-vars SENDGRID_API_KEY=${SENDGRID_API_KEY} \
             --set-env-vars SENDGRID_FROM_EMAIL=${SENDGRID_FROM_EMAIL} \
             --set-env-vars SENDGRID_INVITATION_TEMPLATE_ID=${SENDGRID_INVITATION_TEMPLATE_ID} \
@@ -794,6 +798,10 @@ jobs:
       name: production
       url: https://app.mako.ai
     env:
+      # Production keeps deploying to the prod project.
+      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+      GCP_ARTIFACT_REPOSITORY: ${{ vars.GCP_ARTIFACT_REPOSITORY }}
+      GCS_DASHBOARD_BUCKET: revops-462013-dashboard-artifacts
       BASE_URL: https://app.mako.ai
       BCRYPT_ROUNDS: ${{ vars.BCRYPT_ROUNDS }}
       CLIENT_URL: https://app.mako.ai


### PR DESCRIPTION
## Summary

- PR preview deploys (and their cleanup) now target the new dedicated **`mako-ai-dev`** GCP project instead of sharing `revops-462013` with production. Production deploys are unchanged.
- Preview services no longer receive `REDIS_URL` — the prod Memorystore instance is only reachable inside the prod VPC; the API's documented in-process pub/sub fallback covers previews.
- New repo variables wired in: `GCP_DEV_PROJECT_ID`, `GCP_DEV_ARTIFACT_REPOSITORY`, `GCS_DEV_DASHBOARD_BUCKET` (already set).

## Infrastructure (already provisioned in mako-ai-dev)

- `mako-vpc` + `mako-subnet` (europe-west1) — same names the deploy flags expect
- Cloud Router + NAT with static egress IP **34.14.101.173** (add to the Atlas allowlist if the staging cluster doesn't allow 0.0.0.0/0)
- Artifact Registry repo `mako`, GCS bucket `mako-ai-dev-dashboard-artifacts` (runtime SA has objectAdmin)
- `github-actions-deployer@revops-462013` granted `run.admin`, `artifactregistry.repoAdmin`, `iam.serviceAccountUser` on `mako-ai-dev` — same key, no new GitHub secret

## Test plan

- [ ] This PR's own preview deploy (it modifies `deploy-app.yml`, so the preview job runs with the new config) deploys `mako-pr-<n>` into `mako-ai-dev`
- [ ] Preview URL responds and boots with in-process pub/sub
- [ ] Production deploy on merge still targets `revops-462013`

Note: existing `mako-pr-*` services in `revops-462013` will be swept by the nightly cleanup only after this merges (the sweep now points at the dev project); stale ones in prod can be deleted manually.

Made with [Cursor](https://cursor.com)