### PR TITLE
docs(notebooks): track out-of-band GCP account changes in provision.sh + README

### DIFF
--- a/deploy/notebook-kernels/README.md
+++ b/deploy/notebook-kernels/README.md
@@ -16,9 +16,18 @@ notebook/agent code under gVisor.
 | Artifact Registry repo | `mako` | hosts the `notebook-kernel` image |
 | GKE Standard cluster | `mako-notebooks` | kernel substrate (Workload Identity, Dataplane V2) |
 | gVisor node pool | `kernels` | high-mem, CPU-only, autoscales `0..5`, `runsc` sandbox |
-| GCS bucket | `<project>-notebook-artifacts` | notebook outputs + kernel snapshots |
-| IAM bindings | node SA | pull images + read/write the bucket |
+| GCS bucket | `<project>-notebook-artifacts` | notebook **documents** + outputs + snapshots |
+| Bucket object versioning | on that bucket | version history + overwrite protection |
+| IAM bindings — node SA | `<projnum>-compute@…` | pull images + read/write the bucket |
+| IAM bindings — **runtime SA** | `RUNTIME_SA` (prod) | `container.developer` (spawn kernels) + bucket `objectAdmin` |
+| Firewall | `mako-notebooks-cr-to-kernels` | Cloud Run subnet → kernel nodes `:8888` |
 | k8s namespace | `mako-notebooks` | quota + limits + warm pool + egress policy |
