### PR TITLE
perf(ci): cut deploy time by building once + Docker layer cache

### DIFF
--- a/.cursor/rules/90-build-deploy.mdc
+++ b/.cursor/rules/90-build-deploy.mdc
@@ -18,6 +18,7 @@ description: Build outputs, deployment paths, and do-not-edit policy for dist
 - Production deploys on push to `master`. PR previews deploy automatically on PR open/sync.
 - Cloud Run config (memory, instances, timeouts, env vars) must be changed in the workflow file, not `deploy.sh`.
 - Cloud Run services run with `--memory=1Gi`, `--timeout=600`, `--min-instances=1` (prod) or `0` (preview).
+- CI builds once via `pnpm run build:ci` (no re-lint), then packages with `docker build --build-arg USE_PREBUILT=1` + BuildKit registry cache (`mako:buildcache`). Do not reintroduce a second full compile inside the image for deploy jobs.
 
 Environment variables (local defaults):
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 node_modules
+**/node_modules
 .git
 .gitignore
 .vscode
@@ -7,6 +8,12 @@ Dockerfile
 docker-compose.yml
 npm-debug.log
 yarn-error.log
-# Build artifacts
-*/dist
-*/.next 
+
+# Framework caches — do NOT ignore */dist (CI packages host-built dist into the image)
+**/.next
+**/.turbo
+**/coverage
+
+# Docs site output is never served from the API image
+docs/dist
+docs/.astro

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -257,8 +257,10 @@ jobs:
       - name: Lint API
         run: pnpm run --filter api lint
 
-      - name: Build workspaces (Fail Fast Check)
-        run: pnpm run build
+      # Lint already ran above — build:ci skips lint:fix so we don't triple-lint.
+      # Frontend env (including VITE_BUILD_ID) is baked here; the Docker step only packages.
+      - name: Build workspaces
+        run: pnpm run build:ci
         env:
           BASE_URL: ${{ env.BASE_URL }}
           CLIENT_URL: ${{ env.CLIENT_URL }}
@@ -266,6 +268,7 @@ jobs:
           VITE_API_URL: ${{ env.VITE_API_URL }}
           VITE_MUI_LICENSE_KEY: ${{ env.VITE_MUI_LICENSE_KEY }}
           VITE_GTM_ID: ${{ env.VITE_GTM_ID }}
+          VITE_BUILD_ID: ${{ needs.detect-changes.outputs.pr_sha || github.sha }}
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
@@ -288,36 +291,31 @@ jobs:
           CODE_SHA: ${{ needs.detect-changes.outputs.pr_sha || github.sha }}
         run: |
           IMAGE_URI="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/${IMAGE_NAME}"
+          # Shared cache across PR preview images in this Artifact Registry
+          CACHE_URI="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/mako:buildcache"
           echo "uri=${IMAGE_URI}" >> "$GITHUB_OUTPUT"
           echo "sha_tag=${IMAGE_URI}:${CODE_SHA}" >> "$GITHUB_OUTPUT"
           echo "latest_tag=${IMAGE_URI}:latest" >> "$GITHUB_OUTPUT"
+          echo "cache_uri=${CACHE_URI}" >> "$GITHUB_OUTPUT"
 
-      - name: Create .env.production for Docker build
-        env:
-          # Build ID baked into the frontend bundle + version.json so clients
-          # can detect stale bundles (served back via GET /api/version)
-          VITE_BUILD_ID: ${{ needs.detect-changes.outputs.pr_sha || github.sha }}
-        run: |
-          cat <<EOF > .env.production
-          VITE_API_URL=${VITE_API_URL}
-          VITE_MUI_LICENSE_KEY=${VITE_MUI_LICENSE_KEY}
-          VITE_GTM_ID=${VITE_GTM_ID}
-          VITE_BUILD_ID=${VITE_BUILD_ID}
-          EOF
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker image
-        run: docker build --platform linux/amd64 -t ${{ steps.image.outputs.sha_tag }} .
-
-      - name: Tag Docker image as latest
-        run: docker tag ${{ steps.image.outputs.sha_tag }} ${{ steps.image.outputs.latest_tag }}
-
-      - name: Push Docker images
-        run: |
-          docker push ${{ steps.image.outputs.sha_tag }}
-          docker push ${{ steps.image.outputs.latest_tag }}
-
-      - name: Clean temporary env.production file
-        run: rm -f .env.production
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ steps.image.outputs.sha_tag }}
+            ${{ steps.image.outputs.latest_tag }}
+          build-args: |
+            USE_PREBUILT=1
+          cache-from: type=registry,ref=${{ steps.image.outputs.cache_uri }}
+          cache-to: type=registry,ref=${{ steps.image.outputs.cache_uri }},mode=max
+          provenance: false
+          sbom: false
 
       # Handle ephemeral database if migrations changed OR manual rebuild requested
       # Step 1: Calculate ephemeral DB URL (when PR has migrations or rebuild requested)
