### PR TITLE
feat(apps): mobile viewport preview for agents and users on every surface

### DIFF
--- a/api/src/agent-skills/apps/SKILL.md
+++ b/api/src/agent-skills/apps/SKILL.md
@@ -186,6 +186,27 @@ preview; headless MCP renders server-side); `open_app` just focuses a UI tab.
    `useDuckDB` calls. Data sources are also visible to the user under "Data sources" in the
    app's explorer tree.
 
+### Mobile & responsive layouts
+
+Apps are often opened on phones (shared links especially). Build responsive by
+default and **verify at mobile size before publishing** — media queries respond
+to the render viewport, so a run at phone size IS the mobile check:
+
+- **Verify loop**: before `app_save_version`, call `run_app` at
+  `width: 390, height: 844` (phone) and once at the default desktop viewport,
+  and fix what breaks. In a browser the phone-size render is applied for that
+  render only — the user's preview viewport is restored afterward.
+- **Iterating on mobile fixes in chat/Desktop**: `app_set_preview_viewport`
+  with `preset: "phone"` (or `"tablet"`, or custom `width`/`height`) switches
+  the on-screen preview so you and the user look at the same mobile layout
+  while you edit; `preset: "desktop"` resets. This is per-user view state —
+  it never changes the app definition. The user has the same toggle on the
+  preview toolbar.
+- **Design rules**: fluid layouts (flex/grid + `minmax`/`flex-wrap`), no fixed
+  pixel widths on containers, `max-width: 100%` on media, touch targets ≥ 44px,
+  collapse multi-column tables to cards/lists under ~640px, keep charts inside
+  responsive containers, and avoid hover-only affordances for primary actions.
+
 ### Version history, drafts & publishing
 
 Apps use a **draft → published** split:

--- a/api/src/agents/modes/registry.ts
+++ b/api/src/agents/modes/registry.ts
@@ -182,6 +182,7 @@ const APP_MODE_TOOL_NAMES: string[] = [
   "materialize_binding",
   "run_app",
   "app_set_preview_environment",
+  "app_set_preview_viewport",
   // Shared surface-scoped data-source primitives (apps + dashboards)
   "list_data_sources",
   "inspect_data_source",

--- a/api/src/mcp/mako-mcp-server.ts
+++ b/api/src/mcp/mako-mcp-server.ts
@@ -80,7 +80,7 @@ Typical loop:
 1. Discover data: list_connections, then sql_list_tables / sql_inspect_table.
 2. Validate queries with sql_execute_query (short exploration timeout). For slow warehouses: create_console → run_console → check_query_status.
 3. create_app → app_write_file / app_edit_file → app_create_data_binding (bind the validated query; pass consoleId to seed from a console).
-4. Verify with run_app after edits (server-side headless render). Pass includeScreenshot: false when you only need status/errors — it is much cheaper than the screenshot.
+4. Verify with run_app after edits (server-side headless render). Pass includeScreenshot: false when you only need status/errors — it is much cheaper than the screenshot. Pass width/height (e.g. 390x844) to verify the mobile layout before publishing.
 5. app_save_version to snapshot/publish.
 
 dbt: read_dbt_project_tree → read/edit files → validate with dbt_parse / dbt_compile_model / dbt_show (async: poll dbt_get_run). Check dbt_git_status before finishing — edits are working-tree drafts until committed. Warehouse-mutating runs (dbt_run_model, dbt_run_job) appear only when the API key has the warehouse:write scope; Git mutations (dbt_commit_to_branch, branches, PRs) only with git:write.

--- a/api/src/mcp/preview-tools.ts
+++ b/api/src/mcp/preview-tools.ts
@@ -70,13 +70,10 @@ async function previewBaseUnreachableError(
   }
 }
 
-// Shared cross-surface input, plus headless-only viewport extras. `rebuild`
-// from the base schema is accepted but moot here: a headless render is always
-// a fresh build.
-const renderAppSchema = runAppBaseSchema.extend({
-  width: z.number().int().min(320).max(1920).optional(),
-  height: z.number().int().min(320).max(1920).optional(),
-});
+// Shared cross-surface input (width/height render the draft at that viewport
+// — e.g. 390x844 for the mobile layout). `rebuild` from the base schema is
+// accepted but moot here: a headless render is always a fresh build.
+const renderAppSchema = runAppBaseSchema;
 
 type RenderAppInput = z.infer<typeof renderAppSchema>;
 

--- a/app/src/agent-runtime/client-tool-manifest.ts
+++ b/app/src/agent-runtime/client-tool-manifest.ts
@@ -673,6 +673,23 @@ export const AGENT_TOOL_MANIFEST = {
     },
     icon: "database",
   },
+  app_set_preview_viewport: {
+    domain: "app",
+    execution: "client",
+    clientExecutor: "app",
+    getLabel: input => {
+      const { preset, width, height } = (input ?? {}) as {
+        preset?: string;
+        width?: number;
+        height?: number;
+      };
+      if (width && height) return `Preview viewport ${width}×${height}`;
+      return preset && preset !== "desktop"
+        ? `Preview viewport: ${preset}`
+        : "Preview viewport: desktop";
+    },
+    icon: "eye",
+  },
   // dbt reads execute SERVER-SIDE (issue #475) — reading the authoritative
   // DbtProject/DbtFile docs avoids a pending client tool tearing down the SSE
   // turn ("stream disconnected before tool completed") when the tab is slow or

