### PR TITLE
fix(apps): restore MongoDB source materialization broken by read-only gate

### DIFF
--- a/api/src/services/parquet-build.readonly.test.ts
+++ b/api/src/services/parquet-build.readonly.test.ts
@@ -130,6 +130,25 @@ async function main() {
     "non-SQL engines must still fail closed under read-only",
   );
 
+  // 5. Regression for MongoDB materialization (broken by PR #688): because
+  //    MongoDB fails closed under `readOnly` (test 4 above), the materialization
+  //    core must NOT force read-only for Mongo — the binding's JS-shell code
+  //    (e.g. `db.client.db('x').collection('y').aggregate([...])`) can never
+  //    pass the SQL read-only analyzer. Without read-only, the streaming path
+  //    reaches the Mongo driver (and fails on the credential-less connection),
+  //    rather than being rejected by the SELECT/WITH gate.
+  const mongoStream = await databaseConnectionService.executeStreamingQuery(
+    fakeConnection("mongodb"),
+    "db.client.db('production').collection('users').aggregate([]).toArray()",
+    { readOnly: false, batchSize: 1, onBatch: async () => {} },
+  );
+  assert.equal(mongoStream.success, false);
+  assert.doesNotMatch(
+    mongoStream.error ?? "",
+    /SELECT or WITH|read-only|not supported/i,
+    "Mongo materialization streaming must reach the driver, not the SQL read-only gate",
+  );
+
   // eslint-disable-next-line no-console
   console.log("parquet-build/read-only regression tests passed");
 }

--- a/api/src/services/parquet-build.service.ts
+++ b/api/src/services/parquet-build.service.ts
@@ -109,13 +109,22 @@ export async function buildQueryParquetFile(
 
   assertReadOnlyMaterializationQuery(executableQuery, connection.type);
 
+  // The driver-level `readOnly` gate is a SQL analyzer: it requires string
+  // queries to be a single SELECT/WITH and fails closed for engines it can't
+  // validate (MongoDB JS-shell code, Cloudflare KV). Those sources can never
+  // pass it, so materializing them read-only errors out. They're exempted here
+  // exactly as `assertReadOnlyMaterializationQuery` exempts them above — their
+  // read-only safety is the source driver's own execution path, not this gate.
+  const enforceReadOnly =
+    connection.type !== "mongodb" && connection.type !== "cloudflare-kv";
+
   let fields: FieldMeta[] = [];
   try {
     const schemaResult =
       await databaseConnectionService.getStreamingQueryFields(
         connection,
         executableQuery,
-        { databaseId, databaseName, readOnly: true },
+        { databaseId, databaseName, readOnly: enforceReadOnly },
       );
     if (schemaResult.success && schemaResult.fields) {
       fields = schemaResult.fields;
@@ -150,7 +159,7 @@ export async function buildQueryParquetFile(
             databaseId,
             databaseName,
             onBatch: insertBatch,
-            readOnly: true,
+            readOnly: enforceReadOnly,
           },
         );
       // A mid-stream failure must fail the build — otherwise a silently


### PR DESCRIPTION
## Problem

MongoDB source materialization (React App data bindings **and** dashboard data sources) fails for every Mongo query with the generic error *"Materialization failed. Check the binding query."* — even though the exact same query runs fine live. Users see a dashboard/app full of `Catalog Error: Table ... does not exist` because no parquet artifact is ever produced.

## Root cause

Commit `00cf5c2d` (PR #688, "Mako MCP server") added an enforced read-only mode and passed `readOnly: true` into both driver calls in `buildQueryParquetFile` (the schema probe and the streaming execution).

The driver-level `readOnly` gate is a **SQL analyzer** (`checkPreviewQuerySafety`): it requires every string query to be a single `SELECT`/`WITH`, and fails closed for engines in `READ_ONLY_UNSUPPORTED_TYPES` (`mongodb`, `cloudflare-kv`). But a MongoDB binding's `code` is a JS-shell string like:

```js
db.client.db('production').collection('query_executions').aggregate([...]).toArray()
```

That can never pass a SQL analyzer, so **every Mongo materialization dies at the stream step**. The live query path works because `mongo_execute_query` doesn't set `readOnly`.

The materialization core already intended to exempt these engines from the SQL gate at `assertReadOnlyMaterializationQuery` — PR #688 just re-imposed it one layer deeper via the `readOnly` flag. (That PR's own regression test fixed the same class of breakage for BigQuery but never covered Mongo.)

## Fix

Only enforce the driver-level read-only gate for source types the SQL analyzer can actually validate, mirroring the existing `assertReadOnlyMaterializationQuery` exemption:

```ts
const enforceReadOnly =
  connection.type !== "mongodb" && connection.type !== "cloudflare-kv";
```

SQL sources keep full read-only enforcement; Mongo/KV materialize through the source driver's own path (unchanged from pre-#688 behavior). Also fixes dashboard Mongo sources, which pass structured executables and hit the same `"arbitrary MongoDB execution is disabled"` rejection.

## Testing

- Added a regression test to `parquet-build.readonly.test.ts` asserting the Mongo streaming path reaches the driver rather than being rejected by the SQL read-only gate.
- `pnpm exec tsx src/services/parquet-build.readonly.test.ts` passes (all read-only regression tests, incl. the new Mongo case).
- Typecheck clean for the touched files (pre-existing unrelated test errors only).

## Note / follow-up

This means Mongo materialization has no *lexical* read-only enforcement — it relies on the binding code being a read pipeline, consistent with how `mongo_execute_query` and dashboards already run. Adding real read-only guarantees for Mongo would be a larger, separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)