### PR TITLE
fix(ui): rematerialize progress + refresh only when complete

### DIFF
--- a/app/src/components/AppRenderer.tsx
+++ b/app/src/components/AppRenderer.tsx
@@ -5,6 +5,7 @@ import {
   CircularProgress,
   Divider,
   IconButton,
+  LinearProgress,
   ListItemIcon,
   ListItemText,
   Menu,
@@ -77,6 +78,13 @@ export default function AppRenderer({
   const publishSuggestion = useSaveCommentSuggestion();
   const [publishedNotice, setPublishedNotice] = useState<string | null>(null);
   const [rematerializing, setRematerializing] = useState(false);
+  const [rematerializeProgress, setRematerializeProgress] = useState<{
+    total: number;
+    settled: number;
+    ready: number;
+    failed: number;
+    phase: "building" | "loading";
+  } | null>(null);
 
   // The sandboxed preview inherits the host theme: the current mode seeds the
   // srcdoc, and later toggles are pushed via postMessage (rebuilding the
@@ -224,15 +232,56 @@ export default function AppRenderer({
   // Rebuild every parquet binding's artifact in one shot. Recovers an app whose
   // materialized cache was lost (e.g. a DB restore) — the query definitions and
   // bindings are untouched; only the Parquet artifacts + cache are regenerated.
+  // Wait for every binding to settle, load fresh DuckDB tables, then post a
+  // data-refresh — never rebuild the preview mid-flight with partial data.
   const handleRematerialize = useCallback(async () => {
     if (!workspaceId || rematerializing) return;
     setRematerializing(true);
+    setRematerializeProgress({
+      total: 0,
+      settled: 0,
+      ready: 0,
+      failed: 0,
+      phase: "building",
+    });
     setPublishedNotice("Rebuilding data for all bindings…");
     try {
-      const result = await materializeAllBindings(workspaceId, appId);
+      const result = await materializeAllBindings(workspaceId, appId, {
+        onProgress: progress =>
+          setRematerializeProgress({ ...progress, phase: "building" }),
+      });
       if (result.total === 0) {
         setPublishedNotice("No materialized bindings to rebuild.");
-      } else if (result.failed === 0) {
+        return;
+      }
+
+      // Pull every ready snapshot into DuckDB before telling the booted app
+      // to re-query — same pattern as the public share refresh path.
+      setRematerializeProgress(prev =>
+        prev ? { ...prev, phase: "loading" } : prev,
+      );
+      setPublishedNotice("Loading refreshed data…");
+      const freshApp = useAppStore.getState().openApps[appId];
+      if (freshApp) {
+        await Promise.all(
+          freshApp.dataBindings
+            .filter(binding => binding.materialization === "parquet")
+            .map(binding => {
+              const load = ensureBindingLoadedForPreview(
+                workspaceId,
+                appId,
+                binding,
+              );
+              return load.catch(() => false);
+            }),
+        );
+      }
+      iframeRef.current?.contentWindow?.postMessage(
+        { type: PREVIEW_MESSAGE.dataRefresh },
+        "*",
+      );
+
+      if (result.failed === 0) {
         setPublishedNotice(
           `Rebuilt data for ${result.ready} binding${result.ready === 1 ? "" : "s"}.`,
         );
@@ -247,6 +296,7 @@ export default function AppRenderer({
       );
     } finally {
       setRematerializing(false);
+      setRematerializeProgress(null);
     }
   }, [workspaceId, appId, rematerializing, materializeAllBindings]);
 
@@ -790,12 +840,46 @@ export default function AppRenderer({
       />
 
       <Snackbar
-        open={!!publishedNotice}
+        open={!!publishedNotice && !rematerializing}
         autoHideDuration={4000}
         onClose={() => setPublishedNotice(null)}
         anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
         message={publishedNotice ?? ""}
       />
+
+      {rematerializeProgress && (
+        <Box sx={{ borderBottom: "1px solid", borderColor: "divider" }}>
+          <LinearProgress
+            variant={
+              rematerializeProgress.total > 0 &&
+              rematerializeProgress.phase === "building"
+                ? "determinate"
+                : "indeterminate"
+            }
+            value={
+              rematerializeProgress.total > 0
+                ? (rematerializeProgress.settled /
+                    rematerializeProgress.total) *
+                  100
+                : undefined
+            }
+          />
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ display: "block", px: 1.5, py: 0.5 }}
+          >
+            {rematerializeProgress.phase === "loading"
+              ? "Loading refreshed data into the preview…"
+              : rematerializeProgress.total > 0
+                ? `Rebuilding data ${rematerializeProgress.settled}/${rematerializeProgress.total}` +
+                  (rematerializeProgress.failed > 0
+                    ? ` (${rematerializeProgress.failed} failed)`
+                    : "")
+                : "Rebuilding data for all bindings…"}
+          </Typography>
+        </Box>
+      )}
 
       {errors.length > 0 && (
         <Alert severity="error" sx={{ borderRadius: 0, py: 0.25 }}>

--- a/app/src/components/DashboardCanvas.tsx
+++ b/app/src/components/DashboardCanvas.tsx
@@ -192,16 +192,22 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
     }
   }, [dashboard?.title]);
 
+  const [reloadingData, setReloadingData] = useState(false);
+
   const handleRefresh = useCallback(() => {
     if (!workspaceId) {
       return;
     }
     if (isEditMode) {
-      void reloadDashboardDataSourcesCommand(workspaceId, dashboardId);
+      if (reloadingData) return;
+      setReloadingData(true);
+      void reloadDashboardDataSourcesCommand(workspaceId, dashboardId)
+        .catch(() => undefined)
+        .finally(() => setReloadingData(false));
       return;
     }
     void refreshDashboardCommand(workspaceId, dashboardId);
-  }, [workspaceId, dashboardId, isEditMode]);
+  }, [workspaceId, dashboardId, isEditMode, reloadingData]);
 
   const dataFreshness = useMemo(() => {
     if (!dashboard || dashboard.dataSources.length === 0) return null;
@@ -259,15 +265,17 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
   ]);
 
   const handleReloadData = useCallback(async () => {
-    if (workspaceId) {
-      setFreshnessDismissed(true);
-      try {
-        await reloadDashboardDataSourcesCommand(workspaceId, dashboardId);
-      } catch {
-        setFreshnessDismissed(false);
-      }
+    if (!workspaceId || reloadingData) return;
+    setFreshnessDismissed(true);
+    setReloadingData(true);
+    try {
+      await reloadDashboardDataSourcesCommand(workspaceId, dashboardId);
+    } catch {
+      setFreshnessDismissed(false);
+    } finally {
+      setReloadingData(false);
     }
-  }, [workspaceId, dashboardId]);
+  }, [workspaceId, dashboardId, reloadingData]);
 
   const handleDismissStaleLock = useCallback(async () => {
     if (workspaceId && dashboardId) {
@@ -375,27 +383,35 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
         </Tooltip>
 
         <Tooltip title="Clear filters and rerun all widgets">
-          <Chip
-            icon={<RefreshCw size={14} />}
-            label="Refresh"
-            size="small"
-            variant="outlined"
-            onClick={handleRefresh}
-            sx={{ cursor: "pointer" }}
-          />
+          <span>
+            <Chip
+              icon={<RefreshCw size={14} />}
+              label={isEditMode && reloadingData ? "Reloading…" : "Refresh"}
+              size="small"
+              variant="outlined"
+              onClick={handleRefresh}
+              disabled={isEditMode && reloadingData}
+              sx={{
+                cursor: isEditMode && reloadingData ? "default" : "pointer",
+              }}
+            />
+          </span>
         </Tooltip>
 
         {isEditMode && (
           <>
             <Tooltip title="Reload data from source database">
-              <Chip
-                icon={<Database size={14} />}
-                label="Reload data"
-                size="small"
-                variant="outlined"
-                onClick={handleReloadData}
-                sx={{ cursor: "pointer" }}
-              />
+              <span>
+                <Chip
+                  icon={<Database size={14} />}
+                  label={reloadingData ? "Reloading…" : "Reload data"}
+                  size="small"
+                  variant="outlined"
+                  onClick={handleReloadData}
+                  disabled={reloadingData}
+                  sx={{ cursor: reloadingData ? "default" : "pointer" }}
+                />
+              </span>
             </Tooltip>
 
             <Tooltip title="Add widget">

--- a/app/src/components/dashboard/DashboardRuntimeChrome.tsx
+++ b/app/src/components/dashboard/DashboardRuntimeChrome.tsx
@@ -163,6 +163,32 @@ const DashboardRuntimeChrome: React.FC<DashboardRuntimeChromeProps> = ({
     [runtimeSession?.eventLog],
   );
 
+  const materializationProgress = useMemo(() => {
+    if (!runtimeSession?.materializationPolling || !dashboard) return null;
+    const parquetSources = dashboard.dataSources.filter(
+      ds => ds.materialization !== "live",
+    );
+    if (parquetSources.length === 0) return null;
+    let settled = 0;
+    let building = 0;
+    for (const source of parquetSources) {
+      const status =
+        runtimeSession.dataSources[source.id]?.materializationStatus;
+      if (status === "queued" || status === "building") {
+        building += 1;
+      } else {
+        settled += 1;
+      }
+    }
+    return {
+      total: parquetSources.length,
+      settled,
+      building,
+      progress:
+        parquetSources.length > 0 ? (settled / parquetSources.length) * 100 : 0,
+    };
+  }, [dashboard, runtimeSession]);
+
   return (
     <>
       {lockError && (
@@ -319,21 +345,33 @@ const DashboardRuntimeChrome: React.FC<DashboardRuntimeChromeProps> = ({
         </Box>
       )}
       {runtimeSession?.materializationPolling && (
-        <Box
-          sx={{
-            px: 1.5,
-            py: 0.75,
-            borderBottom: "1px solid",
-            borderColor: "divider",
-            backgroundColor: "warning.light",
-            color: "warning.contrastText",
-          }}
-        >
-          <Typography variant="caption" sx={{ display: "block" }}>
-            {isEditMode
-              ? "Building a fresh published artifact in the background. Edit mode keeps the currently loaded draft/view data until you leave edit mode or rerun a source."
-              : "Refreshing data sources in the background. The dashboard is using the previous materialized snapshot until fresh data is ready."}
-          </Typography>
+        <Box sx={{ borderBottom: "1px solid", borderColor: "divider" }}>
+          <LinearProgress
+            variant={
+              materializationProgress != null ? "determinate" : "indeterminate"
+            }
+            value={materializationProgress?.progress ?? undefined}
+          />
+          <Box
+            sx={{
+              px: 1.5,
+              py: 0.75,
+              backgroundColor: "warning.light",
+              color: "warning.contrastText",
+            }}
+          >
+            <Typography variant="caption" sx={{ display: "block" }}>
+              {materializationProgress
+                ? `Rebuilding data ${materializationProgress.settled}/${materializationProgress.total}` +
+                  (materializationProgress.building > 0
+                    ? ` · ${materializationProgress.building} still building`
+                    : "") +
+                  ". Dashboard refreshes when every data source is ready."
+                : isEditMode
+                  ? "Rebuilding materialized data… The dashboard will refresh when every data source is ready."
+                  : "Refreshing data sources… The dashboard is using the previous snapshot until all fresh data is ready."}
+            </Typography>
+          </Box>
         </Box>
       )}
       {runtimeSession?.freshDataAvailable && workspaceId && dashboardId && (

--- a/app/src/components/dashboard/DataSourcePanel.tsx
+++ b/app/src/components/dashboard/DataSourcePanel.tsx
@@ -201,6 +201,7 @@ const DataSourcePanel: React.FC<DataSourcePanelProps> = ({
     [],
   );
   const [historyLoading, setHistoryLoading] = useState(false);
+  const [refreshingAll, setRefreshingAll] = useState(false);
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
   const [selectedRunDetail, setSelectedRunDetail] =
     useState<MaterializationRunRecord | null>(null);
@@ -1199,15 +1200,25 @@ const DataSourcePanel: React.FC<DataSourcePanelProps> = ({
               size="small"
               fullWidth
               variant="outlined"
-              startIcon={<RefreshCw size={14} />}
-              disabled={hasBuildingMaterialization}
+              startIcon={
+                refreshingAll || hasBuildingMaterialization ? (
+                  <CircularProgress size={14} />
+                ) : (
+                  <RefreshCw size={14} />
+                )
+              }
+              disabled={refreshingAll || hasBuildingMaterialization}
               onClick={() => {
-                if (workspaceId) {
-                  void reloadDashboardDataSourcesCommand(workspaceId);
-                }
+                if (!workspaceId || refreshingAll) return;
+                setRefreshingAll(true);
+                void reloadDashboardDataSourcesCommand(workspaceId)
+                  .catch(() => undefined)
+                  .finally(() => setRefreshingAll(false));
               }}
             >
-              Refresh All
+              {refreshingAll || hasBuildingMaterialization
+                ? "Refreshing…"
+                : "Refresh All"}
             </Button>
           </Box>
         </>

--- a/app/src/components/public/PublicAppViewer.tsx
+++ b/app/src/components/public/PublicAppViewer.tsx
@@ -4,6 +4,7 @@ import {
   Box,
   Button,
   CircularProgress,
+  LinearProgress,
   Typography,
 } from "@mui/material";
 import { RefreshCw } from "lucide-react";
@@ -79,12 +80,36 @@ function toLoadableBinding(
   } as AppDataBinding;
 }
 
-function latestMaterializedAt(content: PublicAppContent): string | null {
-  const timestamps = content.dataBindings
-    .map(binding => binding.materializedAt)
-    .filter((value): value is string => !!value)
-    .sort();
-  return timestamps[timestamps.length - 1] ?? null;
+/** Per-binding snapshot timestamps used to detect when a refresh has finished. */
+function parquetMaterializedAts(
+  content: PublicAppContent,
+): Map<string, string | null> {
+  return new Map(
+    content.dataBindings
+      .filter(binding => binding.materialization === "parquet")
+      .map(binding => [binding.id, binding.materializedAt]),
+  );
+}
+
+/**
+ * True once every parquet binding has a new ready snapshot vs `before`.
+ * Waiting on a single "latest" timestamp would refresh mid-flight when the
+ * first binding finishes while siblings are still building.
+ */
+function allParquetBindingsRefreshed(
+  before: Map<string, string | null>,
+  content: PublicAppContent,
+): boolean {
+  const parquet = content.dataBindings.filter(
+    binding => binding.materialization === "parquet",
+  );
+  if (parquet.length === 0) return true;
+  return parquet.every(binding => {
+    if (!binding.ready || !binding.materializedAt) return false;
+    const previous = before.get(binding.id) ?? null;
+    if (previous == null) return true;
+    return binding.materializedAt !== previous;
+  });
 }
 
 export default function PublicAppViewer({
@@ -393,11 +418,11 @@ export default function PublicAppViewer({
       }
 
       setRefreshNote("Refreshing data…");
-      const before = latestMaterializedAt(contentRef.current);
+      const before = parquetMaterializedAts(contentRef.current);
       for (let attempt = 0; attempt < 15; attempt++) {
         await new Promise(resolve => setTimeout(resolve, 8000));
         const fresh = await reloadContent();
-        if (fresh && latestMaterializedAt(fresh) !== before) {
+        if (fresh && allParquetBindingsRefreshed(before, fresh)) {
           // Pull the new snapshots into DuckDB *before* telling the booted app
           // to re-query — otherwise its hooks could read the previous table.
           // ensureBindingLoaded reloads in place (revision changed), and the
@@ -471,6 +496,20 @@ export default function PublicAppViewer({
           {refreshing ? "Refreshing…" : "Refresh data"}
         </Button>
       </Box>
+
+      {refreshing && (
+        <Box sx={{ borderBottom: "1px solid", borderColor: "divider" }}>
+          <LinearProgress />
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ display: "block", px: 1.5, py: 0.5 }}
+          >
+            Waiting for every data binding to finish rebuilding before
+            refreshing the app…
+          </Typography>
+        </Box>
+      )}
 
       {previewError && (
         <Alert severity="error" sx={{ borderRadius: 0, py: 0.25 }}>

--- a/app/src/components/public/PublicDashboardViewer.tsx
+++ b/app/src/components/public/PublicDashboardViewer.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   Button,
   CircularProgress,
+  LinearProgress,
   Tooltip,
   Typography,
 } from "@mui/material";
@@ -94,6 +95,37 @@ function latestMaterializedAt(content: PublicDashboardContent): string | null {
     }
   }
   return latest;
+}
+
+function parquetMaterializedAts(
+  content: PublicDashboardContent,
+): Map<string, string | null> {
+  return new Map(
+    content.dataSources
+      .filter(ds => ds.materialization !== "live")
+      .map(ds => [ds.id, ds.materializedAt]),
+  );
+}
+
+/**
+ * True once every parquet data source has a new ready snapshot vs `before`.
+ * A single global "latest" timestamp would refresh as soon as the first
+ * source finishes while others are still building.
+ */
+function allParquetSourcesRefreshed(
+  before: Map<string, string | null>,
+  content: PublicDashboardContent,
+): boolean {
+  const parquet = content.dataSources.filter(
+    ds => ds.materialization !== "live",
+  );
+  if (parquet.length === 0) return true;
+  return parquet.every(ds => {
+    if (!ds.ready || !ds.materializedAt) return false;
+    const previous = before.get(ds.id) ?? null;
+    if (previous == null) return true;
+    return ds.materializedAt !== previous;
+  });
 }
 
 export default function PublicDashboardViewer({
@@ -205,12 +237,13 @@ export default function PublicDashboardViewer({
       }
 
       setRefreshNote("Refreshing data…");
-      const before = latestMaterializedAt(contentRef.current);
-      // Poll for the new snapshot (server materializes in the background).
+      const before = parquetMaterializedAts(contentRef.current);
+      // Poll until every parquet source has a fresh snapshot — never remount
+      // the dashboard mid-flight when only the first source has finished.
       for (let attempt = 0; attempt < 15; attempt++) {
         await new Promise(resolve => setTimeout(resolve, 8000));
         const fresh = await reloadContent();
-        if (fresh && latestMaterializedAt(fresh) !== before) {
+        if (fresh && allParquetSourcesRefreshed(before, fresh)) {
           setDataVersion(v => v + 1);
           setRefreshNote(null);
           return;
@@ -295,11 +328,25 @@ export default function PublicDashboardViewer({
               disabled={refreshing}
               onClick={() => void handleRefresh()}
             >
-              Refresh data
+              {refreshing ? "Refreshing…" : "Refresh data"}
             </Button>
           </span>
         </Tooltip>
       </Box>
+
+      {refreshing && (
+        <Box sx={{ borderBottom: "1px solid", borderColor: "divider" }}>
+          <LinearProgress />
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ display: "block", px: 3, py: 0.75 }}
+          >
+            Waiting for every data source to finish rebuilding before refreshing
+            the dashboard…
+          </Typography>
+        </Box>
+      )}
 
       <Box ref={gridContainerRef} sx={{ p: 2 }}>
         {loadError ? (

--- a/app/src/dashboard-runtime/commands.ts
+++ b/app/src/dashboard-runtime/commands.ts
@@ -576,17 +576,16 @@ export async function refreshDashboardDataSourceCommand(options: {
       force: true,
       dataSourceIds: [options.dataSourceId],
     });
+  // Explicit Materialize: wait until the build finishes, then swap runtime
+  // data — including in edit mode. Background rematerialize still defers.
   await waitForDashboardMaterialization({
     workspaceId: options.workspaceId,
     dashboardId: dashboard._id,
   });
-  if (isDashboardInEditMode(dashboard._id)) {
-    return;
-  }
   await applyDashboardMaterializedData({
     workspaceId: options.workspaceId,
     dashboardId: dashboard._id,
-    runtimeContext: "viewer",
+    runtimeContext: isDashboardInEditMode(dashboard._id) ? "builder" : "viewer",
   });
 }
 
@@ -600,17 +599,16 @@ export async function reloadDashboardDataSourcesCommand(
     .materializeDashboard(workspaceId, dashboard._id, {
       force: true,
     });
+  // Explicit "Reload data" / "Refresh All": wait for every source to finish
+  // building, then refresh the runtime once — never swap mid-flight.
   await waitForDashboardMaterialization({
     workspaceId,
     dashboardId: dashboard._id,
   });
-  if (isDashboardInEditMode(dashboard._id)) {
-    return;
-  }
   await applyDashboardMaterializedData({
     workspaceId,
     dashboardId: dashboard._id,
-    runtimeContext: "viewer",
+    runtimeContext: isDashboardInEditMode(dashboard._id) ? "builder" : "viewer",
   });
 }
 

--- a/app/src/store/appStore.ts
+++ b/app/src/store/appStore.ts
@@ -243,12 +243,21 @@ interface AppActions {
    * is ready, fails, or the bounded wait elapses. Never hangs: `timeoutMs`
    * caps the wait and `signal` aborts the polling (the build itself keeps
    * running server-side either way).
+   *
+   * `refreshPreview` (default true) refetches the app and bumps the preview
+   * when the binding becomes ready. Bulk rematerialize passes false so the
+   * preview refreshes once after every binding settles.
    */
   materializeBinding: (
     workspaceId: string,
     appId: string,
     bindingId: string,
-    options?: { force?: boolean; signal?: AbortSignal; timeoutMs?: number },
+    options?: {
+      force?: boolean;
+      signal?: AbortSignal;
+      timeoutMs?: number;
+      refreshPreview?: boolean;
+    },
   ) => Promise<{
     success: boolean;
     status: "ready" | "building" | "error";
@@ -261,11 +270,25 @@ interface AppActions {
    * default) and returns an aggregate summary. Used by the "Rebuild data"
    * toolbar action to recover an app whose artifact cache was lost (e.g. a DB
    * restore) without deleting/recreating bindings.
+   *
+   * Does not bump the preview mid-flight — callers should load fresh DuckDB
+   * tables and post a data-refresh (or bumpPreview) only after this resolves.
+   * `onProgress` reports settled binding counts while builds are still running.
    */
   materializeAllBindings: (
     workspaceId: string,
     appId: string,
-    options?: { force?: boolean; signal?: AbortSignal; timeoutMs?: number },
+    options?: {
+      force?: boolean;
+      signal?: AbortSignal;
+      timeoutMs?: number;
+      onProgress?: (progress: {
+        total: number;
+        settled: number;
+        ready: number;
+        failed: number;
+      }) => void;
+    },
   ) => Promise<{
     total: number;
     ready: number;
@@ -815,6 +838,7 @@ export const useAppStore = create<AppStore>()(
     materializeBinding: async (workspaceId, appId, bindingId, options) => {
       const signal = options?.signal;
       const timeoutMs = options?.timeoutMs ?? MATERIALIZE_DEFAULT_TIMEOUT_MS;
+      const refreshPreview = options?.refreshPreview !== false;
 
       // Mirror the server-reported status onto the open app so UI chips
       // (binding editor, explorer) update live while the build runs.
@@ -836,8 +860,10 @@ export const useAppStore = create<AppStore>()(
       };
 
       const finishReady = async () => {
-        await get().fetchApp(workspaceId, appId);
-        get().bumpPreview(appId);
+        if (refreshPreview) {
+          await get().fetchApp(workspaceId, appId);
+          get().bumpPreview(appId);
+        }
         return { success: true, status: "ready" as const };
       };
 
@@ -867,10 +893,17 @@ export const useAppStore = create<AppStore>()(
         // Cache hit — artifact already built, nothing queued.
         if (res.status?.status === "ready") {
           if (res.app) {
-            set(state => {
-              state.openApps[appId] = res.app as AppEntity;
-            });
-            get().bumpPreview(appId);
+            // Only replace the open app when refreshing the preview. During
+            // bulk rematerialize, a cache-hit response may carry stale sibling
+            // binding caches and would clobber in-flight status updates.
+            if (refreshPreview) {
+              set(state => {
+                state.openApps[appId] = res.app as AppEntity;
+              });
+              get().bumpPreview(appId);
+            } else {
+              setLocalStatus("ready");
+            }
             return { success: true, status: "ready" };
           }
           return await finishReady();
@@ -941,10 +974,17 @@ export const useAppStore = create<AppStore>()(
         return { total: 0, ready: 0, failed: 0, errors: [] };
       }
 
+      const total = parquetBindings.length;
+      let settled = 0;
+      let ready = 0;
+      let failed = 0;
+      options?.onProgress?.({ total, settled, ready, failed });
+
       // Build every binding concurrently. Each call queues a background build
       // and polls to completion; the shared per-binding claim on the server
       // dedupes against any build already in flight. Default to a force rebuild
-      // so a lost/stale cache is always regenerated.
+      // so a lost/stale cache is always regenerated. Skip per-binding preview
+      // refreshes — the caller applies data once after every binding settles.
       const results = await Promise.all(
         parquetBindings.map(binding =>
           get()
@@ -952,19 +992,29 @@ export const useAppStore = create<AppStore>()(
               force: options?.force ?? true,
               signal: options?.signal,
               timeoutMs: options?.timeoutMs,
+              refreshPreview: false,
             })
-            .then(result => ({ name: binding.name, ...result })),
+            .then(result => {
+              settled += 1;
+              if (result.status === "ready") {
+                ready += 1;
+              } else {
+                failed += 1;
+              }
+              options?.onProgress?.({ total, settled, ready, failed });
+              return { name: binding.name, ...result };
+            }),
         ),
       );
 
       // Ensure the open app reflects the freshly hydrated cache (parquetUrl)
-      // once all builds settle, so the preview can load every table.
+      // once all builds settle, so the preview can load every table. Do not
+      // bumpPreview here — AppRenderer loads DuckDB then posts data-refresh.
       await get().fetchApp(workspaceId, appId);
-      get().bumpPreview(appId);
 
       const failures = results.filter(r => r.status !== "ready");
       return {
-        total: parquetBindings.length,
+        total,
         ready: results.length - failures.length,
         failed: failures.length,
         errors: failures.map(f => `${f.name}: ${f.error ?? f.status}`),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When rematerializing an app or dashboard, show a progress indicator and only refresh the runtime once **every** parquet source has finished building.

### Apps
- `materializeAllBindings` no longer calls `fetchApp`/`bumpPreview` per binding mid-flight
- Progress bar shows `settled/total` while rebuilding, then a loading phase while DuckDB tables swap
- After all bindings settle: load fresh Parquet into DuckDB, then post `mako-app:data-refresh` (keeps UI state; no full srcdoc reboot)

### Dashboards
- Explicit **Reload data** / **Refresh All** / per-source **Materialize** wait for `!anyBuilding`, then apply materialized data once (including edit mode)
- Materialization banner uses a determinate progress bar (`settled/total`)
- Toolbar/panel buttons show Reloading… and disable while a reload is in flight

### Public shares
- Refresh waits until **all** parquet bindings/sources have new `materializedAt` values (not just the first one to finish)
- Linear progress banner while waiting

## Test plan
- [ ] App with multiple parquet bindings → **Materialize data**: progress bar advances; preview refreshes once at the end
- [ ] Dashboard → **Reload data** / **Refresh All**: banner shows progress; widgets update only after all sources ready
- [ ] Public app/dashboard share → **Refresh data**: waits for every source before remounting/refreshing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fa8592c-5616-4d81-9e20-a3216aafbf8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fa8592c-5616-4d81-9e20-a3216aafbf8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

