### PR TITLE
fix(apps): let external links escape the preview sandbox

### DIFF
--- a/app/src/app-runtime/preview.ts
+++ b/app/src/app-runtime/preview.ts
@@ -213,7 +213,10 @@ export function buildPreviewHtml(
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!-- The frame is an opaque origin (no allow-same-origin), so a plain
          <a href> can't navigate the top frame. Default every link to a new
-         tab so app links open externally instead of silently no-opping. -->
+         tab so app links open externally instead of silently no-opping.
+         Host iframes must include allow-popups + allow-popups-to-escape-sandbox
+         or the new tab inherits the sandbox and sites like Close refuse with
+         ERR_BLOCKED_BY_RESPONSE. -->
     <base target="_blank" />
     <script type="importmap">${importMap}</script>
     <script src="https://unpkg.com/@babel/standalone@7.25.6/babel.min.js"></script>

--- a/app/src/components/AppRenderer.tsx
+++ b/app/src/components/AppRenderer.tsx
@@ -826,7 +826,7 @@ export default function AppRenderer({
           title={`app-preview-${appId}`}
           data-mako-app-preview={appId}
           srcDoc={srcDoc}
-          sandbox="allow-scripts allow-downloads allow-popups"
+          sandbox="allow-scripts allow-downloads allow-popups allow-popups-to-escape-sandbox"
           style={{ width: "100%", height: "100%", border: "none" }}
         />
         {booting && errors.length === 0 && (

--- a/app/src/components/public/PublicAppViewer.tsx
+++ b/app/src/components/public/PublicAppViewer.tsx
@@ -495,7 +495,7 @@ export default function PublicAppViewer({
           ref={iframeRef}
           title={`public-app-${token}`}
           srcDoc={srcDoc}
-          sandbox="allow-scripts allow-downloads allow-popups"
+          sandbox="allow-scripts allow-downloads allow-popups allow-popups-to-escape-sandbox"
           style={{ width: "100%", height: "100%", border: "none" }}
         />
         {booting && !previewError && (

--- a/app/src/components/widgets/CodeWidget.tsx
+++ b/app/src/components/widgets/CodeWidget.tsx
@@ -123,7 +123,7 @@ const CodeWidget: React.FC<CodeWidgetProps> = ({
       )}
       <iframe
         ref={iframeRef}
-        sandbox="allow-scripts allow-downloads allow-popups"
+        sandbox="allow-scripts allow-downloads allow-popups allow-popups-to-escape-sandbox"
         style={{
           width: "100%",
           height: "100%",

--- a/app/src/pages/AppPreviewPage.tsx
+++ b/app/src/pages/AppPreviewPage.tsx
@@ -310,7 +310,7 @@ export default function AppPreviewPage() {
           ref={iframeRef}
           title={`preview-app-${token}`}
           srcDoc={srcDoc}
-          sandbox="allow-scripts allow-downloads allow-popups"
+          sandbox="allow-scripts allow-downloads allow-popups allow-popups-to-escape-sandbox"
           style={{ width: "100%", height: "100%", border: "none" }}
         />
         {booting && !previewError && (


### PR DESCRIPTION
## Summary
- App preview iframes allowed popups but did not let them escape the sandbox, so `target=_blank` links (e.g. Close) opened in a sandboxed tab and failed with `ERR_BLOCKED_BY_RESPONSE`.
- Add `allow-popups-to-escape-sandbox` on all app iframe hosts (editor preview, public share, MCP preview token page, code widgets).

## Test plan
- [ ] Open an app with a link to `https://app.close.com/...` (or any site that sets `X-Frame-Options` / restrictive `frame-ancestors`)
- [ ] Click the link from the in-product app preview — it should open a normal browser tab
- [ ] Repeat from a public share view (`/share/...`)
- [ ] Confirm popup blockers still apply as usual; only sandbox inheritance changes


Made with [Cursor](https://cursor.com)