### PR TITLE
fix(wise): activities backfill never finishes + recipients truncated early

### DIFF
--- a/api/src/connectors/incremental-capability.test.ts
+++ b/api/src/connectors/incremental-capability.test.ts
@@ -254,7 +254,8 @@ function testWiseCreatedAnchorTransfersAndNoneFallback() {
   assert.equal(wise.mode, "none");
   assert.equal(wise.perEntity?.transfers?.mode, "created-anchor");
   assert.equal(wise.perEntity?.transfers?.anchorField, "createdDateStart");
-  assert.equal(wise.perEntity?.activities?.mode, "client-filter");
+  assert.equal(wise.perEntity?.activities?.mode, "native");
+  assert.equal(wise.perEntity?.activities?.anchorField, "since");
   assert.ok(wise.warning && wise.warning.length > 0);
 }
 
@@ -361,6 +362,32 @@ async function testWiseTransfersCreatedDateStartWhenSinceSet() {
   assert.equal(captured.createdDateStart, "2026-07-15");
 }
 
+async function testWiseActivitiesNativeSinceWhenSinceSet() {
+  const connector = new WiseConnector({
+    id: "ds_wise",
+    name: "Wise",
+    type: "wise",
+    config: { api_key: "test", profile_id: "1" },
+  } as any);
+
+  let captured: any;
+  (connector as any).wiseApi = {
+    get: async (_path: string, config?: { params?: any }) => {
+      captured = config?.params;
+      return { data: { activities: [], cursor: null } };
+    },
+  };
+
+  await connector.fetchEntityChunk({
+    entity: "activities",
+    since: new Date("2026-07-15T12:00:00.000Z"),
+    onBatch: async () => {},
+  } as any);
+
+  assert.equal(captured.since, "2026-07-15T12:00:00.000Z");
+  assert.equal(captured.cursor, undefined);
+}
+
 async function main() {
   testEveryConnectorReturnsWellFormedCapabilities();
   testConnectorsWithNoRealIncrementalDeclareNone();
@@ -371,6 +398,7 @@ async function main() {
   await testCloseSearchApiUsesDateUpdatedWhenSinceSet();
   await testStripeCreatedGteWhenSinceSet();
   await testWiseTransfersCreatedDateStartWhenSinceSet();
+  await testWiseActivitiesNativeSinceWhenSinceSet();
   testPandadocDocumentsAreNativeContactsAreNot();
   testRestDeclaresClientFilterWithWarning();
   testWiseCreatedAnchorTransfersAndNoneFallback();

--- a/api/src/connectors/wise/connector.test.ts
+++ b/api/src/connectors/wise/connector.test.ts
@@ -240,7 +240,8 @@ function testIncrementalCapabilitiesHonest() {
   assert.equal(caps.mode, "none");
   assert.equal(caps.perEntity?.transfers?.mode, "created-anchor");
   assert.equal(caps.perEntity?.transfers?.anchorField, "createdDateStart");
-  assert.equal(caps.perEntity?.activities?.mode, "client-filter");
+  assert.equal(caps.perEntity?.activities?.mode, "native");
+  assert.equal(caps.perEntity?.activities?.anchorField, "since");
   assert.equal(caps.perEntity?.profiles, undefined);
   assert.equal(caps.perEntity?.balances, undefined);
   assert.equal(caps.perEntity?.recipients, undefined);
@@ -420,11 +421,21 @@ async function testRecipientsChunkUsesSeekPosition() {
           },
         };
       }
-      assert.equal(config?.params?.seekPosition, 9);
+      if (calls === 2) {
+        assert.equal(config?.params?.seekPosition, 9);
+        return {
+          data: {
+            content: [{ id: 8 }],
+            seekPositionForNext: 8,
+            size: 2,
+          },
+        };
+      }
+      assert.equal(config?.params?.seekPosition, 8);
       return {
         data: {
-          content: [{ id: 8 }],
-          seekPositionForNext: 8,
+          content: [],
+          seekPositionForNext: null,
           size: 2,
         },
       };
@@ -436,6 +447,7 @@ async function testRecipientsChunkUsesSeekPosition() {
     entity: "recipients",
     batchSize: 2,
     maxIterations: 1,
+    rateLimitDelay: 0,
     onBatch: async () => {},
   } as any);
   assert.equal(first.hasMore, true);
