### PR TITLE
ci: preserve public access on production deploys

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -966,6 +966,7 @@ jobs:
             --concurrency=80 \
             --min-instances=1 \
             --max-instances=15 \
+            --allow-unauthenticated \
             --network=mako-vpc \
             --subnet=mako-subnet \
             --vpc-egress=all-traffic \


### PR DESCRIPTION
## Summary
- keep production Cloud Run publicly invokable when the service is created or recreated
- prevent direct health and Inngest sync requests from failing with Google Frontend 403s

## Test plan
- [x] `git diff --check`
- [x] confirmed preview and canary deploys already use `--allow-unauthenticated`
- [ ] merge and dispatch a production deploy; verify Cloud Run deploy, migration, and Inngest sync succeed

Made with [Cursor](https://cursor.com)