### PR TITLE
fix(desktop): recover from renderer and ACP failures

### DIFF
--- a/app/src/components/AppErrorBoundary.test.tsx
+++ b/app/src/components/AppErrorBoundary.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AppErrorBoundary } from "./AppErrorBoundary";
+
+function BrokenChild(): React.ReactNode {
+  throw new Error("tool card exploded");
+}
+
+describe("AppErrorBoundary", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("shows a recoverable screen when the React root throws", () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    render(
+      <AppErrorBoundary>
+        <BrokenChild />
+      </AppErrorBoundary>,
+    );
+
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Mako hit a display error",
+    );
+    expect(screen.getByText("tool card exploded")).toBeTruthy();
+  });
+
+  it("reloads on request", () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const onReload = vi.fn();
+
+    render(
+      <AppErrorBoundary onReload={onReload}>
+        <BrokenChild />
+      </AppErrorBoundary>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Reload Mako" }));
+
+    expect(onReload).toHaveBeenCalledOnce();
+  });
+});

--- a/app/src/components/AppErrorBoundary.tsx
+++ b/app/src/components/AppErrorBoundary.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+
+interface AppErrorBoundaryProps {
+  children: React.ReactNode;
+  onReload?: () => void;
+}
+
+interface AppErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * Last-resort renderer boundary. Without this, an uncaught React render error
+ * unmounts the root and leaves Electron showing only its dark window
+ * background.
+ */
+export class AppErrorBoundary extends React.Component<
+  AppErrorBoundaryProps,
+  AppErrorBoundaryState
+> {
+  state: AppErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): AppErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    console.error("[mako-renderer-error]", error, info.componentStack);
+  }
+
+  private reload = (): void => {
+    if (this.props.onReload) {
+      this.props.onReload();
+      return;
+    }
+    window.location.reload();
+  };
+
+  render(): React.ReactNode {
+    if (!this.state.error) return this.props.children;
+
+    return (
+      <main
+        role="alert"
+        style={{
+          alignItems: "center",
+          background: "#111418",
+          color: "#f5f7f8",
+          display: "flex",
+          flexDirection: "column",
+          gap: 16,
+          height: "100vh",
+          justifyContent: "center",
+          padding: 32,
+          textAlign: "center",
+        }}
+      >
+        <h1 style={{ fontSize: 20, margin: 0 }}>Mako hit a display error</h1>
+        <p style={{ color: "#aeb7be", margin: 0, maxWidth: 520 }}>
+          Your work is still saved. Reload the window to reconnect and continue.
+        </p>
+        <pre
+          style={{
+            background: "#1a1f23",
+            border: "1px solid #30383e",
+            borderRadius: 6,
+            color: "#e4e8eb",
+            margin: 0,
+            maxWidth: 720,
+            overflow: "auto",
+            padding: 12,
+            textAlign: "left",
+            whiteSpace: "pre-wrap",
+          }}
+        >
+          {this.state.error.message || "Unknown renderer error"}
+        </pre>
+        <button
+          type="button"
+          onClick={this.reload}
+          style={{
+            background: "#1976d2",
+            border: 0,
+            borderRadius: 6,
+            color: "#fff",
+            cursor: "pointer",
+            font: "inherit",
+            padding: "9px 16px",
+          }}
+        >
+          Reload Mako
+        </button>
+      </main>
+    );
+  }
+}

--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -106,6 +106,7 @@ import { useQueuedPrompts } from "./chat/hooks/useQueuedPrompts";
 import { useChatScroll } from "./chat/hooks/useChatScroll";
 import { useNotebookAutoOpen } from "./chat/hooks/useNotebookAutoOpen";
 import { ChatMessageRow, MessageVirtuosoList } from "./chat/ChatMessageRow";
+import { ChatMessageErrorBoundary } from "./chat/ChatMessageErrorBoundary";
 import { QueuedPromptList } from "./chat/QueuedPrompts";
 import { ChatInputArea } from "./chat/ChatInputArea";
 import { AcpPermissionBanner } from "./AcpPermissionBanner";