--- a/app/src/app-runtime/agent-tools.run-app.test.ts
+++ b/app/src/app-runtime/agent-tools.run-app.test.ts
@@ -158,4 +158,73 @@ describe("run_app client executor", () => {
     expect(result).toMatchObject({ success: false, status: "timeout" });
     expect(String(result.error)).toMatch(/open_app/);
   }, 10_000);
+
+  it("applies width/height as an ephemeral viewport and restores the user's", async () => {
+    useAppStore.getState().setPreviewViewport(APP_ID, {
+      width: 768,
+      height: 1024,
+      preset: "tablet",
+    });
+    let viewportDuringCapture: unknown;
+    captureAppPreview.mockImplementation(async () => {
+      viewportDuringCapture = useAppStore.getState().previewViewport[APP_ID];
+      return PNG_DATA_URL;
+    });
+    reportPreview(200, []);
+    const result = await executeAppAgentTool("run_app", {
+      appId: APP_ID,
+      width: 390,
+      height: 844,
+    });
+    expect(result).toMatchObject({
+      success: true,
+      viewport: { width: 390, height: 844 },
+    });
+    // Captured at the requested size, then put back to what the user had.
+    expect(viewportDuringCapture).toEqual({ width: 390, height: 844 });
+    expect(useAppStore.getState().previewViewport[APP_ID]).toEqual({
+      width: 768,
+      height: 1024,
+      preset: "tablet",
+    });
+  });
+});
+
+describe("app_set_preview_viewport client executor", () => {
+  it("sets a named preset as sticky view state", async () => {
+    const result = await executeAppAgentTool("app_set_preview_viewport", {
+      appId: APP_ID,
+      preset: "phone",
+    });
+    expect(result).toMatchObject({
+      success: true,
+      viewport: { width: 390, height: 844, preset: "phone" },
+    });
+    expect(useAppStore.getState().previewViewport[APP_ID]).toEqual({
+      width: 390,
+      height: 844,
+      preset: "phone",
+    });
+  });
+
+  it("desktop preset clears the override", async () => {
+    useAppStore
+      .getState()
+      .setPreviewViewport(APP_ID, { width: 390, height: 844, preset: "phone" });
+    const result = await executeAppAgentTool("app_set_preview_viewport", {
+      appId: APP_ID,
+      preset: "desktop",
+    });
+    expect(result).toMatchObject({ success: true, viewport: null });
+    expect(useAppStore.getState().previewViewport[APP_ID]).toBeNull();
+  });
+
+  it("rejects a custom size missing one dimension", async () => {
+    const result = await executeAppAgentTool("app_set_preview_viewport", {
+      appId: APP_ID,
+      width: 390,
+    });
+    expect(result).toMatchObject({ success: false });
+    expect(String(result.error)).toMatch(/both width and height/);
+  });
 });

