### PR TITLE
feat(mcp): smart agent↔MCP tool bridge with gap catalog

### DIFF
--- a/api/src/agent-lib/tools/skill-tools.ts
+++ b/api/src/agent-lib/tools/skill-tools.ts
@@ -1,18 +1,17 @@
 /**
  * Skill tools — agent-side CRUD + search for the skills system (issue #365).
  *
- * Four tools:
- *   - save_skill     upsert a named playbook (auto-extracts entities)
- *   - delete_skill   retract a skill by name
- *   - load_skill     explicit load; appears in trace, forces commitment
- *   - read_skill_resource load a system skill reference file
- *   - search_skills  fallback when the injected index misses
+ * Tools:
+ *   - save_skill / delete_skill     workspace skill writes (in-product)
+ *   - list_skills                   compact index (workspace + system)
+ *   - get_relevant_skills           same retrieval as pre-turn auto-inject
+ *   - load_skill                    explicit load by name
+ *   - read_skill_resource           system skill references/*.md
+ *   - search_skills                 free-text fallback
  *
- * The main retrieval happens *before* the agent runs — the system prompt
- * is pre-populated with the skill index and top-k auto-loaded bodies. These
- * tools exist so the agent can (a) write what it learns, (b) correct itself
- * by deleting wrong skills, (c) pull a specific skill mid-turn, and (d) run
- * a direct search if the index hint didn't fire.
+ * The in-product agent also gets the index + top-k bodies injected into the
+ * system prompt before each turn. MCP clients do not — they call list_skills /
+ * get_relevant_skills instead.
  */
 
 import { tool } from "ai";
@@ -21,6 +20,7 @@ import {
   deleteSkill,
   loadSkill,
   readSkillResource,
+  retrieveRelevantSkills,
   saveSkill,
   searchSkills,
 } from "../../services/skills.service";
@@ -103,6 +103,17 @@ const readSkillResourceSchema = z.object({
     ),
 });
 
+const listSkillsSchema = z.object({});
+
+const getRelevantSkillsSchema = z.object({
+  query: z
+    .string()
+    .min(1)
+    .describe(
+      "Natural-language task or question to rank skills against — same signal the in-product agent uses for pre-turn auto-injection.",
+    ),
+});
+
 export function createSkillTools(workspaceId: string, userId?: string) {
   const authorId = userId && userId.length > 0 ? userId : "agent";
 
@@ -133,9 +144,64 @@ export function createSkillTools(workspaceId: string, userId?: string) {
         return deleteSkill(workspaceId, name);
       },
     }),
