### PR TITLE
feat(mcp): bridge dbt validation to external MCP; gate runs behind warehouse:write scope

### DIFF
--- a/AUTH_README.md
+++ b/AUTH_README.md
@@ -498,8 +498,9 @@ would fall through to the SPA fallback and poison client discovery.
 - `unifiedAuthMiddleware` recognizes the `mcpat_` Bearer prefix and sets
   `authType: "mcpOAuth"` with the grant's workspace binding and scopes.
 - Scopes are always the read-only set (`mcp`, `query:read`). There is
-  deliberately no `query:write` scope — an OAuth grant can never do more
-  than a freshly-created MCP API key.
+  deliberately no `query:write` scope, and OAuth grants can never carry
+  `warehouse:write` — an OAuth grant can never do more than a
+  freshly-created MCP API key with default scopes.
 - Redirect URIs accepted at registration: `https` anywhere, `http` on
   loopback only (RFC 8252), or a custom app scheme (e.g. `cursor://`).
   Max 10 per client.
@@ -513,6 +514,12 @@ Workspace API keys (`revops_*`) now carry a `scopes` array
 `["mcp", "query:read"]`. Legacy keys created before scopes existed have
 `scopes: undefined` and are refused by the MCP endpoint with a rotation
 hint — they keep working everywhere else.
+
+The opt-in `warehouse:write` scope (never granted by default, never
+available to OAuth) maps to the `warehouse-write` capability grant on the
+external MCP surface, exposing governed dbt executions (`dbt_run_model`,
+`dbt_run_job`, `dbt_cancel_run`). It does not unlock raw SQL writes —
+`sql_execute_query` stays read-only under every scope combination.
 
 ### Managing connected agents
 

--- a/api/src/auth/api-key-scopes.ts
+++ b/api/src/auth/api-key-scopes.ts
@@ -1,9 +1,21 @@
+import type { CapabilityGrant } from "@mako/agent-tools";
+
 /**
- * Mako MCP is read-only against workspace data by design: apps are read-only
- * data products, so there is deliberately no `query:write` scope. Anyone who
- * needs database writes should use their own database tooling.
+ * Mako MCP is read-only against workspace *data* by design: apps are
+ * read-only data products, so there is deliberately no `query:write` scope.
+ * Anyone who needs raw database writes should use their own database tooling.
+ *
+ * `warehouse:write` is narrower than a query-write scope would be: it does
+ * not unlock arbitrary DML — it maps to the `warehouse-write` capability
+ * grant, whose only external-MCP tools are governed dbt executions
+ * (dbt_run_model / dbt_run_job / dbt_cancel_run). It is never granted by
+ * default; workspace admins opt a key in explicitly.
  */
-export const WORKSPACE_API_KEY_SCOPES = ["mcp", "query:read"] as const;
+export const WORKSPACE_API_KEY_SCOPES = [
+  "mcp",
+  "query:read",
+  "warehouse:write",
+] as const;
 
 export type WorkspaceApiKeyScope = (typeof WORKSPACE_API_KEY_SCOPES)[number];
 
