### PR TITLE
feat(api): record connection test outcomes server-side

### DIFF
--- a/api/src/database/workspace-schema.ts
+++ b/api/src/database/workspace-schema.ts
@@ -1171,6 +1171,28 @@ export interface IQueryExecution extends Document {
   bytesScanned?: number; // BigQuery, ClickHouse report this
 }
 
+export interface IConnectionVerification extends Document {
+  _id: Types.ObjectId;
+  verifiedAt: Date;
+
+  // Who triggered the test (absent for unauthenticated/system paths)
+  userId?: string;
+  workspaceId?: Types.ObjectId;
+
+  // Saved connection under test; absent for pre-save tests of unsaved configs
+  connectionId?: Types.ObjectId;
+  databaseType: string;
+
+  // Where in the product the test ran
+  trigger: "standalone_test" | "create_verify" | "update_verify" | "saved_test";
+
+  // Outcome
+  success: boolean;
+  durationMs: number;
+  errorClass?: string; // auth_failed, host_not_found, timeout, tls, ...
+  errorMessage?: string; // Truncated driver error, for drill-down
+}
+
 /**
  * Workspace Schema
  */
@@ -2825,6 +2847,49 @@ CdcStateTransitionSchema.index({ workspaceId: 1, flowId: 1, at: -1 });
  * QueryExecution Schema
  * Tracks all query executions for usage analytics and billing
  */
