### PR TITLE
docs(acp): document composer image attachments for local Claude/Codex

### DIFF
--- a/docs/src/content/docs/coding-agents-acp.md
+++ b/docs/src/content/docs/coding-agents-acp.md
@@ -37,6 +37,12 @@ This is the reverse of [MCP Server](/mcp-server/):
    `session/set_config_option` — no Terminal `/model` required.
 4. Send messages in the normal Chat composer. Mako starts the local ACP session
    automatically and attaches workspace data tools.
+5. Optional: attach images in the composer (screenshots, diagrams). They are
+   sent to Claude Code / Codex as ACP image blocks, same as cloud chats.
+   Requires **Desktop 0.3.11+** — older Local Agents reject the turn with an
+   "update Mako Desktop" error instead of silently dropping the image.
+   Non-image and remote attachments are not supported on the local ACP path
+   and fail loudly.
 
 ACP traffic stays on loopback (`127.0.0.1:41720`). Mako Cloud does **not** proxy
 the ACP stdio pipe — prompts and tool calls do not transit Mako servers.


### PR DESCRIPTION
## What

Daily docs-maintenance run flagged one gap from the last 24h of merges:

- **#774** (ACP image attachments) shipped user-facing behavior — composer images now reach local Claude Code / Codex as ACP image blocks, with a hard "update Mako Desktop" gate on bridge < 8 — but `coding-agents-acp.md` never mentioned it.
- **#771** (MCP double-gated SQL writes) and **#773** (tiered self-directive memory) shipped with their own doc updates (AUTH_README.md, mcp-server.md, self-directive.md) — verified, no gaps.

## Change

One step added to the "How to use" section of `coding-agents-acp.md`:

- image attachments supported on the local ACP path
- requires Desktop 0.3.11+ (bridge ≥ 8), older builds reject with an update prompt instead of dropping the image silently
- non-image / remote attachments fail loudly (not supported locally)

Source: `app/src/lib/local-acp-chat.ts` (`acpSupportsPromptImages` gate + error copy), `app/src/lib/acp-capabilities.ts`, `packages/local-agent/src/acp/prompt-images.ts`.