### PR TITLE
Show console execution logs in Runs tab + agent tool

### DIFF
--- a/CONSOLE_API_DOCUMENTATION.md
+++ b/CONSOLE_API_DOCUMENTATION.md
@@ -43,12 +43,25 @@ Get a list of all consoles in the workspace.
       "createdAt": "2024-01-01T00:00:00Z",
       "updatedAt": "2024-01-01T00:00:00Z",
       "lastExecutedAt": "2024-01-01T00:00:00Z",
-      "executionCount": 10
+      "executionCount": 10,
+      "lastExternalUsedAt": "2024-01-01T00:00:00Z",
+      "externalUseCount": 3,
+      "lastExternalSource": "api"
     }
   ],
   "total": 1
 }
 ```
+
+**Usage fields for archival decisions:**
+
+| Field | Meaning |
+|---|---|
+| `lastExecutedAt` / `executionCount` | Any execution (UI, API, MCP, in-app agent) |
+| `lastExternalUsedAt` / `externalUseCount` | External-only: REST API key execute, or MCP `run_console` / `read_console` / details |
+| `lastExternalSource` | `"api"` or `"mcp"` — which external surface last touched the console |
+
+Consoles with `lastExternalUsedAt: null` have never been used via API key or MCP (since this tracking shipped). Prefer that signal when deciding what is safe to archive from an external-integrations perspective.
 
 ### Get Console Details
 
@@ -76,7 +89,10 @@ Get detailed information about a specific console, including its code.
     "createdAt": "2024-01-01T00:00:00Z",
     "updatedAt": "2024-01-01T00:00:00Z",
     "lastExecutedAt": "2024-01-01T00:00:00Z",
-    "executionCount": 10
+    "executionCount": 10,
+    "lastExternalUsedAt": "2024-01-01T00:00:00Z",
+    "externalUseCount": 3,
+    "lastExternalSource": "api"
   }
 }
 ```

--- a/CONSOLE_API_DOCUMENTATION.md
+++ b/CONSOLE_API_DOCUMENTATION.md
@@ -53,7 +53,7 @@ Get a list of all consoles in the workspace.
 }
 ```
 
-**Usage fields for archival decisions:**
+**Usage fields (monitoring):**
 
 | Field | Meaning |
 |---|---|
@@ -61,7 +61,7 @@ Get a list of all consoles in the workspace.
 | `lastExternalUsedAt` / `externalUseCount` | External-only: REST API key execute, or MCP `run_console` / `read_console` / details |
 | `lastExternalSource` | `"api"` or `"mcp"` — which external surface last touched the console |
 
-Consoles with `lastExternalUsedAt: null` have never been used via API key or MCP (since this tracking shipped). Prefer that signal when deciding what is safe to archive from an external-integrations perspective.
+`lastExternalUsedAt: null` means the console has not been observed via API key or MCP since this tracking shipped.
 
 ### Get Console Details
 

--- a/CONSOLE_API_DOCUMENTATION.md
+++ b/CONSOLE_API_DOCUMENTATION.md
@@ -63,6 +63,37 @@ Get a list of all consoles in the workspace.
 
 `lastExternalUsedAt: null` means the console has not been observed via API key or MCP since this tracking shipped.
 
+### List Recent Console Executions
+
+Return the most recent query execution logs for a console (from `query_executions`, retained for 90 days).
+
+**Endpoint:** `GET /api/workspaces/{workspaceId}/consoles/{consoleId}/executions?limit=10`
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "executions": [
+    {
+      "id": "execution_id",
+      "executedAt": "2024-01-01T00:00:00Z",
+      "source": "api",
+      "status": "success",
+      "executionTimeMs": 42,
+      "rowCount": 10,
+      "errorType": null,
+      "userId": "user_id",
+      "apiKeyId": "api_key_id",
+      "databaseType": "postgresql",
+      "queryLanguage": "sql"
+    }
+  ]
+}
+```
+
+`source` is one of: `console_ui`, `console_ui_admin_override`, `api`, `mcp`, `agent`, `flow`, `scheduled_query`.
+
 ### Get Console Details
 
 Get detailed information about a specific console, including its code.

