### PR TITLE
feat(stripe): add disputes entity for CDC revenue netting

### DIFF
--- a/api/src/connectors/stripe/connector.test.ts
+++ b/api/src/connectors/stripe/connector.test.ts
@@ -27,10 +27,12 @@ function testAvailableEntitiesIncludeModernEntities() {
   assert.ok(entities.includes("payment_intents"));
   assert.ok(entities.includes("prices"));
   assert.ok(entities.includes("plans"));
+  assert.ok(entities.includes("disputes"));
 
   const metadata = connector.getEntityMetadata().map(entry => entry.name);
   assert.ok(metadata.includes("payment_intents"));
   assert.ok(metadata.includes("prices"));
+  assert.ok(metadata.includes("disputes"));
 }
 
 function testResolveRecordTimestampUsesEpochCreated() {
@@ -69,6 +71,7 @@ async function testResolveSchema() {
   for (const entity of [
     "customers",
     "subscriptions",
+    "disputes",
     "charges",
     "invoices",
     "products",
@@ -89,6 +92,11 @@ async function testResolveSchema() {
   assert.equal(charge?.fields.amount?.type, "integer");
   assert.equal(charge?.fields.currency?.type, "string");
   assert.equal(charge?.fields.billing_details?.type, "json");
+
+  const dispute = await connector.resolveSchema("disputes");
+  assert.equal(dispute?.fields.status?.type, "string");
+  assert.equal(dispute?.fields.amount?.type, "integer");
+  assert.equal(dispute?.fields.charge?.type, "string");
 
   // Invoice fields that were previously absent (and therefore string-coerced
   // by the unknown-field policy) must now carry their real types.
@@ -176,6 +184,27 @@ function testNormalizeBackfillRecordTsParityWithWebhook() {
   assert.equal(webhook.recordId, "pi_123");
   // Backfill and webhook records must agree on the source timestamp.
   assert.equal(backfill?.sourceTs.getTime(), webhook.sourceTs.getTime());
+}
+
+function testDisputeEventsMapToDisputesEntity() {
+  const connector = createConnector();
+  assert.deepEqual(connector.getWebhookEventMapping("charge.dispute.created"), {
+    entity: "disputes",
+    operation: "upsert",
+  });
+  assert.deepEqual(connector.getWebhookEventMapping("charge.dispute.closed"), {
+    entity: "disputes",
+    operation: "upsert",
+  });
+
+  const events = connector.getWebhookEventsForEntities(["disputes"]).sort();
+  assert.deepEqual(events, [
+    "charge.dispute.closed",
+    "charge.dispute.created",
+    "charge.dispute.funds_reinstated",
+    "charge.dispute.funds_withdrawn",
+    "charge.dispute.updated",
+  ]);
 }
 
 function testPriceEventsMapToPricesEntity() {
@@ -321,6 +350,7 @@ async function main() {
   await testResolveSchema();
   await testSubscriptionsBackfillRequestsAllStatuses();
   testNormalizeBackfillRecordTsParityWithWebhook();
+  testDisputeEventsMapToDisputesEntity();
   testPriceEventsMapToPricesEntity();
   testNoLegacySubscriptionWebhookEvents();
   testWebhookEventsForEntities();

--- a/api/src/connectors/stripe/connector.ts
+++ b/api/src/connectors/stripe/connector.ts
@@ -30,6 +30,7 @@ const STRIPE_DEFAULT_HOST = "api.stripe.com";
 const STRIPE_ENTITIES = [
   "customers",
   "subscriptions",
+  "disputes",
   "charges",
   "invoices",
   "products",
@@ -223,6 +224,7 @@ export class StripeConnector extends BaseConnector {
     return [
       { name: "customers", label: "Customers", layoutSuggestion },
       { name: "subscriptions", label: "Subscriptions", layoutSuggestion },
+      { name: "disputes", label: "Disputes", layoutSuggestion },
       { name: "charges", label: "Charges", layoutSuggestion },
       { name: "invoices", label: "Invoices", layoutSuggestion },
       { name: "products", label: "Products", layoutSuggestion },
@@ -292,6 +294,16 @@ export class StripeConnector extends BaseConnector {
 
         case "charges":
           response = await stripe.charges.list({
+            limit: batchSize,
+            ...(startingAfter && { starting_after: startingAfter }),
+            ...(since && {
+              created: { gte: Math.floor(since.getTime() / 1000) },
+            }),
+          });
+          break;
+
+        case "disputes":
+          response = await stripe.disputes.list({
             limit: batchSize,
             ...(startingAfter && { starting_after: startingAfter }),
             ...(since && {
@@ -434,6 +446,16 @@ export class StripeConnector extends BaseConnector {
 
         case "charges":
           response = await stripe.charges.list({
+            limit: batchSize,
+            ...(startingAfter && { starting_after: startingAfter }),
+            ...(since && {
+              created: { gte: Math.floor(since.getTime() / 1000) },
+            }),
+          });
+          break;
+
+        case "disputes":
+          response = await stripe.disputes.list({
             limit: batchSize,
             ...(startingAfter && { starting_after: startingAfter }),
             ...(since && {
@@ -634,6 +656,19 @@ export class StripeConnector extends BaseConnector {
       "charge.refunded": { entity: "charges", operation: "upsert" },
       "charge.updated": { entity: "charges", operation: "upsert" },
 
+      // Disputes (status lost/won/open + amount for revenue netting)
+      "charge.dispute.created": { entity: "disputes", operation: "upsert" },
+      "charge.dispute.updated": { entity: "disputes", operation: "upsert" },
+      "charge.dispute.closed": { entity: "disputes", operation: "upsert" },
+      "charge.dispute.funds_withdrawn": {
+        entity: "disputes",
+        operation: "upsert",
+      },
+      "charge.dispute.funds_reinstated": {
+        entity: "disputes",
+        operation: "upsert",
+      },
+
       // Payment Intents
       "payment_intent.succeeded": {
         entity: "payment_intents",
@@ -697,6 +732,12 @@ export class StripeConnector extends BaseConnector {
       "charge.captured",
       "charge.refunded",
       "charge.updated",
+      // Disputes
+      "charge.dispute.created",
+      "charge.dispute.updated",
+      "charge.dispute.closed",
+      "charge.dispute.funds_withdrawn",
+      "charge.dispute.funds_reinstated",
       // Payment Intents
       "payment_intent.succeeded",
       "payment_intent.payment_failed",

--- a/api/src/connectors/stripe/schema.ts
+++ b/api/src/connectors/stripe/schema.ts
@@ -97,6 +97,22 @@ export const SUBSCRIPTION_SCHEMA: Record<string, ConnectorFieldSchema> = {
   cancellation_details: j(),
 };
 
+export const DISPUTE_SCHEMA: Record<string, ConnectorFieldSchema> = {
+  ...COMMON_STRIPE_SCHEMA,
+  amount: i(),
+  currency: s(),
+  charge: s(),
+  payment_intent: s(),
+  status: s(),
+  reason: s(),
+  balance_transaction: s(),
+  balance_transactions: j(),
+  evidence: j(),
+  evidence_details: j(),
+  is_charge_refundable: b(),
+  network_reason_code: s(),
+};
+
 export const CHARGE_SCHEMA: Record<string, ConnectorFieldSchema> = {
   ...COMMON_STRIPE_SCHEMA,
   amount: i(),
@@ -276,6 +292,7 @@ export const STRIPE_ENTITY_SCHEMA_MAP: Record<
 > = {
   customers: CUSTOMER_SCHEMA,
   subscriptions: SUBSCRIPTION_SCHEMA,
+  disputes: DISPUTE_SCHEMA,
   charges: CHARGE_SCHEMA,
   invoices: INVOICE_SCHEMA,
   products: PRODUCT_SCHEMA,

--- a/docs/src/content/docs/connectors.md
+++ b/docs/src/content/docs/connectors.md
@@ -13,7 +13,7 @@ Connectors pull data from external services and sync it into your connected data
 
 | Connector     | Source          | Entities                                                                         |
 | ------------- | --------------- | -------------------------------------------------------------------------------- |
-| **Stripe**    | Stripe API      | Customers, Subscriptions, Charges, Invoices, Products, Prices, Plans, Payment Intents. *Supports backfill and CDC webhooks (auto-provisioning via Stripe webhook endpoints).* |
+| **Stripe**    | Stripe API      | Customers, Subscriptions, Disputes, Charges, Invoices, Products, Prices, Plans, Payment Intents. *Supports backfill and CDC webhooks (auto-provisioning via Stripe webhook endpoints).* |
 | **Close CRM** | Close API       | Leads, Opportunities, Activities (10+ sub-types), Contacts, Users, Custom Fields. *Webhooks are automatically scoped to synced entities only.* |
 | **Claap**     | Claap API       | Recordings, Workspace. *Supports backfill and CDC webhooks (auto-provisioning via "Create in Claap").* |
 | **Calendly**  | Calendly API    | Organizations, Users, Groups, Event Types, Scheduled Events, Invitees, Contacts. *Real-time invitee + event-type webhooks (auto-provisioned); scheduled backfill covers the rest.* |


### PR DESCRIPTION
## Summary
- Add a Stripe `disputes` entity (schema, backfill via `disputes.list`, entity metadata) so warehouse tables include `status` (`lost`/`won`/`open`) and `amount`, not just `charges.disputed`.
- Wire CDC webhook mappings for `charge.dispute.*` events (`created`, `updated`, `closed`, `funds_withdrawn`, `funds_reinstated`) and cover them in connector tests.
- Document Disputes in the connectors docs list.

## Test plan
- [x] `pnpm --filter api exec tsx src/connectors/stripe/connector.test.ts`
- [x] `pnpm --filter api run lint`
- [ ] Enable **Disputes** on an existing Stripe CDC flow and re-provision webhooks (or add dispute events in Stripe Dashboard)
- [ ] Run disputes backfill and confirm rows land with `status` + `charge` join key
- [ ] Spot-check a lost dispute joins to its charge and can be netted in a mart query


Made with [Cursor](https://cursor.com)