### PR TITLE
fix(notebooks): kernel-authed /notebook/sources so mako.sources.read resolves under the kernel token

### DIFF
--- a/api/src/routes/notebook-data.ts
+++ b/api/src/routes/notebook-data.ts
@@ -108,6 +108,40 @@ const ReadRequestSchema = z
   })
   .openapi("NotebookReadRequest");
 
+// GET /api/workspaces/:workspaceId/notebook/sources
+// The SDK's source list — `mako.sources.list()` / `.resolve()` map a source
+// NAME to a connection id from inside the sandbox. Kernel-token authed (same as
+// /read) and deliberately minimal: id, name, type ONLY — never the credentialed
+// connection doc (the generic /databases route decrypts creds and must not be
+// reachable by a kernel token).
+notebookDataRoutes.openapi(
+  createRoute({
+    method: "get",
+    path: "/sources",
+    tags: ["Notebooks"],
+    security: AUTH_SECURITY,
+    middleware: [kernelOrUnifiedAuth, requireWorkspace] as const,
+    request: {
+      params: z.object({ workspaceId: pathParam("workspaceId") }),
+    },
+    responses: { ...OPEN_RESPONSES },
+  }),
+  async c => {
+    const workspace = c.get("workspace") as { _id: unknown };
+    const rows = await DatabaseConnection.find({
+      workspaceId: new Types.ObjectId(String(workspace._id)),
+    })
+      .select("_id name type")
+      .lean();
+    const data = rows.map(r => ({
+      id: String(r._id),
+      name: (r as { name?: string }).name ?? "",
+      type: (r as { type?: string }).type ?? "",
+    }));
+    return c.json({ success: true, data });
+  },
+);
+
 // POST /api/workspaces/:workspaceId/notebook/read
 notebookDataRoutes.openapi(
   createRoute({

--- a/api/src/services/kernel-session.service.ts
+++ b/api/src/services/kernel-session.service.ts
@@ -85,7 +85,13 @@ class KernelSessionService {
    * kernels. Two jobs:
    *  1. Wire the mako SDK — the read-only token + workspace so
    *     `mako.sources.sql.read(...)` proxies through the API.
-   *  2. Activate the Jupyter inline backend so matplotlib figures render as
+   *  2. Point the mako SDK's source resolution at the kernel-token-authed
+   *     `/notebook/sources` route. `mako.sources.read(...)` first resolves a
+   *     source NAME to an id via that list; the SDK's baked default hits the
+   *     generic `/databases` route, which rejects kernel tokens (and echoes
+   *     credentials), so reads 403. This override reconfigures the baked SDK at
+   *     runtime — no kernel-image rebuild needed.
+   *  3. Activate the Jupyter inline backend so matplotlib figures render as
    *     inline PNGs. The kernel image defaults to the headless Agg backend
    *     (`MPLBACKEND=Agg`), which emits no image output; `%matplotlib inline`
    *     switches to the inline backend (auto-displaying figures at cell end,
@@ -102,6 +108,14 @@ class KernelSessionService {
     return [
       `import os as _os`,
       `_os.environ.update(${JSON.stringify(env)})`,
+      // Resolve sources via the kernel-authed notebook route, not the generic
+      // (credentialed, session-only) /databases route. Isolated so an SDK issue
+      // can't break the rest of init.
+      `try:`,
+      `    import mako as _mako`,
+      `    _mako.configure(databases_path="/api/workspaces/{workspace_id}/notebook/sources")`,
+      `except Exception:`,
+      `    pass`,
       // Inline matplotlib — isolated so a matplotlib issue can't break the SDK
       // env setup above. Overrides MPLBACKEND=Agg at runtime.
       `try:`,

--- a/app/src/api/schema.d.ts
+++ b/app/src/api/schema.d.ts
@@ -3321,6 +3321,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/workspaces/{workspaceId}/notebook/sources": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["get_api_workspaces_workspaceId_notebook_sources"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/workspaces/{workspaceId}/notebook/read": {
         parameters: {
             query?: never;
@@ -15754,6 +15770,46 @@ export interface operations {
             path: {
                 workspaceId: string;
                 id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    get_api_workspaces_workspaceId_notebook_sources: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
             };
             cookie?: never;
         };

--- a/docs/src/openapi/mako-api.json
+++ b/docs/src/openapi/mako-api.json
@@ -21478,6 +21478,74 @@
         "operationId": "get_api_workspaces_workspaceId_apps_id_public_share_password"
       }
     },
+    "/api/workspaces/{workspaceId}/notebook/sources": {
+      "get": {
+        "tags": [
+          "Notebooks"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get_api_workspaces_workspaceId_notebook_sources"
+      }
+    },
     "/api/workspaces/{workspaceId}/notebook/read": {
       "post": {
         "tags": [

--- a/packages/mako-sdk-py/src/mako/_config.py
+++ b/packages/mako-sdk-py/src/mako/_config.py
@@ -23,7 +23,10 @@ from .errors import MakoConfigError
 # companion backend slice). Point at ``/api/workspaces/{workspace_id}/execute/export``
 # via ``configure(read_path=...)`` to run against an instance before it ships.
 DEFAULT_READ_PATH = "/api/workspaces/{workspace_id}/notebook/read"
-DEFAULT_DATABASES_PATH = "/api/workspaces/{workspace_id}/databases"
+# Source resolution goes through the kernel-token-authed notebook route (id /
+# name / type only). The generic ``/databases`` route rejects kernel tokens and
+# echoes credentialed connection docs, so it must not be reachable from a kernel.
+DEFAULT_DATABASES_PATH = "/api/workspaces/{workspace_id}/notebook/sources"
 DEFAULT_TIMEOUT_SECONDS = 300.0
 
 


### PR DESCRIPTION
## Problem

Running `mako.sources.sql.read(...)` from a notebook Python cell fails in prod with:

```
MakoAuthError: Mako API request failed (HTTP 403)
```

The SDK resolves a source **name → id** via `Sources.list()`, which pointed at the generic `GET /api/workspaces/:id/databases` route. That route:

- is **session / API-key authed** → rejects the `mnk_` kernel token → **403**, and
- **echoes decrypted connection docs** → must never be reachable from a sandbox.

The kernel could only reach `/notebook/read`, never a source list.

## Fix

1. **New `GET /api/workspaces/:id/notebook/sources`** — kernel-token authed (same `kernelOrUnifiedAuth` guard as `/read`), returning **`{id, name, type}` only** — never credentials. The missing budgeted surface for source resolution.
2. **Reconfigure the baked SDK at kernel-session start** — the silent init cell now runs `mako.configure(databases_path=".../notebook/sources")`, so the fix lands on the **currently-running warm pods with no kernel-image rebuild**.
3. **Correct the SDK default** (`DEFAULT_DATABASES_PATH`) to the notebook route — long-term correctness; picked up on the next image build, redundant with the runtime override (item 2) until then.

## Deployment

- Items (1) and (2) deploy with the API → SQL-from-Python works on existing pods after the next deploy (Restart the kernel to start a fresh session running the updated init). **No image rebuild needed.**
- Item (3) touches `packages/mako-sdk-py`, which triggers the kernel-image CI rebuild automatically (hardening, off the critical path).

## Verification

- `configure()` on the container's **baked** SDK (same version as prod pods) resolves to `…/api/workspaces/<ws>/notebook/sources` ✓
- API typecheck + lint clean; OpenAPI + app schema regenerated ✓

