### PR TITLE
docs: update render_app references to canonical run_app after #758

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -185,10 +185,11 @@ KERNEL_GATEWAY_URL=http://localhost:8888
 # kernel container the host is host.docker.internal (mapped in docker-compose).
 NOTEBOOK_KERNEL_API_URL=http://host.docker.internal:8080
 
-# Mako MCP server — headless render_app tool (optional)
+# Mako MCP server — headless run_app rendering (optional)
 # Path to a Chromium binary on the API host; unset disables server-side
-# rendering (the MCP render_app tool degrades gracefully and external agents
-# fall back to create_preview_token + their own browser). Container images
-# typically also need --no-sandbox.
+# rendering (the MCP run_app tool degrades gracefully and external agents
+# fall back to create_preview_token + their own browser). render_app remains
+# as a deprecated alias of run_app for existing MCP clients. Container
+# images typically also need --no-sandbox.
 # RENDER_APP_BROWSER_PATH=/usr/bin/chromium
 # RENDER_APP_BROWSER_ARGS=--no-sandbox

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,8 @@ INNGEST_EVENT_KEY=your_inngest_event_key
 INNGEST_SIGNING_KEY=your_inngest_signing_key
 
 # Optional: headless Chromium for server-side app rendering
-# (MCP render_app tool; unset = agents fall back to preview tokens)
+# (MCP run_app tool — render_app is a deprecated alias; unset = agents fall
+# back to preview tokens)
 # RENDER_APP_BROWSER_PATH=/usr/bin/chromium
 
 # Notebook Python kernel (local dev — see .env.example)


### PR DESCRIPTION
## What

Two doc-adjacent comments still called `render_app` "the MCP tool" after #758 unified app preview under the canonical `run_app` capability (three surface adapters: Chat client tool, Desktop ACP loopback, external MCP headless render) and demoted `render_app` to a deprecated alias:

- **CLAUDE.md** (env-vars section): `RENDER_APP_BROWSER_PATH` comment
- **.env.example**: headless-render block

`docs/src/content/docs/mcp-server.md` was already correct (`run_app` canonical, `render_app` noted as deprecated alias). The env var name itself is unchanged — only the comments describing it.

No behavior change; comment-only.