### PR TITLE
fix(cdc): stop Recover inflating pending event counts

### DIFF
--- a/api/src/routes/flows.ts
+++ b/api/src/routes/flows.ts
@@ -26,6 +26,11 @@ import { syncMachineService } from "../sync-cdc/sync-state";
 import { databaseRegistry } from "../databases/registry";
 import { cdcLiveTableName, cdcStageTableName } from "../sync-cdc/normalization";
 import { resolveConfiguredEntities } from "../sync-cdc/entity-selection";
+import {
+  computeEntityPendingBacklog,
+  computeEntitySeqGap,
+  computePendingLagSeconds,
+} from "../sync-cdc/backlog";
 import { syncConnectorRegistry } from "../sync/connector-registry";
 import { databaseDataSourceManager } from "../sync/database-data-source-manager";
 import { databaseConnectionService } from "../services/database-connection.service";
@@ -137,11 +142,6 @@ function resolveWebhookBaseUrl(
   }
 
   return requestBaseUrl;
-}
-
-function toLagSeconds(value: Date | null): number | null {
-  if (!value) return null;
-  return Math.max(Math.floor((Date.now() - value.getTime()) / 1000), 0);
 }
 
 const DESTINATION_COUNT_CACHE_TTL_MS = 60_000;
@@ -3527,23 +3527,24 @@ flowRoutes.openapi(
           (state?.backfillCursor as any)?.hasMore === false;
         const ingestSeq = state?.lastIngestSeq || 0;
         const materializedSeq = state?.lastMaterializedSeq || 0;
-        const backlogCount = Math.max(
+        // Real pending rows only — never inflate with ingest/materialized seq
+        // gap (Recover/Reprocess used to rewind the cursor and make the gap
+        // look like hundreds of thousands of "pending" events).
+        const backlogCount = computeEntityPendingBacklog(
           pendingCountMap.get(entity) || 0,
-          ingestSeq - materializedSeq,
-          state?.backlogCount || 0,
         );
+        const seqGap = computeEntitySeqGap(ingestSeq, materializedSeq);
         const oldestPendingTs = pendingOldestTsMap.get(entity) ?? null;
         return {
           entity,
           lastIngestSeq: ingestSeq,
           lastMaterializedSeq: materializedSeq,
           backlogCount,
-          lagSeconds:
-            backlogCount > 0
-              ? oldestPendingTs
-                ? toLagSeconds(oldestPendingTs)
-                : toLagSeconds(lastMaterializedAt)
-              : 0,
+          seqGap,
+          lagSeconds: computePendingLagSeconds({
+            pendingCount: backlogCount,
+            oldestPendingTs,
+          }),
           lastMaterializedAt,
           destinationRowCount: (state as any)?.destinationRowCount ?? null,
           lifetimeEventsProcessed,
@@ -3569,26 +3570,13 @@ flowRoutes.openapi(
       const materializedDates = entities
         .map(e => e.lastMaterializedAt)
         .filter((d): d is Date => d instanceof Date);
-      let lagSeconds: number | null;
-      if (totalBacklog === 0) {
-        lagSeconds = 0;
-      } else {
-        const oldestPendingTs = Array.from(pendingOldestTsMap.values()).sort(
-          (a, b) => a.getTime() - b.getTime(),
-        )[0];
-        if (oldestPendingTs) {
-          lagSeconds = toLagSeconds(oldestPendingTs);
-        } else {
-          const oldestMaterialized = entities
-            .filter(e => e.backlogCount > 0)
-            .map(e => e.lastMaterializedAt)
-            .filter((d): d is Date => d instanceof Date)
-            .sort((a, b) => a.getTime() - b.getTime())[0];
-          lagSeconds = oldestMaterialized
-            ? toLagSeconds(oldestMaterialized)
-            : -1;
-        }
-      }
+      const oldestPendingTs = Array.from(pendingOldestTsMap.values()).sort(
+        (a, b) => a.getTime() - b.getTime(),
+      )[0];
+      const lagSeconds = computePendingLagSeconds({
+        pendingCount: totalBacklog,
+        oldestPendingTs,
+      });
 
       let backfillStatus = flow.backfillState?.status || "idle";
       if (
@@ -3635,11 +3623,10 @@ flowRoutes.openapi(
           consecutiveFailures: flow.backfillState?.consecutiveFailures ?? 0,
           lastError,
           backlogCount: totalBacklog,
-          // The UI "pending" counter must reflect the TRUE CDC materialization
-          // backlog (pending CdcChangeEvents + cursor lag), not the raw
-          // WebhookEvent.applyStatus count — the latter stays inflated by
-          // orphaned/deduped rows that will never materialize, which made the
-          // count look stuck at 50k+ even when nothing was actually pending.
+          // The UI "pending" counter must reflect real pending CdcChangeEvents
+          // only — not cursor seq gaps (Recover rewind used to inflate those
+          // into hundreds of thousands of fake "pending" events) and not the
+          // raw WebhookEvent.applyStatus count (orphaned/deduped rows).
           webhookPendingCount: totalBacklog,
           // Raw applyStatus=pending count kept for diagnostics only.
           webhookApplyPendingCount,

--- a/api/src/sync-cdc/backfill.ts
+++ b/api/src/sync-cdc/backfill.ts
@@ -660,7 +660,8 @@ export class CdcBackfillService {
       flow.streamState === "paused" &&
       flow.syncStateMeta?.lastEvent === "REPARTITION_PAUSE"
     ) {
-      flow.streamState = (previousStreamState as IFlow["streamState"]) || "idle";
+      flow.streamState =
+        (previousStreamState as IFlow["streamState"]) || "idle";
       flow.syncStateMeta = {
         ...(flow.syncStateMeta || {}),
         lastEvent: "REPARTITION_RESUME",
@@ -685,7 +686,10 @@ export class CdcBackfillService {
     workspaceId: string;
     flowId: string;
     entity: string;
-  }): Promise<{ outcome: "repartitioned" | "missing" | "failed"; error?: string }> {
+  }): Promise<{
+    outcome: "repartitioned" | "missing" | "failed";
+    error?: string;
+  }> {
     const { workspaceId, flowId, entity } = params;
     const flow = await Flow.findOne({
       _id: new Types.ObjectId(flowId),
@@ -736,11 +740,16 @@ export class CdcBackfillService {
         entity,
         error: message,
       });
-      await this.setEntityRepartitionStatus(flow.workspaceId, flow._id, entity, {
-        status: "failed",
-        completedAt: new Date(),
-        error: message.slice(0, 500),
-      });
+      await this.setEntityRepartitionStatus(
+        flow.workspaceId,
+        flow._id,
+        entity,
+        {
+          status: "failed",
+          completedAt: new Date(),
+          error: message.slice(0, 500),
+        },
+      );
       return { outcome: "failed", error: message };
     }
   }
@@ -798,10 +807,7 @@ export class CdcBackfillService {
       .select({ _id: 1, workspaceId: 1 })
       .lean();
     for (const flow of stuck) {
-      await this.recoverRepartition(
-        String(flow.workspaceId),
-        String(flow._id),
-      );
+      await this.recoverRepartition(String(flow.workspaceId), String(flow._id));
     }
     if (stuck.length > 0) {
       log.warn("Recovered stale repartition pauses", { count: stuck.length });
@@ -839,7 +845,11 @@ export class CdcBackfillService {
     entities: string[],
     deleteDestination?: boolean,
   ): Promise<void> {
-    await getCdcEventStore().deleteFlowEvents({ workspaceId, flowId, entities });
+    await getCdcEventStore().deleteFlowEvents({
+      workspaceId,
+      flowId,
+      entities,
+    });
     await CdcEntityState.deleteMany({
       workspaceId: new Types.ObjectId(workspaceId),
       flowId: new Types.ObjectId(flowId),
@@ -943,32 +953,12 @@ export class CdcBackfillService {
       );
     }
 
+    // Do NOT rewind lastMaterializedSeq under the oldest pending event.
+    // readAfter() already selects pending rows independent of the cursor, and
+    // findEntitiesWithPendingEvents() triggers drain without a rewind. Rewinding
+    // invents a huge ingest/materialized seq gap that the status UI used to
+    // surface as hundreds of thousands of fake "pending" events.
     for (const entity of entities) {
-      const minPending = await CdcChangeEvent.findOne({
-        flowId: new Types.ObjectId(params.flowId),
-        entity,
-        materializationStatus: "pending",
-      })
-        .sort({ ingestSeq: 1 })
-        .select({ ingestSeq: 1 })
-        .lean();
-      if (minPending) {
-        await CdcEntityState.updateOne(
-          {
-            flowId: new Types.ObjectId(params.flowId),
-            entity,
-          },
-          {
-            $set: {
-              lastMaterializedSeq: Math.max(
-                0,
-                (parseInt(String(minPending.ingestSeq), 10) || 0) - 1,
-              ),
-            },
-          },
-        );
-      }
-
       await inngest.send({
         name: "cdc/materialize",
         data: {
@@ -1084,7 +1074,6 @@ export class CdcBackfillService {
       ]);
 
     let materializeTriggered = 0;
-    let cursorsRewound = 0;
     let pendingEntities = 0;
     const drainErrors: string[] = [];
 
@@ -1102,41 +1091,9 @@ export class CdcBackfillService {
       pendingEntities++;
 
       try {
-        // Rewind the consumer cursor just below the oldest pending event so the
-        // scheduler's findStaleEntities re-flags this entity (lastIngestSeq >
-        // lastMaterializedSeq) and a forced materialize actually reads it.
-        const minPending = await CdcChangeEvent.findOne({
-          flowId: new Types.ObjectId(params.flowId),
-          entity: item.entity,
-          materializationStatus: "pending",
-        })
-          .sort({ ingestSeq: 1 })
-          .select({ ingestSeq: 1 })
-          .lean();
-
-        if (minPending) {
-          const targetSeq = Math.max(
-            0,
-            (parseInt(String(minPending.ingestSeq), 10) || 0) - 1,
-          );
-          const state = await CdcEntityState.findOne({
-            flowId: new Types.ObjectId(params.flowId),
-            entity: item.entity,
-          })
-            .select({ lastMaterializedSeq: 1 })
-            .lean();
-          if (state && Number(state.lastMaterializedSeq || 0) > targetSeq) {
-            await CdcEntityState.updateOne(
-              {
-                flowId: new Types.ObjectId(params.flowId),
-                entity: item.entity,
-              },
-              { $set: { lastMaterializedSeq: targetSeq } },
-            );
-            cursorsRewound++;
-          }
-        }
-
+        // Force-trigger materialize only. Do not rewind lastMaterializedSeq —
+        // readAfter() + findEntitiesWithPendingEvents() already drain orphans
+        // without inventing a cursor seq gap that inflates the pending UI.
         await inngest.send({
           name: "cdc/materialize",
           data: {
@@ -1181,7 +1138,6 @@ export class CdcBackfillService {
       resetFailedWebhooks,
       pendingEntities,
       materializeTriggered,
-      cursorsRewound,
       orphanedResolved,
       drainErrors: drainErrors.length,
     });
@@ -1192,7 +1148,6 @@ export class CdcBackfillService {
       resetFailedWebhooks,
       pendingEntities,
       materializeTriggered,
-      cursorsRewound,
       orphanedResolved,
       drainErrors,
     };
@@ -1904,30 +1859,8 @@ export async function forceDrainCdcFlow(params: {
   for (const item of byEntity) {
     if (item.count <= 0) continue;
 
-    const minPending = await CdcChangeEvent.findOne({
-      flowId: new Types.ObjectId(params.flowId),
-      entity: item.entity,
-      materializationStatus: "pending",
-    })
-      .sort({ ingestSeq: 1 })
-      .select({ ingestSeq: 1 })
-      .lean();
-
-    if (minPending) {
-      const targetSeq = Math.max(
-        0,
-        (parseInt(String(minPending.ingestSeq), 10) || 0) - 1,
-      );
-      await CdcEntityState.updateOne(
-        {
-          flowId: new Types.ObjectId(params.flowId),
-          entity: item.entity,
-          lastMaterializedSeq: { $gt: targetSeq },
-        },
-        { $set: { lastMaterializedSeq: targetSeq } },
-      );
-    }
-
+    // Force materialize without rewinding the consumer cursor (see
+    // reprocessStaleEvents / retryFailedMaterialization).
     await inngest.send({
       name: "cdc/materialize",
       data: {

--- a/api/src/sync-cdc/backlog.test.ts
+++ b/api/src/sync-cdc/backlog.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeEntityPendingBacklog,
+  computeEntitySeqGap,
+  computePendingLagSeconds,
+} from "./backlog";
+
+describe("CDC pending backlog (recover cursor-gap inflation)", () => {
+  it("uses real pending count only — not ingest/materialized seq gap", () => {
+    // Recover rewound lastMaterializedSeq under an orphan at seq ~110k while
+    // head is ~800k; only a couple thousand rows are actually pending.
+    const realPending = 2_400;
+    const seqGap = computeEntitySeqGap(800_000, 109_999);
+    expect(seqGap).toBe(690_001);
+    expect(computeEntityPendingBacklog(realPending)).toBe(2_400);
+    expect(computeEntityPendingBacklog(realPending)).not.toBe(seqGap);
+  });
+
+  it("treats zero / negative pending as empty backlog", () => {
+    expect(computeEntityPendingBacklog(0)).toBe(0);
+    expect(computeEntityPendingBacklog(-1)).toBe(0);
+  });
+
+  it("does not invent lag from a seq gap when nothing is pending", () => {
+    expect(
+      computePendingLagSeconds({
+        pendingCount: 0,
+        oldestPendingTs: new Date(Date.now() - 978 * 3600 * 1000),
+      }),
+    ).toBe(0);
+  });
+
+  it("reports lag from the oldest real pending ingestTs", () => {
+    const nowMs = Date.parse("2026-08-12T08:00:00.000Z");
+    const oldest = new Date(nowMs - 3_600_000);
+    expect(
+      computePendingLagSeconds({
+        pendingCount: 12,
+        oldestPendingTs: oldest,
+        nowMs,
+      }),
+    ).toBe(3600);
+  });
+});

--- a/api/src/sync-cdc/backlog.ts
+++ b/api/src/sync-cdc/backlog.ts
@@ -1,0 +1,42 @@
+/**
+ * CDC backlog / lag helpers.
+ *
+ * Pending counts must reflect real `materializationStatus: "pending"` rows
+ * only. Using `lastIngestSeq - lastMaterializedSeq` as a pending proxy
+ * inflates the Stream "X pending" counter after Recover/Reprocess rewinds
+ * the cursor under an old orphaned event (seq gap looks like hundreds of
+ * thousands of pending rows even when only a few thousand exist).
+ *
+ * Cursor seq gaps are still useful for the materialize scheduler
+ * (`findStaleEntities`); they are not a user-facing pending event count.
+ */
+
+export function computeEntityPendingBacklog(pendingCount: number): number {
+  return Math.max(0, pendingCount || 0);
+}
+
+export function computeEntitySeqGap(
+  lastIngestSeq: number,
+  lastMaterializedSeq: number,
+): number {
+  return Math.max(0, (lastIngestSeq || 0) - (lastMaterializedSeq || 0));
+}
+
+/**
+ * Flow-level lag: age of the oldest real pending event.
+ * Returns 0 when nothing is pending (seq gap alone must not invent lag).
+ */
+export function computePendingLagSeconds(params: {
+  pendingCount: number;
+  oldestPendingTs: Date | null | undefined;
+  nowMs?: number;
+}): number {
+  if ((params.pendingCount || 0) <= 0 || !params.oldestPendingTs) {
+    return 0;
+  }
+  const now = params.nowMs ?? Date.now();
+  return Math.max(
+    0,
+    Math.floor((now - params.oldestPendingTs.getTime()) / 1000),
+  );
+}

--- a/api/src/sync-cdc/sync-state.ts
+++ b/api/src/sync-cdc/sync-state.ts
@@ -9,6 +9,10 @@ import {
   BackfillStatus,
 } from "../database/workspace-schema";
 import { loggers } from "../logging";
+import {
+  computeEntityPendingBacklog,
+  computePendingLagSeconds,
+} from "./backlog";
 
 const log = loggers.sync("cdc.sync-state");
 
@@ -565,52 +569,18 @@ export async function getCdcFlowStats(params: { flowId: string }): Promise<{
     };
   }
 
-  const backlogCount = Math.max(
-    pendingCount,
-    states.reduce(
-      (sum, state) =>
-        sum +
-        Math.max(
-          (state.lastIngestSeq || 0) - (state.lastMaterializedSeq || 0),
-          state.backlogCount || 0,
-        ),
-      0,
-    ),
-  );
+  // Real pending CdcChangeEvents only — do not max() with cursor seq gaps.
+  const backlogCount = computeEntityPendingBacklog(pendingCount);
   const mode = states.some(state => state.mode === "backfill")
     ? "backfill"
     : "steady";
-  let lagSeconds: number | null;
-  if (backlogCount > 0) {
-    const oldestPendingTs = oldestPendingResult?.ingestTs
-      ? new Date(oldestPendingResult.ingestTs).getTime()
-      : null;
-    if (oldestPendingTs) {
-      lagSeconds = Math.max(
-        Math.floor((Date.now() - oldestPendingTs) / 1000),
-        0,
-      );
-    } else {
-      const withBacklog = states.filter(
-        s =>
-          Math.max(
-            (s.lastIngestSeq || 0) - (s.lastMaterializedSeq || 0),
-            s.backlogCount || 0,
-          ) > 0,
-      );
-      const candidates = withBacklog.length > 0 ? withBacklog : states;
-      const oldest = candidates
-        .map(s => s.lastMaterializedAt)
-        .filter(Boolean)
-        .map(d => new Date(d as Date).getTime())
-        .sort((a, b) => a - b)[0];
-      lagSeconds = oldest
-        ? Math.max(Math.floor((Date.now() - oldest) / 1000), 0)
-        : -1;
-    }
-  } else {
-    lagSeconds = 0;
-  }
+  const oldestPendingTs = oldestPendingResult?.ingestTs
+    ? new Date(oldestPendingResult.ingestTs)
+    : null;
+  const lagSeconds = computePendingLagSeconds({
+    pendingCount: backlogCount,
+    oldestPendingTs,
+  });
 
   return {
     enabled: true,

--- a/api/vitest.destinations.config.ts
+++ b/api/vitest.destinations.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
       "src/databases/**/*.test.ts",
       "src/services/destination-writer.service.test.ts",
       "src/sync-cdc/adapters/**/*.test.ts",
+      "src/sync-cdc/backlog.test.ts",
       "src/sync-cdc/consumer.test.ts",
       "src/sync/legacy-flow-migration.test.ts",
       "src/sync/sync-orchestrator.test.ts",


### PR DESCRIPTION
## Summary
- Stream "X pending" / `backlogCount` now count real `materializationStatus: "pending"` CDC rows only — no more `max(..., lastIngestSeq - lastMaterializedSeq)` inflation after Recover/Reprocess.
- Remove consumer-cursor rewinds from `retryFailedMaterialization`, `reprocessStaleEvents`, and `forceDrainCdcFlow` (`readAfter` + pending-entity discovery already drain orphans).
- Lag uses oldest pending `ingestTs` only when something is actually pending.

## Context
On `fr_close -> bigquery_write`, Recover said a couple thousand events needed recovering, then the UI jumped to ~690k pending / ~978h lag. Root cause: rewind under an old orphaned pending seq created a huge cursor gap, and status treated that gap as pending.

## Test plan
- [x] `pnpm --filter api exec vitest run --config vitest.destinations.config.ts src/sync-cdc/backlog.test.ts`
- [x] `pnpm --filter api run test:destinations`
- [ ] Deploy preview: Recover/Reprocess on a CDC flow with a small real pending backlog — pending counter should stay near the real count (not jump by seq gap).
- [ ] Confirm entities flip to Live when real pending hits 0 even if a seq gap still exists (scheduler still closes the gap via empty-pending cursor advance).


Made with [Cursor](https://cursor.com)