--- a/CONSOLE_API_DOCUMENTATION.md
+++ b/CONSOLE_API_DOCUMENTATION.md
@@ -79,6 +79,7 @@ Return the most recent query execution logs for a console (from `query_execution
       "id": "execution_id",
       "executedAt": "2024-01-01T00:00:00Z",
       "source": "api",
+      "sourceLabel": "API key",
       "status": "success",
       "executionTimeMs": 42,
       "rowCount": 10,
@@ -92,7 +93,16 @@ Return the most recent query execution logs for a console (from `query_execution
 }
 ```
 
-`source` is one of: `console_ui`, `console_ui_admin_override`, `api`, `mcp`, `agent`, `flow`, `scheduled_query`.
+`source` / `sourceLabel`:
+
+| source | sourceLabel |
+|---|---|
+| `console_ui` | App UI |
+| `api` | API key |
+| `mcp` | MCP |
+| `agent` | AI agent |
+| `scheduled_query` | Schedule |
+| `flow` | Flow |
 
 ### Get Console Details
 

--- a/api/src/agent-lib/tools/server-console-tools.ts
+++ b/api/src/agent-lib/tools/server-console-tools.ts
@@ -24,6 +24,7 @@ import {
   runConsoleSchema,
   checkQueryStatusSchema,
   cancelQueryStatusSchema,
+  listConsoleExecutionsSchema,
   applyModification,
   buildModificationDiff,
   type ConsoleModification,
@@ -40,6 +41,7 @@ import {
   startDetachedConsoleRun,
   cancelDetachedConsoleRun,
 } from "../../services/console-execution.service";
+import { queryExecutionService } from "../../services/query-execution.service";
 import {
   MONGO_QUERY_WRITE_SCOPE_REQUIRED,
   sqlReadOnlyAccessError,
@@ -768,6 +770,51 @@ export function createServerConsoleTools({
               error instanceof Error
                 ? error.message
                 : "Failed to cancel query.",
+          };
+        }
+      },
+    }),
+
+    list_console_executions: tool({
+      description:
+        "List recent query executions for a console (App UI, API key, MCP, in-app agent, schedule). Returns newest-first rows with source, status, duration, and rowCount. History is retained for ~90 days. Use this to see whether a console is used externally (source api/mcp) or only in-app.",
+      inputSchema: listConsoleExecutionsSchema,
+      execute: async ({ consoleId, limit }) => {
+        try {
+          const loaded = await loadConsole(consoleId);
+          if (isLoadError(loaded)) return { success: false, ...loaded };
+
+          const executions = await queryExecutionService.getConsoleExecutions(
+            workspaceId,
+            consoleId,
+            { limit: limit ?? 10 },
+          );
+
+          return {
+            success: true,
+            consoleId,
+            executions: executions.map(execution => ({
+              id: execution._id.toString(),
+              executedAt: execution.executedAt,
+              source: execution.source,
+              status: execution.status,
+              executionTimeMs: execution.executionTimeMs,
+              rowCount: execution.rowCount ?? null,
+              errorType: execution.errorType ?? null,
+              apiKeyId: execution.apiKeyId
+                ? execution.apiKeyId.toString()
+                : null,
+              databaseType: execution.databaseType,
+              queryLanguage: execution.queryLanguage,
+            })),
+          };
+        } catch (error) {
+          return {
+            success: false,
+            error:
+              error instanceof Error
+                ? error.message
+                : "Failed to list console executions",
           };
         }
       },

--- a/api/src/agent-lib/tools/server-console-tools.ts
+++ b/api/src/agent-lib/tools/server-console-tools.ts
@@ -82,6 +82,11 @@ export interface ServerConsoleToolsOptions {
   chatId?: string;
   /** Database capability granted by the calling API key. */
   queryAccess?: QueryAccess;
+  /**
+   * Where these tools are hosted. MCP is an external surface and updates
+   * lastExternalUsedAt; in-product agent stays internal (`agent`).
+   */
+  surface?: "agent" | "mcp";
 }
 
 interface LoadedConsole {
@@ -116,8 +121,10 @@ export function createServerConsoleTools({
   executionContext,
   chatId,
   queryAccess = "write",
+  surface = "agent",
 }: ServerConsoleToolsOptions) {
   const agentClientId = `agent:${chatId ?? "unknown"}`;
+  const runSource = surface === "mcp" ? ("mcp" as const) : ("agent" as const);
 
   const loadConsole = async (consoleId: string): Promise<LoadResult> => {
     if (!consoleId) {
@@ -191,6 +198,14 @@ export function createServerConsoleTools({
           const loaded = await loadConsole(consoleId);
           if (isLoadError(loaded)) return { success: false, ...loaded };
           const { doc } = loaded;
+          if (surface === "mcp") {
+            void consoleManager.recordExternalUse(
+              doc._id.toString(),
+              workspaceId,
+              "mcp",
+              "access",
+            );
+          }
           const { content, totalLines } = withLineNumbers(doc.code);
           return {
             success: true,
@@ -616,7 +631,7 @@ export function createServerConsoleTools({
             workspaceId,
             consoleId,
             userId: userId ?? "agent",
-            source: "agent",
+            source: runSource,
             executionId,
             signal: executionContext?.signal,
             readOnly: queryAccess === "read",

--- a/api/src/agent-lib/tools/server-console-tools.ts
+++ b/api/src/agent-lib/tools/server-console-tools.ts
@@ -42,6 +42,7 @@ import {
   cancelDetachedConsoleRun,
 } from "../../services/console-execution.service";
 import { queryExecutionService } from "../../services/query-execution.service";
+import { queryExecutionSourceLabel } from "../../services/query-execution-source";
 import {
   MONGO_QUERY_WRITE_SCOPE_REQUIRED,
   sqlReadOnlyAccessError,
@@ -777,7 +778,7 @@ export function createServerConsoleTools({
 
     list_console_executions: tool({
       description:
-        "List recent query executions for a console (App UI, API key, MCP, in-app agent, schedule). Returns newest-first rows with source, status, duration, and rowCount. History is retained for ~90 days. Use this to see whether a console is used externally (source api/mcp) or only in-app.",
+        "List recent query executions for a console. Each row includes source (raw) and sourceLabel (App UI / API key / MCP / AI agent / Schedule / Flow). Use sourceLabel when explaining to the user; source api|mcp means external. History is retained for ~90 days.",
       inputSchema: listConsoleExecutionsSchema,
       execute: async ({ consoleId, limit }) => {
         try {
@@ -797,6 +798,7 @@ export function createServerConsoleTools({
               id: execution._id.toString(),
               executedAt: execution.executedAt,
               source: execution.source,
+              sourceLabel: queryExecutionSourceLabel(execution.source),
               status: execution.status,
               executionTimeMs: execution.executionTimeMs,
               rowCount: execution.rowCount ?? null,

--- a/api/src/agents/modes/registry.ts
+++ b/api/src/agents/modes/registry.ts
@@ -90,6 +90,7 @@ const QUERY_MODE_TOOL_NAMES: string[] = [
   // Long-running query lifecycle (pairs with sql_execute_query / run_console)
   "check_query_status",
   "cancel_query",
+  "list_console_executions",
 ];
 
 const DASHBOARD_MODE_TOOL_NAMES: string[] = [

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -508,8 +508,8 @@ export interface ISavedConsole extends Document {
   executionCount: number;
   /**
    * Last time this console was used via an external surface (REST API key
-   * execute, or MCP read/run). Used to decide what is safe to archive.
-   * Distinct from lastExecutedAt, which also includes in-app UI / agent runs.
+   * execute, or MCP read/run). Distinct from lastExecutedAt, which also
+   * includes in-app UI / agent runs.
    */
   lastExternalUsedAt?: Date;
   /** Number of external executions (API key / MCP run_console). Reads do not increment. */

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -506,6 +506,16 @@ export interface ISavedConsole extends Document {
   updatedAt: Date;
   lastExecutedAt?: Date;
   executionCount: number;
+  /**
+   * Last time this console was used via an external surface (REST API key
+   * execute, or MCP read/run). Used to decide what is safe to archive.
+   * Distinct from lastExecutedAt, which also includes in-app UI / agent runs.
+   */
+  lastExternalUsedAt?: Date;
+  /** Number of external executions (API key / MCP run_console). Reads do not increment. */
+  externalUseCount: number;
+  /** Which external surface last touched this console. */
+  lastExternalSource?: "api" | "mcp";
 }
 
 export interface IScheduledQueryRun extends Document {
@@ -1119,6 +1129,7 @@ export interface IQueryExecution extends Document {
     | "console_ui"
     | "console_ui_admin_override"
     | "api"
+    | "mcp"
     | "agent"
     | "flow"
     | "scheduled_query";
@@ -1731,6 +1742,18 @@ const SavedConsoleSchema = new Schema<ISavedConsole>(
       type: Number,
       default: 0,
     },
+    lastExternalUsedAt: {
+      type: Date,
+    },
+    externalUseCount: {
+      type: Number,
+      default: 0,
+    },
+    lastExternalSource: {
+      type: String,
+      enum: ["api", "mcp"],
+      required: false,
+    },
     version: {
       type: Number,
       default: 1,
@@ -1796,6 +1819,10 @@ SavedConsoleSchema.index({ workspaceId: 1, access: 1, owner_id: 1 }); // Console
 SavedConsoleSchema.index(
   { workspaceId: 1, "scheduledRun.nextAt": 1 },
   { sparse: true },
+);
+SavedConsoleSchema.index(
+  { workspaceId: 1, lastExternalUsedAt: 1 },
+  { sparse: true, name: "savedconsoles_workspace_last_external_used" },
 );
 SavedConsoleSchema.index(
   { name: "text", description: "text" },
@@ -2788,6 +2815,7 @@ const QueryExecutionSchema = new Schema<IQueryExecution>(
         "console_ui",
         "console_ui_admin_override",
         "api",
+        "mcp",
         "agent",
         "flow",
         "scheduled_query",

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -2853,6 +2853,10 @@ QueryExecutionSchema.index({ workspaceId: 1, executedAt: -1 }); // Usage over ti
 QueryExecutionSchema.index({ userId: 1, executedAt: -1 }); // Per-user analytics
 QueryExecutionSchema.index({ apiKeyId: 1, executedAt: -1 }, { sparse: true }); // API key usage
 QueryExecutionSchema.index({ workspaceId: 1, status: 1 }); // Error rate monitoring
+QueryExecutionSchema.index(
+  { workspaceId: 1, consoleId: 1, executedAt: -1 },
+  { sparse: true, name: "query_executions_workspace_console_executed" },
+); // Per-console recent runs
 QueryExecutionSchema.index({ executedAt: 1 }, { expireAfterSeconds: 7776000 }); // TTL: 90 days
 
 const ScheduledQueryRunSchema = new Schema<IScheduledQueryRun>(

--- a/api/src/mcp/bridge-policy.ts
+++ b/api/src/mcp/bridge-policy.ts
@@ -155,6 +155,7 @@ export const MCP_BRIDGE_POLICY: Readonly<Record<string, McpBridgeEntry>> = {
   ),
   read_console: bridge(),
   run_console: bridge({ requiresQueryAccess: true }),
+  list_console_executions: bridge(),
   schedule_query: exclude(
     "in-product-only",
     "Scheduled writes need session auth + console ownership UX; not in MCP read-only apps loop.",

--- a/api/src/mcp/mako-mcp-server.ts
+++ b/api/src/mcp/mako-mcp-server.ts
@@ -124,6 +124,7 @@ export function buildMakoMcpCandidateTools(
     userId,
     chatId,
     queryAccess,
+    surface: "mcp",
   });
 
   const sqlTools = createSqlToolsV2(

--- a/api/src/migrations/2026-07-23-030000_console_external_usage_index.ts
+++ b/api/src/migrations/2026-07-23-030000_console_external_usage_index.ts
@@ -1,0 +1,47 @@
+import { Db } from "mongodb";
+import { loggers } from "../logging";
+
+const log = loggers.migration();
+
+export const description =
+  "Index savedconsoles by workspaceId + lastExternalUsedAt for unused-console queries";
+
+function hasIndexOnKeys(
+  indexes: Array<{ key?: Record<string, unknown> }>,
+  keyPattern: Record<string, number>,
+): boolean {
+  const target = JSON.stringify(keyPattern);
+  return indexes.some(idx => JSON.stringify(idx.key ?? {}) === target);
+}
+
+export async function up(db: Db): Promise<void> {
+  const collection = db.collection("savedconsoles");
+  const keyPattern = { workspaceId: 1, lastExternalUsedAt: 1 };
+
+  try {
+    const existingIndexes = await collection.indexes();
+    if (hasIndexOnKeys(existingIndexes, keyPattern)) {
+      log.info(
+        "Index { workspaceId: 1, lastExternalUsedAt: 1 } already exists on savedconsoles",
+      );
+      return;
+    }
+
+    await collection.createIndex(keyPattern, {
+      name: "savedconsoles_workspace_last_external_used",
+      background: true,
+      sparse: true,
+    });
+    log.info(
+      "Created sparse index { workspaceId: 1, lastExternalUsedAt: 1 } on savedconsoles",
+    );
+  } catch (err: unknown) {
+    const code = (err as { code?: number; codeName?: string })?.code;
+    const codeName = (err as { codeName?: string })?.codeName;
+    if (code === 85 || codeName === "IndexOptionsConflict") {
+      log.info("Index already exists under a different name, skipping");
+      return;
+    }
+    throw err;
+  }
+}

--- a/api/src/migrations/2026-07-23-030000_console_external_usage_index.ts
+++ b/api/src/migrations/2026-07-23-030000_console_external_usage_index.ts
@@ -4,7 +4,7 @@ import { loggers } from "../logging";
 const log = loggers.migration();
 
 export const description =
-  "Index savedconsoles by workspaceId + lastExternalUsedAt for unused-console queries";
+  "Index savedconsoles by workspaceId + lastExternalUsedAt for external-usage queries";
 
 function hasIndexOnKeys(
   indexes: Array<{ key?: Record<string, unknown> }>,

--- a/api/src/migrations/2026-07-23-040000_query_executions_console_index.ts
+++ b/api/src/migrations/2026-07-23-040000_query_executions_console_index.ts
@@ -1,0 +1,47 @@
+import { Db } from "mongodb";
+import { loggers } from "../logging";
+
+const log = loggers.migration();
+
+export const description =
+  "Index query_executions by workspaceId + consoleId + executedAt for per-console logs";
+
+function hasIndexOnKeys(
+  indexes: Array<{ key?: Record<string, unknown> }>,
+  keyPattern: Record<string, number>,
+): boolean {
+  const target = JSON.stringify(keyPattern);
+  return indexes.some(idx => JSON.stringify(idx.key ?? {}) === target);
+}
+
+export async function up(db: Db): Promise<void> {
+  const collection = db.collection("query_executions");
+  const keyPattern = { workspaceId: 1, consoleId: 1, executedAt: -1 };
+
+  try {
+    const existingIndexes = await collection.indexes();
+    if (hasIndexOnKeys(existingIndexes, keyPattern)) {
+      log.info(
+        "Index { workspaceId: 1, consoleId: 1, executedAt: -1 } already exists on query_executions",
+      );
+      return;
+    }
+
+    await collection.createIndex(keyPattern, {
+      name: "query_executions_workspace_console_executed",
+      background: true,
+      sparse: true,
+    });
+    log.info(
+      "Created sparse index { workspaceId: 1, consoleId: 1, executedAt: -1 } on query_executions",
+    );
+  } catch (err: unknown) {
+    const code = (err as { code?: number; codeName?: string })?.code;
+    const codeName = (err as { codeName?: string })?.codeName;
+    if (code === 85 || codeName === "IndexOptionsConflict") {
+      log.info("Index already exists under a different name, skipping");
+      return;
+    }
+    throw err;
+  }
+}

--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -2878,6 +2878,16 @@ consoleRoutes.openapi(
         },
       );
 
+      // API-key executes are external use — durable signal for archive decisions.
+      if (apiKey) {
+        void consoleManager.recordExternalUse(
+          savedConsole._id.toString(),
+          access.workspaceId,
+          "api",
+          "execute",
+        );
+      }
+
       // Return the result
       const previewRows =
         "rows" in result && Array.isArray(result.rows)
@@ -3239,7 +3249,7 @@ consoleRoutes.openapi(
         workspaceId: new Types.ObjectId(access.workspaceId),
       })
         .select(
-          "_id name description language connectionId databaseName createdAt updatedAt lastExecutedAt executionCount access owner_id createdBy",
+          "_id name description language connectionId databaseName createdAt updatedAt lastExecutedAt executionCount lastExternalUsedAt externalUseCount lastExternalSource access owner_id createdBy",
         )
         .populate("connectionId", "name type")
         .sort({ updatedAt: -1 });
@@ -3271,6 +3281,9 @@ consoleRoutes.openapi(
           updatedAt: console.updatedAt,
           lastExecutedAt: console.lastExecutedAt,
           executionCount: console.executionCount,
+          lastExternalUsedAt: console.lastExternalUsedAt ?? null,
+          externalUseCount: console.externalUseCount ?? 0,
+          lastExternalSource: console.lastExternalSource ?? null,
           access: ConsoleManager.resolveAccess(console),
           owner_id: console.owner_id || console.createdBy,
         })),
@@ -3366,6 +3379,16 @@ consoleRoutes.openapi(
         ownerDisplayName = ownerUser?.email;
       }
 
+      // API-key clients reading console details count as external access.
+      if (isApiKeyAuth(c)) {
+        void consoleManager.recordExternalUse(
+          savedConsole._id.toString(),
+          access.workspaceId,
+          "api",
+          "access",
+        );
+      }
+
       return c.json({
         success: true,
         console: {
@@ -3387,6 +3410,9 @@ consoleRoutes.openapi(
           updatedAt: savedConsole.updatedAt,
           lastExecutedAt: savedConsole.lastExecutedAt,
           executionCount: savedConsole.executionCount,
+          lastExternalUsedAt: savedConsole.lastExternalUsedAt ?? null,
+          externalUseCount: savedConsole.externalUseCount ?? 0,
+          lastExternalSource: savedConsole.lastExternalSource ?? null,
           access: resolvedAccess,
           owner_id: ownerId,
           ownerDisplayName,

--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -23,6 +23,7 @@ import {
   QueryLanguage,
   QueryStatus,
 } from "../services/query-execution.service";
+import { queryExecutionSourceLabel } from "../services/query-execution-source";
 import { Types } from "mongoose";
 import { loggers, enrichContextWithWorkspace } from "../logging";
 import { AuthenticatedContext } from "../middleware/workspace.middleware";
@@ -3380,6 +3381,7 @@ consoleRoutes.openapi(
           id: execution._id,
           executedAt: execution.executedAt,
           source: execution.source,
+          sourceLabel: queryExecutionSourceLabel(execution.source),
           status: execution.status,
           executionTimeMs: execution.executionTimeMs,
           rowCount: execution.rowCount ?? null,

--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -2878,7 +2878,8 @@ consoleRoutes.openapi(
         },
       );
 
-      // API-key executes are external use — durable signal for archive decisions.
+      // API-key executes count as external use (monitor integrations separately
+      // from in-app runs).
       if (apiKey) {
         void consoleManager.recordExternalUse(
           savedConsole._id.toString(),

--- a/api/src/routes/consoles.ts
+++ b/api/src/routes/consoles.ts
@@ -3304,6 +3304,108 @@ consoleRoutes.openapi(
   },
 );
 
+// GET /api/workspaces/:workspaceId/consoles/:id/executions - Recent query execution logs
+consoleRoutes.openapi(
+  createRoute({
+    method: "get",
+    path: "/{id}/executions",
+    tags: ["Consoles"],
+    summary: "GET /{id}/executions",
+    security: AUTH_SECURITY,
+    request: {
+      params: z.object({
+        workspaceId: z
+          .string()
+          .openapi({ param: { name: "workspaceId", in: "path" } }),
+        id: z.string().openapi({ param: { name: "id", in: "path" } }),
+      }),
+      query: z.object({
+        limit: z
+          .string()
+          .optional()
+          .openapi({ param: { name: "limit", in: "query" } }),
+      }),
+    },
+    responses: { ...OPEN_RESPONSES },
+  }),
+  async c => {
+    try {
+      const access = await verifyWorkspaceAccess(c);
+      if (!access) {
+        return c.json(
+          { success: false, error: "Access denied to workspace" },
+          403,
+        );
+      }
+
+      const consoleId = c.req.param("id");
+      if (!Types.ObjectId.isValid(consoleId)) {
+        return c.json({ success: false, error: "Invalid console ID" }, 400);
+      }
+
+      const savedConsole = await SavedConsole.findOne({
+        _id: new Types.ObjectId(consoleId),
+        workspaceId: new Types.ObjectId(access.workspaceId),
+        $or: [
+          { is_deleted: { $ne: true } },
+          { is_deleted: { $exists: false } },
+        ],
+      });
+
+      if (!savedConsole) {
+        return c.json({ success: false, error: "Console not found" }, 404);
+      }
+
+      const user = c.get("user");
+      if (
+        user?.id &&
+        !(await consoleManager.canReadWithInheritance(savedConsole, user.id))
+      ) {
+        return c.json({ success: false, error: "Console not found" }, 404);
+      }
+
+      const limitParam = c.req.query("limit");
+      const parsedLimit = limitParam ? Number.parseInt(limitParam, 10) : 10;
+      const limit = Number.isFinite(parsedLimit) ? parsedLimit : 10;
+
+      const executions = await queryExecutionService.getConsoleExecutions(
+        access.workspaceId,
+        consoleId,
+        { limit },
+      );
+
+      return c.json({
+        success: true,
+        executions: executions.map(execution => ({
+          id: execution._id,
+          executedAt: execution.executedAt,
+          source: execution.source,
+          status: execution.status,
+          executionTimeMs: execution.executionTimeMs,
+          rowCount: execution.rowCount ?? null,
+          errorType: execution.errorType ?? null,
+          userId: execution.userId,
+          apiKeyId: execution.apiKeyId ?? null,
+          databaseType: execution.databaseType,
+          queryLanguage: execution.queryLanguage,
+        })),
+      });
+    } catch (error) {
+      logger.error("Error listing console executions", { error });
+      return c.json(
+        {
+          success: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Failed to list console executions",
+        },
+        500,
+      );
+    }
+  },
+);
+
 // GET /api/workspaces/:workspaceId/consoles/:id/details - Get console details (for API clients)
 consoleRoutes.openapi(
   createRoute({

--- a/api/src/routes/workspace-databases.ts
+++ b/api/src/routes/workspace-databases.ts
@@ -11,6 +11,7 @@ import {
   DatabaseConnection,
   IDatabaseConnection,
   Flow,
+  SavedConsole,
 } from "../database/workspace-schema";
 import { databaseConnectionService } from "../services/database-connection.service";
 import {
@@ -21,6 +22,7 @@ import {
 } from "../services/query-execution.service";
 import { Types } from "mongoose";
 import { loggers } from "../logging";
+import { ConsoleManager } from "../utils/console-manager";
 import { checkPreviewQuerySafety } from "../services/query-pagination.service";
 import { createStreamingExportResponse } from "../utils/query-export-stream";
 import { createArrowIPCStreamResponse } from "../utils/arrow-serializer";
@@ -31,6 +33,7 @@ import { promises as fsPromises } from "fs";
 import { AUTH_SECURITY, OPEN_RESPONSES, createRouter } from "../openapi/core";
 
 const logger = loggers.db();
+const consoleManager = new ConsoleManager();
 
 type WorkspaceDatabaseRouteError = {
   response: { success: false; error: string };
@@ -2149,6 +2152,36 @@ workspaceExecuteRoutes.openapi(
           rowCount,
           errorType,
         });
+
+        // When a saved console id is provided, keep console execution stats
+        // current (UI runs historically omitted this). API-key runs also bump
+        // the durable external-use signal used for archive decisions.
+        if (validConsoleId) {
+          void SavedConsole.updateOne(
+            {
+              _id: validConsoleId,
+              workspaceId: workspace._id,
+            },
+            {
+              $set: { lastExecutedAt: new Date() },
+              $inc: { executionCount: 1 },
+            },
+          ).catch(error => {
+            logger.warn("Failed to update console execution stats", {
+              error,
+              consoleId: validConsoleId.toString(),
+            });
+          });
+
+          if (apiKey) {
+            void consoleManager.recordExternalUse(
+              validConsoleId.toString(),
+              workspace._id.toString(),
+              "api",
+              "execute",
+            );
+          }
+        }
 
         if (
           isPreviewMode &&

--- a/api/src/routes/workspace-databases.ts
+++ b/api/src/routes/workspace-databases.ts
@@ -2155,7 +2155,7 @@ workspaceExecuteRoutes.openapi(
 
         // When a saved console id is provided, keep console execution stats
         // current (UI runs historically omitted this). API-key runs also bump
-        // the durable external-use signal used for archive decisions.
+        // the durable external-use signal.
         if (validConsoleId) {
           void SavedConsole.updateOne(
             {

--- a/api/src/services/console-execution.service.ts
+++ b/api/src/services/console-execution.service.ts
@@ -327,7 +327,7 @@ async function runResolvedConsole(args: {
   });
 
   // External surfaces (REST API key / MCP) get a durable per-console signal
-  // for archive decisions. In-app agent runs stay on lastExecutedAt only.
+  // so integrations can be monitored separately from in-app agent runs.
   if (source === "api" || source === "mcp") {
     void consoleManager.recordExternalUse(
       consoleId,

--- a/api/src/services/console-execution.service.ts
+++ b/api/src/services/console-execution.service.ts
@@ -27,8 +27,10 @@ import {
 import { publishRealtimeEvent } from "./realtime.service";
 import { loggers } from "../logging";
 import { QUERY_HARD_MAX_EXECUTION_MS } from "../config/long-running-queries";
+import { ConsoleManager } from "../utils/console-manager";
 
 const logger = loggers.query();
+const consoleManager = new ConsoleManager();
 
 /** Caps applied to the persisted run artifact. */
 const ARTIFACT_MAX_ROWS = 50;
@@ -323,6 +325,17 @@ async function runResolvedConsole(args: {
     rowCount: result.success ? rowCount : undefined,
     errorType,
   });
+
+  // External surfaces (REST API key / MCP) get a durable per-console signal
+  // for archive decisions. In-app agent runs stay on lastExecutedAt only.
+  if (source === "api" || source === "mcp") {
+    void consoleManager.recordExternalUse(
+      consoleId,
+      workspaceId,
+      source,
+      "execute",
+    );
+  }
 
   // Poke attached windows: open tabs render the run artifact immediately.
   // The realtime event contract is success|error; the precise cancelled

--- a/api/src/services/query-execution-source.ts
+++ b/api/src/services/query-execution-source.ts
@@ -1,0 +1,14 @@
+/** Human-readable labels for query_executions.source (API + agent). */
+export const QUERY_EXECUTION_SOURCE_LABELS: Record<string, string> = {
+  console_ui: "App UI",
+  console_ui_admin_override: "App UI (admin)",
+  api: "API key",
+  mcp: "MCP",
+  agent: "AI agent",
+  flow: "Flow",
+  scheduled_query: "Schedule",
+};
+
+export function queryExecutionSourceLabel(source: string): string {
+  return QUERY_EXECUTION_SOURCE_LABELS[source] ?? source;
+}

--- a/api/src/services/query-execution.service.ts
+++ b/api/src/services/query-execution.service.ts
@@ -176,6 +176,32 @@ export class QueryExecutionService {
   /**
    * Get usage summary for a workspace
    */
+
+  /**
+   * Recent executions for a single saved console (newest first).
+   * Relies on the 90-day TTL on query_executions.
+   */
+  async getConsoleExecutions(
+    workspaceId: Types.ObjectId | string,
+    consoleId: Types.ObjectId | string,
+    options: { limit?: number } = {},
+  ): Promise<IQueryExecution[]> {
+    const limit = Math.min(Math.max(options.limit ?? 10, 1), 50);
+
+    const executions = await QueryExecution.find({
+      workspaceId: new Types.ObjectId(workspaceId.toString()),
+      consoleId: new Types.ObjectId(consoleId.toString()),
+    })
+      .sort({ executedAt: -1 })
+      .limit(limit)
+      .select(
+        "executedAt source status executionTimeMs rowCount errorType userId apiKeyId databaseType queryLanguage",
+      )
+      .lean();
+
+    return executions as IQueryExecution[];
+  }
+
   async getWorkspaceUsageSummary(
     workspaceId: Types.ObjectId | string,
     startDate: Date,

--- a/api/src/services/query-execution.service.ts
+++ b/api/src/services/query-execution.service.ts
@@ -11,6 +11,7 @@ export type QuerySource =
   | "console_ui"
   | "console_ui_admin_override"
   | "api"
+  | "mcp"
   | "agent"
   | "flow"
   | "scheduled_query";

--- a/api/src/utils/console-manager.ts
+++ b/api/src/utils/console-manager.ts
@@ -1204,6 +1204,65 @@ export class ConsoleManager {
   }
 
   /**
+   * Record external (API key / MCP) use of a console.
+   *
+   * - `execute`: bumps lastExternalUsedAt, externalUseCount, lastExternalSource
+   * - `access`: bumps lastExternalUsedAt / lastExternalSource only, throttled
+   *   to at most once per minute (reads/list details should not write-amplify)
+   */
+  async recordExternalUse(
+    consoleId: string,
+    workspaceId: string,
+    source: "api" | "mcp",
+    mode: "execute" | "access" = "execute",
+  ): Promise<void> {
+    if (!Types.ObjectId.isValid(consoleId)) return;
+    try {
+      const now = new Date();
+      const filter: Record<string, unknown> = {
+        _id: new Types.ObjectId(consoleId),
+        workspaceId: new Types.ObjectId(workspaceId),
+      };
+
+      if (mode === "access") {
+        // Throttle access bumps so chatty MCP/API clients don't hammer writes.
+        filter.$or = [
+          { lastExternalUsedAt: { $exists: false } },
+          { lastExternalUsedAt: null },
+          {
+            lastExternalUsedAt: {
+              $lte: new Date(now.getTime() - 60_000),
+            },
+          },
+        ];
+        await SavedConsole.updateOne(filter, {
+          $set: {
+            lastExternalUsedAt: now,
+            lastExternalSource: source,
+          },
+        });
+        return;
+      }
+
+      await SavedConsole.updateOne(filter, {
+        $set: {
+          lastExternalUsedAt: now,
+          lastExternalSource: source,
+        },
+        $inc: { externalUseCount: 1 },
+      });
+    } catch (error) {
+      logger.error("Error recording external console use", {
+        error,
+        consoleId,
+        workspaceId,
+        source,
+        mode,
+      });
+    }
+  }
+
+  /**
    * Ensure folder path exists, creating folders as needed
    * Returns the ID of the deepest folder in the path
    */

--- a/app/src/agent-runtime/client-tool-manifest.ts
+++ b/app/src/agent-runtime/client-tool-manifest.ts
@@ -111,6 +111,12 @@ export const AGENT_TOOL_MANIFEST = {
     getLabel: () => "Executing console query",
     icon: "play",
   },
+  list_console_executions: {
+    domain: "console",
+    execution: "server",
+    getLabel: () => "Listing console executions",
+    icon: "list",
+  },
   sql_execute_query: {
     domain: "database",
     execution: "server",

--- a/app/src/components/ConsoleExecutionsPanel.tsx
+++ b/app/src/components/ConsoleExecutionsPanel.tsx
@@ -1,0 +1,129 @@
+import {
+  Alert,
+  Box,
+  Chip,
+  CircularProgress,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+
+export interface ConsoleExecutionRow {
+  id: string;
+  executedAt: string;
+  source: string;
+  status: string;
+  executionTimeMs: number;
+  rowCount: number | null;
+  errorType: string | null;
+  apiKeyId: string | null;
+}
+
+interface ConsoleExecutionsPanelProps {
+  loading: boolean;
+  error?: string | null;
+  executions: ConsoleExecutionRow[];
+}
+
+const sourceLabels: Record<string, string> = {
+  console_ui: "App",
+  console_ui_admin_override: "App (admin)",
+  api: "API",
+  mcp: "MCP",
+  agent: "Agent",
+  flow: "Flow",
+  scheduled_query: "Schedule",
+};
+
+function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "—";
+  if (ms < 1000) return `${Math.round(ms)} ms`;
+  return `${(ms / 1000).toFixed(1)} s`;
+}
+
+export default function ConsoleExecutionsPanel({
+  loading,
+  error,
+  executions,
+}: ConsoleExecutionsPanelProps) {
+  if (loading) {
+    return (
+      <Box sx={{ height: "100%", display: "grid", placeItems: "center" }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return <Alert severity="error">{error}</Alert>;
+  }
+
+  if (executions.length === 0) {
+    return (
+      <Box sx={{ p: 3 }}>
+        <Typography variant="body2" color="text.secondary">
+          No executions recorded in the last 90 days.
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ height: "100%", overflow: "auto" }}>
+      <Table size="small" stickyHeader>
+        <TableHead>
+          <TableRow>
+            <TableCell>When</TableCell>
+            <TableCell>Source</TableCell>
+            <TableCell>Status</TableCell>
+            <TableCell align="right">Duration</TableCell>
+            <TableCell align="right">Rows</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {executions.map(execution => (
+            <TableRow key={execution.id} hover>
+              <TableCell sx={{ whiteSpace: "nowrap" }}>
+                {new Date(execution.executedAt).toLocaleString()}
+              </TableCell>
+              <TableCell>
+                <Chip
+                  label={sourceLabels[execution.source] || execution.source}
+                  size="small"
+                  variant="outlined"
+                  color={
+                    execution.source === "api" || execution.source === "mcp"
+                      ? "primary"
+                      : "default"
+                  }
+                />
+              </TableCell>
+              <TableCell>
+                <Typography
+                  variant="body2"
+                  color={
+                    execution.status === "success"
+                      ? "success.main"
+                      : execution.status === "cancelled"
+                        ? "text.secondary"
+                        : "error.main"
+                  }
+                >
+                  {execution.status}
+                  {execution.errorType ? ` (${execution.errorType})` : ""}
+                </Typography>
+              </TableCell>
+              <TableCell align="right" sx={{ whiteSpace: "nowrap" }}>
+                {formatDuration(execution.executionTimeMs)}
+              </TableCell>
+              <TableCell align="right">{execution.rowCount ?? "—"}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Box>
+  );
+}

--- a/app/src/components/ConsoleExecutionsPanel.tsx
+++ b/app/src/components/ConsoleExecutionsPanel.tsx
@@ -10,6 +10,10 @@ import {
   TableRow,
   Typography,
 } from "@mui/material";
+import {
+  consoleExecutionSourceLabel,
+  isExternalConsoleExecutionSource,
+} from "../lib/console-execution-source";
 
 export interface ConsoleExecutionRow {
   id: string;
@@ -28,20 +32,45 @@ interface ConsoleExecutionsPanelProps {
   executions: ConsoleExecutionRow[];
 }
 
-const sourceLabels: Record<string, string> = {
-  console_ui: "App",
-  console_ui_admin_override: "App (admin)",
-  api: "API",
-  mcp: "MCP",
-  agent: "Agent",
-  flow: "Flow",
-  scheduled_query: "Schedule",
-};
-
 function formatDuration(ms: number): string {
   if (!Number.isFinite(ms) || ms < 0) return "—";
   if (ms < 1000) return `${Math.round(ms)} ms`;
   return `${(ms / 1000).toFixed(1)} s`;
+}
+
+function TriggerSourceCell({
+  source,
+  apiKeyId,
+}: {
+  source: string;
+  apiKeyId: string | null;
+}) {
+  const label = consoleExecutionSourceLabel(source);
+  const external = isExternalConsoleExecutionSource(source);
+  const keySuffix =
+    apiKeyId && (source === "api" || source === "mcp")
+      ? ` · key …${apiKeyId.slice(-6)}`
+      : "";
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 0.25 }}>
+      <Chip
+        label={label}
+        size="small"
+        color={external ? "primary" : "default"}
+        variant={external ? "filled" : "outlined"}
+        sx={{
+          alignSelf: "flex-start",
+          fontWeight: external ? 600 : 500,
+        }}
+      />
+      {keySuffix ? (
+        <Typography variant="caption" color="text.secondary">
+          {keySuffix.replace(/^ · /, "")}
+        </Typography>
+      ) : null}
+    </Box>
+  );
 }
 
 export default function ConsoleExecutionsPanel({
@@ -77,7 +106,7 @@ export default function ConsoleExecutionsPanel({
         <TableHead>
           <TableRow>
             <TableCell>When</TableCell>
-            <TableCell>Source</TableCell>
+            <TableCell>Trigger</TableCell>
             <TableCell>Status</TableCell>
             <TableCell align="right">Duration</TableCell>
             <TableCell align="right">Rows</TableCell>
@@ -90,15 +119,9 @@ export default function ConsoleExecutionsPanel({
                 {new Date(execution.executedAt).toLocaleString()}
               </TableCell>
               <TableCell>
-                <Chip
-                  label={sourceLabels[execution.source] || execution.source}
-                  size="small"
-                  variant="outlined"
-                  color={
-                    execution.source === "api" || execution.source === "mcp"
-                      ? "primary"
-                      : "default"
-                  }
+                <TriggerSourceCell
+                  source={execution.source}
+                  apiKeyId={execution.apiKeyId}
                 />
               </TableCell>
               <TableCell>

--- a/app/src/components/ConsoleInfoModal.tsx
+++ b/app/src/components/ConsoleInfoModal.tsx
@@ -19,6 +19,10 @@ import {
 } from "@mui/material";
 import { ContentCopy } from "@mui/icons-material";
 import { useConsoleStore } from "../store/consoleStore";
+import {
+  consoleExecutionSourceLabel,
+  isExternalConsoleExecutionSource,
+} from "../lib/console-execution-source";
 
 interface ConsoleInfoModalProps {
   open: boolean;
@@ -91,16 +95,6 @@ const MonospaceField = ({ value, onCopy, disabled }: MonospaceFieldProps) => {
 const accessLabels: Record<string, string> = {
   private: "Private",
   workspace: "Shared with workspace",
-};
-
-const sourceLabels: Record<string, string> = {
-  console_ui: "App",
-  console_ui_admin_override: "App (admin)",
-  api: "API",
-  mcp: "MCP",
-  agent: "Agent",
-  flow: "Flow",
-  scheduled_query: "Schedule",
 };
 
 function formatDuration(ms: number): string {
@@ -294,7 +288,7 @@ export default function ConsoleInfoModal({
                   <TableHead>
                     <TableRow>
                       <TableCell>When</TableCell>
-                      <TableCell>Source</TableCell>
+                      <TableCell>Trigger</TableCell>
                       <TableCell>Status</TableCell>
                       <TableCell align="right">Duration</TableCell>
                     </TableRow>
@@ -307,17 +301,27 @@ export default function ConsoleInfoModal({
                         </TableCell>
                         <TableCell>
                           <Chip
-                            label={
-                              sourceLabels[execution.source] || execution.source
-                            }
+                            label={consoleExecutionSourceLabel(
+                              execution.source,
+                            )}
                             size="small"
-                            variant="outlined"
                             color={
-                              execution.source === "api" ||
-                              execution.source === "mcp"
+                              isExternalConsoleExecutionSource(execution.source)
                                 ? "primary"
                                 : "default"
                             }
+                            variant={
+                              isExternalConsoleExecutionSource(execution.source)
+                                ? "filled"
+                                : "outlined"
+                            }
+                            sx={{
+                              fontWeight: isExternalConsoleExecutionSource(
+                                execution.source,
+                              )
+                                ? 600
+                                : 500,
+                            }}
                           />
                         </TableCell>
                         <TableCell>

--- a/app/src/components/ConsoleInfoModal.tsx
+++ b/app/src/components/ConsoleInfoModal.tsx
@@ -11,9 +11,14 @@ import {
   IconButton,
   Skeleton,
   Chip,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
 } from "@mui/material";
 import { ContentCopy } from "@mui/icons-material";
-import { apiClient } from "../lib/api-client";
+import { useConsoleStore } from "../store/consoleStore";
 
 interface ConsoleInfoModalProps {
   open: boolean;
@@ -31,6 +36,17 @@ interface ConsoleDetails {
   updatedAt?: string;
   executionCount?: number;
   lastExecutedAt?: string;
+}
+
+interface ConsoleExecutionLog {
+  id: string;
+  executedAt: string;
+  source: string;
+  status: string;
+  executionTimeMs: number;
+  rowCount: number | null;
+  errorType: string | null;
+  apiKeyId: string | null;
 }
 
 interface MonospaceFieldProps {
@@ -77,14 +93,45 @@ const accessLabels: Record<string, string> = {
   workspace: "Shared with workspace",
 };
 
+const sourceLabels: Record<string, string> = {
+  console_ui: "App",
+  console_ui_admin_override: "App (admin)",
+  api: "API",
+  mcp: "MCP",
+  agent: "Agent",
+  flow: "Flow",
+  scheduled_query: "Schedule",
+};
+
+function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "—";
+  if (ms < 1000) return `${Math.round(ms)} ms`;
+  return `${(ms / 1000).toFixed(1)} s`;
+}
+
+function formatExecutedAt(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
 export default function ConsoleInfoModal({
   open,
   onClose,
   consoleId,
   workspaceId,
 }: ConsoleInfoModalProps) {
+  const fetchConsoleDetails = useConsoleStore(s => s.fetchConsoleDetails);
+  const fetchConsoleExecutions = useConsoleStore(s => s.fetchConsoleExecutions);
   const [details, setDetails] = useState<ConsoleDetails | null>(null);
+  const [executions, setExecutions] = useState<ConsoleExecutionLog[]>([]);
   const [loadingDetails, setLoadingDetails] = useState(false);
+  const [loadingExecutions, setLoadingExecutions] = useState(false);
 
   const handleCopyToClipboard = useCallback((text: string) => {
     navigator.clipboard.writeText(text);
@@ -93,32 +140,40 @@ export default function ConsoleInfoModal({
   useEffect(() => {
     if (!open || !workspaceId || !consoleId) {
       setDetails(null);
+      setExecutions([]);
       return;
     }
 
     let cancelled = false;
     setLoadingDetails(true);
+    setLoadingExecutions(true);
 
-    apiClient
-      .get<{ success: boolean; console?: ConsoleDetails }>(
-        `/workspaces/${workspaceId}/consoles/${consoleId}/details`,
-      )
-      .then(data => {
-        if (!cancelled && data.console) {
-          setDetails(data.console);
-        }
-      })
-      .catch(() => {
-        // Ignore errors for details fetch
+    void fetchConsoleDetails(workspaceId, consoleId)
+      .then(consoleDetails => {
+        if (!cancelled) setDetails(consoleDetails);
       })
       .finally(() => {
         if (!cancelled) setLoadingDetails(false);
       });
 
+    void fetchConsoleExecutions(workspaceId, consoleId, { limit: 10 })
+      .then(rows => {
+        if (!cancelled) setExecutions(rows);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingExecutions(false);
+      });
+
     return () => {
       cancelled = true;
     };
-  }, [open, workspaceId, consoleId]);
+  }, [
+    open,
+    workspaceId,
+    consoleId,
+    fetchConsoleDetails,
+    fetchConsoleExecutions,
+  ]);
 
   const apiEndpoint = `/workspaces/${workspaceId || ":id"}/consoles/${consoleId}/execute`;
 
@@ -210,6 +265,87 @@ export default function ConsoleInfoModal({
               value={apiEndpoint}
               onCopy={() => handleCopyToClipboard(apiEndpoint)}
             />
+          </Box>
+
+          <Box>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              Recent executions
+            </Typography>
+            {loadingExecutions ? (
+              <Stack spacing={0.5}>
+                <Skeleton variant="rounded" height={28} />
+                <Skeleton variant="rounded" height={28} />
+                <Skeleton variant="rounded" height={28} />
+              </Stack>
+            ) : executions.length === 0 ? (
+              <Typography variant="body2" color="text.disabled">
+                No executions recorded in the last 90 days.
+              </Typography>
+            ) : (
+              <Box
+                sx={{
+                  border: 1,
+                  borderColor: "divider",
+                  borderRadius: 1,
+                  overflow: "hidden",
+                }}
+              >
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>When</TableCell>
+                      <TableCell>Source</TableCell>
+                      <TableCell>Status</TableCell>
+                      <TableCell align="right">Duration</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {executions.map(execution => (
+                      <TableRow key={execution.id}>
+                        <TableCell sx={{ whiteSpace: "nowrap" }}>
+                          {formatExecutedAt(execution.executedAt)}
+                        </TableCell>
+                        <TableCell>
+                          <Chip
+                            label={
+                              sourceLabels[execution.source] || execution.source
+                            }
+                            size="small"
+                            variant="outlined"
+                            color={
+                              execution.source === "api" ||
+                              execution.source === "mcp"
+                                ? "primary"
+                                : "default"
+                            }
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <Typography
+                            variant="body2"
+                            color={
+                              execution.status === "success"
+                                ? "success.main"
+                                : execution.status === "cancelled"
+                                  ? "text.secondary"
+                                  : "error.main"
+                            }
+                          >
+                            {execution.status}
+                            {execution.errorType
+                              ? ` (${execution.errorType})`
+                              : ""}
+                          </Typography>
+                        </TableCell>
+                        <TableCell align="right" sx={{ whiteSpace: "nowrap" }}>
+                          {formatDuration(execution.executionTimeMs)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </Box>
+            )}
           </Box>
         </Stack>
       </DialogContent>

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -1099,6 +1099,7 @@ function Editor({
     setCancellingTabs(prev => ({ ...prev, [tabId]: false }));
     const startTime = Date.now();
     try {
+      const consoleTab = tabs[tabId];
       const result = await executeQuery(
         currentWorkspace.id,
         connectionId,
@@ -1110,6 +1111,10 @@ function Editor({
           pageSize: options?.pageSize ?? 500,
           cursor: options?.cursor ?? null,
           confirmUnsafe: options?.confirmUnsafe,
+          // Console tab ids are Mongo ObjectIds (generateObjectId / server id).
+          ...(consoleTab?.kind === "console" || consoleTab?.kind === undefined
+            ? { consoleId: tabId }
+            : {}),
         },
       );
       const executionTime = Date.now() - startTime;

--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -85,6 +85,9 @@ import type { LoadError } from "../api";
 import ScheduleConsoleModal from "./ScheduleConsoleModal";
 import ConsoleRemoteUpdateBanner from "./ConsoleRemoteUpdateBanner";
 import ScheduledRunsPanel from "./ScheduledRunsPanel";
+import ConsoleExecutionsPanel, {
+  type ConsoleExecutionRow,
+} from "./ConsoleExecutionsPanel";
 import type { DbFlowFormRef } from "./DbFlowForm";
 import ConflictResolutionDialog, {
   ConflictData,
@@ -504,6 +507,15 @@ function Editor({
   const [tabScheduledRunsError, setTabScheduledRunsError] = useState<
     Record<string, string | null>
   >({});
+  const [tabExecutions, setTabExecutions] = useState<
+    Record<string, ConsoleExecutionRow[]>
+  >({});
+  const [tabExecutionsLoading, setTabExecutionsLoading] = useState<
+    Record<string, boolean>
+  >({});
+  const [tabExecutionsError, setTabExecutionsError] = useState<
+    Record<string, string | null>
+  >({});
 
   // Conflict resolution state
   const [conflictDialogOpen, setConflictDialogOpen] = useState(false);
@@ -564,6 +576,9 @@ function Editor({
   const removeSchedule = useConsoleStore(state => state.removeSchedule);
   const runScheduledNow = useConsoleStore(state => state.runScheduledNow);
   const listScheduledRuns = useConsoleStore(state => state.listScheduledRuns);
+  const fetchConsoleExecutions = useConsoleStore(
+    state => state.fetchConsoleExecutions,
+  );
   const updateTabScheduledRun = useConsoleStore(
     state => state.updateTabScheduledRun,
   );
@@ -1164,6 +1179,14 @@ function Editor({
         if (isMobile) {
           setMobileTab("results");
         }
+        // Keep the Runs panel fresh when it's open (fire-and-forget).
+        if (currentWorkspace && tabBottomPanel[tabId] === "runs") {
+          void fetchConsoleExecutions(currentWorkspace.id, tabId, {
+            limit: 25,
+          }).then(rows => {
+            setTabExecutions(prev => ({ ...prev, [tabId]: rows }));
+          });
+        }
       } else if (result.error !== "Query cancelled") {
         const errText =
           typeof result.error === "string"
@@ -1561,6 +1584,44 @@ function Editor({
     [currentWorkspace, listScheduledRuns, updateTabScheduledRun],
   );
 
+  const loadExecutionsForTab = useCallback(
+    async (tabId: string) => {
+      if (!currentWorkspace) return;
+
+      setTabExecutionsLoading(prev => ({ ...prev, [tabId]: true }));
+      setTabExecutionsError(prev => ({ ...prev, [tabId]: null }));
+
+      try {
+        const rows = await fetchConsoleExecutions(currentWorkspace.id, tabId, {
+          limit: 25,
+        });
+        setTabExecutions(prev => ({ ...prev, [tabId]: rows }));
+      } catch (error) {
+        setTabExecutionsError(prev => ({
+          ...prev,
+          [tabId]:
+            error instanceof Error
+              ? error.message
+              : "Failed to load executions",
+        }));
+      }
+
+      setTabExecutionsLoading(prev => ({ ...prev, [tabId]: false }));
+    },
+    [currentWorkspace, fetchConsoleExecutions],
+  );
+
+  const loadRunsPanelForTab = useCallback(
+    async (tabId: string) => {
+      const tab = useConsoleStore.getState().tabs[tabId];
+      await loadExecutionsForTab(tabId);
+      if (tab?.schedule) {
+        await loadScheduledRunsForTab(tabId);
+      }
+    },
+    [loadExecutionsForTab, loadScheduledRunsForTab],
+  );
+
   useEffect(() => {
     if (!activeTabId) return;
 
@@ -1570,7 +1631,7 @@ function Editor({
     setTabBottomPanel(prev =>
       prev[activeTabId] === "runs" ? prev : { ...prev, [activeTabId]: "runs" },
     );
-    void loadScheduledRunsForTab(activeTabId);
+    void loadRunsPanelForTab(activeTabId);
 
     const nextMetadata = { ...(activeTab.metadata || {}) };
     delete nextMetadata.openScheduledRuns;
@@ -1578,7 +1639,7 @@ function Editor({
       activeTabId,
       Object.keys(nextMetadata).length > 0 ? nextMetadata : undefined,
     );
-  }, [activeTabId, tabs, loadScheduledRunsForTab, updateMetadata]);
+  }, [activeTabId, tabs, loadRunsPanelForTab, updateMetadata]);
 
   const handleOpenScheduleModal = useCallback(
     (tabId: string, mode: "create" | "update") => {
@@ -1637,9 +1698,9 @@ function Editor({
       setTabBottomPanel(prev => ({ ...prev, [tabId]: "runs" }));
       setSnackbarMessage("Async query run queued");
       setSnackbarOpen(true);
-      await loadScheduledRunsForTab(tabId);
+      await loadRunsPanelForTab(tabId);
     },
-    [currentWorkspace, runScheduledNow, loadScheduledRunsForTab],
+    [currentWorkspace, runScheduledNow, loadRunsPanelForTab],
   );
 
   // Conflict resolution handlers
@@ -2539,7 +2600,7 @@ function Editor({
                           [tab.id]: value,
                         }));
                         if (value === "runs") {
-                          void loadScheduledRunsForTab(tab.id);
+                          void loadRunsPanelForTab(tab.id);
                         }
                       }}
                       sx={{
@@ -2569,7 +2630,7 @@ function Editor({
                       />
                       <Tab
                         value="runs"
-                        label={`Runs (${tab.scheduledRun?.runCount ?? 0})`}
+                        label="Runs"
                         disabled={!tab.isSaved}
                         disableRipple
                         sx={{
@@ -2593,11 +2654,51 @@ function Editor({
                   </Box>
                   <Box sx={{ flexGrow: 1, minHeight: 0 }}>
                     {(tabBottomPanel[tab.id] || "results") === "runs" ? (
-                      <ScheduledRunsPanel
-                        loading={tabScheduledRunsLoading[tab.id] || false}
-                        error={tabScheduledRunsError[tab.id]}
-                        runs={tabScheduledRuns[tab.id] || []}
-                      />
+                      <Box
+                        sx={{
+                          height: "100%",
+                          display: "flex",
+                          flexDirection: "column",
+                          minHeight: 0,
+                        }}
+                      >
+                        <Box sx={{ flex: 1, minHeight: 0 }}>
+                          <ConsoleExecutionsPanel
+                            loading={tabExecutionsLoading[tab.id] || false}
+                            error={tabExecutionsError[tab.id]}
+                            executions={tabExecutions[tab.id] || []}
+                          />
+                        </Box>
+                        {tab.schedule ? (
+                          <Box
+                            sx={{
+                              borderTop: 1,
+                              borderColor: "divider",
+                              maxHeight: "45%",
+                              minHeight: 120,
+                              display: "flex",
+                              flexDirection: "column",
+                            }}
+                          >
+                            <Typography
+                              variant="caption"
+                              color="text.secondary"
+                              sx={{ px: 1.5, py: 0.75, fontWeight: 600 }}
+                            >
+                              Scheduled runs
+                            </Typography>
+                            <Box sx={{ flex: 1, minHeight: 0 }}>
+                              <ScheduledRunsPanel
+                                loading={
+                                  tabScheduledRunsLoading[tab.id] || false
+                                }
+                                error={tabScheduledRunsError[tab.id]}
+                                runs={tabScheduledRuns[tab.id] || []}
+                              />
+                            </Box>
+                          </Box>
+                        ) : null}
+                      </Box>
                     ) : (
                       <ResultsTable
                         results={tabResults[tab.id] || null}

--- a/app/src/lib/console-execution-source.ts
+++ b/app/src/lib/console-execution-source.ts
@@ -1,0 +1,19 @@
+/** Human-readable labels for query_executions.source */
+export const CONSOLE_EXECUTION_SOURCE_LABELS: Record<string, string> = {
+  console_ui: "App UI",
+  console_ui_admin_override: "App UI (admin)",
+  api: "API key",
+  mcp: "MCP",
+  agent: "AI agent",
+  flow: "Flow",
+  scheduled_query: "Schedule",
+};
+
+export function consoleExecutionSourceLabel(source: string): string {
+  return CONSOLE_EXECUTION_SOURCE_LABELS[source] ?? source;
+}
+
+/** External integration surfaces (vs in-product). */
+export function isExternalConsoleExecutionSource(source: string): boolean {
+  return source === "api" || source === "mcp";
+}

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -200,6 +200,37 @@ interface ConsoleActions {
     consoleId: string,
     options?: { signal?: AbortSignal },
   ) => Promise<ConsoleContentResponse | null>;
+  /** Lightweight console metadata for the Console Information dialog. */
+  fetchConsoleDetails: (
+    workspaceId: string,
+    consoleId: string,
+  ) => Promise<{
+    description?: string;
+    ownerDisplayName?: string;
+    owner_id?: string;
+    access?: string;
+    createdAt?: string;
+    updatedAt?: string;
+    executionCount?: number;
+    lastExecutedAt?: string;
+  } | null>;
+  /** Recent query_executions rows for a console (90-day TTL). */
+  fetchConsoleExecutions: (
+    workspaceId: string,
+    consoleId: string,
+    options?: { limit?: number },
+  ) => Promise<
+    Array<{
+      id: string;
+      executedAt: string;
+      source: string;
+      status: string;
+      executionTimeMs: number;
+      rowCount: number | null;
+      errorType: string | null;
+      apiKeyId: string | null;
+    }>
+  >;
   saveConsole: (
     workspaceId: string,
     tabId: string,
@@ -1335,6 +1366,60 @@ export const useConsoleStore = create<ConsoleStore>()(
           }
           console.error("Failed to fetch console content", e);
           return null;
+        }
+      },
+
+      fetchConsoleDetails: async (workspaceId, consoleId) => {
+        try {
+          const data = await apiClient.get<{
+            success: boolean;
+            console?: {
+              description?: string;
+              ownerDisplayName?: string;
+              owner_id?: string;
+              access?: string;
+              createdAt?: string;
+              updatedAt?: string;
+              executionCount?: number;
+              lastExecutedAt?: string;
+            };
+          }>(`/workspaces/${workspaceId}/consoles/${consoleId}/details`);
+          return data.success && data.console ? data.console : null;
+        } catch {
+          return null;
+        }
+      },
+
+      fetchConsoleExecutions: async (workspaceId, consoleId, options) => {
+        try {
+          const limit = options?.limit ?? 10;
+          const data = await apiClient.get<{
+            success: boolean;
+            executions?: Array<{
+              id: string;
+              executedAt: string;
+              source: string;
+              status: string;
+              executionTimeMs: number;
+              rowCount: number | null;
+              errorType: string | null;
+              apiKeyId: string | null;
+            }>;
+          }>(
+            `/workspaces/${workspaceId}/consoles/${consoleId}/executions?limit=${limit}`,
+          );
+          if (!data.success || !Array.isArray(data.executions)) return [];
+          return data.executions.map(execution => ({
+            ...execution,
+            id: String(execution.id),
+            executedAt:
+              typeof execution.executedAt === "string"
+                ? execution.executedAt
+                : new Date(execution.executedAt).toISOString(),
+            apiKeyId: execution.apiKeyId ? String(execution.apiKeyId) : null,
+          }));
+        } catch {
+          return [];
         }
       },
 

--- a/app/src/store/consoleStore.ts
+++ b/app/src/store/consoleStore.ts
@@ -229,6 +229,8 @@ interface ConsoleActions {
       pageSize?: number;
       cursor?: string | null;
       confirmUnsafe?: boolean;
+      /** When set, links the run to a saved console for usage stats. */
+      consoleId?: string;
     },
   ) => Promise<QueryExecuteResult>;
   cancelQuery: (
@@ -1533,6 +1535,7 @@ export const useConsoleStore = create<ConsoleStore>()(
             cursor: options?.cursor,
             mode: "preview" as const,
             source: "console_ui",
+            ...(options?.consoleId ? { consoleId: options.consoleId } : {}),
             ...(options?.confirmUnsafe ? { confirmUnsafe: true } : {}),
           };
 

--- a/packages/agent-tools/src/console-tools.ts
+++ b/packages/agent-tools/src/console-tools.ts
@@ -128,6 +128,21 @@ export const cancelQueryStatusSchema = z.object({
     .describe("The executionId returned by run_console for the running query."),
 });
 
+export const listConsoleExecutionsSchema = z.object({
+  consoleId: z
+    .string()
+    .describe(
+      "Console ID whose recent execution history to list (from search_consoles / list_open_consoles).",
+    ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(50)
+    .optional()
+    .describe("Max rows to return (default 10, max 50). Retained for 90 days."),
+});
+
 export const setConsoleConnectionSchema = z.object({
   consoleId: z
     .string()
@@ -175,3 +190,6 @@ export type OpenConsoleInput = z.infer<typeof openConsoleSchema>;
 export type RunConsoleInput = z.infer<typeof runConsoleSchema>;
 export type CheckQueryStatusInput = z.infer<typeof checkQueryStatusSchema>;
 export type CancelQueryStatusInput = z.infer<typeof cancelQueryStatusSchema>;
+export type ListConsoleExecutionsInput = z.infer<
+  typeof listConsoleExecutionsSchema
+>;

--- a/packages/agent-tools/src/index.ts
+++ b/packages/agent-tools/src/index.ts
@@ -37,6 +37,7 @@ export {
   runConsoleSchema,
   checkQueryStatusSchema,
   cancelQueryStatusSchema,
+  listConsoleExecutionsSchema,
 } from "./console-tools";
 export type {
   ModifyConsoleInput,
@@ -48,6 +49,7 @@ export type {
   RunConsoleInput,
   CheckQueryStatusInput,
   CancelQueryStatusInput,
+  ListConsoleExecutionsInput,
 } from "./console-tools";
 
 export { clientChartTools } from "./chart-tools";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Execution history lives in `query_executions` (90-day TTL). This PR surfaces it where people already look for runs, and lets the agent/MCP query it.

### UI
- Console bottom panel **Runs** tab → recent executions (App / API / MCP / Agent / Schedule)
- If the console is scheduled, **Scheduled runs** remains as a subsection
- Console Information dialog still shows a short recent list too

### API
- `GET /api/workspaces/{id}/consoles/{consoleId}/executions?limit=10`
- Index on `{ workspaceId, consoleId, executedAt }`

### Agent / MCP
- New tool: `list_console_executions` (query mode + MCP bridge)
- Returns newest-first rows with `source`, `status`, `executionTimeMs`, `rowCount`, etc.

### Also
- UI runs send `consoleId` so they appear in the log
- External usage fields (`lastExternalUsedAt`, …) kept for API monitoring (no archive UX)

## Test plan
- [ ] Open a saved console → **Runs** tab → see recent App executions after running a query
- [ ] API-key / MCP execute → see API / MCP rows in Runs
- [ ] Scheduled console → Scheduled runs subsection still loads
- [ ] Agent: `list_console_executions({ consoleId })` returns the same history
- [ ] MCP: tool is exposed and callable
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8ce5-43c9-7ef2-813d-5559855e7dfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8ce5-43c9-7ef2-813d-5559855e7dfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

