### PR TITLE
feat(mcp): RFC — double-gated SQL write opt-in (query:write scope + per-connection allowAgentWrites)

### DIFF
--- a/AUTH_README.md
+++ b/AUTH_README.md
@@ -527,6 +527,13 @@ branch, and pull-request tools). Git *reads* (`dbt_git_status`, branch and
 PR listings) are part of the default surface so headless agents can tell
 when their edits are uncommitted drafts.
 
+The opt-in `query:write` scope is double-gated: it yields "write-opt-in"
+query access, which `sql_execute_query` resolves per connection — write
+only where a workspace admin set `allowAgentWrites` on the connection
+document, read-only everywhere else. Console runs and REST query
+endpoints fail closed to read under this scope, and the connection flag
+can never upgrade a key that lacks `query:write`.
+
 ### Managing connected agents
 
 | Method | Endpoint                                        | Description                     |

--- a/api/src/agent-lib/tools/server-console-tools.ts
+++ b/api/src/agent-lib/tools/server-console-tools.ts
@@ -123,11 +123,16 @@ export function createServerConsoleTools({
   userId,
   executionContext,
   chatId,
-  queryAccess = "write",
+  queryAccess: rawQueryAccess = "write",
   surface = "agent",
 }: ServerConsoleToolsOptions) {
   const agentClientId = `agent:${chatId ?? "unknown"}`;
   const runSource = surface === "mcp" ? ("mcp" as const) : ("agent" as const);
+  // Console runs have not adopted per-connection allowAgentWrites
+  // resolution; a query:write ("write-opt-in") credential fails closed to
+  // read here. Only sql_execute_query honors the connection opt-in.
+  const queryAccess: QueryAccess =
+    rawQueryAccess === "write-opt-in" ? "read" : rawQueryAccess;
 
   const loadConsole = async (consoleId: string): Promise<LoadResult> => {
     if (!consoleId) {

--- a/api/src/agent-lib/tools/sql-tools.ts
+++ b/api/src/agent-lib/tools/sql-tools.ts
@@ -873,6 +873,20 @@ function compactQueryFields(fields: unknown): unknown {
   });
 }
 
+/**
+ * Resolve "write-opt-in" (the query:write scope) against one connection:
+ * write only where a workspace admin set allowAgentWrites, read everywhere
+ * else. A plain "read" key can never be upgraded by the connection flag.
+ * Exported for tests.
+ */
+export function effectiveSqlQueryAccess(
+  queryAccess: QueryAccess,
+  connection: { allowAgentWrites?: boolean },
+): QueryAccess {
+  if (queryAccess !== "write-opt-in") return queryAccess;
+  return connection.allowAgentWrites === true ? "write" : "read";
+}
+
 async function executeQueryImpl(
   connectionId: string,
   requestedDatabase: string | undefined,
@@ -897,6 +911,19 @@ async function executeQueryImpl(
 
   const database = await fetchSqlDatabase(connectionId, workspaceId);
   const dialect = getDialect(database.type);
+  const effectiveAccess = effectiveSqlQueryAccess(queryAccess, database);
+  if (queryAccess === "write-opt-in" && effectiveAccess === "read") {
+    const accessError = sqlReadOnlyAccessError(query);
+    if (accessError) {
+      // Agents relay this verbatim, so the error is the docs: say why AND
+      // how to fix it.
+      throw new Error(
+        `${accessError} This API key has the query:write scope, but this ` +
+          "connection has not opted into agent writes — a workspace admin " +
+          "must enable allowAgentWrites on the connection first.",
+      );
+    }
+  }
 
   // Resolve the target database, falling back to the connection's configured
   // default when the model omits `database`. BigQuery/ClickHouse/MSSQL run
@@ -953,7 +980,7 @@ async function executeQueryImpl(
             ...options,
             executionId: registeredExecutionId,
             signal,
-            readOnly: queryAccess === "read",
+            readOnly: effectiveAccess === "read",
           },
         ),
       { signal },

--- a/api/src/auth/api-key-scopes.ts
+++ b/api/src/auth/api-key-scopes.ts
@@ -10,11 +10,20 @@ import type { CapabilityGrant } from "@mako/agent-tools";
  * grant, whose only external-MCP tools are governed dbt executions
  * (dbt_run_model / dbt_run_job / dbt_cancel_run). `git:write` maps to the
  * `git-write` grant behind the dbt Git mutations (commit, branch, PR).
- * Neither is granted by default; workspace admins opt a key in explicitly.
+ *
+ * `query:write` is double-gated: the scope alone only yields
+ * "write-opt-in" access, which stays read-only against every connection
+ * except those a workspace admin explicitly marked `allowAgentWrites` —
+ * so raw DML/DDL requires BOTH a deliberately-scoped key AND a
+ * deliberately-flagged connection.
+ *
+ * None of the write scopes are granted by default; workspace admins opt a
+ * key in explicitly.
  */
 export const WORKSPACE_API_KEY_SCOPES = [
   "mcp",
   "query:read",
+  "query:write",
   "warehouse:write",
   "git:write",
 ] as const;
@@ -78,13 +87,18 @@ export function hasWorkspaceApiKeyScope(
 
 /**
  * "write" only exists for internal callers (the in-product agent and legacy
- * unscoped REST keys); no grantable scope maps to it.
+ * unscoped REST keys); no grantable scope maps to it. "write-opt-in" is the
+ * most a scoped key can get (via query:write): read-only everywhere except
+ * connections explicitly marked allowAgentWrites, resolved at execution
+ * time by the SQL tool layer. Consumers that have not adopted per-connection
+ * resolution MUST treat "write-opt-in" exactly like "read" — fail closed.
  */
-export type QueryAccess = "none" | "read" | "write";
+export type QueryAccess = "none" | "read" | "write-opt-in" | "write";
 
 export function queryAccessFromScopes(
   scopes: readonly WorkspaceApiKeyScope[],
 ): QueryAccess {
+  if (hasWorkspaceApiKeyScope(scopes, "query:write")) return "write-opt-in";
   if (hasWorkspaceApiKeyScope(scopes, "query:read")) return "read";
   return "none";
 }
@@ -92,7 +106,10 @@ export function queryAccessFromScopes(
 /** Legacy unscoped keys retain their pre-existing REST query capability. */
 export function restQueryAccessFromStoredScopes(value: unknown): QueryAccess {
   if (value === undefined) return "write";
-  return queryAccessFromScopes(resolveWorkspaceApiKeyScopes(value));
+  const access = queryAccessFromScopes(resolveWorkspaceApiKeyScopes(value));
+  // REST query endpoints have not adopted per-connection allowAgentWrites
+  // resolution; until they do, a query:write key is read-only there.
+  return access === "write-opt-in" ? "read" : access;
 }
 
 /**

--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -260,6 +260,12 @@ export interface IDatabaseConnection extends Document {
     };
   };
   isDemo?: boolean; // True if this is a demo database connection
+  /**
+   * Opt-in: scoped agent credentials (MCP query:write keys) may run write
+   * statements against this connection. Off by default; read-only agent
+   * access is unaffected. Set it on connections created for agent writes.
+   */
+  allowAgentWrites?: boolean;
   createdBy: string;
   createdAt: Date;
   updatedAt: Date;
@@ -1428,6 +1434,10 @@ const DatabaseConnectionSchema = new Schema<IDatabaseConnection>(
       get: decryptObject,
     },
     isDemo: {
+      type: Boolean,
+      default: false,
+    },
+    allowAgentWrites: {
       type: Boolean,
       default: false,
     },

--- a/api/src/mcp/bridge-policy.ts
+++ b/api/src/mcp/bridge-policy.ts
@@ -401,7 +401,7 @@ export function assertBridgePolicyNotStale(
  */
 export function mcpReadOnlyHint(
   name: string,
-  queryAccess: "none" | "read" | "write",
+  queryAccess: "none" | "read" | "write-opt-in" | "write",
 ): boolean {
   if (READ_ONLY_TOOL_NAMES.has(name)) return true;
   const entry = MCP_BRIDGE_POLICY[name];
@@ -420,6 +420,15 @@ export function mcpReadOnlyHint(
     // (affects auto-approval annotations). check_query_status and
     // list_console_executions are read-risk in the capability registry, so
     // they are covered by READ_ONLY_TOOL_NAMES above regardless of scope.
+    return true;
+  }
+  if (
+    queryAccess === "write-opt-in" &&
+    (name === "run_console" || name === "cancel_query")
+  ) {
+    // Console runs fail closed to read under write-opt-in (only
+    // sql_execute_query resolves the per-connection allowAgentWrites flag,
+    // so it must NOT be annotated read-only here).
     return true;
   }
   return false;

--- a/api/src/mcp/mako-mcp-server.test.ts
+++ b/api/src/mcp/mako-mcp-server.test.ts
@@ -28,10 +28,12 @@ import { StatelessMcpTransport } from "./stateless-transport";
 import {
   capabilityGrantsFromScopes,
   parseWorkspaceApiKeyScopes,
+  queryAccessFromScopes,
   restQueryAccessFromStoredScopes,
   resolveWorkspaceApiKeyScopes,
   type WorkspaceApiKeyScope,
 } from "../auth/api-key-scopes";
+import { effectiveSqlQueryAccess } from "../agent-lib/tools/sql-tools";
 import { sqlReadOnlyAccessError } from "../services/read-only-query.service";
 import {
   assertBridgePolicyCovers,
@@ -84,10 +86,41 @@ async function main() {
     () => parseWorkspaceApiKeyScopes(["mcp", "unknown"]),
     /Unsupported API key scope/,
   );
-  // MCP is read-only by design: query:write is not a grantable scope.
-  assert.throws(
-    () => parseWorkspaceApiKeyScopes(["mcp", "query:write"]),
-    /Unsupported API key scope/,
+  // query:write is double-gated: the scope alone yields "write-opt-in",
+  // which resolves to write ONLY against connections a workspace admin
+  // marked allowAgentWrites — and can never upgrade a plain query:read key.
+  assert.deepEqual(parseWorkspaceApiKeyScopes(["mcp", "query:write"]), [
+    "mcp",
+    "query:write",
+  ]);
+  assert.equal(
+    queryAccessFromScopes(["mcp", "query:read", "query:write"]),
+    "write-opt-in",
+  );
+  assert.equal(queryAccessFromScopes(["mcp", "query:read"]), "read");
+  assert.equal(
+    effectiveSqlQueryAccess("write-opt-in", { allowAgentWrites: true }),
+    "write",
+  );
+  assert.equal(
+    effectiveSqlQueryAccess("write-opt-in", { allowAgentWrites: false }),
+    "read",
+  );
+  assert.equal(effectiveSqlQueryAccess("write-opt-in", {}), "read");
+  assert.equal(
+    effectiveSqlQueryAccess("read", { allowAgentWrites: true }),
+    "read",
+    "the connection flag must never upgrade a read-only key",
+  );
+  assert.equal(
+    effectiveSqlQueryAccess("none", { allowAgentWrites: true }),
+    "none",
+  );
+  // REST endpoints have not adopted per-connection resolution: a
+  // query:write key stays read there.
+  assert.equal(
+    restQueryAccessFromStoredScopes(["mcp", "query:read", "query:write"]),
+    "read",
   );
   // warehouse:write is grantable (opt-in, never default) and maps to the
   // warehouse-write capability grant only.
@@ -526,6 +559,31 @@ async function main() {
       /Invalid arguments/,
       "git:write key reaches dbt_commit_to_branch",
     );
+  }
+
+  // 3a3. query:write annotations: sql_execute_query may write (per-connection
+  //      resolution happens at execution), so it must NOT be annotated
+  //      read-only; console runs fail closed to read and stay annotated so.
+  {
+    const [res] = await exchange(
+      [{ jsonrpc: "2.0", id: "qw-list", method: "tools/list" }],
+      ["mcp", "query:read", "query:write"],
+    );
+    const { tools } = res.result as {
+      tools: { name: string; annotations?: { readOnlyHint?: boolean } }[];
+    };
+    const byName = new Map(tools.map(tool => [tool.name, tool]));
+    assert.equal(
+      byName.get("sql_execute_query")?.annotations?.readOnlyHint,
+      false,
+      "sql_execute_query may write under query:write — no read-only hint",
+    );
+    assert.equal(
+      byName.get("run_console")?.annotations?.readOnlyHint,
+      true,
+      "run_console fails closed to read under query:write",
+    );
+    assert.equal(byName.get("cancel_query")?.annotations?.readOnlyHint, true);
   }
 
   // 3b. Bridge policy covers the live agent inventory — this is how we stay

--- a/api/src/routes/workspace-databases.ts
+++ b/api/src/routes/workspace-databases.ts
@@ -811,6 +811,22 @@ workspaceDatabaseRoutes.openapi(
 
       // Update fields
       if (body.name) database.name = body.name;
+      if (typeof body.allowAgentWrites === "boolean") {
+        // Security-sensitive opt-in (scoped agent credentials may write to
+        // this connection) — owners/admins only, unlike general edits.
+        const memberRole = c.get("memberRole");
+        if (memberRole !== "owner" && memberRole !== "admin") {
+          return c.json(
+            {
+              success: false,
+              error:
+                "Only workspace owners or admins can change allowAgentWrites",
+            },
+            403,
+          );
+        }
+        database.allowAgentWrites = body.allowAgentWrites;
+      }
       if (body.connection) {
         // Build candidate connection using decrypted previous + incoming patch
         const previous =

--- a/docs/src/content/docs/mcp-server.md
+++ b/docs/src/content/docs/mcp-server.md
@@ -9,7 +9,7 @@ Where [MCP Connectors](/mcp-connectors/) let Mako's agent use *other* systems' t
 
 Want Claude Code or Codex **inside** the Mako UI instead? See [Coding Agents (ACP)](/coding-agents-acp/).
 
-**Data access over MCP is read-only by design.** Agents can never run raw SQL writes against your databases through Mako — there is no scope or setting that enables DML/DDL. The one deliberate, opt-in exception is governed dbt execution: an API key explicitly created with the `warehouse:write` scope may trigger dbt runs (which build model definitions that live in your project, not ad-hoc statements). OAuth sign-in grants remain fully read-only.
+**Data access over MCP is read-only by default, everywhere.** OAuth sign-in grants are *always* read-only — no scope can change that. Writes exist only as narrow, double-gated API-key opt-ins a workspace admin must configure deliberately: governed dbt runs (`warehouse:write` scope), dbt Git mutations (`git:write` scope), and — narrowest of all — SQL writes, which require **both** a key with the `query:write` scope **and** a connection explicitly marked *Allow agent writes*. A default key can touch none of these.
 
 ## Connect by signing in (no API key)
 
@@ -101,7 +101,7 @@ Read-only tools are annotated per the MCP spec (`readOnlyHint`), so well-behaved
 
 ## Security model
 
-- **SQL is read-only, no exceptions.** SQL must be a single `SELECT`/`WITH` statement; enforcement also happens *inside the database* where supported (PostgreSQL/Cloud SQL/Redshift read-only transactions, MySQL `START TRANSACTION READ ONLY`, ClickHouse `readonly=2`). Arbitrary MongoDB JavaScript is not exposed at all — Mongo is discovery/inspection only. There is no scope that unlocks raw DML/DDL over MCP.
+- **SQL is read-only unless double-gated otherwise.** By default SQL must be a single `SELECT`/`WITH` statement; enforcement also happens *inside the database* where supported (PostgreSQL/Cloud SQL/Redshift read-only transactions, MySQL `START TRANSACTION READ ONLY`, ClickHouse `readonly=2`). Arbitrary MongoDB JavaScript is not exposed at all — Mongo is discovery/inspection only. SQL writes require an API key with the `query:write` scope **and** a connection a workspace admin marked `allowAgentWrites` — the key scope alone stays read-only against every other connection, the connection flag alone does nothing for read-scoped keys, and console runs, app data bindings, and materializations stay read-only regardless.
 - **Warehouse mutations are opt-in and governed.** The only write path to a warehouse over MCP is dbt execution (`dbt_run_model` / `dbt_run_job`), which builds committed, reviewable model definitions — never ad-hoc SQL. These tools are hidden unless a workspace admin creates an API key with the `warehouse:write` scope (never granted by default; OAuth grants stay pinned to the read-only set).
 - **Git mutations are opt-in the same way.** dbt repository writes (commits, branches, pull requests) require the `git:write` scope; without it the agent can read Git state but every mutation tool stays hidden. Repository-side protections (protected branches, PR reviews) apply on top.
 - **Non-SQL engines fail closed** (MongoDB shell code, Cloudflare KV): the lexical analyzer cannot validate them, so read-only execution refuses them outright. SQL engines without a session-level read-only mode (BigQuery, MSSQL, Cloudflare D1) rely on the validated single-`SELECT`/`WITH` statement instead.


### PR DESCRIPTION
> Supersedes #768 (including its follow-up commit: the connection PUT route accepts `allowAgentWrites`, owner/admin-gated). Stacked PR: base is `feat/mcp-dbt-git-tools`, so this diff shows only the two write-opt-in commits. RFC / design-first — treat the description as the proposal.

## The problem

`sql_execute_query` over MCP is read-only on **every** connection — including connections a workspace admin created *specifically* to receive agent writes (our workspace has a warehouse connection whose whole purpose is materializing agent-built tables). The current docs state the position plainly: *"there is no scope or setting that enables it."* The blanket read-only **default** is absolutely right, and nothing in this PR weakens it. The gap is that there is no opt-in at any layer, so achieving parity with the in-product agent (which writes freely) requires a human to relay every `CREATE TABLE` / `MERGE` by hand.

## Proposed design: double-gated, fail-closed everywhere else

A write requires **two deliberate admin actions**, neither of which exists by default:

1. **A key with the new `query:write` scope** — never granted by default, never available to OAuth grants (those stay pinned to the read-only set). The scope alone yields a new `QueryAccess` level, **`"write-opt-in"`**, not `"write"`.
2. **A connection with `allowAgentWrites: true`** — a new boolean on the connection document (default `false`). `sql_execute_query` resolves `write-opt-in` per connection via an exported pure function `effectiveSqlQueryAccess`: write where the connection opted in, read-only everywhere else, with an actionable error naming the missing flag.

Key invariants, all tested:

- The connection flag can **never upgrade** a key that lacks `query:write` (`effectiveSqlQueryAccess("read", {allowAgentWrites: true}) === "read"`).
- Everything that hasn't adopted per-connection resolution **fails closed to read**: console runs normalize `write-opt-in` → `read`, app data bindings/materializations keep their unconditional read-only enforcement, REST query endpoints map the scope down to `read` (`restQueryAccessFromStoredScopes`).
- Annotations stay honest: under `query:write`, `sql_execute_query` loses its `readOnlyHint` (it *may* write), while `run_console` / `cancel_query` keep theirs (still forced read).
- In-product agent behavior (`queryAccess: "write"`) is untouched.

## Alternatives we considered (and why we landed here)

- **Workspace-level toggle instead of per-connection** — too coarse: the realistic pattern is one dedicated write connection next to many read connections, and a workspace toggle would open all of them at once.
- **Scope-only (no connection flag)** — one compromised/mis-scoped key would reach every connection; the double gate keeps the blast radius to connections designed for writes.
- **Connection-flag-only (no scope)** — every existing default key would silently gain write on flagged connections; scope-on-key keeps the credential itself declaring intent.
- **dbt-only writes (#766)** — right for transformations, but doesn't cover operational writes (scratch tables, agent-managed marts) that the in-product agent does today.

Not in this diff, deliberately: a UI checkbox for the connection flag (the field rides the existing connection document; happy to follow up in `app/` if the shape is accepted) and REST/`run_console` adoption of per-connection resolution (fail-closed until someone needs it).

## Why

Real-world friction from agentic workspace use via the claude.ai MCP connector: a week of attribution work needed a handful of `CREATE OR REPLACE TABLE` statements on a write-designated warehouse connection; each one detoured through a human driving the in-product agent, which does the same write ungated. We (RealAdvisor) drive Mako both ways daily; Mako team members (Jonas/Joan) invited us to upstream fixes for the MCP gaps we hit. Last of the series (#765, #766, #767, plus bug #764).

## Test plan

- [x] `pnpm --filter api run lint` (0 errors)
- [x] Full `pnpm --filter api run test` chain
- [x] `tsx src/mcp/mako-mcp-server.test.ts` — scope parsing; `write-opt-in` mapping; `effectiveSqlQueryAccess` invariants (incl. no-upgrade-for-read-keys); REST fail-closed mapping; annotation honesty under `query:write`
- [ ] Live: `query:write` key + flagged connection → DDL succeeds; same key + unflagged connection → read-only error naming `allowAgentWrites`; default key + flagged connection → read-only error

## Docs

- `docs/src/content/docs/mcp-server.md` — the "read-only by design" intro and security model now describe the default + the three explicit opt-ins precisely
- `AUTH_README.md` — `query:write` double-gate semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)
