### PR TITLE
docs: sync modes matrix, Wise connector, notebook folders, tool-tier fixes

### DIFF
--- a/api/src/connectors/README.md
+++ b/api/src/connectors/README.md
@@ -120,6 +120,13 @@ All sensitive configuration data (API keys, passwords, etc.) is encrypted before
 - Supports custom queries with offset or cursor pagination
 - Required config: `endpoint`, `queries`
 
+### Wise
+
+- Syncs Wise (TransferWise) financial data
+- Supported entities: profiles, balances, balance_updates, transfers, recipients, activities
+- Required config: `api_key` (personal API token); optional `profile_id`, `api_base_url` (sandbox)
+- Webhooks verified with Wise's RSA-SHA256 public keys; provisioning is manual (personal tokens can't create subscriptions — register the webhook URL in the Wise Developer Hub)
+
 ## Future Connectors
 
 The architecture supports easy addition of new connectors such as:

--- a/docs/src/content/docs/ai-agent.md
+++ b/docs/src/content/docs/ai-agent.md
@@ -85,7 +85,7 @@ Beyond the always-on self-directive, Mako supports **skills** — named, workspa
 
 Every turn, Mako injects a compact index of every skill plus the top-3 auto-retrieved bodies (entity overlap 0.6 + semantic similarity 0.4). See [Skills](/skills/) for the full model, admin UI, and REST API.
 
