### PR TITLE
docs(auth): document MCP OAuth server, API key scopes, connected-agent management

### DIFF
--- a/AUTH_README.md
+++ b/AUTH_README.md
@@ -463,6 +463,81 @@ Desktop app (deep link received: open-url on macOS, argv on Win/Linux)
 | `app/src/utils/desktop-auth-redirect.ts` | sessionStorage resume across the login round trip      |
 | `packages/desktop/src/main.ts`         | PKCE generation, `mako://` protocol, deep-link handling  |
 
+## MCP OAuth (AI agent connections)
+
+The MCP endpoint (`POST /api/mcp`) accepts two credentials: a workspace API
+key (`Authorization: Bearer revops_...`) or an OAuth 2.1 grant minted by
+Mako's own built-in authorization server. Session cookies are rejected there
+so the workspace binding is always unambiguous.
+
+### Authorization server
+
+Public clients only (`token_endpoint_auth_methods_supported: ["none"]`) with
+mandatory PKCE S256 — the MCP spec's auth profile, implemented by Claude,
+Cursor, and Codex. Clients self-register via RFC 7591 dynamic registration;
+no provider console setup is needed.
+
+| Method | Endpoint                  | Description                                        |
+| ------ | ------------------------- | -------------------------------------------------- |
+| POST   | `/api/oauth/mcp/register` | RFC 7591 dynamic client registration               |
+| GET    | `/api/oauth/mcp/authorize`| Consent page (bounces through `/login` if needed)  |
+| POST   | `/api/oauth/mcp/authorize`| Consent form submit → authorization code redirect  |
+| POST   | `/api/oauth/mcp/token`    | Code/refresh-token exchange                        |
+
+Discovery documents are mounted at root in `src/index.ts` (not in
+`register-routes.ts`): `/.well-known/oauth-protected-resource` and six
+authorization-server metadata spellings (RFC 8414 path-inserted variants plus
+OIDC-discovery spellings). All variants serve the same metadata — a miss
+would fall through to the SPA fallback and poison client discovery.
+
+### Token model
+
+- Opaque tokens, stored as SHA-256 hashes: access `mcpat_*` (8 h TTL),
+  refresh `mcprt_*` (30 d TTL, rotated on every refresh). Auth codes live
+  10 minutes and are consumed atomically.
+- `unifiedAuthMiddleware` recognizes the `mcpat_` Bearer prefix and sets
+  `authType: "mcpOAuth"` with the grant's workspace binding and scopes.
+- Scopes are always the read-only set (`mcp`, `query:read`). There is
+  deliberately no `query:write` scope — an OAuth grant can never do more
+  than a freshly-created MCP API key.
+- Redirect URIs accepted at registration: `https` anywhere, `http` on
+  loopback only (RFC 8252), or a custom app scheme (e.g. `cursor://`).
+  Max 10 per client.
+- `lastUsedAt` is written at most once per minute per grant to avoid a
+  DB write on every MCP request.
+
+### Workspace API key scopes
+
+Workspace API keys (`revops_*`) now carry a `scopes` array
+(`api/src/auth/api-key-scopes.ts`). New keys default to
+`["mcp", "query:read"]`. Legacy keys created before scopes existed have
+`scopes: undefined` and are refused by the MCP endpoint with a rotation
+hint — they keep working everywhere else.
+
+### Managing connected agents
+
+| Method | Endpoint                                        | Description                     |
+| ------ | ----------------------------------------------- | ------------------------------- |
+| GET    | `/api/workspaces/:id/mcp-connections`           | List agents connected via OAuth |
+| DELETE | `/api/workspaces/:id/mcp-connections/:clientId` | Revoke an agent's grants        |
+
+Members see and revoke their own connections; owners/admins see everyone's.
+The app surface for this is **Settings → Connect Agents**.
+
+### Key Files
+
+| File                                    | Purpose                                                        |
+| --------------------------------------- | -------------------------------------------------------------- |
+| `api/src/routes/mcp-oauth.routes.ts`    | AS endpoints, well-known discovery documents, consent page      |
+| `api/src/auth/mcp-oauth.service.ts`     | Code/token mint, exchange, refresh rotation, revocation         |
+| `api/src/database/mcp-oauth-schema.ts`  | `McpOAuthClient`, `McpOAuthCode`, `McpOAuthToken` models        |
+| `api/src/auth/api-key-scopes.ts`        | Scope constants, parsing, legacy-key resolution                 |
+| `api/src/auth/unified-auth.middleware.ts` | `mcpat_` Bearer recognition alongside sessions and API keys   |
+| `api/src/routes/mcp-server.routes.ts`   | `POST /api/mcp` — auth-type and scope enforcement               |
+
+User-facing setup docs live in the Starlight site: `docs/src/content/docs/mcp-server.md`.
+
+
 ## Customization
 
 ### Adding New OAuth Providers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Mako - The AI-native SQL Client**
 
