### PR TITLE
fix(inngest): cap dashboard refresh concurrency per workspace

### DIFF
--- a/api/src/inngest/functions/dashboard-refresh.ts
+++ b/api/src/inngest/functions/dashboard-refresh.ts
@@ -14,14 +14,32 @@ const logger = loggers.inngest();
 
 const WORKER_ID = `inngest-${os.hostname()}-${process.pid}`;
 
+/**
+ * Global cap across all dashboard refreshes. Per-dashboard concurrency alone
+ * lets N scheduled dashboards hit BigQuery in parallel (each with multiple
+ * heavy sources + retries) and starve shared reservations.
+ * Override with DASHBOARD_REFRESH_CONCURRENCY (default 2).
+ */
+const DASHBOARD_REFRESH_CONCURRENCY = Math.max(
+  parseInt(process.env.DASHBOARD_REFRESH_CONCURRENCY || "2", 10) || 2,
+  1,
+);
+
 export const dashboardRefreshFunction = inngest.createFunction(
   {
     id: "dashboard-refresh",
     name: "Refresh Dashboard Data Sources",
-    concurrency: {
-      limit: 1,
-      key: "event.data.dashboardId",
-    },
+    concurrency: [
+      {
+        scope: "fn",
+        limit: DASHBOARD_REFRESH_CONCURRENCY,
+      },
+      {
+        scope: "fn",
+        key: "event.data.dashboardId",
+        limit: 1,
+      },
+    ],
     retries: 2,
   },
   { event: "dashboard.refresh" },

--- a/api/src/inngest/functions/dashboard-refresh.ts
+++ b/api/src/inngest/functions/dashboard-refresh.ts
@@ -15,13 +15,16 @@ const logger = loggers.inngest();
 const WORKER_ID = `inngest-${os.hostname()}-${process.pid}`;
 
 /**
- * Global cap across all dashboard refreshes. Per-dashboard concurrency alone
- * lets N scheduled dashboards hit BigQuery in parallel (each with multiple
- * heavy sources + retries) and starve shared reservations.
- * Override with DASHBOARD_REFRESH_CONCURRENCY (default 2).
+ * Cap concurrent dashboard refreshes per workspace. Per-dashboard concurrency
+ * alone lets N scheduled dashboards in the same workspace hit BigQuery in
+ * parallel (multi-source scans + retries) and starve shared reservations.
+ * Override with DASHBOARD_REFRESH_CONCURRENCY_PER_WORKSPACE (default 2).
  */
-const DASHBOARD_REFRESH_CONCURRENCY = Math.max(
-  parseInt(process.env.DASHBOARD_REFRESH_CONCURRENCY || "2", 10) || 2,
+const DASHBOARD_REFRESH_CONCURRENCY_PER_WORKSPACE = Math.max(
+  parseInt(
+    process.env.DASHBOARD_REFRESH_CONCURRENCY_PER_WORKSPACE || "2",
+    10,
+  ) || 2,
   1,
 );
 
@@ -32,7 +35,10 @@ export const dashboardRefreshFunction = inngest.createFunction(
     concurrency: [
       {
         scope: "fn",
-        limit: DASHBOARD_REFRESH_CONCURRENCY,
+        // Requires workspaceId on the event (queueDashboardArtifactRefresh and
+        // the scheduler below both set it).
+        key: "event.data.workspaceId",
+        limit: DASHBOARD_REFRESH_CONCURRENCY_PER_WORKSPACE,
       },
       {
         scope: "fn",
@@ -46,12 +52,14 @@ export const dashboardRefreshFunction = inngest.createFunction(
   async ({ event, step }) => {
     const {
       dashboardId,
+      workspaceId,
       dataSourceIds,
       force,
       triggerType,
       queuedRunIdsByDataSourceId,
     } = event.data as {
       dashboardId: string;
+      workspaceId?: string;
       dataSourceIds?: string[];
       queuedRunIdsByDataSourceId?: Record<string, string>;
       force?: boolean;
@@ -70,6 +78,7 @@ export const dashboardRefreshFunction = inngest.createFunction(
 
     logger.info("Refreshing dashboard data sources", {
       dashboardId,
+      workspaceId: workspaceId ?? dashboard.workspaceId?.toString(),
       dataSourceCount: filteredDataSources.length,
       workerId: WORKER_ID,
     });
@@ -112,7 +121,7 @@ export const dashboardSchedulerFunction = inngest.createFunction(
       return Dashboard.find({
         "materializationSchedule.enabled": true,
         "materializationSchedule.cron": { $type: "string", $ne: "" },
-      }).select("_id cache dataSources materializationSchedule");
+      }).select("_id workspaceId cache dataSources materializationSchedule");
     })) as any[];
 
     let triggered = 0;
@@ -136,6 +145,15 @@ export const dashboardSchedulerFunction = inngest.createFunction(
       }
 
       if (isDue && dashboard.dataSources?.length > 0) {
+        const workspaceId = dashboard.workspaceId?.toString();
+        if (!workspaceId) {
+          logger.warn(
+            "Skipping scheduled refresh: dashboard missing workspaceId",
+            { dashboardId: dashboard._id.toString() },
+          );
+          continue;
+        }
+
         await Dashboard.findByIdAndUpdate(dashboard._id, {
           $set: { "cache.lastRefreshedAt": new Date() },
         });
@@ -143,6 +161,7 @@ export const dashboardSchedulerFunction = inngest.createFunction(
           name: "dashboard.refresh",
           data: {
             dashboardId: dashboard._id.toString(),
+            workspaceId,
             triggerType: "schedule",
             force: true,
           },


### PR DESCRIPTION
## Summary
- Cap concurrent `dashboard-refresh` runs **per workspace** (default **2**), in addition to 1 per `dashboardId`.
- Tunable via `DASHBOARD_REFRESH_CONCURRENCY_PER_WORKSPACE`.
- Scheduler now puts `workspaceId` on `dashboard.refresh` events (manual queue path already did via `queueDashboardArtifactRefresh`).

## Why
Per-dashboard concurrency alone let N scheduled Experiment / VS funnel dashboards in the same workspace rematerialize in parallel and starve shared BigQuery reservations. A global cap would unfairly throttle unrelated workspaces; connection-keyed caps are awkward because one dashboard can span multiple connections.

## Test plan
- [ ] Deploy API / confirm Inngest syncs the updated concurrency config
- [ ] Trigger several refreshes in one workspace → at most ~2 concurrent for that `workspaceId`
- [ ] Confirm another workspace can still refresh in parallel
- [ ] Confirm scheduled refreshes include `workspaceId` in Inngest event payloads
- [ ] Optional: set `DASHBOARD_REFRESH_CONCURRENCY_PER_WORKSPACE=1` during an incident