### PR TITLE
feat(app): show last data refresh time in dashboard and app toolbars

### DIFF
--- a/app/src/components/AppRenderer.tsx
+++ b/app/src/components/AppRenderer.tsx
@@ -43,7 +43,9 @@ import ShareDialog from "./ShareDialog";
 import { SaveCommentDialog } from "./SaveCommentDialog";
 import { VersionHistoryPanel } from "./VersionHistoryPanel";
 import { useSaveCommentSuggestion } from "../hooks/useSaveCommentSuggestion";
-import ResourceRefreshControl from "./ResourceRefreshControl";
+import ResourceRefreshControl, {
+  LastRefreshedLabel,
+} from "./ResourceRefreshControl";
 import { buildPreviewHtml, PREVIEW_MESSAGE } from "../app-runtime/preview";
 import { appLocationFromHostSearch } from "../app-runtime/app-location";
 import {
@@ -270,6 +272,20 @@ export default function AppRenderer({
   );
 
   const hasAnyBindings = (appEntity?.dataBindings.length ?? 0) > 0;
+
+  // Oldest materialized artifact across parquet bindings — "every binding is
+  // at least this fresh". Null for live-only apps (data is queried on read).
+  const lastRefreshedAt = useMemo(() => {
+    let oldest: string | null = null;
+    for (const binding of appEntity?.dataBindings ?? []) {
+      if (binding.materialization !== "parquet") continue;
+      const builtAt =
+        binding.cache?.parquetBuiltAt ?? binding.cache?.lastRefreshedAt;
+      if (!builtAt || Number.isNaN(Date.parse(builtAt))) continue;
+      if (!oldest || Date.parse(builtAt) < Date.parse(oldest)) oldest = builtAt;
+    }
+    return oldest;
+  }, [appEntity?.dataBindings]);
 
   // Single "Refresh" action: force-rebuild every parquet binding, wait until
   // ALL settle, load DuckDB tables, then poke the running app once. Never
@@ -847,12 +863,16 @@ export default function AppRenderer({
               </Box>
             </Tooltip>
           ))}
-        {canManage && hasAnyBindings && (
+        {canManage && hasAnyBindings ? (
           <ResourceRefreshControl
             subject="binding"
             busy={rematerializing}
             onClick={() => void handleRefreshData()}
+            lastRefreshedAt={lastRefreshedAt}
           />
+        ) : (
+          // Viewers can't refresh, but data freshness still matters to them.
+          <LastRefreshedLabel lastRefreshedAt={lastRefreshedAt} />
         )}
         <Tooltip title="Share">
           <IconButton size="small" onClick={() => setShareOpen(true)}>

--- a/app/src/components/DashboardCanvas.tsx
+++ b/app/src/components/DashboardCanvas.tsx
@@ -207,22 +207,26 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
       .finally(() => setReloadingData(false));
   }, [workspaceId, dashboardId, reloadingData]);
 
-  const dataFreshness = useMemo(() => {
+  // Oldest materialized artifact across data sources — "every source is at
+  // least this fresh". Drives both the toolbar "Updated X ago" caption and
+  // the staleness banner.
+  const lastRefreshedAt = useMemo(() => {
     if (!dashboard || dashboard.dataSources.length === 0) return null;
-    const ttl = dashboard.materializationSchedule?.dataFreshnessTtlMs;
-    const threshold = ttl ?? 24 * 60 * 60 * 1000;
-    let oldestDate: Date | null = null;
+    let oldest: string | null = null;
     for (const ds of dashboard.dataSources) {
       const builtAt = ds.cache?.parquetBuiltAt;
-      if (!builtAt) continue;
-      const d = new Date(builtAt);
-      if (!oldestDate || d < oldestDate) oldestDate = d;
+      if (!builtAt || Number.isNaN(Date.parse(builtAt))) continue;
+      if (!oldest || Date.parse(builtAt) < Date.parse(oldest)) oldest = builtAt;
     }
-    if (!oldestDate) {
-      const lr = dashboard.cache?.lastRefreshedAt;
-      if (lr) oldestDate = new Date(lr);
-    }
-    if (!oldestDate) return null;
+    return oldest ?? dashboard.cache?.lastRefreshedAt ?? null;
+  }, [dashboard]);
+
+  const dataFreshness = useMemo(() => {
+    if (!dashboard || !lastRefreshedAt) return null;
+    const ttl = dashboard.materializationSchedule?.dataFreshnessTtlMs;
+    const threshold = ttl ?? 24 * 60 * 60 * 1000;
+    const oldestDate = new Date(lastRefreshedAt);
+    if (Number.isNaN(oldestDate.getTime())) return null;
     const ageMs = Date.now() - oldestDate.getTime();
     if (ageMs < threshold) return null;
     const hours = Math.floor(ageMs / (1000 * 60 * 60));
@@ -232,7 +236,7 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
         ? `${days} day${days !== 1 ? "s" : ""} ago`
         : `${hours} hour${hours !== 1 ? "s" : ""} ago`;
     return { ageMs, label };
-  }, [dashboard]);
+  }, [dashboard, lastRefreshedAt]);
 
   useEffect(() => {
     setFreshnessDismissed(false);
@@ -429,6 +433,7 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
           subject="data source"
           busy={reloadingData}
           onClick={handleRefresh}
+          lastRefreshedAt={lastRefreshedAt}
         />
 
         {canManageShare && (

--- a/app/src/components/ResourceRefreshControl.tsx
+++ b/app/src/components/ResourceRefreshControl.tsx
@@ -1,10 +1,49 @@
-import { Chip, CircularProgress, Tooltip } from "@mui/material";
+import { useEffect, useState } from "react";
+import { Chip, CircularProgress, Tooltip, Typography } from "@mui/material";
 import { RefreshCw } from "lucide-react";
+import { formatRelativeTime } from "../utils/relative-time";
+
+/**
+ * Muted "Updated X ago" caption for the app/dashboard toolbars, ticking so it
+ * never goes stale on a long-lived tab. Renders nothing when the timestamp is
+ * unknown (e.g. live-only bindings, never-materialized sources). Exported
+ * standalone so viewers without the Refresh action still see data freshness.
+ */
+export function LastRefreshedLabel({
+  lastRefreshedAt,
+}: {
+  lastRefreshedAt?: string | null;
+}) {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (!lastRefreshedAt) return;
+    const id = setInterval(() => setTick(t => t + 1), 60_000);
+    return () => clearInterval(id);
+  }, [lastRefreshedAt]);
+
+  const label = formatRelativeTime(lastRefreshedAt);
+  if (!label || !lastRefreshedAt) return null;
+  return (
+    <Tooltip
+      title={`Data last refreshed ${new Date(lastRefreshedAt).toLocaleString()}`}
+    >
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        noWrap
+        sx={{ flexShrink: 0, mr: 0.5 }}
+      >
+        Updated {label}
+      </Typography>
+    </Tooltip>
+  );
+}
 
 /**
  * Shared Refresh control for app + dashboard toolbars. Always means the same
  * thing: force-rebuild every data source / binding from upstream, wait until
- * all settle, then update the UI once.
+ * all settle, then update the UI once. When `lastRefreshedAt` is provided, a
+ * muted "Updated X ago" caption precedes the chip.
  */
 export default function ResourceRefreshControl({
   onClick,
@@ -12,32 +51,38 @@ export default function ResourceRefreshControl({
   disabled = false,
   /** Used in the tooltip — e.g. "binding" or "data source". */
   subject,
+  /** ISO timestamp of the oldest materialized artifact, if known. */
+  lastRefreshedAt,
 }: {
   onClick: () => void;
   busy?: boolean;
   disabled?: boolean;
   subject: "binding" | "data source";
+  lastRefreshedAt?: string | null;
 }) {
   const isDisabled = disabled || busy;
   return (
-    <Tooltip title={`Refresh data from source (waits for every ${subject})`}>
-      <span>
-        <Chip
-          icon={
-            busy ? (
-              <CircularProgress size={14} color="inherit" />
-            ) : (
-              <RefreshCw size={14} />
-            )
-          }
-          label={busy ? "Refreshing…" : "Refresh"}
-          size="small"
-          variant="outlined"
-          onClick={onClick}
-          disabled={isDisabled}
-          sx={{ cursor: isDisabled ? "default" : "pointer" }}
-        />
-      </span>
-    </Tooltip>
+    <>
+      {!busy && <LastRefreshedLabel lastRefreshedAt={lastRefreshedAt} />}
+      <Tooltip title={`Refresh data from source (waits for every ${subject})`}>
+        <span>
+          <Chip
+            icon={
+              busy ? (
+                <CircularProgress size={14} color="inherit" />
+              ) : (
+                <RefreshCw size={14} />
+              )
+            }
+            label={busy ? "Refreshing…" : "Refresh"}
+            size="small"
+            variant="outlined"
+            onClick={onClick}
+            disabled={isDisabled}
+            sx={{ cursor: isDisabled ? "default" : "pointer" }}
+          />
+        </span>
+      </Tooltip>
+    </>
   );
 }

--- a/app/src/components/dashboard/DataSourcePanel.tsx
+++ b/app/src/components/dashboard/DataSourcePanel.tsx
@@ -59,6 +59,7 @@ import {
 import { useDashboardRuntimeStore } from "../../dashboard-runtime/store";
 import { focusDashboardDataSourceTab } from "../../dashboard-runtime/shell";
 import { useSchemaStore } from "../../store/schemaStore";
+import { formatRelativeTime } from "../../utils/relative-time";
 
 interface ConsoleResult {
   id: string;
@@ -82,20 +83,6 @@ const STATUS_CHIP_PROPS: Record<
   ready: { label: "Ready", color: "success" },
   error: { label: "Error", color: "error" },
 };
-
-function formatRelativeTime(value?: string): string | null {
-  if (!value) return null;
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return null;
-  const diffMs = Date.now() - date.getTime();
-  const diffMinutes = Math.round(diffMs / 60000);
-  if (diffMinutes < 1) return "just now";
-  if (diffMinutes < 60) return `${diffMinutes} min ago`;
-  const diffHours = Math.round(diffMinutes / 60);
-  if (diffHours < 24) return `${diffHours} hr ago`;
-  const diffDays = Math.round(diffHours / 24);
-  return `${diffDays} day${diffDays === 1 ? "" : "s"} ago`;
-}
 
 function formatBytes(value?: number): string | null {
   if (!value || value <= 0) return null;

--- a/app/src/utils/relative-time.ts
+++ b/app/src/utils/relative-time.ts
@@ -1,0 +1,17 @@
+/**
+ * Compact relative-time formatting for data freshness labels
+ * ("just now", "5 min ago", "3 hr ago", "2 days ago").
+ */
+export function formatRelativeTime(value?: string | null): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  const diffMs = Date.now() - date.getTime();
+  const diffMinutes = Math.round(diffMs / 60000);
+  if (diffMinutes < 1) return "just now";
+  if (diffMinutes < 60) return `${diffMinutes} min ago`;
+  const diffHours = Math.round(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours} hr ago`;
+  const diffDays = Math.round(diffHours / 24);
+  return `${diffDays} day${diffDays === 1 ? "" : "s"} ago`;
+}


### PR DESCRIPTION
## Summary

Adds a muted, live-ticking **"Updated X ago"** caption next to the shared Refresh chip in both the dashboard and app toolbars, with the exact local timestamp in a tooltip. The time shown is the **oldest** materialized artifact across sources/bindings — i.e. "every source is at least this fresh" — matching the existing staleness-banner semantics.

## Changes

- **`ResourceRefreshControl`**: new optional `lastRefreshedAt` prop; exports a standalone `LastRefreshedLabel` (ticks every minute so long-lived tabs never show a stale label) so app viewers without the Refresh action still see data freshness.
- **`DashboardCanvas`**: extracts the oldest-artifact timestamp (`dataSources[].cache.parquetBuiltAt`, falling back to `dashboard.cache.lastRefreshedAt`) into its own memo, reused by the staleness banner, and passes it to the control. Shown to everyone including read-only viewers.
- **`AppRenderer`**: computes the oldest parquet-binding build time. Live-only apps show nothing — their data is queried fresh on every read. Viewers who can't manage the app get the standalone freshness label.
- **`utils/relative-time.ts`**: consolidates `formatRelativeTime` (previously private to `DataSourcePanel`).

The label updates automatically after a refresh because both refresh flows already refetch the entity once builds settle.

## Testing

- `eslint` clean
- `tsc --noEmit` clean
- Full unit suite: 435 tests passing
- Full production build (`pnpm build`) succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdVVy8Pzo7oyYVbfqHzfdN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdVVy8Pzo7oyYVbfqHzfdN)_