### PR TITLE
docs: cover #720 budgeted tool working set (tool paging, deferred tiers)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,18 @@ belongs in git-versioned system skills under `api/src/agent-skills/**`, not in
 always-on prompt literals. See `.cursor/rules/35-agent-prompts.mdc` and
 `api/src/agent-skills/README.md` before changing prompt content.
 
+## Agent tools: tier classification is mandatory
+
+The agent sends a _budgeted working set_ of tools to the provider, not every
+registered tool (`api/src/agent-lib/tool-catalog.ts`). Every built-in tool must
+be classified as **core** (always active), **mode** (in a mode's `toolNames` in
+`api/src/agents/modes/registry.ts`), or **deferred**
+(`DEFERRED_BUILTIN_TOOL_DOMAINS`) — the tier-policy test in
+`api/src/agents/modes/tool-working-set.test.ts` fails on unclassified tools.
+An unclassified tool is registered but never reaches the model (silently dead).
+MCP tools are always deferred; they activate via `search_tools`/`load_tools`.
+`pnpm --filter api tools:measure` prints per-tool token weights.
+
 ## Essential Commands
 
 ### Development

--- a/docs/src/content/docs/ai-agent.md
+++ b/docs/src/content/docs/ai-agent.md
@@ -85,9 +85,11 @@ Beyond the always-on self-directive, Mako supports **skills** — named, workspa
 
 Every turn, Mako injects a compact index of every skill plus the top-3 auto-retrieved bodies (entity overlap 0.6 + semantic similarity 0.4). See [Skills](/skills/) for the full model, admin UI, and REST API.
 