+const ConnectionVerificationSchema = new Schema<IConnectionVerification>(
+  {
+    verifiedAt: { type: Date, required: true, default: Date.now },
+    userId: { type: String, ref: "User", required: false },
+    workspaceId: {
+      type: Schema.Types.ObjectId,
+      ref: "Workspace",
+      required: false,
+    },
+    connectionId: {
+      type: Schema.Types.ObjectId,
+      ref: "DatabaseConnection",
+      required: false,
+    },
+    databaseType: { type: String, required: true },
+    trigger: {
+      type: String,
+      enum: ["standalone_test", "create_verify", "update_verify", "saved_test"],
+      required: true,
+    },
+    success: { type: Boolean, required: true },
+    durationMs: { type: Number, required: true },
+    errorClass: { type: String, required: false },
+    errorMessage: { type: String, required: false },
+  },
+  {
+    collection: "connection_verifications",
+    timestamps: false,
+  },
+);
+
+ConnectionVerificationSchema.index({ workspaceId: 1, verifiedAt: -1 });
+ConnectionVerificationSchema.index({ userId: 1, verifiedAt: -1 });
+ConnectionVerificationSchema.index({
+  success: 1,
+  errorClass: 1,
+  verifiedAt: -1,
+}); // Failure-mode rollups
+ConnectionVerificationSchema.index(
+  { verifiedAt: 1 },
+  { expireAfterSeconds: 7776000 },
+); // TTL: 90 days
+
 const QueryExecutionSchema = new Schema<IQueryExecution>(
   {
     executedAt: { type: Date, required: true, default: Date.now },
@@ -4040,6 +4105,10 @@ export const BigQueryCdcState = CdcEntityState;
 export const QueryExecution = mongoose.model<IQueryExecution>(
   "QueryExecution",
   QueryExecutionSchema,
+);
+export const ConnectionVerification = mongoose.model<IConnectionVerification>(
+  "ConnectionVerification",
+  ConnectionVerificationSchema,
 );
 export const ScheduledQueryRun = mongoose.model<IScheduledQueryRun>(
   "ScheduledQueryRun",

--- a/api/src/routes/workspace-databases.ts
+++ b/api/src/routes/workspace-databases.ts
@@ -14,6 +14,7 @@ import {
   SavedConsole,
 } from "../database/workspace-schema";
 import { databaseConnectionService } from "../services/database-connection.service";
+import { recordConnectionVerification } from "../services/connection-verification.service";
 import {
   queryExecutionService,
   QueryLanguage,
@@ -609,8 +610,18 @@ workspaceDatabaseRoutes.openapi(
         connection: body.connection,
       } as IDatabaseConnection;
 
+      const startedAt = Date.now();
       const result =
         await databaseConnectionService.testConnection(tempDatabase);
+      recordConnectionVerification({
+        userId: c.get("user")?.id,
+        workspaceId: c.get("workspace")?._id,
+        databaseType: body.type,
+        trigger: "standalone_test",
+        success: result.success,
+        durationMs: Date.now() - startedAt,
+        error: result.error,
+      });
 
       return c.json(result);
     } catch (error) {
@@ -700,8 +711,18 @@ workspaceDatabaseRoutes.openapi(
           type: body.type,
           connection: body.connection || {},
         } as IDatabaseConnection;
+        const startedAt = Date.now();
         const test =
           await databaseConnectionService.testConnection(tempDatabase);
+        recordConnectionVerification({
+          userId: user.id,
+          workspaceId: workspace._id,
+          databaseType: body.type,
+          trigger: "create_verify",
+          success: test.success,
+          durationMs: Date.now() - startedAt,
+          error: test.error,
+        });
         if (!test.success) {
           return c.json({
             success: false,
@@ -840,8 +861,19 @@ workspaceDatabaseRoutes.openapi(
             type: database.type,
             connection: candidate,
           } as IDatabaseConnection;
+          const startedAt = Date.now();
           const test =
             await databaseConnectionService.testConnection(tempDatabase);
+          recordConnectionVerification({
+            userId: c.get("user")?.id,
+            workspaceId: database.workspaceId,
+            connectionId: database._id,
+            databaseType: database.type,
+            trigger: "update_verify",
+            success: test.success,
+            durationMs: Date.now() - startedAt,
+            error: test.error,
+          });
           if (!test.success) {
             return c.json({
               success: false,
@@ -1011,7 +1043,18 @@ workspaceDatabaseRoutes.openapi(
         return c.json({ success: false, error: "Database not found" }, 404);
       }
 
+      const startedAt = Date.now();
       const result = await databaseConnectionService.testConnection(database);
+      recordConnectionVerification({
+        userId: c.get("user")?.id,
+        workspaceId: database.workspaceId,
+        connectionId: database._id,
+        databaseType: database.type,
+        trigger: "saved_test",
+        success: result.success,
+        durationMs: Date.now() - startedAt,
+        error: result.error,
+      });
 
       if (result.success) {
         // Update last connected timestamp

--- a/api/src/services/connection-verification.service.ts
+++ b/api/src/services/connection-verification.service.ts
@@ -1,0 +1,61 @@
+import { Types } from "mongoose";
+import { ConnectionVerification } from "../database/workspace-schema";
+import { loggers } from "../logging";
+
+const logger = loggers.db();
+
+// Ordered: first match wins. Buckets chosen so a failure-mode rollup answers
+// "why do connection tests fail" without reading raw driver messages.
+const ERROR_CLASSES: Array<[RegExp, string]> = [
+  [
+    /auth|password|credential|access denied|login failed|permission denied|28p01|1045/i,
+    "auth_failed",
+  ],
+  [/enotfound|getaddrinfo|name or service not known|dns/i, "host_not_found"],
+  [/econnrefused|connection refused/i, "connection_refused"],
+  [/etimedout|timed?\s?out/i, "timeout"],
+  [/ssl|tls|certificate/i, "tls"],
+  [
+    /firewall|allowlist|whitelist|not allowed to connect|pg_hba|ip address/i,
+    "network_blocked",
+  ],
+  [/does not exist|unknown database|not found/i, "database_not_found"],
+  [/unsupported database type/i, "unsupported_type"],
+];
+
+export function classifyConnectionError(error: string): string {
+  for (const [pattern, cls] of ERROR_CLASSES) {
+    if (pattern.test(error)) return cls;
+  }
+  return "other";
+}
+
+/**
+ * Fire-and-forget record of a connection test outcome. Never throws and never
+ * blocks the response path — losing a telemetry row is always preferable to
+ * failing or slowing the actual connection test.
+ */
+export function recordConnectionVerification(entry: {
+  userId?: string;
+  workspaceId?: Types.ObjectId;
+  connectionId?: Types.ObjectId;
+  databaseType: string;
+  trigger: "standalone_test" | "create_verify" | "update_verify" | "saved_test";
+  success: boolean;
+  durationMs: number;
+  error?: string;
+}): void {
+  const { error, ...rest } = entry;
+  void ConnectionVerification.create({
+    ...rest,
+    verifiedAt: new Date(),
+    ...(error && !entry.success
+      ? {
+          errorClass: classifyConnectionError(error),
+          errorMessage: error.slice(0, 500),
+        }
+      : {}),
+  }).catch((err: unknown) => {
+    logger.warn("Failed to record connection verification", { err });
+  });
+}


### PR DESCRIPTION
Adds a `connection_verifications` collection and records every connection test outcome server-side at all four call sites in the workspace database routes (`/test-connection`, create with `verifyBeforeSave`, update with `verifyBeforeSave`, `/{id}/test`).

Each row: userId, workspaceId, connectionId (when saved), databaseType, trigger, success, durationMs, and on failure a classified `errorClass` (`auth_failed`, `host_not_found`, `connection_refused`, `timeout`, `tls`, `network_blocked`, `database_not_found`, `other`) plus a truncated driver message.

**Why:** client-side analytics only see a fraction of connection attempts, so today we can't distinguish 'users never try to connect' from 'users try and fail'. This gives a queryable failure-mode breakdown (which DB types fail, on what error class, how often) to diagnose the connect → first-query drop-off.

Design notes:
- Fire-and-forget (`recordConnectionVerification` never throws or blocks the response path).
- 90-day TTL, matching `query_executions`.
- No connection credentials stored — only type, outcome, and error text (capped at 500 chars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xza3ZQSNpvFrPvE6o4cvpU