### PR TITLE
fix(realtime): deliver Redis pub/sub messages (presence, pokes) in multi-instance prod

### DIFF
--- a/api/src/services/pubsub.service.redis.test.ts
+++ b/api/src/services/pubsub.service.redis.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Redis-mode pub/sub adapter test. Guards against the class of bug where a
+ * `new Redis() as unknown as Subscriber` cast type-checks but silently drops
+ * every message — ioredis routes messages to its "message" event, not to the
+ * subscribe() callback that resumable-stream's node-redis-shaped interface
+ * expects. In-process coverage (realtime.service.test.ts) cannot catch this.
+ *
+ * Run with a disposable Redis, e.g.:
+ *   docker run -d --rm -p 6399:6379 redis:7-alpine
+ *   TEST_REDIS_URL=redis://127.0.0.1:6399 \
+ *     pnpm --filter api exec tsx src/services/pubsub.service.redis.test.ts
+ *
+ * No-ops when TEST_REDIS_URL is unset so CI without Redis stays green. The
+ * factories read REDIS_URL at call time, so it is set inside main() (below the
+ * skip guard) rather than at module load.
+ */
+import assert from "node:assert/strict";
+
+import {
+  createPubSubPublisher,
+  createPubSubSubscriber,
+  getPubSubBackendKind,
+} from "./pubsub.service";
+
+const delay = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+
+async function main() {
+  const testRedisUrl = process.env.TEST_REDIS_URL;
+  if (!testRedisUrl) {
+    console.info("⏭  TEST_REDIS_URL unset — skipping Redis-mode pub/sub test");
+    return;
+  }
+  process.env.REDIS_URL = testRedisUrl;
+
+  assert.equal(
+    getPubSubBackendKind(),
+    "redis",
+    "must select the Redis backend",
+  );
+
+  const pub = createPubSubPublisher();
+  const sub = createPubSubSubscriber();
+
+  // One subscriber, many channels, each with its own handler — the pattern
+  // realtime.service uses (a shared subscriber fanning out per workspace).
+  const gotA: string[] = [];
+  const gotB: string[] = [];
+  await sub.subscribe("mako:test:A", m => gotA.push(m));
+  await sub.subscribe("mako:test:B", m => gotB.push(m));
+  await delay(150);
+
+  await pub.publish("mako:test:A", "a1");
+  await pub.publish("mako:test:B", "b1");
+  await pub.publish("mako:test:A", "a2");
+  await delay(150);
+
+  assert.deepEqual(gotA, ["a1", "a2"], "channel A messages delivered in order");
+  assert.deepEqual(gotB, ["b1"], "channel B delivered without cross-talk");
+
+  await sub.unsubscribe("mako:test:A");
+  await delay(50);
+  await pub.publish("mako:test:A", "a3");
+  await delay(100);
+  assert.deepEqual(gotA, ["a1", "a2"], "no delivery after unsubscribe");
+
+  // Publisher key ops (used by resumable-stream) must survive the ioredis
+  // positional-arg translation of `set(key, value, { EX })`.
+  await pub.set("mako:test:k", "v", { EX: 60 });
+  assert.equal(
+    await pub.get("mako:test:k"),
+    "v",
+    "set/get round-trips with EX",
+  );
+  const n = await pub.incr("mako:test:counter");
+  assert.equal(typeof n, "number", "incr returns a number");
+
+  console.info(
+    "✅ Redis-mode pub/sub: delivers, isolates channels, unsubscribes, set/get/incr ok",
+  );
+}
+
+main()
+  .then(() => {
+    // Redis sockets keep the event loop alive; exit deterministically.
+    // eslint-disable-next-line no-process-exit
+    process.exit(0);
+  })
+  .catch(error => {
+    console.error("❌ Redis-mode pub/sub test failed:", error);
+    // eslint-disable-next-line no-process-exit
+    process.exit(1);
+  });

--- a/api/src/services/pubsub.service.ts
+++ b/api/src/services/pubsub.service.ts
@@ -181,6 +181,55 @@ export function getPubSubBackendKind(): "redis" | "memory" {
   return process.env.REDIS_URL ? "redis" : "memory";
 }
 