+Skill _retrieval_ (`get_relevant_skills`, `load_skill`) is always active; skill _writes_ and long-tail lookups (`save_skill`, `delete_skill`, `list_skills`, `search_skills`, `read_skill_resource`) are deferred tools the agent activates on demand — see [Tool paging](#tool-paging) below.
+
 ## Expertise Modes
 
-Mako runs a **single unified agent**, not a fleet of separate agents. Capability is loaded dynamically: the agent switches *expertise modes* mid-conversation via the `enable_mode` tool, and each mode unlocks a domain-specific toolset plus guidance. A set of core tools (memory, skills, search, web access, version history, planning, mode-switching) is always available regardless of mode.
+Mako runs a **single unified agent**, not a fleet of separate agents. Capability is loaded dynamically: the agent switches *expertise modes* mid-conversation via the `enable_mode` tool, and each mode unlocks a domain-specific toolset plus guidance. A small set of core tools (memory, skill retrieval, web access, planning, mode-switching, tool discovery) is always available regardless of mode; everything else is either mode-scoped or deferred (see [Tool paging](#tool-paging)).
 
 On a fresh request the default mode is picked from what you're looking at — a dashboard view opens in **Dashboard**, the flow editor in **Sync Flow**, an app in **React App**, a dbt file/job in **Transforms** — otherwise **Query**. The agent then switches as the task demands.
 
@@ -102,9 +104,23 @@ On a fresh request the default mode is picked from what you're looking at — a 
 
 `Explore` is read-only by design. Mode ids persist in chat history, so renames stay backward-compatible (the legacy `dbt` mode resolves to `transform`). Enabling a mode adds its tools — modes accumulate across a turn rather than replacing one another.
 
+### Tool Paging
+
+The provider request carries a bounded **working set** of tools instead of every registered tool. Every tool sits in one of three tiers:
+
+- **core** — always active (lifecycle, memory, skill retrieval, web access, tool discovery)
+- **mode** — activates with an expertise mode
+- **deferred** — registered and executable (approval flow intact) but dormant: all MCP tools plus demoted built-ins (skill writes, version history)
+
+Deferred tools are discoverable via the `search_tools` meta-tool (compact cards, no schemas) and activated with `load_tools`, which mutates the active set exactly like `enable_mode` and replays statelessly from the chat transcript. A deterministic per-turn relevance preload activates obviously-relevant deferred tools from the last user message, so common cases need no search/load round-trip.
+
+Budgets: at most 110 active tools and ~12k tokens of tool definitions per step, whichever binds first — with per-provider hard caps as a backstop (xAI rejects requests above 250 tools, OpenAI above 128). Core and mode tools are never evicted; loaded deferred tools are evicted oldest-first. Small workspaces whose whole tool surface fits the budget bypass paging entirely and keep the zero-friction behavior. When paging is active, the system prompt lists deferred sources one line per connector, and provider-facing MCP tool descriptions are truncated (full descriptions stay in the search catalog).
+
+`pnpm --filter api tools:measure` prints per-tool token weights and per-mode totals.
+
 ### Plan Gate
 
-There is no user-facing plan/agent toggle. The model decides when planning is worthwhile: the moment it calls `submit_plan` in a turn, mutating tools are hard-gated until you approve the plan. Read-only and lifecycle tools (e.g. `enable_mode`, `todo_write`, `ask_clarifying_questions`) stay available throughout.
+There is no user-facing plan/agent toggle. The model decides when planning is worthwhile: the moment it calls `submit_plan` in a turn, mutating tools are hard-gated until you approve the plan. Read-only and lifecycle tools (e.g. `enable_mode`, `todo_write`, `ask_clarifying_questions`, `search_tools`, `load_tools`) stay available throughout — finding and loading a tool mutates nothing, and loaded write-tools remain gated.
 
 ### Dashboard specifics
 
@@ -120,7 +136,7 @@ Edit-mode locking is handled automatically so concurrent users cannot conflict.
 
 ## Version-Aware Tools
 
-All modes share two always-on tools for inspecting the history of saved consoles and dashboards:
+Two tools inspect the history of saved consoles and dashboards. They are deferred — the agent activates them via `search_tools`/`load_tools` (or the relevance preload) when a history question comes up:
 
 - `browse_version_history` — list past versions of a console or dashboard with author, timestamp, and comment.
 - `get_version_snapshot` — fetch the full snapshot of a specific version.

--- a/docs/src/content/docs/mcp-connectors.md
+++ b/docs/src/content/docs/mcp-connectors.md
@@ -79,6 +79,8 @@ Grants are per-user and per-tool. Manage or revoke them under **Settings → MCP
 
 Tools are namespaced `mcp_<server>_<tool>` in the agent runtime, and are treated as cross-cutting across modes. The [plan gate](/skills/) keeps only read-tier MCP tools available during planning.
 
+MCP tools are **deferred** in the agent's [tool working set](/ai-agent/#tool-paging): they stay registered and executable (approval flow intact) but are sent to the model only after discovery (`search_tools`/`load_tools`) or a per-turn relevance preload. This keeps workspaces with many connectors under provider tool-count caps and context budgets — adding MCP servers no longer bloats every request. Workspaces whose whole tool surface fits the budget bypass paging and behave as before.
+
 ## Security
 
 - Server URLs are SSRF-guarded (no internal/loopback targets).

--- a/docs/src/content/docs/version-history.md
+++ b/docs/src/content/docs/version-history.md
@@ -128,7 +128,7 @@ For **consoles and dashboards**, an unsaved draft has no version history yet, so
 
 ## AI Agent Tools
 
-The assistant can inspect version history through two dedicated tools, which are part of the always-on core toolset. See [AI Agent](/ai-agent/) for the full tool surface.
+The assistant can inspect version history through two dedicated tools. They are _deferred_ tools — activated on demand via tool discovery (`search_tools`/`load_tools`) rather than always loaded. See [AI Agent](/ai-agent/#tool-paging) for how tool paging works.
 
 ### `browse_version_history`
 


### PR DESCRIPTION
Daily docs maintenance. #720 changed the agent's tool surface fundamentally — tools are now paged (core/mode/deferred tiers, `search_tools`/`load_tools`, 110-tool/12k-token budgets, provider caps). Four doc statements became factually wrong or incomplete:

**P0 — factually wrong:**
- `version-history.md` claimed `browse_version_history`/`get_version_snapshot` are "part of the always-on core toolset" — they were demoted to deferred in #720.
- `ai-agent.md` core-tool list included version history and full skill toolset; skill writes (`save_skill`, `delete_skill`, `list_skills`, `search_skills`, `read_skill_resource`) are now deferred.

**P1 — new behavior, zero docs:**
- New **Tool Paging** section in `ai-agent.md`: tiers, discovery meta-tools, budgets, hybrid bypass, relevance preload, `tools:measure`.
- `mcp-connectors.md`: MCP tools are deferred; this is the fix for provider tool-cap 400s (447 tools > xAI's 250 cap).
- `CLAUDE.md`: mandatory tier-classification rule — unclassified built-ins are silently dead (the tier-policy test already caught `check_query_status`/`cancel_query`).
- Plan-gate doc updated: `search_tools`/`load_tools` stay available while gated.

All claims source-verified against `tool-catalog.ts`, `registry.ts`, `runtime.ts`, `tool-discovery-tools.ts`, `read-only-tools.ts`, and `api/package.json`. Prettier-clean on changed lines.