### PR TITLE
feat(mcp): support connecting Mako MCP as a ChatGPT connector

### DIFF
--- a/api/src/agent-lib/tools/dashboard-search-tools.ts
+++ b/api/src/agent-lib/tools/dashboard-search-tools.ts
@@ -21,7 +21,7 @@ interface DashboardSearchResult {
   widgetCount: number;
 }
 
-async function searchDashboardsByQuery(
+export async function searchDashboardsByQuery(
   query: string,
   workspaceId: string,
   limit: number,

--- a/api/src/mcp/bridge-policy.ts
+++ b/api/src/mcp/bridge-policy.ts
@@ -150,6 +150,13 @@ export const MCP_BRIDGE_POLICY: Readonly<Record<string, McpBridgeEntry>> = {
   create_preview_token: mcpOnly(),
   render_app: mcpOnly(),
 
+  // ── MCP-only ChatGPT connector contract (chatgpt-connector-tools.ts) ──
+  // ChatGPT only accepts an MCP server as a chat/deep-research connector
+  // when it exposes this exact search/fetch pair; both are read-only views
+  // over content other bridged tools already expose.
+  fetch: mcpOnly(),
+  search: mcpOnly(),
+
   // ── Charts / screenshots (client) ─────────────────────────────────────
   capture_screenshot: exclude(
     "client-only",

--- a/api/src/mcp/chatgpt-connector-tools.ts
+++ b/api/src/mcp/chatgpt-connector-tools.ts
@@ -1,0 +1,436 @@
+/**
+ * ChatGPT connector compatibility: top-level `search` and `fetch` tools.
+ *
+ * ChatGPT only treats an MCP server as a usable connector (chat + deep
+ * research, with citations) when it exposes exactly this pair — `search`
+ * returns candidate documents for a query, `fetch` returns one document by
+ * id — each as a single JSON-encoded text content item. Without them the
+ * server is reachable only in ChatGPT's developer mode. Both tools are plain
+ * read-only views over content the rest of the MCP surface already exposes
+ * (consoles, dashboards, apps, skills), so registering them for every
+ * external client adds capability for ChatGPT without widening access.
+ *
+ * Contract reference: OpenAI "Building MCP servers for ChatGPT and the API"
+ * (search → { results: [{ id, title, text, url }] }; fetch → { id, title,
+ * text, url, metadata }).
+ */
+import { tool } from "ai";
+import { Types } from "mongoose";
+import { z } from "zod";
+
+import { searchConsoles } from "../agent-lib/tools/console-search-tools";
+import { searchDashboardsByQuery } from "../agent-lib/tools/dashboard-search-tools";
+import {
+  getSystemSkillIndex,
+  getSystemSkillFullText,
+} from "../agent-lib/skills/system-skills";
+import {
+  Dashboard,
+  MakoApp,
+  SavedConsole,
+  Skill,
+} from "../database/workspace-schema";
+import { searchSkills } from "../services/skills.service";
+import { loggers } from "../logging";
+import type { BridgeableTool, MakoMcpContext } from "./mako-mcp-server";
+
+const logger = loggers.api("mcp-chatgpt");
+
+/** Per-kind cap keeps one search exchange bounded (4 kinds × 5 = ≤20 results). */
+const RESULTS_PER_KIND = 5;
+
+/** fetch() text ceiling — ChatGPT ingests the document into model context. */
+const MAX_DOCUMENT_CHARS = 60_000;
+
+interface SearchResultDoc {
+  id: string;
+  title: string;
+  text: string;
+  url: string | null;
+}
+
+interface FetchedDoc extends SearchResultDoc {
+  metadata: Record<string, unknown>;
+}
+
+function clientBaseUrl(): string {
+  return (
+    process.env.CLIENT_URL?.replace(/\/$/, "") ||
+    process.env.PUBLIC_URL?.replace(/\/$/, "") ||
+    "http://localhost:5173"
+  );
+}
+
+/** Workspace deep links (same prefixes the app's Copy-link share uses). */
+function resourceUrl(
+  kind: "console" | "dashboard" | "app",
+  id: string,
+): string {
+  const prefix = { console: "c", dashboard: "d", app: "a" }[kind];
+  return `${clientBaseUrl()}/${prefix}/${id}`;
+}
+
+function truncate(text: string, max = MAX_DOCUMENT_CHARS): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max) + "\n… [truncated]";
+}
+
+function requireObjectId(kind: string, id: string): Types.ObjectId {
+  if (!Types.ObjectId.isValid(id)) {
+    throw new Error(`Invalid ${kind} id: ${id}`);
+  }
+  return new Types.ObjectId(id);
+}
+
+// ---------------------------------------------------------------------------
+// search
+// ---------------------------------------------------------------------------
+
+async function searchWorkspaceApps(
+  workspaceId: string,
+  query: string,
+): Promise<SearchResultDoc[]> {
+  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const apps = await MakoApp.find({
+    workspaceId: new Types.ObjectId(workspaceId),
+    $or: [
+      { title: { $regex: escaped, $options: "i" } },
+      { description: { $regex: escaped, $options: "i" } },
+    ],
+  })
+    .select("title description updatedAt")
+    .sort({ updatedAt: -1 })
+    .limit(RESULTS_PER_KIND)
+    .lean();
+  return apps.map(app => ({
+    id: `app:${app._id.toString()}`,
+    title: `App: ${app.title}`,
+    text: app.description || "Mako data app.",
+    url: resourceUrl("app", app._id.toString()),
+  }));
+}
+
+async function searchAllSkills(
+  workspaceId: string,
+  query: string,
+): Promise<SearchResultDoc[]> {
+  const results: SearchResultDoc[] = [];
+  const hits = await searchSkills(workspaceId, query, RESULTS_PER_KIND);
+  for (const hit of hits) {
+    results.push({
+      id: `skill:${hit.name}`,
+      title: `Skill: ${hit.name}`,
+      text: hit.loadWhen || hit.body.slice(0, 300),
+      url: null,
+    });
+  }
+  const lowered = query.toLowerCase();
+  for (const skill of getSystemSkillIndex()) {
+    if (results.length >= RESULTS_PER_KIND) break;
+    if (results.some(r => r.id === `skill:${skill.name}`)) continue;
+    if (
+      skill.name.toLowerCase().includes(lowered) ||
+      skill.description.toLowerCase().includes(lowered)
+    ) {
+      results.push({
+        id: `skill:${skill.name}`,
+        title: `Skill: ${skill.name}`,
+        text: skill.description,
+        url: null,
+      });
+    }
+  }
+  return results;
+}
+
+async function executeSearch(
+  workspaceId: string,
+  query: string,
+): Promise<{ results: SearchResultDoc[] }> {
+  const [consoles, dashboards, apps, skills] = await Promise.allSettled([
+    searchConsoles(query, workspaceId, RESULTS_PER_KIND),
+    searchDashboardsByQuery(query, workspaceId, RESULTS_PER_KIND),
+    searchWorkspaceApps(workspaceId, query),
+    searchAllSkills(workspaceId, query),
+  ]);
+
+  const results: SearchResultDoc[] = [];
+  if (consoles.status === "fulfilled") {
+    for (const c of consoles.value) {
+      results.push({
+        id: `console:${c.id}`,
+        title: `Console: ${c.title}`,
+        text:
+          c.description ||
+          `Saved ${c.language} console` +
+            (c.connectionName ? ` on ${c.connectionName}` : "") +
+            ".",
+        url: resourceUrl("console", c.id),
+      });
+    }
+  }
+  if (dashboards.status === "fulfilled") {
+    for (const d of dashboards.value) {
+      results.push({
+        id: `dashboard:${d.id}`,
+        title: `Dashboard: ${d.title}`,
+        text:
+          d.description ||
+          `Dashboard with ${d.widgetCount} widget(s)` +
+            (d.dataSourceNames.length
+              ? ` over ${d.dataSourceNames.join(", ")}`
+              : "") +
+            ".",
+        url: resourceUrl("dashboard", d.id),
+      });
+    }
+  }
+  if (apps.status === "fulfilled") results.push(...apps.value);
+  if (skills.status === "fulfilled") results.push(...skills.value);
+
+  for (const outcome of [consoles, dashboards, apps, skills]) {
+    if (outcome.status === "rejected") {
+      logger.warn("ChatGPT connector search leg failed", {
+        workspaceId,
+        error:
+          outcome.reason instanceof Error
+            ? outcome.reason.message
+            : String(outcome.reason),
+      });
+    }
+  }
+
+  return { results };
+}
+
+// ---------------------------------------------------------------------------
+// fetch
+// ---------------------------------------------------------------------------
+
+async function fetchConsoleDoc(
+  workspaceId: string,
+  id: string,
+): Promise<FetchedDoc | null> {
+  const console_ = await SavedConsole.findOne({
+    _id: requireObjectId("console", id),
+    workspaceId: new Types.ObjectId(workspaceId),
+    $or: [{ is_deleted: { $ne: true } }, { is_deleted: { $exists: false } }],
+  })
+    .select("name description code language databaseName")
+    .lean();
+  if (!console_) return null;
+  const text = [
+    console_.description || "",
+    `Language: ${console_.language}` +
+      (console_.databaseName ? ` · Database: ${console_.databaseName}` : ""),
+    "```",
+    console_.code,
+    "```",
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+  return {
+    id: `console:${id}`,
+    title: console_.name,
+    text: truncate(text),
+    url: resourceUrl("console", id),
+    metadata: { kind: "console", language: console_.language },
+  };
+}
+
+async function fetchDashboardDoc(
+  workspaceId: string,
+  id: string,
+): Promise<FetchedDoc | null> {
+  const dashboard = await Dashboard.findOne({
+    _id: requireObjectId("dashboard", id),
+    workspaceId: new Types.ObjectId(workspaceId),
+  })
+    .select("title description widgets dataSources")
+    .lean();
+  if (!dashboard) return null;
+  const widgets = (
+    (dashboard.widgets ?? []) as Array<{ title?: string; type?: string }>
+  ).map(w => `- ${w.title || "Untitled"}${w.type ? ` (${w.type})` : ""}`);
+  const dataSources = (dashboard.dataSources ?? []).map(ds =>
+    [
+      `### ${ds.name || "Unnamed source"}`,
+      ds.query?.code ? `\`\`\`\n${ds.query.code}\n\`\`\`` : "",
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  );
+  const text = [
+    dashboard.description || "",
+    widgets.length ? `## Widgets\n${widgets.join("\n")}` : "",
+    dataSources.length ? `## Data sources\n${dataSources.join("\n\n")}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+  return {
+    id: `dashboard:${id}`,
+    title: dashboard.title || "Untitled dashboard",
+    text: truncate(text || "Empty dashboard."),
+    url: resourceUrl("dashboard", id),
+    metadata: {
+      kind: "dashboard",
+      widgetCount: dashboard.widgets?.length ?? 0,
+    },
+  };
+}
+
+async function fetchAppDoc(
+  workspaceId: string,
+  id: string,
+): Promise<FetchedDoc | null> {
+  const app = await MakoApp.findOne({
+    _id: requireObjectId("app", id),
+    workspaceId: new Types.ObjectId(workspaceId),
+  })
+    .select("title description entrypoint files.path dataBindings")
+    .lean();
+  if (!app) return null;
+  const files = (app.files ?? []).map(f => `- ${f.path}`);
+  const bindings = (app.dataBindings ?? []).map(b =>
+    [`### ${b.name} (${b.language})`, b.code ? `\`\`\`\n${b.code}\n\`\`\`` : ""]
+      .filter(Boolean)
+      .join("\n"),
+  );
+  const text = [
+    app.description || "",
+    `Entrypoint: ${app.entrypoint}`,
+    files.length ? `## Files\n${files.join("\n")}` : "",
+    bindings.length ? `## Data bindings\n${bindings.join("\n\n")}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+  return {
+    id: `app:${id}`,
+    title: app.title,
+    text: truncate(text),
+    url: resourceUrl("app", id),
+    metadata: { kind: "app", fileCount: app.files?.length ?? 0 },
+  };
+}
+
+async function fetchSkillDoc(
+  workspaceId: string,
+  name: string,
+): Promise<FetchedDoc | null> {
+  const workspaceSkill = await Skill.findOne({
+    workspaceId: new Types.ObjectId(workspaceId),
+    name,
+  })
+    .select("name loadWhen body")
+    .lean();
+  if (workspaceSkill) {
+    return {
+      id: `skill:${name}`,
+      title: workspaceSkill.name,
+      text: truncate(
+        [
+          workspaceSkill.loadWhen ? `When: ${workspaceSkill.loadWhen}` : "",
+          workspaceSkill.body,
+        ]
+          .filter(Boolean)
+          .join("\n\n"),
+      ),
+      url: null,
+      metadata: { kind: "skill", scope: "workspace" },
+    };
+  }
+  const systemText = getSystemSkillFullText(name);
+  if (!systemText) return null;
+  return {
+    id: `skill:${name}`,
+    title: name,
+    text: truncate(systemText),
+    url: null,
+    metadata: { kind: "skill", scope: "system" },
+  };
+}
+
+async function executeFetch(
+  workspaceId: string,
+  id: string,
+): Promise<FetchedDoc> {
+  const separator = id.indexOf(":");
+  const kind = separator === -1 ? "" : id.slice(0, separator);
+  const rest = separator === -1 ? "" : id.slice(separator + 1);
+  if (!kind || !rest) {
+    throw new Error(
+      `Invalid document id "${id}". Expected "<kind>:<id>" where kind is ` +
+        "console, dashboard, app, or skill — use ids returned by search.",
+    );
+  }
+  let doc: FetchedDoc | null;
+  switch (kind) {
+    case "console":
+      doc = await fetchConsoleDoc(workspaceId, rest);
+      break;
+    case "dashboard":
+      doc = await fetchDashboardDoc(workspaceId, rest);
+      break;
+    case "app":
+      doc = await fetchAppDoc(workspaceId, rest);
+      break;
+    case "skill":
+      doc = await fetchSkillDoc(workspaceId, rest);
+      break;
+    default:
+      throw new Error(
+        `Unknown document kind "${kind}". Supported: console, dashboard, app, skill.`,
+      );
+  }
+  if (!doc) {
+    throw new Error(`Document not found in this workspace: ${id}`);
+  }
+  return doc;
+}
+
+// ---------------------------------------------------------------------------
+// Tool registrations
+// ---------------------------------------------------------------------------
+
+/**
+ * The `search` / `fetch` pair ChatGPT requires. Registered for every external
+ * (non-ACP) MCP client — other clients simply gain a compact workspace
+ * search; Desktop ACP omits them (it has richer in-product search).
+ */
+export function createChatGptConnectorTools(
+  context: MakoMcpContext,
+): Record<string, BridgeableTool> {
+  const { workspaceId } = context;
+  return {
+    search: tool({
+      description:
+        "Search this Mako workspace for saved consoles (queries), " +
+        "dashboards, apps, and skills matching a query. Returns a list of " +
+        "documents with ids to pass to fetch. Searches workspace content " +
+        "only — use sql_execute_query to query the connected databases " +
+        "themselves.",
+      inputSchema: z.object({
+        query: z
+          .string()
+          .min(1)
+          .describe("Free-text search query (e.g. 'monthly revenue')."),
+      }),
+      execute: async ({ query }) => executeSearch(workspaceId, query),
+    }),
+    fetch: tool({
+      description:
+        "Retrieve the full content of one workspace document found via " +
+        "search: a saved console (including its SQL), dashboard (widgets + " +
+        "data source queries), app (files + data bindings), or skill.",
+      inputSchema: z.object({
+        id: z
+          .string()
+          .min(1)
+          .describe(
+            'Document id from search results, e.g. "console:64ac…" or "skill:apps".',
+          ),
+      }),
+      execute: async ({ id }) => executeFetch(workspaceId, id),
+    }),
+  };
+}

--- a/api/src/mcp/mako-mcp-server.test.ts
+++ b/api/src/mcp/mako-mcp-server.test.ts
@@ -24,6 +24,7 @@ import {
   type CapabilityGrant,
 } from "@mako/agent-tools";
 import { buildMakoMcpServer } from "./mako-mcp-server";
+import { createChatGptConnectorTools } from "./chatgpt-connector-tools";
 import { StatelessMcpTransport } from "./stateless-transport";
 import {
   capabilityGrantsFromScopes,
@@ -795,6 +796,115 @@ async function main() {
       false,
       "Desktop ACP must get list_open_consoles from mako-desktop, not the Mako bridge",
     );
+  }
+
+  // 3g. ChatGPT connector contract: the route layer registers search/fetch
+  //     as extraTools for external clients (ChatGPT refuses a connector
+  //     without exactly this pair). Both are read-only and policy-classified.
+  {
+    const context = {
+      workspaceId: WORKSPACE_ID,
+      scopes: ["mcp", "query:read"] as WorkspaceApiKeyScope[],
+    };
+    const chatGptExchange = async (messages: Record<string, unknown>[]) => {
+      const server = buildMakoMcpServer(
+        context,
+        createChatGptConnectorTools(context),
+      );
+      const transport = new StatelessMcpTransport();
+      await server.connect(transport);
+      try {
+        return (await transport.handle(
+          messages as unknown as JSONRPCMessage[],
+          5_000,
+        )) as unknown as Record<string, unknown>[];
+      } finally {
+        await server.close().catch(() => undefined);
+      }
+    };
+
+    const [listRes] = await chatGptExchange([
+      { jsonrpc: "2.0", id: "chatgpt-list", method: "tools/list" },
+    ]);
+    const { tools } = listRes.result as {
+      tools: {
+        name: string;
+        inputSchema: { type?: string };
+        annotations?: { readOnlyHint?: boolean };
+      }[];
+    };
+    const byName = new Map(tools.map(tool => [tool.name, tool]));
+    for (const name of ["search", "fetch"]) {
+      const entry = byName.get(name);
+      assert.ok(entry, `ChatGPT connector tool missing: ${name}`);
+      assert.equal(entry?.inputSchema.type, "object");
+      assert.equal(
+        entry?.annotations?.readOnlyHint,
+        true,
+        `${name} must be annotated read-only`,
+      );
+      const policy = MCP_BRIDGE_POLICY[name];
+      assert.equal(
+        policy?.status,
+        "mcp-only",
+        `${name} must be classified mcp-only in the bridge policy`,
+      );
+    }
+
+    // Malformed / unknown document ids fail in-band before any DB access.
+    const [badId] = await chatGptExchange([
+      {
+        jsonrpc: "2.0",
+        id: "chatgpt-bad-id",
+        method: "tools/call",
+        params: { name: "fetch", arguments: { id: "bogus" } },
+      },
+    ]);
+    const badIdResult = badId.result as {
+      isError?: boolean;
+      content: { text: string }[];
+    };
+    assert.equal(badIdResult.isError, true);
+    assert.match(badIdResult.content[0].text, /console, dashboard, app/);
+
+    const [badKind] = await chatGptExchange([
+      {
+        jsonrpc: "2.0",
+        id: "chatgpt-bad-kind",
+        method: "tools/call",
+        params: { name: "fetch", arguments: { id: "widget:123" } },
+      },
+    ]);
+    assert.match(
+      (badKind.result as { content: { text: string }[] }).content[0].text,
+      /Unknown document kind/,
+    );
+
+    // Zod schema validation applies like every other bridged tool.
+    const [missingQuery] = await chatGptExchange([
+      {
+        jsonrpc: "2.0",
+        id: "chatgpt-no-query",
+        method: "tools/call",
+        params: { name: "search", arguments: {} },
+      },
+    ]);
+    assert.match(
+      (missingQuery.result as { content: { text: string }[] }).content[0].text,
+      /Invalid arguments/,
+    );
+
+    // ACP Desktop must NOT get the pair (route passes no extraTools there).
+    const [acpList] = await exchange(
+      [{ jsonrpc: "2.0", id: "chatgpt-acp", method: "tools/list" }],
+      ["mcp", "query:read"],
+      true,
+    );
+    const acpNames = new Set(
+      (acpList.result as { tools: { name: string }[] }).tools.map(t => t.name),
+    );
+    assert.equal(acpNames.has("search"), false);
+    assert.equal(acpNames.has("fetch"), false);
   }
 
   // 4. Arbitrary MongoDB JavaScript execution is never bridged over MCP.

--- a/api/src/routes/mcp-server.routes.ts
+++ b/api/src/routes/mcp-server.routes.ts
@@ -29,6 +29,7 @@ import {
   resolveWorkspaceApiKeyScopes,
 } from "../auth/api-key-scopes";
 import { buildMakoMcpServer } from "../mcp/mako-mcp-server";
+import { createChatGptConnectorTools } from "../mcp/chatgpt-connector-tools";
 import { createMcpPreviewTools } from "../mcp/preview-tools";
 import { StatelessMcpTransport } from "../mcp/stateless-transport";
 import { ACP_MCP_CLIENT_ID } from "../auth/mcp-oauth.service";
@@ -151,9 +152,17 @@ mcpProtocolRoutes.post(
       acpDesktop,
       capabilityGrants,
     };
+    // External clients also get the ChatGPT connector contract (search /
+    // fetch) — required for ChatGPT to accept the server as a connector,
+    // harmless workspace search for everyone else.
     const server = buildMakoMcpServer(
       mcpContext,
-      acpDesktop ? undefined : createMcpPreviewTools(mcpContext),
+      acpDesktop
+        ? undefined
+        : {
+            ...createMcpPreviewTools(mcpContext),
+            ...createChatGptConnectorTools(mcpContext),
+          },
     );
     const transport = new StatelessMcpTransport();
 

--- a/app/src/components/McpAgentsPanel.tsx
+++ b/app/src/components/McpAgentsPanel.tsx
@@ -69,6 +69,12 @@ function buildMcpOAuthSetups() {
         deeplinkLabel: "Add to Claude",
       },
       {
+        client: "ChatGPT",
+        instruction:
+          "In ChatGPT: Settings → Connectors → Create (if you don't see it, enable Developer mode under Advanced settings first). Name it mako, paste the URL, choose OAuth, and sign in. Works in chat and deep research — Mako implements ChatGPT's search / fetch connector contract.",
+        snippet: endpoint,
+      },
+      {
         client: "Cursor",
         instruction:
           "One click below — Cursor opens, installs the server, and prompts you to sign in. Or paste into .cursor/mcp.json:",

--- a/docs/src/content/docs/mcp-server.md
+++ b/docs/src/content/docs/mcp-server.md
@@ -1,9 +1,9 @@
 ---
 title: MCP Server (Use Mako from Claude Code)
-description: Connect Claude Code, Cursor, or Codex to your Mako workspace over MCP — explore data, run read-only queries, and build Mako apps headlessly with your own AI agent and your own AI subscription.
+description: Connect Claude Code, Cursor, Codex, or ChatGPT to your Mako workspace over MCP — explore data, run read-only queries, and build Mako apps headlessly with your own AI agent and your own AI subscription.
 ---
 
-Mako is itself an [MCP](https://modelcontextprotocol.io) **server**: point Claude Code, Cursor, Codex, or any MCP client at your workspace and your agent can explore your databases, validate queries, and build full Mako apps — using **your** AI subscription's tokens, not Mako's in-product agent.
+Mako is itself an [MCP](https://modelcontextprotocol.io) **server**: point Claude Code, Cursor, Codex, ChatGPT, or any MCP client at your workspace and your agent can explore your databases, validate queries, and build full Mako apps — using **your** AI subscription's tokens, not Mako's in-product agent.
 
 Where [MCP Connectors](/mcp-connectors/) let Mako's agent use *other* systems' tools, the MCP server is the reverse: it lets *your* agent use Mako.
 
@@ -30,6 +30,8 @@ Then type `/mcp` inside a session to trigger the sign-in.
 ```text
 https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=mako&connectorUrl=<percent-encoded MCP URL>
 ```
+
+**ChatGPT** — Mako implements ChatGPT's connector contract (top-level `search` / `fetch` tools), so it can be added as a ChatGPT connector and used in regular chat and deep research with citations back into your workspace. In ChatGPT (Plus/Pro/Business/Enterprise): **Settings → Connectors → Create** — if you don't see the option, enable **Developer mode** under **Settings → Connectors → Advanced settings** first. Name it `mako`, paste `https://your-mako-host/api/mcp`, choose **OAuth** authentication, and sign in when prompted (same consent flow: pick a workspace, read-only). In chat and deep research ChatGPT uses `search` / `fetch` to find and cite saved consoles, dashboards, apps, and skills; with developer mode on, the full Mako tool surface (SQL exploration, the apps loop, dbt) is available too.
 
 **Cursor** — add to `.cursor/mcp.json` (project) or `~/.cursor/mcp.json` (global); Cursor prompts you to sign in on first use. **Settings → Connect Agents** also has a one-click **Add to Cursor** button.
 
@@ -95,6 +97,8 @@ The server ships usage instructions with the handshake, so agents discover this 
 
 Optional helpers: `web_search` / `fetch_url` for public docs (annotated `openWorldHint`).
 
+For ChatGPT compatibility the server also exposes a top-level `search` / `fetch` pair — workspace-wide search over saved consoles, dashboards, apps, and skills, plus document retrieval by id (`console:…`, `dashboard:…`, `app:…`, `skill:…`). ChatGPT requires exactly these two tools to accept a connector for chat and deep research; other clients can use them as a quick workspace search.
+
 The MCP tool surface is a curated subset of the in-product agent tools. Classification lives in `api/src/mcp/bridge-policy.ts` — every agent tool is either bridged, MCP-only, or explicitly excluded (client-only UI, security, in-product UX, or deferred). Adding an agent tool without classifying it fails the MCP inventory test.
 
 Read-only tools are annotated per the MCP spec (`readOnlyHint`), so well-behaved clients run the whole discovery/query loop without approval prompts. If you keep a Mako tab open on the app being edited, it live-reloads on every agent change.
@@ -133,3 +137,4 @@ To keep agent context lean, agents can pass `includeScreenshot: false` to `run_a
 | `Server-side rendering is not configured` | The deployment has no `RENDER_APP_BROWSER_PATH` (headless Chromium). Agents fall back to `create_preview_token` — open the URL in any browser. |
 | `Preview base URL … is unreachable` | `CLIENT_URL`/`PUBLIC_URL` on the API server is wrong — it must point at the Mako frontend. |
 | Client shows the server but tools error with 401 | The OAuth token or `Authorization: Bearer` key is missing/revoked — reconnect or rotate. |
+| ChatGPT rejects the connector ("does not implement our spec") | The deployment predates the `search` / `fetch` connector tools — update Mako. Custom MCP connectors also require Developer mode to be enabled under ChatGPT's connector settings. |


### PR DESCRIPTION
## Summary

Makes Mako's MCP server (`POST /api/mcp`) connectable from ChatGPT as a custom connector, usable in regular chat and deep research with citations back into the workspace.

ChatGPT accepts an MCP server as a connector only when it (1) supports OAuth with dynamic client registration — already in place — and (2) exposes a top-level `search` / `fetch` tool pair returning JSON documents it can cite. This PR adds that pair.

## Changes

- **`api/src/mcp/chatgpt-connector-tools.ts`** (new): implements ChatGPT's connector contract.
  - `search` — workspace-scoped, read-only search over saved consoles (reusing the existing vector → text → regex search chain), dashboards, apps, and skills; results carry citation deep links (`/c/:id`, `/d/:id`, `/a/:id` — same URLs as the Share dialog's Copy link).
  - `fetch` — retrieves one document by namespaced id (`console:…`, `dashboard:…`, `app:…`, `skill:…`): console SQL, dashboard widgets + data-source queries, app files + data bindings, skill bodies. 60k-char cap.
- **`api/src/routes/mcp-server.routes.ts`**: registers the pair as extraTools for external (non-ACP) MCP clients next to the preview tools. Other clients simply gain a compact workspace search; Desktop ACP omits them.
- **`api/src/mcp/bridge-policy.ts`**: both classified `mcp-only` so they inherit read-only annotations and pass the inventory/staleness tests.
- **`api/src/agent-lib/tools/dashboard-search-tools.ts`**: export `searchDashboardsByQuery` for reuse.
- **Docs**: ChatGPT setup section, `search`/`fetch` contract note, and a troubleshooting row in `docs/src/content/docs/mcp-server.md`.
- **UI**: ChatGPT tab in **Settings → Connect Agents** next to Claude/Cursor/Codex.

## Testing

- New assertions in `api/src/mcp/mako-mcp-server.test.ts`: tool exposure + read-only annotations, document-id validation, zod rejection of bad arguments, and Desktop-ACP omission. Full API test chain (`pnpm test`) passes; API + app lint and typecheck clean.
- End-to-end dry run against an in-memory MongoDB, replaying ChatGPT's exact sequence: RFC 9728/8414 discovery → dynamic client registration with ChatGPT's redirect URI (`https://chatgpt.com/connector_platform_oauth_redirect`) → `initialize` → `tools/list` → `search` → `fetch` on every result. All passed, including cross-workspace isolation (fetching another workspace's document fails with "not found").

## How to test from ChatGPT

1. Deploy this branch, then in ChatGPT: **Settings → Connectors → Create** (enable **Developer mode** under Advanced settings if the option isn't visible).
2. Name it `mako`, paste `https://<your-mako-host>/api/mcp`, choose **OAuth**, sign in, and pick a workspace (read-only).
3. In a chat, ask e.g. *"Search my Mako workspace for revenue dashboards"* — results should cite workspace deep links. Developer mode additionally unlocks the full tool surface (SQL exploration, apps loop, dbt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tAyZvYQXoKrP39ueqMuMY

---
_Generated by [Claude Code](https://claude.ai/code/session_012tAyZvYQXoKrP39ueqMuMY)_