-Skill _retrieval_ (`get_relevant_skills`, `load_skill`) is always active; skill _writes_ and long-tail lookups (`save_skill`, `delete_skill`, `list_skills`, `search_skills`, `read_skill_resource`) are deferred tools the agent activates on demand — see [Tool paging](#tool-paging) below.
+Skill _retrieval_ and _writes_ (`get_relevant_skills`, `load_skill`, `save_skill`, `read_skill_resource`) are always active — the skills prompt names them every turn, so keeping them core avoids search/load round-trips. Long-tail lookups (`delete_skill`, `list_skills`, `search_skills`) are deferred tools the agent activates on demand — see [Tool paging](#tool-paging) below.
 
 ## Expertise Modes
 
@@ -111,9 +111,9 @@ The provider request carries a bounded **working set** of tools instead of every
 
 - **core** — always active (lifecycle, memory, skill retrieval, web access, tool discovery)
 - **mode** — activates with an expertise mode
-- **deferred** — registered and executable (approval flow intact) but dormant: all MCP tools plus demoted built-ins (skill writes, version history)
+- **deferred** — registered and executable (approval flow intact) but dormant: all MCP tools plus demoted built-ins (rare skill-management ops: `delete_skill`, `list_skills`, `search_skills`)
 
-Deferred tools are discoverable via the `search_tools` meta-tool (compact cards, no schemas) and activated with `load_tools`, which mutates the active set exactly like `enable_mode` and replays statelessly from the chat transcript. A deterministic per-turn relevance preload activates obviously-relevant deferred tools from the last user message, so common cases need no search/load round-trip.
+Deferred tools are discoverable via the `search_tools` meta-tool (compact cards, no schemas) and activated with `load_tools`, which mutates the active set exactly like `enable_mode` and replays statelessly from the chat transcript. A deterministic per-turn relevance preload activates obviously-relevant deferred tools from the last user message, so common cases need no search/load round-trip. To close the named-but-not-loaded trap, the system prompt always carries a compact name-only inventory: every built-in tool name grouped by tier (core/mode/deferred, no schemas) plus MCP servers with tool counts — individual MCP tool names are only discoverable via `search_tools`.
 
 Budgets: at most 110 active tools and ~12k tokens of tool definitions per step, whichever binds first — with per-provider hard caps as a backstop (xAI rejects requests above 250 tools, OpenAI above 128). Core and mode tools are never evicted; loaded deferred tools are evicted oldest-first. Small workspaces whose whole tool surface fits the budget bypass paging entirely and keep the zero-friction behavior. When paging is active, the system prompt lists deferred sources one line per connector, and provider-facing MCP tool descriptions are truncated (full descriptions stay in the search catalog).
 
@@ -137,7 +137,7 @@ Edit-mode locking is handled automatically so concurrent users cannot conflict.
 
 ## Version-Aware Tools
 
-Two tools inspect the history of saved consoles and dashboards. They are deferred — the agent activates them via `search_tools`/`load_tools` (or the relevance preload) when a history question comes up:
+Two tools inspect the history of saved consoles and dashboards. They are mode tools — active in the **Dashboard** and **React App** modes, where history questions actually come up:
 
 - `browse_version_history` — list past versions of a console or dashboard with author, timestamp, and comment.
 - `get_version_snapshot` — fetch the full snapshot of a specific version.

--- a/docs/src/content/docs/connectors.md
+++ b/docs/src/content/docs/connectors.md
@@ -1,6 +1,6 @@
 ---
 title: SaaS Sync (Connectors)
-description: Pull data from SaaS tools like Stripe, Close CRM, Claap, Calendly, PandaDoc, PostHog, and more into your data warehouse.
+description: Pull data from SaaS tools like Stripe, Close CRM, Claap, Calendly, PandaDoc, PostHog, Wise, and more into your data warehouse.
 ---
 
 :::caution[Experimental]
@@ -18,6 +18,7 @@ Connectors pull data from external services and sync it into your connected data
 | **Claap**     | Claap API       | Recordings, Workspace. *Supports backfill and CDC webhooks (auto-provisioning via "Create in Claap").* |
 | **Calendly**  | Calendly API    | Organizations, Users, Groups, Event Types, Scheduled Events, Invitees, Contacts. *Real-time invitee + event-type webhooks (auto-provisioned); scheduled backfill covers the rest.* |
 | **PandaDoc**  | PandaDoc API    | Documents, Templates, Contacts, Members. *Document + template webhooks (CDC, auto-provisioned); scheduled backfill covers contacts and members. Documents are hydrated with full detail (fields, tokens, pricing, products, recipients) during backfill.* |
+| **Wise**      | Wise API        | Profiles, Balances, Balance Updates, Transfers, Recipients, Activities. *CDC webhooks verified with Wise's RSA-SHA256 public keys; auto-provisioning is not possible with personal API tokens — subscribe the Mako webhook URL manually in the Wise Developer Hub. Transfer polls only see newly created transfers; status changes arrive via webhooks.* |
 | **PostHog**   | PostHog HogQL   | Dynamic — each configured HogQL query becomes an entity                          |
 | **GraphQL**   | Any GraphQL API | Dynamic — each configured query becomes an entity                                |
 | **BigQuery**  | Google BigQuery | Dynamic — each configured query becomes an entity                                |

--- a/docs/src/content/docs/data-sync.md
+++ b/docs/src/content/docs/data-sync.md
@@ -23,6 +23,20 @@ Each flow run:
 4. Saves the new cursor position
 5. Repeats until no more records
 
+## Sync Modes
+
+Each flow entity runs with one of five sync/write mode combinations:
+
+| Mode | Fetches | Writes |
+|------|---------|--------|
+| **Incremental \| Append + Deduped** | New or updated records since the last cursor | Upsert by primary key — one deduplicated row per record |
+| **Incremental \| Append** | New or updated records since the last cursor | Every version added as a new row (history) |
+| **Full Refresh \| Deduped** | Everything, each run | Upsert by primary key (reconciles drift) |
+| **Full Refresh \| Append** | Everything, each run | All rows appended — accumulates a snapshot per run |
+| **Full Refresh \| Overwrite** | Everything, each run | Destination cleared once at the start of the run, then written — ends up an exact snapshot |
+
+Connectors declare **incremental capabilities** per entity (`full-support`, `created-anchor`, `client-filter`, or `none`), and the flow form only offers honest combinations — an entity whose API can't see updates to old records (e.g. Wise transfers) won't pretend to support true incremental sync, and the connector's warning is surfaced in the UI. Webhook-applied CDC events respect the flow's write mode: append flows append, deduped flows merge.
+
 ## Change Data Capture (CDC) & Streaming
 
 In addition to scheduled batch syncing, Mako supports experimental Change Data Capture (CDC) for near real-time updates.
@@ -78,6 +92,6 @@ pnpm run sync --workspace <workspace-id>
 
 ## Error Handling
 
-- Syncs are idempotent — re-running won't create duplicates (upsert-based writes)
+- Deduped and overwrite syncs are idempotent — re-running won't create duplicates. Append-mode flows intentionally keep every fetched version as a new row.
 - Cursor is saved after each successful chunk, so failures resume from the last checkpoint
 - Failed syncs are retried automatically by Inngest with exponential backoff

--- a/docs/src/content/docs/notebooks.md
+++ b/docs/src/content/docs/notebooks.md
@@ -37,6 +37,10 @@ Reads stream **Arrow IPC** back into pandas zero-copy. Queries must be read-only
 - **Streaming runs** — executions stream outputs over SSE, and a run continues server-side even if your tab disconnects.
 - **Version history** — prior generations of the document can be listed, inspected, and restored (see the API surface below).
 
+## Folders & Organization
+
+Notebooks are organized like dashboards and consoles: a **My Notebooks** section (private to you) and a **Workspace** section (shared), each supporting arbitrarily nested folders. Create, rename, and delete folders in the explorer; drag notebooks between folders or move them via `PATCH /api/workspaces/:wid/notebooks/:id/move` (set `folderId` and/or `access`). Folder structure updates in real time for everyone in the workspace.
+
 ## Building Notebooks with the AI Agent
 
 Notebooks have their own [expertise mode](/ai-agent/#expertise-modes) — opening a notebook tab defaults the agent to **Notebook** mode. The agent can create notebooks, add/edit/delete cells, run SQL cells against a data source, and run Python cells on the kernel, reading each run's stdout/result/error to iterate. Tools:


### PR DESCRIPTION
Daily docs maintenance — catches up documentation with yesterday's merges (#729, #726, #723).

## Changes

**data-sync.md** (#729)
- New **Sync Modes** section documenting the five sync/write mode combos from `packages/schemas/src/sync-mode-matrix.ts`, including per-entity incremental capabilities and honest-mode filtering in the flow form
- Fixed stale claim that *all* syncs are idempotent — append-mode flows intentionally keep every version

**connectors.md + api/src/connectors/README.md** (#729)
- Added the **Wise** connector: 6 entities, RSA-SHA256 webhook verification, manual webhook provisioning caveat (personal tokens can't create subscriptions), transfer-poll limitation

**notebooks.md** (#726)
- New **Folders & Organization** section: My/Workspace sections, nested folders, move endpoint, realtime updates

**ai-agent.md** (#723) — P0 factual fixes
- `save_skill` and `read_skill_resource` are core again (docs said they were deferred)
- `browse_version_history`/`get_version_snapshot` are Dashboard/App **mode** tools now, not deferred
- Documented the always-injected name-only tool inventory

All claims verified against `api/src/agents/modes/registry.ts`, `packages/schemas/src/sync-mode-matrix.ts`, `api/src/connectors/wise/connector.ts`, and `api/src/routes/notebooks.ts`.