### PR TITLE
fix(acp): send composer image attachments to local Claude/Codex as ACP image blocks

### DIFF
--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -33,6 +33,7 @@ import {
   DefaultChatTransport,
   lastAssistantMessageIsCompleteWithApprovalResponses,
   lastAssistantMessageIsCompleteWithToolCalls,
+  type FileUIPart,
 } from "ai";
 import { useMcpStore } from "../store/mcpStore";
 import { api } from "../api/client";
@@ -298,7 +299,7 @@ const Chat: React.FC<ChatProps> = ({
   const manualStopRequestedRef = useRef(false);
   const drainQueuedPromptAfterTurnRef = useRef<(() => void) | null>(null);
   const sendViaLocalAcpRef = useRef<
-    ((text: string) => Promise<boolean>) | null
+    ((text: string, files?: FileUIPart[]) => Promise<boolean>) | null
   >(null);
   const localAcpAbortRef = useRef<AbortController | null>(null);
   const localAcpBindingRef = useRef<{
@@ -715,7 +716,7 @@ const Chat: React.FC<ChatProps> = ({
   // Generation counter: overlapping send/abort must not clear busy while an
   // older turn is still awaiting the Local Agent (that race poisoned Skill
   // cards as "Interrupted" and surfaced "Session is already processing").
-  sendViaLocalAcpRef.current = async (text: string) => {
+  sendViaLocalAcpRef.current = async (text: string, files?: FileUIPart[]) => {
     const modelId = modelIdRef.current;
     if (!modelId || !isLocalAcpModelId(modelId)) return false;
 
@@ -741,6 +742,7 @@ const Chat: React.FC<ChatProps> = ({
       await runLocalAcpChatTurn({
         modelId,
         text,
+        files,
         workspaceId: workspaceIdRef.current,
         chatId: chatIdRef.current,
         preferredSessionId:

--- a/app/src/components/chat/hooks/useQueuedPrompts.test.ts
+++ b/app/src/components/chat/hooks/useQueuedPrompts.test.ts
@@ -13,7 +13,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook } from "@testing-library/react";
 import type { MutableRefObject } from "react";
-import type { UIMessage } from "ai";
+import type { FileUIPart, UIMessage } from "ai";
 import type { SubmitPlanOutput } from "@mako/agent-tools";
 
 vi.mock("../../../store/consoleStore", () => ({
@@ -83,9 +83,9 @@ function buildArgs(overrides: Partial<UseQueuedPromptsArgs> = {}): Harness {
     autoSendWhenComplete: () => false,
     interruptActiveTurn,
     drainQueuedPromptAfterTurnRef: makeRef<(() => void) | null>(null),
-    sendViaLocalAcpRef: makeRef<((text: string) => Promise<boolean>) | null>(
-      null,
-    ),
+    sendViaLocalAcpRef: makeRef<
+      ((text: string, files?: FileUIPart[]) => Promise<boolean>) | null
+    >(null),
     ...overrides,
   };
   return { args, sendMessage, interruptActiveTurn };

--- a/app/src/components/chat/hooks/useQueuedPrompts.ts
+++ b/app/src/components/chat/hooks/useQueuedPrompts.ts
@@ -52,7 +52,7 @@ export interface UseQueuedPromptsArgs {
    * Chat.tsx handles the turn. Return true if the send was claimed.
    */
   sendViaLocalAcpRef: MutableRefObject<
-    ((text: string) => Promise<boolean>) | null
+    ((text: string, files?: FileUIPart[]) => Promise<boolean>) | null
   >;
 }
 
@@ -256,7 +256,7 @@ export function useQueuedPrompts({
     });
     const localSend = sendViaLocalAcpRef.current;
     if (localSend) {
-      void localSend(next.text).then(handled => {
+      void localSend(next.text, next.files).then(handled => {
         if (!handled) {
           sendMessageRef.current?.({ text: next.text, files: next.files });
         }
@@ -364,7 +364,7 @@ export function useQueuedPrompts({
       const localSend = sendViaLocalAcpRef.current;
       if (localSend) {
         isLoadingRef.current = true;
-        void localSend(text).then(handled => {
+        void localSend(text, files).then(handled => {
           if (!handled) {
             sendMessageRef.current?.({ text, files });
           }

--- a/app/src/lib/acp-capabilities.test.ts
+++ b/app/src/lib/acp-capabilities.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   acpSupportsAdapterEnsure,
   acpSupportsModelWarm,
+  acpSupportsPromptImages,
   acpSupportsWorkspaceMcp,
 } from "./acp-capabilities";
 import type { AcpStatus } from "./acp-types";
@@ -31,6 +32,16 @@ describe("acp capabilities", () => {
     );
     expect(
       acpSupportsAdapterEnsure(status({ version: 3, adapterEnsure: true })),
+    ).toBe(true);
+  });
+
+  it("gates prompt images on bridge ≥ 8 or the promptImages flag", () => {
+    expect(acpSupportsPromptImages(null)).toBe(false);
+    expect(acpSupportsPromptImages(status(undefined))).toBe(false);
+    expect(acpSupportsPromptImages(status({ version: 7 }))).toBe(false);
+    expect(acpSupportsPromptImages(status({ version: 8 }))).toBe(true);
+    expect(
+      acpSupportsPromptImages(status({ version: 7, promptImages: true })),
     ).toBe(true);
   });
 });

--- a/app/src/lib/acp-capabilities.ts
+++ b/app/src/lib/acp-capabilities.ts
@@ -20,6 +20,15 @@ export function acpSupportsModelWarm(
   );
 }
 
+/** Prompt image attachments forwarded as ACP ContentBlocks (bridge ≥ 8). */
+export function acpSupportsPromptImages(
+  status: AcpStatus | null | undefined,
+): boolean {
+  const bridge = status?.acpBridge;
+  if (!bridge) return false;
+  return Boolean(bridge.promptImages || bridge.version >= 8);
+}
+
 /** MCP attach / reconnect baseline (bridge ≥ 2). */
 export function acpSupportsWorkspaceMcp(
   status: AcpStatus | null | undefined,

--- a/app/src/lib/acp-client.ts
+++ b/app/src/lib/acp-client.ts
@@ -7,6 +7,7 @@ import type {
   AcpAuthenticateResult,
   AcpBridgeEvent,
   AcpEnsureAdapterResult,
+  AcpPromptImage,
   AcpProviderId,
   AcpSessionInfo,
   AcpStatus,
@@ -141,10 +142,11 @@ export const acpClient = {
   async prompt(
     sessionId: string,
     text: string,
+    images?: AcpPromptImage[],
   ): Promise<{ stopReason: string }> {
     const body = await localAgentClient.post<Envelope<{ stopReason: string }>>(
       `/acp/sessions/${encodeURIComponent(sessionId)}/prompt`,
-      { text },
+      images?.length ? { text, images } : { text },
     );
     return unwrap(body, "Prompt failed");
   },

--- a/app/src/lib/acp-types.ts
+++ b/app/src/lib/acp-types.ts
@@ -55,6 +55,7 @@ export interface AcpStatus {
     hitlTools?: boolean;
     adapterEnsure?: boolean;
     modelWarm?: boolean;
+    promptImages?: boolean;
   };
   lastAdapterError?: string | null;
   ensureByProvider?: Partial<
@@ -148,6 +149,14 @@ export type AcpBridgeEvent =
       message: string;
       at: string;
     };
+
+/** Image attachment forwarded to the Local Agent as an ACP image ContentBlock. */
+export interface AcpPromptImage {
+  /** Base64 payload (no `data:` URL prefix). */
+  data: string;
+  /** e.g. `image/png` */
+  mimeType: string;
+}
 
 export interface AcpChatMessage {
   id: string;

--- a/app/src/lib/local-acp-chat.ts
+++ b/app/src/lib/local-acp-chat.ts
@@ -3,9 +3,11 @@
  * Tool calls become `dynamic-tool` UIMessage parts so Chat uses the same
  * StreamingToolCard UI as the in-app agent.
  */
-import type { UIMessage } from "ai";
+import type { FileUIPart, UIMessage } from "ai";
 import { generateObjectId } from "../utils/objectId";
 import { acpClient } from "./acp-client";
+import { acpSupportsPromptImages } from "./acp-capabilities";
+import { fileUiPartsToAcpImages } from "./local-acp-images";
 import {
   isLocalAcpModelId,
   localAcpModelIdToProviderId,
@@ -233,6 +235,8 @@ export async function ensureAcpSessionForProvider(
 export interface LocalAcpChatTurnArgs {
   modelId: string;
   text: string;
+  /** Composer image attachments (base64 data URLs) — sent as ACP image blocks. */
+  files?: FileUIPart[];
   workspaceId?: string;
   /** Mako History chat id — when set, transcript is persisted after the turn. */
   chatId?: string;
@@ -257,6 +261,7 @@ export async function runLocalAcpChatTurn(
   const {
     modelId,
     text,
+    files,
     workspaceId,
     chatId,
     preferredSessionId,
@@ -272,7 +277,8 @@ export async function runLocalAcpChatTurn(
   }
 
   const trimmed = text.trim();
-  if (!trimmed) return true;
+  const { images, skipped: skippedAttachments } = fileUiPartsToAcpImages(files);
+  if (!trimmed && images.length === 0 && skippedAttachments === 0) return true;
 
   // Mirror message updates synchronously so we can persist after the turn
   // without racing React's batched setState flush.
@@ -298,7 +304,12 @@ export async function runLocalAcpChatTurn(
       {
         id: userId,
         role: "user",
-        parts: [{ type: "text", text: trimmed }],
+        // File parts first (same order the cloud transport uses) so the user
+        // bubble renders attachment thumbnails above the text.
+        parts: [
+          ...((files ?? []) as UIMessage["parts"]),
+          ...(trimmed ? [{ type: "text" as const, text: trimmed }] : []),
+        ],
       },
       {
         id: assistantId,
@@ -417,6 +428,18 @@ export async function runLocalAcpChatTurn(
       { forceNew, model: modelPreference },
     );
     sessionId = ensured.sessionId;
+    // Old Local Agents flatten prompt content to text and silently drop
+    // images — fail loudly instead so the user knows the screenshot never
+    // reached the model.
+    if (
+      images.length > 0 &&
+      !acpSupportsPromptImages(useAcpStore.getState().status)
+    ) {
+      throw new Error(
+        "This Local Agent build can't send image attachments. " +
+          "Update Mako Desktop (or restart the Local Agent), then retry.",
+      );
+    }
     useAcpStore.getState().ensureEventSubscription(sessionId);
     // Fail closed across turns: a missed end-of-turn revoke (renderer/network
     // interruption) must never carry an old plan grant into this request.
@@ -550,7 +573,7 @@ export async function runLocalAcpChatTurn(
 
     try {
       // Prompt includes UI context / continuity; transcript keeps raw user text.
-      await acpClient.prompt(activeSessionId, promptText);
+      await acpClient.prompt(activeSessionId, promptText, images);
       if (signal?.aborted) {
         throw new DOMException("Cancelled", "AbortError");
       }
@@ -600,6 +623,12 @@ export async function runLocalAcpChatTurn(
   try {
     if (signal?.aborted) {
       throw new DOMException("Cancelled", "AbortError");
+    }
+    if (skippedAttachments > 0) {
+      throw new Error(
+        "Only image attachments can be sent to local Claude/Codex. " +
+          "Remove other file types and try again.",
+      );
     }
 
     try {

--- a/app/src/lib/local-acp-images.test.ts
+++ b/app/src/lib/local-acp-images.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import type { FileUIPart } from "ai";
+import { fileUiPartsToAcpImages } from "./local-acp-images";
+
+const PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
+function filePart(url: string, mediaType = "image/png"): FileUIPart {
+  return { type: "file", url, mediaType };
+}
+
+describe("fileUiPartsToAcpImages", () => {
+  it("returns empty for no files", () => {
+    expect(fileUiPartsToAcpImages(undefined)).toEqual({
+      images: [],
+      skipped: 0,
+    });
+    expect(fileUiPartsToAcpImages([])).toEqual({ images: [], skipped: 0 });
+  });
+
+  it("converts base64 data URLs to ACP image payloads", () => {
+    const { images, skipped } = fileUiPartsToAcpImages([
+      filePart(`data:image/png;base64,${PNG_BASE64}`),
+    ]);
+    expect(skipped).toBe(0);
+    expect(images).toEqual([{ data: PNG_BASE64, mimeType: "image/png" }]);
+  });
+
+  it("uses the data URL mime when mediaType is missing", () => {
+    const part = {
+      type: "file",
+      url: `data:image/jpeg;base64,${PNG_BASE64}`,
+    } as FileUIPart;
+    const { images } = fileUiPartsToAcpImages([part]);
+    expect(images[0]?.mimeType).toBe("image/jpeg");
+  });
+
+  it("skips remote URLs and non-image media", () => {
+    const { images, skipped } = fileUiPartsToAcpImages([
+      filePart("https://example.com/shot.png"),
+      filePart(`data:application/pdf;base64,${PNG_BASE64}`, "application/pdf"),
+      filePart(`data:image/png;base64,${PNG_BASE64}`),
+    ]);
+    expect(images).toHaveLength(1);
+    expect(skipped).toBe(2);
+  });
+
+  it("skips data URLs without base64 payloads", () => {
+    const { images, skipped } = fileUiPartsToAcpImages([
+      filePart("data:image/svg+xml,<svg/>", "image/svg+xml"),
+    ]);
+    expect(images).toHaveLength(0);
+    expect(skipped).toBe(1);
+  });
+});

--- a/app/src/lib/local-acp-images.ts
+++ b/app/src/lib/local-acp-images.ts
@@ -1,0 +1,33 @@
+/**
+ * Convert composer image attachments (AI SDK `FileUIPart`s carrying base64
+ * data URLs) into ACP prompt image payloads for the Local Agent bridge.
+ */
+import type { FileUIPart } from "ai";
+import type { AcpPromptImage } from "./acp-types";
+
+const DATA_URL_RE = /^data:([^;,]+)?((?:;[^;,]+)*);base64,(.*)$/s;
+
+/**
+ * Returns the image payloads plus how many attachments could not be converted
+ * (non-image media, non-base64 or remote URLs). Callers surface `skipped`
+ * instead of silently dropping — that silence was the original bug.
+ */
+export function fileUiPartsToAcpImages(files: FileUIPart[] | undefined): {
+  images: AcpPromptImage[];
+  skipped: number;
+} {
+  if (!files?.length) return { images: [], skipped: 0 };
+  const images: AcpPromptImage[] = [];
+  let skipped = 0;
+  for (const file of files) {
+    const match = DATA_URL_RE.exec(file.url || "");
+    const mimeType = (file.mediaType || match?.[1] || "").trim();
+    const data = match?.[3]?.replace(/\s+/g, "") || "";
+    if (!match || !data || !mimeType.startsWith("image/")) {
+      skipped += 1;
+      continue;
+    }
+    images.push({ data, mimeType });
+  }
+  return { images, skipped };
+}

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mako/desktop",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "description": "Mako Desktop: a thin Electron shell that loads the Mako web app and bundles the Mako Local Agent, enabling connections to databases on this machine.",
   "main": "dist/main.js",

--- a/packages/local-agent/package.json
+++ b/packages/local-agent/package.json
@@ -12,7 +12,7 @@
     "start": "tsx src/index.ts",
     "build": "node build.mjs",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test src/acp/manager.test.ts src/acp/permissions.test.ts src/acp/mcp-probe.test.ts src/acp/mako-system-append.test.ts src/acp/connection-errors.test.ts src/acp/connection.test.ts src/acp/terminal-auth.test.ts src/acp/codex-models.test.ts src/acp/codex-login-status.test.ts src/acp/ensure-adapter.test.ts src/acp/session-config.test.ts src/acp/prompt-guidance.test.ts src/desktop-bridge/mcp.test.ts",
+    "test": "tsx --test src/acp/manager.test.ts src/acp/permissions.test.ts src/acp/mcp-probe.test.ts src/acp/mako-system-append.test.ts src/acp/connection-errors.test.ts src/acp/connection.test.ts src/acp/terminal-auth.test.ts src/acp/codex-models.test.ts src/acp/codex-login-status.test.ts src/acp/ensure-adapter.test.ts src/acp/session-config.test.ts src/acp/prompt-guidance.test.ts src/acp/prompt-images.test.ts src/desktop-bridge/mcp.test.ts",
     "acp:mock-agent": "tsx src/acp/mock-agent.ts"
   },
   "dependencies": {

--- a/packages/local-agent/src/acp/connection.ts
+++ b/packages/local-agent/src/acp/connection.ts
@@ -54,6 +54,12 @@ export interface AcpAuthMethodInfo {
   };
 }
 
+export interface AcpPromptCapabilities {
+  image?: boolean;
+  audio?: boolean;
+  embeddedContext?: boolean;
+}
+
 export interface AcpProviderConnection {
   providerId: AcpProviderId;
   child: ChildProcess;
@@ -63,6 +69,8 @@ export interface AcpProviderConnection {
   authMethods: AcpAuthMethodInfo[];
   authRequired: boolean;
   authenticated: boolean;
+  /** Prompt content types the adapter advertised on initialize. */
+  promptCapabilities: AcpPromptCapabilities;
   /** Rolling stderr from the adapter process (for UI diagnostics). */
   lastStderr: string;
   close: () => Promise<void>;
@@ -330,6 +338,14 @@ export async function openProviderConnection(options: {
       })
     : [];
 
+  const promptCapabilities: AcpPromptCapabilities = {
+    image: initResult.agentCapabilities?.promptCapabilities?.image === true,
+    audio: initResult.agentCapabilities?.promptCapabilities?.audio === true,
+    embeddedContext:
+      initResult.agentCapabilities?.promptCapabilities?.embeddedContext ===
+      true,
+  };
+
   connectionHolder = {
     providerId,
     child,
@@ -337,6 +353,7 @@ export async function openProviderConnection(options: {
     agent,
     protocolVersion: Number(initResult.protocolVersion ?? acp.PROTOCOL_VERSION),
     authMethods,
+    promptCapabilities,
     authRequired: authMethods.length > 0,
     authenticated: authMethods.length === 0,
     lastStderr,

--- a/packages/local-agent/src/acp/manager.test.ts
+++ b/packages/local-agent/src/acp/manager.test.ts
@@ -100,6 +100,50 @@ describe("AcpSessionManager with mock agent", () => {
     await manager.closeSession(session.id);
   });
 
+  it("forwards image attachments as ACP image ContentBlocks", async () => {
+    const events: AcpBridgeEvent[] = [];
+    const unsub = manager.subscribeAll(event => {
+      events.push(event);
+    });
+
+    const session = await manager.createSession({
+      providerId: "claude",
+      cwd: process.cwd(),
+      title: "image-test",
+    });
+
+    // 1x1 transparent PNG.
+    const pngBase64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+    const result = await manager.prompt(session.id, "what is in this image?", [
+      { data: pngBase64, mimeType: "image/png" },
+    ]);
+    assert.equal(result.stopReason, "end_turn");
+
+    const texts = events
+      .filter(e => e.type === "session_update")
+      .map(e => {
+        const update = e.update as {
+          sessionUpdate?: string;
+          content?: { type?: string; text?: string };
+        };
+        if (
+          update.sessionUpdate === "agent_message_chunk" &&
+          update.content?.type === "text"
+        ) {
+          return update.content.text || "";
+        }
+        return "";
+      })
+      .join("");
+
+    assert.match(texts, /Mock agent received: what is in this image\?/);
+    assert.match(texts, /\[images:1\]/);
+
+    unsub();
+    await manager.closeSession(session.id);
+  });
+
   it("attaches Mako MCP on session/new when requested", async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = (async () =>

--- a/packages/local-agent/src/acp/manager.ts
+++ b/packages/local-agent/src/acp/manager.ts
@@ -4,7 +4,7 @@
 import { randomUUID } from "node:crypto";
 import { homedir } from "node:os";
 import { resolve as resolvePath } from "node:path";
-import type { ActiveSession } from "@agentclientprotocol/sdk";
+import type { ActiveSession, ContentBlock } from "@agentclientprotocol/sdk";
 import {
   openProviderConnection,
   type AcpProviderConnection,
@@ -48,6 +48,7 @@ import {
 import type {
   AcpAuthenticateResult,
   AcpBridgeEvent,
+  AcpPromptImage,
   AcpProviderStatus,
   AcpSessionInfo,
   AcpStatusResponse,
@@ -266,7 +267,7 @@ export class AcpSessionManager {
       defaultCwd: defaultCwd(),
       providers,
       acpBridge: {
-        version: 7,
+        version: 8,
         terminalAuth: true,
         mcpProbe: true,
         reconnect: true,
@@ -275,6 +276,7 @@ export class AcpSessionManager {
         hitlTools: true,
         adapterEnsure: true,
         modelWarm: true,
+        promptImages: true,
       },
       lastAdapterError: this.lastAdapterError,
       ensureByProvider,
@@ -1170,6 +1172,7 @@ export class AcpSessionManager {
   async prompt(
     sessionId: string,
     text: string,
+    images: AcpPromptImage[] = [],
   ): Promise<{ stopReason: string }> {
     const session = this.sessions.get(sessionId);
     if (!session?.active) {
@@ -1177,7 +1180,7 @@ export class AcpSessionManager {
         `Unknown or expired ACP session: ${sessionId}. Send again to reconnect.`,
       );
     }
-    if (!text.trim()) {
+    if (!text.trim() && images.length === 0) {
       throw new Error("Prompt text is required");
     }
 
@@ -1196,9 +1199,21 @@ export class AcpSessionManager {
     }
 
     const providerId = session.info.providerId;
-    if (!isConnectionAlive(this.connections.get(providerId))) {
+    const connection = this.connections.get(providerId);
+    if (!isConnectionAlive(connection)) {
       this.invalidateProvider(providerId, "adapter not alive before prompt");
       throw new Error(acpReconnectMessage(ACP_PROVIDERS[providerId].label));
+    }
+
+    // Silently dropping attachments is worse than failing: the model answers
+    // as if the screenshot never existed. Fail loudly when the adapter did
+    // not advertise image support on initialize.
+    if (images.length > 0 && connection?.promptCapabilities?.image !== true) {
+      throw new Error(
+        `${ACP_PROVIDERS[providerId].label} (this adapter version) does not ` +
+          "support image attachments. Update the adapter via Settings → " +
+          "Coding Agents → Update, then retry.",
+      );
     }
 
     session.busy = true;
@@ -1237,8 +1252,22 @@ export class AcpSessionManager {
 
     // Capture after the null guard — nested async closures lose the narrow.
     const active = session.active;
+    const promptContent: string | ContentBlock[] =
+      images.length === 0
+        ? promptText
+        : [
+            ...(promptText
+              ? [{ type: "text" as const, text: promptText }]
+              : []),
+            ...images.map(img => ({
+              type: "image" as const,
+              data: img.data,
+              mimeType: img.mimeType,
+              ...(img.uri ? { uri: img.uri } : {}),
+            })),
+          ];
     const drainPrompt = async (): Promise<{ stopReason: string }> => {
-      const promptPromise = active.prompt(promptText);
+      const promptPromise = active.prompt(promptContent);
       for (;;) {
         const message = await active.nextUpdate();
         if (message.kind === "session_update") {

--- a/packages/local-agent/src/acp/mock-agent.ts
+++ b/packages/local-agent/src/acp/mock-agent.ts
@@ -44,6 +44,7 @@ async function main(): Promise<void> {
       protocolVersion: acp.PROTOCOL_VERSION,
       agentCapabilities: {
         loadSession: false,
+        promptCapabilities: { image: true },
         mcpCapabilities: { http: true, sse: false },
       },
       authMethods: [],
@@ -111,6 +112,13 @@ async function main(): Promise<void> {
           block?.type === "text" ? String(block.text || "") : "",
         )
         .join("");
+      // Echo image blocks so tests can assert attachments crossed the wire.
+      const imageBlocks = (ctx.params.prompt || []).filter(
+        block =>
+          block?.type === "image" &&
+          typeof block.data === "string" &&
+          block.data.length > 0,
+      );
 
       await ctx.client.notify(acp.methods.client.session.update, {
         sessionId,
@@ -118,7 +126,9 @@ async function main(): Promise<void> {
           sessionUpdate: "agent_message_chunk",
           content: {
             type: "text",
-            text: `Mock agent received: ${userText || "(empty)"}`,
+            text: `Mock agent received: ${userText || "(empty)"}${
+              imageBlocks.length > 0 ? ` [images:${imageBlocks.length}]` : ""
+            }`,
           },
         },
       });

--- a/packages/local-agent/src/acp/prompt-images.test.ts
+++ b/packages/local-agent/src/acp/prompt-images.test.ts
@@ -1,0 +1,90 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  MAX_PROMPT_IMAGES,
+  MAX_PROMPT_IMAGE_BYTES,
+  parsePromptImages,
+} from "./prompt-images";
+
+const PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
+describe("parsePromptImages", () => {
+  it("returns [] for undefined/null/empty", () => {
+    assert.deepEqual(parsePromptImages(undefined), []);
+    assert.deepEqual(parsePromptImages(null), []);
+    assert.deepEqual(parsePromptImages([]), []);
+  });
+
+  it("accepts valid base64 images and preserves uri", () => {
+    const images = parsePromptImages([
+      { data: PNG_BASE64, mimeType: "image/png" },
+      { data: PNG_BASE64, mimeType: "image/jpeg", uri: "file:///shot.jpg" },
+    ]);
+    assert.equal(images.length, 2);
+    assert.equal(images[0].mimeType, "image/png");
+    assert.equal(images[0].uri, undefined);
+    assert.equal(images[1].uri, "file:///shot.jpg");
+  });
+
+  it("strips whitespace from base64 payloads", () => {
+    const chunked = `${PNG_BASE64.slice(0, 20)}\n${PNG_BASE64.slice(20)}`;
+    const images = parsePromptImages([
+      { data: chunked, mimeType: "image/png" },
+    ]);
+    assert.equal(images[0].data, PNG_BASE64);
+  });
+
+  it("rejects non-array input", () => {
+    assert.throws(() => parsePromptImages({}), /must be an array/);
+  });
+
+  it("rejects non-image mime types", () => {
+    assert.throws(
+      () => parsePromptImages([{ data: PNG_BASE64, mimeType: "text/plain" }]),
+      /Only image attachments/,
+    );
+  });
+
+  it("rejects data: URL payloads (must be raw base64)", () => {
+    assert.throws(
+      () =>
+        parsePromptImages([
+          {
+            data: `data:image/png;base64,${PNG_BASE64}`,
+            mimeType: "image/png",
+          },
+        ]),
+      /base64/,
+    );
+  });
+
+  it("rejects missing or empty data", () => {
+    assert.throws(
+      () => parsePromptImages([{ mimeType: "image/png" }]),
+      /missing base64 data/,
+    );
+    assert.throws(
+      () => parsePromptImages([{ data: "   ", mimeType: "image/png" }]),
+      /missing base64 data/,
+    );
+  });
+
+  it("rejects too many images", () => {
+    const many = Array.from({ length: MAX_PROMPT_IMAGES + 1 }, () => ({
+      data: PNG_BASE64,
+      mimeType: "image/png",
+    }));
+    assert.throws(() => parsePromptImages(many), /Too many image attachments/);
+  });
+
+  it("rejects oversized images", () => {
+    // Base64 string large enough to decode past the per-image cap.
+    const hugeLen = Math.ceil((MAX_PROMPT_IMAGE_BYTES * 4) / 3) + 8;
+    const huge = "A".repeat(hugeLen);
+    assert.throws(
+      () => parsePromptImages([{ data: huge, mimeType: "image/png" }]),
+      /too large/,
+    );
+  });
+});

--- a/packages/local-agent/src/acp/prompt-images.ts
+++ b/packages/local-agent/src/acp/prompt-images.ts
@@ -1,0 +1,82 @@
+/**
+ * Validate image attachments on `/acp/sessions/:id/prompt` before they are
+ * forwarded to the ACP adapter as `image` ContentBlocks. Invalid payloads
+ * fail loudly — silently dropping an attachment looks like the model ignored
+ * the user's screenshot.
+ */
+import type { AcpPromptImage } from "./types";
+
+export const MAX_PROMPT_IMAGES = 10;
+/** Per-image decoded size cap (matches typical provider limits ~5MB + slack). */
+export const MAX_PROMPT_IMAGE_BYTES = 10 * 1024 * 1024;
+/** Total decoded size cap for one prompt. */
+export const MAX_PROMPT_IMAGES_TOTAL_BYTES = 25 * 1024 * 1024;
+
+const BASE64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
+
+function approxDecodedBytes(base64: string): number {
+  return Math.floor((base64.length * 3) / 4);
+}
+
+/**
+ * Parse and validate the `images` field of a prompt request.
+ * Returns a clean array (possibly empty); throws with a user-facing message
+ * on any malformed entry.
+ */
+export function parsePromptImages(raw: unknown): AcpPromptImage[] {
+  if (raw === undefined || raw === null) return [];
+  if (!Array.isArray(raw)) {
+    throw new Error("Prompt images must be an array");
+  }
+  if (raw.length === 0) return [];
+  if (raw.length > MAX_PROMPT_IMAGES) {
+    throw new Error(
+      `Too many image attachments (${raw.length}). Limit is ${MAX_PROMPT_IMAGES} per message.`,
+    );
+  }
+
+  let totalBytes = 0;
+  const images: AcpPromptImage[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") {
+      throw new Error("Each prompt image must be an object");
+    }
+    const { data, mimeType, uri } = entry as {
+      data?: unknown;
+      mimeType?: unknown;
+      uri?: unknown;
+    };
+    if (typeof mimeType !== "string" || !mimeType.startsWith("image/")) {
+      throw new Error(
+        `Unsupported attachment type${
+          typeof mimeType === "string" ? ` (${mimeType})` : ""
+        }. Only image attachments are supported.`,
+      );
+    }
+    if (typeof data !== "string" || !data.trim()) {
+      throw new Error("Prompt image is missing base64 data");
+    }
+    const cleaned = data.replace(/\s+/g, "");
+    if (!BASE64_RE.test(cleaned)) {
+      throw new Error("Prompt image data must be base64 (no data: URL prefix)");
+    }
+    const bytes = approxDecodedBytes(cleaned);
+    if (bytes > MAX_PROMPT_IMAGE_BYTES) {
+      throw new Error(
+        `Image attachment is too large (${Math.round(bytes / (1024 * 1024))}MB). Limit is ${Math.round(MAX_PROMPT_IMAGE_BYTES / (1024 * 1024))}MB per image.`,
+      );
+    }
+    totalBytes += bytes;
+    if (totalBytes > MAX_PROMPT_IMAGES_TOTAL_BYTES) {
+      throw new Error(
+        `Image attachments are too large together. Limit is ${Math.round(MAX_PROMPT_IMAGES_TOTAL_BYTES / (1024 * 1024))}MB per message.`,
+      );
+    }
+    images.push({
+      data: cleaned,
+      mimeType,
+      ...(typeof uri === "string" && uri ? { uri } : {}),
+    });
+  }
+  return images;
+}

--- a/packages/local-agent/src/acp/routes.ts
+++ b/packages/local-agent/src/acp/routes.ts
@@ -5,6 +5,7 @@ import type { Context, Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import { isAcpProviderId } from "./providers";
 import { acpSessionManager } from "./manager";
+import { parsePromptImages } from "./prompt-images";
 import type {
   CreateAcpSessionRequest,
   PermissionResponseRequest,
@@ -126,7 +127,8 @@ export function registerAcpRoutes(app: Hono): void {
                 })
                 .join("")
             : "";
-      const result = await acpSessionManager.prompt(sessionId, text);
+      const images = parsePromptImages(body?.images);
+      const result = await acpSessionManager.prompt(sessionId, text, images);
       return c.json({ success: true, data: result });
     } catch (error) {
       const message =

--- a/packages/local-agent/src/acp/types.ts
+++ b/packages/local-agent/src/acp/types.ts
@@ -118,7 +118,7 @@ export interface AcpStatusResponse {
    * agent (raw "ACP connection closed" with no rewrite / no terminal auth).
    */
   acpBridge?: {
-    version: 3 | 4 | 5 | 6 | 7;
+    version: 3 | 4 | 5 | 6 | 7 | 8;
     terminalAuth: true;
     mcpProbe: true;
     reconnect: true;
@@ -129,6 +129,8 @@ export interface AcpStatusResponse {
     adapterEnsure?: true;
     /** Local Agent can warm model catalogs via a throwaway session/new. */
     modelWarm?: true;
+    /** Prompt route accepts `images` and forwards ACP image ContentBlocks. */
+    promptImages?: true;
   };
   /** Last Claude/Codex adapter stderr snippet (when a connection died). */
   lastAdapterError?: string | null;
@@ -205,9 +207,19 @@ export interface SetAcpSessionConfigRequest {
   value: string | boolean;
 }
 
+/** Image attachment forwarded to the ACP adapter as an `image` ContentBlock. */
+export interface AcpPromptImage {
+  /** Base64-encoded payload (no `data:` URL prefix). */
+  data: string;
+  /** e.g. `image/png` */
+  mimeType: string;
+  uri?: string;
+}
+
 export interface PromptAcpSessionRequest {
   text?: string;
   content?: unknown[];
+  images?: AcpPromptImage[];
 }
 
 export interface PermissionResponseRequest {


### PR DESCRIPTION
## Problem

Images attached in Chat were silently dropped when the selected model is a local ACP provider (Claude Code / Codex). The attachment vanished at every layer:

1. `useQueuedPrompts` called `sendViaLocalAcp(text)` without the composer's `FileUIPart[]` (the cloud transport got them, the local path didn't).
2. `acpClient.prompt()` posted only `{ text }` to the Local Agent.
3. The Local Agent's prompt route flattened content to text and `manager.prompt()` sent a plain string to the adapter.

The model answered as if the screenshot never existed. The ACP SDK supports this natively — `ActiveSession.prompt` accepts `ContentBlock[]` with `{ type: "image", data, mimeType }`, and adapters advertise `promptCapabilities.image` on initialize.

## Changes

**App**
- `useQueuedPrompts` / `Chat.tsx` pass attachments through `sendViaLocalAcp` into `runLocalAcpChatTurn`; the user transcript message now carries the file parts so thumbnails render and persist to History like cloud chats.
- New `fileUiPartsToAcpImages` (`app/src/lib/local-acp-images.ts`) converts base64 data URLs to ACP image payloads; non-image or remote attachments fail the turn with a visible error instead of vanishing.
- `acpClient.prompt` sends `{ text, images }`; new `acpSupportsPromptImages` gates on bridge ≥ 8 / `promptImages` so an outdated Local Agent produces a clear "update Mako Desktop" error.

**Local Agent**
- Prompt route validates an `images` field via new `parsePromptImages` (base64, `image/*` mime, ≤ 10 images, ≤ 10MB each / 25MB total).
- `manager.prompt` forwards `[text, ...images]` ContentBlocks to `ActiveSession.prompt`, and rejects images when the adapter did not advertise `promptCapabilities.image` on initialize (fail loudly, never drop silently).
- Connection captures `agentCapabilities.promptCapabilities`; status advertises `acpBridge` v8 + `promptImages`.
- Mock agent advertises image support and echoes received image blocks.

**Release**
- Bumps `packages/desktop` to **0.3.11** so merging this PR publishes a Desktop release containing the new Local Agent. Without the bump, the web half would deploy continuously while `desktop-v0.3.10` (already released) lacks the agent-side support — every image attempt would hit the "update Mako Desktop" error with no update available.

## Testing

- New end-to-end manager test proves image ContentBlocks cross the ACP wire to the mock agent (`[images:1]` echo).
- New unit tests for `parsePromptImages` (local-agent, node:test) and `fileUiPartsToAcpImages` + capability gate (app, vitest).
- local-agent: typecheck + all 66 tests pass. App: typecheck, eslint, all 391 vitest tests, and production build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E35xY71wSZagqLKTNdnrC3