@@ -1422,17 +1423,22 @@ const Chat: React.FC<ChatProps> = ({
             components={messageVirtuosoComponents}
             style={{ flex: 1 }}
             itemContent={(msgIdx, message) => (
-              <ChatMessageRow
-                message={message}
-                isLastMessage={msgIdx === messages.length - 1}
-                isStreaming={status === "streaming" || localAcpBusy}
-                collapseEmptyReasoningWhileStreaming={localAcpBusy}
-                onToolClick={handleToolClick}
-                onConsoleTitleClick={handleConsoleTitleClick}
-                onMcpApprovalResponse={handleMcpApprovalResponse}
-                connectionIconById={connectionIconById}
-                paletteMode={paletteMode}
-              />
+              <ChatMessageErrorBoundary
+                messageId={message.id}
+                messageRevision={message}
+              >
+                <ChatMessageRow
+                  message={message}
+                  isLastMessage={msgIdx === messages.length - 1}
+                  isStreaming={status === "streaming" || localAcpBusy}
+                  collapseEmptyReasoningWhileStreaming={localAcpBusy}
+                  onToolClick={handleToolClick}
+                  onConsoleTitleClick={handleConsoleTitleClick}
+                  onMcpApprovalResponse={handleMcpApprovalResponse}
+                  connectionIconById={connectionIconById}
+                  paletteMode={paletteMode}
+                />
+              </ChatMessageErrorBoundary>
             )}
           />
         </React.Profiler>

--- a/app/src/components/chat/ChatMessageErrorBoundary.test.tsx
+++ b/app/src/components/chat/ChatMessageErrorBoundary.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ChatMessageErrorBoundary } from "./ChatMessageErrorBoundary";
+
+function BrokenMessage(): React.ReactNode {
+  throw new Error("invalid tool payload");
+}
+
+describe("ChatMessageErrorBoundary", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("isolates a broken message from its siblings", () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    render(
+      <>
+        <div>Earlier message remains visible</div>
+        <ChatMessageErrorBoundary
+          messageId="message-1"
+          messageRevision="revision-1"
+        >
+          <BrokenMessage />
+        </ChatMessageErrorBoundary>
+      </>,
+    );
+
+    expect(screen.getByText("Earlier message remains visible")).toBeTruthy();
+    expect(screen.getByRole("alert").textContent).toContain(
+      "The rest of the chat is still running",
+    );
+  });
+
+  it("resets when the virtualized row receives another message", () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const view = render(
+      <ChatMessageErrorBoundary
+        messageId="message-1"
+        messageRevision="revision-1"
+      >
+        <BrokenMessage />
+      </ChatMessageErrorBoundary>,
+    );
+
+    view.rerender(
+      <ChatMessageErrorBoundary
+        messageId="message-2"
+        messageRevision="revision-1"
+      >
+        <div>Replacement message</div>
+      </ChatMessageErrorBoundary>,
+    );
+
+    expect(screen.getByText("Replacement message")).toBeTruthy();
+  });
+
+  it("retries a streamed message when its content advances", () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const view = render(
+      <ChatMessageErrorBoundary
+        messageId="message-1"
+        messageRevision="revision-1"
+      >
+        <BrokenMessage />
+      </ChatMessageErrorBoundary>,
+    );
+
+    view.rerender(
+      <ChatMessageErrorBoundary
+        messageId="message-1"
+        messageRevision="revision-2"
+      >
+        <div>Completed tool result</div>
+      </ChatMessageErrorBoundary>,
+    );
+
+    expect(screen.getByText("Completed tool result")).toBeTruthy();
+  });
+});