@@ -889,8 +887,10 @@ jobs:
       - name: Lint API
         run: pnpm run --filter api lint
 
-      - name: Build workspaces (Fail Fast Check)
-        run: pnpm run build
+      # Lint already ran above — build:ci skips lint:fix so we don't triple-lint.
+      # Frontend env (including VITE_BUILD_ID) is baked here; the Docker step only packages.
+      - name: Build workspaces
+        run: pnpm run build:ci
         env:
           BASE_URL: ${{ env.BASE_URL }}
           CLIENT_URL: ${{ env.CLIENT_URL }}
@@ -898,6 +898,7 @@ jobs:
           VITE_API_URL: ${{ env.VITE_API_URL }}
           VITE_MUI_LICENSE_KEY: ${{ env.VITE_MUI_LICENSE_KEY }}
           VITE_GTM_ID: ${{ env.VITE_GTM_ID }}
+          VITE_BUILD_ID: ${{ github.sha }}
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
@@ -916,32 +917,30 @@ jobs:
         id: image
         run: |
           IMAGE_URI="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/${IMAGE_NAME}"
+          CACHE_URI="${IMAGE_URI}:buildcache"
           echo "uri=${IMAGE_URI}" >> "$GITHUB_OUTPUT"
           echo "sha_tag=${IMAGE_URI}:${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
           echo "latest_tag=${IMAGE_URI}:latest" >> "$GITHUB_OUTPUT"
+          echo "cache_uri=${CACHE_URI}" >> "$GITHUB_OUTPUT"
 
-      - name: Create .env.production for Docker build
-        run: |
-          cat <<EOF > .env.production
-          VITE_API_URL=${VITE_API_URL}
-          VITE_MUI_LICENSE_KEY=${VITE_MUI_LICENSE_KEY}
-          VITE_GTM_ID=${VITE_GTM_ID}
-          VITE_BUILD_ID=${GITHUB_SHA}
-          EOF
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker image
-        run: docker build --platform linux/amd64 -t ${{ steps.image.outputs.sha_tag }} .
-
-      - name: Tag Docker image as latest
-        run: docker tag ${{ steps.image.outputs.sha_tag }} ${{ steps.image.outputs.latest_tag }}
-
-      - name: Push Docker images
-        run: |
-          docker push ${{ steps.image.outputs.sha_tag }}
-          docker push ${{ steps.image.outputs.latest_tag }}
-
-      - name: Clean temporary env.production file
-        run: rm -f .env.production
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ steps.image.outputs.sha_tag }}
+            ${{ steps.image.outputs.latest_tag }}
+          build-args: |
+            USE_PREBUILT=1
+          cache-from: type=registry,ref=${{ steps.image.outputs.cache_uri }}
+          cache-to: type=registry,ref=${{ steps.image.outputs.cache_uri }},mode=max
+          provenance: false
+          sbom: false
 
       - name: Resolve existing Cloud Run URL
         id: cloud-run-before

--- a/.github/workflows/deploy-prod-canary.yml
+++ b/.github/workflows/deploy-prod-canary.yml
@@ -103,9 +103,13 @@ jobs:
         run: pnpm run --filter api lint
 
       - name: Build workspaces
-        run: pnpm run build
+        run: pnpm run build:ci
         env:
           NODE_ENV: production
+          VITE_API_URL: ${{ env.VITE_API_URL }}
+          VITE_MUI_LICENSE_KEY: ${{ env.VITE_MUI_LICENSE_KEY }}
+          VITE_GTM_ID: ${{ env.VITE_GTM_ID }}
+          VITE_BUILD_ID: ${{ github.sha }}
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
@@ -124,22 +128,26 @@ jobs:
         id: image
         run: |
           IMAGE_URI="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/${IMAGE_NAME}"
+          CACHE_URI="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/mako:buildcache"
           echo "sha_tag=${IMAGE_URI}:${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          echo "cache_uri=${CACHE_URI}" >> "$GITHUB_OUTPUT"
 
