### PR TITLE
Consolidate duplicate agent tools; keep old names as deferred aliases

### DIFF
--- a/api/src/agent-skills/apps/SKILL.md
+++ b/api/src/agent-skills/apps/SKILL.md
@@ -157,7 +157,7 @@ preview; headless MCP renders server-side); `open_app` just focuses a UI tab.
 
    The token resolves to the dbt project's PROD-like environment schema for
    published apps, parquet materialization, and public shares. In the DRAFT
-   preview it can be switched per user with `app_set_preview_environment`
+   preview it can be switched per user with `app_set_preview`
    (e.g. to a personal `dbt_<user>` schema) to verify an app against
    freshly-built dev models WITHOUT affecting other editors or viewers —
    pass `environment: null` to reset to prod. While an override is active,
@@ -204,7 +204,7 @@ to the render viewport, so a run at phone size IS the mobile check:
   `width: 390, height: 844` (phone) and once at the default desktop viewport,
   and fix what breaks. In a browser the phone-size render is applied for that
   render only — the user's preview viewport is restored afterward.
-- **Iterating on mobile fixes in chat/Desktop**: `app_set_preview_viewport`
+- **Iterating on mobile fixes in chat/Desktop**: `app_set_preview`
   with `preset: "phone"` (or `"tablet"`, or custom `width`/`height`) switches
   the on-screen preview so you and the user look at the same mobile layout
   while you edit; `preset: "desktop"` resets. This is per-user view state —

--- a/api/src/agent-skills/dashboards/SKILL.md
+++ b/api/src/agent-skills/dashboards/SKILL.md
@@ -62,8 +62,7 @@ Dashboards use a draft → published split:
 
 **Dashboard Management:**
 * `create_dashboard` — Create a brand new empty dashboard. After creation, use `create_data_source` to add data. Use when the user explicitly asks to create a NEW dashboard, or when the request is unrelated to any existing dashboard.
-* `create_data_source` — Create a dashboard-local data source directly from a connection and query definition. Requires `dashboardId`.
-* `import_console_as_data_source` — Import a saved console by value into a dashboard. Requires `dashboardId`.
+* `create_data_source` — Create a dashboard-local data source: either directly from a connection and query definition, or pass `consoleId` to import a saved console by value. Requires `dashboardId`.
 * `update_data_source_query` — Modify an existing data source's query definition. By default this only saves the definition; it does NOT rerun the query. Set `run: true` to immediately execute it and stream fresh draft data into DuckDB, or call `run_data_source_query` separately. Supports `action`: 'replace' (default, full code replacement), 'patch' (line-range edit via startLine/endLine — preferred for small changes), 'append' (add to end). Non-code fields are always shallow-merged.
 * `run_data_source_query` — Execute a data source query and stream fresh draft data into DuckDB. Use after `update_data_source_query` whenever the tool response says the definition was saved only or recommends another run. Automatically recovers if DuckDB crashes. Requires `dashboardId`.
 * `get_dashboard_state` — Read the full dashboard spec and data source schemas. Requires `dashboardId`.
@@ -79,8 +78,7 @@ Dashboards use a draft → published split:
 * `remove_widget` — Remove a widget. Requires `dashboardId`.
 
 **Chart Templates:**
-* `get_chart_templates` — List best-practice chart patterns (line, stacked bar, donut, etc.)
-* `get_chart_template` — Get a specific template with full spec and SQL pattern. Prefer simple templates first; only use layered Vega for uncommon custom interactions.
+* `get_chart_template` — Get a specific template with full spec and SQL pattern, or omit `templateId` to list best-practice chart patterns (line, stacked bar, donut, etc.). Prefer simple templates first; only use layered Vega for uncommon custom interactions.
 
 **Filters & Relationships:**
 * `add_global_filter` — Add a dashboard-level filter. Requires `dashboardId`.
@@ -101,7 +99,7 @@ Load these tier-3 references with `read_skill_resource` only when the task needs
 **Working with an existing dashboard (most common):**
 1. Use `list_open_dashboards` to get the dashboard ID. If the dashboard isn't open, use `search_dashboards` then `open_dashboard`.
 2. Use `enter_edit_mode` with the `dashboardId` before making changes.
-3. When a saved console already contains the query (or something close), PREFER `search_consoles` + `import_console_as_data_source` — it copies the console's code and connection by reference, so you never re-type the SQL. Only use `create_data_source` to define a genuinely new query from scratch. Pass `dashboardId` to both.
+3. When a saved console already contains the query (or something close), PREFER `search_consoles` + `create_data_source` with `consoleId` — it copies the console's code and connection by value, so you never re-type the SQL. Only define a query from scratch (connectionId + code) when no console fits. Pass `dashboardId` either way.
 4. Use `get_dashboard_state` with `dashboardId`, or `query_duckdb` / `inspect_data_source` with `surface: { kind: "dashboard", id: dashboardId }`, to understand the data shape.
 5. Use `add_widget` with `dashboardId` to create charts, KPIs, or tables.
 

--- a/api/src/agent-skills/dbt/SKILL.md
+++ b/api/src/agent-skills/dbt/SKILL.md
@@ -232,7 +232,7 @@ The full safe-iteration loop:
    `dbt_run_model` (defaults: the user's dev environment — dev itself when
    solo, personal `dbt_<user>` in teams (auto-provisioned on first build) —
    + defer to prod manifest).
-2. `app_set_preview_environment` with the personal environment — the app's
+2. `app_set_preview` with `environment` set to the personal one — the app's
    DRAFT preview now reads the freshly built schema. This is per-user view
    state: other editors, the published app, and shared links keep reading
    prod. Verify visually (screenshot) if useful.