+    list_skills: tool({
+      description: [
+        "List every available skill (workspace + system) as a compact index:",
+        "name, loadWhen trigger, scope, and optional references paths.",
+        "Bodies are NOT included — call get_relevant_skills for ranked bodies,",
+        "or load_skill / read_skill_resource for a specific skill.",
+        "Prefer this over guessing skill names.",
+      ].join(" "),
+      inputSchema: listSkillsSchema,
+      execute: async () => {
+        // Empty query → index only (no body injection / useCount bumps).
+        const result = await retrieveRelevantSkills(workspaceId, "");
+        return {
+          success: true as const,
+          skills: result.index.map(s => ({
+            name: s.name,
+            loadWhen: s.loadWhen,
+            scope: s.scope,
+            ...(s.references && s.references.length > 0
+              ? { references: s.references }
+              : {}),
+          })),
+        };
+      },
+    }),
+    get_relevant_skills: tool({
+      description: [
+        "Rank skills against a task/query and return the top relevant bodies",
+        "(same retrieval the in-product agent auto-injects each turn).",
+        "Call this at the start of a multi-step task, or when switching domains",
+        "(e.g. apps → SQL dialect). Also returns near-misses so you can",
+        "load_skill anything the threshold skipped.",
+      ].join(" "),
+      inputSchema: getRelevantSkillsSchema,
+      execute: async ({ query }) => {
+        const result = await retrieveRelevantSkills(workspaceId, query);
+        return {
+          success: true as const,
+          queryEntities: result.queryEntities,
+          relevant: result.injected.map(h => ({
+            name: h.name,
+            loadWhen: h.loadWhen,
+            scope: h.scope,
+            score: Math.round(h.score * 100) / 100,
+            body: h.body,
+          })),
+          considered: result.considered.map(h => ({
+            name: h.name,
+            loadWhen: h.loadWhen,
+            scope: h.scope,
+            score: Math.round(h.score * 100) / 100,
+          })),
+        };
+      },
+    }),
     load_skill: tool({
       description:
-        "Explicitly load a skill by name from the index. Use this when you spot a skill in the injected index whose `loadWhen` matches what you're about to do, but it wasn't auto-loaded. Bumps the skill's useCount so retrieval can reinforce it later.",
+        "Explicitly load a skill by name from the index. Use this when you spot a skill in the index whose `loadWhen` matches what you're about to do, but it wasn't auto-loaded. Bumps the skill's useCount so retrieval can reinforce it later.",
       inputSchema: loadSkillSchema,
       execute: async ({ name }) => {
         return loadSkill(workspaceId, name);

--- a/api/src/agents/modes/registry.ts
+++ b/api/src/agents/modes/registry.ts
@@ -26,6 +26,8 @@ export const CORE_ALWAYS_TOOL_NAMES: readonly string[] = [
   // Skills
   "save_skill",
   "delete_skill",
+  "list_skills",
+  "get_relevant_skills",
   "load_skill",
   "read_skill_resource",
   "search_skills",

--- a/api/src/mcp/bridge-inventory.ts
+++ b/api/src/mcp/bridge-inventory.ts
@@ -1,0 +1,113 @@
+/**
+ * Live inventory of agent tool names (server factories + client packages).
+ *
+ * Used by the MCP bridge policy tests to detect unclassified / stale tools.
+ * Instantiating factories only builds tool *definitions* — execute is not
+ * called — so this is safe without a database.
+ */
+import {
+  clientAgentTools,
+  clientScreenshotTools,
+  PLAN_GATE_ALLOWED_TOOL_NAMES,
+} from "@mako/agent-tools";
+import { Types } from "mongoose";
+
+import { createFlowTools } from "../agents/flow";
+import { createConsoleSearchTools } from "../agent-lib/tools/console-search-tools";
+import { createDashboardSearchTools } from "../agent-lib/tools/dashboard-search-tools";
+import { createDbtServerTools } from "../agent-lib/tools/dbt-tools";
+import { createMongoToolsV2 } from "../agent-lib/tools/mongodb-tools";
+import { createScheduleQueryTool } from "../agent-lib/tools/schedule-query-tool";
+import { createSelfDirectiveTools } from "../agent-lib/tools/self-directive-tool";
+import { createServerAppTools } from "../agent-lib/tools/server-app-tools";
+import { createServerConsoleTools } from "../agent-lib/tools/server-console-tools";
+import { createSkillTools } from "../agent-lib/tools/skill-tools";
+import { createSqlToolsV2 } from "../agent-lib/tools/sql-tools";
+import { createUniversalTools } from "../agent-lib/tools/universal-tools";
+import { createVersionHistoryTools } from "../agent-lib/tools/version-history-tools";
+import { createWebTools } from "../agent-lib/tools/web-tools";
+import { CORE_ALWAYS_TOOL_NAMES, modeRegistry } from "../agents/modes/registry";
+
+/** Stable dummy workspace id for definition-only factory calls. */
+const INVENTORY_WORKSPACE_ID = new Types.ObjectId().toString();
+
+function keysOf(tools: Record<string, unknown>): string[] {
+  return Object.keys(tools);
+}
+
+/**
+ * Every tool name the in-product agent can expose (union across modes),
+ * including client-only tools that never have `execute` on the server.
+ */
+export function collectLiveAgentToolNames(): string[] {
+  const names = new Set<string>();
+
+  const add = (list: Iterable<string>) => {
+    for (const name of list) names.add(name);
+  };
+
+  // Mode allowlists + core always-on tools (string sources of truth for UX).
+  add(CORE_ALWAYS_TOOL_NAMES);
+  add(PLAN_GATE_ALLOWED_TOOL_NAMES);
+  for (const mode of Object.values(modeRegistry)) {
+    add(mode.toolNames);
+  }
+
+  // Client packages (no execute).
+  add(keysOf(clientAgentTools));
+  add(keysOf(clientScreenshotTools));
+
+  // Server factories (with execute) — namespaced as the unified agent sees them.
+  const appTools = createServerAppTools({
+    workspaceId: INVENTORY_WORKSPACE_ID,
+  });
+  add(keysOf(appTools));
+
+  const consoleTools = createServerConsoleTools({
+    workspaceId: INVENTORY_WORKSPACE_ID,
+  });
+  add(keysOf(consoleTools));
+
+  const sqlTools = createSqlToolsV2(INVENTORY_WORKSPACE_ID, []);
+  add(keysOf(sqlTools));
+
+  const mongoTools = createMongoToolsV2(INVENTORY_WORKSPACE_ID, []);
+  // Unified agent namespaces these with mongo_*.
+  add([
+    "mongo_list_connections",
+    "mongo_list_databases",
+    "mongo_list_collections",
+    "mongo_inspect_collection",
+    "mongo_execute_query",
+  ]);
+  // Raw factory also exports unnamespaced aliases used by older paths.
+  add(keysOf(mongoTools));
+
+  const universal = createUniversalTools(INVENTORY_WORKSPACE_ID, []);
+  add(keysOf(universal));
+
+  add(keysOf(createConsoleSearchTools(INVENTORY_WORKSPACE_ID)));
+  add(keysOf(createDashboardSearchTools(INVENTORY_WORKSPACE_ID)));
+  add(keysOf(createVersionHistoryTools(INVENTORY_WORKSPACE_ID)));
+  add(keysOf(createSkillTools(INVENTORY_WORKSPACE_ID)));
+  add(keysOf(createSelfDirectiveTools(INVENTORY_WORKSPACE_ID)));
+  add(keysOf(createWebTools()));
+  add(keysOf(createDbtServerTools(INVENTORY_WORKSPACE_ID)));
+  add(
+    keysOf(
+      createScheduleQueryTool({
+        workspaceId: INVENTORY_WORKSPACE_ID,
+        canManageScheduledQueries: true,
+      }),
+    ),
+  );
+
+  // Flow unique tools (validate/execute/explain + client form tools + discovery).
+  add(keysOf(createFlowTools(INVENTORY_WORKSPACE_ID)));
+
+  // Conditional tools that factories omit without optional providers/config —
+  // still part of the agent surface when configured.
+  add(["web_search"]);
+
+  return [...names].sort();
+}

--- a/api/src/mcp/bridge-policy.ts
+++ b/api/src/mcp/bridge-policy.ts
@@ -309,6 +309,8 @@ export const MCP_BRIDGE_POLICY: Readonly<Record<string, McpBridgeEntry>> = {
     "in-product-only",
     "Expertise modes are the in-product agent runtime.",
   ),
+  get_relevant_skills: bridge(),
+  list_skills: bridge(),
   load_skill: bridge(),
   read_self_directive: exclude(
     "in-product-only",

--- a/api/src/mcp/bridge-policy.ts
+++ b/api/src/mcp/bridge-policy.ts
@@ -1,0 +1,451 @@
+/**
+ * MCP ↔ agent tool bridge policy.
+ *
+ * The in-product agent and Mako's MCP server share server-side tool
+ * factories, but MCP deliberately exposes a curated subset (headless,
+ * read-only data access, apps loop). This module is the single place that
+ * says, for every known agent tool name:
+ *
+ *   - bridge it over MCP, or
+ *   - exclude it, with an explicit why + note
+ *
+ * Adding a new agent tool without classifying it here fails the MCP
+ * inventory test — that's how we stay smart about what's missing.
+ */
+import { READ_ONLY_TOOL_NAMES } from "@mako/agent-tools";
+
+/** Why a tool is kept off the MCP surface. */
+export type McpBridgeExclusionWhy =
+  | "client-only"
+  | "security"
+  | "in-product-only"
+  | "deferred";
+
+export type McpBridgeEntry =
+  | {
+      status: "bridge";
+      /** Omit when the API key has no query access (`query:read`). */
+      requiresQueryAccess?: boolean;
+      /**
+       * Factory may omit this tool without credentials/config (e.g. web_search
+       * when no search provider is configured). Still classified so the catalog
+       * stays complete; inventory/staleness checks treat it as optional.
+       */
+      conditional?: boolean;
+      /** MCP annotation — defaults from READ_ONLY_TOOL_NAMES + special cases. */
+      openWorldHint?: boolean;
+      destructiveHint?: boolean;
+    }
+  | {
+      status: "exclude";
+      why: McpBridgeExclusionWhy;
+      note: string;
+    }
+  | {
+      /** Exists only on the MCP server (not the in-product agent). */
+      status: "mcp-only";
+      openWorldHint?: boolean;
+      destructiveHint?: boolean;
+    };
+
+const bridge = (
+  opts: Omit<Extract<McpBridgeEntry, { status: "bridge" }>, "status"> = {},
+): McpBridgeEntry => ({ status: "bridge", ...opts });
+
+const exclude = (
+  why: McpBridgeExclusionWhy,
+  note: string,
+): McpBridgeEntry => ({ status: "exclude", why, note });
+
+const mcpOnly = (
+  opts: Omit<Extract<McpBridgeEntry, { status: "mcp-only" }>, "status"> = {},
+): McpBridgeEntry => ({ status: "mcp-only", ...opts });
+
+/**
+ * Complete classification of every agent / MCP tool name.
+ * Keep alphabetical within each section so diffs stay reviewable.
+ */
+export const MCP_BRIDGE_POLICY: Readonly<Record<string, McpBridgeEntry>> = {
+  // ── Apps (server) — full headless authoring surface ───────────────────
+  app_add_dependency: bridge(),
+  app_create_data_binding: bridge(),
+  app_delete_data_binding: bridge({ destructiveHint: true }),
+  app_delete_file: bridge({ destructiveHint: true }),
+  app_edit_file: bridge(),
+  app_read_file: bridge(),
+  app_remove_dependency: bridge({ destructiveHint: true }),
+  app_rename_file: bridge(),
+  app_restore_version: bridge(),
+  app_save_version: bridge(),
+  app_set_binding_materialization: bridge(),
+  app_set_binding_schedule: bridge(),
+  app_set_preview_environment: exclude(
+    "client-only",
+    "Per-user browser preview state; headless agents use render_app / bindings directly.",
+  ),
+  app_update_data_binding: bridge(),
+  app_write_file: bridge(),
+  create_app: bridge(),
+  get_app_state: bridge(),
+  list_open_apps: bridge(),
+  materialize_binding: bridge(),
+  open_app: exclude(
+    "client-only",
+    "UI tab focus only; MCP operates on appId directly.",
+  ),
+  run_app: exclude(
+    "client-only",
+    "Browser iframe preview; MCP uses render_app instead.",
+  ),
+
+  // ── MCP-only preview / render ─────────────────────────────────────────
+  create_preview_token: mcpOnly(),
+  render_app: mcpOnly(),
+
+  // ── Console / query (server) ───────────────────────────────────────────
+  cancel_query: bridge({ requiresQueryAccess: true }),
+  check_query_status: bridge({ requiresQueryAccess: true }),
+  create_console: bridge(),
+  list_open_consoles: exclude(
+    "client-only",
+    "Lists open browser tabs; MCP uses search_consoles for workspace discovery.",
+  ),
+  modify_console: bridge(),
+  open_console: exclude(
+    "client-only",
+    "Opens a UI tab; headless agents use consoleId directly.",
+  ),
+  read_console: bridge(),
+  run_console: bridge({ requiresQueryAccess: true }),
+  schedule_query: exclude(
+    "in-product-only",
+    "Scheduled writes need session auth + console ownership UX; not in MCP read-only apps loop.",
+  ),
+  search_consoles: bridge(),
+  set_console_connection: bridge(),
+
+  // ── Charts / screenshots (client) ─────────────────────────────────────
+  capture_screenshot: exclude(
+    "client-only",
+    "Captures the open browser tab; MCP uses render_app screenshots.",
+  ),
+  get_chart_template: exclude(
+    "client-only",
+    "Chart templates are a console/dashboard UI concern.",
+  ),
+  get_chart_templates: exclude(
+    "client-only",
+    "Dashboard chart template catalog; not part of the apps MCP loop.",
+  ),
+  modify_chart_spec: exclude(
+    "client-only",
+    "Mutates the open console chart in the browser.",
+  ),
+
+  // ── SQL / Mongo discovery + execute ───────────────────────────────────
+  list_connections: bridge(),
+  mongo_execute_query: exclude(
+    "security",
+    "Arbitrary MongoDB JavaScript has no reliable per-query read-only mode.",
+  ),
+  mongo_inspect_collection: bridge(),
+  mongo_list_collections: bridge(),
+  mongo_list_connections: bridge(),
+  mongo_list_databases: bridge(),
+  sql_execute_query: bridge({ requiresQueryAccess: true }),
+  sql_inspect_table: bridge(),
+  sql_list_connections: bridge(),
+  sql_list_databases: bridge(),
+  sql_list_tables: bridge(),
+
+  // ── Flow / sync (mostly UI + deferred) ────────────────────────────────
+  create_flow_tab: exclude(
+    "client-only",
+    "Flow editor tab management requires the browser.",
+  ),
+  execute_query: exclude(
+    "deferred",
+    "Unnamespaced mongo/flow execute alias; MCP uses sql_execute_query and never bridges mongo_execute_query.",
+  ),
+  explain_template: exclude(
+    "deferred",
+    "Flow template placeholder docs; not needed for apps authoring.",
+  ),
+  get_form_state: exclude("client-only", "Reads the open flow form in the UI."),
+  inspect_collection: exclude(
+    "deferred",
+    "Unnamespaced mongo alias; MCP uses mongo_inspect_collection.",
+  ),
+  inspect_table: exclude(
+    "deferred",
+    "Unnamespaced flow discovery duplicate of sql_inspect_table.",
+  ),
+  list_collections: exclude(
+    "deferred",
+    "Unnamespaced mongo alias; MCP uses mongo_list_collections.",
+  ),
+  list_databases: exclude(
+    "deferred",
+    "Unnamespaced mongo/flow discovery alias; MCP uses sql_list_databases / mongo_list_databases.",
+  ),
+  list_flow_tabs: exclude("client-only", "Lists open flow editor tabs."),
+  list_tables: exclude(
+    "deferred",
+    "Unnamespaced flow discovery duplicate of sql_list_tables.",
+  ),
+  set_form_field: exclude("client-only", "Writes the open flow form in the UI."),
+  set_multiple_fields: exclude(
+    "client-only",
+    "Writes the open flow form in the UI.",
+  ),
+  validate_query: exclude(
+    "deferred",
+    "Flow sync validation; MCP uses sql_execute_query for query checks.",
+  ),
+
+  // ── Dashboards (client mutations + server search) ─────────────────────
+  add_data_source: exclude(
+    "client-only",
+    "Dashboard builder is browser-driven; MCP focuses on apps.",
+  ),
+  add_global_filter: exclude("client-only", "Dashboard builder UI."),
+  add_widget: exclude("client-only", "Dashboard builder UI."),
+  create_dashboard: exclude("client-only", "Dashboard builder UI."),
+  create_data_source: exclude("client-only", "Dashboard builder UI."),
+  dashboard_restore_version: exclude(
+    "deferred",
+    "Dashboard versioning stays in-product until dashboards are MCP-bridged.",
+  ),
+  dashboard_save_version: exclude(
+    "deferred",
+    "Dashboard versioning stays in-product until dashboards are MCP-bridged.",
+  ),
+  enter_edit_mode: exclude("client-only", "Dashboard builder UI."),
+  get_dashboard_state: exclude("client-only", "Reads open dashboard tab state."),
+  import_console_as_data_source: exclude("client-only", "Dashboard builder UI."),
+  link_tables: exclude("client-only", "Dashboard builder UI."),
+  list_open_dashboards: exclude(
+    "client-only",
+    "Lists open dashboard tabs; MCP uses search_dashboards.",
+  ),
+  modify_widget: exclude("client-only", "Dashboard builder UI."),
+  open_dashboard: exclude("client-only", "Opens a dashboard tab."),
+  remove_global_filter: exclude("client-only", "Dashboard builder UI."),
+  remove_widget: exclude("client-only", "Dashboard builder UI."),
+  run_data_source_query: exclude("client-only", "Dashboard builder UI."),
+  search_dashboards: bridge(),
+  set_time_dimension: exclude("client-only", "Dashboard builder UI."),
+  update_data_source_query: exclude("client-only", "Dashboard builder UI."),
+
+  // ── Shared DuckDB data-source primitives (client) ─────────────────────
+  inspect_data_source: exclude(
+    "client-only",
+    "Inspects in-browser DuckDB materializations.",
+  ),
+  list_data_sources: exclude(
+    "client-only",
+    "Lists in-browser DuckDB materializations.",
+  ),
+  query_duckdb: exclude(
+    "client-only",
+    "Queries in-browser DuckDB; MCP validates via sql_execute_query.",
+  ),
+
+  // ── dbt / transform (server-capable, not yet on MCP) ──────────────────
+  create_dbt_file: exclude(
+    "deferred",
+    "Transform mode is in-product; MCP v1 is the apps + data loop.",
+  ),
+  dbt_cancel_run: exclude("deferred", "Transform mode not yet on MCP."),
+  dbt_close_pull_request: exclude("deferred", "Transform mode not yet on MCP."),
+  dbt_commit_and_push: exclude("deferred", "Transform mode not yet on MCP."),
+  dbt_commit_to_branch: exclude("deferred", "Transform mode not yet on MCP."),
+  dbt_compare_branches: exclude("deferred", "Transform mode not yet on MCP."),
+  dbt_compile_model: exclude("deferred", "Transform mode not yet on MCP."),
+  dbt_create_branch: exclude("deferred", "Transform mode not yet on MCP."),
+  dbt_create_job: exclude("deferred", "Transform mode not yet on MCP."),
+  dbt_create_project: exclude("deferred", "Transform mode not yet on MCP."),
+  dbt_delete_branch: exclude("deferred", "Transform mode not yet on MCP."),
+  dbt_delete_job: exclude("deferred", "Transform mode not yet on MCP."),
+  dbt_ensure_dev_environment: exclude(
+    "deferred",
+    "Transform mode not yet on MCP.",
+  ),
+  dbt_get_run: exclude("deferred", "Transform mode not yet on MCP."),
+  dbt_git_status: exclude("deferred", "Transform mode not yet on MCP."),
+  dbt_list_branches: exclude("deferred", "Transform mode not yet on MCP."),
+  dbt_list_pull_requests: exclude("deferred", "Transform mode not yet on MCP."),
+  dbt_list_recoverable_files: exclude(
+    "deferred",
+    "Transform mode not yet on MCP.",
+  ),
+  dbt_merge_pull_request: exclude("deferred", "Transform mode not yet on MCP."),
+  dbt_open_pull_request: exclude("deferred", "Transform mode not yet on MCP."),
+  dbt_parse: exclude("deferred", "Transform mode not yet on MCP."),
+  dbt_restore_file: exclude("deferred", "Transform mode not yet on MCP."),
+  dbt_run_job: exclude("deferred", "Transform mode not yet on MCP."),
+  dbt_run_model: exclude("deferred", "Transform mode not yet on MCP."),
+  dbt_show: exclude("deferred", "Transform mode not yet on MCP."),
+  dbt_switch_branch: exclude("deferred", "Transform mode not yet on MCP."),
+  dbt_sync_from_repo: exclude("deferred", "Transform mode not yet on MCP."),
+  dbt_update_job: exclude("deferred", "Transform mode not yet on MCP."),
+  dbt_update_pull_request: exclude("deferred", "Transform mode not yet on MCP."),
+  delete_dbt_file: exclude("deferred", "Transform mode not yet on MCP."),
+  edit_dbt_file: exclude("deferred", "Transform mode not yet on MCP."),
+  modify_dbt_file: exclude("deferred", "Transform mode not yet on MCP."),
+  read_dbt_file: exclude("deferred", "Transform mode not yet on MCP."),
+  read_dbt_project_tree: exclude("deferred", "Transform mode not yet on MCP."),
+
+  // ── Skills / memory / modes / plan ────────────────────────────────────
+  ask_clarifying_questions: exclude(
+    "in-product-only",
+    "Plan UX is chat-UI specific.",
+  ),
+  delete_skill: exclude(
+    "in-product-only",
+    "Skill writes stay in-product; MCP is read-only for skills.",
+  ),
+  enable_mode: exclude(
+    "in-product-only",
+    "Expertise modes are the in-product agent runtime.",
+  ),
+  load_skill: bridge(),
+  read_self_directive: exclude(
+    "in-product-only",
+    "Workspace self-directive memory is chat-agent scoped.",
+  ),
+  read_skill_resource: bridge(),
+  save_skill: exclude(
+    "in-product-only",
+    "Skill writes stay in-product; MCP is read-only for skills.",
+  ),
+  search_skills: bridge(),
+  submit_plan: exclude("in-product-only", "Plan UX is chat-UI specific."),
+  todo_write: exclude(
+    "in-product-only",
+    "In-product agent todo list; external MCP clients have their own planning.",
+  ),
+  update_self_directive: exclude(
+    "in-product-only",
+    "Workspace self-directive memory is chat-agent scoped.",
+  ),
+
+  // ── Version history ───────────────────────────────────────────────────
+  browse_version_history: bridge(),
+  get_version_snapshot: bridge(),
+
+  // ── Web ───────────────────────────────────────────────────────────────
+  fetch_url: bridge({ openWorldHint: true }),
+  // Only registered when a web-search provider is configured
+  // (see createWebTools); still classified so the gap catalog stays complete.
+  web_search: bridge({ openWorldHint: true, conditional: true }),
+};
+
+/** Tools the MCP server should register (bridged + mcp-only). */
+export function mcpExposedToolNames(): string[] {
+  return Object.entries(MCP_BRIDGE_POLICY)
+    .filter(
+      ([, entry]) => entry.status === "bridge" || entry.status === "mcp-only",
+    )
+    .map(([name]) => name)
+    .sort();
+}
+
+/** Agent tools intentionally not on MCP, grouped by why. */
+export function summarizeBridgeGaps(): Array<{
+  why: McpBridgeExclusionWhy;
+  tools: Array<{ name: string; note: string }>;
+}> {
+  const byWhy = new Map<
+    McpBridgeExclusionWhy,
+    Array<{ name: string; note: string }>
+  >();
+  for (const [name, entry] of Object.entries(MCP_BRIDGE_POLICY)) {
+    if (entry.status !== "exclude") continue;
+    const list = byWhy.get(entry.why) ?? [];
+    list.push({ name, note: entry.note });
+    byWhy.set(entry.why, list);
+  }
+  return (["security", "client-only", "in-product-only", "deferred"] as const)
+    .filter(why => byWhy.has(why))
+    .map(why => ({
+      why,
+      tools: (byWhy.get(why) ?? []).sort((a, b) => a.name.localeCompare(b.name)),
+    }));
+}
+
+/**
+ * Fail if `toolNames` contains anything not classified in the policy.
+ * Call with the live inventory from factories + client packages.
+ */
+export function assertBridgePolicyCovers(toolNames: Iterable<string>): void {
+  const missing: string[] = [];
+  for (const name of toolNames) {
+    if (!(name in MCP_BRIDGE_POLICY)) missing.push(name);
+  }
+  if (missing.length > 0) {
+    missing.sort();
+    throw new Error(
+      `MCP bridge policy is missing classifications for: ${missing.join(", ")}. ` +
+        "Add each to MCP_BRIDGE_POLICY as bridge / exclude / mcp-only so we stay smart about gaps.",
+    );
+  }
+}
+
+/**
+ * Fail if the policy references tool names that no longer exist in the live
+ * inventory (except mcp-only entries, which are not agent tools, and
+ * conditional bridges that are only registered when optional deps exist).
+ */
+export function assertBridgePolicyNotStale(
+  liveToolNames: Iterable<string>,
+): void {
+  const live = new Set(liveToolNames);
+  const stale: string[] = [];
+  for (const [name, entry] of Object.entries(MCP_BRIDGE_POLICY)) {
+    if (entry.status === "mcp-only") continue;
+    if (entry.status === "bridge" && entry.conditional) continue;
+    if (!live.has(name)) stale.push(name);
+  }
+  if (stale.length > 0) {
+    stale.sort();
+    throw new Error(
+      `MCP bridge policy has stale entries (no longer in agent inventory): ${stale.join(", ")}.`,
+    );
+  }
+}
+
+/**
+ * MCP readOnlyHint: prefer the shared agent-tools set, plus MCP-only reads,
+ * plus the query:read envelope for sql_execute_query / run_console.
+ */
+export function mcpReadOnlyHint(
+  name: string,
+  queryAccess: "none" | "read" | "write",
+): boolean {
+  if (READ_ONLY_TOOL_NAMES.has(name)) return true;
+  const entry = MCP_BRIDGE_POLICY[name];
+  if (entry?.status === "mcp-only") {
+    // Preview/render tools never mutate workspace definitions beyond reads.
+    return true;
+  }
+  if (
+    queryAccess === "read" &&
+    (name === "sql_execute_query" || name === "run_console")
+  ) {
+    return true;
+  }
+  return false;
+}
+
+export function mcpDestructiveHint(name: string): boolean {
+  const entry = MCP_BRIDGE_POLICY[name];
+  if (!entry || entry.status === "exclude") return false;
+  return entry.destructiveHint === true;
+}
+
+export function mcpOpenWorldHint(name: string): boolean {
+  const entry = MCP_BRIDGE_POLICY[name];
+  if (!entry || entry.status === "exclude") return false;
+  return entry.openWorldHint === true;
+}

--- a/api/src/mcp/mako-mcp-server.test.ts
+++ b/api/src/mcp/mako-mcp-server.test.ts
@@ -25,6 +25,14 @@ import {
   type WorkspaceApiKeyScope,
 } from "../auth/api-key-scopes";
 import { sqlReadOnlyAccessError } from "../services/read-only-query.service";
+import {
+  assertBridgePolicyCovers,
+  assertBridgePolicyNotStale,
+  MCP_BRIDGE_POLICY,
+  mcpExposedToolNames,
+  summarizeBridgeGaps,
+} from "./bridge-policy";
+import { collectLiveAgentToolNames } from "./bridge-inventory";
 
 const WORKSPACE_ID = new Types.ObjectId().toString();
 
@@ -189,6 +197,8 @@ async function main() {
       "sql_execute_query",
       "mongo_list_connections",
       "search_consoles",
+      "search_dashboards",
+      "search_skills",
       "read_console",
       "create_console",
       "run_console",
@@ -198,6 +208,7 @@ async function main() {
       "get_version_snapshot",
       "load_skill",
       "read_skill_resource",
+      "fetch_url",
     ]) {
       assert.ok(names.has(expected), `missing tool: ${expected}`);
     }
@@ -213,6 +224,63 @@ async function main() {
       false,
       "read-only keys must not expose arbitrary MongoDB JavaScript execution",
     );
+    if (names.has("web_search")) {
+      assert.equal(
+        byName.get("web_search")?.annotations?.openWorldHint,
+        true,
+        "web_search should be annotated open-world",
+      );
+    }
+    assert.equal(
+      byName.get("fetch_url")?.annotations?.openWorldHint,
+      true,
+      "fetch_url should be annotated open-world",
+    );
+    assert.equal(
+      names.has("save_skill"),
+      false,
+      "skill writes stay in-product",
+    );
+    assert.equal(
+      names.has("open_app"),
+      false,
+      "client-only app tools must not be bridged",
+    );
+  }
+
+  // 3b. Bridge policy covers the live agent inventory — this is how we stay
+  //     smart about gaps when someone adds a new agent tool.
+  {
+    const live = collectLiveAgentToolNames();
+    assertBridgePolicyCovers(live);
+    assertBridgePolicyNotStale(live);
+
+    const [res] = await exchange([
+      { jsonrpc: "2.0", id: "policy", method: "tools/list" },
+    ]);
+    const { tools } = res.result as { tools: { name: string }[] };
+    const exposed = new Set(tools.map(t => t.name));
+    for (const [name, entry] of Object.entries(MCP_BRIDGE_POLICY)) {
+      if (entry.status !== "bridge") continue;
+      // Conditional tools (e.g. web_search) only appear when optional
+      // providers are configured.
+      if (entry.conditional) continue;
+      assert.ok(
+        exposed.has(name),
+        `policy says bridge ${name} but tools/list omitted it`,
+      );
+    }
+    for (const name of exposed) {
+      const entry = MCP_BRIDGE_POLICY[name];
+      assert.ok(
+        entry && (entry.status === "bridge" || entry.status === "mcp-only"),
+        `tools/list exposed ${name} without a bridge/mcp-only policy entry`,
+      );
+    }
+    // Sanity: gaps summary is non-empty and includes the security exclusion.
+    const gaps = summarizeBridgeGaps();
+    assert.ok(gaps.some(g => g.why === "security"));
+    assert.ok(mcpExposedToolNames().includes("create_app"));
   }
 
   // 4. Arbitrary MongoDB JavaScript execution is never bridged over MCP.

--- a/api/src/mcp/mako-mcp-server.test.ts
+++ b/api/src/mcp/mako-mcp-server.test.ts
@@ -199,6 +199,8 @@ async function main() {
       "search_consoles",
       "search_dashboards",
       "search_skills",
+      "list_skills",
+      "get_relevant_skills",
       "read_console",
       "create_console",
       "run_console",

--- a/api/src/mcp/mako-mcp-server.ts
+++ b/api/src/mcp/mako-mcp-server.ts
@@ -8,6 +8,9 @@
  * factories the in-product agent uses — this module only bridges AI SDK
  * tool definitions (zod input schema + execute) into MCP registrations.
  *
+ * Which agent tools are exposed is decided by bridge-policy.ts (not by
+ * hand-picking in this file). Unclassified tools fail the inventory test.
+ *
  * One Server instance is built per HTTP request (stateless Streamable HTTP,
  * JSON response mode) — see stateless-transport.ts and mcp-server.routes.ts.
  */
@@ -28,8 +31,10 @@ import { createMongoToolsV2 } from "../agent-lib/tools/mongodb-tools";
 import { createUniversalTools } from "../agent-lib/tools/universal-tools";
 import { createServerConsoleTools } from "../agent-lib/tools/server-console-tools";
 import { createConsoleSearchTools } from "../agent-lib/tools/console-search-tools";
+import { createDashboardSearchTools } from "../agent-lib/tools/dashboard-search-tools";
 import { createVersionHistoryTools } from "../agent-lib/tools/version-history-tools";
 import { createSkillTools } from "../agent-lib/tools/skill-tools";
+import { createWebTools } from "../agent-lib/tools/web-tools";
 import {
   getSystemSkillIndex,
   getSystemSkillFullText,
@@ -41,6 +46,12 @@ import {
   type WorkspaceApiKeyScope,
 } from "../auth/api-key-scopes";
 import { loggers } from "../logging";
+import {
+  MCP_BRIDGE_POLICY,
+  mcpDestructiveHint,
+  mcpOpenWorldHint,
+  mcpReadOnlyHint,
+} from "./bridge-policy";
 
 const logger = loggers.api("mcp-server");
 
@@ -61,7 +72,8 @@ Typical loop:
 4. Verify with render_app after edits. Pass includeScreenshot: false when you only need status/errors — it is much cheaper than the screenshot.
 5. app_save_version to snapshot/publish.
 
-Before writing app code, read the authoring playbook: resource mako://skills/apps (or the load_skill tool).`;
+Before writing app code, read the authoring playbook: resource mako://skills/apps (or load_skill / search_skills).
+Optional: search_dashboards for existing workspace dashboards, web_search / fetch_url for public docs.`;
 
 /** Defensive cap so a huge query result cannot blow up the JSON response. */
 const MAX_TOOL_RESULT_CHARS = 200_000;
@@ -76,14 +88,16 @@ export interface MakoMcpContext {
   scopes?: readonly WorkspaceApiKeyScope[];
 }
 
-type BridgeableTool = Pick<AiTool, "description" | "inputSchema" | "execute">;
+export type BridgeableTool = Pick<
+  AiTool,
+  "description" | "inputSchema" | "execute"
+>;
 
 /**
- * The toolset exposed over MCP. Same implementations the in-product agent
- * uses; assembled per request so every execution is bound to the caller's
- * workspace + acting user.
+ * Assemble every server-side candidate the MCP bridge *could* expose.
+ * `buildMakoMcpToolset` then filters by MCP_BRIDGE_POLICY.
  */
-export function buildMakoMcpToolset(
+export function buildMakoMcpCandidateTools(
   context: MakoMcpContext,
 ): Record<string, BridgeableTool> {
   const { workspaceId, userId } = context;
@@ -101,12 +115,6 @@ export function buildMakoMcpToolset(
     queryAccess,
   });
 
-  // Long-running query escape hatch: sql_execute_query enforces a short
-  // exploration timeout and points at the resumable console path
-  // (create_console → run_console → check_query_status) for slow
-  // warehouses — without these, binding validation on e.g. BigQuery
-  // dead-ends. read_console also lets the agent inspect a console found
-  // via search_consoles before seeding a binding from it.
   const consoleTools = createServerConsoleTools({
     workspaceId,
     userId,
@@ -123,8 +131,6 @@ export function buildMakoMcpToolset(
     queryAccess,
   );
   const mongoTools = createMongoToolsV2(workspaceId, [], undefined, userId);
-  // Cross-database discovery: one call that spans SQL + MongoDB connections
-  // (the same entry point the in-product app mode starts from).
   const { list_connections } = createUniversalTools(
     workspaceId,
     [],
@@ -132,104 +138,64 @@ export function buildMakoMcpToolset(
     userId,
   );
   const consoleSearchTools = createConsoleSearchTools(workspaceId);
+  const dashboardSearchTools = createDashboardSearchTools(workspaceId);
   const versionHistoryTools = createVersionHistoryTools(workspaceId);
-  // Read-only skill access; the write tools (save/delete) stay in-product.
-  const { load_skill, read_skill_resource } = createSkillTools(
-    workspaceId,
-    userId,
-  );
+  const skillTools = createSkillTools(workspaceId, userId);
+  const webTools = createWebTools();
 
   return {
     ...appTools,
+    ...consoleTools,
     list_connections,
-    sql_list_connections: sqlTools.sql_list_connections,
-    sql_list_databases: sqlTools.sql_list_databases,
-    sql_list_tables: sqlTools.sql_list_tables,
-    sql_inspect_table: sqlTools.sql_inspect_table,
-    ...(queryAccess !== "none"
-      ? { sql_execute_query: sqlTools.sql_execute_query }
-      : {}),
-    // Arbitrary MongoDB JavaScript (mongo_execute_query) is deliberately NOT
-    // bridged: MCP data access is read-only and Mongo has no reliable
-    // per-query read-only mode.
+    ...sqlTools,
+    // Namespace mongo the same way the unified agent does.
     mongo_list_connections: mongoTools.list_connections,
     mongo_list_databases: mongoTools.list_databases,
     mongo_list_collections: mongoTools.list_collections,
     mongo_inspect_collection: mongoTools.inspect_collection,
-    // Reuse existing validated queries as binding sources
-    // (app_create_data_binding accepts a consoleId to seed from).
-    search_consoles: consoleSearchTools.search_consoles,
-    read_console: consoleTools.read_console,
-    create_console: consoleTools.create_console,
-    modify_console: consoleTools.modify_console,
-    set_console_connection: consoleTools.set_console_connection,
-    ...(queryAccess !== "none"
-      ? {
-          run_console: consoleTools.run_console,
-          check_query_status: consoleTools.check_query_status,
-          cancel_query: consoleTools.cancel_query,
-        }
-      : {}),
-    // Version history: app_restore_version needs these to be discoverable.
-    browse_version_history: versionHistoryTools.browse_version_history,
-    get_version_snapshot: versionHistoryTools.get_version_snapshot,
-    // Authoring guidance (apps playbook, SQL dialects) — same knowledge the
-    // in-product agent retrieves; also exposed as mako://skills resources.
-    load_skill,
-    read_skill_resource,
+    // Included in candidates so the policy can deliberately exclude it;
+    // buildMakoMcpToolset will strip it.
+    mongo_execute_query: mongoTools.execute_query,
+    ...consoleSearchTools,
+    ...dashboardSearchTools,
+    ...versionHistoryTools,
+    ...skillTools,
+    ...webTools,
   };
 }
 
 /**
- * Tools that never mutate workspace state. Clients (Claude Code, Cursor)
- * use readOnlyHint to auto-approve these without prompting the user, so
- * discovery/verification loops run uninterrupted.
+ * The toolset exposed over MCP. Same implementations the in-product agent
+ * uses; assembled per request so every execution is bound to the caller's
+ * workspace + acting user. Filtering is driven by bridge-policy.ts.
  */
-const READ_ONLY_TOOLS = new Set([
-  "list_open_apps",
-  "get_app_state",
-  "app_read_file",
-  "list_connections",
-  "sql_list_connections",
-  "sql_list_databases",
-  "sql_list_tables",
-  "sql_inspect_table",
-  "mongo_list_connections",
-  "mongo_list_databases",
-  "mongo_list_collections",
-  "mongo_inspect_collection",
-  "search_consoles",
-  "read_console",
-  "check_query_status",
-  "browse_version_history",
-  "get_version_snapshot",
-  "load_skill",
-  "read_skill_resource",
-  "render_app",
-  "create_preview_token",
-]);
+export function buildMakoMcpToolset(
+  context: MakoMcpContext,
+): Record<string, BridgeableTool> {
+  const scopes = resolveWorkspaceApiKeyScopes(context.scopes);
+  const queryAccess = queryAccessFromScopes(scopes);
+  const candidates = buildMakoMcpCandidateTools(context);
+  const exposed: Record<string, BridgeableTool> = {};
 
-/** Irreversible deletions (destructiveHint defaults to true in the spec). */
-const DESTRUCTIVE_TOOLS = new Set([
-  "app_delete_file",
-  "app_delete_data_binding",
-  "app_remove_dependency",
-]);
+  for (const [name, tool] of Object.entries(candidates)) {
+    const entry = MCP_BRIDGE_POLICY[name];
+    if (!entry || entry.status !== "bridge") continue;
+    if (entry.requiresQueryAccess && queryAccess === "none") continue;
+    exposed[name] = tool;
+  }
+
+  return exposed;
+}
 
 function toolAnnotations(
   name: string,
   queryAccess: QueryAccess,
 ): Record<string, unknown> {
-  // Under a query:read key these run inside an enforced read-only envelope,
-  // so clients can safely auto-approve the whole query loop.
-  const readOnly =
-    READ_ONLY_TOOLS.has(name) ||
-    (queryAccess === "read" &&
-      (name === "sql_execute_query" || name === "run_console"));
+  const readOnly = mcpReadOnlyHint(name, queryAccess);
   return {
     readOnlyHint: readOnly,
-    destructiveHint: !readOnly && DESTRUCTIVE_TOOLS.has(name),
-    openWorldHint: false,
+    destructiveHint: !readOnly && mcpDestructiveHint(name),
+    openWorldHint: mcpOpenWorldHint(name),
   };
 }
 

--- a/api/src/mcp/mako-mcp-server.ts
+++ b/api/src/mcp/mako-mcp-server.ts
@@ -72,8 +72,12 @@ Typical loop:
 4. Verify with render_app after edits. Pass includeScreenshot: false when you only need status/errors — it is much cheaper than the screenshot.
 5. app_save_version to snapshot/publish.
 
-Before writing app code, read the authoring playbook: resource mako://skills/apps (or load_skill / search_skills).
-Optional: search_dashboards for existing workspace dashboards, web_search / fetch_url for public docs.`;
+Skills (same knowledge as the in-product agent):
+- list_skills → compact index (workspace + system).
+- get_relevant_skills({ query }) → ranked bodies for your task (call this early).
+- load_skill / read_skill_resource / mako://skills/{name} for specifics.
+Before writing app code: get_relevant_skills("build a Mako app") or resource mako://skills/apps.
+Optional: search_dashboards, web_search / fetch_url for public docs.`;
 
 /** Defensive cap so a huge query result cannot blow up the JSON response. */
 const MAX_TOOL_RESULT_CHARS = 200_000;

--- a/api/src/services/skills.service.ts
+++ b/api/src/services/skills.service.ts
@@ -652,10 +652,12 @@ export function renderSkillsPromptBlock(result: SkillRetrievalResult): string {
   lines.push(
     "Skills extend or refine the self-directive for specific contexts. " +
       "If a skill conflicts with the directive, follow the directive. " +
-      "Use `load_skill` to pull in any indexed skill on demand, `save_skill` " +
-      "to record new workspace knowledge, `delete_skill` to retract, and " +
-      "`search_skills` as a fallback. Use `read_skill_resource` only when a " +
-      "system skill points you to a `references/*.md` resource.",
+      "Use `list_skills` for the compact index, `get_relevant_skills` to " +
+      "re-rank bodies mid-task, `load_skill` to pull any indexed skill on " +
+      "demand, `save_skill` to record new workspace knowledge, `delete_skill` " +
+      "to retract, and `search_skills` as a fallback. Use " +
+      "`read_skill_resource` only when a system skill points you to a " +
+      "`references/*.md` resource.",
   );
   lines.push("");
   lines.push("#### Available skills (index)");

--- a/docs/src/content/docs/mcp-server.md
+++ b/docs/src/content/docs/mcp-server.md
@@ -83,11 +83,15 @@ Try: *"Using the mako tools, explore my data and build a dashboard app showing r
 
 The server ships usage instructions with the handshake, so agents discover this workflow on their own:
 
-1. **Discover** — `list_connections`, `sql_list_tables`, `sql_inspect_table` (schemas + sample rows), plus MongoDB discovery/inspection.
+1. **Discover** — `list_connections`, `sql_list_tables`, `sql_inspect_table` (schemas + sample rows), plus MongoDB discovery/inspection. `search_consoles` / `search_dashboards` / `search_skills` find existing workspace work and playbooks.
 2. **Validate queries** — `sql_execute_query` (read-only, short exploration timeout). Slow warehouse? `create_console` → `run_console` → `check_query_status` for long-running queries.
 3. **Build apps** — `create_app`, `app_write_file` / `app_edit_file`, `app_create_data_binding` (bind the validated query), version history and restore.
 4. **Verify visually** — `render_app` renders the draft server-side and returns status, errors, filtered console output, and a screenshot. `create_preview_token` mints a short-lived, login-free preview URL to share or open yourself.
 5. **Publish** — `app_save_version`.
+
+Optional helpers: `web_search` / `fetch_url` for public docs (annotated `openWorldHint`).
+
+The MCP tool surface is a curated subset of the in-product agent tools. Classification lives in `api/src/mcp/bridge-policy.ts` — every agent tool is either bridged, MCP-only, or explicitly excluded (client-only UI, security, in-product UX, or deferred). Adding an agent tool without classifying it fails the MCP inventory test.
 
 Read-only tools are annotated per the MCP spec (`readOnlyHint`), so well-behaved clients run the whole discovery/query loop without approval prompts. If you keep a Mako tab open on the app being edited, it live-reloads on every agent change.
 

--- a/docs/src/content/docs/mcp-server.md
+++ b/docs/src/content/docs/mcp-server.md
@@ -83,7 +83,7 @@ Try: *"Using the mako tools, explore my data and build a dashboard app showing r
 
 The server ships usage instructions with the handshake, so agents discover this workflow on their own:
 
-1. **Discover** — `list_connections`, `sql_list_tables`, `sql_inspect_table` (schemas + sample rows), plus MongoDB discovery/inspection. `search_consoles` / `search_dashboards` / `search_skills` find existing workspace work and playbooks.
+1. **Discover** — `list_connections`, `sql_list_tables`, `sql_inspect_table` (schemas + sample rows), plus MongoDB discovery/inspection. `search_consoles` / `search_dashboards` find existing workspace work. Skills: `list_skills` (index), `get_relevant_skills` (ranked bodies for your task — same retrieval as the in-product agent), then `load_skill` / `read_skill_resource` as needed.
 2. **Validate queries** — `sql_execute_query` (read-only, short exploration timeout). Slow warehouse? `create_console` → `run_console` → `check_query_status` for long-running queries.
 3. **Build apps** — `create_app`, `app_write_file` / `app_edit_file`, `app_create_data_binding` (bind the validated query), version history and restore.
 4. **Verify visually** — `render_app` renders the draft server-side and returns status, errors, filtered console output, and a screenshot. `create_preview_token` mints a short-lived, login-free preview URL to share or open yourself.

--- a/packages/agent-tools/src/read-only-tools.ts
+++ b/packages/agent-tools/src/read-only-tools.ts
@@ -67,6 +67,8 @@ export const READ_ONLY_TOOL_NAMES: ReadonlySet<string> = new Set<string>([
   "search_consoles",
   "search_dashboards",
   "search_skills",
+  "list_skills",
+  "get_relevant_skills",
   "fetch_url",
   "web_search",
   // Memory reads


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the drift risk between in-product agent tools and Mako’s MCP server by making every tool’s MCP fate **explicit and tested**, and closes the skills discovery gap for headless MCP clients.

### Bridge policy (smart gaps)

`api/src/mcp/bridge-policy.ts` classifies every agent tool as `bridge` / `exclude` / `mcp-only`. Inventory test fails on unclassified or stale tools.

### Newly bridged

- `search_skills`, `search_dashboards`, `fetch_url`, `web_search` (conditional)
- **`list_skills`** — compact workspace + system index (no bodies)
- **`get_relevant_skills(query)`** — same retrieval as in-product pre-turn auto-inject (ranked bodies + near-misses)

MCP clients never get prompt injection, so these two tools are the parity path. Also wired into the in-product agent (`CORE_ALWAYS` + `READ_ONLY_TOOL_NAMES`) for mid-turn re-ranking.

### Still excluded (documented)

| Why | Examples |
| --- | --- |
| **security** | `mongo_execute_query` |
| **client-only** | dashboards, `run_app`/`open_app`, DuckDB, flow forms |
| **in-product-only** | plan/modes/memory, skill writes |
| **deferred** | full dbt surface, flow sync execute |

### Test plan

- [x] `pnpm --filter api exec tsx src/mcp/mako-mcp-server.test.ts`
- [x] `pnpm --filter api run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5cb1-b53e-7834-9d0f-5a7d420acd83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5cb1-b53e-7834-9d0f-5a7d420acd83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

