### PR TITLE
Fold notebook cell CRUD into edit_notebook_cell with a mode enum

### DIFF
--- a/api/src/agent-lib/tools/server-notebook-tools.ts
+++ b/api/src/agent-lib/tools/server-notebook-tools.ts
@@ -14,7 +14,9 @@ import { z } from "zod";
 import { randomUUID } from "crypto";
 import { Types } from "mongoose";
 import {
+  addNotebookCellSchema,
   applyStrReplace,
+  deleteNotebookCellSchema,
   editNotebookCellSchema,
   notebookCellResourceVersion,
   readNotebookCellRange,
@@ -23,6 +25,7 @@ import {
   searchNotebookCells,
   searchNotebookSchema,
   summarizeNotebookCell,
+  type EditNotebookCellInput,
 } from "@mako/agent-tools";
 
 import { getNotebookStore } from "../../notebooks/store";
@@ -68,13 +71,6 @@ const notebookIdField = z
   .string()
   .optional()
   .describe("Notebook id. Defaults to the notebook the user is viewing.");
-
-const cellTypeField = z
-  .enum(["code", "sql", "markdown"])
-  .describe(
-    "Cell type: 'sql' runs against a data source, 'code' is Python (managed " +
-      "kernel), 'markdown' renders as prose.",
-  );
 
 /** Truncate outputs so the persisted notebook doc stays small. */
 function capOutputs(outputs: KernelOutput[]): KernelOutput[] {
@@ -200,6 +196,133 @@ export function createNotebookServerTools({
       notebookId,
       title,
     });
+  };
+
+  // Shared cell CRUD: edit_notebook_cell dispatches on mode, and the
+  // deprecated add/delete aliases delegate here with mode preset.
+  const editCellImpl = async (input: EditNotebookCellInput) => {
+    const id = resolveId(input);
+    if (!id) return noNotebook;
+    const access = await assertWriteAccess(id);
+    if (!access.ok) return { success: false, error: access.error };
+    const doc = await store.get(workspaceId, id);
+    if (!doc) return { success: false, error: `Notebook ${id} not found` };
+    const mode = input.mode ?? "replace";
+
+    if (mode === "insert") {
+      if (!input.type) {
+        return { success: false, error: "type is required to insert a cell" };
+      }
+      const cell: NotebookBlock = {
+        id: randomUUID(),
+        type: input.type as NotebookBlockType,
+        source: input.source ?? "",
+        ...(input.connectionId ? { connectionId: input.connectionId } : {}),
+      };
+      const blocks = [...doc.blocks];
+      blocks.splice(input.atIndex ?? blocks.length, 0, cell);
+      const version = await saveBlocks(id, blocks, doc.version);
+      if (version === SAVE_CONFLICT) {
+        return {
+          success: false,
+          error: "Notebook changed while adding the cell. Re-read and retry.",
+        };
+      }
+      if (version == null) {
+        return { success: false, error: "Failed to add cell" };
+      }
+      return { success: true, cellId: cell.id, type: cell.type };
+    }
+
+    if (!input.cellId) {
+      return { success: false, error: `cellId is required to ${mode} a cell` };
+    }
+    const current = doc.blocks.find(block => block.id === input.cellId);
+    if (!current) {
+      return { success: false, error: `No cell with id "${input.cellId}"` };
+    }
+
+    if (mode === "delete") {
+      const version = await saveBlocks(
+        id,
+        doc.blocks.filter(b => b.id !== input.cellId),
+        doc.version,
+      );
+      if (version === SAVE_CONFLICT) {
+        return {
+          success: false,
+          error: "Notebook changed while deleting the cell. Re-read and retry.",
+        };
+      }
+      if (version == null) {
+        return { success: false, error: "Failed to delete cell" };
+      }
+      return { success: true, cellId: input.cellId, deleted: true };
+    }
+
+    const currentResourceVersion = notebookCellResourceVersion(
+      current,
+      doc.version,
+    );
+    if (
+      input.resourceVersion &&
+      input.resourceVersion !== currentResourceVersion
+    ) {
+      return {
+        success: false,
+        error:
+          "Cell changed since it was read. Re-read it and retry with the " +
+          "latest resourceVersion.",
+        currentResourceVersion,
+      };
+    }
+    let nextSource = input.source;
+    let replacements: number | undefined;
+    if (input.oldString !== undefined && input.newString !== undefined) {
+      const edit = applyStrReplace(
+        current.source,
+        input.oldString,
+        input.newString,
+        input.replaceAll,
+      );
+      if (!edit.ok) return { success: false, error: edit.error };
+      nextSource = edit.contents;
+      replacements = edit.replacements;
+    }
+    const blocks = doc.blocks.map(b =>
+      b.id === input.cellId
+        ? {
+            ...b,
+            ...(nextSource !== undefined ? { source: nextSource } : {}),
+            ...(input.type ? { type: input.type as NotebookBlockType } : {}),
+            ...(input.connectionId !== undefined
+              ? { connectionId: input.connectionId }
+              : {}),
+          }
+        : b,
+    );
+    const version = await saveBlocks(id, blocks, doc.version);
+    if (version === SAVE_CONFLICT) {
+      return {
+        success: false,
+        error:
+          "Notebook changed while editing the cell. Re-read and retry with " +
+          "the latest resourceVersion.",
+      };
+    }
+    if (version == null) {
+      return { success: false, error: "Failed to edit cell" };
+    }
+    const updated = blocks.find(block => block.id === input.cellId);
+    return {
+      success: true,
+      cellId: input.cellId,
+      version,
+      resourceVersion: updated
+        ? notebookCellResourceVersion(updated, version)
+        : undefined,
+      replacements,
+    };
   };
 
   return {
@@ -395,170 +518,34 @@ export function createNotebookServerTools({
       },
     }),
 
-    add_notebook_cell: tool({
-      description:
-        "Append (or insert at atIndex) a cell. For a SQL cell set connectionId " +
-        "to a data source id (from list_connections) so it can run.",
-      inputSchema: z.object({
-        notebookId: notebookIdField,
-        type: cellTypeField,
-        source: z.string().optional().describe("Cell contents"),
-        connectionId: z
-          .string()
-          .optional()
-          .describe("Data source id for SQL cells"),
-        atIndex: z
-          .number()
-          .int()
-          .optional()
-          .describe("Insert position; appends when omitted"),
-      }),
-      execute: async input => {
-        const id = resolveId(input);
-        if (!id) return noNotebook;
-        const access = await assertWriteAccess(id);
-        if (!access.ok) return { success: false, error: access.error };
-        const doc = await store.get(workspaceId, id);
-        if (!doc) return { success: false, error: `Notebook ${id} not found` };
-        const cell: NotebookBlock = {
-          id: randomUUID(),
-          type: input.type as NotebookBlockType,
-          source: input.source ?? "",
-          ...(input.connectionId ? { connectionId: input.connectionId } : {}),
-        };
-        const blocks = [...doc.blocks];
-        blocks.splice(input.atIndex ?? blocks.length, 0, cell);
-        const version = await saveBlocks(id, blocks, doc.version);
-        if (version === SAVE_CONFLICT) {
-          return {
-            success: false,
-            error: "Notebook changed while adding the cell. Re-read and retry.",
-          };
-        }
-        if (version == null) {
-          return { success: false, error: "Failed to add cell" };
-        }
-        return { success: true, cellId: cell.id, type: cell.type };
-      },
-    }),
-
     edit_notebook_cell: tool({
       description:
-        "Edit a cell's source or metadata. For large cells, use a unique " +
-        "oldString/newString plus resourceVersion instead of replacing the full source.",
+        "Insert, replace, or delete a cell (mode; default 'replace'). insert " +
+        "adds a new cell of `type` — for SQL cells set connectionId (a data " +
+        "source id from list_connections). replace edits cellId's source/" +
+        "metadata; for large cells prefer oldString/newString + " +
+        "resourceVersion. delete removes cellId.",
       inputSchema: editNotebookCellSchema,
-      execute: async input => {
-        const id = resolveId(input);
-        if (!id) return noNotebook;
-        const access = await assertWriteAccess(id);
-        if (!access.ok) return { success: false, error: access.error };
-        const doc = await store.get(workspaceId, id);
-        if (!doc) return { success: false, error: `Notebook ${id} not found` };
-        const current = doc.blocks.find(block => block.id === input.cellId);
-        if (!current) {
-          return { success: false, error: `No cell with id "${input.cellId}"` };
-        }
-        const currentResourceVersion = notebookCellResourceVersion(
-          current,
-          doc.version,
-        );
-        if (
-          input.resourceVersion &&
-          input.resourceVersion !== currentResourceVersion
-        ) {
-          return {
-            success: false,
-            error:
-              "Cell changed since it was read. Re-read it and retry with the " +
-              "latest resourceVersion.",
-            currentResourceVersion,
-          };
-        }
-        let nextSource = input.source;
-        let replacements: number | undefined;
-        if (input.oldString !== undefined && input.newString !== undefined) {
-          const edit = applyStrReplace(
-            current.source,
-            input.oldString,
-            input.newString,
-            input.replaceAll,
-          );
-          if (!edit.ok) return { success: false, error: edit.error };
-          nextSource = edit.contents;
-          replacements = edit.replacements;
-        }
-        const blocks = doc.blocks.map(b =>
-          b.id === input.cellId
-            ? {
-                ...b,
-                ...(nextSource !== undefined ? { source: nextSource } : {}),
-                ...(input.type
-                  ? { type: input.type as NotebookBlockType }
-                  : {}),
-                ...(input.connectionId !== undefined
-                  ? { connectionId: input.connectionId }
-                  : {}),
-              }
-            : b,
-        );
-        const version = await saveBlocks(id, blocks, doc.version);
-        if (version === SAVE_CONFLICT) {
-          return {
-            success: false,
-            error:
-              "Notebook changed while editing the cell. Re-read and retry with " +
-              "the latest resourceVersion.",
-          };
-        }
-        if (version == null) {
-          return { success: false, error: "Failed to edit cell" };
-        }
-        const updated = blocks.find(block => block.id === input.cellId);
-        return {
-          success: true,
-          cellId: input.cellId,
-          version,
-          resourceVersion: updated
-            ? notebookCellResourceVersion(updated, version)
-            : undefined,
-          replacements,
-        };
-      },
+      execute: editCellImpl,
+    }),
+
+    add_notebook_cell: tool({
+      description:
+        "Deprecated alias of edit_notebook_cell (mode: 'insert') — use that instead.",
+      inputSchema: addNotebookCellSchema,
+      execute: async input => editCellImpl({ ...input, mode: "insert" }),
     }),
 
     delete_notebook_cell: tool({
-      description: "Delete a cell by id.",
-      inputSchema: z.object({
-        notebookId: notebookIdField,
-        cellId: z.string(),
-      }),
-      execute: async input => {
-        const id = resolveId(input);
-        if (!id) return noNotebook;
-        const access = await assertWriteAccess(id);
-        if (!access.ok) return { success: false, error: access.error };
-        const doc = await store.get(workspaceId, id);
-        if (!doc) return { success: false, error: `Notebook ${id} not found` };
-        if (!doc.blocks.some(b => b.id === input.cellId)) {
-          return { success: false, error: `No cell with id "${input.cellId}"` };
-        }
-        const version = await saveBlocks(
-          id,
-          doc.blocks.filter(b => b.id !== input.cellId),
-          doc.version,
-        );
-        if (version === SAVE_CONFLICT) {
-          return {
-            success: false,
-            error:
-              "Notebook changed while deleting the cell. Re-read and retry.",
-          };
-        }
-        if (version == null) {
-          return { success: false, error: "Failed to delete cell" };
-        }
-        return { success: true, cellId: input.cellId };
-      },
+      description:
+        "Deprecated alias of edit_notebook_cell (mode: 'delete') — use that instead.",
+      inputSchema: deleteNotebookCellSchema,
+      execute: async input =>
+        editCellImpl({
+          notebookId: input.notebookId,
+          cellId: input.cellId,
+          mode: "delete",
+        }),
     }),
 
     run_notebook_sql_cell: tool({

--- a/api/src/agents/modes/prompts.ts
+++ b/api/src/agents/modes/prompts.ts
@@ -254,9 +254,10 @@ state persists across runs so cells build on each other), and \`markdown\` (pros
 Notebook tools act on the notebook in the active tab (pass \`notebookId\` to target another).
 Use \`list_open_notebooks\` / \`read_notebook\` to get the compact cell manifest. Do not load every
 cell's full source: use \`search_notebook\`, then \`read_notebook_cell\` for only the relevant ranges.
-Add cells with \`add_notebook_cell\`; for large cells, edit with a unique \`oldString\`/\`newString\`
-and the latest \`resourceVersion\` instead of resending the full source. Remove cells with
-\`delete_notebook_cell\`. For a SQL cell, set \`connectionId\` to a data source id (discover with
+All cell writes go through \`edit_notebook_cell\`: \`mode: 'insert'\` adds a cell, \`'replace'\`
+(default) edits one — for large cells use a unique \`oldString\`/\`newString\` and the latest
+\`resourceVersion\` instead of resending the full source — and \`'delete'\` removes one.
+For a SQL cell, set \`connectionId\` to a data source id (discover with
 \`list_connections\`), then run it with \`run_notebook_sql_cell\`. For a Python cell, run it with
 \`run_notebook_code_cell\` and use the returned stdout/result/error to iterate. Prefer a short
 Markdown cell explaining each analysis above its code.`;

--- a/api/src/agents/modes/registry.ts
+++ b/api/src/agents/modes/registry.ts
@@ -63,6 +63,11 @@ export const DEFERRED_BUILTIN_TOOL_DOMAINS: Readonly<Record<string, string>> = {
   // external MCP clients; the in-product agent uses the merged tool.
   app_set_binding_materialization: "apps",
   app_set_binding_schedule: "apps",
+  // Deprecated aliases of edit_notebook_cell (mode: 'insert' | 'delete').
+  // Kept executable for external MCP clients; the in-product agent uses the
+  // merged tool.
+  add_notebook_cell: "notebooks",
+  delete_notebook_cell: "notebooks",
 };
 
 export const DEFERRED_BUILTIN_TOOL_NAMES: readonly string[] = Object.keys(
@@ -248,9 +253,7 @@ const NOTEBOOK_MODE_TOOL_NAMES: string[] = [
   "read_notebook",
   "search_notebook",
   "read_notebook_cell",
-  "add_notebook_cell",
   "edit_notebook_cell",
-  "delete_notebook_cell",
   "run_notebook_sql_cell",
   "run_notebook_code_cell",
   // Discovery: find data sources + tables for SQL cells

--- a/api/src/agents/modes/tool-working-set.test.ts
+++ b/api/src/agents/modes/tool-working-set.test.ts
@@ -575,6 +575,21 @@ async function endToEnd() {
     false,
     "redundant app_get_data_binding should not be registered",
   );
+  // Notebook cell CRUD fold: only the merged edit_notebook_cell stays in the
+  // notebook working set; the add/delete aliases remain loadable.
+  const notebookModeTools = toolNamesForModes(new Set(["notebook"] as const));
+  assert.ok(notebookModeTools.has("edit_notebook_cell"));
+  for (const alias of ["add_notebook_cell", "delete_notebook_cell"]) {
+    assert.equal(
+      notebookModeTools.has(alias),
+      false,
+      `deprecated ${alias} should stay out of the notebook working set`,
+    );
+    assert.ok(
+      DEFERRED_BUILTIN_TOOL_NAMES.includes(alias),
+      `deprecated ${alias} should remain loadable for compatibility`,
+    );
+  }
 
   // Preload: a Slack-flavored user message pre-activates relevant tools
   // with zero search/load round-trips.

--- a/app/src/agent-runtime/client-tool-manifest.ts
+++ b/app/src/agent-runtime/client-tool-manifest.ts
@@ -1276,24 +1276,31 @@ export const AGENT_TOOL_MANIFEST = {
     getLabel: () => "Reading notebook cell",
     icon: "eye",
   },
+  edit_notebook_cell: {
+    domain: "notebook",
+    execution: "server",
+    getLabel: input => {
+      const inp = input as Record<string, unknown>;
+      if (inp?.mode === "insert") {
+        const type = inp?.type;
+        return typeof type === "string" ? `Adding ${type} cell` : "Adding cell";
+      }
+      if (inp?.mode === "delete") return "Deleting cell";
+      return "Editing cell";
+    },
+    icon: "pencil",
+    preview: { field: "source", language: "sql" },
+  },
+  // Deprecated aliases of edit_notebook_cell (mode: 'insert' / 'delete');
+  // still registered for external MCP clients, so keep their tool cards.
   add_notebook_cell: {
     domain: "notebook",
     execution: "server",
     getLabel: input => {
       const type = (input as Record<string, unknown>)?.type;
-      return `Adding ${typeof type === "string" ? type : ""} cell`.replace(
-        "  ",
-        " ",
-      );
+      return typeof type === "string" ? `Adding ${type} cell` : "Adding cell";
     },
     icon: "plus",
-    preview: { field: "source", language: "sql" },
-  },
-  edit_notebook_cell: {
-    domain: "notebook",
-    execution: "server",
-    getLabel: () => "Editing cell",
-    icon: "pencil",
     preview: { field: "source", language: "sql" },
   },
   delete_notebook_cell: {

--- a/app/src/notebook-runtime/agent-tools.ts
+++ b/app/src/notebook-runtime/agent-tools.ts
@@ -147,6 +147,84 @@ export async function executeNotebookAgentTool(
   if (!doc) return fail("Notebook not found");
   const store = useNotebookStore.getState();
 
+  // Shared cell CRUD: edit_notebook_cell dispatches on mode, and the
+  // deprecated add/delete alias tools reuse the same legs.
+  const insertCell = (inp: Record<string, unknown>): ToolResult => {
+    const type = (inp.type as NotebookBlockType) || "code";
+    const atIndex = typeof inp.atIndex === "number" ? inp.atIndex : undefined;
+    const cell = store.addCell(notebookId, type, atIndex);
+    if (!cell) return fail("Failed to add cell");
+    const patch: Partial<NotebookBlock> = {};
+    if (typeof inp.source === "string") patch.source = inp.source;
+    if (typeof inp.connectionId === "string") {
+      patch.connectionId = inp.connectionId;
+    }
+    if (Object.keys(patch).length > 0) {
+      store.updateCell(notebookId, cell.id, patch);
+    }
+    return { success: true, cellId: cell.id, type };
+  };
+
+  const replaceCell = (inp: Record<string, unknown>): ToolResult => {
+    const cellId = inp.cellId as string;
+    const current = doc.blocks.find(block => block.id === cellId);
+    if (!current) {
+      return fail(`No cell with id "${cellId}"`);
+    }
+    const currentResourceVersion = notebookCellResourceVersion(
+      current,
+      doc.version,
+    );
+    if (
+      typeof inp.resourceVersion === "string" &&
+      inp.resourceVersion !== currentResourceVersion
+    ) {
+      return {
+        success: false,
+        error:
+          "Cell changed since it was read. Re-read it and retry with the " +
+          "latest resourceVersion.",
+        currentResourceVersion,
+      };
+    }
+    const patch: Partial<NotebookBlock> = {};
+    if (
+      typeof inp.oldString === "string" &&
+      typeof inp.newString === "string"
+    ) {
+      const edit = applyStrReplace(
+        current.source,
+        inp.oldString,
+        inp.newString,
+        inp.replaceAll === true,
+      );
+      if (!edit.ok) return fail(edit.error);
+      patch.source = edit.contents;
+    } else if (typeof inp.source === "string") {
+      patch.source = inp.source;
+    }
+    if (typeof inp.type === "string") {
+      patch.type = inp.type as NotebookBlockType;
+    }
+    if (typeof inp.connectionId === "string") {
+      patch.connectionId = inp.connectionId;
+    }
+    store.updateCell(notebookId, cellId, patch);
+    return {
+      success: true,
+      cellId,
+    };
+  };
+
+  const deleteCell = (inp: Record<string, unknown>): ToolResult => {
+    const cellId = inp.cellId as string;
+    if (!doc.blocks.some(b => b.id === cellId)) {
+      return fail(`No cell with id "${cellId}"`);
+    }
+    store.deleteCell(notebookId, cellId);
+    return { success: true, cellId, deleted: true };
+  };
+
   switch (toolName) {
     case "read_notebook": {
       const cellOffset =
@@ -220,82 +298,17 @@ export async function executeNotebookAgentTool(
       };
     }
 
-    case "add_notebook_cell": {
-      const type = (input.type as NotebookBlockType) || "code";
-      const atIndex =
-        typeof input.atIndex === "number" ? input.atIndex : undefined;
-      const cell = store.addCell(notebookId, type, atIndex);
-      if (!cell) return fail("Failed to add cell");
-      const patch: Partial<NotebookBlock> = {};
-      if (typeof input.source === "string") patch.source = input.source;
-      if (typeof input.connectionId === "string") {
-        patch.connectionId = input.connectionId;
-      }
-      if (Object.keys(patch).length > 0) {
-        store.updateCell(notebookId, cell.id, patch);
-      }
-      return { success: true, cellId: cell.id, type };
-    }
-
     case "edit_notebook_cell": {
-      const cellId = input.cellId as string;
-      const current = doc.blocks.find(block => block.id === cellId);
-      if (!current) {
-        return fail(`No cell with id "${cellId}"`);
-      }
-      const currentResourceVersion = notebookCellResourceVersion(
-        current,
-        doc.version,
-      );
-      if (
-        typeof input.resourceVersion === "string" &&
-        input.resourceVersion !== currentResourceVersion
-      ) {
-        return {
-          success: false,
-          error:
-            "Cell changed since it was read. Re-read it and retry with the " +
-            "latest resourceVersion.",
-          currentResourceVersion,
-        };
-      }
-      const patch: Partial<NotebookBlock> = {};
-      if (
-        typeof input.oldString === "string" &&
-        typeof input.newString === "string"
-      ) {
-        const edit = applyStrReplace(
-          current.source,
-          input.oldString,
-          input.newString,
-          input.replaceAll === true,
-        );
-        if (!edit.ok) return fail(edit.error);
-        patch.source = edit.contents;
-      } else if (typeof input.source === "string") {
-        patch.source = input.source;
-      }
-      if (typeof input.type === "string") {
-        patch.type = input.type as NotebookBlockType;
-      }
-      if (typeof input.connectionId === "string") {
-        patch.connectionId = input.connectionId;
-      }
-      store.updateCell(notebookId, cellId, patch);
-      return {
-        success: true,
-        cellId,
-      };
+      if (input.mode === "insert") return insertCell(input);
+      if (input.mode === "delete") return deleteCell(input);
+      return replaceCell(input);
     }
 
-    case "delete_notebook_cell": {
-      const cellId = input.cellId as string;
-      if (!doc.blocks.some(b => b.id === cellId)) {
-        return fail(`No cell with id "${cellId}"`);
-      }
-      store.deleteCell(notebookId, cellId);
-      return { success: true, cellId };
-    }
+    case "add_notebook_cell":
+      return insertCell(input);
+
+    case "delete_notebook_cell":
+      return deleteCell(input);
 
     case "run_notebook_sql_cell": {
       const cellId = input.cellId as string;

--- a/docs/src/content/docs/notebooks.md
+++ b/docs/src/content/docs/notebooks.md
@@ -45,7 +45,7 @@ Notebooks are organized like dashboards and consoles: a **My Notebooks** section
 
 Notebooks have their own [expertise mode](/ai-agent/#expertise-modes) — opening a notebook tab defaults the agent to **Notebook** mode. The agent can create notebooks, add/edit/delete cells, run SQL cells against a data source, and run Python cells on the kernel, reading each run's stdout/result/error to iterate. Tools:
 
-`create_notebook`, `list_open_notebooks`, `read_notebook`, `add_notebook_cell`, `edit_notebook_cell`, `delete_notebook_cell`, `run_notebook_sql_cell`, `run_notebook_code_cell` — plus the SQL discovery tools (`list_connections`, `sql_list_tables`, `sql_inspect_table`, …) for finding data sources.
+`create_notebook`, `list_open_notebooks`, `read_notebook`, `edit_notebook_cell` (insert / replace / delete a cell via its `mode` parameter), `run_notebook_sql_cell`, `run_notebook_code_cell` — plus the SQL discovery tools (`list_connections`, `sql_list_tables`, `sql_inspect_table`, …) for finding data sources.
 
 Agent runs execute server-side against the durable document and live-update any open tabs. Agent SQL runs persist up to 200 result rows with the cell. Notebook tools are deliberately **not** exposed over the [MCP server](/mcp-server/) yet — authoring stays in-product until notebooks get a dedicated MCP surface.
 

--- a/packages/agent-tools/src/capabilities/notebook-capabilities.ts
+++ b/packages/agent-tools/src/capabilities/notebook-capabilities.ts
@@ -64,14 +64,10 @@ export const NOTEBOOK_CAPABILITIES = [
     resultKind: "artifact",
   }),
   define({
-    name: "add_notebook_cell",
-    pack: "notebook-edit",
-    risk: "write",
-    requiredGrant: "artifact-write",
-    surfaces: ALL_AGENT_SURFACES,
-    resultKind: "artifact",
-  }),
-  define({
+    // Single cell CRUD tool: mode 'insert' | 'replace' (default) | 'delete'.
+    // The delete leg is recoverable via notebook versions and needs the same
+    // artifact-write grant, so the merged tool stays write-risk; the
+    // deprecated delete_notebook_cell alias below keeps its destructive hint.
     name: "edit_notebook_cell",
     pack: "notebook-edit",
     risk: "write",
@@ -80,6 +76,20 @@ export const NOTEBOOK_CAPABILITIES = [
     resultKind: "artifact",
   }),
   define({
+    // Deprecated alias of edit_notebook_cell (mode: 'insert'); kept
+    // registered for external MCP clients. Deferred out of the in-product
+    // working set (see DEFERRED_BUILTIN_TOOL_DOMAINS).
+    name: "add_notebook_cell",
+    pack: "notebook-edit",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+  define({
+    // Deprecated alias of edit_notebook_cell (mode: 'delete'); kept
+    // registered for external MCP clients. Deferred out of the in-product
+    // working set (see DEFERRED_BUILTIN_TOOL_DOMAINS).
     name: "delete_notebook_cell",
     pack: "notebook-edit",
     risk: "destructive",

--- a/packages/agent-tools/src/index.ts
+++ b/packages/agent-tools/src/index.ts
@@ -135,6 +135,8 @@ export { clientDataSourceTools } from "./data-source-tools";
 
 export {
   clientNotebookTools,
+  addNotebookCellSchema,
+  deleteNotebookCellSchema,
   editNotebookCellSchema,
   notebookCellResourceVersion,
   readNotebookCellRange,
@@ -146,6 +148,7 @@ export {
   NOTEBOOK_CELL_PAGE_LIMIT,
   NOTEBOOK_SOURCE_PREVIEW_CHARS,
 } from "./notebook-tools";
+export type { EditNotebookCellInput } from "./notebook-tools";
 
 export {
   runAppBaseSchema,

--- a/packages/agent-tools/src/notebook-tools.ts
+++ b/packages/agent-tools/src/notebook-tools.ts
@@ -91,37 +91,66 @@ export const readNotebookCellSchema = z.object({
 export const editNotebookCellSchema = z
   .object({
     notebookId: notebookIdField,
-    cellId: z.string().describe("Cell id from read_notebook"),
-    source: z
+    mode: z.enum(["insert", "replace", "delete"]).optional(),
+    cellId: z
       .string()
       .optional()
-      .describe(
-        "Replace the full source. Prefer oldString/newString for large cells.",
-      ),
+      .describe("Target cell id (required for replace/delete)."),
+    type: cellTypeField.optional(),
+    source: z.string().optional().describe("Cell contents."),
     oldString: z
       .string()
       .optional()
-      .describe(
-        "Unique source text to replace without resending the full cell.",
-      ),
+      .describe("Unique source text to replace."),
     newString: z.string().optional().describe("Replacement for oldString."),
     replaceAll: z
       .boolean()
       .optional()
-      .describe("Replace every occurrence of oldString (default false)."),
+      .describe("Replace every occurrence (default false)."),
     resourceVersion: z
       .string()
       .optional()
       .describe(
-        "Version from read_notebook, search_notebook, or read_notebook_cell. " +
-          "The edit is rejected if the cell changed since it was read.",
+        "Version from a read/search result; the edit is rejected if the " +
+          "cell changed since.",
       ),
-    type: cellTypeField.optional(),
-    connectionId: z.string().optional(),
+    connectionId: z
+      .string()
+      .optional()
+      .describe("Data source id for SQL cells."),
+    atIndex: z
+      .number()
+      .int()
+      .optional()
+      .describe("Insert position; appends when omitted."),
   })
   .superRefine((value, ctx) => {
+    const mode = value.mode ?? "replace";
     const hasTargetedEdit =
       value.oldString !== undefined || value.newString !== undefined;
+    if (mode === "insert") {
+      if (value.type === undefined) {
+        ctx.addIssue({
+          code: "custom",
+          message: "type is required to insert a cell",
+        });
+      }
+      if (value.cellId !== undefined || hasTargetedEdit) {
+        ctx.addIssue({
+          code: "custom",
+          message:
+            "insert creates a new cell — omit cellId/oldString/newString",
+        });
+      }
+      return;
+    }
+    if (value.cellId === undefined) {
+      ctx.addIssue({
+        code: "custom",
+        message: `cellId is required to ${mode} a cell`,
+      });
+    }
+    if (mode === "delete") return;
     if (
       hasTargetedEdit &&
       (value.oldString === undefined || value.newString === undefined)
@@ -138,6 +167,27 @@ export const editNotebookCellSchema = z
       });
     }
   });
+
+export type EditNotebookCellInput = z.infer<typeof editNotebookCellSchema>;
+
+/** Deprecated alias schema — edit_notebook_cell(mode: 'insert'). */
+export const addNotebookCellSchema = z.object({
+  notebookId: notebookIdField,
+  type: cellTypeField,
+  source: z.string().optional().describe("Cell contents"),
+  connectionId: z.string().optional().describe("Data source id for SQL cells"),
+  atIndex: z
+    .number()
+    .int()
+    .optional()
+    .describe("Insert position; appends when omitted"),
+});
+
+/** Deprecated alias schema — edit_notebook_cell(mode: 'delete'). */
+export const deleteNotebookCellSchema = z.object({
+  notebookId: notebookIdField,
+  cellId: z.string(),
+});
 
 export function notebookCellResourceVersion(
   cell: {
@@ -278,37 +328,24 @@ export const clientNotebookTools = {
       "metadata and a resourceVersion for safe targeted edits.",
     inputSchema: readNotebookCellSchema,
   }),
-  add_notebook_cell: tool({
-    description:
-      "Append (or insert at atIndex) a cell. For a SQL cell, set connectionId " +
-      "to a data source id (from list_connections) so it can run.",
-    inputSchema: z.object({
-      notebookId: notebookIdField,
-      type: cellTypeField,
-      source: z.string().optional().describe("Cell contents"),
-      connectionId: z
-        .string()
-        .optional()
-        .describe("Data source id for SQL cells"),
-      atIndex: z
-        .number()
-        .int()
-        .optional()
-        .describe("Insert position; appends when omitted"),
-    }),
-  }),
   edit_notebook_cell: tool({
     description:
-      "Edit a cell's source or metadata. For large cells, use a unique " +
-      "oldString/newString plus resourceVersion instead of replacing the full source.",
+      "Insert, replace, or delete a cell (mode; default 'replace'). insert " +
+      "adds a new cell of `type` — for SQL cells set connectionId (a data " +
+      "source id from list_connections). replace edits cellId's source/" +
+      "metadata; for large cells prefer oldString/newString + " +
+      "resourceVersion. delete removes cellId.",
     inputSchema: editNotebookCellSchema,
   }),
+  add_notebook_cell: tool({
+    description:
+      "Deprecated alias of edit_notebook_cell (mode: 'insert') — use that instead.",
+    inputSchema: addNotebookCellSchema,
+  }),
   delete_notebook_cell: tool({
-    description: "Delete a cell by id.",
-    inputSchema: z.object({
-      notebookId: notebookIdField,
-      cellId: z.string(),
-    }),
+    description:
+      "Deprecated alias of edit_notebook_cell (mode: 'delete') — use that instead.",
+    inputSchema: deleteNotebookCellSchema,
   }),
   run_notebook_sql_cell: tool({
     description:
@@ -325,7 +362,7 @@ export const clientNotebookTools = {
       "its stdout/stderr, any error + traceback, and the result. Kernel state " +
       "persists across runs (variables, imports), so cells build on each other. " +
       "pandas, polars, numpy, matplotlib, plotly, duckdb and the `mako` SDK are " +
-      "preinstalled. Use after add_notebook_cell to execute + iterate: run, read " +
+      "preinstalled. Use after edit_notebook_cell to execute + iterate: run, read " +
       "the output/error, fix the cell, rerun.",
     inputSchema: z.object({
       notebookId: notebookIdField,

--- a/packages/local-agent/src/acp/mako-system-append.ts
+++ b/packages/local-agent/src/acp/mako-system-append.ts
@@ -33,7 +33,7 @@ When you need a decision or approval, call Desktop tools — never ask as plain 
 Use \`${prefix}create_console\`, \`${prefix}open_console\`, \`${prefix}run_console\`, \`${prefix}modify_console\`, \`${prefix}search_consoles\`. Desktop opens/focuses the console tab automatically. For tabs the user already has open, call \`${desktopPrefix}list_open_consoles\`.
 
 ## Notebooks
-Use \`${prefix}create_notebook\` / \`${prefix}list_open_notebooks\`, then \`${prefix}read_notebook\` for the compact manifest. Use \`${prefix}search_notebook\` and \`${prefix}read_notebook_cell\` for only relevant source ranges. For large cells, prefer targeted oldString/newString edits with resourceVersion over full rewrites. Cell add/edit/delete and \`${prefix}run_notebook_sql_cell\` / \`${prefix}run_notebook_code_cell\` remain available. Desktop opens the notebook tab on create or mutation; read-only inspection does not steal focus.
+Use \`${prefix}create_notebook\` / \`${prefix}list_open_notebooks\`, then \`${prefix}read_notebook\` for the compact manifest. Use \`${prefix}search_notebook\` and \`${prefix}read_notebook_cell\` for only relevant source ranges. Cell writes go through \`${prefix}edit_notebook_cell\` (\`mode\`: insert | replace | delete); for large cells, prefer targeted oldString/newString edits with resourceVersion over full rewrites. \`${prefix}run_notebook_sql_cell\` / \`${prefix}run_notebook_code_cell\` remain available. Desktop opens the notebook tab on create or mutation; read-only inspection does not steal focus.
 
 ## Apps (Desktop preview — not headless)
 The user can see apps in the Mako window. After \`${prefix}create_app\` / \`${prefix}app_write_file\` / \`${prefix}app_edit_file\`, Desktop opens/refreshes the app tab automatically.


### PR DESCRIPTION
## Summary

`add_notebook_cell` + `edit_notebook_cell` + `delete_notebook_cell` merge into a single `edit_notebook_cell` with `mode: 'insert' | 'replace' (default) | 'delete'` — the same shape as Claude Code's own NotebookEdit tool. Measured with `pnpm --filter api tools:measure`, the merged tool weighs **~384 tokens vs ~612** for the old trio, saving **~228 tokens per notebook-mode turn**.

Follows the `app_set_binding_*` fold precedent (#786):

- **Shared schema** (`packages/agent-tools/src/notebook-tools.ts`): one `editNotebookCellSchema` with `mode` and `atIndex`, and per-leg `superRefine` validation — insert requires `type` and rejects `cellId`/`oldString`; replace/delete require `cellId`; the source-vs-oldString pairing rules apply to replace only.
- **Deprecated aliases kept for external MCP clients**: `add_notebook_cell` and `delete_notebook_cell` stay registered as thin aliases delegating to the shared implementation, but are demoted out of the in-product agent's always-active working set (`DEFERRED_BUILTIN_TOOL_DOMAINS`) and removed from `NOTEBOOK_MODE_TOOL_NAMES` — still loadable via `search_tools`/`load_tools`.
- **One implementation per surface**: the server tools (`server-notebook-tools.ts`) and the client executor (`notebook-runtime/agent-tools.ts`) each dispatch on `mode` from a single code path, with the aliases mapping onto it.
- **No grant changes**: all three legs already required `artifact-write`, so no input-conditional grant is needed. The merged capability stays write-risk (the delete leg is recoverable via notebook versions); the deprecated `delete_notebook_cell` alias keeps its destructive MCP hint.
- **Prompts/docs/UI updated**: notebook mode prompt, ACP desktop system append, `docs/notebooks.md`, mode-aware tool-card labels ("Adding/Editing/Deleting cell"), and capability registry comments.

Note: deleting via the merged tool (`mode: 'delete'`) no longer carries the MCP `destructiveHint`, since annotations are per-tool. Keeping that hint for the delete leg would need a per-input annotation mechanism the capability registry doesn't have today.

## Test plan

- [x] `@mako/agent-tools` build + package tests (24 pass)
- [x] `api` tier-policy test (`tool-working-set.test.ts`) — new assertions that the aliases stay out of the notebook working set but remain loadable
- [x] `api` MCP server test (`mako-mcp-server.test.ts`)
- [x] `pnpm api:build` (lint + tsc) — 0 errors; `tsc --noEmit` error count byte-identical to baseline
- [x] `app` typecheck + `client-tool-manifest` / `acp-notebook-focus` vitest suites
- [x] `local-agent` typecheck + `mako-system-append` test
- [x] `tools:measure` before/after: 612 → 384 tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXFyd5xueCNEgAjT6B4bDZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXFyd5xueCNEgAjT6B4bDZ)_