### PR TITLE
feat(agent): extend capability registry to apps, consoles, SQL/mongo, and notebooks

### DIFF
--- a/api/src/agent-lib/capabilities/runtime.ts
+++ b/api/src/agent-lib/capabilities/runtime.ts
@@ -1,5 +1,5 @@
 import {
-  DBT_CAPABILITY_BY_NAME,
+  AGENT_CAPABILITY_BY_NAME,
   type AgentSurface,
   type CapabilityGrant,
 } from "@mako/agent-tools";
@@ -21,7 +21,7 @@ export function authorizeAgentCapability(
   name: string,
   context: AgentCapabilityAuthorizationContext,
 ): AgentCapabilityDecision {
-  const capability = DBT_CAPABILITY_BY_NAME.get(name);
+  const capability = AGENT_CAPABILITY_BY_NAME.get(name);
   // The shared registry is being introduced domain-by-domain. Unregistered
   // tools continue through their existing policy until migrated.
   if (!capability) return { allowed: true };

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -75,9 +75,11 @@ YOU decide when these make sense:
 - \`submit_plan\` — use BEFORE acting when the work is large, destructive, or spans multiple
   artifacts (e.g. building a dashboard from scratch, modifying many consoles, deleting or
   overwriting data, reconfiguring a sync flow), or when the user explicitly asks for a plan.
-  The user can Approve, Request changes, or Cancel. For dbt work, include only the
+  The user can Approve, Request changes, or Cancel. Include only the
   \`requiredCapabilities\` the visible plan needs: \`artifact-write\`, \`warehouse-write\`,
-  \`git-write\`, and/or \`schedule-write\`.
+  \`git-write\`, and/or \`schedule-write\`. Scheduling mutations (dbt jobs, binding
+  schedules, scheduled queries) always need an approved plan with \`schedule-write\`;
+  dbt warehouse runs need \`warehouse-write\`; Git mutations need \`git-write\`.
 
 IMPORTANT: once you call \`submit_plan\`, mutating tools are blocked until the user approves.
 Do your read-only exploration BEFORE submitting so the plan is concrete. For small,

--- a/api/src/agents/modes/tool-working-set.test.ts
+++ b/api/src/agents/modes/tool-working-set.test.ts
@@ -245,6 +245,35 @@ const baseModeState = (loaded: string[] = []): ModeState => ({
   assert.ok(!activeApproved.includes("dbt_commit_and_push"));
 }
 
+// --- app capabilities: edits are implicit; schedules need a plan grant --------
+{
+  const all = new Set([
+    "app_write_file",
+    "app_set_binding_schedule",
+    "materialize_binding",
+  ]);
+  const withoutPlan: ModeState = {
+    enabledModes: new Set(["app"]),
+    planSubmitted: false,
+    planApproved: false,
+    approvedCapabilityGrants: new Set(),
+    loadedToolNames: [],
+  };
+  const activeWithoutPlan = computeActiveTools(withoutPlan, all);
+  assert.ok(activeWithoutPlan.includes("app_write_file"));
+  assert.ok(activeWithoutPlan.includes("materialize_binding"));
+  assert.ok(!activeWithoutPlan.includes("app_set_binding_schedule"));
+
+  const approved: ModeState = {
+    ...withoutPlan,
+    planSubmitted: true,
+    planApproved: true,
+    approvedCapabilityGrants: new Set(["schedule-write"]),
+  };
+  const activeApproved = computeActiveTools(approved, all);
+  assert.ok(activeApproved.includes("app_set_binding_schedule"));
+}
+
 // --- provider caps ------------------------------------------------------------
 {
   assert.equal(providerToolCap("xai/grok-4.5"), 250);

--- a/api/src/mcp/bridge-policy.ts
+++ b/api/src/mcp/bridge-policy.ts
@@ -12,7 +12,11 @@
  * Adding a new agent tool without classifying it here fails the MCP
  * inventory test — that's how we stay smart about what's missing.
  */
-import { DBT_CAPABILITIES, READ_ONLY_TOOL_NAMES } from "@mako/agent-tools";
+import {
+  AGENT_CAPABILITIES,
+  READ_ONLY_TOOL_NAMES,
+  type AgentCapabilityDefinition,
+} from "@mako/agent-tools";
 
 /** Why a tool is kept off the MCP surface. */
 export type McpBridgeExclusionWhy =
@@ -64,9 +68,11 @@ const mcpOnly = (
   opts: Omit<Extract<McpBridgeEntry, { status: "mcp-only" }>, "status"> = {},
 ): McpBridgeEntry => ({ status: "mcp-only", ...opts });
 
-function dbtBridgePolicyEntries(): Record<string, McpBridgeEntry> {
+function capabilityBridgePolicyEntries(
+  capabilities: readonly AgentCapabilityDefinition[],
+): Record<string, McpBridgeEntry> {
   return Object.fromEntries(
-    DBT_CAPABILITIES.map(capability => {
+    capabilities.map(capability => {
       if (capability.requiresAsyncMcp) {
         return [
           capability.name,
@@ -98,6 +104,12 @@ function dbtBridgePolicyEntries(): Record<string, McpBridgeEntry> {
           }),
         ];
       }
+      if (capability.mcpExclusion) {
+        return [
+          capability.name,
+          exclude(capability.mcpExclusion.why, capability.mcpExclusion.note),
+        ];
+      }
       return [
         capability.name,
         exclude("deferred", "Not available on an MCP surface."),
@@ -111,75 +123,13 @@ function dbtBridgePolicyEntries(): Record<string, McpBridgeEntry> {
  * Keep alphabetical within each section so diffs stay reviewable.
  */
 export const MCP_BRIDGE_POLICY: Readonly<Record<string, McpBridgeEntry>> = {
-  // ── Apps (server) — full headless authoring surface ───────────────────
-  app_add_dependency: bridge(),
-  app_create_data_binding: bridge(),
-  app_delete_data_binding: bridge({ destructiveHint: true }),
-  app_delete_file: bridge({ destructiveHint: true }),
-  app_edit_file: bridge(),
-  app_read_file: bridge(),
-  app_remove_dependency: bridge({ destructiveHint: true }),
-  app_rename_file: bridge(),
-  app_restore_version: bridge(),
-  app_save_version: bridge(),
-  app_set_binding_materialization: bridge(),
-  app_set_binding_schedule: bridge(),
-  app_set_preview_environment: exclude(
-    "client-only",
-    "Per-user browser preview state; headless agents use render_app / bindings directly.",
-  ),
-  app_update_data_binding: bridge(),
-  app_write_file: bridge(),
-  create_app: bridge(),
-  get_app_state: bridge(),
-  app_search: bridge(),
-  app_read_resource: bridge(),
-  list_open_apps: bridge(),
-  materialize_binding: bridge(),
-  open_app: exclude(
-    "client-only",
-    "UI tab focus only; MCP operates on appId directly.",
-  ),
-  run_app: exclude(
-    "client-only",
-    "Browser iframe preview; MCP uses render_app instead.",
-  ),
-
-  // ── Notebooks (server) — durable GCS + kernel; Desktop opens tabs via focus ─
-  add_notebook_cell: bridge(),
-  create_notebook: bridge(),
-  delete_notebook_cell: bridge(),
-  edit_notebook_cell: bridge(),
-  list_open_notebooks: bridge(),
-  read_notebook: bridge(),
-  read_notebook_cell: bridge(),
-  run_notebook_code_cell: bridge(),
-  run_notebook_sql_cell: bridge(),
-  search_notebook: bridge(),
+  // ── Apps / notebooks / consoles / SQL / Mongo / dbt — derived from the
+  //    shared capability registry (@mako/agent-tools capabilities/*) ───────
+  ...capabilityBridgePolicyEntries(AGENT_CAPABILITIES),
 
   // ── MCP-only preview / render ─────────────────────────────────────────
   create_preview_token: mcpOnly(),
   render_app: mcpOnly(),
-
-  // ── Console / query (server) ───────────────────────────────────────────
-  cancel_query: bridge({ requiresQueryAccess: true }),
-  check_query_status: bridge({ requiresQueryAccess: true }),
-  create_console: bridge(),
-  list_open_consoles: exclude(
-    "client-only",
-    "Open browser tabs; Desktop ACP uses mako-desktop list_open_consoles / UI context.",
-  ),
-  modify_console: bridge(),
-  open_console: bridge(),
-  read_console: bridge(),
-  run_console: bridge({ requiresQueryAccess: true }),
-  list_console_executions: bridge(),
-  schedule_query: exclude(
-    "in-product-only",
-    "Scheduled writes need session auth + console ownership UX; not in MCP read-only apps loop.",
-  ),
-  search_consoles: bridge(),
-  set_console_connection: bridge(),
 
   // ── Charts / screenshots (client) ─────────────────────────────────────
   capture_screenshot: exclude(
@@ -198,22 +148,6 @@ export const MCP_BRIDGE_POLICY: Readonly<Record<string, McpBridgeEntry>> = {
     "client-only",
     "Mutates the open console chart in the browser.",
   ),
-
-  // ── SQL / Mongo discovery + execute ───────────────────────────────────
-  list_connections: bridge(),
-  mongo_execute_query: exclude(
-    "security",
-    "Arbitrary MongoDB JavaScript has no reliable per-query read-only mode.",
-  ),
-  mongo_inspect_collection: bridge(),
-  mongo_list_collections: bridge(),
-  mongo_list_connections: bridge(),
-  mongo_list_databases: bridge(),
-  sql_execute_query: bridge({ requiresQueryAccess: true }),
-  sql_inspect_table: bridge(),
-  sql_list_connections: bridge(),
-  sql_list_databases: bridge(),
-  sql_list_tables: bridge(),
 
   // ── Flow / sync (mostly UI + deferred) ────────────────────────────────
   create_flow_tab: exclude(
@@ -316,9 +250,6 @@ export const MCP_BRIDGE_POLICY: Readonly<Record<string, McpBridgeEntry>> = {
     "client-only",
     "Queries in-browser DuckDB; MCP validates via sql_execute_query.",
   ),
-
-  // ── dbt / transform — derived from the shared capability registry ─────
-  ...dbtBridgePolicyEntries(),
 
   // ── Skills / memory / modes / plan ────────────────────────────────────
   ask_clarifying_questions: exclude(

--- a/api/src/mcp/mako-mcp-server.test.ts
+++ b/api/src/mcp/mako-mcp-server.test.ts
@@ -17,6 +17,7 @@ process.env.ENCRYPTION_KEY =
 
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 import {
+  AGENT_CAPABILITIES,
   CAPABILITY_GRANTS,
   DBT_CAPABILITY_NAMES,
   type CapabilityGrant,
@@ -474,6 +475,90 @@ async function main() {
       tools.some(tool => tool.name === "dbt_get_run"),
       false,
       "dbt run output must stay hidden without query:read",
+    );
+    // Warehouse-executing tools from the other migrated domains carry the
+    // same query envelope.
+    for (const queryTool of ["run_notebook_sql_cell", "materialize_binding"]) {
+      assert.equal(
+        tools.some(tool => tool.name === queryTool),
+        false,
+        `${queryTool} must stay hidden without query:read`,
+      );
+    }
+  }
+
+  // 3e. Schedule mutations: implicit for external MCP (existing headless
+  //     authoring authority), plan-grant-gated for Desktop ACP.
+  {
+    const registryNames = new Set(
+      AGENT_CAPABILITIES.map(capability => capability.name),
+    );
+    assert.equal(
+      registryNames.size,
+      AGENT_CAPABILITIES.length,
+      "capability registry must not contain duplicate tool names",
+    );
+
+    // External MCP: authorization passes, so the zod schema rejects the
+    // bogus arguments (proves the call was not blocked by a grant).
+    const [externalCall] = await exchange([
+      {
+        jsonrpc: "2.0",
+        id: "schedule-external",
+        method: "tools/call",
+        params: { name: "app_set_binding_schedule", arguments: { appId: 42 } },
+      },
+    ]);
+    assert.match(
+      (externalCall.result as { content: { text: string }[] }).content[0].text,
+      /Invalid arguments/,
+      "external MCP keeps implicit schedule authority",
+    );
+
+    // Desktop ACP without an approved plan grant: blocked before execution.
+    const [desktopDenied] = await exchange(
+      [
+        {
+          jsonrpc: "2.0",
+          id: "schedule-acp-denied",
+          method: "tools/call",
+          params: {
+            name: "app_set_binding_schedule",
+            arguments: { appId: 42 },
+          },
+        },
+      ],
+      ["mcp", "query:read"],
+      true,
+    );
+    const deniedSchedule = desktopDenied.result as {
+      isError?: boolean;
+      content: { text: string }[];
+    };
+    assert.equal(deniedSchedule.isError, true);
+    assert.match(deniedSchedule.content[0].text, /schedule-write/);
+
+    // Desktop ACP with the grant: authorization passes (zod rejects args).
+    const [desktopGranted] = await exchange(
+      [
+        {
+          jsonrpc: "2.0",
+          id: "schedule-acp-granted",
+          method: "tools/call",
+          params: {
+            name: "app_set_binding_schedule",
+            arguments: { appId: 42 },
+          },
+        },
+      ],
+      ["mcp", "query:read"],
+      true,
+      ["schedule-write"],
+    );
+    assert.match(
+      (desktopGranted.result as { content: { text: string }[] }).content[0]
+        .text,
+      /Invalid arguments/,
     );
   }
 

--- a/api/src/mcp/mako-mcp-server.ts
+++ b/api/src/mcp/mako-mcp-server.ts
@@ -91,7 +91,7 @@ Typical loop:
 1. Discover data: list_connections, then sql_list_tables / sql_inspect_table.
 2. Validate queries with sql_execute_query (short exploration timeout). For slow warehouses: create_console → run_console → check_query_status.
 3. create_app → app_write_file / app_edit_file → app_create_data_binding (bind the validated query; pass consoleId to seed from a console).
-4. For dbt work: read_dbt_project_tree → read/edit files → validate asynchronously, then poll dbt_get_run. Before dbt mutations, submit a plan whose requiredCapabilities lists only the needed artifact-write, warehouse-write, git-write, or schedule-write grants.
+4. For dbt work: read_dbt_project_tree → read/edit files → validate asynchronously, then poll dbt_get_run. Warehouse, Git, and scheduling mutations (dbt runs/jobs, app_set_binding_schedule) need a plan approved via mako-desktop submit_plan whose requiredCapabilities lists only the needed artifact-write, warehouse-write, git-write, or schedule-write grants.
 5. Desktop opens/refreshes the app tab automatically. Do NOT create_preview_token, render_app, or paste /preview/… URLs. Use mako-desktop run_app / get_preview_errors for iframe errors. For consoles use open_console / create_console; for notebooks use create_notebook / cell tools.
 6. Interactive UX: mako-desktop ask_clarifying_questions / submit_plan (docked Chat cards) — never ask as plain text.
 7. Durable memory: read_self_directive / update_self_directive only. Do NOT write .claude/**/MEMORY.md or other local Claude memory files.
@@ -354,10 +354,14 @@ export function buildMakoMcpServer(
       surface: context.acpDesktop ? "desktop-acp" : "external-mcp",
       queryAccess,
       // External MCP's `mcp` scope is the existing workspace-authoring
-      // authority. Small dbt working-tree edits match native Chat and do not
-      // require a plan; warehouse, Git, and scheduling mutations do.
+      // authority: artifact edits and binding schedules have always been part
+      // of the headless apps loop, so they stay implicit there. Desktop ACP
+      // only carries artifact-write implicitly; warehouse, Git, and schedule
+      // mutations need an approved plan grant. dbt working-tree edits match
+      // native Chat and stay implicit on both surfaces.
       grants: new Set<CapabilityGrant>([
         "artifact-write",
+        ...(context.acpDesktop ? [] : (["schedule-write"] as const)),
         ...(context.capabilityGrants ?? []),
       ]),
     });

--- a/packages/agent-tools/src/capabilities/app-capabilities.ts
+++ b/packages/agent-tools/src/capabilities/app-capabilities.ts
@@ -1,0 +1,230 @@
+/**
+ * Transport-neutral app (data apps) capability metadata.
+ *
+ * Apps are the primary headless MCP authoring loop, so almost every server
+ * tool is exposed on all surfaces. Client-only tools (browser tab focus,
+ * iframe preview) stay in-chat.
+ */
+import {
+  ALL_AGENT_SURFACES,
+  IN_CHAT_ONLY_SURFACES,
+  type AgentCapabilityDefinition,
+} from "./types";
+
+export type AppCapabilityPack =
+  | "app-orient"
+  | "app-edit"
+  | "app-data"
+  | "app-versions"
+  | "app-ui";
+
+export type AppCapabilityDefinition = AgentCapabilityDefinition<
+  "app",
+  AppCapabilityPack
+>;
+
+const define = (
+  definition: Omit<AppCapabilityDefinition, "domain">,
+): AppCapabilityDefinition => ({ domain: "app", ...definition });
+
+export const APP_CAPABILITIES = [
+  // ── Orientation / reads ─────────────────────────────────────────────────
+  define({
+    name: "list_open_apps",
+    pack: "app-orient",
+    risk: "read",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "data",
+  }),
+  define({
+    name: "get_app_state",
+    pack: "app-orient",
+    risk: "read",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "data",
+  }),
+  define({
+    name: "app_search",
+    pack: "app-orient",
+    risk: "read",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "data",
+  }),
+  define({
+    name: "app_read_resource",
+    pack: "app-orient",
+    risk: "read",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "data",
+  }),
+  define({
+    name: "app_read_file",
+    pack: "app-orient",
+    risk: "read",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "data",
+  }),
+  // ── Files / dependencies ────────────────────────────────────────────────
+  define({
+    name: "create_app",
+    pack: "app-edit",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "app_write_file",
+    pack: "app-edit",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "app_edit_file",
+    pack: "app-edit",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "app_rename_file",
+    pack: "app-edit",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "app_delete_file",
+    pack: "app-edit",
+    risk: "destructive",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "app_add_dependency",
+    pack: "app-edit",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "app_remove_dependency",
+    pack: "app-edit",
+    risk: "destructive",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  // ── Data bindings / materialization ─────────────────────────────────────
+  define({
+    name: "app_create_data_binding",
+    pack: "app-data",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "app_update_data_binding",
+    pack: "app-data",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "app_delete_data_binding",
+    pack: "app-data",
+    risk: "destructive",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "app_set_binding_materialization",
+    pack: "app-data",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    // Executes the binding's saved query against the connection, so it needs
+    // the same query envelope as run_console / sql_execute_query.
+    name: "materialize_binding",
+    pack: "app-data",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "run",
+    requiresQueryAccess: true,
+  }),
+  define({
+    name: "app_set_binding_schedule",
+    pack: "app-data",
+    risk: "write",
+    requiredGrant: "schedule-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  // ── Versions ────────────────────────────────────────────────────────────
+  define({
+    name: "app_save_version",
+    pack: "app-versions",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "app_restore_version",
+    pack: "app-versions",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  // ── Client-only UI effects ──────────────────────────────────────────────
+  define({
+    name: "open_app",
+    pack: "app-ui",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: IN_CHAT_ONLY_SURFACES,
+    resultKind: "ui-effect",
+    mcpExclusion: {
+      why: "client-only",
+      note: "UI tab focus only; MCP operates on appId directly.",
+    },
+  }),
+  define({
+    name: "run_app",
+    pack: "app-ui",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: IN_CHAT_ONLY_SURFACES,
+    resultKind: "ui-effect",
+    mcpExclusion: {
+      why: "client-only",
+      note: "Browser iframe preview; MCP uses render_app instead.",
+    },
+  }),
+  define({
+    name: "app_set_preview_environment",
+    pack: "app-ui",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: IN_CHAT_ONLY_SURFACES,
+    resultKind: "ui-effect",
+    mcpExclusion: {
+      why: "client-only",
+      note: "Per-user browser preview state; headless agents use render_app / bindings directly.",
+    },
+  }),
+] as const satisfies readonly AppCapabilityDefinition[];

--- a/packages/agent-tools/src/capabilities/console-capabilities.ts
+++ b/packages/agent-tools/src/capabilities/console-capabilities.ts
@@ -1,0 +1,134 @@
+/**
+ * Transport-neutral console / query-lifecycle capability metadata.
+ *
+ * Query execution tools carry `requiresQueryAccess` (the `query:read`
+ * scope envelope) instead of a task grant: read-only enforcement happens per
+ * query at the driver level, matching sql_execute_query.
+ */
+import {
+  ALL_AGENT_SURFACES,
+  IN_CHAT_ONLY_SURFACES,
+  type AgentCapabilityDefinition,
+} from "./types";
+
+export type ConsoleCapabilityPack =
+  | "console-orient"
+  | "console-edit"
+  | "console-run"
+  | "console-schedule";
+
+export type ConsoleCapabilityDefinition = AgentCapabilityDefinition<
+  "console",
+  ConsoleCapabilityPack
+>;
+
+const define = (
+  definition: Omit<ConsoleCapabilityDefinition, "domain">,
+): ConsoleCapabilityDefinition => ({ domain: "console", ...definition });
+
+export const CONSOLE_CAPABILITIES = [
+  // ── Orientation / reads ─────────────────────────────────────────────────
+  define({
+    name: "read_console",
+    pack: "console-orient",
+    risk: "read",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "data",
+  }),
+  define({
+    name: "search_consoles",
+    pack: "console-orient",
+    risk: "read",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "data",
+  }),
+  define({
+    name: "list_open_consoles",
+    pack: "console-orient",
+    risk: "read",
+    surfaces: IN_CHAT_ONLY_SURFACES,
+    resultKind: "data",
+    mcpExclusion: {
+      why: "client-only",
+      note: "Open browser tabs; Desktop ACP uses mako-desktop list_open_consoles / UI context.",
+    },
+  }),
+  // ── Authoring ───────────────────────────────────────────────────────────
+  define({
+    name: "create_console",
+    pack: "console-edit",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "modify_console",
+    pack: "console-edit",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "set_console_connection",
+    pack: "console-edit",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "open_console",
+    pack: "console-edit",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "ui-effect",
+  }),
+  // ── Run lifecycle ───────────────────────────────────────────────────────
+  define({
+    name: "run_console",
+    pack: "console-run",
+    risk: "write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "run",
+    requiresQueryAccess: true,
+  }),
+  define({
+    name: "check_query_status",
+    pack: "console-run",
+    risk: "write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "run",
+    requiresQueryAccess: true,
+  }),
+  define({
+    name: "cancel_query",
+    pack: "console-run",
+    risk: "write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "run",
+    requiresQueryAccess: true,
+  }),
+  define({
+    name: "list_console_executions",
+    pack: "console-run",
+    risk: "write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "data",
+  }),
+  // ── Scheduling (legacy console agent only today) ────────────────────────
+  define({
+    name: "schedule_query",
+    pack: "console-schedule",
+    risk: "write",
+    requiredGrant: "schedule-write",
+    surfaces: IN_CHAT_ONLY_SURFACES,
+    resultKind: "artifact",
+    mcpExclusion: {
+      why: "in-product-only",
+      note: "Scheduled writes need session auth + console ownership UX; not in MCP read-only apps loop.",
+    },
+  }),
+] as const satisfies readonly ConsoleCapabilityDefinition[];

--- a/packages/agent-tools/src/capabilities/dbt-capabilities.ts
+++ b/packages/agent-tools/src/capabilities/dbt-capabilities.ts
@@ -5,23 +5,13 @@
  * for mode membership, MCP exposure, authorization, token packs, and UI
  * result semantics.
  */
+import {
+  ALL_AGENT_SURFACES,
+  PRODUCT_AGENT_SURFACES,
+  type AgentCapabilityDefinition,
+  type AgentSurface,
+} from "./types";
 
-export type AgentSurface = "in-chat" | "desktop-acp" | "external-mcp";
-
-export type CapabilityRisk = "read" | "write" | "destructive";
-
-export type CapabilityGrant =
-  | "artifact-write"
-  | "git-write"
-  | "schedule-write"
-  | "warehouse-write";
-
-export const CAPABILITY_GRANTS = [
-  "artifact-write",
-  "git-write",
-  "schedule-write",
-  "warehouse-write",
-] as const satisfies readonly CapabilityGrant[];
 
 export type DbtCapabilityPack =
   | "dbt-orient"
@@ -32,37 +22,10 @@ export type DbtCapabilityPack =
   | "dbt-git-write"
   | "dbt-jobs";
 
-export type CapabilityResultKind =
-  | "data"
-  | "artifact"
-  | "run"
-  | "ui-effect";
-
-export interface DbtCapabilityDefinition {
-  name: string;
-  domain: "dbt";
-  pack: DbtCapabilityPack;
-  risk: CapabilityRisk;
-  requiredGrant?: CapabilityGrant;
-  surfaces: readonly AgentSurface[];
-  resultKind: CapabilityResultKind;
-  requiresQueryAccess?: boolean;
-  /**
-   * Long-running validation must move to the run registry before MCP exposure.
-   */
-  requiresAsyncMcp?: boolean;
-}
-
-const ALL_AGENT_SURFACES = [
-  "in-chat",
-  "desktop-acp",
-  "external-mcp",
-] as const satisfies readonly AgentSurface[];
-
-const PRODUCT_AGENT_SURFACES = [
-  "in-chat",
-  "desktop-acp",
-] as const satisfies readonly AgentSurface[];
+export type DbtCapabilityDefinition = AgentCapabilityDefinition<
+  "dbt",
+  DbtCapabilityPack
+>;
 
 const define = (
   definition: Omit<DbtCapabilityDefinition, "domain">,

--- a/packages/agent-tools/src/capabilities/notebook-capabilities.ts
+++ b/packages/agent-tools/src/capabilities/notebook-capabilities.ts
@@ -1,0 +1,108 @@
+/**
+ * Transport-neutral notebook capability metadata.
+ *
+ * Notebooks are durable (GCS) with server-side kernels, so the whole domain
+ * is exposed on every surface. Cell runs execute real queries / kernel code
+ * and carry the query envelope where warehouse access is involved.
+ */
+import {
+  ALL_AGENT_SURFACES,
+  type AgentCapabilityDefinition,
+} from "./types";
+
+export type NotebookCapabilityPack =
+  | "notebook-orient"
+  | "notebook-edit"
+  | "notebook-run";
+
+export type NotebookCapabilityDefinition = AgentCapabilityDefinition<
+  "notebook",
+  NotebookCapabilityPack
+>;
+
+const define = (
+  definition: Omit<NotebookCapabilityDefinition, "domain">,
+): NotebookCapabilityDefinition => ({ domain: "notebook", ...definition });
+
+export const NOTEBOOK_CAPABILITIES = [
+  // ── Orientation / reads ─────────────────────────────────────────────────
+  define({
+    name: "list_open_notebooks",
+    pack: "notebook-orient",
+    risk: "read",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "data",
+  }),
+  define({
+    name: "read_notebook",
+    pack: "notebook-orient",
+    risk: "read",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "data",
+  }),
+  define({
+    name: "read_notebook_cell",
+    pack: "notebook-orient",
+    risk: "read",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "data",
+  }),
+  define({
+    name: "search_notebook",
+    pack: "notebook-orient",
+    risk: "read",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "data",
+  }),
+  // ── Authoring ───────────────────────────────────────────────────────────
+  define({
+    name: "create_notebook",
+    pack: "notebook-edit",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "add_notebook_cell",
+    pack: "notebook-edit",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "edit_notebook_cell",
+    pack: "notebook-edit",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    name: "delete_notebook_cell",
+    pack: "notebook-edit",
+    risk: "destructive",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  // ── Cell runs ───────────────────────────────────────────────────────────
+  define({
+    // Runs a warehouse query, so it needs the same query envelope as
+    // sql_execute_query / run_console.
+    name: "run_notebook_sql_cell",
+    pack: "notebook-run",
+    risk: "write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "run",
+    requiresQueryAccess: true,
+  }),
+  define({
+    name: "run_notebook_code_cell",
+    pack: "notebook-run",
+    risk: "write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "run",
+  }),
+] as const satisfies readonly NotebookCapabilityDefinition[];

--- a/packages/agent-tools/src/capabilities/query-capabilities.ts
+++ b/packages/agent-tools/src/capabilities/query-capabilities.ts
@@ -1,0 +1,79 @@
+/**
+ * Transport-neutral SQL / MongoDB discovery + execution capability metadata.
+ *
+ * Discovery and inspection are read-only everywhere. Raw execution carries
+ * the `query:read` scope envelope; MongoDB execution stays in-product because
+ * arbitrary Mongo JavaScript has no reliable per-query read-only mode.
+ */
+import {
+  ALL_AGENT_SURFACES,
+  IN_CHAT_ONLY_SURFACES,
+  type AgentCapabilityDefinition,
+} from "./types";
+
+export type QueryCapabilityPack =
+  | "sql-discover"
+  | "sql-execute"
+  | "mongo-discover"
+  | "mongo-execute";
+
+export type QueryCapabilityDefinition = AgentCapabilityDefinition<
+  "query",
+  QueryCapabilityPack
+>;
+
+const define = (
+  definition: Omit<QueryCapabilityDefinition, "domain">,
+): QueryCapabilityDefinition => ({ domain: "query", ...definition });
+
+const sqlDiscover = (name: string): QueryCapabilityDefinition =>
+  define({
+    name,
+    pack: "sql-discover",
+    risk: "read",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "data",
+  });
+
+const mongoDiscover = (name: string): QueryCapabilityDefinition =>
+  define({
+    name,
+    pack: "mongo-discover",
+    risk: "read",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "data",
+  });
+
+export const QUERY_CAPABILITIES = [
+  // ── Cross-engine discovery ──────────────────────────────────────────────
+  sqlDiscover("list_connections"),
+  // ── SQL ─────────────────────────────────────────────────────────────────
+  sqlDiscover("sql_list_connections"),
+  sqlDiscover("sql_list_databases"),
+  sqlDiscover("sql_list_tables"),
+  sqlDiscover("sql_inspect_table"),
+  define({
+    name: "sql_execute_query",
+    pack: "sql-execute",
+    risk: "write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "data",
+    requiresQueryAccess: true,
+  }),
+  // ── MongoDB ─────────────────────────────────────────────────────────────
+  mongoDiscover("mongo_list_connections"),
+  mongoDiscover("mongo_list_databases"),
+  mongoDiscover("mongo_list_collections"),
+  mongoDiscover("mongo_inspect_collection"),
+  define({
+    name: "mongo_execute_query",
+    pack: "mongo-execute",
+    risk: "write",
+    surfaces: IN_CHAT_ONLY_SURFACES,
+    resultKind: "data",
+    mcpExclusion: {
+      why: "security",
+      note: "Arbitrary MongoDB JavaScript has no reliable per-query read-only mode.",
+    },
+  }),
+] as const satisfies readonly QueryCapabilityDefinition[];

--- a/packages/agent-tools/src/capabilities/registry.ts
+++ b/packages/agent-tools/src/capabilities/registry.ts
@@ -1,0 +1,34 @@
+/**
+ * Combined agent capability registry across every migrated domain.
+ *
+ * Domains not yet migrated (dashboards, flows, charts, skills, web, …) keep
+ * their existing hand-maintained policy in mode registry / bridge policy /
+ * read-only sets until they get a registry of their own.
+ */
+import { APP_CAPABILITIES } from "./app-capabilities";
+import { CONSOLE_CAPABILITIES } from "./console-capabilities";
+import { DBT_CAPABILITIES } from "./dbt-capabilities";
+import { NOTEBOOK_CAPABILITIES } from "./notebook-capabilities";
+import { QUERY_CAPABILITIES } from "./query-capabilities";
+import type { AgentCapabilityDefinition, AgentSurface } from "./types";
+
+export const AGENT_CAPABILITIES: readonly AgentCapabilityDefinition[] = [
+  ...DBT_CAPABILITIES,
+  ...APP_CAPABILITIES,
+  ...CONSOLE_CAPABILITIES,
+  ...QUERY_CAPABILITIES,
+  ...NOTEBOOK_CAPABILITIES,
+];
+
+export const AGENT_CAPABILITY_BY_NAME: ReadonlyMap<
+  string,
+  AgentCapabilityDefinition
+> = new Map(AGENT_CAPABILITIES.map(capability => [capability.name, capability]));
+
+export function agentCapabilitiesForSurface(
+  surface: AgentSurface,
+): readonly AgentCapabilityDefinition[] {
+  return AGENT_CAPABILITIES.filter(capability =>
+    capability.surfaces.includes(surface),
+  );
+}

--- a/packages/agent-tools/src/capabilities/types.ts
+++ b/packages/agent-tools/src/capabilities/types.ts
@@ -1,0 +1,72 @@
+/**
+ * Transport-neutral agent capability metadata, shared by every domain
+ * registry (dbt, apps, consoles, query, notebooks, …).
+ *
+ * Tool implementations stay server-side. Registries built from these types
+ * are the single source for mode membership, MCP exposure, authorization,
+ * token packs, and UI result semantics.
+ */
+
+export type AgentSurface = "in-chat" | "desktop-acp" | "external-mcp";
+
+export type CapabilityRisk = "read" | "write" | "destructive";
+
+export type CapabilityGrant =
+  | "artifact-write"
+  | "git-write"
+  | "schedule-write"
+  | "warehouse-write";
+
+export const CAPABILITY_GRANTS = [
+  "artifact-write",
+  "git-write",
+  "schedule-write",
+  "warehouse-write",
+] as const satisfies readonly CapabilityGrant[];
+
+export type CapabilityResultKind = "data" | "artifact" | "run" | "ui-effect";
+
+/** Mirrors the MCP bridge policy's exclusion taxonomy. */
+export type CapabilityMcpExclusionWhy =
+  | "client-only"
+  | "security"
+  | "in-product-only"
+  | "deferred";
+
+export interface AgentCapabilityDefinition<
+  Domain extends string = string,
+  Pack extends string = string,
+> {
+  name: string;
+  domain: Domain;
+  pack: Pack;
+  risk: CapabilityRisk;
+  requiredGrant?: CapabilityGrant;
+  surfaces: readonly AgentSurface[];
+  resultKind: CapabilityResultKind;
+  requiresQueryAccess?: boolean;
+  /**
+   * Long-running validation must move to the run registry before MCP exposure.
+   */
+  requiresAsyncMcp?: boolean;
+  /**
+   * When the tool is kept off MCP surfaces, the bridge policy surfaces this
+   * why + note instead of a generic "deferred" classification.
+   */
+  mcpExclusion?: { why: CapabilityMcpExclusionWhy; note: string };
+}
+
+export const ALL_AGENT_SURFACES = [
+  "in-chat",
+  "desktop-acp",
+  "external-mcp",
+] as const satisfies readonly AgentSurface[];
+
+export const PRODUCT_AGENT_SURFACES = [
+  "in-chat",
+  "desktop-acp",
+] as const satisfies readonly AgentSurface[];
+
+export const IN_CHAT_ONLY_SURFACES = [
+  "in-chat",
+] as const satisfies readonly AgentSurface[];

--- a/packages/agent-tools/src/index.ts
+++ b/packages/agent-tools/src/index.ts
@@ -168,19 +168,54 @@ export {
 } from "./read-only-tools";
 
 export {
+  CAPABILITY_GRANTS,
+  type AgentCapabilityDefinition,
+  type AgentSurface,
+  type CapabilityGrant,
+  type CapabilityMcpExclusionWhy,
+  type CapabilityResultKind,
+  type CapabilityRisk,
+} from "./capabilities/types";
+
+export {
   DBT_CAPABILITIES,
   DBT_CAPABILITY_BY_NAME,
   DBT_CAPABILITY_NAMES,
-  CAPABILITY_GRANTS,
   dbtCapabilitiesForPack,
   dbtCapabilitiesForSurface,
-  type AgentSurface,
-  type CapabilityGrant,
-  type CapabilityResultKind,
-  type CapabilityRisk,
   type DbtCapabilityDefinition,
   type DbtCapabilityPack,
 } from "./capabilities/dbt-capabilities";
+
+export {
+  APP_CAPABILITIES,
+  type AppCapabilityDefinition,
+  type AppCapabilityPack,
+} from "./capabilities/app-capabilities";
+
+export {
+  CONSOLE_CAPABILITIES,
+  type ConsoleCapabilityDefinition,
+  type ConsoleCapabilityPack,
+} from "./capabilities/console-capabilities";
+
+export {
+  QUERY_CAPABILITIES,
+  type QueryCapabilityDefinition,
+  type QueryCapabilityPack,
+} from "./capabilities/query-capabilities";
+
+export {
+  NOTEBOOK_CAPABILITIES,
+  type NotebookCapabilityDefinition,
+  type NotebookCapabilityPack,
+} from "./capabilities/notebook-capabilities";
+
+export {
+  AGENT_CAPABILITIES,
+  AGENT_CAPABILITY_BY_NAME,
+  agentCapabilitiesForSurface,
+} from "./capabilities/registry";
 
 export {
   applyModification,

--- a/packages/agent-tools/src/read-only-tools.ts
+++ b/packages/agent-tools/src/read-only-tools.ts
@@ -15,48 +15,23 @@
  * a raw query can contain writes (INSERT/UPDATE/DELETE/DDL) and we cannot
  * statically guarantee otherwise, so plan mode blocks them until approval.
  */
-import { DBT_CAPABILITIES } from "./capabilities/dbt-capabilities";
+import { AGENT_CAPABILITIES } from "./capabilities/registry";
 
 export const READ_ONLY_TOOL_NAMES: ReadonlySet<string> = new Set<string>([
-  // Cross-surface discovery
-  "list_connections",
-  // SQL discovery / inspection
-  "sql_list_connections",
-  "sql_list_databases",
-  "sql_list_tables",
-  "sql_inspect_table",
-  // MongoDB discovery / inspection
-  "mongo_list_connections",
-  "mongo_list_databases",
-  "mongo_list_collections",
-  "mongo_inspect_collection",
+  // Migrated domains (dbt, apps, consoles, SQL/mongo, notebooks) derive their
+  // read inventory from the shared capability registry.
+  ...AGENT_CAPABILITIES.filter(capability => capability.risk === "read").map(
+    capability => capability.name,
+  ),
   // Flow discovery / inspection (shared agent-lib builders)
   "list_databases",
   "list_tables",
   "inspect_table",
-  // Console reads
-  "read_console",
-  "list_open_consoles",
   // Dashboard reads / previews
   "list_open_dashboards",
   "get_dashboard_state",
   "get_chart_templates",
   "get_chart_template",
-  // App reads
-  "list_open_apps",
-  "get_app_state",
-  "app_search",
-  "app_read_resource",
-  "app_read_file",
-  // Notebook reads
-  "list_open_notebooks",
-  "read_notebook",
-  "search_notebook",
-  "read_notebook_cell",
-  // dbt read/validation inventory is derived from the capability registry.
-  ...DBT_CAPABILITIES.filter(capability => capability.risk === "read").map(
-    capability => capability.name,
-  ),
   // Surface-scoped data-source reads (apps + dashboards, local DuckDB only)
   "list_data_sources",
   "inspect_data_source",
@@ -64,7 +39,6 @@ export const READ_ONLY_TOOL_NAMES: ReadonlySet<string> = new Set<string>([
   // Visual inspection (no mutation)
   "capture_screenshot",
   // Search
-  "search_consoles",
   "search_dashboards",
   "search_skills",
   "search_tools",


### PR DESCRIPTION
## Summary

Follow-up to #755: the "same exercise" for the other MCP-bridged tool domains. Apps, consoles, SQL/mongo, and notebooks (~48 tools) move onto the shared capability registry, so MCP bridging, read-only classification, and grant authorization derive from one source per domain instead of three hand-maintained lists.

- **Shared types** (`packages/agent-tools/src/capabilities/types.ts`): the dbt registry's surface/risk/grant/result metadata generalized to `AgentCapabilityDefinition`, plus an `mcpExclusion` field so registry-driven exclusions keep their why/note in the bridge-gap catalog.
- **Four new registries** (`app-`, `console-`, `query-`, `notebook-capabilities.ts`) combined into `AGENT_CAPABILITIES`; `authorizeAgentCapability`, `MCP_BRIDGE_POLICY`, and `READ_ONLY_TOOL_NAMES` now consume the combined registry (dbt's `dbtBridgePolicyEntries` became the generic `capabilityBridgePolicyEntries`).

### Intentional behavior changes (registry semantics, matching dbt)

- `app_set_binding_schedule` / `schedule_query` require an approved **schedule-write** plan grant on native Chat and Desktop ACP (like dbt jobs). External MCP keeps its implicit headless-authoring authority, so existing MCP clients are unaffected.
- `run_notebook_sql_cell` and `materialize_binding` execute warehouse queries and now carry the **query:read** envelope like `sql_execute_query` / `run_console` (hidden from keys without query scope; Desktop tokens carry `query:read` by default).
- `delete_notebook_cell` is annotated **destructive** over MCP.

Everything else is exposure-preserving: bridged/excluded status, exclusion notes, destructive hints, and the plan-gate read-only set are byte-identical for all migrated tools (verified by the existing MCP inventory + working-set tests).

Dashboards, flows, charts, and DuckDB primitives stay hand-classified for now — they are client-only and gain nothing until server-side implementations exist.

## Test plan

- [x] `mako-mcp-server.test.ts` — new coverage: schedule grant gate on Desktop ACP vs implicit external authority, query-scope hiding of notebook SQL / materialize, duplicate-name guard on the combined registry
- [x] `tool-working-set.test.ts` — native chat blocks `app_set_binding_schedule` without an approved `schedule-write` grant, allows it after approval
- [x] Full api test chain, `@mako/agent-tools` tests, api lint, app typecheck + lint all green locally

Made with [Cursor](https://cursor.com)