### PR TITLE
docs: console Runs tab, executions endpoint, list_console_executions (#734)

### DIFF
--- a/docs/src/content/docs/ai-agent.md
+++ b/docs/src/content/docs/ai-agent.md
@@ -230,6 +230,7 @@ The agent then calls `check_query_status` to fetch the result, and can stop a ru
 | `run_console`        | Executes a console's query as a detached run; returns rows, or `status: "running"` + `executionId`   |
 | `check_query_status` | Polls a running query by `consoleId` (+ optional `executionId`); returns `running`/`success`/`error`/`cancelled` |
 | `cancel_query`       | Aborts a running detached query (task + engine-native cancel)                                         |
+| `list_console_executions` | Lists a console's recent executions with trigger source (App UI / API key / MCP / AI agent / Schedule / Flow), status, duration, and row count |
 
 Results land via the persisted `lastRun` record and the realtime `console.run.completed` pipeline, so result polling works across server instances for **every engine** — no re-attach and no Inngest dependency (multi-instance realtime fan-out uses `REDIS_URL`). A server-side hard cap (`QUERY_HARD_MAX_EXECUTION_MS`, 5 minutes default) aborts any detached run that exceeds it, so no query can run forever.
 

--- a/docs/src/content/docs/api-reference.md
+++ b/docs/src/content/docs/api-reference.md
@@ -112,6 +112,7 @@ The legacy unauthenticated `POST /api/execute` and `POST /api/run/:path` endpoin
 | `DELETE` | `/api/workspaces/:wid/consoles/:id/schedule` | Remove a saved console schedule (admin only) |
 | `POST` | `/api/workspaces/:wid/consoles/:id/schedule/run` | Trigger a scheduled console immediately (admin only) |
 | `GET` | `/api/workspaces/:wid/consoles/:id/schedule/runs` | List scheduled run history (admin only) |
+| `GET` | `/api/workspaces/:wid/consoles/:id/executions` | List recent query executions with trigger source (`?limit=`, ~90-day retention) |
 | `GET` | `/api/workspaces/:wid/scheduled-queries` | List scheduled consoles in the workspace (admin only) |
 | `GET`    | `/api/workspaces/:wid/consoles/:id/collaborators`           | List per-user collaborators                  |
 | `POST`   | `/api/workspaces/:wid/consoles/:id/collaborators`           | Add/update a collaborator (`{ userId, role }`; owner/admin only) |

--- a/docs/src/content/docs/console.md
+++ b/docs/src/content/docs/console.md
@@ -59,6 +59,12 @@ When a console is scheduled, Mako stores the next run time and executes it throu
 
 Triggering an async run requires workspace admin access and hits `POST /api/workspaces/:wid/consoles/:id/schedule/run`.
 
+### Runs Tab
+
+The **Runs** tab below the editor lists the console's recent query executions (retained for ~90 days) — not just scheduled runs. Each row shows status, duration, row count, and a **Trigger** label identifying what ran the query: App UI, API key, MCP, AI agent, Schedule, or Flow. External triggers (API key, MCP) are highlighted and show a key suffix when available. For scheduled consoles, the scheduled run history appears as a subsection.
+
+The same history is available programmatically via `GET /api/workspaces/:wid/consoles/:id/executions` and to agents via the `list_console_executions` tool.
+
 ## Live Editing & Streaming
 
 When the agent edits a console, changes are applied **server-side to the authoritative draft** and any open windows update live — you don't have to be the one driving the chat to see the edit land.
@@ -107,6 +113,7 @@ Authorization: Bearer revops_YOUR_API_KEY
 | `DELETE` | `/api/workspaces/:wid/consoles/:id/schedule` | Remove a schedule (admin only) |
 | `POST` | `/api/workspaces/:wid/consoles/:id/schedule/run` | Trigger a scheduled console now (admin only) |
 | `GET` | `/api/workspaces/:wid/consoles/:id/schedule/runs` | List scheduled run history (admin only) |
+| `GET` | `/api/workspaces/:wid/consoles/:id/executions` | List recent query executions (any trigger, ~90-day retention) |
 | `GET` | `/api/workspaces/:wid/scheduled-queries` | List scheduled consoles in the workspace (admin only) |
 
 ### Example


### PR DESCRIPTION
Daily docs maintenance — covers yesterday's merges.

## What changed in code
- **#734** — Console execution logs in the Runs tab + `list_console_executions` agent tool + `GET /consoles/:id/executions` endpoint. `CONSOLE_API_DOCUMENTATION.md` was updated in the PR itself, but the Starlight docs were not.
- **#738** — Wise pagination fix (internal bugfix, no doc impact; connectors.md Wise row still accurate).
- **#736** — Cursor cloud agent env config (documented in AGENTS.md within the PR; no user-facing doc impact).

## Docs updated
- `console.md`: new **Runs Tab** section — trigger labels (App UI / API key / MCP / AI agent / Schedule / Flow), ~90-day retention, scheduled-runs subsection; added the executions endpoint to the Console API table.
- `api-reference.md`: added `GET /api/workspaces/:wid/consoles/:id/executions` to the Consoles route table.
- `ai-agent.md`: added `list_console_executions` to the long-running query tools table (it's a Query-mode tool alongside `check_query_status`/`cancel_query`).

Verified against `api/src/routes/consoles.ts`, `api/src/agent-lib/tools/server-console-tools.ts`, `api/src/agents/modes/registry.ts`, and the #734 diff.