### PR TITLE
docs: Workflows as Code PRD

### DIFF
--- a/docs/workflows-as-code-prd.md
+++ b/docs/workflows-as-code-prd.md
@@ -80,7 +80,7 @@ editing, and disconnected from Mako connectors, marts, and auth.
 | --- | --- |
 | MVP | One real n8n flow replaced (Calendly → Close opportunity) running in Mako |
 | v1 | Reverse-ETL style mart → Close upsert as a second workflow; run history + agent edit |
-| v1.5 | Optional GitHub binding; webhook + cron triggers; basic fixture tests |
+| v1.5 | Optional GitHub binding; optional HMAC verification on ingress; basic fixture tests |
 | Later | OCR/compute steps; self-heal from Slack/run failures; engine consolidation |
 
 ### 4.2 Success metrics
@@ -145,11 +145,9 @@ const CalendlyInviteeCreated = z.object({
 export default workflow({
   name: "calendly_to_close_opportunity",
   description: "Create a Close opportunity when a Calendly demo is booked",
-  trigger: {
-    type: "connector_webhook",
-    connector: "calendly",
-    event: "invitee.created",
-  },
+  // "manual" = run via POST URL. Point Calendly (or any provider) at the
+  // workflow's URL — Mako doesn't need to know who is calling.
+  trigger: { type: "manual" },
   input: CalendlyInviteeCreated,
 
   async run(input, ctx) {
@@ -269,7 +267,7 @@ Editing draft does not affect production until publish (same spirit as apps/dbt)
                              │ publish snapshot
                              ▼
 ┌─ Control plane (Mako API) ──────────────────────────────────┐
-│  Triggers: connector webhooks, cron, manual                  │
+│  Triggers: tokenized POST URL (webhooks/manual), cron         │
 │  Credential injection: workspace connectors (encrypted)      │
 │  Run records: status, step timeline, I/O redaction           │
 │  Deploy registry: workspace → published workflow bundle      │
@@ -323,10 +321,10 @@ The workflow body only sees a typed `input`. It does not register webhooks or
 crons itself.
 
 ```
-[Calendly / cron / UI]
+[any provider POST / cron / UI]
         │
         ▼
- Mako ingress (verify / due check)
+ Mako ingress (token check / due check)
         │
         ▼
  create WorkflowRun(input)
@@ -342,15 +340,22 @@ This is the same split Sync already uses (schedule/webhook on `IFlow`, executor
 elsewhere) — but Workflows **must not** drain into CDC materialization. Ingress
 enqueues a workflow run, not a warehouse MERGE.
 
-### 9.1 Trigger kinds (MVP)
+### 9.1 Trigger kinds (MVP) — only two
 
 | Kind | Who fires it | What `input` is |
 | --- | --- | --- |
-| `connector_webhook` | External provider → Mako URL | Normalized event payload from the connector |
+| `manual` | Anything that can POST JSON: provider webhooks (Calendly, Stripe, GitHub, …), UI “Run now”, agent, curl | Raw JSON body, validated by the workflow’s Zod schema |
 | `cron` | Platform scheduler | Empty/`{}` or last-cursor bag (declared by workflow) |
-| `manual` | UI / API “Run now” | JSON the user pastes (often a fixture) |
 
-Later (not MVP): `http` signed URL, `on_sync_completed`, Slack events.
+**Triggers are provider-agnostic.** Every published `manual` workflow gets a
+stable **tokenized POST URL**. External webhooks are not a special trigger
+type — the author pastes the workflow URL into Calendly (or any provider) and
+Mako neither knows nor cares who is calling. UI “Run now” and provider
+deliveries go through the exact same ingress pipeline.
+
+Later (not MVP): optional per-provider HMAC verification, connector-assisted
+subscription provisioning (convenience, not core), `on_sync_completed`, Slack
+events.
 
 ### 9.2 Where trigger config lives
 
@@ -359,24 +364,19 @@ Later (not MVP): `http` signed URL, `on_sync_completed`, Slack events.
 ```ts
 export default workflow({
   name: "calendly_to_close_opportunity",
-  trigger: {
-    type: "connector_webhook",
-    connector: "calendly",           // logical name → workspace connector binding
-    event: "invitee.created",        // must be in connector webhook catalog
-  },
-  input: CalendlyInviteeCreated,
+  trigger: { type: "manual" },       // default — may be omitted
+  input: CalendlyInviteeCreated,     // the only contract with the caller
   async run(input, ctx) { /* ... */ },
 });
 ```
 
 **Bound at publish** into a `Workflow` deploy record:
 
-- resolve `connector: "calendly"` → workspace `connectorId`
-- allocate public endpoint + signing secret (if webhook)
-- optionally call `connector.createWebhookSubscription()` (same as Sync provision)
-- store `enabled`, cron expression, endpoint URL on the deploy record
+- allocate the public POST URL + secret token (capability URL)
+- store `enabled`, cron expression (if cron), `nextRunAt`
+- token is rotatable from the UI; rotating invalidates the old URL
 
-Draft edits do not move provider webhooks until **Publish**.
+Draft edits do not change the live URL or schedule until **Publish**.
 
 Cron example:
 
@@ -384,64 +384,76 @@ Cron example:
 trigger: { type: "cron", cron: "0 */6 * * *", timezone: "UTC" }
 ```
 
-Manual:
+Cron workflows still get the POST URL — “Run now” with a fixture payload is
+always available regardless of trigger kind.
 
-```ts
-trigger: { type: "manual" } // also always available as “Run now” even if primary trigger is webhook/cron
-```
-
-### 9.3 Connector webhook — end-to-end (Calendly → workflow)
+### 9.3 HTTP ingress — end-to-end (works for Calendly, Stripe, curl, UI)
 
 Today Sync uses:
 
 `POST /api/webhooks/:workspaceId/:flowId` → `WebhookEvent` → CDC cron (~5 min) → warehouse.
 
-Workflows get a **sibling ingress** that shares verification, not CDC:
+Workflows get a **sibling ingress** that shares the ack-fast pattern, not CDC
+and not connector coupling:
 
 ```
-POST /api/webhooks/:workspaceId/workflows/:workflowId
+POST /api/webhooks/:workspaceId/workflows/:workflowId/:token
 ```
+
+The `:token` is a per-workflow secret generated at publish (capability URL —
+the only auth an external provider needs, since most providers can only be
+given a URL). Authenticated callers (UI, agent, API) can instead use:
+
+```
+POST /api/workspaces/:id/workflows/:wid/runs   (workspace auth, no token)
+```
+
+Both doors funnel into the same pipeline:
 
 ```mermaid
 sequenceDiagram
-  participant Cal as Calendly
-  participant API as Mako webhook route
-  participant Conn as Calendly connector
+  participant Src as Any caller (Calendly / UI / curl)
+  participant API as Mako ingress route
   participant Run as WorkflowRun
   participant Eng as Engine worker
 
-  Note over Cal,API: On publish: provision subscription to workflow URL
-  Cal->>API: POST signed invitee.created
-  API->>API: Load Workflow deploy (enabled)
-  API->>Conn: verifyWebhook(payload, headers, secret)
-  API->>API: Map payload → workflow input (Zod)
-  API->>Run: insert status=queued
+  Note over Src,API: Author pasted workflow URL into provider (one-time)
+  Src->>API: POST JSON body
+  API->>API: Load Workflow deploy (enabled) + constant-time token check
+  API->>API: Validate body → workflow input (Zod)
+  API->>Run: insert status=queued (idempotency key = body hash)
   API->>Eng: enqueue workflow.execute(runId)
-  API-->>Cal: 200 received
+  API-->>Src: 200 received
   Eng->>Eng: run(input) with step() checkpoints
   Eng->>Run: steps + succeeded/failed
 ```
 
 **Important differences from Sync webhooks:**
 
-| | Sync webhook flow | Workflow webhook |
+| | Sync webhook flow | Workflow ingress |
 | --- | --- | --- |
-| URL | `/api/webhooks/:ws/:flowId` | `/api/webhooks/:ws/workflows/:workflowId` |
-| After verify | Persist `WebhookEvent` → CDC batch | Create `WorkflowRun` → execute ASAP |
+| URL | `/api/webhooks/:ws/:flowId` | `/api/webhooks/:ws/workflows/:workflowId/:token` |
+| Caller identity | Bound to a connector | Agnostic — anything that can POST |
+| After accept | Persist `WebhookEvent` → CDC batch | Create `WorkflowRun` → execute ASAP |
 | Latency | Up to ~5 min (scheduler drain) | Near-real-time enqueue (required for CRM actions) |
 | Outcome | Rows in destination table | Side effects inside TS steps |
 
 **Reuse from Sync:**
 
-- Connector `supportsWebhooks` / `verifyWebhook` / `createWebhookSubscription`
-- Calendly HMAC (`Calendly-Webhook-Signature`) already implemented
-- Ack-fast pattern (verify + persist + 200, work async)
+- Ack-fast pattern (accept + persist + 200, work async)
+- Route scaffolding / workspace scoping in `api/src/routes/webhooks.ts`
 
-**Do not reuse:** `WebhookEvent` → `CdcChangeEvent` → materialize path.
+**Do not reuse:** `WebhookEvent` → `CdcChangeEvent` → materialize path, and no
+dependency on connector `verifyWebhook` / `createWebhookSubscription` /
+webhook-event catalogs. Optional per-workflow HMAC verification (e.g. Calendly’s
+`Calendly-Webhook-Signature`) can be layered on later as deploy-record config
+for providers that support signing — hardening, not a prerequisite.
 
-**Idempotency at the door:** store provider delivery id (or body hash) on
-`WorkflowRun` unique key so Calendly retries do not start a second run. Step-level
-idempotency keys still protect Close writes if a run is retried mid-flight.
+**Idempotency at the door:** store a body hash (provider-agnostic) on a
+`WorkflowRun` unique key so provider retries do not start a second run. An
+optional header mapping (e.g. use `X-Delivery-Id` as the key) can be configured
+per workflow. Step-level idempotency keys still protect Close writes if a run
+is retried mid-flight.
 
 ### 9.4 Cron — end-to-end
 
@@ -450,77 +462,65 @@ Inngest cron registration per workflow).
 
 ```
 every minute (or */5):
-  find Workflow where trigger.type=cron AND enabled
+  atomically claim Workflow where trigger.type=cron AND enabled
                    AND nextRunAt <= now
-                   AND no running run (optional concurrency policy)
-  for each: create WorkflowRun → enqueue engine
-  update nextRunAt from cron expression
+                   (findOneAndUpdate advances nextRunAt — safe with
+                    multiple API instances, no double-fire)
+  for each claimed: create WorkflowRun → enqueue engine
 ```
 
 Align with `flowSchedulerFunction` / scheduled-query patterns
 (`api/src/inngest/functions/flow.ts`, `scheduled-query.ts`).
 
-Workflows that only run on cron (reverse-ETL) never need a public URL.
+### 9.5 Binding connectors for the run
 
-### 9.5 Manual — end-to-end
-
-```
-POST /api/workspaces/:id/workflows/:wid/runs
-Body: { input: { ... } }
-
-→ validate against workflow Zod input
-→ WorkflowRun(triggerKind=manual)
-→ enqueue engine
-→ return run id for UI polling
-```
-
-Used for fixtures, debugging, and agent “try this payload.”
-
-### 9.6 Binding connectors for the run
-
-Triggers name **logical** connectors (`calendly`, `close`). The workflow project
-environment maps those to workspace resources:
+Connector bindings exist only for **actions inside steps** — triggers no longer
+reference connectors at all. The workflow project environment maps logical
+names to workspace resources:
 
 ```yaml
 # mako_workflows.yml (or project settings UI)
 bindings:
-  calendly: { connectorId: "..." }   # source of webhooks + optional API reads
   close:    { connectorId: "..." }   # injected as ctx.connectors.close()
   warehouse:{ databaseConnectionId: "..." }
 ```
 
 At run time:
 
-- Webhook secret / verify path uses the **trigger** connector binding
-- `ctx.connectors.*` uses the **action** bindings
+- `ctx.connectors.*` resolves through the action bindings
 - Secrets never appear in the TS file or in run logs (redacted)
 
-### 9.7 What the author does vs what Mako does
+### 9.6 What the author does vs what Mako does
 
-| Author writes | Mako does |
+| Author writes / does | Mako does |
 | --- | --- |
-| `trigger: { type: "connector_webhook", connector: "calendly", event: "invitee.created" }` | On publish: create endpoint, secret, call Calendly provision API |
+| `trigger: { type: "manual" }` (or omits it) | On publish: allocate POST URL + token |
+| Pastes the URL into Calendly / Stripe / anywhere (one-time) | Accepts POSTs, checks token, enqueues run |
 | Zod `input` schema | Validate ingress payload before run starts |
 | `async run(input, ctx)` | Enqueue, inject connectors, record steps |
 | `step("create_opp", ...)` | Durable retry / checkpoint |
 
-Author never pastes a Calendly signing key into code. Author never opens n8n to
-“add a webhook node.”
+Author never pastes a signing key into code. Author never opens n8n to “add a
+webhook node.” The one manual step — pasting a URL into the provider — buys
+freedom from connector webhook catalogs, provisioning APIs, and per-provider
+trigger types.
 
-### 9.8 Failure modes (trigger layer)
+### 9.7 Failure modes (trigger layer)
 
 | Failure | Behavior |
 | --- | --- |
-| Bad signature | `401/403`, no run created |
+| Bad/missing token | `401/403`, no run created |
 | Workflow disabled | `404/410`, no run |
-| Zod input mismatch | Run created as `failed` with validation error **or** reject at ingress (prefer reject for webhooks) |
+| Zod input mismatch | Reject at ingress (`422`) **and** record a rejected-delivery event so failed payloads stay debuggable from the UI |
 | Engine down | Run stays `queued`; retry dispatch; alert |
-| Step fails mid-run | Engine retries step; run `failed` if exhausted; trigger can fire again only if provider retries **and** ingress idempotency key differs |
-| Publish changes event filter | Re-provision or update subscription; old URL stays until cutover |
+| Step fails mid-run | Engine retries step; run `failed` if exhausted; a provider retry only creates a new run if the body-hash idempotency key differs |
+| Token rotated | Old URL returns `401` immediately; author updates the provider |
 
-### 9.9 Explicit non-design
+### 9.8 Explicit non-design
 
 - Workflows do **not** share Sync’s `type: "webhook"` flow documents.
+- No connector-bound trigger types, no webhook-event catalogs, no publish-time
+  provider provisioning in v1 — the tokenized URL is the whole contract.
 - A Sync Calendly→BigQuery flow and a Workflow Calendly→Close job are **two
   subscriptions** (or one fan-out later) — v1 keeps them independent to avoid
   coupling CRM latency to CDC batching.
@@ -553,7 +553,8 @@ New workspace-scoped collections (names illustrative):
 ### 10.4 `Workflow` (deployed unit — denormalized for runtime)
 
 - `projectId`, `versionId`, `name`, `trigger`, `enabled`
-- Pointer used by scheduler / webhook router
+- `ingressToken` (hashed), `nextRunAt` (cron)
+- Pointer used by scheduler / ingress router
 
 ### 10.5 `WorkflowRun`
 
@@ -579,7 +580,8 @@ All under workspace auth (`unifiedAuthMiddleware` + workspace context):
 | List | `.../workflows` | Deployed workflows + enabled flag |
 | Run | `.../workflows/:wid/runs` | Manual trigger + history |
 | Get run | `.../workflows/:wid/runs/:rid` | Step timeline |
-| Webhook | existing or `.../hooks/workflows/:wid/...` | Ingress |
+| Ingress | `POST /api/webhooks/:ws/workflows/:wid/:token` (public, tokenized) | External POST → run |
+| Token | `.../workflows/:wid/token/rotate` | Rotate ingress URL |
 
 Agent tools (server-side): `workflow_write_file`, `workflow_read_file`,
 `workflow_publish`, `workflow_explain_run`, `workflow_list_runs` — dedicated
@@ -610,7 +612,7 @@ timeline, never the source of truth.
 - Publish RBAC: member edit drafts; admin (or role TBD) publish to prod
 - Idempotency keys required by convention for mutate steps; lint/guide in skill docs
 - v1 assumes trusted workspace authors (same trust as writing sync config / dbt). Untrusted multi-tenant sandbox is out of scope
-- Webhook signatures verified via existing connector webhook capabilities
+- Ingress guarded by per-workflow secret tokens (constant-time compare, rotatable); optional HMAC verification later for providers that sign
 
 ---
 
@@ -618,7 +620,7 @@ timeline, never the source of truth.
 
 1. Pick highest-pain flow (Calendly → Close)
 2. Agent reimplements as TS workflow using connector guidelines / skills
-3. Point Calendly webhook at Mako (or dual-run shadow)
+3. Paste the workflow's POST URL into Calendly (or dual-run shadow)
 4. Compare outcomes; disable n8n
 5. Repeat for reverse-ETL and remaining automations
 
@@ -694,11 +696,11 @@ MVP should ship Close lead/opportunity actions needed for the golden path.
 - Register workflows with chosen engine
 - Inject connector clients
 - Persist step timeline → `WorkflowRun`
-- Manual + cron + one connector webhook trigger
+- Manual/HTTP ingress (tokenized POST URL) + cron trigger
 
 ### WS3 — Golden path: Calendly → Close
 
-- Webhook trigger wiring
+- Point Calendly at the workflow's tokenized POST URL
 - Close action helpers
 - End-to-end run in a workspace
 - Agent skill: how to write workflows + connector action shapes
@@ -738,7 +740,7 @@ MVP should ship Close lead/opportunity actions needed for the golden path.
 
 - [ ] Virtual FS project + editor
 - [ ] Publish → worker register
-- [ ] `connector_webhook` + `manual` + `cron`
+- [ ] Tokenized POST URL ingress (`manual`) + `cron`
 - [ ] Run history with step timeline
 - [ ] Calendly → Close golden path in one workspace
 - [ ] Minimal agent file edit tools

--- a/docs/workflows-as-code-prd.md
+++ b/docs/workflows-as-code-prd.md
@@ -313,19 +313,218 @@ connector clients is enough for internal RevOps replacement of n8n.
 
 ---
 
-## 9. Triggers
+## 9. Triggers — how they actually work
 
-| Trigger | MVP | Notes |
+A **trigger is not part of the TypeScript business logic**. It is platform
+config that answers: *when should we create a `WorkflowRun` and call
+`workflow.run(input)`?*
+
+The workflow body only sees a typed `input`. It does not register webhooks or
+crons itself.
+
+```
+[Calendly / cron / UI]
+        │
+        ▼
+ Mako ingress (verify / due check)
+        │
+        ▼
+ create WorkflowRun(input)
+        │
+        ▼
+ engine.execute(workflowName, input)   ← Hatchet/Inngest
+        │
+        ▼
+ user TS: async run(input, ctx) { await step(...) }
+```
+
+This is the same split Sync already uses (schedule/webhook on `IFlow`, executor
+elsewhere) — but Workflows **must not** drain into CDC materialization. Ingress
+enqueues a workflow run, not a warehouse MERGE.
+
+### 9.1 Trigger kinds (MVP)
+
+| Kind | Who fires it | What `input` is |
 | --- | --- | --- |
-| `connector_webhook` | ✅ | Reuse webhook ingress patterns from sync/CDC where possible |
-| `cron` | ✅ | Schedule stored on workflow publish config |
-| `manual` | ✅ | “Run now” from UI with optional JSON payload |
-| `flow.run.terminal` / sync completed | Later | Event bridge from existing Inngest bus |
-| `http` (signed URL) | Later | Generic ingress |
+| `connector_webhook` | External provider → Mako URL | Normalized event payload from the connector |
+| `cron` | Platform scheduler | Empty/`{}` or last-cursor bag (declared by workflow) |
+| `manual` | UI / API “Run now” | JSON the user pastes (often a fixture) |
 
-Trigger config lives with the workflow export (or sibling config in
-`mako_workflows.yml` for env-specific cron). Platform validates connector webhook
-capability at publish time.
+Later (not MVP): `http` signed URL, `on_sync_completed`, Slack events.
+
+### 9.2 Where trigger config lives
+
+**Declared in the workflow file** (source of truth for intent):
+
+```ts
+export default workflow({
+  name: "calendly_to_close_opportunity",
+  trigger: {
+    type: "connector_webhook",
+    connector: "calendly",           // logical name → workspace connector binding
+    event: "invitee.created",        // must be in connector webhook catalog
+  },
+  input: CalendlyInviteeCreated,
+  async run(input, ctx) { /* ... */ },
+});
+```
+
+**Bound at publish** into a `Workflow` deploy record:
+
+- resolve `connector: "calendly"` → workspace `connectorId`
+- allocate public endpoint + signing secret (if webhook)
+- optionally call `connector.createWebhookSubscription()` (same as Sync provision)
+- store `enabled`, cron expression, endpoint URL on the deploy record
+
+Draft edits do not move provider webhooks until **Publish**.
+
+Cron example:
+
+```ts
+trigger: { type: "cron", cron: "0 */6 * * *", timezone: "UTC" }
+```
+
+Manual:
+
+```ts
+trigger: { type: "manual" } // also always available as “Run now” even if primary trigger is webhook/cron
+```
+
+### 9.3 Connector webhook — end-to-end (Calendly → workflow)
+
+Today Sync uses:
+
+`POST /api/webhooks/:workspaceId/:flowId` → `WebhookEvent` → CDC cron (~5 min) → warehouse.
+
+Workflows get a **sibling ingress** that shares verification, not CDC:
+
+```
+POST /api/webhooks/:workspaceId/workflows/:workflowId
+```
+
+```mermaid
+sequenceDiagram
+  participant Cal as Calendly
+  participant API as Mako webhook route
+  participant Conn as Calendly connector
+  participant Run as WorkflowRun
+  participant Eng as Engine worker
+
+  Note over Cal,API: On publish: provision subscription to workflow URL
+  Cal->>API: POST signed invitee.created
+  API->>API: Load Workflow deploy (enabled)
+  API->>Conn: verifyWebhook(payload, headers, secret)
+  API->>API: Map payload → workflow input (Zod)
+  API->>Run: insert status=queued
+  API->>Eng: enqueue workflow.execute(runId)
+  API-->>Cal: 200 received
+  Eng->>Eng: run(input) with step() checkpoints
+  Eng->>Run: steps + succeeded/failed
+```
+
+**Important differences from Sync webhooks:**
+
+| | Sync webhook flow | Workflow webhook |
+| --- | --- | --- |
+| URL | `/api/webhooks/:ws/:flowId` | `/api/webhooks/:ws/workflows/:workflowId` |
+| After verify | Persist `WebhookEvent` → CDC batch | Create `WorkflowRun` → execute ASAP |
+| Latency | Up to ~5 min (scheduler drain) | Near-real-time enqueue (required for CRM actions) |
+| Outcome | Rows in destination table | Side effects inside TS steps |
+
+**Reuse from Sync:**
+
+- Connector `supportsWebhooks` / `verifyWebhook` / `createWebhookSubscription`
+- Calendly HMAC (`Calendly-Webhook-Signature`) already implemented
+- Ack-fast pattern (verify + persist + 200, work async)
+
+**Do not reuse:** `WebhookEvent` → `CdcChangeEvent` → materialize path.
+
+**Idempotency at the door:** store provider delivery id (or body hash) on
+`WorkflowRun` unique key so Calendly retries do not start a second run. Step-level
+idempotency keys still protect Close writes if a run is retried mid-flight.
+
+### 9.4 Cron — end-to-end
+
+Same bicycle Sync uses: **platform cron polls Mongo for due work** (not one
+Inngest cron registration per workflow).
+
+```
+every minute (or */5):
+  find Workflow where trigger.type=cron AND enabled
+                   AND nextRunAt <= now
+                   AND no running run (optional concurrency policy)
+  for each: create WorkflowRun → enqueue engine
+  update nextRunAt from cron expression
+```
+
+Align with `flowSchedulerFunction` / scheduled-query patterns
+(`api/src/inngest/functions/flow.ts`, `scheduled-query.ts`).
+
+Workflows that only run on cron (reverse-ETL) never need a public URL.
+
+### 9.5 Manual — end-to-end
+
+```
+POST /api/workspaces/:id/workflows/:wid/runs
+Body: { input: { ... } }
+
+→ validate against workflow Zod input
+→ WorkflowRun(triggerKind=manual)
+→ enqueue engine
+→ return run id for UI polling
+```
+
+Used for fixtures, debugging, and agent “try this payload.”
+
+### 9.6 Binding connectors for the run
+
+Triggers name **logical** connectors (`calendly`, `close`). The workflow project
+environment maps those to workspace resources:
+
+```yaml
+# mako_workflows.yml (or project settings UI)
+bindings:
+  calendly: { connectorId: "..." }   # source of webhooks + optional API reads
+  close:    { connectorId: "..." }   # injected as ctx.connectors.close()
+  warehouse:{ databaseConnectionId: "..." }
+```
+
+At run time:
+
+- Webhook secret / verify path uses the **trigger** connector binding
+- `ctx.connectors.*` uses the **action** bindings
+- Secrets never appear in the TS file or in run logs (redacted)
+
+### 9.7 What the author does vs what Mako does
+
+| Author writes | Mako does |
+| --- | --- |
+| `trigger: { type: "connector_webhook", connector: "calendly", event: "invitee.created" }` | On publish: create endpoint, secret, call Calendly provision API |
+| Zod `input` schema | Validate ingress payload before run starts |
+| `async run(input, ctx)` | Enqueue, inject connectors, record steps |
+| `step("create_opp", ...)` | Durable retry / checkpoint |
+
+Author never pastes a Calendly signing key into code. Author never opens n8n to
+“add a webhook node.”
+
+### 9.8 Failure modes (trigger layer)
+
+| Failure | Behavior |
+| --- | --- |
+| Bad signature | `401/403`, no run created |
+| Workflow disabled | `404/410`, no run |
+| Zod input mismatch | Run created as `failed` with validation error **or** reject at ingress (prefer reject for webhooks) |
+| Engine down | Run stays `queued`; retry dispatch; alert |
+| Step fails mid-run | Engine retries step; run `failed` if exhausted; trigger can fire again only if provider retries **and** ingress idempotency key differs |
+| Publish changes event filter | Re-provision or update subscription; old URL stays until cutover |
+
+### 9.9 Explicit non-design
+
+- Workflows do **not** share Sync’s `type: "webhook"` flow documents.
+- A Sync Calendly→BigQuery flow and a Workflow Calendly→Close job are **two
+  subscriptions** (or one fan-out later) — v1 keeps them independent to avoid
+  coupling CRM latency to CDC batching.
+- No “trigger node” inside the TS file beyond the declarative `trigger` field.
 
 ---
 

--- a/docs/workflows-as-code-prd.md
+++ b/docs/workflows-as-code-prd.md
@@ -1,0 +1,649 @@
+# PRD: Workflows as Code
+
+> Vibe-code deterministic multi-step jobs in TypeScript. Mako is the trigger,
+> connector context, runtime, and monitor — not an n8n canvas.
+
+**Status:** Proposal  
+**Related:** Sync Flows (`IFlow` / CDC), Transforms (dbt virtual FS + GitHub binding),
+Connectors, Inngest platform jobs, [Hatchet](https://github.com/hatchet-dev/hatchet)
+
+---
+
+## 1. Summary
+
+Replace cumbersome n8n-style JSON graphs with **TypeScript workflows** stored in
+Mako (virtual filesystem, optional Git sync — same pattern as dbt Transforms).
+
+A workflow is a normal `async` function. Multi-step durability comes from named
+**steps** (Inngest `step.run` / Hatchet child-task style). Triggers, connector
+credentials, retries, and run history are platform concerns. The AI agent edits
+workflow files and debugs failed runs — “vibe code / vibe fix,” not drag-and-drop.
+
+This is a **new product surface**, separate from Sync Flows (ELT into warehouses).
+Sync stays the high-throughput data plane. Workflows cover event automation,
+reverse-ETL-style SaaS writes, and (later) compute/OCR pipelines that Sync cannot
+express cleanly.
+
+---
+
+## 2. Motivation
+
+### 2.1 Jobs Sync Flows cannot own
+
+| Use case | Why Sync is the wrong tool |
+| --- | --- |
+| Calendly webhook → create Close opportunity | Multi-step side effects, branching, CRM writes |
+| Reverse-ETL: dbt mart → Close / RealAdvisor | Warehouse → SaaS mutate, not table materialization |
+| Document OCR → BigQuery | Long-running compute + structured extract |
+| Slack-driven ops / self-heal loops | Event + agent + mutate, not CDC MERGE |
+
+Today these live in n8n (or one-off scripts). n8n JSON is verbose, hostile to AI
+editing, and disconnected from Mako connectors, marts, and auth.
+
+### 2.2 Desired outcomes
+
+1. **Vibe-code workflows** — agent (or human) writes ~50 lines of TS instead of an n8n graph.
+2. **Deterministic jobs** — durable steps, retries, idempotency; not “ask an LLM every time.”
+3. **Git-friendly files** — virtual FS now; GitHub binding later (dbt precedent).
+4. **Mako as orchestrator + monitor** — triggers, secrets, runs, logs; no required canvas.
+5. **Reuse connectors** — Close, Calendly, BQ, etc. injected; keys never in source files.
+6. **Thin abstraction** — one clear `workflow()` + `step()` contract; engine swappable.
+
+### 2.3 Non-goals (v1)
+
+- Visual node editor / n8n-compatible import as source of truth
+- Language-agnostic runtimes (Python/Ruby workers) — TypeScript only
+- Replacing Sync Flows / CDC with workflows
+- Full Inngest → Hatchet migration of existing platform jobs
+- Self-healing Slack agents (follow-on once runs + files exist)
+- YAML workflow DSLs
+
+---
+
+## 3. Product principles
+
+1. **TypeScript is the source language.** Conditionals, loops, and fan-out are language features.
+2. **Files are the artifact.** Same mental model as dbt models / app files — not Mongo form blobs.
+3. **Steps make side effects durable.** Bare connector calls inside a workflow body are a lint error once we enforce it.
+4. **Connectors are injected context.** Workflows never embed API keys.
+5. **Canvas is optional projection.** Monitoring + code view first; lineage graph later if useful.
+6. **Bicycle before rocket.** Static load of published workflows into a worker beats hot-reload architecture on day one.
+7. **Keep Sync and Workflows distinct.** Shared credentials and UX chrome; different schemas and engines.
+
+---
+
+## 4. Goals & success metrics
+
+### 4.1 Goals
+
+| Horizon | Goal |
+| --- | --- |
+| MVP | One real n8n flow replaced (Calendly → Close opportunity) running in Mako |
+| v1 | Reverse-ETL style mart → Close upsert as a second workflow; run history + agent edit |
+| v1.5 | Optional GitHub binding; webhook + cron triggers; basic fixture tests |
+| Later | OCR/compute steps; self-heal from Slack/run failures; engine consolidation |
+
+### 4.2 Success metrics
+
+- Time to author Calendly→Close workflow (agent-assisted) ≪ equivalent n8n build
+- ≥1 production n8n workflow migrated and n8n dependency removed for that path
+- Failed runs diagnosable from Mako UI + agent chat without leaving the product
+- Zero secrets committed in workflow source (static check)
+- Step retries do not double-create CRM objects when idempotency keys are set
+
+---
+
+## 5. Personas & jobs-to-be-done
+
+| Persona | JTBD |
+| --- | --- |
+| RevOps / founder (Jonas) | Replace n8n with vibe-coded TS jobs tied to Mako connectors |
+| Platform eng (Kirill) | Thin runtime abstraction; durable execution without Inngest UI pain at scale |
+| AI agent | Read connector shapes + write/edit workflow files + explain failed steps |
+| Workspace member | Enable/disable workflows, see runs, replay, inspect inputs/outputs |
+
+---
+
+## 6. Core abstraction
+
+### 6.1 Mental model
+
+```
+Trigger  →  Workflow (async TS)  →  named Steps (durable I/O)  →  Result
+                │
+                ├── connectors.*  (injected)
+                ├── step("name", fn)
+                ├── step.sleep / waitForEvent
+                └── normal if / map / try
+```
+
+**Multi-step convention (non-negotiable):**
+
+> A workflow is a normal TypeScript `async` function. Every external side effect
+> goes through `step("name", ...)`. Branching and loops are ordinary TS.
+> On retry, completed step names are skipped and their results reused.
+
+This matches battle-tested patterns in Inngest (`step.run`) and Hatchet
+(`task.run` / durable child spawn). Mako should adopt this convention, not invent
+a graph DSL on top.
+
+### 6.2 Authoring API (proposed)
+
+```ts
+import { workflow, step } from "@mako/workflow";
+import { z } from "zod";
+
+const CalendlyInviteeCreated = z.object({
+  invitee: z.object({
+    uri: z.string(),
+    email: z.string().email(),
+    name: z.string().optional(),
+  }),
+  event_type: z.string(),
+});
+
+export default workflow({
+  name: "calendly_to_close_opportunity",
+  description: "Create a Close opportunity when a Calendly demo is booked",
+  trigger: {
+    type: "connector_webhook",
+    connector: "calendly",
+    event: "invitee.created",
+  },
+  input: CalendlyInviteeCreated,
+
+  async run(input, ctx) {
+    const close = ctx.connectors.close();
+    const email = input.invitee.email.toLowerCase();
+
+    const lead = await step("find_or_create_lead", async () => {
+      return close.leads.upsert({
+        email,
+        name: input.invitee.name,
+        idempotencyKey: `lead:${email}`,
+      });
+    });
+
+    if (input.event_type !== "demo") {
+      return { status: "skipped", reason: "not_demo", leadId: lead.id };
+    }
+
+    const opp = await step("create_opportunity", async () => {
+      return close.opportunities.create({
+        leadId: lead.id,
+        name: `Demo — ${email}`,
+        idempotencyKey: `opp:${input.invitee.uri}`,
+      });
+    });
+
+    return { status: "ok", leadId: lead.id, opportunityId: opp.id };
+  },
+});
+```
+
+### 6.3 Reverse-ETL sketch
+
+```ts
+export default workflow({
+  name: "sync_account_managers_to_close",
+  trigger: { type: "cron", cron: "0 */6 * * *" },
+
+  async run(_input, ctx) {
+    const bq = ctx.connectors.bigquery(); // or ctx.databases.get("warehouse")
+    const close = ctx.connectors.close();
+
+    const rows = await step("fetch_mart", async () => {
+      return bq.query(`
+        select account_id, name, domain, owner_email, updated_at
+        from \`proj.dbt.mart_accounts\`
+        where updated_at > timestamp_sub(current_timestamp(), interval 12 hour)
+      `);
+    });
+
+    await Promise.all(
+      rows.map((row) =>
+        step(`upsert_lead:${row.account_id}`, async () => {
+          return close.leads.upsert({
+            ...row,
+            idempotencyKey: `acct:${row.account_id}`,
+          });
+        })
+      )
+    );
+
+    return { upserted: rows.length };
+  },
+});
+```
+
+### 6.4 What belongs in a step vs inline
+
+| Inline (OK) | Must be a `step` |
+| --- | --- |
+| Pure transforms, string/date math | Connector / HTTP / DB calls |
+| Input Zod parse (platform) | Slack/email sends |
+| Cheap deterministic branching predicates | Sleeps, wait-for-event, human approval |
+| Building payloads from prior step outputs | Anything that must not double-fire on retry |
+
+---
+
+## 7. Project layout
+
+Mirror Transforms (dbt) — Mongo virtual FS first; optional GitHub binding later.
+
+```text
+workflows/                              # project root (per workspace project)
+  mako_workflows.yml                    # name, version, defaults
+  calendlyToCloseOpportunity.ts
+  syncAccountManagersToClose.ts
+  _lib/                                 # shared helpers (optional)
+    closeMappers.ts
+  _fixtures/                            # sample payloads for local/CI replay
+    calendly_invitee_created.json
+```
+
+`mako_workflows.yml` (minimal):
+
+```yaml
+name: revenue_ops_workflows
+version: 1
+# Environments bind logical connector names → workspace connector IDs
+# (resolved at publish/run time; never store secrets here)
+```
+
+**Publish model (v1):** draft files in virtual FS → **Publish** snapshots a
+version (SHA / `EntityVersion`) → worker loads **published** bundle only.
+Editing draft does not affect production until publish (same spirit as apps/dbt).
+
+---
+
+## 8. Architecture
+
+### 8.1 Context diagram
+
+```
+┌─ Authoring ─────────────────────────────────────────────────┐
+│  In-Mako editor + agent  │  (later) GitHub sync / Cursor     │
+│  Virtual FS (Mongo)      │  workflow_write_file tools        │
+└────────────────────────────┬────────────────────────────────┘
+                             │ publish snapshot
+                             ▼
+┌─ Control plane (Mako API) ──────────────────────────────────┐
+│  Triggers: connector webhooks, cron, manual                  │
+│  Credential injection: workspace connectors (encrypted)      │
+│  Run records: status, step timeline, I/O redaction           │
+│  Deploy registry: workspace → published workflow bundle      │
+└────────────────────────────┬────────────────────────────────┘
+                             │ enqueue
+                             ▼
+┌─ Execution plane ───────────────────────────────────────────┐
+│  Durable engine (decision: Hatchet and/or Inngest — §15)     │
+│  Worker(s): load published TS bundle, register workflows     │
+│  step() → engine checkpoint / retry / concurrency            │
+└────────────────────────────┬────────────────────────────────┘
+                             │
+                             ▼
+              Close / Calendly / BQ / Slack / …
+              via existing Mako connector clients
+```
+
+### 8.2 Relationship to existing systems
+
+| System | Relationship |
+| --- | --- |
+| **Sync Flows (`IFlow`)** | Unchanged. ELT/CDC into destinations. Workflows may *call* SQL or react to sync completion later; they do not replace Sync. |
+| **Connectors** | Read credentials + typed clients from workspace connectors. Prefer existing connector SDK surfaces; add thin “action” helpers where sync-only APIs are insufficient (e.g. Close create opportunity). |
+| **dbt Transforms** | Virtual FS + GitHub binding + drafts/publish are the **pattern to copy**, not the storage to share. Workflows are a sibling project type. |
+| **Inngest today** | Continues to run sync/CDC/dbt/dashboard jobs unless/until a deliberate migration. Workflows may use Inngest *or* Hatchet — see open decisions. |
+| **n8n** | Migration target: reimplement flows as TS workflows; no requirement to import n8n JSON. |
+| **Apps / MCP** | Out of scope for MVP. Later: agent/MCP tools to edit workflows headlessly (apps PRD precedent). |
+
+### 8.3 Worker load model (bicycle)
+
+**v1:** On publish (or worker boot), materialize published files to disk (or
+esbuild bundle), register `workflow()` exports with the engine, restart or
+hot-swap worker process for that workspace/pool.
+
+**Not v1:** Arbitrary eval of draft code on every save; multi-tenant untrusted
+code without sandbox. If user-defined npm deps become required, revisit
+sandboxing (connector-builder PRD / E2B) as a separate workstream.
+
+Trusted authors (workspace members) writing TS that imports `@mako/workflow` +
+connector clients is enough for internal RevOps replacement of n8n.
+
+---
+
+## 9. Triggers
+
+| Trigger | MVP | Notes |
+| --- | --- | --- |
+| `connector_webhook` | ✅ | Reuse webhook ingress patterns from sync/CDC where possible |
+| `cron` | ✅ | Schedule stored on workflow publish config |
+| `manual` | ✅ | “Run now” from UI with optional JSON payload |
+| `flow.run.terminal` / sync completed | Later | Event bridge from existing Inngest bus |
+| `http` (signed URL) | Later | Generic ingress |
+
+Trigger config lives with the workflow export (or sibling config in
+`mako_workflows.yml` for env-specific cron). Platform validates connector webhook
+capability at publish time.
+
+---
+
+## 10. Data model (proposed)
+
+New workspace-scoped collections (names illustrative):
+
+### 10.1 `WorkflowProject`
+
+- `workspaceId`, `name`, `slug`
+- `defaultEnvironment` bindings (logical connector name → `connectorId` / `databaseConnectionId`)
+- Optional `repoBinding` (same shape as `IDbtRepoBinding` — later)
+- `publishedVersionId`, timestamps
+
+### 10.2 `WorkflowFile`
+
+- `projectId`, `path`, `content`, `updatedAt`, `updatedBy`
+- Draft tree in Mongo (dbt `DbtFile` precedent)
+
+### 10.3 `WorkflowVersion` (publish snapshot)
+
+- Immutable file tree + compiled manifest (workflow names, triggers, step names if statically discoverable)
+- `gitSha` optional
+- Content hash
+
+### 10.4 `Workflow` (deployed unit — denormalized for runtime)
+
+- `projectId`, `versionId`, `name`, `trigger`, `enabled`
+- Pointer used by scheduler / webhook router
+
+### 10.5 `WorkflowRun`
+
+- `workflowId`, `versionId`, `triggerKind`, `status` (`queued|running|succeeded|failed|cancelled`)
+- `input` (redacted), `output`, `error`
+- `steps[]`: `{ name, status, attempt, startedAt, finishedAt, error? }`
+- Engine run id (Inngest/Hatchet) for deep links
+
+Reuse `EntityVersion` / notification patterns where they already fit
+(`NotificationResourceType` may gain `"workflow"`).
+
+---
+
+## 11. API surface (sketch)
+
+All under workspace auth (`unifiedAuthMiddleware` + workspace context):
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| CRUD | `/workspaces/:id/workflow-projects` | Project lifecycle |
+| Files | `.../workflow-projects/:pid/files` | Virtual FS read/write (agent tools) |
+| Publish | `.../workflow-projects/:pid/publish` | Snapshot → register worker |
+| List | `.../workflows` | Deployed workflows + enabled flag |
+| Run | `.../workflows/:wid/runs` | Manual trigger + history |
+| Get run | `.../workflows/:wid/runs/:rid` | Step timeline |
+| Webhook | existing or `.../hooks/workflows/:wid/...` | Ingress |
+
+Agent tools (server-side): `workflow_write_file`, `workflow_read_file`,
+`workflow_publish`, `workflow_explain_run`, `workflow_list_runs` — dedicated
+agent mode/skill later (`api/src/agent-skills/workflows/`).
+
+---
+
+## 12. UI (thin)
+
+MVP UI — **no node canvas**:
+
+1. **Workflows explorer** — list projects / workflows, enabled toggle
+2. **Code editor** — Monaco on virtual FS (reuse dbt/app editor patterns)
+3. **Publish / versions**
+4. **Run history** — status, duration, step timeline, input/output JSON
+5. **Manual run** — paste fixture JSON
+6. **Agent side chat** — edit files + explain failures (monitor, not canvas)
+
+Lineage / graph view is a later projection of the compiled manifest + step
+timeline, never the source of truth.
+
+---
+
+## 13. Security & tenancy
+
+- Workspace-scoped everything; connector credentials decrypted only in worker/runtime path
+- Redact secrets from run logs and step I/O
+- Publish RBAC: member edit drafts; admin (or role TBD) publish to prod
+- Idempotency keys required by convention for mutate steps; lint/guide in skill docs
+- v1 assumes trusted workspace authors (same trust as writing sync config / dbt). Untrusted multi-tenant sandbox is out of scope
+- Webhook signatures verified via existing connector webhook capabilities
+
+---
+
+## 14. Migration from n8n
+
+1. Pick highest-pain flow (Calendly → Close)
+2. Agent reimplements as TS workflow using connector guidelines / skills
+3. Point Calendly webhook at Mako (or dual-run shadow)
+4. Compare outcomes; disable n8n
+5. Repeat for reverse-ETL and remaining automations
+
+No automated n8n JSON importer in v1.
+
+---
+
+## 15. Open decisions
+
+### 15.1 Execution engine: Hatchet vs Inngest
+
+| Option | Pros | Cons |
+| --- | --- | --- |
+| **A. Inngest for workflows** | Already in-repo; `step.run` matches convention; fastest MVP | Self-hosted UI pain at high event volume (scrapers signal); couples workflows to current bus |
+| **B. Hatchet for workflows only** | Durable tasks/DAGs, workers, better high-churn ops story; keeps Sync on Inngest | Second runtime to operate; dynamic registration still required |
+| **C. Migrate platform to Hatchet** | One engine long-term | Large rewrite; blocks bicycle |
+
+**Recommendation:** Decide with a short spike — implement the same Calendly→Close
+workflow against both `step` shims. Prefer **B** if scraper/event-volume pain is
+already forcing Hatchet; else **A** for MVP speed with an engine-agnostic
+`@mako/workflow` façade so B remains possible.
+
+`@mako/workflow` must not leak engine types into user workflow files.
+
+### 15.2 Dynamic registration
+
+Engines expect workflows registered on workers. Approaches:
+
+1. **Publish → rebuild bundle → restart/reload worker** (MVP)
+2. Per-workspace worker pools with versioned bundles
+3. Sandboxed eval / isolate (later, if untrusted code)
+
+Document reload SLOs (e.g. publish visible within N seconds).
+
+### 15.3 Connector action coverage
+
+Sync connectors are pull/CDC oriented. Workflows need **outbound actions**
+(create opportunity, upsert lead). Options:
+
+- Extend connector classes with an `actions` surface
+- Thin workflow-only clients wrapping existing APIs
+- HTTP step + documented Close API (escape hatch)
+
+MVP should ship Close lead/opportunity actions needed for the golden path.
+
+### 15.4 Git
+
+- **MVP:** Mongo virtual FS + publish versions (dbt-like)
+- **Next:** `IWorkflowRepoBinding` copying `IDbtRepoBinding`
+- Real git is valuable for AI/PRs; not a blocker for first production workflow
+
+---
+
+## 16. Workstreams
+
+### WS0 — Package & convention (`@mako/workflow`)
+
+- `workflow()` / `step()` / context types
+- Zod input validation
+- Engine adapter interface (`InngestAdapter` | `HatchetAdapter`)
+- Fixture replay helper for tests
+- Lint guidance: no secrets; mutate steps need idempotency keys
+
+### WS1 — Persistence & virtual FS
+
+- Schema: project, files, versions, runs
+- Routes + Zustand store + Monaco editor shell
+- Publish snapshot pipeline
+
+### WS2 — Runtime worker
+
+- Bundle published project
+- Register workflows with chosen engine
+- Inject connector clients
+- Persist step timeline → `WorkflowRun`
+- Manual + cron + one connector webhook trigger
+
+### WS3 — Golden path: Calendly → Close
+
+- Webhook trigger wiring
+- Close action helpers
+- End-to-end run in a workspace
+- Agent skill: how to write workflows + connector action shapes
+
+### WS4 — Reverse-ETL path
+
+- Cron + BQ/SQL query step + Close upsert fan-out
+- Concurrency limits / batching helpers
+- Document pattern: mart → SaaS
+
+### WS5 — Agent mode
+
+- File tools + explain run + “fix from error” loop
+- Skill under `api/src/agent-skills/workflows/`
+
+### WS6 — GitHub binding (optional)
+
+- Reuse GitHub App install + push sync + protected branch patterns from dbt
+
+### WS7 — Hardening
+
+- Redaction, RBAC, rate limits, replay, alerting (`flow.run.terminal`-style fanout)
+- Metrics: run success rate, step latency, publish reload time
+
+---
+
+## 17. Implementation phases
+
+### Phase 0 — Spike (engine + API shape)
+
+- [ ] Spike Calendly→Close on Inngest `step.run` behind `@mako/workflow`
+- [ ] Spike same on Hatchet durable tasks
+- [ ] Choose engine for WS2; keep façade
+- [ ] List Close actions required; gap vs current connector
+
+### Phase 1 — MVP (bicycle)
+
+- [ ] Virtual FS project + editor
+- [ ] Publish → worker register
+- [ ] `connector_webhook` + `manual` + `cron`
+- [ ] Run history with step timeline
+- [ ] Calendly → Close golden path in one workspace
+- [ ] Minimal agent file edit tools
+
+### Phase 2 — v1
+
+- [ ] Reverse-ETL workflow example + helpers
+- [ ] Agent skill + explain failed run
+- [ ] Notifications on failure
+- [ ] Fixture-based replay in CI/publish checks
+
+### Phase 3 — Expand
+
+- [ ] GitHub binding
+- [ ] Sync-completion triggers
+- [ ] Compute/OCR step type (kernel or worker)
+- [ ] Self-heal experiments (agent reads failure + opens draft fix)
+- [ ] Revisit engine consolidation
+
+---
+
+## 18. Risks & mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Second orchestrator ops burden | Façade + single product surface; Sync stays on Inngest until deliberate migration |
+| Double-writes on retry | Mandatory `step` + idempotency keys; tests with fixture replay |
+| Dynamic registration complexity | Publish/restart bicycle first |
+| Connector gaps for CRM writes | Explicit Close action work in Phase 0/1 |
+| Scope creep into “n8n clone” | No canvas; TS files only; one golden path |
+| Untrusted code execution | Trusted authors only in v1; sandbox later if needed |
+| Confusion with Sync “Flows” | Product naming: **Workflows** vs **Sync**; separate nav |
+
+---
+
+## 19. Naming
+
+| Term | Meaning |
+| --- | --- |
+| **Sync / Sync Flow** | Existing ELT/CDC `IFlow` into warehouse/DB tables |
+| **Workflow** | This PRD — TS durable automation |
+| **Step** | Named durable unit of side effect inside a workflow |
+| **Workflow project** | Virtual FS bundle of workflow files (like a dbt project) |
+| **Publish** | Immutable snapshot loaded by workers |
+
+Avoid calling workflows “flows” in UI copy to prevent collision with Sync.
+
+---
+
+## 20. Appendix A — Why not X
+
+| Alternative | Why not (for this product) |
+| --- | --- |
+| **n8n in Mako** | JSON graphs are AI-hostile; duplicates connectors; canvas-first |
+| **YAML DSL (Kestra-style)** | Poor fit for branching; team preference is TS; YAML was illustrative only |
+| **Stretch Sync `IFlow`** | Wrong write model (MERGE/tables vs CRM side effects) |
+| **Cursor-only + raw Hatchet** | Works for one-shots; loses shared connectors, webhooks, workspace monitor, agent context |
+| **Full Dagster/asset platform** | Right philosophy for data assets; heavy for RevOps automations; Python-first |
+| **LLM does the job every run** | Costly, slow, nondeterministic — agents *author* workflows; engines *run* them |
+
+---
+
+## 21. Appendix B — Multi-step convention cheatsheet
+
+```ts
+// Sequence
+const a = await step("a", () => ...);
+const b = await step("b", () => ...);
+
+// Branch
+if (a.ok) {
+  await step("c", () => ...);
+} else {
+  await step("d", () => ...);
+}
+
+// Fan-out
+await Promise.all(
+  items.map((item) => step(`work:${item.id}`, () => ...))
+);
+
+// Wait
+await step.sleep("cooldown", "5m");
+const evt = await step.waitForEvent("approved", { timeout: "48h" });
+
+// Compose
+const enriched = await step.run(enrichWorkflow, input);
+```
+
+**Remember:** the workflow function may be replayed; only `step` boundaries are
+safe for side effects.
+
+---
+
+## 22. Appendix C — Thread consensus (internal)
+
+Product direction distilled from internal discussion:
+
+- n8n is cumbersome; target is thin TS workflows in Mako
+- Hatchet is interesting (also for scrapers vs Inngest UI limits) but engine ≠ product
+- Missing piece called out: **dynamic registration of code from storage into workers**
+- Virtual FS (like dbt) is acceptable; git sync is valuable later, not a blocker
+- Canvas not required — monitoring + code view
+- Simplest useful shape: **trigger + data + keys + TypeScript function + success/failure**
+- Mako’s unique value: connectors, webhooks, shared context, monitor/agent — not locking authoring away from Cursor
+
+This PRD turns that consensus into an implementable convention and phased plan.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a product PRD for **Workflows as Code** — TypeScript durable automations in Mako as an n8n replacement, separate from Sync Flows.

Doc: [`docs/workflows-as-code-prd.md`](docs/workflows-as-code-prd.md)

## What’s in the PRD

- **Problem:** Sync can’t own Calendly→Close, reverse-ETL to CRM, OCR pipelines; n8n JSON is AI-hostile
- **Convention:** `workflow()` + named `step()` (Inngest/Hatchet-style); branching is normal TS
- **Storage:** Mongo virtual FS + publish snapshots (dbt Transforms pattern); GitHub binding later
- **Mako role:** triggers, connector injection, run monitor — no required canvas
- **Triggers (provider-agnostic):** only `cron` + `manual`; every workflow gets a tokenized POST URL used by both UI “Run now” and any provider webhook — no connector-bound trigger types, no publish-time provisioning
- **MVP golden path:** Calendly webhook → Close opportunity
- **Open decision:** Hatchet vs Inngest behind an engine-agnostic `@mako/workflow` façade
- Phased workstreams (spike → bicycle MVP → reverse-ETL → agent → git)

## Out of scope (called out)

Visual n8n clone, YAML DSL, replacing Sync/CDC, full platform engine migration, self-heal agents (later)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8cdf-1fae-7c80-82a0-c28ede53dd7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8cdf-1fae-7c80-82a0-c28ede53dd7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


