### PR TITLE
security: audit quick wins (headers, CORS, decrypt oracle, iframe sandbox)

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -2,6 +2,7 @@ import { OpenAPIHono } from "@hono/zod-openapi";
 import { serve } from "@hono/node-server";
 import { compress } from "hono/compress";
 import { cors } from "hono/cors";
+import { secureHeaders } from "hono/secure-headers";
 import { serve as serveInngest } from "inngest/hono";
 import { Scalar } from "@scalar/hono-api-reference";
 import dotenv from "dotenv";
@@ -67,11 +68,42 @@ const REQUIRED_SYSTEM_SKILLS = [
 
 const app = new OpenAPIHono<AuthEnv>();
 
-// CORS middleware
+const isProduction = process.env.NODE_ENV === "production";
+
+// Security headers. CSP is intentionally left unset here because the SPA loads
+// GTM, Google Fonts, and renders sandboxed blob/srcdoc iframes; a tuned CSP is
+// tracked as a follow-up. COOP/CORP/COEP are disabled to avoid breaking OAuth
+// popups and cross-origin asset loads.
+app.use(
+  "*",
+  secureHeaders({
+    contentSecurityPolicy: undefined,
+    xFrameOptions: "SAMEORIGIN",
+    xContentTypeOptions: "nosniff",
+    referrerPolicy: "strict-origin-when-cross-origin",
+    strictTransportSecurity: isProduction
+      ? "max-age=31536000; includeSubDomains"
+      : false,
+    crossOriginOpenerPolicy: false,
+    crossOriginResourcePolicy: false,
+    crossOriginEmbedderPolicy: false,
+  }),
+);
+
+// CORS middleware. Never fall back to a wildcard origin: combined with
+// `credentials: true` that is both rejected by browsers and a footgun if the
+// fallback ever changed to reflect the request origin. Require an explicit
+// client origin instead.
+const clientOrigin = process.env.CLIENT_URL || "http://localhost:5173";
+if (!process.env.CLIENT_URL) {
+  logger.warn(
+    "CLIENT_URL is not set; defaulting CORS origin to http://localhost:5173. Set CLIENT_URL explicitly in non-local environments.",
+  );
+}
 app.use(
   "*",
   cors({
-    origin: process.env.CLIENT_URL || "*",
+    origin: clientOrigin,
     allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     allowHeaders: ["Content-Type", "Authorization"],
     credentials: true,

--- a/api/src/routes/sources.ts
+++ b/api/src/routes/sources.ts
@@ -813,15 +813,15 @@ dataSourceRoutes.openapi(
           },
         });
       } catch (error: any) {
+        // Log full detail server-side, but return a single opaque error to the
+        // client. Distinct decryption-failure messages (e.g. bad padding) turn
+        // this endpoint into a padding oracle against the unauthenticated
+        // AES-256-CBC scheme, enabling plaintext recovery.
         logger.error("Decryption error", { error });
         return c.json(
           {
             success: false,
-            error: `Decryption failed: ${error.message}`,
-            details: {
-              code: error.code,
-              message: error.message,
-            },
+            error: "Decryption failed",
           },
           400,
         );

--- a/api/src/routes/workspace-databases.ts
+++ b/api/src/routes/workspace-databases.ts
@@ -379,7 +379,7 @@ workspaceDatabaseRoutes.openapi(
         201,
       );
     } catch (error) {
-      console.error("Error creating demo database:", error);
+      logger.error("Error creating demo database", { error });
       return c.json(
         {
           success: false,

--- a/app/src/components/AppRenderer.tsx
+++ b/app/src/components/AppRenderer.tsx
@@ -773,7 +773,7 @@ export default function AppRenderer({
           title={`app-preview-${appId}`}
           data-mako-app-preview={appId}
           srcDoc={srcDoc}
-          sandbox="allow-scripts allow-downloads allow-popups allow-popups-to-escape-sandbox"
+          sandbox="allow-scripts allow-downloads allow-popups"
           style={{ width: "100%", height: "100%", border: "none" }}
         />
         {booting && errors.length === 0 && (

--- a/app/src/components/public/PublicAppViewer.tsx
+++ b/app/src/components/public/PublicAppViewer.tsx
@@ -495,7 +495,7 @@ export default function PublicAppViewer({
           ref={iframeRef}
           title={`public-app-${token}`}
           srcDoc={srcDoc}
-          sandbox="allow-scripts allow-downloads allow-popups allow-popups-to-escape-sandbox"
+          sandbox="allow-scripts allow-downloads allow-popups"
           style={{ width: "100%", height: "100%", border: "none" }}
         />
         {booting && !previewError && (

--- a/app/src/components/widgets/CodeWidget.tsx
+++ b/app/src/components/widgets/CodeWidget.tsx
@@ -123,7 +123,7 @@ const CodeWidget: React.FC<CodeWidgetProps> = ({
       )}
       <iframe
         ref={iframeRef}
-        sandbox="allow-scripts allow-downloads allow-popups allow-popups-to-escape-sandbox"
+        sandbox="allow-scripts allow-downloads allow-popups"
         style={{
           width: "100%",
           height: "100%",

--- a/app/src/pages/AppPreviewPage.tsx
+++ b/app/src/pages/AppPreviewPage.tsx
@@ -310,7 +310,7 @@ export default function AppPreviewPage() {
           ref={iframeRef}
           title={`preview-app-${token}`}
           srcDoc={srcDoc}
-          sandbox="allow-scripts allow-downloads allow-popups allow-popups-to-escape-sandbox"
+          sandbox="allow-scripts allow-downloads allow-popups"
           style={{ width: "100%", height: "100%", border: "none" }}
         />
         {booting && !previewError && (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Output of a full security audit of the Mako monorepo. This PR ships the **low-risk, high-value quick wins**; the higher-severity findings that need product/design decisions are listed below for follow-up (not fixed here).

### Quick wins implemented
- **HTTP security headers** (`api/src/index.ts`): registered `hono/secure-headers` — `X-Content-Type-Options: nosniff`, `X-Frame-Options: SAMEORIGIN`, `Referrer-Policy: strict-origin-when-cross-origin`, and HSTS in production. COOP/CORP/COEP are explicitly disabled to avoid breaking OAuth popups / cross-origin assets. A tuned CSP is left as a documented follow-up (GTM + fonts + blob/srcdoc iframes need allowlisting).
- **CORS hardening** (`api/src/index.ts`): removed the `origin: process.env.CLIENT_URL || "*"` fallback that combined a wildcard origin with `credentials: true`. Now requires an explicit `CLIENT_URL` (dev default `http://localhost:5173` with a startup warning).
- **Padding-oracle fix** (`api/src/routes/sources.ts`): `POST /connectors/decrypt` no longer returns distinct decryption-failure detail (bad padding vs other). Full detail is logged server-side; the client gets a single opaque error. This removes the padding-oracle plaintext-recovery vector against the unauthenticated AES-256-CBC scheme.
- **Iframe sandbox tightening** (4 app files): dropped `allow-popups-to-escape-sandbox` from the untrusted app/widget iframes (`AppRenderer`, `PublicAppViewer`, `AppPreviewPage`, `CodeWidget`). Popups still work but remain sandboxed, so AI-generated/shared app HTML can no longer open a non-sandboxed top-level phishing window.
- **Log hygiene** (`api/src/routes/workspace-databases.ts`): replaced a stray `console.error` with the structured logger.

## Testing
- `pnpm --filter api run lint` — pass
- `pnpm --filter api run build` (typecheck) — pass
- `pnpm --filter app run typecheck && lint` — pass
- Booted the API against an in-memory Mongo replica set and verified headers/CORS via curl: security headers present on `/health`; `Access-Control-Allow-Origin` reflects only `http://localhost:5173` and is absent for `http://evil.com`.

## High-severity findings NOT in this PR (need follow-up decisions)
1. **[Critical] RCE via `eval()` in the MongoDB console path** — `database-connection.service.ts:3304` runs raw console JS with `eval` in full module scope (`require`/`process` reachable). Authenticated workspace member → shell/`process.env`/`ENCRYPTION_KEY` exfiltration → decrypt all tenants' credentials. Fix: route Mongo execution through the existing structured executor or an `isolated-vm` sandbox.
2. **[Critical] OAuth account linking without `email_verified`** — GitHub/Google callbacks auto-link to an existing account by email without checking the provider verified it → account takeover.
3. **[High] Decrypted DB credentials returned to any workspace role** — `GET /workspaces/:id/databases/{id}` returns plaintext connection (password / BigQuery private key) with no role gate; a `viewer` can read them.
4. **[High] `/connectors/decrypt` is a general decryption oracle** — this PR removes the padding-oracle signal, but the endpoint still decrypts arbitrary ciphertext with the global key; it should be removed or scoped to the caller's own workspace values.
5. **[High] Broken object-level auth on agent chat** — `POST /api/agent/chat` and the stream resume/stop endpoints authorize on workspace membership only, not chat ownership → cross-user chat overwrite / live-stream read.
6. **[High] Credential encryption uses AES-256-CBC without a MAC** — migrate to AES-256-GCM (the local agent already does).
7. **[High] SSRF in REST/GraphQL connector + DB "test connection"** — user-supplied URLs/hosts are fetched/dialed with no private-IP/metadata block; a hardened `safe-fetch.service.ts` exists but isn't wired into these paths.
8. **[Medium] Brute-forceable 6-digit codes + spoofable/in-memory rate limiter** — verification/reset codes have no per-account attempt cap; the limiter keys on client-controllable `X-Forwarded-For` and is per-process.

Also worth doing soon (mechanical): bump `hono` to ≥4.11.4 (fixes an Improper-Authorization + JWT algorithm-confusion advisory) and `axios` to ≥1.12.0.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f588320-0b98-4c41-8857-d939dc8c6e8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f588320-0b98-4c41-8857-d939dc8c6e8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