@@ -445,12 +457,208 @@ async function testRecipientsChunkUsesSeekPosition() {
     entity: "recipients",
     batchSize: 2,
     maxIterations: 1,
+    rateLimitDelay: 0,
     state: first,
     onBatch: async () => {},
   } as any);
-  // Next seek equals previous → profile complete
+  assert.equal(second.hasMore, true);
+  assert.equal(second.metadata?.seekPosition, 8);
+
+  const third = await connector.fetchEntityChunk({
+    entity: "recipients",
+    batchSize: 2,
+    maxIterations: 1,
+    rateLimitDelay: 0,
+    state: second,
+    onBatch: async () => {},
+  } as any);
+  // Null seekPositionForNext → profile complete
+  assert.equal(third.hasMore, false);
+  assert.equal(calls, 3);
+}
+
+async function testRecipientsContinuesWhenPageShorterThanRequestedSize() {
+  // Wise often caps page size (e.g. 20) below our requested size (100). A
+  // short page must NOT end the sync while seekPositionForNext is set.
+  const connector = createConnector({ profile_id: "12636519" });
+  let calls = 0;
+  const batches: Array<Record<string, unknown>> = [];
+
+  (connector as any).wiseApi = {
+    get: async () => {
+      calls++;
+      if (calls === 1) {
+        return {
+          data: {
+            content: Array.from({ length: 20 }, (_, i) => ({ id: 100 - i })),
+            seekPositionForNext: 81,
+            size: 20,
+          },
+        };
+      }
+      if (calls === 2) {
+        return {
+          data: {
+            content: Array.from({ length: 7 }, (_, i) => ({ id: 80 - i })),
+            seekPositionForNext: 74,
+            size: 20,
+          },
+        };
+      }
+      return {
+        data: {
+          content: [],
+          seekPositionForNext: null,
+          size: 20,
+        },
+      };
+    },
+  };
+
+  const state = await connector.fetchEntityChunk({
+    entity: "recipients",
+    batchSize: 100,
+    maxIterations: 10,
+    rateLimitDelay: 0,
+    onBatch: async batch => {
+      batches.push(...batch);
+    },
+  } as any);
+
+  assert.equal(calls, 3);
+  assert.equal(batches.length, 27);
+  assert.equal(state.hasMore, false);
+  assert.equal(state.totalProcessed, 27);
+}
+
+async function testActivitiesChunkUsesNextCursorQueryParam() {
+  const connector = createConnector({ profile_id: "12636519" });
+  const captured: Array<Record<string, unknown>> = [];
+  let calls = 0;
+
+  (connector as any).wiseApi = {
+    get: async (
+      path: string,
+      config?: { params?: Record<string, unknown> },
+    ) => {
+      calls++;
+      captured.push({ path, ...(config?.params ?? {}) });
+      if (calls === 1) {
+        return {
+          data: {
+            activities: [
+              { id: "act-1", createdOn: "2026-07-01T00:00:00.000Z" },
+              { id: "act-2", createdOn: "2026-06-01T00:00:00.000Z" },
+            ],
+            cursor: "cursor-page-2",
+          },
+        };
+      }
+      return {
+        data: {
+          activities: [{ id: "act-3", createdOn: "2026-05-01T00:00:00.000Z" }],
+          cursor: null,
+        },
+      };
+    },
+  };
+
+  const batches: Array<Record<string, unknown>> = [];
+  const first = await connector.fetchEntityChunk({
+    entity: "activities",
+    batchSize: 50,
+    maxIterations: 1,
+    rateLimitDelay: 0,
+    onBatch: async batch => {
+      batches.push(...batch);
+    },
+  } as any);
+
+  assert.equal(captured[0].path, "/v1/profiles/12636519/activities");
+  assert.equal(captured[0].cursor, undefined);
+  assert.equal(captured[0].nextCursor, undefined);
+  assert.equal(first.hasMore, true);
+  assert.equal(first.metadata?.cursor, "cursor-page-2");
+  assert.equal(batches.length, 2);
+
+  const second = await connector.fetchEntityChunk({
+    entity: "activities",
+    batchSize: 50,
+    maxIterations: 1,
+    rateLimitDelay: 0,
+    state: first,
+    onBatch: async batch => {
+      batches.push(...batch);
+    },
+  } as any);
+
+  assert.equal(captured[1].nextCursor, "cursor-page-2");
+  // Must not send the wrong query key — that re-fetches page 1 forever.
+  assert.equal(captured[1].cursor, undefined);
+  assert.equal(second.hasMore, false);
+  assert.equal(batches.length, 3);
+  assert.equal(batches[2].id, "act-3");
+  assert.equal(batches[2].profileId, "12636519");
+}
+
+async function testActivitiesStopsWhenCursorDoesNotAdvance() {
+  const connector = createConnector({ profile_id: "12636519" });
+  let calls = 0;
+
+  (connector as any).wiseApi = {
+    get: async () => {
+      calls++;
+      return {
+        data: {
+          activities: [{ id: `act-${calls}` }],
+          cursor: "stuck-cursor",
+        },
+      };
+    },
+  };
+
+  // First page establishes cursor; second echoes the same cursor → done.
+  const first = await connector.fetchEntityChunk({
+    entity: "activities",
+    maxIterations: 1,
+    rateLimitDelay: 0,
+    onBatch: async () => {},
+  } as any);
+  assert.equal(first.hasMore, true);
+  assert.equal(first.metadata?.cursor, "stuck-cursor");
+
+  const second = await connector.fetchEntityChunk({
+    entity: "activities",
+    maxIterations: 1,
+    rateLimitDelay: 0,
+    state: first,
+    onBatch: async () => {},
+  } as any);
   assert.equal(second.hasMore, false);
   assert.equal(calls, 2);
+}
+
+async function testActivitiesIncrementalPassesNativeSince() {
+  const connector = createConnector({ profile_id: "12636519" });
+  let captured: Record<string, unknown> | undefined;
+
+  (connector as any).wiseApi = {
+    get: async (
+      _path: string,
+      config?: { params?: Record<string, unknown> },
+    ) => {
+      captured = config?.params;
+      return { data: { activities: [], cursor: null } };
+    },
+  };
+
+  await connector.fetchEntityChunk({
+    entity: "activities",
+    since: new Date("2026-07-15T12:34:56.000Z"),
+    onBatch: async () => {},
+  } as any);
+
+  assert.equal(captured?.since, "2026-07-15T12:34:56.000Z");
 }
 
 async function testProfilesChunkFiltersConfiguredProfile() {
@@ -501,6 +709,10 @@ async function main() {
   await testTransfersChunkUsesOffsetAndProfile();
   await testTransfersIncrementalPassesCreatedDateStart();
   await testRecipientsChunkUsesSeekPosition();
+  await testRecipientsContinuesWhenPageShorterThanRequestedSize();
+  await testActivitiesChunkUsesNextCursorQueryParam();
+  await testActivitiesStopsWhenCursorDoesNotAdvance();
+  await testActivitiesIncrementalPassesNativeSince();
   await testProfilesChunkFiltersConfiguredProfile();
 }
 

--- a/api/src/connectors/wise/connector.ts
+++ b/api/src/connectors/wise/connector.ts
@@ -758,11 +758,12 @@ export class WiseConnector extends BaseConnector {
       iterations++;
       const nextSeek = body.seekPositionForNext;
 
-      // End of profile when: empty page, short page, missing next cursor, or
-      // Wise echoes the same seekPositionForNext (no forward progress).
+      // End of profile when: empty page, missing next seek, or Wise echoes
+      // the same seekPositionForNext (no forward progress).
+      // Do NOT treat short pages as terminal — Wise caps `size` (often at 20)
+      // below our requested page size while still returning seekPositionForNext.
       if (
         page.length === 0 ||
-        page.length < size ||
         nextSeek == null ||
         String(nextSeek) === String(seekPosition)
       ) {
@@ -805,7 +806,6 @@ export class WiseConnector extends BaseConnector {
     let recordCount = state?.totalProcessed ?? 0;
     let iterations = 0;
     const size = this.resolvePageSize(batchSize, ACTIVITY_PAGE_LIMIT);
-    const sinceMs = since instanceof Date ? since.getTime() : null;
 
     const api = this.getClient();
 
@@ -814,9 +814,17 @@ export class WiseConnector extends BaseConnector {
       iterations < maxIterations
     ) {
       const profileId = multi.profileIds[profileIndex];
+      // Wise paginates with response `cursor` → next request `nextCursor`
+      // (not `cursor`). Sending the wrong param ignores pagination and
+      // re-fetches page 1 forever.
       const params: Record<string, string | number> = { size };
       if (cursor) {
-        params.cursor = cursor;
+        params.nextCursor = cursor;
+      }
+      // Native server-side filter (ISO 8601). Prefer this over client-side
+      // scanning of the newest-first feed.
+      if (since instanceof Date) {
+        params.since = since.toISOString();
       }
 
       const response = await this.executeWithRetry(() =>
@@ -828,26 +836,7 @@ export class WiseConnector extends BaseConnector {
         activities?: Array<Record<string, unknown>>;
         cursor?: string | null;
       };
-      const rawPage = Array.isArray(body.activities) ? body.activities : [];
-
-      // Activities feed is newest-first. If every item on this page is older
-      // than `since`, remaining pages for this profile are also older — stop
-      // paging and advance to the next profile.
-      const profileExhaustedBySince =
-        sinceMs != null &&
-        rawPage.length > 0 &&
-        rawPage.every(item => {
-          const ts = parseWiseDate(item.updatedOn ?? item.createdOn);
-          return ts != null && ts.getTime() < sinceMs;
-        });
-
-      let page = rawPage;
-      if (sinceMs != null) {
-        page = page.filter(item => {
-          const ts = parseWiseDate(item.updatedOn ?? item.createdOn);
-          return ts ? ts.getTime() >= sinceMs : false;
-        });
-      }
+      const page = Array.isArray(body.activities) ? body.activities : [];
 
       const records = page.map(activity =>
         withStringId({ ...activity, profileId: String(profileId) }),
@@ -865,7 +854,13 @@ export class WiseConnector extends BaseConnector {
           ? body.cursor
           : null;
 
-      if (profileExhaustedBySince || !nextCursor || rawPage.length === 0) {
+      // End of profile when: empty page, missing next cursor, or Wise echoes
+      // the same cursor (no forward progress — otherwise backfill never ends).
+      if (
+        page.length === 0 ||
+        !nextCursor ||
+        (cursor != null && nextCursor === cursor)
+      ) {
         profileIndex++;
         cursor = undefined;
       } else {
@@ -940,11 +935,10 @@ export class WiseConnector extends BaseConnector {
           mode: "created-anchor",
           anchorField: "createdDateStart",
         },
-        // Activities feed is newest-first; we drop rows older than `since`
-        // client-side but still page the API until the chunk budget ends.
+        // Activities list accepts a native ISO `since` query param.
         activities: {
-          mode: "client-filter",
-          anchorField: "createdOn",
+          mode: "native",
+          anchorField: "since",
         },
       },
       warning:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wise `activities` backfill was stuck in an infinite loop (millions of rows written, ~50 destination rows — exactly one page). Root cause: we sent the pagination token as query param `cursor`, but the Wise API expects `nextCursor`. Every request re-fetched page 1, so `hasMore` never cleared.

Also fixes recipients sync stopping early (~27 of hundreds): we treated short pages as end-of-list, but Wise often caps `size` below our requested page size while still returning `seekPositionForNext`.

### Changes
- Activities: send `nextCursor`, stall-guard on echoed cursors, use native ISO `since` filter (capability → `native`)
- Recipients: end only on empty page / null seek / no forward progress — not short pages
- Tests covering both pagination bugs

### Test plan
- [x] `pnpm --filter api exec tsx src/connectors/wise/connector.test.ts`
- [x] `pnpm --filter api exec tsx src/connectors/incremental-capability.test.ts`
- [x] `pnpm --filter api run lint`
- [ ] Re-run Wise CDC backfill for `activities` + `recipients` and confirm both reach Done with full destination row counts

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-353bfda2-9a8f-4e22-a006-cfd008cd2914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-353bfda2-9a8f-4e22-a006-cfd008cd2914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

