### PR TITLE
fix(notebooks): open the notebook on a shared /n/:id deep link

### DIFF
--- a/app/src/components/UrlSync.test.tsx
+++ b/app/src/components/UrlSync.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+/**
+ * UrlSync hydration — deep-linking a notebook URL.
+ *
+ * Regression coverage for "a shared /n/:id link opens a different object
+ * (a console, another notebook) or redirects to root". The URL→tab mapping in
+ * lib/tab-routing.ts is compile-exhaustive over TabKind, but UrlSync's
+ * hydration is a hand-written if-chain that is NOT — the `notebook` branch was
+ * missing, so `/n/:id` matched nothing, hydration no-op'd, and the sync effect
+ * then rewrote the address bar to the persisted active tab's URL. This asserts
+ * hydration actually opens the notebook tab for a /n/:id deep link.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+
+const h = vi.hoisted(() => {
+  const consoleState = {
+    loadConsole: vi.fn(),
+    openTab: vi.fn(),
+    setActiveTab: vi.fn(),
+    activeTabId: null as string | null,
+    tabs: {} as Record<string, unknown>,
+  };
+  return {
+    focusNotebookTab: vi.fn(),
+    setLeftPane: vi.fn(),
+    captureOAuthReturn: vi.fn(),
+    consoleState,
+    useConsoleStore: Object.assign(
+      (selector: (s: typeof consoleState) => unknown) => selector(consoleState),
+      { getState: () => consoleState },
+    ),
+  };
+});
+
+vi.mock("../notebook-runtime/shell", () => ({
+  focusNotebookTab: h.focusNotebookTab,
+}));
+vi.mock("../contexts/workspace-context", () => ({
+  useWorkspace: () => ({ currentWorkspace: { id: "ws1" } }),
+}));
+vi.mock("../contexts/auth-context", () => ({
+  useAuth: () => ({ user: { id: "u1" } }),
+}));
+vi.mock("../store/consoleStore", () => ({
+  useConsoleStore: h.useConsoleStore,
+  selectTabBySettingsSection: () => () => undefined,
+}));
+vi.mock("../store/uiStore", () => ({
+  useUIStore: (
+    selector: (s: { leftPane: string; setLeftPane: unknown }) => unknown,
+  ) => selector({ leftPane: "consoles", setLeftPane: h.setLeftPane }),
+}));
+vi.mock("../store/mcpStore", () => ({
+  useMcpStore: {
+    getState: () => ({ captureOAuthReturn: h.captureOAuthReturn }),
+  },
+}));
+
+// Stores/shells only touched by branches the notebook path never enters; stub
+// their named exports so module import resolves without pulling real deps.
+vi.mock("../store/dashboardStore", () => ({
+  useDashboardStore: { getState: () => ({}) },
+}));
+vi.mock("../store/appStore", () => ({ useAppStore: { getState: () => ({}) } }));
+vi.mock("../store/dbtStore", () => ({ useDbtStore: { getState: () => ({}) } }));
+vi.mock("../dashboard-runtime/shell", () => ({
+  focusDashboardDataSourceTab: vi.fn(),
+}));
+vi.mock("../app-runtime/shell", () => ({
+  focusAppBindingTab: vi.fn(),
+  focusAppFileTab: vi.fn(),
+  focusAppTab: vi.fn(),
+}));
+vi.mock("../dbt-runtime/shell", () => ({
+  focusDbtConsoleTab: vi.fn(),
+  focusDbtFileTab: vi.fn(),
+  focusDbtJobTab: vi.fn(),
+  focusDbtRunsTab: vi.fn(),
+}));
+
+import { UrlSync } from "./UrlSync";
+
+describe("UrlSync hydration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.consoleState.activeTabId = null;
+    h.consoleState.tabs = {};
+  });
+
+  it("opens the notebook tab when deep-linking /n/:id", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/n/ce545d56-98d3-4d13-b1b5-0fd640fc1f5c",
+    );
+
+    render(<UrlSync />);
+
+    await waitFor(() =>
+      expect(h.focusNotebookTab).toHaveBeenCalledWith(
+        "ce545d56-98d3-4d13-b1b5-0fd640fc1f5c",
+        expect.any(String),
+      ),
+    );
+    expect(h.setLeftPane).toHaveBeenCalledWith("notebooks");
+  });
+});

--- a/app/src/components/UrlSync.tsx
+++ b/app/src/components/UrlSync.tsx
@@ -23,6 +23,7 @@ import {
 import { useDbtStore } from "../store/dbtStore";
 import { useMcpStore } from "../store/mcpStore";
 import { focusDashboardDataSourceTab } from "../dashboard-runtime/shell";
+import { focusNotebookTab } from "../notebook-runtime/shell";
 import {
   TAB_DEEP_LINK_PATTERNS,
   decodePathSegments,
@@ -107,6 +108,7 @@ export function UrlSync() {
     const dbtJobMatch = path.match(TAB_DEEP_LINK_PATTERNS["dbt-job"]);
     const dbtRunsMatch = path.match(TAB_DEEP_LINK_PATTERNS["dbt-runs"]);
     const dbtConsoleMatch = path.match(TAB_DEEP_LINK_PATTERNS["dbt-console"]);
+    const notebookMatch = path.match(TAB_DEEP_LINK_PATTERNS.notebook);
     const planMatch = path.match(TAB_DEEP_LINK_PATTERNS.plan);
     const settingsSectionMatch = path.match(TAB_DEEP_LINK_PATTERNS.settings);
     const settingsMatch = path.match(/^\/settings\/?$/);
@@ -314,6 +316,13 @@ export function UrlSync() {
       const projectId = dbtConsoleMatch[1];
       setLeftPane("dbt");
       focusDbtConsoleTab(projectId, "Console");
+    } else if (notebookMatch) {
+      // /n/:notebookId — focusNotebookTab dedupes against an existing tab and
+      // activates it. NotebookRenderer loads the doc by id and syncs the real
+      // name onto the tab, so a placeholder title is fine on cold load.
+      const notebookId = notebookMatch[1];
+      setLeftPane("notebooks");
+      focusNotebookTab(notebookId, "Untitled notebook");
     } else if (planMatch) {
       // /p/:chatId — plans only exist within a chat session, so we can only
       // focus a plan tab that is already present in this browser's state.


### PR DESCRIPTION
## The bug

Clicking a shared notebook link (`/n/:id`) on a cold page load lands on a **different object** — a console, another notebook — or **redirects to `/`**. (You also see a stale `/chats/:id → 404` in the console from restored UI state.)

## Root cause

`UrlSync`'s hydration effect handles every deep-linkable tab kind — console, dashboard, app, dbt, plan, settings — **except `notebook`**. The URL↔tab mapping in `lib/tab-routing.ts` is **compile-exhaustive** over `TabKind` (so the pattern exists), but the hydration if-chain in `UrlSync.tsx` is hand-written and **not** exhaustiveness-checked, so the notebook branch was simply never added.

So on a fresh load of `/n/:id`:
1. Hydration matches no branch → does nothing → sets `isHydrated = true`.
2. The **sync** effect then derives the URL from the **persisted active tab** and `history.replaceState`s the address bar — to the last-open console/notebook, or `/` when nothing was persisted.

The notebook only ever opened via in-session paths (explorer click, agent auto-open from the chat stream) — never from a cold deep link.

## Fix

Add the missing hydration branch: match `/n/:id`, open the notebooks pane, and `focusNotebookTab()` (dedupes an already-open tab and activates it). `NotebookRenderer` loads the doc by id and syncs the real name onto the tab, so a placeholder title is fine on cold load — identical to the `app`/`dashboard` branches.

## Test

Adds a jsdom test (`UrlSync.test.tsx`) that renders `UrlSync` at `/n/:id` and asserts the notebook tab is opened + the notebooks pane is focused. **Verified it fails without the branch** (counterfactual checked).

## Note

The underlying class of bug — hydration silently missing a `TabKind` — isn't compile-guarded the way the mapping is. A follow-up could make hydration exhaustive over `TabKind` so this can't recur; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)