### PR TITLE
fix(notebooks): agent-created notebook appears in the list + opens in the editor

### DIFF
--- a/api/src/agent-lib/tools/server-notebook-tools.ts
+++ b/api/src/agent-lib/tools/server-notebook-tools.ts
@@ -102,6 +102,20 @@ export function createNotebookServerTools({
     return updated.version;
   };
 
+  // Ask the window viewing this chat to open the notebook in the editor. The
+  // client tool that used to do this on create no longer runs (notebook tools
+  // are server-executed now), so the server signals the intent instead.
+  const publishOpenIntent = (notebookId: string, title: string) => {
+    if (!chatId) return;
+    publishRealtimeEvent(workspaceId, {
+      type: "chat.ui-intent",
+      chatId,
+      intent: "open_notebook",
+      notebookId,
+      title,
+    });
+  };
+
   return {
     create_notebook: tool({
       description:
@@ -120,6 +134,8 @@ export function createNotebookServerTools({
           clientId: agentClientId,
           origin: "agent",
         });
+        // Surface it: refresh the explorer list + open it in the editor.
+        publishOpenIntent(doc.id, doc.name);
         return { success: true, notebookId: doc.id, name: doc.name, cellCount: 0 };
       },
     }),

--- a/api/src/services/realtime.service.ts
+++ b/api/src/services/realtime.service.ts
@@ -49,11 +49,22 @@ export type RealtimeEvent =
       durationMs?: number;
       error?: string;
     }
+  // A server-executed agent tool asks the window viewing this chat to open a
+  // tab (e.g. after creating a console/notebook the user can't otherwise see or
+  // open, since the tool ran server-side). Addressed to `chatId`; only the
+  // window on that chat acts.
   | {
       type: "chat.ui-intent";
       chatId: string;
       intent: "open_console";
       consoleId: string;
+    }
+  | {
+      type: "chat.ui-intent";
+      chatId: string;
+      intent: "open_notebook";
+      notebookId: string;
+      title?: string;
     }
   | {
       type: "chat.activity";

--- a/app/src/store/realtimeStore.ts
+++ b/app/src/store/realtimeStore.ts
@@ -27,6 +27,7 @@ import { useAppStore } from "./appStore";
 import { useDashboardStore } from "./dashboardStore";
 import { useDbtStore } from "./dbtStore";
 import { useNotebookStore } from "./notebookStore";
+import { focusNotebookTab } from "../notebook-runtime/shell";
 import { useNotebookPresenceStore } from "./notebookPresenceStore";
 import { computeDashboardStateHash } from "../utils/stateHash";
 import { decideRemoteApply } from "./lib/remoteApplyGate";
@@ -58,6 +59,13 @@ export type RealtimeEvent =
       chatId: string;
       intent: "open_console";
       consoleId: string;
+    }
+  | {
+      type: "chat.ui-intent";
+      chatId: string;
+      intent: "open_notebook";
+      notebookId: string;
+      title?: string;
     }
   | { type: "chat.activity"; chatId: string; state: "streaming" | "idle" }
   | {
@@ -386,8 +394,20 @@ export const useRealtimeStore = create<RealtimeStore>()(
       // other chats replay their intents on reattach (console restore).
       if (!get().activeChatId || event.chatId !== get().activeChatId) return;
       const workspaceId = get().workspaceId;
-      if (!workspaceId || event.intent !== "open_console") return;
+      if (!workspaceId) return;
 
+      // A server-executed create_notebook ran: refresh the explorer list so the
+      // new notebook appears, and open it in the editor (the client tool that
+      // used to do this no longer runs now that notebook tools are
+      // server-executed).
+      if (event.intent === "open_notebook") {
+        const nb = useNotebookStore.getState();
+        void nb.loadNotebooks();
+        focusNotebookTab(event.notebookId, event.title || "Untitled notebook");
+        return;
+      }
+
+      if (event.intent !== "open_console") return;
       const consoleStore = useConsoleStore.getState();
       void (async () => {
         if (consoleStore.tabs[event.consoleId]) {


### PR DESCRIPTION
## Problem

When an agent creates a notebook, it doesn't appear in the left explorer list until a page refresh, and it isn't opened in the editor.

This is a **regression from the double-create fix** (marking notebook agent tools server-executed to stop the duplicate notebook). The client-side `create_notebook` handler used to call `focusNotebookTab(...)` — which both opened the tab and surfaced the notebook — and that handler no longer runs now that the tools execute server-side.

## Fix

Reuse the existing **`chat.ui-intent`** mechanism (exactly as `open_console` already does), so it's small and consistent:

- **`realtime.service.ts`** — add an `open_notebook` variant to `chat.ui-intent` (`notebookId` + `title`).
- **`realtimeStore.ts`** — mirror the type; the intent handler, on `open_notebook`, refreshes the explorer list (`loadNotebooks`) **and** opens the notebook (`focusNotebookTab`).
- **`server-notebook-tools.ts`** — `create_notebook` publishes the `open_notebook` intent alongside the existing `notebook.updated` poke.

Gated on `chatId === activeChatId`, so only the window that asked the agent opens it; other open windows still get the `notebook.updated` list refresh.

## Result

Ask the agent to create a notebook → it appears in the left list immediately (no refresh) and opens in the editor.

API typecheck + app typecheck + lint all clean. No REST/OpenAPI change (these are SSE event types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