--- a/app/src/app-runtime/agent-tools.ts
+++ b/app/src/app-runtime/agent-tools.ts
@@ -8,6 +8,7 @@
  */
 
 import {
+  APP_PREVIEW_VIEWPORT_PRESETS,
   APP_READ_FILE_MAX_CHARS,
   appBindingResourceVersion,
   appResourceRef,
@@ -24,7 +25,11 @@ import {
 } from "@mako/agent-tools";
 import { enqueueScreenshotVisionAttachment } from "../agent-runtime/screenshot-agent-tools";
 import { useConsoleStore } from "../store/consoleStore";
-import { useAppStore, type AppEntity } from "../store/appStore";
+import {
+  useAppStore,
+  type AppEntity,
+  type AppPreviewViewport,
+} from "../store/appStore";
 import { captureAppPreview, findAppPreviewIframe } from "./preview-capture";
 import { focusAppTab, getCurrentWorkspaceId } from "./shell";
 
@@ -508,86 +513,155 @@ export async function executeAppAgentTool(
     case "run_app": {
       if (!appId) return fail("appId is required");
       await ensureApp(appId);
-      // rebuild: false = read the current preview state — no bumpPreview,
-      // which flashes a black "Building preview…" screen and can remount Chat.
-      if (input.rebuild !== false) {
-        store.bumpPreview(appId);
+      // Ephemeral viewport: verify the responsive layout at an exact size
+      // (e.g. 390x844 for mobile) without stickily changing what the user
+      // sees — the previous viewport is restored after the capture. Media
+      // queries respond to the iframe's own size, so a resize IS the
+      // responsive check; no rebuild is needed for it.
+      const requestedWidth =
+        typeof input.width === "number" ? input.width : undefined;
+      const requestedHeight =
+        typeof input.height === "number" ? input.height : undefined;
+      const ephemeralViewport: AppPreviewViewport | null =
+        requestedWidth !== undefined || requestedHeight !== undefined
+          ? { width: requestedWidth ?? 1280, height: requestedHeight ?? 800 }
+          : null;
+      const previousViewport = ephemeralViewport
+        ? (useAppStore.getState().previewViewport[appId] ?? null)
+        : null;
+      if (ephemeralViewport) {
+        store.setPreviewViewport(appId, ephemeralViewport);
       }
-      const timeoutMs = clampRunAppTimeoutMs(
-        typeof input.timeoutMs === "number" ? input.timeoutMs : undefined,
-      );
-      const settled = await waitForPreviewSettle(
-        appId,
-        timeoutMs,
-        options?.signal,
-      );
-      const errors = summarizePreviewErrors(
-        useAppStore.getState().previewErrors[appId],
-      );
-      const result: RunAppResult = {
-        success: settled.status === "ready",
-        status: settled.status,
-        errors,
-        consoleLogs: [],
-        source: "iframe",
-        ...(settled.noIframe
-          ? {
-              error:
-                "No visible preview iframe for this app — open it with " +
-                "open_app so the preview can build and report.",
-            }
-          : {}),
-      };
+      try {
+        // rebuild: false = read the current preview state — no bumpPreview,
+        // which flashes a black "Building preview…" screen and can remount
+        // Chat. With only a viewport change, give the app a beat to re-lay
+        // out before capturing.
+        if (input.rebuild !== false) {
+          store.bumpPreview(appId);
+        } else if (ephemeralViewport) {
+          await new Promise(resolve => setTimeout(resolve, 350));
+        }
+        const timeoutMs = clampRunAppTimeoutMs(
+          typeof input.timeoutMs === "number" ? input.timeoutMs : undefined,
+        );
+        const settled = await waitForPreviewSettle(
+          appId,
+          timeoutMs,
+          options?.signal,
+        );
+        const errors = summarizePreviewErrors(
+          useAppStore.getState().previewErrors[appId],
+        );
+        const result: RunAppResult = {
+          success: settled.status === "ready",
+          status: settled.status,
+          errors,
+          consoleLogs: [],
+          source: "iframe",
+          ...(settled.noIframe
+            ? {
+                error:
+                  "No visible preview iframe for this app — open it with " +
+                  "open_app so the preview can build and report.",
+              }
+            : {}),
+        };
 
-      const delivery = options?.screenshotDelivery ?? "vision-attachment";
-      const wantScreenshot = input.includeScreenshot !== false;
-      let screenshotPassedToModel = false;
-      if (wantScreenshot && delivery === "none") {
-        result.screenshotUnavailableReason =
-          "This client cannot deliver screenshots (update Mako Desktop / " +
-          "Local Agent). Status and errors above are still authoritative.";
-      } else if (wantScreenshot) {
-        try {
-          const dataUrl = await captureAppPreview(appId);
-          const parts = dataUrlToParts(dataUrl);
-          if (!parts) {
-            throw new Error("Preview returned an unreadable capture");
-          }
-          if (delivery === "inline") {
-            result.screenshot = {
-              mimeType: parts.mimeType,
-              base64: parts.base64,
-            };
-          } else {
-            const enqueued = enqueueScreenshotVisionAttachment({
-              renderer: "app-preview-self-capture",
-              filename: `run-app-${appId}-${Date.now()}.png`,
-              mediaType: "image/png",
-              dataUrl,
-              outputBytes: Math.ceil((parts.base64.length * 3) / 4),
-              targetLabel: "app-preview",
-            });
-            if (enqueued) {
-              screenshotPassedToModel = true;
-            } else {
-              result.screenshotUnavailableReason =
-                "Screenshot was too large to pass to the model.";
-            }
-          }
-        } catch (error) {
+        const delivery = options?.screenshotDelivery ?? "vision-attachment";
+        const wantScreenshot = input.includeScreenshot !== false;
+        let screenshotPassedToModel = false;
+        if (wantScreenshot && delivery === "none") {
           result.screenshotUnavailableReason =
-            error instanceof Error ? error.message : "Preview capture failed";
+            "This client cannot deliver screenshots (update Mako Desktop / " +
+            "Local Agent). Status and errors above are still authoritative.";
+        } else if (wantScreenshot) {
+          try {
+            const dataUrl = await captureAppPreview(appId);
+            const parts = dataUrlToParts(dataUrl);
+            if (!parts) {
+              throw new Error("Preview returned an unreadable capture");
+            }
+            if (delivery === "inline") {
+              result.screenshot = {
+                mimeType: parts.mimeType,
+                base64: parts.base64,
+              };
+            } else {
+              const enqueued = enqueueScreenshotVisionAttachment({
+                renderer: "app-preview-self-capture",
+                filename: `run-app-${appId}-${Date.now()}.png`,
+                mediaType: "image/png",
+                dataUrl,
+                outputBytes: Math.ceil((parts.base64.length * 3) / 4),
+                targetLabel: "app-preview",
+              });
+              if (enqueued) {
+                screenshotPassedToModel = true;
+              } else {
+                result.screenshotUnavailableReason =
+                  "Screenshot was too large to pass to the model.";
+              }
+            }
+          } catch (error) {
+            result.screenshotUnavailableReason =
+              error instanceof Error ? error.message : "Preview capture failed";
+          }
+        }
+
+        return {
+          ...result,
+          ...(ephemeralViewport
+            ? {
+                viewport: {
+                  width: ephemeralViewport.width,
+                  height: ephemeralViewport.height,
+                },
+              }
+            : {}),
+          ...(screenshotPassedToModel
+            ? {
+                screenshotPassedToModel: true,
+                note: "The preview screenshot is sent as a real image input in the next model request, not inside this tool result.",
+              }
+            : {}),
+        };
+      } finally {
+        // The verify viewport is ephemeral — put back whatever the user had.
+        if (ephemeralViewport) {
+          store.setPreviewViewport(appId, previousViewport);
         }
       }
+    }
 
+    case "app_set_preview_viewport": {
+      if (!appId) return fail("appId is required");
+      await ensureApp(appId);
+      const width = typeof input.width === "number" ? input.width : undefined;
+      const height =
+        typeof input.height === "number" ? input.height : undefined;
+      const preset = input.preset as "phone" | "tablet" | "desktop" | undefined;
+      let viewport: AppPreviewViewport | null;
+      if (width !== undefined && height !== undefined) {
+        viewport = { width, height };
+      } else if (width !== undefined || height !== undefined) {
+        return fail("Pass both width and height for a custom viewport.");
+      } else if (preset === "phone" || preset === "tablet") {
+        viewport = { ...APP_PREVIEW_VIEWPORT_PRESETS[preset], preset };
+      } else if (preset === "desktop") {
+        viewport = null;
+      } else {
+        return fail(
+          "Pass preset ('phone' | 'tablet' | 'desktop') or width + height.",
+        );
+      }
+      store.setPreviewViewport(appId, viewport);
       return {
-        ...result,
-        ...(screenshotPassedToModel
-          ? {
-              screenshotPassedToModel: true,
-              note: "The preview screenshot is sent as a real image input in the next model request, not inside this tool result.",
-            }
-          : {}),
+        success: true,
+        viewport,
+        hint: viewport
+          ? `Preview now renders at ${viewport.width}×${viewport.height} for you AND the user — no rebuild needed. Verify with run_app; reset with preset: "desktop".`
+          : "Preview viewport reset — the app fills the pane again.",
       };
     }
 

--- a/app/src/components/AppRenderer.tsx
+++ b/app/src/components/AppRenderer.tsx
@@ -23,8 +23,12 @@ import {
   CheckCircle2 as PublishedIcon,
   MoreVertical as MoreIcon,
   Info as InfoIcon,
+  Monitor as DesktopViewportIcon,
+  Smartphone as PhoneViewportIcon,
+  Tablet as TabletViewportIcon,
 } from "lucide-react";
 import { containsDbtSchemaToken } from "@mako/schemas";
+import { APP_PREVIEW_VIEWPORT_PRESETS } from "@mako/agent-tools";
 import { useWorkspace } from "../contexts/workspace-context";
 import { useAuth } from "../contexts/auth-context";
 import EntityLoadErrorState, {
@@ -138,6 +142,46 @@ export default function AppRenderer({
   const dbtOverrideActive = Boolean(
     effectiveDbtEnv && prodEnvName && effectiveDbtEnv !== prodEnvName,
   );
+
+  // Preview viewport override (per-user view state): the iframe is laid out
+  // at exactly this CSS size so media queries render the true responsive
+  // layout; the pane scales it down visually when it doesn't fit.
+  const previewViewport = useAppStore(s => s.previewViewport[appId] ?? null);
+  const setPreviewViewport = useAppStore(s => s.setPreviewViewport);
+  const paneRef = useRef<HTMLDivElement | null>(null);
+  const [paneSize, setPaneSize] = useState<{ w: number; h: number } | null>(
+    null,
+  );
+  useEffect(() => {
+    if (!previewViewport) return;
+    const pane = paneRef.current;
+    if (!pane) return;
+    const update = () =>
+      setPaneSize({ w: pane.clientWidth, h: pane.clientHeight });
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(pane);
+    return () => observer.disconnect();
+  }, [previewViewport]);
+  // Fit the true-size viewport into the pane (never upscale). The 16px inset
+  // keeps the device frame's shadow off the pane edges.
+  const viewportScale =
+    previewViewport && paneSize
+      ? Math.min(
+          1,
+          (paneSize.w - 16) / previewViewport.width,
+          (paneSize.h - 16) / previewViewport.height,
+        )
+      : 1;
+  const cyclePreviewViewport = useCallback(() => {
+    const next =
+      previewViewport == null
+        ? { ...APP_PREVIEW_VIEWPORT_PRESETS.phone, preset: "phone" }
+        : previewViewport.preset === "phone"
+          ? { ...APP_PREVIEW_VIEWPORT_PRESETS.tablet, preset: "tablet" }
+          : null;
+    setPreviewViewport(appId, next);
+  }, [appId, previewViewport, setPreviewViewport]);
 
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
 
@@ -755,6 +799,29 @@ export default function AppRenderer({
           </Tooltip>
         )}
         <Box sx={{ flex: 1 }} />
+        <Tooltip
+          title={
+            previewViewport == null
+              ? "Preview viewport: desktop (fill) — click for phone"
+              : previewViewport.preset === "phone"
+                ? `Preview viewport: phone ${previewViewport.width}×${previewViewport.height} — click for tablet`
+                : `Preview viewport: ${previewViewport.preset === "tablet" ? "tablet" : "custom"} ${previewViewport.width}×${previewViewport.height} — click for desktop`
+          }
+        >
+          <IconButton
+            size="small"
+            onClick={cyclePreviewViewport}
+            sx={previewViewport ? { color: "info.main" } : undefined}
+          >
+            {previewViewport == null ? (
+              <DesktopViewportIcon size={18} strokeWidth={1.5} />
+            ) : previewViewport.preset === "phone" ? (
+              <PhoneViewportIcon size={18} strokeWidth={1.5} />
+            ) : (
+              <TabletViewportIcon size={18} strokeWidth={1.5} />
+            )}
+          </IconButton>
+        </Tooltip>
         {canManage &&
           (appEntity.hasUnpublishedChanges ? (
             <Button
@@ -926,27 +993,62 @@ export default function AppRenderer({
         </Alert>
       )}
 
-      {/* Full-screen preview */}
+      {/* Full-screen preview. With a viewport override the iframe keeps its
+          TRUE CSS size (so media queries render the real responsive layout)
+          and is only scaled visually to fit the pane. */}
       <Box
+        ref={paneRef}
         sx={{
           flex: 1,
           minHeight: 0,
-          bgcolor: "background.default",
+          bgcolor: previewViewport ? "action.hover" : "background.default",
           position: "relative",
+          ...(previewViewport && {
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            overflow: "hidden",
+          }),
         }}
       >
-        <iframe
-          // Keyed on the nonce so preview reboots after restore/publish: with
-          // unchanged code the regenerated srcDoc string is identical, so a
-          // srcdoc-prop update alone would be skipped by React entirely.
-          key={previewNonce}
-          ref={iframeRef}
-          title={`app-preview-${appId}`}
-          data-mako-app-preview={appId}
-          srcDoc={srcDoc}
-          sandbox="allow-scripts allow-downloads allow-popups allow-popups-to-escape-sandbox"
-          style={{ width: "100%", height: "100%", border: "none" }}
-        />
+        <Box
+          sx={
+            previewViewport
+              ? {
+                  width: previewViewport.width * viewportScale,
+                  height: previewViewport.height * viewportScale,
+                  borderRadius: 2,
+                  boxShadow: 6,
+                  overflow: "hidden",
+                  flexShrink: 0,
+                  bgcolor: "background.default",
+                }
+              : { width: "100%", height: "100%" }
+          }
+        >
+          <iframe
+            // Keyed on the nonce so preview reboots after restore/publish: with
+            // unchanged code the regenerated srcDoc string is identical, so a
+            // srcdoc-prop update alone would be skipped by React entirely.
+            key={previewNonce}
+            ref={iframeRef}
+            title={`app-preview-${appId}`}
+            data-mako-app-preview={appId}
+            srcDoc={srcDoc}
+            sandbox="allow-scripts allow-downloads allow-popups allow-popups-to-escape-sandbox"
+            style={
+              previewViewport
+                ? {
+                    width: previewViewport.width,
+                    height: previewViewport.height,
+                    border: "none",
+                    transform: `scale(${viewportScale})`,
+                    transformOrigin: "top left",
+                  }
+                : { width: "100%", height: "100%", border: "none" }
+            }
+          />
+        </Box>
         {booting && errors.length === 0 && (
           <Box
             sx={{

--- a/app/src/lib/desktop-acp-bridge.ts
+++ b/app/src/lib/desktop-acp-bridge.ts
@@ -101,6 +101,8 @@ async function executeImmediateJob(job: BridgeJob): Promise<unknown> {
         rebuild: job.arguments.rebuild,
         includeScreenshot: job.arguments.includeScreenshot,
         timeoutMs: job.arguments.timeoutMs,
+        width: job.arguments.width,
+        height: job.arguments.height,
       },
       {
         screenshotDelivery:

--- a/app/src/store/appStore.ts
+++ b/app/src/store/appStore.ts
@@ -114,6 +114,44 @@ function readStoredPreviewDbtEnv(appId: string): string | null {
   }
 }
 
+/**
+ * Per-user, per-app viewport override for the DRAFT PREVIEW (view state,
+ * mirrors previewDbtEnv). The iframe is laid out at exactly this size so
+ * media queries render the true mobile/tablet layout; null = fill the pane.
+ */
+export interface AppPreviewViewport {
+  width: number;
+  height: number;
+  /** Named preset ("phone" / "tablet") or undefined for a custom size. */
+  preset?: string;
+}
+
+const previewViewportStorageKey = (appId: string) =>
+  `mako:appPreviewViewport:${appId}`;
+
+function readStoredPreviewViewport(appId: string): AppPreviewViewport | null {
+  try {
+    const raw = localStorage.getItem(previewViewportStorageKey(appId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<AppPreviewViewport>;
+    if (
+      typeof parsed.width === "number" &&
+      typeof parsed.height === "number" &&
+      parsed.width > 0 &&
+      parsed.height > 0
+    ) {
+      return {
+        width: parsed.width,
+        height: parsed.height,
+        ...(typeof parsed.preset === "string" ? { preset: parsed.preset } : {}),
+      };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 interface AppState {
   myApps: Record<string, AppListItem[]>;
   workspaceApps: Record<string, AppListItem[]>;
@@ -154,6 +192,14 @@ interface AppState {
   previewDbtEnv: Record<string, string | null>;
   /** Cached dbt project environments for binding resolution (by projectId). */
   dbtEnvInfo: Record<string, AppDbtEnvInfo>;
+
+  /**
+   * Per-user, per-app preview viewport override (view state, persisted in
+   * localStorage). null/undefined = fill the pane (desktop). AppRenderer
+   * lays the iframe out at exactly this size (scaled to fit visually), so
+   * media queries render the true responsive layout.
+   */
+  previewViewport: Record<string, AppPreviewViewport | null>;
 }
 
 interface AppActions {
@@ -237,6 +283,15 @@ interface AppActions {
    * data hooks re-run against the new schema.
    */
   setPreviewDbtEnvironment: (appId: string, environment: string | null) => void;
+
+  /**
+   * Switch the app preview's viewport (per-user view state; null = fill the
+   * pane). No rebuild — the iframe resizes and the app re-lays out live.
+   */
+  setPreviewViewport: (
+    appId: string,
+    viewport: AppPreviewViewport | null,
+  ) => void;
 
   /** Fetch (and cache) a dbt project's environments for binding resolution. */
   fetchDbtEnvInfo: (
@@ -332,6 +387,7 @@ const initialState: AppState = {
   dataRefreshNonce: {},
   previewErrors: {},
   previewStatus: {},
+  previewViewport: {},
   previewDbtEnv: {},
   dbtEnvInfo: {},
 };
@@ -436,6 +492,9 @@ export const useAppStore = create<AppStore>()(
           if (state.previewDbtEnv[appId] === undefined) {
             state.previewDbtEnv[appId] = readStoredPreviewDbtEnv(appId);
           }
+          if (state.previewViewport[appId] === undefined) {
+            state.previewViewport[appId] = readStoredPreviewViewport(appId);
+          }
         });
         return res.app;
       } catch (e) {
@@ -482,6 +541,7 @@ export const useAppStore = create<AppStore>()(
           delete state.dataRefreshNonce[appId];
           delete state.previewErrors[appId];
           delete state.previewStatus[appId];
+          delete state.previewViewport[appId];
         });
         void get().fetchList(workspaceId);
         return true;
@@ -802,6 +862,26 @@ export const useAppStore = create<AppStore>()(
       // No preview bump here: AppRenderer watches this state and posts a
       // data-refresh into the booted iframe, so data hooks re-run against the
       // new schema without a (slow) srcdoc rebuild or losing app UI state.
+    },
+
+    setPreviewViewport: (appId, viewport) => {
+      set(state => {
+        state.previewViewport[appId] = viewport;
+      });
+      try {
+        if (viewport) {
+          localStorage.setItem(
+            previewViewportStorageKey(appId),
+            JSON.stringify(viewport),
+          );
+        } else {
+          localStorage.removeItem(previewViewportStorageKey(appId));
+        }
+      } catch {
+        /* view state only — losing persistence is harmless */
+      }
+      // No preview bump: resizing the iframe re-lays the app out live and
+      // media queries re-evaluate — a rebuild would only add a flash.
     },
 
     fetchDbtEnvInfo: async (workspaceId, dbtProjectId) => {

--- a/packages/agent-tools/src/app-tools.ts
+++ b/packages/agent-tools/src/app-tools.ts
@@ -14,7 +14,11 @@
 import { tool } from "ai";
 import { z } from "zod";
 
-import { runAppBaseSchema } from "./run-app";
+import {
+  runAppBaseSchema,
+  RUN_APP_MIN_VIEWPORT_PX,
+  RUN_APP_MAX_VIEWPORT_PX,
+} from "./run-app";
 
 const appIdField = z.string().describe("App ID (from list_open_apps)");
 
@@ -815,6 +819,40 @@ export const clientAppTools = {
           "dbt environment name from the linked project (e.g. 'dev' or a " +
             "personal environment), or null to reset to the prod default",
         ),
+    }),
+  }),
+  app_set_preview_viewport: tool({
+    description:
+      "Switch the app's DRAFT PREVIEW to a device viewport (phone 390x844, " +
+      "tablet 768x1024, or custom width/height) so you AND the user see the " +
+      "responsive layout while iterating — media queries re-evaluate at the " +
+      "new size, no rebuild. This is per-user VIEW state; it never changes " +
+      "the app definition or what viewers see. Pass preset: 'desktop' to go " +
+      "back to filling the pane. For a one-off verification without changing " +
+      "what's on screen, pass width/height to run_app instead.",
+    inputSchema: z.object({
+      appId: appIdField,
+      preset: z
+        .enum(["phone", "tablet", "desktop"])
+        .optional()
+        .describe(
+          "Named viewport: phone 390x844, tablet 768x1024, desktop = clear " +
+            "the override (fill the pane). Ignored when width/height are set.",
+        ),
+      width: z
+        .number()
+        .int()
+        .min(RUN_APP_MIN_VIEWPORT_PX)
+        .max(RUN_APP_MAX_VIEWPORT_PX)
+        .optional()
+        .describe("Custom viewport width in px (with height)"),
+      height: z
+        .number()
+        .int()
+        .min(RUN_APP_MIN_VIEWPORT_PX)
+        .max(RUN_APP_MAX_VIEWPORT_PX)
+        .optional()
+        .describe("Custom viewport height in px (with width)"),
     }),
   }),
 };

--- a/packages/agent-tools/src/capabilities/app-capabilities.ts
+++ b/packages/agent-tools/src/capabilities/app-capabilities.ts
@@ -229,4 +229,18 @@ export const APP_CAPABILITIES = [
       note: "Per-user browser preview state; headless agents use run_app / bindings directly.",
     },
   }),
+  define({
+    // Pure view state (which viewport the browser preview renders at) — the
+    // sticky sibling of run_app's ephemeral width/height. Mutates nothing
+    // durable, so read-risk; headless agents pass width/height to run_app.
+    name: "app_set_preview_viewport",
+    pack: "app-ui",
+    risk: "read",
+    surfaces: IN_CHAT_ONLY_SURFACES,
+    resultKind: "ui-effect",
+    mcpExclusion: {
+      why: "client-only",
+      note: "Per-user browser preview viewport; headless agents pass width/height to run_app.",
+    },
+  }),
 ] as const satisfies readonly AppCapabilityDefinition[];

--- a/packages/agent-tools/src/index.ts
+++ b/packages/agent-tools/src/index.ts
@@ -156,8 +156,12 @@ export {
   RUN_APP_DEFAULT_TIMEOUT_MS,
   RUN_APP_MIN_TIMEOUT_MS,
   RUN_APP_MAX_TIMEOUT_MS,
+  RUN_APP_MIN_VIEWPORT_PX,
+  RUN_APP_MAX_VIEWPORT_PX,
+  APP_PREVIEW_VIEWPORT_PRESETS,
 } from "./run-app";
 export type {
+  AppPreviewViewportPreset,
   RunAppBaseInput,
   RunAppResult,
   RunAppScreenshot,

--- a/packages/agent-tools/src/run-app.test.ts
+++ b/packages/agent-tools/src/run-app.test.ts
@@ -4,8 +4,10 @@ import assert from "node:assert/strict";
 import {
   clampRunAppTimeoutMs,
   isRunAppResult,
+  runAppBaseSchema,
   runAppResultToMcpContent,
   summarizeRunAppResult,
+  APP_PREVIEW_VIEWPORT_PRESETS,
   RUN_APP_DEFAULT_TIMEOUT_MS,
   RUN_APP_MAX_TIMEOUT_MS,
   RUN_APP_MIN_TIMEOUT_MS,
@@ -62,6 +64,21 @@ describe("run-app shared contract", () => {
       (content[0] as { text: string }).text,
       /renderer disabled/,
     );
+  });
+
+  it("accepts viewport width/height on every surface, within render bounds", () => {
+    const phone = runAppBaseSchema.safeParse({
+      appId: "a",
+      ...APP_PREVIEW_VIEWPORT_PRESETS.phone,
+    });
+    assert.equal(phone.success, true);
+    // Presets must themselves be valid run_app viewports.
+    assert.deepEqual(APP_PREVIEW_VIEWPORT_PRESETS.phone, {
+      width: 390,
+      height: 844,
+    });
+    const tooSmall = runAppBaseSchema.safeParse({ appId: "a", width: 100 });
+    assert.equal(tooSmall.success, false);
   });
 
   it("guards envelopes crossing loose boundaries", () => {

--- a/packages/agent-tools/src/run-app.ts
+++ b/packages/agent-tools/src/run-app.ts
@@ -24,6 +24,36 @@ export function clampRunAppTimeoutMs(timeoutMs: number | undefined): number {
   );
 }
 
+/** Render viewport bounds shared by every adapter (headless + live iframe). */
+export const RUN_APP_MIN_VIEWPORT_PX = 320;
+export const RUN_APP_MAX_VIEWPORT_PX = 1920;
+
+/**
+ * Named viewports for verifying responsive layouts. One list feeds the
+ * preview toolbar toggle, the app_set_preview_viewport tool, and skill
+ * guidance — media queries respond to the (iframe or headless) viewport, so
+ * rendering at these sizes IS the mobile/tablet layout check.
+ */
+export const APP_PREVIEW_VIEWPORT_PRESETS = {
+  phone: { width: 390, height: 844 },
+  tablet: { width: 768, height: 1024 },
+} as const;
+
+export type AppPreviewViewportPreset = keyof typeof APP_PREVIEW_VIEWPORT_PRESETS;
+
+const viewportPxField = (axis: "width" | "height") =>
+  z
+    .number()
+    .int()
+    .min(RUN_APP_MIN_VIEWPORT_PX)
+    .max(RUN_APP_MAX_VIEWPORT_PX)
+    .optional()
+    .describe(
+      `Viewport ${axis} in px. Pass e.g. 390x844 to verify the MOBILE ` +
+        "layout (media queries respond to this size). Omit for the default " +
+        "desktop viewport.",
+    );
+
 export const runAppBaseSchema = z.object({
   appId: z.string().describe("App ID (from list_open_apps)"),
   rebuild: z
@@ -47,6 +77,8 @@ export const runAppBaseSchema = z.object({
     .max(RUN_APP_MAX_TIMEOUT_MS)
     .optional()
     .describe("How long to wait for the app to finish rendering (ms)"),
+  width: viewportPxField("width"),
+  height: viewportPxField("height"),
 });
 
 export type RunAppBaseInput = z.infer<typeof runAppBaseSchema>;

--- a/packages/local-agent/src/acp/mako-system-append.ts
+++ b/packages/local-agent/src/acp/mako-system-append.ts
@@ -38,7 +38,7 @@ Use \`${prefix}create_notebook\` / \`${prefix}list_open_notebooks\`, then \`${pr
 ## Apps (Desktop preview — not headless)
 The user can see apps in the Mako window. After \`${prefix}create_app\` / \`${prefix}app_write_file\` / \`${prefix}app_edit_file\`, Desktop opens/refreshes the app tab automatically.
 - \`create_preview_token\` / \`render_app\` / \`/preview/…\` URLs are **unavailable and forbidden** in Desktop Chat — never call them or invent preview links.
-- After edits, verify with \`${desktopPrefix}run_app\`: it rebuilds the iframe, waits for it to render, and returns status, build/runtime errors, and a screenshot of exactly what the user sees. Pass \`rebuild: false\` to poll the current state without rebuilding, and \`includeScreenshot: false\` when you only need status/errors (much cheaper).
+- After edits, verify with \`${desktopPrefix}run_app\`: it rebuilds the iframe, waits for it to render, and returns status, build/runtime errors, and a screenshot of exactly what the user sees. Pass \`rebuild: false\` to poll the current state without rebuilding, and \`includeScreenshot: false\` when you only need status/errors (much cheaper). Pass \`width\`/\`height\` (e.g. 390x844) to verify the MOBILE layout — applied for that render only, the user's viewport is restored afterward.
 
 ## Workspace memory (Mako — not local Claude files)
 Durable knowledge for this workspace lives in Mako's self-directive:

--- a/packages/local-agent/src/desktop-bridge/mcp.test.ts
+++ b/packages/local-agent/src/desktop-bridge/mcp.test.ts
@@ -177,13 +177,19 @@ describe("desktop-bridge MCP", () => {
       jsonrpc: "2.0",
       id: 30,
       method: "tools/call",
-      params: { name: "run_app", arguments: { appId: "app-3" } },
+      params: {
+        name: "run_app",
+        arguments: { appId: "app-3", width: 390, height: 844 },
+      },
     });
     const job = await desktopBridgeRegistry.claim(5_000);
     assert.ok(job);
     // The renderer keys inline screenshot delivery off this marker — an
     // older Local Agent (no marker) must keep getting text-only results.
     assert.equal(job.capabilities?.imageContent, true);
+    // Viewport args flow through for the mobile-layout verify.
+    assert.equal(job.arguments.width, 390);
+    assert.equal(job.arguments.height, 844);
     desktopBridgeRegistry.complete(job.id, { success: true, errors: [] });
     await callPromise;
   });

--- a/packages/local-agent/src/desktop-bridge/mcp.ts
+++ b/packages/local-agent/src/desktop-bridge/mcp.ts
@@ -72,6 +72,15 @@ const TOOLS: Array<{
           description:
             "How long to wait for the preview to finish rendering, in ms (5000-45000, default 20000).",
         },
+        width: {
+          type: "number",
+          description:
+            "Viewport width in px (320-1920). Pass e.g. 390x844 to verify the MOBILE layout — applied for this render only, then the user's viewport is restored.",
+        },
+        height: {
+          type: "number",
+          description: "Viewport height in px (320-1920), with width.",
+        },
       },
       required: ["appId"],
     },


### PR DESCRIPTION
## Summary

Follow-up to #777. Media queries respond to the render viewport, so rendering at phone size **is** the mobile-layout check — this PR makes that check first-class for agents and humans on all three surfaces.

| Surface | Ephemeral verify | Sticky mobile view |
|---|---|---|
| External MCP | `run_app({ width: 390, height: 844 })` (already worked; now in the shared base schema) | n/a (headless) |
| In-chat agent | `run_app` width/height — applied for that render + capture, then the user's viewport is restored | new `app_set_preview_viewport` tool (`phone` / `tablet` / custom / `desktop`) |
| Desktop ACP | same, passed through the loopback bridge | toolbar toggle (shared with the user) |
| Human | — | device-cycle toggle on the preview toolbar (desktop → phone → tablet) |

## Changes

- **`@mako/agent-tools`**: `width`/`height` (320–1920) promoted into the shared `runAppBaseSchema` (the headless renderer already honored them — its `.extend()` is now just the base schema), plus `APP_PREVIEW_VIEWPORT_PRESETS` (phone 390×844, tablet 768×1024) shared by the toolbar, both tools, and skill guidance.
- **Preview rendering**: new per-user `previewViewport` view state in `appStore` (localStorage-persisted, exactly mirroring the `previewDbtEnv` pattern). `AppRenderer` lays the iframe out at the exact CSS size and only scales it visually to fit the pane (`transform: scale`, layout size untouched) — the true responsive layout renders with **no rebuild**, since resizing re-evaluates media queries live.
- **`run_app` ephemeral viewport**: the client executor applies the requested size before the rebuild/settle, captures, and restores the previous viewport in a `finally`. The desktop bridge passes `width`/`height` through.
- **`app_set_preview_viewport`**: the sticky sibling — flips the on-screen preview so agent and user look at the same mobile layout while iterating. Pure view state → `read`-risk capability, client-only (`IN_CHAT_ONLY_SURFACES`), auto-classified by the existing bridge-policy/tier machinery; manifest + mode-registry entries included.
- **Guidance**: "Mobile & responsive" section in the apps skill (verify at 390×844 + desktop before `app_save_version`, responsive design rules), plus one-line mobile hints in the MCP server instructions and ACP system append.

## Compatibility

All additive: older MCP clients, Local Agents, and stale app bundles ignore the new fields; no result-shape changes; no handshake needed.

## Tests

- New: ephemeral apply/restore (asserts the viewport during capture AND the user's viewport after), `app_set_preview_viewport` preset/clear/validation, schema bounds + preset validity, bridge width/height passthrough.
- Full suites green: app 413/413 (58 files), API suite (incl. MCP inventory + tier-policy tests), local-agent 72, agent-tools 24. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFAGxnhZm5WTg7UQu9mtDd

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFAGxnhZm5WTg7UQu9mtDd)_