-      - name: Create frontend build environment
-        run: |
-          cat <<EOF > .env.production
-          VITE_API_URL=${VITE_API_URL}
-          VITE_MUI_LICENSE_KEY=${VITE_MUI_LICENSE_KEY}
-          VITE_GTM_ID=${VITE_GTM_ID}
-          VITE_BUILD_ID=${GITHUB_SHA}
-          EOF
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push Docker image
-        run: |
-          docker build --platform linux/amd64 -t "${{ steps.image.outputs.sha_tag }}" .
-          docker push "${{ steps.image.outputs.sha_tag }}"
-          rm -f .env.production
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.image.outputs.sha_tag }}
+          build-args: |
+            USE_PREBUILT=1
+          cache-from: type=registry,ref=${{ steps.image.outputs.cache_uri }}
+          cache-to: type=registry,ref=${{ steps.image.outputs.cache_uri }},mode=max
+          provenance: false
+          sbom: false
 
       - name: Deploy quiesced canary
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,74 @@
-# Just build everything in one go
-FROM node:20 AS builder
+# syntax=docker/dockerfile:1
+#
+# Dual-mode production image:
+# - Default (USE_PREBUILT=0): build from source inside Docker (local `docker build -t mako .`)
+# - CI (USE_PREBUILT=1): package host-built dist/ artifacts (avoids rebuilding twice)
+#
+# Runtime layers (apt, dbt venvs, pnpm) are ordered for BuildKit cache reuse.
+
+# =============================================================================
+# Builder: compile from source (local / docs path)
+# =============================================================================
+FROM node:20 AS builder-source
 WORKDIR /app
 
-# Install pnpm first (this layer will be cached)
 RUN npm install -g pnpm
-
-# Copy everything
-COPY . .
 
 # Skip the Electron binary download (only needed by packages/desktop on
 # developer machines, never in the server image)
 ENV ELECTRON_SKIP_BINARY_DOWNLOAD=1
 
-# Install all dependencies (workspace handles conflicts)
-RUN pnpm install
+# Manifests first so dependency installs stay cached across source-only changes
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY app/package.json ./app/package.json
+COPY api/package.json ./api/package.json
+COPY docs/package.json ./docs/package.json
+COPY packages/schemas/package.json packages/schemas/prepare.js ./packages/schemas/
+COPY packages/agent-tools/package.json packages/agent-tools/prepare.js ./packages/agent-tools/
+COPY packages/desktop/package.json ./packages/desktop/package.json
+COPY packages/local-agent/package.json ./packages/local-agent/package.json
 
-# Build shared packages first, then apps
-RUN pnpm --filter @mako/schemas run build
-RUN pnpm --filter @mako/agent-tools run build
-RUN pnpm run app:build
-RUN pnpm run api:build
+RUN pnpm install --frozen-lockfile
 
-# Production stage
+COPY . .
+
+RUN pnpm --filter @mako/schemas run build \
+  && pnpm --filter @mako/agent-tools run build \
+  && pnpm run app:build \
+  && pnpm run api:build
+
+# =============================================================================
+# Builder: stage host-built artifacts (CI path)
+# =============================================================================
+FROM node:20 AS builder-prebuilt
+WORKDIR /app
+
+# Same paths the production stage expects from the source builder
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY api/package.json ./api/package.json
+COPY packages/schemas/package.json packages/schemas/prepare.js ./packages/schemas/
+COPY packages/schemas/dist ./packages/schemas/dist
+COPY packages/agent-tools/package.json packages/agent-tools/prepare.js ./packages/agent-tools/
+COPY packages/agent-tools/dist ./packages/agent-tools/dist
+COPY api/dist ./api/dist
+COPY app/dist ./app/dist
+
+# =============================================================================
+# Select builder based on USE_PREBUILT (0 = source, 1 = prebuilt)
+# =============================================================================
+ARG USE_PREBUILT=0
+FROM builder-source AS builder-0
+FROM builder-prebuilt AS builder-1
+FROM builder-${USE_PREBUILT} AS builder
+
+# =============================================================================
+# Production runtime
+# =============================================================================
 FROM node:20-slim
 WORKDIR /app
 
-# Install build tools needed for native modules (+ venv for the dbt runner)
+# Install build tools needed for native modules (+ venv for the dbt runner).
+# This layer is stable and should stay cached across app deploys.
 RUN apt-get update && apt-get install -y \
     python3 \
     python3-venv \