--- a/app/src/components/chat/ChatMessageErrorBoundary.tsx
+++ b/app/src/components/chat/ChatMessageErrorBoundary.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+
+interface ChatMessageErrorBoundaryProps {
+  children: React.ReactNode;
+  messageId: string;
+  messageRevision: unknown;
+}
+
+interface ChatMessageErrorBoundaryState {
+  failed: boolean;
+}
+
+/**
+ * Keeps one malformed or unsupported streamed message from tearing down Chat
+ * and its ACP event subscription.
+ */
+export class ChatMessageErrorBoundary extends React.Component<
+  ChatMessageErrorBoundaryProps,
+  ChatMessageErrorBoundaryState
+> {
+  state: ChatMessageErrorBoundaryState = { failed: false };
+
+  static getDerivedStateFromError(): ChatMessageErrorBoundaryState {
+    return { failed: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    console.error(
+      "[mako-chat-message-render-error]",
+      this.props.messageId,
+      error,
+      info.componentStack,
+    );
+  }
+
+  componentDidUpdate(previousProps: ChatMessageErrorBoundaryProps): void {
+    if (
+      this.state.failed &&
+      (previousProps.messageId !== this.props.messageId ||
+        previousProps.messageRevision !== this.props.messageRevision)
+    ) {
+      this.setState({ failed: false });
+    }
+  }
+
+  render(): React.ReactNode {
+    if (!this.state.failed) return this.props.children;
+
+    return (
+      <div
+        role="alert"
+        style={{
+          border: "1px solid rgba(211, 47, 47, 0.45)",
+          borderRadius: 6,
+          color: "#d32f2f",
+          margin: "8px 16px",
+          padding: "10px 12px",
+        }}
+      >
+        This message could not be displayed. The rest of the chat is still
+        running.
+      </div>
+    );
+  }
+}

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -6,6 +6,7 @@ import CssBaseline from "@mui/material/CssBaseline";
 import { LicenseInfo } from "@mui/x-license";
 import { enableMapSet } from "immer";
 import App from "./App.tsx";
+import { AppErrorBoundary } from "./components/AppErrorBoundary";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import { AuthProvider } from "./contexts/auth-context.tsx";
 import { initializeStoreVersion } from "./store/lib/storeVersion";
@@ -37,13 +38,15 @@ if (!rootElement) throw new Error("Root element not found");
 
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <ThemeProvider>
-        <CssBaseline />
-        <AuthProvider>
-          <App />
-        </AuthProvider>
-      </ThemeProvider>
-    </BrowserRouter>
+    <AppErrorBoundary>
+      <BrowserRouter>
+        <ThemeProvider>
+          <CssBaseline />
+          <AuthProvider>
+            <App />
+          </AuthProvider>
+        </ThemeProvider>
+      </BrowserRouter>
+    </AppErrorBoundary>
   </React.StrictMode>,
 );

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -15,6 +15,7 @@
 import { app, BrowserWindow, dialog, ipcMain, shell } from "electron";
 import { autoUpdater } from "electron-updater";
 import { execFile, spawn, ChildProcess } from "child_process";
+import * as fs from "fs";
 import * as http from "http";
 import * as os from "os";
 import * as path from "path";
@@ -38,6 +39,25 @@ const UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
 
 let mainWindow: BrowserWindow | null = null;
 let agentProcess: ChildProcess | null = null;
+let lastRendererRecoveryAt = 0;
+let rendererRecoveryTimer: ReturnType<typeof setTimeout> | null = null;
+
+function recordRendererFailure(
+  event: string,
+  details: Record<string, unknown> = {},
+): void {
+  try {
+    const logsDirectory = app.getPath("logs");
+    fs.mkdirSync(logsDirectory, { recursive: true });
+    fs.appendFileSync(
+      path.join(logsDirectory, "renderer-failures.log"),
+      `${JSON.stringify({ at: new Date().toISOString(), event, ...details })}\n`,
+      "utf8",
+    );
+  } catch {
+    // Diagnostics must never make a renderer failure worse.
+  }
+}
 
 // ── Browser-based sign-in (deep-link handoff) ────────────────────────────────
 // Third-party logins (Google/GitHub) never render inside this window: the
