### PR TITLE
feat(apps): agent-visible run_app render previews on all three surfaces

### DIFF
--- a/api/src/agent-lib/tools/server-app-tools.ts
+++ b/api/src/agent-lib/tools/server-app-tools.ts
@@ -14,9 +14,11 @@
  * MakoApp document here, so a headless / detached agent can build and operate
  * an app end-to-end with no browser.
  *
- * The only browser-only leg is `run_app` (rebuild the sandboxed-iframe preview
- * and read render/build errors); `open_app` is a pure UI tab-focus convenience.
- * A headless agent skips both and works on the appId directly.
+ * Verification (`run_app`) is one capability with per-surface adapters: the
+ * browser client rebuilds the sandboxed-iframe preview and self-captures a
+ * screenshot; external MCP uses the server-side headless renderer
+ * (api/src/mcp/preview-tools.ts). `open_app` is a pure UI tab-focus
+ * convenience a headless agent skips, working on the appId directly.
  *
  * Tool schemas live in @mako/agent-tools (shared with the app's tool cards).
  */
@@ -469,8 +471,8 @@ export function createServerAppTools({
         "data binding metadata (name/language/connection/codeLength + a short " +
         "codePreview — NOT full SQL), entrypoint, runtime, and version/publish " +
         "state. This is a manifest: use app_search, then app_read_resource for " +
-        "specific line ranges. NOTE: live preview build/runtime errors are only " +
-        "available in an attached browser via run_app.",
+        "specific line ranges. NOTE: to verify the app renders (status, " +
+        "build/runtime errors, screenshot), call run_app.",
       inputSchema: getAppStateSchema,
       execute: async ({ appId, resourceOffset, resourceLimit }) =>
         wrap("get_app_state", async () => {

--- a/api/src/agent-skills/apps/SKILL.md
+++ b/api/src/agent-skills/apps/SKILL.md
@@ -32,9 +32,10 @@ All app tools run server-side except the live preview: `list_open_apps`,
 `create_app`, `get_app_state`, `app_search`, `app_read_resource`, the
 file/dependency/binding edits, `materialize_binding`, and versioning all operate
 on the server document,
-so you can build and operate an app with no browser attached. The only
-browser-only tool is `run_app` (rebuild the preview and read render/build
-errors); `open_app` just focuses a UI tab.
+so you can build and operate an app with no browser attached. `run_app` is the
+verify tool on every surface — it renders the app and returns status,
+build/runtime errors, and a screenshot (in a browser it rebuilds the live
+preview; headless MCP renders server-side); `open_app` just focuses a UI tab.
 
 ### Workflow
 
@@ -50,8 +51,8 @@ errors); `open_app` just focuses a UI tab.
    `truncated`, continue with its `nextOffset`. Do not dump every resource.
    `app_read_file` remains a deferred compatibility fallback for older flows;
    new work should use the bounded resource reader.
-   (Live preview build/runtime errors are only available in an attached browser
-   via `run_app`.)
+   (To verify the app actually renders — status, build/runtime errors, and a
+   screenshot — call `run_app`.)
 3. Modify existing files with `app_edit_file` — an anchored replacement: pass the
    exact current text as `oldString` (must match exactly once — include a few
    surrounding lines to disambiguate) and the replacement as `newString` (`""`
@@ -170,10 +171,13 @@ errors); `open_app` just focuses a UI tab.
    you genuinely need more rows, pass `useDuckDB(sql, { rowLimit: 2_000_000 })` or
    `{ rowLimit: null }` to disable the cap (costs memory + serialization time), and
    surface `truncated` in the UI whenever you render row-level data.
-6. After a batch of edits, in an attached browser call `run_app` to rebuild the
-   preview and read build/runtime errors, then fix them. Iterate until the preview
-   is error-free. (Headless, with no browser, you cannot render — rely on
-   `get_app_state` and careful editing.)
+6. After a batch of edits, call `run_app` to render the app and read its status,
+   build/runtime errors, and screenshot, then fix what you find. Iterate until
+   the preview is error-free. Pass `includeScreenshot: false` while iterating on
+   errors (much cheaper); fetch one screenshot at the end to confirm the visual
+   result. Note the screenshot reflects the surface you are on: in a browser it
+   is the user's live preview (including any dbt preview-env override); headless
+   MCP renders the draft server-side against prod data.
 7. Understand and validate data before coding against it using the shared data-source
    primitives (they work for apps and dashboards — pass `surface: { kind: "app", id: appId }`):
    `list_data_sources` shows every data source (connection, query, materialization, status);

--- a/api/src/mcp/mako-mcp-server.ts
+++ b/api/src/mcp/mako-mcp-server.ts
@@ -100,7 +100,7 @@ Typical loop:
 2. Validate queries with sql_execute_query (short exploration timeout). For slow warehouses: create_console → run_console → check_query_status.
 3. create_app → app_write_file / app_edit_file → app_create_data_binding (bind the validated query; pass consoleId to seed from a console).
 4. For dbt work: read_dbt_project_tree → read/edit files → validate asynchronously, then poll dbt_get_run. For large or destructive work (warehouse runs, Git mutations, schedules), prefer proposing a plan via mako-desktop submit_plan before acting.
-5. Desktop opens/refreshes the app tab automatically. Do NOT create_preview_token, render_app, or paste /preview/… URLs. Use mako-desktop run_app for iframe errors (rebuild: false polls without rebuilding). For consoles use open_console / create_console; for notebooks use create_notebook / cell tools.
+5. Desktop opens/refreshes the app tab automatically. Do NOT create_preview_token, render_app, or paste /preview/… URLs. Verify with mako-desktop run_app: status, iframe errors, and a screenshot of the live tab (rebuild: false polls without rebuilding; includeScreenshot: false is much cheaper). For consoles use open_console / create_console; for notebooks use create_notebook / cell tools.
 6. Interactive UX: mako-desktop ask_clarifying_questions / submit_plan (docked Chat cards) — never ask as plain text.
 7. Durable memory: read_self_directive / update_self_directive only. Do NOT write .claude/**/MEMORY.md or other local Claude memory files.
 8. app_save_version to snapshot/publish.

--- a/api/src/mcp/preview-tools.ts
+++ b/api/src/mcp/preview-tools.ts
@@ -9,6 +9,12 @@
  *     (e.g. Claude Code's local Playwright) can load and screenshot.
  *   render_app → deprecated alias of run_app, kept for existing clients.
  */
+import {
+  runAppBaseSchema,
+  runAppResultToMcpContent,
+  summarizeRunAppResult,
+  type RunAppResult,
+} from "@mako/agent-tools";
 import { tool } from "ai";
 import { Types } from "mongoose";
 import { z } from "zod";
@@ -64,24 +70,12 @@ async function previewBaseUnreachableError(
   }
 }
 
-const renderAppSchema = z.object({
-  appId: z.string().describe("The app whose DRAFT should be rendered"),
+// Shared cross-surface input, plus headless-only viewport extras. `rebuild`
+// from the base schema is accepted but moot here: a headless render is always
+// a fresh build.
+const renderAppSchema = runAppBaseSchema.extend({
   width: z.number().int().min(320).max(1920).optional(),
   height: z.number().int().min(320).max(1920).optional(),
-  timeoutMs: z
-    .number()
-    .int()
-    .min(5_000)
-    .max(45_000)
-    .optional()
-    .describe("How long to wait for the app to finish rendering (ms)"),
-  includeScreenshot: z
-    .boolean()
-    .optional()
-    .describe(
-      "Default true. Pass false to get status/errors/console only — much " +
-        "cheaper when you just need to know whether the render succeeded.",
-    ),
 });
 
 type RenderAppInput = z.infer<typeof renderAppSchema>;
@@ -95,8 +89,17 @@ async function executeHeadlessRender(
   workspaceId: string,
   { appId, width, height, timeoutMs, includeScreenshot }: RenderAppInput,
 ) {
+  const failed = (error: string): RunAppResult => ({
+    success: false,
+    status: "error",
+    errors: [],
+    consoleLogs: [],
+    source: "headless",
+    error,
+  });
+
   if (!Types.ObjectId.isValid(appId)) {
-    return { success: false, error: `Invalid app ID: ${appId}` };
+    return summarizeRunAppResult(failed(`Invalid app ID: ${appId}`));
   }
   const app = await MakoApp.findOne({
     _id: new Types.ObjectId(appId),
@@ -105,10 +108,11 @@ async function executeHeadlessRender(
     .select({ _id: 1 })
     .lean();
   if (!app) {
-    return {
-      success: false,
-      error: `App ${appId} not found. Use list_open_apps to see available apps.`,
-    };
+    return summarizeRunAppResult(
+      failed(
+        `App ${appId} not found. Use list_open_apps to see available apps.`,
+      ),
+    );
   }
 
   const baseUrl = clientBaseUrl();
@@ -117,7 +121,7 @@ async function executeHeadlessRender(
     // own "rendering disabled" message otherwise).
     const unreachable = await previewBaseUnreachableError(baseUrl);
     if (unreachable) {
-      return { success: false, error: unreachable };
+      return summarizeRunAppResult(failed(unreachable));
     }
   }
 
@@ -127,7 +131,7 @@ async function executeHeadlessRender(
     workspaceId,
     ttlSeconds: 300,
   });
-  const result = await renderAppPreview({
+  const rendered = await renderAppPreview({
     url: `${baseUrl}/preview/${token}`,
     width,
     height,
@@ -135,26 +139,34 @@ async function executeHeadlessRender(
     screenshot: includeScreenshot !== false,
   });
 
-  const summary = {
-    success: result.success,
-    status: result.status,
-    errors: result.errors,
-    consoleLogs: result.consoleLogs,
-    ...(result.error ? { error: result.error } : {}),
+  const result: RunAppResult = {
+    success: rendered.success,
+    status: rendered.status,
+    errors: rendered.errors,
+    consoleLogs: rendered.consoleLogs,
+    source: "headless",
+    ...(rendered.screenshotBase64
+      ? {
+          screenshot: {
+            mimeType: "image/jpeg",
+            base64: rendered.screenshotBase64,
+          },
+        }
+      : includeScreenshot !== false
+        ? {
+            screenshotUnavailableReason: isAppRenderEnabled()
+              ? "The headless render did not produce a screenshot."
+              : "Server-side rendering is not configured " +
+                "(RENDER_APP_BROWSER_PATH is unset).",
+          }
+        : {}),
+    ...(rendered.error ? { error: rendered.error } : {}),
   };
-  if (includeScreenshot === false || !result.screenshotBase64) {
-    return summary;
+
+  if (!result.screenshot) {
+    return summarizeRunAppResult(result);
   }
-  return {
-    mcpContent: [
-      { type: "text", text: JSON.stringify(summary) },
-      {
-        type: "image",
-        data: result.screenshotBase64,
-        mimeType: "image/jpeg",
-      },
-    ],
-  };
+  return { mcpContent: runAppResultToMcpContent(result) };
 }
 
 /**

--- a/api/src/services/app-render.service.ts
+++ b/api/src/services/app-render.service.ts
@@ -16,14 +16,11 @@
  * freshly-minted preview token — the tool takes an appId, never a URL, so
  * the pool cannot be steered at arbitrary targets (no SSRF surface).
  */
+import { clampRunAppTimeoutMs } from "@mako/agent-tools";
 import type { Browser } from "playwright-core";
 import { loggers } from "../logging";
 
 const logger = loggers.api("app-render");
-
-/** Wait budget for the preview to report ready/error after navigation. */
-const DEFAULT_SETTLE_TIMEOUT_MS = 20_000;
-const MAX_SETTLE_TIMEOUT_MS = 45_000;
 /** Post-ready delay so late paints (fonts, charts) land before screenshot. */
 const PAINT_DELAY_MS = 750;
 const MAX_CONCURRENT_RENDERS = 2;
@@ -122,10 +119,8 @@ export async function renderAppPreview(input: {
     };
   }
 
-  const timeoutMs = Math.min(
-    Math.max(input.timeoutMs ?? DEFAULT_SETTLE_TIMEOUT_MS, 5_000),
-    MAX_SETTLE_TIMEOUT_MS,
-  );
+  // Shared cross-surface settle budget (same clamp on every adapter).
+  const timeoutMs = clampRunAppTimeoutMs(input.timeoutMs);
 
   await acquireSlot();
   const consoleLogs: string[] = [];

--- a/app/src/agent-runtime/screenshot-agent-tools.ts
+++ b/app/src/agent-runtime/screenshot-agent-tools.ts
@@ -1,5 +1,8 @@
 import { useDashboardStore } from "../store/dashboardStore";
-import { PREVIEW_MESSAGE } from "../app-runtime/preview";
+import {
+  findAppPreviewIframes,
+  requestAppPreviewCapture,
+} from "../app-runtime/preview-capture";
 
 type ScreenshotTarget =
   | "active_dashboard"
@@ -10,7 +13,7 @@ type ScreenshotTarget =
   | "widget"
   | "selector";
 
-type ScreenshotRendererName = "modern-screenshot";
+type ScreenshotRendererName = "modern-screenshot" | "app-preview-self-capture";
 
 interface CaptureScreenshotInput {
   target?: ScreenshotTarget;
@@ -510,90 +513,6 @@ async function analyzeImageQuality(
   };
 }
 
-/**
- * App previews render in opaque-origin iframes (`sandbox="allow-scripts"`),
- * which modern-screenshot cannot rasterize from the parent — they come out
- * blank. Ask each visible app-preview iframe inside the capture target to
- * screenshot itself (the preview bootstrap handles `mako-app:capture`) and
- * composite the returned PNGs over the parent capture at the iframe rects.
- */
-const APP_PREVIEW_IFRAME_SELECTOR = "iframe[data-mako-app-preview]";
-// Per-iframe self-capture cap. Kept deliberately short: capture_screenshot is a
-// client-only, long-running tool, so the longer it runs the wider the window in
-// which a mobile lock / computer sleep / proxy idle timeout can interrupt the
-// turn and strand the card. Iframes are captured in parallel (Promise.all), so
-// this bounds the whole composite, not each iframe serially. A timed-out iframe
-// degrades gracefully (its region is reported as a capture failure).
-const APP_PREVIEW_CAPTURE_TIMEOUT_MS = 4000;
-let captureSeq = 0;
-
-function findAppPreviewIframes(target: HTMLElement): HTMLIFrameElement[] {
-  const iframes = Array.from(
-    target.querySelectorAll<HTMLIFrameElement>(APP_PREVIEW_IFRAME_SELECTOR),
-  );
-  if (
-    target instanceof HTMLIFrameElement &&
-    target.matches(APP_PREVIEW_IFRAME_SELECTOR)
-  ) {
-    iframes.unshift(target);
-  }
-  return iframes.filter(iframe => {
-    const rect = iframe.getBoundingClientRect();
-    return rect.width >= 8 && rect.height >= 8 && iframe.contentWindow != null;
-  });
-}
-
-function requestAppPreviewCapture(
-  iframe: HTMLIFrameElement,
-  options: { scale: number; backgroundColor?: string | null },
-): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const contentWindow = iframe.contentWindow;
-    if (!contentWindow) {
-      reject(new Error("App preview iframe has no content window"));
-      return;
-    }
-    const requestId = `capture_${Date.now()}_${++captureSeq}`;
-    const timeout = window.setTimeout(() => {
-      window.removeEventListener("message", onMessage);
-      reject(new Error("App preview capture timed out"));
-    }, APP_PREVIEW_CAPTURE_TIMEOUT_MS);
-
-    function onMessage(event: MessageEvent) {
-      const data = (event.data ?? {}) as {
-        type?: string;
-        requestId?: string;
-        success?: boolean;
-        dataUrl?: string;
-        error?: string;
-      };
-      if (
-        event.source !== contentWindow ||
-        data.type !== PREVIEW_MESSAGE.captureResult ||
-        data.requestId !== requestId
-      ) {
-        return;
-      }
-      window.clearTimeout(timeout);
-      window.removeEventListener("message", onMessage);
-      if (data.success && data.dataUrl) resolve(data.dataUrl);
-      else reject(new Error(data.error || "App preview capture failed"));
-    }
-
-    window.addEventListener("message", onMessage);
-    // The sandboxed iframe has an opaque origin, so "*" is required.
-    contentWindow.postMessage(
-      {
-        type: PREVIEW_MESSAGE.capture,
-        requestId,
-        scale: options.scale,
-        backgroundColor: options.backgroundColor,
-      },
-      "*",
-    );
-  });
-}
-
 async function compositeAppPreviews(
   baseDataUrl: string,
   target: HTMLElement,
@@ -693,8 +612,19 @@ async function captureWithModernScreenshot(
   };
 }
 
-function enqueueVisionAttachment(attachment: ScreenshotVisionAttachment): void {
+/**
+ * Queue an image to ride along as a REAL image input on the next chat model
+ * request (Chat drains the queue in prepareSendMessagesRequest). Shared by
+ * capture_screenshot and the run_app verify screenshot — base64 must never
+ * travel inside a JSON tool result. Returns false (and queues nothing) when
+ * the image exceeds the model-input size cap.
+ */
+export function enqueueScreenshotVisionAttachment(
+  attachment: ScreenshotVisionAttachment,
+): boolean {
+  if (attachment.outputBytes > MAX_MODEL_IMAGE_BYTES) return false;
   pendingVisionAttachments.push(attachment);
+  return true;
 }
 
 export function consumePendingScreenshotVisionAttachments(): ScreenshotVisionAttachment[] {
@@ -804,9 +734,8 @@ export async function captureScreenshot(
 
     if (
       input.passImageToModel !== false &&
-      outputBytes <= MAX_MODEL_IMAGE_BYTES
+      enqueueScreenshotVisionAttachment(attachment)
     ) {
-      enqueueVisionAttachment(attachment);
       imagesPassedToModel.push({
         renderer: attachment.renderer,
         filename: attachment.filename,

--- a/app/src/app-runtime/agent-tools.run-app.test.ts
+++ b/app/src/app-runtime/agent-tools.run-app.test.ts
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+/**
+ * Client run_app executor: settle-await on previewStatus, shared RunAppResult
+ * envelope, and per-delivery screenshot handling (chat vision attachment vs
+ * desktop-bridge inline vs none for older Local Agents).
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const captureAppPreview = vi.fn<(appId: string) => Promise<string>>();
+const findAppPreviewIframe = vi.fn<(appId: string) => unknown>();
+const enqueueScreenshotVisionAttachment = vi.fn<(a: unknown) => boolean>();
+
+vi.mock("./preview-capture", () => ({
+  captureAppPreview: (appId: string) => captureAppPreview(appId),
+  findAppPreviewIframe: (appId: string) => findAppPreviewIframe(appId),
+}));
+
+vi.mock("../agent-runtime/screenshot-agent-tools", () => ({
+  enqueueScreenshotVisionAttachment: (a: unknown) =>
+    enqueueScreenshotVisionAttachment(a),
+}));
+
+vi.mock("./shell", () => ({
+  focusAppTab: () => undefined,
+  getCurrentWorkspaceId: () => null,
+}));
+
+vi.mock("../store/consoleStore", () => ({
+  useConsoleStore: { getState: () => ({ tabs: {}, activeTabId: null }) },
+}));
+
+import { executeAppAgentTool } from "./agent-tools";
+import { useAppStore, type AppEntity } from "../store/appStore";
+
+const APP_ID = "app-under-test";
+const PNG_DATA_URL = `data:image/png;base64,${"iVBORw0KGgo="}`;
+
+function openTestApp(): void {
+  useAppStore.setState(state => ({
+    ...state,
+    openApps: {
+      [APP_ID]: {
+        _id: APP_ID,
+        workspaceId: "w1",
+        title: "Test App",
+        template: "react",
+        runtime: "cdn",
+        entrypoint: "index.tsx",
+        files: [],
+        dependencies: {},
+        dataBindings: [],
+        version: 1,
+      } as unknown as AppEntity,
+    },
+    previewNonce: { [APP_ID]: 0 },
+    previewErrors: {},
+    previewStatus: {},
+  }));
+}
+
+/** Simulate the AppRenderer iframe bootstrap reporting after `delayMs`. */
+function reportPreview(
+  delayMs: number,
+  errors: Array<{ message: string; source?: "build" | "runtime"; at: number }>,
+): void {
+  setTimeout(() => {
+    useAppStore.getState().setPreviewErrors(APP_ID, errors);
+  }, delayMs);
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  captureAppPreview.mockResolvedValue(PNG_DATA_URL);
+  findAppPreviewIframe.mockReturnValue({});
+  enqueueScreenshotVisionAttachment.mockReturnValue(true);
+  openTestApp();
+});
+
+describe("run_app client executor", () => {
+  it("awaits the ready report and queues the screenshot as a vision attachment", async () => {
+    reportPreview(200, []);
+    const result = await executeAppAgentTool("run_app", { appId: APP_ID });
+    expect(result).toMatchObject({
+      success: true,
+      status: "ready",
+      errors: [],
+      source: "iframe",
+      screenshotPassedToModel: true,
+    });
+    // Base64 must never enter the JSON tool result on the chat path.
+    expect(result.screenshot).toBeUndefined();
+    expect(enqueueScreenshotVisionAttachment).toHaveBeenCalledOnce();
+    expect(useAppStore.getState().previewNonce[APP_ID]).toBe(1);
+  });
+
+  it("reports build errors as a settled error envelope", async () => {
+    reportPreview(200, [{ message: "boom", source: "build", at: Date.now() }]);
+    const result = await executeAppAgentTool("run_app", {
+      appId: APP_ID,
+      includeScreenshot: false,
+    });
+    expect(result).toMatchObject({ success: false, status: "error" });
+    expect(result.errors).toEqual([{ message: "boom", source: "build" }]);
+    expect(captureAppPreview).not.toHaveBeenCalled();
+  });
+
+  it("returns the screenshot inline for the desktop bridge", async () => {
+    reportPreview(200, []);
+    const result = await executeAppAgentTool(
+      "run_app",
+      { appId: APP_ID },
+      { screenshotDelivery: "inline" },
+    );
+    expect(result.screenshot).toEqual({
+      mimeType: "image/png",
+      base64: "iVBORw0KGgo=",
+    });
+    expect(enqueueScreenshotVisionAttachment).not.toHaveBeenCalled();
+  });
+
+  it("skips capture entirely for clients that cannot deliver images", async () => {
+    reportPreview(200, []);
+    const result = await executeAppAgentTool(
+      "run_app",
+      { appId: APP_ID },
+      { screenshotDelivery: "none" },
+    );
+    expect(result.screenshot).toBeUndefined();
+    expect(captureAppPreview).not.toHaveBeenCalled();
+    expect(String(result.screenshotUnavailableReason)).toMatch(/update/i);
+  });
+
+  it("rebuild:false reads the settled state without bumping the preview", async () => {
+    useAppStore.getState().setPreviewErrors(APP_ID, []);
+    const result = await executeAppAgentTool("run_app", {
+      appId: APP_ID,
+      rebuild: false,
+      includeScreenshot: false,
+    });
+    expect(result).toMatchObject({ success: true, status: "ready" });
+    expect(useAppStore.getState().previewNonce[APP_ID]).toBe(0);
+  });
+
+  it("degrades to a reason (not a failure) when capture breaks", async () => {
+    captureAppPreview.mockRejectedValue(new Error("no iframe"));
+    reportPreview(200, []);
+    const result = await executeAppAgentTool("run_app", { appId: APP_ID });
+    expect(result).toMatchObject({ success: true, status: "ready" });
+    expect(result.screenshotUnavailableReason).toBe("no iframe");
+  });
+
+  it("bails as timeout when no preview iframe is mounted", async () => {
+    findAppPreviewIframe.mockReturnValue(null);
+    const result = await executeAppAgentTool("run_app", {
+      appId: APP_ID,
+      includeScreenshot: false,
+    });
+    expect(result).toMatchObject({ success: false, status: "timeout" });
+    expect(String(result.error)).toMatch(/open_app/);
+  }, 10_000);
+});

--- a/app/src/app-runtime/agent-tools.ts
+++ b/app/src/app-runtime/agent-tools.ts
@@ -13,21 +13,86 @@ import {
   appResourceRef,
   appResourceVersion,
   appVersionedResourceVersion,
+  clampRunAppTimeoutMs,
   clipAgentText,
   parseAppResourceRef,
   readAppResourceRange,
   searchAppResources,
   summarizeAppBindingForState,
   summarizePreviewErrors,
+  type RunAppResult,
 } from "@mako/agent-tools";
+import { enqueueScreenshotVisionAttachment } from "../agent-runtime/screenshot-agent-tools";
 import { useConsoleStore } from "../store/consoleStore";
 import { useAppStore, type AppEntity } from "../store/appStore";
+import { captureAppPreview, findAppPreviewIframe } from "./preview-capture";
 import { focusAppTab, getCurrentWorkspaceId } from "./shell";
 
 type ToolResult = Record<string, unknown>;
 
 function fail(error: string): ToolResult {
   return { success: false, error };
+}
+
+/**
+ * How a run_app screenshot reaches the calling agent:
+ *  - "vision-attachment" (chat): queued as a real image input on the next
+ *    model request — base64 never enters the JSON tool result.
+ *  - "inline" (desktop bridge): returned in the envelope for the mako-desktop
+ *    loopback server to emit as MCP image content.
+ *  - "none": caller cannot deliver images (older Local Agent) — skip capture.
+ */
+export type RunAppScreenshotDelivery = "vision-attachment" | "inline" | "none";
+
+const PREVIEW_SETTLE_POLL_MS = 150;
+/** Grace for a preview iframe to mount after bumpPreview / tab focus. */
+const PREVIEW_IFRAME_MOUNT_GRACE_MS = 2_000;
+
+/**
+ * Await the iframe bootstrap's ready/error report (previewStatus in the app
+ * store) instead of sleeping a fixed delay. Bails early as "timeout" when no
+ * preview iframe is on screen — nothing will ever report in that case.
+ */
+async function waitForPreviewSettle(
+  appId: string,
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<{ status: "ready" | "error" | "timeout"; noIframe?: boolean }> {
+  const startedAt = Date.now();
+  for (;;) {
+    const status = useAppStore.getState().previewStatus[appId];
+    if (status === "ready" || status === "error") return { status };
+    if (status === undefined) {
+      // Nothing has ever built/reported for this app in this browser. Fall
+      // back to the error list (pre-previewStatus behavior) when a preview
+      // is on screen; report cleanly when it is not.
+      if (findAppPreviewIframe(appId)) {
+        const hasErrors =
+          (useAppStore.getState().previewErrors[appId] ?? []).length > 0;
+        return { status: hasErrors ? "error" : "ready" };
+      }
+      if (Date.now() - startedAt >= PREVIEW_IFRAME_MOUNT_GRACE_MS) {
+        return { status: "timeout", noIframe: true };
+      }
+    } else if (
+      !findAppPreviewIframe(appId) &&
+      Date.now() - startedAt >= PREVIEW_IFRAME_MOUNT_GRACE_MS
+    ) {
+      // "building" with no iframe mounted: the report can never arrive.
+      return { status: "timeout", noIframe: true };
+    }
+    if (signal?.aborted || Date.now() - startedAt >= timeoutMs) {
+      return { status: "timeout" };
+    }
+    await new Promise(resolve => setTimeout(resolve, PREVIEW_SETTLE_POLL_MS));
+  }
+}
+
+function dataUrlToParts(
+  dataUrl: string,
+): { mimeType: string; base64: string } | null {
+  const match = /^data:([^;,]+);base64,(.+)$/.exec(dataUrl);
+  return match ? { mimeType: match[1], base64: match[2] } : null;
 }
 
 function listOpenApps() {
@@ -69,7 +134,12 @@ const MATERIALIZE_TOOL_MAX_WAIT_MS = 600_000;
 export async function executeAppAgentTool(
   toolName: string,
   input: Record<string, unknown>,
-  options?: { executionId?: string; signal?: AbortSignal },
+  options?: {
+    executionId?: string;
+    signal?: AbortSignal;
+    /** run_app only — how a captured screenshot reaches the agent. */
+    screenshotDelivery?: RunAppScreenshotDelivery;
+  },
 ): Promise<ToolResult> {
   const store = useAppStore.getState();
   const workspaceId = getCurrentWorkspaceId();
@@ -438,19 +508,86 @@ export async function executeAppAgentTool(
     case "run_app": {
       if (!appId) return fail("appId is required");
       await ensureApp(appId);
-      // rebuild: false = read current errors only — no bumpPreview, which
-      // flashes a black "Building preview…" screen and can remount Chat.
+      // rebuild: false = read the current preview state — no bumpPreview,
+      // which flashes a black "Building preview…" screen and can remount Chat.
       if (input.rebuild !== false) {
         store.bumpPreview(appId);
-        // Give the preview a moment to rebuild and report errors.
-        await new Promise(resolve => setTimeout(resolve, 1200));
       }
+      const timeoutMs = clampRunAppTimeoutMs(
+        typeof input.timeoutMs === "number" ? input.timeoutMs : undefined,
+      );
+      const settled = await waitForPreviewSettle(
+        appId,
+        timeoutMs,
+        options?.signal,
+      );
       const errors = summarizePreviewErrors(
         useAppStore.getState().previewErrors[appId],
       );
-      return {
-        success: true,
+      const result: RunAppResult = {
+        success: settled.status === "ready",
+        status: settled.status,
         errors,
+        consoleLogs: [],
+        source: "iframe",
+        ...(settled.noIframe
+          ? {
+              error:
+                "No visible preview iframe for this app — open it with " +
+                "open_app so the preview can build and report.",
+            }
+          : {}),
+      };
+
+      const delivery = options?.screenshotDelivery ?? "vision-attachment";
+      const wantScreenshot = input.includeScreenshot !== false;
+      let screenshotPassedToModel = false;
+      if (wantScreenshot && delivery === "none") {
+        result.screenshotUnavailableReason =
+          "This client cannot deliver screenshots (update Mako Desktop / " +
+          "Local Agent). Status and errors above are still authoritative.";
+      } else if (wantScreenshot) {
+        try {
+          const dataUrl = await captureAppPreview(appId);
+          const parts = dataUrlToParts(dataUrl);
+          if (!parts) {
+            throw new Error("Preview returned an unreadable capture");
+          }
+          if (delivery === "inline") {
+            result.screenshot = {
+              mimeType: parts.mimeType,
+              base64: parts.base64,
+            };
+          } else {
+            const enqueued = enqueueScreenshotVisionAttachment({
+              renderer: "app-preview-self-capture",
+              filename: `run-app-${appId}-${Date.now()}.png`,
+              mediaType: "image/png",
+              dataUrl,
+              outputBytes: Math.ceil((parts.base64.length * 3) / 4),
+              targetLabel: "app-preview",
+            });
+            if (enqueued) {
+              screenshotPassedToModel = true;
+            } else {
+              result.screenshotUnavailableReason =
+                "Screenshot was too large to pass to the model.";
+            }
+          }
+        } catch (error) {
+          result.screenshotUnavailableReason =
+            error instanceof Error ? error.message : "Preview capture failed";
+        }
+      }
+
+      return {
+        ...result,
+        ...(screenshotPassedToModel
+          ? {
+              screenshotPassedToModel: true,
+              note: "The preview screenshot is sent as a real image input in the next model request, not inside this tool result.",
+            }
+          : {}),
       };
     }
 

--- a/app/src/app-runtime/preview-capture.ts
+++ b/app/src/app-runtime/preview-capture.ts
@@ -1,0 +1,138 @@
+/**
+ * Self-capture of sandboxed app-preview iframes.
+ *
+ * App previews render in opaque-origin iframes (`sandbox="allow-scripts"`),
+ * which DOM rasterizers (modern-screenshot) cannot capture from the parent —
+ * they come out blank. The preview bootstrap handles `mako-app:capture` and
+ * screenshots itself from inside (see preview.ts), returning a PNG data URL.
+ *
+ * Shared by `capture_screenshot` (composites every visible preview into a
+ * page capture) and the `run_app` executor (captures one app's preview as
+ * the verify screenshot) — one capture protocol, one implementation.
+ */
+import { PREVIEW_MESSAGE } from "./preview";
+
+export const APP_PREVIEW_IFRAME_SELECTOR = "iframe[data-mako-app-preview]";
+
+/**
+ * Per-iframe self-capture cap. Kept deliberately short: callers are
+ * client-only, long-running tools, so the longer this runs the wider the
+ * window in which a mobile lock / computer sleep / proxy idle timeout can
+ * interrupt the turn and strand the card. A timed-out capture degrades
+ * gracefully (reported as a capture failure, never a thrown turn).
+ */
+export const APP_PREVIEW_CAPTURE_TIMEOUT_MS = 4000;
+
+let captureSeq = 0;
+
+export interface PreviewCaptureOptions {
+  scale: number;
+  backgroundColor?: string | null;
+}
+
+function escapeAttributeValue(value: string): string {
+  const css = globalThis.CSS as
+    | { escape?: (value: string) => string }
+    | undefined;
+  return css?.escape ? css.escape(value) : value.replace(/["\\]/g, "\\$&");
+}
+
+function isCapturable(iframe: HTMLIFrameElement): boolean {
+  const rect = iframe.getBoundingClientRect();
+  return rect.width >= 8 && rect.height >= 8 && iframe.contentWindow != null;
+}
+
+/** All visible app-preview iframes inside (or being) the capture target. */
+export function findAppPreviewIframes(
+  target: HTMLElement,
+): HTMLIFrameElement[] {
+  const iframes = Array.from(
+    target.querySelectorAll<HTMLIFrameElement>(APP_PREVIEW_IFRAME_SELECTOR),
+  );
+  if (
+    target instanceof HTMLIFrameElement &&
+    target.matches(APP_PREVIEW_IFRAME_SELECTOR)
+  ) {
+    iframes.unshift(target);
+  }
+  return iframes.filter(isCapturable);
+}
+
+/** The visible preview iframe for one app (data-mako-app-preview={appId}). */
+export function findAppPreviewIframe(appId: string): HTMLIFrameElement | null {
+  const iframe = document.querySelector<HTMLIFrameElement>(
+    `iframe[data-mako-app-preview="${escapeAttributeValue(appId)}"]`,
+  );
+  return iframe && isCapturable(iframe) ? iframe : null;
+}
+
+/**
+ * Ask one preview iframe to screenshot itself; resolves to a PNG data URL.
+ */
+export function requestAppPreviewCapture(
+  iframe: HTMLIFrameElement,
+  options: PreviewCaptureOptions,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const contentWindow = iframe.contentWindow;
+    if (!contentWindow) {
+      reject(new Error("App preview iframe has no content window"));
+      return;
+    }
+    const requestId = `capture_${Date.now()}_${++captureSeq}`;
+    const timeout = window.setTimeout(() => {
+      window.removeEventListener("message", onMessage);
+      reject(new Error("App preview capture timed out"));
+    }, APP_PREVIEW_CAPTURE_TIMEOUT_MS);
+
+    function onMessage(event: MessageEvent) {
+      const data = (event.data ?? {}) as {
+        type?: string;
+        requestId?: string;
+        success?: boolean;
+        dataUrl?: string;
+        error?: string;
+      };
+      if (
+        event.source !== contentWindow ||
+        data.type !== PREVIEW_MESSAGE.captureResult ||
+        data.requestId !== requestId
+      ) {
+        return;
+      }
+      window.clearTimeout(timeout);
+      window.removeEventListener("message", onMessage);
+      if (data.success && data.dataUrl) resolve(data.dataUrl);
+      else reject(new Error(data.error || "App preview capture failed"));
+    }
+
+    window.addEventListener("message", onMessage);
+    // The sandboxed iframe has an opaque origin, so "*" is required.
+    contentWindow.postMessage(
+      {
+        type: PREVIEW_MESSAGE.capture,
+        requestId,
+        scale: options.scale,
+        backgroundColor: options.backgroundColor,
+      },
+      "*",
+    );
+  });
+}
+
+/**
+ * Capture one app's visible preview iframe as a PNG data URL. Throws when no
+ * capturable iframe is on screen (tab not open / preview hidden).
+ */
+export async function captureAppPreview(
+  appId: string,
+  options: PreviewCaptureOptions = { scale: 1 },
+): Promise<string> {
+  const iframe = findAppPreviewIframe(appId);
+  if (!iframe) {
+    throw new Error(
+      "No visible preview iframe for this app — open its tab to capture a screenshot.",
+    );
+  }
+  return requestAppPreviewCapture(iframe, options);
+}

--- a/app/src/lib/desktop-acp-bridge.ts
+++ b/app/src/lib/desktop-acp-bridge.ts
@@ -29,6 +29,12 @@ interface BridgeJob {
   arguments: Record<string, unknown>;
   agentSessionId?: string;
   workspaceId?: string;
+  /**
+   * Delivery capabilities of the enqueuing Local Agent build. Absent on
+   * older builds — which must never receive inline image payloads (they
+   * stringify the whole result into the model context).
+   */
+  capabilities?: { imageContent?: boolean };
 }
 
 interface ClaimEnvelope {
@@ -83,12 +89,24 @@ async function executeImmediateJob(job: BridgeJob): Promise<unknown> {
   }
 
   if (job.tool === "run_app") {
-    // rebuild: false = the executor skips the iframe rebuild and returns
-    // the current preview errors (the old get_preview_errors behavior).
-    return executeAppAgentTool("run_app", {
-      appId,
-      rebuild: job.arguments.rebuild,
-    });
+    // rebuild: false = the executor skips the iframe rebuild and reports
+    // the current preview state (the old get_preview_errors behavior).
+    // Screenshots go inline in the envelope ONLY when this Local Agent
+    // build declared it emits MCP image content; otherwise skip capture so
+    // an older build never stringifies base64 into the model context.
+    return executeAppAgentTool(
+      "run_app",
+      {
+        appId,
+        rebuild: job.arguments.rebuild,
+        includeScreenshot: job.arguments.includeScreenshot,
+        timeoutMs: job.arguments.timeoutMs,
+      },
+      {
+        screenshotDelivery:
+          job.capabilities?.imageContent === true ? "inline" : "none",
+      },
+    );
   }
 
   throw new Error(`Unsupported desktop bridge tool: ${job.tool}`);

--- a/app/src/store/appStore.ts
+++ b/app/src/store/appStore.ts
@@ -137,6 +137,13 @@ interface AppState {
    */
   dataRefreshNonce: Record<string, number>;
   previewErrors: Record<string, AppPreviewError[]>;
+  /**
+   * Preview lifecycle per app: "building" from bumpPreview until the iframe
+   * bootstrap posts ready/error (which lands via setPreviewErrors — [] on
+   * ready, non-empty on error). Undefined until the first build/report. The
+   * run_app executor awaits this instead of sleeping a fixed delay.
+   */
+  previewStatus: Record<string, "building" | "ready" | "error">;
 
   /**
    * Per-user, per-app dbt environment override for the DRAFT PREVIEW only
@@ -324,6 +331,7 @@ const initialState: AppState = {
   previewNonce: {},
   dataRefreshNonce: {},
   previewErrors: {},
+  previewStatus: {},
   previewDbtEnv: {},
   dbtEnvInfo: {},
 };
@@ -473,6 +481,7 @@ export const useAppStore = create<AppStore>()(
           delete state.previewNonce[appId];
           delete state.dataRefreshNonce[appId];
           delete state.previewErrors[appId];
+          delete state.previewStatus[appId];
         });
         void get().fetchList(workspaceId);
         return true;
@@ -747,6 +756,7 @@ export const useAppStore = create<AppStore>()(
     bumpPreview: appId =>
       set(state => {
         state.previewNonce[appId] = (state.previewNonce[appId] || 0) + 1;
+        state.previewStatus[appId] = "building";
       }),
 
     requestDataRefresh: appId =>
@@ -771,6 +781,9 @@ export const useAppStore = create<AppStore>()(
     setPreviewErrors: (appId, errors) =>
       set(state => {
         state.previewErrors[appId] = errors;
+        // The iframe bootstrap reports exactly one of ready ([]) or error
+        // (non-empty), so error presence IS the settled preview status.
+        state.previewStatus[appId] = errors.length > 0 ? "error" : "ready";
       }),
 
     setPreviewDbtEnvironment: (appId, environment) => {

--- a/packages/agent-tools/package.json
+++ b/packages/agent-tools/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "pnpm run build && node --test dist/*-tools-state.test.js",
+    "test": "pnpm run build && node --test dist/*.test.js",
     "prepare": "node prepare.js"
   },
   "dependencies": {

--- a/packages/agent-tools/src/app-tools.ts
+++ b/packages/agent-tools/src/app-tools.ts
@@ -14,6 +14,8 @@
 import { tool } from "ai";
 import { z } from "zod";
 
+import { runAppBaseSchema } from "./run-app";
+
 const appIdField = z.string().describe("App ID (from list_open_apps)");
 
 // NOTE: the mutation tools below (write/delete/rename file, add/remove
@@ -783,21 +785,13 @@ export const clientAppTools = {
   }),
   run_app: tool({
     description:
-      "Rebuild and reload the app's LIVE PREVIEW in the browser and return any " +
-      "build/runtime errors. Pass rebuild: false to read the current preview " +
-      "errors without forcing a rebuild. Use it to validate that edits render " +
-      "and to read preview errors. Requires an attached browser tab; it is " +
-      "not needed to author or persist an app.",
-    inputSchema: z.object({
-      appId: appIdField,
-      rebuild: z
-        .boolean()
-        .optional()
-        .describe(
-          "Default true. false = return the current preview errors without " +
-            "rebuilding the iframe (no preview flash).",
-        ),
-    }),
+      "Verify the app: rebuild and reload its LIVE PREVIEW, wait for it to " +
+      "render, and return status, build/runtime errors, and a screenshot of " +
+      "the rendered preview. Use after edits to confirm the app actually " +
+      "works. Pass rebuild: false to read the current preview state without " +
+      "forcing a rebuild, and includeScreenshot: false when you only need " +
+      "status/errors (much cheaper).",
+    inputSchema: runAppBaseSchema,
   }),
   app_set_preview_environment: tool({
     description:

--- a/packages/agent-tools/src/capabilities/app-capabilities.ts
+++ b/packages/agent-tools/src/capabilities/app-capabilities.ts
@@ -204,11 +204,12 @@ export const APP_CAPABILITIES = [
     },
   }),
   define({
-    // One capability, one name, three adapters: Chat rebuilds the live
-    // iframe (client tool), Desktop delivers it via the mako-desktop
-    // loopback server, and external MCP runs the server-side headless
-    // renderer (api/src/mcp/preview-tools.ts). Rendering a draft mutates
-    // nothing, so it is read-risk on every surface.
+    // One capability, one name, one result envelope (run-app.ts), three
+    // adapters: Chat rebuilds the live iframe and self-captures a screenshot
+    // (client tool), Desktop delivers the same executor via the mako-desktop
+    // loopback server (screenshot as MCP image content), and external MCP
+    // runs the server-side headless renderer (api/src/mcp/preview-tools.ts).
+    // Rendering a draft mutates nothing, so it is read-risk on every surface.
     name: "run_app",
     pack: "app-ui",
     risk: "read",

--- a/packages/agent-tools/src/index.ts
+++ b/packages/agent-tools/src/index.ts
@@ -147,6 +147,24 @@ export {
   NOTEBOOK_SOURCE_PREVIEW_CHARS,
 } from "./notebook-tools";
 
+export {
+  runAppBaseSchema,
+  clampRunAppTimeoutMs,
+  summarizeRunAppResult,
+  runAppResultToMcpContent,
+  isRunAppResult,
+  RUN_APP_DEFAULT_TIMEOUT_MS,
+  RUN_APP_MIN_TIMEOUT_MS,
+  RUN_APP_MAX_TIMEOUT_MS,
+} from "./run-app";
+export type {
+  RunAppBaseInput,
+  RunAppResult,
+  RunAppScreenshot,
+  RunAppSource,
+  RunAppMcpContent,
+} from "./run-app";
+
 export { clientScreenshotTools } from "./screenshot-tools";
 export type { CaptureScreenshotInput } from "./screenshot-tools";
 

--- a/packages/agent-tools/src/run-app.test.ts
+++ b/packages/agent-tools/src/run-app.test.ts
@@ -1,0 +1,82 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  clampRunAppTimeoutMs,
+  isRunAppResult,
+  runAppResultToMcpContent,
+  summarizeRunAppResult,
+  RUN_APP_DEFAULT_TIMEOUT_MS,
+  RUN_APP_MAX_TIMEOUT_MS,
+  RUN_APP_MIN_TIMEOUT_MS,
+  type RunAppResult,
+} from "./run-app";
+
+const ready: RunAppResult = {
+  success: true,
+  status: "ready",
+  errors: [],
+  consoleLogs: ["[mako-preview-ready]"],
+  source: "headless",
+  screenshot: { mimeType: "image/jpeg", base64: "c2NyZWVuc2hvdA==" },
+};
+
+describe("run-app shared contract", () => {
+  it("clamps the settle timeout to the shared range", () => {
+    assert.equal(clampRunAppTimeoutMs(undefined), RUN_APP_DEFAULT_TIMEOUT_MS);
+    assert.equal(clampRunAppTimeoutMs(1), RUN_APP_MIN_TIMEOUT_MS);
+    assert.equal(clampRunAppTimeoutMs(999_999), RUN_APP_MAX_TIMEOUT_MS);
+    assert.equal(clampRunAppTimeoutMs(30_000), 30_000);
+  });
+
+  it("summarize strips the screenshot but keeps everything else", () => {
+    const summary = summarizeRunAppResult(ready);
+    assert.equal("screenshot" in summary, false);
+    assert.equal(summary.status, "ready");
+    assert.deepEqual(summary.consoleLogs, ["[mako-preview-ready]"]);
+  });
+
+  it("formats a screenshot result as text + image MCP content", () => {
+    const content = runAppResultToMcpContent(ready);
+    assert.equal(content.length, 2);
+    assert.equal(content[0].type, "text");
+    const text = (content[0] as { text: string }).text;
+    assert.match(text, /"status":"ready"/);
+    // Base64 must never leak into the text part.
+    assert.doesNotMatch(text, /c2NyZWVuc2hvdA==/);
+    assert.deepEqual(content[1], {
+      type: "image",
+      data: "c2NyZWVuc2hvdA==",
+      mimeType: "image/jpeg",
+    });
+  });
+
+  it("formats a screenshot-less result as a single text part", () => {
+    const { screenshot: _screenshot, ...noShot } = ready;
+    const content = runAppResultToMcpContent({
+      ...noShot,
+      screenshotUnavailableReason: "renderer disabled",
+    });
+    assert.equal(content.length, 1);
+    assert.match(
+      (content[0] as { text: string }).text,
+      /renderer disabled/,
+    );
+  });
+
+  it("guards envelopes crossing loose boundaries", () => {
+    assert.equal(isRunAppResult(ready), true);
+    assert.equal(isRunAppResult({ success: true, errors: [] }), false);
+    assert.equal(isRunAppResult(null), false);
+    assert.equal(isRunAppResult("ok"), false);
+    assert.equal(
+      isRunAppResult({
+        success: true,
+        status: "ready",
+        errors: [],
+        source: "iframe",
+      }),
+      true,
+    );
+  });
+});

--- a/packages/agent-tools/src/run-app.ts
+++ b/packages/agent-tools/src/run-app.ts
@@ -1,0 +1,137 @@
+/**
+ * Shared contract for the canonical cross-surface `run_app` capability.
+ *
+ * One tool name, one result envelope, three delivery adapters:
+ *   - external MCP  → server-side headless render (api/src/mcp/preview-tools.ts)
+ *   - Desktop ACP   → mako-desktop loopback bridge against the live iframe
+ *   - in-chat       → client executor against the live iframe
+ *
+ * Every adapter returns a `RunAppResult`; only the capture mechanics differ.
+ * Inputs share `runAppBaseSchema` (adapters may extend it — e.g. the headless
+ * renderer adds viewport width/height, meaningless for a live iframe).
+ */
+import { z } from "zod";
+
+/** Wait budget for the preview to report ready/error (all adapters). */
+export const RUN_APP_DEFAULT_TIMEOUT_MS = 20_000;
+export const RUN_APP_MIN_TIMEOUT_MS = 5_000;
+export const RUN_APP_MAX_TIMEOUT_MS = 45_000;
+
+export function clampRunAppTimeoutMs(timeoutMs: number | undefined): number {
+  return Math.min(
+    Math.max(timeoutMs ?? RUN_APP_DEFAULT_TIMEOUT_MS, RUN_APP_MIN_TIMEOUT_MS),
+    RUN_APP_MAX_TIMEOUT_MS,
+  );
+}
+
+export const runAppBaseSchema = z.object({
+  appId: z.string().describe("App ID (from list_open_apps)"),
+  rebuild: z
+    .boolean()
+    .optional()
+    .describe(
+      "Default true. false = report the current preview state without " +
+        "forcing a rebuild (no preview flash).",
+    ),
+  includeScreenshot: z
+    .boolean()
+    .optional()
+    .describe(
+      "Default true. Pass false to get status/errors only — much cheaper " +
+        "when you just need to know whether the render succeeded.",
+    ),
+  timeoutMs: z
+    .number()
+    .int()
+    .min(RUN_APP_MIN_TIMEOUT_MS)
+    .max(RUN_APP_MAX_TIMEOUT_MS)
+    .optional()
+    .describe("How long to wait for the app to finish rendering (ms)"),
+});
+
+export type RunAppBaseInput = z.infer<typeof runAppBaseSchema>;
+
+export interface RunAppScreenshot {
+  mimeType: string;
+  /** Raw base64, no data: prefix. */
+  base64: string;
+}
+
+/** Which adapter produced the result (and therefore what the pixels show). */
+export type RunAppSource = "headless" | "desktop" | "iframe";
+
+export interface RunAppResult {
+  success: boolean;
+  /** ready | error | timeout — what the preview reported within the budget. */
+  status: "ready" | "error" | "timeout";
+  errors: Array<string | { message: string; source?: string }>;
+  consoleLogs: string[];
+  source: RunAppSource;
+  /** Present when captured AND delivered inline (MCP / desktop bridge). */
+  screenshot?: RunAppScreenshot;
+  /** Why no screenshot came back (renderer unconfigured, capture failed…). */
+  screenshotUnavailableReason?: string;
+  /** Transport-level failure detail (render pool crash, unreachable base…). */
+  error?: string;
+}
+
+/**
+ * The JSON-safe half of a result: everything except the screenshot bytes.
+ * What adapters put in text/tool-result parts — base64 never travels as text.
+ */
+export function summarizeRunAppResult(
+  result: RunAppResult,
+): Omit<RunAppResult, "screenshot"> {
+  const { screenshot: _screenshot, ...summary } = result;
+  return summary;
+}
+
+interface McpTextContent {
+  type: "text";
+  text: string;
+}
+
+interface McpImageContent {
+  type: "image";
+  data: string;
+  mimeType: string;
+}
+
+export type RunAppMcpContent = McpTextContent | McpImageContent;
+
+/**
+ * MCP tool-result content for a RunAppResult: JSON summary text plus an image
+ * block when a screenshot is present. Both MCP-facing adapters (headless
+ * bridge, mako-desktop loopback) format through here so clients see one shape.
+ */
+export function runAppResultToMcpContent(
+  result: RunAppResult,
+): RunAppMcpContent[] {
+  const content: RunAppMcpContent[] = [
+    { type: "text", text: JSON.stringify(summarizeRunAppResult(result)) },
+  ];
+  if (result.screenshot) {
+    content.push({
+      type: "image",
+      data: result.screenshot.base64,
+      mimeType: result.screenshot.mimeType,
+    });
+  }
+  return content;
+}
+
+/** Type guard for envelopes crossing loosely-typed boundaries (bridge jobs). */
+export function isRunAppResult(value: unknown): value is RunAppResult {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<RunAppResult>;
+  return (
+    typeof candidate.success === "boolean" &&
+    (candidate.status === "ready" ||
+      candidate.status === "error" ||
+      candidate.status === "timeout") &&
+    Array.isArray(candidate.errors) &&
+    (candidate.source === "headless" ||
+      candidate.source === "desktop" ||
+      candidate.source === "iframe")
+  );
+}

--- a/packages/local-agent/src/acp/mako-system-append.ts
+++ b/packages/local-agent/src/acp/mako-system-append.ts
@@ -38,8 +38,7 @@ Use \`${prefix}create_notebook\` / \`${prefix}list_open_notebooks\`, then \`${pr
 ## Apps (Desktop preview — not headless)
 The user can see apps in the Mako window. After \`${prefix}create_app\` / \`${prefix}app_write_file\` / \`${prefix}app_edit_file\`, Desktop opens/refreshes the app tab automatically.
 - \`create_preview_token\` / \`render_app\` / \`/preview/…\` URLs are **unavailable and forbidden** in Desktop Chat — never call them or invent preview links.
-- After edits, call \`${desktopPrefix}run_app\` with the appId to rebuild the iframe and read \`previewErrors\`. Pass \`rebuild: false\` to poll errors without rebuilding.
-- Describe what changed in the in-app preview; ask the user to look at the app tab if you need visual confirmation.
+- After edits, verify with \`${desktopPrefix}run_app\`: it rebuilds the iframe, waits for it to render, and returns status, build/runtime errors, and a screenshot of exactly what the user sees. Pass \`rebuild: false\` to poll the current state without rebuilding, and \`includeScreenshot: false\` when you only need status/errors (much cheaper).
 
 ## Workspace memory (Mako — not local Claude files)
 Durable knowledge for this workspace lives in Mako's self-directive:

--- a/packages/local-agent/src/desktop-bridge/mcp.test.ts
+++ b/packages/local-agent/src/desktop-bridge/mcp.test.ts
@@ -171,6 +171,84 @@ describe("desktop-bridge MCP", () => {
     assert.match(body.result.content[0].text, /"decision":"approve"/);
   });
 
+  it("stamps every job with this build's delivery capabilities", async () => {
+    desktopBridgeRegistry.touchClient();
+    const callPromise = handleDesktopMcpExchange({
+      jsonrpc: "2.0",
+      id: 30,
+      method: "tools/call",
+      params: { name: "run_app", arguments: { appId: "app-3" } },
+    });
+    const job = await desktopBridgeRegistry.claim(5_000);
+    assert.ok(job);
+    // The renderer keys inline screenshot delivery off this marker — an
+    // older Local Agent (no marker) must keep getting text-only results.
+    assert.equal(job.capabilities?.imageContent, true);
+    desktopBridgeRegistry.complete(job.id, { success: true, errors: [] });
+    await callPromise;
+  });
+
+  it("emits a run_app envelope screenshot as an MCP image content block", async () => {
+    desktopBridgeRegistry.touchClient();
+    const callPromise = handleDesktopMcpExchange({
+      jsonrpc: "2.0",
+      id: 31,
+      method: "tools/call",
+      params: { name: "run_app", arguments: { appId: "app-4" } },
+    });
+    const job = await desktopBridgeRegistry.claim(5_000);
+    assert.ok(job);
+    desktopBridgeRegistry.complete(job.id, {
+      success: true,
+      status: "ready",
+      errors: [],
+      consoleLogs: [],
+      source: "desktop",
+      screenshot: { mimeType: "image/png", base64: "aGVsbG8=" },
+    });
+
+    const exchange = await callPromise;
+    const body = exchange.body as {
+      result: {
+        isError?: boolean;
+        content: Array<{
+          type: string;
+          text?: string;
+          data?: string;
+          mimeType?: string;
+        }>;
+      };
+    };
+    assert.equal(body.result.isError, undefined);
+    assert.equal(body.result.content.length, 2);
+    const [summary, image] = body.result.content;
+    assert.equal(summary.type, "text");
+    assert.match(summary.text ?? "", /"status":"ready"/);
+    // Base64 must never leak into the text part.
+    assert.doesNotMatch(summary.text ?? "", /aGVsbG8=/);
+    assert.equal(image.type, "image");
+    assert.equal(image.data, "aGVsbG8=");
+    assert.equal(image.mimeType, "image/png");
+  });
+
+  it("legacy get_preview_errors polls without rebuild or screenshot", async () => {
+    desktopBridgeRegistry.touchClient();
+    const callPromise = handleDesktopMcpExchange({
+      jsonrpc: "2.0",
+      id: 32,
+      method: "tools/call",
+      params: { name: "get_preview_errors", arguments: { appId: "app-5" } },
+    });
+    const job = await desktopBridgeRegistry.claim(5_000);
+    assert.ok(job);
+    assert.equal(job.tool, "run_app");
+    assert.equal(job.arguments.rebuild, false);
+    // Old cheap error poll must stay cheap — no screenshot capture.
+    assert.equal(job.arguments.includeScreenshot, false);
+    desktopBridgeRegistry.complete(job.id, { success: true, errors: [] });
+    await callPromise;
+  });
+
   it("translates legacy get_preview_errors into run_app({ rebuild: false })", async () => {
     desktopBridgeRegistry.touchClient();
     const callPromise = handleDesktopMcpExchange({

--- a/packages/local-agent/src/desktop-bridge/mcp.ts
+++ b/packages/local-agent/src/desktop-bridge/mcp.ts
@@ -4,18 +4,29 @@
  */
 import {
   HITL_TOOL_JSON_SCHEMAS,
+  isRunAppResult,
+  runAppResultToMcpContent,
   validateHitlToolArguments,
 } from "@mako/agent-tools";
 
 import {
   desktopBridgeRegistry,
   isDesktopHitlTool,
+  type DesktopBridgeCapabilities,
   type DesktopBridgeToolName,
 } from "./registry";
 
 const SERVER_NAME = "mako-desktop";
-const SERVER_VERSION = "0.3.0";
+const SERVER_VERSION = "0.4.0";
 const PROTOCOL_VERSION = "2024-11-05";
+
+/**
+ * Delivery capabilities of THIS build, stamped on every bridge job. The
+ * renderer inlines screenshot payloads only when the enqueuing Local Agent
+ * declares it can emit them as MCP image content — an older build without
+ * the marker keeps getting the old text-only result shape.
+ */
+const BRIDGE_CAPABILITIES: DesktopBridgeCapabilities = { imageContent: true };
 
 type JsonRpcId = string | number | null;
 
@@ -41,7 +52,7 @@ const TOOLS: Array<{
   {
     name: "run_app",
     description:
-      "Rebuild the in-Desktop app preview iframe and return live build/runtime errors (previewErrors). Pass rebuild: false to read the current previewErrors without forcing a rebuild. Prefer this over create_preview_token when Chat is open in Mako Desktop.",
+      "Verify the app: rebuild the in-Desktop preview iframe, wait for it to render, and return status, live build/runtime errors, and a screenshot of exactly what the user sees. Pass rebuild: false to read the current preview state without forcing a rebuild, and includeScreenshot: false when you only need status/errors (much cheaper). Prefer this over create_preview_token when Chat is open in Mako Desktop.",
     inputSchema: {
       type: "object",
       properties: {
@@ -49,7 +60,17 @@ const TOOLS: Array<{
         rebuild: {
           type: "boolean",
           description:
-            "Default true. false = return current previewErrors without rebuilding the iframe.",
+            "Default true. false = return the current preview state without rebuilding the iframe.",
+        },
+        includeScreenshot: {
+          type: "boolean",
+          description:
+            "Default true. false = status/errors only, no screenshot (much cheaper).",
+        },
+        timeoutMs: {
+          type: "number",
+          description:
+            "How long to wait for the preview to finish rendering, in ms (5000-45000, default 20000).",
         },
       },
       required: ["appId"],
@@ -88,18 +109,27 @@ function fail(id: JsonRpcId, code: number, message: string): JsonRpcResponse {
   return { jsonrpc: "2.0", id, error: { code, message } };
 }
 
+type McpContent = Array<Record<string, unknown>>;
+
+function textContent(text: string): McpContent {
+  return [{ type: "text", text }];
+}
+
 async function callTool(
   rawName: string,
   rawArgs: Record<string, unknown>,
   context?: { agentSessionId?: string; workspaceId?: string },
-): Promise<{ text: string; isError?: boolean }> {
+): Promise<{ content: McpContent; isError?: boolean }> {
   // Legacy alias from pre-0.3 tool lists: agents mid-session across an
-  // update may still call it — same job as run_app({ rebuild: false }).
+  // update may still call it — same job as run_app({ rebuild: false }),
+  // minus the screenshot (the old cheap error poll).
   const legacyPreviewErrors = rawName === "get_preview_errors";
   const name = legacyPreviewErrors ? "run_app" : rawName;
-  let args = legacyPreviewErrors ? { ...rawArgs, rebuild: false } : rawArgs;
+  let args = legacyPreviewErrors
+    ? { ...rawArgs, rebuild: false, includeScreenshot: false }
+    : rawArgs;
   if (!TOOL_NAMES.has(name as DesktopBridgeToolName)) {
-    return { text: `Unknown tool: ${name}`, isError: true };
+    return { content: textContent(`Unknown tool: ${name}`), isError: true };
   }
   // HITL payloads render directly in the Desktop dock — bounce malformed
   // arguments back to the agent as a correctable tool error instead of
@@ -107,7 +137,7 @@ async function callTool(
   if (isDesktopHitlTool(name)) {
     const validated = validateHitlToolArguments(name, args);
     if (!validated.ok) {
-      return { text: validated.error, isError: true };
+      return { content: textContent(validated.error), isError: true };
     }
     args = validated.data;
   }
@@ -116,14 +146,26 @@ async function callTool(
       name as DesktopBridgeToolName,
       args && typeof args === "object" ? args : {},
       undefined,
-      context,
+      { ...context, capabilities: BRIDGE_CAPABILITIES },
     );
+    // run_app envelopes with a screenshot become text + image content blocks
+    // (shared formatter — same shape the Mako MCP server emits). The
+    // renderer only inlines screenshots because we declared imageContent.
+    if (isRunAppResult(result) && result.screenshot) {
+      return {
+        content: runAppResultToMcpContent(result).map(part => ({ ...part })),
+      };
+    }
     return {
-      text: typeof result === "string" ? result : JSON.stringify(result),
+      content: textContent(
+        typeof result === "string" ? result : JSON.stringify(result),
+      ),
     };
   } catch (error) {
     return {
-      text: error instanceof Error ? error.message : String(error),
+      content: textContent(
+        error instanceof Error ? error.message : String(error),
+      ),
       isError: true,
     };
   }
@@ -175,7 +217,7 @@ async function handleOne(
     ) {
       const result = await callTool(name, args, context);
       return ok(id, {
-        content: [{ type: "text", text: result.text }],
+        content: result.content,
         ...(result.isError ? { isError: true } : {}),
       });
     }

--- a/packages/local-agent/src/desktop-bridge/registry.ts
+++ b/packages/local-agent/src/desktop-bridge/registry.ts
@@ -9,6 +9,17 @@ export type DesktopBridgeToolName =
   | "ask_clarifying_questions"
   | "submit_plan";
 
+/**
+ * What THIS Local Agent build can deliver back to the calling agent. Travels
+ * on every job so the renderer can shape results for the enqueuing version —
+ * an older Local Agent (no marker) must never receive inline image payloads
+ * it would stringify into the model context.
+ */
+export interface DesktopBridgeCapabilities {
+  /** This build emits MCP image content blocks from bridge results. */
+  imageContent?: boolean;
+}
+
 export interface DesktopBridgeJob {
   id: string;
   tool: DesktopBridgeToolName;
@@ -16,6 +27,7 @@ export interface DesktopBridgeJob {
   createdAt: number;
   agentSessionId?: string;
   workspaceId?: string;
+  capabilities?: DesktopBridgeCapabilities;
 }
 
 interface PendingJob extends DesktopBridgeJob {
@@ -32,6 +44,11 @@ interface ClaimWaiter {
 const DEFAULT_JOB_TTL_MS = 25_000;
 /** Clarifying questions / plan approval — user may take minutes. */
 const HITL_JOB_TTL_MS = 30 * 60 * 1000;
+/**
+ * run_app awaits the preview's ready/error report (up to the shared 45s
+ * settle cap) plus screenshot capture — needs headroom over the default TTL.
+ */
+const RUN_APP_JOB_TTL_MS = 60_000;
 const DEFAULT_CLAIM_WAIT_MS = 20_000;
 
 const HITL_TOOLS = new Set<DesktopBridgeToolName>([
@@ -46,7 +63,9 @@ export function isDesktopHitlTool(
 }
 
 function ttlForTool(tool: DesktopBridgeToolName): number {
-  return isDesktopHitlTool(tool) ? HITL_JOB_TTL_MS : DEFAULT_JOB_TTL_MS;
+  if (isDesktopHitlTool(tool)) return HITL_JOB_TTL_MS;
+  if (tool === "run_app") return RUN_APP_JOB_TTL_MS;
+  return DEFAULT_JOB_TTL_MS;
 }
 
 function newId(): string {
@@ -72,7 +91,11 @@ class DesktopBridgeRegistry {
     tool: DesktopBridgeToolName,
     args: Record<string, unknown>,
     timeoutMs = ttlForTool(tool),
-    context?: { agentSessionId?: string; workspaceId?: string },
+    context?: {
+      agentSessionId?: string;
+      workspaceId?: string;
+      capabilities?: DesktopBridgeCapabilities;
+    },
   ): Promise<unknown> {
     return new Promise((resolve, reject) => {
       if (!this.hasRecentClient()) {
@@ -92,6 +115,7 @@ class DesktopBridgeRegistry {
         createdAt: Date.now(),
         agentSessionId: context?.agentSessionId,
         workspaceId: context?.workspaceId,
+        capabilities: context?.capabilities,
         resolve,
         reject,
         timer: setTimeout(() => {
@@ -173,6 +197,7 @@ function publicJob(job: PendingJob): DesktopBridgeJob {
     createdAt: job.createdAt,
     agentSessionId: job.agentSessionId,
     workspaceId: job.workspaceId,
+    capabilities: job.capabilities,
   };
 }
 


### PR DESCRIPTION
## Summary

`run_app` becomes one capability with one result envelope and three delivery adapters, so agents get a real verify leg — status, build/runtime errors, **and a screenshot** — on every surface:

| Surface | Adapter | Screenshot delivery |
|---|---|---|
| External MCP (Claude Code, claude.ai, CI) | server-side headless Chromium (unchanged renderer) | MCP image content block |
| In-chat agent | live iframe + settle signal + self-capture | vision attachment (real image input on the next model request) |
| Desktop ACP (Local Agent) | same client executor via the mako-desktop loopback bridge | MCP image content block, gated on a capability handshake |

## Changes

- **`@mako/agent-tools`**: new `run-app.ts` — shared `RunAppResult` envelope, `runAppBaseSchema` (`appId` / `rebuild` / `includeScreenshot` / `timeoutMs`), shared settle-timeout clamp, and the MCP text+image content formatter used by both MCP-facing adapters.
- **External MCP** (`api/src/mcp/preview-tools.ts`): conforms to the envelope (`source: "headless"`, `screenshotUnavailableReason` when `RENDER_APP_BROWSER_PATH` is unset). Result is a strict superset of the old shape; `render_app` alias unchanged.
- **In chat** (`app/src/app-runtime/agent-tools.ts`): the executor awaits the preview's real ready/error report — new `previewStatus` in `appStore`, maintained entirely by the existing `bumpPreview` / `setPreviewErrors` actions (AppRenderer untouched) — replacing the fixed 1.2 s sleep. It then self-captures the sandboxed iframe via the existing `mako-app:capture` protocol, extracted into `app-runtime/preview-capture.ts` and shared with `capture_screenshot`. Screenshots ride the existing vision-attachment queue; base64 never enters a JSON tool result. No mounted iframe → clean 2 s bail with an `open_app` hint instead of a hang.
- **Desktop ACP** (`packages/local-agent`): the Local Agent stamps every bridge job with `capabilities: { imageContent: true }`; the renderer inlines a screenshot **only** when that marker is present, so an older Local Agent (which stringifies results into model context) can never receive base64. The loopback server emits the envelope as MCP text+image blocks via the shared formatter; `run_app` job TTL raised to 60 s; legacy `get_preview_errors` stays a cheap no-rebuild / no-screenshot poll.
- **Prompts/docs**: ACP system append, MCP server instructions, apps skill, and capability-registry comments now describe the unified verify loop (`includeScreenshot: false` for cheap status checks). The "ask the user to look at the app tab" fallback is gone.

## Rollout / compatibility

Skew-safe in both directions: every consumer tolerates the previous producer's result shape, and Desktop screenshot delivery is gated on the bridge capability handshake rather than deploy order. No breaking changes for existing MCP clients.

## Tests

- New: 7 vitest cases for the client executor (settle await, error envelope, all three delivery modes, capture-failure degradation, no-iframe bail), 3 loopback bridge tests (capability marker, image content block with no base64 leakage into the text part, legacy alias stays cheap), 5 shared-contract tests.
- Full suites green: app 409/409 (58 files), API suite (incl. MCP inventory + tier-policy tests), local-agent, agent-tools. Lint clean (4 pre-existing API warnings unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFAGxnhZm5WTg7UQu9mtDd

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFAGxnhZm5WTg7UQu9mtDd)_