### PR TITLE
docs: surface Coding Agents (ACP) page in sidebar + cross-links

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -53,6 +53,7 @@ export default defineConfig({
             { label: "Skills", slug: "skills" },
             { label: "MCP Connectors", slug: "mcp-connectors" },
             { label: "MCP Server (AI Agents)", slug: "mcp-server" },
+            { label: "Coding Agents (ACP)", slug: "coding-agents-acp" },
             { label: "Notifications", slug: "notifications" },
             { label: "Mako Desktop", slug: "desktop" },
           ],

--- a/docs/src/content/docs/ai-agent.md
+++ b/docs/src/content/docs/ai-agent.md
@@ -182,6 +182,8 @@ Mako routes all AI requests through the **Vercel AI Gateway**, which provides ac
 
 Models are discovered dynamically at runtime by merging the Gateway model catalog with [arena.ai](https://arena.ai) code leaderboard ELO scores. The catalog refreshes hourly.
 
+On **Mako Desktop**, the model dropdown also shows an **On this machine** group — Claude Code and Codex running locally via ACP on your own subscription. See [Coding Agents (ACP)](/coding-agents-acp/).
+
 ### Free vs Pro Models
 
 When billing is enabled, models are split into two tiers:

--- a/docs/src/content/docs/desktop.md
+++ b/docs/src/content/docs/desktop.md
@@ -31,6 +31,8 @@ How it behaves:
 - **Identical behavior** — the agent reuses the exact same database drivers as the cloud API, so query execution, preview safety checks, schema trees, and autocomplete work identically. All connection types are supported locally, including PostgreSQL, MySQL, MongoDB, ClickHouse, Redshift, BigQuery, Cloud SQL, and Cloudflare D1/KV.
 - **Loopback only** — the agent listens on `127.0.0.1` exclusively and allows requests only from Mako origins. It is never reachable from the network.
 
+Beyond local databases, the bundled agent also hosts the **ACP bridge** for [Coding Agents](/coding-agents-acp/) — running Claude Code or Codex inside Mako Chat on your own subscription.
+
 Using the **web app** instead of the desktop app? You can still query local databases by running the agent standalone — see [`packages/local-agent`](https://github.com/mako-ai/mako/tree/master/packages/local-agent) for details. Your browser will ask once for permission to reach the local agent (Chromium's Local Network Access prompt).
 
 ## Troubleshooting


### PR DESCRIPTION
## What

#739 (Local Agent ACP + Chat dropdown) shipped with a complete docs page — `docs/src/content/docs/coding-agents-acp.md` — but never added it to the Starlight sidebar in `astro.config.mjs`. The page is currently unreachable except through a single cross-link in mcp-server.md.

## Changes

- **astro.config.mjs** — add `Coding Agents (ACP)` to Core Features, directly after MCP Server (its natural counterpart)
- **desktop.md** — one line noting the bundled Local Agent also hosts the ACP bridge, with link
- **ai-agent.md** — mention the **On this machine** model dropdown group on Desktop (local Claude Code / Codex via ACP), in the AI Models section

## Verified against

- `docs/src/content/docs/coding-agents-acp.md` exists on master (added in #739)
- Sidebar slugs cross-checked against `docs/src/content/docs/` contents
- #747 (Codex auto-approve fix) needs no doc change — the ACP page already describes auto-approve behavior generically

Part of daily docs maintenance.