### PR TITLE
fix(close): fill webhook secret when re-provisioning existing URL

### DIFF
--- a/api/src/connectors/close/connector.test.ts
+++ b/api/src/connectors/close/connector.test.ts
@@ -14,27 +14,28 @@ function createConnector() {
 function testUserWebhookEventsAreSupported() {
   const connector = createConnector();
 
+  // Close has no user.* webhook selectors — membership carries user CDC.
   assert.deepEqual(connector.getWebhookEventsForEntities(["users"]), [
-    "user.created",
-    "user.updated",
-    "user.deleted",
+    "membership.activated",
+    "membership.deactivated",
   ]);
 }
 
 function testUserWebhookEventsAreMapped() {
   const connector = createConnector();
 
+  assert.deepEqual(connector.getWebhookEventMapping("membership.activated"), {
+    entity: "users",
+    operation: "upsert",
+  });
+  assert.deepEqual(connector.getWebhookEventMapping("membership.deactivated"), {
+    entity: "users",
+    operation: "delete",
+  });
+  // Legacy user.* mappings retained for defensive processing.
   assert.deepEqual(connector.getWebhookEventMapping("user.created"), {
     entity: "users",
     operation: "upsert",
-  });
-  assert.deepEqual(connector.getWebhookEventMapping("user.updated"), {
-    entity: "users",
-    operation: "upsert",
-  });
-  assert.deepEqual(connector.getWebhookEventMapping("user.deleted"), {
-    entity: "users",
-    operation: "delete",
   });
 }
 
@@ -44,14 +45,18 @@ function testUserWebhookPayloadIsExtractedForProcessing() {
   assert.deepEqual(
     connector.extractWebhookData({
       event: {
-        object_type: "user",
-        action: "updated",
-        object_id: "user_123",
+        object_type: "membership",
+        action: "activated",
+        object_id: "memb_123",
         data: {
-          id: "user_123",
-          email: "user@example.com",
-          first_name: "Test",
-          date_updated: "2026-05-20T07:00:00.000Z",
+          id: "memb_123",
+          user_id: "user_123",
+          user: {
+            id: "user_123",
+            email: "user@example.com",
+            first_name: "Test",
+            date_updated: "2026-05-20T07:00:00.000Z",
+          },
         },
       },
     }),
@@ -74,12 +79,17 @@ function testUserWebhookCdcRecordUsesUsersEntity() {
     {
       id: "evt_123",
       event: {
-        object_type: "user",
-        action: "deleted",
-        object_id: "user_123",
+        object_type: "membership",
+        action: "deactivated",
+        object_id: "memb_123",
+        data: {
+          id: "memb_123",
+          user_id: "user_123",
+          user: { id: "user_123" },
+        },
       },
     },
-    "user.deleted",
+    "membership.deactivated",
   );
 
   assert.equal(records.length, 1);

--- a/api/src/connectors/close/connector.test.ts
+++ b/api/src/connectors/close/connector.test.ts
@@ -406,6 +406,108 @@ async function testOpportunitySearchBackfillRequestsAndFlattensCustomFields() {
   );
 }
 
+async function testCreateWebhookSubscriptionReturnsSignatureKey() {
+  const connector = createConnector();
+  const endpointUrl = "https://app.mako.ai/api/webhooks/ws/flow";
+
+  (connector as any).closeApi = {
+    get: async () => ({ data: { data: [] } }),
+    post: async (_url: string, body: Record<string, unknown>) => {
+      assert.equal(body.url, endpointUrl);
+      return {
+        data: {
+          id: "whsub_new",
+          url: endpointUrl,
+          signature_key: "aabbccddeeff00112233445566778899",
+        },
+      };
+    },
+  };
+
+  const result = await connector.createWebhookSubscription({
+    endpointUrl,
+    enabledEntities: ["leads"],
+  });
+
+  assert.equal(result.providerWebhookId, "whsub_new");
+  assert.equal(result.signingSecret, "aabbccddeeff00112233445566778899");
+}
+
+async function testExistingWebhookSubscriptionReturnsSignatureKey() {
+  const connector = createConnector();
+  const endpointUrl = "https://app.mako.ai/api/webhooks/ws/flow";
+  let putCalled = false;
+
+  (connector as any).closeApi = {
+    get: async (url: string) => {
+      if (url === "/webhook/") {
+        return {
+          data: {
+            data: [
+              {
+                id: "whsub_existing",
+                url: endpointUrl,
+                signature_key: "00112233445566778899aabbccddeeff",
+              },
+            ],
+          },
+        };
+      }
+      throw new Error(`Unexpected GET ${url}`);
+    },
+    put: async (url: string) => {
+      putCalled = true;
+      assert.equal(url, "/webhook/whsub_existing/");
+      return { data: {} };
+    },
+  };
+
+  const result = await connector.createWebhookSubscription({
+    endpointUrl,
+    enabledEntities: ["leads"],
+  });
+
+  assert.equal(putCalled, true);
+  assert.equal(result.providerWebhookId, "whsub_existing");
+  assert.equal(result.signingSecret, "00112233445566778899aabbccddeeff");
+}
+
+async function testExistingWebhookFetchesDetailWhenListOmitsSignatureKey() {
+  const connector = createConnector();
+  const endpointUrl = "https://app.mako.ai/api/webhooks/ws/flow";
+
+  (connector as any).closeApi = {
+    get: async (url: string) => {
+      if (url === "/webhook/") {
+        return {
+          data: {
+            data: [{ id: "whsub_existing", url: endpointUrl }],
+          },
+        };
+      }
+      if (url === "/webhook/whsub_existing/") {
+        return {
+          data: {
+            id: "whsub_existing",
+            url: endpointUrl,
+            signature_key: "fedcba9876543210fedcba9876543210",
+          },
+        };
+      }
+      throw new Error(`Unexpected GET ${url}`);
+    },
+    put: async () => ({ data: {} }),
+  };
+
+  const result = await connector.createWebhookSubscription({
+    endpointUrl,
+    enabledEntities: ["contacts"],
+  });
+
+  assert.equal(result.providerWebhookId, "whsub_existing");
+  assert.equal(result.signingSecret, "fedcba9876543210fedcba9876543210");
+}
+
 async function main() {
   testUserWebhookEventsAreSupported();
   testUserWebhookEventsAreMapped();
@@ -422,6 +524,9 @@ async function main() {
   testContactBackfillFlattensCustomFields();
   testSearchFieldSelectionIncludesCustomFieldSelectors();
   await testOpportunitySearchBackfillRequestsAndFlattensCustomFields();
+  await testCreateWebhookSubscriptionReturnsSignatureKey();
+  await testExistingWebhookSubscriptionReturnsSignatureKey();
+  await testExistingWebhookFetchesDetailWhenListOmitsSignatureKey();
 }
 
 main().catch(error => {

--- a/api/src/connectors/close/connector.ts
+++ b/api/src/connectors/close/connector.ts
@@ -64,6 +64,18 @@ type CloseWebhookSelector = {
   action: string;
 };
 
+/** Close returns the HMAC key as `signature_key` on create/list/get. */
+function extractCloseSigningSecret(
+  webhook: Record<string, unknown> | null | undefined,
+): string | undefined {
+  if (!webhook || typeof webhook !== "object") return undefined;
+  const candidate =
+    webhook.signature_key ?? webhook.signing_secret ?? webhook.secret;
+  return typeof candidate === "string" && candidate.length > 0
+    ? candidate
+    : undefined;
+}
+
 // Close webhook selectors from official event list.
 const CLOSE_SUPPORTED_WEBHOOK_SELECTORS: CloseWebhookSelector[] = [
   { object_type: "lead", action: "created" },
@@ -2291,9 +2303,30 @@ export class CloseConnector extends BaseConnector {
               error: updateError,
             });
           }
+
+          // Close includes `signature_key` on list/get responses. Re-use it so
+          // re-provisioning (same URL) still fills Mako's Webhook Secret field —
+          // the create-only path is the only place that previously returned it.
+          let signingSecret = extractCloseSigningSecret(existing);
+          if (!signingSecret) {
+            try {
+              const detailResponse = await api.get(`/webhook/${existingId}/`);
+              signingSecret = extractCloseSigningSecret(detailResponse?.data);
+            } catch (detailError) {
+              logger.warn(
+                "Could not fetch signature_key for existing Close webhook",
+                {
+                  webhookId: existingId,
+                  error: detailError,
+                },
+              );
+            }
+          }
+
           return {
             providerWebhookId: String(existingId),
             endpointUrl: options.endpointUrl,
+            signingSecret,
           };
         }
       }
@@ -2308,16 +2341,10 @@ export class CloseConnector extends BaseConnector {
         );
       }
 
-      const signingSecret =
-        data.signature_key || data.signing_secret || data.secret;
-
       return {
         providerWebhookId: String(providerWebhookId),
         endpointUrl: options.endpointUrl,
-        signingSecret:
-          typeof signingSecret === "string" && signingSecret.length > 0
-            ? signingSecret
-            : undefined,
+        signingSecret: extractCloseSigningSecret(data),
       };
     } catch (error) {
       const message = (() => {

--- a/api/src/connectors/close/connector.ts
+++ b/api/src/connectors/close/connector.ts
@@ -85,9 +85,10 @@ const CLOSE_SUPPORTED_WEBHOOK_SELECTORS: CloseWebhookSelector[] = [
   { object_type: "contact", action: "created" },
   { object_type: "contact", action: "updated" },
   { object_type: "contact", action: "deleted" },
-  { object_type: "user", action: "created" },
-  { object_type: "user", action: "updated" },
-  { object_type: "user", action: "deleted" },
+  // Close has no `user` webhook object_type — membership activated/deactivated
+  // carries embedded user data (see Close "List of Event Types").
+  { object_type: "membership", action: "activated" },
+  { object_type: "membership", action: "deactivated" },
   { object_type: "opportunity", action: "created" },
   { object_type: "opportunity", action: "updated" },
   { object_type: "opportunity", action: "deleted" },
@@ -2447,7 +2448,10 @@ export class CloseConnector extends BaseConnector {
       "contact.updated": { entity: "contacts", operation: "upsert" },
       "contact.deleted": { entity: "contacts", operation: "delete" },
 
-      // Users
+      // Users — Close emits membership events (not user.*). Keep legacy
+      // user.* mappings so any older payloads still route to the users entity.
+      "membership.activated": { entity: "users", operation: "upsert" },
+      "membership.deactivated": { entity: "users", operation: "delete" },
       "user.created": { entity: "users", operation: "upsert" },
       "user.updated": { entity: "users", operation: "upsert" },
       "user.deleted": { entity: "users", operation: "delete" },
@@ -2578,7 +2582,7 @@ export class CloseConnector extends BaseConnector {
     const entityToObjectTypes: Record<string, string[]> = {
       leads: ["lead"],
       contacts: ["contact"],
-      users: ["user"],
+      users: ["membership"],
       opportunities: ["opportunity"],
       custom_fields: [
         "custom_fields.lead",
@@ -2624,7 +2628,29 @@ export class CloseConnector extends BaseConnector {
     // Close webhook payload: {subscription_id, event: {object_type, action, data: {...}}}
     // Prefer object_id from wrapper, then fall back to nested payload ids.
     const innerEvent = event?.event;
+    const objectType = innerEvent?.object_type || event?.object_type;
     const data = innerEvent?.data || event?.data;
+
+    // Membership events embed the user record; CDC writes the users entity.
+    if (objectType === "membership" && data && typeof data === "object") {
+      const embeddedUser =
+        data.user && typeof data.user === "object"
+          ? data.user
+          : data.user_id
+            ? { id: data.user_id }
+            : null;
+      if (embeddedUser) {
+        const userId =
+          embeddedUser.id || data.user_id || innerEvent?.object_id || event?.id;
+        if (userId) {
+          return {
+            id: String(userId),
+            data: { ...embeddedUser, id: String(userId) },
+          };
+        }
+      }
+    }
+
     const objectId =
       innerEvent?.object_id || event?.object_id || data?.id || event?.id;
 

--- a/app/src/components/SyncFlowForm.tsx
+++ b/app/src/components/SyncFlowForm.tsx
@@ -3,9 +3,9 @@
  *
  * Replaces the ScheduledFlowForm / WebhookFlowForm split: the trigger set
  * (scheduled poll and/or webhook push) is a property of one Sync, chosen in
- * step 3, instead of a flow "type" picked up-front. Composed from the proven
- * pieces of both legacy forms (destination + schema/prefix, entity layout
- * table, webhook secret/provisioning block, cron presets).
+ * the last step, instead of a flow "type" picked up-front. Composed from the
+ * proven pieces of both legacy forms (destination + schema/prefix, entity
+ * layout table, webhook secret/provisioning block, cron presets).
  */
 import { useEffect, useState, useMemo } from "react";
 import { useForm, Controller, useFieldArray } from "react-hook-form";
@@ -208,14 +208,14 @@ const STEPS = [
   { label: "Source", description: "Where the data comes from" },
   { label: "Destination", description: "Where the data is written" },
   {
-    label: "Triggers",
-    description: "How the sync is triggered — schedule, webhook, or both",
-  },
-  {
     label: "Sync Configuration",
     description: "Sync mode, delete behavior, periodic reconcile",
   },
   { label: "Entities", description: "What data is synced" },
+  {
+    label: "Triggers",
+    description: "How the sync is triggered — schedule, webhook, or both",
+  },
 ];
 
 export function SyncFlowForm({
@@ -681,17 +681,17 @@ export function SyncFlowForm({
     // Trigger-set validation
     if (!data.scheduleEnabled && !data.webhookEnabled) {
       setError("Enable at least one trigger — a schedule, a webhook, or both.");
-      setOpenSteps(prev => new Set([...prev, 2]));
+      setOpenSteps(prev => new Set([...prev, 4]));
       return;
     }
     if (data.scheduleEnabled && !data.scheduleCron.trim()) {
       setError("A cron expression is required for the scheduled trigger.");
-      setOpenSteps(prev => new Set([...prev, 2]));
+      setOpenSteps(prev => new Set([...prev, 4]));
       return;
     }
     if (data.webhookEnabled && !connectorSupportsWebhook) {
       setError("This connector does not provide webhooks — use a schedule.");
-      setOpenSteps(prev => new Set([...prev, 2]));
+      setOpenSteps(prev => new Set([...prev, 4]));
       return;
     }
     if (data.webhookEnabled && !isCdcCapableDest) {
@@ -722,7 +722,7 @@ export function SyncFlowForm({
     }
     if (requiresQueries && (!data.queries || data.queries.length === 0)) {
       setError("Please add at least one query to define what data to sync");
-      setOpenSteps(prev => new Set([...prev, 4]));
+      setOpenSteps(prev => new Set([...prev, 3]));
       return;
     }
     const backfillSchedule = {
@@ -737,7 +737,7 @@ export function SyncFlowForm({
       setError(
         "A valid cron expression is required to enable the periodic full reconcile.",
       );
-      setOpenSteps(prev => new Set([...prev, 3]));
+      setOpenSteps(prev => new Set([...prev, 2]));
       return;
     }
 
@@ -832,7 +832,7 @@ export function SyncFlowForm({
         // automatically on first create so the user doesn't have to reopen
         // Triggers just to click "Create in {Provider}".
         if (data.webhookEnabled && provisioning?.supported) {
-          setOpenSteps(new Set([2]));
+          setOpenSteps(new Set([4]));
           await provisionWebhookForFlow(newFlow._id);
         }
       } else if (currentFlowId) {
@@ -948,9 +948,9 @@ export function SyncFlowForm({
     const errorStepFields: string[][] = [
       ["dataSourceId"],
       ["destinationDatabaseId", "tableDestination", "destinationDatabaseName"],
+      [],
+      [],
       ["scheduleCron"],
-      [],
-      [],
     ];
     const firstErrorStep = errorStepFields.findIndex(fields =>
       fields.some(f => f in fieldErrors),
@@ -1334,271 +1334,6 @@ export function SyncFlowForm({
                       onClick={() => openNextStep(1)}
                       disabled={!watchDestinationId}
                     >
-                      Continue to Triggers
-                    </Button>
-                  </Box>
-                </Stack>
-              </AccordionDetails>
-            </Accordion>
-
-            {/* Step 3: Triggers */}
-            <Accordion
-              expanded={openSteps.has(2)}
-              onChange={() => toggleStep(2)}
-              sx={{ mb: 1 }}
-            >
-              {renderStepHeader(2)}
-              <AccordionDetails>
-                <Stack spacing={2}>
-                  {!watchScheduleEnabled && !watchWebhookEnabled && (
-                    <Alert severity="warning">
-                      Enable at least one trigger — a schedule, a webhook, or
-                      both.
-                    </Alert>
-                  )}
-
-                  {/* Scheduled trigger */}
-                  <Box
-                    sx={{
-                      border: 1,
-                      borderColor: "divider",
-                      borderRadius: 1,
-                      p: 2,
-                    }}
-                  >
-                    <Controller
-                      name="scheduleEnabled"
-                      control={control}
-                      render={({ field }) => (
-                        <FormControlLabel
-                          control={
-                            <Checkbox
-                              checked={Boolean(field.value)}
-                              onChange={e => field.onChange(e.target.checked)}
-                            />
-                          }
-                          label={
-                            <Box>
-                              <Typography variant="subtitle2">
-                                Scheduled
-                              </Typography>
-                              <Typography
-                                variant="caption"
-                                color="text.secondary"
-                              >
-                                Poll the source on a cron cadence.
-                              </Typography>
-                            </Box>
-                          }
-                        />
-                      )}
-                    />
-                    {watchScheduleEnabled && (
-                      <Stack
-                        direction={{ xs: "column", sm: "row" }}
-                        spacing={2}
-                        sx={{ mt: 1 }}
-                      >
-                        <FormControl size="small" fullWidth>
-                          <InputLabel>Cadence</InputLabel>
-                          <Select
-                            label="Cadence"
-                            value={
-                              scheduleCronMode === "custom"
-                                ? "__custom__"
-                                : cronPresetValue
-                            }
-                            onChange={e => {
-                              const value = e.target.value;
-                              if (value === "__custom__") {
-                                setScheduleCronMode("custom");
-                              } else {
-                                setScheduleCronMode("preset");
-                                setValue("scheduleCron", value, {
-                                  shouldDirty: true,
-                                });
-                              }
-                            }}
-                          >
-                            {SCHEDULE_PRESETS.map(preset => (
-                              <MenuItem key={preset.cron} value={preset.cron}>
-                                {preset.label}
-                              </MenuItem>
-                            ))}
-                            <MenuItem value="__custom__">Custom cron…</MenuItem>
-                          </Select>
-                        </FormControl>
-                        {scheduleCronMode === "custom" && (
-                          <Controller
-                            name="scheduleCron"
-                            control={control}
-                            render={({ field }) => (
-                              <TextField
-                                {...field}
-                                label="Cron Expression"
-                                placeholder="0 * * * *"
-                                size="small"
-                                fullWidth
-                                helperText="Format: minute hour day month weekday"
-                              />
-                            )}
-                          />
-                        )}
-                        <Controller
-                          name="scheduleTimezone"
-                          control={control}
-                          render={({ field }) => (
-                            <TextField
-                              {...field}
-                              label="Timezone"
-                              placeholder="UTC"
-                              size="small"
-                              fullWidth
-                            />
-                          )}
-                        />
-                      </Stack>
-                    )}
-                  </Box>
-
-                  {/* Webhook trigger */}
-                  <Tooltip
-                    title={
-                      !watchDataSourceId
-                        ? "Select a data source first"
-                        : connectorSupportsWebhook
-                          ? ""
-                          : "This connector does not provide webhooks — use a schedule"
-                    }
-                    placement="top-start"
-                  >
-                    <Box
-                      sx={{
-                        border: 1,
-                        borderColor: "divider",
-                        borderRadius: 1,
-                        p: 2,
-                        opacity: connectorSupportsWebhook ? 1 : 0.55,
-                      }}
-                    >
-                      <Controller
-                        name="webhookEnabled"
-                        control={control}
-                        render={({ field }) => (
-                          <FormControlLabel
-                            control={
-                              <Checkbox
-                                checked={Boolean(field.value)}
-                                disabled={!connectorSupportsWebhook}
-                                onChange={e => field.onChange(e.target.checked)}
-                              />
-                            }
-                            label={
-                              <Box>
-                                <Typography variant="subtitle2">
-                                  Webhook
-                                </Typography>
-                                <Typography
-                                  variant="caption"
-                                  color="text.secondary"
-                                >
-                                  Receive pushed changes in real time
-                                  {connectorSupportsWebhook
-                                    ? "."
-                                    : " (unavailable for this connector)."}
-                                </Typography>
-                              </Box>
-                            }
-                          />
-                        )}
-                      />
-
-                      {watchWebhookEnabled && (
-                        <Stack spacing={2} sx={{ mt: 1 }}>
-                          {!isCdcCapableDest && (
-                            <Alert severity="warning">
-                              Webhook-triggered syncs require a CDC-capable
-                              destination (BigQuery, PostgreSQL, ClickHouse, or
-                              MongoDB).
-                            </Alert>
-                          )}
-                          {isNewMode ? (
-                            <Alert severity="info" icon={<WebhookIcon />}>
-                              {provisioning?.supported
-                                ? `Finish the steps and create the sync — we'll generate the webhook URL and create it in ${provisionProviderLabel} automatically.`
-                                : "Finish the steps and create the sync to generate the webhook URL, then paste the signing secret from your provider."}
-                            </Alert>
-                          ) : (
-                            <>
-                              {webhookUrl && (
-                                <TextField
-                                  value={webhookUrl}
-                                  label="Webhook URL"
-                                  fullWidth
-                                  size="small"
-                                  InputProps={{
-                                    readOnly: true,
-                                    endAdornment: (
-                                      <Button
-                                        size="small"
-                                        onClick={() =>
-                                          navigator.clipboard.writeText(
-                                            webhookUrl,
-                                          )
-                                        }
-                                      >
-                                        <CopyIcon fontSize="small" />
-                                      </Button>
-                                    ),
-                                  }}
-                                />
-                              )}
-                              <Controller
-                                name="webhookSecret"
-                                control={control}
-                                render={({ field }) => (
-                                  <TextField
-                                    {...field}
-                                    label="Webhook Secret"
-                                    placeholder="Enter webhook secret"
-                                    fullWidth
-                                    size="small"
-                                    helperText={webhookSecretHelpText}
-                                  />
-                                )}
-                              />
-                              {canProvisionWebhook && (
-                                <Box>
-                                  <Button
-                                    size="small"
-                                    variant="outlined"
-                                    onClick={handleProvisionWebhook}
-                                    disabled={
-                                      isSubmitting || isProvisioningWebhook
-                                    }
-                                  >
-                                    {isProvisioningWebhook
-                                      ? `Creating in ${provisionProviderLabel}...`
-                                      : `Create in ${provisionProviderLabel}`}
-                                  </Button>
-                                </Box>
-                              )}
-                            </>
-                          )}
-                        </Stack>
-                      )}
-                    </Box>
-                  </Tooltip>
-
-                  <Box
-                    sx={{ display: "flex", justifyContent: "flex-end", pt: 1 }}
-                  >
-                    <Button
-                      variant="contained"
-                      endIcon={<NextIcon />}
-                      onClick={() => openNextStep(2)}
-                      disabled={!watchScheduleEnabled && !watchWebhookEnabled}
-                    >
                       Continue to Sync Configuration
                     </Button>
                   </Box>
@@ -1606,13 +1341,13 @@ export function SyncFlowForm({
               </AccordionDetails>
             </Accordion>
 
-            {/* Step 4: Sync Configuration */}
+            {/* Step 3: Sync Configuration */}
             <Accordion
-              expanded={openSteps.has(3)}
-              onChange={() => toggleStep(3)}
+              expanded={openSteps.has(2)}
+              onChange={() => toggleStep(2)}
               sx={{ mb: 1 }}
             >
-              {renderStepHeader(3)}
+              {renderStepHeader(2)}
               <AccordionDetails>
                 <Stack spacing={3}>
                   <FormControl fullWidth>
@@ -1773,7 +1508,7 @@ export function SyncFlowForm({
                     <Button
                       variant="contained"
                       endIcon={<NextIcon />}
-                      onClick={() => openNextStep(3)}
+                      onClick={() => openNextStep(2)}
                     >
                       Continue to Entities
                     </Button>
@@ -1782,13 +1517,13 @@ export function SyncFlowForm({
               </AccordionDetails>
             </Accordion>
 
-            {/* Step 5: Entities */}
+            {/* Step 4: Entities */}
             <Accordion
-              expanded={openSteps.has(4)}
-              onChange={() => toggleStep(4)}
+              expanded={openSteps.has(3)}
+              onChange={() => toggleStep(3)}
               sx={{ mb: 1 }}
             >
-              {renderStepHeader(4)}
+              {renderStepHeader(3)}
               <AccordionDetails>
                 <Stack spacing={3}>
                   {/* Query-based connectors (GraphQL / PostHog) */}
@@ -2194,16 +1929,305 @@ export function SyncFlowForm({
                     />
                   )}
 
-                  {isNewMode && (
+                  <Box
+                    sx={{ display: "flex", justifyContent: "flex-end", pt: 1 }}
+                  >
+                    <Button
+                      variant="contained"
+                      endIcon={<NextIcon />}
+                      onClick={() => openNextStep(3)}
+                    >
+                      Continue to Triggers
+                    </Button>
+                  </Box>
+                </Stack>
+              </AccordionDetails>
+            </Accordion>
+            {/* Step 5: Triggers */}
+            <Accordion
+              expanded={openSteps.has(4)}
+              onChange={() => toggleStep(4)}
+              sx={{ mb: 1 }}
+            >
+              {renderStepHeader(4)}
+              <AccordionDetails>
+                <Stack spacing={2}>
+                  {!watchScheduleEnabled && !watchWebhookEnabled && (
+                    <Alert severity="warning">
+                      Enable at least one trigger — a schedule, a webhook, or
+                      both.
+                    </Alert>
+                  )}
+
+                  {/* Scheduled trigger */}
+                  <Box
+                    sx={{
+                      border: 1,
+                      borderColor: "divider",
+                      borderRadius: 1,
+                      p: 2,
+                    }}
+                  >
+                    <Controller
+                      name="scheduleEnabled"
+                      control={control}
+                      render={({ field }) => (
+                        <FormControlLabel
+                          control={
+                            <Checkbox
+                              checked={Boolean(field.value)}
+                              onChange={e => field.onChange(e.target.checked)}
+                            />
+                          }
+                          label={
+                            <Box>
+                              <Typography variant="subtitle2">
+                                Scheduled
+                              </Typography>
+                              <Typography
+                                variant="caption"
+                                color="text.secondary"
+                              >
+                                Poll the source on a cron cadence.
+                              </Typography>
+                            </Box>
+                          }
+                        />
+                      )}
+                    />
+                    {watchScheduleEnabled && (
+                      <Stack
+                        direction={{ xs: "column", sm: "row" }}
+                        spacing={2}
+                        sx={{ mt: 1 }}
+                      >
+                        <FormControl size="small" fullWidth>
+                          <InputLabel>Cadence</InputLabel>
+                          <Select
+                            label="Cadence"
+                            value={
+                              scheduleCronMode === "custom"
+                                ? "__custom__"
+                                : cronPresetValue
+                            }
+                            onChange={e => {
+                              const value = e.target.value;
+                              if (value === "__custom__") {
+                                setScheduleCronMode("custom");
+                              } else {
+                                setScheduleCronMode("preset");
+                                setValue("scheduleCron", value, {
+                                  shouldDirty: true,
+                                });
+                              }
+                            }}
+                          >
+                            {SCHEDULE_PRESETS.map(preset => (
+                              <MenuItem key={preset.cron} value={preset.cron}>
+                                {preset.label}
+                              </MenuItem>
+                            ))}
+                            <MenuItem value="__custom__">Custom cron…</MenuItem>
+                          </Select>
+                        </FormControl>
+                        {scheduleCronMode === "custom" && (
+                          <Controller
+                            name="scheduleCron"
+                            control={control}
+                            render={({ field }) => (
+                              <TextField
+                                {...field}
+                                label="Cron Expression"
+                                placeholder="0 * * * *"
+                                size="small"
+                                fullWidth
+                                helperText="Format: minute hour day month weekday"
+                              />
+                            )}
+                          />
+                        )}
+                        <Controller
+                          name="scheduleTimezone"
+                          control={control}
+                          render={({ field }) => (
+                            <TextField
+                              {...field}
+                              label="Timezone"
+                              placeholder="UTC"
+                              size="small"
+                              fullWidth
+                            />
+                          )}
+                        />
+                      </Stack>
+                    )}
+                  </Box>
+
+                  {/* Webhook trigger */}
+                  <Tooltip
+                    title={
+                      !watchDataSourceId
+                        ? "Select a data source first"
+                        : connectorSupportsWebhook
+                          ? ""
+                          : "This connector does not provide webhooks — use a schedule"
+                    }
+                    placement="top-start"
+                  >
+                    <Box
+                      sx={{
+                        border: 1,
+                        borderColor: "divider",
+                        borderRadius: 1,
+                        p: 2,
+                        opacity: connectorSupportsWebhook ? 1 : 0.55,
+                      }}
+                    >
+                      <Controller
+                        name="webhookEnabled"
+                        control={control}
+                        render={({ field }) => (
+                          <FormControlLabel
+                            control={
+                              <Checkbox
+                                checked={Boolean(field.value)}
+                                disabled={!connectorSupportsWebhook}
+                                onChange={e => field.onChange(e.target.checked)}
+                              />
+                            }
+                            label={
+                              <Box>
+                                <Typography variant="subtitle2">
+                                  Webhook
+                                </Typography>
+                                <Typography
+                                  variant="caption"
+                                  color="text.secondary"
+                                >
+                                  Receive pushed changes in real time
+                                  {connectorSupportsWebhook
+                                    ? "."
+                                    : " (unavailable for this connector)."}
+                                </Typography>
+                              </Box>
+                            }
+                          />
+                        )}
+                      />
+
+                      {watchWebhookEnabled && (
+                        <Stack spacing={2} sx={{ mt: 1 }}>
+                          {!isCdcCapableDest && (
+                            <Alert severity="warning">
+                              Webhook-triggered syncs require a CDC-capable
+                              destination (BigQuery, PostgreSQL, ClickHouse, or
+                              MongoDB).
+                            </Alert>
+                          )}
+                          {isNewMode ? (
+                            <Alert severity="info" icon={<WebhookIcon />}>
+                              {provisioning?.supported
+                                ? `Create the sync below — we'll generate the webhook URL and create it in ${provisionProviderLabel} automatically.`
+                                : "Create the sync below to generate the webhook URL, then paste the signing secret from your provider."}
+                            </Alert>
+                          ) : (
+                            <>
+                              {webhookUrl && (
+                                <TextField
+                                  value={webhookUrl}
+                                  label="Webhook URL"
+                                  fullWidth
+                                  size="small"
+                                  InputProps={{
+                                    readOnly: true,
+                                    endAdornment: (
+                                      <Button
+                                        size="small"
+                                        onClick={() =>
+                                          navigator.clipboard.writeText(
+                                            webhookUrl,
+                                          )
+                                        }
+                                      >
+                                        <CopyIcon fontSize="small" />
+                                      </Button>
+                                    ),
+                                  }}
+                                />
+                              )}
+                              <Controller
+                                name="webhookSecret"
+                                control={control}
+                                render={({ field }) => (
+                                  <TextField
+                                    {...field}
+                                    label="Webhook Secret"
+                                    placeholder="Enter webhook secret"
+                                    fullWidth
+                                    size="small"
+                                    helperText={webhookSecretHelpText}
+                                  />
+                                )}
+                              />
+                              {canProvisionWebhook && (
+                                <Box>
+                                  <Button
+                                    size="small"
+                                    variant="outlined"
+                                    onClick={handleProvisionWebhook}
+                                    disabled={
+                                      isSubmitting || isProvisioningWebhook
+                                    }
+                                  >
+                                    {isProvisioningWebhook
+                                      ? `Creating in ${provisionProviderLabel}...`
+                                      : `Create in ${provisionProviderLabel}`}
+                                  </Button>
+                                </Box>
+                              )}
+                            </>
+                          )}
+                        </Stack>
+                      )}
+                    </Box>
+                  </Tooltip>
+
+                  {isNewMode ? (
                     <Button
                       variant="contained"
                       startIcon={<AddIcon />}
                       onClick={handleFormSubmit}
-                      disabled={isSubmitting}
+                      disabled={
+                        isSubmitting ||
+                        (!watchScheduleEnabled && !watchWebhookEnabled)
+                      }
                       fullWidth
                     >
-                      {isSubmitting ? "Creating..." : "Create Sync"}
+                      {isSubmitting
+                        ? "Creating..."
+                        : watchWebhookEnabled && provisioning?.supported
+                          ? `Create Sync & connect ${provisionProviderLabel}`
+                          : "Create Sync"}
                     </Button>
+                  ) : (
+                    <Box
+                      sx={{
+                        display: "flex",
+                        justifyContent: "flex-end",
+                        pt: 1,
+                      }}
+                    >
+                      <Button
+                        variant="contained"
+                        onClick={handleFormSubmit}
+                        disabled={
+                          isSubmitting ||
+                          (!watchScheduleEnabled && !watchWebhookEnabled)
+                        }
+                      >
+                        {isSubmitting ? "Saving..." : "Save triggers"}
+                      </Button>
+                    </Box>
                   )}
                 </Stack>
               </AccordionDetails>

--- a/app/src/components/SyncFlowForm.tsx
+++ b/app/src/components/SyncFlowForm.tsx
@@ -273,6 +273,10 @@ export function SyncFlowForm({
   const [webhookUrl, setWebhookUrl] = useState<string>("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isProvisioningWebhook, setIsProvisioningWebhook] = useState(false);
+  /** Keep Triggers expanded after create until the user can see provision result. */
+  const [pinTriggersOpen, setPinTriggersOpen] = useState(false);
+  const [webhookProvisionSucceeded, setWebhookProvisionSucceeded] =
+    useState(false);
   const [error, setError] = useState<string | null>(null);
   const [currentFlowId, setCurrentFlowId] = useState<string | undefined>(
     flowId,
@@ -292,10 +296,21 @@ export function SyncFlowForm({
   const [transferQueriesSchema, setTransferQueriesSchema] = useState<any>(null);
 
   const toggleStep = (stepIndex: number) => {
+    // Keep Triggers open while provisioning, and after success until the
+    // user dismisses the confirmation (pinTriggersOpen). Failures stay open
+    // but can be collapsed once the error is visible (!isProvisioningWebhook).
+    if (stepIndex === 4 && openSteps.has(4)) {
+      if (isProvisioningWebhook) return;
+      if (pinTriggersOpen && !error) return;
+    }
     setOpenSteps(prev => {
       const next = new Set(prev);
-      if (next.has(stepIndex)) next.delete(stepIndex);
-      else next.add(stepIndex);
+      if (next.has(stepIndex)) {
+        next.delete(stepIndex);
+        if (stepIndex === 4) setPinTriggersOpen(false);
+      } else {
+        next.add(stepIndex);
+      }
       return next;
     });
   };
@@ -828,12 +843,20 @@ export function SyncFlowForm({
         reset(data);
         onSave?.();
 
-        // Provisioning needs a persisted flowId for the webhook URL. Do it
-        // automatically on first create so the user doesn't have to reopen
-        // Triggers just to click "Create in {Provider}".
-        if (data.webhookEnabled && provisioning?.supported) {
+        // Triggers is last: stay on it after create so webhook URL/secret are
+        // visible. Pin open until provisioning finishes (or URL is shown).
+        if (data.webhookEnabled) {
+          setPinTriggersOpen(true);
+          setWebhookProvisionSucceeded(false);
           setOpenSteps(new Set([4]));
-          await provisionWebhookForFlow(newFlow._id);
+          if (provisioning?.supported) {
+            const ok = await provisionWebhookForFlow(newFlow._id);
+            if (ok) {
+              setWebhookProvisionSucceeded(true);
+            }
+            // Keep Triggers pinned until the user dismisses the success
+            // (or failure) so URL/secret stay visible.
+          }
         }
       } else if (currentFlowId) {
         await updateFlow(currentWorkspace.id, currentFlowId, payload);
@@ -878,13 +901,16 @@ export function SyncFlowForm({
     }
   };
 
-  const provisionWebhookForFlow = async (flowIdToProvision: string) => {
+  const provisionWebhookForFlow = async (
+    flowIdToProvision: string,
+  ): Promise<boolean> => {
     if (!currentWorkspace?.id) {
       setError("Save the sync first before creating the provider webhook");
-      return;
+      return false;
     }
     setIsProvisioningWebhook(true);
     setError(null);
+    setWebhookProvisionSucceeded(false);
     try {
       const publicBaseUrl =
         typeof window !== "undefined" ? window.location.origin : undefined;
@@ -912,12 +938,14 @@ export function SyncFlowForm({
           });
         }, 0);
       }
+      return Boolean(provisioned.endpoint && provisioned.webhookSecret);
     } catch (err) {
       setError(
         err instanceof Error
           ? err.message
           : `Failed to create webhook in ${provisionProviderLabel}`,
       );
+      return false;
     } finally {
       setIsProvisioningWebhook(false);
     }
@@ -928,7 +956,12 @@ export function SyncFlowForm({
       setError("Save the sync first before creating the provider webhook");
       return;
     }
-    await provisionWebhookForFlow(currentFlowId);
+    setPinTriggersOpen(true);
+    setOpenSteps(prev => new Set([...prev, 4]));
+    const ok = await provisionWebhookForFlow(currentFlowId);
+    if (ok) {
+      setWebhookProvisionSucceeded(true);
+    }
   };
 
   const stepHasError = (stepIndex: number): boolean => {
@@ -1945,7 +1978,9 @@ export function SyncFlowForm({
             </Accordion>
             {/* Step 5: Triggers */}
             <Accordion
-              expanded={openSteps.has(4)}
+              expanded={
+                openSteps.has(4) || pinTriggersOpen || isProvisioningWebhook
+              }
               onChange={() => toggleStep(4)}
               sx={{ mb: 1 }}
             >
@@ -2132,6 +2167,25 @@ export function SyncFlowForm({
                             </Alert>
                           ) : (
                             <>
+                              {isProvisioningWebhook && (
+                                <Alert severity="info" icon={<WebhookIcon />}>
+                                  Creating webhook in {provisionProviderLabel}…
+                                </Alert>
+                              )}
+                              {webhookProvisionSucceeded &&
+                                !isProvisioningWebhook && (
+                                  <Alert
+                                    severity="success"
+                                    onClose={() => {
+                                      setWebhookProvisionSucceeded(false);
+                                      setPinTriggersOpen(false);
+                                    }}
+                                  >
+                                    Webhook created in {provisionProviderLabel}.
+                                    URL and signing secret are filled below —
+                                    save if you change anything.
+                                  </Alert>
+                                )}
                               {webhookUrl && (
                                 <TextField
                                   value={webhookUrl}
@@ -2181,7 +2235,9 @@ export function SyncFlowForm({
                                   >
                                     {isProvisioningWebhook
                                       ? `Creating in ${provisionProviderLabel}...`
-                                      : `Create in ${provisionProviderLabel}`}
+                                      : webhookProvisionSucceeded
+                                        ? `Recreate in ${provisionProviderLabel}`
+                                        : `Create in ${provisionProviderLabel}`}
                                   </Button>
                                 </Box>
                               )}

--- a/app/src/components/SyncFlowForm.tsx
+++ b/app/src/components/SyncFlowForm.tsx
@@ -587,7 +587,11 @@ export function SyncFlowForm({
       scheduleCron: flow.schedule?.cron || "0 * * * *",
       scheduleTimezone: flow.schedule?.timezone || "UTC",
       webhookEnabled: hasWebhookTrigger,
-      webhookSecret: flow.webhookConfig?.secret || "",
+      // Prefer the server secret when present. If a flows refresh races with
+      // one-click provisioning (secret just set in the form, not yet visible
+      // on the list payload), keep the in-form value instead of blanking it.
+      webhookSecret:
+        flow.webhookConfig?.secret || getValues("webhookSecret") || "",
       syncMode: (flow.syncMode as "full" | "incremental") || "full",
       writeMode:
         (flow.writeMode as "append_dedup" | "append" | "overwrite") ||
@@ -621,7 +625,7 @@ export function SyncFlowForm({
         : "custom",
     );
     reset(formData);
-  }, [isNewMode, currentFlowId, flows, reset]);
+  }, [isNewMode, currentFlowId, flows, reset, getValues]);
 
   useEffect(() => {
     return () => {
@@ -891,6 +895,15 @@ export function SyncFlowForm({
         });
       }
       await useFlowStore.getState().fetchFlows(currentWorkspace.id);
+      // fetchFlows triggers the flows→reset useEffect. Re-apply after that
+      // paint so a missing/racy list secret can't wipe the provisioned value.
+      if (provisioned.webhookSecret) {
+        setTimeout(() => {
+          setValue("webhookSecret", provisioned.webhookSecret!, {
+            shouldDirty: true,
+          });
+        }, 0);
+      }
     } catch (err) {
       setError(
         err instanceof Error

--- a/app/src/components/SyncFlowForm.tsx
+++ b/app/src/components/SyncFlowForm.tsx
@@ -827,6 +827,14 @@ export function SyncFlowForm({
         onSaved?.(newFlow._id);
         reset(data);
         onSave?.();
+
+        // Provisioning needs a persisted flowId for the webhook URL. Do it
+        // automatically on first create so the user doesn't have to reopen
+        // Triggers just to click "Create in {Provider}".
+        if (data.webhookEnabled && provisioning?.supported) {
+          setOpenSteps(new Set([2]));
+          await provisionWebhookForFlow(newFlow._id);
+        }
       } else if (currentFlowId) {
         await updateFlow(currentWorkspace.id, currentFlowId, payload);
 
@@ -870,8 +878,8 @@ export function SyncFlowForm({
     }
   };
 
-  const handleProvisionWebhook = async () => {
-    if (!currentWorkspace?.id || !currentFlowId) {
+  const provisionWebhookForFlow = async (flowIdToProvision: string) => {
+    if (!currentWorkspace?.id) {
       setError("Save the sync first before creating the provider webhook");
       return;
     }
@@ -882,7 +890,7 @@ export function SyncFlowForm({
         typeof window !== "undefined" ? window.location.origin : undefined;
       const provisioned = await provisionFlowWebhook(
         currentWorkspace.id,
-        currentFlowId,
+        flowIdToProvision,
         { verifySsl: true, publicBaseUrl },
       );
       if (!provisioned) {
@@ -913,6 +921,14 @@ export function SyncFlowForm({
     } finally {
       setIsProvisioningWebhook(false);
     }
+  };
+
+  const handleProvisionWebhook = async () => {
+    if (!currentFlowId) {
+      setError("Save the sync first before creating the provider webhook");
+      return;
+    }
+    await provisionWebhookForFlow(currentFlowId);
   };
 
   const stepHasError = (stepIndex: number): boolean => {
@@ -1508,8 +1524,9 @@ export function SyncFlowForm({
                           )}
                           {isNewMode ? (
                             <Alert severity="info" icon={<WebhookIcon />}>
-                              Save the sync to generate the webhook URL and
-                              secret.
+                              {provisioning?.supported
+                                ? `Finish the steps and create the sync — we'll generate the webhook URL and create it in ${provisionProviderLabel} automatically.`
+                                : "Finish the steps and create the sync to generate the webhook URL, then paste the signing secret from your provider."}
                             </Alert>
                           ) : (
                             <>


### PR DESCRIPTION
## Summary
- Close `createWebhookSubscription` now returns `signature_key` when an existing webhook URL is reused (and GETs by id if the list omits it), so **Create in Close** fills **Webhook Secret** again.
- SyncFlowForm keeps a just-provisioned secret across the post-provision `fetchFlows` → form reset race.

## Test plan
- [ ] Open a Close webhook sync with an already-registered Mako webhook URL
- [ ] Click **Create in Close** → Webhook Secret populates
- [ ] Save the sync; reload → secret still present
- [ ] `pnpm --filter api exec tsx src/connectors/close/connector.test.ts`


Made with [Cursor](https://cursor.com)