### PR TITLE
fix(ui): one Refresh that force-rebuilds and loads once all sources are ready

### DIFF
--- a/api/src/agent-lib/tools/server-app-tools.ts
+++ b/api/src/agent-lib/tools/server-app-tools.ts
@@ -501,10 +501,15 @@ export function createServerAppTools({
                 "then call materialize_binding again. Do not delete/recreate it.",
             };
           }
+          // Explicit "rebuild" request: force past the definition-hash cache
+          // so the artifact is rebuilt from the current upstream data even when
+          // the binding query is unchanged. Without this, a rematerialize over
+          // an unchanged query is a no-op cache hit.
           const queued = await queueAppBindingMaterialization({
             workspaceId,
             appId,
             bindingId: binding.id,
+            force: true,
           });
           const waitMs = Math.min(Math.max(waitSeconds ?? 120, 0), 600) * 1000;
           const deadline = Date.now() + waitMs;

--- a/app/src/app-runtime/agent-tools.ts
+++ b/app/src/app-runtime/agent-tools.ts
@@ -239,7 +239,9 @@ export async function executeAppAgentTool(
         workspaceId,
         appId,
         binding.id,
-        { signal: options?.signal, timeoutMs },
+        // Explicit rebuild request: force past the definition-hash cache so
+        // unchanged queries still pick up new upstream data.
+        { force: true, signal: options?.signal, timeoutMs },
       );
       if (result.status === "building") {
         // Not an error: the build continues server-side. Return so the agent

--- a/app/src/components/AppBindingEditor.tsx
+++ b/app/src/components/AppBindingEditor.tsx
@@ -176,8 +176,8 @@ export default function AppBindingEditor({
     if (!workspaceId) return;
     setMaterializing(true);
     // Explicit user action = rebuild now. Force past the definition-hash cache
-    // so a rematerialize picks up new upstream data even when the query text is
-    // unchanged (parity with the dashboard data source Materialize button).
+    // so a refresh picks up new upstream data even when the query text is
+    // unchanged (parity with the dashboard data source Refresh button).
     await materializeBinding(workspaceId, appId, bindingId, { force: true });
     setMaterializing(false);
   }, [workspaceId, appId, bindingId, materializeBinding]);
@@ -292,8 +292,8 @@ export default function AppBindingEditor({
             <Typography variant="caption" display="block">
               <b>Materialized</b> — the query is snapshotted to a Parquet file
               (stored like dashboards) and loaded into DuckDB in the browser, so
-              the app can run fast analytical SQL. Click <b>Materialize</b> to
-              build/refresh the snapshot.
+              the app can run fast analytical SQL. Click <b>Refresh</b> to
+              rebuild the snapshot from source.
             </Typography>
           </Box>
         }

--- a/app/src/components/AppRenderer.tsx
+++ b/app/src/components/AppRenderer.tsx
@@ -22,7 +22,6 @@ import {
   History as HistoryIcon,
   UploadCloud as PublishIcon,
   CheckCircle2 as PublishedIcon,
-  DatabaseZap as RematerializeIcon,
   MoreVertical as MoreIcon,
   Info as InfoIcon,
 } from "lucide-react";
@@ -225,16 +224,13 @@ export default function AppRenderer({
     [workspaceId, appId, persistApp, saveVersion, fetchApp, publishSuggestion],
   );
 
-  const hasParquetBindings = !!appEntity?.dataBindings.some(
-    b => b.materialization === "parquet",
-  );
+  const hasAnyBindings = (appEntity?.dataBindings.length ?? 0) > 0;
 
-  // Rebuild every parquet binding's artifact in one shot. Recovers an app whose
-  // materialized cache was lost (e.g. a DB restore) — the query definitions and
-  // bindings are untouched; only the Parquet artifacts + cache are regenerated.
-  // Wait for every binding to settle, load fresh DuckDB tables, then post a
-  // data-refresh — never rebuild the preview mid-flight with partial data.
-  const handleRematerialize = useCallback(async () => {
+  // Single "Refresh" action: force-rebuild every parquet binding, wait until
+  // ALL settle, load DuckDB tables, then poke the running app once. Never
+  // reload the preview mid-flight with partial data (parity with public share
+  // and dashboard Refresh).
+  const handleRefreshData = useCallback(async () => {
     if (!workspaceId || rematerializing) return;
     setRematerializing(true);
     setRematerializeProgress({
@@ -244,14 +240,20 @@ export default function AppRenderer({
       failed: 0,
       phase: "building",
     });
-    setPublishedNotice("Rebuilding data for all bindings…");
+    setPublishedNotice("Refreshing data for all bindings…");
     try {
       const result = await materializeAllBindings(workspaceId, appId, {
+        force: true,
         onProgress: progress =>
           setRematerializeProgress({ ...progress, phase: "building" }),
       });
       if (result.total === 0) {
-        setPublishedNotice("No materialized bindings to rebuild.");
+        // Live-only app: just re-query in the running preview.
+        iframeRef.current?.contentWindow?.postMessage(
+          { type: PREVIEW_MESSAGE.dataRefresh },
+          "*",
+        );
+        setPublishedNotice("Refreshed live bindings.");
         return;
       }
 
@@ -283,16 +285,16 @@ export default function AppRenderer({
 
       if (result.failed === 0) {
         setPublishedNotice(
-          `Rebuilt data for ${result.ready} binding${result.ready === 1 ? "" : "s"}.`,
+          `Refreshed data for ${result.ready} binding${result.ready === 1 ? "" : "s"}.`,
         );
       } else {
         setPublishedNotice(
-          `Rebuilt ${result.ready}/${result.total}. Failed: ${result.errors.join("; ")}`,
+          `Refreshed ${result.ready}/${result.total}. Failed: ${result.errors.join("; ")}`,
         );
       }
     } catch (error) {
       setPublishedNotice(
-        error instanceof Error ? error.message : "Failed to rebuild data.",
+        error instanceof Error ? error.message : "Failed to refresh data.",
       );
     } finally {
       setRematerializing(false);
@@ -733,11 +735,23 @@ export default function AppRenderer({
             <ShareIcon size={18} strokeWidth={1.5} />
           </IconButton>
         </Tooltip>
-        <Tooltip title="Rebuild preview">
-          <IconButton size="small" onClick={() => bumpPreview(appId)}>
-            <RefreshIcon size={18} strokeWidth={1.5} />
-          </IconButton>
-        </Tooltip>
+        {canManage && hasAnyBindings && (
+          <Tooltip title="Refresh data from source (waits for every binding)">
+            <span>
+              <IconButton
+                size="small"
+                onClick={() => void handleRefreshData()}
+                disabled={rematerializing}
+              >
+                {rematerializing ? (
+                  <CircularProgress size={16} />
+                ) : (
+                  <RefreshIcon size={18} strokeWidth={1.5} />
+                )}
+              </IconButton>
+            </span>
+          </Tooltip>
+        )}
         <Tooltip title="More">
           <IconButton
             size="small"
@@ -764,27 +778,6 @@ export default function AppRenderer({
           </ListItemIcon>
           <ListItemText>Version history</ListItemText>
         </MenuItem>
-        {canManage && hasParquetBindings && (
-          <MenuItem
-            disabled={rematerializing}
-            onClick={() => {
-              setMoreAnchor(null);
-              void handleRematerialize();
-            }}
-          >
-            <ListItemIcon>
-              {rematerializing ? (
-                <CircularProgress size={14} />
-              ) : (
-                <RematerializeIcon size={16} strokeWidth={1.5} />
-              )}
-            </ListItemIcon>
-            <ListItemText
-              primary={rematerializing ? "Materializing…" : "Materialize data"}
-              secondary="Rebuild every query's Parquet file"
-            />
-          </MenuItem>
-        )}
         <Divider />
         <MenuItem disabled sx={{ "&.Mui-disabled": { opacity: 1 } }}>
           <ListItemText
@@ -872,11 +865,12 @@ export default function AppRenderer({
             {rematerializeProgress.phase === "loading"
               ? "Loading refreshed data into the preview…"
               : rematerializeProgress.total > 0
-                ? `Rebuilding data ${rematerializeProgress.settled}/${rematerializeProgress.total}` +
+                ? `Refreshing data ${rematerializeProgress.settled}/${rematerializeProgress.total}` +
                   (rematerializeProgress.failed > 0
                     ? ` (${rematerializeProgress.failed} failed)`
-                    : "")
-                : "Rebuilding data for all bindings…"}
+                    : "") +
+                  ". App reloads when every binding is ready."
+                : "Refreshing data for all bindings…"}
           </Typography>
         </Box>
       )}
@@ -902,7 +896,7 @@ export default function AppRenderer({
         }}
       >
         <iframe
-          // Keyed on the nonce so "Rebuild preview" always reboots: with
+          // Keyed on the nonce so preview reboots after restore/publish: with
           // unchanged code the regenerated srcDoc string is identical, so a
           // srcdoc-prop update alone would be skipped by React entirely.
           key={previewNonce}

--- a/app/src/components/AppRenderer.tsx
+++ b/app/src/components/AppRenderer.tsx
@@ -95,6 +95,7 @@ export default function AppRenderer({
   const appEntity = useAppStore(s => s.openApps[appId]);
   const appLoadError = useAppStore(s => s.openAppErrors[appId]);
   const previewNonce = useAppStore(s => s.previewNonce[appId] ?? 0);
+  const dataRefreshNonce = useAppStore(s => s.dataRefreshNonce[appId] ?? 0);
   const previewErrors = useAppStore(s => s.previewErrors[appId]);
   const fetchApp = useAppStore(s => s.fetchApp);
   const bumpPreview = useAppStore(s => s.bumpPreview);
@@ -360,8 +361,8 @@ export default function AppRenderer({
       setPublishedNotice(`Building data for "${binding.name}"…`);
       void materializeBinding(workspaceId, appId, binding.id).then(result => {
         if (result.status === "ready") {
-          // materializeBinding already refetched the app and bumped the
-          // preview, so the fresh artifact loads on the rebuilt preview.
+          // materializeBinding refetches + requestDataRefresh so DuckDB loads
+          // before the running preview re-queries (data → UI).
           setPublishedNotice(`Data for "${binding.name}" is ready.`);
         } else if (result.status === "error") {
           setPublishedNotice(
@@ -568,6 +569,40 @@ export default function AppRenderer({
     }
     lastDbtEnvRef.current = current;
   }, [effectiveDbtEnv]);
+
+  // Explicit binding refresh settled: load every ready parquet table into
+  // DuckDB first, then poke the running preview once (data → UI).
+  const lastDataRefreshNonceRef = useRef(0);
+  useEffect(() => {
+    if (
+      !dataRefreshNonce ||
+      dataRefreshNonce === lastDataRefreshNonceRef.current
+    ) {
+      return;
+    }
+    lastDataRefreshNonceRef.current = dataRefreshNonce;
+    if (!workspaceId || !appEntity) return;
+    let cancelled = false;
+    void (async () => {
+      await Promise.all(
+        appEntity.dataBindings
+          .filter(binding => binding.materialization === "parquet")
+          .map(binding =>
+            ensureBindingLoadedForPreview(workspaceId, appId, binding).catch(
+              () => false,
+            ),
+          ),
+      );
+      if (cancelled) return;
+      iframeRef.current?.contentWindow?.postMessage(
+        { type: PREVIEW_MESSAGE.dataRefresh },
+        "*",
+      );
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [dataRefreshNonce, workspaceId, appId, appEntity]);
 
   // Rebuild the preview document whenever files/deps change (nonce bumps).
   // The theme is read from a ref on purpose: it only seeds the boot paint and

--- a/app/src/components/AppRenderer.tsx
+++ b/app/src/components/AppRenderer.tsx
@@ -356,6 +356,13 @@ export default function AppRenderer({
       const hasArtifact =
         status === "ready" && Boolean(binding.cache?.parquetUrl);
       if (hasArtifact || status === "error") continue;
+      // A build is already in flight — an explicit Refresh (bulk or single),
+      // the agent, or a scheduled run flipped this binding to queued/building.
+      // Do NOT start a competing refreshPreview build: that path refreshes the
+      // running app once per binding, so the whole batch would poke the preview
+      // N times instead of once when every binding settles. The in-flight
+      // build's own caller applies data when it's done.
+      if (status === "queued" || status === "building") continue;
       if (autoMaterializeAttempted.current.has(binding.id)) continue;
       autoMaterializeAttempted.current.add(binding.id);
       setPublishedNotice(`Building data for "${binding.name}"…`);

--- a/app/src/components/AppRenderer.tsx
+++ b/app/src/components/AppRenderer.tsx
@@ -17,7 +17,6 @@ import {
   Snackbar,
 } from "@mui/material";
 import {
-  RefreshCw as RefreshIcon,
   Share2 as ShareIcon,
   History as HistoryIcon,
   UploadCloud as PublishIcon,
@@ -40,6 +39,7 @@ import ShareDialog from "./ShareDialog";
 import { SaveCommentDialog } from "./SaveCommentDialog";
 import { VersionHistoryPanel } from "./VersionHistoryPanel";
 import { useSaveCommentSuggestion } from "../hooks/useSaveCommentSuggestion";
+import ResourceRefreshControl from "./ResourceRefreshControl";
 import { buildPreviewHtml, PREVIEW_MESSAGE } from "../app-runtime/preview";
 import { appLocationFromHostSearch } from "../app-runtime/app-location";
 import {
@@ -765,28 +765,18 @@ export default function AppRenderer({
               </Box>
             </Tooltip>
           ))}
+        {canManage && hasAnyBindings && (
+          <ResourceRefreshControl
+            subject="binding"
+            busy={rematerializing}
+            onClick={() => void handleRefreshData()}
+          />
+        )}
         <Tooltip title="Share">
           <IconButton size="small" onClick={() => setShareOpen(true)}>
             <ShareIcon size={18} strokeWidth={1.5} />
           </IconButton>
         </Tooltip>
-        {canManage && hasAnyBindings && (
-          <Tooltip title="Refresh data from source (waits for every binding)">
-            <span>
-              <IconButton
-                size="small"
-                onClick={() => void handleRefreshData()}
-                disabled={rematerializing}
-              >
-                {rematerializing ? (
-                  <CircularProgress size={16} />
-                ) : (
-                  <RefreshIcon size={18} strokeWidth={1.5} />
-                )}
-              </IconButton>
-            </span>
-          </Tooltip>
-        )}
         <Tooltip title="More">
           <IconButton
             size="small"

--- a/app/src/components/AppsExplorer.tsx
+++ b/app/src/components/AppsExplorer.tsx
@@ -30,7 +30,6 @@ import {
   ExternalLink as OpenIcon,
   Pencil as RenameIcon,
   Trash2 as DeleteIcon,
-  Database as MaterializeIcon,
   History as HistoryIcon,
   Save as SaveVersionIcon,
 } from "lucide-react";
@@ -606,14 +605,21 @@ export function AppsExplorer() {
             <MenuItem
               key="materialize"
               onClick={() => {
-                void materializeBinding(workspaceId, parsed.appId, parsed.path);
+                // Explicit refresh = rebuild now. Force past the definition-hash
+                // cache so unchanged queries still pick up new upstream data.
+                void materializeBinding(
+                  workspaceId,
+                  parsed.appId,
+                  parsed.path,
+                  { force: true },
+                );
                 helpers.closeMenu();
               }}
             >
               <ListItemIcon>
-                <MaterializeIcon size={16} strokeWidth={1.5} />
+                <RefreshIcon size={16} strokeWidth={1.5} />
               </ListItemIcon>
-              Materialize
+              Refresh
             </MenuItem>,
           );
         }

--- a/app/src/components/DashboardCanvas.tsx
+++ b/app/src/components/DashboardCanvas.tsx
@@ -16,7 +16,6 @@ import {
   Alert,
 } from "@mui/material";
 import {
-  RefreshCw,
   Save,
   Download,
   Database,
@@ -61,6 +60,7 @@ import WidgetInspector from "./dashboard/WidgetInspector";
 import { SaveCommentDialog } from "./SaveCommentDialog";
 import { useSaveCommentSuggestion } from "../hooks/useSaveCommentSuggestion";
 import { VersionHistoryPanel } from "./VersionHistoryPanel";
+import ResourceRefreshControl from "./ResourceRefreshControl";
 
 type ViewMode = "canvas" | "code";
 
@@ -365,22 +365,6 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
           />
         </Tooltip>
 
-        <Tooltip title="Refresh data from source (waits for every data source)">
-          <span>
-            <Chip
-              icon={<RefreshCw size={14} />}
-              label={reloadingData ? "Refreshing…" : "Refresh"}
-              size="small"
-              variant="outlined"
-              onClick={handleRefresh}
-              disabled={reloadingData}
-              sx={{
-                cursor: reloadingData ? "default" : "pointer",
-              }}
-            />
-          </span>
-        </Tooltip>
-
         {isEditMode && (
           <>
             <Tooltip title="Add widget">
@@ -439,8 +423,16 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
           </IconButton>
         </Tooltip>
 
+        <Box sx={{ flex: 1 }} />
+
+        <ResourceRefreshControl
+          subject="data source"
+          busy={reloadingData}
+          onClick={handleRefresh}
+        />
+
         {canManageShare && (
-          <Tooltip title="Share dashboard">
+          <Tooltip title="Share">
             <IconButton size="small" onClick={() => setShareOpen(true)}>
               <Share2 size={16} />
             </IconButton>
@@ -510,7 +502,7 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
             label={`Logs ${recentEventLogCount}`}
             variant={showEventLog ? "filled" : "outlined"}
             onClick={() => setShowEventLog(prev => !prev)}
-            sx={{ cursor: "pointer", ml: "auto" }}
+            sx={{ cursor: "pointer" }}
           />
         </Tooltip>
       </Box>

--- a/app/src/components/DashboardCanvas.tsx
+++ b/app/src/components/DashboardCanvas.tsx
@@ -41,7 +41,6 @@ import { useAuth } from "../contexts/auth-context";
 import {
   applyFreshMaterializationCommand,
   materializeDashboardInBackgroundCommand,
-  refreshDashboardCommand,
   reloadDashboardDataSourcesCommand,
   shouldAutoApplyFreshMaterialization,
 } from "../dashboard-runtime/commands";
@@ -193,21 +192,20 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
   }, [dashboard?.title]);
 
   const [reloadingData, setReloadingData] = useState(false);
+  const [freshnessDismissed, setFreshnessDismissed] = useState(false);
 
+  // One Refresh action everywhere: force-rematerialize every data source,
+  // wait until ALL builds settle, then apply into the runtime once.
   const handleRefresh = useCallback(() => {
-    if (!workspaceId) {
-      return;
-    }
-    if (isEditMode) {
-      if (reloadingData) return;
-      setReloadingData(true);
-      void reloadDashboardDataSourcesCommand(workspaceId, dashboardId)
-        .catch(() => undefined)
-        .finally(() => setReloadingData(false));
-      return;
-    }
-    void refreshDashboardCommand(workspaceId, dashboardId);
-  }, [workspaceId, dashboardId, isEditMode, reloadingData]);
+    if (!workspaceId || reloadingData) return;
+    setFreshnessDismissed(true);
+    setReloadingData(true);
+    void reloadDashboardDataSourcesCommand(workspaceId, dashboardId)
+      .catch(() => {
+        setFreshnessDismissed(false);
+      })
+      .finally(() => setReloadingData(false));
+  }, [workspaceId, dashboardId, reloadingData]);
 
   const dataFreshness = useMemo(() => {
     if (!dashboard || dashboard.dataSources.length === 0) return null;
@@ -236,8 +234,6 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
     return { ageMs, label };
   }, [dashboard]);
 
-  const [freshnessDismissed, setFreshnessDismissed] = useState(false);
-
   useEffect(() => {
     setFreshnessDismissed(false);
   }, [dataFreshness?.ageMs]);
@@ -263,19 +259,6 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
     runtimeSession?.freshDataAvailable,
     workspaceId,
   ]);
-
-  const handleReloadData = useCallback(async () => {
-    if (!workspaceId || reloadingData) return;
-    setFreshnessDismissed(true);
-    setReloadingData(true);
-    try {
-      await reloadDashboardDataSourcesCommand(workspaceId, dashboardId);
-    } catch {
-      setFreshnessDismissed(false);
-    } finally {
-      setReloadingData(false);
-    }
-  }, [workspaceId, dashboardId, reloadingData]);
 
   const handleDismissStaleLock = useCallback(async () => {
     if (workspaceId && dashboardId) {
@@ -382,17 +365,17 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
           />
         </Tooltip>
 
-        <Tooltip title="Clear filters and rerun all widgets">
+        <Tooltip title="Refresh data from source (waits for every data source)">
           <span>
             <Chip
               icon={<RefreshCw size={14} />}
-              label={isEditMode && reloadingData ? "Reloading…" : "Refresh"}
+              label={reloadingData ? "Refreshing…" : "Refresh"}
               size="small"
               variant="outlined"
               onClick={handleRefresh}
-              disabled={isEditMode && reloadingData}
+              disabled={reloadingData}
               sx={{
-                cursor: isEditMode && reloadingData ? "default" : "pointer",
+                cursor: reloadingData ? "default" : "pointer",
               }}
             />
           </span>
@@ -400,20 +383,6 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
 
         {isEditMode && (
           <>
-            <Tooltip title="Reload data from source database">
-              <span>
-                <Chip
-                  icon={<Database size={14} />}
-                  label={reloadingData ? "Reloading…" : "Reload data"}
-                  size="small"
-                  variant="outlined"
-                  onClick={handleReloadData}
-                  disabled={reloadingData}
-                  sx={{ cursor: reloadingData ? "default" : "pointer" }}
-                />
-              </span>
-            </Tooltip>
-
             <Tooltip title="Add widget">
               <IconButton size="small" onClick={() => setAddWidgetOpen(true)}>
                 <Plus size={18} />
@@ -561,7 +530,7 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
         onForceEditMode={handleForceEditMode}
         onDismissStaleLock={handleDismissStaleLock}
         onEditModeToggle={handleEditModeToggle}
-        onReloadData={handleReloadData}
+        onReloadData={handleRefresh}
         dataFreshness={freshnessDismissed ? null : dataFreshness}
       />
 

--- a/app/src/components/DashboardDataSourceEditor.tsx
+++ b/app/src/components/DashboardDataSourceEditor.tsx
@@ -25,6 +25,7 @@ import DataSourceMaterializationControls, {
   type MaterializationHistoryItem,
 } from "./DataSourceMaterializationControls";
 import type { MaterializationScheduleValue } from "../lib/materializationSchedule";
+import { refreshDashboardDataSourceCommand } from "../dashboard-runtime/commands";
 
 interface PreviewResult {
   results: Record<string, unknown>[];
@@ -33,9 +34,6 @@ interface PreviewResult {
   executionTime?: number;
   fields?: Array<{ name?: string; originalName?: string } | string>;
 }
-
-const MATERIALIZE_POLL_INTERVAL_MS = 2500;
-const MATERIALIZE_POLL_TIMEOUT_MS = 10 * 60 * 1000;
 
 function dataSourceFilePath(name: string): string {
   return `${name.replace(/[^a-zA-Z0-9_-]/g, "_")}.sql`;
@@ -65,12 +63,6 @@ export default function DashboardDataSourceEditor({
   const openDashboard = useDashboardStore(s => s.openDashboard);
   const updateDataSource = useDashboardStore(s => s.updateDataSource);
   const saveDashboard = useDashboardStore(s => s.saveDashboard);
-  const materializeDataSource = useDashboardStore(
-    s => s.materializeDashboardDataSource,
-  );
-  const fetchMaterializationStatus = useDashboardStore(
-    s => s.fetchDashboardMaterializationStatus,
-  );
   const fetchMaterializationRuns = useDashboardStore(
     s => s.fetchMaterializationRuns,
   );
@@ -155,41 +147,17 @@ export default function DashboardDataSourceEditor({
     if (!workspaceId) return;
     setMaterializing(true);
     try {
-      await materializeDataSource(workspaceId, dashboardId, dataSourceId, {
-        force: true,
+      // Same contract as the data-source panel Refresh: force rebuild, wait
+      // until builds settle, then apply into the dashboard runtime once.
+      await refreshDashboardDataSourceCommand({
+        workspaceId,
+        dataSourceId,
+        dashboardId,
       });
-      // Poll until this data source leaves queued/building (status fetch also
-      // syncs cache onto the open dashboard, so the chip updates live).
-      const deadline = Date.now() + MATERIALIZE_POLL_TIMEOUT_MS;
-      while (Date.now() < deadline) {
-        await new Promise(resolve =>
-          setTimeout(resolve, MATERIALIZE_POLL_INTERVAL_MS),
-        );
-        const status = await fetchMaterializationStatus(
-          workspaceId,
-          dashboardId,
-        );
-        const sourceStatus = status?.dataSources.find(
-          source => source.dataSourceId === dataSourceId,
-        );
-        if (
-          !sourceStatus ||
-          (sourceStatus.status !== "queued" &&
-            sourceStatus.status !== "building")
-        ) {
-          break;
-        }
-      }
     } finally {
       setMaterializing(false);
     }
-  }, [
-    workspaceId,
-    dashboardId,
-    dataSourceId,
-    materializeDataSource,
-    fetchMaterializationStatus,
-  ]);
+  }, [workspaceId, dashboardId, dataSourceId]);
 
   const cache = dataSource?.cache;
 
@@ -313,7 +281,7 @@ export default function DashboardDataSourceEditor({
           <Typography variant="caption" display="block">
             <b>Materialized</b> — the query is snapshotted to a Parquet file and
             loaded into DuckDB, so widgets render fast and public viewers get a
-            cached snapshot. Click <b>Materialize</b> to build/refresh.
+            cached snapshot. Click <b>Refresh</b> to rebuild from source.
           </Typography>
         </Box>
       }

--- a/app/src/components/DataSourceMaterializationControls.tsx
+++ b/app/src/components/DataSourceMaterializationControls.tsx
@@ -14,7 +14,7 @@ import {
   Divider,
 } from "@mui/material";
 import {
-  DatabaseZap as MaterializeIcon,
+  RefreshCw as RefreshIcon,
   CalendarClock as ScheduleIcon,
   History as HistoryIcon,
   Eye as PreviewIcon,
@@ -27,7 +27,7 @@ import type { MaterializationScheduleValue } from "../lib/materializationSchedul
 
 /**
  * Shared materialization toolbar for app data bindings and dashboard data
- * sources. Both surfaces present the same controls — Materialize button, one
+ * sources. Both surfaces present the same controls — Refresh button, one
  * combined status/freshness chip, and a ⋮ menu holding the snapshot preview,
  * schedule, and history — so the two editors look and behave identically and
  * the (already crowded) data-source toolbar keeps a small footprint.
@@ -164,7 +164,7 @@ export default function DataSourceMaterializationControls({
       label: [rows, age].filter(Boolean).join(" · ") || "ready",
       color: freshness?.stale ? "warning" : "success",
       tooltip: freshness?.stale
-        ? "The snapshot is older than its freshness window — click Materialize to refresh."
+        ? "The snapshot is older than its freshness window — click Refresh."
         : "The snapshot is up to date.",
     };
   } else if (buildStatus) {
@@ -184,17 +184,17 @@ export default function DataSourceMaterializationControls({
 
       {showMaterializeControls && (
         <>
-          <Tooltip title="Re-materialize this query's Parquet file">
+          <Tooltip title="Refresh this query's data from source">
             <span>
               <Button
                 size="small"
                 variant="outlined"
                 color="inherit"
-                startIcon={<MaterializeIcon size={16} strokeWidth={1.5} />}
+                startIcon={<RefreshIcon size={16} strokeWidth={1.5} />}
                 onClick={onMaterialize}
                 disabled={materializing}
               >
-                {materializing ? "Materializing…" : "Materialize"}
+                {materializing ? "Refreshing…" : "Refresh"}
               </Button>
             </span>
           </Tooltip>
@@ -234,9 +234,7 @@ export default function DataSourceMaterializationControls({
                 </ListItemIcon>
                 <ListItemText
                   primary="Preview snapshot"
-                  secondary={
-                    canPreview ? undefined : "Materialize the data first"
-                  }
+                  secondary={canPreview ? undefined : "Refresh the data first"}
                 />
               </MenuItem>
             )}

--- a/app/src/components/ResourceRefreshControl.tsx
+++ b/app/src/components/ResourceRefreshControl.tsx
@@ -1,0 +1,43 @@
+import { Chip, CircularProgress, Tooltip } from "@mui/material";
+import { RefreshCw } from "lucide-react";
+
+/**
+ * Shared Refresh control for app + dashboard toolbars. Always means the same
+ * thing: force-rebuild every data source / binding from upstream, wait until
+ * all settle, then update the UI once.
+ */
+export default function ResourceRefreshControl({
+  onClick,
+  busy = false,
+  disabled = false,
+  /** Used in the tooltip — e.g. "binding" or "data source". */
+  subject,
+}: {
+  onClick: () => void;
+  busy?: boolean;
+  disabled?: boolean;
+  subject: "binding" | "data source";
+}) {
+  const isDisabled = disabled || busy;
+  return (
+    <Tooltip title={`Refresh data from source (waits for every ${subject})`}>
+      <span>
+        <Chip
+          icon={
+            busy ? (
+              <CircularProgress size={14} color="inherit" />
+            ) : (
+              <RefreshCw size={14} />
+            )
+          }
+          label={busy ? "Refreshing…" : "Refresh"}
+          size="small"
+          variant="outlined"
+          onClick={onClick}
+          disabled={isDisabled}
+          sx={{ cursor: isDisabled ? "default" : "pointer" }}
+        />
+      </span>
+    </Tooltip>
+  );
+}

--- a/app/src/components/dashboard/DashboardGrid.tsx
+++ b/app/src/components/dashboard/DashboardGrid.tsx
@@ -8,7 +8,8 @@ import {
   useDashboardStore,
   type DashboardWidget,
 } from "../../store/dashboardStore";
-import { refreshDashboardWidgetCommand } from "../../dashboard-runtime/commands";
+import { refreshDashboardWidgetDataCommand } from "../../dashboard-runtime/commands";
+import { useWorkspace } from "../../contexts/workspace-context";
 import type { MosaicInstance } from "../../lib/mosaic";
 import type {
   Dashboard,
@@ -83,6 +84,8 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
   onOpenAddWidget,
   onInspectWidget,
 }) => {
+  const { currentWorkspace } = useWorkspace();
+  const workspaceId = currentWorkspace?.id;
   const widgets = useMemo(() => dashboard?.widgets ?? [], [dashboard]);
   const crossFilterResolution =
     dashboard?.crossFilter.resolution ?? "intersect";
@@ -338,13 +341,14 @@ const DashboardGrid: React.FC<DashboardGridProps> = ({
                   loading={!allSourcesReady}
                   error={widgetError || undefined}
                   isEditMode={isEditMode}
-                  onRefresh={() =>
-                    dashboardId &&
-                    refreshDashboardWidgetCommand({
+                  onRefresh={() => {
+                    if (!workspaceId || !dashboardId) return;
+                    void refreshDashboardWidgetDataCommand({
+                      workspaceId,
                       dashboardId,
                       widgetId: widget.id,
-                    })
-                  }
+                    });
+                  }}
                   onRemove={() =>
                     dashboardId && removeWidgetAction(dashboardId, widget.id)
                   }

--- a/app/src/components/dashboard/DashboardRuntimeChrome.tsx
+++ b/app/src/components/dashboard/DashboardRuntimeChrome.tsx
@@ -269,7 +269,7 @@ const DashboardRuntimeChrome: React.FC<DashboardRuntimeChromeProps> = ({
           sx={{ borderRadius: 0, py: 0, ".MuiAlert-message": { py: 0.75 } }}
           action={
             <Button color="inherit" size="small" onClick={onReloadData}>
-              Refresh now
+              Refresh
             </Button>
           }
         >

--- a/app/src/components/dashboard/DataSourcePanel.tsx
+++ b/app/src/components/dashboard/DataSourcePanel.tsx
@@ -1019,6 +1019,7 @@ const DataSourcePanel: React.FC<DataSourcePanelProps> = ({
                     </Typography>
                     <IconButton
                       size="small"
+                      title="Refresh from source"
                       onClick={() => handleRefreshDataSource(ds.id)}
                       disabled={status === "loading" || materializationPending}
                       sx={{ p: 0.5 }}
@@ -1181,7 +1182,7 @@ const DataSourcePanel: React.FC<DataSourcePanelProps> = ({
                       }}
                       onClick={() => handleRefreshDataSource(ds.id)}
                     >
-                      Materialize
+                      Refresh
                     </Button>
                   </Box>
                 </Box>

--- a/app/src/components/widgets/WidgetContainer.tsx
+++ b/app/src/components/widgets/WidgetContainer.tsx
@@ -141,7 +141,7 @@ const WidgetContainer: React.FC<WidgetContainerProps> = ({
         {isEditMode && (
           <>
             {onRefresh && (
-              <Tooltip title="Refresh widget">
+              <Tooltip title="Refresh data from source">
                 <IconButton size="small" onClick={onRefresh} sx={{ p: 0.25 }}>
                   <RefreshCw size={14} />
                 </IconButton>

--- a/app/src/dashboard-runtime/commands.ts
+++ b/app/src/dashboard-runtime/commands.ts
@@ -685,6 +685,38 @@ export function refreshDashboardWidgetCommand(options: {
     );
 }
 
+/**
+ * Widget Refresh: force-rebuild the widget's data source from upstream, wait
+ * until builds settle, apply into the runtime, then remount the widget
+ * (data → UI). Same contract as the dashboard toolbar Refresh, scoped to one
+ * source.
+ */
+export async function refreshDashboardWidgetDataCommand(options: {
+  workspaceId: string;
+  dashboardId?: string;
+  widgetId: string;
+}): Promise<void> {
+  const dashboard = getDashboardOrThrow(options.dashboardId);
+  const widget = dashboard.widgets.find(w => w.id === options.widgetId);
+  if (!widget?.dataSourceId) {
+    refreshDashboardWidgetCommand({
+      dashboardId: dashboard._id,
+      widgetId: options.widgetId,
+    });
+    return;
+  }
+
+  await refreshDashboardDataSourceCommand({
+    workspaceId: options.workspaceId,
+    dataSourceId: widget.dataSourceId,
+    dashboardId: dashboard._id,
+  });
+  refreshDashboardWidgetCommand({
+    dashboardId: dashboard._id,
+    widgetId: options.widgetId,
+  });
+}
+
 export function getDashboardStateSnapshot(dashboardId: string) {
   const dashboard = getDashboardOrThrow(dashboardId);
 

--- a/app/src/store/appStore.ts
+++ b/app/src/store/appStore.ts
@@ -130,6 +130,12 @@ interface AppState {
 
   /** Bumping the nonce forces the renderer to rebuild that app's preview. */
   previewNonce: Record<string, number>;
+  /**
+   * Bumping the nonce tells the renderer to reload DuckDB tables from the
+   * latest artifacts, then post a data-refresh to the running preview (data
+   * first, then UI — never a mid-flight iframe reboot).
+   */
+  dataRefreshNonce: Record<string, number>;
   previewErrors: Record<string, AppPreviewError[]>;
 
   /**
@@ -195,6 +201,11 @@ interface AppActions {
   setRuntime: (appId: string, runtime: "cdn" | "webcontainer") => void;
 
   bumpPreview: (appId: string) => void;
+  /**
+   * Ask the open preview to reload data into DuckDB and re-query — without
+   * rebuilding the iframe. Used after an explicit binding refresh settles.
+   */
+  requestDataRefresh: (appId: string) => void;
   setPreviewErrors: (appId: string, errors: AppPreviewError[]) => void;
 
   /** Sync sharing settings updated by the ShareDialog into the open app. */
@@ -244,9 +255,10 @@ interface AppActions {
    * caps the wait and `signal` aborts the polling (the build itself keeps
    * running server-side either way).
    *
-   * `refreshPreview` (default true) refetches the app and bumps the preview
-   * when the binding becomes ready. Bulk rematerialize passes false so the
-   * preview refreshes once after every binding settles.
+   * `refreshPreview` (default true) refetches the app and requests a
+   * data-then-UI refresh (DuckDB load + data-refresh) when the binding
+   * becomes ready. Bulk rematerialize passes false so the caller applies
+   * data once after every binding settles.
    */
   materializeBinding: (
     workspaceId: string,
@@ -310,6 +322,7 @@ const initialState: AppState = {
   openAppErrors: {},
   activeAppId: null,
   previewNonce: {},
+  dataRefreshNonce: {},
   previewErrors: {},
   previewDbtEnv: {},
   dbtEnvInfo: {},
@@ -452,6 +465,7 @@ export const useAppStore = create<AppStore>()(
           delete state.openApps[appId];
           delete state.openAppErrors[appId];
           delete state.previewNonce[appId];
+          delete state.dataRefreshNonce[appId];
           delete state.previewErrors[appId];
         });
         void get().fetchList(workspaceId);
@@ -703,6 +717,12 @@ export const useAppStore = create<AppStore>()(
         state.previewNonce[appId] = (state.previewNonce[appId] || 0) + 1;
       }),
 
+    requestDataRefresh: appId =>
+      set(state => {
+        state.dataRefreshNonce[appId] =
+          (state.dataRefreshNonce[appId] || 0) + 1;
+      }),
+
     applySharingChanges: (appId, changes) =>
       set(state => {
         const appEntity = state.openApps[appId];
@@ -861,8 +881,11 @@ export const useAppStore = create<AppStore>()(
 
       const finishReady = async () => {
         if (refreshPreview) {
+          // Data first, then UI: refetch binding caches, then ask the renderer
+          // to load DuckDB and post data-refresh. Do NOT bumpPreview — that
+          // reboots the iframe before tables are ready.
           await get().fetchApp(workspaceId, appId);
-          get().bumpPreview(appId);
+          get().requestDataRefresh(appId);
         }
         return { success: true, status: "ready" as const };
       };
@@ -900,7 +923,7 @@ export const useAppStore = create<AppStore>()(
               set(state => {
                 state.openApps[appId] = res.app as AppEntity;
               });
-              get().bumpPreview(appId);
+              get().requestDataRefresh(appId);
             } else {
               setLocalStatus("ready");
             }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

[#610](https://github.com/mako-ai/mako/pull/610) never landed. Explicit Materialize could no-op on a definition-hash cache hit, and apps/dashboards had overlapping Refresh / Rematerialize / Reload data actions.

## What `force: true` means

Parquet artifacts are cached by **query definition hash** (SQL + connection), not by upstream row data. Without `force: true`, clicking Refresh on an unchanged query returns “already ready” and never re-runs the query.

So every explicit user/agent Refresh now passes `force: true`:

- Binding / data-source editors
- Explorer context menu
- Agent `materialize_binding`
- App + dashboard toolbar Refresh

Scheduled refresh and the unified refresh API already did this.

## Fix

**One Refresh everywhere** — force-rebuild from source, wait for all sources, then update UI once.

**Shared toolbar control** — `ResourceRefreshControl` (labeled Refresh chip) on both app and dashboard toolbars, trailing cluster next to Share.

[Unified Refresh toolbar](https://cursor.com/agents/bc-019f8cf5-e3a4-7d9f-941a-c01cb82f480b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Funified-toolbar-refresh.png)

Preview: https://pr-735.mako.ai

Supersedes #610.

## Testing

- `pnpm --filter app run typecheck`
- `pnpm --filter app run lint`


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8cf5-e3a4-7d9f-941a-c01cb82f480b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8cf5-e3a4-7d9f-941a-c01cb82f480b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

