### PR TITLE
feat(agent): unify dbt capabilities across Chat, MCP, and Desktop ACP

### DIFF
--- a/api/src/agent-lib/capabilities/runtime.ts
+++ b/api/src/agent-lib/capabilities/runtime.ts
@@ -1,0 +1,68 @@
+import {
+  DBT_CAPABILITY_BY_NAME,
+  type AgentSurface,
+  type CapabilityGrant,
+} from "@mako/agent-tools";
+
+import type { QueryAccess } from "../../auth/api-key-scopes";
+
+export interface AgentCapabilityAuthorizationContext {
+  surface: AgentSurface;
+  queryAccess: QueryAccess;
+  grants: ReadonlySet<CapabilityGrant>;
+}
+
+export interface AgentCapabilityDecision {
+  allowed: boolean;
+  reason?: string;
+}
+
+export function authorizeAgentCapability(
+  name: string,
+  context: AgentCapabilityAuthorizationContext,
+): AgentCapabilityDecision {
+  const capability = DBT_CAPABILITY_BY_NAME.get(name);
+  // The shared registry is being introduced domain-by-domain. Unregistered
+  // tools continue through their existing policy until migrated.
+  if (!capability) return { allowed: true };
+
+  if (!capability.surfaces.includes(context.surface)) {
+    return {
+      allowed: false,
+      reason: `${name} is not available on the ${context.surface} surface`,
+    };
+  }
+  if (capability.requiresAsyncMcp && context.surface !== "in-chat") {
+    return {
+      allowed: false,
+      reason: `${name} must use the async run lifecycle before MCP exposure`,
+    };
+  }
+  if (capability.requiresQueryAccess && context.queryAccess === "none") {
+    return {
+      allowed: false,
+      reason: `${name} requires query access`,
+    };
+  }
+  if (
+    capability.requiredGrant &&
+    !context.grants.has(capability.requiredGrant)
+  ) {
+    return {
+      allowed: false,
+      reason: `${name} requires an approved ${capability.requiredGrant} task grant`,
+    };
+  }
+  return { allowed: true };
+}
+
+export function filterAuthorizedCapabilities<T>(
+  tools: Record<string, T>,
+  context: AgentCapabilityAuthorizationContext,
+): Record<string, T> {
+  return Object.fromEntries(
+    Object.entries(tools).filter(
+      ([name]) => authorizeAgentCapability(name, context).allowed,
+    ),
+  );
+}