+// resumable-stream's Publisher/Subscriber interfaces are node-redis-shaped:
+// `subscribe(channel, cb)` must invoke `cb` for every message, and
+// `set(key, value, { EX })` takes an options object. ioredis differs on both —
+// its `subscribe` callback only signals subscription confirmation (messages
+// arrive via the "message" event) and its `set` takes positional `"EX", secs`.
+// These thin adapters bridge ioredis to the interface; a bare
+// `new Redis() as unknown as Subscriber` cast type-checks but silently drops
+// every subscribed message in Redis mode (workspace realtime + cross-instance
+// stream resume), which is exactly the outage this comment prevents recurring.
+
+/** Wrap an ioredis connection as a resumable-stream Publisher. */
+function redisPublisher(redis: Redis): Publisher {
+  return {
+    connect: async () => undefined,
+    publish: (channel: string, message: string) =>
+      redis.publish(channel, message),
+    set: async (key: string, value: string, options?: { EX?: number }) =>
+      options?.EX != null
+        ? redis.set(key, value, "EX", options.EX)
+        : redis.set(key, value),
+    get: (key: string) => redis.get(key),
+    incr: (key: string) => redis.incr(key),
+  };
+}
+
+/**
+ * Wrap an ioredis connection as a resumable-stream Subscriber. ioredis delivers
+ * messages through a single "message" event, so route it to per-channel
+ * handlers — mirroring the in-process impl (one handler per channel, last wins,
+ * which matches how both consumers subscribe each channel exactly once).
+ */
+function redisSubscriber(redis: Redis): Subscriber {
+  const handlers = new Map<string, (message: string) => void>();
+  redis.on("message", (channel: string, message: string) => {
+    handlers.get(channel)?.(message);
+  });
+  return {
+    connect: async () => undefined,
+    subscribe: async (channel: string, callback: (message: string) => void) => {
+      handlers.set(channel, callback);
+      await redis.subscribe(channel);
+    },
+    unsubscribe: async (channel: string) => {
+      handlers.delete(channel);
+      await redis.unsubscribe(channel);
+    },
+  };
+}
+
 /**
  * Create a publisher handle. Redis mode: a fresh connection the caller owns.
  * Memory mode: a handle onto the shared in-process backend.
@@ -188,10 +237,9 @@ export function getPubSubBackendKind(): "redis" | "memory" {
 export function createPubSubPublisher(): Publisher {
   const redisUrl = process.env.REDIS_URL;
   if (redisUrl) {
-    return attachRedisErrorListener(
-      new Redis(redisUrl),
-      "publisher",
-    ) as unknown as Publisher;
+    return redisPublisher(
+      attachRedisErrorListener(new Redis(redisUrl), "publisher"),
+    );
   }
   return getInMemoryPubSub().createPublisher();
 }
@@ -204,10 +252,9 @@ export function createPubSubPublisher(): Publisher {
 export function createPubSubSubscriber(): Subscriber {
   const redisUrl = process.env.REDIS_URL;
   if (redisUrl) {
-    return attachRedisErrorListener(
-      new Redis(redisUrl),
-      "subscriber",
-    ) as unknown as Subscriber;
+    return redisSubscriber(
+      attachRedisErrorListener(new Redis(redisUrl), "subscriber"),
+    );
   }
   return getInMemoryPubSub().createSubscriber();
 }


### PR DESCRIPTION
## The bug

On prod, concurrent-edit **presence bubbles never appear** and block **pokes never arrive** — while dev works fine. Root cause is in the shared pub/sub backend, and it also degrades **cross-instance resumable chat-stream resume**.

`createPubSubSubscriber()` (in `api/src/services/pubsub.service.ts`) returned:

```ts
new Redis(url) as unknown as Subscriber
```

But **ioredis** and resumable-stream's **node-redis-shaped** `Subscriber` interface disagree on the subscribe contract:

| | `subscribe(channel, cb)` semantics |
|---|---|
| resumable-stream interface | `cb` is called **for every message** |
| ioredis | `cb` is called **once**, on subscription *confirmation* (`(err, count)`); messages arrive via the `"message"` event |

The `as unknown as` cast silenced the mismatch. So in **Redis mode** (prod, multi-instance) every subscribed event was silently dropped. Dev works because `REDIS_URL` is unset there → the in-process implementation, which honors the contract.

A bare `PING` health check passes the whole time — only the **publish→subscribe round-trip** is broken, which is why this hid so long.

### Proof

Counterfactual against a real Redis: the old raw-cast handler received `[null]` (ioredis's confirmation callback) and **never** the published message. The new adapter delivers correctly. Verified with a throwaway `redis:7-alpine`.

## The fix

Replace both raw casts with faithful ioredis→interface adapters:

- **Subscriber** routes ioredis's single `"message"` event to per-channel handlers (mirroring the in-process impl — one handler per channel, matching how both consumers subscribe each channel exactly once).
- **Publisher** translates `set(key, value, { EX })` → ioredis's positional `"EX", secs` form. Same latent cast bug on the publisher side; resumable-stream relies on `set` for key TTLs.

Publish itself was already fine (`publish`/`get`/`incr` match ioredis), which is why pokes were being *published* (200s) but never *received*.

## Test

Adds `pubsub.service.redis.test.ts` — a Redis-mode regression test that proves messages are delivered, channels stay isolated, unsubscribe stops delivery, and `set`/`get`/`incr` work. It **skips when `TEST_REDIS_URL` is unset** so CI without Redis stays green; run locally with:

```
docker run -d --rm -p 6399:6379 redis:7-alpine
TEST_REDIS_URL=redis://127.0.0.1:6399 pnpm --filter api exec tsx src/services/pubsub.service.redis.test.ts
```

The in-process `realtime.service.test.ts` still passes (couldn't catch this — it never exercises Redis mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)