### PR TITLE
fix(acp): reconnect Local ACP chat streaming after page refresh

### DIFF
--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -53,6 +53,7 @@ import {
   localAcpModelIdToProviderId,
 } from "../lib/local-acp-models";
 import { runLocalAcpChatTurn } from "../lib/local-acp-chat";
+import { resumeLocalAcpChatTurn } from "../lib/resume-local-acp-chat";
 import { clearLocalAcpChatBinding } from "../lib/persist-local-acp-chat";
 import {
   completeDesktopHitlJob,
@@ -309,6 +310,9 @@ const Chat: React.FC<ChatProps> = ({
   } | null>(null);
   /** Bumps on each ACP send so overlapping finally blocks don't clear busy early. */
   const localAcpGenerationRef = useRef(0);
+  /** In-flight refresh/wake reattach to a Local Agent turn (see resume below). */
+  const localAcpResumeAbortRef = useRef<AbortController | null>(null);
+  const requestLocalAcpResumeRef = useRef<(() => void) | undefined>();
   const [localAcpBusy, setLocalAcpBusy] = useState(false);
   const localAcpBusyRef = useRef(false);
   localAcpBusyRef.current = localAcpBusy;
@@ -684,6 +688,8 @@ const Chat: React.FC<ChatProps> = ({
     // Abort an in-flight local ACP (Claude Code / Codex) turn if any.
     localAcpAbortRef.current?.abort();
     localAcpAbortRef.current = null;
+    localAcpResumeAbortRef.current?.abort();
+    localAcpResumeAbortRef.current = null;
     setLocalAcpBusy(false);
     void useAcpStore
       .getState()
@@ -721,6 +727,10 @@ const Chat: React.FC<ChatProps> = ({
     if (!modelId || !isLocalAcpModelId(modelId)) return false;
 
     localAcpAbortRef.current?.abort();
+    // A refresh-reattach must yield to a fresh user send (it would otherwise
+    // race this turn's assistant bubble with replayed events).
+    localAcpResumeAbortRef.current?.abort();
+    localAcpResumeAbortRef.current = null;
     // Cancel the in-flight ACP prompt so the next turn can start cleanly.
     void useAcpStore
       .getState()
@@ -771,6 +781,84 @@ const Chat: React.FC<ChatProps> = ({
     }
     return true;
   };
+
+  // Refresh / History-reopen / tab-wake reattach for Local ACP: the Local
+  // Agent keeps running the turn (and buffering events for replay) while the
+  // page is gone, but nothing re-subscribed — the chat froze at the last
+  // checkpoint. Rebuild the in-flight turn from the replay backlog, stream
+  // the rest live, and persist the finished turn. Cheap no-op when idle.
+  requestLocalAcpResumeRef.current = () => {
+    const binding = localAcpBindingRef.current;
+    const workspaceId = workspaceIdRef.current;
+    const targetChatId = chatIdRef.current;
+    if (!binding || !workspaceId || !targetChatId) return;
+    // An in-page turn (or an already-attached resume) is streaming — leave it.
+    if (localAcpBusyRef.current) return;
+    localAcpResumeAbortRef.current?.abort();
+    const abort = new AbortController();
+    localAcpResumeAbortRef.current = abort;
+    let attached = false;
+    void resumeLocalAcpChatTurn({
+      binding,
+      workspaceId,
+      chatId: targetChatId,
+      setMessages,
+      getMessages: () => messagesRef.current,
+      signal: abort.signal,
+      onLiveAttach: () => {
+        if (abort.signal.aborted) return;
+        attached = true;
+        // Ref first: the state flush lags, and the wake handler must not
+        // start a second resume in that window.
+        localAcpBusyRef.current = true;
+        setLocalAcpBusy(true);
+        isLoadingRef.current = true;
+      },
+      onPersisted: b => {
+        if (b) localAcpBindingRef.current = b;
+        setIsExistingChat(true);
+        void fetchSessionsRef.current?.();
+      },
+    })
+      .catch(() => undefined)
+      .finally(() => {
+        if (localAcpResumeAbortRef.current === abort) {
+          localAcpResumeAbortRef.current = null;
+        }
+        // Clear busy only if no in-page send took over after aborting us.
+        if (attached && !localAcpAbortRef.current) {
+          localAcpBusyRef.current = false;
+          setLocalAcpBusy(false);
+          isLoadingRef.current = false;
+          queueMicrotask(() => drainQueuedPromptAfterTurnRef.current?.());
+        }
+      });
+  };
+
+  // Drop a stale reattach when the user switches chats (the loader kicks off
+  // a fresh one for the next chat if its binding warrants it) or unmounts.
+  useEffect(() => {
+    return () => {
+      localAcpResumeAbortRef.current?.abort();
+      localAcpResumeAbortRef.current = null;
+    };
+  }, [chatId]);
+
+  // Tab wake / network back: if the resume (or its SSE) died while the
+  // machine slept, reattach to a still-running local ACP turn. No-ops fast
+  // when there is no binding or a turn is already streaming in-page.
+  useEffect(() => {
+    const onWake = () => {
+      if (document.visibilityState !== "visible") return;
+      requestLocalAcpResumeRef.current?.();
+    };
+    document.addEventListener("visibilitychange", onWake);
+    window.addEventListener("online", onWake);
+    return () => {
+      document.removeEventListener("visibilitychange", onWake);
+      window.removeEventListener("online", onWake);
+    };
+  }, []);
 
   // Bottom-pin / streaming-follow machinery (see useChatScroll).
   const { isAtBottom, setIsAtBottom, scrollerElRef, handleListHeightChanged } =
@@ -851,6 +939,7 @@ const Chat: React.FC<ChatProps> = ({
     toolDispatchGateRef,
     loadPersistedMessagesRef,
     requestResumeRef,
+    requestLocalAcpResumeRef,
     localAcpBindingRef,
     localAcpBusyRef,
   });

--- a/app/src/components/chat/convert-stored-messages.ts
+++ b/app/src/components/chat/convert-stored-messages.ts
@@ -16,7 +16,8 @@ export interface ConvertedUiMessage {
   parts: Array<Record<string, unknown>>;
 }
 
-const INTERRUPTED_TEXT =
+/** Exported for the Local ACP resume path's incomplete-turn heuristic. */
+export const INTERRUPTED_TOOL_TEXT =
   "Interrupted — stream disconnected before tool completed";
 
 // Human-in-the-loop tools resolve via an interactive card, so a persisted
@@ -138,7 +139,7 @@ function convertStoredPart(
       state: "output-error",
       input: p.input ?? {},
       output: undefined,
-      errorText: INTERRUPTED_TEXT,
+      errorText: INTERRUPTED_TOOL_TEXT,
     };
   }
   // Unknown part type - pass through as-is

--- a/app/src/components/chat/hooks/useChatSessionLoader.ts
+++ b/app/src/components/chat/hooks/useChatSessionLoader.ts
@@ -141,6 +141,11 @@ export interface UseChatSessionLoaderArgs {
     ((opts?: { skipReload?: boolean }) => Promise<void>) | undefined
   >;
   /**
+   * Local ACP counterpart of requestResumeRef: reattaches to a Local Agent
+   * turn that kept running through a refresh (cheap no-op without a binding).
+   */
+  requestLocalAcpResumeRef?: MutableRefObject<(() => void) | undefined>;
+  /**
    * Bound Local Agent ACP session for this History chat (if any). Cleared by
    * Chat on new-session; set here when a persisted localAcp payload is loaded.
    */
@@ -172,6 +177,7 @@ export function useChatSessionLoader({
   toolDispatchGateRef,
   loadPersistedMessagesRef,
   requestResumeRef,
+  requestLocalAcpResumeRef,
   localAcpBindingRef,
   localAcpBusyRef,
 }: UseChatSessionLoaderArgs): void {
@@ -350,6 +356,10 @@ export function useChatSessionLoader({
       // (or unknown), making this a cheap no-op.
       if (!cancelled) {
         void requestResumeRef.current?.({ skipReload: true });
+        // Local ACP turns keep running on the Local Agent through a refresh;
+        // rebind + replay them after the persisted snapshot is in place
+        // (loadPersistedMessages set localAcpBindingRef just above).
+        requestLocalAcpResumeRef?.current?.();
       }
     };
     loadSession();
@@ -362,5 +372,6 @@ export function useChatSessionLoader({
     workspaceId,
     loadPersistedMessagesRef,
     requestResumeRef,
+    requestLocalAcpResumeRef,
   ]);
 }

--- a/app/src/lib/acp-client.ts
+++ b/app/src/lib/acp-client.ts
@@ -53,6 +53,20 @@ export const acpClient = {
     return unwrap(body, "Failed to list ACP sessions");
   },
 
+  /** Null when the session is unknown or the Local Agent is unreachable. */
+  async getSession(sessionId: string): Promise<AcpSessionInfo | null> {
+    try {
+      const body = await localAgentClient.get<Envelope<AcpSessionInfo>>(
+        `/acp/sessions/${encodeURIComponent(sessionId)}`,
+        undefined,
+        { timeoutMs: 5000 },
+      );
+      return body?.success && body.data ? body.data : null;
+    } catch {
+      return null;
+    }
+  },
+
   async authenticate(
     providerId: AcpProviderId,
     methodId?: string,

--- a/app/src/lib/resume-local-acp-chat.test.ts
+++ b/app/src/lib/resume-local-acp-chat.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from "vitest";
+import type { UIMessage } from "ai";
+import type { AcpBridgeEvent } from "./acp-types";
+import {
+  extractResumeTail,
+  finalizeResumedParts,
+  lastAssistantLooksIncomplete,
+  lastUserMessageText,
+  partsHaveContent,
+  rebuildAssistantParts,
+} from "./resume-local-acp-chat";
+import { INTERRUPTED_TOOL_TEXT } from "../components/chat/convert-stored-messages";
+
+const AT = "2026-08-01T10:00:00.000Z";
+
+function userChunk(text: string): AcpBridgeEvent {
+  return {
+    type: "session_update",
+    sessionId: "s1",
+    update: {
+      sessionUpdate: "user_message_chunk",
+      content: { type: "text", text },
+    },
+    at: AT,
+  };
+}
+
+function agentChunk(text: string, phase?: string): AcpBridgeEvent {
+  return {
+    type: "session_update",
+    sessionId: "s1",
+    update: {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text },
+      ...(phase ? { _meta: { codex: { phase } } } : {}),
+    },
+    at: AT,
+  };
+}
+
+function thoughtChunk(text: string): AcpBridgeEvent {
+  return {
+    type: "session_update",
+    sessionId: "s1",
+    update: {
+      sessionUpdate: "agent_thought_chunk",
+      content: { type: "text", text },
+    },
+    at: AT,
+  };
+}
+
+function toolCall(
+  toolCallId: string,
+  status: string,
+  extra?: Record<string, unknown>,
+): AcpBridgeEvent {
+  return {
+    type: "session_update",
+    sessionId: "s1",
+    update: {
+      sessionUpdate: status === "pending" ? "tool_call" : "tool_call_update",
+      toolCallId,
+      name: "sql_execute_query",
+      status,
+      ...extra,
+    },
+    at: AT,
+  };
+}
+
+function turnDone(): AcpBridgeEvent {
+  return { type: "turn_done", sessionId: "s1", stopReason: "end_turn", at: AT };
+}
+
+function msg(role: string, parts: Array<Record<string, unknown>>): UIMessage {
+  return { id: `${role}-${Math.random()}`, role, parts } as UIMessage;
+}
+
+describe("extractResumeTail", () => {
+  it("returns unmatched when the backlog has no user prompt", () => {
+    const tail = extractResumeTail([agentChunk("hi")], "hello");
+    expect(tail.matched).toBe(false);
+    expect(tail.events).toHaveLength(0);
+  });
+
+  it("slices to the newest turn and matches the layered prompt suffix", () => {
+    const events = [
+      userChunk("old question"),
+      agentChunk("old answer"),
+      turnDone(),
+      userChunk("[UI context]\nstuff\n\n[User message]\nnew question"),
+      thoughtChunk("thinking"),
+    ];
+    const tail = extractResumeTail(events, "new question");
+    expect(tail.matched).toBe(true);
+    expect(tail.done).toBe(false);
+    expect(tail.events).toHaveLength(1);
+  });
+
+  it("detects a finished turn via turn_done in the tail", () => {
+    const events = [userChunk("q"), agentChunk("a"), turnDone()];
+    const tail = extractResumeTail(events, "q");
+    expect(tail.matched).toBe(true);
+    expect(tail.done).toBe(true);
+  });
+
+  it("refuses another chat's turn (prompt does not end with our text)", () => {
+    const events = [userChunk("different chat prompt"), agentChunk("a")];
+    const tail = extractResumeTail(events, "our last user message");
+    expect(tail.matched).toBe(false);
+  });
+});
+
+describe("rebuildAssistantParts", () => {
+  it("rebuilds reasoning, text, and tool parts from replayed events", () => {
+    const parts = rebuildAssistantParts(
+      [
+        thoughtChunk("Let me check."),
+        toolCall("t1", "pending", { rawInput: { query: "select 1" } }),
+        toolCall("t1", "completed", { rawOutput: { rowCount: 1 } }),
+        agentChunk("Here are the results."),
+        turnDone(),
+        agentChunk("chunk after done must be ignored"),
+      ],
+      "claude",
+    );
+    expect(parts.map(p => p.type)).toEqual([
+      "reasoning",
+      "dynamic-tool",
+      "text",
+    ]);
+    const tool = parts[1] as { state?: string; toolCallId?: string };
+    expect(tool.toolCallId).toBe("t1");
+    expect(tool.state).toBe("output-available");
+    expect((parts[2] as { text?: string }).text).toBe("Here are the results.");
+  });
+
+  it("routes Codex commentary-phase message chunks into reasoning", () => {
+    const parts = rebuildAssistantParts(
+      [agentChunk("planning…", "commentary"), agentChunk("final answer")],
+      "codex",
+    );
+    expect(parts.map(p => p.type)).toEqual(["reasoning", "text"]);
+  });
+});
+
+describe("lastAssistantLooksIncomplete", () => {
+  it("is true when the newest message is an unanswered user turn", () => {
+    expect(
+      lastAssistantLooksIncomplete([
+        msg("user", [{ type: "text", text: "q" }]),
+      ]),
+    ).toBe(true);
+  });
+
+  it("is true for streaming reasoning / pending or poisoned tool parts", () => {
+    expect(
+      lastAssistantLooksIncomplete([
+        msg("assistant", [{ type: "reasoning", text: "", state: "streaming" }]),
+      ]),
+    ).toBe(true);
+    expect(
+      lastAssistantLooksIncomplete([
+        msg("assistant", [
+          { type: "dynamic-tool", toolCallId: "t", state: "output-streaming" },
+        ]),
+      ]),
+    ).toBe(true);
+    expect(
+      lastAssistantLooksIncomplete([
+        msg("assistant", [
+          {
+            type: "dynamic-tool",
+            toolCallId: "t",
+            state: "output-error",
+            errorText: INTERRUPTED_TOOL_TEXT,
+          },
+        ]),
+      ]),
+    ).toBe(true);
+  });
+
+  it("is false for a settled assistant reply", () => {
+    expect(
+      lastAssistantLooksIncomplete([
+        msg("assistant", [
+          { type: "reasoning", text: "thought", state: "done" },
+          { type: "text", text: "answer" },
+        ]),
+      ]),
+    ).toBe(false);
+  });
+});
+
+describe("finalizeResumedParts / partsHaveContent", () => {
+  it("drops empty reasoning placeholders and falls back when empty", () => {
+    const finalized = finalizeResumedParts([
+      { type: "reasoning", text: "", state: "streaming" },
+    ]);
+    expect(finalized).toEqual([
+      { type: "text", text: "(No response from local agent)" },
+    ]);
+  });
+
+  it("marks streaming reasoning done and keeps real content", () => {
+    const finalized = finalizeResumedParts([
+      { type: "reasoning", text: "thinking", state: "streaming" },
+      { type: "text", text: "answer" },
+    ]);
+    expect(finalized).toEqual([
+      { type: "reasoning", text: "thinking", state: "done" },
+      { type: "text", text: "answer" },
+    ]);
+    expect(partsHaveContent(finalized)).toBe(true);
+  });
+});
+
+describe("lastUserMessageText", () => {
+  it("reads the newest user message's text parts", () => {
+    expect(
+      lastUserMessageText([
+        msg("user", [{ type: "text", text: "first" }]),
+        msg("assistant", [{ type: "text", text: "reply" }]),
+        msg("user", [
+          { type: "file", url: "data:..." },
+          { type: "text", text: " second " },
+        ]),
+      ]),
+    ).toBe("second");
+  });
+});

--- a/app/src/lib/resume-local-acp-chat.test.ts
+++ b/app/src/lib/resume-local-acp-chat.test.ts
@@ -110,6 +110,16 @@ describe("extractResumeTail", () => {
     const tail = extractResumeTail(events, "our last user message");
     expect(tail.matched).toBe(false);
   });
+
+  it("requires the [User message] boundary — a short suffix is not enough", () => {
+    const events = [
+      userChunk("[User message]\nis the migration ok"),
+      agentChunk("a"),
+    ];
+    // "ok" is a suffix of the other chat's prompt but not its user message.
+    expect(extractResumeTail(events, "ok").matched).toBe(false);
+    expect(extractResumeTail(events, "is the migration ok").matched).toBe(true);
+  });
 });
 
 describe("rebuildAssistantParts", () => {

--- a/app/src/lib/resume-local-acp-chat.ts
+++ b/app/src/lib/resume-local-acp-chat.ts
@@ -1,0 +1,575 @@
+/**
+ * Reattach main Chat to its Local Agent ACP turn after a page refresh or
+ * History reopen. The Local Agent keeps running the turn (and recording its
+ * events for SSE replay) while the browser is gone — this rebuilds the
+ * in-flight assistant message from that replay backlog, streams the rest
+ * live until `turn_done`, and persists the finished turn. It also backfills
+ * a turn that finished while the page was closed (the tail was never
+ * persisted because ACP transcripts persist client-side).
+ */
+import type { UIMessage } from "ai";
+import { generateObjectId } from "../utils/objectId";
+import { acpClient } from "./acp-client";
+import { isAcpConnectionClosedError } from "./acp-connection-errors";
+import { sanitizeAcpUserError } from "./acp-user-errors";
+import type { AcpBridgeEvent, AcpProviderId } from "./acp-types";
+import { localAcpModelIdToProviderId } from "./local-acp-models";
+import {
+  appendAssistantReasoning,
+  appendAssistantText,
+  getAssistantParts,
+  isAcpCodexCommentaryPhase,
+  markStreamingReasoningDone,
+  setAssistantErrorText,
+  upsertAcpToolPart,
+  type AcpToolUpdate,
+} from "./local-acp-parts";
+import {
+  persistLocalAcpChat,
+  type LocalAcpChatBinding,
+} from "./persist-local-acp-chat";
+import { useAcpStore } from "../store/acpStore";
+import { INTERRUPTED_TOOL_TEXT } from "../components/chat/convert-stored-messages";
+
+type AssistantParts = ReturnType<typeof getAssistantParts>;
+
+type SessionUpdatePayload = AcpToolUpdate & {
+  content?: { type?: string; text?: string };
+};
+
+/** Old Local Agents may never send the `status: subscribed` backlog marker. */
+const BACKLOG_SETTLE_TIMEOUT_MS = 10_000;
+const MAX_ATTACH_ATTEMPTS = 3;
+
+export type AcpResumeOutcome = "resumed" | "backfilled" | "none" | "aborted";
+
+const TERMINAL_TOOL_STATES = new Set([
+  "output-available",
+  "output-error",
+  "output-denied",
+  "error",
+]);
+
+/** Raw text of the newest user message (what the last ACP prompt ended with). */
+export function lastUserMessageText(messages: UIMessage[]): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg?.role !== "user") continue;
+    return (msg.parts ?? [])
+      .filter(
+        p =>
+          p.type === "text" &&
+          typeof (p as { text?: unknown }).text === "string",
+      )
+      .map(p => String((p as { text: string }).text))
+      .join("\n")
+      .trim();
+  }
+  return "";
+}
+
+/**
+ * True when the persisted transcript looks cut off mid-turn: the newest
+ * message is a user turn with no reply, or an assistant checkpoint with
+ * streaming/pending/poisoned parts and no settled content. Used to decide
+ * whether a non-busy session still deserves a replay backfill.
+ */
+export function lastAssistantLooksIncomplete(messages: UIMessage[]): boolean {
+  const last = messages[messages.length - 1];
+  if (!last) return false;
+  if (last.role === "user") return true;
+  if (last.role !== "assistant") return false;
+  const parts = (last.parts ?? []) as Array<Record<string, unknown>>;
+  if (parts.length === 0) return true;
+  let hasContent = false;
+  for (const p of parts) {
+    const type = String(p.type ?? "");
+    if (type === "reasoning") {
+      if (p.state === "streaming") return true;
+      if (String(p.text ?? "").trim()) hasContent = true;
+      continue;
+    }
+    if (type === "text") {
+      if (String(p.text ?? "").trim()) hasContent = true;
+      continue;
+    }
+    if (type === "dynamic-tool" || type.startsWith("tool-")) {
+      const state = String(p.state ?? "");
+      if (!TERMINAL_TOOL_STATES.has(state)) return true;
+      // History loader poisons pending tools of a dead turn to this text —
+      // a refresh mid-turn lands here before the resume rebuild runs.
+      if (p.errorText === INTERRUPTED_TOOL_TEXT) return true;
+      hasContent = true;
+    }
+  }
+  return !hasContent;
+}
+
+export interface AcpResumeTail {
+  /** True when the backlog's newest prompt matches this chat's last user turn. */
+  matched: boolean;
+  /** Events after the newest user_message_chunk (the in-flight turn). */
+  events: AcpBridgeEvent[];
+  /** True when that turn already has a turn_done marker in the backlog. */
+  done: boolean;
+}
+
+function sessionUpdateOf(event: AcpBridgeEvent): SessionUpdatePayload | null {
+  if (event.type !== "session_update") return null;
+  const update = event.update as SessionUpdatePayload | null | undefined;
+  return update && typeof update === "object" ? update : null;
+}
+
+/**
+ * Slice the replay backlog down to the newest turn and verify it belongs to
+ * this chat. ACP process sessions can be reused across Mako chats, so the
+ * prompt recorded on the bridge (which ends with the raw `[User message]`
+ * text) must end with this chat's last user message — otherwise we would
+ * paint another chat's turn into this transcript.
+ */
+export function extractResumeTail(
+  events: AcpBridgeEvent[],
+  lastUserText: string,
+): AcpResumeTail {
+  let lastUserIdx = -1;
+  let lastUserChunkText = "";
+  for (const [i, event] of events.entries()) {
+    const update = sessionUpdateOf(event);
+    if (
+      update?.sessionUpdate === "user_message_chunk" &&
+      update.content?.type === "text" &&
+      typeof update.content.text === "string"
+    ) {
+      lastUserIdx = i;
+      lastUserChunkText = update.content.text.trim();
+    }
+  }
+  if (lastUserIdx === -1 || !lastUserText) {
+    return { matched: false, events: [], done: false };
+  }
+  const matched =
+    lastUserChunkText === lastUserText ||
+    lastUserChunkText.endsWith(lastUserText);
+  const tail = events.slice(lastUserIdx + 1);
+  return {
+    matched,
+    events: tail,
+    done: tail.some(e => e.type === "turn_done"),
+  };
+}
+
+function reduceSessionUpdate(
+  parts: AssistantParts,
+  update: SessionUpdatePayload,
+): AssistantParts {
+  if (
+    update.sessionUpdate === "agent_thought_chunk" &&
+    update.content?.type === "text" &&
+    typeof update.content.text === "string" &&
+    update.content.text
+  ) {
+    return appendAssistantReasoning(parts, update.content.text);
+  }
+  if (
+    update.sessionUpdate === "agent_message_chunk" &&
+    update.content?.type === "text" &&
+    typeof update.content.text === "string" &&
+    update.content.text
+  ) {
+    // Codex puts most "thinking" in commentary-phase message chunks.
+    return isAcpCodexCommentaryPhase(update)
+      ? appendAssistantReasoning(parts, update.content.text)
+      : appendAssistantText(parts, update.content.text);
+  }
+  if (
+    update.sessionUpdate === "tool_call" ||
+    update.sessionUpdate === "tool_call_update"
+  ) {
+    return upsertAcpToolPart(parts, update);
+  }
+  return parts;
+}
+
+/**
+ * Rebuild the assistant message for one turn from its replayed events.
+ * No UI focus side-effects here — replayed tool events must not yank tabs
+ * around on reload the way live ones do.
+ */
+export function rebuildAssistantParts(
+  tail: AcpBridgeEvent[],
+  providerId: AcpProviderId,
+): AssistantParts {
+  let parts: AssistantParts = [];
+  for (const event of tail) {
+    if (event.type === "turn_done") break;
+    if (event.type === "session_update") {
+      const update = sessionUpdateOf(event);
+      if (!update || update.sessionUpdate === "user_message_chunk") continue;
+      parts = reduceSessionUpdate(parts, update);
+    } else if (event.type === "error" || event.type === "session_invalidated") {
+      if (!isAcpConnectionClosedError(event.message)) {
+        const cleaned = sanitizeAcpUserError(event.message, { providerId });
+        if (cleaned) {
+          parts = setAssistantErrorText(parts, `Error: ${cleaned}`);
+        }
+      }
+    }
+  }
+  return parts;
+}
+
+export function partsHaveContent(parts: AssistantParts): boolean {
+  return parts.some(p => {
+    if (p.type === "dynamic-tool") return true;
+    if (p.type === "text" || p.type === "reasoning") {
+      return Boolean(String((p as { text?: string }).text ?? "").trim());
+    }
+    return false;
+  });
+}
+
+/** Same end-of-turn cleanup the live ACP transport applies. */
+export function finalizeResumedParts(parts: AssistantParts): AssistantParts {
+  let out = markStreamingReasoningDone(parts);
+  out = out.filter(
+    p =>
+      !(
+        p.type === "reasoning" &&
+        !String((p as { text?: string }).text ?? "").trim()
+      ),
+  );
+  if (!partsHaveContent(out)) {
+    return [{ type: "text", text: "(No response from local agent)" }];
+  }
+  return out;
+}
+
+export interface ResumeLocalAcpChatArgs {
+  binding: LocalAcpChatBinding;
+  workspaceId: string;
+  chatId: string;
+  setMessages: (
+    updater: UIMessage[] | ((prev: UIMessage[]) => UIMessage[]),
+  ) => void;
+  /** Live in-memory transcript (post history-load) — read at call time. */
+  getMessages: () => UIMessage[];
+  signal?: AbortSignal;
+  /** Fired once when we attach to a genuinely in-flight turn (show busy UI). */
+  onLiveAttach?: () => void;
+  /** Called after a successful persist so History can refresh / rebind. */
+  onPersisted?: (binding?: LocalAcpChatBinding) => void;
+}
+
+/**
+ * Check the bound ACP session and, when its newest turn belongs to this chat
+ * and is still running (or finished unpersisted), rebuild + stream + persist
+ * it. Resolves once the turn is settled locally; cheap no-op ("none") when
+ * there is nothing to reattach to.
+ */
+export async function resumeLocalAcpChatTurn(
+  args: ResumeLocalAcpChatArgs,
+): Promise<AcpResumeOutcome> {
+  const {
+    binding,
+    workspaceId,
+    chatId,
+    setMessages,
+    getMessages,
+    signal,
+    onLiveAttach,
+    onPersisted,
+  } = args;
+  const providerId = localAcpModelIdToProviderId(binding.modelId);
+  if (!providerId) return "none";
+
+  let sessionBusy = false;
+  try {
+    const sessions = await acpClient.listSessions();
+    const session = sessions.find(s => s.id === binding.sessionId);
+    if (!session) return "none";
+    sessionBusy = Boolean(session.busy);
+  } catch {
+    // Local Agent unreachable (not running / different machine) — nothing to do.
+    return "none";
+  }
+  if (signal?.aborted) return "aborted";
+
+  // The history loader's setMessages may not have flushed into the caller's
+  // messages ref yet (React batches state updates) — wait briefly for the
+  // transcript instead of silently skipping the resume.
+  let lastUserText = lastUserMessageText(getMessages());
+  for (let i = 0; i < 10 && !lastUserText; i++) {
+    await new Promise(resolve => setTimeout(resolve, 100));
+    if (signal?.aborted) return "aborted";
+    lastUserText = lastUserMessageText(getMessages());
+  }
+  if (!lastUserText) return "none";
+  if (!sessionBusy && !lastAssistantLooksIncomplete(getMessages())) {
+    return "none";
+  }
+
+  // Mirror message updates synchronously so persists never race React's
+  // batched setState flush (same pattern as runLocalAcpChatTurn).
+  let mirrored: UIMessage[] | null = null;
+  const applyMessages = (
+    updater: UIMessage[] | ((prev: UIMessage[]) => UIMessage[]),
+  ) => {
+    setMessages(prev => {
+      const base = mirrored ?? prev;
+      const next = typeof updater === "function" ? updater(base) : updater;
+      mirrored = next;
+      return next;
+    });
+  };
+  const appendedAssistantId = generateObjectId();
+  const applyAssistantParts = (parts: AssistantParts) => {
+    applyMessages(prev => {
+      const last = prev[prev.length - 1];
+      if (last?.role === "assistant") {
+        return prev.map((m, i) =>
+          i === prev.length - 1
+            ? { ...m, parts: parts as UIMessage["parts"] }
+            : m,
+        );
+      }
+      return [
+        ...prev,
+        {
+          id: appendedAssistantId,
+          role: "assistant" as const,
+          parts: parts as UIMessage["parts"],
+        },
+      ];
+    });
+  };
+
+  let persistTimer: ReturnType<typeof setTimeout> | null = null;
+  let persistChain: Promise<void> = Promise.resolve();
+  let notifiedPersist = false;
+  const persistIfPossible = async () => {
+    if (!mirrored || mirrored.length === 0) return;
+    const ok = await persistLocalAcpChat({
+      workspaceId,
+      chatId,
+      messages: mirrored,
+      localAcp: binding,
+    });
+    if (!ok) return;
+    if (!notifiedPersist) {
+      notifiedPersist = true;
+      onPersisted?.(binding);
+    }
+  };
+  const schedulePersist = (mode: "debounce" | "immediate" = "debounce") => {
+    if (persistTimer) {
+      clearTimeout(persistTimer);
+      persistTimer = null;
+    }
+    const run = () => {
+      persistTimer = null;
+      persistChain = persistChain
+        .then(() => persistIfPossible())
+        .catch(() => undefined);
+    };
+    if (mode === "immediate") {
+      run();
+      return;
+    }
+    persistTimer = setTimeout(run, 750);
+  };
+  const flushPersist = async () => {
+    if (persistTimer) {
+      clearTimeout(persistTimer);
+      persistTimer = null;
+    }
+    await persistChain.catch(() => undefined);
+    await persistIfPossible();
+  };
+
+  let liveAttached = false;
+  const sessionId = binding.sessionId;
+
+  const attachOnce = () =>
+    new Promise<AcpResumeOutcome | "retry">(resolve => {
+      let phase: "backlog" | "live" = "backlog";
+      const backlog: AcpBridgeEvent[] = [];
+      let parts: AssistantParts = [];
+      let settled = false;
+      let sawTurnDone = false;
+      let backlogTimer: ReturnType<typeof setTimeout> | null = null;
+
+      let unsub: () => void = () => undefined;
+      const teardown = () => {
+        settled = true;
+        if (backlogTimer) clearTimeout(backlogTimer);
+        signal?.removeEventListener("abort", onAbort);
+        unsub();
+      };
+      const settle = (outcome: AcpResumeOutcome | "retry") => {
+        if (settled) return;
+        teardown();
+        resolve(outcome);
+      };
+      const onAbort = () => settle("aborted");
+      const finishTurn = (outcome: "resumed" | "backfilled") => {
+        if (settled) return;
+        // Tear down first so late events can't mutate the finalized state.
+        teardown();
+        parts = finalizeResumedParts(parts);
+        applyAssistantParts(parts);
+        void flushPersist().finally(() => resolve(outcome));
+      };
+
+      const processBacklog = () => {
+        if (settled || phase !== "backlog") return;
+        if (backlogTimer) {
+          clearTimeout(backlogTimer);
+          backlogTimer = null;
+        }
+        const tail = extractResumeTail(backlog, lastUserText);
+        if (!tail.matched) {
+          // Newest turn on this session belongs to another chat (or the
+          // agent restarted and the log is gone) — nothing safe to resume.
+          settle("none");
+          return;
+        }
+        parts = rebuildAssistantParts(tail.events, providerId);
+        if (tail.done || !sessionBusy) {
+          // Turn already over: repaint the completed tail and persist it —
+          // this is the refresh-after-finish case where the final tokens
+          // never reached History.
+          if (!tail.done && !partsHaveContent(parts)) {
+            settle("none");
+            return;
+          }
+          finishTurn("backfilled");
+          return;
+        }
+        // Turn still streaming — seed a live Thinking block if the backlog
+        // had nothing visible yet, then keep painting live events.
+        if (parts.length === 0) {
+          parts = [{ type: "reasoning", text: "", state: "streaming" }];
+        }
+        applyAssistantParts(parts);
+        phase = "live";
+        if (!liveAttached) {
+          liveAttached = true;
+          // Active session drives Stop (cancelActive) + the permission banner.
+          useAcpStore.getState().setActiveSession(sessionId);
+          onLiveAttach?.();
+        }
+      };
+
+      unsub = acpClient.subscribeEvents(
+        sessionId,
+        event => {
+          if (settled) return;
+          if (signal?.aborted) {
+            settle("aborted");
+            return;
+          }
+          if (phase === "backlog") {
+            if (event.type === "status") {
+              processBacklog();
+            } else {
+              backlog.push(event);
+            }
+            return;
+          }
+          if (event.type === "session_update") {
+            const update = sessionUpdateOf(event);
+            if (!update) return;
+            if (update.sessionUpdate === "user_message_chunk") {
+              // A new prompt started on this session (another window/tab) —
+              // this chat's turn is over; keep what we reconstructed.
+              finishTurn("resumed");
+              return;
+            }
+            parts = reduceSessionUpdate(parts, update);
+            applyAssistantParts(parts);
+            if (
+              update.sessionUpdate === "tool_call" ||
+              update.sessionUpdate === "tool_call_update"
+            ) {
+              schedulePersist(
+                update.status === "completed" || update.status === "failed"
+                  ? "immediate"
+                  : "debounce",
+              );
+            }
+          } else if (event.type === "turn_done") {
+            sawTurnDone = true;
+            finishTurn("resumed");
+          } else if (event.type === "permission_request") {
+            useAcpStore.getState().ingestPermissionRequest(sessionId, {
+              requestId: event.requestId,
+              toolCall: event.toolCall,
+              options: event.options || [],
+            });
+          } else if (
+            event.type === "error" ||
+            event.type === "session_invalidated"
+          ) {
+            if (isAcpConnectionClosedError(event.message)) {
+              // Adapter process died mid-turn — the turn cannot finish.
+              parts = setAssistantErrorText(
+                parts,
+                "_Local Claude/Codex connection was lost — the reply may be incomplete._",
+              );
+              finishTurn("resumed");
+              return;
+            }
+            const cleaned = sanitizeAcpUserError(event.message, {
+              providerId,
+            });
+            if (cleaned) {
+              parts = setAssistantErrorText(parts, `Error: ${cleaned}`);
+              applyAssistantParts(parts);
+              schedulePersist("immediate");
+            }
+            if (event.type === "session_invalidated") {
+              finishTurn("resumed");
+            }
+          }
+        },
+        () => {
+          if (settled) return;
+          if (signal?.aborted) {
+            settle("aborted");
+            return;
+          }
+          // SSE transport dropped. Mid-turn we re-attach (replay rebuilds the
+          // whole turn, so nothing is lost); before/after that it's a no-op.
+          settle(phase === "live" && !sawTurnDone ? "retry" : "none");
+        },
+        // Default replay=true: the backlog IS the reconnect mechanism here.
+      );
+
+      signal?.addEventListener("abort", onAbort, { once: true });
+      if (signal?.aborted) {
+        onAbort();
+        return;
+      }
+      backlogTimer = setTimeout(processBacklog, BACKLOG_SETTLE_TIMEOUT_MS);
+    });
+
+  try {
+    for (let attempt = 0; attempt < MAX_ATTACH_ATTEMPTS; attempt++) {
+      const outcome = await attachOnce();
+      if (outcome !== "retry") return outcome;
+      await new Promise(resolve => setTimeout(resolve, 1000 * (attempt + 1)));
+      if (signal?.aborted) return "aborted";
+      const session = await acpClient.getSession(sessionId);
+      if (!session) break;
+      sessionBusy = Boolean(session.busy);
+    }
+    // Retries exhausted (or session gone) mid-turn — keep the checkpoint.
+    await flushPersist();
+    return "resumed";
+  } finally {
+    if (signal?.aborted) {
+      // Chat switched / new send took over — checkpoint what we painted.
+      void flushPersist();
+    }
+  }
+}

--- a/app/src/lib/resume-local-acp-chat.ts
+++ b/app/src/lib/resume-local-acp-chat.ts
@@ -147,9 +147,13 @@ export function extractResumeTail(
   if (lastUserIdx === -1 || !lastUserText) {
     return { matched: false, events: [], done: false };
   }
+  // Exact match (no prompt layers) or the layered form, which always ends
+  // with `[User message]\n<raw text>` (prependAcpPromptLayers). A bare
+  // endsWith would let a short message ("ok") match another chat's prompt
+  // that merely ends with the same words.
   const matched =
     lastUserChunkText === lastUserText ||
-    lastUserChunkText.endsWith(lastUserText);
+    lastUserChunkText.endsWith(`[User message]\n${lastUserText}`);
   const tail = events.slice(lastUserIdx + 1);
   return {
     matched,


### PR DESCRIPTION
## Problem

Refreshing (or reopening from History) mid-turn froze local Claude/Codex chats. The Local Agent keeps running the turn and records every event for SSE replay, but the web app never re-attached — the chat stalled at the last persisted checkpoint, pending tool cards were poisoned to "Interrupted", and since ACP transcripts persist client-side, the rest of the reply was permanently lost.

## Changes

- **`app/src/lib/resume-local-acp-chat.ts` (new):** after history load, verify the chat's bound ACP session, confirm the session's newest recorded turn belongs to this chat (its prompt must end with the `[User message]\n<text>` boundary of the chat's last user message — process sessions are reused across chats), rebuild the in-flight assistant message from the replay backlog, stream the remainder live until `turn_done`, and persist. Also backfills a turn that finished while the page was closed, re-attaches up to 3× if the SSE pipe drops, and re-ingests permission prompts.
- **`Chat.tsx`:** `requestLocalAcpResumeRef` with busy/Stop/abort plumbing (a fresh send or Stop cancels the reattach; chat switches drop it), plus tab-wake and network-online reattach triggers. All paths gate on the ACP binding — cloud chats are untouched.
- **`useChatSessionLoader`:** kicks the ACP resume after history load, alongside the cloud resumable-stream reattach.
- **Supports:** `acpClient.getSession()`, exported `INTERRUPTED_TOOL_TEXT` for the incomplete-checkpoint heuristic.

## Testing

- 13 new unit tests (tail extraction/turn ownership, rebuild, heuristics, finalization).
- Full app suite 422 tests green; `@mako/local-agent` 72/72; `@mako/agent-tools` 23/23.
- App production build (eslint + tsc + vite) clean; branch merged with current master (incl. #777, which also touches `Chat.tsx`) and re-verified.
- Known limit: if the Local Agent process itself restarts, the replay log is gone — the existing fresh-session + continuity-seed path covers the next message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015p5WEHpooKHVJwu9agoVJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_015p5WEHpooKHVJwu9agoVJ6)_