### PR TITLE
Compact the apps + data source toolbars so they fit on normal screens

### DIFF
--- a/app/src/components/AppBindingEditor.tsx
+++ b/app/src/components/AppBindingEditor.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import {
   Box,
-  Chip,
   MenuItem,
   Select,
   Typography,
@@ -277,25 +276,12 @@ export default function AppBindingEditor({
     binding.dbtProjectId && !containsDbtSchemaToken(binding.code),
   );
 
+  // Deliberately compact: the data-source toolbar shares one row with the
+  // Console's run/save/connection controls and hardly fits on normal screens.
+  // No caption labels; the Live/Materialized explanation lives in a tooltip on
+  // the toggle itself, and the dbt token warning is an icon, not a chip.
   const leadingControls = (
     <>
-      <Typography variant="caption" color="text.secondary">
-        Data
-      </Typography>
-      <ToggleButtonGroup
-        size="small"
-        exclusive
-        value={binding.materialization}
-        onChange={(_e, value) => {
-          if (value && workspaceId) {
-            updateBinding(appId, bindingId, { materialization: value });
-            void persistApp(workspaceId, appId);
-          }
-        }}
-      >
-        <ToggleButton value="live">Live</ToggleButton>
-        <ToggleButton value="parquet">Materialized</ToggleButton>
-      </ToggleButtonGroup>
       <Tooltip
         title={
           <Box sx={{ p: 0.5 }}>
@@ -312,30 +298,39 @@ export default function AppBindingEditor({
           </Box>
         }
       >
-        <InfoIcon
-          size={15}
-          strokeWidth={1.5}
-          style={{ opacity: 0.6, cursor: "help" }}
-        />
+        <ToggleButtonGroup
+          size="small"
+          exclusive
+          value={binding.materialization}
+          onChange={(_e, value) => {
+            if (value && workspaceId) {
+              updateBinding(appId, bindingId, { materialization: value });
+              void persistApp(workspaceId, appId);
+            }
+          }}
+        >
+          <ToggleButton value="live">Live</ToggleButton>
+          <ToggleButton value="parquet">Materialized</ToggleButton>
+        </ToggleButtonGroup>
       </Tooltip>
       {showDbtLink && (
         <>
-          <Typography variant="caption" color="text.secondary" sx={{ ml: 1 }}>
-            dbt
-          </Typography>
+          {/* NOTE: deliberately NOT wrapped in a Tooltip — a tooltip anchored
+              on the Select stays visible while its menu is open and covers the
+              first menu items. The info icon carries the explanation. */}
           <Select
             size="small"
             variant="outlined"
             displayEmpty
             value={binding.dbtProjectId ?? ""}
             onChange={e => handleDbtLinkChange(e.target.value)}
-            sx={{ fontSize: "0.72rem", height: 26, minWidth: 110 }}
+            sx={{ fontSize: "0.72rem", height: 26, minWidth: 90, ml: 0.5 }}
             renderValue={value => {
-              if (!value) return "Not linked";
-              return (
+              if (!value) return "dbt: not linked";
+              return `dbt: ${
                 dbtProjects.find(p => p._id === value)?.name ??
-                (linkedDbtProjectMissing ? "Deleted project" : "…")
-              );
+                (linkedDbtProjectMissing ? "deleted project" : "…")
+              }`;
             }}
           >
             <MenuItem value="">Not linked</MenuItem>
@@ -378,12 +373,15 @@ export default function AppBindingEditor({
                 "in the app preview."
               }
             >
-              <Chip
-                size="small"
-                color="warning"
-                variant="outlined"
-                label="No {{ dbt_schema }} token"
-              />
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  color: "warning.main",
+                }}
+              >
+                <InfoIcon size={15} strokeWidth={1.5} />
+              </Box>
             </Tooltip>
           )}
         </>

--- a/app/src/components/AppRenderer.tsx
+++ b/app/src/components/AppRenderer.tsx
@@ -3,12 +3,15 @@ import {
   Box,
   Button,
   CircularProgress,
+  Divider,
   IconButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
   MenuItem,
   Select,
   Tooltip,
   Typography,
-  Chip,
   Alert,
   Snackbar,
 } from "@mui/material";
@@ -19,6 +22,8 @@ import {
   UploadCloud as PublishIcon,
   CheckCircle2 as PublishedIcon,
   DatabaseZap as RematerializeIcon,
+  MoreVertical as MoreIcon,
+  Info as InfoIcon,
 } from "lucide-react";
 import { containsDbtSchemaToken } from "@mako/schemas";
 import { useWorkspace } from "../contexts/workspace-context";
@@ -66,6 +71,7 @@ export default function AppRenderer({
   const workspaceId = currentWorkspace?.id;
   const [shareOpen, setShareOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
+  const [moreAnchor, setMoreAnchor] = useState<HTMLElement | null>(null);
   const [publishOpen, setPublishOpen] = useState(false);
   const [publishing, setPublishing] = useState(false);
   const publishSuggestion = useSaveCommentSuggestion();
@@ -550,7 +556,9 @@ export default function AppRenderer({
 
   return (
     <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
-      {/* Slim toolbar */}
+      {/* Slim toolbar. Kept deliberately sparse so it fits narrow screens:
+          secondary info (runtime) and rare actions (materialize, history)
+          live in the overflow menu; draft state is a dot, not a chip. */}
       <Box
         sx={{
           display: "flex",
@@ -558,29 +566,36 @@ export default function AppRenderer({
           gap: 1,
           px: 1.5,
           py: 0.5,
+          minWidth: 0,
+          overflow: "hidden",
           borderBottom: "1px solid",
           borderColor: "divider",
         }}
       >
-        <Typography variant="body2" sx={{ fontWeight: 600 }}>
+        <Typography
+          variant="body2"
+          noWrap
+          sx={{ fontWeight: 600, minWidth: 0, flexShrink: 1 }}
+        >
           {appEntity.title}
         </Typography>
-        <Chip
-          size="small"
-          variant="outlined"
-          label={appEntity.runtime === "cdn" ? "CDN preview" : "WebContainer"}
-        />
         {appEntity.hasUnpublishedChanges && (
-          <Chip
-            size="small"
-            color="warning"
-            variant="outlined"
-            label="Unpublished changes"
-          />
+          <Tooltip title="Unpublished changes — viewers still see the last published version">
+            <Box
+              sx={{
+                width: 8,
+                height: 8,
+                borderRadius: "50%",
+                bgcolor: "warning.main",
+                flexShrink: 0,
+              }}
+            />
+          </Tooltip>
         )}
         {/* NOTE: deliberately NOT wrapped in a Tooltip — a tooltip anchored on
             the Select stays visible while its menu is open and covers the
-            first menu items. The chip below carries the explanation. */}
+            first menu items. The info icon next to it carries the
+            explanation while an override is active. */}
         {dbtProjectId && dbtEnvInfo && effectiveDbtEnv && (
           <Select
             size="small"
@@ -592,7 +607,13 @@ export default function AppRenderer({
                 e.target.value === prodEnvName ? null : e.target.value,
               )
             }
-            sx={{ fontSize: "0.72rem", height: 26, ml: 0.5 }}
+            sx={{
+              fontSize: "0.72rem",
+              height: 26,
+              ml: 0.5,
+              flexShrink: 0,
+              ...(dbtOverrideActive && { color: "info.main" }),
+            }}
           >
             {dbtEnvInfo.environments
               .filter(
@@ -615,16 +636,20 @@ export default function AppRenderer({
         {dbtOverrideActive && (
           <Tooltip
             title={
-              "dbt data environment for THIS preview only (your view). " +
-              "Published/shared viewers always read prod."
+              `Previewing dbt env "${effectiveDbtEnv}" — for THIS preview ` +
+              "only (your view). Published/shared viewers always read prod."
             }
           >
-            <Chip
-              size="small"
-              color="info"
-              variant="outlined"
-              label={`Previewing dbt env: ${effectiveDbtEnv}`}
-            />
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                color: "info.main",
+                flexShrink: 0,
+              }}
+            >
+              <InfoIcon size={15} strokeWidth={1.5} />
+            </Box>
           </Tooltip>
         )}
         <Box sx={{ flex: 1 }} />
@@ -635,51 +660,24 @@ export default function AppRenderer({
               variant="contained"
               startIcon={<PublishIcon size={16} strokeWidth={1.5} />}
               onClick={openPublishDialog}
+              sx={{ flexShrink: 0 }}
             >
               Publish
             </Button>
           ) : (
-            <Tooltip title="Draft matches the published version">
-              <span>
-                <Button
-                  size="small"
-                  variant="outlined"
-                  color="inherit"
-                  disabled
-                  startIcon={<PublishedIcon size={16} strokeWidth={1.5} />}
-                >
-                  Published
-                </Button>
-              </span>
+            <Tooltip title="Published — draft matches the published version">
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  color: "success.main",
+                  flexShrink: 0,
+                }}
+              >
+                <PublishedIcon size={18} strokeWidth={1.5} />
+              </Box>
             </Tooltip>
           ))}
-        {canManage && hasParquetBindings && (
-          <Tooltip title="Re-materialize every query's Parquet file">
-            <span>
-              <Button
-                size="small"
-                variant="outlined"
-                color="inherit"
-                disabled={rematerializing}
-                startIcon={
-                  rematerializing ? (
-                    <CircularProgress size={14} />
-                  ) : (
-                    <RematerializeIcon size={16} strokeWidth={1.5} />
-                  )
-                }
-                onClick={() => void handleRematerialize()}
-              >
-                {rematerializing ? "Materializing…" : "Materialize"}
-              </Button>
-            </span>
-          </Tooltip>
-        )}
-        <Tooltip title="Version history">
-          <IconButton size="small" onClick={() => setHistoryOpen(true)}>
-            <HistoryIcon size={18} strokeWidth={1.5} />
-          </IconButton>
-        </Tooltip>
         <Tooltip title="Share">
           <IconButton size="small" onClick={() => setShareOpen(true)}>
             <ShareIcon size={18} strokeWidth={1.5} />
@@ -690,7 +688,62 @@ export default function AppRenderer({
             <RefreshIcon size={18} strokeWidth={1.5} />
           </IconButton>
         </Tooltip>
+        <Tooltip title="More">
+          <IconButton
+            size="small"
+            onClick={e => setMoreAnchor(e.currentTarget)}
+          >
+            <MoreIcon size={18} strokeWidth={1.5} />
+          </IconButton>
+        </Tooltip>
       </Box>
+
+      <Menu
+        anchorEl={moreAnchor}
+        open={!!moreAnchor}
+        onClose={() => setMoreAnchor(null)}
+      >
+        <MenuItem
+          onClick={() => {
+            setMoreAnchor(null);
+            setHistoryOpen(true);
+          }}
+        >
+          <ListItemIcon>
+            <HistoryIcon size={16} strokeWidth={1.5} />
+          </ListItemIcon>
+          <ListItemText>Version history</ListItemText>
+        </MenuItem>
+        {canManage && hasParquetBindings && (
+          <MenuItem
+            disabled={rematerializing}
+            onClick={() => {
+              setMoreAnchor(null);
+              void handleRematerialize();
+            }}
+          >
+            <ListItemIcon>
+              {rematerializing ? (
+                <CircularProgress size={14} />
+              ) : (
+                <RematerializeIcon size={16} strokeWidth={1.5} />
+              )}
+            </ListItemIcon>
+            <ListItemText
+              primary={rematerializing ? "Materializing…" : "Materialize data"}
+              secondary="Rebuild every query's Parquet file"
+            />
+          </MenuItem>
+        )}
+        <Divider />
+        <MenuItem disabled sx={{ "&.Mui-disabled": { opacity: 1 } }}>
+          <ListItemText
+            secondary={`Runtime: ${
+              appEntity.runtime === "cdn" ? "CDN preview" : "WebContainer"
+            }`}
+          />
+        </MenuItem>
+      </Menu>
 
       <VersionHistoryPanel
         open={historyOpen}

--- a/app/src/components/DashboardDataSourceEditor.tsx
+++ b/app/src/components/DashboardDataSourceEditor.tsx
@@ -6,7 +6,6 @@ import {
   ToggleButton,
   Tooltip,
 } from "@mui/material";
-import { Info as InfoIcon } from "lucide-react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { useWorkspace } from "../contexts/workspace-context";
 import {
@@ -300,11 +299,25 @@ export default function DashboardDataSourceEditor({
 
   const isParquet = (dataSource.materialization ?? "parquet") === "parquet";
 
+  // Compact on purpose (shares the toolbar row with run/save/connection): no
+  // caption label; the Live/Materialized explanation lives in a tooltip on
+  // the toggle itself.
   const leadingControls = (
-    <>
-      <Typography variant="caption" color="text.secondary">
-        Data
-      </Typography>
+    <Tooltip
+      title={
+        <Box sx={{ p: 0.5 }}>
+          <Typography variant="caption" display="block" sx={{ mb: 0.5 }}>
+            <b>Live</b> — the query streams from the connection each time the
+            dashboard loads. Always fresh; not shown in public shares.
+          </Typography>
+          <Typography variant="caption" display="block">
+            <b>Materialized</b> — the query is snapshotted to a Parquet file and
+            loaded into DuckDB, so widgets render fast and public viewers get a
+            cached snapshot. Click <b>Materialize</b> to build/refresh.
+          </Typography>
+        </Box>
+      }
+    >
       <ToggleButtonGroup
         size="small"
         exclusive
@@ -322,28 +335,7 @@ export default function DashboardDataSourceEditor({
         <ToggleButton value="live">Live</ToggleButton>
         <ToggleButton value="parquet">Materialized</ToggleButton>
       </ToggleButtonGroup>
-      <Tooltip
-        title={
-          <Box sx={{ p: 0.5 }}>
-            <Typography variant="caption" display="block" sx={{ mb: 0.5 }}>
-              <b>Live</b> — the query streams from the connection each time the
-              dashboard loads. Always fresh; not shown in public shares.
-            </Typography>
-            <Typography variant="caption" display="block">
-              <b>Materialized</b> — the query is snapshotted to a Parquet file
-              and loaded into DuckDB, so widgets render fast and public viewers
-              get a cached snapshot. Click <b>Materialize</b> to build/refresh.
-            </Typography>
-          </Box>
-        }
-      >
-        <InfoIcon
-          size={15}
-          strokeWidth={1.5}
-          style={{ opacity: 0.6, cursor: "help" }}
-        />
-      </Tooltip>
-    </>
+    </Tooltip>
   );
 
   const headerExtras = (

--- a/app/src/components/DataSourceMaterializationControls.tsx
+++ b/app/src/components/DataSourceMaterializationControls.tsx
@@ -6,6 +6,10 @@ import {
   Chip,
   Tooltip,
   IconButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
   Popover,
   Divider,
 } from "@mui/material";
@@ -16,16 +20,19 @@ import {
   Eye as PreviewIcon,
   CheckCircle2 as SuccessIcon,
   XCircle as ErrorIcon,
+  MoreVertical as MoreIcon,
 } from "lucide-react";
 import MaterializationScheduleControls from "./MaterializationScheduleControls";
 import type { MaterializationScheduleValue } from "../lib/materializationSchedule";
 
 /**
  * Shared materialization toolbar for app data bindings and dashboard data
- * sources. Both surfaces present the same controls — Materialize button, build
- * status chip, freshness badge, snapshot preview, schedule popover, and history
- * popover — so the two editors look and behave identically. Surface-specific
- * wiring (where the schedule/cache live, how history is loaded) is passed in.
+ * sources. Both surfaces present the same controls — Materialize button, one
+ * combined status/freshness chip, and a ⋮ menu holding the snapshot preview,
+ * schedule, and history — so the two editors look and behave identically and
+ * the (already crowded) data-source toolbar keeps a small footprint.
+ * Surface-specific wiring (where the schedule/cache live, how history is
+ * loaded) is passed in.
  */
 
 export type MaterializationBuildStatus =
@@ -115,6 +122,7 @@ export default function DataSourceMaterializationControls({
   onOpenHistory,
   showHistory = true,
 }: Props) {
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
   const [scheduleAnchor, setScheduleAnchor] = useState<HTMLElement | null>(
     null,
   );
@@ -128,7 +136,7 @@ export default function DataSourceMaterializationControls({
     [onOpenHistory],
   );
 
-  // Freshness badge: only meaningful once a snapshot exists. Stale when the
+  // Freshness: only meaningful once a snapshot exists. Stale when the
   // artifact is older than the freshness window (default 24h, matching the
   // dashboard canvas badge).
   let freshness: { label: string; stale: boolean } | null = null;
@@ -136,6 +144,38 @@ export default function DataSourceMaterializationControls({
     const ageMs = Date.now() - builtAtMs;
     const ttl = dataFreshnessTtlMs ?? DEFAULT_FRESHNESS_TTL_MS;
     freshness = { label: formatRelative(ageMs), stale: ageMs > ttl };
+  }
+
+  // One combined chip carries build status + row count + freshness (the old
+  // separate chips ate too much toolbar width on normal screens).
+  let statusChip: {
+    label: string;
+    color: "success" | "error" | "warning" | "default";
+    tooltip: string;
+  } | null = null;
+  if (buildStatus === "ready") {
+    const rows = rowCount != null ? `${rowCount.toLocaleString()} rows` : null;
+    const age = freshness
+      ? freshness.stale
+        ? `stale · ${freshness.label}`
+        : freshness.label
+      : null;
+    statusChip = {
+      label: [rows, age].filter(Boolean).join(" · ") || "ready",
+      color: freshness?.stale ? "warning" : "success",
+      tooltip: freshness?.stale
+        ? "The snapshot is older than its freshness window — click Materialize to refresh."
+        : "The snapshot is up to date.",
+    };
+  } else if (buildStatus) {
+    statusChip = {
+      label: buildStatus,
+      color: buildStatus === "error" ? "error" : "default",
+      tooltip:
+        buildStatus === "error"
+          ? "The last materialization failed — see the history for details."
+          : "Snapshot build status.",
+    };
   }
 
   return (
@@ -158,78 +198,76 @@ export default function DataSourceMaterializationControls({
               </Button>
             </span>
           </Tooltip>
-          {buildStatus && (
-            <Chip
-              size="small"
-              variant="outlined"
-              color={
-                buildStatus === "ready"
-                  ? "success"
-                  : buildStatus === "error"
-                    ? "error"
-                    : "default"
-              }
-              label={
-                buildStatus === "ready" && rowCount != null
-                  ? `${rowCount.toLocaleString()} rows`
-                  : buildStatus
-              }
-            />
-          )}
-          {freshness && (
-            <Tooltip
-              title={
-                freshness.stale
-                  ? "The snapshot is older than its freshness window — click Materialize to refresh."
-                  : "The snapshot is up to date."
-              }
-            >
+          {statusChip && (
+            <Tooltip title={statusChip.tooltip}>
               <Chip
                 size="small"
                 variant="outlined"
-                color={freshness.stale ? "warning" : "default"}
-                label={
-                  freshness.stale
-                    ? `Stale · ${freshness.label}`
-                    : `Updated ${freshness.label}`
-                }
+                color={statusChip.color}
+                label={statusChip.label}
               />
             </Tooltip>
           )}
-          {canPreview && onPreviewSnapshot && (
-            <Tooltip title="Preview the materialized data">
-              <span>
-                <IconButton
-                  size="small"
-                  onClick={() => onPreviewSnapshot()}
-                  disabled={previewing}
-                >
-                  <PreviewIcon size={18} strokeWidth={1.5} />
-                </IconButton>
-              </span>
-            </Tooltip>
-          )}
-          <Tooltip title="Materialization schedule">
+          <Tooltip title="Snapshot options">
             <IconButton
               size="small"
-              onClick={e => setScheduleAnchor(e.currentTarget)}
+              onClick={e => setMenuAnchor(e.currentTarget)}
             >
-              <ScheduleIcon size={18} strokeWidth={1.5} />
+              <MoreIcon size={18} strokeWidth={1.5} />
             </IconButton>
           </Tooltip>
-          {showHistory && (
-            <Tooltip title="Materialization history">
-              <span>
-                <IconButton
-                  size="small"
-                  onClick={e => openHistory(e.currentTarget)}
-                  disabled={history.length === 0 && !onOpenHistory}
-                >
-                  <HistoryIcon size={18} strokeWidth={1.5} />
-                </IconButton>
-              </span>
-            </Tooltip>
-          )}
+          <Menu
+            anchorEl={menuAnchor}
+            open={!!menuAnchor}
+            onClose={() => setMenuAnchor(null)}
+          >
+            {onPreviewSnapshot && (
+              <MenuItem
+                disabled={!canPreview || previewing}
+                onClick={() => {
+                  setMenuAnchor(null);
+                  onPreviewSnapshot();
+                }}
+              >
+                <ListItemIcon>
+                  <PreviewIcon size={16} strokeWidth={1.5} />
+                </ListItemIcon>
+                <ListItemText
+                  primary="Preview snapshot"
+                  secondary={
+                    canPreview ? undefined : "Materialize the data first"
+                  }
+                />
+              </MenuItem>
+            )}
+            {/* Popovers anchor on the ⋮ button (menuAnchor): menu items
+                unmount when the menu closes, so they can't be anchors. */}
+            <MenuItem
+              onClick={() => {
+                setScheduleAnchor(menuAnchor);
+                setMenuAnchor(null);
+              }}
+            >
+              <ListItemIcon>
+                <ScheduleIcon size={16} strokeWidth={1.5} />
+              </ListItemIcon>
+              <ListItemText>Schedule…</ListItemText>
+            </MenuItem>
+            {showHistory && (
+              <MenuItem
+                disabled={history.length === 0 && !onOpenHistory}
+                onClick={() => {
+                  if (menuAnchor) openHistory(menuAnchor);
+                  setMenuAnchor(null);
+                }}
+              >
+                <ListItemIcon>
+                  <HistoryIcon size={16} strokeWidth={1.5} />
+                </ListItemIcon>
+                <ListItemText>History…</ListItemText>
+              </MenuItem>
+            )}
+          </Menu>
         </>
       )}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The app preview toolbar and — the main offender — the **data source editor toolbar** hardly fit on normal screens. The data source view crams the Console's run/save/connection controls plus a "Data" caption, Live/Materialized toggle, info icon, dbt caption + select + info icon, a token-warning chip, Materialize button, TWO status chips (build status + freshness), and three icon buttons (preview/schedule/history) into one row.

## Changes

### `app/src/components/AppRenderer.tsx` (app preview toolbar)

- "Unpublished changes" chip → small warning dot next to the title, with the explanation in a tooltip.
- Runtime chip ("CDN preview" / "WebContainer") → info row inside a new ⋮ overflow menu.
- "Materialize" button → "Materialize data" item in the overflow menu, still gated on `canManage && hasParquetBindings`.
- Version history icon button → overflow menu item.
- Disabled "Published" button → green check icon with tooltip.
- dbt override chip → info icon + tooltip; the env Select tints info-blue while an override is active.
- Title truncates (`noWrap` + `minWidth: 0`) instead of forcing overflow.

### `app/src/components/DataSourceMaterializationControls.tsx` (shared by app bindings + dashboard data sources)

- Build-status chip + freshness chip merged into ONE chip: `5 rows · 42m ago` (success), `… · stale` (warning), `error` (error) — details in its tooltip.
- Preview / Schedule / History moved from three inline icon buttons into a single ⋮ menu ("Preview snapshot", "Schedule…", "History…"); popovers anchor on the ⋮ button.

### `app/src/components/AppBindingEditor.tsx` + `DashboardDataSourceEditor.tsx`

- Dropped the "Data" and "dbt" caption labels; the Live/Materialized explanation moved into a tooltip on the toggle itself.
- dbt select now renders its own context (`dbt: not linked` / `dbt: <project>`).
- "No {{ dbt_schema }} token" warning chip → warning-colored info icon with the same tooltip.

## Testing

- ✅ `pnpm --filter app run typecheck`
- ✅ `pnpm --filter app run lint`
- Manual end-to-end in the local dev environment, at a ~900px-wide window:
  - App toolbar: dot tooltip, overflow menu, version history, publish flow → green check, materialize-from-menu (parquet artifact built: `parquetBuildStatus: "ready"`, 5 rows).
  - Data source toolbar: single combined chip + tooltip, ⋮ menu, Preview snapshot fills the results table with the 5 artist rows, Schedule and History popovers open correctly, everything on one line with no clipping.

[data_source_toolbar_compact_demo.mp4](https://cursor.com/agents/bc-fa21e7ce-7aae-4a71-96a1-22b48f068d7e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdata_source_toolbar_compact_demo.mp4)
[app_toolbar_compact_demo.mp4](https://cursor.com/agents/bc-fa21e7ce-7aae-4a71-96a1-22b48f068d7e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_toolbar_compact_demo.mp4)

[Compact data source toolbar at ~900px](https://cursor.com/agents/bc-fa21e7ce-7aae-4a71-96a1-22b48f068d7e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdata_source_toolbar_compact.webp)
[Snapshot ⋮ menu with Preview / Schedule / History](https://cursor.com/agents/bc-fa21e7ce-7aae-4a71-96a1-22b48f068d7e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdata_source_snapshot_menu.webp)
[Preview snapshot fills the results panel](https://cursor.com/agents/bc-fa21e7ce-7aae-4a71-96a1-22b48f068d7e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdata_source_preview_snapshot.webp)
[App toolbar overflow menu](https://cursor.com/agents/bc-fa21e7ce-7aae-4a71-96a1-22b48f068d7e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foverflow_menu_with_materialize.webp)
[App toolbar fits at ~900px width](https://cursor.com/agents/bc-fa21e7ce-7aae-4a71-96a1-22b48f068d7e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftoolbar_narrow_900px.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa21e7ce-7aae-4a71-96a1-22b48f068d7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa21e7ce-7aae-4a71-96a1-22b48f068d7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

