### PR TITLE
docs: Notebooks page + kernel-plane coverage (ai-agent, api-reference, CLAUDE.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ pnpm lint:fix:all          # Auto-fix linting issues across workspace
 ### Data Operations
 
 ```bash
-pnpm docker:up             # Start MongoDB and services (docker-compose up -d)
+pnpm docker:up             # Start the local notebook Python kernel sidecar (docker-compose up -d; dev DB is hosted Atlas)
 pnpm docker:down           # Stop all services
 pnpm docker:logs           # View service logs
 pnpm docker:rebuild        # Rebuild and restart containers
@@ -125,10 +125,18 @@ INNGEST_SIGNING_KEY=your_inngest_signing_key
 # (MCP render_app tool; unset = agents fall back to preview tokens)
 # RENDER_APP_BROWSER_PATH=/usr/bin/chromium
 
-# Redis (optional — resumable chat streams)
-# Unset: in-process stream buffer (local dev / single API instance).
+# Notebook Python kernel (local dev — see .env.example)
+# `code` cells run on a managed kernel; locally, `pnpm docker:up` starts the
+# sidecar and StaticKernelProvider drives it. Deployed envs auto-detect GKE.
+KERNEL_PROVIDER=static
+KERNEL_GATEWAY_URL=http://localhost:8888
+NOTEBOOK_KERNEL_API_URL=http://host.docker.internal:8080
+
+# Redis (optional — resumable chat streams + kernel session registry)
+# Unset: in-process buffers (local dev / single API instance).
 # Set when running multiple API instances so chat stream resume
-# (GET /api/agent/chat/:chatId/stream) works across instances.
+# (GET /api/agent/chat/:chatId/stream) and the shared kernel-session
+# registry (notebook kernels visible to every instance) work.
 REDIS_URL=redis://localhost:6379
 ```
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -48,6 +48,7 @@ export default defineConfig({
             { label: "Apps", slug: "apps" },
             { label: "Transforms (dbt)", slug: "transforms" },
             { label: "Query Runner", slug: "query-runner" },
+            { label: "Notebooks", slug: "notebooks" },
             { label: "Self-Directive", slug: "self-directive" },
             { label: "Skills", slug: "skills" },
             { label: "MCP Connectors", slug: "mcp-connectors" },

--- a/docs/src/content/docs/ai-agent.md
+++ b/docs/src/content/docs/ai-agent.md
@@ -89,7 +89,7 @@ Every turn, Mako injects a compact index of every skill plus the top-3 auto-retr
 
 Mako runs a **single unified agent**, not a fleet of separate agents. Capability is loaded dynamically: the agent switches *expertise modes* mid-conversation via the `enable_mode` tool, and each mode unlocks a domain-specific toolset plus guidance. A set of core tools (memory, skills, search, web access, version history, planning, mode-switching) is always available regardless of mode.
 
-On a fresh request the default mode is picked from what you're looking at — a dashboard view opens in **Dashboard**, the flow editor in **Sync Flow**, an app in **React App**, a dbt file/job in **Transforms** — otherwise **Query**. The agent then switches as the task demands.
+On a fresh request the default mode is picked from what you're looking at — a dashboard view opens in **Dashboard**, the flow editor in **Sync Flow**, an app in **React App**, a dbt file/job in **Transforms**, a notebook in **Notebook** — otherwise **Query**. The agent then switches as the task demands.
 
 | Mode | Does |
 |------|------|
@@ -98,6 +98,7 @@ On a fresh request the default mode is picked from what you're looking at — a 
 | **Sync Flow** | Configure database-to-database sync flows, query templates, and schema mapping |
 | **React App** | Build [React apps](/apps/) wired to workspace data — edit files, add dependencies, create data bindings |
 | **Transforms** | Build and run [dbt transformations](/transforms/) — edit project files, compile, test, and run models against the warehouse |
+| **Notebook** | Build [notebooks](/notebooks/) — add SQL/Python/Markdown cells, run SQL against data sources and Python on the managed kernel, iterate on results |
 | **Explore** | Read-only investigation across connections, consoles, dashboards, and memory |
 
 `Explore` is read-only by design. Mode ids persist in chat history, so renames stay backward-compatible (the legacy `dbt` mode resolves to `transform`). Enabling a mode adds its tools — modes accumulate across a turn rather than replacing one another.

--- a/docs/src/content/docs/api-reference.md
+++ b/docs/src/content/docs/api-reference.md
@@ -331,6 +331,10 @@ React apps built inside the workspace ([Apps](/apps/)). Private apps are owner-o
 | `GET`    | `/api/workspaces/:wid/apps/:id/bindings/:bid/materialization`           | Poll a binding's materialization status                  |
 | `GET`    | `/api/workspaces/:wid/apps/:id/bindings/:bid/materialization/artifact`  | Stream the materialized Parquet artifact                 |
 
+## Notebooks
+
+Notebook CRUD, kernel sessions, executions, versions, presence, and the kernel's read-only data plane live under `/api/workspaces/:workspaceId/notebooks` and `…/notebook/*`. See [Notebooks](/notebooks/#api-surface) for the route table and the OpenAPI spec for full schemas.
+
 ## Public Shares
 
 Token-gated, **read-only** endpoints for published dashboard/app links. These are intentionally unauthenticated (no session or API key) and serve only materialized snapshots.

--- a/docs/src/content/docs/notebooks.md
+++ b/docs/src/content/docs/notebooks.md
@@ -1,0 +1,79 @@
+---
+title: Notebooks
+description: Cloud, collaborative data notebooks — SQL, Python, and Markdown cells with a managed kernel, credential-free data access, and full AI agent support.
+---
+
+Notebooks are ordered lists of cells that live in your workspace: **SQL** cells run against your database connections, **code** cells run Python on a managed cloud kernel, and **markdown** cells render as prose. They're durable, collaborative, and the AI agent can build and run them for you.
+
+## Cell Types
+
+| Type | Runs where | Notes |
+|------|-----------|-------|
+| `sql` | Control plane, through the [Query Runner](/query-runner/) driver layer | Set a `connectionId` (data source) per cell; no kernel involved |
+| `code` | Managed Python kernel | pandas, polars, numpy, pyarrow, matplotlib, plotly, duckdb, requests, and the `mako` SDK preinstalled |
+| `markdown` | Client | Prose, headings, explanation between analyses |
+
+Kernel state persists across runs — variables and imports carry over, so cells build on each other. Idle kernel sessions are stopped after 15 minutes (`KERNEL_SESSION_IDLE_MS`). Sessions are registered in a shared store (Redis when `REDIS_URL` is set), so in multi-instance deployments every API instance routes execution to the same kernel — no session affinity needed.
+
+## Reading Workspace Data from Python
+
+Code cells never hold database credentials. The kernel reads workspace data through the **`mako` Python SDK**, which proxies through the Mako API with a short-lived, read-only kernel token:
+
+```python
+import mako
+
+mako.sources.list()
+df = mako.sources.sql.read("warehouse", "select date, mrr from metrics.mrr")
+tbl = mako.sources.sql.read_arrow("warehouse", "select 1 as n")  # pyarrow.Table
+```
+
+Reads stream **Arrow IPC** back into pandas zero-copy. Queries must be read-only (`SELECT`/`WITH`) — the SDK fast-fails writes and the API is the authoritative enforcement point, applying row, byte, and time budgets. Pass `params=` for server-side parameter binding and `limit=` to cap rows. The endpoint is `POST /api/workspaces/:workspaceId/notebook/read`.
+
+## Collaboration & Persistence
+
+- **Durable storage** — in deployed environments, notebook documents live in GCS (`NOTEBOOK_GCS_BUCKET`); locally they fall back to an ephemeral filesystem store. Edits autosave; agent and human edits share one document.
+- **Presence** — open the same notebook as a teammate and you'll see live avatars, per-cell cursors, and soft-lock indicators, driven by a lightweight presence heartbeat.
+- **Outputs survive reload** — rendered outputs are persisted with cells. Large payloads (a matplotlib PNG, a wide HTML table) are offloaded to storage as *artifacts* and fetched back on demand (`GET …/notebooks/:id/artifacts/:artifactId`), so documents stay small and no output is ever dropped.
+- **Streaming runs** — executions stream outputs over SSE, and a run continues server-side even if your tab disconnects.
+- **Version history** — prior generations of the document can be listed, inspected, and restored (see the API surface below).
+
+## Building Notebooks with the AI Agent
+
+Notebooks have their own [expertise mode](/ai-agent/#expertise-modes) — opening a notebook tab defaults the agent to **Notebook** mode. The agent can create notebooks, add/edit/delete cells, run SQL cells against a data source, and run Python cells on the kernel, reading each run's stdout/result/error to iterate. Tools:
+
+`create_notebook`, `list_open_notebooks`, `read_notebook`, `add_notebook_cell`, `edit_notebook_cell`, `delete_notebook_cell`, `run_notebook_sql_cell`, `run_notebook_code_cell` — plus the SQL discovery tools (`list_connections`, `sql_list_tables`, `sql_inspect_table`, …) for finding data sources.
+
+Agent runs execute server-side against the durable document and live-update any open tabs. Agent SQL runs persist up to 200 result rows with the cell. Notebook tools are deliberately **not** exposed over the [MCP server](/mcp-server/) yet — authoring stays in-product until notebooks get a dedicated MCP surface.
+
+## Architecture
+
+The control plane stays on Cloud Run; Python execution runs on a separate **GKE kernel plane** where untrusted notebook/agent code is sandboxed under **gVisor**, with a warm pod pool that autoscales 0–5 nodes and a network policy restricting egress. Provisioning is scripted (plain `gcloud`/`kubectl`, idempotent) — see `deploy/notebook-kernels/README.md`.
+
+### Local Development
+
+`pnpm docker:up` starts a local sidecar kernel so `code` cells run on your machine. Configure in `.env`:
+
+```env
+KERNEL_PROVIDER=static
+KERNEL_GATEWAY_URL=http://localhost:8888
+NOTEBOOK_KERNEL_API_URL=http://host.docker.internal:8080
+```
+
+Deployed environments auto-detect the GKE provider instead; no static config needed.
+
+### API Surface
+
+| Route | Purpose |
+|-------|---------|
+| `GET/POST/PATCH/DELETE /api/workspaces/:id/notebooks[/:id]` | Notebook CRUD (rename, replace cells) |
+| `POST …/notebooks/:id/sessions` | Start (or return) the notebook's kernel session |
+| `GET …/notebooks/:id/sessions/current` | Session status |
+| `DELETE …/notebooks/:id/sessions/current` | Stop the kernel |
+| `POST …/notebooks/:id/executions` | Run code on the kernel (SSE stream) |
+| `POST …/notebook/read` | Read-only, budgeted data reads from the kernel (Arrow IPC) |
+| `GET …/notebook/sources` | Data sources visible to the kernel (backs `mako.sources.list()`) |
+| `GET …/notebooks/:id/versions[/:versionId]` | List / fetch prior generations of the document |
+| `POST …/notebooks/:id/versions/:versionId/restore` | Restore a prior generation as current |
+| `POST …/notebooks/:id/presence` | Presence heartbeat (avatars, per-cell cursors) |
+
+The cell schema is deliberately Deepnote-block-shaped; canonical `.deepnote` format support and richer block types are planned with the Git storage/interop slice.


### PR DESCRIPTION
## What

The notebooks feature (#692, plus fixes #710/#711 and durable sessions #712) shipped with zero Starlight coverage and left CLAUDE.md factually wrong. This PR:

**New page: `docs/notebooks.md`** (added to sidebar after Query Runner)
- Cell types (sql / code / markdown) and where each runs
- Credential-free data reads via the `mako` Python SDK (Arrow IPC, read-only guard, row/byte/time budgets, `params=`/`limit=`)
- Collaboration: GCS-durable docs, presence, artifact offload, SSE streaming runs, version history
- Agent **Notebook** expertise mode + tool list; note that notebook tools are excluded from the MCP bridge (per `bridge-policy.ts`)
- Architecture: GKE kernel plane, gVisor sandbox, 0–5 node autoscaling pool; local dev via `pnpm docker:up` sidecar + `KERNEL_*` env
- API surface table incl. `/notebook/sources` (#710), versions, presence
- Shared kernel-session registry via Redis (#712)

**`ai-agent.md`** — Notebook mode added to the expertise-modes table and the default-mode-selection sentence (registry.ts now has 7 modes; docs listed 6).

**`api-reference.md`** — Notebooks section pointing to the route table + OpenAPI spec.

**`CLAUDE.md`** (P0) — `pnpm docker:up` said "Start MongoDB"; docker-compose.yml now runs the notebook kernel sidecar and the dev DB is hosted Atlas. Fixed, added `KERNEL_PROVIDER`/`KERNEL_GATEWAY_URL`/`NOTEBOOK_KERNEL_API_URL` env vars, and updated the `REDIS_URL` comment (now also backs the kernel-session registry).

## Source-verified against
`api/src/agents/modes/registry.ts`, `api/src/agent-lib/tools/server-notebook-tools.ts` (MAX_SQL_ROWS=200), `api/src/mcp/bridge-policy.ts`, `api/src/services/kernel-session-store.ts`, `kernel-session.service.ts` (15-min idle TTL), `api/src/routes/notebook{s,-sessions,-data}.ts`, `deploy/notebook-kernels/provision.sh` (0–5 nodes, e2-highmem-4, gVisor), `packages/kernel-image/requirements.txt`, `packages/mako-sdk-py`, `docker-compose.yml`, `.env.example`.

Part of daily docs maintenance.