### PR TITLE
Unify dashboard data-source management with app bindings

### DIFF
--- a/api/src/agent-lib/tools/server-app-tools.ts
+++ b/api/src/agent-lib/tools/server-app-tools.ts
@@ -88,10 +88,7 @@ import {
 import { minimizeDirtyPaths } from "../../utils/mongoose-dirty-paths";
 import { canReadResource, canWriteResource } from "../../utils/resource-acl";
 import { loggers } from "../../logging";
-import {
-  MONGO_QUERY_WRITE_SCOPE_REQUIRED,
-  sqlReadOnlyAccessError,
-} from "../../services/read-only-query.service";
+import { bindingQueryAccessError as sharedBindingQueryAccessError } from "./shared/binding-query-access";
 import type { QueryAccess } from "../../auth/api-key-scopes";
 
 const logger = loggers.agent();
@@ -167,38 +164,18 @@ export function createServerAppTools({
     return canWriteResource(doc, userId, await memberRole());
   };
 
-  const bindingQueryAccessError = async (
+  const bindingQueryAccessError = (
     language: unknown,
     code: unknown,
     connectionId: unknown,
-  ): Promise<string | null> => {
-    // In-product agents keep their existing behavior. MCP data bindings are
-    // always read-only: a binding is a data source,
-    // not an arbitrary command channel.
-    if (queryAccess === undefined) return null;
-    if (queryAccess === "none") {
-      return "This API key does not have query access.";
-    }
-    if (
-      typeof connectionId !== "string" ||
-      !Types.ObjectId.isValid(connectionId)
-    ) {
-      return "Data binding connection is invalid.";
-    }
-    const connection = await DatabaseConnection.findOne({
-      _id: new Types.ObjectId(connectionId),
-      workspaceId: new Types.ObjectId(workspaceId),
-    }).select("type");
-    if (!connection) return "Data binding connection is invalid.";
-    if (
-      connection.type === "mongodb" ||
-      language === "javascript" ||
-      language === "mongodb"
-    ) {
-      return MONGO_QUERY_WRITE_SCOPE_REQUIRED;
-    }
-    return sqlReadOnlyAccessError(typeof code === "string" ? code : "");
-  };
+  ): Promise<string | null> =>
+    sharedBindingQueryAccessError({
+      workspaceId,
+      queryAccess,
+      language,
+      code,
+      connectionId,
+    });
 
   // Display name stamped on version checkpoints the agent creates.
   const savedByName = async (): Promise<string> =>

--- a/api/src/agent-lib/tools/server-dashboard-tools.ts
+++ b/api/src/agent-lib/tools/server-dashboard-tools.ts
@@ -1,0 +1,342 @@
+/**
+ * Server-side dashboard data-source tools.
+ *
+ * Dashboards manage data sources the same way apps manage data bindings:
+ * `update_data_source_query` is one capability with per-surface adapters
+ * (the run_app pattern) — the browser client applies edits to the open
+ * dashboard tab, while this server leg executes against the authoritative
+ * Dashboard document so headless / MCP agents can edit queries, switch
+ * live/parquet materialization, and set the refresh schedule with no
+ * browser attached.
+ *
+ * The code-edit semantics (action replace/patch/append) are shared with the
+ * browser executor via resolveDataSourceCodeEdit in @mako/agent-tools, so
+ * the two surfaces cannot drift.
+ *
+ * Persistence matches the resource-data-sources settings route: mutate the
+ * loaded document and save() (Mongoose minimizes dirty paths, so this is
+ * immune to the $set path-conflict class of bug; concurrency is
+ * last-write-wins, same as that route). The version bump + realtime poke
+ * make open tabs pull the new definition.
+ */
+import { tool } from "ai";
+import { Types } from "mongoose";
+import {
+  updateDataSourceQuerySchema,
+  resolveDataSourceCodeEdit,
+  type UpdateDataSourceQueryInput,
+} from "@mako/agent-tools";
+import { Dashboard, type IDashboard } from "../../database/workspace-schema";
+import { DashboardManager } from "../../utils/dashboard-manager";
+import { workspaceService } from "../../services/workspace.service";
+import { publishRealtimeEvent } from "../../services/realtime.service";
+import { validateDashboardMaterializationSchedule } from "../../services/dashboard-materialization-schedule.service";
+import { queueDashboardArtifactRefresh } from "../../services/dashboard-refresh-runner.service";
+import { bindingQueryAccessError } from "./shared/binding-query-access";
+import type { QueryAccess } from "../../auth/api-key-scopes";
+import { loggers } from "../../logging";
+
+const logger = loggers.agent();
+
+export interface ServerDashboardToolsOptions {
+  workspaceId: string;
+  /** Acting user (session user id, or API-key creator). */
+  userId?: string;
+  /** Chat driving this turn — used as the realtime echo-suppression id. */
+  chatId?: string;
+  /** Database capability granted by the calling API key. */
+  queryAccess?: QueryAccess;
+}
+
+export function createServerDashboardTools({
+  workspaceId,
+  userId,
+  chatId,
+  queryAccess,
+}: ServerDashboardToolsOptions) {
+  const agentClientId = `agent:${chatId ?? "unknown"}`;
+
+  let cachedRole: string | undefined | null = null;
+  const memberRole = async (): Promise<string | undefined> => {
+    if (cachedRole !== null) return cachedRole;
+    if (!userId) {
+      cachedRole = undefined;
+      return undefined;
+    }
+    try {
+      const member = await workspaceService.getMember(workspaceId, userId);
+      cachedRole = member?.role;
+    } catch {
+      cachedRole = undefined;
+    }
+    return cachedRole ?? undefined;
+  };
+
+  const wrap = async <T>(
+    label: string,
+    fn: () => Promise<T>,
+  ): Promise<T | { success: false; error: string }> => {
+    try {
+      return await fn();
+    } catch (error) {
+      logger.warn(`Server dashboard tool failed: ${label}`, {
+        error,
+        workspaceId,
+      });
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : `Failed: ${label}`,
+      };
+    }
+  };
+
+  const loadDashboard = async (
+    dashboardId: string,
+  ): Promise<{ doc: IDashboard } | { error: string }> => {
+    if (!dashboardId || !Types.ObjectId.isValid(dashboardId)) {
+      return {
+        error: `Invalid dashboard ID: ${dashboardId}. Use search_dashboards to find dashboard IDs.`,
+      };
+    }
+    const doc = await Dashboard.findOne({
+      _id: new Types.ObjectId(dashboardId),
+      workspaceId: new Types.ObjectId(workspaceId),
+    });
+    if (!doc) {
+      return {
+        error: `Dashboard ${dashboardId} not found. Use search_dashboards to find dashboard IDs.`,
+      };
+    }
+    if (userId && !DashboardManager.canRead(doc, userId, await memberRole())) {
+      return {
+        error: `Dashboard ${dashboardId} not found. Use search_dashboards to find dashboard IDs.`,
+      };
+    }
+    return { doc };
+  };
+
+  const canWrite = async (doc: IDashboard): Promise<boolean> => {
+    if (!userId) return true; // workspace-scoped API-key automation
+    const role = await memberRole();
+    const isAdmin = role === "owner" || role === "admin";
+    return DashboardManager.canWrite(doc, userId, isAdmin, role);
+  };
+
+  return {
+    update_data_source_query: tool({
+      description:
+        "Modify an existing dashboard data source IN PLACE: query code " +
+        "(action 'replace' | 'patch' with startLine/endLine | 'append'), " +
+        "connection, language, database, name, live/parquet materialization, " +
+        "or the dashboard's cron auto-refresh (materializationSchedule — " +
+        "dashboard-level: ONE schedule refreshes all parquet sources; " +
+        "mirrors app_update_data_binding). Non-code fields are shallow-" +
+        "merged. run=true (or any definition change on a parquet source) " +
+        "queues a server-side artifact rebuild. Find dashboards with " +
+        "search_dashboards.",
+      inputSchema: updateDataSourceQuerySchema,
+      execute: async (input: UpdateDataSourceQueryInput) =>
+        wrap("update_data_source_query", async () => {
+          const loaded = await loadDashboard(input.dashboardId);
+          if ("error" in loaded) return { success: false, ...loaded };
+          const { doc } = loaded;
+          if (!(await canWrite(doc))) {
+            return {
+              success: false,
+              error: `You do not have write access to dashboard ${input.dashboardId}.`,
+            };
+          }
+          const dataSource = (doc.dataSources ?? []).find(
+            ds => ds.id === input.dataSourceId,
+          );
+          if (!dataSource) {
+            return {
+              success: false,
+              error: `No data source with id "${input.dataSourceId}" on this dashboard.`,
+            };
+          }
+
+          const edit = resolveDataSourceCodeEdit(
+            dataSource.query?.code ?? "",
+            input,
+          );
+          if (!edit.ok) return { success: false, error: edit.error };
+
+          if (
+            input.connectionId !== undefined &&
+            !Types.ObjectId.isValid(input.connectionId)
+          ) {
+            return {
+              success: false,
+              error: `Invalid connectionId: ${input.connectionId}`,
+            };
+          }
+
+          // Materialization / schedule legs (same semantics as
+          // app_update_data_binding; the schedule is dashboard-level).
+          const currentMaterialization =
+            dataSource.materialization === "live" ? "live" : "parquet";
+          const nextMaterialization =
+            input.materialization ?? currentMaterialization;
+          const materializationChanged =
+            nextMaterialization !== currentMaterialization;
+
+          let nextSchedule = doc.materializationSchedule;
+          let scheduleChanged = false;
+          if (input.materializationSchedule) {
+            try {
+              nextSchedule = validateDashboardMaterializationSchedule(
+                input.materializationSchedule,
+              );
+            } catch (error) {
+              return {
+                success: false,
+                error:
+                  error instanceof Error
+                    ? error.message
+                    : "Invalid materialization schedule",
+              };
+            }
+            if (nextSchedule.enabled) {
+              const anyParquet = (doc.dataSources ?? []).some(
+                ds =>
+                  (ds.id === input.dataSourceId
+                    ? nextMaterialization
+                    : (ds.materialization ?? "parquet")) === "parquet",
+              );
+              if (!anyParquet) {
+                return {
+                  success: false,
+                  error:
+                    "Scheduled refresh only rebuilds 'parquet' data sources and this dashboard has none. Switch a data source to materialization: 'parquet' first (this tool can do both in one call).",
+                };
+              }
+            }
+            scheduleChanged = true;
+          }
+
+          const touchesDefinition =
+            input.code !== undefined ||
+            input.connectionId !== undefined ||
+            input.language !== undefined ||
+            input.databaseId !== undefined ||
+            input.databaseName !== undefined;
+          const nextLanguage =
+            input.language ?? dataSource.query?.language ?? "sql";
+          // Query-access is only needed when the update (re)runs the query:
+          // definition edits, enabling a schedule, or building a parquet
+          // artifact. A disable-only schedule change stays possible for
+          // read-only keys.
+          if (
+            touchesDefinition ||
+            input.materializationSchedule?.enabled === true ||
+            (materializationChanged && nextMaterialization === "parquet")
+          ) {
+            const accessError = await bindingQueryAccessError({
+              workspaceId,
+              queryAccess,
+              language: nextLanguage,
+              code: edit.code,
+              connectionId:
+                input.connectionId ??
+                dataSource.query?.connectionId?.toString(),
+            });
+            if (accessError) return { success: false, error: accessError };
+          }
+
+          const definitionChanged =
+            edit.code !== (dataSource.query?.code ?? "") ||
+            (input.connectionId !== undefined &&
+              input.connectionId !==
+                dataSource.query?.connectionId?.toString()) ||
+            (input.language !== undefined &&
+              input.language !== dataSource.query?.language) ||
+            (input.databaseId !== undefined &&
+              input.databaseId !== dataSource.query?.databaseId) ||
+            (input.databaseName !== undefined &&
+              input.databaseName !== dataSource.query?.databaseName);
+
+          // Apply — shallow-merge non-code fields, same as the browser leg.
+          dataSource.query.code = edit.code;
+          if (input.connectionId !== undefined) {
+            dataSource.query.connectionId = new Types.ObjectId(
+              input.connectionId,
+            );
+          }
+          if (input.language !== undefined) {
+            dataSource.query.language = input.language;
+          }
+          if (input.databaseId !== undefined) {
+            dataSource.query.databaseId = input.databaseId;
+          }
+          if (input.databaseName !== undefined) {
+            dataSource.query.databaseName = input.databaseName;
+          }
+          if (input.name !== undefined) dataSource.name = input.name;
+          if (input.timeDimension !== undefined) {
+            dataSource.timeDimension = input.timeDimension;
+          }
+          if (input.rowLimit !== undefined)
+            dataSource.rowLimit = input.rowLimit;
+          dataSource.materialization = nextMaterialization;
+          if (scheduleChanged) doc.materializationSchedule = nextSchedule;
+          doc.markModified("dataSources");
+          // Version bump so open tabs treat the realtime poke as newer and
+          // pull the updated definition; UI saves against the old version
+          // will conflict and reload, as with any concurrent edit.
+          doc.version = (doc.version ?? 1) + 1;
+          await doc.save();
+
+          publishRealtimeEvent(workspaceId, {
+            type: "dashboard.updated",
+            dashboardId: doc._id.toString(),
+            version: doc.version,
+            updatedBy: userId ?? "agent",
+            clientId: agentClientId,
+            origin: "agent",
+          });
+
+          // Definition/materialization changes (or an explicit run) rebuild
+          // the parquet artifact server-side. Schedule-only changes don't
+          // touch the artifact — the schedule itself will refresh it.
+          let refreshQueued = false;
+          if (
+            nextMaterialization === "parquet" &&
+            (definitionChanged || materializationChanged || input.run === true)
+          ) {
+            await queueDashboardArtifactRefresh({
+              workspaceId,
+              dashboardId: doc._id.toString(),
+              dataSourceIds: [dataSource.id],
+              force: true,
+              triggerType: "manual",
+            }).catch(() => undefined);
+            refreshQueued = true;
+          }
+
+          const scheduleHint = scheduleChanged
+            ? nextSchedule?.enabled
+              ? ` Dashboard auto-refresh schedule: ${nextSchedule.cron} (${nextSchedule.timezone}) — one schedule refreshes all parquet sources.`
+              : " Dashboard auto-refresh schedule is off."
+            : "";
+          return {
+            success: true,
+            dataSourceId: dataSource.id,
+            state: "definition_updated" as const,
+            materialization: nextMaterialization,
+            ...(scheduleChanged || input.materializationSchedule !== undefined
+              ? { materializationSchedule: nextSchedule }
+              : {}),
+            refreshQueued,
+            version: doc.version,
+            message:
+              (definitionChanged || materializationChanged
+                ? refreshQueued
+                  ? `Updated "${dataSource.name}"; a parquet artifact rebuild was queued.`
+                  : `Updated "${dataSource.name}". Live sources run fresh on the next dashboard load.`
+                : `Updated "${dataSource.name}".`) + scheduleHint,
+          };
+        }),
+    }),
+  };
+}

--- a/api/src/agent-lib/tools/server-dashboard-tools.ts
+++ b/api/src/agent-lib/tools/server-dashboard-tools.ts
@@ -272,14 +272,19 @@ export function createServerDashboardTools({
           if (input.databaseName !== undefined) {
             dataSource.query.databaseName = input.databaseName;
           }
-          if (input.name !== undefined) dataSource.name = input.name;
+          if (input.name !== undefined) {
+            dataSource.name = input.name;
+          }
           if (input.timeDimension !== undefined) {
             dataSource.timeDimension = input.timeDimension;
           }
-          if (input.rowLimit !== undefined)
+          if (input.rowLimit !== undefined) {
             dataSource.rowLimit = input.rowLimit;
+          }
           dataSource.materialization = nextMaterialization;
-          if (scheduleChanged) doc.materializationSchedule = nextSchedule;
+          if (scheduleChanged) {
+            doc.materializationSchedule = nextSchedule;
+          }
           doc.markModified("dataSources");
           // Version bump so open tabs treat the realtime poke as newer and
           // pull the updated definition; UI saves against the old version

--- a/api/src/agent-lib/tools/shared/binding-query-access.ts
+++ b/api/src/agent-lib/tools/shared/binding-query-access.ts
@@ -1,0 +1,49 @@
+import { Types } from "mongoose";
+import { DatabaseConnection } from "../../../database/workspace-schema";
+import {
+  MONGO_QUERY_WRITE_SCOPE_REQUIRED,
+  sqlReadOnlyAccessError,
+} from "../../../services/read-only-query.service";
+import type { QueryAccess } from "../../../auth/api-key-scopes";
+
+/**
+ * Access error for persisting a data-source query definition (app data
+ * bindings and dashboard data sources), or null when allowed.
+ *
+ * In-product agents keep their existing behavior (queryAccess undefined).
+ * MCP-scoped keys treat bindings/data sources as read-only data sources, not
+ * an arbitrary command channel: mongo requires the write scope outright and
+ * SQL must be a read-only statement.
+ */
+export async function bindingQueryAccessError(input: {
+  workspaceId: string;
+  queryAccess: QueryAccess | undefined;
+  language: unknown;
+  code: unknown;
+  connectionId: unknown;
+}): Promise<string | null> {
+  const { workspaceId, queryAccess, language, code, connectionId } = input;
+  if (queryAccess === undefined) return null;
+  if (queryAccess === "none") {
+    return "This API key does not have query access.";
+  }
+  if (
+    typeof connectionId !== "string" ||
+    !Types.ObjectId.isValid(connectionId)
+  ) {
+    return "Data binding connection is invalid.";
+  }
+  const connection = await DatabaseConnection.findOne({
+    _id: new Types.ObjectId(connectionId),
+    workspaceId: new Types.ObjectId(workspaceId),
+  }).select("type");
+  if (!connection) return "Data binding connection is invalid.";
+  if (
+    connection.type === "mongodb" ||
+    language === "javascript" ||
+    language === "mongodb"
+  ) {
+    return MONGO_QUERY_WRITE_SCOPE_REQUIRED;
+  }
+  return sqlReadOnlyAccessError(typeof code === "string" ? code : "");
+}

--- a/api/src/agent-skills/dashboards/SKILL.md
+++ b/api/src/agent-skills/dashboards/SKILL.md
@@ -20,6 +20,7 @@ When working with dashboards, you help users create interactive data dashboards 
 
 You can create, modify, and manage dashboards using structured tool calls. Dashboards consist of:
 - **Data sources** — dashboard-local query definitions loaded into an in-browser DuckDB instance. Each has a `materialization` mode (mirrors app data bindings): `parquet` (default) snapshots the query to a cached artifact (fast for aggregation, served to public shares); `live` streams the query server-side into DuckDB on every dashboard load (always fresh, but not shown in anonymous public shares). Set it on `create_data_source` or switch it later with `update_data_source_query`. Only parquet sources are materialized/scheduled/refreshed.
+- **Scheduled refresh** — a dashboard can auto-refresh its parquet sources on a cron. Pass `materializationSchedule` to `update_data_source_query` (e.g. `{ enabled: true, cron: "0 * * * *" }` for hourly, `{ enabled: false }` to turn it off). Unlike apps (per-binding), a dashboard has ONE schedule that refreshes all of its parquet sources — setting it from any data source updates the whole dashboard. Mirrors `app_update_data_binding`'s `materializationSchedule`.
 - **Widgets** — charts (Vega-Lite), KPI cards, and data tables that query the local DuckDB data
 - **Cross-filtering** — clicking a bar or slice in one chart filters all other charts automatically
 - **Global filters** — dashboard-level date range pickers, dropdowns, and search fields

--- a/api/src/mcp/bridge-policy.ts
+++ b/api/src/mcp/bridge-policy.ts
@@ -261,7 +261,8 @@ export const MCP_BRIDGE_POLICY: Readonly<Record<string, McpBridgeEntry>> = {
   run_data_source_query: exclude("client-only", "Dashboard builder UI."),
   search_dashboards: bridge(),
   set_time_dimension: exclude("client-only", "Dashboard builder UI."),
-  update_data_source_query: exclude("client-only", "Dashboard builder UI."),
+  // update_data_source_query migrated to the capability registry (dashboard
+  // domain) with a server leg — its bridge entry now derives from there.
 
   // ── Shared DuckDB data-source primitives (client) ─────────────────────
   inspect_data_source: exclude(

--- a/api/src/mcp/mako-mcp-server.ts
+++ b/api/src/mcp/mako-mcp-server.ts
@@ -40,6 +40,7 @@ import { createSqlToolsV2 } from "../agent-lib/tools/sql-tools";
 import { createMongoToolsV2 } from "../agent-lib/tools/mongodb-tools";
 import { createUniversalTools } from "../agent-lib/tools/universal-tools";
 import { createServerConsoleTools } from "../agent-lib/tools/server-console-tools";
+import { createServerDashboardTools } from "../agent-lib/tools/server-dashboard-tools";
 import { createNotebookServerTools } from "../agent-lib/tools/server-notebook-tools";
 import { createConsoleSearchTools } from "../agent-lib/tools/console-search-tools";
 import { createDashboardSearchTools } from "../agent-lib/tools/dashboard-search-tools";
@@ -171,6 +172,17 @@ export function buildMakoMcpCandidateTools(
     surface: "mcp",
   });
 
+  // Dashboards manage data sources the same way apps manage bindings: the
+  // server leg of update_data_source_query (per-surface adapter, run_app
+  // pattern) lets headless agents edit queries, toggle materialization, and
+  // set the dashboard refresh schedule.
+  const dashboardTools = createServerDashboardTools({
+    workspaceId,
+    userId,
+    chatId,
+    queryAccess,
+  });
+
   const notebookTools = createNotebookServerTools({
     workspaceId,
     userId,
@@ -208,6 +220,7 @@ export function buildMakoMcpCandidateTools(
     ...appTools,
     ...headlessRunApp,
     ...consoleTools,
+    ...dashboardTools,
     ...notebookTools,
     ...selfDirectiveTools,
     list_connections,

--- a/app/src/dashboard-runtime/agent-tools.ts
+++ b/app/src/dashboard-runtime/agent-tools.ts
@@ -12,13 +12,15 @@ import {
 } from "./commands";
 import { useDashboardStore } from "../store/dashboardStore";
 import { useVersionStore } from "../store/versionStore";
-import type { DashboardDataSource, DashboardWidget } from "./types";
+import type { Dashboard, DashboardDataSource, DashboardWidget } from "./types";
+import { CronExpressionParser } from "cron-parser";
 import { classifyDuckDBError, classifySourceError } from "./error-kinds";
 import { computeDashboardStateHash } from "../utils/stateHash";
 import {
   DASHBOARD_EXECUTOR_TOOL_NAMES,
   type AgentToolName,
 } from "../agent-runtime/client-tool-manifest";
+import { resolveDataSourceCodeEdit } from "@mako/agent-tools";
 import { captureScreenshot } from "../agent-runtime/screenshot-agent-tools";
 import { focusDashboardTab, getCurrentWorkspaceId } from "./shell";
 import {
@@ -563,69 +565,17 @@ export async function executeDashboardAgentTool(
       return { success: false, error: "Data source not found" };
     }
 
-    const action = typeof input.action === "string" ? input.action : "replace";
-
-    if (action === "patch") {
-      if (
-        typeof input.startLine !== "number" ||
-        typeof input.endLine !== "number"
-      ) {
-        return {
-          success: false,
-          error:
-            "startLine and endLine are required for patch action. Use get_dashboard_state to see the current query code.",
-        };
-      }
-      if (typeof input.code !== "string") {
-        return {
-          success: false,
-          error: "code is required for patch action.",
-        };
-      }
+    const edit = resolveDataSourceCodeEdit(existing.query.code ?? "", {
+      action: typeof input.action === "string" ? input.action : undefined,
+      code: typeof input.code === "string" ? input.code : undefined,
+      startLine:
+        typeof input.startLine === "number" ? input.startLine : undefined,
+      endLine: typeof input.endLine === "number" ? input.endLine : undefined,
+    });
+    if (!edit.ok) {
+      return { success: false, error: edit.error };
     }
-
-    const existingCode = existing.query.code ?? "";
-    let resolvedCode = existingCode;
-
-    if (typeof input.code === "string") {
-      switch (action) {
-        case "patch": {
-          const lines = existingCode.split("\n");
-          const rawStart = input.startLine as number;
-          const rawEnd = input.endLine as number;
-          if (rawStart < 1 || rawStart > lines.length) {
-            return {
-              success: false,
-              error: `startLine ${rawStart} is out of range — the query only has ${lines.length} line(s). Use get_dashboard_state to see the current query code.`,
-            };
-          }
-          if (rawEnd < rawStart || rawEnd > lines.length) {
-            return {
-              success: false,
-              error: `endLine ${rawEnd} is out of range — the query only has ${lines.length} line(s) and startLine is ${rawStart}. Use get_dashboard_state to see the current query code.`,
-            };
-          }
-          const startLine = rawStart;
-          const endLine = rawEnd;
-          const before = lines.slice(0, startLine - 1);
-          const after = lines.slice(endLine);
-          const patchLines = input.code.split("\n");
-          resolvedCode = [...before, ...patchLines, ...after].join("\n");
-          break;
-        }
-        case "append": {
-          resolvedCode =
-            existingCode +
-            (existingCode.endsWith("\n") ? "" : "\n") +
-            input.code;
-          break;
-        }
-        case "replace":
-        default:
-          resolvedCode = input.code;
-          break;
-      }
-    }
+    const resolvedCode = edit.code;
 
     const nextLanguage = (
       typeof input.language === "string"
@@ -678,6 +628,91 @@ export async function executeDashboardAgentTool(
       });
       throwIfAborted(signal);
 
+      // Dashboard-level cron auto-refresh (parity with
+      // app_update_data_binding's materializationSchedule): one schedule
+      // refreshes every parquet source of the dashboard.
+      let scheduleMessage = "";
+      if (
+        input.materializationSchedule &&
+        typeof input.materializationSchedule === "object"
+      ) {
+        const requested = input.materializationSchedule as {
+          enabled?: boolean;
+          cron?: string | null;
+          timezone?: string;
+          dataFreshnessTtlMs?: number | null;
+        };
+        const enabled = requested.enabled === true;
+        const cron = enabled ? (requested.cron ?? "").trim() || null : null;
+        if (enabled) {
+          if (!cron) {
+            return {
+              success: false,
+              error:
+                "materializationSchedule.cron is required when enabling the schedule (5-field cron, e.g. '0 * * * *' = hourly).",
+            };
+          }
+          try {
+            CronExpressionParser.parse(cron, {
+              tz: requested.timezone ?? "UTC",
+            });
+          } catch {
+            return {
+              success: false,
+              error: `Invalid materialization schedule cron: "${cron}"`,
+            };
+          }
+          const dashboardAfterUpdate =
+            useDashboardStore.getState().openDashboards[ctx.dashboardId];
+          const hasParquetSource = dashboardAfterUpdate?.dataSources.some(
+            ds => ds.materialization === "parquet",
+          );
+          if (!hasParquetSource) {
+            return {
+              success: false,
+              error:
+                "Scheduled refresh only rebuilds 'parquet' data sources and this dashboard has none. Switch a data source to materialization: 'parquet' first (this tool can do both in one call).",
+            };
+          }
+        }
+        const current =
+          useDashboardStore.getState().openDashboards[ctx.dashboardId]
+            ?.materializationSchedule;
+        const nextSchedule = {
+          enabled,
+          cron,
+          timezone: requested.timezone ?? current?.timezone ?? "UTC",
+          dataFreshnessTtlMs:
+            requested.dataFreshnessTtlMs !== undefined
+              ? requested.dataFreshnessTtlMs
+              : (current?.dataFreshnessTtlMs ?? null),
+        };
+        await useDashboardStore
+          .getState()
+          .updateDashboard(ctx.workspaceId, ctx.dashboardId, {
+            materializationSchedule: nextSchedule,
+          } as Partial<Dashboard>);
+        throwIfAborted(signal);
+        // updateDashboard swallows request errors — confirm the write landed
+        // before reporting success to the agent.
+        const persisted =
+          useDashboardStore.getState().openDashboards[ctx.dashboardId]
+            ?.materializationSchedule;
+        if (
+          (persisted?.enabled ?? false) !== enabled ||
+          (persisted?.cron ?? null) !== cron
+        ) {
+          return {
+            success: false,
+            error:
+              "The data source was updated, but persisting the dashboard schedule failed. Retry the schedule change, or check write access to this dashboard.",
+          };
+        }
+        scheduleMessage = enabled
+          ? ` Dashboard auto-refresh schedule set: ${cron} (${nextSchedule.timezone}) — one schedule refreshes all parquet sources.`
+          : " Dashboard auto-refresh schedule is now off.";
+      }
+
       if (shouldRun) {
         const snapshot = getDashboardStateSnapshot(ctx.dashboardId);
         const runtimeSource = snapshot.dataSources.find(
@@ -694,7 +729,7 @@ export async function executeDashboardAgentTool(
           rowCount: runtimeSource?.rowCount ?? null,
           schema: runtimeSource?.columns ?? [],
           sampleRows: runtimeSource?.sampleRows?.slice(0, 5) ?? [],
-          message: `Updated "${existing.name}" and loaded fresh draft-stream data into DuckDB.`,
+          message: `Updated "${existing.name}" and loaded fresh draft-stream data into DuckDB.${scheduleMessage}`,
         };
       }
       const snapshot = getDashboardStateSnapshot(ctx.dashboardId);
@@ -712,8 +747,7 @@ export async function executeDashboardAgentTool(
         rowCount: null,
         schema: [],
         sampleRows: [],
-        message:
-          "Definition saved only. The dashboard is still using the previously loaded data until run_data_source_query is called.",
+        message: `Definition saved only. The dashboard is still using the previously loaded data until run_data_source_query is called.${scheduleMessage}`,
       };
     } catch (error) {
       const message =

--- a/packages/agent-tools/src/capabilities/dashboard-capabilities.ts
+++ b/packages/agent-tools/src/capabilities/dashboard-capabilities.ts
@@ -1,0 +1,50 @@
+/**
+ * Transport-neutral dashboard capability metadata.
+ *
+ * Only the tools migrated to per-surface adapters live here; the remaining
+ * dashboard tools (widgets, filters, dashboard state) are still browser-only
+ * and keep their hand-maintained entries in the MCP bridge policy until they
+ * grow server legs.
+ */
+import {
+  ALL_AGENT_SURFACES,
+  type AgentCapabilityDefinition,
+} from "./types";
+
+export type DashboardCapabilityPack = "dashboard-data";
+
+export type DashboardCapabilityDefinition = AgentCapabilityDefinition<
+  "dashboard",
+  DashboardCapabilityPack
+>;
+
+const define = (
+  definition: Omit<DashboardCapabilityDefinition, "domain">,
+): DashboardCapabilityDefinition => ({ domain: "dashboard", ...definition });
+
+export const DASHBOARD_CAPABILITIES = [
+  define({
+    // One capability, per-surface adapters (run_app pattern): browser
+    // executor edits the open tab; the server leg
+    // (api/src/agent-lib/tools/server-dashboard-tools.ts) executes against
+    // the Dashboard document for headless / MCP agents. Mirrors
+    // app_update_data_binding, including the schedule leg's gate.
+    name: "update_data_source_query",
+    pack: "dashboard-data",
+    risk: "write",
+    requiredGrant: "artifact-write",
+    inputConditionalGrants: [
+      {
+        grant: "schedule-write",
+        behavior: "changing the dashboard's materialization schedule",
+        appliesTo: input =>
+          typeof input === "object" &&
+          input !== null &&
+          (input as { materializationSchedule?: unknown })
+            .materializationSchedule !== undefined,
+      },
+    ],
+    surfaces: ALL_AGENT_SURFACES,
+    resultKind: "artifact",
+  }),
+] as const satisfies readonly DashboardCapabilityDefinition[];

--- a/packages/agent-tools/src/capabilities/registry.ts
+++ b/packages/agent-tools/src/capabilities/registry.ts
@@ -1,12 +1,14 @@
 /**
  * Combined agent capability registry across every migrated domain.
  *
- * Domains not yet migrated (dashboards, flows, charts, skills, web, …) keep
- * their existing hand-maintained policy in mode registry / bridge policy /
- * read-only sets until they get a registry of their own.
+ * Domains not yet migrated (flows, charts, skills, web, and the browser-only
+ * dashboard tools) keep their existing hand-maintained policy in mode
+ * registry / bridge policy / read-only sets until they get a registry of
+ * their own.
  */
 import { APP_CAPABILITIES } from "./app-capabilities";
 import { CONSOLE_CAPABILITIES } from "./console-capabilities";
+import { DASHBOARD_CAPABILITIES } from "./dashboard-capabilities";
 import { DBT_CAPABILITIES } from "./dbt-capabilities";
 import { NOTEBOOK_CAPABILITIES } from "./notebook-capabilities";
 import { QUERY_CAPABILITIES } from "./query-capabilities";
@@ -16,6 +18,7 @@ export const AGENT_CAPABILITIES: readonly AgentCapabilityDefinition[] = [
   ...DBT_CAPABILITIES,
   ...APP_CAPABILITIES,
   ...CONSOLE_CAPABILITIES,
+  ...DASHBOARD_CAPABILITIES,
   ...QUERY_CAPABILITIES,
   ...NOTEBOOK_CAPABILITIES,
 ];

--- a/packages/agent-tools/src/dashboard-tools.ts
+++ b/packages/agent-tools/src/dashboard-tools.ts
@@ -14,6 +14,7 @@
 
 import { tool } from "ai";
 import { z } from "zod";
+import { bindingMaterializationScheduleSchema } from "./app-tools";
 import { clientScreenshotTools } from "./screenshot-tools";
 
 // A loose record instead of the full ~98 KB Vega-Lite JSON Schema. The model
@@ -220,7 +221,7 @@ const createDataSourceSchema = z.object({
     ),
 });
 
-const updateDataSourceQuerySchema = z.object({
+export const updateDataSourceQuerySchema = z.object({
   dashboardId: z.string().describe("Dashboard ID"),
   dataSourceId: z.string().describe("Dashboard data source ID"),
   action: z
@@ -253,6 +254,16 @@ const updateDataSourceQuerySchema = z.object({
       "Switch this data source between 'live' (stream on every load) and " +
         "'parquet' (cached materialized artifact).",
     ),
+  materializationSchedule: bindingMaterializationScheduleSchema
+    .optional()
+    .describe(
+      "Set or clear the cron auto-refresh, e.g. { enabled: true, cron: " +
+        "'0 * * * *' } for hourly or { enabled: false } to turn it off. " +
+        "NOTE: unlike apps (per-binding), a dashboard has ONE schedule that " +
+        "refreshes all of its 'parquet' data sources — setting it here " +
+        "updates the whole dashboard's schedule. Mirrors " +
+        "app_update_data_binding's materializationSchedule.",
+    ),
   startLine: z
     .number()
     .optional()
@@ -271,6 +282,80 @@ const updateDataSourceQuerySchema = z.object({
         "If false (default), only saves the query definition. The dashboard keeps using the previously loaded data until run_data_source_query is called.",
     ),
 });
+
+export type UpdateDataSourceQueryInput = z.infer<
+  typeof updateDataSourceQuerySchema
+>;
+
+/**
+ * Resolve the `action`-based code edit for update_data_source_query. Shared
+ * by the browser executor and the server (MCP) leg so the edit semantics
+ * cannot drift between surfaces. Returns the unchanged code when no `code`
+ * was provided (non-patch actions treat code as optional).
+ */
+export function resolveDataSourceCodeEdit(
+  existingCode: string,
+  input: {
+    action?: string;
+    code?: string;
+    startLine?: number;
+    endLine?: number;
+  },
+): { ok: true; code: string } | { ok: false; error: string } {
+  const action = typeof input.action === "string" ? input.action : "replace";
+  if (action === "patch") {
+    if (
+      typeof input.startLine !== "number" ||
+      typeof input.endLine !== "number"
+    ) {
+      return {
+        ok: false,
+        error:
+          "startLine and endLine are required for patch action. Use get_dashboard_state to see the current query code.",
+      };
+    }
+    if (typeof input.code !== "string") {
+      return { ok: false, error: "code is required for patch action." };
+    }
+  }
+  if (typeof input.code !== "string") {
+    return { ok: true, code: existingCode };
+  }
+  switch (action) {
+    case "patch": {
+      const lines = existingCode.split("\n");
+      const rawStart = input.startLine as number;
+      const rawEnd = input.endLine as number;
+      if (rawStart < 1 || rawStart > lines.length) {
+        return {
+          ok: false,
+          error: `startLine ${rawStart} is out of range — the query only has ${lines.length} line(s). Use get_dashboard_state to see the current query code.`,
+        };
+      }
+      if (rawEnd < rawStart || rawEnd > lines.length) {
+        return {
+          ok: false,
+          error: `endLine ${rawEnd} is out of range — the query only has ${lines.length} line(s) and startLine is ${rawStart}. Use get_dashboard_state to see the current query code.`,
+        };
+      }
+      const before = lines.slice(0, rawStart - 1);
+      const after = lines.slice(rawEnd);
+      return {
+        ok: true,
+        code: [...before, ...input.code.split("\n"), ...after].join("\n"),
+      };
+    }
+    case "append":
+      return {
+        ok: true,
+        code:
+          existingCode + (existingCode.endsWith("\n") ? "" : "\n") + input.code,
+      };
+    case "replace":
+    default:
+      return { ok: true, code: input.code };
+  }
+}
 
 const runDataSourceQuerySchema = z.object({
   dashboardId: z.string().describe("Dashboard ID"),
@@ -351,7 +436,8 @@ export const clientDashboardTools = {
       "'replace' (default — full code replacement), " +
       "'patch' (replace a specific line range — requires startLine/endLine, preferred for small edits), " +
       "'append' (add lines to the end of the existing code). " +
-      "Non-code fields (name, connectionId, language, etc.) are always shallow-merged regardless of action. " +
+      "Non-code fields (name, connectionId, language, materialization, etc.) are always shallow-merged regardless of action. " +
+      "materializationSchedule sets the dashboard's cron auto-refresh (dashboard-level — one schedule refreshes all parquet sources). " +
       "When run=false, treat the response as definition_saved_only and use the returned nextRecommendedTool if you need fresh data. " +
       "IMPORTANT for 'patch': line numbers are 1-indexed and inclusive; do NOT include line number prefixes in your code content.",
     inputSchema: updateDataSourceQuerySchema,

--- a/packages/agent-tools/src/index.ts
+++ b/packages/agent-tools/src/index.ts
@@ -55,7 +55,12 @@ export type {
 export { clientChartTools } from "./chart-tools";
 export type { ModifyChartSpecInput } from "./chart-tools";
 
-export { clientDashboardTools } from "./dashboard-tools";
+export {
+  clientDashboardTools,
+  updateDataSourceQuerySchema,
+  resolveDataSourceCodeEdit,
+  type UpdateDataSourceQueryInput,
+} from "./dashboard-tools";
 export { clientFlowTools } from "./flow-tools";
 
 export { clientAppTools } from "./app-tools";


### PR DESCRIPTION
Follow-up to #786: dashboards now manage data sources through the same interface as apps manage data bindings — using the existing `update_data_source_query` tool, no new tool names.

## Schedule parity

`update_data_source_query` accepts `materializationSchedule` with the same shape and semantics as `app_update_data_binding` (set `{ enabled, cron, timezone }`, or `{ enabled: false }` to turn it off), gated by the same `schedule-write` input-conditional grant from #786. One documented semantic difference reflecting the existing data model: a dashboard has **one** schedule that refreshes all of its parquet sources, so setting it from any data source updates the whole dashboard's cron.

## Dashboards are no longer read-only over MCP

Previously every dashboard mutation tool was `exclude("client-only")` in the MCP bridge policy. `update_data_source_query` becomes one capability with per-surface adapters (the `run_app` pattern):

- **Browser leg** — unchanged behavior, plus the new schedule field (applied via the store's `updateDashboard`, with client-side cron validation and a persistence check since the store swallows request errors).
- **Server leg** (new `server-dashboard-tools.ts`) — executes against the authoritative Dashboard document so headless/MCP agents can edit query code (`replace`/`patch`/`append`), switch live/parquet, and set the refresh schedule. Writes bump the dashboard version and publish the `dashboard.updated` realtime poke so open tabs pull the change; definition/materialization changes queue a parquet artifact rebuild (schedule-only changes don't). Read-only API keys keep the same envelope as app bindings: definition edits and schedule-enables require query access; disable-only schedule changes stay possible.

## Shared code so the surfaces can't drift

- The `action`-based code-edit resolver moved into `@mako/agent-tools` (`resolveDataSourceCodeEdit`) and both legs use it.
- The binding query-access check for read-only keys is extracted from `server-app-tools` into `shared/binding-query-access.ts` and shared by both domains.
- New `dashboard-capabilities.ts` registry entry seeds the MCP bridge policy for the migrated tool; the manual client-only exclude is removed.

## Testing

- Full API test chain (21 suites), API lint + build, `@mako/agent-tools` build, and frontend typecheck all pass.
- Grant mechanics are covered by the input-conditional grant tests from #786 (same machinery, applied via the new dashboard capability entry).

## Follow-ups toward full parity (not in this PR)

1. `create_data_source` gaining `consoleId` seeding + schedule-at-create, retiring `import_console_as_data_source` / `add_data_source`.
2. Server legs for data-source create/delete.
3. Product decision: move dashboards to per-source schedules like apps (schema + refresh-scheduler migration) vs. keeping the one-cron-per-dashboard model — this PR is interface-compatible with either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXgVqz3CACBuisZxoU75h7

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXgVqz3CACBuisZxoU75h7)_