@@ -240,7 +240,7 @@ The full safe-iteration loop:
    (after review) `dbt_merge_pull_request`; then run the prod job via
    `dbt_run_job` — ONLY with explicit user confirmation.
 4. After the prod build succeeds, reset the preview
-   (`app_set_preview_environment` with `environment: null`) and, if app code
+   (`app_set_preview` with `environment: null`) and, if app code
    changed, publish with `app_save_version`.
 
 ## Tier-3 references

--- a/api/src/agent-skills/flows/SKILL.md
+++ b/api/src/agent-skills/flows/SKILL.md
@@ -66,13 +66,13 @@ LIMIT {{limit}}
 4. **Write Query:** Create an appropriate query with template placeholders based on the user's needs.
 5. **Validate Query:** Use `validate_query` to test the query BEFORE setting form fields. This returns columns and sample data so you can verify it works. Template placeholders like `{{limit}}` are automatically substituted with safe defaults during validation.
 6. **⭐ Get Source Schema (CRITICAL):** Use `sql_inspect_table` to get the authoritative source column types (declared types, nullability). If you need more information, use `execute_query` to run any query - introspection queries, NULL checks, data sampling, etc.
-7. **Set Schema Mappings:** Use `set_form_field` with `fieldName="typeCoercions"` to set column type mappings. Each item has: `column` (name), `sourceType`, `targetType`, `nullable` (boolean), and optional `transformer`. Explain your reasoning to the user.
+7. **Set Schema Mappings:** Use `set_multiple_fields` with a `"typeCoercions"` key to set column type mappings. Each item has: `column` (name), `sourceType`, `targetType`, `nullable` (boolean), and optional `transformer`. Explain your reasoning to the user.
 8. **Discover Destination Options:** 
    - Use `sql_list_databases` on the destination connection to get available databases/datasets
    - **For BigQuery:** You MUST set `tableDestination.schema` (the dataset name). If not specified by user, ask which dataset to use.
    - **For PostgreSQL:** Optionally set `tableDestination.schema` for the schema (defaults to "public")
 9. **Configure Settings:** Set pagination mode, sync mode, conflict resolution, etc.
-10. **Set Query:** Once validated and schema mapped, use `set_form_field` or `set_multiple_fields` to update the form.
+10. **Set Query:** Once validated and schema mapped, use `set_multiple_fields` to update the form.
 
 **⚠️ IMPORTANT:** Before configuring the destination, ALWAYS:
 1. Check the destination connection type (use `list_connections`)
@@ -97,14 +97,13 @@ Flow-specific discovery tools:
 
 **Form Manipulation (Client-side):**
 * `get_form_state` - Read current form configuration values
-* `set_form_field` - Update a single form field using nested path (e.g., "databaseSource.query", "schedule.cron", "tableDestination.tableName")
-* `set_multiple_fields` - Update multiple fields at once using nested paths
+* `set_multiple_fields` - Update one or more fields at once using nested paths (e.g., "databaseSource.query", "schedule.cron", "tableDestination.tableName")
 
 **IMPORTANT:** 
 1. Use `validate_query` (server-side) to test queries first
 2. Use `sql_inspect_table` to get the authoritative source column types
 3. Use `execute_query` if you need to run additional queries (introspection, NULL checks, data sampling)
-4. Use `set_form_field` with `fieldName="typeCoercions"` to apply type mappings (array of {column, sourceType, targetType, nullable, transformer})
+4. Use `set_multiple_fields` with a `"typeCoercions"` key to apply type mappings (array of {column, sourceType, targetType, nullable, transformer})
 
 ---
 
@@ -213,7 +212,7 @@ After writing and validating the query, you MUST get the source schema to propos
    - TEXT columns with JSON data → suggest JSON type for structured storage
    - Columns named `*_at` or `*_time` with DATETIME type → TIMESTAMP
    - Ask user if unsure about ambiguous mappings