@@ -53,32 +96,28 @@ RUN python3 -m venv /opt/dbt-mysql \
     "dbt-mysql==1.7.0"
 ENV DBT_MYSQL_VENV_BIN=/opt/dbt-mysql/bin/dbt
 
-# Install pnpm in production too (this layer will be cached)
 RUN npm install -g pnpm
 
-# Set up minimal workspace so pnpm can resolve workspace:* deps
+# Minimal workspace so pnpm can resolve workspace:* deps
 RUN echo '{"private":true}' > package.json
 COPY --from=builder /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
 COPY --from=builder /app/pnpm-lock.yaml ./pnpm-lock.yaml
 
-# Copy API package manifest
+# Package manifests only — keeps prod install cached when only compiled output changes
 COPY --from=builder /app/api/package.json ./api/package.json
-
-# Copy compiled shared schemas package (runtime dependency of API)
 COPY --from=builder /app/packages/schemas/package.json ./packages/schemas/package.json
 COPY --from=builder /app/packages/schemas/prepare.js ./packages/schemas/prepare.js
-COPY --from=builder /app/packages/schemas/dist ./packages/schemas/dist
-
-# Copy compiled shared agent-tools package (runtime dependency of API)
 COPY --from=builder /app/packages/agent-tools/package.json ./packages/agent-tools/package.json
 COPY --from=builder /app/packages/agent-tools/prepare.js ./packages/agent-tools/prepare.js
-COPY --from=builder /app/packages/agent-tools/dist ./packages/agent-tools/dist
 
-# Install production dependencies
+# Placeholder dist dirs so prepare hooks / package mains resolve during install
+RUN mkdir -p packages/schemas/dist packages/agent-tools/dist
+
 RUN pnpm install --prod --filter api...
 
-# Copy built API into api/dist and frontend into api/public
-# (API server resolves public/ from process.cwd())
+# Copy compiled shared packages + app/API output
+COPY --from=builder /app/packages/schemas/dist ./packages/schemas/dist
+COPY --from=builder /app/packages/agent-tools/dist ./packages/agent-tools/dist
 COPY --from=builder /app/api/dist ./api/dist
 COPY --from=builder /app/app/dist ./api/public
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@
 #
 # Runtime layers (apt, dbt venvs, pnpm) are ordered for BuildKit cache reuse.
 
+# Must be declared before any FROM so it can interpolate the builder selector stage.
+ARG USE_PREBUILT=0
+
 # =============================================================================
 # Builder: compile from source (local / docs path)
 # =============================================================================
@@ -56,7 +59,6 @@ COPY app/dist ./app/dist
 # =============================================================================
 # Select builder based on USE_PREBUILT (0 = source, 1 = prebuilt)
 # =============================================================================
-ARG USE_PREBUILT=0
 FROM builder-source AS builder-0
 FROM builder-prebuilt AS builder-1
 FROM builder-${USE_PREBUILT} AS builder

--- a/deploy.sh
+++ b/deploy.sh
@@ -47,10 +47,10 @@ echo "ESLint checks passed. Proceeding with local build..."
 # Local verification step (build & quick start)
 # -------------------------------------------------------------
 
-# Attempt to build both front-end and API locally. If this fails, abort early.
+# Building app and API locally (lint already ran — skip lint:fix).
 echo "Building app and API with pnpm..."
-if ! pnpm run build; then
-  echo "❌ pnpm build failed! Aborting deploy."
+if ! pnpm run build:ci; then
+  echo "❌ pnpm build:ci failed! Aborting deploy."
   exit 1
 fi
 
@@ -157,20 +157,14 @@ echo "API startup verification succeeded."
 #     --role="roles/iam.serviceAccountTokenCreator"
 # -------------------------------------------------------------
 
-# Rebuild and redeploy (explicitly build for linux/amd64 platform)
+# Rebuild and redeploy (explicitly build for linux/amd64 platform).
+# Host already built dist/ — USE_PREBUILT=1 packages those artifacts (no second compile).
 echo "Building Docker image..."
 
-# Create a temporary .env.production file for the build to pick up variables
-echo "VITE_API_URL=$VITE_API_URL" > .env.production
-echo "VITE_MUI_LICENSE_KEY=$VITE_MUI_LICENSE_KEY" >> .env.production
-echo "VITE_GTM_ID=$VITE_GTM_ID" >> .env.production
-
-if ! docker build --platform linux/amd64 -t $IMAGE_NAME:latest .; then
+if ! docker build --platform linux/amd64 --build-arg USE_PREBUILT=1 -t $IMAGE_NAME:latest .; then
     echo "❌ Docker build failed!"
