### PR TITLE
fix(acp): Codex mako-desktop auto-approve + preview blackout

### DIFF
--- a/app/src/agent-runtime/client-tool-manifest.ts
+++ b/app/src/agent-runtime/client-tool-manifest.ts
@@ -631,6 +631,14 @@ export const AGENT_TOOL_MANIFEST = {
     getLabel: () => "Rebuilding app preview",
     icon: "play",
   },
+  // Desktop ACP (mako-desktop) — read live iframe errors without rebuilding.
+  get_preview_errors: {
+    domain: "app",
+    execution: "client",
+    clientExecutor: "app",
+    getLabel: () => "Checking preview errors",
+    icon: "eye",
+  },
   app_set_preview_environment: {
     domain: "app",
     execution: "client",

--- a/app/src/components/AppRenderer.tsx
+++ b/app/src/components/AppRenderer.tsx
@@ -305,6 +305,14 @@ export default function AppRenderer({
   // with Babel can take several seconds; show progress instead of a white box.
   const [booting, setBooting] = useState(true);
 
+  // If the iframe never posts ready/error (crash, hung CDN), clear the overlay
+  // so users aren't stuck on a black "Building preview…" screen.
+  useEffect(() => {
+    if (!booting) return;
+    const timer = window.setTimeout(() => setBooting(false), 20_000);
+    return () => window.clearTimeout(timer);
+  }, [booting, previewNonce]);
+
   useEffect(() => {
     if (!appEntity && workspaceId) void fetchApp(workspaceId, appId);
   }, [appEntity, workspaceId, appId, fetchApp]);

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -308,6 +308,8 @@ const Chat: React.FC<ChatProps> = ({
   /** Bumps on each ACP send so overlapping finally blocks don't clear busy early. */
   const localAcpGenerationRef = useRef(0);
   const [localAcpBusy, setLocalAcpBusy] = useState(false);
+  const localAcpBusyRef = useRef(false);
+  localAcpBusyRef.current = localAcpBusy;
   // Client-tool registry: in-flight executions, cancel/interrupt plumbing,
   // and the per-chat toolCallId dispatch dedupe gate (the triplicate-tool
   // fix). Created before useChat — its register/settle callbacks are wired
@@ -847,6 +849,7 @@ const Chat: React.FC<ChatProps> = ({
     loadPersistedMessagesRef,
     requestResumeRef,
     localAcpBindingRef,
+    localAcpBusyRef,
   });
 
   // Create new chat session - just generate a new ID locally (no API call needed)

--- a/app/src/components/chat/hooks/useChatSessionLoader.ts
+++ b/app/src/components/chat/hooks/useChatSessionLoader.ts
@@ -145,6 +145,12 @@ export interface UseChatSessionLoaderArgs {
    * Chat on new-session; set here when a persisted localAcp payload is loaded.
    */
   localAcpBindingRef: MutableRefObject<LocalAcpChatBinding | null>;
+  /**
+   * True while a Local ACP turn is streaming. Mid-turn History checkpoints
+   * persist in-flight tools; without this flag, reload would poison them to
+   * "Interrupted — stream disconnected…" (ACP has no activeStreamId).
+   */
+  localAcpBusyRef: MutableRefObject<boolean>;
 }
 
 /**
@@ -167,6 +173,7 @@ export function useChatSessionLoader({
   loadPersistedMessagesRef,
   requestResumeRef,
   localAcpBindingRef,
+  localAcpBusyRef,
 }: UseChatSessionLoaderArgs): void {
   // Fetch the persisted chat and swap it into the hook state. Shared by the
   // history-load effect below and the resume manager's reload-before-replay
@@ -244,7 +251,10 @@ export function useChatSessionLoader({
       // persisted the poison over the server's correct finalization.
       const convertedMessages = convertStoredMessages(
         data.messages as unknown[],
-        { turnActive: Boolean(data.activeStreamId) },
+        {
+          turnActive:
+            Boolean(data.activeStreamId) || Boolean(localAcpBusyRef.current),
+        },
       );
 
       // Restored tool parts must not re-trigger the in-band console

--- a/app/src/lib/acp-app-focus.test.ts
+++ b/app/src/lib/acp-app-focus.test.ts
@@ -95,6 +95,22 @@ describe("acp-app-focus", () => {
     expect(focusAppTab).not.toHaveBeenCalled();
   });
 
+  it("does not rebuild preview on get_app_state (avoids black flash)", async () => {
+    mockOpenApps = { app1: { _id: "app1" } };
+    const scheduled = maybeFocusAppFromAcpTool("ws1", {
+      status: "completed",
+      name: "mcp__mako-workspace__get_app_state",
+      rawInput: { appId: "app1" },
+      rawOutput: { success: true, appId: "app1" },
+    });
+    expect(scheduled).toBe(true);
+    await vi.waitFor(() => {
+      expect(fetchApp).toHaveBeenCalled();
+    });
+    expect(bumpPreview).not.toHaveBeenCalled();
+    expect(focusAppTab).not.toHaveBeenCalled();
+  });
+
   it("ignores unrelated tools", () => {
     expect(
       maybeFocusAppFromAcpTool("ws1", {

--- a/app/src/lib/acp-app-focus.ts
+++ b/app/src/lib/acp-app-focus.ts
@@ -22,7 +22,27 @@ export const ACP_APP_FOCUS_TOOLS = new Set([
   "app_delete_data_binding",
   "create_preview_token",
   "render_app",
+  // Read-only inspect — open the tab if needed, but do NOT rebuild the iframe
+  // (bumpPreview). Rebuilding flashes a black “Building preview…” screen and
+  // can remount Chat mid-tool (get_preview_errors then looks Interrupted).
   "get_app_state",
+]);
+
+/** Mutations / explicit preview that need an iframe srcdoc rebuild. */
+const ACP_APP_BUMP_PREVIEW_TOOLS = new Set([
+  "create_app",
+  "open_app",
+  "app_write_file",
+  "app_edit_file",
+  "app_delete_file",
+  "app_rename_file",
+  "app_add_dependency",
+  "app_remove_dependency",
+  "app_create_data_binding",
+  "app_update_data_binding",
+  "app_delete_data_binding",
+  "create_preview_token",
+  "render_app",
 ]);
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -83,6 +103,8 @@ export function maybeFocusAppFromAcpTool(
     toolName === "create_preview_token" ||
     toolName === "render_app";
 
+  const shouldBump = ACP_APP_BUMP_PREVIEW_TOOLS.has(toolName);
+
   void useAppStore
     .getState()
     .fetchApp(workspaceId, appId)
@@ -91,7 +113,12 @@ export function maybeFocusAppFromAcpTool(
         if (shouldFocus) {
           focusAppTab(appId, app?.title || title || "App");
         }
-        useAppStore.getState().bumpPreview(appId);
+        // Only rebuild the sandboxed iframe when files/bindings changed.
+        // Read tools (get_app_state) used to bump every time → black flash +
+        // Chat remount → mid-flight mako-desktop tools marked Interrupted.
+        if (shouldBump) {
+          useAppStore.getState().bumpPreview(appId);
+        }
         void useAppStore.getState().fetchList(workspaceId);
       } catch {
         // Preview/tab focus must never surface as an unhandled rejection —

--- a/app/src/lib/desktop-acp-bridge.ts
+++ b/app/src/lib/desktop-acp-bridge.ts
@@ -62,6 +62,8 @@ async function executeImmediateJob(job: BridgeJob): Promise<unknown> {
   }
 
   if (job.tool === "get_preview_errors") {
+    // Read-only — never bumpPreview / rebuild the iframe (that blacks out
+    // the app preview and can remount Chat mid-turn).
     const errors = useAppStore.getState().previewErrors[appId] ?? [];
     return {
       success: true,
@@ -70,7 +72,11 @@ async function executeImmediateJob(job: BridgeJob): Promise<unknown> {
     };
   }
 
-  return executeAppAgentTool("run_app", { appId });
+  if (job.tool === "run_app") {
+    return executeAppAgentTool("run_app", { appId });
+  }
+
+  throw new Error(`Unsupported desktop bridge tool: ${job.tool}`);
 }
 
 export async function completeDesktopHitlJob(

--- a/app/src/lib/local-acp-parts.test.ts
+++ b/app/src/lib/local-acp-parts.test.ts
@@ -148,6 +148,23 @@ describe("local-acp-parts", () => {
         state: "streaming",
       },
     ]);
+    // Claude summarized titles arrive without separators — don't mash them.
+    parts = appendAssistantReasoning(
+      [{ type: "reasoning", text: "", state: "streaming" }],
+      "**Inspecting available tools**",
+    );
+    parts = appendAssistantReasoning(
+      parts,
+      "I'll review the current app's structure.",
+    );
+    parts = appendAssistantReasoning(
+      parts,
+      "**Identifying precise call names**",
+    );
+    expect(parts[0]).toMatchObject({
+      type: "reasoning",
+      text: "**Inspecting available tools**\n\nI'll review the current app's structure.\n\n**Identifying precise call names**",
+    });
     parts = upsertAcpToolPart(parts, {
       toolCallId: "t3",
       name: "sql_execute_query",

--- a/app/src/lib/local-acp-parts.ts
+++ b/app/src/lib/local-acp-parts.ts
@@ -338,11 +338,31 @@ export function appendAssistantText(
 }
 
 /**
+ * Claude `thinking.display: "summarized"` streams short title + prose chunks
+ * without separators (`**Inspecting…**` then `I'll review…`). Naive concat
+ * produces `**tools**I'll`. Insert a break / space at the boundary.
+ */
+export function joinReasoningChunks(prev: string, chunk: string): string {
+  if (!prev) return chunk;
+  if (!chunk) return prev;
+  if (/\s$/.test(prev) || /^\s/.test(chunk)) return prev + chunk;
+  // New summarized heading, or previous chunk ended on a markdown heading.
+  if (/^\*\*/.test(chunk) || /\*\*[^*\n]+\*\*$/.test(prev.trimEnd())) {
+    return `${prev}\n\n${chunk}`;
+  }
+  return `${prev} ${chunk}`;
+}
+
+/**
  * Append ACP `agent_thought_chunk` text as UIMessage `reasoning` parts so Chat
  * renders the same Thinking/ReasoningDisplay blocks as the in-app agent.
  * Extends the trailing reasoning part; starts a new block after tools/text.
  * Stamps `state: "streaming"` so Chat's streaming-reasoning heuristic expands
  * the block live (same as cloud AI SDK parts).
+ *
+ * Note: Claude ACP only exposes Anthropic's summarized thinking (titles +
+ * short blurbs), not full extended-thinking traces — `display: "omitted"` is
+ * empty; there is no "full" display mode on Opus 4.7+.
  */
 export function appendAssistantReasoning(
   parts: AssistantPart[],
@@ -364,7 +384,7 @@ export function appendAssistantReasoning(
     const copy = parts.slice();
     copy[copy.length - 1] = {
       type: "reasoning",
-      text: `${(last as ReasoningPart).text}${chunk}`,
+      text: joinReasoningChunks((last as ReasoningPart).text, chunk),
       state: "streaming",
     };
     return copy;

--- a/packages/local-agent/src/acp/permissions.test.ts
+++ b/packages/local-agent/src/acp/permissions.test.ts
@@ -20,6 +20,37 @@ describe("ACP permission auto-approve", () => {
     assert.equal(isMakoMcpToolName("Bash"), false);
   });
 
+  it("detects Codex dotted MCP titles for mako workspace/desktop", () => {
+    assert.equal(
+      isMakoMcpToolName("mcp.mako-desktop.get_preview_errors"),
+      true,
+    );
+    assert.equal(
+      isMakoMcpToolName("mcp.mako-workspace.get_relevant_skills"),
+      true,
+    );
+    assert.equal(
+      isMakoMcpToolName("Mcp.Mako-Workspace.Sql Execute Query"),
+      true,
+    );
+    assert.equal(isMakoMcpToolName("mcp.slack.post_message"), false);
+  });
+
+  it("auto-approves Codex mako-desktop execute tools", () => {
+    const decision = shouldAutoApprovePermission({
+      toolCall: {
+        title: "mcp.mako-desktop.get_preview_errors",
+        kind: "execute",
+        _meta: { is_mcp_tool_call: true },
+      },
+      options: [
+        { optionId: "allow-once", kind: "allow_once" },
+        { optionId: "reject-once", kind: "reject_once" },
+      ],
+    });
+    assert.deepEqual(decision, { optionId: "allow-once" });
+  });
+
   it("prefers allow_always over allow_once", () => {
     assert.equal(
       pickAllowOptionId([

--- a/packages/local-agent/src/acp/permissions.ts
+++ b/packages/local-agent/src/acp/permissions.ts
@@ -31,19 +31,32 @@ export function extractToolCallKind(toolCall: unknown): string {
   return typeof kind === "string" ? kind : "";
 }
 
-/** Claude Agent SDK names MCP tools `mcp__{server}__{tool}`. */
+/**
+ * True for Mako workspace / desktop MCP tools under either naming scheme:
+ * - Claude Agent SDK: `mcp__mako-workspace__list_connections`
+ * - Codex ACP titles: `mcp.mako-desktop.get_preview_errors` /
+ *   `Mcp.Mako-Workspace.Sql Execute Query`
+ *
+ * Codex marks these `kind: "execute"`, so without this match they sit in
+ * request_permission forever (black / stuck Chat) while Claude's `mcp__*`
+ * names auto-approve.
+ */
 export function isMakoMcpToolName(name: string): boolean {
   if (!name) return false;
-  const lower = name.toLowerCase();
-  return (
-    lower.startsWith("mcp__mako-workspace__") ||
-    lower === "mcp__mako-workspace" ||
-    lower.startsWith("mcp__mako-desktop__") ||
-    lower === "mcp__mako-desktop" ||
+  const lower = name.trim().toLowerCase();
+  if (
+    lower.startsWith("mcp__mako-workspace") ||
+    lower.startsWith("mcp__mako-desktop") ||
     lower.startsWith("mcp__mako__") ||
-    lower === "mcp__mako" ||
-    /\bmcp__mako(-workspace|-desktop)?\b/i.test(name)
-  );
+    lower === "mcp__mako"
+  ) {
+    return true;
+  }
+  // Codex dotted / Title Case forms (server segment may include hyphens).
+  if (/^mcp\.mako(-workspace|-desktop)?(\.|$)/.test(lower)) {
+    return true;
+  }
+  return /\bmcp__mako(-workspace|-desktop)?\b/i.test(name);
 }
 
 /** Safe to auto-approve without a human click (reads / search / think). */


### PR DESCRIPTION
## Summary
- Auto-approve Codex ACP MCP titles (`mcp.mako-desktop.get_preview_errors`, `Mcp.Mako-Workspace.*`) the same way as Claude’s `mcp__*` names — Codex was hanging on `kind: execute` permission prompts (black / stuck preview).
- Skip iframe `bumpPreview` on read-only app tools (`get_app_state`) so Chat doesn’t remount mid-tool.
- Keep mid-turn ACP tool cards pending while `localAcpBusy` (no false “Interrupted — stream disconnected…”).
- `get_preview_errors` stays read-only; preview boot overlay clears after 20s if the iframe never reports ready.
- Thinking chunk join: don’t mash Claude summarized titles into adjacent prose.

Follow-up to #739 (squash merge missed these post-merge polish commits).

## Test plan
- [ ] Codex Terra: Enable workspace tools → ask to improve an open app → `get_preview_errors` completes without Allow/Deny hang or black preview
- [ ] Claude Code local: same flow still works (no regression)
- [ ] Mid-turn remount/refresh during ACP tools does not mark in-flight tools Interrupted
- [ ] `get_app_state` does not flash “Building preview…”


Made with [Cursor](https://cursor.com)