+
+> **These are the only out-of-repo account changes the notebook feature needs.**
+> `provision.sh` applies them all idempotently, so the account state is tracked
+> here rather than living only in someone's shell history. See
+> [Out-of-band account changes](#out-of-band-account-changes) for the exact
+> per-environment values.
 
 ## Prerequisites
 
@@ -31,15 +40,21 @@ notebook/agent code under gVisor.
 ```bash
 cd deploy/notebook-kernels
 
-# 1. Provision cloud resources (cluster, pool, bucket, registry, IAM).
-PROJECT_ID=revops-462013 REGION=europe-west1 ./provision.sh
+# 1. Provision cloud resources (cluster, pool, bucket + versioning, registry,
+#    node-SA IAM, runtime-SA IAM, firewall). Pass RUNTIME_SA in prod.
+PROJECT_ID=mako-ai-prod REGION=europe-west1 \
+  RUNTIME_SA=mako-runtime@mako-ai-prod.iam.gserviceaccount.com ./provision.sh
 
-# 2. Point kubectl at the new cluster.
-gcloud container clusters get-credentials mako-notebooks --region europe-west1
+# 2. Point kubectl at the new cluster (zonal — use --location).
+gcloud container clusters get-credentials mako-notebooks --location europe-west1-b
 
 # 3. Build + push the kernel image and apply manifests.
-PROJECT_ID=revops-462013 REGION=europe-west1 ./build-and-deploy.sh
+PROJECT_ID=mako-ai-prod REGION=europe-west1 ./build-and-deploy.sh
 ```
+
+> Environments: **`mako-ai-dev`** (PR previews) and **`mako-ai-prod`**
+> (production), both in `europe-west1`. Dev can omit `RUNTIME_SA` (its Cloud Run
+> runs as the already-broad default compute SA).
 
 ## Configuration (env vars, all optional)
 
@@ -54,8 +69,56 @@ PROJECT_ID=revops-462013 REGION=europe-west1 ./build-and-deploy.sh
 | `KERNEL_MIN_NODES` / `KERNEL_MAX_NODES` | `0` / `5` | provision |
 | `ARTIFACT_REPO` | `mako` | both |
 | `ARTIFACT_BUCKET` | `<project>-notebook-artifacts` | provision |
+| `RUNTIME_SA` | _(unset → skipped)_ | provision — Cloud Run runtime SA to grant (prod) |
+| `CLOUD_RUN_SUBNET` | `mako-subnet` | provision — Cloud Run egress subnet (firewall source) |
 | `IMAGE_NAME` | `notebook-kernel` | build-and-deploy |
 | `IMAGE_TAG` | current git short SHA | build-and-deploy |
+
+## Out-of-band account changes
+
+Everything the notebook feature needs beyond application code and k8s manifests
+— the GCP **account** mutations — is applied idempotently by `provision.sh`.
+This is the record of *what*, *why*, and the exact per-environment values, so no
+change lives only in someone's shell history.
+
+| Change | Command (idempotent) | dev (`mako-ai-dev`) | prod (`mako-ai-prod`) |
+|---|---|---|---|
+| Bucket object versioning | `storage buckets update gs://<bucket> --versioning` | `mako-ai-dev-notebook-artifacts` | `mako-ai-prod-notebook-artifacts` |
+| Runtime SA → GKE | `projects add-iam-policy-binding <proj> --role=roles/container.developer` | default compute SA _(already broad)_ | `mako-runtime@mako-ai-prod.iam.gserviceaccount.com` |
+| Runtime SA → bucket | `storage buckets add-iam-policy-binding gs://<bucket> --role=roles/storage.objectAdmin` | default compute SA _(already broad)_ | `mako-runtime@…` |
+| Node SA → registry + bucket | `add-iam-policy-binding … artifactregistry.reader` + `storage.objectAdmin` | `<projnum>-compute@…` | `<projnum>-compute@…` |
+| Firewall CR → kernels:8888 | `compute firewall-rules create mako-notebooks-cr-to-kernels …` | src `10.10.0.0/20` | src `10.0.0.0/24` |
+
+**Why dev needs no runtime-SA grants:** dev previews run Cloud Run as the
+*default compute SA*, which carries `roles/editor` — already covering GKE +
+bucket access. Prod runs as the dedicated least-privilege `mako-runtime@` SA, so
+each capability is an explicit grant. (That mismatch is exactly what caused the
+first prod notebook use to fail with `storage.objects.list denied` and a GKE
+`403` until the grants were added.)
+
+Re-apply for an environment (safe to re-run — every step is idempotent):
+
+```bash
+# prod — pass the dedicated runtime SA
+PROJECT_ID=mako-ai-prod REGION=europe-west1 \
+  RUNTIME_SA=mako-runtime@mako-ai-prod.iam.gserviceaccount.com \
+  ./provision.sh
+
+# dev — runtime SA is already broad, so RUNTIME_SA is optional
+PROJECT_ID=mako-ai-dev REGION=europe-west1 ./provision.sh
+```
+
+### Related settings already tracked in the repo
+
+For completeness — these live in version control, not in this out-of-band list:
+
+- **`NOTEBOOK_KERNEL_API_URL`** — set by `.github/workflows/deploy-app.yml` to
+  the service's **direct `run.app` URL**, so kernel pods reach the API bypassing
+  Cloudflare (which `1010`-blocks their non-browser requests from GCP IPs).
+- **`KERNEL_PROVIDER` / `KERNEL_GKE_ENDPOINT` / `KERNEL_GKE_CA_CERT` /
+  `NOTEBOOK_GCS_BUCKET` / `REDIS_URL`** — Cloud Run env, set in the deploy
+  workflow from repo vars/secrets. `REDIS_URL` also backs the durable kernel
+  session registry (`api/src/services/kernel-session-store.ts`).
 
 ## Security posture (baked into the manifests)
 
@@ -91,26 +154,22 @@ the autoscaler grows the `kernels` pool to fit demand.
 
 To turn it on, the Cloud Run `mako` service needs:
 
-**IAM** — the runtime SA may call the cluster's k8s API:
+**IAM** — the runtime SA needs `roles/container.developer` (call the k8s API to
+spawn/scale kernels) and `roles/storage.objectAdmin` on the notebook bucket.
+`provision.sh` applies both when `RUNTIME_SA` is set — see
+[Out-of-band account changes](#out-of-band-account-changes).
 
-```bash
-gcloud container clusters add-iam-policy-binding ...   # or, project-scoped:
-gcloud projects add-iam-policy-binding revops-462013 \
-  --member="serviceAccount:813928377715-compute@developer.gserviceaccount.com" \
-  --role="roles/container.developer"
-```
-
-**Env** (the endpoint is the in-VPC private one, reached over the existing
-`mako-vpc` egress; the CA authenticates it):
+**Env** — set by `.github/workflows/deploy-app.yml` from repo vars/secrets:
 
 ```bash
 KERNEL_PROVIDER=gke
-KERNEL_GKE_ENDPOINT=https://10.200.0.2
-KERNEL_GKE_CA_CERT=$(gcloud container clusters describe mako-notebooks \
-  --location europe-west1-b --format='value(masterAuth.clusterCaCertificate)')
+KERNEL_GKE_ENDPOINT=<vars.KERNEL_GKE_ENDPOINT>   # the cluster's API endpoint
+KERNEL_GKE_CA_CERT=<vars.KERNEL_GKE_CA_CERT>     # base64 cluster CA
+NOTEBOOK_GCS_BUCKET=<vars.NOTEBOOK_GCS_BUCKET>   # the notebook store bucket
+NOTEBOOK_KERNEL_API_URL=<direct run.app URL>     # kernel→API base, Cloudflare-bypassing
+REDIS_URL=<secrets.REDIS_URL>                    # durable session registry (multi-instance)
 # optional: KERNEL_NAMESPACE, KERNEL_POOL_DEPLOYMENT, KERNEL_ACQUIRE_TIMEOUT_MS,
-#           NOTEBOOK_KERNEL_SECRET (else falls back to SESSION_SECRET),
-#           NOTEBOOK_KERNEL_API_URL (kernel→API base for the mako SDK; defaults BASE_URL)
+#           KERNEL_TOKEN_TTL_SECONDS, NOTEBOOK_KERNEL_SECRET (else SESSION_SECRET)
 ```
 
 Without `KERNEL_PROVIDER`/endpoint the provider auto-detects: a configured GKE

--- a/deploy/notebook-kernels/provision.sh
+++ b/deploy/notebook-kernels/provision.sh
@@ -52,6 +52,15 @@ KERNEL_MAX_NODES="${KERNEL_MAX_NODES:-5}"
 # not a new one — the kernel image is just another tag under it.
 ARTIFACT_REPO="${ARTIFACT_REPO:-revops}"
 ARTIFACT_BUCKET="${ARTIFACT_BUCKET:-${PROJECT_ID}-notebook-artifacts}"
+# The Cloud Run runtime service account (the control-plane `mako` service runs
+# as this). It must reach the GKE cluster + the notebook bucket. Prod runs as a
+# dedicated least-privilege SA (e.g. `mako-runtime@<project>.iam...`); dev/
+# preview run as the default compute SA, which is already broad — so this is
+# OPTIONAL and skipped with a note when unset.
+RUNTIME_SA="${RUNTIME_SA:-}"
+# Cloud Run's VPC-egress subnet — the SOURCE range for kernel ingress on :8888.
+# (Distinct from KERNEL_SUBNET, which is the cluster's own subnet.)
+CLOUD_RUN_SUBNET="${CLOUD_RUN_SUBNET:-mako-subnet}"
 
 if [[ -z "${PROJECT_ID}" ]]; then
   echo "PROJECT_ID is not set and no gcloud default project is configured." >&2
@@ -137,7 +146,7 @@ else
   echo "✓ Node pool ${KERNEL_NODE_POOL} exists"
 fi
 
-# --- 6. GCS bucket for outputs + snapshots ----------------------------------
+# --- 6. GCS bucket for notebook docs + outputs + snapshots ------------------
 if ! gcloud storage buckets describe "gs://${ARTIFACT_BUCKET}" >/dev/null 2>&1; then
   echo "→ Creating GCS bucket ${ARTIFACT_BUCKET}"
   gcloud storage buckets create "gs://${ARTIFACT_BUCKET}" \
@@ -145,6 +154,11 @@ if ! gcloud storage buckets describe "gs://${ARTIFACT_BUCKET}" >/dev/null 2>&1; 
 else
   echo "✓ Bucket ${ARTIFACT_BUCKET} exists"
 fi
+# Object versioning keeps prior generations of notebook documents (the version-
+# history feature reads them) and protects offloaded cell outputs from an
+# accidental overwrite. Idempotent — enabling when already on is a no-op.
+gcloud storage buckets update "gs://${ARTIFACT_BUCKET}" --versioning --quiet >/dev/null
+echo "✓ Object versioning enabled on ${ARTIFACT_BUCKET}"
 
 # --- 7. IAM: let the node service account read images + use the bucket ------
 # Pools created without an explicit SA report "default"; in that case the nodes
@@ -163,6 +177,52 @@ gcloud artifacts repositories add-iam-policy-binding "${ARTIFACT_REPO}" \
 gcloud storage buckets add-iam-policy-binding "gs://${ARTIFACT_BUCKET}" \
   --member="serviceAccount:${NODE_SA}" \
   --role="roles/storage.objectAdmin" --quiet >/dev/null
+
+# --- 8. Cloud Run RUNTIME service account: reach GKE + the notebook bucket ---
+# The control-plane `mako` service (Cloud Run) drives the kernel plane and owns
+# the notebook store. Its runtime SA must (a) call the cluster's k8s API to
+# spawn/scale kernels and (b) read/write the notebook bucket. This is a DIFFERENT
+# SA from the node SA above. Prod runs as a dedicated least-privilege SA
+# (RUNTIME_SA); dev/preview run as the default compute SA (already broad), so
+# RUNTIME_SA is optional and skipped with a note when unset.
+if [[ -n "${RUNTIME_SA}" ]]; then
+  echo "→ Granting Cloud Run runtime SA ${RUNTIME_SA} GKE + bucket access (idempotent)"
+  gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+    --member="serviceAccount:${RUNTIME_SA}" \
+    --role="roles/container.developer" --condition=None --quiet >/dev/null
+  gcloud storage buckets add-iam-policy-binding "gs://${ARTIFACT_BUCKET}" \
+    --member="serviceAccount:${RUNTIME_SA}" \
+    --role="roles/storage.objectAdmin" --quiet >/dev/null
+else
+  echo "! RUNTIME_SA not set — skipping Cloud Run runtime-SA grants."
+  echo "  In prod, set RUNTIME_SA=<cloud-run-sa> to grant roles/container.developer"
+  echo "  (spawn kernels) + roles/storage.objectAdmin on the bucket (notebook store)."
+fi
+
+# --- 9. Firewall: let Cloud Run reach kernel gateways on :8888 --------------
+# Cloud Run egresses into ${NETWORK} via ${CLOUD_RUN_SUBNET}; kernel pods listen
+# on :8888. Allow that specific path (the k8s NetworkPolicy is the second
+# layer). The source is the Cloud Run subnet range; the target is the kernel
+# cluster's node tag (GKE auto-tags nodes `gke-<cluster>-<hash>-node`).
+FW_NAME="mako-notebooks-cr-to-kernels"
+if gcloud compute firewall-rules describe "${FW_NAME}" >/dev/null 2>&1; then
+  echo "✓ Firewall ${FW_NAME} exists"
+else
+  CR_RANGE="$(gcloud compute networks subnets describe "${CLOUD_RUN_SUBNET}" \
+    --region="${REGION}" --format='value(ipCidrRange)' 2>/dev/null || true)"
+  NODE_TAG="$(gcloud compute firewall-rules list \
+    --filter="network=${NETWORK} AND name~^gke-${CLUSTER}-" \
+    --format='value(targetTags[0])' 2>/dev/null | head -1)"
+  if [[ -n "${CR_RANGE}" && -n "${NODE_TAG}" ]]; then
+    echo "→ Creating firewall ${FW_NAME} (${CR_RANGE} → ${NODE_TAG}:8888)"
+    gcloud compute firewall-rules create "${FW_NAME}" \
+      --network="${NETWORK}" --direction=INGRESS --action=ALLOW \
+      --rules=tcp:8888 --source-ranges="${CR_RANGE}" --target-tags="${NODE_TAG}"
+  else
+    echo "! Skipping ${FW_NAME}: could not resolve Cloud Run range (${CR_RANGE:-?})"
+    echo "  or the kernel node tag (${NODE_TAG:-?}). Create it once the cluster exists."
+  fi
+fi
 
 cat <<EOF
 


### PR DESCRIPTION
## Why

Standing up notebooks in prod needed several **GCP account** changes applied by hand — service-account grants, bucket object-versioning, a firewall rule — that lived only in shell history. The dev↔prod service-account mismatch (dev's default compute SA is broad; prod's `mako-runtime@` is least-privilege) meant the first prod notebook use failed with `storage.objects.list denied` and a GKE `403` until those grants were spotted and added. This folds every out-of-band change into the existing idempotent provisioning, so the account state is reproducible from the repo instead of tribal knowledge.

## `provision.sh` (still fully idempotent)

Adds, guarded/no-op on re-run:
- **Bucket object versioning** — `buckets update --versioning` (backs version history + protects offloaded outputs).
- **Runtime-SA grants** via a new `RUNTIME_SA` var — `roles/container.developer` (spawn/scale kernels on GKE) + bucket `roles/storage.objectAdmin` (notebook store). Skipped with a clear note when unset, since dev runs Cloud Run as the already-broad default compute SA.
- **Cloud Run → kernels `:8888` firewall** (`mako-notebooks-cr-to-kernels`) — derives the Cloud Run subnet range and the GKE node tag automatically.

## `README.md`

- New **"Out-of-band account changes"** section: a table of *what / why / dev value / prod value* per change, the "why dev needs no runtime grants" explanation, per-env re-apply commands, and a note on the related settings already tracked in the repo (`NOTEBOOK_KERNEL_API_URL`, `REDIS_URL`, kernel env).
- Refreshed the stale `revops-462013` references to `mako-ai-dev` / `mako-ai-prod`.

## Notes

- Docs + shell only — no application code. `bash -n` clean.
- Re-apply, e.g.: `PROJECT_ID=mako-ai-prod REGION=europe-west1 RUNTIME_SA=mako-runtime@mako-ai-prod.iam.gserviceaccount.com ./provision.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