--- a/api/src/agent-lib/tools/dbt-tools.ts
+++ b/api/src/agent-lib/tools/dbt-tools.ts
@@ -42,10 +42,6 @@ import {
   getUserDisplayName,
 } from "../../services/entity-version.service";
 import {
-  loadDbtDeferState,
-  runAdhocDbtCommand,
-} from "../../dbt/dbt-project.service";
-import {
   ensurePersonalDbtEnvironment,
   findPersonalEnvironment,
   getUserDevEnvPreference,
@@ -354,6 +350,34 @@ export const createDbtServerTools = (
   ): boolean =>
     Boolean(project.lastProdManifestKey) &&
     environmentName !== resolveProdLikeEnvironmentName(project);
+
+  const queueAgentRun = async (
+    project: Awaited<ReturnType<typeof assertProject>>,
+    environment: string,
+    commands: string[],
+    deferToProduction = false,
+  ) => {
+    const run = await triggerDbtRun({
+      workspaceId,
+      projectId: project._id.toString(),
+      environment,
+      commands,
+      trigger: "agent",
+      triggeredBy: "agent",
+      workingTreeUserId: project.repo ? actingUserId : undefined,
+      deferToProduction,
+    });
+    publishRunUpdated(project._id.toString(), {
+      runId: run._id.toString(),
+    });
+    return {
+      success: true as const,
+      runId: run._id.toString(),
+      status: run.status,
+      environment: run.environment,
+      commands: run.commands,
+    };
+  };
 
   const deferField = z
     .boolean()
@@ -857,7 +881,8 @@ export const createDbtServerTools = (
       description:
         "Validate the entire dbt project (dbt parse): catches Jinja errors, " +
         "bad refs/sources, and schema.yml problems WITHOUT touching the " +
-        "warehouse. Run this after editing YAML or multiple files.",
+        "warehouse. Queues an asynchronous run and returns runId immediately; " +
+        "poll dbt_get_run for the result.",
       inputSchema: z.object({
         projectId: projectIdField,
         environment: z
@@ -871,20 +896,16 @@ export const createDbtServerTools = (
       execute: async ({ projectId, environment }) => {
         try {
           const project = await assertProject(projectId);
-          const result = await runAdhocDbtCommand({
-            workspaceId,
-            projectId,
-            environmentName: await resolveEnvironment(project, environment),
-            userId: actingUserId,
-            command: "parse",
-            timeoutMs: 2 * 60 * 1000,
-          });
+          const environmentName = await resolveEnvironment(
+            project,
+            environment,
+          );
+          const result = await queueAgentRun(project, environmentName, [
+            "parse",
+          ]);
           return {
-            success: result.success,
-            ...(result.success
-              ? { message: "Project parsed successfully" }
-              : { error: "dbt parse failed" }),
-            logs: summarizeLogs(result.logs),
+            ...result,
+            message: "Parse queued. Poll dbt_get_run with runId.",
           };
         } catch (error) {
           return toolError(error, "Failed to run dbt parse");
@@ -894,11 +915,11 @@ export const createDbtServerTools = (
 
     dbt_compile_model: tool({
       description:
-        "Compile dbt nodes (dbt compile --select <selector>) and return the " +
-        "rendered SQL for a single model, or the Jinja/compilation error. No " +
+        "Compile dbt nodes (dbt compile --select <selector>) and surface the " +
+        "Jinja/compilation result through dbt_get_run. No " +
         "warehouse writes. `model` accepts a node name (stg_orders) or a dbt " +
         "selector with graph operators/methods (+stg_orders, tag:nightly, " +
-        "path:models/staging). Use after writing or editing a model.",
+        "path:models/staging). Queues an asynchronous run and returns runId.",
       inputSchema: z.object({
         projectId: projectIdField,
         model: z
@@ -921,23 +942,16 @@ export const createDbtServerTools = (
           );
           const wantsDefer =
             defer ?? shouldDeferByDefault(project, environmentName);
-          const result = await runAdhocDbtCommand({
-            workspaceId,
-            projectId,
+          const result = await queueAgentRun(
+            project,
             environmentName,
-            userId: actingUserId,
-            command: `compile --select ${model}`,
-            select: model,
-            deferState: wantsDefer
-              ? await loadDbtDeferState(project)
-              : undefined,
-            timeoutMs: 3 * 60 * 1000,
-          });
+            [`compile --select ${model}`],
+            wantsDefer,
+          );
           return {
-            success: result.success,
-            environment: environmentName,
-            compiledSql: result.compiledSql,
-            logs: summarizeLogs(result.logs),
+            ...result,
+            defer: wantsDefer,
+            message: "Compile queued. Poll dbt_get_run with runId.",
           };
         } catch (error) {
           return toolError(error, "Failed to compile model");
@@ -1207,8 +1221,9 @@ export const createDbtServerTools = (
     dbt_get_run: tool({
       description:
         "Read the status, step results, and logs of a dbt run — use this " +
-        "AFTER dbt_run_model or dbt_run_job to see whether the run passed or " +
-        "failed (those only queue it). Pass `runId` for a specific run, or " +
+        "AFTER dbt_parse, dbt_compile_model, dbt_show, dbt_run_model, or " +
+        "dbt_run_job to see whether the run passed or failed (those only " +
+        "queue it). Pass `runId` for a specific run, or " +
         "`jobId` to get that job's most recent run. Pass `waitMs` to block " +
         "server-side until the run reaches a terminal status (success/error/" +
         "cancelled) or the wait elapses — call it ONCE with waitMs ~90000 " +
@@ -1297,6 +1312,7 @@ export const createDbtServerTools = (
             completedAt: run.completedAt,
             durationMs: run.durationMs,
             error: run.error,
+            output: run.output,
             stepResults: (run.stepResults ?? []).map(step => ({
               name: step.name,
               resourceType: step.resourceType,
@@ -1324,7 +1340,8 @@ export const createDbtServerTools = (
         "Preview the rows a model/selector would return (dbt show --select " +
         "<selector> --limit N) WITHOUT materializing it. Runs a bounded " +
         "SELECT against the environment; no warehouse writes. Use to validate " +
-        "that a transform produces the expected output.",
+        "that a transform produces the expected output. Queues an asynchronous " +
+        "run; poll dbt_get_run for the preview logs.",
       inputSchema: z.object({
         projectId: projectIdField,
         model: z
@@ -1352,46 +1369,16 @@ export const createDbtServerTools = (
           );
           const wantsDefer =
             defer ?? shouldDeferByDefault(project, environmentName);
-          const result = await runAdhocDbtCommand({
-            workspaceId,
-            projectId,
+          const result = await queueAgentRun(
+            project,
             environmentName,
-            userId: actingUserId,
-            command: `show --select ${model} --limit ${limit}`,
-            deferState: wantsDefer
-              ? await loadDbtDeferState(project)
-              : undefined,
-            timeoutMs: 3 * 60 * 1000,
-          });
-          // The preview table arrives as info-level log line(s) (ShowNode);
-          // anchor on the "Previewing" marker to drop dbt startup boilerplate,
-          // falling back to all info lines if the marker text ever changes.
-          const infoLines = result.logs
-            .filter(log => log.level === "info")
-            .map(log => log.line);
-          const markerIdx = infoLines.findIndex(line =>
-            line.includes("Previewing"),
+            [`show --select ${model} --limit ${limit}`],
+            wantsDefer,
           );
-          const preview = (
-            markerIdx >= 0 ? infoLines.slice(markerIdx) : infoLines
-          )
-            .join("\n")
-            .slice(0, 8000);
-          if (!result.success) {
-            const reason = result.logs
-              .filter(log => log.level === "error")
-              .map(log => log.line)
-              .join("\n");
-            return {
-              success: false,
-              error: reason || "dbt show failed",
-              logs: summarizeLogs(result.logs),
-            };
-          }
           return {
-            success: true,
-            preview,
-            logs: summarizeLogs(result.logs),
+            ...result,
+            defer: wantsDefer,
+            message: "Preview queued. Poll dbt_get_run with runId.",
           };
         } catch (error) {
           return toolError(error, "Failed to preview model");

--- a/api/src/agent-lib/tools/tool-discovery-tools.test.ts
+++ b/api/src/agent-lib/tools/tool-discovery-tools.test.ts
@@ -91,6 +91,7 @@ async function endToEnd() {
     enabledModes: new Set(["query"]),
     planSubmitted: false,
     planApproved: false,
+    approvedCapabilityGrants: new Set(),
     loadedToolNames: ["save_skill"],
   };
 

--- a/api/src/agent-skills/dbt-git-workflow/SKILL.md
+++ b/api/src/agent-skills/dbt-git-workflow/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: dbt-git-workflow
+description: Load for dbt branches, commits, pushes, pull requests, merges, repository sync, or branch cleanup.
+entities:
+  - dbt git
+  - branch
+  - commit
+  - push
+  - pull request
+  - PR
+  - merge
+  - checkout
+  - repository
+---
+
+# dbt Git workflow
+
+dbt file edits live in the acting user's working tree and are never pushed
+automatically. Read `dbt_git_status` before shipping and preserve unrelated
+pending files by passing an explicit `paths` list.
+
+## Required flow
+
+1. Edit and validate the working tree with `dbt_parse`,
+   `dbt_compile_model`, and `dbt_run_model`.
+2. If the user wants a new review branch, use `dbt_commit_to_branch`. It is an
+   atomic branch-and-commit operation; do not compose `dbt_create_branch` with
+   `dbt_commit_and_push`.
+3. Open the PR with `dbt_open_pull_request`.
+4. Before merge, check `dbt_git_status` so intended drafts are not omitted.
+5. Merge only when the user asks, using `dbt_merge_pull_request`.
+6. Run the production job only after merge and explicit confirmation.
+
+For an existing tracked branch, use `dbt_commit_and_push` only after the user
+asks to commit. Omit the message to use Mako's generated commit message.
+
+## Branch safety
+
+- Drafts are isolated per user and branch. Switching branches preserves each
+  branch's work.
+- `discardLocalChanges` abandons the current branch's pending work. Use it only
+  when the approved plan explicitly includes that discard.
+- Before deleting a branch, call `dbt_compare_branches`. Delete automatically
+  only when `fullyMergedIntoBase` is true; otherwise require explicit
+  destructive approval.
+- `dbt_sync_from_repo` may discard local changes when requested. Inspect status
+  first and never discard implicitly.
+- Recover missing work with `dbt_list_recoverable_files` and
+  `dbt_restore_file`.
+
+## Pull-request safety
+
+- PR operations ship committed work only; they never include drafts.
+- Preserve existing admin/owner checks for merge, update, and close.
+- Closing a PR or deleting its branch is destructive and must be present in the
+  approved plan.

--- a/api/src/agent-skills/dbt-jobs/SKILL.md
+++ b/api/src/agent-skills/dbt-jobs/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: dbt-jobs
+description: Load when creating, editing, scheduling, running, or debugging dbt jobs and production deployments.
+entities:
+  - dbt job
+  - schedule
+  - cron
+  - production
+  - deploy
+  - run job
+  - source freshness
+---
+
+# dbt jobs and production runs
+
+Jobs execute the committed tracked branch. They never include the acting
+user's checkout branch or uncommitted drafts.
+
+## Required flow
+
+1. Use ad-hoc `dbt_parse`, `dbt_compile_model`, `dbt_show`, and
+   `dbt_run_model` to verify working-tree changes in the user's development
+   environment.
+2. Commit, review, and merge through the dbt Git workflow.
+3. Trigger `dbt_run_job` only after the user explicitly confirms the job and
+   the approved plan includes production execution.
+4. Poll once with `dbt_get_run`; report terminal node/test outcomes or say the
+   run remains active.
+
+Never use a job to test a draft—it silently runs older committed code.
+
+## Job definitions
+
+- Add or change a cron schedule only when the user requests recurring
+  execution.
+- Deleting a job is destructive and requires explicit approval.
+- Keep job commands within the supported dbt command allowlist.
+- A full refresh for an edited incremental model belongs on
+  `dbt_run_model({ fullRefresh: true })` during development, not on a
+  production job.
+
+## Environments
+
+- Ad-hoc builds use the caller's saved or personal development environment.
+- Production-like environments reject ad-hoc writes.
+- Jobs are the deployment path after committed changes reach the tracked
+  branch.

--- a/api/src/agents/modes/derive-mode-state.test.ts
+++ b/api/src/agents/modes/derive-mode-state.test.ts
@@ -18,13 +18,21 @@ const msg = (role: "user" | "assistant", parts: Part[]): UIMessage =>
 
 const user = (text: string) => msg("user", [{ type: "text", text }]);
 
-const submitPlan = (decision?: "approve" | "request_changes" | "cancel") =>
+const submitPlan = (
+  decision?: "approve" | "request_changes" | "cancel",
+  requiredCapabilities?: string[],
+) =>
   msg("assistant", [
     {
       type: "tool-submit_plan",
       toolCallId: `c${idCounter}`,
       state: decision ? "output-available" : "input-available",
-      input: { title: "Plan", planMarkdown: "…", todos: [] },
+      input: {
+        title: "Plan",
+        planMarkdown: "…",
+        todos: [],
+        requiredCapabilities,
+      },
       ...(decision ? { output: { success: true, decision } } : {}),
     },
   ]);
@@ -44,6 +52,15 @@ const submitPlan = (decision?: "approve" | "request_changes" | "cancel") =>
   );
   assert.equal(state.planSubmitted, true);
   assert.equal(state.planApproved, true);
+}
+
+// --- approval carries only the requested task capabilities ------------------
+{
+  const state = deriveModeState(
+    [user("build it"), submitPlan("approve", ["warehouse-write"])],
+    "query",
+  );
+  assert.deepEqual([...state.approvedCapabilityGrants], ["warehouse-write"]);
 }
 
 // --- feedback user message after request_changes KEEPS the gate engaged ------

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -75,7 +75,9 @@ YOU decide when these make sense:
 - \`submit_plan\` — use BEFORE acting when the work is large, destructive, or spans multiple
   artifacts (e.g. building a dashboard from scratch, modifying many consoles, deleting or
   overwriting data, reconfiguring a sync flow), or when the user explicitly asks for a plan.
-  The user can Approve, Request changes, or Cancel.
+  The user can Approve, Request changes, or Cancel. For dbt work, include only the
+  \`requiredCapabilities\` the visible plan needs: \`artifact-write\`, \`warehouse-write\`,
+  \`git-write\`, and/or \`schedule-write\`.
 
 IMPORTANT: once you call \`submit_plan\`, mutating tools are blocked until the user approves.
 Do your read-only exploration BEFORE submitting so the plan is concrete. For small,

--- a/api/src/agents/modes/registry.ts
+++ b/api/src/agents/modes/registry.ts
@@ -1,4 +1,7 @@
-import { PLAN_GATE_ALLOWED_TOOL_NAMES } from "@mako/agent-tools";
+import {
+  DBT_CAPABILITY_NAMES,
+  PLAN_GATE_ALLOWED_TOOL_NAMES,
+} from "@mako/agent-tools";
 import type { AgentContext } from "../types";
 import type { AgentMode, ExpertiseModeId } from "./types";
 import {
@@ -202,46 +205,7 @@ const APP_MODE_TOOL_NAMES: string[] = [
 ];
 
 const TRANSFORM_MODE_TOOL_NAMES: string[] = [
-  // Bootstrap: create a project when the workspace has none
-  "dbt_create_project",
-  // Personal (per-developer) environment for safe fast iteration
-  "dbt_ensure_dev_environment",
-  // Client dbt file tools
-  "read_dbt_project_tree",
-  "read_dbt_file",
-  "create_dbt_file",
-  "modify_dbt_file",
-  "edit_dbt_file",
-  "delete_dbt_file",
-  // Server dbt verification + execution tools
-  "dbt_parse",
-  "dbt_compile_model",
-  "dbt_run_model",
-  "dbt_run_job",
-  "dbt_cancel_run",
-  "dbt_get_run",
-  "dbt_show",
-  "dbt_create_job",
-  "dbt_update_job",
-  "dbt_delete_job",
-  // Git: commit/push edits to the connected repo (only when the user asks).
-  "dbt_git_status",
-  "dbt_sync_from_repo",
-  "dbt_commit_and_push",
-  "dbt_commit_to_branch",
-  "dbt_create_branch",
-  "dbt_switch_branch",
-  "dbt_list_branches",
-  "dbt_compare_branches",
-  "dbt_delete_branch",
-  "dbt_open_pull_request",
-  "dbt_merge_pull_request",
-  "dbt_list_pull_requests",
-  "dbt_update_pull_request",
-  "dbt_close_pull_request",
-  // Recovery: surface + restore work hidden by a destructive switch/sync.
-  "dbt_list_recoverable_files",
-  "dbt_restore_file",
+  ...DBT_CAPABILITY_NAMES,
   // Discovery: inspect sources before writing staging models; preview built
   // tables after dbt_run_model.
   "list_connections",

--- a/api/src/agents/modes/runtime.ts
+++ b/api/src/agents/modes/runtime.ts
@@ -14,14 +14,17 @@
 import type { SystemModelMessage, ToolSet, UIMessage } from "ai";
 import {
   clientPlanTools,
+  CAPABILITY_GRANTS,
   READ_ONLY_TOOL_NAMES,
   PLAN_GATE_ALLOWED_TOOL_NAMES,
+  type CapabilityGrant,
 } from "@mako/agent-tools";
 import type { AgentContext } from "../types";
 import { unifiedAgentFactory } from "../unified";
 import { buildCurrentScreenContext } from "../unified/prompt";
 import { createModeTools } from "../../agent-lib/tools/mode-tools";
 import { createToolDiscoveryTools } from "../../agent-lib/tools/tool-discovery-tools";
+import { authorizeAgentCapability } from "../../agent-lib/capabilities/runtime";
 import {
   effectiveToolCountLimit,
   estimateToolSetTokens,
@@ -79,6 +82,7 @@ export function deriveModeState(
   const loadedToolNames: string[] = [];
   let planSubmitted = false;
   let planApproved = false;
+  let approvedCapabilityGrants = new Set<CapabilityGrant>();
   let lastPlanDecision: unknown;
 
   const recordLoadedTools = (names: unknown) => {
@@ -109,6 +113,7 @@ export function deriveModeState(
         planSubmitted = false;
       }
       planApproved = false;
+      approvedCapabilityGrants = new Set();
     }
 
     const parts = (message.parts ?? []) as UIMessagePart[];
@@ -129,6 +134,19 @@ export function deriveModeState(
         );
       } else if (toolName === "submit_plan") {
         planSubmitted = true;
+        const requested = (
+          part.input as { requiredCapabilities?: unknown } | undefined
+        )?.requiredCapabilities;
+        const validGrants = new Set<CapabilityGrant>(CAPABILITY_GRANTS);
+        approvedCapabilityGrants = new Set(
+          Array.isArray(requested)
+            ? requested.filter(
+                (grant): grant is CapabilityGrant =>
+                  typeof grant === "string" &&
+                  validGrants.has(grant as CapabilityGrant),
+              )
+            : ["artifact-write"],
+        );
         const decision = (part.output as { decision?: unknown } | undefined)
           ?.decision;
         lastPlanDecision = decision;
@@ -139,7 +157,13 @@ export function deriveModeState(
     }
   }
 
-  return { enabledModes, planSubmitted, planApproved, loadedToolNames };
+  return {
+    enabledModes,
+    planSubmitted,
+    planApproved,
+    approvedCapabilityGrants,
+    loadedToolNames,
+  };
 }
 
 /**
@@ -322,6 +346,20 @@ export function computeActiveTools(
         PLAN_GATE_ALLOWED_TOOL_NAMES.has(name),
     );
   }
+  const nativeCapabilityGrants = new Set<CapabilityGrant>([
+    // Small working-tree edits retain native Chat's act-without-a-plan flow.
+    // Warehouse, Git, and scheduling mutations always require plan approval.
+    "artifact-write",
+    ...(modeState.planApproved ? [...modeState.approvedCapabilityGrants] : []),
+  ]);
+  names = names.filter(
+    name =>
+      authorizeAgentCapability(name, {
+        surface: "in-chat",
+        queryAccess: "write",
+        grants: nativeCapabilityGrants,
+      }).allowed,
+  );
 
   // Count budget: trim the evictable tail; base is never evicted (it is
   // bounded by the mode registry, far under every provider cap).

--- a/api/src/agents/modes/tool-working-set.test.ts
+++ b/api/src/agents/modes/tool-working-set.test.ts
@@ -62,6 +62,7 @@ const baseModeState = (loaded: string[] = []): ModeState => ({
   enabledModes: new Set(["query"]),
   planSubmitted: false,
   planApproved: false,
+  approvedCapabilityGrants: new Set(),
   loadedToolNames: loaded,
 });
 
@@ -162,6 +163,7 @@ const baseModeState = (loaded: string[] = []): ModeState => ({
     enabledModes: new Set(),
     planSubmitted: false,
     planApproved: false,
+    approvedCapabilityGrants: new Set(),
     loadedToolNames: ["heavy_a", "heavy_b"],
   };
   const active = computeActiveTools(state, all, undefined, {
@@ -194,6 +196,7 @@ const baseModeState = (loaded: string[] = []): ModeState => ({
     enabledModes: new Set(),
     planSubmitted: true,
     planApproved: false,
+    approvedCapabilityGrants: new Set(),
     loadedToolNames: ["mcp_read_tool", "mcp_write_tool"],
   };
   const active = computeActiveTools(
@@ -209,6 +212,37 @@ const baseModeState = (loaded: string[] = []): ModeState => ({
   assert.ok(active.includes("load_tools"), "loading allowed under gate");
   assert.ok(active.includes("mcp_read_tool"), "read MCP allowed under gate");
   assert.ok(!active.includes("mcp_write_tool"), "write MCP gated");
+}
+
+// --- dbt capabilities: small edits are implicit; writes need plan grants -----
+{
+  const all = new Set([
+    "edit_dbt_file",
+    "dbt_run_model",
+    "dbt_commit_and_push",
+  ]);
+  const withoutPlan: ModeState = {
+    enabledModes: new Set(["transform"]),
+    planSubmitted: false,
+    planApproved: false,
+    approvedCapabilityGrants: new Set(),
+    loadedToolNames: [],
+  };
+  const activeWithoutPlan = computeActiveTools(withoutPlan, all);
+  assert.ok(activeWithoutPlan.includes("edit_dbt_file"));
+  assert.ok(!activeWithoutPlan.includes("dbt_run_model"));
+  assert.ok(!activeWithoutPlan.includes("dbt_commit_and_push"));
+
+  const approved: ModeState = {
+    ...withoutPlan,
+    planSubmitted: true,
+    planApproved: true,
+    approvedCapabilityGrants: new Set(["warehouse-write"]),
+  };
+  const activeApproved = computeActiveTools(approved, all);
+  assert.ok(activeApproved.includes("edit_dbt_file"));
+  assert.ok(activeApproved.includes("dbt_run_model"));
+  assert.ok(!activeApproved.includes("dbt_commit_and_push"));
 }
 
 // --- provider caps ------------------------------------------------------------

--- a/api/src/agents/modes/types.ts
+++ b/api/src/agents/modes/types.ts
@@ -9,6 +9,7 @@
  *   `submit_plan` in the current user turn, mutating tools are hard-gated
  *   until the user approves the plan.
  */
+import type { CapabilityGrant } from "@mako/agent-tools";
 
 /** Dynamic expertise modes the model can enable via `enable_mode`. */
 export type ExpertiseModeId =
@@ -55,6 +56,8 @@ export interface ModeState {
   planSubmitted: boolean;
   /** Whether the user has approved the submitted plan (latest decision). */
   planApproved: boolean;
+  /** Mutation capabilities explicitly approved with the latest plan. */
+  approvedCapabilityGrants: Set<CapabilityGrant>;
   /**
    * Deferred-tier tools activated via `load_tools`, oldest-first (the order
    * doubles as the LRU eviction order when the working-set budget binds).

--- a/api/src/auth/mcp-oauth.service.ts
+++ b/api/src/auth/mcp-oauth.service.ts
@@ -119,6 +119,7 @@ export interface IssuedTokens {
   refreshToken: string;
   expiresInSeconds: number;
   scopes: string[];
+  agentSessionId?: string;
 }
 
 async function issueTokens(grant: {
@@ -126,6 +127,7 @@ async function issueTokens(grant: {
   userId: string;
   workspaceId: string;
   scopes: string[];
+  agentSessionId?: string;
 }): Promise<IssuedTokens> {
   const accessToken = randomToken(MCP_ACCESS_TOKEN_PREFIX);
   const refreshToken = randomToken(MCP_REFRESH_TOKEN_PREFIX);
@@ -135,6 +137,7 @@ async function issueTokens(grant: {
     clientId: grant.clientId,
     userId: grant.userId,
     workspaceId: grant.workspaceId,
+    agentSessionId: grant.agentSessionId,
     scopes: grant.scopes,
     accessExpiresAt: new Date(Date.now() + ACCESS_TOKEN_TTL_MS),
     refreshExpiresAt: new Date(Date.now() + REFRESH_TOKEN_TTL_MS),
@@ -144,6 +147,7 @@ async function issueTokens(grant: {
     refreshToken,
     expiresInSeconds: Math.floor(ACCESS_TOKEN_TTL_MS / 1000),
     scopes: grant.scopes,
+    agentSessionId: grant.agentSessionId,
   };
 }
 
@@ -184,11 +188,13 @@ export async function mintMcpAccessTokenForUser(input: {
   workspaceId: string;
 }): Promise<IssuedTokens> {
   await ensureAcpMcpClient();
+  const agentSessionId = crypto.randomUUID();
   return issueTokens({
     clientId: ACP_MCP_CLIENT_ID,
     userId: input.userId,
     workspaceId: input.workspaceId,
     scopes: [...DEFAULT_WORKSPACE_API_KEY_SCOPES],
+    agentSessionId,
   });
 }
 
@@ -256,6 +262,7 @@ export async function refreshAccessToken(input: {
     userId: record.userId,
     workspaceId: record.workspaceId,
     scopes: record.scopes,
+    agentSessionId: record.agentSessionId,
   });
 }
 
@@ -336,6 +343,7 @@ export interface ValidatedMcpToken {
   scopes: WorkspaceApiKeyScope[];
   /** OAuth client that minted the grant (e.g. `mako-acp-local`). */
   clientId: string;
+  agentSessionId?: string;
 }
 
 export async function validateMcpAccessToken(
@@ -363,5 +371,6 @@ export async function validateMcpAccessToken(
     workspaceId: record.workspaceId,
     scopes: resolveWorkspaceApiKeyScopes(record.scopes),
     clientId: record.clientId,
+    agentSessionId: record.agentSessionId,
   };
 }

--- a/api/src/auth/unified-auth.middleware.ts
+++ b/api/src/auth/unified-auth.middleware.ts
@@ -56,6 +56,7 @@ export async function unifiedAuthMiddleware(c: Context, next: Next) {
         c.set("workspaceId", workspace._id.toString());
         c.set("mcpOAuthScopes", validated.scopes);
         c.set("mcpOAuthClientId", validated.clientId);
+        c.set("mcpAgentSessionId", validated.agentSessionId);
 
         enrichContextWithUser(tokenUser._id);
         enrichContextWithWorkspace(workspace._id.toString());

--- a/api/src/database/acp-plan-grant-schema.ts
+++ b/api/src/database/acp-plan-grant-schema.ts
@@ -1,0 +1,39 @@
+import mongoose, { Schema, type Document, type Types } from "mongoose";
+import type { CapabilityGrant } from "@mako/agent-tools";
+
+export interface IAcpPlanGrant extends Document {
+  _id: Types.ObjectId;
+  workspaceId: string;
+  userId: string;
+  agentSessionId: string;
+  planDigest: string;
+  grants: CapabilityGrant[];
+  status: "approved" | "revoked";
+  expiresAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const AcpPlanGrantSchema = new Schema<IAcpPlanGrant>(
+  {
+    workspaceId: { type: String, required: true, index: true },
+    userId: { type: String, required: true, index: true },
+    agentSessionId: { type: String, required: true, unique: true },
+    planDigest: { type: String, required: true },
+    grants: { type: [String], required: true },
+    status: {
+      type: String,
+      enum: ["approved", "revoked"],
+      required: true,
+    },
+    expiresAt: { type: Date, required: true },
+  },
+  { timestamps: true },
+);
+
+AcpPlanGrantSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+export const AcpPlanGrant = mongoose.model<IAcpPlanGrant>(
+  "AcpPlanGrant",
+  AcpPlanGrantSchema,
+);

--- a/api/src/database/mcp-oauth-schema.ts
+++ b/api/src/database/mcp-oauth-schema.ts
@@ -63,6 +63,8 @@ export interface IMcpOAuthToken extends Document {
   clientId: string;
   userId: string;
   workspaceId: string;
+  /** Server-generated identity for one attached Desktop ACP session. */
+  agentSessionId?: string;
   scopes: string[];
   accessExpiresAt: Date;
   refreshExpiresAt: Date;
@@ -76,6 +78,7 @@ const McpOAuthTokenSchema = new Schema<IMcpOAuthToken>({
   clientId: { type: String, required: true },
   userId: { type: String, required: true },
   workspaceId: { type: String, required: true },
+  agentSessionId: { type: String, index: true },
   scopes: { type: [String], required: true },
   accessExpiresAt: { type: Date, required: true },
   refreshExpiresAt: { type: Date, required: true },

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -5022,6 +5022,11 @@ export interface IDbtRun extends Document {
   logs: IDbtRunLogLine[];
   /** Parsed from run_results.json after each command. */
   stepResults: IDbtRunStepResult[];
+  /** Structured bounded output for commands whose result is not run_results. */
+  output?: {
+    kind: "show-preview";
+    text: string;
+  };
   artifactKeys: {
     manifest?: string;
     runResults?: string;
@@ -5124,6 +5129,10 @@ const DbtRunSchema = new Schema<IDbtRun>(
         ),
       ],
       default: [],
+    },
+    output: {
+      kind: { type: String, enum: ["show-preview"] },
+      text: { type: String },
     },
     artifactKeys: {
       manifest: { type: String },

--- a/api/src/dbt/agent-turn-preparation.test.ts
+++ b/api/src/dbt/agent-turn-preparation.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MAX_SKILL_EXCERPT_CHARS,
+  renderCompactSkillBlock,
+} from "../services/agent-turn-preparation.service";
+
+describe("renderCompactSkillBlock", () => {
+  it("injects one relevant skill within the turn budget", () => {
+    const body = "x".repeat(MAX_SKILL_EXCERPT_CHARS * 2);
+    const block = renderCompactSkillBlock({
+      injected: [
+        {
+          id: "one",
+          name: "dbt",
+          loadWhen: "Use for dbt",
+          body,
+          score: 1,
+          entityOverlap: 1,
+          semanticScore: 0,
+          injected: true,
+          scope: "system",
+        },
+        {
+          id: "two",
+          name: "unrelated",
+          loadWhen: "Use elsewhere",
+          body: "must not be injected",
+          score: 0.9,
+          entityOverlap: 1,
+          semanticScore: 0,
+          injected: true,
+          scope: "system",
+        },
+      ],
+    });
+
+    expect(block).toContain("`dbt`");
+    expect(block).toContain("Excerpt truncated");
+    expect(block).not.toContain("must not be injected");
+    expect(block.length).toBeLessThan(MAX_SKILL_EXCERPT_CHARS + 500);
+  });
+
+  it("returns no block when retrieval selected no skill", () => {
+    expect(renderCompactSkillBlock({ injected: [] })).toBe("");
+  });
+});

--- a/api/src/inngest/functions/dbt-run.ts
+++ b/api/src/inngest/functions/dbt-run.ts
@@ -61,6 +61,16 @@ const logger = loggers.inngest("dbt");
 const MAX_LOG_LINES = 5000;
 const LOG_FLUSH_INTERVAL_MS = 2000;
 
+function extractShowPreview(logs: DbtLogLine[]): string {
+  const infoLines = logs
+    .filter(log => log.level === "info")
+    .map(log => log.line);
+  const markerIndex = infoLines.findIndex(line => line.includes("Previewing"));
+  return (markerIndex >= 0 ? infoLines.slice(markerIndex) : infoLines)
+    .join("\n")
+    .slice(0, 8_000);
+}
+
 /** Buffered writer for dbt_runs.logs — capped, batched $push. */
 function createLogWriter(runId: Types.ObjectId) {
   let buffer: DbtLogLine[] = [];
@@ -453,6 +463,12 @@ export const dbtRunExecutorFunction = inngest.createFunction(
             const update: Record<string, unknown> = {};
             for (const [kind, key] of Object.entries(artifactKeys)) {
               update[`artifactKeys.${kind}`] = key;
+            }
+            if (parsed.subcommand === "show" && commandResult?.logLines) {
+              update.output = {
+                kind: "show-preview",
+                text: extractShowPreview(commandResult.logLines),
+              };
             }
             if (stepResults.length > 0 || Object.keys(update).length > 0) {
               await DbtRun.updateOne(

--- a/api/src/mcp/bridge-policy.ts
+++ b/api/src/mcp/bridge-policy.ts
@@ -12,7 +12,7 @@
  * Adding a new agent tool without classifying it here fails the MCP
  * inventory test — that's how we stay smart about what's missing.
  */
-import { READ_ONLY_TOOL_NAMES } from "@mako/agent-tools";
+import { DBT_CAPABILITIES, READ_ONLY_TOOL_NAMES } from "@mako/agent-tools";
 
 /** Why a tool is kept off the MCP surface. */
 export type McpBridgeExclusionWhy =
@@ -26,6 +26,8 @@ export type McpBridgeEntry =
       status: "bridge";
       /** Omit when the API key has no query access (`query:read`). */
       requiresQueryAccess?: boolean;
+      /** Expose only to the signed-in Mako Desktop ACP client. */
+      acpDesktopOnly?: boolean;
       /**
        * Factory may omit this tool without credentials/config (e.g. web_search
        * when no search provider is configured). Still classified so the catalog
@@ -61,6 +63,48 @@ const exclude = (why: McpBridgeExclusionWhy, note: string): McpBridgeEntry => ({
 const mcpOnly = (
   opts: Omit<Extract<McpBridgeEntry, { status: "mcp-only" }>, "status"> = {},
 ): McpBridgeEntry => ({ status: "mcp-only", ...opts });
+
+function dbtBridgePolicyEntries(): Record<string, McpBridgeEntry> {
+  return Object.fromEntries(
+    DBT_CAPABILITIES.map(capability => {
+      if (capability.requiresAsyncMcp) {
+        return [
+          capability.name,
+          exclude(
+            "deferred",
+            "Move this operation to the async run lifecycle before MCP exposure.",
+          ),
+        ];
+      }
+
+      const external = capability.surfaces.includes("external-mcp");
+      const desktop = capability.surfaces.includes("desktop-acp");
+      if (external) {
+        return [
+          capability.name,
+          bridge({
+            requiresQueryAccess: capability.requiresQueryAccess,
+            destructiveHint: capability.risk === "destructive",
+          }),
+        ];
+      }
+      if (desktop) {
+        return [
+          capability.name,
+          bridge({
+            acpDesktopOnly: true,
+            requiresQueryAccess: capability.requiresQueryAccess,
+            destructiveHint: capability.risk === "destructive",
+          }),
+        ];
+      }
+      return [
+        capability.name,
+        exclude("deferred", "Not available on an MCP surface."),
+      ];
+    }),
+  );
+}
 
 /**
  * Complete classification of every agent / MCP tool name.
@@ -273,53 +317,8 @@ export const MCP_BRIDGE_POLICY: Readonly<Record<string, McpBridgeEntry>> = {
     "Queries in-browser DuckDB; MCP validates via sql_execute_query.",
   ),
 
-  // ── dbt / transform (server-capable, not yet on MCP) ──────────────────
-  create_dbt_file: exclude(
-    "deferred",
-    "Transform mode is in-product; MCP v1 is the apps + data loop.",
-  ),
-  dbt_cancel_run: exclude("deferred", "Transform mode not yet on MCP."),
-  dbt_close_pull_request: exclude("deferred", "Transform mode not yet on MCP."),
-  dbt_commit_and_push: exclude("deferred", "Transform mode not yet on MCP."),
-  dbt_commit_to_branch: exclude("deferred", "Transform mode not yet on MCP."),
-  dbt_compare_branches: exclude("deferred", "Transform mode not yet on MCP."),
-  dbt_compile_model: exclude("deferred", "Transform mode not yet on MCP."),
-  dbt_create_branch: exclude("deferred", "Transform mode not yet on MCP."),
-  dbt_create_job: exclude("deferred", "Transform mode not yet on MCP."),
-  dbt_create_project: exclude("deferred", "Transform mode not yet on MCP."),
-  dbt_delete_branch: exclude("deferred", "Transform mode not yet on MCP."),
-  dbt_delete_job: exclude("deferred", "Transform mode not yet on MCP."),
-  dbt_ensure_dev_environment: exclude(
-    "deferred",
-    "Transform mode not yet on MCP.",
-  ),
-  dbt_get_run: exclude("deferred", "Transform mode not yet on MCP."),
-  dbt_git_status: exclude("deferred", "Transform mode not yet on MCP."),
-  dbt_list_branches: exclude("deferred", "Transform mode not yet on MCP."),
-  dbt_list_pull_requests: exclude("deferred", "Transform mode not yet on MCP."),
-  dbt_list_recoverable_files: exclude(
-    "deferred",
-    "Transform mode not yet on MCP.",
-  ),
-  dbt_merge_pull_request: exclude("deferred", "Transform mode not yet on MCP."),
-  dbt_open_pull_request: exclude("deferred", "Transform mode not yet on MCP."),
-  dbt_parse: exclude("deferred", "Transform mode not yet on MCP."),
-  dbt_restore_file: exclude("deferred", "Transform mode not yet on MCP."),
-  dbt_run_job: exclude("deferred", "Transform mode not yet on MCP."),
-  dbt_run_model: exclude("deferred", "Transform mode not yet on MCP."),
-  dbt_show: exclude("deferred", "Transform mode not yet on MCP."),
-  dbt_switch_branch: exclude("deferred", "Transform mode not yet on MCP."),
-  dbt_sync_from_repo: exclude("deferred", "Transform mode not yet on MCP."),
-  dbt_update_job: exclude("deferred", "Transform mode not yet on MCP."),
-  dbt_update_pull_request: exclude(
-    "deferred",
-    "Transform mode not yet on MCP.",
-  ),
-  delete_dbt_file: exclude("deferred", "Transform mode not yet on MCP."),
-  edit_dbt_file: exclude("deferred", "Transform mode not yet on MCP."),
-  modify_dbt_file: exclude("deferred", "Transform mode not yet on MCP."),
-  read_dbt_file: exclude("deferred", "Transform mode not yet on MCP."),
-  read_dbt_project_tree: exclude("deferred", "Transform mode not yet on MCP."),
+  // ── dbt / transform — derived from the shared capability registry ─────
+  ...dbtBridgePolicyEntries(),
 
   // ── Skills / memory / modes / plan ────────────────────────────────────
   ask_clarifying_questions: exclude(

--- a/api/src/mcp/mako-mcp-server.test.ts
+++ b/api/src/mcp/mako-mcp-server.test.ts
@@ -16,6 +16,11 @@ process.env.ENCRYPTION_KEY =
   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+import {
+  CAPABILITY_GRANTS,
+  DBT_CAPABILITY_NAMES,
+  type CapabilityGrant,
+} from "@mako/agent-tools";
 import { buildMakoMcpServer } from "./mako-mcp-server";
 import { StatelessMcpTransport } from "./stateless-transport";
 import {
@@ -40,8 +45,15 @@ const WORKSPACE_ID = new Types.ObjectId().toString();
 async function exchange(
   messages: Record<string, unknown>[],
   scopes: WorkspaceApiKeyScope[] = ["mcp", "query:read"],
+  acpDesktop = false,
+  capabilityGrants?: CapabilityGrant[],
 ): Promise<Record<string, unknown>[]> {
-  const server = buildMakoMcpServer({ workspaceId: WORKSPACE_ID, scopes });
+  const server = buildMakoMcpServer({
+    workspaceId: WORKSPACE_ID,
+    scopes,
+    acpDesktop,
+    ...(capabilityGrants ? { capabilityGrants } : {}),
+  });
   const transport = new StatelessMcpTransport();
   await server.connect(transport);
   try {
@@ -201,6 +213,9 @@ async function main() {
       "read_notebook",
       "search_notebook",
       "read_notebook_cell",
+      "read_dbt_project_tree",
+      "read_dbt_file",
+      "dbt_get_run",
     ]) {
       assert.equal(
         byName.get(readOnlyTool)?.annotations?.readOnlyHint,
@@ -264,6 +279,15 @@ async function main() {
       "update_self_directive",
       "read_skill_resource",
       "fetch_url",
+      "read_dbt_project_tree",
+      "read_dbt_file",
+      "create_dbt_file",
+      "edit_dbt_file",
+      "modify_dbt_file",
+      "delete_dbt_file",
+      "dbt_get_run",
+      "dbt_list_recoverable_files",
+      "dbt_restore_file",
     ]) {
       assert.ok(names.has(expected), `missing tool: ${expected}`);
     }
@@ -306,6 +330,19 @@ async function main() {
       false,
       "client-only app tools must not be bridged",
     );
+    for (const desktopOnlyTool of [
+      "dbt_parse",
+      "dbt_compile_model",
+      "dbt_show",
+      "dbt_run_model",
+      "dbt_cancel_run",
+    ]) {
+      assert.equal(
+        names.has(desktopOnlyTool),
+        false,
+        `${desktopOnlyTool} must stay off general MCP`,
+      );
+    }
   }
 
   // 3b. Bridge policy covers the live agent inventory — this is how we stay
@@ -324,7 +361,7 @@ async function main() {
       if (entry.status !== "bridge") continue;
       // Conditional tools (e.g. web_search) only appear when optional
       // providers are configured.
-      if (entry.conditional) continue;
+      if (entry.conditional || entry.acpDesktopOnly) continue;
       assert.ok(
         exposed.has(name),
         `policy says bridge ${name} but tools/list omitted it`,
@@ -341,6 +378,103 @@ async function main() {
     const gaps = summarizeBridgeGaps();
     assert.ok(gaps.some(g => g.why === "security"));
     assert.ok(mcpExposedToolNames().includes("create_app"));
+  }
+
+  // 3c. Desktop ACP only gets warehouse execution after plan approval.
+  {
+    const [unapprovedList] = await exchange(
+      [{ jsonrpc: "2.0", id: "acp-dbt-list", method: "tools/list" }],
+      ["mcp", "query:read"],
+      true,
+    );
+    const unapprovedTools = (
+      unapprovedList.result as { tools: { name: string }[] }
+    ).tools;
+    assert.ok(
+      unapprovedTools.some(tool => tool.name === "dbt_run_model"),
+      "Desktop should discover plan-gated tools before approval",
+    );
+    const [unapprovedCall] = await exchange(
+      [
+        {
+          jsonrpc: "2.0",
+          id: "acp-dbt-denied",
+          method: "tools/call",
+          params: { name: "dbt_run_model", arguments: {} },
+        },
+      ],
+      ["mcp", "query:read"],
+      true,
+    );
+    const deniedResult = unapprovedCall.result as {
+      isError?: boolean;
+      content: { text: string }[];
+    };
+    assert.equal(deniedResult.isError, true);
+    assert.match(deniedResult.content[0].text, /warehouse-write/);
+    const [wrongGrantCall] = await exchange(
+      [
+        {
+          jsonrpc: "2.0",
+          id: "acp-dbt-wrong-grant",
+          method: "tools/call",
+          params: { name: "dbt_run_model", arguments: {} },
+        },
+      ],
+      ["mcp", "query:read"],
+      true,
+      ["artifact-write"],
+    );
+    assert.match(
+      (
+        wrongGrantCall.result as {
+          content: { text: string }[];
+        }
+      ).content[0].text,
+      /warehouse-write/,
+    );
+
+    const [res] = await exchange(
+      [{ jsonrpc: "2.0", id: "acp-dbt", method: "tools/list" }],
+      ["mcp", "query:read"],
+      true,
+      [...CAPABILITY_GRANTS],
+    );
+    const { tools } = res.result as {
+      tools: {
+        name: string;
+        annotations?: {
+          destructiveHint?: boolean;
+        };
+      }[];
+    };
+    const byName = new Map(tools.map(tool => [tool.name, tool]));
+    for (const capabilityName of DBT_CAPABILITY_NAMES) {
+      assert.ok(
+        byName.has(capabilityName),
+        `Desktop ACP missing registered dbt capability: ${capabilityName}`,
+      );
+    }
+    assert.ok(byName.has("dbt_run_model"));
+    assert.ok(byName.has("dbt_cancel_run"));
+    assert.equal(
+      byName.get("dbt_run_model")?.annotations?.destructiveHint,
+      true,
+    );
+  }
+
+  // 3d. Run logs / dbt show output require query scope.
+  {
+    const [res] = await exchange(
+      [{ jsonrpc: "2.0", id: "dbt-no-query", method: "tools/list" }],
+      ["mcp"],
+    );
+    const { tools } = res.result as { tools: { name: string }[] };
+    assert.equal(
+      tools.some(tool => tool.name === "dbt_get_run"),
+      false,
+      "dbt run output must stay hidden without query:read",
+    );
   }
 
   // 4. Arbitrary MongoDB JavaScript execution is never bridged over MCP.

--- a/api/src/mcp/mako-mcp-server.ts
+++ b/api/src/mcp/mako-mcp-server.ts
@@ -24,7 +24,9 @@ import {
 import type { Tool as AiTool } from "ai";
 import { nanoid } from "nanoid";
 import { z } from "zod";
+import { type CapabilityGrant } from "@mako/agent-tools";
 
+import { authorizeAgentCapability } from "../agent-lib/capabilities/runtime";
 import { createServerAppTools } from "../agent-lib/tools/server-app-tools";
 import { createSqlToolsV2 } from "../agent-lib/tools/sql-tools";
 import { createMongoToolsV2 } from "../agent-lib/tools/mongodb-tools";
@@ -37,6 +39,7 @@ import { createVersionHistoryTools } from "../agent-lib/tools/version-history-to
 import { createSkillTools } from "../agent-lib/tools/skill-tools";
 import { createSelfDirectiveTools } from "../agent-lib/tools/self-directive-tool";
 import { createWebTools } from "../agent-lib/tools/web-tools";
+import { createDbtServerTools } from "../agent-lib/tools/dbt-tools";
 import {
   getSystemSkillIndex,
   getSystemSkillFullText,
@@ -88,10 +91,11 @@ Typical loop:
 1. Discover data: list_connections, then sql_list_tables / sql_inspect_table.
 2. Validate queries with sql_execute_query (short exploration timeout). For slow warehouses: create_console → run_console → check_query_status.
 3. create_app → app_write_file / app_edit_file → app_create_data_binding (bind the validated query; pass consoleId to seed from a console).
-4. Desktop opens/refreshes the app tab automatically. Do NOT create_preview_token, render_app, or paste /preview/… URLs. Use mako-desktop run_app / get_preview_errors for iframe errors. For consoles use open_console / create_console; for notebooks use create_notebook / cell tools.
-5. Interactive UX: mako-desktop ask_clarifying_questions / submit_plan (docked Chat cards) — never ask as plain text.
-6. Durable memory: read_self_directive / update_self_directive only. Do NOT write .claude/**/MEMORY.md or other local Claude memory files.
-7. app_save_version to snapshot/publish.
+4. For dbt work: read_dbt_project_tree → read/edit files → validate asynchronously, then poll dbt_get_run. Before dbt mutations, submit a plan whose requiredCapabilities lists only the needed artifact-write, warehouse-write, git-write, or schedule-write grants.
+5. Desktop opens/refreshes the app tab automatically. Do NOT create_preview_token, render_app, or paste /preview/… URLs. Use mako-desktop run_app / get_preview_errors for iframe errors. For consoles use open_console / create_console; for notebooks use create_notebook / cell tools.
+6. Interactive UX: mako-desktop ask_clarifying_questions / submit_plan (docked Chat cards) — never ask as plain text.
+7. Durable memory: read_self_directive / update_self_directive only. Do NOT write .claude/**/MEMORY.md or other local Claude memory files.
+8. app_save_version to snapshot/publish.
 
 Skills (same knowledge as the in-product agent):
 - list_skills → compact index (workspace + system).
@@ -117,6 +121,8 @@ export interface MakoMcpContext {
    * registered for these clients).
    */
   acpDesktop?: boolean;
+  /** Approved task grants resolved server-side for this agent session. */
+  capabilityGrants?: readonly CapabilityGrant[];
 }
 
 export type BridgeableTool = Pick<
@@ -181,6 +187,7 @@ export function buildMakoMcpCandidateTools(
   const skillTools = createSkillTools(workspaceId, userId);
   const selfDirectiveTools = createSelfDirectiveTools(workspaceId);
   const webTools = createWebTools();
+  const dbtTools = createDbtServerTools(workspaceId, userId, { chatId });
 
   return {
     ...appTools,
@@ -202,6 +209,7 @@ export function buildMakoMcpCandidateTools(
     ...versionHistoryTools,
     ...skillTools,
     ...webTools,
+    ...dbtTools,
   };
 }
 
@@ -221,6 +229,7 @@ export function buildMakoMcpToolset(
   for (const [name, tool] of Object.entries(candidates)) {
     const entry = MCP_BRIDGE_POLICY[name];
     if (!entry || entry.status !== "bridge") continue;
+    if (entry.acpDesktopOnly && !context.acpDesktop) continue;
     if (entry.requiresQueryAccess && queryAccess === "none") continue;
     exposed[name] = tool;
   }
@@ -338,6 +347,28 @@ export function buildMakoMcpServer(
     if (!tool?.execute) {
       return {
         content: [{ type: "text" as const, text: `Unknown tool: ${name}` }],
+        isError: true,
+      };
+    }
+    const authorization = authorizeAgentCapability(name, {
+      surface: context.acpDesktop ? "desktop-acp" : "external-mcp",
+      queryAccess,
+      // External MCP's `mcp` scope is the existing workspace-authoring
+      // authority. Small dbt working-tree edits match native Chat and do not
+      // require a plan; warehouse, Git, and scheduling mutations do.
+      grants: new Set<CapabilityGrant>([
+        "artifact-write",
+        ...(context.capabilityGrants ?? []),
+      ]),
+    });
+    if (!authorization.allowed) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: authorization.reason ?? `Tool ${name} is not authorized`,
+          },
+        ],
         isError: true,
       };
     }

--- a/api/src/openapi/core.ts
+++ b/api/src/openapi/core.ts
@@ -23,6 +23,8 @@ export interface AuthVariables {
   mcpOAuthScopes?: string[];
   /** OAuth client id for MCP access tokens (e.g. `mako-acp-local`). */
   mcpOAuthClientId?: string;
+  /** Server-generated identity for a Desktop ACP attachment. */
+  mcpAgentSessionId?: string;
 }
 
 export type AuthEnv = { Variables: AuthVariables };

--- a/api/src/routes/agent.routes.ts
+++ b/api/src/routes/agent.routes.ts
@@ -56,11 +56,7 @@ import {
   generateDescriptionAndEmbedding,
 } from "../services/console-description.service";
 import { searchConsoles } from "../agent-lib/tools/console-search-tools";
-import {
-  retrieveRelevantSkills,
-  renderSkillsPromptBlock,
-} from "../services/skills.service";
-import { resolveDbtRulesBlockForTurn } from "../dbt/dbt-rules-turn.service";
+import { prepareAgentTurnGuidance } from "../services/agent-turn-preparation.service";
 import { isDbtShapedTurn } from "../dbt/dbt-turn-shape";
 import { sanitizeMessagesForModel } from "../utils/message-sanitizer";
 import { resolveChatAttachmentsForModel } from "../services/chat-attachment.service";
@@ -643,53 +639,30 @@ agentRoutes.openapi(
       }
     }
 
-    // Skills retrieval — runs for console + unified agents (parity with
-    // self-directive). Index is always included when any skills exist;
-    // bodies are only pulled in when score clears threshold.
     let skillsBlock = "";
+    let dbtRulesBlock = "";
     if (resolvedAgentId === "console" || resolvedAgentId === "unified") {
       try {
-        const retrieval = await retrieveRelevantSkills(
-          workspaceId,
-          lastUserText,
-        );
-        skillsBlock = renderSkillsPromptBlock(retrieval);
-      } catch (err) {
-        logger.debug("Skills block injection skipped", { error: err });
-      }
-    }
-
-    // `.makorules` — the dbt project's own SQL conventions. Binding for any
-    // model the agent writes, so it is injected rather than left for the agent
-    // to look up. `detectAgentId` always resolves to "unified", so gating on
-    // resolvedAgentId would fire on every turn — gate on the turn actually
-    // being dbt-shaped instead (open dbt tab, or an active dbt-* tab kind),
-    // otherwise non-dbt turns (console, notebook) pay uncached prompt tokens
-    // for rules that don't apply to them. Never fatal: a failed lookup just
-    // means no rules this turn.
-    let dbtRulesBlock = "";
-    if (isDbtShapedTurn({ openTabs, tabKind })) {
-      try {
+        const includeDbtRules = isDbtShapedTurn({ openTabs, tabKind });
         const dbtTabs = (openTabs ?? []).filter(t => t.dbtProjectId);
         const activeDbtProjectId = dbtTabs.find(t => t.isActive)?.dbtProjectId;
         const distinctProjectIds = new Set(dbtTabs.map(t => t.dbtProjectId));
-        // No active dbt tab and several distinct projects open: falling back
-        // to dbtTabs[0] would pick a project by arbitrary tab order and tell
-        // the model its rules are binding while the user edits another one.
-        // Resolve nothing instead — read_dbt_project_tree still returns the
-        // right project's rules inline once the agent orients.
         const dbtProjectId =
           activeDbtProjectId ??
           (distinctProjectIds.size === 1
             ? dbtTabs[0]?.dbtProjectId
             : undefined);
-        dbtRulesBlock = await resolveDbtRulesBlockForTurn({
+        const guidance = await prepareAgentTurnGuidance({
           workspaceId,
           userId: actorId,
+          userText: lastUserText,
+          includeDbtRules,
           dbtProjectId,
         });
+        skillsBlock = guidance.skillsBlock;
+        dbtRulesBlock = guidance.dbtRulesBlock;
       } catch (err) {
-        logger.warn("dbt rules injection skipped", { error: err });
+        logger.warn("Turn guidance injection skipped", { error: err });
       }
     }
 

--- a/api/src/routes/custom-prompt.ts
+++ b/api/src/routes/custom-prompt.ts
@@ -11,6 +11,7 @@ import {
   errorJson,
   jsonContent,
 } from "../openapi/core";
+import { prepareAgentTurnGuidance } from "../services/agent-turn-preparation.service";
 
 const logger = loggers.workspace();
 
@@ -20,6 +21,12 @@ const WorkspaceParam = z.object({
   workspaceId: z
     .string()
     .openapi({ param: { name: "workspaceId", in: "path" } }),
+});
+
+const TurnGuidanceBody = z.object({
+  userText: z.string().min(1).max(100_000),
+  includeDbtRules: z.boolean().default(false),
+  dbtProjectId: z.string().optional(),
 });
 
 // Apply unified auth middleware to all custom prompt routes
@@ -150,6 +157,63 @@ customPromptRoutes.openapi(
             error instanceof Error
               ? error.message
               : "Failed to read custom prompt",
+        },
+        500,
+      );
+    }
+  },
+);
+
+customPromptRoutes.openapi(
+  createRoute({
+    method: "post",
+    path: "/turn-guidance",
+    tags: ["Custom Prompt"],
+    summary: "Prepare budgeted agent guidance for one turn",
+    security: AUTH_SECURITY,
+    request: {
+      params: WorkspaceParam,
+      body: {
+        required: true,
+        content: { "application/json": { schema: TurnGuidanceBody } },
+      },
+    },
+    responses: {
+      200: jsonContent(
+        z.object({
+          success: z.literal(true),
+          skillsBlock: z.string(),
+          dbtRulesBlock: z.string(),
+        }),
+        "Prepared turn guidance.",
+      ),
+      400: errorJson("Invalid request"),
+      403: errorJson("Access denied"),
+      500: errorJson("Failed to prepare guidance"),
+    },
+  }),
+  async c => {
+    try {
+      const { workspaceId } = c.req.valid("param");
+      const user = c.get("user");
+      const input = c.req.valid("json");
+      const guidance = await prepareAgentTurnGuidance({
+        workspaceId,
+        userId: user ? String(user.id) : undefined,
+        userText: input.userText,
+        includeDbtRules: input.includeDbtRules,
+        dbtProjectId: input.dbtProjectId,
+      });
+      return c.json({ success: true as const, ...guidance }, 200);
+    } catch (error) {
+      logger.error("Error preparing turn guidance", { error });
+      return c.json(
+        {
+          success: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Failed to prepare guidance",
         },
         500,
       );

--- a/api/src/routes/mcp-server.routes.ts
+++ b/api/src/routes/mcp-server.routes.ts
@@ -34,6 +34,7 @@ import { StatelessMcpTransport } from "../mcp/stateless-transport";
 import { ACP_MCP_CLIENT_ID } from "../auth/mcp-oauth.service";
 import type { AuthEnv } from "../openapi/core";
 import { loggers } from "../logging";
+import { resolveAcpPlanGrants } from "../services/acp-plan-grant.service";
 
 const logger = loggers.api("mcp-server");
 
@@ -135,11 +136,20 @@ mcpProtocolRoutes.post(
     // Desktop ACP attaches via a fixed OAuth client. Those sessions already
     // have a live iframe — hide headless create_preview_token / render_app.
     const acpDesktop = c.get("mcpOAuthClientId") === ACP_MCP_CLIENT_ID;
+    const capabilityGrants =
+      acpDesktop && user
+        ? await resolveAcpPlanGrants({
+            workspaceId,
+            userId: String(user.id),
+            agentSessionId: c.get("mcpAgentSessionId"),
+          })
+        : undefined;
     const mcpContext = {
       workspaceId,
       userId: user ? String(user.id) : undefined,
       scopes,
       acpDesktop,
+      capabilityGrants,
     };
     const server = buildMakoMcpServer(
       mcpContext,

--- a/api/src/routes/workspaces.ts
+++ b/api/src/routes/workspaces.ts
@@ -15,6 +15,10 @@ import {
 } from "../auth/mcp-oauth.service";
 import { workspaceService } from "../services/workspace.service";
 import {
+  approveAcpPlanGrant,
+  revokeAcpPlanGrant,
+} from "../services/acp-plan-grant.service";
+import {
   requireWorkspace,
   requireWorkspaceRole,
   optionalWorkspace,
@@ -51,6 +55,23 @@ const AddMemberBody = jsonBody(
 const UpdateMemberRoleBody = jsonBody(z.object({ role: MemberRole }));
 const CreateInviteBody = jsonBody(
   z.object({ email: z.string(), role: MemberRole }),
+);
+const AcpPlanDecisionBody = jsonBody(
+  z.object({
+    agentSessionId: z.string().uuid(),
+    decision: z.enum(["approve", "request_changes", "cancel"]),
+    planMarkdown: z.string().max(100_000).optional(),
+    grants: z
+      .array(
+        z.enum([
+          "artifact-write",
+          "warehouse-write",
+          "git-write",
+          "schedule-write",
+        ]),
+      )
+      .optional(),
+  }),
 );
 
 const WorkspaceSchema = z
@@ -1604,6 +1625,7 @@ workspaceRoutes.openapi(
           accessToken: tokens.accessToken,
           expiresIn: tokens.expiresInSeconds,
           scopes: tokens.scopes,
+          agentSessionId: tokens.agentSessionId,
           mcpPath: "/api/mcp",
           authorization: `Bearer ${tokens.accessToken}`,
         },
@@ -1620,6 +1642,72 @@ workspaceRoutes.openapi(
         },
         500,
       );
+    }
+  },
+);
+
+// POST /api/workspaces/:id/acp-plan-grant — approve/revoke Desktop task grants
+workspaceRoutes.openapi(
+  createRoute({
+    method: "post",
+    path: "/{id}/acp-plan-grant",
+    tags: ["Workspaces"],
+    summary: "Apply a Desktop ACP plan decision",
+    security: AUTH_SECURITY,
+    middleware: [unifiedAuthMiddleware, requireWorkspace] as const,
+    request: { params: IdParam, body: AcpPlanDecisionBody },
+    responses: { ...OPEN_RESPONSES },
+  }),
+  async c => {
+    try {
+      if (!isSessionAuth(c)) {
+        return c.json(
+          { success: false, error: "Plan decisions require a browser session" },
+          403,
+        );
+      }
+      const workspace = c.get("workspace");
+      const user = c.get("user");
+      if (!user) {
+        return c.json({ success: false, error: "Unauthorized" }, 401);
+      }
+      if (c.req.param("id") !== workspace._id.toString()) {
+        return c.json({ success: false, error: "Workspace ID mismatch" }, 400);
+      }
+      const input = c.req.valid("json");
+      if (input.decision === "approve") {
+        if (!input.planMarkdown?.trim()) {
+          return c.json(
+            {
+              success: false,
+              error: "An approved plan must include planMarkdown",
+            },
+            400,
+          );
+        }
+        const grant = await approveAcpPlanGrant({
+          workspaceId: workspace._id.toString(),
+          userId: String(user.id),
+          agentSessionId: input.agentSessionId,
+          planMarkdown: input.planMarkdown,
+          grants: input.grants ?? ["artifact-write"],
+        });
+        return c.json({ success: true, data: grant });
+      }
+      await revokeAcpPlanGrant({
+        workspaceId: workspace._id.toString(),
+        userId: String(user.id),
+        agentSessionId: input.agentSessionId,
+      });
+      return c.json({ success: true });
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Failed to apply plan decision";
+      const status = /not found/i.test(message) ? 404 : 500;
+      logger.error("Error applying ACP plan decision", { error });
+      return c.json({ success: false, error: message }, status);
     }
   },
 );

--- a/api/src/services/acp-plan-grant.service.ts
+++ b/api/src/services/acp-plan-grant.service.ts
@@ -1,0 +1,93 @@
+import { createHash } from "node:crypto";
+import type { CapabilityGrant } from "@mako/agent-tools";
+
+import { AcpPlanGrant } from "../database/acp-plan-grant-schema";
+import { McpOAuthToken } from "../database/mcp-oauth-schema";
+import { ACP_MCP_CLIENT_ID } from "../auth/mcp-oauth.service";
+
+const PLAN_GRANT_TTL_MS = 2 * 60 * 60 * 1000;
+
+function planDigest(planMarkdown: string): string {
+  return createHash("sha256").update(planMarkdown).digest("hex");
+}
+
+export async function assertAcpAgentSessionOwner(input: {
+  workspaceId: string;
+  userId: string;
+  agentSessionId: string;
+}): Promise<void> {
+  const ownsSession = await McpOAuthToken.exists({
+    workspaceId: input.workspaceId,
+    userId: input.userId,
+    clientId: ACP_MCP_CLIENT_ID,
+    agentSessionId: input.agentSessionId,
+    refreshExpiresAt: { $gt: new Date() },
+  });
+  if (!ownsSession) {
+    throw new Error("ACP agent session not found");
+  }
+}
+
+export async function approveAcpPlanGrant(input: {
+  workspaceId: string;
+  userId: string;
+  agentSessionId: string;
+  planMarkdown: string;
+  grants: CapabilityGrant[];
+}): Promise<{
+  grants: CapabilityGrant[];
+  expiresAt: Date;
+}> {
+  await assertAcpAgentSessionOwner(input);
+  const expiresAt = new Date(Date.now() + PLAN_GRANT_TTL_MS);
+  const grants = [...new Set(input.grants)];
+  await AcpPlanGrant.findOneAndUpdate(
+    { agentSessionId: input.agentSessionId },
+    {
+      $set: {
+        workspaceId: input.workspaceId,
+        userId: input.userId,
+        planDigest: planDigest(input.planMarkdown),
+        grants,
+        status: "approved",
+        expiresAt,
+      },
+    },
+    { upsert: true, new: true },
+  );
+  return { grants, expiresAt };
+}
+
+export async function revokeAcpPlanGrant(input: {
+  workspaceId: string;
+  userId: string;
+  agentSessionId: string;
+}): Promise<void> {
+  await assertAcpAgentSessionOwner(input);
+  await AcpPlanGrant.updateOne(
+    {
+      workspaceId: input.workspaceId,
+      userId: input.userId,
+      agentSessionId: input.agentSessionId,
+    },
+    { $set: { status: "revoked", expiresAt: new Date() } },
+  );
+}
+
+export async function resolveAcpPlanGrants(input: {
+  workspaceId: string;
+  userId: string;
+  agentSessionId?: string;
+}): Promise<CapabilityGrant[]> {
+  if (!input.agentSessionId) return [];
+  const grant = await AcpPlanGrant.findOne({
+    workspaceId: input.workspaceId,
+    userId: input.userId,
+    agentSessionId: input.agentSessionId,
+    status: "approved",
+    expiresAt: { $gt: new Date() },
+  })
+    .select({ grants: 1 })
+    .lean();
+  return grant?.grants ?? [];
+}

--- a/api/src/services/agent-turn-preparation.service.ts
+++ b/api/src/services/agent-turn-preparation.service.ts
@@ -1,0 +1,56 @@
+import { resolveDbtRulesBlockForTurn } from "../dbt/dbt-rules-turn.service";
+import { retrieveRelevantSkills } from "./skills.service";
+
+export const MAX_SKILL_EXCERPT_CHARS = 2_500;
+
+export function renderCompactSkillBlock(
+  retrieval: Pick<
+    Awaited<ReturnType<typeof retrieveRelevantSkills>>,
+    "injected"
+  >,
+): string {
+  const skill = retrieval.injected[0];
+  if (!skill?.body.trim()) return "";
+  const body =
+    skill.body.length <= MAX_SKILL_EXCERPT_CHARS
+      ? skill.body
+      : `${skill.body.slice(0, MAX_SKILL_EXCERPT_CHARS)}\n\n[Excerpt truncated. Use load_skill("${skill.name}") or read_skill_resource for the complete guide.]`;
+  return [
+    "\n\n---\n",
+    "### Auto-loaded skill",
+    `\`${skill.name}\` — ${skill.loadWhen}`,
+    "",
+    body,
+  ].join("\n");
+}
+
+export interface AgentTurnGuidance {
+  skillsBlock: string;
+  dbtRulesBlock: string;
+}
+
+/**
+ * Shared, budgeted turn preparation for native Chat and Desktop ACP.
+ */
+export async function prepareAgentTurnGuidance(input: {
+  workspaceId: string;
+  userId?: string;
+  userText: string;
+  includeDbtRules: boolean;
+  dbtProjectId?: string;
+}): Promise<AgentTurnGuidance> {
+  const [retrieval, dbtRulesBlock] = await Promise.all([
+    retrieveRelevantSkills(input.workspaceId, input.userText).catch(() => null),
+    input.includeDbtRules
+      ? resolveDbtRulesBlockForTurn({
+          workspaceId: input.workspaceId,
+          userId: input.userId,
+          dbtProjectId: input.dbtProjectId,
+        }).catch(() => "")
+      : Promise.resolve(""),
+  ]);
+  return {
+    skillsBlock: retrieval ? renderCompactSkillBlock(retrieval) : "",
+    dbtRulesBlock,
+  };
+}

--- a/app/src/api/schema.d.ts
+++ b/app/src/api/schema.d.ts
@@ -607,6 +607,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/workspaces/{id}/acp-plan-grant": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Apply a Desktop ACP plan decision */
+        post: operations["post_api_workspaces_id_acp_plan_grant"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/workspaces/{id}/mcp-connections": {
         parameters: {
             query?: never;
@@ -1491,6 +1508,23 @@ export interface paths {
         /** Update the workspace custom prompt */
         put: operations["put_api_workspaces_workspaceId_custom_prompt"];
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workspaces/{workspaceId}/custom-prompt/turn-guidance": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Prepare budgeted agent guidance for one turn */
+        post: operations["post_api_workspaces_workspaceId_custom_prompt_turn_guidance"];
         delete?: never;
         options?: never;
         head?: never;
@@ -6772,6 +6806,57 @@ export interface operations {
             };
         };
     };
+    post_api_workspaces_id_acp_plan_grant: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** Format: uuid */
+                    agentSessionId: string;
+                    /** @enum {string} */
+                    decision: "approve" | "request_changes" | "cancel";
+                    planMarkdown?: string;
+                    grants?: ("artifact-write" | "warehouse-write" | "git-write" | "schedule-write")[];
+                };
+            };
+        };
+        responses: {
+            /** @description Successful response */
+            "2XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericJsonResponse"] & (Record<string, never> | null);
+                };
+            };
+            /** @description Invalid request */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal server error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
     get_api_workspaces_id_mcp_connections: {
         parameters: {
             query?: never;
@@ -9672,6 +9757,69 @@ export interface operations {
                 };
             };
             /** @description Failed to update custom prompt */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    post_api_workspaces_workspaceId_custom_prompt_turn_guidance: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    userText: string;
+                    /** @default false */
+                    includeDbtRules?: boolean;
+                    dbtProjectId?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Prepared turn guidance. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {boolean} */
+                        success: true;
+                        skillsBlock: string;
+                        dbtRulesBlock: string;
+                    };
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Access denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Failed to prepare guidance */
             500: {
                 headers: {
                     [name: string]: unknown;

--- a/app/src/components/PlanCard.tsx
+++ b/app/src/components/PlanCard.tsx
@@ -79,6 +79,8 @@ export const PlanCard: React.FC<PlanCardProps> = ({
       ? plan.status
       : output?.decision;
   const pending = !decision && !isStreaming;
+  const requiredCapabilities =
+    plan?.input.requiredCapabilities ?? input?.requiredCapabilities ?? [];
 
   const openTab = () => {
     if (!toolCallId) return;
@@ -150,6 +152,18 @@ export const PlanCard: React.FC<PlanCardProps> = ({
                 : `Plan · ${stepCount} step${stepCount === 1 ? "" : "s"}`}
           </Typography>
         </Box>
+        {requiredCapabilities.length > 0 && (
+          <Tooltip
+            title={`Approval grants this task: ${requiredCapabilities.join(", ")}`}
+            placement="top"
+          >
+            <Chip
+              size="small"
+              label={requiredCapabilities.join(" · ")}
+              variant="outlined"
+            />
+          </Tooltip>
+        )}
         {decision && (
           <Chip
             size="small"

--- a/app/src/lib/acp-client.ts
+++ b/app/src/lib/acp-client.ts
@@ -111,6 +111,8 @@ export const acpClient = {
     mcpUrl?: string;
     mcpAuthorization?: string;
     mcpServerName?: string;
+    makoAgentSessionId?: string;
+    makoWorkspaceId?: string;
     /** Lean workspace guidance for Claude systemPrompt.append (not full skills). */
     systemPromptAppend?: string;
     /** Preferred Claude/Codex model (`fable`, `sonnet`, …). */

--- a/app/src/lib/acp-continuity.ts
+++ b/app/src/lib/acp-continuity.ts
@@ -73,13 +73,16 @@ export function prependAcpPromptLayers(args: {
   userText: string;
   continuitySeed?: string;
   uiContext?: string;
+  turnGuidance?: string;
 }): string {
   const trimmed = args.userText.trim();
   const layers: string[] = [];
   const continuity = args.continuitySeed?.trim();
   const ui = args.uiContext?.trim();
+  const guidance = args.turnGuidance?.trim();
   if (continuity) layers.push(continuity);
   if (ui) layers.push(ui);
+  if (guidance) layers.push(guidance);
   if (layers.length === 0) return trimmed;
   return `${layers.join("\n\n")}\n\n[User message]\n${trimmed}`;
 }

--- a/app/src/lib/acp-types.ts
+++ b/app/src/lib/acp-types.ts
@@ -98,6 +98,10 @@ export interface AcpSessionInfo {
   cwd: string;
   createdAt: string;
   updatedAt: string;
+  /** API-side identity bound to this session's Mako MCP Bearer. */
+  makoAgentSessionId?: string;
+  /** Workspace bound to this session's Mako MCP Bearer. */
+  makoWorkspaceId?: string;
   busy: boolean;
   /** True when Mako `/api/mcp` was attached on session/new. */
   makoMcpAttached?: boolean;

--- a/app/src/lib/acp-ui-context.ts
+++ b/app/src/lib/acp-ui-context.ts
@@ -13,6 +13,47 @@ import { selectActiveExplorer, useUIStore } from "../store/uiStore";
 import { useAppStore } from "../store/appStore";
 
 const MAX_CONTEXT_CHARS = 6_000;
+const DBT_TAB_KINDS = new Set([
+  "dbt-file",
+  "dbt-job",
+  "dbt-console",
+  "dbt-runs",
+]);
+
+export function getAcpDbtFocus(): {
+  active: boolean;
+  projectId?: string;
+} {
+  const consoleStore = useConsoleStore.getState();
+  const dbtTabs = Object.values(consoleStore.tabs).filter(
+    tab => tab.kind && DBT_TAB_KINDS.has(tab.kind),
+  );
+  if (dbtTabs.length === 0) return { active: false };
+  const activeTab = consoleStore.activeTabId
+    ? consoleStore.tabs[consoleStore.activeTabId]
+    : undefined;
+  const activeProjectId =
+    activeTab?.kind && DBT_TAB_KINDS.has(activeTab.kind)
+      ? activeTab.metadata?.projectId
+      : undefined;
+  const projectIds = new Set(
+    dbtTabs
+      .map(tab => tab.metadata?.projectId)
+      .filter(
+        (projectId): projectId is string => typeof projectId === "string",
+      ),
+  );
+  const projectId =
+    typeof activeProjectId === "string"
+      ? activeProjectId
+      : projectIds.size === 1
+        ? [...projectIds][0]
+        : undefined;
+  return {
+    active: true,
+    projectId,
+  };
+}
 
 export function buildAcpUiContextBlock(args: {
   workspaceId?: string;
@@ -88,6 +129,7 @@ export function buildAcpUiContextBlock(args: {
           id: t.id,
           dashboardId: t.dashboardId,
           notebookId: t.notebookId,
+          dbtProjectId: t.dbtProjectId,
         })),
       )}`,
     );

--- a/app/src/lib/desktop-acp-bridge.ts
+++ b/app/src/lib/desktop-acp-bridge.ts
@@ -2,7 +2,10 @@
  * Polls Local Agent for mako-desktop MCP jobs and fulfills them in the
  * Desktop/web renderer (apps, consoles, HITL clarify/plan cards).
  */
-import { summarizePreviewErrors } from "@mako/agent-tools";
+import {
+  summarizePreviewErrors,
+  type CapabilityGrant,
+} from "@mako/agent-tools";
 import { executeAppAgentTool } from "../app-runtime/agent-tools";
 import { useAppStore } from "../store/appStore";
 import { useConsoleStore } from "../store/consoleStore";
@@ -10,6 +13,7 @@ import {
   useDesktopHitlStore,
   type DesktopHitlToolName,
 } from "../store/desktopHitlStore";
+import { useAcpStore } from "../store/acpStore";
 import { localAgentClient } from "./local-agent-client";
 
 type BridgeToolName =
@@ -22,6 +26,8 @@ interface BridgeJob {
   id: string;
   tool: BridgeToolName;
   arguments: Record<string, unknown>;
+  agentSessionId?: string;
+  workspaceId?: string;
 }
 
 interface ClaimEnvelope {
@@ -85,10 +91,82 @@ export async function completeDesktopHitlJob(
   jobId: string,
   result: unknown,
 ): Promise<void> {
-  await localAgentClient.post(
-    `/desktop/bridge/jobs/${encodeURIComponent(jobId)}/result`,
-    { ok: true, result },
-  );
+  const pending = useDesktopHitlStore.getState().pending;
+  let approvedGrantContext:
+    | { workspaceId: string; agentSessionId: string }
+    | undefined;
+  if (
+    pending?.jobId === jobId &&
+    pending.toolName === "submit_plan" &&
+    result &&
+    typeof result === "object"
+  ) {
+    const output = result as {
+      decision?: unknown;
+      editedPlan?: { planMarkdown?: unknown };
+    };
+    if (
+      output.decision === "approve" ||
+      output.decision === "request_changes" ||
+      output.decision === "cancel"
+    ) {
+      if (!pending.agentSessionId || !pending.workspaceId) {
+        throw new Error(
+          "This plan came from an outdated Local Agent session. Restart the local session and submit the plan again.",
+        );
+      }
+      const editedPlanMarkdown = output.editedPlan?.planMarkdown;
+      const originalPlanMarkdown = pending.input.planMarkdown;
+      const allowedGrants = new Set<CapabilityGrant>([
+        "artifact-write",
+        "warehouse-write",
+        "git-write",
+        "schedule-write",
+      ]);
+      const requestedGrants = Array.isArray(pending.input.requiredCapabilities)
+        ? pending.input.requiredCapabilities.filter(
+            (grant): grant is CapabilityGrant =>
+              typeof grant === "string" &&
+              allowedGrants.has(grant as CapabilityGrant),
+          )
+        : undefined;
+      await useAcpStore.getState().applyPlanDecision({
+        workspaceId: pending.workspaceId,
+        agentSessionId: pending.agentSessionId,
+        decision: output.decision,
+        planMarkdown:
+          typeof editedPlanMarkdown === "string"
+            ? editedPlanMarkdown
+            : typeof originalPlanMarkdown === "string"
+              ? originalPlanMarkdown
+              : undefined,
+        grants: requestedGrants,
+      });
+      if (output.decision === "approve") {
+        approvedGrantContext = {
+          workspaceId: pending.workspaceId,
+          agentSessionId: pending.agentSessionId,
+        };
+      }
+    }
+  }
+  try {
+    await localAgentClient.post(
+      `/desktop/bridge/jobs/${encodeURIComponent(jobId)}/result`,
+      { ok: true, result },
+    );
+  } catch (error) {
+    if (approvedGrantContext) {
+      await useAcpStore
+        .getState()
+        .applyPlanDecision({
+          ...approvedGrantContext,
+          decision: "cancel",
+        })
+        .catch(() => undefined);
+    }
+    throw error;
+  }
   useDesktopHitlStore.getState().clearPending(jobId);
 }
 
@@ -141,6 +219,8 @@ async function pollLoop(): Promise<void> {
               ? job.arguments
               : {},
           createdAt: Date.now(),
+          agentSessionId: job.agentSessionId,
+          workspaceId: job.workspaceId,
         });
         // Completes when Chat dock cards call completeDesktopHitlJob.
         continue;

--- a/app/src/lib/local-acp-chat.ts
+++ b/app/src/lib/local-acp-chat.ts
@@ -33,7 +33,7 @@ import type { AcpProviderId } from "./acp-types";
 import { maybeFocusAppFromAcpTool } from "./acp-app-focus";
 import { maybeFocusConsoleFromAcpTool } from "./acp-console-focus";
 import { maybeFocusNotebookFromAcpTool } from "./acp-notebook-focus";
-import { buildAcpUiContextBlock } from "./acp-ui-context";
+import { buildAcpUiContextBlock, getAcpDbtFocus } from "./acp-ui-context";
 import {
   buildAcpContinuitySeed,
   prependAcpPromptLayers,
@@ -396,6 +396,18 @@ export async function runLocalAcpChatTurn(
     chatId,
     modelId,
   });
+  const dbtFocus = getAcpDbtFocus();
+  const turnGuidance = workspaceId
+    ? await useAcpStore
+        .getState()
+        .fetchTurnGuidance({
+          workspaceId,
+          userText: trimmed,
+          includeDbtRules: dbtFocus.active,
+          dbtProjectId: dbtFocus.projectId,
+        })
+        .catch(() => "")
+    : "";
 
   const runAgainstSession = async (forceNew: boolean) => {
     const ensured = await ensureAcpSessionForProvider(
@@ -406,6 +418,9 @@ export async function runLocalAcpChatTurn(
     );
     sessionId = ensured.sessionId;
     useAcpStore.getState().ensureEventSubscription(sessionId);
+    // Fail closed across turns: a missed end-of-turn revoke (renderer/network
+    // interruption) must never carry an old plan grant into this request.
+    await useAcpStore.getState().revokeSessionGrant(sessionId);
 
     const continuitySeed =
       ensured.isFresh && priorMessages.length > 0
@@ -415,6 +430,7 @@ export async function runLocalAcpChatTurn(
       userText: trimmed,
       continuitySeed,
       uiContext,
+      turnGuidance,
     });
 
     // Ignore any backlog that still arrives (older Local Agents always replay).
@@ -572,6 +588,10 @@ export async function runLocalAcpChatTurn(
         );
       });
     } finally {
+      await useAcpStore
+        .getState()
+        .revokeSessionGrant(activeSessionId)
+        .catch(() => undefined);
       signal?.removeEventListener("abort", onAbort);
       unsub();
     }

--- a/app/src/lib/mako-mcp-attach.ts
+++ b/app/src/lib/mako-mcp-attach.ts
@@ -15,6 +15,7 @@ export interface MakoMcpAttachCredentials {
   mcpAuthorization: string;
   expiresIn: number;
   mcpServerName: string;
+  agentSessionId: string;
 }
 
 /** Absolute MCP URL that the Local Agent (on the user's machine) can reach. */
@@ -46,6 +47,7 @@ export async function mintMakoMcpAttach(
       accessToken?: string;
       authorization?: string;
       expiresIn?: number;
+      agentSessionId?: string;
       mcpPath?: string;
     };
     error?: string;
@@ -58,12 +60,16 @@ export async function mintMakoMcpAttach(
   if (!authorization) {
     throw new Error(response?.error || "Failed to mint Mako MCP access token");
   }
+  if (!data?.agentSessionId) {
+    throw new Error("Mako MCP access token is missing its agent session");
+  }
 
   return {
     mcpUrl: resolveAbsoluteMcpUrl(),
     mcpAuthorization: authorization,
     expiresIn: data?.expiresIn ?? 0,
     mcpServerName: MAKO_WORKSPACE_MCP_NAME,
+    agentSessionId: data.agentSessionId,
   };
 }
 

--- a/app/src/store/acpStore.ts
+++ b/app/src/store/acpStore.ts
@@ -20,6 +20,7 @@ import {
 } from "../lib/mako-mcp-attach";
 import { fetchWorkspaceGuidanceForAcp } from "../lib/acp-system-append";
 import { startDesktopAcpCliLogin } from "../lib/desktop";
+import { apiClient } from "../lib/api-client";
 import {
   sanitizeAcpUserError,
   shouldClearAcpAuthGuidance,
@@ -130,6 +131,22 @@ interface AcpState {
     outcome: "cancelled" | "selected",
     optionId?: string,
   ) => Promise<void>;
+  applyPlanDecision: (input: {
+    workspaceId: string;
+    agentSessionId: string;
+    decision: "approve" | "request_changes" | "cancel";
+    planMarkdown?: string;
+    grants?: Array<
+      "artifact-write" | "warehouse-write" | "git-write" | "schedule-write"
+    >;
+  }) => Promise<void>;
+  revokeSessionGrant: (sessionId: string) => Promise<void>;
+  fetchTurnGuidance: (input: {
+    workspaceId: string;
+    userText: string;
+    includeDbtRules: boolean;
+    dbtProjectId?: string;
+  }) => Promise<string>;
   /** Start SSE for the active session (idempotent per session). */
   ensureEventSubscription: (sessionId: string) => void;
 }
@@ -189,7 +206,18 @@ export const useAcpStore = create<AcpState>()(
       try {
         const sessions = await acpClient.listSessions();
         set(s => {
-          s.sessions = sessions;
+          const existingById = new Map(
+            s.sessions.map(session => [session.id, session]),
+          );
+          s.sessions = sessions.map(session => ({
+            ...session,
+            makoAgentSessionId:
+              existingById.get(session.id)?.makoAgentSessionId ??
+              session.makoAgentSessionId,
+            makoWorkspaceId:
+              existingById.get(session.id)?.makoWorkspaceId ??
+              session.makoWorkspaceId,
+          }));
         });
       } catch (error) {
         set(s => {
@@ -367,6 +395,57 @@ export const useAcpStore = create<AcpState>()(
       });
     },
 
+    applyPlanDecision: async input => {
+      await apiClient.request(
+        `/workspaces/${encodeURIComponent(input.workspaceId)}/acp-plan-grant`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            agentSessionId: input.agentSessionId,
+            decision: input.decision,
+            planMarkdown: input.planMarkdown,
+            grants: input.grants,
+          }),
+        },
+      );
+    },
+
+    revokeSessionGrant: async sessionId => {
+      const session = get().sessions.find(item => item.id === sessionId);
+      if (!session?.makoAgentSessionId || !session.makoWorkspaceId) return;
+      await get().applyPlanDecision({
+        workspaceId: session.makoWorkspaceId,
+        agentSessionId: session.makoAgentSessionId,
+        decision: "cancel",
+      });
+    },
+
+    fetchTurnGuidance: async input => {
+      const response = await apiClient.request<{
+        success: boolean;
+        skillsBlock?: string;
+        dbtRulesBlock?: string;
+      }>(
+        `/workspaces/${encodeURIComponent(input.workspaceId)}/custom-prompt/turn-guidance`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            userText: input.userText,
+            includeDbtRules: input.includeDbtRules,
+            dbtProjectId: input.dbtProjectId,
+          }),
+        },
+      );
+      return [response.skillsBlock, response.dbtRulesBlock]
+        .filter(
+          (section): section is string =>
+            typeof section === "string" && section.trim().length > 0,
+        )
+        .join("\n\n");
+    },
+
     createSession: async options => {
       const { selectedProviderId, cwdDraft } = get();
       const requireMakoMcp = options?.requireMakoMcp !== false;
@@ -394,6 +473,8 @@ export const useAcpStore = create<AcpState>()(
           mcpUrl: creds.mcpUrl,
           mcpAuthorization: creds.mcpAuthorization,
           mcpServerName: creds.mcpServerName,
+          makoAgentSessionId: creds.agentSessionId,
+          makoWorkspaceId: workspaceId,
           systemPromptAppend,
           model: options?.model?.trim() || undefined,
         });
@@ -402,19 +483,25 @@ export const useAcpStore = create<AcpState>()(
             "Local session started without Mako data tools. Restart Local Agent from this branch and try again.",
           );
         }
+        const boundSession: AcpSessionInfo = {
+          ...session,
+          makoAgentSessionId:
+            session.makoAgentSessionId ?? creds.agentSessionId,
+          makoWorkspaceId: session.makoWorkspaceId ?? workspaceId,
+        };
         set(s => {
           s.sessions = [
-            session,
-            ...s.sessions.filter(x => x.id !== session.id),
+            boundSession,
+            ...s.sessions.filter(x => x.id !== boundSession.id),
           ];
-          s.activeSessionId = session.id;
-          s.messagesBySession[session.id] ??= [];
+          s.activeSessionId = boundSession.id;
+          s.messagesBySession[boundSession.id] ??= [];
           s.error = null;
         });
         // Refresh status so Chat's model picker picks up availableModels.
         void get().refreshStatus();
-        get().ensureEventSubscription(session.id);
-        return session;
+        get().ensureEventSubscription(boundSession.id);
+        return boundSession;
       } catch (error) {
         let message =
           error instanceof Error ? error.message : "Failed to create session";

--- a/app/src/store/desktopHitlStore.ts
+++ b/app/src/store/desktopHitlStore.ts
@@ -11,6 +11,8 @@ export interface DesktopHitlPending {
   toolName: DesktopHitlToolName;
   input: Record<string, unknown>;
   createdAt: number;
+  agentSessionId?: string;
+  workspaceId?: string;
 }
 
 interface DesktopHitlState {

--- a/docs/src/openapi/mako-api.json
+++ b/docs/src/openapi/mako-api.json
@@ -4497,6 +4497,119 @@
         "operationId": "post_api_workspaces_id_mcp_access_token"
       }
     },
+    "/api/workspaces/{id}/acp-plan-grant": {
+      "post": {
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Apply a Desktop ACP plan decision",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "agentSessionId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "decision": {
+                    "type": "string",
+                    "enum": [
+                      "approve",
+                      "request_changes",
+                      "cancel"
+                    ]
+                  },
+                  "planMarkdown": {
+                    "type": "string",
+                    "maxLength": 100000
+                  },
+                  "grants": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "artifact-write",
+                        "warehouse-write",
+                        "git-write",
+                        "schedule-write"
+                      ]
+                    }
+                  }
+                },
+                "required": [
+                  "agentSessionId",
+                  "decision"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "2XX": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GenericJsonResponse"
+                    },
+                    {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "post_api_workspaces_id_acp_plan_grant"
+      }
+    },
     "/api/workspaces/{id}/mcp-connections": {
       "get": {
         "tags": [
@@ -9913,6 +10026,121 @@
           }
         },
         "operationId": "put_api_workspaces_workspaceId_custom_prompt"
+      }
+    },
+    "/api/workspaces/{workspaceId}/custom-prompt/turn-guidance": {
+      "post": {
+        "tags": [
+          "Custom Prompt"
+        ],
+        "summary": "Prepare budgeted agent guidance for one turn",
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "workspaceId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userText": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 100000
+                  },
+                  "includeDbtRules": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "dbtProjectId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "userText"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Prepared turn guidance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "skillsBlock": {
+                      "type": "string"
+                    },
+                    "dbtRulesBlock": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "skillsBlock",
+                    "dbtRulesBlock"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Failed to prepare guidance",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "post_api_workspaces_workspaceId_custom_prompt_turn_guidance"
       }
     },
     "/api/workspaces/{workspaceId}/custom-prompt/reset": {

--- a/packages/agent-tools/src/capabilities/dbt-capabilities.ts
+++ b/packages/agent-tools/src/capabilities/dbt-capabilities.ts
@@ -1,0 +1,360 @@
+/**
+ * Transport-neutral dbt capability metadata.
+ *
+ * Tool implementations stay server-side. This registry is the shared source
+ * for mode membership, MCP exposure, authorization, token packs, and UI
+ * result semantics.
+ */
+
+export type AgentSurface = "in-chat" | "desktop-acp" | "external-mcp";
+
+export type CapabilityRisk = "read" | "write" | "destructive";
+
+export type CapabilityGrant =
+  | "artifact-write"
+  | "git-write"
+  | "schedule-write"
+  | "warehouse-write";
+
+export const CAPABILITY_GRANTS = [
+  "artifact-write",
+  "git-write",
+  "schedule-write",
+  "warehouse-write",
+] as const satisfies readonly CapabilityGrant[];
+
+export type DbtCapabilityPack =
+  | "dbt-orient"
+  | "dbt-edit"
+  | "dbt-validation"
+  | "dbt-projects"
+  | "dbt-git-read"
+  | "dbt-git-write"
+  | "dbt-jobs";
+
+export type CapabilityResultKind =
+  | "data"
+  | "artifact"
+  | "run"
+  | "ui-effect";
+
+export interface DbtCapabilityDefinition {
+  name: string;
+  domain: "dbt";
+  pack: DbtCapabilityPack;
+  risk: CapabilityRisk;
+  requiredGrant?: CapabilityGrant;
+  surfaces: readonly AgentSurface[];
+  resultKind: CapabilityResultKind;
+  requiresQueryAccess?: boolean;
+  /**
+   * Long-running validation must move to the run registry before MCP exposure.
+   */
+  requiresAsyncMcp?: boolean;
+}
+
+const ALL_AGENT_SURFACES = [
+  "in-chat",
+  "desktop-acp",
+  "external-mcp",
+] as const satisfies readonly AgentSurface[];
+
+const PRODUCT_AGENT_SURFACES = [
+  "in-chat",
+  "desktop-acp",
+] as const satisfies readonly AgentSurface[];
+
+const define = (
+  definition: Omit<DbtCapabilityDefinition, "domain">,
+): DbtCapabilityDefinition => ({ domain: "dbt", ...definition });
+
+export const DBT_CAPABILITIES = [
+  define({
+    name: "read_dbt_project_tree",
+    pack: "dbt-orient",
+    risk: "read",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "data",
+  }),
+  define({
+    name: "read_dbt_file",
+    pack: "dbt-orient",
+    risk: "read",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "data",
+  }),
+  define({
+    name: "create_dbt_file",
+    pack: "dbt-edit",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "modify_dbt_file",
+    pack: "dbt-edit",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "edit_dbt_file",
+    pack: "dbt-edit",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "delete_dbt_file",
+    pack: "dbt-edit",
+    risk: "destructive",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "dbt_list_recoverable_files",
+    pack: "dbt-edit",
+    risk: "read",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "data",
+  }),
+  define({
+    name: "dbt_restore_file",
+    pack: "dbt-edit",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "dbt_parse",
+    pack: "dbt-validation",
+    risk: "read",
+    surfaces: PRODUCT_AGENT_SURFACES,
+    resultKind: "run",
+  }),
+  define({
+    name: "dbt_compile_model",
+    pack: "dbt-validation",
+    risk: "read",
+    surfaces: PRODUCT_AGENT_SURFACES,
+    resultKind: "run",
+  }),
+  define({
+    name: "dbt_show",
+    pack: "dbt-validation",
+    risk: "read",
+    surfaces: PRODUCT_AGENT_SURFACES,
+    resultKind: "run",
+    requiresQueryAccess: true,
+  }),
+  define({
+    name: "dbt_run_model",
+    pack: "dbt-validation",
+    risk: "destructive",
+    requiredGrant: "warehouse-write",
+    surfaces: PRODUCT_AGENT_SURFACES,
+    resultKind: "run",
+    requiresQueryAccess: true,
+  }),
+  define({
+    name: "dbt_get_run",
+    pack: "dbt-validation",
+    risk: "read",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "run",
+    requiresQueryAccess: true,
+  }),
+  define({
+    name: "dbt_cancel_run",
+    pack: "dbt-validation",
+    risk: "write",
+    requiredGrant: "warehouse-write",
+    surfaces: PRODUCT_AGENT_SURFACES,
+    resultKind: "run",
+  }),
+  define({
+    name: "dbt_create_project",
+    pack: "dbt-projects",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: PRODUCT_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "dbt_ensure_dev_environment",
+    pack: "dbt-projects",
+    risk: "write",
+    requiredGrant: "warehouse-write",
+    surfaces: PRODUCT_AGENT_SURFACES,
+    resultKind: "artifact",
+    requiresQueryAccess: true,
+  }),
+  define({
+    name: "dbt_git_status",
+    pack: "dbt-git-read",
+    risk: "read",
+    surfaces: PRODUCT_AGENT_SURFACES,
+    resultKind: "data",
+  }),
+  define({
+    name: "dbt_list_branches",
+    pack: "dbt-git-read",
+    risk: "read",
+    surfaces: PRODUCT_AGENT_SURFACES,
+    resultKind: "data",
+  }),
+  define({
+    name: "dbt_compare_branches",
+    pack: "dbt-git-read",
+    risk: "read",
+    surfaces: PRODUCT_AGENT_SURFACES,
+    resultKind: "data",
+  }),
+  define({
+    name: "dbt_list_pull_requests",
+    pack: "dbt-git-read",
+    risk: "read",
+    surfaces: PRODUCT_AGENT_SURFACES,
+    resultKind: "data",
+  }),
+  define({
+    name: "dbt_sync_from_repo",
+    pack: "dbt-git-write",
+    risk: "destructive",
+    requiredGrant: "git-write",
+    surfaces: PRODUCT_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "dbt_commit_and_push",
+    pack: "dbt-git-write",
+    risk: "write",
+    requiredGrant: "git-write",
+    surfaces: PRODUCT_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "dbt_commit_to_branch",
+    pack: "dbt-git-write",
+    risk: "write",
+    requiredGrant: "git-write",
+    surfaces: PRODUCT_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "dbt_create_branch",
+    pack: "dbt-git-write",
+    risk: "write",
+    requiredGrant: "git-write",
+    surfaces: PRODUCT_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "dbt_switch_branch",
+    pack: "dbt-git-write",
+    risk: "destructive",
+    requiredGrant: "git-write",
+    surfaces: PRODUCT_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "dbt_delete_branch",
+    pack: "dbt-git-write",
+    risk: "destructive",
+    requiredGrant: "git-write",
+    surfaces: PRODUCT_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "dbt_open_pull_request",
+    pack: "dbt-git-write",
+    risk: "write",
+    requiredGrant: "git-write",
+    surfaces: PRODUCT_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "dbt_merge_pull_request",
+    pack: "dbt-git-write",
+    risk: "destructive",
+    requiredGrant: "git-write",
+    surfaces: PRODUCT_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "dbt_update_pull_request",
+    pack: "dbt-git-write",
+    risk: "write",
+    requiredGrant: "git-write",
+    surfaces: PRODUCT_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "dbt_close_pull_request",
+    pack: "dbt-git-write",
+    risk: "destructive",
+    requiredGrant: "git-write",
+    surfaces: PRODUCT_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "dbt_create_job",
+    pack: "dbt-jobs",
+    risk: "write",
+    requiredGrant: "schedule-write",
+    surfaces: PRODUCT_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "dbt_update_job",
+    pack: "dbt-jobs",
+    risk: "write",
+    requiredGrant: "schedule-write",
+    surfaces: PRODUCT_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "dbt_delete_job",
+    pack: "dbt-jobs",
+    risk: "destructive",
+    requiredGrant: "schedule-write",
+    surfaces: PRODUCT_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "dbt_run_job",
+    pack: "dbt-jobs",
+    risk: "destructive",
+    requiredGrant: "warehouse-write",
+    surfaces: PRODUCT_AGENT_SURFACES,
+    resultKind: "run",
+    requiresQueryAccess: true,
+  }),
+] as const satisfies readonly DbtCapabilityDefinition[];
+
+export const DBT_CAPABILITY_NAMES = DBT_CAPABILITIES.map(
+  capability => capability.name,
+);
+
+export const DBT_CAPABILITY_BY_NAME = new Map(
+  DBT_CAPABILITIES.map(capability => [capability.name, capability]),
+);
+
+export function dbtCapabilitiesForSurface(
+  surface: AgentSurface,
+): readonly DbtCapabilityDefinition[] {
+  return DBT_CAPABILITIES.filter(capability =>
+    capability.surfaces.includes(surface),
+  );
+}
+
+export function dbtCapabilitiesForPack(
+  pack: DbtCapabilityPack,
+): readonly DbtCapabilityDefinition[] {
+  return DBT_CAPABILITIES.filter(capability => capability.pack === pack);
+}

--- a/packages/agent-tools/src/index.ts
+++ b/packages/agent-tools/src/index.ts
@@ -168,6 +168,21 @@ export {
 } from "./read-only-tools";
 
 export {
+  DBT_CAPABILITIES,
+  DBT_CAPABILITY_BY_NAME,
+  DBT_CAPABILITY_NAMES,
+  CAPABILITY_GRANTS,
+  dbtCapabilitiesForPack,
+  dbtCapabilitiesForSurface,
+  type AgentSurface,
+  type CapabilityGrant,
+  type CapabilityResultKind,
+  type CapabilityRisk,
+  type DbtCapabilityDefinition,
+  type DbtCapabilityPack,
+} from "./capabilities/dbt-capabilities";
+
+export {
   applyModification,
   buildModificationDiff,
   type ConsoleModification,

--- a/packages/agent-tools/src/plan-tools.ts
+++ b/packages/agent-tools/src/plan-tools.ts
@@ -84,6 +84,20 @@ export const submitPlanSchema = z.object({
     .array(planTodoSchema)
     .min(1)
     .describe("Ordered list of concrete steps you will execute once approved."),
+  requiredCapabilities: z
+    .array(
+      z.enum([
+        "artifact-write",
+        "warehouse-write",
+        "git-write",
+        "schedule-write",
+      ]),
+    )
+    .optional()
+    .describe(
+      "Task-scoped mutation capabilities this plan needs. Include only those " +
+        "the plan visibly describes. Desktop ACP enforces this list after approval.",
+    ),
 });
 
 /**

--- a/packages/agent-tools/src/read-only-tools.ts
+++ b/packages/agent-tools/src/read-only-tools.ts
@@ -15,6 +15,8 @@
  * a raw query can contain writes (INSERT/UPDATE/DELETE/DDL) and we cannot
  * statically guarantee otherwise, so plan mode blocks them until approval.
  */
+import { DBT_CAPABILITIES } from "./capabilities/dbt-capabilities";
+
 export const READ_ONLY_TOOL_NAMES: ReadonlySet<string> = new Set<string>([
   // Cross-surface discovery
   "list_connections",
@@ -51,19 +53,10 @@ export const READ_ONLY_TOOL_NAMES: ReadonlySet<string> = new Set<string>([
   "read_notebook",
   "search_notebook",
   "read_notebook_cell",
-  // dbt reads + verification (parse/compile/show/get_run never mutate the
-  // warehouse; show runs a bounded SELECT, get_run reads run history)
-  "read_dbt_project_tree",
-  "read_dbt_file",
-  "dbt_parse",
-  "dbt_compile_model",
-  "dbt_get_run",
-  "dbt_show",
-  // dbt git reads (status + branch listing/compare never mutate the repo)
-  "dbt_git_status",
-  "dbt_list_branches",
-  "dbt_compare_branches",
-  "dbt_list_recoverable_files",
+  // dbt read/validation inventory is derived from the capability registry.
+  ...DBT_CAPABILITIES.filter(capability => capability.risk === "read").map(
+    capability => capability.name,
+  ),
   // Surface-scoped data-source reads (apps + dashboards, local DuckDB only)
   "list_data_sources",
   "inspect_data_source",

--- a/packages/local-agent/src/acp/manager.ts
+++ b/packages/local-agent/src/acp/manager.ts
@@ -969,7 +969,22 @@ export class AcpSessionManager {
           Number.isFinite(parsedPort) && parsedPort > 0
             ? parsedPort
             : LOCAL_AGENT_PORT;
-        const desktopMcpUrl = `http://127.0.0.1:${agentPort}${DESKTOP_MCP_PATH}`;
+        const desktopMcpUrlValue = new URL(
+          `http://127.0.0.1:${agentPort}${DESKTOP_MCP_PATH}`,
+        );
+        if (body.makoAgentSessionId?.trim()) {
+          desktopMcpUrlValue.searchParams.set(
+            "agentSessionId",
+            body.makoAgentSessionId.trim(),
+          );
+        }
+        if (body.makoWorkspaceId?.trim()) {
+          desktopMcpUrlValue.searchParams.set(
+            "workspaceId",
+            body.makoWorkspaceId.trim(),
+          );
+        }
+        const desktopMcpUrl = desktopMcpUrlValue.toString();
         builder = builder.withMcpServer({
           type: "http",
           name: DESKTOP_MCP_SERVER_NAME,
@@ -995,6 +1010,12 @@ export class AcpSessionManager {
         updatedAt: nowIso(),
         busy: false,
         makoMcpAttached: attachMakoMcp,
+        makoAgentSessionId: attachMakoMcp
+          ? body.makoAgentSessionId?.trim()
+          : undefined,
+        makoWorkspaceId: attachMakoMcp
+          ? body.makoWorkspaceId?.trim()
+          : undefined,
       };
 
       const managed: ManagedSession = {

--- a/packages/local-agent/src/acp/types.ts
+++ b/packages/local-agent/src/acp/types.ts
@@ -57,6 +57,10 @@ export interface AcpSessionInfo {
   busy: boolean;
   /** True when Mako `/api/mcp` was attached on session/new. */
   makoMcpAttached?: boolean;
+  /** Non-secret API identity bound to this session's Mako MCP token. */
+  makoAgentSessionId?: string;
+  /** Workspace bound to the attached Mako MCP token. */
+  makoWorkspaceId?: string;
   /** Current Claude/Codex model id from session configOptions (when known). */
   currentModel?: string | null;
   /** Selectable models advertised by the adapter for this session. */
@@ -173,6 +177,10 @@ export interface CreateAcpSessionRequest {
   mcpUrl?: string;
   /** `Bearer mcpat_…` (or raw token — normalized to Bearer). */
   mcpAuthorization?: string;
+  /** Non-secret API identity returned alongside the MCP token. */
+  makoAgentSessionId?: string;
+  /** Workspace bound to the attached MCP token. */
+  makoWorkspaceId?: string;
   /**
    * MCP server name advertised to the agent (Claude tool prefix mcp__{name}__).
    * Default `mako-workspace` — avoid `mako` which collides with Claude.ai connectors.

--- a/packages/local-agent/src/desktop-bridge/mcp.test.ts
+++ b/packages/local-agent/src/desktop-bridge/mcp.test.ts
@@ -41,17 +41,22 @@ describe("desktop-bridge MCP", () => {
 
   it("completes run_app when a client claims the job", async () => {
     desktopBridgeRegistry.touchClient();
-    const callPromise = handleDesktopMcpExchange({
-      jsonrpc: "2.0",
-      id: 3,
-      method: "tools/call",
-      params: { name: "run_app", arguments: { appId: "app-1" } },
-    });
+    const callPromise = handleDesktopMcpExchange(
+      {
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: { name: "run_app", arguments: { appId: "app-1" } },
+      },
+      { agentSessionId: "agent-1", workspaceId: "workspace-1" },
+    );
 
     const job = await desktopBridgeRegistry.claim(5_000);
     assert.ok(job);
     assert.equal(job.tool, "run_app");
     assert.equal(job.arguments.appId, "app-1");
+    assert.equal(job.agentSessionId, "agent-1");
+    assert.equal(job.workspaceId, "workspace-1");
     assert.equal(
       desktopBridgeRegistry.complete(job.id, {
         success: true,

--- a/packages/local-agent/src/desktop-bridge/mcp.ts
+++ b/packages/local-agent/src/desktop-bridge/mcp.ts
@@ -94,7 +94,7 @@ const TOOLS: Array<{
   {
     name: "submit_plan",
     description:
-      "Present a reviewable plan in the Mako Chat dock for Approve / Request changes / Cancel. Use before large or multi-step work. Returns the user's decision.",
+      "Present a reviewable plan in the Mako Chat dock for Approve / Request changes / Cancel. Use before large or multi-step work. For dbt mutations, include only the requiredCapabilities visibly described by the plan. Returns the user's decision.",
     inputSchema: {
       type: "object",
       properties: {
@@ -116,6 +116,20 @@ const TOOLS: Array<{
             required: ["content"],
           },
         },
+        requiredCapabilities: {
+          type: "array",
+          items: {
+            type: "string",
+            enum: [
+              "artifact-write",
+              "warehouse-write",
+              "git-write",
+              "schedule-write",
+            ],
+          },
+          description:
+            "Task-scoped mutation capabilities requested by this plan. Include only capabilities explicitly described in the plan.",
+        },
       },
       required: ["title", "planMarkdown", "todos"],
     },
@@ -135,6 +149,7 @@ function fail(id: JsonRpcId, code: number, message: string): JsonRpcResponse {
 async function callTool(
   name: string,
   args: Record<string, unknown>,
+  context?: { agentSessionId?: string; workspaceId?: string },
 ): Promise<{ text: string; isError?: boolean }> {
   if (!TOOL_NAMES.has(name as DesktopBridgeToolName)) {
     return { text: `Unknown tool: ${name}`, isError: true };
@@ -143,6 +158,8 @@ async function callTool(
     const result = await desktopBridgeRegistry.enqueue(
       name as DesktopBridgeToolName,
       args && typeof args === "object" ? args : {},
+      undefined,
+      context,
     );
     return {
       text: typeof result === "string" ? result : JSON.stringify(result),
@@ -157,6 +174,7 @@ async function callTool(
 
 async function handleOne(
   message: JsonRpcRequest,
+  context?: { agentSessionId?: string; workspaceId?: string },
 ): Promise<JsonRpcResponse | null> {
   const id = message.id ?? null;
   const method = message.method;
@@ -193,7 +211,7 @@ async function handleOne(
         : {};
     // HITL tools block the HTTP exchange until Desktop completes — expected.
     if (isDesktopHitlTool(name) || TOOL_NAMES.has(name as DesktopBridgeToolName)) {
-      const result = await callTool(name, args);
+      const result = await callTool(name, args, context);
       return ok(id, {
         content: [{ type: "text", text: result.text }],
         ...(result.isError ? { isError: true } : {}),
@@ -211,6 +229,7 @@ async function handleOne(
 
 export async function handleDesktopMcpExchange(
   body: unknown,
+  context?: { agentSessionId?: string; workspaceId?: string },
 ): Promise<{ status: 200 | 202 | 400; body: unknown }> {
   const incoming = Array.isArray(body) ? body : [body];
   if (
@@ -234,7 +253,7 @@ export async function handleDesktopMcpExchange(
 
   const responses: JsonRpcResponse[] = [];
   for (const message of incoming) {
-    const response = await handleOne(message as JsonRpcRequest);
+    const response = await handleOne(message as JsonRpcRequest, context);
     if (response) responses.push(response);
   }
 

--- a/packages/local-agent/src/desktop-bridge/registry.ts
+++ b/packages/local-agent/src/desktop-bridge/registry.ts
@@ -15,6 +15,8 @@ export interface DesktopBridgeJob {
   tool: DesktopBridgeToolName;
   arguments: Record<string, unknown>;
   createdAt: number;
+  agentSessionId?: string;
+  workspaceId?: string;
 }
 
 interface PendingJob extends DesktopBridgeJob {
@@ -71,6 +73,7 @@ class DesktopBridgeRegistry {
     tool: DesktopBridgeToolName,
     args: Record<string, unknown>,
     timeoutMs = ttlForTool(tool),
+    context?: { agentSessionId?: string; workspaceId?: string },
   ): Promise<unknown> {
     return new Promise((resolve, reject) => {
       if (!this.hasRecentClient()) {
@@ -88,6 +91,8 @@ class DesktopBridgeRegistry {
         tool,
         arguments: args,
         createdAt: Date.now(),
+        agentSessionId: context?.agentSessionId,
+        workspaceId: context?.workspaceId,
         resolve,
         reject,
         timer: setTimeout(() => {
@@ -167,6 +172,8 @@ function publicJob(job: PendingJob): DesktopBridgeJob {
     tool: job.tool,
     arguments: job.arguments,
     createdAt: job.createdAt,
+    agentSessionId: job.agentSessionId,
+    workspaceId: job.workspaceId,
   };
 }
 

--- a/packages/local-agent/src/desktop-bridge/routes.ts
+++ b/packages/local-agent/src/desktop-bridge/routes.ts
@@ -73,7 +73,10 @@ export function registerDesktopBridgeRoutes(app: Hono): void {
         400,
       );
     }
-    const exchange = await handleDesktopMcpExchange(body);
+    const exchange = await handleDesktopMcpExchange(body, {
+      agentSessionId: c.req.query("agentSessionId"),
+      workspaceId: c.req.query("workspaceId"),
+    });
     if (exchange.status === 202) {
       return c.body(null, 202);
     }


### PR DESCRIPTION
## Summary

- Introduces a single dbt capability registry (`packages/agent-tools/src/capabilities/dbt-capabilities.ts`) that drives tool exposure and authorization on every agent surface — native Chat, external MCP, and Desktop ACP — via a shared `authorizeAgentCapability` runtime, so there is one policy path instead of three.
- Warehouse, Git, and scheduling mutations now require a plan-approved, session-scoped capability grant (`submit_plan` declares `requiredCapabilities`; Desktop approvals persist as `AcpPlanGrant` bound to the MCP OAuth `agentSessionId` and are revoked fail-closed at turn boundaries). Small working-tree edits (`artifact-write`) stay implicit to preserve the act-without-a-plan flow.
- `dbt_parse` / `dbt_compile_model` / `dbt_show` become asynchronous runs (queue + poll `dbt_get_run`, with structured show-preview output persisted on the run), fixing MCP timeout and read-only bypass issues.
- Skills and dbt `.makorules` guidance are unified through a shared turn-preparation service exposed to Desktop ACP via a new `POST /custom-prompt/turn-guidance` endpoint, with token-budgeted skill excerpts.
- Adds `dbt-git-workflow` and `dbt-jobs` system skills.

## Notes for reviewers

- Plan grants are validated per agent session but not yet tied to the approved plan's digest; one approval unlocks the granted capabilities for that session until end-of-turn revocation. Follow-up candidate.

## Test plan

- [x] `pnpm --filter app run typecheck && pnpm --filter app run lint`
- [x] `pnpm --filter api run build` (includes lint + typecheck)
- [x] `tool-working-set`, `mako-mcp-server`, `derive-mode-state`, `tool-discovery-tools`, `agent-turn-preparation` test suites
- [x] `@mako/local-agent` typecheck + full test suite (54 passing)
- [x] End-to-end: local Claude Code (Desktop ACP) dbt discovery request completes; plan-gated `dbt_run_model` blocked without `warehouse-write` grant, allowed with it; native Transform parity verified

Made with [Cursor](https://cursor.com)