### PR TITLE
feat(agent): one tool per job — unify run_app, console delivery, and HITL schemas across surfaces

### DIFF
--- a/api/src/mcp/bridge-policy.ts
+++ b/api/src/mcp/bridge-policy.ts
@@ -101,6 +101,18 @@ function capabilityBridgePolicyEntries(
           }),
         ];
       }
+      if (desktop && capability.desktopDelivery === "mako-desktop") {
+        // Desktop ACP gets this tool from the mako-desktop loopback server;
+        // the Mako bridge never serves it on any MCP surface.
+        return [
+          capability.name,
+          exclude(
+            capability.mcpExclusion?.why ?? "client-only",
+            capability.mcpExclusion?.note ??
+              "Delivered by the mako-desktop loopback server on Desktop ACP.",
+          ),
+        ];
+      }
       if (desktop) {
         return [
           capability.name,
@@ -401,13 +413,13 @@ export function mcpReadOnlyHint(
     queryAccess === "read" &&
     (name === "sql_execute_query" ||
       name === "run_console" ||
-      name === "check_query_status" ||
-      name === "list_console_executions" ||
       name === "cancel_query")
   ) {
-    // Under query:read the SQL loop is forced read-only; status/cancel/list
-    // are part of that same lifecycle and should not look like writes to MCP
-    // clients (affects auto-approval annotations).
+    // Under query:read the SQL loop is forced read-only; cancel is part of
+    // that same lifecycle and should not look like a write to MCP clients
+    // (affects auto-approval annotations). check_query_status and
+    // list_console_executions are read-risk in the capability registry, so
+    // they are covered by READ_ONLY_TOOL_NAMES above regardless of scope.
     return true;
   }
   return false;

--- a/api/src/mcp/bridge-policy.ts
+++ b/api/src/mcp/bridge-policy.ts
@@ -153,7 +153,7 @@ export const MCP_BRIDGE_POLICY: Readonly<Record<string, McpBridgeEntry>> = {
   // ── Charts / screenshots (client) ─────────────────────────────────────
   capture_screenshot: exclude(
     "client-only",
-    "Captures the open browser tab; MCP uses render_app screenshots.",
+    "Captures the open browser tab; MCP uses run_app screenshots.",
   ),
   get_chart_template: exclude(
     "client-only",

--- a/api/src/mcp/bridge-policy.ts
+++ b/api/src/mcp/bridge-policy.ts
@@ -33,6 +33,11 @@ export type McpBridgeEntry =
       /** Expose only to the signed-in Mako Desktop ACP client. */
       acpDesktopOnly?: boolean;
       /**
+       * Omit for Desktop ACP clients: the mako-desktop loopback server
+       * delivers this same tool name there (one name, one provider).
+       */
+      omitForAcpDesktop?: boolean;
+      /**
        * Factory may omit this tool without credentials/config (e.g. web_search
        * when no search provider is configured). Still classified so the catalog
        * stays complete; inventory/staleness checks treat it as optional.
@@ -91,6 +96,8 @@ function capabilityBridgePolicyEntries(
           bridge({
             requiresQueryAccess: capability.requiresQueryAccess,
             destructiveHint: capability.risk === "destructive",
+            omitForAcpDesktop:
+              capability.desktopDelivery === "mako-desktop" || undefined,
           }),
         ];
       }

--- a/api/src/mcp/mako-mcp-server.test.ts
+++ b/api/src/mcp/mako-mcp-server.test.ts
@@ -211,6 +211,7 @@ async function main() {
       "check_query_status",
       "list_console_executions",
       "cancel_query",
+      "open_console",
       "read_notebook",
       "search_notebook",
       "read_notebook_cell",
@@ -547,6 +548,11 @@ async function main() {
       desktopTools.some(tool => tool.name === "run_app"),
       false,
       "Desktop ACP must get run_app from mako-desktop, not the Mako bridge",
+    );
+    assert.equal(
+      desktopTools.some(tool => tool.name === "list_open_consoles"),
+      false,
+      "Desktop ACP must get list_open_consoles from mako-desktop, not the Mako bridge",
     );
   }
 

--- a/api/src/mcp/mako-mcp-server.test.ts
+++ b/api/src/mcp/mako-mcp-server.test.ts
@@ -139,7 +139,7 @@ async function main() {
     assert.ok(result.capabilities.resources);
     assert.match(
       result.instructions ?? "",
-      /render_app/,
+      /Verify with run_app/,
       "initialize should ship the workflow instructions",
     );
   }
@@ -173,8 +173,8 @@ async function main() {
       assert.match(result.instructions ?? "", /mako-desktop|Desktop Chat/i);
       assert.doesNotMatch(
         result.instructions ?? "",
-        /Verify with render_app/,
-        "ACP Desktop must not steer agents toward render_app",
+        /Verify with run_app|Verify with render_app/,
+        "ACP Desktop must not steer agents toward the headless renderer",
       );
     } finally {
       await server.close().catch(() => undefined);
@@ -330,6 +330,14 @@ async function main() {
       names.has("open_app"),
       false,
       "client-only app tools must not be bridged",
+    );
+    // Canonical verify capability: external MCP gets run_app (headless
+    // renderer adapter), annotated read-only like the render it performs.
+    assert.ok(names.has("run_app"), "run_app must be bridged for external MCP");
+    assert.equal(
+      byName.get("run_app")?.annotations?.readOnlyHint,
+      true,
+      "run_app renders a draft and mutates nothing",
     );
     for (const desktopOnlyTool of [
       "dbt_parse",
@@ -520,6 +528,25 @@ async function main() {
         .text,
       /Invalid arguments/,
       "ACP gating disabled: no schedule-write grant required",
+    );
+  }
+
+  // 3f. run_app delivery per surface: external MCP gets the headless
+  //     adapter from the Mako server (asserted in section 3); Desktop ACP
+  //     gets run_app from the mako-desktop loopback server against the live
+  //     tab, so the Mako bridge must omit it there — one name, one provider.
+  {
+    const [desktopList] = await exchange(
+      [{ jsonrpc: "2.0", id: "run-app-acp", method: "tools/list" }],
+      ["mcp", "query:read"],
+      true,
+    );
+    const desktopTools = (desktopList.result as { tools: { name: string }[] })
+      .tools;
+    assert.equal(
+      desktopTools.some(tool => tool.name === "run_app"),
+      false,
+      "Desktop ACP must get run_app from mako-desktop, not the Mako bridge",
     );
   }
 

--- a/api/src/mcp/mako-mcp-server.ts
+++ b/api/src/mcp/mako-mcp-server.ts
@@ -93,7 +93,7 @@ Typical loop:
 2. Validate queries with sql_execute_query (short exploration timeout). For slow warehouses: create_console → run_console → check_query_status.
 3. create_app → app_write_file / app_edit_file → app_create_data_binding (bind the validated query; pass consoleId to seed from a console).
 4. For dbt work: read_dbt_project_tree → read/edit files → validate asynchronously, then poll dbt_get_run. For large or destructive work (warehouse runs, Git mutations, schedules), prefer proposing a plan via mako-desktop submit_plan before acting.
-5. Desktop opens/refreshes the app tab automatically. Do NOT create_preview_token, render_app, or paste /preview/… URLs. Use mako-desktop run_app / get_preview_errors for iframe errors. For consoles use open_console / create_console; for notebooks use create_notebook / cell tools.
+5. Desktop opens/refreshes the app tab automatically. Do NOT create_preview_token, render_app, or paste /preview/… URLs. Use mako-desktop run_app for iframe errors (rebuild: false polls without rebuilding). For consoles use open_console / create_console; for notebooks use create_notebook / cell tools.
 6. Interactive UX: mako-desktop ask_clarifying_questions / submit_plan (docked Chat cards) — never ask as plain text.
 7. Durable memory: read_self_directive / update_self_directive only. Do NOT write .claude/**/MEMORY.md or other local Claude memory files.
 8. app_save_version to snapshot/publish.

--- a/api/src/mcp/mako-mcp-server.ts
+++ b/api/src/mcp/mako-mcp-server.ts
@@ -27,6 +27,7 @@ import { z } from "zod";
 import { CAPABILITY_GRANTS, type CapabilityGrant } from "@mako/agent-tools";
 
 import { authorizeAgentCapability } from "../agent-lib/capabilities/runtime";
+import { createHeadlessRunAppTool } from "./preview-tools";
 import { createServerAppTools } from "../agent-lib/tools/server-app-tools";
 import { createSqlToolsV2 } from "../agent-lib/tools/sql-tools";
 import { createMongoToolsV2 } from "../agent-lib/tools/mongodb-tools";
@@ -74,7 +75,7 @@ Typical loop:
 1. Discover data: list_connections, then sql_list_tables / sql_inspect_table.
 2. Validate queries with sql_execute_query (short exploration timeout). For slow warehouses: create_console → run_console → check_query_status.
 3. create_app → app_write_file / app_edit_file → app_create_data_binding (bind the validated query; pass consoleId to seed from a console).
-4. Verify with render_app after edits. Pass includeScreenshot: false when you only need status/errors — it is much cheaper than the screenshot.
+4. Verify with run_app after edits (server-side headless render). Pass includeScreenshot: false when you only need status/errors — it is much cheaper than the screenshot.
 5. app_save_version to snapshot/publish.
 
 Skills (same knowledge as the in-product agent):
@@ -188,9 +189,14 @@ export function buildMakoMcpCandidateTools(
   const selfDirectiveTools = createSelfDirectiveTools(workspaceId);
   const webTools = createWebTools();
   const dbtTools = createDbtServerTools(workspaceId, userId, { chatId });
+  // Headless adapter for the canonical run_app capability (external MCP
+  // only — the bridge policy omits it for Desktop ACP, where mako-desktop
+  // provides run_app against the live tab).
+  const headlessRunApp = createHeadlessRunAppTool(context);
 
   return {
     ...appTools,
+    ...headlessRunApp,
     ...consoleTools,
     ...notebookTools,
     ...selfDirectiveTools,
@@ -230,6 +236,7 @@ export function buildMakoMcpToolset(
     const entry = MCP_BRIDGE_POLICY[name];
     if (!entry || entry.status !== "bridge") continue;
     if (entry.acpDesktopOnly && !context.acpDesktop) continue;
+    if (entry.omitForAcpDesktop && context.acpDesktop) continue;
     if (entry.requiresQueryAccess && queryAccess === "none") continue;
     exposed[name] = tool;
   }

--- a/api/src/mcp/preview-tools.ts
+++ b/api/src/mcp/preview-tools.ts
@@ -1,12 +1,13 @@
 /**
- * MCP-only preview tools — the "render" leg of the headless iteration loop.
+ * Headless preview tools — the "verify" leg for external MCP clients.
  *
- * These are not part of the in-product agent's toolset (the in-product
- * agent has a live browser tab via run_app); they exist for external MCP
- * clients that need to see a draft render without a human tab open:
+ * `run_app` is the canonical cross-surface verify capability; this module
+ * provides its headless adapter (Chat uses the live iframe, Desktop ACP the
+ * mako-desktop bridge). Also here:
  *
  *   create_preview_token → signed short-TTL URL an agent-driven browser
  *     (e.g. Claude Code's local Playwright) can load and screenshot.
+ *   render_app → deprecated alias of run_app, kept for existing clients.
  */
 import { tool } from "ai";
 import { Types } from "mongoose";
@@ -83,6 +84,105 @@ const renderAppSchema = z.object({
     ),
 });
 
+type RenderAppInput = z.infer<typeof renderAppSchema>;
+
+/**
+ * Shared execute for the headless verify leg. `run_app` is the canonical
+ * cross-surface name (Chat iframe / mako-desktop bridge / this renderer);
+ * `render_app` remains as a deprecated alias for existing MCP clients.
+ */
+async function executeHeadlessRender(
+  workspaceId: string,
+  { appId, width, height, timeoutMs, includeScreenshot }: RenderAppInput,
+) {
+  if (!Types.ObjectId.isValid(appId)) {
+    return { success: false, error: `Invalid app ID: ${appId}` };
+  }
+  const app = await MakoApp.findOne({
+    _id: new Types.ObjectId(appId),
+    workspaceId: new Types.ObjectId(workspaceId),
+  })
+    .select({ _id: 1 })
+    .lean();
+  if (!app) {
+    return {
+      success: false,
+      error: `App ${appId} not found. Use list_open_apps to see available apps.`,
+    };
+  }
+
+  const baseUrl = clientBaseUrl();
+  if (isAppRenderEnabled()) {
+    // Probe only when we will actually render (renderAppPreview reports its
+    // own "rendering disabled" message otherwise).
+    const unreachable = await previewBaseUnreachableError(baseUrl);
+    if (unreachable) {
+      return { success: false, error: unreachable };
+    }
+  }
+
+  // Short-lived token minted per render; never returned to the caller.
+  const { token } = mintAppPreviewToken({
+    appId,
+    workspaceId,
+    ttlSeconds: 300,
+  });
+  const result = await renderAppPreview({
+    url: `${baseUrl}/preview/${token}`,
+    width,
+    height,
+    timeoutMs,
+    screenshot: includeScreenshot !== false,
+  });
+
+  const summary = {
+    success: result.success,
+    status: result.status,
+    errors: result.errors,
+    consoleLogs: result.consoleLogs,
+    ...(result.error ? { error: result.error } : {}),
+  };
+  if (includeScreenshot === false || !result.screenshotBase64) {
+    return summary;
+  }
+  return {
+    mcpContent: [
+      { type: "text", text: JSON.stringify(summary) },
+      {
+        type: "image",
+        data: result.screenshotBase64,
+        mimeType: "image/jpeg",
+      },
+    ],
+  };
+}
+
+/**
+ * Headless adapter for the canonical `run_app` capability: external MCP
+ * clients get the same tool name Chat and Desktop use, backed by the
+ * server-side renderer. Registered in the MCP candidate set; the bridge
+ * policy omits it for Desktop ACP (mako-desktop provides `run_app` there).
+ */
+export function createHeadlessRunAppTool(context: MakoMcpContext) {
+  const { workspaceId } = context;
+  return {
+    run_app: tool({
+      description:
+        "Verify the app: render its current DRAFT in a server-side headless " +
+        "browser and return render status, build/runtime errors, filtered " +
+        "console output, and a screenshot. Use after edits to confirm the " +
+        "app actually works — no browser needed on your side. " +
+        (isAppRenderEnabled()
+          ? ""
+          : "NOTE: server-side rendering is not configured on this " +
+            "deployment; use create_preview_token with your own browser instead."),
+      inputSchema: renderAppSchema,
+      execute: (input: RenderAppInput) =>
+        executeHeadlessRender(workspaceId, input),
+    }),
+  };
+}
+
 const createPreviewTokenSchema = z.object({
   appId: z.string().describe("The app whose DRAFT should be previewable"),
   ttlSeconds: z
@@ -145,83 +245,13 @@ export function createMcpPreviewTools(context: MakoMcpContext) {
 
     render_app: tool({
       description:
-        "Render the app's current DRAFT in a server-side headless browser " +
-        "and return its render status, any build/runtime errors, filtered " +
-        "console output, and a screenshot. Use this after edits to verify " +
-        "the app actually works — it needs no browser on your side. " +
-        (isAppRenderEnabled()
-          ? ""
-          : "NOTE: server-side rendering is not configured on this " +
-            "deployment; use create_preview_token with your own browser instead."),
+        "DEPRECATED alias of run_app — call run_app instead (same inputs, " +
+        "same result). Renders the app's current DRAFT in a server-side " +
+        "headless browser and returns render status, errors, console " +
+        "output, and a screenshot.",
       inputSchema: renderAppSchema,
-      execute: async ({
-        appId,
-        width,
-        height,
-        timeoutMs,
-        includeScreenshot,
-      }) => {
-        if (!Types.ObjectId.isValid(appId)) {
-          return { success: false, error: `Invalid app ID: ${appId}` };
-        }
-        const app = await MakoApp.findOne({
-          _id: new Types.ObjectId(appId),
-          workspaceId: new Types.ObjectId(workspaceId),
-        })
-          .select({ _id: 1 })
-          .lean();
-        if (!app) {
-          return {
-            success: false,
-            error: `App ${appId} not found. Use list_open_apps to see available apps.`,
-          };
-        }
-
-        const baseUrl = clientBaseUrl();
-        if (isAppRenderEnabled()) {
-          // Probe only when we will actually render (renderAppPreview
-          // reports its own "rendering disabled" message otherwise).
-          const unreachable = await previewBaseUnreachableError(baseUrl);
-          if (unreachable) {
-            return { success: false, error: unreachable };
-          }
-        }
-
-        // Short-lived token minted per render; never returned to the caller.
-        const { token } = mintAppPreviewToken({
-          appId,
-          workspaceId,
-          ttlSeconds: 300,
-        });
-        const result = await renderAppPreview({
-          url: `${baseUrl}/preview/${token}`,
-          width,
-          height,
-          timeoutMs,
-          screenshot: includeScreenshot !== false,
-        });
-
-        const summary = {
-          success: result.success,
-          status: result.status,
-          errors: result.errors,
-          consoleLogs: result.consoleLogs,
-          ...(result.error ? { error: result.error } : {}),
-        };
-        if (includeScreenshot === false || !result.screenshotBase64) {
-          return summary;
-        }
-        return {
-          mcpContent: [
-            { type: "text", text: JSON.stringify(summary) },
-            {
-              type: "image",
-              data: result.screenshotBase64,
-              mimeType: "image/jpeg",
-            },
-          ],
-        };
-      },
+      execute: (input: RenderAppInput) =>
+        executeHeadlessRender(workspaceId, input),
     }),
   };
 }

--- a/app/src/agent-runtime/client-tool-manifest.ts
+++ b/app/src/agent-runtime/client-tool-manifest.ts
@@ -646,10 +646,13 @@ export const AGENT_TOOL_MANIFEST = {
     execution: "client",
     clientExecutor: "app",
     longRunning: true,
-    getLabel: () => "Rebuilding app preview",
+    getLabel: input =>
+      (input as { rebuild?: boolean } | undefined)?.rebuild === false
+        ? "Checking preview errors"
+        : "Rebuilding app preview",
     icon: "play",
   },
-  // Desktop ACP (mako-desktop) — read live iframe errors without rebuilding.
+  // Legacy alias from pre-0.3 Local Agent builds — run_app({ rebuild: false }).
   get_preview_errors: {
     domain: "app",
     execution: "client",

--- a/app/src/app-runtime/agent-tools.ts
+++ b/app/src/app-runtime/agent-tools.ts
@@ -438,9 +438,13 @@ export async function executeAppAgentTool(
     case "run_app": {
       if (!appId) return fail("appId is required");
       await ensureApp(appId);
-      store.bumpPreview(appId);
-      // Give the preview a moment to rebuild and report errors.
-      await new Promise(resolve => setTimeout(resolve, 1200));
+      // rebuild: false = read current errors only — no bumpPreview, which
+      // flashes a black "Building preview…" screen and can remount Chat.
+      if (input.rebuild !== false) {
+        store.bumpPreview(appId);
+        // Give the preview a moment to rebuild and report errors.
+        await new Promise(resolve => setTimeout(resolve, 1200));
+      }
       const errors = summarizePreviewErrors(
         useAppStore.getState().previewErrors[appId],
       );

--- a/app/src/lib/desktop-acp-bridge.ts
+++ b/app/src/lib/desktop-acp-bridge.ts
@@ -18,6 +18,7 @@ import { localAgentClient } from "./local-agent-client";
 
 type BridgeToolName =
   | "run_app"
+  // Legacy alias from pre-0.3 Local Agent builds — run_app({ rebuild: false }).
   | "get_preview_errors"
   | "list_open_consoles"
   | DesktopHitlToolName;
@@ -69,8 +70,9 @@ async function executeImmediateJob(job: BridgeJob): Promise<unknown> {
   }
 
   if (job.tool === "get_preview_errors") {
-    // Read-only — never bumpPreview / rebuild the iframe (that blacks out
-    // the app preview and can remount Chat mid-turn).
+    // Legacy alias from pre-0.3 Local Agent builds. Read-only — never
+    // bumpPreview / rebuild the iframe (that blacks out the app preview
+    // and can remount Chat mid-turn).
     return {
       success: true,
       appId,
@@ -81,7 +83,12 @@ async function executeImmediateJob(job: BridgeJob): Promise<unknown> {
   }
 
   if (job.tool === "run_app") {
-    return executeAppAgentTool("run_app", { appId });
+    // rebuild: false = the executor skips the iframe rebuild and returns
+    // the current preview errors (the old get_preview_errors behavior).
+    return executeAppAgentTool("run_app", {
+      appId,
+      rebuild: job.arguments.rebuild,
+    });
   }
 
   throw new Error(`Unsupported desktop bridge tool: ${job.tool}`);

--- a/docs/src/content/docs/mcp-server.md
+++ b/docs/src/content/docs/mcp-server.md
@@ -88,7 +88,7 @@ The server ships usage instructions with the handshake, so agents discover this 
 1. **Discover** — `list_connections`, `sql_list_tables`, `sql_inspect_table` (schemas + sample rows), plus MongoDB discovery/inspection. `search_consoles` / `search_dashboards` find existing workspace work. Skills: `list_skills` (index), `get_relevant_skills` (ranked bodies for your task — same retrieval as the in-product agent), then `load_skill` / `read_skill_resource` as needed.
 2. **Validate queries** — `sql_execute_query` (read-only, short exploration timeout). Slow warehouse? `create_console` → `run_console` → `check_query_status` for long-running queries.
 3. **Build apps** — `create_app`, `app_write_file` / `app_edit_file`, `app_create_data_binding` (bind the validated query), version history and restore.
-4. **Verify visually** — `render_app` renders the draft server-side and returns status, errors, filtered console output, and a screenshot. `create_preview_token` mints a short-lived, login-free preview URL to share or open yourself.
+4. **Verify visually** — `run_app` renders the draft server-side and returns status, errors, filtered console output, and a screenshot (same tool name the in-product and Desktop agents use; `render_app` remains as a deprecated alias). `create_preview_token` mints a short-lived, login-free preview URL to share or open yourself.
 5. **Publish** — `app_save_version`.
 
 Optional helpers: `web_search` / `fetch_url` for public docs (annotated `openWorldHint`).
@@ -114,7 +114,7 @@ Non-interactive runs (`claude -p …`) don't show permission dialogs — allowli
 claude -p "explore my mako data and summarize revenue" --allowedTools "mcp__mako"
 ```
 
-To keep agent context lean, agents can pass `includeScreenshot: false` to `render_app` while iterating (status + errors only, ~100 bytes) and fetch one screenshot at the end.
+To keep agent context lean, agents can pass `includeScreenshot: false` to `run_app` while iterating (status + errors only, ~100 bytes) and fetch one screenshot at the end.
 
 ## Troubleshooting
 

--- a/packages/agent-tools/src/app-tools.ts
+++ b/packages/agent-tools/src/app-tools.ts
@@ -784,10 +784,20 @@ export const clientAppTools = {
   run_app: tool({
     description:
       "Rebuild and reload the app's LIVE PREVIEW in the browser and return any " +
-      "build/runtime errors. This is the only browser-only app tool — use it to " +
-      "validate that edits render and to read preview errors. Requires an " +
-      "attached browser tab; it is not needed to author or persist an app.",
-    inputSchema: z.object({ appId: appIdField }),
+      "build/runtime errors. Pass rebuild: false to read the current preview " +
+      "errors without forcing a rebuild. Use it to validate that edits render " +
+      "and to read preview errors. Requires an attached browser tab; it is " +
+      "not needed to author or persist an app.",
+    inputSchema: z.object({
+      appId: appIdField,
+      rebuild: z
+        .boolean()
+        .optional()
+        .describe(
+          "Default true. false = return the current preview errors without " +
+            "rebuilding the iframe (no preview flash).",
+        ),
+    }),
   }),
   app_set_preview_environment: tool({
     description:

--- a/packages/agent-tools/src/capabilities/app-capabilities.ts
+++ b/packages/agent-tools/src/capabilities/app-capabilities.ts
@@ -204,16 +204,17 @@ export const APP_CAPABILITIES = [
     },
   }),
   define({
+    // One capability, one name, three adapters: Chat rebuilds the live
+    // iframe (client tool), Desktop delivers it via the mako-desktop
+    // loopback server, and external MCP runs the server-side headless
+    // renderer (api/src/mcp/preview-tools.ts). Rendering a draft mutates
+    // nothing, so it is read-risk on every surface.
     name: "run_app",
     pack: "app-ui",
-    risk: "write",
-    requiredGrant: "artifact-write",
-    surfaces: IN_CHAT_ONLY_SURFACES,
+    risk: "read",
+    surfaces: ALL_AGENT_SURFACES,
     resultKind: "ui-effect",
-    mcpExclusion: {
-      why: "client-only",
-      note: "Browser iframe preview; MCP uses render_app instead.",
-    },
+    desktopDelivery: "mako-desktop",
   }),
   define({
     name: "app_set_preview_environment",

--- a/packages/agent-tools/src/capabilities/app-capabilities.ts
+++ b/packages/agent-tools/src/capabilities/app-capabilities.ts
@@ -225,7 +225,7 @@ export const APP_CAPABILITIES = [
     resultKind: "ui-effect",
     mcpExclusion: {
       why: "client-only",
-      note: "Per-user browser preview state; headless agents use render_app / bindings directly.",
+      note: "Per-user browser preview state; headless agents use run_app / bindings directly.",
     },
   }),
 ] as const satisfies readonly AppCapabilityDefinition[];

--- a/packages/agent-tools/src/capabilities/console-capabilities.ts
+++ b/packages/agent-tools/src/capabilities/console-capabilities.ts
@@ -8,6 +8,7 @@
 import {
   ALL_AGENT_SURFACES,
   IN_CHAT_ONLY_SURFACES,
+  PRODUCT_AGENT_SURFACES,
   type AgentCapabilityDefinition,
 } from "./types";
 
@@ -43,14 +44,19 @@ export const CONSOLE_CAPABILITIES = [
     resultKind: "data",
   }),
   define({
+    // One name, one provider per surface: Chat reads the open tabs directly
+    // (client tool) and Desktop ACP gets the same tool from the mako-desktop
+    // loopback server. No external adapter — headless clients have no open
+    // tabs and use search_consoles instead.
     name: "list_open_consoles",
     pack: "console-orient",
     risk: "read",
-    surfaces: IN_CHAT_ONLY_SURFACES,
+    surfaces: PRODUCT_AGENT_SURFACES,
     resultKind: "data",
+    desktopDelivery: "mako-desktop",
     mcpExclusion: {
       why: "client-only",
-      note: "Open browser tabs; Desktop ACP uses mako-desktop list_open_consoles / UI context.",
+      note: "Open tabs are client state: Desktop ACP gets it from the mako-desktop loopback server; external MCP uses search_consoles.",
     },
   }),
   // ── Authoring ───────────────────────────────────────────────────────────
@@ -79,10 +85,11 @@ export const CONSOLE_CAPABILITIES = [
     resultKind: "artifact",
   }),
   define({
+    // Focuses/opens a tab (realtime event) without changing the console
+    // definition — a UI effect, not a mutation.
     name: "open_console",
     pack: "console-edit",
-    risk: "write",
-    requiredGrant: "artifact-write",
+    risk: "read",
     surfaces: ALL_AGENT_SURFACES,
     resultKind: "ui-effect",
   }),
@@ -96,9 +103,10 @@ export const CONSOLE_CAPABILITIES = [
     requiresQueryAccess: true,
   }),
   define({
+    // Polls a run without affecting it — read-lifecycle, not a write.
     name: "check_query_status",
     pack: "console-run",
-    risk: "write",
+    risk: "read",
     surfaces: ALL_AGENT_SURFACES,
     resultKind: "run",
     requiresQueryAccess: true,
@@ -112,9 +120,10 @@ export const CONSOLE_CAPABILITIES = [
     requiresQueryAccess: true,
   }),
   define({
+    // Lists past runs — read-lifecycle, not a write.
     name: "list_console_executions",
     pack: "console-run",
-    risk: "write",
+    risk: "read",
     surfaces: ALL_AGENT_SURFACES,
     resultKind: "data",
   }),

--- a/packages/agent-tools/src/capabilities/types.ts
+++ b/packages/agent-tools/src/capabilities/types.ts
@@ -54,6 +54,12 @@ export interface AgentCapabilityDefinition<
    * why + note instead of a generic "deferred" classification.
    */
   mcpExclusion?: { why: CapabilityMcpExclusionWhy; note: string };
+  /**
+   * On desktop-acp this capability is delivered by the mako-desktop loopback
+   * server (same tool name), so the Mako MCP bridge must NOT register it for
+   * acpDesktop clients — one name, one provider per surface.
+   */
+  desktopDelivery?: "mako-desktop";
 }
 
 export const ALL_AGENT_SURFACES = [

--- a/packages/agent-tools/src/index.ts
+++ b/packages/agent-tools/src/index.ts
@@ -150,7 +150,7 @@ export {
 export { clientScreenshotTools } from "./screenshot-tools";
 export type { CaptureScreenshotInput } from "./screenshot-tools";
 
-export { clientPlanTools } from "./plan-tools";
+export { clientPlanTools, HITL_TOOL_JSON_SCHEMAS } from "./plan-tools";
 export type {
   ClarifyingQuestion,
   AskClarifyingQuestionsInput,

--- a/packages/agent-tools/src/plan-tools.ts
+++ b/packages/agent-tools/src/plan-tools.ts
@@ -130,6 +130,26 @@ export const clientPlanTools = {
   }),
 };
 
+/**
+ * MCP-ready JSON Schemas for the HITL pair, derived from the zod schemas
+ * above — the single source of truth for every surface. Chat uses the zod
+ * `clientPlanTools` directly; the mako-desktop loopback server (Desktop ACP)
+ * serves these same schemas under the same tool names.
+ */
+function toMcpJsonSchema(schema: z.ZodType): Record<string, unknown> {
+  const json = z.toJSONSchema(schema, {
+    target: "draft-7",
+    io: "input",
+  }) as Record<string, unknown>;
+  delete json.$schema;
+  return json;
+}
+
+export const HITL_TOOL_JSON_SCHEMAS = {
+  ask_clarifying_questions: toMcpJsonSchema(askClarifyingQuestionsSchema),
+  submit_plan: toMcpJsonSchema(submitPlanSchema),
+} as const;
+
 export type ClarifyingQuestion = z.infer<typeof clarifyingQuestionSchema>;
 export type AskClarifyingQuestionsInput = z.infer<
   typeof askClarifyingQuestionsSchema

--- a/packages/local-agent/package.json
+++ b/packages/local-agent/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@agentclientprotocol/sdk": "^1.3.0",
     "@hono/node-server": "^1.14.4",
+    "@mako/agent-tools": "workspace:*",
     "hono": "^4.7.11"
   },
   "devDependencies": {

--- a/packages/local-agent/src/acp/mako-system-append.ts
+++ b/packages/local-agent/src/acp/mako-system-append.ts
@@ -38,7 +38,7 @@ Use \`${prefix}create_notebook\` / \`${prefix}list_open_notebooks\`, then \`${pr
 ## Apps (Desktop preview — not headless)
 The user can see apps in the Mako window. After \`${prefix}create_app\` / \`${prefix}app_write_file\` / \`${prefix}app_edit_file\`, Desktop opens/refreshes the app tab automatically.
 - \`create_preview_token\` / \`render_app\` / \`/preview/…\` URLs are **unavailable and forbidden** in Desktop Chat — never call them or invent preview links.
-- After edits, call \`${desktopPrefix}run_app\` with the appId to rebuild the iframe and read \`previewErrors\`. Use \`${desktopPrefix}get_preview_errors\` to poll without rebuilding.
+- After edits, call \`${desktopPrefix}run_app\` with the appId to rebuild the iframe and read \`previewErrors\`. Pass \`rebuild: false\` to poll errors without rebuilding.
 - Describe what changed in the in-app preview; ask the user to look at the app tab if you need visual confirmation.
 
 ## Workspace memory (Mako — not local Claude files)

--- a/packages/local-agent/src/acp/permissions.test.ts
+++ b/packages/local-agent/src/acp/permissions.test.ts
@@ -21,10 +21,7 @@ describe("ACP permission auto-approve", () => {
   });
 
   it("detects Codex dotted MCP titles for mako workspace/desktop", () => {
-    assert.equal(
-      isMakoMcpToolName("mcp.mako-desktop.get_preview_errors"),
-      true,
-    );
+    assert.equal(isMakoMcpToolName("mcp.mako-desktop.run_app"), true);
     assert.equal(
       isMakoMcpToolName("mcp.mako-workspace.get_relevant_skills"),
       true,
@@ -39,7 +36,7 @@ describe("ACP permission auto-approve", () => {
   it("auto-approves Codex mako-desktop execute tools", () => {
     const decision = shouldAutoApprovePermission({
       toolCall: {
-        title: "mcp.mako-desktop.get_preview_errors",
+        title: "mcp.mako-desktop.run_app",
         kind: "execute",
         _meta: { is_mcp_tool_call: true },
       },

--- a/packages/local-agent/src/acp/permissions.ts
+++ b/packages/local-agent/src/acp/permissions.ts
@@ -34,7 +34,7 @@ export function extractToolCallKind(toolCall: unknown): string {
 /**
  * True for Mako workspace / desktop MCP tools under either naming scheme:
  * - Claude Agent SDK: `mcp__mako-workspace__list_connections`
- * - Codex ACP titles: `mcp.mako-desktop.get_preview_errors` /
+ * - Codex ACP titles: `mcp.mako-desktop.run_app` /
  *   `Mcp.Mako-Workspace.Sql Execute Query`
  *
  * Codex marks these `kind: "execute"`, so without this match they sit in

--- a/packages/local-agent/src/desktop-bridge/mcp.test.ts
+++ b/packages/local-agent/src/desktop-bridge/mcp.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { HITL_TOOL_JSON_SCHEMAS } from "@mako/agent-tools";
 import { handleDesktopMcpExchange } from "./mcp";
 import { desktopBridgeRegistry } from "./registry";
 
@@ -28,6 +29,25 @@ describe("desktop-bridge MCP", () => {
       runApp?.inputSchema.properties.rebuild,
       "run_app must accept rebuild (absorbs the old get_preview_errors)",
     );
+  });
+
+  it("serves the HITL schemas from the shared @mako/agent-tools source", async () => {
+    const exchange = await handleDesktopMcpExchange({
+      jsonrpc: "2.0",
+      id: 10,
+      method: "tools/list",
+    });
+    const body = exchange.body as {
+      result: { tools: Array<{ name: string; inputSchema: unknown }> };
+    };
+    for (const name of ["ask_clarifying_questions", "submit_plan"] as const) {
+      const listed = body.result.tools.find(t => t.name === name);
+      assert.deepEqual(
+        listed?.inputSchema,
+        HITL_TOOL_JSON_SCHEMAS[name],
+        `${name} must serve the schema derived from the chat zod definition`,
+      );
+    }
   });
 
   it("fails run_app when Desktop Chat is not connected", async () => {

--- a/packages/local-agent/src/desktop-bridge/mcp.test.ts
+++ b/packages/local-agent/src/desktop-bridge/mcp.test.ts
@@ -17,11 +17,17 @@ describe("desktop-bridge MCP", () => {
     const names = body.result.tools.map(t => t.name).sort();
     assert.deepEqual(names, [
       "ask_clarifying_questions",
-      "get_preview_errors",
       "list_open_consoles",
       "run_app",
       "submit_plan",
     ]);
+    const runApp = body.result.tools.find(t => t.name === "run_app") as
+      | { inputSchema: { properties: Record<string, unknown> } }
+      | undefined;
+    assert.ok(
+      runApp?.inputSchema.properties.rebuild,
+      "run_app must accept rebuild (absorbs the old get_preview_errors)",
+    );
   });
 
   it("fails run_app when Desktop Chat is not connected", async () => {
@@ -67,6 +73,30 @@ describe("desktop-bridge MCP", () => {
 
     const exchange = await callPromise;
     assert.equal(exchange.status, 200);
+    const body = exchange.body as {
+      result: { isError?: boolean; content: Array<{ text: string }> };
+    };
+    assert.equal(body.result.isError, undefined);
+    assert.match(body.result.content[0].text, /"success":true/);
+  });
+
+  it("translates legacy get_preview_errors into run_app({ rebuild: false })", async () => {
+    desktopBridgeRegistry.touchClient();
+    const callPromise = handleDesktopMcpExchange({
+      jsonrpc: "2.0",
+      id: 4,
+      method: "tools/call",
+      params: { name: "get_preview_errors", arguments: { appId: "app-2" } },
+    });
+
+    const job = await desktopBridgeRegistry.claim(5_000);
+    assert.ok(job);
+    assert.equal(job.tool, "run_app");
+    assert.equal(job.arguments.appId, "app-2");
+    assert.equal(job.arguments.rebuild, false);
+    desktopBridgeRegistry.complete(job.id, { success: true, errors: [] });
+
+    const exchange = await callPromise;
     const body = exchange.body as {
       result: { isError?: boolean; content: Array<{ text: string }> };
     };

--- a/packages/local-agent/src/desktop-bridge/mcp.ts
+++ b/packages/local-agent/src/desktop-bridge/mcp.ts
@@ -2,6 +2,8 @@
  * Minimal stateless MCP (JSON-RPC) server for Desktop-only tools.
  * Claude ACP attaches this as `mako-desktop` over loopback HTTP.
  */
+import { HITL_TOOL_JSON_SCHEMAS } from "@mako/agent-tools";
+
 import {
   desktopBridgeRegistry,
   isDesktopHitlTool,
@@ -57,75 +59,19 @@ const TOOLS: Array<{
     inputSchema: { type: "object", properties: {} },
   },
   {
+    // Schemas are single-sourced from @mako/agent-tools (same zod
+    // definitions the in-app agent uses); only the description is
+    // Desktop-tailored.
     name: "ask_clarifying_questions",
     description:
       "Pause and show clarifying questions in the Mako Chat dock (same UI as the in-app agent). Use this instead of asking questions as plain text. Returns the user's answers.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        questions: {
-          type: "array",
-          minItems: 1,
-          items: {
-            type: "object",
-            properties: {
-              id: { type: "string" },
-              prompt: { type: "string" },
-              type: { type: "string", enum: ["choice", "text"] },
-              options: { type: "array", items: { type: "string" } },
-              allowMultiple: { type: "boolean" },
-              allowOther: { type: "boolean" },
-              recommendedOption: { type: "string" },
-            },
-            required: ["id", "prompt", "type"],
-          },
-        },
-      },
-      required: ["questions"],
-    },
+    inputSchema: HITL_TOOL_JSON_SCHEMAS.ask_clarifying_questions,
   },
   {
     name: "submit_plan",
     description:
-      "Present a reviewable plan in the Mako Chat dock for Approve / Request changes / Cancel. Use before large or multi-step work. For dbt mutations, include only the requiredCapabilities visibly described by the plan. Returns the user's decision.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        title: { type: "string" },
-        planMarkdown: { type: "string" },
-        todos: {
-          type: "array",
-          minItems: 1,
-          items: {
-            type: "object",
-            properties: {
-              id: { type: "string" },
-              content: { type: "string" },
-              status: {
-                type: "string",
-                enum: ["pending", "in_progress", "completed", "cancelled"],
-              },
-            },
-            required: ["content"],
-          },
-        },
-        requiredCapabilities: {
-          type: "array",
-          items: {
-            type: "string",
-            enum: [
-              "artifact-write",
-              "warehouse-write",
-              "git-write",
-              "schedule-write",
-            ],
-          },
-          description:
-            "Task-scoped mutation capabilities requested by this plan. Include only capabilities explicitly described in the plan.",
-        },
-      },
-      required: ["title", "planMarkdown", "todos"],
-    },
+      "Present a reviewable plan in the Mako Chat dock for Approve / Request changes / Cancel. Use before large, destructive, or multi-step work. Include only the requiredCapabilities visibly described by the plan — approval grants exactly those. Returns the user's decision.",
+    inputSchema: HITL_TOOL_JSON_SCHEMAS.submit_plan,
   },
 ];
 

--- a/packages/local-agent/src/desktop-bridge/mcp.ts
+++ b/packages/local-agent/src/desktop-bridge/mcp.ts
@@ -9,7 +9,7 @@ import {
 } from "./registry";
 
 const SERVER_NAME = "mako-desktop";
-const SERVER_VERSION = "0.2.0";
+const SERVER_VERSION = "0.3.0";
 const PROTOCOL_VERSION = "2024-11-05";
 
 type JsonRpcId = string | number | null;
@@ -36,23 +36,16 @@ const TOOLS: Array<{
   {
     name: "run_app",
     description:
-      "Rebuild the in-Desktop app preview iframe and return live build/runtime errors (previewErrors). Prefer this over create_preview_token / render_app when Chat is open in Mako Desktop.",
+      "Rebuild the in-Desktop app preview iframe and return live build/runtime errors (previewErrors). Pass rebuild: false to read the current previewErrors without forcing a rebuild. Prefer this over create_preview_token when Chat is open in Mako Desktop.",
     inputSchema: {
       type: "object",
       properties: {
         appId: { type: "string", description: "App id to preview" },
-      },
-      required: ["appId"],
-    },
-  },
-  {
-    name: "get_preview_errors",
-    description:
-      "Return the current Desktop iframe previewErrors for an open app without forcing a rebuild.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        appId: { type: "string", description: "App id" },
+        rebuild: {
+          type: "boolean",
+          description:
+            "Default true. false = return current previewErrors without rebuilding the iframe.",
+        },
       },
       required: ["appId"],
     },
@@ -147,10 +140,17 @@ function fail(id: JsonRpcId, code: number, message: string): JsonRpcResponse {
 }
 
 async function callTool(
-  name: string,
-  args: Record<string, unknown>,
+  rawName: string,
+  rawArgs: Record<string, unknown>,
   context?: { agentSessionId?: string; workspaceId?: string },
 ): Promise<{ text: string; isError?: boolean }> {
+  // Legacy alias from pre-0.3 tool lists: agents mid-session across an
+  // update may still call it — same job as run_app({ rebuild: false }).
+  const legacyPreviewErrors = rawName === "get_preview_errors";
+  const name = legacyPreviewErrors ? "run_app" : rawName;
+  const args = legacyPreviewErrors
+    ? { ...rawArgs, rebuild: false }
+    : rawArgs;
   if (!TOOL_NAMES.has(name as DesktopBridgeToolName)) {
     return { text: `Unknown tool: ${name}`, isError: true };
   }
@@ -210,7 +210,12 @@ async function handleOne(
         ? (params.arguments as Record<string, unknown>)
         : {};
     // HITL tools block the HTTP exchange until Desktop completes — expected.
-    if (isDesktopHitlTool(name) || TOOL_NAMES.has(name as DesktopBridgeToolName)) {
+    // get_preview_errors is a legacy alias resolved inside callTool.
+    if (
+      isDesktopHitlTool(name) ||
+      TOOL_NAMES.has(name as DesktopBridgeToolName) ||
+      name === "get_preview_errors"
+    ) {
       const result = await callTool(name, args, context);
       return ok(id, {
         content: [{ type: "text", text: result.text }],

--- a/packages/local-agent/src/desktop-bridge/registry.ts
+++ b/packages/local-agent/src/desktop-bridge/registry.ts
@@ -5,7 +5,6 @@
 
 export type DesktopBridgeToolName =
   | "run_app"
-  | "get_preview_errors"
   | "list_open_consoles"
   | "ask_clarifying_questions"
   | "submit_plan";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -623,10 +623,13 @@ importers:
     dependencies:
       '@agentclientprotocol/sdk':
         specifier: ^1.3.0
-        version: 1.3.0(zod@3.25.76)
+        version: 1.3.0(zod@4.4.3)
       '@hono/node-server':
         specifier: ^1.14.4
         version: 1.14.4(hono@4.7.11)
+      '@mako/agent-tools':
+        specifier: workspace:*
+        version: link:../agent-tools
       hono:
         specifier: ^4.7.11
         version: 4.7.11
@@ -11499,9 +11502,9 @@ packages:
 
 snapshots:
 
-  '@agentclientprotocol/sdk@1.3.0(zod@3.25.76)':
+  '@agentclientprotocol/sdk@1.3.0(zod@4.4.3)':
     dependencies:
-      zod: 3.25.76
+      zod: 4.4.3
 
   '@ai-sdk/gateway@3.0.124(zod@4.2.1)':
     dependencies:


### PR DESCRIPTION
## Summary

Continues the capability-registry consolidation (#755, #757): where the same logical job was served by multiple tool names or duplicated definitions across Chat / Desktop ACP / external MCP, there is now one canonical capability with surface-specific adapters.

- **`run_app` is the one preview/verify tool everywhere.** Chat keeps the client iframe rebuild, Desktop ACP keeps the `mako-desktop` loopback delivery, and external MCP gains `run_app` backed by the server-side headless renderer. `render_app` stays as a deprecated alias (delete after a deprecation window); `create_preview_token` is unchanged (different job). New registry field `desktopDelivery` + bridge flag `omitForAcpDesktop` guarantee one provider per name per surface. `run_app` is reclassified read-risk — rendering a draft mutates nothing — so external clients get a correct `readOnlyHint` and Chat can verify previews while a plan is pending.
- **`get_preview_errors` folded into `run_app({ rebuild: false })`.** One flag instead of a second tool; skips the iframe rebuild (no black preview flash). The loopback server (0.3.0) stops advertising the old name but translates legacy calls mid-session across an update, and the renderer still executes legacy jobs from pre-0.3 Local Agent builds. **Fully lands with the next desktop release.**
- **`list_open_consoles` is registry-truthful:** declared on in-chat + desktop-acp with `desktopDelivery: mako-desktop`; the Mako-bridge exclusion is now derived from the registry instead of a stale hand-written note.
- **Console read-lifecycle risk labels fixed:** `check_query_status`, `list_console_executions`, `open_console` → `risk: "read"` (poll/list/focus, no mutation). Their MCP read-only annotations are now registry-driven; the hardcoded `mcpReadOnlyHint` special case shrinks to the genuinely scope-contextual trio (`sql_execute_query`, `run_console`, `cancel_query`).
- **HITL schemas single-sourced:** the `mako-desktop` loopback serves `submit_plan` / `ask_clarifying_questions` JSON Schemas derived (`z.toJSONSchema`) from the same zod definitions Chat uses — the hand-maintained copy had drifted (missing field docs, stale dbt-specific description). Desktop agents now get the full field guidance.

## Test plan

- [x] `@mako/agent-tools` tests (18) — read-only set derivation
- [x] `@mako/local-agent` tests (55) — loopback tool list, `rebuild` schema, legacy `get_preview_errors` translation, HITL schemas byte-identical to shared source
- [x] `api` MCP server test — `run_app` bridged externally with `readOnlyHint: true`, omitted for Desktop ACP; `list_open_consoles` never served by the Mako bridge; read-only annotations for the console lifecycle
- [x] `api` tool-working-set / derive-mode-state / preview-token tests
- [x] Lint + typecheck: api, app, local-agent; local-agent esbuild bundle builds
- [ ] After merge: ship a desktop release (loopback 0.3.0), then delete the `render_app` alias in a follow-up

Made with [Cursor](https://cursor.com)