### PR TITLE
fix(notebooks): kernel reaches the API via the direct Cloud Run URL (bypass Cloudflare 1010)

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -642,6 +642,12 @@ jobs:
           CLOUD_RUN_URL=$(gcloud run services describe ${SERVICE_NAME} --project ${GCP_PROJECT_ID} --region ${GCP_REGION} --format='value(status.url)')
           echo "cloud_run_url=${CLOUD_RUN_URL}" >> "$GITHUB_OUTPUT"
 
+          # Kernel pods reach the API via the DIRECT run.app URL (not the
+          # Cloudflare-fronted pr-N.mako.ai, which 1010-blocks the pods).
+          gcloud run services update ${SERVICE_NAME} \
+            --project ${GCP_PROJECT_ID} --region ${GCP_REGION} \
+            --update-env-vars="NOTEBOOK_KERNEL_API_URL=${CLOUD_RUN_URL}" --quiet
+
       - name: Sync Inngest branch environment
         continue-on-error: true
         run: |
@@ -1068,13 +1074,20 @@ jobs:
             --region="${GCP_REGION}" \
             --format="value(status.url)")
 
+          # Notebook kernel pods reach the API via the DIRECT run.app URL, not
+          # the public (Cloudflare-fronted) domain — Cloudflare 1010-blocks the
+          # pods' non-browser requests from GCP egress IPs. Always kept in sync
+          # with the current direct URL. INNGEST_SERVE_ORIGIN is only set on the
+          # first deploy (unchanged thereafter).
+          EXTRA_ENV=""
           if [ -z "${{ steps.cloud-run-before.outputs.url }}" ]; then
-            gcloud run services update "${SERVICE_NAME}" \
-              --project="${GCP_PROJECT_ID}" \
-              --region="${GCP_REGION}" \
-              --update-env-vars="INNGEST_SERVE_ORIGIN=${CLOUD_RUN_URL},INNGEST_SERVE_PATH=/api/inngest" \
-              --quiet
+            EXTRA_ENV=",INNGEST_SERVE_ORIGIN=${CLOUD_RUN_URL},INNGEST_SERVE_PATH=/api/inngest"
           fi
+          gcloud run services update "${SERVICE_NAME}" \
+            --project="${GCP_PROJECT_ID}" \
+            --region="${GCP_REGION}" \
+            --update-env-vars="NOTEBOOK_KERNEL_API_URL=${CLOUD_RUN_URL}${EXTRA_ENV}" \
+            --quiet
 
           echo "cloud_run_url=${CLOUD_RUN_URL}" >> "$GITHUB_OUTPUT"
           echo "Cloud Run direct URL: ${CLOUD_RUN_URL}"


### PR DESCRIPTION
## Problem

`mako.sources.sql.read(...)` from a notebook Python cell fails in prod with:

```
MakoAuthError: Mako API request failed (HTTP 403)  ->  b'error code: 1010\n'
```

`error code: 1010` is a **Cloudflare** block, not the Mako API. The kernel pods call back into the API for source reads, but the public domain (`app.mako.ai`, `pr-N.mako.ai`) is fronted by Cloudflare, which 1010-blocks the pods' non-browser requests coming from GCP egress IPs. The request never reaches the origin — so the route and kernel token were never the problem (token verified valid: `mnk_…`, 274 chars).

Verified:
- `app.mako.ai` → `server: cloudflare`, `cf-ray: …`
- direct `…run.app` → `server: Google Frontend` (no Cloudflare), reaches origin.

## Fix

Point the kernel at the service's **direct `run.app` URL** via `NOTEBOOK_KERNEL_API_URL`, in both the prod and preview deploys — reusing the `CLOUD_RUN_URL` the deploy already resolves. `kernelInitCode` already prefers `NOTEBOOK_KERNEL_API_URL` over `BASE_URL`, so kernel pods now hit the origin directly and the kernel token validates.

- **prod**: set on every deploy in the "Finalize Cloud Run direct URL" step (kept in sync; `INNGEST_SERVE_ORIGIN` still first-deploy-only).
- **preview**: set right after the per-PR `CLOUD_RUN_URL` is resolved.

## After merge

Redeploy prod, then Restart the kernel on the notebook — `mako.sources.sql.read(...)` should return rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