-5. **Set the mappings** using `set_form_field` with fieldName="typeCoercions" - each item: {column, sourceType, targetType, nullable, transformer}
+5. **Set the mappings** using `set_multiple_fields` with a "typeCoercions" key - each item: {column, sourceType, targetType, nullable, transformer}
 6. **Explain your choices** to the user so they can make informed edits
 
 **Example Reasoning:**

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -118,8 +118,8 @@ with \`browse_version_history\` (\`entityType: "dashboard"\`) and revert with
 \`dashboard_restore_version\` (reverts the draft; publish afterward to push live).
 
 When a saved console already contains the query you need, prefer \`search_consoles\` +
-\`import_console_as_data_source\` (copies its code and connection by reference) over
-re-typing the SQL with \`create_data_source\`.
+\`create_data_source\` with \`consoleId\` (copies the console's code and connection by value)
+over re-typing the SQL from scratch.
 
 For dashboard creation, editing, widget SQL, Vega-Lite specs, layout, and cross-filtering
 guidance, load the \`dashboards\` system skill. If that skill points to a needed

--- a/api/src/agents/modes/registry.ts
+++ b/api/src/agents/modes/registry.ts
@@ -63,6 +63,20 @@ export const DEFERRED_BUILTIN_TOOL_DOMAINS: Readonly<Record<string, string>> = {
   // external MCP clients; the in-product agent uses the merged tool.
   app_set_binding_materialization: "apps",
   app_set_binding_schedule: "apps",
+  // Deprecated aliases of app_set_preview (environment + viewport folded into
+  // one preview setter). Kept executable for old chats.
+  app_set_preview_environment: "apps",
+  app_set_preview_viewport: "apps",
+  // Deprecated single-field alias of set_multiple_fields (which updates one
+  // or many fields). Its FIELD_PATHS enum makes it one of the heaviest
+  // schemas in the catalog, so it stays out of the flow working set.
+  set_form_field: "flows",
+  // Deprecated aliases of create_data_source({ consoleId }) — both imported a
+  // saved console into a dashboard by value. Kept executable for old chats.
+  import_console_as_data_source: "dashboards",
+  add_data_source: "dashboards",
+  // Deprecated alias of get_chart_template without templateId (lists all).
+  get_chart_templates: "dashboards",
 };
 
 export const DEFERRED_BUILTIN_TOOL_NAMES: readonly string[] = Object.keys(
@@ -109,8 +123,6 @@ const DASHBOARD_MODE_TOOL_NAMES: string[] = [
   "open_dashboard",
   "enter_edit_mode",
   "create_dashboard",
-  "import_console_as_data_source",
-  "add_data_source",
   "create_data_source",
   "update_data_source_query",
   "run_data_source_query",
@@ -126,7 +138,6 @@ const DASHBOARD_MODE_TOOL_NAMES: string[] = [
   "remove_global_filter",
   "link_tables",
   "set_time_dimension",
-  "get_chart_templates",
   "get_chart_template",
   "dashboard_save_version",
   "dashboard_restore_version",
@@ -150,7 +161,6 @@ const FLOW_MODE_TOOL_NAMES: string[] = [
   "explain_template",
   // Client flow form tools
   "get_form_state",
-  "set_form_field",
   "set_multiple_fields",
   "create_flow_tab",
   "list_flow_tabs",
@@ -184,8 +194,7 @@ const APP_MODE_TOOL_NAMES: string[] = [
   "get_version_snapshot",
   "materialize_binding",
   "run_app",
-  "app_set_preview_environment",
-  "app_set_preview_viewport",
+  "app_set_preview",
   // Shared surface-scoped data-source primitives (apps + dashboards)
   "list_data_sources",
   "inspect_data_source",

--- a/app/src/agent-runtime/client-tool-manifest.ts
+++ b/app/src/agent-runtime/client-tool-manifest.ts
@@ -285,7 +285,13 @@ export const AGENT_TOOL_MANIFEST = {
     clientExecutor: "dashboard",
     longRunning: true,
     getLabel: input => {
-      const name = (input as Record<string, unknown>)?.name;
+      const inp = input as Record<string, unknown>;
+      const name = inp?.name;
+      if (inp?.consoleId) {
+        return name
+          ? `Importing console as "${name}"`
+          : "Importing console as data source";
+      }
       return name ? `Creating data source "${name}"` : "Creating data source";
     },
     icon: "plus",
@@ -665,6 +671,30 @@ export const AGENT_TOOL_MANIFEST = {
     execution: "client",
     clientExecutor: "app",
     getLabel: () => "Checking preview errors",
+    icon: "eye",
+  },
+  app_set_preview: {
+    domain: "app",
+    execution: "client",
+    clientExecutor: "app",
+    longRunning: true,
+    getLabel: input => {
+      const { environment, preset, width, height } = (input ?? {}) as {
+        environment?: string | null;
+        preset?: string;
+        width?: number;
+        height?: number;
+      };
+      const parts: string[] = [];
+      if (width && height) parts.push(`${width}×${height}`);
+      else if (preset) parts.push(preset);
+      if (environment !== undefined) {
+        parts.push(environment ? `dbt env "${environment}"` : "dbt env prod");
+      }
+      return parts.length > 0
+        ? `Preview: ${parts.join(", ")}`
+        : "Configuring preview";
+    },
     icon: "eye",
   },
   app_set_preview_environment: {

--- a/app/src/app-runtime/agent-tools.run-app.test.ts
+++ b/app/src/app-runtime/agent-tools.run-app.test.ts
@@ -190,7 +190,53 @@ describe("run_app client executor", () => {
   });
 });
 
-describe("app_set_preview_viewport client executor", () => {
+describe("app_set_preview client executor", () => {
+  it("sets a named preset as sticky view state via the merged tool", async () => {
+    const result = await executeAppAgentTool("app_set_preview", {
+      appId: APP_ID,
+      preset: "phone",
+    });
+    expect(result).toMatchObject({
+      success: true,
+      viewport: { width: 390, height: 844, preset: "phone" },
+    });
+    expect(useAppStore.getState().previewViewport[APP_ID]).toEqual({
+      width: 390,
+      height: 844,
+      preset: "phone",
+    });
+  });
+
+  it("requires at least one of viewport or environment", async () => {
+    const result = await executeAppAgentTool("app_set_preview", {
+      appId: APP_ID,
+    });
+    expect(result).toMatchObject({ success: false });
+    expect(String(result.error)).toMatch(/at least one/);
+  });
+
+  it("reports an applied viewport when the environment leg fails", async () => {
+    // getCurrentWorkspaceId is mocked to null, so the environment leg fails
+    // after the viewport leg already applied.
+    const result = await executeAppAgentTool("app_set_preview", {
+      appId: APP_ID,
+      preset: "tablet",
+      environment: "dev",
+    });
+    expect(result).toMatchObject({
+      success: false,
+      viewport: { width: 768, height: 1024, preset: "tablet" },
+    });
+    expect(String(result.note)).toMatch(/viewport change was applied/);
+    expect(useAppStore.getState().previewViewport[APP_ID]).toEqual({
+      width: 768,
+      height: 1024,
+      preset: "tablet",
+    });
+  });
+});
+
+describe("app_set_preview_viewport client executor (deprecated alias)", () => {
   it("sets a named preset as sticky view state", async () => {
     const result = await executeAppAgentTool("app_set_preview_viewport", {
       appId: APP_ID,

--- a/app/src/app-runtime/agent-tools.ts
+++ b/app/src/app-runtime/agent-tools.ts
@@ -162,6 +162,89 @@ export async function executeAppAgentTool(
     if (workspaceId && appId) await store.persistApp(workspaceId, appId);
   };
 
+  // Viewport leg of app_set_preview (and its deprecated alias
+  // app_set_preview_viewport): sticky per-user preview viewport.
+  const applyPreviewViewport = async (
+    id: string,
+    legInput: Record<string, unknown>,
+  ): Promise<ToolResult> => {
+    await ensureApp(id);
+    const width =
+      typeof legInput.width === "number" ? legInput.width : undefined;
+    const height =
+      typeof legInput.height === "number" ? legInput.height : undefined;
+    const preset = legInput.preset as
+      | "phone"
+      | "tablet"
+      | "desktop"
+      | undefined;
+    let viewport: AppPreviewViewport | null;
+    if (width !== undefined && height !== undefined) {
+      viewport = { width, height };
+    } else if (width !== undefined || height !== undefined) {
+      return fail("Pass both width and height for a custom viewport.");
+    } else if (preset === "phone" || preset === "tablet") {
+      viewport = { ...APP_PREVIEW_VIEWPORT_PRESETS[preset], preset };
+    } else if (preset === "desktop") {
+      viewport = null;
+    } else {
+      return fail(
+        "Pass preset ('phone' | 'tablet' | 'desktop') or width + height.",
+      );
+    }
+    store.setPreviewViewport(id, viewport);
+    return {
+      success: true,
+      viewport,
+      hint: viewport
+        ? `Preview now renders at ${viewport.width}×${viewport.height} for you AND the user — no rebuild needed. Verify with run_app; reset with preset: "desktop".`
+        : "Preview viewport reset — the app fills the pane again.",
+    };
+  };
+
+  // Environment leg of app_set_preview (and its deprecated alias
+  // app_set_preview_environment): per-user dbt environment override.
+  const applyPreviewEnvironment = async (
+    id: string,
+    legInput: Record<string, unknown>,
+  ): Promise<ToolResult> => {
+    if (!workspaceId) return fail("No active workspace");
+    const appEntity = await ensureApp(id);
+    if (!appEntity) return fail("App not found");
+    const environment = (legInput.environment ?? null) as string | null;
+    const dbtProjectId = appEntity.dataBindings.find(
+      b => b.dbtProjectId,
+    )?.dbtProjectId;
+    if (!dbtProjectId) {
+      return fail(
+        "This app has no dbt-linked data bindings. Link a binding to a " +
+          "dbt project (dbtProjectId + the {{ dbt_schema }} token) first.",
+      );
+    }
+    if (environment) {
+      const info = await store.fetchDbtEnvInfo(workspaceId, dbtProjectId);
+      if (!info) return fail("Failed to load the linked dbt project");
+      if (!info.environments.some(env => env.name === environment)) {
+        return fail(
+          `Environment "${environment}" not found on the linked dbt ` +
+            `project. Available: ${info.environments
+              .map(env => env.name)
+              .join(", ")}`,
+        );
+      }
+    }
+    store.setPreviewDbtEnvironment(id, environment);
+    return {
+      success: true,
+      appId: id,
+      environment,
+      hint: environment
+        ? `Draft preview now reads dbt environment "${environment}". This ` +
+          "is your view only — published/shared viewers still read prod."
+        : "Draft preview reset to the default (prod) dbt environment.",
+    };
+  };
+
   switch (toolName) {
     case "list_open_apps":
       return { success: true, apps: listOpenApps() };
@@ -634,74 +717,52 @@ export async function executeAppAgentTool(
       }
     }
 
-    case "app_set_preview_viewport": {
+    // app_set_preview merges the two deprecated per-leg setters below; all
+    // three share the same viewport/environment legs.
+    case "app_set_preview": {
       if (!appId) return fail("appId is required");
-      await ensureApp(appId);
-      const width = typeof input.width === "number" ? input.width : undefined;
-      const height =
-        typeof input.height === "number" ? input.height : undefined;
-      const preset = input.preset as "phone" | "tablet" | "desktop" | undefined;
-      let viewport: AppPreviewViewport | null;
-      if (width !== undefined && height !== undefined) {
-        viewport = { width, height };
-      } else if (width !== undefined || height !== undefined) {
-        return fail("Pass both width and height for a custom viewport.");
-      } else if (preset === "phone" || preset === "tablet") {
-        viewport = { ...APP_PREVIEW_VIEWPORT_PRESETS[preset], preset };
-      } else if (preset === "desktop") {
-        viewport = null;
-      } else {
+      const wantsViewport =
+        input.preset !== undefined ||
+        input.width !== undefined ||
+        input.height !== undefined;
+      const wantsEnvironment = input.environment !== undefined;
+      if (!wantsViewport && !wantsEnvironment) {
         return fail(
-          "Pass preset ('phone' | 'tablet' | 'desktop') or width + height.",
+          "Pass at least one of preset, width + height, or environment.",
         );
       }
-      store.setPreviewViewport(appId, viewport);
-      return {
-        success: true,
-        viewport,
-        hint: viewport
-          ? `Preview now renders at ${viewport.width}×${viewport.height} for you AND the user — no rebuild needed. Verify with run_app; reset with preset: "desktop".`
-          : "Preview viewport reset — the app fills the pane again.",
-      };
+      const result: ToolResult = { success: true };
+      if (wantsViewport) {
+        const viewportResult = await applyPreviewViewport(appId, input);
+        if (viewportResult.success !== true) return viewportResult;
+        result.viewport = viewportResult.viewport;
+        result.viewportHint = viewportResult.hint;
+      }
+      if (wantsEnvironment) {
+        const envResult = await applyPreviewEnvironment(appId, input);
+        if (envResult.success !== true) {
+          return wantsViewport
+            ? {
+                ...envResult,
+                viewport: result.viewport,
+                note: "The viewport change was applied; the environment change failed.",
+              }
+            : envResult;
+        }
+        result.environment = envResult.environment;
+        result.environmentHint = envResult.hint;
+      }
+      return result;
+    }
+
+    case "app_set_preview_viewport": {
+      if (!appId) return fail("appId is required");
+      return applyPreviewViewport(appId, input);
     }
 
     case "app_set_preview_environment": {
       if (!appId) return fail("appId is required");
-      if (!workspaceId) return fail("No active workspace");
-      const appEntity = await ensureApp(appId);
-      if (!appEntity) return fail("App not found");
-      const environment = (input.environment ?? null) as string | null;
-      const dbtProjectId = appEntity.dataBindings.find(
-        b => b.dbtProjectId,
-      )?.dbtProjectId;
-      if (!dbtProjectId) {
-        return fail(
-          "This app has no dbt-linked data bindings. Link a binding to a " +
-            "dbt project (dbtProjectId + the {{ dbt_schema }} token) first.",
-        );
-      }
-      if (environment) {
-        const info = await store.fetchDbtEnvInfo(workspaceId, dbtProjectId);
-        if (!info) return fail("Failed to load the linked dbt project");
-        if (!info.environments.some(env => env.name === environment)) {
-          return fail(
-            `Environment "${environment}" not found on the linked dbt ` +
-              `project. Available: ${info.environments
-                .map(env => env.name)
-                .join(", ")}`,
-          );
-        }
-      }
-      store.setPreviewDbtEnvironment(appId, environment);
-      return {
-        success: true,
-        appId,
-        environment,
-        hint: environment
-          ? `Draft preview now reads dbt environment "${environment}". This ` +
-            "is your view only — published/shared viewers still read prod."
-          : "Draft preview reset to the default (prod) dbt environment.",
-      };
+      return applyPreviewEnvironment(appId, input);
     }
 
     default:

--- a/app/src/dashboard-runtime/agent-tools.ts
+++ b/app/src/dashboard-runtime/agent-tools.ts
@@ -420,7 +420,10 @@ export async function executeDashboardAgentTool(
 
   if (
     toolName === "add_data_source" ||
-    toolName === "import_console_as_data_source"
+    toolName === "import_console_as_data_source" ||
+    // create_data_source with consoleId imports the console by value — same
+    // path as the deprecated import aliases above.
+    (toolName === "create_data_source" && typeof input.consoleId === "string")
   ) {
     const ctx = requireDashboardId(input);
     if (!ctx) {
@@ -481,13 +484,22 @@ export async function executeDashboardAgentTool(
     }
 
     if (typeof input.name !== "string") {
-      return { success: false, error: "name is required" };
+      return {
+        success: false,
+        error: "name is required (unless consoleId is given)",
+      };
     }
     if (typeof input.connectionId !== "string") {
-      return { success: false, error: "connectionId is required" };
+      return {
+        success: false,
+        error: "connectionId is required (unless consoleId is given)",
+      };
     }
     if (typeof input.code !== "string") {
-      return { success: false, error: "code is required" };
+      return {
+        success: false,
+        error: "code is required (unless consoleId is given)",
+      };
     }
 
     try {
@@ -789,13 +801,14 @@ export async function executeDashboardAgentTool(
 
   if (toolName === "get_chart_template") {
     if (typeof input.templateId !== "string") {
-      return { success: false, error: "templateId is required" };
+      // No templateId = list mode (folded in from get_chart_templates).
+      return { success: true, templates: getAllTemplates() };
     }
     const tpl = getTemplate(input.templateId);
     if (!tpl) {
       return {
         success: false,
-        error: `Template "${input.templateId}" not found. Call get_chart_templates to see available IDs.`,
+        error: `Template "${input.templateId}" not found. Call get_chart_template without templateId to see available IDs.`,
       };
     }
     return { success: true, template: tpl };

--- a/docs/src/content/docs/apps.md
+++ b/docs/src/content/docs/apps.md
@@ -88,7 +88,7 @@ The draft preview can render at phone or tablet size so you can check responsive
 
 The choice is per-user view state (remembered per app, like the dbt environment switcher) — it never changes the app definition, and published/shared viewers are unaffected.
 
-The AI agent verifies mobile layouts the same way: it runs `run_app` with an explicit `width`/`height` (e.g. 390×844 for phone) and inspects the screenshot, or switches your on-screen preview with `app_set_preview_viewport` while iterating in chat.
+The AI agent verifies mobile layouts the same way: it runs `run_app` with an explicit `width`/`height` (e.g. 390×844 for phone) and inspects the screenshot, or switches your on-screen preview with `app_set_preview` while iterating in chat.
 
 ## Versioning & Publishing
 

--- a/packages/agent-tools/src/app-tools.ts
+++ b/packages/agent-tools/src/app-tools.ts
@@ -815,19 +815,59 @@ export const clientAppTools = {
       "status/errors (much cheaper).",
     inputSchema: runAppBaseSchema,
   }),
+  app_set_preview: tool({
+    description:
+      "Configure the app's DRAFT PREVIEW: a device viewport (preset phone " +
+      "390x844 / tablet 768x1024 / desktop = fill the pane, or custom " +
+      "width/height — media queries re-evaluate, no rebuild) and/or which " +
+      "dbt ENVIRONMENT it reads data from (for dbt-linked bindings using the " +
+      "{{ dbt_schema }} token; null resets to prod). Pass at least one of " +
+      "preset, width+height, or environment. This is per-user VIEW state — " +
+      "it never changes the app definition or what published/shared viewers " +
+      "see (those always read prod). While a dbt override is active, " +
+      "dbt-linked parquet bindings serve a live (row-capped) run against the " +
+      "override schema — do NOT call materialize_binding to preview dev data " +
+      "(materialization always builds from prod). For a one-off size check " +
+      "without changing what's on screen, pass width/height to run_app " +
+      "instead.",
+    inputSchema: z.object({
+      appId: appIdField,
+      preset: z
+        .enum(["phone", "tablet", "desktop"])
+        .optional()
+        .describe(
+          "Named viewport: phone 390x844, tablet 768x1024, desktop = clear " +
+            "the override (fill the pane). Ignored when width/height are set.",
+        ),
+      width: z
+        .number()
+        .int()
+        .min(RUN_APP_MIN_VIEWPORT_PX)
+        .max(RUN_APP_MAX_VIEWPORT_PX)
+        .optional()
+        .describe("Custom viewport width in px (with height)"),
+      height: z
+        .number()
+        .int()
+        .min(RUN_APP_MIN_VIEWPORT_PX)
+        .max(RUN_APP_MAX_VIEWPORT_PX)
+        .optional()
+        .describe("Custom viewport height in px (with width)"),
+      environment: z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          "dbt environment name from the linked project (e.g. 'dev' or a " +
+            "personal environment), or null to reset to the prod default. " +
+            "Omit to leave the environment unchanged.",
+        ),
+    }),
+  }),
   app_set_preview_environment: tool({
     description:
-      "Switch which dbt ENVIRONMENT the app's DRAFT PREVIEW reads data from " +
-      "(for dbt-linked bindings using the {{ dbt_schema }} token). This is " +
-      "per-user VIEW state — it never changes the app definition, other " +
-      "editors' previews, or what published/shared viewers see (those always " +
-      "read the prod environment). While an override is active, dbt-linked " +
-      "parquet bindings serve a live (row-capped) run against the override " +
-      "schema — useQuery, useDuckDB, and query_duckdb all read it; do NOT " +
-      "call materialize_binding to preview dev data (materialization always " +
-      "builds from prod). Pass environment: null to go back to the default " +
-      "(prod). Use it to verify an app against models you just built in a " +
-      "dev/personal schema before promoting them to prod.",
+      "Deprecated alias of app_set_preview({ environment }) — switch which " +
+      "dbt environment the app's draft preview reads data from.",
     inputSchema: z.object({
       appId: appIdField,
       environment: z
@@ -841,13 +881,8 @@ export const clientAppTools = {
   }),
   app_set_preview_viewport: tool({
     description:
-      "Switch the app's DRAFT PREVIEW to a device viewport (phone 390x844, " +
-      "tablet 768x1024, or custom width/height) so you AND the user see the " +
-      "responsive layout while iterating — media queries re-evaluate at the " +
-      "new size, no rebuild. This is per-user VIEW state; it never changes " +
-      "the app definition or what viewers see. Pass preset: 'desktop' to go " +
-      "back to filling the pane. For a one-off verification without changing " +
-      "what's on screen, pass width/height to run_app instead.",
+      "Deprecated alias of app_set_preview({ preset | width+height }) — " +
+      "switch the app's draft preview to a device viewport.",
     inputSchema: z.object({
       appId: appIdField,
       preset: z

--- a/packages/agent-tools/src/capabilities/app-capabilities.ts
+++ b/packages/agent-tools/src/capabilities/app-capabilities.ts
@@ -238,6 +238,34 @@ export const APP_CAPABILITIES = [
     desktopDelivery: "mako-desktop",
   }),
   define({
+    // Merged preview setter (viewport + dbt environment). The environment leg
+    // keeps app_set_preview_environment's artifact-write gate, applied only
+    // when the input actually switches the environment; viewport-only calls
+    // are pure per-user view state.
+    name: "app_set_preview",
+    pack: "app-ui",
+    risk: "write",
+    inputConditionalGrants: [
+      {
+        grant: "artifact-write",
+        behavior: "switching the draft preview's dbt environment",
+        appliesTo: input =>
+          typeof input === "object" &&
+          input !== null &&
+          (input as { environment?: unknown }).environment !== undefined,
+      },
+    ],
+    surfaces: IN_CHAT_ONLY_SURFACES,
+    resultKind: "ui-effect",
+    mcpExclusion: {
+      why: "client-only",
+      note: "Per-user browser preview state; headless agents pass width/height to run_app.",
+    },
+  }),
+  define({
+    // Deprecated alias of app_set_preview({ environment }); kept registered
+    // for old chats. Deferred out of the in-product working set (see
+    // DEFERRED_BUILTIN_TOOL_DOMAINS).
     name: "app_set_preview_environment",
     pack: "app-ui",
     risk: "write",
@@ -250,7 +278,8 @@ export const APP_CAPABILITIES = [
     },
   }),
   define({
-    // Pure view state (which viewport the browser preview renders at) — the
+    // Deprecated alias of app_set_preview({ preset | width+height }). Pure
+    // view state (which viewport the browser preview renders at) — the
     // sticky sibling of run_app's ephemeral width/height. Mutates nothing
     // durable, so read-risk; headless agents pass width/height to run_app.
     name: "app_set_preview_viewport",

--- a/packages/agent-tools/src/chart-tools.ts
+++ b/packages/agent-tools/src/chart-tools.ts
@@ -53,11 +53,16 @@ export const clientChartTools = {
     description:
       "Get a best-practice chart template with full vegaLiteSpec, SQL pattern, and implementation notes. " +
       "Use for complex patterns (e.g. multi-series hover rule, stacked bar, donut) instead of inventing specs from scratch. " +
-      "Available IDs: multi-series-line-hover, time-series-area, grouped-bar, stacked-bar, horizontal-ranking, donut, kpi-sparkline.",
+      "Available IDs: multi-series-line-hover, time-series-area, grouped-bar, stacked-bar, horizontal-ranking, donut, kpi-sparkline. " +
+      "Omit templateId to list all templates with descriptions.",
     inputSchema: z.object({
       templateId: z
         .string()
-        .describe("Template ID (e.g. 'multi-series-line-hover', 'donut')"),
+        .optional()
+        .describe(
+          "Template ID (e.g. 'multi-series-line-hover', 'donut'). Omit to " +
+            "list all available templates.",
+        ),
     }),
   }),
 };

--- a/packages/agent-tools/src/dashboard-tools.ts
+++ b/packages/agent-tools/src/dashboard-tools.ts
@@ -192,15 +192,39 @@ const importConsoleAsDataSourceSchema = z.object({
 
 const createDataSourceSchema = z.object({
   dashboardId: z.string().describe("Dashboard ID to add the data source to"),
-  name: z.string().describe("Dashboard-local data source name"),
+  name: z
+    .string()
+    .optional()
+    .describe(
+      "Dashboard-local data source name. Required unless consoleId is given " +
+        "(then defaults to the console's name).",
+    ),
+  consoleId: z
+    .string()
+    .optional()
+    .describe(
+      "Import a saved console by ID (from search_consoles): its query code, " +
+        "connection, and language are copied by value, so you do not need to " +
+        "re-type the SQL. When set, omit connectionId/language/code.",
+    ),
   connectionId: z
     .string()
-    .describe("Connection ID to execute the query against"),
+    .optional()
+    .describe(
+      "Connection ID to execute the query against (required unless " +
+        "consoleId is given)",
+    ),
   language: z
     .enum(["sql", "javascript", "mongodb"])
-    .default("sql")
-    .describe("Query language"),
-  code: z.string().describe("Query text/code to materialize into DuckDB"),
+    .optional()
+    .describe("Query language (default sql)"),
+  code: z
+    .string()
+    .optional()
+    .describe(
+      "Query text/code to materialize into DuckDB (required unless " +
+        "consoleId is given)",
+    ),
   databaseId: z.string().optional().describe("Optional sub-database ID"),
   databaseName: z.string().optional().describe("Optional database name"),
   timeDimension: z.string().optional().describe("Default time column"),
@@ -326,20 +350,21 @@ export const clientDashboardTools = {
   }),
   import_console_as_data_source: tool({
     description:
-      "Import a saved console into a dashboard by value. " +
-      "This duplicates the console's query definition into a dashboard-local data source and materializes it into DuckDB. " +
-      "Use search_consoles first to find the console ID.",
+      "Deprecated alias of create_data_source({ consoleId }) — import a saved console into a dashboard by value. " +
+      "Prefer create_data_source with consoleId.",
     inputSchema: importConsoleAsDataSourceSchema,
   }),
   add_data_source: tool({
     description:
-      "Legacy alias for importing a saved console into the dashboard. Prefer import_console_as_data_source.",
+      "Legacy alias for importing a saved console into the dashboard. Prefer create_data_source with consoleId.",
     inputSchema: importConsoleAsDataSourceSchema,
   }),
   create_data_source: tool({
     description:
-      "Create a dashboard-local data source directly from a connection and query definition. " +
-      "Use this when the user wants to add data without saving a console first.",
+      "Create a dashboard-local data source. Either define the query from scratch " +
+      "(connectionId + code), or pass consoleId to import a saved console by value " +
+      "(copies its query, connection, and language — use search_consoles to find it). " +
+      "The query is materialized into DuckDB either way.",
     inputSchema: createDataSourceSchema,
   }),
   update_data_source_query: tool({
@@ -408,17 +433,24 @@ export const clientDashboardTools = {
   }),
   get_chart_templates: tool({
     description:
-      "List available best-practice chart templates with IDs and descriptions. " +
-      "Call before creating charts to discover proven simple patterns " +
-      "(e.g. multi-series line with hover rule, donut, stacked bar).",
+      "Deprecated alias of get_chart_template without templateId — lists available " +
+      "best-practice chart templates with IDs and descriptions.",
     inputSchema: z.object({}),
   }),
   get_chart_template: tool({
     description:
-      "Get a specific chart template with full vegaLiteSpec, SQL pattern, and implementation notes. " +
-      "Prefer template-driven simple specs over hand-written complex layering.",
+      "Get a best-practice chart template with full vegaLiteSpec, SQL pattern, and implementation notes. " +
+      "Omit templateId to list all available templates with IDs and descriptions. " +
+      "Prefer template-driven simple specs over hand-written complex layering " +
+      "(e.g. multi-series line with hover rule, donut, stacked bar).",
     inputSchema: z.object({
-      templateId: z.string().describe("Template ID from get_chart_templates"),
+      templateId: z
+        .string()
+        .optional()
+        .describe(
+          "Template ID (e.g. 'multi-series-line-hover', 'donut'). Omit to " +
+            "list all available templates.",
+        ),
     }),
   }),
   dashboard_save_version: tool({

--- a/packages/agent-tools/src/flow-tools.ts
+++ b/packages/agent-tools/src/flow-tools.ts
@@ -93,13 +93,18 @@ export const clientFlowTools = {
 
   set_form_field: tool({
     description:
-      'Update a single form field using nested path. Examples: "databaseSource.query", "schedule.cron", "tableDestination.tableName", "typeCoercions" (for column mappings array).',
+      "Deprecated alias of set_multiple_fields — update a single form field " +
+      "using a nested path. Prefer set_multiple_fields, which handles one or " +
+      "many fields.",
     inputSchema: setFormFieldSchema,
   }),
 
   set_multiple_fields: tool({
     description:
-      "Update multiple form fields at once. Use nested paths as keys.",
+      "Update one or more form fields at once. Use nested field paths as " +
+      'keys, e.g. "databaseSource.query", "schedule.cron", ' +
+      '"tableDestination.tableName", or "typeCoercions" (column mappings ' +
+      "array). Arrays and objects must be actual JSON, NOT stringified.",
     inputSchema: setMultipleFieldsSchema,
   }),
 

--- a/packages/agent-tools/src/run-app.ts
+++ b/packages/agent-tools/src/run-app.ts
@@ -30,7 +30,7 @@ export const RUN_APP_MAX_VIEWPORT_PX = 1920;
 
 /**
  * Named viewports for verifying responsive layouts. One list feeds the
- * preview toolbar toggle, the app_set_preview_viewport tool, and skill
+ * preview toolbar toggle, the app_set_preview tool, and skill
  * guidance — media queries respond to the (iframe or headless) viewport, so
  * rendering at these sizes IS the mobile/tablet layout check.
  */

--- a/packages/schemas/src/chart-templates.ts
+++ b/packages/schemas/src/chart-templates.ts
@@ -2,7 +2,7 @@
  * Chart Template Registry
  *
  * Named best-practice chart patterns that the AI agent can look up on demand
- * via `get_chart_templates` / `get_chart_template` tools. Each template
+ * via the `get_chart_template` tool (no templateId = list). Each template
  * provides a full working vegaLiteSpec, an example SQL pattern, and notes
  * about constraints and gotchas.
  *


### PR DESCRIPTION
## Summary

Five tool consolidations, all following the binding-fold recipe (`app_set_binding_*` → `app_update_data_binding`): merge each redundant pair into one tool, keep the old name registered and executable but demoted to `DEFERRED_BUILTIN_TOOL_DOMAINS` so it stays out of the per-request working set while old chats and external MCP callers keep working.

1. **`set_form_field` → deferred** — strictly subsumed by `set_multiple_fields` (now described as "one or more fields"). Its `FIELD_PATHS` enum made it a ~650-token schema, the heaviest tool in the Sync Flow working set. Flow skill docs now teach `set_multiple_fields` everywhere.
2. **`add_data_source` → deferred** — pure legacy alias with an identical schema, previously sitting in the Dashboard working set.
3. **`import_console_as_data_source` folded into `create_data_source`** — `create_data_source` gains an optional `consoleId` to seed from a saved console (mirroring `app_create_data_binding`); `name`/`connectionId`/`code` become "required unless consoleId is given". The client executor routes consoleId calls through the existing console-import path; the Dashboard mode prompt and skill now recommend `search_consoles` + `create_data_source({consoleId})`. Both import aliases deferred.
4. **`get_chart_templates` folded into `get_chart_template`** — `templateId` is now optional; omitting it returns the template list. Updated in both the dashboard and console tool definitions and the client executor.
5. **`app_set_preview_environment` + `app_set_preview_viewport` → `app_set_preview`** — one tool with optional `environment`, `preset`, `width`/`height` (at least one required; both legs can apply in one call, with a partial-failure note if the environment leg fails after the viewport applied). The capability entry keeps the environment leg's `artifact-write` gate as an input-conditional grant, exactly like the schedule leg of the binding fold.

## Measured effect

Per `pnpm --filter api tools:measure`:

- Sync Flow mode: **−650 tokens** (`set_form_field` out)
- Dashboard mode: **−340 tokens net** (455 removed; `create_data_source` +117 for the consoleId field)
- App/React mode: **−150 tokens** (581 → 430 for the merged preview setter)

## Notes for review

- `app_set_preview` is classified `risk: "write"` (the old viewport-only tool was `read`), so viewport changes are now plan-gated like environment changes — conservative; the read-only alias remains loadable if that matters.
- Client dispatch is manifest-driven, so the merged tools route automatically; deferred aliases stay dispatchable for replayed/old chats.

## Testing

- agent-tools package build + tests (24 pass)
- API: tier-policy/working-set test, derive-mode-state, MCP bridge inventory, prompt-size — all pass
- App: executor/manifest/chat-dispatch vitest suites (48 tests across the touched areas), incl. new coverage for the merged `app_set_preview` executor
- `tsc` typechecks clean for both `api` and `app`; eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EfStP3GH15MkqsMKx5ekW

---
_Generated by [Claude Code](https://claude.ai/code/session_019EfStP3GH15MkqsMKx5ekW)_