-    rm .env.production
     exit 1
 fi
-rm .env.production
 
 # Verify that the freshly built image can start successfully.
 echo "Testing Docker image locally..."

--- a/docs/src/content/docs/deployment.md
+++ b/docs/src/content/docs/deployment.md
@@ -8,8 +8,12 @@ description: Deploy Mako to production with Docker, Google Cloud Run, or Cloudfl
 Mako ships with a production-ready Dockerfile.
 
 ```bash
-# Build the image
+# Build the image from source (default)
 docker build -t mako .
+
+# Or: build packages on the host, then package only (what CI does)
+pnpm run build:ci
+docker build --build-arg USE_PREBUILT=1 -t mako .
 
 # Run it
 docker run -p 8080:8080 \
@@ -21,6 +25,8 @@ docker run -p 8080:8080 \
 ```
 
 The image bundles both the API and the pre-built React frontend. The API serves the frontend from `/public`.
+
+CI (`deploy-app.yml`) builds once on the runner with `pnpm run build:ci`, then packages with `USE_PREBUILT=1` and BuildKit registry cache so apt/dbt/pnpm layers are reused across deploys.
 
 ### Docker Compose (Development)
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "concurrently \"pnpm --filter app run dev\" \"pnpm --filter api run dev\" \"pnpm dlx inngest-cli@latest dev\"",
     "dev:tunnel": "concurrently \"pnpm dev\" \"cloudflared tunnel --url http://localhost:5173 --no-tls-verify\"",
-    "build": "pnpm run lint:fix:all && pnpm --filter @mako/schemas run build && pnpm --filter @mako/agent-tools run build && pnpm run app:build && pnpm run api:build && node scripts/check-connector-agnosticism.js",
+    "build": "pnpm run lint:fix:all && pnpm run build:ci",
+  "build:ci": "pnpm --filter @mako/schemas run build && pnpm --filter @mako/agent-tools run build && pnpm run app:build && pnpm run api:build && node scripts/check-connector-agnosticism.js",
     "start": "node dist/index.js",
     "format": "prettier --write \"api/**/*.ts\"",
     "sync": "ts-node api/src/sync/cli.ts",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`deploy-app.yml` was consistently **~16–18 minutes**. Step timings from a recent prod run before this change:

| Step | Time |
|---|---|
| Docker build (full recompile + apt + 2× dbt pip venvs) | ~6 min |
| Host `pnpm run build` (second full compile) | ~5–6 min |
| Lint app + API | ~1.5 min |
| Cloud Run deploy + push | ~2–3 min |

Root causes: **build twice**, **lint three times** (`lint` steps + `lint:fix:all` inside `pnpm run build`), and **zero Docker layer cache** on ephemeral runners.

## Changes

1. **`pnpm run build:ci`** — compile schemas/agent-tools/app/api + connector check, no lint. Root `build` still runs `lint:fix:all && build:ci` for local use.
2. **Dual-mode `Dockerfile`**
   - Default `USE_PREBUILT=0`: build from source (`docker build -t mako .` still works)
   - CI `USE_PREBUILT=1`: package host-built `dist/` (no second TypeScript/Vite compile)
   - Manifest-first + apt/dbt layers ordered for cache reuse
3. **Buildx + Artifact Registry cache** (`mako:buildcache`, `mode=max`) on preview, production, and canary workflows
4. **`.dockerignore`** no longer excludes `*/dist` (required for prebuilt packaging)
5. Docs / `deploy.sh` / build-deploy rule updated to match

## Measured on this PR

| | Before (typical) | Cold cache (run after fix) | Warm cache (2nd push) |
|---|---|---|---|
| **Preview job total** | ~16–18 min | **10.6 min** (634s) | **8.9 min** (535s) |
| Docker build+push | ~364s | **168s** | **88s** |
| Host build | ~337s (incl. re-lint) | **226s** (`build:ci`) | **233s** |
| Cloud Run deploy | ~90s | 80s | 35s |

Cold run correctly used only `builder-prebuilt` (no source recompile) and seeded `mako:buildcache`. Warm run reused apt/dbt/pnpm layers.

Remaining floor is mostly host lint (~1.5 min) + host compile (~4 min) + Cloud Run rollout. Further wins would be parallelizing lint/build or caching the TS/Vite build itself.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4221195d-2e42-4901-a677-e653e25f1cca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4221195d-2e42-4901-a677-e653e25f1cca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

