### PR TITLE
fix(notebooks): open agent-created notebook off the chat stream (reliable on prod)

### DIFF
--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -92,6 +92,7 @@ import { ToolDetailsDialog } from "./chat/ToolDetailsDialog";
 import { useChatSessionLoader } from "./chat/hooks/useChatSessionLoader";
 import { useQueuedPrompts } from "./chat/hooks/useQueuedPrompts";
 import { useChatScroll } from "./chat/hooks/useChatScroll";
+import { useNotebookAutoOpen } from "./chat/hooks/useNotebookAutoOpen";
 import { ChatMessageRow, MessageVirtuosoList } from "./chat/ChatMessageRow";
 import { QueuedPromptList } from "./chat/QueuedPrompts";
 import { ChatInputArea } from "./chat/ChatInputArea";
@@ -514,6 +515,10 @@ const Chat: React.FC<ChatProps> = ({
   // re-bound to a fresh Chat instance whenever chatId changes.
   const resumeStreamRef = useRef(resumeStream);
   resumeStreamRef.current = resumeStream;
+
+  // Open + list-refresh a notebook the agent creates, driven off the chat
+  // stream (reliable) rather than the ephemeral workspace realtime poke.
+  useNotebookAutoOpen(messages);
 
   // Latest status for use inside stable event-listener / callback closures
   // (the wake handler and onError) without re-installing listeners every turn.

--- a/app/src/components/chat/hooks/useNotebookAutoOpen.ts
+++ b/app/src/components/chat/hooks/useNotebookAutoOpen.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from "react";
+import type { UIMessage } from "ai";
+
+import { useNotebookStore } from "../../../store/notebookStore";
+import { focusNotebookTab } from "../../../notebook-runtime/shell";
+import { toolNameFromPartType } from "../tool-presentation";
+
+/**
+ * Surface a notebook the agent just created — off the **chat stream**, not the
+ * workspace realtime channel.
+ *
+ * `create_notebook` runs server-side (headless), so the browser only learns of
+ * the new notebook through a poke. The workspace realtime channel (Redis
+ * pub/sub) is ephemeral: on prod's multi-instance Cloud Run it's easily missed
+ * (the client's realtime SSE can reconnect mid-run, and there's no replay), so
+ * the new notebook wouldn't appear or open until a page reload. The chat stream,
+ * by contrast, is the SSE the user is actively watching, and it carries the
+ * tool's *result* (`{ notebookId, name }`) — a reliable signal.
+ *
+ * When a `create_notebook` tool part settles with a notebook id, refresh the
+ * explorer list and open the notebook — once per tool call.
+ */
+export function useNotebookAutoOpen(messages: UIMessage[]): void {
+  const handled = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    for (const message of messages) {
+      if (message.role !== "assistant") continue;
+      for (const part of message.parts ?? []) {
+        const partType = part.type as string;
+        if (toolNameFromPartType(partType) !== "create_notebook") continue;
+
+        const record = part as Record<string, unknown>;
+        if (record.state !== "output-available") continue;
+
+        const toolCallId = record.toolCallId as string | undefined;
+        if (!toolCallId || handled.current.has(toolCallId)) continue;
+
+        const output = record.output as
+          | { success?: boolean; notebookId?: string; name?: string }
+          | undefined;
+        if (!output?.notebookId) continue;
+
+        handled.current.add(toolCallId);
+        void useNotebookStore.getState().loadNotebooks();
+        focusNotebookTab(output.notebookId, output.name || "Untitled notebook");
+      }
+    }
+  }, [messages]);
+}


### PR DESCRIPTION
## Problem

[#715](https://github.com/mako-ai/mako/pull/715) is deployed, but on **prod** an agent-created notebook still doesn't appear in the explorer list or open in the editor (works only after a page reload).

Root cause is the **mechanism**, not the deploy: #715 drives create→open→list via the **workspace realtime channel** — ephemeral Redis pub/sub across many stateless Cloud Run instances. The agent run and the client's realtime SSE can be on different instances, and a routine mid-run SSE reconnect **drops the poke with no replay**. So the `chat.ui-intent` (open) and `notebook.updated` (list refresh) never land. The console `open_console` path shares this fragility; notebooks just surfaced it.

## Fix

Drive it off the **chat stream** — the SSE the user is actively watching, which *reliably* carries the `create_notebook` tool **result** (`{ notebookId, name }`):

- **`useNotebookAutoOpen.ts`** (new hook) — watches the chat `messages`; when a `create_notebook` tool part settles with a `notebookId`, refresh the explorer list (`loadNotebooks`) and open the notebook (`focusNotebookTab`), deduped per tool call.
- **`Chat.tsx`** — `useNotebookAutoOpen(messages)`.

**Idempotent with #715:** if the realtime poke *does* arrive, `focusNotebookTab` just focuses the already-open tab. So the chat-stream path is the reliable primary; #715's realtime path stays as a harmless fallback.

## Notes

- App typecheck + lint clean. 2 files, ~55 lines.
- Broader flag (separate): if the workspace realtime channel is unreliable on prod, it also affects live agent edits to open notebooks, presence, and collaboration — worth a look at prod Redis pub/sub health.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