@@ -419,6 +439,28 @@ function createWindow(): void {
       event.preventDefault();
       startBrowserAuth();
     }
+  });
+
+  mainWindow.webContents.on("unresponsive", () => {
+    recordRendererFailure("unresponsive");
+  });
+
+  mainWindow.webContents.on("render-process-gone", (_event, details) => {
+    recordRendererFailure("render-process-gone", {
+      reason: details.reason,
+      exitCode: details.exitCode,
+    });
+    if (details.reason === "clean-exit") return;
+
+    if (rendererRecoveryTimer) return;
+    const now = Date.now();
+    const recoveryDelay = now - lastRendererRecoveryAt < 60_000 ? 5000 : 500;
+    lastRendererRecoveryAt = now;
+    rendererRecoveryTimer = setTimeout(() => {
+      rendererRecoveryTimer = null;
+      if (!mainWindow || mainWindow.isDestroyed()) return;
+      mainWindow.webContents.reload();
+    }, recoveryDelay);
   });
 
   mainWindow.on("closed", () => {

--- a/packages/local-agent/package.json
+++ b/packages/local-agent/package.json
@@ -12,7 +12,7 @@
     "start": "tsx src/index.ts",
     "build": "node build.mjs",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test src/acp/manager.test.ts src/acp/permissions.test.ts src/acp/mcp-probe.test.ts src/acp/mako-system-append.test.ts src/acp/connection-errors.test.ts src/acp/terminal-auth.test.ts src/acp/codex-models.test.ts src/acp/codex-login-status.test.ts src/acp/ensure-adapter.test.ts src/acp/session-config.test.ts src/acp/prompt-guidance.test.ts src/desktop-bridge/mcp.test.ts",
+    "test": "tsx --test src/acp/manager.test.ts src/acp/permissions.test.ts src/acp/mcp-probe.test.ts src/acp/mako-system-append.test.ts src/acp/connection-errors.test.ts src/acp/connection.test.ts src/acp/terminal-auth.test.ts src/acp/codex-models.test.ts src/acp/codex-login-status.test.ts src/acp/ensure-adapter.test.ts src/acp/session-config.test.ts src/acp/prompt-guidance.test.ts src/desktop-bridge/mcp.test.ts",
     "acp:mock-agent": "tsx src/acp/mock-agent.ts"
   },
   "dependencies": {

--- a/packages/local-agent/src/acp/connection.test.ts
+++ b/packages/local-agent/src/acp/connection.test.ts
@@ -1,0 +1,32 @@
+import { spawn } from "node:child_process";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { terminateAdapterProcess } from "./connection";
+
+test(
+  "terminateAdapterProcess escalates when an adapter ignores SIGTERM",
+  { skip: process.platform === "win32", timeout: 5000 },
+  async () => {
+    const child = spawn(
+      process.execPath,
+      [
+        "-e",
+        [
+          'process.on("SIGTERM", () => {});',
+          'process.stdout.write("ready\\n");',
+          "setInterval(() => {}, 1000);",
+        ].join(""),
+      ],
+      { stdio: ["ignore", "pipe", "ignore"] },
+    );
+
+    await new Promise<void>((resolve, reject) => {
+      child.once("error", reject);
+      child.stdout?.once("data", () => resolve());
+    });
+
+    await terminateAdapterProcess(child, 20);
+
+    assert.equal(child.signalCode, "SIGKILL");
+  },
+);

--- a/packages/local-agent/src/acp/connection.ts
+++ b/packages/local-agent/src/acp/connection.ts
@@ -65,7 +65,52 @@ export interface AcpProviderConnection {
   authenticated: boolean;
   /** Rolling stderr from the adapter process (for UI diagnostics). */
   lastStderr: string;
-  close: () => void;
+  close: () => Promise<void>;
+}
+
+function isChildRunning(child: ChildProcess): boolean {
+  return child.exitCode === null && child.signalCode === null;
+}
+
+/**
+ * Ask an adapter to exit, then force it down if it ignores SIGTERM. Do not use
+ * `child.killed` here: Node sets that flag when a signal is sent, not when the
+ * process has actually exited.
+ */
+export function terminateAdapterProcess(
+  child: ChildProcess,
+  gracePeriodMs = 2000,
+): Promise<void> {
+  if (!isChildRunning(child)) return Promise.resolve();
+
+  return new Promise(resolve => {
+    let forceTimer: ReturnType<typeof setTimeout> | undefined;
+    child.once("exit", () => {
+      if (forceTimer) clearTimeout(forceTimer);
+      resolve();
+    });
+
+    try {
+      child.kill("SIGTERM");
+    } catch {
+      resolve();
+      return;
+    }
+
+    forceTimer = setTimeout(() => {
+      if (!isChildRunning(child)) {
+        resolve();
+        return;
+      }
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // Process exited between the running check and the signal.
+        resolve();
+      }
+    }, gracePeriodMs);
+    forceTimer.unref?.();
+  });
 }
 
 function nodeToWebStreams(child: ChildProcess): {
@@ -251,7 +296,7 @@ export async function openProviderConnection(options: {
     } catch {
       // ignore
     }
-    if (!child.killed) child.kill("SIGTERM");
+    await terminateAdapterProcess(child);
     throw new Error(`${base}${detail ? `.${detail}` : ""}`.trim());
   }
 
@@ -295,18 +340,13 @@ export async function openProviderConnection(options: {
     authRequired: authMethods.length > 0,
     authenticated: authMethods.length === 0,
     lastStderr,
-    close: () => {
+    close: async () => {
       try {
         connection.close?.();
       } catch {
         // ignore
       }
-      if (!child.killed) {
-        child.kill("SIGTERM");
-        setTimeout(() => {
-          if (!child.killed) child.kill("SIGKILL");
-        }, 2000).unref?.();
-      }
+      await terminateAdapterProcess(child);
     },
   };
   return connectionHolder;

--- a/packages/local-agent/src/acp/manager.ts
+++ b/packages/local-agent/src/acp/manager.ts
@@ -140,6 +140,11 @@ function normalizeBearerAuth(value: string): string {
 
 export class AcpSessionManager {
   private connections = new Map<AcpProviderId, AcpProviderConnection>();
+  private connectionInFlight = new Map<
+    AcpProviderId,
+    Promise<AcpProviderConnection>
+  >();
+  private shuttingDown = false;
   private sessions = new Map<string, ManagedSession>();
   private pendingPermissions = new Map<string, PendingPermission>();
   /** Global listeners (all sessions) — used by tests. */
@@ -532,11 +537,7 @@ export class AcpSessionManager {
         : `${acpReconnectMessage(label)} (${reason})`;
     if (conn) {
       this.connections.delete(providerId);
-      try {
-        conn.close();
-      } catch {
-        // already dead
-      }
+      void conn.close().catch(() => undefined);
     }
 
     const deadSessionIds: string[] = [];
@@ -577,6 +578,30 @@ export class AcpSessionManager {
   }
 
   private async ensureConnection(
+    providerId: AcpProviderId,
+  ): Promise<AcpProviderConnection> {
+    if (this.shuttingDown) {
+      throw new Error("ACP session manager is shutting down");
+    }
+
+    const existing = this.connections.get(providerId);
+    if (existing && isConnectionAlive(existing)) {
+      return existing;
+    }
+
+    const inFlight = this.connectionInFlight.get(providerId);
+    if (inFlight) return inFlight;
+
+    const pending = this.openConnection(providerId).finally(() => {
+      if (this.connectionInFlight.get(providerId) === pending) {
+        this.connectionInFlight.delete(providerId);
+      }
+    });
+    this.connectionInFlight.set(providerId, pending);
+    return pending;
+  }
+
+  private async openConnection(
     providerId: AcpProviderId,
   ): Promise<AcpProviderConnection> {
     const existing = this.connections.get(providerId);
@@ -1516,6 +1541,7 @@ export class AcpSessionManager {
   }
 
   async shutdown(): Promise<void> {
+    this.shuttingDown = true;
     const warms = [...this.modelWarmInFlight.values()];
     if (warms.length > 0) {
       await Promise.race([
@@ -1525,13 +1551,18 @@ export class AcpSessionManager {
         }),
       ]);
     }
+    const connectionStarts = [...this.connectionInFlight.values()];
+    if (connectionStarts.length > 0) {
+      await Promise.allSettled(connectionStarts);
+    }
     await Promise.allSettled(
       [...this.sessions.keys()].map(id => this.closeSession(id)),
     );
-    for (const conn of this.connections.values()) {
-      conn.close();
-    }
+    await Promise.allSettled(
+      [...this.connections.values()].map(conn => conn.close()),
+    );
     this.connections.clear();
+    this.connectionInFlight.clear();
   }
 }
 

--- a/packages/local-agent/src/index.ts
+++ b/packages/local-agent/src/index.ts
@@ -9,11 +9,23 @@ const agent = startAgent();
 
 let shuttingDown = false;
 
+/**
+ * `agent.close()` awaits `server.close()`, which never settles while an ACP
+ * SSE stream (`/acp/sessions/:id/events`) is still connected — so cap the
+ * graceful drain to keep SIGTERM guaranteed to exit.
+ */
+const SHUTDOWN_TIMEOUT_MS = 5000;
+
 async function shutdown(): Promise<void> {
   if (shuttingDown) return;
   shuttingDown = true;
   try {
-    await agent.close();
+    await Promise.race([
+      agent.close(),
+      new Promise<void>(resolve => {
+        setTimeout(resolve, SHUTDOWN_TIMEOUT_MS).unref?.();
+      }),
+    ]);
     process.exit(0);
   } catch {
     process.exit(1);

--- a/packages/local-agent/src/index.ts
+++ b/packages/local-agent/src/index.ts
@@ -7,10 +7,18 @@ import { startAgent } from "./server";
 
 const agent = startAgent();
 
-function shutdown() {
-  agent.close();
-  process.exit(0);
+let shuttingDown = false;
+
+async function shutdown(): Promise<void> {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  try {
+    await agent.close();
+    process.exit(0);
+  } catch {
+    process.exit(1);
+  }
 }
 
-process.on("SIGINT", shutdown);
-process.on("SIGTERM", shutdown);
+process.on("SIGINT", () => void shutdown());
+process.on("SIGTERM", () => void shutdown());

--- a/packages/local-agent/src/server.ts
+++ b/packages/local-agent/src/server.ts
@@ -493,7 +493,7 @@ export function createAgentApp(): Hono {
 
 export interface StartedAgent {
   port: number;
-  close: () => void;
+  close: () => Promise<void>;
 }
 
 export function startAgent(port?: number): StartedAgent {
@@ -517,9 +517,14 @@ export function startAgent(port?: number): StartedAgent {
 
   return {
     port: resolvedPort,
-    close: () => {
-      void acpSessionManager.shutdown();
-      server.close();
+    close: async () => {
+      await acpSessionManager.shutdown();
+      await new Promise<void>((resolve, reject) => {
+        server.close(error => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
     },
   };
 }


### PR DESCRIPTION
## Summary
- isolate malformed streamed chat messages and show a recoverable root fallback instead of a black window
- reload crashed Electron renderers and persist renderer failure diagnostics
- reliably terminate ACP adapters, deduplicate concurrent starts, and drain sessions/connections during shutdown

## Test plan
- [x] `pnpm --filter app run test:unit`
- [x] `pnpm --filter app run typecheck`
- [x] `pnpm --filter app run lint`
- [x] `pnpm --filter @mako/local-agent test`
- [x] `pnpm --filter @mako/local-agent typecheck`
- [x] `pnpm --filter @mako/local-agent build`
- [x] `pnpm --filter @mako/desktop typecheck`
- [x] `pnpm --filter @mako/desktop build`

Made with [Cursor](https://cursor.com)