-Mako is a production-ready, multi-tenant AI-powered SQL client built with a PNPM workspace monorepo structure. It combines multi-database query execution (MongoDB, PostgreSQL, BigQuery, ClickHouse, etc.), AI-powered query generation with multi-provider LLM support (OpenAI, Anthropic, Google), team collaboration features, and optional data source connectors (Stripe, Close CRM, GraphQL APIs, PostHog, REST APIs) with event-driven synchronization (batch and CDC/streaming) via Inngest.
+Mako is a production-ready, multi-tenant AI-powered SQL client built with a PNPM workspace monorepo structure. It combines multi-database query execution (MongoDB, PostgreSQL, BigQuery, ClickHouse, etc.), AI-powered query generation with multi-provider LLM support (OpenAI, Anthropic, Google), team collaboration features, and optional data source connectors (Stripe, Close CRM, GraphQL APIs, PostHog, REST APIs) with event-driven synchronization (batch and CDC/streaming) via Inngest. Mako is also an MCP server (`POST /api/mcp`, OAuth 2.1 or scoped workspace API keys) so external agents like Claude Code can explore data and build apps headlessly — see `docs/src/content/docs/mcp-server.md` and the MCP OAuth section of `AUTH_README.md`.
 
 **Architecture:** Five main packages:
 
@@ -120,6 +120,10 @@ SENDGRID_VERIFICATION_TEMPLATE_ID=d-xxxxxxxxx
 # Inngest (optional)
 INNGEST_EVENT_KEY=your_inngest_event_key
 INNGEST_SIGNING_KEY=your_inngest_signing_key
+
+# Optional: headless Chromium for server-side app rendering
+# (MCP render_app tool; unset = agents fall back to preview tokens)
+# RENDER_APP_BROWSER_PATH=/usr/bin/chromium
 
 # Redis (optional — resumable chat streams)
 # Unset: in-process stream buffer (local dev / single API instance).


### PR DESCRIPTION
## Why

#688 shipped Mako-as-MCP-server with a full OAuth 2.1 authorization server (RFC 7591 dynamic registration, PKCE-only public clients, opaque `mcpat_`/`mcprt_` tokens, root-mounted well-known discovery) and scoped workspace API keys. The user-facing setup guide landed with it (`docs/src/content/docs/mcp-server.md`), but **AUTH_README.md — the auth system's engineering reference — didn't mention any of it**. Anyone reading it would conclude auth = sessions + Google/GitHub OAuth + desktop handoff.

## What

**AUTH_README.md** — new *MCP OAuth (AI agent connections)* section (placed after Desktop App Authentication, mirroring its structure):
- AS endpoints table (`/api/oauth/mcp/{register,authorize,token}`)
- Why discovery documents are mounted at root in `src/index.ts` (SPA-fallback poisoning)
- Token model: hashes only, TTLs (code 10 min / access 8 h / refresh 30 d with rotation), `unifiedAuthMiddleware` `mcpat_` recognition
- Read-only scope design (`mcp`, `query:read`; deliberately no `query:write`)
- Workspace API key `scopes` array + legacy-key behavior at the MCP endpoint
- `mcp-connections` list/revoke routes and role visibility
- Key files table

**CLAUDE.md**:
- Project overview now mentions the MCP server surface
- `RENDER_APP_BROWSER_PATH` added to the env var reference (was in `.env.example` but missing here)

All facts verified against the code on master (`api-key-scopes.ts`, `mcp-oauth.service.ts`, `mcp-oauth.routes.ts`, `mcp-server.routes.ts`, `unified-auth.middleware.ts`, `workspaces.ts`).

🤖 Automated docs maintenance (Aura)