### PR TITLE
chore(desktop): bump version to 0.3.10

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mako/desktop",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "description": "Mako Desktop: a thin Electron shell that loads the Mako web app and bundles the Mako Local Agent, enabling connections to databases on this machine.",
   "main": "dist/main.js",


### PR DESCRIPTION
## Summary
- Bump Mako Desktop to 0.3.10 so `release-desktop.yml` publishes a new release on merge. Recent desktop-adjacent merges (#739, #747, #748, #755, #758) landed without a version bump, so the workflow kept skipping ("release desktop-v0.3.9 already exists") and installed apps had nothing to auto-update to.
- This picks up the latest bundled Local Agent (ACP bridge, unified dbt capabilities) for desktop users via the auto-updater.

## Test plan
- [ ] `release-desktop.yml` runs on merge and creates the `desktop-v0.3.10` release with all feed assets (`latest*.yml`, dmg/zip/exe/AppImage, blockmaps)
- [ ] An installed 0.3.9 app picks up the update (check on launch or within 6h)

Made with [Cursor](https://cursor.com)