@@ -79,4 +91,20 @@ export function queryAccessFromScopes(
 export function restQueryAccessFromStoredScopes(value: unknown): QueryAccess {
   if (value === undefined) return "write";
   return queryAccessFromScopes(resolveWorkspaceApiKeyScopes(value));
+}
+
+/**
+ * Capability grants an external MCP credential opts into via scopes.
+ * Grants that no scope maps to (artifact-write, schedule-write) are the
+ * implicit headless-authoring authority external MCP has always had; the
+ * MCP server unions those in itself (see externalMcpCapabilityGrants).
+ */
+export function capabilityGrantsFromScopes(
+  scopes: readonly WorkspaceApiKeyScope[],
+): CapabilityGrant[] {
+  const grants: CapabilityGrant[] = [];
+  if (hasWorkspaceApiKeyScope(scopes, "warehouse:write")) {
+    grants.push("warehouse-write");
+  }
+  return grants;
 }

--- a/api/src/mcp/mako-mcp-server.test.ts
+++ b/api/src/mcp/mako-mcp-server.test.ts
@@ -18,6 +18,7 @@ process.env.ENCRYPTION_KEY =
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 import {
   AGENT_CAPABILITIES,
+  AGENT_CAPABILITY_BY_NAME,
   CAPABILITY_GRANTS,
   DBT_CAPABILITY_NAMES,
   type CapabilityGrant,
@@ -25,6 +26,7 @@ import {
 import { buildMakoMcpServer } from "./mako-mcp-server";
 import { StatelessMcpTransport } from "./stateless-transport";
 import {
+  capabilityGrantsFromScopes,
   parseWorkspaceApiKeyScopes,
   restQueryAccessFromStoredScopes,
   resolveWorkspaceApiKeyScopes,
@@ -87,6 +89,17 @@ async function main() {
     () => parseWorkspaceApiKeyScopes(["mcp", "query:write"]),
     /Unsupported API key scope/,
   );
+  // warehouse:write is grantable (opt-in, never default) and maps to the
+  // warehouse-write capability grant only.
+  assert.deepEqual(
+    parseWorkspaceApiKeyScopes(["mcp", "query:read", "warehouse:write"]),
+    ["mcp", "query:read", "warehouse:write"],
+  );
+  assert.deepEqual(
+    capabilityGrantsFromScopes(["mcp", "query:read", "warehouse:write"]),
+    ["warehouse-write"],
+  );
+  assert.deepEqual(capabilityGrantsFromScopes(["mcp", "query:read"]), []);
   assert.equal(
     sqlReadOnlyAccessError("SELECT 'UPDATE is text' AS value"),
     null,
@@ -290,6 +303,11 @@ async function main() {
       "dbt_get_run",
       "dbt_list_recoverable_files",
       "dbt_restore_file",
+      // Async validation runs (queue + poll dbt_get_run) — read-risk, so
+      // they bridge for every query:read key: author AND validate headlessly.
+      "dbt_parse",
+      "dbt_compile_model",
+      "dbt_show",
     ]) {
       assert.ok(names.has(expected), `missing tool: ${expected}`);
     }
@@ -340,19 +358,88 @@ async function main() {
       true,
       "run_app renders a draft and mutates nothing",
     );
-    for (const desktopOnlyTool of [
-      "dbt_parse",
-      "dbt_compile_model",
-      "dbt_show",
+    // Warehouse-mutating dbt runs require the explicit warehouse:write
+    // scope; a default query:read key must not see them.
+    for (const warehouseGatedTool of [
       "dbt_run_model",
+      "dbt_run_job",
       "dbt_cancel_run",
     ]) {
       assert.equal(
-        names.has(desktopOnlyTool),
+        names.has(warehouseGatedTool),
         false,
-        `${desktopOnlyTool} must stay off general MCP`,
+        `${warehouseGatedTool} must stay hidden without warehouse:write`,
       );
     }
+  }
+
+  // 3a. warehouse:write opt-in: run tools appear (destructive-annotated) and
+  //     authorize; without the scope the call fails as an unknown tool and
+  //     the capability runtime would refuse it regardless.
+  {
+    const [res] = await exchange(
+      [{ jsonrpc: "2.0", id: "wh-list", method: "tools/list" }],
+      ["mcp", "query:read", "warehouse:write"],
+    );
+    const { tools } = res.result as {
+      tools: {
+        name: string;
+        annotations?: { destructiveHint?: boolean; readOnlyHint?: boolean };
+      }[];
+    };
+    const byName = new Map(tools.map(tool => [tool.name, tool]));
+    for (const runTool of ["dbt_run_model", "dbt_run_job", "dbt_cancel_run"]) {
+      assert.ok(
+        byName.has(runTool),
+        `${runTool} must be exposed with warehouse:write`,
+      );
+    }
+    assert.equal(
+      byName.get("dbt_run_model")?.annotations?.destructiveHint,
+      true,
+    );
+    assert.equal(byName.get("dbt_run_job")?.annotations?.destructiveHint, true);
+    // Validation stays read-annotated so clients can auto-approve it.
+    assert.equal(byName.get("dbt_parse")?.annotations?.readOnlyHint, true);
+    assert.equal(byName.get("dbt_show")?.annotations?.readOnlyHint, true);
+
+    const [ungated] = await exchange([
+      {
+        jsonrpc: "2.0",
+        id: "wh-call",
+        method: "tools/call",
+        params: { name: "dbt_run_model", arguments: {} },
+      },
+    ]);
+    const ungatedResult = ungated.result as {
+      isError?: boolean;
+      content: { text: string }[];
+    };
+    assert.equal(
+      ungatedResult.isError,
+      true,
+      "dbt_run_model without warehouse:write must fail",
+    );
+    assert.match(ungatedResult.content[0].text, /Unknown tool/);
+
+    // With the scope, authorization passes and the zod schema rejects the
+    // empty arguments (proves no grant gate blocked the call).
+    const [gatedCall] = await exchange(
+      [
+        {
+          jsonrpc: "2.0",
+          id: "wh-call-scoped",
+          method: "tools/call",
+          params: { name: "dbt_run_model", arguments: {} },
+        },
+      ],
+      ["mcp", "query:read", "warehouse:write"],
+    );
+    assert.match(
+      (gatedCall.result as { content: { text: string }[] }).content[0].text,
+      /Invalid arguments/,
+      "warehouse:write key reaches dbt_run_model",
+    );
   }
 
   // 3b. Bridge policy covers the live agent inventory — this is how we stay
@@ -372,6 +459,16 @@ async function main() {
       // Conditional tools (e.g. web_search) only appear when optional
       // providers are configured.
       if (entry.conditional || entry.acpDesktopOnly) continue;
+      // Grant-gated tools only appear when the key's scopes opt into the
+      // grant (e.g. warehouse:write); this exchange used the default scopes.
+      const requiredGrant = AGENT_CAPABILITY_BY_NAME.get(name)?.requiredGrant;
+      if (
+        requiredGrant &&
+        requiredGrant !== "artifact-write" &&
+        requiredGrant !== "schedule-write"
+      ) {
+        continue;
+      }
       assert.ok(
         exposed.has(name),
         `policy says bridge ${name} but tools/list omitted it`,

--- a/api/src/mcp/mako-mcp-server.ts
+++ b/api/src/mcp/mako-mcp-server.ts
@@ -24,7 +24,11 @@ import {
 import type { Tool as AiTool } from "ai";
 import { nanoid } from "nanoid";
 import { z } from "zod";
-import { CAPABILITY_GRANTS, type CapabilityGrant } from "@mako/agent-tools";
+import {
+  AGENT_CAPABILITY_BY_NAME,
+  CAPABILITY_GRANTS,
+  type CapabilityGrant,
+} from "@mako/agent-tools";
 
 import { authorizeAgentCapability } from "../agent-lib/capabilities/runtime";
 import { createHeadlessRunAppTool } from "./preview-tools";
@@ -46,6 +50,7 @@ import {
   getSystemSkillFullText,
 } from "../agent-lib/skills/system-skills";
 import {
+  capabilityGrantsFromScopes,
   queryAccessFromScopes,
   resolveWorkspaceApiKeyScopes,
   type QueryAccess,
@@ -77,6 +82,8 @@ Typical loop:
 3. create_app → app_write_file / app_edit_file → app_create_data_binding (bind the validated query; pass consoleId to seed from a console).
 4. Verify with run_app after edits (server-side headless render). Pass includeScreenshot: false when you only need status/errors — it is much cheaper than the screenshot.
 5. app_save_version to snapshot/publish.
+
+dbt: read_dbt_project_tree → read/edit files → validate with dbt_parse / dbt_compile_model / dbt_show (async: poll dbt_get_run). Warehouse-mutating runs (dbt_run_model, dbt_run_job) appear only when the API key has the warehouse:write scope.
 
 Skills (same knowledge as the in-product agent):
 - list_skills → compact index (workspace + system).
@@ -220,6 +227,40 @@ export function buildMakoMcpCandidateTools(
 }
 
 /**
+ * Grants held by this MCP session.
+ *
+ * External MCP keeps its long-standing implicit headless-authoring authority
+ * (artifact-write for app/notebook/dbt-file drafts, schedule-write for
+ * binding schedules — both relied on by every existing key), and derives the
+ * rest from explicit opt-in API-key scopes (warehouse:write → the
+ * warehouse-write grant behind dbt_run_model / dbt_run_job / dbt_cancel_run).
+ *
+ * Desktop ACP holds every grant: plan-grant gating is DISABLED pending
+ * product review — see the CallTool comment below.
+ */
+const EXTERNAL_MCP_IMPLICIT_GRANTS: readonly CapabilityGrant[] = [
+  "artifact-write",
+  "schedule-write",
+];
+
+function sessionCapabilityGrants(
+  context: MakoMcpContext,
+  scopes: readonly WorkspaceApiKeyScope[],
+): Set<CapabilityGrant> {
+  if (context.acpDesktop) {
+    return new Set<CapabilityGrant>([
+      ...CAPABILITY_GRANTS,
+      ...(context.capabilityGrants ?? []),
+    ]);
+  }
+  return new Set<CapabilityGrant>([
+    ...EXTERNAL_MCP_IMPLICIT_GRANTS,
+    ...capabilityGrantsFromScopes(scopes),
+    ...(context.capabilityGrants ?? []),
+  ]);
+}
+
+/**
  * The toolset exposed over MCP. Same implementations the in-product agent
  * uses; assembled per request so every execution is bound to the caller's
  * workspace + acting user. Filtering is driven by bridge-policy.ts.
@@ -229,6 +270,7 @@ export function buildMakoMcpToolset(
 ): Record<string, BridgeableTool> {
   const scopes = resolveWorkspaceApiKeyScopes(context.scopes);
   const queryAccess = queryAccessFromScopes(scopes);
+  const grants = sessionCapabilityGrants(context, scopes);
   const candidates = buildMakoMcpCandidateTools(context);
   const exposed: Record<string, BridgeableTool> = {};
 
@@ -238,6 +280,11 @@ export function buildMakoMcpToolset(
     if (entry.acpDesktopOnly && !context.acpDesktop) continue;
     if (entry.omitForAcpDesktop && context.acpDesktop) continue;
     if (entry.requiresQueryAccess && queryAccess === "none") continue;
+    // Grant-gated tools stay hidden from stateless external clients that
+    // did not opt in via scopes (mirrors the requiresQueryAccess hiding
+    // above). Execution re-checks via authorizeAgentCapability regardless.
+    const requiredGrant = AGENT_CAPABILITY_BY_NAME.get(name)?.requiredGrant;
+    if (requiredGrant && !grants.has(requiredGrant)) continue;
     exposed[name] = tool;
   }
 
@@ -360,17 +407,20 @@ export function buildMakoMcpServer(
     const authorization = authorizeAgentCapability(name, {
       surface: context.acpDesktop ? "desktop-acp" : "external-mcp",
       queryAccess,
-      // Capability-grant gating is DISABLED on every surface pending product
-      // review: the philosophy for now is "same capabilities everywhere", so
-      // external MCP and Desktop ACP implicitly hold every grant, matching
+      // Desktop ACP plan-grant gating is DISABLED pending product review:
+      // the philosophy there is "same capabilities everywhere", matching
       // native Chat (see PLAN_GRANT_GATING_ENABLED in
-      // agents/modes/runtime.ts). Surface membership and query-access scopes
-      // still apply. To re-enable ACP gating, restore: artifact-write +
+      // agents/modes/runtime.ts) — sessionCapabilityGrants hands ACP every
+      // grant. External MCP has no human in the loop, so it holds only the
+      // implicit headless-authoring grants plus whatever the API key's
+      // scopes explicitly opt into (warehouse:write → warehouse-write).
+      // Surface membership and query-access scopes still apply. To
+      // re-enable ACP gating, restore: artifact-write +
       // context.capabilityGrants (from resolveAcpPlanGrants).
-      grants: new Set<CapabilityGrant>([
-        ...CAPABILITY_GRANTS,
-        ...(context.capabilityGrants ?? []),
-      ]),
+      grants: sessionCapabilityGrants(
+        context,
+        resolveWorkspaceApiKeyScopes(context.scopes),
+      ),
     });
     if (!authorization.allowed) {
       return {

--- a/docs/src/content/docs/mcp-server.md
+++ b/docs/src/content/docs/mcp-server.md
@@ -9,7 +9,7 @@ Where [MCP Connectors](/mcp-connectors/) let Mako's agent use *other* systems' t
 
 Want Claude Code or Codex **inside** the Mako UI instead? See [Coding Agents (ACP)](/coding-agents-acp/).
 
-**Data access over MCP is read-only by design.** Agents can never write to your databases through Mako — there is no scope or setting that enables it.
+**Data access over MCP is read-only by design.** Agents can never run raw SQL writes against your databases through Mako — there is no scope or setting that enables DML/DDL. The one deliberate, opt-in exception is governed dbt execution: an API key explicitly created with the `warehouse:write` scope may trigger dbt runs (which build model definitions that live in your project, not ad-hoc statements). OAuth sign-in grants remain fully read-only.
 
 ## Connect by signing in (no API key)
 
@@ -90,6 +90,7 @@ The server ships usage instructions with the handshake, so agents discover this 
 3. **Build apps** — `create_app`, `app_write_file` / `app_edit_file`, `app_create_data_binding` (bind the validated query), version history and restore.
 4. **Verify visually** — `run_app` renders the draft server-side and returns status, errors, filtered console output, and a screenshot (same tool name the in-product and Desktop agents use; `render_app` remains as a deprecated alias). `create_preview_token` mints a short-lived, login-free preview URL to share or open yourself.
 5. **Publish** — `app_save_version`.
+6. **dbt** — `read_dbt_project_tree` and the dbt file tools author models headlessly; `dbt_parse` / `dbt_compile_model` / `dbt_show` validate them asynchronously (start a run, poll `dbt_get_run`). Warehouse-mutating runs (`dbt_run_model`, `dbt_run_job`, plus `dbt_cancel_run`) only appear for API keys carrying the opt-in `warehouse:write` scope — see the security model below.
 
 Optional helpers: `web_search` / `fetch_url` for public docs (annotated `openWorldHint`).
 
@@ -99,7 +100,8 @@ Read-only tools are annotated per the MCP spec (`readOnlyHint`), so well-behaved
 
 ## Security model
 
-- **Read-only, no exceptions.** SQL must be a single `SELECT`/`WITH` statement; enforcement also happens *inside the database* where supported (PostgreSQL/Cloud SQL/Redshift read-only transactions, MySQL `START TRANSACTION READ ONLY`, ClickHouse `readonly=2`). Arbitrary MongoDB JavaScript is not exposed at all — Mongo is discovery/inspection only.
+- **SQL is read-only, no exceptions.** SQL must be a single `SELECT`/`WITH` statement; enforcement also happens *inside the database* where supported (PostgreSQL/Cloud SQL/Redshift read-only transactions, MySQL `START TRANSACTION READ ONLY`, ClickHouse `readonly=2`). Arbitrary MongoDB JavaScript is not exposed at all — Mongo is discovery/inspection only. There is no scope that unlocks raw DML/DDL over MCP.
+- **Warehouse mutations are opt-in and governed.** The only write path to a warehouse over MCP is dbt execution (`dbt_run_model` / `dbt_run_job`), which builds committed, reviewable model definitions — never ad-hoc SQL. These tools are hidden unless a workspace admin creates an API key with the `warehouse:write` scope (never granted by default; OAuth grants stay pinned to the read-only set).
 - **Non-SQL engines fail closed** (MongoDB shell code, Cloudflare KV): the lexical analyzer cannot validate them, so read-only execution refuses them outright. SQL engines without a session-level read-only mode (BigQuery, MSSQL, Cloudflare D1) rely on the validated single-`SELECT`/`WITH` statement instead.
 - **MCP credentials are MCP-only.** OAuth access tokens and scoped keys are rejected on every other API endpoint, so an MCP credential can never be replayed against REST mutation routes.
 - **OAuth grants are least-privilege by construction**: public clients with mandatory PKCE, single-use authorization codes, rotating refresh tokens, hashed at rest, always scoped to the read-only MCP set, and bound to the one workspace chosen at consent.

--- a/packages/agent-tools/src/capabilities/dbt-capabilities.ts
+++ b/packages/agent-tools/src/capabilities/dbt-capabilities.ts
@@ -93,25 +93,30 @@ export const DBT_CAPABILITIES = [
     surfaces: ALL_AGENT_SURFACES,
     resultKind: "artifact",
   }),
+  // Validation runs are async (queue + poll dbt_get_run) since #755, so they
+  // are safe on the stateless external MCP surface. Read-risk validation
+  // bridges for every key; warehouse-mutating runs additionally require the
+  // warehouse-write grant, which external MCP only derives from an explicit
+  // warehouse:write API-key scope.
   define({
     name: "dbt_parse",
     pack: "dbt-validation",
     risk: "read",
-    surfaces: PRODUCT_AGENT_SURFACES,
+    surfaces: ALL_AGENT_SURFACES,
     resultKind: "run",
   }),
   define({
     name: "dbt_compile_model",
     pack: "dbt-validation",
     risk: "read",
-    surfaces: PRODUCT_AGENT_SURFACES,
+    surfaces: ALL_AGENT_SURFACES,
     resultKind: "run",
   }),
   define({
     name: "dbt_show",
     pack: "dbt-validation",
     risk: "read",
-    surfaces: PRODUCT_AGENT_SURFACES,
+    surfaces: ALL_AGENT_SURFACES,
     resultKind: "run",
     requiresQueryAccess: true,
   }),
@@ -120,7 +125,7 @@ export const DBT_CAPABILITIES = [
     pack: "dbt-validation",
     risk: "destructive",
     requiredGrant: "warehouse-write",
-    surfaces: PRODUCT_AGENT_SURFACES,
+    surfaces: ALL_AGENT_SURFACES,
     resultKind: "run",
     requiresQueryAccess: true,
   }),
@@ -137,7 +142,7 @@ export const DBT_CAPABILITIES = [
     pack: "dbt-validation",
     risk: "write",
     requiredGrant: "warehouse-write",
-    surfaces: PRODUCT_AGENT_SURFACES,
+    surfaces: ALL_AGENT_SURFACES,
     resultKind: "run",
   }),
   define({
@@ -294,7 +299,7 @@ export const DBT_CAPABILITIES = [
     pack: "dbt-jobs",
     risk: "destructive",
     requiredGrant: "warehouse-write",
-    surfaces: PRODUCT_AGENT_SURFACES,
+    surfaces: ALL_AGENT_SURFACES,
     resultKind: "run",
     requiresQueryAccess: true,
   }),


### PR DESCRIPTION
## Summary

External MCP could **author** dbt models (the file tools have bridged since #755) but not **validate or run** them: `dbt_get_run`'s own description tells the agent to poll it "AFTER dbt_parse, dbt_compile_model, dbt_show, dbt_run_model, or dbt_run_job" — none of which were exposed. This PR closes that loop in two tiers:

- **Validation bridges unconditionally** — `dbt_parse` / `dbt_compile_model` / `dbt_show` move to `ALL_AGENT_SURFACES` in the capability registry. They became async runs (queue + poll `dbt_get_run`) in #755, which removes the original timeout objection to stateless exposure, and they are read-risk, so they carry `readOnlyHint` and clients can auto-approve them. Headless agents can now author *and* validate.
- **Warehouse-mutating runs are opt-in** — `dbt_run_model` / `dbt_run_job` / `dbt_cancel_run` also join the external surface, but only appear for API keys carrying a new **`warehouse:write` scope** (never granted by default, and never available to OAuth grants — `mcp-oauth.service.ts` pins grants to `DEFAULT_WORKSPACE_API_KEY_SCOPES`). The scope maps to the existing `warehouse-write` capability grant from #755's registry, so authorization flows through the same `authorizeAgentCapability` path every surface uses.

Mechanically, external MCP no longer holds every capability grant implicitly: `sessionCapabilityGrants` gives it the long-standing implicit authoring authority (`artifact-write`, `schedule-write` — behavior-preserving: no previously-exposed external tool required any other grant) plus scope-derived grants. Grant-gated tools are hidden from `tools/list` for keys that didn't opt in (mirroring the existing `requiresQueryAccess` hiding), and execution re-checks authorization regardless. **Desktop ACP behavior is unchanged** — it still holds every grant while plan-grant gating is disabled pending product review (#757).

I read the test that previously asserted these tools "must stay off general MCP" as encoding the legitimate concern that external MCP has no human in the loop — so this PR deliberately does *not* expose runs to existing keys. Every existing key sees exactly one change: three new read-only validation tools. Warehouse mutation requires a workspace admin to mint a new key with the explicit scope. If you'd prefer a different opt-in shape (workspace-level setting instead of a key scope, or holding `dbt_run_*` back entirely), happy to split the PR — the validation tier alone fixes most of the friction.

## Why

Real-world friction from agentic workspace use via the claude.ai MCP connector: during a week of attribution work our Claude sessions authored dbt models over MCP but had to hand off to the in-product agent (via a human relay) for every `dbt_parse`/`dbt_show` round-trip. We (RealAdvisor) drive Mako both ways daily; Mako team members (Jonas/Joan) invited us to upstream fixes for the MCP gaps we hit. Second in the series after #765.

## Test plan

- [x] `pnpm --filter api run lint` (0 errors)
- [x] `tsx src/mcp/mako-mcp-server.test.ts` — updated + new coverage: scope parsing/mapping; default key sees `dbt_parse`/`dbt_compile_model`/`dbt_show` (read-annotated) but not `dbt_run_model`/`dbt_run_job`/`dbt_cancel_run`; `warehouse:write` key sees them destructive-annotated and reaches execution (zod rejects empty args, proving no grant gate blocked it); default-key call fails as unknown tool; policy⇄list consistency accounts for grant hiding
- [x] `tsx src/agents/modes/tool-working-set.test.ts`, `derive-mode-state.test.ts`, `tool-discovery-tools.test.ts`
- [x] `pnpm --filter @mako/agent-tools run test` (18 pass), `pnpm --filter @mako/local-agent run test` (56 pass) — Desktop ACP surface unchanged
- [ ] Live: MCP key with default scopes → author + `dbt_parse` → poll `dbt_get_run`; key with `warehouse:write` → `dbt_run_model` on a dev environment

## Docs

- `docs/src/content/docs/mcp-server.md` — dbt workflow step + security-model wording (the "no scope or setting" absolute now says: raw SQL writes have no scope, governed dbt execution has an explicit opt-in)
- `AUTH_README.md` — `warehouse:write` scope semantics; OAuth stays pinned to read-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
