### PR TITLE
Add Cursor Cloud Agent environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,10 @@
+{
+  "name": "Mako",
+  "install": "export PNPM_HOME=\"${PNPM_HOME:-$HOME/.local/share/pnpm}\"; export PATH=\"$PNPM_HOME:$PATH\"; command -v pnpm >/dev/null || npm install -g pnpm@10.33.3; pnpm install",
+  "start": "bash .cursor/start-local-dbs.sh",
+  "ports": [
+    { "name": "API", "port": 8080 },
+    { "name": "App", "port": 5173 },
+    { "name": "Inngest", "port": 8288 }
+  ]
+}

--- a/.cursor/start-local-dbs.sh
+++ b/.cursor/start-local-dbs.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Idempotent boot helper for Cursor Cloud Agent VMs (no systemd).
+# Starts local MongoDB (replica set rs0) + PostgreSQL 16, then reseeds the
+# known cloud-agent login if the API package is available.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+export PNPM_HOME="${PNPM_HOME:-$HOME/.local/share/pnpm}"
+case ":$PATH:" in
+  *":$PNPM_HOME:"*) ;;
+  *) export PATH="$PNPM_HOME:$PATH" ;;
+esac
+
+# --- MongoDB (single-node replica set; required for transactions) ---
+if ! pgrep -x mongod >/dev/null 2>&1; then
+  sudo mkdir -p /var/log/mongodb /var/lib/mongodb
+  sudo chown -R mongodb:mongodb /var/log/mongodb /var/lib/mongodb 2>/dev/null || true
+  if [[ -f /etc/mongod.conf ]]; then
+    sudo mongod --config /etc/mongod.conf --bind_ip 127.0.0.1 --fork \
+      --logpath /var/log/mongodb/mongod.log
+  else
+    echo "[start-local-dbs] WARN: /etc/mongod.conf missing; skipping MongoDB start" >&2
+  fi
+fi
+
+if command -v mongosh >/dev/null 2>&1; then
+  for _ in $(seq 1 30); do
+    if mongosh --quiet --eval 'db.runCommand({ ping: 1 }).ok' 2>/dev/null | grep -q 1; then
+      break
+    fi
+    sleep 1
+  done
+  mongosh --quiet --eval \
+    'try{rs.status()}catch(e){rs.initiate({_id:"rs0",members:[{_id:0,host:"127.0.0.1:27017"}]})}' \
+    >/dev/null 2>&1 || true
+fi
+
+# --- PostgreSQL 16 (Chinook demo source) ---
+if command -v pg_ctlcluster >/dev/null 2>&1; then
+  if ! sudo pg_ctlcluster 16 main status >/dev/null 2>&1; then
+    sudo pg_ctlcluster 16 main start || true
+  fi
+fi
+
+# --- Seed known admin (soft-fail; script exits 0 if Mongo unreachable) ---
+if [[ -f "$ROOT/api/src/scripts/seed-dev-admin.ts" ]] && command -v pnpm >/dev/null 2>&1; then
+  pnpm --filter api exec tsx src/scripts/seed-dev-admin.ts || true
+fi
+
+echo "[start-local-dbs] ready"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,20 +29,22 @@ PostgreSQL 16 locally (persist in the VM snapshot) and config lives in a
 gitignored root `.env` (also persisted in the snapshot — `api/src/index.ts`
 loads it via `dotenv.config()`).
 
-Both DB servers must be **started on each VM boot** (no systemd here); the update
-script does NOT start them. Start them before `pnpm dev`:
+Both DB servers must be **started on each VM boot** (no systemd here). The
+`.cursor/environment.json` `start` command runs
+[`.cursor/start-local-dbs.sh`](.cursor/start-local-dbs.sh) automatically; if you
+need to start them by hand before `pnpm dev`:
 
 ```bash
-# MongoDB — single-node replica set (the app uses transactions, which REQUIRE a
-# replica set; a standalone mongod fails with "Transaction numbers are only
-# allowed on a replica set member"). Config already has replSetName: rs0.
-sudo mongod --config /etc/mongod.conf --bind_ip 127.0.0.1 &   # logs: /var/log/mongodb/mongod.log
-# First boot only (idempotent thereafter — already initiated in this snapshot):
-mongosh --quiet --eval 'try{rs.status()}catch(e){rs.initiate({_id:"rs0",members:[{_id:0,host:"127.0.0.1:27017"}]})}'
-
-# PostgreSQL (demo data source)
-sudo pg_ctlcluster 16 main start
+bash .cursor/start-local-dbs.sh
+# Equivalent manual steps:
+# sudo mongod --config /etc/mongod.conf --bind_ip 127.0.0.1 &
+# mongosh --quiet --eval 'try{rs.status()}catch(e){rs.initiate({_id:"rs0",members:[{_id:0,host:"127.0.0.1:27017"}]})}'
+# sudo pg_ctlcluster 16 main start
 ```
+
+MongoDB must be a single-node replica set (`replSetName: rs0`) — the app uses
+transactions, and a standalone `mongod` fails with "Transaction numbers are only
+allowed on a replica set member".
 
 `.env` points the app at these: `DATABASE_URL=mongodb://127.0.0.1:27017/mako` and
 the demo source `DEMO_DATABASE_URL=postgresql://mako:mako@127.0.0.1:5432/demo`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a reusable Cursor Cloud Agent environment for this repo.

### What’s in the VM (this setup run)
- MongoDB 8.0 as single-node replica set `rs0` on `127.0.0.1:27017`
- PostgreSQL 16 with `demo` DB + Chinook (lowercase tables) as `mako`/`mako`
- Root `.env` pointing at local DBs (`DATABASE_URL`, `DEMO_DATABASE_URL`)
- `pnpm install` completed
- Seeded login: `cloud-agent@mako.dev` / `CloudAgentDev!2024`
- Verified: `GET /health` → ok, login → 200

### Repo changes
- `.cursor/environment.json` — `install` (`pnpm install`) + `start` (local DBs + seed) + ports 8080/5173/8288
- `.cursor/start-local-dbs.sh` — idempotent Mongo/Postgres boot + `seed-dev-admin`
- `AGENTS.md` — documents the start script

### After merge / before team use
1. **Save a snapshot** of this VM from the [Cloud Agents Environments](https://cursor.com/dashboard/cloud-agents#environments) UI so future agents start warm.
2. Add team secrets as needed (`AI_GATEWAY_API_KEY`, OAuth keys). Core SQL-client flows work without AI keys.
3. New agents will pick up `.cursor/environment.json` from the repo (highest priority).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8d1a-457a-7e46-8930-3300a0cb95d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8d1a-457a-7e46-8930-3300a0cb95d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

